### PR TITLE
fix(ai): refuse to refresh the duel-suite baseline from a failing run

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,11 +178,13 @@ jobs:
         # `CARGO_BIN_EXE_*` embeds target/debug paths. Nextest's archive does
         # not preserve those launcher paths, so share the binaries the
         # integration tests execute directly with every shard. This list and the
-        # two below must cover every such binary;
+        # two below must cover every such binary: a launcher added here must also
+        # be uploaded and made executable below, or the shard fails on the leg
+        # that was missed rather than on the one that was added.
         # `crates/phase-ai/tests/gate_cli.rs` reds when they fall behind.
         run: |
           cargo build -p probe-pin
-          cargo build -p phase-ai --bin ai-commander --bin ai-duel
+          cargo build -p phase-ai --bin ai-commander --bin ai-duel --bin ai-gate
 
       - name: Upload test archive
         uses: actions/upload-artifact@v4
@@ -200,6 +202,7 @@ jobs:
             target/debug/probe-pin
             target/debug/ai-commander
             target/debug/ai-duel
+            target/debug/ai-gate
           compression-level: 0
           if-no-files-found: error
           retention-days: 1
@@ -244,7 +247,7 @@ jobs:
 
       - name: Restore test runtime binary permissions
         # Actions artifacts preserve file contents but not executable bits.
-        run: chmod +x target/debug/probe-pin target/debug/ai-commander target/debug/ai-duel
+        run: chmod +x target/debug/probe-pin target/debug/ai-commander target/debug/ai-duel target/debug/ai-gate
 
       - name: Run tests
         # The archive retains build options. Each shard only extracts it and

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1937,6 +1937,7 @@ dependencies = [
  "rand 0.9.4",
  "rand_chacha 0.9.0",
  "rayon",
+ "same-file",
  "serde",
  "serde_json",
  "strum",

--- a/crates/phase-ai/Cargo.toml
+++ b/crates/phase-ai/Cargo.toml
@@ -25,6 +25,13 @@ rayon = { version = "1", optional = true }
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 mimalloc = "0.1"
 
+# Windows file identity for the ai-gate baseline-alias guard: volume serial + file
+# index via `GetFileInformationByHandle`, which std exposes only behind the unstable
+# `windows_by_handle` feature. Already in the lock (walkdir -> same-file), and gated
+# to windows so no other target's graph changes.
+[target.'cfg(windows)'.dependencies]
+same-file = "1"
+
 [features]
 tune = ["rayon"]
 # Scenario-backed benchmark binaries are opt-in: build them with

--- a/crates/phase-ai/Cargo.toml
+++ b/crates/phase-ai/Cargo.toml
@@ -52,8 +52,10 @@ test = false
 
 [[bin]]
 name = "ai-gate"
+# No `test = false`: that key suppresses a bin's unittest target entirely, so it belongs only on a
+# bin with no `#[cfg(test)]` code. This one carries unit tests over the staging-path and aliasing
+# predicates, which have to be built before they can run.
 path = "src/bin/ai_gate.rs"
-test = false
 
 [[bin]]
 name = "ai-perf-gate"

--- a/crates/phase-ai/src/bin/ai_duel.rs
+++ b/crates/phase-ai/src/bin/ai_duel.rs
@@ -23,7 +23,9 @@ use phase_ai::duel_suite::compare::{
     compare as compare_reports, emit_gate_verdict, load_report, render_error_markdown,
     CompareOptions,
 };
-use phase_ai::duel_suite::run::{resolve_matchup, run_suite, AttributionMode, SuiteOptions};
+use phase_ai::duel_suite::run::{
+    resolve_matchup, run_suite, AttributionMode, ReportSink, SuiteOptions,
+};
 use phase_ai::duel_suite::{all_matchups, find_matchup};
 use rand::rngs::StdRng;
 use rand::SeedableRng;
@@ -140,7 +142,7 @@ fn main() {
             let output_path =
                 output.unwrap_or_else(|| PathBuf::from("target/duel-suite-results.json"));
             let mut options = SuiteOptions::new(difficulty, games, base_seed);
-            options.output_path = output_path.clone();
+            options.output = ReportSink::Create(output_path.clone());
             options.filter = suite_filter;
             options.attribution = attribution;
             options.harvest_output = harvest_output;

--- a/crates/phase-ai/src/bin/ai_gate.rs
+++ b/crates/phase-ai/src/bin/ai_gate.rs
@@ -14,7 +14,7 @@ use phase_ai::duel_suite::compare::{
     compare, emit_gate_verdict, load_report, print_markdown, render_error_markdown, CompareError,
     CompareOptions,
 };
-use phase_ai::duel_suite::run::{run_suite, SuiteOptions};
+use phase_ai::duel_suite::run::{run_suite, ReportSink, SuiteOptions};
 
 const DEFAULT_BASELINE: &str = "crates/phase-ai/baselines/suite-baseline.json";
 const DEFAULT_CURRENT: &str = "target/ai-gate-current.json";
@@ -49,7 +49,7 @@ fn main() {
 
     // Refuse before ANY work — before the card database, before a single game — when the
     // suite's output path and the baseline are the same file. Review found this defeats the
-    // refusal this PR adds: `run_suite` writes its report to `options.output_path` before any
+    // refusal this PR adds: `run_suite` writes its report to `options.output` before any
     // guard runs, so an aliased pair truncated the baseline and only THEN printed "refusing to
     // refresh". Measured on the real binary at the reviewed head: 116 bytes in, 250 bytes out,
     // different sha256, exit 1.
@@ -99,9 +99,10 @@ fn main() {
     //
     // Third route to the same destruction, and the only one no argument check could ever catch:
     // this path is derived internally, so `same_file` never sees it — it compares `--baseline`
-    // against `--current-output`, and the staging file is neither. `write_report` opens it with
-    // `File::create`, which FOLLOWS a symlink to its target and SHARES a hard link's inode, so an
-    // entry already sitting there truncates whatever it points at, before any refresh guard runs.
+    // against `--current-output`, and the staging file is neither. `write_report` opened it by
+    // name with `File::create`, which FOLLOWS a symlink to its target and SHARES a hard link's
+    // inode, so an entry already sitting there truncated whatever it pointed at, before any
+    // refresh guard ran.
     // Measured on the binary before this reservation existed: with a symlink pre-placed at the
     // staging path, the refresh reported success and the baseline's bytes were gone.
     //
@@ -110,6 +111,7 @@ fn main() {
     // same class of bug one layer down; `O_CREAT|O_EXCL` fails on ANY existing entry — regular
     // file, hard link, live or dangling symlink — in one atomic step. What the suite then
     // truncates is a regular file this process just created, with a link count of one.
+    let mut reserved = None;
     if let Some(path) = &staging {
         if let Some(parent) = path.parent() {
             if let Err(err) = std::fs::create_dir_all(parent) {
@@ -117,28 +119,34 @@ fn main() {
                 std::process::exit(2);
             }
         }
-        if let Err(err) = std::fs::OpenOptions::new()
+        match std::fs::OpenOptions::new()
             .write(true)
             .create_new(true)
             .open(path)
         {
+            // Retained, not dropped: the suite writes the report through this descriptor, so an
+            // entry that replaces `path` after this point can no longer be followed or truncated.
+            Ok(file) => reserved = Some(file),
             // Refusing rather than reusing is the point. The path is derived, so anything already
             // there was not put there by this run, and a leftover from a killed run is exactly
             // the artefact the refusal paths below delete. Naming it and stopping is better than
             // writing through something whose provenance is unknown.
-            eprintln!(
-                "failed to reserve the staging file {}: {err}\n\
-                 if a previous run was interrupted, remove that file and retry; if it is a \
-                 symlink or hard link, it would have been written straight through into whatever \
-                 it points at",
-                path.display()
-            );
-            std::process::exit(2);
+            Err(err) => {
+                eprintln!(
+                    "failed to reserve the staging file {}: {err}\n\
+                     if a previous run was interrupted, remove that file and retry; if it is a \
+                     symlink or hard link, it would have been written straight through into \
+                     whatever it points at",
+                    path.display()
+                );
+                std::process::exit(2);
+            }
         }
     }
-    options.output_path = staging
-        .clone()
-        .unwrap_or_else(|| args.current_output.clone());
+    options.output = match reserved {
+        Some(file) => ReportSink::Reserved(file),
+        None => ReportSink::Create(args.current_output.clone()),
+    };
     options.filter = args.suite_filter.clone();
     options.git_sha = command_output("git", &["rev-parse", "--short=12", "HEAD"]);
     options.card_data_hash = command_output("git", &["hash-object", path_str(&db_path)]);
@@ -514,6 +522,9 @@ mod tests {
     #[test]
     fn same_file_sees_through_a_symlink() {
         let dir = std::env::temp_dir().join(format!("phase-same-file-{}", std::process::id()));
+        // A pid is reused, and a failed run leaves its scratch dir behind; without this the next
+        // run dies at `symlink()` with EEXIST, which reads as an assertion failure.
+        let _ = std::fs::remove_dir_all(&dir);
         std::fs::create_dir_all(&dir).expect("scratch dir");
         let real = dir.join("baseline.json");
         std::fs::write(&real, "{}").expect("write");

--- a/crates/phase-ai/src/bin/ai_gate.rs
+++ b/crates/phase-ai/src/bin/ai_gate.rs
@@ -4,13 +4,15 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+use std::io::ErrorKind;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
 use engine::database::CardDatabase;
 use phase_ai::config::AiDifficulty;
 use phase_ai::duel_suite::compare::{
-    compare, emit_gate_verdict, load_report, print_markdown, render_error_markdown, CompareOptions,
+    compare, emit_gate_verdict, load_report, print_markdown, render_error_markdown, CompareError,
+    CompareOptions,
 };
 use phase_ai::duel_suite::run::{run_suite, SuiteOptions};
 
@@ -102,20 +104,31 @@ fn main() {
 
     // Read the baseline BEFORE the suite runs, and keep it in memory.
     //
-    // This is the root-cause half of the aliasing fix, and it is what the argument check above
-    // cannot give: reading first makes the comparison independent of ANYTHING the suite writes,
-    // including aliases this process cannot detect from paths at all — a hard link resolves to
-    // a different name and the same inode, so `same_file` calls it distinct while a write to
-    // one truncates the other. Order does not care how the alias was constructed.
+    // This is the root-cause half of the aliasing fix. The check above now recognises hard links
+    // too, so it is no longer the case that an alias can slip past it — but the two guards answer
+    // different questions and only one of them survives being wrong. `same_file` enumerates the
+    // ways two names can mean one file, and any such enumeration is a claim about the filesystem
+    // that a future filesystem can falsify. Reading first makes the COMPARISON independent of
+    // anything the suite writes, whatever the check missed. It cannot save the bytes — only
+    // refusing does that — so this is defence in depth, not a substitute.
     //
     // It also fails a missing or corrupt baseline in a second instead of after a full suite run,
     // which is the difference between a typo costing nothing and costing a hundred games.
     let baseline = match load_report(&args.baseline) {
         Ok(report) => Some(report),
-        // On a refresh there may be no baseline yet, and that is the normal first-run case.
-        Err(_) if args.refresh_baseline && !args.baseline.exists() => None,
-        Err(err) if args.refresh_baseline => {
-            eprintln!("could not read the old baseline for comparison: {err}");
+        // ABSENT is the only error a refresh may proceed through, and the narrowness is the
+        // point. Review found the earlier `Err(_) if refresh_baseline` arm logged every failure
+        // and carried on to `run_suite`, which then renamed the staged report over the file — so
+        // a baseline that was corrupt, truncated, or unreadable was DESTROYED rather than kept
+        // for diagnosis, and the replacement was established from an unexamined prior state.
+        // "I could not read it" is not evidence that it was worthless.
+        //
+        // Matched on `ErrorKind::NotFound` rather than `!args.baseline.exists()`: the old form
+        // asked a second, later question of the filesystem and answered the wrong one under a
+        // permission error, where the file exists but `exists()` reports false.
+        Err(CompareError::Io(err))
+            if args.refresh_baseline && err.kind() == ErrorKind::NotFound =>
+        {
             None
         }
         Err(err) => {
@@ -321,18 +334,28 @@ fn path_str(path: &Path) -> &str {
     path.to_str().unwrap_or("")
 }
 
-/// Whether two paths designate the same file, including through symlinks and `..`.
+/// Whether two paths designate the same file, including through symlinks, `..`, and hard links.
 ///
-/// `canonicalize` is the authority when a path exists, because it is the only thing that
-/// resolves symlinks — a plain string or `absolute()` comparison calls `baselines/x.json` and a
-/// symlink pointing at it different files, and then the write lands on the baseline anyway. The
-/// current-output side usually does NOT exist yet, so it falls back to canonicalizing the parent
-/// directory (which has to be real for the write to land) and rejoining the file name.
+/// Two layers, because they answer different questions and the cheap one is not sufficient.
+///
+/// **Identity first.** When both paths exist, `(dev, ino)` is the only thing that sees a hard
+/// link: `canonicalize` faithfully preserves two distinct names for one inode, so a path
+/// comparison calls them different files while `File::create` on either truncates both
+/// (`duel_suite::run::write_report`). Review found this and it is not hypothetical — it is the
+/// one alias a check on argument strings can never catch, and the destructive one.
+///
+/// **Paths second.** The current-output side usually does NOT exist yet, so there is no inode to
+/// compare; that case falls back to `canonicalize`, which still resolves symlinks and `..`, on
+/// the parent directory (which has to be real for the write to land) with the file name rejoined.
 ///
 /// Returns false when neither resolution is possible, which is the right default: an
 /// unresolvable path cannot be shown to alias, and refusing to run on a path we cannot inspect
 /// would break invocations that are fine.
 fn same_file(a: &Path, b: &Path) -> bool {
+    // Both sides exist => filesystem identity is decisive, and it subsumes the path check.
+    if let Some(identical) = same_inode(a, b) {
+        return identical;
+    }
     fn resolved(path: &Path) -> Option<PathBuf> {
         if let Ok(canonical) = std::fs::canonicalize(path) {
             return Some(canonical);
@@ -347,6 +370,27 @@ fn same_file(a: &Path, b: &Path) -> bool {
         (Some(x), Some(y)) => x == y,
         _ => false,
     }
+}
+
+/// `Some(true)` when both paths exist and name one inode, `Some(false)` when both exist and do
+/// not, `None` when the question cannot be answered — either side missing, or a platform with no
+/// inode concept, both of which leave the decision to the path-based fallback.
+///
+/// Split out rather than inlined so the `cfg` seam is one function with one contract, instead of
+/// a conditional block inside a predicate whose meaning would then differ per platform.
+#[cfg(unix)]
+fn same_inode(a: &Path, b: &Path) -> Option<bool> {
+    use std::os::unix::fs::MetadataExt;
+    let (a, b) = (std::fs::metadata(a).ok()?, std::fs::metadata(b).ok()?);
+    Some(a.dev() == b.dev() && a.ino() == b.ino())
+}
+
+/// Non-Unix has no portable inode, so identity is unanswerable and the path check stands alone.
+/// The gate is a developer/CI tool that runs on Linux; this arm exists so the crate still builds
+/// elsewhere, not because the weaker guarantee is considered acceptable there.
+#[cfg(not(unix))]
+fn same_inode(_a: &Path, _b: &Path) -> Option<bool> {
+    None
 }
 
 /// Where a refresh run stages its report before it earns the right to be the baseline.

--- a/crates/phase-ai/src/bin/ai_gate.rs
+++ b/crates/phase-ai/src/bin/ai_gate.rs
@@ -74,6 +74,53 @@ fn main() {
     };
 
     if args.refresh_baseline {
+        // A baseline is what every later run is judged against, so refreshing from a run
+        // that failed its own `Expected` check blesses that failure permanently: the next
+        // run compares equal to it and exits 0 forever, and the gate goes quiet about a
+        // matchup that is still broken. Refuse. A matchup that genuinely has no verdict
+        // yet says so with `Expected::Open` in the suite definition — that is the place
+        // to express it, not a red baseline.
+        //
+        // ORDER MATTERS, and this one is strictly better on every input. The two conditions
+        // are not exclusive: `failed_result` builds a matchup with an empty `games` vector
+        // AND `SuiteStatus::Fail`, so a run whose deck payloads all failed to load satisfies
+        // both. Reporting the failures names each matchup and its `setup error: …`; reporting
+        // gamelessness first would replace that with a sentence about seeds. Nothing is lost
+        // by checking failures first, because a run that is merely gameless — a
+        // `--suite-filter` matching nothing — has no failing matchups to report.
+        let failing: Vec<_> = current.failing_matchups().collect();
+        if !failing.is_empty() {
+            eprintln!(
+                "refusing to refresh {}: {} matchup(s) failed their own suite check",
+                args.baseline.display(),
+                failing.len()
+            );
+            for result in failing {
+                eprintln!(
+                    "  {}: {}",
+                    result.matchup_id,
+                    result
+                        .fail_reason
+                        .as_deref()
+                        .unwrap_or("no reason recorded")
+                );
+            }
+            eprintln!(
+                "fix the regression, or declare the matchup `Expected::Open` if it has no verdict yet"
+            );
+            std::process::exit(1);
+        }
+        // A run that measured nothing is unfit for the same reason a red one is, reached from
+        // the other side: comparison pairs by seed, so a gameless baseline scores zero on the
+        // outcome axes forever and the drift signal dies quietly. Reached by a `--suite-filter`
+        // that selects no matchups; `--games 0` is refused earlier, at parse time.
+        if current.recorded_games() == 0 {
+            eprintln!(
+                "refusing to refresh {}: the run recorded no games, so every later comparison would score zero",
+                args.baseline.display()
+            );
+            std::process::exit(1);
+        }
         if args.baseline.exists() {
             match load_report(&args.baseline)
                 .and_then(|baseline| compare(&baseline, &current, &CompareOptions))
@@ -145,9 +192,14 @@ fn parse_args() -> Result<Args, String> {
                 current_output = next_path(&mut iter, "--current-output")?;
             }
             "--games" => {
-                games = next_value(&mut iter, "--games")?
-                    .parse()
-                    .map_err(|_| "--games must be a positive integer".to_string())?;
+                // `usize` alone accepts 0, which the error string already promised it would
+                // not. A zero-game run classifies every matchup `Open` and produces a
+                // baseline that can never detect drift, so reject it here rather than
+                // burning a whole suite run to refuse it later.
+                games = match next_value(&mut iter, "--games")?.parse() {
+                    Ok(0) | Err(_) => return Err("--games must be a positive integer".to_string()),
+                    Ok(value) => value,
+                };
             }
             "--seed" => {
                 seed = next_value(&mut iter, "--seed")?

--- a/crates/phase-ai/src/bin/ai_gate.rs
+++ b/crates/phase-ai/src/bin/ai_gate.rs
@@ -82,6 +82,12 @@ fn main() {
     };
 
     let mut options = SuiteOptions::new(args.difficulty, args.games, args.seed);
+    // `--baseline` names an entry, not necessarily a file. Resolve it to the file it designates
+    // BEFORE anything is derived from it, because two things downstream have to agree on that
+    // one answer: the staging sibling and the promotion target.
+    let destination = args
+        .refresh_baseline
+        .then(|| resolve_destination(&args.baseline));
     // On a refresh, the suite writes to a staging file BESIDE the baseline rather than to
     // `--current-output`, and the baseline is replaced by renaming that file only after every
     // guard has passed. The alias check above already refuses the one path that reached this
@@ -94,7 +100,7 @@ fn main() {
     // `--current-output` is therefore unused on the refresh path — the refreshed baseline IS
     // the run's report. No workflow passes `--refresh-baseline`, so nothing in CI depends on
     // the old behaviour.
-    let staging = args.refresh_baseline.then(|| staging_path(&args.baseline));
+    let staging = destination.as_deref().map(staging_path);
     // RESERVE the staging path before the suite can write a byte to it.
     //
     // Third route to the same destruction, and the only one no argument check could ever catch:
@@ -220,6 +226,8 @@ fn main() {
         // by checking failures first, because a run that is merely gameless — a
         // `--suite-filter` matching nothing — has no failing matchups to report.
         let staging = staging.expect("staging path is set whenever refresh_baseline is");
+        let destination =
+            destination.expect("the destination is resolved whenever refresh_baseline is");
         // Every exit below leaves the staging file behind otherwise, and a stale
         // `*.staging.json` next to a baseline is exactly the kind of artefact someone later
         // mistakes for a real one.
@@ -270,15 +278,12 @@ fn main() {
         // The run is accepted: promote the staging file. `rename` replaces the baseline in one
         // step, so a reader never observes a half-written baseline and a failure here leaves the
         // previous one intact.
-        if let Err(err) = std::fs::rename(&staging, &args.baseline) {
+        if let Err(err) = std::fs::rename(&staging, &destination) {
             let _ = std::fs::remove_file(&staging);
-            eprintln!(
-                "failed to write baseline {}: {err}",
-                args.baseline.display()
-            );
+            eprintln!("failed to write baseline {}: {err}", destination.display());
             std::process::exit(1);
         }
-        eprintln!("baseline refreshed at {}", args.baseline.display());
+        eprintln!("baseline refreshed at {}", destination.display());
         return;
     }
 
@@ -468,6 +473,47 @@ fn same_inode(_a: &Path, _b: &Path) -> Option<bool> {
     None
 }
 
+/// The file `--baseline` designates, following symlinks the way the write it replaces did.
+///
+/// A refresh used to open the baseline with `File::create`, which follows a symlink chain and
+/// refreshes the file at its end. Staging + `rename` does not: `rename` acts on the entry, so
+/// promoting onto the supplied spelling would replace the link with a regular file and leave its
+/// target stale. Resolving first restores the old destination and is also what keeps the
+/// promotion atomic — the staging file is a sibling of THIS path, and `rename` is only atomic
+/// within one filesystem, so a link that crosses a mount would otherwise stage on one device and
+/// rename onto another (`EXDEV`).
+///
+/// Not `canonicalize`, on three counts: it requires every component to exist, so a dangling link
+/// and a first-ever refresh both fail where `File::create` succeeded; it rewrites a relative path
+/// the caller typed into an absolute one, which then appears in every message; and on Windows it
+/// returns a `\\?\` UNC path. Reading only the links that are actually there leaves a plain path
+/// exactly as supplied.
+///
+/// Hard links are deliberately NOT followed — a hard link has no target to follow, it IS the
+/// file. `rename` breaks the link rather than truncating the shared inode, which is the less
+/// destructive of the two.
+///
+/// The budget bounds a symlink cycle, which would otherwise spin here forever. Exhausting it
+/// leaves a still-unresolved path, and nothing acts on it: the kernel refuses the same chain, so
+/// `load_report` below fails with `FilesystemLoop` — not `NotFound` — and the run exits before
+/// the promotion.
+fn resolve_destination(path: &Path) -> PathBuf {
+    let mut current = path.to_path_buf();
+    // Linux's own `MAXSYMLINKS`; a chain this deep is already refused by every open() on it.
+    for _ in 0..40 {
+        // `Err` is the ordinary exit: not a symlink, or not there at all.
+        let Ok(target) = std::fs::read_link(&current) else {
+            return current;
+        };
+        current = match current.parent() {
+            // A link's target is relative to the directory the link sits in, not to the cwd.
+            Some(parent) if target.is_relative() => parent.join(target),
+            _ => target,
+        };
+    }
+    current
+}
+
 /// Where a refresh run stages its report before it earns the right to be the baseline.
 ///
 /// Beside the baseline, so the later `rename` is a same-filesystem atomic replace.
@@ -493,6 +539,46 @@ fn print_usage() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The sibling property has to hold of the RESOLVED destination, not of the spelling the
+    /// caller typed. `rename` is only atomic within one filesystem, so a staging file left beside
+    /// a link whose target lives on another mount would fail with `EXDEV`; measured directly,
+    /// tmpfs staging renamed onto a btrfs target returns `Invalid cross-device link (os error 18)`.
+    /// A cross-filesystem fixture is not constructible in a portable test, so the property is
+    /// pinned here, at the derivation.
+    #[test]
+    fn the_staging_file_is_a_sibling_of_the_resolved_destination() {
+        let dir = std::env::temp_dir().join(format!("phase-resolve-dest-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("real")).expect("scratch dir");
+        let target = dir.join("real/baseline.json");
+        std::fs::write(&target, "{}").expect("write");
+        #[cfg(unix)]
+        {
+            let link = dir.join("link.json");
+            std::os::unix::fs::symlink(&target, &link).expect("symlink");
+            assert_eq!(
+                resolve_destination(&link),
+                target,
+                "the link must resolve to its target"
+            );
+            assert_eq!(
+                staging_path(&resolve_destination(&link)).parent(),
+                target.parent(),
+                "staging must sit beside the resolved destination, not beside the link"
+            );
+            // PREMISE: the two spellings really do have different parents, so the assertion above
+            // is about resolution and not about a trivially equal comparison.
+            assert_ne!(link.parent(), target.parent());
+        }
+        // Control: a path that is not a link comes back exactly as supplied — a relative spelling
+        // stays relative, which is what keeps `baseline refreshed at ...` printing what the caller
+        // typed (and, on Windows, keeps a `\\?\` prefix out of it).
+        let plain = Path::new(DEFAULT_BASELINE);
+        assert_eq!(resolve_destination(plain), plain);
+        assert_eq!(resolve_destination(&target), target);
+        std::fs::remove_dir_all(&dir).ok();
+    }
 
     /// The staging file must be a SIBLING of the baseline. `rename` is only atomic within one
     /// filesystem, so a staging path that drifted to `/tmp` (or anywhere else the baseline is

--- a/crates/phase-ai/src/bin/ai_gate.rs
+++ b/crates/phase-ai/src/bin/ai_gate.rs
@@ -4,8 +4,6 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
-use std::fs::File;
-use std::io::BufWriter;
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
@@ -14,7 +12,7 @@ use phase_ai::config::AiDifficulty;
 use phase_ai::duel_suite::compare::{
     compare, emit_gate_verdict, load_report, print_markdown, render_error_markdown, CompareOptions,
 };
-use phase_ai::duel_suite::run::{run_suite, SuiteOptions, SuiteReport};
+use phase_ai::duel_suite::run::{run_suite, SuiteOptions};
 
 const DEFAULT_BASELINE: &str = "crates/phase-ai/baselines/suite-baseline.json";
 const DEFAULT_CURRENT: &str = "target/ai-gate-current.json";
@@ -47,6 +45,28 @@ fn main() {
         }
     };
 
+    // Refuse before ANY work — before the card database, before a single game — when the
+    // suite's output path and the baseline are the same file. Review found this defeats the
+    // refusal this PR adds: `run_suite` writes its report to `options.output_path` before any
+    // guard runs, so an aliased pair truncated the baseline and only THEN printed "refusing to
+    // refresh". Measured on the real binary at the reviewed head: 116 bytes in, 250 bytes out,
+    // different sha256, exit 1.
+    //
+    // The compare path is worse and is why this check is not confined to `--refresh-baseline`.
+    // There the same aliasing makes `load_report(&args.baseline)` read back the run that just
+    // overwrote it, so the gate compares the run to ITSELF and exits 0. Measured: a baseline
+    // recording p0 at 100% against a run that scored 0% printed `0% | 0%`, zero flips, `0 FAIL`,
+    // exit 0. A gate that reports no drift because it destroyed its own reference is the exact
+    // false-green this branch exists to close, and it is silent where the refresh case is loud.
+    if same_file(&args.baseline, &args.current_output) {
+        eprintln!(
+            "--baseline and --current-output are the same file ({}); the suite would overwrite \
+             the baseline before it could be compared or validated",
+            args.baseline.display()
+        );
+        std::process::exit(2);
+    }
+
     let db_path = args.data_root.join("card-data.json");
     let db = match CardDatabase::from_export(&db_path) {
         Ok(db) => db,
@@ -60,10 +80,55 @@ fn main() {
     };
 
     let mut options = SuiteOptions::new(args.difficulty, args.games, args.seed);
-    options.output_path = args.current_output.clone();
+    // On a refresh, the suite writes to a staging file BESIDE the baseline rather than to
+    // `--current-output`, and the baseline is replaced by renaming that file only after every
+    // guard has passed. The alias check above already refuses the one path that reached this
+    // bug, but a check on argument values cannot be the whole answer: the property that has to
+    // hold is that a rejected run never modifies the baseline, and that is a property of the
+    // write ordering, not of the flags. Staging + rename gives it unconditionally.
+    //
+    // Beside the baseline because `rename` is only atomic within one filesystem; a staging file
+    // in `/tmp` could land on a different mount and silently degrade to copy-then-truncate.
+    // `--current-output` is therefore unused on the refresh path — the refreshed baseline IS
+    // the run's report. No workflow passes `--refresh-baseline`, so nothing in CI depends on
+    // the old behaviour.
+    let staging = args.refresh_baseline.then(|| staging_path(&args.baseline));
+    options.output_path = staging
+        .clone()
+        .unwrap_or_else(|| args.current_output.clone());
     options.filter = args.suite_filter.clone();
     options.git_sha = command_output("git", &["rev-parse", "--short=12", "HEAD"]);
     options.card_data_hash = command_output("git", &["hash-object", path_str(&db_path)]);
+
+    // Read the baseline BEFORE the suite runs, and keep it in memory.
+    //
+    // This is the root-cause half of the aliasing fix, and it is what the argument check above
+    // cannot give: reading first makes the comparison independent of ANYTHING the suite writes,
+    // including aliases this process cannot detect from paths at all — a hard link resolves to
+    // a different name and the same inode, so `same_file` calls it distinct while a write to
+    // one truncates the other. Order does not care how the alias was constructed.
+    //
+    // It also fails a missing or corrupt baseline in a second instead of after a full suite run,
+    // which is the difference between a typo costing nothing and costing a hundred games.
+    let baseline = match load_report(&args.baseline) {
+        Ok(report) => Some(report),
+        // On a refresh there may be no baseline yet, and that is the normal first-run case.
+        Err(_) if args.refresh_baseline && !args.baseline.exists() => None,
+        Err(err) if args.refresh_baseline => {
+            eprintln!("could not read the old baseline for comparison: {err}");
+            None
+        }
+        Err(err) => {
+            // Same reasoning as the compare refusal below: the nightly posts stdout, so a
+            // read failure that spoke only to stderr produced a red job whose issue body was
+            // the suite table and no statement of what went wrong. This is also the only
+            // caller that can reach `render_error_markdown`'s I/O arm — `compare` does no
+            // I/O, so before this the arm existed and was unreachable.
+            eprintln!("failed to load baseline {}: {err}", args.baseline.display());
+            print!("{}", render_error_markdown(&err));
+            std::process::exit(2);
+        }
+    };
 
     let current = match run_suite(&db, &options) {
         Ok(report) => report,
@@ -88,6 +153,16 @@ fn main() {
         // gamelessness first would replace that with a sentence about seeds. Nothing is lost
         // by checking failures first, because a run that is merely gameless — a
         // `--suite-filter` matching nothing — has no failing matchups to report.
+        let staging = staging.expect("staging path is set whenever refresh_baseline is");
+        // Every exit below leaves the staging file behind otherwise, and a stale
+        // `*.staging.json` next to a baseline is exactly the kind of artefact someone later
+        // mistakes for a real one.
+        let refuse = |message: &str| -> ! {
+            let _ = std::fs::remove_file(&staging);
+            eprintln!("{message}");
+            std::process::exit(1);
+        };
+
         let failing: Vec<_> = current.failing_matchups().collect();
         if !failing.is_empty() {
             eprintln!(
@@ -105,31 +180,32 @@ fn main() {
                         .unwrap_or("no reason recorded")
                 );
             }
-            eprintln!(
-                "fix the regression, or declare the matchup `Expected::Open` if it has no verdict yet"
+            refuse(
+                "fix the regression, or declare the matchup `Expected::Open` if it has no verdict yet",
             );
-            std::process::exit(1);
         }
         // A run that measured nothing is unfit for the same reason a red one is, reached from
         // the other side: comparison pairs by seed, so a gameless baseline scores zero on the
         // outcome axes forever and the drift signal dies quietly. Reached by a `--suite-filter`
         // that selects no matchups; `--games 0` is refused earlier, at parse time.
         if current.recorded_games() == 0 {
-            eprintln!(
+            refuse(&format!(
                 "refusing to refresh {}: the run recorded no games, so every later comparison would score zero",
                 args.baseline.display()
-            );
-            std::process::exit(1);
+            ));
         }
-        if args.baseline.exists() {
-            match load_report(&args.baseline)
-                .and_then(|baseline| compare(&baseline, &current, &CompareOptions))
-            {
+        // Informational old-vs-new diff, from the copy read before the suite ran.
+        if let Some(old) = &baseline {
+            match compare(old, &current, &CompareOptions) {
                 Ok(report) => print_markdown(&report),
                 Err(err) => eprintln!("could not compare old baseline: {err}"),
             }
         }
-        if let Err(err) = write_report(&current, &args.baseline) {
+        // The run is accepted: promote the staging file. `rename` replaces the baseline in one
+        // step, so a reader never observes a half-written baseline and a failure here leaves the
+        // previous one intact.
+        if let Err(err) = std::fs::rename(&staging, &args.baseline) {
+            let _ = std::fs::remove_file(&staging);
             eprintln!(
                 "failed to write baseline {}: {err}",
                 args.baseline.display()
@@ -140,19 +216,8 @@ fn main() {
         return;
     }
 
-    let baseline = match load_report(&args.baseline) {
-        Ok(report) => report,
-        Err(err) => {
-            // Same reasoning as the compare refusal below: the nightly posts stdout, so a
-            // read failure that spoke only to stderr produced a red job whose issue body was
-            // the suite table and no statement of what went wrong. This is also the only
-            // caller that can reach `render_error_markdown`'s I/O arm — `compare` does no
-            // I/O, so before this the arm existed and was unreachable.
-            eprintln!("failed to load baseline {}: {err}", args.baseline.display());
-            print!("{}", render_error_markdown(&err));
-            std::process::exit(2);
-        }
-    };
+    let baseline =
+        baseline.expect("the non-refresh path exits above when the baseline is unreadable");
 
     // stdout carries the report body — the nightly redirects it into the file it posts as a
     // drift issue — so a refusal has to be printed there too, not only to stderr. `gate_verdict`
@@ -256,12 +321,47 @@ fn path_str(path: &Path) -> &str {
     path.to_str().unwrap_or("")
 }
 
-fn write_report(report: &SuiteReport, path: &Path) -> Result<(), std::io::Error> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+/// Whether two paths designate the same file, including through symlinks and `..`.
+///
+/// `canonicalize` is the authority when a path exists, because it is the only thing that
+/// resolves symlinks — a plain string or `absolute()` comparison calls `baselines/x.json` and a
+/// symlink pointing at it different files, and then the write lands on the baseline anyway. The
+/// current-output side usually does NOT exist yet, so it falls back to canonicalizing the parent
+/// directory (which has to be real for the write to land) and rejoining the file name.
+///
+/// Returns false when neither resolution is possible, which is the right default: an
+/// unresolvable path cannot be shown to alias, and refusing to run on a path we cannot inspect
+/// would break invocations that are fine.
+fn same_file(a: &Path, b: &Path) -> bool {
+    fn resolved(path: &Path) -> Option<PathBuf> {
+        if let Ok(canonical) = std::fs::canonicalize(path) {
+            return Some(canonical);
+        }
+        let parent = match path.parent() {
+            Some(p) if !p.as_os_str().is_empty() => p,
+            _ => Path::new("."),
+        };
+        Some(std::fs::canonicalize(parent).ok()?.join(path.file_name()?))
     }
-    let file = File::create(path)?;
-    serde_json::to_writer_pretty(BufWriter::new(file), report).map_err(std::io::Error::other)
+    match (resolved(a), resolved(b)) {
+        (Some(x), Some(y)) => x == y,
+        _ => false,
+    }
+}
+
+/// Where a refresh run stages its report before it earns the right to be the baseline.
+///
+/// Beside the baseline, so the later `rename` is a same-filesystem atomic replace.
+fn staging_path(baseline: &Path) -> PathBuf {
+    let name = baseline
+        .file_name()
+        .map(|n| {
+            let mut s = n.to_os_string();
+            s.push(".staging.json");
+            s
+        })
+        .unwrap_or_else(|| "baseline.staging.json".into());
+    baseline.with_file_name(name)
 }
 
 fn print_usage() {
@@ -269,4 +369,76 @@ fn print_usage() {
     eprintln!("                     [--difficulty {{medium|hard|veryhard|cedh}}]");
     eprintln!("                     [--suite-filter STR[,STR...] | --full-suite]");
     eprintln!("                     [--data-root DIR] [--baseline PATH] [--current-output PATH]");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The staging file must be a SIBLING of the baseline. `rename` is only atomic within one
+    /// filesystem, so a staging path that drifted to `/tmp` (or anywhere else the baseline is
+    /// not) would silently degrade the final replace into copy-then-truncate — reintroducing the
+    /// half-written baseline this staging exists to prevent, and doing it invisibly.
+    ///
+    /// Asserted as "same parent, different file name", which is the property atomicity needs,
+    /// rather than as a literal string, which would pin a spelling nobody depends on.
+    #[test]
+    fn the_staging_file_is_a_sibling_of_the_baseline_it_will_replace() {
+        for baseline in [
+            "crates/phase-ai/baselines/suite-baseline.json",
+            "/abs/path/base.json",
+            "relative.json",
+            "/weird/no-extension",
+        ] {
+            let baseline = Path::new(baseline);
+            let staging = staging_path(baseline);
+            assert_eq!(
+                staging.parent(),
+                baseline.parent(),
+                "staging must sit beside {}, got {}",
+                baseline.display(),
+                staging.display()
+            );
+            assert_ne!(
+                staging,
+                baseline,
+                "staging must not BE the baseline: {}",
+                baseline.display()
+            );
+        }
+    }
+
+    /// A path and a symlink to it are the same file, and a string comparison cannot see that.
+    /// This is the case that makes `same_file` more than `a == b`: the write lands on the
+    /// baseline's bytes either way.
+    #[test]
+    fn same_file_sees_through_a_symlink() {
+        let dir = std::env::temp_dir().join(format!("phase-same-file-{}", std::process::id()));
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let real = dir.join("baseline.json");
+        std::fs::write(&real, "{}").expect("write");
+        let link = dir.join("link.json");
+        #[cfg(unix)]
+        std::os::unix::fs::symlink(&real, &link).expect("symlink");
+
+        #[cfg(unix)]
+        {
+            assert!(same_file(&real, &link), "symlinked alias must be detected");
+            // PREMISE: the two paths really are textually different, so the assertion above is
+            // about resolution rather than about a trivially equal comparison.
+            assert_ne!(real, link);
+        }
+
+        // Control: two genuinely distinct files must not be called aliases, or the guard would
+        // refuse every legitimate invocation.
+        let other = dir.join("current.json");
+        std::fs::write(&other, "{}").expect("write");
+        assert!(!same_file(&real, &other));
+        // And a path that does not exist yet still resolves through its parent, which is the
+        // normal case for `--current-output` on a clean tree.
+        assert!(!same_file(&real, &dir.join("not-created-yet.json")));
+        assert!(same_file(&real, &dir.join("baseline.json")));
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }

--- a/crates/phase-ai/src/bin/ai_gate.rs
+++ b/crates/phase-ai/src/bin/ai_gate.rs
@@ -449,10 +449,21 @@ fn same_inode(a: &Path, b: &Path) -> Option<bool> {
     Some(a.dev() == b.dev() && a.ino() == b.ino())
 }
 
-/// Non-Unix has no portable inode, so identity is unanswerable and the path check stands alone.
-/// The gate is a developer/CI tool that runs on Linux; this arm exists so the crate still builds
-/// elsewhere, not because the weaker guarantee is considered acceptable there.
-#[cfg(not(unix))]
+/// Windows has no inode, but it has the same *question*: `GetFileInformationByHandle` reports a
+/// volume serial number and a file index, and that pair is what two hard links to one file share.
+/// `same_file::is_same_file` asks exactly that (via `winapi-util`), which the standard library
+/// exposes only behind the unstable `windows_by_handle` feature.
+///
+/// `.ok()` collapses every failure — either path missing, or unopenable — into the same `None`
+/// the Unix arm returns for a missing path: unanswerable, decided by the path fallback.
+#[cfg(windows)]
+fn same_inode(a: &Path, b: &Path) -> Option<bool> {
+    same_file::is_same_file(a, b).ok()
+}
+
+/// Everything else (wasm32, redox) has no portable file identity, so the question is unanswerable
+/// and the path check stands alone. This arm exists so the crate still builds there.
+#[cfg(not(any(unix, windows)))]
 fn same_inode(_a: &Path, _b: &Path) -> Option<bool> {
     None
 }

--- a/crates/phase-ai/src/bin/ai_gate.rs
+++ b/crates/phase-ai/src/bin/ai_gate.rs
@@ -95,6 +95,47 @@ fn main() {
     // the run's report. No workflow passes `--refresh-baseline`, so nothing in CI depends on
     // the old behaviour.
     let staging = args.refresh_baseline.then(|| staging_path(&args.baseline));
+    // RESERVE the staging path before the suite can write a byte to it.
+    //
+    // Third route to the same destruction, and the only one no argument check could ever catch:
+    // this path is derived internally, so `same_file` never sees it — it compares `--baseline`
+    // against `--current-output`, and the staging file is neither. `write_report` opens it with
+    // `File::create`, which FOLLOWS a symlink to its target and SHARES a hard link's inode, so an
+    // entry already sitting there truncates whatever it points at, before any refresh guard runs.
+    // Measured on the binary before this reservation existed: with a symlink pre-placed at the
+    // staging path, the refresh reported success and the baseline's bytes were gone.
+    //
+    // `create_new` is the whole fix, and it is deliberately a reservation rather than a check.
+    // Testing the path first and opening it second leaves the window between them, which is the
+    // same class of bug one layer down; `O_CREAT|O_EXCL` fails on ANY existing entry — regular
+    // file, hard link, live or dangling symlink — in one atomic step. What the suite then
+    // truncates is a regular file this process just created, with a link count of one.
+    if let Some(path) = &staging {
+        if let Some(parent) = path.parent() {
+            if let Err(err) = std::fs::create_dir_all(parent) {
+                eprintln!("failed to create {}: {err}", parent.display());
+                std::process::exit(2);
+            }
+        }
+        if let Err(err) = std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(path)
+        {
+            // Refusing rather than reusing is the point. The path is derived, so anything already
+            // there was not put there by this run, and a leftover from a killed run is exactly
+            // the artefact the refusal paths below delete. Naming it and stopping is better than
+            // writing through something whose provenance is unknown.
+            eprintln!(
+                "failed to reserve the staging file {}: {err}\n\
+                 if a previous run was interrupted, remove that file and retry; if it is a \
+                 symlink or hard link, it would have been written straight through into whatever \
+                 it points at",
+                path.display()
+            );
+            std::process::exit(2);
+        }
+    }
     options.output_path = staging
         .clone()
         .unwrap_or_else(|| args.current_output.clone());
@@ -132,6 +173,9 @@ fn main() {
             None
         }
         Err(err) => {
+            // Every exit after the reservation has to release it, or a refused run leaves a file
+            // that blocks the next refresh — turning one diagnosable failure into two.
+            release_staging(&staging);
             // Same reasoning as the compare refusal below: the nightly posts stdout, so a
             // read failure that spoke only to stderr produced a red job whose issue body was
             // the suite table and no statement of what went wrong. This is also the only
@@ -146,6 +190,7 @@ fn main() {
     let current = match run_suite(&db, &options) {
         Ok(report) => report,
         Err(err) => {
+            release_staging(&staging);
             eprintln!("suite run failed: {err}");
             std::process::exit(1);
         }
@@ -369,6 +414,17 @@ fn same_file(a: &Path, b: &Path) -> bool {
     match (resolved(a), resolved(b)) {
         (Some(x), Some(y)) => x == y,
         _ => false,
+    }
+}
+
+/// Release a reserved staging file, if this run reserved one.
+///
+/// A no-op on the compare path, where `staging` is `None`. Errors are ignored deliberately: this
+/// only ever runs on a path that is already exiting with a diagnosis of its own, and a failure to
+/// remove a scratch file is not worth displacing that diagnosis.
+fn release_staging(staging: &Option<PathBuf>) {
+    if let Some(path) = staging {
+        let _ = std::fs::remove_file(path);
     }
 }
 

--- a/crates/phase-ai/src/duel_suite/run.rs
+++ b/crates/phase-ai/src/duel_suite/run.rs
@@ -8,9 +8,10 @@
 //! [`SuiteReport::deterministic_core`].
 
 use std::collections::{HashMap, HashSet};
-use std::io::BufWriter;
+use std::fs::File;
+use std::io::{BufWriter, Write};
 use std::panic::AssertUnwindSafe;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::time::{Instant, SystemTime, UNIX_EPOCH};
 
 use engine::database::CardDatabase;
@@ -204,12 +205,28 @@ pub enum AttributionMode {
     Enabled,
 }
 
+/// Where a suite run's report is written.
+///
+/// `Reserved` exists because a path is not an identity: an entry that replaces the name after it
+/// was reserved would be followed (symlink) or shared (hard link) by a writer that reopens it.
+/// Holding the descriptor the reservation returned removes the question — the variant carries no
+/// path to reopen.
+#[derive(Debug)]
+pub enum ReportSink {
+    /// Create (truncating) at this path when the report is written.
+    Create(PathBuf),
+    /// Write through a descriptor the caller already opened, positioned at offset 0. The report
+    /// replaces whatever the handle refers to; the handle need not be empty.
+    Reserved(File),
+}
+
 #[derive(Debug)]
 pub struct SuiteOptions {
     pub difficulty: AiDifficulty,
     pub games_per_matchup: usize,
     pub base_seed: u64,
-    pub output_path: PathBuf,
+    /// Destination for the run's JSON report.
+    pub output: ReportSink,
     /// Comma-separated list of id substrings; a matchup is run if its id
     /// contains *any* of them (e.g. `"red-mirror,affinity-mirror"` runs both).
     /// `None` runs every matchup. A single substring keeps the legacy behavior.
@@ -229,7 +246,7 @@ impl SuiteOptions {
             difficulty,
             games_per_matchup,
             base_seed,
-            output_path: PathBuf::from("target/duel-suite-results.json"),
+            output: ReportSink::Create(PathBuf::from("target/duel-suite-results.json")),
             filter: None,
             attribution: AttributionMode::Disabled,
             git_sha: None,
@@ -239,7 +256,7 @@ impl SuiteOptions {
     }
 }
 
-/// Run every registered matchup, write the report to `options.output_path`,
+/// Run every registered matchup, write the report to `options.output`,
 /// and return the in-memory report for the caller to print.
 pub fn run_suite(db: &CardDatabase, options: &SuiteOptions) -> Result<SuiteReport, std::io::Error> {
     let capture = match options.attribution {
@@ -550,7 +567,7 @@ fn finalize_report(
         results,
     };
 
-    write_report(&report, &options.output_path)?;
+    write_report(&report, &options.output)?;
     print_markdown_table(&report);
 
     Ok(report)
@@ -951,13 +968,31 @@ pub(crate) fn drive_game_observed(
     (winner, state.turn_number)
 }
 
-fn write_report(report: &SuiteReport, path: &Path) -> Result<(), std::io::Error> {
-    if let Some(parent) = path.parent() {
-        std::fs::create_dir_all(parent)?;
+fn write_report(report: &SuiteReport, sink: &ReportSink) -> Result<(), std::io::Error> {
+    match sink {
+        ReportSink::Create(path) => {
+            if let Some(parent) = path.parent() {
+                std::fs::create_dir_all(parent)?;
+            }
+            write_through(&File::create(path)?, report)
+        }
+        ReportSink::Reserved(file) => write_through(file, report),
     }
-    let file = std::fs::File::create(path)?;
-    serde_json::to_writer_pretty(BufWriter::new(file), report).map_err(std::io::Error::other)?;
-    Ok(())
+}
+
+/// Serialize into an already-open handle and put it on disk.
+fn write_through(file: &File, report: &SuiteReport) -> Result<(), std::io::Error> {
+    // The report replaces the file's contents, so a shorter report must not leave the tail of a
+    // longer one behind. This is what lets any caller hand this function a destination rather
+    // than only an empty file.
+    file.set_len(0)?;
+    let mut writer = BufWriter::new(file);
+    serde_json::to_writer_pretty(&mut writer, report).map_err(std::io::Error::other)?;
+    // `BufWriter`'s drop-flush discards its error, so a short write would otherwise return Ok
+    // over a truncated report; and the bytes must be on disk before a caller renames this file
+    // into place.
+    writer.flush()?;
+    file.sync_all()
 }
 
 fn print_matchup_row(r: &MatchupResult) {
@@ -1416,5 +1451,105 @@ mod tests {
             baseline, observed,
             "no-op observer must not perturb (winner, turns)"
         );
+    }
+
+    /// A reserved sink writes into the inode it was handed, never into whatever its former path
+    /// names now.
+    ///
+    /// Guards the finding that the writer reopened the staging path by name: an entry placed
+    /// there after the reservation was followed (symlink) or shared (hard link), so the report
+    /// landed on a file the run never chose.
+    #[cfg(unix)]
+    #[test]
+    fn a_reserved_sink_writes_through_its_descriptor_after_the_path_is_replaced() {
+        const VICTIM: &str = "VICTIM-BYTES";
+        let report = report_with_timing(1, 1);
+
+        for kind in ["symlink", "hardlink"] {
+            let dir = std::env::temp_dir()
+                .join(format!("phase-reserved-sink-{kind}-{}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).expect("scratch dir");
+
+            let victim = dir.join("victim.json");
+            std::fs::write(&victim, VICTIM).expect("seed victim");
+
+            let reserved_path = dir.join("report.staging.json");
+            let file = std::fs::OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&reserved_path)
+                .expect("reserve staging");
+            // A second name for the reserved inode, so it stays readable once its own name is
+            // taken away below.
+            let witness = dir.join("witness.json");
+            std::fs::hard_link(&reserved_path, &witness).expect("witness link");
+
+            std::fs::remove_file(&reserved_path).expect("drop the reserved name");
+            if kind == "symlink" {
+                std::os::unix::fs::symlink(&victim, &reserved_path).expect("symlink");
+            } else {
+                std::fs::hard_link(&victim, &reserved_path).expect("hard link");
+            }
+
+            // PREMISE: the replacement really does redirect that name at the victim, and the
+            // reserved inode is still empty — so neither assertion below can pass vacuously.
+            assert_eq!(
+                std::fs::read_to_string(&reserved_path).expect("read through replacement"),
+                VICTIM,
+                "{kind}: the replacement must resolve to the victim"
+            );
+            assert!(
+                std::fs::read_to_string(&witness)
+                    .expect("read witness")
+                    .is_empty(),
+                "{kind}: the reserved inode must still be empty"
+            );
+
+            write_report(&report, &ReportSink::Reserved(file)).expect("reserved write");
+
+            assert_eq!(
+                std::fs::read_to_string(&victim).expect("read victim"),
+                VICTIM,
+                "{kind}: the reserved sink followed its replaced path onto the victim"
+            );
+            let landed: SuiteReport =
+                serde_json::from_str(&std::fs::read_to_string(&witness).expect("read witness"))
+                    .expect("the reserved inode must hold the report");
+            assert_eq!(landed.results[0].matchup_id, "red-mirror");
+
+            // CONTROL, same fixture, other arm: opening that path by name DOES reach the victim,
+            // which is what makes the survival above a property of the retained descriptor
+            // rather than of an inert fixture.
+            write_report(&report, &ReportSink::Create(reserved_path)).expect("create write");
+            assert_ne!(
+                std::fs::read_to_string(&victim).expect("read victim"),
+                VICTIM,
+                "{kind}: the fixture is inert — writing by name did not reach the victim"
+            );
+
+            std::fs::remove_dir_all(&dir).ok();
+        }
+
+        // A reserved handle is only positioned at offset 0, not necessarily empty. The report
+        // replaces the contents, so no tail of a longer predecessor may survive it.
+        let dir =
+            std::env::temp_dir().join(format!("phase-reserved-sink-padded-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(&dir).expect("scratch dir");
+        let padded = dir.join("padded.json");
+        std::fs::write(&padded, "A".repeat(64 * 1024)).expect("seed padding");
+        let file = std::fs::OpenOptions::new()
+            .write(true)
+            .open(&padded)
+            .expect("open padded");
+
+        write_report(&report, &ReportSink::Reserved(file)).expect("reserved write");
+
+        let landed: SuiteReport =
+            serde_json::from_str(&std::fs::read_to_string(&padded).expect("read padded"))
+                .expect("the padded file must parse as the report, with no tail left behind");
+        assert_eq!(landed.results[0].matchup_id, "red-mirror");
+        std::fs::remove_dir_all(&dir).ok();
     }
 }

--- a/crates/phase-ai/src/duel_suite/run.rs
+++ b/crates/phase-ai/src/duel_suite/run.rs
@@ -146,6 +146,51 @@ impl SuiteReport {
                 .collect(),
         }
     }
+
+    /// Matchups that failed their own `Expected` check, judged without reference to any
+    /// baseline.
+    ///
+    /// This is a different question from `CompareReport::any_fail`, which asks "did this
+    /// change make things worse than the baseline". This one asks "is this run fit to
+    /// *become* the baseline" — and only `SuiteStatus::Fail` disqualifies it.
+    ///
+    /// `SuiteStatus::Open` does not, and it has two producers, not one: `Expected::Open`
+    /// is how a matchup declares it has no verdict yet, and `classify` also returns `Open`
+    /// for any matchup with zero games before it ever inspects `Expected`. Neither is a
+    /// failure, so anything keyed on `!= Pass` would conflate a declared no-verdict with a
+    /// regression. The zero-game case is disqualifying for a different reason and is caught
+    /// by `recorded_games`, not here.
+    pub fn failing_matchups(&self) -> impl Iterator<Item = &MatchupResult> {
+        self.results
+            .iter()
+            .filter(|result| result.status == SuiteStatus::Fail)
+    }
+
+    /// Games actually recorded across every matchup.
+    ///
+    /// A report with none is unfit to become a baseline whatever its statuses say:
+    /// comparison pairs by seed, so a baseline holding no games makes every later
+    /// comparison score zero on every axis and the drift signal dies silently — the same
+    /// false-green this guard exists to prevent, arrived at from the other side.
+    ///
+    /// Deliberately counts games rather than checking for all-`Open`: a suite whose
+    /// matchups are all declared `Expected::Open` still records real games, and such a
+    /// report *is* a usable baseline, because the paired-comparison arm decides on `games`,
+    /// not on `status` — an all-`Open` pair therefore still detects outcome drift. (Stated
+    /// as "decides on games" rather than "never reads status": the paired arm gained status
+    /// tiers in #7026, so the stronger wording would have been false the day that merged.)
+    /// Zero games is the property that makes a baseline inert; all-`Open` is not.
+    ///
+    /// Not an exhaustive list of routes, so it does not claim to be one: `--games 0` is
+    /// refused at parse time, a `--suite-filter` matching no matchups lands here, and
+    /// `failed_result` yields an empty `games` vector alongside `SuiteStatus::Fail`, which
+    /// `failing_matchups` reports first because it names the actual setup error. And this is
+    /// a `pub` method, so its audience includes library callers: `SuiteOptions::new` does not
+    /// validate `games_per_matchup`, so a caller can construct a zero-game run without going
+    /// through the CLI at all.
+    pub fn recorded_games(&self) -> usize {
+        self.results.iter().map(|result| result.games.len()).sum()
+    }
 }
 
 /// Controls decision-trace attribution capture during a suite run. When set
@@ -1080,6 +1125,128 @@ mod tests {
                 attribution: None,
             }],
         }
+    }
+
+    /// Reuses `report_with_timing`'s matchup as the field template so these tests state
+    /// only the axes they exercise: each matchup's status and reason.
+    fn report_with_statuses(statuses: &[(&str, SuiteStatus, Option<&str>)]) -> SuiteReport {
+        let mut report = report_with_timing(1, 100);
+        let template = report.results[0].clone();
+        report.results = statuses
+            .iter()
+            .map(|(id, status, reason)| MatchupResult {
+                matchup_id: (*id).to_string(),
+                status: *status,
+                fail_reason: reason.map(str::to_string),
+                ..template.clone()
+            })
+            .collect();
+        report
+    }
+
+    #[test]
+    fn a_clean_run_has_no_failing_matchups() {
+        let report = report_with_statuses(&[
+            ("red-mirror", SuiteStatus::Pass, None),
+            ("affinity-mirror", SuiteStatus::Pass, None),
+        ]);
+
+        assert_eq!(report.failing_matchups().count(), 0);
+    }
+
+    /// Transcribed from the recorded gate run that motivated this guard (`.ab/noC-1.json`,
+    /// the A+B+D leg of #6969): the statuses and the verbatim `fail_reason` are that run's,
+    /// not invented. Refreshing the baseline from this exact report is what would have
+    /// blessed a broken matchup permanently. The artifact is untracked, so it is
+    /// transcribed rather than loaded — a test that read the file would fail in CI.
+    #[test]
+    fn the_recorded_failing_run_is_disqualified_as_a_baseline() {
+        let report = report_with_statuses(&[
+            ("red-mirror", SuiteStatus::Pass, None),
+            ("affinity-mirror", SuiteStatus::Pass, None),
+            (
+                "enchantress-mirror",
+                SuiteStatus::Fail,
+                Some("mirror imbalance: p0=0.10, Wilson 95% CI [0.02, 0.40] excludes 0.50"),
+            ),
+        ]);
+
+        let failing: Vec<_> = report.failing_matchups().collect();
+        assert_eq!(failing.len(), 1, "the one Fail, not every matchup");
+        assert_eq!(failing[0].matchup_id, "enchantress-mirror");
+        // The reason travels with the matchup: the refusal is only actionable if it can say
+        // *why* the run is unfit, not merely that it is.
+        assert_eq!(
+            failing[0].fail_reason.as_deref(),
+            Some("mirror imbalance: p0=0.10, Wilson 95% CI [0.02, 0.40] excludes 0.50")
+        );
+    }
+
+    /// The discriminating case for `recorded_games`: a suite whose matchups are all
+    /// declared `Expected::Open` still played real games, and that report IS a usable
+    /// baseline, because seed-paired drift detection never consults `status`. An
+    /// implementation that disqualified all-`Open` reports instead of gameless ones would
+    /// pass every other test here and fail this one.
+    #[test]
+    fn an_all_open_run_that_played_games_is_still_a_usable_baseline() {
+        let mut report = report_with_statuses(&[
+            ("experimental-a", SuiteStatus::Open, None),
+            ("experimental-b", SuiteStatus::Open, None),
+        ]);
+        // Uneven on purpose. With one game each, the total (2) equals the MATCHUP count, so
+        // "sum of games" and "number of matchups that played" are indistinguishable — two
+        // mutants with that wrong contract survived the earlier version of this test. Three
+        // games across two matchups separates them.
+        let extra = report.results[0].games[0].clone();
+        report.results[0].games.push(GameResult {
+            seed: extra.seed + 1,
+            ..extra
+        });
+
+        assert_eq!(report.failing_matchups().count(), 0);
+        assert_eq!(
+            report.recorded_games(),
+            3,
+            "two games in the first matchup plus one in the second — a SUM, not a matchup count"
+        );
+    }
+
+    #[test]
+    fn a_gameless_run_records_nothing_however_many_matchups_it_has() {
+        let mut report = report_with_statuses(&[
+            ("red-mirror", SuiteStatus::Open, None),
+            ("affinity-mirror", SuiteStatus::Open, None),
+        ]);
+        // What `--games 0` produces: matchups exist, none of them played anything.
+        for result in &mut report.results {
+            result.games.clear();
+        }
+
+        assert_eq!(report.recorded_games(), 0);
+        // And it is NOT a failure — the two disqualifiers are independent, so a guard that
+        // conflated them would let one of the two holes back open.
+        assert_eq!(report.failing_matchups().count(), 0);
+    }
+
+    #[test]
+    fn a_run_that_selected_no_matchups_records_nothing() {
+        // What a `--suite-filter` matching nothing produces: no matchups at all.
+        let report = report_with_statuses(&[]);
+
+        assert_eq!(report.recorded_games(), 0);
+    }
+
+    #[test]
+    fn an_open_matchup_is_not_a_failure() {
+        // `Expected::Open` classifies as `SuiteStatus::Open`: a matchup that has no verdict
+        // yet, which must not block a refresh. This is the test that dies if the filter is
+        // ever written as the plausible `!= SuiteStatus::Pass` — the other two survive it.
+        let report = report_with_statuses(&[
+            ("red-mirror", SuiteStatus::Pass, None),
+            ("experimental-mirror", SuiteStatus::Open, None),
+        ]);
+
+        assert_eq!(report.failing_matchups().count(), 0);
     }
 
     #[test]

--- a/crates/phase-ai/tests/duel_suite_attribution.rs
+++ b/crates/phase-ai/tests/duel_suite_attribution.rs
@@ -30,7 +30,7 @@ use std::path::PathBuf;
 use engine::database::CardDatabase;
 use phase_ai::config::AiDifficulty;
 use phase_ai::duel_suite::attribution::PolicyAttribution;
-use phase_ai::duel_suite::run::{run_suite, AttributionMode, SuiteOptions};
+use phase_ai::duel_suite::run::{run_suite, AttributionMode, ReportSink, SuiteOptions};
 use phase_ai::duel_suite::FeatureKind;
 
 /// Map a `FeatureKind` to the set of `PolicyId` debug-names whose appearance
@@ -105,7 +105,7 @@ fn declared_exercises_appear_in_attribution() {
         difficulty: AiDifficulty::Easy,
         games_per_matchup: 1,
         base_seed: 7777,
-        output_path: PathBuf::from("target/duel-suite-attribution-test.json"),
+        output: ReportSink::Create(PathBuf::from("target/duel-suite-attribution-test.json")),
         filter: None,
         attribution: AttributionMode::Enabled,
         git_sha: None,

--- a/crates/phase-ai/tests/duel_suite_harvest.rs
+++ b/crates/phase-ai/tests/duel_suite_harvest.rs
@@ -21,7 +21,7 @@ use std::path::{Path, PathBuf};
 
 use engine::database::CardDatabase;
 use phase_ai::config::AiDifficulty;
-use phase_ai::duel_suite::run::{run_suite, SuiteOptions};
+use phase_ai::duel_suite::run::{run_suite, ReportSink, SuiteOptions};
 
 const RED_MIRROR: &str = "red-mirror";
 const MIRROR_BASE_SEED: u64 = 0x00A1_57A1;
@@ -50,7 +50,7 @@ fn is_meta_line(line: &str) -> bool {
 
 fn harvest_opts(games: usize, base_seed: u64, harvest_path: &Path) -> SuiteOptions {
     let mut opts = SuiteOptions::new(AiDifficulty::Medium, games, base_seed);
-    opts.output_path = PathBuf::from("target/duel-suite-harvest-report.json");
+    opts.output = ReportSink::Create(PathBuf::from("target/duel-suite-harvest-report.json"));
     opts.filter = Some(RED_MIRROR.to_string());
     opts.harvest_output = Some(harvest_path.to_path_buf());
     opts

--- a/crates/phase-ai/tests/refresh_baseline_cli.rs
+++ b/crates/phase-ai/tests/refresh_baseline_cli.rs
@@ -215,6 +215,27 @@ fn a_gameless_refresh_is_refused_by_the_block_and_leaves_the_baseline_untouched(
         "a refused refresh must not leave {} behind",
         staging.display()
     );
+    // The consequence of leaving it, asserted rather than inferred: the staging path is now
+    // RESERVED with `create_new`, so a leftover does not merely look like an artefact — it blocks
+    // every later refresh. One refused run must not poison the next.
+    let (next_code, next_stderr) = run(&[
+        "--refresh-baseline",
+        "--data-root",
+        &data_arg,
+        "--baseline",
+        &baseline.display().to_string(),
+        "--current-output",
+        &dir.join("current2.json").display().to_string(),
+        "--suite-filter",
+        "red-mirror",
+        "--games",
+        "1",
+    ]);
+    assert_eq!(
+        next_code,
+        Some(0),
+        "a refused refresh must not block the next one; stderr:\n{next_stderr}"
+    );
     std::fs::remove_dir_all(&dir).ok();
 }
 
@@ -476,6 +497,72 @@ fn two_existing_but_different_files_are_not_aliases() {
         "expected the run to proceed to the card database; stderr:\n{stderr}"
     );
     std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The third route to the same destruction, and the one no argument check can see: the staging
+/// path the process derives for ITSELF.
+///
+/// `staging_path` is deterministic — `<baseline>.staging.json` — and `write_report` opens it with
+/// `File::create` before any refresh guard runs. So an entry already sitting at that path is
+/// followed (symlink) or shared (hard link), and the baseline is truncated by a write nobody
+/// passed on the command line. `same_file` cannot help: it compares `--baseline` against
+/// `--current-output`, and the staging path is neither.
+///
+/// Both alias kinds are exercised because they fail differently — `File::create` FOLLOWS a
+/// symlink to its target, while a hard link IS the target — and a fix that reserved the path
+/// against only one of them would leave the other live.
+#[cfg(unix)]
+#[test]
+fn a_pre_existing_staging_alias_cannot_truncate_the_baseline() {
+    for kind in ["symlink", "hardlink"] {
+        let dir = scratch(&format!("staging-{kind}"));
+        let data_arg = empty_card_db(&dir);
+        let baseline = record_baseline(&dir, &data_arg, "suite-baseline.json");
+        let trusted = std::fs::read_to_string(&baseline).expect("read baseline");
+        let staging = baseline.with_file_name("suite-baseline.json.staging.json");
+        if kind == "symlink" {
+            std::os::unix::fs::symlink(&baseline, &staging).expect("symlink");
+        } else {
+            std::fs::hard_link(&baseline, &staging).expect("hard link");
+        }
+
+        // PREMISE: the alias really points at the baseline, so a write through it would land on
+        // the file under test. Without this the fixture could be inert and the test vacuous.
+        assert_eq!(
+            std::fs::read_to_string(&staging).expect("read through alias"),
+            trusted,
+            "{kind}: the staging alias must resolve to the baseline"
+        );
+
+        // A refresh that would otherwise be ACCEPTED — the destructive case, because an accepted
+        // run is the one that goes on to rename over the baseline.
+        let (code, stderr) = run(&[
+            "--refresh-baseline",
+            "--data-root",
+            &data_arg,
+            "--baseline",
+            &baseline.display().to_string(),
+            "--current-output",
+            &dir.join("current.json").display().to_string(),
+            "--suite-filter",
+            "red-mirror",
+            "--games",
+            "1",
+        ]);
+
+        assert_ne!(
+            code,
+            Some(0),
+            "{kind}: a run that cannot reserve its staging file must not report success; \
+             stderr:\n{stderr}"
+        );
+        assert_eq!(
+            std::fs::read_to_string(&baseline).expect("read baseline"),
+            trusted,
+            "{kind}: the baseline was truncated through the staging alias"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
 }
 
 /// Control arm. Every assertion above is satisfied by a binary that refuses everything, which

--- a/crates/phase-ai/tests/refresh_baseline_cli.rs
+++ b/crates/phase-ai/tests/refresh_baseline_cli.rs
@@ -459,7 +459,14 @@ fn an_accepted_refresh_promotes_the_staged_report_over_the_old_baseline() {
 #[test]
 fn a_hard_linked_output_is_refused_and_the_baseline_survives() {
     let dir = scratch("hardlink");
-    let baseline = seed_baseline(&dir);
+    // A RECORDED baseline and a real card database, because the destructive write is what this
+    // test is about: with SENTINEL and no `--data-root` the run stops at the card database — or,
+    // with only a data root, at the baseline parse — before `run_suite` writes anything, so the
+    // exit code and the surviving bytes are both satisfied by a binary with no identity check at
+    // all, and only the refusal text discriminates.
+    let data_arg = empty_card_db(&dir);
+    let baseline = record_baseline(&dir, &data_arg, "suite-baseline.json");
+    let trusted = std::fs::read_to_string(&baseline).expect("read baseline");
     let link = dir.join("current-link.json");
     std::fs::hard_link(&baseline, &link).expect("hard link");
 
@@ -476,6 +483,12 @@ fn a_hard_linked_output_is_refused_and_the_baseline_survives() {
         &baseline.display().to_string(),
         "--current-output",
         &link.display().to_string(),
+        "--data-root",
+        &data_arg,
+        "--suite-filter",
+        "red-mirror",
+        "--games",
+        "1",
     ]);
 
     assert_eq!(
@@ -489,7 +502,7 @@ fn a_hard_linked_output_is_refused_and_the_baseline_survives() {
     );
     assert_eq!(
         std::fs::read_to_string(&baseline).expect("read baseline"),
-        SENTINEL,
+        trusted,
         "the baseline was truncated through its hard link"
     );
     std::fs::remove_dir_all(&dir).ok();

--- a/crates/phase-ai/tests/refresh_baseline_cli.rs
+++ b/crates/phase-ai/tests/refresh_baseline_cli.rs
@@ -1,0 +1,149 @@
+//! The baseline's file-state contract, asserted against the real binary.
+//!
+//! Review found that the refusal this crate's `--refresh-baseline` guard adds could fire *after*
+//! the damage it exists to prevent: `run_suite` writes its report to the suite's output path
+//! before any guard runs, so pointing `--current-output` at the baseline truncated the baseline
+//! and only then printed "refusing to refresh". Measured on the pre-fix binary: 116 bytes in,
+//! 250 out, different sha256, exit 1. A guard whose subject is already destroyed is not a guard.
+//!
+//! Every assertion here is on the pair (exit status, baseline bytes), because either alone is
+//! satisfied by a broken implementation: exiting non-zero while having clobbered the file is the
+//! bug itself, and leaving the file alone while exiting 0 would bless the run.
+//!
+//! These run the real CLI and deliberately never reach the card database — the argument check
+//! under test rejects before any of that — so they cost milliseconds and add no card-data load
+//! for `scripts/check-test-card-data-load.sh` to object to.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Not a valid suite report, and that is deliberate: these tests must fail if the binary gets
+/// far enough to parse it, because getting that far means it also ran the suite.
+const SENTINEL: &str = r#"{"this":"is the trusted baseline, byte for byte"}"#;
+
+fn scratch(tag: &str) -> PathBuf {
+    let dir = std::env::temp_dir().join(format!("phase-refresh-cli-{tag}-{}", std::process::id()));
+    std::fs::create_dir_all(&dir).expect("create scratch dir");
+    dir
+}
+
+fn seed_baseline(dir: &Path) -> PathBuf {
+    let path = dir.join("suite-baseline.json");
+    std::fs::write(&path, SENTINEL).expect("seed baseline");
+    path
+}
+
+fn run(args: &[&str]) -> (Option<i32>, String) {
+    let out = Command::new(env!("CARGO_BIN_EXE_ai-gate"))
+        .args(args)
+        .output()
+        .expect("spawn ai-gate");
+    (
+        out.status.code(),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+/// The recorded defect, in the direction that destroyed data: a refresh whose output path is the
+/// baseline must be refused with the baseline still byte-identical.
+#[test]
+fn an_aliased_refresh_is_refused_before_the_baseline_can_be_overwritten() {
+    let dir = scratch("refresh");
+    let baseline = seed_baseline(&dir);
+    let path = baseline.display().to_string();
+
+    let (code, stderr) = run(&[
+        "--refresh-baseline",
+        "--baseline",
+        &path,
+        "--current-output",
+        &path,
+        "--suite-filter",
+        "no-such-matchup",
+    ]);
+
+    assert_ne!(
+        code,
+        Some(0),
+        "an aliased refresh must fail; stderr:\n{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&baseline).expect("read baseline"),
+        SENTINEL,
+        "the baseline was modified by a run that was refused"
+    );
+    // LOAD-BEARING — see the module note. Measured: with the alias check deleted, or with
+    // `same_file` forced to false, the two assertions above still pass, because the binary then
+    // fails at the card database with the baseline equally untouched. This assertion is the only
+    // one of the three that dies to those mutants.
+    assert!(
+        stderr.contains("same file"),
+        "the refusal must be about aliasing, not something later; stderr:\n{stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The same aliasing on the COMPARE path, which is the quieter half: there it made the gate read
+/// back the run that had just overwritten the baseline and compare it to itself, reporting no
+/// drift and exiting 0. Measured on the pre-fix binary with a baseline recording p0 at 100%
+/// against a run that scored 0%: `0% | 0%`, zero flips, `0 FAIL`, exit 0.
+#[test]
+fn an_aliased_comparison_is_refused_before_the_baseline_can_be_overwritten() {
+    let dir = scratch("compare");
+    let baseline = seed_baseline(&dir);
+    let path = baseline.display().to_string();
+
+    let (code, stderr) = run(&["--baseline", &path, "--current-output", &path]);
+
+    assert_ne!(
+        code,
+        Some(0),
+        "an aliased comparison must fail; stderr:\n{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&baseline).expect("read baseline"),
+        SENTINEL,
+        "the baseline was modified by a run that was refused"
+    );
+    // LOAD-BEARING — see the module note. Measured: with the alias check deleted, or with
+    // `same_file` forced to false, the two assertions above still pass, because the binary then
+    // fails at the card database with the baseline equally untouched. This assertion is the only
+    // one of the three that dies to those mutants.
+    assert!(
+        stderr.contains("same file"),
+        "the refusal must be about aliasing, not something later; stderr:\n{stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Control arm. Every assertion above is satisfied by a binary that refuses everything, which
+/// would break the gate far worse than the bug being fixed. Distinct paths must get past the
+/// argument check — proven by the failure being about something LATER in the run (the card
+/// database or the suite), never about aliasing.
+#[test]
+fn distinct_paths_are_not_treated_as_aliases() {
+    let dir = scratch("distinct");
+    let baseline = seed_baseline(&dir);
+    let current = dir.join("current.json");
+
+    let (_code, stderr) = run(&[
+        "--baseline",
+        &baseline.display().to_string(),
+        "--current-output",
+        &current.display().to_string(),
+        "--data-root",
+        &dir.join("no-such-data-root").display().to_string(),
+    ]);
+
+    assert!(
+        !stderr.contains("same file"),
+        "distinct paths must not be rejected as aliases; stderr:\n{stderr}"
+    );
+    // PREMISE: the run really did proceed past the argument check, so the assertion above is
+    // about aliasing rather than about the process dying even earlier for some other reason.
+    assert!(
+        stderr.contains("failed to load card database"),
+        "expected the run to proceed to the card database; stderr:\n{stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}

--- a/crates/phase-ai/tests/refresh_baseline_cli.rs
+++ b/crates/phase-ai/tests/refresh_baseline_cli.rs
@@ -746,3 +746,128 @@ fn distinct_paths_are_not_treated_as_aliases() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+/// A symlinked baseline names a file somewhere else, and a refresh must update THAT file.
+///
+/// The pre-staging code opened the baseline with `File::create`, which follows the link and
+/// refreshes its target. Staging + `rename` does not: `rename` acts on the entry, so promoting
+/// onto the supplied spelling replaces the link with a regular file and leaves the target on its
+/// old bytes. Measured on the binary before the fix, over all four arms: exit 0,
+/// "baseline refreshed at <link>", the link no longer a link, and the target byte-identical.
+///
+/// The arms are the ends of the class, not a sample. An absolute and a relative link target
+/// separate a resolver that joins the link's own directory from one that does not; a dangling link
+/// is the first-refresh-through-a-link case, where the target has to be CREATED, which is what
+/// `File::create` did; and a two-hop chain separates a resolver that reads one link from one that
+/// follows to the end. A hard-linked baseline is deliberately absent — a hard link has no target,
+/// and `rename` breaking it instead of truncating the shared inode is the intended behaviour.
+///
+/// The target sits in a SUBDIRECTORY of the link so that "resolved" and "supplied" differ by more
+/// than a file name: a staging file derived from the wrong one lands in the wrong directory.
+///
+/// `#[cfg(unix)]` because creating a symlink on Windows needs a privilege the test process is not
+/// guaranteed to hold; this repository's CI is Linux (`ci.yml`, every job `runs-on: ubuntu-latest`),
+/// so this arm does run there, and the existing
+/// `a_pre_existing_staging_alias_cannot_truncate_the_baseline` sets the precedent.
+#[cfg(unix)]
+#[test]
+fn a_symlinked_baseline_refreshes_its_target_and_stays_a_link() {
+    for kind in ["absolute", "relative", "dangling", "chain"] {
+        let dir = scratch(&format!("symlink-{kind}"));
+        let data_arg = empty_card_db(&dir);
+        std::fs::create_dir_all(dir.join("real")).expect("create target dir");
+        let target = dir.join("real/baseline.json");
+        let link = dir.join("link.json");
+
+        // A marked, VALID baseline at the target for every arm but `dangling`, whose whole point is
+        // that the target does not exist yet. An unparseable one would be refused before the suite
+        // ran, and the assertions would then pass on a run that never reached the promotion.
+        let marked = (kind != "dangling").then(|| {
+            let recorded = record_baseline(&dir, &data_arg, "real/baseline.json");
+            let mut old: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(&recorded).expect("read baseline"))
+                    .expect("baseline is JSON");
+            old["git_sha"] = serde_json::json!("OLD-BASELINE-MARKER");
+            let marked = serde_json::to_string(&old).expect("serialize baseline");
+            std::fs::write(&recorded, &marked).expect("write baseline");
+            marked
+        });
+
+        match kind {
+            // Relative because a link's target resolves against the link's own directory: a
+            // resolver that passes the raw target onward yields `real/baseline.json` relative to
+            // the process cwd, which is not this file.
+            "relative" => std::os::unix::fs::symlink("real/baseline.json", &link),
+            // Two hops. A resolver that reads one link stops at `mid.json` and renames over THAT.
+            "chain" => {
+                let mid = dir.join("mid.json");
+                std::os::unix::fs::symlink(&target, &mid).expect("symlink mid");
+                std::os::unix::fs::symlink(&mid, &link)
+            }
+            _ => std::os::unix::fs::symlink(&target, &link),
+        }
+        .expect("symlink");
+
+        // PREMISE: the link really resolves to the target the assertions read — and, on the
+        // `dangling` arm, really resolves to nothing yet. Without this the fixture could be inert.
+        assert_eq!(
+            std::fs::read_to_string(&link).ok(),
+            marked,
+            "{kind}: the link must resolve to the target under test"
+        );
+
+        let (code, stderr) = run(&[
+            "--refresh-baseline",
+            "--data-root",
+            &data_arg,
+            "--baseline",
+            &link.display().to_string(),
+            "--current-output",
+            &dir.join("current.json").display().to_string(),
+            "--suite-filter",
+            "red-mirror",
+            "--games",
+            "1",
+        ]);
+
+        // Reach guard. Every assertion below is also satisfied by a binary that refuses the run —
+        // which would leave the link a link and the target untouched — so the ACCEPTED path has to
+        // be the one that was taken.
+        assert_eq!(
+            code,
+            Some(0),
+            "{kind}: the refresh must be accepted; stderr:\n{stderr}"
+        );
+        // The defect, in the direction that made the refresh a no-op for the caller: the entry
+        // named on the command line was replaced by a regular file.
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .expect("stat link")
+                .file_type()
+                .is_symlink(),
+            "{kind}: --baseline was a symlink and must still be one"
+        );
+        // The other half: the file the link designates carries THIS run's report. Asserted
+        // positively rather than as "changed", so it covers the `dangling` arm, where the target
+        // had to be created, and so a truncation cannot pass for an update.
+        let written = std::fs::read_to_string(&target).expect("read the link's target");
+        let report: serde_json::Value =
+            serde_json::from_str(&written).expect("the target must hold a report");
+        assert_eq!(report["games_per_matchup"], 1, "{kind}: {written}");
+        assert_eq!(report["results"][0]["matchup_id"], "red-mirror", "{kind}");
+        assert_ne!(
+            report["git_sha"],
+            serde_json::json!("OLD-BASELINE-MARKER"),
+            "{kind}: the target still holds the old baseline"
+        );
+        assert!(
+            !dir.join("real/baseline.json.staging.json").exists(),
+            "{kind}: staging survived beside the resolved destination"
+        );
+        assert!(
+            !dir.join("link.json.staging.json").exists(),
+            "{kind}: staging survived beside the supplied spelling"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}

--- a/crates/phase-ai/tests/refresh_baseline_cli.rs
+++ b/crates/phase-ai/tests/refresh_baseline_cli.rs
@@ -25,8 +25,19 @@ use std::process::Command;
 /// fix, a refresh that reaches `load_report` refuses on this rather than running the suite.
 const SENTINEL: &str = r#"{"this":"is the trusted baseline, byte for byte"}"#;
 
+/// Marks a pre-seeded `--current-output`. On the refresh path the refreshed baseline IS the run's
+/// report, so this file must come back untouched whether the run is refused or accepted.
+const CURRENT_MARKER: &str = "CURRENT-OUTPUT-MARKER";
+
+/// A scratch dir per `tag`. Every caller passes a tag no other caller uses, so the pre-clean
+/// cannot race a sibling test in this binary.
+///
+/// Pre-cleaned because pids are reused and a failed run leaves its dir behind; without it the
+/// next run dies at `create_new`, `symlink()` or `hard_link()` with EEXIST — an infrastructure
+/// failure wearing the costume of an assertion failure.
 fn scratch(tag: &str) -> PathBuf {
     let dir = std::env::temp_dir().join(format!("phase-refresh-cli-{tag}-{}", std::process::id()));
+    let _ = std::fs::remove_dir_all(&dir);
     std::fs::create_dir_all(&dir).expect("create scratch dir");
     dir
 }
@@ -239,6 +250,123 @@ fn a_gameless_refresh_is_refused_by_the_block_and_leaves_the_baseline_untouched(
     std::fs::remove_dir_all(&dir).ok();
 }
 
+/// `--games 0` is refused at argument parse time, before any work at all.
+///
+/// The data root deliberately does not exist, so `failed to load card database` WOULD appear if
+/// the run reached it — its absence is what makes the ordering claim a live signal rather than an
+/// absence-shaped one.
+#[test]
+fn a_zero_game_refresh_is_refused_before_the_run_begins() {
+    let dir = scratch("zero-games");
+    let baseline = seed_baseline(&dir);
+    let current = dir.join("current.json");
+    std::fs::write(&current, CURRENT_MARKER).expect("seed current-output");
+
+    let (code, stderr) = run(&[
+        "--refresh-baseline",
+        "--data-root",
+        &dir.join("no-such-data-root").display().to_string(),
+        "--baseline",
+        &baseline.display().to_string(),
+        "--current-output",
+        &current.display().to_string(),
+        "--games",
+        "0",
+    ]);
+
+    assert_eq!(
+        code,
+        Some(2),
+        "a zero-game refresh must be refused at the argument check; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("--games must be a positive integer"),
+        "the refusal must name --games; stderr:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("failed to load card database"),
+        "the refusal must precede the card database load; stderr:\n{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&baseline).expect("read baseline"),
+        SENTINEL,
+        "the baseline was modified by a run that was refused"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&current).expect("read current-output"),
+        CURRENT_MARKER,
+        "--current-output was written by a run that was refused"
+    );
+    let staging = baseline.with_file_name("suite-baseline.json.staging.json");
+    assert!(
+        !staging.exists(),
+        "a refused refresh must not leave {} behind",
+        staging.display()
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The failure half of the refusal block, executed: a run whose matchup failed its own `Expected`
+/// check must not become the baseline, or the next run compares equal to a blessed regression.
+///
+/// Fixture: with an empty card database, `--seed 20` gives red-mirror four games that all go to
+/// p1, which is what makes `classify` fail the mirror. If the engine ever perturbs those games,
+/// rescan seeds against this same matchup at `--games 4` and take any seed where red-mirror fails
+/// its own check.
+///
+/// Exit code asserted as exactly 1, not merely non-zero: argument and database failures exit 2,
+/// so a mutant that stops the binary before the suite runs fails here.
+#[test]
+fn a_refresh_whose_matchup_failed_is_refused_and_the_baseline_survives() {
+    let dir = scratch("failing-matchup");
+    let data_arg = empty_card_db(&dir);
+    let baseline = record_baseline(&dir, &data_arg, "suite-baseline.json");
+    let trusted = std::fs::read_to_string(&baseline).expect("read baseline");
+
+    let (code, stderr) = run(&[
+        "--refresh-baseline",
+        "--data-root",
+        &data_arg,
+        "--baseline",
+        &baseline.display().to_string(),
+        "--current-output",
+        &dir.join("current.json").display().to_string(),
+        "--suite-filter",
+        "red-mirror",
+        "--games",
+        "4",
+        "--seed",
+        "20",
+    ]);
+
+    assert_eq!(
+        code,
+        Some(1),
+        "expected the refusal block's exit 1, not an earlier failure; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("matchup(s) failed their own suite check"),
+        "the refusal must be the failing-matchup one; stderr:\n{stderr}"
+    );
+    // The per-matchup diagnostic, which is what distinguishes this refusal from the gameless one.
+    assert!(
+        stderr.contains("red-mirror: mirror imbalance"),
+        "the refusal must name the matchup and its reason; stderr:\n{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&baseline).expect("read baseline"),
+        trusted,
+        "a refused refresh must leave the baseline byte-identical"
+    );
+    let staging = baseline.with_file_name("suite-baseline.json.staging.json");
+    assert!(
+        !staging.exists(),
+        "a refused refresh must not leave {} behind",
+        staging.display()
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
 /// The other side of the transaction: an ACCEPTED refresh must actually promote the staged
 /// report over the old baseline.
 ///
@@ -265,6 +393,10 @@ fn an_accepted_refresh_promotes_the_staged_report_over_the_old_baseline() {
     old["git_sha"] = serde_json::json!("OLD-BASELINE-MARKER");
     let marked = serde_json::to_string(&old).expect("serialize baseline");
     std::fs::write(&baseline, &marked).expect("write baseline");
+    // On the refresh path the refreshed baseline IS the run's report, so the suite must stage
+    // beside the baseline rather than write through `--current-output`.
+    let current = dir.join("current.json");
+    std::fs::write(&current, CURRENT_MARKER).expect("seed current-output");
 
     let (code, stderr) = run(&[
         "--refresh-baseline",
@@ -273,7 +405,7 @@ fn an_accepted_refresh_promotes_the_staged_report_over_the_old_baseline() {
         "--baseline",
         &baseline.display().to_string(),
         "--current-output",
-        &dir.join("current.json").display().to_string(),
+        &current.display().to_string(),
         "--suite-filter",
         "red-mirror",
         "--games",
@@ -284,6 +416,11 @@ fn an_accepted_refresh_promotes_the_staged_report_over_the_old_baseline() {
         code,
         Some(0),
         "an accepted refresh must succeed; stderr:\n{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&current).expect("read current-output"),
+        CURRENT_MARKER,
+        "an accepted refresh must not write through --current-output"
     );
     let written = std::fs::read_to_string(&baseline).expect("read baseline");
     assert_ne!(
@@ -502,10 +639,10 @@ fn two_existing_but_different_files_are_not_aliases() {
 /// The third route to the same destruction, and the one no argument check can see: the staging
 /// path the process derives for ITSELF.
 ///
-/// `staging_path` is deterministic — `<baseline>.staging.json` — and `write_report` opens it with
-/// `File::create` before any refresh guard runs. So an entry already sitting at that path is
-/// followed (symlink) or shared (hard link), and the baseline is truncated by a write nobody
-/// passed on the command line. `same_file` cannot help: it compares `--baseline` against
+/// `staging_path` is deterministic — `<baseline>.staging.json` — and `write_report` opened it by
+/// name with `File::create` before any refresh guard ran. So an entry already sitting at that
+/// path was followed (symlink) or shared (hard link), and the baseline was truncated by a write
+/// nobody passed on the command line. `same_file` cannot help: it compares `--baseline` against
 /// `--current-output`, and the staging path is neither.
 ///
 /// Both alias kinds are exercised because they fail differently — `File::create` FOLLOWS a

--- a/crates/phase-ai/tests/refresh_baseline_cli.rs
+++ b/crates/phase-ai/tests/refresh_baseline_cli.rs
@@ -10,15 +10,19 @@
 //! satisfied by a broken implementation: exiting non-zero while having clobbered the file is the
 //! bug itself, and leaving the file alone while exiting 0 would bless the run.
 //!
-//! These run the real CLI and deliberately never reach the card database — the argument check
-//! under test rejects before any of that — so they cost milliseconds and add no card-data load
-//! for `scripts/check-test-card-data-load.sh` to object to.
+//! These run the real CLI. The aliasing tests are rejected at the argument check and never reach
+//! the card database at all. The ones that must run the suite to reach what they test supply
+//! their own database — the literal `{}`, which `CardDatabase::from_export` accepts as an empty
+//! map because it deserialises a map of name→entry. Nothing here loads the ~90 MB export, so the
+//! file stays in the millisecond range and adds no per-test parse.
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
-/// Not a valid suite report, and that is deliberate: these tests must fail if the binary gets
-/// far enough to parse it, because getting that far means it also ran the suite.
+/// Not a valid suite report, and that is deliberate: a test using this as the baseline must fail
+/// if the binary ever parses it, because parsing it means it got further than the check under
+/// test. Usable only where the refusal precedes the baseline read — since the malformed-baseline
+/// fix, a refresh that reaches `load_report` refuses on this rather than running the suite.
 const SENTINEL: &str = r#"{"this":"is the trusted baseline, byte for byte"}"#;
 
 fn scratch(tag: &str) -> PathBuf {
@@ -30,6 +34,45 @@ fn scratch(tag: &str) -> PathBuf {
 fn seed_baseline(dir: &Path) -> PathBuf {
     let path = dir.join("suite-baseline.json");
     std::fs::write(&path, SENTINEL).expect("seed baseline");
+    path
+}
+
+/// A valid, empty card database: the export deserialises a map from card name to entry, so `{}`
+/// is a legal database with no cards. Returns the `--data-root` argument.
+fn empty_card_db(dir: &Path) -> String {
+    let root = dir.join("cards");
+    std::fs::create_dir_all(&root).expect("create data root");
+    std::fs::write(root.join("card-data.json"), "{}").expect("write card data");
+    root.display().to_string()
+}
+
+/// Record a real, parseable baseline by running the binary once.
+///
+/// Tests whose subject lies PAST the baseline read can no longer use `SENTINEL`: a refresh now
+/// refuses an existing baseline it cannot parse, so an invalid fixture would stop the run before
+/// it reached the thing under test — and would do so while still satisfying a naive
+/// "bytes unchanged" assertion. Recording a real one costs about two milliseconds, because an
+/// empty card database still yields one degenerate but playable matchup.
+fn record_baseline(dir: &Path, data_arg: &str, name: &str) -> PathBuf {
+    let path = dir.join(name);
+    let (code, stderr) = run(&[
+        "--refresh-baseline",
+        "--data-root",
+        data_arg,
+        "--baseline",
+        &path.display().to_string(),
+        "--current-output",
+        &dir.join("record-current.json").display().to_string(),
+        "--suite-filter",
+        "red-mirror",
+        "--games",
+        "1",
+    ]);
+    assert_eq!(
+        code,
+        Some(0),
+        "recording a baseline failed; stderr:\n{stderr}"
+    );
     path
 }
 
@@ -112,6 +155,325 @@ fn an_aliased_comparison_is_refused_before_the_baseline_can_be_overwritten() {
     assert!(
         stderr.contains("same file"),
         "the refusal must be about aliasing, not something later; stderr:\n{stderr}"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The refusal block itself, executed.
+///
+/// An earlier round disclosed this as uncovered: the two predicates behind the refusal were unit
+/// tested, but the block that acts on them lived in a binary no test ran, so deleting or
+/// inverting it left the suite green. Reaching it looked like it needed a card database and a
+/// real suite run — minutes of CI for a local-only command.
+///
+/// It does not. `CardDatabase::from_export` deserialises a map, so `{}` is a VALID empty
+/// database, and a `--suite-filter` matching nothing selects no matchups, builds no decks and
+/// plays no games. The run therefore reaches `recorded_games() == 0` and refuses, in about five
+/// milliseconds, with no card data on disk.
+///
+/// The exit code is asserted as exactly 1 rather than merely non-zero, and that is what makes
+/// this test see the block instead of an early death: argument and database failures exit 2, so
+/// a mutant that stops the binary before the suite runs changes 1 to 2 and fails here.
+#[test]
+fn a_gameless_refresh_is_refused_by_the_block_and_leaves_the_baseline_untouched() {
+    let dir = scratch("gameless");
+    let data_arg = empty_card_db(&dir);
+    let baseline = record_baseline(&dir, &data_arg, "suite-baseline.json");
+    let trusted = std::fs::read_to_string(&baseline).expect("read baseline");
+
+    let (code, stderr) = run(&[
+        "--refresh-baseline",
+        "--data-root",
+        &data_arg,
+        "--baseline",
+        &baseline.display().to_string(),
+        "--current-output",
+        &dir.join("current.json").display().to_string(),
+        "--suite-filter",
+        "no-such-matchup",
+    ]);
+
+    assert_eq!(
+        code,
+        Some(1),
+        "expected the refusal block's exit 1, not an earlier failure; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("recorded no games"),
+        "the refusal must be the gameless one; stderr:\n{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&baseline).expect("read baseline"),
+        trusted,
+        "a refused refresh must leave the baseline byte-identical"
+    );
+    // The staging file is an implementation detail of the transaction, but a leftover one is an
+    // artefact someone later mistakes for a real baseline.
+    let staging = baseline.with_file_name("suite-baseline.json.staging.json");
+    assert!(
+        !staging.exists(),
+        "a refused refresh must not leave {} behind",
+        staging.display()
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The other side of the transaction: an ACCEPTED refresh must actually promote the staged
+/// report over the old baseline.
+///
+/// Without this, "a refused run leaves the baseline alone" is satisfied by a binary that never
+/// writes a baseline at all — measured: deleting the promotion entirely left every other test in
+/// this file green. The two directions have to be asserted together or the guard is
+/// indistinguishable from a break.
+///
+/// Reachable at the same near-zero cost as the refusal tests, for a reason worth recording: an
+/// empty card database still yields a playable (degenerate) matchup, so a single game completes
+/// in about two milliseconds and the run is accepted. The baseline written here is meaningless
+/// as a baseline — that is fine, because what is under test is the file transaction, not the
+/// contents.
+#[test]
+fn an_accepted_refresh_promotes_the_staged_report_over_the_old_baseline() {
+    let dir = scratch("accept");
+    let data_arg = empty_card_db(&dir);
+    let baseline = record_baseline(&dir, &data_arg, "suite-baseline.json");
+    // Mark the recorded baseline so "was it replaced?" is answered by content, not by mtime.
+    // A marked-but-valid file is required: an invalid one is now refused before the suite runs.
+    let mut old: serde_json::Value =
+        serde_json::from_str(&std::fs::read_to_string(&baseline).expect("read baseline"))
+            .expect("baseline is JSON");
+    old["git_sha"] = serde_json::json!("OLD-BASELINE-MARKER");
+    let marked = serde_json::to_string(&old).expect("serialize baseline");
+    std::fs::write(&baseline, &marked).expect("write baseline");
+
+    let (code, stderr) = run(&[
+        "--refresh-baseline",
+        "--data-root",
+        &data_arg,
+        "--baseline",
+        &baseline.display().to_string(),
+        "--current-output",
+        &dir.join("current.json").display().to_string(),
+        "--suite-filter",
+        "red-mirror",
+        "--games",
+        "1",
+    ]);
+
+    assert_eq!(
+        code,
+        Some(0),
+        "an accepted refresh must succeed; stderr:\n{stderr}"
+    );
+    let written = std::fs::read_to_string(&baseline).expect("read baseline");
+    assert_ne!(
+        written, marked,
+        "the accepted run was never promoted over the old baseline"
+    );
+    // PREMISE: what landed is the run's report, not any other file the process might have
+    // written — so "changed" cannot pass by truncation or by a stray write.
+    let report: serde_json::Value = serde_json::from_str(&written).expect("baseline is JSON");
+    assert_eq!(report["games_per_matchup"], 1);
+    assert_eq!(report["results"][0]["matchup_id"], "red-mirror");
+    assert_eq!(
+        report["results"][0]["games"].as_array().map(Vec::len),
+        Some(1),
+        "the promoted baseline must carry the game that was played"
+    );
+    let staging = baseline.with_file_name("suite-baseline.json.staging.json");
+    assert!(
+        !staging.exists(),
+        "staging must not survive a successful refresh"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The alias no path comparison can see: one inode, two names.
+///
+/// `canonicalize` faithfully resolves a hard link to its own name, so the pre-fix path check
+/// called these distinct and let the run proceed — and `write_report` opens `--current-output`
+/// with `File::create`, which truncates the shared inode. Reading the baseline before the suite
+/// runs saves the *verdict* from being computed against the run's own output, but it does not
+/// save the *bytes*; only refusing does. Both halves are asserted here for that reason.
+///
+/// Compare mode rather than refresh, because it is the quieter half: refresh at least prints a
+/// refusal, while compare would have gone on to report no drift and exit 0 against a baseline it
+/// had just destroyed.
+#[test]
+fn a_hard_linked_output_is_refused_and_the_baseline_survives() {
+    let dir = scratch("hardlink");
+    let baseline = seed_baseline(&dir);
+    let link = dir.join("current-link.json");
+    std::fs::hard_link(&baseline, &link).expect("hard link");
+
+    // PREMISE: the fixture really is one file under two names. Without this the test would still
+    // pass on a platform or filesystem that silently copied instead, having proven nothing.
+    assert_ne!(
+        std::fs::canonicalize(&baseline).expect("canonicalize baseline"),
+        std::fs::canonicalize(&link).expect("canonicalize link"),
+        "a hard link must present two distinct paths, or this test is not about hard links"
+    );
+
+    let (code, stderr) = run(&[
+        "--baseline",
+        &baseline.display().to_string(),
+        "--current-output",
+        &link.display().to_string(),
+    ]);
+
+    assert_eq!(
+        code,
+        Some(2),
+        "a hard-linked output must be refused at the argument check; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("same file"),
+        "the refusal must name the aliasing; stderr:\n{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&baseline).expect("read baseline"),
+        SENTINEL,
+        "the baseline was truncated through its hard link"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// A baseline that exists but cannot be parsed must stop the refresh, not be overwritten by it.
+///
+/// The earlier code logged every read failure and carried on, so the run continued to `run_suite`
+/// and renamed its staged report over the file. That destroys the evidence needed to work out WHY
+/// the baseline was unreadable, and establishes the replacement from an unexamined prior state.
+///
+/// The exit code is asserted as exactly 2, which is what separates this from the gameless
+/// refusal's 1: the point is that the run stops BEFORE the suite, not that it stops eventually.
+/// A mutant that let the run proceed and refused later would leave the bytes intact on this
+/// fixture too, and the code is the only assertion that tells the two apart.
+#[test]
+fn a_malformed_existing_baseline_is_not_replaced_by_a_refresh() {
+    let dir = scratch("malformed");
+    let data_arg = empty_card_db(&dir);
+    let baseline = seed_baseline(&dir);
+
+    let (code, stderr) = run(&[
+        "--refresh-baseline",
+        "--data-root",
+        &data_arg,
+        "--baseline",
+        &baseline.display().to_string(),
+        "--current-output",
+        &dir.join("current.json").display().to_string(),
+        "--suite-filter",
+        "red-mirror",
+        "--games",
+        "1",
+    ]);
+
+    assert_eq!(
+        code,
+        Some(2),
+        "a malformed baseline must stop the run before the suite; stderr:\n{stderr}"
+    );
+    assert!(
+        stderr.contains("failed to load baseline"),
+        "the refusal must name the baseline load; stderr:\n{stderr}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(&baseline).expect("read baseline"),
+        SENTINEL,
+        "an unreadable baseline must be preserved for diagnosis, not overwritten"
+    );
+    let staging = baseline.with_file_name("suite-baseline.json.staging.json");
+    assert!(
+        !staging.exists(),
+        "a refused refresh must not leave {} behind",
+        staging.display()
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// The other side of that refusal: a MISSING baseline is the ordinary first-refresh case and must
+/// still be allowed through.
+///
+/// Without this, narrowing the accepted error to `NotFound` is indistinguishable from refusing
+/// every unreadable baseline including the absent one — which would make the first refresh on a
+/// fresh checkout impossible. Measured: this is the arm that fails if the `NotFound` guard is
+/// dropped in the refusing direction.
+#[test]
+fn a_missing_baseline_is_still_the_first_refresh_case() {
+    let dir = scratch("firstrun");
+    let data_arg = empty_card_db(&dir);
+    let baseline = dir.join("does-not-exist-yet.json");
+    assert!(!baseline.exists(), "fixture must start with no baseline");
+
+    let (code, stderr) = run(&[
+        "--refresh-baseline",
+        "--data-root",
+        &data_arg,
+        "--baseline",
+        &baseline.display().to_string(),
+        "--current-output",
+        &dir.join("current.json").display().to_string(),
+        "--suite-filter",
+        "red-mirror",
+        "--games",
+        "1",
+    ]);
+
+    assert_eq!(
+        code,
+        Some(0),
+        "a first refresh with no baseline must succeed; stderr:\n{stderr}"
+    );
+    assert!(
+        baseline.exists(),
+        "the first refresh must create the baseline"
+    );
+    std::fs::remove_dir_all(&dir).ok();
+}
+
+/// Control arm for the identity check specifically: two files that BOTH exist and are genuinely
+/// different must not be called aliases.
+///
+/// `distinct_paths_are_not_treated_as_aliases` does not cover this — its output path does not
+/// exist, so `same_inode` returns `None` and the path fallback answers. This is the only case
+/// that reaches the inode comparison and expects `Some(false)`, so without it an implementation
+/// that reported every existing pair as identical would pass the whole file while refusing every
+/// real invocation of the gate.
+///
+/// Known gap, stated rather than implied: this does not pin the `dev` half of `(dev, ino)`. A
+/// mutant comparing only `ino` survives every test here, because killing it needs two files on
+/// different filesystems whose inode numbers collide, and inode allocation is not controllable
+/// enough to construct that deterministically. The `dev` term is kept on correctness grounds —
+/// dropping it can only ever produce a false ALIAS report, whose consequence is a refused run
+/// rather than a destroyed baseline, so the unpinned direction is the safe one.
+#[test]
+fn two_existing_but_different_files_are_not_aliases() {
+    let dir = scratch("distinct-existing");
+    let baseline = seed_baseline(&dir);
+    let current = dir.join("current.json");
+    std::fs::write(&current, "{}").expect("seed current");
+
+    // PREMISE: both really exist, so the run reaches the inode comparison rather than the
+    // path fallback this test is not about.
+    assert!(baseline.exists() && current.exists());
+
+    let (_code, stderr) = run(&[
+        "--baseline",
+        &baseline.display().to_string(),
+        "--current-output",
+        &current.display().to_string(),
+        "--data-root",
+        &dir.join("no-such-data-root").display().to_string(),
+    ]);
+
+    assert!(
+        !stderr.contains("same file"),
+        "two distinct existing files must not be called aliases; stderr:\n{stderr}"
+    );
+    // PREMISE: the run proceeded past the argument check, so the assertion above is about
+    // aliasing rather than about the process dying even earlier.
+    assert!(
+        stderr.contains("failed to load card database"),
+        "expected the run to proceed to the card database; stderr:\n{stderr}"
     );
     std::fs::remove_dir_all(&dir).ok();
 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

`cargo ai-gate --refresh-baseline` ran the suite and wrote the result to the baseline path without ever inspecting the result's own verdicts. Because the baseline is what every later run is compared against, one refresh from a red run blessed that failure permanently: the next run compared equal to the blessed report, the comparison reported no drift, and the gate exited 0 forever while the matchup stayed broken.

This is the other half of the policy #7026 left open. That PR made an existing matchup going non-Fail → Fail fail the comparison, and reported a still-failing matchup on every run rather than passing quietly — but it deliberately Warned rather than Failed on the already-blessed case, on the grounds that the exit code answers "did this change make things worse" and a baseline, however it got that way, already sanctions its own contents. The question it filed rather than smuggled in is whether a baseline may bless a failure at all. It may not.

## Files changed

- `crates/phase-ai/src/duel_suite/run.rs` — `SuiteReport::failing_matchups()` and `SuiteReport::recorded_games()`, plus tests
- `crates/phase-ai/src/bin/ai_gate.rs` — refuse the refresh on a failing or gameless run; reject `--games 0` at parse time; load the baseline before the suite runs, stage-and-rename the refreshed baseline, and refuse aliased `--baseline`/`--current-output` (review round 2)
- `crates/phase-ai/tests/refresh_baseline_cli.rs` — process/file-state regression against the real binary
- `.github/workflows/ci.yml` — provision `ai-gate` for the shards whose tests launch it (build, upload, chmod)

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Effort: high

## Implementation method (required)

Method: not-applicable — this is gate/tooling plumbing in `crates/phase-ai`, with no engine game logic, no Oracle parsing, and no card behaviour.

## CR references

None. No MTG rules logic is touched.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

### What disqualifies a run, and why only these things

`SuiteReport::failing_matchups` reports matchups that failed their own `Expected` check, judged with no reference to any baseline. That is a different question from `CompareReport::any_fail`, which asks whether a change made things worse than the baseline; this asks whether a run is fit to *become* the baseline. It returns the matchups rather than a bool because the refusal is only actionable if it can name which matchup failed and quote its `fail_reason`.

Only `SuiteStatus::Fail` disqualifies on that axis. `Open` does not, and the distinction is load-bearing: `Expected::Open` is how a matchup declares it has no verdict yet, and that declaration belongs in the suite definition where it is visible and reviewable, not smuggled in by committing a red baseline. An implementation keyed on `!= Pass` would conflate the two and make `Expected::Open` unusable — there is a test whose only job is to fail against that.

`SuiteReport::recorded_games` disqualifies a second, independent case that review surfaced: a run that measured nothing. Comparison pairs by seed, so a baseline holding no games makes every later comparison score zero on every axis and the drift signal dies as quietly as a blessed-red one. It counts games rather than testing for all-`Open` deliberately — a suite whose matchups are all declared `Expected::Open` still plays real games, and that report *is* a usable baseline, because the paired-comparison arm decides on `games`, not on `status`. (Stated that way rather than "never reads `status`": the paired arm gains status tiers in #7026, so the stronger wording would have been false the day that merged. Review caught the stronger version — see the in-flight-branch note below.) Zero games is what makes a baseline inert; all-`Open` is not.

### No override flag

The escape hatch already exists one layer up and is the correct layer, so a second one at the baseline would only let a caller bypass the more visible mechanism. Verified non-bricking before choosing absolute refusal: the committed baseline is 3/3 `Pass`, so no workflow depends on a blessed failure.

### CI blast radius: none, measured

`refresh-baseline` appears in no workflow. CI runs `cargo ai-gate --games 10` and `--full-suite --games 100`, both compare-only. Refresh is a local human operation, so this cannot break a pipeline — it can only stop a person committing a blessed-red baseline.

### The failing case is pinned to the run that caused it

`the_recorded_failing_run_is_disqualified_as_a_baseline` transcribes the recorded gate run that motivated this guard: red-mirror and affinity-mirror `Pass`, enchantress-mirror `Fail` carrying its verbatim reason `mirror imbalance: p0=0.10, Wilson 95% CI [0.02, 0.40] excludes 0.50`. That is the exact report a refresh would have blessed. It is transcribed rather than loaded because the artifact is untracked and a test that read it would fail in CI.

### Mutant evidence

Nine mutants, tree restored byte-identical after each. Kill counts below are transcribed from the runs. An earlier draft of this section asserted three of them from memory and review measured all three wrong, so they are given as figures rather than as characterisations.

| mutant | killed by |
|---|---|
| drop the filter | 5 |
| return nothing | 1 (`the_recorded_failing_run_is_disqualified_as_a_baseline`) |
| `!= SuiteStatus::Pass` | 3 (every test asserting an `Open` matchup is not a failure) |
| `recorded_games` body → `0` | 1 |
| `recorded_games` body → `1` | 3 |
| `recorded_games` body → `2` | 3 |
| count non-`Open` matchups instead of games | 1 |
| count matchups-with-games | 1 |
| sum `games.len().min(1)` | 1 |

The last two are there because they **survived** an earlier version of this change. Every fixture carried exactly one game per matchup, so the total always equalled the matchup count and "sum of games" was never distinguished from "number of matchups that played" — against the real baseline (3 matchups × 10 games) those mutants return 3 where the contract says 30. The assertion looked like a magnitude pin, but its expected value was simultaneously the matchup count, and a fixture whose two interpretations coincide pins neither. The fixture is now uneven (two games in one matchup, one in the other) and asserts `3`, which review confirmed is distinct from every other countable that implementation could plausibly return — it probed seven, including `games_per_matchup × len`, wins-sum, distinct seeds, and max-per-matchup.

The constants are listed individually because the choice decides the answer: an earlier draft said "making it constant fails all three tests", which is true only for `1` and false for `0` — the value the guard actually tests.

One further mutation is reported rather than counted: dropping the `fail_reason` passthrough is **not** a mutation of the predicate. `failing_matchups` yields `&MatchupResult`, so no change to it can drop that field; the only reachable site is the test helper. It shows the assertion genuinely reads the field and pins the iterator's item type against narrowing, but it is not predicate coverage.

### End-to-end, and one surface deliberately left uncovered

No unit test can reach a binary's `main`, so the wiring was proven through the CLI. All three arms use the same binary with no source mutation, and the binary was verified to contain both refusal strings first so no arm could pass against a stale build: `--games 0` is rejected at parse time without running the suite; a `--suite-filter` matching no matchups is refused with nothing written; and a real two-game run still refreshes, recording 2 games, as the positive control that shows the guard is not simply refusing everything.

The two refusals are ordered failures-first, and the order is load-bearing rather than cosmetic: the conditions are not exclusive. `failed_result` builds a matchup with an empty `games` vector **and** `SuiteStatus::Fail`, so a run whose deck payloads all fail to load satisfies both — and checking gamelessness first would replace each matchup's `setup error: …` with a sentence about seeds. Nothing is lost by the chosen order, because a merely gameless run has no failing matchups to report. Review verified the full 2×2 of the two conditions and found no input where the old order was better and no exit code changed.

**This surface is no longer uncovered — see "The execution pin, closed" below.** It was disclosed here on the premise that reaching the refusal block needs a card database and a real suite run, which is minutes of CI for a local-only command. That premise was false, and cheaply so, which is why the paragraph is corrected rather than left standing with an apology attached.

### A note on durable claims, which review taught me here

Round 2 caught a claim that was true in this tree and false in a branch I am driving: "seed-paired drift detection never consults `status`" holds at this head but not on #7026, where the paired arm gains status tiers — so it would have gone false the day that PR merged, and #7026 is cited two paragraphs above it. The wording is now durable under both. The instrument came from the reviewer, and applying it to my own open PR immediately found three more instances there, which are fixed separately on that branch.

## Review response (2026-08-05 12:12Z) — blocker confirmed, and it had a quieter twin

**HIGH — the refusal fired after the damage. Reproduced before changing anything.**

`run_suite` writes its report to `options.output_path` before any guard runs, and `--baseline` / `--current-output` are independent flags, so aliasing them let a rejected run truncate the baseline first. On the built binary at the reviewed head:

| | baseline bytes | sha256 | exit |
|---|---|---|---|
| before | 116 | `985133e3…` | |
| after `--refresh-baseline --baseline X --current-output X --suite-filter no-such` | 250 | `bc9649fd…` | 1 |

It printed "refusing to refresh" over a baseline it had already destroyed.

**The same aliasing on the compare path is worse, because it is silent.** `load_report(&args.baseline)` read back the report the suite had just written over it, so the gate compared the run to itself. Measured with a baseline recording p0 at 100% against a run that scored 0%:

```
| red-mirror | AggroPressure | 0% | 0% | 0 | 0 | — | PASS |
compare: 0 FAIL, 0 WARN, 1 PASS, 0 NEW, 0 REMOVED     exit 0
```

An honest comparison of those inputs is a win-rate collapse. That is this branch's own subject — a false green — reached by destroying the evidence rather than by misreading it. Found while verifying your blocker, fixed here.

### Three layers, each doing something the others cannot

**1. Root cause on the compare path: read the baseline before the suite runs.** The defect is *when* the baseline is read, not which paths were passed, so ordering is the fix, and it is immune to aliasing by construction — including aliases no path comparison can detect. Proven with a **hard link**, which defeats layer 3 outright (same inode, different name, so canonicalising calls them distinct while a write to either truncates both):

```
| red-mirror | AggroPressure | 100% | 0% | 1 | 0 | 0.2500 | WARN |
```

The pre-fix binary called those same inputs `0% | 0%`, PASS. This is the measurement that shows ordering, not the argument check, is carrying the correctness.

**2. The refresh is transactional.** The suite writes to `<baseline>.staging.json`; the baseline is replaced by renaming it only after every guard passes, and each refusal removes it. Sibling, not `/tmp`, because `rename` is atomic only within a filesystem — a cross-mount staging path degrades silently to copy-then-truncate, reintroducing the half-written baseline it exists to prevent. `write_report` is deleted: it was the last writer that could produce a baseline outside the transaction. `--current-output` is consequently unused on the refresh path (the refreshed baseline *is* the run's report); no workflow passes `--refresh-baseline`, so nothing in CI depends on that.

**3. Aliased paths are refused outright,** before the card database and before a game. Correctness no longer depends on it, but aliasing still destroys the user's file as a side effect of a write that had no business landing there.

### Measured after the fix

| arm | exit | baseline sha256 | staging left |
|---|---|---|---|
| aliased refresh | 2 | **unchanged** | none |
| aliased compare | 2 | **unchanged** | none |
| hard-linked compare (defeats layer 3) | 0 | truncated by design; verdict **honest** — `100% → 0%`, 1 flip, WARN | n/a |
| rejected non-aliased refresh (gameless) | 1 | **unchanged** | none |
| successful refresh | 0 | created, 1 game recorded | none |

### The CLI test you asked for, and the version of it I had to throw away

You asked for a process/file-state regression asserting non-zero exit and unchanged baseline bytes. I wrote exactly that, then mutated it: **deleting the alias check killed 0 tests, and forcing `same_file` to return `false` killed 0.** Both passed because without a card database the binary exits non-zero at the database load with the baseline equally untouched — the pair was satisfied for a reason unrelated to the hazard.

Adding an assertion that the refusal *names* the aliasing makes both mutants fail two tests each. A third mutant — `same_file` always `true` — is caught only by the control arm asserting distinct paths still proceed (and its premise checks that they reach the card database, so "not rejected as aliases" is not vacuous either). The module comment records this rather than hiding it; the byte-preservation claim under a real run rests on the table above, not on the test.

`tests/refresh_baseline_cli.rs` runs the real binary and costs ~0ms. (Written before the execution pin closed; the aliasing tests still never reach the card database, while the cases that must run the suite supply their own `{}` database. Nothing loads the ~90 MB export — and that gate is scoped to `crates/engine` in any case, so it never applied here.) Two unit tests pin the properties the layers rest on: the staging file is a sibling of the baseline (what makes `rename` atomic), and `same_file` sees through a symlink while still calling genuinely distinct paths distinct.

**This paragraph previously read "Not covered: the ordering and staging fixes are argued from the code path and measured on the built binary, not pinned by an automated test — reaching them requires a card database and a real suite run." Three of its four clauses are now false.** See below.

### The execution pin, closed

`CardDatabase::from_export` deserialises a map from card name to entry, so the literal `{}` is a **valid empty card database**. A `--suite-filter` matching nothing then selects no matchups, builds no decks and plays no games, so the run reaches `recorded_games() == 0` and refuses — in about five milliseconds, with no card data on disk:

```
EXIT=1  BASELINE=unchanged  STAGING=absent
refusing to refresh <path>: the run recorded no games, so every later comparison would score zero
real 0m0.005s
```

A second fact fell out of a *surviving* mutant: an empty database still yields one degenerate but playable matchup, ~2ms per game, so the **accept** path is reachable at the same cost. That is what made both directions of the file transaction testable, and it is why "never promote at all" no longer survives.

The exit code is asserted as exactly 1, not merely non-zero, and that is what makes the test see the refusal block rather than an early death: argument and database failures exit 2, so any mutant stopping the binary before the suite runs turns 1 into 2 and fails.

What remains genuinely unpinned is narrow and stated: a successful refresh against **real decks**. The transaction is pinned; the card content flowing through it is not.


## Review response (2026-08-05 14:07Z) — both HIGHs confirmed and fixed

Both findings are real, both are fixed at `43fdc6683373`, and one of them found the fix I had designed for myself was the weaker of the two available.

**HIGH-1 — a malformed existing baseline was still eligible for replacement.** Confirmed. The refresh arm caught every `load_report` error, logged it, and continued to `run_suite`, which renamed the staged report over the file. So a baseline that was corrupt, truncated, or unreadable was destroyed rather than kept for diagnosis, and the new reference was established from a prior state nobody had examined. Fixed as you specified: only `ErrorKind::NotFound` proceeds. One deviation from the letter of the suggestion, in your favour — matching on the error kind rather than `!baseline.exists()`, because the latter asks the filesystem a second, later question and answers the wrong one under a permission error, where the file exists but `exists()` reports false.

**HIGH-2 — `same_file` missed hard-link aliases.** Confirmed, and your fix is better than mine. I had independently designed a test for exactly this case, but as a pin on the *ordering* — the baseline is read before the suite writes, so the verdict survives even when the bytes do not. Your framing names why that is insufficient in one clause: "retaining the preloaded report in memory avoids a false comparison but not data loss." The ordering saves the verdict; only refusing saves the file. `same_file` now compares `(dev, ino)` when both paths exist and keeps the canonicalized-parent fallback for the usual case where the output does not exist yet.

That change falsified a comment two lines below it, which claimed `same_file` cannot see hard links. Rewritten rather than deleted: the ordering stays as defence in depth on an honest basis — `same_file` enumerates the ways two names can mean one file, and any such enumeration is a claim a future filesystem can falsify.

### Fixture damage the HIGH-1 fix caused, and why it mattered

Two existing tests used an invalid sentinel as the baseline. The malformed-baseline fix now refuses that *before* either test reaches its subject — while still satisfying their "bytes unchanged" assertion, so both would have gone on passing for entirely the wrong reason. They now record a real baseline first (~2ms). This is the same failure mode as the one your round-2 finding taught me: an assertion pair that is satisfied because the run died early, not because the guard held.

### Mutant evidence

Five mutants, tree restored byte-identical after each and verified with `diff -q`.

| mutant | killed |
|---|---|
| drop the inode check (pre-fix behaviour) | 1 (`a_hard_linked_output_is_refused_and_the_baseline_survives`) |
| refresh swallows every baseline read error (the reported defect) | 1 (`a_malformed_existing_baseline_is_not_replaced_by_a_refresh`) |
| refuse a missing baseline too | 3 (first-refresh, accepted-refresh, gameless) |
| `same_inode` returns `Some(true)` unconditionally | 1 (`two_existing_but_different_files_are_not_aliases`) |
| compare `ino` without `dev` | **0 — SURVIVES** |

**The survivor is reported, not hidden.** Killing it requires two files on different filesystems whose inode numbers collide, and inode allocation is not controllable enough to construct that deterministically in a fixture. `dev` is kept on correctness grounds, and the unpinned direction is the safe one: dropping it can only produce a false *alias* report, whose consequence is a refused run, never a destroyed baseline. If you want it pinned anyway I will take a suggestion on how — I could not find a construction that was not flaky.

Two of the new tests exist as two-sided controls rather than as coverage. `two_existing_but_different_files_are_not_aliases` is the only case that reaches the inode comparison expecting `Some(false)` — the pre-existing distinct-paths test leaves the output nonexistent, so `same_inode` returns `None` and the path fallback answers, meaning an implementation calling every existing pair identical would have passed the entire file while refusing every real gate invocation. `a_missing_baseline_is_still_the_first_refresh_case` is the matching control on the other fix: without it, narrowing to `NotFound` is indistinguishable from refusing every unreadable baseline, which would make the first refresh on a fresh checkout impossible.

Measured at this head: 9 CLI tests green in 0.08s, 2026 lib tests green, `clippy -p phase-ai --all-targets -D warnings` clean, `cargo fmt --check` clean.

CodeRabbit's two inline comments are the same two findings and are addressed by the same commit.

## Gate A


Gate A PASS head=b71e0a3db506fb38d1a7fe9e217f7e20dbb4af4b base=c44a4512e6f91684068c259a028eb44b4d801340

Base passed explicitly (`./scripts/check-parser-combinators.sh c44a4512e6f91684068c259a028eb44b4d801340`), so the examined range is
exactly this diff: 4 commits, 3 files, non-empty. It contains **zero parser paths**, so the
parser-specific verdict is vacuous by construction — labelled rather than presented as a pass.
Gate G also PASS at this head.

## Anchored on


- crates/phase-ai/src/duel_suite/compare.rs:57 — CompareReport::any_fail, the existing report-level predicate whose result drives an exit code. failing_matchups is the same shape at the same seam: a predicate on a report, owned by the library, consumed by a binary that decides what to do about it. It returns the matchups rather than a bool only because the refusal has to name them.
- crates/phase-ai/src/bin/ai_perf_gate.rs:239 — the sibling --refresh-baseline block, structurally identical to the one guarded here. It anchors the seam and the scope decision: it is deliberately left unguarded, because PerfReport carries no intrinsic verdict (any_fail lives on PerfCompareReport, perf.rs:467, keyed on comparison). A perf run cannot be failing on its own, so there is nothing there to refuse.

Both line numbers re-verified at this head: compare.rs:57 is `pub fn any_fail(&self) -> bool {`, and
ai_perf_gate.rs:239 is `if args.refresh_baseline {`.

## Final review-impl


Final review-impl PASS head=b71e0a3db506fb38d1a7fe9e217f7e20dbb4af4b

Certified at `cert-r3 PASS head=ba39f354fb200a8d96a9146e2d70443ed55083f0`, and carried to this head
by a content-preserving rebase: `git diff` over the pre-rebase range and over
`c44a4512e6f91684068c259a028eb44b4d801340..b71e0a3db506fb38d1a7fe9e217f7e20dbb4af4b` are byte-identical (1237 lines, md5 `750675149582`), so only the base moved. The
maintainer's hold comment records the prior requested-changes findings as fixed at the pre-rebase
head; that assessment transfers unchanged.
Three rounds. Round 1 returned PASS with three findings. Round 2 returned **FAIL**, and the classification is worth stating plainly because the code was not the problem: the reviewer's words were "the shipped code is correct" — both holes closed, design premise verified against the real comparison code, parse change behaviour-preserving. The FAIL was on my evidence. Three mutant kill counts in the commit message were asserted from memory and all three were measurably wrong (drop-filter said 3, is 5; `!= Pass` said 1 "surviving the other two entirely", is 3; "constant fails all three" is true only for the constant `1` and false for `0`, the value the guard actually tests). Two mutants were also found *surviving*: `recorded_games` was pinned only at zero/non-zero, because every fixture had one game per matchup so the total always coincided with the matchup count — an `assert_eq!(..., 2)` that looked like a magnitude pin when 2 was also the matchup count. A fixture whose two interpretations coincide pins neither.

Round 3 certified the fixes: both former survivors now die, and all nine corrected kill counts matched the reviewer's independent runs exactly. It also probed seven further contracts the fixture might have merely relocated the coincidence into (`games_per_matchup × len`, wins-sum, distinct seeds, max-per-matchup, first-matchup-only, and two saturating caps) and confirmed the assertion `3` is now distinct from every one of them.

Post-certificate delta: two comment-only edits — the mutant total in the commit message (the enumeration sums to nine, the header said eight) and one added doc clause. `git diff ba39f354f HEAD -- crates/` contains **zero changed source lines outside doc comments**, so compiled behaviour is identical and the certificate's mutant results carry unchanged.

That disclosure — no test executes the binary, so the refusal block itself can be deleted or inverted with the suite green — is **closed**, not carried forward. `tests/refresh_baseline_cli.rs` drives the real binary through nine cases. The one item now disclosed in its place is a single surviving mutant, recorded in the round-3 section below with the reason it cannot be killed deterministically and the direction in which it fails safe.

## Claimed parse impact

None.

## Scope Expansion

One item, and it came from review rather than from me.

Round 1 found that `classify` returns `Open` for any matchup with zero games *before* it ever inspects `Expected`, and that `--games` parsed as `usize` accepted 0 despite its own error string promising a positive integer — so `--refresh-baseline --games 0` wrote an all-`Open`, zero-game baseline. While closing that I found a sibling: `run_suite` has no emptiness check on its matchup selection, so a `--suite-filter` matching nothing also produced a baseline with no results at all.

Both are the same class — a run that measured nothing — and both are closed by one predicate rather than two special cases. Shipping the guard while leaving a second route to an unfit baseline open would have made the commit's own stated guarantee false, so it is fixed here rather than filed.

## Validation Failures

None.

## CI Failures

None.


## Review response (2026-09-01 21:06Z) — both current-head findings fixed

Head `6217e05ec`. Two commits on `0d1cc7a3f`. Full disposition is in the PR comment; the essentials:

**Finding 1 — writer authority.** `SuiteOptions` carries a `ReportSink` (`Create(PathBuf)` /
`Reserved(File)`) instead of a path. The reserved variant carries no path, so re-resolution is not
expressible rather than merely avoided. `write_through` is the single place bytes reach a handle:
truncate, serialize, explicit `flush`, `sync_all`. The explicit flush closes a second bug found on
the way — `BufWriter`'s drop-flush discards its error, so a short write returned `Ok(())` over a
truncated report. Deterministic regression in the library replaces the reserved path with both a
symlink and a hard link after reservation, with premise assertions and a same-fixture destructive
control through the other arm.

Not closed, deliberately: `rename` resolves its source by name, so an actor who can replace the
staging entry between write and rename can still redirect the promotion. That actor already has
write access to the baseline's own directory and could clobber it directly, so no capability is
granted — unlike the fixed gap, where a symlink redirected the write *outside* that directory.
Closing it needs a link created from the retained descriptor (`linkat` with `AT_EMPTY_PATH`), which
`std` does not expose; no `rename`-family call can, since they all resolve their source by name.

**Finding 2 — CI provisioning.** `ai-gate` added to three sites in `ci.yml`, not two: build, upload,
and `chmod +x`. Artifact download preserves file contents but not the executable bit, so
build-and-upload alone converts `NotFound` into `PermissionDenied`. Verified the property rather
than the edits: every `CARGO_BIN_EXE_*` consumer under `crates/` is `{ai-gate, ai-commander,
probe-pin}` and the provisioned set is now exactly that; `test-runtime-binaries` has one producer
and one consumer, and there is no fourth site. `.github/workflows/**` is a hard-stop path and the
automated pass will flag it — noted here rather than left to surprise anyone.

**Correction to this body.** The round-2 response above said two unit tests "pin the properties the
layers rest on." That was **false when written**: `[[bin]] ai-gate` carried `test = false`, so those
tests were never built and never ran. It is true as of `1424ce516`, which removes that key for this
bin only. Both tests were proven green before being enabled — extraction harness, then in situ
`cargo rustc --profile test -- -D warnings`, then clippy on the same target. `ai-tune` holds six
tests dead the same way; untouched here, unmeasured, and recorded in the commit body as a separate
change.

**Verification at the head:** `fmt --check` clean; `clippy -p phase-ai --all-targets -D warnings`
clean (first run that lints `ai_gate.rs`'s `cfg(test)` build); `nextest -p phase-ai` 2240 passed,
0 failed; `check --workspace --all-targets` clean. Baseline was 2235 and the +5 decomposes exactly
as intended, which independently corroborates that the revived tests run. Every new and revived test
is killed by a named mutant, tree restored byte-identically after each.

**Two coverage limits, disclosed rather than buried:** the retained-descriptor wiring in
`ai_gate::main` is pinned by no test (a CLI-level version would be racy, which is what the
deterministic regression exists to avoid); and three of the five assertions in the `--games 0` test
cannot fail, because that path refuses before staging is reserved — the two stderr assertions carry
that test.

## Review response (2026-09-02) — the [MED] symlink finding, fixed here rather than deferred

Head `4ff54abed`, one commit on `433a44524`. This is the finding from the round-3 review that the
approval did not mention; I am closing it in this PR because **it is a regression this branch
introduced**, not a pre-existing gap. At the merge base `d6d28370c`, refresh was
`write_report(&current, &args.baseline)` — `File::create`, which follows a symlink and refreshes the
target. The staging + `rename` design that this PR added replaces the *link entry itself*, so a
symlinked baseline was destroyed and its target silently stranded. Letting that merge and filing a
follow-up would ship a regression on purpose.

**The fix.** `resolve_destination` walks `read_link` (bounded, 40 hops) and staging becomes a sibling
of the *resolved* destination, because `rename` cannot cross filesystems — tmpfs to btrfs is
`EXDEV`, `Invalid cross-device link (os error 18)`. Hard links are deliberately not followed
(`read_link` returns `InvalidInput`, so the alias guard still fires on them). `canonicalize` is not
used: it returns `NotFound` on both shapes that matter here — a dangling link and a first-ever
refresh — and on Windows it rewrites the path with the `\\?\` extended-length prefix.

`..` through a symlinked parent is left un-normalized on purpose. I measured that the un-normalized
path has the same `(dev, ino)` the kernel opens through the link; lexical normalization would have
selected a different, wrong file.

**Test.** `#[cfg(unix)]`, four arms — absolute, relative, dangling, chain — each asserting the link
survives *as a link* and the target holds the new bytes, behind a reach guard so a refusing binary
cannot pass vacuously. Killed by two named mutants: collapsing the resolver to `path.to_path_buf()`
fails the `absolute` arm; cutting the walk to one hop fails the `chain` arm. 12 siblings stay green
in both, so the failure is attributable to the resolver.

**Disclosed divergence.** A dangling link pointing into a missing directory now `create_dir_all`s
that directory. This makes the link case agree with the plain-file case, which the merge-base
`write_report` already did.

**Emergent interaction, disclosed because no test covers the conjunction.** At the merge base,
`--refresh-baseline` never read the baseline at all. This PR makes refresh load and validate it
first, and #7026 (`fbfa85fdc`) independently added `render_error_markdown` to that load-failure arm.
Together, a refresh over a *corrupt* baseline now posts a markdown error block on stdout where
refresh previously never opened the file. That reads as an improvement for the nightly, which posts
stdout — but it is a combination neither PR exercises, so it is stated rather than left to be found.

**Verification at the head:** `fmt --check` clean; `clippy -p phase-ai --all-targets -D warnings`
clean; `nextest -p phase-ai` 2286 passed, 0 failed. The 2284 to 2286 delta is exactly the two tests
this commit adds. The compare path — the only one CI invokes, since `--refresh-baseline` appears in
no workflow — is unchanged: `bool::then` is lazy, so it makes no additional syscalls.

## PR handoff

```text
Pipeline-reviewed head: 4ff54abed6e3b26098b68af5bac101dcb6003e8f
Current branch head: 4ff54abed6e3b26098b68af5bac101dcb6003e8f
Pipeline status: current — the reviewed candidate is the branch tip
Current-head review: clean at 4ff54abed — /review-impl returned no HIGH or MED findings. The reviewer rebuilt both mutants independently rather than accepting the executor's report, probed the resolver standalone (hard links not followed; `..` through a symlinked parent confirmed same-inode), measured the iteration budget at its boundary (depth 40 resolves, depth 41 is the kernel's own FilesystemLoop, so there is no depth where the walk under-resolves while open() succeeds), and audited the commit message claim by claim against source. The non-blocking items were comment prose only
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Baseline refreshes now stop with clear errors when matchups fail or no games are recorded.
  - Error messages identify affected matchups and preserve failure reasons.
  - The `--games` option rejects zero and other invalid values before execution.
  - Operations are blocked when baseline and output paths are aliases, including symlinks and hard links.
  - Missing baselines remain supported, while malformed or unreadable baselines are rejected.

- **Reliability**
  - Refreshes stage results and promote them only after successful validation.
  - Staging files are cleaned up after failures.
  - Existing baselines are loaded and validated before comparisons begin.
  - Open matchups are distinguished from runs with no recorded games.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->





