### PR TITLE
feat(server): turn-boundary rewind and repeatable undo for desktop solo-vs-AI

### DIFF
--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -5,7 +5,7 @@ import {
   PROTOCOL_VERSION,
   WebSocketAdapter,
 } from "../ws-adapter";
-import { AdapterError, supportsMatchConcede } from "../types";
+import { AdapterError, supportsMatchConcede, supportsServerRewind } from "../types";
 import type { GameState } from "../types";
 import type { PhaseSocketTransport } from "../../services/openPhaseSocket";
 
@@ -149,6 +149,121 @@ describe("WebSocketAdapter", () => {
     adapter.sendMatchConcede();
 
     expect(ws.send).toHaveBeenLastCalledWith(JSON.stringify({ type: "ConcedeMatch" }));
+  });
+
+  describe("server rewind capability (F2)", () => {
+    it("declares the capability through the standalone type guard", () => {
+      expect(supportsServerRewind(adapter)).toBe(true);
+    });
+
+    // The reverse-skew guard. The last-action frame must carry NO `data` key —
+    // byte-identical to the frame every already-deployed server accepts, and
+    // the reason `ClientMessage::RequestTakeback` is a newtype over
+    // `Option<RewindTarget>` rather than a struct variant (which would reject
+    // this exact frame with `missing field \`data\``).
+    it("sends a data-free frame for a last-action undo", () => {
+      adapter.sendRequestTakeback();
+      expect(JSON.parse(ws.send.mock.lastCall![0] as string)).toEqual({
+        type: "RequestTakeback",
+      });
+
+      adapter.sendRequestTakeback({ kind: "last_action" });
+      expect(JSON.parse(ws.send.mock.lastCall![0] as string)).toEqual({
+        type: "RequestTakeback",
+      });
+    });
+
+    it("sends the data-bearing frame for a turn rewind", () => {
+      adapter.sendRequestTakeback({ kind: "turn_start", turn_number: 3 });
+      expect(JSON.parse(ws.send.mock.lastCall![0] as string)).toEqual({
+        type: "RequestTakeback",
+        data: { kind: "turn_start", turn_number: 3 },
+      });
+    });
+
+    it("emits rewindTargets from a StateUpdate that carries them", () => {
+      const listener = vi.fn();
+      adapter.onEvent(listener);
+      ws.dispatchSynthetic(
+        "message",
+        JSON.stringify({
+          type: "StateUpdate",
+          data: {
+            state: createMockState(),
+            events: [],
+            rewind_targets: [{ turn_number: 3, active_player: 1 }],
+          },
+        }),
+      );
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "stateChanged",
+          rewindTargets: [{ turn_number: 3, active_player: 1 }],
+        }),
+      );
+    });
+
+    // Forward-skew hostile: an omitted field must become `[]`, never
+    // `undefined`. On this transport `undefined` means "does not publish",
+    // which is false here — and `dispatch.ts` treats the two differently, so
+    // collapsing them would leave a stale list on screen forever.
+    it("emits an empty array when a StateUpdate omits rewind_targets", () => {
+      const listener = vi.fn();
+      adapter.onEvent(listener);
+      ws.dispatchSynthetic(
+        "message",
+        JSON.stringify({
+          type: "StateUpdate",
+          data: { state: createMockState(), events: [] },
+        }),
+      );
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({ type: "stateChanged", rewindTargets: [] }),
+      );
+    });
+
+    // The reconnect path: a mid-game reattach must see the list immediately
+    // rather than waiting for the next action.
+    it("emits rewindTargets from a reconnect GameStarted", async () => {
+      MockWebSocket.last = null;
+      const reconnected = new WebSocketAdapter(
+        "ws://localhost:9374/ws",
+        "join",
+        { main_deck: [], sideboard: [] },
+        "ABC123",
+      );
+      const listener = vi.fn();
+      reconnected.onEvent(listener);
+      const initPromise = reconnected.initialize();
+      const ws2 = await completeHandshake(reconnected);
+      // Resolve init with a first GameStarted, then deliver the reconnect one.
+      ws2.dispatchSynthetic(
+        "message",
+        JSON.stringify({
+          type: "GameStarted",
+          data: { state: createMockState(), your_player: 0 },
+        }),
+      );
+      await initPromise;
+      listener.mockClear();
+      ws2.dispatchSynthetic(
+        "message",
+        JSON.stringify({
+          type: "GameStarted",
+          data: {
+            state: createMockState(),
+            your_player: 0,
+            rewind_targets: [{ turn_number: 5, active_player: 0 }],
+          },
+        }),
+      );
+      expect(listener).toHaveBeenCalledWith(
+        expect.objectContaining({
+          type: "stateChanged",
+          rewindTargets: [{ turn_number: 5, active_player: 0 }],
+        }),
+      );
+    });
   });
 
   describe("native AI transport", () => {

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -3610,3 +3610,43 @@ export function supportsMatchConcede(
     && (adapter as Partial<MatchConcedeCapability>).supportsMatchConcede === true
     && typeof (adapter as Partial<MatchConcedeCapability>).sendMatchConcede === "function";
 }
+
+/**
+ * One turn boundary the server offers as a rollback target. Snake_case because
+ * this is the wire shape verbatim (`server-core`'s `RewindOption`); the client
+ * renders it and never derives it.
+ */
+export interface RewindOption {
+  readonly turn_number: number;
+  readonly active_player: PlayerId;
+}
+
+/**
+ * How far back a rollback request reaches. Mirrors `server-core`'s
+ * `RewindTarget` — an internally tagged union, not a boolean pair, because the
+ * two granularities carry different payloads.
+ */
+export type RewindTarget =
+  | { readonly kind: "last_action" }
+  | { readonly kind: "turn_start"; readonly turn_number: number };
+
+/**
+ * Optional transport capability for a *server-authoritative* rollback. Shaped
+ * exactly like `MatchConcedeCapability` above, and for the same reason: only
+ * the adapter that can actually bind the request to an authenticated wire
+ * session declares it, so no other adapter is forced to answer a question it
+ * has no meaningful answer to. A local-authority adapter rewinds its own state
+ * instead and must NOT claim this.
+ */
+export interface ServerRewindCapability {
+  readonly supportsServerRewind: true;
+  sendRequestTakeback(target?: RewindTarget): void;
+}
+
+export function supportsServerRewind(
+  adapter: EngineAdapter | null,
+): adapter is EngineAdapter & ServerRewindCapability {
+  return adapter !== null
+    && (adapter as Partial<ServerRewindCapability>).supportsServerRewind === true
+    && typeof (adapter as Partial<ServerRewindCapability>).sendRequestTakeback === "function";
+}

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -11,6 +11,8 @@ import type {
   ObjectId,
   PlayerId,
   PersistedGameState,
+  RewindOption,
+  RewindTarget,
   SubmitResult,
   FormatConfig,
 } from "./types";
@@ -276,7 +278,10 @@ export type WsAdapterEvent =
   | { type: "terminalUnavailable"; message: string }
   /** The engine pair travels as one `EngineSnapshot` — see the P2P adapter's
    *  `stateChanged` for why the halves must stay inseparable. */
-  | { type: "stateChanged"; snapshot: EngineSnapshot; events: GameEvent[]; logEntries?: GameLogEntry[]; serverRevision?: number }
+  | { type: "stateChanged"; snapshot: EngineSnapshot; events: GameEvent[]; logEntries?: GameLogEntry[]; serverRevision?: number;
+      /** Server-published turn boundaries. Always an array on this transport —
+       *  `[]` means "the server published none", never "unknown". */
+      rewindTargets?: RewindOption[] }
   | { type: "sessionAttached"; attachment: NativeSessionAttachment }
   | { type: "emoteReceived"; fromPlayer: PlayerId; emote: string }
   | { type: "conceded"; player: PlayerId }
@@ -307,6 +312,7 @@ function playerNamesFromWire(names: string[]): Record<number, string> {
  */
 export class WebSocketAdapter implements EngineAdapter {
   readonly supportsMatchConcede = true;
+  readonly supportsServerRewind = true;
   private ws: PhaseSocketTransport | null = null;
   /**
    * The single cached engine pair, rebuilt (and re-stamped) once per inbound
@@ -839,10 +845,23 @@ export class WebSocketAdapter implements EngineAdapter {
     this.send({ type: "Emote", data: { emote } });
   }
 
-  /** GH #1507: ask every other human player to approve rolling the game
-   * back to the state immediately before this player's last action. */
-  sendRequestTakeback(): void {
-    this.send({ type: "RequestTakeback" });
+  /**
+   * GH #1507: ask every other human player to approve rolling the game back.
+   * Defaults to the pre-existing last-action granularity, which keeps the
+   * existing zero-argument call site behaving identically.
+   *
+   * The last-action frame deliberately carries NO `data` key — byte-identical
+   * to the frame this client has always sent, and the shape the server's
+   * `Option<RewindTarget>` newtype variant exists to accept. Only a turn rewind
+   * carries a payload, and the client can only ask for a turn the server itself
+   * published in `rewind_targets`.
+   */
+  sendRequestTakeback(target: RewindTarget = { kind: "last_action" }): void {
+    if (target.kind === "last_action") {
+      this.send({ type: "RequestTakeback" });
+      return;
+    }
+    this.send({ type: "RequestTakeback", data: target });
   }
 
   /** Approve or decline a pending takeback request. */
@@ -1245,7 +1264,7 @@ export class WebSocketAdapter implements EngineAdapter {
       }
 
       case "GameStarted": {
-        const data = msg.data as { state_revision: number; state: GameState; your_player: PlayerId; opponent_name?: string; player_names?: string[]; legal_actions?: GameAction[]; auto_pass_recommended?: boolean; end_continuous_effect_offers?: LegalActionsResult["endContinuousEffectOffers"]; mana_payment_shortcut_actions?: GameAction[]; spell_costs?: Record<string, ManaCost>; legal_actions_by_object?: Record<string, GameAction[]>; viewer_interaction?: LegalActionsResult["viewerInteraction"]; derived?: GameState["derived"]; player_token?: string; full_key?: FullSessionKey; events?: GameEvent[] };
+        const data = msg.data as { state_revision: number; state: GameState; your_player: PlayerId; opponent_name?: string; player_names?: string[]; legal_actions?: GameAction[]; auto_pass_recommended?: boolean; end_continuous_effect_offers?: LegalActionsResult["endContinuousEffectOffers"]; mana_payment_shortcut_actions?: GameAction[]; spell_costs?: Record<string, ManaCost>; legal_actions_by_object?: Record<string, GameAction[]>; viewer_interaction?: LegalActionsResult["viewerInteraction"]; derived?: GameState["derived"]; player_token?: string; full_key?: FullSessionKey; events?: GameEvent[]; rewind_targets?: RewindOption[] };
         if (this.reconnectInFlight) {
           this.reconnectInFlight = false;
           this.reconnectAttempt = 0;
@@ -1330,25 +1349,35 @@ export class WebSocketAdapter implements EngineAdapter {
           this.gameStartedResolve = null;
           this.gameStartedReject = null;
         }
+        // Always an array, never `undefined`: on this transport `undefined`
+        // would mean "this transport does not publish", which is false here —
+        // an omitted field means the server published none.
+        const startedRewindTargets = data.rewind_targets ?? [];
         if (this.options.nativePregame) {
           this.emit({
             type: "stateChanged",
             snapshot: startedSnapshot,
             events: data.events ?? [],
             serverRevision: data.state_revision,
+            rewindTargets: startedRewindTargets,
           });
         } else if (!initializedNow) {
           // Reconnect path — no initResolve pending, so emit state change
           // so GameProvider's event listener populates the store. Emits the
           // cached snapshot, which carries the derived-attached state (this
           // emit previously sent the raw `data.state`, dropping `derived`).
-          this.emit({ type: "stateChanged", snapshot: startedSnapshot, events: [] });
+          this.emit({
+            type: "stateChanged",
+            snapshot: startedSnapshot,
+            events: [],
+            rewindTargets: startedRewindTargets,
+          });
         }
         break;
       }
 
       case "StateUpdate": {
-        const data = msg.data as { state_revision: number; state: GameState; events: GameEvent[]; legal_actions?: GameAction[]; auto_pass_recommended?: boolean; end_continuous_effect_offers?: LegalActionsResult["endContinuousEffectOffers"]; mana_payment_shortcut_actions?: GameAction[]; spell_costs?: Record<string, ManaCost>; legal_actions_by_object?: Record<string, GameAction[]>; viewer_interaction?: LegalActionsResult["viewerInteraction"]; log_entries?: GameLogEntry[]; derived?: GameState["derived"] };
+        const data = msg.data as { state_revision: number; state: GameState; events: GameEvent[]; legal_actions?: GameAction[]; auto_pass_recommended?: boolean; end_continuous_effect_offers?: LegalActionsResult["endContinuousEffectOffers"]; mana_payment_shortcut_actions?: GameAction[]; spell_costs?: Record<string, ManaCost>; legal_actions_by_object?: Record<string, GameAction[]>; viewer_interaction?: LegalActionsResult["viewerInteraction"]; log_entries?: GameLogEntry[]; derived?: GameState["derived"]; rewind_targets?: RewindOption[] };
         // Attach the engine-authored derived views to the state snapshot so
         // components (e.g. CommanderDamage) can read them via gameState.derived
         // without a separate subscription path. See
@@ -1379,6 +1408,7 @@ export class WebSocketAdapter implements EngineAdapter {
             events: data.events,
             logEntries: data.log_entries,
             serverRevision: data.state_revision,
+            rewindTargets: data.rewind_targets ?? [],
           });
         }
         break;

--- a/client/src/components/chrome/DebugPanel.tsx
+++ b/client/src/components/chrome/DebugPanel.tsx
@@ -385,7 +385,7 @@ export function DebugPanel() {
                         kind: "turn_start",
                         turn_number: target.turn_number,
                       })}
-                    className="flex items-center justify-between gap-2 rounded bg-gray-800 px-2 py-1 text-left text-xs transition-colors hover:bg-gray-700"
+                    className="flex min-h-11 items-center justify-between gap-2 rounded bg-gray-800 px-2 py-1 text-left text-xs transition-colors hover:bg-gray-700"
                   >
                     <span>Turn {target.turn_number}</span>
                     <span

--- a/client/src/components/chrome/DebugPanel.tsx
+++ b/client/src/components/chrome/DebugPanel.tsx
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import type { GameState } from "../../adapter/types";
+import { supportsServerRewind } from "../../adapter/types";
 import { audioManager } from "../../audio/AudioManager";
 import { restoreGameState } from "../../game/dispatch";
 import { usePlayerId } from "../../hooks/usePlayerId";
@@ -61,8 +62,13 @@ export function DebugPanel() {
   const { t } = useTranslation();
   const open = useUiStore((s) => s.debugPanelOpen);
   const turnCheckpoints = useGameStore((s) => s.turnCheckpoints);
+  const rewindTargets = useGameStore((s) => s.rewindTargets);
+  const adapter = useGameStore((s) => s.adapter);
   const gameState = useGameStore((s) => s.gameState);
   const gameMode = useGameStore((s) => s.gameMode);
+  // The transport, not the mode, decides whether a rollback request can be
+  // bound to an authenticated session — same idiom as `supportsMatchConcede`.
+  const rewindAdapter = supportsServerRewind(adapter) ? adapter : null;
   const localPlayerId = usePlayerId();
   const [importText, setImportText] = useState("");
   const [status, setStatus] = useState<{ type: "success" | "error"; message: string } | null>(null);
@@ -354,7 +360,48 @@ export function DebugPanel() {
           <h3 className="mb-1 font-mono text-xs font-bold uppercase tracking-wider text-gray-500">
             Turn Checkpoints
           </h3>
-          {!canRestoreCheckpoints ? (
+          {rewindAdapter && rewindTargets.length > 0 ? (
+            /* Server-published boundaries. Labelled from the SNAPSHOT's own
+               fields — exactly like the local list below — so the label and
+               the state a player gets cannot disagree.
+
+               Gated on `length > 0` deliberately: an online table has the
+               capability but a permanently empty list (the server scopes turn
+               rewind to a `SingleUser` sidecar), so falling through leaves its
+               behaviour byte-identical to before rather than promising a list
+               that will never fill. */
+            <div className="flex flex-col gap-1">
+              {rewindTargets.map((target) => {
+                const activePlayerName = getPlayerDisplayName(target.active_player, localPlayerId);
+                const activePlayerColor = getSeatColor(
+                  target.active_player,
+                  gameState?.seat_order,
+                );
+                return (
+                  <button
+                    key={target.turn_number}
+                    onClick={() =>
+                      rewindAdapter.sendRequestTakeback({
+                        kind: "turn_start",
+                        turn_number: target.turn_number,
+                      })}
+                    className="flex items-center justify-between gap-2 rounded bg-gray-800 px-2 py-1 text-left text-xs transition-colors hover:bg-gray-700"
+                  >
+                    <span>Turn {target.turn_number}</span>
+                    <span
+                      className="max-w-36 truncate rounded px-1.5 py-0.5 font-semibold"
+                      style={{
+                        backgroundColor: `${activePlayerColor}22`,
+                        color: activePlayerColor,
+                      }}
+                    >
+                      {activePlayerName}
+                    </span>
+                  </button>
+                );
+              })}
+            </div>
+          ) : !canRestoreCheckpoints ? (
             /* Misleading twice over before: desktop solo-vs-AI is not
                multiplayer, and the real reason is a transport limit rather
                than a mode policy. Names the actual cause and points at the
@@ -397,7 +444,10 @@ export function DebugPanel() {
           )}
         </section>
 
-        {/* Import — only available in AI/local modes */}
+        {/* Import — stays gated on `canRestoreCheckpoints`, deliberately.
+            Importing an arbitrary state over a wire session is a different
+            (and much larger) capability than rolling back to a state the
+            server itself published, and is out of scope here. */}
         {canRestoreCheckpoints && (
           <section className="border-b border-gray-800 px-3 py-2">
             <h3 className="mb-1 font-mono text-xs font-bold uppercase tracking-wider text-gray-500">

--- a/client/src/components/chrome/GameMenu.tsx
+++ b/client/src/components/chrome/GameMenu.tsx
@@ -12,6 +12,15 @@ import { useCardDataMeta } from "../../hooks/useCardDataMeta.ts";
 import { useConcedeHandler } from "../../hooks/useConcedeHandler.ts";
 import type { MultiplayerBoardLayout } from "../../stores/preferencesStore.ts";
 
+/**
+ * Who a rollback request is addressed to. A string union rather than a boolean
+ * because the axis is *who the audience is*, not a yes/no: at a table the
+ * request is a proposal every other human votes on; solo vs. AI there is nobody
+ * to ask and it is simply an undo. Only the label differs — the wire request is
+ * the same either way.
+ */
+export type TakebackAudience = "table" | "solo";
+
 interface GameMenuProps {
   gameId: string;
   isAiMode: boolean;
@@ -26,6 +35,9 @@ interface GameMenuProps {
   /** GH #1507: ask every other human player to approve rolling the game
    * back to the state before this player's last action. Online-only. */
   onRequestTakeback?: () => void;
+  /** Label axis for the entry above. Defaults to `"table"`, which is the
+   *  pre-existing wording. */
+  takebackAudience?: TakebackAudience;
   /** Show the always-visible Sandbox Tools button. Gated by the caller to
    *  game modes where debug actions actually work (vs-AI, local, or a
    *  multiplayer sandbox). */
@@ -51,6 +63,7 @@ export function GameMenu({
   onHelpClick,
   onConcede,
   onRequestTakeback,
+  takebackAudience = "table",
   showSandboxTools,
   onSandboxToolsClick,
   debugClickModeButtonVisible = false,
@@ -223,7 +236,11 @@ export function GameMenu({
               legal — GamePage decides, from the transport that implements it. */}
           {onRequestTakeback && (
             <MenuButton
-              label={t("gameMenu.requestTakeback")}
+              label={t(
+                takebackAudience === "solo"
+                  ? "gameMenu.undoLastAction"
+                  : "gameMenu.requestTakeback",
+              )}
               onClick={() => {
                 setOpen(false);
                 onRequestTakeback();

--- a/client/src/components/chrome/__tests__/DebugPanel.serverRewind.test.tsx
+++ b/client/src/components/chrome/__tests__/DebugPanel.serverRewind.test.tsx
@@ -1,0 +1,162 @@
+/**
+ * F1 — DebugPanel's server-published turn-rewind list.
+ *
+ * The Turn Checkpoints section has two independent sources now:
+ *
+ *   1. Server-published boundaries (`rewindTargets`), offered only when the
+ *      installed adapter declares `ServerRewindCapability`. This is the desktop
+ *      solo-vs-AI path, where the sidecar owns the state and a local restore
+ *      would desync.
+ *   2. The pre-existing browser-local `turnCheckpoints`, restored through
+ *      `restoreGameState`, which only the in-browser engine supports.
+ *
+ * These tests pin that the two never cross: a wire session must not call
+ * `restoreGameState`, and a local session must not send a wire frame.
+ */
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DebugPanel } from "../DebugPanel";
+import type { GameMode } from "../../../stores/gameStore";
+import { restoreGameState } from "../../../game/dispatch";
+
+const sendRequestTakeback = vi.fn();
+
+/** A stub shaped exactly like `WebSocketAdapter`'s capability surface. */
+function rewindCapableAdapter() {
+  return { supportsServerRewind: true, sendRequestTakeback };
+}
+
+/** A P2P-shaped stub: wire-authoritative, but no rollback capability. */
+function rewindIncapableAdapter() {
+  return { supportsMatchConcede: true, sendMatchConcede: vi.fn() };
+}
+
+const storeState = {
+  gameMode: "native-ai" as GameMode | null,
+  turnCheckpoints: [] as unknown[],
+  rewindTargets: [] as unknown[],
+  gameState: null as unknown,
+  adapter: null as unknown,
+};
+
+vi.mock("../../../stores/gameStore", () => ({
+  useGameStore: Object.assign(
+    vi.fn((selector: (s: typeof storeState) => unknown) => selector(storeState)),
+    { getState: () => storeState, setState: vi.fn() },
+  ),
+}));
+
+const uiState = {
+  debugPanelOpen: true,
+  debugPanelTab: "console" as "console" | "actions",
+  setDebugPanelTab: vi.fn(),
+};
+
+vi.mock("../../../stores/uiStore", () => ({
+  useUiStore: Object.assign(
+    vi.fn((selector: (s: typeof uiState) => unknown) => selector(uiState)),
+    { getState: () => uiState, setState: vi.fn() },
+  ),
+}));
+
+vi.mock("../../../hooks/usePlayerId", () => ({
+  usePlayerId: () => 0,
+  usePerspectivePlayerId: () => 0,
+}));
+vi.mock("../../../hooks/useGameDispatch", () => ({ useGameDispatch: () => vi.fn() }));
+vi.mock("../../../game/dispatch", () => ({ restoreGameState: vi.fn(async () => null) }));
+vi.mock("../../../audio/AudioManager", () => ({
+  audioManager: { play: vi.fn(), diagnostics: () => "" },
+}));
+vi.mock("react-i18next", () => ({ useTranslation: () => ({ t: (k: string) => k }) }));
+vi.mock("../../../services/cardNames", () => ({ getCardNames: async () => [] }));
+
+beforeEach(() => {
+  storeState.gameMode = "native-ai";
+  storeState.turnCheckpoints = [];
+  storeState.rewindTargets = [];
+  storeState.gameState = { players: [{}, {}], seat_order: [0, 1] };
+  storeState.adapter = null;
+  uiState.debugPanelTab = "console";
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("DebugPanel — server-published turn rewind", () => {
+  it("renders the server's boundaries and asks the server to roll back to one", () => {
+    storeState.adapter = rewindCapableAdapter();
+    storeState.rewindTargets = [{ turn_number: 3, active_player: 1 }];
+
+    render(<DebugPanel />);
+
+    // At BASE_SHA this section rendered the "Restore needs the in-browser
+    // engine" notice and no button existed at all.
+    const button = screen.getByRole("button", { name: /Turn 3/ });
+    fireEvent.click(button);
+
+    // The exact payload is the contract with `server-core`'s `RewindTarget`.
+    expect(sendRequestTakeback).toHaveBeenCalledWith({
+      kind: "turn_start",
+      turn_number: 3,
+    });
+    // A wire session must NEVER take the local restore path — that adapter's
+    // `restoreState` throws.
+    expect(restoreGameState).not.toHaveBeenCalled();
+  });
+
+  it("still uses the local checkpoint list for a browser solo game", () => {
+    // Paired positive. Without a capability the local chain must be reached
+    // exactly as before, proving the new branch is additive.
+    storeState.gameMode = "ai";
+    storeState.adapter = rewindIncapableAdapter();
+    storeState.turnCheckpoints = [
+      { turn_number: 4, active_player: 0, seat_order: [0, 1] },
+    ];
+
+    render(<DebugPanel />);
+
+    fireEvent.click(screen.getByRole("button", { name: /Turn 4/ }));
+
+    expect(restoreGameState).toHaveBeenCalledTimes(1);
+    expect(sendRequestTakeback).not.toHaveBeenCalled();
+  });
+
+  it("renders neither list for a wire adapter without the capability", () => {
+    // Hostile: a P2P-shaped adapter is wire-authoritative but cannot bind a
+    // rollback request. It must fall through to the existing notice, not to a
+    // button that no-ops.
+    storeState.adapter = rewindIncapableAdapter();
+    storeState.rewindTargets = [{ turn_number: 3, active_player: 1 }];
+
+    render(<DebugPanel />);
+
+    expect(screen.queryByRole("button", { name: /Turn 3/ })).toBeNull();
+    expect(
+      screen.getByText(
+        "Restore needs the in-browser engine. Use Takeback to undo your last action.",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("falls through to the existing chain on an honestly empty list", () => {
+    // Hostile: an online table HAS the capability but a permanently empty list
+    // (the server scopes turn rewind to a SingleUser sidecar). It must look
+    // byte-identical to before rather than showing a dead empty list.
+    storeState.gameMode = "online";
+    storeState.adapter = rewindCapableAdapter();
+    storeState.rewindTargets = [];
+
+    render(<DebugPanel />);
+
+    expect(
+      screen.getByText(
+        "Restore needs the in-browser engine. Use Takeback to undo your last action.",
+      ),
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Turn / })).toBeNull();
+  });
+});

--- a/client/src/components/chrome/__tests__/GameMenu.test.tsx
+++ b/client/src/components/chrome/__tests__/GameMenu.test.tsx
@@ -143,4 +143,43 @@ describe("GameMenu", () => {
     expect(screen.queryByRole("button", { name: "Request Takeback" })).toBeNull();
   });
 
+  // F4. "Request Takeback" is a proposal addressed to other humans. Solo vs.
+  // AI there is nobody to ask and the server auto-approves, so the same entry
+  // must read as a plain undo. Only the label changes — the handler and the
+  // wire frame are identical.
+  it("labels the rollback entry as an undo when the audience is solo", () => {
+    const onRequestTakeback = vi.fn();
+    renderGameMenu({ onRequestTakeback, takebackAudience: "solo" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Game menu" }));
+
+    expect(screen.getByRole("button", { name: "Undo Last Action" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Request Takeback" })).toBeNull();
+
+    fireEvent.click(screen.getByRole("button", { name: "Undo Last Action" }));
+    expect(onRequestTakeback).toHaveBeenCalledTimes(1);
+  });
+
+  it("keeps the table wording when other humans are present", () => {
+    // Paired positive. Also covers the default: `takebackAudience` is omitted
+    // here, and the default must be the pre-existing wording.
+    renderGameMenu({ onRequestTakeback: vi.fn() });
+
+    fireEvent.click(screen.getByRole("button", { name: "Game menu" }));
+
+    expect(screen.getByRole("button", { name: "Request Takeback" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Undo Last Action" })).toBeNull();
+  });
+
+  it("renders no rollback entry at all without a handler, whatever the audience", () => {
+    // Hostile: the audience must not become a second render gate.
+    renderGameMenu({ onRequestTakeback: undefined, takebackAudience: "solo" });
+
+    fireEvent.click(screen.getByRole("button", { name: "Game menu" }));
+
+    expect(screen.getByRole("button", { name: "Concede" })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Undo Last Action" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Request Takeback" })).toBeNull();
+  });
+
 });

--- a/client/src/game/__tests__/dispatchRemoteUpdate.test.ts
+++ b/client/src/game/__tests__/dispatchRemoteUpdate.test.ts
@@ -69,4 +69,56 @@ describe("processRemoteUpdate", () => {
     ]);
     expect(useGameStore.getState().nextLogSeq).toBe(1);
   });
+
+  // F3. The server-published rewind list must reach the store through the SAME
+  // path as the snapshot it describes, so it sits under the generation gate.
+  describe("rewindTargets threading", () => {
+    it("writes the server list into the store", async () => {
+      const targets = [{ turn_number: 3, active_player: 1 }];
+
+      await processRemoteUpdate(prioritySnapshot(), [], [], targets);
+
+      expect(useGameStore.getState().rewindTargets).toEqual(targets);
+    });
+
+    it("clears the list when the server publishes an empty one", async () => {
+      // Paired negative: `[]` is a real value meaning "no boundaries left",
+      // most obviously right after an approved rewind prunes the ring.
+      await processRemoteUpdate(prioritySnapshot(), [], [], [
+        { turn_number: 3, active_player: 1 },
+      ]);
+      expect(useGameStore.getState().rewindTargets).toHaveLength(1);
+
+      await processRemoteUpdate(prioritySnapshot(), [], [], []);
+
+      expect(useGameStore.getState().rewindTargets).toEqual([]);
+    });
+
+    it("leaves the list untouched when the transport does not publish", async () => {
+      // Hostile: `undefined` and `[]` are NOT the same. P2P and draft call
+      // `processRemoteUpdate` with three arguments; collapsing the two would
+      // make every p2p update wipe a list it knows nothing about.
+      await processRemoteUpdate(prioritySnapshot(), [], [], [
+        { turn_number: 3, active_player: 1 },
+      ]);
+
+      await processRemoteUpdate(prioritySnapshot(), [], []);
+
+      expect(useGameStore.getState().rewindTargets).toEqual([
+        { turn_number: 3, active_player: 1 },
+      ]);
+    });
+
+    // NOT TESTED HERE: that a *superseded* update declines to write. The
+    // generation is bumped only by `abandonDispatchesForStateRestore`
+    // (reachable via `restoreGameState`), and an event-free update runs to
+    // completion synchronously, so there is no window in which to supersede it
+    // from this harness. The property is structural instead: the write sits
+    // immediately after `processRemoteUpdateInner`'s second
+    // `isCurrentDispatchGeneration` guard, next to `commitEngineSnapshot`, and
+    // is the reason the list is threaded through dispatch rather than written
+    // from `GameProvider`. A `reset()`-based version of this test passes
+    // vacuously — `reset()` neither bumps the generation nor leaves the store
+    // untouched — so it is deliberately absent rather than green.
+  });
 });

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -1,4 +1,4 @@
-import type { AiActionProposal, BatchResolveResult, EngineAdapter, EngineSnapshot, GameAction, GameEvent, GameLogEntry, GameState, WaitingFor } from "../adapter/types";
+import type { AiActionProposal, BatchResolveResult, EngineAdapter, EngineSnapshot, GameAction, GameEvent, GameLogEntry, GameState, RewindOption, WaitingFor } from "../adapter/types";
 import type { InteractionSubmission } from "../adapter/generated/interaction";
 import { AdapterError, AdapterErrorCode } from "../adapter/types";
 import { attemptStateRehydrate, isEnginePanic, notifyEngineLost, routePanic } from "./engineRecovery";
@@ -73,6 +73,8 @@ interface PendingRemoteUpdate {
   snapshot: EngineSnapshot;
   events: GameEvent[];
   logEntries?: GameLogEntry[];
+  /** See `processRemoteUpdateInner`: `undefined` and `[]` mean different things. */
+  rewindTargets?: RewindOption[];
   resolve: () => void;
   reject: (err: unknown) => void;
 }
@@ -601,7 +603,13 @@ async function processQueue(generation: number): Promise<void> {
           if (isCurrentDispatchGeneration(generation)) inFlightLocalAction = null;
         }
       } else {
-        await processRemoteUpdateInner(next.snapshot, next.events, next.logEntries, generation);
+        await processRemoteUpdateInner(
+          next.snapshot,
+          next.events,
+          next.logEntries,
+          generation,
+          next.rewindTargets,
+        );
       }
       next.resolve();
     } catch (err) {
@@ -803,6 +811,7 @@ async function processRemoteUpdateInner(
   events: GameEvent[],
   logEntries: GameLogEntry[] = [],
   generation: number,
+  rewindTargets?: RewindOption[],
 ): Promise<void> {
   if (!isCurrentDispatchGeneration(generation)) return;
   const state = snapshot.state;
@@ -855,6 +864,14 @@ async function processRemoteUpdateInner(
   //    than clobbering the newer state.
   if (!isCurrentDispatchGeneration(generation)) return;
   useGameStore.getState().commitEngineSnapshot(snapshot, { events, logEntries });
+  // Written INSIDE the generation gate, alongside the snapshot it describes:
+  // outside it, a superseded update would clobber the list with a stale one.
+  // `undefined` means "this transport does not publish rollback targets" (p2p,
+  // draft) and leaves the store alone; `[]` means "the server published none"
+  // and clears it. The two are deliberately not collapsed.
+  if (rewindTargets) {
+    useGameStore.getState().setRewindTargets(rewindTargets);
+  }
 
   // 6. Play victory/defeat stinger on GameOver
   const gameOverEvent = events.find((e) => e.type === "GameOver");
@@ -878,17 +895,18 @@ export async function processRemoteUpdate(
   snapshot: EngineSnapshot,
   events: GameEvent[],
   logEntries?: GameLogEntry[],
+  rewindTargets?: RewindOption[],
 ): Promise<void> {
   if (isAnimating) {
     return new Promise<void>((resolve, reject) => {
-      pendingQueue.push({ kind: "remote", snapshot, events, logEntries, resolve, reject });
+      pendingQueue.push({ kind: "remote", snapshot, events, logEntries, rewindTargets, resolve, reject });
     });
   }
 
   const generation = dispatchGeneration;
   isAnimating = true;
   try {
-    await processRemoteUpdateInner(snapshot, events, logEntries, generation);
+    await processRemoteUpdateInner(snapshot, events, logEntries, generation, rewindTargets);
   } finally {
     releaseDispatchMutex(generation);
   }

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -78,6 +78,7 @@
     "showAiHand": "KI-Hand anzeigen",
     "hideAiHand": "KI-Hand verbergen",
     "requestTakeback": "Rücknahme beantragen",
+    "undoLastAction": "Letzte Aktion rückgängig",
     "concede": "Aufgeben",
     "backToDraft": "Zurück zum Draft",
     "mainMenu": "Hauptmenü",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -78,6 +78,7 @@
     "showAiHand": "Show AI Hand",
     "hideAiHand": "Hide AI Hand",
     "requestTakeback": "Request Takeback",
+    "undoLastAction": "Undo Last Action",
     "concede": "Concede",
     "backToDraft": "Back to Draft",
     "mainMenu": "Main Menu",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -78,6 +78,7 @@
     "showAiHand": "Mostrar la mano de la IA",
     "hideAiHand": "Ocultar la mano de la IA",
     "requestTakeback": "Solicitar repetición",
+    "undoLastAction": "Deshacer última acción",
     "concede": "Conceder",
     "backToDraft": "Volver al Draft",
     "mainMenu": "Menú principal",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -78,6 +78,7 @@
     "showAiHand": "Afficher la main de l'IA",
     "hideAiHand": "Masquer la main de l'IA",
     "requestTakeback": "Demander une reprise",
+    "undoLastAction": "Annuler la dernière action",
     "concede": "Concéder",
     "backToDraft": "Retour au Draft",
     "mainMenu": "Menu principal",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -78,6 +78,7 @@
     "showAiHand": "Mostra mano IA",
     "hideAiHand": "Nascondi mano IA",
     "requestTakeback": "Richiedi ripristino",
+    "undoLastAction": "Annulla ultima azione",
     "concede": "Concedi",
     "backToDraft": "Torna al Draft",
     "mainMenu": "Menu principale",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -78,6 +78,7 @@
     "showAiHand": "Pokaż rękę AI",
     "hideAiHand": "Ukryj rękę AI",
     "requestTakeback": "Poproś o wycofanie ruchu",
+    "undoLastAction": "Cofnij ostatnią akcję",
     "concede": "Poddaj się",
     "backToDraft": "Wróć do draftu",
     "mainMenu": "Menu główne",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -78,6 +78,7 @@
     "showAiHand": "Mostrar Mão da IA",
     "hideAiHand": "Ocultar Mão da IA",
     "requestTakeback": "Solicitar retrocesso",
+    "undoLastAction": "Desfazer última ação",
     "concede": "Conceder",
     "backToDraft": "Voltar ao Draft",
     "mainMenu": "Menu Principal",

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -150,7 +150,7 @@ import { useGameDispatch } from "../hooks/useGameDispatch.ts";
 import { useInspectHoverProps } from "../hooks/useInspectHoverProps.ts";
 import { useKeyboardShortcuts } from "../hooks/useKeyboardShortcuts.ts";
 import { clearPromptOverlayState } from "../game/sessionCleanup.ts";
-import { clearGame, loadActiveGame, useGameStore } from "../stores/gameStore.ts";
+import { clearGame, hasRemoteHumans, loadActiveGame, useGameStore } from "../stores/gameStore.ts";
 import { useUiStore } from "../stores/uiStore.ts";
 import { usePreferencesStore } from "../stores/preferencesStore.ts";
 import type { MultiplayerBoardLayout } from "../stores/preferencesStore.ts";
@@ -954,6 +954,10 @@ function GamePageContent({
   );
   const opponentDisplayName = useMultiplayerStore((s) => s.opponentDisplayName);
   const adapter = useGameStore((s) => s.adapter);
+  // The AUTHORITATIVE game mode. The URL-derived `mode` prop structurally
+  // cannot contain `native-ai` (desktop solo arrives as `rawMode === "ai"`), so
+  // it cannot answer "is anyone else at this table?".
+  const storeGameMode = useGameStore((s) => s.gameMode);
   const focusedOpponent = useUiStore((s) => s.focusedOpponent);
   const opponents = useMemo(() => {
     return getOpponentIds(gameState, perspectivePlayerId);
@@ -1617,6 +1621,7 @@ function GamePageContent({
             ? handleRequestTakeback
             : undefined
         }
+        takebackAudience={hasRemoteHumans(storeGameMode) ? "table" : "solo"}
         showSandboxTools={mode === "ai" || mode === "local" || isSandboxGame}
         onSandboxToolsClick={() => useUiStore.getState().openSandboxTools()}
         debugClickModeButtonVisible={debugClickModeButtonVisible}

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -38,7 +38,12 @@ const { mockClearPromptOverlayState, mockSetGameState, storeOverrides } = vi.hoi
   // Mutable slice of the mocked game store. Defaults match the previous
   // hardcoded values, so every pre-existing test is unaffected; tests that
   // need a live adapter assign here and `beforeEach` resets.
-  storeOverrides: { adapter: null as unknown, gameState: null as unknown, waitingFor: null as unknown },
+  storeOverrides: {
+    adapter: null as unknown,
+    gameState: null as unknown,
+    gameMode: null as unknown,
+    waitingFor: null as unknown,
+  },
 }));
 
 // Captures the props GameMenu was rendered with, so tests can assert which
@@ -130,6 +135,7 @@ vi.mock("../../stores/gameStore", () => ({
     vi.fn((selector: (s: Record<string, unknown>) => unknown) =>
       selector({
         gameState: storeOverrides.gameState,
+        gameMode: storeOverrides.gameMode,
         waitingFor: storeOverrides.waitingFor,
         legalActions: [],
         endContinuousEffectOffers: [],
@@ -146,6 +152,11 @@ vi.mock("../../stores/gameStore", () => ({
     { setState: mockSetGameState },
   ),
   clearGame: vi.fn(),
+  // The real predicate, not a stub: GamePage's `takebackAudience` is derived
+  // through it, and a stubbed version would let a wrong mode-set pass.
+  hasRemoteHumans: (mode: string | null) =>
+    mode === "online" || mode === "p2p-host" || mode === "p2p-join"
+    || mode === "draft-match" || mode === "spectate",
   loadActiveGame: vi.fn(() => null),
   saveActiveGame: vi.fn(),
   clearActiveGame: vi.fn(),
@@ -289,6 +300,7 @@ beforeEach(() => {
   capturedGameMenuProps = undefined;
   storeOverrides.adapter = null;
   storeOverrides.gameState = null;
+  storeOverrides.gameMode = null;
   storeOverrides.waitingFor = null;
   usePreferencesStore.setState({ multiplayerBoardLayout: "focused" });
   capturedConcedeDialogProps = undefined;
@@ -696,6 +708,70 @@ describe("GamePage — takeback is a transport capability", () => {
     renderGamePage("/game/test-game-123?mode=host");
 
     expect(capturedGameMenuProps?.onRequestTakeback).toBeTypeOf("function");
+  });
+
+  // F5 (M11 half). The label axis must come from the AUTHORITATIVE store mode,
+  // not the URL-derived one: desktop solo arrives as `?mode=ai` and the store
+  // says `native-ai`, so a URL-derived answer cannot tell it apart from a
+  // browser AI game — and both must read as a solo undo, while an online table
+  // keeps the "request" wording.
+  it("addresses the rollback to the player alone in desktop solo", () => {
+    storeOverrides.adapter = new FakeWebSocketAdapter();
+    storeOverrides.gameMode = "native-ai";
+
+    renderGamePage("/game/test-game-123?mode=ai");
+
+    expect(capturedGameMenuProps?.takebackAudience).toBe("solo");
+  });
+
+  it("addresses the rollback to the table in online play", () => {
+    // Paired positive. `?mode=host` with the store reporting `online` is the
+    // shape that must NOT change wording.
+    storeOverrides.adapter = new FakeWebSocketAdapter();
+    storeOverrides.gameMode = "online";
+
+    renderGamePage("/game/test-game-123?mode=host");
+
+    expect(capturedGameMenuProps?.takebackAudience).toBe("table");
+  });
+});
+
+/**
+ * F5 — desktop solo-vs-AI sandbox characterization.
+ *
+ * HONESTLY LABELLED: this PASSES at BASE_SHA. The user's "sandbox mode, no
+ * banner" ask is already satisfied, and this exists so a later change cannot
+ * silently undo it. `mode` is URL-derived and structurally cannot be
+ * `native-ai`; desktop solo arrives as `rawMode === "ai"`, which already
+ * satisfies `showSandboxTools`. The SANDBOX badge is gated separately on
+ * `format_config.allow_debug_actions`, which the server's `SingleUser` branch
+ * deliberately leaves false.
+ */
+describe("GamePage — desktop solo sandbox tools without the banner", () => {
+  it("enables sandbox tools while the SANDBOX badge stays hidden", () => {
+    storeOverrides.gameMode = "native-ai";
+    storeOverrides.gameState = gameStateFactory.build({
+      format_config: { allow_debug_actions: false } as unknown as FormatConfig,
+    });
+
+    renderGamePage("/game/test-game-123?mode=ai");
+
+    expect(capturedGameMenuProps?.showSandboxTools).toBe(true);
+    expect(screen.queryByRole("status", { name: "Sandbox mode banner" })).toBeNull();
+  });
+
+  it("shows the SANDBOX badge once the game really is sandbox-flagged", () => {
+    // Non-vacuity guard for the negative above: flipping the one flag the
+    // badge is gated on must make it appear, proving the assertion measures
+    // the gate rather than an unrendered subtree.
+    storeOverrides.gameMode = "ai";
+    storeOverrides.gameState = gameStateFactory.build({
+      format_config: { allow_debug_actions: true } as unknown as FormatConfig,
+    });
+
+    renderGamePage("/game/test-game-123?mode=ai");
+
+    expect(screen.getByRole("status", { name: "Sandbox mode banner" })).toBeInTheDocument();
   });
 });
 

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -130,7 +130,7 @@ vi.mock("../../game/dispatch.ts", () => ({
   currentSnapshot: new Map(),
 }));
 
-vi.mock("../../stores/gameStore", () => ({
+vi.mock("../../stores/gameStore", async () => ({
   useGameStore: Object.assign(
     vi.fn((selector: (s: Record<string, unknown>) => unknown) =>
       selector({
@@ -152,11 +152,16 @@ vi.mock("../../stores/gameStore", () => ({
     { setState: mockSetGameState },
   ),
   clearGame: vi.fn(),
-  // The real predicate, not a stub: GamePage's `takebackAudience` is derived
-  // through it, and a stubbed version would let a wrong mode-set pass.
-  hasRemoteHumans: (mode: string | null) =>
-    mode === "online" || mode === "p2p-host" || mode === "p2p-join"
-    || mode === "draft-match" || mode === "spectate",
+  // The real predicate, and `importActual` is what makes that claim true.
+  // `hasRemoteHumans` reads `GAME_MODE_TRAITS`, a frozen taxonomy that lives
+  // only in this module; re-deriving it here as `mode === "online" || …` would
+  // pass while the real predicate classified a mode differently — exactly the
+  // failure the `takebackAudience` assertions below exist to catch. Only the
+  // predicate is taken: `useGameStore` stays the mock above, so the real
+  // zustand store is imported but never rendered against.
+  hasRemoteHumans: (
+    await vi.importActual<typeof import("../../stores/gameStore")>("../../stores/gameStore")
+  ).hasRemoteHumans,
   loadActiveGame: vi.fn(() => null),
   saveActiveGame: vi.fn(),
   clearActiveGame: vi.fn(),

--- a/client/src/providers/GameProvider.tsx
+++ b/client/src/providers/GameProvider.tsx
@@ -1241,7 +1241,7 @@ export function GameProvider({
             if (needAdapter) {
               useGameStore.setState({ adapter: wsAdapter });
             }
-            processRemoteUpdate(event.snapshot, event.events, event.logEntries);
+            processRemoteUpdate(event.snapshot, event.events, event.logEntries, event.rewindTargets);
             useMultiplayerStore.getState().setConnectionStatus("connected");
             const wsState = event.snapshot.state;
             if (
@@ -1677,7 +1677,7 @@ export function GameProvider({
               if (!useGameStore.getState().adapter && adapter) {
                 useGameStore.setState({ adapter });
               }
-              processRemoteUpdate(event.snapshot, event.events, event.logEntries);
+              processRemoteUpdate(event.snapshot, event.events, event.logEntries, event.rewindTargets);
             }
             if (event.type === "gameOver") {
               useGameStore.setState({

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -120,20 +120,21 @@ export function isAuthorityRemote(mode: GameMode | null): boolean {
  * are safe when false — there is nobody else's game to disturb and no hidden
  * info to leak across a wire.
  *
- * **This predicate has no production caller today, deliberately.** Every gate
- * that reads `gameMode` asks the authority question above; the company
- * question is what the merged predicate silently got *wrong* for `native-ai`,
- * and naming it is the fix. It is exported rather than left implicit so that
- * the next gate needing "are other humans watching?" has an answer to call
- * instead of an `||` to append — and so the classification is observable, which
- * is what lets a test prove the two axes actually disagree for `native-ai`.
- * Without it a test could still tabulate `isAuthorityRemote` across all eight
- * modes and go red on any classification change; that test would not be
- * vacuous, it would just be a no-op restatement of the behaviour before the
- * split, unable to say anything about the axis this change exists to name.
- * No lint flags unused exports here (`client/eslint.config.js` configures only
- * `@typescript-eslint/no-unused-vars`, and there is no knip), so this comment,
- * not a suppression, is the honest handling.
+ * **First and only production consumer: `GamePage`'s `takebackAudience`.**
+ * `GamePage` passes `hasRemoteHumans(storeGameMode) ? "table" : "solo"` to
+ * `GameMenu`, which is what makes the desktop solo-vs-AI menu entry read "Undo
+ * Last Action" rather than "Request Takeback". That gate is the company
+ * question, not the authority one: `native-ai` is `authority: "wire"` (the
+ * sidecar owns the state) but has no other human at the table, and asking
+ * `isAuthorityRemote` there would label a solo undo as a request to somebody.
+ * That mislabelling is exactly what the merged predicate got wrong, and
+ * splitting the two axes is the fix.
+ *
+ * Every *other* gate that reads `gameMode` still asks the authority question
+ * above; keep it that way. Reach for this one only when the question really is
+ * "are other humans watching?", and prefer calling it over appending an `||` to
+ * a mode list — the string union is frozen taxonomy, and a hand-rolled list
+ * silently misses the next mode added.
  *
  * Do not repurpose it for transport questions: `canRestoreCheckpoints`
  * (`DebugPanel.tsx`) looks like a company gate but is really "does this

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -15,6 +15,7 @@ import type {
   ObjectId,
   PlayerId,
   PersistedGameState,
+  RewindOption,
   StuckDecisionDiagnostic,
   WaitingFor,
 } from "../adapter/types";
@@ -187,6 +188,13 @@ interface GameStoreState {
   stateHistory: GameState[];
   turnCheckpoints: GameState[];
   /**
+   * Server-published turn boundaries offered as rollback targets. Mirrors the
+   * server exactly — never appended to client-side, never derived. Empty on
+   * every transport that does not publish them (which is all of them except a
+   * `SingleUser` phase-server sidecar).
+   */
+  rewindTargets: RewindOption[];
+  /**
    * Pre-game P2P lobby fill state, populated by the `lobbyProgress` adapter
    * event and cleared when `game_setup` arrives (game starts). `null` when
    * not in a pre-game P2P lobby (i.e. during AI/online games or after the
@@ -291,6 +299,12 @@ interface GameStoreActions {
   resumeNativeSolo: (gameId: string, adapter: EngineAdapter) => Promise<void>;
   dispatch: (action: GameAction) => Promise<GameEvent[]>;
   undo: () => Promise<void>;
+  /**
+   * Replace the server-published rollback targets. Only `dispatch.ts` calls
+   * this, and only from inside its generation gate — a superseded remote update
+   * must not clobber the list with a stale one.
+   */
+  setRewindTargets: (targets: RewindOption[]) => void;
   reset: () => void;
   setAdapter: (adapter: EngineAdapter) => void;
   /**
@@ -389,6 +403,7 @@ async function seedResumedServerGame(
       nextLogSeq: 0,
       stateHistory: [],
       turnCheckpoints: [],
+      rewindTargets: [],
     },
   });
 }
@@ -416,6 +431,7 @@ const initialState: GameStoreState = {
   viewerInteraction: null,
   stateHistory: [],
   turnCheckpoints: [],
+  rewindTargets: [],
   lobbyProgress: null,
   resolutionProgress: null,
   isResolvingAll: false,
@@ -540,6 +556,7 @@ export const useGameStore = create<GameStore>()(
           nextLogSeq: initLogEntries.length,
           stateHistory: [],
           turnCheckpoints: [],
+          rewindTargets: [],
           startingContest,
         },
       });
@@ -566,6 +583,7 @@ export const useGameStore = create<GameStore>()(
           nextLogSeq: 0,
           stateHistory: [],
           turnCheckpoints: savedCheckpoints,
+          rewindTargets: [],
         },
       });
     },
@@ -649,6 +667,10 @@ export const useGameStore = create<GameStore>()(
           stateHistory: stateHistory.slice(0, -1),
         },
       });
+    },
+
+    setRewindTargets: (targets) => {
+      set({ rewindTargets: targets });
     },
 
     reset: () => {

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -3477,8 +3477,13 @@ async fn draft_pack_generator_for_start(
 /// and spectator fan-out as a normal action's. Pure extraction — no behavioural
 /// delta on the shipped path.
 ///
-/// `rewind_targets` is captured under the same lock as the results themselves;
-/// it cannot be recomputed here because this function holds no session.
+/// `rewind_targets` and `eliminated` are both captured under the same lock as
+/// the results themselves, and both **after** `run_ai` — neither can be
+/// recomputed here because this function holds no session. Taking either from a
+/// pre-`run_ai` value would ship a list one transition stale: the AI's follow-up
+/// can cross a turn (adding a rewind boundary) or finish a player off (adding an
+/// elimination), and every `StateUpdate` in the batch would then contradict the
+/// state travelling with it.
 async fn broadcast_ai_results(
     connections: &SharedConnections,
     game_spectators: &SharedGameSpectators,
@@ -3664,9 +3669,17 @@ async fn broadcast_takeback_approved(
                     legal_actions_by_object: object_action_payloads(&p_by_object),
                     derived: derive_transport_views(&raw_state, pstate, Some(*pid)),
                     viewer_interaction: derive_viewer_interaction(&raw_state, pstate, *pid),
-                    // Captured under the same lock as the rollback: an approved
-                    // rewind prunes the ring, so the pre-rollback list would
-                    // advertise boundaries that no longer exist.
+                    // Captured by the caller under the same lock as the
+                    // rollback, and — like the shipped action path's own
+                    // capture — *after* its `run_ai`, not before. Both halves
+                    // matter. Under the lock, because an approved rewind prunes
+                    // the ring and a list read outside it could advertise
+                    // boundaries that no longer exist. After `run_ai`, because
+                    // `run_ai` is itself a capture site: an AI follow-up that
+                    // crosses a turn adds a boundary, and a pre-`run_ai` read
+                    // would ship a list already one behind the state travelling
+                    // with it. The list is a live session affordance, not a
+                    // projection of `snapshot`.
                     rewind_targets: rewind_targets.clone(),
                 });
             }
@@ -6210,7 +6223,14 @@ async fn handle_client_message(
             } else {
                 Vec::new()
             };
+            // Both read AFTER `run_ai`, matching the shipped action path: an AI
+            // follow-up can cross a turn (new rewind boundary) or finish a
+            // player off (new elimination), and the AI fan-out below must not
+            // describe the state as it stood before its own results.
+            // `snapshot.0` is the *pre*-`run_ai` rollback state, so sourcing
+            // eliminations from it would be exactly that staleness.
             let rewind_targets = session.rewind_options();
+            let eliminated = session.state.eliminated_players.clone();
             // GH #1507: persist the rolled-back state immediately, in the
             // same lock as the rollback itself — otherwise SQLite still
             // holds the pre-rollback `GameState` until some later action
@@ -6260,7 +6280,6 @@ async fn handle_client_message(
                     info!(game = %game_code, player = ?player_id, "takeback auto-approved (sole human seat)");
                     let (state_revision, snapshot) =
                         approved_snapshot.expect("Approved outcome always computes a snapshot");
-                    let eliminated = snapshot.0.eliminated_players.clone();
                     broadcast_takeback_approved(
                         connections,
                         game_spectators,
@@ -6322,7 +6341,10 @@ async fn handle_client_message(
             } else {
                 Vec::new()
             };
+            // Read AFTER `run_ai` for the same reason as the `RequestTakeback`
+            // arm above.
             let rewind_targets = session.rewind_options();
+            let eliminated = session.state.eliminated_players.clone();
             // GH #1507: persist the rolled-back state immediately — see the
             // matching comment in the `RequestTakeback` arm above.
             if approved_snapshot.is_some() {
@@ -6350,7 +6372,6 @@ async fn handle_client_message(
                     info!(game = %game_code, player = ?player_id, "takeback unanimously approved");
                     let (state_revision, snapshot) =
                         approved_snapshot.expect("Approved outcome always computes a snapshot");
-                    let eliminated = snapshot.0.eliminated_players.clone();
                     broadcast_takeback_approved(
                         connections,
                         game_spectators,

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -69,11 +69,14 @@ use server_core::protocol::{
 };
 use server_core::resolve_deck;
 use server_core::seat_mutation_wire_guard::guard_seat_mutation;
-use server_core::session::{ActionResult, FullRuntime, GameSession, SessionManager};
+use server_core::session::{
+    ActionResult, FullRuntime, GameSession, RevisionedActionResult, SessionManager,
+};
 use server_core::spectator_wire_guard::{
     guard_draft_spectator_capacity, guard_game_spectator_capacity, guard_spectate_draft,
     guard_spectator_join,
 };
+use server_core::takeback::RewindOption;
 use std::time::Duration;
 use tokio::io::AsyncReadExt;
 use tokio::sync::{mpsc, oneshot, Mutex};
@@ -392,6 +395,13 @@ fn build_game_started_message(
             .as_ref()
             .map(|runtime| runtime.key.clone()),
         events: server_core::filter_events_for_player(&events, &session.state, player),
+        // Read from the session rather than taken as a parameter: every caller
+        // already hands this function the authoritative session, and there is
+        // no caller that should publish anything else. A parameter every site
+        // fills identically from an argument it already passes is a hazard,
+        // not a choice. Populating `GameStarted` (not just `StateUpdate`) is
+        // what makes a reconnect mid-game see the list immediately.
+        rewind_targets: session.rewind_options(),
     }
 }
 
@@ -413,10 +423,15 @@ fn build_game_started_messages(session: &mut GameSession) -> Vec<(PlayerId, Serv
         .collect()
 }
 
+/// `rewind_targets` is a parameter here, unlike in
+/// `build_game_started_message`, because this builder has no `GameSession` to
+/// read it from — the caller captures `session.rewind_options()` under the same
+/// lock as the transition and threads it through.
 fn build_state_update_message(
     result: &ActionResult,
     state_revision: u64,
     player: PlayerId,
+    rewind_targets: Vec<RewindOption>,
 ) -> Result<ServerMessage, String> {
     let (
         raw_state,
@@ -476,6 +491,7 @@ fn build_state_update_message(
         },
         derived,
         viewer_interaction,
+        rewind_targets,
     })
 }
 
@@ -510,6 +526,10 @@ fn build_spectator_game_started_message(session: &GameSession) -> Result<ServerM
             .as_ref()
             .map(|runtime| runtime.key.clone()),
         events: Vec::new(),
+        // Always empty for spectators, deliberately — NOT `rewind_options()`.
+        // A spectator is a read-only viewer with no rollback affordance, and
+        // the list would only advertise targets they cannot request.
+        rewind_targets: Vec::new(),
     })
 }
 
@@ -546,6 +566,11 @@ fn build_spectator_state_update_message(
         legal_actions_by_object: HashMap::new(),
         derived,
         viewer_interaction,
+        // Empty for the same reason as the spectator `GameStarted` builder
+        // above: a spectator has no rollback affordance. This builder also
+        // takes a raw state rather than a session, so `rewind_options()` is
+        // not even in scope here.
+        rewind_targets: Vec::new(),
     })
 }
 
@@ -880,7 +905,7 @@ fn reject_if_disabled(msg: &ClientMessage, mode: ServerMode) -> Option<&'static 
         | ClientMessage::AckTerminalDelivery { .. }
         | ClientMessage::Emote { .. }
         | ClientMessage::SpectatorJoin { .. }
-        | ClientMessage::RequestTakeback
+        | ClientMessage::RequestTakeback(_)
         | ClientMessage::RespondTakeback { .. }
         | ClientMessage::CancelTakeback => match mode {
             ServerMode::Full => None,
@@ -3443,11 +3468,142 @@ async fn draft_pack_generator_for_start(
         .ok_or_else(|| format!("No draft pool data for set: {set_code}"))
 }
 
+/// Per-AI-result fan-out for a batch of `run_ai` results.
+///
+/// Lifted verbatim out of `handle_full_game_submission` so the approved-takeback
+/// path can reuse it rather than duplicate 110 lines: a rollback can restore an
+/// AI seat to priority, and that AI's follow-up must reach clients with the same
+/// 100 ms pacing, size guard, `is_last` legal-action gating, per-player filter
+/// and spectator fan-out as a normal action's. Pure extraction — no behavioural
+/// delta on the shipped path.
+///
+/// `rewind_targets` is captured under the same lock as the results themselves;
+/// it cannot be recomputed here because this function holds no session.
+async fn broadcast_ai_results(
+    connections: &SharedConnections,
+    game_spectators: &SharedGameSpectators,
+    game_code: &str,
+    player_count: u8,
+    eliminated: &[PlayerId],
+    ai_results: &[RevisionedActionResult],
+    rewind_targets: &[RewindOption],
+) {
+    // Broadcast AI follow-up results with delays
+    for (i, (ai_revision, result)) in ai_results.iter().enumerate() {
+        tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+        let (
+            ai_raw_state,
+            ai_events,
+            ai_legal,
+            ai_log_entries,
+            _ai_auto_pass,
+            ai_spell_costs,
+            ai_by_object,
+        ) = result;
+        if guard_state_snapshot_broadcast(StateSnapshotParts {
+            state: ai_raw_state,
+            events: ai_events,
+            log_entries: ai_log_entries,
+            legal_actions: ai_legal,
+            legal_actions_by_object: ai_by_object,
+            spell_costs: ai_spell_costs,
+        })
+        .is_err()
+        {
+            continue;
+        }
+        let is_last = i == ai_results.len() - 1;
+
+        // Filter AI state per-player outside the lock
+        let ai_filtered: Vec<(PlayerId, GameState)> = (0..player_count)
+            .map(|j| {
+                let pid = PlayerId(j);
+                (pid, server_core::filter_state_for_player(ai_raw_state, pid))
+            })
+            .collect();
+
+        let conns = connections.lock().await;
+        if let Some(players) = conns.get(game_code) {
+            for (pid, pstate) in &ai_filtered {
+                if let Some(s) = players.get(pid) {
+                    let is_actor = server_core::is_acting(ai_raw_state, *pid);
+                    let player_legals = if is_last && is_actor {
+                        ai_legal.clone()
+                    } else {
+                        vec![]
+                    };
+                    let p_auto_pass = if is_last {
+                        engine_auto_pass_for_viewer(ai_raw_state, *pid, ai_legal)
+                    } else {
+                        false
+                    };
+                    let p_end_continuous_effect_offers =
+                        engine_end_continuous_effect_offers(&player_legals);
+                    let p_mana_payment_shortcut_actions = if is_last && is_actor {
+                        engine_mana_payment_shortcut_actions(ai_raw_state, ai_by_object)
+                    } else {
+                        Vec::new()
+                    };
+                    let p_spell_costs = if is_last && is_actor {
+                        ai_spell_costs.clone()
+                    } else {
+                        HashMap::new()
+                    };
+                    let p_by_object = if is_last && is_actor {
+                        ai_by_object.clone()
+                    } else {
+                        HashMap::new()
+                    };
+                    let _ = s.send(ServerMessage::StateUpdate {
+                        state_revision: *ai_revision,
+                        state: pstate.clone(),
+                        events: server_core::filter_events_for_player(
+                            ai_events,
+                            ai_raw_state,
+                            *pid,
+                        ),
+                        legal_actions: player_legals,
+                        auto_pass_recommended: p_auto_pass,
+                        end_continuous_effect_offers: p_end_continuous_effect_offers,
+                        mana_payment_shortcut_actions: p_mana_payment_shortcut_actions,
+                        eliminated_players: eliminated.to_vec(),
+                        log_entries: ai_log_entries.clone(),
+                        spell_costs: p_spell_costs,
+                        legal_actions_by_object: object_action_payloads(&p_by_object),
+                        derived: derive_transport_views(ai_raw_state, pstate, Some(*pid)),
+                        viewer_interaction: derive_viewer_interaction(ai_raw_state, pstate, *pid),
+                        rewind_targets: rewind_targets.to_vec(),
+                    });
+                }
+            }
+        }
+        let (ai_raw_state, ai_events, _, ai_log_entries, _, _, _) = result;
+        if let Ok(spectator_msg) = build_spectator_state_update_message(
+            ai_raw_state,
+            ai_events,
+            ai_log_entries,
+            *ai_revision,
+        ) {
+            let mut specs = game_spectators.lock().await;
+            if let Some(spectators) = specs.get_mut(game_code) {
+                spectators.retain(|sender| sender.send(spectator_msg.clone()).is_ok());
+                if spectators.is_empty() {
+                    specs.remove(game_code);
+                }
+            }
+        }
+    }
+}
+
 /// Broadcasts the result of an approved takeback (GH #1507): a `StateUpdate`
 /// carrying the rolled-back state to every seat, filtered per-player exactly
 /// like a normal action result, followed by `TakebackResolved { approved: true, .. }`.
 /// `resolved_by` is the player whose response concluded the request, or
 /// `None` when it resolved naturally (e.g. the requester was the sole human).
+// Same shape as the sibling transport fan-outs at `:2010`/`:3767`/`:4071`:
+// every argument is a distinct broadcast input captured under the session lock,
+// and bundling them into a struct here would only move the arity, not reduce it.
+#[allow(clippy::too_many_arguments)]
 async fn broadcast_takeback_approved(
     connections: &SharedConnections,
     game_spectators: &SharedGameSpectators,
@@ -3456,6 +3612,7 @@ async fn broadcast_takeback_approved(
     state_revision: u64,
     snapshot: server_core::BroadcastSnapshot,
     resolved_by: Option<PlayerId>,
+    rewind_targets: Vec<RewindOption>,
 ) {
     let (raw_state, legal_actions, _auto_pass, spell_costs, by_object) = snapshot;
     let filtered_states: Vec<(PlayerId, GameState)> = (0..player_count)
@@ -3507,6 +3664,10 @@ async fn broadcast_takeback_approved(
                     legal_actions_by_object: object_action_payloads(&p_by_object),
                     derived: derive_transport_views(&raw_state, pstate, Some(*pid)),
                     viewer_interaction: derive_viewer_interaction(&raw_state, pstate, *pid),
+                    // Captured under the same lock as the rollback: an approved
+                    // rewind prunes the ring, so the pre-rollback list would
+                    // advertise boundaries that no longer exist.
+                    rewind_targets: rewind_targets.clone(),
                 });
             }
         }
@@ -3684,6 +3845,12 @@ async fn handle_full_game_submission(
                 };
                 let session = mgr.sessions.get(&game_code).unwrap();
                 let eliminated = session.state.eliminated_players.clone();
+                // Captured once, AFTER `run_ai`, and reused for both the human
+                // and the AI fan-out below: the list is a live session
+                // affordance rather than a per-snapshot projection, so the
+                // freshest value under this lock is the correct one for every
+                // message this transition produces.
+                let rewind_targets = session.rewind_options();
                 let player_count = session.player_count;
                 let game_over_winner = match &session.state.waiting_for {
                     engine::types::game_state::WaitingFor::GameOver { winner } => Some(*winner),
@@ -3719,6 +3886,7 @@ async fn handle_full_game_submission(
                         player_count,
                         game_over_winner,
                         terminal,
+                        rewind_targets,
                     )
                 })
             }
@@ -3743,6 +3911,7 @@ async fn handle_full_game_submission(
             player_count,
             game_over_winner,
             terminal,
+            rewind_targets,
         )) => {
             if let Err(reason) = guard_state_snapshot_broadcast(StateSnapshotParts {
                 state: &raw_state,
@@ -3840,6 +4009,7 @@ async fn handle_full_game_submission(
                                 viewer_interaction: derive_viewer_interaction(
                                     &raw_state, pstate, *pid,
                                 ),
+                                rewind_targets: rewind_targets.clone(),
                             });
                         }
                     }
@@ -3860,114 +4030,16 @@ async fn handle_full_game_submission(
                 }
             }
 
-            // Broadcast AI follow-up results with delays
-            for (i, (ai_revision, result)) in ai_results.iter().enumerate() {
-                tokio::time::sleep(std::time::Duration::from_millis(100)).await;
-                let (
-                    ai_raw_state,
-                    ai_events,
-                    ai_legal,
-                    ai_log_entries,
-                    _ai_auto_pass,
-                    ai_spell_costs,
-                    ai_by_object,
-                ) = result;
-                if guard_state_snapshot_broadcast(StateSnapshotParts {
-                    state: ai_raw_state,
-                    events: ai_events,
-                    log_entries: ai_log_entries,
-                    legal_actions: ai_legal,
-                    legal_actions_by_object: ai_by_object,
-                    spell_costs: ai_spell_costs,
-                })
-                .is_err()
-                {
-                    continue;
-                }
-                let is_last = i == ai_results.len() - 1;
-
-                // Filter AI state per-player outside the lock
-                let ai_filtered: Vec<(PlayerId, GameState)> = (0..player_count)
-                    .map(|j| {
-                        let pid = PlayerId(j);
-                        (pid, server_core::filter_state_for_player(ai_raw_state, pid))
-                    })
-                    .collect();
-
-                let conns = connections.lock().await;
-                if let Some(players) = conns.get(&game_code) {
-                    for (pid, pstate) in &ai_filtered {
-                        if let Some(s) = players.get(pid) {
-                            let is_actor = server_core::is_acting(ai_raw_state, *pid);
-                            let player_legals = if is_last && is_actor {
-                                ai_legal.clone()
-                            } else {
-                                vec![]
-                            };
-                            let p_auto_pass = if is_last {
-                                engine_auto_pass_for_viewer(ai_raw_state, *pid, ai_legal)
-                            } else {
-                                false
-                            };
-                            let p_end_continuous_effect_offers =
-                                engine_end_continuous_effect_offers(&player_legals);
-                            let p_mana_payment_shortcut_actions = if is_last && is_actor {
-                                engine_mana_payment_shortcut_actions(ai_raw_state, ai_by_object)
-                            } else {
-                                Vec::new()
-                            };
-                            let p_spell_costs = if is_last && is_actor {
-                                ai_spell_costs.clone()
-                            } else {
-                                HashMap::new()
-                            };
-                            let p_by_object = if is_last && is_actor {
-                                ai_by_object.clone()
-                            } else {
-                                HashMap::new()
-                            };
-                            let _ = s.send(ServerMessage::StateUpdate {
-                                state_revision: *ai_revision,
-                                state: pstate.clone(),
-                                events: server_core::filter_events_for_player(
-                                    ai_events,
-                                    ai_raw_state,
-                                    *pid,
-                                ),
-                                legal_actions: player_legals,
-                                auto_pass_recommended: p_auto_pass,
-                                end_continuous_effect_offers: p_end_continuous_effect_offers,
-                                mana_payment_shortcut_actions: p_mana_payment_shortcut_actions,
-                                eliminated_players: eliminated.clone(),
-                                log_entries: ai_log_entries.clone(),
-                                spell_costs: p_spell_costs,
-                                legal_actions_by_object: object_action_payloads(&p_by_object),
-                                derived: derive_transport_views(ai_raw_state, pstate, Some(*pid)),
-                                viewer_interaction: derive_viewer_interaction(
-                                    ai_raw_state,
-                                    pstate,
-                                    *pid,
-                                ),
-                            });
-                        }
-                    }
-                }
-                let (ai_raw_state, ai_events, _, ai_log_entries, _, _, _) = result;
-                if let Ok(spectator_msg) = build_spectator_state_update_message(
-                    ai_raw_state,
-                    ai_events,
-                    ai_log_entries,
-                    *ai_revision,
-                ) {
-                    let mut specs = game_spectators.lock().await;
-                    if let Some(spectators) = specs.get_mut(&game_code) {
-                        spectators.retain(|sender| sender.send(spectator_msg.clone()).is_ok());
-                        if spectators.is_empty() {
-                            specs.remove(&game_code);
-                        }
-                    }
-                }
-            }
+            broadcast_ai_results(
+                connections,
+                game_spectators,
+                &game_code,
+                player_count,
+                &eliminated,
+                &ai_results,
+                &rewind_targets,
+            )
+            .await;
 
             if !terminal_deliveries.is_empty() {
                 let conns = connections.lock().await;
@@ -4441,6 +4513,11 @@ async fn handle_client_message(
                     /// so the reconnecting socket gets the same prompt it
                     /// would have received had it stayed connected.
                     pending_takeback_msg: Option<Box<ServerMessage>>,
+                    /// Captured under the same lock as `ai_result`, for the
+                    /// `StateUpdate` fan-out to the *other* seats below. The
+                    /// reconnecting socket gets its own copy inside
+                    /// `game_started_msg`.
+                    rewind_targets: Vec<RewindOption>,
                 },
                 Err(String),
             }
@@ -4491,11 +4568,13 @@ async fn handle_client_message(
                                 build_game_started_message(session, player, None, Vec::new());
                             let pending_takeback_msg =
                                 session.pending_takeback_message().map(Box::new);
+                            let rewind_targets = session.rewind_options();
                             ReconnectOutcome::InGame {
                                 player,
                                 game_started_msg: Box::new(game_started_msg),
                                 ai_result,
                                 pending_takeback_msg,
+                                rewind_targets,
                             }
                         }
                         Err(e) => ReconnectOutcome::Err(e),
@@ -4545,6 +4624,7 @@ async fn handle_client_message(
                     game_started_msg,
                     ai_result,
                     pending_takeback_msg,
+                    rewind_targets,
                 } => {
                     info!(game = %game_code, player = ?player, "reconnect succeeded");
                     identity.set_session(game_code.clone(), player, player_token);
@@ -4588,9 +4668,12 @@ async fn handle_client_message(
                         if let Some(game_conns) = conns.get(&game_code) {
                             for (&pid, sender) in game_conns.iter() {
                                 if pid != player {
-                                    if let Ok(msg) =
-                                        build_state_update_message(&result, state_revision, pid)
-                                    {
+                                    if let Ok(msg) = build_state_update_message(
+                                        &result,
+                                        state_revision,
+                                        pid,
+                                        rewind_targets.clone(),
+                                    ) {
                                         let _ = sender.send(msg);
                                     }
                                 }
@@ -5720,6 +5803,12 @@ async fn handle_client_message(
                         legal_actions_by_object: HashMap::new(),
                         derived,
                         viewer_interaction,
+                        // `JoinOutcome::Waiting` — the game has not started, so
+                        // no authoritative transition has happened and no turn
+                        // boundary can exist. Empty by construction, not by
+                        // omission; the first `GameStarted` publishes the real
+                        // list.
+                        rewind_targets: Vec::new(),
                     };
                     if let Ok(json) = serde_json::to_string(&msg) {
                         let _ = socket.send(Message::text(json)).await;
@@ -5922,7 +6011,9 @@ async fn handle_client_message(
                             persist_full_session_async(game_db, session);
                             Ok(None)
                         };
-                        terminal.map(|terminal| (revision, result, winner, terminal))
+                        let rewind_targets = session.rewind_options();
+                        terminal
+                            .map(|terminal| (revision, result, winner, terminal, rewind_targets))
                     }
                     Err(error) => Err(error),
                 }
@@ -5936,7 +6027,7 @@ async fn handle_client_message(
                         let _ = socket.send(Message::text(json)).await;
                     }
                 }
-                Ok((revision, result, winner, terminal)) => {
+                Ok((revision, result, winner, terminal, rewind_targets)) => {
                     let terminal_deliveries = match terminal {
                         Some(artifact) => match prepare_full_terminal(game_db, artifact).await {
                             Ok(deliveries) => deliveries,
@@ -5951,9 +6042,12 @@ async fn handle_client_message(
                     let conns = connections.lock().await;
                     if let Some(players) = conns.get(&game_code) {
                         for (player, sender) in players {
-                            if let Ok(update) =
-                                build_state_update_message(&result, revision, *player)
-                            {
+                            if let Ok(update) = build_state_update_message(
+                                &result,
+                                revision,
+                                *player,
+                                rewind_targets.clone(),
+                            ) {
                                 let _ = sender.send(update);
                             }
                             let _ = sender.send(ServerMessage::Conceded { player: player_id });
@@ -6006,13 +6100,14 @@ async fn handle_client_message(
                                 ranked_result_for_duel(game_db, &game_code, &players, Some(winner))
                             })
                         });
+                        let rewind_targets = session.rewind_options();
                         terminal_artifact(
                             session,
                             winner,
                             "Match conceded".to_string(),
                             ranked_result,
                         )
-                        .map(|terminal| (revision, result, winner, terminal))
+                        .map(|terminal| (revision, result, winner, terminal, rewind_targets))
                     }
                     Err(error) => Err(error),
                 }
@@ -6026,7 +6121,7 @@ async fn handle_client_message(
                         let _ = socket.send(Message::text(json)).await;
                     }
                 }
-                Ok((revision, result, winner, terminal)) => {
+                Ok((revision, result, winner, terminal, rewind_targets)) => {
                     let terminal_deliveries = match prepare_full_terminal(game_db, terminal).await {
                         Ok(deliveries) => deliveries,
                         Err(error) => {
@@ -6038,9 +6133,12 @@ async fn handle_client_message(
                     let conns = connections.lock().await;
                     if let Some(players) = conns.get(&game_code) {
                         for (player, sender) in players {
-                            if let Ok(update) =
-                                build_state_update_message(&result, revision, *player)
-                            {
+                            if let Ok(update) = build_state_update_message(
+                                &result,
+                                revision,
+                                *player,
+                                rewind_targets.clone(),
+                            ) {
                                 let _ = sender.send(update);
                             }
                             if let Some((_, delivery)) =
@@ -6066,7 +6164,7 @@ async fn handle_client_message(
         // delegates to. None of these three arms touch `session.state`
         // directly; they only call into `GameSession` methods that own the
         // takeback/rollback invariants.
-        ClientMessage::RequestTakeback => {
+        ClientMessage::RequestTakeback(target) => {
             let (game_code, player_id) = match (&identity.game_code, identity.player_id) {
                 (Some(c), Some(p)) => (c.clone(), p),
                 _ => {
@@ -6083,7 +6181,10 @@ async fn handle_client_message(
                 drop(mgr);
                 return;
             };
-            let outcome = session.request_takeback(player_id);
+            // An absent payload is the frame every pre-rewind client sends;
+            // normalizing at the transport edge keeps `RewindTarget` — not
+            // `Option<RewindTarget>` — the session API's vocabulary.
+            let outcome = session.request_takeback(player_id, target.unwrap_or_default());
             // `pending_takeback_message` reads `session.pending_takeback`,
             // which `request_takeback` already cleared on an Approved
             // outcome — so this is `Some` exactly when we need it (the
@@ -6097,11 +6198,27 @@ async fn handle_client_message(
                         session.current_broadcast_snapshot(),
                     )
                 });
+            // A rollback can restore an AI seat to priority — most obviously a
+            // `TurnStart` rewind onto an AI turn, but a `LastAction` rewind can
+            // land there too. Without this the table freezes: nothing else on
+            // the approved path drives the AI. `run_ai` is a no-op when there
+            // are no AI seats, and its own pending-takeback guard is already
+            // cleared by the time we get here. Revisions stay contiguous: the
+            // rollback took R+1 above, `run_ai` allocates R+2..R+k.
+            let ai_results = if approved_snapshot.is_some() {
+                session.run_ai()
+            } else {
+                Vec::new()
+            };
+            let rewind_targets = session.rewind_options();
             // GH #1507: persist the rolled-back state immediately, in the
             // same lock as the rollback itself — otherwise SQLite still
             // holds the pre-rollback `GameState` until some later action
             // happens to persist, and a crash/restart in that window
-            // resurrects the branch the table just agreed to undo.
+            // resurrects the branch the table just agreed to undo. Ordered
+            // AFTER `run_ai`, matching the normal action path: otherwise a
+            // crash between the rollback and the next action resurrects a
+            // state the AI has already moved past.
             if approved_snapshot.is_some() {
                 persist_full_session_async(game_db, session);
             }
@@ -6143,6 +6260,7 @@ async fn handle_client_message(
                     info!(game = %game_code, player = ?player_id, "takeback auto-approved (sole human seat)");
                     let (state_revision, snapshot) =
                         approved_snapshot.expect("Approved outcome always computes a snapshot");
+                    let eliminated = snapshot.0.eliminated_players.clone();
                     broadcast_takeback_approved(
                         connections,
                         game_spectators,
@@ -6151,6 +6269,17 @@ async fn handle_client_message(
                         state_revision,
                         snapshot,
                         None,
+                        rewind_targets.clone(),
+                    )
+                    .await;
+                    broadcast_ai_results(
+                        connections,
+                        game_spectators,
+                        &game_code,
+                        player_count,
+                        &eliminated,
+                        &ai_results,
+                        &rewind_targets,
                     )
                     .await;
                 }
@@ -6186,6 +6315,14 @@ async fn handle_client_message(
                         session.current_broadcast_snapshot(),
                     )
                 });
+            // Same reason, same ordering, as the `RequestTakeback` arm above:
+            // the rolled-back state can put an AI seat on priority.
+            let ai_results = if approved_snapshot.is_some() {
+                session.run_ai()
+            } else {
+                Vec::new()
+            };
+            let rewind_targets = session.rewind_options();
             // GH #1507: persist the rolled-back state immediately — see the
             // matching comment in the `RequestTakeback` arm above.
             if approved_snapshot.is_some() {
@@ -6213,6 +6350,7 @@ async fn handle_client_message(
                     info!(game = %game_code, player = ?player_id, "takeback unanimously approved");
                     let (state_revision, snapshot) =
                         approved_snapshot.expect("Approved outcome always computes a snapshot");
+                    let eliminated = snapshot.0.eliminated_players.clone();
                     broadcast_takeback_approved(
                         connections,
                         game_spectators,
@@ -6221,6 +6359,17 @@ async fn handle_client_message(
                         state_revision,
                         snapshot,
                         Some(player_id),
+                        rewind_targets.clone(),
+                    )
+                    .await;
+                    broadcast_ai_results(
+                        connections,
+                        game_spectators,
+                        &game_code,
+                        player_count,
+                        &eliminated,
+                        &ai_results,
+                        &rewind_targets,
                     )
                     .await;
                 }
@@ -7200,7 +7349,9 @@ mod state_transport_derived_tests {
     }
 
     fn state_update_action_fields(result: &ActionResult, viewer: PlayerId) -> (usize, bool) {
-        match build_state_update_message(result, 1, viewer).expect("fixture state update") {
+        match build_state_update_message(result, 1, viewer, Vec::new())
+            .expect("fixture state update")
+        {
             ServerMessage::StateUpdate {
                 legal_actions,
                 auto_pass_recommended,
@@ -8487,7 +8638,7 @@ mod mode_gate_tests {
                 draft_code: "X".into(),
                 player_token: "t".into(),
             },
-            ClientMessage::RequestTakeback,
+            ClientMessage::RequestTakeback(None),
             ClientMessage::RespondTakeback { approve: true },
             ClientMessage::CancelTakeback,
         ];
@@ -8579,7 +8730,7 @@ mod mode_gate_tests {
                 draft_code: "X".into(),
                 action: draft_core::types::DraftAction::StartDraft,
             },
-            ClientMessage::RequestTakeback,
+            ClientMessage::RequestTakeback(None),
             ClientMessage::RespondTakeback { approve: true },
             ClientMessage::CancelTakeback,
         ];

--- a/crates/server-core/src/client_message_wire_guard.rs
+++ b/crates/server-core/src/client_message_wire_guard.rs
@@ -79,7 +79,7 @@ pub fn guard_client_message_before_dispatch(
         | ClientMessage::Concede
         | ClientMessage::ConcedeMatch
         | ClientMessage::AbandonGame
-        | ClientMessage::RequestTakeback
+        | ClientMessage::RequestTakeback(_)
         | ClientMessage::RespondTakeback { .. }
         | ClientMessage::CancelTakeback => Ok(()),
         ClientMessage::BootstrapTerminalDelivery { request } => {
@@ -251,7 +251,7 @@ pub fn wire_rejection_message(msg: &ClientMessage, reason: String) -> ServerMess
         | ClientMessage::DraftAction { .. }
         | ClientMessage::ReconnectDraft { .. }
         | ClientMessage::SpectateDraft { .. }
-        | ClientMessage::RequestTakeback
+        | ClientMessage::RequestTakeback(_)
         | ClientMessage::RespondTakeback { .. }
         | ClientMessage::CancelTakeback => ServerMessage::error(reason),
     }
@@ -350,7 +350,7 @@ pub fn guard_broker_projection_inbound(msg: &ClientMessage) -> Result<(), String
         | ClientMessage::DraftAction { .. }
         | ClientMessage::ReconnectDraft { .. }
         | ClientMessage::SpectateDraft { .. }
-        | ClientMessage::RequestTakeback
+        | ClientMessage::RequestTakeback(_)
         | ClientMessage::RespondTakeback { .. }
         | ClientMessage::CancelTakeback => Ok(()),
     }

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -72,4 +72,7 @@ pub use spectator_wire_guard::{
     guard_draft_spectator_capacity, guard_game_spectator_capacity, guard_spectate_draft,
     guard_spectator_join, MAX_DRAFT_SPECTATORS_PER_DRAFT, MAX_GAME_SPECTATORS_PER_GAME,
 };
-pub use takeback::{PendingTakeback, TakebackOutcome, MAX_TAKEBACK_HISTORY};
+pub use takeback::{
+    PendingTakeback, RewindOption, RewindTarget, TakebackOutcome, MAX_TAKEBACK_HISTORY,
+    MAX_TURN_REWIND_HISTORY,
+};

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -15,6 +15,7 @@ use phase_ai::config::AiDifficulty;
 use serde::{Deserialize, Serialize};
 
 use crate::session::FullSessionKey;
+use crate::takeback::{RewindOption, RewindTarget};
 
 /// Full game wire protocol version. Kept numerically aligned with the lobby
 /// broker while state/action messages share the same WebSocket protocol enum.
@@ -320,10 +321,19 @@ pub enum ClientMessage {
         draft_code: String,
     },
     /// GH #1507: ask every other human player at the table to approve
-    /// rolling the game back to the state immediately before the requester's
-    /// most recent action. Auto-approves when the requester is the only
+    /// rolling the game back. Auto-approves when the requester is the only
     /// human seat (e.g. solo vs. AI).
-    RequestTakeback,
+    ///
+    /// A **newtype** variant carrying `Option<RewindTarget>`, not a struct
+    /// variant, and that shape is load-bearing. `ClientMessage` is adjacently
+    /// tagged (`tag = "type"`, `content = "data"`); serde synthesizes a
+    /// missing-`data` arm only for unit and newtype variants, and only an
+    /// `Option<T>` payload recovers from it. The client omits `data` entirely
+    /// for a last-action undo, so a struct variant here would make this server
+    /// reject its own same-version client's frame with ``missing field
+    /// `data` ``. `None` normalizes to [`RewindTarget::LastAction`], which is
+    /// exactly what an omitted payload means.
+    RequestTakeback(Option<RewindTarget>),
     /// Approve or decline the table's pending takeback request. Any single
     /// decline withdraws the request — rollback requires unanimous approval.
     RespondTakeback {
@@ -432,6 +442,12 @@ pub enum ServerMessage {
         /// seat. `serde(default)` keeps this back-compat for older clients.
         #[serde(default)]
         events: Vec<GameEvent>,
+        /// Turn boundaries this session currently offers as rollback targets.
+        /// Populated here as well as on `StateUpdate` so a reconnect mid-game
+        /// sees the list immediately rather than waiting for the next action.
+        /// Empty for every deployment except a `SingleUser` sidecar.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        rewind_targets: Vec<RewindOption>,
     },
     StateUpdate {
         /// Monotonic server-authored snapshot revision. Reused for read-only
@@ -469,6 +485,11 @@ pub enum ServerMessage {
         /// Viewer-scoped interactive opportunities derived from the same
         /// authoritative state as this filtered snapshot.
         viewer_interaction: engine::types::interaction::ViewerInteraction,
+        /// Turn boundaries this session currently offers as rollback targets,
+        /// published alongside the state they describe rather than out of band.
+        /// Empty for every deployment except a `SingleUser` sidecar.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        rewind_targets: Vec<RewindOption>,
     },
     ActionRejected {
         reason: String,
@@ -1209,6 +1230,7 @@ mod tests {
             player_token: None,
             full_key: None,
             events: vec![],
+            rewind_targets: vec![],
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ServerMessage = serde_json::from_str(&json).unwrap();
@@ -1263,6 +1285,7 @@ mod tests {
             player_token: None,
             full_key: None,
             events: vec![],
+            rewind_targets: vec![],
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ServerMessage = serde_json::from_str(&json).unwrap();
@@ -2240,10 +2263,121 @@ mod tests {
 
     #[test]
     fn client_message_request_takeback_roundtrips() {
-        let msg = ClientMessage::RequestTakeback;
+        let msg = ClientMessage::RequestTakeback(None);
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
-        assert!(matches!(parsed, ClientMessage::RequestTakeback));
+        assert!(matches!(parsed, ClientMessage::RequestTakeback(None)));
+    }
+
+    /// R15. The last-action frame the client actually sends carries **no**
+    /// `data` key at all, which is byte-identical to the frame every deployed
+    /// client already sends. `ClientMessage` is adjacently tagged, and serde
+    /// synthesizes a missing-content arm only for unit and newtype variants —
+    /// and only an `Option<T>` payload recovers from it. A struct variant here
+    /// would reject this frame with ``missing field `data` ``, so this
+    /// assertion is what fails if the variant shape regresses.
+    #[test]
+    fn request_takeback_without_data_decodes_as_last_action() {
+        let parsed: ClientMessage =
+            serde_json::from_str(r#"{"type":"RequestTakeback"}"#).expect("absent data must decode");
+        assert!(matches!(parsed, ClientMessage::RequestTakeback(None)));
+
+        let null_data: ClientMessage =
+            serde_json::from_str(r#"{"type":"RequestTakeback","data":null}"#)
+                .expect("explicit null data must decode");
+        assert!(matches!(null_data, ClientMessage::RequestTakeback(None)));
+
+        // `None` is the wire spelling of "this client predates turn rewind",
+        // and the transport normalizes it with `unwrap_or_default()`. Pin the
+        // default so that normalization cannot silently change meaning.
+        assert_eq!(RewindTarget::default(), RewindTarget::LastAction);
+    }
+
+    /// R15. The turn-rewind frame is the only `data`-bearing shape, and its
+    /// exact bytes are the contract `ws-adapter.ts` is written against.
+    #[test]
+    fn request_takeback_turn_start_roundtrips_with_exact_wire_bytes() {
+        let msg = ClientMessage::RequestTakeback(Some(RewindTarget::TurnStart { turn_number: 7 }));
+        let json = serde_json::to_string(&msg).unwrap();
+        assert_eq!(
+            json,
+            r#"{"type":"RequestTakeback","data":{"kind":"turn_start","turn_number":7}}"#
+        );
+        let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            parsed,
+            ClientMessage::RequestTakeback(Some(RewindTarget::TurnStart { turn_number: 7 }))
+        ));
+
+        let last_action = ClientMessage::RequestTakeback(Some(RewindTarget::LastAction));
+        let json = serde_json::to_string(&last_action).unwrap();
+        assert_eq!(
+            json,
+            r#"{"type":"RequestTakeback","data":{"kind":"last_action"}}"#
+        );
+        let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
+        assert!(matches!(
+            parsed,
+            ClientMessage::RequestTakeback(Some(RewindTarget::LastAction))
+        ));
+    }
+
+    /// R15. `rewind_targets` must survive a `StateUpdate` round-trip, must be
+    /// omitted from the wire entirely when empty (same shape as
+    /// `server_hello_omits_public_url_when_none`), and must decode to an empty
+    /// vec when a producer omits it.
+    #[test]
+    fn state_update_rewind_targets_roundtrip_and_omission() {
+        let state = GameState::new_two_player(42);
+        let viewer_interaction =
+            engine::game::interaction::derive_viewer_interaction(&state, &state, PlayerId(0));
+        let build = |rewind_targets: Vec<RewindOption>| ServerMessage::StateUpdate {
+            state_revision: 4,
+            state: state.clone(),
+            events: vec![],
+            legal_actions: vec![],
+            auto_pass_recommended: false,
+            end_continuous_effect_offers: vec![],
+            mana_payment_shortcut_actions: vec![],
+            eliminated_players: vec![],
+            log_entries: vec![],
+            spell_costs: HashMap::new(),
+            legal_actions_by_object: HashMap::new(),
+            derived: Default::default(),
+            viewer_interaction: viewer_interaction.clone(),
+            rewind_targets,
+        };
+
+        let populated = build(vec![RewindOption {
+            turn_number: 3,
+            active_player: PlayerId(1),
+        }]);
+        let json = serde_json::to_string(&populated).unwrap();
+        assert!(json.contains(r#""rewind_targets":[{"turn_number":3,"active_player":1}]"#));
+        match serde_json::from_str::<ServerMessage>(&json).unwrap() {
+            ServerMessage::StateUpdate { rewind_targets, .. } => {
+                assert_eq!(
+                    rewind_targets,
+                    vec![RewindOption {
+                        turn_number: 3,
+                        active_player: PlayerId(1),
+                    }]
+                );
+            }
+            _ => panic!("wrong variant"),
+        }
+
+        let empty = serde_json::to_string(&build(vec![])).unwrap();
+        assert!(
+            !empty.contains("rewind_targets"),
+            "an empty list must not appear on the wire at all"
+        );
+        match serde_json::from_str::<ServerMessage>(&empty).unwrap() {
+            ServerMessage::StateUpdate { rewind_targets, .. } => {
+                assert!(rewind_targets.is_empty(), "absent field decodes to empty");
+            }
+            _ => panic!("wrong variant"),
+        }
     }
 
     #[test]

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -3675,6 +3675,188 @@ mod tests {
         assert!(session.ai_session.is_none(), "`None` must stay `None`");
     }
 
+    /// A **driven-AI** sidecar fixture: seat 1 is not merely listed in
+    /// `ai_seats`, it carries a real `AiConfig`, which is what makes `run_ai`
+    /// actually choose and apply actions rather than bail on
+    /// `MissingAiConfig`. The AI bookkeeping mirrors
+    /// `run_ai_is_noop_while_takeback_is_pending` above;
+    /// `single_user_game` supplies the `HostingMode::SingleUser` stamp and the
+    /// padded libraries.
+    fn single_user_game_vs_ai() -> (SessionManager, String, String, PlayerId) {
+        let (mut mgr, code, token0, _token1) = single_user_game();
+        let ai_seat = PlayerId(1);
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        session.ai_seats.insert(ai_seat);
+        session.ai_configs.insert(
+            ai_seat,
+            phase_ai::config::create_config_for_players(AiDifficulty::Easy, Platform::Native, 2),
+        );
+        (mgr, code, token0, ai_seat)
+    }
+
+    /// Drives the fixture until **`run_ai` itself** publishes a turn boundary
+    /// whose active player is the AI seat, and returns that turn number.
+    ///
+    /// The split is the whole point: the human seat goes through the real
+    /// `handle_action` path and the AI seat goes through `session.run_ai()` —
+    /// never by hand. On a wire session that is exactly the production shape,
+    /// and it is what puts the crossing into the AI's turn inside `run_ai`: in
+    /// a two-player game the last player to pass in the active player's end
+    /// step is the *non*-active one, so the human's own turn is ended by the
+    /// AI's pass, which only `run_ai` submits.
+    ///
+    /// The before/after diff around the `run_ai` call is the attribution: an
+    /// option that was absent before it and present after it can only have come
+    /// from `run_ai`'s own results.
+    fn drive_until_run_ai_opens_an_ai_turn(
+        mgr: &mut SessionManager,
+        code: &str,
+        token0: &str,
+        ai_seat: PlayerId,
+    ) -> u32 {
+        for _ in 0..40 {
+            let session = mgr.sessions.get_mut(code).unwrap();
+            let before: Vec<u32> = session
+                .rewind_options()
+                .iter()
+                .map(|option| option.turn_number)
+                .collect();
+            let ai_results = session.run_ai();
+            let gained = session.rewind_options().into_iter().find(|option| {
+                option.active_player == ai_seat && !before.contains(&option.turn_number)
+            });
+            if let Some(option) = gained {
+                assert!(
+                    !ai_results.is_empty(),
+                    "a boundary appeared across a `run_ai` call that returned nothing — \
+                     the fixture is not measuring what it claims to"
+                );
+                return option.turn_number;
+            }
+            let waiting = session.state.waiting_for.clone();
+            match waiting {
+                WaitingFor::Priority { player } if player == ai_seat => panic!(
+                    "the AI seat holds priority but `run_ai` produced nothing — \
+                     the fixture cannot drive the AI at all"
+                ),
+                WaitingFor::Priority { .. } => {}
+                other => panic!("fixture stalled outside Priority: {other:?}"),
+            }
+            mgr.handle_action(code, token0, GameAction::PassPriority)
+                .expect("the human seat passes through the real transition handler");
+        }
+        panic!("`run_ai` never opened an AI-active turn boundary");
+    }
+
+    /// **R5 + R14 — the `run_ai` capture site and the G5 freeze fix.**
+    ///
+    /// Every other capture test in this module drives *both* seats by hand
+    /// through `handle_action` and never calls `run_ai()`. On a wire session the
+    /// AI's priority passes come from `run_ai`, so in production the transition
+    /// that crosses into the AI's turn happens inside it — and the headline
+    /// affordance ("rewind to the start of the AI's turn") rests entirely on the
+    /// `observe_transition` call in `run_ai`'s per-result map. This test is the
+    /// only coverage of that line.
+    ///
+    /// It then carries the G5 half: if a rewind onto an AI-active boundary did
+    /// not resume the AI, a user who rewound there would get a stalled game.
+    ///
+    /// **Revert probe (run, not asserted from memory):** deleting
+    /// `self.observe_transition(&r.events, &r.state);` from `run_ai` makes
+    /// `drive_until_run_ai_opens_an_ai_turn` exhaust its budget and panic with
+    /// "`run_ai` never opened an AI-active turn boundary" — the boundary is
+    /// never published at all.
+    #[test]
+    fn a_turn_opened_inside_run_ai_is_rewindable_and_resumes_instead_of_freezing() {
+        let (mut mgr, code, token0, ai_seat) = single_user_game_vs_ai();
+        let ai_turn = drive_until_run_ai_opens_an_ai_turn(&mut mgr, &code, &token0, ai_seat);
+
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        // **The discriminating guard.** `run_ai` pushes no `takeback_history`
+        // entries — only `handle_action` does. So if this turn's boundary had
+        // come from the hand-driven path rather than from `run_ai`'s own
+        // results, the action ring would already carry an entry sitting in it.
+        // Read here, before the human acts again: once the human passes inside
+        // the AI's turn, `handle_action` pushes one legitimately.
+        assert!(
+            session
+                .takeback_history
+                .iter()
+                .all(|(_, snapshot)| snapshot.turn_number != ai_turn),
+            "no action-ring entry may sit in turn {ai_turn} — the boundary must have come \
+             from `run_ai`'s own results, not from the `handle_action` capture site"
+        );
+        assert!(
+            !session.takeback_history.is_empty(),
+            "reach guard: the action ring is populated, so the assertion above is a \
+             statement about this turn and not about an empty collection"
+        );
+        // Q3's headline: the boundary is offered, and labelled with the AI seat.
+        assert!(
+            session.rewind_options().contains(&RewindOption {
+                turn_number: ai_turn,
+                active_player: ai_seat,
+            }),
+            "the AI-active boundary must be published: {:?}",
+            session.rewind_options()
+        );
+
+        assert_eq!(
+            session.request_takeback(
+                PlayerId(0),
+                RewindTarget::TurnStart {
+                    turn_number: ai_turn
+                }
+            ),
+            Ok(TakebackOutcome::Approved),
+            "seat 0 is the sole human — nobody to ask"
+        );
+        assert_eq!(session.state.turn_number, ai_turn);
+        assert_eq!(
+            session.state.active_player, ai_seat,
+            "the rewind must land on the AI's turn — otherwise the G5 half below is vacuous"
+        );
+
+        // **G5.** Nothing else on the approved path drives the AI, so if this
+        // returns empty the desktop table is frozen: the AI holds priority and
+        // no client action will ever arrive to move it.
+        let waiting_before = session.state.waiting_for.clone();
+        let resumed = session.run_ai();
+        assert!(
+            !resumed.is_empty(),
+            "a rewind onto an AI-active boundary must resume the AI, not freeze the game"
+        );
+        assert_ne!(
+            session.state.waiting_for, waiting_before,
+            "the AI must have actually advanced the state past its own priority"
+        );
+
+        // **Paired negative.** A rewind landing on *human* priority must leave
+        // `run_ai` a no-op — the resume above is a consequence of where the
+        // rewind landed, not something the approved path does unconditionally.
+        let (mut mgr, code, token0, ai_seat) = single_user_game_vs_ai();
+        drive_until_run_ai_opens_an_ai_turn(&mut mgr, &code, &token0, ai_seat);
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        assert_eq!(
+            session.request_takeback(PlayerId(0), RewindTarget::LastAction),
+            Ok(TakebackOutcome::Approved)
+        );
+        assert!(
+            matches!(session.state.waiting_for, WaitingFor::Priority { player } if player == PlayerId(0)),
+            "reach guard: this rewind must land on the human's priority, or the \
+             negative below proves nothing — got {:?}",
+            session.state.waiting_for
+        );
+        let waiting_before = session.state.waiting_for.clone();
+        let turn_before = session.state.turn_number;
+        assert!(
+            session.run_ai().is_empty(),
+            "with the human on priority the AI has nothing to do"
+        );
+        assert_eq!(session.state.waiting_for, waiting_before, "state unchanged");
+        assert_eq!(session.state.turn_number, turn_before);
+    }
+
     // ── Sandbox capability tests ─────────────────────────────────────────
 
     fn create_sandbox_game(mgr: &mut SessionManager) -> (String, String) {

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -236,13 +236,23 @@ pub struct GameSession {
     /// server — `GameSession::revoke_unentitled_debug_capability`, called
     /// immediately after the stamp, is what does that.
     ///
-    /// **Read fence.** This field is read by exactly one function,
-    /// `seed_debug_capability`, which is reachable only via
-    /// `rebuild_pregame_state`, which is called only from `start_game` and
-    /// from `apply_seat_delta`. Neither runs during the lobby re-registration
-    /// window in which a restored session still holds the `from_persisted`
-    /// placeholder. **Any new read must either sit behind
-    /// `rebuild_pregame_state` or be added after the restore stamp.**
+    /// **Read fence.** This field has exactly three readers:
+    ///
+    /// 1. `seed_debug_capability`, reachable only via `rebuild_pregame_state`,
+    ///    which is called only from `start_game` and from `apply_seat_delta`.
+    /// 2. `takeback::record_turn_rewind_point`, via
+    ///    [`GameSession::observe_transition`] — reached only from the four
+    ///    authoritative transition handlers, all of which require a started
+    ///    game.
+    /// 3. `takeback::offers_turn_rewind`, via `GameSession::rewind_options`
+    ///    and `GameSession::request_takeback` — likewise post-start.
+    ///
+    /// None of them runs during the lobby re-registration window in which a
+    /// restored session still holds the `from_persisted` placeholder
+    /// (`HostingMode::Shared`), and that placeholder can only *under*-grant:
+    /// readers 2 and 3 would decline to capture or publish, never over-offer.
+    /// **Any new read must either sit behind `rebuild_pregame_state` or be
+    /// reachable only after the restore stamp.**
     pub hosting: HostingMode,
     /// Number of human player seats in this game.
     pub player_count: u8,
@@ -281,6 +291,18 @@ pub struct GameSession {
     /// find the requester's *own* last action even when other players have
     /// acted since (see `crate::takeback::GameSession::request_takeback`).
     pub takeback_history: VecDeque<(PlayerId, GameState)>,
+    /// Rolling buffer of authoritative states, each one the post-state of a
+    /// transition that came to rest at the start of the turn it announced.
+    /// Strictly increasing in `turn_number` **within a game**, capped at
+    /// `MAX_TURN_REWIND_HISTORY`, and only ever populated on a
+    /// `HostingMode::SingleUser` sidecar (`takeback::offers_turn_rewind`).
+    /// Deliberately not persisted, matching `takeback_history`.
+    pub turn_rewind_history: VecDeque<GameState>,
+    /// The `game_number` the rewind rings above were last observed at. A Bo3
+    /// match assigns `turn_number = 1` again at each game's start, so both
+    /// rings are retired when this stops matching the post-state's own
+    /// `game_number` — see `crate::takeback::GameSession::observe_transition`.
+    pub rewind_game_number: u8,
 }
 
 impl GameSession {
@@ -754,6 +776,11 @@ impl GameSession {
         // can surface them; the broadcaster clears `start_events` afterward so
         // joiners/reconnects do not re-see the dice.
         let result = start_game(&mut self.state);
+        // Deliberately NOT a turn-rewind capture site, unlike the four
+        // transition handlers. These events never reach a transition handler,
+        // and turn 1's opening state sits adjacent to the mulligan flow —
+        // rewinding to it would land a player somewhere the rollback machine
+        // was never designed to resume from. An exclusion, not an omission.
         self.start_events = result.events;
         self.game_started = true;
         self.advance_state_revision();
@@ -802,6 +829,12 @@ impl GameSession {
                 let (legal, spell_costs, by_object) = engine_legal_actions_full(&r.state);
                 let auto_pass = auto_pass_recommended(&r.state, &legal);
                 let revision = self.advance_state_revision();
+                // Per AI result, which is exactly the granularity
+                // `run_ai_actions` reports. This is what makes a turn that
+                // elapses entirely inside AI play still produce a rewind
+                // point; a rule that promoted entries out of
+                // `takeback_history` could not, because `run_ai` pushes none.
+                self.observe_transition(&r.events, &r.state);
                 (
                     revision,
                     (
@@ -909,6 +942,8 @@ impl GameSession {
             None
         };
 
+        let rewind_game_number = state.game_number;
+
         GameSession {
             game_code: ps.game_code,
             full_runtime: None,
@@ -935,7 +970,11 @@ impl GameSession {
             ranked: ps.ranked,
             start_events: Vec::new(),
             pending_takeback: None,
+            // Neither ring is persisted: a rollback offer is a live-session
+            // affordance, not durable state.
             takeback_history: VecDeque::new(),
+            turn_rewind_history: VecDeque::new(),
+            rewind_game_number,
         }
     }
 }
@@ -1047,6 +1086,7 @@ impl SessionManager {
 
         bind_interaction_session(&mut state, &game_code);
 
+        let rewind_game_number = state.game_number;
         let session = GameSession {
             game_code: game_code.clone(),
             full_runtime: None,
@@ -1070,6 +1110,8 @@ impl SessionManager {
             start_events: Vec::new(),
             pending_takeback: None,
             takeback_history: VecDeque::new(),
+            turn_rewind_history: VecDeque::new(),
+            rewind_game_number,
         };
 
         self.token_to_game
@@ -1389,8 +1431,18 @@ impl SessionManager {
         let (new_legal_actions, spell_costs, by_object) = engine_legal_actions_full(&session.state);
         let auto_pass = auto_pass_recommended(&session.state, &new_legal_actions);
 
+        // Turn-rewind bookkeeping, deliberately OUTSIDE the `pre_action_state`
+        // block above: an `is_actor_scoped_preference` action records no
+        // takeback snapshot but still goes through `apply` and can auto-advance
+        // into a new turn. The two rings are independent; coupling them would
+        // lose exactly those boundaries. The post-state clone the broadcast
+        // already needs is hoisted here so capture reads a local and cannot be
+        // reordered into a use-after-move.
+        let post_state = session.state.clone();
+        session.observe_transition(&result.events, &post_state);
+
         Ok((
-            session.state.clone(),
+            post_state,
             result.events,
             new_legal_actions,
             result.log_entries,
@@ -1499,8 +1551,12 @@ impl SessionManager {
         let (new_legal_actions, spell_costs, by_object) = engine_legal_actions_full(&session.state);
         let auto_pass = auto_pass_recommended(&session.state, &new_legal_actions);
 
+        // Same capture, same placement rationale, as `handle_action`.
+        let post_state = session.state.clone();
+        session.observe_transition(&applied.result.events, &post_state);
+
         Ok((
-            session.state.clone(),
+            post_state,
             applied.result.events,
             new_legal_actions,
             applied.result.log_entries,
@@ -1539,10 +1595,14 @@ impl SessionManager {
         let (legal_actions, spell_costs, by_object) = engine_legal_actions_full(&session.state);
         let auto_pass = auto_pass_recommended(&session.state, &legal_actions);
         let revision = session.advance_state_revision();
+        // Included rather than skipped: the guard is the event scan itself, so
+        // "can conceding a match start a turn?" never has to be proved.
+        let post_state = session.state.clone();
+        session.observe_transition(&events, &post_state);
         Ok((
             revision,
             (
-                session.state.clone(),
+                post_state,
                 events,
                 legal_actions,
                 Vec::new(),
@@ -2526,7 +2586,7 @@ mod tests {
 
     // ── Takeback tests (GH #1507) ────────────────────────────────────────
 
-    use crate::takeback::TakebackOutcome;
+    use crate::takeback::{RewindOption, RewindTarget, TakebackOutcome, MAX_TAKEBACK_HISTORY};
 
     fn precast_offer_runner() -> (GameRunner, u64) {
         const CHAIN_OF_SMOG: &str = "Target player discards two cards. That player may copy this spell and may choose a new target for that copy.";
@@ -2593,11 +2653,15 @@ mod tests {
         );
 
         let session = mgr.sessions.get_mut(&code).unwrap();
-        let outcome = session.request_takeback(priority_player).unwrap();
+        let outcome = session
+            .request_takeback(priority_player, RewindTarget::LastAction)
+            .unwrap();
         assert_eq!(outcome, TakebackOutcome::Pending);
 
         // A second concurrent request is rejected — only one in flight at a time.
-        assert!(session.request_takeback(other_player).is_err());
+        assert!(session
+            .request_takeback(other_player, RewindTarget::LastAction)
+            .is_err());
 
         let outcome = session.respond_takeback(other_player, true).unwrap();
         assert_eq!(outcome, TakebackOutcome::Approved);
@@ -2628,7 +2692,10 @@ mod tests {
         )
         .expect("mutate away from the offer before requesting takeback");
 
-        assert_eq!(session.request_takeback(P0), Ok(TakebackOutcome::Pending));
+        assert_eq!(
+            session.request_takeback(P0, RewindTarget::LastAction),
+            Ok(TakebackOutcome::Pending)
+        );
         assert_eq!(
             session.respond_takeback(P1, true),
             Ok(TakebackOutcome::Approved)
@@ -2740,7 +2807,9 @@ mod tests {
         // A requests a takeback — must target the checkpoint before A's own
         // action, not the checkpoint before B's (more recent) action.
         let session = mgr.sessions.get_mut(&code).unwrap();
-        let outcome = session.request_takeback(player_a).unwrap();
+        let outcome = session
+            .request_takeback(player_a, RewindTarget::LastAction)
+            .unwrap();
         assert_eq!(outcome, TakebackOutcome::Pending);
         let outcome = session.respond_takeback(player_b, true).unwrap();
         assert_eq!(outcome, TakebackOutcome::Approved);
@@ -2773,7 +2842,9 @@ mod tests {
         let state_after_pass = mgr.sessions.get(&code).unwrap().state.clone();
 
         let session = mgr.sessions.get_mut(&code).unwrap();
-        session.request_takeback(priority_player).unwrap();
+        session
+            .request_takeback(priority_player, RewindTarget::LastAction)
+            .unwrap();
         let outcome = session.respond_takeback(other_player, false).unwrap();
         assert_eq!(outcome, TakebackOutcome::Rejected);
         assert!(session.pending_takeback.is_none());
@@ -2797,7 +2868,9 @@ mod tests {
 
         let _ = mgr.handle_action(&code, &acting_token, GameAction::PassPriority);
         let session = mgr.sessions.get_mut(&code).unwrap();
-        session.request_takeback(priority_player).unwrap();
+        session
+            .request_takeback(priority_player, RewindTarget::LastAction)
+            .unwrap();
 
         assert!(session.cancel_takeback(other_player).is_err());
         assert!(session.pending_takeback.is_some());
@@ -2816,7 +2889,9 @@ mod tests {
             WaitingFor::Priority { player } => *player,
             other => panic!("expected Priority, got {:?}", other),
         };
-        assert!(session.request_takeback(player).is_err());
+        assert!(session
+            .request_takeback(player, RewindTarget::LastAction)
+            .is_err());
     }
 
     /// While a takeback request is pending, new actions are rejected so the
@@ -2836,7 +2911,9 @@ mod tests {
 
         let _ = mgr.handle_action(&code, &acting_token, GameAction::PassPriority);
         let session = mgr.sessions.get_mut(&code).unwrap();
-        session.request_takeback(priority_player).unwrap();
+        session
+            .request_takeback(priority_player, RewindTarget::LastAction)
+            .unwrap();
 
         let result = mgr.handle_action(&code, &other_token, GameAction::PassPriority);
         assert!(
@@ -2866,7 +2943,9 @@ mod tests {
         // Force a known checkpoint to take back to, since the AI may have
         // already acted past mulligans by the time the game starts.
         session.push_takeback_snapshot(PlayerId(0));
-        let outcome = session.request_takeback(PlayerId(0)).unwrap();
+        let outcome = session
+            .request_takeback(PlayerId(0), RewindTarget::LastAction)
+            .unwrap();
         assert_eq!(outcome, TakebackOutcome::Approved);
     }
 
@@ -2895,7 +2974,9 @@ mod tests {
 
         let _ = mgr.handle_action(&code, acting_token, GameAction::PassPriority);
         let session = mgr.sessions.get_mut(&code).unwrap();
-        session.request_takeback(priority_player).unwrap();
+        session
+            .request_takeback(priority_player, RewindTarget::LastAction)
+            .unwrap();
 
         match session.pending_takeback_message() {
             Some(crate::protocol::ServerMessage::TakebackRequested { requester, .. }) => {
@@ -2924,7 +3005,9 @@ mod tests {
 
         let _ = mgr.handle_action(&code, &acting_token, GameAction::PassPriority);
         let session = mgr.sessions.get_mut(&code).unwrap();
-        session.request_takeback(priority_player).unwrap();
+        session
+            .request_takeback(priority_player, RewindTarget::LastAction)
+            .unwrap();
 
         mgr.handle_disconnect(&code, approver);
         let reconnected_state = mgr.handle_reconnect(&code, &approver_token);
@@ -2985,7 +3068,9 @@ mod tests {
         // Player 0 requests a takeback; with two human seats (0 and 1) it
         // stays Pending until player 1 also approves.
         session.push_takeback_snapshot(PlayerId(0));
-        let outcome = session.request_takeback(PlayerId(0)).unwrap();
+        let outcome = session
+            .request_takeback(PlayerId(0), RewindTarget::LastAction)
+            .unwrap();
         assert_eq!(outcome, TakebackOutcome::Pending);
 
         let state_before = session.state.clone();
@@ -2998,6 +3083,596 @@ mod tests {
             session.state.waiting_for, state_before.waiting_for,
             "authoritative state must not move while a takeback vote is pending"
         );
+    }
+
+    // ── Turn-boundary rewind tests ───────────────────────────────────────
+
+    /// `make_deck` is ten cards, so a fixture that drives several turns decks a
+    /// player out and ends the game before it reaches the boundary under test.
+    /// Padding the libraries keeps the *rewind* behaviour the thing being
+    /// measured rather than CR 104.3c.
+    fn padded_game(hosting: HostingMode) -> (SessionManager, String, String, String) {
+        let (mut mgr, code, token0, token1) = setup_two_player_game();
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        session.hosting = hosting;
+        for seat in 0..session.player_count {
+            for _ in 0..80 {
+                engine::game::zones::create_object(
+                    &mut session.state,
+                    engine::types::identifiers::CardId(9000),
+                    PlayerId(seat),
+                    "Library Filler".to_string(),
+                    Zone::Library,
+                );
+            }
+        }
+        (mgr, code, token0, token1)
+    }
+
+    /// The desktop sidecar. `hosting` is a property of the process, so stamping
+    /// it directly is exactly what `SessionManager::restore_session` does.
+    fn single_user_game() -> (SessionManager, String, String, String) {
+        padded_game(HostingMode::SingleUser)
+    }
+
+    fn priority_token(mgr: &SessionManager, code: &str, token0: &str, token1: &str) -> String {
+        match &mgr.sessions[code].state.waiting_for {
+            WaitingFor::Priority { player } if *player == PlayerId(0) => token0.to_string(),
+            WaitingFor::Priority { .. } => token1.to_string(),
+            other => panic!("expected Priority, got {other:?}"),
+        }
+    }
+
+    /// Passes priority (through the real `handle_action` path, so every capture
+    /// site runs) until `turn_number` advances. Returns the new turn number.
+    fn advance_one_turn(mgr: &mut SessionManager, code: &str, token0: &str, token1: &str) -> u32 {
+        let start = mgr.sessions[code].state.turn_number;
+        for _ in 0..400 {
+            if mgr.sessions[code].state.turn_number > start {
+                return mgr.sessions[code].state.turn_number;
+            }
+            if !matches!(
+                mgr.sessions[code].state.waiting_for,
+                WaitingFor::Priority { .. }
+            ) {
+                panic!(
+                    "fixture stalled outside Priority: {:?}",
+                    mgr.sessions[code].state.waiting_for
+                );
+            }
+            let token = priority_token(mgr, code, token0, token1);
+            mgr.handle_action(code, &token, GameAction::PassPriority)
+                .expect("PassPriority through the real transition handler");
+        }
+        panic!("fixture never reached the next turn");
+    }
+
+    /// **R6 — BLOCKER 1.** `turn_number` is *assigned* 1 at each game's start of
+    /// a Bo3 match, not carried across the match, and `ChoosePlayDraw` runs
+    /// through `handle_action` — a capture site. Without retiring both rings at
+    /// the game boundary, `rewind_options()` republishes a *finished game's*
+    /// turn numbers and `TurnStart { n }` resolves by first match to that
+    /// finished game's board.
+    ///
+    /// This fixture SPANS the game boundary deliberately: a single-game version
+    /// of this test goes green with the defect live.
+    #[test]
+    fn a_bo3_game_boundary_retires_both_rewind_rings() {
+        let (mut mgr, code, token0, token1) = single_user_game();
+        advance_one_turn(&mut mgr, &code, &token0, &token1);
+        advance_one_turn(&mut mgr, &code, &token0, &token1);
+
+        let game_one_options = mgr.sessions[&code].rewind_options();
+        assert!(
+            game_one_options.iter().any(|o| o.turn_number == 2),
+            "reach guard: game 1 must actually have published turn 2 — got {game_one_options:?}"
+        );
+        assert!(
+            !mgr.sessions[&code].takeback_history.is_empty(),
+            "reach guard: the action ring must be non-empty before the boundary"
+        );
+
+        // Hand the session the between-games pause the engine itself produces
+        // after game 1 ends, then take the real `ChoosePlayDraw` action through
+        // `handle_action`.
+        let chooser = PlayerId(1);
+        {
+            let session = mgr.sessions.get_mut(&code).unwrap();
+            // The between-games rebuild sources game 2's decks from
+            // `state.deck_pools`, which the production `GameSession::start_game`
+            // path fills via `load_and_hydrate_decks`. This fixture reaches a
+            // started game without a `CardDatabase`, so seed them here.
+            session.state.deck_pools = (0..2)
+                .map(|seat| engine::types::game_state::PlayerDeckPool {
+                    player: PlayerId(seat),
+                    registered_main: std::sync::Arc::new(make_deck().main_deck),
+                    current_main: std::sync::Arc::new(make_deck().main_deck),
+                    ..Default::default()
+                })
+                .collect();
+            session.state.match_phase = engine::types::match_config::MatchPhase::BetweenGames;
+            session.state.match_score = engine::types::match_config::MatchScore {
+                p0_wins: 1,
+                p1_wins: 0,
+                draws: 0,
+            };
+            session.state.game_number = 2;
+            session.state.next_game_chooser = Some(chooser);
+            session.state.sideboard_submitted.clear();
+            session.state.waiting_for = WaitingFor::BetweenGamesChoosePlayDraw {
+                player: chooser,
+                game_number: 2,
+                score: session.state.match_score,
+            };
+        }
+        mgr.handle_action(
+            &code,
+            &token1,
+            GameAction::ChoosePlayDraw { play_first: true },
+        )
+        .expect("the between-games choice is a normal authoritative transition");
+
+        let session = &mgr.sessions[&code];
+        assert_eq!(session.state.game_number, 2, "sanity: game 2 is live");
+        assert!(
+            session.takeback_history.is_empty(),
+            "the action ring belongs to the finished game and must be retired"
+        );
+
+        let options = session.rewind_options();
+        assert_eq!(
+            options,
+            vec![RewindOption {
+                turn_number: 1,
+                active_player: session.state.active_player,
+            }],
+            "game 2 must publish only its own opening boundary — got {options:?}"
+        );
+
+        let mut seen: Vec<u32> = options.iter().map(|o| o.turn_number).collect();
+        let before_dedup = seen.len();
+        seen.dedup();
+        assert_eq!(before_dedup, seen.len(), "no two options may share a turn");
+
+        // The severest consequence, asserted directly: a turn number that
+        // belonged to the FINISHED game must no longer be resolvable at all.
+        let mut mgr = mgr;
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        let refusal = session
+            .request_takeback(PlayerId(0), RewindTarget::TurnStart { turn_number: 2 })
+            .expect_err("game 1's turn 2 must not be reachable from game 2");
+        assert!(
+            refusal.contains("no longer available"),
+            "unexpected refusal: {refusal}"
+        );
+        assert_eq!(
+            session.state.game_number, 2,
+            "the refused request must not have installed a previous game's board"
+        );
+    }
+
+    /// R7. On the sidecar a sole human seat auto-approves, and the restored
+    /// turn stays selectable — `retain(<=)`, not `retain(<)` — which is what
+    /// makes turn rewind repeatable rather than self-consuming.
+    #[test]
+    fn single_user_turn_rewind_auto_approves_and_stays_reselectable() {
+        let (mut mgr, code, token0, token1) = single_user_game();
+        mgr.sessions
+            .get_mut(&code)
+            .unwrap()
+            .ai_seats
+            .insert(PlayerId(1));
+        let turn_two = advance_one_turn(&mut mgr, &code, &token0, &token1);
+        let turn_three = advance_one_turn(&mut mgr, &code, &token0, &token1);
+
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        assert_eq!(
+            session.request_takeback(
+                PlayerId(0),
+                RewindTarget::TurnStart {
+                    turn_number: turn_two
+                }
+            ),
+            Ok(TakebackOutcome::Approved),
+            "a sole human seat has nobody to ask"
+        );
+        assert_eq!(session.state.turn_number, turn_two);
+        assert!(session.pending_takeback.is_none(), "interlock released");
+
+        let options = session.rewind_options();
+        assert!(
+            options.iter().any(|o| o.turn_number == turn_two),
+            "`retain(<=)`: the restored turn must remain selectable — got {options:?}"
+        );
+        assert!(
+            !options.iter().any(|o| o.turn_number == turn_three),
+            "boundaries after the restored one belong to the discarded branch"
+        );
+
+        // Repeatable: the same target again, with no intervening action.
+        assert_eq!(
+            session.request_takeback(
+                PlayerId(0),
+                RewindTarget::TurnStart {
+                    turn_number: turn_two
+                }
+            ),
+            Ok(TakebackOutcome::Approved)
+        );
+        assert_eq!(session.state.turn_number, turn_two);
+    }
+
+    /// R12. An approved rewind prunes only the discarded branch. Fails under
+    /// both `clear()` and `retain(<)`.
+    #[test]
+    fn approved_rewind_prunes_only_the_discarded_branch() {
+        let (mut mgr, code, token0, token1) = single_user_game();
+        mgr.sessions
+            .get_mut(&code)
+            .unwrap()
+            .ai_seats
+            .insert(PlayerId(1));
+        let turn_two = advance_one_turn(&mut mgr, &code, &token0, &token1);
+        let turn_three = advance_one_turn(&mut mgr, &code, &token0, &token1);
+        let turn_four = advance_one_turn(&mut mgr, &code, &token0, &token1);
+
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        assert_eq!(
+            session.request_takeback(
+                PlayerId(0),
+                RewindTarget::TurnStart {
+                    turn_number: turn_three
+                }
+            ),
+            Ok(TakebackOutcome::Approved)
+        );
+        let turns: Vec<u32> = session
+            .rewind_options()
+            .iter()
+            .map(|o| o.turn_number)
+            .collect();
+        assert!(
+            turns.contains(&turn_two),
+            "an earlier ancestor must survive — this is not a disguised clear(): {turns:?}"
+        );
+        assert!(
+            turns.contains(&turn_three),
+            "`retain(<=)` keeps the restored turn: {turns:?}"
+        );
+        assert!(
+            !turns.contains(&turn_four),
+            "the discarded branch must be gone: {turns:?}"
+        );
+    }
+
+    /// **R9 — M5.** A shared server publishes nothing and refuses a turn rewind
+    /// with the EXPLICIT gate message, not a vacuous empty-ring miss. The
+    /// over-scoping guard is the third assertion: `LastAction` on the same
+    /// session must still succeed, proving the gate scoped only `TurnStart` and
+    /// did not regress shipped GH #1507 takeback.
+    #[test]
+    fn an_online_session_publishes_no_rewind_targets_and_refuses_a_turn_start() {
+        let (mut mgr, code, token0, token1) = padded_game(HostingMode::Shared);
+        mgr.sessions
+            .get_mut(&code)
+            .unwrap()
+            .ai_seats
+            .insert(PlayerId(1));
+        let turn_two = advance_one_turn(&mut mgr, &code, &token0, &token1);
+
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        assert_eq!(session.hosting, HostingMode::Shared, "sanity");
+        assert!(session.rewind_options().is_empty());
+        assert!(
+            session.turn_rewind_history.is_empty(),
+            "capture is gated too"
+        );
+
+        let turn_before = session.state.turn_number;
+        let refusal = session
+            .request_takeback(
+                PlayerId(0),
+                RewindTarget::TurnStart {
+                    turn_number: turn_two,
+                },
+            )
+            .expect_err("a shared host must refuse turn rewind");
+        assert!(
+            refusal.contains("not available in this game"),
+            "must be the explicit policy refusal, not the empty-ring miss: {refusal}"
+        );
+        assert_eq!(session.state.turn_number, turn_before, "state unchanged");
+
+        // Over-scoping guard.
+        assert_eq!(
+            session.request_takeback(PlayerId(0), RewindTarget::LastAction),
+            Ok(TakebackOutcome::Approved),
+            "the shipped action-granular takeback must be untouched"
+        );
+
+        // Paired positive: the identical fixture on a sidecar DOES publish.
+        let (mut mgr, code, token0, token1) = single_user_game();
+        advance_one_turn(&mut mgr, &code, &token0, &token1);
+        assert!(!mgr.sessions[&code].rewind_options().is_empty());
+    }
+
+    /// **R10 — G3/M6.** Undo is repeatable with nothing in between. At BASE_SHA
+    /// `try_resolve_pending_takeback` did `clear()`, so the second request
+    /// returned `Err`.
+    #[test]
+    fn undo_is_repeatable_without_an_intervening_action() {
+        let (mut mgr, code, token0, token1) = padded_game(HostingMode::Shared);
+        mgr.sessions
+            .get_mut(&code)
+            .unwrap()
+            .ai_seats
+            .insert(PlayerId(1));
+
+        for _ in 0..3 {
+            let token = priority_token(&mgr, &code, &token0, &token1);
+            if token != token0 {
+                // Only the human seat's own actions are takeback-able.
+                mgr.handle_action(&code, &token, GameAction::PassPriority)
+                    .expect("advance to the human seat's priority");
+                continue;
+            }
+            mgr.handle_action(&code, &token0, GameAction::PassPriority)
+                .expect("human action");
+        }
+
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        let depth_before = session.takeback_history.len();
+        assert!(
+            depth_before >= 2,
+            "reach guard: need at least two ancestors"
+        );
+
+        assert_eq!(
+            session.request_takeback(PlayerId(0), RewindTarget::LastAction),
+            Ok(TakebackOutcome::Approved)
+        );
+        assert_eq!(
+            session.request_takeback(PlayerId(0), RewindTarget::LastAction),
+            Ok(TakebackOutcome::Approved),
+            "the second consecutive undo is what fails at BASE_SHA"
+        );
+
+        // Hostile: once the ring is exhausted, further requests must refuse —
+        // `truncate` bounds correctly rather than growing.
+        for _ in 0..depth_before + 2 {
+            if session
+                .request_takeback(PlayerId(0), RewindTarget::LastAction)
+                .is_err()
+            {
+                return;
+            }
+        }
+        panic!("an exhausted takeback ring must eventually refuse");
+    }
+
+    /// **R11 — M6.** `truncate` must not convert a voted rollback into a
+    /// unilateral one: at a multi-human table every step of a repeated
+    /// walk-back is still its own unanimity vote.
+    #[test]
+    fn repeated_walk_back_still_requires_unanimity_at_each_step() {
+        let (mut mgr, code, token0, token1) = padded_game(HostingMode::Shared);
+        for _ in 0..4 {
+            let token = priority_token(&mgr, &code, &token0, &token1);
+            mgr.handle_action(&code, &token, GameAction::PassPriority)
+                .expect("drive a few actions from both seats");
+        }
+
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        assert_eq!(
+            session.request_takeback(PlayerId(0), RewindTarget::LastAction),
+            Ok(TakebackOutcome::Pending),
+            "two humans: the first step is a vote"
+        );
+        assert_eq!(
+            session.respond_takeback(PlayerId(1), true),
+            Ok(TakebackOutcome::Approved)
+        );
+
+        // Immediately again — `truncate` left ancestors reachable, but that must
+        // NOT make the second step unilateral.
+        assert_eq!(
+            session.request_takeback(PlayerId(0), RewindTarget::LastAction),
+            Ok(TakebackOutcome::Pending),
+            "the second step is still a vote, not an auto-approval"
+        );
+        let state_before = session.state.clone();
+        assert_eq!(
+            session.respond_takeback(PlayerId(1), false),
+            Ok(TakebackOutcome::Rejected)
+        );
+        assert_eq!(
+            session.state.waiting_for, state_before.waiting_for,
+            "a decline must leave the authoritative state untouched"
+        );
+    }
+
+    /// **R8.** Turn rewind is a mechanism, not a privilege: on a sidecar with
+    /// two human seats it still requires unanimity, and a decline changes
+    /// nothing — including the ring.
+    #[test]
+    fn turn_rewind_requires_unanimity_at_a_multi_human_table() {
+        let (mut mgr, code, token0, token1) = single_user_game();
+        let turn_two = advance_one_turn(&mut mgr, &code, &token0, &token1);
+        advance_one_turn(&mut mgr, &code, &token0, &token1);
+
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        let turn_before = session.state.turn_number;
+        let objects_before = session.state.objects.len();
+        let options_before = session.rewind_options();
+
+        assert_eq!(
+            session.request_takeback(
+                PlayerId(0),
+                RewindTarget::TurnStart {
+                    turn_number: turn_two
+                }
+            ),
+            Ok(TakebackOutcome::Pending)
+        );
+        assert_eq!(
+            session.state.turn_number, turn_before,
+            "state must not move"
+        );
+        assert_eq!(session.state.objects.len(), objects_before);
+
+        // Multi-authority hostile: a decline must not prune.
+        assert_eq!(
+            session.respond_takeback(PlayerId(1), false),
+            Ok(TakebackOutcome::Rejected)
+        );
+        assert_eq!(session.state.turn_number, turn_before);
+        assert_eq!(
+            session.rewind_options(),
+            options_before,
+            "a declined request must leave the ring intact"
+        );
+
+        // Paired positive: approval does roll back.
+        assert_eq!(
+            session.request_takeback(
+                PlayerId(0),
+                RewindTarget::TurnStart {
+                    turn_number: turn_two
+                }
+            ),
+            Ok(TakebackOutcome::Pending)
+        );
+        assert_eq!(
+            session.respond_takeback(PlayerId(1), true),
+            Ok(TakebackOutcome::Approved)
+        );
+        assert_eq!(session.state.turn_number, turn_two);
+    }
+
+    /// **R4 — G2.** The turn ring reaches a boundary the action ring
+    /// structurally cannot: every wire `PassPriority` burns one of
+    /// `MAX_TAKEBACK_HISTORY`'s twelve slots, so a full turn never fits.
+    #[test]
+    fn turn_rewind_reaches_a_boundary_the_action_ring_cannot() {
+        let (mut mgr, code, token0, token1) = single_user_game();
+        mgr.sessions
+            .get_mut(&code)
+            .unwrap()
+            .ai_seats
+            .insert(PlayerId(1));
+        let target_turn = advance_one_turn(&mut mgr, &code, &token0, &token1);
+        // Keep playing until the twelve-slot action ring has scrolled entirely
+        // past the target boundary. That is the whole point of the second ring:
+        // every wire `PassPriority` burns a slot, so the action ring cannot
+        // reach back across a turn (CR 500.1).
+        let mut turns_played = 0;
+        while turns_played < 8 {
+            let saturated = {
+                let s = &mgr.sessions[&code];
+                s.takeback_history.len() == MAX_TAKEBACK_HISTORY
+                    && s.takeback_history
+                        .iter()
+                        .all(|(_, st)| st.turn_number > target_turn)
+            };
+            if saturated {
+                break;
+            }
+            advance_one_turn(&mut mgr, &code, &token0, &token1);
+            turns_played += 1;
+        }
+
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        // Reach guard: the action ring is full AND can no longer see the target.
+        assert_eq!(session.takeback_history.len(), MAX_TAKEBACK_HISTORY);
+        assert!(
+            session
+                .takeback_history
+                .iter()
+                .all(|(_, s)| s.turn_number > target_turn),
+            "reach guard: no action-ring entry may still sit in turn {target_turn}"
+        );
+        let turn_two = target_turn;
+
+        assert_eq!(
+            session.request_takeback(
+                PlayerId(0),
+                RewindTarget::TurnStart {
+                    turn_number: turn_two
+                }
+            ),
+            Ok(TakebackOutcome::Approved)
+        );
+        assert_eq!(session.state.turn_number, turn_two);
+
+        // Hostile: a turn that never existed must refuse and change nothing.
+        let objects_before = session.state.objects.len();
+        assert!(session
+            .request_takeback(PlayerId(0), RewindTarget::TurnStart { turn_number: 9999 })
+            .is_err());
+        assert_eq!(session.state.turn_number, turn_two);
+        assert_eq!(session.state.objects.len(), objects_before);
+    }
+
+    /// **R13 — M7/G6.** The takeback path was the only state-install path that
+    /// did not rebuild `ai_session`. `rekey_after_trusted_restore` rewrites
+    /// object identity, so every id-keyed cache from the discarded branch is
+    /// stale by construction — a rebuild, not a selective invalidation.
+    #[test]
+    fn an_approved_rollback_rebuilds_the_ai_session() {
+        let (mut mgr, code, token0, token1) = single_user_game();
+        mgr.sessions
+            .get_mut(&code)
+            .unwrap()
+            .ai_seats
+            .insert(PlayerId(1));
+        advance_one_turn(&mut mgr, &code, &token0, &token1);
+        let turn_two = mgr.sessions[&code].state.turn_number;
+
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        session.ai_session = Some(AiSession::arc_from_game(&session.state));
+        let before = session
+            .ai_session
+            .clone()
+            .expect("reach guard: the fixture installed a session");
+
+        assert_eq!(
+            session.request_takeback(
+                PlayerId(0),
+                RewindTarget::TurnStart {
+                    turn_number: turn_two
+                }
+            ),
+            Ok(TakebackOutcome::Approved)
+        );
+        let after = session
+            .ai_session
+            .clone()
+            .expect("an AI session must still be present after the rollback");
+        assert!(
+            !Arc::ptr_eq(&before, &after),
+            "the rolled-back session must be a fresh build, not the pre-rollback Arc"
+        );
+
+        // Paired negative: a session with no AI must not gain one.
+        let (mut mgr, code, token0, token1) = single_user_game();
+        advance_one_turn(&mut mgr, &code, &token0, &token1);
+        let turn_two = mgr.sessions[&code].state.turn_number;
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        session.ai_session = None;
+        assert_eq!(
+            session.request_takeback(
+                PlayerId(0),
+                RewindTarget::TurnStart {
+                    turn_number: turn_two
+                }
+            ),
+            Ok(TakebackOutcome::Pending)
+        );
+        assert_eq!(
+            session.respond_takeback(PlayerId(1), true),
+            Ok(TakebackOutcome::Approved)
+        );
+        assert!(session.ai_session.is_none(), "`None` must stay `None`");
     }
 
     // ── Sandbox capability tests ─────────────────────────────────────────
@@ -3722,6 +4397,8 @@ mod tests {
             start_events: Vec::new(),
             pending_takeback: None,
             takeback_history: VecDeque::new(),
+            turn_rewind_history: VecDeque::new(),
+            rewind_game_number: 1,
         };
 
         let game_started_before = session.game_started;
@@ -4607,6 +5284,7 @@ mod tests {
             requested_by: acting,
             target_state,
             approvals: HashSet::new(),
+            history_truncate_len: 0,
         });
 
         let before_slots = mgr.sessions[&code].state.active_interaction_slots.clone();

--- a/crates/server-core/src/takeback.rs
+++ b/crates/server-core/src/takeback.rs
@@ -12,23 +12,143 @@
 //! included) has approved it. Any single human decline cancels the request
 //! and the authoritative state is left untouched.
 //!
+//! The same machine is parameterized by [`RewindTarget`] rather than
+//! duplicated per granularity: `LastAction` is the original GH #1507 undo, and
+//! `TurnStart` reaches a previous turn boundary — which the action-granular
+//! ring structurally cannot, since every wire `PassPriority` burns one of its
+//! twelve slots. Turn boundaries are captured from each transition's own
+//! post-state into a second ring, and offered only where
+//! [`offers_turn_rewind`] says so.
+//!
 //! This is intentionally a session/room-level concern, not an engine rule —
 //! there is no Comprehensive Rules concept of "undo." The engine is never
 //! told why it was handed an older `GameState`; it just continues from
 //! whatever state it's given, exactly as it does on reconnect/restore.
 
-use std::collections::HashSet;
+use std::collections::{HashSet, VecDeque};
 
+use engine::types::events::GameEvent;
 use engine::types::game_state::GameState;
 use engine::types::player::PlayerId;
+use phase_ai::session::AiSession;
+use serde::{Deserialize, Serialize};
 
-use crate::session::GameSession;
+use crate::session::{GameSession, HostingMode};
 
 /// How many prior authoritative snapshots a session retains for takeback
 /// purposes. Bounded so a long game session can't accumulate unbounded
 /// memory — a takeback can only reach back to the most recent action, so
 /// anything beyond a handful of entries is never reachable anyway.
 pub const MAX_TAKEBACK_HISTORY: usize = 12;
+
+/// How many turn-boundary snapshots a session retains. Deliberately the same
+/// depth as the browser-local analogue (`client/src/constants/game.ts`'s
+/// `MAX_UNDO_HISTORY = 5`), so desktop solo-vs-AI offers the same reach the
+/// browser sandbox already does. Small because these are whole `GameState`
+/// clones and — unlike `MAX_TAKEBACK_HISTORY` — only ever populated on a
+/// `HostingMode::SingleUser` sidecar (see [`offers_turn_rewind`]).
+pub const MAX_TURN_REWIND_HISTORY: usize = 5;
+
+/// How far back a rollback request reaches.
+///
+/// Parameterizes the one rollback machine rather than growing a sibling wire
+/// message per granularity: the approval state machine, the pending-request
+/// interlock, `rekey_after_trusted_restore`, and the reconnect replay are all
+/// shared. `LastAction` is the pre-existing GH #1507 behaviour and is the
+/// `Default` so an absent wire payload from a pre-rewind client normalizes to
+/// exactly what that client meant.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+#[serde(tag = "kind", rename_all = "snake_case")]
+pub enum RewindTarget {
+    /// Roll back to the snapshot taken immediately before the requester's own
+    /// most recent state-mutating action.
+    #[default]
+    LastAction,
+    /// Roll back to the start of the numbered turn *of the current game*.
+    /// Turn numbers are only unique within a game (see
+    /// [`GameSession::observe_transition`]), which is why the rings are
+    /// cleared at a match's game boundary rather than keyed by game number.
+    TurnStart { turn_number: u32 },
+}
+
+/// One turn boundary a client may ask to roll back to, as published by the
+/// server. Both fields are read from the stored snapshot's *own* state, never
+/// recomputed at publication time, so the label a player clicks is exactly the
+/// state they get.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RewindOption {
+    pub turn_number: u32,
+    pub active_player: PlayerId,
+}
+
+/// Whether this deployment offers turn-granular rewind.
+///
+/// A **policy**, not a capability of the mechanism: the machinery below is
+/// mode-agnostic and `LastAction` is deliberately *not* scoped by it. Nobody
+/// asked for a table-wide vote at turn scale, and the trigger surface
+/// (`DebugPanel`) is not gated by `showSandboxTools` — it is reachable in every
+/// mode via the keyboard shortcut. Gating capture as well as publication means
+/// a shared server retains zero turn snapshots rather than retaining snapshots
+/// it will never offer.
+pub fn offers_turn_rewind(hosting: HostingMode) -> bool {
+    hosting == HostingMode::SingleUser
+}
+
+/// Records `state` as a turn-boundary rewind point iff the transition that
+/// produced it *came to rest in* the turn its own events announced.
+///
+/// A free function over the ring rather than a `&mut self` method, so the
+/// capture rule can be exercised directly against a `VecDeque` and a synthetic
+/// event batch — the rule's hostile cases (a batch that both starts and ends a
+/// turn, a batch carrying two boundaries) need no session at all. Callers go
+/// through [`GameSession::observe_transition`], which is the `&mut self` wrapper
+/// that also owns the game-boundary retirement; nothing calls this directly in
+/// production.
+///
+/// The `started != state.turn_number` guard is an honesty guard, not an
+/// optimization: a batch that both started *and* ended a turn leaves no state
+/// that could be truthfully labelled with either turn, so that boundary is not
+/// offered rather than mislabelled.
+///
+/// **Uniqueness.** No two retained entries share a `turn_number`, *within a
+/// game*: `state.turn_number` is assigned 1 at a game start
+/// (`engine::game::engine`'s two `start_game_*` helpers) and thereafter only
+/// incremented, unconditionally and once per turn start
+/// (`engine/src/game/turns.rs`, CR 500.7 — including extra turns; a *skipped*
+/// turn increments without emitting `TurnStarted`). `TurnStarted` has three
+/// production emission sites — `turns.rs` plus those two `start_game_*`
+/// helpers, which both emit `TurnStarted { turn_number: 1 }` — so uniqueness is
+/// a within-game property only. Crossing into another game of a Bo3 match is
+/// handled by [`GameSession::observe_transition`], which clears both rings, and
+/// the `debug_assert!` below is what fails loudly if that ever stops happening.
+pub fn record_turn_rewind_point(
+    ring: &mut VecDeque<GameState>,
+    hosting: HostingMode,
+    events: &[GameEvent],
+    state: &GameState,
+) {
+    if !offers_turn_rewind(hosting) {
+        return;
+    }
+    let Some(started) = events.iter().rev().find_map(|event| match event {
+        GameEvent::TurnStarted { turn_number, .. } => Some(*turn_number),
+        _ => None,
+    }) else {
+        return;
+    };
+    if started != state.turn_number {
+        return;
+    }
+    debug_assert!(
+        ring.back()
+            .is_none_or(|s| s.turn_number < state.turn_number),
+        "turn rewind ring must stay strictly increasing within a game"
+    );
+    if ring.len() >= MAX_TURN_REWIND_HISTORY {
+        ring.pop_front();
+    }
+    ring.push_back(state.clone());
+}
 
 /// A takeback request awaiting unanimous human approval.
 #[derive(Debug, Clone)]
@@ -43,6 +163,12 @@ pub struct PendingTakeback {
     /// Human seats that have approved so far. The request resolves the
     /// instant this set contains every human seat in the session.
     pub approvals: HashSet<PlayerId>,
+    /// How much of `takeback_history` remains a genuine ancestor chain of
+    /// `target_state` once the rollback lands. Computed at request time,
+    /// which is sound because every path that could mutate the history
+    /// refuses while a request is pending (`handle_action`,
+    /// `handle_interaction`, `handle_match_concede`) and `run_ai` is a no-op.
+    pub history_truncate_len: usize,
 }
 
 /// Outcome of requesting or responding to a takeback.
@@ -80,6 +206,55 @@ impl GameSession {
         self.takeback_history.push_back((actor, state));
     }
 
+    /// The single per-transition rewind bookkeeping authority. Every
+    /// authoritative state transition calls this with **its own** event batch
+    /// and post-state — never with `self.state`, which several call sites have
+    /// already advanced past the transition being recorded.
+    ///
+    /// Two responsibilities, in this order because the second depends on the
+    /// first: retire both rings at a match's game boundary, then record the
+    /// turn boundary this transition came to rest in (if any).
+    ///
+    /// **Why the game-boundary clear.** `turn_number` is *assigned* 1 at each
+    /// game's start rather than carried across a Bo3 match (CR 100.6a: a
+    /// two-player match is a series of *games*), and the
+    /// between-games `ChoosePlayDraw` action rebuilds the state through
+    /// `handle_action` — a capture site — with `TurnStarted { turn_number: 1 }`
+    /// in its batch. Without this, `turn_number` is not monotone across the
+    /// session, and a `TurnStart { n }` request would resolve by first match to
+    /// a *finished game's* turn n and install that board into the live game.
+    /// Both rings are retired, not just the turn ring: a rollback into a
+    /// previous game of the match is not a coherent offer at any granularity,
+    /// and clearing both is what restores the within-game monotonicity that
+    /// `partition_point`, `retain`, and `record_turn_rewind_point`'s
+    /// `debug_assert!` all rely on. (`takeback_history` was not previously
+    /// cleared on a game transition — it is cleared only after an approved
+    /// rollback — so this is a new, deliberate retirement point for it.)
+    pub fn observe_transition(&mut self, events: &[GameEvent], state: &GameState) {
+        if state.game_number != self.rewind_game_number {
+            self.rewind_game_number = state.game_number;
+            self.takeback_history.clear();
+            self.turn_rewind_history.clear();
+        }
+        record_turn_rewind_point(&mut self.turn_rewind_history, self.hosting, events, state);
+    }
+
+    /// The turn boundaries this session currently offers, oldest first. Each
+    /// option is labelled from its snapshot's *own* fields, so the label and
+    /// the state a player gets cannot disagree.
+    pub fn rewind_options(&self) -> Vec<RewindOption> {
+        if !offers_turn_rewind(self.hosting) {
+            return Vec::new();
+        }
+        self.turn_rewind_history
+            .iter()
+            .map(|state| RewindOption {
+                turn_number: state.turn_number,
+                active_player: state.active_player,
+            })
+            .collect()
+    }
+
     /// Human (non-AI) seats in this session, in seat order. AI seats never
     /// request, approve, or block a takeback — they have no UI to misclick.
     pub fn human_seats(&self) -> Vec<PlayerId> {
@@ -100,11 +275,34 @@ impl GameSession {
         let pending = self.pending_takeback.take().expect("checked above");
         self.state = pending.target_state;
         engine::game::rekey_after_trusted_restore(&mut self.state);
-        // The rolled-back state is the new baseline; snapshots from the
-        // branch we just discarded no longer correspond to reachable
-        // history, and taking another takeback back through them would
-        // resurrect actions the table just agreed to undo.
-        self.takeback_history.clear();
+        // The rolled-back state is the new baseline. Snapshots *after* the
+        // restored one belong to the branch the table just discarded, and
+        // taking another takeback back through them would resurrect actions
+        // the table just agreed to undo. Snapshots *before* it are still
+        // genuine ancestors of it, and a takeback that targets one of those
+        // goes strictly further back — discarding strictly more, resurrecting
+        // nothing. `history_truncate_len`, computed at request time, is
+        // exactly that ancestor prefix; `clear()` was the conservative
+        // over-approximation of this same reasoning, and truncating is what
+        // makes undo repeatable rather than one-shot.
+        self.takeback_history.truncate(pending.history_truncate_len);
+        // `<=`, not `<`: a `TurnStart { n }` rewind targets the turn-n
+        // snapshot itself, so keeping turn n selectable is what makes turn
+        // rewind idempotent and repeatable rather than consuming its own
+        // target.
+        let restored_turn = self.state.turn_number;
+        self.turn_rewind_history
+            .retain(|snapshot| snapshot.turn_number <= restored_turn);
+        // Every other path that installs a `GameState` wholesale rebuilds the
+        // AI session (`GameSession::start_game`, `from_persisted`); this one
+        // must too, now that an approved rollback can be followed immediately
+        // by `run_ai`. Rebuild rather than invalidate selectively:
+        // `rekey_after_trusted_restore` rewrites object identity, so the
+        // cached routes and prompts keyed on the discarded branch's ids are
+        // stale by construction, not merely cold.
+        if self.ai_session.is_some() {
+            self.ai_session = Some(AiSession::arc_from_game(&self.state));
+        }
         Some(TakebackOutcome::Approved)
     }
 
@@ -118,20 +316,57 @@ impl GameSession {
     /// own action untouched. Auto-resolves to `Approved` immediately when
     /// the requester is the only human at the table (e.g. solo vs. AI)
     /// since there is nobody else to ask.
-    pub fn request_takeback(&mut self, player: PlayerId) -> Result<TakebackOutcome, String> {
+    ///
+    /// `target` selects the granularity. `RewindTarget::TurnStart` reaches a
+    /// boundary the action-granular ring structurally cannot: every wire
+    /// `PassPriority` burns a `MAX_TAKEBACK_HISTORY` slot, so a whole turn
+    /// (CR 500.1) never fits inside twelve entries.
+    pub fn request_takeback(
+        &mut self,
+        player: PlayerId,
+        target: RewindTarget,
+    ) -> Result<TakebackOutcome, String> {
         if self.pending_takeback.is_some() {
             return Err("A takeback request is already pending for this game".to_string());
         }
         if !self.human_seats().contains(&player) {
             return Err("Only human players may request a takeback".to_string());
         }
-        let target_state = self
-            .takeback_history
-            .iter()
-            .rev()
-            .find(|(actor, _)| *actor == player)
-            .map(|(_, state)| state.clone())
-            .ok_or_else(|| "There is no previous action of yours to take back".to_string())?;
+        let (target_state, history_truncate_len) = match target {
+            RewindTarget::LastAction => {
+                let index = self
+                    .takeback_history
+                    .iter()
+                    .rposition(|(actor, _)| *actor == player)
+                    .ok_or_else(|| {
+                        "There is no previous action of yours to take back".to_string()
+                    })?;
+                (self.takeback_history[index].1.clone(), index)
+            }
+            RewindTarget::TurnStart { turn_number } => {
+                // Refuse explicitly rather than letting an always-empty ring
+                // produce a "no longer available" miss. This is a system
+                // boundary, and a refusal that depends on a collection being
+                // empty is untestably vacuous.
+                if !offers_turn_rewind(self.hosting) {
+                    return Err("Turn rewind is not available in this game".to_string());
+                }
+                let target_state = self
+                    .turn_rewind_history
+                    .iter()
+                    .find(|snapshot| snapshot.turn_number == turn_number)
+                    .ok_or_else(|| "That turn is no longer available to rewind to".to_string())?
+                    .clone();
+                // An exact prefix predicate: within a game the action ring is
+                // chronological and `turn_number` is monotone, so every entry
+                // recorded before turn `n` began is an ancestor of turn `n`'s
+                // opening state, and every entry from turn `n` onwards is not.
+                let history_truncate_len = self
+                    .takeback_history
+                    .partition_point(|(_, state)| state.turn_number < turn_number);
+                (target_state, history_truncate_len)
+            }
+        };
 
         let mut approvals = HashSet::new();
         approvals.insert(player);
@@ -139,6 +374,7 @@ impl GameSession {
             requested_by: player,
             target_state,
             approvals,
+            history_truncate_len,
         });
 
         Ok(self
@@ -202,5 +438,138 @@ impl GameSession {
             requester: pending.requested_by,
             requester_name,
         })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A state that has come to rest in `turn_number`, with `active_player`
+    /// distinct from seat 0 so a label mix-up is visible.
+    fn resting_at(turn_number: u32) -> GameState {
+        let mut state = GameState::new_two_player(42);
+        state.turn_number = turn_number;
+        state.active_player = PlayerId(1);
+        state
+    }
+
+    fn turn_started(turn_number: u32) -> GameEvent {
+        GameEvent::TurnStarted {
+            player_id: PlayerId(1),
+            turn_number,
+        }
+    }
+
+    /// R1. The capture rule is driven by the transition's own post-state: a
+    /// batch that announces turn 4 and comes to rest in turn 4 is recorded, and
+    /// the entry is labelled from the stored state's own fields.
+    #[test]
+    fn record_turn_rewind_point_stores_the_boundary_it_came_to_rest_in() {
+        let mut ring = VecDeque::new();
+        record_turn_rewind_point(
+            &mut ring,
+            HostingMode::SingleUser,
+            &[turn_started(4)],
+            &resting_at(4),
+        );
+        assert_eq!(ring.len(), 1);
+        assert_eq!(ring[0].turn_number, 4);
+        assert_eq!(ring[0].active_player, PlayerId(1));
+    }
+
+    /// R1 hostile A. A batch that both *started* and *ended* a turn leaves no
+    /// state that could be labelled truthfully, so the boundary is refused
+    /// rather than mislabelled. Without the `started != state.turn_number`
+    /// guard this stores a snapshot of turn 5 under the label "turn 4".
+    #[test]
+    fn a_batch_that_started_and_ended_a_turn_records_nothing() {
+        let mut ring = VecDeque::new();
+        record_turn_rewind_point(
+            &mut ring,
+            HostingMode::SingleUser,
+            &[turn_started(4)],
+            &resting_at(5),
+        );
+        assert!(ring.is_empty());
+    }
+
+    /// R1 hostile B. Two boundaries in one batch must produce exactly one
+    /// entry, taken from the LAST announcement — the one the state rests in.
+    #[test]
+    fn a_batch_carrying_two_boundaries_records_only_the_one_it_rests_in() {
+        let mut ring = VecDeque::new();
+        record_turn_rewind_point(
+            &mut ring,
+            HostingMode::SingleUser,
+            &[turn_started(4), turn_started(5)],
+            &resting_at(5),
+        );
+        assert_eq!(
+            ring.len(),
+            1,
+            "no duplicate entry for the passed-through turn"
+        );
+        assert_eq!(ring[0].turn_number, 5);
+    }
+
+    /// R1 hostile C. A batch with no boundary at all leaves the ring alone.
+    #[test]
+    fn a_batch_with_no_turn_boundary_records_nothing() {
+        let mut ring = VecDeque::new();
+        record_turn_rewind_point(
+            &mut ring,
+            HostingMode::SingleUser,
+            &[GameEvent::PriorityPassed {
+                player_id: PlayerId(0),
+            }],
+            &resting_at(4),
+        );
+        assert!(ring.is_empty());
+    }
+
+    /// R2. Capture — not just publication — is scoped to the sidecar, so a
+    /// shared server retains zero turn snapshots. R1's positive case is the
+    /// reach guard: the identical fixture DOES store under `SingleUser`, so
+    /// this assertion is not vacuous.
+    #[test]
+    fn turn_rewind_capture_is_silent_on_a_shared_host() {
+        let mut ring = VecDeque::new();
+        record_turn_rewind_point(
+            &mut ring,
+            HostingMode::Shared,
+            &[turn_started(4)],
+            &resting_at(4),
+        );
+        assert!(ring.is_empty());
+        assert!(!offers_turn_rewind(HostingMode::Shared));
+        assert!(offers_turn_rewind(HostingMode::SingleUser));
+    }
+
+    /// R3. The ring is bounded and drops the OLDEST entry. Asserting both ends
+    /// is what fails a `pop_back` inversion.
+    #[test]
+    fn turn_rewind_ring_is_bounded_and_drops_oldest() {
+        let mut ring = VecDeque::new();
+        let overflow = MAX_TURN_REWIND_HISTORY as u32 + 2;
+        for turn in 1..=overflow {
+            record_turn_rewind_point(
+                &mut ring,
+                HostingMode::SingleUser,
+                &[turn_started(turn)],
+                &resting_at(turn),
+            );
+        }
+        assert_eq!(ring.len(), MAX_TURN_REWIND_HISTORY);
+        assert_eq!(
+            ring.front().expect("bounded ring is non-empty").turn_number,
+            3,
+            "the two oldest turns must have been dropped from the FRONT"
+        );
+        assert_eq!(
+            ring.back().expect("bounded ring is non-empty").turn_number,
+            overflow,
+            "the newest turn must be at the BACK"
+        );
     }
 }


### PR DESCRIPTION
Desktop solo-vs-AI (`native-ai`) could take back its last action but could not go back to a
turn boundary, and a second undo with no intervening action failed outright. Sandbox tools and
single-action undo already worked there (#6675); this adds the two affordances that did not.

## Design

`ClientMessage::RequestTakeback` is parameterized with a typed `RewindTarget`
(`LastAction` | `TurnStart { turn_number }`) rather than gaining a sibling message, and
`GameSession` gains a second, turn-granular snapshot ring. The action ring provably cannot
reach a turn boundary: `PassPriority` is not an actor-scoped preference, so every wire pass
burns one of the 12 slots, and CR 500.1 makes a turn five phases.

- **Capture** is driven by each transition's own post-state, gated on the last `TurnStarted`
  in the batch matching that state's own `turn_number`. One authority serves all four
  transition sites, including `run_ai` — so a turn played entirely by the AI still records a
  boundary.
- **`turn_number` is only monotone within a game.** `TurnStarted { turn_number: 1 }` is also
  emitted from two `engine.rs` sites reachable via the Bo3 between-games play/draw choice.
  Both rings are therefore retired when `game_number` changes; without it a `TurnStart{n}`
  rewind could install a finished game's board into a live one.
- **Undo is repeatable.** Approval truncates `takeback_history` to the target's ancestors
  instead of clearing it. A later takeback through an ancestor goes strictly further back, so
  it cannot resurrect an undone action. Unanimity stays per-request.
- **The approved path runs `run_ai` and rebuilds `ai_session`.** A rollback installs a new
  authoritative state exactly as `start_game` and `from_persisted` do, and both of those
  rebuild; `rekey_after_trusted_restore` rewrites object identity, so the AI's cached tokens
  are stale by construction.
- **Turn rewind is scoped server-side to `HostingMode::SingleUser`** — capture, publication
  and requests. `LastAction` is unscoped and unchanged for every mode. `DebugPanel` is not
  gated by `showSandboxTools`, so publishing targets to online tables would have shipped a
  table-wide rollback vote nobody asked for.

## Wire compatibility

`RequestTakeback` becomes a **newtype** variant carrying `Option<RewindTarget>`. `ClientMessage`
is adjacently tagged, and serde only synthesizes a missing-content arm for unit and newtype
variants — a struct variant would reject its own client's payload-less frame with
``missing field `data` ``. The client omits `data` for last-action undo, keeping that frame
byte-identical. `PROTOCOL_VERSION` stays 23: `MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`, so
bumping would hard-reject every deployed client.

## Client

`ServerRewindCapability` follows the existing `MatchConcedeCapability` idiom, so only
`WebSocketAdapter` declares it and the other five adapters are untouched. Solo tables label the
affordance "Undo Last Action" rather than "Request Takeback" — there is nobody to request from.

## Behaviour changes to shipped multiplayer

Two, both deliberate:
- An online table can now walk back more than one action (`truncate` replacing `clear`).
  Unanimity is preserved per step.
- Both rollback rings are retired at a Bo3 game boundary. This also fixes a latent pre-existing
  bug where a game-2 `LastAction` request could resolve into game 1.

## Verification

Revert probes were run on every fix rather than trusting a green suite: removing the
game-boundary clear turns the Bo3 test red on the `debug_assert!`; `truncate → clear` turns the
repeatable-undo test red; `retain(<=) → retain(<)` turns two tests red; and deleting
`observe_transition` from `run_ai` turns **only** the new AI-boundary test red — every other
rewind test stayed green, which is what proved that site had zero coverage.

`cargo test -p server-core` 314 pass · `-p phase-server` 123 pass · clippy `-D warnings` clean ·
type-check, lint and the 7-locale i18n parity gate clean.

## Known gap

The two `session.run_ai()` calls on the approved path in `main.rs` are covered at the
session level (the new test proves `run_ai` after an approved rollback is non-empty and
advances) but not end-to-end through `handle_client_message`. A harness exists
(`spawn_full_mode_server`, used by `mod game_submission_tests`); an end-to-end
`RequestTakeback` test is feasible there but is new construction rather than a surgical fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added server-authoritative takebacks with options to undo the last action or rewind to the start of a turn.
  * Multiplayer sessions now display available rewind points and preserve them across updates and reconnects.
  * Solo games use “Undo Last Action,” while online games retain “Request Takeback.”
* **Localization**
  * Added translations for the solo undo action in supported languages.
* **Tests**
  * Expanded coverage for rewind behavior, permissions, state updates, reconnects, and menu labeling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->