### PR TITLE
fix(engine): scope the tracked-set cast filter context to the published set

### DIFF
--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -93,12 +93,26 @@ fn tracked_set_cast_candidates(
     let Some(members) = state.tracked_object_sets.get(&id) else {
         return Vec::new();
     };
-    let ctx = crate::game::filter::FilterContext::from_ability(ability);
     let mut seen = HashSet::new();
-    members
+    let deduped: Vec<ObjectId> = members
         .iter()
         .copied()
         .filter(|obj_id| seen.insert(*obj_id))
+        .collect();
+    // CR 607.2a + CR 608.2c: bind the filter's object-scope reads to exactly the
+    // published set, mirroring the two `ExiledBySource` sites below. Building the
+    // context from `ability` directly would carry `ability.targets` — for Sanar,
+    // the whole reveal window the chain seam injected — so a residual leg that
+    // reads object scope (a `ParentTarget`-relative comparison, a same-name or
+    // shares-a-type leg) would evaluate against the injected window rather than
+    // the members actually published. Latent today (all 51 cards bind
+    // `filter: Any`, which reads no object scope) and closed here so it stays that
+    // way.
+    let mut scoped_ability = ability.clone();
+    scoped_ability.targets = deduped.iter().copied().map(TargetRef::Object).collect();
+    let ctx = crate::game::filter::FilterContext::from_ability(&scoped_ability);
+    deduped
+        .into_iter()
         .filter(|obj_id| crate::game::filter::matches_target_filter(state, *obj_id, &bound, &ctx))
         .collect()
 }

--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -2431,7 +2431,7 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
                 let has_tracked_ref = contains_explicit_tracked_set_pronoun(&source_text_lower)
                     || contains_implicit_tracked_set_pronoun(&source_text_lower);
                 if has_tracked_ref {
-                    // CR 608.2c + CR 614.6: same walk, narrower predicate —
+                    // CR 608.2c + CR 607.2a: same walk, narrower predicate —
                     // does any prior clause publish members stamped `Exiled`?
                     // Only then may a cast anaphor narrow to
                     // `caused_by: Exiled`.

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -22561,6 +22561,23 @@ fn exiled_cause_publishers_all_stamp_exiled_at_runtime() {
     // accepted by `chain_clause_is_exile_producer` and must stay rejected here.
     let uncaused_exilers = [
         Effect::HeistExile,
+        Effect::Dig {
+            player: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 1 },
+            destination: Some(Zone::Exile),
+            keep_count: Some(1),
+            keep_count_expr: None,
+            up_to: false,
+            filter: TargetFilter::Any,
+            rest_destination: None,
+            reveal: false,
+            enter_tapped: false,
+            source: crate::types::ability::DigSource::default(),
+        },
+        Effect::ExileHaunting {
+            target: TargetFilter::Any,
+        },
+        Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile: None },
         Effect::RevealUntil {
             player: TargetFilter::Controller,
             filter: TargetFilter::Any,


### PR DESCRIPTION
Follow-up to #7034. Three CodeRabbit findings were posted on that PR, but the merge queue landed it before the fixes could be pushed — queued branches can't be updated, and by the time I dequeued it had already merged. These are those fixes, unchanged in substance from what was verified against #7034's head.

## 1. Scope the filter context to the published set (Major, correctness)

`tracked_set_cast_candidates` stopped reading `ability.targets` for its *candidates* but still built the `FilterContext` from the same unscoped ability. `FilterContext::from_ability` carries `ability.targets` — for Sanar, the whole reveal window the chain seam injected — so a filter leg that reads object scope (a `ParentTarget`-relative comparison, a same-name or shares-a-type leg) would still have evaluated against the injected window rather than the members actually published.

Same defect class as the bug #7034 fixed, one layer down.

**Latent, not live:** all 51 tracked-set cast cards bind `filter: Any`, which reads no object scope, so nothing misbehaves today. It is closed so it stays that way. Both sibling sites in this same resolver already clone and rescope the ability before constructing the context — one of them under the same `CR 607.2a`. This makes the third site consistent with them.

## 2. `CR 614.6` → `CR 607.2a` at `assembly.rs:2434`

Missed in #7034's citation sweep because that sweep used a hand-listed file set which omitted `assembly.rs`.

614.6 is "if an event is replaced, it never happens" and does not describe this code. 607.2a is the linked-ability rule for an activated or triggered ability that *instructs a player to exile*, which is what this block narrows against.

## 3. Pin the three unpinned uncaused exile shapes

`uncaused_exilers` in `exiled_cause_publishers_all_stamp_exiled_at_runtime` named five shapes in its doc comment and pinned two. Adds `Dig { destination: Some(Exile) }`, `ExileHaunting` and `ExileResolvingSpellInsteadOfGraveyard`.

Each now carries both the positive `chain_clause_is_exile_producer` check and the negative `publishes_exiled_cause_at_resolution` / `this_way_cause_for_effect` checks. All three confirm as genuinely uncaused — the test passes with them added, which is what establishes that a cause-filtered anaphor must not be bound after any of them.

## Verification

- `exiled_cause_publishers_all_stamp_exiled_at_runtime` green with all five shapes pinned
- 9 integration tests green (`issue_4253_sanar_vivid` ×7, `urza_lord_high_artificer` ×2), covering the `cast_from_zone` behavioural change
- Cherry-picked onto post-merge `main` (`14b11cf5bf`) with no conflicts


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved tracked-set casting behavior by removing duplicate candidates while preserving their original order.
  * Ensured filtering evaluates only the intended published targets, preventing unrelated targets from affecting results.

* **Tests**
  * Expanded coverage for effects that exile cards, including resolving spells and haunting effects.

* **Documentation**
  * Corrected a tracked-set rules reference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->