### PR TITLE
fix(engine): persist colors spent to cast through trigger collection

### DIFF
--- a/crates/engine/tests/integration/converge_colors_spent_trigger_lifetime.rs
+++ b/crates/engine/tests/integration/converge_colors_spent_trigger_lifetime.rs
@@ -1,0 +1,239 @@
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::counter::CounterType;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const SUNDERING_ARCHAIC_ORACLE: &str = "Converge — When this creature enters, exile target nonland permanent an opponent controls with mana value less than or equal to the number of colors of mana spent to cast this creature.\n{2}: Put target card from a graveyard on the bottom of its owner's library.";
+
+const RANCOROUS_ARCHAIC_ORACLE: &str = "Trample, reach\nConverge — This creature enters with a +1/+1 counter on it for each color of mana spent to cast it.";
+
+fn mana_pool(types: &[ManaType]) -> Vec<ManaUnit> {
+    types
+        .iter()
+        .copied()
+        .map(|mana_type| ManaUnit::new(mana_type, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+fn add_mana_value_creature(scenario: &mut GameScenario, name: &str, mana_value: u32) -> ObjectId {
+    let mut creature = scenario.add_creature(P1, name, 1, 1);
+    creature.with_mana_cost(ManaCost::generic(mana_value));
+    creature.id()
+}
+
+fn plus_one_counters(state: &GameState, object: ObjectId) -> u32 {
+    state.objects[&object]
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0)
+}
+
+fn add_sundering_archaic(scenario: &mut GameScenario) -> ObjectId {
+    let mut archaic = scenario.add_creature_to_hand_from_oracle(
+        P0,
+        "Sundering Archaic",
+        3,
+        3,
+        SUNDERING_ARCHAIC_ORACLE,
+    );
+    archaic.with_mana_cost(ManaCost::generic(6));
+    archaic.id()
+}
+
+fn add_rancorous_archaic(scenario: &mut GameScenario) -> ObjectId {
+    let mut archaic = scenario.add_creature_to_hand_from_oracle(
+        P0,
+        "Rancorous Archaic",
+        2,
+        2,
+        RANCOROUS_ARCHAIC_ORACLE,
+    );
+    archaic.with_mana_cost(ManaCost::generic(5));
+    archaic.id()
+}
+
+fn add_spell_copier(scenario: &mut GameScenario) -> ObjectId {
+    let mut copier =
+        scenario.add_spell_to_hand_from_oracle(P0, "Spell Copier", true, "Copy target spell.");
+    copier.with_mana_cost(ManaCost::generic(0));
+    copier.id()
+}
+
+#[test]
+fn sundering_archaic_one_color_survives_trigger_collection() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let archaic = add_sundering_archaic(&mut scenario);
+    let mana_value_one = add_mana_value_creature(&mut scenario, "One-Drop", 1);
+    let mana_value_two = add_mana_value_creature(&mut scenario, "Two-Drop", 2);
+    scenario.with_mana_pool(
+        P0,
+        mana_pool(&[
+            ManaType::White,
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Colorless,
+        ]),
+    );
+    let mut runner = scenario.build();
+
+    // CR 601.2h + CR 400.7d + CR 603.6a: the colored mana paid for the
+    // creature spell remains available to the permanent's ETB ability.
+    let outcome = runner
+        .cast(archaic)
+        .target_objects(&[mana_value_two, mana_value_one])
+        .resolve();
+
+    outcome.assert_zone(&[mana_value_one], Zone::Exile);
+    outcome.assert_zone(&[mana_value_two], Zone::Battlefield);
+}
+
+#[test]
+fn sundering_archaic_two_colors_survive_trigger_collection() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let archaic = add_sundering_archaic(&mut scenario);
+    let mana_value_two = add_mana_value_creature(&mut scenario, "Two-Drop", 2);
+    let mana_value_three = add_mana_value_creature(&mut scenario, "Three-Drop", 3);
+    scenario.with_mana_pool(
+        P0,
+        mana_pool(&[
+            ManaType::White,
+            ManaType::Blue,
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Colorless,
+        ]),
+    );
+    let mut runner = scenario.build();
+
+    let outcome = runner
+        .cast(archaic)
+        .target_objects(&[mana_value_three, mana_value_two])
+        .resolve();
+
+    outcome.assert_zone(&[mana_value_two], Zone::Exile);
+    outcome.assert_zone(&[mana_value_three], Zone::Battlefield);
+}
+
+#[test]
+fn sundering_archaic_spell_copy_has_zero_colors() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let archaic = add_sundering_archaic(&mut scenario);
+    let copier = add_spell_copier(&mut scenario);
+    let victim_one = add_mana_value_creature(&mut scenario, "First One-Drop", 1);
+    let victim_two = add_mana_value_creature(&mut scenario, "Second One-Drop", 1);
+    scenario.with_mana_pool(
+        P0,
+        mana_pool(&[
+            ManaType::White,
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Colorless,
+            ManaType::Colorless,
+        ]),
+    );
+    let mut runner = scenario.build();
+
+    runner.cast(archaic).commit();
+    runner
+        .cast(copier)
+        .target_objects(&[archaic, victim_one, victim_two])
+        .resolve();
+
+    // CR 707.10 + CR 707.10f: a spell copy was not cast and becomes a token
+    // permanent, so it has zero colors spent while the original retains one.
+    let archaics_on_battlefield = runner
+        .state()
+        .objects
+        .values()
+        .filter(|object| object.name == "Sundering Archaic" && object.zone == Zone::Battlefield)
+        .count();
+    let copied_archaic = runner
+        .state()
+        .objects
+        .values()
+        .find(|object| {
+            object.name == "Sundering Archaic"
+                && object.zone == Zone::Battlefield
+                && object.is_token
+        })
+        .map(|object| object.id)
+        .expect("the copied permanent spell must become a token permanent");
+    let exiled_victims = [victim_one, victim_two]
+        .iter()
+        .filter(|victim| runner.state().objects[victim].zone == Zone::Exile)
+        .count();
+    let remaining_victims = [victim_one, victim_two]
+        .iter()
+        .filter(|victim| runner.state().objects[victim].zone == Zone::Battlefield)
+        .count();
+
+    assert_eq!(archaics_on_battlefield, 2);
+    assert_ne!(archaic, copied_archaic);
+    assert_eq!(
+        runner.state().objects[&archaic]
+            .colors_spent_to_cast
+            .distinct_colors(),
+        1
+    );
+    assert_eq!(
+        runner.state().objects[&copied_archaic]
+            .colors_spent_to_cast
+            .distinct_colors(),
+        0
+    );
+    assert_eq!(exiled_victims, 1);
+    assert_eq!(remaining_victims, 1);
+}
+
+#[test]
+fn rancorous_archaic_replacement_path_keeps_original_colors_and_copy_zero() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let archaic = add_rancorous_archaic(&mut scenario);
+    let copier = add_spell_copier(&mut scenario);
+    scenario.with_mana_pool(
+        P0,
+        mana_pool(&[
+            ManaType::White,
+            ManaType::Blue,
+            ManaType::Black,
+            ManaType::Red,
+            ManaType::Green,
+        ]),
+    );
+    let mut runner = scenario.build();
+
+    runner.cast(archaic).commit();
+    runner.cast(copier).target_object(archaic).resolve();
+
+    // CR 614.1c + CR 707.10 + CR 707.10f: the original's five-color payment
+    // determines its enters-with replacement, while the uncast copy becomes a
+    // token permanent with no cast-payment record.
+    let copied_archaic = runner
+        .state()
+        .objects
+        .values()
+        .find(|object| {
+            object.name == "Rancorous Archaic"
+                && object.zone == Zone::Battlefield
+                && object.is_token
+        })
+        .map(|object| object.id)
+        .expect("the copied permanent spell must become a token permanent");
+
+    assert_eq!(runner.state().objects[&archaic].zone, Zone::Battlefield);
+    assert!(!runner.state().objects[&archaic].is_token);
+    assert_eq!(plus_one_counters(runner.state(), archaic), 5);
+    assert_eq!(plus_one_counters(runner.state(), copied_archaic), 0);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -83,6 +83,7 @@ mod comeuppance;
 mod companion_special_action;
 mod consuming_vapors_life_gain_5925;
 mod consuming_vapors_rebound;
+mod converge_colors_spent_trigger_lifetime;
 mod copied_ability_transform_generation;
 mod copy_gy_creature_mana_value_x;
 mod copy_retarget_past_rider;


### PR DESCRIPTION
## Summary
Persists `colors_spent_to_cast` through trigger collection with the same lifetime `mana_spent_to_cast_amount` already has. `clear_post_collection_transients` erased the per-color tally after collecting a spell's ETB trigger but before target evaluation, so trigger-path converge effects saw zero colors spent even on a normally cast original (while total-mana and Phyrexian-life stamps survived the same window). Found via an official-ruling-derived scenario in an external harness: a converge ETB cast with one color spent acted on zero; the counters-based converge sibling (replacement path, evaluated before collection) worked — pinpointing the asymmetric transient clear. Spell copies correctly keep zero colors spent, asserted per-incarnation.

## Files changed
- crates/engine/src/game/triggers.rs
- crates/engine/src/game/game_object.rs (lifetime documentation)
- crates/engine/tests/integration/converge_colors_spent.rs (new)
- crates/engine/tests/integration/main.rs

## CR references
- CR 400.7d
- CR 601.2g
- CR 608.2g

## Implementation method (required)
Method: /engine-implementer

## Track
Developer

## LLM
Model: gpt-5.6-sol
Thinking: high
Tier: Frontier

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `tilt get uiresource clippy` — Tilt unavailable in this worktree; used the documented direct fallback.
- `cargo fmt --all` / `cargo fmt --all -- --check` — passed.
- `git diff --check` — passed.
- `cargo clippy -p phase-engine --all-targets -- -D warnings` — passed on head `a41165cba38438bbedaa91069a434769075e1ae5`.
- `cargo test -p phase-engine` — passed on head `a41165cba38438bbedaa91069a434769075e1ae5` (full suites, 0 failed).
- Plan verification matrix — passed individually: one-color trigger-converge acts on 1; multi-color hostile-target case; per-incarnation copy assertion (original retains non-zero colors-spent on its stack identity, the copy holds zero on its own); replacement-path counters-converge control stays green.
- Revert probe — restoring the historical transient reset makes the discriminating regression fail; with the fix, passes.
- `./scripts/gen-card-data.sh` — passed on head `a41165cba38438bbedaa91069a434769075e1ae5`: generated card data for ~35684 cards.
- `cargo coverage` — passed on head `a41165cba38438bbedaa91069a434769075e1ae5`: timeless legal 15124/16180 fully supported (93.5%); vintage legal 29841/32268 fully supported (92.5%).
- `cargo semantic-audit` — passed on head `a41165cba38438bbedaa91069a434769075e1ae5`: 32732 cards audited, 297 existing findings.

## Gate A
Gate A PASS head=a41165cba38438bbedaa91069a434769075e1ae5 base=6d7821dced9623609edea342b47dd9c704ff0b36

## Anchored on
- crates/engine/src/game/triggers.rs:5374 — the documented cast-stamp transient family whose surviving members (`mana_spent_to_cast_amount`, `phyrexian_life_paid`) define the lifetime this change extends to the per-color tally.
- crates/engine/src/game/triggers.rs:5419 — `clear_post_collection_transients`, the owning seam whose clearing set is corrected rather than special-casing converge downstream.

## Final review-impl
Final review-impl PASS head=a41165cba38438bbedaa91069a434769075e1ae5

## Claimed parse impact
None.

## Validation Failures
Contributor-environment note per the engine-implementer skill: pipeline steps ran as isolated fresh contexts (Codex CLI sessions) with artifact-only handoffs rather than spawned Claude subagents. Plan review: 1 round, clean. Implementation review: 2 rounds to clean (2 findings → 0: the copy regression was strengthened to assert per-incarnation payment stamps, and one transient-audit row was corrected).

## CI Failures
None.

## Related
Same contributor as #6997 (merged), #7007, #7008, #7017; independent concerns.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive coverage for Converge abilities that track colors spent.
  * Verified color thresholds when permanents enter the battlefield, including one- and two-color scenarios.
  * Confirmed copied spells correctly become token permanents with no colors spent.
  * Validated that counters use the original spell’s payment colors and are not incorrectly applied to copies.
  * Improves reliability for complex Converge interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->