### PR TITLE
Apply card hover preferences across deck and draft views

### DIFF
--- a/client/src/components/card/CardPreview.tsx
+++ b/client/src/components/card/CardPreview.tsx
@@ -67,6 +67,7 @@ if (typeof window !== "undefined") {
 
 export interface CardHoverInfo {
   name: string;
+  scryfallId?: string;
   sourcePrinting?: SourcePrinting;
 }
 

--- a/client/src/components/card/HoverCardPreview.tsx
+++ b/client/src/components/card/HoverCardPreview.tsx
@@ -1,0 +1,63 @@
+import { useEffect, useState } from "react";
+
+import { useShiftHeld } from "../../hooks/useShiftHeld.ts";
+import { usePreferencesStore } from "../../stores/preferencesStore.ts";
+import { useUiStore } from "../../stores/uiStore.ts";
+import { CardPreview, type CardHoverInfo } from "./CardPreview.tsx";
+
+interface HoverCardPreviewProps {
+  card: CardHoverInfo | null;
+  onDismiss?: () => void;
+  mobileLayout?: "modal" | "compact";
+}
+
+/**
+ * Applies the shared card-hover preferences to card-name preview surfaces such
+ * as drafting and deck building. In-game object previews use GameCardPreview.
+ */
+export function HoverCardPreview({
+  card,
+  onDismiss,
+  mobileLayout,
+}: HoverCardPreviewProps) {
+  const cardPreviewMode = usePreferencesStore((s) => s.cardPreviewMode);
+  const cardPreviewHoverDelayMs = usePreferencesStore((s) => s.cardPreviewHoverDelayMs);
+  const shiftHeld = useUiStore((s) => s.shiftHeld);
+  const [visibleCard, setVisibleCard] = useState<CardHoverInfo | null>(null);
+
+  useShiftHeld();
+
+  useEffect(() => {
+    if (card == null) {
+      setVisibleCard(null);
+      return undefined;
+    }
+
+    // Match uiStore.inspectObject: delay only the first desktop hover, so
+    // scrubbing between cards stays responsive once a preview is open.
+    if (
+      cardPreviewMode === "shift"
+      || cardPreviewHoverDelayMs === 0
+      || visibleCard != null
+    ) {
+      setVisibleCard(card);
+      return undefined;
+    }
+
+    const timerId = window.setTimeout(() => setVisibleCard(card), cardPreviewHoverDelayMs);
+    return () => window.clearTimeout(timerId);
+  }, [card, cardPreviewHoverDelayMs, cardPreviewMode, visibleCard]);
+
+  const previewCard = cardPreviewMode === "shift" && !shiftHeld ? null : visibleCard;
+
+  return (
+    <CardPreview
+      cardName={previewCard?.name ?? null}
+      scryfallId={previewCard?.scryfallId}
+      sourcePrinting={previewCard?.sourcePrinting}
+      dockSide={cardPreviewMode === "side"}
+      onDismiss={onDismiss}
+      mobileLayout={mobileLayout}
+    />
+  );
+}

--- a/client/src/components/card/__tests__/HoverCardPreview.test.tsx
+++ b/client/src/components/card/__tests__/HoverCardPreview.test.tsx
@@ -1,0 +1,64 @@
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePreferencesStore } from "../../../stores/preferencesStore.ts";
+import { useUiStore } from "../../../stores/uiStore.ts";
+import { HoverCardPreview } from "../HoverCardPreview.tsx";
+
+vi.mock("../CardPreview.tsx", () => ({
+  CardPreview: ({ cardName, dockSide }: { cardName: string | null; dockSide?: boolean }) => (
+    <div data-dock-side={dockSide} data-testid="preview">
+      {cardName}
+    </div>
+  ),
+}));
+
+const CARD = { name: "Pithing Needle" };
+
+describe("HoverCardPreview", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    usePreferencesStore.setState({ cardPreviewMode: "follow", cardPreviewHoverDelayMs: 0 });
+    useUiStore.setState({ shiftHeld: false });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+    usePreferencesStore.setState({ cardPreviewMode: "follow", cardPreviewHoverDelayMs: 0 });
+    useUiStore.setState({ shiftHeld: false });
+  });
+
+  it("docks non-game hover previews when the side preference is selected", () => {
+    usePreferencesStore.setState({ cardPreviewMode: "side" });
+
+    render(<HoverCardPreview card={CARD} />);
+
+    expect(screen.getByTestId("preview")).toHaveTextContent(CARD.name);
+    expect(screen.getByTestId("preview")).toHaveAttribute("data-dock-side", "true");
+  });
+
+  it("shows a hovered card only while Shift is held in shift mode", () => {
+    usePreferencesStore.setState({ cardPreviewMode: "shift" });
+    render(<HoverCardPreview card={CARD} />);
+
+    expect(screen.getByTestId("preview")).toBeEmptyDOMElement();
+
+    fireEvent.keyDown(window, { key: "Shift" });
+    expect(screen.getByTestId("preview")).toHaveTextContent(CARD.name);
+
+    fireEvent.keyUp(window, { key: "Shift" });
+    expect(screen.getByTestId("preview")).toBeEmptyDOMElement();
+  });
+
+  it("applies the configured delay before the first hover preview", () => {
+    usePreferencesStore.setState({ cardPreviewHoverDelayMs: 250 });
+    const { rerender } = render(<HoverCardPreview card={null} />);
+
+    rerender(<HoverCardPreview card={CARD} />);
+    expect(screen.getByTestId("preview")).toBeEmptyDOMElement();
+
+    act(() => vi.advanceTimersByTime(250));
+    expect(screen.getByTestId("preview")).toHaveTextContent(CARD.name);
+  });
+});

--- a/client/src/components/draft/LimitedDeckBuilder.tsx
+++ b/client/src/components/draft/LimitedDeckBuilder.tsx
@@ -6,7 +6,8 @@ import { useCardImage } from "../../hooks/useCardImage";
 import { useDraftStore } from "../../stores/draftStore";
 import { menuButtonClass } from "../menu/buttonStyles";
 import type { DraftCardInstance, DraftPlayerView } from "../../adapter/draft-adapter";
-import { CardPreview, type CardHoverInfo } from "../card/CardPreview";
+import type { CardHoverInfo } from "../card/CardPreview";
+import { HoverCardPreview } from "../card/HoverCardPreview";
 import { ManaCurve } from "./ManaCurve";
 
 // Shared enter/exit for cards moving between the pool and the deck.
@@ -248,9 +249,8 @@ export function LimitedDeckBuilder({
 
   return (
     <div className="flex h-full flex-col gap-4">
-      <CardPreview
-        cardName={hoveredCard?.name ?? null}
-        sourcePrinting={hoveredCard?.sourcePrinting}
+      <HoverCardPreview
+        card={hoveredCard}
         mobileLayout="compact"
         onDismiss={() => setHoveredCard(null)}
       />

--- a/client/src/pages/DeckBuilderPage.tsx
+++ b/client/src/pages/DeckBuilderPage.tsx
@@ -3,7 +3,7 @@ import { useSearchParams } from "react-router";
 
 import type { GameFormat } from "../adapter/types";
 import { useAudioContext } from "../audio/useAudioContext";
-import { CardPreview } from "../components/card/CardPreview";
+import { HoverCardPreview } from "../components/card/HoverCardPreview";
 import { DeckBuilder } from "../components/deck-builder/DeckBuilder";
 import type { BrowserLegalityFilter, CardSearchFilters } from "../components/deck-builder/CardSearch";
 import { DECK_CONSTRUCTION_FORMATS } from "../data/formatRegistry";
@@ -132,9 +132,8 @@ export function DeckBuilderPage() {
         onSearchFiltersChange={handleSearchFiltersChange}
         onResetSearch={handleResetSearch}
       />
-      <CardPreview
-        cardName={hoveredCard?.name ?? null}
-        scryfallId={hoveredCard?.scryfallId}
+      <HoverCardPreview
+        card={hoveredCard}
         onDismiss={useCallback(() => setHoveredCard(null), [])}
         mobileLayout="compact"
       />

--- a/client/src/pages/DraftPage.tsx
+++ b/client/src/pages/DraftPage.tsx
@@ -4,8 +4,8 @@ import { motion } from "framer-motion";
 import { useNavigate, useSearchParams } from "react-router";
 
 import { useDraftStore } from "../stores/draftStore";
-import { CardPreview } from "../components/card/CardPreview";
 import type { CardHoverInfo } from "../components/card/CardPreview";
+import { HoverCardPreview } from "../components/card/HoverCardPreview";
 import { BotDifficultySelector } from "../components/draft/BotDifficultySelector";
 import { CubeSetupPanel } from "../components/draft/CubeSetupPanel";
 import { DraftIntro } from "../components/draft/DraftIntro";
@@ -372,7 +372,7 @@ export function DraftPage() {
     <div className="menu-scene relative flex min-h-screen flex-col overflow-hidden">
       <ScreenChrome onBack={() => navigate("/draft")} />
       {phase === "drafting" && introDismissed && (
-        <CardPreview cardName={hoveredCard?.name ?? null} sourcePrinting={hoveredCard?.sourcePrinting} />
+        <HoverCardPreview card={hoveredCard} />
       )}
 
       {/* Centered MenuShell column — identical framing to home/setup/online so

--- a/client/src/pages/DraftPodPage.tsx
+++ b/client/src/pages/DraftPodPage.tsx
@@ -12,9 +12,9 @@ import { useCallback, useEffect, useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { useNavigate, useSearchParams } from "react-router";
 
-import { CardPreview } from "../components/card/CardPreview";
 import { MenuSelect } from "../components/ui/MenuSelect";
 import type { CardHoverInfo } from "../components/card/CardPreview";
+import { HoverCardPreview } from "../components/card/HoverCardPreview";
 import { ScreenChrome } from "../components/chrome/ScreenChrome";
 import { CubeSetupPanel } from "../components/draft/CubeSetupPanel";
 import { DraftIntro } from "../components/draft/DraftIntro";
@@ -481,9 +481,8 @@ function MatchInProgressView() {
         </button>
         {showPool && <PoolPanel onCardHover={setHoveredCard} />}
       </div>
-      <CardPreview
-        cardName={hoveredCard?.name ?? null}
-        sourcePrinting={hoveredCard?.sourcePrinting}
+      <HoverCardPreview
+        card={hoveredCard}
         mobileLayout="compact"
         onDismiss={() => setHoveredCard(null)}
       />
@@ -667,7 +666,7 @@ function DraftingPhaseContent() {
         </div>
         <PoolPanel view={view} onCardHover={setHoveredCard} />
       </div>
-      <CardPreview cardName={hoveredCard?.name ?? null} sourcePrinting={hoveredCard?.sourcePrinting} />
+      <HoverCardPreview card={hoveredCard} />
     </>
   );
 }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added card previews when hovering over cards in deck building, drafting, and match-review views.
  * Previews support configurable hover delays, side docking, mobile layouts, and Shift-key activation.
  * Preview behavior now updates immediately while browsing an open preview.

* **Tests**
  * Added coverage for docking, Shift-key activation, and configurable hover timing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->