### PR TITLE
Fix card hover preview interactions

### DIFF
--- a/client/src/components/card/GameCardPreview.tsx
+++ b/client/src/components/card/GameCardPreview.tsx
@@ -24,6 +24,7 @@ export function GameCardPreview() {
 
   const inspectedObjectId = useUiStore((s) => s.inspectedObjectId);
   const inspectedFaceIndex = useUiStore((s) => s.inspectedFaceIndex);
+  const previewPlacement = useUiStore((s) => s.previewPlacement);
   const isDragging = useUiStore((s) => s.isDragging);
   const shiftHeld = useUiStore((s) => s.shiftHeld);
   // Card-preview behavior preference. In "shift" mode the preview only renders
@@ -59,7 +60,7 @@ export function GameCardPreview() {
       cardName={previewSuppressed ? null : inspectedCardName}
       objectId={inspectedObj?.id ?? null}
       backFaceName={previewSuppressed ? null : inspectedOtherFaceName}
-      dockSide={cardPreviewMode === "side"}
+      dockSide={cardPreviewMode === "side" || previewPlacement === "side"}
       handSourceObjectId={inspectedObj?.zone === "Hand" ? inspectedObj.id : null}
     />
   );

--- a/client/src/components/card/__tests__/GameCardPreview.test.tsx
+++ b/client/src/components/card/__tests__/GameCardPreview.test.tsx
@@ -63,6 +63,7 @@ afterEach(() => {
   useUiStore.setState({
     inspectedObjectId: null,
     inspectedFaceIndex: 0,
+    previewPlacement: "cursor",
     isDragging: false,
     mobileHandGesture: null,
     shiftHeld: false,
@@ -79,6 +80,17 @@ describe("GameCardPreview", () => {
     render(<GameCardPreview />);
 
     expect(screen.getAllByAltText("Pithing Needle").length).toBeGreaterThan(0);
+  });
+
+  it("docks a preview opened from a modal even when cursor-follow is preferred", () => {
+    inspect(battlefieldObject());
+    useUiStore.setState({ previewPlacement: "side" });
+
+    const { container } = render(<GameCardPreview />);
+
+    expect(container.querySelector<HTMLElement>("[data-card-preview]")).toHaveStyle({
+      right: "calc(env(safe-area-inset-right) + 1rem + var(--game-right-rail-offset, 0px))",
+    });
   });
 
   it("anchors the preview to the hand card hovered through PlayerHand", async () => {

--- a/client/src/components/deck-builder/CardEntryRow.tsx
+++ b/client/src/components/deck-builder/CardEntryRow.tsx
@@ -5,7 +5,7 @@ import type { DeckEntry } from "../../services/deckParser";
 import type { ParsedItem, UnsupportedCard } from "../../services/deckCompatibility";
 import { hasAlternatePrintingsSync, resolveOracleIdSync } from "../../services/scryfall";
 import { usePrintingsLoaded } from "../../hooks/usePrintingsLoaded";
-import { mouseHoverPreview } from "./hoverPreview";
+import { mouseHoverPreview, type CardHoverHandler } from "./hoverPreview";
 
 const CATEGORY_COLORS: Record<string, string> = {
   keyword: "text-sky-400",
@@ -57,7 +57,7 @@ export interface CardEntryRowProps {
    *  permitting the increment so a not-yet-loaded limit never blocks a legal
    *  add. */
   canIncrement?: (name: string) => boolean;
-  onCardHover?: (cardName: string | null) => void;
+  onCardHover?: CardHoverHandler;
   unsupported?: UnsupportedCard;
   onChooseArt?: (cardName: string, x: number, y: number) => void;
   /** When defined and the card is commander-eligible in the current format,
@@ -117,6 +117,7 @@ export function CardEntryRow({
   const printingsLoaded = usePrintingsLoaded();
   const oracleId = printingsLoaded ? resolveOracleIdSync(entry.name) : null;
   const hasAlternates = oracleId ? hasAlternatePrintingsSync(oracleId) : false;
+  const hoverInfo = { name: entry.name, sourcePrinting: entry.sourcePrinting };
   // Labelled "→ {target}" pill when the destination name is known (deck
   // builder); bare directional arrow otherwise (BO3 sideboard modal). The
   // labelled variant widens to fit text, so it overrides the square sizing.
@@ -147,8 +148,8 @@ export function CardEntryRow({
             own actions. */}
         <span
           className={`${unsupported ? "text-amber-200/80" : "text-gray-300"} ${onCardHover ? "cursor-pointer" : ""}`}
-          onClick={() => onCardHover?.(entry.name)}
-          {...mouseHoverPreview(onCardHover, entry.name)}
+          onClick={() => onCardHover?.(hoverInfo)}
+          {...mouseHoverPreview(onCardHover, hoverInfo)}
         >
           <span className="mr-1 text-gray-500">{entry.count}x</span>
           {entry.name}

--- a/client/src/components/deck-builder/CardGrid.tsx
+++ b/client/src/components/deck-builder/CardGrid.tsx
@@ -4,12 +4,12 @@ import { scryfallLegalityKey, type ScryfallCard } from "../../services/scryfall"
 import { useLongPress } from "../../hooks/useLongPress";
 import type { BrowserLegalityFilter } from "./CardSearch";
 import { LegalityBadge } from "./LegalityBadge";
-import { mouseHoverPreview } from "./hoverPreview";
+import { mouseHoverPreview, type CardHoverHandler } from "./hoverPreview";
 
 interface CardGridProps {
   cards: ScryfallCard[];
   onAddCard: (card: ScryfallCard) => void;
-  onCardHover?: (cardName: string | null) => void;
+  onCardHover?: CardHoverHandler;
   cardCounts?: Map<string, number>;
   legalityFormat?: BrowserLegalityFilter;
 }
@@ -61,7 +61,7 @@ interface CardGridTileProps {
   count: number | undefined;
   legalityFormat: BrowserLegalityFilter;
   onAddCard: (card: ScryfallCard) => void;
-  onCardHover?: (cardName: string | null) => void;
+  onCardHover?: CardHoverHandler;
 }
 
 function CardGridTile({
@@ -77,12 +77,13 @@ function CardGridTile({
   const formatLabel = legalityFormat === "all"
     ? t("grid.allFormats")
     : legalityFormat.charAt(0).toUpperCase() + legalityFormat.slice(1);
+  const hoverInfo = { name: card.name, scryfallId: card.id };
 
   // Touch model (mirrors MobileHandDrawer's DrawerCard): tap adds the card,
   // long-press opens the preview. firedRef suppresses the click that follows a
   // long-press so a long-press never also adds the card. Desktop is unaffected
   // (handlers are touch-only; hover still drives the preview).
-  const { handlers, firedRef } = useLongPress(() => onCardHover?.(card.name));
+  const { handlers, firedRef } = useLongPress(() => onCardHover?.(hoverInfo));
 
   const handleClick = () => {
     if (firedRef.current) {
@@ -101,7 +102,7 @@ function CardGridTile({
       exit={{ opacity: 0, scale: 0.9 }}
       transition={{ duration: 0.15 }}
       onClick={handleClick}
-      {...mouseHoverPreview(onCardHover, card.name)}
+      {...mouseHoverPreview(onCardHover, hoverInfo)}
       {...handlers}
       disabled={!legal}
       title={legal ? t("grid.addCard", { name: card.name }) : t("grid.notLegal", { name: card.name, format: formatLabel })}

--- a/client/src/components/deck-builder/CommanderPanel.tsx
+++ b/client/src/components/deck-builder/CommanderPanel.tsx
@@ -63,6 +63,10 @@ export function CommanderPanel({
 }: CommanderPanelProps) {
   const { t } = useTranslation("deck-builder");
   const identity = getCombinedColorIdentity(commanders, cardDataCache);
+  const hoverInfo = (name: string) => ({
+    name,
+    scryfallId: cardDataCache.get(name)?.id,
+  });
   const totalCards = deck.reduce((sum, e) => sum + e.count, 0)
     + commanders.length
     + (signatureSpell ? 1 : 0);
@@ -93,7 +97,7 @@ export function CommanderPanel({
           return (
             <div
               key={name}
-              {...mouseHoverPreview(onCardHover, { name })}
+              {...mouseHoverPreview(onCardHover, hoverInfo(name))}
               className="flex items-center justify-between rounded bg-purple-900/30 px-2 py-1.5"
             >
               <span className="text-sm font-medium text-purple-300">
@@ -137,7 +141,7 @@ export function CommanderPanel({
             <button
               key={name}
               onClick={() => onSetCommander(name)}
-              {...mouseHoverPreview(onCardHover, { name })}
+              {...mouseHoverPreview(onCardHover, hoverInfo(name))}
               className="block w-full truncate rounded bg-purple-800/40 px-2 py-1 text-left text-xs text-purple-300 hover:bg-purple-700/40"
             >
               {name}
@@ -153,7 +157,7 @@ export function CommanderPanel({
           </h5>
           {signatureSpell ? (
             <div
-              {...mouseHoverPreview(onCardHover, { name: signatureSpell })}
+              {...mouseHoverPreview(onCardHover, hoverInfo(signatureSpell))}
               className="flex items-center justify-between rounded bg-purple-900/30 px-2 py-1.5"
             >
               <span className="text-sm font-medium text-purple-300">{signatureSpell}</span>
@@ -173,7 +177,7 @@ export function CommanderPanel({
             <button
               key={name}
               onClick={() => onSetSignatureSpell(name)}
-              {...mouseHoverPreview(onCardHover, { name })}
+              {...mouseHoverPreview(onCardHover, hoverInfo(name))}
               className="block min-h-11 w-full truncate rounded bg-purple-800/40 px-2 py-1 text-left text-xs text-purple-300 hover:bg-purple-700/40 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-300"
             >
               {name}
@@ -189,7 +193,7 @@ export function CommanderPanel({
           </h5>
           {companion ? (
             <div
-              {...mouseHoverPreview(onCardHover, { name: companion })}
+              {...mouseHoverPreview(onCardHover, hoverInfo(companion))}
               className="flex items-center justify-between rounded bg-blue-900/30 px-2 py-1.5"
             >
               <span className="text-sm font-medium text-blue-300">{companion}</span>
@@ -207,7 +211,7 @@ export function CommanderPanel({
             <button
               key={name}
               onClick={() => onSetCompanion(name)}
-              {...mouseHoverPreview(onCardHover, { name })}
+              {...mouseHoverPreview(onCardHover, hoverInfo(name))}
               className="block min-h-11 w-full truncate rounded bg-blue-800/40 px-2 py-1 text-left text-xs text-blue-300 hover:bg-blue-700/40 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-300"
             >
               {name}

--- a/client/src/components/deck-builder/CommanderPanel.tsx
+++ b/client/src/components/deck-builder/CommanderPanel.tsx
@@ -6,6 +6,7 @@ import {
   getCombinedColorIdentity,
 } from "./commanderUtils";
 import { mouseHoverPreview } from "./hoverPreview";
+import type { CardHoverHandler } from "./hoverPreview";
 
 const WUBRG_COLORS = ["W", "U", "B", "R", "G"] as const;
 
@@ -35,7 +36,7 @@ interface CommanderPanelProps {
   companionCandidates?: string[] | null;
   onSetCompanion?: (cardName: string) => void;
   onRemoveCompanion?: () => void;
-  onCardHover?: (cardName: string | null) => void;
+  onCardHover?: CardHoverHandler;
   /** Engine evaluateDeckCompatibility reasons for the active format. */
   formatValidationReasons?: string[];
 }
@@ -92,7 +93,7 @@ export function CommanderPanel({
           return (
             <div
               key={name}
-              {...mouseHoverPreview(onCardHover, name)}
+              {...mouseHoverPreview(onCardHover, { name })}
               className="flex items-center justify-between rounded bg-purple-900/30 px-2 py-1.5"
             >
               <span className="text-sm font-medium text-purple-300">
@@ -136,7 +137,7 @@ export function CommanderPanel({
             <button
               key={name}
               onClick={() => onSetCommander(name)}
-              {...mouseHoverPreview(onCardHover, name)}
+              {...mouseHoverPreview(onCardHover, { name })}
               className="block w-full truncate rounded bg-purple-800/40 px-2 py-1 text-left text-xs text-purple-300 hover:bg-purple-700/40"
             >
               {name}
@@ -152,7 +153,7 @@ export function CommanderPanel({
           </h5>
           {signatureSpell ? (
             <div
-              {...mouseHoverPreview(onCardHover, signatureSpell)}
+              {...mouseHoverPreview(onCardHover, { name: signatureSpell })}
               className="flex items-center justify-between rounded bg-purple-900/30 px-2 py-1.5"
             >
               <span className="text-sm font-medium text-purple-300">{signatureSpell}</span>
@@ -172,7 +173,7 @@ export function CommanderPanel({
             <button
               key={name}
               onClick={() => onSetSignatureSpell(name)}
-              {...mouseHoverPreview(onCardHover, name)}
+              {...mouseHoverPreview(onCardHover, { name })}
               className="block min-h-11 w-full truncate rounded bg-purple-800/40 px-2 py-1 text-left text-xs text-purple-300 hover:bg-purple-700/40 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-purple-300"
             >
               {name}
@@ -188,7 +189,7 @@ export function CommanderPanel({
           </h5>
           {companion ? (
             <div
-              {...mouseHoverPreview(onCardHover, companion)}
+              {...mouseHoverPreview(onCardHover, { name: companion })}
               className="flex items-center justify-between rounded bg-blue-900/30 px-2 py-1.5"
             >
               <span className="text-sm font-medium text-blue-300">{companion}</span>
@@ -206,7 +207,7 @@ export function CommanderPanel({
             <button
               key={name}
               onClick={() => onSetCompanion(name)}
-              {...mouseHoverPreview(onCardHover, name)}
+              {...mouseHoverPreview(onCardHover, { name })}
               className="block min-h-11 w-full truncate rounded bg-blue-800/40 px-2 py-1 text-left text-xs text-blue-300 hover:bg-blue-700/40 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-blue-300"
             >
               {name}

--- a/client/src/components/deck-builder/DeckBuilder.tsx
+++ b/client/src/components/deck-builder/DeckBuilder.tsx
@@ -19,9 +19,10 @@ import { DeckBuilderToolbar } from "./DeckBuilderToolbar";
 import { DeckBuilderTabBar } from "./DeckBuilderTabBar";
 import { panelId, tabId } from "./deckBuilderTabs";
 import { useDeckBuilder } from "./useDeckBuilder";
+import type { CardHoverInfo } from "../card/CardPreview";
 
 interface DeckBuilderProps {
-  onCardHover?: (cardName: string | null, scryfallId?: string) => void;
+  onCardHover?: (card: CardHoverInfo | null) => void;
   format: GameFormat;
   onFormatChange: (format: GameFormat) => void;
   initialDeckName?: string | null;

--- a/client/src/components/deck-builder/DeckList.tsx
+++ b/client/src/components/deck-builder/DeckList.tsx
@@ -253,8 +253,13 @@ export function DeckList({
             >
               <span
                 className={`text-fuchsia-50 ${onCardHover ? "cursor-pointer" : ""}`}
-                onClick={() => onCardHover?.({ name })}
-                {...mouseHoverPreview(onCardHover, { name })}
+                onClick={() =>
+                  onCardHover?.({ name, scryfallId: cardDataCache.get(name)?.id })
+                }
+                {...mouseHoverPreview(onCardHover, {
+                  name,
+                  scryfallId: cardDataCache.get(name)?.id,
+                })}
               >
                 {name}
               </span>

--- a/client/src/components/deck-builder/DeckList.tsx
+++ b/client/src/components/deck-builder/DeckList.tsx
@@ -13,6 +13,7 @@ import type { ScryfallCard } from "../../services/scryfall";
 
 import { MoveList } from "./MoveList";
 import { mouseHoverPreview } from "./hoverPreview";
+import type { CardHoverHandler } from "./hoverPreview";
 import { groupAccent, groupKey, groupOrder, groupTitleKey, type GroupMode } from "./deckGrouping";
 import { isMaybeboardPolicy, useSideboardPolicy } from "./useSideboardPolicy";
 
@@ -27,7 +28,7 @@ interface DeckListProps {
   canIncrementCard: (name: string) => boolean;
   onMoveCard: (name: string, from: "main" | "sideboard") => void;
   onImport: (deck: ParsedDeck) => void;
-  onCardHover?: (cardName: string | null) => void;
+  onCardHover?: CardHoverHandler;
   format?: string;
   compatibility?: DeckCompatibilityResult | null;
   onChooseArt?: (cardName: string, x: number, y: number) => void;
@@ -252,8 +253,8 @@ export function DeckList({
             >
               <span
                 className={`text-fuchsia-50 ${onCardHover ? "cursor-pointer" : ""}`}
-                onClick={() => onCardHover?.(name)}
-                {...mouseHoverPreview(onCardHover, name)}
+                onClick={() => onCardHover?.({ name })}
+                {...mouseHoverPreview(onCardHover, { name })}
               >
                 {name}
               </span>

--- a/client/src/components/deck-builder/DeckStack.tsx
+++ b/client/src/components/deck-builder/DeckStack.tsx
@@ -11,7 +11,7 @@ import { usePreferencesStore } from "../../stores/preferencesStore";
 import type { GameFormat } from "../../adapter/types";
 import { DeckCardContextMenu } from "./DeckCardContextMenu";
 import { PrintingPickerModal } from "./PrintingPickerModal";
-import { mouseHoverPreview } from "./hoverPreview";
+import { mouseHoverPreview, type CardHoverHandler } from "./hoverPreview";
 import { groupAccent, groupKey, groupRank, groupTitleKey, type GroupMode } from "./deckGrouping";
 import { isMaybeboardPolicy, useSideboardPolicy } from "./useSideboardPolicy";
 
@@ -26,7 +26,7 @@ interface DeckStackProps {
   onRemoveCard: (name: string, section: "main" | "sideboard") => void;
   onMoveCard: (name: string, from: "main" | "sideboard") => void;
   onRemoveCommander: (cardName: string) => void;
-  onCardHover?: (cardName: string | null, scryfallId?: string) => void;
+  onCardHover?: CardHoverHandler;
   /** Deck format — resolves the sideboard policy so the second section
    *  is labelled "Sideboard" or "Maybeboard" consistently with the list view. */
   format?: GameFormat;
@@ -42,6 +42,7 @@ interface DeckStackItem {
   section: DeckStackSection;
   groupTitle: string;
   sortKey: [number, number, string];
+  scryfallId?: string;
   sourcePrinting?: SourcePrinting;
 }
 
@@ -78,6 +79,7 @@ function createDeckStackItems(
     commandersItems.push({
       count: 1,
       name,
+      scryfallId: card?.id,
       section: "commander",
       groupTitle: "",
       sortKey: [0, card?.cmc ?? 0, name.toLowerCase()],
@@ -90,6 +92,7 @@ function createDeckStackItems(
     mainItems.push({
       count: entry.count,
       name: entry.name,
+      scryfallId: card?.id,
       sourcePrinting: entry.sourcePrinting,
       section: "main",
       groupTitle: groupTitleKey(mode, groupKey(mode, card)),
@@ -103,6 +106,7 @@ function createDeckStackItems(
     sideboardItems.push({
       count: entry.count,
       name: entry.name,
+      scryfallId: card?.id,
       sourcePrinting: entry.sourcePrinting,
       section: "sideboard",
       groupTitle: groupTitleKey(mode, groupKey(mode, card)),
@@ -173,7 +177,7 @@ function DeckStackCard({
   onRemoveCard: (name: string, section: "main" | "sideboard") => void;
   onMoveCard: (name: string, from: "main" | "sideboard") => void;
   onRemoveCommander: (cardName: string) => void;
-  onCardHover?: (cardName: string | null, scryfallId?: string) => void;
+  onCardHover?: CardHoverHandler;
   onContextMenu?: (cardName: string, x: number, y: number) => void;
 }) {
   const { t } = useTranslation("deck-builder");
@@ -182,6 +186,11 @@ function DeckStackCard({
   const oracleId = printingsLoaded ? resolveOracleIdSync(item.name) : null;
   const hasAlternates = oracleId ? hasAlternatePrintingsSync(oracleId) : false;
   const isCommander = item.section === "commander";
+  const hoverInfo = {
+    name: item.name,
+    scryfallId: item.scryfallId,
+    sourcePrinting: item.sourcePrinting,
+  };
   const showAddButton = item.section === "main";
   // The commander isn't part of the main/maybeboard partition, so it has no
   // move target. Main cards move out to the sideboard/maybeboard; second-section
@@ -224,8 +233,8 @@ function DeckStackCard({
       style={{ zIndex, width: CARD_WIDTH }}
       // Tap previews the card on touch; hover previews on mouse (guarded so the
       // touch-compat mouseleave can't tear down the overlay the tap just opened).
-      onClick={() => onCardHover?.(item.name)}
-      {...mouseHoverPreview(onCardHover, item.name)}
+      onClick={() => onCardHover?.(hoverInfo)}
+      {...mouseHoverPreview(onCardHover, hoverInfo)}
       onContextMenu={(e) => {
         if (onContextMenu) {
           e.preventDefault();
@@ -349,7 +358,7 @@ function DeckStackSectionLane({
   onRemoveCard: (name: string, section: "main" | "sideboard") => void;
   onMoveCard: (name: string, from: "main" | "sideboard") => void;
   onRemoveCommander: (cardName: string) => void;
-  onCardHover?: (cardName: string | null, scryfallId?: string) => void;
+  onCardHover?: CardHoverHandler;
   onContextMenu?: (cardName: string, x: number, y: number) => void;
 }) {
   const { t } = useTranslation("deck-builder");

--- a/client/src/components/deck-builder/MoveList.tsx
+++ b/client/src/components/deck-builder/MoveList.tsx
@@ -5,6 +5,7 @@ import type { UnsupportedCard } from "../../services/deckCompatibility";
 import type { GroupAccent } from "./deckGrouping";
 
 import { CardEntryRow } from "./CardEntryRow";
+import type { CardHoverHandler } from "./hoverPreview";
 
 function totalCards(entries: DeckEntry[]): number {
   return entries.reduce((sum, e) => sum + e.count, 0);
@@ -22,7 +23,7 @@ export interface MoveListProps {
   onIncrement?: (name: string, section: "main" | "sideboard") => void;
   /** Forwarded to each row. See `CardEntryRowProps.canIncrement`. */
   canIncrement?: (name: string) => boolean;
-  onCardHover?: (name: string | null) => void;
+  onCardHover?: CardHoverHandler;
   unsupportedMap?: Map<string, UnsupportedCard>;
   /** Render the section even when it has zero entries, showing `emptyHint`.
    *  Used for the always-visible sideboard target in the deck editor. */

--- a/client/src/components/deck-builder/PrintingPickerModal.tsx
+++ b/client/src/components/deck-builder/PrintingPickerModal.tsx
@@ -5,11 +5,12 @@ import { getCardPrintings } from "../../services/scryfall.ts";
 import type { PrintingEntry } from "../../services/scryfall.ts";
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import { ModalPanelShell } from "../ui/ModalPanelShell";
+import type { CardHoverHandler } from "./hoverPreview";
 
 interface PrintingPickerModalProps {
   cardName: string;
   oracleId: string;
-  onCardHover?: (cardName: string | null, scryfallId?: string) => void;
+  onCardHover?: CardHoverHandler;
   onClose: () => void;
 }
 
@@ -140,7 +141,7 @@ export function PrintingPickerModal({
                   key={printing.id}
                   type="button"
                   onClick={() => handleSelect(printing)}
-                  onMouseEnter={() => onCardHover?.(cardName, printing.id)}
+                  onMouseEnter={() => onCardHover?.({ name: cardName, scryfallId: printing.id })}
                   onMouseLeave={() => onCardHover?.(null)}
                   className={`group relative overflow-hidden rounded-xl border transition-all ${
                     isSelected

--- a/client/src/components/deck-builder/__tests__/CardEntryRow.test.tsx
+++ b/client/src/components/deck-builder/__tests__/CardEntryRow.test.tsx
@@ -25,6 +25,28 @@ describe("CardEntryRow", () => {
     expect(onMove).toHaveBeenCalledWith("Lightning Bolt", "main");
   });
 
+  it("forwards a row's selected printing to the hover preview", () => {
+    const onCardHover = vi.fn();
+    render(
+      <CardEntryRow
+        entry={{
+          ...entry,
+          sourcePrinting: { setCode: "lea", collectorNumber: "161" },
+        }}
+        section="main"
+        onMove={vi.fn()}
+        onCardHover={onCardHover}
+      />,
+    );
+
+    fireEvent.click(screen.getByText("Lightning Bolt"));
+
+    expect(onCardHover).toHaveBeenCalledWith({
+      name: "Lightning Bolt",
+      sourcePrinting: { setCode: "lea", collectorNumber: "161" },
+    });
+  });
+
   it("shows an arrow pointing the opposite direction for sideboard rows", () => {
     const onMove = vi.fn();
     render(

--- a/client/src/components/deck-builder/hoverPreview.ts
+++ b/client/src/components/deck-builder/hoverPreview.ts
@@ -1,4 +1,7 @@
 import type { PointerEvent } from "react";
+import type { CardHoverInfo } from "../card/CardPreview";
+
+export type CardHoverHandler = (card: CardHoverInfo | null) => void;
 
 /**
  * Hover-to-preview handlers for the deck-builder card surfaces (list, stack,
@@ -21,12 +24,12 @@ import type { PointerEvent } from "react";
  *    immune: its preview is `pointer-events-none` and never the relatedTarget.)
  */
 export function mouseHoverPreview(
-  onCardHover: ((name: string | null) => void) | undefined,
-  name: string,
+  onCardHover: CardHoverHandler | undefined,
+  card: CardHoverInfo,
 ) {
   return {
     onPointerEnter: (e: PointerEvent) => {
-      if (e.pointerType === "mouse") onCardHover?.(name);
+      if (e.pointerType === "mouse") onCardHover?.(card);
     },
     onPointerLeave: (e: PointerEvent) => {
       if (e.pointerType !== "mouse") return;

--- a/client/src/components/draft/LimitedDeckBuilder.tsx
+++ b/client/src/components/draft/LimitedDeckBuilder.tsx
@@ -3,6 +3,7 @@ import { useTranslation } from "react-i18next";
 import { AnimatePresence, motion } from "framer-motion";
 
 import { useCardImage } from "../../hooks/useCardImage";
+import { useLongPress } from "../../hooks/useLongPress";
 import { useDraftStore } from "../../stores/draftStore";
 import { menuButtonClass } from "../menu/buttonStyles";
 import type { DraftCardInstance, DraftPlayerView } from "../../adapter/draft-adapter";
@@ -53,17 +54,26 @@ function CardTile({ card, count, dimmed, onClick, onHover }: CardTileProps) {
     size: "normal",
     sourcePrinting: { setCode: card.set_code, collectorNumber: card.collector_number },
   });
+  const hoverInfo = {
+    name: card.name,
+    sourcePrinting: { setCode: card.set_code, collectorNumber: card.collector_number },
+  };
+  const { handlers, firedRef } = useLongPress(() => onHover(hoverInfo));
+
+  const handleClick = () => {
+    if (firedRef.current) {
+      firedRef.current = false;
+      return;
+    }
+    onClick();
+  };
 
   return (
     <button
-      onClick={onClick}
-      onMouseEnter={() =>
-        onHover({
-          name: card.name,
-          sourcePrinting: { setCode: card.set_code, collectorNumber: card.collector_number },
-        })
-      }
+      onClick={handleClick}
+      onMouseEnter={() => onHover(hoverInfo)}
       onMouseLeave={() => onHover(null)}
+      {...handlers}
       className={`relative cursor-pointer overflow-hidden rounded-[14px] ring-1 ring-white/10 transition-all duration-150 hover:scale-[1.02] hover:ring-white/20
         ${dimmed ? "opacity-70 hover:opacity-90" : ""}`}
     >

--- a/client/src/components/draft/__tests__/LimitedDeckBuilder.test.tsx
+++ b/client/src/components/draft/__tests__/LimitedDeckBuilder.test.tsx
@@ -129,12 +129,35 @@ describe("LimitedDeckBuilder", () => {
       pointerType: "touch",
     });
     act(() => vi.advanceTimersByTime(500));
-    fireEvent.click(card);
+    fireEvent.click(card, { detail: 0 });
 
     expect(screen.getByTestId("hover-preview")).toHaveTextContent("Wind Drake");
     expect(screen.getByRole("meter", { name: "Mana value 3" })).toHaveAttribute(
       "aria-valuenow",
       "0",
+    );
+  });
+
+  it("does not suppress activation after a canceled long press", () => {
+    vi.useFakeTimers();
+    render(<Harness />);
+
+    const card = screen.getByRole("button", { name: /wind drake/i });
+    fireEvent.pointerDown(card, {
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: "touch",
+    });
+    act(() => vi.advanceTimersByTime(500));
+    fireEvent.pointerCancel(card, { pointerId: 1, pointerType: "touch" });
+    fireEvent.click(card, { detail: 0 });
+
+    expect(screen.getByRole("meter", { name: "Mana value 3" })).toHaveAttribute(
+      "aria-valuenow",
+      "1",
     );
   });
 });

--- a/client/src/components/draft/__tests__/LimitedDeckBuilder.test.tsx
+++ b/client/src/components/draft/__tests__/LimitedDeckBuilder.test.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { LimitedDeckBuilder } from "../LimitedDeckBuilder";
 
@@ -19,6 +19,12 @@ vi.mock("../../../stores/draftStore", () => ({
       autoSuggestLands: async () => {},
       submitDeck: async () => {},
     }),
+}));
+
+vi.mock("../../card/HoverCardPreview", () => ({
+  HoverCardPreview: ({ card }: { card: { name: string } | null }) => (
+    <div data-testid="hover-preview">{card?.name}</div>
+  ),
 }));
 
 type BuilderView = NonNullable<NonNullable<Parameters<typeof LimitedDeckBuilder>[0]>["view"]>;
@@ -81,6 +87,11 @@ function Harness() {
 }
 
 describe("LimitedDeckBuilder", () => {
+  afterEach(() => {
+    cleanup();
+    vi.useRealTimers();
+  });
+
   it("updates mana curve when a card is added from pool", () => {
     render(<Harness />);
 
@@ -102,5 +113,28 @@ describe("LimitedDeckBuilder", () => {
     expect(screen.getByText("Academy Ruins")).toBeInTheDocument();
     expect(screen.queryByText("Plains")).not.toBeInTheDocument();
     expect(screen.queryByText("Island")).not.toBeInTheDocument();
+  });
+
+  it("opens a preview on touch long press without moving the card", () => {
+    vi.useFakeTimers();
+    render(<Harness />);
+
+    const card = screen.getByRole("button", { name: /wind drake/i });
+    fireEvent.pointerDown(card, {
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: "touch",
+    });
+    act(() => vi.advanceTimersByTime(500));
+    fireEvent.click(card);
+
+    expect(screen.getByTestId("hover-preview")).toHaveTextContent("Wind Drake");
+    expect(screen.getByRole("meter", { name: "Mana value 3" })).toHaveAttribute(
+      "aria-valuenow",
+      "0",
+    );
   });
 });

--- a/client/src/components/modal/ChoiceOverlay.tsx
+++ b/client/src/components/modal/ChoiceOverlay.tsx
@@ -27,7 +27,10 @@ export function ChoiceOverlay({
   const peek = useOptionalDialogPeek();
 
   return (
-    <div className="fixed inset-0 z-50 flex flex-col px-0 py-0 lg:items-center lg:justify-center lg:px-4 lg:py-6">
+    <div
+      className="fixed inset-0 z-50 flex flex-col px-0 py-0 lg:items-center lg:justify-center lg:px-4 lg:py-6"
+      data-card-preview-dock="side"
+    >
       <div className="absolute inset-0 bg-black/68" />
       <div className={`relative flex h-full flex-col lg:h-auto lg:max-h-[calc(100vh_-_3rem)] ${widthClassName} ${maxWidthClassName}`}>
         <motion.div

--- a/client/src/components/modal/DialogShell.tsx
+++ b/client/src/components/modal/DialogShell.tsx
@@ -89,6 +89,7 @@ export function DialogShell({
       <motion.div
         ref={constraintsRef}
         className="fixed inset-0 z-50 flex items-center justify-center px-2 py-2 lg:px-4 lg:py-6"
+        data-card-preview-dock="side"
         initial={{ opacity: 0 }}
         animate={{ opacity: 1 }}
         exit={{ opacity: 0 }}

--- a/client/src/components/modal/DistributeAmongModal.tsx
+++ b/client/src/components/modal/DistributeAmongModal.tsx
@@ -59,6 +59,7 @@ export function DistributeAmongModal({ data }: { data: DistributeAmong["data"] }
     <ChoiceOverlay
       title={t("distributeAmong.title", { total: data.total, unit: label })}
       subtitle={t("distributeAmong.subtitle", { unit: label, remaining })}
+      maxWidthClassName="max-w-xl"
       footer={<ConfirmButton onClick={handleConfirm} disabled={!isValid} />}
     >
       <div className="mb-4 space-y-3">

--- a/client/src/hooks/__tests__/useInspectHoverProps.test.tsx
+++ b/client/src/hooks/__tests__/useInspectHoverProps.test.tsx
@@ -12,6 +12,15 @@ function HoverPropsHarness() {
   return <div data-testid="card" {...hoverProps(OBJECT_ID)} />;
 }
 
+function ModalHoverPropsHarness() {
+  const hoverProps = useInspectHoverProps();
+  return (
+    <div data-card-preview-dock="side">
+      <div data-testid="card" {...hoverProps(OBJECT_ID)} />
+    </div>
+  );
+}
+
 // React derives onPointerEnter/onPointerLeave from pointerover/pointerout, which
 // is what fireEvent.pointerEnter/pointerLeave fire — a hand-built
 // `new PointerEvent("pointerenter")` would reach no handler at all.
@@ -20,7 +29,12 @@ describe("useInspectHoverProps", () => {
     vi.useFakeTimers();
     Object.defineProperty(window, "innerWidth", { configurable: true, value: 1920 });
     usePreferencesStore.setState({ cardPreviewMode: "follow", cardPreviewHoverDelayMs: 0 });
-    useUiStore.setState({ inspectedObjectId: null, hoveredObjectId: null, previewSticky: false });
+    useUiStore.setState({
+      inspectedObjectId: null,
+      hoveredObjectId: null,
+      previewPlacement: "cursor",
+      previewSticky: false,
+    });
   });
 
   afterEach(() => {
@@ -50,6 +64,14 @@ describe("useInspectHoverProps", () => {
     fireEvent.pointerEnter(screen.getByTestId("card"), { pointerType: "mouse" });
 
     expect(useUiStore.getState().inspectedObjectId).toBe(OBJECT_ID);
+  });
+
+  it("docks previews opened from a modal", () => {
+    render(<ModalHoverPropsHarness />);
+
+    fireEvent.pointerEnter(screen.getByTestId("card"), { pointerType: "mouse" });
+
+    expect(useUiStore.getState().previewPlacement).toBe("side");
   });
 
   // A pen genuinely hovers, so it is deliberately treated like a mouse; only

--- a/client/src/hooks/__tests__/useInspectHoverProps.test.tsx
+++ b/client/src/hooks/__tests__/useInspectHoverProps.test.tsx
@@ -21,6 +21,16 @@ function ModalHoverPropsHarness() {
   );
 }
 
+function TwoCardHoverPropsHarness() {
+  const hoverProps = useInspectHoverProps();
+  return (
+    <>
+      <div data-testid="card-one" {...hoverProps(OBJECT_ID)} />
+      <div data-testid="card-two" {...hoverProps(OBJECT_ID + 1)} />
+    </>
+  );
+}
+
 // React derives onPointerEnter/onPointerLeave from pointerover/pointerout, which
 // is what fireEvent.pointerEnter/pointerLeave fire — a hand-built
 // `new PointerEvent("pointerenter")` would reach no handler at all.
@@ -132,6 +142,30 @@ describe("useInspectHoverProps", () => {
 
     expect(useUiStore.getState().inspectedObjectId).toBeNull();
     expect(useUiStore.getState().previewSticky).toBe(false);
+  });
+
+  it("keeps the first touch as the armed preview target", () => {
+    render(<TwoCardHoverPropsHarness />);
+
+    fireEvent.pointerDown(screen.getByTestId("card-one"), {
+      button: 0,
+      clientX: 10,
+      clientY: 10,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: "touch",
+    });
+    fireEvent.pointerDown(screen.getByTestId("card-two"), {
+      button: 0,
+      clientX: 20,
+      clientY: 20,
+      isPrimary: false,
+      pointerId: 2,
+      pointerType: "touch",
+    });
+    act(() => vi.advanceTimersByTime(500));
+
+    expect(useUiStore.getState().inspectedObjectId).toBe(OBJECT_ID);
   });
 
   it("keeps the long-press preview open when the finger lifts", () => {

--- a/client/src/hooks/useInspectHoverProps.ts
+++ b/client/src/hooks/useInspectHoverProps.ts
@@ -2,6 +2,7 @@ import { useCallback, useRef } from "react";
 import type React from "react";
 
 import { useUiStore } from "../stores/uiStore.ts";
+import type { PreviewPlacement } from "../stores/uiStore.ts";
 import { useLongPress } from "./useLongPress.ts";
 import type { ObjectId } from "../adapter/types.ts";
 
@@ -39,12 +40,18 @@ export function useInspectHoverProps() {
   // Which card most recently began a press — lets the single shared long-press
   // timer resolve the correct id on fire (one active pointer at a time).
   const pressedIdRef = useRef<ObjectId | null>(null);
+  const pressedPlacementRef = useRef<PreviewPlacement>("cursor");
   const { handlers: longPressHandlers, firedRef } = useLongPress(
     useCallback(() => {
       if (pressedIdRef.current != null) {
         // Long-press is explicit intent (a hold past the timer), so bypass hover
         // latency and show the sticky preview immediately, mirroring useCardHover.
-        inspectObject(pressedIdRef.current, undefined, "immediate");
+        inspectObject(
+          pressedIdRef.current,
+          undefined,
+          "immediate",
+          pressedPlacementRef.current,
+        );
         setPreviewSticky(true);
       }
     }, [inspectObject, setPreviewSticky]),
@@ -70,11 +77,19 @@ export function useInspectHoverProps() {
       onPointerDown: (e: React.PointerEvent) => {
         if (e.pointerType !== "touch") return;
         pressedIdRef.current = id;
+        pressedPlacementRef.current = e.currentTarget.closest("[data-card-preview-dock='side']")
+          ? "side"
+          : "cursor";
         armLongPress(e);
       },
       onPointerEnter: (e: React.PointerEvent) => {
         if (e.pointerType === "touch") return;
-        inspectObject(id);
+        inspectObject(
+          id,
+          undefined,
+          "hover",
+          e.currentTarget.closest("[data-card-preview-dock='side']") ? "side" : "cursor",
+        );
       },
       onPointerLeave: (e: React.PointerEvent) => {
         cancelLongPress(e);

--- a/client/src/hooks/useInspectHoverProps.ts
+++ b/client/src/hooks/useInspectHoverProps.ts
@@ -75,7 +75,7 @@ export function useInspectHoverProps() {
       // complementary: an unrecognized pointerType still hovers, and only a
       // known finger gets the long-press substitute.
       onPointerDown: (e: React.PointerEvent) => {
-        if (e.pointerType !== "touch") return;
+        if (e.pointerType !== "touch" || !e.isPrimary || e.button !== 0) return;
         pressedIdRef.current = id;
         pressedPlacementRef.current = e.currentTarget.closest("[data-card-preview-dock='side']")
           ? "side"

--- a/client/src/hooks/useLongPress.ts
+++ b/client/src/hooks/useLongPress.ts
@@ -84,6 +84,7 @@ export function useLongPress(
       // Ignore capture-release mismatches from browsers/test harnesses.
     }
     clear();
+    firedRef.current = false;
   }, [clear]);
 
   const onPointerLeave = useCallback((e: React.PointerEvent) => {

--- a/client/src/pages/DeckBuilderPage.tsx
+++ b/client/src/pages/DeckBuilderPage.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from "react-router";
 import type { GameFormat } from "../adapter/types";
 import { useAudioContext } from "../audio/useAudioContext";
 import { HoverCardPreview } from "../components/card/HoverCardPreview";
+import type { CardHoverInfo } from "../components/card/CardPreview";
 import { DeckBuilder } from "../components/deck-builder/DeckBuilder";
 import type { BrowserLegalityFilter, CardSearchFilters } from "../components/deck-builder/CardSearch";
 import { DECK_CONSTRUCTION_FORMATS } from "../data/formatRegistry";
@@ -57,7 +58,7 @@ export function DeckBuilderPage() {
   useAudioContext("deck_builder");
   useAltToggle();
   const [searchParams, setSearchParams] = useSearchParams();
-  const [hoveredCard, setHoveredCard] = useState<{ name: string; scryfallId?: string } | null>(null);
+  const [hoveredCard, setHoveredCard] = useState<CardHoverInfo | null>(null);
   const format = parseDeckFormat(searchParams.get("format"));
   const initialDeckName = searchParams.get("create") === "1"
     ? null
@@ -121,9 +122,7 @@ export function DeckBuilderPage() {
   return (
     <div className="menu-scene deck-builder-shell flex flex-col overflow-hidden">
       <DeckBuilder
-        onCardHover={useCallback((name: string | null, scryfallId?: string) => {
-          setHoveredCard(name ? { name, scryfallId } : null);
-        }, [])}
+        onCardHover={setHoveredCard}
         format={format}
         onFormatChange={handleFormatChange}
         initialDeckName={initialDeckName}

--- a/client/src/stores/uiStore.ts
+++ b/client/src/stores/uiStore.ts
@@ -14,6 +14,7 @@ import type { FilterKey } from "../components/modal/cardChoice/gridSelection";
  * attacker, so the value is a set rather than a single attacker id.
  */
 export type BlockerAssignments = Map<ObjectId, Set<ObjectId>>;
+export type PreviewPlacement = "cursor" | "side";
 
 /** Flatten the UI's per-blocker representation at the engine action boundary. */
 export function blockerAssignmentPairs(
@@ -162,6 +163,8 @@ interface UiStoreState {
   hoveredObjectId: ObjectId | null;
   inspectedObjectId: ObjectId | null;
   inspectedFaceIndex: number;
+  /** Presentation requested by the element that opened the current preview. */
+  previewPlacement: PreviewPlacement;
   altHeld: boolean;
   /** Whether the Shift key is currently held. Drives the "shift" card-preview
    *  mode (preview shows only while Shift is down). Tracked as held-state via
@@ -260,7 +263,12 @@ interface UiStoreActions {
   hoverObject: (id: ObjectId | null) => void;
   /** `timing` defaults to "hover" (subject to the configurable preview latency);
    *  "immediate" bypasses the delay for explicit-intent triggers (long-press). */
-  inspectObject: (id: ObjectId | null, faceIndex?: number, timing?: "hover" | "immediate") => void;
+  inspectObject: (
+    id: ObjectId | null,
+    faceIndex?: number,
+    timing?: "hover" | "immediate",
+    placement?: PreviewPlacement,
+  ) => void;
   dismissPreview: () => void;
   setAltHeld: (held: boolean) => void;
   setShiftHeld: (held: boolean) => void;
@@ -332,6 +340,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   hoveredObjectId: null,
   inspectedObjectId: null,
   inspectedFaceIndex: 0,
+  previewPlacement: "cursor",
   altHeld: false,
   shiftHeld: false,
   selectedCardIds: [],
@@ -376,7 +385,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
   setDebugHighlightedPlayerId: (id) => set({ debugHighlightedPlayerId: id }),
   setAltHeld: (held) => set({ altHeld: held }),
   setShiftHeld: (held) => set({ shiftHeld: held }),
-  inspectObject: (id, faceIndex, timing = "hover") => {
+  inspectObject: (id, faceIndex, timing = "hover", placement = "cursor") => {
     if (id != null) {
       // Setting a new inspection target: cancel any pending clear, and drop a
       // pending delayed-show for a previous target before scheduling this one.
@@ -389,6 +398,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
         set((s) => ({
           inspectedObjectId: id,
           inspectedFaceIndex: faceIndex ?? 0,
+          previewPlacement: placement,
           // Inspecting a DIFFERENT object replaces (dismisses) the previous
           // preview, so a pinned Alt state must not leak onto the new card —
           // Alt has to be pressed again to expand it. Re-inspecting the SAME
@@ -465,7 +475,13 @@ export const useUiStore = create<UiStore>()((set, get) => ({
           return;
         }
         cancelPendingShow();
-        set({ inspectedObjectId: null, inspectedFaceIndex: 0, previewSticky: false, altHeld: false });
+        set({
+          inspectedObjectId: null,
+          inspectedFaceIndex: 0,
+          previewPlacement: "cursor",
+          previewSticky: false,
+          altHeld: false,
+        });
       }, 50);
     }
   },
@@ -479,6 +495,7 @@ export const useUiStore = create<UiStore>()((set, get) => ({
     set({
       inspectedObjectId: null,
       inspectedFaceIndex: 0,
+      previewPlacement: "cursor",
       previewSticky: false,
       altHeld: false,
       mobileHandGesture: null,


### PR DESCRIPTION
Fixes modal card-preview placement and incorporates the outstanding hover-preview review feedback from the now-merged #7040.

- Dock card previews to the side within dialogs and compact the counter-distribution modal.
- Preserve complete printing-aware hover metadata through deck-builder components.
- Add touch long-press previews in Limited deck builder without moving cards.

Validation: formatting, Clippy, parser gates, 619 Oracle-parser tests, and 2,020 phase-AI tests passed. Card-data generation could not run because data/mtgjson/AtomicCards.json is absent locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Card previews opened from dialogs and choice screens now dock consistently to the side.
  * Touch users can long-press cards in limited deck building to preview them without adding them.
  * Card previews now preserve printing details for more accurate results across deck-building views.
* **Bug Fixes**
  * Improved preview behavior when switching between cursor-based and side-docked placement.
  * Side-docked modal previews now use a more suitable display width.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->