### PR TITLE
test(client): make the scryfall TMP_COUNT probe portable across wc variants

### DIFF
--- a/client/src/services/__tests__/scryfall.test.ts
+++ b/client/src/services/__tests__/scryfall.test.ts
@@ -1071,7 +1071,9 @@ curl() {
 ${mvDef}${validatorDef}scryfall_download "https://example.invalid/data.json" "${dest}"${validatorArg} 2> "${stderr}"
 echo "RC=$?"
 echo "MV_CALLED=\${MV_CALLED:-0}"
-echo "TMP_COUNT=$(ls -1 "${dest}".* 2>/dev/null | wc -l)"
+# BSD wc -l left-pads its count ("       0") where GNU wc -l does not, so strip
+# the padding here to keep the TMP_COUNT= assertions exact on macOS and Linux.
+echo "TMP_COUNT=$(ls -1 "${dest}".* 2>/dev/null | wc -l | tr -d '[:space:]')"
 `;
 
     const out = execFileSync("bash", ["-c", finalScript], {


### PR DESCRIPTION
The mv-failure recovery cases assert /TMP_COUNT=0/, but the probe emitted
the count straight from `wc -l`. BSD wc left-pads its output ("       0")
where GNU wc does not, so all four cases failed on macOS while passing on
CI's Linux -- leaving the local `test-frontend` suite permanently red for
a reason unrelated to the code under test.

Strip the padding at the producer rather than loosening the four
assertions, so they stay exact and a genuinely malformed count still
fails. No production script uses `wc` here; this is test-harness only.
