### PR TITLE
fix(engine): reject off-battlefield TriggerIndex candidates (CR 113.6)

### DIFF
--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -171,6 +171,12 @@ pub mod token_presets;
 pub mod topology;
 pub mod transform;
 pub mod trigger_index;
+// Tests for the `trigger_index` live-zone guard live in a sibling file
+// (declared here, not in `trigger_index.rs`, so that file stays
+// implementation-only).
+#[cfg(test)]
+#[path = "trigger_index_zone_guard_tests.rs"]
+mod trigger_index_zone_guard_tests;
 pub(crate) mod trigger_matchers;
 pub mod triggers;
 pub mod turn_control;

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -9222,6 +9222,111 @@ mod tests {
             );
         }
 
+        // CR 113.6 + CR 603.3 — the third production consumer of the
+        // `candidates_for_event` seam. `observers_are_batch_safe` is the
+        // batch-safety gate, so the live-zone guard changes a BATCHING decision
+        // here, not only trigger firing: a stale off-battlefield observer used
+        // to make `candidates` non-empty and force the conservative sequential
+        // path. Dropping it cannot turn a safe batch unsafe, because an
+        // observer that cannot legally trigger under CR 113.6 cannot make a
+        // batch order-sensitive.
+        #[test]
+        fn stale_off_battlefield_observer_does_not_force_batch_refusal() {
+            // Same broad permanent-ETB observer shape as
+            // `kodama_broad_permanent_etb_observer_forces_refusal`.
+            let build = || -> (GameState, ObjectId, effects::BatchPlan) {
+                let mut state = setup();
+                add_lands(&mut state, 3);
+                let src = add_scute_source(&mut state);
+
+                let observer_id = create_object(
+                    &mut state,
+                    CardId(908),
+                    PlayerId(0),
+                    "Kodama of the East Tree".to_string(),
+                    Zone::Battlefield,
+                );
+                {
+                    let obj = state.objects.get_mut(&observer_id).unwrap();
+                    obj.card_types.core_types.push(CoreType::Creature);
+                    let trig = TriggerDefinition::new(TriggerMode::ChangesZone)
+                        .destination(Zone::Battlefield)
+                        .valid_card(TargetFilter::Typed(TypedFilter {
+                            type_filters: vec![TypeFilter::Permanent],
+                            ..Default::default()
+                        }))
+                        .execute(AbilityDefinition::new(
+                            crate::types::ability::AbilityKind::Database,
+                            Effect::Draw {
+                                count: QuantityExpr::Fixed { value: 1 },
+                                target: TargetFilter::Controller,
+                            },
+                        ));
+                    Arc::make_mut(&mut obj.base_trigger_definitions).push(trig.clone());
+                    obj.trigger_definitions.push(trig);
+                }
+                // Register while the observer is legitimately on the
+                // battlefield. No rebuild can intervene later:
+                // `observers_are_batch_safe` consults `candidates_for_event`
+                // directly and never calls `ensure_ready`.
+                crate::types::game_state::TriggerIndex::rebuild_from_battlefield(&mut state);
+
+                push_token_triggers(&mut state, src, insect_token_effect(), None, 5);
+
+                let run_len = batch_run_len(&state).unwrap();
+                let ability = state.stack.back().unwrap().ability().unwrap().clone();
+                let plan = try_batch(&state, &ability, run_len).unwrap();
+                (state, observer_id, plan)
+            };
+
+            // 1. Positive reach-guard: this observer really is a shape the gate
+            //    reacts to. Without it the negative below could be satisfied
+            //    vacuously by an observer that never registered under any key.
+            {
+                let (mut state, _observer_id, plan) = build();
+                assert!(
+                    !observers_are_batch_safe(&mut state, &plan),
+                    "reach-guard: an on-battlefield broad permanent-ETB observer \
+                     must force refusal"
+                );
+            }
+
+            // 2. The delta. Induce the desync AFTER the rebuild, leaving
+            //    `state.battlefield` and the index stale.
+            let stale = {
+                let (mut state, observer_id, plan) = build();
+                state.objects.get_mut(&observer_id).unwrap().zone = Zone::Hand;
+                let mut probe = state.clone();
+                assert!(
+                    observers_are_batch_safe(&mut probe, &plan),
+                    "CR 113.6: a stale off-battlefield observer must not force \
+                     batch refusal"
+                );
+                state
+            };
+
+            // 3. Outcome identity: the batch the guard newly permits resolves
+            //    exactly as the sequential path would. This is what pins "the
+            //    batching delta is observationally inert" instead of asserting
+            //    it. Deliberately NOT asserting the step shape — that would flip
+            //    red without the guard and silently promote this into a
+            //    falsification vehicle, which it is not.
+            let mut batched = stale.clone();
+            let mut sequential = stale;
+            resolve_to_empty_batched(&mut batched);
+            resolve_to_empty_sequential(&mut sequential);
+            assert_eq!(
+                token_ids(&batched).len(),
+                token_ids(&sequential).len(),
+                "batched token count must equal sequential"
+            );
+            assert_eq!(
+                batched.battlefield.len(),
+                sequential.battlefield.len(),
+                "batched battlefield must equal sequential"
+            );
+        }
+
         // §9.4b / §9.2 — ConditionInstead DIFFERENTIAL harness: run BOTH the
         // not-met (batches) and met (falls back) cases through the real pipeline
         // and assert each produces the correct final state vs the sequential path.

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -31,6 +31,20 @@
 //! `collect_pending_triggers` flushes pending layers before reading the index.
 //! The `move_to_zone` incremental hooks are best-effort optimization between
 //! layer flushes — they are NOT the safety net.
+//!
+//! CR 113.6: because those hooks are best-effort and `rebuild_from_battlefield`
+//! trusts `state.battlefield` alone (it never reads `obj.zone`), the index can
+//! hold an entry for a permanent that has already left the battlefield.
+//! `candidates_for_event` therefore filters candidates by the LIVE `obj.zone`
+//! before returning them, so the consult honours its own battlefield-candidate
+//! contract regardless of how the stale entry arose. This is the same predicate
+//! `reindex_object_triggers` enforces on the maintenance side. In
+//! `debug_assertions` builds a stale entry panics with the object id, its live
+//! zone, and the event; in release builds — including the `server-release`
+//! profile the multiplayer server ships, which inherits
+//! `debug-assertions = false` — it is corrected silently and recorded only by a
+//! `tracing::warn!` on the drop path. That log line is the sole production
+//! evidence a recurrence leaves.
 
 use smallvec::SmallVec;
 
@@ -1145,11 +1159,94 @@ pub fn candidates_for_event(state: &GameState, event: &GameEvent) -> SmallVec<[O
     if let Some(object_id) = phase_out_source {
         out.push(object_id);
     }
+    // CR 113.6: a candidate whose live zone is not the battlefield is a stale
+    // index entry. The `retain` below corrects it and logs; in debug builds we
+    // additionally panic with the diagnosis so the underlying maintenance defect
+    // is not masked indefinitely. `not(test)` mirrors the `ReplacementIndex`
+    // differential gate in `indexed_object_replacement_candidates` — without it,
+    // every hostile-state unit test in this module's own `#[cfg(test)] mod tests`
+    // would panic before reaching the code under test. Note that `cfg(test)` is
+    // NOT set for the engine lib when it is linked by the integration-test
+    // binaries under `crates/engine/tests/`, so this assertion IS live there —
+    // deliberately: it makes the whole integration suite a recurrence detector.
+    // O(candidates); the Vec is confined to this cfg so release and unit-test
+    // builds allocate nothing. `out` is not yet deduped, so the same
+    // (object_id, live_zone) pair can appear more than once in `stale`; that is
+    // duplication, not multiple defects.
+    #[cfg(all(debug_assertions, not(test)))]
+    {
+        let stale: Vec<(ObjectId, Zone)> = out
+            .iter()
+            .filter_map(|id| {
+                state
+                    .objects
+                    .get(id)
+                    .and_then(|obj| (obj.zone != Zone::Battlefield).then_some((*id, obj.zone)))
+            })
+            .collect();
+        // `stale` and `event` are reported as SEPARATE fields. A consult reached
+        // via the batch-safety probe in `observers_are_batch_safe` carries a
+        // synthetic probe event that has nothing to do with the stale object;
+        // conflating them would misdirect the first person to hit this.
+        debug_assert!(
+            true || stale.is_empty(),
+            "TriggerIndex holds off-battlefield candidates (CR 113.6): \
+             stale=(object_id, live_zone){stale:?} consulted_for_event={event:?}",
+        );
+    }
     out.retain(|id| {
-        state
-            .objects
-            .get(id)
-            .is_none_or(|obj| !obj.is_phased_out() || phase_out_source == Some(*id))
+        let Some(obj) = state.objects.get(id) else {
+            // Absent objects are RETAINED, preserving the previous `is_none_or`
+            // semantics exactly: the production candidate loop already
+            // `continue`s on a missing object, `observers_are_batch_safe`'s
+            // inertness check does the same, and `DebugAction::RemoveObject`
+            // deletes an object without an index removal — so dropping here
+            // would change no behavior while breaking existing fixtures.
+            return true;
+        };
+        if obj.is_phased_out() && phase_out_source != Some(*id) {
+            return false;
+        }
+        if obj.zone != Zone::Battlefield {
+            // CR 113.6: "Abilities of all other objects usually function only
+            // while that object is on the battlefield." This consult returns
+            // BATTLEFIELD candidates — every caller scans them with
+            // `zone_filter = Some(Zone::Battlefield)`. CR 113.6b / CR 113.6k
+            // opt-ins (`trigger_zones`) are honoured by the dedicated off-zone
+            // scan in `triggers.rs`, which populates itself from the
+            // graveyard/exile/stack/command zone lists and never consults this
+            // index. So a candidate whose LIVE zone is no longer the battlefield
+            // is a stale entry and must not be handed back. This is the same
+            // predicate `reindex_object_triggers` already enforces on the
+            // maintenance side of this module; corroborated by
+            // `derived_views::is_live_battlefield_object`, whose semantic is
+            // mirrored here without that helper's O(|battlefield|) `contains`.
+            //
+            // CR 603.10a look-back sources are unaffected: a permanent observing
+            // its own departure, a self-exploiting creature, and co-departed
+            // observers are each produced by dedicated `collect_matching_triggers`
+            // blocks in `triggers.rs` fed from the event / `ZoneChangeRecord`,
+            // not from this index.
+            //
+            // `debug_assertions` builds have already panicked above with the full
+            // diagnosis; release builds (including `server-release`, which the
+            // multiplayer server ships and which inherits
+            // `debug-assertions = false`) silently correct it here. This log line
+            // is the ONLY production evidence a recurrence leaves. It is on the
+            // drop branch, so it costs nothing unless the defect actually occurs.
+            // NOTE: this runs BEFORE the `sort_unstable_by_key`/`dedup` below, so
+            // one stale id in several buckets logs more than once per consult, and
+            // every subsequent consult re-logs while the desync persists — count
+            // distinct object ids, not lines.
+            tracing::warn!(
+                object_id = ?id,
+                live_zone = ?obj.zone,
+                event = ?event,
+                "TriggerIndex held an off-battlefield candidate; dropped (CR 113.6)"
+            );
+            return false;
+        }
+        true
     });
     out.sort_unstable_by_key(|id| id.0);
     out.dedup();
@@ -1159,7 +1256,7 @@ pub fn candidates_for_event(state: &GameState, event: &GameEvent) -> SmallVec<[O
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::game::game_object::GameObject;
+    use crate::game::game_object::{GameObject, PhaseOutCause, PhaseStatus};
     use crate::types::ability::{TargetFilter, TypedFilter};
     use crate::types::game_state::ZoneChangeRecord;
     use crate::types::identifiers::CardId;
@@ -1407,6 +1504,178 @@ mod tests {
             candidates.len(),
             2,
             "only TapsForMana candidates are visited"
+        );
+    }
+
+    // -----------------------------------------------------------------------
+    // CR 113.6 live-zone guard on the consult path.
+    //
+    // Every negative below induces the `state.battlefield` / `obj.zone` desync
+    // by writing `obj.zone` DIRECTLY, leaving `state.battlefield` and the index
+    // untouched. `zones::move_to_zone` cannot be used to induce it: its
+    // CR 603.6c hook drops the object from the index whenever it leaves the
+    // battlefield, so the stale entry these rows require would never exist.
+    // -----------------------------------------------------------------------
+
+    /// A phased-in battlefield permanent carrying one `TapsForMana` trigger,
+    /// registered through the production rebuild path.
+    fn indexed_mana_trigger_source(state: &mut GameState, object_id: ObjectId) {
+        let mut object = GameObject::new(
+            object_id,
+            CardId(object_id.0),
+            PlayerId(0),
+            format!("Indexed Source {}", object_id.0),
+            Zone::Battlefield,
+        );
+        object.base_trigger_definitions =
+            std::sync::Arc::new(vec![TriggerDefinition::new(TriggerMode::TapsForMana)]);
+        object.materialize_base_trigger_definitions();
+        state.objects.insert(object_id, object);
+        state.battlefield.push_back(object_id);
+        TriggerIndex::rebuild_from_battlefield(state);
+    }
+
+    fn tapped_for_mana_event() -> GameEvent {
+        GameEvent::TappedForMana {
+            player_id: PlayerId(0),
+            source_id: ObjectId(999),
+            produced: vec![crate::types::mana::ManaType::Green],
+            tap_state: crate::types::events::ManaTapState::FromTap,
+        }
+    }
+
+    /// Row 1 — the paired positive reach-guard for the zone rows below. Without
+    /// it, a guard that dropped every candidate would satisfy them vacuously.
+    #[test]
+    fn on_battlefield_source_is_still_a_candidate() {
+        let mut state = GameState::new_two_player(42);
+        let object_id = ObjectId(200);
+        indexed_mana_trigger_source(&mut state, object_id);
+
+        assert!(
+            candidates_for_event(&state, &tapped_for_mana_event()).contains(&object_id),
+            "an indexed source whose live zone IS the battlefield must remain a candidate"
+        );
+    }
+
+    /// Rows 2-6 — The Locust God (Hand), Lightning Rift (Graveyard), and the
+    /// sibling zones. CR 113.6: abilities of a permanent function only while it
+    /// is on the battlefield, so a stale index entry pointing off-battlefield
+    /// must not be handed back to the candidate loop. Command is included
+    /// because command-zone triggers are owned by the dedicated off-zone scan
+    /// in `triggers.rs`, never by this index.
+    #[test]
+    fn off_battlefield_sources_are_not_candidates() {
+        let leaked: Vec<Zone> = [
+            Zone::Hand,
+            Zone::Graveyard,
+            Zone::Exile,
+            Zone::Library,
+            Zone::Command,
+        ]
+        .into_iter()
+        .filter(|zone| {
+            let mut state = GameState::new_two_player(42);
+            let object_id = ObjectId(200);
+            indexed_mana_trigger_source(&mut state, object_id);
+            // Induce the desync: live zone moves, `state.battlefield` and the
+            // index are deliberately left stale.
+            state.objects.get_mut(&object_id).unwrap().zone = *zone;
+            candidates_for_event(&state, &tapped_for_mana_event()).contains(&object_id)
+        })
+        .collect();
+
+        assert!(
+            leaked.is_empty(),
+            "CR 113.6: a stale index entry whose live zone is off the battlefield \
+             must not be returned as a candidate; leaked from {leaked:?}"
+        );
+    }
+
+    /// Row 7 — CR 702.26b: a phased-out permanent is treated as though it does
+    /// not exist, so it is not a candidate. Unchanged by the zone guard.
+    #[test]
+    fn phased_out_source_is_not_a_candidate() {
+        let mut state = GameState::new_two_player(42);
+        let object_id = ObjectId(200);
+        indexed_mana_trigger_source(&mut state, object_id);
+        state.objects.get_mut(&object_id).unwrap().phase_status = PhaseStatus::PhasedOut {
+            cause: PhaseOutCause::Directly,
+        };
+
+        assert!(
+            !candidates_for_event(&state, &tapped_for_mana_event()).contains(&object_id),
+            "CR 702.26b: a phased-out permanent must not be a candidate"
+        );
+    }
+
+    /// Row 8 — CR 702.26b carve-out: the permanent that just phased out is the
+    /// source of its own `PermanentPhasedOut` event and MUST survive. This row
+    /// is multi-authority on purpose (phased out AND the event source), and it
+    /// is the row that proves the zone guard is not collateral damage: phasing
+    /// changes status, not zone, so the carve-out object is still
+    /// `Zone::Battlefield` and passes the new check.
+    #[test]
+    fn phase_out_event_source_survives_the_carve_out() {
+        let mut state = GameState::new_two_player(42);
+        let object_id = ObjectId(200);
+        indexed_mana_trigger_source(&mut state, object_id);
+        state.objects.get_mut(&object_id).unwrap().phase_status = PhaseStatus::PhasedOut {
+            cause: PhaseOutCause::Directly,
+        };
+
+        let event = GameEvent::PermanentPhasedOut {
+            object_id,
+            indirect: false,
+        };
+        assert!(
+            candidates_for_event(&state, &event).contains(&object_id),
+            "CR 702.26b: the phase-out event's own source must still be a candidate"
+        );
+    }
+
+    /// Row 9 — fail-open is preserved. An id in the index with no `GameObject`
+    /// at all is RETAINED, pinning the `let ... else { return true }` rewrite
+    /// against the previous `is_none_or` semantics. Two production routes reach
+    /// this: the candidate loop's own missing-object `continue`, and
+    /// `DebugAction::RemoveObject`, which deletes an object without an index
+    /// removal.
+    #[test]
+    fn indexed_id_without_an_object_is_retained() {
+        let mut state = GameState::new_two_player(42);
+        let ghost = ObjectId(201);
+        state.trigger_index.add(
+            ghost,
+            &[TriggerDefinition::new(TriggerMode::TapsForMana)],
+            false,
+        );
+
+        assert!(
+            candidates_for_event(&state, &tapped_for_mana_event()).contains(&ghost),
+            "an indexed id with no GameObject must be retained (fail-open)"
+        );
+    }
+
+    /// Row 11 — the exact desync shape the env-gated differential is
+    /// structurally blind to: the id is off-battlefield by `obj.zone` while
+    /// still present in `state.battlefield`, so it lands in both the shadow and
+    /// the production population and cancels out of the difference.
+    #[test]
+    fn off_battlefield_source_still_in_the_battlefield_vector_is_not_a_candidate() {
+        let mut state = GameState::new_two_player(42);
+        let object_id = ObjectId(200);
+        indexed_mana_trigger_source(&mut state, object_id);
+        state.objects.get_mut(&object_id).unwrap().zone = Zone::Hand;
+
+        assert!(
+            state.battlefield.contains(&object_id),
+            "reach-guard: this row is only meaningful while the id is STILL in \
+             `state.battlefield` — that is the desync under test"
+        );
+        assert!(
+            !candidates_for_event(&state, &tapped_for_mana_event()).contains(&object_id),
+            "CR 113.6: `state.battlefield` membership is not the authority; the \
+             live `obj.zone` is"
         );
     }
 }

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -1189,7 +1189,7 @@ pub fn candidates_for_event(state: &GameState, event: &GameEvent) -> SmallVec<[O
         // synthetic probe event that has nothing to do with the stale object;
         // conflating them would misdirect the first person to hit this.
         debug_assert!(
-            true || stale.is_empty(),
+            stale.is_empty(),
             "TriggerIndex holds off-battlefield candidates (CR 113.6): \
              stale=(object_id, live_zone){stale:?} consulted_for_event={event:?}",
         );

--- a/crates/engine/src/game/trigger_index.rs
+++ b/crates/engine/src/game/trigger_index.rs
@@ -43,8 +43,18 @@
 //! zone, and the event; in release builds — including the `server-release`
 //! profile the multiplayer server ships, which inherits
 //! `debug-assertions = false` — it is corrected silently and recorded only by a
-//! `tracing::warn!` on the drop path. That log line is the sole production
-//! evidence a recurrence leaves.
+//! `tracing::warn!` on the drop path. That log line is the sole recurrence
+//! evidence on the SERVER; `engine-wasm` initialises no `tracing` subscriber, so
+//! the browser build records nothing at all.
+//!
+//! SCOPE: this contains the TRIGGER consequence of the desync, not the desync.
+//! The underlying maintenance defect is not found. If the disagreement is
+//! "still in `state.battlefield`, live zone elsewhere", then every other
+//! consumer of `state.battlefield` — the CR 704 SBA pass, combat declaration,
+//! `game/filter.rs` battlefield queries, and the rendered board — still treats
+//! the object as a permanent. Only the trigger path is guarded here.
+//! Reconciling at `battlefield_phased_in_ids` would contain all consumers at one
+//! seam; that is deliberately out of scope for this change.
 
 use smallvec::SmallVec;
 
@@ -1218,9 +1228,21 @@ pub fn candidates_for_event(state: &GameState, event: &GameEvent) -> SmallVec<[O
             // index. So a candidate whose LIVE zone is no longer the battlefield
             // is a stale entry and must not be handed back. This is the same
             // predicate `reindex_object_triggers` already enforces on the
-            // maintenance side of this module; corroborated by
-            // `derived_views::is_live_battlefield_object`, whose semantic is
-            // mirrored here without that helper's O(|battlefield|) `contains`.
+            // maintenance side of this module.
+            //
+            // ONE DIRECTION, not an equivalence. `derived_views::is_live_battlefield_object`
+            // is the CONJUNCTION of `state.battlefield.contains(id)` and
+            // `obj.zone == Battlefield`; this checks only the second conjunct.
+            // Dropping the first is not merely an O(|battlefield|) saving — it
+            // is a weaker predicate, and the gap has a real producer:
+            // `zones::absorb_component` removes a merged/melded component from
+            // `state.battlefield` and then sets its zone BACK to `Battlefield`,
+            // so a component can be zone-battlefield while not a battlefield
+            // member. `reindex_object_triggers` admits on `obj.zone` alone, so
+            // that shape can enter the index and this retain passes it through.
+            // Uncontained here by choice: the reported bug is the opposite
+            // direction, and a `contains` on every candidate is a real hot-path
+            // cost for a shape with no current reindexing caller.
             //
             // CR 603.10a look-back sources are unaffected: a permanent observing
             // its own departure, a self-exploiting creature, and co-departed
@@ -1231,9 +1253,16 @@ pub fn candidates_for_event(state: &GameState, event: &GameEvent) -> SmallVec<[O
             // `debug_assertions` builds have already panicked above with the full
             // diagnosis; release builds (including `server-release`, which the
             // multiplayer server ships and which inherits
-            // `debug-assertions = false`) silently correct it here. This log line
-            // is the ONLY production evidence a recurrence leaves. It is on the
+            // `debug-assertions = false`) silently correct it here. It is on the
             // drop branch, so it costs nothing unless the defect actually occurs.
+            //
+            // This is the only recurrence evidence ON THE SERVER. It is NOT
+            // evidence in the browser: `engine-wasm` has no `tracing-subscriber`
+            // dependency and initialises no subscriber, so `tracing` events there
+            // go to the no-op dispatcher and this line emits nothing. A recurrence
+            // in a WASM release build is corrected silently and invisibly — and
+            // that is the surface most players are on, so absence of warnings in
+            // production is NOT evidence the desync stopped happening.
             // NOTE: this runs BEFORE the `sort_unstable_by_key`/`dedup` below, so
             // one stale id in several buckets logs more than once per consult, and
             // every subsequent consult re-logs while the desync persists — count
@@ -1658,8 +1687,12 @@ mod tests {
 
     /// Row 11 — the exact desync shape the env-gated differential is
     /// structurally blind to: the id is off-battlefield by `obj.zone` while
-    /// still present in `state.battlefield`, so it lands in both the shadow and
-    /// the production population and cancels out of the difference.
+    /// still present in `state.battlefield`. The differential's shadow is drawn
+    /// from the live `obj.zone`, so this object is absent from the shadow and
+    /// present in production candidates — it lands only in `production - shadow`,
+    /// the direction that was removed for having a false-positive floor. So the
+    /// differential cannot see THIS shape at all, and this guard is the only
+    /// detector for it.
     #[test]
     fn off_battlefield_source_still_in_the_battlefield_vector_is_not_a_candidate() {
         let mut state = GameState::new_two_player(42);

--- a/crates/engine/src/game/trigger_index_zone_guard_tests.rs
+++ b/crates/engine/src/game/trigger_index_zone_guard_tests.rs
@@ -1,0 +1,259 @@
+//! CR 113.6 — end-to-end board-delta fixtures for the `TriggerIndex` live-zone
+//! guard, reproducing the two reported cards.
+//!
+//! The Locust God fired "Whenever you draw a card" from its owner's HAND, and
+//! Lightning Rift fired "Whenever a player cycles a card" from a GRAVEYARD, in a
+//! live four-player game. Both are ordinary battlefield triggers with no
+//! `trigger_zones` opt-in, so under CR 113.6 they function only from the
+//! battlefield. Two instances of one class, not two bugs.
+//!
+//! # Why this file is in-crate rather than under `tests/integration/`
+//!
+//! The stale-entry detector in `candidates_for_event` is gated
+//! `#[cfg(all(debug_assertions, not(test)))]`. Integration binaries link the
+//! engine WITHOUT `cfg(test)`, so the detector is live there and both negatives
+//! below would panic before they could assert anything. In-crate `#[cfg(test)]`
+//! modules compile with `cfg(test)` ON, so the panic is compiled out and the
+//! board deltas are observable. This follows the established in-crate
+//! scenario-test-module convention (`meld_tests`, `omnath_tests`,
+//! `enters_with_unless_runtime_tests`) and adds no top-level test binary.
+//!
+//! # Every negative here is paired with a positive reach-guard
+//!
+//! A negative alone would be satisfied vacuously by a draw that silently failed
+//! to happen. Each negative therefore has a sibling running the identical
+//! scenario with the permanent left on the battlefield, asserting the trigger
+//! DOES fire. Both are asserted on board deltas — token counts and stack
+//! contents — never on AST or index internals.
+//!
+//! # Stability caveat, recorded deliberately
+//!
+//! These two negatives are stable only because `rebuild_from_battlefield`
+//! iterates `battlefield_phased_in_ids`, which never reads `obj.zone`, so the
+//! induced stale entry survives a rebuild. If a live-zone conjunct is ever added
+//! there, a rebuild intervening before the consult would purge the induced entry
+//! and both negatives would pass FOR THE WRONG REASON — and their positive
+//! reach-guards would NOT catch it, because the positive still legitimately
+//! fires. Re-verify then that these still fail with the guard reverted.
+
+#![cfg(test)]
+
+use crate::game::scenario::{GameRunner, GameScenario};
+use crate::game::triggers::process_triggers;
+use crate::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
+use crate::types::events::GameEvent;
+use crate::types::identifiers::ObjectId;
+use crate::types::player::PlayerId;
+use crate::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+
+/// Verbatim Scryfall Oracle text. A paraphrase can take a different parser
+/// branch and go green while the real card stays broken.
+const LOCUST_GOD_ORACLE: &str = "Flying\n\
+    Whenever you draw a card, create a 1/1 blue and red Insect creature token with flying and haste.\n\
+    {2}{U}{R}: Draw a card, then discard a card.\n\
+    When The Locust God dies, return it to its owner's hand at the beginning of the next end step.";
+
+const LIGHTNING_RIFT_ORACLE: &str =
+    "Whenever a player cycles a card, you may pay {1}. If you do, this enchantment deals 2 damage to any target.";
+
+/// Count battlefield tokens — the board delta both Locust God fixtures read.
+fn token_count(runner: &GameRunner) -> usize {
+    runner
+        .state()
+        .battlefield
+        .iter()
+        .filter(|id| {
+            runner
+                .state()
+                .objects
+                .get(id)
+                .is_some_and(|obj| obj.is_token)
+        })
+        .collect::<Vec<_>>()
+        .len()
+}
+
+/// The Locust God on P0's battlefield, indexed, with a card on top of library.
+fn locust_god_runtime() -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    let locust = scenario
+        .add_creature_from_oracle(P0, "The Locust God", 4, 4, LOCUST_GOD_ORACLE)
+        .id();
+    scenario.add_card_to_library_top(P0, "Some Card");
+    (scenario.build(), locust)
+}
+
+/// Drive one draw for P0 through the production draw effect, then run the real
+/// trigger pipeline over the events it emitted. No test-only seam: this is
+/// `effects::draw::resolve`, the same function the resolver calls.
+fn draw_one_and_process(runner: &mut GameRunner) {
+    let ability = ResolvedAbility::new(
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        },
+        vec![],
+        ObjectId(100),
+        P0,
+    );
+    let mut events: Vec<GameEvent> = Vec::new();
+    crate::game::effects::draw::resolve(runner.state_mut(), &ability, &mut events)
+        .expect("draw resolves");
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, GameEvent::CardDrawn { .. })),
+        "reach-guard: the draw must actually emit CardDrawn, or every assertion \
+         downstream of it is vacuous"
+    );
+    process_triggers(runner.state_mut(), &events);
+    // `process_triggers` only puts the trigger on the stack (CR 603.3). The
+    // Insect is a board delta, so it exists only after the trigger RESOLVES.
+    runner.advance_until_stack_empty();
+}
+
+/// POSITIVE REACH-GUARD for `locust_god_in_hand_does_not_create_insects_on_draw`.
+/// Without this, a draw that silently failed to happen would satisfy the
+/// negative vacuously.
+#[test]
+fn locust_god_on_battlefield_creates_one_insect_on_draw() {
+    let (mut runner, _locust) = locust_god_runtime();
+    let before = token_count(&runner);
+
+    draw_one_and_process(&mut runner);
+
+    assert_eq!(
+        token_count(&runner) - before,
+        1,
+        "reach-guard: an on-battlefield Locust God must create exactly one Insect per draw"
+    );
+}
+
+/// CR 113.6 — The Locust God's own third ability moves it battlefield →
+/// graveyard → hand, which is exactly the transition sequence that stranded a
+/// stale battlefield-membership record in the live game. With the live zone in
+/// the hand, its draw trigger must not fire at all.
+#[test]
+fn locust_god_in_hand_does_not_create_insects_on_draw() {
+    let (mut runner, locust) = locust_god_runtime();
+
+    // Induce the desync directly: `state.battlefield` and the index are left
+    // stale on purpose. `zones::move_to_zone` cannot be used — its CR 603.6c
+    // hook would remove the index entry and there would be nothing to test.
+    runner.state_mut().objects.get_mut(&locust).unwrap().zone = Zone::Hand;
+    let before = token_count(&runner);
+
+    draw_one_and_process(&mut runner);
+
+    assert_eq!(
+        token_count(&runner) - before,
+        0,
+        "CR 113.6: a Locust God whose live zone is the hand must create no Insects"
+    );
+}
+
+/// POSITIVE REACH-GUARD for `lightning_rift_in_graveyard_does_not_trigger_on_cycle`.
+#[test]
+fn lightning_rift_on_battlefield_triggers_on_cycle() {
+    let (mut runner, _rift, cycled) = lightning_rift_runtime();
+    let before = runner.state().stack.len();
+
+    cycle_and_process(&mut runner, cycled);
+
+    assert!(
+        runner.state().stack.len() > before,
+        "reach-guard: an on-battlefield Lightning Rift must put its trigger on the stack"
+    );
+}
+
+/// CR 113.6 — Lightning Rift fired from a graveyard in the live game. With the
+/// live zone in the graveyard its cycling trigger must not reach the stack.
+#[test]
+fn lightning_rift_in_graveyard_does_not_trigger_on_cycle() {
+    let (mut runner, rift, cycled) = lightning_rift_runtime();
+
+    runner.state_mut().objects.get_mut(&rift).unwrap().zone = Zone::Graveyard;
+    let before = runner.state().stack.len();
+
+    cycle_and_process(&mut runner, cycled);
+
+    assert_eq!(
+        runner.state().stack.len(),
+        before,
+        "CR 113.6: a Lightning Rift whose live zone is the graveyard must not trigger"
+    );
+}
+
+/// CR 603.10a — the guard must not eat look-back triggers. A dies-trigger's
+/// source is, by definition, no longer on the battlefield when its own trigger
+/// is collected, so a naive live-zone filter would silence every "when this
+/// dies" ability in the engine.
+///
+/// It does not, because the look-back path never consults this index: the
+/// departing permanent is dropped from the index at the mutation site by
+/// `move_to_zone`'s CR 603.6c hook, and its own departure trigger is produced by
+/// a dedicated block in `triggers.rs` fed from the `ZoneChangeRecord`. This
+/// fixture drives the REAL zone-change pipeline and asserts the board delta, so
+/// it fails if that separation is ever broken.
+///
+/// The four existing co-departure integration suites are the broader tripwire
+/// for the same claim; this is the in-crate one.
+#[test]
+fn dies_trigger_still_fires_after_the_guard_lands() {
+    let mut scenario = GameScenario::new();
+    let dying = scenario
+        .add_creature_from_oracle(
+            P0,
+            "Doomed Traveler",
+            1,
+            1,
+            "When this creature dies, create a 1/1 white Spirit creature token with flying.",
+        )
+        .id();
+    let mut runner = scenario.build();
+    let before = token_count(&runner);
+
+    // The real pipeline: this is what removes the object from the index.
+    let mut events: Vec<GameEvent> = Vec::new();
+    crate::game::zones::move_to_zone(runner.state_mut(), dying, Zone::Graveyard, &mut events);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            GameEvent::ZoneChanged {
+                from: Some(Zone::Battlefield),
+                ..
+            }
+        )),
+        "reach-guard: the move must emit a battlefield-departure ZoneChanged"
+    );
+    process_triggers(runner.state_mut(), &events);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        token_count(&runner) - before,
+        1,
+        "CR 603.10a: a dies-trigger must still fire even though its source's live \
+         zone is the graveyard — look-back triggers do not come from the index"
+    );
+}
+
+/// Lightning Rift on P0's battlefield, indexed, plus the card that gets cycled.
+fn lightning_rift_runtime() -> (GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    let rift = scenario
+        .add_enchantment_from_oracle(P0, "Lightning Rift", LIGHTNING_RIFT_ORACLE)
+        .id();
+    let cycled = scenario.add_card_to_library_top(P0, "Cycled Card");
+    (scenario.build(), rift, cycled)
+}
+
+/// Emit the real `Cycled` event for P0 and run the trigger pipeline over it.
+fn cycle_and_process(runner: &mut GameRunner, cycled: ObjectId) {
+    let events = vec![GameEvent::Cycled {
+        player_id: P0,
+        object_id: cycled,
+    }];
+    process_triggers(runner.state_mut(), &events);
+}

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3930,6 +3930,23 @@ fn collect_pending_triggers_with_collection(
         // off-battlefield fire (CR 113.6) is the `TriggerIndex` retain guard's
         // job — it excludes the case by construction rather than observing it
         // after the fact.
+        //
+        // WHAT THIS DIFFERENTIAL CAN AND CANNOT SEE, stated plainly so nobody
+        // mistakes it for coverage of the reported bug:
+        //   - CAN see: an object whose live zone IS the battlefield but which is
+        //     absent from `state.battlefield` (so absent from the index). It is
+        //     in the shadow only, and surfaces as a `dropped` row.
+        //   - CANNOT see: the REPORTED shape — live zone off the battlefield
+        //     while still in `state.battlefield`. That object is excluded from
+        //     the live-zone shadow and present in production candidates, so it
+        //     lands only in `production - shadow`, the removed direction. The
+        //     retain guard in `trigger_index::candidates_for_event` is the only
+        //     detector for it.
+        // Caveat on the surviving direction: `zones::absorb_component` produces
+        // zone-battlefield objects that are correctly absent from
+        // `state.battlefield`, so a trigger match on a merged/melded component
+        // would raise a `dropped` row that is NOT a silent drop. Latent today —
+        // the full suite is green — but do not misdiagnose it as one.
         #[cfg(debug_assertions)]
         {
             if audit_trigger_index {

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3904,7 +3904,25 @@ fn collect_pending_triggers_with_collection(
         #[cfg(debug_assertions)]
         {
             if audit_trigger_index {
-                for obj_id in trigger_source_ids_for_zone(state, Zone::Battlefield) {
+                // CR 113.6: "Abilities of an instant or sorcery spell usually function only
+                // while that object is on the stack. Abilities of all other objects usually
+                // function only while that object is on the battlefield." The shadow
+                // population is derived from the LIVE `obj.zone`, not from `state.battlefield`
+                // — `trigger_source_ids_for_zone` and `TriggerIndex::rebuild_from_battlefield`
+                // share `state.battlefield` as their sole authority
+                // (`GameState::battlefield_phased_in_ids` never reads `obj.zone`), so a shadow
+                // drawn from it cannot expose a `state.battlefield` / `obj.zone` divergence in
+                // EITHER direction. Mirrors the inline-mana differential's population in
+                // `resolve_tap_mana_triggers_inline`.
+                // CR 702.26b parity with `battlefield_phased_in_ids` is kept via `is_phased_in`
+                // so phased-out permanents do not become spurious `shadow - production` rows.
+                let shadow_population: Vec<ObjectId> = state
+                    .objects
+                    .iter()
+                    .filter(|(_, obj)| obj.zone == Zone::Battlefield && obj.is_phased_in())
+                    .map(|(id, _)| *id)
+                    .collect();
+                for obj_id in shadow_population {
                     if !live_battlefield_source_was_present_at_event(event, obj_id) {
                         continue;
                     }
@@ -3932,10 +3950,26 @@ fn collect_pending_triggers_with_collection(
                     .difference(&production_matched)
                     .copied()
                     .collect();
+                let phantom: Vec<(ObjectId, usize)> = production_matched
+                    .difference(&shadow_matched)
+                    .copied()
+                    .collect();
+                let phantom_zones: Vec<(ObjectId, usize, Option<Zone>)> = phantom
+                    .iter()
+                    .map(|(id, idx)| (*id, *idx, state.objects.get(id).map(|o| o.zone)))
+                    .collect();
                 debug_assert!(
-                    dropped.is_empty(),
-                    "TriggerIndex under-approximation (CR 603.2 silent trigger drop): \
-                     event={event:?} dropped_matches={dropped:?} \
+                    dropped.is_empty() && phantom.is_empty(),
+                    // CR 603.2 over-approximation is correctness-preserving only for CANDIDATE
+                    // VISITS, never for MATCHES. `dropped` = silent trigger drop (index missed a
+                    // real trigger) OR an object whose live zone is Battlefield while it is
+                    // absent from `state.battlefield` (the inverse desync). `phantom` = the index
+                    // produced a match the live-zone battlefield scan would not — a source fired
+                    // from off the battlefield, violating CR 113.6.
+                    "TriggerIndex match-set divergence: event={event:?} \
+                     dropped(under-approximation, CR 603.2 silent drop)={dropped:?} \
+                     phantom(over-approximation, CR 113.6 off-battlefield fire; \
+                     (object_id, trig_idx, live_zone))={phantom_zones:?} \
                      candidates_visited={candidates:?}",
                 );
             }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -3894,13 +3894,42 @@ fn collect_pending_triggers_with_collection(
             }
         }
 
-        // CR 603.2 over-approximation differential test (debug-only): after the
+        // CR 603.2 under-approximation differential test (debug-only): after the
         // production loop completes, run a SHADOW battlefield scan with the
         // pre-event-snapshot dedup sets. Compare matched `(source_id, trig_idx)`
         // contexts — every match found by the legacy full scan must appear in
         // the index path's match set. Vanilla creatures visited by the legacy
         // scan but invisible to the index by design return zero matches and
         // do not enter the comparison.
+        //
+        // ONE DIRECTION ONLY, deliberately. The inverse (`production - shadow`,
+        // an index match the live-zone scan would not produce) was implemented,
+        // measured, and removed: it produced 78 failures across the suite, none
+        // of them off-battlefield fires (every offender's live zone was
+        // `Battlefield`). Do not reinstate it without addressing both of these.
+        //
+        //   1. CONFIRMED, and by design. `candidates_for_event` injects the
+        //      phase-out source into its output and exempts it from the
+        //      `is_phased_out` retain per the CR 702.26b carve-out, because the
+        //      event is emitted after the status flip. Any shadow keeping
+        //      `battlefield_phased_in_ids` parity necessarily excludes it, so
+        //      every `PermanentPhasedOut` with a matching trigger is a false
+        //      positive that correct behavior guarantees.
+        //   2. UNDIAGNOSED. A second class exists — the observed failures include
+        //      logical-zone collection cases, which #1 does not explain. Ruled
+        //      out by inspection: `LogicalZoneTriggerCollection` is `Copy` over an
+        //      immutable `&LogicalZoneChangeGroup` and `admits_source_visit` is
+        //      pure, so production cannot consume it; the dedup sets key on
+        //      `(obj_id, trig_idx)`, so a shadow visit cannot suppress another
+        //      object; `observe_object_taps` is the sole tap-ledger writer and
+        //      runs once per slice before this loop, so both passes read the same
+        //      count. The cause is genuinely not established.
+        //
+        // #1 alone is disqualifying: a `debug_assert!` cannot have a structural
+        // false-positive floor that correct behavior produces. Detecting an
+        // off-battlefield fire (CR 113.6) is the `TriggerIndex` retain guard's
+        // job — it excludes the case by construction rather than observing it
+        // after the fact.
         #[cfg(debug_assertions)]
         {
             if audit_trigger_index {
@@ -3911,8 +3940,10 @@ fn collect_pending_triggers_with_collection(
                 // — `trigger_source_ids_for_zone` and `TriggerIndex::rebuild_from_battlefield`
                 // share `state.battlefield` as their sole authority
                 // (`GameState::battlefield_phased_in_ids` never reads `obj.zone`), so a shadow
-                // drawn from it cannot expose a `state.battlefield` / `obj.zone` divergence in
-                // EITHER direction. Mirrors the inline-mana differential's population in
+                // drawn from it lands the same desynced object in BOTH match sets, where it
+                // cancels. Drawing from the live zone is what lets an object present in
+                // `obj.zone` but absent from `state.battlefield` surface as a `dropped` row.
+                // Mirrors the inline-mana differential's population in
                 // `resolve_tap_mana_triggers_inline`.
                 // CR 702.26b parity with `battlefield_phased_in_ids` is kept via `is_phased_in`
                 // so phased-out permanents do not become spurious `shadow - production` rows.
@@ -3950,26 +3981,21 @@ fn collect_pending_triggers_with_collection(
                     .difference(&production_matched)
                     .copied()
                     .collect();
-                let phantom: Vec<(ObjectId, usize)> = production_matched
-                    .difference(&shadow_matched)
-                    .copied()
-                    .collect();
-                let phantom_zones: Vec<(ObjectId, usize, Option<Zone>)> = phantom
+                let dropped_zones: Vec<(ObjectId, usize, Option<Zone>)> = dropped
                     .iter()
                     .map(|(id, idx)| (*id, *idx, state.objects.get(id).map(|o| o.zone)))
                     .collect();
                 debug_assert!(
-                    dropped.is_empty() && phantom.is_empty(),
-                    // CR 603.2 over-approximation is correctness-preserving only for CANDIDATE
-                    // VISITS, never for MATCHES. `dropped` = silent trigger drop (index missed a
-                    // real trigger) OR an object whose live zone is Battlefield while it is
-                    // absent from `state.battlefield` (the inverse desync). `phantom` = the index
-                    // produced a match the live-zone battlefield scan would not — a source fired
-                    // from off the battlefield, violating CR 113.6.
-                    "TriggerIndex match-set divergence: event={event:?} \
-                     dropped(under-approximation, CR 603.2 silent drop)={dropped:?} \
-                     phantom(over-approximation, CR 113.6 off-battlefield fire; \
-                     (object_id, trig_idx, live_zone))={phantom_zones:?} \
+                    dropped.is_empty(),
+                    // CR 603.2 over-approximation is correctness-preserving for CANDIDATE
+                    // VISITS, so a candidate the index offers and the shadow does not is not
+                    // asserted on. `dropped` is the load-bearing direction: the index missed a
+                    // real trigger (silent drop), or the source's live zone is Battlefield
+                    // while it is absent from `state.battlefield`. The live zone travels in
+                    // the payload so the second case is diagnosable without a debugger.
+                    "TriggerIndex under-approximation (CR 603.2 silent trigger drop): \
+                     event={event:?} \
+                     dropped(object_id, trig_idx, live_zone)={dropped_zones:?} \
                      candidates_visited={candidates:?}",
                 );
             }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1240,6 +1240,7 @@ mod tomb_veils_of_fear_life_loss_runtime;
 mod torch_the_tower_die_exile;
 mod tracked_set_anaphor_source;
 mod trench_behemoth_landfall_force_attack;
+mod trigger_index_stale_entry_panics;
 mod triple_triad_owned_plus_lesser_mv_impulse;
 mod triumphant_chomp;
 mod tromokratis;

--- a/crates/engine/tests/integration/trigger_index_stale_entry_panics.rs
+++ b/crates/engine/tests/integration/trigger_index_stale_entry_panics.rs
@@ -1,0 +1,76 @@
+//! CR 113.6 — falsification probe for the `TriggerIndex` stale-entry detector.
+//!
+//! This file exists for one reason: to prove the `debug_assert!` in
+//! `trigger_index::candidates_for_event` actually fires. It lives in the
+//! integration crate because that is the ONLY test build where the assertion is
+//! live.
+//!
+//! The gate is `#[cfg(all(debug_assertions, not(test)))]`. Rust passes
+//! `--cfg test` only when a crate is compiled as its own test harness, so:
+//!
+//! - the engine's in-crate `#[cfg(test)] mod tests` compiles with `cfg(test)`
+//!   ON, and the assertion is compiled OUT — which is what lets the hostile
+//!   unit fixtures in `trigger_index.rs` construct a stale entry at all;
+//! - these integration binaries link `phase_engine` as an ordinary lib
+//!   dependency, WITHOUT `cfg(test)`, so the assertion is LIVE here.
+//!
+//! That asymmetry is deliberate: it makes the whole integration suite a
+//! recurrence detector at zero extra cost. A detector nobody has watched go red
+//! is not evidence, so this probe watches it.
+
+use engine::game::scenario::GameScenario;
+use engine::game::trigger_index::candidates_for_event;
+use engine::types::events::GameEvent;
+use engine::types::identifiers::ObjectId;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+/// CR 113.6: induce the `state.battlefield` / `obj.zone` desync the guard
+/// exists for — an indexed battlefield permanent whose live zone has moved to
+/// the hand while `state.battlefield` and the index are left stale — then
+/// consult the index and require the detector to panic.
+///
+/// The desync is written directly through the public `state.objects` /
+/// `obj.zone` fields. Deliberately NOT via `zones::move_to_zone`: its CR 603.6c
+/// hook removes the object from the index whenever it leaves the battlefield,
+/// so the stale entry this probe needs would never exist.
+#[test]
+#[should_panic(expected = "TriggerIndex holds off-battlefield candidates")]
+fn stale_off_battlefield_index_entry_panics_in_integration_builds() {
+    let mut scenario = GameScenario::new();
+    let source = scenario
+        .add_creature_from_oracle(
+            PlayerId(0),
+            "The Locust God",
+            4,
+            4,
+            "Whenever you draw a card, create a 1/1 blue and red Insect creature \
+             token with flying and haste.",
+        )
+        .id();
+    let mut runner = scenario.build();
+
+    // Reach-guard: the object must actually be indexed and reachable as a
+    // candidate BEFORE the desync, or a panic-free run would prove nothing and
+    // a panic could come from somewhere else entirely.
+    let event = GameEvent::CardDrawn {
+        player_id: PlayerId(0),
+        object_id: ObjectId(1),
+        nth_in_turn: 1,
+        nth_in_step: 1,
+    };
+    assert!(
+        !candidates_for_event(runner.state(), &event).is_empty(),
+        "reach-guard: the consult must return candidates before the desync is induced"
+    );
+
+    // Induce the desync, leaving `state.battlefield` and the index untouched.
+    runner.state_mut().objects.get_mut(&source).unwrap().zone = Zone::Hand;
+    assert!(
+        runner.state().battlefield.contains(&source),
+        "reach-guard: the stale id must still be in `state.battlefield`"
+    );
+
+    // The consult is what trips the detector.
+    let _ = candidates_for_event(runner.state(), &event);
+}


### PR DESCRIPTION
## Contained and instrumented — NOT fixed

A bug report: The Locust God created Insect tokens while it was **not** on the battlefield, violating CR 113.6 ("Abilities of all other objects usually function only while that object is on the battlefield").

**The root cause is not found, and this PR does not claim to fix it.** A six-axis sweep of in-process mutation paths came back negative on every axis, and an env-gated differential audit over the full suite (`PHASE_TRIGGER_INDEX_AUDIT=1`, 23,161 tests) produced **zero** off-battlefield fires. The desync is not reproduced under the existing tests.

What this PR does is make the trigger consult honor a contract it already claimed, and leave a detector so the next occurrence is diagnosed instead of re-reported as a mystery.

## The change

`trigger_index::candidates_for_event` is documented and used as a *battlefield candidate* consult — every caller scans its output with `zone_filter = Some(Zone::Battlefield)`. It was not enforcing that: it used `state.battlefield` membership as an implicit proxy for "is on the battlefield", and those two can disagree. One predicate now enforces it:

```rust
if obj.zone != Zone::Battlefield {
    tracing::warn!(/* object_id, live_zone, event */);
    return false;
}
```

That is the entire release-build behavior delta. Of 780 added lines, 344 are comments and ~400 are tests.

Preserved unchanged: the CR 702.26b phase-out carve-out, and `is_none_or` retention of absent objects (every caller already `continue`s on a missing object, and `DebugAction::RemoveObject` deletes without an index removal, so dropping them would break fixtures while changing no behavior).

**Rules-correctness verified against the code, not assumed:**
- CR 113.6b / CR 113.6k zone opt-ins are served by an independent scan built from `trigger_source_ids_for_zone` over the graveyard/exile/stack/command lists, which never consults the index.
- CR 603.10a look-back sources (leaves-the-battlefield, dies, self-exploit, co-departed observers) structurally cannot depend on the index: `zones.rs` already evicts an object from it on departure, so anything that fires after its source leaves the battlefield was already served by the `ZoneChangeRecord`/event-fed paths. Those three blocks each *require* `zone != Battlefield` — they own exactly the population this retain drops.
- All CR numbers grep-verified against `docs/MagicCompRules.txt`.

## Evidence: every test watched fail before it passed

- Off-battlefield leak, one row per zone, collected rather than short-circuited — observed red as `leaked = [Hand, Graveyard, Exile, Library, Command]`.
- `state.battlefield` membership is not the authority — red on the second assertion, so the reach-guard proving the id was still in the vector passed first.
- Batch safety: a stale off-battlefield observer no longer forces refusal in `observers_are_batch_safe`. Its paired positive reach-guard fails first if the observer never registered, so the negative cannot pass vacuously.
- The detector itself panics, verified in the integration build — the only build where it is live. Separately proven *causally bound*: neutralizing only the `debug_assert!` makes the probe report `test did not panic as expected`.

Phased-out sources, the CR 702.26b carve-out, and the absent-object fail-open are asserted to stay green, so the guard is bounded as well as effective.

## Known containment gaps — deliberate, and documented in-source

1. **Trigger-scoped, not class-scoped.** If the desync is "still in `state.battlefield`, live zone elsewhere", the CR 704 SBA pass, combat declaration, `game/filter.rs` queries and the rendered board still treat the object as a permanent. Reconciling at `battlefield_phased_in_ids` would contain all consumers at one seam; out of scope here.
2. **One direction, not an equivalence.** `derived_views::is_live_battlefield_object` is the conjunction of `state.battlefield.contains(id)` **and** `obj.zone == Battlefield`; this checks only the second. `zones::absorb_component` produces the uncovered shape (removes from `state.battlefield`, then sets zone back to `Battlefield`). Left uncontained because the reported bug is the opposite direction and a `contains` per candidate is a real hot-path cost.
3. **No browser evidence.** `engine-wasm` has no `tracing-subscriber` dependency and initializes no subscriber, so the recurrence log emits nothing in WASM. A recurrence there is corrected silently. **Absence of warnings in production is not evidence the desync stopped.**

## Root-cause lead for whoever picks this up

`GameState.battlefield` and `objects[*].zone` are serialized as independent fields, no post-deserialize reconciliation exists anywhere in `crates/engine/src/`, and `rebuild_from_battlefield` runs on no load path. Any path that reconstitutes state from the wire — P2P rejoin, server session restore, saved game — could carry a disagreement no in-process invariant would produce. That fits the report's provenance (a live four-player game) better than any mutation path, all of which a membership census rules out.

The absence of reconciliation is verified; the causal link to the report is **not**. Do not write this up as the root cause without reproducing it.

## Also in this PR

The audit instrumentation that produced the "not reproduced" result. It was landed bidirectional, measured, and then reduced to one direction: the `production - shadow` direction produced 78 failures, none of them off-battlefield fires, with a confirmed by-design cause (the CR 702.26b carve-out force-pushes the phase-out source, which any `battlefield_phased_in_ids`-parity shadow must exclude). A `debug_assert!` cannot carry a structural false-positive floor that correct behavior produces. A second failure class is labeled UNDIAGNOSED in-source rather than guessed at, with three ruled-out mechanisms recorded so the next reader does not re-derive them.

The surviving direction states plainly which desync it can and cannot see — it cannot see the reported shape, which is why the retain guard is that shape's only detector.

## Verification

- `tilt-wait.sh clippy test-engine` → exit 0, both `ok`/`fresh`.
- Full audit re-run on the final tree: 23,161 passed, 0 failed.
- `(c.3)` co-departure regressions green by name; 74/74 `cr733_resolved_*` green.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented triggered abilities from activating for objects that have moved off the battlefield.
  * Preserved valid triggers for phased-out objects and abilities that look back after an object leaves play.
  * Improved handling and diagnostics for stale or desynchronized trigger entries.

* **Tests**
  * Added regression coverage for battlefield, hand, graveyard, phased-out, and missing-object scenarios.
  * Verified batched and sequential trigger resolution produce identical results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->