### PR TITLE
ship/fix effect zone duplicate selection 7064

### DIFF
--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -1,5 +1,5 @@
 // engine-citation-gate: symbol anchors only
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::types::ability::{
     AbilityCost, ChoiceType, ChosenAttribute, Effect, EffectKind, GuessOutcome, LibraryPosition,
@@ -4810,6 +4810,16 @@ pub(super) fn handle_resolution_choice(
                     count,
                     chosen.len()
                 )));
+            }
+
+            // CR 608.2d: A resolving player can't choose an illegal option.
+            // Choosing one eligible card more than once is not a legal
+            // selection of distinct cards for this effect.
+            let unique_chosen: HashSet<ObjectId> = chosen.iter().copied().collect();
+            if unique_chosen.len() != chosen.len() {
+                return Err(EngineError::InvalidAction(
+                    "Selected cards must be distinct".to_string(),
+                ));
             }
 
             for card_id in &chosen {

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -787,9 +787,9 @@ pub(crate) fn move_object_with_terminal(
     //   - discover.rs:~103 (put-back of unhit cards)
     //   - put_on_top.rs:~153 / ~158
     //   - cascade.rs:~154 (bottom-in-random-order)
-    // Migrating each onto this arm is a guaranteed no-op today (zero pool
-    // `Moved` defs target the library) but pins the redirect consult for the
-    // future. Re-verify the census before lifting:
+    // Migrating each onto this arm is a production no-op today (the only
+    // `Moved` definition targeting the library is test-only) but pins the
+    // redirect consult for the future. Re-verify the census before lifting:
     //   rg -o 'destination_zone\(Zone::\w+\)' crates/engine/src | sort | uniq -c
     if let Some(position) = req.placement.clone() {
         if req.to == Zone::Library {

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -778,15 +778,16 @@ pub(crate) fn move_object_with_terminal(
     // requested index and the tail's auto-shuffle is suppressed (CR 701.24a: a
     // placement is not a shuffle).
     //
-    // Phase E tranche 2: 11 raw library-position callers still bypass this consult
-    // by calling `zones::move_to_library_position` / `move_to_library_at_index`
-    // directly instead of routing through `move_object`'s placement arm. They are:
-    //   - engine_resolution_choices.rs (×5)
-    //   - reveal_until.rs:~400 (`shuffle_to_bottom`)
-    //   - drawn_this_turn_choice.rs:~114
-    //   - discover.rs:~103 (put-back of unhit cards)
-    //   - put_on_top.rs:~153 / ~158
-    //   - cascade.rs:~154 (bottom-in-random-order)
+    // Phase E tranche 2: six production raw library-position callers still bypass
+    // this consult by calling `zones::move_to_library_position` /
+    // `move_to_library_at_index` directly instead of routing through
+    // `move_object`'s placement arm. They are:
+    //   - engine_resolution_choices.rs: clash return (~2989)
+    //   - engine_resolution_choices.rs: EffectZoneChoice bottom placement (~7260)
+    //   - engine_resolution_choices.rs: EffectZoneChoice top/Nth placement (~7272)
+    //   - engine_resolution_choices.rs: EffectZoneChoice mixed-source reorder (~7333)
+    //   - zone_pipeline.rs: exempt library-placement delivery (~821)
+    //   - zone_pipeline.rs: replacement delivery placement (~2353)
     // Migrating each onto this arm is a production no-op today (the only
     // `Moved` definition targeting the library is test-only) but pins the
     // redirect consult for the future. Re-verify the census before lifting:

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -9722,6 +9722,97 @@ fn effect_zone_put_on_top_hand_redirect_pauses_before_tail() {
     );
 }
 
+/// A resolver-created PutAtLibraryPosition choice must reject a repeated card
+/// before mutating its source zone, while preserving selection-order placement
+/// for a distinct follow-up choice.
+#[test]
+fn effect_zone_put_at_library_position_rejects_duplicate_selection() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Put-On-Top Duplicate Selection Source", 1, 1)
+        .id();
+    let first = scenario
+        .add_spell_to_hand(P0, "Put-On-Top Duplicate First", true)
+        .id();
+    let second = scenario
+        .add_spell_to_hand(P0, "Put-On-Top Duplicate Second", true)
+        .id();
+    let marker = scenario
+        .add_spell_to_library_top(P0, "Put-On-Top Duplicate Marker", true)
+        .id();
+    let ability = ResolvedAbility::new(
+        Effect::PutAtLibraryPosition {
+            target: TargetFilter::Typed(
+                TypedFilter::card().properties(vec![FilterProp::InZone { zone: Zone::Hand }]),
+            ),
+            count: QuantityExpr::Fixed { value: 2 },
+            position: engine::types::ability::LibraryPosition::Top,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    let mut runner = scenario.build();
+    runner.state_mut().players[P0.0 as usize].library = im::vector![marker];
+    let mut initial_events = Vec::new();
+
+    resolve_ability_chain(runner.state_mut(), &ability, &mut initial_events, 0)
+        .expect("PutAtLibraryPosition reaches its real resolver-created choice");
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::EffectZoneChoice {
+            effect_kind: EffectKind::PutAtLibraryPosition,
+            ..
+        }
+    ));
+
+    let duplicate = runner
+        .act(GameAction::SelectCards {
+            cards: vec![first, first],
+        })
+        .expect_err("a repeated card is not a legal resolution-time choice");
+    assert!(
+        matches!(duplicate, engine::game::EngineError::InvalidAction(message) if message == "Selected cards must be distinct")
+    );
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::EffectZoneChoice {
+            effect_kind: EffectKind::PutAtLibraryPosition,
+            ..
+        }
+    ));
+    assert_eq!(runner.state().objects[&first].zone, Zone::Hand);
+    assert_eq!(runner.state().objects[&second].zone, Zone::Hand);
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .library
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![marker],
+        "rejected input must not mutate the library"
+    );
+
+    let completed = runner
+        .act(GameAction::SelectCards {
+            cards: vec![first, second],
+        })
+        .expect("distinct eligible cards resolve the existing choice");
+    assert!(matches!(completed.waiting_for, WaitingFor::Priority { .. }));
+    assert_eq!(runner.state().objects[&first].zone, Zone::Library);
+    assert_eq!(runner.state().objects[&second].zone, Zone::Library);
+    assert_eq!(
+        runner.state().players[P0.0 as usize]
+            .library
+            .iter()
+            .copied()
+            .collect::<Vec<_>>(),
+        vec![first, second, marker],
+        "distinct selection retains the requested top order"
+    );
+}
+
 /// W-164-B: a mixed hand/library selection preserves the raw synchronous order
 /// when only the hand members use the replacement-aware delivery path.
 #[test]


### PR DESCRIPTION
- **fix(engine): reject duplicate effect-zone selections**
- **docs(engine): correct library placement caller census**
