### PR TITLE
ship/fix library reorder zone events 7063

### DIFF
--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -8080,7 +8080,7 @@ fn surveil_keep_on_top(
     player: crate::types::player::PlayerId,
     top_cards: &[ObjectId],
 ) {
-    zones::reorder_within_library(state, player, top_cards, 0);
+    zones::reorder_within_library(state, player, top_cards, Some(0));
 }
 
 fn resume_with_error_propagation(

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -8481,7 +8481,7 @@ pub(crate) fn filter_consumed_trigger_events(
 ///     (`tests/integration/search_delivery_observer_dedup.rs`) pins the
 ///     allocator->event fidelity link in production on ONE emit path only
 ///     (`zone_pipeline` -> `move_to_zone` ordinary arm -> `zones.rs:1362`). It
-///     is a sentinel, not a census over the three emit sites.
+///     is a sentinel, not a census over the four emit sites.
 ///
 /// KNOWN UNCLOSED GUARD GAP, deliberately out of scope here:
 /// `apply_resolved_zone_change` compares the recorder's return value against

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -8410,11 +8410,12 @@ pub(crate) fn filter_consumed_trigger_events(
 /// ONE occurrence emitted twice — precisely what this filter should drop — and
 /// two DISTINCT occurrences are never byte-identical, because
 /// `ZoneChangeRecord::turn_zone_change_index` participates in `GameEvent`
-/// equality and is unique per occurrence within a turn. All THREE production
+/// equality and is unique per occurrence within a turn. All FOUR production
 /// sites that construct a `ZoneChanged` into an event buffer ship the index
 /// `restrictions::record_zone_change` assigned: `move_to_zone`'s tail,
-/// `record_and_emit_entry_from_no_zone`, and `merge.rs`'s CR 730.3c component
-/// split. A within-library reorder emits neither a `ZoneChanged` event nor a
+/// `record_and_emit_entry_from_no_zone`, `move_to_library_at_index` when
+/// `from != Zone::Library`, and `merge.rs`'s CR 730.3c component split. Only
+/// the same-library reorder branch emits neither a `ZoneChanged` event nor a
 /// ledger row. The recorder is the SOLE grower of `state.zone_changes_this_turn` (it reads
 /// `len()`, stamps, then pushes) and the ledger never shrinks mid-turn, so two
 /// distinct occurrences in one turn carry distinct indices and the `position()`

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -8410,12 +8410,12 @@ pub(crate) fn filter_consumed_trigger_events(
 /// ONE occurrence emitted twice — precisely what this filter should drop — and
 /// two DISTINCT occurrences are never byte-identical, because
 /// `ZoneChangeRecord::turn_zone_change_index` participates in `GameEvent`
-/// equality and is unique per occurrence within a turn. All FOUR production
+/// equality and is unique per occurrence within a turn. All THREE production
 /// sites that construct a `ZoneChanged` into an event buffer ship the index
 /// `restrictions::record_zone_change` assigned: `move_to_zone`'s tail,
-/// `record_and_emit_entry_from_no_zone`, the library-insert path
-/// `move_to_library_at_index`, and `merge.rs`'s CR 730.3c component split. That
-/// recorder is the SOLE grower of `state.zone_changes_this_turn` (it reads
+/// `record_and_emit_entry_from_no_zone`, and `merge.rs`'s CR 730.3c component
+/// split. A within-library reorder emits neither a `ZoneChanged` event nor a
+/// ledger row. The recorder is the SOLE grower of `state.zone_changes_this_turn` (it reads
 /// `len()`, stamps, then pushes) and the ledger never shrinks mid-turn, so two
 /// distinct occurrences in one turn carry distinct indices and the `position()`
 /// match below cannot cross-consume them.
@@ -8433,18 +8433,7 @@ pub(crate) fn filter_consumed_trigger_events(
 ///     snapshots of one object taken at different incarnations. Inert on any
 ///     path that does not bump the incarnation.
 ///
-/// EXCEPTION — THE WITHIN-ZONE REPOSITION FAMILY. For `move_to_library_at_index`
-/// with `from == Zone::Library` (the CR 400.7 zero-bump branch at
-/// `zones.rs:1809-1812`, emit at `zones.rs:1829`; CR 701.20b — revealing a card
-/// does not move it) all THREE additional separators are dead at once and
-/// `turn_zone_change_index` is the SOLE discriminator. Those events are
-/// reachable as witnesses here — library-destination `ChangesZoneAll` observers
-/// exist in the card pool and `zone_change_clause_matches`
-/// (`trigger_matchers.rs:1091-1130`) has no same-zone guard — AND inside a
-/// `park_search_observer_triggers` slice, via the tutor-to-top class
-/// (`SearchLibrary` -> `Shuffle` -> `PutAtLibraryPosition{Top}`).
-///
-/// SCOPE: LIVE PLAY. Four residuals remain open, are filed as issues, and are
+/// SCOPE: LIVE PLAY. Three residuals remain open, are filed as issues, and are
 /// NOT closed by this filter:
 ///   * R1 — the index is PER-TURN. `zone_changes_this_turn` is cleared at
 ///     `turns.rs:1253`, while `start_next_turn` does NOT clear
@@ -8453,22 +8442,11 @@ pub(crate) fn filter_consumed_trigger_events(
 ///     drain-at-priority (`drain_deferred_trigger_queue_unchecked`), by the
 ///     CR 724 end-the-turn / end-the-combat-phase EFFECTS, and by elimination
 ///     — NOT by the turn boundary.
-///     For the within-zone reposition family the two incarnation
-///     fields add NO cross-turn protection, because they were never advanced.
 ///   * R2 — deserialized states bypass the recorder.
 ///     `PersistedGameState::into_game_state` (`types/game_state.rs:9024`)
 ///     reconstructs `ZoneChanged` straight into live buffers with
 ///     `#[serde(default)]` indices, so a restored state can carry index `0` on
 ///     distinct occurrences. Pre-existing and out of scope here.
-///   * R3 — `zone_change_clause_matches` (`trigger_matchers.rs:1091-1130`) has
-///     no same-zone guard, so a library-destination `ChangesZoneAll` observer
-///     fires on a within-library reposition, which CR 400.7 / CR 701.20b say is
-///     not a zone change. The record is ALSO written to the ledger
-///     unconditionally (`zones.rs:1818-1819`), so
-///     `QuantityRef::ZoneChangeCountThisTurn` / `ZoneChangeAggregateThisTurn`
-///     (`game/quantity.rs:4125-4165`) over-count and the ledger-subscript
-///     consumers (`types/ability.rs:23726`, `:23841`) see phantom rows. Gating
-///     the matcher alone would NOT fix those.
 ///   * R4 — the `EffectZoneChoice` `SelectCards` arm
 ///     (`engine_resolution_choices.rs:4493-4540`) validates length, membership
 ///     and current zone but NOT uniqueness, unlike its FIVE sibling arms:
@@ -8495,15 +8473,14 @@ pub(crate) fn filter_consumed_trigger_events(
 ///     the R4 validation gap, and when R4 is fixed the action would be REJECTED,
 ///     so such a row would fail to construct and go RED — coupling it to a
 ///     validation gap rather than to the invariant.
-///   * `within_library_repositions_are_separated_only_by_the_occurrence_index`
-///     (`game/zones.rs`) pins the exception family at the library-insert emit
-///     site with the real mover: zero bump, `entered_incarnation` `None` on
-///     both, identical `trigger_source_context`, consecutive indices.
+///   * `within_library_reposition_does_not_create_a_zone_change`
+///     (`game/zones.rs`) pins the separate contract: a within-library reorder
+///     emits neither an event nor a ledger row.
 ///   * `parked_delivery_records_carry_distinct_occurrence_indices`
 ///     (`tests/integration/search_delivery_observer_dedup.rs`) pins the
 ///     allocator->event fidelity link in production on ONE emit path only
 ///     (`zone_pipeline` -> `move_to_zone` ordinary arm -> `zones.rs:1362`). It
-///     is a sentinel, not a census over the four emit sites.
+///     is a sentinel, not a census over the three emit sites.
 ///
 /// KNOWN UNCLOSED GUARD GAP, deliberately out of scope here:
 /// `apply_resolved_zone_change` compares the recorder's return value against

--- a/crates/engine/src/game/triggers_dedup_regression_tests.rs
+++ b/crates/engine/src/game/triggers_dedup_regression_tests.rs
@@ -3823,12 +3823,13 @@ fn owner_collected_filter_never_drops_non_zone_change_events() {
 /// event, sibling to `record`), by `entered_incarnation` (battlefield
 /// destinations only), and by
 /// `trigger_source_context.identity.reference.incarnation` (only where the path
-/// bumps the incarnation) — with the within-library reposition family the
-/// exception in which only the index survives. Those links are pinned by
+/// bumps the incarnation). Within-library reorders are excluded entirely: they
+/// emit neither a `ZoneChanged` event nor a ledger row, as pinned by
+/// `within_library_reposition_does_not_create_a_zone_change` (in `game/zones.rs`).
+/// The occurrence-separation links are pinned by
 /// `occurrence_exact_witness_consumes_the_occurrence_its_witness_names` (U5,
-/// below), by `within_library_repositions_are_separated_only_by_the_occurrence_index`
-/// (in `game/zones.rs`), and by `parked_delivery_records_carry_distinct_occurrence_indices`
-/// (in `tests/integration/search_delivery_observer_dedup.rs`).
+/// below) and by `parked_delivery_records_carry_distinct_occurrence_indices` (in
+/// `tests/integration/search_delivery_observer_dedup.rs`).
 #[test]
 fn owner_collected_filter_counts_contexts_not_occurrences() {
     let mut state = setup();
@@ -3871,13 +3872,11 @@ fn owner_collected_filter_counts_contexts_not_occurrences() {
 /// `trigger_source_context` and `entered_incarnation` as `None`, and both events
 /// here share one `ObjectId`, so the index is the SOLE difference.
 ///
-/// A production analogue of this shape DOES exist — a within-library reposition
-/// (CR 400.7 zero-bump branch, `zones.rs:1809-1812`) neutralizes the same three
-/// fields — see `within_library_repositions_are_separated_only_by_the_occurrence_index`
-/// in `zones.rs`. That row IS red under a `turn_zone_change_index`-excluding
-/// `PartialEq`, but it pins the zones EMIT link; a production fixture for the
-/// FILTER-AUTHORITY link pinned here is CONSTRUCTIBLE but is deliberately NOT
-/// built: the only known route depends on a duplicate-id
+/// There is no production analogue with these same three fields neutralized:
+/// a within-library reorder emits neither a `ZoneChanged` event nor a ledger row
+/// (see `within_library_reposition_does_not_create_a_zone_change` in `zones.rs`).
+/// A production fixture for the FILTER-AUTHORITY link pinned here is
+/// CONSTRUCTIBLE but deliberately NOT built: the only known route depends on a duplicate-id
 /// `SelectCards` payload that the `EffectZoneChoice` arm fails to reject, and
 /// every sibling validator rejects such a payload with an error. So once that
 /// gap is closed the action is REJECTED, the row fails to construct, and it goes

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -1671,12 +1671,13 @@ pub(crate) fn capture_combat_status(
 }
 
 /// Reorder objects that remain in one player's library without performing a
-/// zone change. `ordered` is placed at `start_index` in the supplied order.
+/// zone change. `ordered` is placed at `index` in the supplied order, or
+/// appended when `index` is `None`.
 pub(crate) fn reorder_within_library(
     state: &mut GameState,
     player: PlayerId,
     ordered: &[ObjectId],
-    start_index: usize,
+    index: Option<usize>,
 ) {
     let player_state = state
         .players
@@ -1684,8 +1685,13 @@ pub(crate) fn reorder_within_library(
         .find(|candidate| candidate.id == player)
         .expect("player exists");
     player_state.library.retain(|id| !ordered.contains(id));
+    let insert_index = index
+        .unwrap_or(player_state.library.len())
+        .min(player_state.library.len());
     for (offset, &object_id) in ordered.iter().enumerate() {
-        player_state.library.insert(start_index + offset, object_id);
+        player_state
+            .library
+            .insert(insert_index + offset, object_id);
     }
 
     // CR 401.5 + CR 611.3a: A library reorder can change its top card without
@@ -1742,12 +1748,16 @@ pub fn move_to_library_at_index(
         return;
     }
 
-    // CR 903.9a: A fresh zone change resets the "declined zone return" flag.
-    state.commander_declined_zone_return.remove(&object_id);
-
     let obj = state.objects.get(&object_id).expect("object exists");
     let from = obj.zone;
     let owner = obj.owner;
+    if from == Zone::Library {
+        reorder_within_library(state, owner, &[object_id], index);
+        return;
+    }
+
+    // CR 903.9a: A fresh zone change resets the "declined zone return" flag.
+    state.commander_declined_zone_return.remove(&object_id);
     let unattached_from = state.objects.get(&object_id).and_then(|obj| {
         obj.attached_to
             .map(super::effects::attach::target_ref_from_attach_target)
@@ -3232,41 +3242,8 @@ mod tests {
         assert_eq!(state.players[0].library[1], id2); // goes to bottom
     }
 
-    /// U6 — CR 400.7 + CR 701.20b: a within-Library reposition is ZERO MOVES, so
-    /// two repositions of ONE card in one turn are separated by
-    /// `turn_zone_change_index` ALONE.
-    ///
-    /// This is the ONE production family in which the occurrence index is the SOLE
-    /// discriminator. The zero-bump branch below (`if from != Zone::Library`) is
-    /// rules-correct — CR 701.20b: "Revealing a card doesn't cause it to leave the
-    /// zone it's in", and CR 400.7 only makes a new object on a move BETWEEN zones —
-    /// and its correctness is exactly what kills the other three separators:
-    ///   * `object_id`                                  — same object, twice;
-    ///   * `entered_incarnation`                        — `None` on both (not a
-    ///     battlefield destination; `snapshot_for_zone_change` seeds `None`);
-    ///   * `trigger_source_context…reference.incarnation` — identical on both (the
-    ///     incarnation is deliberately not bumped).
-    ///
-    /// Every other family is over-determined and would survive losing the index.
-    /// This one would not.
-    ///
-    /// The sibling rows `move_to_library_top` and `move_to_library_bottom` above
-    /// cover the `from != Library` (bumping) arm of the same branch; this row
-    /// covers the `from == Library` arm.
-    ///
-    /// Reached in production from clash placement (CR 701.30a,
-    /// `engine_resolution_choices.rs`), the `EffectZoneChoice` library-origin
-    /// repositioners, and both `zone_pipeline` library-placement arms; and reached
-    /// inside a `park_search_observer_triggers` slice by the tutor-to-top class
-    /// (`SearchLibrary -> Shuffle -> PutAtLibraryPosition{Top}`).
-    ///
-    /// Goes red under EITHER of:
-    ///   * a `ZoneChangeRecord` `PartialEq` that stops comparing
-    ///     `turn_zone_change_index` (the two events become fully equal); or
-    ///   * an emit-site-3 regression that ships the `0` placeholder instead of the
-    ///     index `restrictions::record_zone_change` returned.
     #[test]
-    fn within_library_repositions_are_separated_only_by_the_occurrence_index() {
+    fn within_library_reposition_does_not_create_a_zone_change() {
         let mut state = setup();
         let filler = create_object(
             &mut state,
@@ -3284,79 +3261,67 @@ mod tests {
         );
 
         let incarnation_before = state.objects[&card].incarnation;
+        state.commander_declined_zone_return.insert(card);
         let mut events = Vec::new();
         move_to_library_at_index(&mut state, card, Some(0), &mut events); // to top
         move_to_library_at_index(&mut state, card, None, &mut events); // to bottom
 
-        let zone_changes: Vec<&GameEvent> = events
-            .iter()
-            .filter(|event| matches!(event, GameEvent::ZoneChanged { .. }))
-            .collect();
-        assert_eq!(
-            zone_changes.len(),
-            2,
-            "each reposition emits exactly one ZoneChanged"
-        );
-
-        let GameEvent::ZoneChanged {
-            object_id: first_object,
-            from: first_from,
-            to: first_to,
-            record: first,
-        } = zone_changes[0]
-        else {
-            panic!("the first reposition must emit a ZoneChanged");
-        };
-        let GameEvent::ZoneChanged {
-            object_id: second_object,
-            from: second_from,
-            to: second_to,
-            record: second,
-        } = zone_changes[1]
-        else {
-            panic!("the second reposition must emit a ZoneChanged");
-        };
-
-        assert_eq!(*first_object, card);
-        assert_eq!(*second_object, card);
-        assert_eq!(*first_from, Some(Zone::Library));
-        assert_eq!(*second_from, Some(Zone::Library));
-        assert_eq!(*first_to, Zone::Library);
-        assert_eq!(*second_to, Zone::Library);
-
         assert_eq!(
             state.objects[&card].incarnation, incarnation_before,
-            "CR 400.7 + CR 701.20b: a within-Library reposition is zero moves, so \
-             the zero-bump branch must have been taken"
+            "a within-library reposition must preserve object identity"
         );
         assert!(
-            state.players[0].library.contains(&filler) && state.players[0].library.contains(&card),
-            "both cards stay in the library across the two repositions"
+            state.players[0].library.contains(&filler) && state.players[0].library.contains(&card)
         );
-
         assert!(
-            first.entered_incarnation.is_none() && second.entered_incarnation.is_none(),
-            "CR 400.7: a within-Library reposition has no battlefield entry, so \
-             `entered_incarnation` separates nothing here"
+            events.is_empty(),
+            "repositioning within a library emits no events"
         );
-        assert_eq!(
-            first.trigger_source_context, second.trigger_source_context,
-            "CR 701.20b: the zero-bump branch leaves the source context identical, so it \
-             separates nothing here"
+        assert!(
+            state.zone_changes_this_turn.is_empty(),
+            "repositioning within a library does not enter the zone-change ledger"
+        );
+        assert!(
+            state.commander_declined_zone_return.contains(&card),
+            "without a zone change, the commander marker must be preserved"
+        );
+    }
+
+    #[test]
+    fn reorder_within_library_clamps_after_removal_and_appends_when_unspecified() {
+        let mut state = setup();
+        let first = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "First".to_string(),
+            Zone::Library,
+        );
+        let second = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Second".to_string(),
+            Zone::Library,
+        );
+        let third = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Third".to_string(),
+            Zone::Library,
         );
 
+        reorder_within_library(&mut state, PlayerId(0), &[first, third], Some(99));
         assert_eq!(
-            second.turn_zone_change_index,
-            first.turn_zone_change_index + 1,
-            "restrictions::record_zone_change is the sole allocator and never shrinks the \
-             ledger, so two repositions in one turn get consecutive indices; emit site 3 \
-             (zones.rs:1829) must ship the allocator's value, not the `0` placeholder"
+            state.players[0].library.iter().copied().collect::<Vec<_>>(),
+            [second, first, third]
         );
-        assert_ne!(
-            zone_changes[0], zone_changes[1],
-            "turn_zone_change_index is the ONLY field separating these two events — dropping \
-             it from ZoneChangeRecord's equality collapses two distinct CR 603.2c occurrences \
-             into one"
+
+        reorder_within_library(&mut state, PlayerId(0), &[first], None);
+        assert_eq!(
+            state.players[0].library.iter().copied().collect::<Vec<_>>(),
+            [second, third, first]
         );
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -17011,7 +17011,7 @@ fn try_parse_one_or_more_put_into_graveyard(
     None
 }
 
-/// Parse "whenever one or more cards are put into [a|your|an opponent's] library
+/// Parse "whenever one or more cards are put into [a|a player's|your|an opponent's] library
 /// [from <zone>]" — batched zone-change triggers with library destination.
 /// CR 603.2c + CR 603.10a: "One or more" triggers fire once per batch of
 /// simultaneous zone-change events. Example: Wan Shi Tong, All-Knowing —
@@ -17028,6 +17028,7 @@ fn try_parse_one_or_more_put_into_library(lower: &str) -> Option<(TriggerMode, T
         fn parse_library_possessive(input: &str) -> OracleResult<'_, Option<TargetFilter>> {
             alt((
                 value(None, tag("a library")),
+                value(None, tag("a player's library")),
                 value(
                     Some(TargetFilter::Typed(
                         TypedFilter::default().controller(ControllerRef::You),

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -17650,6 +17650,42 @@ fn trigger_one_or_more_cards_put_into_graveyard_from_anywhere() {
 }
 
 #[test]
+fn trigger_one_or_more_cards_put_into_a_players_library_from_anywhere() {
+    let def = parse_trigger_line(
+        "Whenever one or more cards are put into a player's library from anywhere, put a +1/+1 counter on Dutiful Knowledge Seeker.",
+        "Dutiful Knowledge Seeker",
+    );
+    assert_eq!(def.mode, TriggerMode::ChangesZoneAll);
+    assert_eq!(def.origin, None);
+    assert_eq!(def.destination, Some(Zone::Library));
+    assert!(def.batched);
+    assert_eq!(def.valid_card, None);
+    assert!(
+        def.valid_target.is_none(),
+        "a player's library must not add a target filter"
+    );
+
+    let execute = def.execute.as_ref().expect("execute ability");
+    assert!(
+        !matches!(execute.effect.as_ref(), Effect::Unimplemented { .. }),
+        "counter effect must not be Unimplemented: {:?}",
+        execute.effect
+    );
+    match execute.effect.as_ref() {
+        Effect::PutCounter {
+            counter_type,
+            count,
+            target,
+        } => {
+            assert_eq!(*counter_type, CounterType::Plus1Plus1);
+            assert_eq!(*count, QuantityExpr::Fixed { value: 1 });
+            assert_eq!(*target, TargetFilter::SelfRef);
+        }
+        other => panic!("expected PutCounter +1/+1 on SelfRef, got {other:?}"),
+    }
+}
+
+#[test]
 fn trigger_precombat_main_phase() {
     // CR 505.1: "precombat main phase" maps to PreCombatMain.
     let def = parse_trigger_line(

--- a/crates/engine/tests/integration/issue_7063_library_reorder.rs
+++ b/crates/engine/tests/integration/issue_7063_library_reorder.rs
@@ -1,0 +1,52 @@
+//! Regression for #7063: a card repositioned within a library is not a zone
+//! change, while a different card put into that library still is.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::counter::CounterType;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const DUTIFUL_KNOWLEDGE_SEEKER: &str =
+    "Whenever one or more cards are put into a player's library from anywhere, put a +1/+1 counter on Dutiful Knowledge Seeker.";
+const TIME_EBB: &str = "Put target creature on top of its owner's library.";
+
+#[test]
+fn time_ebb_triggers_dutiful_knowledge_seeker_for_a_distinct_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let dutiful = scenario
+        .add_creature_from_oracle(
+            P1,
+            "Dutiful Knowledge Seeker",
+            2,
+            2,
+            DUTIFUL_KNOWLEDGE_SEEKER,
+        )
+        .id();
+    let victim = scenario.add_creature(P1, "Victim", 2, 2).id();
+    let time_ebb = scenario
+        .add_spell_to_hand_from_oracle(P0, "Time Ebb", false, TIME_EBB)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+
+    let outcome = scenario
+        .build()
+        .cast(time_ebb)
+        .target_object(victim)
+        .resolve();
+    let state = outcome.state();
+
+    assert_eq!(state.objects[&victim].zone, Zone::Library);
+    assert_eq!(state.players[1].library.front(), Some(&victim));
+    assert_eq!(state.objects[&dutiful].zone, Zone::Battlefield);
+    assert_eq!(
+        state.objects[&dutiful]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied(),
+        Some(1),
+        "the distinct creature's move into the library must trigger Dutiful Knowledge Seeker"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -661,6 +661,7 @@ mod issue_688_mind_into_matter;
 mod issue_689_resonating_lute_hand_size;
 mod issue_691_sheoldred_saga_lore;
 mod issue_6943_faerie_slumber_party;
+mod issue_7063_library_reorder;
 mod issue_709_regression;
 mod issue_718_dina_sacrifice_draw;
 mod issue_735_amalia_power_threshold;

--- a/crates/engine/tests/integration/search_delivery_observer_dedup.rs
+++ b/crates/engine/tests/integration/search_delivery_observer_dedup.rs
@@ -656,11 +656,12 @@ fn fetch_with_no_legal_target_parks_nothing() {
 //        -> deliver_replaced_zone_change -> zones::move_to_zone (ordinary arm)
 //        -> resolve_and_apply_zone_change (zones.rs:826)
 //        -> zones.rs:1199 -> emit at zones.rs:1362.
-//      A regression at the other three production emit sites — zones.rs:1430
-//      (`from: None` entries), zones.rs:1829 (library insert; covered instead by
-//      `within_library_repositions_are_separated_only_by_the_occurrence_index`
-//      in game/zones.rs), or merge.rs:689 (CR 730.3c split) — is NEVER EXECUTED
-//      by this fixture and will NOT turn it red.
+//      A regression at the other two production emit sites — zones.rs:1430
+//      (`from: None` entries) or merge.rs:689 (CR 730.3c split) — is NEVER
+//      EXECUTED by this fixture and will NOT turn it red. A within-library reorder
+//      is not an emit site: it creates neither a `ZoneChanged` event nor a ledger
+//      row, as covered by `within_library_reposition_does_not_create_a_zone_change`
+//      in game/zones.rs.
 //
 //      WHY IT IS NONETHELESS LOAD-BEARING: the `TurnRecordIndexMismatch` guard
 //      at zones.rs:946-953 validates the COMMAND's `turn_zone_change_index`

--- a/crates/engine/tests/integration/search_delivery_observer_dedup.rs
+++ b/crates/engine/tests/integration/search_delivery_observer_dedup.rs
@@ -656,11 +656,12 @@ fn fetch_with_no_legal_target_parks_nothing() {
 //        -> deliver_replaced_zone_change -> zones::move_to_zone (ordinary arm)
 //        -> resolve_and_apply_zone_change (zones.rs:826)
 //        -> zones.rs:1199 -> emit at zones.rs:1362.
-//      A regression at the other two production emit sites — zones.rs:1430
-//      (`from: None` entries) or merge.rs:689 (CR 730.3c split) — is NEVER
-//      EXECUTED by this fixture and will NOT turn it red. A within-library reorder
-//      is not an emit site: it creates neither a `ZoneChanged` event nor a ledger
-//      row, as covered by `within_library_reposition_does_not_create_a_zone_change`
+//      A regression at the other three production emit sites — zones.rs:1430
+//      (`from: None` entries), the `from != Library` path in
+//      `move_to_library_at_index`, or merge.rs:689 (CR 730.3c split) — is NEVER
+//      EXECUTED by this fixture and will NOT turn it red. Only the same-library
+//      reorder path is not an emit site: it creates neither a `ZoneChanged` event
+//      nor a ledger row, as covered by `within_library_reposition_does_not_create_a_zone_change`
 //      in game/zones.rs.
 //
 //      WHY IT IS NONETHELESS LOAD-BEARING: the `TurnRecordIndexMismatch` guard


### PR DESCRIPTION
- **fix(engine): treat library reorders as non-moves**
- **docs(engine): align trigger contract with library reorders**
- **docs(engine): retain cross-zone library emitter census**
- **docs(engine): correct occurrence emitter count**
