### PR TITLE
test(engine): assert the promised Gift kind reaches the casting prompt

### DIFF
--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -2694,6 +2694,57 @@ mod tests {
         );
     }
 
+    /// CR 702.174a + CR 702.174b: the promised [something] is the discriminant that
+    /// selects the gift effect ("The specific effect is defined by the [something]
+    /// listed"), so `effective_gift_kind` must report which kind was promised — not
+    /// merely that Gift is present. The value reaches the casting prompt as
+    /// `WaitingFor::OptionalCostChoice`'s `gift_kind`, which is what the client
+    /// renders; a blanket `None` would silently strip the promise from the prompt
+    /// with no other observable effect.
+    #[test]
+    fn effective_gift_kind_reports_each_promised_kind() {
+        for kind in [
+            GiftKind::Card,
+            GiftKind::Treasure,
+            GiftKind::Food,
+            GiftKind::TappedFish,
+        ] {
+            let mut state = GameState::new_two_player(1);
+            let id = create_object(
+                &mut state,
+                CardId(1),
+                PlayerId(0),
+                "Gifted Spell".to_string(),
+                Zone::Hand,
+            );
+            {
+                let obj = state.objects.get_mut(&id).unwrap();
+                obj.keywords.push(Keyword::Gift(kind.clone()));
+                obj.base_keywords = obj.keywords.clone();
+            }
+            assert_eq!(
+                effective_gift_kind(&state, id),
+                Some(kind.clone()),
+                "{kind:?} must survive to the casting prompt",
+            );
+        }
+
+        // No Gift keyword: the prompt must not claim a promise that wasn't made.
+        let mut state = GameState::new_two_player(1);
+        let plain = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Plain Spell".to_string(),
+            Zone::Hand,
+        );
+        assert_eq!(
+            effective_gift_kind(&state, plain),
+            None,
+            "an object without Gift must report no promised kind",
+        );
+    }
+
     /// CR 702.49: synthesized marker must be classified so it cannot stack via
     /// `ActivateAbility` without paying mana (issue #5338).
     #[test]


### PR DESCRIPTION
Closes a coverage gap found by mutation testing: `effective_gift_kind` had **no assertion anywhere in the Rust tree**, unit or integration.

### The gap

Mutating the function to return `None` unconditionally passed the entire suite. Nothing failed. In production that mutation would strip the promised-kind label from every Gift casting prompt in the UI, silently:

```
effective_gift_kind  →  gift_kind_for_object (casting_costs.rs:351)
                     →  WaitingFor::OptionalCostChoice.gift_kind
                     →  OptionalCostModal.tsx  giftKindLabel()
```

The only existing reference to `gift_kind` was a frontend fixture that supplies **its own** value:

```ts
gift_kind: { type: "Treasure" }   // OptionalCostModal.test.tsx
```

That test proves the component formats the value. It cannot fail if the engine stops producing one — the test and the defect sit on opposite sides of a stubbed boundary. This is why a redundancy audit could never have surfaced it: the test isn't duplicated by anything, it's just pointed at the wrong side of the seam.

Note the field is display-only here. The separate `instance.origin == AdditionalCostOrigin::Gift` check at `casting_costs.rs:631` is unaffected, so no other assertion incidentally covers it.

### The test

CR 702.174b makes the promised [something] the discriminant that selects the gift effect — "the specific effect is defined by the [something] listed" — with CR 702.174d/e spelling out the per-kind outcomes. It is the payload, not decoration.

So the test loops **all four** `GiftKind` variants rather than spot-checking one; a test asserting only `Treasure` would pass while `Food` mapped wrong. It adds a negative case so an object without Gift cannot report a promise that was never made — which also holds the line if someone later derives `Default` for `GiftKind`.

### Verification

Confirmed by re-running the mutants, not by inspection:

| Mutant | Before | After |
|---|---|---|
| `replace effective_gift_kind -> Option<GiftKind> with None` | **MISSED** | **CAUGHT** |
| `delete match arm Keyword::Gift(kind)` | — | **CAUGHT** |
| `replace ... with Some(Default::default())` | — | unviable (no `Default` impl) |

The unmutated baseline passed (1848s build + 203s test), so the test is green on correct code and red on the specific defect it was written for.
