### PR TITLE
feat(parser): implement the assimilate keyword action

### DIFF
--- a/crates/engine/src/game/gap_analysis.rs
+++ b/crates/engine/src/game/gap_analysis.rs
@@ -54,6 +54,7 @@ const IMPERATIVE_EXTRA_VERBS: &[&str] = &[
     "clash",
     "planeswalk",
     "recruit",
+    "assimilate",
 ];
 
 /// Pre-dispatch verbs handled in `parse_effect_clause` before imperative dispatch.

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -9756,6 +9756,37 @@ fn parse_activation_cost_referent(input: &str) -> OracleResult<'_, ()> {
     .parse(input)
 }
 
+/// CR 205.1a + CR 205.1b + CR 110.2a + CR 122.1 + CR 115.2: recognize the
+/// `assimilate <target phrase>` keyword action and return the phrase's target
+/// filter.
+///
+/// Anchored on `tag("assimilate ")` — the trailing space IS the word boundary,
+/// so `assimilates`/`assimilation`/`Assimilation Aegis` cannot match. The
+/// target phrase itself is delegated to `parse_target_with_ctx`, the shared
+/// target-phrase authority, so "from an opponent's graveyard" resolves through
+/// `parse_zone_suffix` to `Owned{Opponent}` + `InZone{Graveyard}` exactly as it
+/// does for Ashen Powder and Puppeteer Clique.
+///
+/// Fails closed (returns `None`, so the caller falls through to the imperative
+/// `Effect::Unimplemented` fallback and coverage stays red) when either:
+///   * the target phrase leaves an unconsumed remainder, or
+///   * CR 115.2: the phrase does not name a graveyard zone. This second guard
+///     exists for COVERAGE HONESTY, not to license an `origin` value: the
+///     lowering emits `ChangeZone { origin: None }` (the zone constraint travels
+///     on the target filter), and a non-graveyard `assimilate` phrasing is a
+///     shape this production does not model, so it must keep reporting as
+///     unsupported rather than be silently lowered into a reanimation.
+fn parse_assimilate_target(lower: &str, ctx: &mut ParseContext) -> Option<TargetFilter> {
+    let (rest, _) = tag::<_, _, OracleError<'_>>("assimilate ")
+        .parse(lower.trim())
+        .ok()?;
+    let (target, remainder) = parse_target_with_ctx(rest, ctx);
+    if !remainder.trim().is_empty() {
+        return None;
+    }
+    (target.extract_in_zone() == Some(Zone::Graveyard)).then_some(target)
+}
+
 pub(super) fn parse_imperative_family_ast(
     text: &str,
     lower: &str,
@@ -9793,6 +9824,16 @@ pub(super) fn parse_imperative_family_ast(
     .is_ok()
     {
         return Some(ImperativeFamilyAst::Recruit);
+    }
+
+    // CR 205.1a + CR 205.1b + CR 613.1d: `assimilate <target phrase>` is a
+    // standalone keyword action whose definition lives in reminder text the
+    // parser never sees. Probe it here, as an anchored nom production alongside
+    // `recruit`, rather than as a `match first_word` arm: a new string-literal
+    // match arm is exactly what `scripts/check-parser-combinators.sh` family (B)
+    // forbids.
+    if let Some(target) = parse_assimilate_target(lower, ctx) {
+        return Some(ImperativeFamilyAst::Assimilate { target });
     }
 
     // CR 724.1: "end the turn" (Time Stop, Sundial of the Infinite, Obeka,
@@ -11951,6 +11992,127 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             clause.sub_ability = Some(Box::new(discard));
             clause
         }
+        // CR 205.1a + CR 205.1b + CR 613.1d + CR 110.2a + CR 122.1: `assimilate`
+        // expands to the same two-step chain the reanimate-then-retype class
+        // already produces from spelled-out Oracle text (Ashen Powder's move,
+        // Rise from the Grave's / Grave Betrayal's type rider): move the
+        // targeted graveyard card to the battlefield under the instruction's
+        // controller with a +1/+1 counter, then install a Duration::Permanent
+        // layer-4 type override on that same object.
+        ImperativeFamilyAst::Assimilate { target } => {
+            // CR 205.1b: "becomes a '[creature type or types] artifact
+            // creature'" RETAINS every prior card type, supertype, and
+            // non-creature subtype and REPLACES only the creature types.
+            // `SetCardTypes` would replace the whole card-type set and is
+            // therefore rules-WRONG here.
+            //
+            // WRITTEN ORDER IS LOAD-BEARING and all four modifications must ride
+            // ONE StaticDefinition: they are all layer 4 (CR 613.1d), so list
+            // order decides. The CR 613.8 intra-static dependency edge
+            // RemoveAllSubtypes -> AddSubtype is deliberately suppressed in
+            // layers.rs so the written pre-sort wins (guarded by
+            // layers.rs::same_static_modifications_apply_in_written_order);
+            // splitting these into separate StaticDefinitions would create
+            // separate transient effects ordered by CR 613.7 timestamp instead,
+            // and the wipe could erase Borg.
+            let retype = StaticDefinition::continuous()
+                .affected(TargetFilter::ParentTarget)
+                .modifications(vec![
+                    // CR 205.1a: the new creature subtype replaces the existing
+                    // creature-type set. Wipe first.
+                    ContinuousModification::RemoveAllSubtypes {
+                        set: crate::types::card_type::SubtypeSet::Creature,
+                    },
+                    ContinuousModification::AddSubtype {
+                        subtype: "Borg".to_string(),
+                    },
+                    // CR 205.1b: additive card types — prior card types and all
+                    // supertypes (e.g. Legendary) are retained.
+                    ContinuousModification::AddType {
+                        core_type: CoreType::Artifact,
+                    },
+                    // CR 205.1b + CR 613.7: the phrase asserts the object IS a
+                    // creature. The filter's creature guarantee was checked once
+                    // in the graveyard at target selection (CR 601.2c), not
+                    // continuously, so a lower-timestamped type-removal effect
+                    // must be overridden here. Idempotent when already present.
+                    ContinuousModification::AddType {
+                        core_type: CoreType::Creature,
+                    },
+                ])
+                .description(
+                    "It's a Borg artifact creature and loses all other creature types.".to_string(),
+                );
+
+            // CR 611.2a: no stated duration on a keyword-action definition means
+            // "until the end of the game" — Duration::Permanent. Setting this
+            // explicitly is REQUIRED: effects/effect.rs's
+            // `ability.duration.or(duration).unwrap_or(Duration::UntilEndOfTurn)`
+            // would otherwise let layers.rs::prune_end_of_turn_effects drop the
+            // override at the next cleanup.
+            // CR 611.2c: the affected set freezes to the resolved parent target
+            // at install.
+            let override_step = AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::GenericEffect {
+                    static_abilities: vec![retype],
+                    duration: Some(Duration::Permanent),
+                    target: Some(TargetFilter::ParentTarget),
+                    end_cost: None,
+                },
+            )
+            .duration(Duration::Permanent);
+
+            // CR 110.2a: enters under the instruction's controller, not its
+            // owner (CR 108.3: ownership is unchanged).
+            // CR 122.1: the +1/+1 counter is placed as part of the entry event;
+            // it modifies P/T in layer 7c (CR 613.4c), never in the layer-4
+            // modification list above.
+            // CR 115.2: `origin` stays None — the graveyard constraint travels
+            // on the target filter (FilterProp::InZone{Graveyard} +
+            // FilterProp::Owned{Opponent}), which is what both target
+            // enumeration and resolution-time re-legality consult. This matches
+            // every shipped card with this exact phrase ("from an opponent's
+            // graveyard"): Ashen Powder, Puppeteer Clique, Macabre Mockery all
+            // store origin: None. (Cards phrased "from A graveyard" — Rise from
+            // the Grave, Reanimate — store Some(Graveyard); that is a different
+            // phrase and not this card's.)
+            let mut clause = parsed_clause(Effect::ChangeZone {
+                origin: None,
+                destination: Zone::Battlefield,
+                target,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: Some(ControllerRef::You),
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![(
+                    crate::types::counter::CounterType::Plus1Plus1,
+                    QuantityExpr::Fixed { value: 1 },
+                )],
+                conditional_enter_with_counters: Vec::new(),
+                face_down_profile: None,
+                enters_modified_if: None,
+            });
+            // CR 608.2c: the type override is a resolution STEP of the single
+            // `assimilate` instruction, not a following independent instruction,
+            // so the link stays the default `ContinuationStep` (mirroring
+            // Recruit). `forward_result` is intentionally NOT hand-set: the sub
+            // binds via `ParentTarget`, not `SelfRef`, and
+            // `lower::rewire_result_anchored_subchain` already stamps the flag
+            // for this shape.
+            //
+            // CR 611.2e DEVIATION (pre-existing, class-wide): the definition's
+            // "It's a Borg artifact creature" is the "is [characteristic]" form,
+            // which the rule says must apply SIMULTANEOUSLY with the permanent
+            // entering the battlefield. This continuation applies it AFTER
+            // entry, so an ETB trigger keying on the new types does not see
+            // them. Same behavior as Rise from the Grave / Grave Betrayal (both
+            // also the "is" form); NOT fixed here.
+            clause.sub_ability = Some(Box::new(override_step));
+            clause
+        }
         // CR 118.12: A Counter with an "unless [player] pays [cost]" modifier
         // — intercepted here so the modifier propagates to
         // `ParsedEffectClause.unless_pay`. The Effect itself becomes the
@@ -12651,6 +12813,9 @@ fn lower_imperative_family_effect(ast: ImperativeFamilyAst) -> Effect {
         },
         ImperativeFamilyAst::Recruit => {
             unreachable!("Recruit lowering constructs a sub-ability chain")
+        }
+        ImperativeFamilyAst::Assimilate { .. } => {
+            unreachable!("Assimilate lowering constructs a sub-ability chain")
         }
         ImperativeFamilyAst::ForceBlock { attacker, duration } => Effect::ForceBlock {
             target: TargetFilter::Any,
@@ -22125,6 +22290,38 @@ mod tests {
             parse_imperative_family_ast("recruiter", "recruiter", &mut ParseContext::default())
                 .is_none(),
             "the anchored Recruit grammar must not accept a longer word"
+        );
+    }
+
+    /// The `tag("assimilate ")` word boundary. Mirrors
+    /// `recruiter_is_not_recruit`: the trailing space in the tag IS the boundary,
+    /// so no longer word beginning "assimilat…" may reach the Assimilate node.
+    /// Positive reach-guard included so the negatives cannot pass vacuously.
+    #[test]
+    fn assimilation_is_not_assimilate() {
+        for text in [
+            "assimilation",
+            "assimilates target creature card from an opponent's graveyard",
+            "assimilation aegis target creature card from an opponent's graveyard",
+        ] {
+            assert!(
+                !matches!(
+                    parse_imperative_family_ast(text, text, &mut ParseContext::default()),
+                    Some(ImperativeFamilyAst::Assimilate { .. })
+                ),
+                "the anchored Assimilate grammar must not accept {text:?}"
+            );
+        }
+        // Positive reach-guard: the real phrase DOES reach the node, so the
+        // negatives above are about the word boundary and not about a
+        // production that never fires.
+        let real = "assimilate target creature card from an opponent's graveyard";
+        assert!(
+            matches!(
+                parse_imperative_family_ast(real, real, &mut ParseContext::default()),
+                Some(ImperativeFamilyAst::Assimilate { .. })
+            ),
+            "reach-guard: the printed assimilate phrase must produce the Assimilate node"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -52413,3 +52413,205 @@ fn chain_continuation_each_of_head_keeps_its_announced_count() {
          announce exactly two targets on its own sub-ability"
     );
 }
+
+/// SHAPE — Borg Queen, Perfection Manifest's `assimilate` keyword action lowers
+/// to the shipped reanimate-then-retype chain: a `ChangeZone` that moves the
+/// targeted opponent-graveyard creature card to the battlefield under the
+/// instruction's controller with a +1/+1 counter (CR 110.2a + CR 122.1), plus a
+/// `Duration::Permanent` `GenericEffect` continuation carrying ONE
+/// `StaticDefinition` whose four layer-4 modifications (CR 613.1d) implement
+/// CR 205.1b's "[creature type or types] artifact creature" semantics.
+///
+/// Driven through `parse_oracle_text` on the VERBATIM printed Oracle text
+/// (reminder text included, MTGJSON keyword hint included) — the same entry the
+/// card-data pipeline uses — not a direct call to the private production.
+#[test]
+fn borg_queen_assimilate_lowers_to_reanimate_then_retype_chain() {
+    const BORG_QUEEN: &str = "Artifact creatures you control get +2/+0.\n\
+         When Borg Queen enters, assimilate target creature card from an opponent's graveyard. \
+         (Put it onto the battlefield under your control with a +1/+1 counter. It's a Borg \
+         artifact creature and loses all other creature types.)";
+
+    let parsed = parse_oracle_text(
+        BORG_QUEEN,
+        "Borg Queen, Perfection Manifest",
+        &["Assimilate".to_string()],
+        &["Artifact".to_string(), "Creature".to_string()],
+        &["Borg".to_string(), "Noble".to_string()],
+    );
+
+    let trigger = parsed
+        .triggers
+        .first()
+        .expect("the ETB trigger must be extracted");
+    let execute = trigger
+        .execute
+        .as_deref()
+        .expect("the ETB trigger must carry an execute body");
+
+    // (1) POSITIVE REACH-GUARD (mandatory): zero `Effect::Unimplemented` in the
+    // whole chain. Every negative assertion below is non-vacuous only because
+    // this passes — at BASE_SHA the execute IS an `Unimplemented { name:
+    // "assimilate" }`, so this is also the revert-failing assertion.
+    assert!(
+        !ability_chain_has_unimplemented(execute),
+        "the assimilate trigger must lower with no residual Unimplemented node: {execute:#?}"
+    );
+
+    // (2) CR 110.2a + CR 115.2: the move itself. `origin` is None — the graveyard
+    // constraint travels on the target filter, matching Ashen Powder / Puppeteer
+    // Clique / Macabre Mockery, the shipped cards with this exact target phrase.
+    let Effect::ChangeZone {
+        origin,
+        destination,
+        enters_under,
+        target,
+        enter_with_counters,
+        up_to,
+        ..
+    } = &*execute.effect
+    else {
+        panic!(
+            "assimilate must lower to a ChangeZone head, got {:#?}",
+            execute.effect
+        );
+    };
+    assert_eq!(
+        *origin, None,
+        "CR 115.2: origin stays None for the \"from an opponent's graveyard\" phrase"
+    );
+    assert_eq!(*destination, Zone::Battlefield);
+    assert_eq!(
+        *enters_under,
+        Some(ControllerRef::You),
+        "CR 110.2a: the assimilated permanent enters under the instruction's controller"
+    );
+    assert!(!*up_to, "assimilate is mandatory, not an \"up to\" move");
+
+    // (3) CR 122.1 + CR 614.1c: exactly one +1/+1 counter, placed as part of the
+    // entry event rather than by a later PutCounter step.
+    assert_eq!(
+        *enter_with_counters,
+        vec![(
+            crate::types::counter::CounterType::Plus1Plus1,
+            QuantityExpr::Fixed { value: 1 }
+        )],
+        "the entry counter must be exactly one +1/+1 counter"
+    );
+
+    // (4) CR 108.3 + CR 109.4 + CR 115.2: the target shape is ASSERTED, not
+    // constructed, so a future `parse_zone_suffix` change is caught here rather
+    // than silently forked. A graveyard card has no controller (CR 109.4), so the
+    // opponent restriction rides as OWNERSHIP (CR 108.3).
+    let TargetFilter::Typed(typed) = target else {
+        panic!("the assimilate target must be a Typed filter, got {target:#?}");
+    };
+    assert_eq!(
+        typed.type_filters,
+        vec![TypeFilter::Creature],
+        "\"target creature card\" must yield exactly the Creature type filter"
+    );
+    assert_eq!(
+        typed.controller, None,
+        "CR 109.4: a graveyard card has no controller, so the filter-level controller stays None"
+    );
+    assert!(
+        typed.properties.contains(&FilterProp::Owned {
+            controller: ControllerRef::Opponent
+        }),
+        "CR 108.3: \"an opponent's graveyard\" must restrict by OWNERSHIP, got {:#?}",
+        typed.properties
+    );
+    assert!(
+        typed.properties.contains(&FilterProp::InZone {
+            zone: Zone::Graveyard
+        }),
+        "CR 115.2: the graveyard zone must ride on the target filter, got {:#?}",
+        typed.properties
+    );
+
+    // (5) The continuation step. CR 613.1d: all four modifications are layer 4,
+    // so LIST ORDER decides the outcome and they must ride ONE StaticDefinition —
+    // splitting them would order by CR 613.7 timestamp instead and the subtype
+    // wipe could erase Borg. This one assertion pins both invariants.
+    let sub = execute
+        .sub_ability
+        .as_deref()
+        .expect("assimilate must chain the type override as a direct child");
+    let Effect::GenericEffect {
+        static_abilities,
+        duration,
+        target: sub_target,
+        ..
+    } = &*sub.effect
+    else {
+        panic!(
+            "the override step must be a GenericEffect, got {:#?}",
+            sub.effect
+        );
+    };
+    assert_eq!(
+        static_abilities.len(),
+        1,
+        "CR 613.1d: all four layer-4 modifications must ride ONE StaticDefinition"
+    );
+    let retype = &static_abilities[0];
+    assert_eq!(
+        retype.affected,
+        Some(TargetFilter::ParentTarget),
+        "CR 611.2c: the override must bind to the parent's chosen target"
+    );
+    assert_eq!(
+        *sub_target,
+        Some(TargetFilter::ParentTarget),
+        "the GenericEffect target must be the parent target so the TCE freezes to the moved object"
+    );
+    assert_eq!(
+        retype.modifications,
+        vec![
+            ContinuousModification::RemoveAllSubtypes {
+                set: crate::types::card_type::SubtypeSet::Creature,
+            },
+            ContinuousModification::AddSubtype {
+                subtype: "Borg".to_string(),
+            },
+            ContinuousModification::AddType {
+                core_type: CoreType::Artifact,
+            },
+            ContinuousModification::AddType {
+                core_type: CoreType::Creature,
+            },
+        ],
+        "CR 205.1a + CR 205.1b: wipe the creature-type set FIRST, then add Borg, \
+         then the additive card types — written order is load-bearing"
+    );
+
+    // (6) CR 611.2a: no stated duration on a keyword-action definition means
+    // "until the end of the game". This is a SHAPE assertion and does NOT
+    // substitute for runtime semantics — the runtime guard against the
+    // `effect.rs` `unwrap_or(UntilEndOfTurn)` fallback is
+    // `tests/integration/borg_queen_assimilate.rs`'s cleanup-survival test.
+    assert_eq!(
+        *duration,
+        Some(Duration::Permanent),
+        "CR 611.2a: the type override must be explicitly Permanent"
+    );
+    assert_eq!(
+        sub.duration,
+        Some(Duration::Permanent),
+        "CR 611.2a: the AbilityDefinition duration must also be Permanent"
+    );
+
+    // (7) NEGATIVE, paired with (1): CR 205.1b retains prior card types, so a
+    // set-replacement `SetCardTypes` is rules-WRONG here; and the card says
+    // nothing about color, so no `AddColor` may appear (contrast Rise from the
+    // Grave, which does emit one).
+    assert!(
+        !retype.modifications.iter().any(|m| matches!(
+            m,
+            ContinuousModification::SetCardTypes { .. } | ContinuousModification::AddColor { .. }
+        )),
+        "CR 205.1b: no SetCardTypes (card types are RETAINED) and no AddColor: {:#?}",
+        retype.modifications
+    );
+}

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -615,6 +615,47 @@ pub(crate) enum ImperativeFamilyAst {
     /// three-step, direct-child chain rather than introduce a card-specific
     /// runtime effect.
     Recruit,
+    /// CR 205.1a + CR 205.1b + CR 613.1d + CR 110.2a + CR 122.1: `assimilate
+    /// <target phrase>` (Borg Queen, Perfection Manifest — Star Trek Commander).
+    ///
+    /// The keyword action's definition is supplied ONLY by reminder text, which
+    /// is stripped before the parser runs, so it is encoded here rather than
+    /// parsed: "Put it onto the battlefield under your control with a +1/+1
+    /// counter. It's a Borg artifact creature and loses all other creature
+    /// types."
+    ///
+    /// Like `Recruit`, this remains a parser IR node because lowering must build
+    /// a two-step, direct-child chain (`ChangeZone` + a `Duration::Permanent`
+    /// `GenericEffect` bound to the parent target) rather than introduce a
+    /// card-specific runtime effect. The chain it lowers to is the SAME shape
+    /// the reanimate-then-retype class already produces from spelled-out Oracle
+    /// text (Ashen Powder's move + Rise from the Grave's type rider).
+    ///
+    /// CR 205.1b: "becomes a '[creature type or types] artifact creature'"
+    /// RETAINS all prior card types, supertypes, and non-creature subtypes and
+    /// REPLACES only the creature types — so the lowering emits additive
+    /// `AddType`s plus a creature-set-scoped subtype replacement, never
+    /// `SetCardTypes`.
+    ///
+    /// CR 611.2e: because the definition uses the "is [characteristic]" form
+    /// ("It's a Borg artifact creature"), the rule requires the type change to
+    /// apply SIMULTANEOUSLY with the permanent entering the battlefield. The
+    /// engine installs it after entry via the shared `ChangeZone` +
+    /// `GenericEffect` continuation, so an ETB trigger keying on the new
+    /// characteristics does not see them. This is a PRE-EXISTING, CLASS-WIDE
+    /// deviation shared with Rise from the Grave and Grave Betrayal (both also
+    /// the "is" form); Puppeteer Clique's "It gains haste" is the "gains" form
+    /// and is correct. Not introduced here, and out of scope to fix.
+    ///
+    /// `assimilate` has NO CR 701.x keyword-action number: the set is
+    /// unreleased and `docs/MagicCompRules.txt` has zero matches for it. Do not
+    /// invent one, and do not reuse Recruit's `CR 701.70a` — that number is
+    /// Recruit's, not assimilate's.
+    Assimilate {
+        /// The card the keyword action moves — "target creature card from an
+        /// opponent's graveyard" (CR 115.2: a non-battlefield-zone target).
+        target: TargetFilter,
+    },
     /// CR 509.1c: Block this turn/combat if able.
     ForceBlock {
         attacker: Option<ForceBlockAttackerRef>,

--- a/crates/engine/tests/integration/borg_queen_assimilate.rs
+++ b/crates/engine/tests/integration/borg_queen_assimilate.rs
@@ -1,0 +1,748 @@
+//! Borg Queen, Perfection Manifest — the `assimilate` keyword action, driven
+//! through the REAL cast pipeline.
+//!
+//! Oracle (verbatim, MTGJSON-verified):
+//!   "Artifact creatures you control get +2/+0.
+//!    When Borg Queen enters, assimilate target creature card from an opponent's
+//!    graveyard. (Put it onto the battlefield under your control with a +1/+1
+//!    counter. It's a Borg artifact creature and loses all other creature types.)"
+//!
+//! `assimilate` has NO CR 701.x number (the set is unreleased; zero matches in
+//! `docs/MagicCompRules.txt`). Its definition lives only in reminder text, which
+//! is stripped before the parser runs, so the parser encodes it as a two-step
+//! chain: `ChangeZone` (CR 110.2a controller override + CR 122.1 entry counter)
+//! with a `Duration::Permanent` `GenericEffect` continuation carrying ONE
+//! `StaticDefinition` of four layer-4 modifications (CR 613.1d) implementing
+//! CR 205.1b's "[creature type or types] artifact creature" semantics.
+//!
+//! These are RUNTIME tests: they cast through `GameRunner::cast(..).resolve()`
+//! and read back EFFECTIVE post-`evaluate_layers` characteristics. The AST-shape
+//! coverage lives in `parser/oracle_effect/tests.rs`
+//! (`borg_queen_assimilate_lowers_to_reanimate_then_retype_chain`).
+//!
+//! FOOT-GUN, load-bearing in every test here: `layers.rs`'s
+//! `RemoveAllSubtypes { SubtypeSet::Creature }` arm retains any subtype NOT in
+//! `state.all_creature_types`, and `GameScenario` leaves that vector EMPTY. With
+//! it empty the subtype wipe is a silent no-op and every "does not contain
+//! Human" assertion would pass vacuously. Each test seeds it explicitly.
+//!
+//! EFFECTIVE-P/T ARITHMETIC (verified, not assumed): Borg Queen's FIRST line is
+//! a lord whose `affected` filter is `Typed { type_filters: [Creature, Artifact],
+//! controller: You }`, and `type_filters` is CONJUNCTIVE (`filter.rs`
+//! `filter_inner`: "Type filters check (all must match — conjunction)"). Because
+//! assimilation adds BOTH `Artifact` and `Creature` and the victim enters under
+//! Borg Queen's controller, the victim MATCHES that lord and gains +2/+0 in
+//! layer 7c (CR 613.4c) on top of the +1/+1 counter. So while Borg Queen is on
+//! the battlefield an assimilated victim is `printed + (1,1) + (2,0)`; once she
+//! leaves it is `printed + (1,1)`. A layer-4-granted type earning a layer-7c
+//! lord buff is exactly the in-tree "artifacts become creatures" precedent.
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::zones::move_to_zone;
+use engine::parser::oracle_effect::parse_effect;
+use engine::types::ability::Effect;
+use engine::types::card_type::{CoreType, Supertype};
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+/// Borg Queen's verbatim printed Oracle text, reminder text included, so the
+/// real reminder-stripping path runs (never a paraphrase).
+const BORG_QUEEN: &str = "Artifact creatures you control get +2/+0.\n\
+     When Borg Queen enters, assimilate target creature card from an opponent's graveyard. \
+     (Put it onto the battlefield under your control with a +1/+1 counter. It's a Borg \
+     artifact creature and loses all other creature types.)";
+
+/// Pharika, God of Affliction's verbatim Oracle text. Her SECOND line is the
+/// whole point of test 7: a static ability of the permanent ITSELF that removes
+/// its `Creature` card type.
+const PHARIKA: &str = "Indestructible\n\
+     As long as your devotion to black and green is less than seven, Pharika isn't a creature.\n\
+     {B}{G}: Exile target creature card from a graveyard. Its owner creates a 1/1 black and \
+     green Snake enchantment creature token with deathtouch.";
+
+// ---------------------------------------------------------------------------
+// Read-back helpers (effective, post-layer characteristics)
+// ---------------------------------------------------------------------------
+
+/// CR 613.1: re-derive every characteristic from the printed base plus all live
+/// continuous effects. Called before each read-back so nothing is stale.
+fn relayer(runner: &mut GameRunner) {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+}
+
+fn has_subtype(runner: &GameRunner, id: ObjectId, subtype: &str) -> bool {
+    runner.state().objects[&id]
+        .card_types
+        .subtypes
+        .iter()
+        .any(|s| s.eq_ignore_ascii_case(subtype))
+}
+
+fn has_core_type(runner: &GameRunner, id: ObjectId, core_type: CoreType) -> bool {
+    runner.state().objects[&id]
+        .card_types
+        .core_types
+        .contains(&core_type)
+}
+
+fn has_supertype(runner: &GameRunner, id: ObjectId, supertype: Supertype) -> bool {
+    runner.state().objects[&id]
+        .card_types
+        .supertypes
+        .contains(&supertype)
+}
+
+fn plus_one_counters(runner: &GameRunner, id: ObjectId) -> u32 {
+    runner.state().objects[&id]
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0)
+}
+
+fn effective_pt(runner: &GameRunner, id: ObjectId) -> (i32, i32) {
+    let obj = &runner.state().objects[&id];
+    (
+        obj.power.expect("creature has power"),
+        obj.toughness.expect("creature has toughness"),
+    )
+}
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+/// Borg Queen in P0's hand at `ManaCost::zero()`.
+///
+/// The mana cost is deliberately zero: it is not under test, a pool-funded
+/// zero-cost cast never surfaces a `ManaPayment` window, and it keeps P0's
+/// devotion to black/green at 0 — which test 7's `Not(DevotionGE)` fixture
+/// depends on. Her own type line is likewise not set: no assertion in this file
+/// reads it, the lord's `affected` filter is evaluated against the OBJECTS it
+/// modifies (not against its source's types), and leaving the `Legendary`
+/// supertype off keeps CR 704.5j out of test 4's two-Queen fixture.
+fn borg_queen_in_hand(scenario: &mut GameScenario) -> ObjectId {
+    scenario
+        .add_creature_to_hand_from_oracle(P0, "Borg Queen, Perfection Manifest", 1, 4, BORG_QUEEN)
+        .with_mana_cost(ManaCost::zero())
+        .id()
+}
+
+/// The hostile victim for tests 2, 5 and 6: a `Legendary Artifact Enchantment
+/// Creature — Human Wizard Equipment`, printed 2/2, in P1's graveyard.
+///
+/// Every axis of the CR 205.1b table is probed by ONE object: two creature
+/// subtypes to replace, one ARTIFACT subtype (`Equipment`) to retain, a
+/// non-`Artifact`/non-`Creature` card type (`Enchantment`) to retain, and a
+/// supertype (`Legendary`) to retain. `as_artifact()`/`as_enchantment()` each
+/// strip `Creature`, so `as_creature()` runs last to restore it.
+fn hostile_victim_in_p1_graveyard(scenario: &mut GameScenario) -> ObjectId {
+    scenario
+        .add_creature_to_graveyard(P1, "Assimilation Test Subject", 2, 2)
+        .as_artifact()
+        .as_enchantment()
+        .as_creature()
+        .as_legendary()
+        .with_subtypes(vec!["Human", "Wizard", "Equipment"])
+        .id()
+}
+
+/// Seeds `all_creature_types` for the hostile-victim fixture. `"Equipment"` is
+/// deliberately ABSENT — that absence is what makes the non-creature-subtype
+/// retention assertion meaningful (CR 205.1b).
+fn seed_hostile_creature_types(runner: &mut GameRunner) {
+    runner.state_mut().all_creature_types = vec![
+        "Human".to_string(),
+        "Wizard".to_string(),
+        "Borg".to_string(),
+        "Noble".to_string(),
+    ];
+}
+
+// ---------------------------------------------------------------------------
+// Test 2 — the full CR 205.1b table
+// ---------------------------------------------------------------------------
+
+/// CR 205.1b: assimilation ADDS `Artifact` + `Creature`, REPLACES the creature
+/// subtype set with exactly `Borg`, and RETAINS every prior card type,
+/// supertype, and non-creature subtype. Plus CR 110.2a's controller override,
+/// CR 108.3's unchanged ownership, and CR 122.1's entry counter.
+///
+/// Revert-failing: at BASE_SHA the ETB trigger is `Effect::Unimplemented`, so
+/// the victim never leaves the graveyard and reach-guard 2.1 fails first.
+#[test]
+fn assimilate_applies_the_full_cr_205_1b_type_change() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let victim = hostile_victim_in_p1_graveyard(&mut scenario);
+    let borg_queen = borg_queen_in_hand(&mut scenario);
+    let mut runner = scenario.build();
+    seed_hostile_creature_types(&mut runner);
+
+    let outcome = runner.cast(borg_queen).target_objects(&[victim]).resolve();
+
+    // 2.1 REACH-GUARD (CR 110.2a). Every negative assertion below is
+    // non-vacuous only because this passes.
+    outcome.assert_zone(&[victim], Zone::Battlefield);
+
+    // 2.2 CR 110.2a + CR 108.3: controlled by us, still OWNED by the opponent.
+    assert_eq!(
+        runner.state().objects[&victim].controller,
+        P0,
+        "CR 110.2a: the assimilated permanent enters under the instruction's controller"
+    );
+    assert_eq!(
+        runner.state().objects[&victim].owner,
+        P1,
+        "CR 108.3: ownership never changes"
+    );
+
+    relayer(&mut runner);
+
+    // 2.3 CR 122.1 + CR 613.4c: exactly one +1/+1 counter, and the effective P/T
+    // is printed 2/2 + the counter (1,1) + Borg Queen's own +2/+0 lord — which
+    // the victim now matches BECAUSE assimilation made it an artifact creature
+    // under her controller.
+    assert_eq!(
+        plus_one_counters(&runner, victim),
+        1,
+        "CR 122.1: the victim enters with exactly one +1/+1 counter"
+    );
+    assert_eq!(
+        effective_pt(&runner, victim),
+        (5, 3),
+        "CR 613.4c: printed 2/2 + (1,1) counter + (2,0) from Borg Queen's artifact-creature lord"
+    );
+
+    // 2.4 CR 205.1a: the new creature type is present.
+    assert!(
+        has_subtype(&runner, victim, "Borg"),
+        "CR 205.1a: the assimilated permanent gains the Borg creature type"
+    );
+
+    // 2.5 THE DISCRIMINATING ASSERTION (paired with 2.1 and 2.4): CR 205.1b
+    // REPLACES the creature types rather than merging them.
+    assert!(
+        !has_subtype(&runner, victim, "Human"),
+        "CR 205.1b: prior creature types are REPLACED, not merged"
+    );
+    assert!(
+        !has_subtype(&runner, victim, "Wizard"),
+        "CR 205.1b: prior creature types are REPLACED, not merged"
+    );
+
+    // 2.6 CR 205.1b: non-creature subtypes are retained. `Equipment` is an
+    // ARTIFACT subtype, and the wipe is scoped to `SubtypeSet::Creature`.
+    assert!(
+        has_subtype(&runner, victim, "Equipment"),
+        "CR 205.1b: non-creature subtypes (Equipment is an artifact subtype) are RETAINED"
+    );
+
+    // 2.7 Regression tripwire only. NOT discriminating on this fixture: the
+    // victim is a PRINTED artifact AND a printed creature, so this leg passes
+    // even with both `AddType`s removed. `AddType{Artifact}` is discriminated by
+    // test 4's Goblin victim and by test 7; `AddType{Creature}` only by test 7.
+    assert!(has_core_type(&runner, victim, CoreType::Artifact));
+    assert!(has_core_type(&runner, victim, CoreType::Creature));
+
+    // 2.8 CR 205.1b: prior card types are RETAINED. This is the assertion a
+    // `SetCardTypes` (set-replacement) implementation fails.
+    assert!(
+        has_core_type(&runner, victim, CoreType::Enchantment),
+        "CR 205.1b: prior card types are RETAINED — a SetCardTypes implementation fails here"
+    );
+
+    // 2.9 CR 205.1b: supertypes are RETAINED.
+    assert!(
+        has_supertype(&runner, victim, Supertype::Legendary),
+        "CR 205.1b: supertypes are RETAINED"
+    );
+
+    // 2.10 CR 613.1: a second layer pass must reproduce the same answer. Every
+    // pass resets `obj.card_types` to `base_card_types` and re-applies the live
+    // continuous effects, so a one-shot mutation of `card_types` would be erased
+    // here.
+    relayer(&mut runner);
+    assert!(has_subtype(&runner, victim, "Borg"));
+    assert!(!has_subtype(&runner, victim, "Human"));
+    assert!(!has_subtype(&runner, victim, "Wizard"));
+    assert!(has_subtype(&runner, victim, "Equipment"));
+    assert!(has_core_type(&runner, victim, CoreType::Artifact));
+    assert!(has_core_type(&runner, victim, CoreType::Creature));
+    assert!(has_core_type(&runner, victim, CoreType::Enchantment));
+    assert!(
+        has_supertype(&runner, victim, Supertype::Legendary),
+        "CR 613.1: the override is a re-derived layer-4 continuous effect, not a one-shot mutation"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 3 — fail-closed / negative-sibling coverage
+// ---------------------------------------------------------------------------
+
+/// 3a. CR 115.2: the filter's `Creature` leg. With only a LAND card in the
+/// opponent's graveyard the ETB trigger has no legal target, so nothing enters.
+/// Paired positive reach-guard: Borg Queen herself IS on the battlefield, so the
+/// cast demonstrably resolved.
+#[test]
+fn assimilate_finds_no_target_when_the_opponent_graveyard_holds_only_a_land() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let land = scenario.add_land_to_graveyard(P1, "Wastes").id();
+    let borg_queen = borg_queen_in_hand(&mut scenario);
+    let mut runner = scenario.build();
+    seed_hostile_creature_types(&mut runner);
+
+    let outcome = runner.cast(borg_queen).resolve();
+
+    // Positive reach-guard: the cast resolved.
+    outcome.assert_zone(&[borg_queen], Zone::Battlefield);
+    // CR 115.2: a land card is not a legal `target creature card`.
+    outcome.assert_zone(&[land], Zone::Graveyard);
+}
+
+/// 3b. CR 108.3: the `Owned { controller: Opponent }` leg. A creature card in
+/// P0's OWN graveyard is not a legal target.
+///
+/// This case also passes at BASE_SHA (where nothing moves at all), so it is a
+/// GUARD against a future filter regression, not a revert-failing test. The
+/// paired positive reach-guard keeps it from being vacuous about the cast.
+#[test]
+fn assimilate_cannot_take_a_card_from_its_own_controllers_graveyard() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let own_card = scenario
+        .add_creature_to_graveyard(P0, "Own Graveyard Wizard", 2, 2)
+        .with_subtypes(vec!["Human", "Wizard"])
+        .id();
+    let borg_queen = borg_queen_in_hand(&mut scenario);
+    let mut runner = scenario.build();
+    seed_hostile_creature_types(&mut runner);
+
+    let outcome = runner.cast(borg_queen).resolve();
+
+    // Positive reach-guard: the cast resolved.
+    outcome.assert_zone(&[borg_queen], Zone::Battlefield);
+    // CR 108.3: "an opponent's graveyard" restricts by OWNERSHIP.
+    outcome.assert_zone(&[own_card], Zone::Graveyard);
+}
+
+/// 3c. Parser fail-closed: an `assimilate` phrasing whose target is NOT a
+/// graveyard card is a shape this production does not model, so it must keep
+/// producing `Effect::Unimplemented` and coverage must stay honestly RED rather
+/// than be silently lowered into a reanimation. `name` is `"assimilate"` because
+/// the imperative fallback derives it from the clause's first word.
+///
+/// Paired positive: the real card's phrasing in the same test produces a
+/// `ChangeZone`, so the negative is about the graveyard guard and not about a
+/// production that never fires.
+#[test]
+fn assimilate_without_a_graveyard_target_stays_unimplemented() {
+    let non_graveyard = parse_effect("assimilate target creature you control");
+    assert!(
+        matches!(
+            &non_graveyard,
+            Effect::Unimplemented { name, .. } if name == "assimilate"
+        ),
+        "a non-graveyard assimilate phrasing must stay honestly unsupported, got {non_graveyard:?}"
+    );
+
+    let real = parse_effect("assimilate target creature card from an opponent's graveyard");
+    assert!(
+        matches!(real, Effect::ChangeZone { .. }),
+        "reach-guard: the printed phrasing must lower to a ChangeZone, got {real:?}"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 4 — multi-authority identity binding
+// ---------------------------------------------------------------------------
+
+/// CR 611.2c + CR 400.7: two independent assimilations install two transient
+/// continuous effects, each frozen to its OWN `SpecificObject { id }`. Neither
+/// broadcasts onto the other's victim, and killing one victim prunes only its
+/// own effect.
+///
+/// Victim B is a plain `Goblin` with NO printed `Artifact` — that is what makes
+/// 4.3's `Artifact` leg discriminate `AddType { core_type: Artifact }`. Do not
+/// make victim B an artifact.
+#[test]
+fn two_assimilations_bind_to_distinct_objects_and_prune_independently() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let victim_a = scenario
+        .add_creature_to_graveyard(P1, "Graveyard Wizard", 2, 2)
+        .with_subtypes(vec!["Human", "Wizard"])
+        .id();
+    let victim_b = scenario
+        .add_creature_to_graveyard(P1, "Graveyard Goblin", 1, 1)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    let queen_one = borg_queen_in_hand(&mut scenario);
+    let queen_two = borg_queen_in_hand(&mut scenario);
+    let mut runner = scenario.build();
+    runner.state_mut().all_creature_types = vec![
+        "Human".to_string(),
+        "Wizard".to_string(),
+        "Goblin".to_string(),
+        "Borg".to_string(),
+        "Noble".to_string(),
+    ];
+
+    let first = runner.cast(queen_one).target_objects(&[victim_a]).resolve();
+    first.assert_zone(&[victim_a], Zone::Battlefield);
+    let second = runner.cast(queen_two).target_objects(&[victim_b]).resolve();
+    second.assert_zone(&[victim_b], Zone::Battlefield);
+
+    relayer(&mut runner);
+
+    // 4.1 Both under P0's control (CR 110.2a), each with exactly one counter
+    // (CR 122.1).
+    assert_eq!(runner.state().objects[&victim_a].controller, P0);
+    assert_eq!(runner.state().objects[&victim_b].controller, P0);
+    assert_eq!(plus_one_counters(&runner, victim_a), 1);
+    assert_eq!(plus_one_counters(&runner, victim_b), 1);
+
+    // 4.2 CR 611.2c: neither victim carries the other's pre-assimilation
+    // creature types, so the two effects bound to distinct objects rather than
+    // broadcasting.
+    assert!(has_subtype(&runner, victim_a, "Borg"));
+    assert!(!has_subtype(&runner, victim_a, "Human"));
+    assert!(!has_subtype(&runner, victim_a, "Wizard"));
+    assert!(
+        !has_subtype(&runner, victim_a, "Goblin"),
+        "CR 611.2c: victim A must not receive victim B's creature types"
+    );
+    assert!(has_subtype(&runner, victim_b, "Borg"));
+    assert!(!has_subtype(&runner, victim_b, "Goblin"));
+    assert!(
+        !has_subtype(&runner, victim_b, "Human") && !has_subtype(&runner, victim_b, "Wizard"),
+        "CR 611.2c: victim B must not receive victim A's creature types"
+    );
+
+    // 4.3 CR 400.7: victim A leaving the battlefield prunes ONLY its own effect.
+    // Victim B's `Artifact` here is the DISCRIMINATING leg for
+    // `AddType { Artifact }` — victim B is printed as a plain Goblin creature.
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), victim_a, Zone::Graveyard, &mut events);
+    relayer(&mut runner);
+    assert!(
+        has_subtype(&runner, victim_b, "Borg"),
+        "CR 400.7: pruning victim A's effect must not touch victim B's"
+    );
+    assert!(
+        has_core_type(&runner, victim_b, CoreType::Artifact),
+        "AddType{{Artifact}} is the only reason a printed Goblin creature is an artifact"
+    );
+
+    // 4.4 CR 400.7: victim A returns as a NEW object with no memory of the
+    // override, paired with the positive reach-guard that it really is back on
+    // the battlefield.
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), victim_a, Zone::Battlefield, &mut events);
+    relayer(&mut runner);
+    assert_eq!(
+        runner.state().objects[&victim_a].zone,
+        Zone::Battlefield,
+        "reach-guard: victim A is back on the battlefield"
+    );
+    assert!(
+        !has_subtype(&runner, victim_a, "Borg"),
+        "CR 400.7: the returned object is a new object and is not Borg"
+    );
+    assert!(
+        has_subtype(&runner, victim_a, "Human"),
+        "CR 400.7: the returned object has its printed creature types back"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 5 — source independence
+// ---------------------------------------------------------------------------
+
+/// CR 611.2a: a continuous effect created by a resolving ability with no stated
+/// duration lasts until the end of the game and is INDEPENDENT of its source.
+/// Destroying Borg Queen must not end the type override.
+///
+/// The DISCRIMINATING legs are `Borg` present and `Human`/`Wizard` absent — the
+/// `Artifact`/`Creature` legs would pass on this printed-artifact-creature
+/// fixture even with both `AddType`s removed (see 2.7). This test also proves
+/// independently that the TYPE override is source-independent while the lord
+/// BUFF correctly is not: the +2/+0 disappears with her.
+///
+/// Guards against a future "simplification" of the duration to
+/// `UntilHostLeavesPlay`, which `transient_effect_is_live` would then prune.
+#[test]
+fn assimilated_permanent_keeps_its_types_after_borg_queen_dies() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let victim = hostile_victim_in_p1_graveyard(&mut scenario);
+    let borg_queen = borg_queen_in_hand(&mut scenario);
+    let mut runner = scenario.build();
+    seed_hostile_creature_types(&mut runner);
+
+    let outcome = runner.cast(borg_queen).target_objects(&[victim]).resolve();
+    outcome.assert_zone(&[victim], Zone::Battlefield);
+
+    // Baseline WITH Borg Queen present: printed 2/2 + (1,1) counter + (2,0) lord.
+    relayer(&mut runner);
+    assert_eq!(effective_pt(&runner, victim), (5, 3));
+
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), borg_queen, Zone::Graveyard, &mut events);
+    relayer(&mut runner);
+
+    assert_eq!(
+        runner.state().objects[&borg_queen].zone,
+        Zone::Graveyard,
+        "reach-guard: Borg Queen really left the battlefield"
+    );
+
+    // CR 611.2a: the type override survives its source.
+    assert!(
+        has_subtype(&runner, victim, "Borg"),
+        "CR 611.2a: the override is independent of its source once created"
+    );
+    assert!(!has_subtype(&runner, victim, "Human"));
+    assert!(!has_subtype(&runner, victim, "Wizard"));
+    assert!(has_core_type(&runner, victim, CoreType::Artifact));
+    assert!(has_core_type(&runner, victim, CoreType::Creature));
+
+    // CR 611.3b (a continuous effect from a STATIC ability applies only while the
+    // permanent generating it is on the battlefield): her LORD, by contrast, stops
+    // applying — printed 2/2 + (1,1) counter only, with NO +2/+0.
+    assert_eq!(
+        effective_pt(&runner, victim),
+        (3, 3),
+        "Borg Queen's static lord ends with her; only the counter remains"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 6 — the override survives cleanup into the next turn
+// ---------------------------------------------------------------------------
+
+/// CR 611.2a: `Duration::Permanent`, exercised through the PRODUCTION end-of-turn
+/// prune. This is the ONLY runtime test that can catch a missing
+/// `Duration::Permanent`.
+///
+/// The failure mode: `game/effects/effect.rs`'s
+/// `ability.duration.or(duration).unwrap_or(Duration::UntilEndOfTurn)` silently
+/// degrades an unset duration to `UntilEndOfTurn`, and
+/// `layers.rs::prune_end_of_turn_effects` (reached from `turns.rs`) DROPS exactly
+/// those at cleanup. Tests 2-5 all run inside one turn, so none of them observes
+/// the prune. The shape assertion in the parser SHAPE test passes by
+/// construction and is not a substitute for this.
+#[test]
+fn assimilated_types_survive_cleanup_into_the_next_turn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let victim = hostile_victim_in_p1_graveyard(&mut scenario);
+    let borg_queen = borg_queen_in_hand(&mut scenario);
+    let mut runner = scenario.build();
+    seed_hostile_creature_types(&mut runner);
+
+    let outcome = runner.cast(borg_queen).target_objects(&[victim]).resolve();
+    // Confirmed BEFORE advancing — this is what makes the post-cleanup
+    // assertions non-vacuous.
+    outcome.assert_zone(&[victim], Zone::Battlefield);
+    relayer(&mut runner);
+    assert!(
+        has_subtype(&runner, victim, "Borg"),
+        "baseline: the override is in place before the turn advances"
+    );
+
+    let turn_before = runner.state().turn_number;
+
+    // Cross the end step AND the cleanup step into the next turn, running the
+    // real `prune_end_of_turn_effects` call site rather than invoking it by hand.
+    runner.advance_to_upkeep();
+
+    // 6.2 POSITIVE VACUITY GUARD: the turn really advanced past cleanup, so a
+    // no-op advance cannot make the assertions below pass for free.
+    assert_eq!(
+        runner.state().phase,
+        Phase::Upkeep,
+        "the advance must land in the next turn's upkeep step"
+    );
+    assert!(
+        runner.state().turn_number > turn_before,
+        "the turn counter must have advanced past cleanup, was {turn_before}"
+    );
+
+    relayer(&mut runner);
+
+    // 6.1 REACH-GUARD: the victim did not die to an unrelated state-based action.
+    assert_eq!(
+        runner.state().objects[&victim].zone,
+        Zone::Battlefield,
+        "CR 400.7: reach-guard — the victim is still on the battlefield"
+    );
+
+    // 6.3 / 6.4 CR 205.1a + CR 205.1b: these fail if — and among these tests only
+    // if — the installed effect's duration degraded to `UntilEndOfTurn`.
+    assert!(
+        has_subtype(&runner, victim, "Borg"),
+        "CR 611.2a: Duration::Permanent must survive the cleanup-step prune"
+    );
+    assert!(!has_subtype(&runner, victim, "Human"));
+    assert!(!has_subtype(&runner, victim, "Wizard"));
+
+    // 6.5 The discriminating legs here are `Enchantment` and `Legendary`
+    // retention; the `Artifact`+`Creature` legs inherit 2.7's printed types.
+    assert!(has_core_type(&runner, victim, CoreType::Artifact));
+    assert!(has_core_type(&runner, victim, CoreType::Creature));
+    assert!(has_core_type(&runner, victim, CoreType::Enchantment));
+    assert!(has_supertype(&runner, victim, Supertype::Legendary));
+
+    // 6.6 CR 122.1: a counter is not a duration-bound effect. This separates a
+    // counter regression from a duration regression.
+    assert_eq!(
+        plus_one_counters(&runner, victim),
+        1,
+        "CR 122.1: the +1/+1 counter is not duration-bound"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Test 7 — the AddType modifications are load-bearing
+// ---------------------------------------------------------------------------
+
+/// CR 613.7n: when a resolving ability both puts a permanent onto the
+/// battlefield and sets its characteristics (CR 611.2e's paradigm case), the
+/// continuous effect from the permanent's OWN static ability receives an EARLIER
+/// relative timestamp. So a victim whose own static removes its `Creature` card
+/// type applies FIRST, and our later `AddType { Creature }` must restore it
+/// (CR 613.7). The engine implements this by construction — the entry timestamp
+/// is drawn before the resolution's transient effect.
+///
+/// This is the ONLY test that discriminates `AddType { Creature }`, and the
+/// second that discriminates `AddType { Artifact }` (Pharika has no printed
+/// `Artifact`).
+///
+/// PRE-COMMITMENT — do not resolve a failure here by weakening the test:
+///   * If 7.1 and 7.2 pass but the `Creature` assertion FAILS, the expected value
+///     is `Creature` PRESENT. On a faithful implementation that is a finding
+///     about the engine's layer-4 ordering (CR 613.7n) — surface it. Never delete
+///     the assertion, and never delete `AddType { Creature }` from the lowering.
+///   * If 7.2 fails (the control Pharika IS a creature), the FIXTURE is at fault:
+///     the devotion condition is not firing. Fix the fixture (fewer black/green
+///     pips, or switch to `Erebos, God of the Dead` at devotion-to-black < 5),
+///     never the guard. A test with 7.2 failing is VACUOUS.
+///   * Effective P/T is 5/5 printed + (1,1) counter + (2,0) lord = 8/6. Observing
+///     6/6 means an `AddType` did not apply (so the victim missed the
+///     artifact-creature lord) — a bug in the implementation, NOT in the layer
+///     engine.
+#[test]
+fn assimilate_restores_a_creature_type_its_victims_own_static_removes() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Victim: Pharika in P1's graveyard. Identity setters FIRST, Oracle text
+    // LAST — `from_oracle_text` overwrites abilities/statics but preserves
+    // identity (name, P/T, card_types, mana cost). Deliberately NOT an artifact:
+    // the absence of a printed `Artifact` is what makes the Artifact assertion
+    // discriminating.
+    let victim = scenario
+        .add_creature_to_graveyard(P1, "Pharika, God of Affliction", 5, 5)
+        .as_enchantment()
+        .as_creature()
+        .as_legendary()
+        .with_subtypes(vec!["God"])
+        .from_oracle_text(PHARIKA)
+        .id();
+
+    // CONTROL COPY (the vacuity guard): a second Pharika already on the
+    // battlefield under P1. Legal alongside the assimilated copy because
+    // CR 704.5j is PER-PLAYER — after resolution the two are controlled by
+    // different players, so the legend rule does not fire. Built with the SAME
+    // identity-first / Oracle-last order as the victim so the two copies cannot
+    // parse differently.
+    let control = scenario
+        .add_creature(P1, "Pharika, God of Affliction", 5, 5)
+        .as_enchantment()
+        .as_creature()
+        .as_legendary()
+        .with_subtypes(vec!["God"])
+        .from_oracle_text(PHARIKA)
+        .id();
+
+    let borg_queen = borg_queen_in_hand(&mut scenario);
+    let mut runner = scenario.build();
+    // Same mandatory foot-gun as test 2: without "God" here the subtype wipe is a
+    // no-op and 7.7 would pass vacuously.
+    runner.state_mut().all_creature_types =
+        vec!["God".to_string(), "Borg".to_string(), "Noble".to_string()];
+
+    let outcome = runner.cast(borg_queen).target_objects(&[victim]).resolve();
+
+    // 7.1 REACH-GUARD (CR 110.2a).
+    outcome.assert_zone(&[victim], Zone::Battlefield);
+    assert_eq!(runner.state().objects[&victim].controller, P0);
+
+    relayer(&mut runner);
+
+    // 7.2 VACUITY GUARD (CR 613.1d + CR 613.7a): the un-assimilated control
+    // Pharika is NOT a creature, which proves the `Not(DevotionGE)` static is
+    // live in this game state — so 7.3 below is a genuine override and not a
+    // tautology.
+    assert!(
+        !has_core_type(&runner, control, CoreType::Creature),
+        "VACUITY GUARD: the control Pharika's own static must be removing Creature \
+         in this state; if it is not, fix the FIXTURE (devotion pips), not the assertion"
+    );
+
+    // 7.3 CR 205.1b + CR 613.7n + CR 613.7: the ONLY assertion that discriminates
+    // `AddType { core_type: Creature }`.
+    assert!(
+        has_core_type(&runner, victim, CoreType::Creature),
+        "CR 613.7n: the victim's own earlier-timestamped static removes Creature, so \
+         AddType{{Creature}} at the later timestamp must restore it"
+    );
+
+    // 7.4 CR 205.1b: discriminates `AddType { core_type: Artifact }` — Pharika has
+    // no printed `Artifact` card type.
+    assert!(
+        has_core_type(&runner, victim, CoreType::Artifact),
+        "CR 205.1b: AddType{{Artifact}} is the only reason Pharika is an artifact"
+    );
+
+    // 7.5 CR 205.1b: prior card types retained on a two-card-type fixture — the
+    // assertion a `SetCardTypes` implementation fails.
+    assert!(
+        has_core_type(&runner, victim, CoreType::Enchantment),
+        "CR 205.1b: Enchantment is RETAINED"
+    );
+
+    // 7.6 CR 205.1b: supertype retained.
+    assert!(has_supertype(&runner, victim, Supertype::Legendary));
+
+    // 7.7 CR 205.1a + CR 205.1b: creature-type replacement.
+    assert!(has_subtype(&runner, victim, "Borg"));
+    assert!(
+        !has_subtype(&runner, victim, "God"),
+        "CR 205.1b: God is replaced, not merged"
+    );
+
+    // 7.8 CR 122.1 + CR 613.4c: 5/5 printed + (1,1) counter + (2,0) from Borg
+    // Queen's artifact-creature lord. This is a STRONGER discriminator than the
+    // bare counter arithmetic: reaching 8/6 requires BOTH `AddType`s to have
+    // landed, because the lord's conjunctive `[Creature, Artifact]` filter only
+    // matches once the victim is both. A 6/6 here means an `AddType` was dropped.
+    assert_eq!(
+        plus_one_counters(&runner, victim),
+        1,
+        "CR 122.1: exactly one +1/+1 counter"
+    );
+    assert_eq!(
+        effective_pt(&runner, victim),
+        (8, 6),
+        "CR 613.4c: 5/5 + (1,1) counter + (2,0) lord — the lord applies only because \
+         BOTH AddTypes landed"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -54,6 +54,7 @@ mod blessed_orator_other_anthem;
 mod bolas_citadel_regression;
 mod boneyard_parley_pile_separation;
 mod boon_reflection_gain_life_drain;
+mod borg_queen_assimilate;
 mod bounce_destination_redirect;
 mod bound_by_moonsilver_sacrifice_source_relative_6017;
 mod braids_arisen_nightmare_decline;


### PR DESCRIPTION
Lower `assimilate <target>` to the reanimate-then-retype chain the engine
already ships: move the targeted card from an opponent's graveyard to the
battlefield under your control with a +1/+1 counter, then install a
permanent layer-4 type override making it a Borg artifact creature that
loses its other creature types.

The keyword action's definition arrives only as reminder text, which is
stripped before the parser runs, so it is encoded in lowering rather than
parsed -- the same reason Recruit is a parser IR node (CR 701.70a).

CR 205.1b: an effect making an object a "[creature type or types] artifact
creature" retains all prior card types, supertypes, and non-creature
subtypes, and replaces only the creature types. So the lowering emits
additive AddTypes plus a creature-set-scoped subtype replacement, never
SetCardTypes -- an assimilated legendary artifact enchantment creature
keeps Legendary and Enchantment.

All four modifications ride one StaticDefinition because they are all
layer 4 (CR 613.1d), so written order decides: RemoveAllSubtypes{Creature}
must precede AddSubtype{Borg} or the wipe erases Borg. Split across
separate definitions they would instead order by CR 613.7 timestamp.

Duration is explicitly Permanent (CR 611.2a): the GenericEffect fallback
is UntilEndOfTurn, which would silently expire the type change at cleanup
without failing any shape assertion.

`origin` is None, matching Ashen Powder and Puppeteer Clique for the same
"from an opponent's graveyard" phrase. Some(Graveyard) would additionally
flip AI reanimation detection for this card alone while mechanically
identical cards stayed unflipped.

AddType{Creature} is required rather than defensive: per CR 613.7n a
permanent's own static ability receives an earlier relative timestamp than
a characteristic-setting effect from the same resolution, so a
devotion-gated RemoveType{Creature} would otherwise win.

Registers the verb in gap_analysis::IMPERATIVE_EXTRA_VERBS, mirroring
recruit, which is likewise an anchored pre-dispatch nom probe.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `assimilate` action.
  * Valid graveyard targets are returned to the battlefield under the controller’s control, gain a +1/+1 counter, and become Artifact Creatures with the Borg subtype.
  * Existing card types and supertypes are preserved.

* **Bug Fixes**
  * Prevented longer words containing “assimilate” from being incorrectly recognized as the action.

* **Tests**
  * Added parser and gameplay coverage for targeting, counters, type changes, ownership, persistence, and layer interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->