### PR TITLE
fix(visibility): keep debug library identities out of normal state

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2838,6 +2838,12 @@ export interface TurnOrderSlotView {
 /** CR 509.1g: engine-authored public `(blocker, attacker)` combat display pair. */
 export type BlockerAssignmentPair = [ObjectId, ObjectId];
 
+/** Debug-only card identity authorized for the viewing player's library browser. */
+export interface DebugLibraryCardView {
+  object_id: ObjectId;
+  name: string;
+}
+
 /**
  * Engine-authored projections computed at each state snapshot. Rides
  * alongside GameState through every adapter path. Frontend components
@@ -2847,6 +2853,12 @@ export type BlockerAssignmentPair = [ObjectId, ObjectId];
  */
 export interface DerivedViews {
   unique_authorized_submitter?: PlayerId;
+  /**
+   * Explicit debug-only identities for the viewing player's library. Normal
+   * library objects remain hidden in `GameState.objects`; only the debug
+   * browser consumes this separately authorized projection.
+   */
+  debug_library_cards?: DebugLibraryCardView[];
   /**
    * Engine-classified live keyword badges for battlefield permanents. The
    * strip renders this map directly rather than deciding which keyword timing

--- a/client/src/components/chrome/DebugLibraryViewer.tsx
+++ b/client/src/components/chrome/DebugLibraryViewer.tsx
@@ -1,9 +1,8 @@
 import { useCallback, useMemo, useState, type CSSProperties } from "react";
 
-import type { DebugAction, GameObject } from "../../adapter/types";
+import type { DebugAction, DebugLibraryCardView } from "../../adapter/types";
 import { CardImage } from "../card/CardImage";
 import { ModalPanelShell } from "../ui/ModalPanelShell";
-import { useInspectHoverProps } from "../../hooks/useInspectHoverProps";
 import { useGameDispatch } from "../../hooks/useGameDispatch";
 import { useGameStore } from "../../stores/gameStore";
 import { useUiStore } from "../../stores/uiStore";
@@ -14,10 +13,10 @@ import { useUiStore } from "../../stores/uiStore";
  * scrubbing through a dropdown.
  *
  * The cards are shown in a STABLE RANDOMIZED order rather than their true
- * library order. The engine deliberately leaves the on-wire `library` Vec order
- * untouched (debug exposes card *names* but must not leak *draw order*, per
- * `visibility.rs`), so this view shuffles the display once per open. Moving a
- * card out simply removes it from its slot — the rest keep their positions.
+ * library order. The engine supplies a separate, authorized debug projection
+ * rather than revealing normal library objects, and this view shuffles it once
+ * per open. Moving a card out simply removes it from its slot — the rest keep
+ * their positions.
  */
 export function DebugLibraryViewer() {
   const viewer = useUiStore((s) => s.debugLibraryViewer);
@@ -35,8 +34,7 @@ function DebugLibraryViewerInner({
   playerId: number;
   onClose: () => void;
 }) {
-  const objects = useGameStore((s) => s.gameState?.objects);
-  const libraryIds = useGameStore((s) => s.gameState?.players[playerId]?.library);
+  const libraryCards = useGameStore((s) => s.gameState?.derived?.debug_library_cards);
   const openDebugContextMenu = useUiStore((s) => s.openDebugContextMenu);
   const dispatch = useGameDispatch();
 
@@ -45,17 +43,14 @@ function DebugLibraryViewerInner({
   const [seed] = useState(() => Math.floor(Math.random() * 2 ** 31));
 
   const cards = useMemo(() => {
-    if (!objects || !libraryIds) return [];
+    if (!libraryCards) return [];
     const rank = (id: number) => {
       // Deterministic per (seed, id) pseudo-random key — a stable shuffle.
       const x = Math.sin((id + 1) * (seed + 1)) * 43758.5453;
       return x - Math.floor(x);
     };
-    return libraryIds
-      .map((id) => objects[id])
-      .filter((obj): obj is GameObject => Boolean(obj))
-      .sort((a, b) => rank(a.id) - rank(b.id));
-  }, [objects, libraryIds, seed]);
+    return [...libraryCards].sort((a, b) => rank(a.object_id) - rank(b.object_id));
+  }, [libraryCards, seed]);
 
   const move = useCallback(
     (objectId: number, toZone: "Battlefield" | "Hand") => {
@@ -91,12 +86,12 @@ function DebugLibraryViewerInner({
               } as CSSProperties
             }
           >
-            {cards.map((obj) => (
+            {cards.map((card) => (
               <LibraryCard
-                key={obj.id}
-                obj={obj}
-                onOpenMenu={(x, y) => openDebugContextMenu({ objectId: obj.id, x, y })}
-                onMove={(zone) => move(obj.id, zone)}
+                key={card.object_id}
+                card={card}
+                onOpenMenu={(x, y) => openDebugContextMenu({ objectId: card.object_id, x, y })}
+                onMove={(zone) => move(card.object_id, zone)}
               />
             ))}
           </div>
@@ -107,26 +102,23 @@ function DebugLibraryViewerInner({
 }
 
 function LibraryCard({
-  obj,
+  card,
   onOpenMenu,
   onMove,
 }: {
-  obj: GameObject;
+  card: DebugLibraryCardView;
   onOpenMenu: (x: number, y: number) => void;
   onMove: (zone: "Battlefield" | "Hand") => void;
 }) {
-  const hoverProps = useInspectHoverProps();
-
   return (
     <div
       className="group relative shrink-0 cursor-pointer rounded-lg transition-transform hover:scale-[1.03] hover:ring-1 hover:ring-white/20"
-      {...hoverProps(obj.id)}
       onClick={(e) => {
         e.stopPropagation();
         onOpenMenu(e.clientX, e.clientY);
       }}
     >
-      <CardImage cardName={obj.name} size="normal" />
+      <CardImage cardName={card.name} size="normal" />
       {/* Quick-move buttons for the two most common debug destinations; the
           full zone list is one click away via the card's debug context menu. */}
       <div className="pointer-events-none absolute inset-x-0 bottom-0 flex justify-center gap-1 rounded-b-lg bg-black/60 p-1 opacity-0 transition-opacity group-hover:pointer-events-auto group-hover:opacity-100">

--- a/client/src/components/chrome/DebugPlayerActions.tsx
+++ b/client/src/components/chrome/DebugPlayerActions.tsx
@@ -225,10 +225,9 @@ function ModifyEnergyForm({ onDispatch }: Props) {
 }
 
 // Opens the debug library browser for the local (perspective) player. The
-// engine only exposes the viewer's OWN library names while that viewer has an
-// active debug capability (`visibility.rs`), so this is intentionally scoped
-// to the perspective seat rather than offering a player picker that would
-// render opponent backs.
+// engine supplies its separately authorized OWN-library debug projection, so
+// this remains scoped to the perspective seat rather than offering a picker
+// that could expose opponent library identities.
 function BrowseLibraryForm() {
   const openDebugLibraryViewer = useUiStore((s) => s.openDebugLibraryViewer);
   const perspectivePlayerId = usePerspectivePlayerId();

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -914,18 +914,7 @@ pub fn initialize_game(
     }
 
     let mut state = GameState::new(format_config.clone(), count, seed);
-    state.debug_mode = true;
-    // Sandbox capability: in a P2P-host (WASM-authoritative) game, the
-    // `submit_action` gate checks `debug_permitted`, mirroring server-core's
-    // WebSocket gate. server-core seeds every seat when `allow_debug_actions`
-    // is set (session.rs); the WASM host must do the same or sandbox Debug
-    // actions are rejected for everyone — the host included. Every seat is
-    // permitted by default; the host's grant/revoke flow still narrows it.
-    if state.format_config.allow_debug_actions {
-        for i in 0..count {
-            state.debug_permitted.insert(PlayerId(i));
-        }
-    }
+    initialize_debug_permissions(&mut state, is_multiplayer_mode());
     let match_config = if !match_config_js.is_null() && !match_config_js.is_undefined() {
         serde_wasm_bindgen::from_value::<MatchConfig>(match_config_js)
             .unwrap_or_else(|_| MatchConfig::default())
@@ -1566,8 +1555,8 @@ pub fn legal_targets_for_castables_js(object_ids: JsValue) -> JsValue {
 /// the TS side accepts it via structural typing.
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
-struct ViewerSnapshot {
-    state: GameState,
+struct ViewerSnapshot<'a> {
+    state: engine::game::derived_views::ClientGameStateRef<'a>,
     actions: Vec<GameAction>,
     auto_pass_recommended: bool,
     end_continuous_effect_offers: Vec<GameAction>,
@@ -1608,6 +1597,7 @@ fn legal_actions_result_for_viewer(state: &GameState, viewer: PlayerId) -> Legal
 #[cfg(test)]
 mod viewer_priority_tests {
     use super::*;
+    use engine::types::format::FormatConfig;
     use engine::types::game_state::{PriorityPassingMode, WaitingFor};
     use engine::types::phase::Phase;
 
@@ -1646,6 +1636,23 @@ mod viewer_priority_tests {
             "the controlled viewer is not authorized to act and must receive false"
         );
     }
+
+    #[test]
+    fn local_debug_permission_is_explicit_but_non_sandbox_p2p_stays_empty() {
+        let mut local = GameState::new(FormatConfig::standard(), 2, 42);
+        initialize_debug_permissions(&mut local, false);
+        assert!(local.debug_mode);
+        assert!(local.debug_permitted.contains(&PlayerId(0)));
+        assert!(!local.debug_permitted.contains(&PlayerId(1)));
+
+        let mut p2p = GameState::new(FormatConfig::standard(), 2, 42);
+        initialize_debug_permissions(&mut p2p, true);
+        assert!(p2p.debug_mode);
+        assert!(
+            p2p.debug_permitted.is_empty(),
+            "normal P2P must not receive the debug-library capability"
+        );
+    }
 }
 
 #[wasm_bindgen]
@@ -1658,7 +1665,11 @@ pub fn get_viewer_snapshot_js(player_id: u32) -> JsValue {
         let viewer_interaction =
             engine::game::interaction::derive_viewer_interaction(state, &filtered, viewer);
         to_js(&ViewerSnapshot {
-            state: filtered,
+            state: engine::game::derived_views::ClientGameStateRef::wrap_filtered(
+                state,
+                &filtered,
+                Some(viewer),
+            ),
             actions: legal.actions,
             auto_pass_recommended: legal.auto_pass_recommended,
             end_continuous_effect_offers: legal.end_continuous_effect_offers,
@@ -1814,6 +1825,20 @@ fn decode_and_rehydrate_restored_game_state(json_str: &str) -> Result<GameState,
     Ok(state)
 }
 
+/// Sets the explicit debug capability that client projections consume. Local
+/// games authorize their perspective seat; multiplayer reserves debug access
+/// for the sandbox permission set so ordinary P2P games cannot expose it.
+fn initialize_debug_permissions(state: &mut GameState, multiplayer: bool) {
+    state.debug_mode = true;
+    if state.format_config.allow_debug_actions {
+        state
+            .debug_permitted
+            .extend(state.players.iter().map(|player| player.id));
+    } else if !multiplayer {
+        state.debug_permitted.insert(PlayerId(0));
+    }
+}
+
 #[cfg(test)]
 fn load_minimal_test_card_database() {
     CARD_DB.with(|cell| {
@@ -1847,6 +1872,12 @@ pub fn restore_game_state(json_str: &str) -> Result<(), JsValue> {
     // and reproduce the previous rewind-to-origin behavior.
     state.rehydrate_rng();
     state.debug_mode = true;
+    // Legacy local saves predate the explicit P0 capability. Backfill only
+    // that case; a sandbox save's grant/revoke set is authoritative and must
+    // survive restore unchanged.
+    if !state.format_config.allow_debug_actions && state.debug_permitted.is_empty() {
+        state.debug_permitted.insert(PlayerId(0));
+    }
     finalize_public_state(&mut state);
     bind_interaction_session(&mut state);
     GAME_STATE.with(|cell| cell.set(Some(state)));

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -125,6 +125,7 @@ fn format_diagnostic_value(value: &serde_json::Value) -> String {
     }
 }
 
+#[derive(Debug)]
 struct DecodedRestoredGameState {
     state: GameState,
     debug_permitted_was_serialized: bool,

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -125,10 +125,27 @@ fn format_diagnostic_value(value: &serde_json::Value) -> String {
     }
 }
 
-fn decode_restored_game_state(json_str: &str) -> Result<GameState, String> {
-    serde_json::from_str::<PersistedGameState>(json_str)
+struct DecodedRestoredGameState {
+    state: GameState,
+    debug_permitted_was_serialized: bool,
+}
+
+fn decode_restored_game_state(json_str: &str) -> Result<DecodedRestoredGameState, String> {
+    let serialized = serde_json::from_str::<serde_json::Value>(json_str)
+        .map_err(|error| format!("Failed to deserialize GameState: {error}"))?;
+    let state = serialized
+        .get("state")
+        .and_then(serde_json::Value::as_object)
+        .or_else(|| serialized.as_object());
+    let debug_permitted_was_serialized =
+        state.is_some_and(|state| state.contains_key("debug_permitted"));
+    let state = serde_json::from_value::<PersistedGameState>(serialized)
         .map(PersistedGameState::into_game_state)
-        .map_err(|error| format!("Failed to deserialize GameState: {error}"))
+        .map_err(|error| format!("Failed to deserialize GameState: {error}"))?;
+    Ok(DecodedRestoredGameState {
+        state,
+        debug_permitted_was_serialized,
+    })
 }
 
 /// Bind the engine's interaction authority for the one game this module hosts.
@@ -1819,10 +1836,12 @@ fn rehydrate_restored_state_from_card_db(state: &mut GameState) -> Result<(), St
     })
 }
 
-fn decode_and_rehydrate_restored_game_state(json_str: &str) -> Result<GameState, String> {
-    let mut state = decode_restored_game_state(json_str)?;
-    rehydrate_restored_state_from_card_db(&mut state)?;
-    Ok(state)
+fn decode_and_rehydrate_restored_game_state(
+    json_str: &str,
+) -> Result<DecodedRestoredGameState, String> {
+    let mut restored = decode_restored_game_state(json_str)?;
+    rehydrate_restored_state_from_card_db(&mut restored.state)?;
+    Ok(restored)
 }
 
 /// Sets the explicit debug capability that client projections consume. Local
@@ -1830,6 +1849,26 @@ fn decode_and_rehydrate_restored_game_state(json_str: &str) -> Result<GameState,
 /// for the sandbox permission set so ordinary P2P games cannot expose it.
 fn initialize_debug_permissions(state: &mut GameState, multiplayer: bool) {
     state.debug_mode = true;
+    if state.format_config.allow_debug_actions {
+        state
+            .debug_permitted
+            .extend(state.players.iter().map(|player| player.id));
+    } else if !multiplayer {
+        state.debug_permitted.insert(PlayerId(0));
+    }
+}
+
+/// Reconstructs the capability set omitted by saves created before
+/// `debug_permitted` was persisted. Current saves carry the field even when
+/// its intentionally empty, so their grant/revoke state remains authoritative.
+fn backfill_legacy_debug_permissions(
+    state: &mut GameState,
+    debug_permitted_was_serialized: bool,
+    multiplayer: bool,
+) {
+    if debug_permitted_was_serialized {
+        return;
+    }
     if state.format_config.allow_debug_actions {
         state
             .debug_permitted
@@ -1863,8 +1902,9 @@ pub fn restore_game_state(json_str: &str) -> Result<(), JsValue> {
             "restore_game_state refused: undo is disabled in multiplayer sessions",
         ));
     }
-    let mut state = decode_and_rehydrate_restored_game_state(json_str)
+    let restored = decode_and_rehydrate_restored_game_state(json_str)
         .map_err(|error| JsValue::from_str(&error))?;
+    let mut state = restored.state;
     // Reseed the skipped `rng` and fast-forward it to the offset captured at
     // export (issue #5466) so the restored game draws the values that would have
     // come NEXT rather than replaying from origin. The engine owns this logic
@@ -1872,12 +1912,7 @@ pub fn restore_game_state(json_str: &str) -> Result<(), JsValue> {
     // and reproduce the previous rewind-to-origin behavior.
     state.rehydrate_rng();
     state.debug_mode = true;
-    // Legacy local saves predate the explicit P0 capability. Backfill only
-    // that case; a sandbox save's grant/revoke set is authoritative and must
-    // survive restore unchanged.
-    if !state.format_config.allow_debug_actions && state.debug_permitted.is_empty() {
-        state.debug_permitted.insert(PlayerId(0));
-    }
+    backfill_legacy_debug_permissions(&mut state, restored.debug_permitted_was_serialized, false);
     finalize_public_state(&mut state);
     bind_interaction_session(&mut state);
     GAME_STATE.with(|cell| cell.set(Some(state)));
@@ -1930,8 +1965,10 @@ pub fn resume_multiplayer_host_state(json_str: &str) -> Result<(), JsValue> {
         ));
     }
 
-    let mut state = decode_and_rehydrate_restored_game_state(json_str)
+    let restored = decode_and_rehydrate_restored_game_state(json_str)
         .map_err(|error| JsValue::from_str(&error))?;
+    let mut state = restored.state;
+    backfill_legacy_debug_permissions(&mut state, restored.debug_permitted_was_serialized, true);
 
     // Deliberately re-roll a fresh seed on multiplayer host resume so continued
     // play diverges from any pre-save sequence (mirrors server-core). This is a
@@ -1974,6 +2011,72 @@ mod restored_card_db_requirements_tests {
         assert!(error.contains("card database"));
         assert!(GAME_STATE.with(|cell| cell.replace(None).is_none()));
         assert!(!is_multiplayer_mode());
+    }
+}
+
+#[cfg(test)]
+mod legacy_debug_permission_restore_tests {
+    use super::*;
+
+    fn legacy_save_without_debug_permissions(state: GameState) -> String {
+        let mut serialized = serde_json::to_value(PersistedGameState::capture(state))
+            .expect("persisted test state must serialize");
+        serialized
+            .get_mut("state")
+            .and_then(serde_json::Value::as_object_mut)
+            .expect("trusted persisted state must contain a state object")
+            .remove("debug_permitted");
+        serde_json::to_string(&serialized).expect("legacy persisted test state must serialize")
+    }
+
+    #[test]
+    fn legacy_sandbox_save_backfills_every_seat() {
+        let json = legacy_save_without_debug_permissions(GameState::new(
+            FormatConfig::standard().with_sandbox(),
+            2,
+            42,
+        ));
+
+        let mut restored = decode_restored_game_state(&json).expect("legacy save must decode");
+        assert!(!restored.debug_permitted_was_serialized);
+        backfill_legacy_debug_permissions(&mut restored.state, false, false);
+
+        assert_eq!(
+            restored.state.debug_permitted,
+            [PlayerId(0), PlayerId(1)].into_iter().collect(),
+            "legacy sandbox saves predate per-seat grants and must retain sandbox access"
+        );
+    }
+
+    #[test]
+    fn current_empty_sandbox_permission_set_remains_revoked() {
+        let mut state = GameState::new(FormatConfig::standard().with_sandbox(), 2, 42);
+        state.debug_permitted.clear();
+        let json = serde_json::to_string(&PersistedGameState::capture(state))
+            .expect("current persisted state must serialize");
+
+        let mut restored = decode_restored_game_state(&json).expect("current save must decode");
+        assert!(restored.debug_permitted_was_serialized);
+        backfill_legacy_debug_permissions(&mut restored.state, true, false);
+
+        assert!(
+            restored.state.debug_permitted.is_empty(),
+            "an explicit empty set records intentional sandbox revocation"
+        );
+    }
+
+    #[test]
+    fn legacy_normal_p2p_save_does_not_gain_debug_access() {
+        let json =
+            legacy_save_without_debug_permissions(GameState::new(FormatConfig::standard(), 2, 42));
+
+        let mut restored = decode_restored_game_state(&json).expect("legacy save must decode");
+        backfill_legacy_debug_permissions(&mut restored.state, false, true);
+
+        assert!(
+            restored.state.debug_permitted.is_empty(),
+            "normal P2P restores must not gain a debug projection"
+        );
     }
 }
 

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -390,6 +390,15 @@ pub struct TurnOrderSlotView {
     pub is_starting_player: bool,
 }
 
+/// A card identity deliberately exposed to the debug library browser. This
+/// is separate from normal hidden-zone visibility: only the authorized viewer
+/// receives their own library identities through this explicit debug surface.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct DebugLibraryCardView {
+    pub object_id: ObjectId,
+    pub name: String,
+}
+
 /// Engine-authored projections used by the display layer. Keep this struct
 /// small — every field becomes mandatory payload on every state snapshot
 /// the client receives. Add a new field only when the frontend would
@@ -400,6 +409,11 @@ pub struct DerivedViews {
     /// when there is no actor or multiple distinct authorized submitters.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_authorized_submitter: Option<PlayerId>,
+    /// Debug-only identities for the viewing player's own library. The normal
+    /// `GameState` projection keeps those objects hidden; this capability is
+    /// intentionally narrow so a debug browser can select a card by name.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub debug_library_cards: Vec<DebugLibraryCardView>,
     /// The live (post-layer) keyword badges each battlefield permanent should
     /// display. The engine classifies the complete keyword list so the client
     /// can render the compact strip without reinterpreting keyword timing.
@@ -912,6 +926,7 @@ pub fn derive_views(state: &GameState, viewer: Option<PlayerId>) -> DerivedViews
     let mut views = DerivedViews {
         unique_authorized_submitter: unique_authorized_submitter(state),
         blocker_assignment_pairs: blocker_assignment_pairs(state),
+        debug_library_cards: debug_library_cards(state, viewer),
         ..DerivedViews::default()
     };
 
@@ -1342,11 +1357,41 @@ pub fn derive_filtered_views(
 ) -> DerivedViews {
     let mut views = derive_views(filtered_state, viewer);
     views.unique_authorized_submitter = unique_authorized_submitter(authoritative_state);
+    views.debug_library_cards = debug_library_cards(authoritative_state, viewer);
     // CR 509.1g: blocking relationships are public information. Preserve this
     // display projection even when a viewer-safe state intentionally omits raw
     // combat records unrelated to rendering.
     views.blocker_assignment_pairs = blocker_assignment_pairs(authoritative_state);
     views
+}
+
+fn debug_library_cards(state: &GameState, viewer: Option<PlayerId>) -> Vec<DebugLibraryCardView> {
+    let Some(viewer) = viewer else {
+        return Vec::new();
+    };
+    if !state.debug_mode || !state.debug_permitted.contains(&viewer) {
+        return Vec::new();
+    }
+    let mut cards = state
+        .players
+        .iter()
+        .find(|player| player.id == viewer)
+        .into_iter()
+        .flat_map(|player| player.library.iter())
+        .filter_map(|object_id| {
+            state
+                .objects
+                .get(object_id)
+                .map(|object| DebugLibraryCardView {
+                    object_id: *object_id,
+                    name: object.name.clone(),
+                })
+        })
+        .collect::<Vec<_>>();
+    // Keep the explicit identity capability independent of the library's
+    // current order. The debug UI randomizes this stable list for display.
+    cards.sort_by_key(|card| card.object_id);
+    cards
 }
 
 /// CR 509.1g: flatten each blocking creature's chosen attacking creatures into
@@ -2409,6 +2454,84 @@ mod tests {
         let unknown: ClientGameState =
             serde_json::from_str(&unknown_wire).expect("round-trip other viewer client state");
         assert!(!unknown.state.objects[&secret].display_visible_to_viewer);
+    }
+
+    #[test]
+    fn debug_library_projection_is_separate_from_filtered_library_visibility() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        state.debug_mode = true;
+        state.debug_permitted.insert(PlayerId(0));
+        let own = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Authorized Debug Card".to_string(),
+            Zone::Library,
+        );
+        let another_own = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Second Authorized Debug Card".to_string(),
+            Zone::Library,
+        );
+        let opponent = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Opponent Library Card".to_string(),
+            Zone::Library,
+        );
+        state.players[0].library.swap(0, 1);
+
+        let filtered = crate::game::visibility::filter_state_for_viewer(&state, PlayerId(0));
+        let wire = serde_json::to_string(&ClientGameStateRef::wrap_filtered(
+            &state,
+            &filtered,
+            Some(PlayerId(0)),
+        ))
+        .expect("serialize filtered debug viewer state");
+        let client: ClientGameState =
+            serde_json::from_str(&wire).expect("deserialize filtered debug viewer state");
+
+        assert_eq!(
+            client.state.objects[&own].name, "Hidden Card",
+            "normal filtered library objects must remain hidden"
+        );
+        assert_eq!(
+            client.state.objects[&opponent].name, "Hidden Card",
+            "an opponent's library must remain hidden"
+        );
+        assert_eq!(
+            client.derived.debug_library_cards,
+            vec![
+                DebugLibraryCardView {
+                    object_id: own,
+                    name: "Authorized Debug Card".to_string(),
+                },
+                DebugLibraryCardView {
+                    object_id: another_own,
+                    name: "Second Authorized Debug Card".to_string(),
+                },
+            ],
+            "the explicit debug surface must expose only the authorized viewer's own cards in a non-library order"
+        );
+
+        let local_wire =
+            serde_json::to_string(&ClientGameStateRef::wrap(&state, Some(PlayerId(0))))
+                .expect("serialize local debug viewer state");
+        let local: ClientGameState =
+            serde_json::from_str(&local_wire).expect("deserialize local debug viewer state");
+        assert_eq!(
+            local.derived.debug_library_cards,
+            client.derived.debug_library_cards
+        );
+
+        let unauthorized = derive_views(&state, Some(PlayerId(1)));
+        assert!(
+            unauthorized.debug_library_cards.is_empty(),
+            "a player without debug permission must not receive a debug library projection"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -449,16 +449,6 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
             HashSet::new()
         };
 
-    // Debug exposure: a viewer with an active debug capability (CR is silent;
-    // this is an out-of-game capability) sees the names of cards in their own
-    // library, so the debug "move card from library to hand" picker can identify
-    // a specific card. This includes native single-user games, whose debug
-    // capability is intentionally independent of the multiplayer sandbox
-    // format flag. Opponents' libraries remain hidden. The FE alphabetizes the
-    // picker within each zone bucket, so name exposure does not leak draw order.
-    // The actual `library` Vec order on the wire is left untouched (preserving
-    // simulate-mode draw semantics) but is never surfaced as draw order.
-    let debug_self_library_visible = state.debug_mode && state.debug_permitted.contains(&viewer);
     // CR 701.20e + CR 400.2: "looking at a card ... is shown only to the
     // specified player." A player with a continuous "you may look at the top
     // card of your library" permission (MayLookAtTopOfLibrary — Vizier of the
@@ -482,7 +472,6 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         .flat_map(|p| p.library.iter().copied())
         .collect();
     for obj_id in all_library_ids {
-        let owner = state.objects.get(&obj_id).map(|o| o.owner);
         let visible = manifest_dread_visible.contains(&obj_id)
             || dig_visible.contains(&obj_id)
             || scry_visible.contains(&obj_id)
@@ -501,8 +490,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
             || state.viewer_knows_card_identity(viewer, obj_id)
             // CR 701.20e: own (or controlled-turn) library top under a
             // MayLookAtTopOfLibrary permission — see `look_top_visible` above.
-            || look_top_visible.contains(&obj_id)
-            || (debug_self_library_visible && owner == Some(viewer));
+            || look_top_visible.contains(&obj_id);
         if !visible
             && !effect_zone_hand_cards.contains(&obj_id)
             && !drawn_choice_hand_cards.contains(&obj_id)
@@ -3094,10 +3082,10 @@ mod tests {
         );
     }
 
-    /// Debug capability exposure lets a viewer identify cards in their own
-    /// library for debug actions, without exposing an opponent's library.
+    /// Debug permission does not alter normal hidden-zone visibility. The
+    /// explicit debug browser receives its separately authorized projection.
     #[test]
-    fn debug_permitted_sees_own_library_but_not_opponent_library() {
+    fn debug_permission_keeps_all_unrevealed_library_cards_hidden() {
         let mut state = GameState::new(FormatConfig::standard(), 2, 42);
         state.debug_mode = true;
         state.debug_permitted.insert(PlayerId(0));
@@ -3120,8 +3108,8 @@ mod tests {
         let filtered = filter_state_for_viewer(&state, PlayerId(0));
         assert_eq!(
             filtered.objects.get(&own).map(|obj| obj.name.as_str()),
-            Some("My Library Card"),
-            "viewer must see their own library names with debug capability"
+            Some("Hidden Card"),
+            "debug permission must not make normal library objects visible"
         );
         assert_eq!(
             filtered.objects.get(&opp).map(|obj| obj.name.as_str()),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an authorized debug library view showing card names and IDs for the viewing player’s own library.
  * Debug library browsing now uses a dedicated, permission-aware card projection.
* **Bug Fixes**
  * Prevented unrevealed library cards—including the viewer’s own—from appearing in normal game state views, even when debug access is enabled.
  * Improved permission handling across local, sandbox, multiplayer, and restored games.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->