### PR TITLE
docs(engine): correct eleven wrong CR annotations across five files

### DIFF
--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -5015,7 +5015,7 @@ fn matches_filter_prop(
         // (recorded in the source's `convoked_creatures`). Source-relative,
         // mirroring `SaddledSource`.
         FilterProp::ConvokedSource => source.convoked_creatures.contains(&object_id),
-        // CR 310.8a: "each battle they protect" — protector is an opponent of
+        // CR 310.9 + CR 310.9e: "each battle they protect" — protector is an opponent of
         // the source controller (Joyful Stormsculptor class).
         FilterProp::ProtectorMatches { controller } => {
             if !obj.card_types.core_types.contains(&CoreType::Battle) {

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -2812,7 +2812,7 @@ impl GameObject {
         })
     }
 
-    /// CR 310.8a + CR 310.8e: Return this battle's protector, if any. Derived
+    /// CR 310.9 + CR 310.9a: Return this battle's protector, if any. Derived
     /// from `ChosenAttribute::Player` stored when the Siege's "As ~ enters"
     /// replacement resolved. Non-battle permanents return `None`.
     pub fn protector(&self) -> Option<PlayerId> {

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -1961,7 +1961,7 @@ fn check_battle_protector(
         let protector = battle.protector();
 
         // Legal protectors for a Siege are opponents of the controller (CR 310.11a).
-        // For non-Siege battles with no battle type, CR 310.8a says the controller
+        // For non-Siege battles with no battle type, CR 310.9a says the controller
         // becomes the protector; we treat the controller as legal in that case.
         let protector_legal = match protector {
             Some(p) if is_siege => crate::game::players::opponents(state, controller).contains(&p),
@@ -1993,7 +1993,7 @@ fn check_battle_protector(
                 .filter(|p| !state.eliminated_players.contains(p))
                 .collect()
         } else {
-            // CR 310.8a: With no battle types, controller is the protector.
+            // CR 310.9a: With no battle types, controller is the protector.
             vec![controller]
         };
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -16859,7 +16859,7 @@ fn try_parse_compound_player_object_damage(lower: &str) -> Option<ParsedEffectCl
     }
 
     // CR 109.4 + CR 109.5: Probe for controller-suffix variants on the object
-    // half, or the battle-specific "they protect" suffix (CR 310.8a).
+    // half, or the battle-specific "they protect" suffix (CR 310.9e).
     fn set_opponent_controller(filter: &mut TargetFilter) {
         match filter {
             TargetFilter::Typed(tf) => {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4203,7 +4203,7 @@ pub enum FilterProp {
     /// `QuantityRef::ConvokedCreatureCount` (both read `convoked_creatures`).
     /// Used by "a creature that convoked this spell" (Everything Comes to Dust).
     ConvokedSource,
-    /// CR 310.8a + CR 310.8e: Matches battles whose protector satisfies
+    /// CR 310.9 + CR 310.9e: Matches battles whose protector satisfies
     /// `controller` relative to the ability source ("each battle they protect").
     ProtectorMatches {
         controller: ControllerRef,
@@ -4560,7 +4560,7 @@ pub enum FilterProp {
     DistinctFrom {
         reference: Box<TargetFilter>,
     },
-    /// CR 604.3: Matches objects whose current zone is any of the listed zones (OR semantics).
+    /// CR 400.1: Matches objects whose current zone is any of the listed zones (OR semantics).
     /// Used for zone-based restrictions like "cards in graveyards and libraries".
     InAnyZone {
         zones: Vec<Zone>,
@@ -6090,7 +6090,7 @@ pub enum QuantityRef {
     /// source set. Covers zone cards, linked-exile cards, and matching objects
     /// without proliferating card-type-count siblings.
     DistinctCardTypes { source: CardTypeSetSource },
-    /// CR 205.3 + CR 604.3: Count distinct subtype *values* across a
+    /// CR 205.3: Count distinct subtype *values* across a
     /// parameterized source set (Subgoyf — "the number of different subtypes
     /// other than creature types among cards in all graveyards"). The subtype
     /// peer of [`QuantityRef::DistinctCardTypes`] (CR 205.2, card types): it
@@ -6120,7 +6120,7 @@ pub enum QuantityRef {
     /// CR 607.2b: The power of a specific card exiled by the source, indexed by order.
     /// Used by The Mimeoplasm to read the second exiled card's power for counter placement.
     ExiledCardPower { index: u32 },
-    /// CR 604.3: Count cards in a zone matching optional type filters.
+    /// CR 400.1: Count cards in a zone matching optional type filters.
     /// Empty card_types means all cards. Multiple entries = OR (any match).
     /// "creature cards in your graveyard" → zone=Graveyard, card_types=[Creature], scope=Controller
     ZoneCardCount {
@@ -7156,7 +7156,7 @@ pub enum QuantityExpr {
         divisor: u32,
         rounding: RoundingMode,
     },
-    /// CR 604.3: Base expression plus a fixed integer offset.
+    /// Base expression plus a fixed integer offset.
     /// "N plus the number of X" / "that number plus N" patterns.
     Offset {
         inner: Box<QuantityExpr>,
@@ -14907,7 +14907,7 @@ impl TargetFilter {
         }
     }
 
-    /// CR 400.3 + CR 701.23: Returns the union of explicit zone constraints in this filter.
+    /// CR 400.1: Returns the union of explicit zone constraints in this filter.
     /// Preserves the multi-zone semantics of `FilterProp::InAnyZone` (e.g.
     /// "search ... graveyard, hand, and library") that `extract_in_zone` collapses
     /// to a single zone. Falls back to the single `InZone` when only that variant


### PR DESCRIPTION
Corrects eleven wrong MTG Comprehensive Rules annotations across five engine files. Comment-only — zero non-comment changed lines.

A wrong CR number is worse than no CR number. It asserts that code was verified against a rule it was never checked against, and it poisons `grep -r "CR NNN"`, which is the discovery mechanism the convention exists to provide.

## Two distinct defect classes

**Fabricated (0 grep matches).** `CR 310.8a` and `CR 310.8e` do not exist — `310.8` is a childless parent rule about a defense-counter state-based action. Six sites cited them for battle **protector** logic, which is `310.9`–`310.9g`.

**Wrong-but-real (a real rule, governing something else).** Five sites cited `CR 604.3` (characteristic-defining abilities) for an object's **zone**; its "function in all zones" clause is the likely source of the confusion.

The second class is the more dangerous one, because an existence check cannot see it. A fabrication grep returns zero and passes forever.

## Commit 1 — six annotations in `types/ability.rs`

| Site | Was | Now | Why |
|---|---|---|---|
| `FilterProp::ProtectorMatches` | `310.8a + 310.8e` | `310.9 + 310.9e` | Two-clause doc needs two rules: "battles whose protector" is `310.9`, the quoted "each battle they protect" is `310.9e`. Not `310.9a` — the runtime arm reads a *stored* protector via `obj.protector()` and never establishes one, so the ETB-choice rule doesn't apply. |
| `FilterProp::InAnyZone` | `604.3` | `400.1` | About an object's zone. |
| `QuantityRef::ZoneCardCount` | `604.3` | `400.1` | Same. |
| `TargetFilter::extract_zones` | `400.3 + 701.23` | `400.1` | Also drops `701.23` (Search): a census of its ~20 call sites found none is a search, so the citation was decorative rather than governing. |
| `QuantityRef::DistinctCardTypes` subtype peer | `205.3 + 604.3` | `205.3` | Drops the `604.3` parasite. |
| `QuantityExpr::Offset` | `107.1a` | *(none)* | CR 107.1a/b/c read in full; no rule governs addition. |

`400.1` is the number this engine already uses for the zone concept at three shipped sites, two of which name `InAnyZone` and `extract_zones` explicitly (`types/zones.rs`, `game/ability_rw.rs`, `game/quantity.rs`).

`QuantityExpr::Offset` losing its prefix entirely rather than gaining a replacement is deliberate, and the enum demonstrates the convention by contrast: `DivideRounded` cites `107.1a` because *rounding* is rules-specified, the negative clamp cites `107.1b` because *negative-becomes-zero* is rules-specified, while `Ref` and `Fixed` carry none. Adding an offset has no rules-specified behaviour, so per CLAUDE.md it is plumbing and takes no annotation.

**Five further `CR 400.3` citations in this file are deliberately left alone** — all are genuine owner-redirection ("delivered to its owner's library"), which is exactly what `400.3` governs. That `400.3` is used correctly five times while the `extract_zones` instance was the lone outlier is itself evidence the correction targets a real defect rather than a stylistic preference.

## Commit 2 — the same fabricated citation at its five remaining sites

The first commit fixed the *instance*; the generating condition was that five siblings carried the identical fabricated number, including `ProtectorMatches`'s own runtime arm.

| File | Now |
|---|---|
| `game/game_object.rs` | `310.9 + 310.9a` — returns the ETB-stored player, so the choice rule *is* correct here |
| `game/filter.rs` | `310.9 + 310.9e` — the runtime arm of `ProtectorMatches` |
| `game/sba.rs` (×2) | `310.9a` |
| `parser/oracle_effect/mod.rs` | `310.9e` |

`game_object.rs` taking `310.9a` where its neighbour takes `310.9e` is the substantive part: matching a sibling's citation shape would have reproduced the very mechanism that generated the original bug. The rule has to be chosen from what each site *does*, not from what its neighbour cites.

## Verification

- Every number grep-verified against `docs/MagicCompRules.txt` with a **positive control** (`^704.5a` → 2 matches) and a **negative control** (`^999.99` → 0). A grep tool that returns 0 for everything would otherwise "confirm" any claim.
- **Comment-only, measured not asserted:** 0 non-comment changed lines, with a nonvacuity control (the same probe saw 12 total changed lines in commit 1, so the zero is a measurement rather than an empty pipeline).
- **Collateral-damage proof:** with the target tokens stripped from both diff sides, the residues differ only at the deliberate structural edits, and every other CR token appears at identical counts on both sides.
- Residual gate re-run **on this branch's tree**: `310.8a`/`310.8e` → 0 in `crates/engine/src/`; `CR 604.3` → 0 in `ability.rs`.

## Known follow-up, deliberately not in this PR

Two further clusters in the same CR block are found, located, and verified, and are tracked rather than silently folded in:

1. **`CR 310.11a`/`310.11b` fabricated** — ~31 occurrences, including two shipped user-visible `description` strings in `database/synthesis.rs`.
2. **`CR 310.10` real but misapplied** — 25 sites citing the *attachment* SBA for the *protector* SBA. Smoking gun at `sba.rs:1977`: `// CR 310.10: Only applies to battles that aren't being attacked` — `310.10` says nothing about attacking; that phrase is verbatim `310.11`.

There is a **speculative** unifying hypothesis worth recording but not acting on: `310.8x→310.9x`, `310.10→310.11`, and `310.11x→310.12x` together look like a uniform +1 parent shift with letters preserved, i.e. code annotated against an older CR edition. It is flagged speculative pending an old CR text, and it is useful mainly because it *predicts* which other citations in the `310.8`–`310.12` block are shifted — testable before a sweep rather than after.
