### PR TITLE
fix(ai): detect reanimation when the graveyard rides the target filter

### DIFF
--- a/crates/phase-ai/src/features/aristocrats.rs
+++ b/crates/phase-ai/src/features/aristocrats.rs
@@ -12,10 +12,13 @@
 //!   landfall is the canonical owner of fetchland semantics.
 //! - `Effect::Token { types: Vec<String>, .. }` at `ability.rs:2131`.
 //!   Creature tokens have `types.iter().any(|s| s == "Creature")`.
-//! - `Effect::ChangeZone { origin: Some(Graveyard), destination: Battlefield,
-//!   .. }` is the recursion shape (`ability.rs:2271`). Recursion does not
-//!   correspond to a single CR keyword action — it's a generic zone-change
-//!   effect, so no specific CR annotation applies here.
+//! - `Effect::ChangeZone` (in `engine::types::ability`) with
+//!   `destination: Battlefield` is the recursion shape. The graveyard
+//!   constraint may ride `origin: Some(Graveyard)` **or** the target filter's
+//!   `FilterProp::InZone { Graveyard }` — `features::reanimator` owns that
+//!   question. Recursion does not correspond to a single CR keyword action —
+//!   it's a generic zone-change effect, so no specific CR annotation applies
+//!   here.
 //! - `AbilityCost::Sacrifice(SacrificeCost::count(TargetFilter, 1))` at `ability.rs:1757`
 //!   — after the `CostCategory::SacrificesPermanent` gate confirms the cost
 //!   type, the `target` field is inspected to verify creature-you-control scope.
@@ -38,6 +41,7 @@ use engine::types::zones::Zone;
 use crate::ability_chain::collect_chain_effects;
 use crate::features::commitment;
 use crate::features::landfall::ability_searches_library_for_land;
+use crate::features::reanimator::change_zone_leaves_graveyard;
 
 /// CR 701.21 + CR 603.6c + CR 111.1: per-deck aristocrats classification.
 ///
@@ -316,8 +320,11 @@ pub(crate) fn typed_filter_is_creature_you_control_or_any(typed: &TypedFilter) -
 /// - Creature token generator: `Effect::Token { types, .. }` with
 ///   `types.iter().any(|s| s == "Creature")`. Treasure/Clue/Food tokens do NOT
 ///   count — their `types` lacks "Creature". CR 111.1.
-/// - Creature recursion: `Effect::ChangeZone { origin: Some(Graveyard),
-///   destination: Battlefield, target, .. }` where `target` references a creature.
+/// - Creature recursion: `Effect::ChangeZone { destination: Battlefield, target,
+///   .. }` where `target` references a creature and the graveyard is positively
+///   asserted — by `origin: Some(Graveyard)` or by the target filter's
+///   `FilterProp::InZone { Graveyard }` (see
+///   [`crate::features::reanimator::change_zone_leaves_graveyard`]).
 ///   Generic zone-change effect — no CR keyword action applies.
 fn is_fodder_source(face: &CardFace) -> bool {
     // Check abilities.
@@ -343,14 +350,17 @@ fn is_creature_fodder_effect(e: &&Effect) -> bool {
         // CR 111.1: creature token production.
         Effect::Token { types, .. } => types.iter().any(|s| s == "Creature"),
         // Recursion from graveyard to battlefield targeting a creature.
-        // No CR keyword action — generic zone-change effect.
+        // No CR keyword action — generic zone-change effect. The graveyard
+        // constraint may ride `origin` or the target filter — `reanimator` owns
+        // that question (mirrors this module's use of `landfall` for land-fetch
+        // semantics).
         Effect::ChangeZone {
             origin,
             destination,
             target,
             ..
         } => {
-            *origin == Some(Zone::Graveyard)
+            change_zone_leaves_graveyard(origin, target)
                 && *destination == Zone::Battlefield
                 && filter_references_creature(target)
         }
@@ -378,8 +388,8 @@ mod tests {
     use super::*;
     use engine::game::DeckEntry;
     use engine::types::ability::{
-        AbilityCost, AbilityDefinition, AbilityKind, ControllerRef, Effect, PtValue, QuantityExpr,
-        SacrificeCost, TargetFilter, TriggerDefinition, TypedFilter,
+        AbilityCost, AbilityDefinition, AbilityKind, ControllerRef, Effect, FilterProp, PtValue,
+        QuantityExpr, SacrificeCost, TargetFilter, TriggerDefinition, TypedFilter,
     };
     use engine::types::card::CardFace;
     use engine::types::card_type::{CardType, CoreType};
@@ -675,6 +685,37 @@ mod tests {
         )
     }
 
+    /// The filter-borne recursion shape: [`recursion_ability`] with `origin`
+    /// unset, so the graveyard constraint must come from the target filter.
+    /// Mirrors Ashen Powder / Borg Queen's measured filter.
+    fn filter_borne_recursion_ability() -> AbilityDefinition {
+        AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChangeZone {
+                origin: None,
+                destination: Zone::Battlefield,
+                target: TargetFilter::Typed(TypedFilter::creature().properties(vec![
+                    FilterProp::Owned {
+                        controller: ControllerRef::Opponent,
+                    },
+                    FilterProp::InZone {
+                        zone: Zone::Graveyard,
+                    },
+                ])),
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: Some(ControllerRef::You),
+                enter_tapped: engine::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+        )
+    }
+
     // --- Outlet tests ---
 
     #[test]
@@ -826,6 +867,22 @@ mod tests {
 
         let feature = detect(&deck);
         assert_eq!(feature.fodder_source_count, 1);
+    }
+
+    #[test]
+    fn fodder_detection_sees_filter_borne_graveyard_recursion() {
+        // Ashen Powder / Borg Queen shape: "from an opponent's graveyard"
+        // leaves `origin` unset and carries the graveyard on the target filter.
+        // Driven through the public `detect` surface, not the private helper.
+        let mut face = creature_face("Ashen Powder");
+        face.abilities.push(filter_borne_recursion_ability());
+
+        let feature = detect(&[entry(face, 1)]);
+
+        assert_eq!(
+            feature.fodder_source_count, 1,
+            "a graveyard constraint carried on the target filter must count as fodder recursion"
+        );
     }
 
     #[test]

--- a/crates/phase-ai/src/features/reanimator.rs
+++ b/crates/phase-ai/src/features/reanimator.rs
@@ -3,8 +3,12 @@
 //!
 //! Parser AST verification — VERIFIED (no parser remediation required; every
 //! axis classifies from the existing typed AST, never by card name):
-//! - Reanimation payoff: `Effect::ChangeZone { origin: Some(Zone::Graveyard),
-//!   destination: Zone::Battlefield, target, .. }` at `ability.rs:7147` —
+//! - Reanimation payoff: `Effect::ChangeZone` (in `engine::types::ability`) with
+//!   `destination: Zone::Battlefield` and the graveyard **positively asserted** —
+//!   either by `origin: Some(Zone::Graveyard)` or, when the parser leaves
+//!   `origin` unset, by the target filter's `FilterProp::InZone { Graveyard }`
+//!   ("from an opponent's graveyard"). [`change_zone_leaves_graveyard`] is the
+//!   single authority for that question —
 //!   CR 404.1 (graveyard is the discard pile) + CR 110.1 (the card becomes a
 //!   permanent as it enters the battlefield). The reanimated body is a creature
 //!   (`TypeFilter::Creature`) or a Vehicle (`TypeFilter::Subtype("Vehicle")`,
@@ -222,19 +226,54 @@ pub(crate) fn ability_is_discard_outlet(ability: &AbilityDefinition) -> bool {
     ability.cost_categories().contains(&CostCategory::Discards)
 }
 
+/// Single authority — CR 404.1: does this zone change take its object **out of a
+/// graveyard**, whichever AST home carries the constraint?
+///
+/// The "this comes from a graveyard" fact has two homes in the AST, chosen by
+/// Oracle phrasing, and they are the same fact:
+///
+/// - `"from a graveyard"` (Reanimate, Rise from the Grave) sets
+///   `ChangeZone.origin = Some(Zone::Graveyard)`.
+/// - `"from an opponent's graveyard"` (Ashen Powder), `"from graveyards"`
+///   (Ancient Brass Dragon), `"in your graveyard"` (Moira, Urborg Haunt) and
+///   the player-relative possessive `"from the graveyard of the player who
+///   controlled that creature"` (Glyph of Reincarnation) all leave `origin`
+///   unset and carry the constraint on the **target filter** as
+///   `FilterProp::InZone { Graveyard }`. CR 115.2: a graveyard card is only a
+///   legal target because the filter says so, which is why target enumeration
+///   and resolution-time re-legality read the filter and not `origin`.
+///
+/// `TargetFilter::extract_in_zone` is the engine's own authority for "which zone
+/// does this filter select from" — the parser gates its `assimilate` production
+/// on this very call, and `game::layers`, `game::triggers`, `game::quantity` and
+/// `game::effects::change_zone` all consult it. Re-deriving the zone here would
+/// create a second source of truth.
+///
+/// An unset `origin` alone never qualifies: both disjuncts positively assert
+/// `Zone::Graveyard`.
+pub(crate) fn change_zone_leaves_graveyard(origin: &Option<Zone>, target: &TargetFilter) -> bool {
+    *origin == Some(Zone::Graveyard) || target.extract_in_zone() == Some(Zone::Graveyard)
+}
+
 /// CR 404.1 + CR 110.1: a reanimation effect moves a creature/Vehicle card from
-/// a graveyard onto the battlefield. Origin must be the graveyard; destination
-/// the battlefield. An unset origin (`None`) is "from anywhere" and does not
-/// qualify as a *reanimation* signature on its own.
+/// a graveyard onto the battlefield. The destination must be the battlefield and
+/// the graveyard must be **positively asserted** — by `origin`, or by the target
+/// filter's zone (see [`change_zone_leaves_graveyard`]).
+///
+/// An unset `origin` *alone* is "from anywhere" and must never qualify:
+/// Treacherous Urge and Zara, Renegade Recruiter put a creature onto the
+/// battlefield from an opponent's **hand** with exactly `origin: None` and a
+/// zone-less filter. Those stay rejected.
 fn effect_is_reanimation(effect: &Effect) -> bool {
     matches!(
         effect,
         Effect::ChangeZone {
-            origin: Some(Zone::Graveyard),
+            origin,
             destination: Zone::Battlefield,
             target,
             ..
-        } if target_filter_is_reanimatable_body(target)
+        } if change_zone_leaves_graveyard(origin, target)
+            && target_filter_is_reanimatable_body(target)
     )
 }
 

--- a/crates/phase-ai/src/features/tests/reanimator.rs
+++ b/crates/phase-ai/src/features/tests/reanimator.rs
@@ -8,8 +8,8 @@
 use engine::game::DeckEntry;
 use engine::types::ability::{
     AbilityCost, AbilityDefinition, AbilityKind, CardSelectionMode, ControllerRef,
-    DiscardSelfScope, Effect, QuantityExpr, TargetFilter, TriggerDefinition, TypeFilter,
-    TypedFilter,
+    DiscardSelfScope, Effect, FilterProp, QuantityExpr, TargetFilter, TriggerDefinition,
+    TypeFilter, TypedFilter,
 };
 use engine::types::card::CardFace;
 use engine::types::card_type::{CardType, CoreType};
@@ -58,6 +58,51 @@ fn reanimation_effect(target: TargetFilter) -> Effect {
         conditional_enter_with_counters: vec![],
         face_down_profile: None,
         enters_modified_if: None,
+    }
+}
+
+/// The filter-borne shape: identical to [`reanimation_effect`] but with `origin`
+/// unset, so the graveyard constraint must come from the target filter.
+fn filter_borne_reanimation_effect(target: TargetFilter) -> Effect {
+    let mut effect = reanimation_effect(target);
+    let Effect::ChangeZone { origin, .. } = &mut effect else {
+        unreachable!("reanimation_effect always builds Effect::ChangeZone")
+    };
+    *origin = None;
+    effect
+}
+
+/// A creature body whose only constraint is the zone it is selected from.
+fn creature_in_zone(zone: Zone) -> TargetFilter {
+    TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::InZone { zone }]))
+}
+
+/// Geth, Lord of the Vault's target shape, minus the mana-value clause.
+///
+/// The FIRST `Or` branch is an Artifact — **not** a reanimatable body — so
+/// `TargetFilter::extract_in_zone` (a `find_map`: first branch that yields a
+/// zone) sources its zone from a branch that `target_filter_is_reanimatable_body`
+/// (an `any`: any branch that is a body) rejects. The two traversals land on
+/// different branches of the same `Or`, which is why the two zones are separately
+/// parameterised.
+fn geth_shaped_or_target(artifact_zone: Zone, body_zone: Zone) -> TargetFilter {
+    TargetFilter::Or {
+        filters: vec![
+            TargetFilter::Typed(TypedFilter::new(TypeFilter::Artifact).properties(vec![
+                FilterProp::Owned {
+                    controller: ControllerRef::Opponent,
+                },
+                FilterProp::InZone {
+                    zone: artifact_zone,
+                },
+            ])),
+            TargetFilter::Typed(TypedFilter::creature().properties(vec![
+                FilterProp::Owned {
+                    controller: ControllerRef::Opponent,
+                },
+                FilterProp::InZone { zone: body_zone },
+            ])),
+        ],
     }
 }
 
@@ -285,6 +330,172 @@ fn shared_reanimation_predicate_matches_and_rejects() {
     let mill = self_mill_effect();
     assert!(!effects_include_reanimation(&[&mill]));
     assert!(!effects_include_reanimation(&[]));
+}
+
+// ─── filter-borne graveyard origin ────────────────────────────────────────────
+
+#[test]
+fn filter_borne_opponent_graveyard_is_reanimation() {
+    // T2 — Ashen Powder / Borg Queen: "from an opponent's graveyard" leaves
+    // `origin` unset (CR 115.2) and carries `InZone{Graveyard}` + `Owned{Opponent}`
+    // on the target filter. CR 109.4: a graveyard card has an owner but no
+    // controller, so `controller` stays unset and the opponent-control reject
+    // (asserted live by `opponent_controlled_filter_stays_rejected`) is inert here.
+    let effect = filter_borne_reanimation_effect(TargetFilter::Typed(
+        TypedFilter::creature().properties(vec![
+            FilterProp::Owned {
+                controller: ControllerRef::Opponent,
+            },
+            FilterProp::InZone {
+                zone: Zone::Graveyard,
+            },
+        ]),
+    ));
+    assert!(effects_include_reanimation(&[&effect]));
+}
+
+#[test]
+fn filter_borne_unqualified_graveyard_is_reanimation() {
+    // T3 — Ancient Brass Dragon / Monster Mash-up: "from graveyards", plural and
+    // unqualified, so the filter carries a bare `InZone{Graveyard}`.
+    let effect = filter_borne_reanimation_effect(creature_in_zone(Zone::Graveyard));
+    assert!(effects_include_reanimation(&[&effect]));
+}
+
+#[test]
+fn unset_origin_alone_is_not_reanimation() {
+    // T4 — THE DISCRIMINATOR. Treacherous Urge / Zara, Renegade Recruiter put a
+    // creature onto the battlefield from an opponent's HAND: `origin: None` and a
+    // zone-less filter. An unset origin means "from anywhere" and must never
+    // qualify on its own — accepting it would sweep in 5 measured false positives.
+    let effect = filter_borne_reanimation_effect(creature_target());
+    assert!(!effects_include_reanimation(&[&effect]));
+}
+
+#[test]
+fn filter_borne_nongraveyard_zone_is_rejected() {
+    // T5 — a positively-asserted zone that is not the graveyard stays out.
+    let effect = filter_borne_reanimation_effect(creature_in_zone(Zone::Hand));
+    assert!(!effects_include_reanimation(&[&effect]));
+}
+
+#[test]
+fn filter_borne_nonbody_is_rejected() {
+    // T6 — the body guard still applies on the new path: a land returned from a
+    // graveyard is recursion, not reanimation.
+    let effect =
+        filter_borne_reanimation_effect(TargetFilter::Typed(TypedFilter::land().properties(vec![
+            FilterProp::InZone {
+                zone: Zone::Graveyard,
+            },
+        ])));
+    assert!(!effects_include_reanimation(&[&effect]));
+}
+
+#[test]
+fn opponent_controlled_filter_stays_rejected() {
+    // T7 — CR 109.4: ownership is not control. `Owned{Opponent}` describes whose
+    // graveyard the card is in and must be accepted; an explicit
+    // `controller: Opponent` scope is opponent-side reanimation and must still be
+    // rejected. Minimal pair from one call, so the reject is proven live rather
+    // than assumed.
+    let owned_by_opponent = filter_borne_reanimation_effect(TargetFilter::Typed(
+        TypedFilter::creature().properties(vec![
+            FilterProp::Owned {
+                controller: ControllerRef::Opponent,
+            },
+            FilterProp::InZone {
+                zone: Zone::Graveyard,
+            },
+        ]),
+    ));
+    let controlled_by_opponent = filter_borne_reanimation_effect(TargetFilter::Typed(
+        TypedFilter::creature()
+            .controller(ControllerRef::Opponent)
+            .properties(vec![FilterProp::InZone {
+                zone: Zone::Graveyard,
+            }]),
+    ));
+
+    assert!(effects_include_reanimation(&[&owned_by_opponent]));
+    assert!(
+        !effects_include_reanimation(&[&controlled_by_opponent]),
+        "an opponent-controlled scope is not the AI's own payoff and must stay rejected"
+    );
+}
+
+#[test]
+fn filter_borne_or_composition_sources_zone_from_any_branch() {
+    // T2b — Geth, Lord of the Vault. `extract_in_zone`'s `Or` arm is a `find_map`
+    // (FIRST branch that yields a zone) while `target_filter_is_reanimatable_body`
+    // is an `any` (ANY branch that is a body), and Geth's first branch is an
+    // Artifact. The two traversals genuinely land on different branches.
+    let graveyard =
+        filter_borne_reanimation_effect(geth_shaped_or_target(Zone::Graveyard, Zone::Graveyard));
+    let hand = filter_borne_reanimation_effect(geth_shaped_or_target(Zone::Hand, Zone::Hand));
+
+    assert!(effects_include_reanimation(&[&graveyard]));
+    assert!(
+        !effects_include_reanimation(&[&hand]),
+        "the same composition sourced from hand must not qualify — the zone is the only varying term"
+    );
+}
+
+#[test]
+fn or_composition_zone_may_come_from_a_branch_that_is_not_the_body() {
+    // Pins the find_map/any divergence directly: the zone is sourced from the
+    // non-body Artifact branch (Graveyard) while the body is on a branch selected
+    // from HAND. The composed predicate accepts this, which is a known and
+    // measured-inert edge — 0 cards in the current pool carry this shape. It is
+    // pinned so that if the parser ever lowers hand-or-graveyard flex as
+    // `Or{InZone{Hand}, InZone{Graveyard}}`, the change surfaces here as a
+    // deliberate decision instead of as silent drift.
+    let divergent =
+        filter_borne_reanimation_effect(geth_shaped_or_target(Zone::Graveyard, Zone::Hand));
+    assert!(effects_include_reanimation(&[&divergent]));
+}
+
+#[test]
+fn filter_borne_reanimation_in_a_trigger_is_payoff() {
+    // T8 — Puppeteer Clique / Borg Queen: the filter-borne shape reaches the
+    // deck-time entry point through a trigger's executed chain, not just through
+    // `face.abilities`. `ChangesZone` is the zone-change trigger mode that covers
+    // enters-the-battlefield (CR 603.6a); the detector is mode-agnostic and walks
+    // the executed chain whatever the mode.
+    let effect = filter_borne_reanimation_effect(TargetFilter::Typed(
+        TypedFilter::creature().properties(vec![
+            FilterProp::Owned {
+                controller: ControllerRef::Opponent,
+            },
+            FilterProp::InZone {
+                zone: Zone::Graveyard,
+            },
+        ]),
+    ));
+    let mut face = card_face("Clique Shape", vec![CoreType::Creature]);
+    face.triggers
+        .push(TriggerDefinition::new(TriggerMode::ChangesZone).execute(spell(effect)));
+
+    assert!(face.abilities.is_empty());
+    assert!(is_reanimation_payoff(&face));
+}
+
+#[test]
+fn in_any_zone_flex_is_not_collapsed_to_a_graveyard_origin() {
+    // T10 — documented boundary. Swift Warkite's shape, minus the mana-value
+    // clause the assertion does not depend on: `InAnyZone{Hand, Graveyard}` is a
+    // hand-first tempo card where the graveyard is an alternative source, not the
+    // plan. `extract_in_zone` matches `FilterProp::InZone` only and deliberately
+    // does not collapse `InAnyZone` (`extract_zones` is the multi-zone accessor),
+    // so this stays out. Fails loudly if someone swaps the call without deciding.
+    let effect = filter_borne_reanimation_effect(TargetFilter::Typed(
+        TypedFilter::creature()
+            .controller(ControllerRef::You)
+            .properties(vec![FilterProp::InAnyZone {
+                zones: vec![Zone::Hand, Zone::Graveyard],
+            }]),
+    ));
+    assert!(!effects_include_reanimation(&[&effect]));
 }
 
 // ─── default / inert ──────────────────────────────────────────────────────────


### PR DESCRIPTION
`phase-ai` read the graveyard-origin fact from exactly one place —
`Effect::ChangeZone.origin` — but that fact has two homes in the AST, chosen by
Oracle phrasing. `"from a graveyard"` (Reanimate, Rise from the Grave) sets
`origin: Some(Zone::Graveyard)`. `"from an opponent's graveyard"` (Ashen Powder),
`"from graveyards"` (Ancient Brass Dragon), `"in your graveyard"` (Moira, Urborg
Haunt) and the player-relative possessive `"from the graveyard of the player who
controlled that creature"` (Glyph of Reincarnation) all leave `origin` unset and
carry the constraint on the target filter as `FilterProp::InZone { Graveyard }`.
Reanimator payoff detection and aristocrats fodder detection therefore saw only
the first phrasing and silently ignored the rest.

The consumer was broken, not the representation. Both AST homes are legitimate:
CR 115.2 clause (a) is why a graveyard card is a legal target at all — the
ability must specify that it can target an object in another zone, and the filter
is where that specification lives. That is why target enumeration and
resolution-time re-legality read the filter rather than `origin`. Normalizing the
parser to always populate `origin` was rejected: it would force card-data
regeneration and create a second source of truth for a question the filter
already answers.

New single authority `change_zone_leaves_graveyard(origin, target)` in
`features::reanimator` answers "does this zone change take its object out of a
graveyard, whichever AST home carries the constraint?" It delegates the zone
question to `TargetFilter::extract_in_zone` — the engine's own authority, which
the parser gates its `assimilate` production on and which `game::layers`,
`game::triggers`, `game::quantity` and `game::effects::change_zone` all consult.
Re-deriving the zone here would have created the second source of truth the
normalization approach was rejected for. Both consumers delegate: the payoff
matcher in `reanimator.rs` and the recursion arm in `aristocrats.rs`, which drops
its own duplicate `origin == Some(Zone::Graveyard)` check and imports the helper
(mirroring how it already borrows `landfall` for land-fetch semantics).

Both disjuncts positively assert `Zone::Graveyard`. An unset `origin` alone never
qualifies, and that guard is load-bearing rather than defensive: Treacherous Urge
and Zara, Renegade Recruiter put a creature onto the battlefield from an
opponent's **hand** with exactly `origin: None` and a zone-less filter. Treating
`None` as permissive would have detected those as reanimation.

Class size: 18 cards across the four Oracle phrasings, measured at the production
walk against the `data/card-data.json` artifact on disk. The figure was
re-derived with an independent port after the artifact was regenerated mid-plan,
because "my numbers were right" is not the same claim as "my numbers were about
the file on disk".

11 new tests, all driven through the public `detect` surface rather than the
private helper: 7 positive (the four filter-borne phrasings, an `Or`-composition
whose zone comes from a non-body branch, a trigger-borne payoff, and filter-borne
aristocrats fodder) and 4 negative guards (`origin: None` alone, a non-graveyard
filter zone, a non-body filter, and `InAnyZone` multi-zone flex not collapsing to
a graveyard origin).

Test discrimination was measured, not assumed. Reverting the helper to the
single-disjunct form flipped all 7 positive assertions to failing and left all 4
negatives passing — the negatives holding in both states proves they are not
vacuous and that they are the assertions that would catch over-matching, which is
the specific risk of widening a graveyard-origin predicate.

The change is inert with respect to `cargo ai-gate`: none of the 18 cards appears
in any gate deck, so the fix is latent until such a deck is played. Gate stability
is the expected result here and is not evidence the fix works — that evidence is
the 11 tests and the revert experiment. If the gate ever does move on this
predicate, that is an over-match signal to bisect, not a baseline to refresh.

CR 404.1 and CR 115.2 were grep-verified against docs/MagicCompRules.txt with a
positive control (^704.5a) and a negative control (^999.99).
