### PR TITLE
docs(engine): correct the remaining fabricated CR 310.x citations

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -8827,7 +8827,7 @@ pub fn synthesize_suspend(face: &mut CardFace) {
     // CR 702.62a: Last-counter free-cast trigger — "When the last time counter
     // is removed from this card, if it's exiled, you may play it without
     // paying its mana cost." Mirrors `synthesize_siege_intrinsics` victory
-    // trigger (CR 310.11b) — both use `CounterRemoved` with `threshold: Some(0)`.
+    // trigger (CR 310.12b) — both use `CounterRemoved` with `threshold: Some(0)`.
     // The cast itself goes through the normal casting pipeline; `prepare_spell_cast`
     // detects the variant via `obj.zone == Exile && Keyword::Suspend` and assigns
     // `CastingVariant::Suspend`, which tags `CastVariantPaid::Suspend` at
@@ -9668,12 +9668,12 @@ pub fn synthesize_partner_with(face: &mut CardFace) {
     );
 }
 
-/// CR 310.11a + CR 310.11b: Synthesize the two intrinsic abilities every Siege has:
+/// CR 310.12a + CR 310.12b: Synthesize the two intrinsic abilities every Siege has:
 ///   1. As-enters replacement: "As this Siege enters, its controller chooses an
-///      opponent to be its protector." (CR 310.11a)
+///      opponent to be its protector." (CR 310.12a)
 ///   2. Victory trigger: "When the last defense counter is removed from this
 ///      permanent, exile it, then you may cast it transformed without paying
-///      its mana cost." (CR 310.11b)
+///      its mana cost." (CR 310.12b)
 ///
 /// The defense-counter ETB replacement (CR 310.4b) is handled directly by
 /// `apply_card_face_to_object` which seeds `CounterType::Defense` at load time,
@@ -9685,7 +9685,7 @@ pub fn synthesize_siege_intrinsics(face: &mut CardFace) {
         return;
     }
 
-    // CR 310.11a: "As a Siege enters the battlefield, its controller must
+    // CR 310.12a: "As a Siege enters the battlefield, its controller must
     // choose its protector from among their opponents." Modeled as a
     // self-referential `Moved` replacement that persists the opponent choice
     // as a `ChosenAttribute::Player`, which `GameObject::protector()` reads.
@@ -9706,7 +9706,7 @@ pub fn synthesize_siege_intrinsics(face: &mut CardFace) {
         protector_replacement.valid_card = Some(TargetFilter::SelfRef);
         protector_replacement.destination_zone = Some(Zone::Battlefield);
         protector_replacement.description = Some(
-            "CR 310.11a: As a Siege enters, its controller chooses an opponent as its protector."
+            "CR 310.12a: As a Siege enters, its controller chooses an opponent as its protector."
                 .to_string(),
         );
         protector_replacement.execute = Some(Box::new(AbilityDefinition::new(
@@ -9720,7 +9720,7 @@ pub fn synthesize_siege_intrinsics(face: &mut CardFace) {
         face.replacements.push(protector_replacement);
     }
 
-    // CR 310.11b: Victory triggered ability — "When the last defense counter
+    // CR 310.12b: Victory triggered ability — "When the last defense counter
     // is removed from this permanent, exile it, then you may cast it
     // transformed without paying its mana cost."
     let already_has_victory_trigger = face.triggers.iter().any(|t| {
@@ -9741,7 +9741,7 @@ pub fn synthesize_siege_intrinsics(face: &mut CardFace) {
                 alt_ability_cost: None,
                 constraint: None,
                 duration: None,
-                // CR 310.11b + CR 608.2g: the Siege victory ability casts the
+                // CR 310.12b + CR 608.2g: the Siege victory ability casts the
                 // exiled back face AS this trigger resolves — a self-free-cast
                 // during resolution, structurally identical to Suspend's
                 // last-counter cast. (Pre-`driver`, the `duration.is_none()`
@@ -9780,7 +9780,7 @@ pub fn synthesize_siege_intrinsics(face: &mut CardFace) {
             })
             .execute(exile_then_cast)
             .description(
-                "CR 310.11b: When the last defense counter is removed from this Siege, exile it, then you may cast it transformed without paying its mana cost.".to_string(),
+                "CR 310.12b: When the last defense counter is removed from this Siege, exile it, then you may cast it transformed without paying its mana cost.".to_string(),
             );
         face.triggers.push(trigger);
     }
@@ -17110,7 +17110,7 @@ mod siege_synthesis_tests {
         face
     }
 
-    /// CR 310.11a: Sieges get a synthesized Moved-replacement that asks the
+    /// CR 310.12a: Sieges get a synthesized Moved-replacement that asks the
     /// controller to choose an opponent as the protector.
     #[test]
     fn synthesize_adds_protector_choice_replacement() {
@@ -17133,7 +17133,7 @@ mod siege_synthesis_tests {
         ));
     }
 
-    /// CR 310.11b: Sieges get a synthesized `CounterRemoved` trigger with a
+    /// CR 310.12b: Sieges get a synthesized `CounterRemoved` trigger with a
     /// `CounterTriggerFilter` targeting defense at threshold 0 (last counter
     /// removed). The execute chain exiles the Siege then offers an optional
     /// `CastFromZone` with both `without_paying_mana_cost` and `cast_transformed`.

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -1163,7 +1163,7 @@ fn per_defender_caps(state: &GameState) -> Vec<(PlayerId, u32)> {
         .collect()
 }
 
-/// CR 508.5 + CR 310.8d: Resolve the defending player for an `AttackTarget` —
+/// CR 508.5 + CR 310.9d: Resolve the defending player for an `AttackTarget` —
 /// the player for a direct attack, a planeswalker's controller, or a battle's
 /// protector.
 fn defending_player_for_target(state: &GameState, target: AttackTarget) -> PlayerId {
@@ -3653,7 +3653,7 @@ fn attacker_can_attack_target(
     gates: &CombatStaticGates,
     active_team: &[PlayerId],
 ) -> bool {
-    // CR 508.1b + CR 310.5/310.8b: target validity + active-team exclusion.
+    // CR 508.1b + CR 310.5/310.9b: target validity + active-team exclusion.
     match target {
         AttackTarget::Player(pid) => {
             if !state.players.iter().any(|p| p.id == pid)
@@ -4668,7 +4668,7 @@ pub(super) fn commit_attack_declaration(
     let mut attackers: Vec<AttackerInfo> = attacks
         .iter()
         .map(|(object_id, target)| {
-            // CR 508.5 + CR 310.8d: Defending player for a battle = its protector,
+            // CR 508.5 + CR 310.9d: Defending player for a battle = its protector,
             // not its controller. For planeswalkers, defending player = controller.
             let defending_player = defending_player_for_target(state, *target);
             AttackerInfo::new(*object_id, *target, defending_player)
@@ -6118,9 +6118,9 @@ pub fn get_valid_attack_targets(state: &GameState) -> Vec<AttackTarget> {
         }
     }
 
-    // CR 310.8b + CR 506.2: A battle can be attacked by any attacking player for whom
+    // CR 310.9b + CR 506.2: A battle can be attacked by any attacking player for whom
     // its protector is a defending player. Notably a Siege can be attacked by its own
-    // controller if the protector is a different player (CR 310.8b "Siege battle can
+    // controller if the protector is a different player (CR 310.9b "Siege battle can
     // be attacked by its own controller"). The only player who cannot attack is the
     // battle's protector.
     for &id in &state.battlefield {

--- a/crates/engine/src/game/effects/cast_from_zone.rs
+++ b/crates/engine/src/game/effects/cast_from_zone.rs
@@ -592,7 +592,7 @@ pub fn resolve(
         );
     }
 
-    // CR 310.11b + CR 608.2c: "exile it, then you may cast it transformed" —
+    // CR 310.12b + CR 608.2c: "exile it, then you may cast it transformed" —
     // the SelfRef filter resolves to the source object itself. When
     // `ability.targets` is empty (no pre-selected target, as is typical for
     // Siege defeat and Suspend self-cast triggers), fall back to the source
@@ -2080,7 +2080,7 @@ mod tests {
         );
     }
 
-    /// CR 310.11b (#2876): Siege defeat — "exile it, then you may cast it
+    /// CR 310.12b (#2876): Siege defeat — "exile it, then you may cast it
     /// transformed". The `CastFromZone { target: SelfRef }` sub-ability fires
     /// with an EMPTY `ability.targets` (the exile step doesn't pre-select a
     /// target; the source IS the card to cast). Without the SelfRef fallback in
@@ -2167,7 +2167,7 @@ mod tests {
         assert_eq!(
             state.stack.len(),
             1,
-            "CR 310.11b: Siege defeat must put the card on the stack (cast it), \
+            "CR 310.12b: Siege defeat must put the card on the stack (cast it), \
              not silently return with it still in exile"
         );
         assert_eq!(

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -1911,7 +1911,7 @@ fn check_illegal_attachment_unattach(
     }
 }
 
-/// CR 704.5w + CR 704.5x + CR 310.10 + CR 310.11a: If a battle that isn't being
+/// CR 704.5w + CR 704.5x + CR 310.11 + CR 310.12a: If a battle that isn't being
 /// attacked has no protector, an illegal protector, or (for Sieges) a protector
 /// that equals its controller, its controller chooses a legal protector. If no
 /// legal player exists, the battle is put into its owner's graveyard.
@@ -1960,7 +1960,7 @@ fn check_battle_protector(
         let is_siege = battle.card_types.subtypes.iter().any(|s| s == "Siege");
         let protector = battle.protector();
 
-        // Legal protectors for a Siege are opponents of the controller (CR 310.11a).
+        // Legal protectors for a Siege are opponents of the controller (CR 310.12a).
         // For non-Siege battles with no battle type, CR 310.9a says the controller
         // becomes the protector; we treat the controller as legal in that case.
         let protector_legal = match protector {
@@ -1978,7 +1978,7 @@ fn check_battle_protector(
         }
 
         // Compute legal choices.
-        // CR 310.11a: a Siege's controller "must choose its protector from among their
+        // CR 310.12a: a Siege's controller "must choose its protector from among their
         // opponents", and CR 704.5w's SBA phrasing — "no player IN THE GAME designated as
         // its protector ... chooses an appropriate player" — seats CR 102.1 directly on
         // this seam. A CHOICE, not a target (CR 115.10a), so the candidate list is the

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -1650,7 +1650,7 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                     *enter_tapped = crate::types::proposed_event::EtbTapState::Tapped;
                 }
             }
-            // CR 712.14a + CR 310.11b: If this spell was finalized from an
+            // CR 712.14a + CR 310.12b: If this spell was finalized from an
             // ExileWithAltCost permission with `cast_transformed`, the permanent
             // enters the battlefield transformed (resolving to its back face).
             // The finalized stack-paid snapshot is authoritative here; the

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -2225,7 +2225,7 @@ pub(super) fn match_counter_removed(
         if !valid_card_matches(trigger, state, *object_id, source_context) {
             return false;
         }
-        // CR 310.11b + CR 714.2a-mirror: Apply counter filter (type + optional
+        // CR 310.12b + CR 714.2a-mirror: Apply counter filter (type + optional
         // "crossed zero" threshold). Used by the Siege victory trigger
         // "When the last defense counter is removed from this permanent".
         // A threshold of Some(0) means "fire only when the current count

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -3135,7 +3135,7 @@ pub enum CastingPermission {
     /// Card may be cast from exile for the specified cost by its owner.
     /// Building block for Airbending, Suspend, and similar "cast from exile" mechanics.
     /// `cast_transformed` causes the spell to resolve to its back face (CR 712.14a); used
-    /// by Siege victory triggers (CR 310.11b: "cast it transformed without paying its mana cost").
+    /// by Siege victory triggers (CR 310.12b: "cast it transformed without paying its mana cost").
     ExileWithAltCost {
         cost: ManaCost,
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]
@@ -12639,7 +12639,7 @@ pub enum Effect {
         /// CR 601.2 vs CR 305.1: Cast (spells only) vs Play (spells + lands).
         #[serde(default)]
         mode: CardPlayMode,
-        /// CR 712.14a + CR 310.11b: When true, the card is cast transformed — it
+        /// CR 712.14a + CR 310.12b: When true, the card is cast transformed — it
         /// resolves to its back face (used by Siege victory: "cast it transformed
         /// without paying its mana cost").
         #[serde(default, skip_serializing_if = "std::ops::Not::not")]

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -13360,7 +13360,7 @@ pub struct StackPaidSnapshot {
     pub additional_cost_paid: bool,
     #[serde(default, skip_serializing_if = "CastingVariant::is_normal")]
     pub casting_variant: CastingVariant,
-    /// CR 310.11b + CR 712.14a: Exile alt-cost casts that were explicitly cast
+    /// CR 310.12b + CR 712.14a: Exile alt-cost casts that were explicitly cast
     /// transformed resolve onto the battlefield back face up.
     #[serde(default, skip_serializing_if = "std::ops::Not::not")]
     pub cast_transformed: bool,

--- a/crates/engine/tests/integration/rules/battle.rs
+++ b/crates/engine/tests/integration/rules/battle.rs
@@ -3,9 +3,9 @@
 //! Covers:
 //! - Defense-counter ETB (CR 310.4b)
 //! - Zero-defense SBA (CR 704.5v + CR 310.7)
-//! - Protector choice/getter (CR 310.11a + CR 310.8e)
-//! - Attack target routing — defending player = protector (CR 508.5 + CR 310.8d)
-//! - Protector cannot attack own battle (CR 310.8b)
+//! - Protector choice/getter (CR 310.12a + CR 310.9)
+//! - Attack target routing — defending player = protector (CR 508.5 + CR 310.9d)
+//! - Protector cannot attack own battle (CR 310.9b)
 
 #![allow(unused_imports)]
 use super::*;
@@ -63,7 +63,7 @@ fn battle_has_defense_equal_to_counters() {
     assert_eq!(obj.counters.get(&CounterType::Defense).copied(), Some(4));
 }
 
-/// CR 310.11b + CR 712.14a: Accepting a Siege victory cast during trigger
+/// CR 310.12b + CR 712.14a: Accepting a Siege victory cast during trigger
 /// resolution must preserve `cast_transformed`, so the permanent resolves onto
 /// the battlefield back face up.
 #[test]
@@ -166,14 +166,14 @@ fn zero_defense_battle_goes_to_graveyard_via_sba() {
     );
 }
 
-/// CR 310.8e + CR 310.11a: The `protector()` getter returns the chosen opponent.
+/// CR 310.9 + CR 310.9a: The `protector()` getter returns the chosen opponent.
 #[test]
 fn protector_getter_returns_chosen_player() {
     let (runner, battle) = prime_siege(P0, P1, "Protected Siege", 3);
     assert_eq!(runner.state().objects[&battle].protector(), Some(P1));
 }
 
-/// CR 310.8e: Non-battle permanents always return None from `protector()`.
+/// CR 310.9: Non-battle permanents always return None from `protector()`.
 #[test]
 fn non_battle_has_no_protector() {
     let mut scenario = GameScenario::new();
@@ -183,10 +183,10 @@ fn non_battle_has_no_protector() {
     assert_eq!(runner.state().objects[&creature].protector(), None);
 }
 
-/// CR 508.1b + CR 508.5 + CR 310.8d: When a creature attacks a battle, the
+/// CR 508.1b + CR 508.5 + CR 310.9d: When a creature attacks a battle, the
 /// defending player for combat purposes is the battle's protector, not the
 /// battle's controller. Controller (P0) can attack their own Siege when the
-/// protector (P1) is different — CR 310.8b.
+/// protector (P1) is different — CR 310.9b.
 #[test]
 fn battle_attack_defending_player_is_protector() {
     let mut scenario = GameScenario::new();
@@ -242,7 +242,7 @@ fn battle_attack_defending_player_is_protector() {
 #[test]
 fn battle_protector_auto_applies_with_single_candidate_2p() {
     let (mut runner, battle) = prime_siege(P0, P0, "Self-Protected Siege", 3);
-    // Baseline: protector == controller (illegal per CR 310.8b / 310.11a).
+    // Baseline: protector == controller (illegal per CR 310.12a).
     assert_eq!(runner.state().objects[&battle].protector(), Some(P0));
 
     let mut events = Vec::new();
@@ -328,7 +328,7 @@ fn battle_protector_choice_rejects_invalid_candidate() {
         WaitingFor::BattleProtectorChoice { .. }
     ));
 
-    // P0 is the controller — not a legal Siege protector (CR 310.11a).
+    // P0 is the controller — not a legal Siege protector (CR 310.12a).
     let err = runner
         .act(GameAction::ChooseBattleProtector { protector: P0 })
         .expect_err("choosing a non-candidate player must be rejected");
@@ -365,7 +365,7 @@ fn battle_with_no_legal_protector_goes_to_graveyard() {
     ));
 }
 
-/// R4l — CR 310.11a (*"must choose its protector from among their opponents"*) +
+/// R4l — CR 310.12a (*"must choose its protector from among their opponents"*) +
 /// CR 704.5w (*"no player **in the game** designated as its protector"*): the protector
 /// pick is a CHOICE (CR 115.10a), so a phased-out seat is not among the choosable
 /// opponents (the CR 702.26b MIRROR), and a departed one is not either (CR 800.4 +
@@ -413,7 +413,7 @@ fn battle_protector_choice_excludes_a_phased_out_opponent_and_still_offers_the_r
 /// boundary, and at `1` the engine writes the protector ITSELF and publishes nothing: no
 /// `WaitingFor`, no events. That is invisible to every `candidates` assertion the R4-family
 /// shape prescribes, so it needs its own arm. The auto-applied seat is not wrong — it is
-/// the sole surviving legal opponent, which CR 310.10 / CR 310.11a make the only
+/// the sole surviving legal opponent, which CR 310.11 + CR 310.12a make the only
 /// appropriate player. What this arm guards is the SILENT DISAPPEARANCE of the prompt.
 ///
 /// BOTH halves are required: (a) alone would pass on a board where the SBA never ran at
@@ -445,7 +445,7 @@ fn battle_protector_narrowing_to_one_auto_applies_silently() {
     assert_eq!(
         runner.state().objects[&battle].protector(),
         Some(PlayerId(3)),
-        "the auto-applied seat is the ONLY surviving legal opponent (CR 310.11a)"
+        "the auto-applied seat is the ONLY surviving legal opponent (CR 310.12a)"
     );
     assert!(runner.state().battlefield.contains(&battle));
 }
@@ -542,7 +542,7 @@ fn battle_protector_choice_emits_ai_candidates_per_opponent() {
     assert_eq!(picks.len(), 2);
 }
 
-/// CR 310.8b: A battle's protector cannot attack it — the declaration is illegal.
+/// CR 310.9b: A battle's protector cannot attack it — the declaration is illegal.
 #[test]
 fn battle_protector_cannot_attack_own_battle() {
     let mut scenario = GameScenario::new();


### PR DESCRIPTION
Completes the CR 310.8-310.12 cleanup. Every `310.8<letter>` and every
`310.11<letter>` in the tree was fabricated: `310.8` and `310.11` are both
childless rules in docs/MagicCompRules.txt (310.8 is a defense-counter
state-based action, 310.11 is the protector state-based action), so no lettered
subrule of either exists.

The correct rule in every case is the same parent number plus one, letter
preserved. That mapping is confirmed rather than assumed: each site's own prose
matches the rule text at parent+1.

| Was | Now | Evidence |
|---|---|---|
| `310.8b` | `310.9b` | 310.9b: "A battle's protector can never attack it. A battle can be attacked by any attacking player for whom its protector is a defending player. Notably, a Siege battle can be attacked by its own controller." — the code comments quote this nearly verbatim |
| `310.8d` | `310.9d` | 310.9d governs "defending player" relative to a battle and itself says "See rule 508.5", which is why these sites already paired it with 508.5 |
| `310.8e` | `310.9`/`310.9a` | chosen per site: the stored-protector getter takes 310.9, the ETB choice takes 310.9a |
| `310.11a` | `310.12a` | 310.12a: "As a Siege enters the battlefield, its controller must choose its protector from among their opponents." |
| `310.11b` | `310.12b` | 310.12b: the intrinsic "When the last defense counter is removed... exile it, then you may cast it transformed without paying its mana cost." |
| `310.10` | `310.11` | two byproduct sites only: 310.11 is the "battle that isn't being attacked has no protector" SBA. The remaining 23 misapplied `310.10` sites are deliberately out of scope (see below) |

One site is a deletion rather than a shift. `battle.rs` carried
`(illegal per CR 310.8b / 310.11a)` on a "protector == controller" baseline;
only 310.12a governs protector *eligibility*, while 310.9b is about *attacking*.
So the citation now reads `(illegal per CR 310.12a)` alone. This is why the
before/after token counts are asymmetric — 6 `310.8b` leave, 5 `310.9b` arrive —
and the asymmetry is the intended result, not a missed site.

Rule choice is per site, not per neighbour. `game_object.rs` takes `310.9a`
where its neighbour in `filter.rs` takes `310.9e`, because one returns the
ETB-stored protector and the other is the reference rule. Matching a neighbour's
citation shape is the mechanism that generated this bug class in the first place.

Scope: 9 files, 82 changed lines. Five of them are in `game/combat.rs`, which no
earlier pass touched — the cluster was only visible once the residual gate was
widened from `310\.8[ae]` to `310\.8[a-z]`. A gate scoped narrower than its
cluster reports completeness it has not measured.

Non-comment changed lines: 4 sites (8 diff lines), against a nonvacuity control
of 82 total changed lines seen by the same probe. Two are user-visible
`description` string literals in `database/synthesis.rs` (:9709, :9783). The
other two are test assertion messages — `effects/cast_from_zone.rs:2170` is
inside `#[cfg(test)] mod tests`, which opens at :1526 with no intervening `mod`,
and `tests/integration/rules/battle.rs:448` is in the integration tree.

Collateral-damage proof: with the target tokens replaced by a placeholder on both
diff sides, `combat.rs`'s removed and added residues are byte-identical, and
across all 9 files every CR token count is unchanged except the deliberate
substitutions above.

Verified with a positive control (`^704.5a` → 2 matches) and a negative control
(`^999.99` → 0), so a grep that silently matched nothing could not have produced
these results. Post-state gates: `310\.8[a-z]` → 0 across `crates/`, `client/`
and `scripts/`; `310\.11[a-z]` → 0 across `crates/` and `scripts/`. It is NOT 0
under `client/`, and deliberately so — 76 occurrences remain in gitignored
generated data, which is follow-up 2 below and not something source edits can
reach.

Two follow-ups are deliberately NOT folded in:

1. **`CR 310.10` is real but misapplied at 23 remaining sites** — it is the
   *attachment* SBA being cited for the *protector* SBA. Smoking gun at
   `sba.rs`: "Only applies to battles that aren't being attacked" is verbatim
   310.11, not 310.10. This class is invisible to a fabrication gate: an
   existence check returns a match and passes forever. Catching it requires
   reading each citation against its rule text, which is a census rather than a
   pattern.

2. **The generated data still carries the old strings.** 74 occurrences of
   `CR 310.11a`/`310.11b` remain in `client/public/coverage-data.json` and one
   each in the `card-data.json` files. Those are gitignored build products
   generated from the `synthesis.rs` literals fixed here, so the user-visible
   correction is inert until card data is regenerated and redeployed.

The cause of the uniform +1 shift remains speculative. Annotation against an
older CR edition would explain it, but so would a systematic misreading, and no
older CR text was consulted. Recorded because the hypothesis predicts which
other citations in this block are shifted, which is testable before a sweep.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Comprehensive Rules citations throughout Battle, Siege, combat, and transformed-casting documentation.
  * Corrected references to the revised CR 310.9 and CR 310.12 provisions.
  * Updated related test descriptions and explanatory comments for consistency.
* **Tests**
  * Refreshed rules references in integration-test documentation without changing test behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->