### PR TITLE
fix(ai): keep choices inside issued action domain

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -16,9 +16,9 @@ use crate::types::card::LayoutKind;
 use crate::types::card_type::CoreType;
 use crate::types::counter::CounterMatch;
 use crate::types::game_state::{
-    CastOfferKind, CastPaymentMode, CompanionDeclaration, ConvokeMode, CounterCostChoice,
-    CounterMoveChoice, CounterRemoveChoice, GameState, MulliganDecisionPhase, PayCostKind,
-    PayableResource, PendingMulliganAction, TargetSelectionSlot, WaitingFor,
+    CastOfferKind, CastPaymentMode, CompanionDeclaration, ConvokeMode, CostResume,
+    CounterCostChoice, CounterMoveChoice, CounterRemoveChoice, GameState, MulliganDecisionPhase,
+    PayCostKind, PayableResource, PendingMulliganAction, TargetSelectionSlot, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::interaction::MAX_INTERACTION_LIST_LEN;
@@ -2086,6 +2086,14 @@ pub fn candidate_actions_broad_with_probe(
         ),
         WaitingFor::PayCost {
             player,
+            kind: PayCostKind::Sacrifice,
+            choices,
+            count,
+            resume: CostResume::ManaAbility { .. },
+            ..
+        } => bounded_select_card_candidates(*player, choices, [*count]),
+        WaitingFor::PayCost {
+            player,
             kind: PayCostKind::Sacrifice | PayCostKind::ExileFromZone { .. },
             choices,
             count,
@@ -2237,25 +2245,9 @@ pub fn candidate_actions_broad_with_probe(
             player,
             legal_targets,
             min_targets,
+            max_targets,
             ..
-        } => {
-            let mut actions = Vec::new();
-            actions.push(candidate(
-                GameAction::SelectCards {
-                    cards: legal_targets.clone(),
-                },
-                TacticalClass::Selection,
-                Some(*player),
-            ));
-            if *min_targets == 0 {
-                actions.push(candidate(
-                    GameAction::SelectCards { cards: vec![] },
-                    TacticalClass::Selection,
-                    Some(*player),
-                ));
-            }
-            actions
-        }
+        } => bounded_select_card_candidates(*player, legal_targets, *min_targets..=*max_targets),
         WaitingFor::CastOffer {
             player,
             kind: CastOfferKind::Adventure { .. },

--- a/crates/engine/src/game/engine_stack.rs
+++ b/crates/engine/src/game/engine_stack.rs
@@ -3,6 +3,7 @@ use crate::types::events::GameEvent;
 use crate::types::game_state::{
     GameState, TargetSelectionConstraint, TargetSelectionSlot, WaitingFor,
 };
+use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
 
 use super::ability_utils::{
@@ -393,10 +394,18 @@ pub(super) fn handle_multi_target_selection(
         )));
     }
 
+    let mut selected_ids = std::collections::HashSet::<ObjectId>::new();
     for id in selected {
         if !legal_targets.contains(id) {
             return Err(EngineError::InvalidAction(
                 "Selected target not in legal set".to_string(),
+            ));
+        }
+        // CR 115.3: The same target can't be chosen multiple times for one
+        // instance of the word "target" on a spell or ability.
+        if !selected_ids.insert(*id) {
+            return Err(EngineError::InvalidAction(
+                "Selected target more than once".to_string(),
             ));
         }
     }

--- a/crates/engine/tests/integration/ai_multi_target_selection.rs
+++ b/crates/engine/tests/integration/ai_multi_target_selection.rs
@@ -1,0 +1,159 @@
+//! Regression coverage for multi-target AI candidates and selection validation.
+
+use engine::ai_support::{candidate_actions_broad, legal_actions, AiDecisionContract};
+use engine::game::engine::apply_as_current;
+use engine::game::zones::create_object;
+use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{
+    CostResume, GameState, ManaAbilityResume, PayCostKind, PendingManaAbility, WaitingFor,
+};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+
+fn exact_thirteen_targets_state() -> (GameState, Vec<ObjectId>) {
+    let mut state = GameState::new_two_player(42);
+    let targets = (0..14)
+        .map(|index| {
+            create_object(
+                &mut state,
+                CardId(100 + index),
+                P0,
+                format!("Target {index}"),
+                Zone::Battlefield,
+            )
+        })
+        .collect();
+    let ability = ResolvedAbility::new(
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            player: TargetFilter::Controller,
+        },
+        Vec::new(),
+        targets[0],
+        P0,
+    );
+    state.waiting_for = WaitingFor::MultiTargetSelection {
+        player: P0,
+        legal_targets: targets.clone(),
+        min_targets: 13,
+        max_targets: 13,
+        pending_ability: Box::new(ability),
+    };
+    (state, targets)
+}
+
+fn mana_ability_resume() -> CostResume {
+    CostResume::ManaAbility {
+        mana_ability: Box::new(PendingManaAbility {
+            player: P0,
+            source_id: ObjectId(900),
+            ability_index: None,
+            rules_execution_node: None,
+            ability_snapshot: None,
+            color_override: None,
+            resume: ManaAbilityResume::Priority,
+            cost_move_resume: None,
+            chosen_tappers: Vec::new(),
+            chosen_discards: Vec::new(),
+            chosen_mana_payment: None,
+            chosen_counter_count: None,
+            chosen_x: None,
+            collected_evidence: Vec::new(),
+            chosen_exiled: Vec::new(),
+            chosen_sacrificed_battlefield: Vec::new(),
+            cost_paid_object: None,
+            batch_siblings: Vec::new(),
+        }),
+    }
+}
+
+#[test]
+fn multi_target_selection_offers_and_applies_an_exact_oversized_choice() {
+    let (mut state, targets) = exact_thirteen_targets_state();
+
+    let actions = legal_actions(&state);
+    let action = actions
+        .into_iter()
+        .find(|action| matches!(action, GameAction::SelectCards { cards } if cards.len() == 13))
+        .expect("the public legal-action set must include an exact 13-target selection");
+    let GameAction::SelectCards { cards } = &action else {
+        unreachable!("selected multi-target action must select cards");
+    };
+    assert_eq!(cards.len(), 13);
+    assert!(cards.iter().all(|id| targets.contains(id)));
+    assert!(
+        AiDecisionContract::issue(&state, P0).contains_action(&state, &action),
+        "the exact selection must remain in the AI contract"
+    );
+
+    apply_as_current(&mut state, action).expect("the exact multi-target selection must apply");
+    assert_eq!(state.players[P0.0 as usize].life, 21);
+}
+
+#[test]
+fn multi_target_selection_rejects_duplicates_before_mutating_state() {
+    let (mut state, targets) = exact_thirteen_targets_state();
+    let before = serde_json::to_value(&state).expect("game state serializes");
+
+    let error = apply_as_current(
+        &mut state,
+        GameAction::SelectCards {
+            cards: vec![targets[0]; 13],
+        },
+    )
+    .expect_err("one target cannot fill all thirteen slots");
+    assert!(error.to_string().contains("more than once"));
+    assert_eq!(
+        serde_json::to_value(&state).expect("game state serializes"),
+        before,
+        "rejected duplicates must not mutate game state"
+    );
+
+    apply_as_current(
+        &mut state,
+        GameAction::SelectCards {
+            cards: targets.into_iter().take(13).collect(),
+        },
+    )
+    .expect("a distinct exact-size selection remains legal");
+}
+
+#[test]
+fn mana_ability_sacrifice_candidates_are_exact_while_generic_costs_keep_their_range() {
+    let choices = vec![ObjectId(1), ObjectId(2)];
+    let mut state = GameState::new_two_player(42);
+    state.waiting_for = WaitingFor::PayCost {
+        player: P0,
+        kind: PayCostKind::Sacrifice,
+        choices,
+        count: 2,
+        min_count: 0,
+        resume: mana_ability_resume(),
+    };
+
+    let exact_sizes: Vec<_> = candidate_actions_broad(&state)
+        .into_iter()
+        .filter_map(|candidate| match candidate.action {
+            GameAction::SelectCards { cards } => Some(cards.len()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(exact_sizes, vec![2]);
+
+    let WaitingFor::PayCost { resume, .. } = &mut state.waiting_for else {
+        unreachable!("fixture must remain a payment prompt");
+    };
+    *resume = CostResume::Resolution;
+    let generic_sizes: Vec<_> = candidate_actions_broad(&state)
+        .into_iter()
+        .filter_map(|candidate| match candidate.action {
+            GameAction::SelectCards { cards } => Some(cards.len()),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(generic_sizes, vec![0, 1, 1, 2]);
+}

--- a/crates/engine/tests/integration/ai_multi_target_selection.rs
+++ b/crates/engine/tests/integration/ai_multi_target_selection.rs
@@ -16,7 +16,7 @@ const P0: PlayerId = PlayerId(0);
 
 fn exact_thirteen_targets_state() -> (GameState, Vec<ObjectId>) {
     let mut state = GameState::new_two_player(42);
-    let targets = (0..14)
+    let targets: Vec<ObjectId> = (0..14)
         .map(|index| {
             create_object(
                 &mut state,

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -5,6 +5,7 @@ mod adamant_enters_with_leading_if_gate;
 mod adapter_contract_fixtures;
 mod advanced_reconstruction_regression;
 mod ai_decision_contract;
+mod ai_multi_target_selection;
 mod ajani_nacatl_pariah_co_departure_6427;
 mod ajani_nacatl_pariah_sacrifice_outlet_6018;
 mod ajani_nacatl_pariah_transform;

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -1143,18 +1143,26 @@ pub fn fallback_action(
     config: &AiConfig,
     contract: &AiDecisionContract,
 ) -> Option<GameAction> {
+    let gate = |action: Option<GameAction>| {
+        action.filter(|action| contract.contains_action(state, action))
+    };
+    let issued = |predicate: fn(&GameAction) -> bool| {
+        contract
+            .candidates
+            .iter()
+            .find(|candidate| predicate(&candidate.action))
+            .map(|candidate| candidate.action.clone())
+    };
     // CR 605.3b: A sacrificial mana prompt is an explicit payment decision,
     // not a generic pending-cast failure. Pick only an engine-issued source or
     // the exact BackToManaPayment escape; never synthesize CancelCast here.
     if matches!(state.waiting_for, WaitingFor::ManaSourceSelection { .. }) {
-        return engine::ai_support::legal_actions(state)
-            .into_iter()
-            .find(|action| {
-                matches!(
-                    action,
-                    GameAction::ActivateManaSource { .. } | GameAction::BackToManaPayment
-                )
-            });
+        return gate(issued(|action| {
+            matches!(
+                action,
+                GameAction::ActivateManaSource { .. } | GameAction::BackToManaPayment
+            )
+        }));
     }
     // Target prompts must answer from the exact domain that will gate the
     // public proposal. The contract has already filtered current targets
@@ -1164,21 +1172,13 @@ pub fn fallback_action(
         state.waiting_for,
         WaitingFor::TargetSelection { .. } | WaitingFor::TriggerTargetSelection { .. }
     ) {
-        let target = contract
-            .candidates
-            .iter()
-            .find(|candidate| matches!(candidate.action, GameAction::ChooseTarget { .. }))
-            .map(|candidate| candidate.action.clone());
+        let target = issued(|action| matches!(action, GameAction::ChooseTarget { .. }));
         if target.is_some()
             || matches!(state.waiting_for, WaitingFor::TriggerTargetSelection { .. })
         {
-            return target;
+            return gate(target);
         }
-        return contract
-            .candidates
-            .iter()
-            .find(|candidate| matches!(candidate.action, GameAction::CancelCast))
-            .map(|candidate| candidate.action.clone());
+        return gate(issued(|action| matches!(action, GameAction::CancelCast)));
     }
 
     // Pending-cast states can always be escaped with CancelCast (CR 601.2).
@@ -1224,10 +1224,10 @@ pub fn fallback_action(
              that allowed an uncompletable cast through. Tighten the pre-cast check rather \
              than relying on CancelCast recovery."
         );
-        return Some(GameAction::CancelCast);
+        return gate(Some(GameAction::CancelCast));
     }
 
-    match &state.waiting_for {
+    let action = match &state.waiting_for {
         // Terminal — no action possible.
         WaitingFor::GameOver { .. } => None,
 
@@ -1236,23 +1236,21 @@ pub fn fallback_action(
 
         // CR 732.2a: if tactical scoring found no choice, take the conservative legal escape
         // from the engine's candidate set. The AI is never forced to propose a shortcut.
-        WaitingFor::LoopShortcut { .. } => engine::ai_support::legal_actions(state)
-            .into_iter()
-            .find(|action| matches!(action, GameAction::DeclineShortcut)),
+        WaitingFor::LoopShortcut { .. } => {
+            issued(|action| matches!(action, GameAction::DeclineShortcut))
+        }
         // CR 732.2a: the finite pre-cast family has the same conservative
         // proposer fallback as the legacy shortcut. Ask the engine for its
         // issued decline capability instead of fabricating a route response.
-        WaitingFor::PrecastCopyShortcutOffer { .. } => engine::ai_support::legal_actions(state)
-            .into_iter()
-            .find(|action| {
-                matches!(
-                    action,
-                    GameAction::PrecastCopyShortcut {
-                        response: engine::types::actions::PrecastCopyShortcutResponse::Decline,
-                        ..
-                    }
-                )
-            }),
+        WaitingFor::PrecastCopyShortcutOffer { .. } => issued(|action| {
+            matches!(
+                action,
+                GameAction::PrecastCopyShortcut {
+                    response: engine::types::actions::PrecastCopyShortcutResponse::Decline,
+                    ..
+                }
+            )
+        }),
         // PR-7 Phase 4c (LOW-2): self-preservation via the single-authority
         // `smart_shortcut_response` — Shorten when the polled player has a meaningful
         // way to break the loop, else Accept.
@@ -1292,14 +1290,14 @@ pub fn fallback_action(
 
         // Combat declarations: an empty declaration is NOT always legal —
         // CR 508.1d / CR 701.15b require goaded / "attacks if able" creatures
-        // to be declared. Delegate to the engine's `legal_actions`, which runs
-        // the simulation filter and only emits engine-legal candidates.
-        WaitingFor::DeclareAttackers { .. } => engine::ai_support::legal_actions(state)
-            .into_iter()
-            .find(|a| matches!(a, GameAction::DeclareAttackers { .. })),
-        WaitingFor::DeclareBlockers { .. } => engine::ai_support::legal_actions(state)
-            .into_iter()
-            .find(|a| matches!(a, GameAction::DeclareBlockers { .. })),
+        // to be declared. The contract's engine-issued candidates already ran
+        // the simulation filter and only contain legal declarations.
+        WaitingFor::DeclareAttackers { .. } => {
+            issued(|action| matches!(action, GameAction::DeclareAttackers { .. }))
+        }
+        WaitingFor::DeclareBlockers { .. } => {
+            issued(|action| matches!(action, GameAction::DeclareBlockers { .. }))
+        }
         WaitingFor::UntapChoice { candidates, .. } => {
             candidates
                 .first()
@@ -1584,9 +1582,9 @@ pub fn fallback_action(
         // intentionally keep `options` empty and synthesize candidates from
         // `all_card_names` (#6248); reading `options.first()` softlocks after
         // restore when rehydrate succeeded but options stayed empty (#6393).
-        WaitingFor::NamedChoice { .. } => engine::ai_support::legal_actions(state)
-            .into_iter()
-            .find(|a| matches!(a, GameAction::ChooseOption { .. })),
+        WaitingFor::NamedChoice { .. } => {
+            issued(|action| matches!(action, GameAction::ChooseOption { .. }))
+        }
 
         // CR 608.2d: opponent-guess fallback — any printed guess is legal. The
         // hidden-info determinization in `choose_action` already pre-empts this
@@ -1827,7 +1825,7 @@ pub fn fallback_action(
             // first candidate object rather than emitting an action the engine
             // would reject.
             if !candidate_objects.is_empty() {
-                return Some(GameAction::SubmitVoteCandidate { candidate_index: 0 });
+                return gate(Some(GameAction::SubmitVoteCandidate { candidate_index: 0 }));
             }
             // The friend-or-foe heuristic only fires when the controller is
             // labeling other players (the delegated shape) — matching
@@ -2101,9 +2099,7 @@ pub fn fallback_action(
         WaitingFor::PayCost {
             resume: CostResume::Resolution,
             ..
-        } => engine::ai_support::legal_actions(state)
-            .into_iter()
-            .find(|action| matches!(action, GameAction::SelectCards { .. })),
+        } => issued(|action| matches!(action, GameAction::SelectCards { .. })),
 
         // CR 101.4 + CR 701.21a: Category choice — pick one permanent
         // per type category, the rest are sacrificed. A permanent that belongs
@@ -2165,12 +2161,12 @@ pub fn fallback_action(
         WaitingFor::SeparatePilesChoice { .. } => Some(GameAction::ChoosePile {
             pile: engine::types::game_state::PileSide::A,
         }),
-        WaitingFor::MoveCountersDistribution { .. } => engine::ai_support::legal_actions(state)
-            .into_iter()
-            .find(|action| matches!(action, GameAction::ChooseCounterMoveDistribution { .. })),
-        WaitingFor::RemoveCountersChoice { .. } => engine::ai_support::legal_actions(state)
-            .into_iter()
-            .find(|action| matches!(action, GameAction::ChooseCountersToRemove { .. })),
+        WaitingFor::MoveCountersDistribution { .. } => {
+            issued(|action| matches!(action, GameAction::ChooseCounterMoveDistribution { .. }))
+        }
+        WaitingFor::RemoveCountersChoice { .. } => {
+            issued(|action| matches!(action, GameAction::ChooseCountersToRemove { .. }))
+        }
 
         // Remaining pending-cast states are caught by the has_pending_cast
         // guard above. This arm is structurally unreachable but required
@@ -2194,7 +2190,9 @@ pub fn fallback_action(
             // is unreachable at runtime but keeps the match exhaustive.
             Some(GameAction::CancelCast)
         }
-    }
+    };
+
+    gate(action)
 }
 
 /// Score all candidate actions without selecting one.
@@ -9441,10 +9439,10 @@ mod tests {
     }
 
     /// Issue #6393: CardName NamedChoice keeps `options` empty and synthesizes
-    /// candidates from `all_card_names`. Fallback must ask `legal_actions`, not
-    /// `options.first()`, or restore softlocks after a successful rehydrate.
+    /// candidates from `all_card_names`. Fallback must use the issued contract,
+    /// not `options.first()`, or restore softlocks after a successful rehydrate.
     #[test]
-    fn named_choice_card_name_fallback_uses_legal_actions_when_options_empty() {
+    fn named_choice_card_name_fallback_uses_issued_contract_when_options_empty() {
         let mut state = make_state();
         create_object(
             &mut state,
@@ -9465,7 +9463,36 @@ mod tests {
         let action = fallback_action_default(&state).expect("fallback returns ChooseOption");
         assert!(
             matches!(action, GameAction::ChooseOption { ref choice } if choice == "Forest"),
-            "expected Forest from legal_actions, got {action:?}"
+            "expected Forest from the issued contract, got {action:?}"
+        );
+    }
+
+    #[test]
+    fn fallback_rejects_a_non_owner_contract_after_constructing_an_action() {
+        let mut state = make_state();
+        state.all_card_names = vec!["Forest".to_string()].into();
+        state.waiting_for = WaitingFor::NamedChoice {
+            player: P0,
+            choice_type: ChoiceType::CardName,
+            options: Vec::new(),
+            source: None,
+            persist_player: None,
+        };
+        let config = create_config(AiDifficulty::Medium, Platform::Native);
+        let owner_contract = AiDecisionContract::issue(&state, P0);
+        let action = fallback_action(&state, &config, &owner_contract)
+            .expect("the owner must receive the issued card-name choice");
+        assert!(owner_contract.contains_action(&state, &action));
+
+        let bystander_contract = AiDecisionContract::issue(&state, P1);
+        assert!(
+            bystander_contract.candidates.is_empty(),
+            "fixture premise: the bystander owes no NamedChoice"
+        );
+        assert_eq!(
+            fallback_action(&state, &config, &bystander_contract),
+            None,
+            "an empty non-owner contract must gate every fallback result"
         );
     }
 

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -1470,10 +1470,9 @@ pub fn fallback_action(
             })
         }
 
-        // Multi-target selection: zero targets is valid when min == 0.
-        WaitingFor::MultiTargetSelection { .. } => {
-            Some(GameAction::SelectCards { cards: Vec::new() })
-        }
+        // Choose an engine-issued target set. The legal cardinality is
+        // prompt-specific, so an empty selection is not always valid.
+        WaitingFor::MultiTargetSelection { .. } => issued_selection(contract),
 
         // Soulbond pair choice: choose the first legal partner; if none remain,
         // decline the pair.
@@ -12496,6 +12495,58 @@ mod tests {
             "an `up_to` prompt legally admits nothing, and the conservative pick \
              is still nothing"
         );
+    }
+
+    /// A multi-target prompt can require more targets than the ordinary
+    /// selection pool cap. The enumerator still issues one concrete exact-size
+    /// candidate, which the fallback must return unchanged rather than
+    /// synthesizing an illegal empty selection.
+    #[test]
+    fn fallback_multi_target_selection_uses_the_issued_exact_selection() {
+        let mut state = make_state();
+        let ai = P0;
+        let targets: Vec<ObjectId> = (0..14)
+            .map(|index| {
+                create_object(
+                    &mut state,
+                    CardId(80_000 + index),
+                    ai,
+                    format!("Fallback target {index}"),
+                    Zone::Battlefield,
+                )
+            })
+            .collect();
+        let ability = ResolvedAbility::new(
+            Effect::GainLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                player: TargetFilter::Controller,
+            },
+            Vec::new(),
+            targets[0],
+            ai,
+        );
+        state.waiting_for = WaitingFor::MultiTargetSelection {
+            player: ai,
+            legal_targets: targets.clone(),
+            min_targets: 13,
+            max_targets: 13,
+            pending_ability: Box::new(ability),
+        };
+
+        let contract = AiDecisionContract::issue(&state, ai);
+        let action = fallback_action_default(&state)
+            .expect("the exact multi-target prompt must have an issued fallback");
+        let GameAction::SelectCards { cards } = &action else {
+            panic!("expected SelectCards, got {action:?}");
+        };
+        assert_eq!(cards.len(), 13, "the prompt requires exactly 13 targets");
+        assert!(cards.iter().all(|target| targets.contains(target)));
+        assert!(
+            contract.contains_action(&state, &action),
+            "the fallback must return the exact issued selection"
+        );
+        engine::game::engine::apply_as_current(&mut state, action)
+            .expect("the issued exact selection must apply");
     }
 
     /// T4. Hostile sibling for the "exactly one" sub-family. `WardDiscardChoice`


### PR DESCRIPTION
Fixes AI stalls caused by invalid or fabricated interaction fallbacks.\n\n- Generate bounded multi-target and exact mana-sacrifice selections.\n- Reject duplicate selections at the reducer boundary.\n- Require all AI fallback actions to be present in the issued decision contract.\n\nValidated with focused engine integration and AI fallback tests.