### PR TITLE
feat(engine): type limited range configuration

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -59,6 +59,11 @@ export type GameFormat =
 
 export type FormatGroup = "Constructed" | "Commander" | "Multiplayer" | "Limited";
 
+export interface RangeOfInfluenceConfig {
+  default_range: number;
+  player_overrides: Record<string, number>;
+}
+
 export interface FormatConfig {
   format: GameFormat;
   starting_life: number;
@@ -68,7 +73,7 @@ export interface FormatConfig {
   singleton: boolean;
   command_zone: boolean;
   commander_damage_threshold: number | null;
-  range_of_influence: number | null;
+  range_of_influence: RangeOfInfluenceConfig | null;
   team_based: boolean;
   /**
    * Engine-derived predicate: true when the format uses a commander card

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -143,10 +143,54 @@ fn decode_restored_game_state(json_str: &str) -> Result<DecodedRestoredGameState
     let state = serde_json::from_value::<PersistedGameState>(serialized)
         .map(PersistedGameState::into_game_state)
         .map_err(|error| format!("Failed to deserialize GameState: {error}"))?;
+    state
+        .format_config
+        .reject_unimplemented_range_of_influence()
+        .map_err(|error| format!("Failed to restore GameState: {error}"))?;
     Ok(DecodedRestoredGameState {
         state,
         debug_permitted_was_serialized,
     })
+}
+
+fn validate_external_format_config(config: &FormatConfig, player_count: u8) -> Result<(), String> {
+    config.validate_for_player_count(player_count)?;
+    config.reject_unimplemented_range_of_influence()
+}
+
+#[cfg(test)]
+mod external_format_config_tests {
+    use std::collections::BTreeMap;
+
+    use super::*;
+    use engine::types::format::RangeOfInfluenceConfig;
+
+    #[test]
+    fn external_initialization_rejects_limited_range_configuration() {
+        let mut config = FormatConfig::standard();
+        config.range_of_influence = Some(RangeOfInfluenceConfig {
+            default_range: 0,
+            player_overrides: BTreeMap::new(),
+        });
+
+        assert!(validate_external_format_config(&config, 2)
+            .expect_err("limited range must remain disabled at the WASM boundary")
+            .contains("not supported"));
+    }
+
+    #[test]
+    fn restored_state_with_limited_range_is_rejected_before_rehydration() {
+        let mut state = GameState::new_two_player(42);
+        state.format_config.range_of_influence = Some(RangeOfInfluenceConfig {
+            default_range: 0,
+            player_overrides: BTreeMap::new(),
+        });
+        let json = serde_json::to_string(&state).expect("state serializes");
+
+        assert!(decode_restored_game_state(&json)
+            .expect_err("limited range must remain disabled at the restore boundary")
+            .contains("not supported"));
+    }
 }
 
 /// Bind the engine's interaction authority for the one game this module hosts.
@@ -952,14 +996,21 @@ pub fn initialize_game(
     let seed = seed.map(|s| s as u64).unwrap_or(42);
 
     let format_config = if !format_config_js.is_null() && !format_config_js.is_undefined() {
-        serde_wasm_bindgen::from_value::<FormatConfig>(format_config_js)
-            .unwrap_or_else(|_| FormatConfig::standard())
+        match serde_wasm_bindgen::from_value::<FormatConfig>(format_config_js) {
+            Ok(config) => config,
+            Err(error) => {
+                return to_js(&serde_json::json!({
+                    "error": true,
+                    "reasons": [format!("Format config deserialization failed: {error}")],
+                }));
+            }
+        }
     } else {
         FormatConfig::standard()
     };
     let count = player_count.unwrap_or(2);
     let game_format = format_config.format;
-    if let Err(reason) = format_config.validate_for_player_count(count) {
+    if let Err(reason) = validate_external_format_config(&format_config, count) {
         return to_js(&serde_json::json!({
             "error": true,
             "reasons": [reason],

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -218,6 +218,20 @@ mod external_format_config_tests {
             .expect_err("limited range must remain disabled at the restore boundary")
             .contains("not supported"));
     }
+
+    #[test]
+    fn legacy_scalar_range_restore_reaches_the_feature_gate() {
+        let mut serialized =
+            serde_json::to_value(GameState::new_two_player(42)).expect("state serializes");
+        serialized["format_config"]["range_of_influence"] = serde_json::json!(1);
+        let json = serde_json::to_string(&serialized).expect("legacy state serializes");
+
+        let error = decode_restored_game_state(&json)
+            .expect_err("legacy enabled range must be rejected after migration");
+
+        assert!(error.contains("not supported"));
+        assert!(!error.contains("deserialize"));
+    }
 }
 
 /// Bind the engine's interaction authority for the one game this module hosts.
@@ -3002,6 +3016,31 @@ mod tests {
     fn proposal_outcome(token: &str, actor: PlayerId, action: &GameAction) -> serde_json::Value {
         serde_wasm_bindgen::from_value(submit_ai_action_proposal(token, actor.0, to_js(action)))
             .expect("proposal outcome must serialize")
+    }
+
+    #[test]
+    fn initialize_game_returns_error_for_malformed_format_config_without_standard_fallback() {
+        clear_game_state();
+        let malformed_format_config = serde_wasm_bindgen::to_value(&serde_json::json!(42))
+            .expect("malformed JSON value converts to a JS input");
+
+        let result = initialize_game(
+            JsValue::NULL,
+            Some(42.0),
+            malformed_format_config,
+            JsValue::NULL,
+            Some(2),
+            None,
+        );
+        let error: serde_json::Value =
+            serde_wasm_bindgen::from_value(result).expect("initializer error is a JS object");
+
+        assert_eq!(error["error"], true);
+        assert!(error["reasons"][0]
+            .as_str()
+            .expect("error reason is a string")
+            .contains("Format config deserialization failed"));
+        assert!(GAME_STATE.with(|cell| cell.replace(None).is_none()));
     }
 
     /// Installs a real engine state and returns the production finite decision

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -158,6 +158,17 @@ fn validate_external_format_config(config: &FormatConfig, player_count: u8) -> R
     config.reject_unimplemented_range_of_influence()
 }
 
+fn parse_initialize_format_config(
+    decoded: Result<FormatConfig, String>,
+) -> Result<FormatConfig, serde_json::Value> {
+    decoded.map_err(|error| {
+        serde_json::json!({
+            "error": true,
+            "reasons": [format!("Format config deserialization failed: {error}")],
+        })
+    })
+}
+
 #[cfg(test)]
 mod external_format_config_tests {
     use std::collections::BTreeMap;
@@ -176,6 +187,22 @@ mod external_format_config_tests {
         assert!(validate_external_format_config(&config, 2)
             .expect_err("limited range must remain disabled at the WASM boundary")
             .contains("not supported"));
+    }
+
+    #[test]
+    fn malformed_initialize_format_config_returns_an_error_envelope() {
+        let malformed_js_config = serde_json::json!(42);
+        let decoded = serde_json::from_value::<FormatConfig>(malformed_js_config)
+            .map_err(|error| error.to_string());
+
+        let error = parse_initialize_format_config(decoded)
+            .expect_err("malformed JS config must not fall back to Standard");
+
+        assert_eq!(error["error"], true);
+        assert!(error["reasons"][0]
+            .as_str()
+            .expect("error reason is a string")
+            .contains("Format config deserialization failed"));
     }
 
     #[test]
@@ -996,14 +1023,12 @@ pub fn initialize_game(
     let seed = seed.map(|s| s as u64).unwrap_or(42);
 
     let format_config = if !format_config_js.is_null() && !format_config_js.is_undefined() {
-        match serde_wasm_bindgen::from_value::<FormatConfig>(format_config_js) {
+        match parse_initialize_format_config(
+            serde_wasm_bindgen::from_value::<FormatConfig>(format_config_js)
+                .map_err(|error| error.to_string()),
+        ) {
             Ok(config) => config,
-            Err(error) => {
-                return to_js(&serde_json::json!({
-                    "error": true,
-                    "reasons": [format!("Format config deserialization failed: {error}")],
-                }));
-            }
+            Err(error) => return to_js(&error),
         }
     } else {
         FormatConfig::standard()

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -179,10 +179,10 @@ mod external_format_config_tests {
     #[test]
     fn external_initialization_rejects_limited_range_configuration() {
         let mut config = FormatConfig::standard();
-        config.range_of_influence = Some(RangeOfInfluenceConfig {
+        config.range_of_influence = Some(Box::new(RangeOfInfluenceConfig {
             default_range: 0,
             player_overrides: BTreeMap::new(),
-        });
+        }));
 
         assert!(validate_external_format_config(&config, 2)
             .expect_err("limited range must remain disabled at the WASM boundary")
@@ -208,10 +208,10 @@ mod external_format_config_tests {
     #[test]
     fn restored_state_with_limited_range_is_rejected_before_rehydration() {
         let mut state = GameState::new_two_player(42);
-        state.format_config.range_of_influence = Some(RangeOfInfluenceConfig {
+        state.format_config.range_of_influence = Some(Box::new(RangeOfInfluenceConfig {
             default_range: 0,
             player_overrides: BTreeMap::new(),
-        });
+        }));
         let json = serde_json::to_string(&state).expect("state serializes");
 
         assert!(decode_restored_game_state(&json)

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -1,3 +1,5 @@
+use std::collections::BTreeMap;
+
 use serde::{Deserialize, Serialize};
 
 use crate::database::legality::LegalityFormat;
@@ -126,6 +128,21 @@ pub enum FormatTopology {
     },
 }
 
+/// Configuration for the limited range of influence option.
+///
+/// The engine does not implement limited-range rules yet. This type preserves
+/// the full per-seat configuration shape so external boundaries can reject it
+/// explicitly until the corresponding game-rule support exists.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RangeOfInfluenceConfig {
+    /// The number of seats away that each player can influence by default.
+    /// Zero is valid and means a player can influence only themself.
+    pub default_range: u8,
+    /// Per-seat exceptions to [`Self::default_range`].
+    #[serde(default)]
+    pub player_overrides: BTreeMap<PlayerId, u8>,
+}
+
 /// Configuration for a game format, describing player counts, starting life, deck rules, etc.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FormatConfig {
@@ -144,7 +161,7 @@ pub struct FormatConfig {
     pub singleton: bool,
     pub command_zone: bool,
     pub commander_damage_threshold: Option<u8>,
-    pub range_of_influence: Option<u8>,
+    pub range_of_influence: Option<RangeOfInfluenceConfig>,
     pub team_based: bool,
     /// CR 904.2a / CR 904.6: In default Archenemy, the single-player team is
     /// designated as the archenemy and takes the first turn.
@@ -626,6 +643,39 @@ impl FormatConfig {
                     "archenemy_player must be less than player_count ({player_count})"
                 ));
             }
+        }
+        if let Some(range) = &self.range_of_influence {
+            let max_radius = player_count / 2;
+            if range.default_range > max_radius {
+                return Err(format!(
+                    "range_of_influence.default_range must be at most {max_radius} for {player_count} players"
+                ));
+            }
+            for (&player, &radius) in &range.player_overrides {
+                if player.0 >= player_count {
+                    return Err(format!(
+                        "range_of_influence.player_overrides contains seat {} outside player_count ({player_count})",
+                        player.0
+                    ));
+                }
+                if radius > max_radius {
+                    return Err(format!(
+                        "range_of_influence.player_overrides[{}] must be at most {max_radius} for {player_count} players",
+                        player.0
+                    ));
+                }
+            }
+        }
+        Ok(())
+    }
+
+    /// Rejects limited-range configuration until the engine implements its rules.
+    pub fn reject_unimplemented_range_of_influence(&self) -> Result<(), String> {
+        if self.range_of_influence.is_some() {
+            return Err(
+                "range_of_influence is not supported until limited-range rules are implemented"
+                    .to_string(),
+            );
         }
         Ok(())
     }
@@ -1251,6 +1301,64 @@ mod tests {
             let deserialized: FormatConfig = serde_json::from_str(&json).unwrap();
             assert_eq!(config, deserialized);
         }
+    }
+
+    #[test]
+    fn range_of_influence_config_round_trips_with_player_overrides() {
+        let config = RangeOfInfluenceConfig {
+            default_range: 0,
+            player_overrides: BTreeMap::from([(PlayerId(1), 1), (PlayerId(3), 2)]),
+        };
+
+        let json = serde_json::to_value(&config).expect("range config serializes");
+        assert_eq!(json["default_range"], 0);
+        assert_eq!(json["player_overrides"]["1"], 1);
+        assert_eq!(json["player_overrides"]["3"], 2);
+        assert_eq!(
+            serde_json::from_value::<RangeOfInfluenceConfig>(json)
+                .expect("range config deserializes"),
+            config
+        );
+    }
+
+    #[test]
+    fn range_of_influence_config_defaults_missing_overrides_to_empty() {
+        let config: RangeOfInfluenceConfig =
+            serde_json::from_str(r#"{"default_range":0}"#).expect("range config deserializes");
+
+        assert_eq!(config.default_range, 0);
+        assert!(config.player_overrides.is_empty());
+    }
+
+    #[test]
+    fn range_of_influence_validation_uses_actual_seating() {
+        let mut config = FormatConfig::commander();
+        config.range_of_influence = Some(RangeOfInfluenceConfig {
+            default_range: 0,
+            player_overrides: BTreeMap::from([(PlayerId(1), 1), (PlayerId(3), 2)]),
+        });
+        assert!(config.validate_for_player_count(4).is_ok());
+
+        config.range_of_influence.as_mut().unwrap().player_overrides =
+            BTreeMap::from([(PlayerId(4), 0)]);
+        assert!(config
+            .validate_for_player_count(4)
+            .expect_err("an override must name an occupied seat")
+            .contains("outside player_count"));
+
+        config.range_of_influence.as_mut().unwrap().player_overrides =
+            BTreeMap::from([(PlayerId(1), 3)]);
+        assert!(config
+            .validate_for_player_count(4)
+            .expect_err("an override cannot exceed the table radius")
+            .contains("player_overrides[1]"));
+
+        config.range_of_influence.as_mut().unwrap().player_overrides = BTreeMap::new();
+        config.range_of_influence.as_mut().unwrap().default_range = 3;
+        assert!(config
+            .validate_for_player_count(4)
+            .expect_err("a range cannot exceed the table radius")
+            .contains("at most 2"));
     }
 
     #[test]

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -1,6 +1,6 @@
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use crate::database::legality::LegalityFormat;
 use crate::types::player::PlayerId;
@@ -143,6 +143,30 @@ pub struct RangeOfInfluenceConfig {
     pub player_overrides: BTreeMap<PlayerId, u8>,
 }
 
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum RangeOfInfluenceConfigWire {
+    Current(RangeOfInfluenceConfig),
+    Legacy(u8),
+}
+
+fn deserialize_range_of_influence<'de, D>(
+    deserializer: D,
+) -> Result<Option<RangeOfInfluenceConfig>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    Option::<RangeOfInfluenceConfigWire>::deserialize(deserializer).map(|range| {
+        range.map(|range| match range {
+            RangeOfInfluenceConfigWire::Current(config) => config,
+            RangeOfInfluenceConfigWire::Legacy(default_range) => RangeOfInfluenceConfig {
+                default_range,
+                player_overrides: BTreeMap::new(),
+            },
+        })
+    })
+}
+
 /// Configuration for a game format, describing player counts, starting life, deck rules, etc.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct FormatConfig {
@@ -161,6 +185,7 @@ pub struct FormatConfig {
     pub singleton: bool,
     pub command_zone: bool,
     pub commander_damage_threshold: Option<u8>,
+    #[serde(default, deserialize_with = "deserialize_range_of_influence")]
     pub range_of_influence: Option<RangeOfInfluenceConfig>,
     pub team_based: bool,
     /// CR 904.2a / CR 904.6: In default Archenemy, the single-player team is
@@ -1328,6 +1353,28 @@ mod tests {
 
         assert_eq!(config.default_range, 0);
         assert!(config.player_overrides.is_empty());
+    }
+
+    #[test]
+    fn legacy_scalar_range_of_influence_deserializes_and_remains_rejected() {
+        let mut serialized = serde_json::to_value(FormatConfig::standard())
+            .expect("format config serializes before legacy rewrite");
+        serialized["range_of_influence"] = serde_json::json!(1);
+
+        let config: FormatConfig =
+            serde_json::from_value(serialized).expect("legacy scalar range config deserializes");
+
+        assert_eq!(
+            config.range_of_influence,
+            Some(RangeOfInfluenceConfig {
+                default_range: 1,
+                player_overrides: BTreeMap::new(),
+            })
+        );
+        assert!(config
+            .reject_unimplemented_range_of_influence()
+            .expect_err("legacy enabled range must reach the normal feature gate")
+            .contains("not supported"));
     }
 
     #[test]

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -152,17 +152,19 @@ enum RangeOfInfluenceConfigWire {
 
 fn deserialize_range_of_influence<'de, D>(
     deserializer: D,
-) -> Result<Option<RangeOfInfluenceConfig>, D::Error>
+) -> Result<Option<Box<RangeOfInfluenceConfig>>, D::Error>
 where
     D: Deserializer<'de>,
 {
     Option::<RangeOfInfluenceConfigWire>::deserialize(deserializer).map(|range| {
-        range.map(|range| match range {
-            RangeOfInfluenceConfigWire::Current(config) => config,
-            RangeOfInfluenceConfigWire::Legacy(default_range) => RangeOfInfluenceConfig {
-                default_range,
-                player_overrides: BTreeMap::new(),
-            },
+        range.map(|range| {
+            Box::new(match range {
+                RangeOfInfluenceConfigWire::Current(config) => config,
+                RangeOfInfluenceConfigWire::Legacy(default_range) => RangeOfInfluenceConfig {
+                    default_range,
+                    player_overrides: BTreeMap::new(),
+                },
+            })
         })
     })
 }
@@ -186,7 +188,7 @@ pub struct FormatConfig {
     pub command_zone: bool,
     pub commander_damage_threshold: Option<u8>,
     #[serde(default, deserialize_with = "deserialize_range_of_influence")]
-    pub range_of_influence: Option<RangeOfInfluenceConfig>,
+    pub range_of_influence: Option<Box<RangeOfInfluenceConfig>>,
     pub team_based: bool,
     /// CR 904.2a / CR 904.6: In default Archenemy, the single-player team is
     /// designated as the archenemy and takes the first turn.
@@ -1380,10 +1382,10 @@ mod tests {
     #[test]
     fn range_of_influence_validation_uses_actual_seating() {
         let mut config = FormatConfig::commander();
-        config.range_of_influence = Some(RangeOfInfluenceConfig {
+        config.range_of_influence = Some(Box::new(RangeOfInfluenceConfig {
             default_range: 0,
             player_overrides: BTreeMap::from([(PlayerId(1), 1), (PlayerId(3), 2)]),
-        });
+        }));
         assert!(config.validate_for_player_count(4).is_ok());
 
         config.range_of_influence.as_mut().unwrap().player_overrides =

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -1368,10 +1368,10 @@ mod tests {
 
         assert_eq!(
             config.range_of_influence,
-            Some(RangeOfInfluenceConfig {
+            Some(Box::new(RangeOfInfluenceConfig {
                 default_range: 1,
                 player_overrides: BTreeMap::new(),
-            })
+            }))
         );
         assert!(config
             .reject_unimplemented_range_of_influence()

--- a/crates/lobby-broker/src/broker.rs
+++ b/crates/lobby-broker/src/broker.rs
@@ -345,6 +345,16 @@ impl Broker {
             return vec![error("ClientHello required before any other message")];
         }
 
+        let pc = requested_player_count.clamp(2, 6);
+        if let Some(format_config) = format_config.as_ref() {
+            if let Err(reason) = format_config.validate_for_player_count(pc) {
+                return vec![error(&reason)];
+            }
+            if let Err(reason) = format_config.reject_unimplemented_range_of_influence() {
+                return vec![error(&reason)];
+            }
+        }
+
         let mut out = Vec::new();
 
         // Re-registration cleanup: drop a previously-owned entry first so a
@@ -375,15 +385,6 @@ impl Broker {
 
         let game_code = env.new_game_code();
         let player_token = env.new_token();
-        let pc = requested_player_count.clamp(2, 6);
-        if let Some(format_config) = format_config.as_ref() {
-            if let Err(reason) = format_config.validate_for_player_count(pc) {
-                return vec![error(&reason)];
-            }
-            if let Err(reason) = format_config.reject_unimplemented_range_of_influence() {
-                return vec![error(&reason)];
-            }
-        }
         let (host_version, host_build_commit) = conn
             .client_hello
             .as_ref()
@@ -905,6 +906,44 @@ mod tests {
         );
         // The new entry replaced the old ownership stamp.
         assert_ne!(conn.host_game.as_deref(), Some(first_code.as_str()));
+    }
+
+    #[test]
+    fn rejected_limited_range_re_registration_preserves_the_existing_lobby() {
+        let env = FakeEnv::new();
+        let mut broker = Broker::new();
+        let mut conn = ConnState::default();
+        hello(&mut conn, &mut broker, &env);
+        let first = create(&mut conn, &mut broker, &env);
+        let first_code = game_code_of(&first);
+        let mut format_config = engine::types::format::FormatConfig::standard();
+        format_config.range_of_influence = Some(engine::types::format::RangeOfInfluenceConfig {
+            default_range: 0,
+            player_overrides: std::collections::BTreeMap::new(),
+        });
+
+        let out = broker.handle_create_game(
+            &mut conn,
+            "Host".into(),
+            true,
+            None,
+            None,
+            4,
+            Default::default(),
+            Some(format_config),
+            None,
+            Some("peer-1".into()),
+            None,
+            false,
+            &env,
+        );
+
+        assert!(matches!(
+            out.as_slice(),
+            [Outbound::ToSelf(LobbyServerMessage::Error { .. })]
+        ));
+        assert_eq!(conn.host_game.as_deref(), Some(first_code.as_str()));
+        assert!(broker.lobby_mut().public_game(&first_code).is_some());
     }
 
     #[test]

--- a/crates/lobby-broker/src/broker.rs
+++ b/crates/lobby-broker/src/broker.rs
@@ -345,16 +345,6 @@ impl Broker {
             return vec![error("ClientHello required before any other message")];
         }
 
-        let pc = requested_player_count.clamp(2, 6);
-        if let Some(format_config) = format_config.as_ref() {
-            if let Err(reason) = format_config.validate_for_player_count(pc) {
-                return vec![error(&reason)];
-            }
-            if let Err(reason) = format_config.reject_unimplemented_range_of_influence() {
-                return vec![error(&reason)];
-            }
-        }
-
         let mut out = Vec::new();
 
         // Re-registration cleanup: drop a previously-owned entry first so a
@@ -385,6 +375,7 @@ impl Broker {
 
         let game_code = env.new_game_code();
         let player_token = env.new_token();
+        let pc = requested_player_count.clamp(2, 6);
         let (host_version, host_build_commit) = conn
             .client_hello
             .as_ref()
@@ -922,19 +913,23 @@ mod tests {
             player_overrides: std::collections::BTreeMap::new(),
         });
 
-        let out = broker.handle_create_game(
+        let out = broker.handle(
             &mut conn,
-            "Host".into(),
-            true,
-            None,
-            None,
-            4,
-            Default::default(),
-            Some(format_config),
-            None,
-            Some("peer-1".into()),
-            None,
-            false,
+            LobbyClientMessage::CreateGameWithSettings {
+                deck: test_deck(),
+                display_name: "Host".into(),
+                public: true,
+                password: None,
+                timer_seconds: None,
+                player_count: 4,
+                match_config: Default::default(),
+                format_config: Some(format_config),
+                room_name: None,
+                host_peer_id: Some("peer-1".into()),
+                draft_metadata: None,
+                start_when_full: true,
+                ranked: false,
+            },
             &env,
         );
 
@@ -1338,41 +1333,6 @@ mod tests {
                 start_when_full: true,
                 ranked: false,
             },
-            &env,
-        );
-
-        assert!(matches!(
-            out.as_slice(),
-            [Outbound::ToSelf(LobbyServerMessage::Error { .. })]
-        ));
-        assert!(conn.host_game.is_none());
-    }
-
-    #[test]
-    fn create_rejects_limited_range_until_supported() {
-        let env = FakeEnv::new();
-        let mut broker = Broker::new();
-        let mut conn = ConnState::default();
-        hello(&mut conn, &mut broker, &env);
-        let mut format_config = engine::types::format::FormatConfig::standard();
-        format_config.range_of_influence = Some(engine::types::format::RangeOfInfluenceConfig {
-            default_range: 0,
-            player_overrides: std::collections::BTreeMap::new(),
-        });
-
-        let out = broker.handle_create_game(
-            &mut conn,
-            "Host".into(),
-            true,
-            None,
-            None,
-            2,
-            Default::default(),
-            Some(format_config),
-            None,
-            Some("peer-host".into()),
-            None,
-            false,
             &env,
         );
 

--- a/crates/lobby-broker/src/broker.rs
+++ b/crates/lobby-broker/src/broker.rs
@@ -908,10 +908,11 @@ mod tests {
         let first = create(&mut conn, &mut broker, &env);
         let first_code = game_code_of(&first);
         let mut format_config = engine::types::format::FormatConfig::standard();
-        format_config.range_of_influence = Some(engine::types::format::RangeOfInfluenceConfig {
-            default_range: 0,
-            player_overrides: std::collections::BTreeMap::new(),
-        });
+        format_config.range_of_influence =
+            Some(Box::new(engine::types::format::RangeOfInfluenceConfig {
+                default_range: 0,
+                player_overrides: std::collections::BTreeMap::new(),
+            }));
 
         let out = broker.handle(
             &mut conn,

--- a/crates/lobby-broker/src/broker.rs
+++ b/crates/lobby-broker/src/broker.rs
@@ -380,6 +380,9 @@ impl Broker {
             if let Err(reason) = format_config.validate_for_player_count(pc) {
                 return vec![error(&reason)];
             }
+            if let Err(reason) = format_config.reject_unimplemented_range_of_influence() {
+                return vec![error(&reason)];
+            }
         }
         let (host_version, host_build_commit) = conn
             .client_hello
@@ -1296,6 +1299,41 @@ mod tests {
                 start_when_full: true,
                 ranked: false,
             },
+            &env,
+        );
+
+        assert!(matches!(
+            out.as_slice(),
+            [Outbound::ToSelf(LobbyServerMessage::Error { .. })]
+        ));
+        assert!(conn.host_game.is_none());
+    }
+
+    #[test]
+    fn create_rejects_limited_range_until_supported() {
+        let env = FakeEnv::new();
+        let mut broker = Broker::new();
+        let mut conn = ConnState::default();
+        hello(&mut conn, &mut broker, &env);
+        let mut format_config = engine::types::format::FormatConfig::standard();
+        format_config.range_of_influence = Some(engine::types::format::RangeOfInfluenceConfig {
+            default_range: 0,
+            player_overrides: std::collections::BTreeMap::new(),
+        });
+
+        let out = broker.handle_create_game(
+            &mut conn,
+            "Host".into(),
+            true,
+            None,
+            None,
+            2,
+            Default::default(),
+            Some(format_config),
+            None,
+            Some("peer-host".into()),
+            None,
+            false,
             &env,
         );
 

--- a/crates/lobby-broker/src/inbound_guard.rs
+++ b/crates/lobby-broker/src/inbound_guard.rs
@@ -125,6 +125,7 @@ pub fn guard_create_game_settings_inbound(
     validate_create_game_settings_inbound_fields(&fields)?;
     if let Some(format_config) = fields.format_config {
         format_config.validate_for_player_count(fields.player_count.clamp(2, MAX_PLAYER_COUNT))?;
+        format_config.reject_unimplemented_range_of_influence()?;
     }
     validate_deck_payload("deck", fields.deck)
 }
@@ -270,6 +271,30 @@ mod tests {
         .unwrap_err();
 
         assert!(err.contains("archenemy_player"));
+    }
+
+    #[test]
+    fn borrowed_create_guard_rejects_limited_range_until_supported() {
+        let mut format_config = FormatConfig::standard();
+        format_config.range_of_influence = Some(engine::types::format::RangeOfInfluenceConfig {
+            default_range: 0,
+            player_overrides: std::collections::BTreeMap::new(),
+        });
+
+        let err = guard_create_game_settings_inbound(CreateGameSettingsInbound {
+            deck: &deck(1, 0),
+            display_name: "Host",
+            password: None,
+            timer_seconds: None,
+            player_count: 2,
+            format_config: Some(&format_config),
+            room_name: None,
+            host_peer_id: None,
+            draft_metadata: None,
+        })
+        .unwrap_err();
+
+        assert!(err.contains("range_of_influence"));
     }
 
     #[test]

--- a/crates/lobby-broker/src/inbound_guard.rs
+++ b/crates/lobby-broker/src/inbound_guard.rs
@@ -276,10 +276,11 @@ mod tests {
     #[test]
     fn borrowed_create_guard_rejects_limited_range_until_supported() {
         let mut format_config = FormatConfig::standard();
-        format_config.range_of_influence = Some(engine::types::format::RangeOfInfluenceConfig {
-            default_range: 0,
-            player_overrides: std::collections::BTreeMap::new(),
-        });
+        format_config.range_of_influence =
+            Some(Box::new(engine::types::format::RangeOfInfluenceConfig {
+                default_range: 0,
+                player_overrides: std::collections::BTreeMap::new(),
+            }));
 
         let err = guard_create_game_settings_inbound(CreateGameSettingsInbound {
             deck: &deck(1, 0),

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -7890,10 +7890,11 @@ mod full_create_guard_tests {
         let deck = deck();
         let mut fields = fields(&deck, None, None);
         let mut format_config = engine::types::format::FormatConfig::standard();
-        format_config.range_of_influence = Some(engine::types::format::RangeOfInfluenceConfig {
-            default_range: 0,
-            player_overrides: std::collections::BTreeMap::new(),
-        });
+        format_config.range_of_influence =
+            Some(Box::new(engine::types::format::RangeOfInfluenceConfig {
+                default_range: 0,
+                player_overrides: std::collections::BTreeMap::new(),
+            }));
         fields.format_config = Some(&format_config);
 
         let err = guard_full_create_game_settings_inbound(fields, &[]).unwrap_err();

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -185,7 +185,7 @@ type SharedGameSpectators = Arc<Mutex<HashMap<String, Vec<mpsc::UnboundedSender<
 fn restore_persisted_session(json: &str, db: SharedDb) -> Result<GameSession, String> {
     let persisted = serde_json::from_str::<server_core::PersistedSession>(json)
         .map_err(|error| error.to_string())?;
-    Ok(GameSession::from_persisted(persisted, db.as_ref()))
+    GameSession::from_persisted(persisted, db.as_ref())
 }
 
 async fn reserve_lobby_subscriber_slot(
@@ -947,6 +947,7 @@ fn guard_full_create_game_settings_inbound(
     lobby_broker::validate_create_game_settings_inbound_fields(&fields)?;
     if let Some(format_config) = fields.format_config {
         format_config.validate_for_player_count(pc)?;
+        format_config.reject_unimplemented_range_of_influence()?;
     }
     guard_create_ai_seats(ai_seats, pc)?;
     lobby_broker::validate_deck_payload("deck", fields.deck)?;
@@ -2663,7 +2664,7 @@ async fn create_and_connect_multiplayer_session(
             pc,
             match_config,
             format_config,
-        );
+        )?;
         let full_key = match game_db.create_full_session_key(&game_code) {
             Ok(key) => key,
             Err(error) => {
@@ -4970,7 +4971,7 @@ async fn handle_client_message(
                 // --- AI game path: create, start, and run initial AI actions ---
                 let (game_code, player_token, full_key, game_started_msg) = {
                     let mut mgr = state.lock().await;
-                    let (game_code, player_token) = mgr.create_game_with_ai(
+                    let (game_code, player_token) = match mgr.create_game_with_ai(
                         resolved,
                         display_name.clone(),
                         timer_seconds,
@@ -4979,7 +4980,13 @@ async fn handle_client_message(
                         db.card_names(),
                         format_config.clone(),
                         db.as_ref(),
-                    );
+                    ) {
+                        Ok(created) => created,
+                        Err(error) => {
+                            let _ = tx.send(ServerMessage::error(error));
+                            return;
+                        }
+                    };
 
                     let full_key = match game_db.create_full_session_key(&game_code) {
                         Ok(key) => key,
@@ -7876,6 +7883,22 @@ mod full_create_guard_tests {
         let err = guard_full_create_game_settings_inbound(fields, &[]).unwrap_err();
 
         assert!(err.contains("archenemy_player"));
+    }
+
+    #[test]
+    fn full_create_guard_rejects_limited_range_until_supported() {
+        let deck = deck();
+        let mut fields = fields(&deck, None, None);
+        let mut format_config = engine::types::format::FormatConfig::standard();
+        format_config.range_of_influence = Some(engine::types::format::RangeOfInfluenceConfig {
+            default_range: 0,
+            player_overrides: std::collections::BTreeMap::new(),
+        });
+        fields.format_config = Some(&format_config);
+
+        let err = guard_full_create_game_settings_inbound(fields, &[]).unwrap_err();
+
+        assert!(err.contains("range_of_influence"));
     }
 
     #[test]

--- a/crates/server-core/src/draft_session.rs
+++ b/crates/server-core/src/draft_session.rs
@@ -563,7 +563,7 @@ impl DraftSessionManager {
                 2,
                 match_config,
                 Some(format_config.clone()),
-            );
+            )?;
             let (token1, _) = game_mgr.join_game_with_name(&game_code, decks[1].clone(), name1)?;
 
             game_mgr

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -900,8 +900,14 @@ impl GameSession {
     /// - card characteristics from the card database
     /// - `log_player_names` from the persisted display names
     /// - `rng` re-seeded with fresh randomness
-    pub fn from_persisted(ps: PersistedSession, db: &CardDatabase) -> Self {
+    pub fn from_persisted(ps: PersistedSession, db: &CardDatabase) -> Result<Self, String> {
         let mut state = ps.state.into_game_state();
+        state
+            .format_config
+            .validate_for_player_count(ps.player_count)?;
+        state
+            .format_config
+            .reject_unimplemented_range_of_influence()?;
 
         // Restore #[serde(skip)] fields
         state.all_card_names = db.card_names().into();
@@ -944,7 +950,7 @@ impl GameSession {
 
         let rewind_game_number = state.game_number;
 
-        GameSession {
+        Ok(GameSession {
             game_code: ps.game_code,
             full_runtime: None,
             state_revision: ps.state_revision,
@@ -975,7 +981,7 @@ impl GameSession {
             takeback_history: VecDeque::new(),
             turn_rewind_history: VecDeque::new(),
             rewind_game_number,
-        }
+        })
     }
 }
 
@@ -1015,6 +1021,7 @@ impl SessionManager {
     /// Create a new game session (2-player default). Returns (game_code, player_token).
     pub fn create_game(&mut self, deck: PlayerDeckPayload) -> (String, String) {
         self.create_game_n_players(deck, String::new(), None, 2, MatchConfig::default(), None)
+            .expect("the standard format must be supported")
     }
 
     /// Create a new game session with lobby settings (2-player default). Returns (game_code, player_token).
@@ -1026,6 +1033,7 @@ impl SessionManager {
         match_config: MatchConfig,
     ) -> (String, String) {
         self.create_game_n_players(deck, display_name, timer_seconds, 2, match_config, None)
+            .expect("the standard format must be supported")
     }
 
     /// Create a new N-player game session. Returns (game_code, player_token).
@@ -1037,7 +1045,11 @@ impl SessionManager {
         player_count: u8,
         match_config: MatchConfig,
         format_config: Option<FormatConfig>,
-    ) -> (String, String) {
+    ) -> Result<(String, String), String> {
+        let format_config = format_config.unwrap_or_else(FormatConfig::standard);
+        format_config.validate_for_player_count(player_count)?;
+        format_config.reject_unimplemented_range_of_influence()?;
+
         let game_code = generate_game_code();
         let player_token = generate_player_token();
         let pc = player_count as usize;
@@ -1051,11 +1063,7 @@ impl SessionManager {
         let mut display_names = vec![String::new(); pc];
         display_names[0] = display_name;
 
-        let mut state = GameState::new(
-            format_config.unwrap_or_else(FormatConfig::standard),
-            player_count,
-            rand::rng().random(),
-        );
+        let mut state = GameState::new(format_config, player_count, rand::rng().random());
         // CR 732.2a: Bo3 is inherently 2-player, but the combo-detector opt-in is
         // player-count-agnostic (infinite loops are a Commander staple), so carry
         // `loop_detection` through for any table size while resetting `match_type`.
@@ -1120,7 +1128,7 @@ impl SessionManager {
 
         info!(game = %game_code, player_count, "game session created");
 
-        (game_code, player_token)
+        Ok((game_code, player_token))
     }
 
     /// Join an existing game. Returns (player_id, player_token, initial_state_for_joiner) on success.
@@ -1270,7 +1278,7 @@ impl SessionManager {
         card_names: Vec<String>,
         format_config: Option<FormatConfig>,
         db: &CardDatabase,
-    ) -> (String, String) {
+    ) -> Result<(String, String), String> {
         let total_players = 1 + ai_requests.len() as u8;
         let (game_code, player_token) = self.create_game_n_players(
             host_deck,
@@ -1279,7 +1287,7 @@ impl SessionManager {
             total_players,
             match_config,
             format_config,
-        );
+        )?;
 
         let session = self.sessions.get_mut(&game_code).unwrap();
         for (seat_index, difficulty, deck) in &ai_requests {
@@ -1302,7 +1310,7 @@ impl SessionManager {
             .start_game(db)
             .expect("start_game in tests should not hit cEDH validation");
 
-        (game_code, player_token)
+        Ok((game_code, player_token))
     }
 
     /// Returns the exact mana sources automatic payment would use without
@@ -1945,7 +1953,8 @@ mod tests {
         let persisted = mgr.sessions.get(&code).unwrap().to_persisted();
 
         let db = CardDatabase::default();
-        let restored = GameSession::from_persisted(persisted, &db);
+        let restored =
+            GameSession::from_persisted(persisted, &db).expect("supported persisted format config");
 
         assert_eq!(
             restored.state.interaction_session_id,
@@ -1956,17 +1965,39 @@ mod tests {
     }
 
     #[test]
+    fn persisted_session_with_limited_range_is_rejected() {
+        let mut mgr = SessionManager::new();
+        let (code, _token) = mgr.create_game(make_deck());
+        let mut persisted = mgr.sessions.get(&code).unwrap().to_persisted();
+        let mut state = persisted.state.into_game_state();
+        state.format_config.range_of_influence =
+            Some(engine::types::format::RangeOfInfluenceConfig {
+                default_range: 0,
+                player_overrides: std::collections::BTreeMap::new(),
+            });
+        persisted.state = PersistedGameState::capture(state);
+
+        let error = GameSession::from_persisted(persisted, &CardDatabase::default())
+            .err()
+            .expect("limited range must remain disabled at the restore boundary");
+
+        assert!(error.contains("not supported"));
+    }
+
+    #[test]
     fn player_slot_info_omits_team_metadata_for_individual_formats() {
         for format in [FormatConfig::standard(), FormatConfig::commander()] {
             let mut mgr = SessionManager::new();
-            let (code, _) = mgr.create_game_n_players(
-                make_deck(),
-                "Host".to_string(),
-                None,
-                2,
-                MatchConfig::default(),
-                Some(format),
-            );
+            let (code, _) = mgr
+                .create_game_n_players(
+                    make_deck(),
+                    "Host".to_string(),
+                    None,
+                    2,
+                    MatchConfig::default(),
+                    Some(format),
+                )
+                .expect("supported format config");
 
             let slots = mgr.sessions.get(&code).unwrap().player_slot_info();
             assert_eq!(slots.len(), 2);
@@ -1980,14 +2011,16 @@ mod tests {
     #[test]
     fn player_slot_info_includes_two_headed_giant_team_metadata() {
         let mut mgr = SessionManager::new();
-        let (code, _) = mgr.create_game_n_players(
-            make_deck(),
-            "Host".to_string(),
-            None,
-            4,
-            MatchConfig::default(),
-            Some(FormatConfig::two_headed_giant()),
-        );
+        let (code, _) = mgr
+            .create_game_n_players(
+                make_deck(),
+                "Host".to_string(),
+                None,
+                4,
+                MatchConfig::default(),
+                Some(FormatConfig::two_headed_giant()),
+            )
+            .expect("supported format config");
 
         let slots = mgr.sessions.get(&code).unwrap().player_slot_info();
         let team_indices: Vec<u8> = slots
@@ -2001,6 +2034,29 @@ mod tests {
 
         assert_eq!(team_indices, vec![0, 0, 1, 1]);
         assert_eq!(positions, vec![0, 1, 0, 1]);
+    }
+
+    #[test]
+    fn create_game_rejects_limited_range_until_supported() {
+        let mut mgr = SessionManager::new();
+        let mut format_config = FormatConfig::standard();
+        format_config.range_of_influence = Some(engine::types::format::RangeOfInfluenceConfig {
+            default_range: 0,
+            player_overrides: std::collections::BTreeMap::new(),
+        });
+
+        assert!(mgr
+            .create_game_n_players(
+                make_deck(),
+                "Host".to_string(),
+                None,
+                2,
+                MatchConfig::default(),
+                Some(format_config),
+            )
+            .expect_err("limited range must remain disabled at the session boundary")
+            .contains("not supported"));
+        assert!(mgr.sessions.is_empty());
     }
 
     /// CR 732.2a (#4603 opt-in, Best-of-N): the combo-detector opt-in lives on the
@@ -2018,17 +2074,19 @@ mod tests {
         use engine::types::match_config::MatchType;
 
         let mut mgr = SessionManager::new();
-        let (code, _) = mgr.create_game_n_players(
-            make_deck(),
-            "Host".to_string(),
-            None,
-            2,
-            MatchConfig {
-                match_type: MatchType::Bo3,
-                loop_detection: LoopDetectionMode::On,
-            },
-            None,
-        );
+        let (code, _) = mgr
+            .create_game_n_players(
+                make_deck(),
+                "Host".to_string(),
+                None,
+                2,
+                MatchConfig {
+                    match_type: MatchType::Bo3,
+                    loop_detection: LoopDetectionMode::On,
+                },
+                None,
+            )
+            .expect("supported format config");
 
         // Game 1: the creation site projects the opt-in onto the runtime flag.
         assert!(
@@ -2739,7 +2797,8 @@ mod tests {
                 .join("../../data/mtgjson/test_fixture.json"),
         )
         .expect("parser fixture must contain Witherbloom Apprentice");
-        let legacy_restored = GameSession::from_persisted(legacy, &db);
+        let legacy_restored =
+            GameSession::from_persisted(legacy, &db).expect("supported persisted format config");
         assert!(matches!(
             legacy_restored.state.waiting_for,
             WaitingFor::Priority { player } if player == P0
@@ -2751,7 +2810,8 @@ mod tests {
         )
         .expect("trusted persisted session remains decodable");
         assert!(matches!(&trusted.state, PersistedGameState::Trusted(_)));
-        let trusted_restored = GameSession::from_persisted(trusted, &db);
+        let trusted_restored =
+            GameSession::from_persisted(trusted, &db).expect("supported persisted format config");
         let fresh_epoch = match trusted_restored.state.waiting_for {
             WaitingFor::PrecastCopyShortcutOffer { epoch, .. } => epoch,
             ref other => panic!("trusted restore must reissue its offer, got {other:?}"),
@@ -2928,16 +2988,18 @@ mod tests {
     fn takeback_auto_approves_for_sole_human_seat() {
         let mut mgr = SessionManager::new();
         let db = engine::database::CardDatabase::default();
-        let (code, _token) = mgr.create_game_with_ai(
-            make_deck(),
-            "Host".to_string(),
-            None,
-            MatchConfig::default(),
-            vec![(1, AiDifficulty::Easy, make_deck())],
-            Vec::new(),
-            None,
-            &db,
-        );
+        let (code, _token) = mgr
+            .create_game_with_ai(
+                make_deck(),
+                "Host".to_string(),
+                None,
+                MatchConfig::default(),
+                vec![(1, AiDifficulty::Easy, make_deck())],
+                Vec::new(),
+                None,
+                &db,
+            )
+            .expect("supported format config");
 
         let session = mgr.sessions.get_mut(&code).unwrap();
         // Force a known checkpoint to take back to, since the AI may have
@@ -3034,14 +3096,16 @@ mod tests {
     #[test]
     fn run_ai_is_noop_while_takeback_is_pending() {
         let mut mgr = SessionManager::new();
-        let (code, _token0) = mgr.create_game_n_players(
-            make_deck(),
-            "Host".to_string(),
-            None,
-            3,
-            MatchConfig::default(),
-            None,
-        );
+        let (code, _token0) = mgr
+            .create_game_n_players(
+                make_deck(),
+                "Host".to_string(),
+                None,
+                3,
+                MatchConfig::default(),
+                None,
+            )
+            .expect("supported format config");
         let (_token1, _) = mgr.join_game(&code, make_deck()).unwrap();
         let (_token2, _) = mgr.join_game(&code, make_deck()).unwrap();
 
@@ -3869,6 +3933,7 @@ mod tests {
             MatchConfig::default(),
             Some(sandbox_config),
         )
+        .expect("supported sandbox config")
     }
 
     #[test]
@@ -3942,16 +4007,18 @@ mod tests {
     /// than a restatement of the sandbox flag.
     fn single_ai_opponent_game(mgr: &mut SessionManager) -> String {
         let db = engine::database::CardDatabase::default();
-        let (code, _token) = mgr.create_game_with_ai(
-            make_deck(),
-            "Host".to_string(),
-            None,
-            MatchConfig::default(),
-            vec![(1, AiDifficulty::Easy, make_deck())],
-            Vec::new(),
-            None,
-            &db,
-        );
+        let (code, _token) = mgr
+            .create_game_with_ai(
+                make_deck(),
+                "Host".to_string(),
+                None,
+                MatchConfig::default(),
+                vec![(1, AiDifficulty::Easy, make_deck())],
+                Vec::new(),
+                None,
+                &db,
+            )
+            .expect("supported format config");
         code
     }
 
@@ -4002,16 +4069,18 @@ mod tests {
         // SAME `session.state`.
         let mut mgr = SessionManager::single_user(Duration::from_secs(60));
         let db = engine::database::CardDatabase::default();
-        let (code, host_token) = mgr.create_game_with_ai(
-            make_deck(),
-            "Host".to_string(),
-            None,
-            MatchConfig::default(),
-            vec![(1, AiDifficulty::Easy, make_deck())],
-            Vec::new(),
-            None,
-            &db,
-        );
+        let (code, host_token) = mgr
+            .create_game_with_ai(
+                make_deck(),
+                "Host".to_string(),
+                None,
+                MatchConfig::default(),
+                vec![(1, AiDifficulty::Easy, make_deck())],
+                Vec::new(),
+                None,
+                &db,
+            )
+            .expect("supported format config");
 
         // POSITIVE, through the real wire gate. `ShuffleLibrary` (not
         // `CreateCard`) is the reach-guard: `CreateCard` is resolved at the
@@ -4080,14 +4149,16 @@ mod tests {
 
         let db = engine::database::CardDatabase::default();
         let mut mgr = SessionManager::single_user(Duration::from_secs(60));
-        let (code, _host) = mgr.create_game_n_players(
-            make_deck(),
-            "Host".to_string(),
-            None,
-            3,
-            MatchConfig::default(),
-            None,
-        );
+        let (code, _host) = mgr
+            .create_game_n_players(
+                make_deck(),
+                "Host".to_string(),
+                None,
+                3,
+                MatchConfig::default(),
+                None,
+            )
+            .expect("supported format config");
         // Seat 1 joins; seat 2 is left waiting, because the reducer rejects
         // removing a claimed seat (`SeatClaimed`).
         mgr.join_game(&code, make_deck()).unwrap();
@@ -4146,7 +4217,8 @@ mod tests {
         let mut origin = SessionManager::new();
         let code = single_ai_opponent_game(&mut origin);
         let persisted = origin.sessions.get(&code).unwrap().to_persisted();
-        let restored = GameSession::from_persisted(persisted, &db);
+        let restored =
+            GameSession::from_persisted(persisted, &db).expect("supported persisted format config");
         assert_eq!(
             restored.hosting,
             HostingMode::Shared,
@@ -4178,7 +4250,7 @@ mod tests {
     fn round_trip_through_disk(session: &GameSession, db: &CardDatabase) -> GameSession {
         let json = serde_json::to_string(&session.to_persisted()).unwrap();
         let persisted: crate::persist::PersistedSession = serde_json::from_str(&json).unwrap();
-        GameSession::from_persisted(persisted, db)
+        GameSession::from_persisted(persisted, db).expect("supported persisted format config")
     }
 
     #[test]
@@ -5215,14 +5287,16 @@ mod tests {
         use engine::types::identifiers::CardId;
 
         let mut mgr = SessionManager::new();
-        let (code, token0) = mgr.create_game_n_players(
-            make_deck(),
-            "Host".to_string(),
-            None,
-            3,
-            MatchConfig::default(),
-            Some(FormatConfig::standard()),
-        );
+        let (code, token0) = mgr
+            .create_game_n_players(
+                make_deck(),
+                "Host".to_string(),
+                None,
+                3,
+                MatchConfig::default(),
+                Some(FormatConfig::standard()),
+            )
+            .expect("supported format config");
         let _ = mgr.join_game(&code, make_deck()).unwrap();
         let _ = mgr.join_game(&code, make_deck()).unwrap();
 

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -1971,10 +1971,10 @@ mod tests {
         let mut persisted = mgr.sessions.get(&code).unwrap().to_persisted();
         let mut state = persisted.state.into_game_state();
         state.format_config.range_of_influence =
-            Some(engine::types::format::RangeOfInfluenceConfig {
+            Some(Box::new(engine::types::format::RangeOfInfluenceConfig {
                 default_range: 0,
                 player_overrides: std::collections::BTreeMap::new(),
-            });
+            }));
         persisted.state = PersistedGameState::capture(state);
 
         let error = GameSession::from_persisted(persisted, &CardDatabase::default())
@@ -2040,10 +2040,11 @@ mod tests {
     fn create_game_rejects_limited_range_until_supported() {
         let mut mgr = SessionManager::new();
         let mut format_config = FormatConfig::standard();
-        format_config.range_of_influence = Some(engine::types::format::RangeOfInfluenceConfig {
-            default_range: 0,
-            player_overrides: std::collections::BTreeMap::new(),
-        });
+        format_config.range_of_influence =
+            Some(Box::new(engine::types::format::RangeOfInfluenceConfig {
+                default_range: 0,
+                player_overrides: std::collections::BTreeMap::new(),
+            }));
 
         assert!(mgr
             .create_game_n_players(


### PR DESCRIPTION
Introduces a typed, backwards-compatible limited-range configuration and keeps it rejected at every external creation/restore ingress until the full CR 801 implementation lands.\n\n- replaces scalar radius with default plus per-player overrides\n- preserves legacy scalar decode then rejects enabled use safely\n- rejects incomplete LROI across WASM/server/P2P/lobby ingress\n- removes malformed WASM fallback to Standard\n\nValidation: cargo fmt, diff check, pre-commit gates, and independent implementation review. CI is the authoritative build/test gate.\n\nFollow-up series will add turn snapshots, CR 801 range enforcement, partial-draw protocol, and unconditional CR 104 detector.