### PR TITLE
fix(engine): cite CR 310.10 for the attachment SBA's battle half

### DIFF
--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -1790,7 +1790,7 @@ fn check_zero_defense(
     zones::mark_simultaneous_departures(events, &zones::departed_subset(state, &performed_ids));
 }
 
-/// CR 704.5p (+ CR 310.9 for the battle half): the full "this permanent may not
+/// CR 704.5p (+ CR 310.10 for the battle half): the full "this permanent may not
 /// be attached to anything" state-based action, expressed as its two printed
 /// sentences.
 ///


### PR DESCRIPTION
`check_illegal_attachment_unattach` cited `CR 310.9` for the battle half of
the illegal-attachment state-based action. CR 310.9 is "Each battle has a
player designated as its protector" (MagicCompRules:1822) - nothing to do
with attachment. The battle half is CR 310.10 (:1838): "A battle can't be
attached to players or permanents, even if it is also an Aura, Equipment, or
Fortification. If a battle is somehow attached to a permanent, it becomes
unattached. This is a state-based action (see rule 704)."

This is the 25th site of the same staleness the CR 310.x campaign has been
correcting, and it is the one the census could not see. Unit F corrected
310.8d -> 310.9d and 310.8b -> 310.9b; #7125 corrected 310.10 -> 310.11 at
24 sites. The campaign is a uniform one-subsection upward shift: the
citations were written against a CR revision predating an insertion in §310.
Under that shift the rule now numbered 310.10 was formerly 310.9 - exactly
what this comment said. Its stale value is what the shift predicts, so this
is the same defect, not a coincidental typo.

The census missed it because it was keyed on the OUTPUT token (`310.10`)
rather than the semantic class (§310 citations written against pre-shift
numbering). A site whose stale value is `310.9` contains no `310.10` token
and so never entered the population.

Why it matters now: after #7125, `CR 310.10` has zero occurrences tree-wide
while the sole function implementing that rule cites the wrong number. So
`grep "CR 310.10"` - the lookup workflow CLAUDE.md documents - returns
nothing for a rule the engine does implement. Per CLAUDE.md, "a wrong CR
number is worse than no CR number."

Scope verified by an independent semantic census of every CR 310.x citation
in the tree, each paired with the rule text it cites. All 15 distinct
citations resolve to real rules whose text matches their usage, with this one
exception. Of the seven bare `CR 310.9` citations, six are correctly about
protector designation (filter.rs:5018, game_object.rs:2815, ability.rs:4206,
battle.rs:6/169/176) and only sba.rs:1793 is about attachment.

Comment-only change; no behavioural effect.
