### PR TITLE
fix(engine): resolve delayed-payload placement over the clause sequence

### DIFF
--- a/crates/engine/src/parser/oracle_effect/assembly.rs
+++ b/crates/engine/src/parser/oracle_effect/assembly.rs
@@ -18,8 +18,8 @@ use nom::Parser;
 
 use crate::parser::oracle_ir::ast::*;
 use crate::parser::oracle_ir::effect_chain::{
-    AbsorbKind, ClauseDisposition, ClauseId, EffectChainIr, OtherwiseKind, PlayerScopeRewrite,
-    PriorModifier, ReplaceMeaningKind, ReplicateKind,
+    AbsorbKind, ClauseDisposition, ClauseId, ClausePlacement, EffectChainIr, OtherwiseKind,
+    PlayerScopeRewrite, PriorModifier, ReplaceMeaningKind, ReplicateKind,
 };
 use crate::parser::oracle_nom::bridge::nom_on_lower;
 use crate::parser::oracle_nom::error::OracleError;
@@ -550,8 +550,8 @@ impl Arena {
     }
 }
 
-/// Is a def with this witness anywhere in `def`'s tree? Walks the two slots a
-/// handler can nest an absorbed node into.
+/// Is a def with this witness anywhere in `def`'s tree? Walks the slots a
+/// handler can nest an absorbed node into, including a delayed trigger payload.
 ///
 /// `AbilityDefinition` has a THIRD nested-def slot — `mode_abilities` — and it is
 /// excluded deliberately, not by oversight: assembly never writes it (verified; the
@@ -560,11 +560,110 @@ impl Arena {
 /// absorbed-parenthood assert goes RED — the safe direction, and the signal to add
 /// the slot here rather than a silent pass.
 fn def_tree_contains(def: &AbilityDefinition, witness: DefWitness) -> bool {
-    def_witness(def) == witness
-        || [def.sub_ability.as_deref(), def.else_ability.as_deref()]
-            .into_iter()
-            .flatten()
-            .any(|child| def_tree_contains(child, witness))
+    if def_witness(def) == witness {
+        return true;
+    }
+    // CR 603.7: a delayed trigger's payload is a DEFINITION held inside the
+    // effect, not in `sub_ability`/`else_ability`.
+    // `relocate_clause_defs_into_delayed_payload` is the first handler to absorb
+    // a node into that slot, so the walk must descend into it — otherwise the
+    // absorbed-parenthood assert reports "wrong parent" for a node whose parent
+    // is exactly right, on every relocated continuation.
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_contains(effect, witness) {
+            return true;
+        }
+    }
+    [def.sub_ability.as_deref(), def.else_ability.as_deref()]
+        .into_iter()
+        .flatten()
+        .any(|child| def_tree_contains(child, witness))
+}
+
+/// CR 603.7: a clause whose lowered definitions must move into an earlier delayed
+/// trigger payload. Recorded during the clause loop and executed afterwards.
+///
+/// `[base, end)` is over `defs` as the loop leaves it. Pending ranges are
+/// disjoint and strictly increasing because each base is recorded before the
+/// clause extends `defs`, and each end after its intrinsic continuation runs.
+struct PendingRelocation {
+    base: usize,
+    end: usize,
+}
+
+/// CR 603.7: the delayed-trigger wrapper immediately preceding `[base, end)`,
+/// or `None` when the assembled definitions do not support a safe relocation.
+///
+/// The shared receiver makes the refusal path structurally mutation-free: the
+/// caller cannot drain `defs` until this predicate has accepted the range.
+fn relocation_antecedent(defs: &[AbilityDefinition], base: usize, end: usize) -> Option<usize> {
+    if base == 0 || end <= base || end > defs.len() {
+        return None;
+    }
+    let antecedent = base - 1;
+    matches!(
+        &*defs[antecedent].effect,
+        Effect::CreateDelayedTrigger { .. }
+    )
+    .then_some(antecedent)
+}
+
+/// CR 603.7 + CR 608.2c: move `[base, end)` into the delayed payload it
+/// continues. On refusal, mutate nothing and retain the prior sibling layout.
+///
+/// Moved definitions are appended in printed order. `sub_link` is deliberately
+/// not rewritten: its stamped boundary is the CR 608.2c ordering signal, and a
+/// `ContinuationStep` rewrite could make an optional first continuation swallow
+/// the next. `absorb_last_created_riders` stamps `sub_link` for its own distinct
+/// same-chain rider operation; that idiom authorizes only this mover's `kind`
+/// normalization, never a `sub_link` change here.
+fn relocate_clause_defs_into_delayed_payload(
+    defs: &mut Vec<AbilityDefinition>,
+    base: usize,
+    end: usize,
+    continuation_kind: AbilityKind,
+    env: &mut AssemblyEnv,
+) -> bool {
+    let Some(antecedent) = relocation_antecedent(defs, base, end) else {
+        return false;
+    };
+
+    // Capture every identity before removal. `antecedent < base`, but that index
+    // relationship is an implementation fact, not a substitute for the contract.
+    let parent_id = env
+        .node_id_at(antecedent)
+        .expect("a valid antecedent is mirrored by the arena");
+    let count = end - base;
+    let mut moved_ids: Vec<NodeId> = Vec::with_capacity(count);
+    let mut moved: Vec<AbilityDefinition> = Vec::with_capacity(count);
+    for _ in 0..count {
+        // Mid-vector removal: later clause definitions can follow this range, so
+        // `sync_len` would pop the wrong arena node. Repeating at `base` preserves
+        // the printed order in `moved`.
+        moved_ids.push(env.arena.remove_at(base));
+        moved.push(defs.remove(base));
+    }
+
+    let Effect::CreateDelayedTrigger { effect, .. } = defs[antecedent].effect.as_mut() else {
+        unreachable!(
+            "the accepted antecedent remains a delayed trigger because every removal is after it"
+        )
+    };
+    for mut def in moved {
+        // CR 113.3b: a relocated continuation has no activation cost and resolves
+        // as part of the delayed ability. The Phase-2 fold normalizes ordinary
+        // sub-abilities to `continuation_kind`, but this definition leaves `defs`
+        // before that fold, so normalize it here. Do not stamp the payload head.
+        def.kind = continuation_kind;
+        append_to_deepest_sub_ability(effect, Some(Box::new(def)));
+    }
+
+    // Name the parent explicitly: `settle` would infer `order.last()`, which is
+    // not necessarily the delayed-trigger wrapper after later clauses emitted.
+    for id in moved_ids {
+        env.arena.absorb(id, parent_id);
+    }
+    true
 }
 
 /// Emit-time facts about the chain assembled so far.
@@ -1269,6 +1368,10 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
     // makes it a `SequentialSibling` (independent following instruction); a
     // `Comma`/`Then`/no boundary makes it a within-clause `ContinuationStep`.
     let mut prev_boundary: Option<ClauseBoundary> = None;
+    // CR 603.7 + CR 608.2c: record delayed-payload relocations during the clause
+    // loop and execute them only after every later clause has performed its
+    // top-level binding work against today's unchanged `defs` shape.
+    let mut pending_relocations: Vec<PendingRelocation> = Vec::new();
     for clause_ir in &ir.clauses {
         // "The arena mirrors `defs`" is load-bearing for every binding below, and it
         // is asserted HERE, at the one point every clause path must pass through.
@@ -1867,6 +1970,10 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
         // normal clause stamps its `sub_link` from the boundary AFTER this
         // clause, not the stale boundary that preceded it.
         if handled_as_special {
+            debug_assert!(
+                clause_ir.placement == ClausePlacement::Sibling,
+                "only emitted clauses may be nested into delayed payloads"
+            );
             prev_boundary = clause_ir.boundary;
             // Classify anything this handler detached; the mirror is asserted at the
             // next loop-top, or at the Phase-1/Phase-2 boundary for the last clause.
@@ -2594,6 +2701,9 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
             }
         }
 
+        // CR 608.2c: this clause's definitions begin here. A nested delayed
+        // payload relocation records exactly this range for the post-loop pass.
+        let nest_base = defs.len();
         defs.extend(current_defs);
         env.observe(&defs, Some(clause_ir.id), NodeRole::Primary);
 
@@ -2603,6 +2713,16 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
             apply_clause_continuation(&mut defs, continuation.clone(), kind, &env);
             env.observe(&defs, None, NodeRole::ContinuationProduct);
             apply_where_x_to_latest_def(&mut defs, clause_ir.where_x_expression.as_deref());
+        }
+
+        // CR 603.7: a continuation of an open delayed payload resolves when the
+        // payload resolves, not with the enclosing ability. Record its complete
+        // emitted range now, but do not mutate `defs` until the clause loop ends.
+        if clause_ir.placement == ClausePlacement::NestedInDelayedPayload {
+            pending_relocations.push(PendingRelocation {
+                base: nest_base,
+                end: defs.len(),
+            });
         }
 
         // CR 608.2c: Advance the separating boundary for the next normal-path
@@ -2625,6 +2745,101 @@ pub(crate) fn assemble_effect_chain(ir: &EffectChainIr) -> AbilityDefinition {
     // assert would ever run again. Phase 2 does not touch `env`, so this is the last
     // moment the mirror still means anything. Assert it here, and Phase 1 is covered
     // end to end.
+    // CR 603.7 + CR 608.2c: execute recorded relocations in printed order.
+    // `shift` turns a recorded range into its live index after earlier ranges
+    // have been removed. It advances only when the mover actually succeeded.
+    // Do not add `settle` here: `assert_mirrors` immediately below checks its
+    // detached-node invariant and stronger identity and parenthood invariants.
+    //
+    // Maximality corollary: this is the unique safe position. The locator lemma
+    // permits only recorded relocations between recording and execution; later
+    // Phase-2 folds remove definitions without records. Do not move this pass
+    // below `env.arena.assert_mirrors(&defs)`.
+    //
+    // Watchlist (structural census, md5 b6310463ac18b5bd12d5560501032136): 201
+    // post-CreateDelayedTrigger sibling nodes across 173 spines — every
+    // AbilityDefinition-shaped node reachable in card-data, deduped to spine
+    // heads, taking every node strictly after the first delayed trigger. Do not
+    // re-cut this as JSON containers. Re-run if a candidate carries Dig; if the
+    // Elemental-Appeal (a)∧(b) consumer probe exceeds one or T-ROW5 reds (the
+    // silent-wrong-binding, highest-severity exposure); if CopySpell with
+    // ParentTarget/TrackedSet(0) is nonterminal; if a bare FlipCoin/RollDie and
+    // its branch share a payload; if ChooseDamageSource/ChosenDamageSource occurs
+    // at any depth; or if an antecedent gains else_ability or an instead condition.
+    // Record the data md5 for every re-run.
+    //
+    // Additional presence-direction watchlist: a DT-holder with a strictly earlier
+    // token producer and affirmative reflexive gate (F1); the unmeasured
+    // rewire_result_anchored_subchain upper-bound-40 exposure (F2); an F3
+    // "whenever ... this turn" cleanup that would nest below a relocated
+    // continuation; or any new pass in the pre-fold range / existing payload
+    // recursion (S3).
+    //
+    // Closed at parse time — V3/V4's shield or cast-time veto remains a top-level
+    // definition and breaks the fold's contiguous relocation run, so the following
+    // continuation stays a sibling and never reaches the structural locator. The
+    // driver's assertion remains the guard for a genuine future parse/assembly
+    // divergence. Reopen only if a card establishes that a continuation must cross
+    // such a veto; carry an explicit antecedent handle rather than weakening this guard.
+    // Closed by plan-r17 §R17.4.1 — the leading-if body split's absorbed clauses are now
+    // classified against the OUTER registry, because placement is resolved by a fold over the
+    // finished clause sequence rather than at a push site. Residual: the fold cannot see a
+    // non-`Emit` disposition's relationship to its absorb TARGET — an `Absorb` rider that
+    // merges INTO the installer clause still CLEARS the registry rather than passing through,
+    // so a continuation after such a rider stays a sibling. That is today's behaviour, chosen
+    // because the alternative (pass-through) can only ADD mis-attachments. Reopen with a card
+    // whose installer carries an absorbed rider AND a following continuation; the fix is to
+    // resolve the absorb target before the fold, not to widen the disposition gate.
+    // Deferred — coin/die consolidation is top-level only. Goblin Kites, Fickle
+    // Efreet, and Frenetic Sliver keep their flip and branch on opposite sides of
+    // the payload boundary. Reopen when they share a payload, a fourth row appears,
+    // or a double-flip report arrives; a payload-descending pass needs review.
+    // Deferred — payload-`sub_ability`-invisible anaphor rewrite: the effect-space
+    // recursion below delayed-trigger payloads cannot rewrite a continuation's
+    // LastCreated binding. Reopen on T-ROW5, a wider Elemental Appeal consumer
+    // probe, or a bare-pronoun misbinding; any definition-space repair is pool-wide.
+    // Deferred — resolve_populated_token_anaphors cannot reach payload.sub_ability:
+    // its effect-space recursion receives inner.effect, never inner. Reopen when
+    // T-ROW5 reds, the consumer probe exceeds Elemental Appeal, or a bare pronoun
+    // misbinds; a definition-space recursion would be a pool-wide widening.
+    // Deferred — relocated Jodah cleanup normalization: relocation can put the
+    // `ExileFromTopUntil` → optional `CastFromZone { ParentTarget }` → bottom
+    // `PutAtLibraryPosition { TrackedSet }` triple inside a delayed payload, but
+    // `normalize_linked_exile_cast_pair` examines adjacent top-level definitions
+    // only. Its lower-layer gate documents that the parser-default `TrackedSet`
+    // has no publisher for this exile pile, leaving the pile stranded. This
+    // worktree's delayed-trigger integration test asserts Codie's three node
+    // variants but has neither a Jodah fixture nor a cleanup-target assertion.
+    // Reopen when a payload-descending normalization is designed; add a Jodah test
+    // that asserts the cleanup target, not only its `PutAtLibraryPosition` variant.
+    // Post-relocation, nine `&mut defs` passes and three pairwise-fold helpers run.
+    // Beyond the named coin/die and token-anaphor passes, the block also contains
+    // `resolve_those_tokens_anaphors`, `resolve_populated_unsuspect_anaphors`,
+    // `fold_cast_copy_of_card_defs`, `merge_search_tail_into_additional_cost_else`,
+    // `normalize_linked_exile_cast_pair`, and `rebind_condition_instead_damage_anaphor`.
+    let mut shift = 0usize;
+    for pending in &pending_relocations {
+        let base = pending.base - shift;
+        let end = pending.end - shift;
+        if relocate_clause_defs_into_delayed_payload(
+            &mut defs,
+            base,
+            end,
+            continuation_kind,
+            &mut env,
+        ) {
+            shift += end - base;
+        } else {
+            debug_assert!(
+                false,
+                "delayed-payload relocation refused: the definition preceding a \
+                 `NestedInDelayedPayload` clause is not an `Effect::CreateDelayedTrigger`, \
+                 or the clause emitted no definition — the parse-time registry and the \
+                 assembled `defs` have diverged. The definitions were left as top-level \
+                 siblings, which is the pre-change behaviour."
+            );
+        }
+    }
     env.arena.assert_mirrors(&defs);
 
     // ── Phase 2: Post-loop assembly (unchanged) ────────────────────────
@@ -3042,6 +3257,14 @@ fn instead_replaces_optional_payment_continuation(root: &AbilityDefinition) -> b
 #[cfg(test)]
 mod arena_tests {
     use super::*;
+    use crate::parser::oracle_effect::parse_effect_chain_ir;
+    use crate::parser::oracle_ir::ast::parsed_clause;
+    use crate::parser::oracle_ir::effect_chain::{ClauseIr, ClauseIrBuilder};
+    use crate::parser::oracle_nom::context::ParseContext;
+    use crate::types::ability::{DelayedTriggerCondition, ReplacementDefinition};
+    use crate::types::phase::Phase;
+    use crate::types::replacements::ReplacementEvent;
+    use crate::types::zones::EtbTapState;
 
     fn shuffle_def() -> AbilityDefinition {
         AbilityDefinition::new(
@@ -3169,6 +3392,369 @@ mod arena_tests {
         assert!(matches!(
             arena.node(absorbed).status,
             NodeStatus::Absorbed { into } if into == parent
+        ));
+    }
+
+    fn delayed_trigger(payload: AbilityDefinition) -> AbilityDefinition {
+        AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::CreateDelayedTrigger {
+                condition: DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
+                effect: Box::new(payload),
+                uses_tracked_set: false,
+            },
+        )
+    }
+
+    fn delayed_trigger_effect(payload: AbilityDefinition) -> Effect {
+        delayed_trigger(payload).effect.as_ref().clone()
+    }
+
+    fn replacement_shield_effect() -> Effect {
+        Effect::AddTargetReplacement {
+            replacement: Box::new(ReplacementDefinition::new(ReplacementEvent::DamageDone)),
+            target: TargetFilter::Any,
+        }
+    }
+
+    fn shuffle_effect() -> Effect {
+        Effect::Shuffle {
+            target: TargetFilter::Controller,
+        }
+    }
+
+    fn zone_change(destination: Zone, target: TargetFilter) -> Effect {
+        Effect::ChangeZone {
+            origin: None,
+            destination,
+            target,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: EtbTapState::Unspecified,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            conditional_enter_with_counters: vec![],
+            face_down_profile: None,
+            enters_modified_if: None,
+        }
+    }
+
+    fn emitted_clause(
+        builder: &mut ClauseIrBuilder,
+        source: &str,
+        effect: Effect,
+        boundary: Option<ClauseBoundary>,
+    ) {
+        builder
+            .clause(
+                source,
+                parsed_clause(effect),
+                boundary,
+                ClauseDisposition::Emit {
+                    followup: None,
+                    intrinsic: None,
+                },
+            )
+            .push();
+    }
+
+    fn chain_ir(clauses: Vec<ClauseIr>, kind: AbilityKind) -> EffectChainIr {
+        EffectChainIr {
+            clauses,
+            kind,
+            continuation_kind: None,
+            player_scope_rewrite: PlayerScopeRewrite::Apply,
+            chain_rounding: None,
+            actor: None,
+            in_trigger: false,
+            repeat_until: None,
+        }
+    }
+
+    fn chain_len(def: &AbilityDefinition) -> usize {
+        1 + def.sub_ability.as_deref().map_or(0, chain_len)
+    }
+
+    fn first_delayed_after(def: &AbilityDefinition) -> &AbilityDefinition {
+        let mut current = def.sub_ability.as_deref();
+        while let Some(candidate) = current {
+            if matches!(*candidate.effect, Effect::CreateDelayedTrigger { .. }) {
+                return candidate;
+            }
+            current = candidate.sub_ability.as_deref();
+        }
+        panic!("expected a second delayed trigger in the assembled top-level chain")
+    }
+
+    fn delayed_payload_origin(def: &AbilityDefinition) -> Option<Zone> {
+        let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect else {
+            panic!("expected delayed trigger, got {:?}", def.effect);
+        };
+        let Effect::ChangeZone { origin, .. } = &*effect.effect else {
+            panic!(
+                "expected delayed payload ChangeZone, got {:?}",
+                effect.effect
+            );
+        };
+        *origin
+    }
+
+    #[test]
+    fn delayed_payload_tree_walk_finds_only_members() {
+        let inner = AbilityDefinition::new(AbilityKind::Spell, shuffle_effect());
+        let payload = AbilityDefinition::new(AbilityKind::Spell, replacement_shield_effect())
+            .sub_ability(inner);
+        let outer = delayed_trigger(payload);
+        let absent = AbilityDefinition::new(AbilityKind::Spell, shuffle_effect());
+        let Effect::CreateDelayedTrigger { effect, .. } = &*outer.effect else {
+            unreachable!("delayed_trigger always constructs a delayed trigger");
+        };
+        let contained = effect
+            .sub_ability
+            .as_deref()
+            .expect("the payload construction must retain its nested definition");
+
+        assert!(
+            def_tree_contains(&outer, def_witness(contained)),
+            "T-DTC: the CreateDelayedTrigger payload is a definition-tree slot"
+        );
+        assert!(
+            !def_tree_contains(&outer, def_witness(&absent)),
+            "T-DTC negative: the widened walk must still discriminate non-members"
+        );
+    }
+
+    #[test]
+    fn relocation_antecedent_refuses_hostile_shapes_and_accepts_the_valid_one() {
+        let delayed = delayed_trigger(AbilityDefinition::new(AbilityKind::Spell, shuffle_effect()));
+        let ordinary = AbilityDefinition::new(AbilityKind::Spell, shuffle_effect());
+        let shield = AbilityDefinition::new(AbilityKind::Spell, replacement_shield_effect());
+
+        assert_eq!(
+            relocation_antecedent(std::slice::from_ref(&ordinary), 0, 1),
+            None
+        );
+        assert_eq!(
+            relocation_antecedent(std::slice::from_ref(&ordinary), 1, 1),
+            None
+        );
+        assert_eq!(
+            relocation_antecedent(std::slice::from_ref(&ordinary), 1, 2),
+            None
+        );
+        assert_eq!(
+            relocation_antecedent(&[shield, ordinary.clone()], 1, 2),
+            None
+        );
+        assert_eq!(relocation_antecedent(&[delayed, ordinary], 1, 2), Some(0));
+    }
+
+    #[test]
+    fn relocation_mover_refusal_is_lossless_and_valid_move_shrinks_the_range() {
+        let shield = AbilityDefinition::new(AbilityKind::Spell, replacement_shield_effect());
+        let ordinary = AbilityDefinition::new(AbilityKind::Spell, shuffle_effect());
+        let mut refused_defs = vec![shield, ordinary];
+        let before = refused_defs
+            .iter()
+            .map(|def| std::mem::discriminant(def.effect.as_ref()))
+            .collect::<Vec<_>>();
+        let mut refused_env = AssemblyEnv::default();
+        refused_env
+            .arena
+            .sync_len(&refused_defs, None, NodeRole::Primary);
+
+        assert!(!relocate_clause_defs_into_delayed_payload(
+            &mut refused_defs,
+            1,
+            2,
+            AbilityKind::Spell,
+            &mut refused_env,
+        ));
+        assert_eq!(refused_defs.len(), 2);
+        assert_eq!(
+            refused_defs
+                .iter()
+                .map(|def| std::mem::discriminant(def.effect.as_ref()))
+                .collect::<Vec<_>>(),
+            before,
+            "T-AR2b: refusal leaves the effect sequence untouched"
+        );
+
+        let delayed = delayed_trigger(AbilityDefinition::new(AbilityKind::Spell, shuffle_effect()));
+        let continuation = AbilityDefinition::new(AbilityKind::Activated, shuffle_effect());
+        let mut accepted_defs = vec![delayed, continuation];
+        let mut accepted_env = AssemblyEnv::default();
+        accepted_env
+            .arena
+            .sync_len(&accepted_defs, None, NodeRole::Primary);
+
+        assert!(relocate_clause_defs_into_delayed_payload(
+            &mut accepted_defs,
+            1,
+            2,
+            AbilityKind::Spell,
+            &mut accepted_env,
+        ));
+        assert_eq!(accepted_defs.len(), 1);
+    }
+
+    #[test]
+    #[should_panic(expected = "delayed-payload relocation refused")]
+    fn relocation_driver_reports_registry_assembly_divergence() {
+        let mut builder = ClauseIrBuilder::new("shield. shuffle");
+        emitted_clause(
+            &mut builder,
+            "shield",
+            replacement_shield_effect(),
+            Some(ClauseBoundary::Sentence),
+        );
+        emitted_clause(&mut builder, "shuffle", shuffle_effect(), None);
+        let mut clauses = builder.finish();
+        clauses[1].placement = ClausePlacement::NestedInDelayedPayload;
+
+        let _ = assemble_effect_chain(&chain_ir(clauses, AbilityKind::Spell));
+    }
+
+    #[test]
+    fn relocation_preserves_the_boundary_stamped_sub_link() {
+        for (boundary, expected) in [
+            (ClauseBoundary::Comma, SubAbilityLink::ContinuationStep),
+            (ClauseBoundary::Sentence, SubAbilityLink::SequentialSibling),
+        ] {
+            let mut builder = ClauseIrBuilder::new("delay. shuffle");
+            emitted_clause(
+                &mut builder,
+                "delay",
+                delayed_trigger_effect(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    shuffle_effect(),
+                )),
+                Some(boundary),
+            );
+            emitted_clause(&mut builder, "shuffle", shuffle_effect(), None);
+            let mut clauses = builder.finish();
+            clauses[1].placement = ClausePlacement::NestedInDelayedPayload;
+
+            let assembled = assemble_effect_chain(&chain_ir(clauses, AbilityKind::Spell));
+            let Effect::CreateDelayedTrigger { effect, .. } = &*assembled.effect else {
+                panic!(
+                    "expected delayed-trigger wrapper, got {:?}",
+                    assembled.effect
+                );
+            };
+            let continuation = effect
+                .sub_ability
+                .as_deref()
+                .expect("promoted clause must be appended to the payload chain");
+            assert_eq!(continuation.sub_link, expected);
+        }
+    }
+
+    fn origin_after_post_loop_relocation(
+        second_effect: Effect,
+        second_placement: ClausePlacement,
+    ) -> Option<Zone> {
+        let mut builder = ClauseIrBuilder::new("delay. second. return");
+        emitted_clause(
+            &mut builder,
+            "delay",
+            delayed_trigger_effect(AbilityDefinition::new(AbilityKind::Spell, shuffle_effect())),
+            Some(ClauseBoundary::Sentence),
+        );
+        emitted_clause(
+            &mut builder,
+            "second",
+            second_effect,
+            Some(ClauseBoundary::Sentence),
+        );
+        builder
+            .clause(
+                "return",
+                parsed_clause(zone_change(Zone::Battlefield, TargetFilter::ParentTarget)),
+                None,
+                ClauseDisposition::Emit {
+                    followup: None,
+                    intrinsic: None,
+                },
+            )
+            .delayed_condition(Some(DelayedTriggerCondition::AtNextPhase {
+                phase: Phase::End,
+            }))
+            .push();
+        let mut clauses = builder.finish();
+        clauses[1].placement = second_placement;
+
+        let assembled = assemble_effect_chain(&chain_ir(clauses, AbilityKind::Spell));
+        delayed_payload_origin(first_delayed_after(&assembled))
+    }
+
+    #[test]
+    fn later_clause_binding_sees_the_unrelocated_definition() {
+        let battlefield_move = zone_change(Zone::Battlefield, TargetFilter::ParentTarget);
+        assert_eq!(
+            origin_after_post_loop_relocation(
+                battlefield_move.clone(),
+                ClausePlacement::NestedInDelayedPayload,
+            ),
+            Some(Zone::Battlefield),
+            "T-PLoc: post-loop relocation leaves the preceding zone move visible"
+        );
+        assert_eq!(
+            origin_after_post_loop_relocation(battlefield_move, ClausePlacement::Sibling),
+            Some(Zone::Battlefield),
+            "T-PLoc control: the stamp depends on the prior zone move, not placement"
+        );
+        assert_eq!(
+            origin_after_post_loop_relocation(
+                shuffle_effect(),
+                ClausePlacement::NestedInDelayedPayload
+            ),
+            None,
+            "T-PLoc control: a non-zone predecessor must not receive a hard-coded origin"
+        );
+    }
+
+    #[test]
+    fn codie_ranges_relocate_in_printed_order_and_shrink_by_two() {
+        let text = "Add {W}{U}{B}{R}{G}. When you next cast a spell this turn, exile cards from the \
+                    top of your library until you exile an instant or sorcery card with lesser mana \
+                    value. Until end of turn, you may cast that card without paying its mana cost. Put \
+                    each other card exiled this way on the bottom of your library in a random order.";
+        let mut context = ParseContext::default();
+        let ir = parse_effect_chain_ir(text, AbilityKind::Activated, &mut context);
+        let sibling_count = chain_len(&assemble_effect_chain(&{
+            let mut sibling = ir.clone();
+            for clause in &mut sibling.clauses {
+                clause.placement = ClausePlacement::Sibling;
+            }
+            sibling
+        }));
+        let assembled = assemble_effect_chain(&ir);
+        let Effect::CreateDelayedTrigger { effect, .. } = &*assembled
+            .sub_ability
+            .as_deref()
+            .expect("Codie's mana definition must lead to its delayed trigger")
+            .effect
+        else {
+            panic!("Codie must install a delayed trigger");
+        };
+
+        assert_eq!(chain_len(&assembled), sibling_count - 2);
+        assert_eq!(chain_len(effect), 3);
+        assert!(matches!(*effect.effect, Effect::ExileFromTopUntil { .. }));
+        assert!(matches!(
+            effect.sub_ability.as_deref().map(|def| &*def.effect),
+            Some(Effect::CastFromZone { .. })
+        ));
+        assert!(matches!(
+            effect
+                .sub_ability
+                .as_deref()
+                .and_then(|def| def.sub_ability.as_deref())
+                .map(|def| &*def.effect),
+            Some(Effect::PutAtLibraryPosition { .. })
         ));
     }
 }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -79,6 +79,7 @@ use nom::sequence::{pair, preceded, terminated};
 use nom::Parser;
 
 use super::oracle_nom::bridge::nom_on_lower;
+use super::oracle_nom::condition::parse_reflexive_conditional_connector;
 use super::oracle_nom::error::OracleResult;
 use super::oracle_nom::primitives as nom_primitives;
 use super::oracle_nom::quantity as nom_quantity;
@@ -164,10 +165,276 @@ pub(crate) use crate::parser::oracle_ir::context::{
 };
 use crate::parser::oracle_ir::effect_chain::{
     AbilityIr, AbilityRootTransform, AbilityShellIr, AbsorbKind, ClauseDisposition, ClauseIr,
-    ClauseIrBuilder, DieResultBranchIr, EffectChainIr, OtherwiseKind, PlayerScopeRewrite,
-    PriorModifier, ReplaceMeaningKind, ReplicateKind, ResidualConditionPolicy, ShellStage,
+    ClauseIrBuilder, ClausePlacement, DieResultBranchIr, EffectChainIr, OtherwiseKind,
+    PlayerScopeRewrite, PriorModifier, ReplaceMeaningKind, ReplicateKind, ResidualConditionPolicy,
+    ShellStage,
 };
 use crate::types::mana::ManaExpiry;
+
+/// CR 608.2c + CR 400.7: what, if anything, a delayed trigger's payload
+/// introduces — the referent a following continuation's anaphor can bind to.
+///
+/// Scans the payload's own `sub_ability` chain head-to-tail and returns the first
+/// minting variant found; `None` if the scan finds none. The effect's `target` —
+/// and every other field — is never consulted. The scan does not descend into
+/// `else_ability`, `mode_abilities`, or a nested delayed-trigger payload.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum PayloadMint {
+    /// CR 111.1: a token brought into existence by the payload.
+    Token,
+    /// CR 707.1: a copy brought into existence by the payload.
+    Copy,
+    /// CR 608.2d: a value chosen during the payload's resolution.
+    ChosenValue(ChoiceType),
+    /// CR 400.7: objects the payload itself selects out of a zone.
+    SelectedFromZone,
+    /// CR 705.1: a randomized outcome produced by the payload.
+    RandomOutcome,
+    /// CR 601.2: a spell put onto the stack by the payload's own cast.
+    CastSpell,
+}
+
+/// A still-open delayed payload and the typed antecedents its continuation may
+/// consume. This parser-local registry is scoped to one effect chain.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct DelayedPayloadAntecedent {
+    /// What the payload introduced; `None` means it introduced nothing relevant.
+    mint: Option<PayloadMint>,
+    /// CR 603.7a: the payload's own reflexive-result gate, if it has one.
+    /// `Option<AbilityCondition>` — never a bool.
+    result: Option<AbilityCondition>,
+}
+
+/// Which arm of the delayed-payload continuation decision fired.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) enum ContinuationVerdict {
+    /// Nest into the most recent open payload.
+    Nest,
+    /// Stay a sibling; `veto` says which veto, if any, applied.
+    Emit { veto: Option<ContinuationVeto> },
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ContinuationVeto {
+    PeerDelayedTrigger,
+    ReplacementShield,
+    CastTimeCostCondition,
+}
+
+/// Scan only the payload's own definition spine for the first typed mint.
+fn payload_mint(payload: &AbilityDefinition) -> Option<PayloadMint> {
+    let mut current = Some(payload);
+    while let Some(definition) = current {
+        let mint = match definition.effect.as_ref() {
+            Effect::Token { .. } | Effect::CopyTokenOf { .. } => Some(PayloadMint::Token),
+            Effect::CopySpell { .. } => Some(PayloadMint::Copy),
+            Effect::Choose { choice_type, .. } => {
+                Some(PayloadMint::ChosenValue(choice_type.clone()))
+            }
+            Effect::ExileFromTopUntil { .. } | Effect::ExileTop { .. } => {
+                Some(PayloadMint::SelectedFromZone)
+            }
+            Effect::FlipCoin { .. } => Some(PayloadMint::RandomOutcome),
+            Effect::CastFromZone { .. } => Some(PayloadMint::CastSpell),
+            _ => None,
+        };
+        if mint.is_some() {
+            return mint;
+        }
+        current = definition.sub_ability.as_deref();
+    }
+    None
+}
+
+/// CR 603.7a: obtain the payload for either delayed-trigger producer shape.
+fn clause_delayed_payload(clause: &ClauseIr, kind: AbilityKind) -> Option<AbilityDefinition> {
+    match clause.parsed.effect {
+        Effect::CreateDelayedTrigger { ref effect, .. } => Some((**effect).clone()),
+        _ if clause.delayed_condition.is_some() => {
+            let mut payload = AbilityDefinition::new(kind, clause.parsed.effect.clone());
+            payload.sub_ability = clause.parsed.sub_ability.clone();
+            Some(payload)
+        }
+        _ => None,
+    }
+}
+
+/// V2 is deliberately pinned to the two actual delayed-trigger producer fields.
+fn clause_installs_delayed_trigger(clause: &ClauseIr) -> bool {
+    matches!(clause.parsed.effect, Effect::CreateDelayedTrigger { .. })
+        || clause.delayed_condition.is_some()
+}
+
+/// CR 614.1 + CR 615.1: whether a clause installs a replacement or prevention
+/// shield that must remain a top-level sibling.
+fn effect_installs_replacement_shield(effect: &Effect) -> bool {
+    matches!(
+        effect,
+        Effect::AddTargetReplacement { .. }
+            | Effect::AddPendingETBCounters { .. }
+            | Effect::PreventDamage { .. }
+            | Effect::CreateDamageReplacement { .. }
+            | Effect::CreateDrawReplacement { .. }
+            | Effect::CreatePlaneswalkReplacement { .. }
+            | Effect::Regenerate { .. }
+    )
+}
+
+/// CR 601.2b: cast-time conditions are decided before a delayed trigger exists.
+fn clause_has_cast_time_cost_condition(clause: &ClauseIr) -> bool {
+    clause.condition.as_ref().is_some_and(|condition| {
+        matches!(
+            condition,
+            AbilityCondition::AdditionalCostPaid { .. }
+                | AbilityCondition::AdditionalCostPaidInstead
+                | AbilityCondition::AlternativeManaCostPaid
+                | AbilityCondition::CastVariantPaid { .. }
+                | AbilityCondition::CastVariantPaidInstead { .. }
+        )
+    })
+}
+
+/// Reuse the shared connector authority to distinguish a reflexive result gate
+/// from any other `AbilityCondition` carried by a clause.
+fn clause_reflexive_result(clause: &ClauseIr) -> Option<AbilityCondition> {
+    let source = clause.source.fragment()?;
+    let lower = source.to_lowercase();
+    nom_on_lower(source, &lower, parse_reflexive_conditional_connector)
+        .map(|(condition, _)| condition)
+}
+
+/// CR 608.2c: decide where one candidate continuation clause attaches, given
+/// the delayed payloads still open in this chain.
+fn classify_continuation_clause(
+    clause: &ClauseIr,
+    open: &[DelayedPayloadAntecedent],
+) -> ContinuationVerdict {
+    if clause_installs_delayed_trigger(clause) {
+        return ContinuationVerdict::Emit {
+            veto: Some(ContinuationVeto::PeerDelayedTrigger),
+        };
+    }
+    if effect_installs_replacement_shield(&clause.parsed.effect) {
+        return ContinuationVerdict::Emit {
+            veto: Some(ContinuationVeto::ReplacementShield),
+        };
+    }
+    if clause_has_cast_time_cost_condition(clause) {
+        return ContinuationVerdict::Emit {
+            veto: Some(ContinuationVeto::CastTimeCostCondition),
+        };
+    }
+
+    let Some(antecedent) = open.iter().next_back() else {
+        return ContinuationVerdict::Emit { veto: None };
+    };
+    let result = clause_reflexive_result(clause);
+    if result.as_ref().is_some_and(|result| {
+        antecedent
+            .result
+            .as_ref()
+            .is_none_or(|payload_result| payload_result == result)
+    }) || antecedent.mint.is_some()
+    {
+        return ContinuationVerdict::Nest;
+    }
+    ContinuationVerdict::Emit { veto: None }
+}
+
+/// CR 608.2c: the controller "follows its instructions in the order written", so which delayed
+/// payload a clause continues into is a property of the clause's POSITION IN THE FINISHED SEQUENCE —
+/// not of which producer in the chunk loop happened to emit it. Every producer appends through
+/// `ClauseIrBuilder::push`, so one fold over the built sequence sees each clause exactly once.
+///
+/// The registry transitions, stated exactly. `classify_continuation_clause` owns the verdict; this
+/// fold owns only the transition:
+/// - a non-`Emit` clause CLEARS, unconditionally, before the classifier is consulted;
+/// - a delayed-trigger installer OPENS an antecedent;
+/// - a replacement-shield or cast-time-cost veto PRESERVES without opening;
+/// - `Nest` promotes only when it immediately follows the installer or a prior promotion;
+///   otherwise it CLEARS because the emitted top-level clause between them breaks the assembly run;
+/// - `Emit { veto: None }` — the only classifier-side clear — CLEARS.
+///
+/// What that deliberately does NOT say: the registry is *not* "cleared by every other clause". While
+/// the most recent open antecedent carries a `PayloadMint`, `classify_continuation_clause`
+/// short-circuits on `antecedent.mint.is_some()` and returns `Nest` for EVERY non-vetoed `Emit`
+/// clause. An earlier mint-carrying antecedent does not prevent a classifier-side clear once a newer
+/// mint-less installer is open: the classifier consults only the most recent antecedent. An unrelated
+/// or unimplemented emitted clause does NOT clear while that most recent antecedent carries a mint —
+/// it nests, and is itself relocated into the payload. That short-circuit is
+/// `classify_continuation_clause`'s own pre-existing rule and is unchanged here; this fold only widens
+/// the population of clauses that reach it (plan-r18 §R18.3).
+///
+/// This replaces a transition that lived after the canonical terminal `.push()`. The rationale for
+/// deciding AFTER the push is unchanged and still applies: the decision reads a built `ClauseIr`, and
+/// promoting it in place is the documented mid-chain patch channel (`ClauseIrBuilder::clauses_mut`).
+/// Only the channel's ARITY changed — from `last_mut()` at one push site to the whole slice — because
+/// 35 other producers `continue` (or, at one site, `break`) past the entire loop tail and can never be
+/// reached by any statement placed inside the loop body.
+///
+/// Runs before `ClauseIrBuilder::finish` so that no post-loop pass has yet removed or rewritten a
+/// clause (`try_fold_loses_other_sibling` removes one; the leading-host-lifetime pass rewrites
+/// `parsed`): the sequence this fold reads is exactly the sequence the chunk loop built.
+fn resolve_delayed_payload_placements(clauses: &mut [ClauseIr], kind: AbilityKind) {
+    let mut open: Vec<DelayedPayloadAntecedent> = Vec::new();
+    let mut last_contiguous_clause = None;
+    for (clause_index, clause) in clauses.iter_mut().enumerate() {
+        // CR 603.7a: a continuation is relocated as a DEFINITION into the payload, so only a clause
+        // that assembly emits as an independent sibling definition can be promoted. Every other
+        // disposition is absorbed into, replaces, or patches a neighbour and emits no definition of
+        // its own — promoting one would record a relocation range that
+        // `relocate_clause_defs_into_delayed_payload` must refuse, and would trip the
+        // `handled_as_special` tripwire in `assembly.rs`. Such a clause is also "every other clause"
+        // for the registry, so it closes the open run.
+        if !matches!(clause.disposition, ClauseDisposition::Emit { .. }) {
+            open.clear();
+            last_contiguous_clause = None;
+            continue;
+        }
+        let verdict = classify_continuation_clause(clause, &open);
+        // V2 → V3 → V4 → P-a/P-b: the classifier owns the decision; this table owns only the
+        // registry transition. V2 opens an antecedent; the two vetoes preserve it but leave an
+        // emitted top-level definition, so a later `Nest` must pass the contiguous-run check.
+        // `Emit { veto: None }` clears. Note that arm is unreachable while a mint-carrying
+        // antecedent is open (see the fn doc) — in that regime the non-`Emit` gate above or a
+        // failed contiguous-run check clears.
+        match verdict {
+            ContinuationVerdict::Emit {
+                veto: Some(ContinuationVeto::PeerDelayedTrigger),
+            } => {
+                let payload = clause_delayed_payload(clause, kind)
+                    .expect("V2 only classifies delayed-trigger installer clauses");
+                open.push(DelayedPayloadAntecedent {
+                    mint: payload_mint(&payload),
+                    result: clause_reflexive_result(clause),
+                });
+                last_contiguous_clause = Some(clause_index);
+            }
+            ContinuationVerdict::Emit {
+                veto:
+                    Some(
+                        ContinuationVeto::ReplacementShield
+                        | ContinuationVeto::CastTimeCostCondition,
+                    ),
+            } => {}
+            ContinuationVerdict::Nest => {
+                if last_contiguous_clause.is_some_and(|last| last + 1 == clause_index) {
+                    clause.placement = ClausePlacement::NestedInDelayedPayload;
+                    last_contiguous_clause = Some(clause_index);
+                } else {
+                    // A veto stays top-level, so it breaks the contiguous run the assembly
+                    // locator requires. Clearing here prevents a later clause from skipping it.
+                    open.clear();
+                    last_contiguous_clause = None;
+                }
+            }
+            ContinuationVerdict::Emit { veto: None } => {
+                open.clear();
+                last_contiguous_clause = None;
+            }
+        }
+    }
+}
 
 /// CR 608.2k: True when `text` is a standalone object pronoun referring to
 /// the trigger/spell subject. Used by effect-target parsers that need to
@@ -29703,7 +29970,6 @@ pub(crate) fn parse_effect_chain_ir(
     // recipient through it) rather than boundary-cleared, preventing leak into
     // an unrelated later sentence.
     let mut chain_parent_target_controller_scope: Option<ControllerRef> = None;
-
     for (chunk_idx, chunk) in chunks.iter().enumerate() {
         let normalized_text = strip_leading_sequence_connector(&chunk.text).trim();
         if normalized_text.is_empty() {
@@ -33088,6 +33354,12 @@ pub(crate) fn parse_effect_chain_ir(
 
     // Merge per-chunk diagnostics and any pre-loop diagnostics into the outer ctx.
     ctx.diagnostics.extend(chunk_diagnostics);
+
+    // CR 608.2c + CR 603.7: resolve delayed-payload placement over the finished clause sequence.
+    // Must stay ABOVE `builder.finish()`: `try_fold_loses_other_sibling` removes a clause and the
+    // leading-host-lifetime pass rewrites every `parsed`, so a later position would fold a different
+    // sequence than the chunk loop built.
+    resolve_delayed_payload_placements(builder.clauses_mut(), kind);
 
     // CR 113.10 + chunk-splitter normalization: Bronzehide Lion's "and it loses
     // all other abilities" was pre-split by

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -52871,3 +52871,312 @@ fn assimilate_without_a_graveyard_target_stays_unimplemented() {
         "reach-guard: the printed phrasing must lower to a ChangeZone, got {real:?}"
     );
 }
+
+const CODIE_CONTINUATION_TEXT: &str = "Add {W}{U}{B}{R}{G}. When you next cast a spell this turn, \
+exile cards from the top of your library until you exile an instant or sorcery card with lesser mana \
+value. Until end of turn, you may cast that card without paying its mana cost. Put each other card \
+exiled this way on the bottom of your library in a random order.";
+
+/// T-B1 (plan-r18 §R18.1): a NON-`Emit` clause between a delayed installer and its
+/// continuations must close the open-payload run. In the adopted code the intervening
+/// clause is emitted by an early-exit producer that `continue`s past the registry block,
+/// so the mint-carrying antecedent stays open and `classify_continuation_clause`'s
+/// `|| antecedent.mint.is_some()` short-circuit nests both continuations anyway.
+///
+/// Text is two real printed sentences composed: Codie, Vociferous Codex's activated
+/// ability (the adopted `CODIE_CONTINUATION_TEXT`) with Kathril, Aspect Warper's
+/// "Repeat this process for ..." sentence spliced in after the installer. That sentence
+/// routes to the text-local producer at `mod.rs:30356`, which pushes
+/// `ClauseDisposition::ReplicatePerKeyword` and `continue`s (`:30367`/`:30368`).
+///
+/// PARSE-TIME ONLY. The composition is not a playable card — `ReplicatePerKeyword` is
+/// relational at lowering and Codie's installer is not a keyword-counter antecedent.
+/// Do NOT extend this test to `assemble_effect_chain`.
+#[test]
+fn a_non_emitted_clause_between_installer_and_continuation_closes_the_payload_run() {
+    const KATHRIL_REPEAT_SENTENCE: &str = "Repeat this process for first strike, double strike, \
+deathtouch, hexproof, indestructible, lifelink, menace, reach, trample, and vigilance. ";
+
+    // Splice the non-`Emit` sentence in after the installer sentence, i.e. immediately
+    // before the first continuation. Located by content, not by a byte offset.
+    const FIRST_CONTINUATION: &str = "Until end of turn, you may cast that card";
+    let split_at = CODIE_CONTINUATION_TEXT
+        .find(FIRST_CONTINUATION)
+        .expect("T-B1 fixture: the adopted Codie constant must contain its first continuation");
+    let intervened_text = format!(
+        "{}{KATHRIL_REPEAT_SENTENCE}{}",
+        &CODIE_CONTINUATION_TEXT[..split_at],
+        &CODIE_CONTINUATION_TEXT[split_at..]
+    );
+
+    let mut intervened_context = ParseContext::default();
+    let intervened = parse_effect_chain_ir(
+        &intervened_text,
+        AbilityKind::Activated,
+        &mut intervened_context,
+    );
+
+    // Shape preconditions. A failure here means the fixture no longer routes as traced
+    // (plan-r18 §R18.1.3/§R18.1.4) — re-derive the fixture. Do NOT relax the assertion
+    // below to accommodate it.
+    assert_eq!(
+        intervened
+            .clauses
+            .iter()
+            .filter(|clause| matches!(clause.parsed.effect, Effect::CreateDelayedTrigger { .. }))
+            .count(),
+        1,
+        "T-B1 precondition: the splice must leave exactly one delayed installer: {intervened:#?}"
+    );
+    assert_eq!(
+        intervened
+            .clauses
+            .iter()
+            .filter(|clause| !matches!(clause.disposition, ClauseDisposition::Emit { .. }))
+            .count(),
+        1,
+        "T-B1 precondition: the spliced sentence must be the chain's only non-emitted \
+         clause (producer mod.rs:30356 → ReplicatePerKeyword): {intervened:#?}"
+    );
+
+    let intervened_promoted = intervened
+        .clauses
+        .iter()
+        .filter(|clause| clause.placement == ClausePlacement::NestedInDelayedPayload)
+        .count();
+
+    // Paired positive reach-guard: the same text WITHOUT the intervening clause must
+    // still promote, so a 0 above cannot be a parse failure masquerading as a pass.
+    let mut baseline_context = ParseContext::default();
+    let baseline = parse_effect_chain_ir(
+        CODIE_CONTINUATION_TEXT,
+        AbilityKind::Activated,
+        &mut baseline_context,
+    );
+    let baseline_promoted = baseline
+        .clauses
+        .iter()
+        .filter(|clause| clause.placement == ClausePlacement::NestedInDelayedPayload)
+        .count();
+    assert!(
+        baseline_promoted > 0,
+        "T-B1 reach-guard: the un-intervened chain must still reach the promotion path"
+    );
+
+    assert_eq!(
+        intervened_promoted, 0,
+        "T-B1: a non-emitted clause must close the open-payload run, so no later clause \
+         may be promoted (plan-r18 §R18.1). Baseline promoted {baseline_promoted}; got \
+         {intervened_promoted}: {intervened:#?}"
+    );
+}
+
+#[test]
+fn delayed_payload_continuation_binds_the_nearest_open_installer() {
+    const DELAYED_INSTALLER: &str =
+        "When you next cast a spell this turn, exile cards from the top of \
+your library until you exile an instant or sorcery card with lesser mana value.";
+    const CONTINUATION: &str =
+        "Until end of turn, you may cast that card without paying its mana cost.";
+    let text = format!(
+        "Add {{W}}{{U}}{{B}}{{R}}{{G}}. {DELAYED_INSTALLER} {DELAYED_INSTALLER} {CONTINUATION}"
+    );
+    let mut context = ParseContext::default();
+    let chain = parse_effect_chain_ir(&text, AbilityKind::Activated, &mut context);
+
+    let installers: Vec<_> = chain
+        .clauses
+        .iter()
+        .filter(|clause| matches!(clause.parsed.effect, Effect::CreateDelayedTrigger { .. }))
+        .collect();
+    assert_eq!(
+        installers.len(),
+        2,
+        "T-PEER precondition: the fixture must produce two delayed installers: {chain:#?}"
+    );
+    assert_eq!(
+        installers[0].placement,
+        ClausePlacement::Sibling,
+        "T-PEER: the earlier installer stays a sibling while the continuation binds the nearer one"
+    );
+    let promoted = chain
+        .clauses
+        .iter()
+        .filter(|clause| clause.placement == ClausePlacement::NestedInDelayedPayload)
+        .count();
+    assert_eq!(
+        promoted, 1,
+        "T-PEER: exactly the continuation binds the nearest open delayed payload: {chain:#?}"
+    );
+}
+
+#[test]
+fn delayed_payload_placement_defaults_to_siblings_and_promotes_only_continuations() {
+    let mut ordinary_context = ParseContext::default();
+    let ordinary = parse_effect_chain_ir(
+        "Draw a card. You gain 3 life.",
+        AbilityKind::Spell,
+        &mut ordinary_context,
+    );
+    assert!(
+        ordinary
+            .clauses
+            .iter()
+            .all(|clause| clause.placement == ClausePlacement::Sibling),
+        "T-PL1: an ordinary chain must retain the construction default"
+    );
+
+    let mut codie_context = ParseContext::default();
+    let codie = parse_effect_chain_ir(
+        CODIE_CONTINUATION_TEXT,
+        AbilityKind::Activated,
+        &mut codie_context,
+    );
+    let promoted = codie
+        .clauses
+        .iter()
+        .filter(|clause| clause.placement == ClausePlacement::NestedInDelayedPayload)
+        .count();
+    assert_eq!(
+        promoted, 2,
+        "T-PL1 positive control: Codie's two payload continuations must be observable"
+    );
+}
+
+#[test]
+fn delayed_payload_placement_requires_an_emitted_clause() {
+    let mut codie_context = ParseContext::default();
+    let codie = parse_effect_chain_ir(
+        CODIE_CONTINUATION_TEXT,
+        AbilityKind::Activated,
+        &mut codie_context,
+    );
+    let mut flickerform_context = ParseContext::default();
+    let flickerform = parse_effect_chain_ir(
+        "Exile enchanted creature and all Auras attached to it. At the beginning of the next end step, \
+         return that card to the battlefield under its owner's control. If you do, return the other cards \
+         exiled this way to the battlefield under their owners' control attached to that creature.",
+        AbilityKind::Activated,
+        &mut flickerform_context,
+    );
+    let mut ordinary_context = ParseContext::default();
+    let ordinary = parse_effect_chain_ir(
+        "Draw a card. You gain 3 life.",
+        AbilityKind::Spell,
+        &mut ordinary_context,
+    );
+
+    for chain in [&codie, &flickerform, &ordinary] {
+        assert!(
+            chain.clauses.iter().all(|clause| {
+                clause.placement != ClausePlacement::NestedInDelayedPayload
+                    || matches!(clause.disposition, ClauseDisposition::Emit { .. })
+            }),
+            "T-DP1: nested placement is valid only on an emitted clause: {chain:#?}"
+        );
+    }
+    assert_eq!(
+        codie
+            .clauses
+            .iter()
+            .filter(|clause| clause.placement == ClausePlacement::NestedInDelayedPayload)
+            .count(),
+        2,
+        "T-DP1 positive control: the universal must observe promoted clauses"
+    );
+}
+
+#[test]
+fn absorbed_nested_chain_recomputes_delayed_payload_placement_in_its_outer_context() {
+    let mut nested_context = ParseContext::default();
+    let nested = parse_effect_chain_ir(
+        CODIE_CONTINUATION_TEXT,
+        AbilityKind::Spell,
+        &mut nested_context,
+    );
+    assert!(
+        nested
+            .clauses
+            .iter()
+            .any(|clause| clause.placement == ClausePlacement::NestedInDelayedPayload),
+        "T-DP2 positive control: the nested body must reach the promotion path"
+    );
+
+    let mut outer_context = ParseContext::default();
+    let outer = parse_effect_chain_ir(
+        &format!("If you control an artifact, {CODIE_CONTINUATION_TEXT}"),
+        AbilityKind::Spell,
+        &mut outer_context,
+    );
+    let nested_promoted = nested
+        .clauses
+        .iter()
+        .filter(|clause| clause.placement == ClausePlacement::NestedInDelayedPayload)
+        .count();
+    let outer_promoted = outer
+        .clauses
+        .iter()
+        .filter(|clause| clause.placement == ClausePlacement::NestedInDelayedPayload)
+        .count();
+    assert_eq!(
+        outer_promoted, nested_promoted,
+        "T-DP2′: an absorbed nested chain's continuations must be re-promoted against the OUTER \
+         registry (plan-r17 §R17.4.1; closes the leading-if deferral at assembly.rs:2781)"
+    );
+}
+
+/// A replacement shield remains an emitted top-level definition, so a following
+/// continuation cannot be relocated past it into the preceding delayed payload.
+/// This composes Codie's delayed installer and cast continuation with Riot
+/// Control's printed damage-prevention rider to drive parse and assembly end-to-end.
+#[test]
+fn replacement_shield_between_installer_and_continuation_stays_a_sibling() {
+    const DELAYED_INSTALLER: &str =
+        "When you next cast a spell this turn, exile cards from the top of your library until you exile an instant or sorcery card with lesser mana value.";
+    const REPLACEMENT_SHIELD: &str = "Prevent all damage that would be dealt to you this turn.";
+    const CONTINUATION: &str =
+        "Until end of turn, you may cast that card without paying its mana cost.";
+    let text = format!("{DELAYED_INSTALLER} {REPLACEMENT_SHIELD} {CONTINUATION}");
+    let mut context = ParseContext::default();
+    let chain = parse_effect_chain_ir(&text, AbilityKind::Spell, &mut context);
+
+    assert_eq!(
+        chain
+            .clauses
+            .iter()
+            .filter(|clause| matches!(clause.parsed.effect, Effect::CreateDelayedTrigger { .. }))
+            .count(),
+        1,
+        "fixture must produce exactly one delayed installer: {chain:#?}"
+    );
+    let shield_index = chain
+        .clauses
+        .iter()
+        .position(|clause| effect_installs_replacement_shield(&clause.parsed.effect))
+        .expect("fixture must produce an emitted replacement-shield clause");
+    assert!(
+        matches!(
+            chain.clauses[shield_index].disposition,
+            ClauseDisposition::Emit { .. }
+        ),
+        "fixture's shield must remain a top-level emitted definition: {chain:#?}"
+    );
+    let continuation = chain
+        .clauses
+        .get(shield_index + 1)
+        .expect("fixture must retain a continuation after the shield");
+    assert!(
+        matches!(continuation.parsed.effect, Effect::CastFromZone { .. }),
+        "fixture's post-shield clause must be the intended cast continuation: {chain:#?}"
+    );
+
+    // The adopted placement marks this continuation as nested. Assembly must then
+    // reject the relocation because the shield, not the installer, precedes it.
+    let _ = lower_effect_chain_ir(&chain);
+
+    assert_eq!(
+        continuation.placement,
+        ClausePlacement::Sibling,
+        "an emitted replacement shield breaks the relocation run"
+    );
+}

--- a/crates/engine/src/parser/oracle_ir/effect_chain.rs
+++ b/crates/engine/src/parser/oracle_ir/effect_chain.rs
@@ -673,6 +673,42 @@ pub(crate) enum AbsorbKind {
     CantBeRegenerated,
 }
 
+/// CR 608.2c + CR 603.7a: WHERE a clause's lowered definition lives in the
+/// assembled tree — an axis orthogonal to [`ClauseDisposition`], which says WHAT
+/// the clause does relative to its neighbours.
+///
+/// The two are genuinely independent. A payload continuation *emits* its own
+/// definition (so its disposition is `Emit`, with `Emit`'s continuation channels
+/// intact), but that definition belongs inside a delayed trigger's payload chain
+/// rather than beside it. Folding this into `ClauseDisposition` would either
+/// duplicate `Emit`'s channels on a second variant or force every one of `Emit`'s
+/// construction sites to restate "not nested".
+///
+/// CR 608.2c: later text can modify the meaning of earlier text. A continuation
+/// whose referent was minted by a delayed payload must be followed when that
+/// payload is followed — CR 603.7a: at the delayed ability's resolution, not at
+/// its creation.
+///
+/// Set to `Sibling` for every clause by construction; only
+/// `classify_continuation_clause` (`oracle_effect/mod.rs`) ever promotes a clause
+/// to `NestedInDelayedPayload`, and only `assemble_effect_chain` ever reads it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Default)]
+pub(crate) enum ClausePlacement {
+    /// The clause's definition joins the chain as a top-level sibling.
+    #[default]
+    Sibling,
+    /// CR 603.7a: the clause's definition is relocated into the nearest still-open
+    /// delayed trigger installed earlier in this chain.
+    NestedInDelayedPayload,
+}
+
+impl ClausePlacement {
+    /// `skip_serializing_if` predicate — the default needs no JSON byte.
+    pub(crate) fn is_sibling(placement: &Self) -> bool {
+        matches!(placement, Self::Sibling)
+    }
+}
+
 /// CR 608.2c: a field-level modification folded onto the prior emitted def
 /// (emits no sibling). Promoted from the former special-clause markers
 /// `AltCostRider` / `ManaRetention` / `EntersTappedAttacking` (U5-M2). Each
@@ -811,6 +847,11 @@ pub(crate) struct ClauseIr {
     /// targeted "of their choice" controlled by the phase-trigger active player.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub(crate) target_chooser: Option<TargetFilter>,
+    /// CR 608.2c + CR 603.7a: where this clause's lowered definition attaches.
+    /// `Sibling` (default) is promoted only when this clause continues an open
+    /// delayed payload and is consumed by `assemble_effect_chain`'s relocation step.
+    #[serde(default, skip_serializing_if = "ClausePlacement::is_sibling")]
+    pub(crate) placement: ClausePlacement,
     /// Construction seal: a private field forces all construction through
     /// [`ClauseIrBuilder`], so no call site can mint a clause without identity,
     /// source, disposition, and provenance (Plan 01 §5 construction gate).
@@ -968,6 +1009,7 @@ impl ClauseIrBuilder {
             unless_pay: None,
             target_selection_mode: TargetSelectionMode::Chosen,
             target_chooser: None,
+            placement: ClausePlacement::Sibling,
         }
     }
 
@@ -1000,6 +1042,14 @@ impl ClauseIrBuilder {
     /// THIS chain), preserving all content. Keeps single-construction — still
     /// routes through [`ClauseIrBuilder::clause`] + [`ClauseDraft::push`].
     pub(crate) fn absorb_clause(&mut self, c: ClauseIr) {
+        // CR 608.2c: `placement` is deliberately NOT propagated. Every field below is
+        // an intrinsic property of the clause; `placement` is a RELATIONAL verdict
+        // about one position in one chain's delayed-payload placement registry, and a
+        // verdict computed against a nested chain's registry has no meaning in this
+        // one. The re-minted clause starts at `ClausePlacement::Sibling` (the
+        // `#[default]`, set by `ClauseIrBuilder::clause`), and only this chain's own
+        // `classify_continuation_clause` may promote it. Same reasoning as §R8.1.1's
+        // rejection of a recursively-lowered rider, one chain level down.
         self.clause(
             c.source.fragment().unwrap_or_default(),
             c.parsed,
@@ -1051,6 +1101,7 @@ pub(crate) struct ClauseDraft<'a> {
     unless_pay: Option<UnlessPayModifier>,
     target_selection_mode: TargetSelectionMode,
     target_chooser: Option<TargetFilter>,
+    placement: ClausePlacement,
 }
 
 impl ClauseDraft<'_> {
@@ -1144,6 +1195,7 @@ impl ClauseDraft<'_> {
             unless_pay: self.unless_pay,
             target_selection_mode: self.target_selection_mode,
             target_chooser: self.target_chooser,
+            placement: self.placement,
             _sealed: (),
         });
     }

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -356,10 +356,10 @@ fn detect_replacement(
     // FALSE POSITIVES pool-wide: chocobo camp, kumano faces kakkazan, osteomancer adept,
     // summon: fenrir, yuna.
     //
-    // It must be probed via the tree-global typed evidence, NOT via the structural
-    // `effect_is_replacement_carrier` walk: that walk descends `sub_ability` / `else_ability`
-    // / `mode_abilities` only, so it cannot see a carrier nested inside an EFFECT — and
-    // Yuna's carrier lives inside `Effect::CreateDelayedTrigger`'s inner definition.
+    // It must be probed via tree-global typed evidence, not the structural
+    // `effect_is_replacement_carrier` matcher: that deliberately finite matcher does
+    // not enumerate these CR 614.1c carrier variants. Typed evidence reaches all
+    // fields, including Yuna's `Effect::CreateDelayedTrigger` inner definition.
     if evidence.any_static_mode(|m| {
         matches!(
             m,
@@ -893,6 +893,11 @@ fn def_tree_has_target_replacement(def: &AbilityDefinition) -> bool {
         } if flip_branch_has_target_replacement(win_effect, lose_effect) => return true,
         _ => {}
     }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_target_replacement(effect) {
+            return true;
+        }
+    }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_target_replacement(sub) {
             return true;
@@ -1030,6 +1035,11 @@ fn def_tree_has_unimplemented(def: &AbilityDefinition) -> bool {
     if matches!(*def.effect, Effect::Unimplemented { .. }) {
         return true;
     }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_unimplemented(effect) {
+            return true;
+        }
+    }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_unimplemented(sub) {
             return true;
@@ -1120,6 +1130,11 @@ fn def_tree_has_exile_parent_rider(def: &AbilityDefinition) -> bool {
     {
         return true;
     }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_exile_parent_rider(effect) {
+            return true;
+        }
+    }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_exile_parent_rider(sub) {
             return true;
@@ -1163,6 +1178,11 @@ fn def_tree_has_cast_graveyard_redirect_rider(def: &AbilityDefinition) -> bool {
             .is_some_and(def_is_graveyard_redirect_to_parent))
     {
         return true;
+    }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_cast_graveyard_redirect_rider(effect) {
+            return true;
+        }
     }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_cast_graveyard_redirect_rider(sub) {
@@ -1223,6 +1243,11 @@ fn def_tree_has_parent_target_cant_gain_life(def: &AbilityDefinition) -> bool {
             return true;
         }
     }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_parent_target_cant_gain_life(effect) {
+            return true;
+        }
+    }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_parent_target_cant_gain_life(sub) {
             return true;
@@ -1274,6 +1299,11 @@ fn def_tree_has_parent_target_discard(def: &AbilityDefinition) -> bool {
         }
     ) {
         return true;
+    }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_parent_target_discard(effect) {
+            return true;
+        }
     }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_parent_target_discard(sub) {
@@ -1335,6 +1365,11 @@ fn def_tree_has_graveyard_cast_from_zone(def: &AbilityDefinition) -> bool {
             return true;
         }
     }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_graveyard_cast_from_zone(effect) {
+            return true;
+        }
+    }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_graveyard_cast_from_zone(sub) {
             return true;
@@ -1383,6 +1418,11 @@ fn def_tree_has_instead_condition(def: &AbilityDefinition) -> bool {
         .is_some_and(condition_has_instead_semantics)
     {
         return true;
+    }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_instead_condition(effect) {
+            return true;
+        }
     }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_instead_condition(sub) {
@@ -1479,6 +1519,11 @@ fn def_tree_has_replacement_carrier(def: &AbilityDefinition) -> bool {
     if effect_is_replacement_carrier(&def.effect) || def_is_represented_instead_branch(def) {
         return true;
     }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_replacement_carrier(effect) {
+            return true;
+        }
+    }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_replacement_carrier(sub) {
             return true;
@@ -1567,6 +1612,11 @@ fn def_tree_has_conditional_mana_spell_grant(def: &AbilityDefinition) -> bool {
             return true;
         }
     }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_conditional_mana_spell_grant(effect) {
+            return true;
+        }
+    }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_conditional_mana_spell_grant(sub) {
             return true;
@@ -1603,6 +1653,11 @@ fn def_tree_has_cast_from_zone_alt_ability_cost(def: &AbilityDefinition) -> bool
         }
     ) {
         return true;
+    }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_cast_from_zone_alt_ability_cost(effect) {
+            return true;
+        }
     }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_cast_from_zone_alt_ability_cost(sub) {
@@ -1789,11 +1844,17 @@ fn parsed_has_conditional_modal_max(parsed: &ParsedAbilities) -> bool {
 }
 
 fn def_tree_has_conditional_modal_max(def: &AbilityDefinition) -> bool {
-    def.modal.as_ref().is_some_and(modal_has_conditional_max)
-        || def
-            .sub_ability
-            .as_ref()
-            .is_some_and(|sub| def_tree_has_conditional_modal_max(sub))
+    if def.modal.as_ref().is_some_and(modal_has_conditional_max) {
+        return true;
+    }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_conditional_modal_max(effect) {
+            return true;
+        }
+    }
+    def.sub_ability
+        .as_ref()
+        .is_some_and(|sub| def_tree_has_conditional_modal_max(sub))
         || def
             .else_ability
             .as_ref()
@@ -1862,6 +1923,11 @@ fn unit_has_end_of_turn_mana_expiry(parsed: &ParsedAbilities) -> bool {
         } = &*def.effect
         {
             if mana_expiry_is_end_of_turn(expiry) {
+                return true;
+            }
+        }
+        if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+            if def_has(effect) {
                 return true;
             }
         }
@@ -1955,6 +2021,11 @@ fn def_tree_has_activation_limit(def: &AbilityDefinition) -> bool {
     {
         return true;
     }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_activation_limit(effect) {
+            return true;
+        }
+    }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_activation_limit(sub) {
             return true;
@@ -1996,6 +2067,11 @@ fn def_tree_has_apnap_ordering(def: &AbilityDefinition) -> bool {
     // variant's presence IS the ordering fact.
     if matches!(&*def.effect, Effect::Vote { .. }) {
         return true;
+    }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_apnap_ordering(effect) {
+            return true;
+        }
     }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_apnap_ordering(sub) {
@@ -2685,6 +2761,11 @@ fn def_tree_has_plotted_grant(def: &AbilityDefinition) -> bool {
     {
         return true;
     }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_plotted_grant(effect) {
+            return true;
+        }
+    }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_plotted_grant(sub) {
             return true;
@@ -2721,6 +2802,11 @@ fn plotted_grant_linkage_is_only_if_marker(stripped: &str) -> bool {
 fn def_tree_has_dig(def: &AbilityDefinition) -> bool {
     if matches!(&*def.effect, Effect::Dig { .. }) {
         return true;
+    }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_dig(effect) {
+            return true;
+        }
     }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_dig(sub) {
@@ -2791,6 +2877,11 @@ fn def_tree_has_exile_resolving_rider(def: &AbilityDefinition) -> bool {
         Effect::ExileResolvingSpellInsteadOfGraveyard { on_exile: Some(_) }
     ) {
         return true;
+    }
+    if let Effect::CreateDelayedTrigger { effect, .. } = &*def.effect {
+        if def_tree_has_exile_resolving_rider(effect) {
+            return true;
+        }
     }
     if let Some(ref sub) = def.sub_ability {
         if def_tree_has_exile_resolving_rider(sub) {
@@ -5891,6 +5982,18 @@ mod tests {
              If this spell was kicked, prevent the next 6 damage this way instead.",
             "Pollen Remedy",
             &["Instant"],
+        );
+
+        assert!(!has_swallowed_detector(&parsed, "Replacement_Instead"));
+    }
+
+    #[test]
+    fn replacement_instead_accepts_power_pack_delayed_payload_rider() {
+        let parsed = parse_named(
+            "Flying, vigilance, trample, haste\n\
+             Whenever Power Pack deals combat damage to a player, exile target instant or sorcery card from your graveyard chosen at random. At the beginning of your next upkeep, you may cast that card without paying its mana cost. If that spell would be put into your graveyard, exile it instead.",
+            "Power Pack",
+            &["Creature"],
         );
 
         assert!(!has_swallowed_detector(&parsed, "Replacement_Instead"));

--- a/crates/engine/tests/integration/delayed_trigger_continuation.rs
+++ b/crates/engine/tests/integration/delayed_trigger_continuation.rs
@@ -1,0 +1,229 @@
+//! Regression coverage for continuations that belong to delayed-trigger payloads.
+
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, Effect, SubAbilityLink, TargetFilter,
+};
+use engine::types::zones::Zone;
+
+const CODIE: &str = "You can't cast permanent spells.\n{4}, {T}: Add {W}{U}{B}{R}{G}. When you next cast a spell this turn, exile cards from the top of your library until you exile an instant or sorcery card with lesser mana value. Until end of turn, you may cast that card without paying its mana cost. Put each other card exiled this way on the bottom of your library in a random order.";
+const POWER_PACK: &str = "Flying, vigilance, trample, haste\nWhenever Power Pack deals combat damage to a player, exile target instant or sorcery card from your graveyard chosen at random. At the beginning of your next upkeep, you may cast that card without paying its mana cost. If that spell would be put into your graveyard, exile it instead.";
+const KYLOX: &str = "Collect evidence 6: This Vehicle becomes an artifact creature until end of turn.\nWhenever this Vehicle attacks, you may cast an instant or sorcery spell from among cards exiled with it. If that spell would be put into a graveyard, put it on the bottom of its owner's library instead.\nCrew 2";
+const GOBLIN_KITES: &str = "{R}: Target creature you control with toughness 2 or less gains flying until end of turn. Flip a coin at the beginning of the next end step. If you lose the flip, sacrifice that creature.";
+const ELEMENTAL_APPEAL: &str = "Kicker {5} (You may pay an additional {5} as you cast this spell.)\nCreate a 7/1 red Elemental creature token with trample and haste. Exile it at the beginning of the next end step. If this spell was kicked, that creature gets +7/+0 until end of turn.";
+const BUMIS_FEAST_LECTURE: &str = "Create a Food token. Then earthbend X, where X is twice the number of Foods you control. (A Food token is an artifact with \"{2}, {T}, Sacrifice this token: You gain 3 life.\" To earthbend X, target land you control becomes a 0/0 creature with haste that's still a land. Put X +1/+1 counters on it. When it dies or is exiled, return it to the battlefield tapped.)";
+
+fn parse_card(name: &str, text: &str) -> engine::parser::oracle::ParsedAbilities {
+    parse_oracle_text(text, name, &[], &[], &[])
+}
+
+fn spine(def: &AbilityDefinition) -> Vec<&AbilityDefinition> {
+    let mut spine = vec![def];
+    while let Some(next) = spine.last().and_then(|node| node.sub_ability.as_deref()) {
+        spine.push(next);
+    }
+    spine
+}
+
+fn delayed_payload(def: &AbilityDefinition) -> &AbilityDefinition {
+    for node in spine(def) {
+        if let Effect::CreateDelayedTrigger { effect, .. } = node.effect.as_ref() {
+            return effect;
+        }
+    }
+    panic!("expected a delayed-trigger installer on the ability spine: {def:#?}")
+}
+
+fn find_effect<'a>(
+    def: &'a AbilityDefinition,
+    predicate: &impl Fn(&Effect) -> bool,
+) -> Option<&'a AbilityDefinition> {
+    if predicate(def.effect.as_ref()) {
+        return Some(def);
+    }
+    if let Effect::CreateDelayedTrigger { effect, .. } = def.effect.as_ref() {
+        if let Some(found) = find_effect(effect, predicate) {
+            return Some(found);
+        }
+    }
+    def.sub_ability
+        .as_deref()
+        .and_then(|child| find_effect(child, predicate))
+        .or_else(|| {
+            def.else_ability
+                .as_deref()
+                .and_then(|child| find_effect(child, predicate))
+        })
+}
+
+fn codie_activation() -> AbilityDefinition {
+    parse_card("Codie, Vociferous Codex", CODIE)
+        .abilities
+        .into_iter()
+        .find(|ability| ability.kind == AbilityKind::Activated)
+        .expect("Codie's verbatim Oracle text must produce an activated ability")
+}
+
+#[test]
+fn codie_relocates_two_continuations_in_printed_order() {
+    let activated = codie_activation();
+    let top_level = spine(&activated);
+    let payload = delayed_payload(&activated);
+    let payload_spine = spine(payload);
+
+    assert_eq!(
+        top_level.len(),
+        2,
+        "T-AR1: Codie's top-level chain must shrink by its two relocated definitions"
+    );
+    assert_eq!(
+        payload_spine.len(),
+        3,
+        "T-PL2/T-PLoc2: the delayed payload must contain exactly three definitions"
+    );
+    assert!(matches!(
+        payload_spine[0].effect.as_ref(),
+        Effect::ExileFromTopUntil { .. }
+    ));
+    assert!(matches!(
+        payload_spine[1].effect.as_ref(),
+        Effect::CastFromZone { .. }
+    ));
+    assert!(matches!(
+        payload_spine[2].effect.as_ref(),
+        Effect::PutAtLibraryPosition { .. }
+    ));
+    assert_eq!(
+        payload_spine[1].kind,
+        AbilityKind::Spell,
+        "T-KIND: Codie's relocated CastFromZone must be a spell continuation"
+    );
+    assert_eq!(
+        payload_spine[2].kind,
+        AbilityKind::Spell,
+        "T-KIND: Codie's relocated library placement must be a spell continuation"
+    );
+    assert_eq!(
+        activated.kind,
+        AbilityKind::Activated,
+        "T-KIND control: the activation's chain head is not relocated"
+    );
+    assert_eq!(
+        payload_spine[0].kind,
+        AbilityKind::Spell,
+        "T-KIND control: Codie's payload head is already a spell and is not mover-owned"
+    );
+    assert_eq!(
+        payload_spine[2].sub_link,
+        SubAbilityLink::SequentialSibling,
+        "T-SL: the mover preserves the parsed sentence boundary"
+    );
+}
+
+#[test]
+fn power_pack_relocates_the_exile_replacement_rider_but_kylox_keeps_its_folded_rider() {
+    let power_pack = parse_card("Power Pack", POWER_PACK);
+    let power_execute = power_pack
+        .triggers
+        .first()
+        .and_then(|trigger| trigger.execute.as_deref())
+        .expect("Power Pack's combat-damage trigger must execute an ability");
+    let power_payload = delayed_payload(power_execute);
+    assert!(
+        find_effect(power_payload, &|effect| matches!(
+            effect,
+            Effect::ChangeZone {
+                destination: Zone::Exile,
+                target: TargetFilter::ParentTarget,
+                ..
+            }
+        ))
+        .is_some(),
+        "T-PP: Power Pack's exile replacement rider must live in its delayed payload; \
+         payload = {power_payload:#?}; execute = {power_execute:#?}"
+    );
+
+    let kylox = parse_card("Kylox's Voltstrider", KYLOX);
+    let kylox_execute = kylox
+        .triggers
+        .first()
+        .and_then(|trigger| trigger.execute.as_deref())
+        .expect("Kylox's attack trigger must execute an ability");
+    let cast = find_effect(kylox_execute, &|effect| {
+        matches!(effect, Effect::CastFromZone { .. })
+    })
+    .expect("Kylox must produce its cast-from-exile instruction");
+    assert!(matches!(
+        cast.sub_ability
+            .as_deref()
+            .map(|child| child.effect.as_ref()),
+        Some(Effect::PutAtLibraryPosition { .. })
+    ));
+    assert!(
+        !matches!(cast.effect.as_ref(), Effect::CreateDelayedTrigger { .. }),
+        "T-PP control: Kylox's folded rider remains attached to CastFromZone, not a delayed payload"
+    );
+}
+
+#[test]
+fn goblin_kites_payload_head_is_not_stamped_as_a_spell() {
+    let kites = parse_card("Goblin Kites", GOBLIN_KITES);
+    let activated = kites
+        .abilities
+        .iter()
+        .find(|ability| ability.kind == AbilityKind::Activated)
+        .expect("Goblin Kites must produce its activated ability");
+    let payload = delayed_payload(activated);
+
+    assert_eq!(
+        payload.kind,
+        AbilityKind::Activated,
+        "T-KIND control: Goblin Kites detects an over-stamping mover at the payload head"
+    );
+}
+
+#[test]
+fn elemental_appeal_keeps_its_kicker_pump_outside_the_delayed_payload() {
+    let elemental = parse_card("Elemental Appeal", ELEMENTAL_APPEAL);
+    let root = elemental
+        .abilities
+        .first()
+        .expect("Elemental Appeal must produce its spell ability");
+    let outer_spine = spine(root);
+    let payload = delayed_payload(root);
+
+    assert!(matches!(root.effect.as_ref(), Effect::Token { .. }));
+    assert!(matches!(
+        outer_spine.last().map(|node| node.effect.as_ref()),
+        Some(Effect::Pump {
+            target: TargetFilter::LastCreated,
+            ..
+        })
+    ));
+    assert!(matches!(
+        payload.effect.as_ref(),
+        Effect::ChangeZone {
+            target: TargetFilter::LastCreated,
+            ..
+        }
+    ));
+    assert!(
+        !find_effect(payload, &|effect| matches!(effect, Effect::Pump { .. })).is_some(),
+        "T-ROW5: Elemental Appeal's kicker pump is a top-level sibling, not a delayed payload child"
+    );
+
+    let bumi = parse_card("Bumi's Feast Lecture", BUMIS_FEAST_LECTURE);
+    let bumi_root = bumi
+        .abilities
+        .first()
+        .expect("Bumi's Feast Lecture must produce its spell ability");
+    assert!(matches!(bumi_root.effect.as_ref(), Effect::Token { .. }));
+    assert!(
+        find_effect(bumi_root, &|effect| matches!(
+            effect,
+            Effect::RegisterBending { .. }
+        ))
+        .is_some(),
+        "T-ROW5 hostile control: Bumi's post-token earthbend remains RegisterBending"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -157,6 +157,7 @@ mod dark_confidant_upkeep;
 mod dark_depths_thespian_stage;
 mod death_priest_myrkul_oxford_anthem;
 mod delayed_parent_target_incarnation;
+mod delayed_trigger_continuation;
 mod demilich_helbrute_graveyard_exile_cost;
 mod demon_of_fates_design;
 mod descendants_fury_sacrificed_referent_4795;


### PR DESCRIPTION
## The bug

Clauses that continue a delayed trigger's payload were assembled as **siblings of the chain head** instead of nesting inside the payload. Codie, Vociferous Codex is the flagship case; Power Pack's exile rider is another.

## Why the old fix location could never work

The placement verdict was computed in the chunk loop, immediately after the one canonical terminal `.push()`. That site is reachable by **1 of 36 producers**:

| Producer class | Count |
|---|---|
| Direct `.push()` early-exit sites | 31 |
| Indirect (push one frame down via `unimplemented_clause`, `absorb_clause`) | 4 |
| Canonical terminal push | 1 |

Every one of the 35 others exits with `continue` — or, at `mod.rs:30010`, `break` — past the entire loop tail. The transition therefore fired on one producer, and failed in **both** directions: a delayed installer emitted by the temporal-prefix producer never registered an antecedent (Power Pack), and an ordinary clause emitted by any other early-exit producer never closed an open run.

No statement inside the loop body can fix this. `continue` skips the whole remainder of the body, and the transition must read a **built** `ClauseIr`, which does not exist until after the producer has pushed. There is no path-independent point that is both after the push and before the next iteration.

## The fix

Resolve placement in one fold over the finished clause sequence, before `ClauseIrBuilder::finish()`.

Per **CR 608.2c** the controller follows a spell's instructions *in the order written*, so which payload a clause continues into is a property of its **position in the sequence**, not of which recognizer matched. Every producer appends through a single `push` site, so the fold sees each clause exactly once and cannot be invalidated by a 36th producer.

Promotion additionally requires an **unbroken run** from the installer. The two classifier vetoes (replacement shield, cast-time cost) preserve the antecedent, but their clauses are `Emit` and leave a top-level definition behind — promoting across one yields a clause whose preceding definition is not the installer, which `relocation_antecedent` must refuse and which the driver's `debug_assert!` turns into a **panic in debug and test builds**. The fold tracks the last contiguous clause and clears the run instead.

## Tests

| Row | Guards |
|---|---|
| Power Pack / Kylox | the rider relocates; Kylox's folded rider still does not |
| Codie | two continuations relocate in printed order |
| **T-B1** | a non-emitted clause (Kathril's `ReplicatePerKeyword`) between installer and continuation closes the run — **observed red at 2 promoted, green at 0** |
| **Shield regression** | Codie installer + Riot Control prevention shield + Codie continuation — **reproduces the `debug_assert` panic end to end pre-fix, green under the guard** |
| T-PEER | a continuation binds the *nearest* open installer |
| T-DP2′ | an absorbed nested chain is re-promoted against the outer registry |
| Goblin Kites / Elemental Appeal / Bumi | payload-head stamping and hostile-sibling controls |

`clippy --all-targets -D warnings` clean; 1,590 parser tests green.

## Known and recorded, not fixed

- **Mint-regime widening.** `classify_continuation_clause`'s `|| antecedent.mint.is_some()` short-circuit makes the clearing verdict unreachable while a mint-carrying antecedent is open. It is unchanged here — the fold only changes *which* clauses reach the classifier — so an intervening emitted clause is now promoted where it previously stayed a sibling. Inherited rather than introduced, not licensed by CR 603.7a or CR 608.2c, recorded as unmeasured. Deliberately unpinned by any test: pinning would entrench a heuristic.
- **Jodah cleanup triple.** Relocation can move the `ExileFromTopUntil` → `CastFromZone` → bottom `PutAtLibraryPosition` triple inside a payload, where `normalize_linked_exile_cast_pair` (top-level pairs only) cannot reach it. Not a regression — pre-change the preceding definition was the `CreateDelayedTrigger` wrapper, so it could not fire either. New deferral entry.
- **T-RT3 not written.** Its prescribed recipe cannot work: `activate(..).resolve()` installs Codie's "when you next cast a spell" trigger but cannot itself produce the cast offer without a further spell-cast event. The hazard it guards is the creation-time `parent_target_snapshot` binding, which post-loop relocation explicitly does not remove — pre-existing and orthogonal to this change.
- No corpus sweep: `card-data.json` is absent from the implementation worktree.