### PR TITLE
ship/add sealed draft event support

### DIFF
--- a/client/src/adapter/__tests__/draftPodAdapter.test.ts
+++ b/client/src/adapter/__tests__/draftPodAdapter.test.ts
@@ -123,6 +123,7 @@ function mockView(status: string): DraftPlayerView {
     tournament_format: "Swiss",
     pod_policy: "Competitive",
     pairings: [],
+    match_config: { match_type: "Bo1" },
   };
 }
 

--- a/client/src/adapter/__tests__/server-draft-adapter.test.ts
+++ b/client/src/adapter/__tests__/server-draft-adapter.test.ts
@@ -77,6 +77,7 @@ function createMockDraftView(overrides: Partial<DraftPlayerView> = {}): DraftPla
     tournament_format: "Swiss",
     pod_policy: "Competitive",
     pairings: [],
+    match_config: { match_type: "Bo1" },
     ...overrides,
   };
 }

--- a/client/src/adapter/draft-adapter.ts
+++ b/client/src/adapter/draft-adapter.ts
@@ -1,4 +1,5 @@
 import type * as DraftWasm from "@wasm/draft";
+import type { MatchConfig } from "./types";
 
 // ── Types (mirror Rust serde output from draft-core) ────────────────────
 
@@ -95,6 +96,7 @@ export interface SpectatorDraftView {
   tournament_format: TournamentFormat;
   pod_policy: PodPolicy;
   pairings: PairingView[];
+  match_config: MatchConfig;
   /** Present only when the host enabled omniscient spectator visibility. */
   pools?: DraftCardInstance[][];
   current_packs?: (DraftCardInstance[] | null)[];
@@ -120,6 +122,7 @@ export interface DraftPlayerView {
   tournament_format: TournamentFormat;
   pod_policy: PodPolicy;
   pairings: PairingView[];
+  match_config: MatchConfig;
 }
 
 export type MultiplayerSeatDescriptor =

--- a/client/src/adapter/draft-adapter.ts
+++ b/client/src/adapter/draft-adapter.ts
@@ -34,6 +34,8 @@ export type DraftStatus =
   | "Complete"
   | "Abandoned";
 
+export type DraftKind = "Quick" | "Premier" | "Traditional" | "Sealed";
+
 export type TournamentFormat = "Swiss" | "SingleElimination";
 
 export type PodPolicy = "Competitive" | "Casual";
@@ -79,7 +81,7 @@ export interface PairingView {
 // @sync-with: crates/draft-core/src/view.rs
 export interface SpectatorDraftView {
   status: DraftStatus;
-  kind: "Quick" | "Premier" | "Traditional";
+  kind: DraftKind;
   current_pack_number: number;
   pick_number: number;
   pass_direction: "Left" | "Right";
@@ -101,7 +103,7 @@ export interface SpectatorDraftView {
 // @sync-with: crates/draft-core/src/view.rs
 export interface DraftPlayerView {
   status: DraftStatus;
-  kind: "Quick" | "Premier" | "Traditional";
+  kind: DraftKind;
   current_pack_number: number;
   pick_number: number;
   pass_direction: "Left" | "Right";
@@ -193,6 +195,15 @@ export class DraftAdapter {
     return wasm.start_quick_draft(setPoolJson, difficulty, seed) as DraftPlayerView;
   }
 
+  async initializeSealed(
+    setPoolJson: string,
+    difficulty: number,
+    seed: number,
+  ): Promise<DraftPlayerView> {
+    const wasm = await ensureDraftWasm();
+    return wasm.start_sealed_draft(setPoolJson, difficulty, seed) as DraftPlayerView;
+  }
+
   async initializeCube(
     cubeListText: string,
     cubeName: string,
@@ -253,36 +264,25 @@ export class DraftAdapter {
 
   // ── Multi-seat API (P2P Tournament Host) ─────────────────────────────
 
-  async startMultiplayerDraft(
-    setPoolJson: string,
-    kind: "Premier" | "Traditional",
-    seatNames: string[],
-    seed: number,
-  ): Promise<DraftPlayerView> {
-    const wasm = await ensureDraftWasm();
-    return wasm.start_multiplayer_draft(
-      setPoolJson,
-      kind,
-      JSON.stringify(seatNames),
-      seed,
-    ) as DraftPlayerView;
-  }
-
   async createMultiplayerDraft(
     poolInput: PoolInput,
     seats: MultiplayerSeatDescriptor[],
-    kind: "Premier" | "Traditional",
+    kind: Exclude<DraftKind, "Quick">,
     seed: number,
     draftCode: string,
     tournamentFormat: TournamentFormat,
     podPolicy: PodPolicy,
   ): Promise<DraftPlayerView> {
     const wasm = await ensureDraftWasm();
-    const kindId = kind === "Premier" ? 1 : 2;
+    const kindId: Record<Exclude<DraftKind, "Quick">, number> = {
+      Premier: 1,
+      Traditional: 2,
+      Sealed: 3,
+    };
     return wasm.create_multiplayer_draft(
       JSON.stringify(poolInput),
       JSON.stringify(seats),
-      kindId,
+      kindId[kind],
       seed,
       draftCode,
       tournamentFormat,

--- a/client/src/adapter/draftPodHostAdapter.ts
+++ b/client/src/adapter/draftPodHostAdapter.ts
@@ -292,7 +292,7 @@ export class DraftPodHostAdapter {
         this.emit({ type: "lobbyFull" });
         break;
       case "draftStarted":
-        this.setStatus("drafting");
+        this.setStatus(hostStatusForView(event.view));
         this.emit({ type: "draftStarted", view: event.view });
         break;
       case "pickReceived":

--- a/client/src/adapter/draftPodHostAdapter.ts
+++ b/client/src/adapter/draftPodHostAdapter.ts
@@ -11,7 +11,7 @@
  */
 
 import { DraftAdapter } from "./draft-adapter";
-import type { DraftPlayerView, PairingView, PodPolicy, PoolInput, SeatPublicView, TournamentFormat } from "./draft-adapter";
+import type { DraftKind, DraftPlayerView, PairingView, PodPolicy, PoolInput, SeatPublicView, TournamentFormat } from "./draft-adapter";
 import type { MatchScore } from "./types";
 import { P2PDraftHost, type DraftHostEvent } from "./p2p-draft-host";
 import { hostRoom, type HostResult } from "../network/connection";
@@ -105,7 +105,7 @@ function hostStatusForView(view: DraftPlayerView): DraftPodHostStatus {
 
 export interface DraftPodHostConfig {
   poolInput: PoolInput;
-  kind: "Premier" | "Traditional";
+  kind: Exclude<DraftKind, "Quick">;
   podSize: number;
   hostDisplayName: string;
   /** Swiss (3 rounds) or Single Elimination bracket. */

--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -248,7 +248,7 @@ export class P2PDraftHost {
       handler: (conn: DataConnection) => void,
     ) => () => void,
     private readonly poolInput: PoolInput,
-    private readonly kind: "Premier" | "Traditional",
+    private readonly kind: "Premier" | "Traditional" | "Sealed",
     private readonly podSize: number,
     private readonly hostDisplayName: string,
     private readonly tournamentFormat: TournamentFormat,
@@ -560,7 +560,10 @@ export class P2PDraftHost {
     this.draftCode = draftCode;
     this.activePodSize = seats.length;
     this.picksThisRound.clear();
-    await this.resolveBotPicks({ emit: false, persist: false });
+    const startView = await this.adapter.getViewForSeat(0);
+    if (startView.status === "Drafting") {
+      await this.resolveBotPicks({ emit: false, persist: false });
+    }
 
     // Send each guest their filtered view
     for (const [seat, session] of this.guestSessions) {
@@ -575,7 +578,9 @@ export class P2PDraftHost {
     this.persistSession();
     const freshHostView = await this.adapter.getViewForSeat(0);
     this.emit({ type: "draftStarted", view: freshHostView });
-    this.startPickTimer(0);
+    if (freshHostView.status === "Drafting") {
+      this.startPickTimer(0);
+    }
   }
 
   /**

--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -34,6 +34,10 @@ import {
   clearDraftHostSession,
   type PersistedDraftHostSession,
 } from "../services/draftPersistence";
+
+function matchConfigForView(view: DraftPlayerView): MatchConfig {
+  return view.match_config;
+}
 import {
   commandAcknowledgement,
   draftIntergameDigest,
@@ -1115,7 +1119,7 @@ export class P2PDraftHost {
           botSeat,
           botName,
           deckPayload,
-          matchConfig: this.matchConfig(),
+          matchConfig: matchConfigForView(view),
           binding,
       });
       return;
@@ -1144,7 +1148,7 @@ export class P2PDraftHost {
         opponentName: hostOpponentName,
         matchHostPeerId: matchRoomCode,
         deckPayload,
-        matchConfig: this.matchConfig(),
+        matchConfig: matchConfigForView(view),
         binding,
     });
     this.sendMatchLaunch(guestSeat, {
@@ -1157,7 +1161,7 @@ export class P2PDraftHost {
         opponentName: guestOpponentName,
         matchHostPeerId: matchRoomCode,
         localDeck: guestDeck,
-        matchConfig: this.matchConfig(),
+        matchConfig: matchConfigForView(view),
         binding,
     });
   }
@@ -1250,9 +1254,6 @@ export class P2PDraftHost {
     );
   }
 
-  private matchConfig(): MatchConfig {
-    return { match_type: this.kind === "Traditional" ? "Bo3" : "Bo1" };
-  }
 
   /**
    * Report a match result. Called when a guest sends draft_match_result.
@@ -2025,6 +2026,7 @@ export class P2PDraftHost {
       tournament_format: "Swiss",
       pod_policy: "Competitive",
       pairings: [],
+      match_config: { match_type: this.kind === "Traditional" ? "Bo3" : "Bo1" },
     };
   }
 

--- a/client/src/adapter/server-draft-adapter.ts
+++ b/client/src/adapter/server-draft-adapter.ts
@@ -26,6 +26,7 @@ import type {
   StandingEntry,
   TournamentFormat,
   PodPolicy,
+  DraftKind,
 } from "./draft-adapter";
 import type { ServerInfo } from "./ws-adapter";
 
@@ -43,7 +44,7 @@ export type DraftPhase =
 export interface CreateDraftSettings {
   displayName: string;
   setCode: string;
-  kind: "Premier" | "Traditional";
+  kind: Exclude<DraftKind, "Quick">;
   public: boolean;
   password?: string;
   timerSeconds?: number;

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -202,6 +202,7 @@ export class NativeEngineVersionMismatchError extends Error {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 27 — Added DraftKind.Sealed, serialized by draft WebSocket messages.
  * 26 — Added ActionNoOp acknowledgement for accepted transport no-ops.
  * 25 — DebugCardEntries added a serialized, private resolution frame for
  *      multi-card sandbox battlefield entries that pause for replacement or
@@ -232,7 +233,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 26;
+export const PROTOCOL_VERSION = 27;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/components/draft/__tests__/LimitedDeckBuilder.test.tsx
+++ b/client/src/components/draft/__tests__/LimitedDeckBuilder.test.tsx
@@ -59,6 +59,7 @@ const TEST_VIEW: BuilderView = {
   tournament_format: "Swiss",
   pod_policy: "Competitive",
   pairings: [],
+  match_config: { match_type: "Bo1" },
 };
 
 function Harness() {

--- a/client/src/components/draft/__tests__/PackDisplay.pod.test.tsx
+++ b/client/src/components/draft/__tests__/PackDisplay.pod.test.tsx
@@ -50,6 +50,7 @@ const view: DraftPlayerView = {
   tournament_format: "Swiss",
   pod_policy: "Competitive",
   pairings: [],
+  match_config: { match_type: "Bo1" },
 };
 
 describe("PackDisplay pod state", () => {

--- a/client/src/i18n/locales/de/draft.json
+++ b/client/src/i18n/locales/de/draft.json
@@ -239,6 +239,7 @@
   "page": {
     "cubeDraftTitle": "Cube Draft",
     "quickDraftTitle": "Quick Draft",
+    "sealedTitle": "Sealed",
     "setDraftTab": "Set Draft",
     "cubeTab": "Cube"
   },
@@ -264,6 +265,8 @@
     "kindPremierDesc": "Best-of-One-Turnierpartien nach dem Deckbau. Schnellere Runden, kein Sideboarding zwischen den Spielen.",
     "kindTraditional": "Traditional",
     "kindTraditionalDesc": "Best-of-Three-Turnierpartien nach dem Deckbau, mit Sideboarding zwischen den Spielen.",
+    "kindSealed": "Sealed",
+    "kindSealedDesc": "Öffne sechs Booster direkt für den Pool jedes Spielers und baue dann ein Best-of-One-Turnierdeck.",
     "tournamentFormat": "Turnierformat",
     "tournamentSwiss": "Schweizer System",
     "tournamentSwissDesc": "Alle spielen drei Runden lang weiter, auch nach einer Niederlage.",

--- a/client/src/i18n/locales/en/draft.json
+++ b/client/src/i18n/locales/en/draft.json
@@ -239,6 +239,7 @@
   "page": {
     "cubeDraftTitle": "Cube Draft",
     "quickDraftTitle": "Quick Draft",
+    "sealedTitle": "Sealed",
     "setDraftTab": "Set Draft",
     "cubeTab": "Cube"
   },
@@ -264,6 +265,8 @@
     "kindPremierDesc": "Best-of-one tournament matches after deckbuilding. Faster rounds, no sideboarding between games.",
     "kindTraditional": "Traditional",
     "kindTraditionalDesc": "Best-of-three tournament matches after deckbuilding, with sideboarding between games.",
+    "kindSealed": "Sealed",
+    "kindSealedDesc": "Open six packs directly into each player's pool, then build a best-of-one tournament deck.",
     "tournamentFormat": "Tournament Format",
     "tournamentSwiss": "Swiss",
     "tournamentSwissDesc": "Everyone keeps playing through three rounds, even after a loss.",

--- a/client/src/i18n/locales/es/draft.json
+++ b/client/src/i18n/locales/es/draft.json
@@ -239,6 +239,7 @@
   "page": {
     "cubeDraftTitle": "Cube Draft",
     "quickDraftTitle": "Draft Rápido",
+    "sealedTitle": "Sellado",
     "setDraftTab": "Set Draft",
     "cubeTab": "Cube"
   },
@@ -264,6 +265,8 @@
     "kindPremierDesc": "Partidas de torneo al mejor de uno tras la construcción de mazo. Rondas más rápidas, sin banquillo entre juegos.",
     "kindTraditional": "Tradicional",
     "kindTraditionalDesc": "Partidas de torneo al mejor de tres tras la construcción de mazo, con banquillo entre juegos.",
+    "kindSealed": "Sellado",
+    "kindSealedDesc": "Abre seis sobres directamente en el pool de cada jugador y luego construye un mazo de torneo al mejor de uno.",
     "tournamentFormat": "Formato de torneo",
     "tournamentSwiss": "Suizo",
     "tournamentSwissDesc": "Todos siguen jugando durante tres rondas, incluso tras una derrota.",

--- a/client/src/i18n/locales/fr/draft.json
+++ b/client/src/i18n/locales/fr/draft.json
@@ -239,6 +239,7 @@
   "page": {
     "cubeDraftTitle": "Cube Draft",
     "quickDraftTitle": "Quick Draft",
+    "sealedTitle": "Scellé",
     "setDraftTab": "Draft d'extension",
     "cubeTab": "Cube"
   },
@@ -264,6 +265,8 @@
     "kindPremierDesc": "Matchs de tournoi en meilleur des un après la construction. Manches plus rapides, pas de réserve entre les parties.",
     "kindTraditional": "Traditionnel",
     "kindTraditionalDesc": "Matchs de tournoi en meilleur des trois après la construction, avec réserve entre les parties.",
+    "kindSealed": "Scellé",
+    "kindSealedDesc": "Ouvrez six boosters directement dans la réserve de chaque joueur, puis construisez un deck de tournoi en meilleur des un.",
     "tournamentFormat": "Format du tournoi",
     "tournamentSwiss": "Suisse",
     "tournamentSwissDesc": "Tout le monde continue de jouer sur trois manches, même après une défaite.",

--- a/client/src/i18n/locales/it/draft.json
+++ b/client/src/i18n/locales/it/draft.json
@@ -239,6 +239,7 @@
   "page": {
     "cubeDraftTitle": "Cube Draft",
     "quickDraftTitle": "Quick Draft",
+    "sealedTitle": "Sealed",
     "setDraftTab": "Set Draft",
     "cubeTab": "Cube"
   },
@@ -264,6 +265,8 @@
     "kindPremierDesc": "Partite di torneo al meglio di una dopo la costruzione del mazzo. Round più rapidi, niente sideboard tra le partite.",
     "kindTraditional": "Tradizionale",
     "kindTraditionalDesc": "Partite di torneo al meglio di tre dopo la costruzione del mazzo, con sideboard tra le partite.",
+    "kindSealed": "Sealed",
+    "kindSealedDesc": "Apri sei buste direttamente nel pool di ogni giocatore, poi costruisci un mazzo da torneo al meglio di una.",
     "tournamentFormat": "Formato torneo",
     "tournamentSwiss": "Svizzero",
     "tournamentSwissDesc": "Tutti continuano a giocare per tre round, anche dopo una sconfitta.",

--- a/client/src/i18n/locales/pl/draft.json
+++ b/client/src/i18n/locales/pl/draft.json
@@ -239,6 +239,7 @@
   "page": {
     "cubeDraftTitle": "Draft kostki",
     "quickDraftTitle": "Szybki draft",
+    "sealedTitle": "Sealed",
     "setDraftTab": "Draft dodatku",
     "cubeTab": "Kostka"
   },
@@ -264,6 +265,8 @@
     "kindPremierDesc": "Mecze turniejowe do jednej wygranej po budowaniu talii. Szybsze rundy, bez wymiany kart bocznych między grami.",
     "kindTraditional": "Tradycyjny",
     "kindTraditionalDesc": "Mecze turniejowe do dwóch wygranych po budowaniu talii, z wymianą kart bocznych między grami.",
+    "kindSealed": "Sealed",
+    "kindSealedDesc": "Otwórz sześć boosterów bezpośrednio do puli każdego gracza, a następnie zbuduj talię turniejową do jednej wygranej.",
     "tournamentFormat": "Format turnieju",
     "tournamentSwiss": "Szwajcarski",
     "tournamentSwissDesc": "Wszyscy grają przez trzy rundy, nawet po porażce.",

--- a/client/src/i18n/locales/pt/draft.json
+++ b/client/src/i18n/locales/pt/draft.json
@@ -239,6 +239,7 @@
   "page": {
     "cubeDraftTitle": "Cube Draft",
     "quickDraftTitle": "Quick Draft",
+    "sealedTitle": "Selado",
     "setDraftTab": "Set Draft",
     "cubeTab": "Cube"
   },
@@ -264,6 +265,8 @@
     "kindPremierDesc": "Partidas de torneio melhor de um após a montagem do deck. Rodadas mais rápidas, sem sideboarding entre os jogos.",
     "kindTraditional": "Tradicional",
     "kindTraditionalDesc": "Partidas de torneio melhor de três após a montagem do deck, com sideboarding entre os jogos.",
+    "kindSealed": "Selado",
+    "kindSealedDesc": "Abra seis boosters diretamente no pool de cada jogador e depois monte um deck de torneio melhor de um.",
     "tournamentFormat": "Formato do Torneio",
     "tournamentSwiss": "Suíço",
     "tournamentSwissDesc": "Todos continuam jogando por três rodadas, mesmo após uma derrota.",

--- a/client/src/network/__tests__/draftProtocol.test.ts
+++ b/client/src/network/__tests__/draftProtocol.test.ts
@@ -10,8 +10,8 @@ import type { DraftP2PMessage } from "../draftProtocol";
 
 describe("draftProtocol", () => {
   describe("DRAFT_PROTOCOL_VERSION", () => {
-    it("is version 7", () => {
-      expect(DRAFT_PROTOCOL_VERSION).toBe(7);
+    it("is version 8", () => {
+      expect(DRAFT_PROTOCOL_VERSION).toBe(8);
     });
   });
 

--- a/client/src/network/draftProtocol.ts
+++ b/client/src/network/draftProtocol.ts
@@ -38,8 +38,9 @@ import type {
  *   5 — bind match settlement to a durable pod-issued capability
  *   6 — durable authorized Bo3 intergame command ledger
  *   7 — forward authenticated match-host between-games observations
+ *   8 — add Sealed event kind and deckbuilding-first start flow
  */
-export const DRAFT_PROTOCOL_VERSION = 7 as const;
+export const DRAFT_PROTOCOL_VERSION = 8 as const;
 
 /**
  * Typed reason for a draft pause, used over the wire and on the i18n key path.

--- a/client/src/pages/DraftLandingPage.tsx
+++ b/client/src/pages/DraftLandingPage.tsx
@@ -225,6 +225,7 @@ function ActiveDraftCard({ meta }: { meta: ActiveQuickDraftMeta }) {
       case "complete":
         return t("quickPhase.runComplete", { wins: meta.runWins ?? 0, losses: meta.runLosses ?? 0 });
     }
+    return t("quickPhase.drafting");
   }
 
   function handleClick() {

--- a/client/src/pages/DraftPage.tsx
+++ b/client/src/pages/DraftPage.tsx
@@ -31,7 +31,7 @@ const FORMAT_OPTIONS: Array<{ value: DraftRunFormat; labelKey: string; descKey: 
 
 type DraftSetupMode = "set" | "cube";
 
-function FormatPicker({ onLaunch, sealed }: { onLaunch: () => void; sealed: boolean }) {
+function FormatPicker({ onLaunch, supportsBo3 }: { onLaunch: () => void; supportsBo3: boolean }) {
   const { t } = useTranslation("draft");
   const runFormat = useDraftStore((s) => s.runFormat);
   const setRunFormat = useDraftStore((s) => s.setRunFormat);
@@ -44,7 +44,7 @@ function FormatPicker({ onLaunch, sealed }: { onLaunch: () => void; sealed: bool
       </div>
 
       <div className="flex w-full max-w-lg flex-col gap-3">
-        {(sealed ? FORMAT_OPTIONS.filter((opt) => opt.value === "single") : FORMAT_OPTIONS).map((opt) => (
+        {(supportsBo3 ? FORMAT_OPTIONS : FORMAT_OPTIONS.filter((opt) => opt.value !== "bo3")).map((opt) => (
           <button
             key={opt.value}
             type="button"
@@ -312,7 +312,6 @@ export function DraftPage() {
     requestedSetupMode === "cube" ? "cube" : "set",
   );
   const [localKind, setLocalKind] = useState<LocalDraftKind>("Quick");
-  const draftKind = useDraftStore((s) => s.kind);
 
   useEffect(() => {
     if (searchParams.get("resume") !== "1") return;
@@ -426,7 +425,7 @@ export function DraftPage() {
             {setupMode === "set" ? (
               <div className="flex flex-col gap-6">
                 <div className="flex items-center gap-4 text-sm text-white/70">
-                  <label className="flex items-center gap-2">
+                  <label className="flex min-h-11 items-center gap-2 py-2">
                     <input
                       type="radio"
                       name="localDraftKind"
@@ -435,7 +434,7 @@ export function DraftPage() {
                     />
                     {t("page.quickDraftTitle")}
                   </label>
-                  <label className="flex items-center gap-2">
+                  <label className="flex min-h-11 items-center gap-2 py-2">
                     <input
                       type="radio"
                       name="localDraftKind"
@@ -487,7 +486,10 @@ export function DraftPage() {
         )}
 
         {phase === "launching" && (
-          <FormatPicker onLaunch={handleLaunchMatch} sealed={draftKind === "Sealed"} />
+          <FormatPicker
+            onLaunch={handleLaunchMatch}
+            supportsBo3={draftView?.match_config.match_type === "Bo3"}
+          />
         )}
 
         {!resumeLoading && phase === "playing" && (

--- a/client/src/pages/DraftPage.tsx
+++ b/client/src/pages/DraftPage.tsx
@@ -3,7 +3,7 @@ import { useTranslation } from "react-i18next";
 import { motion } from "framer-motion";
 import { useNavigate, useSearchParams } from "react-router";
 
-import { useDraftStore } from "../stores/draftStore";
+import { useDraftStore, type LocalDraftKind } from "../stores/draftStore";
 import type { CardHoverInfo } from "../components/card/CardPreview";
 import { HoverCardPreview } from "../components/card/HoverCardPreview";
 import { BotDifficultySelector } from "../components/draft/BotDifficultySelector";
@@ -31,7 +31,7 @@ const FORMAT_OPTIONS: Array<{ value: DraftRunFormat; labelKey: string; descKey: 
 
 type DraftSetupMode = "set" | "cube";
 
-function FormatPicker({ onLaunch }: { onLaunch: () => void }) {
+function FormatPicker({ onLaunch, sealed }: { onLaunch: () => void; sealed: boolean }) {
   const { t } = useTranslation("draft");
   const runFormat = useDraftStore((s) => s.runFormat);
   const setRunFormat = useDraftStore((s) => s.setRunFormat);
@@ -44,7 +44,7 @@ function FormatPicker({ onLaunch }: { onLaunch: () => void }) {
       </div>
 
       <div className="flex w-full max-w-lg flex-col gap-3">
-        {FORMAT_OPTIONS.map((opt) => (
+        {(sealed ? FORMAT_OPTIONS.filter((opt) => opt.value === "single") : FORMAT_OPTIONS).map((opt) => (
           <button
             key={opt.value}
             type="button"
@@ -311,6 +311,8 @@ export function DraftPage() {
   const [setupMode, setSetupMode] = useState<DraftSetupMode>(() =>
     requestedSetupMode === "cube" ? "cube" : "set",
   );
+  const [localKind, setLocalKind] = useState<LocalDraftKind>("Quick");
+  const draftKind = useDraftStore((s) => s.kind);
 
   useEffect(() => {
     if (searchParams.get("resume") !== "1") return;
@@ -343,7 +345,7 @@ export function DraftPage() {
 
   const handleStartDraft = useCallback(
     async (setCode: string, setName: string) => {
-      const { difficulty, startDraft } = useDraftStore.getState();
+      const { difficulty, startDraft, startSealedDraft } = useDraftStore.getState();
 
       const resp = await fetch(__DRAFT_POOLS_URL__);
       if (!resp.ok) throw new Error(`Failed to load draft pools: ${resp.status}`);
@@ -351,9 +353,13 @@ export function DraftPage() {
       const setPool = allPools[setCode.toLowerCase()] ?? allPools[setCode.toUpperCase()];
       if (!setPool) throw new Error(`No pool data for set: ${setCode}`);
 
-      await startDraft(JSON.stringify(setPool), setCode, setName, difficulty);
+      if (localKind === "Sealed") {
+        await startSealedDraft(JSON.stringify(setPool), setCode, setName, difficulty);
+      } else {
+        await startDraft(JSON.stringify(setPool), setCode, setName, difficulty);
+      }
     },
-    [],
+    [localKind],
   );
 
   const handleLaunchMatch = useCallback(async () => {
@@ -395,7 +401,11 @@ export function DraftPage() {
         {!resumeLoading && phase === "setup" && (
           <div className="mx-auto w-full max-w-4xl">
             <h1 className="mb-8 menu-display text-3xl text-white">
-              {setupMode === "cube" ? t("page.cubeDraftTitle") : t("page.quickDraftTitle")}
+              {setupMode === "cube"
+                ? t("page.cubeDraftTitle")
+                : localKind === "Sealed"
+                  ? t("page.sealedTitle")
+                  : t("page.quickDraftTitle")}
             </h1>
             <div className="mb-5 inline-flex rounded-lg border border-white/10 bg-black/25 p-1">
               {(["set", "cube"] as const).map((mode) => (
@@ -414,7 +424,29 @@ export function DraftPage() {
               ))}
             </div>
             {setupMode === "set" ? (
-              <SetSelector onStartDraft={handleStartDraft} />
+              <div className="flex flex-col gap-6">
+                <div className="flex items-center gap-4 text-sm text-white/70">
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="localDraftKind"
+                      checked={localKind === "Quick"}
+                      onChange={() => setLocalKind("Quick")}
+                    />
+                    {t("page.quickDraftTitle")}
+                  </label>
+                  <label className="flex items-center gap-2">
+                    <input
+                      type="radio"
+                      name="localDraftKind"
+                      checked={localKind === "Sealed"}
+                      onChange={() => setLocalKind("Sealed")}
+                    />
+                    {t("page.sealedTitle")}
+                  </label>
+                </div>
+                <SetSelector onStartDraft={handleStartDraft} />
+              </div>
             ) : (
               <div className="flex flex-col gap-6">
                 <BotDifficultySelector />
@@ -455,7 +487,7 @@ export function DraftPage() {
         )}
 
         {phase === "launching" && (
-          <FormatPicker onLaunch={handleLaunchMatch} />
+          <FormatPicker onLaunch={handleLaunchMatch} sealed={draftKind === "Sealed"} />
         )}
 
         {!resumeLoading && phase === "playing" && (

--- a/client/src/pages/DraftPodPage.tsx
+++ b/client/src/pages/DraftPodPage.tsx
@@ -167,7 +167,7 @@ function PodSetup() {
             {t("podSetup.draftType")}
           </label>
           <div className="flex gap-4">
-            <label className="flex items-center gap-2 text-sm text-white/70">
+            <label className="flex min-h-11 items-center gap-2 py-2 text-sm text-white/70">
               <input
                 type="radio"
                 name="draftKind"

--- a/client/src/pages/DraftPodPage.tsx
+++ b/client/src/pages/DraftPodPage.tsx
@@ -61,9 +61,11 @@ function PodSetup() {
   const poolMode = useDraftPodStore((s) => s.poolMode);
   const setPoolMode = useDraftPodStore((s) => s.setPoolMode);
   const setCubeForm = useDraftPodStore((s) => s.setCubeForm);
-  const kindDescription = config.kind === "Premier"
-    ? t("podSetup.kindPremierDesc")
-    : t("podSetup.kindTraditionalDesc");
+  const kindDescription = {
+    Premier: t("podSetup.kindPremierDesc"),
+    Traditional: t("podSetup.kindTraditionalDesc"),
+    Sealed: t("podSetup.kindSealedDesc"),
+  }[config.kind];
   const tournamentDescription = config.tournamentFormat === "Swiss"
     ? t("podSetup.tournamentSwissDesc")
     : t("podSetup.tournamentEliminationDesc");
@@ -185,6 +187,16 @@ function PodSetup() {
               />
               {t("podSetup.kindTraditional")}
             </label>
+            <label className="flex items-center gap-2 text-sm text-white/70">
+              <input
+                type="radio"
+                name="draftKind"
+                checked={config.kind === "Sealed"}
+                onChange={() => setConfig({ kind: "Sealed" })}
+                className="accent-emerald-400"
+              />
+              {t("podSetup.kindSealed")}
+            </label>
           </div>
           <p className="text-xs text-white/40">{kindDescription}</p>
         </div>
@@ -283,6 +295,7 @@ function PodSetup() {
           <button
             type="button"
             onClick={() => setPoolMode("cube")}
+            disabled={config.kind === "Sealed"}
             className={
               poolMode === "cube"
                 ? "border-b-2 border-emerald-400 px-4 py-2 text-sm font-medium text-white"
@@ -293,7 +306,7 @@ function PodSetup() {
           </button>
         </div>
 
-        {poolMode === "set" ? (
+        {poolMode === "set" || config.kind === "Sealed" ? (
           <>
             {/* Set selector — reuse the Quick Draft component */}
             <div className="rounded-[16px] border border-white/8 bg-white/3 px-4 py-3 text-sm text-white/45">

--- a/client/src/services/draftPersistence.ts
+++ b/client/src/services/draftPersistence.ts
@@ -12,7 +12,7 @@
 
 import { createStore, del, get, set } from "idb-keyval";
 
-import type { PoolInput } from "../adapter/draft-adapter";
+import type { DraftKind, PoolInput } from "../adapter/draft-adapter";
 import type { DraftMatchBinding, DraftMatchLaunch, DraftMatchSettlement } from "../network/draftProtocol";
 import { ACTIVE_DRAFT_POD_KEY } from "../constants/storage";
 import type { DraftIntergameCommand } from "./intergameCommandLedger";
@@ -30,7 +30,7 @@ export type { PoolInput } from "../adapter/draft-adapter";
 export interface PersistedDraftHostSession {
   persistenceId: string;
   roomCode: string;
-  kind: "Premier" | "Traditional";
+  kind: Exclude<DraftKind, "Quick">;
   podSize: number;
   hostDisplayName: string;
   tournamentFormat: "Swiss" | "SingleElimination";
@@ -104,7 +104,7 @@ export type ActiveDraftPodPhase =
 export interface ActiveDraftPodMeta {
   id: string;
   roomCode: string;
-  kind: "Premier" | "Traditional";
+  kind: Exclude<DraftKind, "Quick">;
   podSize: number;
   hostDisplayName: string;
   tournamentFormat: "Swiss" | "SingleElimination";

--- a/client/src/services/quickDraftPersistence.ts
+++ b/client/src/services/quickDraftPersistence.ts
@@ -1,7 +1,7 @@
 import { del, get, set } from "idb-keyval";
 
 import { ACTIVE_QUICK_DRAFT_KEY, DRAFT_RUN_KEY_PREFIX, QUICK_DRAFT_KEY_PREFIX } from "../constants/storage";
-import type { DraftPhase, PoolSortMode } from "../stores/draftStore";
+import type { DraftPhase, LocalDraftKind, PoolSortMode } from "../stores/draftStore";
 import { getDraftStore } from "./draftPersistence";
 
 // ── Types ──────────────────────────────────────────────────────────────
@@ -13,7 +13,9 @@ export interface ActiveQuickDraftMeta {
   setCode: string;
   setName?: string;
   difficulty: number;
-  phase: "drafting" | "deckbuilding" | "playing" | "complete";
+  /** Defaults to Quick for snapshots created before local Sealed existed. */
+  kind?: LocalDraftKind;
+  phase: "drafting" | "deckbuilding" | "launching" | "playing" | "complete";
   pickCount: number;
   updatedAt: number;
   runFormat?: DraftRunFormat;

--- a/client/src/stores/__tests__/multiplayerDraftStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerDraftStore.test.ts
@@ -91,6 +91,7 @@ function mockView(status: string): DraftPlayerView {
     tournament_format: "Swiss",
     pod_policy: "Competitive",
     pairings: [],
+    match_config: { match_type: "Bo1" },
   };
 }
 

--- a/client/src/stores/draftPodStore.ts
+++ b/client/src/stores/draftPodStore.ts
@@ -16,7 +16,7 @@
 
 import { create } from "zustand";
 
-import type { CubeDraftSettings, TournamentFormat, PodPolicy } from "../adapter/draft-adapter";
+import type { CubeDraftSettings, TournamentFormat, PodPolicy, DraftKind as CoreDraftKind } from "../adapter/draft-adapter";
 import type { DraftPodHostConfig } from "../adapter/draftPodHostAdapter";
 import type { DraftPodGuestConfig } from "../adapter/draftPodGuestAdapter";
 import {
@@ -28,7 +28,7 @@ import { useMultiplayerDraftStore } from "./multiplayerDraftStore";
 
 // ── Types ──────────────────────────────────────────────────────────────
 
-export type DraftKind = "Premier" | "Traditional";
+export type DraftKind = Exclude<CoreDraftKind, "Quick">;
 
 export type PoolMode = "set" | "cube";
 
@@ -137,6 +137,7 @@ export const useDraftPodStore = create<DraftPodState & DraftPodActions>()(
     setConfig: (partial) => {
       set((prev) => ({
         config: normalizePodConfig({ ...prev.config, ...partial }),
+        poolMode: partial.kind === "Sealed" ? "set" : prev.poolMode,
         configError: null,
       }));
     },

--- a/client/src/stores/draftPodStore.ts
+++ b/client/src/stores/draftPodStore.ts
@@ -137,7 +137,7 @@ export const useDraftPodStore = create<DraftPodState & DraftPodActions>()(
     setConfig: (partial) => {
       set((prev) => ({
         config: normalizePodConfig({ ...prev.config, ...partial }),
-        poolMode: partial.kind === "Sealed" ? "set" : prev.poolMode,
+        poolMode: (partial.kind ?? prev.config.kind) === "Sealed" ? "set" : prev.poolMode,
         configError: null,
       }));
     },
@@ -159,7 +159,10 @@ export const useDraftPodStore = create<DraftPodState & DraftPodActions>()(
     },
 
     setPoolMode: (mode) => {
-      set({ poolMode: mode, configError: null });
+      set((prev) => ({
+        poolMode: prev.config.kind === "Sealed" ? "set" : mode,
+        configError: null,
+      }));
     },
 
     setCubeForm: (form) => {
@@ -168,6 +171,11 @@ export const useDraftPodStore = create<DraftPodState & DraftPodActions>()(
 
     createPod: async () => {
       const { config, hostDisplayName, poolMode, cubeForm } = get();
+
+      if (config.kind === "Sealed" && poolMode !== "set") {
+        set({ configError: "Sealed pods require a set pool" });
+        return;
+      }
 
       if (!hostDisplayName.trim()) {
         set({ configError: "Enter a display name" });

--- a/client/src/stores/draftStore.ts
+++ b/client/src/stores/draftStore.ts
@@ -527,7 +527,7 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
       const gameId = crypto.randomUUID();
       storeDraftDeckData(gameId, fullDeck, botFullDeck);
 
-      const matchType = kind === "Sealed" || runFormat !== "bo3" ? "bo1" : "bo3";
+      const matchType = view?.match_config.match_type === "Bo3" && runFormat === "bo3" ? "bo3" : "bo1";
 
       const newRunState: DraftRunState = {
         format: runFormat,
@@ -613,7 +613,7 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
       const gameId = crypto.randomUUID();
       storeDraftDeckData(gameId, runState.playerDeck, botFullDeck);
 
-      const matchType = kind === "Sealed" || runFormat !== "bo3" ? "bo1" : "bo3";
+      const matchType = view?.match_config.match_type === "Bo3" && runFormat === "bo3" ? "bo3" : "bo1";
 
       const usedBotSeats = runState.usedBotSeats.length >= 7
         ? [botSeat]

--- a/client/src/stores/draftStore.ts
+++ b/client/src/stores/draftStore.ts
@@ -28,6 +28,7 @@ import type {
 // ── Types ───────────────────────────────────────────────────────────────
 
 export type DraftPhase = "setup" | "drafting" | "deckbuilding" | "launching" | "playing" | "complete";
+export type LocalDraftKind = "Quick" | "Sealed";
 export type PoolSortMode = "color" | "type" | "cmc";
 
 interface DraftStoreState {
@@ -39,6 +40,7 @@ interface DraftStoreState {
   difficulty: number;
   selectedSet: string | null;
   selectedSetName: string | null;
+  kind: LocalDraftKind;
   mainDeck: string[];
   landCounts: Record<string, number>;
   poolSortMode: PoolSortMode;
@@ -49,6 +51,7 @@ interface DraftStoreState {
 
 interface DraftStoreActions {
   startDraft: (setPoolJson: string, setCode: string, setName: string, difficulty: number) => Promise<void>;
+  startSealedDraft: (setPoolJson: string, setCode: string, setName: string, difficulty: number) => Promise<void>;
   startCubeDraft: (cubeListText: string, cubeName: string, settings: CubeDraftSettings, difficulty: number) => Promise<void>;
   resumeDraft: () => Promise<void>;
   abandonDraft: () => Promise<void>;
@@ -85,6 +88,7 @@ const initialState: DraftStoreState = {
   difficulty: 2,
   selectedSet: null,
   selectedSetName: null,
+  kind: "Quick",
   mainDeck: [],
   landCounts: {},
   poolSortMode: "color",
@@ -142,9 +146,9 @@ function pickBotSeat(usedSeats: number[], view: DraftPlayerView | null): number 
 let debounceTimer: ReturnType<typeof setTimeout> | null = null;
 
 function persistDraft(): void {
-  const { adapter, draftId, phase, view, mainDeck, landCounts, poolSortMode, poolPanelOpen, difficulty, selectedSet, selectedSetName } =
+  const { adapter, draftId, phase, view, mainDeck, landCounts, poolSortMode, poolPanelOpen, difficulty, selectedSet, selectedSetName, kind } =
     useDraftStore.getState();
-  if (!adapter || !draftId || !selectedSet || phase === "setup" || phase === "launching" || phase === "playing" || phase === "complete") return;
+  if (!adapter || !draftId || !selectedSet || phase === "setup" || phase === "playing" || phase === "complete") return;
   const persistPhase = phase;
 
   void (async () => {
@@ -162,6 +166,7 @@ function persistDraft(): void {
         setCode: selectedSet,
         setName: selectedSetName ?? undefined,
         difficulty,
+        kind,
         phase: persistPhase,
         pickCount: view?.pool.length ?? 0,
         updatedAt: Date.now(),
@@ -217,12 +222,44 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
         difficulty,
         selectedSet: setCode,
         selectedSetName: setName,
+        kind: "Quick",
         selectedCard: null,
         mainDeck: [],
         landCounts: {},
         runState: null,
       });
 
+      persistDraft();
+    },
+
+    startSealedDraft: async (setPoolJson, setCode, setName, difficulty) => {
+      const oldMeta = loadActiveQuickDraft();
+      if (oldMeta) void clearDraftRun(oldMeta.id);
+
+      const adapter = new DraftAdapter();
+      const resp = await fetch(__CARD_DATA_URL__);
+      await adapter.loadCardDatabase(await resp.text());
+      const view = await adapter.initializeSealed(
+        setPoolJson,
+        difficulty,
+        Math.floor(Math.random() * 0xffffffff),
+      );
+      const draftId = crypto.randomUUID();
+      set({
+        draftId,
+        adapter,
+        view,
+        phase: view.status === "Deckbuilding" ? "deckbuilding" : "drafting",
+        difficulty,
+        selectedSet: setCode,
+        selectedSetName: setName,
+        kind: "Sealed",
+        selectedCard: null,
+        mainDeck: [],
+        landCounts: {},
+        runFormat: "single",
+        runState: null,
+      });
       persistDraft();
     },
 
@@ -249,6 +286,7 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
         difficulty,
         selectedSet: "custom-cube",
         selectedSetName: cubeName,
+        kind: "Quick",
         selectedCard: null,
         mainDeck: [],
         landCounts: {},
@@ -281,7 +319,7 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
 
         const adapter = new DraftAdapter();
 
-        if (meta.difficulty >= 3) {
+        if (meta.difficulty >= 3 || meta.kind === "Sealed") {
           const resp = await fetch(__CARD_DATA_URL__);
           const json = await resp.text();
           await adapter.loadCardDatabase(json);
@@ -293,16 +331,21 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
           draftId: meta.id,
           adapter,
           view,
-          phase: meta.phase,
+          phase: view.status === "Deckbuilding"
+            ? "deckbuilding"
+            : view.status === "Pairing"
+              ? "launching"
+              : meta.phase,
           difficulty: meta.difficulty,
           selectedSet: meta.setCode,
           selectedSetName: meta.setName ?? null,
+          kind: meta.kind ?? "Quick",
           selectedCard: null,
           mainDeck: saved.mainDeck,
           landCounts: saved.landCounts,
           poolSortMode: saved.poolSortMode,
           poolPanelOpen: saved.poolPanelOpen,
-          runFormat: run.format,
+          runFormat: meta.kind === "Sealed" ? "single" : run.format,
           runState: run,
         });
         return;
@@ -317,7 +360,7 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
       try {
         const adapter = new DraftAdapter();
 
-        if (meta.difficulty >= 3) {
+        if (meta.difficulty >= 3 || meta.kind === "Sealed") {
           const resp = await fetch(__CARD_DATA_URL__);
           const json = await resp.text();
           await adapter.loadCardDatabase(json);
@@ -329,16 +372,21 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
           draftId: meta.id,
           adapter,
           view,
-          phase: meta.phase,
+          phase: view.status === "Deckbuilding"
+            ? "deckbuilding"
+            : view.status === "Pairing"
+              ? "launching"
+              : meta.phase,
           difficulty: meta.difficulty,
           selectedSet: meta.setCode,
           selectedSetName: meta.setName ?? null,
+          kind: meta.kind ?? "Quick",
           selectedCard: null,
           mainDeck: saved.mainDeck,
           landCounts: saved.landCounts,
           poolSortMode: saved.poolSortMode,
           poolPanelOpen: saved.poolPanelOpen,
-          runFormat: run?.format ?? "run",
+          runFormat: meta.kind === "Sealed" ? "single" : run?.format ?? "run",
           runState: run,
         });
       } catch (err) {
@@ -436,7 +484,8 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
 
       const fullDeck = [...mainDeck, ...landCards];
       const view = await adapter.submitDeck(fullDeck);
-      set({ view, phase: "launching" });
+      set({ view, phase: view.status === "Deckbuilding" ? "deckbuilding" : "launching" });
+      persistDraft();
     },
 
     setPoolSortMode: (mode) => {
@@ -462,7 +511,7 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
     },
 
     launchMatch: async (navigate) => {
-      const { adapter, mainDeck, landCounts, difficulty, draftId, selectedSet, selectedSetName, runFormat, view } = get();
+      const { adapter, mainDeck, landCounts, difficulty, draftId, selectedSet, selectedSetName, runFormat, view, kind } = get();
       if (!adapter || !draftId || !selectedSet) return;
 
       const fullDeck = [...mainDeck, ...expandLands(landCounts)];
@@ -478,7 +527,7 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
       const gameId = crypto.randomUUID();
       storeDraftDeckData(gameId, fullDeck, botFullDeck);
 
-      const matchType = runFormat === "bo3" ? "bo3" : "bo1";
+      const matchType = kind === "Sealed" || runFormat !== "bo3" ? "bo1" : "bo3";
 
       const newRunState: DraftRunState = {
         format: runFormat,
@@ -496,6 +545,7 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
         setCode: selectedSet,
         setName: selectedSetName ?? undefined,
         difficulty,
+        kind,
         phase: "playing",
         pickCount: get().view?.pool.length ?? 0,
         updatedAt: Date.now(),
@@ -548,7 +598,7 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
     },
 
     launchNextMatch: async (navigate) => {
-      const { adapter, draftId, selectedSet, selectedSetName, difficulty, runState, runFormat, view } = get();
+      const { adapter, draftId, selectedSet, selectedSetName, difficulty, runState, runFormat, view, kind } = get();
       if (!adapter || !draftId || !selectedSet || !runState) return;
 
       const botSeat = pickBotSeat(runState.usedBotSeats, view);
@@ -563,7 +613,7 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
       const gameId = crypto.randomUUID();
       storeDraftDeckData(gameId, runState.playerDeck, botFullDeck);
 
-      const matchType = runFormat === "bo3" ? "bo3" : "bo1";
+      const matchType = kind === "Sealed" || runFormat !== "bo3" ? "bo1" : "bo3";
 
       const usedBotSeats = runState.usedBotSeats.length >= 7
         ? [botSeat]
@@ -582,6 +632,7 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()(
         setCode: selectedSet,
         setName: selectedSetName ?? undefined,
         difficulty,
+        kind,
         phase: "playing",
         pickCount: get().view?.pool.length ?? 0,
         updatedAt: Date.now(),

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -1086,10 +1086,12 @@ function handleHostEvent(event: DraftPodHostEvent, set: SetFn): void {
       break;
     case "lobbyFull":
       break;
-    case "draftStarted":
-      set({ view: event.view, phase: "drafting" });
-      saveDraftPodProgress("drafting", event.view);
+    case "draftStarted": {
+      const activePhase = activePhaseForDraftViewStatus(event.view.status);
+      set({ view: event.view, phase: phaseForDraftViewStatus(event.view.status) });
+      if (activePhase) saveDraftPodProgress(activePhase, event.view);
       break;
+    }
     case "draftComplete":
       set({ phase: "deckbuilding" });
       saveDraftPodProgress("deckbuilding");

--- a/client/src/wasm/draft_wasm.d.ts
+++ b/client/src/wasm/draft_wasm.d.ts
@@ -30,15 +30,15 @@ export function auto_pick(): any;
 
 /**
  * Create a multiplayer draft session. Used by the P2P host to initialize a
- * Premier or Traditional draft with human + bot seats from either a Set pool
+ * Premier, Traditional, or Sealed draft with human + bot seats from either a Set pool
  * or a custom Cube list.
  *
  * - `pool_input_json`: serialized `PoolInput` discriminated union
  *   (`{ "type": "Set" | "Cube", "data": { ... } }`)
  * - `seats_json`: JSON array of SeatDescriptors
- * - `kind`: 0=Quick, 1=Premier, 2=Traditional. The user-selected DraftKind
+ * - `kind`: 0=Quick, 1=Premier, 2=Traditional, 3=Sealed. The user-selected DraftKind
  *   flows through to `DraftConfig.kind` unchanged. Tournament match format
- *   (Bo1 for Premier, Bo3 for Traditional) is identical to set drafts.
+ *   (Bo1 for Premier and Sealed, Bo3 for Traditional) is identical to set drafts.
  * - `seed`: RNG seed for deterministic pack generation
  * - `draft_code`: unique room identifier
  *
@@ -122,18 +122,6 @@ export function load_card_database(json_str: string): number;
 export function set_seat_connected(seat: number, connected: boolean): any;
 
 /**
- * Start a multiplayer draft session (Premier or Traditional).
- *
- * - `set_pool_json`: serialized LimitedSetPool
- * - `kind`: "Premier" or "Traditional"
- * - `seat_names_json`: JSON array of display names, one per seat (length = pod size)
- * - `seed`: RNG seed for deterministic pack generation
- *
- * Returns the DraftPlayerView for seat 0 (the host).
- */
-export function start_multiplayer_draft(set_pool_json: string, kind: string, seat_names_json: string, seed: number): any;
-
-/**
  * Start a Quick Cube Draft session from a counted cube list.
  */
 export function start_quick_cube_draft(cube_list_text: string, cube_name: string, settings_json: string, difficulty: number, seed: number): any;
@@ -148,6 +136,12 @@ export function start_quick_cube_draft(cube_list_text: string, cube_name: string
  * Returns the initial DraftPlayerView as a JS object.
  */
 export function start_quick_draft(set_pool_json: string, difficulty: number, seed: number): any;
+
+/**
+ * Start a local Sealed event: one human and seven bots each open six packs,
+ * then deckbuilding begins immediately.
+ */
+export function start_sealed_draft(set_pool_json: string, difficulty: number, seed: number): any;
 
 /**
  * Submit the human player's deck for limited play.
@@ -213,9 +207,9 @@ export interface InitOutput {
     readonly import_draft_session: (a: number, b: number, c: number) => [number, number, number];
     readonly load_card_database: (a: number, b: number) => [number, number, number];
     readonly set_seat_connected: (a: number, b: number) => [number, number, number];
-    readonly start_multiplayer_draft: (a: number, b: number, c: number, d: number, e: number, f: number, g: number) => [number, number, number];
     readonly start_quick_cube_draft: (a: number, b: number, c: number, d: number, e: number, f: number, g: number, h: number) => [number, number, number];
     readonly start_quick_draft: (a: number, b: number, c: number, d: number) => [number, number, number];
+    readonly start_sealed_draft: (a: number, b: number, c: number, d: number) => [number, number, number];
     readonly submit_deck: (a: number, b: number) => [number, number, number];
     readonly submit_deck_for_seat: (a: number, b: number, c: number) => [number, number, number];
     readonly submit_pick: (a: number, b: number) => [number, number, number];

--- a/crates/draft-core/src/session.rs
+++ b/crates/draft-core/src/session.rs
@@ -163,7 +163,10 @@ fn apply_generate_pairings(
             action: "GeneratePairings".to_string(),
         });
     }
-    if session.config.tournament_format == TournamentFormat::SingleElimination
+    if matches!(
+        session.kind,
+        DraftKind::Premier | DraftKind::Traditional | DraftKind::Sealed
+    ) && session.config.tournament_format == TournamentFormat::SingleElimination
         && session.seats.len() != 8
     {
         return Err(DraftError::UnsupportedTournamentSize {
@@ -595,20 +598,26 @@ fn apply_start_draft(
     }
 
     let seat_count = session.seats.len() as u8;
-    let valid_size = match session.config.tournament_format {
-        TournamentFormat::Swiss => (2..=8).contains(&seat_count),
-        TournamentFormat::SingleElimination => seat_count == 8,
-    };
-    if !valid_size {
-        return Err(DraftError::UnsupportedTournamentSize {
-            format: session.config.tournament_format,
-            required: if session.config.tournament_format == TournamentFormat::SingleElimination {
-                8
-            } else {
-                2
-            },
-            actual: seat_count,
-        });
+    if matches!(
+        session.kind,
+        DraftKind::Premier | DraftKind::Traditional | DraftKind::Sealed
+    ) {
+        let valid_size = match session.config.tournament_format {
+            TournamentFormat::Swiss => (2..=8).contains(&seat_count),
+            TournamentFormat::SingleElimination => seat_count == 8,
+        };
+        if !valid_size {
+            return Err(DraftError::UnsupportedTournamentSize {
+                format: session.config.tournament_format,
+                required: if session.config.tournament_format == TournamentFormat::SingleElimination
+                {
+                    8
+                } else {
+                    2
+                },
+                actual: seat_count,
+            });
+        }
     }
     if session.kind == DraftKind::Sealed || session.config.kind == DraftKind::Sealed {
         if session.kind != DraftKind::Sealed || session.config.kind != DraftKind::Sealed {
@@ -836,6 +845,49 @@ mod tests {
         );
         assert_eq!(session.status, DraftStatus::Lobby);
         assert_eq!(session.pools, before);
+    }
+
+    #[test]
+    fn tournament_size_limits_apply_to_sealed_boundaries() {
+        for (format, pod_size, accepted) in [
+            (TournamentFormat::Swiss, 1, false),
+            (TournamentFormat::Swiss, 2, true),
+            (TournamentFormat::Swiss, 8, true),
+            (TournamentFormat::Swiss, 9, false),
+            (TournamentFormat::SingleElimination, 7, false),
+            (TournamentFormat::SingleElimination, 8, true),
+            (TournamentFormat::SingleElimination, 9, false),
+        ] {
+            let (mut session, source) = test_session(pod_size);
+            session.kind = DraftKind::Sealed;
+            session.config.kind = DraftKind::Sealed;
+            session.config.pack_count = 6;
+            session.config.tournament_format = format;
+
+            assert_eq!(
+                apply(&mut session, DraftAction::StartDraft, Some(&source)).is_ok(),
+                accepted,
+                "{format:?} with {pod_size} seats"
+            );
+        }
+    }
+
+    #[test]
+    fn quick_cube_allows_single_and_large_pods() {
+        for pod_size in [1, 9, 16] {
+            let (mut session, source) = test_session(pod_size);
+            session.kind = DraftKind::Quick;
+            session.config.kind = DraftKind::Quick;
+            session.config.source = DraftSource::Cube {
+                id: "cube".to_string(),
+                name: "Cube".to_string(),
+            };
+
+            assert!(
+                apply(&mut session, DraftAction::StartDraft, Some(&source)).is_ok(),
+                "Quick Cube with {pod_size} seats should start"
+            );
+        }
     }
 
     #[test]

--- a/crates/draft-core/src/session.rs
+++ b/crates/draft-core/src/session.rs
@@ -69,6 +69,20 @@ impl DraftSession {
                 reason: "sealed requires six packs and a 40-card minimum deck".to_string(),
             });
         }
+        let valid_size = match self.config.tournament_format {
+            TournamentFormat::Swiss => (2..=8).contains(&(self.seats.len() as u8)),
+            TournamentFormat::SingleElimination => self.seats.len() == 8,
+        };
+        if !valid_size {
+            return Err(DraftError::InvalidSealedSnapshot {
+                reason: "sealed tournament size is invalid".to_string(),
+            });
+        }
+        if self.status == DraftStatus::Drafting {
+            return Err(DraftError::InvalidSealedSnapshot {
+                reason: "sealed sessions cannot be in drafting status".to_string(),
+            });
+        }
         let seat_count = self.seats.len();
         if self.config.pod_size as usize != seat_count
             || self.pools.len() != seat_count
@@ -960,6 +974,29 @@ mod tests {
         let (mut session, _) = test_session(2);
         session.kind = DraftKind::Sealed;
 
+        assert!(matches!(
+            session.validate_sealed_snapshot(),
+            Err(DraftError::InvalidSealedSnapshot { .. })
+        ));
+    }
+
+    #[test]
+    fn sealed_snapshot_rejects_invalid_tournament_size_and_drafting_status() {
+        let (mut session, _source) = test_session(1);
+        session.kind = DraftKind::Sealed;
+        session.config.kind = DraftKind::Sealed;
+        session.config.pack_count = 6;
+        assert!(matches!(
+            session.validate_sealed_snapshot(),
+            Err(DraftError::InvalidSealedSnapshot { .. })
+        ));
+
+        let (mut session, source) = test_session(2);
+        session.kind = DraftKind::Sealed;
+        session.config.kind = DraftKind::Sealed;
+        session.config.pack_count = 6;
+        apply(&mut session, DraftAction::StartDraft, Some(&source)).unwrap();
+        session.status = DraftStatus::Drafting;
         assert!(matches!(
             session.validate_sealed_snapshot(),
             Err(DraftError::InvalidSealedSnapshot { .. })

--- a/crates/draft-core/src/session.rs
+++ b/crates/draft-core/src/session.rs
@@ -41,6 +41,54 @@ impl DraftSession {
             updated_at: 0,
         }
     }
+
+    /// Validate the small set of invariants unique to persisted Sealed events.
+    ///
+    /// This is intentionally an import/restore boundary check. Reducer-created
+    /// sessions establish these properties at start and legacy `SeatFlags`
+    /// snapshots remain compatible because their bitmap lengths are unrelated.
+    pub fn validate_sealed_snapshot(&self) -> Result<(), DraftError> {
+        if self.kind != DraftKind::Sealed {
+            return Ok(());
+        }
+        if self.config.kind != DraftKind::Sealed {
+            return Err(DraftError::InvalidSealedSnapshot {
+                reason: "session kind does not match configuration".to_string(),
+            });
+        }
+        let DraftSource::Set { code } = &self.config.source else {
+            return Err(DraftError::SealedRequiresSetSource);
+        };
+        if code != &self.config.set_code || self.set_code != self.config.set_code {
+            return Err(DraftError::InvalidSealedSnapshot {
+                reason: "set source and session codes must match".to_string(),
+            });
+        }
+        if self.config.pack_count != 6 || self.config.min_deck_size != 40 {
+            return Err(DraftError::InvalidSealedSnapshot {
+                reason: "sealed requires six packs and a 40-card minimum deck".to_string(),
+            });
+        }
+        let seat_count = self.seats.len();
+        if self.config.pod_size as usize != seat_count
+            || self.pools.len() != seat_count
+            || self.current_pack.len() != seat_count
+            || self.packs_by_seat.len() != seat_count
+        {
+            return Err(DraftError::InvalidSealedSnapshot {
+                reason: "per-seat vectors do not match the core seats".to_string(),
+            });
+        }
+        if self.status != DraftStatus::Lobby
+            && (self.current_pack.iter().any(Option::is_some)
+                || self.packs_by_seat.iter().any(|packs| !packs.is_empty()))
+        {
+            return Err(DraftError::InvalidSealedSnapshot {
+                reason: "sealed packs must be retained only in player pools".to_string(),
+            });
+        }
+        Ok(())
+    }
 }
 
 /// Apply a draft action to the session, returning deltas or an error.
@@ -546,11 +594,71 @@ fn apply_start_draft(
         });
     }
 
+    let seat_count = session.seats.len() as u8;
+    let valid_size = match session.config.tournament_format {
+        TournamentFormat::Swiss => (2..=8).contains(&seat_count),
+        TournamentFormat::SingleElimination => seat_count == 8,
+    };
+    if !valid_size {
+        return Err(DraftError::UnsupportedTournamentSize {
+            format: session.config.tournament_format,
+            required: if session.config.tournament_format == TournamentFormat::SingleElimination {
+                8
+            } else {
+                2
+            },
+            actual: seat_count,
+        });
+    }
+    if session.kind == DraftKind::Sealed || session.config.kind == DraftKind::Sealed {
+        if session.kind != DraftKind::Sealed || session.config.kind != DraftKind::Sealed {
+            return Err(DraftError::InvalidSealedConfiguration {
+                reason: "session kind does not match configuration".to_string(),
+            });
+        }
+        let DraftSource::Set { code } = &session.config.source else {
+            return Err(DraftError::SealedRequiresSetSource);
+        };
+        if code != &session.config.set_code || session.set_code != session.config.set_code {
+            return Err(DraftError::InvalidSealedConfiguration {
+                reason: "set source and session codes must match".to_string(),
+            });
+        }
+        if session.config.pack_count != 6 || session.config.min_deck_size != 40 {
+            return Err(DraftError::InvalidSealedConfiguration {
+                reason: "sealed requires six packs and a 40-card minimum deck".to_string(),
+            });
+        }
+    }
+
     let pack_source = pack_source.expect("StartDraft requires a PackSource");
-    let pod_size = session.seats.len() as u8;
+    let pod_size = seat_count;
     let mut rng = ChaCha20Rng::seed_from_u64(session.config.rng_seed);
 
     let all_packs = pack_source.generate_packs(&mut rng, &session.config, pod_size)?;
+    if session.kind == DraftKind::Sealed {
+        if all_packs.len() != session.seats.len() || all_packs.iter().any(|packs| packs.len() != 6)
+        {
+            return Err(DraftError::InvalidSealedConfiguration {
+                reason: "pack source did not generate six packs per seat".to_string(),
+            });
+        }
+        let pools = all_packs
+            .into_iter()
+            .map(|packs| packs.into_iter().flat_map(|pack| pack.0).collect())
+            .collect();
+        session.pools = pools;
+        session.current_pack.fill(None);
+        session.packs_by_seat.iter_mut().for_each(Vec::clear);
+        session.status = DraftStatus::Deckbuilding;
+        return Ok(vec![
+            DraftDelta::DraftStarted,
+            DraftDelta::TransitionedTo {
+                status: DraftStatus::Deckbuilding,
+            },
+        ]);
+    }
+
     for (seat, mut seat_packs) in all_packs.into_iter().enumerate() {
         // First pack goes to current_pack, rest go to packs_by_seat
         session.current_pack[seat] = Some(seat_packs.remove(0));
@@ -638,7 +746,7 @@ fn apply_submit_deck(
         // Quick Draft (1 human) completes directly.
         let next_status = match session.kind {
             DraftKind::Quick => DraftStatus::Complete,
-            DraftKind::Premier | DraftKind::Traditional => DraftStatus::Pairing,
+            DraftKind::Premier | DraftKind::Traditional | DraftKind::Sealed => DraftStatus::Pairing,
         };
         session.status = next_status;
         deltas.push(DraftDelta::TransitionedTo {
@@ -683,6 +791,86 @@ mod tests {
         };
         let session = DraftSession::new(config, seats, "TEST-001".to_string());
         (session, source)
+    }
+
+    #[test]
+    fn sealed_atomically_allocates_six_packs_per_seat_and_enters_deckbuilding() {
+        let (mut session, source) = test_session(2);
+        session.kind = DraftKind::Sealed;
+        session.config.kind = DraftKind::Sealed;
+        session.config.pack_count = 6;
+
+        let deltas = apply(&mut session, DraftAction::StartDraft, Some(&source)).unwrap();
+
+        assert_eq!(session.status, DraftStatus::Deckbuilding);
+        assert_eq!(session.pools.len(), 2);
+        assert!(session.pools.iter().all(|pool| pool.len() == 84));
+        assert!(session.current_pack.iter().all(Option::is_none));
+        assert!(session.packs_by_seat.iter().all(Vec::is_empty));
+        assert_eq!(
+            deltas,
+            vec![
+                DraftDelta::DraftStarted,
+                DraftDelta::TransitionedTo {
+                    status: DraftStatus::Deckbuilding,
+                },
+            ]
+        );
+    }
+
+    #[test]
+    fn sealed_rejects_cube_source_without_mutating_pools() {
+        let (mut session, source) = test_session(2);
+        session.kind = DraftKind::Sealed;
+        session.config.kind = DraftKind::Sealed;
+        session.config.pack_count = 6;
+        session.config.source = DraftSource::Cube {
+            id: "cube".to_string(),
+            name: "Cube".to_string(),
+        };
+
+        let before = session.pools.clone();
+        assert_eq!(
+            apply(&mut session, DraftAction::StartDraft, Some(&source)),
+            Err(DraftError::SealedRequiresSetSource)
+        );
+        assert_eq!(session.status, DraftStatus::Lobby);
+        assert_eq!(session.pools, before);
+    }
+
+    #[test]
+    fn sealed_rejects_mismatched_set_code_before_generating_packs() {
+        let (mut session, source) = test_session(2);
+        session.kind = DraftKind::Sealed;
+        session.config.kind = DraftKind::Sealed;
+        session.config.pack_count = 6;
+        session.config.source = DraftSource::Set {
+            code: "OTHER".to_string(),
+        };
+
+        assert!(matches!(
+            apply(&mut session, DraftAction::StartDraft, Some(&source)),
+            Err(DraftError::InvalidSealedConfiguration { .. })
+        ));
+        assert_eq!(session.status, DraftStatus::Lobby);
+    }
+
+    #[test]
+    fn sealed_snapshot_rejects_retained_packs_but_allows_legacy_seat_flags() {
+        let (mut session, source) = test_session(2);
+        session.kind = DraftKind::Sealed;
+        session.config.kind = DraftKind::Sealed;
+        session.config.pack_count = 6;
+        apply(&mut session, DraftAction::StartDraft, Some(&source)).unwrap();
+        session.seats_picked_this_round = SeatFlags::default();
+        session.connected_seats = SeatFlags::default();
+        assert!(session.validate_sealed_snapshot().is_ok());
+
+        session.packs_by_seat[0].push(DraftPack(Vec::new()));
+        assert!(matches!(
+            session.validate_sealed_snapshot(),
+            Err(DraftError::InvalidSealedSnapshot { .. })
+        ));
     }
 
     #[test]

--- a/crates/draft-core/src/session.rs
+++ b/crates/draft-core/src/session.rs
@@ -48,13 +48,13 @@ impl DraftSession {
     /// sessions establish these properties at start and legacy `SeatFlags`
     /// snapshots remain compatible because their bitmap lengths are unrelated.
     pub fn validate_sealed_snapshot(&self) -> Result<(), DraftError> {
-        if self.kind != DraftKind::Sealed {
-            return Ok(());
-        }
-        if self.config.kind != DraftKind::Sealed {
+        if self.kind != self.config.kind {
             return Err(DraftError::InvalidSealedSnapshot {
                 reason: "session kind does not match configuration".to_string(),
             });
+        }
+        if self.kind != DraftKind::Sealed {
+            return Ok(());
         }
         let DraftSource::Set { code } = &self.config.source else {
             return Err(DraftError::SealedRequiresSetSource);
@@ -77,6 +77,20 @@ impl DraftSession {
         {
             return Err(DraftError::InvalidSealedSnapshot {
                 reason: "per-seat vectors do not match the core seats".to_string(),
+            });
+        }
+        let expected_pool_size =
+            usize::from(self.config.pack_count) * usize::from(self.config.cards_per_pack);
+        if self.status != DraftStatus::Lobby
+            && self
+                .pools
+                .iter()
+                .any(|pool| pool.len() != expected_pool_size)
+        {
+            return Err(DraftError::InvalidSealedSnapshot {
+                reason:
+                    "started sealed pools must contain exactly one card from each configured pack"
+                        .to_string(),
             });
         }
         if self.status != DraftStatus::Lobby
@@ -919,6 +933,33 @@ mod tests {
         assert!(session.validate_sealed_snapshot().is_ok());
 
         session.packs_by_seat[0].push(DraftPack(Vec::new()));
+        assert!(matches!(
+            session.validate_sealed_snapshot(),
+            Err(DraftError::InvalidSealedSnapshot { .. })
+        ));
+    }
+
+    #[test]
+    fn sealed_snapshot_rejects_started_pool_with_wrong_card_count() {
+        let (mut session, source) = test_session(2);
+        session.kind = DraftKind::Sealed;
+        session.config.kind = DraftKind::Sealed;
+        session.config.pack_count = 6;
+        apply(&mut session, DraftAction::StartDraft, Some(&source)).unwrap();
+
+        session.pools[0].pop();
+
+        assert!(matches!(
+            session.validate_sealed_snapshot(),
+            Err(DraftError::InvalidSealedSnapshot { .. })
+        ));
+    }
+
+    #[test]
+    fn sealed_snapshot_rejects_session_and_configuration_kind_mismatch() {
+        let (mut session, _) = test_session(2);
+        session.kind = DraftKind::Sealed;
+
         assert!(matches!(
             session.validate_sealed_snapshot(),
             Err(DraftError::InvalidSealedSnapshot { .. })

--- a/crates/draft-core/src/types.rs
+++ b/crates/draft-core/src/types.rs
@@ -60,6 +60,8 @@ pub enum DraftKind {
     Premier,
     /// Traditional Draft: 8 humans, Bo3 matches.
     Traditional,
+    /// Sealed: each player receives six unopened packs directly, Bo1 matches.
+    Sealed,
 }
 
 impl DraftKind {
@@ -72,14 +74,14 @@ impl DraftKind {
     pub fn human_seats(self) -> u8 {
         match self {
             DraftKind::Quick => 1,
-            DraftKind::Premier | DraftKind::Traditional => 8,
+            DraftKind::Premier | DraftKind::Traditional | DraftKind::Sealed => 8,
         }
     }
 
     /// Match configuration for this draft kind.
     pub fn match_config(self) -> MatchConfig {
         match self {
-            DraftKind::Quick | DraftKind::Premier => MatchConfig {
+            DraftKind::Quick | DraftKind::Premier | DraftKind::Sealed => MatchConfig {
                 match_type: MatchType::Bo1,
                 ..MatchConfig::default()
             },
@@ -440,6 +442,12 @@ pub enum DraftError {
     SeatAlreadyPickedThisRound { seat: u8 },
     #[error("seat {seat} is a bot — operation not applicable")]
     SeatIsBot { seat: u8 },
+    #[error("sealed events require a set source")]
+    SealedRequiresSetSource,
+    #[error("invalid sealed configuration: {reason}")]
+    InvalidSealedConfiguration { reason: String },
+    #[error("invalid sealed snapshot: {reason}")]
+    InvalidSealedSnapshot { reason: String },
 }
 
 /// Configuration for a draft session.
@@ -580,6 +588,7 @@ mod tests {
         assert_eq!(DraftKind::Quick.default_pod_size(), 8);
         assert_eq!(DraftKind::Premier.default_pod_size(), 8);
         assert_eq!(DraftKind::Traditional.default_pod_size(), 8);
+        assert_eq!(DraftKind::Sealed.default_pod_size(), 8);
     }
 
     #[test]
@@ -587,6 +596,7 @@ mod tests {
         assert_eq!(DraftKind::Quick.human_seats(), 1);
         assert_eq!(DraftKind::Premier.human_seats(), 8);
         assert_eq!(DraftKind::Traditional.human_seats(), 8);
+        assert_eq!(DraftKind::Sealed.human_seats(), 8);
     }
 
     #[test]
@@ -597,6 +607,7 @@ mod tests {
             DraftKind::Traditional.match_config().match_type,
             MatchType::Bo3
         );
+        assert_eq!(DraftKind::Sealed.match_config().match_type, MatchType::Bo1);
     }
 
     #[test]
@@ -623,7 +634,12 @@ mod tests {
 
     #[test]
     fn serde_roundtrip_draft_kind() {
-        for kind in [DraftKind::Quick, DraftKind::Premier, DraftKind::Traditional] {
+        for kind in [
+            DraftKind::Quick,
+            DraftKind::Premier,
+            DraftKind::Traditional,
+            DraftKind::Sealed,
+        ] {
             let json = serde_json::to_string(&kind).unwrap();
             let back: DraftKind = serde_json::from_str(&json).unwrap();
             assert_eq!(kind, back);

--- a/crates/draft-core/src/view.rs
+++ b/crates/draft-core/src/view.rs
@@ -49,7 +49,7 @@ pub struct SeatPublicView {
 pub struct DraftPlayerView {
     /// Current draft status
     pub status: DraftStatus,
-    /// Draft kind (Quick/Premier/Traditional)
+    /// Draft kind (Quick/Premier/Traditional/Sealed)
     pub kind: DraftKind,
     /// Which pack round (0, 1, 2)
     pub current_pack_number: u8,

--- a/crates/draft-core/src/view.rs
+++ b/crates/draft-core/src/view.rs
@@ -2,6 +2,7 @@ use engine::types::player::PlayerId;
 use serde::{Deserialize, Serialize};
 
 use crate::types::*;
+use engine::types::match_config::MatchConfig;
 
 /// A single entry in the standings table.
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -84,6 +85,8 @@ pub struct DraftPlayerView {
     pub pod_policy: PodPolicy,
     /// Pairings for the current round.
     pub pairings: Vec<PairingView>,
+    /// Resolved match configuration owned by the draft engine.
+    pub match_config: MatchConfig,
 }
 
 /// Re-export SpectatorVisibility from types for convenience.
@@ -110,6 +113,8 @@ pub struct SpectatorDraftView {
     pub tournament_format: TournamentFormat,
     pub pod_policy: PodPolicy,
     pub pairings: Vec<PairingView>,
+    /// Resolved match configuration owned by the draft engine.
+    pub match_config: MatchConfig,
     /// Populated only in `Omniscient` mode. Each inner Vec is a seat's pool.
     pub pools: Option<Vec<Vec<DraftCardInstance>>>,
     /// Populated only in `Omniscient` mode. Each entry is a seat's current pack.
@@ -204,6 +209,7 @@ pub fn filter_for_spectator(
         tournament_format: session.config.tournament_format,
         pod_policy: session.config.pod_policy,
         pairings,
+        match_config: session.kind.match_config(),
         pools,
         current_packs,
     }
@@ -303,6 +309,7 @@ pub fn filter_for_player(session: &DraftSession, seat_index: u8) -> DraftPlayerV
         tournament_format: session.config.tournament_format,
         pod_policy: session.config.pod_policy,
         pairings,
+        match_config: session.kind.match_config(),
     }
 }
 

--- a/crates/draft-wasm/src/lib.rs
+++ b/crates/draft-wasm/src/lib.rs
@@ -210,6 +210,57 @@ pub fn start_quick_draft(
     Ok(to_js(&view))
 }
 
+/// Start a local Sealed event: one human and seven bots each open six packs,
+/// then the human proceeds directly to deckbuilding.
+#[wasm_bindgen]
+pub fn start_sealed_draft(
+    set_pool_json: &str,
+    difficulty: u8,
+    seed: u32,
+) -> Result<JsValue, JsValue> {
+    let set_pool: LimitedSetPool = serde_json::from_str(set_pool_json)
+        .map_err(|e| JsValue::from_str(&format!("Failed to parse set pool: {e}")))?;
+    let set_code = set_pool.code.clone();
+    let config = DraftConfig {
+        source: DraftSource::Set {
+            code: set_code.clone(),
+        },
+        set_code,
+        kind: DraftKind::Sealed,
+        pod_size: 8,
+        cards_per_pack: 14,
+        pack_count: 6,
+        min_deck_size: 40,
+        addable_cards: DeckAddableCards::standard_basics(),
+        rng_seed: seed as u64,
+        tournament_format: TournamentFormat::Swiss,
+        pod_policy: PodPolicy::Competitive,
+        spectator_visibility: SpectatorVisibility::default(),
+    };
+    let mut seats = vec![DraftSeat::Human {
+        player_id: engine::types::player::PlayerId(0),
+        display_name: "Player".to_string(),
+    }];
+    for i in 1..8u8 {
+        seats.push(DraftSeat::Bot {
+            name: format!("Bot {i}"),
+        });
+    }
+
+    let mut draft_session = DraftSession::new(config, seats, "sealed-draft".to_string());
+    let pack_gen = PackGenerator::new(set_pool);
+    session::apply(&mut draft_session, DraftAction::StartDraft, Some(&pack_gen))
+        .map_err(|e| JsValue::from_str(&format!("Failed to start sealed event: {e}")))?;
+    let view = filter_for_player(&draft_session, 0);
+
+    DRAFT_SESSION.with(|cell| cell.set(Some(draft_session)));
+    PACK_GEN.with(|cell| cell.set(Some(pack_gen)));
+    DIFFICULTY.with(|cell| cell.set(map_difficulty(difficulty)));
+    RNG.with(|cell| cell.set(Some(ChaCha20Rng::seed_from_u64(seed as u64))));
+
+    Ok(to_js(&view))
+}
+
 /// Start a Quick Cube Draft session from a counted cube list.
 #[wasm_bindgen]
 pub fn start_quick_cube_draft(
@@ -505,79 +556,9 @@ pub fn suggest_lands(spells_json: &str) -> Result<JsValue, JsValue> {
 //
 // These exports support the P2P draft host running an authoritative
 // DraftSession for 8 human players. Unlike Quick Draft (single human +
-// bots), the host calls `start_multiplayer_draft` with human seat names,
+// bots), the host calls `create_multiplayer_draft` with seat descriptors,
 // then proxies picks/decks per-seat as guests submit them over the
 // DataChannel.
-
-/// Start a multiplayer draft session (Premier or Traditional).
-///
-/// - `set_pool_json`: serialized LimitedSetPool
-/// - `kind`: "Premier" or "Traditional"
-/// - `seat_names_json`: JSON array of display names, one per seat (length = pod size)
-/// - `seed`: RNG seed for deterministic pack generation
-///
-/// Returns the DraftPlayerView for seat 0 (the host).
-#[wasm_bindgen]
-pub fn start_multiplayer_draft(
-    set_pool_json: &str,
-    kind: &str,
-    seat_names_json: &str,
-    seed: u32,
-) -> Result<JsValue, JsValue> {
-    let set_pool: LimitedSetPool = serde_json::from_str(set_pool_json)
-        .map_err(|e| JsValue::from_str(&format!("Failed to parse set pool: {e}")))?;
-
-    let seat_names: Vec<String> = serde_json::from_str(seat_names_json)
-        .map_err(|e| JsValue::from_str(&format!("Failed to parse seat names: {e}")))?;
-
-    let draft_kind = match kind {
-        "Premier" => DraftKind::Premier,
-        "Traditional" => DraftKind::Traditional,
-        other => return Err(JsValue::from_str(&format!("Unknown draft kind: {other}"))),
-    };
-
-    let set_code = set_pool.code.clone();
-    let config = DraftConfig {
-        source: DraftSource::Set {
-            code: set_code.clone(),
-        },
-        set_code,
-        kind: draft_kind,
-        pod_size: seat_names.len() as u8,
-        cards_per_pack: 14,
-        pack_count: 3,
-        min_deck_size: 40,
-        addable_cards: DeckAddableCards::standard_basics(),
-        rng_seed: seed as u64,
-        tournament_format: TournamentFormat::default(),
-        pod_policy: PodPolicy::default(),
-        spectator_visibility: SpectatorVisibility::default(),
-    };
-
-    let seats: Vec<DraftSeat> = seat_names
-        .iter()
-        .enumerate()
-        .map(|(i, name)| DraftSeat::Human {
-            player_id: engine::types::player::PlayerId(i as u8),
-            display_name: name.clone(),
-        })
-        .collect();
-
-    let draft_code = format!("draft-{seed:08x}");
-    let mut draft_session = DraftSession::new(config, seats, draft_code);
-    let pack_gen = PackGenerator::new(set_pool);
-
-    session::apply(&mut draft_session, DraftAction::StartDraft, Some(&pack_gen))
-        .map_err(|e| JsValue::from_str(&format!("Failed to start draft: {e}")))?;
-
-    let view = filter_for_player(&draft_session, 0);
-
-    DRAFT_SESSION.with(|cell| cell.set(Some(draft_session)));
-    PACK_GEN.with(|cell| cell.set(Some(pack_gen)));
-    RNG.with(|cell| cell.set(Some(ChaCha20Rng::seed_from_u64(seed as u64))));
-
-    Ok(to_js(&view))
-}
 
 /// Submit a pick for any seat (host proxies guest picks).
 ///
@@ -666,6 +647,9 @@ pub fn export_draft_session() -> Result<String, JsValue> {
 pub fn import_draft_session(json: &str, difficulty: u8) -> Result<JsValue, JsValue> {
     let session: DraftSession = serde_json::from_str(json)
         .map_err(|e| JsValue::from_str(&format!("Failed to deserialize draft session: {e}")))?;
+    session
+        .validate_sealed_snapshot()
+        .map_err(|e| JsValue::from_str(&format!("Invalid draft snapshot: {e}")))?;
 
     let offset = session.current_pack_number as u64 * session.config.cards_per_pack as u64
         + session.pick_number as u64;
@@ -759,15 +743,15 @@ enum PoolInput {
 }
 
 /// Create a multiplayer draft session. Used by the P2P host to initialize a
-/// Premier or Traditional draft with human + bot seats from either a Set pool
+/// Premier, Traditional, or Sealed draft with human + bot seats from either a Set pool
 /// or a custom Cube list.
 ///
 /// - `pool_input_json`: serialized `PoolInput` discriminated union
 ///   (`{ "type": "Set" | "Cube", "data": { ... } }`)
 /// - `seats_json`: JSON array of SeatDescriptors
-/// - `kind`: 0=Quick, 1=Premier, 2=Traditional. The user-selected DraftKind
+/// - `kind`: 0=Quick, 1=Premier, 2=Traditional, 3=Sealed.
 ///   flows through to `DraftConfig.kind` unchanged. Tournament match format
-///   (Bo1 for Premier, Bo3 for Traditional) is identical to set drafts.
+///   (Bo1 for Premier and Sealed, Bo3 for Traditional) is identical to set drafts.
 /// - `seed`: RNG seed for deterministic pack generation
 /// - `draft_code`: unique room identifier
 ///
@@ -820,8 +804,11 @@ fn create_multiplayer_draft_inner(
         0 => DraftKind::Quick,
         1 => DraftKind::Premier,
         2 => DraftKind::Traditional,
+        3 => DraftKind::Sealed,
         _ => {
-            return Err("kind must be 0 (Quick), 1 (Premier), or 2 (Traditional)".to_string());
+            return Err(
+                "kind must be 0 (Quick), 1 (Premier), 2 (Traditional), or 3 (Sealed)".to_string(),
+            );
         }
     };
 
@@ -869,7 +856,11 @@ fn create_multiplayer_draft_inner(
                 kind: draft_kind,
                 pod_size: seats.len() as u8,
                 cards_per_pack: 14,
-                pack_count: 3,
+                pack_count: if draft_kind == DraftKind::Sealed {
+                    6
+                } else {
+                    3
+                },
                 min_deck_size: 40,
                 addable_cards: DeckAddableCards::standard_basics(),
                 rng_seed: seed as u64,
@@ -897,6 +888,9 @@ fn create_multiplayer_draft_inner(
             cube_name,
             cube_draft_settings: settings,
         } => {
+            if draft_kind == DraftKind::Sealed {
+                return Err("Sealed events require a Set pool".to_string());
+            }
             let entries = parse_cube_list(&cube_list_text).map_err(|errors| {
                 format!(
                     "Failed to parse cube list: {}",

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -141,7 +141,7 @@ pub struct DraftLobbyMetadata {
     /// `"custom-cube"`; see [`DraftLobbyMetadata::cube_name`] for the
     /// human-readable cube name.
     pub set_code: String,
-    /// Draft kind label: "Quick", "Premier", or "Traditional".
+    /// Draft kind label: "Quick", "Premier", "Traditional", or "Sealed".
     pub draft_kind: String,
     /// Human-readable cube name when the pod is a cube draft. Absent for
     /// set drafts. Backward-compatible: `#[serde(default)]` accepts

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -43,6 +43,7 @@ pub enum ServerErrorCode {
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
 ///
+/// 27 — Added `DraftKind::Sealed`, serialized by draft WebSocket messages.
 /// 26 — Added `ServerMessage::ActionNoOp` for accepted transport no-ops.
 /// 25 — `DebugCardEntries` added a serialized, private resolution frame for
 ///      multi-card sandbox battlefield entries that pause for replacement or
@@ -73,7 +74,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 26;
+pub const PROTOCOL_VERSION: u32 = 27;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake. Lobby traffic has a one-version rollout window; full game servers
@@ -410,12 +411,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 26);
+        assert_eq!(PROTOCOL_VERSION, 27);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot
         // understand a success acknowledgment the submitting client awaits.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 25);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 26);
     }
 
     #[test]

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -6868,7 +6868,8 @@ async fn handle_client_message(
                 return;
             }
 
-            if tournament_format == draft_core::types::TournamentFormat::SingleElimination
+            if kind != draft_core::types::DraftKind::Quick
+                && tournament_format == draft_core::types::TournamentFormat::SingleElimination
                 && pod_size != 8
             {
                 let msg = ServerMessage::DraftActionRejected {

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1270,7 +1270,11 @@ async fn serve() {
                             let register_req =
                                 server_core::persist::restored_draft_lobby_register_request(&ps);
                             let timer_ms = ps.timer_remaining_ms;
-                            dsm.restore_session(ps);
+                            if let Err(error) = dsm.restore_persisted_session(ps) {
+                                warn!(draft = %draft_code, error = %error, "invalid persisted draft session, deleting");
+                                let _ = game_db.delete_draft_session(draft_code);
+                                continue;
+                            }
                             if let Some(req) = register_req {
                                 lob.register_game(draft_code, req, &SysEnv);
                             }
@@ -6864,6 +6868,18 @@ async fn handle_client_message(
                 return;
             }
 
+            if tournament_format == draft_core::types::TournamentFormat::SingleElimination
+                && pod_size != 8
+            {
+                let msg = ServerMessage::DraftActionRejected {
+                    reason: "Single-elimination draft events require exactly 8 seats".to_string(),
+                };
+                if let Ok(json) = serde_json::to_string(&msg) {
+                    let _ = socket.send(Message::text(json)).await;
+                }
+                return;
+            }
+
             let config = draft_core::types::DraftConfig {
                 source: draft_core::types::DraftSource::Set {
                     code: set_code.clone(),
@@ -6872,7 +6888,11 @@ async fn handle_client_message(
                 kind,
                 pod_size,
                 cards_per_pack: 14,
-                pack_count: 3,
+                pack_count: if kind == draft_core::types::DraftKind::Sealed {
+                    6
+                } else {
+                    3
+                },
                 min_deck_size: 40,
                 addable_cards: draft_core::types::DeckAddableCards::standard_basics(),
                 rng_seed: rand::random(),

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -6850,6 +6850,7 @@ async fn handle_client_message(
                 &password,
                 timer_seconds,
                 pod_size,
+                kind,
             ) {
                 let msg = ServerMessage::DraftActionRejected { reason };
                 if let Ok(json) = serde_json::to_string(&msg) {

--- a/crates/server-core/src/client_message_wire_guard.rs
+++ b/crates/server-core/src/client_message_wire_guard.rs
@@ -180,6 +180,7 @@ pub fn guard_client_message_before_dispatch(
             timer_seconds,
             pod_size,
             kind,
+            ..
         } => guard_create_draft_with_settings(
             display_name,
             set_code,

--- a/crates/server-core/src/client_message_wire_guard.rs
+++ b/crates/server-core/src/client_message_wire_guard.rs
@@ -179,13 +179,14 @@ pub fn guard_client_message_before_dispatch(
             password,
             timer_seconds,
             pod_size,
-            ..
+            kind,
         } => guard_create_draft_with_settings(
             display_name,
             set_code,
             password,
             *timer_seconds,
             *pod_size,
+            *kind,
         ),
         ClientMessage::JoinDraftWithPassword {
             draft_code,

--- a/crates/server-core/src/draft_session.rs
+++ b/crates/server-core/src/draft_session.rs
@@ -91,6 +91,27 @@ impl DraftSession {
         }
     }
 
+    /// Validate a disk snapshot before it becomes a live server session.
+    fn try_from_persisted(ps: PersistedDraftSession) -> Result<Self, String> {
+        let core = &ps.session;
+        let seat_count = core.seats.len();
+        if ps.draft_code != core.draft_code {
+            return Err("persisted draft code does not match core session".to_string());
+        }
+        if ps.config != core.config {
+            return Err("persisted draft configuration does not match core session".to_string());
+        }
+        if ps.config.pod_size as usize != seat_count
+            || ps.player_tokens.len() != seat_count
+            || ps.display_names.len() != seat_count
+        {
+            return Err("persisted draft seat vectors do not match core seats".to_string());
+        }
+        core.validate_sealed_snapshot()
+            .map_err(|error| format!("invalid persisted sealed snapshot: {error}"))?;
+        Ok(Self::from_persisted(ps))
+    }
+
     /// Inject server-side timer into the filtered view before serializing.
     pub fn view_for_seat(&self, seat: usize) -> DraftPlayerView {
         let mut view = draft_core::view::filter_for_player(&self.session, seat as u8);
@@ -423,6 +444,21 @@ impl DraftSessionManager {
             }
         }
         self.sessions.insert(draft_code, session);
+    }
+
+    /// Restore an untrusted persisted snapshot only after its wrapper and core
+    /// session agree. The manager remains unchanged when validation fails.
+    pub fn restore_persisted_session(&mut self, ps: PersistedDraftSession) -> Result<(), String> {
+        let session = DraftSession::try_from_persisted(ps)?;
+        let draft_code = session.draft_code.clone();
+        for token in &session.player_tokens {
+            if !token.is_empty() {
+                self.token_to_draft
+                    .insert(token.clone(), draft_code.clone());
+            }
+        }
+        self.sessions.insert(draft_code, session);
+        Ok(())
     }
 
     /// Auto-pick a random card for a disconnected seat whose grace period expired.
@@ -1188,6 +1224,18 @@ mod tests {
 
         // Original host token should still work
         assert_eq!(mgr2.draft_for_token(&token), Some(code.as_str()));
+    }
+
+    #[test]
+    fn restore_persisted_session_rejects_mismatched_wrapper_without_mutation() {
+        let mut mgr = DraftSessionManager::new();
+        let (code, _token, _) = mgr.create_draft(test_config(), "Alice".to_string());
+        let mut persisted = mgr.sessions[&code].to_persisted();
+        persisted.display_names.pop();
+
+        let mut restored = DraftSessionManager::new();
+        assert!(restored.restore_persisted_session(persisted).is_err());
+        assert!(restored.sessions.is_empty());
     }
 
     fn fill_and_start(mgr: &mut DraftSessionManager, code: &str) {

--- a/crates/server-core/src/draft_session.rs
+++ b/crates/server-core/src/draft_session.rs
@@ -107,6 +107,15 @@ impl DraftSession {
         {
             return Err("persisted draft seat vectors do not match core seats".to_string());
         }
+        let mut tokens = std::collections::HashSet::new();
+        if ps
+            .player_tokens
+            .iter()
+            .filter(|token| !token.is_empty())
+            .any(|token| !tokens.insert(token))
+        {
+            return Err("persisted draft player tokens must be unique".to_string());
+        }
         core.validate_sealed_snapshot()
             .map_err(|error| format!("invalid persisted sealed snapshot: {error}"))?;
         Ok(Self::from_persisted(ps))
@@ -1232,6 +1241,18 @@ mod tests {
         let (code, _token, _) = mgr.create_draft(test_config(), "Alice".to_string());
         let mut persisted = mgr.sessions[&code].to_persisted();
         persisted.display_names.pop();
+
+        let mut restored = DraftSessionManager::new();
+        assert!(restored.restore_persisted_session(persisted).is_err());
+        assert!(restored.sessions.is_empty());
+    }
+
+    #[test]
+    fn restore_persisted_session_rejects_duplicate_player_tokens() {
+        let mut mgr = DraftSessionManager::new();
+        let (code, token, _) = mgr.create_draft(test_config(), "Alice".to_string());
+        let mut persisted = mgr.sessions[&code].to_persisted();
+        persisted.player_tokens[1] = token;
 
         let mut restored = DraftSessionManager::new();
         assert!(restored.restore_persisted_session(persisted).is_err());

--- a/crates/server-core/src/draft_wire_guard.rs
+++ b/crates/server-core/src/draft_wire_guard.rs
@@ -23,8 +23,8 @@ pub fn guard_create_draft_with_settings(
     validate_required_label("display_name", display_name, MAX_DISPLAY_NAME_LEN)?;
     validate_token("set_code", set_code, MAX_DRAFT_SET_CODE_LEN)?;
     validate_optional_token("password", password.as_deref(), MAX_PASSWORD_LEN)?;
-    if pod_size == 0 || pod_size > MAX_PLAYER_COUNT {
-        return Err(format!("pod_size must be between 1 and {MAX_PLAYER_COUNT}"));
+    if !(2..=MAX_PLAYER_COUNT).contains(&pod_size) {
+        return Err(format!("pod_size must be between 2 and {MAX_PLAYER_COUNT}"));
     }
     if let Some(secs) = timer_seconds {
         if secs > MAX_TIMER_SECONDS {

--- a/crates/server-core/src/draft_wire_guard.rs
+++ b/crates/server-core/src/draft_wire_guard.rs
@@ -5,6 +5,7 @@
 //! through `lobby_broker::validate_lobby_message`, so client-supplied names,
 //! codes, passwords, and tokens must be bounded before clone-heavy work.
 
+use draft_core::types::DraftKind;
 use lobby_broker::validation::{
     validate_optional_token, validate_required_label, validate_token, MAX_DISPLAY_NAME_LEN,
     MAX_DRAFT_SET_CODE_LEN, MAX_GAME_CODE_LEN, MAX_PASSWORD_LEN, MAX_PLAYER_COUNT,
@@ -19,12 +20,16 @@ pub fn guard_create_draft_with_settings(
     password: &Option<String>,
     timer_seconds: Option<u32>,
     pod_size: u8,
+    kind: DraftKind,
 ) -> Result<(), String> {
     validate_required_label("display_name", display_name, MAX_DISPLAY_NAME_LEN)?;
     validate_token("set_code", set_code, MAX_DRAFT_SET_CODE_LEN)?;
     validate_optional_token("password", password.as_deref(), MAX_PASSWORD_LEN)?;
-    if !(2..=MAX_PLAYER_COUNT).contains(&pod_size) {
-        return Err(format!("pod_size must be between 2 and {MAX_PLAYER_COUNT}"));
+    let minimum_pod_size = if kind == DraftKind::Quick { 1 } else { 2 };
+    if !(minimum_pod_size..=MAX_PLAYER_COUNT).contains(&pod_size) {
+        return Err(format!(
+            "pod_size must be between {minimum_pod_size} and {MAX_PLAYER_COUNT}"
+        ));
     }
     if let Some(secs) = timer_seconds {
         if secs > MAX_TIMER_SECONDS {
@@ -60,6 +65,7 @@ pub fn guard_draft_action(draft_code: &str) -> Result<(), String> {
 
 #[cfg(test)]
 mod tests {
+    use draft_core::types::DraftKind;
     use lobby_broker::validation::MAX_GAME_CODE_LEN;
 
     use super::{
@@ -69,13 +75,28 @@ mod tests {
 
     #[test]
     fn create_draft_accepts_valid_fields() {
-        assert!(guard_create_draft_with_settings("Alice", "TST", &None, None, 4).is_ok());
+        assert!(guard_create_draft_with_settings(
+            "Alice",
+            "TST",
+            &None,
+            None,
+            4,
+            DraftKind::Premier
+        )
+        .is_ok());
     }
 
     #[test]
     fn create_draft_rejects_oversized_display_name() {
-        let err =
-            guard_create_draft_with_settings(&"a".repeat(21), "TST", &None, None, 4).unwrap_err();
+        let err = guard_create_draft_with_settings(
+            &"a".repeat(21),
+            "TST",
+            &None,
+            None,
+            4,
+            DraftKind::Premier,
+        )
+        .unwrap_err();
         assert!(err.contains("display_name"));
     }
 

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -1953,11 +1953,11 @@ mod tests {
     }
 
     #[test]
-    fn client_message_create_draft_with_settings_roundtrips() {
+    fn client_message_create_sealed_draft_with_settings_roundtrips() {
         let msg = ClientMessage::CreateDraftWithSettings {
             display_name: "Alice".to_string(),
             set_code: "MKM".to_string(),
-            kind: draft_core::types::DraftKind::Premier,
+            kind: draft_core::types::DraftKind::Sealed,
             public: true,
             password: Some("secret".to_string()),
             timer_seconds: Some(75),
@@ -1980,7 +1980,7 @@ mod tests {
             } => {
                 assert_eq!(display_name, "Alice");
                 assert_eq!(set_code, "MKM");
-                assert_eq!(kind, draft_core::types::DraftKind::Premier);
+                assert_eq!(kind, draft_core::types::DraftKind::Sealed);
                 assert!(public);
                 assert_eq!(password, Some("secret".to_string()));
                 assert_eq!(timer_seconds, Some(75));
@@ -2261,8 +2261,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_26() {
-        assert_eq!(PROTOCOL_VERSION, 26);
+    fn protocol_version_is_27() {
+        assert_eq!(PROTOCOL_VERSION, 27);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -2272,7 +2272,7 @@ mod tests {
     /// understand.
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
-    /// this guards — and this test reds while `protocol_version_is_26` stays
+    /// this guards — and this test reds while `protocol_version_is_27` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -2245,6 +2245,7 @@ mod tests {
             tournament_format: TournamentFormat::Swiss,
             pod_policy: PodPolicy::Competitive,
             pairings: Vec::new(),
+            match_config: DraftKind::Premier.match_config(),
             pools: None,
             current_packs: None,
         };

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -2106,6 +2106,7 @@ mod tests {
             tournament_format: TournamentFormat::Swiss,
             pod_policy: PodPolicy::Competitive,
             pairings: Vec::new(),
+            match_config: DraftKind::Premier.match_config(),
         };
         let msg = ServerMessage::DraftStateUpdate { view: view.clone() };
         let json = serde_json::to_string(&msg).unwrap();

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 26;
+const EXPECTED_PROTOCOL_VERSION = 27;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);


### PR DESCRIPTION
- **feat(draft): add sealed event support**
- **fix(draft): preserve cube sizes and version sealed wire**
- **fix(draft): align sealed host state and restore checks**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Sealed draft support for set-based events, including six-pack allocation, deckbuilding, and single-match play.
  * Added Quick/Sealed selection for local drafts and Sealed setup for draft pods.
  * Added Sealed labels, descriptions, and setup guidance.
  * Draft views now provide match configuration details for accurate match setup.
* **Bug Fixes**
  * Improved validation for draft configuration and persisted sessions.
  * Prevented invalid drafts and unsupported pool configurations from starting or restoring.
* **Compatibility**
  * Updated networking protocols to support Sealed drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->