### PR TITLE
fix(parser): keep shared-event subject disjunctions as one trigger (Ironsoul Enforcer)

### DIFF
--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -7893,7 +7893,7 @@ fn split_cross_subject_event_compound(cond_lower: &str, condition: &str) -> Opti
     if is_enters_or_haunted_creature_dies_compound(cond_lower) {
         return None;
     }
-    let (after_lower, _) = parse_cross_subject_or_split(cond_lower).ok()?;
+    let (after_lower, before_lower) = parse_cross_subject_or_split(cond_lower).ok()?;
     let (after_original, before_original) = parse_cross_subject_or_split(condition).ok()?;
 
     // Check if what follows " or " starts with a valid subject phrase
@@ -7922,6 +7922,38 @@ fn split_cross_subject_event_compound(cond_lower: &str, condition: &str) -> Opti
     //     -> Unknown("Whenever ~") + Taps   (correct today: ONE Taps with an Or subject)
     // Both yield a bogus first half with no event at all.
     scan_preceded(after_trimmed, |i| parse_event_verb_start(i))?;
+
+    // CR 603.1 + CR 603.2: symmetric gate — a genuine CROSS-SUBJECT compound
+    // carries an event on BOTH sides of the "or" (Norin the Wary: "a player
+    // casts a spell" / "a creature attacks"). A SUBJECT disjunction shares one
+    // event between two subjects, so its first half is a bare noun phrase
+    // ("whenever ~", "whenever this creature"). Splitting that strands the
+    // leading subject in a trigger with no event at all and silently drops the
+    // self leg, so the card fires only for its second subject.
+    //
+    // This is the same `Unknown("Whenever ~")` husk the comment above keeps the
+    // SECOND-half gate narrow to avoid; the two gates close the failure from
+    // opposite sides. Donna Noble and The Bus Runner never reach this arm (their
+    // second half carries no narrow-lexicon verb, so the gate above already
+    // declines) and are unaffected here. What slips past that gate is a subject
+    // disjunction whose second subject IS followed by an active-voice verb —
+    // Ironsoul Enforcer's "or a commander you control attacks alone", which the
+    // scan above cannot tell apart from a second event.
+    // `parse_trigger_subject` already folds these into one `TargetFilter::Or`
+    // subject, which is the CR 603.1-correct single trigger.
+    //
+    // Measured over the MTGJSON corpus, this recovers the dropped leading leg on
+    // Ironsoul Enforcer, Campsite Cuisine, Calix, Syr Carah, Shipwreck Sifters,
+    // Long Feng and Surrak — four distinct event families (Attacks, ChangesZone,
+    // DamageDone, BecomesTarget) — and splits zero lines it split before.
+    //
+    // This gate uses the WIDE `parse_event_head_start` on purpose: it must
+    // decline only when the leading half has NO event of any kind. A
+    // state-change or passive leading leg ("whenever ~ becomes tapped or a
+    // creature you control attacks") is still a real two-event compound and
+    // must keep splitting, so narrowing this to `parse_event_verb_start` would
+    // collapse it into a bogus single trigger.
+    scan_preceded(before_lower.trim(), |i| parse_event_head_start(i))?;
 
     let (_, keyword) = parse_trigger_keyword_prefix(cond_lower).ok()?;
 

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -4088,6 +4088,93 @@ fn trigger_attacks_you_or_planeswalker_not_split() {
     );
 }
 
+/// CR 603.1 + CR 603.2: a SUBJECT disjunction ("<self> or <class> <verb>") is
+/// one trigger with an `Or` subject, not a cross-subject compound. The
+/// second-half event-verb gate in `split_cross_subject_event_compound` cannot
+/// tell the two apart on its own — Ironsoul Enforcer's second subject is
+/// followed by "attacks", a narrow-lexicon active-voice verb — so the split
+/// also requires an event in the FIRST half. Without that symmetric gate the
+/// line splits into `Unknown("Whenever ~")` + the commander leg, silently
+/// dropping the self leg so the card never fires off its own attack.
+///
+/// This is the production path (`parse_trigger_lines`); `parse_trigger_line`
+/// alone never reaches the splitter and so cannot catch the regression.
+#[test]
+fn trigger_self_or_class_subject_disjunction_not_split() {
+    let triggers = parse_trigger_lines(
+        "Whenever this creature or a commander you control attacks alone, return target artifact card from your graveyard to the battlefield.",
+        "Ironsoul Enforcer",
+    );
+    assert_eq!(
+        triggers.len(),
+        1,
+        "a shared-event subject disjunction must stay one trigger: {:?}",
+        triggers.iter().map(|t| &t.mode).collect::<Vec<_>>()
+    );
+    assert_eq!(triggers[0].mode, TriggerMode::Attacks);
+    let Some(TargetFilter::Or { filters }) = triggers[0].valid_card.as_ref() else {
+        panic!("expected an Or subject, got {:?}", triggers[0].valid_card);
+    };
+    assert_eq!(filters.len(), 2, "one leg per subject: {filters:?}");
+    assert_eq!(filters[0], TargetFilter::SelfRef);
+    assert!(
+        matches!(&filters[1], TargetFilter::Typed(tf)
+            if tf.properties.contains(&FilterProp::IsCommander)),
+        "CR 903.3: second leg must carry IsCommander, got {:?}",
+        filters[1]
+    );
+    assert_eq!(
+        triggers[0].condition,
+        Some(TriggerCondition::Not {
+            condition: Box::new(TriggerCondition::MinCoAttackers {
+                minimum: 1,
+                filter: None,
+            }),
+        }),
+        "CR 506.5: the alone gate applies to whichever subject attacked"
+    );
+}
+
+/// CR 603.1: the same gate, a different event family — the fix must be
+/// class-level, not attack-specific. Campsite Cuisine's "this enchantment or a
+/// legendary creature you control enters" shares one ETB event between two
+/// subjects; before the first-half gate it split into `Unknown("Whenever ~")`
+/// plus the legendary-creature leg, so the enchantment's own ETB never fired.
+#[test]
+fn trigger_self_or_class_subject_disjunction_not_split_etb() {
+    let triggers = parse_trigger_lines(
+        "Whenever this enchantment or a legendary creature you control enters, create a Food token.",
+        "Campsite Cuisine",
+    );
+    assert_eq!(
+        triggers.len(),
+        1,
+        "a shared-ETB subject disjunction must stay one trigger: {:?}",
+        triggers.iter().map(|t| &t.mode).collect::<Vec<_>>()
+    );
+    assert_eq!(triggers[0].mode, TriggerMode::ChangesZone);
+    assert_eq!(triggers[0].destination, Some(Zone::Battlefield));
+    let Some(TargetFilter::Or { filters }) = triggers[0].valid_card.as_ref() else {
+        panic!("expected an Or subject, got {:?}", triggers[0].valid_card);
+    };
+    assert_eq!(filters.len(), 2, "one leg per subject: {filters:?}");
+    assert_eq!(
+        filters[0],
+        TargetFilter::SelfRef,
+        "the source's own ETB leg must survive the split gate"
+    );
+    assert!(
+        matches!(&filters[1], TargetFilter::Typed(tf)
+        if tf.controller == Some(ControllerRef::You)
+            && tf.type_filters == vec![TypeFilter::Creature]
+            && tf.properties.contains(&FilterProp::HasSupertype {
+                value: Supertype::Legendary
+            })),
+        "second leg must be a legendary creature you control, got {:?}",
+        filters[1]
+    );
+}
+
 #[test]
 fn trigger_counter_put_on_self() {
     let def = parse_trigger_line(
@@ -14832,6 +14919,50 @@ fn trigger_dragon_you_control_attacks() {
                 .subtype("Dragon".to_string())
                 .controller(ControllerRef::You)
         ))
+    );
+}
+
+/// CR 506.5 + CR 903.3: a *disjunctive* attacks-alone subject — a
+/// self-reference OR'd with a non-self class (Ironsoul Enforcer's "this
+/// creature or a commander you control"). Two building blocks must compose:
+/// `parse_trigger_subject`'s `" or "` fold must produce an `Or` whose second
+/// leg carries `FilterProp::IsCommander` (the CR 903.3 designation, NOT a
+/// subtype), and `strip_attack_alone_qualifier` must still gate the whole
+/// trigger on zero co-attackers. The alone-gate lives on the condition, not on
+/// either leg, so it applies to whichever disjunct matched.
+#[test]
+fn trigger_self_or_commander_attacks_alone() {
+    let def = parse_trigger_line(
+        "Whenever this creature or a commander you control attacks alone, return target artifact card from your graveyard to the battlefield.",
+        "Ironsoul Enforcer",
+    );
+    assert!(matches!(def.mode, TriggerMode::Attacks));
+    let Some(TargetFilter::Or { filters }) = def.valid_card.as_ref() else {
+        panic!("expected a disjunctive subject, got {:?}", def.valid_card);
+    };
+    assert_eq!(filters.len(), 2, "one leg per disjunct: {filters:?}");
+    assert_eq!(
+        filters[0],
+        TargetFilter::SelfRef,
+        "\"this creature\" must bind to the trigger source"
+    );
+    let TargetFilter::Typed(commander) = &filters[1] else {
+        panic!("expected a typed commander leg, got {:?}", filters[1]);
+    };
+    assert_eq!(commander.controller, Some(ControllerRef::You));
+    assert!(
+        commander.properties.contains(&FilterProp::IsCommander),
+        "CR 903.3: \"commander\" is the IsCommander designation, not a subtype: {commander:?}"
+    );
+    assert_eq!(
+        def.condition,
+        Some(TriggerCondition::Not {
+            condition: Box::new(TriggerCondition::MinCoAttackers {
+                minimum: 1,
+                filter: None,
+            }),
+        }),
+        "CR 506.5: the alone gate must survive the disjunctive subject"
     );
 }
 

--- a/crates/engine/tests/integration/ironsoul_enforcer_commander_attacks_alone.rs
+++ b/crates/engine/tests/integration/ironsoul_enforcer_commander_attacks_alone.rs
@@ -1,0 +1,120 @@
+//! Ironsoul Enforcer — "Whenever this creature or a commander you control
+//! attacks alone, return target artifact card from your graveyard to the
+//! battlefield."
+//!
+//! The building block under test is a *disjunctive* attacks-alone trigger
+//! subject: a self-reference OR'd with a non-self class (here CR 903.3's
+//! commander designation). Two axes must hold together:
+//!
+//!   * CR 506.5 — "attacks alone" is evaluated against the creature that was
+//!     declared as an attacker, not against the ability's source. When the
+//!     commander attacks alone the Enforcer is not in combat at all, so the
+//!     co-attacker tally must exclude the *commander*, not the Enforcer.
+//!   * CR 903.3 — "commander" is a deck-construction designation carried by
+//!     `is_commander`, not a creature subtype. A creature that is not flagged
+//!     must not satisfy the second disjunct.
+//!
+//! Covers the whole `<self> or <class> attacks alone` class (Ironsoul Enforcer
+//! and any future card whose attacks-alone subject is a disjunction), not just
+//! this card.
+
+use engine::types::phase::Phase;
+
+use super::rules::{run_combat, GameScenario, P0};
+
+const ORACLE: &str = "Whenever this creature or a commander you control attacks alone, return target artifact card from your graveyard to the battlefield.";
+
+/// Which creatures P0 declares as attackers in the fixture.
+#[derive(Clone, Copy)]
+enum Attack {
+    /// The commander attacks by itself; the Enforcer stays home.
+    CommanderAlone,
+    /// The Enforcer attacks by itself; the commander stays home.
+    EnforcerAlone,
+    /// Both attack — no creature attacks alone.
+    Both,
+    /// A non-commander bear attacks by itself — neither disjunct matches.
+    NonCommanderAlone,
+}
+
+/// Returns whether the graveyard artifact ("Ornithopter") reached the
+/// battlefield, i.e. whether the trigger fired and resolved.
+fn artifact_returned(attack: Attack) -> bool {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let enforcer = scenario
+        .add_creature_from_oracle(P0, "Ironsoul Enforcer", 4, 4, ORACLE)
+        .id();
+    let commander = scenario
+        .add_creature(P0, "Kediss, Emberclaw Familiar", 2, 2)
+        .id();
+    let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+
+    // The reanimation target: an artifact card in P0's graveyard.
+    let ornithopter = scenario
+        .add_creature_to_graveyard(P0, "Ornithopter", 0, 2)
+        .as_artifact()
+        .id();
+
+    let mut runner = scenario.build();
+
+    // CR 903.3: the commander designation is a per-object flag, not a subtype.
+    // Mirrors `make_commander` in `rules/layers.rs` — owner == controller == P0
+    // with the object on the battlefield, so `FilterProp::IsCommander` matches.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&commander)
+        .expect("commander object exists")
+        .is_commander = true;
+
+    let attackers = match attack {
+        Attack::CommanderAlone => vec![commander],
+        Attack::EnforcerAlone => vec![enforcer],
+        Attack::Both => vec![commander, enforcer],
+        Attack::NonCommanderAlone => vec![bear],
+    };
+
+    run_combat(&mut runner, attackers, vec![]);
+    runner.advance_until_stack_empty();
+
+    runner.state().battlefield.contains(&ornithopter)
+}
+
+#[test]
+fn commander_attacking_alone_fires_while_the_enforcer_stays_home() {
+    // CR 506.5: the commander is the only declared attacker, so it attacks
+    // alone even though the trigger's source is not in combat.
+    assert!(
+        artifact_returned(Attack::CommanderAlone),
+        "CR 506.5 + CR 903.3: a lone commander attacker must satisfy the second \
+         disjunct and return the graveyard artifact"
+    );
+}
+
+#[test]
+fn enforcer_attacking_alone_fires_on_the_self_disjunct() {
+    assert!(
+        artifact_returned(Attack::EnforcerAlone),
+        "CR 506.5: the self-reference disjunct must still fire when the source \
+         itself is the lone attacker"
+    );
+}
+
+#[test]
+fn two_attackers_do_not_attack_alone() {
+    assert!(
+        !artifact_returned(Attack::Both),
+        "CR 506.5: with two declared attackers neither creature attacks alone"
+    );
+}
+
+#[test]
+fn non_commander_attacking_alone_does_not_fire() {
+    assert!(
+        !artifact_returned(Attack::NonCommanderAlone),
+        "CR 903.3: an unflagged creature is not a commander, so a lone \
+         non-commander attacker matches neither disjunct"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -284,6 +284,7 @@ mod integration_landfall;
 mod interaction_contract;
 mod invoke_calamity_free_cast;
 mod ir_spell_node_readers;
+mod ironsoul_enforcer_commander_attacks_alone;
 mod issue_1005_suffer_the_past;
 mod issue_1007_fractal_harness_attach;
 mod issue_1008_korvold_sacrifice_triggers;


### PR DESCRIPTION
## Summary

Implements **Ironsoul Enforcer** — *"Whenever this creature or a commander you control attacks alone, return target artifact card from your graveyard to the battlefield."*

The card needed no new engine surface. Attacks-alone (CR 506.5), `FilterProp::IsCommander` (CR 903.3), disjunctive-subject folding, and graveyard→battlefield reanimation all already existed and compose correctly — `parse_trigger_line` produced a correct AST from the start.

What was broken is a **shared parser gate**, and fixing it repairs six other cards.

## The bug

`split_cross_subject_event_compound` decides whether `"Whenever A or B <verb>"` is two events or one event shared by two subjects. It gated only the **second** half on containing an event verb, so a subject disjunction whose second subject happens to be followed by an active-voice verb was split as if it were a cross-subject compound:

| | produced today |
|---|---|
| 1 | `Unknown("Whenever ~")` — dead husk, leading leg dropped |
| 2 | `Whenever a commander you control attacks alone, …` — works |

In play: Ironsoul Enforcer's **own attack never triggered**. Only a commander's did.

## The fix

Add the symmetric gate. CR 603.1: a genuine cross-subject compound carries an event on **both** sides of the `or` (Norin the Wary: "a player casts a spell" / "a creature attacks"); a subject disjunction has a bare noun phrase on the left. `parse_trigger_subject` already folds the latter into a single `TargetFilter::Or` subject, which is the CR-correct shape.

The gate uses the wide `parse_event_head_start` deliberately, so a state-change or passive leading leg (`"becomes tapped or a creature you control attacks"`) is still recognized as an event and still splits.

## Corpus effect

Measured over MTGJSON AtomicCards. Seven cards across four event families recover their dropped leading leg; **zero lines that split before stop splitting**.

| Card | Family | Leg recovered |
|---|---|---|
| Ironsoul Enforcer | Attacks | its own attack |
| Campsite Cuisine | ChangesZone | its own ETB |
| Shipwreck Sifters | ChangesZone | Spirit cards |
| Long Feng, Grand Secretariat | ChangesZone | creatures (only lands fired) |
| Calix, Guided by Fate | DamageDone | its own combat damage |
| Syr Carah, the Bold | DamageDone | its own damage |
| Surrak, Elusive Hunter | BecomesTarget | creatures you control |

Donna Noble and The Bus Runner — the two cards the existing comment names — never reach this arm (their second half carries no narrow-lexicon verb, so the second-half gate already declines) and are unaffected. Norin the Wary still splits into two triggers.

## Not fixed here

**Leovold, Emissary of Trest / Rayne, Academy Chancellor / Parnesse, the Subtle Brush / Unsettled Mariner** — `"Whenever you or a permanent you control becomes the target of…"`. These lose the dead husk, but the subject parser drops the `"you"` (player) leg rather than folding it into the `Or`, so only the permanent leg fires. Net improvement, not a fix; worth a follow-up that teaches the subject fold to carry a mixed player/object disjunction.

## Verification

- `cargo test -p phase-engine --lib parser::oracle_trigger::tests` — **1031 passed / 0 failed**
- `cargo test -p phase-engine --test integration` — **4773 passed / 0 failed**
- `cargo clippy -p phase-engine --all-targets -- -D warnings` — exit 0, zero warnings
- `scripts/check-parser-combinators.sh` — PASS
- `scripts/check-prelowered-ratchet.sh` — Gate P PASS
- `cargo fmt --all` — clean

Two environment caveats, stated rather than glossed:

- One **pre-existing** lib test fails on Windows only — `bounded_offer_conjunct_tests::f2c_the_cr_603_5_conjunct_set_has_one_production_assembler`. `crates/engine/src/game/engine.rs:18685` builds its relative path with `Path::display()` (backslashes on Windows) and then asserts `starts_with("game/effects/")`, so every legitimate in-authority call site reads as "outside". Unrelated to this diff — which touches no file under `game/` — and green on Linux CI.
- `scripts/check-engine-authorities.sh` **could not run**: only the Windows Store `python3` stub is on PATH, so its four census gates errored out. That is "couldn't find out", not "passed". They cover raw zone mutation, draw-replacement producers, and post-replacement continuations, none of which this diff touches.

## Tests added

- `trigger_self_or_commander_attacks_alone` — AST shape: `Or[SelfRef, Typed{IsCommander, You}]` + `Not(MinCoAttackers{1})`
- `trigger_self_or_class_subject_disjunction_not_split` — production path (`parse_trigger_lines`) yields exactly one trigger; `parse_trigger_line` alone never reaches the splitter and so cannot catch this regression
- `trigger_self_or_class_subject_disjunction_not_split_etb` — Campsite Cuisine, proving the fix is class-level rather than attack-specific
- `ironsoul_enforcer_commander_attacks_alone` — four runtime cases: commander attacks alone / source attacks alone / two attackers / unflagged non-commander

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected parsing for triggers with disjunctive subjects, preventing malformed triggers while preserving valid event combinations.
  * Fixed handling of “attacks alone” conditions when either a commander or another qualifying creature attacks alone.
  * Improved support for passive and state-change events involving multiple subjects.

* **Tests**
  * Added coverage for subject disjunctions, typed subject filters, and commander combat scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->