### PR TITLE
Add Exuberant Wolfbear

### DIFF
--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -40,7 +40,9 @@ use super::super::oracle_static::{
     parse_continuous_modifications, parse_continuous_subject_filter, parse_static_line,
     parse_static_line_multi, peel_compound_all_quantified_conjuncts,
 };
-use super::super::oracle_target::{parse_target, parse_target_with_ctx, parse_type_phrase};
+use super::super::oracle_target::{
+    parse_target, parse_target_with_ctx, parse_target_with_syntax, parse_type_phrase, TargetSyntax,
+};
 use super::super::oracle_util::{
     merge_or_filters, parse_number, TextPair, SELF_REF_PARSE_ONLY_PHRASES, SELF_REF_TYPE_PHRASES,
 };
@@ -1195,8 +1197,48 @@ fn try_parse_subject_base_pt_set_clause_ast(
             .parse(parse_lower)
             .ok()
     };
-    let (subject, axes, remainder) =
-        if let Some((rest_lower, (axes, _, subject_lower, _, _, _))) = inverted {
+    let targeted_inverted = if is_change {
+        // Transitive inverted genitive: "change the base power [and toughness]
+        // of target <subject> to <value>" (Exuberant Wolfbear). The subject is
+        // a target phrase rather than a possessive, so retain its syntax: only
+        // the explicit `target` keyword creates a target slot on the effect.
+        // Parse the grammatical prefix before delegating the subject phrase to
+        // the shared target parser; then consume the transitive copula from
+        // that parser's exact remainder so a `to` inside the subject cannot be
+        // mistaken for the value boundary.
+        preceded(
+            tag::<_, _, VE>("the "),
+            terminated(parse_base_pt_axes, tag(" of ")),
+        )
+        .parse(parse_lower)
+        .ok()
+        .and_then(|(after_of_lower, axes)| {
+            let target_text = &parse_body[parse_body.len() - after_of_lower.len()..];
+            let (filter, target_remainder, syntax) = parse_target_with_syntax(target_text, ctx);
+            if !matches!(syntax, TargetSyntax::TargetKeyword) {
+                // Durationless inverted-transitive descriptor effects (such as
+                // Brine Hag) need duration provenance the existing
+                // `GenericEffect` representation cannot yet express. Keep
+                // them unsupported rather than lowering them incorrectly as
+                // until-end-of-turn effects; this targeted arm is for cards
+                // such as Exuberant Wolfbear with an explicit duration.
+                return None;
+            }
+            let target_remainder_lower = target_remainder.to_lowercase();
+            let (after_to_lower, _) = tag::<_, _, VE>(" to ")
+                .parse(target_remainder_lower.as_str())
+                .ok()?;
+            let remainder = &target_remainder[target_remainder.len() - after_to_lower.len()..];
+            let application = subject_filter_application(filter, true)?;
+            Some((axes, remainder, application))
+        })
+    } else {
+        None
+    };
+    let (subject, axes, remainder, target_application) =
+        if let Some((axes, remainder, application)) = targeted_inverted {
+            ("", axes, remainder, Some(application))
+        } else if let Some((rest_lower, (axes, _, subject_lower, _, _, _))) = inverted {
             // `subject_lower` is a sub-slice of `parse_lower`; its byte offset is
             // the pointer delta. Recover original case at the same span.
             let subject_start = subject_lower.as_ptr() as usize - parse_lower.as_ptr() as usize;
@@ -1204,7 +1246,7 @@ fn try_parse_subject_base_pt_set_clause_ast(
                 .get(subject_start..subject_start + subject_lower.len())?
                 .trim();
             let remainder = &parse_body[parse_body.len() - rest_lower.len()..];
-            (subject, axes, remainder)
+            (subject, axes, remainder, None)
         } else {
             // Possessive: "<subject>'s base power [and toughness]" followed by the
             // copula (" to " for the transitive "change" frame, else "become[s] ").
@@ -1230,7 +1272,7 @@ fn try_parse_subject_base_pt_set_clause_ast(
             let (rest_lower, ()) = parse_base_pt_copula(rest_lower, is_change).ok()?;
             let subject = parse_body[..subject_lower.len()].trim();
             let remainder = &parse_body[parse_body.len() - rest_lower.len()..];
-            (subject, axes, remainder)
+            (subject, axes, remainder, None)
         };
 
     // Parse the value side. The transitive "change … to" frame carries a bare
@@ -1249,7 +1291,7 @@ fn try_parse_subject_base_pt_set_clause_ast(
     // Parse the optional trailing keyword-grant conjunct ("and they gain trample").
     let keywords = parse_base_pt_set_trailing_keywords(after_pt);
 
-    let application = parse_subject_application(subject, ctx)?;
+    let application = target_application.or_else(|| parse_subject_application(subject, ctx))?;
     let affected = static_affected_for_application(&application);
 
     // CR 208.1 + CR 613.4b: emit per-axis layer-7b set modifications. Fixed

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -2839,6 +2839,125 @@ fn sita_varma_full_card_supported_inverted_genitive_base_pt() {
     );
 }
 
+/// CR 603.2 + CR 115.1 + CR 208.1 + CR 613.4b: Exuberant Wolfbear's attack
+/// trigger uses the transitive inverted-genitive base-P/T form, "change the
+/// base power and toughness of target Human you control to this creature's
+/// power and toughness." The target must remain a real target slot (rather
+/// than a resolution-time descriptor), and each axis reads the attacking source.
+#[test]
+fn exuberant_wolfbear_full_oracle_attack_trigger_targets_human_and_sets_dynamic_base_pt() {
+    const ORACLE: &str = "Whenever this creature attacks, you may change the base power and toughness of target Human you control to this creature's power and toughness until end of turn.";
+
+    let parsed = parse(
+        ORACLE,
+        "Exuberant Wolfbear",
+        &[],
+        &["Creature"],
+        &["Wolf", "Bear"],
+    );
+    assert_eq!(
+        parsed.triggers.len(),
+        1,
+        "expected one attack trigger: {parsed:#?}"
+    );
+    assert!(
+        parsed
+            .abilities
+            .iter()
+            .all(|ability| !matches!(ability.effect.as_ref(), Effect::Unimplemented { .. })),
+        "Wolfbear must not produce standalone Unimplemented abilities: {parsed:#?}"
+    );
+
+    let trigger = &parsed.triggers[0];
+    assert_eq!(trigger.mode, TriggerMode::Attacks);
+    assert!(trigger.optional, "'you may' must keep the trigger optional");
+    let execute = trigger
+        .execute
+        .as_deref()
+        .expect("attack trigger must have an execute body");
+
+    fn assert_no_unimplemented(definition: &AbilityDefinition) {
+        assert!(
+            !matches!(definition.effect.as_ref(), Effect::Unimplemented { .. }),
+            "unexpected unimplemented effect: {definition:#?}"
+        );
+        if let Some(sub_ability) = definition.sub_ability.as_deref() {
+            assert_no_unimplemented(sub_ability);
+        }
+    }
+    assert_no_unimplemented(execute);
+
+    let Effect::GenericEffect {
+        static_abilities,
+        duration,
+        target,
+        ..
+    } = execute.effect.as_ref()
+    else {
+        panic!("expected base-P/T GenericEffect, got {:#?}", execute.effect);
+    };
+    assert_eq!(*duration, Some(Duration::UntilEndOfTurn));
+    assert_eq!(
+        target,
+        &Some(TargetFilter::Typed(
+            TypedFilter::new(TypeFilter::Subtype("Human".to_string()))
+                .controller(ControllerRef::You)
+        )),
+        "the explicit target keyword must produce a Human-you-control target slot"
+    );
+
+    let modifications = &static_abilities[0].modifications;
+    for (label, modification) in [
+        (
+            "power",
+            ContinuousModification::SetPowerDynamic {
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::Power {
+                        scope: ObjectScope::Source,
+                    },
+                },
+            },
+        ),
+        (
+            "toughness",
+            ContinuousModification::SetToughnessDynamic {
+                value: QuantityExpr::Ref {
+                    qty: QuantityRef::Toughness {
+                        scope: ObjectScope::Source,
+                    },
+                },
+            },
+        ),
+    ] {
+        assert!(
+            modifications.contains(&modification),
+            "Wolfbear must set dynamic base {label} from the source: {modifications:#?}"
+        );
+    }
+}
+
+/// Regression: Brine Hag's durationless, descriptor-scoped inverted transitive
+/// base-P/T effect must remain an explicit parser gap. Only the `target`
+/// syntactic form can use the new target-slot lowering path.
+#[test]
+fn brine_hag_durationless_descriptor_base_pt_effect_remains_unimplemented() {
+    const ORACLE: &str = "When this creature dies, change the base power and toughness of all creatures that dealt damage to it this turn to 0/2. (This effect lasts indefinitely.)";
+
+    let parsed = parse(ORACLE, "Brine Hag", &[], &["Creature"], &[]);
+    assert_eq!(
+        parsed.triggers.len(),
+        1,
+        "expected Brine Hag's dies trigger: {parsed:#?}"
+    );
+    assert!(
+        has_unimplemented_mentioning(
+            &parsed,
+            "change the base power and toughness of all creatures that dealt damage to it this turn to 0/2",
+        ),
+        "the durationless descriptor form must not lower through the target-only path: {parsed:#?}"
+    );
+}
+
 /// CR 601.2a + CR 609.4b + CR 601.3b: Azula, Cunning Usurper — the
 /// cast-from-exile static line must lower to a supported
 /// `StaticMode::ExileCastPermission` carrying the persistent Cast permission,

--- a/crates/engine/tests/integration/exuberant_wolfbear_base_pt_target.rs
+++ b/crates/engine/tests/integration/exuberant_wolfbear_base_pt_target.rs
@@ -49,7 +49,7 @@ fn setup() -> (GameRunner, ObjectId, ObjectId, ObjectId, ObjectId) {
     )
 }
 
-fn attack_until_optional_choice(runner: &mut GameRunner, wolfbear: ObjectId) {
+fn attack_until_target_selection(runner: &mut GameRunner, wolfbear: ObjectId) {
     runner.pass_both_players();
     runner
         .act(GameAction::DeclareAttackers {
@@ -60,6 +60,29 @@ fn attack_until_optional_choice(runner: &mut GameRunner, wolfbear: ObjectId) {
 
     for _ in 0..16 {
         match runner.state().waiting_for.clone() {
+            WaitingFor::TriggerTargetSelection { source_id, .. } => {
+                assert_eq!(
+                    source_id,
+                    Some(wolfbear),
+                    "Wolfbear must own the target prompt"
+                );
+                return;
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+            }
+            WaitingFor::Priority { .. } => runner.pass_both_players(),
+            other => {
+                panic!("expected Wolfbear's target selection, got waiting state {other:?}")
+            }
+        }
+    }
+    panic!("Wolfbear attack trigger did not reach target selection");
+}
+
+fn target_selected_until_optional_choice(runner: &mut GameRunner, wolfbear: ObjectId) {
+    for _ in 0..16 {
+        match runner.state().waiting_for.clone() {
             WaitingFor::OptionalEffectChoice { source_id, .. } => {
                 assert_eq!(source_id, wolfbear, "Wolfbear must own the may prompt");
                 return;
@@ -68,9 +91,7 @@ fn attack_until_optional_choice(runner: &mut GameRunner, wolfbear: ObjectId) {
                 engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
             }
             WaitingFor::Priority { .. } => runner.pass_both_players(),
-            other => {
-                panic!("expected Wolfbear's optional attack trigger, got waiting state {other:?}")
-            }
+            other => panic!("expected Wolfbear's optional choice, got waiting state {other:?}"),
         }
     }
     panic!("Wolfbear attack trigger did not reach its optional choice");
@@ -104,10 +125,7 @@ fn exuberant_wolfbear_accepts_only_controlled_humans_and_expires_at_cleanup() {
     let (mut runner, wolfbear, chosen_human, other_human, opponent_human) = setup();
     let current_turn = runner.state().turn_number;
 
-    attack_until_optional_choice(&mut runner, wolfbear);
-    runner
-        .act(GameAction::DecideOptionalEffect { accept: true })
-        .expect("controller may accept Wolfbear's trigger");
+    attack_until_target_selection(&mut runner, wolfbear);
 
     let chosen_target = match runner.state().waiting_for.clone() {
         WaitingFor::TriggerTargetSelection {
@@ -146,6 +164,10 @@ fn exuberant_wolfbear_accepts_only_controlled_humans_and_expires_at_cleanup() {
             target: Some(chosen_target),
         })
         .expect("select the engine-offered controlled Human target");
+    target_selected_until_optional_choice(&mut runner, wolfbear);
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("controller may accept Wolfbear's trigger");
     runner.advance_until_stack_empty();
 
     assert_eq!(
@@ -176,7 +198,28 @@ fn exuberant_wolfbear_accepts_only_controlled_humans_and_expires_at_cleanup() {
 fn exuberant_wolfbear_decline_leaves_controlled_human_unchanged() {
     let (mut runner, wolfbear, chosen_human, _other_human, _opponent_human) = setup();
 
-    attack_until_optional_choice(&mut runner, wolfbear);
+    attack_until_target_selection(&mut runner, wolfbear);
+    let chosen_target = match runner.state().waiting_for.clone() {
+        WaitingFor::TriggerTargetSelection {
+            target_slots,
+            selection,
+            ..
+        } => target_slots[selection.current_slot]
+            .legal_targets
+            .iter()
+            .find(|target| {
+                matches!(target, engine::types::ability::TargetRef::Object(id) if *id == chosen_human)
+            })
+            .cloned()
+            .expect("chosen controlled Human must be offered by the engine"),
+        other => panic!("expected target selection before optional choice: {other:?}"),
+    };
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(chosen_target),
+        })
+        .expect("select the engine-offered controlled Human target");
+    target_selected_until_optional_choice(&mut runner, wolfbear);
     runner
         .act(GameAction::DecideOptionalEffect { accept: false })
         .expect("controller may decline Wolfbear's trigger");

--- a/crates/engine/tests/integration/exuberant_wolfbear_base_pt_target.rs
+++ b/crates/engine/tests/integration/exuberant_wolfbear_base_pt_target.rs
@@ -1,0 +1,190 @@
+//! Exuberant Wolfbear's attack trigger targets a Human its controller controls
+//! and sets that Human's base power and toughness to the attacker's current P/T
+//! until end of turn.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+use super::rules::AttackTarget;
+
+const WOLFBEAR_ORACLE: &str = "Whenever this creature attacks, you may change the base power and toughness of target Human you control to this creature's power and toughness until end of turn.";
+
+fn power_toughness(runner: &GameRunner, object_id: ObjectId) -> (Option<i32>, Option<i32>) {
+    let object = runner
+        .state()
+        .objects
+        .get(&object_id)
+        .expect("test permanent must remain on the battlefield");
+    (object.power, object.toughness)
+}
+
+fn setup() -> (GameRunner, ObjectId, ObjectId, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let wolfbear = scenario
+        .add_creature_from_oracle(P0, "Exuberant Wolfbear", 7, 5, WOLFBEAR_ORACLE)
+        .id();
+    let chosen_human = scenario
+        .add_creature(P0, "Chosen Human", 1, 1)
+        .with_subtypes(vec!["Human"])
+        .id();
+    let other_human = scenario
+        .add_creature(P0, "Other Human", 1, 1)
+        .with_subtypes(vec!["Human"])
+        .id();
+    let opponent_human = scenario
+        .add_creature(P1, "Opponent Human", 1, 1)
+        .with_subtypes(vec!["Human"])
+        .id();
+
+    (
+        scenario.build(),
+        wolfbear,
+        chosen_human,
+        other_human,
+        opponent_human,
+    )
+}
+
+fn attack_until_optional_choice(runner: &mut GameRunner, wolfbear: ObjectId) {
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(wolfbear, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("Wolfbear attack declaration must succeed");
+
+    for _ in 0..16 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalEffectChoice { source_id, .. } => {
+                assert_eq!(source_id, wolfbear, "Wolfbear must own the may prompt");
+                return;
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+            }
+            WaitingFor::Priority { .. } => runner.pass_both_players(),
+            other => {
+                panic!("expected Wolfbear's optional attack trigger, got waiting state {other:?}")
+            }
+        }
+    }
+    panic!("Wolfbear attack trigger did not reach its optional choice");
+}
+
+fn finish_current_turn(runner: &mut GameRunner, turn_number: u32) {
+    for _ in 0..32 {
+        if runner.state().turn_number > turn_number {
+            return;
+        }
+        match runner.state().waiting_for.clone() {
+            WaitingFor::Priority { .. } => runner.pass_both_players(),
+            WaitingFor::DeclareBlockers { .. } => {
+                runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .expect("defender may declare no blockers");
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+            }
+            other => panic!("unexpected state while advancing to cleanup: {other:?}"),
+        }
+    }
+    panic!("turn did not advance through cleanup");
+}
+
+#[test]
+fn exuberant_wolfbear_accepts_only_controlled_humans_and_expires_at_cleanup() {
+    let (mut runner, wolfbear, chosen_human, other_human, opponent_human) = setup();
+    let current_turn = runner.state().turn_number;
+
+    attack_until_optional_choice(&mut runner, wolfbear);
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("controller may accept Wolfbear's trigger");
+
+    let chosen_target = match runner.state().waiting_for.clone() {
+        WaitingFor::TriggerTargetSelection {
+            target_slots,
+            selection,
+            ..
+        } => {
+            let legal_targets = &target_slots[selection.current_slot].legal_targets;
+            let legal_object_ids: Vec<_> = legal_targets
+                .iter()
+                .filter_map(|target| match target {
+                    engine::types::ability::TargetRef::Object(id) => Some(*id),
+                    engine::types::ability::TargetRef::Player(_) => None,
+                })
+                .collect();
+            assert!(
+                legal_object_ids.contains(&chosen_human) && legal_object_ids.contains(&other_human),
+                "both controlled Humans must be legal targets: {legal_targets:?}"
+            );
+            assert!(
+                !legal_object_ids.contains(&opponent_human),
+                "opponent's Human must not be a legal target: {legal_targets:?}"
+            );
+            legal_targets
+                .iter()
+                .find(|target| {
+                    matches!(target, engine::types::ability::TargetRef::Object(id) if *id == chosen_human)
+                })
+                .cloned()
+                .expect("chosen controlled Human must be offered by the engine")
+        }
+        other => panic!("expected target selection after accepting Wolfbear: {other:?}"),
+    };
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(chosen_target),
+        })
+        .expect("select the engine-offered controlled Human target");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        power_toughness(&runner, chosen_human),
+        (Some(7), Some(5)),
+        "selected Human must take Wolfbear's 7/5 base P/T this turn"
+    );
+    assert_eq!(
+        power_toughness(&runner, other_human),
+        (Some(1), Some(1)),
+        "unchosen controlled Human must stay 1/1"
+    );
+    assert_eq!(
+        power_toughness(&runner, opponent_human),
+        (Some(1), Some(1)),
+        "opponent's Human must stay 1/1"
+    );
+
+    finish_current_turn(&mut runner, current_turn);
+    assert_eq!(
+        power_toughness(&runner, chosen_human),
+        (Some(1), Some(1)),
+        "until-end-of-turn base P/T must expire during cleanup"
+    );
+}
+
+#[test]
+fn exuberant_wolfbear_decline_leaves_controlled_human_unchanged() {
+    let (mut runner, wolfbear, chosen_human, _other_human, _opponent_human) = setup();
+
+    attack_until_optional_choice(&mut runner, wolfbear);
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: false })
+        .expect("controller may decline Wolfbear's trigger");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        power_toughness(&runner, chosen_human),
+        (Some(1), Some(1)),
+        "declining Wolfbear's optional trigger must leave the Human unchanged"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -210,6 +210,7 @@ mod exile_dynamic_from_top;
 mod export_runtime_canaries;
 mod exquisite_blood_routing;
 mod extract_power_each_player_exile;
+mod exuberant_wolfbear_base_pt_target;
 mod eyetwitch_learn_decline_lesson;
 mod fact_or_fiction_pile_separation;
 mod fantastic_four_bounded_loop;


### PR DESCRIPTION
## Summary

Adds parser support for Exuberant Wolfbear's inverted-transitive base power/toughness trigger. The target is parsed through the existing target grammar, so only a controlled Human is selected and the temporary P/T change uses the existing continuous-effect pipeline.

## Files changed

- `crates/engine/src/parser/oracle_effect/subject.rs`
- `crates/engine/src/parser/oracle_tests.rs`
- `crates/engine/tests/integration/exuberant_wolfbear_base_pt_target.rs`
- `crates/engine/tests/integration/main.rs`

## Track

Developer

## LLM

Model: gpt-5-6
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

CR 603.2, CR 603.3d, CR 603.5, CR 115.1, CR 208.1, CR 613.4b, and CR 514.2.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — PASS
- `git diff --check` — PASS
- `./scripts/check-parser-combinators.sh` — `Gate G PASS`; `Gate A PASS head=6066103d48d5abca7d8cbc7565bae68e48b497c9 base=ee76bc54aee4941f20c126b49c5d6b54a36d86c5`
- `cargo test -p phase-engine exuberant_wolfbear --lib` — `rustc` terminated with `SIGTERM` before test execution; no compiler diagnostics (recorded below).

## Gate A

Gate A PASS head=6066103d48d5abca7d8cbc7565bae68e48b497c9 base=ee76bc54aee4941f20c126b49c5d6b54a36d86c5

## Anchored on

- `crates/engine/src/parser/oracle_effect/subject.rs:1136` — existing base-P/T clause parser owns axes, value lowering, target threading, and `GenericEffect` emission.
- `crates/engine/src/parser/oracle_effect/subject.rs:3531` — existing `subject_filter_application` preserves target-versus-mass semantics.

## Final review-impl

Final review-impl PASS head=6066103d48d5abca7d8cbc7565bae68e48b497c9

## Claimed parse impact

Exuberant Wolfbear.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

`cargo test -p phase-engine exuberant_wolfbear --lib` could not complete because the environment terminated the `phase-engine` `rustc` process with `signal: 15, SIGTERM` after compilation began. No test result or compiler diagnostic was emitted. Tilt was unavailable (`exit 127`).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved support for targeted base power and toughness changes.
  * Added support for effects that modify a target’s base power and toughness until end of turn.

* **Bug Fixes**
  * Correctly handles optional attack triggers and legal target selection.
  * Ensures effects apply only to eligible targets and can be declined without unintended changes.

* **Tests**
  * Added regression and integration coverage for these behaviors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->