### PR TITLE
ci: split Rust test job into four nextest shards

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,13 +118,13 @@ jobs:
           ./scripts/check-test-card-data-load.sh "$BASE"
 
   rust-test:
-    name: Rust tests (shard ${{ matrix.shard }}/2)
+    name: Rust tests (shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
     timeout-minutes: 30
     strategy:
       fail-fast: false
       matrix:
-        shard: [1, 2]
+        shard: [1, 2, 3, 4]
     steps:
       - uses: actions/checkout@v4
 
@@ -174,7 +174,7 @@ jobs:
         # caught before it lands on the branch that feeds staging/preview.
         env:
           PROPTEST_CASES: ${{ github.event_name == 'pull_request' && '32' || '256' }}
-        run: cargo nextest run --profile ci --partition count:${{ matrix.shard }}/2 --workspace --exclude phase-tauri --exclude mtgish-import --features engine/proptest --status-level fail --final-status-level fail
+        run: cargo nextest run --profile ci --partition count:${{ matrix.shard }}/4 --workspace --exclude phase-tauri --exclude mtgish-import --features engine/proptest --status-level fail --final-status-level fail
 
   card-data-gate:
     name: Card data (generate, validate, coverage)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,7 @@ jobs:
   rust-test:
     name: Rust tests (shard ${{ matrix.shard }}/4)
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Splits the `rust-test` matrix from two nextest count-partition shards to four, roughly halving per-shard test-execution wall-clock, and lowers the per-shard timeout from 30 to 20 minutes to match. USER-requested change.

**Hard-stop self-flag:** this PR edits `.github/workflows/**`, a `hard_stops` path in `.agents/pr-review-policy.toml` — posted for the maintainer to apply/approve per policy; no contributor urgency.

## Files changed

- `.github/workflows/ci.yml` — `rust-test` job: shard matrix `[1, 2]` → `[1, 2, 3, 4]`, job name `/2` → `/4`, nextest `--partition count:N/2` → `count:N/4`, `timeout-minutes: 30` → `20` (4 lines)

## Track

Developer

## LLM

Model: claude-fable-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — CI workflow matrix change only; no `crates/engine/` game logic touched.

## CR references

None. No game logic is touched.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `scripts/check-parser-combinators.sh upstream/main` at `e080f402d` — Gate G PASS, Gate A PASS, Gate P PASS
- CI-owned alternative for the workflow itself: `pull_request` runs use the merge-commit's workflow file, so **this PR's own CI run exercises the four-shard matrix and the 20-minute ceiling** — the change validates itself on this PR, and the run's shard durations are the measurement for the new timeout.

Blast-radius checks, measured:

- `rust-check` aggregation (`ci.yml` `needs.rust-test.result`) is matrix-wide — no downstream job change needed.
- The `main merge queue` ruleset uses `ALLGREEN` grouping with no name-pinned `required_status_checks` contexts (ruleset 16952848 queried via API), so renaming `Rust tests (shard N/2)` → `(shard N/4)` orphans no pinned required check. If any org-level setting invisible to the contributor pins the old names, it needs the same rename.
- `.config/nextest.toml` references "the rust-test matrix" generically (no shard-count literal) — no comment drift.
- Timeout note: per-shard workspace build cost is unchanged (each shard already builds the whole workspace); only execution shrinks to a quarter partition. A cold-sccache run is the case that could approach the new 20-minute ceiling — this PR's own shard timings are the direct evidence either way.

## Gate A

Gate A PASS head=e080f402df911d59ef051b37b6f31721d61d8659 base=ee76bc54aee4941f20c126b49c5d6b54a36d86c5

## Anchored on

- .github/workflows/ci.yml:127 — the existing shard matrix being extended (same seam, same mechanism)
- .github/workflows/ci.yml:679 — `rust-check` matrix-wide aggregation that makes the shard count a local detail

## Final review-impl

Final review-impl PASS head=e080f402df911d59ef051b37b6f31721d61d8659

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Increased parallel test execution from two to four shards.
  * Reduced the test job timeout from 30 to 20 minutes.
  * Improved automated test throughput and feedback speed without changing application functionality or end-user behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->