### PR TITLE
fix(native): harden resolve all transport

### DIFF
--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -200,11 +200,36 @@ describe("WebSocketAdapter", () => {
     });
   });
 
-  it("rejects Resolve All when the server reports a batch error", async () => {
+  it("settles Resolve All only from its correlated server response", async () => {
     const resultPromise = adapter.resolveAll(0, [{ playerId: 1, difficulty: "Medium" }], 5);
+    const settled = vi.fn();
+    void resultPromise.then(settled, settled);
+
     ws.dispatchSynthetic(
       "message",
       JSON.stringify({ type: "Error", data: { message: "batch snapshot rejected" } }),
+    );
+    ws.dispatchSynthetic(
+      "message",
+      JSON.stringify({ type: "ActionRejected", data: { reason: "stale action rejection" } }),
+    );
+    ws.dispatchSynthetic(
+      "message",
+      JSON.stringify({
+        type: "ResolveAllRejected",
+        data: { request_id: 2, reason: "a different batch" },
+      }),
+    );
+
+    await Promise.resolve();
+    expect(settled).not.toHaveBeenCalled();
+
+    ws.dispatchSynthetic(
+      "message",
+      JSON.stringify({
+        type: "ResolveAllRejected",
+        data: { request_id: 1, reason: "batch snapshot rejected" },
+      }),
     );
 
     await expect(resultPromise).rejects.toMatchObject({ message: "batch snapshot rejected" });

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -3841,6 +3841,8 @@ export interface EngineAdapter {
     aiSeats: { playerId: number; difficulty: string }[],
     maxResolutions?: number,
   ): Promise<BatchResolveResult>;
+  /** True when Resolve All delegates AI decisions to the authenticated server. */
+  readonly resolveAllUsesServerAi?: true;
   restoreState(state: PersistedGameState): void | Promise<void>;
   /** Trusted local persistence snapshot, when this adapter owns the engine. */
   exportPersistenceState?(): Promise<string>;

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -203,6 +203,7 @@ export class NativeEngineVersionMismatchError extends Error {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 29 — Added requester-correlated ResolveAllRejected response frames.
  * 28 — Added native ResolveAll request/result frames.
  * 27 — Added DraftKind.Sealed, serialized by draft WebSocket messages.
  * 26 — Added ActionNoOp acknowledgement for accepted transport no-ops.
@@ -235,7 +236,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 28;
+export const PROTOCOL_VERSION = 29;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.
@@ -326,6 +327,7 @@ function playerNamesFromWire(names: string[]): Record<number, string> {
 export class WebSocketAdapter implements EngineAdapter {
   readonly supportsMatchConcede = true;
   readonly supportsServerRewind = true;
+  readonly resolveAllUsesServerAi: true | undefined;
   private ws: PhaseSocketTransport | null = null;
   /**
    * The single cached engine pair, rebuilt (and re-stamped) once per inbound
@@ -410,6 +412,7 @@ export class WebSocketAdapter implements EngineAdapter {
     private readonly displayName = "Player",
     private readonly options: WebSocketAdapterOptions = {},
   ) {
+    this.resolveAllUsesServerAi = options.nativeAi ? true : undefined;
     // 0 is terminal, not "retry once": `attemptReconnect` compares
     // `reconnectAttempt >= maxReconnectAttempts`, so 0 >= 0 is true on the
     // very first attempt — it emits `reconnectFailed` and returns without
@@ -1479,9 +1482,6 @@ export class WebSocketAdapter implements EngineAdapter {
           );
           this.pendingResolve = null;
           this.pendingReject = null;
-        } else if (this.pendingResolveAll) {
-          this.pendingResolveAll.reject(actionRejectionError(data.reason));
-          this.pendingResolveAll = null;
         } else {
           // No in-flight action owns this rejection, so it answers a
           // fire-and-forget request — `sendRequestTakeback` is the only one
@@ -1521,6 +1521,15 @@ export class WebSocketAdapter implements EngineAdapter {
             itemsResolved: data.items_resolved,
             total: data.total,
           });
+          this.pendingResolveAll = null;
+        }
+        break;
+      }
+
+      case "ResolveAllRejected": {
+        const data = msg.data as { request_id: number; reason: string };
+        if (this.pendingResolveAll?.requestId === data.request_id) {
+          this.pendingResolveAll.reject(actionRejectionError(data.reason));
           this.pendingResolveAll = null;
         }
         break;
@@ -1720,10 +1729,6 @@ export class WebSocketAdapter implements EngineAdapter {
         this.rejectInitialization(initializationError);
         this.rejectPregameMutation(actionRejectionError(data.message));
         this.rejectAbandon(actionRejectionError(data.message));
-        if (this.pendingResolveAll) {
-          this.pendingResolveAll.reject(actionRejectionError(data.message));
-          this.pendingResolveAll = null;
-        }
         this.emit({ type: "error", message: data.message });
         break;
       }

--- a/client/src/components/board/ActionButton.tsx
+++ b/client/src/components/board/ActionButton.tsx
@@ -422,11 +422,13 @@ export function ActionButton() {
                 // starts Resolve All; stack pressure never opts the player in.
                 // Draft matches: only a Bot pairing has an AI seat, and it uses
                 // the same binding installMatchRuntime gives the live controller.
-                // Everything else — "local" hotseat above all (#4978) — gets an
-                // empty list so dispatchResolveAll falls back to the per-seat
-                // engine auto-yield instead of handing human seats to the AI.
+                // Native AI likewise gets an empty list: its authenticated server
+                // advertises the Resolve All capability and owns AI-seat selection.
+                // Everything else — "local" hotseat above all (#4978) — falls
+                // back to per-seat engine auto-yield instead of handing human
+                // seats to the AI.
                 let seats: { playerId: number; difficulty: string }[] = [];
-                if (gameMode === "ai" || gameMode === "native-ai") {
+                if (gameMode === "ai") {
                   const playerCount = gs?.players?.length ?? 2;
                   const aiSeats = usePreferencesStore.getState().aiSeats;
                   seats = Array.from({ length: playerCount - 1 }, (_, i) => ({

--- a/client/src/components/board/__tests__/ActionButton.test.tsx
+++ b/client/src/components/board/__tests__/ActionButton.test.tsx
@@ -181,7 +181,7 @@ describe("ActionButton", () => {
     ]);
   });
 
-  it("builds the AI seat list for native AI Resolve All", () => {
+  it("leaves native AI Resolve All seat ownership to the server", () => {
     useGameStore.setState({
       gameMode: "native-ai",
       gameState: {
@@ -197,9 +197,7 @@ describe("ActionButton", () => {
     render(<ActionButton />);
 
     fireEvent.click(screen.getByRole("button", { name: /^Resolve All/ }));
-    expect(vi.mocked(dispatchResolveAll)).toHaveBeenLastCalledWith(0, [
-      { playerId: 1, difficulty: "Medium" },
-    ]);
+    expect(vi.mocked(dispatchResolveAll)).toHaveBeenLastCalledWith(0, []);
   });
 
   it("uses the live controller's bot seat binding for a Bot draft match", () => {

--- a/client/src/game/__tests__/dispatchResolveAll.test.ts
+++ b/client/src/game/__tests__/dispatchResolveAll.test.ts
@@ -167,6 +167,28 @@ describe("dispatchResolveAll progress", () => {
     );
   });
 
+  it("uses an empty AI-seat list when the adapter delegates native AI ownership to its server", async () => {
+    const resolveAll = vi.fn<EngineResolveAll>().mockResolvedValue(chunk(0, 2));
+    const getState = vi.fn().mockResolvedValue(stateWithStack(0));
+    const submitAction = vi.fn();
+    useGameStore.setState({
+      gameState: stateWithStack(2),
+      adapter: {
+        resolveAll,
+        resolveAllUsesServerAi: true,
+        submitAction,
+        getState,
+        getLegalActions: vi.fn().mockResolvedValue({ actions: [], autoPassRecommended: false }),
+        getSnapshot: snapshotVia(getState),
+      } as never,
+    });
+
+    await dispatchResolveAll(0, []);
+
+    expect(resolveAll).toHaveBeenCalledWith(0, [], 5);
+    expect(submitAction).not.toHaveBeenCalled();
+  });
+
   it("falls back to an engine-side UntilStackEmpty auto-pass when the adapter has no batch resolveAll (multiplayer)", async () => {
     const submitAction = vi
       .fn<(action: unknown, actor: number) => Promise<{ events: never[] }>>()

--- a/client/src/game/__tests__/dispatchResolveAll.test.ts
+++ b/client/src/game/__tests__/dispatchResolveAll.test.ts
@@ -3,6 +3,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { BatchResolveResult, EngineSnapshot, GameState } from "../../adapter/types";
 import { nextSnapshotSeq } from "../../adapter/types";
 import { useGameStore } from "../../stores/gameStore";
+import { useAppNotificationStore } from "../../stores/appToastStore";
 import { usePreferencesStore } from "../../stores/preferencesStore";
 import { buildGameState, buildPriorityWaitingFor, buildStackEntry } from "../../test/factories/gameStateFactory";
 import { dispatchResolveAll } from "../dispatch";
@@ -41,6 +42,7 @@ describe("dispatchResolveAll progress", () => {
   beforeEach(() => {
     progressCalls = [];
     usePreferencesStore.setState({ animationSpeedMultiplier: 1.0 });
+    useAppNotificationStore.setState({ notification: null, expiresAt: 0 });
     // Stack length read at each iteration start to classify pressure; keep it
     // in the "Instant" band (>=100) so the rAF-yield branch is exercised.
     useGameStore.setState({
@@ -187,6 +189,29 @@ describe("dispatchResolveAll progress", () => {
 
     expect(resolveAll).toHaveBeenCalledWith(0, [], 5);
     expect(submitAction).not.toHaveBeenCalled();
+  });
+
+  it("shows a server-provided Resolve All rejection without rejecting the click handler", async () => {
+    const resolveAll = vi
+      .fn<EngineResolveAll>()
+      .mockRejectedValue(new Error("Resolve All requires your priority"));
+    const getState = vi.fn().mockResolvedValue(stateWithStack(2));
+    useGameStore.setState({
+      gameState: stateWithStack(2),
+      adapter: {
+        resolveAll,
+        resolveAllUsesServerAi: true,
+        getState,
+        getLegalActions: vi.fn().mockResolvedValue({ actions: [], autoPassRecommended: false }),
+        getSnapshot: snapshotVia(getState),
+      } as never,
+    });
+
+    await expect(dispatchResolveAll(0, [])).resolves.toBeUndefined();
+
+    expect(useAppNotificationStore.getState().notification).toMatchObject({
+      description: "Resolve All requires your priority",
+    });
   });
 
   it("falls back to an engine-side UntilStackEmpty auto-pass when the adapter has no batch resolveAll (multiplayer)", async () => {

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -1079,6 +1079,9 @@ export async function dispatchResolveAll(
     if (gameId && adapter && newState) {
       await saveAuthoritativeGame(gameId, adapter, newState);
     }
+  } catch (err) {
+    debugLog(`Resolve All error: ${err instanceof Error ? err.message : String(err)}`);
+    showActionError({ type: "PassPriority" }, err);
   } finally {
     batchResolveInProgress = false;
     setIsResolvingAll(false);

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -979,11 +979,14 @@ export async function dispatchResolveAll(
     debugLog("dispatchResolveAll: no adapter");
     return;
   }
-  if (!batchAdapter.resolveAll || aiSeats.length === 0) {
-    // No batch drain (transports without the capability), or no AI deciders for the other
-    // seats (local hotseat — every seat is a human, #4978): those seats are
-    // humans, and CR 117.4 entitles each of them to their own priority window
-    // before anything resolves — the engine must not pass on their behalf.
+  if (
+    !batchAdapter.resolveAll
+    || (aiSeats.length === 0 && batchAdapter.resolveAllUsesServerAi !== true)
+  ) {
+    // No batch drain (transports without the capability), or no AI deciders for
+    // the other seats (local hotseat — every seat is a human, #4978). A native
+    // adapter explicitly vouches that its authenticated server owns AI-seat
+    // selection; all other transports must preserve human priority windows.
     // Arena-style "Resolve All" instead: an engine-side auto-yield for THIS
     // seat only (AutoPassMode::UntilStackEmpty), which auto-passes whenever
     // this player receives priority and clears itself when the stack empties

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -43,6 +43,8 @@ pub enum ServerErrorCode {
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
 ///
+/// 29 — Added requester-correlated `ResolveAllRejected` response frames.
+/// 28 — Added native `ResolveAll` request/result frames.
 /// 27 — Added `DraftKind::Sealed`, serialized by draft WebSocket messages.
 /// 26 — Added `ServerMessage::ActionNoOp` for accepted transport no-ops.
 /// 25 — `DebugCardEntries` added a serialized, private resolution frame for
@@ -74,7 +76,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 28;
+pub const PROTOCOL_VERSION: u32 = 29;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake. Lobby traffic has a one-version rollout window; full game servers
@@ -411,12 +413,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 28);
+        assert_eq!(PROTOCOL_VERSION, 29);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot
         // understand a success acknowledgment the submitting client awaits.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 27);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 28);
     }
 
     #[test]

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -4275,7 +4275,19 @@ async fn handle_resolve_all(
         legal_actions_by_object: by_object,
         spell_costs,
     }) {
-        let _ = tx.send(ServerMessage::ResolveAllRejected { request_id, reason });
+        warn!(game = %game_code, %reason, "Resolve All snapshot exceeds broadcast bounds after commit");
+        let _ = tx.send(build_resolve_all_state_update_message(
+            raw_state,
+            log_entries,
+            legal_actions,
+            spell_costs,
+            by_object,
+            revision,
+            requester,
+            eliminated.clone(),
+            rewind_targets.clone(),
+        ));
+        let _ = tx.send(acknowledgement);
         return;
     }
 
@@ -4283,10 +4295,19 @@ async fn handle_resolve_all(
         Some(artifact) => match prepare_full_terminal(game_db, artifact).await {
             Ok(deliveries) => deliveries,
             Err(error) => {
-                let _ = tx.send(ServerMessage::ResolveAllRejected {
-                    request_id,
-                    reason: error,
-                });
+                error!(game = %game_code, %error, "Resolve All terminal preparation failed after commit");
+                let _ = tx.send(build_resolve_all_state_update_message(
+                    raw_state,
+                    log_entries,
+                    legal_actions,
+                    spell_costs,
+                    by_object,
+                    revision,
+                    requester,
+                    eliminated.clone(),
+                    rewind_targets.clone(),
+                ));
+                let _ = tx.send(acknowledgement);
                 return;
             }
         },

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -497,12 +497,15 @@ fn build_state_update_message(
 
 /// Resolve All can collect thousands of engine events. They are needed for
 /// authoritative transition bookkeeping, but replaying them in one wire frame
-/// defeats the batch path and breaches the snapshot payload guard. Publish the
-/// final, fully-derived state only; the requester acknowledgement carries
-/// progress metadata separately.
+/// defeats the batch path and breaches the snapshot payload guard. Preserve a
+/// bounded tail of engine-authored logs alongside the final, fully-derived
+/// state; the requester acknowledgement carries progress metadata separately.
+const MAX_RESOLVE_ALL_LOG_ENTRIES: usize = 128;
+
 #[allow(clippy::too_many_arguments)]
 fn build_resolve_all_state_update_message(
     raw_state: &GameState,
+    log_entries: &[GameLogEntry],
     legal_actions: &[GameAction],
     spell_costs: &HashMap<engine::types::identifiers::ObjectId, engine::types::mana::ManaCost>,
     legal_actions_by_object: &HashMap<engine::types::identifiers::ObjectId, Vec<GameAction>>,
@@ -537,7 +540,7 @@ fn build_resolve_all_state_update_message(
         end_continuous_effect_offers,
         mana_payment_shortcut_actions,
         eliminated_players,
-        log_entries: Vec::new(),
+        log_entries: log_entries.to_vec(),
         spell_costs: if is_actor {
             spell_costs.clone()
         } else {
@@ -4179,7 +4182,6 @@ async fn handle_full_game_submission(
 async fn handle_resolve_all(
     request_id: u64,
     max_resolutions: u32,
-    socket: &mut WebSocket,
     state: &SharedState,
     draft_state: &SharedDraftState,
     connections: &SharedConnections,
@@ -4193,12 +4195,11 @@ async fn handle_resolve_all(
         identity.player_token.clone(),
         identity.player_id,
     ) else {
-        let msg = ServerMessage::ActionRejected {
+        let msg = ServerMessage::ResolveAllRejected {
+            request_id,
             reason: "Not in a game".to_string(),
         };
-        if let Ok(json) = serde_json::to_string(&msg) {
-            let _ = socket.send(Message::text(json)).await;
-        }
+        let _ = tx.send(msg);
         return;
     };
 
@@ -4249,10 +4250,7 @@ async fn handle_resolve_all(
         match processed {
             Ok(processed) => processed,
             Err(reason) => {
-                let msg = ServerMessage::ActionRejected { reason };
-                if let Ok(json) = serde_json::to_string(&msg) {
-                    let _ = socket.send(Message::text(json)).await;
-                }
+                let _ = tx.send(ServerMessage::ResolveAllRejected { request_id, reason });
                 return;
             }
         };
@@ -4266,20 +4264,18 @@ async fn handle_resolve_all(
         let _ = tx.send(acknowledgement);
         return;
     };
-    let (raw_state, _events, legal_actions, _logs, _auto_pass, spell_costs, by_object) = &result;
+    let (raw_state, _events, legal_actions, logs, _auto_pass, spell_costs, by_object) = &result;
+    let log_entries = &logs[logs.len().saturating_sub(MAX_RESOLVE_ALL_LOG_ENTRIES)..];
 
     if let Err(reason) = guard_state_snapshot_broadcast(StateSnapshotParts {
         state: raw_state,
         events: &[],
-        log_entries: &[],
+        log_entries,
         legal_actions,
         legal_actions_by_object: by_object,
         spell_costs,
     }) {
-        let msg = ServerMessage::error(reason);
-        if let Ok(json) = serde_json::to_string(&msg) {
-            let _ = socket.send(Message::text(json)).await;
-        }
+        let _ = tx.send(ServerMessage::ResolveAllRejected { request_id, reason });
         return;
     }
 
@@ -4287,10 +4283,10 @@ async fn handle_resolve_all(
         Some(artifact) => match prepare_full_terminal(game_db, artifact).await {
             Ok(deliveries) => deliveries,
             Err(error) => {
-                let msg = ServerMessage::error(error);
-                if let Ok(json) = serde_json::to_string(&msg) {
-                    let _ = socket.send(Message::text(json)).await;
-                }
+                let _ = tx.send(ServerMessage::ResolveAllRejected {
+                    request_id,
+                    reason: error,
+                });
                 return;
             }
         },
@@ -4301,6 +4297,7 @@ async fn handle_resolve_all(
     // sender in order; the adapter resolves only after this cached snapshot.
     let requester_update = build_resolve_all_state_update_message(
         raw_state,
+        log_entries,
         legal_actions,
         spell_costs,
         by_object,
@@ -4322,6 +4319,7 @@ async fn handle_resolve_all(
                 if let Some(sender) = players.get(&player) {
                     let _ = sender.send(build_resolve_all_state_update_message(
                         raw_state,
+                        log_entries,
                         legal_actions,
                         spell_costs,
                         by_object,
@@ -4335,7 +4333,7 @@ async fn handle_resolve_all(
         }
     }
     if let Ok(spectator_update) =
-        build_spectator_state_update_message(raw_state, &[], &[], revision)
+        build_spectator_state_update_message(raw_state, &[], log_entries, revision)
     {
         let mut spectators = game_spectators.lock().await;
         if let Some(senders) = spectators.get_mut(&game_code) {
@@ -4371,6 +4369,8 @@ async fn handle_resolve_all(
         )
         .await;
         state.lock().await.remove_game(&game_code);
+        connections.lock().await.remove(&game_code);
+        game_spectators.lock().await.remove(&game_code);
     }
 }
 
@@ -4759,7 +4759,6 @@ async fn handle_client_message(
             handle_resolve_all(
                 request_id,
                 max_resolutions,
-                socket,
                 state,
                 draft_state,
                 connections,
@@ -7668,6 +7667,7 @@ mod state_transport_derived_tests {
         ActiveSearchDecisionAuthority, ActiveSearchDecisionControl, PriorityPassingMode, WaitingFor,
     };
     use engine::types::identifiers::ObjectId;
+    use engine::types::log::{GameLogEntry, LogCategory, LogSegment};
     use engine::types::phase::Phase;
 
     fn low_use_window_priority_result(
@@ -7714,6 +7714,47 @@ mod state_transport_derived_tests {
                 auto_pass_recommended,
                 ..
             } => (legal_actions.len(), auto_pass_recommended),
+            other => panic!("expected StateUpdate, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_all_snapshot_keeps_a_bounded_tail_of_engine_logs() {
+        let state = GameState::new_two_player(42);
+        let logs: Vec<_> = (0..=MAX_RESOLVE_ALL_LOG_ENTRIES)
+            .map(|seq| GameLogEntry {
+                seq: seq as u32,
+                turn: 1,
+                phase: Phase::PreCombatMain,
+                category: LogCategory::Game,
+                segments: vec![LogSegment::Text(format!("entry {seq}"))],
+                presentation: Default::default(),
+            })
+            .collect();
+        let tail = &logs[logs.len().saturating_sub(MAX_RESOLVE_ALL_LOG_ENTRIES)..];
+
+        let update = build_resolve_all_state_update_message(
+            &state,
+            tail,
+            &[],
+            &HashMap::new(),
+            &HashMap::new(),
+            1,
+            PlayerId(0),
+            Vec::new(),
+            Vec::new(),
+        );
+
+        match update {
+            ServerMessage::StateUpdate {
+                log_entries,
+                events,
+                ..
+            } => {
+                assert!(events.is_empty());
+                assert_eq!(log_entries.as_slice(), tail);
+                assert_eq!(log_entries.len(), MAX_RESOLVE_ALL_LOG_ENTRIES);
+            }
             other => panic!("expected StateUpdate, got {other:?}"),
         }
     }

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -504,6 +504,12 @@ pub enum ServerMessage {
     /// transition. The submitting adapter resolves its pending request without
     /// caching or publishing a replacement snapshot.
     ActionNoOp,
+    /// Requester-only rejection for a native Resolve All batch. The request
+    /// identifier prevents unrelated action failures from settling this promise.
+    ResolveAllRejected {
+        request_id: u64,
+        reason: String,
+    },
     /// Requester-only acknowledgement for a native Resolve All batch. The
     /// matching StateUpdate is sent first and carries the authoritative state.
     ResolveAllResult {
@@ -2314,8 +2320,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_28() {
-        assert_eq!(PROTOCOL_VERSION, 28);
+    fn protocol_version_is_29() {
+        assert_eq!(PROTOCOL_VERSION, 29);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -2325,7 +2331,7 @@ mod tests {
     /// understand.
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
-    /// this guards — and this test reds while `protocol_version_is_28` stays
+    /// this guards — and this test reds while `protocol_version_is_29` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {
@@ -2369,6 +2375,15 @@ mod tests {
             r#"{"type":"ResolveAllResult","data":{"request_id":7,"items_resolved":3,"total":52}}"#
         );
         assert!(!json.contains("waiting_for"));
+
+        let rejected = ServerMessage::ResolveAllRejected {
+            request_id: 7,
+            reason: "Resolve All requires your priority".to_string(),
+        };
+        assert_eq!(
+            serde_json::to_string(&rejected).unwrap(),
+            r#"{"type":"ResolveAllRejected","data":{"request_id":7,"reason":"Resolve All requires your priority"}}"#
+        );
     }
 
     /// R15. The last-action frame the client actually sends carries **no**

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 28;
+const EXPECTED_PROTOCOL_VERSION = 29;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);


### PR DESCRIPTION
Follow-up to #7215 addressing CodeRabbit review findings.

- correlate Resolve All failures by request ID
- retain a bounded engine-log tail in compact batch state updates
- clean connection and spectator registries after terminal batch cleanup
- keep native AI ownership in the authenticated server adapter

Validation: full pre-push suite (Rust lint/tests, card-data gates, frontend lint, protocol check, and TypeScript type-check).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Native AI Resolve All requests are now handled by the server.
  * Resolve All failures include the specific request and server-provided reason.
  * Final Resolve All engine log entries are shared with players and spectators, up to a capped limit.

* **Bug Fixes**
  * Prevented unrelated errors or rejected actions from incorrectly completing Resolve All requests.
  * Improved cleanup after Resolve All completes or fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->