### PR TITLE
Fix Scythecat Cub

### DIFF
--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -1977,6 +1977,23 @@ fn resolve_defined_or_targets(
             .collect();
     }
 
+    // CR 608.2c: A `ParentTarget` in a chained counter effect refers to the
+    // object chosen by the parent instruction. Prefer that propagated object
+    // target over the triggering event context; for a landfall trigger, the
+    // latter is the entering land rather than the creature chosen by the
+    // player. The object guard deliberately excludes the chooser-only target
+    // bookkeeping used by `ChooseOneOf` branches above.
+    if matches!(target_spec, Some(TargetFilter::ParentTarget)) && has_object_target {
+        return ability
+            .live_object_targets(state)
+            .into_iter()
+            .filter_map(|target| match target {
+                TargetRef::Object(id) => Some(id),
+                TargetRef::Player(_) => None,
+            })
+            .collect();
+    }
+
     if let Some(filter) = target_spec {
         let event_targets =
             crate::game::targeting::resolve_event_context_targets(state, filter, ability.source_id);

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -896,6 +896,7 @@ mod scarab_god_regression;
 mod scholarship_sponsor;
 mod screaming_nemesis_combat_damage_multi_trigger;
 mod screaming_nemesis_life_lock;
+mod scythecat_cub_second_resolution;
 mod search_delivery_observer_dedup;
 mod season_points_budget_modal;
 mod seasoned_dungeoneer_initiative_room_trigger;

--- a/crates/engine/tests/integration/scythecat_cub_second_resolution.rs
+++ b/crates/engine/tests/integration/scythecat_cub_second_resolution.rs
@@ -1,0 +1,89 @@
+//! Scythecat Cub doubles the counters placed by its second landfall resolution.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+
+const SCYTHECAT_CUB_ORACLE: &str = "Trample\n\
+Landfall — Whenever a land you control enters, put a +1/+1 counter on target creature you control. If this is the second time this ability has resolved this turn, double the number of +1/+1 counters on that creature instead.";
+
+fn resolve_cub_landfall(
+    runner: &mut engine::game::scenario::GameRunner,
+    land_id: engine::types::identifiers::ObjectId,
+    target_id: engine::types::identifiers::ObjectId,
+) {
+    let card_id = runner.state().objects[&land_id].card_id;
+    runner
+        .act(GameAction::PlayLand {
+            object_id: land_id,
+            card_id,
+        })
+        .expect("land should be playable");
+
+    match &runner.state().waiting_for {
+        WaitingFor::TriggerTargetSelection { target_slots, .. } => {
+            assert!(
+                target_slots[0]
+                    .legal_targets
+                    .iter()
+                    .any(|target| matches!(target, TargetRef::Object(id) if *id == target_id)),
+                "Lotus Cobra must be a legal Scythecat Cub target"
+            );
+        }
+        other => panic!("expected Scythecat Cub target selection, got {other:?}"),
+    }
+
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(target_id)),
+        })
+        .expect("Lotus Cobra should be selectable");
+    runner.advance_until_stack_empty();
+}
+
+#[test]
+fn scythecat_cub_doubles_counters_on_second_landfall_resolution() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let cub_id = scenario
+        .add_creature_from_oracle(P0, "Scythecat Cub", 2, 2, SCYTHECAT_CUB_ORACLE)
+        .id();
+    let cobra_id = scenario.add_creature(P0, "Lotus Cobra", 2, 1).id();
+    let first_land_id = scenario.add_land_to_hand(P0, "First Land").id();
+    let second_land_id = scenario.add_land_to_hand(P0, "Second Land").id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().max_lands_per_turn = 2;
+
+    resolve_cub_landfall(&mut runner, first_land_id, cobra_id);
+    assert_eq!(
+        runner.state().objects[&cobra_id]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied(),
+        Some(1),
+        "the first landfall resolution should place one +1/+1 counter"
+    );
+
+    resolve_cub_landfall(&mut runner, second_land_id, cobra_id);
+    assert_eq!(
+        runner.state().objects[&cobra_id]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied(),
+        Some(2),
+        "the second landfall resolution should double Lotus Cobra's counter"
+    );
+    assert_eq!(
+        runner
+            .state()
+            .ability_resolutions_this_turn
+            .get(&(cub_id, 0)),
+        Some(&2),
+        "both landfall triggers should share Cub's printed ability index"
+    );
+}

--- a/crates/engine/tests/integration/scythecat_cub_second_resolution.rs
+++ b/crates/engine/tests/integration/scythecat_cub_second_resolution.rs
@@ -58,6 +58,13 @@ fn scythecat_cub_doubles_counters_on_second_landfall_resolution() {
 
     let mut runner = scenario.build();
     runner.state_mut().max_lands_per_turn = 2;
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&cobra_id)
+        .expect("Lotus Cobra should start on the battlefield")
+        .counters
+        .insert(CounterType::Plus1Plus1, 1);
 
     resolve_cub_landfall(&mut runner, first_land_id, cobra_id);
     assert_eq!(
@@ -65,8 +72,8 @@ fn scythecat_cub_doubles_counters_on_second_landfall_resolution() {
             .counters
             .get(&CounterType::Plus1Plus1)
             .copied(),
-        Some(1),
-        "the first landfall resolution should place one +1/+1 counter"
+        Some(2),
+        "the first landfall resolution should place one +1/+1 counter on the seeded target"
     );
 
     resolve_cub_landfall(&mut runner, second_land_id, cobra_id);
@@ -75,8 +82,8 @@ fn scythecat_cub_doubles_counters_on_second_landfall_resolution() {
             .counters
             .get(&CounterType::Plus1Plus1)
             .copied(),
-        Some(2),
-        "the second landfall resolution should double Lotus Cobra's counter"
+        Some(4),
+        "the second landfall resolution should double Lotus Cobra's counters"
     );
     assert_eq!(
         runner


### PR DESCRIPTION
## Summary

Fixes Scythecat Cub's second landfall resolution so the explicitly chosen creature's +1/+1 counters are doubled instead of resolving against the entering land.

## Files changed

- crates/engine/src/game/effects/counters.rs
- crates/engine/tests/integration/main.rs
- crates/engine/tests/integration/scythecat_cub_second_resolution.rs

## Track

Developer

## LLM

Model: GitHub Copilot (canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver,
> targeting, rules behavior — is expected to go through `/engine-implementer`.
> The "not used" box is for changes that genuinely fall outside that scope.

## CR references

- CR 608.2c — later text in a resolving ability can modify the meaning of earlier text; the chained counter effect must retain the parent instruction's chosen object.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — PASS
- `cargo clippy -p phase-engine --all-targets -- -D warnings` — PASS
- `cargo test -p phase-engine --test integration scythecat_cub_second_resolution::scythecat_cub_doubles_counters_on_second_landfall_resolution -- --exact --nocapture` — PASS (1 test)
- `cargo test -p phase-engine --lib effects::counters -- --nocapture` — PASS (62 tests)
- `cargo test -p phase-engine` — started successfully; manually interrupted during long-running unrelated loop tests, with no test failure reported; CI should run the complete suite.
- `cargo coverage` — tool built, but card-level coverage could not run because `data/card-data.json` is absent in this dedicated worktree; CI-owned alternative is the generated card-data pipeline.
- `cargo semantic-audit` — tool built, but the audit could not run because `client/public/card-data.json` is absent in this dedicated worktree; CI-owned alternative is the generated card-data pipeline.

## Gate A

Gate A PASS head=35e45338b37f7d953e8652ced0cb8616720ddcb2 base=97591656218103d8e8c7315725b24cfe64645dd4

## Anchored on

- crates/engine/src/game/effects/counters.rs:1914 — existing `ParentTarget` branch distinguishes chooser-only bookkeeping from an absent object target.
- crates/engine/src/game/effects/counters.rs:1929 — existing batched `ParentTarget` resolution uses the same `has_object_target` guard and shared target-resolution vocabulary.

## Final review-impl

Final review-impl PASS head=35e45338b37f7d953e8652ced0cb8616720ddcb2

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

- Full `cargo test -p phase-engine` was not completed locally because long-running unrelated loop tests were manually interrupted; no failure was observed before interruption.
- `cargo coverage` and `cargo semantic-audit` require generated `data/card-data.json` and `client/public/card-data.json`, which are absent from this dedicated worktree; CI must run the generated card-data pipeline before these audits.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed chained counter effects so explicitly selected creature targets resolve correctly.
  * Corrected Scythecat Cub’s second landfall resolution so it properly doubles the counters placed on the selected creature.
  * Improved consistency when resolving repeated abilities that reference the same target.

* **Tests**
  * Added integration coverage for repeated landfall resolutions, target validation, shared ability behavior, and resulting counter totals.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->