### PR TITLE
fix(engine): normalize census path separators on Windows

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -18688,7 +18688,12 @@ mod bounded_offer_conjunct_tests {
                 .strip_prefix(&root)
                 .expect("under src")
                 .display()
-                .to_string();
+                .to_string()
+                // Canonicalize to forward slashes so the census pins below are
+                // platform-independent: `Path::display()` emits the OS-native
+                // separator (backslash on Windows), but the pins are written in
+                // the crate's forward-slash convention. No-op on Unix/CI.
+                .replace('\\', "/");
             let test_file = rel.trim_end_matches(".rs").ends_with("_tests");
             for (n, line) in lines.iter().enumerate() {
                 if line.trim_start().starts_with("//") {


### PR DESCRIPTION
Two CR 603.5 census tests in `crates/engine/src/game/engine.rs` build their site strings from `Path::display()`, which emits the OS-native separator. On Windows that yields `game\effects\mod.rs:6175` while the pinned expectations are written in the crate's forward-slash convention, so the assertions fail on separators alone — every line number matches exactly. This is not census drift.

`the_cr_603_5_prompt_census_is_pinned_so_a_sixth_producer_is_a_counted_event` already carried the canonicalization. This applies the same treatment, verbatim, to the remaining site in `f2c_the_cr_603_5_conjunct_set_has_one_production_assembler` so the two censuses read identically.

That census feeds two forward-slash-shaped consumers, both of which the raw separator breaks:

- the `{rel}:{line}` site strings compared against the pinned expectations, and
- the `site.starts_with("game/effects/")` prefix filter, which would otherwise classify **every** site as outside that module on Windows.

Pinned line numbers and census counts are unchanged. No-op on Unix/CI.

## Verification

`cargo fmt --all` clean. Tilt was not up in this worktree (`tilt get uiresource clippy` → exit 1), so the test ran directly:

```
cargo test -p phase-engine --lib cr_603_5
```

```
test game::engine::stage2_injector_tests::one_published_may_slot_stands_for_exactly_one_cr_603_5_prompt ... ok
test game::engine::stage2_injector_tests::a_may_slot_is_minted_only_for_the_seat_the_cr_603_5_gate_will_ask ... ok
test analysis::resource::tests::f2b_guard_b_withholds_a_pin_the_cr_603_5_gate_can_never_spend ... ok
test game::engine::stage2_injector_tests::the_cr_603_5_prompt_census_is_pinned_so_a_sixth_producer_is_a_counted_event ... ok
test game::engine::bounded_offer_conjunct_tests::f2c_the_cr_603_5_conjunct_set_has_one_production_assembler ... ok
test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 18837 filtered out
```

Test-only change; no engine behavior is affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cross-platform handling of relative paths by standardizing path separators.
  * Path comparisons now work consistently across operating systems.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->