### PR TITLE
fix(parser): qualify the counters-among phrase by counter kind

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -19606,3 +19606,59 @@ mod tests {
         );
     }
 }
+
+/// CR 122.1: the "[kind] counters among [filter]" quantity phrase, at the
+/// building-block level — both ends of its one variation axis.
+#[cfg(test)]
+mod counters_among_condition_tests {
+    use super::parse_inner_condition;
+    use crate::types::ability::{Comparator, QuantityExpr, QuantityRef, StaticCondition};
+    use crate::types::counter::CounterType;
+
+    fn counters_among(text: &str) -> (Option<CounterType>, Comparator, i32) {
+        let (rest, condition) = parse_inner_condition(text).expect("condition must parse");
+        assert_eq!(rest, "", "the whole clause must be consumed");
+        let StaticCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty: QuantityRef::CountersOnObjects { counter_type, .. },
+                },
+            comparator,
+            rhs: QuantityExpr::Fixed { value },
+        } = condition
+        else {
+            panic!("expected a counters-among comparison, got {condition:?}");
+        };
+        (counter_type, comparator, value)
+    }
+
+    /// Tom Bombadil — a counter-kind qualifier narrows the sum to that kind.
+    #[test]
+    fn typed_counters_among_narrows_to_that_kind() {
+        assert_eq!(
+            counters_among("there are four or more lore counters among sagas you control"),
+            (Some(CounterType::Lore), Comparator::GE, 4)
+        );
+    }
+
+    /// Lux Artillery — the qualifier is optional, and its absence still means
+    /// "every kind", not "some default kind".
+    #[test]
+    fn untyped_counters_among_sums_every_kind() {
+        assert_eq!(
+            counters_among(
+                "there are thirty or more counters among artifacts and creatures you control"
+            ),
+            (None, Comparator::GE, 30)
+        );
+    }
+
+    /// The qualifier is a real parameter, not a lore special case.
+    #[test]
+    fn other_counter_kinds_qualify_too() {
+        assert_eq!(
+            counters_among("there are two or more stun counters among creatures you control"),
+            (Some(CounterType::Stun), Comparator::GE, 2)
+        );
+    }
+}

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -1234,17 +1234,37 @@ fn parse_commander_mana_value_ref(input: &str) -> OracleResult<'_, QuantityRef> 
     Ok((rest, QuantityRef::CommanderManaValue { owner }))
 }
 
-/// CR 122.1: Parse "counters among [filter]" — sum across every counter type.
+/// CR 122.1: Parse "[kind] counters among [filter]".
 ///
-/// Used for phrases like "thirty or more counters among artifacts and creatures
-/// you control" (Lux Artillery's intervening-if). The counter type is `None`
-/// because the Oracle text does not restrict to any particular counter kind;
-/// the resolver sums counters of every type on every matching object.
+/// The counter-kind qualifier is optional, which is the whole variation axis of
+/// this phrase:
+///
+/// * absent — "thirty or more counters among artifacts and creatures you
+///   control" (Lux Artillery's intervening-if). `counter_type: None`, and the
+///   resolver sums counters of EVERY kind on every matching object.
+/// * present — "four or more lore counters among Sagas you control" (Tom
+///   Bombadil). `counter_type: Some(kind)` narrows the sum to that kind.
+///
+/// One `opt` rather than two combinators: the qualifier is a leaf parameter of
+/// the same phrase, and every counter kind `parse_counter_type_typed` knows is
+/// covered by writing it once.
 ///
 /// Composes with `parse_there_are_conditions` to form the full
-/// "there are N or more counters among [filter]" condition.
+/// "there are N or more [kind] counters among [filter]" condition.
 fn parse_counters_among_ref(input: &str) -> OracleResult<'_, QuantityRef> {
-    let (rest, _) = tag("counters among ").parse(input)?;
+    // The qualifier and the noun are ONE unit, not an `opt` qualifier followed by
+    // a separate noun: `parse_counter_type_typed` also accepts the bare word
+    // "counters" (as `CounterType::Any`), so an `opt` would succeed on the
+    // untyped phrase, consume the noun as if it were the qualifier, and then
+    // strand the parse with no branch left to back off to.
+    let (rest, counter_type) = alt((
+        map(
+            terminated(parse_counter_type_typed, tag(" counters among ")),
+            Some,
+        ),
+        value(None, tag("counters among ")),
+    ))
+    .parse(input)?;
     let type_text = rest.trim_end_matches('.').trim_end_matches(',');
     let (filter, remainder) = parse_type_phrase(type_text);
     if matches!(filter, TargetFilter::Any) {
@@ -1260,7 +1280,7 @@ fn parse_counters_among_ref(input: &str) -> OracleResult<'_, QuantityRef> {
     Ok((
         &input[consumed..],
         QuantityRef::CountersOnObjects {
-            counter_type: None,
+            counter_type,
             filter,
         },
     ))

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -971,6 +971,7 @@ mod throw_instead_tail_class;
 mod timely_ward_regression;
 mod tinybones_joins_up_multi_target;
 mod tobita_master_of_winds_flying_grant;
+mod tom_bombadil_lore_counter_gate;
 mod tombstone_stairwell_per_player_tokens;
 mod top_of_library_mixed_permission;
 mod total_war_attacking_player_scope;

--- a/crates/engine/tests/integration/tom_bombadil_lore_counter_gate.rs
+++ b/crates/engine/tests/integration/tom_bombadil_lore_counter_gate.rs
@@ -1,0 +1,119 @@
+//! CR 611.3a + CR 122.1 — Tom Bombadil's lore-counter gate.
+//!
+//! Oracle: `As long as there are four or more lore counters among Sagas you
+//! control, Tom Bombadil has hexproof and indestructible.`
+//!
+//! Before the `[kind] counters among [filter]` quantity phrase existed, this
+//! condition parsed to `StaticCondition::Unrecognized`, which the layer
+//! evaluator treats as satisfied. That is not a missing feature but an active
+//! over-application: Tom Bombadil was hexproof and indestructible unconditionally,
+//! strictly better than printed. So the load-bearing assertion here is the
+//! NEGATIVE one — below the threshold he must have neither keyword.
+
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::counter::CounterType;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+
+const BOMBADIL_ORACLE: &str = "As long as there are four or more lore counters among Sagas you control, ~ has hexproof and indestructible.";
+
+/// A Saga bearing `lore` lore counters. Chapter text is irrelevant to the gate —
+/// only the counters are counted (CR 122.1) — but a Saga with chapter abilities
+/// is the honest shape.
+const SAGA_ORACLE: &str = "I — Create a 1/1 white Soldier creature token.\n\
+II — Create a 1/1 white Soldier creature token.\n\
+III — Create a 1/1 white Soldier creature token.\n\
+IV — Create a 1/1 white Soldier creature token.\n\
+V — Create a 1/1 white Soldier creature token.";
+
+/// Build a board with Tom Bombadil and `lore_counters` lore spread over one Saga,
+/// then report whether he has the granted keywords.
+fn bombadil_has_keywords(lore_counters: u32) -> (bool, bool) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let bombadil = scenario
+        .add_creature(P0, "Tom Bombadil", 4, 4)
+        .as_legendary()
+        .from_oracle_text(BOMBADIL_ORACLE)
+        .id();
+
+    let saga = scenario
+        .add_creature(P0, "Lore Test Saga", 0, 0)
+        .as_enchantment()
+        .with_subtypes(vec!["Saga"])
+        .from_oracle_text(SAGA_ORACLE)
+        .id();
+    scenario.with_counter(saga, CounterType::Lore, lore_counters);
+
+    let mut runner = scenario.build();
+    evaluate_layers(runner.state_mut());
+
+    let obj = &runner.state().objects[&bombadil];
+    (
+        obj.has_keyword(&Keyword::Hexproof),
+        obj.has_keyword(&Keyword::Indestructible),
+    )
+}
+
+/// The regression that matters: three lore counters is below the threshold, so
+/// neither keyword may be granted. A permissive `Unrecognized` condition fails
+/// exactly here.
+#[test]
+fn below_four_lore_counters_grants_nothing() {
+    assert_eq!(
+        bombadil_has_keywords(3),
+        (false, false),
+        "CR 611.3a: an unmet 'as long as' gate must grant neither keyword"
+    );
+}
+
+/// CR 122.1: at the threshold the gate is satisfied and both keywords apply.
+#[test]
+fn four_lore_counters_grants_both_keywords() {
+    assert_eq!(
+        bombadil_has_keywords(4),
+        (true, true),
+        "four lore counters among Sagas you control satisfies the gate"
+    );
+}
+
+/// The comparison is "four or more", not "exactly four".
+#[test]
+fn above_the_threshold_still_grants() {
+    assert_eq!(bombadil_has_keywords(5), (true, true));
+}
+
+/// CR 122.1: the count is summed ACROSS every Saga you control, not read from a
+/// single permanent — two Sagas at two counters each reach the threshold.
+#[test]
+fn lore_counters_are_summed_across_sagas() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let bombadil = scenario
+        .add_creature(P0, "Tom Bombadil", 4, 4)
+        .as_legendary()
+        .from_oracle_text(BOMBADIL_ORACLE)
+        .id();
+
+    for name in ["Lore Test Saga A", "Lore Test Saga B"] {
+        let saga = scenario
+            .add_creature(P0, name, 0, 0)
+            .as_enchantment()
+            .with_subtypes(vec!["Saga"])
+            .from_oracle_text(SAGA_ORACLE)
+            .id();
+        scenario.with_counter(saga, CounterType::Lore, 2);
+    }
+
+    let mut runner = scenario.build();
+    evaluate_layers(runner.state_mut());
+
+    let obj = &runner.state().objects[&bombadil];
+    assert!(
+        obj.has_keyword(&Keyword::Hexproof) && obj.has_keyword(&Keyword::Indestructible),
+        "2 + 2 lore counters across two Sagas must satisfy the four-counter gate"
+    );
+}


### PR DESCRIPTION
Fixes **Tom Bombadil**'s static ability, which parsed its keywords but not its gate:

> As long as there are four or more lore counters among Sagas you control, Tom Bombadil has hexproof and indestructible.

The condition fell out as `StaticCondition::Unrecognized`, and the layer evaluator treats that as **satisfied** ([layers.rs `evaluate_condition_with_context`](https://github.com/phase-rs/phase/blob/main/crates/engine/src/game/layers.rs)). So this is not a missing feature — it is an active over-application: Tom Bombadil had hexproof and indestructible unconditionally, regardless of lore counters, which is strictly better than printed.

## The fix is one combinator, because everything else already existed

`StaticCondition::QuantityComparison`, `QuantityRef::CountersOnObjects` and `parse_there_are_conditions` (which already delegates to the general `parse_quantity_ref`) were all in place. The only gap was that `parse_counters_among_ref` accepted the **unqualified** phrase only. The counter kind is now a leaf parameter of that same combinator, so every kind `parse_counter_type_typed` knows is covered by writing it once:

| Phrase | Card | Result |
|---|---|---|
| `thirty or more counters among artifacts and creatures you control` | Lux Artillery | `counter_type: None` — sums every kind |
| `four or more lore counters among Sagas you control` | Tom Bombadil | `counter_type: Some(Lore)` — narrows the sum |

Tom Bombadil's clause now parses fully-consumed to exactly:

```
QuantityComparison {
  lhs: CountersOnObjects { counter_type: Some(Lore), filter: Typed(Saga + You) },
  comparator: GE,
  rhs: Fixed(4),
}
```

## One trap worth naming

The obvious shape — an `opt` counter-kind qualifier followed by the noun — is wrong, and silently so. `parse_counter_type_typed` also accepts the bare word `counters`, so on the **untyped** phrase the `opt` succeeds, consumes the noun as if it were the qualifier, and then strands the parse with no branch left to back off to. That regresses Lux Artillery while the new card passes.

The qualifier and the noun are therefore one atomic `alt` branch. The untyped test in this PR is what caught it.

## Testing

Parser tests cover both ends of the qualifier axis plus a non-lore kind, so the parameter is exercised as a parameter rather than as a lore special case.

The runtime tests lead with the **negative** case — three lore counters grants neither keyword — because that is the assertion a permissive `Unrecognized` condition fails. The satisfied case at four keeps it from passing vacuously, and a two-Saga case pins that CR 122.1 sums across permanents rather than reading one:

- `below_four_lore_counters_grants_nothing`
- `four_lore_counters_grants_both_keywords`
- `above_the_threshold_still_grants`
- `lore_counters_are_summed_across_sagas`

Verified with `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings` (clean), and `cargo test --workspace`.

Two `mtgish-import` tests (`search_players_library_target_opponent_preserves_acquire_shape`, `would_deal_damage_fixed_actions_convert_to_typed_modifications`) fail on my Windows machine but pass on CI's Linux runners. They reproduce on a clean branch off current `main` with none of this PR's changes, and neither touches counter or condition code — tracked separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
