### PR TITLE
fix(ai): block menace-class attackers via the engine minimum-blocker authority (#7183)

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -74,6 +74,14 @@ pub struct CandidateAction {
 const SELECTION_POOL_CAP: usize = 12;
 const SELECTION_CANDIDATE_CAP: usize = 64;
 
+/// Bounds for gang-block proposal enumeration against a CR 509.1b
+/// minimum-blocker restriction. Sized so the widest realistic case stays cheap:
+/// `C(10, 3) = 120` combinations trimmed to 32 per attacker, mirroring the
+/// `SELECTION_*` precedent above — take the first `pool_cap` eligible blockers in
+/// the engine's deterministic order, then cap the emitted set.
+const GANG_BLOCK_POOL_CAP: usize = 10;
+const GANG_BLOCK_CANDIDATE_CAP: usize = 32;
+
 fn collect_mana_combinations(
     count: usize,
     options: &[ManaType],
@@ -947,8 +955,15 @@ pub fn candidate_actions_broad_with_probe(
             player,
             valid_blocker_ids,
             valid_block_targets,
+            block_requirements,
             ..
-        } => blocker_actions(state, *player, valid_blocker_ids, valid_block_targets),
+        } => blocker_actions(
+            state,
+            *player,
+            valid_blocker_ids,
+            valid_block_targets,
+            block_requirements,
+        ),
         WaitingFor::UntapChoice {
             player, candidates, ..
         } => candidates
@@ -4448,6 +4463,10 @@ fn blocker_actions(
         crate::types::identifiers::ObjectId,
         Vec<crate::types::identifiers::ObjectId>,
     >,
+    block_requirements: &std::collections::HashMap<
+        crate::types::identifiers::ObjectId,
+        crate::game::combat::BlockRequirement,
+    >,
 ) -> Vec<CandidateAction> {
     let mut proposals = vec![Vec::new()];
 
@@ -4456,6 +4475,46 @@ fn blocker_actions(
             for &attacker_id in targets {
                 proposals.push(vec![(blocker_id, attacker_id)]);
             }
+        }
+    }
+
+    // CR 509.1b + CR 702.111b: an attacker carrying menace or a `MinBlockers`
+    // restriction can't be blocked except by `count` or more creatures, so every
+    // one-blocker proposal seeded above is an illegal declaration against it and
+    // `complete_blocker_proposals` collapses each to the same tax-free witness.
+    // Without an explicit gang-block seed the defending player's whole candidate
+    // set degenerates to "don't block" and the AI can never block a menace-class
+    // attacker at all. Seed the bounded set of `count`-sized combinations drawn
+    // from that attacker's own eligible blockers; legality is still decided by
+    // `complete_blocker_proposals` below, which is the single authority.
+    //
+    // `block_requirements` only carries attackers whose floor exceeds 1 (see
+    // `block_requirements_for_player`); the `<= 1` guard keeps that contract
+    // local rather than assumed. Attackers are visited in `ObjectId` order so a
+    // `HashMap` iteration order can't perturb candidate ordering (issue #4878).
+    let mut gang_attackers: Vec<_> = block_requirements
+        .iter()
+        .filter(|(_, requirement)| requirement.count > 1)
+        .map(|(&attacker_id, requirement)| (attacker_id, requirement.count as usize))
+        .collect();
+    gang_attackers.sort_unstable();
+    for (attacker_id, needed) in gang_attackers {
+        let eligible: Vec<crate::types::identifiers::ObjectId> = valid_blocker_ids
+            .iter()
+            .copied()
+            .filter(|blocker_id| {
+                valid_block_targets
+                    .get(blocker_id)
+                    .is_some_and(|targets| targets.contains(&attacker_id))
+            })
+            .collect();
+        for combo in bounded_combinations_for_sizes(
+            &eligible,
+            [needed],
+            GANG_BLOCK_POOL_CAP,
+            GANG_BLOCK_CANDIDATE_CAP,
+        ) {
+            proposals.push(combo.into_iter().map(|b| (b, attacker_id)).collect());
         }
     }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -797,6 +797,7 @@ mod militant_angel_attacked_opponents;
 mod mill_double_redirect_choice_continuation;
 mod mill_rest_in_peace_redirect;
 mod mimeoplasm_interactive_exile;
+mod min_blocker_floor_block_candidates_7183;
 mod mindblade_render_warrior_intervening_if_2867;
 mod mirror_march_copy_token_exile;
 mod mizzixs_mastery;

--- a/crates/engine/tests/integration/min_blocker_floor_block_candidates_7183.rs
+++ b/crates/engine/tests/integration/min_blocker_floor_block_candidates_7183.rs
@@ -1,0 +1,155 @@
+//! Issue #7183 — the AI's `DeclareBlockers` candidate enumerator must be able to
+//! express a legal gang block against a minimum-blocker floor.
+//!
+//! CR 509.1b lets an attacker carry a floor on how many creatures must block it.
+//! Two things create one: the Menace keyword (CR 702.111b, floor 2) and a
+//! `CantBeBlockedExceptBy { MinBlockers { min } }` static parsed from "can't be
+//! blocked except by N or more creatures" (Pathrazer of Ulamog, floor 3).
+//!
+//! `blocker_actions` used to seed only the empty declaration plus every *single*
+//! `(blocker, attacker)` pair. Against a floor above 1 every one of those pairs is
+//! an illegal declaration, so `complete_blocker_proposals` rewrote each to the same
+//! tax-free witness and dedup collapsed the whole candidate set to a single entry —
+//! "don't block". The defending player's entire legal-action list therefore said
+//! blocking was impossible even with a board full of untapped creatures, and the
+//! engine would happily accept a hand-built gang block the enumerator never
+//! offered. This test drives the real `legal_actions_full` entry point.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::StaticDefinition;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+use engine::types::statics::{BlockExceptionKind, StaticMode};
+
+use super::rules::AttackTarget;
+
+/// One 6/6 attacker carrying `floor` (as a keyword and/or a `MinBlockers` static)
+/// attacks P1, who controls eight untapped 2/2s. Returns the enumerated
+/// `DeclareBlockers` actions and the attacker's id.
+fn declare_blockers_candidates(
+    menace: bool,
+    min_blockers: Option<u32>,
+) -> (Vec<Vec<(ObjectId, ObjectId)>>, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let attacker = scenario.add_creature(P0, "Attacker", 6, 6).id();
+    for i in 0..8 {
+        scenario.add_creature(P1, &format!("Blocker {i}"), 2, 2);
+    }
+
+    let mut runner = scenario.build();
+    {
+        let obj = runner.state_mut().objects.get_mut(&attacker).unwrap();
+        if menace {
+            obj.keywords.push(Keyword::Menace);
+        }
+        if let Some(min) = min_blockers {
+            obj.static_definitions
+                .push(StaticDefinition::new(StaticMode::CantBeBlockedExceptBy {
+                    kind: BlockExceptionKind::MinBlockers { min },
+                }));
+        }
+    }
+
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(attacker, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("declare attackers");
+    runner.pass_both_players();
+
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::DeclareBlockers { .. }
+        ),
+        "expected the defending player's declare-blockers prompt, got {}",
+        runner.state().waiting_for.variant_name()
+    );
+
+    let declarations = engine::ai_support::legal_actions_full(runner.state())
+        .0
+        .into_iter()
+        .filter_map(|action| match action {
+            GameAction::DeclareBlockers { assignments } => Some(assignments),
+            _ => None,
+        })
+        .collect();
+    (declarations, attacker)
+}
+
+/// CR 702.111b: a menace attacker's floor of 2 must be reachable — at least one
+/// enumerated declaration puts exactly two blockers on it.
+#[test]
+fn menace_attacker_enumerates_two_blocker_gang_declarations() {
+    let (declarations, attacker) = declare_blockers_candidates(true, None);
+
+    assert!(
+        declarations.iter().any(|assignments| assignments
+            .iter()
+            .filter(|&&(_, a)| a == attacker)
+            .count()
+            == 2),
+        "the AI must be offered a legal two-blocker gang block against menace; \
+         got {declarations:?}"
+    );
+}
+
+/// CR 509.1b: an arbitrary `MinBlockers` floor (Pathrazer of Ulamog's three) is the
+/// same class and must be reachable too. This is the arm that regressed — menace is
+/// a keyword the AI special-cased, a `MinBlockers` static is not.
+#[test]
+fn min_blockers_three_attacker_enumerates_three_blocker_gang_declarations() {
+    let (declarations, attacker) = declare_blockers_candidates(false, Some(3));
+
+    assert!(
+        declarations.iter().any(|assignments| assignments
+            .iter()
+            .filter(|&&(_, a)| a == attacker)
+            .count()
+            == 3),
+        "the AI must be offered a legal three-blocker gang block against a \
+         'can't be blocked except by three or more creatures' attacker; got {declarations:?}"
+    );
+}
+
+/// No enumerated declaration may sit below the floor — a short set is illegal, and
+/// offering one only burns a candidate slot on an action the completion authority
+/// rewrites away.
+#[test]
+fn no_enumerated_declaration_falls_below_the_floor() {
+    for (menace, min, floor) in [(true, None, 2), (false, Some(3), 3), (true, Some(4), 4)] {
+        let (declarations, attacker) = declare_blockers_candidates(menace, min);
+        for assignments in &declarations {
+            let on_attacker = assignments.iter().filter(|&&(_, a)| a == attacker).count();
+            assert!(
+                on_attacker == 0 || on_attacker >= floor,
+                "floor {floor}: enumerated declaration {assignments:?} puts {on_attacker} \
+                 blocker(s) on the attacker — below the CR 509.1b floor"
+            );
+        }
+    }
+}
+
+/// Guard against over-correction: an attacker with no floor keeps its ordinary
+/// single-blocker candidates, which are the overwhelmingly common case.
+#[test]
+fn unrestricted_attacker_keeps_single_blocker_declarations() {
+    let (declarations, attacker) = declare_blockers_candidates(false, None);
+
+    assert!(
+        declarations.iter().any(|assignments| assignments
+            .iter()
+            .filter(|&&(_, a)| a == attacker)
+            .count()
+            == 1),
+        "an attacker with no minimum-blocker floor must still offer single blocks; \
+         got {declarations:?}"
+    );
+}

--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -980,6 +980,7 @@ pub fn choose_blockers_with_profile(
         let attacker_has_deathtouch = attacker.has_keyword(&Keyword::Deathtouch);
         let attacker_has_first_strike = attacker.has_keyword(&Keyword::FirstStrike)
             || attacker.has_keyword(&Keyword::DoubleStrike);
+        let attacker_has_trample = attacker.has_keyword(&Keyword::Trample);
 
         // Collect eligible unused blockers sorted by value (ascending = sacrifice cheapest)
         let mut gang_candidates: Vec<(ObjectId, i32, f64)> = available_blockers
@@ -1015,10 +1016,43 @@ pub fn choose_blockers_with_profile(
             continue;
         }
 
+        // CR 509.1b + CR 903.10a: the lethal-pressure test for the survival override
+        // below. Hoisted above the two value heuristics that follow because both of
+        // them short-circuit this attacker out of the pass entirely, and whether
+        // that is correct depends on whether a block is the player's last line.
+        let p_life = state.players[player.0 as usize].life;
+        let effective_life = commander_lethal_headroom(state, player, attacker_id)
+            .map(|headroom| p_life.min(headroom as i32))
+            .unwrap_or(p_life);
+
+        // CR 509.1b: an attacker whose minimum-blocker floor exceeds 1 is skipped by
+        // both single-blocker passes, so this gang pass is its only blocking route.
+        let floor_stabilize_route = needed_blockers > 1
+            && matches!(objective, CombatObjective::Stabilize)
+            && effective_life <= attacker_power * 3;
+
+        // CR 510.1c: a blocked creature assigns its combat damage to the creatures
+        // blocking it, and "if no creatures are currently blocking it (if, for
+        // example, they were destroyed or removed from combat), it assigns no combat
+        // damage." So for a *nontrampling* attacker a legal block prevents every
+        // point of damage to the player whether or not the blockers survive it and
+        // whether or not they can kill the attacker — a doomed block is still a full
+        // save. Trample is the exception (CR 702.19b): excess damage past lethal to
+        // the blockers is assigned to the player, and under deathtouch "lethal" is
+        // only 1 per blocker (CR 702.2c), so a trampler's damage still lands.
+        //
+        // The two heuristics below are value heuristics — correct when the question
+        // is "is this trade worth it", wrong when the question is "do I survive".
+        // They may only decline a block that is not the difference between living
+        // and losing (issue #7183).
+        let doomed_block_still_saves = floor_stabilize_route && !attacker_has_trample;
+
         // CR 702.7b: If attacker has first strike and blocker doesn't, the blocker
-        // dies before dealing damage. Skip blockers that would die to first strike.
+        // dies before dealing damage. Skip blockers that would die to first strike —
+        // they contribute no damage, so they cannot be counted toward a kill.
         let effective_candidates: Vec<(ObjectId, i32, f64)> = gang_candidates
-            .into_iter()
+            .iter()
+            .copied()
             .filter(|&(bid, _, _)| {
                 if !attacker_has_first_strike {
                     return true;
@@ -1038,8 +1072,10 @@ pub fn choose_blockers_with_profile(
         // CR 702.2c: Deathtouch means any nonzero damage is lethal, so one
         // blocker with deathtouch is enough — no need to gang-block.
         // Also skip if attacker has deathtouch: every blocker dies, so
-        // gang-blocking just loses more creatures.
-        if attacker_has_deathtouch {
+        // gang-blocking just loses more creatures — unless the block is the
+        // player's only route to surviving the turn, where CR 510.1c makes the
+        // doomed block a full save anyway.
+        if attacker_has_deathtouch && !doomed_block_still_saves {
             continue;
         }
 
@@ -1062,11 +1098,28 @@ pub fn choose_blockers_with_profile(
         // one. Loops rather than adding a single blocker: menace's floor is 2, but a
         // `MinBlockers` restriction can require any number (Pathrazer of Ulamog
         // requires 3), so one top-up is not enough (issue #7183).
+        // Damage-dealing candidates come first so the kill claim below stays honest.
+        // Only when a doomed block is still a full save (CR 510.1c) may the floor be
+        // filled out with blockers that die to first strike before dealing damage
+        // (CR 702.7b) — otherwise a legal, life-saving declaration is impossible to
+        // reach for a floored first- or double-striker at all.
         while gang_set.len() < needed_blockers {
-            let Some(&(bid, power, value)) = effective_candidates
+            let next = effective_candidates
                 .iter()
                 .find(|(bid, _, _)| !gang_set.contains(bid))
-            else {
+                .copied()
+                .or_else(|| {
+                    if !doomed_block_still_saves {
+                        return None;
+                    }
+                    // Contributes no damage, so it is added with zero power: it pads
+                    // the CR 509.1b floor without inflating `combined_power`.
+                    gang_candidates
+                        .iter()
+                        .find(|(bid, _, _)| !gang_set.contains(bid))
+                        .map(|&(bid, _, value)| (bid, 0, value))
+                });
+            let Some((bid, power, value)) = next else {
                 break;
             };
             combined_power += power;
@@ -1094,10 +1147,6 @@ pub fn choose_blockers_with_profile(
         // lethal damage to every blocker before any tramples through, CR 702.19b),
         // and the same exclusion of damage-reflection blockers, which hand the
         // attacker's power straight back to the player and so save nothing.
-        let p_life = state.players[player.0 as usize].life;
-        let effective_life = commander_lethal_headroom(state, player, attacker_id)
-            .map(|headroom| p_life.min(headroom as i32))
-            .unwrap_or(p_life);
         let gang_toughness: i32 = gang_set
             .iter()
             .filter_map(|bid| state.objects.get(bid).and_then(|b| b.toughness))
@@ -1108,19 +1157,22 @@ pub fn choose_blockers_with_profile(
                 .get(bid)
                 .is_some_and(has_damage_reflection_to_controller)
         });
-        let gang_stabilize = needed_blockers > 1
-            && matches!(objective, CombatObjective::Stabilize)
-            && effective_life <= attacker_power * 3
+        let gang_stabilize = floor_stabilize_route
             && !gang_reflects_damage
             && !commander_chump_unsafe(state, player, attacker_id, gang_toughness);
+
+        // CR 702.2c: never gang a deathtouch attacker for *value* — every blocker
+        // assigned any damage dies, so the kill is paid for with the whole gang.
+        // Preserves the pre-existing skip for deathtouch attackers now that the
+        // survival route above no longer short-circuits them out of the pass.
+        let gang_kills_for_value = !attacker_has_deathtouch
+            && combined_power >= attacker_toughness
+            && gang_value <= attacker_value;
 
         // Only gang-block if combined power can kill AND total value risked <=
         // attacker value — or if declining loses the game outright. Never below the
         // CR 509.1b floor, which would make the declaration illegal.
-        if gang_set.len() >= needed_blockers
-            && ((combined_power >= attacker_toughness && gang_value <= attacker_value)
-                || gang_stabilize)
-        {
+        if gang_set.len() >= needed_blockers && (gang_kills_for_value || gang_stabilize) {
             for bid in gang_set {
                 assignments.push((bid, attacker_id));
                 used_blockers.insert(bid);
@@ -4356,9 +4408,20 @@ mod tests {
 
     /// Board where `blockers` 4/4s face one lethal attacker at `life`.
     fn lethal_attacker_board(life: i32, blockers: usize) -> (GameState, ObjectId, Vec<ObjectId>) {
+        lethal_attacker_board_with(life, blockers, vec![])
+    }
+
+    /// Same board, with `keywords` on the 11/11 attacker. Parameterized rather than
+    /// duplicated so each floor source (Menace / `MinBlockers`) can be crossed with
+    /// each combat-damage keyword class (deathtouch, first strike, trample).
+    fn lethal_attacker_board_with(
+        life: i32,
+        blockers: usize,
+        keywords: Vec<Keyword>,
+    ) -> (GameState, ObjectId, Vec<ObjectId>) {
         let mut state = setup();
         state.players[1].life = life;
-        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 11, 11, vec![]);
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 11, 11, keywords);
         let blocker_ids = (0..blockers)
             .map(|i| {
                 add_creature(
@@ -4468,6 +4531,129 @@ mod tests {
             assignments.is_empty(),
             "at 40 life a 5/5 is not worth three 4/4s — the survival override must not \
              fire outside Stabilize. Got {assignments:?}"
+        );
+    }
+
+    // ── CR 510.1c doomed-but-saving floor blocks (issue #7183 review) ─────────
+    //
+    // A floored attacker reaches the battlefield-clearing gang pass as its ONLY
+    // blocking route. Two value heuristics live on that route — the CR 702.7b
+    // first-strike filter and the CR 702.2c deathtouch skip — and both used to
+    // fire before the survival override, so a menace/min-3 attacker with either
+    // keyword walked past a full board for lethal even though CR 510.1c makes the
+    // block a complete save: a blocked nontrampling attacker assigns its damage to
+    // its blockers, and none to the player even when every blocker is already dead.
+    //
+    // Each test below is discriminating: reverting its half of the fix (the
+    // `!doomed_block_still_saves` guard on the deathtouch skip, or the doomed
+    // top-up pool behind the first-strike filter) drops the block to zero.
+
+    /// Nothing the gang does can save the blockers from an 11/11 deathtouch
+    /// attacker, but CR 510.1c means the block still prevents all 11 damage.
+    /// At 6 life that is the difference between living and losing.
+    #[test]
+    fn min_blockers_three_deathtouch_attacker_is_gang_blocked_at_lethal() {
+        let (mut state, attacker, _) = lethal_attacker_board_with(6, 10, vec![Keyword::Deathtouch]);
+        add_min_blockers_restriction(&mut state, attacker, 3);
+
+        let assignments = choose_blockers(&state, PlayerId(1), &[attacker]);
+
+        let on_attacker = assignments.iter().filter(|&&(_, a)| a == attacker).count();
+        assert!(
+            on_attacker >= 3,
+            "CR 510.1c: a min-3 deathtouch attacker must still be gang-blocked at \
+             lethal — the blockers all die, but the player takes 0. Got {assignments:?}"
+        );
+        assert_eq!(
+            engine::game::combat::complete_blocker_proposal(&state, PlayerId(1), &assignments),
+            engine::types::actions::GameAction::DeclareBlockers {
+                assignments: assignments.clone()
+            },
+            "the AI's declaration must survive the CR 509.1c completion authority"
+        );
+    }
+
+    /// Same class through the Menace floor of 2 (CR 702.111b).
+    #[test]
+    fn menace_deathtouch_attacker_is_gang_blocked_at_lethal() {
+        let (state, attacker, _) =
+            lethal_attacker_board_with(6, 10, vec![Keyword::Menace, Keyword::Deathtouch]);
+
+        let assignments = choose_blockers(&state, PlayerId(1), &[attacker]);
+
+        let on_attacker = assignments.iter().filter(|&&(_, a)| a == attacker).count();
+        assert!(
+            on_attacker >= 2,
+            "CR 510.1c: a menace deathtouch attacker must still be gang-blocked at \
+             lethal. Got {assignments:?}"
+        );
+    }
+
+    /// CR 702.7b: every 4/4 blocker dies in the first-strike step before dealing
+    /// damage, so the first-strike filter empties the candidate set. CR 510.1c
+    /// still makes the block a full save — the attacker has no blockers left to
+    /// assign to, and no trample to push damage through to the player.
+    #[test]
+    fn min_blockers_three_first_strike_attacker_is_gang_blocked_at_lethal() {
+        let (mut state, attacker, _) =
+            lethal_attacker_board_with(6, 10, vec![Keyword::FirstStrike]);
+        add_min_blockers_restriction(&mut state, attacker, 3);
+
+        let assignments = choose_blockers(&state, PlayerId(1), &[attacker]);
+
+        let on_attacker = assignments.iter().filter(|&&(_, a)| a == attacker).count();
+        assert!(
+            on_attacker >= 3,
+            "CR 510.1c: a min-3 first-striker must still be gang-blocked at lethal \
+             even though no blocker survives to deal damage. Got {assignments:?}"
+        );
+        assert_eq!(
+            engine::game::combat::complete_blocker_proposal(&state, PlayerId(1), &assignments),
+            engine::types::actions::GameAction::DeclareBlockers {
+                assignments: assignments.clone()
+            },
+            "the AI's declaration must survive the CR 509.1c completion authority"
+        );
+    }
+
+    /// Double strike takes the same route (CR 702.4b): the blockers die in the
+    /// first-strike step, and CR 510.1c leaves the attacker with nothing to assign
+    /// to in the regular step.
+    #[test]
+    fn menace_double_strike_attacker_is_gang_blocked_at_lethal() {
+        let (state, attacker, _) =
+            lethal_attacker_board_with(6, 10, vec![Keyword::Menace, Keyword::DoubleStrike]);
+
+        let assignments = choose_blockers(&state, PlayerId(1), &[attacker]);
+
+        let on_attacker = assignments.iter().filter(|&&(_, a)| a == attacker).count();
+        assert!(
+            on_attacker >= 2,
+            "CR 510.1c: a menace double-striker must still be gang-blocked at lethal. \
+             Got {assignments:?}"
+        );
+    }
+
+    /// CR 702.19b + CR 702.2c: trample is the boundary of the CR 510.1c argument.
+    /// A deathtouch trampler assigns only 1 damage per blocker as "lethal" and
+    /// tramples the remaining 8 through to a player at 6 life, so the gang block
+    /// saves nothing and must not be thrown away. Guards the `!attacker_has_trample`
+    /// term — dropping it makes the AI chump three creatures and still lose.
+    #[test]
+    fn menace_deathtouch_trampler_is_not_chump_ganged_at_lethal() {
+        let (state, attacker, _) = lethal_attacker_board_with(
+            6,
+            10,
+            vec![Keyword::Menace, Keyword::Deathtouch, Keyword::Trample],
+        );
+
+        let assignments = choose_blockers(&state, PlayerId(1), &[attacker]);
+
+        let on_attacker = assignments.iter().filter(|&&(_, a)| a == attacker).count();
+        assert_eq!(
+            on_attacker, 0,
+            "a deathtouch trampler tramples past a chump gang (1 lethal per blocker, \
+             CR 702.2c), so the block saves nothing. Got {assignments:?}"
         );
     }
 }

--- a/crates/phase-ai/src/combat_ai.rs
+++ b/crates/phase-ai/src/combat_ai.rs
@@ -790,6 +790,33 @@ pub fn choose_blockers_with_profile(
         .collect();
     let blocker_value = |id: &ObjectId| -> f64 { blocker_values.get(id).copied().unwrap_or(0.0) };
 
+    // CR 509.1b + CR 702.111b: the minimum number of creatures that must block a
+    // given attacker. Menace is only the most common source of that floor — a
+    // `MinBlockers` restriction ("can't be blocked except by three or more
+    // creatures", e.g. Pathrazer of Ulamog) imposes an arbitrary one, and every
+    // pass below must respect it or the declaration it builds is illegal and gets
+    // rewritten to the empty witness by `complete_blocker_proposal` (issue #7183).
+    //
+    // `min_blockers_required` is the engine's single authority for the floor — the
+    // same value `validate_blockers` enforces and `block_requirements_for_player`
+    // shows the UI — so the AI can never plan against a rule different from the one
+    // enforced. Read through it rather than through `block_requirements_for_player`
+    // because that helper derives from `state.combat`, which callers that evaluate
+    // a hypothetical block (lookahead, tests) may not have populated; the floor is
+    // a property of the attacker's own restrictions, not of the combat record.
+    //
+    // The block-restriction statics are collected once here and threaded through
+    // the precomputed variant: every pass below reads this per attacker, and the
+    // non-precomputed entry point re-walks the battlefield on each call.
+    let block_restriction_statics = engine::game::combat::collect_block_restriction_statics(state);
+    let required_blockers = |attacker_id: &ObjectId| -> usize {
+        engine::game::combat::min_blockers_required_from_precomputed(
+            state,
+            *attacker_id,
+            &block_restriction_statics,
+        ) as usize
+    };
+
     // Sort attackers by value (highest first) to prioritize blocking high-value threats
     let mut sorted_attackers: Vec<(ObjectId, f64)> = attacker_ids
         .iter()
@@ -798,13 +825,13 @@ pub fn choose_blockers_with_profile(
     sorted_attackers.sort_by(|a, b| b.1.partial_cmp(&a.1).unwrap_or(std::cmp::Ordering::Equal));
 
     // First pass: assign deathtouch blockers to highest-value attackers.
-    // CR 702.111b: Skip menace attackers — they require 2+ blockers (handled in gang-block pass).
+    // CR 509.1b: Skip attackers with a minimum-blocker floor above 1 — a lone
+    // blocker is an illegal declaration against them (handled in gang-block pass).
     for &(attacker_id, _) in &sorted_attackers {
-        let attacker = match state.objects.get(&attacker_id) {
-            Some(a) => a,
-            None => continue,
-        };
-        if attacker.has_keyword(&Keyword::Menace) {
+        if !state.objects.contains_key(&attacker_id) {
+            continue;
+        }
+        if required_blockers(&attacker_id) > 1 {
             continue;
         }
 
@@ -827,7 +854,8 @@ pub fn choose_blockers_with_profile(
     }
 
     // Second pass: assign remaining blockers where they'd survive.
-    // CR 702.111b: Skip menace attackers — they require 2+ blockers (handled in gang-block pass).
+    // CR 509.1b: Skip attackers with a minimum-blocker floor above 1 — a lone
+    // blocker is an illegal declaration against them (handled in gang-block pass).
     for &(attacker_id, attacker_value) in &sorted_attackers {
         if blocked_attackers.contains(&attacker_id) {
             continue; // Already blocked
@@ -837,7 +865,7 @@ pub fn choose_blockers_with_profile(
             Some(a) => a,
             None => continue,
         };
-        if attacker.has_keyword(&Keyword::Menace) {
+        if required_blockers(&attacker_id) > 1 {
             continue;
         }
 
@@ -968,10 +996,11 @@ pub fn choose_blockers_with_profile(
         gang_candidates.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap_or(std::cmp::Ordering::Equal));
 
         // Skip if any single blocker can already kill it (handled in second pass above).
-        // CR 702.111b: Exception — menace attackers MUST be gang-blocked even when a
-        // single blocker could kill them, because single blocks are illegal.
-        let has_menace = attacker.has_keyword(&Keyword::Menace);
-        if !has_menace
+        // CR 509.1b: Exception — an attacker with a minimum-blocker floor MUST be
+        // gang-blocked even when a single blocker could kill it, because a lone
+        // block is an illegal declaration.
+        let needed_blockers = required_blockers(&attacker_id);
+        if needed_blockers <= 1
             && gang_candidates.iter().any(|&(bid, _, _)| {
                 state
                     .objects
@@ -1027,25 +1056,70 @@ pub fn choose_blockers_with_profile(
             }
         }
 
-        // CR 702.111b: Menace requires at least 2 blockers. If the gang set is too
-        // small, try to add another blocker even if combined power already suffices.
-        if has_menace && gang_set.len() < 2 {
-            if let Some(&(bid, power, value)) = effective_candidates
+        // CR 509.1b: The declaration needs at least `needed_blockers` creatures on
+        // this attacker. Top the gang set up to that floor even when combined power
+        // already suffices — a short set is an illegal declaration, not a cheaper
+        // one. Loops rather than adding a single blocker: menace's floor is 2, but a
+        // `MinBlockers` restriction can require any number (Pathrazer of Ulamog
+        // requires 3), so one top-up is not enough (issue #7183).
+        while gang_set.len() < needed_blockers {
+            let Some(&(bid, power, value)) = effective_candidates
                 .iter()
                 .find(|(bid, _, _)| !gang_set.contains(bid))
-            {
-                combined_power += power;
-                gang_set.push(bid);
-                gang_value += value;
-            }
+            else {
+                break;
+            };
+            combined_power += power;
+            gang_set.push(bid);
+            gang_value += value;
         }
 
-        // Only gang-block if combined power can kill AND total value risked <= attacker value.
-        // For menace attackers, also require at least 2 blockers.
-        let min_blockers = if has_menace { 2 } else { 1 };
-        if combined_power >= attacker_toughness
-            && gang_set.len() >= min_blockers
-            && gang_value <= attacker_value
+        // CR 509.1b + CR 704.5a: Survival override, restricted to attackers that a
+        // minimum-blocker floor routes here. Such an attacker is skipped by BOTH
+        // single-blocker chump passes, which are the only places carrying a
+        // survival override (`should_chump_stabilize`), so this gang pass is its
+        // sole blocking route — and the kill-and-trade gates below are a pure value
+        // heuristic that declines a legal, life-saving block. That is how a menace /
+        // "can't be blocked except by three or more creatures" attacker (Pathrazer
+        // of Ulamog) walks past a full board for lethal (issue #7183).
+        //
+        // Deliberately NOT applied when the floor is 1: those attackers already ran
+        // through the single-blocker passes with their full guard set, so widening
+        // the gate here would double-count their chump decision.
+        //
+        // Mirrors the single-blocker pass guard-for-guard: the same
+        // `effective_life <= attacker_power * 3` threshold with the CR 903.10a
+        // commander-damage tightening, the same `commander_chump_unsafe` rejection
+        // (evaluated against the gang's combined toughness, since trample assigns
+        // lethal damage to every blocker before any tramples through, CR 702.19b),
+        // and the same exclusion of damage-reflection blockers, which hand the
+        // attacker's power straight back to the player and so save nothing.
+        let p_life = state.players[player.0 as usize].life;
+        let effective_life = commander_lethal_headroom(state, player, attacker_id)
+            .map(|headroom| p_life.min(headroom as i32))
+            .unwrap_or(p_life);
+        let gang_toughness: i32 = gang_set
+            .iter()
+            .filter_map(|bid| state.objects.get(bid).and_then(|b| b.toughness))
+            .sum();
+        let gang_reflects_damage = gang_set.iter().any(|bid| {
+            state
+                .objects
+                .get(bid)
+                .is_some_and(has_damage_reflection_to_controller)
+        });
+        let gang_stabilize = needed_blockers > 1
+            && matches!(objective, CombatObjective::Stabilize)
+            && effective_life <= attacker_power * 3
+            && !gang_reflects_damage
+            && !commander_chump_unsafe(state, player, attacker_id, gang_toughness);
+
+        // Only gang-block if combined power can kill AND total value risked <=
+        // attacker value — or if declining loses the game outright. Never below the
+        // CR 509.1b floor, which would make the declaration illegal.
+        if gang_set.len() >= needed_blockers
+            && ((combined_power >= attacker_toughness && gang_value <= attacker_value)
+                || gang_stabilize)
         {
             for bid in gang_set {
                 assignments.push((bid, attacker_id));
@@ -1096,8 +1170,9 @@ pub fn choose_blockers_with_profile(
                     Some(a) => a,
                     None => continue,
                 };
-                // CR 702.111b: Skip menace attackers — single chump blocks are illegal.
-                if attacker.has_keyword(&Keyword::Menace) {
+                // CR 509.1b: Skip attackers with a minimum-blocker floor above 1 —
+                // a single chump block is an illegal declaration against them.
+                if required_blockers(&attacker_id) > 1 {
                     continue;
                 }
                 // Find any unused blocker that can legally block this attacker.
@@ -1142,8 +1217,9 @@ pub fn choose_blockers_with_profile(
                 Some(a) => a,
                 None => continue,
             };
-            // CR 702.111b: Menace requires 2+ blockers — handled by gang-block, not chump.
-            if attacker.has_keyword(&Keyword::Menace) {
+            // CR 509.1b: A minimum-blocker floor above 1 is handled by the
+            // gang-block pass, not by a single-creature chump.
+            if required_blockers(&attacker_id) > 1 {
                 continue;
             }
             let Some(headroom) = commander_lethal_headroom(state, player, attacker_id) else {
@@ -4247,6 +4323,151 @@ mod tests {
             ),
             "combat_lookahead == false must map to Disabled in measurement mode too — \
              measurement must not enable a projection the tier never takes"
+        );
+    }
+
+    // ── CR 509.1b minimum-blocker floors (issue #7183) ────────────────────────
+    //
+    // These exercise the *class* — any attacker whose minimum-blocker floor
+    // exceeds 1 — through both of its sources: the Menace keyword (CR 702.111b,
+    // floor 2) and a `CantBeBlockedExceptBy { MinBlockers { min } }` static
+    // (CR 509.1b, arbitrary floor). Before the fix the AI keyed on the Menace
+    // keyword alone, so a `MinBlockers` attacker was routed through the
+    // single-blocker passes, produced an illegal lone block, and had it rewritten
+    // to the empty declaration by `complete_blocker_proposal` — the AI never
+    // blocked Pathrazer of Ulamog even at lethal.
+
+    /// Give `attacker` a "can't be blocked except by `min` or more creatures"
+    /// restriction — the static half of the CR 509.1b floor, as parsed from
+    /// Pathrazer of Ulamog's second line.
+    fn add_min_blockers_restriction(state: &mut GameState, attacker: ObjectId, min: u32) {
+        use engine::types::ability::StaticDefinition;
+        use engine::types::statics::BlockExceptionKind;
+
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::CantBeBlockedExceptBy {
+                kind: BlockExceptionKind::MinBlockers { min },
+            }));
+    }
+
+    /// Board where `blockers` 4/4s face one lethal attacker at `life`.
+    fn lethal_attacker_board(life: i32, blockers: usize) -> (GameState, ObjectId, Vec<ObjectId>) {
+        let mut state = setup();
+        state.players[1].life = life;
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 11, 11, vec![]);
+        let blocker_ids = (0..blockers)
+            .map(|i| {
+                add_creature(
+                    &mut state,
+                    PlayerId(1),
+                    &format!("Blocker {i}"),
+                    4,
+                    4,
+                    vec![],
+                )
+            })
+            .collect();
+        (state, attacker, blocker_ids)
+    }
+
+    /// CR 509.1b: an attacker with a `MinBlockers { min: 3 }` restriction must be
+    /// gang-blocked by at least three creatures. The AI is at 6 life facing 11
+    /// power, so declining loses the game outright while a legal three-creature
+    /// block is available.
+    #[test]
+    fn min_blockers_three_attacker_is_gang_blocked_at_lethal() {
+        let (mut state, attacker, _) = lethal_attacker_board(6, 10);
+        add_min_blockers_restriction(&mut state, attacker, 3);
+
+        let assignments = choose_blockers(&state, PlayerId(1), &[attacker]);
+
+        let on_attacker = assignments.iter().filter(|&&(_, a)| a == attacker).count();
+        assert!(
+            on_attacker >= 3,
+            "a 'can't be blocked except by three or more creatures' attacker must be \
+             gang-blocked by at least 3 at lethal, got {assignments:?}"
+        );
+        // The declaration the engine would actually accept — proves the proposal is
+        // legal rather than silently rewritten to the empty witness.
+        assert_eq!(
+            engine::game::combat::complete_blocker_proposal(&state, PlayerId(1), &assignments),
+            engine::types::actions::GameAction::DeclareBlockers {
+                assignments: assignments.clone()
+            },
+            "the AI's declaration must survive the CR 509.1c completion authority"
+        );
+    }
+
+    /// CR 702.111b: the Menace floor of 2 is the same class and must behave
+    /// identically — the fix must not be specific to the static form.
+    #[test]
+    fn menace_attacker_is_gang_blocked_at_lethal() {
+        let (mut state, attacker, _) = lethal_attacker_board(6, 10);
+        state
+            .objects
+            .get_mut(&attacker)
+            .unwrap()
+            .keywords
+            .push(Keyword::Menace);
+
+        let assignments = choose_blockers(&state, PlayerId(1), &[attacker]);
+
+        let on_attacker = assignments.iter().filter(|&&(_, a)| a == attacker).count();
+        assert!(
+            on_attacker >= 2,
+            "a menace attacker must be gang-blocked by at least 2 at lethal, got {assignments:?}"
+        );
+    }
+
+    /// A floor above 1 must never produce a *short* declaration. With only two
+    /// creatures available against a `MinBlockers { min: 3 }` attacker no legal
+    /// block exists, so the AI must decline rather than offer an illegal pair
+    /// (which the completion authority would rewrite to empty anyway).
+    #[test]
+    fn min_blockers_floor_is_never_under_filled() {
+        let (mut state, attacker, _) = lethal_attacker_board(6, 2);
+        add_min_blockers_restriction(&mut state, attacker, 3);
+
+        let assignments = choose_blockers(&state, PlayerId(1), &[attacker]);
+
+        let on_attacker = assignments.iter().filter(|&&(_, a)| a == attacker).count();
+        assert!(
+            on_attacker == 0 || on_attacker >= 3,
+            "a declaration against a min-3 attacker is either absent or at least 3 \
+             creatures — never a short, illegal set. Got {assignments:?}"
+        );
+    }
+
+    /// The survival override is scoped to lethal pressure: at a comfortable life
+    /// total the AI must still decline an unprofitable gang block rather than
+    /// throwing three 4/4s at a 5/5. Guards against the fix over-blocking.
+    #[test]
+    fn min_blockers_attacker_is_not_gang_blocked_when_not_under_pressure() {
+        let mut state = setup();
+        state.players[1].life = 40;
+        let attacker = add_creature(&mut state, PlayerId(0), "Attacker", 5, 5, vec![]);
+        add_min_blockers_restriction(&mut state, attacker, 3);
+        for i in 0..10 {
+            add_creature(
+                &mut state,
+                PlayerId(1),
+                &format!("Blocker {i}"),
+                4,
+                4,
+                vec![],
+            );
+        }
+
+        let assignments = choose_blockers(&state, PlayerId(1), &[attacker]);
+
+        assert!(
+            assignments.is_empty(),
+            "at 40 life a 5/5 is not worth three 4/4s — the survival override must not \
+             fire outside Stabilize. Got {assignments:?}"
         );
     }
 }


### PR DESCRIPTION
Fixes #7183.

Related to #6874, but **not** a fix for it: Emrakul carries no minimum-blocker floor (`Flying`, `Protection(spells that are one or more colors)`, `Annihilator 6`, and one `CantBeCountered` static — no Menace, no `CantBeBlockedExceptBy { MinBlockers }`), so the blocking fix below does not touch it. The two issues share only the annihilator *sacrifice* softlock, which this PR does not fix — see the last section.

Model: claude-opus-5[1m]
Tier: Frontier
Thinking: High

## Problem

Pathrazer of Ulamog attacks and the AI **never blocks it, at any life total**. The same holds for every Menace creature.

CR 509.1b lets an attacker impose a floor on how many creatures must block it. Two things create one: the Menace keyword (CR 702.111b, floor 2) and a `CantBeBlockedExceptBy { MinBlockers { min } }` static parsed from "can't be blocked except by N or more creatures" (Pathrazer, floor 3).

The engine already has a single authority for that floor — `min_blockers_required` — which `validate_blockers` enforces and `block_requirements_for_player` shows the UI. **Neither the AI's candidate enumerator nor its combat heuristic read it**; both hardcoded the Menace keyword. Pathrazer carries no Menace keyword, so it was treated as blockable by one creature and every declaration the AI built against it was illegal, then silently rewritten to the empty declaration by `complete_blocker_proposal`.

## Three defects, all fixed by routing through the existing authority

**1. `blocker_actions` could not express a legal gang block.** It seeded only the empty declaration plus every *single* `(blocker, attacker)` pair. Against a floor above 1 all of them are illegal, so `complete_blocker_proposals` rewrote each to the same tax-free witness and dedup collapsed the whole candidate set to one entry — "don't block". Measured on an 8-blocker board:

| attacker | valid blockers | enumerated `DeclareBlockers` (before → after) |
|---|---|---|
| Pathrazer (floor 3) | 5 | **1** → 11 |
| Menace (floor 2) | 8 | **1** → 29 |
| vanilla | 8 | 9 → 9 (unchanged) |

Now seeds bounded `count`-sized combinations per floored attacker, drawn from that attacker's own eligible blockers. Legality is still decided downstream by `complete_blocker_proposals`, which remains the single authority.

**2. `choose_blockers_with_profile` keyed all six passes on `has_keyword(Menace)`.** A `MinBlockers` attacker fell through the single-blocker passes (producing an illegal lone block) and the gang pass computed a floor of 1 for it. The floor now comes from `min_blockers_required_from_precomputed`, hoisted once for the whole call. Read through that rather than `block_requirements_for_player` because the latter derives from `state.combat`, which callers evaluating a hypothetical block (lookahead, tests) may not have populated — the floor is a property of the attacker's own restrictions, not of the combat record. The gang top-up also loops now: menace needs 2, Pathrazer needs 3, and a single top-up could never reach an arbitrary floor.

**3. The gang pass had no survival override.** A floored attacker is skipped by *both* single-blocker chump passes, which are the only places carrying `should_chump_stabilize` — so the gang pass is its sole blocking route, and it gated purely on trade value. Concretely: at 6 life facing an 11/11, the AI held a legal three-creature block and declined it because `gang_value=30 > attacker_value=26`, then died. The gang pass now mirrors the single-blocker override **for floored attackers only**, guard-for-guard: the same `effective_life <= attacker_power * 3` threshold with the CR 903.10a commander-damage tightening, the same `commander_chump_unsafe` rejection (evaluated against the gang's combined toughness per CR 702.19b), and the same damage-reflection exclusion. Unfloored attackers keep their existing value semantics — they already ran the single-blocker passes with the full guard set, so widening the gate for them would double-count their chump decision.

## Anchored on

- `crates/engine/src/game/combat.rs:5982` — `min_blockers_required`, the engine's stated single authority for the floor ("`validate_blocks` enforces it and `block_requirements_for_player` surfaces it to the UI, so the count a player sees can never disagree with the count the engine enforces"). Both fixes read the floor through this rather than re-deriving it.
- `crates/engine/src/game/combat.rs:2105` — `complete_blocker_proposals`, the existing legality/witness authority that `blocker_actions` already routed through; the new gang seeds go through the same call unchanged.
- `crates/engine/src/ai_support/candidates.rs:4516` — `bounded_select_card_candidates`, the existing bounded-combination pattern (`pool_cap` + `output_cap` over `bounded_combinations_for_sizes`); the gang-block seeding mirrors it, including the sibling `GANG_BLOCK_*` cap constants placed beside `SELECTION_*`.
- `crates/phase-ai/src/combat_ai.rs:933` — the single-blocker `should_chump_stabilize` override the gang-pass override is mirrored from, guard-for-guard.

## Tests

Four engine integration tests (`crates/engine/tests/integration/min_blocker_floor_block_candidates_7183.rs`) drive the real `legal_actions_full` at a genuine declare-blockers prompt: menace floor 2 reachable, `MinBlockers` floor 3 reachable, no enumerated declaration below any floor (2/3/4), and unfloored attackers keep their single-blocker candidates.

Four `combat_ai` tests cover the heuristic: gang-blocks at lethal for both floor sources, never under-fills a floor it cannot satisfy, and does **not** over-block at 40 life (guards against the fix over-correcting).

Both `MinBlockers` arms were verified to **fail on pre-fix logic** by temporarily reverting each change independently. The two menace tests pass before and after — they are class-sibling regression guards, not bug proofs, and are labelled as such.

## Gate A

```
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=084ad38ea0ed12947208f97b1dbc6ab81edebc42 base=b02c8bbe9094d4e9a21a549bb99f3d411ecc3093
```

## Verification

- `cargo fmt --all --check` clean
- `cargo clippy --workspace --all-targets -- -D warnings` clean
- `cargo test -p phase-engine` — 18844 lib + 4815 integration + 30 others, 0 failures
- `cargo test -p phase-ai` — 2075 lib + all integration, 0 failures

No AI behavior baselines were refreshed; `cargo ai-gate` has **not** been run for this change (see below).

## What this PR does not fix

**It does not explain the reported freeze**, and #7183/#6874 should stay open until that is settled. This PR makes the AI play the card correctly; the softlock is a separate failure at a different decision point.

#6874 pins it via its console diagnostic — `AI controller halted after 3 failed proposals on EffectZoneChoice` — i.e. the annihilator *sacrifice* prompt, not blocking. I exercised that path across annihilator 3–8, boards of 4–30 permanents, 2- and 4-player pods, both attack directions, and aura/host batches, applying **every** enumerated candidate rather than just the AI's pick: no empty candidate set, no rejected proposal, no `None` from the AI. Also ruled out: chooser misrouting, `priority_player` desync, and a `DeclareBlockers` wedge (`complete_blocker_proposals` always emits a witness, so that legal set is never empty). The remaining candidates are a panic inside `getAiAction` or state I could not synthesize — #6874 has a saved game state attached, which would settle it.

Two adjacent quality issues observed but deliberately left alone, as out of scope here:

- The AI sacrifices its **creatures before its lands** to annihilator even when facing lethal and needing blockers.
- `SELECTION_POOL_CAP = 12` means sacrifice candidates only ever come from the first 12 eligible permanents, so on a wide board most of the pool is unreachable to both the AI and (via the enumeration gate) a human in a server game.

Since this changes AI combat behavior, `cargo ai-gate` with a paired-seed report is worth running before merge — I did not run it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Combat decisions now support attackers requiring multiple blockers, including arbitrary minimum blocker requirements.
  - Legal blocking options now include valid gang blocks while limiting excessive combinations for consistent performance.
  - Combat AI can assign the required number of blockers when necessary to prevent lethal damage.

- **Bug Fixes**
  - Improved handling of Menace, deathtouch, first strike, trample, commander damage, and damage reflection.
  - Prevented invalid under-filled blocks and unnecessary gang blocks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->