### PR TITLE
fix(engine): preserve tagged keyword payload values

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -4469,7 +4469,8 @@ fn collect_target_slot_specs(
         }
         filters.push(target);
         for filter in filters {
-            if matches!(filter, TargetFilter::SelfRef | TargetFilter::ParentTarget) {
+            // Keep per-slot metadata aligned with the surfaced cast-time slots.
+            if filter.is_context_ref() {
                 continue;
             }
             let id = TargetInstanceId(*next_instance);
@@ -6761,7 +6762,10 @@ fn assign_selected_slots_recursive(
         }
         filters.push(target);
         for filter in filters {
-            if matches!(filter, TargetFilter::SelfRef | TargetFilter::ParentTarget) {
+            // Mirror `collect_target_slots` and `assign_targets_recursive`:
+            // context-reference fighters resolve from the ability chain, so they
+            // consume no interactive target-selection slot.
+            if filter.is_context_ref() {
                 continue;
             }
             let Some(selected_slot) = selected_slots.get(*next_slot) else {

--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -1726,6 +1726,7 @@ pub fn resolve_all(
             .iter()
             .filter(|(&id, obj)| {
                 origin_zones.contains(&obj.zone)
+                    && ability.target_pin_is_current(id, state)
                     && crate::game::filter::matches_target_filter(
                         state,
                         id,

--- a/crates/engine/src/game/effects/delayed_trigger.rs
+++ b/crates/engine/src/game/effects/delayed_trigger.rs
@@ -651,53 +651,7 @@ fn concrete_parent_target_filter(
     filter: &TargetFilter,
     parent_targets: &[TargetRef],
 ) -> TargetFilter {
-    let filter = crate::game::filter::normalize_contextual_filter(filter, parent_targets);
-    match filter {
-        TargetFilter::ParentTarget => parent_targets_filter(parent_targets),
-        // CR 603.7c + CR 608.2c: bind a `ParentTargetSlot { index }` delayed
-        // condition filter to the concrete parent object at that declared slot
-        // (single-slot analogue of the `ParentTarget` arm). Out-of-range/empty
-        // slots fall back to `Any`, matching `parent_targets_filter`'s empty case.
-        TargetFilter::ParentTargetSlot { index } => parent_targets
-            .get(index)
-            .map(|target| match target {
-                TargetRef::Object(id) => TargetFilter::SpecificObject { id: *id },
-                TargetRef::Player(id) => TargetFilter::SpecificPlayer { id: *id },
-            })
-            .unwrap_or(TargetFilter::Any),
-        TargetFilter::Not { filter } => TargetFilter::Not {
-            filter: Box::new(concrete_parent_target_filter(&filter, parent_targets)),
-        },
-        TargetFilter::Or { filters } => TargetFilter::Or {
-            filters: filters
-                .iter()
-                .map(|filter| concrete_parent_target_filter(filter, parent_targets))
-                .collect(),
-        },
-        TargetFilter::And { filters } => TargetFilter::And {
-            filters: filters
-                .iter()
-                .map(|filter| concrete_parent_target_filter(filter, parent_targets))
-                .collect(),
-        },
-        other => other,
-    }
-}
-
-fn parent_targets_filter(parent_targets: &[TargetRef]) -> TargetFilter {
-    let targets: Vec<_> = parent_targets
-        .iter()
-        .map(|target| match target {
-            TargetRef::Object(id) => TargetFilter::SpecificObject { id: *id },
-            TargetRef::Player(id) => TargetFilter::SpecificPlayer { id: *id },
-        })
-        .collect();
-
-    match targets.as_slice() {
-        [] => TargetFilter::Any,
-        [target] => target.clone(),
-        _ => TargetFilter::Or { filters: targets },
-    }
+    crate::game::filter::normalize_contextual_filter(filter, parent_targets)
 }
 
 fn bind_tracked_set_to_condition(condition: &mut DelayedTriggerCondition, real_id: TrackedSetId) {
@@ -1033,6 +987,13 @@ fn bind_tracked_set_to_effect(effect: &mut Effect, real_id: TrackedSetId) {
                 }
                 | TargetFilter::Any => TargetFilter::TrackedSet { id: real_id },
                 TargetFilter::TrackedSet { id } => TargetFilter::TrackedSet { id: *id },
+                TargetFilter::ParentTarget | TargetFilter::ParentTargetSlot { .. } => {
+                    TargetFilter::TrackedSetFiltered {
+                        id: real_id,
+                        filter: Box::new(target.clone()),
+                        caused_by: None,
+                    }
+                }
                 _ => TargetFilter::TrackedSet { id: real_id },
             };
             *effect = Effect::ChangeZoneAll {
@@ -1105,6 +1066,9 @@ fn filter_refs_parent_object_anaphor(filter: &TargetFilter) -> bool {
             filters.iter().any(filter_refs_parent_object_anaphor)
         }
         TargetFilter::Not { filter } => filter_refs_parent_object_anaphor(filter),
+        TargetFilter::TrackedSetFiltered { filter, .. } => {
+            filter_refs_parent_object_anaphor(filter)
+        }
         _ => false,
     }
 }
@@ -3515,6 +3479,103 @@ mod tests {
             state.objects[&second_token].zone,
             Zone::Exile,
             "the remaining tracked-set token on the battlefield must be exiled"
+        );
+    }
+
+    /// CR 400.7 + CR 603.7c (issue #7100): an end-step return referring to
+    /// the parent-selected tracked-set member must retain that anaphor through
+    /// the ChangeZoneAll upgrade. A later zone change makes the same object id
+    /// a new object, which the creation-time incarnation pin excludes.
+    #[test]
+    fn tracked_set_delayed_change_zone_preserves_parent_pin_across_reentry() {
+        let mut state = GameState::new_two_player(42);
+        let creature = crate::game::zones::create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Eerie Interlude target".to_string(),
+            Zone::Battlefield,
+        );
+        let set_id = TrackedSetId(1);
+        state.tracked_object_sets.insert(set_id, vec![creature]);
+        state.chain_tracked_set_id = Some(set_id);
+        state.next_tracked_set_id = 2;
+
+        let effect = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChangeZone {
+                origin: Some(Zone::Battlefield),
+                destination: Zone::Exile,
+                target: TargetFilter::ParentTarget,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+        );
+        let create = ResolvedAbility::new(
+            Effect::CreateDelayedTrigger {
+                condition: DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
+                effect: Box::new(effect),
+                uses_tracked_set: true,
+            },
+            vec![TargetRef::Object(creature)],
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let mut events = Vec::new();
+        resolve(&mut state, &create, &mut events).expect("delayed trigger installs");
+
+        let delayed = &state.delayed_triggers[0].ability;
+        assert!(delayed.target_pin_is_current(creature, &state));
+        assert_eq!(delayed.targets, vec![TargetRef::Object(creature)]);
+        assert!(matches!(
+            &delayed.effect,
+            Effect::ChangeZoneAll {
+                target: TargetFilter::TrackedSetFiltered {
+                    id,
+                    filter,
+                    caused_by: None,
+                },
+                ..
+            } if *id == set_id && matches!(filter.as_ref(), TargetFilter::ParentTarget)
+        ));
+
+        let mut current_state = state.clone();
+        let current_delayed = current_state.delayed_triggers[0].ability.clone();
+        crate::game::effects::resolve_ability_chain(
+            &mut current_state,
+            &current_delayed,
+            &mut Vec::new(),
+            0,
+        )
+        .expect("current delayed trigger resolves");
+        assert_eq!(
+            current_state.objects[&creature].zone,
+            Zone::Exile,
+            "the still-current tracked-set member must be affected"
+        );
+
+        crate::game::zones::move_to_zone(&mut state, creature, Zone::Graveyard, &mut Vec::new());
+        crate::game::zones::move_to_zone(&mut state, creature, Zone::Battlefield, &mut Vec::new());
+        let delayed = state.delayed_triggers[0].ability.clone();
+        assert!(
+            !delayed.target_pin_is_current(creature, &state),
+            "the returned object is a new incarnation"
+        );
+
+        crate::game::effects::resolve_ability_chain(&mut state, &delayed, &mut events, 0)
+            .expect("delayed trigger resolves");
+        assert_eq!(
+            state.objects[&creature].zone,
+            Zone::Battlefield,
+            "the stale tracked-set member must not be exiled"
         );
     }
 

--- a/crates/engine/src/game/effects/forage.rs
+++ b/crates/engine/src/game/effects/forage.rs
@@ -22,7 +22,7 @@ use crate::types::ability::{
     FilterProp, MultiTargetSpec, PlayerFilter, QuantityExpr, ResolvedAbility, TargetChoiceTiming,
     TargetFilter, TargetRef, TypedFilter,
 };
-use crate::types::events::GameEvent;
+use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::GameState;
 use crate::types::identifiers::ObjectId;
 use crate::types::player::PlayerId;
@@ -115,6 +115,7 @@ pub(crate) fn resolve(
         branches.push(sacrifice_food_branch());
     }
 
+    let foraged = !branches.is_empty();
     match branches.len() {
         // CR 701.61a: neither mode performable — foraging does nothing.
         0 => {}
@@ -144,6 +145,16 @@ pub(crate) fn resolve(
             choose.context = ability.context.clone();
             super::choose_one_of::resolve(state, &choose, events)?;
         }
+    }
+
+    if foraged {
+        events.push(GameEvent::PlayerPerformedAction {
+            player_id: controller,
+            action: PlayerActionKind::Forage,
+            look_count: None,
+            scry_bottom_count: None,
+            scry_top_count: None,
+        });
     }
 
     events.push(GameEvent::EffectResolved {
@@ -212,6 +223,16 @@ mod tests {
                 ..
             }
         )));
+        assert!(
+            !events.iter().any(|event| matches!(
+                event,
+                GameEvent::PlayerPerformedAction {
+                    action: PlayerActionKind::Forage,
+                    ..
+                }
+            )),
+            "an impossible forage must not emit a player-action event"
+        );
     }
 
     /// CR 701.61a (exile mode): three graveyard cards and no Food prompts an
@@ -283,6 +304,14 @@ mod tests {
             state.waiting_for,
             WaitingFor::ChooseOneOfBranch { .. }
         ));
+        assert!(events.iter().any(|event| matches!(
+            event,
+            GameEvent::PlayerPerformedAction {
+                player_id: PlayerId(0),
+                action: PlayerActionKind::Forage,
+                ..
+            }
+        )));
     }
 
     /// CR 701.61a: both modes available — the forager chooses which via a modal prompt.

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5712,6 +5712,9 @@ fn effect_parent_ref_slots(effect: &Effect) -> Vec<&TargetFilter> {
         Effect::UnattachAll { attachment, .. } if attachment.is_context_ref() => {
             slots.push(attachment)
         }
+        Effect::ChangeZoneAll { target, .. } if filter_refs_parent_target(target) => {
+            slots.push(target)
+        }
         _ => {}
     }
     slots
@@ -5788,6 +5791,7 @@ fn filter_refs_parent_target(filter: &TargetFilter) -> bool {
             filters.iter().any(filter_refs_parent_target)
         }
         TargetFilter::Not { filter } => filter_refs_parent_target(filter),
+        TargetFilter::TrackedSetFiltered { filter, .. } => filter_refs_parent_target(filter),
         _ => false,
     }
 }

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -3707,7 +3707,7 @@ pub(super) fn handle_resolution_choice(
                         .expect("a settled reveal choice must resume its continuation");
                 } else {
                     let _ = state
-                        .clear_active_ability_continuation()
+                        .clear_active_ability_continuation_or_batch_delivery_child()
                         .expect("declined reveal cannot clear a buried continuation");
                 }
                 return Ok(ResolutionChoiceOutcome::WaitingFor(
@@ -3758,7 +3758,7 @@ pub(super) fn handle_resolution_choice(
             // on the revealed card (e.g., Thoughtseize's exile).
             if optional && decline_runs_continuation {
                 let _ = state
-                    .clear_active_ability_continuation()
+                    .clear_active_ability_continuation_or_batch_delivery_child()
                     .expect("accepted reveal cannot clear a buried continuation");
             } else if let Some(frame) = state.active_ability_continuation_frame_mut() {
                 frame.pending.chain.targets = vec![TargetRef::Object(chosen_id)];

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -1026,11 +1026,11 @@ fn entered_perturbs_quantity(
     })
 }
 
-/// CR 608.2c: Resolve contextual parent-target exclusions before a mass-effect scan.
+/// CR 608.2c: Resolve contextual parent-target references before an object scan.
 ///
-/// This intentionally supports only `Not(ParentTarget)` and
-/// `Not(ParentTargetSlot { index })` inside composite filters. Positive
-/// `ParentTarget` / `ParentTargetSlot` inside `And` / `Or` remains unresolved here.
+/// `ParentTarget` and `ParentTargetSlot` are resolution-time references, not
+/// object-matcher predicates. Normalize them to their concrete parent targets
+/// before a composite filter reaches `matches_target_filter`.
 pub fn normalize_contextual_filter(
     filter: &TargetFilter,
     parent_targets: &[TargetRef],
@@ -1080,6 +1080,11 @@ pub fn normalize_contextual_filter(
         TargetFilter::Not { filter: inner } => TargetFilter::Not {
             filter: Box::new(normalize_contextual_filter(inner, parent_targets)),
         },
+        TargetFilter::ParentTarget => parent_targets_filter(parent_targets),
+        TargetFilter::ParentTargetSlot { index } => parent_targets
+            .get(*index)
+            .map(target_ref_filter)
+            .unwrap_or(TargetFilter::Any),
         TargetFilter::Or { filters } => TargetFilter::Or {
             filters: filters
                 .iter()
@@ -1092,7 +1097,33 @@ pub fn normalize_contextual_filter(
                 .map(|inner| normalize_contextual_filter(inner, parent_targets))
                 .collect(),
         },
+        TargetFilter::TrackedSetFiltered {
+            id,
+            filter,
+            caused_by,
+        } => TargetFilter::TrackedSetFiltered {
+            id: *id,
+            filter: Box::new(normalize_contextual_filter(filter, parent_targets)),
+            caused_by: *caused_by,
+        },
         _ => filter.clone(),
+    }
+}
+
+fn parent_targets_filter(parent_targets: &[TargetRef]) -> TargetFilter {
+    match parent_targets {
+        [] => TargetFilter::Any,
+        [target] => target_ref_filter(target),
+        targets => TargetFilter::Or {
+            filters: targets.iter().map(target_ref_filter).collect(),
+        },
+    }
+}
+
+fn target_ref_filter(target: &TargetRef) -> TargetFilter {
+    match target {
+        TargetRef::Object(id) => TargetFilter::SpecificObject { id: *id },
+        TargetRef::Player(id) => TargetFilter::SpecificPlayer { id: *id },
     }
 }
 
@@ -10463,6 +10494,24 @@ mod tests {
                         filter: Box::new(TargetFilter::SpecificObject { id: ObjectId(7) }),
                     },
                 ],
+            }
+        );
+    }
+
+    #[test]
+    fn normalize_contextual_filter_binds_positive_parent_target_inside_tracked_set() {
+        let filter = TargetFilter::TrackedSetFiltered {
+            id: crate::types::identifiers::TrackedSetId(3),
+            filter: Box::new(TargetFilter::ParentTarget),
+            caused_by: None,
+        };
+
+        assert_eq!(
+            normalize_contextual_filter(&filter, &[TargetRef::Object(ObjectId(7))]),
+            TargetFilter::TrackedSetFiltered {
+                id: crate::types::identifiers::TrackedSetId(3),
+                filter: Box::new(TargetFilter::SpecificObject { id: ObjectId(7) }),
+                caused_by: None,
             }
         );
     }

--- a/crates/engine/src/game/mana_abilities.rs
+++ b/crates/engine/src/game/mana_abilities.rs
@@ -2102,6 +2102,19 @@ fn suspend_mana_ability_parent_chain(parent: Option<&mut ManaAbilityCostParent>)
     }
 }
 
+/// Only a pre-delivery replacement-ordering pause may replace the active prompt
+/// with `ReplacementChoice`. A post-delivery substitute can keep a replacement
+/// record while it waits on its own prompt, so it has no ordering player and
+/// must remain visible.
+fn pause_pre_delivery_mana_cost_replacement_choice(
+    state: &mut GameState,
+    choice_player: Option<PlayerId>,
+) {
+    if let Some(choice_player) = choice_player.filter(|_| state.pending_replacement.is_some()) {
+        super::costs::pause_cost_payment_for_replacement_choice(state, choice_player);
+    }
+}
+
 fn pause_mana_ability_cost_payment(
     state: &mut GameState,
     pre_delivery_choice_player: Option<PlayerId>,
@@ -2126,19 +2139,7 @@ fn pause_mana_ability_cost_payment(
         pending: Box::new(pending),
         cursor,
     });
-    // `NeedsChoice` also reports a post-delivery replacement continuation.
-    // That continuation has already consumed `pending_replacement` and installed
-    // its own live prompt, which must remain visible while the typed cursor is
-    // parked. Pre-delivery CR 616.1 ordering is the only case that needs a
-    // synthesized ReplacementChoice.
-    if state.pending_replacement.is_some() {
-        super::costs::pause_cost_payment_for_replacement_choice(
-            state,
-            pre_delivery_choice_player.expect(
-                "a pending replacement must identify the player ordering the interrupted mana cost",
-            ),
-        );
-    }
+    pause_pre_delivery_mana_cost_replacement_choice(state, pre_delivery_choice_player);
 }
 
 fn mana_ability_cursor_after_current_component(
@@ -4423,6 +4424,7 @@ pub(crate) fn resume_waiting_for(
 
 #[cfg(test)]
 mod tests {
+    use std::collections::HashSet;
     use std::sync::Arc;
 
     use super::*;
@@ -4485,18 +4487,19 @@ mod tests {
     use crate::types::ability::{
         AbilityCondition, AbilityCost, AbilityKind, AbilityTag, ActivationRestriction, Comparator,
         ContinuousModification, ControllerRef, CopyRetargetPermission, DelayedTriggerCondition,
-        DevotionColors, Duration, Effect, FilterProp, LinkedExileScope, ManaContribution,
-        ManaProduction, MultiTargetSpec, ObjectScope, PlayerFilter, PlayerScope, QuantityExpr,
-        QuantityRef, SacrificeCost, StaticDefinition, TargetFilter, TriggerDefinition, TypeFilter,
-        TypedFilter, REMOVE_COUNTER_COST_ANY_NUMBER,
+        DevotionColors, Duration, Effect, EffectKind, FilterProp, LinkedExileScope,
+        ManaContribution, ManaProduction, MultiTargetSpec, ObjectScope, PlayerFilter, PlayerScope,
+        QuantityExpr, QuantityRef, SacrificeCost, StaticDefinition, TargetFilter,
+        TriggerDefinition, TypeFilter, TypedFilter, REMOVE_COUNTER_COST_ANY_NUMBER,
     };
     use crate::types::card_type::CoreType;
     use crate::types::counter::CounterType;
-    use crate::types::game_state::{ExileLink, ExileLinkKind};
-    use crate::types::identifiers::CardId;
+    use crate::types::game_state::{ExileLink, ExileLinkKind, PendingReplacement};
+    use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::mana::{
         ManaColor, ManaCost, ManaCostShard, ManaRestriction, ManaType, ManaUnit,
     };
+    use crate::types::proposed_event::{ProposedEvent, ReplacementId};
     use crate::types::statics::{CostPaymentProhibition, ProhibitionScope, StaticMode};
     use crate::types::triggers::TriggerMode;
     use crate::types::zones::Zone;
@@ -4513,6 +4516,61 @@ mod tests {
             },
         )
         .cost(AbilityCost::Tap)
+    }
+
+    #[test]
+    fn post_delivery_mana_cost_pause_preserves_its_live_prompt() {
+        let mut state = GameState::new_two_player(42);
+        state.pending_replacement = Some(PendingReplacement {
+            proposed: ProposedEvent::Draw {
+                player_id: PlayerId(0),
+                count: 1,
+                applied: HashSet::new(),
+            },
+            sacrifice_provenance: None,
+            candidates: vec![ReplacementId {
+                source: ObjectId(7),
+                index: 0,
+            }],
+            search_found_candidates: Vec::new(),
+            depth: 0,
+            is_optional: false,
+            library_placement: None,
+            excess_recipient: None,
+            lifelink_bonus: 0,
+            may_cost_paid: false,
+            may_cost_remaining: None,
+        });
+        let live_prompt = WaitingFor::DiscardChoice {
+            player: PlayerId(0),
+            count: 1,
+            cards: Vec::new(),
+            source_id: ObjectId(7),
+            effect_kind: EffectKind::Discard,
+            up_to: false,
+            unless_filter: None,
+            discard_frame: None,
+        };
+        state.waiting_for = live_prompt.clone();
+
+        pause_pre_delivery_mana_cost_replacement_choice(&mut state, None);
+        assert_eq!(
+            state.waiting_for, live_prompt,
+            "a post-delivery substitute has no ordering player and retains its live prompt"
+        );
+
+        pause_pre_delivery_mana_cost_replacement_choice(&mut state, Some(PlayerId(0)));
+        assert!(
+            matches!(
+                state.waiting_for,
+                WaitingFor::ReplacementChoice {
+                    player: PlayerId(0),
+                    candidate_count: 1,
+                    ..
+                }
+            ),
+            "an explicit pre-delivery ordering player still opens the replacement choice"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1786,35 +1786,66 @@ fn is_visible_revealed_card(state: &GameState, viewer: PlayerId, obj_id: ObjectI
         })
 }
 
+/// Removes printed-card identity from a viewer projection while retaining the
+/// public object identity and runtime state needed to render the game.
+fn redact_printed_identity(obj: &mut crate::game::game_object::GameObject) {
+    obj.card_id = CardId(0);
+    obj.base_name = HIDDEN_CARD_NAME.to_string();
+    obj.token_rules_text = None;
+    obj.attraction_lights.clear();
+    obj.token_image_ref = None;
+    obj.source_related_token_ids.clear();
+    obj.spellbook.clear();
+    obj.parse_warnings.clear();
+    obj.back_face = None;
+    obj.specialize_faces = None;
+    obj.cleave_variant = None;
+    obj.modal = None;
+    obj.additional_cost = None;
+    obj.strive_cost = None;
+    obj.casting_restrictions.clear();
+    obj.casting_options.clear();
+    obj.casting_permissions.clear();
+    obj.unimplemented_mechanics.clear();
+
+    obj.base_power = None;
+    obj.base_toughness = None;
+    obj.base_loyalty = None;
+    obj.base_printed_loyalty = None;
+    obj.base_defense = None;
+    obj.base_card_types = Default::default();
+    obj.base_mana_cost = Default::default();
+    obj.base_keywords.clear();
+    Arc::make_mut(&mut obj.base_abilities).clear();
+    Arc::make_mut(&mut obj.base_trigger_definitions).clear();
+    Arc::make_mut(&mut obj.base_replacement_definitions).clear();
+    Arc::make_mut(&mut obj.base_static_definitions).clear();
+    obj.base_color.clear();
+    obj.base_printed_ref = None;
+}
+
 fn hide_card(state: &mut GameState, obj_id: ObjectId) {
     if let Some(obj) = state.objects.get_mut(&obj_id) {
+        // CR 400.2: library and hand are hidden zones — a viewer without
+        // look-permission may not see the card's face or any printed-card
+        // metadata that identifies it.
         obj.face_down = true;
         obj.name = HIDDEN_CARD_NAME.to_string();
+        redact_printed_identity(obj);
         Arc::make_mut(&mut obj.abilities).clear();
         obj.keywords.clear();
-        obj.base_keywords.clear();
         obj.power = None;
         obj.toughness = None;
         obj.loyalty = None;
+        obj.printed_loyalty = None;
+        obj.defense = None;
+        obj.card_types = Default::default();
+        obj.mana_cost = Default::default();
         obj.color.clear();
-        obj.base_color.clear();
         obj.trigger_definitions.clear();
         obj.replacement_definitions.clear();
         obj.static_definitions.clear();
-        obj.casting_permissions.clear();
         obj.printed_ref = None;
-        obj.base_printed_ref = None;
-        obj.back_face = None;
-        obj.token_image_ref = None;
-        obj.source_related_token_ids.clear();
-        // CR 400.2: library and hand are hidden zones — a viewer without
-        // look-permission may not see the card's face. `parse_warnings` is
-        // parser evidence derived from that face's printed text (a
-        // `SwallowedClause` carries the rules text verbatim), and only 891 of
-        // 35,657 card faces carry a non-empty vector, so its presence and
-        // contents both fingerprint the card. Redact it with the rest of the
-        // printed identity.
-        obj.parse_warnings.clear();
         obj.foretold = false;
     }
 }
@@ -1840,10 +1871,8 @@ fn reveal_face_down_identity_to_controller(obj: &mut crate::game::game_object::G
 
 fn redact_face_down_identity_from_observer(obj: &mut crate::game::game_object::GameObject) {
     obj.name = HIDDEN_CARD_NAME.to_string();
-    obj.base_name = HIDDEN_CARD_NAME.to_string();
+    redact_printed_identity(obj);
     obj.printed_ref = None;
-    obj.base_printed_ref = None;
-    obj.back_face = None;
     // CR 708.5 + CR 708.2: a face-down permanent has no name and no abilities,
     // and no player but its controller may look at the card underneath.
     // `parse_warnings` survives the face-down transformation on the
@@ -2764,6 +2793,90 @@ mod tests {
 
         assert_eq!(hidden.name, "Hidden Card");
         assert!(hidden.back_face.is_none());
+    }
+
+    /// CR 400.2: a non-owner's hidden-zone projection must not carry printed
+    /// identity through baseline characteristics or card metadata. The owner
+    /// arm proves each sentinel is present before the observer projection.
+    #[test]
+    fn hidden_hand_card_redacts_printed_identity_metadata_from_opponent() {
+        let mut state = GameState::new_two_player(42);
+        let card_id = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Secret Printed Card".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&card_id).unwrap();
+            let card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec!["Secret Type".to_string()],
+            };
+            obj.base_name = "Secret Base Name".to_string();
+            obj.token_rules_text = Some("Secret token rules".to_string());
+            obj.spellbook = vec!["Secret Spellbook Card".to_string()];
+            obj.unimplemented_mechanics = vec!["Secret mechanic".to_string()];
+            obj.power = Some(7);
+            obj.toughness = Some(9);
+            obj.base_power = Some(7);
+            obj.base_toughness = Some(9);
+            obj.card_types = card_types.clone();
+            obj.base_card_types = card_types;
+            obj.mana_cost = ManaCost::generic(7);
+            obj.base_mana_cost = ManaCost::generic(7);
+        }
+
+        let owner_view = filter_state_for_viewer(&state, PlayerId(1));
+        let owned = owner_view.objects.get(&card_id).unwrap();
+        assert_eq!(owned.base_name, "Secret Base Name");
+        assert_eq!(owned.spellbook, vec!["Secret Spellbook Card".to_string()]);
+        assert_eq!(
+            owned.token_rules_text.as_deref(),
+            Some("Secret token rules")
+        );
+        assert_eq!(
+            owned.unimplemented_mechanics,
+            vec!["Secret mechanic".to_string()]
+        );
+        assert_eq!(owned.base_power, Some(7));
+        assert_eq!(owned.base_toughness, Some(9));
+        assert_ne!(owned.base_card_types, CardType::default());
+        assert_eq!(owned.base_mana_cost, ManaCost::generic(7));
+
+        let opponent_view = filter_state_for_viewer(&state, PlayerId(0));
+        let hidden = opponent_view.objects.get(&card_id).unwrap();
+        assert_eq!(hidden.name, HIDDEN_CARD_NAME);
+        assert_eq!(hidden.card_id, CardId(0));
+        assert_eq!(hidden.base_name, HIDDEN_CARD_NAME);
+        assert!(hidden.token_rules_text.is_none());
+        assert!(hidden.spellbook.is_empty());
+        assert!(hidden.unimplemented_mechanics.is_empty());
+        assert_eq!(hidden.power, None);
+        assert_eq!(hidden.toughness, None);
+        assert_eq!(hidden.base_power, None);
+        assert_eq!(hidden.base_toughness, None);
+        assert_eq!(hidden.card_types, CardType::default());
+        assert_eq!(hidden.base_card_types, CardType::default());
+        assert_eq!(hidden.mana_cost, ManaCost::default());
+        assert_eq!(hidden.base_mana_cost, ManaCost::default());
+
+        let serialized = serde_json::to_string(hidden).unwrap();
+        for secret in [
+            "Secret Printed Card",
+            "Secret Base Name",
+            "Secret token rules",
+            "Secret Spellbook Card",
+            "Secret mechanic",
+            "Secret Type",
+        ] {
+            assert!(
+                !serialized.contains(secret),
+                "hidden card's serialized payload must not reveal {secret:?}"
+            );
+        }
     }
 
     /// CR 400.2: a hand is a hidden zone. `parse_warnings` is derived from the

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -15858,6 +15858,9 @@ fn parse_player_action_phrase(text: &str) -> Option<PlayerActionKind> {
     if let Ok(("", action)) = parse_proliferate_player_action(text) {
         return Some(action);
     }
+    if let Ok(("", action)) = parse_forage_player_action(text) {
+        return Some(action);
+    }
     match text {
         "search your library" | "searches their library" => Some(PlayerActionKind::SearchedLibrary),
         "scry" | "scries" => Some(PlayerActionKind::Scry),
@@ -15882,6 +15885,15 @@ fn parse_proliferate_player_action(input: &str) -> OracleResult<'_, PlayerAction
     all_consuming(alt((
         value(PlayerActionKind::Proliferate, tag("proliferate")),
         value(PlayerActionKind::Proliferate, tag("proliferates")),
+    )))
+    .parse(input)
+}
+
+fn parse_forage_player_action(input: &str) -> OracleResult<'_, PlayerActionKind> {
+    // CR 701.61a: Forage — exile three cards from your graveyard or sacrifice a Food.
+    all_consuming(alt((
+        value(PlayerActionKind::Forage, tag("forage")),
+        value(PlayerActionKind::Forage, tag("forages")),
     )))
     .parse(input)
 }

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -11706,6 +11706,17 @@ fn trigger_you_proliferate() {
 }
 
 #[test]
+fn trigger_you_forage() {
+    let def = parse_trigger_line(
+        "Whenever you forage, put a +1/+1 counter on this creature.",
+        "Corpseberry Cultivator",
+    );
+    assert_eq!(def.mode, TriggerMode::PlayerPerformedAction);
+    assert_eq!(def.valid_target, Some(TargetFilter::Controller));
+    assert_eq!(def.player_actions, Some(vec![PlayerActionKind::Forage]));
+}
+
+#[test]
 fn trigger_you_scry_or_surveil() {
     let def = parse_trigger_line(
         "Whenever you scry or surveil, draw a card.",

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -145,6 +145,9 @@ pub enum PlayerActionKind {
     Proliferate,
     /// CR 701.16a: A player investigated (created a Clue token).
     Investigate,
+    /// CR 701.61a: A player foraged by exiling three cards from their graveyard
+    /// or sacrificing a Food.
+    Forage,
     /// A player completed a draw instruction that delivered at least
     /// one card. Emitted once per settled draw INSTRUCTION (at draw-sequence
     /// completion), not once per card — so a multi-card draw records a single

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -17239,6 +17239,17 @@ impl GameState {
         Ok(self.take_active_ability_continuation()?.is_some())
     }
 
+    /// Clears the reveal choice's continuation while allowing an exact active
+    /// batch-delivery child to retain its own pending zone-change work.
+    pub fn clear_active_ability_continuation_or_batch_delivery_child(
+        &mut self,
+    ) -> Result<bool, ResolutionStackError> {
+        Ok(self
+            .resolution_stack
+            .take_active_ability_continuation_or_batch_delivery_child()?
+            .is_some())
+    }
+
     /// Returns the complete ChangeZone owner only when it owns the stack top.
     pub fn active_change_zone_frame(&self) -> Option<&ChangeZoneFrame> {
         self.resolution_stack.active_change_zone()
@@ -19163,11 +19174,32 @@ impl GameState {
     }
 
     pub(crate) fn current_or_begin_rules_execution_node(&mut self) -> RulesExecutionNodeRef {
-        self.active_rules_execution_node.unwrap_or_else(|| {
+        self.live_active_rules_execution_node().unwrap_or_else(|| {
             self.resolved_rules_journal
                 .begin_proposal()
                 .expect("resolved-rules journal proposal ordinal overflow")
         })
+    }
+
+    /// Returns the ambient execution node only while its provenance record is
+    /// still retained. The journal has an intentionally shorter retention
+    /// window than the transient scope, so a boundary may discard a completed
+    /// parent before a later nested mana activation observes that scope.
+    fn live_active_rules_execution_node(&mut self) -> Option<RulesExecutionNodeRef> {
+        let node = self.active_rules_execution_node?;
+        if self.rules_execution_node_is_live(node) {
+            Some(node)
+        } else {
+            self.active_rules_execution_node = None;
+            None
+        }
+    }
+
+    fn rules_execution_node_is_live(&self, node: RulesExecutionNodeRef) -> bool {
+        self.resolved_rules_journal
+            .nodes()
+            .iter()
+            .any(|candidate| candidate.identity == node)
     }
 
     /// CR 800.4: Begin the distinct execution node for one player leaving the
@@ -19192,8 +19224,9 @@ impl GameState {
             .get(&source_id)
             .map(ObjectIncarnationRef::from_object)
             .expect("mana ability activation source must exist");
+        let parent = self.live_active_rules_execution_node();
         self.resolved_rules_journal
-            .begin_activated_mana(source, self.active_rules_execution_node)
+            .begin_activated_mana(source, parent)
             .expect("resolved-rules journal settlement ordinal overflow")
     }
 
@@ -19206,12 +19239,11 @@ impl GameState {
         trigger: Option<TriggerDefinitionRef>,
         caused_by: Option<RulesExecutionNodeRef>,
     ) -> RulesExecutionNodeRef {
+        let parent = caused_by
+            .filter(|node| self.rules_execution_node_is_live(*node))
+            .or_else(|| self.live_active_rules_execution_node());
         self.resolved_rules_journal
-            .begin_triggered_mana(
-                source,
-                trigger,
-                caused_by.or(self.active_rules_execution_node),
-            )
+            .begin_triggered_mana(source, trigger, parent)
             .expect("resolved-rules journal settlement ordinal overflow")
     }
 
@@ -22564,7 +22596,7 @@ mod tests {
     };
     use crate::types::deterministic_serde::test_support::ReverseBuildHasher;
     use crate::types::identifiers::{
-        DelayedTriggerInstanceId, DelayedTriggerOrigin, DelayedTriggerToken,
+        CardId, DelayedTriggerInstanceId, DelayedTriggerOrigin, DelayedTriggerToken,
     };
     use crate::types::resolved_commands::ResolvedDelayedTriggerCommand;
 
@@ -22616,6 +22648,72 @@ mod tests {
             delivery.terminal_completion_after_resume(),
             ZoneMoveCompletion::Prevented,
             "an explicit replacement outcome remains authoritative over slice inference"
+        );
+    }
+
+    #[test]
+    fn mana_journal_ignores_a_stale_nested_parent_after_journal_reset() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Mana Source".to_string(),
+            Zone::Battlefield,
+        );
+        let source = state
+            .objects
+            .get(&source_id)
+            .map(ObjectIncarnationRef::from_object)
+            .expect("test source exists");
+
+        let mut parent = None;
+        for _ in 0..7 {
+            state.active_rules_execution_node = parent;
+            let node = state.begin_activated_mana_journal_node(source_id);
+            assert_eq!(
+                state
+                    .resolved_rules_journal
+                    .nodes()
+                    .iter()
+                    .find(|candidate| candidate.identity == node)
+                    .expect("activation node is retained")
+                    .caused_by,
+                parent,
+                "a live nested activation keeps its exact parent"
+            );
+            parent = Some(node);
+        }
+        let stale_parent = parent.expect("deep chain creates a terminal parent");
+
+        state.resolved_rules_journal = Default::default();
+        state.active_rules_execution_node = Some(stale_parent);
+        let fresh_activation = state.begin_activated_mana_journal_node(source_id);
+        assert_eq!(
+            state
+                .resolved_rules_journal
+                .nodes()
+                .iter()
+                .find(|candidate| candidate.identity == fresh_activation)
+                .expect("fresh activation node is retained")
+                .caused_by,
+            None,
+            "a journal reset must not retain a parent ordinal it no longer owns"
+        );
+
+        state.active_rules_execution_node = Some(stale_parent);
+        let fresh_trigger =
+            state.begin_triggered_mana_journal_node(source, None, Some(stale_parent));
+        assert_eq!(
+            state
+                .resolved_rules_journal
+                .nodes()
+                .iter()
+                .find(|candidate| candidate.identity == fresh_trigger)
+                .expect("fresh trigger node is retained")
+                .caused_by,
+            None,
+            "triggered mana also rejects an absent explicit or ambient parent"
         );
     }
 

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -3090,8 +3090,10 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
             count: 0,
             cost: ManaCost::default(),
         }),
-        "Gift" => Ok(Keyword::Gift(GiftKind::Card)),
-        "Discover" => Ok(Keyword::Discover(0)),
+        "Gift" => serde_json::from_value(data.clone())
+            .map(Keyword::Gift)
+            .map_err(|error| format!("GiftKind: {error}")),
+        "Discover" => Ok(Keyword::Discover(uint(data))),
         "Spree" => Ok(Keyword::Spree),
         "Ravenous" => Ok(Keyword::Ravenous),
         "Daybound" => Ok(Keyword::Daybound),
@@ -3117,19 +3119,19 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "Cumulative" => Ok(Keyword::CumulativeUpkeep(AbilityCost::Mana {
             cost: ManaCost::zero(),
         })),
-        // CR 702.24a: Legacy serialized data had `Keyword::CumulativeUpkeep`
-        // carry a raw `String` cost (e.g. "{1}"). Task 3 changed the field
-        // to a typed `AbilityCost`, but parsing the legacy string requires
-        // the Oracle parser, which doesn't live in this deserialization
-        // path. Card-data.json is regenerated from MTGJSON+Oracle text by
-        // the pipeline (`./scripts/gen-card-data.sh`), so the practical
-        // fix is to re-run that pipeline rather than recover legacy data
-        // here. The zero-cost sentinel is a well-formed placeholder until
-        // the pipeline rebuilds the typed cost.
-        "CumulativeUpkeep" => Ok(Keyword::CumulativeUpkeep(AbilityCost::Mana {
-            cost: ManaCost::zero(),
-        })),
-        "Ripple" => Ok(Keyword::Ripple(1)),
+        // CR 702.24a: Legacy snapshots stored this cost as raw Oracle text,
+        // which cannot be interpreted at this serde boundary. Current
+        // card-data and snapshots carry the typed AbilityCost and must retain
+        // it exactly.
+        "CumulativeUpkeep" => match data {
+            serde_json::Value::String(_) => Ok(Keyword::CumulativeUpkeep(AbilityCost::Mana {
+                cost: ManaCost::zero(),
+            })),
+            _ => serde_json::from_value(data.clone())
+                .map(Keyword::CumulativeUpkeep)
+                .map_err(|error| format!("CumulativeUpkeep: {error}")),
+        },
+        "Ripple" => Ok(Keyword::Ripple(uint(data))),
         "Totem" => Ok(Keyword::Totem),
         // Parameterized: ManaCost (new keywords)
         "Warp" => Ok(Keyword::Warp(mana(data)?)),
@@ -4667,6 +4669,30 @@ mod tests {
         let json = serde_json::to_string(&keywords).unwrap();
         let deserialized: Vec<Keyword> = serde_json::from_str(&json).unwrap();
         assert_eq!(keywords, deserialized);
+    }
+
+    #[test]
+    fn tagged_keyword_payloads_deserialize_without_substitution() {
+        let gift: Keyword = serde_json::from_str(r#"{"Gift":{"type":"TappedFish"}}"#)
+            .expect("Gift payload deserializes");
+        assert_eq!(gift, Keyword::Gift(GiftKind::TappedFish));
+
+        let discover: Keyword =
+            serde_json::from_str(r#"{"Discover": 7}"#).expect("Discover payload deserializes");
+        assert_eq!(discover, Keyword::Discover(7));
+
+        let ripple: Keyword =
+            serde_json::from_str(r#"{"Ripple": 4}"#).expect("Ripple payload deserializes");
+        assert_eq!(ripple, Keyword::Ripple(4));
+
+        let cumulative_upkeep: Keyword = serde_json::from_str(
+            r#"{"CumulativeUpkeep":{"type":"EffectCost","effect":{"type":"PutCounter","counter_type":"M1M1","count":{"type":"Fixed","value":1},"target":{"type":"SelfRef"}}}}"#,
+        )
+        .expect("Cumulative upkeep payload deserializes");
+        assert!(matches!(
+            cumulative_upkeep,
+            Keyword::CumulativeUpkeep(AbilityCost::EffectCost { .. })
+        ));
     }
 
     #[test]

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -712,6 +712,40 @@ impl ResolutionStack {
         }
     }
 
+    /// Consumes the active continuation, or its exact parent when a
+    /// `BatchDelivery` child currently owns the stack top. The batch remains
+    /// parked so its undelivered zone-change members settle before the enclosing
+    /// resolution advances; this fixed two-frame shape is not a general search.
+    pub fn take_active_ability_continuation_or_batch_delivery_child(
+        &mut self,
+    ) -> Result<Option<AbilityContinuationFrame>, ResolutionStackError> {
+        match self.last() {
+            Some(ResolutionFrame::AbilityContinuation(_)) | None => {
+                self.take_active_ability_continuation()
+            }
+            Some(ResolutionFrame::BatchDelivery(_)) => {
+                let Some(parent_index) = self.frames.len().checked_sub(2) else {
+                    return Ok(None);
+                };
+                if !matches!(
+                    self.frames.get(parent_index),
+                    Some(ResolutionFrame::AbilityContinuation(_))
+                ) {
+                    return Ok(None);
+                }
+                let ResolutionFrame::AbilityContinuation(frame) = self.frames.remove(parent_index)
+                else {
+                    unreachable!("checked batch parent must retain its frame kind")
+                };
+                Ok(Some(frame))
+            }
+            Some(frame) => Err(ResolutionStackError::UnexpectedTop {
+                expected: FrameKind::AbilityContinuation,
+                actual: frame.kind(),
+            }),
+        }
+    }
+
     /// Park a newly active ability continuation.
     pub fn push_ability_continuation(&mut self, frame: AbilityContinuationFrame) {
         self.push_inner(ResolutionFrame::AbilityContinuation(frame));
@@ -3956,6 +3990,63 @@ mod tests {
             pending: PendingContinuation::new(Box::new(resolved_draw(source_id)), &state),
             choose_zone_trigger_context: None,
         })
+    }
+
+    fn batch_delivery_frame(seed: u64) -> ResolutionFrame {
+        let mut state = GameState::new_two_player(seed);
+        let mut logical_zone_change_group = state.allocate_logical_zone_change_group(&[]);
+        logical_zone_change_group
+            .latch_immediately_before(Vec::new(), Vec::new())
+            .expect("empty batch group retains its pre-delivery latch");
+        ResolutionFrame::BatchDelivery(Box::new(PendingBatchDeliveries {
+            logical_zone_change_group,
+            paused_current: None,
+            remaining: Vec::new(),
+            destination: Zone::Graveyard,
+            source_id: None,
+            enter_tapped: EtbTapState::Unspecified,
+            exile_tracking: ZoneDeliveryExileTracking::None,
+            library_placement: None,
+            completion: None,
+            replacement_applied: HashSet::new(),
+            requests: Vec::new(),
+            attempted: Vec::new(),
+            zone_change_record_start: state.zone_changes_this_turn.len(),
+            deferred_events: Vec::new(),
+        }))
+    }
+
+    #[test]
+    fn take_continuation_preserves_an_active_batch_delivery_child() {
+        let mut stack = ResolutionStack::default();
+        stack.push_inner(continuation_frame(1));
+        stack.push_inner(batch_delivery_frame(1));
+
+        assert!(
+            stack
+                .take_active_ability_continuation_or_batch_delivery_child()
+                .expect("the direct batch-child relation is consumable")
+                .is_some(),
+            "the direct continuation parent is removed"
+        );
+        assert!(
+            matches!(stack.last(), Some(ResolutionFrame::BatchDelivery(_))),
+            "the unrelated active batch remains available for its delivery drain"
+        );
+
+        let mut unrelated_child = ResolutionStack::default();
+        unrelated_child.push_inner(continuation_frame(2));
+        unrelated_child.push_inner(change_zone_frame(2));
+        assert!(
+            matches!(
+                unrelated_child.take_active_ability_continuation_or_batch_delivery_child(),
+                Err(ResolutionStackError::UnexpectedTop {
+                    expected: FrameKind::AbilityContinuation,
+                    actual: FrameKind::ChangeZone,
+                })
+            ),
+            "the helper does not search through an arbitrary child frame"
+        );
     }
 
     #[test]

--- a/crates/engine/tests/integration/issue_7221_forage_trigger.rs
+++ b/crates/engine/tests/integration/issue_7221_forage_trigger.rs
@@ -1,0 +1,62 @@
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+
+const CORPSEBERRY_CULTIVATOR: &str = "At the beginning of combat on your turn, you may forage. \
+(Exile three cards from your graveyard or sacrifice a Food.)\n\
+Whenever you forage, put a +1/+1 counter on this creature.";
+
+fn p1p1(runner: &GameRunner, id: ObjectId) -> u32 {
+    runner.state().objects[&id]
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0)
+}
+
+fn resolve_until_counter(runner: &mut GameRunner, cultivator: ObjectId) {
+    for _ in 0..200 {
+        if p1p1(runner, cultivator) > 0 {
+            return;
+        }
+        match &runner.state().waiting_for {
+            WaitingFor::OptionalEffectChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("accept the forage trigger");
+            }
+            WaitingFor::EffectZoneChoice { cards, count, .. } => {
+                let cards = cards.iter().take(*count).copied().collect();
+                runner
+                    .act(GameAction::SelectCards { cards })
+                    .expect("exile three cards to forage");
+            }
+            _ => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("advance the game");
+            }
+        }
+    }
+    panic!("forage trigger did not resolve");
+}
+
+#[test]
+fn foraging_from_graveyard_triggers_corpseberry_cultivator() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let cultivator = scenario
+        .add_creature_from_oracle(P0, "Corpseberry Cultivator", 2, 3, CORPSEBERRY_CULTIVATOR)
+        .id();
+    for _ in 0..3 {
+        scenario.add_creature_to_graveyard(P0, "Fodder", 1, 1);
+    }
+
+    let mut runner = scenario.build();
+    resolve_until_counter(&mut runner, cultivator);
+
+    assert_eq!(p1p1(&runner, cultivator), 1);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -691,6 +691,7 @@ mod issue_7063_library_reorder;
 mod issue_7087_recruit_discard_provenance;
 mod issue_709_regression;
 mod issue_718_dina_sacrifice_draw;
+mod issue_7221_forage_trigger;
 mod issue_7232_expend_auto_land_payment;
 mod issue_735_amalia_power_threshold;
 mod issue_735_cost_paid_object_non_regression;


### PR DESCRIPTION
Fixes #7234.

Deserialize typed tagged keyword payloads instead of replacing `Gift`, `Discover`, `Ripple`, and current `CumulativeUpkeep` values with defaults. Legacy raw cumulative-upkeep text retains its existing placeholder behavior.