### PR TITLE
fix(engine): retain batch delivery on reveal continuation cleanup

### DIFF
--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -3707,7 +3707,7 @@ pub(super) fn handle_resolution_choice(
                         .expect("a settled reveal choice must resume its continuation");
                 } else {
                     let _ = state
-                        .clear_active_ability_continuation()
+                        .clear_active_ability_continuation_or_batch_delivery_child()
                         .expect("declined reveal cannot clear a buried continuation");
                 }
                 return Ok(ResolutionChoiceOutcome::WaitingFor(
@@ -3758,7 +3758,7 @@ pub(super) fn handle_resolution_choice(
             // on the revealed card (e.g., Thoughtseize's exile).
             if optional && decline_runs_continuation {
                 let _ = state
-                    .clear_active_ability_continuation()
+                    .clear_active_ability_continuation_or_batch_delivery_child()
                     .expect("accepted reveal cannot clear a buried continuation");
             } else if let Some(frame) = state.active_ability_continuation_frame_mut() {
                 frame.pending.chain.targets = vec![TargetRef::Object(chosen_id)];

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -17239,6 +17239,17 @@ impl GameState {
         Ok(self.take_active_ability_continuation()?.is_some())
     }
 
+    /// Clears the reveal choice's continuation while allowing an exact active
+    /// batch-delivery child to retain its own pending zone-change work.
+    pub fn clear_active_ability_continuation_or_batch_delivery_child(
+        &mut self,
+    ) -> Result<bool, ResolutionStackError> {
+        Ok(self
+            .resolution_stack
+            .take_active_ability_continuation_or_batch_delivery_child()?
+            .is_some())
+    }
+
     /// Returns the complete ChangeZone owner only when it owns the stack top.
     pub fn active_change_zone_frame(&self) -> Option<&ChangeZoneFrame> {
         self.resolution_stack.active_change_zone()

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -712,6 +712,40 @@ impl ResolutionStack {
         }
     }
 
+    /// Consumes the active continuation, or its exact parent when a
+    /// `BatchDelivery` child currently owns the stack top. The batch remains
+    /// parked so its undelivered zone-change members settle before the enclosing
+    /// resolution advances; this fixed two-frame shape is not a general search.
+    pub fn take_active_ability_continuation_or_batch_delivery_child(
+        &mut self,
+    ) -> Result<Option<AbilityContinuationFrame>, ResolutionStackError> {
+        match self.last() {
+            Some(ResolutionFrame::AbilityContinuation(_)) | None => {
+                self.take_active_ability_continuation()
+            }
+            Some(ResolutionFrame::BatchDelivery(_)) => {
+                let Some(parent_index) = self.frames.len().checked_sub(2) else {
+                    return Ok(None);
+                };
+                if !matches!(
+                    self.frames.get(parent_index),
+                    Some(ResolutionFrame::AbilityContinuation(_))
+                ) {
+                    return Ok(None);
+                }
+                let ResolutionFrame::AbilityContinuation(frame) = self.frames.remove(parent_index)
+                else {
+                    unreachable!("checked batch parent must retain its frame kind")
+                };
+                Ok(Some(frame))
+            }
+            Some(frame) => Err(ResolutionStackError::UnexpectedTop {
+                expected: FrameKind::AbilityContinuation,
+                actual: frame.kind(),
+            }),
+        }
+    }
+
     /// Park a newly active ability continuation.
     pub fn push_ability_continuation(&mut self, frame: AbilityContinuationFrame) {
         self.push_inner(ResolutionFrame::AbilityContinuation(frame));
@@ -3956,6 +3990,63 @@ mod tests {
             pending: PendingContinuation::new(Box::new(resolved_draw(source_id)), &state),
             choose_zone_trigger_context: None,
         })
+    }
+
+    fn batch_delivery_frame(seed: u64) -> ResolutionFrame {
+        let mut state = GameState::new_two_player(seed);
+        let mut logical_zone_change_group = state.allocate_logical_zone_change_group(&[]);
+        logical_zone_change_group
+            .latch_immediately_before(Vec::new(), Vec::new())
+            .expect("empty batch group retains its pre-delivery latch");
+        ResolutionFrame::BatchDelivery(Box::new(PendingBatchDeliveries {
+            logical_zone_change_group,
+            paused_current: None,
+            remaining: Vec::new(),
+            destination: Zone::Graveyard,
+            source_id: None,
+            enter_tapped: EtbTapState::Unspecified,
+            exile_tracking: ZoneDeliveryExileTracking::None,
+            library_placement: None,
+            completion: None,
+            replacement_applied: HashSet::new(),
+            requests: Vec::new(),
+            attempted: Vec::new(),
+            zone_change_record_start: state.zone_changes_this_turn.len(),
+            deferred_events: Vec::new(),
+        }))
+    }
+
+    #[test]
+    fn take_continuation_preserves_an_active_batch_delivery_child() {
+        let mut stack = ResolutionStack::default();
+        stack.push_inner(continuation_frame(1));
+        stack.push_inner(batch_delivery_frame(1));
+
+        assert!(
+            stack
+                .take_active_ability_continuation_or_batch_delivery_child()
+                .expect("the direct batch-child relation is consumable")
+                .is_some(),
+            "the direct continuation parent is removed"
+        );
+        assert!(
+            matches!(stack.last(), Some(ResolutionFrame::BatchDelivery(_))),
+            "the unrelated active batch remains available for its delivery drain"
+        );
+
+        let mut unrelated_child = ResolutionStack::default();
+        unrelated_child.push_inner(continuation_frame(2));
+        unrelated_child.push_inner(change_zone_frame(2));
+        assert!(
+            matches!(
+                unrelated_child.take_active_ability_continuation_or_batch_delivery_child(),
+                Err(ResolutionStackError::UnexpectedTop {
+                    expected: FrameKind::AbilityContinuation,
+                    actual: FrameKind::ChangeZone,
+                })
+            ),
+            "the helper does not search through an arbitrary child frame"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #7135.