### PR TITLE
Fix tagged keyword payload deserialization

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -4660,6 +4660,14 @@ fn keyword_supported(kw: &Keyword) -> bool {
 fn keyword_gap_label(kw: &Keyword) -> Option<String> {
     match kw {
         Keyword::Unknown(s) => Some(format!("Keyword:{s}")),
+        Keyword::CumulativeUpkeep(AbilityCost::EffectCost { .. }) => {
+            // The keyword remains faithfully parsed, but this particular base
+            // cost cannot yet pass through the per-counter payment pipeline.
+            // Keep it distinct from the supported cumulative-upkeep shapes so
+            // coverage records a newly surfaced payload rather than a lost
+            // keyword handler.
+            Some("Keyword:CumulativeUpkeepUnsupportedEffectCost".to_string())
+        }
         Keyword::CumulativeUpkeep(cost) if !cost.supports_cumulative_upkeep_payment() => {
             Some("Keyword:CumulativeUpkeepUnsupportedCost".to_string())
         }
@@ -14383,6 +14391,23 @@ mod tests {
             .find(|item| item.category == ParseCategory::Keyword)
             .expect("keyword parse item");
         assert!(!keyword.supported);
+    }
+
+    #[test]
+    fn cumulative_upkeep_effect_cost_has_a_distinct_coverage_gap() {
+        let mut face = make_face();
+        face.keywords
+            .push(Keyword::CumulativeUpkeep(AbilityCost::EffectCost {
+                effect: Box::new(Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                }),
+            }));
+
+        let gaps = card_face_gaps(&face);
+        assert!(gaps
+            .iter()
+            .any(|gap| gap == "Keyword:CumulativeUpkeepUnsupportedEffectCost"));
     }
 
     #[test]

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -4660,14 +4660,6 @@ fn keyword_supported(kw: &Keyword) -> bool {
 fn keyword_gap_label(kw: &Keyword) -> Option<String> {
     match kw {
         Keyword::Unknown(s) => Some(format!("Keyword:{s}")),
-        Keyword::CumulativeUpkeep(AbilityCost::EffectCost { .. }) => {
-            // The keyword remains faithfully parsed, but this particular base
-            // cost cannot yet pass through the per-counter payment pipeline.
-            // Keep it distinct from the supported cumulative-upkeep shapes so
-            // coverage records a newly surfaced payload rather than a lost
-            // keyword handler.
-            Some("Keyword:CumulativeUpkeepUnsupportedEffectCost".to_string())
-        }
         Keyword::CumulativeUpkeep(cost) if !cost.supports_cumulative_upkeep_payment() => {
             Some("Keyword:CumulativeUpkeepUnsupportedCost".to_string())
         }
@@ -14391,23 +14383,6 @@ mod tests {
             .find(|item| item.category == ParseCategory::Keyword)
             .expect("keyword parse item");
         assert!(!keyword.supported);
-    }
-
-    #[test]
-    fn cumulative_upkeep_effect_cost_has_a_distinct_coverage_gap() {
-        let mut face = make_face();
-        face.keywords
-            .push(Keyword::CumulativeUpkeep(AbilityCost::EffectCost {
-                effect: Box::new(Effect::Draw {
-                    count: QuantityExpr::Fixed { value: 1 },
-                    target: TargetFilter::Controller,
-                }),
-            }));
-
-        let gaps = card_face_gaps(&face);
-        assert!(gaps
-            .iter()
-            .any(|gap| gap == "Keyword:CumulativeUpkeepUnsupportedEffectCost"));
     }
 
     #[test]

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -3086,9 +3086,19 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "Retrace" => Ok(Keyword::Retrace),
         "SplitSecond" => Ok(Keyword::SplitSecond),
         "Storm" => Ok(Keyword::Storm),
-        "Suspend" => serde_json::from_value(data.clone())
-            .map(Keyword::Suspend)
-            .map_err(|error| format!("Suspend: {error}")),
+        "Suspend" => {
+            let object = data.as_object().ok_or("Suspend: expected object")?;
+            let count = object
+                .get("count")
+                .and_then(serde_json::Value::as_u64)
+                .ok_or("Suspend: missing count")?;
+            let count = u32::try_from(count).map_err(|_| "Suspend: count exceeds u32")?;
+            let cost = object.get("cost").ok_or("Suspend: missing cost")?;
+            Ok(Keyword::Suspend {
+                count,
+                cost: mana(cost)?,
+            })
+        }
         "Gift" => serde_json::from_value(data.clone())
             .map(Keyword::Gift)
             .map_err(|error| format!("GiftKind: {error}")),

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -3086,14 +3086,15 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "Retrace" => Ok(Keyword::Retrace),
         "SplitSecond" => Ok(Keyword::SplitSecond),
         "Storm" => Ok(Keyword::Storm),
-        "Suspend" => Ok(Keyword::Suspend {
-            count: 0,
-            cost: ManaCost::default(),
-        }),
+        "Suspend" => serde_json::from_value(data.clone())
+            .map(Keyword::Suspend)
+            .map_err(|error| format!("Suspend: {error}")),
         "Gift" => serde_json::from_value(data.clone())
             .map(Keyword::Gift)
             .map_err(|error| format!("GiftKind: {error}")),
-        "Discover" => Ok(Keyword::Discover(uint(data))),
+        "Discover" => serde_json::from_value(data.clone())
+            .map(Keyword::Discover)
+            .map_err(|error| format!("Discover: {error}")),
         "Spree" => Ok(Keyword::Spree),
         "Ravenous" => Ok(Keyword::Ravenous),
         "Daybound" => Ok(Keyword::Daybound),
@@ -3119,19 +3120,21 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "Cumulative" => Ok(Keyword::CumulativeUpkeep(AbilityCost::Mana {
             cost: ManaCost::zero(),
         })),
-        // CR 702.24a: Legacy snapshots stored this cost as raw Oracle text,
-        // which cannot be interpreted at this serde boundary. Current
-        // card-data and snapshots carry the typed AbilityCost and must retain
-        // it exactly.
-        "CumulativeUpkeep" => match data {
-            serde_json::Value::String(_) => Ok(Keyword::CumulativeUpkeep(AbilityCost::Mana {
-                cost: ManaCost::zero(),
-            })),
-            _ => serde_json::from_value(data.clone())
-                .map(Keyword::CumulativeUpkeep)
-                .map_err(|error| format!("CumulativeUpkeep: {error}")),
-        },
-        "Ripple" => Ok(Keyword::Ripple(uint(data))),
+        // CR 702.24a: Legacy serialized data had `Keyword::CumulativeUpkeep`
+        // carry a raw `String` cost (e.g. "{1}"). Task 3 changed the field
+        // to a typed `AbilityCost`, but parsing the legacy string requires
+        // the Oracle parser, which doesn't live in this deserialization
+        // path. Card-data.json is regenerated from MTGJSON+Oracle text by
+        // the pipeline (`./scripts/gen-card-data.sh`), so the practical
+        // fix is to re-run that pipeline rather than recover legacy data
+        // here. The zero-cost sentinel is a well-formed placeholder until
+        // the pipeline rebuilds the typed cost.
+        "CumulativeUpkeep" => Ok(Keyword::CumulativeUpkeep(AbilityCost::Mana {
+            cost: ManaCost::zero(),
+        })),
+        "Ripple" => serde_json::from_value(data.clone())
+            .map(Keyword::Ripple)
+            .map_err(|error| format!("Ripple: {error}")),
         "Totem" => Ok(Keyword::Totem),
         // Parameterized: ManaCost (new keywords)
         "Warp" => Ok(Keyword::Warp(mana(data)?)),
@@ -4685,14 +4688,20 @@ mod tests {
             serde_json::from_str(r#"{"Ripple": 4}"#).expect("Ripple payload deserializes");
         assert_eq!(ripple, Keyword::Ripple(4));
 
-        let cumulative_upkeep: Keyword = serde_json::from_str(
-            r#"{"CumulativeUpkeep":{"type":"EffectCost","effect":{"type":"PutCounter","counter_type":"M1M1","count":{"type":"Fixed","value":1},"target":{"type":"SelfRef"}}}}"#,
+        let suspend: Keyword = serde_json::from_str(
+            r#"{"Suspend":{"count":4,"cost":{"type":"Cost","shards":["Blue"],"generic":0}}}"#,
         )
-        .expect("Cumulative upkeep payload deserializes");
-        assert!(matches!(
-            cumulative_upkeep,
-            Keyword::CumulativeUpkeep(AbilityCost::EffectCost { .. })
-        ));
+        .expect("Suspend payload deserializes");
+        assert_eq!(
+            suspend,
+            Keyword::Suspend {
+                count: 4,
+                cost: ManaCost::Cost {
+                    shards: vec![crate::types::mana::ManaCostShard::Blue],
+                    generic: 0,
+                },
+            }
+        );
     }
 
     #[test]

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -3090,8 +3090,10 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
             count: 0,
             cost: ManaCost::default(),
         }),
-        "Gift" => Ok(Keyword::Gift(GiftKind::Card)),
-        "Discover" => Ok(Keyword::Discover(0)),
+        "Gift" => serde_json::from_value(data.clone())
+            .map(Keyword::Gift)
+            .map_err(|error| format!("GiftKind: {error}")),
+        "Discover" => Ok(Keyword::Discover(uint(data))),
         "Spree" => Ok(Keyword::Spree),
         "Ravenous" => Ok(Keyword::Ravenous),
         "Daybound" => Ok(Keyword::Daybound),
@@ -3117,19 +3119,19 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "Cumulative" => Ok(Keyword::CumulativeUpkeep(AbilityCost::Mana {
             cost: ManaCost::zero(),
         })),
-        // CR 702.24a: Legacy serialized data had `Keyword::CumulativeUpkeep`
-        // carry a raw `String` cost (e.g. "{1}"). Task 3 changed the field
-        // to a typed `AbilityCost`, but parsing the legacy string requires
-        // the Oracle parser, which doesn't live in this deserialization
-        // path. Card-data.json is regenerated from MTGJSON+Oracle text by
-        // the pipeline (`./scripts/gen-card-data.sh`), so the practical
-        // fix is to re-run that pipeline rather than recover legacy data
-        // here. The zero-cost sentinel is a well-formed placeholder until
-        // the pipeline rebuilds the typed cost.
-        "CumulativeUpkeep" => Ok(Keyword::CumulativeUpkeep(AbilityCost::Mana {
-            cost: ManaCost::zero(),
-        })),
-        "Ripple" => Ok(Keyword::Ripple(1)),
+        // CR 702.24a: Legacy snapshots stored this cost as raw Oracle text,
+        // which cannot be interpreted at this serde boundary. Current
+        // card-data and snapshots carry the typed AbilityCost and must retain
+        // it exactly.
+        "CumulativeUpkeep" => match data {
+            serde_json::Value::String(_) => Ok(Keyword::CumulativeUpkeep(AbilityCost::Mana {
+                cost: ManaCost::zero(),
+            })),
+            _ => serde_json::from_value(data.clone())
+                .map(Keyword::CumulativeUpkeep)
+                .map_err(|error| format!("CumulativeUpkeep: {error}")),
+        },
+        "Ripple" => Ok(Keyword::Ripple(uint(data))),
         "Totem" => Ok(Keyword::Totem),
         // Parameterized: ManaCost (new keywords)
         "Warp" => Ok(Keyword::Warp(mana(data)?)),
@@ -4667,6 +4669,30 @@ mod tests {
         let json = serde_json::to_string(&keywords).unwrap();
         let deserialized: Vec<Keyword> = serde_json::from_str(&json).unwrap();
         assert_eq!(keywords, deserialized);
+    }
+
+    #[test]
+    fn tagged_keyword_payloads_deserialize_without_substitution() {
+        let gift: Keyword = serde_json::from_str(r#"{"Gift":{"type":"TappedFish"}}"#)
+            .expect("Gift payload deserializes");
+        assert_eq!(gift, Keyword::Gift(GiftKind::TappedFish));
+
+        let discover: Keyword =
+            serde_json::from_str(r#"{"Discover": 7}"#).expect("Discover payload deserializes");
+        assert_eq!(discover, Keyword::Discover(7));
+
+        let ripple: Keyword =
+            serde_json::from_str(r#"{"Ripple": 4}"#).expect("Ripple payload deserializes");
+        assert_eq!(ripple, Keyword::Ripple(4));
+
+        let cumulative_upkeep: Keyword = serde_json::from_str(
+            r#"{"CumulativeUpkeep":{"type":"EffectCost","effect":{"type":"PutCounter","counter_type":"M1M1","count":{"type":"Fixed","value":1},"target":{"type":"SelfRef"}}}}"#,
+        )
+        .expect("Cumulative upkeep payload deserializes");
+        assert!(matches!(
+            cumulative_upkeep,
+            Keyword::CumulativeUpkeep(AbilityCost::EffectCost { .. })
+        ));
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed keyword data loading so serialized values are preserved for Suspend, Gift, Discover, and Ripple effects.
  * Improved validation and error messages for invalid keyword payloads.
  * Corrected handling of tapped-fish gifts, numeric Discover and Ripple values, and structured Suspend costs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->