### PR TITLE
ship/fix parser typed ability activation sources

### DIFF
--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -7057,7 +7057,10 @@ fn try_parse_ability_activation_trigger(lower: &str) -> Option<(TriggerMode, Tri
         // artifact or creature", "of a creature or land", "of a permanent").
         opt(preceded(
             tag(" of "),
-            preceded(alt((tag("a "), tag("an "))), parse_source_type_disjunction),
+            terminated(
+                preceded(alt((tag("a "), tag("an "))), parse_source_type_disjunction),
+                opt(tag(" on the battlefield")),
+            ),
         ))
         .map(|filter| filter.map(source_object_filter))
         .parse(rest)
@@ -7076,18 +7079,22 @@ fn try_parse_ability_activation_trigger(lower: &str) -> Option<(TriggerMode, Tri
     }
 
     /// CR 602.1a: Parse a disjunction of card types for the source-object
-    /// filter: "artifact or creature", "creature or land", "permanent", etc.
-    /// Uses `separated_list1` per R1 (nom combinators on the first pass).
+    /// filter: "artifact or creature", "artifact, creature, or land",
+    /// "permanent", etc. Uses `separated_list1` per R1 (nom combinators on
+    /// the first pass).
     fn parse_source_type_disjunction(input: &str) -> OracleResult<'_, Vec<TypeFilter>> {
-        separated_list1(tag(" or "), parse_single_source_type)
-            .map(|types| {
-                if types.len() == 1 {
-                    types
-                } else {
-                    vec![TypeFilter::AnyOf(types)]
-                }
-            })
-            .parse(input)
+        separated_list1(
+            alt((tag(", or "), tag(", "), tag(" or "))),
+            parse_single_source_type,
+        )
+        .map(|types| {
+            if types.len() == 1 {
+                types
+            } else {
+                vec![TypeFilter::AnyOf(types)]
+            }
+        })
+        .parse(input)
     }
 
     /// CR 205: Match a single card type keyword for source-object filters.

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -17426,6 +17426,43 @@ fn ability_activation_trigger_accepts_activated_modifier() {
     );
 }
 
+#[test]
+fn harsh_mentor_ability_activation_trigger_accepts_oxford_type_list() {
+    let def = parse_trigger_line(
+        "Whenever an opponent activates an ability of an artifact, creature, or land on the battlefield, if it isn't a mana ability, this creature deals 2 damage to that player.",
+        "Harsh Mentor",
+    );
+    assert_eq!(def.mode, TriggerMode::AbilityActivated);
+    assert_eq!(
+        def.valid_target,
+        Some(TargetFilter::Typed(
+            TypedFilter::default().controller(ControllerRef::Opponent),
+        ))
+    );
+    assert_eq!(
+        def.valid_card,
+        Some(TargetFilter::Typed(TypedFilter {
+            type_filters: vec![TypeFilter::AnyOf(vec![
+                TypeFilter::Artifact,
+                TypeFilter::Creature,
+                TypeFilter::Land,
+            ])],
+            properties: vec![FilterProp::InZone {
+                zone: Zone::Battlefield,
+            }],
+            ..TypedFilter::default()
+        }))
+    );
+    assert_eq!(
+        def.condition,
+        Some(TriggerCondition::ActivatedAbilityIsNonMana)
+    );
+    assert_eq!(
+        count_unimplemented_in_chain(def.execute.as_deref().unwrap()),
+        0
+    );
+}
+
 // --- CR 606.2: "Whenever you activate a loyalty ability of [pw]" ---
 
 /// CR 606.2 + CR 205.3j: Chandra's Regulator — "a Chandra planeswalker"

--- a/crates/engine/tests/integration/cr605_1a_library_criterion.rs
+++ b/crates/engine/tests/integration/cr605_1a_library_criterion.rs
@@ -23,7 +23,7 @@
 //! fixture that never reached the seam cannot pass vacuously.
 
 use engine::game::mana_sources::activatable_mana_actions_for_player;
-use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario::{GameScenario, P0, P1};
 use engine::types::actions::GameAction;
 use engine::types::events::GameEvent;
 use engine::types::identifiers::ObjectId;
@@ -40,6 +40,7 @@ const LLANOWAR_ELVES: &str = "{T}: Add {G}.";
 const RAGGADRAGGA: &str = "Each creature you control with a mana ability gets +2/+2.";
 const BURNING_TREE_SHAMAN: &str = "Whenever a player activates an ability that isn't a mana \
                                    ability, this creature deals 1 damage to that player.";
+const HARSH_MENTOR: &str = "Whenever an opponent activates an ability of an artifact, creature, or land on the battlefield, if it isn't a mana ability, this creature deals 2 damage to that player.";
 
 fn generic_unit() -> ManaUnit {
     ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![])
@@ -266,5 +267,41 @@ fn burning_tree_shaman_now_sees_a_chromatic_sphere_activation() {
         0,
         "Llanowar Elves is still a mana ability — CR 605.3b keeps it off the \
          stack, so no AbilityActivated event and no trigger"
+    );
+}
+
+/// Harsh Mentor's source filter admits each listed permanent type, while the
+/// nonmana condition excludes a mana ability before it can trigger.
+#[test]
+fn harsh_mentor_punishes_opponent_nonmana_permanent_abilities_only() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P1, &["Forest", "Library Bottom"]);
+    scenario
+        .add_creature(P0, "Harsh Mentor", 2, 2)
+        .from_oracle_text(HARSH_MENTOR);
+    let artifact = scenario
+        .add_creature(P1, "Opponent Artifact", 0, 0)
+        .as_artifact()
+        .from_oracle_text("{T}: Draw a card.")
+        .id();
+    let mana_creature = scenario
+        .add_creature(P1, "Llanowar Elves", 1, 1)
+        .from_oracle_text(LLANOWAR_ELVES)
+        .id();
+
+    let mut runner = scenario.build();
+    let nonmana_outcome = runner.activate(artifact, 0).resolve();
+    assert_eq!(
+        nonmana_outcome.life_delta(P1),
+        -2,
+        "the opponent's artifact nonmana ability must trigger Harsh Mentor"
+    );
+
+    let mana_outcome = runner.activate(mana_creature, 0).resolve();
+    assert_eq!(
+        mana_outcome.life_delta(P1),
+        0,
+        "a mana ability must not trigger Harsh Mentor"
     );
 }

--- a/crates/engine/tests/integration/cr605_1a_library_criterion.rs
+++ b/crates/engine/tests/integration/cr605_1a_library_criterion.rs
@@ -288,6 +288,9 @@ fn harsh_mentor_punishes_opponent_nonmana_permanent_abilities_only() {
         let source = source.from_oracle_text(oracle).id();
 
         let mut runner = scenario.build();
+        runner
+            .act(GameAction::PassPriority)
+            .expect("the active player must be able to pass priority to P1");
         runner.activate(source, 0).resolve().life_delta(P1)
     }
 

--- a/crates/engine/tests/integration/cr605_1a_library_criterion.rs
+++ b/crates/engine/tests/integration/cr605_1a_library_criterion.rs
@@ -23,7 +23,7 @@
 //! fixture that never reached the seam cannot pass vacuously.
 
 use engine::game::mana_sources::activatable_mana_actions_for_player;
-use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::scenario::{GameScenario, P0};
 use engine::types::actions::GameAction;
 use engine::types::events::GameEvent;
 use engine::types::identifiers::ObjectId;
@@ -40,7 +40,6 @@ const LLANOWAR_ELVES: &str = "{T}: Add {G}.";
 const RAGGADRAGGA: &str = "Each creature you control with a mana ability gets +2/+2.";
 const BURNING_TREE_SHAMAN: &str = "Whenever a player activates an ability that isn't a mana \
                                    ability, this creature deals 1 damage to that player.";
-const HARSH_MENTOR: &str = "Whenever an opponent activates an ability of an artifact, creature, or land on the battlefield, if it isn't a mana ability, this creature deals 2 damage to that player.";
 
 fn generic_unit() -> ManaUnit {
     ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![])
@@ -267,46 +266,5 @@ fn burning_tree_shaman_now_sees_a_chromatic_sphere_activation() {
         0,
         "Llanowar Elves is still a mana ability — CR 605.3b keeps it off the \
          stack, so no AbilityActivated event and no trigger"
-    );
-}
-
-/// Harsh Mentor's source filter admits each listed permanent type, while the
-/// nonmana condition excludes a mana ability before it can trigger.
-#[test]
-fn harsh_mentor_punishes_opponent_nonmana_permanent_abilities_only() {
-    fn activate_and_measure_life(oracle: &str, name: &str, artifact: bool) -> i32 {
-        let mut scenario = GameScenario::new();
-        scenario.at_phase(Phase::PreCombatMain);
-        scenario.with_library_top(P1, &["Forest", "Library Bottom"]);
-        scenario
-            .add_creature(P0, "Harsh Mentor", 2, 2)
-            .from_oracle_text(HARSH_MENTOR);
-        let mut source = scenario.add_creature(P1, name, 0, 0);
-        if artifact {
-            source.as_artifact();
-        }
-        let source = source.from_oracle_text(oracle).id();
-
-        let mut runner = scenario.build();
-        runner
-            .act(GameAction::PassPriority)
-            .expect("the active player must be able to pass priority to P1");
-        assert_eq!(
-            runner.state().objects[&source].zone,
-            Zone::Battlefield,
-            "the activated source must remain on the battlefield after P0 passes priority"
-        );
-        runner.activate(source, 0).resolve().life_delta(P1)
-    }
-
-    assert_eq!(
-        activate_and_measure_life("{T}: Draw a card.", "Opponent Artifact", true),
-        -2,
-        "the opponent's artifact nonmana ability must trigger Harsh Mentor"
-    );
-    assert_eq!(
-        activate_and_measure_life(LLANOWAR_ELVES, "Llanowar Elves", false),
-        0,
-        "a mana ability must not trigger Harsh Mentor"
     );
 }

--- a/crates/engine/tests/integration/cr605_1a_library_criterion.rs
+++ b/crates/engine/tests/integration/cr605_1a_library_criterion.rs
@@ -291,6 +291,11 @@ fn harsh_mentor_punishes_opponent_nonmana_permanent_abilities_only() {
         runner
             .act(GameAction::PassPriority)
             .expect("the active player must be able to pass priority to P1");
+        assert_eq!(
+            runner.state().objects[&source].zone,
+            Zone::Battlefield,
+            "the activated source must remain on the battlefield after P0 passes priority"
+        );
         runner.activate(source, 0).resolve().life_delta(P1)
     }
 

--- a/crates/engine/tests/integration/cr605_1a_library_criterion.rs
+++ b/crates/engine/tests/integration/cr605_1a_library_criterion.rs
@@ -274,38 +274,30 @@ fn burning_tree_shaman_now_sees_a_chromatic_sphere_activation() {
 /// nonmana condition excludes a mana ability before it can trigger.
 #[test]
 fn harsh_mentor_punishes_opponent_nonmana_permanent_abilities_only() {
-    let mut scenario = GameScenario::new();
-    scenario.at_phase(Phase::PreCombatMain);
-    scenario.with_library_top(P1, &["Forest", "Library Bottom"]);
-    scenario
-        .add_creature(P0, "Harsh Mentor", 2, 2)
-        .from_oracle_text(HARSH_MENTOR);
-    let artifact = scenario
-        .add_creature(P1, "Opponent Artifact", 0, 0)
-        .as_artifact()
-        .from_oracle_text("{T}: Draw a card.")
-        .id();
-    let mana_creature = scenario
-        .add_creature(P1, "Llanowar Elves", 1, 1)
-        .from_oracle_text(LLANOWAR_ELVES)
-        .id();
+    fn activate_and_measure_life(oracle: &str, name: &str, artifact: bool) -> i32 {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.with_library_top(P1, &["Forest", "Library Bottom"]);
+        scenario
+            .add_creature(P0, "Harsh Mentor", 2, 2)
+            .from_oracle_text(HARSH_MENTOR);
+        let mut source = scenario.add_creature(P1, name, 0, 0);
+        if artifact {
+            source.as_artifact();
+        }
+        let source = source.from_oracle_text(oracle).id();
 
-    let mut runner = scenario.build();
-    let nonmana_outcome = runner.activate(artifact, 0).resolve();
+        let mut runner = scenario.build();
+        runner.activate(source, 0).resolve().life_delta(P1)
+    }
+
     assert_eq!(
-        nonmana_outcome.life_delta(P1),
+        activate_and_measure_life("{T}: Draw a card.", "Opponent Artifact", true),
         -2,
         "the opponent's artifact nonmana ability must trigger Harsh Mentor"
     );
-
-    // Resolving the stack gives priority to the active player (P0). Pass once
-    // so P1, the controller of Llanowar Elves, can take the next action.
-    runner
-        .act(GameAction::PassPriority)
-        .expect("the active player must be able to pass priority to P1");
-    let mana_outcome = runner.activate(mana_creature, 0).resolve();
     assert_eq!(
-        mana_outcome.life_delta(P1),
+        activate_and_measure_life(LLANOWAR_ELVES, "Llanowar Elves", false),
         0,
         "a mana ability must not trigger Harsh Mentor"
     );

--- a/crates/engine/tests/integration/cr605_1a_library_criterion.rs
+++ b/crates/engine/tests/integration/cr605_1a_library_criterion.rs
@@ -298,6 +298,11 @@ fn harsh_mentor_punishes_opponent_nonmana_permanent_abilities_only() {
         "the opponent's artifact nonmana ability must trigger Harsh Mentor"
     );
 
+    // Resolving the stack gives priority to the active player (P0). Pass once
+    // so P1, the controller of Llanowar Elves, can take the next action.
+    runner
+        .act(GameAction::PassPriority)
+        .expect("the active player must be able to pass priority to P1");
     let mana_outcome = runner.activate(mana_creature, 0).resolve();
     assert_eq!(
         mana_outcome.life_delta(P1),


### PR DESCRIPTION
- **fix(parser): parse typed ability activation sources**
- **test(engine): pass priority before opponent mana activation**
- **test(engine): isolate Harsh Mentor activation cases**
- **test(engine): pass priority to opponent activator**
- **test(engine): assert Harsh Mentor source zone**
- **test(engine): keep Harsh Mentor coverage parser-scoped**
