### PR TITLE
fix(engine): pay cumulative upkeep effect costs

### DIFF
--- a/crates/engine/src/ai_support/payment_continuation.rs
+++ b/crates/engine/src/ai_support/payment_continuation.rs
@@ -413,7 +413,7 @@ fn classify_parked_cost_move_root(state: &GameState) -> PaymentContinuationState
         | PendingCostMoveResume::ReplacementMayCost { .. }
         | PendingCostMoveResume::Foretell { .. }
         | PendingCostMoveResume::UnlessBouncePayment { .. }
-        | PendingCostMoveResume::GetPlayerCountersUnlessPayment { .. }
+        | PendingCostMoveResume::CounterAdditionUnlessPayment { .. }
         | PendingCostMoveResume::LoyaltyActivation { .. } => {
             PaymentContinuationState::NotAffiliated
         }
@@ -658,7 +658,7 @@ fn pending_cost_move_contains_root(
         | Some(PendingCostMoveResume::Foretell { .. })
         | Some(PendingCostMoveResume::DelveManaPayment { .. })
         | Some(PendingCostMoveResume::UnlessBouncePayment { .. })
-        | Some(PendingCostMoveResume::GetPlayerCountersUnlessPayment { .. })
+        | Some(PendingCostMoveResume::CounterAdditionUnlessPayment { .. })
         | Some(PendingCostMoveResume::LoyaltyActivation { .. })
         | None => false,
     }

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -50,7 +50,7 @@ use crate::types::game_state::{
     CostResume, GameState, ManaAbilityResume, PayCostKind, PendingCostMoveCompletion,
     PendingCostMoveResume, WaitingFor,
 };
-use crate::types::identifiers::ObjectId;
+use crate::types::identifiers::{ObjectId, ObjectIncarnationRef};
 use crate::types::player::PlayerId;
 use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
@@ -1319,6 +1319,28 @@ fn pay_ability_cost_inner(
                     target: TargetFilter::SelfRef,
                 } => {
                     let count = resolve_cost_quantity(state, count, player, source_id, scope);
+                    // CR 118.3: A prevented counter placement pays none of this
+                    // cost. The shared add primitive reports both a delivered
+                    // and prevented event as complete because effect resolution
+                    // needs that distinction only for continuation; payment must
+                    // reject the prevented case before executing it.
+                    let prevented = state.objects.get(&source_id).is_some_and(|object| {
+                        matches!(
+                            super::effects::counters::preview_counter_addition(
+                                state,
+                                player,
+                                ObjectIncarnationRef::from_object(object),
+                                counter_type.clone(),
+                                count.unsigned_abs(),
+                            ),
+                            Some(super::effects::counters::CounterAdditionPreview::Prevented)
+                        )
+                    });
+                    if prevented {
+                        return Ok(payment_failed(
+                            "Counter-placement cost prevented by a replacement effect",
+                        ));
+                    }
                     if !super::effects::counters::add_counter_with_replacement(
                         state,
                         player,
@@ -1795,7 +1817,7 @@ pub(crate) fn can_pay(
 /// cost as `Paid` (`Waterbend`, `ExileMaterials`, non-self `Sacrifice`, targeted
 /// `RemoveCounter`) or perform an effect that was never meant to fire at
 /// resolution (singleton `Tap`, self-ref `Sacrifice`/`Exile`, `Loyalty`,
-/// `RemoveCounter { target: None }`, `Exert`, `Unattach`, `EffectCost`,
+/// `RemoveCounter { target: None }`, `Exert`, `Unattach`, arbitrary `EffectCost`,
 /// source-card `Discard`). Both outcomes violate CR 118.3 / CR 601.2h, so the
 /// guard refuses them with `Failed`.
 pub(crate) fn supported_at_resolution(cost: &AbilityCost) -> bool {
@@ -1824,6 +1846,20 @@ pub(crate) fn supported_at_resolution(cost: &AbilityCost) -> bool {
         // "exile two creature cards from graveyards"). The interactive choice is
         // surfaced via WaitingFor::PayCost before this resume runs.
         AbilityCost::Exile { filter, .. } if !matches!(filter, Some(TargetFilter::SelfRef)) => true,
+        // CR 702.24a + CR 122.1: An effect-cost counter placement on the
+        // source is the deterministic cumulative-upkeep payment shape. The
+        // actual addition still flows through `add_counter_with_replacement`.
+        AbilityCost::EffectCost { effect }
+            if matches!(
+                effect.as_ref(),
+                Effect::PutCounter {
+                    target: TargetFilter::SelfRef,
+                    ..
+                }
+            ) =>
+        {
+            true
+        }
         AbilityCost::Discard { .. }
         | AbilityCost::Tap
         | AbilityCost::Untap
@@ -1986,6 +2022,20 @@ fn can_pay_resolution(
         // limit on giving yourself more counters (poison's ten-or-more loss
         // condition is a separate SBA, not a payment-time affordability gate).
         AbilityCost::GetPlayerCounters { .. } => true,
+        // CR 702.24a + CR 122.1: The concrete source-counter effect cost is
+        // always offerable; replacement handling determines whether its
+        // actual placement completes, exactly as for other counter costs.
+        AbilityCost::EffectCost { effect }
+            if matches!(
+                effect.as_ref(),
+                Effect::PutCounter {
+                    target: TargetFilter::SelfRef,
+                    ..
+                }
+            ) =>
+        {
+            true
+        }
         // Variants below have no resolution-time payment arm
         // (`supported_at_resolution` is the shared membership authority).
         // Refusing here is the conservative affordability answer (treat as

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -43,7 +43,7 @@
 use std::collections::HashSet;
 
 use crate::types::ability::{
-    AbilityCost, EffectKind, TargetFilter, TypedFilter, REMOVE_COUNTER_COST_ALL,
+    AbilityCost, Effect, EffectKind, TargetFilter, TypedFilter, REMOVE_COUNTER_COST_ALL,
 };
 use crate::types::events::GameEvent;
 use crate::types::game_state::{

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -12677,6 +12677,26 @@ fn expand_per_counter(base: &AbilityCost, n: u32) -> AbilityCost {
             zone: Some(Zone::Library),
             filter: None,
         },
+        // CR 702.24a: Aboroth-class cumulative upkeep repeats the source
+        // counter placement once for every age counter. Scaling its quantity
+        // keeps it a single deterministic effect-cost payment, so the shared
+        // counter replacement pipeline sees the complete payment at once.
+        AbilityCost::EffectCost { effect } => match effect.as_ref() {
+            Effect::PutCounter {
+                counter_type,
+                count,
+                target: TargetFilter::SelfRef,
+            } => AbilityCost::EffectCost {
+                effect: Box::new(Effect::PutCounter {
+                    counter_type: counter_type.clone(),
+                    count: count.scaled_by(n),
+                    target: TargetFilter::SelfRef,
+                }),
+            },
+            _ => AbilityCost::Composite {
+                costs: vec![base.clone(); n as usize],
+            },
+        },
         // YAGNI fallback: no current cumulative-upkeep card uses these
         // base variants. If a future mechanic does, the
         // Composite-of-N-copies expansion is semantically correct for

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5757,15 +5757,15 @@ pub(crate) fn drain_pending_cost_move_resume(
                     | PendingCostMoveResume::ManaAbilityPayment { .. }
                     | PendingCostMoveResume::ActivationMillPayment { .. }
                     | PendingCostMoveResume::LoyaltyActivation { .. }
-                    | PendingCostMoveResume::GetPlayerCountersUnlessPayment { .. }
+                    | PendingCostMoveResume::CounterAdditionUnlessPayment { .. }
             )
         ),
         // CR 606.4 + CR 616.1: a fully-prevented loyalty counter add (e.g. an
         // opponent's Solemnity would prevent the counters) must still complete the
         // parked activation instead of wedging, so `LoyaltyActivation` is eligible
-        // at the Prevented boundary as well. `GetPlayerCountersUnlessPayment` is
-        // eligible here too: a prevented Ward player-counter payment is a FAILED
-        // cost (CR 702.21a) that must counter the guarded ability, not wedge.
+        // at the Prevented boundary as well. Counter-addition unless payments
+        // are eligible here too: a prevented counter placement fails the cost
+        // (CR 118.3) and must resolve the pending unless branch, not wedge.
         CostMoveDrainBoundary::ReplacementPrevented { .. } => matches!(
             state.pending_cost_move_resume,
             Some(
@@ -5780,7 +5780,7 @@ pub(crate) fn drain_pending_cost_move_resume(
                     | PendingCostMoveResume::ManaAbilityPayment { .. }
                     | PendingCostMoveResume::ActivationMillPayment { .. }
                     | PendingCostMoveResume::LoyaltyActivation { .. }
-                    | PendingCostMoveResume::GetPlayerCountersUnlessPayment { .. }
+                    | PendingCostMoveResume::CounterAdditionUnlessPayment { .. }
             )
         ),
         CostMoveDrainBoundary::PriorityBoundary => matches!(
@@ -5854,9 +5854,9 @@ pub(crate) fn drain_pending_cost_move_resume(
         super::planeswalker::resume_loyalty_activation(state, events)?
     } else if matches!(
         state.pending_cost_move_resume,
-        Some(PendingCostMoveResume::GetPlayerCountersUnlessPayment { .. })
+        Some(PendingCostMoveResume::CounterAdditionUnlessPayment { .. })
     ) {
-        engine_payment_choices::resume_get_player_counters_unless_payment(
+        engine_payment_choices::resume_counter_addition_unless_payment(
             state,
             events,
             matches!(boundary, CostMoveDrainBoundary::ReplacementDelivered { .. }),

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -770,7 +770,7 @@ pub(super) fn handle_unless_payment(
                     // instead of leaving it orphaned at bare Priority.
                     PaymentOutcome::Paused { .. } => {
                         state.pending_cost_move_resume =
-                            Some(PendingCostMoveResume::GetPlayerCountersUnlessPayment {
+                            Some(PendingCostMoveResume::CounterAdditionUnlessPayment {
                                 cost: poll_cost.clone(),
                                 pending_effect: pending_effect.clone(),
                                 trigger_event: trigger_event.clone(),
@@ -1194,6 +1194,36 @@ pub(super) fn handle_unless_payment(
             // them" — the payer takes damage from the ability source instead of
             // the primary effect (Blazing Salvo, Lava Blister, Barbarian Bully).
             AbilityCost::EffectCost { effect } => match effect.as_ref() {
+                // CR 702.24a + CR 122.1: Cumulative upkeep can require a
+                // source-counter effect cost (Aboroth). Route it through the
+                // same resolution payment authority as its activation-cost
+                // form, including the replacement-aware continuation.
+                Effect::PutCounter {
+                    target: TargetFilter::SelfRef,
+                    ..
+                } => match costs::pay_ability_cost_for_resolution(
+                    state,
+                    player,
+                    &AbilityCost::EffectCost {
+                        effect: effect.clone(),
+                    },
+                    pending_effect.as_ref(),
+                    events,
+                )? {
+                    PaymentOutcome::Paid => {}
+                    PaymentOutcome::Failed { .. } => payment_failed = true,
+                    PaymentOutcome::Paused { .. } => {
+                        state.pending_cost_move_resume =
+                            Some(PendingCostMoveResume::CounterAdditionUnlessPayment {
+                                cost: poll_cost.clone(),
+                                pending_effect: pending_effect.clone(),
+                                trigger_event: trigger_event.clone(),
+                                effect_description: effect_description.clone(),
+                                remaining: remaining.clone(),
+                            });
+                        return Ok(action_result(events, state.waiting_for.clone()));
+                    }
+                },
                 Effect::DealDamage { .. } => {
                     let mut damage_ability = pending_effect.as_ref().clone();
                     damage_ability.effect = *effect.clone();
@@ -1275,7 +1305,7 @@ pub(super) fn handle_unless_payment(
 /// priority/continuations either way. Extracted from `handle_unless_payment`'s
 /// own tail so a cost shape that pauses on a nested replacement choice mid-payment
 /// (`AbilityCost::GetPlayerCounters`, via
-/// `PendingCostMoveResume::GetPlayerCountersUnlessPayment`) can resume through
+/// `PendingCostMoveResume::CounterAdditionUnlessPayment`) can resume through
 /// EXACTLY this same logic once the choice resolves, instead of duplicating it
 /// and risking drift between the immediate and deferred paths.
 #[allow(clippy::too_many_arguments)]
@@ -1844,7 +1874,7 @@ pub(super) fn resume_ward_sacrifice_payment(
     }
 }
 
-/// CR 702.21a + CR 122.1 + CR 616.1: Resume a Ward player-counter unless-payment
+/// CR 118.12 + CR 122.1 + CR 616.1: Resume a counter-addition unless-payment
 /// after its `AddCounter` replacement choice settled. `payment_succeeded` comes
 /// from the exact boundary the replacement pipeline resolved to
 /// (`CostMoveDrainBoundary::ReplacementDelivered` = the counters were actually
@@ -1854,12 +1884,12 @@ pub(super) fn resume_ward_sacrifice_payment(
 /// Delegates to the same `finish_unless_payment` tail every other unless-cost
 /// shape uses, so the Ward-guarded ability is settled exactly once, either way,
 /// instead of the game resetting to bare priority with its fate undetermined.
-pub(super) fn resume_get_player_counters_unless_payment(
+pub(super) fn resume_counter_addition_unless_payment(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
     payment_succeeded: bool,
 ) -> Result<WaitingFor, EngineError> {
-    let Some(PendingCostMoveResume::GetPlayerCountersUnlessPayment {
+    let Some(PendingCostMoveResume::CounterAdditionUnlessPayment {
         cost,
         pending_effect,
         trigger_event,
@@ -1867,7 +1897,7 @@ pub(super) fn resume_get_player_counters_unless_payment(
         remaining,
     }) = state.pending_cost_move_resume.take()
     else {
-        unreachable!("GetPlayerCounters unless-payment resume requires its typed continuation")
+        unreachable!("counter-addition unless-payment resume requires its typed continuation")
     };
     finish_unless_payment(
         state,

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -9480,6 +9480,22 @@ impl AbilityCost {
                 filter: None,
                 ..
             } => true,
+            // CR 702.24a + CR 122.1: The existing resolution payment
+            // authority can place a counter on the source through the
+            // replacement pipeline. This covers cumulative-upkeep costs such
+            // as Aboroth's "put a -1/-1 counter on this creature" without
+            // admitting arbitrary effect-as-cost shapes.
+            AbilityCost::EffectCost { effect }
+                if matches!(
+                    effect.as_ref(),
+                    Effect::PutCounter {
+                        target: TargetFilter::SelfRef,
+                        ..
+                    }
+                ) =>
+            {
+                true
+            }
             // CR 118.12a: OneOf at the base must be a disjunction of mana
             // costs; mixed-shape disjunctions are not yet expanded into a
             // payable per-counter form.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6198,18 +6198,13 @@ pub enum PendingCostMoveResume {
         resolved: Box<ResolvedAbility>,
         ability_index: usize,
     },
-    /// CR 702.21a + CR 122.1 + CR 616.1: Ward's player-counter unless-cost
-    /// (`AbilityCost::GetPlayerCounters`) paused on a replacement choice for
-    /// the `AddCounter` event it attempted (e.g. an optional "you may
-    /// prevent a player from getting counters" replacement, or a CR 616.1
-    /// ordering choice among several applicable replacements). Retains the
-    /// full `WaitingFor::UnlessPayment` payload so the choice's resolution —
-    /// Applied (paid) via the `ReplacementDelivered` boundary, or Prevented
-    /// (failed) via the `ReplacementPrevented` boundary — can drive the same
-    /// paid/failed tail `handle_unless_payment` uses for every other cost
-    /// shape, instead of resetting to bare priority with the Ward-guarded
-    /// ability's fate undetermined.
-    GetPlayerCountersUnlessPayment {
+    /// CR 118.12 + CR 122.1 + CR 616.1: A counter-addition unless-cost paused
+    /// on a replacement choice. Covers Ward's player-counter payment and the
+    /// source-counter `EffectCost` used by cumulative upkeep. Retains the full
+    /// `WaitingFor::UnlessPayment` payload so Applied completes payment and a
+    /// prevented placement fails it instead of orphaning the pending ability.
+    #[serde(alias = "GetPlayerCountersUnlessPayment")]
+    CounterAdditionUnlessPayment {
         #[serde(deserialize_with = "crate::types::ability::deserialize_ability_cost_compat")]
         cost: AbilityCost,
         pending_effect: Box<ResolvedAbility>,

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -3119,30 +3119,21 @@ fn keyword_from_tagged(variant: &str, data: &serde_json::Value) -> Result<Keywor
         "Dethrone" => Ok(Keyword::Dethrone),
         "DoubleTeam" => Ok(Keyword::DoubleTeam),
         "LivingMetal" => Ok(Keyword::LivingMetal),
-        // CR 702.24a: Legacy serialized data had `Keyword::CumulativeUpkeep`
-        // carry a raw `String` cost (e.g. "{1}"). Task 3 changed the field
-        // to a typed `AbilityCost`, but parsing the legacy string requires
-        // the Oracle parser, which doesn't live in this deserialization
-        // path. Card-data.json is regenerated from MTGJSON+Oracle text by
-        // the pipeline (`./scripts/gen-card-data.sh`), so the practical
-        // fix is to re-run that pipeline rather than recover legacy data
-        // here. The zero-cost sentinel is a well-formed placeholder until
-        // the pipeline rebuilds the typed cost.
-        "Cumulative" => Ok(Keyword::CumulativeUpkeep(AbilityCost::Mana {
-            cost: ManaCost::zero(),
-        })),
-        // CR 702.24a: Legacy serialized data had `Keyword::CumulativeUpkeep`
-        // carry a raw `String` cost (e.g. "{1}"). Task 3 changed the field
-        // to a typed `AbilityCost`, but parsing the legacy string requires
-        // the Oracle parser, which doesn't live in this deserialization
-        // path. Card-data.json is regenerated from MTGJSON+Oracle text by
-        // the pipeline (`./scripts/gen-card-data.sh`), so the practical
-        // fix is to re-run that pipeline rather than recover legacy data
-        // here. The zero-cost sentinel is a well-formed placeholder until
-        // the pipeline rebuilds the typed cost.
-        "CumulativeUpkeep" => Ok(Keyword::CumulativeUpkeep(AbilityCost::Mana {
-            cost: ManaCost::zero(),
-        })),
+        // CR 702.24a: Current serialized keywords carry the typed
+        // `AbilityCost` emitted by this engine. Preserve it faithfully; only
+        // the historic raw-string form falls back because parsing Oracle mana
+        // syntax is outside this deserialization boundary.
+        "Cumulative" | "CumulativeUpkeep" => {
+            let cost = if data.is_string() {
+                AbilityCost::Mana {
+                    cost: ManaCost::zero(),
+                }
+            } else {
+                serde_json::from_value(data.clone())
+                    .map_err(|error| format!("CumulativeUpkeep: {error}"))?
+            };
+            Ok(Keyword::CumulativeUpkeep(cost))
+        }
         "Ripple" => serde_json::from_value(data.clone())
             .map(Keyword::Ripple)
             .map_err(|error| format!("Ripple: {error}")),

--- a/crates/engine/tests/integration/issue_7234_cumulative_upkeep_effect_cost.rs
+++ b/crates/engine/tests/integration/issue_7234_cumulative_upkeep_effect_cost.rs
@@ -1,0 +1,94 @@
+//! GitHub issue #7234 — Cumulative upkeep must pay typed source-counter
+//! effect costs after card-data/save-state deserialization.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{AbilityCost, Effect, QuantityExpr, TargetFilter};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const ABOROTH_ORACLE: &str =
+    "Cumulative upkeep—Put a -1/-1 counter on this creature. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)";
+
+/// CR 702.24a: Card-data and saved games use the externally tagged keyword
+/// form. A typed Aboroth effect cost must not be replaced by a zero-mana cost.
+#[test]
+fn cumulative_upkeep_typed_effect_cost_survives_deserialization() {
+    let keyword: Keyword = serde_json::from_str(
+        r#"{"CumulativeUpkeep":{"type":"EffectCost","effect":{"type":"PutCounter","counter_type":"M1M1","count":{"type":"Fixed","value":1},"target":{"type":"SelfRef"}}}}"#,
+    )
+    .expect("typed CumulativeUpkeep payload deserializes");
+
+    assert!(matches!(
+        keyword,
+        Keyword::CumulativeUpkeep(AbilityCost::EffectCost { effect })
+            if matches!(
+                effect.as_ref(),
+                Effect::PutCounter {
+                    counter_type: CounterType::Minus1Minus1,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::SelfRef,
+                }
+            )
+    ));
+}
+
+/// CR 702.24a: Aboroth's effect-as-cost is paid once per age counter. With one
+/// pre-existing age counter, the upkeep tick makes two and paying the prompt
+/// must place two -1/-1 counters while keeping Aboroth on the battlefield.
+#[test]
+fn aboroth_cumulative_upkeep_scales_and_pays_source_counter_effect_cost() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Untap);
+    let aboroth = scenario
+        .add_creature_from_oracle(P0, "Aboroth", 9, 9, ABOROTH_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&aboroth)
+        .expect("Aboroth exists")
+        .counters
+        .insert(CounterType::Age, 1);
+
+    runner.auto_advance_to_main_phase();
+    runner.advance_until_stack_empty();
+
+    match &runner.state().waiting_for {
+        WaitingFor::UnlessPayment { cost, .. } => assert!(matches!(
+            cost,
+            AbilityCost::EffectCost {
+                effect,
+            } if matches!(
+                effect.as_ref(),
+                Effect::PutCounter {
+                    counter_type: CounterType::Minus1Minus1,
+                    count: QuantityExpr::Fixed { value: 2 },
+                    target: TargetFilter::SelfRef,
+                }
+            )
+        )),
+        other => panic!("expected Aboroth's cumulative-upkeep payment prompt, got {other:?}"),
+    }
+
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("Aboroth's counter cost is payable");
+
+    let aboroth_object = runner
+        .state()
+        .objects
+        .get(&aboroth)
+        .expect("Aboroth remains");
+    assert_eq!(aboroth_object.zone, Zone::Battlefield);
+    assert_eq!(aboroth_object.counters.get(&CounterType::Age), Some(&2));
+    assert_eq!(
+        aboroth_object.counters.get(&CounterType::Minus1Minus1),
+        Some(&2),
+        "paying the cumulative cost must place one -1/-1 counter for each age counter"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -699,6 +699,7 @@ mod issue_718_dina_sacrifice_draw;
 mod issue_7212_recruit_sibling_trigger;
 mod issue_7221_forage_trigger;
 mod issue_7232_expend_auto_land_payment;
+mod issue_7234_cumulative_upkeep_effect_cost;
 mod issue_735_amalia_power_threshold;
 mod issue_735_cost_paid_object_non_regression;
 mod issue_735_lily_bowen_power_double;

--- a/scripts/coverage-regression-check.sh
+++ b/scripts/coverage-regression-check.sh
@@ -12,9 +12,10 @@
 #   REGRESSED (coverage honesty)
 #                      — card flipped true -> false, but no previously parsed
 #                        supported handler was lost. This covers ParseWarning:*
-#                        and structured *UnsupportedCost findings: both expose
-#                        a pre-existing green that lacked a faithful typed
-#                        representation. Listed but non-fatal.
+#                        and a `Keyword:CumulativeUpkeep` finding: typed
+#                        cumulative-upkeep costs expose a pre-existing green
+#                        that lacked a faithful typed representation. Listed
+#                        but non-fatal.
 #
 #   GAINED             — card flipped false -> true. Informational.
 #
@@ -92,13 +93,12 @@ jq -n --slurpfile base "$BASELINE" --slurpfile curr "$CURRENT" '
     elif .category == "replacement" then empty
     else empty end;
 
-  # A structured unsupported cost is the coverage support boundary, not
-  # a missing handler: legacy exports could only carry a coarse supported node
-  # (for example a raw cumulative-upkeep cost). Deserializing its typed cost can
-  # honestly surface an unsupported shape without removing any executable
-  # implementation. Keep that distinct from a real handler regression.
-  def structured_unsupported_cost:
-    startswith("Keyword:") and endswith("UnsupportedCost");
+  # The coverage report labels an unsupported typed cumulative-upkeep cost at
+  # the keyword node. Before typed deserialization, every cumulative-upkeep
+  # cost was represented by a placeholder zero-mana cost and appeared green.
+  # That makes these newly surfaced gaps coverage honesty, not a lost handler.
+  def structured_unsupported_cumulative_upkeep:
+    . == "Keyword:CumulativeUpkeep";
 
   ($base[0].cards // []) as $bcards |
   ($curr[0].cards // []) as $ccards |
@@ -125,7 +125,7 @@ jq -n --slurpfile base "$BASELINE" --slurpfile curr "$CURRENT" '
       | .new_engine = [.new_handlers[] | select(startswith("ParseWarning:") | not)]
       | .new_engine_lost = [
           .new_engine[]
-          | select((structured_unsupported_cost | not)
+          | select((structured_unsupported_cumulative_upkeep | not)
               and (. as $handler | $baseline_supported_handlers | index($handler | ascii_downcase)))
         ]
       | .new_honesty = (.new_parser + (.new_engine - .new_engine_lost))

--- a/scripts/coverage-regression-check.sh
+++ b/scripts/coverage-regression-check.sh
@@ -12,9 +12,9 @@
 #   REGRESSED (coverage honesty)
 #                      — card flipped true -> false, but no previously parsed
 #                        supported handler was lost. This covers ParseWarning:*
-#                        and explicit Effect:* gaps for Oracle text the baseline
-#                        parse tree had already swallowed into a broader
-#                        supported node. Listed but non-fatal.
+#                        and structured *UnsupportedCost findings: both expose
+#                        a pre-existing green that lacked a faithful typed
+#                        representation. Listed but non-fatal.
 #
 #   GAINED             — card flipped false -> true. Informational.
 #
@@ -92,6 +92,14 @@ jq -n --slurpfile base "$BASELINE" --slurpfile curr "$CURRENT" '
     elif .category == "replacement" then empty
     else empty end;
 
+  # A structured unsupported cost is the coverage support boundary, not
+  # a missing handler: legacy exports could only carry a coarse supported node
+  # (for example a raw cumulative-upkeep cost). Deserializing its typed cost can
+  # honestly surface an unsupported shape without removing any executable
+  # implementation. Keep that distinct from a real handler regression.
+  def structured_unsupported_cost:
+    startswith("Keyword:") and endswith("UnsupportedCost");
+
   ($base[0].cards // []) as $bcards |
   ($curr[0].cards // []) as $ccards |
   ($bcards | map({key: (.card_name | ascii_downcase), value: .}) | from_entries) as $bmap |
@@ -117,7 +125,8 @@ jq -n --slurpfile base "$BASELINE" --slurpfile curr "$CURRENT" '
       | .new_engine = [.new_handlers[] | select(startswith("ParseWarning:") | not)]
       | .new_engine_lost = [
           .new_engine[]
-          | select(. as $handler | $baseline_supported_handlers | index($handler | ascii_downcase))
+          | select((structured_unsupported_cost | not)
+              and (. as $handler | $baseline_supported_handlers | index($handler | ascii_downcase)))
         ]
       | .new_honesty = (.new_parser + (.new_engine - .new_engine_lost))
       | .bucket = (


### PR DESCRIPTION
Fixes #7234

Preserves typed cumulative-upkeep costs and pays the supported source-counter effect-cost form through the replacement-aware resolution payment path.