### PR TITLE
Fix Pyrogoyf attack target restore

### DIFF
--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -1962,6 +1962,9 @@ fn decode_and_rehydrate_restored_game_state(
 ) -> Result<DecodedRestoredGameState, String> {
     let mut restored = decode_restored_game_state(json_str)?;
     rehydrate_restored_state_from_card_db(&mut restored.state)?;
+    // Combat declaration snapshots are display data derived from the rehydrated
+    // live board. Rebuild them before this external state becomes interactive.
+    engine::game::combat::refresh_combat_declaration_waiting_for(&mut restored.state);
     Ok(restored)
 }
 
@@ -2132,6 +2135,151 @@ mod restored_card_db_requirements_tests {
         assert!(error.contains("card database"));
         assert!(GAME_STATE.with(|cell| cell.replace(None).is_none()));
         assert!(!is_multiplayer_mode());
+    }
+}
+
+#[cfg(test)]
+mod combat_prompt_restore_tests {
+    use super::*;
+    use std::collections::HashSet;
+
+    use engine::game::combat::{build_declare_attackers_waiting_for, AttackTarget};
+    use engine::game::scenario::{GameScenario, P0, P1};
+    use engine::types::game_state::WaitingFor;
+    use engine::types::phase::Phase;
+
+    #[test]
+    fn restore_rebuilds_an_empty_declare_attackers_target_snapshot() {
+        clear_game_state();
+        set_multiplayer_mode(false);
+        load_minimal_test_card_database();
+
+        let mut scenario = GameScenario::new_n_player(2, 42);
+        scenario.at_phase(Phase::DeclareAttackers);
+        let pyrogoyf = scenario.add_creature(P0, "Pyrogoyf", 2, 3).id();
+        let guide_of_souls = scenario.add_creature(P0, "Guide of Souls", 2, 2).id();
+        let mut runner = scenario.build();
+        runner.state_mut().waiting_for = build_declare_attackers_waiting_for(runner.state());
+        let WaitingFor::DeclareAttackers {
+            valid_attack_targets,
+            valid_attack_targets_by_attacker,
+            ..
+        } = &mut runner.state_mut().waiting_for
+        else {
+            panic!("scenario must enter DeclareAttackers");
+        };
+        valid_attack_targets.clear();
+        *valid_attack_targets_by_attacker = Some(std::collections::HashMap::from([
+            (pyrogoyf, Vec::new()),
+            (guide_of_souls, Vec::new()),
+        ]));
+
+        let json = serde_json::to_string(runner.state())
+            .expect("stale externally exported prompt serializes");
+        restore_game_state(&json).expect("external restore succeeds");
+
+        with_state(|state| match &state.waiting_for {
+            WaitingFor::DeclareAttackers {
+                valid_attack_targets,
+                valid_attack_targets_by_attacker: Some(by_attacker),
+                ..
+            } => {
+                assert_eq!(valid_attack_targets, &vec![AttackTarget::Player(P1)]);
+                assert_eq!(
+                    valid_attack_targets.iter().copied().collect::<HashSet<_>>(),
+                    by_attacker.values().flatten().copied().collect(),
+                    "aggregate targets remain the union of per-attacker support"
+                );
+                assert_eq!(
+                    by_attacker.get(&pyrogoyf),
+                    Some(&vec![AttackTarget::Player(P1)]),
+                    "Pyrogoyf regains its engine-authored attack target after restore"
+                );
+                assert_eq!(
+                    by_attacker.get(&guide_of_souls),
+                    Some(&vec![AttackTarget::Player(P1)]),
+                    "the restored prompt rebuilds every selected attacker's target support"
+                );
+            }
+            waiting_for => panic!("expected DeclareAttackers after restore, got {waiting_for:?}"),
+        })
+        .expect("restored state remains available");
+        with_state_mut(|state| {
+            apply(
+                state,
+                P0,
+                GameAction::DeclareAttackers {
+                    attacks: vec![
+                        (pyrogoyf, AttackTarget::Player(P1)),
+                        (guide_of_souls, AttackTarget::Player(P1)),
+                    ],
+                    bands: vec![],
+                },
+            )
+        })
+        .expect("restored state remains available")
+        .expect("restored target choices reach the declaration reducer");
+        clear_game_state();
+    }
+
+    #[test]
+    fn restore_rebuilds_an_empty_declare_blockers_target_snapshot() {
+        clear_game_state();
+        set_multiplayer_mode(false);
+        load_minimal_test_card_database();
+
+        let mut scenario = GameScenario::new_n_player(2, 42);
+        scenario.at_phase(Phase::DeclareAttackers);
+        let attacker = scenario.add_creature(P0, "Attacker", 2, 2).id();
+        let blocker = scenario.add_creature(P1, "Blocker", 2, 2).id();
+        let mut runner = scenario.build();
+        runner.state_mut().waiting_for = build_declare_attackers_waiting_for(runner.state());
+        runner
+            .act(GameAction::DeclareAttackers {
+                attacks: vec![(attacker, AttackTarget::Player(P1))],
+                bands: vec![],
+            })
+            .expect("attacker enters combat before the blocker prompt");
+        runner.pass_both_players();
+        let WaitingFor::DeclareBlockers {
+            valid_blocker_ids,
+            valid_block_targets,
+            ..
+        } = &mut runner.state_mut().waiting_for
+        else {
+            panic!("combat must enter DeclareBlockers");
+        };
+        valid_blocker_ids.clear();
+        valid_block_targets.clear();
+
+        let json = serde_json::to_string(runner.state())
+            .expect("stale externally exported blocker prompt serializes");
+        restore_game_state(&json).expect("external restore succeeds");
+
+        with_state(|state| match &state.waiting_for {
+            WaitingFor::DeclareBlockers {
+                valid_blocker_ids,
+                valid_block_targets,
+                ..
+            } => {
+                assert_eq!(valid_blocker_ids, &vec![blocker]);
+                assert_eq!(valid_block_targets.get(&blocker), Some(&vec![attacker]));
+            }
+            waiting_for => panic!("expected DeclareBlockers after restore, got {waiting_for:?}"),
+        })
+        .expect("restored state remains available");
+        with_state_mut(|state| {
+            apply(
+                state,
+                P1,
+                GameAction::DeclareBlockers {
+                    assignments: vec![(blocker, attacker)],
+                },
+            )
+        })
+        .expect("restored state remains available")
+        .expect("restored blocker choices reach the declaration reducer");
+        clear_game_state();
     }
 }
 


### PR DESCRIPTION
## Summary

Rebuilds derived combat declaration prompts after an externally restored game state has been rehydrated from card data. This prevents stale empty attack-target snapshots from opening an unwinnable target picker.

## Files changed

- crates/engine-wasm/src/lib.rs

## Track

Developer

## LLM

Model: GitHub Copilot (canonical id not exposed)
Tier: not-applicable (model tier not exposed)
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

None. This refreshes existing engine-authored combat prompt projections; it adds no rules behavior.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — passed
- `cargo clippy-strict` — passed
- `cargo test -p engine-wasm` — 26 passed
- `cargo test -p phase-engine` — interrupted twice by unrelated long-running loop tests after thousands of passing cases; CI will complete the full suite.
- `cargo test -p phase-engine --test integration numeric_maps_round_trip_through_value_bare_raw_and_trusted` — 2 passed
- `cargo test -p phase-engine --test integration real_game_state_hash_owners_are_canonical_and_round_trip_across_all_persistence_forms` — passed
- Independent final `/review-impl` pass — clean at `5b61bb220052679b2c2600ea244883d19ff28b30`

## Gate A

Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=5b61bb220052679b2c2600ea244883d19ff28b30 base=97591656218103d8e8c7315725b24cfe64645dd4

## Anchored on

- crates/engine-wasm/src/lib.rs:2029 — single-player restore calls the shared decode-and-rehydrate helper before public-state finalization.
- crates/engine-wasm/src/lib.rs:2092 — multiplayer host resume calls the same shared decode-and-rehydrate helper.

## Final review-impl

Final review-impl PASS head=5b61bb220052679b2c2600ea244883d19ff28b30

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

`cargo test -p phase-engine` was interrupted twice during unrelated long-running loop tests after thousands of passing cases, so local full-suite completion remains CI-owned.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored games now refresh combat prompts with current attacker and blocker choices.
  * Resuming a restored combat encounter now provides accurate interaction options.

* **Tests**
  * Added coverage for restoring outdated attacker and blocker prompts.
  * Verified refreshed combat choices can be submitted successfully.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->