### PR TITLE
fix(engine): retain completed pay-life amount

### DIFF
--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -651,14 +651,25 @@ pub(crate) fn pay_ability_cost_for_resolution(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<PaymentOutcome, EngineError> {
-    pay_ability_cost_for_resolution_with_cost_move_root(
+    let outcome = pay_ability_cost_for_resolution_with_cost_move_root(
         state,
         payer,
         cost,
         ability,
         ResolutionCostMoveRoot::EffectPayCost,
         events,
-    )
+    )?;
+    // CR 118.1 + CR 119.4b: `effects::pay` records a concrete life component
+    // on its continuation-owned ability before this authority can pause. Stamp
+    // it only after the entire cost finishes, including a mana-root resume.
+    // `None` is deliberately distinct from `Some(0)`: mana-only costs retain
+    // their preceding amount, while a completed zero-life cost reports zero.
+    if outcome == PaymentOutcome::Paid {
+        if let Some(amount) = ability.context.pay_cost_paid_life_amount {
+            state.last_effect_amount = Some(amount as i32);
+        }
+    }
+    Ok(outcome)
 }
 
 /// Pays a replacement's MayCost. Its dedicated root owns the outer

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -7255,14 +7255,10 @@ fn amount_channel(effect: &Effect) -> Option<AmountChannel> {
         // CR 118.1: `PayCost`'s `cost` is an arbitrary `AbilityCost`, and only a
         // life payment emits the negative `LifeChanged` events this channel sums;
         // a mana / sacrifice / discard payment owns no amount here at all.
-        // CR 119.4b makes paying 0 life a real, always-legal payment whose result
-        // is zero, so a life payment SHOULD report it — but `pay::resolve` pushes
-        // no events whatsoever, so it emits no `EffectResolved` terminal marker
-        // and the completion half of the zero rule cannot be established for it.
-        // Closing this arm means first giving cost payment a terminal marker,
-        // which is its own change with its own blast radius (the per-player
-        // counts helper, the trigger matchers and the game log all read that
-        // event class).
+        // CR 118.1 + CR 119.4b: `PayCost` has no life-loss event of its own;
+        // the cost authority therefore stamps its completed life-payment result
+        // directly. Keep this event channel indistinguishable so mana-only
+        // costs still preserve the preceding amount.
         Effect::PayCost { .. } => (AmountEvents::LifeLost, ZeroSemantics::Indistinguishable),
         // CR 119.3 + CR 119.9: gaining zero life is not a life-GAIN EVENT, so
         // "whenever you gain life" correctly does not trigger — but CR 119.9
@@ -29116,16 +29112,10 @@ mod tests {
         );
     }
 
-    /// NOT CLOSED (#6956): CR 118.1 + CR 119.4b say paying 0 life is a real,
-    /// always-legal payment whose result is zero, so this SHOULD read 0 — but
-    /// `pay::resolve` emits no `EffectResolved` terminal marker, so the
-    /// completion half of the zero rule cannot be established for
-    /// `Effect::PayCost`. Pinned at the PREDECESSOR behaviour
-    /// (the preceding step's 7 survives) so the arm's status is a visible,
-    /// asserted fact rather than an untested assumption. Flipping this
-    /// expectation to 0 is the acceptance test for the follow-up.
+    /// CR 118.1 + CR 119.4b: Paying 0 life is a real, always-legal payment,
+    /// so its completed result overwrites the preceding amount with zero.
     #[test]
-    fn zero_life_pay_cost_is_not_yet_distinguished_from_an_absent_producer() {
+    fn zero_life_pay_cost_overwrites_the_preceding_amount() {
         let (mut state, source) = state_for_previous_amount_probe();
         let drawn = previous_effect_amount_seen_by_next_clause(
             &mut state,
@@ -29140,9 +29130,8 @@ mod tests {
             vec![],
         );
         assert_eq!(
-            drawn, 7,
-            "PayCost has no terminal marker, so its zero cannot yet be told apart \
-             from an absent producer; see `amount_channel`'s PayCost arm"
+            drawn, 0,
+            "a completed zero-life PayCost must not leave the preceding amount in place"
         );
     }
 

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -37,7 +37,7 @@ fn paid_life_amount_for_cost(
                 .unwrap_or(0),
         ),
         AbilityCost::Composite { costs } => {
-            let mut total = None;
+            let mut total: Option<u32> = None;
             for cost in costs {
                 if let Some(amount) = paid_life_amount_for_cost(state, ability, cost) {
                     total = Some(total.unwrap_or(0).saturating_add(amount));

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -23,6 +23,46 @@ fn is_pay_any_amount(amount: &QuantityExpr) -> bool {
     )
 }
 
+/// CR 118.1 + CR 119.4b: Resolve the life-payment channel owned by a concrete
+/// `PayCost`. `None` means this cost has no life-payment component; `Some(0)`
+/// is a completed, always-legal zero-life payment and must remain distinct.
+fn paid_life_amount_for_cost(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    cost: &AbilityCost,
+) -> Option<u32> {
+    match cost {
+        AbilityCost::PayLife { amount } => Some(
+            u32::try_from(resolve_quantity_with_targets(state, amount, ability).max(0))
+                .unwrap_or(0),
+        ),
+        AbilityCost::Composite { costs } => {
+            let mut total = None;
+            for cost in costs {
+                if let Some(amount) = paid_life_amount_for_cost(state, ability, cost) {
+                    total = Some(total.unwrap_or(0).saturating_add(amount));
+                }
+            }
+            total
+        }
+        _ => None,
+    }
+}
+
+/// CR 118.1 + CR 119.4b: Record the resolved life-payment amount before a
+/// cost can pause. The cloned ability is the continuation authority for both
+/// ordinary cost choices and `ManaAbilityResume::EffectPayCost` roots.
+fn prepare_pay_cost_life_amount(
+    state: &GameState,
+    ability: &mut ResolvedAbility,
+    cost: &AbilityCost,
+) {
+    if ability.context.pay_cost_paid_life_amount.is_none() {
+        let paid_life_amount = paid_life_amount_for_cost(state, ability, cost);
+        ability.context.pay_cost_paid_life_amount = paid_life_amount;
+    }
+}
+
 /// CR 118.1: Pay a cost as part of an effect resolution.
 /// CR 117.1: Mana payment uses auto-tap + pool deduction.
 /// CR 119.4: Paying life IS losing life — replacement effects and the
@@ -200,6 +240,7 @@ pub fn resolve(
         // pipeline + lock both apply inside the authority's
         // `pay_life_as_cost`).
         _ => {
+            prepare_pay_cost_life_amount(state, &mut payment_ability, cost);
             resolve_ability_cost_payment(state, &payment_ability, payer, cost, events)?;
         }
     }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -16110,7 +16110,7 @@ mod stage2_injector_tests {
                 // `OptionalEffect` prompt. Re-pinned against the merged source.
                 "game/effects/mod.rs:6300".to_string(),
                 "game/effects/mod.rs:6377".to_string(),
-                "game/effects/mod.rs:9576".to_string(),
+                "game/effects/mod.rs:9572".to_string(),
                 // UNMOVED across the rebase, and that is itself evidence the SET did not
                 // move: a census that had gained or lost a producer would not leave this
                 // entry both byte-identical AND at the same coordinate.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -20535,6 +20535,12 @@ pub struct DiscardedCardResult {
 /// Conditions in the sub_ability chain are evaluated against this context.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub struct SpellContext {
+    /// CR 118.1 + CR 119.4b: A completed resolution-time `PayCost` that paid
+    /// life reports this amount to the immediate following "that much" clause.
+    /// `Some(0)` is distinct from no life-payment channel at all, and the value
+    /// stays with a paused payment's continuation until that cost completes.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pay_cost_paid_life_amount: Option<u32>,
     /// CR 701.9a + CR 608.2c: The result of the immediately preceding discard
     /// instruction. `apply_parent_chain_context` copies this only to that
     /// discard's direct child and clears it on every other hand-off.


### PR DESCRIPTION
Fixes #6956.

Preserves the distinction between a completed zero-life cost and a cost with no life-payment component across cost-payment continuations.