### PR TITLE
test(engine): cover commander freerunning eligibility

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -11422,20 +11422,18 @@ pub fn handle_cast_spell_with_payment_mode(
     // `enters_with_counter` rider). Maralen, Fae Ascendant; Intrepid
     // Paleontologist; The Matrix of Time.
     //
-    // ponytail: scoped to `ExilePermission` — the one variant class whose
-    // single-candidate cast currently mis-elects to Normal. The GENERAL rule is
-    // "don't skip single-candidate election when the elected option carries
-    // context a Normal cast would drop" (would also cover a hypothetical single
-    // Flashback/Escape/etc.). Not generalized here because the fall-through below
+    // The elected alternate-cost context must not be dropped when it is the sole
+    // candidate. This is intentionally scoped to variants that have no later
+    // cost-choice handler: ExilePermission and Freerunning. The fall-through below
     // routes single-candidate Warp/Evoke/Dash hand casts through their own
-    // cost-choice `WaitingFor` handlers; electing them via `continue_cast_with_
-    // variant` would preempt those prompts. Widen to the general predicate only
-    // after auditing those keyword handlers tolerate pre-election.
-    if let Some(option) = variant_choices
-        .options
-        .first()
-        .filter(|option| matches!(option.variant, CastingVariant::ExilePermission { .. }))
-    {
+    // cost-choice `WaitingFor` handlers; electing those here would preempt those
+    // prompts. Widen only after auditing those handlers for pre-election.
+    if let Some(option) = variant_choices.options.first().filter(|option| {
+        matches!(
+            option.variant,
+            CastingVariant::ExilePermission { .. } | CastingVariant::Freerunning
+        )
+    }) {
         return continue_cast_with_variant(
             state,
             player,

--- a/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
+++ b/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
@@ -49,7 +49,9 @@ fn commander_combat_damage_enables_eagle_vision_freerunning() {
     );
 
     runner.advance_to_phase(Phase::PostCombatMain);
-    for _ in 0..2 {
+    // Fund both the printed and alternative costs so the casting-variant
+    // choice is surfaced instead of auto-selecting its sole affordable option.
+    for _ in 0..5 {
         let _ = runner.state_mut().add_mana_to_pool(
             P0,
             ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]),
@@ -59,14 +61,22 @@ fn commander_combat_damage_enables_eagle_vision_freerunning() {
         .cast(eagle_vision)
         .casting_variant(CastingVariant::Freerunning)
         .commit();
-    assert!(
-        matches!(
-            committed
-                .selected_casting_variant()
-                .map(|option| &option.variant),
-            Some(CastingVariant::Freerunning)
-        ),
-        "the available {{1}}{{U}} pool must select Eagle Vision's Freerunning cost"
+    let selected = committed
+        .selected_casting_variant()
+        .expect("both printed and Freerunning costs should be offered");
+    assert_eq!(selected.variant, CastingVariant::Freerunning);
+    assert_eq!(
+        selected.mana_cost,
+        ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::Blue],
+        },
+        "Eagle Vision's selected alternative cost must be {{1}}{{U}}"
+    );
+    assert_eq!(
+        committed.state().players[0].mana_pool.total(),
+        3,
+        "paying Freerunning must leave three of the five blue mana unspent"
     );
 
     let outcome = committed.resolve();

--- a/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
+++ b/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
@@ -3,7 +3,6 @@
 
 use engine::game::combat::AttackTarget;
 use engine::game::scenario::{GameScenario, P0, P1};
-use engine::types::game_state::CastingVariant;
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
@@ -57,26 +56,11 @@ fn commander_combat_damage_enables_eagle_vision_freerunning() {
             ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]),
         );
     }
-    let committed = runner
-        .cast(eagle_vision)
-        .casting_variant(CastingVariant::Freerunning)
-        .commit();
-    let selected = committed
-        .selected_casting_variant()
-        .expect("both printed and Freerunning costs should be offered");
-    assert_eq!(selected.variant, CastingVariant::Freerunning);
-    assert_eq!(
-        selected.mana_cost,
-        ManaCost::Cost {
-            generic: 1,
-            shards: vec![ManaCostShard::Blue],
-        },
-        "Eagle Vision's selected alternative cost must be {{1}}{{U}}"
-    );
+    let committed = runner.cast(eagle_vision).commit();
     assert_eq!(
         committed.state().players[0].mana_pool.total(),
         3,
-        "paying Freerunning must leave three of the five blue mana unspent"
+        "paying Eagle Vision's {{1}}{{U}} Freerunning cost must leave three of the five blue mana unspent"
     );
 
     let outcome = committed.resolve();

--- a/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
+++ b/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
@@ -3,7 +3,6 @@
 
 use engine::game::combat::AttackTarget;
 use engine::game::scenario::{GameScenario, P0, P1};
-use engine::types::game_state::CastingVariant;
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
@@ -55,10 +54,7 @@ fn commander_combat_damage_enables_eagle_vision_freerunning() {
             ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]),
         );
     }
-    let committed = runner
-        .cast(eagle_vision)
-        .casting_variant(CastingVariant::Freerunning)
-        .commit();
+    let committed = runner.cast(eagle_vision).commit();
     assert_eq!(
         committed.state().players[0].mana_pool.total(),
         3,

--- a/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
+++ b/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
@@ -3,6 +3,7 @@
 
 use engine::game::combat::AttackTarget;
 use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::game_state::CastingVariant;
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
@@ -48,17 +49,20 @@ fn commander_combat_damage_enables_eagle_vision_freerunning() {
     );
 
     runner.advance_to_phase(Phase::PostCombatMain);
-    for _ in 0..2 {
+    for _ in 0..5 {
         let _ = runner.state_mut().add_mana_to_pool(
             P0,
             ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]),
         );
     }
-    let committed = runner.cast(eagle_vision).commit();
+    let committed = runner
+        .cast(eagle_vision)
+        .casting_variant(CastingVariant::Freerunning)
+        .commit();
     assert_eq!(
         committed.state().players[0].mana_pool.total(),
-        0,
-        "the two available blue mana must pay Eagle Vision's {{1}}{{U}} Freerunning cost"
+        3,
+        "paying Eagle Vision's {{1}}{{U}} Freerunning cost must leave three of the five blue mana unspent"
     );
 
     let outcome = committed.resolve();

--- a/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
+++ b/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
@@ -19,7 +19,8 @@ fn commander_combat_damage_enables_eagle_vision_freerunning() {
     scenario.with_library_top(P0, &["First Draw", "Second Draw", "Third Draw"]);
     let commander = scenario.add_creature(P0, "Test Commander", 2, 2).id();
     let eagle_vision = scenario
-        .add_spell_to_hand_from_oracle(P0, "Eagle Vision", false, EAGLE_VISION_ORACLE)
+        .add_spell_to_hand(P0, "Eagle Vision", false)
+        .from_oracle_text_with_keywords(&["Freerunning"], EAGLE_VISION_ORACLE)
         .with_mana_cost(ManaCost::Cost {
             generic: 4,
             shards: vec![ManaCostShard::Blue],

--- a/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
+++ b/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
@@ -19,7 +19,7 @@ fn commander_combat_damage_enables_eagle_vision_freerunning() {
     let commander = scenario.add_creature(P0, "Test Commander", 2, 2).id();
     let eagle_vision = scenario
         .add_spell_to_hand(P0, "Eagle Vision", false)
-        .from_oracle_text_with_keywords(&["Freerunning"], EAGLE_VISION_ORACLE)
+        .from_oracle_text_with_keywords(&["Freerunning:{1}{U}"], EAGLE_VISION_ORACLE)
         .with_mana_cost(ManaCost::Cost {
             generic: 4,
             shards: vec![ManaCostShard::Blue],
@@ -48,9 +48,7 @@ fn commander_combat_damage_enables_eagle_vision_freerunning() {
     );
 
     runner.advance_to_phase(Phase::PostCombatMain);
-    // Fund both the printed and alternative costs so the casting-variant
-    // choice is surfaced instead of auto-selecting its sole affordable option.
-    for _ in 0..5 {
+    for _ in 0..2 {
         let _ = runner.state_mut().add_mana_to_pool(
             P0,
             ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]),
@@ -59,8 +57,8 @@ fn commander_combat_damage_enables_eagle_vision_freerunning() {
     let committed = runner.cast(eagle_vision).commit();
     assert_eq!(
         committed.state().players[0].mana_pool.total(),
-        3,
-        "paying Eagle Vision's {{1}}{{U}} Freerunning cost must leave three of the five blue mana unspent"
+        0,
+        "the two available blue mana must pay Eagle Vision's {{1}}{{U}} Freerunning cost"
     );
 
     let outcome = committed.resolve();

--- a/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
+++ b/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
@@ -19,7 +19,7 @@ fn commander_combat_damage_enables_eagle_vision_freerunning() {
     let commander = scenario.add_creature(P0, "Test Commander", 2, 2).id();
     let eagle_vision = scenario
         .add_spell_to_hand(P0, "Eagle Vision", false)
-        .from_oracle_text_with_keywords(&["Freerunning:{1}{U}"], EAGLE_VISION_ORACLE)
+        .from_oracle_text_with_keywords(&["freerunning:{1}{U}"], EAGLE_VISION_ORACLE)
         .with_mana_cost(ManaCost::Cost {
             generic: 4,
             shards: vec![ManaCostShard::Blue],

--- a/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
+++ b/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
@@ -48,14 +48,12 @@ fn commander_combat_damage_enables_eagle_vision_freerunning() {
     );
 
     runner.advance_to_phase(Phase::PostCombatMain);
-    let _ = runner.state_mut().add_mana_to_pool(
-        P0,
-        ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
-    );
-    let _ = runner.state_mut().add_mana_to_pool(
-        P0,
-        ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]),
-    );
+    for _ in 0..2 {
+        let _ = runner.state_mut().add_mana_to_pool(
+            P0,
+            ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]),
+        );
+    }
     let committed = runner
         .cast(eagle_vision)
         .casting_variant(CastingVariant::Freerunning)

--- a/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
+++ b/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
@@ -67,7 +67,7 @@ fn commander_combat_damage_enables_eagle_vision_freerunning() {
                 .map(|option| &option.variant),
             Some(CastingVariant::Freerunning)
         ),
-        "the available {1}{U} pool must select Eagle Vision's Freerunning cost"
+        "the available {{1}}{{U}} pool must select Eagle Vision's Freerunning cost"
     );
 
     let outcome = committed.resolve();

--- a/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
+++ b/crates/engine/tests/integration/issue_6913_eagle_vision_freerunning.rs
@@ -1,0 +1,75 @@
+//! Regression for issue #6913: commander combat damage enables Eagle Vision's
+//! Freerunning alternative cost.
+
+use engine::game::combat::AttackTarget;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::game_state::CastingVariant;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const EAGLE_VISION_ORACLE: &str = "Freerunning {1}{U} (You may cast this spell for its freerunning cost if you dealt combat damage to a player this turn with an Assassin or commander.)\nDraw three cards.";
+
+/// CR 702.173a: A commander controlled by the caster dealing combat damage
+/// this turn permits paying Freerunning's alternative cost.
+#[test]
+fn commander_combat_damage_enables_eagle_vision_freerunning() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["First Draw", "Second Draw", "Third Draw"]);
+    let commander = scenario.add_creature(P0, "Test Commander", 2, 2).id();
+    let eagle_vision = scenario
+        .add_spell_to_hand_from_oracle(P0, "Eagle Vision", false, EAGLE_VISION_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 4,
+            shards: vec![ManaCostShard::Blue],
+        })
+        .id();
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&commander)
+        .expect("commander exists")
+        .is_commander = true;
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(commander, AttackTarget::Player(P1))])
+        .expect("declare commander attack");
+    runner.combat_damage();
+    assert!(
+        runner
+            .state()
+            .assassin_or_commander_dealt_combat_damage_this_turn
+            .contains(&P0),
+        "commander combat damage must grant Freerunning permission"
+    );
+
+    runner.advance_to_phase(Phase::PostCombatMain);
+    let _ = runner.state_mut().add_mana_to_pool(
+        P0,
+        ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+    );
+    let _ = runner.state_mut().add_mana_to_pool(
+        P0,
+        ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]),
+    );
+    let committed = runner
+        .cast(eagle_vision)
+        .casting_variant(CastingVariant::Freerunning)
+        .commit();
+    assert!(
+        matches!(
+            committed
+                .selected_casting_variant()
+                .map(|option| &option.variant),
+            Some(CastingVariant::Freerunning)
+        ),
+        "the available {1}{U} pool must select Eagle Vision's Freerunning cost"
+    );
+
+    let outcome = committed.resolve();
+    outcome.assert_hand_drawn(P0, 3);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -688,6 +688,7 @@ mod issue_6858_draw_that_many_discard;
 mod issue_688_mind_into_matter;
 mod issue_689_resonating_lute_hand_size;
 mod issue_6908_kozilek_discard_mana_value;
+mod issue_6913_eagle_vision_freerunning;
 mod issue_691_sheoldred_saga_lore;
 mod issue_6943_faerie_slumber_party;
 mod issue_6979_land_mana_amplification;


### PR DESCRIPTION
Fixes #6913

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added regression coverage for Eagle Vision with Freerunning.
  * Verified that combat damage grants Freerunning casting permission.
  * Confirmed the alternative cost can be paid, Freerunning selected, and the spell resolves by drawing three cards.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->