### PR TITLE
Fix combat phase stops during auto-pass

### DIFF
--- a/client/src/components/board/ActionButton.tsx
+++ b/client/src/components/board/ActionButton.tsx
@@ -278,7 +278,8 @@ export function ActionButton() {
   // grows. Surfaced with the same pulsing cancel affordance as UntilTurnBoundary
   // so the player can revoke it between opponents' windows.
   const isResolvingStack = autoPass?.type === "UntilStackEmpty";
-  const canActDuringAutoPass = mode === "combat-blockers";
+  const canActDuringAutoPass =
+    mode === "combat-attackers" || mode === "combat-blockers";
 
   const actionPending = useMultiplayerStore((s) => s.actionPending);
   const isResolvingAll = useGameStore((s) => s.isResolvingAll);
@@ -293,7 +294,7 @@ export function ActionButton() {
   return (
     <>
       <div className={panelClassName} data-action-button-panel>
-        {mode === "combat-attackers" && !isEndingTurn && (
+        {mode === "combat-attackers" && (
           <>
             <button
               disabled={actionBlocked}

--- a/client/src/components/board/__tests__/ActionButton.test.tsx
+++ b/client/src/components/board/__tests__/ActionButton.test.tsx
@@ -31,6 +31,19 @@ function blockerPrompt(): WaitingFor {
   };
 }
 
+function attackerPrompt(): WaitingFor {
+  const target = { type: "Player", data: 1 } as const;
+  return {
+    type: "DeclareAttackers",
+    data: {
+      player: 0,
+      valid_attacker_ids: [100],
+      valid_attack_targets: [target],
+      valid_attack_targets_by_attacker: { "100": [target] },
+    },
+  };
+}
+
 function priorityPrompt(player = 0): WaitingFor {
   return buildPriorityWaitingFor({ data: { player } });
 }
@@ -97,6 +110,24 @@ describe("ActionButton", () => {
     render(<ActionButton />);
 
     expect(screen.getByRole("button", { name: "Block with None" })).toBeInTheDocument();
+    expect(screen.queryByText("Auto-Passing to End Step...")).not.toBeInTheDocument();
+  });
+
+  it("keeps attacker controls available while pass-until-end-of-turn is armed", () => {
+    const waitingFor = attackerPrompt();
+    useGameStore.setState({
+      gameState: {
+        ...createGameState(waitingFor),
+        phase: "DeclareAttackers",
+        active_player: 0,
+      },
+      waitingFor,
+    });
+
+    render(<ActionButton />);
+
+    expect(screen.getByRole("button", { name: "Attack with All" })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Attack with None" })).toBeInTheDocument();
     expect(screen.queryByText("Auto-Passing to End Step...")).not.toBeInTheDocument();
   });
 

--- a/crates/engine/src/game/engine_phase_trigger_regression_tests.rs
+++ b/crates/engine/src/game/engine_phase_trigger_regression_tests.rs
@@ -14,6 +14,7 @@ use crate::types::ability::{
 use crate::types::card::CardFace;
 use crate::types::card_type::CoreType;
 use crate::types::format::FormatConfig;
+use crate::types::game_state::{AutoPassMode, TurnBoundary};
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::keywords::Keyword;
 use crate::types::mana::{ManaColor, ManaCost, ManaType, ManaUnit};
@@ -156,8 +157,8 @@ fn begin_combat_window_precedes_forced_empty_attacker_declaration() {
     ));
 
     // Submit the only legal declaration through the production action path.
-    // CR 508.8 then skips only DeclareBlockers and CombatDamage, leaving combat
-    // and arriving at PostCombatMain normally.
+    // CR 508.8 skips DeclareBlockers and CombatDamage, but CR 511.1 still
+    // begins EndCombat and grants priority.
     let empty_declaration = apply_as_current(
         &mut state,
         GameAction::DeclareAttackers {
@@ -166,17 +167,139 @@ fn begin_combat_window_precedes_forced_empty_attacker_declaration() {
         },
     )
     .expect("the empty declaration offered by the engine must be submitable");
-    assert_eq!(state.phase, Phase::PostCombatMain);
-    assert!(
-        state.combat.is_none(),
-        "combat ends after the empty declaration"
-    );
+    assert_eq!(state.phase, Phase::EndCombat);
     assert!(matches!(
         empty_declaration.waiting_for,
         WaitingFor::Priority {
             player: PlayerId(0)
         }
     ));
+
+    // The normal priority loop ends EndCombat and enters the postcombat main
+    // phase after both players pass.
+    apply_as_current(&mut state, GameAction::PassPriority).unwrap();
+    let postcombat = apply_as_current(&mut state, GameAction::PassPriority).unwrap();
+    assert_eq!(state.phase, Phase::PostCombatMain);
+    assert!(
+        state.combat.is_none(),
+        "combat ends after the EndCombat step"
+    );
+    assert!(matches!(
+        postcombat.waiting_for,
+        WaitingFor::Priority {
+            player: PlayerId(0)
+        }
+    ));
+}
+
+/// CR 510.4 + CR 511.1 + CR 117.3a: completed combat-damage and end-of-combat
+/// steps each expose their ordinary active-player priority window. The
+/// turn-boundary auto-pass session is re-armed before each opponent pass so the
+/// phase-stop interruption is exercised through the production `apply` path.
+#[test]
+fn combat_phase_stops_pause_damage_and_end_combat_windows() {
+    let mut state = new_game(42);
+    state.turn_number = 2;
+    state.phase = Phase::DeclareBlockers;
+    state.active_player = PlayerId(0);
+    state.priority_player = PlayerId(0);
+
+    let attacker = create_object(
+        &mut state,
+        CardId(201),
+        PlayerId(0),
+        "Combat Creature".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&attacker).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.power = Some(2);
+        obj.toughness = Some(2);
+    }
+    state.combat = Some(crate::game::combat::CombatState {
+        attackers: vec![crate::game::combat::AttackerInfo::attacking_player(
+            attacker,
+            PlayerId(1),
+        )],
+        ..Default::default()
+    });
+    state.waiting_for = WaitingFor::DeclareBlockers {
+        player: PlayerId(1),
+        valid_blocker_ids: Vec::new(),
+        valid_block_targets: Default::default(),
+        block_requirements: Default::default(),
+        blocker_constraints: Default::default(),
+    };
+    state.phase_stops.insert(
+        PlayerId(0),
+        vec![
+            PhaseStop {
+                phase: Phase::CombatDamage,
+                scope: PhaseStopScope::AllTurns,
+            },
+            PhaseStop {
+                phase: Phase::EndCombat,
+                scope: PhaseStopScope::AllTurns,
+            },
+        ],
+    );
+
+    // Finish the blocker declaration, then pass the declare-blockers priority
+    // window. The next pass enters CombatDamage through the normal reducer.
+    apply(
+        &mut state,
+        PlayerId(1),
+        GameAction::DeclareBlockers {
+            assignments: Vec::new(),
+        },
+    )
+    .unwrap();
+    apply_as_current(&mut state, GameAction::PassPriority).unwrap();
+    state.auto_pass.insert(
+        PlayerId(0),
+        AutoPassMode::UntilTurnBoundary {
+            until: TurnBoundary::EndOfCurrentTurn,
+        },
+    );
+    let damage_stop = apply_as_current(&mut state, GameAction::PassPriority).unwrap();
+    assert_eq!(state.phase, Phase::CombatDamage);
+    assert!(matches!(
+        damage_stop.waiting_for,
+        WaitingFor::Priority {
+            player: PlayerId(0)
+        }
+    ));
+    assert!(
+        !state.auto_pass.contains_key(&PlayerId(0)),
+        "CombatDamage stop must interrupt the armed auto-pass session"
+    );
+
+    // Pass through the damage-step priority window, then repeat the same
+    // production flow for EndCombat.
+    apply_as_current(&mut state, GameAction::PassPriority).unwrap();
+    state.auto_pass.insert(
+        PlayerId(0),
+        AutoPassMode::UntilTurnBoundary {
+            until: TurnBoundary::EndOfCurrentTurn,
+        },
+    );
+    let end_combat_stop = apply_as_current(&mut state, GameAction::PassPriority).unwrap();
+    assert_eq!(state.phase, Phase::EndCombat);
+    assert!(matches!(
+        end_combat_stop.waiting_for,
+        WaitingFor::Priority {
+            player: PlayerId(0)
+        }
+    ));
+    assert!(
+        !state.auto_pass.contains_key(&PlayerId(0)),
+        "EndCombat stop must interrupt the armed auto-pass session"
+    );
+
+    apply_as_current(&mut state, GameAction::PassPriority).unwrap();
+    apply_as_current(&mut state, GameAction::PassPriority).unwrap();
+    assert_eq!(state.phase, Phase::PostCombatMain);
 }
 
 /// CR 500.8 + CR 507.2: An inserted combat phase gets the same
@@ -195,12 +318,25 @@ fn inserted_begin_combat_gets_priority_window() {
         });
 
     let mut events = Vec::new();
-    let waiting_for = crate::game::turns::auto_advance(&mut state, &mut events);
+    let end_combat_waiting = crate::game::turns::auto_advance(&mut state, &mut events);
+
+    assert_eq!(state.phase, Phase::EndCombat);
+    assert!(matches!(
+        end_combat_waiting,
+        WaitingFor::Priority {
+            player: PlayerId(0)
+        }
+    ));
+
+    // End Combat is a real priority-bearing step even when no creature
+    // attacked. Passing it lets the inserted phase become the next entry.
+    apply_as_current(&mut state, GameAction::PassPriority).unwrap();
+    let waiting_for = apply_as_current(&mut state, GameAction::PassPriority).unwrap();
 
     assert_eq!(state.phase, Phase::BeginCombat);
     assert!(state.combat.is_some());
     assert!(matches!(
-        waiting_for,
+        waiting_for.waiting_for,
         WaitingFor::Priority {
             player: PlayerId(0)
         }

--- a/crates/engine/src/game/engine_phase_trigger_regression_tests.rs
+++ b/crates/engine/src/game/engine_phase_trigger_regression_tests.rs
@@ -224,6 +224,8 @@ fn combat_phase_stops_pause_damage_and_end_combat_windows() {
         )],
         ..Default::default()
     });
+    state.current_combat_attacker_restriction = Some(TargetFilter::Any);
+    state.current_combat_attacker_restriction_source = Some(attacker);
     state.waiting_for = WaitingFor::DeclareBlockers {
         player: PlayerId(1),
         valid_blocker_ids: Vec::new(),
@@ -293,6 +295,14 @@ fn combat_phase_stops_pause_damage_and_end_combat_windows() {
         }
     ));
     assert!(
+        state.combat.is_some(),
+        "combat remains during EndCombat priority"
+    );
+    assert!(
+        state.current_combat_attacker_restriction.is_some(),
+        "EndCombat restriction remains live during its priority window"
+    );
+    assert!(
         !state.auto_pass.contains_key(&PlayerId(0)),
         "EndCombat stop must interrupt the armed auto-pass session"
     );
@@ -300,6 +310,11 @@ fn combat_phase_stops_pause_damage_and_end_combat_windows() {
     apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     assert_eq!(state.phase, Phase::PostCombatMain);
+    assert!(state.combat.is_none(), "combat clears after EndCombat ends");
+    assert!(
+        state.current_combat_attacker_restriction.is_none(),
+        "EndCombat restriction clears after the step ends"
+    );
 }
 
 /// CR 500.8 + CR 507.2: An inserted combat phase gets the same

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -3974,7 +3974,10 @@ fn integration_full_turn_cycle() {
     assert_eq!(state.phase, Phase::BeginCombat);
 
     // Beginning of combat has its own priority window. With no attackers, the
-    // subsequent forced empty declaration skips only blockers and damage.
+    // subsequent forced empty declaration skips blockers and damage, then
+    // reaches the normal EndCombat priority window.
+    apply_as_current(&mut state, GameAction::PassPriority).unwrap();
+    apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     assert_eq!(state.phase, Phase::PostCombatMain);
@@ -5926,8 +5929,10 @@ fn full_turn_integration_with_mulligan() {
     // PreCombatMain: P1 passes -> BeginCombat priority.
     apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     assert_eq!(state.phase, Phase::BeginCombat);
-    // BeginCombat: both pass. No attackers are declared, so only Declare
-    // Blockers and Combat Damage are skipped before PostCombatMain.
+    // BeginCombat: both pass. No attackers are declared, so Declare Blockers
+    // and Combat Damage are skipped before the EndCombat priority window.
+    apply_as_current(&mut state, GameAction::PassPriority).unwrap();
+    apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     apply_as_current(&mut state, GameAction::PassPriority).unwrap();
     assert_eq!(state.phase, Phase::PostCombatMain);

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -295,22 +295,13 @@ pub(super) fn mark_empty_attackers_end_combat(state: &mut GameState, events: &mu
 }
 
 /// The declaration-continuation form of [`mark_empty_attackers_end_combat`].
-/// It preserves the established ordering that has already processed
-/// declaration triggers and advances past the synthetic marker without
-/// running EndCombat step triggers.
+/// CR 508.8 skips only Declare Blockers and Combat Damage; the normal End
+/// Combat step still begins and must run its triggers and priority window.
 pub(super) fn advance_after_empty_attackers(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
 ) -> WaitingFor {
     mark_empty_attackers_end_combat(state, events);
-    state.combat = None;
-    // CR 511.3: The synthetic empty-attacker path still ends this combat, so
-    // its extra-combat attacker restriction cannot survive to postcombat main.
-    state.current_combat_attacker_restriction = None;
-    state.current_combat_attacker_restriction_source = None;
-    super::layers::prune_end_of_combat_effects(state);
-    super::layers::prune_controller_end_combat_step_effects(state, state.active_player);
-    let _ = advance_phase_once(state, events);
     auto_advance(state, events)
 }
 
@@ -3006,8 +2997,13 @@ fn auto_advance_once(state: &mut GameState, events: &mut Vec<GameEvent>) -> Auto
                     player: state.active_player,
                 });
             }
-            let _ = advance_phase_once(state, events);
-            // Continue to EndCombat
+            // CR 117.3a: After the combat-damage turn-based action and its
+            // triggered abilities are handled, the active player receives
+            // priority before the step ends. This also gives phase stops a
+            // Priority window in which to interrupt auto-pass.
+            return AutoAdvanceStep::waiting(WaitingFor::Priority {
+                player: state.active_player,
+            });
         }
         Phase::EndCombat => {
             // CR 511.1: "At end of combat" triggers fire here.
@@ -3034,12 +3030,13 @@ fn auto_advance_once(state: &mut GameState, events: &mut Vec<GameEvent>) -> Auto
                 if let Some(prompt) = ordering_prompt {
                     return AutoAdvanceStep::waiting(prompt);
                 }
-                return AutoAdvanceStep::waiting(WaitingFor::Priority {
-                    player: state.active_player,
-                });
             }
-            let _ = advance_phase_once(state, events);
-            // Continue to PostCombatMain
+            // CR 511.1: The active player receives priority as the End Combat step
+            // begins, even when no ability triggered. Keeping the phase active until
+            // all players pass lets phase stops interrupt auto-pass here.
+            return AutoAdvanceStep::waiting(WaitingFor::Priority {
+                player: state.active_player,
+            });
         }
         Phase::End => {
             // CR 513.1 + CR 611.2a/b: Expire `PlayFromExile { duration:
@@ -7636,6 +7633,10 @@ mod tests {
         )
         .unwrap();
 
+        // CR 511.1: the empty-attacker path still enters EndCombat, whose
+        // priority window must be passed before PostCombatMain.
+        apply(&mut state, PlayerId(0), GameAction::PassPriority).unwrap();
+        apply(&mut state, PlayerId(1), GameAction::PassPriority).unwrap();
         assert_eq!(state.phase, Phase::PostCombatMain);
     }
 

--- a/crates/engine/src/game/turns.rs
+++ b/crates/engine/src/game/turns.rs
@@ -179,6 +179,12 @@ pub(in crate::game) fn advance_phase_once(
         removed = taken;
     }
 
+    // CR 511.3: End Combat teardown happens when the step ends, after its
+    // priority window, not when the step begins.
+    if leaving == Phase::EndCombat {
+        complete_end_combat_teardown(state);
+    }
+
     // If wrapping from Cleanup to Untap, start next turn. Turn-level skip
     // replacements (CR 614.10) are handled inside `start_next_turn` — the
     // per-phase pipeline below runs only for within-turn phase advances.
@@ -247,18 +253,13 @@ pub fn end_turn_to_cleanup(state: &mut GameState, events: &mut Vec<GameEvent>) {
     enter_phase(state, Phase::Cleanup, events);
 }
 
-/// CR 724.2d: End the current combat phase by removing everything from combat,
-/// expiring "until end of combat" effects, and skipping straight to the
-/// postcombat main phase. Mirrors the end-of-combat teardown the `EndCombat`
-/// step performs (see the `Phase::EndCombat` arm of `advance_phase`), but skips
-/// the intervening end-of-combat step so its "at end of combat" triggers do not
-/// fire (CR 724.2e). Drives `Effect::EndCombatPhase` (Mandate of Peace).
-pub fn end_combat_phase_to_postcombat(state: &mut GameState, events: &mut Vec<GameEvent>) {
-    // CR 724.2d / CR 511.3: Remove all creatures and planeswalkers from combat.
+/// CR 511.2 + CR 511.3: End Combat effects expire and combat objects leave
+/// combat only after the step's priority window has ended. Explicit effects
+/// that skip directly out of combat use the same teardown authority.
+fn complete_end_combat_teardown(state: &mut GameState) {
     state.combat = None;
-    // CR 724.2d: Effects that last "until end of combat" expire — continuous
-    // effects, replacement definitions, and pending damage replacements alike,
-    // matching the normal end-of-combat prune.
+    state.current_combat_attacker_restriction = None;
+    state.current_combat_attacker_restriction_source = None;
     super::layers::prune_end_of_combat_effects(state);
     super::layers::prune_controller_end_combat_step_effects(state, state.active_player);
     for obj in state.objects.iter_mut().map(|(_, v)| v) {
@@ -268,11 +269,19 @@ pub fn end_combat_phase_to_postcombat(state: &mut GameState, events: &mut Vec<Ga
     state
         .pending_damage_replacements
         .retain(|r| !matches!(r.expiry, Some(RestrictionExpiry::EndOfCombat)));
+}
 
-    // CR 511.3 / CR 724.2d: the combat phase is over — clear any active
-    // additional-combat attacker restriction (Last Night Together / Bumi).
-    state.current_combat_attacker_restriction = None;
-    state.current_combat_attacker_restriction_source = None;
+/// CR 724.2d: End the current combat phase by removing everything from combat,
+/// expiring "until end of combat" effects, and skipping straight to the
+/// postcombat main phase. Mirrors the end-of-combat teardown the `EndCombat`
+/// step performs (see the `Phase::EndCombat` arm of `advance_phase`), but skips
+/// the intervening end-of-combat step so its "at end of combat" triggers do not
+/// fire (CR 724.2e). Drives `Effect::EndCombatPhase` (Mandate of Peace).
+pub fn end_combat_phase_to_postcombat(state: &mut GameState, events: &mut Vec<GameEvent>) {
+    // CR 724.2d / CR 511.3: Remove all creatures and planeswalkers from combat.
+    // CR 724.2d: Effects that last "until end of combat" expire through the
+    // same authority as the normal End Combat transition.
+    complete_end_combat_teardown(state);
 
     // CR 724.2d: Skip straight to the postcombat main phase, skipping any
     // intervening steps (including the end-of-combat step — CR 724.2e). Any
@@ -3010,21 +3019,6 @@ fn auto_advance_once(state: &mut GameState, events: &mut Vec<GameEvent>) -> Auto
             let event_snapshot = events.clone();
             let (triggers_fired, ordering_prompt) =
                 process_phase_triggers(state, &event_snapshot, events);
-            // CR 511.3: At end of combat, all creatures are removed from combat.
-            state.combat = None;
-            // CR 511.3: the combat phase is over — its attacker restriction
-            // (Last Night Together / Bumi) ends with it.
-            state.current_combat_attacker_restriction = None;
-            state.current_combat_attacker_restriction_source = None;
-            super::layers::prune_end_of_combat_effects(state);
-            super::layers::prune_controller_end_combat_step_effects(state, state.active_player);
-            for obj in state.objects.iter_mut().map(|(_, v)| v) {
-                obj.replacement_definitions
-                    .retain(|r| !matches!(r.expiry, Some(RestrictionExpiry::EndOfCombat)));
-            }
-            state
-                .pending_damage_replacements
-                .retain(|r| !matches!(r.expiry, Some(RestrictionExpiry::EndOfCombat)));
             if triggers_fired {
                 // CR 603.3b: surface a same-controller ordering prompt before priority.
                 if let Some(prompt) = ordering_prompt {
@@ -3166,7 +3160,14 @@ mod tests {
         state.current_combat_attacker_restriction_source = Some(ObjectId(99));
         let mut events = Vec::new();
 
-        let _ = advance_after_empty_attackers(&mut state, &mut events);
+        let waiting = advance_after_empty_attackers(&mut state, &mut events);
+
+        assert_eq!(state.phase, Phase::EndCombat);
+        assert!(matches!(waiting, WaitingFor::Priority { .. }));
+        assert!(state.current_combat_attacker_restriction.is_some());
+
+        apply(&mut state, PlayerId(0), GameAction::PassPriority).unwrap();
+        apply(&mut state, PlayerId(1), GameAction::PassPriority).unwrap();
 
         assert!(state.current_combat_attacker_restriction.is_none());
         assert!(state.current_combat_attacker_restriction_source.is_none());

--- a/crates/engine/tests/integration/issue_3279_song_of_dryads.rs
+++ b/crates/engine/tests/integration/issue_3279_song_of_dryads.rs
@@ -108,6 +108,9 @@ fn issue_3279_song_of_dryads_strips_enchanted_permanent_abilities() {
 
     runner.pass_both_players();
     runner.pass_both_players();
+    // CR 511.1: the no-attacker combat still enters EndCombat and exposes its
+    // priority window before PostCombatMain.
+    runner.pass_both_players();
     assert_eq!(runner.state().phase, Phase::PostCombatMain);
     assert!(
         !matches!(

--- a/crates/engine/tests/integration/last_night_together_restricted_combat.rs
+++ b/crates/engine/tests/integration/last_night_together_restricted_combat.rs
@@ -132,6 +132,10 @@ fn last_night_together_restricts_additional_combat_to_chosen_creatures() {
         .expect("declaring the chosen attackers must be accepted");
     let _ = runner.combat_damage();
 
+    // `combat_damage()` intentionally stops when EndCombat opens its priority
+    // window. Pass that window before checking the transition out of combat.
+    runner.pass_both_players();
+
     // CR 511.3: once that combat phase is over, its restriction ends.
     assert!(
         runner.state().current_combat_attacker_restriction.is_none(),

--- a/crates/engine/tests/integration/loop_shortcut.rs
+++ b/crates/engine/tests/integration/loop_shortcut.rs
@@ -9609,7 +9609,7 @@ fn bloodloop_state(players: u8) -> GameState {
 /// commit CHANGED; pinning it is what stops a later change from moving it silently.
 #[test]
 fn bloodloop_mandatory_draw_cascade_offers_at_2p_3p_and_4p() {
-    for (players, expected_beat, expected_turn) in [(2u8, 33usize, 4u32), (3, 67, 5), (4, 113, 6)] {
+    for (players, expected_beat, expected_turn) in [(2u8, 37usize, 4u32), (3, 76, 5), (4, 129, 6)] {
         let mut state = bloodloop_state(players);
         let beat = drive_to_bounded_offer(&mut state, 400).unwrap_or_else(|| {
             panic!(


### PR DESCRIPTION
## Summary

Fixes combat phase stops during auto-pass. Combat Damage and End Combat now expose their normal priority windows so configured stops can interrupt auto-pass, while the frontend keeps Declare Attackers and Declare Blockers controls visible when an auto-pass session is armed. End Combat state now remains live through its priority window and is torn down only when the step ends.

## Files changed

- client/src/components/board/ActionButton.tsx
- client/src/components/board/__tests__/ActionButton.test.tsx
- crates/engine/src/game/engine_phase_trigger_regression_tests.rs
- crates/engine/src/game/engine_tests.rs
- crates/engine/src/game/turns.rs
- crates/engine/tests/integration/issue_3279_song_of_dryads.rs
- crates/engine/tests/integration/last_night_together_restricted_combat.rs
- crates/engine/tests/integration/loop_shortcut.rs

## Track

Developer

## LLM

Model: GPT-5.6 Luna (via GitHub Copilot; canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver, targeting, rules behavior — is expected to go through `/engine-implementer`.
> This change follows that engine implementation pipeline, including an independent blocker review and fix round.

## CR references

CR 117.3a, CR 508.8, CR 510.4, CR 511.1, CR 511.2, CR 511.3, CR 724.2d, CR 724.2e.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — passed on the merged head.
- `cargo clippy --all-targets -- -D warnings` — passed on the merged head.
- `cargo test -p phase-engine` — 18,901 unit tests passed, 4,851 integration tests passed, 0 failed; auxiliary test binaries passed (21 and 9 tests); doc-test harness completed with 7 ignored tests and 0 failures.
- `./scripts/gen-card-data.sh` with `MTGJSON_SKIP_REFRESH=1` — completed on the merged head using the complete local MTGJSON cache; 35,798 faces indexed, 31,794 cards supported, 992 existing parser warnings across 3 categories.
- `cargo coverage` — 31,794 of 35,798 cards supported (88.815%).
- `cargo semantic-audit` — completed for 32,753 cards with the existing baseline of 266 findings; no parser files or card parse behavior changed in this PR.
- Merged-source frontend protocol/type-check — passed.
- Merged-source ESLint — 0 errors and 30 existing warnings.
- Merged-source Vitest — 297 test files passed, 3 skipped; 2,698 tests passed, 12 todo.
- The initial PR CI failures were infrastructure-only: Rust shard 4 and Card data failed while downloading the `sccache` binary with `socket hang up`, before compilation or tests. No source failure was reported. CI is rerunning for the updated head.

## Gate A

Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=08340f1b64018993a7fce0c9f82e74fa4ae5b368 base=dae3de6c1e95c71c872270510d4f75016dcb8662

## Anchored on

- crates/engine/src/game/turns.rs:2825 — existing Upkeep turn-interpreter branch that returns the active-player priority window after step actions and triggers.
- crates/engine/src/game/turns.rs:2866 — existing Draw turn-interpreter branch that follows the same priority-window pattern.
- client/src/components/board/ActionButton.tsx:334 — existing Declare Blockers controls remain available while an auto-pass session is armed.

## Final review-impl

Final review-impl PASS head=08340f1b64018993a7fce0c9f82e74fa4ae5b368

The maintainer blocker was independently validated and fixed: normal End Combat teardown is centralized in `complete_end_combat_teardown` and runs when `advance_phase_once` leaves End Combat, while explicit combat skips reuse the same helper. The regression test proves combat and the attacker restriction remain live during End Combat priority and clear after the pass loop.

## Claimed parse impact

None.

## Scope Expansion

None. The blocker fix remains within combat phase-stop and phase-transition behavior.

## Validation Failures

None.

## CI Failures

None unresolved. The prior failed CI jobs were external `sccache` download/bootstrap failures, not code or test failures; the updated head has been pushed for a fresh CI run.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Combat controls remain available while auto-pass is enabled, including “Attack with All” and “Attack with None.”
  * Empty-attacker combat now correctly pauses during combat-damage and end-of-combat priority windows.
  * End-of-combat triggers and cleanup now resolve before advancing to the next phase.
  * Fixed combat progression when inserted phases occur during end-of-combat processing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->