### PR TITLE
test(engine): cover Serra reanimation choice

### DIFF
--- a/crates/engine/tests/integration/issue_6769_serras_emissary_reanimation.rs
+++ b/crates/engine/tests/integration/issue_6769_serras_emissary_reanimation.rs
@@ -1,0 +1,67 @@
+//! Issue #6769 — Serra's Emissary's as-enters card-type choice must be offered
+//! when it returns from a graveyard.
+//!
+//! The report described a missing ETB trigger, but Serra's Emissary actually
+//! has an as-enters replacement effect (CR 614.1c), so this regression drives
+//! the replacement-choice path rather than an ETB trigger.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::ChoiceType;
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const SERRA_ORACLE: &str = "Flying\nAs this creature enters, choose a card type.\nYou and creatures you control have protection from the chosen card type.";
+const REANIMATE_ORACLE: &str =
+    "Return target creature card from your graveyard to the battlefield.";
+
+#[test]
+fn issue_6769_reanimated_serras_emissary_prompts_for_card_type() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let emissary = scenario
+        .add_creature_to_graveyard(P0, "Serra's Emissary", 7, 7)
+        .from_oracle_text(SERRA_ORACLE)
+        .id();
+    let reanimate = scenario
+        .add_spell_to_hand_from_oracle(P0, "Reanimate", false, REANIMATE_ORACLE)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    let mut runner = scenario.build();
+
+    runner.cast(reanimate).target_object(emissary).resolve();
+
+    let WaitingFor::NamedChoice {
+        choice_type,
+        source: Some(source),
+        ..
+    } = runner.state().waiting_for.clone()
+    else {
+        panic!(
+            "reanimated Serra's Emissary must pause for its card-type choice, got {}",
+            runner.waiting_for_kind()
+        );
+    };
+    assert!(
+        matches!(choice_type, ChoiceType::CardType { .. }),
+        "Serra's Emissary must offer a card-type choice, got {choice_type:?}"
+    );
+    assert_eq!(
+        source.prompt.identity.reference.object_id, emissary,
+        "the prompt must be bound to the entering Serra's Emissary"
+    );
+    runner
+        .act(GameAction::ChooseOption {
+            choice: "Artifact".to_string(),
+        })
+        .expect("choose Artifact for Serra's Emissary");
+    runner.advance_until_stack_empty();
+
+    let emissary = &runner.state().objects[&emissary];
+    assert_eq!(emissary.zone, Zone::Battlefield);
+    assert_eq!(emissary.chosen_card_type(), Some(CoreType::Artifact));
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -683,6 +683,7 @@ mod issue_6643_party_dude_opponents_attacked;
 mod issue_6677_wakandan_royal_guard;
 mod issue_6678_captain_america_shield_tap_defender;
 mod issue_6691_enters_under_their_control;
+mod issue_6769_serras_emissary_reanimation;
 mod issue_680_shalai_and_hallar_forgotten_ancient;
 mod issue_680_shalai_upkeep_move;
 mod issue_6858_draw_that_many_discard;


### PR DESCRIPTION
Adds a cast-pipeline regression for #6769: returning Serra’s Emissary from a graveyard must surface its engine-owned card-type choice, bind that choice to the entering permanent, and retain the selected type.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added coverage for Serra’s Emissary reanimation, including the card-type selection prompt.
  * Verified that choosing Artifact correctly applies to the reanimated creature as it enters the battlefield.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->