### PR TITLE
feat(probe-pin): probe-manifest runner that pins comment claims to measured evidence

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -31,6 +31,7 @@ tune-ai = "run --release --features tune --bin ai-tune --"
 ai-gate = "run --profile server-release --bin ai-gate --"
 ai-perf-gate = "run --profile server-release --bin ai-perf-gate --"
 engine-inventory = "run --quiet -p engine-inventory-gen"
+probe-pin = "run --quiet -p probe-pin --"
 
 [env]
 # 16 MB stack for test threads — prevents stack overflow when Debug formatting

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,6 +2280,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "probe-pin"
+version = "0.52.0"
+dependencies = [
+ "anyhow",
+ "clap",
+ "serde",
+ "serde_json",
+ "sha2",
+ "similar",
+ "tempfile",
+ "thiserror 2.0.18",
+ "toml",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Tiltfile
+++ b/Tiltfile
@@ -276,3 +276,20 @@ local_resource('probe-pin-check',
     allow_parallel = True,
     labels = ['lint'],
 )
+
+# The Tier-2 suite is #[ignore]d because GitHub's runners deny unprivileged user namespaces
+# (unshare -> /proc/self/uid_map EPERM), so GH CI never executes a real mount. THIS resource is
+# what keeps that honest: the local venue does have the capability, so Tier 2 runs here on every
+# change. Without it, "ignored in CI" quietly becomes "never run anywhere".
+#
+# `-- --ignored` runs ONLY the ignored tests, which is exactly this suite. A non-zero exit turns
+# the resource red like any other gate — a real Tier-2 gate, not a fire-and-forget reporter.
+local_resource('probe-pin-e2e',
+    cmd = ['bash', '-c',
+           'CARGO_TARGET_DIR=target/probe-pin cargo test -p probe-pin --test isolation_e2e -- --ignored'],
+    deps = ['crates/probe-pin/'],
+    ignore = TMP_IGNORE + ['**/tmp/**'],
+    auto_init = 'lint' in enabled,
+    allow_parallel = True,
+    labels = ['lint'],
+)

--- a/Tiltfile
+++ b/Tiltfile
@@ -284,9 +284,18 @@ local_resource('probe-pin-check',
 #
 # `-- --ignored` runs ONLY the ignored tests, which is exactly this suite. A non-zero exit turns
 # the resource red like any other gate — a real Tier-2 gate, not a fire-and-forget reporter.
+#
+# Its OWN CARGO_TARGET_DIR, not 'probe-pin-check''s. Both resources watch 'crates/probe-pin/', so
+# one edit triggers both, and both set allow_parallel — so Tilt may run them at once. Sharing a
+# target dir across them is not the disjoint-dep-tree case the comment above describes: each
+# isolation test shells a nested `cargo test --test pure_logic --no-run` into that dir while
+# `probe-pin check` resolves the same test binary out of it. The contention is cross-PROCESS, so
+# the in-process SERIAL mutex in isolation_e2e.rs does not span it, and the flake recorded there
+# has exactly this mechanism (artifact freshness). This is the only venue that executes Tier 2, so
+# a flake here is a gate reporting the wrong colour.
 local_resource('probe-pin-e2e',
     cmd = ['bash', '-c',
-           'CARGO_TARGET_DIR=target/probe-pin cargo test -p probe-pin --test isolation_e2e -- --ignored'],
+           'CARGO_TARGET_DIR=target/probe-pin-e2e cargo test -p probe-pin --test isolation_e2e -- --ignored'],
     deps = ['crates/probe-pin/'],
     ignore = TMP_IGNORE + ['**/tmp/**'],
     auto_init = 'lint' in enabled,

--- a/Tiltfile
+++ b/Tiltfile
@@ -257,3 +257,22 @@ local_resource('coverage',
     auto_init = False,
     labels = ['data'],
 )
+
+# The only local enforcement venue for `probe-pin check` (CI enrollment needs a workflow edit,
+# which is a hard stop). Measured cost: 6.25s cold, 0.11s incremental, 0.046s for 10 isolated
+# probe runs -- so an automatic trigger with narrow deps, not a manual knob. This price holds
+# ONLY while the manifest pins probe-pin's own test binary; an engine-census manifest is ~25s
+# of runs plus an engine build and must be re-priced before it is added here.
+local_resource('probe-pin-check',
+    # Separate CARGO_TARGET_DIR (same reason as 'clippy'): probe-pin's dep tree is disjoint
+    # from the engine's, so a shared dir would mutually invalidate fingerprints.
+    cmd = ['bash', '-c',
+           'CARGO_TARGET_DIR=target/probe-pin cargo probe-pin check crates/probe-pin/tests/fixtures/dogfood.toml'],
+    deps = ['crates/probe-pin/', 'docs/probe-pin.md'],
+    # TMP_IGNORE is a FILENAME glob ('**/*.tmp.*') and does not match a tmp/ DIRECTORY, so the
+    # Tier-2 tests' scratch writes under tests/fixtures/tmp/ would retrigger this resource.
+    ignore = TMP_IGNORE + ['**/tmp/**'],
+    auto_init = 'lint' in enabled,
+    allow_parallel = True,
+    labels = ['lint'],
+)

--- a/crates/probe-pin/Cargo.toml
+++ b/crates/probe-pin/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "probe-pin"
+version.workspace = true
+license.workspace = true
+edition = "2021"
+
+[dependencies]
+anyhow = "1"
+clap = { version = "4", features = ["derive"] }
+serde = { workspace = true }
+serde_json = "1"
+sha2 = "0.10"
+similar = "2"
+tempfile = "3"
+thiserror = "2"
+toml = "0.8"

--- a/crates/probe-pin/src/block.rs
+++ b/crates/probe-pin/src/block.rs
@@ -340,9 +340,29 @@ pub fn extract(text: &str, marker: &str, file: &Path) -> Result<String, Abort> {
 
 // ---------------------------------------------------------------- check
 
+/// A block's two regions, split by CONSTRUCTION order rather than by what a line says:
+/// `render` emits the BEGIN line, then exactly one `// instrument <tool> = <version>` line per
+/// recorded instrument, then everything that carries a measured number. Every line after that
+/// contiguous leading run is measured — including a projection sentence that happens to begin
+/// with the word `instrument`, which a whole-block prefix test read as an instrument line and
+/// silently dropped from the "a measured number moved" comparison, disabling the write refusal.
+/// One split, both consumers: the two classifications cannot disagree about a line.
+fn regions(block: &str) -> (Vec<&str>, Vec<&str>) {
+    let (mut header, mut measured) = (Vec::new(), Vec::new());
+    for line in block.lines().skip(1) {
+        if measured.is_empty() && line.starts_with("// instrument ") {
+            header.push(line);
+        } else {
+            measured.push(line);
+        }
+    }
+    (header, measured)
+}
+
 fn instrument_lines(block: &str) -> Vec<(Instrument, String)> {
-    block
-        .lines()
+    regions(block)
+        .0
+        .into_iter()
         .filter_map(|l| l.trim_end_matches('\r').strip_prefix("// instrument "))
         .filter_map(|rest| rest.split_once(" = "))
         .filter_map(|(name, version)| {
@@ -354,14 +374,11 @@ fn instrument_lines(block: &str) -> Vec<(Instrument, String)> {
         .collect()
 }
 
-/// Everything the block asserts about the world MINUS the two lines that name the tools and
-/// the digest: the table rows and the projection sentences. If these differ, a measured
-/// number moved.
+/// Everything the block asserts about the world MINUS the BEGIN line and the lines that name
+/// the tools: the table rows and the projection sentences. If these differ, a measured number
+/// moved.
 fn measured_lines(block: &str) -> Vec<&str> {
-    block
-        .lines()
-        .filter(|l| !l.starts_with("// instrument ") && !l.contains(":BEGIN manifest="))
-        .collect()
+    regions(block).1
 }
 
 fn changed_instruments(committed: &str, generated: &str) -> Vec<InstrumentChange> {

--- a/crates/probe-pin/src/block.rs
+++ b/crates/probe-pin/src/block.rs
@@ -1,0 +1,473 @@
+//! §7 step 12: the digest, the rendered block, the splice, and `check`'s drift classification.
+
+use std::path::{Path, PathBuf};
+
+use serde::Serialize;
+use similar::TextDiff;
+
+use crate::manifest::{Expect, Manifest, Mutation, Probe};
+use crate::verdict::Verdict;
+use crate::{sha256_hex, Abort, CheckOutcome, DriftCause, Instrument, InstrumentChange};
+
+/// What a probe's run produced. Rendering and the digest both read the manifest for the
+/// probe's inputs, so this carries only what was MEASURED.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Outcome {
+    pub id: String,
+    pub rc: i32,
+    pub verdict: Verdict,
+}
+
+/// A projection's measured count, paired with the declaration it came from.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ProjectionCount {
+    pub id: String,
+    pub count: usize,
+}
+
+// ---------------------------------------------------------------- digest
+
+#[derive(Serialize)]
+struct MutationInput<'a> {
+    kind: &'static str,
+    files: Vec<&'a str>,
+    find: Option<String>,
+    replace: Option<String>,
+    text: Option<String>,
+    repeat: Option<u32>,
+}
+
+#[derive(Serialize)]
+struct ProbeInput<'a> {
+    id: &'a str,
+    claim: &'a str,
+    mutations: Vec<MutationInput<'a>>,
+    assert_counts: Vec<(&'a str, &'a str, usize)>,
+    expect: &'a Expect,
+    rc: i32,
+    verdict: &'static str,
+    mounts_reached: Option<usize>,
+    provenance: Option<Vec<PathBuf>>,
+}
+
+#[derive(Serialize)]
+struct ProjectionInput<'a> {
+    id: &'a str,
+    pattern: &'a str,
+    paths: Vec<&'a str>,
+    count: usize,
+}
+
+#[derive(Serialize)]
+struct DigestInput<'a> {
+    manifest: &'a str,
+    target: &'a crate::manifest::Target,
+    output: &'a crate::manifest::Output,
+    probes: Vec<ProbeInput<'a>>,
+    control: &'a str,
+    projections: Vec<ProjectionInput<'a>>,
+    instruments: &'a [(Instrument, String)],
+}
+
+fn mutation_input(m: &Mutation) -> MutationInput<'_> {
+    match m {
+        Mutation::Replace {
+            file,
+            find,
+            replace,
+        } => MutationInput {
+            kind: "replace",
+            files: vec![file.as_str()],
+            find: Some(sha256_hex(find.as_bytes())),
+            replace: Some(sha256_hex(replace.as_bytes())),
+            text: None,
+            repeat: None,
+        },
+        Mutation::Prepend {
+            files,
+            text,
+            repeat,
+        } => MutationInput {
+            kind: "prepend",
+            files: files.iter().map(String::as_str).collect(),
+            find: None,
+            replace: None,
+            text: Some(sha256_hex(text.as_bytes())),
+            repeat: Some(*repeat),
+        },
+    }
+}
+
+/// `sha256(serde_json::to_vec(&DigestInput))`, truncated to 16 hex.
+///
+/// There is no hand-rolled joiner to review: JSON escaping IS the injection safety (a NUL in
+/// an id serializes as `\u0000`) and declaration order IS the canonical order. The digest pins
+/// what was MEASURED — the whole `[target]`, `[output]`, and every projection's pattern and
+/// sorted paths — not just the outcomes, so narrowing a filter or subsetting a projection's
+/// paths flips it even when every verdict and count is identical. Excluded: `:line:col`,
+/// durations, PIDs, absolute paths, completion order.
+pub fn digest(
+    manifest: &Manifest,
+    manifest_rel: &str,
+    outcomes: &[Outcome],
+    counts: &[ProjectionCount],
+    instruments: &[(Instrument, String)],
+) -> anyhow::Result<String> {
+    let probes = manifest
+        .probes
+        .iter()
+        .map(|p| {
+            let outcome = outcomes.iter().find(|o| o.id == p.id);
+            let verdict = outcome.map(|o| &o.verdict);
+            ProbeInput {
+                id: &p.id,
+                claim: &p.claim,
+                mutations: p.mutations.iter().map(mutation_input).collect(),
+                assert_counts: p
+                    .assert_counts
+                    .iter()
+                    .map(|a| (a.file.as_str(), a.text.as_str(), a.count))
+                    .collect(),
+                expect: &p.expect,
+                rc: outcome.map(|o| o.rc).unwrap_or(-1),
+                verdict: match verdict {
+                    Some(Verdict::Pass { .. }) => "pass",
+                    Some(Verdict::Fail { .. }) => "fail",
+                    None => "unmeasured",
+                },
+                mounts_reached: match verdict {
+                    Some(Verdict::Pass { mounts_reached }) => Some(*mounts_reached),
+                    _ => None,
+                },
+                provenance: match verdict {
+                    Some(Verdict::Fail { provenance }) => Some(provenance.clone()),
+                    _ => None,
+                },
+            }
+        })
+        .collect();
+    let projections = manifest
+        .projections
+        .iter()
+        .map(|p| {
+            let mut paths: Vec<&str> = p.paths.iter().map(String::as_str).collect();
+            paths.sort_unstable();
+            ProjectionInput {
+                id: &p.id,
+                pattern: &p.pattern,
+                paths,
+                count: counts.iter().find(|c| c.id == p.id).map_or(0, |c| c.count),
+            }
+        })
+        .collect();
+    let input = DigestInput {
+        manifest: manifest_rel,
+        target: &manifest.target,
+        output: &manifest.output,
+        probes,
+        control: &manifest.control().id,
+        projections,
+        instruments,
+    };
+    let bytes = serde_json::to_vec(&input)?;
+    Ok(sha256_hex(&bytes)[..16].to_string())
+}
+
+// ---------------------------------------------------------------- render
+
+fn cell(text: &str) -> String {
+    text.replace('|', "\\|")
+}
+
+/// `visibility.rs ×1` / `engine.rs ×2 (seq)` / `(none)` for the control.
+pub fn mutation_cell(probe: &Probe) -> String {
+    if probe.mutations.is_empty() {
+        return "(none)".to_string();
+    }
+    let mut sequential = false;
+    let parts: Vec<String> = probe
+        .touched()
+        .iter()
+        .map(|rel| {
+            let n = probe
+                .mutations
+                .iter()
+                .filter(|m| m.files().iter().any(|f| f == rel))
+                .count();
+            sequential |= n > 1;
+            let base = Path::new(rel)
+                .file_name()
+                .map_or(rel.as_str(), |s| s.to_str().unwrap_or(rel.as_str()));
+            format!("{base} ×{n}")
+        })
+        .collect();
+    format!(
+        "{}{}",
+        parts.join(", "),
+        if sequential { " (seq)" } else { "" }
+    )
+}
+
+fn firing_cell(probe: &Probe, verdict: &Verdict) -> String {
+    match verdict {
+        Verdict::Pass { mounts_reached: 0 } => "(control; no mounts)".to_string(),
+        Verdict::Pass { mounts_reached } => format!("mount reached: {mounts_reached} file(s)"),
+        Verdict::Fail { .. } => probe.anchors().join(" / "),
+    }
+}
+
+fn provenance_cell(verdict: &Verdict) -> String {
+    match verdict {
+        Verdict::Pass { .. } => "—".to_string(),
+        Verdict::Fail { provenance } if provenance.is_empty() => "—".to_string(),
+        Verdict::Fail { provenance } => provenance
+            .iter()
+            .map(|p| p.display().to_string())
+            .collect::<Vec<_>>()
+            .join(", "),
+    }
+}
+
+/// Byte-deterministic by construction: probes are iterated through the manifest's declaration
+/// `Vec` (never a `HashMap`), and `[target].env` is a `BTreeMap`, so two parses of the same
+/// manifest render identical bytes.
+pub fn render(
+    manifest: &Manifest,
+    manifest_rel: &str,
+    digest: &str,
+    instruments: &[(Instrument, String)],
+    outcomes: &[Outcome],
+    counts: &[ProjectionCount],
+) -> String {
+    let marker = &manifest.output.marker;
+    let mut out = String::new();
+    out.push_str(&format!(
+        "// {marker}:BEGIN manifest={manifest_rel} digest=sha256:{digest}\n"
+    ));
+    for (instrument, version) in instruments {
+        out.push_str(&format!("// instrument {instrument} = {version}\n"));
+    }
+    out.push_str(
+        "// | probe | mutation | expect | verdict | firing assertion (anchor) | provenance |\n",
+    );
+    out.push_str("// |---|---|---|---|---|---|\n");
+    for probe in &manifest.probes {
+        let Some(outcome) = outcomes.iter().find(|o| o.id == probe.id) else {
+            continue;
+        };
+        let expect = match probe.expect {
+            Expect::Pass {} => "pass",
+            Expect::Fail { .. } => "fail",
+        };
+        let verdict = match outcome.verdict {
+            Verdict::Pass { .. } => "pass",
+            Verdict::Fail { .. } => "fail",
+        };
+        out.push_str(&format!(
+            "// | {} | {} | {expect} | {verdict} | {} | {} |\n",
+            cell(&probe.id),
+            cell(&mutation_cell(probe)),
+            cell(&firing_cell(probe, &outcome.verdict)),
+            cell(&provenance_cell(&outcome.verdict)),
+        ));
+    }
+    for projection in &manifest.projections {
+        let count = counts
+            .iter()
+            .find(|c| c.id == projection.id)
+            .map_or(0, |c| c.count);
+        out.push_str(&format!(
+            "// {}\n",
+            crate::project::sentence(projection, count)
+        ));
+    }
+    out.push_str("// probe-pin validates only the lines between BEGIN and END. Prose outside is never checked.\n");
+    out.push_str(&format!("// {marker}:END"));
+    out
+}
+
+/// Which instruments this run may record, in `Instrument` declaration order.
+pub fn used_instruments(manifest: &Manifest) -> Vec<Instrument> {
+    let mut v = vec![Instrument::Toolchain];
+    if !manifest.projections.is_empty() {
+        v.push(Instrument::AstGrep);
+    }
+    v
+}
+
+// ---------------------------------------------------------------- splice
+
+/// Byte offsets of the BEGIN line's start and the END line's last content byte. Everything
+/// outside that span — prose above, prose below, and the END line's own terminator — is the
+/// caller's to copy verbatim.
+pub fn locate(text: &str, marker: &str, file: &Path) -> Result<(usize, usize), Abort> {
+    let begin_tag = format!("{marker}:BEGIN");
+    let end_tag = format!("{marker}:END");
+    let (mut begins, mut ends) = (0usize, 0usize);
+    let (mut begin_at, mut end_at) = (None, None);
+    let mut offset = 0usize;
+    for line in text.split_inclusive('\n') {
+        let content = line.trim_end_matches('\n').trim_end_matches('\r');
+        if content.contains(&begin_tag) {
+            begins += 1;
+            begin_at.get_or_insert(offset);
+        }
+        if content.contains(&end_tag) {
+            ends += 1;
+            end_at.get_or_insert(offset + content.len());
+        }
+        offset += line.len();
+    }
+    match (begin_at, end_at) {
+        (Some(b), Some(e)) if begins == 1 && ends == 1 && b < e => Ok((b, e)),
+        _ => Err(Abort::MarkerNotUnique {
+            file: file.to_path_buf(),
+            begins,
+            ends,
+        }),
+    }
+}
+
+pub fn splice(text: &str, marker: &str, file: &Path, block: &str) -> Result<String, Abort> {
+    let (begin, end) = locate(text, marker, file)?;
+    Ok(format!("{}{block}{}", &text[..begin], &text[end..]))
+}
+
+pub fn extract(text: &str, marker: &str, file: &Path) -> Result<String, Abort> {
+    let (begin, end) = locate(text, marker, file)?;
+    Ok(text[begin..end].to_string())
+}
+
+// ---------------------------------------------------------------- check
+
+fn instrument_lines(block: &str) -> Vec<(Instrument, String)> {
+    block
+        .lines()
+        .filter_map(|l| l.trim_end_matches('\r').strip_prefix("// instrument "))
+        .filter_map(|rest| rest.split_once(" = "))
+        .filter_map(|(name, version)| {
+            [Instrument::Toolchain, Instrument::AstGrep]
+                .into_iter()
+                .find(|i| i.tool() == name)
+                .map(|i| (i, version.to_string()))
+        })
+        .collect()
+}
+
+/// Everything the block asserts about the world MINUS the two lines that name the tools and
+/// the digest: the table rows and the projection sentences. If these differ, a measured
+/// number moved.
+fn measured_lines(block: &str) -> Vec<&str> {
+    block
+        .lines()
+        .filter(|l| !l.starts_with("// instrument ") && !l.contains(":BEGIN manifest="))
+        .collect()
+}
+
+fn changed_instruments(committed: &str, generated: &str) -> Vec<InstrumentChange> {
+    let old = instrument_lines(committed);
+    let new = instrument_lines(generated);
+    let mut out = Vec::new();
+    for (instrument, now) in &new {
+        // An instrument the committed block never recorded has not MOVED — there is no prior
+        // reading to conflict with. This is what makes the write refusal's documented escape
+        // work: reduce the block to a bare BEGIN/END pair and re-run.
+        let Some((_, was)) = old.iter().find(|(i, _)| i == instrument) else {
+            continue;
+        };
+        if was != now {
+            let was = was.clone();
+            out.push(InstrumentChange {
+                instrument: *instrument,
+                was,
+                now: now.clone(),
+            });
+        }
+    }
+    out
+}
+
+/// The measured-number deltas, for the write refusal's message.
+pub fn deltas(committed: &str, generated: &str) -> String {
+    let (old, new) = (measured_lines(committed), measured_lines(generated));
+    let mut out = Vec::new();
+    for change in TextDiff::from_slices(&old, &new).iter_all_changes() {
+        match change.tag() {
+            similar::ChangeTag::Delete => out.push(format!("- {}", change.value().trim())),
+            similar::ChangeTag::Insert => out.push(format!("+ {}", change.value().trim())),
+            similar::ChangeTag::Equal => {}
+        }
+    }
+    out.join(" ")
+}
+
+pub fn check(committed: &str, generated: &str) -> CheckOutcome {
+    if committed == generated {
+        return CheckOutcome::Clean;
+    }
+    let changed = changed_instruments(committed, generated);
+    let numbers_moved = measured_lines(committed) != measured_lines(generated);
+    CheckOutcome::Drift {
+        cause: if changed.is_empty() {
+            DriftCause::Code
+        } else {
+            DriftCause::Instrument(changed)
+        },
+        diff: TextDiff::from_lines(committed, generated)
+            .unified_diff()
+            .header("committed", "generated")
+            .to_string(),
+        numbers_moved,
+    }
+}
+
+/// `run --write` refuses IFF an instrument moved AND a measured number moved — exactly when
+/// attribution is impossible AND obeying would destroy the evidence of which one changed it.
+/// Escaping needs no new flag: delete the block and re-run, which shows up in the PR diff.
+pub fn write_refusal(outcome: &CheckOutcome, committed: &str, generated: &str) -> Option<Abort> {
+    match outcome {
+        CheckOutcome::Drift {
+            cause: DriftCause::Instrument(changed),
+            numbers_moved: true,
+            ..
+        } => Some(Abort::WriteUnderInstrumentChange {
+            changed: changed.clone(),
+            deltas: deltas(committed, generated),
+        }),
+        _ => None,
+    }
+}
+
+/// 0 clean, 1 drift. Never 2: an abort is an instrument failure and never reaches `check`.
+pub fn exit_code(outcome: &CheckOutcome) -> u8 {
+    match outcome {
+        CheckOutcome::Clean => 0,
+        CheckOutcome::Drift { .. } => 1,
+    }
+}
+
+pub fn report(outcome: &CheckOutcome, manifest_rel: &str) -> String {
+    match outcome {
+        CheckOutcome::Clean => String::new(),
+        CheckOutcome::Drift {
+            cause,
+            diff,
+            numbers_moved,
+        } => {
+            let head = match cause {
+                DriftCause::Code => "probe-pin: the generated block is stale.".to_string(),
+                DriftCause::Instrument(changed) => format!(
+                    "probe-pin: the generated block differs AND {} instrument(s) moved: {}. {}",
+                    changed.len(),
+                    crate::describe_changes(changed),
+                    if *numbers_moved {
+                        "A measured number moved too, so which one changed it cannot be attributed."
+                    } else {
+                        "Measured numbers are unchanged, so this is an instrument change, not code drift."
+                    }
+                ),
+            };
+            format!("{diff}\n{head} Re-run: cargo probe-pin run --write {manifest_rel}")
+        }
+    }
+}

--- a/crates/probe-pin/src/block.rs
+++ b/crates/probe-pin/src/block.rs
@@ -135,13 +135,16 @@ pub fn digest(
                     Some(Verdict::Fail { .. }) => "fail",
                     None => "unmeasured",
                 },
+                // Exhaustive, never `_`: these two fields are what the digest PINS about a
+                // measurement, and a wildcard would silently record `None` — an unmeasured
+                // probe's own value — for a future verdict shape nobody revisited here.
                 mounts_reached: match verdict {
                     Some(Verdict::Pass { mounts_reached }) => Some(*mounts_reached),
-                    _ => None,
+                    Some(Verdict::Fail { .. }) | None => None,
                 },
                 provenance: match verdict {
                     Some(Verdict::Fail { provenance }) => Some(provenance.clone()),
-                    _ => None,
+                    Some(Verdict::Pass { .. }) | None => None,
                 },
             }
         })

--- a/crates/probe-pin/src/block.rs
+++ b/crates/probe-pin/src/block.rs
@@ -211,9 +211,24 @@ pub fn mutation_cell(probe: &Probe) -> String {
     )
 }
 
+/// Keyed on probe IDENTITY, never on the measured count.
+///
+/// `mutation_cell` decides "this is the control" from `probe.mutations.is_empty()`, which is the
+/// definition — `validate` requires exactly one probe with no mutations. Deciding the same fact
+/// here from `mounts_reached == 0` made two discriminators for one concept in adjacent functions,
+/// agreeing only through a property of the current call graph: `main` passes a literal `0` for the
+/// control and `mounts.len()` for every other probe, and `validate` refuses an empty mutation file
+/// list, so a mutation probe cannot reach `0` today.
+///
+/// That is a coincidence to rest an evidence artifact on, not a guarantee. Any future path
+/// yielding a probe with mutations but no materialized mount would render `(control; no mounts)`
+/// for a MUTATION probe — a false claim in a committed block, and one no digest catches, because
+/// the digest pins `mounts_reached` and would agree with it. A row says what a probe IS; the count
+/// says what the run reached. Rendered output is unchanged (measured: the dogfood block and its
+/// digest are byte-identical across this change).
 fn firing_cell(probe: &Probe, verdict: &Verdict) -> String {
     match verdict {
-        Verdict::Pass { mounts_reached: 0 } => "(control; no mounts)".to_string(),
+        Verdict::Pass { .. } if probe.mutations.is_empty() => "(control; no mounts)".to_string(),
         Verdict::Pass { mounts_reached } => format!("mount reached: {mounts_reached} file(s)"),
         Verdict::Fail { .. } => probe.anchors().join(" / "),
     }
@@ -256,6 +271,31 @@ pub fn render(
     out.push_str("// |---|---|---|---|---|---|\n");
     for probe in &manifest.probes {
         let Some(outcome) = outcomes.iter().find(|o| o.id == probe.id) else {
+            // An outcome-less probe gets a VISIBLE row saying so, matching what `digest` already
+            // records for the same input (`rc = -1`, `verdict = "unmeasured"`).
+            //
+            // This used to `continue`, which made the two consumers of one probe list disagree
+            // about what a missing outcome MEANS — in the direction this crate exists to refuse.
+            // A manifest declares N probes, the block shows N-1 rows, and `check` reports CLEAN,
+            // because the committed and the generated block omit the same row and stamp the same
+            // digest. Evidence disappears and nothing is loud.
+            //
+            // Not reachable through `main` today: `record` routes an expectation mismatch to
+            // `mismatches` rather than `outcomes`, and `pipeline` returns at that gate
+            // (`main.rs:190`) before `render` runs. An `unreachable!` was tried here and was
+            // wrong — `render` is public and tests legitimately call it with `&[]` outcomes to
+            // inspect projection sentences, so the panic fired on correct use. A function whose
+            // contract only holds for one caller's call order should not be enforcing that order;
+            // it should represent the state it can actually be handed.
+            out.push_str(&format!(
+                "// | {} | {} | {} | unmeasured | (not measured) | — |\n",
+                cell(&probe.id),
+                cell(&mutation_cell(probe)),
+                match probe.expect {
+                    Expect::Pass {} => "pass",
+                    Expect::Fail { .. } => "fail",
+                },
+            ));
             continue;
         };
         let expect = match probe.expect {

--- a/crates/probe-pin/src/block.rs
+++ b/crates/probe-pin/src/block.rs
@@ -331,9 +331,25 @@ pub fn locate(text: &str, marker: &str, file: &Path) -> Result<(usize, usize), A
     }
 }
 
+/// Splices `block` over the marked span, and refuses to return a result the next `locate` could
+/// not find.
+///
+/// The postcondition is checked HERE, at the write surface, and not only on the manifest fields
+/// that feed `render`. Validation of those fields is necessary and is done — but it can only
+/// cover values probe-pin can see before the run. Two producers reach a rendered line and cannot
+/// be refused in advance: an instrument's `--version` output, and the `provenance` paths lifted
+/// from the target's own panic text. If any producer emits a marker tag, `run --write` would
+/// otherwise commit a block that its own next `check` aborts on with `MarkerNotUnique` — a pin
+/// that can only be recovered by editing the file by hand, which is the regenerable-artifact
+/// guarantee failing exactly where it is supposed to hold.
+///
+/// So the invariant is stated against the bytes actually being written, where it is unconditional:
+/// whatever produced this text, the file probe-pin is about to commit is one `check` can locate.
 pub fn splice(text: &str, marker: &str, file: &Path, block: &str) -> Result<String, Abort> {
     let (begin, end) = locate(text, marker, file)?;
-    Ok(format!("{}{block}{}", &text[..begin], &text[end..]))
+    let spliced = format!("{}{block}{}", &text[..begin], &text[end..]);
+    locate(&spliced, marker, file)?;
+    Ok(spliced)
 }
 
 pub fn extract(text: &str, marker: &str, file: &Path) -> Result<String, Abort> {

--- a/crates/probe-pin/src/isolate.rs
+++ b/crates/probe-pin/src/isolate.rs
@@ -49,9 +49,29 @@ pub fn exit_rc(status: &std::process::ExitStatus) -> i32 {
         .unwrap_or_else(|| 128 + status.signal().unwrap_or(0))
 }
 
+/// The flags probe-pin itself puts on the target's argv. Everything else on that command line
+/// came from `Target::manifest_argv`, which is what `manifest::validate` checks.
+pub const OWNED_FLAGS: &[&str] = &[
+    "--exact",
+    "--test-threads=1",
+    "--format",
+    "json",
+    "-Z",
+    "unstable-options",
+];
+
 /// `[filter] + ["--exact"] iff Exact + [the flags probe-pin owns] + [target].args`.
+///
+/// The manifest's contribution is taken from `Target::manifest_argv` rather than read out of
+/// the fields again: that function is the single authority for WHICH manifest values reach a
+/// target's command line, and validation checks the same list. Reading `target.filter` here
+/// directly is exactly how `filter` came to be argv token 0 with nothing validating it.
 pub fn argv(target: &Target) -> Vec<String> {
-    let mut v = vec![target.filter.clone()];
+    let contributed = target.manifest_argv();
+    let ((_, filter), args) = contributed
+        .split_first()
+        .expect("manifest_argv yields the filter first, then [target].args");
+    let mut v = vec![(*filter).to_string()];
     if target.filter_match == FilterMatch::Exact {
         v.push("--exact".to_string());
     }
@@ -64,8 +84,35 @@ pub fn argv(target: &Target) -> Vec<String> {
     ] {
         v.push(flag.to_string());
     }
-    v.extend(target.args.iter().cloned());
+    v.extend(args.iter().map(|(_, a)| (*a).to_string()));
     v
+}
+
+/// The ambient keys the target child keeps. Everything else is cleared.
+const INHERITED: &[&str] = &["PATH", "HOME"];
+
+/// The variables `run_with_script` hands the SCRIPT, which reads them by these exact names.
+/// The mutant/target pair is one variable per mount, so those two are prefixes.
+const SCRIPT_VARS: &[&str] = &["PP_MOUNTS", "TIMEOUT", "TESTBIN"];
+const SCRIPT_VAR_PREFIXES: &[&str] = &["PP_MUTANT_", "PP_TARGET_"];
+
+/// Does probe-pin itself set this environment variable in the target child? The single
+/// authority for "[target].env may not override this", derived from the two places that set
+/// one — and pinned by `env_keys_probe_pin_sets_are_all_refused`, which builds a real child
+/// command through the shipping path and asserts every key it sets is refused here.
+///
+/// `PATH` is the severe one: the child is `unshare … bash -c SCRIPT`, so `PATH` resolves
+/// `mount`, `cmp` and `timeout` INSIDE the script — a manifest that sets it to a directory of
+/// stubs renders `mount reached: 1 file(s)` for a probe whose mutant was never mounted and
+/// never compared (measured: exit 0, green).
+///
+/// `RUST_MIN_STACK` is deliberately absent: `apply_child_env` sets it as a DEFAULT that
+/// `[target].env` is documented and tested to raise, and lowering it cannot forge a green row —
+/// the target dies mid-run and `HarnessIncomplete` fires.
+pub fn is_probe_pin_owned_env(key: &str) -> bool {
+    INHERITED.contains(&key)
+        || SCRIPT_VARS.contains(&key)
+        || SCRIPT_VAR_PREFIXES.iter().any(|p| key.starts_with(p))
 }
 
 /// The step-8 target run's environment is CONSTRUCTED, not inherited: two developers with
@@ -78,7 +125,7 @@ pub fn argv(target: &Target) -> Vec<String> {
 /// from a cleared environment, libtest reads it as off; `[target].env` can still turn it on.
 pub fn apply_child_env(cmd: &mut Command, target: &Target) {
     cmd.env_clear();
-    for key in ["PATH", "HOME"] {
+    for key in INHERITED {
         if let Ok(v) = std::env::var(key) {
             cmd.env(key, v);
         }
@@ -93,15 +140,15 @@ pub fn run(testbin: &Path, mounts: &[Mount], target: &Target) -> Result<Run, Abo
     run_with_script(SCRIPT, testbin, mounts, target)
 }
 
-/// Split out so §10 rows 1, 2 and 21 can run their DROP arms — each of which is defined as a
-/// mutation OF THIS SCRIPT (drop the readback / compare the mutant with itself / copy instead
-/// of mount) rather than a mutation of the caller.
-pub fn run_with_script(
-    script: &str,
-    testbin: &Path,
-    mounts: &[Mount],
-    target: &Target,
-) -> Result<Run, Abort> {
+/// The target child, fully constructed and not yet spawned. Split out from `run_with_script`
+/// so a test can read back — through `Command::get_envs` — exactly which variables probe-pin
+/// sets, and prove `is_probe_pin_owned_env` refuses every one of them. A hand-maintained list
+/// checked against a hand-maintained list proves nothing; this one is checked against the
+/// command that actually runs.
+///
+/// The probe-pin-owned variables are applied AFTER `apply_child_env`, so `[target].env` cannot
+/// win by ordering either — belt and braces, since validation now refuses them by name.
+pub fn child_command(script: &str, testbin: &Path, mounts: &[Mount], target: &Target) -> Command {
     let mut cmd = Command::new("unshare");
     cmd.args(["--map-root-user", "--mount", "bash", "-c"])
         .arg(script)
@@ -115,10 +162,24 @@ pub fn run_with_script(
     }
     cmd.env("TIMEOUT", target.timeout_secs.to_string());
     cmd.env("TESTBIN", testbin);
-    let out = cmd.output().map_err(|e| Abort::IsolationUnavailable {
-        rc: None,
-        stderr: e.to_string(),
-    })?;
+    cmd
+}
+
+/// Split out so §10 rows 1, 2 and 21 can run their DROP arms — each of which is defined as a
+/// mutation OF THIS SCRIPT (drop the readback / compare the mutant with itself / copy instead
+/// of mount) rather than a mutation of the caller.
+pub fn run_with_script(
+    script: &str,
+    testbin: &Path,
+    mounts: &[Mount],
+    target: &Target,
+) -> Result<Run, Abort> {
+    let out = child_command(script, testbin, mounts, target)
+        .output()
+        .map_err(|e| Abort::IsolationUnavailable {
+            rc: None,
+            stderr: e.to_string(),
+        })?;
     Ok(Run {
         rc: exit_rc(&out.status),
         stdout: String::from_utf8_lossy(&out.stdout).into_owned(),

--- a/crates/probe-pin/src/isolate.rs
+++ b/crates/probe-pin/src/isolate.rs
@@ -1,0 +1,173 @@
+//! §7 steps 5, 6 and 8: the scratch dir, the fingerprints, and the isolated target run.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use tempfile::TempDir;
+
+use crate::manifest::{FilterMatch, Target};
+use crate::mutate::Mount;
+use crate::{sha256_hex, Abort};
+
+/// The whole script. Four probe-pin-owned variables reach it through the child's ENVIRONMENT
+/// (`$MUTANT`/`$TARGET` indexed per mount, `$TIMEOUT`, `$TESTBIN`), never as positionals — so
+/// `"$@"` is exactly the target's argv and shell quoting never touches user-supplied `args`.
+///
+/// The `cmp -s` readback is the whole reason a `pass` verdict means anything: it proves the
+/// bytes the target can see at `$TARGET` are the mutant's, inside the namespace, after the
+/// mount. `set -eu` makes a missing `timeout`/`mount`/`cmp` a non-zero exit, never a silent
+/// unmounted run.
+pub const SCRIPT: &str = r#"set -eu
+i=0
+while [ "$i" -lt "$PP_MOUNTS" ]; do
+  m="PP_MUTANT_$i"; t="PP_TARGET_$i"
+  MUTANT=${!m}; TARGET=${!t}
+  mount --bind "$MUTANT" "$TARGET"
+  cmp -s "$MUTANT" "$TARGET" || { printf 'probe-pin: MOUNT NOT REACHED: %s (mutant %s)\n' "$TARGET" "$MUTANT" >&2; exit 97; }
+  i=$((i + 1))
+done
+exec timeout -k 5 "$TIMEOUT" "$TESTBIN" "$@"
+"#;
+
+/// Streams are never merged: stdout must stay a pure libtest JSON record stream, and a stack
+/// overflow's `fatal runtime error: …` arrives on stderr.
+#[derive(Debug, Clone)]
+pub struct Run {
+    pub rc: i32,
+    pub stdout: String,
+    pub stderr: String,
+}
+
+/// A signal-killed process has no exit CODE at all — `timeout` re-raises the child's signal
+/// rather than translating it. Every shell reports `128 + signal` for that, and so does
+/// probe-pin: a stack-overflow abort is the 134 that `HarnessIncomplete`'s message quotes.
+pub fn exit_rc(status: &std::process::ExitStatus) -> i32 {
+    use std::os::unix::process::ExitStatusExt;
+    status
+        .code()
+        .unwrap_or_else(|| 128 + status.signal().unwrap_or(0))
+}
+
+/// `[filter] + ["--exact"] iff Exact + [the flags probe-pin owns] + [target].args`.
+pub fn argv(target: &Target) -> Vec<String> {
+    let mut v = vec![target.filter.clone()];
+    if target.filter_match == FilterMatch::Exact {
+        v.push("--exact".to_string());
+    }
+    for flag in [
+        "--test-threads=1",
+        "--format",
+        "json",
+        "-Z",
+        "unstable-options",
+    ] {
+        v.push(flag.to_string());
+    }
+    v.extend(target.args.iter().cloned());
+    v
+}
+
+/// The step-8 target run's environment is CONSTRUCTED, not inherited: two developers with
+/// different shells get the same capture bytes. Scope is this run only — the cargo, rustc and
+/// ast-grep shell-outs inherit, because clearing them strips `CARGO_HOME`/`CARGO_TARGET_DIR`.
+///
+/// The ALLOWLIST is the single authority: `RUST_BACKTRACE` is not re-set to `"0"` here, because
+/// an unconditional set makes the clear untestable — it produces identical capture bytes whether
+/// or not `env_clear()` ran, which is exactly how row 12's backtrace arm went vacuous. Absent
+/// from a cleared environment, libtest reads it as off; `[target].env` can still turn it on.
+pub fn apply_child_env(cmd: &mut Command, target: &Target) {
+    cmd.env_clear();
+    for key in ["PATH", "HOME"] {
+        if let Ok(v) = std::env::var(key) {
+            cmd.env(key, v);
+        }
+    }
+    cmd.env("RUST_MIN_STACK", "16777216");
+    for (k, v) in &target.env {
+        cmd.env(k, v);
+    }
+}
+
+pub fn run(testbin: &Path, mounts: &[Mount], target: &Target) -> Result<Run, Abort> {
+    run_with_script(SCRIPT, testbin, mounts, target)
+}
+
+/// Split out so §10 rows 1, 2 and 21 can run their DROP arms — each of which is defined as a
+/// mutation OF THIS SCRIPT (drop the readback / compare the mutant with itself / copy instead
+/// of mount) rather than a mutation of the caller.
+pub fn run_with_script(
+    script: &str,
+    testbin: &Path,
+    mounts: &[Mount],
+    target: &Target,
+) -> Result<Run, Abort> {
+    let mut cmd = Command::new("unshare");
+    cmd.args(["--map-root-user", "--mount", "bash", "-c"])
+        .arg(script)
+        .arg("probe-pin")
+        .args(argv(target));
+    apply_child_env(&mut cmd, target);
+    cmd.env("PP_MOUNTS", mounts.len().to_string());
+    for (i, m) in mounts.iter().enumerate() {
+        cmd.env(format!("PP_MUTANT_{i}"), &m.mutant);
+        cmd.env(format!("PP_TARGET_{i}"), &m.target);
+    }
+    cmd.env("TIMEOUT", target.timeout_secs.to_string());
+    cmd.env("TESTBIN", testbin);
+    let out = cmd.output().map_err(|e| Abort::IsolationUnavailable {
+        rc: None,
+        stderr: e.to_string(),
+    })?;
+    Ok(Run {
+        rc: exit_rc(&out.status),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    })
+}
+
+/// §7 step 5. `TempDir` in `base` (`env::temp_dir()` in production), then the assert that
+/// probe-pin is not creating files under the tree it is measuring.
+pub fn scratch_dir(base: &Path, workspace: &Path) -> Result<TempDir, Abort> {
+    let dir = TempDir::new_in(base).map_err(|e| Abort::MaterializeFailed {
+        path: base.to_path_buf(),
+        err: e.to_string(),
+    })?;
+    let real = std::fs::canonicalize(dir.path()).unwrap_or_else(|_| dir.path().to_path_buf());
+    let ws = std::fs::canonicalize(workspace).unwrap_or_else(|_| workspace.to_path_buf());
+    if real.starts_with(&ws) {
+        return Err(Abort::ScratchInsideWorkspace {
+            scratch: real,
+            workspace: ws,
+        });
+    }
+    Ok(dir)
+}
+
+/// §7 steps 6 and 10: sha256 over the mutated file set only — scoped to the files probe-pin
+/// touches, so a concurrent agent editing anything else cannot discard this run.
+pub fn fingerprint(root: &Path, files: &[String]) -> anyhow::Result<BTreeMap<String, String>> {
+    let mut out = BTreeMap::new();
+    for rel in files {
+        let bytes = std::fs::read(root.join(rel))?;
+        out.insert(rel.clone(), sha256_hex(&bytes));
+    }
+    Ok(out)
+}
+
+pub fn verify_fingerprint(
+    before: &BTreeMap<String, String>,
+    after: &BTreeMap<String, String>,
+) -> Result<(), Abort> {
+    for (file, sha) in before {
+        let now = after.get(file).map(String::as_str).unwrap_or("<missing>");
+        if now != sha {
+            return Err(Abort::TreeMutated {
+                file: PathBuf::from(file),
+                before: sha.clone(),
+                after: now.to_string(),
+            });
+        }
+    }
+    Ok(())
+}

--- a/crates/probe-pin/src/isolate.rs
+++ b/crates/probe-pin/src/isolate.rs
@@ -18,13 +18,18 @@ use crate::{sha256_hex, Abort};
 /// bytes the target can see at `$TARGET` are the mutant's, inside the namespace, after the
 /// mount. `set -eu` makes a missing `timeout`/`mount`/`cmp` a non-zero exit, never a silent
 /// unmounted run.
+///
+/// Two exit codes are RESERVED for the script itself, and `verdict::observe` classifies both
+/// before it ever looks at the record stream: 97 = the mount readback failed, 96 = the script
+/// failed before the target was reached at all.
 pub const SCRIPT: &str = r#"set -eu
+trap 'printf "probe-pin: ISOLATION SCRIPT FAILED before the target ran\n" >&2; exit 96' EXIT
 i=0
 while [ "$i" -lt "$PP_MOUNTS" ]; do
   m="PP_MUTANT_$i"; t="PP_TARGET_$i"
   MUTANT=${!m}; TARGET=${!t}
   mount --bind "$MUTANT" "$TARGET"
-  cmp -s "$MUTANT" "$TARGET" || { printf 'probe-pin: MOUNT NOT REACHED: %s (mutant %s)\n' "$TARGET" "$MUTANT" >&2; exit 97; }
+  cmp -s "$MUTANT" "$TARGET" || { printf 'probe-pin: MOUNT NOT REACHED: %s (mutant %s)\n' "$TARGET" "$MUTANT" >&2; trap - EXIT; exit 97; }
   i=$((i + 1))
 done
 exec timeout -k 5 "$TIMEOUT" "$TESTBIN" "$@"
@@ -49,8 +54,13 @@ pub fn exit_rc(status: &std::process::ExitStatus) -> i32 {
         .unwrap_or_else(|| 128 + status.signal().unwrap_or(0))
 }
 
-/// The flags probe-pin itself puts on the target's argv. Everything else on that command line
-/// came from `Target::manifest_argv`, which is what `manifest::validate` checks.
+/// The flags probe-pin itself puts on the target's argv — the OWNERSHIP allowlist. Everything
+/// else on that command line came from `Target::manifest_argv`, which is what
+/// `manifest::validate` checks.
+///
+/// Token 0 is the one CONDITIONAL flag (`--exact`, iff `filter_match = "exact"`); the rest are
+/// unconditional and `argv` iterates `UNCONDITIONAL_FLAGS` rather than respelling them, so the
+/// allowlist and the argv it authorizes cannot drift apart.
 pub const OWNED_FLAGS: &[&str] = &[
     "--exact",
     "--test-threads=1",
@@ -59,6 +69,9 @@ pub const OWNED_FLAGS: &[&str] = &[
     "-Z",
     "unstable-options",
 ];
+
+/// `OWNED_FLAGS` minus the conditional `--exact`, in argv order — derived, never restated.
+pub const UNCONDITIONAL_FLAGS: &[&str] = OWNED_FLAGS.split_at(1).1;
 
 /// `[filter] + ["--exact"] iff Exact + [the flags probe-pin owns] + [target].args`.
 ///
@@ -75,15 +88,7 @@ pub fn argv(target: &Target) -> Vec<String> {
     if target.filter_match == FilterMatch::Exact {
         v.push("--exact".to_string());
     }
-    for flag in [
-        "--test-threads=1",
-        "--format",
-        "json",
-        "-Z",
-        "unstable-options",
-    ] {
-        v.push(flag.to_string());
-    }
+    v.extend(UNCONDITIONAL_FLAGS.iter().map(|f| (*f).to_string()));
     v.extend(args.iter().map(|(_, a)| (*a).to_string()));
     v
 }

--- a/crates/probe-pin/src/lib.rs
+++ b/crates/probe-pin/src/lib.rs
@@ -1,0 +1,247 @@
+//! probe-pin — pins probe-derived claims to a regenerable, digest-stamped block in source.
+//!
+//! A probe is a mutation of the tree plus an expectation about the target test's outcome.
+//! probe-pin materializes every mutant OUTSIDE the workspace, bind-mounts it over the real
+//! path inside an unprivileged mount namespace, runs the target with libtest's JSON record
+//! format, and renders the measured verdicts into a `PROBE-PIN:BEGIN…END` block.
+//!
+//! Regenerate a block: `cargo probe-pin run --write <manifest>` (alias in `.cargo/config.toml`).
+//! Verify one:         `cargo probe-pin check <manifest>`
+
+use std::path::PathBuf;
+
+pub mod block;
+pub mod isolate;
+pub mod manifest;
+pub mod mutate;
+pub mod project;
+pub mod target;
+pub mod verdict;
+
+use manifest::{FilterMatch, RunMode};
+
+/// The two libtest suite records whose presence proves the harness ran to completion.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum HarnessMarker {
+    SuiteStarted,
+    SuiteFinished,
+}
+
+impl std::fmt::Display for HarnessMarker {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::SuiteFinished => "emitted libtest's suite-started record but never its suite-finished record — the harness started and died mid-run",
+            Self::SuiteStarted => "never emitted libtest's suite-started record — the harness died before it reported a test count",
+        })
+    }
+}
+
+/// A tool whose version produced a number in the block. Recorded iff it produced one:
+/// `rustc` always (every verdict comes through libtest's nightly JSON surface), `ast-grep`
+/// only when the manifest declares at least one projection.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, serde::Serialize)]
+pub enum Instrument {
+    Toolchain,
+    AstGrep,
+}
+
+impl Instrument {
+    /// The name as it appears both on the command line and on the block's `instrument` line.
+    pub fn tool(&self) -> &'static str {
+        match self {
+            Self::Toolchain => "rustc",
+            Self::AstGrep => "ast-grep",
+        }
+    }
+}
+
+impl std::fmt::Display for Instrument {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(self.tool())
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, serde::Serialize)]
+pub struct InstrumentChange {
+    pub instrument: Instrument,
+    pub was: String,
+    pub now: String,
+}
+
+/// `<tool> <was> -> <now>`, joined — used by both the `check` report and the write refusal.
+pub fn describe_changes(changed: &[InstrumentChange]) -> String {
+    changed
+        .iter()
+        .map(|c| format!("{} {} -> {}", c.instrument, c.was, c.now))
+        .collect::<Vec<_>>()
+        .join(", ")
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DriftCause {
+    Code,
+    Instrument(Vec<InstrumentChange>),
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CheckOutcome {
+    Clean,
+    Drift {
+        cause: DriftCause,
+        diff: String,
+        numbers_moved: bool,
+    },
+}
+
+/// Every condition under which probe-pin refuses to report a verdict. An aborted run writes
+/// nothing: `Abort` is never rendered into a block.
+#[derive(thiserror::Error, Debug, Clone, PartialEq, Eq)]
+pub enum Abort {
+    #[error("probe-pin: [target].mode = \"{mode}\" is not supported in schema version 1. Only \"runtime-read\" ships today: the mutant is bind-mounted and read as TEXT, never compiled. Compiled mode is deferred, not removed — see docs/probe-pin.md \"Compiled mode (deferred)\". Aborting.")]
+    UnsupportedMode { mode: RunMode },
+
+    #[error("probe-pin: this manifest does not declare exactly one control probe. The control is the [[probe]] with zero mutations: it runs the unmodified tree, and it is the only thing that shows the instrument itself works — without exactly one, a green run has no baseline and every verdict in it is unfalsifiable. Declare a single zero-mutation probe (conventionally `P0_control`, expect.outcome = \"pass\"), or delete the extra ones. Aborting.")]
+    ControlMissing,
+
+    #[error("probe-pin: [target].args contains \"{arg}\". probe-pin owns --format, -Z, --nocapture, --show-output, --test-threads, --quiet and --exact: it runs the target with libtest's JSON record format, and --nocapture puts raw test output on stdout, which corrupts that stream. Remove it. Aborting.")]
+    ReservedArg { arg: String },
+
+    #[error("probe-pin: {probe} anchor \"{anchor}\" embeds a source line number. Line numbers move on every unrelated edit above them, so this anchor would rot without the pinned behaviour changing. Re-anchor on the assertion's text. Aborting.")]
+    AnchorEmbedsLineNumber { probe: String, anchor: String },
+
+    #[error("probe-pin: {probe}'s anchor list fully matches {collides_with}'s captured failure. These two probes are not distinguished — the pin would stay green if {probe}'s mutation stopped firing. Either merge {probe} and {collides_with} into one probe, or make the target's assertion message distinguish them. (Adding a unique anchor may be impossible if the only distinguishing text is a line number.) Aborting.")]
+    AnchorNotDiscriminating {
+        probe: String,
+        collides_with: String,
+    },
+
+    #[error("probe-pin: {probe} mutation[{index}] {}: 'find' matched {found} times, expected exactly 1. 0 matches = a rotted probe; 2+ = an ambiguous mutation. No verdict in this run is valid. Aborting.", file.display())]
+    FindCount {
+        probe: String,
+        index: usize,
+        file: PathBuf,
+        found: usize,
+    },
+
+    #[error("probe-pin: {probe} {}: the materialized mutant is byte-identical to the original. A no-op mutation makes the mount-reach readback meaningless — it succeeds whether or not the mount happened. Aborting.", file.display())]
+    NoOpMutation { probe: String, file: PathBuf },
+
+    #[error("probe-pin: {probe} assert_count: expected {expected} occurrence(s) of \"{text}\" in the MUTANT of {}, found {found}. The probe's headline claim is not what the mutant text says. Aborting.", file.display())]
+    AssertCount {
+        probe: String,
+        file: PathBuf,
+        text: String,
+        expected: usize,
+        found: usize,
+    },
+
+    #[error("probe-pin: scratch dir {} is inside the workspace {}. probe-pin must never create files under the tree it is measuring. Set TMPDIR outside the worktree.", scratch.display(), workspace.display())]
+    ScratchInsideWorkspace {
+        scratch: PathBuf,
+        workspace: PathBuf,
+    },
+
+    #[error("probe-pin: 'cargo locate-project --workspace' failed: {stderr}. Run probe-pin from inside the workspace. Aborting.")]
+    WorkspaceRootUnresolved { stderr: String },
+
+    // The head names the PATH, not "the mutant": `isolate::scratch_dir` raises this for the
+    // TMPDIR itself, where no mutant exists yet.
+    #[error("probe-pin: scratch-directory write failed at {}: {err}. Mutants are written into probe-pin's scratch directory OUTSIDE the workspace, so this is a scratch-directory failure (permissions, no space, or a TMPDIR that vanished mid-run) — not a problem with your manifest, and not a write to your tree. No mutation was applied, so no verdict in this run is valid. Free space or set TMPDIR to a writable directory outside the worktree, then re-run. Aborting.", path.display())]
+    MaterializeFailed { path: PathBuf, err: String },
+
+    #[error("probe-pin: 'cargo test -p {package} --test {test} --no-run' failed: {stderr}")]
+    TargetBuildFailed {
+        package: String,
+        test: String,
+        stderr: String,
+    },
+
+    /// `found` is the number of artifacts that MATCHED (`kind == ["test"]` and the right name),
+    /// which is the count the exactly-one assertion failed on. `candidates` is every artifact
+    /// carrying an `executable` — a superset, and never the reported number.
+    #[error("probe-pin: expected exactly one test binary for -p {package} --test {test}, found {found}. Candidates: {candidates:?}")]
+    TargetBinaryUnresolved {
+        package: String,
+        test: String,
+        found: usize,
+        candidates: Vec<String>,
+    },
+
+    /// `rc: None` is "the process never started", which has no exit status at all — rendering a
+    /// sentinel like `-1` there would present an invented number as a measurement.
+    #[error("probe-pin: 'unshare --map-root-user --mount' {}: {stderr}. probe-pin cannot isolate mutations and will NOT fall back to writing your worktree. See docs/probe-pin.md.", match rc { Some(rc) => format!("failed (exit {rc})"), None => "could not be spawned".to_string() })]
+    IsolationUnavailable { rc: Option<i32>, stderr: String },
+
+    #[error("probe-pin: {probe} MOUNT NOT REACHED: {}. The mutant was materialized but the target inside the namespace still saw the ORIGINAL bytes. Every 'pass' verdict in this run would be a lie about an unmounted file. Captured stderr: {stderr}. Aborting.", path.display())]
+    MountNotReached {
+        probe: String,
+        path: PathBuf,
+        stderr: String,
+    },
+
+    #[error("probe-pin: {probe} exceeded [target].timeout_secs = {secs} and was killed. This is an instrument failure, not a probe verdict. Captured stderr: {stderr}. Raise timeout_secs, or fix the target. Aborting.")]
+    TargetTimedOut {
+        probe: String,
+        secs: u64,
+        stderr: String,
+    },
+
+    #[error("probe-pin: {probe} produced a line on stdout that is not a libtest JSON record: \"{line}\". probe-pin runs the target with --format json -Z unstable-options and requires a pure record stream. Aborting.")]
+    HarnessOutputUnparseable { probe: String, line: String },
+
+    #[error("probe-pin: {probe} {missing} (exit {rc}). This is an instrument failure, not a probe verdict. If this is a stack overflow: probe-pin runs the target with a constructed environment, and passes RUST_MIN_STACK=16777216 by default — raise it via [target].env.")]
+    HarnessIncomplete {
+        probe: String,
+        missing: HarnessMarker,
+        rc: i32,
+    },
+
+    #[error("probe-pin: the control probe '{probe}' (no mounts, unmodified tree) FAILED with exit {rc}. The instrument is broken; every other verdict in this run is meaningless. Aborting.")]
+    ControlFailed { probe: String, rc: i32 },
+
+    #[error("probe-pin: {probe} selected ZERO tests: [target].filter = \"{filter}\" with filter_match = \"{filter_match}\" matched nothing (libtest reported test_count 0, {filtered_out} filtered out, exit {rc}). A control that ran nothing is an INSTRUMENT FAILURE, not a pass — every verdict in this run would be about tests that never executed. Check the filter against the target's test names, set filter_match = \"substring\", or remove a selecting flag from [target].args (--skip, --ignored and --exclude-should-panic each measured driving test_count to 0). Aborting.")]
+    NoTestsSelected {
+        probe: String,
+        filter: String,
+        filter_match: FilterMatch,
+        filtered_out: usize,
+        rc: i32,
+    },
+
+    #[error("probe-pin: TREE MUTATED. {} sha256 before={before} after={after}. probe-pin must never write the files it mutates.", file.display())]
+    TreeMutated {
+        file: PathBuf,
+        before: String,
+        after: String,
+    },
+
+    #[error("probe-pin: expected exactly one PROBE-PIN:BEGIN/END pair in {}, found {begins}/{ends}.", file.display())]
+    MarkerNotUnique {
+        file: PathBuf,
+        begins: usize,
+        ends: usize,
+    },
+
+    #[error("probe-pin: this manifest declares a projection but '{tool}' could not be run: {stderr}. probe-pin will not emit a block with its projection sentences missing — a table that looks complete and is unmeasured is exactly what this tool exists to prevent. Install ast-grep, set PROBE_PIN_ASTGREP, or remove the [[projection]] section. Aborting.")]
+    ProjectionToolMissing { tool: String, stderr: String },
+
+    #[error("probe-pin: '{instrument} --version' could not be run: {stderr}. probe-pin records the toolchain in the block because libtest's JSON record format is nightly-only surface. Aborting.")]
+    InstrumentUnavailable {
+        instrument: Instrument,
+        stderr: String,
+    },
+
+    #[error("probe-pin: REFUSING to write. {} instrument(s) moved ({}) AND a measured number moved ({deltas}). Re-stamping would record the new number under the new tool and destroy the evidence of which one changed it. Pin one version and re-run, or — if you have confirmed the change is real — delete the PROBE-PIN:BEGIN…END block and re-run to write a fresh one. Aborting.", changed.len(), describe_changes(changed))]
+    WriteUnderInstrumentChange {
+        changed: Vec<InstrumentChange>,
+        deltas: String,
+    },
+}
+
+/// sha256, lowercase hex — the one hashing entry point (fingerprints and the block digest).
+pub fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let mut h = Sha256::new();
+    h.update(bytes);
+    h.finalize().iter().map(|b| format!("{b:02x}")).collect()
+}

--- a/crates/probe-pin/src/lib.rs
+++ b/crates/probe-pin/src/lib.rs
@@ -36,6 +36,31 @@ impl std::fmt::Display for HarnessMarker {
     }
 }
 
+/// WHY a run executed no test body. The PARAMETER of the one "this run measured nothing"
+/// abort, not a second abort: the refusal, its consequence and its exit code are identical in
+/// both shapes, and only the sentence naming what libtest reported differs. (CLAUDE.md:
+/// parameterize, don't proliferate — a sibling variant here would be the third spelling of
+/// one instrument failure.)
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum NothingRan {
+    /// libtest selected no test at all: `test_count == 0`.
+    NoneSelected,
+    /// libtest selected tests and executed no body: `passed + failed == 0` with
+    /// `test_count > 0` — an `#[ignore]`, a `--bench` run, a run-time skip.
+    AllSkipped,
+}
+
+impl std::fmt::Display for NothingRan {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::NoneSelected => "[target].filter selected ZERO tests",
+            Self::AllSkipped => {
+                "every test [target].filter selected was SKIPPED — not one test body executed"
+            }
+        })
+    }
+}
+
 /// A tool whose version produced a number in the block. Recorded iff it produced one:
 /// `rustc` always (every verdict comes through libtest's nightly JSON surface), `ast-grep`
 /// only when the manifest declares at least one projection.
@@ -103,8 +128,12 @@ pub enum Abort {
     #[error("probe-pin: this manifest does not declare exactly one control probe. The control is the [[probe]] with zero mutations: it runs the unmodified tree, and it is the only thing that shows the instrument itself works — without exactly one, a green run has no baseline and every verdict in it is unfalsifiable. Declare a single zero-mutation probe (conventionally `P0_control`, expect.outcome = \"pass\"), or delete the extra ones. Aborting.")]
     ControlMissing,
 
-    #[error("probe-pin: [target].args contains \"{arg}\". probe-pin owns --format, -Z, --nocapture, --show-output, --test-threads, --quiet and --exact: it runs the target with libtest's JSON record format, and --nocapture puts raw test output on stdout, which corrupts that stream. Remove it. Aborting.")]
-    ReservedArg { arg: String },
+    /// `field` is the manifest key that CONTRIBUTED the token, from `Target::manifest_argv` —
+    /// the same enumeration `isolate::argv` builds the argv from. It is carried rather than
+    /// hard-coded because `[target].filter` reaches the argv too, FIRST, where libtest's
+    /// getopts parses a `-`-leading token as a flag.
+    #[error("probe-pin: {field} contributes \"{arg}\" to the target's argv. probe-pin owns --format, -Z, --nocapture, --show-output, --test-threads, --quiet and --exact: it runs the target with libtest's JSON record format, and --nocapture puts raw test output on stdout, which corrupts that stream. Remove it. Aborting.")]
+    ReservedArg { field: String, arg: String },
 
     #[error("probe-pin: {probe} anchor \"{anchor}\" embeds a source line number. Line numbers move on every unrelated edit above them, so this anchor would rot without the pinned behaviour changing. Re-anchor on the assertion's text. Aborting.")]
     AnchorEmbedsLineNumber { probe: String, anchor: String },
@@ -199,11 +228,19 @@ pub enum Abort {
     #[error("probe-pin: the control probe '{probe}' (no mounts, unmodified tree) FAILED with exit {rc}. The instrument is broken; every other verdict in this run is meaningless. Aborting.")]
     ControlFailed { probe: String, rc: i32 },
 
-    #[error("probe-pin: {probe} selected ZERO tests: [target].filter = \"{filter}\" with filter_match = \"{filter_match}\" matched nothing (libtest reported test_count 0, {filtered_out} filtered out, exit {rc}). A control that ran nothing is an INSTRUMENT FAILURE, not a pass — every verdict in this run would be about tests that never executed. Check the filter against the target's test names, set filter_match = \"substring\", or remove a selecting flag from [target].args (--skip, --ignored and --exclude-should-panic each measured driving test_count to 0). Aborting.")]
-    NoTestsSelected {
+    /// The EXECUTION floor: `passed + failed == 0`. It is written on the fields that say what
+    /// RAN, because `test_count` only says what was selected — an `#[ignore]`d pinned test and
+    /// a `--bench` run both report `test_count: 1` with no body executed, and both rendered a
+    /// green row. This one condition covers every flag or attribute that suppresses execution,
+    /// including the ones nobody enumerated.
+    #[error("probe-pin: {probe} MEASURED NOTHING — {reason}: libtest reported test_count {test_count}, passed 0, failed 0, ignored {ignored}, {filtered_out} filtered out, exit {rc} (filter = \"{filter}\", filter_match = \"{filter_match}\"). A run that executed no test body is an INSTRUMENT FAILURE, not a pass — every verdict in it would be about tests that never ran. Check the filter against the target's test names, set filter_match = \"substring\", remove a selecting flag from [target].args (--skip, --ignored, --exclude-should-panic and --bench each measured driving the executed count to 0), or remove #[ignore] from the pinned test. Aborting.")]
+    NothingExecuted {
         probe: String,
+        reason: NothingRan,
         filter: String,
         filter_match: FilterMatch,
+        test_count: usize,
+        ignored: usize,
         filtered_out: usize,
         rc: i32,
     },

--- a/crates/probe-pin/src/lib.rs
+++ b/crates/probe-pin/src/lib.rs
@@ -201,6 +201,20 @@ pub enum Abort {
     #[error("probe-pin: 'unshare --map-root-user --mount' {}: {stderr}. probe-pin cannot isolate mutations and will NOT fall back to writing your worktree. See docs/probe-pin.md.", match rc { Some(rc) => format!("failed (exit {rc})"), None => "could not be spawned".to_string() })]
     IsolationUnavailable { rc: Option<i32>, stderr: String },
 
+    /// The other half of `MountNotReached`'s reserved-code pair. Everything the isolation
+    /// script does before `exec` — resolving `mount`, `cmp` and `timeout` through `PATH`,
+    /// expanding the `PP_*` variables, the `exec` itself — fails with EMPTY stdout and a
+    /// non-zero code, which is byte-for-byte the shape of a target that died before its first
+    /// libtest record. Measured: with `timeout` off `PATH` the child exits 127 with
+    /// `exec: timeout: not found` on stderr, and the classification that fired was
+    /// `HarnessIncomplete`, whose message tells the operator to raise `RUST_MIN_STACK`.
+    #[error("probe-pin: {probe}: the isolation script FAILED before the target ran (exit {rc}). This is an instrument failure, not a probe verdict, and it is not a stack-size problem: the script resolves `mount`, `cmp` and `timeout` through PATH under `set -eu` inside `unshare --map-root-user --mount`, so a missing or non-executable one of those, an unset PP_* variable, or a `mount --bind` onto a path that does not exist all land here. Captured stderr: {stderr}. Aborting.")]
+    IsolationScriptFailed {
+        probe: String,
+        rc: i32,
+        stderr: String,
+    },
+
     #[error("probe-pin: {probe} MOUNT NOT REACHED: {}. The mutant was materialized but the target inside the namespace still saw the ORIGINAL bytes. Every 'pass' verdict in this run would be a lie about an unmounted file. Captured stderr: {stderr}. Aborting.", path.display())]
     MountNotReached {
         probe: String,

--- a/crates/probe-pin/src/main.rs
+++ b/crates/probe-pin/src/main.rs
@@ -122,7 +122,7 @@ fn pipeline(manifest_path: &Path, mode: Mode) -> anyhow::Result<u8> {
     manifest::validate_paths(&m, &root)?;
 
     // 3. resolve the target binary — outside the namespace, on the pristine tree
-    let testbin = target::resolve(&m.target.package, &m.target.test)?;
+    let testbin = target::resolve(&root, &m.target.package, &m.target.test)?;
 
     // 4. record instruments
     let mut instruments = Vec::new();

--- a/crates/probe-pin/src/main.rs
+++ b/crates/probe-pin/src/main.rs
@@ -69,6 +69,29 @@ fn main() -> ExitCode {
     }
 }
 
+/// One probe's measurement, recorded through `verdict::verdict` — the crate's single verdict
+/// authority. Every probe reaches the block through this one function, control included: the
+/// probe whose whole job is "the instrument works" is the last one that should be exempt from
+/// the check that a measurement matched its declared expectation.
+fn record(
+    probe: &manifest::Probe,
+    obs: &verdict::Observed,
+    mounts_reached: usize,
+    outcomes: &mut Vec<Outcome>,
+    captures: &mut BTreeMap<String, Vec<String>>,
+    mismatches: &mut Vec<verdict::Mismatch>,
+) {
+    captures.insert(probe.id.clone(), obs.failed_captures.clone());
+    match verdict::verdict(probe, obs, mounts_reached) {
+        Ok(verdict) => outcomes.push(Outcome {
+            id: probe.id.clone(),
+            rc: obs.rc,
+            verdict,
+        }),
+        Err(mismatch) => mismatches.push(mismatch),
+    }
+}
+
 fn pipeline(manifest_path: &Path, mode: Mode) -> anyhow::Result<u8> {
     // 1. load + validate
     let m = Manifest::load(manifest_path)?;
@@ -76,11 +99,21 @@ fn pipeline(manifest_path: &Path, mode: Mode) -> anyhow::Result<u8> {
 
     // 2. workspace root
     let root = target::workspace_root()?;
+    // Workspace-relative or nothing: this string reaches the digest AND the BEGIN line, so an
+    // absolute path stamps a machine-specific value into a committed artifact — the exact
+    // reproducibility the digest exists to provide (docs/probe-pin.md: "Excluded: … absolute
+    // paths"), and the treatment `is_workspace_relative` already gives every other path key.
     let manifest_rel = manifest_path
         .canonicalize()
         .ok()
         .and_then(|p| p.strip_prefix(&root).ok().map(Path::to_path_buf))
-        .unwrap_or_else(|| manifest_path.to_path_buf())
+        .with_context(|| {
+            format!(
+                "probe-pin: manifest {} is not inside the workspace root {}. Its path is stamped into the block's BEGIN line and into the digest, so an absolute one would pin a block that no other checkout can reproduce. Move the manifest into the workspace and name it relative to the root. Aborting.",
+                manifest_path.display(),
+                root.display()
+            )
+        })?
         .display()
         .to_string();
 
@@ -122,28 +155,33 @@ fn pipeline(manifest_path: &Path, mode: Mode) -> anyhow::Result<u8> {
         }
         .into());
     }
-    let mut outcomes = vec![Outcome {
-        id: control.id.clone(),
-        rc: obs.rc,
-        verdict: verdict::Verdict::Pass { mounts_reached: 0 },
-    }];
+    let mut outcomes: Vec<Outcome> = Vec::new();
     let mut captures: BTreeMap<String, Vec<String>> = BTreeMap::new();
     let mut mismatches: Vec<verdict::Mismatch> = Vec::new();
+    // The control's verdict comes from the same authority as every other probe's. Constructing
+    // one here instead would report a control whose expectation the run REFUTES as a clean pass.
+    record(
+        control,
+        &obs,
+        0,
+        &mut outcomes,
+        &mut captures,
+        &mut mismatches,
+    );
 
     // 8. every other probe
     for probe in m.probes.iter().filter(|p| !p.mutations.is_empty()) {
         let mounts = mutate::apply(probe, &root, scratch.path())?;
         let run = isolate::run(&testbin, &mounts, &m.target)?;
         let obs = verdict::observe(&probe.id, &run, &m.target, &mounts)?;
-        captures.insert(probe.id.clone(), obs.failed_captures.clone());
-        match verdict::verdict(probe, &obs, mounts.len()) {
-            Ok(v) => outcomes.push(Outcome {
-                id: probe.id.clone(),
-                rc: obs.rc,
-                verdict: v,
-            }),
-            Err(mismatch) => mismatches.push(mismatch),
-        }
+        record(
+            probe,
+            &obs,
+            mounts.len(),
+            &mut outcomes,
+            &mut captures,
+            &mut mismatches,
+        );
     }
 
     // 9. all-pairs discrimination over the captured failed-test records

--- a/crates/probe-pin/src/main.rs
+++ b/crates/probe-pin/src/main.rs
@@ -1,0 +1,204 @@
+//! probe-pin's CLI and the §7 pipeline.
+//!
+//! Exit contract: **0** ok · **1** verdict mismatch / drift · **2** every `Abort` and every
+//! internal error · **101** probe-pin itself panicked (out of contract, documented).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use anyhow::Context;
+use clap::{Parser, Subcommand};
+
+use probe_pin::block::{self, Outcome, ProjectionCount};
+use probe_pin::manifest::Manifest;
+use probe_pin::{isolate, manifest, mutate, project, target, verdict, Abort};
+
+#[derive(Parser)]
+#[command(
+    name = "probe-pin",
+    about = "Pin probe-derived claims to a regenerable block"
+)]
+struct Cli {
+    #[command(subcommand)]
+    cmd: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Run every probe; print the block, or splice it into `[output].file` with `--write`.
+    Run {
+        #[arg(long)]
+        write: bool,
+        manifest: PathBuf,
+    },
+    /// Run every probe and compare against the committed block. Same cost as `run`.
+    Check { manifest: PathBuf },
+}
+
+/// What step 12 does with the rendered block. Three states, and `Cmd` is the only thing that
+/// decides which — a `(write, compare)` bool pair spells one of them twice and one not at all.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Mode {
+    Print,
+    Write,
+    Compare,
+}
+
+fn main() -> ExitCode {
+    let cli = Cli::parse();
+    let (path, mode) = match &cli.cmd {
+        Cmd::Run {
+            write: true,
+            manifest,
+        } => (manifest, Mode::Write),
+        Cmd::Run { manifest, .. } => (manifest, Mode::Print),
+        Cmd::Check { manifest } => (manifest, Mode::Compare),
+    };
+    match pipeline(path, mode) {
+        Ok(code) => ExitCode::from(code),
+        Err(e) => {
+            let chain = format!("{e:#}");
+            if chain.starts_with("probe-pin:") {
+                eprintln!("{chain}");
+            } else {
+                eprintln!("probe-pin: {chain}");
+            }
+            ExitCode::from(2)
+        }
+    }
+}
+
+fn pipeline(manifest_path: &Path, mode: Mode) -> anyhow::Result<u8> {
+    // 1. load + validate
+    let m = Manifest::load(manifest_path)?;
+    manifest::validate(&m)?;
+
+    // 2. workspace root
+    let root = target::workspace_root()?;
+    let manifest_rel = manifest_path
+        .canonicalize()
+        .ok()
+        .and_then(|p| p.strip_prefix(&root).ok().map(Path::to_path_buf))
+        .unwrap_or_else(|| manifest_path.to_path_buf())
+        .display()
+        .to_string();
+
+    // 3. resolve the target binary — outside the namespace, on the pristine tree
+    let testbin = target::resolve(&m.target.package, &m.target.test)?;
+
+    // 4. record instruments
+    let mut instruments = Vec::new();
+    for instrument in block::used_instruments(&m) {
+        let program = project::program_for(instrument);
+        instruments.push((
+            instrument,
+            project::instrument_version(instrument, &program)?,
+        ));
+    }
+
+    // 5. scratch, outside the workspace
+    let scratch = isolate::scratch_dir(&std::env::temp_dir(), &root)?;
+
+    // 6. fingerprint every mutated file
+    let mut touched: Vec<String> = Vec::new();
+    for p in &m.probes {
+        for f in p.touched() {
+            if !touched.contains(&f) {
+                touched.push(f);
+            }
+        }
+    }
+    let before = isolate::fingerprint(&root, &touched)?;
+
+    // 7. the control, first — its `test_count > 0` floor gates everything downstream
+    let control = m.control();
+    let run = isolate::run(&testbin, &[], &m.target)?;
+    let obs = verdict::observe(&control.id, &run, &m.target, &[])?;
+    if obs.target_failed {
+        return Err(Abort::ControlFailed {
+            probe: control.id.clone(),
+            rc: obs.rc,
+        }
+        .into());
+    }
+    let mut outcomes = vec![Outcome {
+        id: control.id.clone(),
+        rc: obs.rc,
+        verdict: verdict::Verdict::Pass { mounts_reached: 0 },
+    }];
+    let mut captures: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    let mut mismatches: Vec<verdict::Mismatch> = Vec::new();
+
+    // 8. every other probe
+    for probe in m.probes.iter().filter(|p| !p.mutations.is_empty()) {
+        let mounts = mutate::apply(probe, &root, scratch.path())?;
+        let run = isolate::run(&testbin, &mounts, &m.target)?;
+        let obs = verdict::observe(&probe.id, &run, &m.target, &mounts)?;
+        captures.insert(probe.id.clone(), obs.failed_captures.clone());
+        match verdict::verdict(probe, &obs, mounts.len()) {
+            Ok(v) => outcomes.push(Outcome {
+                id: probe.id.clone(),
+                rc: obs.rc,
+                verdict: v,
+            }),
+            Err(mismatch) => mismatches.push(mismatch),
+        }
+    }
+
+    // 9. all-pairs discrimination over the captured failed-test records
+    verdict::discriminate(&m.probes, &captures)?;
+
+    // 10. re-fingerprint — probe-pin must never write the files it mutates
+    isolate::verify_fingerprint(&before, &isolate::fingerprint(&root, &touched)?)?;
+
+    // A run with a verdict mismatch exits non-zero and never splices a block.
+    if !mismatches.is_empty() {
+        for mismatch in &mismatches {
+            eprintln!("probe-pin: VERDICT MISMATCH: {mismatch}");
+        }
+        return Ok(1);
+    }
+
+    // 11. projections
+    let mut counts = Vec::new();
+    for projection in &m.projections {
+        counts.push(ProjectionCount {
+            id: projection.id.clone(),
+            count: project::count(projection, &root, &project::astgrep_tool())?,
+        });
+    }
+
+    // 12. render, then write or compare
+    let digest = block::digest(&m, &manifest_rel, &outcomes, &counts, &instruments)?;
+    let generated = block::render(&m, &manifest_rel, &digest, &instruments, &outcomes, &counts);
+
+    if mode == Mode::Print {
+        println!("{generated}");
+        return Ok(0);
+    }
+
+    let out_path = root.join(&m.output.file);
+    let text = std::fs::read_to_string(&out_path)
+        .with_context(|| format!("probe-pin: cannot read {}", out_path.display()))?;
+    let committed = block::extract(&text, &m.output.marker, &out_path)?;
+    let outcome = block::check(&committed, &generated);
+
+    if mode == Mode::Compare {
+        let report = block::report(&outcome, &manifest_rel);
+        if !report.is_empty() {
+            eprintln!("{report}");
+        }
+        return Ok(block::exit_code(&outcome));
+    }
+
+    if let Some(abort) = block::write_refusal(&outcome, &committed, &generated) {
+        return Err(abort.into());
+    }
+    std::fs::write(
+        &out_path,
+        block::splice(&text, &m.output.marker, &out_path, &generated)?,
+    )
+    .with_context(|| format!("probe-pin: cannot write {}", out_path.display()))?;
+    Ok(0)
+}

--- a/crates/probe-pin/src/main.rs
+++ b/crates/probe-pin/src/main.rs
@@ -117,6 +117,10 @@ fn pipeline(manifest_path: &Path, mode: Mode) -> anyhow::Result<u8> {
         .display()
         .to_string();
 
+    // 2b. the path refusals that need the root. Between resolving the root and building the
+    // target, so containment is asserted at zero target runs — a refusal must never cost one.
+    manifest::validate_paths(&m, &root)?;
+
     // 3. resolve the target binary — outside the namespace, on the pristine tree
     let testbin = target::resolve(&m.target.package, &m.target.test)?;
 
@@ -144,7 +148,7 @@ fn pipeline(manifest_path: &Path, mode: Mode) -> anyhow::Result<u8> {
     }
     let before = isolate::fingerprint(&root, &touched)?;
 
-    // 7. the control, first — its `test_count > 0` floor gates everything downstream
+    // 7. the control, first — its execution floor gates everything downstream
     let control = m.control();
     let run = isolate::run(&testbin, &[], &m.target)?;
     let obs = verdict::observe(&control.id, &run, &m.target, &[])?;

--- a/crates/probe-pin/src/main.rs
+++ b/crates/probe-pin/src/main.rs
@@ -103,23 +103,15 @@ fn pipeline(manifest_path: &Path, mode: Mode) -> anyhow::Result<u8> {
     // absolute path stamps a machine-specific value into a committed artifact — the exact
     // reproducibility the digest exists to provide (docs/probe-pin.md: "Excluded: … absolute
     // paths"), and the treatment `is_workspace_relative` already gives every other path key.
-    let manifest_rel = manifest_path
-        .canonicalize()
-        .ok()
-        .and_then(|p| p.strip_prefix(&root).ok().map(Path::to_path_buf))
-        .with_context(|| {
-            format!(
-                "probe-pin: manifest {} is not inside the workspace root {}. Its path is stamped into the block's BEGIN line and into the digest, so an absolute one would pin a block that no other checkout can reproduce. Move the manifest into the workspace and name it relative to the root. Aborting.",
-                manifest_path.display(),
-                root.display()
-            )
-        })?
-        .display()
-        .to_string();
+    // The comparison itself lives in `manifest`, realpath against realpath, beside the other
+    // containment assertions rather than inline here where nothing can measure it.
+    let manifest_rel = manifest::workspace_relative(manifest_path, &root)?;
 
-    // 2b. the path refusals that need the root. Between resolving the root and building the
-    // target, so containment is asserted at zero target runs — a refusal must never cost one.
+    // 2b. the refusals that need something step 1 does not have — the workspace root for path
+    // containment, the workspace-relative manifest path for the block's own text. Between
+    // resolving the root and building the target, so both are asserted at zero target runs.
     manifest::validate_paths(&m, &root)?;
+    manifest::validate_block_text(&m, &manifest_rel)?;
 
     // 3. resolve the target binary — outside the namespace, on the pristine tree
     let testbin = target::resolve(&root, &m.target.package, &m.target.test)?;

--- a/crates/probe-pin/src/manifest.rs
+++ b/crates/probe-pin/src/manifest.rs
@@ -102,6 +102,13 @@ fn one() -> u32 {
     1
 }
 
+/// The largest `Prepend` pad probe-pin will materialize, 64 MiB. Not a tuned number: the pad is
+/// held in memory, written to disk and read back by the target as source text, and the largest
+/// pad any manifest in this repository declares is 200 × 14 B = 2.8 kB, so this is four orders
+/// of magnitude of headroom over the shape it exists to allow and still refuses the shape that
+/// killed the process.
+pub const MAX_PREPEND_BYTES: usize = 64 * 1024 * 1024;
+
 #[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct Output {
@@ -386,6 +393,110 @@ pub fn positional_argv_values(m: &Manifest) -> Vec<(String, &str)> {
     out
 }
 
+/// The manifest's path RELATIVE to the workspace root — the string that reaches the BEGIN line
+/// AND the digest, so an absolute one would pin a block no other checkout can reproduce.
+///
+/// BOTH sides are canonicalized, like every other containment assertion in this crate:
+/// `resolve_contained` canonicalizes `base`, `isolate::scratch_dir` canonicalizes both sides.
+/// A prefix comparison between a resolved path and an unresolved base is a LEXICAL comparison
+/// wearing a realpath's clothes, and its failure mode is a refusal no manifest edit can satisfy —
+/// "manifest … is not inside the workspace root" for a manifest that is. `target::workspace_root`
+/// already canonicalizes at the producer; this is the same rule stated at the guard, where it is
+/// measurable (`pure_logic::manifest_rel_compares_realpaths`).
+pub fn workspace_relative(
+    manifest_path: &std::path::Path,
+    root: &std::path::Path,
+) -> anyhow::Result<String> {
+    let real_root = root.canonicalize().unwrap_or_else(|_| root.to_path_buf());
+    manifest_path
+        .canonicalize()
+        .ok()
+        .and_then(|p| {
+            p.strip_prefix(&real_root)
+                .ok()
+                .map(|rel| rel.display().to_string())
+        })
+        .with_context(|| {
+            format!(
+                "probe-pin: manifest {} is not inside the workspace root {}. Its path is stamped into the block's BEGIN line and into the digest, so an absolute one would pin a block that no other checkout can reproduce. Move the manifest into the workspace and name it relative to the root. Aborting.",
+                manifest_path.display(),
+                root.display()
+            )
+        })
+}
+
+/// Every manifest-supplied string that is RENDERED INTO the block, tagged with its field and in
+/// render order. The third single-authority enumeration, beside `Target::manifest_argv` (argv)
+/// and `isolate::is_probe_pin_owned_env` (environment) — and `tests/pure_logic.rs`'s
+/// `block_text_surface_is_one_authority` measures the enumeration against what `block::render`
+/// actually emits, so a field that starts reaching the block is covered or the census fails.
+///
+/// The block is a LINE-oriented, marker-delimited artifact: `block::locate` counts
+/// `<marker>:BEGIN` and `<marker>:END` per line, and `--check` re-verifies exactly the span
+/// between them. A value carrying a newline or a marker tag therefore does not describe the
+/// artifact, it RESHAPES it. Measured on the shipping binary: `anchor = ["PROBE-PIN:END"]`
+/// rendered into the firing-assertion cell, `run --write` exited 0, and the spliced file then
+/// carried two END markers — every later `check` aborts `MarkerNotUnique` (found 1/2), so the
+/// pin can never be re-measured again without a hand edit.
+///
+/// `manifest_rel` is in the list because it is stamped on the BEGIN line: it is not a manifest
+/// VALUE, but it is a caller-supplied string that reaches the same surface.
+///
+/// Mutation paths are checked whole, though `block::mutation_cell` renders only their file
+/// name — over-refusing a directory component costs nothing and keeps this list readable as
+/// "the fields", not "the substrings of the fields".
+pub fn rendered_block_values<'a>(m: &'a Manifest, manifest_rel: &'a str) -> Vec<(String, &'a str)> {
+    let mut out = vec![
+        ("the manifest path".to_string(), manifest_rel),
+        ("[output].marker".to_string(), m.output.marker.as_str()),
+    ];
+    for p in &m.probes {
+        out.push((format!("[[probe]] '{}' id", p.id), p.id.as_str()));
+        for file in p.mutations.iter().flat_map(Mutation::files) {
+            out.push((format!("[[probe]] '{}' mutation file", p.id), file));
+        }
+        for anchor in p.anchors() {
+            out.push((format!("[[probe]] '{}' anchor", p.id), anchor.as_str()));
+        }
+    }
+    for pj in &m.projections {
+        out.push((
+            format!("[[projection]] '{}' sentence", pj.id),
+            pj.sentence.as_str(),
+        ));
+    }
+    out
+}
+
+/// §7 step 1b. The block-text refusals. Split from `validate` for the same reason
+/// `validate_paths` is — it needs a value step 1 does not have, here the workspace-relative
+/// manifest path — and it runs in the same place, before the target binary is resolved, so a
+/// refusal still costs zero target runs.
+pub fn validate_block_text(m: &Manifest, manifest_rel: &str) -> anyhow::Result<()> {
+    // The marker is the block's only structural tag, so it gets the ACCEPTED-charset treatment
+    // a probe id gets rather than a list of the values someone thought of. Measured on the
+    // shipping binary: `marker = ""` was accepted, and its `:BEGIN`/`:END` tags then matched the
+    // `PROBE-PIN:BEGIN`/`PROBE-PIN:END` lines of an UNRELATED manifest's committed block —
+    // `run --write` exited 0 and replaced that block with one keyed on a tag so short that any
+    // line containing it is a match.
+    if !is_plain_name(&m.output.marker) {
+        bail!("probe-pin: [output].marker '{}' is not a plain name. The marker IS the block's structure: probe-pin locates the pin by counting lines containing '<marker>:BEGIN' and '<marker>:END', so a blank or whitespace-only marker degenerates to ':BEGIN'/':END', which matches any line that happens to contain them — measured: a blank marker spliced over an unrelated manifest's committed block at exit 0. Use ASCII letters, digits, '_' and '-' (conventionally PROBE-PIN). Aborting.", m.output.marker);
+    }
+    let (begin_tag, end_tag) = (
+        format!("{}:BEGIN", m.output.marker),
+        format!("{}:END", m.output.marker),
+    );
+    for (field, value) in rendered_block_values(m, manifest_rel) {
+        if let Some(c) = value.chars().find(|c| c.is_control()) {
+            bail!("probe-pin: {field} = {value:?} carries the control character {c:?}. It is rendered into the block, which is a LINE-oriented artifact — a newline splits one measured row into two, and every other control character lands verbatim in a committed file that `check` must re-measure byte for byte. Anchor on printable text. Aborting.");
+        }
+        if value.contains(&begin_tag) || value.contains(&end_tag) {
+            bail!("probe-pin: {field} = {value:?} contains the marker tag '{begin_tag}' or '{end_tag}'. probe-pin finds the block by counting those tags, so rendering one INSIDE the block writes a second marker: measured on the shipping binary, `run --write` exited 0 and the spliced file then held two END markers, after which every `check` aborts with 'expected exactly one {} pair … found 1/2' and the pin can only be recovered by editing the file by hand. Anchor on text that does not contain the marker. Aborting.", m.output.marker);
+        }
+    }
+    Ok(())
+}
+
 /// §7 step 1b. The path refusals that need the workspace ROOT, which step 1 does not have.
 ///
 /// Split from `validate` by necessity, not by taste: containment is a realpath assertion and a
@@ -502,6 +613,19 @@ pub fn validate(m: &Manifest) -> anyhow::Result<()> {
             if mutation.files().is_empty() {
                 bail!("probe-pin: {} mutation[{index}] names no file. A mutation with an empty file list mutates nothing and mounts nothing, so this probe would measure the unmodified tree and render it as a mutant's verdict. Name the file(s) to mutate, or delete the probe. Aborting.", p.id);
             }
+            // The size of the mutant is a manifest-controlled PRODUCT, and the only one:
+            // `Replace` is bounded by the file it edits, `Prepend` is `text.len() × repeat`
+            // with `repeat` a full u32. Measured on the shipping binary: `repeat = 4294967295`
+            // of a 14-byte pad asked `str::repeat` for 60,129,542,130 bytes, and an allocation
+            // failure is not a panic — `handle_alloc_error` ABORTS, so probe-pin died with
+            // SIGABRT (exit 134, core dumped) outside its documented 0/1/2/101 exit contract,
+            // after a full control run had already been spent.
+            if let Mutation::Prepend { text, repeat, .. } = mutation {
+                let bytes = text.len().saturating_mul(*repeat as usize);
+                if bytes > MAX_PREPEND_BYTES {
+                    bail!("probe-pin: {} mutation[{index}] prepends {} bytes ({} × repeat {repeat}), over probe-pin's {MAX_PREPEND_BYTES}-byte cap. The pad is materialized in memory, written to the scratch dir, bind-mounted and then READ by the target, so this is a mutant no probe can measure — and past the allocator's limit it is not even a refusal: probe-pin aborts on allocation failure (measured: 60,129,542,130 bytes requested, SIGABRT). The shipping pads in this repository are ~2.8 kB. Lower `repeat`, or shorten `text`. Aborting.", p.id, bytes, text.len());
+                }
+            }
         }
         for file in p
             .mutations
@@ -558,6 +682,33 @@ pub fn validate(m: &Manifest) -> anyhow::Result<()> {
                 collides_with: twin.id.clone(),
             }
             .into());
+        }
+    }
+    // A `[[projection]]` is a producer of block rows exactly like a `[[probe]]`, and it had only
+    // its path keys checked. The three refusals below are the projection spelling of three the
+    // probe loop above already makes — a row key must be a plain name and unique, and a
+    // declaration that cannot carry a measurement must not reach the block.
+    for (i, pj) in m.projections.iter().enumerate() {
+        if !is_plain_name(&pj.id) {
+            bail!("probe-pin: [[projection]] id '{}' is not a plain name. A projection id is a block row key and one of the digest's ordering keys, exactly like a probe id. Use ASCII letters, digits, '_' and '-'. Aborting.", pj.id);
+        }
+        // Measured on the shipping binary: two projections sharing an id rendered the FIRST
+        // one's count under BOTH sentences, because the count is looked up by id — `Abort` was
+        // measured at 1 site and the block said 7, which is the other pattern's number.
+        if m.projections[..i].iter().any(|q| q.id == pj.id) {
+            bail!("probe-pin: duplicate [[projection]] id '{}'. Counts are looked up by id when the block is rendered and when the digest is computed, so the second projection would render the FIRST one's number under its own sentence — measured: a pattern with 1 match rendered as 7. Projection ids must be unique. Aborting.", pj.id);
+        }
+        // Measured: `paths = []` made ast-grep scan its whole CWD (the workspace root) and
+        // probe-pin rendered "named at 15 sites" for a projection whose declared scan set was
+        // empty, where the paths this crate's own projection names hold 7.
+        if pj.paths.is_empty() {
+            bail!("probe-pin: [[projection]] '{}' names no path. ast-grep with no path operand scans probe-pin's whole working directory — the workspace root — so the rendered count would be a measurement of a tree this projection never declared (measured: 15 sites rendered for an empty path list, against 7 in the paths the manifest meant). Name the directories to scan. Aborting.", pj.id);
+        }
+        // The projection half of this crate's thesis: prose in the block is a TRANSCRIPTION of
+        // a measured number. A sentence with no substitution point is an assertion, and it is
+        // rendered inside the span `check` re-verifies, where it reads as measured.
+        if !pj.sentence.contains("{count}") {
+            bail!("probe-pin: [[projection]] '{}' has a sentence with no '{{count}}' placeholder: {:?}. The count is substituted into that placeholder, so this sentence would be rendered into the block — inside the span `check` re-verifies — carrying no measured number at all, which is the one thing this tool exists to refuse. Put {{count}} where the number belongs. Aborting.", pj.id, pj.sentence);
         }
     }
     Ok(())

--- a/crates/probe-pin/src/manifest.rs
+++ b/crates/probe-pin/src/manifest.rs
@@ -305,6 +305,17 @@ pub fn validate(m: &Manifest) -> anyhow::Result<()> {
             return Err(Abort::ReservedArg { arg: arg.clone() }.into());
         }
     }
+    if m.target.timeout_secs == 0 {
+        bail!("probe-pin: [target].timeout_secs = 0 disables `timeout` entirely — `timeout -k 5 0` runs the child to completion, so a hung target would never be killed and never named. Set a positive value. Aborting.");
+    }
+    // The block is the artifact this whole pipeline exists to produce, and `--check` re-verifies
+    // it by resolving `[output].file` against the workspace root. `root.join("../x")` escapes,
+    // and a pin written outside the workspace is a pin no checkout and no CI job can ever
+    // re-measure — the verification loop it was rendered for cannot reach it. Measured: exit 0,
+    // block spliced into a file outside the root. Same rule already governs every mutation path.
+    if !is_workspace_relative(&m.output.file) {
+        bail!("probe-pin: [output].file '{}' is not workspace-relative. The block is resolved against the workspace root, so a path with '..', a root, or a prefix writes the pin outside the repository — where `probe-pin check` and CI can never re-measure it, which is the one thing a pin exists to allow. Name it relative to the workspace root. Aborting.", m.output.file);
+    }
     if m.probes.iter().filter(|p| p.mutations.is_empty()).count() != 1 {
         return Err(Abort::ControlMissing.into());
     }
@@ -314,6 +325,21 @@ pub fn validate(m: &Manifest) -> anyhow::Result<()> {
         }
         if m.probes[..i].iter().any(|q| q.id == p.id) {
             bail!("probe-pin: duplicate probe id '{}'. Probe ids are the block's row keys and the digest's ordering; they must be unique. Aborting.", p.id);
+        }
+        // The control materializes no mutant, and `assert_count` is checked against the mutant
+        // text — so one declared here is pinned into the digest and never evaluated. Measured:
+        // a control carrying `count = 99` of a string that occurs nowhere exited 0, green.
+        if p.mutations.is_empty() && !p.assert_counts.is_empty() {
+            bail!("probe-pin: {} declares assert_count(s) with no mutation. assert_count is checked against the MUTANT text, and a probe with no mutation is the control — it never materializes one, so these would be pinned into the block's digest without ever being evaluated. Move them to the probe whose mutation they describe. Aborting.", p.id);
+        }
+        // An empty file list is not a mutation: it seeds no file, so `mutate::apply`'s per-file
+        // no-op gate never executes, nothing is mounted, and the probe's verdict is about the
+        // UNMODIFIED tree — the control's job, rendered as a `pass` row that claims a mutant was
+        // visible. Refused per MUTATION so it cannot ride along beside one that names a file.
+        for (index, mutation) in p.mutations.iter().enumerate() {
+            if mutation.files().is_empty() {
+                bail!("probe-pin: {} mutation[{index}] names no file. A mutation with an empty file list mutates nothing and mounts nothing, so this probe would measure the unmodified tree and render it as a mutant's verdict. Name the file(s) to mutate, or delete the probe. Aborting.", p.id);
+            }
         }
         for file in p
             .mutations

--- a/crates/probe-pin/src/manifest.rs
+++ b/crates/probe-pin/src/manifest.rs
@@ -569,6 +569,18 @@ pub fn validate(m: &Manifest) -> anyhow::Result<()> {
             bail!("probe-pin: {field} = \"{value}\" begins with '-'. probe-pin passes it to a program as an OPERAND, where every argv grammar it shells reads a leading '-' as an option instead — measured: `[target].filter = \"--bench\"` ran zero test bodies while libtest still reported test_count 1, and `[[projection]].paths = [\"-h\"]` made ast-grep print its help, which probe-pin counted into a rendered 30-site sentence at exit 0. A filter is a SUBSTRING of a test name; a projection path is a DIRECTORY. Name one. Aborting.");
         }
     }
+    // The same positive shape, applied to the empty end of the range: a filter is a substring
+    // that NAMES a test, and "" names nothing. It is refused here rather than left to the
+    // execution floor because the two `filter_match` modes fail in opposite directions and
+    // neither reports the manifest defect. Measured with `filter_match = "substring"`: the run
+    // widens to the whole target binary while the block still renders a row keyed on one named
+    // filter — caught in that probe only because a widened test happened to fail, which made the
+    // control abort ("the instrument is broken"), not because anything checked the filter. With
+    // `filter_match = "exact"` it matches nothing, and the floor then reports an execution
+    // failure — the right refusal for the wrong reason, blaming the target for a manifest typo.
+    if m.target.filter.trim().is_empty() {
+        bail!("probe-pin: [target].filter is blank. A filter is a SUBSTRING that names the test a probe measures, and \"\" names nothing: with filter_match = \"substring\" libtest matches EVERY test in the target binary, so the probe measures the whole suite while the block renders a row keyed on one named target (measured — the widened run is only caught when one of those tests happens to fail, which reports as a broken control, not as a manifest defect); with filter_match = \"exact\" it matches nothing and the execution floor blames the target for what is a typo here. Name the test. Aborting.");
+    }
     // The manifest may not override an environment variable probe-pin itself sets. The refused
     // set is derived from what `isolate` actually sets, not restated here: `PATH` reaches the
     // `unshare … bash -c` script, where it resolves the `mount` and `cmp` whose readback is the

--- a/crates/probe-pin/src/manifest.rs
+++ b/crates/probe-pin/src/manifest.rs
@@ -72,6 +72,24 @@ pub struct Target {
     pub timeout_secs: u64,
 }
 
+impl Target {
+    /// Every argv token this manifest contributes to the target's command line, in argv order,
+    /// tagged with the field that contributed it.
+    ///
+    /// THE single authority for "which manifest values reach the target's argv". `isolate::argv`
+    /// builds the real argv from this list and `validate` checks RESERVED against it, so the two
+    /// cannot drift: a future field that feeds argv is validated the moment it is added here,
+    /// and is unreachable by `isolate::argv` until it is. `filter` was the miss that made this
+    /// necessary — it is argv token 0, where libtest's getopts parses it as a FLAG if it looks
+    /// like one, and only `args` was ever checked (measured: `filter = "--bench"`, exit 0, a
+    /// green `mount reached: 1 file(s)` row for a run whose every test body was skipped).
+    pub fn manifest_argv(&self) -> Vec<(&'static str, &str)> {
+        std::iter::once(("[target].filter", self.filter.as_str()))
+            .chain(self.args.iter().map(|a| ("[target].args", a.as_str())))
+            .collect()
+    }
+}
+
 fn default_env() -> BTreeMap<String, String> {
     BTreeMap::from([("RUST_MIN_STACK".to_string(), "16777216".to_string())])
 }
@@ -271,11 +289,67 @@ pub fn is_plain_name(id: &str) -> bool {
 
 /// Same rule, one level up: a manifest path is joined onto the workspace root AND onto the
 /// scratch dir, so every component must be a plain name — no root, no prefix, no `..`, no `.`.
+///
+/// LEXICAL only, and that is all it is used for now: `Path::components()` says nothing about
+/// what a component RESOLVES to. It is the pre-filter that gives the actionable `..` message;
+/// `resolve_contained` is the containment assertion.
 pub fn is_workspace_relative(path: &str) -> bool {
     !path.is_empty()
         && std::path::Path::new(path)
             .components()
             .all(|c| matches!(c, std::path::Component::Normal(_)))
+}
+
+/// Realpath containment: `base.join(key)` must RESOLVE inside `base`. Returns the joined path,
+/// or the reason it escapes.
+///
+/// The lexical check above accepts every path whose components are `Normal`, which an in-tree
+/// SYMLINK satisfies while resolving anywhere on the filesystem (measured: `[output].file`
+/// through one, exit 0, the block spliced outside the repository). `isolate::scratch_dir`
+/// already states containment the only way that holds — canonicalize, then `starts_with` — and
+/// this is that same assertion applied to the keys a manifest supplies, so both path
+/// directions (into the workspace, into the scratch dir) are one function.
+///
+/// The named file need not exist: `[output].file` may be created and a mutant's destination
+/// never exists yet. So what is canonicalized is the deepest ancestor that resolves — nothing
+/// below it exists, so nothing below it can redirect the write. The one exception is a name
+/// that EXISTS but does not resolve, i.e. a dangling symlink, which `canonicalize` cannot see
+/// and `fs::write` follows straight out of the tree; it is refused by name.
+pub fn resolve_contained(base: &std::path::Path, key: &str) -> Result<std::path::PathBuf, String> {
+    if !is_workspace_relative(key) {
+        return Err(format!(
+            "'{key}' is not a relative path with no '..' component"
+        ));
+    }
+    let base_real = base
+        .canonicalize()
+        .map_err(|e| format!("{} cannot be resolved: {e}", base.display()))?;
+    let full = base_real.join(key);
+    let mut probe = full.as_path();
+    let resolved = loop {
+        match probe.canonicalize() {
+            Ok(real) => break real,
+            Err(_) if std::fs::symlink_metadata(probe).is_ok() => {
+                return Err(format!(
+                    "'{key}' passes through {}, a symlink whose target does not exist — a write follows it, and probe-pin cannot prove where to",
+                    probe.display()
+                ))
+            }
+            Err(_) => {
+                probe = probe
+                    .parent()
+                    .ok_or_else(|| format!("'{key}' has no resolvable ancestor"))?;
+            }
+        }
+    };
+    if !resolved.starts_with(&base_real) {
+        return Err(format!(
+            "'{key}' resolves to {}, which is outside {}",
+            resolved.display(),
+            base_real.display()
+        ));
+    }
+    Ok(full)
 }
 
 /// The option NAME a token carries: `--test-threads=4` -> `--test-threads`, `-Zfoo` -> `-Z`.
@@ -286,7 +360,70 @@ pub fn option_name(arg: &str) -> &str {
     arg.split_once('=').map_or(arg, |(k, _)| k)
 }
 
-/// §7 step 1. Everything refusable before the tree is touched or a target is built.
+/// Every manifest value that reaches a process argv POSITIONALLY, tagged with its field.
+/// probe-pin shells three programs that take manifest values — the target (`isolate::argv`),
+/// cargo (`target::resolve`) and ast-grep (`project::count`) — and an operand is where a
+/// leading `-` is reinterpreted as an option by all three grammars. Both measured:
+/// `[target].filter = "--bench"` ran zero test bodies while libtest still reported test_count 1,
+/// and `[[projection]].paths = ["-h"]` made ast-grep print its HELP, which probe-pin counted
+/// into a rendered "named at 30 sites" sentence at exit 0.
+///
+/// Three manifest values are deliberately absent. `[target].args` is the one field whose
+/// contract IS flags — it is checked against `RESERVED` instead. `[target].package`,
+/// `[target].test` and `[[projection]].pattern` are never operands: each is the VALUE of a
+/// preceding flag, so a `-`-leading one is refused by the tool itself before any verdict exists
+/// (measured: `cargo test -p --config --test …` exits 2 via `TargetBuildFailed`).
+pub fn positional_argv_values(m: &Manifest) -> Vec<(String, &str)> {
+    let mut out = vec![("[target].filter".to_string(), m.target.filter.as_str())];
+    for pj in &m.projections {
+        for path in &pj.paths {
+            out.push((
+                format!("[[projection]] '{}' paths entry", pj.id),
+                path.as_str(),
+            ));
+        }
+    }
+    out
+}
+
+/// §7 step 1b. The path refusals that need the workspace ROOT, which step 1 does not have.
+///
+/// Split from `validate` by necessity, not by taste: containment is a realpath assertion and a
+/// realpath needs the base. It runs the moment the root is known and BEFORE the target binary
+/// is resolved, so a refusal still costs zero target runs — the property step 1 had.
+pub fn validate_paths(m: &Manifest, root: &std::path::Path) -> anyhow::Result<()> {
+    if let Err(why) = resolve_contained(root, &m.output.file) {
+        bail!("probe-pin: [output].file '{}' is not workspace-relative: {why}. The block is resolved against the workspace root, so a path that leaves it — through '..', a root, a prefix, or a SYMLINK whose components are all ordinary names — writes the pin outside the repository, where `probe-pin check` and CI can never re-measure it. Name it relative to the workspace root. Aborting.", m.output.file);
+    }
+    for p in &m.probes {
+        for file in p
+            .mutations
+            .iter()
+            .flat_map(Mutation::files)
+            .chain(p.assert_counts.iter().map(|a| a.file.as_str()))
+        {
+            if let Err(why) = resolve_contained(root, file) {
+                bail!("probe-pin: {} names '{file}', which is not a workspace-relative path: {why}. Manifest paths are read from the workspace root and materialized under probe-pin's scratch directory; one that resolves outside the root reads a file this pin does not measure. Aborting.", p.id);
+            }
+        }
+    }
+    // The fourth path producer, and the one that reaches a DIFFERENT program: `project::count`
+    // runs ast-grep with `current_dir(root)` and these paths as its operands, so a path that
+    // resolves outside the root renders a projection sentence counting code this repository does
+    // not contain — a measured number about a tree the pin does not pin.
+    for pj in &m.projections {
+        for path in &pj.paths {
+            if let Err(why) = resolve_contained(root, path) {
+                bail!("probe-pin: [[projection]] '{}' scans '{path}', which is not a workspace-relative path: {why}. A projection counts sites in the tree this manifest pins; a path that resolves outside the workspace root renders a sentence about code no checkout of this repository can re-measure. Aborting.", pj.id);
+            }
+        }
+    }
+    Ok(())
+}
+
+/// §7 step 1. Everything refusable before the tree is touched, a target is built, or the
+/// workspace root is even known. The path keys get their LEXICAL refusal here and their
+/// containment refusal in `validate_paths`, which needs the root.
 pub fn validate(m: &Manifest) -> anyhow::Result<()> {
     if m.version != 1 {
         bail!(
@@ -300,9 +437,34 @@ pub fn validate(m: &Manifest) -> anyhow::Result<()> {
         }
         .into());
     }
-    for arg in &m.target.args {
+    // Every token the manifest puts on the target's argv, not just `[target].args` — one
+    // enumeration, shared with `isolate::argv`, so a field cannot reach the argv unvalidated.
+    for (field, arg) in m.target.manifest_argv() {
         if RESERVED.contains(&option_name(arg)) {
-            return Err(Abort::ReservedArg { arg: arg.clone() }.into());
+            return Err(Abort::ReservedArg {
+                field: field.to_string(),
+                arg: arg.to_string(),
+            }
+            .into());
+        }
+    }
+    // What an OPERAND is, stated positively for every field that becomes one — a filter is a
+    // substring of a test name, a projection path is a directory. Not a list of the flags
+    // someone thought of: `--bench` is deliberately NOT in RESERVED, because enumerating hostile
+    // flags is the shape that already failed twice in this crate, and the execution floor in
+    // `verdict::observe` is what generalizes over the ones nobody named.
+    for (field, value) in positional_argv_values(m) {
+        if value.starts_with('-') {
+            bail!("probe-pin: {field} = \"{value}\" begins with '-'. probe-pin passes it to a program as an OPERAND, where every argv grammar it shells reads a leading '-' as an option instead — measured: `[target].filter = \"--bench\"` ran zero test bodies while libtest still reported test_count 1, and `[[projection]].paths = [\"-h\"]` made ast-grep print its help, which probe-pin counted into a rendered 30-site sentence at exit 0. A filter is a SUBSTRING of a test name; a projection path is a DIRECTORY. Name one. Aborting.");
+        }
+    }
+    // The manifest may not override an environment variable probe-pin itself sets. The refused
+    // set is derived from what `isolate` actually sets, not restated here: `PATH` reaches the
+    // `unshare … bash -c` script, where it resolves the `mount` and `cmp` whose readback is the
+    // only reason a `pass` verdict means anything.
+    for key in m.target.env.keys() {
+        if crate::isolate::is_probe_pin_owned_env(key) {
+            bail!("probe-pin: [target].env sets '{key}', which probe-pin itself sets for the target run. PATH and HOME are constructed so two developers pin the same capture bytes — and PATH resolves the `mount`, `cmp` and `timeout` the isolation script runs, so overriding it renders a green 'mount reached' row for a probe whose mutant was never mounted and never compared (measured). PP_MOUNTS, PP_MUTANT_*, PP_TARGET_*, TIMEOUT and TESTBIN are the script's own inputs. Remove it; RUST_MIN_STACK is the one probe-pin-set variable a manifest may raise. Aborting.");
         }
     }
     if m.target.timeout_secs == 0 {
@@ -351,9 +513,31 @@ pub fn validate(m: &Manifest) -> anyhow::Result<()> {
                 bail!("probe-pin: {} names '{file}', which is not a workspace-relative path. Manifest paths are joined onto the workspace root AND onto probe-pin's scratch directory, so an absolute path or a '..' component reads outside the workspace and materializes the mutant outside the scratch directory — inside the tree probe-pin is measuring. Use a path relative to the workspace root, with no '..' component. Aborting.", p.id);
             }
         }
+        // `assert_count` is evaluated against the MUTANT text, inside `mutate::apply`, so the
+        // only file it can be evaluated on is one this probe mutates. Naming any other file
+        // used to fall back to reading the PRISTINE tree while the failure message said "in
+        // the MUTANT of" — the assertion ran, but on text no mutation had touched, so an author
+        // reading that message believed they had pinned post-mutation state. Refusing is the
+        // half that stays true later: it is the same shape as the control refusal above (a
+        // declaration pinned into the digest that its gate never sees), and it costs zero
+        // target runs, where a corrected message would still have pinned pristine text.
+        for ac in &p.assert_counts {
+            if !p.touched().contains(&ac.file) {
+                bail!("probe-pin: {} declares an assert_count on '{}', which this probe does not mutate. assert_count is checked against the MUTANT text; a file with no mutation has no mutant, so this would assert against the pristine tree — a claim about post-mutation state, measured on pre-mutation text. Mutate that file in this probe, or move the assert_count to the probe that does. Aborting.", p.id, ac.file);
+            }
+        }
         if let Expect::Fail { anchor } = &p.expect {
             if anchor.is_empty() {
                 bail!("probe-pin: {} expects outcome = \"fail\" with an empty anchor list. A failure with no anchor pins nothing — any failure would satisfy it. Aborting.", p.id);
+            }
+            // The identical hazard, one character away: anchors are matched with `contains`,
+            // and EVERY capture contains "". The empty list was refused for exactly this reason
+            // while `anchor = [""]` was accepted — measured: exit 0, a green `fail` row whose
+            // firing-assertion cell is BLANK, which reads to a reviewer as "no anchor was
+            // needed" rather than "any failure satisfies this". `" "` behaves the same, hence
+            // the trim.
+            if let Some(blank) = anchor.iter().find(|a| a.trim().is_empty()) {
+                bail!("probe-pin: {} declares the anchor {blank:?}, which is empty after trimming. Anchors are matched with `contains`, and every capture contains the empty string — so this anchor is satisfied by ANY failure, exactly like the empty anchor list, and it renders as a blank firing-assertion cell that reads as 'no anchor was needed'. Anchor on the text of the assertion this probe pins. Aborting.", p.id);
             }
         }
         for a in p.anchors() {

--- a/crates/probe-pin/src/manifest.rs
+++ b/crates/probe-pin/src/manifest.rs
@@ -1,0 +1,354 @@
+//! The manifest schema and everything `validate()` can refuse before a single target runs.
+//!
+//! `Serialize` is derived alongside `Deserialize` purely so `block::digest` needs no
+//! hand-written canonical serializer: declaration order IS the canonical order and JSON
+//! escaping IS the injection safety.
+
+use std::collections::BTreeMap;
+
+use anyhow::{bail, Context};
+use serde::{Deserialize, Serialize};
+
+use crate::Abort;
+
+/// probe-pin owns these libtest options; a manifest may not pass them through `[target].args`.
+/// Compared against the option NAME (`--x=v` -> `--x`, any `-Z…` -> `-Z`), not the raw token.
+const RESERVED: &[&str] = &[
+    "--format",
+    "-Z",
+    "--nocapture",
+    "--show-output",
+    "--test-threads",
+    "-q",
+    "--quiet",
+    "--exact",
+];
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum RunMode {
+    RuntimeRead,
+    Compiled,
+}
+
+impl std::fmt::Display for RunMode {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::RuntimeRead => "runtime-read",
+            Self::Compiled => "compiled",
+        })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(rename_all = "lowercase")]
+pub enum FilterMatch {
+    Substring,
+    Exact,
+}
+
+impl std::fmt::Display for FilterMatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(match self {
+            Self::Substring => "substring",
+            Self::Exact => "exact",
+        })
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Target {
+    pub mode: RunMode,
+    pub package: String,
+    pub test: String,
+    pub filter: String,
+    pub filter_match: FilterMatch,
+    #[serde(default)]
+    pub args: Vec<String>,
+    #[serde(default = "default_env")]
+    pub env: BTreeMap<String, String>,
+    #[serde(default = "default_timeout")]
+    pub timeout_secs: u64,
+}
+
+fn default_env() -> BTreeMap<String, String> {
+    BTreeMap::from([("RUST_MIN_STACK".to_string(), "16777216".to_string())])
+}
+
+fn default_timeout() -> u64 {
+    300
+}
+
+fn one() -> u32 {
+    1
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Output {
+    pub file: String,
+    pub marker: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(tag = "kind", rename_all = "lowercase", deny_unknown_fields)]
+pub enum Mutation {
+    Replace {
+        file: String,
+        find: String,
+        replace: String,
+    },
+    Prepend {
+        files: Vec<String>,
+        text: String,
+        #[serde(default = "one")]
+        repeat: u32,
+    },
+}
+
+impl Mutation {
+    pub fn files(&self) -> Vec<&str> {
+        match self {
+            Self::Replace { file, .. } => vec![file.as_str()],
+            Self::Prepend { files, .. } => files.iter().map(String::as_str).collect(),
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct AssertCount {
+    pub file: String,
+    pub text: String,
+    pub count: usize,
+}
+
+/// `Pass {}` and not a unit variant: a unit variant defeats `deny_unknown_fields`, so a stray
+/// `anchor` under `outcome = "pass"` would be silently accepted.
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(tag = "outcome", rename_all = "lowercase", deny_unknown_fields)]
+pub enum Expect {
+    Pass {},
+    Fail { anchor: Vec<String> },
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Probe {
+    pub id: String,
+    #[serde(default)]
+    pub claim: String,
+    #[serde(default, rename = "mutation")]
+    pub mutations: Vec<Mutation>,
+    #[serde(default, rename = "assert_count")]
+    pub assert_counts: Vec<AssertCount>,
+    pub expect: Expect,
+}
+
+impl Probe {
+    /// Every file this probe mutates, in first-touch order — the fingerprint set of §7 step 6.
+    pub fn touched(&self) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        for m in &self.mutations {
+            for f in m.files() {
+                if !out.iter().any(|p| p == f) {
+                    out.push(f.to_string());
+                }
+            }
+        }
+        out
+    }
+
+    pub fn anchors(&self) -> &[String] {
+        match &self.expect {
+            Expect::Pass {} => &[],
+            Expect::Fail { anchor } => anchor,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Projection {
+    pub id: String,
+    pub pattern: String,
+    pub paths: Vec<String>,
+    pub sentence: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize, Serialize)]
+#[serde(deny_unknown_fields)]
+pub struct Manifest {
+    pub version: u32,
+    pub target: Target,
+    pub output: Output,
+    #[serde(default, rename = "probe")]
+    pub probes: Vec<Probe>,
+    #[serde(default, rename = "projection")]
+    pub projections: Vec<Projection>,
+}
+
+impl Manifest {
+    pub fn load(path: &std::path::Path) -> anyhow::Result<Self> {
+        let text = std::fs::read_to_string(path)
+            .with_context(|| format!("probe-pin: cannot read manifest {}", path.display()))?;
+        toml::from_str(&text)
+            .with_context(|| format!("probe-pin: cannot parse manifest {}", path.display()))
+    }
+
+    /// The zero-mutation probe. `validate()` has already proved there is exactly one.
+    pub fn control(&self) -> &Probe {
+        self.probes
+            .iter()
+            .find(|p| p.mutations.is_empty())
+            .expect("validate() proved exactly one zero-mutation probe exists")
+    }
+}
+
+/// The anchor line-number lint — the invariant the deleted pad subsystem approximated, at
+/// validation time and at zero target runs. Three forms:
+/// `\bline\s*[:=]?\s*\d` ∪ `\.[A-Za-z]{1,5}:\d+` ∪ `:\d+:\d+`.
+///
+/// Named residual (docs/probe-pin.md): a positional integer that is syntactically
+/// indistinguishable from a legitimate count — `("…/engine.rs", 11492)` and `L11492` — is
+/// accepted, because every regex that rejects it also rejects P9's real shipping anchor.
+pub fn embeds_line_number(anchor: &str) -> bool {
+    fn is_word(b: u8) -> bool {
+        b.is_ascii_alphanumeric() || b == b'_' || b >= 0x80
+    }
+    let b = anchor.as_bytes();
+    for i in 0..b.len() {
+        if b[i..].starts_with(b"line") && (i == 0 || !is_word(b[i - 1])) {
+            let mut j = i + 4;
+            while b.get(j).is_some_and(u8::is_ascii_whitespace) {
+                j += 1;
+            }
+            if matches!(b.get(j), Some(b':') | Some(b'=')) {
+                j += 1;
+            }
+            while b.get(j).is_some_and(u8::is_ascii_whitespace) {
+                j += 1;
+            }
+            if b.get(j).is_some_and(u8::is_ascii_digit) {
+                return true;
+            }
+        }
+        if b[i] == b'.' {
+            let mut j = i + 1;
+            while j - i <= 5 && b.get(j).is_some_and(u8::is_ascii_alphabetic) {
+                j += 1;
+            }
+            if j > i + 1 && b.get(j) == Some(&b':') && b.get(j + 1).is_some_and(u8::is_ascii_digit)
+            {
+                return true;
+            }
+        }
+        if b[i] == b':' {
+            let mut j = i + 1;
+            while b.get(j).is_some_and(u8::is_ascii_digit) {
+                j += 1;
+            }
+            if j > i + 1 && b.get(j) == Some(&b':') && b.get(j + 1).is_some_and(u8::is_ascii_digit)
+            {
+                return true;
+            }
+        }
+    }
+    false
+}
+
+/// A probe id is joined onto the scratch dir as ONE path segment, so it is constrained by an
+/// ACCEPTED charset, never by a rejected one: `..`, `.`, `/` and a leading `/` are each a way
+/// out of the container, and a blacklist that names them is a list of the ways someone has
+/// thought of. Ids are also the block's row keys and the digest's ordering keys.
+pub fn is_plain_name(id: &str) -> bool {
+    !id.is_empty()
+        && id
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b'-')
+}
+
+/// Same rule, one level up: a manifest path is joined onto the workspace root AND onto the
+/// scratch dir, so every component must be a plain name — no root, no prefix, no `..`, no `.`.
+pub fn is_workspace_relative(path: &str) -> bool {
+    !path.is_empty()
+        && std::path::Path::new(path)
+            .components()
+            .all(|c| matches!(c, std::path::Component::Normal(_)))
+}
+
+/// The option NAME a token carries: `--test-threads=4` -> `--test-threads`, `-Zfoo` -> `-Z`.
+pub fn option_name(arg: &str) -> &str {
+    if arg.starts_with("-Z") {
+        return "-Z";
+    }
+    arg.split_once('=').map_or(arg, |(k, _)| k)
+}
+
+/// §7 step 1. Everything refusable before the tree is touched or a target is built.
+pub fn validate(m: &Manifest) -> anyhow::Result<()> {
+    if m.version != 1 {
+        bail!(
+            "probe-pin: manifest version = {} is unknown; this probe-pin speaks schema version 1 only. Aborting.",
+            m.version
+        );
+    }
+    if m.target.mode != RunMode::RuntimeRead {
+        return Err(Abort::UnsupportedMode {
+            mode: m.target.mode,
+        }
+        .into());
+    }
+    for arg in &m.target.args {
+        if RESERVED.contains(&option_name(arg)) {
+            return Err(Abort::ReservedArg { arg: arg.clone() }.into());
+        }
+    }
+    if m.probes.iter().filter(|p| p.mutations.is_empty()).count() != 1 {
+        return Err(Abort::ControlMissing.into());
+    }
+    for (i, p) in m.probes.iter().enumerate() {
+        if !is_plain_name(&p.id) {
+            bail!("probe-pin: probe id '{}' is not a plain name. A probe id is joined onto probe-pin's scratch directory as ONE path segment, so a separator or a '..' in it materializes the mutant outside that directory — inside the tree probe-pin is measuring, which is the one thing this tool must never write. Use ASCII letters, digits, '_' and '-'. Aborting.", p.id);
+        }
+        if m.probes[..i].iter().any(|q| q.id == p.id) {
+            bail!("probe-pin: duplicate probe id '{}'. Probe ids are the block's row keys and the digest's ordering; they must be unique. Aborting.", p.id);
+        }
+        for file in p
+            .mutations
+            .iter()
+            .flat_map(Mutation::files)
+            .chain(p.assert_counts.iter().map(|a| a.file.as_str()))
+        {
+            if !is_workspace_relative(file) {
+                bail!("probe-pin: {} names '{file}', which is not a workspace-relative path. Manifest paths are joined onto the workspace root AND onto probe-pin's scratch directory, so an absolute path or a '..' component reads outside the workspace and materializes the mutant outside the scratch directory — inside the tree probe-pin is measuring. Use a path relative to the workspace root, with no '..' component. Aborting.", p.id);
+            }
+        }
+        if let Expect::Fail { anchor } = &p.expect {
+            if anchor.is_empty() {
+                bail!("probe-pin: {} expects outcome = \"fail\" with an empty anchor list. A failure with no anchor pins nothing — any failure would satisfy it. Aborting.", p.id);
+            }
+        }
+        for a in p.anchors() {
+            if embeds_line_number(a) {
+                return Err(Abort::AnchorEmbedsLineNumber {
+                    probe: p.id.clone(),
+                    anchor: a.clone(),
+                }
+                .into());
+            }
+        }
+        if let Some(twin) = m.probes[..i]
+            .iter()
+            .find(|q| !q.anchors().is_empty() && q.anchors() == p.anchors())
+        {
+            return Err(Abort::AnchorNotDiscriminating {
+                probe: p.id.clone(),
+                collides_with: twin.id.clone(),
+            }
+            .into());
+        }
+    }
+    Ok(())
+}

--- a/crates/probe-pin/src/mutate.rs
+++ b/crates/probe-pin/src/mutate.rs
@@ -1,0 +1,143 @@
+//! §7 step 8's first half: sequential mutation, materialization, and the two gates that make
+//! a mount-reach readback meaningful.
+
+use std::path::{Path, PathBuf};
+
+use anyhow::Context;
+
+use crate::manifest::{Mutation, Probe};
+use crate::Abort;
+
+/// One `mount --bind <mutant> <target>` pair.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Mount {
+    pub mutant: PathBuf,
+    pub target: PathBuf,
+}
+
+/// Apply every mutation in declaration order, materialize the result outside the workspace,
+/// and gate it.
+///
+/// Each `Replace`'s `count == 1` check runs against the RUNNING text for that file, so a
+/// two-op sequence whose second `find` only exists after the first op is expressible. The
+/// no-op gate is per FILE on MATERIALIZED bytes — one comparison that covers `Replace`,
+/// `Prepend { repeat: 0 }`, `Prepend { text: "" }` and sequences that cancel out.
+pub fn apply(probe: &Probe, root: &Path, scratch: &Path) -> anyhow::Result<Vec<Mount>> {
+    let mut running: Vec<(String, String, String)> = Vec::new(); // (rel, original, current)
+    for (index, mutation) in probe.mutations.iter().enumerate() {
+        for rel in mutation.files() {
+            if !running.iter().any(|(f, _, _)| f == rel) {
+                let text = std::fs::read_to_string(root.join(rel)).with_context(|| {
+                    format!(
+                        "probe-pin: {} cannot read {}",
+                        probe.id,
+                        root.join(rel).display()
+                    )
+                })?;
+                running.push((rel.to_string(), text.clone(), text));
+            }
+        }
+        match mutation {
+            Mutation::Replace {
+                file,
+                find,
+                replace,
+            } => {
+                let slot = running
+                    .iter_mut()
+                    .find(|(f, _, _)| f == file)
+                    .expect("seeded above");
+                let found = slot.2.matches(find.as_str()).count();
+                if found != 1 {
+                    return Err(Abort::FindCount {
+                        probe: probe.id.clone(),
+                        index,
+                        file: PathBuf::from(file),
+                        found,
+                    }
+                    .into());
+                }
+                slot.2 = slot.2.replacen(find.as_str(), replace, 1);
+            }
+            Mutation::Prepend {
+                files,
+                text,
+                repeat,
+            } => {
+                let pad = text.repeat(*repeat as usize);
+                for file in files {
+                    let slot = running
+                        .iter_mut()
+                        .find(|(f, _, _)| f == file)
+                        .expect("seeded above");
+                    slot.2 = format!("{pad}{}", slot.2);
+                }
+            }
+        }
+    }
+
+    let mut mounts = Vec::new();
+    for (rel, original, mutant) in &running {
+        let dest = scratch.join(&probe.id).join(rel);
+        if let Some(parent) = dest.parent() {
+            std::fs::create_dir_all(parent).map_err(|e| Abort::MaterializeFailed {
+                path: parent.to_path_buf(),
+                err: e.to_string(),
+            })?;
+        }
+        std::fs::write(&dest, mutant).map_err(|e| Abort::MaterializeFailed {
+            path: dest.clone(),
+            err: e.to_string(),
+        })?;
+        let materialized = std::fs::read(&dest).map_err(|e| Abort::MaterializeFailed {
+            path: dest.clone(),
+            err: e.to_string(),
+        })?;
+        if materialized == original.as_bytes() {
+            return Err(Abort::NoOpMutation {
+                probe: probe.id.clone(),
+                file: PathBuf::from(rel),
+            }
+            .into());
+        }
+        mounts.push(Mount {
+            mutant: dest,
+            target: root.join(rel),
+        });
+    }
+
+    assert_counts(probe, root, &running)?;
+    Ok(mounts)
+}
+
+/// `[[probe.assert_count]]` against the FINAL mutant text, after all mutations have composed.
+fn assert_counts(
+    probe: &Probe,
+    root: &Path,
+    running: &[(String, String, String)],
+) -> anyhow::Result<()> {
+    for ac in &probe.assert_counts {
+        let text = match running.iter().find(|(f, _, _)| *f == ac.file) {
+            Some((_, _, mutant)) => mutant.clone(),
+            None => std::fs::read_to_string(root.join(&ac.file)).with_context(|| {
+                format!(
+                    "probe-pin: {} assert_count cannot read {}",
+                    probe.id,
+                    root.join(&ac.file).display()
+                )
+            })?,
+        };
+        let found = text.matches(ac.text.as_str()).count();
+        if found != ac.count {
+            return Err(Abort::AssertCount {
+                probe: probe.id.clone(),
+                file: PathBuf::from(&ac.file),
+                text: ac.text.clone(),
+                expected: ac.count,
+                found,
+            }
+            .into());
+        }
+    }
+    Ok(())
+}

--- a/crates/probe-pin/src/mutate.rs
+++ b/crates/probe-pin/src/mutate.rs
@@ -5,7 +5,7 @@ use std::path::{Path, PathBuf};
 
 use anyhow::Context;
 
-use crate::manifest::{Mutation, Probe};
+use crate::manifest::{self, Mutation, Probe};
 use crate::Abort;
 
 /// One `mount --bind <mutant> <target>` pair.
@@ -78,7 +78,12 @@ pub fn apply(probe: &Probe, root: &Path, scratch: &Path) -> anyhow::Result<Vec<M
 
     let mut mounts = Vec::new();
     for (rel, original, mutant) in &running {
-        let dest = scratch.join(&probe.id).join(rel);
+        // The write side of the same containment rule `validate_paths` applies to the read
+        // side, asserted where the base finally exists: the scratch dir is created at §7 step 5.
+        // Both joined keys go in at once — `probe.id` is lexically a plain name and `rel` is
+        // lexically relative, and neither says where the join RESOLVES.
+        let dest = manifest::resolve_contained(scratch, &format!("{}/{rel}", probe.id))
+            .map_err(|why| anyhow::anyhow!("probe-pin: {} materializes its mutant outside probe-pin's scratch directory: {why}. The mutant path is <scratch>/<probe.id>/<file>, and a join that resolves out of the scratch dir writes into the tree probe-pin is measuring — the one thing this tool must never do. Aborting.", probe.id))?;
         if let Some(parent) = dest.parent() {
             std::fs::create_dir_all(parent).map_err(|e| Abort::MaterializeFailed {
                 path: parent.to_path_buf(),
@@ -106,27 +111,22 @@ pub fn apply(probe: &Probe, root: &Path, scratch: &Path) -> anyhow::Result<Vec<M
         });
     }
 
-    assert_counts(probe, root, &running)?;
+    assert_counts(probe, &running)?;
     Ok(mounts)
 }
 
 /// `[[probe.assert_count]]` against the FINAL mutant text, after all mutations have composed.
-fn assert_counts(
-    probe: &Probe,
-    root: &Path,
-    running: &[(String, String, String)],
-) -> anyhow::Result<()> {
+///
+/// There is no pristine-tree fallback: `validate` refuses an `assert_count` naming a file this
+/// probe does not mutate, so every one of them HAS a mutant here. The fallback that used to
+/// stand in its place read the unmutated file and reported the result as "in the MUTANT of",
+/// which is the message describing text it did not read.
+fn assert_counts(probe: &Probe, running: &[(String, String, String)]) -> anyhow::Result<()> {
     for ac in &probe.assert_counts {
-        let text = match running.iter().find(|(f, _, _)| *f == ac.file) {
-            Some((_, _, mutant)) => mutant.clone(),
-            None => std::fs::read_to_string(root.join(&ac.file)).with_context(|| {
-                format!(
-                    "probe-pin: {} assert_count cannot read {}",
-                    probe.id,
-                    root.join(&ac.file).display()
-                )
-            })?,
-        };
+        let (_, _, text) = running
+            .iter()
+            .find(|(f, _, _)| *f == ac.file)
+            .expect("validate() proved every assert_count names a file this probe mutates");
         let found = text.matches(ac.text.as_str()).count();
         if found != ac.count {
             return Err(Abort::AssertCount {

--- a/crates/probe-pin/src/project.rs
+++ b/crates/probe-pin/src/project.rs
@@ -1,0 +1,77 @@
+//! §7 steps 4 and 11: instrument versions, and the ast-grep projections.
+//!
+//! Recording rule, applied once: an instrument is recorded IFF it produced a number in the
+//! block. `rustc` always did — every verdict came through libtest's nightly-only JSON surface.
+//! `ast-grep` only did when the manifest declares at least one projection.
+
+use std::path::Path;
+use std::process::Command;
+
+use crate::manifest::Projection;
+use crate::{Abort, Instrument};
+
+/// `PROBE_PIN_ASTGREP` serves non-PATH installs and is what makes every projection row
+/// testable with no external install. There is no `PROBE_PIN_RUSTC` twin: `rustc` is on PATH
+/// wherever cargo built the target, so that knob would have zero users.
+pub fn astgrep_tool() -> String {
+    std::env::var("PROBE_PIN_ASTGREP").unwrap_or_else(|_| "ast-grep".to_string())
+}
+
+fn version_of(program: &str) -> Result<String, String> {
+    let out = Command::new(program)
+        .arg("--version")
+        .output()
+        .map_err(|e| e.to_string())?;
+    if !out.status.success() {
+        return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
+    }
+    Ok(String::from_utf8_lossy(&out.stdout).trim().to_string())
+}
+
+/// The program each instrument is read from. `rustc` is on PATH wherever cargo built the
+/// target; ast-grep's is overridable.
+pub fn program_for(instrument: Instrument) -> String {
+    match instrument {
+        Instrument::Toolchain => "rustc".to_string(),
+        Instrument::AstGrep => astgrep_tool(),
+    }
+}
+
+/// The tool is a parameter, not a hidden env read, so a test can drive a fake one without
+/// mutating process-wide state that its parallel siblings share.
+pub fn instrument_version(instrument: Instrument, program: &str) -> Result<String, Abort> {
+    version_of(program).map_err(|stderr| match instrument {
+        Instrument::Toolchain => Abort::InstrumentUnavailable { instrument, stderr },
+        Instrument::AstGrep => Abort::ProjectionToolMissing {
+            tool: program.to_string(),
+            stderr,
+        },
+    })
+}
+
+/// One match per line (`--json=stream`), so the count is the line count.
+pub fn count(projection: &Projection, root: &Path, tool: &str) -> Result<usize, Abort> {
+    let out = Command::new(tool)
+        .current_dir(root)
+        .args(["run", "--pattern", &projection.pattern, "--json=stream"])
+        .args(&projection.paths)
+        .output()
+        .map_err(|e| Abort::ProjectionToolMissing {
+            tool: tool.to_string(),
+            stderr: e.to_string(),
+        })?;
+    if !out.status.success() {
+        return Err(Abort::ProjectionToolMissing {
+            tool: tool.to_string(),
+            stderr: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        });
+    }
+    Ok(String::from_utf8_lossy(&out.stdout)
+        .lines()
+        .filter(|l| !l.trim().is_empty())
+        .count())
+}
+
+pub fn sentence(projection: &Projection, count: usize) -> String {
+    projection.sentence.replace("{count}", &count.to_string())
+}

--- a/crates/probe-pin/src/target.rs
+++ b/crates/probe-pin/src/target.rs
@@ -10,6 +10,17 @@ use std::process::Command;
 use crate::Abort;
 
 /// `cargo locate-project --workspace` — authoritative, and it replaces a walk-up heuristic.
+///
+/// CANONICALIZED here, at the one producer, because every consumer compares it against a path
+/// that has been: `main`'s `manifest_rel` strips it from `manifest_path.canonicalize()`,
+/// `manifest::resolve_contained` canonicalizes `base`, and `isolate::scratch_dir` canonicalizes
+/// both sides. A root that is not itself canonical turns each of those realpath assertions back
+/// into a LEXICAL string comparison — the shape this crate has already had to repair twice — and
+/// the failure mode is a refusal the operator cannot satisfy: "manifest … is not inside the
+/// workspace root" for a manifest that is. Not reached through cargo today (measured: with the
+/// root reached through a symlink, `cargo locate-project --workspace` still prints the resolved
+/// path, because cargo starts from `getcwd`, which the kernel answers physically) — so this is
+/// the guard matching the semantics of its surface, not a repair of a live escape.
 pub fn workspace_root() -> Result<PathBuf, Abort> {
     let out = Command::new("cargo")
         .args(["locate-project", "--workspace", "--message-format", "plain"])
@@ -23,11 +34,16 @@ pub fn workspace_root() -> Result<PathBuf, Abort> {
         });
     }
     let manifest = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim().to_string());
-    manifest
-        .parent()
-        .map(Path::to_path_buf)
-        .ok_or_else(|| Abort::WorkspaceRootUnresolved {
-            stderr: format!("'{}' has no parent directory", manifest.display()),
+    let root =
+        manifest
+            .parent()
+            .map(Path::to_path_buf)
+            .ok_or_else(|| Abort::WorkspaceRootUnresolved {
+                stderr: format!("'{}' has no parent directory", manifest.display()),
+            })?;
+    root.canonicalize()
+        .map_err(|e| Abort::WorkspaceRootUnresolved {
+            stderr: format!("'{}' cannot be resolved: {e}", root.display()),
         })
 }
 

--- a/crates/probe-pin/src/target.rs
+++ b/crates/probe-pin/src/target.rs
@@ -1,0 +1,99 @@
+//! §7 steps 2-3: where the workspace is, and which binary the manifest's target names.
+//!
+//! Both shell out to cargo and both inherit the ambient environment — `env_clear()` is scoped
+//! to the step-8 target run only (MAJOR-3), because clearing it here would strip `CARGO_HOME`
+//! and `CARGO_TARGET_DIR` and silently rejoin the shared `~/.cargo`.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use crate::Abort;
+
+/// `cargo locate-project --workspace` — authoritative, and it replaces a walk-up heuristic.
+pub fn workspace_root() -> Result<PathBuf, Abort> {
+    let out = Command::new("cargo")
+        .args(["locate-project", "--workspace", "--message-format", "plain"])
+        .output()
+        .map_err(|e| Abort::WorkspaceRootUnresolved {
+            stderr: e.to_string(),
+        })?;
+    if !out.status.success() {
+        return Err(Abort::WorkspaceRootUnresolved {
+            stderr: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        });
+    }
+    let manifest = PathBuf::from(String::from_utf8_lossy(&out.stdout).trim().to_string());
+    manifest
+        .parent()
+        .map(Path::to_path_buf)
+        .ok_or_else(|| Abort::WorkspaceRootUnresolved {
+            stderr: format!("'{}' has no parent directory", manifest.display()),
+        })
+}
+
+/// Pick the ONE test binary out of a `--message-format=json` artifact stream.
+///
+/// A `cargo test --test X --no-run` stream carries more than one `executable`: the package's
+/// `bin` target is built too and also reports one. Filtering on `target.kind == ["test"]` and
+/// `target.name` is what makes the choice unambiguous, and exactly-one is asserted rather
+/// than taking the first.
+pub fn pick_executable(stdout: &str, package: &str, test: &str) -> Result<PathBuf, Abort> {
+    let mut candidates: Vec<String> = Vec::new();
+    let mut chosen: Vec<String> = Vec::new();
+    for line in stdout.lines() {
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+            continue;
+        };
+        if v["reason"] != "compiler-artifact" {
+            continue;
+        }
+        let Some(exe) = v["executable"].as_str() else {
+            continue;
+        };
+        candidates.push(exe.to_string());
+        let kind_is_test = v["target"]["kind"]
+            .as_array()
+            .is_some_and(|k| k.len() == 1 && k[0] == "test");
+        if kind_is_test && v["target"]["name"] == test {
+            chosen.push(exe.to_string());
+        }
+    }
+    match chosen.len() {
+        1 => Ok(PathBuf::from(chosen.remove(0))),
+        found => Err(Abort::TargetBinaryUnresolved {
+            package: package.to_string(),
+            test: test.to_string(),
+            found,
+            candidates,
+        }),
+    }
+}
+
+/// `cargo test -p <package> --test <test> --no-run` — run OUTSIDE the namespace, on the
+/// pristine tree, before any mutant exists.
+pub fn resolve(package: &str, test: &str) -> Result<PathBuf, Abort> {
+    let out = Command::new("cargo")
+        .args([
+            "test",
+            "-p",
+            package,
+            "--test",
+            test,
+            "--no-run",
+            "--message-format=json",
+        ])
+        .output()
+        .map_err(|e| Abort::TargetBuildFailed {
+            package: package.to_string(),
+            test: test.to_string(),
+            stderr: e.to_string(),
+        })?;
+    if !out.status.success() {
+        return Err(Abort::TargetBuildFailed {
+            package: package.to_string(),
+            test: test.to_string(),
+            stderr: String::from_utf8_lossy(&out.stderr).trim().to_string(),
+        });
+    }
+    pick_executable(&String::from_utf8_lossy(&out.stdout), package, test)
+}

--- a/crates/probe-pin/src/target.rs
+++ b/crates/probe-pin/src/target.rs
@@ -71,8 +71,18 @@ pub fn pick_executable(stdout: &str, package: &str, test: &str) -> Result<PathBu
 
 /// `cargo test -p <package> --test <test> --no-run` — run OUTSIDE the namespace, on the
 /// pristine tree, before any mutant exists.
-pub fn resolve(package: &str, test: &str) -> Result<PathBuf, Abort> {
+///
+/// Pinned to `root`, matching `project::count`. Unlike `workspace_root`, which must inherit the
+/// caller's cwd because that is how it discovers the root at all, this invocation already has
+/// the root, and inheriting a cwd only makes its side effects depend on where probe-pin was run
+/// from. `CARGO_TARGET_DIR` is commonly relative — the Tilt resources here pass
+/// `target/probe-pin` — and a relative value resolves against the cwd of whichever process
+/// finally execs cargo. Measured: with the cwd left inherited, running the Tier-2 suite (whose
+/// tests run with cwd = the crate directory) materialized a 285M `crates/probe-pin/target/`
+/// that no `.gitignore` rule covers, because the repo ignores a ROOT-anchored `/target`.
+pub fn resolve(root: &Path, package: &str, test: &str) -> Result<PathBuf, Abort> {
     let out = Command::new("cargo")
+        .current_dir(root)
         .args([
             "test",
             "-p",

--- a/crates/probe-pin/src/verdict.rs
+++ b/crates/probe-pin/src/verdict.rs
@@ -36,8 +36,11 @@ pub struct Observed {
 }
 
 /// Classification is ORDERED, not a set: reserved script exit codes first, then stream shape,
-/// then verdict. Both a timeout and an unreached mount satisfy a `HarnessIncomplete` condition
-/// too, and `HarnessIncomplete`'s `RUST_MIN_STACK` hint is actively misleading for either.
+/// then verdict. A timeout, an unreached mount and a script that failed before `exec` all
+/// satisfy a `HarnessIncomplete` condition too — every one of them produces empty stdout and a
+/// non-zero code — and `HarnessIncomplete`'s `RUST_MIN_STACK` hint is actively misleading for
+/// all three. The script raises a RESERVED code for the two it can name (97 mount readback,
+/// 96 script-level), so the cause stays typed instead of being inferred from a stderr prefix.
 pub fn observe(
     probe: &str,
     run: &Run,
@@ -57,6 +60,15 @@ pub fn observe(
         return Err(Abort::MountNotReached {
             probe: probe.to_string(),
             path,
+            stderr: run.stderr.trim().to_string(),
+        });
+    }
+    // Same guard as 97, for the same reason: a script that reached `exec` cannot have produced
+    // this code, and a target that emitted records cannot have failed before it ran.
+    if run.rc == 96 && run.stdout.trim().is_empty() {
+        return Err(Abort::IsolationScriptFailed {
+            probe: probe.to_string(),
+            rc: run.rc,
             stderr: run.stderr.trim().to_string(),
         });
     }

--- a/crates/probe-pin/src/verdict.rs
+++ b/crates/probe-pin/src/verdict.rs
@@ -1,0 +1,253 @@
+//! §7 steps 8-9: libtest's JSON records in, an ordered instrument-failure classification, a
+//! verdict, and the cross-probe discrimination scan.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use crate::isolate::Run;
+use crate::manifest::{Expect, Probe, Target};
+use crate::mutate::Mount;
+use crate::{Abort, HarnessMarker};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Verdict {
+    Pass { mounts_reached: usize },
+    Fail { provenance: Vec<PathBuf> },
+}
+
+/// What the record stream said, once no instrument failure fired.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Observed {
+    pub rc: i32,
+    pub test_count: usize,
+    pub filtered_out: usize,
+    /// The `stdout` field of every `{"type":"test"}` `event:"failed"` record. libtest's
+    /// per-test capture buffer: that test's `println!`, its `eprintln!` and its panic
+    /// message, and NOTHING from any other test. Scoping is structural, not inferred.
+    pub failed_captures: Vec<String>,
+    pub target_failed: bool,
+}
+
+/// Classification is ORDERED, not a set: reserved script exit codes first, then stream shape,
+/// then verdict. Both a timeout and an unreached mount satisfy a `HarnessIncomplete` condition
+/// too, and `HarnessIncomplete`'s `RUST_MIN_STACK` hint is actively misleading for either.
+pub fn observe(
+    probe: &str,
+    run: &Run,
+    target: &Target,
+    mounts: &[Mount],
+) -> Result<Observed, Abort> {
+    // `97` is the mount signal only when stdout is empty: a reached mount always emits the
+    // suite-started record first.
+    if run.rc == 97 && run.stdout.trim().is_empty() {
+        let path = run
+            .stderr
+            .split_once("MOUNT NOT REACHED: ")
+            .and_then(|(_, rest)| rest.split_once(" (mutant"))
+            .map(|(p, _)| PathBuf::from(p))
+            .or_else(|| mounts.first().map(|m| m.target.clone()))
+            .unwrap_or_default();
+        return Err(Abort::MountNotReached {
+            probe: probe.to_string(),
+            path,
+            stderr: run.stderr.trim().to_string(),
+        });
+    }
+    if run.rc == 124 {
+        return Err(Abort::TargetTimedOut {
+            probe: probe.to_string(),
+            secs: target.timeout_secs,
+            stderr: run.stderr.trim().to_string(),
+        });
+    }
+    if run.stdout.trim().is_empty() && run.stderr.starts_with("unshare:") {
+        return Err(Abort::IsolationUnavailable {
+            rc: Some(run.rc),
+            stderr: run.stderr.trim().to_string(),
+        });
+    }
+
+    let mut obs = Observed {
+        rc: run.rc,
+        ..Default::default()
+    };
+    let mut started = false;
+    let mut terminal = false;
+    for line in run.stdout.lines().filter(|l| !l.trim().is_empty()) {
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(line) else {
+            // Fail-closed, and the tripwire if a future libtest changes the format.
+            return Err(Abort::HarnessOutputUnparseable {
+                probe: probe.to_string(),
+                line: line.to_string(),
+            });
+        };
+        match (v["type"].as_str(), v["event"].as_str()) {
+            (Some("suite"), Some("started")) => {
+                started = true;
+                obs.test_count = v["test_count"].as_u64().unwrap_or(0) as usize;
+            }
+            (Some("suite"), Some(event)) => {
+                terminal = true;
+                obs.target_failed = event != "ok";
+                obs.filtered_out = v["filtered_out"].as_u64().unwrap_or(0) as usize;
+            }
+            // `event:"failed"` appears on the suite record too, so the filter is written on
+            // `type`, not on `event`.
+            (Some("test"), Some("failed")) => obs
+                .failed_captures
+                .push(v["stdout"].as_str().unwrap_or_default().to_string()),
+            _ => {}
+        }
+    }
+    for (present, missing) in [
+        (started, HarnessMarker::SuiteStarted),
+        (terminal, HarnessMarker::SuiteFinished),
+    ] {
+        if !present {
+            return Err(Abort::HarnessIncomplete {
+                probe: probe.to_string(),
+                missing,
+                rc: run.rc,
+            });
+        }
+    }
+    if obs.test_count == 0 {
+        return Err(Abort::NoTestsSelected {
+            probe: probe.to_string(),
+            filter: target.filter.clone(),
+            filter_match: target.filter_match,
+            filtered_out: obs.filtered_out,
+            rc: run.rc,
+        });
+    }
+    Ok(obs)
+}
+
+/// Every anchor in the list, inside ONE record's capture. Not a whole run's output, and not
+/// an inferred prose block.
+pub fn all_anchors_in_one(anchors: &[String], captures: &[String]) -> bool {
+    captures
+        .iter()
+        .any(|c| anchors.iter().all(|a| c.contains(a.as_str())))
+}
+
+/// A measured outcome that contradicts the manifest's expectation. It carries the measured
+/// facts and formats at the boundary, like every other refusal in this crate — `main` is the
+/// only thing that turns one into text.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Mismatch {
+    pub probe: String,
+    pub expected: Expect,
+    pub observed_rc: i32,
+    /// `Some` iff the target failed as expected but an anchor did not land.
+    pub missed_anchor: Option<String>,
+}
+
+impl std::fmt::Display for Mismatch {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let probe = &self.probe;
+        match (&self.expected, &self.missed_anchor) {
+            (_, Some(missed)) => write!(
+                f,
+                "{probe} failed as expected, but anchor {missed:?} did not hit inside a single failed-test record"
+            ),
+            (Expect::Pass {}, None) => write!(
+                f,
+                "{probe} expected outcome = \"pass\" but the target FAILED (exit {})",
+                self.observed_rc
+            ),
+            (Expect::Fail { .. }, None) => write!(
+                f,
+                "{probe} expected outcome = \"fail\" but the target PASSED (exit {})",
+                self.observed_rc
+            ),
+        }
+    }
+}
+
+/// `Verdict::Fail` IS "the target failed AND every anchor hit inside one failed-test record".
+/// The complement of that — a target failure whose anchors do not all land in one record — is
+/// a verdict MISMATCH naming the missed anchor, never a `Pass`, because `Pass`'s rendering
+/// would transcribe "visible-and-still-passing" for a run whose target failed.
+pub fn verdict(probe: &Probe, obs: &Observed, mounts_reached: usize) -> Result<Verdict, Mismatch> {
+    let mismatch = |missed_anchor: Option<String>| Mismatch {
+        probe: probe.id.clone(),
+        expected: probe.expect.clone(),
+        observed_rc: obs.rc,
+        missed_anchor,
+    };
+    match &probe.expect {
+        Expect::Pass {} => {
+            if obs.target_failed {
+                Err(mismatch(None))
+            } else {
+                Ok(Verdict::Pass { mounts_reached })
+            }
+        }
+        Expect::Fail { anchor } => {
+            if !obs.target_failed {
+                return Err(mismatch(None));
+            }
+            if !all_anchors_in_one(anchor, &obs.failed_captures) {
+                let missed = anchor
+                    .iter()
+                    .find(|a| !obs.failed_captures.iter().any(|c| c.contains(a.as_str())))
+                    .cloned()
+                    .unwrap_or_else(|| anchor.join(" / "));
+                return Err(mismatch(Some(missed)));
+            }
+            Ok(Verdict::Fail {
+                provenance: provenance(&obs.failed_captures),
+            })
+        }
+    }
+}
+
+/// Sorted, de-duplicated `panicked at <path>` paths. No `:line:col`: a line number is not
+/// evidence a committed artifact can carry.
+pub fn provenance(captures: &[String]) -> Vec<PathBuf> {
+    let mut out: Vec<PathBuf> = Vec::new();
+    for c in captures {
+        for (_, rest) in c
+            .match_indices("panicked at ")
+            .map(|(i, m)| (i, &c[i + m.len()..]))
+        {
+            let path = rest.split([':', '\n']).next().unwrap_or_default().trim();
+            if !path.is_empty() {
+                let p = PathBuf::from(path);
+                if !out.contains(&p) {
+                    out.push(p);
+                }
+            }
+        }
+    }
+    out.sort();
+    out
+}
+
+/// §7 step 9. An anchor list that fully matches ANOTHER probe's captured failure does not
+/// distinguish the two probes: the pin would stay green if this probe's mutation stopped
+/// firing. The self-hit is the reach guard, and it is enforced by `verdict()` above.
+pub fn discriminate(
+    probes: &[Probe],
+    captures: &BTreeMap<String, Vec<String>>,
+) -> Result<(), Abort> {
+    for probe in probes {
+        let anchors = probe.anchors();
+        if anchors.is_empty() {
+            continue;
+        }
+        for (other, other_captures) in captures {
+            if *other == probe.id {
+                continue;
+            }
+            if all_anchors_in_one(anchors, other_captures) {
+                return Err(Abort::AnchorNotDiscriminating {
+                    probe: probe.id.clone(),
+                    collides_with: other.clone(),
+                });
+            }
+        }
+    }
+    Ok(())
+}

--- a/crates/probe-pin/src/verdict.rs
+++ b/crates/probe-pin/src/verdict.rs
@@ -7,7 +7,7 @@ use std::path::PathBuf;
 use crate::isolate::Run;
 use crate::manifest::{Expect, Probe, Target};
 use crate::mutate::Mount;
-use crate::{Abort, HarnessMarker};
+use crate::{Abort, HarnessMarker, NothingRan};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Verdict {
@@ -19,7 +19,14 @@ pub enum Verdict {
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct Observed {
     pub rc: i32,
+    /// What the suite-STARTED record said it would run. Selection, not execution.
     pub test_count: usize,
+    /// What the suite-TERMINAL record said actually happened. `passed + failed` is the only
+    /// number in the stream that counts test BODIES that ran: `test_count` is identical for a
+    /// normal run, an `#[ignore]`d run and a `--bench` run (measured, all three).
+    pub passed: usize,
+    pub failed: usize,
+    pub ignored: usize,
     pub filtered_out: usize,
     /// The `stdout` field of every `{"type":"test"}` `event:"failed"` record. libtest's
     /// per-test capture buffer: that test's `println!`, its `eprintln!` and its panic
@@ -90,6 +97,10 @@ pub fn observe(
                 terminal = true;
                 obs.target_failed = event != "ok";
                 obs.filtered_out = v["filtered_out"].as_u64().unwrap_or(0) as usize;
+                let field = |k| v[k].as_u64().unwrap_or(0) as usize;
+                obs.passed = field("passed");
+                obs.failed = field("failed");
+                obs.ignored = field("ignored");
             }
             // `event:"failed"` appears on the suite record too, so the filter is written on
             // `type`, not on `event`.
@@ -111,11 +122,25 @@ pub fn observe(
             });
         }
     }
-    if obs.test_count == 0 {
-        return Err(Abort::NoTestsSelected {
+    // The EXECUTION floor, and the general guarantee of the whole tool: not "were tests
+    // selected" but "did a test body run". `test_count` answers the first question, and the
+    // three shapes that made this crate render a green row for an unmeasured tree — a filter
+    // that matched nothing, an `#[ignore]` on the pinned test, a `--bench` argv — are
+    // indistinguishable in it (measured: `test_count: 1` for all three). `passed + failed` is
+    // the field that answers the question, and it closes every suppressing flag at once,
+    // including the ones no denylist names.
+    if obs.passed + obs.failed == 0 {
+        return Err(Abort::NothingExecuted {
             probe: probe.to_string(),
+            reason: if obs.test_count == 0 {
+                NothingRan::NoneSelected
+            } else {
+                NothingRan::AllSkipped
+            },
             filter: target.filter.clone(),
             filter_match: target.filter_match,
+            test_count: obs.test_count,
+            ignored: obs.ignored,
             filtered_out: obs.filtered_out,
             rc: run.rc,
         });

--- a/crates/probe-pin/tests/fixtures/astgrep_broken.sh
+++ b/crates/probe-pin/tests/fixtures/astgrep_broken.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+# Fake ast-grep that is present but cannot run — fail-closed, never a table-only block.
+echo "ast-grep: unsupported language" >&2
+exit 1

--- a/crates/probe-pin/tests/fixtures/astgrep_six.sh
+++ b/crates/probe-pin/tests/fixtures/astgrep_six.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Fake ast-grep: 6 matches, version 0.45.0 — the "tool moved AND the number moved" arm.
+case "$1" in
+  --version) echo "ast-grep 0.45.0" ;;
+  run) for i in 1 2 3 4 5 6; do echo "{\"text\":\"HIT-$i\"}"; done ;;
+  *) exit 64 ;;
+esac

--- a/crates/probe-pin/tests/fixtures/astgrep_three.sh
+++ b/crates/probe-pin/tests/fixtures/astgrep_three.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+# Fake ast-grep: 3 matches, version 0.44.1. Makes every projection row testable with no install.
+case "$1" in
+  --version) echo "ast-grep 0.44.1" ;;
+  run) for i in 1 2 3; do echo "{\"text\":\"HIT-$i\"}"; done ;;
+  *) exit 64 ;;
+esac

--- a/crates/probe-pin/tests/fixtures/collide.toml
+++ b/crates/probe-pin/tests/fixtures/collide.toml
@@ -1,0 +1,44 @@
+# §7 step 9's wiring pin (MAJOR-2, impl review). P1's anchor list is a SUBSET of P2's captured
+# failure — "…got" is inside "…got 202" — so the two probes are not distinguished, and nothing
+# but the step-9 all-pairs scan over the CAPTURES can see it: `manifest::validate` compares
+# anchor lists to each other (they differ), never an anchor list to another probe's failure.
+version = 1
+
+[target]
+mode         = "runtime-read"
+package      = "probe-pin"
+test         = "pure_logic"
+filter       = "ppfixture_census"
+filter_match = "substring"
+timeout_secs = 60
+
+[output]
+file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+marker = "PROBE-PIN"
+
+[[probe]]
+id = "P0_control"
+  [probe.expect]
+  outcome = "pass"
+
+[[probe]]
+id = "P1_drop_second_site"
+  [[probe.mutation]]
+  kind    = "replace"
+  file    = "crates/probe-pin/tests/fixtures/prod.txt"
+  find    = "SITE-TWO marker beta\n"
+  replace = ""
+  [probe.expect]
+  outcome = "fail"
+  anchor  = ["CENSUS VIOLATED: expected 2 sites, got"]
+
+[[probe]]
+id = "P2_pad_reaches_target"
+  [[probe.mutation]]
+  kind   = "prepend"
+  files  = ["crates/probe-pin/tests/fixtures/prod.txt"]
+  text   = "// pad marker\n"
+  repeat = 200
+  [probe.expect]
+  outcome = "fail"
+  anchor  = ["CENSUS VIOLATED: expected 2 sites, got 202"]

--- a/crates/probe-pin/tests/fixtures/collide.toml
+++ b/crates/probe-pin/tests/fixtures/collide.toml
@@ -13,7 +13,7 @@ filter_match = "substring"
 timeout_secs = 60
 
 [output]
-file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+file   = "crates/probe-pin/tests/fixtures/tmp/collide_block.md"
 marker = "PROBE-PIN"
 
 [[probe]]

--- a/crates/probe-pin/tests/fixtures/compiled.toml
+++ b/crates/probe-pin/tests/fixtures/compiled.toml
@@ -10,7 +10,7 @@ filter       = "ppfixture_census"
 filter_match = "substring"
 
 [output]
-file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+file   = "crates/probe-pin/tests/fixtures/tmp/compiled_block.md"
 marker = "PROBE-PIN"
 
 [[probe]]

--- a/crates/probe-pin/tests/fixtures/compiled.toml
+++ b/crates/probe-pin/tests/fixtures/compiled.toml
@@ -1,0 +1,19 @@
+# Rows 15 and 31: `mode = "compiled"` parses and is REJECTED at validation time, before the
+# workspace is located or anything is built — so this manifest costs zero target runs.
+version = 1
+
+[target]
+mode         = "compiled"
+package      = "probe-pin"
+test         = "pure_logic"
+filter       = "ppfixture_census"
+filter_match = "substring"
+
+[output]
+file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+marker = "PROBE-PIN"
+
+[[probe]]
+id = "P0_control"
+  [probe.expect]
+  outcome = "pass"

--- a/crates/probe-pin/tests/fixtures/control_expect_fail.toml
+++ b/crates/probe-pin/tests/fixtures/control_expect_fail.toml
@@ -1,0 +1,24 @@
+# The control declares an expectation the run CONTRADICTS (final review-impl, MAJOR-2). The
+# filter selects a test that passes on the unmodified tree, so `outcome = "fail"` is refuted by
+# the measurement — and the control must reach that conclusion through `verdict::verdict`, the
+# same authority every other probe uses, not through a hand-built `Verdict::Pass`.
+version = 1
+
+[target]
+mode         = "runtime-read"
+package      = "probe-pin"
+test         = "pure_logic"
+filter       = "ppfixture_census"
+filter_match = "substring"
+timeout_secs = 60
+
+[output]
+file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+marker = "PROBE-PIN"
+
+[[probe]]
+id = "P0_control"
+claim = "no mounts, unmodified tree — and an expectation the tree refutes"
+  [probe.expect]
+  outcome = "fail"
+  anchor  = ["CENSUS VIOLATED: expected 2 sites, got 1"]

--- a/crates/probe-pin/tests/fixtures/control_expect_fail.toml
+++ b/crates/probe-pin/tests/fixtures/control_expect_fail.toml
@@ -13,7 +13,7 @@ filter_match = "substring"
 timeout_secs = 60
 
 [output]
-file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+file   = "crates/probe-pin/tests/fixtures/tmp/control_expect_fail_block.md"
 marker = "PROBE-PIN"
 
 [[probe]]

--- a/crates/probe-pin/tests/fixtures/control_fails.toml
+++ b/crates/probe-pin/tests/fixtures/control_fails.toml
@@ -1,0 +1,22 @@
+# §8's control-failed row, and §7 step 7's wiring pin (MAJOR-2, impl review). The filter
+# selects a test that genuinely fails on the UNMODIFIED tree, so the control — the only probe
+# here — is a broken instrument. Every verdict downstream of it would be meaningless.
+version = 1
+
+[target]
+mode         = "runtime-read"
+package      = "probe-pin"
+test         = "pure_logic"
+filter       = "ppfixture_panic"
+filter_match = "substring"
+timeout_secs = 60
+env          = { PP_FIXTURE = "panic" }
+
+[output]
+file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+marker = "PROBE-PIN"
+
+[[probe]]
+id = "P0_control"
+  [probe.expect]
+  outcome = "pass"

--- a/crates/probe-pin/tests/fixtures/control_fails.toml
+++ b/crates/probe-pin/tests/fixtures/control_fails.toml
@@ -13,7 +13,7 @@ timeout_secs = 60
 env          = { PP_FIXTURE = "panic" }
 
 [output]
-file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+file   = "crates/probe-pin/tests/fixtures/tmp/control_fails_block.md"
 marker = "PROBE-PIN"
 
 [[probe]]

--- a/crates/probe-pin/tests/fixtures/dogfood.toml
+++ b/crates/probe-pin/tests/fixtures/dogfood.toml
@@ -1,0 +1,53 @@
+# probe-pin's own pin, and the manifest the Tilt `probe-pin-check` resource runs.
+#
+# The target is probe-pin's OWN `pure_logic` test binary — never `isolation_e2e`, which is
+# what runs probe-pin. `ppfixture_census` reads prod.txt at RUNTIME, so a bind-mounted mutant
+# is visible to it and a compiled-in copy would not be.
+version = 1
+
+[target]
+mode         = "runtime-read"
+package      = "probe-pin"
+test         = "pure_logic"
+filter       = "ppfixture_census"
+filter_match = "substring"
+timeout_secs = 60
+
+[output]
+file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+marker = "PROBE-PIN"
+
+[[probe]]
+id = "P0_control"
+claim = "no mounts, unmodified tree — the instrument itself"
+  [probe.expect]
+  outcome = "pass"
+
+[[probe]]
+id = "P1_drop_second_site"
+claim = "the census counts BOTH marker lines, not just the first"
+  [[probe.mutation]]
+  kind    = "replace"
+  file    = "crates/probe-pin/tests/fixtures/prod.txt"
+  find    = "SITE-TWO marker beta\n"
+  replace = ""
+  [[probe.assert_count]]
+  file  = "crates/probe-pin/tests/fixtures/prod.txt"
+  text  = "marker"
+  count = 1
+  [probe.expect]
+  outcome = "fail"
+  anchor  = ["CENSUS VIOLATED: expected 2 sites, got 1",
+             "text: \"SITE-ONE marker alpha\\n\""]
+
+[[probe]]
+id = "P2_pad_reaches_target"
+claim = "a prepend mutant is visible at the mounted path too"
+  [[probe.mutation]]
+  kind   = "prepend"
+  files  = ["crates/probe-pin/tests/fixtures/prod.txt"]
+  text   = "// pad marker\n"
+  repeat = 200
+  [probe.expect]
+  outcome = "fail"
+  anchor  = ["CENSUS VIOLATED: expected 2 sites, got 202"]

--- a/crates/probe-pin/tests/fixtures/dogfood_block.md
+++ b/crates/probe-pin/tests/fixtures/dogfood_block.md
@@ -1,0 +1,18 @@
+# probe-pin's own pin
+
+Human intent lives here, above the marker: probe-pin's mount-and-read isolation is what makes
+every `pass` row in the table below mean "visible-and-still-passing" rather than "unmeasured".
+Regenerate with `cargo probe-pin run --write crates/probe-pin/tests/fixtures/dogfood.toml`.
+
+// PROBE-PIN:BEGIN manifest=crates/probe-pin/tests/fixtures/dogfood.toml digest=sha256:e8abe1adf1a5fd5a
+// instrument rustc = rustc 1.97.0-nightly (0febdbab2 2026-04-18)
+// | probe | mutation | expect | verdict | firing assertion (anchor) | provenance |
+// |---|---|---|---|---|---|
+// | P0_control | (none) | pass | pass | (control; no mounts) | — |
+// | P1_drop_second_site | prod.txt ×1 | fail | fail | CENSUS VIOLATED: expected 2 sites, got 1 / text: "SITE-ONE marker alpha\n" | crates/probe-pin/tests/pure_logic.rs |
+// | P2_pad_reaches_target | prod.txt ×1 | fail | fail | CENSUS VIOLATED: expected 2 sites, got 202 | crates/probe-pin/tests/pure_logic.rs |
+// probe-pin validates only the lines between BEGIN and END. Prose outside is never checked.
+// PROBE-PIN:END
+
+And here, below the marker, is prose probe-pin never reads, never validates, and never
+invalidates. If you write interpretation, label it yourself.

--- a/crates/probe-pin/tests/fixtures/p7.toml
+++ b/crates/probe-pin/tests/fixtures/p7.toml
@@ -1,0 +1,43 @@
+# Schema-adequacy artifact: the archived P7 probe, verbatim in shape.
+# Two Replace ops on ONE file (op 2's `find` exists only in op 1's output), two assert_counts
+# on the FINAL mutant text, and a two-entry line-free anchor. Validated, never run here.
+version = 1
+
+[target]
+mode         = "runtime-read"
+package      = "phase-engine"
+test         = "integration"
+filter       = "loop_shortcut_seat_pin_census"
+filter_match = "substring"
+
+[output]
+file   = "crates/engine/tests/integration/loop_shortcut_seat_pin_census.rs"
+marker = "PROBE-PIN"
+
+[[probe]]
+id = "P0_control"
+claim = "no mounts, unmodified tree — the instrument itself"
+  [probe.expect]
+  outcome = "pass"
+
+[[probe]]
+id = "P7_relocate_arm0_below_arm1"
+claim = "site 2 is pinned to `shortcut_drive_period`'s match arm, not merely present"
+  [[probe.mutation]]
+  kind    = "replace"
+  file    = "crates/engine/src/game/engine.rs"
+  find    = "                    | TargetPin::Player(_) => 1,\n"
+  replace = ""
+  [[probe.mutation]]
+  kind    = "replace"
+  file    = "crates/engine/src/game/engine.rs"
+  find    = "                    | TargetPin::Creature(_) => 1,\n"
+  replace = "                    | TargetPin::Creature(_) => 1,\n                    | TargetPin::Player(_) => 1,\n"
+  [[probe.assert_count]]
+  file  = "crates/engine/src/game/engine.rs"
+  text  = "| TargetPin::Player(_) => 1,"
+  count = 1
+  [probe.expect]
+  outcome = "fail"
+  anchor  = ["site 2 must remain `shortcut_drive_period`'s MATCH arm",
+             "got \"Some(crate::analysis::decision_template::TargetPin::Player(*pl))\""]

--- a/crates/probe-pin/tests/fixtures/p8.toml
+++ b/crates/probe-pin/tests/fixtures/p8.toml
@@ -1,0 +1,34 @@
+# Schema-adequacy artifact: the archived P8 pad probe — an ORDINARY probe again, because
+# probe-pin generates no pad runs (the line-number invariant is a validation-time lint).
+version = 1
+
+[target]
+mode         = "runtime-read"
+package      = "phase-engine"
+test         = "integration"
+filter       = "loop_shortcut_seat_pin_census"
+filter_match = "substring"
+
+[output]
+file   = "crates/engine/tests/integration/loop_shortcut_seat_pin_census.rs"
+marker = "PROBE-PIN"
+
+[[probe]]
+id = "P0_control"
+  [probe.expect]
+  outcome = "pass"
+
+[[probe]]
+id = "P8_line_offset_control"
+claim = "every pinned assertion survives a 200-line offset in all five scanned files"
+  [[probe.mutation]]
+  kind   = "prepend"
+  files  = ["crates/engine/src/game/engine.rs",
+            "crates/engine/src/game/interaction.rs",
+            "crates/engine/src/game/visibility.rs",
+            "crates/engine/src/analysis/decision_template.rs",
+            "crates/server-core/src/game_action_payload_guard.rs"]
+  text   = "// pad\n"
+  repeat = 200
+  [probe.expect]
+  outcome = "pass"

--- a/crates/probe-pin/tests/fixtures/prod.txt
+++ b/crates/probe-pin/tests/fixtures/prod.txt
@@ -1,0 +1,2 @@
+SITE-ONE marker alpha
+SITE-TWO marker beta

--- a/crates/probe-pin/tests/fixtures/projection.toml
+++ b/crates/probe-pin/tests/fixtures/projection.toml
@@ -1,0 +1,27 @@
+# Row 26: a manifest that declares a projection. Fail-closed in BOTH paths (`run --write` and
+# `check`) — probe-pin will not emit a block whose projection sentence is missing, because a
+# table that looks complete and is unmeasured is what this tool exists to prevent.
+version = 1
+
+[target]
+mode         = "runtime-read"
+package      = "probe-pin"
+test         = "pure_logic"
+filter       = "ppfixture_census"
+filter_match = "substring"
+timeout_secs = 60
+
+[output]
+file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+marker = "PROBE-PIN"
+
+[[probe]]
+id = "P0_control"
+  [probe.expect]
+  outcome = "pass"
+
+[[projection]]
+id       = "instrument_sites"
+pattern  = "Instrument::$V"
+paths    = ["crates/probe-pin/src"]
+sentence = "`Instrument` is named at {count} sites."

--- a/crates/probe-pin/tests/fixtures/projection.toml
+++ b/crates/probe-pin/tests/fixtures/projection.toml
@@ -11,8 +11,14 @@ filter       = "ppfixture_census"
 filter_match = "substring"
 timeout_secs = 60
 
+# NOT dogfood_block.md. That block is what `dogfood.toml`, `isolation_e2e::dogfood_check` and the
+# Tilt `probe-pin-check` resource all validate, and THIS manifest is driven with `run --write` by
+# `isolation_e2e::proj_missing_both_paths`. Nothing structural stopped the splice: measured on the
+# shipping binary with ast-grep installed, `run --write` on this fixture exited 0 and replaced the
+# committed dogfood block with a projection block of its own. tmp/ is gitignored and excluded from
+# that Tilt resource's deps, so the write can no longer reach a committed artifact.
 [output]
-file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+file   = "crates/probe-pin/tests/fixtures/tmp/projection_block.md"
 marker = "PROBE-PIN"
 
 [[probe]]

--- a/crates/probe-pin/tests/fixtures/treewrite.toml
+++ b/crates/probe-pin/tests/fixtures/treewrite.toml
@@ -1,0 +1,37 @@
+# §7 step 10's wiring pin (MAJOR-2, impl review). `unshare --mount` isolates the MOUNT TABLE,
+# not the filesystem: a target that writes an unmounted path writes the real tree. This
+# manifest drives exactly that — `ppfixture_treewrite` appends to tests/fixtures/tmp/, which
+# the control run reaches with no mounts — so the step-10 re-fingerprint is the only thing
+# between "the tool measured a tree it also modified" and a rendered block.
+#
+# The mutated file is the one the target writes, so it is IN step 6's fingerprint set. `find`
+# survives the target's write (the appended line does not contain "ORIGINAL").
+version = 1
+
+[target]
+mode         = "runtime-read"
+package      = "probe-pin"
+test         = "pure_logic"
+filter       = "ppfixture_treewrite"
+filter_match = "substring"
+timeout_secs = 60
+env          = { PP_FIXTURE = "treewrite" }
+
+[output]
+file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+marker = "PROBE-PIN"
+
+[[probe]]
+id = "P0_control"
+  [probe.expect]
+  outcome = "pass"
+
+[[probe]]
+id = "P1_mounts_the_written_file"
+  [[probe.mutation]]
+  kind    = "replace"
+  file    = "crates/probe-pin/tests/fixtures/tmp/tree_write.txt"
+  find    = "ORIGINAL"
+  replace = "MUTATED"
+  [probe.expect]
+  outcome = "pass"

--- a/crates/probe-pin/tests/fixtures/treewrite.toml
+++ b/crates/probe-pin/tests/fixtures/treewrite.toml
@@ -17,8 +17,11 @@ filter_match = "substring"
 timeout_secs = 60
 env          = { PP_FIXTURE = "treewrite" }
 
+# NOT dogfood_block.md, for the same reason as projection.toml: this manifest's abort (step 10's
+# re-fingerprint) is POSITIONAL protection only, and a refusal that moves later in the pipeline
+# would put `run --write` on the committed dogfood block.
 [output]
-file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+file   = "crates/probe-pin/tests/fixtures/tmp/treewrite_block.md"
 marker = "PROBE-PIN"
 
 [[probe]]

--- a/crates/probe-pin/tests/fixtures/unsorted_ids.toml
+++ b/crates/probe-pin/tests/fixtures/unsorted_ids.toml
@@ -15,7 +15,7 @@ filter_match = "substring"
 env          = { RUST_MIN_STACK = "16777216", PP_ROW23_A = "1", PP_ROW23_B = "2", PP_ROW23_C = "3" }
 
 [output]
-file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+file   = "crates/probe-pin/tests/fixtures/tmp/unsorted_ids_block.md"
 marker = "PROBE-PIN"
 
 [[probe]]

--- a/crates/probe-pin/tests/fixtures/unsorted_ids.toml
+++ b/crates/probe-pin/tests/fixtures/unsorted_ids.toml
@@ -1,0 +1,46 @@
+# Row 23's fixture. The probe ids MUST be declared out of alphabetical order: the corpus ids
+# P0..P9 are already sorted, so a sorted fixture would make the "sort the ids" TRIVIALIZE arm
+# a no-op. `pure_logic::idempotent` ASSERTS this precondition rather than stating it.
+version = 1
+
+[target]
+mode         = "runtime-read"
+package      = "probe-pin"
+test         = "pure_logic"
+filter       = "ppfixture_census"
+filter_match = "substring"
+# FOUR env keys, not the default's one: row 23's other DROP arm (a `HashMap` for `[target].env`)
+# is invisible on a one-entry map, which has exactly one iteration order. The digest serializes
+# the whole [target], so this is where that arm shows.
+env          = { RUST_MIN_STACK = "16777216", PP_ROW23_A = "1", PP_ROW23_B = "2", PP_ROW23_C = "3" }
+
+[output]
+file   = "crates/probe-pin/tests/fixtures/dogfood_block.md"
+marker = "PROBE-PIN"
+
+[[probe]]
+id = "P0_control"
+  [probe.expect]
+  outcome = "pass"
+
+[[probe]]
+id = "P9_zulu"
+  [[probe.mutation]]
+  kind    = "replace"
+  file    = "crates/probe-pin/tests/fixtures/prod.txt"
+  find    = "SITE-TWO marker beta\n"
+  replace = ""
+  [probe.expect]
+  outcome = "fail"
+  anchor  = ["CENSUS VIOLATED: expected 2 sites, got 1"]
+
+[[probe]]
+id = "P1_alpha"
+  [[probe.mutation]]
+  kind   = "prepend"
+  files  = ["crates/probe-pin/tests/fixtures/prod.txt"]
+  text   = "// pad marker\n"
+  repeat = 200
+  [probe.expect]
+  outcome = "fail"
+  anchor  = ["CENSUS VIOLATED: expected 2 sites, got 202"]

--- a/crates/probe-pin/tests/isolation_e2e.rs
+++ b/crates/probe-pin/tests/isolation_e2e.rs
@@ -100,8 +100,19 @@ fn sha_of(rel: &str) -> String {
 
 /// Every probe-pin child shells its own NESTED `cargo test --test pure_logic --no-run` into the
 /// shared `CARGO_TARGET_DIR`; the three §7 wiring arms take the count of such children from four
-/// to seven, so they run one at a time rather than contending on cargo's build lock. This is
-/// hygiene, NOT MAJOR-3's fix: that flake's mechanism was isolated to the mutation harness (a
+/// to seven, so they run one at a time rather than contending on cargo's build lock.
+///
+/// The lock is IN-PROCESS, and that is the whole guarantee: it serializes these calls under
+/// libtest — one process, threads — which is the venue the Tilt `probe-pin-e2e` resource uses
+/// (`cargo test … -- --ignored`). It does NOT serialize across processes, so a nextest run would
+/// contend instead. Measured, and deliberately not configured around: `cargo nextest list -p
+/// probe-pin --test isolation_e2e` schedules ZERO of these tests, because they are `#[ignore]`d
+/// and CI's `cargo nextest run --profile ci --workspace` never passes `--run-ignored`; forcing it
+/// with `--run-ignored all` still ran 17/17 green in 4.4s against 3.2s under libtest. A
+/// `probe-pin-serial` group in `.config/nextest.toml` would be configuration for a venue nothing
+/// uses, and it would go stale silently.
+///
+/// This is hygiene, NOT MAJOR-3's fix: that flake's mechanism was isolated to the mutation harness (a
 /// `cp -p` restore preserves the pre-mutation mtime, so cargo keeps the artifact built from the
 /// mutant and the NEXT run measures the PREVIOUS mutant — reproduced deterministically, and
 /// cleared by one `touch`). Poisoning is ignored on purpose: a panicking arm must report ITS OWN
@@ -608,19 +619,41 @@ fn tmp_manifest(name: &str, text: &str) -> (PathBuf, String) {
 #[test]
 #[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn execution_floor_aborts_a_zero_run() {
-    let base = std::fs::read_to_string(root().join("crates/probe-pin/tests/fixtures/dogfood.toml"))
-        .unwrap()
+    let dogfood =
+        std::fs::read_to_string(root().join("crates/probe-pin/tests/fixtures/dogfood.toml"))
+            .unwrap();
+    // Each edit is asserted to APPLY, by the same rule the hostile loop below already uses. The
+    // reach guard cannot see a no-op edit: an UNEDITED dogfood.toml also exits 0 here, so three
+    // replaces silently becoming no-ops (one space of formatting drift is enough) would leave
+    // this test green while both hostile arms measured a manifest of a different shape.
+    let mut base = dogfood.clone();
+    for (what, find, replace) in [
         // a probe whose mutant leaves the census passing: the shape that renders a green `pass`
         // row, which is what a skipped run forges
-        .replace(
+        (
+            "the census-preserving mutation",
             "  find    = \"SITE-TWO marker beta\\n\"\n  replace = \"\"",
             "  find    = \"alpha\"\n  replace = \"gamma\"",
-        )
-        .replace("  text  = \"marker\"\n  count = 1", "  text  = \"gamma\"\n  count = 1")
-        .replace(
+        ),
+        (
+            "its assert_count",
+            "  text  = \"marker\"\n  count = 1",
+            "  text  = \"gamma\"\n  count = 1",
+        ),
+        (
+            "P1's expectation",
             "  outcome = \"fail\"\n  anchor  = [\"CENSUS VIOLATED: expected 2 sites, got 1\",\n             \"text: \\\"SITE-ONE marker alpha\\\\n\\\"\"]",
             "  outcome = \"pass\"",
+        ),
+    ] {
+        let edited = base.replace(find, replace);
+        assert_ne!(
+            edited, base,
+            "{what}: the edit must apply — dogfood.toml's formatting drifted, and without it \
+             this test measures the committed manifest instead of the floor's shape"
         );
+        base = edited;
+    }
     // the reach guard: this manifest must be GREEN when the target really runs, or every arm
     // below aborts for a reason that has nothing to do with the floor
     let (_, arg) = tmp_manifest("floor_base.toml", &base);
@@ -725,6 +758,160 @@ fn wiring_validate_paths() {
     ] {
         std::fs::remove_file(root().join(TMP).join(name)).ok();
     }
+}
+
+/// §7 step 1b's block-text half is CALLED. An anchor carrying the END marker is lexically clean
+/// everywhere else — it is not an id, not a path, and `cell()` escapes only `|`. Measured on the
+/// shipping binary before the refusal: `run --write` exited 0, the spliced file then held TWO
+/// END markers, and every subsequent `check` aborted with `expected exactly one
+/// PROBE-PIN:BEGIN/END pair … found 1/2`, so the pin could only be recovered by hand.
+///
+/// Revert-probe: delete the `validate_block_text` call from `main.rs` and the hostile arm goes
+/// to rc 0 with two END markers in the written file — which the arm asserts on directly.
+#[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
+fn wiring_validate_block_text() {
+    let block = root().join(TMP).join("marker_block.md");
+    let manifest = |anchor: &str| {
+        format!(
+            "version = 1\n\
+             [target]\n\
+             mode         = \"runtime-read\"\n\
+             package      = \"probe-pin\"\n\
+             test         = \"pure_logic\"\n\
+             filter       = \"ppfixture_census\"\n\
+             filter_match = \"substring\"\n\
+             timeout_secs = 60\n\
+             [output]\n\
+             file   = \"crates/probe-pin/tests/fixtures/tmp/marker_block.md\"\n\
+             marker = \"PROBE-PIN\"\n\
+             [[probe]]\n\
+             id = \"P0_control\"\n\
+             [probe.expect]\n\
+             outcome = \"pass\"\n\
+             [[probe]]\n\
+             id = \"P1_marker_anchor\"\n\
+             [[probe.mutation]]\n\
+             kind   = \"prepend\"\n\
+             files  = [\"crates/probe-pin/tests/fixtures/prod.txt\"]\n\
+             text   = \"PROBE-PIN:END marker\\n\"\n\
+             repeat = 1\n\
+             [probe.expect]\n\
+             outcome = \"fail\"\n\
+             anchor  = [\"{anchor}\"]\n"
+        )
+    };
+    let fresh = || {
+        std::fs::create_dir_all(root().join(TMP)).unwrap();
+        std::fs::write(
+            &block,
+            "prose above\n// PROBE-PIN:BEGIN placeholder\n// PROBE-PIN:END\nprose below\n",
+        )
+        .unwrap();
+    };
+    let end_markers = || {
+        std::fs::read_to_string(&block)
+            .unwrap()
+            .matches("PROBE-PIN:END")
+            .count()
+    };
+
+    // hostile: the anchor names the END marker, and the anchor really does hit — the mutant
+    // prepends that exact text, so this is refused for being marker-unsafe, not for missing
+    fresh();
+    let (_, arg) = tmp_manifest("marker_attack.toml", &manifest("PROBE-PIN:END"));
+    let (rc, err) = probe_pin_bin(&["run", "--write", &arg], &[]);
+    assert_eq!(rc, 2, "{err}");
+    assert!(err.contains("contains the marker tag"), "{err}");
+    assert!(err.contains("P1_marker_anchor"), "{err}");
+    assert_eq!(end_markers(), 1, "a refused run must not write");
+
+    // reach guard: the SAME manifest with a marker-free anchor runs to a spliced block, so the
+    // refusal above is about the marker text and not about this manifest's shape
+    fresh();
+    let (_, arg) = tmp_manifest(
+        "marker_ok.toml",
+        &manifest("CENSUS VIOLATED: expected 2 sites, got 3"),
+    );
+    let (rc, err) = probe_pin_bin(&["run", "--write", &arg], &[]);
+    assert_eq!(rc, 0, "the benign twin must still write: {err}");
+    assert_eq!(end_markers(), 1, "exactly one END marker survives a write");
+    assert_eq!(probe_pin_bin(&["check", &arg], &[]).0, 0);
+
+    for name in ["marker_attack.toml", "marker_ok.toml", "marker_block.md"] {
+        std::fs::remove_file(root().join(TMP).join(name)).ok();
+    }
+}
+
+/// A script-level failure is NAMED, not inferred from a stderr prefix. `mount`, `cmp` and
+/// `timeout` are resolved through `PATH` INSIDE the namespace under `set -eu`, so a PATH without
+/// them makes the shell die before `exec` — empty stdout, non-zero code, which is byte-for-byte
+/// the shape of a target that died before its first libtest record.
+///
+/// DROP arm: the same run with the script's reserved-code `trap` removed is the measurement
+/// that motivated it — exit 127, and `HarnessIncomplete`, whose message tells the operator to
+/// raise `RUST_MIN_STACK`, which cannot make `timeout` exist.
+#[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
+fn script_failure_is_named_not_inferred() {
+    fn on_path(tool: &str) -> PathBuf {
+        std::env::var("PATH")
+            .unwrap()
+            .split(':')
+            .map(|dir| Path::new(dir).join(tool))
+            .find(|p| p.exists())
+            .unwrap_or_else(|| panic!("{tool} must be on PATH for this test to mean anything"))
+    }
+    let dir = tempfile::tempdir().unwrap();
+    let bin = dir.path().join("bin");
+    std::fs::create_dir_all(&bin).unwrap();
+    // enough to reach the script, and nothing the script needs after that
+    for tool in ["unshare", "bash"] {
+        std::os::unix::fs::symlink(on_path(tool), bin.join(tool)).unwrap();
+    }
+    for missing in ["mount", "cmp", "timeout"] {
+        assert!(
+            !bin.join(missing).exists(),
+            "reach guard: {missing} must be absent from the constructed PATH"
+        );
+    }
+    let t = target("ppfixture_census", 60, &[("PATH", bin.to_str().unwrap())]);
+
+    let run = isolate::run(testbin(), &[], &t).unwrap();
+    assert_eq!(run.rc, 96, "stderr: {}", run.stderr);
+    assert!(
+        run.stdout.trim().is_empty(),
+        "the target never ran: {}",
+        run.stdout
+    );
+    let e = verdict::observe("P1", &run, &t, &[]).unwrap_err();
+    assert!(matches!(e, Abort::IsolationScriptFailed { .. }), "{e}");
+    assert!(
+        !e.to_string().contains("RUST_MIN_STACK"),
+        "the remedy must not name a stack size: {e}"
+    );
+
+    // DROP — the reserved code removed from the SHIPPING script
+    let dropped = script_without(&["trap"]);
+    assert_ne!(dropped, isolate::SCRIPT, "the DROP edit must apply");
+    let run = isolate::run_with_script(&dropped, testbin(), &[], &t).unwrap();
+    assert_eq!(run.rc, 127, "stderr: {}", run.stderr);
+    let e = verdict::observe("P1", &run, &t, &[]).unwrap_err();
+    assert!(
+        matches!(
+            e,
+            Abort::HarnessIncomplete {
+                missing: HarnessMarker::SuiteStarted,
+                ..
+            }
+        ),
+        "{e}"
+    );
+    assert!(e.to_string().contains("RUST_MIN_STACK"), "{e}");
+
+    // positive: the same target with the ambient PATH still runs to a clean observation
+    let t = target("ppfixture_census", 60, &[]);
+    assert!(verdict::observe("P1", &isolate::run(testbin(), &[], &t).unwrap(), &t, &[]).is_ok());
 }
 
 /// The dogfood: probe-pin runs its own committed manifest against its own committed block.

--- a/crates/probe-pin/tests/isolation_e2e.rs
+++ b/crates/probe-pin/tests/isolation_e2e.rs
@@ -1,0 +1,566 @@
+//! Tier 2 — §10 rows 1, 2, 14, 21 and 32, plus the two arms of rows 26 and 33 that need a
+//! real pipeline run. Everything here shells `unshare --map-root-user --mount`.
+//!
+//! The dogfood manifests pin `[target].test = "pure_logic"`, NEVER `isolation_e2e` — this
+//! file is what runs probe-pin, so pinning it would recurse.
+//!
+//! Rows 1, 2 and 21 execute their own DROP arms: each is defined as a mutation of the
+//! isolation SCRIPT (drop the readback / compare the mutant with itself / copy instead of
+//! mount), so the test derives the mutant script and runs it through the same entry point.
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::sync::OnceLock;
+
+use probe_pin::isolate::{self, Run};
+use probe_pin::manifest::{FilterMatch, Manifest, Target};
+use probe_pin::mutate::Mount;
+use probe_pin::verdict::{self, Verdict};
+use probe_pin::{Abort, HarnessMarker};
+
+const PROD: &str = "crates/probe-pin/tests/fixtures/prod.txt";
+/// Row 21 arm 2 WRITES this path. It is gitignored (`.gitignore:113` = `tmp/`), so the arm
+/// cannot leak into the tree even when its assertion panics before a restore — and it is
+/// never a tracked fixture a concurrent `nextest --workspace` reader might be reading.
+const TMP: &str = "crates/probe-pin/tests/fixtures/tmp";
+
+fn root() -> &'static Path {
+    static ROOT: OnceLock<PathBuf> = OnceLock::new();
+    ROOT.get_or_init(|| probe_pin::target::workspace_root().expect("workspace root"))
+}
+
+/// Resolved once per process: the nested `cargo test --no-run` is the expensive part.
+fn testbin() -> &'static Path {
+    static BIN: OnceLock<PathBuf> = OnceLock::new();
+    BIN.get_or_init(|| probe_pin::target::resolve("probe-pin", "pure_logic").expect("test binary"))
+}
+
+fn target(filter: &str, secs: u64, env: &[(&str, &str)]) -> Target {
+    let mut t = Manifest::load(&root().join("crates/probe-pin/tests/fixtures/dogfood.toml"))
+        .unwrap()
+        .target;
+    t.filter = filter.to_string();
+    t.filter_match = FilterMatch::Substring;
+    t.timeout_secs = secs;
+    for (k, v) in env {
+        t.env.insert((*k).to_string(), (*v).to_string());
+    }
+    t
+}
+
+fn mutant(dir: &Path, name: &str, text: &str) -> PathBuf {
+    let p = dir.join(name);
+    std::fs::write(&p, text).unwrap();
+    p
+}
+
+/// The mutant that makes `ppfixture_census` fail: one of the two marker lines is gone.
+fn dropped_site() -> String {
+    std::fs::read_to_string(root().join(PROD))
+        .unwrap()
+        .replace("SITE-TWO marker beta\n", "")
+}
+
+/// The shipping SCRIPT minus the lines whose leading token matches — how rows 1, 2 and 21
+/// build their DROP mutants.
+fn script_without(tokens: &[&str]) -> String {
+    isolate::SCRIPT
+        .lines()
+        .filter(|l| !tokens.iter().any(|t| l.trim_start().starts_with(t)))
+        .collect::<Vec<_>>()
+        .join("\n")
+}
+
+fn sha_of(rel: &str) -> String {
+    probe_pin::sha256_hex(&std::fs::read(root().join(rel)).unwrap())
+}
+
+/// Every probe-pin child shells its own NESTED `cargo test --test pure_logic --no-run` into the
+/// shared `CARGO_TARGET_DIR`; the three §7 wiring arms take the count of such children from four
+/// to seven, so they run one at a time rather than contending on cargo's build lock. This is
+/// hygiene, NOT MAJOR-3's fix: that flake's mechanism was isolated to the mutation harness (a
+/// `cp -p` restore preserves the pre-mutation mtime, so cargo keeps the artifact built from the
+/// mutant and the NEXT run measures the PREVIOUS mutant — reproduced deterministically, and
+/// cleared by one `touch`). Poisoning is ignored on purpose: a panicking arm must report ITS OWN
+/// failure rather than turn every later arm into a poison error that hides it.
+fn probe_pin_bin(args: &[&str], env: &[(&str, &str)]) -> (i32, String) {
+    static SERIAL: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    let _serial = SERIAL
+        .lock()
+        .unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_probe-pin"));
+    cmd.current_dir(root()).args(args);
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("probe-pin runs");
+    (
+        isolate::exit_rc(&out.status),
+        String::from_utf8_lossy(&out.stderr).into_owned(),
+    )
+}
+
+// ------------------------------------------------------------------ row 1
+
+/// Row 1: the mutant is REACHED at the target's path inside the namespace, and the `cmp`
+/// readback is what proves it. Arm A is the pinned behaviour; arm B removes the mount and the
+/// readback catches it; arm C removes the readback too and the same unmounted run reports a
+/// clean PASS — which is the whole reason a `pass` verdict is only worth its readback.
+#[test]
+fn mount_reach() {
+    let dir = tempfile::tempdir().unwrap();
+    let mounts = vec![Mount {
+        mutant: mutant(dir.path(), "prod.txt", &dropped_site()),
+        target: root().join(PROD),
+    }];
+    let t = target("ppfixture_census", 60, &[]);
+    let before = sha_of(PROD);
+
+    // arm A — real mount
+    let run = isolate::run(testbin(), &mounts, &t).unwrap();
+    assert_eq!(run.rc, 101, "the mutant must be visible to the target");
+    let obs = verdict::observe("P1", &run, &t, &mounts).expect("no instrument failure");
+    assert!(verdict::all_anchors_in_one(
+        &["CENSUS VIOLATED: expected 2 sites, got 1".to_string()],
+        &obs.failed_captures
+    ));
+    assert_eq!(sha_of(PROD), before, "the on-disk file must be untouched");
+
+    // arm B — the mount never happened; the readback catches it, and the abort reported is
+    // MountNotReached and NOT the co-firing HarnessIncomplete { SuiteStarted }.
+    let run = isolate::run_with_script(&script_without(&["mount --bind"]), testbin(), &mounts, &t)
+        .unwrap();
+    assert_eq!(run.rc, 97);
+    assert!(
+        run.stdout.trim().is_empty(),
+        "a reached mount emits suite-started first"
+    );
+    assert!(run.stderr.contains("MOUNT NOT REACHED"));
+    let e = verdict::observe("P1", &run, &t, &mounts).unwrap_err();
+    assert!(matches!(e, Abort::MountNotReached { .. }), "ordering: {e}");
+    assert!(!matches!(
+        e,
+        Abort::HarnessIncomplete {
+            missing: HarnessMarker::SuiteStarted,
+            ..
+        }
+    ));
+
+    // arm C (DROP) — without the readback, the very same unmounted run reports a clean pass
+    let run = isolate::run_with_script(
+        &script_without(&["mount --bind", "cmp -s"]),
+        testbin(),
+        &mounts,
+        &t,
+    )
+    .unwrap();
+    assert_eq!(run.rc, 0, "DROP arm: no mount, no readback -> a FALSE pass");
+    let obs = verdict::observe("P1", &run, &t, &mounts).unwrap();
+    assert!(!obs.target_failed);
+    assert_eq!(sha_of(PROD), before);
+}
+
+// ------------------------------------------------------------------ row 2
+
+/// Row 2: a `Prepend` mutant reaches the target too. The census reports 202 sites under a
+/// real 200-line pad, and 2 when the mount is dropped.
+#[test]
+fn pad_reach() {
+    let dir = tempfile::tempdir().unwrap();
+    let padded = format!(
+        "{}{}",
+        "// pad marker\n".repeat(200),
+        std::fs::read_to_string(root().join(PROD)).unwrap()
+    );
+    let mounts = vec![Mount {
+        mutant: mutant(dir.path(), "prod.txt", &padded),
+        target: root().join(PROD),
+    }];
+    let t = target("ppfixture_census", 60, &[]);
+    let before = sha_of(PROD);
+
+    let run = isolate::run(testbin(), &mounts, &t).unwrap();
+    let obs = verdict::observe("P2", &run, &t, &mounts).unwrap();
+    assert!(
+        verdict::all_anchors_in_one(
+            &["CENSUS VIOLATED: expected 2 sites, got 202".to_string()],
+            &obs.failed_captures
+        ),
+        "the 200-line pad must be visible at the target's path"
+    );
+
+    // The readback catches an unmounted Prepend mutant too. This arm derives its script from
+    // the SHIPPING one, so deleting the `cmp` line from `isolate::SCRIPT` flips it — which is
+    // row 2's DROP (M-e: the readback is a single per-file `cmp` with no per-kind branch, so
+    // this row exercises row 1's mutation on a Prepend mutant).
+    let run = isolate::run_with_script(&script_without(&["mount --bind"]), testbin(), &mounts, &t)
+        .unwrap();
+    assert_eq!(
+        run.rc, 97,
+        "an unmounted pad must be caught by the readback"
+    );
+    assert!(matches!(
+        verdict::observe("P2", &run, &t, &mounts).unwrap_err(),
+        Abort::MountNotReached { .. }
+    ));
+
+    // and with the readback removed as well, the same unmounted run is a silent pass
+    let run = isolate::run_with_script(
+        &script_without(&["mount --bind", "cmp -s"]),
+        testbin(),
+        &mounts,
+        &t,
+    )
+    .unwrap();
+    assert_eq!(run.rc, 0);
+    assert!(
+        !verdict::observe("P2", &run, &t, &mounts)
+            .unwrap()
+            .target_failed
+    );
+    assert_eq!(sha_of(PROD), before);
+}
+
+// ------------------------------------------------------------------ row 14
+
+/// Row 14: a hung target is killed and NAMED. Without `timeout` the run would hang past CI's
+/// 240 s hard kill; with `timeout 0` it would never fire. The abort reported is
+/// `TargetTimedOut` and not the co-firing `HarnessIncomplete { SuiteFinished }`.
+#[test]
+fn timeout() {
+    let t = target("ppfixture_hang", 3, &[("PP_FIXTURE", "hang")]);
+    let run = isolate::run(testbin(), &[], &t).unwrap();
+    assert_eq!(run.rc, 124);
+    let e = verdict::observe("P1", &run, &t, &[]).unwrap_err();
+    assert!(
+        matches!(e, Abort::TargetTimedOut { secs: 3, .. }),
+        "ordering: {e}"
+    );
+    assert!(!matches!(e, Abort::HarnessIncomplete { .. }));
+
+    // positive: a fast target under the SAME timeout passes
+    let t = target("ppfixture_census", 3, &[]);
+    let run = isolate::run(testbin(), &[], &t).unwrap();
+    assert_eq!(run.rc, 0);
+    assert!(verdict::observe("P1", &run, &t, &[]).is_ok());
+}
+
+// ------------------------------------------------------------------ row 21
+
+/// Row 21: probe-pin never writes the files it mutates. TWO arms, because a one-armed row
+/// reports the same outcome with and without the sha compare — it contains no phenomenon.
+///
+/// Arm 2's write goes to a GITIGNORED path AND the fingerprint set names that path: the two
+/// move together, because `TreeMutated` only fires on a file in the fingerprint set, and that
+/// set IS the manifest's mutated-file list. Relocating the write alone would stop the row
+/// firing and silently re-vacuate it.
+#[test]
+fn tree() {
+    let dir = tempfile::tempdir().unwrap();
+    let t = target("ppfixture_census", 60, &[]);
+
+    // arm 1 — a bind mount leaves the on-disk bytes alone
+    let files = vec![PROD.to_string()];
+    let mounts = vec![Mount {
+        mutant: mutant(dir.path(), "prod.txt", &dropped_site()),
+        target: root().join(PROD),
+    }];
+    let before = isolate::fingerprint(root(), &files).unwrap();
+    isolate::run(testbin(), &mounts, &t).unwrap();
+    let after = isolate::fingerprint(root(), &files).unwrap();
+    assert_eq!(before, after);
+    assert_eq!(isolate::verify_fingerprint(&before, &after), Ok(()));
+
+    // arm 2 — a test-only "materialize" (copy over the real path instead of mounting it)
+    std::fs::create_dir_all(root().join(TMP)).unwrap();
+    let rel = format!("{TMP}/prod.txt");
+    std::fs::write(
+        root().join(&rel),
+        "SITE-ONE marker alpha\nSITE-TWO marker beta\n",
+    )
+    .unwrap();
+    let files = vec![rel.clone()];
+    let mounts = vec![Mount {
+        mutant: mutant(dir.path(), "arm2.txt", &dropped_site()),
+        target: root().join(&rel),
+    }];
+    let before = isolate::fingerprint(root(), &files).unwrap();
+    isolate::run_with_script(
+        &isolate::SCRIPT.replace("mount --bind", "cp"),
+        testbin(),
+        &mounts,
+        &t,
+    )
+    .unwrap();
+    let after = isolate::fingerprint(root(), &files).unwrap();
+    assert_ne!(
+        before, after,
+        "the copy must actually have written the tree"
+    );
+    let e = isolate::verify_fingerprint(&before, &after).unwrap_err();
+    assert!(matches!(e, Abort::TreeMutated { .. }), "{e}");
+    std::fs::remove_file(root().join(&rel)).ok();
+}
+
+// ------------------------------------------------------------------ row 32
+
+/// Row 32: `check` catches drift in BOTH directions, and the exit codes discriminate — 1 for
+/// drift or a verdict mismatch, 2 for rot (the pinned code moved so far the probe can no
+/// longer be applied).
+#[test]
+fn drift() {
+    let dir = root().join(TMP);
+    std::fs::create_dir_all(&dir).unwrap();
+    let manifest = dir.join("drift.toml");
+    let block_file = dir.join("drift_block.md");
+    let manifest_arg = manifest
+        .strip_prefix(root())
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    let base = std::fs::read_to_string(root().join("crates/probe-pin/tests/fixtures/dogfood.toml"))
+        .unwrap()
+        .replace(
+            "crates/probe-pin/tests/fixtures/dogfood_block.md",
+            "crates/probe-pin/tests/fixtures/tmp/drift_block.md",
+        );
+    std::fs::write(&manifest, &base).unwrap();
+    std::fs::write(
+        &block_file,
+        "prose above\n// PROBE-PIN:BEGIN placeholder\n// PROBE-PIN:END\nprose below\n",
+    )
+    .unwrap();
+
+    // (c) write, then an untouched check -> 0
+    assert_eq!(probe_pin_bin(&["run", "--write", &manifest_arg], &[]).0, 0);
+    let written = std::fs::read_to_string(&block_file).unwrap();
+    assert!(written.starts_with("prose above\n") && written.ends_with("prose below\n"));
+    assert_eq!(probe_pin_bin(&["check", &manifest_arg], &[]).0, 0);
+
+    // (a) hand-edit a cell -> 1. The edit is the SAME LENGTH as what it replaces, so a
+    // length-only comparison reports the tampered block as clean.
+    let edited = written.replace("P1_drop_second_site", "P1_drop_second_SITE");
+    assert_eq!(edited.len(), written.len());
+    assert_ne!(edited, written);
+    std::fs::write(&block_file, edited).unwrap();
+    let (rc, err) = probe_pin_bin(&["check", &manifest_arg], &[]);
+    assert_eq!(rc, 1, "{err}");
+    assert!(err.contains("the generated block is stale"), "{err}");
+    std::fs::write(&block_file, &written).unwrap();
+
+    // (b) the verdict flips -> 1. P2's mutation still makes the target fail; the manifest now
+    // says it should pass, so the run has a measured verdict that contradicts its expectation.
+    let flipped = base.replace(
+        "  outcome = \"fail\"\n  anchor  = [\"CENSUS VIOLATED: expected 2 sites, got 202\"]",
+        "  outcome = \"pass\"",
+    );
+    assert_ne!(flipped, base, "the (b) arm's edit must actually apply");
+    std::fs::write(&manifest, &flipped).unwrap();
+    let (rc, err) = probe_pin_bin(&["run", "--write", &manifest_arg], &[]);
+    assert_eq!(rc, 1, "{err}");
+    assert!(err.contains("VERDICT MISMATCH"), "{err}");
+    assert_eq!(
+        std::fs::read_to_string(&block_file).unwrap(),
+        written,
+        "a non-zero exit must never splice"
+    );
+
+    // (d) the pinned code moved -> the probe cannot be applied -> 2
+    std::fs::write(&manifest, base.replace("SITE-TWO marker beta", "SITE-GONE")).unwrap();
+    let (rc, err) = probe_pin_bin(&["check", &manifest_arg], &[]);
+    assert_eq!(rc, 2, "{err}");
+    assert!(err.contains("'find' matched 0 times"), "{err}");
+
+    std::fs::remove_file(&manifest).ok();
+    std::fs::remove_file(&block_file).ok();
+}
+
+// ------------------------------------------------------------------ rows 26, 33 (binary arms)
+
+/// Row 26's both-paths arm: `run --write` and `check` BOTH abort when a declared projection's
+/// tool cannot be run. Neither emits a block with the sentence missing.
+#[test]
+fn proj_missing_both_paths() {
+    let missing = root().join("crates/probe-pin/tests/fixtures/astgrep_does_not_exist");
+    let env = [("PROBE_PIN_ASTGREP", missing.to_str().unwrap())];
+    for args in [
+        vec![
+            "run",
+            "--write",
+            "crates/probe-pin/tests/fixtures/projection.toml",
+        ],
+        vec!["check", "crates/probe-pin/tests/fixtures/projection.toml"],
+    ] {
+        let (rc, err) = probe_pin_bin(&args, &env);
+        assert_eq!(rc, 2, "{err}");
+        assert!(
+            err.contains("will not emit a block with its projection sentences missing"),
+            "{err}"
+        );
+    }
+}
+
+/// Row 33's ordering arm: the `test_count > 0` floor is evaluated on the CONTROL first, so a
+/// rotted filter aborts naming `P0_control` and no probe is ever run. Under the trivialized
+/// ordering (check every probe but not the control) the run still exits 2, but the control has
+/// already been certified on zero tests and the abort names the wrong probe.
+#[test]
+fn no_tests_selected_ordering() {
+    let dir = root().join(TMP);
+    std::fs::create_dir_all(&dir).unwrap();
+    let manifest = dir.join("rotted.toml");
+    std::fs::write(
+        &manifest,
+        std::fs::read_to_string(root().join("crates/probe-pin/tests/fixtures/dogfood.toml"))
+            .unwrap()
+            .replace(
+                "filter       = \"ppfixture_census\"",
+                "filter       = \"ppfixture_census_OLDNAME\"",
+            ),
+    )
+    .unwrap();
+    let arg = manifest
+        .strip_prefix(root())
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+
+    // MAJOR-3 (impl review): this arm flaked ONCE in ~63 suite runs with text byte-identical to
+    // row 33's own DROP signature (the `test_count` floor deleted), so a bare `assert_eq!(rc, 2)`
+    // reports "the floor regressed" and "a one-off" in the SAME bytes. The one-off's mechanism
+    // has since been reproduced — a mutation harness restoring with `cp -p` leaves cargo holding
+    // the artifact built from the previous mutant — but the COLLISION is repaired here, because
+    // any future one-off collides the same way: on failure the arm re-measures and names which
+    // one it is. It never goes green on a one-off; it reports as one.
+    let (rc, err) = probe_pin_bin(&["run", &arg], &[]);
+    if rc != 2 {
+        let again: Vec<i32> = (0..2)
+            .map(|_| probe_pin_bin(&["run", &arg], &[]).0)
+            .collect();
+        let which = if again.iter().all(|r| *r != 2) {
+            "REGRESSION (reproduced 3/3): the test_count floor is not firing on the control"
+        } else {
+            "FLAKE (1 of 3): the re-runs aborted on the control as specified — MAJOR-3's residual, NOT a floor regression"
+        };
+        panic!("probe-pin: {which}. exit: first={rc}, re-runs={again:?}, expected 2\n{err}");
+    }
+    assert!(err.contains("P0_control selected ZERO tests"), "{err}");
+    assert!(err.contains("INSTRUMENT FAILURE"), "{err}");
+    assert!(
+        !err.contains("P1_drop_second_site") && !err.contains("P2_pad"),
+        "the pipeline must stop at the control: {err}"
+    );
+    std::fs::remove_file(&manifest).ok();
+}
+
+// ------------------------------------------------ §7 wiring: steps 7, 9 and 10 (MAJOR-2)
+//
+// Rows 10, 21 and §8's control-failed row pin the FUNCTIONS. These three arms pin the CALLS:
+// each drives the real binary end-to-end on a manifest that reaches only that step, and each
+// was revert-probed by deleting its step from `main.rs` (measured: rc 2 -> rc 0, all three).
+// No production code participates in them beyond the pipeline itself.
+
+/// §7 step 9 is CALLED. `manifest::validate` compares anchor LISTS to each other, so P1's list
+/// being a SUBSET of P2's captured failure is invisible to it; only the all-pairs scan over the
+/// captures sees it, and that scan runs at exactly one call site.
+#[test]
+fn wiring_discriminate() {
+    let (rc, err) = probe_pin_bin(
+        &["run", "crates/probe-pin/tests/fixtures/collide.toml"],
+        &[],
+    );
+    assert_eq!(rc, 2, "{err}");
+    assert!(
+        err.contains("These two probes are not distinguished"),
+        "{err}"
+    );
+    assert!(
+        err.contains("P1_drop_second_site") && err.contains("P2_pad_reaches_target"),
+        "{err}"
+    );
+}
+
+/// §7 step 10 is CALLED — invariant (a)'s runtime enforcement. The manifest's target writes an
+/// unmounted path during the CONTROL run, which is a real write to the measured tree.
+#[test]
+fn wiring_verify_fingerprint() {
+    std::fs::create_dir_all(root().join(TMP)).unwrap();
+    let file = root().join(TMP).join("tree_write.txt");
+    std::fs::write(&file, "ORIGINAL\n").unwrap();
+
+    let (rc, err) = probe_pin_bin(
+        &["run", "crates/probe-pin/tests/fixtures/treewrite.toml"],
+        &[],
+    );
+    // reach guard: without the write, the step has nothing to detect and the arm is vacuous
+    assert_ne!(
+        std::fs::read_to_string(&file).unwrap(),
+        "ORIGINAL\n",
+        "the target must actually have written the tree: {err}"
+    );
+    assert_eq!(rc, 2, "{err}");
+    assert!(err.contains("TREE MUTATED"), "{err}");
+    assert!(err.contains("tree_write.txt"), "{err}");
+    std::fs::remove_file(&file).ok();
+}
+
+/// §7 step 7's `ControlFailed` branch is CALLED: a control that fails on the unmodified tree is
+/// a broken instrument, and §8's control-failed row is otherwise unreachable.
+#[test]
+fn wiring_control_failed() {
+    let (rc, err) = probe_pin_bin(
+        &["run", "crates/probe-pin/tests/fixtures/control_fails.toml"],
+        &[],
+    );
+    assert_eq!(rc, 2, "{err}");
+    assert!(
+        err.contains("the control probe 'P0_control' (no mounts, unmodified tree) FAILED"),
+        "{err}"
+    );
+    assert!(
+        err.contains("every other verdict in this run is meaningless"),
+        "{err}"
+    );
+}
+
+/// The dogfood: probe-pin runs its own committed manifest against its own committed block.
+/// This is the same invocation the Tilt `probe-pin-check` resource makes.
+#[test]
+fn dogfood_check() {
+    let (rc, err) = probe_pin_bin(
+        &["check", "crates/probe-pin/tests/fixtures/dogfood.toml"],
+        &[],
+    );
+    assert_eq!(rc, 0, "{err}");
+}
+
+/// The isolation model itself: a run under `unshare` never sees the ambient environment, and
+/// `Run`'s streams are never merged.
+#[test]
+fn streams_are_separate() {
+    let t = target("ppfixture_census", 60, &[]);
+    let run: Run = isolate::run(testbin(), &[], &t).unwrap();
+    assert!(
+        run.stdout.lines().next().unwrap().contains("\"suite\""),
+        "stdout must be a pure record stream: {:?}",
+        run.stdout.lines().next()
+    );
+    assert!(
+        run.stderr.is_empty(),
+        "streams are never merged: {:?}",
+        run.stderr
+    );
+    assert_eq!(
+        verdict::verdict(
+            &Manifest::load(&root().join("crates/probe-pin/tests/fixtures/dogfood.toml"))
+                .unwrap()
+                .probes[0],
+            &verdict::observe("P0_control", &run, &t, &[]).unwrap(),
+            0
+        ),
+        Ok(Verdict::Pass { mounts_reached: 0 })
+    );
+}

--- a/crates/probe-pin/tests/isolation_e2e.rs
+++ b/crates/probe-pin/tests/isolation_e2e.rs
@@ -526,6 +526,29 @@ fn wiring_control_failed() {
     );
 }
 
+/// §7 step 7 goes through `verdict::verdict` (final review-impl, MAJOR-2). Step 7 used to
+/// CONSTRUCT `Verdict::Pass { mounts_reached: 0 }` for the control by hand, so the one probe
+/// whose whole job is "the instrument works" was the one probe outside the crate's verdict
+/// authority: a control whose expectation the run refutes rendered `| fail | pass |` in a
+/// spliceable block and exited 0. The complement — a control declared `fail` that really does
+/// fail — is `wiring_control_failed` above: an instrument failure, exit 2, no verdict at all.
+#[test]
+fn wiring_control_goes_through_the_verdict_authority() {
+    let (rc, err) = probe_pin_bin(
+        &[
+            "run",
+            "crates/probe-pin/tests/fixtures/control_expect_fail.toml",
+        ],
+        &[],
+    );
+    assert_eq!(rc, 1, "{err}");
+    assert!(err.contains("VERDICT MISMATCH"), "{err}");
+    assert!(
+        err.contains("P0_control expected outcome = \"fail\" but the target PASSED"),
+        "{err}"
+    );
+}
+
 /// The dogfood: probe-pin runs its own committed manifest against its own committed block.
 /// This is the same invocation the Tilt `probe-pin-check` resource makes.
 #[test]

--- a/crates/probe-pin/tests/isolation_e2e.rs
+++ b/crates/probe-pin/tests/isolation_e2e.rs
@@ -402,10 +402,10 @@ fn proj_missing_both_paths() {
     }
 }
 
-/// Row 33's ordering arm: the `test_count > 0` floor is evaluated on the CONTROL first, so a
-/// rotted filter aborts naming `P0_control` and no probe is ever run. Under the trivialized
-/// ordering (check every probe but not the control) the run still exits 2, but the control has
-/// already been certified on zero tests and the abort names the wrong probe.
+/// Row 33's ordering arm: the execution floor is evaluated on the CONTROL first, so a rotted
+/// filter aborts naming `P0_control` and no probe is ever run. Under the trivialized ordering
+/// (check every probe but not the control) the run still exits 2, but the control has already
+/// been certified on zero tests and the abort names the wrong probe.
 #[test]
 fn no_tests_selected_ordering() {
     let dir = root().join(TMP);
@@ -441,13 +441,14 @@ fn no_tests_selected_ordering() {
             .map(|_| probe_pin_bin(&["run", &arg], &[]).0)
             .collect();
         let which = if again.iter().all(|r| *r != 2) {
-            "REGRESSION (reproduced 3/3): the test_count floor is not firing on the control"
+            "REGRESSION (reproduced 3/3): the execution floor is not firing on the control"
         } else {
             "FLAKE (1 of 3): the re-runs aborted on the control as specified — MAJOR-3's residual, NOT a floor regression"
         };
         panic!("probe-pin: {which}. exit: first={rc}, re-runs={again:?}, expected 2\n{err}");
     }
-    assert!(err.contains("P0_control selected ZERO tests"), "{err}");
+    assert!(err.contains("P0_control MEASURED NOTHING"), "{err}");
+    assert!(err.contains("selected ZERO tests"), "{err}");
     assert!(err.contains("INSTRUMENT FAILURE"), "{err}");
     assert!(
         !err.contains("P1_drop_second_site") && !err.contains("P2_pad"),
@@ -547,6 +548,147 @@ fn wiring_control_goes_through_the_verdict_authority() {
         err.contains("P0_control expected outcome = \"fail\" but the target PASSED"),
         "{err}"
     );
+}
+
+/// A manifest under the gitignored tmp dir, plus its workspace-relative argument.
+fn tmp_manifest(name: &str, text: &str) -> (PathBuf, String) {
+    let dir = root().join(TMP);
+    std::fs::create_dir_all(&dir).unwrap();
+    let path = dir.join(name);
+    std::fs::write(&path, text).unwrap();
+    let arg = path
+        .strip_prefix(root())
+        .unwrap()
+        .to_str()
+        .unwrap()
+        .to_string();
+    (path, arg)
+}
+
+/// The execution floor END TO END — the BLOCKER's exact repro, flipped. A `#[ignore]` on the
+/// pinned test needs no manifest edit at all, so before this floor the digest, the block and the
+/// Tilt resource stayed green forever for a tree nothing measured. Measured on the shipping
+/// binary before the fix: exit 0, and a `| pass | pass | mount reached: 1 file(s) |` row.
+///
+/// Both routes run through the real pipeline, so this pins the CALL as well as the condition.
+#[test]
+fn execution_floor_aborts_a_zero_run() {
+    let base = std::fs::read_to_string(root().join("crates/probe-pin/tests/fixtures/dogfood.toml"))
+        .unwrap()
+        // a probe whose mutant leaves the census passing: the shape that renders a green `pass`
+        // row, which is what a skipped run forges
+        .replace(
+            "  find    = \"SITE-TWO marker beta\\n\"\n  replace = \"\"",
+            "  find    = \"alpha\"\n  replace = \"gamma\"",
+        )
+        .replace("  text  = \"marker\"\n  count = 1", "  text  = \"gamma\"\n  count = 1")
+        .replace(
+            "  outcome = \"fail\"\n  anchor  = [\"CENSUS VIOLATED: expected 2 sites, got 1\",\n             \"text: \\\"SITE-ONE marker alpha\\\\n\\\"\"]",
+            "  outcome = \"pass\"",
+        );
+    // the reach guard: this manifest must be GREEN when the target really runs, or every arm
+    // below aborts for a reason that has nothing to do with the floor
+    let (_, arg) = tmp_manifest("floor_base.toml", &base);
+    let (rc, err) = probe_pin_bin(&["run", &arg], &[]);
+    assert_eq!(rc, 0, "the benign arm must pass: {err}");
+
+    for (name, edit, route) in [
+        (
+            "floor_ignored.toml",
+            base.replace(
+                "filter       = \"ppfixture_census\"",
+                "filter       = \"ppfixture_ignored\"",
+            ),
+            "#[ignore] on the pinned test",
+        ),
+        (
+            "floor_bench.toml",
+            base.replace(
+                "timeout_secs = 60",
+                "timeout_secs = 60\nargs         = [\"--bench\"]",
+            ),
+            "--bench through [target].args",
+        ),
+    ] {
+        assert_ne!(edit, base, "{route}: the edit must apply");
+        let (_, arg) = tmp_manifest(name, &edit);
+        let (rc, err) = probe_pin_bin(&["run", &arg], &[]);
+        assert_eq!(rc, 2, "{route} must abort, got {rc}: {err}");
+        assert!(err.contains("MEASURED NOTHING"), "{route}: {err}");
+        assert!(err.contains("was SKIPPED"), "{route}: {err}");
+        // and it stops at the CONTROL, so no probe's verdict is rendered from a skipped run
+        assert!(err.contains("P0_control"), "{route}: {err}");
+        assert!(!err.contains("PROBE-PIN:BEGIN"), "{route}: {err}");
+    }
+    for name in ["floor_base.toml", "floor_ignored.toml", "floor_bench.toml"] {
+        std::fs::remove_file(root().join(TMP).join(name)).ok();
+    }
+}
+
+/// §7 step 1b is CALLED. `[output].file` through an IN-TREE SYMLINK is lexically clean — every
+/// component is `Normal` — so `validate` accepts it and only the realpath containment assert at
+/// the new call site can refuse it. Measured on the shipping binary before the fix: exit 0, and
+/// the block spliced into a file outside the repository.
+///
+/// Revert-probe: delete the `validate_paths` call from `main.rs` and this arm goes to rc 0 with
+/// the block written at the symlink's target.
+#[test]
+fn wiring_validate_paths() {
+    let outside = tempfile::tempdir().unwrap();
+    let victim = outside.path().join("escape.md");
+    std::fs::write(
+        &victim,
+        "prose above\n// PROBE-PIN:BEGIN placeholder\n// PROBE-PIN:END\nprose below\n",
+    )
+    .unwrap();
+    std::fs::create_dir_all(root().join(TMP)).unwrap();
+    let link = root().join(TMP).join("escape_link");
+    std::fs::remove_file(&link).ok();
+    std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+
+    let text = std::fs::read_to_string(root().join("crates/probe-pin/tests/fixtures/dogfood.toml"))
+        .unwrap()
+        .replace(
+            "crates/probe-pin/tests/fixtures/dogfood_block.md",
+            "crates/probe-pin/tests/fixtures/tmp/escape_link/escape.md",
+        );
+    let (_, arg) = tmp_manifest("escape_out.toml", &text);
+    let before = std::fs::read_to_string(&victim).unwrap();
+
+    let (rc, err) = probe_pin_bin(&["run", "--write", &arg], &[]);
+    assert_eq!(rc, 2, "{err}");
+    assert!(err.contains("[output].file"), "{err}");
+    assert!(err.contains("is not workspace-relative"), "{err}");
+    assert_eq!(
+        std::fs::read_to_string(&victim).unwrap(),
+        before,
+        "nothing may be written outside the workspace"
+    );
+
+    // positive: the same manifest naming a real in-tree output still runs to a block
+    let (_, arg) = tmp_manifest(
+        "escape_out_ok.toml",
+        &text.replace(
+            "crates/probe-pin/tests/fixtures/tmp/escape_link/escape.md",
+            "crates/probe-pin/tests/fixtures/tmp/contained_block.md",
+        ),
+    );
+    std::fs::write(
+        root().join(TMP).join("contained_block.md"),
+        "prose above\n// PROBE-PIN:BEGIN placeholder\n// PROBE-PIN:END\nprose below\n",
+    )
+    .unwrap();
+    let (rc, err) = probe_pin_bin(&["run", "--write", &arg], &[]);
+    assert_eq!(rc, 0, "the contained path must still be writable: {err}");
+
+    std::fs::remove_file(&link).ok();
+    for name in [
+        "escape_out.toml",
+        "escape_out_ok.toml",
+        "contained_block.md",
+    ] {
+        std::fs::remove_file(root().join(TMP).join(name)).ok();
+    }
 }
 
 /// The dogfood: probe-pin runs its own committed manifest against its own committed block.

--- a/crates/probe-pin/tests/isolation_e2e.rs
+++ b/crates/probe-pin/tests/isolation_e2e.rs
@@ -53,7 +53,9 @@ fn root() -> &'static Path {
 /// Resolved once per process: the nested `cargo test --no-run` is the expensive part.
 fn testbin() -> &'static Path {
     static BIN: OnceLock<PathBuf> = OnceLock::new();
-    BIN.get_or_init(|| probe_pin::target::resolve("probe-pin", "pure_logic").expect("test binary"))
+    BIN.get_or_init(|| {
+        probe_pin::target::resolve(root(), "probe-pin", "pure_logic").expect("test binary")
+    })
 }
 
 fn target(filter: &str, secs: u64, env: &[(&str, &str)]) -> Target {

--- a/crates/probe-pin/tests/isolation_e2e.rs
+++ b/crates/probe-pin/tests/isolation_e2e.rs
@@ -7,6 +7,27 @@
 //! Rows 1, 2 and 21 execute their own DROP arms: each is defined as a mutation of the
 //! isolation SCRIPT (drop the readback / compare the mutant with itself / copy instead of
 //! mount), so the test derives the mutant script and runs it through the same entry point.
+//!
+//! # Every test here is `#[ignore]`d, and that is a measurement, not a preference
+//!
+//! GitHub's runners deny unprivileged user namespaces: `unshare --map-root-user --mount`
+//! fails with `write failed /proc/self/uid_map: Operation not permitted`. Measured on
+//! <https://github.com/phase-rs/phase/actions/runs/31646292055> — 14 of these 15 tests failed
+//! there for that one reason, spread across all four test shards.
+//!
+//! The suite is ignored WHOLE rather than per failing test. The lone survivor
+//! (`proj_missing_both_paths`) passes only because its manifest is refused at validation,
+//! before `unshare` is ever reached — a property of that fixture, not of the test. Splitting
+//! the suite on "does this manifest happen to abort early" creates a boundary that moves
+//! silently the next time a fixture or a refusal order changes, and a Tier-2 test that stops
+//! reaching Tier 2 is exactly the unmeasured-green this crate exists to refuse.
+//!
+//! `#[ignore]` and not a runtime capability check: a test that quietly no-ops when the
+//! namespace is missing reports as PASSED. That is this crate's own BLOCKER defect wearing a
+//! test harness. An ignored test reports as ignored.
+//!
+//! Run them where namespaces work:
+//! `cargo test -p probe-pin --test isolation_e2e -- --ignored`
 
 use std::path::{Path, PathBuf};
 use std::process::Command;
@@ -107,6 +128,7 @@ fn probe_pin_bin(args: &[&str], env: &[(&str, &str)]) -> (i32, String) {
 /// readback catches it; arm C removes the readback too and the same unmounted run reports a
 /// clean PASS — which is the whole reason a `pass` verdict is only worth its readback.
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn mount_reach() {
     let dir = tempfile::tempdir().unwrap();
     let mounts = vec![Mount {
@@ -165,6 +187,7 @@ fn mount_reach() {
 /// Row 2: a `Prepend` mutant reaches the target too. The census reports 202 sites under a
 /// real 200-line pad, and 2 when the mount is dropped.
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn pad_reach() {
     let dir = tempfile::tempdir().unwrap();
     let padded = format!(
@@ -227,6 +250,7 @@ fn pad_reach() {
 /// 240 s hard kill; with `timeout 0` it would never fire. The abort reported is
 /// `TargetTimedOut` and not the co-firing `HarnessIncomplete { SuiteFinished }`.
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn timeout() {
     let t = target("ppfixture_hang", 3, &[("PP_FIXTURE", "hang")]);
     let run = isolate::run(testbin(), &[], &t).unwrap();
@@ -255,6 +279,7 @@ fn timeout() {
 /// set IS the manifest's mutated-file list. Relocating the write alone would stop the row
 /// firing and silently re-vacuate it.
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn tree() {
     let dir = tempfile::tempdir().unwrap();
     let t = target("ppfixture_census", 60, &[]);
@@ -308,6 +333,7 @@ fn tree() {
 /// drift or a verdict mismatch, 2 for rot (the pinned code moved so far the probe can no
 /// longer be applied).
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn drift() {
     let dir = root().join(TMP);
     std::fs::create_dir_all(&dir).unwrap();
@@ -382,6 +408,7 @@ fn drift() {
 /// Row 26's both-paths arm: `run --write` and `check` BOTH abort when a declared projection's
 /// tool cannot be run. Neither emits a block with the sentence missing.
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn proj_missing_both_paths() {
     let missing = root().join("crates/probe-pin/tests/fixtures/astgrep_does_not_exist");
     let env = [("PROBE_PIN_ASTGREP", missing.to_str().unwrap())];
@@ -407,6 +434,7 @@ fn proj_missing_both_paths() {
 /// (check every probe but not the control) the run still exits 2, but the control has already
 /// been certified on zero tests and the abort names the wrong probe.
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn no_tests_selected_ordering() {
     let dir = root().join(TMP);
     std::fs::create_dir_all(&dir).unwrap();
@@ -468,6 +496,7 @@ fn no_tests_selected_ordering() {
 /// being a SUBSET of P2's captured failure is invisible to it; only the all-pairs scan over the
 /// captures sees it, and that scan runs at exactly one call site.
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn wiring_discriminate() {
     let (rc, err) = probe_pin_bin(
         &["run", "crates/probe-pin/tests/fixtures/collide.toml"],
@@ -487,6 +516,7 @@ fn wiring_discriminate() {
 /// §7 step 10 is CALLED — invariant (a)'s runtime enforcement. The manifest's target writes an
 /// unmounted path during the CONTROL run, which is a real write to the measured tree.
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn wiring_verify_fingerprint() {
     std::fs::create_dir_all(root().join(TMP)).unwrap();
     let file = root().join(TMP).join("tree_write.txt");
@@ -511,6 +541,7 @@ fn wiring_verify_fingerprint() {
 /// §7 step 7's `ControlFailed` branch is CALLED: a control that fails on the unmodified tree is
 /// a broken instrument, and §8's control-failed row is otherwise unreachable.
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn wiring_control_failed() {
     let (rc, err) = probe_pin_bin(
         &["run", "crates/probe-pin/tests/fixtures/control_fails.toml"],
@@ -534,6 +565,7 @@ fn wiring_control_failed() {
 /// spliceable block and exited 0. The complement — a control declared `fail` that really does
 /// fail — is `wiring_control_failed` above: an instrument failure, exit 2, no verdict at all.
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn wiring_control_goes_through_the_verdict_authority() {
     let (rc, err) = probe_pin_bin(
         &[
@@ -572,6 +604,7 @@ fn tmp_manifest(name: &str, text: &str) -> (PathBuf, String) {
 ///
 /// Both routes run through the real pipeline, so this pins the CALL as well as the condition.
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn execution_floor_aborts_a_zero_run() {
     let base = std::fs::read_to_string(root().join("crates/probe-pin/tests/fixtures/dogfood.toml"))
         .unwrap()
@@ -633,6 +666,7 @@ fn execution_floor_aborts_a_zero_run() {
 /// Revert-probe: delete the `validate_paths` call from `main.rs` and this arm goes to rc 0 with
 /// the block written at the symlink's target.
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn wiring_validate_paths() {
     let outside = tempfile::tempdir().unwrap();
     let victim = outside.path().join("escape.md");
@@ -694,6 +728,7 @@ fn wiring_validate_paths() {
 /// The dogfood: probe-pin runs its own committed manifest against its own committed block.
 /// This is the same invocation the Tilt `probe-pin-check` resource makes.
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn dogfood_check() {
     let (rc, err) = probe_pin_bin(
         &["check", "crates/probe-pin/tests/fixtures/dogfood.toml"],
@@ -705,6 +740,7 @@ fn dogfood_check() {
 /// The isolation model itself: a run under `unshare` never sees the ambient environment, and
 /// `Run`'s streams are never merged.
 #[test]
+#[ignore = "Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`."]
 fn streams_are_separate() {
     let t = target("ppfixture_census", 60, &[]);
     let run: Run = isolate::run(testbin(), &[], &t).unwrap();

--- a/crates/probe-pin/tests/pure_logic.rs
+++ b/crates/probe-pin/tests/pure_logic.rs
@@ -774,6 +774,67 @@ fn control_may_not_declare_an_assert_count() {
     assert!(manifest::validate(&toml::from_str::<Manifest>(&text).unwrap()).is_ok());
 }
 
+/// The Tier-2 suite is `#[ignore]`d because GitHub's runners deny unprivileged user namespaces,
+/// so GH CI never executes a real mount. That is a measured accommodation, and an accommodation
+/// with nothing watching it decays: a Tier-2 test added without the attribute turns CI red for a
+/// reason nobody will connect to namespaces, and — worse — the ignored set can widen into tests
+/// that had no capability problem at all, which is "skipped in CI" quietly becoming "isolation
+/// abandoned".
+///
+/// This guard lives in `pure_logic` on purpose: it is the suite CI actually runs, so the watcher
+/// is not itself ignored. It pins the count, the attribute on EVERY test, and the exact reason
+/// text — reword the reason and this fails, which is the intent: the reason is the only place a
+/// reader is told the accommodation is about namespaces and how to run the suite anyway.
+///
+/// The companion control is the Tilt `probe-pin-e2e` resource, which runs the suite with
+/// `--ignored` in the local venue, where the capability exists. Together: this test says "the
+/// suite is still uniformly ignored and still says why", and Tilt says "and it still passes".
+#[test]
+fn tier2_suite_is_uniformly_ignored_with_the_measured_reason() {
+    const EXPECTED: &str = "#[ignore = \"Tier 2: drives probe-pin through `unshare --map-root-user --mount`. CI runners deny unprivileged user namespaces (uid_map EPERM), so the whole suite runs locally only: `cargo test -p probe-pin --test isolation_e2e -- --ignored`.\"]";
+
+    let src = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/isolation_e2e.rs"),
+    )
+    .expect("the Tier-2 suite is readable");
+    let lines: Vec<&str> = src.lines().collect();
+
+    // Count the ATTRIBUTE, never the string: this file's own doc comments and a fixture label
+    // both contain the text `#[ignore]`, and an unanchored match counts those too — the exact
+    // trap that produced a 7-vs-1 discrepancy when this suite was first measured.
+    let tests: Vec<usize> = lines
+        .iter()
+        .enumerate()
+        .filter(|(_, l)| l.trim() == "#[test]")
+        .map(|(i, _)| i)
+        .collect();
+    assert_eq!(
+        tests.len(),
+        15,
+        "the Tier-2 suite changed size. Every test here needs the #[ignore] attribute (CI cannot \
+         create a mount namespace); update this count deliberately, and keep the Tilt \
+         `probe-pin-e2e` resource as the venue that actually runs them."
+    );
+    assert!(
+        lines.iter().filter(|l| l.contains("#[ignore")).count() > tests.len(),
+        "instrument check: this file is known to contain #[ignore] MENTIONS in prose as well as \
+         attributes, so a raw substring count must exceed the attribute count. If it does not, \
+         the mentions moved and this test's anchoring rationale needs re-reading."
+    );
+
+    for i in tests {
+        let next = lines[i + 1].trim();
+        assert_eq!(
+            next,
+            EXPECTED,
+            "the #[test] at isolation_e2e.rs:{} is not followed by the expected #[ignore]. Every \
+             Tier-2 test must carry it verbatim: CI denies unprivileged user namespaces, so an \
+             unignored test here fails on every run for a reason unrelated to what it asserts.",
+            i + 1
+        );
+    }
+}
+
 /// Driver-added. `docs/probe-pin.md`'s manifest example is the surface a first user COPIES, and
 /// it had no mechanical coverage at all — an example is code that never runs, so nothing caught
 /// that it (a) was not valid TOML (`text = "…" ; count = 1`; `;` is not a TOML separator) and

--- a/crates/probe-pin/tests/pure_logic.rs
+++ b/crates/probe-pin/tests/pure_logic.rs
@@ -1,0 +1,1553 @@
+//! Tier 1 — §10 rows 3-13, 15-20, 22-31 and 33's non-ordering arms. Zero namespace
+//! dependency: nothing here runs `unshare`.
+//!
+//! The `ppfixture_*` tests at the bottom are not assertions about probe-pin — they are the
+//! TARGETS the Tier-2 dogfood manifests and the child-process arms below drive. They are
+//! inert (or trivially passing) unless `PP_FIXTURE` selects them, so a plain
+//! `cargo test --test pure_logic` runs them as no-ops.
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+use probe_pin::block::{self, Outcome, ProjectionCount};
+use probe_pin::isolate::{self, Run};
+use probe_pin::manifest::{self, Manifest, Probe, Target};
+use probe_pin::mutate;
+use probe_pin::project;
+use probe_pin::target;
+use probe_pin::verdict::{self, Verdict};
+use probe_pin::{Abort, CheckOutcome, DriftCause, HarnessMarker, Instrument, InstrumentChange};
+
+// ------------------------------------------------------------------ helpers
+
+fn fixtures() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures")
+}
+
+fn load(name: &str) -> Manifest {
+    Manifest::load(&fixtures().join(name)).expect("fixture manifest parses")
+}
+
+fn abort_of(e: anyhow::Error) -> Abort {
+    e.downcast::<Abort>().expect("error is an Abort")
+}
+
+/// A `[target]` good enough to classify a synthetic record stream against.
+fn target() -> Target {
+    load("dogfood.toml").target
+}
+
+fn run_of(rc: i32, stdout: &str) -> Run {
+    Run {
+        rc,
+        stdout: stdout.to_string(),
+        stderr: String::new(),
+    }
+}
+
+/// A libtest JSON stream: suite started, the given test records, suite terminal.
+fn stream(test_count: usize, records: &[&str], terminal: &str) -> String {
+    let mut s =
+        format!("{{\"type\":\"suite\",\"event\":\"started\",\"test_count\":{test_count}}}\n");
+    for r in records {
+        s.push_str(r);
+        s.push('\n');
+    }
+    s.push_str(&format!(
+        "{{\"type\":\"suite\",\"event\":\"{terminal}\",\"passed\":0,\"failed\":1,\"filtered_out\":3}}\n"
+    ));
+    s
+}
+
+fn probe(toml: &str) -> Probe {
+    toml::from_str(toml).expect("probe fixture parses")
+}
+
+fn write(dir: &Path, rel: &str, text: &str) {
+    let p = dir.join(rel);
+    std::fs::create_dir_all(p.parent().unwrap()).unwrap();
+    std::fs::write(p, text).unwrap();
+}
+
+/// Re-exec THIS test binary as a libtest target: the cheapest real record stream there is.
+/// `filter` is a SUBSTRING filter, exactly like the shipping argv; `extra` is where a test
+/// adds `--exact` or a `[target].args` flag.
+fn child(filter: &str, env: &[(&str, &str)], extra: &[&str]) -> Run {
+    // Under `timeout`, exactly as the shipping script runs the target. That is not cosmetic:
+    // a signal-killed child has no exit CODE at all, and `timeout` is what normalizes SIGABRT
+    // to the 134 the pipeline classifies on.
+    let mut cmd = Command::new("timeout");
+    cmd.args(["-k", "5", "60"])
+        .arg(std::env::current_exe().unwrap())
+        .args([filter, "--test-threads=1", "--format", "json"])
+        .args(["-Z", "unstable-options"])
+        .args(extra);
+    cmd.env_clear();
+    for key in ["PATH", "HOME"] {
+        if let Ok(v) = std::env::var(key) {
+            cmd.env(key, v);
+        }
+    }
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let out = cmd.output().expect("child target runs");
+    Run {
+        rc: isolate::exit_rc(&out.status),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&out.stderr).into_owned(),
+    }
+}
+
+// ------------------------------------------------------------------ row 3, 4, 5, 6
+
+/// Row 3: anchors are scoped to ONE `{"type":"test"}` `failed` record — not to the whole
+/// stdout, and not to an inferred prose block. DROP (scan the whole stdout) makes the forged
+/// anchor hit; TRIVIALIZE (one buffer) makes the cross-record pair hit.
+#[test]
+fn json_scope() {
+    let s = stream(
+        3,
+        &[
+            r#"{"type":"test","name":"c_pass","event":"ok","stdout":"FORGED FROM A PASSING TEST\n"}"#,
+            r#"{"type":"test","name":"a_fail","event":"failed","stdout":"REAL ANCHOR ONE\nREAL ANCHOR TWO\n"}"#,
+            r#"{"type":"test","name":"b_fail","event":"failed","stdout":"OTHER FAILURE\n"}"#,
+        ],
+        "failed",
+    );
+    let obs =
+        verdict::observe("P1", &run_of(101, &s), &target(), &[]).expect("no instrument failure");
+    let anchors = |v: &[&str]| {
+        verdict::all_anchors_in_one(
+            &v.iter().map(|s| s.to_string()).collect::<Vec<_>>(),
+            &obs.failed_captures,
+        )
+    };
+
+    // hostile: a passing test's own output can never satisfy an anchor
+    assert!(!anchors(&["FORGED FROM A PASSING TEST"]));
+    // hostile: two anchors that only jointly exist ACROSS two failed records
+    assert!(!anchors(&["REAL ANCHOR ONE", "OTHER FAILURE"]));
+    // reach guard: the real two-fragment anchor, both fragments in ONE record
+    assert!(anchors(&["REAL ANCHOR ONE", "REAL ANCHOR TWO"]));
+    assert_eq!(obs.failed_captures.len(), 2);
+}
+
+/// Row 4: a `#[should_panic]` test that PASSES is not a failure. libtest reports it
+/// `event:"ok"` with no capture, so it is unreachable by any anchor.
+#[test]
+fn should_panic() {
+    // The `event:"started"` records are what a REAL libtest stream carries, and they are what
+    // separates "failed" from the trivialized "every record whose event != ok".
+    let s = stream(
+        2,
+        &[
+            r#"{"type":"test","event":"started","name":"d_should_panic_passes"}"#,
+            r#"{"type":"test","name":"d_should_panic_passes","event":"ok"}"#,
+            r#"{"type":"test","event":"started","name":"a_fail"}"#,
+            r#"{"type":"test","name":"a_fail","event":"failed","stdout":"REAL\n"}"#,
+        ],
+        "failed",
+    );
+    let obs = verdict::observe("P1", &run_of(101, &s), &target(), &[]).unwrap();
+    assert_eq!(obs.failed_captures, vec!["REAL\n".to_string()]);
+    assert!(!obs
+        .failed_captures
+        .iter()
+        .any(|c| c.contains("should_panic")));
+}
+
+/// Row 5: a panic whose MESSAGE contains a `thread '…' panicked at` line stays ONE record.
+/// The deleted prose block-splitter would have cut it in two and produced a false refutation.
+#[test]
+fn nested_thread_line() {
+    let inner = "thread 'inner' (1) panicked at src/x.rs:1:1:\\nFRAGMENT TWO";
+    let s = stream(
+        1,
+        &[&format!(
+            r#"{{"type":"test","name":"e","event":"failed","stdout":"\nthread 'e' (2) panicked at tests/mount.rs:7:5:\nFRAGMENT ONE {inner}\n"}}"#
+        )],
+        "failed",
+    );
+    let obs = verdict::observe("P1", &run_of(101, &s), &target(), &[]).unwrap();
+    assert_eq!(obs.failed_captures.len(), 1);
+    assert!(verdict::all_anchors_in_one(
+        &["FRAGMENT ONE".to_string(), "FRAGMENT TWO".to_string()],
+        &obs.failed_captures
+    ));
+}
+
+/// Row 6: JSON escaping round-trips exactly — quote, backslash, tab, ESC, non-ASCII.
+#[test]
+fn escaping() {
+    let s = stream(
+        1,
+        &[r#"{"type":"test","name":"f","event":"failed","stdout":"q=\" b=\\ t=\t e=\u001b n=é"}"#],
+        "failed",
+    );
+    let obs = verdict::observe("P1", &run_of(101, &s), &target(), &[]).unwrap();
+    assert_eq!(obs.failed_captures[0], "q=\" b=\\ t=\t e=\u{1b} n=é");
+}
+
+// ------------------------------------------------------------------ row 7
+
+/// Row 7: every reserved flag is rejected, on the option NAME rather than the raw token —
+/// `--test-threads=4`, `--format=terse` and `-Zunstable-options` are the three spellings a
+/// raw-token list misclassifies. The four negative controls still validate, so the fix does
+/// not narrow the live `args` field.
+#[test]
+fn reserved_arg() {
+    let mut m = load("dogfood.toml");
+    for hostile in [
+        "--nocapture",
+        "--format",
+        "--test-threads=4",
+        "--format=terse",
+        "-Zunstable-options",
+        "--exact",
+        "--show-output",
+        "-q",
+    ] {
+        m.target.args = vec![hostile.to_string()];
+        let e = abort_of(manifest::validate(&m).unwrap_err());
+        assert!(
+            matches!(e, Abort::ReservedArg { ref arg } if arg == hostile),
+            "{hostile}"
+        );
+    }
+    for benign in [
+        "--skip=foo",
+        "--skip",
+        "--ignored",
+        "--exclude-should-panic",
+    ] {
+        m.target.args = vec![benign.to_string()];
+        assert!(manifest::validate(&m).is_ok(), "{benign}");
+    }
+    m.target.args = vec![];
+    assert!(manifest::validate(&m).is_ok());
+
+    // Why they are reserved: ONE non-JSON line on stdout breaks the strict parse.
+    let mut s = stream(1, &[], "ok");
+    s.insert_str(0, "SECOND-LINE-OF-B: got [Site { line: 11492 }]\n");
+    let e = verdict::observe("P1", &run_of(0, &s), &target(), &[]).unwrap_err();
+    assert!(matches!(e, Abort::HarnessOutputUnparseable { .. }));
+}
+
+// ------------------------------------------------------------------ row 8
+
+/// Row 8: the harness must have COMPLETED. Fixture A aborts unconditionally, so no
+/// `RUST_MIN_STACK` value rescues it — the suite terminal record is what fires, and dropping
+/// the marker requirement would turn rc 134 into a `Verdict::Fail`.
+#[test]
+fn harness() {
+    for stack in ["", "1", "16777216", "268435456"] {
+        let env: Vec<(&str, &str)> = if stack.is_empty() {
+            vec![("PP_FIXTURE", "abort")]
+        } else {
+            vec![("PP_FIXTURE", "abort"), ("RUST_MIN_STACK", stack)]
+        };
+        let run = child("ppfixture_abort", &env, &[]);
+        assert_eq!(
+            run.rc, 134,
+            "RUST_MIN_STACK={stack:?} should not rescue an abort()"
+        );
+        let e = verdict::observe("P1", &run, &target(), &[]).unwrap_err();
+        assert!(
+            matches!(
+                e,
+                Abort::HarnessIncomplete {
+                    missing: HarnessMarker::SuiteFinished,
+                    rc: 134,
+                    ..
+                }
+            ),
+            "RUST_MIN_STACK={stack:?} -> {e}"
+        );
+    }
+    // reach guard: the same target, not aborting, classifies cleanly
+    let run = child("ppfixture_abort", &[], &[]);
+    assert_eq!(run.rc, 0);
+    assert!(verdict::observe("P1", &run, &target(), &[]).is_ok());
+}
+
+// ------------------------------------------------------------------ row 9
+
+/// Row 9: no anchor may embed a source line number. Measured on the real corpus: 0 of 10
+/// shipping anchors rejected, 7 of 9 hostile spellings rejected, and 0 of 8 plausible
+/// legitimate anchors whose text merely ENDS in "line" rejected.
+#[test]
+fn anchor_lint() {
+    let shipping = [
+        "PROVENANCE SPLIT VIOLATED",
+        "text: \"Ok(TargetPin::Player(*player))\"",
+        "text: \"TargetRef::Player(pl) => Some(TargetPin::Player(*pl)),\"",
+        "site 2 must remain `shortcut_drive_period`'s MATCH arm",
+        "got \"TargetPin::Player(_) => 1,\"",
+        "site 3 must remain the CR 701.34a proliferate CONSTRUCTION",
+        "got \"Some(crate::analysis::decision_template::TargetPin::Player(*other_seat))\"",
+        "got \"Some(crate::analysis::decision_template::TargetPin::Player(*pl))\"",
+        "the TARGET-class spelling must be CONSTRUCTED by BOTH producers",
+        "(\"engine/src/game/engine.rs\", 1)",
+    ];
+    let rejected = |xs: &[&str]| {
+        xs.iter()
+            .filter(|a| manifest::embeds_line_number(a))
+            .count()
+    };
+    assert_eq!(
+        rejected(&shipping),
+        0,
+        "a shipping anchor must never be refused"
+    );
+
+    let hostile = [
+        "line: 8945",
+        "line: 4689",
+        "line: 11492",
+        "loop_shortcut_seat_pin_census.rs:160:5",
+        "got [Site { file: \"engine/src/game/engine.rs\", line: 11490 }]",
+        "at line 11492",
+        "engine.rs:11492",
+        "L11492",                                 // named residual (§12.D row 3)
+        "(\"engine/src/game/engine.rs\", 11492)", // named residual: P9's shape, up to the integer
+    ];
+    assert_eq!(rejected(&hostile), 7);
+    assert!(!manifest::embeds_line_number("L11492"));
+    assert!(!manifest::embeds_line_number(
+        "(\"engine/src/game/engine.rs\", 11492)"
+    ));
+
+    // MINOR-E: `\bline`. Words ENDING in "line" followed by a count are legitimate, and this
+    // repo's own assertion strings contain them.
+    let legit = [
+        "baseline: 1",
+        "baseline: 0",
+        "baseline 3 producers must construct the pin",
+        "inline 2 callers remain",
+        "the pipeline 4 stages are pinned",
+        "deadline: 5 seconds",
+        "airline 7",
+        "outline: 3 sections",
+    ];
+    assert_eq!(rejected(&legit), 0);
+
+    // and the lint is wired into validate()
+    let mut m = load("dogfood.toml");
+    m.probes[1].expect = toml::from_str("outcome='fail'\nanchor=['line: 4689']").unwrap();
+    assert!(matches!(
+        abort_of(manifest::validate(&m).unwrap_err()),
+        Abort::AnchorEmbedsLineNumber { .. }
+    ));
+}
+
+// ------------------------------------------------------------------ row 10
+
+/// Row 10: all-pairs discrimination over the six archived failing probes. Self-misses 0 is
+/// the reach guard; collisions 0 is the claim; r2's one-entry P1 anchor is the hostile
+/// sibling that MUST abort, because it also fully matches P2's capture.
+#[test]
+fn all_pairs() {
+    let corpus: [(&str, [&str; 2]); 6] = [
+        (
+            "P1",
+            [
+                "PROVENANCE SPLIT VIOLATED",
+                "text: \"Ok(TargetPin::Player(*player))\"",
+            ],
+        ),
+        (
+            "P2",
+            [
+                "PROVENANCE SPLIT VIOLATED",
+                "text: \"TargetRef::Player(pl) => Some(TargetPin::Player(*pl)),\"",
+            ],
+        ),
+        (
+            "P6a",
+            [
+                "site 2 must remain `shortcut_drive_period`'s MATCH arm",
+                "got \"TargetPin::Player(_) => 1,\"",
+            ],
+        ),
+        (
+            "P6b",
+            [
+                "site 3 must remain the CR 701.34a proliferate CONSTRUCTION",
+                "got \"Some(crate::analysis::decision_template::TargetPin::Player(*other_seat))\"",
+            ],
+        ),
+        (
+            "P7",
+            [
+                "site 2 must remain `shortcut_drive_period`'s MATCH arm",
+                "got \"Some(crate::analysis::decision_template::TargetPin::Player(*pl))\"",
+            ],
+        ),
+        (
+            "P9",
+            [
+                "the TARGET-class spelling must be CONSTRUCTED by BOTH producers",
+                "(\"engine/src/game/engine.rs\", 1)",
+            ],
+        ),
+    ];
+    let mut probes = Vec::new();
+    let mut captures: BTreeMap<String, Vec<String>> = BTreeMap::new();
+    for (id, anchors) in &corpus {
+        probes.push(probe(&format!(
+            "id = {id:?}\n[[mutation]]\nkind='replace'\nfile='f'\nfind='a'\nreplace='b'\n[expect]\noutcome='fail'\nanchor={:?}\n",
+            anchors
+        )));
+        captures.insert(
+            (*id).to_string(),
+            vec![format!(
+                "panicked at tests/census.rs:1:1:\n{}\n{}\n",
+                anchors[0], anchors[1]
+            )],
+        );
+    }
+
+    // reach guard: every probe's own anchors hit its own capture
+    for p in &probes {
+        assert!(
+            verdict::all_anchors_in_one(p.anchors(), &captures[&p.id]),
+            "self-miss on {}",
+            p.id
+        );
+    }
+    assert_eq!(verdict::discriminate(&probes, &captures), Ok(()));
+
+    // hostile: r2's one-entry P1 anchor list also matches P2's capture
+    let mut hostile = probes.clone();
+    hostile[0].expect =
+        toml::from_str("outcome='fail'\nanchor=['PROVENANCE SPLIT VIOLATED']").unwrap();
+    assert!(matches!(
+        verdict::discriminate(&hostile, &captures),
+        Err(Abort::AnchorNotDiscriminating { ref probe, ref collides_with }) if probe == "P1" && collides_with == "P2"
+    ));
+}
+
+// ------------------------------------------------------------------ row 11
+
+/// Row 11: byte-identical anchor lists are caught at VALIDATE time — before any run. The
+/// TRIVIALIZE (compare lengths only) would accept two same-length distinct lists.
+#[test]
+fn anchor_dup() {
+    let mut m = load("dogfood.toml");
+    let dup: probe_pin::manifest::Expect =
+        toml::from_str("outcome='fail'\nanchor=['A','B']").unwrap();
+    m.probes[1].expect = dup.clone();
+    m.probes[2].expect = dup;
+    assert!(matches!(
+        abort_of(manifest::validate(&m).unwrap_err()),
+        Abort::AnchorNotDiscriminating { .. }
+    ));
+    // positive: two distinct lists of the SAME LENGTH validate
+    m.probes[2].expect = toml::from_str("outcome='fail'\nanchor=['A','C']").unwrap();
+    assert!(manifest::validate(&m).is_ok());
+}
+
+// ------------------------------------------------------------------ row 12
+
+/// Row 12: the target's environment is CONSTRUCTED, not inherited.
+///
+/// The claim is about what a PROCESS's ambient environment does, so the measurement needs a
+/// process whose ambient environment the test owns — mutating this one would race its parallel
+/// siblings. `ppfixture_envprobe` is that process: it calls the shipping `apply_child_env` and
+/// writes the resulting capture length to `PP_OUT`. Both a DROP (no clear) and a TRIVIALIZE
+/// (clear, then re-import everything) leak the ambient value into the innermost target.
+#[test]
+fn env_hermetic() {
+    let dir = tempfile::tempdir().unwrap();
+    let measure = |name: &str, ambient: &[(&str, &str)]| -> usize {
+        let out = dir.path().join(name);
+        let out_s = out.to_str().unwrap().to_string();
+        let mut env: Vec<(&str, &str)> = vec![("PP_FIXTURE", "envprobe"), ("PP_OUT", &out_s)];
+        env.extend_from_slice(ambient);
+        let run = child("ppfixture_envprobe", &env, &[]);
+        assert_eq!(run.rc, 0, "envprobe: {}", run.stdout);
+        std::fs::read_to_string(&out)
+            .unwrap()
+            .trim()
+            .parse()
+            .unwrap()
+    };
+
+    let clean = measure("clean", &[]);
+    assert!(
+        clean > 0,
+        "the reach guard: a panic capture must be non-empty"
+    );
+
+    // an exported RUST_BACKTRACE is the developer-shell hazard: it changes the captured bytes,
+    // and the CLEAR is the only thing stopping it — `apply_child_env` deliberately does not
+    // re-set it to "0", which would make this arm pass with or without the clear (MINOR-5)
+    assert_eq!(
+        measure("backtrace", &[("RUST_BACKTRACE", "1")]),
+        clean,
+        "an ambient RUST_BACKTRACE must not reach the target"
+    );
+    // and RUST_TEST_NOCAPTURE is the severe one: libtest then drops the `stdout` field from
+    // every failed record, so every anchor in every probe silently stops matching
+    assert_eq!(
+        measure("nocapture", &[("RUST_TEST_NOCAPTURE", "1")]),
+        clean,
+        "an ambient RUST_TEST_NOCAPTURE must not reach the target"
+    );
+    // the ALLOWLIST, not the clear, is what decides: [target].env turns it back on
+    assert!(
+        measure("forced", &[("PP_FORCE_BACKTRACE", "1")]) > clean,
+        "[target].env must still be able to set RUST_BACKTRACE"
+    );
+}
+
+// ------------------------------------------------------------------ row 13
+
+/// Row 13: `[target].env` defaults to `RUST_MIN_STACK = "16777216"`, and that value is
+/// load-bearing. Fixture B is RESCUABLE — unlike row 8's fixture, which no value rescues —
+/// so `"1"` (the TRIVIALIZE: a default that exists and is useless) is measurably different
+/// from the shipping default.
+#[test]
+fn env_default() {
+    let t: Target = toml::from_str(
+        "mode='runtime-read'\npackage='p'\ntest='t'\nfilter='f'\nfilter_match='substring'",
+    )
+    .unwrap();
+    assert_eq!(
+        t.env.get("RUST_MIN_STACK").map(String::as_str),
+        Some("16777216")
+    );
+    assert_eq!(t.timeout_secs, 300);
+    assert!(t.args.is_empty());
+
+    let rc = |stack: Option<&str>| {
+        let env: Vec<(&str, &str)> = match stack {
+            Some(v) => vec![("PP_FIXTURE", "stack"), ("RUST_MIN_STACK", v)],
+            None => vec![("PP_FIXTURE", "stack")],
+        };
+        child("ppfixture_stack", &env, &[]).rc
+    };
+    assert_eq!(rc(None), 134, "unset must overflow");
+    assert_eq!(rc(Some("1")), 134, "a useless default must overflow");
+    assert_eq!(
+        rc(Some("16777216")),
+        0,
+        "the shipping default must rescue it"
+    );
+}
+
+/// Schema adequacy (§6 / §11 gate 6), MEASURED rather than asserted: every shipped manifest
+/// parses under `deny_unknown_fields` and passes validation. `p7.toml` is the archived P7
+/// probe verbatim in shape — two sequential `Replace`s on one file whose second `find` exists
+/// only in the first's output, two `assert_count`s, a two-entry line-free anchor — and `p8`
+/// is the 5-file × 200 `Prepend`. Nothing in the corpus was reshaped to fit the schema.
+#[test]
+fn schema_adequacy() {
+    for name in [
+        "collide.toml",
+        "control_fails.toml",
+        "dogfood.toml",
+        "p7.toml",
+        "p8.toml",
+        "projection.toml",
+        "treewrite.toml",
+        "unsorted_ids.toml",
+    ] {
+        let m = load(name);
+        manifest::validate(&m).unwrap_or_else(|e| panic!("{name}: {e}"));
+    }
+    let p7 = load("p7.toml");
+    let seq = &p7.probes[1];
+    assert_eq!(seq.mutations.len(), 2);
+    assert_eq!(seq.touched().len(), 1, "both ops target ONE file");
+    assert_eq!(seq.assert_counts.len(), 1);
+    assert_eq!(seq.anchors().len(), 2);
+    match &load("p8.toml").probes[1].mutations[0] {
+        probe_pin::manifest::Mutation::Prepend { files, repeat, .. } => {
+            assert_eq!((files.len(), *repeat), (5, 200));
+        }
+        m => panic!("P8 must be a Prepend: {m:?}"),
+    }
+}
+
+// ------------------------------------------------------------------ row 15
+
+/// Row 15: `mode = "compiled"` PARSES and is rejected, visibly, with a deferral message.
+#[test]
+fn compiled_rejected() {
+    let m = load("compiled.toml");
+    let e = abort_of(manifest::validate(&m).unwrap_err());
+    assert!(matches!(e, Abort::UnsupportedMode { .. }));
+    assert!(e.to_string().contains("deferred, not removed"));
+
+    // positive: runtime-read validates
+    assert!(manifest::validate(&load("dogfood.toml")).is_ok());
+    // hostile: a TYPO is a different failure — an unknown variant, at parse time
+    let e = toml::from_str::<Manifest>(
+        &std::fs::read_to_string(fixtures().join("compiled.toml"))
+            .unwrap()
+            .replace("\"compiled\"", "\"cmpiled\""),
+    )
+    .unwrap_err();
+    assert!(e.to_string().contains("unknown variant"), "{e}");
+}
+
+// ------------------------------------------------------------------ row 16
+
+/// Row 16: a `--no-run --message-format=json` stream carries MORE than one `executable` —
+/// the package's `bin` reports one too, and it comes FIRST. Taking the first picks the bin.
+#[test]
+fn resolve_bin() {
+    let s = concat!(
+        r#"{"reason":"compiler-artifact","executable":"/t/debug/r4probe","target":{"kind":["bin"],"name":"r4probe"}}"#,
+        "\n",
+        r#"{"reason":"compiler-artifact","executable":"/t/debug/deps/blocks-47ca","target":{"kind":["test"],"name":"blocks"}}"#,
+        "\n",
+        r#"{"reason":"build-finished","success":true}"#,
+    );
+    assert_eq!(
+        target::pick_executable(s, "p", "blocks").unwrap(),
+        PathBuf::from("/t/debug/deps/blocks-47ca")
+    );
+    // hostile: zero test artifacts -> named candidates, never a silent first-match. The
+    // REPORTED count is the number that MATCHED, not the number of candidates (MINOR-1): a
+    // user with a typo'd [target].test was being told two test binaries were found and sent
+    // hunting for a duplicate that does not exist.
+    let e = target::pick_executable(s, "p", "absent").unwrap_err();
+    assert!(
+        matches!(e, Abort::TargetBinaryUnresolved { found: 0, ref candidates, .. } if candidates.len() == 2),
+        "{e:?}"
+    );
+    assert!(e.to_string().contains("found 0. Candidates: ["), "{e}");
+}
+
+// ------------------------------------------------------------------ row 17
+
+/// Row 17: `find` must occur EXACTLY once, against the RUNNING text — so a two-op sequence
+/// whose second `find` only exists after the first op is expressible, and an ambiguous or
+/// rotted `find` is refused.
+#[test]
+fn find_gate() {
+    let dir = tempfile::tempdir().unwrap();
+    let scratch = tempfile::tempdir().unwrap();
+    write(dir.path(), "f.txt", "alpha\nbeta\nalpha\n");
+
+    let mk = |ops: &str| probe(&format!("id='P'\n{ops}\n[expect]\noutcome='pass'\n"));
+    let op = |find: &str, replace: &str| {
+        format!("[[mutation]]\nkind='replace'\nfile='f.txt'\nfind={find:?}\nreplace={replace:?}")
+    };
+
+    let e =
+        abort_of(mutate::apply(&mk(&op("gamma", "x")), dir.path(), scratch.path()).unwrap_err());
+    assert!(
+        matches!(
+            e,
+            Abort::FindCount {
+                found: 0,
+                index: 0,
+                ..
+            }
+        ),
+        "{e}"
+    );
+    let e =
+        abort_of(mutate::apply(&mk(&op("alpha", "x")), dir.path(), scratch.path()).unwrap_err());
+    assert!(matches!(e, Abort::FindCount { found: 2, .. }), "{e}");
+
+    // running text: op 2's `find` exists ONLY after op 1
+    let seq = format!("{}\n{}", op("beta", "delta"), op("delta", "epsilon"));
+    assert!(mutate::apply(&mk(&seq), dir.path(), scratch.path()).is_ok());
+    // and the same op 2 alone is a rotted probe
+    let e = abort_of(
+        mutate::apply(&mk(&op("delta", "epsilon")), dir.path(), scratch.path()).unwrap_err(),
+    );
+    assert!(matches!(e, Abort::FindCount { found: 0, .. }), "{e}");
+}
+
+// ------------------------------------------------------------------ row 18
+
+/// Row 18: the no-op gate is per FILE, on MATERIALIZED bytes. That one comparison covers
+/// `Prepend { repeat: 0 }`, `Prepend { text: "" }` and a sequence that cancels out — none of
+/// which the deleted per-op `replace != find` check ever caught. Without it a mutant that
+/// equals the original defeats the mount readback: the `cmp` succeeds unmounted.
+#[test]
+fn noop() {
+    let dir = tempfile::tempdir().unwrap();
+    let scratch = tempfile::tempdir().unwrap();
+    write(dir.path(), "f.txt", "alpha\nbeta\n");
+    let mk = |ops: &str| probe(&format!("id='P'\n{ops}\n[expect]\noutcome='pass'\n"));
+
+    for hostile in [
+        "[[mutation]]\nkind='prepend'\nfiles=['f.txt']\ntext='// pad\\n'\nrepeat=0",
+        "[[mutation]]\nkind='prepend'\nfiles=['f.txt']\ntext=''\nrepeat=200",
+        "[[mutation]]\nkind='replace'\nfile='f.txt'\nfind='alpha'\nreplace='gamma'\n\
+         [[mutation]]\nkind='replace'\nfile='f.txt'\nfind='gamma'\nreplace='alpha'",
+    ] {
+        let e = abort_of(mutate::apply(&mk(hostile), dir.path(), scratch.path()).unwrap_err());
+        assert!(matches!(e, Abort::NoOpMutation { .. }), "{hostile} -> {e}");
+    }
+    // positive: a DELETION is not a no-op
+    assert!(mutate::apply(
+        &mk("[[mutation]]\nkind='replace'\nfile='f.txt'\nfind='alpha'\nreplace=''"),
+        dir.path(),
+        scratch.path()
+    )
+    .is_ok());
+}
+
+// ------------------------------------------------------------------ row 19
+
+/// Row 19: `assert_count` runs on the MUTANT, after all mutations have composed.
+#[test]
+fn assert_count() {
+    let dir = tempfile::tempdir().unwrap();
+    let scratch = tempfile::tempdir().unwrap();
+    write(dir.path(), "f.txt", "alpha\nbeta\nalpha\n");
+    let mk = |text: &str, count: usize| {
+        probe(&format!(
+            "id='P'\n[[mutation]]\nkind='replace'\nfile='f.txt'\nfind='beta'\nreplace='alpha'\n\
+             [[assert_count]]\nfile='f.txt'\ntext={text:?}\ncount={count}\n[expect]\noutcome='pass'\n"
+        ))
+    };
+    assert!(mutate::apply(&mk("alpha", 3), dir.path(), scratch.path()).is_ok());
+    // off-by-one
+    let e = abort_of(mutate::apply(&mk("alpha", 2), dir.path(), scratch.path()).unwrap_err());
+    assert!(
+        matches!(
+            e,
+            Abort::AssertCount {
+                expected: 2,
+                found: 3,
+                ..
+            }
+        ),
+        "{e}"
+    );
+    // present in the ORIGINAL, absent from the mutant
+    let e = abort_of(mutate::apply(&mk("beta", 1), dir.path(), scratch.path()).unwrap_err());
+    assert!(
+        matches!(
+            e,
+            Abort::AssertCount {
+                expected: 1,
+                found: 0,
+                ..
+            }
+        ),
+        "{e}"
+    );
+}
+
+// ------------------------------------------------------------------ row 20
+
+/// Row 20: probe-pin must never create files under the tree it is measuring. The assert is
+/// on containment, not inequality — a parent-blind `path != workspace_root` accepts every
+/// subdirectory of the worktree.
+#[test]
+fn scratch_outside() {
+    let ws = tempfile::tempdir().unwrap();
+    assert!(isolate::scratch_dir(&std::env::temp_dir(), ws.path()).is_ok());
+
+    let inside = ws.path().join("x");
+    std::fs::create_dir_all(&inside).unwrap();
+    let e = isolate::scratch_dir(&inside, ws.path()).unwrap_err();
+    assert!(matches!(e, Abort::ScratchInsideWorkspace { .. }), "{e}");
+    // TRIVIALIZE control: the scratch is never EQUAL to the root, so equality catches nothing
+    match e {
+        Abort::ScratchInsideWorkspace { scratch, workspace } => assert_ne!(scratch, workspace),
+        _ => unreachable!(),
+    }
+}
+
+// ------------------------------------------- row 20's companion: the escaping key (MAJOR-1)
+
+/// Row 20 constrains the CONTAINER (`scratch` is outside the workspace). This constrains the
+/// KEYS joined onto it: `mutate::apply` writes `scratch.join(&probe.id).join(rel)`, so a `..`
+/// in EITHER half walks back out of the container the row-20 assert just certified, into the
+/// tree being measured. `verify_fingerprint` cannot see the id half either — the escaped write
+/// is not in `probe.touched()`.
+///
+/// Arm 1 and arm 3 EXHIBIT the escape through the shipping `mutate::apply`. Arms 2 and 4 drive
+/// the guarded path in pipeline order (§7 step 1 `validate`, then step 8 `apply`) and assert
+/// both halves of the fix: the abort fires AND nothing appears outside the scratch dir.
+#[test]
+fn path_keys_cannot_escape_the_scratch_dir() {
+    let base = tempfile::tempdir().unwrap();
+    let ws = base.path().join("ws");
+    std::fs::create_dir_all(&ws).unwrap();
+    write(&ws, "f.txt", "alpha\n");
+    write(&ws, "VICTIM2.rs", "alpha\n");
+    let scratch = tempfile::tempdir().unwrap();
+
+    // `../` × depth(dir), then down into the workspace: from `dir`, out to the filesystem root
+    // and back in. Every component exists, so the kernel resolves the whole path.
+    let escape_to = |dir: &Path, name: &str| {
+        let up = dir
+            .components()
+            .filter(|c| matches!(c, std::path::Component::Normal(_)))
+            .count();
+        format!(
+            "{}{}/{name}",
+            "../".repeat(up),
+            ws.strip_prefix("/").unwrap().display()
+        )
+    };
+    let listing = || {
+        let mut v: Vec<String> = std::fs::read_dir(&ws)
+            .unwrap()
+            .map(|e| e.unwrap().file_name().to_string_lossy().into_owned())
+            .collect();
+        v.sort();
+        v
+    };
+    let manifest_with = |block: &str| -> Manifest {
+        toml::from_str(&format!(
+            "version = 1\n\
+             [target]\nmode='runtime-read'\npackage='p'\ntest='t'\nfilter='f'\nfilter_match='substring'\n\
+             [output]\nfile='o.md'\nmarker='PROBE-PIN'\n\
+             [[probe]]\nid='P0_control'\n[probe.expect]\noutcome='pass'\n{block}"
+        ))
+        .expect("hostile manifest parses — the schema does not constrain these fields")
+    };
+    // §7 in miniature: validate, then apply every non-control probe.
+    let guarded = |m: &Manifest| -> anyhow::Result<()> {
+        manifest::validate(m)?;
+        for p in m.probes.iter().filter(|p| !p.mutations.is_empty()) {
+            mutate::apply(p, &ws, scratch.path())?;
+        }
+        Ok(())
+    };
+    let hostile_id = escape_to(scratch.path(), "VICTIM.rs");
+    let id_manifest = manifest_with(&format!(
+        "[[probe]]\nid={hostile_id:?}\n\
+         [[probe.mutation]]\nkind='replace'\nfile='f.txt'\nfind='alpha'\nreplace='beta'\n\
+         [probe.expect]\noutcome='pass'\n"
+    ));
+
+    // arm 1 — the phenomenon: an unvalidated id writes INSIDE the measured workspace
+    mutate::apply(&id_manifest.probes[1], &ws, scratch.path()).expect("the escape succeeds");
+    assert_eq!(
+        std::fs::read_to_string(ws.join("VICTIM.rs/f.txt")).unwrap(),
+        "beta\n",
+        "the escape must be real, or arm 2 pins nothing"
+    );
+    std::fs::remove_dir_all(ws.join("VICTIM.rs")).unwrap();
+
+    // arm 2 — the guard: refused, and NO file appears outside the scratch dir
+    let e = guarded(&id_manifest).unwrap_err();
+    assert!(
+        format!("{e}").contains("is not a plain name"),
+        "the id must be refused by content: {e}"
+    );
+    assert_eq!(listing(), ["VICTIM2.rs", "f.txt"], "nothing may be written");
+
+    // arm 3 — the phenomenon, `.join(rel)` half: the mutant lands ON a workspace file
+    let hostile_file = escape_to(&scratch.path().join("P1_escaping_file"), "VICTIM2.rs");
+    let file_manifest = manifest_with(&format!(
+        "[[probe]]\nid='P1_escaping_file'\n\
+         [[probe.mutation]]\nkind='replace'\nfile={hostile_file:?}\nfind='alpha'\nreplace='beta'\n\
+         [probe.expect]\noutcome='pass'\n"
+    ));
+    mutate::apply(&file_manifest.probes[1], &ws, scratch.path()).expect("the escape succeeds");
+    assert_eq!(
+        std::fs::read_to_string(ws.join("VICTIM2.rs")).unwrap(),
+        "beta\n",
+        "the mutant must have been written over the workspace file"
+    );
+    write(&ws, "VICTIM2.rs", "alpha\n");
+
+    // arm 4 — the guard, same half
+    let e = guarded(&file_manifest).unwrap_err();
+    assert!(
+        format!("{e}").contains("is not a workspace-relative path"),
+        "the mutation file must be refused by content: {e}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(ws.join("VICTIM2.rs")).unwrap(),
+        "alpha\n",
+        "nothing may be written"
+    );
+    assert_eq!(listing(), ["VICTIM2.rs", "f.txt"]);
+
+    // positive: an ordinary id and an ordinary relative file still validate and materialize
+    let ok = manifest_with(
+        "[[probe]]\nid='P1_ordinary'\n\
+         [[probe.mutation]]\nkind='replace'\nfile='f.txt'\nfind='alpha'\nreplace='beta'\n\
+         [probe.expect]\noutcome='pass'\n",
+    );
+    guarded(&ok).expect("the shipping shape must survive the guard");
+    assert!(scratch.path().join("P1_ordinary/f.txt").exists());
+    assert_eq!(listing(), ["VICTIM2.rs", "f.txt"]);
+}
+
+// ------------------------------------------------------------------ row 22
+
+/// Row 22: the splice preserves every byte outside the marker pair — prose above, prose
+/// below, and the file's own line endings.
+#[test]
+fn splice() {
+    let file = Path::new("out.md");
+    let text = "above\r\n// PROBE-PIN:BEGIN old\r\n// stale\r\n// PROBE-PIN:END\r\nbelow\r\n";
+    let out = block::splice(
+        text,
+        "PROBE-PIN",
+        file,
+        "// PROBE-PIN:BEGIN new\n// PROBE-PIN:END",
+    )
+    .unwrap();
+    assert_eq!(
+        out,
+        "above\r\n// PROBE-PIN:BEGIN new\n// PROBE-PIN:END\r\nbelow\r\n"
+    );
+    assert!(out.starts_with("above\r\n") && out.ends_with("below\r\n"));
+
+    for (bad, begins, ends) in [
+        ("// PROBE-PIN:BEGIN x\n", 1, 0),
+        (
+            "// PROBE-PIN:BEGIN x\n// PROBE-PIN:BEGIN y\n// PROBE-PIN:END\n",
+            2,
+            1,
+        ),
+        ("// PROBE-PIN:END\n// PROBE-PIN:BEGIN x\n", 1, 1), // END before BEGIN
+    ] {
+        let e = block::locate(bad, "PROBE-PIN", file).unwrap_err();
+        assert!(
+            matches!(e, Abort::MarkerNotUnique { begins: b, ends: n, .. } if b == begins && n == ends),
+            "{bad:?} -> {e}"
+        );
+    }
+}
+
+// ------------------------------------------------------------------ row 23
+
+/// Row 23: the render is byte-deterministic. The guard PARSES TWICE and renders each: a
+/// render-twice-from-one-parse guard scores identically with and without the defect, because
+/// a `HashMap`'s iteration order is stable within one instance.
+#[test]
+fn idempotent() {
+    let ids: Vec<String> = load("unsorted_ids.toml")
+        .probes
+        .iter()
+        .map(|p| p.id.clone())
+        .collect();
+    // MINOR-F: the fixture precondition is MEASURED, not merely stated. The corpus ids
+    // P0..P9 are already sorted, so a sorted fixture makes the TRIVIALIZE arm a no-op.
+    assert_ne!(ids, {
+        let mut s = ids.clone();
+        s.sort();
+        s
+    });
+
+    let render_once = || {
+        let m = load("unsorted_ids.toml");
+        let outcomes: Vec<Outcome> = m
+            .probes
+            .iter()
+            .map(|p| Outcome {
+                id: p.id.clone(),
+                rc: 0,
+                verdict: Verdict::Pass { mounts_reached: 1 },
+            })
+            .collect();
+        // The DIGEST, not just the table: `[target].env` reaches the block only through the
+        // digest, so a `HashMap` there is invisible to a render-only guard (MINOR-4). It is
+        // also invisible within ONE parse — `RandomState` is per-instance — hence the loop
+        // below, and the fixture's four env keys.
+        let digest = block::digest(&m, "m.toml", &outcomes, &[], &[]).unwrap();
+        (
+            block::render(&m, "m.toml", &digest, &[], &outcomes, &[]),
+            digest,
+        )
+    };
+    let (a, b) = (render_once(), render_once());
+    assert_eq!(a, b);
+    for _ in 0..16 {
+        assert_eq!(render_once(), a, "two parses must render identical bytes");
+    }
+    // the rows appear in DECLARATION order, which is what `check` compares against
+    let rows: Vec<&str> = a.0.lines().filter(|l| l.starts_with("// | P")).collect();
+    assert!(
+        rows[0].contains("P0_control")
+            && rows[1].contains("P9_zulu")
+            && rows[2].contains("P1_alpha")
+    );
+}
+
+// ------------------------------------------------------------------ rows 24, 25, 27
+
+fn digest_of(
+    m: &Manifest,
+    counts: &[ProjectionCount],
+    instruments: &[(Instrument, String)],
+) -> String {
+    let outcomes: Vec<Outcome> = m
+        .probes
+        .iter()
+        .map(|p| Outcome {
+            id: p.id.clone(),
+            rc: 0,
+            verdict: Verdict::Pass { mounts_reached: 1 },
+        })
+        .collect();
+    block::digest(m, "m.toml", &outcomes, counts, instruments).unwrap()
+}
+
+/// Row 24: the digest pins what was MEASURED, not just the outcome. Narrowing `[target]`'s
+/// filter with identical verdicts flips it, and subsetting a projection's `paths` with an
+/// identical count flips it — the two cases a digest over outcomes alone cannot see.
+#[test]
+fn digest_target() {
+    let base = load("projection.toml");
+    let counts = [ProjectionCount {
+        id: "instrument_sites".into(),
+        count: 3,
+    }];
+    let instruments = [(Instrument::Toolchain, "rustc 1.97.0".to_string())];
+    let d0 = digest_of(&base, &counts, &instruments);
+
+    let mut narrowed = base.clone();
+    narrowed.target.filter = "ppfixture_census_narrower".into();
+    assert_ne!(d0, digest_of(&narrowed, &counts, &instruments));
+
+    let mut subset = base.clone();
+    subset.projections[0].paths = vec!["crates/probe-pin/tests".into()];
+    assert_ne!(d0, digest_of(&subset, &counts, &instruments));
+
+    // positive: an unrelated COMMENT in the manifest is not an input
+    let text = std::fs::read_to_string(fixtures().join("projection.toml")).unwrap();
+    let commented: Manifest = toml::from_str(&format!("# an unrelated comment\n{text}")).unwrap();
+    assert_eq!(d0, digest_of(&commented, &counts, &instruments));
+    // determinism
+    assert_eq!(d0, digest_of(&base, &counts, &instruments));
+}
+
+/// Row 25: injection-safe by construction. JSON escapes NUL as `\u0000` and keeps every field
+/// in its own slot; a hand-rolled NUL-joined serializer gives the two manifests below —
+/// which say DIFFERENT things — one and the same byte string, `P1\0claim\0c`.
+#[test]
+fn digest_inject() {
+    let mk = |id: &str, claim: &str| {
+        let mut m = load("dogfood.toml");
+        m.probes[1].id = id.to_string();
+        m.probes[1].claim = claim.to_string();
+        digest_of(&m, &[], &[])
+    };
+    // one colliding pair per candidate joiner — every single-delimiter joiner has one
+    assert_ne!(mk("P1\u{0}claim", "c"), mk("P1", "claim\u{0}c"));
+    assert_ne!(mk("P1+claim", "c"), mk("P1", "claim+c"));
+    // and a field-boundary shift is still visible
+    assert_ne!(mk("P1\u{0}claim\u{0}c", "c"), mk("P1\u{0}claim", "c"));
+    assert_ne!(mk("P1\u{0}claim", "c"), mk("P1", "c"));
+}
+
+/// Row 27: BOTH instruments are digest inputs. With every verdict and count identical, each
+/// version string alone flips the digest.
+#[test]
+fn instrument_digest() {
+    let m = load("projection.toml");
+    let counts = [ProjectionCount {
+        id: "instrument_sites".into(),
+        count: 3,
+    }];
+    let v = |rustc: &str, ag: &str| {
+        digest_of(
+            &m,
+            &counts,
+            &[
+                (Instrument::Toolchain, rustc.to_string()),
+                (Instrument::AstGrep, ag.to_string()),
+            ],
+        )
+    };
+    let base = v("rustc 1.97.0", "ast-grep 0.44.1");
+    assert_ne!(base, v("rustc 1.98.0", "ast-grep 0.44.1"));
+    assert_ne!(base, v("rustc 1.97.0", "ast-grep 0.45.0"));
+}
+
+// ------------------------------------------------------------------ rows 28, 29
+
+/// The five measured skew arms, shared by rows 28 and 29.
+fn skew_arms() -> Vec<(&'static str, String, String)> {
+    let blk = |rustc: &str, ag: &str, count: usize, cell: &str| {
+        format!(
+            "// PROBE-PIN:BEGIN manifest=m.toml digest=sha256:0123456789abcdef\n\
+             // instrument rustc = {rustc}\n\
+             // instrument ast-grep = {ag}\n\
+             // | probe | mutation | expect | verdict | firing assertion (anchor) | provenance |\n\
+             // |---|---|---|---|---|---|\n\
+             // | P1 | f.rs ×1 | fail | fail | {cell} | census.rs |\n\
+             // `TargetPin::Player` is constructed or matched at {count} sites.\n\
+             // PROBE-PIN:END"
+        )
+    };
+    let base = blk("rustc 1.97.0", "ast-grep 0.44.1", 3, "ANCHOR");
+    vec![
+        ("clean", base.clone(), base.clone()),
+        (
+            "code drift only",
+            base.clone(),
+            blk("rustc 1.97.0", "ast-grep 0.44.1", 3, "OTHER"),
+        ),
+        (
+            "toolchain moved, numbers same",
+            base.clone(),
+            blk("rustc 1.98.0", "ast-grep 0.44.1", 3, "ANCHOR"),
+        ),
+        (
+            "ast-grep moved AND 3->6",
+            base.clone(),
+            blk("rustc 1.97.0", "ast-grep 0.45.0", 6, "ANCHOR"),
+        ),
+        (
+            "both moved, numbers same",
+            base,
+            blk("rustc 1.98.0", "ast-grep 0.45.0", 3, "ANCHOR"),
+        ),
+    ]
+}
+
+/// Row 28: an instrument change is not code drift. Both instruments participate, and when
+/// both moved the message lists BOTH in one `Instrument(Vec<…>)` — no precedence rule.
+#[test]
+fn instrument_skew() {
+    let arms = skew_arms();
+    let got: Vec<CheckOutcome> = arms.iter().map(|(_, a, b)| block::check(a, b)).collect();
+
+    assert_eq!(got[0], CheckOutcome::Clean, "Clean must be reachable");
+    match &got[1] {
+        CheckOutcome::Drift {
+            cause,
+            numbers_moved,
+            ..
+        } => {
+            assert_eq!(*cause, DriftCause::Code);
+            assert!(numbers_moved);
+        }
+        o => panic!("code drift -> {o:?}"),
+    }
+    let instrument_of = |o: &CheckOutcome| match o {
+        CheckOutcome::Drift {
+            cause: DriftCause::Instrument(c),
+            numbers_moved,
+            ..
+        } => (
+            c.iter().map(|c| c.instrument).collect::<Vec<_>>(),
+            *numbers_moved,
+        ),
+        o => panic!("expected an instrument drift, got {o:?}"),
+    };
+    assert_eq!(instrument_of(&got[2]), (vec![Instrument::Toolchain], false));
+    assert_eq!(instrument_of(&got[3]), (vec![Instrument::AstGrep], true));
+    assert_eq!(
+        instrument_of(&got[4]),
+        (vec![Instrument::Toolchain, Instrument::AstGrep], false)
+    );
+    assert!(block::report(&got[4], "m.toml").contains("rustc 1.97.0 -> rustc 1.98.0"));
+    assert!(block::report(&got[4], "m.toml").contains("ast-grep 0.44.1 -> ast-grep 0.45.0"));
+}
+
+/// Row 29: `run --write` refuses IFF an instrument moved AND a measured number moved — the
+/// laundering case, where re-stamping would record 6 sites under a new tool and leave `check`
+/// green. Refusing on ANY instrument change instead would make a toolchain bump unwritable.
+#[test]
+fn write_refusal() {
+    let arms = skew_arms();
+    let refused: Vec<bool> = arms
+        .iter()
+        .map(|(_, a, b)| block::write_refusal(&block::check(a, b), a, b).is_some())
+        .collect();
+    assert_eq!(refused, vec![false, false, false, true, false]);
+
+    let (_, a, b) = &arms[3];
+    let abort = block::write_refusal(&block::check(a, b), a, b).unwrap();
+    let text = abort.to_string();
+    assert!(
+        text.contains("ast-grep 0.44.1 -> ast-grep 0.45.0"),
+        "{text}"
+    );
+    assert!(
+        text.contains("at 3 sites") && text.contains("at 6 sites"),
+        "{text}"
+    );
+    assert!(
+        text.contains("delete the PROBE-PIN:BEGIN…END block"),
+        "{text}"
+    );
+}
+
+// ------------------------------------------------------------------ rows 26, 30
+
+/// Row 26: fail-closed on a missing projection tool — probe-pin will not emit a block whose
+/// projection sentence is silently absent. Both `run --write` and `check` reach this through
+/// the same step-4 call, because `used_instruments` is what puts ast-grep on the list.
+#[test]
+fn proj_missing() {
+    let m = load("projection.toml");
+    assert_eq!(
+        block::used_instruments(&m),
+        vec![Instrument::Toolchain, Instrument::AstGrep]
+    );
+    let missing = fixtures().join("astgrep_does_not_exist");
+    let e =
+        project::instrument_version(Instrument::AstGrep, missing.to_str().unwrap()).unwrap_err();
+    assert!(matches!(e, Abort::ProjectionToolMissing { .. }), "{e}");
+    // present but broken is ALSO fail-closed, not a warn-and-continue
+    let broken = fixtures().join("astgrep_broken.sh");
+    let e = project::count(&m.projections[0], &fixtures(), broken.to_str().unwrap()).unwrap_err();
+    assert!(matches!(e, Abort::ProjectionToolMissing { .. }), "{e}");
+
+    // positive: a working tool renders the sentence with the measured count
+    let ok = fixtures().join("astgrep_three.sh");
+    let count = project::count(&m.projections[0], &fixtures(), ok.to_str().unwrap()).unwrap();
+    assert_eq!(count, 3);
+    assert_eq!(
+        project::sentence(&m.projections[0], count),
+        "`Instrument` is named at 3 sites."
+    );
+    assert_eq!(
+        project::instrument_version(Instrument::AstGrep, ok.to_str().unwrap()).unwrap(),
+        "ast-grep 0.44.1"
+    );
+}
+
+/// Row 30: no projections ⇒ no ast-grep dependency and no ast-grep line — but the `rustc`
+/// line is still there. The asymmetry is derived from one rule (an instrument is recorded iff
+/// it produced a number), not special-cased, so it is asserted in both directions.
+#[test]
+fn no_proj() {
+    let m = load("dogfood.toml");
+    assert!(m.projections.is_empty());
+    assert_eq!(block::used_instruments(&m), vec![Instrument::Toolchain]);
+    let outcomes: Vec<Outcome> = m
+        .probes
+        .iter()
+        .map(|p| Outcome {
+            id: p.id.clone(),
+            rc: 0,
+            verdict: Verdict::Pass { mounts_reached: 1 },
+        })
+        .collect();
+    let rendered = block::render(
+        &m,
+        "m.toml",
+        "0123456789abcdef",
+        &[(Instrument::Toolchain, "rustc 1.97.0".into())],
+        &outcomes,
+        &[],
+    );
+    assert!(!rendered.contains("instrument ast-grep"));
+    assert!(rendered.contains("// instrument rustc = rustc 1.97.0"));
+    // and `check` classifies such a block with no tool installed at all
+    assert_eq!(block::check(&rendered, &rendered), CheckOutcome::Clean);
+    assert!(matches!(
+        block::check(&rendered, &rendered.replace("P0_control", "P0_ctl")),
+        CheckOutcome::Drift {
+            cause: DriftCause::Code,
+            ..
+        }
+    ));
+}
+
+// ------------------------------------------------------------------ row 31
+
+/// Row 31: the exit-code contract. An instrument failure is 2, not the anyhow idiom's 1;
+/// drift is 1, not 2. The `run <compiled.toml>` arm aborts at step 1, so it costs zero
+/// target runs. The end-to-end drift-is-1 arm is `isolation_e2e::drift` (a) — it needs a
+/// full pipeline run, which needs the namespace.
+#[test]
+fn exit_codes() {
+    let code = |args: &[&str]| {
+        Command::new(env!("CARGO_BIN_EXE_probe-pin"))
+            .args(args)
+            .output()
+            .unwrap()
+            .status
+            .code()
+            .unwrap()
+    };
+    assert_eq!(
+        code(&["run", fixtures().join("compiled.toml").to_str().unwrap()]),
+        2
+    );
+    assert_eq!(
+        code(&["check", fixtures().join("compiled.toml").to_str().unwrap()]),
+        2
+    );
+    assert_eq!(code(&["run", "/nonexistent/manifest.toml"]), 2);
+
+    assert_eq!(block::exit_code(&CheckOutcome::Clean), 0);
+    assert_eq!(
+        block::exit_code(&CheckOutcome::Drift {
+            cause: DriftCause::Code,
+            diff: String::new(),
+            numbers_moved: true
+        }),
+        1
+    );
+    assert_eq!(
+        block::exit_code(&CheckOutcome::Drift {
+            cause: DriftCause::Instrument(vec![InstrumentChange {
+                instrument: Instrument::Toolchain,
+                was: "a".into(),
+                now: "b".into()
+            }]),
+            diff: String::new(),
+            numbers_moved: false
+        }),
+        1
+    );
+}
+
+// ------------------------------------- §8 message fidelity on the two sentinel-free paths
+
+/// §8's texts are the contract, and each of these rows promised a value the run never measured
+/// (MINOR-2, MINOR-3): a rendered `-1` reads as an exit status when the process never started,
+/// and `scratch_dir`'s failure named "the mutant" for a directory that holds none yet.
+#[test]
+fn abort_texts_promise_only_measured_values() {
+    let spawn_failed = Abort::IsolationUnavailable {
+        rc: None,
+        stderr: "No such file or directory (os error 2)".into(),
+    }
+    .to_string();
+    assert!(
+        spawn_failed.contains("could not be spawned"),
+        "{spawn_failed}"
+    );
+    assert!(!spawn_failed.contains("-1"), "no sentinel: {spawn_failed}");
+
+    let ran = Abort::IsolationUnavailable {
+        rc: Some(1),
+        stderr: "unshare: write failed /proc/self/uid_map".into(),
+    }
+    .to_string();
+    assert!(ran.contains("failed (exit 1):"), "{ran}");
+
+    // the scratch-dir path names the DIRECTORY, and claims no mutant
+    let e = isolate::scratch_dir(Path::new("/nonexistent-tmpdir"), Path::new("/")).unwrap_err();
+    assert!(matches!(e, Abort::MaterializeFailed { .. }), "{e}");
+    assert!(
+        e.to_string()
+            .starts_with("probe-pin: scratch-directory write failed at /nonexistent-tmpdir:"),
+        "{e}"
+    );
+}
+
+// ------------------------------------------------------------------ row 33
+
+/// Row 33: a run that selected ZERO tests is an INSTRUMENT FAILURE, not a pass. Measured on
+/// a real libtest selection: `filter_match = "exact"` against a module-prefix filter selects
+/// nothing, and so does a rotted filter under a perfectly correct substring argv. The
+/// ordering arm — the abort names the CONTROL and no probe runs — is
+/// `isolation_e2e::no_tests_selected_ordering`.
+#[test]
+fn no_tests_selected() {
+    let mut t = target();
+    // arm 1: the shipping substring filter selects tests
+    let run = child("ppfixture_census", &[], &[]);
+    let obs = verdict::observe("P0_control", &run, &t, &[]).expect("substring filter selects");
+    assert!(obs.test_count > 0 && !obs.target_failed);
+
+    // arm 2: exact match on a filter that is a PREFIX selects nothing
+    let run = child("ppfixture_cens", &[], &["--exact"]);
+    t.filter = "ppfixture_cens".into();
+    t.filter_match = manifest::FilterMatch::Exact;
+    let e = verdict::observe("P0_control", &run, &t, &[]).unwrap_err();
+    assert_eq!(run.rc, 0, "libtest reports a green exit for a 0-test run");
+    assert!(
+        matches!(e, Abort::NoTestsSelected { ref probe, filter_match: manifest::FilterMatch::Exact, .. } if probe == "P0_control"),
+        "{e}"
+    );
+    assert!(e.to_string().contains("INSTRUMENT FAILURE"));
+
+    // arm 3: a filter that ROTTED (renamed upstream), under a correct substring argv
+    let run = child("ppfixture_census_OLDNAME", &[], &[]);
+    t.filter = "ppfixture_census_OLDNAME".into();
+    t.filter_match = manifest::FilterMatch::Substring;
+    assert!(matches!(
+        verdict::observe("P0_control", &run, &t, &[]).unwrap_err(),
+        Abort::NoTestsSelected { .. }
+    ));
+}
+
+// ------------------------------------------------------------------ argv + verdict wiring
+
+/// `filter_match` and `[target].args` both reach libtest's own selection — the only place
+/// where a dead schema field would show. Measured against this binary's real test names.
+#[test]
+fn argv_is_live() {
+    let mut t = target();
+    t.filter = "ppfixture".into();
+    assert_eq!(
+        isolate::argv(&t),
+        vec![
+            "ppfixture",
+            "--test-threads=1",
+            "--format",
+            "json",
+            "-Z",
+            "unstable-options"
+        ]
+    );
+    t.filter_match = manifest::FilterMatch::Exact;
+    assert_eq!(isolate::argv(&t)[1], "--exact");
+    t.filter_match = manifest::FilterMatch::Substring;
+    t.args = vec!["--skip".into(), "ppfixture_census".into()];
+    assert_eq!(isolate::argv(&t).last().unwrap(), "ppfixture_census");
+
+    let all = child("ppfixture", &[], &[]);
+    let skipped = child("ppfixture", &[], &["--skip", "ppfixture_census"]);
+    let count = |r: &Run| {
+        let mut t = target();
+        t.filter = "ppfixture".into();
+        verdict::observe("P", r, &t, &[]).unwrap().test_count
+    };
+    // `--exact` here would select 0 (the filter is a prefix), which is exactly row 33's arm 2
+    assert!(
+        count(&all) > count(&skipped),
+        "[target].args must reach the argv"
+    );
+}
+
+/// `Verdict::Fail` IS "target failed AND every anchor in ONE record". Its complement is a
+/// verdict MISMATCH naming the missed anchor — never a `Pass`, whose rendering would
+/// transcribe "visible-and-still-passing" for a run whose target failed.
+#[test]
+fn fail_complement_is_a_mismatch() {
+    let p = probe(
+        "id='P1'\n[[mutation]]\nkind='replace'\nfile='f'\nfind='a'\nreplace='b'\n\
+         [expect]\noutcome='fail'\nanchor=['HIT','MISS']\n",
+    );
+    let mut obs = verdict::Observed {
+        rc: 101,
+        test_count: 1,
+        target_failed: true,
+        failed_captures: vec!["panicked at tests/c.rs:1:1:\nHIT\n".into()],
+        ..Default::default()
+    };
+    // the mismatch is TYPED: `main` formats it, and the missed anchor is a carried value, not
+    // a substring of a pre-formatted report (MINOR-7)
+    let e = verdict::verdict(&p, &obs, 1).unwrap_err();
+    assert_eq!(e.missed_anchor.as_deref(), Some("MISS"));
+    assert_eq!(e.observed_rc, 101);
+    assert!(e.to_string().contains("anchor \"MISS\""), "{e}");
+
+    obs.failed_captures[0].push_str("MISS\n");
+    assert_eq!(
+        verdict::verdict(&p, &obs, 1),
+        Ok(Verdict::Fail {
+            provenance: vec![PathBuf::from("tests/c.rs")]
+        })
+    );
+}
+
+// ------------------------------------------------------------------ targets, not assertions
+
+const PROD: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/prod.txt");
+
+/// The runtime-read census the Tier-2 manifests mutate. Reading at RUNTIME is what makes a
+/// bind-mounted mutant visible; an `include_str!` copy would be baked in at build time.
+#[test]
+fn ppfixture_census() {
+    let text = std::fs::read_to_string(PROD).expect("prod.txt");
+    let sites = text.lines().filter(|l| l.contains("marker")).count();
+    assert_eq!(
+        sites, 2,
+        "CENSUS VIOLATED: expected 2 sites, got {sites}; text: {text:?}"
+    );
+}
+
+/// Row 8's fixture A: UNCONDITIONAL — no `RUST_MIN_STACK` value rescues it.
+#[test]
+fn ppfixture_abort() {
+    if std::env::var("PP_FIXTURE").as_deref() == Ok("abort") {
+        std::process::abort();
+    }
+}
+
+/// Row 13's fixture B: RESCUABLE — 1200 × 4 KiB frames on a spawned thread, whose stack size
+/// is what `RUST_MIN_STACK` sets.
+#[test]
+fn ppfixture_stack() {
+    if std::env::var("PP_FIXTURE").as_deref() != Ok("stack") {
+        return;
+    }
+    fn burn(n: u32) -> u64 {
+        let frame = [0u8; 4096];
+        if n == 0 {
+            return std::hint::black_box(&frame)[0] as u64;
+        }
+        burn(n - 1) + std::hint::black_box(&frame)[7] as u64
+    }
+    std::thread::spawn(|| std::hint::black_box(burn(1200)))
+        .join()
+        .unwrap();
+}
+
+/// Row 12's fixture: a panic whose capture length depends on `RUST_BACKTRACE`.
+#[test]
+fn ppfixture_panic() {
+    if std::env::var("PP_FIXTURE").as_deref() == Ok("panic") {
+        panic!("PPFIXTURE PANIC");
+    }
+}
+
+/// Row 12's instrument: a process whose ambient environment the caller owns, which runs
+/// `ppfixture_panic` through the SHIPPING `apply_child_env` and reports the capture length.
+#[test]
+fn ppfixture_envprobe() {
+    if std::env::var("PP_FIXTURE").as_deref() != Ok("envprobe") {
+        return;
+    }
+    let mut t = target();
+    t.env.clear();
+    if std::env::var("PP_FORCE_BACKTRACE").is_ok() {
+        t.env.insert("RUST_BACKTRACE".into(), "1".into());
+    }
+    let mut cmd = Command::new("timeout");
+    cmd.args(["-k", "5", "60"])
+        .arg(std::env::current_exe().unwrap())
+        .args(["ppfixture_panic", "--exact", "--test-threads=1"])
+        .args(["--format", "json", "-Z", "unstable-options"]);
+    isolate::apply_child_env(&mut cmd, &t);
+    cmd.env("PP_FIXTURE", "panic");
+    let out = cmd.output().unwrap();
+    let run = Run {
+        rc: isolate::exit_rc(&out.status),
+        stdout: String::from_utf8_lossy(&out.stdout).into_owned(),
+        stderr: String::new(),
+    };
+    let obs = verdict::observe("envprobe", &run, &t, &[]).unwrap();
+    std::fs::write(
+        std::env::var("PP_OUT").unwrap(),
+        obs.failed_captures[0].len().to_string(),
+    )
+    .unwrap();
+}
+
+/// §7 step 10's fixture (MAJOR-2): a target that WRITES THE TREE. `unshare --mount` isolates
+/// the mount table, not the filesystem, so this write reaches the real file whenever the path
+/// is not mounted — which is exactly the control run. The appended line deliberately avoids
+/// the word the manifest's `find` matches, so the write does not rot the probe it feeds.
+#[test]
+fn ppfixture_treewrite() {
+    if std::env::var("PP_FIXTURE").as_deref() != Ok("treewrite") {
+        return;
+    }
+    let path = concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/fixtures/tmp/tree_write.txt"
+    );
+    let text = std::fs::read_to_string(path).expect("tree_write.txt");
+    std::fs::write(path, format!("{text}the target wrote here\n")).unwrap();
+}
+
+/// Row 14's fixture: hangs until `timeout` kills it.
+#[test]
+fn ppfixture_hang() {
+    if std::env::var("PP_FIXTURE").as_deref() == Ok("hang") {
+        std::thread::sleep(std::time::Duration::from_secs(600));
+    }
+}

--- a/crates/probe-pin/tests/pure_logic.rs
+++ b/crates/probe-pin/tests/pure_logic.rs
@@ -17,7 +17,9 @@ use probe_pin::mutate;
 use probe_pin::project;
 use probe_pin::target;
 use probe_pin::verdict::{self, Verdict};
-use probe_pin::{Abort, CheckOutcome, DriftCause, HarnessMarker, Instrument, InstrumentChange};
+use probe_pin::{
+    Abort, CheckOutcome, DriftCause, HarnessMarker, Instrument, InstrumentChange, NothingRan,
+};
 
 // ------------------------------------------------------------------ helpers
 
@@ -212,7 +214,7 @@ fn reserved_arg() {
         m.target.args = vec![hostile.to_string()];
         let e = abort_of(manifest::validate(&m).unwrap_err());
         assert!(
-            matches!(e, Abort::ReservedArg { ref arg } if arg == hostile),
+            matches!(e, Abort::ReservedArg { ref arg, ref field } if arg == hostile && field == "[target].args"),
             "{hostile}"
         );
     }
@@ -1037,14 +1039,28 @@ fn path_keys_cannot_escape_the_scratch_dir() {
          [probe.expect]\noutcome='pass'\n"
     ));
 
-    // arm 1 — the phenomenon: an unvalidated id writes INSIDE the measured workspace
-    mutate::apply(&id_manifest.probes[1], &ws, scratch.path()).expect("the escape succeeds");
+    // arm 1 — the phenomenon: the JOIN escapes, so the write lands INSIDE the measured
+    // workspace. `mutate::apply` computed exactly this destination and wrote it; the write-side
+    // containment assert now refuses it first (arm 1b), so the escape is performed here to stay
+    // MEASURED rather than merely asserted about.
+    let escaped_dest = scratch.path().join(&hostile_id).join("f.txt");
+    std::fs::create_dir_all(escaped_dest.parent().unwrap()).unwrap();
+    std::fs::write(&escaped_dest, "beta\n").unwrap();
     assert_eq!(
         std::fs::read_to_string(ws.join("VICTIM.rs/f.txt")).unwrap(),
         "beta\n",
-        "the escape must be real, or arm 2 pins nothing"
+        "the escape must be real, or arms 1b and 2 pin nothing"
     );
     std::fs::remove_dir_all(ws.join("VICTIM.rs")).unwrap();
+
+    // arm 1b — the write-side guard: `mutate::apply` refuses that destination by containment,
+    // whatever validation did or did not do about the id's charset
+    let e = mutate::apply(&id_manifest.probes[1], &ws, scratch.path()).unwrap_err();
+    assert!(
+        format!("{e}").contains("outside probe-pin's scratch directory"),
+        "{e}"
+    );
+    assert_eq!(listing(), ["VICTIM2.rs", "f.txt"], "nothing may be written");
 
     // arm 2 — the guard: refused, and NO file appears outside the scratch dir
     let e = guarded(&id_manifest).unwrap_err();
@@ -1061,13 +1077,22 @@ fn path_keys_cannot_escape_the_scratch_dir() {
          [[probe.mutation]]\nkind='replace'\nfile={hostile_file:?}\nfind='alpha'\nreplace='beta'\n\
          [probe.expect]\noutcome='pass'\n"
     ));
-    mutate::apply(&file_manifest.probes[1], &ws, scratch.path()).expect("the escape succeeds");
+    let escaped_dest = scratch.path().join("P1_escaping_file").join(&hostile_file);
+    std::fs::create_dir_all(escaped_dest.parent().unwrap()).unwrap();
+    std::fs::write(&escaped_dest, "beta\n").unwrap();
     assert_eq!(
         std::fs::read_to_string(ws.join("VICTIM2.rs")).unwrap(),
         "beta\n",
         "the mutant must have been written over the workspace file"
     );
     write(&ws, "VICTIM2.rs", "alpha\n");
+
+    // arm 3b — the same write-side guard, on the `.join(rel)` half
+    let e = mutate::apply(&file_manifest.probes[1], &ws, scratch.path()).unwrap_err();
+    assert!(
+        format!("{e}").contains("outside probe-pin's scratch directory"),
+        "{e}"
+    );
 
     // arm 4 — the guard, same half
     let e = guarded(&file_manifest).unwrap_err();
@@ -1662,7 +1687,7 @@ fn no_tests_selected() {
     let e = verdict::observe("P0_control", &run, &t, &[]).unwrap_err();
     assert_eq!(run.rc, 0, "libtest reports a green exit for a 0-test run");
     assert!(
-        matches!(e, Abort::NoTestsSelected { ref probe, filter_match: manifest::FilterMatch::Exact, .. } if probe == "P0_control"),
+        matches!(e, Abort::NothingExecuted { ref probe, filter_match: manifest::FilterMatch::Exact, reason: NothingRan::NoneSelected, .. } if probe == "P0_control"),
         "{e}"
     );
     assert!(e.to_string().contains("INSTRUMENT FAILURE"));
@@ -1673,8 +1698,95 @@ fn no_tests_selected() {
     t.filter_match = manifest::FilterMatch::Substring;
     assert!(matches!(
         verdict::observe("P0_control", &run, &t, &[]).unwrap_err(),
-        Abort::NoTestsSelected { .. }
+        Abort::NothingExecuted {
+            reason: NothingRan::NoneSelected,
+            ..
+        }
     ));
+}
+
+/// The EXECUTION floor — the general guarantee of the class-closure pass, and the one gate that
+/// covers a suppressing flag nobody enumerated.
+///
+/// `test_count` is what the OLD floor read, and it is IDENTICAL (1) across all three shapes
+/// below: a normal run, an `#[ignore]`d pinned test, and a `--bench` argv. That equality is
+/// asserted first, because it is the whole reason the floor had to move to a different field —
+/// and because it is what makes the DROP arm (restore `test_count == 0`) flip both hostile arms
+/// green while every other assertion in this file stays put.
+///
+/// The `#[ignore]` route needs NO manifest change at all, so digest, block and Tilt resource
+/// stay green forever; `--bench` is reachable through `[target].args`, which is why the argv
+/// shape check alone would not have closed it.
+#[test]
+fn execution_floor_reads_what_executed() {
+    let mut t = target();
+    let obs = |run: &Run, t: &Target| verdict::observe("P0_control", run, t, &[]);
+
+    // the reach guard, and the reason the floor moved: SELECTION cannot tell these apart
+    let normal = child("ppfixture_census", &[], &[]);
+    let ignored = child("ppfixture_ignored", &[], &[]);
+    let benched = child("ppfixture_census", &[], &["--bench"]);
+    for (name, run) in [("ignored", &ignored), ("--bench", &benched)] {
+        assert!(
+            run.stdout.contains("\"test_count\": 1"),
+            "{name}: libtest must still report test_count 1, or this test pins nothing: {}",
+            run.stdout
+        );
+        assert_eq!(run.rc, 0, "{name}: libtest exits GREEN on a skipped run");
+    }
+
+    // positive: a run that executed a body is measured
+    let ok = obs(&normal, &t).expect("a normal run must measure");
+    assert_eq!((ok.passed, ok.failed, ok.ignored), (1, 0, 0));
+
+    // hostile 1: the BLOCKER — `#[ignore]` on the pinned test
+    t.filter = "ppfixture_ignored".into();
+    let e = obs(&ignored, &t).unwrap_err();
+    assert!(
+        matches!(
+            e,
+            Abort::NothingExecuted {
+                reason: NothingRan::AllSkipped,
+                test_count: 1,
+                ignored: 1,
+                ..
+            }
+        ),
+        "{e}"
+    );
+    assert!(e.to_string().contains("MEASURED NOTHING"), "{e}");
+    assert!(
+        e.to_string().contains("was SKIPPED"),
+        "the message must distinguish skipped from unselected: {e}"
+    );
+
+    // hostile 2: `--bench`, which is deliberately NOT on any denylist
+    t.filter = "ppfixture_census".into();
+    t.args = vec!["--bench".into()];
+    let e = obs(&benched, &t).unwrap_err();
+    assert!(
+        matches!(
+            e,
+            Abort::NothingExecuted {
+                reason: NothingRan::AllSkipped,
+                ..
+            }
+        ),
+        "{e}"
+    );
+
+    // and the other parameter of the SAME abort still reads as a selection failure
+    t.args.clear();
+    t.filter = "ppfixture_census_OLDNAME".into();
+    let e = obs(&child("ppfixture_census_OLDNAME", &[], &[]), &t).unwrap_err();
+    assert!(e.to_string().contains("selected ZERO tests"), "{e}");
+    assert!(!e.to_string().contains("was SKIPPED"), "{e}");
+
+    // a FAILING run is executed too: the floor is on passed + failed, not on passed
+    let failed = child("ppfixture_panic", &[("PP_FIXTURE", "panic")], &["--exact"]);
+    t.filter = "ppfixture_panic".into();
+    let obs = obs(&failed, &t).expect("a failing run measured something");
+    assert_eq!((obs.passed, obs.failed), (0, 1));
 }
 
 // ------------------------------------------------------------------ argv + verdict wiring
@@ -1714,6 +1826,365 @@ fn argv_is_live() {
         count(&all) > count(&skipped),
         "[target].args must reach the argv"
     );
+}
+
+// ------------------------------------------------ surface 1: argv (the class, not the field)
+
+/// The ARGV surface. `RESERVED` was checked against `[target].args` while `[target].filter` was
+/// argv token 0 — where libtest's getopts parses it as a flag. The fix is not another field in
+/// the loop: `Target::manifest_argv` is the single enumeration of what the manifest contributes,
+/// `isolate::argv` BUILDS the argv from it, and validation checks the same list, so a future
+/// argv-feeding field is covered by construction.
+///
+/// The DROP arm is `validate` iterating `m.target.args` again: arms 1 and 2 go green, arm 3
+/// (the drift assertion) stays green — which is why arm 3 alone is not the test.
+#[test]
+fn argv_surface_is_one_authority() {
+    let mut m = load("dogfood.toml");
+
+    // arm 1 — a reserved flag in the FILTER slot is refused, and named as the filter
+    m.target.filter = "--format".into();
+    let e = abort_of(manifest::validate(&m).unwrap_err());
+    assert!(
+        matches!(e, Abort::ReservedArg { ref field, ref arg } if field == "[target].filter" && arg == "--format"),
+        "{e}"
+    );
+
+    // arm 2 — the SHAPE constraint, stated as what an OPERAND is. `--bench` is on no denylist
+    // (deliberately: §1's floor is what generalizes), so only the shape rule sees it here.
+    for hostile in ["--bench", "-Zunstable-options", "--list", "-h"] {
+        m.target.filter = hostile.into();
+        let e = manifest::validate(&m).unwrap_err();
+        assert!(
+            e.to_string().contains("begins with '-'")
+                || matches!(abort_of(e), Abort::ReservedArg { .. }),
+            "{hostile} was accepted"
+        );
+    }
+    // positive: an ordinary filter, and a hyphen INSIDE one, still validate
+    for benign in ["ppfixture_census", "census_two-part", ""] {
+        m.target.filter = benign.into();
+        assert!(manifest::validate(&m).is_ok(), "{benign:?} was refused");
+    }
+
+    // arm 2b — the SAME rule on the other program probe-pin hands manifest operands to. `-h`
+    // there is not hypothetical: measured on the shipping binary, ast-grep printed its HELP and
+    // probe-pin counted the lines into a rendered "named at 30 sites" sentence, exit 0.
+    let mut p = load("projection.toml");
+    assert_eq!(
+        manifest::positional_argv_values(&p).len(),
+        2,
+        "the enumeration must cover [target].filter AND the projection's paths"
+    );
+    p.projections[0].paths = vec!["-h".into()];
+    let e = manifest::validate(&p).unwrap_err();
+    assert!(e.to_string().contains("begins with '-'"), "{e}");
+    assert!(e.to_string().contains("instrument_sites"), "{e}");
+    p.projections[0].paths = vec!["crates/probe-pin/src".into()];
+    assert!(manifest::validate(&p).is_ok());
+
+    // arm 3 — the drift assertion: the argv is BUILT from the enumeration validation checks.
+    // Every manifest token reaches the argv, and every argv token that is not probe-pin's own
+    // came from that enumeration — so a field cannot reach libtest unvalidated.
+    let mut t = target();
+    t.filter = "ppfixture_census".into();
+    t.args = vec!["--skip".into(), "ppfixture_ignored".into()];
+    t.filter_match = manifest::FilterMatch::Exact;
+    let argv = isolate::argv(&t);
+    let contributed: Vec<&str> = t.manifest_argv().iter().map(|(_, a)| *a).collect();
+    assert_eq!(
+        contributed,
+        ["ppfixture_census", "--skip", "ppfixture_ignored"]
+    );
+    for token in &contributed {
+        assert!(
+            argv.iter().any(|a| a == token),
+            "{token} never reached argv"
+        );
+    }
+    for token in &argv {
+        assert!(
+            isolate::OWNED_FLAGS.contains(&token.as_str()) || contributed.contains(&token.as_str()),
+            "{token} is on the argv and is neither probe-pin's nor the manifest's"
+        );
+    }
+}
+
+// ------------------------------------------------------------------ surface 2: env
+
+/// The ENV surface. `[target].env` was applied LAST with no key restriction, over a child that
+/// is `unshare … bash -c SCRIPT` — so `PATH` resolved the `mount` and `cmp` the readback is made
+/// of. Measured on the shipping binary: a manifest pointing `PATH` at stub `mount`/`cmp`
+/// rendered `mount reached: 1 file(s)` at exit 0 for a probe whose mutant was never mounted.
+///
+/// Arm 2 is the anti-drift half, and the reason the refused set is not a hand-written list
+/// compared against another hand-written list: it reads the keys the SHIPPING child command
+/// actually sets, through `Command::get_envs`, and requires each to be refused.
+#[test]
+fn env_surface_refuses_probe_pin_owned_keys() {
+    let mut m = load("dogfood.toml");
+
+    // arm 1 — the measured attack, plus the rest of the owned set
+    for key in [
+        "PATH",
+        "HOME",
+        "PP_MOUNTS",
+        "PP_MUTANT_0",
+        "PP_TARGET_3",
+        "TIMEOUT",
+        "TESTBIN",
+    ] {
+        m.target.env = BTreeMap::from([(key.to_string(), "/hostile".to_string())]);
+        let e = manifest::validate(&m).unwrap_err();
+        assert!(e.to_string().contains(key), "{key} was accepted: {e}");
+        assert!(
+            e.to_string().contains("probe-pin itself sets"),
+            "{key} -> {e}"
+        );
+    }
+    // positive: the target's OWN variables, and the one documented overridable default
+    m.target.env = BTreeMap::from([
+        ("PP_FIXTURE".to_string(), "treewrite".to_string()),
+        ("RUST_MIN_STACK".to_string(), "268435456".to_string()),
+        ("RUST_BACKTRACE".to_string(), "1".to_string()),
+    ]);
+    assert!(manifest::validate(&m).is_ok());
+
+    // arm 2 — every key the shipping child command sets must be refused by the same authority.
+    // `[target].env` is emptied first, so what remains in `get_envs` is probe-pin's alone.
+    let mut t = target();
+    t.env.clear();
+    let mounts = vec![
+        mutate::Mount {
+            mutant: PathBuf::from("/scratch/P1/a.rs"),
+            target: PathBuf::from("/ws/a.rs"),
+        },
+        mutate::Mount {
+            mutant: PathBuf::from("/scratch/P1/b.rs"),
+            target: PathBuf::from("/ws/b.rs"),
+        },
+    ];
+    let cmd = isolate::child_command(isolate::SCRIPT, Path::new("/bin/true"), &mounts, &t);
+    let keys: Vec<String> = cmd
+        .get_envs()
+        .filter(|(_, v)| v.is_some())
+        .map(|(k, _)| k.to_string_lossy().into_owned())
+        .collect();
+    assert!(
+        keys.iter().any(|k| k == "PP_MUTANT_1") && keys.iter().any(|k| k == "PATH"),
+        "instrument check: the readback must see the real key set, got {keys:?}"
+    );
+    for key in &keys {
+        assert!(
+            isolate::is_probe_pin_owned_env(key) || key == "RUST_MIN_STACK",
+            "the child sets {key}, which [target].env may still override. Either add it to \
+             isolate's owned set or document it like RUST_MIN_STACK. keys: {keys:?}"
+        );
+    }
+}
+
+// ------------------------------------------------------------------ surface 3: filesystem path
+
+/// The PATH surface. `is_workspace_relative` is LEXICAL — every component `Normal` says nothing
+/// about what a component RESOLVES to — so an in-tree symlink satisfies it and lands the write
+/// anywhere on the filesystem (measured on the shipping binary: `[output].file` through one,
+/// exit 0, the block spliced outside the repository).
+///
+/// Arm 1 is the phenomenon: the lexical check ACCEPTS the escaping key, which is what makes the
+/// containment assertion non-vacuous. `isolate::scratch_dir`'s canonicalize-then-`starts_with`
+/// is the in-tree pattern this reuses, in both directions — into the workspace here, and into
+/// the scratch dir in `mutant_destination_cannot_escape_the_scratch_dir`.
+#[test]
+fn path_surface_is_realpath_containment() {
+    let base = tempfile::tempdir().unwrap();
+    let ws = base.path().join("ws");
+    let outside = base.path().join("outside");
+    std::fs::create_dir_all(ws.join("crates")).unwrap();
+    std::fs::create_dir_all(&outside).unwrap();
+    std::fs::write(outside.join("victim.rs"), "OUTSIDE\n").unwrap();
+    std::os::unix::fs::symlink(&outside, ws.join("crates/link")).unwrap();
+    std::os::unix::fs::symlink(outside.join("does_not_exist"), ws.join("crates/dangling")).unwrap();
+
+    // arm 1 — the phenomenon: every escaping key below passes the LEXICAL check
+    for key in [
+        "crates/link/victim.rs",
+        "crates/link/new_file.md",
+        "crates/dangling",
+    ] {
+        assert!(
+            manifest::is_workspace_relative(key),
+            "{key} must be lexically clean, or the containment arm is vacuous"
+        );
+        let why =
+            manifest::resolve_contained(&ws, key).expect_err(&format!("{key} escaped containment"));
+        assert!(
+            why.contains("outside") || why.contains("symlink whose target does not exist"),
+            "{key} -> {why}"
+        );
+    }
+    // and the lexical refusals still read as lexical ones
+    for key in ["../escape.md", "/tmp/escape.md", "crates/../../escape.md"] {
+        let why = manifest::resolve_contained(&ws, key).unwrap_err();
+        assert!(why.contains("not a relative path"), "{key} -> {why}");
+    }
+
+    // positive: an existing in-tree file, a file that does not exist yet, and a nested new path
+    std::fs::write(ws.join("crates/real.rs"), "IN\n").unwrap();
+    for key in ["crates/real.rs", "crates/new.md", "crates/deep/new.md"] {
+        assert!(
+            manifest::resolve_contained(&ws, key).is_ok(),
+            "{key} was refused"
+        );
+    }
+
+    // and it is WIRED: validate_paths refuses the same key on both path fields
+    let m = |output: &str, mutated: &str| -> Manifest {
+        toml::from_str(&format!(
+            "version = 1\n\
+             [target]\nmode='runtime-read'\npackage='p'\ntest='t'\nfilter='f'\nfilter_match='substring'\n\
+             [output]\nfile={output:?}\nmarker='PROBE-PIN'\n\
+             [[probe]]\nid='P0_control'\n[probe.expect]\noutcome='pass'\n\
+             [[probe]]\nid='P1'\n[[probe.mutation]]\nkind='replace'\nfile={mutated:?}\nfind='a'\nreplace='b'\n\
+             [probe.expect]\noutcome='pass'\n"
+        ))
+        .expect("manifest parses")
+    };
+    let ok = m("crates/new.md", "crates/real.rs");
+    manifest::validate(&ok).expect("the benign manifest validates");
+    manifest::validate_paths(&ok, &ws).expect("the benign manifest is contained");
+
+    let escaping_output = m("crates/link/new_file.md", "crates/real.rs");
+    manifest::validate(&escaping_output).expect("the LEXICAL pass is the phenomenon");
+    let e = manifest::validate_paths(&escaping_output, &ws).unwrap_err();
+    assert!(e.to_string().contains("[output].file"), "{e}");
+    assert!(e.to_string().contains("is not workspace-relative"), "{e}");
+
+    let escaping_mutation = m("crates/new.md", "crates/link/victim.rs");
+    manifest::validate(&escaping_mutation).expect("the LEXICAL pass is the phenomenon");
+    let e = manifest::validate_paths(&escaping_mutation, &ws).unwrap_err();
+    assert!(e.to_string().contains("P1 names"), "{e}");
+
+    // the fourth path producer: a projection's operands reach ast-grep, in the same tree
+    let mut projecting = load("projection.toml");
+    projecting.projections[0].paths = vec!["crates/link".into()];
+    let e = manifest::validate_paths(&projecting, &ws).unwrap_err();
+    assert!(e.to_string().contains("instrument_sites"), "{e}");
+    assert!(e.to_string().contains("scans"), "{e}");
+    projecting.projections[0].paths = vec!["crates/real.rs".into()];
+    assert!(manifest::validate_paths(&projecting, &ws).is_ok());
+}
+
+/// The same containment rule on the WRITE side, where the base is the scratch dir. `mutate::apply`
+/// writes `scratch.join(probe.id).join(rel)`: both halves are lexically constrained already, and
+/// neither says what the join resolves to. Arm 1 exhibits the escape — a symlink in the scratch
+/// dir named as a plain probe id — writing a mutant straight into the measured workspace.
+#[test]
+fn mutant_destination_cannot_escape_the_scratch_dir() {
+    let base = tempfile::tempdir().unwrap();
+    let ws = base.path().join("ws");
+    let scratch = base.path().join("scratch");
+    std::fs::create_dir_all(&scratch).unwrap();
+    write(&ws, "f.txt", "alpha\n");
+    let p = probe(
+        "id='P1_plain_name'\n[[mutation]]\nkind='replace'\nfile='f.txt'\nfind='alpha'\nreplace='beta'\n\
+         [expect]\noutcome='pass'\n",
+    );
+    // the id is a plain name and the file is relative — both LEXICAL checks pass
+    assert!(manifest::is_plain_name(&p.id) && manifest::is_workspace_relative("f.txt"));
+
+    // arm 1 — the phenomenon, with the guard's own base symlinked into the workspace
+    std::os::unix::fs::symlink(&ws, scratch.join("P1_plain_name")).unwrap();
+    let e = mutate::apply(&p, &ws, &scratch).unwrap_err();
+    assert!(
+        e.to_string()
+            .contains("outside probe-pin's scratch directory"),
+        "{e}"
+    );
+    assert_eq!(
+        std::fs::read_to_string(ws.join("f.txt")).unwrap(),
+        "alpha\n",
+        "nothing may be written into the measured tree"
+    );
+
+    // positive: an ordinary scratch dir still materializes the mutant
+    std::fs::remove_file(scratch.join("P1_plain_name")).unwrap();
+    let mounts = mutate::apply(&p, &ws, &scratch).expect("the shipping shape must survive");
+    assert_eq!(mounts.len(), 1);
+    assert_eq!(
+        std::fs::read_to_string(scratch.join("P1_plain_name/f.txt")).unwrap(),
+        "beta\n"
+    );
+}
+
+// ------------------------------------------------------------------ surface 4: anchor semantics
+
+/// The ANCHOR surface. The empty anchor LIST was refused because "any failure would satisfy it";
+/// `all_anchors_in_one` matches with `contains`, and `contains("")` is true for every capture —
+/// so `anchor = [""]` is that identical hazard one character away, and it was accepted
+/// (measured: exit 0, a green `fail` row with a BLANK firing-assertion cell, which reads as "no
+/// anchor was needed").
+#[test]
+fn anchor_surface_refuses_a_blank_anchor() {
+    // the phenomenon: a blank anchor is satisfied by any capture at all
+    assert!(verdict::all_anchors_in_one(
+        &[String::new()],
+        &["a totally unrelated failure".to_string()]
+    ));
+    assert!(!verdict::all_anchors_in_one(
+        &["REAL".to_string()],
+        &["a totally unrelated failure".to_string()]
+    ));
+
+    let mut m = load("dogfood.toml");
+    for hostile in [vec![""], vec![" "], vec!["\t\n"], vec!["REAL ANCHOR", ""]] {
+        m.probes[1].expect = probe_pin::manifest::Expect::Fail {
+            anchor: hostile.iter().map(|s| (*s).to_string()).collect(),
+        };
+        let e = manifest::validate(&m).unwrap_err();
+        assert!(
+            e.to_string().contains("empty after trimming"),
+            "{hostile:?} was accepted: {e}"
+        );
+        assert!(e.to_string().contains("P1_drop_second_site"), "{e}");
+    }
+    // the empty LIST still reports as the empty list, not as a blank anchor
+    m.probes[1].expect = probe_pin::manifest::Expect::Fail { anchor: vec![] };
+    let e = manifest::validate(&m).unwrap_err();
+    assert!(e.to_string().contains("empty anchor list"), "{e}");
+    // positive: the shipping anchors validate
+    assert!(manifest::validate(&load("dogfood.toml")).is_ok());
+}
+
+// ------------------------------------------------------- assert_count says what it measured
+
+/// `assert_count` is evaluated against the MUTANT text, so a file the probe does not mutate had
+/// no mutant — the old fallback read the PRISTINE tree and reported it as "in the MUTANT of".
+/// Refusing is the half that cannot rot: the message stays true because the case is gone.
+#[test]
+fn assert_count_must_name_a_file_this_probe_mutates() {
+    let text = std::fs::read_to_string(fixtures().join("dogfood.toml")).unwrap();
+    let unmutated = text.replace(
+        "  [[probe.assert_count]]\n  file  = \"crates/probe-pin/tests/fixtures/prod.txt\"",
+        "  [[probe.assert_count]]\n  file  = \"crates/probe-pin/tests/fixtures/dogfood.toml\"",
+    );
+    assert_ne!(
+        unmutated, text,
+        "the fixture edit must apply, or this arm is vacuous"
+    );
+    let m = toml::from_str::<Manifest>(&unmutated).expect("manifest parses");
+    assert_eq!(
+        m.probes[1].assert_counts[0].file,
+        "crates/probe-pin/tests/fixtures/dogfood.toml"
+    );
+    let e = manifest::validate(&m).unwrap_err();
+    assert!(
+        e.to_string().contains("which this probe does not mutate"),
+        "{e}"
+    );
+    assert!(e.to_string().contains("P1_drop_second_site"), "{e}");
+
+    // positive: the shipping assert_count names the file its probe mutates
+    assert!(manifest::validate(&toml::from_str::<Manifest>(&text).unwrap()).is_ok());
 }
 
 /// `Verdict::Fail` IS "target failed AND every anchor in ONE record". Its complement is a
@@ -1762,6 +2233,16 @@ fn ppfixture_census() {
         sites, 2,
         "CENSUS VIOLATED: expected 2 sites, got {sites}; text: {text:?}"
     );
+}
+
+/// The execution floor's fixture: a pinned test whose body NEVER RUNS. `#[ignore]` needs no
+/// manifest change at all, so the digest, the block and the Tilt resource stay green forever —
+/// and libtest still reports `test_count: 1` for it, which is why a floor written on
+/// `test_count` cannot see it. The terminal record's `passed`/`failed`/`ignored` can.
+#[test]
+#[ignore = "a probe TARGET, not an assertion: driven by the execution-floor manifests"]
+fn ppfixture_ignored() {
+    assert!(std::fs::read_to_string(PROD).is_ok(), "prod.txt");
 }
 
 /// Row 8's fixture A: UNCONDITIONAL — no `RUST_MIN_STACK` value rescues it.

--- a/crates/probe-pin/tests/pure_logic.rs
+++ b/crates/probe-pin/tests/pure_logic.rs
@@ -882,6 +882,104 @@ fn target_resolve_pins_cargo_to_the_workspace_root() {
     );
 }
 
+/// The `splice` postcondition is only worth what the WRITER CENSUS is worth.
+///
+/// `splice` refusing to return an unlocatable block makes "`run --write` cannot commit a block its
+/// own next `check` aborts on" unconditional — but only while `splice` is the sole route to the
+/// bytes of the pinned file. A second `fs::write` of `output.file` added later would falsify that
+/// sentence in the docs, the PR body and the crate's own comment block, with nothing failing. That
+/// is this crate's recurring defect class wearing new clothes: prose stays green after the thing
+/// it describes has moved.
+///
+/// So the census is executable rather than recited. Measured at the head that added the
+/// postcondition: exactly two write producers exist in `src/` — `mutate.rs` (the mutant, into the
+/// scratch dir, never a rendered block) and `main.rs` (the pinned file), and the latter's content
+/// argument is literally the `splice(..)?` call. The guard is not merely *on* the write path; it
+/// is *inside the only write's argument*, so no byte sequence reaches the file without it.
+///
+/// COUNTED ON SYNTAX, NOT TEXT — but stated as what it is, because the first draft of this
+/// comment got it wrong in the direction that flatters the code. It claimed the comment-strip was
+/// load-bearing today, citing `manifest.rs`'s prose mention of `fs::write`. Measured: that mention
+/// is in backticks with no open paren, every producer pattern here requires the paren, and
+/// deleting the strip left this test GREEN — the arm did not flip. The strip is DEFENSIVE, not
+/// currently load-bearing.
+///
+/// Its value is therefore measured against the input it exists for rather than asserted: inserting
+/// a doc comment that quotes a call site (`// e.g. std::fs::write(&dest, mutant) ...`) into
+/// `mutate.rs` keeps this test green WITH the strip and fails it at `found 3` WITHOUT — same
+/// source, both arms. So it earns its three lines against a comment a future author will
+/// plausibly write, and the census counts call sites rather than the word "write".
+#[test]
+fn every_write_of_the_pinned_file_routes_through_splice() {
+    let src_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("src");
+    let mut sites: Vec<(String, String)> = Vec::new();
+
+    for entry in std::fs::read_dir(&src_dir).expect("src/ is readable") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().is_none_or(|e| e != "rs") {
+            continue;
+        }
+        let text = std::fs::read_to_string(&path).expect("module is readable");
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        for line in text.lines() {
+            let code = line.trim_start();
+            // Strip `//`, `///` and `//!` alike: a doc comment is not a call site.
+            if code.starts_with("//") {
+                continue;
+            }
+            if ["fs::write(", "File::create(", ".write_all(", "OpenOptions"]
+                .iter()
+                .any(|p| code.contains(p))
+            {
+                sites.push((name.clone(), code.to_string()));
+            }
+        }
+    }
+
+    // Positive control: a census that can only return zero proves nothing. If the producer
+    // patterns ever stop matching real code, this fires before the completeness assertion below
+    // can pass vacuously.
+    assert!(
+        !sites.is_empty(),
+        "the writer census found NO filesystem writes in src/, but probe-pin demonstrably writes \
+         both a mutant and the pinned file. The search patterns no longer match real call sites, \
+         so every assertion below this line would pass by finding nothing."
+    );
+
+    let files: Vec<&str> = sites.iter().map(|(f, _)| f.as_str()).collect();
+    assert_eq!(
+        sites.len(),
+        2,
+        "the writer census changed: expected exactly 2 filesystem writes in src/ (mutate.rs's \
+         scratch mutant, main.rs's pinned file), found {} in {files:?}. If a new write is \
+         legitimate, decide which it is: a write of output.file MUST route through \
+         block::splice, or the postcondition stops being unconditional and docs/probe-pin.md \
+         plus the crate's own generated block are asserting something no longer true. \
+         Sites: {sites:#?}",
+        sites.len()
+    );
+    assert!(
+        files.contains(&"mutate.rs") && files.contains(&"main.rs"),
+        "the two writes are no longer the two expected producers: {files:?}"
+    );
+
+    let main_src = std::fs::read_to_string(src_dir.join("main.rs")).expect("main.rs is readable");
+    let write_call = main_src
+        .split_once("std::fs::write(")
+        .expect("main.rs writes the pinned file")
+        .1;
+    let args = write_call
+        .split_once(")\n")
+        .map_or(write_call, |(before, _)| before);
+    assert!(
+        args.contains("block::splice("),
+        "main.rs still writes the pinned file, but the bytes no longer come from block::splice. \
+         The postcondition that refuses an unlocatable block is bypassed, and `run --write` can \
+         again commit a block whose marker span its own `check` cannot find. Write args were: \
+         {args}"
+    );
+}
+
 /// The workspace root is CANONICAL at its one producer, because every consumer compares it
 /// against a path that has been: `main`'s `manifest_rel` strips it from
 /// `manifest_path.canonicalize()`, `resolve_contained` canonicalizes `base`, `scratch_dir`

--- a/crates/probe-pin/tests/pure_logic.rs
+++ b/crates/probe-pin/tests/pure_logic.rs
@@ -1222,6 +1222,176 @@ fn timeout_zero_is_refused() {
     assert!(manifest::validate(&toml::from_str::<Manifest>(&text).unwrap()).is_ok());
 }
 
+/// A blank `[target].filter` is a manifest defect that neither `filter_match` mode reports AS one.
+///
+/// Measured before the refusal existed, running a real manifest with `filter = ""` and
+/// `filter_match = "substring"`: the run widened to the whole target binary and probe-pin exited 2
+/// — but with "the control probe 'P0_control' FAILED with exit 101 … the instrument is broken",
+/// because a test in the widened set happened to fail. Nothing looked at the filter. Had the
+/// widened suite passed, every row would have rendered green while measuring a suite the block
+/// names as one test. The `exact` mode fails the other way: zero matches, which the execution
+/// floor reports as a target that ran nothing.
+#[test]
+fn blank_filter_is_refused() {
+    let text = std::fs::read_to_string(fixtures().join("dogfood.toml")).unwrap();
+    let blank = text.replace("filter       = \"ppfixture_census\"", "filter       = \"\"");
+    assert_ne!(
+        blank, text,
+        "the fixture edit must apply, or this arm is vacuous"
+    );
+    let m = toml::from_str::<Manifest>(&blank).expect("manifest parses");
+    assert_eq!(m.target.filter, "");
+    let e = manifest::validate(&m).unwrap_err();
+    assert!(e.to_string().contains("[target].filter is blank"), "{e}");
+
+    // Whitespace is blank too — a filter of spaces names no test either, and `trim` is what makes
+    // the refusal about NAMING rather than about the empty string.
+    let spaces = text.replace(
+        "filter       = \"ppfixture_census\"",
+        "filter       = \"   \"",
+    );
+    let m = toml::from_str::<Manifest>(&spaces).expect("manifest parses");
+    assert!(
+        manifest::validate(&m)
+            .unwrap_err()
+            .to_string()
+            .contains("[target].filter is blank"),
+        "a whitespace-only filter must be refused for the same reason"
+    );
+
+    // Positive control: the shipping filter still validates, so the refusal is discriminating and
+    // not a blanket rejection of the field.
+    assert!(manifest::validate(&toml::from_str::<Manifest>(&text).unwrap()).is_ok());
+}
+
+/// The control row is keyed on probe IDENTITY, so a MUTATION probe can never claim to be one.
+///
+/// Discriminating by construction: both probes below carry the identical verdict
+/// `Pass { mounts_reached: 0 }`. Only their identity differs. Before this change `firing_cell`
+/// read the count, so both rendered `(control; no mounts)` — the mutation probe's row asserting
+/// it had no mutations, in a committed evidence artifact, with a digest that agrees because the
+/// digest pins the same count.
+///
+/// The zero-mount mutation probe is not reachable through `main` today (`validate` refuses an
+/// empty mutation file list, so `mounts.len() >= 1`), which is exactly why the test constructs the
+/// state directly: the property being pinned is that the ROW cannot lie, not that the current call
+/// graph happens not to produce a liar.
+#[test]
+fn a_mutation_probe_can_never_render_as_the_control() {
+    let text = std::fs::read_to_string(fixtures().join("dogfood.toml")).unwrap();
+    let m = toml::from_str::<Manifest>(&text).expect("manifest parses");
+    let control = &m.probes[0];
+    let mutating = &m.probes[1];
+    assert!(
+        control.mutations.is_empty() && !mutating.mutations.is_empty(),
+        "fixture shape assumed by this test: probe 0 is the control, probe 1 mutates"
+    );
+
+    let render_with = |probe: &Probe| {
+        let one = Manifest {
+            probes: vec![probe.clone()],
+            ..m.clone()
+        };
+        let outcomes = vec![Outcome {
+            id: probe.id.clone(),
+            rc: 0,
+            // The SAME verdict for both probes: identity is the only variable.
+            verdict: Verdict::Pass { mounts_reached: 0 },
+        }];
+        block::render(&one, "m.toml", "d", &[], &outcomes, &[])
+    };
+
+    assert!(
+        render_with(control).contains("(control; no mounts)"),
+        "the control's row must still say so"
+    );
+    let mutant_row = render_with(mutating);
+    assert!(
+        !mutant_row.contains("(control; no mounts)"),
+        "a probe WITH mutations rendered as the control on a zero count. The row is deciding \
+         probe identity from a measured number, so an evidence artifact states that a mutation \
+         probe made no mutations. Row was:\n{mutant_row}"
+    );
+    assert!(
+        mutant_row.contains("mount reached: 0 file(s)"),
+        "and it must report the count it actually measured, however unexpected. Row was:\n{mutant_row}"
+    );
+}
+
+/// The table can never contain fewer rows than the manifest declares probes.
+///
+/// `digest` records an outcome-less probe as `rc = -1`, `verdict = "unmeasured"`. `render` used to
+/// `continue` past it. That disagreement is the silent kind: a manifest declares N probes, the
+/// block shows N-1 rows, and `check` reports CLEAN — the committed and generated blocks omit the
+/// same row and stamp the same digest, so the drift detector agrees with the loss.
+///
+/// Not reachable through `main` (the mismatch gate at `main.rs:190` returns first), which is why
+/// this asserts on `render` directly. `render` is public and this input is legitimate: the
+/// projection-surface test calls it with `&[]` outcomes.
+#[test]
+fn a_probe_with_no_outcome_gets_a_visible_unmeasured_row() {
+    let text = std::fs::read_to_string(fixtures().join("dogfood.toml")).unwrap();
+    let m = toml::from_str::<Manifest>(&text).expect("manifest parses");
+    let declared = m.probes.len();
+    assert!(declared >= 2, "fixture must declare several probes");
+
+    // Every probe measured EXCEPT the last one.
+    let outcomes: Vec<Outcome> = m.probes[..declared - 1]
+        .iter()
+        .map(|p| Outcome {
+            id: p.id.clone(),
+            rc: 0,
+            verdict: Verdict::Pass { mounts_reached: 1 },
+        })
+        .collect();
+    let rendered = block::render(&m, "m.toml", "d", &[], &outcomes, &[]);
+
+    let rows = rendered
+        .lines()
+        .filter(|l| l.starts_with("// | ") && !l.contains("| probe |"))
+        .count();
+    assert_eq!(
+        rows, declared,
+        "the table dropped a declared probe instead of rendering it. A block that silently loses \
+         evidence still passes `check`, because the committed copy lost the same row.\n{rendered}"
+    );
+
+    let dropped = &m.probes[declared - 1].id;
+    let row = rendered
+        .lines()
+        .find(|l| l.contains(dropped.as_str()))
+        .unwrap_or_else(|| panic!("no row for the unmeasured probe:\n{rendered}"));
+    assert!(
+        row.contains("unmeasured"),
+        "the unmeasured probe's row must SAY it is unmeasured, matching what digest records for \
+         the same input: {row}"
+    );
+
+    // Discriminating: a fully-measured run must not gain a phantom row, or the count assertion
+    // above would pass for a render that emits an extra line per probe.
+    let all: Vec<Outcome> = m
+        .probes
+        .iter()
+        .map(|p| Outcome {
+            id: p.id.clone(),
+            rc: 0,
+            verdict: Verdict::Pass { mounts_reached: 1 },
+        })
+        .collect();
+    let full = block::render(&m, "m.toml", "d", &[], &all, &[]);
+    assert_eq!(
+        full.lines()
+            .filter(|l| l.starts_with("// | ") && !l.contains("| probe |"))
+            .count(),
+        declared,
+        "a fully-measured render must have exactly one row per probe:\n{full}"
+    );
+    assert!(
+        !full.contains("unmeasured"),
+        "and none of them may be marked unmeasured:\n{full}"
+    );
+}
+
 // ------------------------------------------------------------------ row 19
 
 /// Row 19: `assert_count` runs on the MUTANT, after all mutations have composed.
@@ -2292,10 +2462,24 @@ fn argv_surface_is_one_authority() {
         );
     }
     // positive: an ordinary filter, and a hyphen INSIDE one, still validate
-    for benign in ["ppfixture_census", "census_two-part", ""] {
+    for benign in ["ppfixture_census", "census_two-part"] {
         m.target.filter = benign.into();
         assert!(manifest::validate(&m).is_ok(), "{benign:?} was refused");
     }
+    // `""` used to sit in that list, asserting a blank filter validates — which it no longer does.
+    // Kept as a probe of WHICH guard refuses it: the naming rule, not this surface. If the argv
+    // rule ever starts rejecting it, the benign list above stops proving the rule is discriminating
+    // and this arm says so rather than passing on any refusal at all.
+    m.target.filter = String::new();
+    let e = manifest::validate(&m).unwrap_err();
+    assert!(
+        e.to_string().contains("[target].filter is blank"),
+        "a blank filter must be refused for naming nothing: {e}"
+    );
+    assert!(
+        !e.to_string().contains("begins with '-'"),
+        "the leading-'-' operand rule must not be what rejects a blank filter: {e}"
+    );
 
     // arm 2b — the SAME rule on the other program probe-pin hands manifest operands to. `-h`
     // there is not hypothetical: measured on the shipping binary, ast-grep printed its HELP and

--- a/crates/probe-pin/tests/pure_logic.rs
+++ b/crates/probe-pin/tests/pure_logic.rs
@@ -774,6 +774,53 @@ fn control_may_not_declare_an_assert_count() {
     assert!(manifest::validate(&toml::from_str::<Manifest>(&text).unwrap()).is_ok());
 }
 
+/// `target::resolve` must run cargo with the workspace root as its cwd, and this is asserted
+/// against the SOURCE because no behavioural test can see it: with the pin removed the whole
+/// Tier-2 suite still passes 15/15 — only the *location of a side effect* moves. Measured, both
+/// arms, same command: pinned, nothing appears; unpinned, a 285M `crates/probe-pin/target/`
+/// materializes, which no `.gitignore` rule covers because the repo ignores a root-anchored
+/// `/target`.
+///
+/// The cause is that `CARGO_TARGET_DIR` is commonly relative (the Tilt resources pass
+/// `target/probe-pin`) and a relative value resolves against the cwd of whichever process
+/// finally execs cargo — here a test whose cwd is the crate directory, not the root.
+/// `workspace_root` is deliberately NOT pinned: inheriting the caller's cwd is how it discovers
+/// the root at all.
+#[test]
+fn target_resolve_pins_cargo_to_the_workspace_root() {
+    let src = std::fs::read_to_string(Path::new(env!("CARGO_MANIFEST_DIR")).join("src/target.rs"))
+        .expect("target.rs is readable");
+
+    let resolve = src
+        .split_once("pub fn resolve(")
+        .expect("target::resolve exists")
+        .1;
+    let body = resolve
+        .split_once("pub fn ")
+        .map_or(resolve, |(before, _)| before);
+    assert!(
+        body.contains(".current_dir(root)"),
+        "target::resolve no longer pins cargo's cwd to the workspace root. A relative \
+         CARGO_TARGET_DIR then resolves against whatever cwd the caller had, scattering build \
+         artifacts outside the root-anchored /target the repo ignores. The Tier-2 suite cannot \
+         catch this — it passes either way."
+    );
+
+    // Instrument control: the same search must NOT find the pin in `workspace_root`, which is
+    // correct precisely because it inherits the caller's cwd. If this ever matches, the search
+    // is picking up the wrong function and the assertion above proves nothing.
+    let wsr = src
+        .split_once("pub fn workspace_root(")
+        .expect("workspace_root exists")
+        .1;
+    let wsr_body = wsr.split_once("pub fn ").map_or(wsr, |(before, _)| before);
+    assert!(
+        !wsr_body.contains(".current_dir("),
+        "workspace_root must NOT pin a cwd — it discovers the root FROM the cwd. If it now does, \
+         this test's function-slicing is wrong and both assertions need re-reading."
+    );
+}
+
 /// The Tier-2 suite is `#[ignore]`d because GitHub's runners deny unprivileged user namespaces,
 /// so GH CI never executes a real mount. That is a measured accommodation, and an accommodation
 /// with nothing watching it decays: a Tier-2 test added without the attribute turns CI red for a

--- a/crates/probe-pin/tests/pure_logic.rs
+++ b/crates/probe-pin/tests/pure_logic.rs
@@ -927,9 +927,23 @@ fn every_write_of_the_pinned_file_routes_through_splice() {
             if code.starts_with("//") {
                 continue;
             }
-            if ["fs::write(", "File::create(", ".write_all(", "OpenOptions"]
-                .iter()
-                .any(|p| code.contains(p))
+            // `fs::copy` and `fs::rename` are here because an independent reviewer ran this
+            // census with a WIDER pattern set than the one shipped above and got the same answer.
+            // Same result, but the agreement was luck: they exist in no `src/` module today, so a
+            // future `fs::copy(tmp, out_path)` would have written the pinned file and this census
+            // would have reported "exactly 2" while missing it. A census is only as wide as its
+            // producer list, and a found hole is a lower bound — the fix is the wider list, not
+            // the reassuring count.
+            if [
+                "fs::write(",
+                "File::create(",
+                ".write_all(",
+                "OpenOptions",
+                "fs::copy(",
+                "fs::rename(",
+            ]
+            .iter()
+            .any(|p| code.contains(p))
             {
                 sites.push((name.clone(), code.to_string()));
             }

--- a/crates/probe-pin/tests/pure_logic.rs
+++ b/crates/probe-pin/tests/pure_logic.rs
@@ -1332,6 +1332,66 @@ fn path_keys_cannot_escape_the_scratch_dir() {
     assert_eq!(listing(), ["VICTIM2.rs", "f.txt"]);
 }
 
+/// Maintainer review on #7315, blocking: "add a regression test proving marker/newline injection
+/// is rejected and that `run --write` cannot produce an uncheckable block". Those are two
+/// different claims and they are proven at two different layers, because closing only the first
+/// leaves the second conditional on probe-pin having seen every producer in advance.
+///
+/// Layer 1 — the manifest fields, refused before any target runs. Layer 2 — the bytes actually
+/// written, refused by `splice` itself. Layer 2 is what makes the guarantee unconditional: an
+/// instrument's `--version` output and the `provenance` paths lifted from the target's panic text
+/// also reach rendered lines, and neither can be validated in advance.
+#[test]
+fn write_can_never_produce_a_block_its_own_check_cannot_locate() {
+    let file = Path::new("out.md");
+    let text = "above\n// PROBE-PIN:BEGIN old\n// stale\n// PROBE-PIN:END\nbelow\n";
+
+    // Layer 1: manifest-derived injection is refused, including the maintainer's exact string.
+    let manifest = std::fs::read_to_string(fixtures().join("dogfood.toml")).unwrap();
+    for hostile in ["\nPROBE-PIN:END", "PROBE-PIN:END", "boom\nsecond"] {
+        let edited = manifest.replace(
+            r#"anchor  = ["CENSUS VIOLATED: expected 2 sites, got 202"]"#,
+            &format!("anchor  = [{}]", serde_json::to_string(hostile).unwrap()),
+        );
+        assert_ne!(
+            edited, manifest,
+            "the fixture edit must apply, or this is vacuous"
+        );
+        let m: Manifest = toml::from_str(&edited).expect("manifest parses");
+        // `validate_block_text` is the guard for values that reach the BLOCK, and it is separate
+        // from `validate` because it needs the manifest's workspace-relative path — which is
+        // itself one of the rendered values. Both run before any target, at `main.rs:113-114`.
+        let msg =
+            match manifest::validate_block_text(&m, "crates/probe-pin/tests/fixtures/dogfood.toml")
+            {
+                Ok(()) => panic!("{hostile:?} was ACCEPTED and would be rendered into the block"),
+                Err(e) => e.to_string(),
+            };
+        assert!(
+            msg.contains("control character") || msg.contains("marker tag"),
+            "{hostile:?} was accepted: {msg}"
+        );
+    }
+
+    // Layer 2: a generated block carrying a second END is refused AT THE WRITE, no manifest
+    // involved — this is the arm that covers producers probe-pin cannot inspect beforehand.
+    let injected = "// PROBE-PIN:BEGIN new\n// | p | m | pass | pass | // PROBE-PIN:END | — |\n// PROBE-PIN:END";
+    let err = block::splice(text, "PROBE-PIN", file, injected)
+        .expect_err("a block carrying a second END must never be returned for writing");
+    assert!(
+        matches!(abort_of(err.into()), Abort::MarkerNotUnique { begins, ends, .. } if begins == 1 && ends == 2),
+        "the refusal must name the marker imbalance it found"
+    );
+
+    // Positive control: the same splice with a well-formed block still succeeds, so the guard
+    // above is refusing the injection and not simply refusing everything.
+    let clean = "// PROBE-PIN:BEGIN new\n// | p | m | pass | pass | fired | — |\n// PROBE-PIN:END";
+    let out = block::splice(text, "PROBE-PIN", file, clean).expect("a well-formed block splices");
+    assert!(out.starts_with("above\n") && out.ends_with("below\n"));
+    // and the result is locatable, which is the property the whole test is about
+    block::extract(&out, "PROBE-PIN", file).expect("the written file must be locatable");
+}
+
 // ------------------------------------------------------------------ row 22
 
 /// Row 22: the splice preserves every byte outside the marker pair — prose above, prose

--- a/crates/probe-pin/tests/pure_logic.rs
+++ b/crates/probe-pin/tests/pure_logic.rs
@@ -547,6 +547,7 @@ fn env_default() {
 fn schema_adequacy() {
     for name in [
         "collide.toml",
+        "control_expect_fail.toml",
         "control_fails.toml",
         "dogfood.toml",
         "p7.toml",
@@ -695,6 +696,216 @@ fn noop() {
         scratch.path()
     )
     .is_ok());
+}
+
+/// Row 18's escape (final review-impl, MAJOR-1): a mutation whose `files` list is EMPTY never
+/// reaches the no-op gate — it seeds no running file, so the per-file loop never executes, no
+/// mount is built, and the probe renders a green `pass` row carrying the control's own firing
+/// text for a run of the UNMODIFIED tree. The refusal is per MUTATION, so the shape cannot be
+/// smuggled in beside one that does name a file either.
+#[test]
+fn mutation_must_name_a_file() {
+    let text = std::fs::read_to_string(fixtures().join("dogfood.toml")).unwrap();
+    let parse = |t: &str| toml::from_str::<Manifest>(t).expect("manifest parses");
+    // positive: the shipping manifest, unedited, validates
+    manifest::validate(&parse(&text)).unwrap();
+
+    let empty = text.replace(
+        "  files  = [\"crates/probe-pin/tests/fixtures/prod.txt\"]",
+        "  files  = []",
+    );
+    assert_ne!(
+        empty, text,
+        "the fixture edit must apply, or this arm is vacuous"
+    );
+    let m = parse(&empty);
+    assert!(
+        m.probes[2].touched().is_empty() && !m.probes[2].mutations.is_empty(),
+        "the shape under test: mutations declared, no file named"
+    );
+    let e = manifest::validate(&m).unwrap_err();
+    assert!(e.to_string().contains("names no file"), "{e}");
+    assert!(e.to_string().contains("P2_pad_reaches_target"), "{e}");
+
+    // beside a real mutation: still refused, and the index names WHICH one
+    let no_file =
+        "  [[probe.mutation]]\n  kind   = \"prepend\"\n  files  = []\n  text   = \"// x\\n\"\n";
+    let mixed = text.replace(
+        "  [[probe.mutation]]\n  kind    = \"replace\"",
+        &format!("{no_file}  [[probe.mutation]]\n  kind    = \"replace\""),
+    );
+    assert_ne!(
+        mixed, text,
+        "the fixture edit must apply, or this arm is vacuous"
+    );
+    let e = manifest::validate(&parse(&mixed)).unwrap_err();
+    assert!(e.to_string().contains("mutation[0] names no file"), "{e}");
+}
+
+/// MAJOR-1's sibling, found by sweeping the same shape (a declaration that never reaches its
+/// gate): `assert_count` is evaluated against the MUTANT text inside `mutate::apply`, which the
+/// control never enters. Measured against the fixed binary before this refusal existed — a
+/// control declaring `count = 99` of a string that occurs nowhere ran green at exit 0, with the
+/// unevaluated triple pinned into the digest.
+#[test]
+fn control_may_not_declare_an_assert_count() {
+    let text = std::fs::read_to_string(fixtures().join("dogfood.toml")).unwrap();
+    let ac = "  [[probe.assert_count]]\n  file  = \"crates/probe-pin/tests/fixtures/prod.txt\"\n  text  = \"NOWHERE\"\n  count = 99\n";
+    let anchor_line = "claim = \"no mounts, unmodified tree — the instrument itself\"\n";
+    let on_control = text.replace(anchor_line, &format!("{anchor_line}{ac}"));
+    assert_ne!(
+        on_control, text,
+        "the fixture edit must apply, or this arm is vacuous"
+    );
+    let m = toml::from_str::<Manifest>(&on_control).expect("manifest parses");
+    assert!(
+        m.probes[0].mutations.is_empty() && !m.probes[0].assert_counts.is_empty(),
+        "the shape under test: the control carries an assert_count"
+    );
+    let e = manifest::validate(&m).unwrap_err();
+    assert!(
+        e.to_string().contains("assert_count(s) with no mutation"),
+        "{e}"
+    );
+    // positive: the SAME assert_count on a probe that mutates is the shipping shape (P1 already
+    // carries one), so the refusal is about the missing mutant, not about assert_count itself
+    assert!(manifest::validate(&toml::from_str::<Manifest>(&text).unwrap()).is_ok());
+}
+
+/// Driver-added. `docs/probe-pin.md`'s manifest example is the surface a first user COPIES, and
+/// it had no mechanical coverage at all — an example is code that never runs, so nothing caught
+/// that it (a) was not valid TOML (`text = "…" ; count = 1`; `;` is not a TOML separator) and
+/// (b) named `package = "engine"`, which does not exist: `crates/engine` is package
+/// `phase-engine` with `[lib] name = "engine"`, so `cargo test -p engine` fails to resolve.
+/// Both shipped. This gate is why the fixtures were clean and the doc was not: fixtures get
+/// parsed by other tests, the doc block got read by humans.
+///
+/// The example carries deliberate `…verbatim…` placeholders, so it cannot be RUN. What is
+/// mechanically checkable is checked: it parses, it validates, and its package resolves.
+#[test]
+fn docs_manifest_example_parses_validates_and_names_a_real_package() {
+    let root = Path::new(env!("CARGO_MANIFEST_DIR")).join("../..");
+    let doc = std::fs::read_to_string(root.join("docs/probe-pin.md")).expect("docs readable");
+    let block = doc
+        .split("```toml\n")
+        .nth(1)
+        .and_then(|rest| rest.split("\n```").next())
+        .expect("docs carry a fenced toml manifest example");
+    assert!(
+        block.contains("[[probe]]") && block.contains("[target]"),
+        "extracted the wrong fence, or the example lost its shape: {block:.200}"
+    );
+
+    let m: Manifest = toml::from_str(block)
+        .unwrap_or_else(|e| panic!("the docs manifest example is not valid TOML: {e}"));
+    manifest::validate(&m).expect("the docs manifest example must pass validate()");
+
+    // Every workspace member is `crates/*` (root Cargo.toml: members = ["crates/*"]), so the
+    // package set is readable without shelling to cargo — which would contend for the target
+    // lock Tilt already holds.
+    let mut names = Vec::new();
+    for entry in std::fs::read_dir(root.join("crates")).expect("crates/ readable") {
+        let toml_path = entry.expect("dir entry").path().join("Cargo.toml");
+        let Ok(text) = std::fs::read_to_string(&toml_path) else {
+            continue;
+        };
+        if let Ok(v) = toml::from_str::<toml::Value>(&text) {
+            if let Some(n) = v
+                .get("package")
+                .and_then(|p| p.get("name"))
+                .and_then(|n| n.as_str())
+            {
+                names.push(n.to_string());
+            }
+        }
+    }
+    assert!(
+        names.contains(&"phase-engine".to_string()),
+        "instrument check: the package scan must find a package it is known to contain, else a \
+         missing package would pass vacuously. found: {names:?}"
+    );
+    assert!(
+        !names.contains(&"engine".to_string()),
+        "positive control for the exact defect: `engine` is the lib TARGET name, and if a package \
+         by that name ever exists this test stops discriminating"
+    );
+    assert!(
+        names.contains(&m.target.package),
+        "the docs example names package '{}', which is not a workspace package. `cargo test -p \
+         {}` would abort for anyone copying it. found: {names:?}",
+        m.target.package,
+        m.target.package
+    );
+}
+
+/// Driver-added beyond the final review-impl finding set, after MEASURING the escape the
+/// reviewer had adjudicated as hardening: `[output].file = "../probepin-run/…"` + `run --write`
+/// exited 0 and spliced the block into a file outside the workspace root. That is not a
+/// containment nicety — `check` resolves `[output].file` against the root, so a pin written
+/// outside it is one no checkout and no CI job can re-measure.
+#[test]
+fn output_file_must_be_workspace_relative() {
+    let text = std::fs::read_to_string(fixtures().join("dogfood.toml")).unwrap();
+    for escape in [
+        "../probepin-run/escape.md",
+        "/tmp/escape.md",
+        "crates/../../escape.md",
+    ] {
+        let edited = text.replace(
+            "file   = \"crates/probe-pin/tests/fixtures/dogfood_block.md\"",
+            &format!("file   = \"{escape}\""),
+        );
+        assert_ne!(
+            edited, text,
+            "the fixture edit must apply, or this is vacuous"
+        );
+        let m = toml::from_str::<Manifest>(&edited).expect("manifest parses");
+        assert_eq!(
+            m.output.file, escape,
+            "the escaping path reached the struct"
+        );
+        let e = manifest::validate(&m).unwrap_err();
+        assert!(
+            e.to_string().contains("is not workspace-relative"),
+            "{escape} was accepted: {e}"
+        );
+    }
+    // positive: the shipping path is workspace-relative and still validates, so the refusal is
+    // about the escape and not about `[output].file` being checked at all
+    assert!(manifest::validate(&toml::from_str::<Manifest>(&text).unwrap()).is_ok());
+}
+
+/// Final review-impl, MINOR-5: `timeout_secs = 0` disables the guard instead of tightening it.
+/// The shell behaviour is MEASURED here, not argued — it is the whole reason for the refusal.
+#[test]
+fn timeout_zero_is_refused() {
+    let rc = |secs: &str, sleep: &str| {
+        Command::new("timeout")
+            .args(["-k", "5", secs, "sleep", sleep])
+            .status()
+            .unwrap()
+            .code()
+            .unwrap()
+    };
+    assert_eq!(
+        rc("0", "0.2"),
+        0,
+        "`timeout 0` runs the child to completion"
+    );
+    assert_eq!(rc("1", "5"), 124, "a positive timeout fires");
+
+    let text = std::fs::read_to_string(fixtures().join("dogfood.toml")).unwrap();
+    let zero = text.replace("timeout_secs = 60", "timeout_secs = 0");
+    assert_ne!(
+        zero, text,
+        "the fixture edit must apply, or this arm is vacuous"
+    );
+    let m = toml::from_str::<Manifest>(&zero).expect("manifest parses");
+    assert_eq!(m.target.timeout_secs, 0);
+    let e = manifest::validate(&m).unwrap_err();
+    assert!(e.to_string().contains("disables `timeout`"), "{e}");
+    // positive: the shipping value validates
+    assert!(manifest::validate(&toml::from_str::<Manifest>(&text).unwrap()).is_ok());
 }
 
 // ------------------------------------------------------------------ row 19
@@ -1177,6 +1388,75 @@ fn write_refusal() {
     );
 }
 
+/// Row 29's escape (final review-impl, MAJOR-3): a projection sentence is free-form manifest
+/// text rendered into the same line-space as the `instrument` lines, so classifying by TEXT
+/// PREFIX let a sentence beginning `instrument ` be read as an instrument line — excluded from
+/// the "a measured number moved" comparison, which silently disabled the write refusal and made
+/// `check` print "Measured numbers are unchanged" about a number that had moved 3 -> 6.
+///
+/// The two arms differ by ONE CHARACTER (`instrument` vs `Instrument`), and both blocks come
+/// out of the real `render`, so classification is pinned where it is produced.
+#[test]
+fn projection_sentence_may_start_with_the_word_instrument() {
+    let outcomes = vec![Outcome {
+        id: "P0_control".to_string(),
+        rc: 0,
+        verdict: Verdict::Pass { mounts_reached: 0 },
+    }];
+    let render = |head: &str, ag: &str, count: usize| {
+        let mut m = load("projection.toml");
+        m.projections[0].sentence = format!("{head} sites counted: {{count}}");
+        let counts = vec![ProjectionCount {
+            id: m.projections[0].id.clone(),
+            count,
+        }];
+        block::render(
+            &m,
+            "m.toml",
+            "0123456789abcdef",
+            &[
+                (Instrument::Toolchain, "rustc 1.97.0".to_string()),
+                (Instrument::AstGrep, ag.to_string()),
+            ],
+            &outcomes,
+            &counts,
+        )
+    };
+
+    for head in ["instrument", "Instrument"] {
+        let committed = render(head, "ast-grep 0.44.1", 3);
+        let generated = render(head, "ast-grep 0.45.0", 6);
+        // reach guard: the sentence really is rendered, and the number really did move
+        assert!(
+            committed.contains(&format!("// {head} sites counted: 3")),
+            "{committed}"
+        );
+        assert!(
+            generated.contains(&format!("// {head} sites counted: 6")),
+            "{generated}"
+        );
+
+        let outcome = block::check(&committed, &generated);
+        assert!(
+            block::write_refusal(&outcome, &committed, &generated).is_some(),
+            "a sentence starting {head:?} must not disable the write refusal"
+        );
+        assert!(
+            block::report(&outcome, "m.toml").contains("cannot be attributed"),
+            "a sentence starting {head:?} must not make `check` claim the numbers held still"
+        );
+    }
+
+    // the layout the classification rests on: BEGIN, then the instrument lines CONTIGUOUSLY,
+    // and the projection sentence outside that run however it is spelled.
+    let block = render("instrument", "ast-grep 0.44.1", 3);
+    let lines: Vec<&str> = block.lines().collect();
+    assert!(lines[0].contains(":BEGIN manifest="), "{:?}", lines[0]);
+    assert!(lines[1].starts_with("// instrument rustc = "));
+    assert!(lines[2].starts_with("// instrument ast-grep = "));
+    assert!(!lines[3].starts_with("// instrument "), "{:?}", lines[3]);
+}
+
 // ------------------------------------------------------------------ rows 26, 30
 
 /// Row 26: fail-closed on a missing projection tool — probe-pin will not emit a block whose
@@ -1297,6 +1577,31 @@ fn exit_codes() {
             numbers_moved: false
         }),
         1
+    );
+}
+
+/// Final review-impl, MINOR-6: the manifest path reaches the digest AND the BEGIN line, so an
+/// absolute one stamps a machine-specific path into a committed artifact — the opposite of the
+/// reproducibility the digest exists to provide, and the one manifest path key that was not
+/// validated workspace-relative. The refusal lands at §7 step 2, so this arm costs zero target
+/// runs; before it existed the same invocation ran the whole pipeline and stamped `/tmp/…`.
+#[test]
+fn manifest_outside_the_workspace_is_refused() {
+    let outside = tempfile::tempdir().unwrap();
+    let path = outside.path().join("dogfood.toml");
+    std::fs::copy(fixtures().join("dogfood.toml"), &path).unwrap();
+    let out = Command::new(env!("CARGO_BIN_EXE_probe-pin"))
+        .args(["check", path.to_str().unwrap()])
+        .output()
+        .unwrap();
+    let err = String::from_utf8_lossy(&out.stderr).into_owned();
+    assert_eq!(out.status.code(), Some(2), "{err}");
+    assert!(err.contains("is not inside the workspace root"), "{err}");
+    // and the absolute path never reached a rendered block
+    assert!(
+        !String::from_utf8_lossy(&out.stdout).contains(":BEGIN manifest=/"),
+        "{}",
+        String::from_utf8_lossy(&out.stdout)
     );
 }
 

--- a/crates/probe-pin/tests/pure_logic.rs
+++ b/crates/probe-pin/tests/pure_logic.rs
@@ -274,6 +274,67 @@ fn harness() {
     assert!(verdict::observe("P1", &run, &target(), &[]).is_ok());
 }
 
+/// Row 8's neighbour, and the classification it was swallowing. The isolation script resolves
+/// `mount`, `cmp` and `timeout` through `PATH` under `set -eu` — and a shell that dies before
+/// `exec` produces EMPTY stdout with a non-zero code, which is byte-for-byte the shape of a
+/// target that died before its first record. Measured on the shipping script with `timeout` off
+/// `PATH`: exit 127, `probe-pin: line 10: exec: timeout: not found` on stderr, no reserved code
+/// fired, and the abort raised was `HarnessIncomplete { SuiteStarted }` — whose message tells
+/// the operator to raise `RUST_MIN_STACK` through `[target].env`, which cannot make `timeout`
+/// exist. The script now names the cause with reserved code 96.
+///
+/// The real script raising 96 is `isolation_e2e::script_failure_is_named_not_inferred`; this is
+/// the classification half, where the DROP arm (the reserved code absent, i.e. exactly the
+/// measurement above) is a literal `Run`.
+#[test]
+fn script_failure_is_named_not_inferred() {
+    let t = target();
+    let script_failed = Run {
+        rc: 96,
+        stdout: String::new(),
+        stderr: "probe-pin: ISOLATION SCRIPT FAILED before the target ran".to_string(),
+    };
+    let e = verdict::observe("P1", &script_failed, &t, &[]).unwrap_err();
+    assert!(
+        matches!(e, Abort::IsolationScriptFailed { rc: 96, .. }),
+        "{e}"
+    );
+    assert!(e.to_string().contains("PATH"), "{e}");
+    assert!(
+        !e.to_string().contains("RUST_MIN_STACK"),
+        "the remedy must not name a stack size: {e}"
+    );
+
+    // DROP — the same failure WITHOUT the reserved code, which is what was measured before it
+    // existed. It classifies as the harness dying mid-run, and names the wrong remedy.
+    let unreserved = Run {
+        rc: 127,
+        stdout: String::new(),
+        stderr: "probe-pin: line 10: exec: timeout: not found".to_string(),
+    };
+    let e = verdict::observe("P1", &unreserved, &t, &[]).unwrap_err();
+    assert!(
+        matches!(
+            e,
+            Abort::HarnessIncomplete {
+                missing: HarnessMarker::SuiteStarted,
+                ..
+            }
+        ),
+        "{e}"
+    );
+    assert!(e.to_string().contains("RUST_MIN_STACK"), "{e}");
+
+    // and 96 is trusted only with EMPTY stdout, exactly like 97: a target that emitted records
+    // reached `exec`, so the code is the target's own
+    let with_records = Run {
+        rc: 96,
+        stdout: stream(1, &[], "ok"),
+        stderr: String::new(),
+    };
+    assert!(verdict::observe("P1", &with_records, &t, &[]).is_ok());
+}
+
 // ------------------------------------------------------------------ row 9
 
 /// Row 9: no anchor may embed a source line number. Measured on the real corpus: 0 of 10
@@ -821,6 +882,51 @@ fn target_resolve_pins_cargo_to_the_workspace_root() {
     );
 }
 
+/// The workspace root is CANONICAL at its one producer, because every consumer compares it
+/// against a path that has been: `main`'s `manifest_rel` strips it from
+/// `manifest_path.canonicalize()`, `resolve_contained` canonicalizes `base`, `scratch_dir`
+/// canonicalizes both sides. A non-canonical root turns each of those realpath assertions back
+/// into a lexical string comparison — the shape this crate has already repaired twice.
+///
+/// DISCLOSURE, measured: no input reaching `cargo locate-project --workspace` produces a
+/// non-canonical root today. Cargo starts from `getcwd`, which the kernel answers physically,
+/// so a workspace reached through a symlink still prints the resolved path (measured: run
+/// through `/tmp/<link> -> the worktree`, exit 0, every row rendered). Arm 2 is therefore the
+/// GUARD's shape measured on a synthetic pair, not a live escape — a found hole is a lower
+/// bound, and this one is "not reached today", not "cannot be reached".
+#[test]
+fn workspace_root_is_canonical() {
+    let root = target::workspace_root().expect("workspace root");
+    assert_eq!(
+        root,
+        root.canonicalize().expect("the root resolves"),
+        "workspace_root must return a canonical path"
+    );
+
+    // arm 2 — the shape: a non-canonical base fails the prefix comparison that IS satisfied
+    let base = tempfile::tempdir().unwrap();
+    let real = base.path().join("real");
+    std::fs::create_dir_all(real.join("crates")).unwrap();
+    std::fs::write(real.join("crates/m.toml"), "version = 1\n").unwrap();
+    let link = base.path().join("link");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    let manifest_real = link.join("crates/m.toml").canonicalize().unwrap();
+    assert!(
+        manifest_real.strip_prefix(&link).is_err(),
+        "the phenomenon: a canonicalized manifest path does not start with a symlinked root, so \
+         the guard would report 'manifest is not inside the workspace root' for one that is"
+    );
+    assert!(
+        manifest_real
+            .strip_prefix(link.canonicalize().unwrap())
+            .is_ok(),
+        "and canonicalizing the root is what makes the comparison realpath-to-realpath"
+    );
+    // and the same rule already governs the other containment assertion, from the same base
+    assert!(manifest::resolve_contained(&link, "crates/m.toml").is_ok());
+}
+
 /// The Tier-2 suite is `#[ignore]`d because GitHub's runners deny unprivileged user namespaces,
 /// so GH CI never executes a real mount. That is a measured accommodation, and an accommodation
 /// with nothing watching it decays: a Tier-2 test added without the attribute turns CI red for a
@@ -857,7 +963,7 @@ fn tier2_suite_is_uniformly_ignored_with_the_measured_reason() {
         .collect();
     assert_eq!(
         tests.len(),
-        15,
+        17,
         "the Tier-2 suite changed size. Every test here needs the #[ignore] attribute (CI cannot \
          create a mount namespace); update this count deliberately, and keep the Tilt \
          `probe-pin-e2e` resource as the venue that actually runs them."
@@ -1738,6 +1844,64 @@ fn manifest_outside_the_workspace_is_refused() {
     );
 }
 
+/// The same comparison, from the other side: the refusal above must fire for a manifest that IS
+/// outside the root, and must NOT fire for one that is inside it by a path whose components
+/// include a symlink. `strip_prefix` between a canonicalized manifest path and an unresolved
+/// root is a lexical comparison wearing a realpath's clothes, and its failure mode is a refusal
+/// no manifest edit can satisfy.
+///
+/// DISCLOSURE: not reached through cargo today — `cargo locate-project --workspace` starts from
+/// `getcwd`, which the kernel answers physically, so the root it prints is already resolved
+/// (measured: a run through `/tmp/<link> -> the worktree` exited 0 with every row rendered).
+/// `target::workspace_root` canonicalizes at the producer anyway, and this is that rule stated
+/// where a test can drive it: arm 1 below is the escaping pair, and it is refused by the shape
+/// this replaced.
+#[test]
+fn manifest_rel_compares_realpaths() {
+    let base = tempfile::tempdir().unwrap();
+    let real = base.path().join("real");
+    std::fs::create_dir_all(real.join("crates")).unwrap();
+    std::fs::write(real.join("crates/m.toml"), "version = 1\n").unwrap();
+    let link = base.path().join("link");
+    std::os::unix::fs::symlink(&real, &link).unwrap();
+
+    // arm 1 — the phenomenon: a canonicalized manifest path shares no prefix with a root
+    // reached through a symlink, so the lexical comparison rejects a manifest that is inside it
+    assert!(
+        link.join("crates/m.toml")
+            .canonicalize()
+            .unwrap()
+            .strip_prefix(&link)
+            .is_err(),
+        "the escaping pair must be lexically unrelated, or this arm is vacuous"
+    );
+    // the guard canonicalizes BOTH sides, so the same pair resolves — through the symlink and
+    // through the real path alike
+    assert_eq!(
+        manifest::workspace_relative(&link.join("crates/m.toml"), &link).unwrap(),
+        "crates/m.toml"
+    );
+    assert_eq!(
+        manifest::workspace_relative(&real.join("crates/m.toml"), &real).unwrap(),
+        "crates/m.toml"
+    );
+
+    // and a manifest that really is outside the root is still refused, by name
+    let outside = base.path().join("outside.toml");
+    std::fs::write(&outside, "version = 1\n").unwrap();
+    let e = manifest::workspace_relative(&outside, &link).unwrap_err();
+    assert!(
+        e.to_string().contains("is not inside the workspace root"),
+        "{e}"
+    );
+    // as is one that does not exist at all: `canonicalize` is the existence check too
+    let e = manifest::workspace_relative(&real.join("crates/gone.toml"), &real).unwrap_err();
+    assert!(
+        e.to_string().contains("is not inside the workspace root"),
+        "{e}"
+    );
+}
+
 // ------------------------------------- §8 message fidelity on the two sentinel-free paths
 
 /// §8's texts are the contract, and each of these rows promised a value the run never measured
@@ -2016,6 +2180,20 @@ fn argv_surface_is_one_authority() {
             "{token} is on the argv and is neither probe-pin's nor the manifest's"
         );
     }
+    // arm 4 — the ownership allowlist and the argv builder are ONE list: `--exact` is the
+    // conditional head, `UNCONDITIONAL_FLAGS` is the tail `argv` emits verbatim. Respelling the
+    // tail inline (as it was) lets a flag reach libtest that the allowlist does not name.
+    assert_eq!(isolate::OWNED_FLAGS[0], "--exact");
+    assert_eq!(isolate::UNCONDITIONAL_FLAGS, &isolate::OWNED_FLAGS[1..]);
+    let emitted: Vec<&str> = argv
+        .iter()
+        .map(String::as_str)
+        .filter(|a| isolate::UNCONDITIONAL_FLAGS.contains(a))
+        .collect();
+    assert_eq!(emitted, isolate::UNCONDITIONAL_FLAGS);
+    // and the conditional one is still conditional
+    t.filter_match = manifest::FilterMatch::Substring;
+    assert!(!isolate::argv(&t).contains(&"--exact".to_string()));
 }
 
 // ------------------------------------------------------------------ surface 2: env
@@ -2261,6 +2439,373 @@ fn anchor_surface_refuses_a_blank_anchor() {
     assert!(e.to_string().contains("empty anchor list"), "{e}");
     // positive: the shipping anchors validate
     assert!(manifest::validate(&load("dogfood.toml")).is_ok());
+}
+
+// ------------------------------------------------- surface 5: the text the block is made of
+
+/// Replace every string LEAF of a serialized manifest with a unique sentinel, so the census
+/// below measures the struct's real string surface instead of a hand-kept list. The four keys
+/// skipped are serde's enum TAGS (`mode`, `filter_match`, `kind`, `outcome`) — sentinelling one
+/// makes the value fail to deserialize, which is what the round-trip `expect` reports.
+fn sentinel_strings(v: &mut serde_json::Value, key: &str, out: &mut Vec<String>) {
+    const TAG_KEYS: &[&str] = &["mode", "filter_match", "kind", "outcome"];
+    match v {
+        serde_json::Value::String(s) if !TAG_KEYS.contains(&key) => {
+            *s = format!("PPSENT{:03}_{key}", out.len());
+            out.push(s.clone());
+        }
+        serde_json::Value::Array(items) => {
+            for item in items {
+                sentinel_strings(item, key, out);
+            }
+        }
+        serde_json::Value::Object(map) => {
+            for (k, value) in map.iter_mut() {
+                let k = k.clone();
+                sentinel_strings(value, &k, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// The BLOCK-TEXT surface, with a CENSUS of its producers.
+///
+/// The block is a line-oriented, marker-delimited artifact — `block::locate` counts
+/// `<marker>:BEGIN`/`<marker>:END` per LINE — and `cell()` escapes only `|`. Measured on the
+/// shipping binary: `anchor = ["PROBE-PIN:END"]` rendered into the firing-assertion cell,
+/// `run --write` exited 0, and the spliced file then carried TWO END markers, after which every
+/// `check` aborts `MarkerNotUnique` (found 1/2). The pin could only be recovered by hand.
+///
+/// Arm 1 is the census and the reason this is a SURFACE and not four field checks: it
+/// sentinels every string in the manifest through serde, renders a block, and asserts that the
+/// set of sentinels that REACH the block is exactly the set `rendered_block_values` enumerates.
+/// A future field that starts rendering is either in the enumeration or fails this test —
+/// which is the property the argv surface got after `[target].filter` was found reaching
+/// libtest with only `[target].args` validated.
+#[test]
+fn block_text_surface_is_one_authority() {
+    // ---- arm 1: the census
+    let mut m = load("dogfood.toml");
+    m.projections = load("projection.toml").projections;
+    let mut json = serde_json::to_value(&m).expect("manifest serializes");
+    let mut sentinels: Vec<String> = Vec::new();
+    sentinel_strings(&mut json, "", &mut sentinels);
+    let m: Manifest = serde_json::from_value(json).expect(
+        "the sentinelled manifest must round-trip. If this failed, a new serde enum TAG field \
+         exists and must be added to TAG_KEYS in sentinel_strings",
+    );
+    assert!(
+        sentinels.len() > 12,
+        "instrument check: the walk must find the manifest's strings, found {}",
+        sentinels.len()
+    );
+    // `manifest_rel` is not a manifest value, but it is a caller string stamped on the BEGIN
+    // line, so it belongs to this surface and carries a sentinel like everything else.
+    let manifest_rel = "PPSENT999_manifest_rel";
+    let outcomes: Vec<Outcome> = m
+        .probes
+        .iter()
+        .map(|p| Outcome {
+            id: p.id.clone(),
+            rc: 101,
+            verdict: match &p.expect {
+                probe_pin::manifest::Expect::Pass {} => Verdict::Pass { mounts_reached: 1 },
+                // a Fail verdict is what renders the anchors; without one they are off-surface
+                probe_pin::manifest::Expect::Fail { .. } => Verdict::Fail {
+                    provenance: Vec::new(),
+                },
+            },
+        })
+        .collect();
+    let counts: Vec<ProjectionCount> = m
+        .projections
+        .iter()
+        .map(|p| ProjectionCount {
+            id: p.id.clone(),
+            count: 3,
+        })
+        .collect();
+    let rendered = block::render(&m, manifest_rel, "d1g357", &[], &outcomes, &counts);
+
+    let appearing: Vec<&str> = sentinels
+        .iter()
+        .map(String::as_str)
+        .chain(std::iter::once(manifest_rel))
+        .filter(|s| rendered.contains(*s))
+        .collect();
+    let mut covered: Vec<&str> = manifest::rendered_block_values(&m, manifest_rel)
+        .into_iter()
+        .map(|(_, value)| value)
+        .collect();
+    covered.sort_unstable();
+    covered.dedup();
+    let mut appearing_sorted = appearing.clone();
+    appearing_sorted.sort_unstable();
+    assert_eq!(
+        appearing_sorted, covered,
+        "the block-text census moved. Every manifest string that reaches the rendered block \
+         must be in `manifest::rendered_block_values`, which is what `validate_block_text` \
+         refuses control characters and marker tags in. rendered:\n{rendered}"
+    );
+    // instrument check: the census must be able to see a value that is NOT rendered, or a
+    // pass proves nothing about the enumeration's tightness
+    assert!(
+        sentinels.len() > appearing.len(),
+        "instrument check: some manifest strings ([target].package, [output].file, claim, \
+         assert_count.file) are NOT rendered; if all of them appear, this census cannot fail"
+    );
+
+    // ---- arm 2: every producer on the surface refuses the same hostile shapes
+    let mut base = load("dogfood.toml");
+    base.projections = load("projection.toml").projections;
+    let rel = "crates/probe-pin/tests/fixtures/dogfood.toml";
+    manifest::validate_block_text(&base, rel).expect("the shipping manifests render a safe block");
+
+    for hostile in [
+        "PROBE-PIN:END",
+        "PROBE-PIN:BEGIN",
+        "two\nlines",
+        "nul\0byte",
+    ] {
+        let mut m = base.clone();
+        m.probes[1].expect = probe_pin::manifest::Expect::Fail {
+            anchor: vec![hostile.to_string()],
+        };
+        let e = manifest::validate_block_text(&m, rel).expect_err(&format!(
+            "the anchor {hostile:?} was ACCEPTED into the block"
+        ));
+        assert!(e.to_string().contains("anchor"), "anchor {hostile:?}: {e}");
+
+        let mut m = base.clone();
+        m.projections[0].sentence = format!("{hostile} {{count}}");
+        let e = manifest::validate_block_text(&m, rel).expect_err(&format!(
+            "the sentence {hostile:?} was ACCEPTED into the block"
+        ));
+        assert!(
+            e.to_string().contains("sentence"),
+            "sentence {hostile:?}: {e}"
+        );
+
+        let mut m = base.clone();
+        m.probes[1].mutations = vec![probe_pin::manifest::Mutation::Replace {
+            file: format!("crates/{hostile}/x.rs"),
+            find: "a".into(),
+            replace: "b".into(),
+        }];
+        let e = manifest::validate_block_text(&m, rel).expect_err(&format!(
+            "the mutation path {hostile:?} was ACCEPTED into the block"
+        ));
+        assert!(
+            e.to_string().contains("mutation file"),
+            "mutation file {hostile:?}: {e}"
+        );
+
+        let e = manifest::validate_block_text(&base, &format!("crates/{hostile}/m.toml"))
+            .expect_err(&format!(
+                "the manifest path {hostile:?} was ACCEPTED into the block"
+            ));
+        assert!(
+            e.to_string().contains("the manifest path"),
+            "manifest path {hostile:?}: {e}"
+        );
+    }
+
+    // ---- arm 3: the marker itself, which is the structure the rest is checked against
+    for hostile in ["", " ", "\t", "PROBE PIN", "PROBE-PIN:END"] {
+        let mut m = base.clone();
+        m.output.marker = hostile.to_string();
+        let e = manifest::validate_block_text(&m, rel).expect_err(&format!(
+            "the marker {hostile:?} was ACCEPTED as the block's tag"
+        ));
+        assert!(
+            e.to_string().contains("is not a plain name"),
+            "marker {hostile:?} was accepted: {e}"
+        );
+    }
+    // positive: the shipping marker, and an ordinary alternative one, both validate
+    for benign in ["PROBE-PIN", "PIN_2"] {
+        let mut m = base.clone();
+        m.output.marker = benign.to_string();
+        assert!(
+            manifest::validate_block_text(&m, rel).is_ok(),
+            "{benign} was refused"
+        );
+    }
+    // positive: a real anchor with punctuation, quotes and a colon still validates — the
+    // refusal is about control characters and the marker, not about anchor text being rich
+    let mut m = base.clone();
+    m.probes[1].expect = probe_pin::manifest::Expect::Fail {
+        anchor: vec!["CENSUS VIOLATED: expected 2 sites, got 1".into()],
+    };
+    assert!(manifest::validate_block_text(&m, rel).is_ok());
+}
+
+/// The `[[projection]]` producer checks. A projection is a block-row producer exactly like a
+/// probe, and it had only its path keys checked. All three refusals below were measured on the
+/// shipping binary rendering a block at exit 0.
+#[test]
+fn projection_surface_gets_the_producer_checks_its_siblings_get() {
+    let base = load("projection.toml");
+    manifest::validate(&base).expect("the shipping projection fixture validates");
+
+    // duplicate id: counts are looked up BY ID, so the second sentence renders the first
+    // projection's number (measured: a 1-match pattern rendered as "7 sites")
+    let mut m = base.clone();
+    let mut twin = base.projections[0].clone();
+    twin.pattern = "Abort::$V".into();
+    twin.sentence = "`Abort` is named at {count} sites.".into();
+    m.projections.push(twin);
+    let e = manifest::validate(&m).expect_err("a duplicate projection id was ACCEPTED");
+    assert!(e.to_string().contains("duplicate"), "{e}");
+    assert!(e.to_string().contains("instrument_sites"), "{e}");
+    // the phenomenon itself, so the refusal is not merely stylistic: with two ids equal, the
+    // render of the SECOND projection carries the FIRST one's count
+    let counts = vec![ProjectionCount {
+        id: "instrument_sites".into(),
+        count: 7,
+    }];
+    let rendered = block::render(&m, "m.toml", "d", &[], &[], &counts);
+    assert_eq!(
+        rendered.matches("at 7 sites").count(),
+        2,
+        "the duplicate id must render the same number twice:\n{rendered}"
+    );
+
+    // a non-plain id, exactly as a probe id is refused
+    let mut m = base.clone();
+    m.projections[0].id = "no placeholder".into();
+    let e = manifest::validate(&m).expect_err("a non-plain projection id was ACCEPTED");
+    assert!(e.to_string().contains("is not a plain name"), "{e}");
+
+    // an empty path list: ast-grep with no operand scans the whole cwd, so the rendered number
+    // is a measurement of a tree the manifest never named (measured: 15 against the meant 7)
+    let mut m = base.clone();
+    m.projections[0].paths = Vec::new();
+    let e = manifest::validate(&m).expect_err("an empty projection path list was ACCEPTED");
+    assert!(e.to_string().contains("names no path"), "{e}");
+
+    // a sentence with no substitution point renders a complete-looking claim with no number
+    let mut m = base.clone();
+    m.projections[0].sentence = "`Instrument` is named at every site that needs one.".into();
+    let e = manifest::validate(&m)
+        .expect_err("a sentence with no {count} placeholder was ACCEPTED into the block");
+    assert!(e.to_string().contains("{count}"), "{e}");
+    assert_eq!(
+        project::sentence(&m.projections[0], 7),
+        "`Instrument` is named at every site that needs one.",
+        "the phenomenon: the count is substituted nowhere, and the sentence still renders"
+    );
+
+    // positive: the shipping projection, and one with the placeholder anywhere in the sentence
+    let mut m = base.clone();
+    m.projections[0].sentence = "{count} sites name `Instrument`.".into();
+    assert!(manifest::validate(&m).is_ok());
+}
+
+/// The mutant's SIZE is a manifest-controlled product, and `Prepend` is the only unbounded one.
+/// Measured on the shipping binary: `repeat = 4294967295` of a 14-byte pad asked for
+/// 60,129,542,130 bytes, and an allocation failure is not a catchable panic — probe-pin died
+/// with SIGABRT (exit 134, core dumped), outside its documented 0/1/2/101 exit contract and
+/// after a full control run had already been spent.
+#[test]
+fn prepend_pad_is_bounded() {
+    let mut m = load("dogfood.toml");
+    let probe_pin::manifest::Mutation::Prepend { text, repeat, .. } = &mut m.probes[2].mutations[0]
+    else {
+        panic!("dogfood.toml's P2 is the Prepend probe; the fixture moved");
+    };
+    assert_eq!(text.len(), 14, "the shipping pad is 14 bytes");
+    *repeat = u32::MAX;
+    let e = manifest::validate(&m)
+        .expect_err("a 60 GB pad was ACCEPTED — the run dies with SIGABRT, not a refusal");
+    assert!(e.to_string().contains("60129542130 bytes"), "{e}");
+    assert!(e.to_string().contains("P2_pad_reaches_target"), "{e}");
+
+    // the boundary, from both sides, on the exact cap
+    let cap = probe_pin::manifest::MAX_PREPEND_BYTES;
+    let probe_pin::manifest::Mutation::Prepend { text, repeat, .. } = &mut m.probes[2].mutations[0]
+    else {
+        unreachable!()
+    };
+    *text = "x".to_string();
+    *repeat = cap as u32;
+    assert!(
+        manifest::validate(&m).is_ok(),
+        "the cap itself must be allowed"
+    );
+    let probe_pin::manifest::Mutation::Prepend { repeat, .. } = &mut m.probes[2].mutations[0]
+    else {
+        unreachable!()
+    };
+    *repeat = cap as u32 + 1;
+    assert!(manifest::validate(&m).is_err(), "one byte over must refuse");
+
+    // positive: the shipping 200 × 14 B pad is four orders of magnitude under the cap
+    assert!(manifest::validate(&load("dogfood.toml")).is_ok());
+}
+
+/// Fixture manifests may not name a COMMITTED block file. `projection.toml` is driven with
+/// `run --write`, and measured on the shipping binary with ast-grep installed it exited 0 and
+/// replaced the committed dogfood block — the one `dogfood.toml`, `isolation_e2e::dogfood_check`
+/// and the Tilt `probe-pin-check` resource all validate — with a projection block of its own.
+///
+/// Written as a census over the whole fixture directory rather than as an edit to the two
+/// manifests that had the property: the risk belongs to "a fixture the binary is DRIVEN on",
+/// not to those two files, and a new fixture gets the rule for free. The census found two more
+/// than the review named — and it also found the honest exception: `p7.toml`/`p8.toml` are
+/// archived corpus manifests, verbatim in shape (`schema_adequacy`), parsed and validated but
+/// never handed to the binary, so what they name is an artifact of the archive.
+#[test]
+fn a_driven_fixture_never_names_a_committed_block() {
+    const TMP: &str = "crates/probe-pin/tests/fixtures/tmp/";
+    // The one file that runs the binary: `probe_pin_bin` is defined there and nowhere else, so
+    // "named in it" IS "driven through the real pipeline".
+    let e2e = std::fs::read_to_string(
+        Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/isolation_e2e.rs"),
+    )
+    .expect("the Tier-2 suite is readable");
+    assert_eq!(
+        e2e.matches("fn probe_pin_bin(").count(),
+        1,
+        "instrument check: the binary is driven from exactly one helper, in this file. If it \
+         moved, this census is reading the wrong source."
+    );
+
+    let (mut checked, mut driven) = (0, 0);
+    for entry in std::fs::read_dir(fixtures()).expect("fixtures/ readable") {
+        let path = entry.expect("dir entry").path();
+        if path.extension().and_then(|e| e.to_str()) != Some("toml") {
+            continue;
+        }
+        let name = path.file_name().unwrap().to_string_lossy().to_string();
+        let m = Manifest::load(&path).unwrap_or_else(|e| panic!("{name}: {e}"));
+        checked += 1;
+        if !e2e.contains(&name) {
+            continue; // archived corpus: parsed and validated, never run
+        }
+        driven += 1;
+        if name == "dogfood.toml" {
+            assert_eq!(
+                m.output.file, "crates/probe-pin/tests/fixtures/dogfood_block.md",
+                "the dogfood manifest is the one that owns the committed block"
+            );
+        } else {
+            assert!(
+                m.output.file.starts_with(TMP),
+                "{name} is driven through the real binary and names [output].file = {:?}, which \
+                 is not under the gitignored {TMP}. Measured: `run --write` on projection.toml \
+                 exited 0 and replaced the committed dogfood block. Where a manifest happens to \
+                 abort is not protection — it moves.",
+                m.output.file
+            );
+        }
+    }
+    assert!(
+        checked >= 8 && driven >= 5,
+        "instrument check: {checked} fixture manifests, {driven} driven. If nothing is driven, \
+         this census cannot fail."
+    );
 }
 
 // ------------------------------------------------------- assert_count says what it measured

--- a/docs/probe-pin.md
+++ b/docs/probe-pin.md
@@ -27,6 +27,9 @@ cargo probe-pin run --write  <manifest>   # ... and splice it into [output].file
 cargo probe-pin check        <manifest>   # ... and compare it against the committed block
 ```
 
+`<manifest>` must live **inside the workspace**: its path is stamped into the BEGIN line and
+into the digest, so an absolute one would pin a block no other checkout can reproduce.
+
 `check` costs the **same target runs as `run`** — it is a re-measurement, not a text
 comparison. Exit codes:
 
@@ -48,13 +51,16 @@ version = 1                                  # unknown value -> refuse
 
 [target]
 mode         = "runtime-read"                # "compiled" parses and is REJECTED (see below)
-package      = "engine"                      # cargo -p     — binary RESOLUTION only
+package      = "phase-engine"                # cargo -p     — binary RESOLUTION only.
+                                             # The PACKAGE name, which is not the lib TARGET name:
+                                             # crates/engine is package `phase-engine`, [lib] `engine`,
+                                             # and `-p engine` fails to resolve.
 test         = "integration"                 # cargo --test
 filter       = "loop_shortcut_seat_pin_census"
 filter_match = "substring"                   # or "exact" -> probe-pin appends --exact
 args         = []                            # appended LAST to the argv; reserved flags refused
 env          = { RUST_MIN_STACK = "16777216" }   # DEFAULT, not empty
-timeout_secs = 300                           # exceeded -> killed, and named
+timeout_secs = 300                           # exceeded -> killed, and named; 0 is REFUSED
 
 [output]
 file   = "crates/engine/tests/integration/loop_shortcut_seat_pin_census.rs"
@@ -71,12 +77,14 @@ claim = "no mounts, unmodified tree — the instrument itself"
 id = "P1_revert_interaction"
   [[probe.mutation]]                         # 0..N, APPLIED IN ORDER
   kind = "replace"                           # or "prepend" { files, text, repeat }
+                                             # every mutation must name >= 1 file
   file = "crates/engine/src/game/interaction.rs"
   find = "…verbatim…"                        # must match EXACTLY once, in the RUNNING text
   replace = ""                               # may be ""; the MATERIALIZED file must differ
   [[probe.assert_count]]                     # checked on the FINAL mutant text
   file = "crates/engine/src/game/interaction.rs"
-  text = "TargetPin::Player" ; count = 1
+  text = "TargetPin::Player"
+  count = 1
   [probe.expect]
   outcome = "fail"
   anchor  = ["PROVENANCE SPLIT VIOLATED", "text: \"Ok(TargetPin::Player(*player))\""]
@@ -128,9 +136,11 @@ writing your tree. It does not stop the *target* from writing anywhere it likes,
 gitignored `target/`. probe-pin's guarantees are about probe-pin, not about your test.
 
 **`env_clear()` is scoped to the target run only (MAJOR-3).** The target child's environment is
-constructed — `PATH`, `HOME`, `RUST_BACKTRACE=0`, `RUST_MIN_STACK` (default `16777216`,
-overridable), then `[target].env` — so two developers with different shells pin the same capture
-bytes. The `cargo`, `rustc` and `ast-grep` shell-outs **inherit** the ambient environment
+constructed — `PATH`, `HOME`, `RUST_MIN_STACK` (default `16777216`, overridable), then
+`[target].env` — so two developers with different shells pin the same capture bytes.
+`RUST_BACKTRACE` is deliberately **not** re-set: an unconditional set produces identical capture
+bytes whether or not the clear ran, which is how row 12's backtrace arm went vacuous. Absent from
+a cleared environment libtest reads it as off, and `[target].env` can still turn it on. The `cargo`, `rustc` and `ast-grep` shell-outs **inherit** the ambient environment
 unmodified: clearing them would strip `CARGO_HOME`/`CARGO_TARGET_DIR` and silently resolve
 against the shared `~/.cargo` instead of a per-worktree home.
 

--- a/docs/probe-pin.md
+++ b/docs/probe-pin.md
@@ -1,0 +1,241 @@
+# probe-pin
+
+probe-pin turns a *probe* — a mutation of the tree plus an expectation about a test's outcome —
+into a regenerable, digest-stamped block of comments in source. The block is the artifact a
+reviewer reads; the manifest is the thing that regenerates it; the digest is what makes a stale
+block loud instead of decorative.
+
+The tool exists to enforce exactly two invariants:
+
+1. **probe-pin never writes the tree it measures.** Mutants are materialized in a scratch
+   directory outside the workspace and bind-mounted over the real path inside an unprivileged
+   mount namespace. Every mutated file is sha256'd before and after the run. That scratch
+   directory is asserted to be outside the workspace — and, since a mutant lands at
+   `<scratch>/<probe.id>/<file>`, the two joined KEYS are validated too: an id must be a plain
+   name (`[A-Za-z0-9_-]`), and every manifest path must be workspace-relative with no `..`
+   component. A container assert cannot see a key that joins its way back out of the container.
+2. **No verdict is reported for a run that measured nothing.** A control that selected zero
+   tests is an instrument failure, not a pass.
+
+Everything else in this document is a bound on what a row in the block actually proves.
+
+## Usage
+
+```bash
+cargo probe-pin run          <manifest>   # run every probe, print the block
+cargo probe-pin run --write  <manifest>   # ... and splice it into [output].file
+cargo probe-pin check        <manifest>   # ... and compare it against the committed block
+```
+
+`check` costs the **same target runs as `run`** — it is a re-measurement, not a text
+comparison. Exit codes:
+
+| exit | meaning |
+|---|---|
+| 0 | ok / the committed block matches |
+| 1 | a verdict mismatched its expectation, or the block is stale |
+| 2 | any abort — an instrument failure. Nothing is written. |
+| 101 | probe-pin itself panicked or failed to build (out of contract) |
+
+The local enforcement venue is the Tilt `probe-pin-check` resource. **`probe-pin check` is not
+enforced in GitHub CI**: enrolling it needs a `.github/workflows/**` edit, which is a hard stop
+for agent changes. CI does build the crate and run its tests (`--workspace`).
+
+## Manifest
+
+```toml
+version = 1                                  # unknown value -> refuse
+
+[target]
+mode         = "runtime-read"                # "compiled" parses and is REJECTED (see below)
+package      = "engine"                      # cargo -p     — binary RESOLUTION only
+test         = "integration"                 # cargo --test
+filter       = "loop_shortcut_seat_pin_census"
+filter_match = "substring"                   # or "exact" -> probe-pin appends --exact
+args         = []                            # appended LAST to the argv; reserved flags refused
+env          = { RUST_MIN_STACK = "16777216" }   # DEFAULT, not empty
+timeout_secs = 300                           # exceeded -> killed, and named
+
+[output]
+file   = "crates/engine/tests/integration/loop_shortcut_seat_pin_census.rs"
+marker = "PROBE-PIN"
+
+[[probe]]
+id    = "P0_control"                         # [A-Za-z0-9_-]: an id is a scratch path SEGMENT
+claim = "no mounts, unmodified tree — the instrument itself"
+  [probe.expect]
+  outcome = "pass"
+# EXACTLY ONE zero-mutation probe is required: it is the control.
+
+[[probe]]
+id = "P1_revert_interaction"
+  [[probe.mutation]]                         # 0..N, APPLIED IN ORDER
+  kind = "replace"                           # or "prepend" { files, text, repeat }
+  file = "crates/engine/src/game/interaction.rs"
+  find = "…verbatim…"                        # must match EXACTLY once, in the RUNNING text
+  replace = ""                               # may be ""; the MATERIALIZED file must differ
+  [[probe.assert_count]]                     # checked on the FINAL mutant text
+  file = "crates/engine/src/game/interaction.rs"
+  text = "TargetPin::Player" ; count = 1
+  [probe.expect]
+  outcome = "fail"
+  anchor  = ["PROVENANCE SPLIT VIOLATED", "text: \"Ok(TargetPin::Player(*player))\""]
+
+[[projection]]                               # 0..N, optional; shells to ast-grep
+id       = "targetpin_sites"
+pattern  = "TargetPin::Player($$$)"
+paths    = ["crates/engine/src", "crates/server-core/src"]
+sentence = "`TargetPin::Player` is constructed or matched at {count} sites."
+```
+
+probe-pin owns `--format`, `-Z`, `--nocapture`, `--show-output`, `--test-threads`, `--quiet` and
+`--exact`; `[target].args` may not pass them. It runs the target with libtest's JSON record
+format (`--format json -Z unstable-options`, **nightly-only surface**) and requires a pure
+record stream on stdout, so `--nocapture` would corrupt the instrument.
+
+Anchors match **inside one `{"type":"test"}` `event:"failed"` record's capture buffer** — that
+test's own `println!`, `eprintln!` and panic message, and nothing from any other test. All
+anchors in the list must hit inside the same record.
+
+## What a row proves, and what it does not
+
+**`fail` rows.** `Verdict::Fail` means the target failed *and* every anchor hit inside one
+failed-test record. A target failure whose anchors do not all land in one record is reported as
+a verdict mismatch (exit 1) naming the missed anchor — never as a pass — and `run --write` does
+not splice a block for a run that exits non-zero.
+
+**`pass` rows** prove **visible-and-still-passing**, not read-and-still-passing. The mutant
+differed from the original, was visible at the target's path inside the namespace (proved by a
+`cmp` readback), the harness ran to completion, and the assertion still passed. The row's
+"firing assertion" cell renders `mount reached: N file(s)` to say exactly that. Three ways a
+`pass` row is silent about reading, all measured:
+
+1. **`include_str!` bakes the original bytes at build time.** The target binary is built
+   outside the namespace, by design, so a compile-time read can never see the mutant.
+2. **A bind mount is path-scoped.** Any second hardlink to the same inode still serves the
+   original bytes.
+3. A manifest naming a file the target's scan root no longer covers yields a green pass row
+   forever.
+
+## Isolation model
+
+Each probe runs as `unshare --map-root-user --mount bash -c <script>`; the script bind-mounts
+every mutant over its real path, `cmp -s`-reads each one back, and `exec timeout -k 5 …`s the
+target. The mounts are private to that process and vanish on exit.
+
+**Mount-isolated is not write-isolated (N-10).** `unshare --mount` stops *probe-pin* from
+writing your tree. It does not stop the *target* from writing anywhere it likes, including
+gitignored `target/`. probe-pin's guarantees are about probe-pin, not about your test.
+
+**`env_clear()` is scoped to the target run only (MAJOR-3).** The target child's environment is
+constructed — `PATH`, `HOME`, `RUST_BACKTRACE=0`, `RUST_MIN_STACK` (default `16777216`,
+overridable), then `[target].env` — so two developers with different shells pin the same capture
+bytes. The `cargo`, `rustc` and `ast-grep` shell-outs **inherit** the ambient environment
+unmodified: clearing them would strip `CARGO_HOME`/`CARGO_TARGET_DIR` and silently resolve
+against the shared `~/.cargo` instead of a per-worktree home.
+
+**Scratch location.** Mutants go in a `TempDir` under `TMPDIR`, and probe-pin asserts that
+directory is not inside the workspace. If your `TMPDIR` is inside the worktree, probe-pin
+aborts rather than creating files under the tree it is measuring.
+
+## Anchors may not embed line numbers — and the bound on that lint
+
+A source line number moves on every unrelated edit above it, so an anchor containing one rots
+without the pinned behaviour changing. Validation rejects three forms, at zero target runs:
+
+```
+\bline\s*[:=]?\s*\d      ∪      \.[A-Za-z]{1,5}:\d+      ∪      :\d+:\d+
+```
+
+Measured against the ten shipping anchors of the real corpus (0 rejected) and nine hostile
+spellings (7 rejected).
+
+**Named residual.** The lint cannot catch a positional integer that is syntactically
+indistinguishable from a legitimate count. The boundary is two strings that differ only in the
+integer:
+
+```
+shipping anchor : ("engine/src/game/engine.rs", 1)       accepted (correctly)
+hostile twin    : ("engine/src/game/engine.rs", 11492)   accepted (the miss)
+```
+
+`L11492` is the other measured miss. Any regex that rejects the hostile form also rejects the
+real shipping anchor, so no lint closes this. The behavioural alternative — re-running each
+probe against a line-shifted tree — is measurably unsound (a line number originating in a file
+no probe mutates survives it) and costs a target run per probe, so it is not shipped. Revisit if
+an anchor of the `("<path>", <int>)` shape is ever authored with a *line* in the integer slot.
+
+Two probes whose anchor lists are byte-identical, or whose anchor list fully matches another
+probe's captured failure, are refused: they do not distinguish each other, so the pin would stay
+green if one of the two mutations stopped firing. The escape is to merge the two probes or to
+make the target's assertion message distinguish them — *not* to add a unique anchor, which may
+be impossible when the only distinguishing text is a line number.
+
+## The block, the digest, and instruments
+
+```
+// human intent prose lives HERE, above the marker, and is never touched — and never validated
+// PROBE-PIN:BEGIN manifest=probe-pin/seat-pin.toml digest=sha256:eb93eb0d0322246d
+// instrument rustc = rustc 1.97.0-nightly (0febdbab2 2026-04-18)
+// instrument ast-grep = ast-grep 0.44.1
+// | probe | mutation | expect | verdict | firing assertion (anchor) | provenance |
+// |---|---|---|---|---|---|
+// | P0_control | (none) | pass | pass | (control; no mounts) | — |
+// probe-pin validates only the lines between BEGIN and END. Prose outside is never checked.
+// PROBE-PIN:END
+// more human prose HERE, below the marker, also never touched and also never validated
+```
+
+**Out-of-marker prose is a known non-guarantee.** probe-pin validates the lines between `BEGIN`
+and `END`. Prose above, below, or anywhere else is never read, never validated, and never
+invalidated by this tool. Detecting stale free prose requires reading intent, and no instrument
+does that. If you write interpretation, label it yourself.
+
+**The digest pins what was MEASURED**, not just the outcomes: the whole `[target]` (including
+`filter`, `filter_match`, `args`, `env` and `timeout_secs`), `[output]`, every probe's inputs and
+its observed exit code and verdict, the control, every projection's `pattern` and sorted `paths`
+and count, and the instrument list. Narrowing a filter or subsetting a projection's paths
+changes the digest even when every verdict and count is identical. Excluded: `:line:col`,
+durations, PIDs, absolute paths, and completion order.
+
+**Line numbers are excluded from the render, the digest and anchors** — one rule applied three
+times. A line number is not evidence a committed artifact can carry, because it changes without
+the pinned behaviour changing. If you need the line, run the target: probe-pin's messages name
+the file and the assertion text.
+
+**An instrument is recorded iff it produced a number in the block.** `rustc` always did — every
+verdict came through libtest's nightly-only JSON surface — so it is unconditional. `ast-grep`
+only did when the manifest declares at least one projection, so its line appears only then.
+`PROBE_PIN_ASTGREP` overrides the ast-grep binary; there is no `rustc` twin, because `rustc` is
+on `PATH` wherever cargo built the target.
+
+**Projections are per-manifest.** A manifest that declares one and cannot run the tool aborts:
+probe-pin will not emit a block whose projection sentence is silently missing.
+
+**`run --write` refuses** when an instrument moved **and** a measured number moved — exactly
+when attribution is impossible and obeying would destroy the evidence of which one changed it.
+The escape needs no flag: reduce the block to a bare `BEGIN`/`END` pair and re-run, which shows
+the deliberate act in the PR diff. A toolchain bump alone (measured numbers identical) simply
+re-stamps; `rust-toolchain.toml` has moved twice in this repository's entire history.
+
+## Compiled mode (deferred)
+
+`[target].mode = "compiled"` parses and is rejected at validation time with an explicit
+deferral message. Only `runtime-read` ships: the mutant is bind-mounted and read as **text**,
+never compiled.
+
+It is deferred rather than removed because the guards it needs are known and measured. Cargo
+fingerprints on mtime; a bind mount presents the mutant's mtime and unmounting restores an
+*older* one, so cargo skips the rebuild and the next verdict is silently the previous probe's:
+
+```
+### mutant, fresh mtime ###        Compiling probe-scratch = 1  -> test result: FAILED  (correct)
+### control immediately after ###  Compiling probe-scratch = 0  -> test result: FAILED  (WRONG)
+### control on a FRESH target dir ###                           -> test result: ok. 1 passed
+```
+
+`touch`ing the real source fixes it and writes your worktree, which is prohibited. Compiled mode
+therefore needs **both**: a fresh `CARGO_TARGET_DIR` per probe under the tool's scratch root, and
+a mandatory `Compiling <package>` assertion on every compiled build, the control included —
+absence aborts. Until that ships, prose about compiled behaviour has no instrument here, and its
+honest home is outside the markers, where probe-pin explicitly never validates it.

--- a/docs/probe-pin.md
+++ b/docs/probe-pin.md
@@ -88,7 +88,9 @@ timeout_secs = 300                           # exceeded -> killed, and named; 0 
 
 [output]
 file   = "crates/engine/tests/integration/loop_shortcut_seat_pin_census.rs"
-marker = "PROBE-PIN"
+marker = "PROBE-PIN"                         # [A-Za-z0-9_-] too: the marker IS the block's
+                                             # structure, and a blank one degenerates to
+                                             # ':BEGIN'/':END'
 
 [[probe]]
 id    = "P0_control"                         # [A-Za-z0-9_-]: an id is a scratch path SEGMENT
@@ -101,7 +103,8 @@ claim = "no mounts, unmodified tree — the instrument itself"
 id = "P1_revert_interaction"
   [[probe.mutation]]                         # 0..N, APPLIED IN ORDER
   kind = "replace"                           # or "prepend" { files, text, repeat }
-                                             # every mutation must name >= 1 file
+                                             # every mutation must name >= 1 file, and a pad
+                                             # (text.len() × repeat) is capped at 64 MiB
   file = "crates/engine/src/game/interaction.rs"
   find = "…verbatim…"                        # must match EXACTLY once, in the RUNNING text
   replace = ""                               # may be ""; the MATERIALIZED file must differ
@@ -115,10 +118,12 @@ id = "P1_revert_interaction"
   anchor  = ["PROVENANCE SPLIT VIOLATED", "text: \"Ok(TargetPin::Player(*player))\""]
 
 [[projection]]                               # 0..N, optional; shells to ast-grep
-id       = "targetpin_sites"
+id       = "targetpin_sites"                 # a plain name, and UNIQUE: counts are looked up by
+                                             # id, so a duplicate renders the FIRST one's number
 pattern  = "TargetPin::Player($$$)"
-paths    = ["crates/engine/src", "crates/server-core/src"]
-sentence = "`TargetPin::Player` is constructed or matched at {count} sites."
+paths    = ["crates/engine/src", "crates/server-core/src"]   # >= 1: ast-grep with no operand
+                                             # scans the whole cwd instead
+sentence = "`TargetPin::Player` is constructed or matched at {count} sites."   # {count} REQUIRED
 ```
 
 probe-pin owns `--format`, `-Z`, `--nocapture`, `--show-output`, `--test-threads`, `--quiet` and
@@ -146,6 +151,27 @@ anchors in the list must hit inside the same record. An anchor that is empty aft
 refused for the same reason the empty anchor LIST is: `contains("")` is true of every capture,
 so it is satisfied by any failure at all.
 
+**Every manifest value that is RENDERED into the block is refused if it carries a control
+character or a marker tag.** The block is line-oriented and marker-delimited — `block::locate`
+counts `<marker>:BEGIN`/`<marker>:END` per line, and the cell escape covers only `|` — so such a
+value does not describe the artifact, it reshapes it. Measured: `anchor = ["PROBE-PIN:END"]`
+rendered into the firing-assertion cell, `run --write` exited 0, and the spliced file then held
+two END markers, after which every `check` aborts `expected exactly one PROBE-PIN:BEGIN/END pair
+… found 1/2` and the pin can only be recovered by hand. The rule is applied to the SURFACE, not
+to `anchor`: `manifest::rendered_block_values` enumerates every value that reaches the block —
+the manifest path, `[output].marker`, each probe id, each mutation path (its file name is
+rendered in the mutation cell), each anchor, each projection sentence — and
+`pure_logic::block_text_surface_is_one_authority` measures that enumeration against what
+`block::render` actually emits, so a new field that starts rendering is either covered or the
+census fails.
+
+**Named residual.** The same census also names the two producers on this surface that are *not*
+manifest values and cannot be refused before the run: an instrument's `--version` string, and a
+`provenance` path taken from the target's own `panicked at …` output. Reaching the failure
+through those needs a tool version or a source file whose name contains `<marker>:END`, and the
+result is loud (`check` aborts `MarkerNotUnique`) rather than a green row for an unmeasured
+tree — so they are disclosed, not guarded.
+
 ## What a row proves, and what it does not
 
 **`fail` rows.** `Verdict::Fail` means the target failed *and* every anchor hit inside one
@@ -171,6 +197,17 @@ differed from the original, was visible at the target's path inside the namespac
 Each probe runs as `unshare --map-root-user --mount bash -c <script>`; the script bind-mounts
 every mutant over its real path, `cmp -s`-reads each one back, and `exec timeout -k 5 …`s the
 target. The mounts are private to that process and vanish on exit.
+
+**The script owns two exit codes, and the classification reads them before the record stream.**
+`97` is the mount readback failing; `96` is the script failing before the target was reached at
+all — `mount`, `cmp` and `timeout` are resolved through `PATH` *inside* the namespace under
+`set -eu`, so a missing one of them, an unset `PP_*` variable, or a failed `exec` kills the shell
+with **empty stdout and a non-zero code**, which is byte-for-byte the shape of a target that died
+before its first libtest record. Measured with `timeout` off `PATH`: exit 127, and the abort
+raised was `HarnessIncomplete`, whose message tells the operator to raise `RUST_MIN_STACK`
+through `[target].env` — a remedy that cannot make `timeout` exist. An `EXIT` trap now raises 96
+for the whole pre-`exec` region (a successful `exec` replaces the shell, so it cannot fire for
+the target's own exit), and both reserved codes are trusted only when stdout is empty.
 
 **Mount-isolated is not write-isolated (N-10).** `unshare --mount` stops *probe-pin* from
 writing your tree. It does not stop the *target* from writing anywhere it likes, including

--- a/docs/probe-pin.md
+++ b/docs/probe-pin.md
@@ -53,6 +53,21 @@ The local enforcement venue is the Tilt `probe-pin-check` resource. **`probe-pin
 enforced in GitHub CI**: enrolling it needs a `.github/workflows/**` edit, which is a hard stop
 for agent changes. CI does build the crate and run its tests (`--workspace`).
 
+**The Tier-2 suite does not run in CI, and this is measured, not assumed.** GitHub's runners deny
+unprivileged user namespaces — `unshare --map-root-user --mount` fails with
+`write failed /proc/self/uid_map: Operation not permitted` — so every test in
+`tests/isolation_e2e.rs` carries `#[ignore]`. CI therefore covers `pure_logic` (schema,
+validation, verdict, digest and drift logic) but never exercises a real mount. Run Tier 2 where
+namespaces work:
+
+```bash
+cargo test -p probe-pin --test isolation_e2e -- --ignored
+```
+
+`#[ignore]` rather than a runtime capability check, on purpose: a test that silently no-ops when
+the namespace is unavailable reports as **passed**, which is exactly the unmeasured-green this
+tool exists to refuse. An ignored test reports as ignored.
+
 ## Manifest
 
 ```toml

--- a/docs/probe-pin.md
+++ b/docs/probe-pin.md
@@ -14,8 +14,17 @@ The tool exists to enforce exactly two invariants:
    `<scratch>/<probe.id>/<file>`, the two joined KEYS are validated too: an id must be a plain
    name (`[A-Za-z0-9_-]`), and every manifest path must be workspace-relative with no `..`
    component. A container assert cannot see a key that joins its way back out of the container.
-2. **No verdict is reported for a run that measured nothing.** A control that selected zero
-   tests is an instrument failure, not a pass.
+   Lexical cleanliness is only the pre-filter: every manifest path is then **canonicalized and
+   asserted to resolve inside its base** — the workspace root for a file probe-pin reads, the
+   scratch dir for a mutant it writes — because `Path::components()` all `Normal` says nothing
+   about what a component resolves to, and an in-tree symlink satisfies it while landing the
+   write anywhere on the filesystem.
+2. **No verdict is reported for a run that measured nothing.** The floor is on what
+   **executed**, not on what was selected: `passed + failed == 0` aborts. `test_count` reads 1
+   for a normal run, for an `#[ignore]`d pinned test and for a `--bench` argv alike (measured,
+   all three), so a floor on selection is blind to every flag or attribute that suppresses
+   execution. One abort covers both shapes and names which it saw — the filter selected
+   nothing, or everything it selected was skipped.
 
 Everything else in this document is a bound on what a row in the block actually proves.
 
@@ -56,10 +65,10 @@ package      = "phase-engine"                # cargo -p     — binary RESOLUTIO
                                              # crates/engine is package `phase-engine`, [lib] `engine`,
                                              # and `-p engine` fails to resolve.
 test         = "integration"                 # cargo --test
-filter       = "loop_shortcut_seat_pin_census"
+filter       = "loop_shortcut_seat_pin_census"   # a SUBSTRING: may not begin with '-'
 filter_match = "substring"                   # or "exact" -> probe-pin appends --exact
 args         = []                            # appended LAST to the argv; reserved flags refused
-env          = { RUST_MIN_STACK = "16777216" }   # DEFAULT, not empty
+env          = { RUST_MIN_STACK = "16777216" }   # DEFAULT, not empty; probe-pin's own keys refused
 timeout_secs = 300                           # exceeded -> killed, and named; 0 is REFUSED
 
 [output]
@@ -81,7 +90,8 @@ id = "P1_revert_interaction"
   file = "crates/engine/src/game/interaction.rs"
   find = "…verbatim…"                        # must match EXACTLY once, in the RUNNING text
   replace = ""                               # may be ""; the MATERIALIZED file must differ
-  [[probe.assert_count]]                     # checked on the FINAL mutant text
+  [[probe.assert_count]]                     # checked on the FINAL mutant text, so the file
+                                             # must be one THIS probe mutates
   file = "crates/engine/src/game/interaction.rs"
   text = "TargetPin::Player"
   count = 1
@@ -97,13 +107,29 @@ sentence = "`TargetPin::Player` is constructed or matched at {count} sites."
 ```
 
 probe-pin owns `--format`, `-Z`, `--nocapture`, `--show-output`, `--test-threads`, `--quiet` and
-`--exact`; `[target].args` may not pass them. It runs the target with libtest's JSON record
+`--exact`; no manifest value may pass them. It runs the target with libtest's JSON record
 format (`--format json -Z unstable-options`, **nightly-only surface**) and requires a pure
 record stream on stdout, so `--nocapture` would corrupt the instrument.
 
+That check is applied to **every token the manifest contributes to the argv**, enumerated once
+in `Target::manifest_argv` and used by `isolate::argv` to build the real argv — `filter` reaches
+libtest too, as token 0, where getopts parses a `-`-leading token as a flag. `filter` is
+additionally constrained by shape: it is a substring matched against test names, so it may not
+begin with `-`. Hostile flags are *not* enumerated (`--bench` is on no list); the execution
+floor is what covers them, this is what keeps the two argv producers from drifting.
+
+`[target].env` may not set a variable probe-pin itself sets — `PATH`, `HOME`, `PP_MOUNTS`,
+`PP_MUTANT_*`, `PP_TARGET_*`, `TIMEOUT`, `TESTBIN`. The target child is `unshare … bash -c
+SCRIPT`, so `PATH` resolves the `mount` and `cmp` the readback is made of: a manifest pointing it
+at stubs renders `mount reached: N file(s)` for a probe whose mutant was never mounted (measured,
+exit 0). `RUST_MIN_STACK` is the one probe-pin-set variable a manifest may override — it is a
+default, and lowering it kills the target mid-run rather than forging a green row.
+
 Anchors match **inside one `{"type":"test"}` `event:"failed"` record's capture buffer** — that
 test's own `println!`, `eprintln!` and panic message, and nothing from any other test. All
-anchors in the list must hit inside the same record.
+anchors in the list must hit inside the same record. An anchor that is empty after trimming is
+refused for the same reason the empty anchor LIST is: `contains("")` is true of every capture,
+so it is satisfied by any failure at all.
 
 ## What a row proves, and what it does not
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Adds `probe-pin`, a standalone workspace tool that turns behavioural prose in code comments into a transcription of measured evidence. It runs a TOML probe manifest — each probe bind-mounts a mutated copy of a source file over the real path inside an unprivileged mount namespace, runs a target test binary, reads libtest JSON records — and renders the resulting verdict table into a digest-stamped comment block that `--check` can re-verify for drift.

The tool eats its own dogfood: its verification matrix is executed by running `probe-pin` on itself, and `cargo probe-pin check` on its own manifest is part of the gate battery below.

## Files changed

- `crates/probe-pin/` — new crate: manifest schema + validation, mutant materialization, namespace isolation, libtest-record verdicts, digest/render/splice/check, CLI (`src/`, 9 modules, 2,686 lines)
- `crates/probe-pin/tests/` — Tier-1 verification matrix and Tier-2 isolation suite (86 tests), plus fixture manifests
- `docs/probe-pin.md` — usage, schema, isolation model, and the tool's stated non-guarantees
- `.cargo/config.toml` — one alias line (`probe-pin`)
- `Tiltfile` — `probe-pin-check` resource so `--check` has an executor, and `probe-pin-e2e` so the Tier-2 suite runs in the venue that has the capability CI lacks
- `Cargo.lock` — purely additive

Root `Cargo.toml` is **not** edited: the workspace globs `members = ["crates/*"]` (`Cargo.toml:5`), so the crate joins automatically. No `build.rs`.

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

Plan → `review-engine-plan` (3 rounds) → implement → `review-impl` → fix → `review-impl` → fix → `review-impl` → **class-closure pass**. Where a pipeline leg is card-parser-specific (card-data projection, parse-diff), it is replaced by this tool's own gate battery — disclosed rather than skipped, because the crate contains zero engine or parser code.

The third review round is why the last commit exists, and the reason is worth stating rather than burying: rounds 1–3 each found instances of a single defect class — *the tool renders a green row, or exits 0, for a run it never measured* — and each round fixed the fields named while the next round found more in different fields. That pattern is evidence the class was not bounded by point review, so the remedy was a closure pass rather than a fourth round. See Scope Expansion.

## CR references

None. `probe-pin` contains no game logic; a CR annotation here would be false provenance.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is stated for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

All measured after the rebase onto `upstream/main` `cc7668062`, at head `8f2836349`:

- `cargo fmt --all -- --check` — **exit 0**
- `cargo clippy --workspace --all-targets -- -D warnings` — **exit 0**, zero warning lines
- `cargo test -p probe-pin` — **exit 0**: `pure_logic` 68 passed / 1 ignored, `isolation_e2e` 0 passed / **17 ignored**, 0 failed
- `cargo test -p probe-pin --test isolation_e2e -- --ignored` — **exit 0**: **17 passed, 0 failed** (the Tier-2 suite actually executed, locally, where user namespaces work — proof the `#[ignore]` hides no failure)
- `cargo probe-pin check crates/probe-pin/tests/fixtures/dogfood.toml` — **exit 0** (the tool run against its own manifest)
- `git diff --numstat upstream/main..HEAD` — 31 files, 7,792 insertions, 0 deletions, **0 binary files** (positive control: a synthesized NUL file returns `-` `-`)

**Ignored tests, disclosed in detail because in this crate an ignored test is exactly the defect the tool exists to catch.** There are 18, of two entirely different kinds:

- **1 in `pure_logic`** — `ppfixture_ignored`, a probe *target* whose body must never run. It is the fixture that drives the execution-floor verification below, not a skipped assertion.
- **17 in `isolation_e2e`** — the whole Tier-2 suite, because CI cannot execute it. See CI Failures below; it is measured, not assumed, and the suite is verified green locally with `-- --ignored`.

Neither is a runtime capability check, deliberately: a test that silently no-ops when the namespace is missing reports as **passed**, which is this PR's own BLOCKER wearing a test harness. An ignored test reports as ignored.

**Two-sided verification.** Every row of the verification matrix has a DROP arm and a TRIVIALIZE arm, and each arm is stated in the test's own doc comment with what it must flip. A row whose DROP arm does not flip its assertion is vacuous — and in a tool whose thesis is that evidence must be measured rather than asserted, a vacuous test is self-refuting.

Scope of that claim, stated precisely rather than as one headline number: the full mutant matrix was executed against the rows that existed at the time, at the head where each was written. The rows added by the last two commits were each measured individually at their own head — every new guard reverted and its test observed to fail with the specific diagnostic it exists to produce, every mutated source restored and verified byte-identical with `sha256sum -c`. The matrix has **not** been re-run wholesale at the current head; `cargo test -p probe-pin` has, and is green.

## Gate A

```
$ ./scripts/check-parser-combinators.sh "$(git rev-parse upstream/main)"
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=8f283634934b04b848122956d8211b8aa54df914 base=cc76680623e4d4628dc0291e88cc9c2d99bf32ff
```

The base is passed **explicitly**. The script defaults to `git merge-base origin/main HEAD` (`:48`), and `origin` here is a fork whose main lags; that default resolved to a different, shorter range. The run above is against the authoritative base.

**Disclosure, because a green line here would otherwise be read as more than it is:** `scripts/check-parser-combinators.sh` scopes to `SCOPE='crates/engine/src/parser'` (`:51`). This PR touches no file under that path, so the gate passes on an **empty range**. It is not-applicable-but-green, not evidence of combinator purity. The combinator mandate does not apply to this crate: its `find` is literal byte substitution, and the anchor lint is a denylist over user-authored manifest text, not parsing dispatch.

## Anchored on

- `crates/engine-inventory-gen/Cargo.toml:2` and `src/main.rs:1` — the workspace's existing standalone tooling-crate pattern: `version.workspace`/`license.workspace`/`edition 2021` manifest shape, and a `//!` header naming the invocation that regenerates its output. `probe-pin` mirrors both.
- `Tiltfile:199` — the existing `local_resource` lint pattern (list-form `cmd`, separate `CARGO_TARGET_DIR`, narrow `deps`, `TMP_IGNORE`, `auto_init`, `allow_parallel`, `labels`). `probe-pin-check` follows it field for field, extending `ignore` because `TMP_IGNORE` is a filename glob (`**/*.tmp.*`) that does not match a `tmp/` directory.

**Honest scope note on Gate B:** this is a new crate, so there is no prior art *inside* `crates/probe-pin/`. The two citations above are the nearest same-class analogs in the repository, and the plan traced the first end-to-end before adopting its conventions. Flagging rather than citing something closer-looking but unrelated.

## Final review-impl

**Round 3 was NOT clean** — 1 BLOCKER, 3 MAJOR, 3 MINOR at head `08924b0ad`, all reproduced against the built binary. Stating that plainly rather than reporting only the pass that followed.

Every one of the green-row findings was the *same* class. The remedy was therefore an authorized class-closure pass (final commit), not a fourth review round, and its acceptance gate was three measurements:

- **(a) each of the four execution surfaces refuses a hostile value, two-sided** — hostile aborts naming the offending construct, benign still passes. Measured for argv, env, path and anchor.
- **(b) the execution floor fires on a zero-run** — the BLOCKER's exact repro, flipped: an `#[ignore]`d pinned test now aborts instead of rendering a green row. Measured for both the `#[ignore]` and `--bench` routes, with the benign arm still passing.
- **(c) the filesystem-write producer census is complete** — every producer proven to route through the containment guard or to be structurally outside manifest control, with the enumerating command published so the census is reproducible.

All three measured clean at the committed head, independently re-run by the driver with exit codes captured before any pipe.

### Maintainer review — marker injection (resolved at head `9104cef64`)

`matthewevans` blocked on: a generated block can inject a second marker. Two acceptable remedies were named; both are implemented, because measuring the first exposed a residual the second closes.

**Manifest-derived fields** were already refused at the head the review was written against, verified by re-running the four attack strings through the built binary — each aborts at **exit 2** before any write: `anchor = "\nPROBE-PIN:END"` (the review's exact string) and `anchor = "boom\nsecond line"` abort naming the control character; `marker = "PROBE\nPIN"` and a projection sentence containing a marker tag abort naming the tag.

That coverage is **field-shaped**, and the same field-vs-surface reasoning that drove the class-closure pass applies here: two producers reach a rendered line without passing through a manifest field — an instrument's `--version` output, and the `provenance` paths lifted from the target's own panic text. Neither can be refused in advance. So `block::splice` now re-runs `locate` over its **own spliced output** and returns an abort rather than a block whose marker span the next `check` could not find. The property is unconditional at the write surface instead of conditional on field coverage.

Regression test `write_can_never_produce_a_block_its_own_check_cannot_locate` asserts both halves the review asked for: `manifest::validate_block_text` refuses the injected marker, and `splice` refuses to return an unlocatable block. Two-sided — deleting the postcondition line makes it fail at **exit 101** naming the injected second `END`; the mutated source was restored and re-verified with `sha256sum -c`.

**The census that premise rests on is now executable, not asserted.** "Unconditional at the write surface" is only true while `splice` is the sole route to the pinned file's bytes. Measured: exactly two filesystem write producers exist in `src/` — the scratch mutant, which is never a rendered block, and the pinned file, whose content argument is literally the `splice(..)?` call. The guard is *inside the only write's argument*, not merely on its path. `every_write_of_the_pinned_file_routes_through_splice` pins that, and a second `fs::write` of `output.file` now fails it rather than silently falsifying this paragraph.

Four arms, each flipping a different assertion: dropping `splice` from the write argument → exit 101 on the property; adding a third producer → exit 101 at `found 3`; breaking the search patterns → exit 101 on the zero-census positive control. **The fourth arm did not flip, and the comment says so:** the comment-strip's DROP arm left the test green, because this comment's own first draft mis-cited `manifest.rs`'s backticked prose mention as a matching hit when every producer pattern requires an open paren. The strip is disclosed as defensive, and its value re-measured against the input it actually defends — a doc comment quoting a call site, green with the strip and `found 3` without.

### Second review round (resolved at head `815aaf279`, census widened at `8f2836349`)

Five findings; four real, one declined with evidence. Each was verified against a run before anything was edited.

- **Rows are keyed on probe identity.** `firing_cell` decided "this is the control" from `mounts_reached == 0` while `mutation_cell` decided the same fact from `probe.mutations.is_empty()` — two discriminators for one concept, agreeing only because `validate` refuses an empty mutation file list. Latent, and the digest pins the same count, so nothing would have disagreed with a lying row. Rendered output byte-identical: the committed block is unchanged in `git` and `check` exits 0.
- **An outcome-less probe gets a visible `unmeasured` row**, matching what `digest` already records for the same input. Skipping it showed N-1 rows for N declared probes while `check` stayed CLEAN, because the committed copy omitted the same row.
- **A blank `[target].filter` is refused.** Measured with `filter_match = "substring"`: the run widens to the whole target binary and is caught only because a widened test happens to fail — reported as a broken control, not as the manifest defect. With `exact` it matches nothing and the execution floor blames the target for a typo in the manifest.
- **`probe-pin-e2e` gets its own `CARGO_TARGET_DIR`**, having shared one with `probe-pin-check` while both watch `crates/probe-pin/` and both allow parallel runs. The contention is cross-process, so the in-process mutex in the suite does not span it.

**Declined, with measurement:** a finding that `validate` admits identity mutations. It does; the refusal is not in `validate`. `find == replace`, `repeat = 0` and `text = ""` each abort at exit 2 on *"the materialized mutant is byte-identical to the original"* — one guard after materialization, covering the class regardless of mutation kind, and `find = ""` is refused by the occurrence gate. The proposed fix would have added narrower per-variant checks at a worse surface, which is the field-enumeration shape this crate already repaired twice.

**One of my own fixes was wrong and the suite caught it.** The first attempt at the missing-row finding used `unreachable!`, as suggested. It panicked in the projection-surface test, which calls `render` with `&[]` outcomes deliberately — `render` is public and that input is legitimate, so the invariant belongs to `main`'s call order, not to `render`. The visible `unmeasured` row closes the actual finding without breaking correct use. A second test listed `""` among *benign* filter values; it now asserts which guard refuses it, so the benign list still proves the operand rule is discriminating.

**The writer census was widened after an independent re-run.** A reviewer ran it with a wider producer set (`fs::copy`, `fs::rename` added) and got the same answer — but the agreement was luck: neither appears in any `src/` module today, so a future `fs::copy(tmp, out_path)` would have written the pinned file while the census still reported "exactly 2". The patterns are now live rather than decorative: injecting an `fs::copy` into `block.rs` fails the census at `found 3`, naming the module, where before the widening it was invisible.

## Claimed parse impact

None. No engine or parser source is touched, so no card parse is affected.

## Scope Expansion

Not "None" — disclosed in full.

The delivered crate is 6,990 LOC (2,686 `src/` + 4,304 `tests/`) against a planned ~1,600. The estimate was wrong, not the code: the dominant drivers are rustfmt physical lines against logical-line estimates, verbatim failure-message texts, and two-sided arms on every verification row. **Tests were deliberately not trimmed to hit the estimate** — cutting evidence to match a projection is the exact failure this tool exists to prevent.

Thirteen items were built outside the original plan's inventory. An independent review adjudicated them **4 necessary, 9 defensible seams, 0 scope creep**. The two load-bearing ones:

- `isolate::exit_rc` — required. `timeout` re-raises the child's signal, so `ExitStatus::code()` is `None` on an abort, making the plan's own rc-134 contract unreachable without a `128+signal` mapping. Measured 134/139/101/124.
- The mount script's indexed loop — the plan's script body was written for one mutant/target, but a five-file mount is an expressible probe. Closed with `${!m}` indirection, no `eval`; `"$@"` still reaches the target as exactly its argv (verified under spaces, `*`, `$HOME`, quotes, and empty strings).

One planned mechanism was **not** shipped (`isolate::capability()`): the pipeline has no step for it and the namespace-unavailable abort is reachable through the ordered classification.

### The class-closure pass (final commit)

Rounds 1–3 each fixed the fields a reviewer named, and the next round found the same defect in a different field. The closure diagnosis: **the crate validated FIELDS, but every defect entered through a SURFACE.** Fields are unbounded and grow with the schema; surfaces are few and each has exactly one construction site. That is why a gate written for `[target].args` missed `[target].filter`, and a path guard written for `mutation.file` missed `[output].file`.

The four surfaces a manifest value can reach are argv, env, filesystem path, and anchor semantics. Validation moved to each surface's construction site.

The general guarantee is the execution floor. `observe` took `test_count` from the suite-**started** record and discarded `passed`/`failed`/`ignored` from the terminal record, so the "this run measured nothing" guard was structurally blind to a run whose every selected test was skipped — a normal run and an all-ignored run both report `test_count 1`. The floor is now `passed + failed == 0`. It caught `--bench` **without `--bench` ever being enumerated**, and it closes the route that needed no manifest change at all: a plain `#[ignore]` on the pinned test, which kept the digest, the block and the Tilt resource green indefinitely.

Deliberately **not** done: adding `--bench` (or `--ignored`, `--list`, `--logfile`) to the reserved-flag list. Enumerating hostile flags is the denylist shape that had already failed twice in this crate. The argv work instead closes the field gap structurally and constrains `filter` by positive shape — a filter is a substring, a projection path is a directory, so neither may begin with `-`.

Two findings surfaced by the closure work itself and fixed in it:

- **A live false green.** `[[projection]].paths = ["-h"]` made `ast-grep` print its *help*, which probe-pin counted into a rendered "named at 30 sites." sentence at exit 0. Same argv surface, different construction site — closed by the same positive shape rule, which is the argument for writing it that way.
- **Path containment was the wrong shape, not merely under-applied.** `is_workspace_relative` was lexical, so a symlink whose every component is an ordinary name escaped it — measured: the block spliced to a destination outside the workspace at exit 0. Replaced with a realpath assertion matching the pattern `isolate::scratch_dir` already used, closing the probe-`id`, `[output].file` and mount-target producers together. Not reachable in this repo today (4 tracked symlinks, all in-tree), so this is hardening — but it is the shape that let three consecutive rounds each patch one more field.

## Validation Failures

None.

## CI Failures

One disclosed risk **materialized on the first CI run and has been remedied**; one remains open.

1. **RESOLVED — the Tier-2 suite cannot run on GitHub runners.** This was disclosed here as a risk with the remedy deliberately deferred until a log existed to name the cause. The log exists: [actions run 31646292055](https://github.com/phase-rs/phase/actions/runs/31646292055) — `unshare --map-root-user --mount` fails with `write failed /proc/self/uid_map: Operation not permitted`, and **14 of the 15 tests then in the suite failed for that one reason, across all four shards**. The `Rust (fmt, clippy, test, coverage-gate)` job is an aggregator reporting `RUST_TEST_RESULT: failure`, not an independent failure.

   Remedied by `#[ignore]` on the suite, with the cause and the local invocation recorded in the file header and `docs/probe-pin.md`. Ignored **whole** rather than per failing test: the lone survivor (`proj_missing_both_paths`) passes only because its manifest is refused at validation before `unshare` is reached — a property of that fixture, not of the test. Splitting on "does this manifest happen to abort early" is a boundary that moves silently the next time a fixture or refusal order changes.

   Two controls keep the accommodation from decaying: the Tilt `probe-pin-e2e` resource runs the suite with `--ignored` in the local venue, which has the capability, so "ignored in CI" means "run elsewhere" and not "never run"; and `pure_logic::tier2_suite_is_uniformly_ignored_with_the_measured_reason` pins the suite size, the attribute on every test, and the exact reason text, so a new Tier-2 test cannot silently join and the ignored set cannot silently widen. Two-sided: removing one attribute and rewording one reason each fail naming `isolation_e2e.rs:130`; adding an 18th test fails the size assertion instead.

   What CI still covers: all 68 executed `pure_logic` tests — schema, validation, verdict, digest, drift, and every surface refusal — but never a real mount. Stated plainly rather than left implied.
2. **`probe-pin-check` cannot be verified from a worktree.** Tilt watches the main checkout, so a Tiltfile edit in a worktree is not what Tilt evaluates — that is a "cannot answer", not a failure. Verified instead by Starlark parse plus running the resource's `cmd` directly (exit 0). Closing the Tilt-side gate is owned by me, post-merge.
