### PR TITLE
fix(menu): bound AI catalog compatibility queue

### DIFF
--- a/client/src/services/__tests__/aiDeckCatalog.test.ts
+++ b/client/src/services/__tests__/aiDeckCatalog.test.ts
@@ -84,6 +84,33 @@ beforeEach(() => {
 });
 
 describe("buildLegalAiDeckCatalog", () => {
+  it("keeps catalog compatibility checks serial so setup cannot flood the engine worker", async () => {
+    saveDeck("First", deck("First Card"));
+    saveDeck("Second", deck("Second Card"));
+    saveDeck("Third", deck("Third Card"));
+    let activeChecks = 0;
+    let maximumActiveChecks = 0;
+    vi.mocked(evaluateDeckCompatibility).mockImplementation(async () => {
+      activeChecks += 1;
+      maximumActiveChecks = Math.max(maximumActiveChecks, activeChecks);
+      await new Promise<void>((resolve) => setTimeout(resolve, 0));
+      activeChecks -= 1;
+      return compatibility(true);
+    });
+
+    const catalog = await buildLegalAiDeckCatalog({
+      selectedFormat: "Standard",
+      selectedMatchType: "Bo1",
+    });
+
+    expect(maximumActiveChecks).toBe(1);
+    expect(catalog.candidates.map((candidate) => candidate.id)).toEqual([
+      "saved:First",
+      "saved:Second",
+      "saved:Third",
+    ]);
+  });
+
   it("includes legal saved Pauper Commander user decks", async () => {
     saveDeck("PDH Legal", deck("Command Tower", "Murmuring Mystic"));
 

--- a/client/src/services/aiDeckCatalog.ts
+++ b/client/src/services/aiDeckCatalog.ts
@@ -137,10 +137,16 @@ export async function buildLegalAiDeckCatalog(
     knownFormat: candidate.knownFormat,
   }));
 
-  const legal = await Promise.all(
-    rawCandidates.map((candidate) => legalCandidate(candidate, options)),
-  );
-  return { candidates: legal.filter((candidate): candidate is AiDeckCandidate => candidate !== null) };
+  // The shared engine worker owns a full card database. Issuing the complete
+  // catalog at once fills its message queue with cloned deck lists before the
+  // worker can service any of them, which can exhaust WebKit's process budget
+  // while the setup page opens. Keep only one compatibility request in flight.
+  const candidates: AiDeckCandidate[] = [];
+  for (const candidate of rawCandidates) {
+    const legalCandidateResult = await legalCandidate(candidate, options);
+    if (legalCandidateResult !== null) candidates.push(legalCandidateResult);
+  }
+  return { candidates };
 }
 
 export function useAiDeckCatalog({


### PR DESCRIPTION
Fixes #6798.

Bounds AI deck-catalog compatibility to one in-flight request, avoiding a large queued deck-payload peak while the Play setup screen opens. Includes a regression test that proves checks remain serial.