### PR TITLE
fix(coverage): surface an ability's activation zone in the parse signature

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3819,6 +3819,24 @@ fn ability_details(def: &AbilityDefinition) -> Vec<(String, String)> {
             ),
         ));
     }
+    // CR 113.6b + CR 113.6j + CR 113.6m: the zone this ability functions from.
+    // `None` is the CR 113.6 battlefield default and emits nothing, so an
+    // unqualified signature stays byte-identical.
+    //
+    // Emitted UNCONDITIONALLY, unlike the narrowly scoped `repeat_for` above.
+    // This is a rules-load-bearing parse output — `can_activate_ability_now`
+    // gates legality on it and the candidate enumerators key their hand,
+    // graveyard and library loops off it, so a change to this field moves cards
+    // between "offered" and "not offered". Scoping it would reproduce exactly
+    // the blindness this exists to remove.
+    //
+    // The key is "activates from", NOT "from": `effect_details` already emits
+    // "from" for a `ChangeZone` origin and `trigger_details` for a trigger
+    // origin, and `build_ability_item` silently drops duplicate keys — reusing
+    // "from" would hide this on precisely the abilities it exists to watch.
+    if let Some(zone) = &def.activation_zone {
+        d.push(("activates from".into(), fmt_zone(zone)));
+    }
     d
 }
 
@@ -11276,6 +11294,83 @@ pub fn format_semantic_audit_markdown(summary: &SemanticAuditSummary) -> String 
 
 #[cfg(test)]
 mod tests {
+
+    /// #7317 — an ability's `activation_zone` must reach the parse-diff
+    /// signature, under a key that does NOT collide with the `from` that
+    /// `effect_details` already emits for a `ChangeZone` origin.
+    ///
+    /// The collision is the whole point. `build_ability_item` drops duplicate
+    /// keys, and the abilities this field matters most on are exactly the ones
+    /// whose effect already occupies `from` — a graveyard self-return carries
+    /// `from: graveyard` for the effect's origin and needs a second, distinct
+    /// key for the zone it is activated from. Naming this one `from` would make
+    /// it invisible on precisely those abilities.
+    ///
+    /// The `None` row is the #5507 requirement restated: an ordinary
+    /// battlefield ability must emit NO zone key at all, byte-identical to
+    /// before, so this addition cannot churn the ~12k abilities that default to
+    /// the battlefield under CR 113.6.
+    #[test]
+    fn activation_zone_reaches_parse_details_without_colliding_with_effect_origin() {
+        use crate::types::ability::AbilityKind;
+        use crate::types::zones::Zone;
+
+        // A graveyard self-return: the shape where the collision bites.
+        let graveyard_self_return = || Effect::ChangeZone {
+            origin: Some(Zone::Graveyard),
+            destination: Zone::Hand,
+            target: TargetFilter::SelfRef,
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: EtbTapState::Unspecified,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            conditional_enter_with_counters: vec![],
+            face_down_profile: None,
+            enters_modified_if: None,
+        };
+        let details = |zone: Option<Zone>| -> Vec<(String, String)> {
+            let mut def = AbilityDefinition::new(AbilityKind::Activated, graveyard_self_return());
+            def.activation_zone = zone;
+            build_ability_item(&def).details
+        };
+
+        // (1) `None` — the CR 113.6 battlefield default. No zone key emitted.
+        let default_zone = details(None);
+        assert!(
+            !default_zone.iter().any(|(k, _)| k == "activates from"),
+            "a battlefield-default ability must emit no activation-zone key, so \
+             existing signatures stay byte-identical (#5507's requirement)"
+        );
+
+        // (2) `Some(Graveyard)` — both keys present, and distinct.
+        let gated = details(Some(Zone::Graveyard));
+        assert!(
+            gated.iter().any(|(k, v)| k == "from" && v == "graveyard"),
+            "the effect's own origin must still render under `from`: {gated:?}"
+        );
+        assert!(
+            gated
+                .iter()
+                .any(|(k, v)| k == "activates from" && v == "graveyard"),
+            "the activation zone must render under its own key; had it been \
+             named `from`, build_ability_item's dedup would have dropped it \
+             silently and this ability would look unchanged (#7317): {gated:?}"
+        );
+
+        // The point of the separate key: the two zones are independent, and a
+        // signature must distinguish them. Cage of Hands returns itself to hand
+        // from the battlefield; Gutterbones returns itself to hand from the
+        // graveyard. Same effect shape, different activation zone.
+        assert_ne!(
+            details(Some(Zone::Graveyard)),
+            details(Some(Zone::Exile)),
+            "two activation zones on the same effect are different parses and \
+             must not collapse to the same sticky signature"
+        );
+    }
 
     /// Matrix row 19 — `parse_details` renders each DECLARED mana role under its
     /// OWN key. Under the old role-blind rendering, Carpet of Flowers (count


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Fixes #7317.

## Summary

`activation_zone` appeared zero times in `crates/engine/src/game/coverage.rs`, so an activated ability's parse-diff signature never rendered the zone it functions from. `can_activate_ability_now_with_restriction_gates` gates legality on that field (`casting.rs:18421`) and the candidate enumerators key their hand, graveyard and library loops off it, so a change to it moves cards between "offered" and "not offered" — with nothing to show for it at the PR gate.

Surfaced on #7316, which moved 55 cards from `activation_zone: null` to `Graveyard`, withdrawing a battlefield offer and unlocking a graveyard one on each. Its parse-diff sticky read `✓ No card-parse changes detected.`

That is the inverse of #5507's failure mode and worse. There, removals with no compensating addition made a correct fix *look* like a regression — visibly wrong, so a reviewer investigates. Here a rules-behavior change across 55 cards was indistinguishable from a no-op, and the only way to tell was to grep `coverage.rs` for the field name.

Fourth instance of the class — #5492 (`PreventDamage.damage_source_filter`), #5495 (`ChangeZone` entry qualifiers), #5507 (`ManaSpellGrant`), #5673 (`ReplacementDefinition` scoping) — and the first in **`ability_details`** rather than `effect_details`, which is where #5501/#5507 applied the exhaustive-destructuring guard. The ability shell renders `AbilityDefinition`'s own fields and picks nine of them by hand from a struct with roughly forty-five.

## ⚠️ This PR's own sticky will report 79 clusters / 986 card rows

That is the intended one-time signature migration, not parser blast radius. Every row is `ability | field | activates from | ∅ → <zone>`; nothing changes value, nothing gains or loses support. The review check is that the sticky shows **zero** `added`, `removed`, `oracle_changed` and support flips — measured locally against `9b8bb91..96eadbd`:

| after-value | card rows |
|---|---|
| `hand` | 651 |
| `graveyard` | 333 |
| `exile` | 1 |
| `command zone` | 1 |
| **total** | **986** (977 unique cards, 79 clusters) |

Completeness cross-check: `client/public/card-data.json` carries **991** non-null `activation_zone` values (hand 656, graveyard 333, command 1, exile 1); the regenerated `coverage-data.json` carries **991** `activates from` entries. One-to-one — nothing is lost to `build_ability_item`'s dedup on any real card. (`Zone::Library`, used by Plot, is set at runtime and never persisted, so it correctly produces no rows.)

## Files changed

- `crates/engine/src/game/coverage.rs` — one unconditional `d.push` at the end of `ability_details`, its rationale comment, and one unit test beside the existing #5507 test in the same module.

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — no game logic, parser, effect, trigger, targeting or state-machine behavior changes. This is a projection-only change to the coverage/parse-diff instrument: the sole production edit appends a `(String, String)` pair to a details vector consumed by `coverage-report`. No `AbilityDefinition` value, no AST, no runtime path is affected. A final `/review-impl` pass ran against the committed head regardless, per CONTRIBUTING.

## CR references

`CR 113.6b`, `CR 113.6j`, `CR 113.6m` in the new comment, with `CR 113.6` named as the battlefield default that makes `None` emit nothing — each grepped from `docs/MagicCompRules.txt` (`:775`, `:791`, `:796`, `:771`) before being written. They are the three rules that put a non-`None` zone on an ability: stated-zone text, a cost unpayable on the battlefield, and a cost or effect that moves the object out of a zone.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo test -p phase-engine` — 18922 + 21 + 9 + 4867 passed, 0 failed, 15 ignored
- `cargo clippy-strict` — clean
- `cargo fmt --all` — clean
- `./scripts/check-parser-combinators.sh` — Gate G PASS, Gate A PASS
- pre-commit — Gate P PASS
- `coverage-parse-diff` base→head on one corpus (MTGJSON `5.3.0+20260810`) — 79 clusters, all `key="activates from"`, all `before=∅`; 0 SupportFlip, 0 added, 0 removed, 0 oracle_changed
- **Two-way control** — with the `d.push` removed, `activation_zone_reaches_parse_details_without_colliding_with_effect_origin` fails at its "must render under its own key" assertion and prints the real signature `[("from","graveyard"),("to","hand"),("target","self"),("kind","activated")]`, reproducing the blindness. Its `None` row independently pins the byte-identity requirement, so the ~12k battlefield-default abilities cannot churn.

Tilt is not installed in this environment; `scripts/tilt-wait.sh` would return `3` (cannot answer), never a build result, so the isolated-direct commands above were used. `cargo nextest` is likewise unavailable.

## Gate A

Gate A PASS head=96eadbd base=9b8bb919a0c0ccd7a6e2eb1217d25c341d90a14f

## Anchored on

- `crates/engine/src/game/coverage.rs:2742` — `effect_details` emits `from` for a `ChangeZone` origin, inside the exhaustively destructured arm #5495/#5501 produced. This is why the new key cannot be called `from`: `build_ability_item` (`:4851`) drops an `ability_details` key already present, so reusing it would hide the field on exactly the graveyard-return abilities it exists to watch.
- `crates/engine/src/game/coverage.rs:3818` — the `timing` push in `ability_details`, the existing precedent for projecting an activation-gating property of the ability shell (`is_sorcery_speed()`, i.e. `ActivationRestriction::AsSorcery`). The new push is its sibling for the zone gate and uses the same shape.

## Final review-impl

Final review-impl PASS head=96eadbd

## Claimed parse impact

No card's parse changes. 977 cards gain a detail key that was previously absent; no existing key changes value, and no card's `supported` flips. See the table above.

## Scope Expansion

None. Two adjacent gaps were found during review and are deliberately **not** in this PR — recorded here so they are not mistaken for oversights, and offered as follow-ups:

1. **The recurrence guard is still missing.** Fixing the instance does not stop instance #5. `ability_details` still hand-picks its keys with no compile-time parity check, while the house idiom for this exact struct already exists in four places — `Serialize for AbilityDefinition` (`types/ability.rs:19086`, *"Exhaustive destructure with NO `..` — this is the field-parity guard"*), `game/ability_scan.rs:4333`, `game/ability_rw.rs:3863`, `ai_support/shortcut_efficacy.rs:635`. A destructure guard changes zero bytes of output, so the usual churn argument does not apply; it is separable and belongs in its own diff.
2. **Two sibling activation gates remain unprojected**, checked by the same production function as the zone. `activator_filter` (CR 602.2a, `casting.rs:18357`) appears zero times in `coverage.rs`, and of `ActivationRestriction`'s 17 variants only `AsSorcery` is rendered. A future PR flipping `OnlyOnceEachTurn`, `MaxTimesEachTurn`, `ClassLevelIs`, `CounterThreshold`, or `activator_filter: None → Some(Opponent)` would move cards between offered and not-offered and post `✓ No card-parse changes detected.` — the #7316 failure, one field over.

Happy to open either as its own PR if maintainers want them.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Ability details now clearly distinguish where an effect originates from where the ability activates.
  * Non-default activation zones are shown under a dedicated **“activates from”** entry.
  * Abilities using the default battlefield activation zone remain concise, without extra activation-zone details.
* **Bug Fixes**
  * Improved ability detail accuracy and differentiation when activation zones vary.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->