### PR TITLE
Add Crackle with Power

### DIFF
--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -4463,6 +4463,57 @@ fn effect_lightning_bolt() {
 }
 
 #[test]
+fn crackle_with_power_full_oracle_parses_multiplier_and_up_to_x_targets() {
+    let parsed = parse_oracle_text(
+        "Crackle with Power deals five times X damage to each of up to X targets.",
+        "Crackle with Power",
+        &[],
+        &["Sorcery".to_string()],
+        &[],
+    );
+
+    assert_eq!(parsed.abilities.len(), 1, "expected one spell ability");
+    assert!(
+        parsed.parse_warnings.is_empty(),
+        "Crackle with Power must not leave parse warnings: {:?}",
+        parsed.parse_warnings
+    );
+    let ability = &parsed.abilities[0];
+    assert!(
+        !ability_chain_has_unimplemented(ability),
+        "Crackle with Power must not retain Unimplemented effects: {ability:#?}"
+    );
+    // CR 107.3i + CR 115.6: all X values share the announced value, and an
+    // optional target set may contain zero targets.
+    assert_eq!(
+        ability.multi_target,
+        Some(MultiTargetSpec::up_to(QuantityExpr::Ref {
+            qty: QuantityRef::Variable {
+                name: "X".to_string(),
+            },
+        })),
+        "each of up to X targets must expose an optional X-sized target set"
+    );
+    assert!(
+        matches!(
+            ability.effect.as_ref(),
+            Effect::DealDamage {
+                amount: QuantityExpr::Multiply { factor: 5, inner },
+                target: TargetFilter::Any,
+                ..
+            } if matches!(
+                inner.as_ref(),
+                QuantityExpr::Ref {
+                    qty: QuantityRef::Variable { name }
+                } if name == "X"
+            )
+        ),
+        "expected five times X damage to Any targets, got {:?}",
+        ability.effect
+    );
+}
+
+#[test]
 fn non_trigger_damage_to_that_permanent_or_player_does_not_use_event_target() {
     let e = parse_effect("Ghyrson Starn, Kelermorph deals 2 damage to that permanent or player");
     if let Effect::DealDamage { target, .. } = &e {

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -37,7 +37,7 @@ use super::oracle_nom::target as nom_target;
 use crate::parser::oracle_effect::counter::normalize_counter_type;
 use crate::parser::oracle_effect::parse_controls_permanent_object;
 use crate::parser::oracle_target::{parse_target, parse_type_phrase, parse_type_phrase_with_ctx};
-use crate::parser::oracle_util::merge_or_filters;
+use crate::parser::oracle_util::{merge_or_filters, parse_count_multiplier};
 use crate::types::ability::{
     AggregateFunction, AttackScope, AttackSubject, Comparator, ControllerRef, CountScope,
     DamageChannel, DamageKindFilter, DevotionColors, FilterProp, ObjectProperty, ObjectScope,
@@ -837,13 +837,10 @@ pub(crate) fn parse_cda_quantity_with_context(
         }
     }
 
-    // "twice [inner]" or "three times [inner]" → Multiply { factor, inner }
-    if let Ok((rest, factor)) = alt((
-        value(2i32, tag::<_, _, OracleError<'_>>("twice ")),
-        value(3, tag("three times ")),
-    ))
-    .parse(text)
-    {
+    // Multiplicative quantity prefixes share the nom authority used by effect
+    // count positions, so `N times <quantity>` has one grammar across CDA and
+    // imperative consumers.
+    if let Ok((rest, factor)) = parse_count_multiplier(text) {
         if let Some(inner) = parse_cda_quantity_with_context(rest, ctx) {
             return Some(QuantityExpr::Multiply {
                 factor,
@@ -5633,6 +5630,23 @@ mod tests {
             }
             other => panic!("Expected Multiply, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn cda_quantity_five_times_object_count() {
+        let qty = parse_cda_quantity("five times the number of creatures you control").unwrap();
+        assert!(matches!(
+            qty,
+            QuantityExpr::Multiply {
+                factor: 5,
+                inner,
+            } if matches!(
+                inner.as_ref(),
+                QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount { .. }
+                }
+            )
+        ));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -13,7 +13,8 @@ use crate::types::mana::{ManaColor, ManaCost};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::space1;
-use nom::combinator::{eof, opt, peek, value};
+use nom::combinator::{eof, map_res, opt, peek, value};
+use nom::sequence::terminated;
 
 /// A borrowed pair of `(original, lowercase)` slices kept in lockstep.
 ///
@@ -413,23 +414,12 @@ pub fn parse_count_expr(text: &str) -> Option<(QuantityExpr, &str)> {
         return Some((expr, rest.trim_start()));
     }
 
-    // CR 107.3: "twice N" / "three times N" — multiplicative count (Procrastinate:
-    // "Put twice X stun counters on it"). Mirrors the `parse_cda_quantity` branch
+    // Multiplicative count prefixes. Mirrors the `parse_cda_quantity` branch
     // but applies inside effect-count positions (put-counter count, draw count,
     // mill count, etc.) so every quantity-taking verb picks it up uniformly. The
-    // inner count recursively delegates back to `parse_count_expr`, so "twice X"
-    // and "three times five" both compose through the same types.
-    if let Some((factor, rest)) = super::oracle_nom::bridge::nom_on_lower(text, &lower, |i| {
-        nom::branch::alt((
-            nom::combinator::value(
-                2i32,
-                nom::bytes::complete::tag::<_, _, OracleError<'_>>("twice "),
-            ),
-            nom::combinator::value(2i32, nom::bytes::complete::tag("two times ")),
-            nom::combinator::value(3i32, nom::bytes::complete::tag("three times ")),
-        ))
-        .parse(i)
-    }) {
+    // inner count recursively delegates back to `parse_count_expr`, so any
+    // supported number word or digit composes through the same types.
+    if let Some((factor, rest)) = nom_on_lower(text, &lower, parse_count_multiplier) {
         if let Some((inner, after)) = parse_count_expr(rest) {
             return Some((
                 QuantityExpr::Multiply {
@@ -641,6 +631,27 @@ pub fn parse_count_expr(text: &str) -> Option<(QuantityExpr, &str)> {
         }
     }
     Some((QuantityExpr::Fixed { value: base }, rest))
+}
+
+/// Parse a multiplicative count prefix, such as `twice ` or `five times `.
+///
+/// A multiplier must be greater than one: `one time` is not a multiplicative
+/// Oracle count phrase, and zero/negative factors cannot arise from the shared
+/// unsigned number grammar.
+fn parse_count_multiplier(input: &str) -> OracleResult<'_, i32> {
+    alt((
+        value(2i32, terminated(tag("twice"), space1)),
+        map_res(
+            terminated(nom_primitives::parse_number, tag(" times ")),
+            |factor| {
+                i32::try_from(factor)
+                    .ok()
+                    .filter(|factor| *factor > 1)
+                    .ok_or(())
+            },
+        ),
+    ))
+    .parse(input)
 }
 
 /// CR 107.1a: Parse a standalone trailing rounding marker left after another
@@ -3623,6 +3634,50 @@ mod tests {
             other => panic!("expected Multiply, got {other:?}"),
         }
         assert_eq!(rest, "cards");
+    }
+
+    #[test]
+    fn parse_count_expr_english_and_numeric_times_x() {
+        for (text, expected_factor) in [
+            ("three times X cards", 3),
+            ("five times X damage", 5),
+            ("17 times X counters", 17),
+        ] {
+            let (qty, rest) = parse_count_expr(text).unwrap();
+            assert!(
+                matches!(
+                    &qty,
+                    QuantityExpr::Multiply { factor, inner }
+                        if *factor == expected_factor
+                            && matches!(
+                                inner.as_ref(),
+                                QuantityExpr::Ref {
+                                    qty: QuantityRef::Variable { name }
+                                } if name == "X"
+                            )
+                ),
+                "{text:?} must retain its multiplier and Variable X, got {qty:?}"
+            );
+            assert!(
+                matches!(rest, "cards" | "damage" | "counters"),
+                "{text:?} must leave the noun phrase untouched, got {rest:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn parse_count_expr_rejects_invalid_multiplier_prefixes() {
+        for (text, expected_remainder) in [
+            ("one time X damage", "time X damage"),
+            ("five timesX damage", "timesX damage"),
+        ] {
+            let (qty, rest) = parse_count_expr(text).unwrap();
+            assert!(
+                !matches!(&qty, QuantityExpr::Multiply { .. }),
+                "{text:?} must not parse as a multiplier, got {qty:?}"
+            );
+            assert_eq!(rest, expected_remainder);
+        }
     }
 
     // CR 107.3: Mathemagics' "draws 2ˣ cards" — digit + U+02E3 MODIFIER LETTER

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -638,7 +638,11 @@ pub fn parse_count_expr(text: &str) -> Option<(QuantityExpr, &str)> {
 /// A multiplier must be greater than one: `one time` is not a multiplicative
 /// Oracle count phrase, and zero/negative factors cannot arise from the shared
 /// unsigned number grammar.
-fn parse_count_multiplier(input: &str) -> OracleResult<'_, i32> {
+// CR 107.3a + CR 107.3i: a spell's controller announces a cost X while
+// casting, and its X instances normally share that announced value. The
+// multiplier wraps the recursively parsed X so each quantity consumer reads
+// that same value.
+pub(crate) fn parse_count_multiplier(input: &str) -> OracleResult<'_, i32> {
     alt((
         value(2i32, terminated(tag("twice"), space1)),
         map_res(

--- a/crates/engine/tests/integration/crackle_with_power.rs
+++ b/crates/engine/tests/integration/crackle_with_power.rs
@@ -1,0 +1,94 @@
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const ORACLE: &str = "Crackle with Power deals five times X damage to each of up to X targets.";
+
+fn crackle_cost() -> ManaCost {
+    ManaCost::Cost {
+        shards: vec![
+            ManaCostShard::X,
+            ManaCostShard::X,
+            ManaCostShard::X,
+            ManaCostShard::Red,
+            ManaCostShard::Red,
+        ],
+        generic: 0,
+    }
+}
+
+fn red_pool_for_x(x: usize) -> Vec<ManaUnit> {
+    (0..(x * 3 + 2))
+        .map(|_| ManaUnit::new(ManaType::Red, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+fn crackle_scenario(x: usize) -> (GameScenario, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(P0, red_pool_for_x(x));
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Crackle with Power", false, ORACLE)
+        .with_mana_cost(crackle_cost())
+        .id();
+    (scenario, spell)
+}
+
+#[test]
+fn crackle_with_power_x2_hits_a_player_and_creature_for_ten_each() {
+    let (mut scenario, spell) = crackle_scenario(2);
+    let creature = scenario.add_creature(P1, "Durable Target", 12, 12).id();
+    let mut runner = scenario.build();
+
+    let outcome = runner
+        .cast(spell)
+        .x(2)
+        .target_player(P1)
+        .target_object(creature)
+        .resolve();
+
+    // CR 107.3a + CR 107.3i + CR 120.2b: the announced X fixes both the
+    // triple-X cost and five-times-X effect amount as the spell deals damage.
+    outcome.assert_life_delta(P1, -10);
+    assert_eq!(
+        outcome.state().objects[&creature].damage_marked,
+        10,
+        "X=2 must deal five times X damage to the targeted creature"
+    );
+}
+
+#[test]
+fn crackle_with_power_x2_allows_fewer_targets_without_hitting_bystanders() {
+    let (mut scenario, spell) = crackle_scenario(2);
+    let target = scenario.add_creature(P1, "Durable Target", 12, 12).id();
+    let bystander = scenario
+        .add_creature(P1, "Untargeted Bystander", 12, 12)
+        .id();
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(spell).x(2).target_object(target).resolve();
+
+    assert_eq!(outcome.state().objects[&target].damage_marked, 10);
+    // CR 601.2c + CR 115.6: the caster chooses fewer than the maximum targets.
+    assert_eq!(
+        outcome.state().objects[&bystander].damage_marked,
+        0,
+        "up to X targets must not damage an unselected creature"
+    );
+}
+
+#[test]
+fn crackle_with_power_x0_resolves_without_target_selection() {
+    let (scenario, spell) = crackle_scenario(0);
+    let mut runner = scenario.build();
+
+    let outcome = runner.cast(spell).x(0).resolve();
+
+    // CR 115.6: an up-to-X targeted spell permits zero targets when X is zero.
+    assert!(
+        matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }),
+        "X=0 with zero targets must resolve back to priority"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -132,6 +132,7 @@ mod cr733_resolved_trigger_collection;
 mod cr733_resolved_trigger_removal;
 mod cr733_resolved_zone_change;
 mod cr_annotations;
+mod crackle_with_power;
 mod craft_tithing_blade_transform;
 mod crime_tracking;
 mod cross_line_instead_override_branch;


### PR DESCRIPTION
## Summary

Adds generic `N times <quantity>` parsing so Crackle with Power correctly deals five times its announced X to each of up to X targets.

## Files changed

- `crates/engine/src/parser/oracle_util.rs` — generalized the shared multiplier-count grammar.
- `crates/engine/src/parser/oracle_effect/tests.rs` — added the exact Oracle parse assertion.
- `crates/engine/tests/integration/crackle_with_power.rs` — added cast-pipeline regressions.
- `crates/engine/tests/integration/main.rs` — registered the integration module.

## Track

Developer

## LLM

Model: gpt-5.6-sol (via Codex; canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

CR 107.3a / CR 107.3i, CR 601.2c, CR 115.6, and CR 120.2b — verified for the parser and cast-pipeline assertions.

## Verification

- [ ] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — PASS.
- `git diff --check` — PASS.
- `./scripts/check-parser-combinators.sh` — PASS (Gate G and Gate A below).
- Final independent `review-impl` of `57e945e507923a76ebdcd63475ae627c2939c4ae` — PASS.
- `cargo test -p phase-engine --test integration crackle_with_power -- --nocapture` — infrastructure failure: `rustc` received external `SIGTERM` while compiling `phase-engine`; no Rust diagnostic was produced.
- `cargo clippy-strict`, `./scripts/gen-card-data.sh`, `cargo coverage`, and `cargo semantic-audit` — each reached the same external `SIGTERM` while compiling `phase-engine`; no code diagnostic was produced. GitHub CI is the required clean-environment verification.

## Gate A

Gate A PASS head=57e945e507923a76ebdcd63475ae627c2939c4ae base=e2355987c9a89fee6a8b9c6b39d9bbb7641ac45d

## Anchored on

- `crates/engine/src/parser/oracle_util.rs:396` — shared effect-count expression parser and existing recursive multiplier seam.
- `crates/engine/src/parser/oracle_effect/lower.rs:parse_each_of_up_to_damage_target` — existing `each of up to X targets` parser and multi-target binding authority.

## Final review-impl

Final review-impl PASS head=57e945e507923a76ebdcd63475ae627c2939c4ae

## Claimed parse impact

Crackle with Power.

## Scope Expansion

None.

## Validation Failures

Local Rust compilation was repeatedly externally terminated with `SIGTERM` while building `phase-engine`; no compiler or test failure was reported. This prevented local test, clippy, card-data, coverage, and semantic-audit completion. The worktree remained clean after each attempt.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for multiplier phrases such as “twice,” “three times,” and other numeric forms like “five times” when interpreting card effects.
  - Improved handling of shared X values and optional targeting for “Crackle with Power.”
  - Added support for resolving effects with fewer than the maximum number of targets, including zero targets.

- **Bug Fixes**
  - Invalid multiplier expressions are now rejected.
  - Improved damage resolution for multiple targets and variable damage amounts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->