### PR TITLE
fix(build): gate probe-pin's Linux-only venues off non-Linux hosts

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -22,6 +22,26 @@ enabled = config.parse().get('enable', [])
 # restarts the watching resources mid-build.
 TMP_IGNORE = ['**/*.tmp.*']
 
+# probe-pin isolates through `unshare --map-root-user --mount` (util-linux) and runs its target
+# under `timeout` (GNU coreutils). macOS ships neither, and there is no Darwin equivalent of an
+# unprivileged mount namespace to port to — so both probe-pin resources abort on a Darwin host
+# no matter what the tree contains. Gate their auto_init rather than let them boot straight into
+# a permanent red: a gate that is red on every change teaches everyone to stop reading the
+# colour, which costs more than the gate earns. They stay VISIBLE and clickable, like every
+# other opt-in resource here, so the refusal is still one click away when someone wants to see
+# it. `os.name` is consulted FIRST and short-circuits, so a Windows host never reaches `uname`
+# — which it does not ship, and which would fail Tiltfile LOAD rather than one resource.
+IS_LINUX = (
+    os.name == 'posix'
+    and str(local('uname -s', quiet = True, echo_off = True)).strip() == 'Linux'
+)
+
+# auto_init alone would NOT be enough: it governs only the STARTUP run, and the default
+# TRIGGER_MODE_AUTO re-runs a resource whenever its deps change. Both probe-pin resources watch
+# 'crates/probe-pin/', so off Linux the very next edit there would drag them back into the red
+# that auto_init just avoided. Off-Linux they must stop watching too, not merely stop booting.
+PROBE_PIN_TRIGGER = TRIGGER_MODE_AUTO if IS_LINUX else TRIGGER_MODE_MANUAL
+
 # Must stay a SUPERSET of what `scripts/engine-source-hash.sh` hashes as the engine cache
 # key (src + data + build.rs + Cargo.toml). `data/` is `include_str!`d into the binary and
 # `build.rs`/`Cargo.toml` change what gets compiled, so a change to any of them changes the
@@ -272,15 +292,22 @@ local_resource('probe-pin-check',
     # TMP_IGNORE is a FILENAME glob ('**/*.tmp.*') and does not match a tmp/ DIRECTORY, so the
     # Tier-2 tests' scratch writes under tests/fixtures/tmp/ would retrigger this resource.
     ignore = TMP_IGNORE + ['**/tmp/**'],
-    auto_init = 'lint' in enabled,
+    auto_init = 'lint' in enabled and IS_LINUX,
+    trigger_mode = PROBE_PIN_TRIGGER,
     allow_parallel = True,
     labels = ['lint'],
 )
 
 # The Tier-2 suite is #[ignore]d because GitHub's runners deny unprivileged user namespaces
 # (unshare -> /proc/self/uid_map EPERM), so GH CI never executes a real mount. THIS resource is
-# what keeps that honest: the local venue does have the capability, so Tier 2 runs here on every
-# change. Without it, "ignored in CI" quietly becomes "never run anywhere".
+# what keeps that honest: a LINUX local venue does have the capability, so Tier 2 runs there on
+# every change. Without it, "ignored in CI" quietly becomes "never run anywhere".
+#
+# On a non-Linux host, "never run anywhere" is not a hedge — it is the literal state. CI cannot
+# mount, and Darwin has no `unshare` to try, so Tier 2's claims are carried entirely by whatever
+# Linux venue last executed them. IS_LINUX only stops this resource auto-starting into a red it
+# can never clear; it does not make that gap smaller. The tests are deliberately NOT cfg'd out,
+# so a manual run here still prints probe-pin's own named refusal rather than a zero-test green.
 #
 # `-- --ignored` runs ONLY the ignored tests, which is exactly this suite. A non-zero exit turns
 # the resource red like any other gate — a real Tier-2 gate, not a fire-and-forget reporter.
@@ -298,7 +325,8 @@ local_resource('probe-pin-e2e',
            'CARGO_TARGET_DIR=target/probe-pin-e2e cargo test -p probe-pin --test isolation_e2e -- --ignored'],
     deps = ['crates/probe-pin/'],
     ignore = TMP_IGNORE + ['**/tmp/**'],
-    auto_init = 'lint' in enabled,
+    auto_init = 'lint' in enabled and IS_LINUX,
+    trigger_mode = PROBE_PIN_TRIGGER,
     allow_parallel = True,
     labels = ['lint'],
 )

--- a/crates/probe-pin/tests/pure_logic.rs
+++ b/crates/probe-pin/tests/pure_logic.rs
@@ -1,6 +1,14 @@
 //! Tier 1 — §10 rows 3-13, 15-20, 22-31 and 33's non-ordering arms. Zero namespace
 //! dependency: nothing here runs `unshare`.
 //!
+//! Zero namespace dependency is not the same as host-portable. The arms that drive a real
+//! libtest child spawn GNU `timeout(1)` — the same binary the shipping isolation script
+//! resolves through `PATH` — which macOS does not ship. Those arms are `ignore`d off Linux
+//! rather than `cfg`'d out, on purpose: a compiled-out test is INVISIBLE in the report, and
+//! an unmeasured claim that reports as nothing is the same failure as one that reports as a
+//! pass. An ignored test reports as ignored — the vocabulary the Tier-2 `#[ignore]`s already
+//! use for "this venue cannot measure it".
+//!
 //! The `ppfixture_*` tests at the bottom are not assertions about probe-pin — they are the
 //! TARGETS the Tier-2 dogfood manifests and the child-process arms below drive. They are
 //! inert (or trivially passing) unless `PP_FIXTURE` selects them, so a plain
@@ -243,6 +251,10 @@ fn reserved_arg() {
 /// `RUST_MIN_STACK` value rescues it — the suite terminal record is what fires, and dropping
 /// the marker requirement would turn rc 134 into a `Verdict::Fail`.
 #[test]
+#[cfg_attr(
+    not(target_os = "linux"),
+    ignore = "spawns GNU timeout(1); see docs/probe-pin.md"
+)]
 fn harness() {
     for stack in ["", "1", "16777216", "268435456"] {
         let env: Vec<(&str, &str)> = if stack.is_empty() {
@@ -522,6 +534,10 @@ fn anchor_dup() {
 /// writes the resulting capture length to `PP_OUT`. Both a DROP (no clear) and a TRIVIALIZE
 /// (clear, then re-import everything) leak the ambient value into the innermost target.
 #[test]
+#[cfg_attr(
+    not(target_os = "linux"),
+    ignore = "spawns GNU timeout(1); see docs/probe-pin.md"
+)]
 fn env_hermetic() {
     let dir = tempfile::tempdir().unwrap();
     let measure = |name: &str, ambient: &[(&str, &str)]| -> usize {
@@ -573,6 +589,10 @@ fn env_hermetic() {
 /// so `"1"` (the TRIVIALIZE: a default that exists and is useless) is measurably different
 /// from the shipping default.
 #[test]
+#[cfg_attr(
+    not(target_os = "linux"),
+    ignore = "spawns GNU timeout(1); see docs/probe-pin.md"
+)]
 fn env_default() {
     let t: Target = toml::from_str(
         "mode='runtime-read'\npackage='p'\ntest='t'\nfilter='f'\nfilter_match='substring'",
@@ -1206,6 +1226,10 @@ fn output_file_must_be_workspace_relative() {
 /// Final review-impl, MINOR-5: `timeout_secs = 0` disables the guard instead of tightening it.
 /// The shell behaviour is MEASURED here, not argued — it is the whole reason for the refusal.
 #[test]
+#[cfg_attr(
+    not(target_os = "linux"),
+    ignore = "spawns GNU timeout(1); see docs/probe-pin.md"
+)]
 fn timeout_zero_is_refused() {
     let rc = |secs: &str, sleep: &str| {
         Command::new("timeout")
@@ -2287,6 +2311,10 @@ fn abort_texts_promise_only_measured_values() {
 /// ordering arm — the abort names the CONTROL and no probe runs — is
 /// `isolation_e2e::no_tests_selected_ordering`.
 #[test]
+#[cfg_attr(
+    not(target_os = "linux"),
+    ignore = "spawns GNU timeout(1); see docs/probe-pin.md"
+)]
 fn no_tests_selected() {
     let mut t = target();
     // arm 1: the shipping substring filter selects tests
@@ -2332,6 +2360,10 @@ fn no_tests_selected() {
 /// stay green forever; `--bench` is reachable through `[target].args`, which is why the argv
 /// shape check alone would not have closed it.
 #[test]
+#[cfg_attr(
+    not(target_os = "linux"),
+    ignore = "spawns GNU timeout(1); see docs/probe-pin.md"
+)]
 fn execution_floor_reads_what_executed() {
     let mut t = target();
     let obs = |run: &Run, t: &Target| verdict::observe("P0_control", run, t, &[]);
@@ -2408,6 +2440,10 @@ fn execution_floor_reads_what_executed() {
 /// `filter_match` and `[target].args` both reach libtest's own selection — the only place
 /// where a dead schema field would show. Measured against this binary's real test names.
 #[test]
+#[cfg_attr(
+    not(target_os = "linux"),
+    ignore = "spawns GNU timeout(1); see docs/probe-pin.md"
+)]
 fn argv_is_live() {
     let mut t = target();
     t.filter = "ppfixture".into();

--- a/docs/probe-pin.md
+++ b/docs/probe-pin.md
@@ -68,6 +68,29 @@ cargo test -p probe-pin --test isolation_e2e -- --ignored
 the namespace is unavailable reports as **passed**, which is exactly the unmeasured-green this
 tool exists to refuse. An ignored test reports as ignored.
 
+### probe-pin is Linux-only, and says so rather than degrading
+
+probe-pin shells out to two binaries that only a Linux host has: `unshare` (util-linux) for the
+mount namespace, and `timeout` (GNU coreutils) for the target run. macOS ships neither, and has
+no unprivileged-mount-namespace equivalent to port to, so **every** probe aborts there with exit
+2 and the named refusal — never a fallback that writes your worktree.
+
+That splits the two tiers on a non-Linux host:
+
+- **Tier 1 (`pure_logic`) passes.** The arms that drive a real libtest child spawn `timeout`, so
+  they carry `#[cfg_attr(not(target_os = "linux"), ignore = "…")]` and report as **ignored** —
+  not compiled out. An invisible claim is the same failure as a falsely green one; `ignore` is
+  the vocabulary already used above for "this venue cannot measure it". `cargo test --workspace`
+  is green, with the skipped count visible.
+- **Tier 2 (`isolation_e2e`) runs nowhere.** CI cannot mount and Darwin has no `unshare`, so on a
+  macOS checkout the suite's claims rest entirely on whatever Linux venue last executed them.
+  Its tests are left un-`cfg`'d on purpose: a manual run still prints the named refusal instead
+  of a zero-test green.
+
+Both Tilt resources are `auto_init`'d off a non-Linux host (`IS_LINUX` in the `Tiltfile`) so they
+do not boot into a red they can never clear. They stay visible and clickable — the refusal is one
+click away, it just is not scheduled on every edit.
+
 ## Manifest
 
 ```toml


### PR DESCRIPTION
probe-pin isolates through `unshare --map-root-user --mount` (util-linux) and
runs its target under `timeout` (GNU coreutils). macOS ships neither and has no
unprivileged-mount-namespace equivalent, so on a Darwin checkout both Tilt
resources abort with exit 2 on every change, and `cargo test --workspace` fails
outright: 7 Tier-1 arms drive a real libtest child through `timeout`.

Tier 1: those 7 arms now carry
`#[cfg_attr(not(target_os = "linux"), ignore = ...)]`. `ignore` rather than
`cfg`, on purpose -- a compiled-out test is INVISIBLE in the report, and an
unmeasured claim that reports as nothing is the same failure as one that reports
as a pass. That is the vocabulary the Tier-2 `#[ignore]`s already use. Measured
on macOS: 61 passed / 8 ignored, against 61 passed / 7 failed / 1 ignored
before. The same 61 pass either way, so the gate moved exactly the failures and
silenced nothing that was working.

Tilt: `IS_LINUX` gates both resources' `auto_init` AND `trigger_mode`. auto_init
alone would not be enough -- it governs only the startup run, and the default
TRIGGER_MODE_AUTO would drag both back into the red on the next edit under
`crates/probe-pin/`. `os.name` is consulted first and short-circuits, so a
Windows host never reaches `uname`, which it does not ship and which would fail
Tiltfile LOAD rather than one resource. Verified with `tilt dump engine`: both
now read TriggerMode=2, matching `coverage`. (`.spec.triggerMode` reads empty
for every resource, including known-manual ones, so it cannot answer this.)

isolation_e2e is deliberately NOT cfg'd out: a manual run there should still
print probe-pin's own named refusal instead of a zero-test green.

The Tier-2 comment asserted "the local venue does have the capability". That is
Linux-only, and false for a macOS checkout: CI cannot mount and Darwin has no
`unshare`, so Tier 2 runs in NO venue and its claims rest entirely on whatever
Linux venue last executed them. Corrected in the Tiltfile and docs/probe-pin.md
rather than left implied by the gate's absence. This narrows the red; it does
not close that gap.

Assisted-by: ClaudeCode:claude-opus-5


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Probe-pin resources now start and trigger automatically on Linux hosts.
  * On non-Linux platforms, resources remain available for manual use without repeatedly entering a failing state.

* **Documentation**
  * Documented Linux-only requirements, platform limitations, and Tier 1/Tier 2 test behavior.
  * Clarified that unsupported hosts are reported appropriately and related tests are marked as ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->