### PR TITLE
fix(engine): allow effect-driven transformed battlefield entry for no…

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -24785,7 +24785,7 @@ pub mod tests {
 
     #[test]
     fn suppress_triggers_does_not_block_transform_on_reentry() {
-        // CR 603.2g + CR 701.28: SuppressTriggers only gates triggered-ability
+        // CR 603.2g + CR 701.27: SuppressTriggers only gates triggered-ability
         // registration. A permanent returning to the battlefield with
         // `enter_transformed=true` (e.g., Ajani, Nacatl Pariah's flip trigger)
         // must still transform — transform is NOT a triggered ability. Any
@@ -24880,7 +24880,7 @@ pub mod tests {
         );
         assert!(
             obj.transformed,
-            "Ajani must flip to his back face — SuppressTriggers must not block CR 701.28 transform"
+            "Ajani must flip to his back face — SuppressTriggers must not block CR 701.27 transform"
         );
         assert_eq!(
             obj.name, "Ajani, Nacatl Avenger",

--- a/crates/engine/src/game/zone_pipeline.rs
+++ b/crates/engine/src/game/zone_pipeline.rs
@@ -3506,7 +3506,20 @@ pub(crate) fn deliver_replaced_zone_change(
                     crate::game::merge::put_component_into_zone(state, object_id, to, events);
                 } else {
                     took_plain_zone_transfer = true;
-                    zones::move_to_zone(state, object_id, to, events);
+                    // CR 712.14a: carry the effect-driven "enters transformed"
+                    // intent into the battlefield-entry guard so a non-permanent
+                    // FRONT face (e.g. instant/sorcery) may enter as its PERMANENT
+                    // back face. `should_transform` is destructured from
+                    // `ProposedEvent::ZoneChange.enter_transformed` above; the
+                    // flag is inert for any non-battlefield destination (the guard
+                    // gates on `to == Battlefield`).
+                    zones::move_to_zone_with_entry_flags(
+                        state,
+                        object_id,
+                        to,
+                        events,
+                        should_transform,
+                    );
                 }
             }
         }
@@ -5938,6 +5951,170 @@ mod layers_incremental_flush_tests {
         assert_eq!(
             counters.layers_full_eval, 1,
             "the escalation must land in a full evaluation"
+        );
+    }
+}
+
+/// CR 712.14a building-block tests for the effect-driven transformed battlefield
+/// entry (Esper Origins class). Both drive `execute_zone_move_with_terminal`
+/// directly (not the raw `zones::move_to_zone`), so the full
+/// `deliver_replaced_zone_change` plain-fallback wiring — including the
+/// `move_to_zone_with_entry_flags(..., enter_transformed)` thread — is exercised.
+#[cfg(test)]
+mod effect_driven_transformed_entry_tests {
+    use super::*;
+    use crate::game::zones::create_object;
+    use crate::types::card_type::{CardType, CoreType};
+    use crate::types::identifiers::CardId;
+
+    /// CR 712.14a (2nd sentence) regression guard: a SINGLE-FACED object
+    /// instructed to enter transformed cannot enter the battlefield — it remains
+    /// in its origin zone (Exile).
+    ///
+    /// This guards the PRE-EXISTING belt-and-suspenders early-return inside
+    /// `execute_zone_move_with_applied_terminal` (before the `zones.rs` SF1 guard
+    /// is reached). It passes both before and after the fix; its role is to pin
+    /// the CR 712.14a-2nd-sentence path against the SF1 guard rewrite ever being
+    /// regressed to a front-face fallback on the full-pipeline route.
+    #[test]
+    fn single_faced_object_instructed_enter_transformed_remains() {
+        let mut state = GameState::new_two_player(42);
+        let object_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Single Faced".to_string(),
+            Zone::Exile,
+        );
+        {
+            let obj = state.objects.get_mut(&object_id).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            // back_face intentionally left None (single-faced).
+        }
+
+        let mut events = Vec::new();
+        let result = execute_zone_move_with_terminal(
+            &mut state,
+            object_id,
+            Zone::Exile,
+            Zone::Battlefield,
+            object_id,
+            None,
+            true, // enter_transformed
+            EtbTapState::Unspecified,
+            false,
+            None,
+            &[],
+            None,
+            false,
+            None,
+            None,
+            &mut events,
+        );
+
+        assert!(
+            matches!(
+                result,
+                ZoneMoveTerminalResult::Completed(ZoneMoveCompletion::Remained)
+            ),
+            "CR 712.14a 2nd sentence: a single-faced object instructed to enter \
+             transformed must remain"
+        );
+        assert_eq!(
+            state.objects[&object_id].zone,
+            Zone::Exile,
+            "the single-faced object must stay in Exile"
+        );
+    }
+
+    /// CR 712.14a CONTROL: a DFC with a PERMANENT front face (Creature) and a
+    /// PERMANENT back face (Land) instructed to enter transformed still lands in
+    /// Battlefield and ends up transformed. Passes before and after the fix — the
+    /// entry-face rewrite must not be front-regressive, and `transform_permanent`
+    /// must still fire after the guarded entry.
+    #[test]
+    fn mdfc_permanent_front_transformed_entry_still_lands() {
+        use crate::game::game_object::BackFaceData;
+
+        let mut state = GameState::new_two_player(42);
+        let object_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "MDFC Front".to_string(),
+            Zone::Exile,
+        );
+        {
+            let obj = state.objects.get_mut(&object_id).unwrap();
+            obj.card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec![],
+            };
+            obj.base_card_types = obj.card_types.clone();
+            obj.back_face = Some(BackFaceData {
+                name: "MDFC Back".to_string(),
+                power: None,
+                toughness: None,
+                loyalty: None,
+                printed_loyalty: None,
+                defense: None,
+                card_types: CardType {
+                    supertypes: vec![],
+                    core_types: vec![CoreType::Land],
+                    subtypes: vec![],
+                },
+                mana_cost: crate::types::mana::ManaCost::default(),
+                keywords: vec![],
+                abilities: vec![],
+                trigger_definitions: Default::default(),
+                replacement_definitions: Default::default(),
+                static_definitions: Default::default(),
+                color: vec![],
+                printed_ref: None,
+                modal: None,
+                additional_cost: None,
+                strive_cost: None,
+                casting_restrictions: vec![],
+                casting_options: vec![],
+                layout_kind: None,
+                parse_warnings: vec![],
+            });
+        }
+
+        let mut events = Vec::new();
+        let result = execute_zone_move_with_terminal(
+            &mut state,
+            object_id,
+            Zone::Exile,
+            Zone::Battlefield,
+            object_id,
+            None,
+            true, // enter_transformed
+            EtbTapState::Unspecified,
+            false,
+            None,
+            &[],
+            None,
+            false,
+            None,
+            None,
+            &mut events,
+        );
+
+        assert!(
+            matches!(result, ZoneMoveTerminalResult::Completed(_)),
+            "the DFC entered the battlefield and completed the move"
+        );
+        let obj = state.objects.get(&object_id).unwrap();
+        assert_eq!(
+            obj.zone,
+            Zone::Battlefield,
+            "a permanent-front DFC entering transformed must land on the battlefield"
+        );
+        assert!(
+            obj.transformed,
+            "CR 712.14a: the DFC must be transformed (back face) after this entry"
         );
     }
 }

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -965,11 +965,59 @@ pub fn apply_resolved_zone_change(
 }
 
 /// CR 400.7: Move an object to a new zone. An object that moves to a new zone becomes a new object.
+///
+/// Plain-entry convenience wrapper: delegates to
+/// [`move_to_zone_with_entry_flags`] with `enter_transformed = false`, so
+/// every existing call site that does not instruct an effect-driven
+/// transformed entry is unchanged. Only the plain-fallback branch of
+/// `deliver_replaced_zone_change` threads the flag through the
+/// `with_entry_flags` form.
 pub fn move_to_zone(
+    state: &mut GameState,
+    object_id: ObjectId,
+    to: Zone,
+    events: &mut Vec<GameEvent>,
+) {
+    move_to_zone_with_entry_flags(state, object_id, to, events, false);
+}
+
+/// CR 400.7: Move an object to a new zone. An object that moves to a new zone becomes a new object.
+///
+/// `enter_transformed` (CR 712.14a) is the transient, single-authority "enters
+/// with its back face up" intent carried LIVE from the post-replacement
+/// `ProposedEvent::ZoneChange.enter_transformed` into the battlefield-entry
+/// guard below. It is a synchronous parameter for this one delivery — never a
+/// stored/written `GameState` field.
+///
+/// WHY a parameter rather than a transient `obj.transformed` marker: CR 712.8a
+/// (zones.rs:291-298) reverts a transformed permanent to its front face on any
+/// non-battlefield zone exit, and the post-move transform itself
+/// (zone_pipeline.rs:3670, `transform_permanent`, CR 712.14a) executes the same
+/// face swap when the object reaches the battlefield. A pre-move transient
+/// `transformed` flag would survive into that authoritative swap and
+/// double-corrupt the face (CR 712.8a exit revert + post-move transform both
+/// mutating `back_face`/the live face). The parameter carries the intent without
+/// touching object state. (The `modal_back_face` revert at zones.rs:301-310 is
+/// a SEPARATE MDFC mechanism and is not implicated.)
+///
+/// SF1 asymmetry: a single-faced object (`back_face.is_none()`) instructed to
+/// enter transformed can never enter that way — CR 712.14a (2nd sentence)
+/// requires a back face, and the object's FRONT-face core types must NOT be
+/// consulted as a fallback for the CR 307.4 / CR 400.4a eligibility check. The
+/// asymmetric guard below therefore returns before any core-type consult.
+///
+/// A3 (no post-move re-assert): unlike the face-down entry profile's
+/// re-assertion authority (`apply_face_down_entry_profile` in zone_pipeline.rs),
+/// a transformed entry needs no analogous re-assert after the move.
+/// `transform_permanent` (zone_pipeline.rs:3687) is the SINGLE authoritative
+/// post-move face swap and already runs on `to == Zone::Battlefield`, so the
+/// guard here only gates eligibility — it never mutates the face.
+pub(crate) fn move_to_zone_with_entry_flags(
     state: &mut GameState,
     object_id: ObjectId,
     mut to: Zone,
     events: &mut Vec<GameEvent>,
+    enter_transformed: bool,
 ) {
     // CR 111.8: A token that has left the battlefield can't move to another zone
     // or come back onto the battlefield — "if such a token would change zones, it
@@ -1027,13 +1075,36 @@ pub fn move_to_zone(
             if is_blocked_from_entering_battlefield(state, obj) {
                 return;
             }
+            // CR 712.14a (2nd sentence) + CR 712.8e: a transformed entry reads
+            // the BACK face's card types for the CR 307.4 / CR 400.4a
+            // eligibility check (CR 712.8e: "read from its back face"). A
+            // single-faced object instructed to enter transformed has no back
+            // face, so it can never enter that way — and its FRONT face's
+            // permanent types must NOT be consulted as a fallback (CR 712.14a
+            // 2nd sentence). This asymmetric guard precedes any core-type
+            // consult so the front face is never used for a transformed entry.
+            if enter_transformed && obj.back_face.is_none() {
+                return; // CR 712.14a: no back face -> remain in previous zone
+            }
+            let entry_core_types = if enter_transformed {
+                // CR 712.14a + CR 712.8e: eligibility reads the back face's core
+                // types. `back_face` is guaranteed `Some` after the guard above;
+                // the `unwrap_or_default()` empty-slice is an unreachable
+                // safeguard (present only so the borrow stays total).
+                obj.back_face
+                    .as_ref()
+                    .map(|b| b.card_types.core_types.as_slice())
+                    .unwrap_or_default()
+            } else {
+                obj.card_types.core_types.as_slice()
+            };
             // CR 304.4 / CR 307.4 / CR 400.4a: Instants and sorceries can't enter
             // the battlefield. Skip for face-down (morph/manifest) and objects with
-            // a permanent type (MDFC back faces).
+            // a permanent type (DFC/MDFC back faces).
             if !obj.face_down
-                && (obj.card_types.core_types.contains(&CoreType::Instant)
-                    || obj.card_types.core_types.contains(&CoreType::Sorcery))
-                && !obj.card_types.core_types.iter().any(|ct| {
+                && (entry_core_types.contains(&CoreType::Instant)
+                    || entry_core_types.contains(&CoreType::Sorcery))
+                && !entry_core_types.iter().any(|ct| {
                     matches!(
                         ct,
                         // CR 110.4: Permanent types
@@ -3666,6 +3737,220 @@ mod tests {
 
         // Should enter because it has a permanent type (Creature)
         assert_eq!(state.objects[&id].zone, Zone::Battlefield);
+    }
+
+    /// CR 712.14a + CR 712.8e: a DFC whose FRONT face is a Sorcery (non-permanent)
+    /// can still enter the battlefield when it is instructed to enter TRANSFORMED
+    /// (back face up) — eligibility reads the BACK face's core types (a Creature,
+    /// a permanent type, CR 110.4), so the CR 307.4 / CR 400.4a reject is bypassed.
+    ///
+    /// REVERT-CATCHER: flips red if the entry-face rewrite (reading the back
+    /// face for a transformed entry) is removed — the front Sorcery type would
+    /// then trip the instant/sorcery guard and the DFC would stay in hand.
+    #[test]
+    fn transform_entry_sorcery_front_creature_back_allowed_via_flag() {
+        use crate::game::game_object::BackFaceData;
+        use crate::types::card_type::CardType;
+
+        let mut state = setup();
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Esper Origins".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Sorcery],
+                subtypes: vec![],
+            };
+            obj.base_card_types = obj.card_types.clone();
+            obj.back_face = Some(BackFaceData {
+                name: "Summon: Esper Maduin".to_string(),
+                power: None,
+                toughness: None,
+                loyalty: None,
+                printed_loyalty: None,
+                defense: None,
+                card_types: CardType {
+                    supertypes: vec![],
+                    core_types: vec![CoreType::Creature],
+                    subtypes: vec![],
+                },
+                mana_cost: crate::types::mana::ManaCost::default(),
+                keywords: vec![],
+                abilities: vec![],
+                trigger_definitions: Default::default(),
+                replacement_definitions: Default::default(),
+                static_definitions: Default::default(),
+                color: vec![],
+                printed_ref: None,
+                modal: None,
+                additional_cost: None,
+                strive_cost: None,
+                casting_restrictions: vec![],
+                casting_options: vec![],
+                layout_kind: None,
+                parse_warnings: vec![],
+            });
+        }
+
+        let mut events = Vec::new();
+        move_to_zone_with_entry_flags(&mut state, id, Zone::Battlefield, &mut events, true);
+
+        assert_eq!(
+            state.objects[&id].zone,
+            Zone::Battlefield,
+            "CR 712.14a + CR 712.8e: a transformed entry reads the back face's \
+             Creature (permanent, CR 110.4) type and is permitted by CR 400.4a"
+        );
+    }
+
+    /// CR 307.4 / CR 400.4a negative reach-guard: the SAME Sorcery//Creature DFC
+    /// entering through the PUBLIC `move_to_zone` (enter_transformed = false) is
+    /// rejected — its FRONT Sorcery face falls to the instant/sorcery guard. This
+    /// proves the transformed-entry carve-out is conditioned on `enter_transformed`
+    /// and is never unconditional.
+    #[test]
+    fn transform_entry_sorcery_front_rejected_without_flag() {
+        use crate::game::game_object::BackFaceData;
+        use crate::types::card_type::CardType;
+
+        let mut state = setup();
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Esper Origins".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&id).unwrap();
+            obj.card_types = CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Sorcery],
+                subtypes: vec![],
+            };
+            obj.base_card_types = obj.card_types.clone();
+            obj.back_face = Some(BackFaceData {
+                name: "Summon: Esper Maduin".to_string(),
+                power: None,
+                toughness: None,
+                loyalty: None,
+                printed_loyalty: None,
+                defense: None,
+                card_types: CardType {
+                    supertypes: vec![],
+                    core_types: vec![CoreType::Creature],
+                    subtypes: vec![],
+                },
+                mana_cost: crate::types::mana::ManaCost::default(),
+                keywords: vec![],
+                abilities: vec![],
+                trigger_definitions: Default::default(),
+                replacement_definitions: Default::default(),
+                static_definitions: Default::default(),
+                color: vec![],
+                printed_ref: None,
+                modal: None,
+                additional_cost: None,
+                strive_cost: None,
+                casting_restrictions: vec![],
+                casting_options: vec![],
+                layout_kind: None,
+                parse_warnings: vec![],
+            });
+        }
+
+        let mut events = Vec::new();
+        move_to_zone(&mut state, id, Zone::Battlefield, &mut events);
+
+        assert_eq!(
+            state.objects[&id].zone,
+            Zone::Hand,
+            "CR 307.4 / CR 400.4a: without enter_transformed the front Sorcery \
+             face cannot enter the battlefield"
+        );
+        assert!(state.players[0].hand.contains(&id));
+    }
+
+    /// CR 712.14a (2nd sentence) — SF1 asymmetric branch, DIRECT reach-guard: a
+    /// SINGLE-FACED permanent-front object (`back_face = None`) instructed to
+    /// enter transformed can NEVER enter, even though its front face is a
+    /// creature. `move_to_zone_with_entry_flags(..., true)` drives the wrapper
+    /// directly, bypassing the zone_pipeline single-faced early-return (so only
+    /// this guard's SF1 branch is exercised).
+    ///
+    /// REVERT-CATCHER for SF1: if the asymmetric guard were removed or regressed
+    /// to a front-face fallback, this single-faced Creature-with-flag=true call
+    /// would land in Battlefield and this test flips red.
+    #[test]
+    fn transform_entry_single_faced_permanent_front_rejected_with_flag() {
+        let mut state = setup();
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Single-Faced".to_string(),
+            Zone::Hand,
+        );
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        // back_face intentionally left None (single-faced; the GameState default).
+
+        let mut events = Vec::new();
+        move_to_zone_with_entry_flags(&mut state, id, Zone::Battlefield, &mut events, true);
+
+        assert_eq!(
+            state.objects[&id].zone,
+            Zone::Hand,
+            "CR 712.14a (2nd sentence): a single-faced object cannot enter transformed"
+        );
+        assert!(state.players[0].hand.contains(&id));
+    }
+
+    /// CR 712.14a + CR 400.4a positive reach-guard pairing the SF1 rejection: the
+    /// SAME single-faced permanent-front fixture entering through the PUBLIC
+    /// `move_to_zone` (enter_transformed = false) lands in Battlefield. Proves the
+    /// rejection above is conditioned on `enter_transformed`, NOT on
+    /// single-facedness — a bare single-faced Creature on a plain entry has no
+    /// instant/sorcery type on the entry face, so CR 400.4a passes.
+    #[test]
+    fn transform_entry_single_faced_permanent_front_allowed_without_flag() {
+        let mut state = setup();
+        let id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Single-Faced".to_string(),
+            Zone::Hand,
+        );
+        state
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        // back_face intentionally left None (single-faced).
+
+        let mut events = Vec::new();
+        move_to_zone(&mut state, id, Zone::Battlefield, &mut events);
+
+        assert_eq!(
+            state.objects[&id].zone,
+            Zone::Battlefield,
+            "CR 400.4a: a single-faced Creature on a plain entry is a permanent and \
+             enters normally"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -44522,7 +44522,7 @@ fn put_zone_change_lifts_with_counters_suffix() {
     }
 }
 
-/// CR 701.28c + CR 122.1 — Esper Origins class:
+/// CR 712.14a + CR 701.27 + CR 122.1 — Esper Origins class:
 /// "put it onto the battlefield transformed ... with a finality counter"
 /// must carry both the transformed entry flag and the counter replacement.
 #[test]

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1515,7 +1515,7 @@ pub(crate) enum PutImperativeAst {
         enters_under: EntersUnderSpec,
         /// CR 603.6d: "enters tapped" — enters the battlefield tapped.
         enter_tapped: bool,
-        /// CR 701.28c: "transformed" — enters with its back face up.
+        /// CR 712.14a: "transformed" — enters with its back face up.
         enter_transformed: bool,
         /// CR 508.4: "tapped and attacking [<player_phrase>]" — the moved
         /// object enters the battlefield as an attacking creature (without

--- a/crates/engine/tests/integration/esper_origins_flashback_transform.rs
+++ b/crates/engine/tests/integration/esper_origins_flashback_transform.rs
@@ -1,0 +1,171 @@
+//! Verification for the reported Esper Origins bug: cast from the graveyard,
+//! the spell must exile itself and then re-enter the battlefield TRANSFORMED
+//! (back face: Summon: Esper Maduin) with a finality counter — not end exiled.
+//!
+//! Front face Oracle (verbatim, MTGJSON):
+//!   "Surveil 2. You gain 2 life. If this spell was cast from a graveyard,
+//!    exile it, then put it onto the battlefield transformed under its owner's
+//!    control with a finality counter on it. (...)
+//!    Flashback {3}{G} (...)"
+//!
+//! The ONLY way to cast Esper Origins from a graveyard is via Flashback
+//! (CR 702.34a), so the flashback path is exercised through the full cast
+//! pipeline (`runner.cast(..).casting_variant(CastingVariant::Flashback)`.
+
+use engine::game::game_object::BackFaceData;
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::counter::CounterType;
+use engine::types::game_state::CastingVariant;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+/// Verbatim front-face Oracle text from MTGJSON (FINAL — Esper Origins).
+const ESPER_ORIGINS_ORACLE: &str = "Surveil 2. You gain 2 life. If this spell was cast from a \
+graveyard, exile it, then put it onto the battlefield transformed under its owner's control with \
+a finality counter on it. (If a creature with a finality counter on it would die, exile it \
+instead.)\nFlashback {3}{G} (You may cast this card from your graveyard for its flashback cost. \
+Then exile it.)";
+
+/// Build the canonical board: Esper Origins in P0's graveyard (front face +
+/// Flashback from the Oracle text), its back face (Summon: Esper Maduin, a
+/// 4/4 Enchantment Creature — Saga Elemental), and a pool able to pay the
+/// Flashback cost {3}{G}.
+fn stage_esper_origins_in_graveyard() -> (engine::game::scenario::GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_graveyard(P0, "Esper Origins", false)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 1,
+        })
+        .from_oracle_text(ESPER_ORIGINS_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    {
+        let obj = runner.state_mut().objects.get_mut(&spell).unwrap();
+        let mut card_types = CardType::default();
+        card_types.core_types.push(CoreType::Enchantment);
+        card_types.core_types.push(CoreType::Creature);
+        card_types.subtypes = vec!["Saga".to_string(), "Elemental".to_string()];
+        obj.back_face = Some(BackFaceData {
+            name: "Summon: Esper Maduin".to_string(),
+            power: Some(4),
+            toughness: Some(4),
+            loyalty: None,
+            printed_loyalty: None,
+            defense: None,
+            card_types,
+            mana_cost: ManaCost::default(),
+            keywords: vec![],
+            abilities: vec![],
+            trigger_definitions: Default::default(),
+            replacement_definitions: Default::default(),
+            static_definitions: Default::default(),
+            color: vec![],
+            printed_ref: None,
+            modal: None,
+            additional_cost: None,
+            strive_cost: None,
+            casting_restrictions: vec![],
+            casting_options: vec![],
+            layout_kind: None,
+            parse_warnings: vec![],
+        });
+    }
+    // Float {3}{G} to pay the Flashback cost.
+    runner.state_mut().add_mana_to_pool(
+        P0,
+        ManaUnit::new(ManaType::Green, ObjectId(0), false, vec![]),
+    );
+    for _ in 0..3 {
+        runner.state_mut().add_mana_to_pool(
+            P0,
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+        );
+    }
+    (runner, spell)
+}
+
+/// The reported behavior is "only exiled". Correct behavior (the card's Oracle
+/// text): exile it, THEN put it onto the battlefield transformed with a
+/// finality counter.
+#[test]
+fn esper_origins_flashback_cast_enters_transformed_with_finality_counter() {
+    let (mut runner, spell) = stage_esper_origins_in_graveyard();
+
+    let outcome = runner
+        .cast(spell)
+        .casting_variant(CastingVariant::Flashback)
+        .resolve();
+
+    // If the bug reproduces, this assertion fails: the card sits in exile.
+    outcome.assert_zone(&[spell], Zone::Battlefield);
+
+    let obj = &outcome.state().objects[&spell];
+    assert!(
+        obj.transformed,
+        "CR 701.27: the spell must enter on its back face (Summon: Esper Maduin)"
+    );
+    assert_eq!(
+        obj.name, "Summon: Esper Maduin",
+        "CR 701.27a: a DFC entering transformed shows its back face"
+    );
+    assert_eq!(
+        outcome.counters(spell, CounterType::Finality),
+        1,
+        "CR 122.1h: must enter with a finality counter"
+    );
+    // The spell's spell-level effects still ran: Surveil 2 + gain 2 life.
+    outcome.assert_life_delta(P0, 2);
+    assert!(
+        matches!(
+            outcome.final_waiting_for(),
+            engine::types::game_state::WaitingFor::Priority { .. }
+        ),
+        "resolution must complete back to a priority window"
+    );
+}
+
+/// Positive control for the same staged board: a spell with NO cast-from-zone
+/// condition must never offer the flashback cast at all — proving the tester
+/// cannot accidentally pass the transformed-entry assertion by the engine
+/// ignoring the cast origin gate (foot-gun 6 reach-guard).
+#[test]
+fn esper_origins_flashback_requires_graveyard_origin_gate() {
+    // Same verbatim text staged in the HAND instead: flashback is a
+    // graveyard-only keyword (CR 702.34a), so the spell must NOT be castable
+    // from hand via the flashback variant.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Esper Origins", false, ESPER_ORIGINS_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 1,
+        })
+        .id();
+    let mut runner = scenario.build();
+    for _ in 0..4 {
+        runner.state_mut().add_mana_to_pool(
+            P0,
+            ManaUnit::new(ManaType::Green, ObjectId(0), false, vec![]),
+        );
+    }
+
+    // From hand there is no flashback offer; the normal cast is {1}{G} and
+    // does NOT transform (the transformed-entry branch requires the
+    // WasCast{Graveyard} condition). Drive the normal cast through the same
+    // pipeline and assert the ordinary sorcery outcome.
+    let outcome = runner.cast(spell).resolve();
+    outcome.assert_zone(&[spell], Zone::Graveyard);
+    let obj = &outcome.state().objects[&spell];
+    assert!(
+        !obj.transformed,
+        "a hand cast must resolve as the front sorcery"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -201,6 +201,7 @@ mod enlightened_tutor_regression;
 mod equipment_etb_attach_parent_target;
 mod ertai_trickery_counter_kicked;
 mod escape_tunnel_landfall;
+mod esper_origins_flashback_transform;
 mod etali_primal_sickness_poison;
 mod etrata_cloak_enters_under_cloaker_5944;
 mod evelyn_regression;


### PR DESCRIPTION
## Summary

Fixes transforming cards with a non-permanent front face (Esper Origins: Sorcery // Summon: Esper Maduin) cast from a graveyard via Flashback being stranded in exile: the CR 307.4/400.4a battlefield-entry guard saw the front Sorcery face because the transform face swap is deferred until after the move, so the effect-driven "enters transformed" intent is now carried into the guard as a synchronous parameter (`move_to_zone_with_entry_flags`), which evaluates the entry face's core types (back face, CR 712.14a/712.8e) and rejects single-faced transformed entries (CR 712.14a 2nd sentence). Also corrects Transform/Convert CR mis-annotations (701.27 vs 701.28c).

## Files changed

- `crates/engine/src/game/zones.rs` — `move_to_zone` split into thin public wrapper + `move_to_zone_with_entry_flags`; entry guard reads entry-face core types (back face when transformed) with asymmetric single-faced rejection; 4 new wrapper tests.
- `crates/engine/src/game/zone_pipeline.rs` — threads `should_transform` into the entry guard at the plain-fallback delivery; 2 new building-block tests.
- `crates/engine/src/game/triggers.rs` — 2 CR annotations corrected (701.28 → 701.27).
- `crates/engine/src/parser/oracle_ir/ast.rs` — 1 CR annotation corrected (701.28c → 712.14a).
- `crates/engine/src/parser/oracle_effect/tests.rs` — 1 CR annotation corrected (701.28c + 122.1 → 712.14a + 701.27 + 122.1).
- `crates/engine/tests/integration/esper_origins_flashback_transform.rs` — new regression test + hand-cast gate control.
- `crates/engine/tests/integration/main.rs` — `mod esper_origins_flashback_transform;`.

## Track

Developer

## LLM

Model: deepseek-v4-flash-0731
Tier: Frontier
Thinking: max

## Implementation method (required)

Method: /engine-implementer

## CR references

Annotations added:
- `CR 712.14a` — `crates/engine/src/game/zones.rs`: asymmetric single-faced rejection (`enter_transformed && back_face.is_none()` → remain) plus the guard's entry-face eligibility read; `crates/engine/src/game/zone_pipeline.rs`: `should_transform` threaded into the entry guard at the plain-fallback delivery.
- `CR 712.8e` — `zones.rs`: a transformed entry's eligibility check reads the back face's core types.
- `CR 712.8a` — `zones.rs` doc note: why `enter_transformed` is a parameter (a transient `transformed` flag would collide with the zone-exit revert at `zones.rs:291-298` and the post-move swap).
- `CR 307.4` / `CR 400.4a` — `zones.rs`: the instant/sorcery battlefield-entry guard rewritten to evaluate the entry face.
- `CR 110.4` — `zones.rs`: the six permanent types listed in the rewritten guard.

Annotations corrected (701.28 = Convert → 701.27 = Transform):
- `CR 701.27` — `crates/engine/src/game/triggers.rs` (two Ajani transform-on-reentry annotations: 24788, 24883), `crates/engine/src/parser/oracle_effect/tests.rs:44522`.
- `CR 712.14a` — `crates/engine/src/parser/oracle_ir/ast.rs:1515` (`ZoneChange.enter_transformed` was `CR 701.28c`).
- `CR 122.1` — `crates/engine/src/parser/oracle_effect/tests.rs:44522` (kept).

Carried in the bootstrap test (`esper_origins_flashback_transform.rs`): `CR 701.27`, `CR 701.27a`, `CR 702.34a`, `CR 122.1h`.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — clean
- `cargo clippy --all-targets -- -D warnings` — clean
- `cargo test -p phase-engine --test integration esper_origins_flashback` — 2 passed (Esper Origins flashback regression now green; hand-cast gate control green)
- `cargo test -p phase-engine --lib transform_entry_ / effect_driven_transformed_entry` — 6 passed (4 zones.rs wrapper + 2 zone_pipeline.rs building-block tests)
- `cargo test -p phase-engine` — 4906 passed, 0 failed, 2 ignored

## Gate A

Gate A PASS head=057451487902a6eed2f116c5f46954c8dc44b67e base=4d7909bb0a968480ab2a9b08ecc4eacb06c43fec

## Anchored on

- crates/engine/src/game/zones.rs:1104 — existing `!obj.face_down` carve-out in the same CR 307.4/400.4a entry guard (the analogous vehicle for the face-down preflight carry; the new entry-face check extends this carve-out family).
- crates/engine/src/game/zone_pipeline.rs:4003-4011 — pre-existing `enter_transformed && back_face.is_none()` → `Remained` early-return (existing CR 712.14a single-faced rejection whose direct-wrapper counterpart is the new asymmetric guard).

## Final review-impl

Final review-impl PASS head=057451487902a6eed2f116c5f46954c8dc44b67e

## Claimed parse impact

None.
<!-- List exact card names only when the parse-diff changes cards. -->

## Scope Expansion

None.
<!-- Describe any change that crosses the issue/card's stated scope. -->

## Validation Failures

None.
<!-- Replace with the unresolved validation failure and its evidence. -->

## CI Failures

None.
<!-- Replace with the unresolved CI failure and its evidence. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Flashback can now correctly put transforming double-faced cards onto the battlefield transformed.
  * Transformed battlefield entries now validate the card’s back-face types correctly.
  * Single-faced cards cannot incorrectly enter the battlefield transformed.

* **Bug Fixes**
  * Preserved normal casting behavior and existing zone-change rules.

* **Tests**
  * Added integration coverage for transformed Flashback, counters, life gain, surveil, and invalid single-faced transformations.
  * Updated rules references in related test documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->