### PR TITLE
Fix Vincent's Limit Break

### DIFF
--- a/crates/engine/tests/integration/vincents_limit_break_tiered.rs
+++ b/crates/engine/tests/integration/vincents_limit_break_tiered.rs
@@ -28,6 +28,7 @@ use engine::game::scenario::{GameScenario, P0};
 use engine::types::counter::CounterType;
 use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
+use engine::types::zones::Zone;
 
 const VINCENTS_ORACLE: &str = "Tiered (Choose one additional cost.)\n\
     Until end of turn, target creature you control gains \"When this creature dies, return it to the battlefield tapped under its owner's control\" and has the chosen base power and toughness.\n\
@@ -153,6 +154,55 @@ fn set_base_pt_applies_before_counter_layer() {
         outcome.power_toughness(creature),
         (4, 3),
         "base set 3/2 (7b) then +1/+1 counter (7c) = 4/3"
+    );
+}
+
+/// CR 603.6c + CR 603.10a + CR 400.7j: the temporary GrantTrigger supplied by
+/// Vincent's selected mode must use last-known information when the creature
+/// dies, then return that new object tapped under its owner's control. The
+/// lethal damage is dealt by a second spell through the normal cast pipeline,
+/// rather than moving the creature directly between zones.
+#[test]
+fn granted_dies_trigger_returns_selected_creature_tapped() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let creature = scenario.add_vanilla(P0, 2, 2);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Vincent's Limit Break", true, VINCENTS_ORACLE)
+        .with_mana_cost(base_cost())
+        .id();
+    let lethal_damage = scenario
+        .add_spell_to_hand_from_oracle(P0, "Shock", true, "Shock deals 3 damage to any target.")
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    scenario.with_mana_pool(P0, black_pool(4));
+
+    let mut runner = scenario.build();
+    runner
+        .cast(spell)
+        .modes(&[0])
+        .target_object(creature)
+        .resolve();
+
+    runner.cast(lethal_damage).target_object(creature).resolve();
+
+    let returned = &runner.state().objects[&creature];
+    assert_eq!(
+        returned.zone,
+        Zone::Battlefield,
+        "the granted trigger must return the dead creature to the battlefield"
+    );
+    assert_eq!(
+        returned.owner, P0,
+        "the returned creature must remain under its owner's identity"
+    );
+    assert_eq!(
+        returned.controller, P0,
+        "the granted trigger must return the creature under its owner's control"
+    );
+    assert!(
+        returned.tapped,
+        "the granted trigger must return the creature tapped"
     );
 }
 

--- a/crates/engine/tests/integration/vincents_limit_break_tiered.rs
+++ b/crates/engine/tests/integration/vincents_limit_break_tiered.rs
@@ -24,7 +24,9 @@
 //! CR 613.4b: layer 7b sets the chosen base power/toughness.
 //! CR 601.2f: the additional cost is part of the spell's total cost.
 
-use engine::game::scenario::{GameScenario, P0};
+use engine::game::engine::apply_as_current;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
 use engine::types::counter::CounterType;
 use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
@@ -157,7 +159,7 @@ fn set_base_pt_applies_before_counter_layer() {
     );
 }
 
-/// CR 603.6c + CR 603.10a + CR 400.7j: the temporary GrantTrigger supplied by
+/// CR 603.6c + CR 603.10a + CR 400.7e: the temporary GrantTrigger supplied by
 /// Vincent's selected mode must use last-known information when the creature
 /// dies, then return that new object tapped under its owner's control. The
 /// lethal damage is dealt by a second spell through the normal cast pipeline,
@@ -166,7 +168,16 @@ fn set_base_pt_applies_before_counter_layer() {
 fn granted_dies_trigger_returns_selected_creature_tapped() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
-    let creature = scenario.add_vanilla(P0, 2, 2);
+    let creature = scenario.add_vanilla(P1, 2, 2);
+    let gain_control = scenario
+        .add_spell_to_hand_from_oracle(
+            P0,
+            "Temporary Control",
+            true,
+            "Gain control of target creature until end of turn.",
+        )
+        .with_mana_cost(ManaCost::zero())
+        .id();
     let spell = scenario
         .add_spell_to_hand_from_oracle(P0, "Vincent's Limit Break", true, VINCENTS_ORACLE)
         .with_mana_cost(base_cost())
@@ -178,26 +189,51 @@ fn granted_dies_trigger_returns_selected_creature_tapped() {
     scenario.with_mana_pool(P0, black_pool(4));
 
     let mut runner = scenario.build();
+    runner.cast(gain_control).target_object(creature).resolve();
+    assert_eq!(runner.state().objects[&creature].owner, P1);
+    assert_eq!(runner.state().objects[&creature].controller, P0);
+
     runner
         .cast(spell)
         .modes(&[0])
         .target_object(creature)
         .resolve();
 
-    runner.cast(lethal_damage).target_object(creature).resolve();
+    let mut committed = runner.cast(lethal_damage).target_object(creature).commit();
+    apply_as_current(committed.state_mut(), GameAction::PassPriority)
+        .expect("P0 passes priority for Shock");
+    apply_as_current(committed.state_mut(), GameAction::PassPriority)
+        .expect("P1 passes priority for Shock");
 
-    let returned = &runner.state().objects[&creature];
+    let pending = committed.state();
+    assert_eq!(
+        pending.objects[&creature].zone,
+        Zone::Graveyard,
+        "state-based actions must move the creature to its graveyard before the dies trigger resolves"
+    );
+    assert_eq!(
+        pending.stack.len(),
+        1,
+        "the granted dies trigger must be pending on the stack after the death"
+    );
+
+    apply_as_current(committed.state_mut(), GameAction::PassPriority)
+        .expect("P0 passes priority for the granted dies trigger");
+    apply_as_current(committed.state_mut(), GameAction::PassPriority)
+        .expect("P1 passes priority for the granted dies trigger");
+
+    let returned = &committed.state().objects[&creature];
     assert_eq!(
         returned.zone,
         Zone::Battlefield,
         "the granted trigger must return the dead creature to the battlefield"
     );
     assert_eq!(
-        returned.owner, P0,
+        returned.owner, P1,
         "the returned creature must remain under its owner's identity"
     );
     assert_eq!(
-        returned.controller, P0,
+        returned.controller, P1,
         "the granted trigger must return the creature under its owner's control"
     );
     assert!(


### PR DESCRIPTION
## Summary

Hardens the cast-pipeline coverage for Vincent's Limit Break's temporary dies trigger. The test now distinguishes ownership from temporary control, observes the creature in its graveyard with the trigger pending, and verifies return under its owner's control.

## Files changed

- `crates/engine/tests/integration/vincents_limit_break_tiered.rs` — hardens the granted dies-trigger runtime regression test.

## Track

Developer

## LLM

Model: gpt-5.6
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer (coverage-only follow-up; the production Tiered implementation is already on `upstream/main`)

## CR references

CR 603.6c + CR 603.10a + CR 400.7e — leaves-the-battlefield trigger uses last-known information and finds the new object in its first public post-zone-change zone.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — PASS.
- `git diff --check` — PASS.
- `./scripts/check-parser-combinators.sh` — PASS; Gate A output below.
- `cargo test -p phase-engine --test integration vincents_limit_break_tiered -- --nocapture` with `CARGO_BUILD_JOBS=1` — CI-owned alternative required: local `rustc` was terminated with SIGTERM while compiling `phase-engine`, with no compiler diagnostics.
- `cargo coverage` and `cargo semantic-audit` — previously attempted on the same branch and likewise terminated by local `rustc` SIGTERM before execution; CI-owned alternatives remain required.

## Gate A

Gate A PASS head=edee1699d1e4d7b7094955ae41371e0bd9ab9974 base=e2355987c9a89fee6a8b9c6b39d9bbb7641ac45d

## Anchored on

- `crates/engine/src/parser/oracle_modal.rs:489` — existing Tiered shared-effect distributor, which substitutes per-mode values and reuses modal lowering.
- `crates/engine/src/parser/oracle_static/keyword_grant.rs:1914` — existing quoted-ability `GrantTrigger` lowering used by the card's temporary dies trigger.
- `crates/engine/tests/integration/undying_malice_edict_sacrifice_5942.rs:72` — existing cast/zone-change runtime coverage for a creature's granted dies-return trigger.

## Final review-impl

Final review-impl PASS head=edee1699d1e4d7b7094955ae41371e0bd9ab9974

## Claimed parse impact

None.

## Scope Expansion

None. The change remains limited to the existing engine integration test for Vincent's Limit Break; it does not touch protected architecture paths, transport layers, frontend code, or card-data generation.

## Validation Failures

None.

## CI Failures

Local targeted compilation was retried with `CARGO_BUILD_JOBS=1` and the environment again terminated `rustc` by SIGTERM while compiling `phase-engine`, without compiler diagnostics. CI should run the targeted test and the audit commands on the pushed commit.
