### PR TITLE
fix(mp): stop hosting from doubling the engine's memory footprint

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-broker.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-broker.test.ts
@@ -40,7 +40,7 @@ vi.mock("../../network/protocol", async (orig) => {
 
 
 const mocks = vi.hoisted(() => ({
-  initializeGame: vi.fn(async () => ({ events: [] })),
+  initializeMultiplayerHostGame: vi.fn(async () => ({ events: [] })),
   getLegalActions: vi.fn(async () => ({
     actions: [],
     autoPassRecommended: false,
@@ -71,23 +71,28 @@ const mocks = vi.hoisted(() => ({
   setMultiplayerMode: vi.fn(async (_enabled: boolean) => undefined),
 }));
 
-vi.mock("../wasm-adapter", () => ({
-  WasmAdapter: vi.fn().mockImplementation(function () {
-    return {
-      initialize: vi.fn(async () => undefined),
-      initializeGame: mocks.initializeGame,
-      submitAction: vi.fn(async () => ({ events: [] })),
-      getState: vi.fn(async () => ({})),
-      getLegalActions: mocks.getLegalActions,
-      getLegalActionsForViewer: mocks.getLegalActionsForViewer,
-      getFilteredState: mocks.getFilteredState,
-      getViewerSnapshot: mocks.getViewerSnapshot,
-      projectSeatView: mocks.projectSeatView,
-      setMultiplayerMode: mocks.setMultiplayerMode,
-      dispose: vi.fn(),
-    };
-  }),
-}));
+// Mirrors `p2p-adapter-multiplayer.test.ts`: the host acquires its engine via
+// `getHostAdapter()`, and teardown goes through `releaseHostSession()`.
+vi.mock("../wasm-adapter", () => {
+  const createEngine = () => ({
+    initialize: vi.fn(async () => undefined),
+    initializeMultiplayerHostGame: mocks.initializeMultiplayerHostGame,
+    submitAction: vi.fn(async () => ({ events: [] })),
+    getState: vi.fn(async () => ({})),
+    getLegalActions: mocks.getLegalActions,
+    getLegalActionsForViewer: mocks.getLegalActionsForViewer,
+    getFilteredState: mocks.getFilteredState,
+    getViewerSnapshot: mocks.getViewerSnapshot,
+    projectSeatView: mocks.projectSeatView,
+    setMultiplayerMode: mocks.setMultiplayerMode,
+    releaseHostSession: vi.fn(async (_claimed: boolean) => undefined),
+    dispose: vi.fn(),
+  });
+  return {
+    WasmAdapter: vi.fn().mockImplementation(createEngine),
+    getHostAdapter: vi.fn(createEngine),
+  };
+});
 
 interface FakePeer {
   on(event: string, handler: (conn: DataConnection) => void): void;
@@ -183,8 +188,8 @@ function makeHost(
 }
 
 beforeEach(() => {
-  mocks.initializeGame.mockClear();
-  mocks.initializeGame.mockImplementation(async () => ({ events: [] }));
+  mocks.initializeMultiplayerHostGame.mockClear();
+  mocks.initializeMultiplayerHostGame.mockImplementation(async () => ({ events: [] }));
   mocks.getLegalActions.mockClear();
   mocks.getFilteredState.mockClear();
   mocks.setMultiplayerMode.mockClear();
@@ -245,7 +250,7 @@ describe("P2PHostAdapter — broker integration", () => {
 
   it("does NOT call broker.unregister when initializeGame throws", async () => {
     const broker = makeBrokerMock();
-    mocks.initializeGame.mockRejectedValueOnce(new Error("WASM panic"));
+    mocks.initializeMultiplayerHostGame.mockRejectedValueOnce(new Error("WASM panic"));
     const { adapter, emitConnection } = makeHost(broker, "GAME01");
     await adapter.initialize();
 

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -12,7 +12,7 @@ import type Peer from "peerjs";
 import type { DataConnection } from "peerjs";
 
 import { P2PGuestAdapter, P2PHostAdapter, playerSlotsFromSeatView } from "../p2p-adapter";
-import { supportsAiDecisionDiagnostics, supportsMatchConcede, type FormatConfig, type GameAction, type GameEvent, type GameLogEntry, type GameState } from "../types";
+import { AdapterError, AdapterErrorCode, supportsAiDecisionDiagnostics, supportsMatchConcede, type FormatConfig, type GameAction, type GameEvent, type GameLogEntry, type GameState } from "../types";
 import { FakeDataConnection } from "../../network/__tests__/fakeDataConnection";
 import { WIRE_PROTOCOL_VERSION } from "../../network/protocol";
 import { p2pFinalStateCommitment } from "../../services/p2pTerminalResult";
@@ -153,8 +153,18 @@ const mocks = vi.hoisted(() => {
         nowStarted: false,
       },
     })),
-    initializeGame: vi.fn(async () => ({ events: [] })),
+    /**
+     * The host's atomic claim: the engine refuses an occupied engine and takes
+     * the multiplayer flag in this one call. Default "the engine accepted" — a
+     * real engine with nothing installed answers the same way.
+     */
+    initializeMultiplayerHostGame: vi.fn(async () => ({ events: [] })),
     setMultiplayerMode: vi.fn(async (_enabled: boolean) => undefined),
+    /**
+     * Replaces the bare `dispose()` the host used to call on its engine.
+     * Shared by every mock instance: assertions read the `claimed` argument.
+     */
+    releaseHostSession: vi.fn(async (_claimed: boolean) => undefined),
     setAiDecisionDiagnosticsEnabled: vi.fn(),
     subscribeAiDecisionDiagnostics: vi.fn(() => () => {}),
   };
@@ -184,7 +194,7 @@ vi.mock("../ws-adapter", () => ({
 const mockSubmitAction = mocks.submitAction;
 const mockCheckDeckCompatibility = mocks.checkDeckCompatibility;
 const mockGetViewerSnapshot = mocks.getViewerSnapshot;
-const mockInitializeGame = mocks.initializeGame;
+const mockInitializeHostGame = mocks.initializeMultiplayerHostGame;
 const mockSetMultiplayerMode = mocks.setMultiplayerMode;
 const mockProjectSeatView = mocks.projectSeatView;
 interface AsyncMockWithResolvedValueOnce {
@@ -253,30 +263,37 @@ async function flushPromises(iterations = 5): Promise<void> {
   }
 }
 
-vi.mock("../wasm-adapter", () => ({
-  WasmAdapter: vi.fn().mockImplementation(function () {
-    return {
-      initialize: mocks.initialize,
-      initializeGame: mocks.initializeGame,
-      submitAction: mocks.submitAction,
-      checkDeckCompatibility: mocks.checkDeckCompatibility,
-      getState: mocks.getState,
-      getLegalActions: mocks.getLegalActions,
-      getSnapshot: mocks.getSnapshot,
-      getLegalActionsForViewer: mocks.getLegalActionsForViewer,
-      getFilteredState: mocks.getFilteredState,
-      getViewerSnapshot: mocks.getViewerSnapshot,
-      getAiActionProposal: mocks.getAiActionProposal,
-      submitAiActionProposal: mocks.submitAiActionProposal,
-      applySeatMutation: mocks.applySeatMutation,
-      projectSeatView: mocks.projectSeatView,
-      setMultiplayerMode: mocks.setMultiplayerMode,
-      setAiDecisionDiagnosticsEnabled: mocks.setAiDecisionDiagnosticsEnabled,
-      subscribeAiDecisionDiagnostics: mocks.subscribeAiDecisionDiagnostics,
-      dispose: vi.fn(),
-    };
-  }),
-}));
+// `getHostAdapter` is how the host acquires its engine (shared worker on
+// memory-constrained devices, a private one everywhere else). Both exports
+// hand back the same instance shape here — the branch itself is exercised
+// against the real module in `wasm-adapter.test.ts`.
+vi.mock("../wasm-adapter", () => {
+  const createEngine = () => ({
+    initialize: mocks.initialize,
+    initializeMultiplayerHostGame: mocks.initializeMultiplayerHostGame,
+    submitAction: mocks.submitAction,
+    checkDeckCompatibility: mocks.checkDeckCompatibility,
+    getState: mocks.getState,
+    getLegalActions: mocks.getLegalActions,
+    getSnapshot: mocks.getSnapshot,
+    getLegalActionsForViewer: mocks.getLegalActionsForViewer,
+    getFilteredState: mocks.getFilteredState,
+    getViewerSnapshot: mocks.getViewerSnapshot,
+    getAiActionProposal: mocks.getAiActionProposal,
+    submitAiActionProposal: mocks.submitAiActionProposal,
+    applySeatMutation: mocks.applySeatMutation,
+    projectSeatView: mocks.projectSeatView,
+    setMultiplayerMode: mocks.setMultiplayerMode,
+    releaseHostSession: mocks.releaseHostSession,
+    setAiDecisionDiagnosticsEnabled: mocks.setAiDecisionDiagnosticsEnabled,
+    subscribeAiDecisionDiagnostics: mocks.subscribeAiDecisionDiagnostics,
+    dispose: vi.fn(),
+  });
+  return {
+    WasmAdapter: vi.fn().mockImplementation(createEngine),
+    getHostAdapter: vi.fn(createEngine),
+  };
+});
 
 // Stub crypto.randomUUID for deterministic token assertions
 const mockInitialize = mocks.initialize;
@@ -290,7 +307,6 @@ beforeEach(() => {
   mockSubmitAction.mockClear();
   mockCheckDeckCompatibility.mockClear();
   mockGetViewerSnapshot.mockClear();
-  mockInitializeGame.mockClear();
   mockSetMultiplayerMode.mockClear();
   mockProjectSeatView.mockClear();
   mockGetState.mockClear();
@@ -298,6 +314,13 @@ beforeEach(() => {
   mockSubmitAiActionProposal.mockClear();
   mocks.setAiDecisionDiagnosticsEnabled.mockClear();
   mocks.subscribeAiDecisionDiagnostics.mockClear();
+  // `mockReset`, not `mockClear`: these two carry per-test
+  // `mockResolvedValueOnce`/`mockRejectedValueOnce` overrides, and only
+  // `mockReset` drops an unconsumed one (a test that throws before consuming it
+  // would otherwise leak a rejecting host-start into the next test). Both are
+  // `vi.fn(impl)`, so the reset restores their default implementations.
+  mocks.initializeMultiplayerHostGame.mockReset();
+  mocks.releaseHostSession.mockReset();
   nativeWebSocketMocks.initializePregame.mockReset();
   nativeWebSocketMocks.waitForPlayerSlots.mockReset();
   nativeWebSocketMocks.onEvent.mockClear();
@@ -581,11 +604,12 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     ).toThrow("P2P supports 2-6 players");
   });
 
-  it("enables multiplayer-mode enforcement at game start, not at lobby open", async () => {
+  it("claims the engine through the atomic host-start call, never a client flag flip", async () => {
     // The engine's multiplayer flag is process-wide and nothing ever clears it,
-    // so an open host lobby must not set it — it is claimed only when the host
-    // actually takes the engine, on the line before `initializeGame`, which is
-    // where `initialize_debug_permissions` reads it.
+    // so an open host lobby must leave zero engine footprint. The claim belongs
+    // to the engine, made inside the same call that installs the game: a client
+    // flag flip followed by a separate install is two round-trips, and a local
+    // `initializeGame` sharing this worker can land between them.
     const { adapter } = makeHost(2);
     expect(mockSetMultiplayerMode).not.toHaveBeenCalled();
 
@@ -605,10 +629,8 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     });
     await adapter.initializeGame();
 
-    expect(mockSetMultiplayerMode).toHaveBeenCalledTimes(1);
-    expect(mockSetMultiplayerMode).toHaveBeenCalledWith(true);
-    expect(mockSetMultiplayerMode.mock.invocationCallOrder[0])
-      .toBeLessThan(mockInitializeGame.mock.invocationCallOrder[0]);
+    expect(mockInitializeHostGame).toHaveBeenCalledTimes(1);
+    expect(mockSetMultiplayerMode).not.toHaveBeenCalled();
   });
 
   it("does not reinitialize the host during the lobby-to-game handoff", async () => {
@@ -750,7 +772,7 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
       signature_spell: ["Invalid Signature Spell"],
       selected_format: "Commander",
     });
-    expect(mockInitializeGame).not.toHaveBeenCalled();
+    expect(mockInitializeHostGame).not.toHaveBeenCalled();
 
     const kicked = (await guest.getSentMessages()).find(
       (message) =>
@@ -2205,5 +2227,188 @@ describe("P2PHostAdapter — bound draft match concession", () => {
       reason: "Whole-match concession is unavailable for this game",
     }));
     adapter.dispose();
+  });
+});
+
+/**
+ * On a memory-constrained device the host's engine is the same worker local
+ * play uses, so teardown must clear engine state for the claimant and only the
+ * claimant, and a start must never overwrite a game that is already live.
+ */
+describe("P2PHostAdapter — shared-engine ownership", () => {
+  beforeEach(() => {
+    // Earlier suites leave persistent `mockResolvedValue` overrides on the AI
+    // mocks (`mockClear` does not undo those). Restore a board where the host
+    // holds priority and no AI proposal is pending, so `runAiLoop` returns
+    // immediately and these tests observe only the ownership bookkeeping.
+    mockGetState.mockResolvedValue({
+      players: [],
+      objects: {},
+      priority_player: 0,
+      waiting_for: { type: "Priority", data: { player: 0 } },
+    });
+    mockGetAiActionProposal.mockResolvedValue(null);
+  });
+
+  async function seatAi(adapter: P2PHostAdapter): Promise<void> {
+    await adapter.applySeatMutation({
+      type: "SetKind",
+      data: {
+        seatIndex: 1,
+        kind: { type: "Ai", data: { difficulty: "Medium", deck: { type: "Random" } } },
+      },
+    });
+  }
+
+  async function startedHost(): Promise<P2PHostAdapter> {
+    const { adapter } = makeHost(2);
+    await adapter.initialize();
+    await seatAi(adapter);
+    await adapter.initializeGame();
+    return adapter;
+  }
+
+  it("clears the engine state it installed when the host tears down", async () => {
+    const adapter = await startedHost();
+    mocks.releaseHostSession.mockClear();
+
+    adapter.dispose();
+
+    expect(mocks.releaseHostSession).toHaveBeenCalledWith(true);
+  });
+
+  it("leaves the engine untouched when a host that never started tears down", async () => {
+    const { adapter } = makeHost(2);
+    await adapter.initialize();
+    mocks.releaseHostSession.mockClear();
+
+    adapter.dispose();
+
+    expect(mocks.releaseHostSession).toHaveBeenCalledWith(false);
+  });
+
+  it("does not let another host's teardown clear the claimant's game", async () => {
+    const claimant = await startedHost();
+    const { adapter: other } = makeHost(2);
+    await other.initialize();
+
+    mocks.releaseHostSession.mockClear();
+    other.dispose();
+    expect(mocks.releaseHostSession).toHaveBeenCalledWith(false);
+
+    mocks.releaseHostSession.mockClear();
+    claimant.dispose();
+    expect(mocks.releaseHostSession).toHaveBeenCalledWith(true);
+  });
+
+  function occupiedRefusal(): AdapterError {
+    return new AdapterError(
+      AdapterErrorCode.ENGINE_OCCUPIED,
+      "Finish or leave your current game before starting a new one.",
+      false,
+    );
+  }
+
+  it("surfaces the engine's refusal when it already holds a game", async () => {
+    const { adapter } = makeHost(2);
+    await adapter.initialize();
+    await seatAi(adapter);
+    // The engine is the authority, not a client-side probe: it tests occupancy
+    // and installs inside one synchronous worker task, so a local
+    // `initializeGame` on the same shared worker cannot land in between.
+    mockInitializeHostGame.mockRejectedValueOnce(occupiedRefusal());
+
+    await expect(adapter.initializeGame()).rejects.toThrow(
+      /Finish or leave your current game/,
+    );
+    // A refused claim installed nothing, so there is nothing to compensate.
+    // `releaseHostSession(true)` here would run `resetGameState()` on the
+    // shared engine and destroy the live local game the refusal just protected.
+    expect(mocks.releaseHostSession).toHaveBeenCalledWith(false);
+    expect(mocks.releaseHostSession).not.toHaveBeenCalledWith(true);
+    expect(mockSetMultiplayerMode).not.toHaveBeenCalled();
+    adapter.dispose();
+  });
+
+  it("leaves the engine untouched when a refused claim is disposed concurrently", async () => {
+    const { adapter } = makeHost(2);
+    await adapter.initialize();
+    await seatAi(adapter);
+    // "Cancel hosting" clicked while a refused start is still in flight:
+    // `dispose()` sets `disposed` synchronously, so the catch takes its
+    // *disposed* branch — which routes to `releaseHostSession` as well. With
+    // `true` that branch would reset the very game the refusal protected. The
+    // test above never disposes, so only this one covers that exit.
+    const gate = deferred<undefined>();
+    mockInitializeHostGame.mockImplementationOnce(async () => {
+      await gate.promise;
+      throw occupiedRefusal();
+    });
+    const start = adapter.initializeGame();
+    await vi.waitFor(() => {
+      expect(mockInitializeHostGame).toHaveBeenCalled();
+    });
+
+    adapter.dispose();
+    mocks.releaseHostSession.mockClear();
+    gate.resolve(undefined);
+
+    await expect(start).rejects.toThrow(/disposed during start/);
+    expect(mocks.releaseHostSession).toHaveBeenCalledWith(false);
+    expect(mocks.releaseHostSession).not.toHaveBeenCalledWith(true);
+  });
+
+  it("hands the engine back when teardown lands while the start call is in flight", async () => {
+    const { adapter } = makeHost(2);
+    await adapter.initialize();
+    await seatAi(adapter);
+    // Park inside the host-start call — the real window is the card-DB load it
+    // awaits, seconds wide with "Cancel hosting" one click away. Here the
+    // engine *accepted*, so this bail owns the state it installed and has to
+    // hand it back, flag included; nothing else ever clears it.
+    const install = deferred<{ events: [] }>();
+    mockInitializeHostGame.mockReturnValueOnce(install.promise);
+    const start = adapter.initializeGame();
+    await vi.waitFor(() => {
+      expect(mockInitializeHostGame).toHaveBeenCalled();
+    });
+
+    adapter.dispose();
+    mocks.releaseHostSession.mockClear();
+    install.resolve({ events: [] });
+
+    await expect(start).rejects.toThrow(/disposed during start/);
+    expect(mocks.releaseHostSession).toHaveBeenCalledWith(true);
+  });
+
+  it("leaves the engine untouched when the start call rejects for any other reason", async () => {
+    const { adapter } = makeHost(2);
+    await adapter.initialize();
+    await seatAi(adapter);
+    // The engine also rejects on deck validation, and on "Card database not
+    // loaded" whenever `ensureCardDb` swallowed a fetch failure — routine on
+    // the flaky-network devices that share this worker. No engine state is
+    // installed on any of those paths either.
+    const refusal = new Error("Card database not loaded");
+    mockInitializeHostGame.mockRejectedValueOnce(refusal);
+
+    await expect(adapter.initializeGame()).rejects.toThrow(refusal);
+
+    expect(mockSetMultiplayerMode).not.toHaveBeenCalled();
+    expect(mocks.releaseHostSession).toHaveBeenCalledWith(false);
+    expect(mocks.releaseHostSession).not.toHaveBeenCalledWith(true);
+    adapter.dispose();
+  });
+
+  it("fails loud on engine calls after teardown", async () => {
+    const { adapter } = makeHost(2);
+    await adapter.initialize();
+
+    adapter.dispose();
+
+    await expect(adapter.getState()).rejects.toThrow("P2P host adapter has been disposed");
+    await expect(adapter.submitAction({ type: "PassPriority" }, 0)).rejects.toThrow(
+      "P2P host adapter has been disposed",
+    );
   });
 });

--- a/client/src/adapter/__tests__/wasm-adapter.test.ts
+++ b/client/src/adapter/__tests__/wasm-adapter.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { WasmAdapter } from "../wasm-adapter";
+import { WasmAdapter, getHostAdapter, getSharedAdapter } from "../wasm-adapter";
 import { EngineWorkerClient } from "../engine-worker-client";
 import type {
   AiActionProposal,
@@ -57,6 +57,8 @@ const mockWorkerClient = {
   exportState: vi.fn().mockResolvedValue("{}"),
   restoreState: vi.fn().mockResolvedValue(undefined),
   resumeMultiplayerHostState: vi.fn().mockResolvedValue(undefined),
+  setMultiplayerMode: vi.fn().mockResolvedValue(undefined),
+  resetGame: vi.fn().mockResolvedValue(undefined),
   applySeatMutation: vi.fn().mockResolvedValue({ state: {}, delta: {} }),
   ping: vi.fn().mockResolvedValue("phase-rs engine ready"),
   takeLastPanic: vi.fn().mockResolvedValue(null),
@@ -689,5 +691,98 @@ describe("WasmAdapter", () => {
       await adapter.initialize();
       expect(adapter.getEngineClient()).toBe(mockWorkerClient);
     });
+  });
+
+});
+
+/**
+ * The device predicate is module-private and reads `navigator` on every call,
+ * so both branches are driven here by redefining the properties it reads (same
+ * technique as `PermanentCard.test.tsx`). Without this, the shared-engine path
+ * would only ever run on the devices we cannot test.
+ */
+describe("getHostAdapter", () => {
+  const realUserAgent = navigator.userAgent;
+
+  function setMemoryConstrained(constrained: boolean): void {
+    Object.defineProperty(navigator, "userAgent", {
+      configurable: true,
+      value: constrained
+        ? "Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15"
+        : realUserAgent,
+    });
+    Object.defineProperty(navigator, "maxTouchPoints", { configurable: true, value: 0 });
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    setMemoryConstrained(false);
+    // `dispose()` nulls the singleton, so a leaked shared adapter cannot
+    // cross-talk into the next test.
+    getSharedAdapter().dispose();
+  });
+
+  it("hands the host the tab's shared engine on a memory-constrained device", () => {
+    setMemoryConstrained(true);
+    expect(getHostAdapter()).toBe(getSharedAdapter());
+  });
+
+  it("gives the host its own engine everywhere else", () => {
+    setMemoryConstrained(false);
+    const host = getHostAdapter();
+    expect(host).not.toBe(getSharedAdapter());
+    host.dispose();
+  });
+});
+
+describe("releaseHostSession", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    getSharedAdapter().dispose();
+  });
+
+  it("keeps the shared worker and its card database, clearing only what the host installed", async () => {
+    const shared = getSharedAdapter();
+    await shared.warmCardDatabase();
+    expect(shared.cardDbLoaded).toBe(true);
+
+    await shared.releaseHostSession(true);
+
+    expect(getSharedAdapter()).toBe(shared);
+    expect(shared.cardDbLoaded).toBe(true);
+    expect(mockWorkerClient.dispose).not.toHaveBeenCalled();
+    expect(mockWorkerClient.setMultiplayerMode).toHaveBeenCalledWith(false);
+    expect(mockWorkerClient.resetGame).toHaveBeenCalledOnce();
+    expect(mockWorkerClient.setMultiplayerMode.mock.invocationCallOrder[0])
+      .toBeLessThan(mockWorkerClient.resetGame.mock.invocationCallOrder[0]);
+  });
+
+  it("leaves the shared engine completely untouched when the host never claimed it", async () => {
+    const shared = getSharedAdapter();
+    await shared.initialize();
+
+    await shared.releaseHostSession(false);
+
+    expect(mockWorkerClient.setMultiplayerMode).not.toHaveBeenCalled();
+    expect(mockWorkerClient.resetGame).not.toHaveBeenCalled();
+    expect(mockWorkerClient.dispose).not.toHaveBeenCalled();
+  });
+
+  it("disposes a private host engine outright, as teardown always did", async () => {
+    const host = new WasmAdapter();
+    await host.initialize();
+
+    await host.releaseHostSession(true);
+
+    expect(mockWorkerClient.dispose).toHaveBeenCalledOnce();
+    await expect(host.getState()).rejects.toThrow(AdapterError);
+    // A private release must never post the shared engine's flag clear.
+    expect(mockWorkerClient.setMultiplayerMode).not.toHaveBeenCalled();
   });
 });

--- a/client/src/adapter/engine-worker-client.ts
+++ b/client/src/adapter/engine-worker-client.ts
@@ -26,7 +26,13 @@ import { notifyEngineSlow } from "../game/engineRecovery";
 
 type EngineResponse =
   | { type: "result"; id: number; data: unknown }
-  | { type: "error"; id: number; message: string; bracketViolation?: true };
+  | {
+      type: "error";
+      id: number;
+      message: string;
+      bracketViolation?: true;
+      engineOccupied?: true;
+    };
 
 /**
  * Watchdog timeout for gameplay round-trip calls. Generous on purpose: a
@@ -95,11 +101,17 @@ export class EngineWorkerClient {
           if (entry) {
             this.pending.delete(msg.id);
             if (entry.timer) clearTimeout(entry.timer);
-            // Bracket violation is a typed rejection so the caller can match
-            // by code rather than by string substring on the error message.
-            const err = msg.bracketViolation
-              ? new AdapterError(AdapterErrorCode.BRACKET_VIOLATION, msg.message, false)
-              : new Error(msg.message);
+            // Bracket violation and occupied-engine refusals are typed
+            // rejections so the caller can match by code rather than by string
+            // substring on the error message.
+            let err: Error;
+            if (msg.bracketViolation) {
+              err = new AdapterError(AdapterErrorCode.BRACKET_VIOLATION, msg.message, false);
+            } else if (msg.engineOccupied) {
+              err = new AdapterError(AdapterErrorCode.ENGINE_OCCUPIED, msg.message, false);
+            } else {
+              err = new Error(msg.message);
+            }
             entry.reject(err);
           }
           break;
@@ -208,6 +220,32 @@ export class EngineWorkerClient {
   ): Promise<SubmitResult> {
     return this.request<SubmitResult>({
       type: "initializeGame",
+      deckData,
+      seed,
+      formatConfig,
+      matchConfig,
+      playerCount,
+      firstPlayer,
+    });
+  }
+
+  /**
+   * Host-start entry point. Unlike `initializeGame`, the engine refuses when it
+   * already holds a game and claims the multiplayer flag in the same call that
+   * installs the state — so a host sharing this worker with local play can
+   * never overwrite (or be overwritten by) the other session. Rejects with
+   * `AdapterErrorCode.ENGINE_OCCUPIED` on refusal.
+   */
+  async initializeMultiplayerHostGame(
+    deckData: unknown | null,
+    seed: number,
+    formatConfig: FormatConfig | null,
+    matchConfig: MatchConfig | null,
+    playerCount?: number,
+    firstPlayer?: number,
+  ): Promise<SubmitResult> {
+    return this.request<SubmitResult>({
+      type: "initializeMultiplayerHostGame",
       deckData,
       seed,
       formatConfig,

--- a/client/src/adapter/engine-worker.ts
+++ b/client/src/adapter/engine-worker.ts
@@ -8,6 +8,7 @@ import init, {
   ping,
   take_last_panic_message,
   initialize_game,
+  initialize_multiplayer_host_game,
   submit_action,
   submit_interaction_js,
   get_game_state,
@@ -51,6 +52,7 @@ import init, {
 import type { AiActionProposal, GameAction } from "./types";
 import type { InteractionSubmission } from "./generated/interaction";
 import type { BracketDeckRequest } from "../types/bracketEstimate";
+import { classifyInitFailure, type InitFailure } from "./init-envelope";
 
 // ── Message Protocol ─────────────────────────────────────────────────────
 
@@ -59,6 +61,16 @@ type EngineRequest =
   | { type: "loadCardDb"; id: number; cardDataText: string }
   | {
       type: "initializeGame";
+      id: number;
+      deckData: unknown | null;
+      seed: number;
+      formatConfig: unknown | null;
+      matchConfig: unknown | null;
+      playerCount?: number;
+      firstPlayer?: number;
+    }
+  | {
+      type: "initializeMultiplayerHostGame";
       id: number;
       deckData: unknown | null;
       seed: number;
@@ -111,7 +123,13 @@ type EngineRequest =
 
 type EngineResponse =
   | { type: "result"; id: number; data: unknown }
-  | { type: "error"; id: number; message: string; bracketViolation?: true };
+  | {
+      type: "error";
+      id: number;
+      message: string;
+      bracketViolation?: true;
+      engineOccupied?: true;
+    };
 
 // ── State ────────────────────────────────────────────────────────────────
 
@@ -129,8 +147,23 @@ function error(id: number, message: string): void {
   respond({ type: "error", id, message });
 }
 
-function bracketViolationError(id: number, message: string): void {
-  respond({ type: "error", id, message, bracketViolation: true });
+/**
+ * Raise an initialize-envelope failure, preserving its typed discriminator so
+ * `EngineWorkerClient` can rebuild a typed `AdapterError` on the main thread
+ * rather than matching on the message text.
+ */
+function initFailureError(id: number, failure: InitFailure): void {
+  switch (failure.kind) {
+    case "bracketViolation":
+      respond({ type: "error", id, message: failure.message, bracketViolation: true });
+      break;
+    case "engineOccupied":
+      respond({ type: "error", id, message: failure.message, engineOccupied: true });
+      break;
+    case "deckValidation":
+      error(id, failure.message);
+      break;
+  }
 }
 
 // ── Message Handler ──────────────────────────────────────────────────────
@@ -223,24 +256,40 @@ self.onmessage = async (e: MessageEvent<EngineRequest>) => {
           msg.playerCount ?? undefined,
           msg.firstPlayer ?? undefined,
         );
-        // Engine returns { error: true, cedh_bracket_violation: true, reasons: [...] }
-        // when the cEDH bracket lock fires. Preserve the violation flag so the
-        // client can throw a typed BracketViolationError rather than matching
-        // on a raw string substring.
-        if (
-          gameResult &&
-          typeof gameResult === "object" &&
-          "error" in gameResult &&
-          gameResult.error
-        ) {
-          const envelope = gameResult as { reasons?: string[]; cedh_bracket_violation?: boolean };
-          const reasons = envelope.reasons ?? [];
-          const message = `Deck validation failed: ${reasons.join("; ")}`;
-          if (envelope.cedh_bracket_violation) {
-            bracketViolationError(msg.id, message);
-          } else {
-            error(msg.id, message);
-          }
+        const failure = classifyInitFailure(gameResult);
+        if (failure) {
+          initFailureError(msg.id, failure);
+          break;
+        }
+        result(msg.id, {
+          events: gameResult.events ?? [],
+          log_entries: gameResult.log_entries ?? [],
+        });
+        break;
+      }
+
+      case "initializeMultiplayerHostGame": {
+        if (!cardDbLoaded && msg.deckData) {
+          error(
+            msg.id,
+            "Card database not loaded. Call loadCardDb or loadCardDbFromUrl first.",
+          );
+          break;
+        }
+        // The host entry point refuses an engine that already holds a game and
+        // claims the multiplayer flag alongside the install — both inside this
+        // one synchronous handler, so no other posted message can interleave.
+        const gameResult = initialize_multiplayer_host_game(
+          msg.deckData ?? null,
+          msg.seed,
+          msg.formatConfig ?? null,
+          msg.matchConfig ?? null,
+          msg.playerCount ?? undefined,
+          msg.firstPlayer ?? undefined,
+        );
+        const failure = classifyInitFailure(gameResult);
+        if (failure) {
+          initFailureError(msg.id, failure);
           break;
         }
         result(msg.id, {

--- a/client/src/adapter/init-envelope.ts
+++ b/client/src/adapter/init-envelope.ts
@@ -1,0 +1,62 @@
+/**
+ * Single authority for reading the engine's initialize-error envelope.
+ *
+ * `initialize_game` and `initialize_multiplayer_host_game` both return
+ * `{ error: true, reasons: [...] }` on failure, optionally carrying a typed
+ * discriminator (`cedh_bracket_violation`, `engine_occupied`) so callers raise
+ * a typed error instead of matching on a raw string substring.
+ *
+ * Four call sites consume that envelope — the engine worker's two initialize
+ * cases and the main-thread fallback's two — and every one of them has to tell
+ * the typed refusals apart from an ordinary deck-validation failure, or it
+ * mislabels an occupied-engine refusal as "Deck validation failed: …". The
+ * classification lives here once; each caller only decides how to raise it
+ * (worker response vs. thrown `AdapterError`).
+ *
+ * Deliberately dependency-free: `engine-worker.ts` imports it into the worker
+ * bundle, which must not pull in the main-thread adapter types.
+ */
+
+export type InitFailureKind = "bracketViolation" | "engineOccupied" | "deckValidation";
+
+export interface InitFailure {
+  kind: InitFailureKind;
+  /** Message to surface to the caller. */
+  message: string;
+  /** Raw engine reasons, for callers that surface them without a prefix. */
+  reasons: string[];
+}
+
+/**
+ * User-facing text for an occupied-engine refusal, worded for both directions
+ * the engine guard refuses in: a hosted game starting on top of a live local
+ * game, and a local game starting on top of a hosted one. On a
+ * memory-constrained device those share one engine worker, so "your current
+ * game" is accurate either way.
+ */
+const ENGINE_OCCUPIED_MESSAGE =
+  "Finish or leave your current game before starting a new one.";
+
+/**
+ * Returns the typed failure an initialize call reported, or `null` when the
+ * result is a normal `ActionResult`.
+ */
+export function classifyInitFailure(result: unknown): InitFailure | null {
+  if (!result || typeof result !== "object" || !("error" in result) || !result.error) {
+    return null;
+  }
+  const envelope = result as {
+    reasons?: string[];
+    cedh_bracket_violation?: boolean;
+    engine_occupied?: boolean;
+  };
+  const reasons = envelope.reasons ?? [];
+  if (envelope.engine_occupied) {
+    return { kind: "engineOccupied", message: ENGINE_OCCUPIED_MESSAGE, reasons };
+  }
+  const message = `Deck validation failed: ${reasons.join("; ")}`;
+  if (envelope.cedh_bracket_violation) {
+    return { kind: "bracketViolation", message, reasons };
+  }
+  return { kind: "deckValidation", message, reasons };
+}

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -24,7 +24,7 @@ import type { InteractionSubmission } from "./generated/interaction";
 import type { BracketDeckRequest, BracketEstimate } from "../types/bracketEstimate";
 
 import { AdapterError, AdapterErrorCode, EMPTY_LEGAL_ACTIONS, actionRejectionError, nextSnapshotSeq } from "./types";
-import { WasmAdapter } from "./wasm-adapter";
+import { getHostAdapter } from "./wasm-adapter";
 import {
   WebSocketAdapter,
   type NativeAiSeat,
@@ -580,6 +580,35 @@ function isZeroCountDebugCreate(action: GameAction): boolean {
 }
 
 /**
+ * The host session, if any, that currently owns the engine's game state.
+ *
+ * On a memory-constrained device `getHostAdapter()` hands every host the tab's
+ * shared engine worker, so "who installed the state that is there now?" stops
+ * being answerable from the adapter's own fields. The claim is recorded only
+ * once an engine call has *accepted* it (after `initializeGame` on the fresh
+ * start arm, after `resumeMultiplayerHostState` on the resume arm) — claiming
+ * earlier would let a refused resume's teardown wipe a live local game it never
+ * owned. Teardown clears engine state only for the current claimant, so a stale
+ * or never-started host cannot clobber the live one.
+ *
+ * Holds each host's claim token rather than the adapter itself, so a claim can
+ * never keep a torn-down host — with its guest sessions and deck payloads —
+ * resident in a module-level reference.
+ */
+let sharedEngineHost: symbol | null = null;
+
+/**
+ * Fail-loud contract for a disposed host. With a private worker, `dispose()`
+ * tore the engine down and every later call threw `assertInitialized`. A shared
+ * worker survives disposal, so a use-after-dispose host (e.g. `getActiveP2PHost()`
+ * handing back an adapter that `GameProvider` disposed directly) would silently
+ * operate on the live shared engine instead.
+ */
+function hostDisposedError(): AdapterError {
+  return new AdapterError("P2P_ERROR", "P2P host adapter has been disposed", false);
+}
+
+/**
  * Host-side P2P adapter.
  *
  * Hub-and-spoke topology: the host runs the authoritative engine (WASM by
@@ -593,7 +622,7 @@ function isZeroCountDebugCreate(action: GameAction): boolean {
  * the `DataConnection` (see `peer.ts` `onSessionEnd` contract).
  */
 export class P2PHostAdapter implements EngineAdapter {
-  private wasm = new WasmAdapter();
+  private wasm = getHostAdapter();
   private nativeBridge: NativeP2PBridge | null = null;
   private nativeInitialSetupPending = false;
   private listeners: P2PAdapterEventListener[] = [];
@@ -605,6 +634,17 @@ export class P2PHostAdapter implements EngineAdapter {
    */
   private initialized = false;
   private initPromise: Promise<void> | null = null;
+  /**
+   * Set synchronously by `dispose()`. Read by every engine entry point (so a
+   * disposed host fails loud even when its engine is the shared worker that
+   * outlives it) and re-checked after each await in the init/start paths, so a
+   * teardown that lands mid-flight cannot be overtaken by a resumed claim.
+   * Deliberately not `ownsAuthority()`: `dispose()` releases the host lease, so
+   * the lease says nothing about *this* adapter having been torn down.
+   */
+  private disposed = false;
+  /** This session's identity in `sharedEngineHost`. */
+  private readonly engineClaim = Symbol("p2p-host-engine-claim");
 
   private guestSessions = new Map<PlayerId, PeerSession>();
   private guestDecks = new Map<PlayerId, DeckListPayload["player"]>();
@@ -990,6 +1030,35 @@ export class P2PHostAdapter implements EngineAdapter {
     return owns;
   }
 
+  /** Engine entry-point guard — see `hostDisposedError`. */
+  private assertNotDisposed(): void {
+    if (this.disposed) throw hostDisposedError();
+  }
+
+  /**
+   * Abandon an in-flight init/start that a `dispose()` overtook, leaving
+   * nothing owning the engine.
+   *
+   * `claimed` must be true whenever a state-installing call
+   * (`initializeMultiplayerHostGame`, `resumeMultiplayerHostState`) already
+   * resolved, and false otherwise — including on every rejection, since the
+   * engine claims itself only on a successful install and a failed call leaves
+   * it untouched. Get it wrong in the `true` direction and a shared engine is
+   * reset out from under whoever does own it; wrong in the `false` direction
+   * and the flag plus the ownerless game it installed sit on the shared engine
+   * forever — `clear_game_state` does not clear the multiplayer flag and local
+   * games never touch it, so the residue would refuse undo in every later local
+   * game and refuse every hosted resume. The release is routed through
+   * `releaseHostSession` rather than a direct `setMultiplayerMode(false)`
+   * because the private/desktop adapter has already been disposed by then and
+   * would throw `assertInitialized`, turning a clean bail into an unhandled
+   * rejection.
+   */
+  private async bailDisposed(claimed: boolean, during: string): Promise<never> {
+    await this.wasm.releaseHostSession(claimed);
+    throw new AdapterError("P2P_ERROR", `Host session disposed during ${during}`, true);
+  }
+
   private send(session: PeerSession, message: P2PMessage): Promise<void> {
     if (!this.ownsAuthority()) return Promise.resolve();
     return session.send({ ...message, authority: this.authority });
@@ -1089,6 +1158,7 @@ export class P2PHostAdapter implements EngineAdapter {
 
   async applySeatMutation(mutation: SeatMutation): Promise<void> {
     await this.enqueuePregameOp(async () => {
+      this.assertNotDisposed();
       if (!this.ownsAuthority()) return;
       if (this.gameStarted) {
         throw new AdapterError("P2P_ERROR", "Pregame seats can no longer be edited", false);
@@ -1171,6 +1241,11 @@ export class P2PHostAdapter implements EngineAdapter {
     let staleRetries = 0;
     for (;;) {
       if (!this.ownsAuthority()) return;
+      // A disposed host must stop driving the engine. With a private worker
+      // the next call threw `assertInitialized` and ended the loop; a shared
+      // worker would happily keep applying AI actions to whatever game is
+      // there now.
+      if (this.disposed) return;
       if (this.gameRunState !== "running") return;
       const state = await this.wasm.getState();
       if (!state || typeof state !== "object" || !("waiting_for" in state)) {
@@ -1257,6 +1332,7 @@ export class P2PHostAdapter implements EngineAdapter {
   }
 
   async initialize(): Promise<void> {
+    this.assertNotDisposed();
     if (this.initialized) return;
     if (this.initPromise) return this.initPromise;
     this.resetPregameReady();
@@ -1311,15 +1387,25 @@ export class P2PHostAdapter implements EngineAdapter {
           this.attachBrowserAiDecisionDiagnostics();
         }
       }
+      // A teardown may have landed while `wasm.initialize()` (and the native
+      // handshake above) were in flight. Bail before installing anything:
+      // nothing has been claimed yet, so there is nothing to undo.
+      if (this.disposed) await this.bailDisposed(false, "initialization");
       // Resume path: load the persisted GameState with a fresh RNG seed
-      // and atomic multiplayer-flag flip. `resumeMultiplayerHostState`
-      // mirrors server-core's `from_persisted` pattern. A fresh host lobby
-      // sets no engine flag at all — `setMultiplayerMode(true)` is deferred to
-      // `startPregameGameInner`, immediately before `initializeGame` claims
-      // the engine, so an open lobby leaves zero engine footprint.
+      // and atomic multiplayer-flag claim. `resumeMultiplayerHostState`
+      // mirrors server-core's `from_persisted` pattern, and
+      // `initializeMultiplayerHostGame` is its fresh-start sibling — both
+      // refuse an engine that is already in use and claim the flag themselves
+      // in the same call that installs the state. No client code sets the flag,
+      // so an open lobby leaves zero engine footprint.
       if (this.isResume && this.resumeGameState) {
         await this.wasm.resumeMultiplayerHostState(this.resumeGameState);
         this.resumeGameState = null;
+        // The engine now holds both this game's state and the multiplayer
+        // flag. Its await window is the widest in the adapter (the full card
+        // DB load happens inside), so re-check before recording the claim.
+        if (this.disposed) await this.bailDisposed(true, "resume");
+        sharedEngineHost = this.engineClaim;
         traceAdapter("Host", "initialize-resume", {
           tokens: this.playerTokens.size,
           gameStarted: this.gameStarted,
@@ -1577,6 +1663,7 @@ export class P2PHostAdapter implements EngineAdapter {
   }
 
   private async startPregameGameInner(): Promise<SubmitResult> {
+      this.assertNotDisposed();
       if (!this.ownsAuthority()) {
         throw new AdapterError("P2P_ERROR", "Host session superseded", true);
       }
@@ -1644,20 +1731,52 @@ export class P2PHostAdapter implements EngineAdapter {
       const playerCount = allowPartialStart
         ? orderedOpponents.length + 1
         : this.pregameSeatState.seats.length;
-      // Claim the engine for multiplayer here, not at lobby open: the only
-      // in-creation reader of the flag is `initialize_debug_permissions`,
-      // evaluated inside `initialize_game`, so setting it on the line before is
-      // equivalent. The resume path is untouched — `resume_multiplayer_host_state`
-      // refuses when the flag is already set and sets it itself.
-      await this.wasm.setMultiplayerMode(true);
-      const result = await this.wasm.initializeGame(
-        deckPayload,
-        this.formatConfig,
-        playerCount,
-        this.matchConfig,
-        undefined,
-      );
-      if (!this.ownsAuthority()) return result;
+      if (this.disposed) await this.bailDisposed(false, "start");
+      // The occupancy test, the install, and the multiplayer claim are one
+      // engine call. `initializeMultiplayerHostGame` refuses an engine that
+      // already holds a game and claims the flag on the line after it installs
+      // the state — on a memory-constrained device this is the same worker
+      // local play uses, so a client-side probe followed by a separate install
+      // would leave a window for a local `initializeGame` to land in between
+      // and destroy the hosted game (or be destroyed by it). A refusal arrives
+      // as `AdapterErrorCode.ENGINE_OCCUPIED`.
+      let result: SubmitResult;
+      try {
+        result = await this.wasm.initializeMultiplayerHostGame(
+          deckPayload,
+          this.formatConfig,
+          playerCount,
+          this.matchConfig,
+          undefined,
+        );
+      } catch (err) {
+        // Nothing to compensate. The engine claims itself only on a successful
+        // install, so a rejection — an occupied-engine refusal, a deck error,
+        // or "Card database not loaded" when `ensureCardDb` swallowed a fetch
+        // failure — leaves the engine byte-for-byte untouched. `claimed: false`
+        // is what says so, and it is load-bearing in both directions: `true`
+        // would run `resetGameState()` on the shared engine and destroy the
+        // live local game a refusal had just protected, while dropping the call
+        // entirely would lose the private-adapter worker disposal and the typed
+        // "disposed during start" error. gameStore catches the rethrow and
+        // shows a toast, so the original error is preserved.
+        if (this.disposed) await this.bailDisposed(false, "start");
+        await this.wasm.releaseHostSession(false);
+        throw err;
+      }
+      // The engine now holds this game. Record the claim only now: claiming
+      // before the engine accepted would let a refused call's teardown clear
+      // state this session never owned.
+      if (this.disposed) await this.bailDisposed(true, "start");
+      // Checked before the stamp: a host whose lease was superseded mid-start
+      // must not take the claim from the host that superseded it. It did
+      // install engine state, so it hands that state back rather than leaving
+      // it for someone else's teardown to find unclaimed.
+      if (!this.ownsAuthority()) {
+        await this.wasm.releaseHostSession(true);
+        throw new AdapterError("P2P_ERROR", "Host session superseded", true);
+      }
+      sharedEngineHost = this.engineClaim;
       this.gameStarted = true;
       this.pregameSeatState.gameStarted = true;
       await this.refreshPregameSeatView();
@@ -1698,6 +1817,7 @@ export class P2PHostAdapter implements EngineAdapter {
     // caller — gameStore — derived it from `getPlayerId()`). The host is
     // the trust boundary for its own actions; the engine's guard still
     // verifies the actor against `authorized_submitter(state)`.
+    this.assertNotDisposed();
     if (!this.ownsAuthority()) {
       throw new AdapterError("P2P_ERROR", "Host session superseded", true);
     }
@@ -1722,6 +1842,7 @@ export class P2PHostAdapter implements EngineAdapter {
     submission: InteractionSubmission,
     actor: PlayerId,
   ): Promise<SubmitResult> {
+    this.assertNotDisposed();
     if (!this.ownsAuthority()) {
       throw new AdapterError("P2P_ERROR", "Host session superseded", true);
     }
@@ -1742,6 +1863,7 @@ export class P2PHostAdapter implements EngineAdapter {
   }
 
   async previewManaPayment(action: GameAction, actor: PlayerId): Promise<ObjectId[]> {
+    this.assertNotDisposed();
     if (!this.ownsAuthority()) {
       throw new AdapterError("P2P_ERROR", "Host session superseded", true);
     }
@@ -1757,6 +1879,7 @@ export class P2PHostAdapter implements EngineAdapter {
   }
 
   async exportPersistenceState(): Promise<string> {
+    this.assertNotDisposed();
     if (!this.ownsAuthority()) {
       throw new AdapterError("P2P_ERROR", "Host session superseded", true);
     }
@@ -1919,11 +2042,13 @@ export class P2PHostAdapter implements EngineAdapter {
   }
 
   async getState(): Promise<GameState> {
+    this.assertNotDisposed();
     if (this.nativeBridge) return this.nativeBridge.getState();
     return this.wasm.getState();
   }
 
   async getLegalActions(): Promise<LegalActionsResult> {
+    this.assertNotDisposed();
     if (this.nativeBridge) return this.nativeBridge.getLegalActions();
     return this.wasm.getLegalActions();
   }
@@ -1934,6 +2059,7 @@ export class P2PHostAdapter implements EngineAdapter {
    *  stamp arrival order on their own ordered channel, and `seq` is never
    *  compared across clients.) */
   async getSnapshot(): Promise<EngineSnapshot> {
+    this.assertNotDisposed();
     if (this.nativeBridge) return this.nativeBridge.getSnapshot();
     return this.wasm.getSnapshot();
   }
@@ -1942,6 +2068,9 @@ export class P2PHostAdapter implements EngineAdapter {
     difficulty: string,
     playerId: number,
   ): Promise<AiActionProposal | null> | AiActionProposal | null {
+    // Rejected rather than thrown: callers wrap this in `Promise.resolve(...)`
+    // without a synchronous try, matching what a disposed private engine did.
+    if (this.disposed) return Promise.reject(hostDisposedError());
     return this.nativeBridge
       ? null
       : this.wasm.getAiActionProposal(difficulty, playerId);
@@ -1951,6 +2080,7 @@ export class P2PHostAdapter implements EngineAdapter {
   async submitAiActionProposal(
     proposal: AiActionProposal,
   ): Promise<AiProposalSubmission> {
+    this.assertNotDisposed();
     if (!this.ownsAuthority()) {
       return { status: "stale", reason: "P2P host authority changed" };
     }
@@ -2023,6 +2153,9 @@ export class P2PHostAdapter implements EngineAdapter {
    * clears the persistence before disposing.
    */
   dispose(): void {
+    // Set first and synchronously: every in-flight init/start re-checks this
+    // after each await, and callers that kept a reference must fail loud.
+    this.disposed = true;
     this.unsubscribeHostConnections();
     for (const { timer } of this.disconnectedSeats.values()) {
       if (timer !== null) clearTimeout(timer);
@@ -2045,7 +2178,20 @@ export class P2PHostAdapter implements EngineAdapter {
     // intentionally not an abandonment: a remount/reload reconnects with the
     // stored local tokens. Explicit termination below sends AbandonGame.
     this.nativeBridge?.dispose();
-    this.wasm.dispose();
+    // Release only what this session owns. A private engine is disposed as
+    // before; a shared one keeps its worker and card DB and has its state
+    // cleared only when this adapter is the recorded claimant — so a stale or
+    // never-started host cannot wipe a live claimant's game (or a local game
+    // that was never a host's to begin with). Idempotent: `dispose()` really is
+    // called twice on the same instance (GameProvider disposes directly, then
+    // `gameStore.reset()` disposes it again), and the second pass takes the
+    // unclaimed branch. Fire-and-forget from a synchronous `dispose()`.
+    if (sharedEngineHost === this.engineClaim) {
+      sharedEngineHost = null;
+      void this.wasm.releaseHostSession(true);
+    } else {
+      void this.wasm.releaseHostSession(false);
+    }
     releaseP2PHostLease(this.authority);
     // Close the broker only when the adapter owns it. When the multiplayer
     // store owns the broker (externally managed), it survives adapter disposal

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -3515,6 +3515,15 @@ export const AdapterErrorCode = {
   /** Engine rejected game init because one or more decks are not bracket 5 at a cEDH table. */
   BRACKET_VIOLATION: "BRACKET_VIOLATION",
   /**
+   * Engine refused game init because another session already owns it. On a
+   * memory-constrained device the P2P host shares the tab's single engine
+   * worker with local play, so the engine refuses in both directions — a
+   * hosted game starting on top of a live local game, and a local game
+   * starting on top of a hosted one. Not recoverable by retry: the user has to
+   * finish or leave the other game first.
+   */
+  ENGINE_OCCUPIED: "ENGINE_OCCUPIED",
+  /**
    * The engine's actor-authorization guards (`check_actor_authorization` /
    * priority checks, CR 117 priority / CR 500 turn structure) rejected the
    * action because the submitting seat is no longer the authorized submitter

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -22,6 +22,7 @@ import { AdapterError, AdapterErrorCode, isStaleRejectionMessage, isStateLostMes
 import type { BracketDeckRequest, BracketEstimate } from "../types/bracketEstimate";
 import { isBracketEstimate } from "../types/bracketEstimate";
 import { EngineWorkerClient } from "./engine-worker-client";
+import { classifyInitFailure } from "./init-envelope";
 import { AiWorkerPool } from "./ai-worker-pool";
 import type { AiCardDataMode, AiPoolCardDbPlan } from "./card-db-subset";
 import {
@@ -133,6 +134,18 @@ let sharedAdapter: WasmAdapter | null = null;
 export function getSharedAdapter(): WasmAdapter {
   if (!sharedAdapter) sharedAdapter = new WasmAdapter();
   return sharedAdapter;
+}
+
+/**
+ * Engine for a P2P host session. Memory-constrained devices reuse the shared
+ * worker (one WASM module + one card DB for the whole tab) and pay for it in
+ * serialized engine calls; everywhere else the host keeps a private worker so
+ * its authoritative game state can never interleave with local play. Mirrors
+ * the AI-pool trade at `ensureAiPool`, which likewise returns null on these
+ * devices rather than spending a second resident allocation.
+ */
+export function getHostAdapter(): WasmAdapter {
+  return isMemoryConstrainedDevice() ? getSharedAdapter() : new WasmAdapter();
 }
 
 /**
@@ -718,12 +731,16 @@ export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapabili
   }
 
   /**
-   * Toggle the engine's multiplayer enforcement flag. When enabled, the
-   * Rust side refuses `restore_game_state` with a descriptive error —
-   * defense against any caller trying to rewind a multiplayer game.
-   * Called by the P2P host immediately before `initializeGame` — not at
-   * lobby open. A pregame lobby owns no game state, so enabling enforcement
-   * there only leaves the flag set on the worker for the lobby's lifetime.
+   * Set the engine's multiplayer enforcement flag. While it is set, the Rust
+   * side refuses `restore_game_state` (undo) and refuses a local
+   * `initializeGame` — defense against any caller rewriting a multiplayer
+   * game.
+   *
+   * Nothing in the client turns it *on*: the engine claims it itself, in the
+   * same call that installs the host's game
+   * (`initializeMultiplayerHostGame`, `resumeMultiplayerHostState`). This
+   * method exists for the release side — `releaseHostSession` clears the flag
+   * when a host session ends.
    */
   async setMultiplayerMode(enabled: boolean): Promise<void> {
     this.assertInitialized();
@@ -859,6 +876,36 @@ export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapabili
     return this.fallback!.getCardRulings(cardName);
   }
 
+  /**
+   * End a multiplayer host session's hold on this adapter — the single
+   * authority for undoing a host session.
+   *
+   * A private host adapter is disposed outright (today's behaviour). The
+   * shared adapter keeps its worker — the card database and TurboFan-compiled
+   * code stay resident for the rest of the tab — and instead clears the
+   * multiplayer flag plus any game state the host installed. Branching on
+   * identity (`sharedAdapter === this`) rather than a stored mode flag mirrors
+   * `dispose()` below.
+   *
+   * `claimed` answers "did this host ever install engine state?", which only
+   * the caller knows. An unclaimed host must leave the shared engine
+   * completely untouched: a live local game may be running on it.
+   */
+  async releaseHostSession(claimed: boolean): Promise<void> {
+    if (sharedAdapter !== this) {
+      this.dispose();
+      return;
+    }
+    if (!claimed) return;
+    // No await between the two posts. `EngineWorkerClient.request` posts
+    // inside a synchronously-executed promise executor, and neither method
+    // awaits before reaching it, so the worker sees them back to back — an
+    // `initializeGame` from a later mount cannot land in between.
+    const flagCleared = this.setMultiplayerMode(false);
+    const stateCleared = this.resetGameState();
+    await Promise.all([flagCleared, stateCleared]);
+  }
+
   dispose(): void {
     this.setAiDecisionDiagnosticsEnabled(false);
     this.aiDecisionDiagnosticListeners.clear();
@@ -925,6 +972,50 @@ export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapabili
     return result;
   }
 
+  /**
+   * Start a P2P host's game. The engine refuses if it already holds a game and
+   * claims the multiplayer flag in the same call that installs the state, so a
+   * host sharing this worker with local play can neither destroy nor be
+   * destroyed by the other session. Rejects with
+   * `AdapterErrorCode.ENGINE_OCCUPIED` when the engine is occupied; nothing in
+   * the engine changed on that path, so callers have nothing to compensate.
+   */
+  async initializeMultiplayerHostGame(
+    deckData?: unknown,
+    formatConfig?: FormatConfig,
+    playerCount?: number,
+    matchConfig?: MatchConfig,
+    firstPlayer?: number,
+  ): Promise<SubmitResult> {
+    this.assertInitialized();
+    if (deckData) {
+      await this.ensureCardDb();
+    }
+    const seed = Math.floor(Math.random() * Number.MAX_SAFE_INTEGER);
+    if (this.engine) {
+      const result = await this.engine.initializeMultiplayerHostGame(
+        deckData ?? null,
+        seed,
+        formatConfig ?? null,
+        matchConfig ?? null,
+        playerCount,
+        firstPlayer,
+      );
+      this.invalidateAiDecisionDiagnostics();
+      return result;
+    }
+    const result = await this.fallback!.initializeMultiplayerHostGame(
+      deckData ?? null,
+      seed,
+      formatConfig ?? null,
+      matchConfig ?? null,
+      playerCount,
+      firstPlayer,
+    );
+    this.invalidateAiDecisionDiagnostics();
+    return result;
+  }
+
   /** Expose the worker client for AI pool state export (Phase 4). */
   getEngineClient(): EngineWorkerClient | null {
     return this.engine;
@@ -976,11 +1067,43 @@ interface MainThreadFallback {
     playerCount?: number,
     firstPlayer?: number,
   ): Promise<SubmitResult>;
+  initializeMultiplayerHostGame(
+    deckData: unknown | null,
+    seed: number,
+    formatConfig: FormatConfig | null,
+    matchConfig: MatchConfig | null,
+    playerCount?: number,
+    firstPlayer?: number,
+  ): Promise<SubmitResult>;
   estimateBracketForDeck(deck: BracketDeckRequest): Promise<BracketEstimate | null>;
   evaluateDeckCompatibility(request: unknown): Promise<unknown>;
   getCardFaceData(cardName: string): Promise<unknown>;
   getCardParseDetails(cardName: string): Promise<unknown>;
   getCardRulings(cardName: string): Promise<unknown>;
+}
+
+/**
+ * Raise an initialize-envelope failure as the typed error the worker path
+ * raises for the same envelope (see `EngineWorkerClient`'s error handling).
+ * Both fallback initialize methods go through here — the fallback is a real
+ * supported path (worker creation failed), so a refusal must not surface as
+ * "Deck validation failed: …" on it either.
+ */
+function throwInitFailure(result: unknown): void {
+  const failure = classifyInitFailure(result);
+  if (!failure) return;
+  switch (failure.kind) {
+    case "bracketViolation":
+      throw new AdapterError(
+        AdapterErrorCode.BRACKET_VIOLATION,
+        failure.reasons.join("; ") || "cEDH bracket violation",
+        false,
+      );
+    case "engineOccupied":
+      throw new AdapterError(AdapterErrorCode.ENGINE_OCCUPIED, failure.message, false);
+    case "deckValidation":
+      throw new Error(failure.message);
+  }
 }
 
 async function createMainThreadFallback(): Promise<MainThreadFallback> {
@@ -1130,19 +1253,28 @@ async function createMainThreadFallback(): Promise<MainThreadFallback> {
           playerCount ?? undefined,
           firstPlayer ?? undefined,
         );
-        if (r && typeof r === "object" && "error" in r && r.error) {
-          const envelope = r as { reasons?: string[]; cedh_bracket_violation?: boolean };
-          const reasons = envelope.reasons ?? [];
-          const message = `Deck validation failed: ${reasons.join("; ")}`;
-          if (envelope.cedh_bracket_violation) {
-            throw new AdapterError(
-              AdapterErrorCode.BRACKET_VIOLATION,
-              envelope.reasons?.join("; ") ?? "cEDH bracket violation",
-              false,
-            );
-          }
-          throw new Error(message);
-        }
+        throwInitFailure(r);
+        return { events: r.events ?? [], log_entries: r.log_entries ?? [] };
+      }),
+
+    initializeMultiplayerHostGame: (
+      deckData: unknown | null,
+      seed: number,
+      formatConfig: FormatConfig | null,
+      matchConfig: MatchConfig | null,
+      playerCount?: number,
+      firstPlayer?: number,
+    ) =>
+      enqueue(() => {
+        const r = wasm.initialize_multiplayer_host_game(
+          deckData,
+          seed,
+          formatConfig,
+          matchConfig,
+          playerCount ?? undefined,
+          firstPlayer ?? undefined,
+        );
+        throwInitFailure(r);
         return { events: r.events ?? [], log_entries: r.log_entries ?? [] };
       }),
 

--- a/client/src/wasm/engine_wasm.d.ts
+++ b/client/src/wasm/engine_wasm.d.ts
@@ -240,7 +240,7 @@ export function has_replay_recording(): boolean;
 export function init_panic_hook(): void;
 
 /**
- * Initialize a new game.
+ * Initialize a new game for local (single-player / AI) play.
  * Accepts deck_data as a DeckList (name-only) or null/undefined for empty libraries.
  * format_config_js: optional FormatConfig JSON — defaults to Standard if null/undefined.
  * match_config_js: optional MatchConfig JSON — defaults to BO1 if null/undefined.
@@ -248,8 +248,32 @@ export function init_panic_hook(): void;
  * first_player: 0 = human plays first (CR 103.1), 1 = opponent plays first, None = random.
  * Names are resolved against the card database loaded via load_card_database().
  * Returns the initial ActionResult (events + waiting_for).
+ *
+ * Refuses with an `engine_occupied` envelope when a multiplayer host session
+ * holds this engine — on a memory-constrained device that host shares this
+ * very worker, and overwriting its game would destroy the authoritative state
+ * its guests are playing against.
  */
 export function initialize_game(deck_data: any, seed: number | null | undefined, format_config_js: any, match_config_js: any, player_count?: number | null, first_player?: number | null): any;
+
+/**
+ * Initialize a new game *and* claim this engine for a multiplayer host
+ * session, in one call.
+ *
+ * Same parameters and same return envelope as `initialize_game`. The P2P host
+ * uses this instead, for two reasons that only a single call can satisfy:
+ *
+ * 1. **Refuses an occupied engine.** A hosted game must never start on top of
+ *    a live local game. A client-side probe followed by an install is two
+ *    round-trips with a window between them; this guard runs inside the same
+ *    synchronous worker task as the install, so nothing can interleave.
+ * 2. **Atomic multiplayer-flag claim.** The flag is set on the line after the
+ *    state install (see `claim_engine_for`), so there is no window where a
+ *    stray `restore_game_state` (undo) would be accepted, and no window where
+ *    a failed init leaves the flag set on an engine it never took. Mirrors
+ *    `resume_multiplayer_host_state`, the resume-side sibling of this call.
+ */
+export function initialize_multiplayer_host_game(deck_data: any, seed: number | null | undefined, format_config_js: any, match_config_js: any, player_count?: number | null, first_player?: number | null): any;
 
 /**
  * Whether the named card can serve as this format's command-zone leader.
@@ -430,10 +454,14 @@ export function resume_multiplayer_host_state(json_str: string): void;
 export function search_cards_js(query: any): any;
 
 /**
- * Toggle the multiplayer enforcement flag. Called by multiplayer adapters
- * (P2P host/guest, WS) after the engine is initialized so subsequent
- * `restore_game_state` calls fail fast with a clear error instead of
- * silently rewriting the local view.
+ * Set the multiplayer enforcement flag directly.
+ *
+ * Entering multiplayer is *not* done here: the engine claims the flag itself,
+ * in the same call that installs the game (`initialize_multiplayer_host_game`,
+ * `resume_multiplayer_host_state`), so no client can leave the flag and the
+ * game it describes out of step. This entry point serves the release side —
+ * `releaseHostSession` clears the flag when a host session ends, so the next
+ * local game on a shared worker may undo again.
  */
 export function set_multiplayer_mode(enabled: boolean): void;
 
@@ -524,6 +552,7 @@ export interface InitOutput {
     readonly get_viewer_snapshot_js: (a: number) => any;
     readonly has_replay_recording: () => number;
     readonly initialize_game: (a: any, b: number, c: number, d: any, e: any, f: number, g: number) => any;
+    readonly initialize_multiplayer_host_game: (a: any, b: number, c: number, d: any, e: any, f: number, g: number) => any;
     readonly isCardCommanderEligibleForFormat: (a: number, b: number, c: any) => number;
     readonly is_card_commander_eligible: (a: number, b: number) => number;
     readonly is_multiplayer_mode: () => number;

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -332,10 +332,13 @@ thread_local! {
     /// Cell::take() + Cell::set() has no borrow guard, making it panic-resilient.
     static GAME_STATE: Cell<Option<GameState>> = const { Cell::new(None) };
     static CARD_DB: RefCell<Option<CardDatabase>> = const { RefCell::new(None) };
-    /// When set, the engine is running inside a multiplayer session (online
-    /// WebSocket, P2P host, or P2P guest). Undo-style state rollback is
-    /// refused in this mode because rewinding a single client's view would
-    /// desync from the authoritative game on the wire. See `restore_game_state`.
+    /// When set, this engine is claimed by a multiplayer host session. The
+    /// engine claims it itself, in the same call that installs the game
+    /// (`initialize_multiplayer_host_game`, `resume_multiplayer_host_state`),
+    /// so there is never a window in which the flag and the game it describes
+    /// disagree. Undo-style state rollback is refused while it is set because
+    /// rewinding a single client's view would desync from the authoritative
+    /// game on the wire. See `restore_game_state`.
     static MULTIPLAYER_MODE: Cell<bool> = const { Cell::new(false) };
     /// Per-thread cache of the last-built `AiSession`, keyed by deck-composition
     /// fingerprint. The WASM bridge cannot hold the session on the stack across
@@ -468,10 +471,14 @@ enum AiProposalSubmission {
     },
 }
 
-/// Toggle the multiplayer enforcement flag. Called by multiplayer adapters
-/// (P2P host/guest, WS) after the engine is initialized so subsequent
-/// `restore_game_state` calls fail fast with a clear error instead of
-/// silently rewriting the local view.
+/// Set the multiplayer enforcement flag directly.
+///
+/// Entering multiplayer is *not* done here: the engine claims the flag itself,
+/// in the same call that installs the game (`initialize_multiplayer_host_game`,
+/// `resume_multiplayer_host_state`), so no client can leave the flag and the
+/// game it describes out of step. This entry point serves the release side —
+/// `releaseHostSession` clears the flag when a host session ends, so the next
+/// local game on a shared worker may undo again.
 #[wasm_bindgen]
 pub fn set_multiplayer_mode(enabled: bool) {
     MULTIPLAYER_MODE.with(|cell| cell.set(enabled));
@@ -1034,7 +1041,73 @@ fn estimate_bracket_inner(deck: &PlayerDeckList) -> Option<BracketEstimate> {
     })
 }
 
-/// Initialize a new game.
+/// Which client-side session is installing this game. Selects the
+/// debug-permission posture and whether the multiplayer flag is claimed in the
+/// same call.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum InitSessionKind {
+    Local,
+    MultiplayerHost,
+}
+
+/// Is a game installed in this engine right now?
+///
+/// `GAME_STATE` is a `Cell<Option<GameState>>` for panic-resilience (see the
+/// thread-local's own doc) and `GameState` is not `Copy`, so take-peek-set is
+/// the only way to read it.
+fn game_state_present() -> bool {
+    GAME_STATE.with(|cell| {
+        let state = cell.take();
+        let present = state.is_some();
+        cell.set(state);
+        present
+    })
+}
+
+/// May a session of `kind` install a game into this engine right now?
+///
+/// Pure over the two thread-locals and free of `JsValue`, so it runs in the
+/// native test suite.
+fn init_guard(kind: InitSessionKind) -> Result<(), &'static str> {
+    match kind {
+        // On a memory-constrained device the P2P host shares the tab's single
+        // engine worker with local play, so an unguarded local initialize would
+        // silently destroy the hosted game. Mirrors `restore_game_state`'s
+        // refusal on the same flag.
+        InitSessionKind::Local if is_multiplayer_mode() => {
+            Err("a multiplayer host session owns this engine")
+        }
+        // The other direction: refuse rather than overwrite a resident local
+        // game.
+        InitSessionKind::MultiplayerHost if game_state_present() => {
+            Err("engine already holds a game")
+        }
+        // A local game may always replace another local game — that is how a
+        // rematch starts, and nothing clears `GAME_STATE` in between.
+        _ => Ok(()),
+    }
+}
+
+/// Claim the engine for `kind`. Called immediately after the state install so
+/// the flag and the game it describes are set in one uninterruptible step.
+fn claim_engine_for(kind: InitSessionKind) {
+    if kind == InitSessionKind::MultiplayerHost {
+        MULTIPLAYER_MODE.with(|cell| cell.set(true));
+    }
+}
+
+/// Envelope for an `init_guard` refusal. Carries the typed `engine_occupied`
+/// discriminator — like `cedh_bracket_violation` below — so the adapter raises
+/// a dedicated error instead of matching on a raw string substring.
+fn occupied_refusal(reason: &str) -> JsValue {
+    to_js(&serde_json::json!({
+        "error": true,
+        "engine_occupied": true,
+        "reasons": [reason],
+    }))
+}
+
+/// Initialize a new game for local (single-player / AI) play.
 /// Accepts deck_data as a DeckList (name-only) or null/undefined for empty libraries.
 /// format_config_js: optional FormatConfig JSON — defaults to Standard if null/undefined.
 /// match_config_js: optional MatchConfig JSON — defaults to BO1 if null/undefined.
@@ -1042,6 +1115,11 @@ fn estimate_bracket_inner(deck: &PlayerDeckList) -> Option<BracketEstimate> {
 /// first_player: 0 = human plays first (CR 103.1), 1 = opponent plays first, None = random.
 /// Names are resolved against the card database loaded via load_card_database().
 /// Returns the initial ActionResult (events + waiting_for).
+///
+/// Refuses with an `engine_occupied` envelope when a multiplayer host session
+/// holds this engine — on a memory-constrained device that host shares this
+/// very worker, and overwriting its game would destroy the authoritative state
+/// its guests are playing against.
 #[wasm_bindgen]
 pub fn initialize_game(
     deck_data: JsValue,
@@ -1050,6 +1128,70 @@ pub fn initialize_game(
     match_config_js: JsValue,
     player_count: Option<u8>,
     first_player: Option<u8>,
+) -> JsValue {
+    if let Err(reason) = init_guard(InitSessionKind::Local) {
+        return occupied_refusal(reason);
+    }
+    initialize_game_impl(
+        deck_data,
+        seed,
+        format_config_js,
+        match_config_js,
+        player_count,
+        first_player,
+        InitSessionKind::Local,
+    )
+}
+
+/// Initialize a new game *and* claim this engine for a multiplayer host
+/// session, in one call.
+///
+/// Same parameters and same return envelope as `initialize_game`. The P2P host
+/// uses this instead, for two reasons that only a single call can satisfy:
+///
+/// 1. **Refuses an occupied engine.** A hosted game must never start on top of
+///    a live local game. A client-side probe followed by an install is two
+///    round-trips with a window between them; this guard runs inside the same
+///    synchronous worker task as the install, so nothing can interleave.
+/// 2. **Atomic multiplayer-flag claim.** The flag is set on the line after the
+///    state install (see `claim_engine_for`), so there is no window where a
+///    stray `restore_game_state` (undo) would be accepted, and no window where
+///    a failed init leaves the flag set on an engine it never took. Mirrors
+///    `resume_multiplayer_host_state`, the resume-side sibling of this call.
+#[wasm_bindgen]
+pub fn initialize_multiplayer_host_game(
+    deck_data: JsValue,
+    seed: Option<f64>,
+    format_config_js: JsValue,
+    match_config_js: JsValue,
+    player_count: Option<u8>,
+    first_player: Option<u8>,
+) -> JsValue {
+    if let Err(reason) = init_guard(InitSessionKind::MultiplayerHost) {
+        return occupied_refusal(reason);
+    }
+    initialize_game_impl(
+        deck_data,
+        seed,
+        format_config_js,
+        match_config_js,
+        player_count,
+        first_player,
+        InitSessionKind::MultiplayerHost,
+    )
+}
+
+/// Shared body of both initialize entry points. The guard lives in the shells
+/// (they are where `JsValue` envelopes are produced); this function assumes it
+/// has already passed and installs unconditionally.
+fn initialize_game_impl(
+    deck_data: JsValue,
+    seed: Option<f64>,
+    format_config_js: JsValue,
+    match_config_js: JsValue,
+    player_count: Option<u8>,
+    first_player: Option<u8>,
+    kind: InitSessionKind,
 ) -> JsValue {
     let seed = seed.map(|s| s as u64).unwrap_or(42);
 
@@ -1074,7 +1216,11 @@ pub fn initialize_game(
     }
 
     let mut state = GameState::new(format_config.clone(), count, seed);
-    initialize_debug_permissions(&mut state, is_multiplayer_mode());
+    // Read the posture from `kind`, not from `is_multiplayer_mode()`: the flag
+    // is claimed *after* this install (see `claim_engine_for`), so the
+    // thread-local is still clear here and a host game would otherwise be given
+    // local debug permissions.
+    initialize_debug_permissions(&mut state, kind == InitSessionKind::MultiplayerHost);
     let match_config = if !match_config_js.is_null() && !match_config_js.is_undefined() {
         serde_wasm_bindgen::from_value::<MatchConfig>(match_config_js)
             .unwrap_or_else(|_| MatchConfig::default())
@@ -1292,6 +1438,9 @@ pub fn initialize_game(
     bind_interaction_session(&mut state);
 
     GAME_STATE.with(|cell| cell.set(Some(state)));
+    // Adjacent to the install, exactly as `resume_multiplayer_host_state` does:
+    // the flag and the game it describes are set in one uninterruptible step.
+    claim_engine_for(kind);
     clear_ai_session_cache();
     invalidate_ai_proposals();
 
@@ -2096,13 +2245,7 @@ pub fn resume_multiplayer_host_state(json_str: &str) -> Result<(), JsValue> {
             "resume_multiplayer_host_state refused: multiplayer mode already set",
         ));
     }
-    let already_has_state = GAME_STATE.with(|cell| {
-        let s = cell.take();
-        let present = s.is_some();
-        cell.set(s);
-        present
-    });
-    if already_has_state {
+    if game_state_present() {
         return Err(JsValue::from_str(
             "resume_multiplayer_host_state refused: engine already initialized; call clear_game_state first",
         ));
@@ -5513,5 +5656,95 @@ mod ai_scoring_rng_bridge_tests {
         drive_scoring();
 
         clear_game_state();
+    }
+}
+
+/// Native coverage for the engine-claim guard. `init_guard` and
+/// `claim_engine_for` are plain Rust functions over the two thread-locals, so —
+/// unlike the `wasm32`-gated `mod tests`, whose assertions never execute in the
+/// native suite — these really run under `cargo test`/nextest. The
+/// `#[wasm_bindgen]` shells that call them take and return `JsValue` and cannot
+/// run natively; the frontend suite covers that wiring.
+///
+/// Each case establishes both thread-locals it reads: nextest's
+/// process-per-test execution keeps them isolated, and the setup makes each
+/// case independent of ordering regardless.
+#[cfg(test)]
+mod engine_claim_guard_tests {
+    use super::*;
+
+    fn install_resident_game() {
+        GAME_STATE.with(|cell| cell.set(Some(GameState::new_two_player(0x0C1A_13ED))));
+    }
+
+    #[test]
+    fn a_multiplayer_host_is_refused_when_the_engine_already_holds_a_game() {
+        clear_game_state();
+        set_multiplayer_mode(false);
+        install_resident_game();
+
+        assert_eq!(
+            init_guard(InitSessionKind::MultiplayerHost),
+            Err("engine already holds a game"),
+            "a hosted game must never overwrite the live local game it shares a worker with"
+        );
+
+        clear_game_state();
+    }
+
+    #[test]
+    fn a_multiplayer_host_may_claim_an_empty_engine() {
+        clear_game_state();
+        set_multiplayer_mode(false);
+
+        assert_eq!(init_guard(InitSessionKind::MultiplayerHost), Ok(()));
+    }
+
+    #[test]
+    fn a_local_game_is_refused_while_a_multiplayer_host_owns_the_engine() {
+        clear_game_state();
+        set_multiplayer_mode(true);
+
+        assert_eq!(
+            init_guard(InitSessionKind::Local),
+            Err("a multiplayer host session owns this engine"),
+            "starting local play on the host's shared worker would destroy the hosted game"
+        );
+
+        set_multiplayer_mode(false);
+    }
+
+    #[test]
+    fn a_local_game_may_still_replace_another_local_game() {
+        clear_game_state();
+        set_multiplayer_mode(false);
+        install_resident_game();
+
+        // The rematch guarantee: a local rematch is a fresh `initialize_game`
+        // with no intervening `clear_game_state`, so refusing an occupied
+        // engine here would break ordinary single-player play.
+        assert_eq!(init_guard(InitSessionKind::Local), Ok(()));
+
+        clear_game_state();
+    }
+
+    #[test]
+    fn only_a_multiplayer_host_claims_the_engine() {
+        clear_game_state();
+        set_multiplayer_mode(false);
+
+        claim_engine_for(InitSessionKind::Local);
+        assert!(
+            !is_multiplayer_mode(),
+            "a local game must leave the flag clear, or undo would be refused for the rest of the tab"
+        );
+
+        claim_engine_for(InitSessionKind::MultiplayerHost);
+        assert!(
+            is_multiplayer_mode(),
+            "the host claim is what refuses a later local initialize and undo"
+        );
+
+        set_multiplayer_mode(false);
     }
 }


### PR DESCRIPTION
Hosting a P2P game reloaded the page on memory-constrained devices (iOS),
consistently and before any guest joined. The multiplayer page warms the
shared engine worker's ~100MB card database on mount, then `P2PHostAdapter`
constructed its own `WasmAdapter` — a second worker, a second WASM instance,
and (once the AI-seat loop called `applySeatMutation`, which awaited
`ensureCardDb`) a second resident copy of that database. On iOS the main
thread and every worker share one web-content-process budget, so the second
copy was not free headroom.

Route the host through `getSharedAdapter()` when `isMemoryConstrainedDevice()`
says the trade is worth it: one worker, slower under contention but not
heavier. Everywhere else keeps its private adapter.

Sharing an engine means two flows can install a game into it, so the claim
has to be arbitrated. Doing that in the client would need a probe followed by
an install — two worker round-trips with a window between them, and on a cold
database both flows await the *same* `cardDbPromise`, so they rendezvous on
one resolution and both post `initialize_game`. The loser's game is destroyed.

So the engine arbitrates instead. `initialize_multiplayer_host_game` refuses
an engine that already holds a game; `initialize_game` refuses one a host
session owns; both run inside the same synchronous worker task as the install,
so nothing can interleave. The multiplayer flag is claimed on the line after
the state install (`claim_engine_for`), mirroring `resume_multiplayer_host_state`
— so a failed init can never leave the flag set on an engine it never took.

Because a refusal now leaves the engine byte-for-byte untouched, the client's
compensating logic goes away: no probe, no `setMultiplayerMode(true)`, and no
flag hand-back on the error path. The catch converts to `claimed: false`
rather than disappearing, which keeps the private-adapter worker disposal and
the typed "disposed during start" error.

Refusals surface as `AdapterErrorCode.ENGINE_OCCUPIED` through a single
`classifyInitFailure` authority, so a local-direction refusal cannot reach the
user mislabeled as "Deck validation failed".

Engine guard logic lives in `init_guard`/`claim_engine_for` — plain functions
over the two thread-locals, covered by native tests in the `engine-wasm`
package. Note that Tilt's `test-engine` runs `-p phase-engine` and does not
execute them; CI's `--workspace` run does.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added reliable multiplayer host-game initialization with exclusive engine ownership.
  * Improved host session cleanup when games end, fail to start, or are interrupted.
  * Added shared-engine support for memory-constrained devices while preserving private sessions elsewhere.

* **Bug Fixes**
  * Prevented active games from being overwritten by new sessions.
  * Added clearer errors for occupied engines, invalid decks, and cEDH bracket violations.
  * Improved handling of disposed or superseded multiplayer hosts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->