### PR TITLE
chore: refresh metagame feeds

### DIFF
--- a/client/public/feeds/mtggoldfish-commander.json
+++ b/client/public/feeds/mtggoldfish-commander.json
@@ -5,15 +5,15 @@
   "icon": "G",
   "format": "commander",
   "version": 1,
-  "updated": "2026-08-14T00:00:00Z",
+  "updated": "2026-08-15T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/commander",
   "decks": [
     {
       "name": "Y'shtola, Night's Blessed",
       "author": "MTGGoldfish",
       "colors": [
-        "U",
         "B",
+        "U",
         "W"
       ],
       "tags": [
@@ -22,151 +22,35 @@
       "main": [
         {
           "count": 1,
-          "name": "Y'shtola, Night's Blessed"
+          "name": "Esper Sentinel"
         },
         {
           "count": 1,
-          "name": "Alisaie Leveilleur"
+          "name": "Sygg, River Cutthroat"
         },
         {
           "count": 1,
-          "name": "Alphinaud Leveilleur"
+          "name": "Delney, Streetwise Lookout"
         },
         {
           "count": 1,
-          "name": "Arcane Signet"
+          "name": "Sakashima of a Thousand Faces"
         },
         {
           "count": 1,
-          "name": "Archaeomancer's Map"
+          "name": "Spark Double"
         },
         {
           "count": 1,
-          "name": "Archmage Emeritus"
+          "name": "Roaming Throne"
         },
         {
           "count": 1,
-          "name": "Ardbert, Warrior of Darkness"
+          "name": "Submerge"
         },
         {
           "count": 1,
-          "name": "Baleful Strix"
-        },
-        {
-          "count": 1,
-          "name": "Circle of Power"
-        },
-        {
-          "count": 1,
-          "name": "Cleansing Nova"
-        },
-        {
-          "count": 1,
-          "name": "Counterspell"
-        },
-        {
-          "count": 1,
-          "name": "Curiosity"
-        },
-        {
-          "count": 1,
-          "name": "Absorb"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves"
-        },
-        {
-          "count": 1,
-          "name": "Dig Through Time"
-        },
-        {
-          "count": 1,
-          "name": "Dismember"
-        },
-        {
-          "count": 1,
-          "name": "Emet-Selch of the Third Seat"
-        },
-        {
-          "count": 1,
-          "name": "Estinien Varlineau"
-        },
-        {
-          "count": 1,
-          "name": "Exsanguinate"
-        },
-        {
-          "count": 1,
-          "name": "Fandaniel, Telophoroi Ascian"
-        },
-        {
-          "count": 1,
-          "name": "Final Judgment"
-        },
-        {
-          "count": 1,
-          "name": "Frantic Search"
-        },
-        {
-          "count": 1,
-          "name": "G'raha Tia, Scion Reborn"
-        },
-        {
-          "count": 1,
-          "name": "Ghostly Prison"
-        },
-        {
-          "count": 1,
-          "name": "Glacial Fortress"
-        },
-        {
-          "count": 1,
-          "name": "Hraesvelgr of the First Brood"
-        },
-        {
-          "count": 1,
-          "name": "Sinister Sabotage"
-        },
-        {
-          "count": 1,
-          "name": "Krile Baldesion"
-        },
-        {
-          "count": 1,
-          "name": "Lethal Scheme"
-        },
-        {
-          "count": 1,
-          "name": "Lyse Hext"
-        },
-        {
-          "count": 1,
-          "name": "Murderous Rider"
-        },
-        {
-          "count": 1,
-          "name": "Cryptic Command"
-        },
-        {
-          "count": 1,
-          "name": "Papalymo Totolymo"
-        },
-        {
-          "count": 1,
-          "name": "Swiftfoot Boots"
-        },
-        {
-          "count": 1,
-          "name": "Relic of Legends"
-        },
-        {
-          "count": 1,
-          "name": "Render Silent"
-        },
-        {
-          "count": 1,
-          "name": "Scavenger Grounds"
+          "name": "Despark"
         },
         {
           "count": 1,
@@ -174,63 +58,7 @@
         },
         {
           "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Sphinx's Revelation"
-        },
-        {
-          "count": 1,
-          "name": "Sublime Epiphany"
-        },
-        {
-          "count": 1,
-          "name": "Swords to Plowshares"
-        },
-        {
-          "count": 1,
-          "name": "Syphon Mind"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Dominance"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Hierarchy"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Progress"
-        },
-        {
-          "count": 1,
-          "name": "Tataru Taru"
-        },
-        {
-          "count": 1,
-          "name": "Command Beacon"
-        },
-        {
-          "count": 1,
-          "name": "Talrand, Sky Summoner"
-        },
-        {
-          "count": 1,
-          "name": "Thought Vessel"
-        },
-        {
-          "count": 1,
-          "name": "Torrential Gearhulk"
-        },
-        {
-          "count": 1,
-          "name": "Transpose"
-        },
-        {
-          "count": 1,
-          "name": "Vindicate"
+          "name": "Cyclonic Rift"
         },
         {
           "count": 1,
@@ -238,51 +66,23 @@
         },
         {
           "count": 1,
-          "name": "White Auracite"
+          "name": "Soul Shatter"
         },
         {
           "count": 1,
-          "name": "Professor Onyx"
+          "name": "Swords to Plowshares"
         },
         {
           "count": 1,
-          "name": "Sedgemoor Witch"
+          "name": "Dismember"
         },
         {
           "count": 1,
-          "name": "Storm of Saruman"
+          "name": "Anguished Unmaking"
         },
         {
           "count": 1,
-          "name": "Metallurgic Summonings"
-        },
-        {
-          "count": 1,
-          "name": "Rhystic Study"
-        },
-        {
-          "count": 1,
-          "name": "Mystic Remora"
-        },
-        {
-          "count": 1,
-          "name": "Vito, Thorn of the Dusk Rose"
-        },
-        {
-          "count": 1,
-          "name": "Teferi's Ageless Insight"
-        },
-        {
-          "count": 1,
-          "name": "Fact or Fiction"
-        },
-        {
-          "count": 1,
-          "name": "Kaya's Guile"
-        },
-        {
-          "count": 1,
-          "name": "Drown in the Loch"
+          "name": "Path to Exile"
         },
         {
           "count": 1,
@@ -290,15 +90,255 @@
         },
         {
           "count": 1,
-          "name": "Vault of Champions"
+          "name": "Swan Song"
         },
         {
           "count": 1,
-          "name": "Ash Barrens"
+          "name": "An Offer You Can't Refuse"
         },
         {
           "count": 1,
-          "name": "Choked Estuary"
+          "name": "Fierce Guardianship"
+        },
+        {
+          "count": 1,
+          "name": "Force of Will"
+        },
+        {
+          "count": 1,
+          "name": "Force of Negation"
+        },
+        {
+          "count": 1,
+          "name": "Mana Drain"
+        },
+        {
+          "count": 1,
+          "name": "Rewind"
+        },
+        {
+          "count": 1,
+          "name": "Unwind"
+        },
+        {
+          "count": 1,
+          "name": "Vampiric Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Teferi's Protection"
+        },
+        {
+          "count": 1,
+          "name": "Frantic Search"
+        },
+        {
+          "count": 1,
+          "name": "Flawless Maneuver"
+        },
+        {
+          "count": 1,
+          "name": "Amphibian Downpour"
+        },
+        {
+          "count": 1,
+          "name": "Restricted Office // Lecture Hall"
+        },
+        {
+          "count": 1,
+          "name": "Grasp of Fate"
+        },
+        {
+          "count": 1,
+          "name": "Smothering Tithe"
+        },
+        {
+          "count": 1,
+          "name": "Curiosity"
+        },
+        {
+          "count": 1,
+          "name": "Ophidian Eye"
+        },
+        {
+          "count": 1,
+          "name": "Mystic Remora"
+        },
+        {
+          "count": 1,
+          "name": "Black Market Connections"
+        },
+        {
+          "count": 1,
+          "name": "Helm of the Ghastlord"
+        },
+        {
+          "count": 1,
+          "name": "Sigil of Sleep"
+        },
+        {
+          "count": 1,
+          "name": "Rhystic Study"
+        },
+        {
+          "count": 1,
+          "name": "Vanquish the Horde"
+        },
+        {
+          "count": 1,
+          "name": "Toxic Deluge"
+        },
+        {
+          "count": 1,
+          "name": "Tragic Arrogance"
+        },
+        {
+          "count": 1,
+          "name": "The Battle of Bywater"
+        },
+        {
+          "count": 1,
+          "name": "Promise of Loyalty"
+        },
+        {
+          "count": 1,
+          "name": "Stock Up"
+        },
+        {
+          "count": 1,
+          "name": "Multiversal Recruitment"
+        },
+        {
+          "count": 1,
+          "name": "Quantum Misalignment"
+        },
+        {
+          "count": 1,
+          "name": "Irenicus's Vile Duplication"
+        },
+        {
+          "count": 1,
+          "name": "Risky Shortcut"
+        },
+        {
+          "count": 1,
+          "name": "Demonic Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "The One Ring"
+        },
+        {
+          "count": 1,
+          "name": "Thought Vessel"
+        },
+        {
+          "count": 1,
+          "name": "Basilisk Collar"
+        },
+        {
+          "count": 1,
+          "name": "Y'shtola, Night's Blessed"
+        },
+        {
+          "count": 1,
+          "name": "Fellwar Stone"
+        },
+        {
+          "count": 1,
+          "name": "Relic of Legends"
+        },
+        {
+          "count": 1,
+          "name": "Bender's Waterskin"
+        },
+        {
+          "count": 1,
+          "name": "Talisman of Dominance"
+        },
+        {
+          "count": 1,
+          "name": "Talisman of Progress"
+        },
+        {
+          "count": 1,
+          "name": "Talisman of Hierarchy"
+        },
+        {
+          "count": 1,
+          "name": "Decanter of Endless Water"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Tomb"
+        },
+        {
+          "count": 1,
+          "name": "Malakir Rebirth"
+        },
+        {
+          "count": 1,
+          "name": "Glacial Fortress"
+        },
+        {
+          "count": 2,
+          "name": "Swamp"
+        },
+        {
+          "count": 2,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Fell the Profane"
+        },
+        {
+          "count": 1,
+          "name": "Caves of Koilos"
+        },
+        {
+          "count": 1,
+          "name": "Bleachbone Verge"
+        },
+        {
+          "count": 1,
+          "name": "Polluted Delta"
+        },
+        {
+          "count": 1,
+          "name": "Raffine's Tower"
+        },
+        {
+          "count": 1,
+          "name": "Midgar, City of Mako"
+        },
+        {
+          "count": 1,
+          "name": "Marsh Flats"
+        },
+        {
+          "count": 1,
+          "name": "Otawara, Soaring City"
+        },
+        {
+          "count": 1,
+          "name": "Underground River"
+        },
+        {
+          "count": 1,
+          "name": "Reliquary Tower"
+        },
+        {
+          "count": 2,
+          "name": "Plains"
         },
         {
           "count": 1,
@@ -306,59 +346,7 @@
         },
         {
           "count": 1,
-          "name": "Fabled Passage"
-        },
-        {
-          "count": 1,
-          "name": "Darkwater Catacombs"
-        },
-        {
-          "count": 1,
-          "name": "Demolition Field"
-        },
-        {
-          "count": 1,
-          "name": "Watery Grave"
-        },
-        {
-          "count": 1,
-          "name": "Drowned Catacomb"
-        },
-        {
-          "count": 1,
-          "name": "Evolving Wilds"
-        },
-        {
-          "count": 1,
-          "name": "Exotic Orchard"
-        },
-        {
-          "count": 1,
-          "name": "Fetid Heath"
-        },
-        {
-          "count": 1,
-          "name": "Godless Shrine"
-        },
-        {
-          "count": 3,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Isolated Chapel"
-        },
-        {
-          "count": 1,
           "name": "Sea of Clouds"
-        },
-        {
-          "count": 4,
-          "name": "Plains"
-        },
-        {
-          "count": 1,
-          "name": "Adarkar Wastes"
         },
         {
           "count": 1,
@@ -366,7 +354,27 @@
         },
         {
           "count": 1,
-          "name": "Skycloud Expanse"
+          "name": "Godless Shrine"
+        },
+        {
+          "count": 1,
+          "name": "Hydroelectric Specimen"
+        },
+        {
+          "count": 1,
+          "name": "Exotic Orchard"
+        },
+        {
+          "count": 1,
+          "name": "Witch Enchanter"
+        },
+        {
+          "count": 1,
+          "name": "Command Beacon"
+        },
+        {
+          "count": 1,
+          "name": "City of Brass"
         },
         {
           "count": 1,
@@ -378,15 +386,27 @@
         },
         {
           "count": 1,
-          "name": "Caves of Koilos"
-        },
-        {
-          "count": 4,
-          "name": "Swamp"
+          "name": "Isolated Chapel"
         },
         {
           "count": 1,
-          "name": "Underground River"
+          "name": "Shattered Sanctum"
+        },
+        {
+          "count": 1,
+          "name": "Deserted Beach"
+        },
+        {
+          "count": 1,
+          "name": "Sink into Stupor"
+        },
+        {
+          "count": 1,
+          "name": "Flooded Strand"
+        },
+        {
+          "count": 1,
+          "name": "Adarkar Wastes"
         }
       ],
       "sideboard": []
@@ -761,7 +781,301 @@
       "name": "The Great Goblin",
       "author": "MTGGoldfish",
       "colors": [
-        "B",
+        "R",
+        "B"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Along the Crooked Way"
+        },
+        {
+          "count": 1,
+          "name": "Assault on Osgiliath"
+        },
+        {
+          "count": 1,
+          "name": "Azog, Moria's Ruin"
+        },
+        {
+          "count": 1,
+          "name": "Barad-dur"
+        },
+        {
+          "count": 1,
+          "name": "Blasphemous Act"
+        },
+        {
+          "count": 1,
+          "name": "Bolg of the North"
+        },
+        {
+          "count": 1,
+          "name": "Bolg, Erebor's Reckoning"
+        },
+        {
+          "count": 1,
+          "name": "Bolg's Company"
+        },
+        {
+          "count": 1,
+          "name": "Book of Mazarbul"
+        },
+        {
+          "count": 1,
+          "name": "Bothersome Noisemaker"
+        },
+        {
+          "count": 1,
+          "name": "Burn, Burn, Tree and Fern"
+        },
+        {
+          "count": 1,
+          "name": "Call of the Ring"
+        },
+        {
+          "count": 1,
+          "name": "Cirith Ungol Patrol"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Crypt Incursion"
+        },
+        {
+          "count": 1,
+          "name": "Decree of Pain"
+        },
+        {
+          "count": 1,
+          "name": "Dragonskull Summit"
+        },
+        {
+          "count": 1,
+          "name": "Fearsome Goblin Pair"
+        },
+        {
+          "count": 1,
+          "name": "Feed the Swarm"
+        },
+        {
+          "count": 1,
+          "name": "Foray of Orcs"
+        },
+        {
+          "count": 1,
+          "name": "Foreboding Ruins"
+        },
+        {
+          "count": 1,
+          "name": "Gathering of Darkness"
+        },
+        {
+          "count": 1,
+          "name": "Go for the Throat"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Cratermaker"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Plate Mail"
+        },
+        {
+          "count": 1,
+          "name": "Goblin-town Flunkies"
+        },
+        {
+          "count": 1,
+          "name": "Gorbag of Minas Morgul"
+        },
+        {
+          "count": 1,
+          "name": "Gothmog, Morgul Lieutenant"
+        },
+        {
+          "count": 1,
+          "name": "Great Goblin, Foul-Hearted"
+        },
+        {
+          "count": 1,
+          "name": "Grima Wormtongue"
+        },
+        {
+          "count": 1,
+          "name": "Grishnakh, Brash Instigator"
+        },
+        {
+          "count": 1,
+          "name": "Heirloom Blade"
+        },
+        {
+          "count": 1,
+          "name": "Lash of the Balrog"
+        },
+        {
+          "count": 1,
+          "name": "March from the Black Gate"
+        },
+        {
+          "count": 1,
+          "name": "Mauhur, Uruk-hai Captain"
+        },
+        {
+          "count": 1,
+          "name": "Merciless Executioner"
+        },
+        {
+          "count": 1,
+          "name": "Misty Mountains Raider"
+        },
+        {
+          "count": 1,
+          "name": "Mithril Coat"
+        },
+        {
+          "count": 1,
+          "name": "Mordor Muster"
+        },
+        {
+          "count": 1,
+          "name": "Moria Marauder"
+        },
+        {
+          "count": 1,
+          "name": "Moria Scavenger"
+        },
+        {
+          "count": 1,
+          "name": "Mount Doom"
+        },
+        {
+          "count": 16,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "My Precious"
+        },
+        {
+          "count": 1,
+          "name": "Nasty End"
+        },
+        {
+          "count": 1,
+          "name": "Night's Whisper"
+        },
+        {
+          "count": 1,
+          "name": "Orcish Bowmasters"
+        },
+        {
+          "count": 1,
+          "name": "Orcish Medicine"
+        },
+        {
+          "count": 1,
+          "name": "Orcish Siegemaster"
+        },
+        {
+          "count": 1,
+          "name": "Path of Ancestry"
+        },
+        {
+          "count": 1,
+          "name": "Rage into the Valley"
+        },
+        {
+          "count": 1,
+          "name": "Reanimate"
+        },
+        {
+          "count": 1,
+          "name": "Rhovanion Rampager"
+        },
+        {
+          "count": 1,
+          "name": "Siege-Gang Commander"
+        },
+        {
+          "count": 1,
+          "name": "Smoldering Marsh"
+        },
+        {
+          "count": 1,
+          "name": "Snowslope Hunter"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Spiteful Banditry"
+        },
+        {
+          "count": 1,
+          "name": "Stir Up Trouble"
+        },
+        {
+          "count": 1,
+          "name": "Sulfurous Springs"
+        },
+        {
+          "count": 1,
+          "name": "Supper for Spiders"
+        },
+        {
+          "count": 16,
+          "name": "Swamp"
+        },
+        {
+          "count": 1,
+          "name": "The One Ring"
+        },
+        {
+          "count": 1,
+          "name": "The Sackville-Bagginses"
+        },
+        {
+          "count": 1,
+          "name": "There and Back Again"
+        },
+        {
+          "count": 1,
+          "name": "Toxic Deluge"
+        },
+        {
+          "count": 1,
+          "name": "Treasure Nabber"
+        },
+        {
+          "count": 1,
+          "name": "Warbeast of Gorgoroth"
+        },
+        {
+          "count": 1,
+          "name": "Warg Rider"
+        },
+        {
+          "count": 1,
+          "name": "The Great Goblin"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "Vivi Ornitier",
+      "author": "MTGGoldfish",
+      "colors": [
+        "U",
         "R"
       ],
       "tags": [
@@ -770,243 +1084,19 @@
       "main": [
         {
           "count": 1,
-          "name": "Azog, Moria's Ruin"
+          "name": "Vivi Ornitier"
         },
         {
           "count": 1,
-          "name": "Bolg of the North"
+          "name": "Aboshan's Desire"
         },
         {
           "count": 1,
-          "name": "Bolg's Company"
+          "name": "An Offer You Can't Refuse"
         },
         {
           "count": 1,
-          "name": "Great Goblin, Foul-Hearted"
-        },
-        {
-          "count": 1,
-          "name": "Boggart Mischief"
-        },
-        {
-          "count": 1,
-          "name": "Scuzzback Scrounger"
-        },
-        {
-          "count": 1,
-          "name": "Boggart Cursecrafter"
-        },
-        {
-          "count": 1,
-          "name": "Grub, Storied Matriarch"
-        },
-        {
-          "count": 1,
-          "name": "Ugluk of the White Hand"
-        },
-        {
-          "count": 1,
-          "name": "Mauhur, Uruk-hai Captain"
-        },
-        {
-          "count": 1,
-          "name": "Krenko, Tin Street Kingpin"
-        },
-        {
-          "count": 1,
-          "name": "Metallic Mimic"
-        },
-        {
-          "count": 1,
-          "name": "Krenko, Mob Boss"
-        },
-        {
-          "count": 1,
-          "name": "Skirk Prospector"
-        },
-        {
-          "count": 1,
-          "name": "Warg Rider"
-        },
-        {
-          "count": 1,
-          "name": "Warren Soultrader"
-        },
-        {
-          "count": 1,
-          "name": "Assault on Osgiliath"
-        },
-        {
-          "count": 1,
-          "name": "Sling-Gang Lieutenant"
-        },
-        {
-          "count": 1,
-          "name": "Gorbag of Minas Morgul"
-        },
-        {
-          "count": 1,
-          "name": "Putrid Goblin"
-        },
-        {
-          "count": 1,
-          "name": "Knucklebone Witch"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Warchief"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Matron"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Bombardment"
-        },
-        {
-          "count": 1,
-          "name": "Bolg, Erebor's Reckoning"
-        },
-        {
-          "count": 1,
-          "name": "Misty Mountains Raider"
-        },
-        {
-          "count": 1,
-          "name": "Fearsome Goblin Pair"
-        },
-        {
-          "count": 1,
-          "name": "Rhovanion Rampager"
-        },
-        {
-          "count": 1,
-          "name": "Taurean Mauler"
-        },
-        {
-          "count": 1,
-          "name": "Skullclamp"
-        },
-        {
-          "count": 1,
-          "name": "The Great Goblin"
-        },
-        {
-          "count": 1,
-          "name": "Orcish Siegemaster"
-        },
-        {
-          "count": 1,
-          "name": "Moria Marauder"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Chirurgeon"
-        },
-        {
-          "count": 1,
-          "name": "Grishnakh, Brash Instigator"
-        },
-        {
-          "count": 1,
-          "name": "Conspicuous Snoop"
-        },
-        {
-          "count": 1,
-          "name": "Muxus, Goblin Grandee"
-        },
-        {
-          "count": 1,
-          "name": "Simian Spirit Guide"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Recruiter"
-        },
-        {
-          "count": 1,
-          "name": "Kiki-Jiki, Mirror Breaker"
-        },
-        {
-          "count": 1,
-          "name": "Legion Warboss"
-        },
-        {
-          "count": 1,
-          "name": "Flare of Duplication"
-        },
-        {
-          "count": 1,
-          "name": "Redirect Lightning"
-        },
-        {
-          "count": 1,
-          "name": "Orcish Medicine"
-        },
-        {
-          "count": 1,
-          "name": "Corrupted Conviction"
-        },
-        {
-          "count": 1,
-          "name": "Deadly Dispute"
-        },
-        {
-          "count": 1,
-          "name": "Village Rites"
-        },
-        {
-          "count": 1,
-          "name": "Brightstone Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Culling the Weak"
-        },
-        {
-          "count": 1,
-          "name": "Dark Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Gathering of Darkness"
-        },
-        {
-          "count": 1,
-          "name": "Bloodline Bidding"
-        },
-        {
-          "count": 1,
-          "name": "Soul Immolation"
-        },
-        {
-          "count": 1,
-          "name": "Widespread Brutality"
-        },
-        {
-          "count": 1,
-          "name": "Blasphemous Act"
-        },
-        {
-          "count": 1,
-          "name": "Victimize"
-        },
-        {
-          "count": 1,
-          "name": "Orcrist, Goblin-cleaver"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves"
-        },
-        {
-          "count": 1,
-          "name": "Ashnod's Altar"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
+          "name": "Arcane Denial"
         },
         {
           "count": 1,
@@ -1014,440 +1104,327 @@
         },
         {
           "count": 1,
-          "name": "Patchwork Banner"
+          "name": "Archmage Emeritus"
         },
         {
           "count": 1,
-          "name": "Anduril, Narsil Reforged"
+          "name": "Birgi, God of Storytelling"
         },
         {
           "count": 1,
-          "name": "Contagion Clasp"
+          "name": "Blade of the Bloodchief"
         },
         {
           "count": 1,
-          "name": "Barad-dur"
+          "name": "Blasphemous Act"
         },
         {
           "count": 1,
-          "name": "Karn's Bastion"
+          "name": "Brain Freeze"
         },
         {
           "count": 1,
-          "name": "High Market"
+          "name": "Brainstorm"
         },
         {
           "count": 1,
-          "name": "Dark Fortress"
+          "name": "Cascade Bluffs"
         },
         {
           "count": 1,
-          "name": "Evolving Wilds"
-        },
-        {
-          "count": 14,
-          "name": "Swamp"
-        },
-        {
-          "count": 15,
-          "name": "Mountain"
+          "name": "Command Tower"
         },
         {
           "count": 1,
-          "name": "Umbral Mantle"
+          "name": "Coruscation Mage"
         },
         {
           "count": 1,
-          "name": "Mana Echoes"
-        }
-      ],
-      "sideboard": []
-    },
-    {
-      "name": "The Ur-Dragon",
-      "author": "MTGGoldfish",
-      "colors": [
-        "R",
-        "B",
-        "W",
-        "U",
-        "G"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Rampant Growth"
+          "name": "Counterspell"
         },
         {
           "count": 1,
-          "name": "Journey of Discovery"
+          "name": "Consider"
         },
         {
           "count": 1,
-          "name": "Keiga, the Tide Star"
-        },
-        {
-          "count": 4,
-          "name": "Mountain"
-        },
-        {
-          "count": 3,
-          "name": "Swamp"
+          "name": "Curiosity"
         },
         {
           "count": 1,
-          "name": "Spectral Searchlight"
+          "name": "Expressive Iteration"
         },
         {
           "count": 1,
-          "name": "Boros Signet"
+          "name": "Faithless Looting"
         },
         {
           "count": 1,
-          "name": "Gruul Signet"
+          "name": "Fellwar Stone"
         },
         {
           "count": 1,
-          "name": "Orzhov Signet"
+          "name": "Fiery Inscription"
         },
         {
           "count": 1,
-          "name": "Gruul Turf"
+          "name": "Fiery Islet"
         },
         {
           "count": 1,
-          "name": "Rakdos Signet"
+          "name": "Flusterstorm"
         },
         {
           "count": 1,
-          "name": "Scion of the Ur-Dragon"
+          "name": "Fists of Flame"
         },
         {
           "count": 1,
-          "name": "Oros, the Avenger"
+          "name": "Forge of Heroes"
         },
         {
           "count": 1,
-          "name": "Vorosh, the Hunter"
+          "name": "Frantic Search"
         },
         {
           "count": 1,
-          "name": "Intet, the Dreamer"
+          "name": "Frostboil Snarl"
         },
         {
           "count": 1,
-          "name": "Teneb, the Harvester"
+          "name": "Gitaxian Probe"
         },
         {
           "count": 1,
-          "name": "Vivid Marsh"
-        },
-        {
-          "count": 2,
-          "name": "Plains"
+          "name": "Grapeshot"
         },
         {
           "count": 1,
+          "name": "Guttersnipe"
+        },
+        {
+          "count": 1,
+          "name": "Hall of Oracles"
+        },
+        {
+          "count": 1,
+          "name": "Harmonic Prodigy"
+        },
+        {
+          "count": 1,
+          "name": "Hexing Squelcher"
+        },
+        {
+          "count": 1,
+          "name": "Hullbreaker Horror"
+        },
+        {
+          "count": 9,
           "name": "Island"
         },
         {
           "count": 1,
-          "name": "Broodmate Dragon"
+          "name": "Izzet Signet"
         },
         {
           "count": 1,
-          "name": "Jund Panorama"
+          "name": "Lightning Bolt"
         },
         {
           "count": 1,
-          "name": "Crucible of Fire"
+          "name": "Lightning Greaves"
         },
         {
           "count": 1,
-          "name": "Rise from the Grave"
+          "name": "Magefire Wings"
         },
         {
           "count": 1,
-          "name": "Evolving Wilds"
+          "name": "Magic Damper"
         },
         {
-          "count": 2,
-          "name": "Forest"
-        },
-        {
-          "count": 1,
-          "name": "Golgari Signet"
-        },
-        {
-          "count": 1,
-          "name": "Call to the Kindred"
-        },
-        {
-          "count": 1,
-          "name": "Orzhov Guildgate"
-        },
-        {
-          "count": 1,
-          "name": "Siege Dragon"
-        },
-        {
-          "count": 1,
-          "name": "Abzan Charm"
-        },
-        {
-          "count": 1,
-          "name": "Sultai Charm"
-        },
-        {
-          "count": 1,
-          "name": "Sandsteppe Citadel"
-        },
-        {
-          "count": 1,
-          "name": "Mystic Monastery"
-        },
-        {
-          "count": 1,
-          "name": "Opulent Palace"
-        },
-        {
-          "count": 1,
-          "name": "Nomad Outpost"
-        },
-        {
-          "count": 1,
-          "name": "Frontier Bivouac"
-        },
-        {
-          "count": 1,
-          "name": "Crackling Doom"
-        },
-        {
-          "count": 1,
-          "name": "Temur Ascendancy"
-        },
-        {
-          "count": 1,
-          "name": "Tranquil Cove"
-        },
-        {
-          "count": 1,
-          "name": "Rugged Highlands"
-        },
-        {
-          "count": 1,
-          "name": "Dromoka, the Eternal"
-        },
-        {
-          "count": 1,
-          "name": "Kolaghan, the Storm's Fury"
-        },
-        {
-          "count": 1,
-          "name": "Ojutai, Soul of Winter"
-        },
-        {
-          "count": 1,
-          "name": "Atarka, World Render"
-        },
-        {
-          "count": 1,
-          "name": "Crucible of the Spirit Dragon"
-        },
-        {
-          "count": 1,
-          "name": "Crux of Fate"
-        },
-        {
-          "count": 1,
-          "name": "Fearsome Awakening"
-        },
-        {
           "count": 1,
-          "name": "Dragonlord's Servant"
+          "name": "Mistrise Village"
         },
         {
-          "count": 1,
-          "name": "Kolaghan Monument"
+          "count": 7,
+          "name": "Mountain"
         },
         {
           "count": 1,
-          "name": "Silumgar Monument"
+          "name": "Mystic Remora"
         },
         {
           "count": 1,
-          "name": "Atarka Monument"
+          "name": "Negate"
         },
         {
           "count": 1,
-          "name": "Deathbringer Regent"
+          "name": "Niv-Mizzet, Parun"
         },
         {
           "count": 1,
-          "name": "Dragon Tempest"
+          "name": "Niv-Mizzet, Visionary"
         },
         {
           "count": 1,
-          "name": "Dragonlord's Prerogative"
+          "name": "Ophidian Eye"
         },
         {
           "count": 1,
-          "name": "Blighted Woodland"
+          "name": "Ponder"
         },
         {
           "count": 1,
-          "name": "Seaside Citadel"
+          "name": "Pongify"
         },
         {
           "count": 1,
-          "name": "Crumbling Necropolis"
+          "name": "Pact of Negation"
         },
         {
           "count": 1,
-          "name": "Ever After"
+          "name": "Opt"
         },
         {
           "count": 1,
-          "name": "Savage Lands"
+          "name": "Preordain"
         },
         {
           "count": 1,
-          "name": "Jungle Shrine"
+          "name": "Wizard's Staff"
         },
         {
           "count": 1,
-          "name": "Selesnya Signet"
+          "name": "Reckless Charge"
         },
         {
           "count": 1,
-          "name": "Putrefy"
+          "name": "Reliquary Tower"
         },
         {
           "count": 1,
-          "name": "Izzet Guildgate"
+          "name": "Rite of Flame"
         },
         {
           "count": 1,
-          "name": "Pillar of Origins"
+          "name": "Riverpyre Verge"
         },
         {
           "count": 1,
-          "name": "Bladewing the Risen"
+          "name": "Shivan Reef"
         },
         {
           "count": 1,
-          "name": "Lathliss, Dragon Queen"
+          "name": "Sigil of Sleep"
         },
         {
           "count": 1,
-          "name": "Dragon's Hoard"
+          "name": "Simian Spirit Guide"
         },
         {
           "count": 1,
-          "name": "Market Festival"
+          "name": "Sink into Stupor"
         },
         {
           "count": 1,
-          "name": "Sylvia Brightspear"
+          "name": "Slip Out the Back"
         },
         {
           "count": 1,
-          "name": "Dimir Signet"
+          "name": "Snap"
         },
         {
           "count": 1,
-          "name": "Primevals' Glorious Rebirth"
+          "name": "Sol Ring"
         },
         {
           "count": 1,
-          "name": "Spit Flame"
+          "name": "Springleaf Drum"
         },
         {
           "count": 1,
-          "name": "Darigaaz Reincarnated"
+          "name": "Starlit Mantle"
         },
         {
           "count": 1,
-          "name": "Haven of the Spirit Dragon"
+          "name": "Steam Vents"
         },
         {
           "count": 1,
-          "name": "Dragonspeaker Shaman"
+          "name": "Storm-Kiln Artist"
         },
         {
           "count": 1,
-          "name": "Earthquake"
+          "name": "Stormcarved Coast"
         },
         {
           "count": 1,
-          "name": "Jodah, Archmage Eternal"
+          "name": "Stormcatch Mentor"
         },
         {
           "count": 1,
-          "name": "Niv-Mizzet, Dracogenius"
+          "name": "Strike It Rich"
         },
         {
           "count": 1,
-          "name": "Steel Hellkite"
+          "name": "Sulfur Falls"
         },
         {
           "count": 1,
-          "name": "Vaevictis Asmadi, the Dire"
+          "name": "Swan Song"
         },
         {
           "count": 1,
-          "name": "O-Kagachi, Vengeful Kami"
+          "name": "Swiftfoot Boots"
         },
         {
           "count": 1,
-          "name": "Scalelord Reckoner"
+          "name": "Talisman of Creativity"
         },
         {
           "count": 1,
-          "name": "Boneyard Scourge"
+          "name": "Tandem Lookout"
         },
         {
           "count": 1,
-          "name": "The Ur-Dragon"
+          "name": "Thought Vessel"
         },
         {
           "count": 1,
-          "name": "Kokusho, the Evening Star"
+          "name": "Thundering Falls"
         },
         {
           "count": 1,
-          "name": "Ryusei, the Falling Star"
+          "name": "Training Center"
         },
         {
           "count": 1,
-          "name": "Yosei, the Morning Star"
+          "name": "Treasure Cruise"
         },
         {
           "count": 1,
-          "name": "Vivid Crag"
+          "name": "Twisted Image"
         },
         {
           "count": 1,
-          "name": "Vivid Creek"
+          "name": "Underworld Breach"
         },
         {
           "count": 1,
-          "name": "Vivid Grove"
+          "name": "Veyran, Voice of Duality"
         },
         {
           "count": 1,
-          "name": "Vivid Meadow"
+          "name": "Wild Ride"
         },
         {
           "count": 1,
-          "name": "Esper Panorama"
+          "name": "Windfall"
         },
         {
           "count": 1,
-          "name": "Naya Panorama"
+          "name": "Zhalfirin Shapecraft"
         }
       ],
       "sideboard": []
@@ -1468,167 +1445,23 @@
         },
         {
           "count": 1,
-          "name": "Youthful Valkyrie"
+          "name": "Adagia, Windswept Bastion"
         },
         {
           "count": 1,
-          "name": "Righteous Valkyrie"
+          "name": "Aetherflux Reservoir"
         },
         {
           "count": 1,
-          "name": "Resplendent Angel"
+          "name": "Akroma's Will"
         },
         {
           "count": 1,
-          "name": "Archangel of Thune"
+          "name": "Alhammarret's Archive"
         },
         {
           "count": 1,
-          "name": "Lyra Dawnbringer"
-        },
-        {
-          "count": 1,
-          "name": "Boon-Bringer Valkyrie"
-        },
-        {
-          "count": 1,
-          "name": "Valkyrie Harbinger"
-        },
-        {
-          "count": 1,
-          "name": "Bishop of Wings"
-        },
-        {
-          "count": 1,
-          "name": "Herald of War"
-        },
-        {
-          "count": 1,
-          "name": "Starnheim Aspirant"
-        },
-        {
-          "count": 1,
-          "name": "Serra Avenger"
-        },
-        {
-          "count": 1,
-          "name": "Serra Angel"
-        },
-        {
-          "count": 1,
-          "name": "Battlegrace Angel"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Finality"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Sanctions"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Grace"
-        },
-        {
-          "count": 1,
-          "name": "Admonition Angel"
-        },
-        {
-          "count": 1,
-          "name": "Exalted Angel"
-        },
-        {
-          "count": 1,
-          "name": "Adarkar Valkyrie"
-        },
-        {
-          "count": 1,
-          "name": "Angelic Skirmisher"
-        },
-        {
-          "count": 1,
-          "name": "Pristine Angel"
-        },
-        {
-          "count": 1,
-          "name": "Sunblast Angel"
-        },
-        {
-          "count": 1,
-          "name": "Aegis Angel"
-        },
-        {
-          "count": 1,
-          "name": "Resolute Archangel"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Salvation"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Deliverance"
-        },
-        {
-          "count": 1,
-          "name": "Requiem Angel"
-        },
-        {
-          "count": 1,
-          "name": "Serra Redeemer"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Invention"
-        },
-        {
-          "count": 1,
-          "name": "Battle Angels of Tyr"
-        },
-        {
-          "count": 1,
-          "name": "Archangel of Tithes"
-        },
-        {
-          "count": 1,
-          "name": "Angel of the Dire Hour"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Glory's Rise"
-        },
-        {
-          "count": 1,
-          "name": "Angel of the Ruins"
-        },
-        {
-          "count": 1,
-          "name": "Dawnbreak Reclaimer"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Indemnity"
-        },
-        {
-          "count": 1,
-          "name": "Serra's Guardian"
-        },
-        {
-          "count": 1,
-          "name": "Radiant, Serra Archangel"
-        },
-        {
-          "count": 1,
-          "name": "Enduring Angel"
-        },
-        {
-          "count": 1,
-          "name": "Platinum Angel"
-        },
-        {
-          "count": 1,
-          "name": "Sun Titan"
+          "name": "Angel of Jubilation"
         },
         {
           "count": 1,
@@ -1636,218 +1469,7 @@
         },
         {
           "count": 1,
-          "name": "Dawn of Hope"
-        },
-        {
-          "count": 1,
-          "name": "Well of Lost Dreams"
-        },
-        {
-          "count": 1,
-          "name": "Angelic Destiny"
-        },
-        {
-          "count": 1,
-          "name": "Marshal's Anthem"
-        },
-        {
-          "count": 1,
-          "name": "White Sun's Zenith"
-        },
-        {
-          "count": 1,
-          "name": "Swords to Plowshares"
-        },
-        {
-          "count": 1,
-          "name": "Path to Exile"
-        },
-        {
-          "count": 1,
-          "name": "Generous Gift"
-        },
-        {
-          "count": 1,
-          "name": "Austere Command"
-        },
-        {
-          "count": 1,
-          "name": "Cleansing Nova"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Herald's Horn"
-        },
-        {
-          "count": 1,
-          "name": "Vanquisher's Banner"
-        },
-        {
-          "count": 1,
-          "name": "Urza's Incubator"
-        },
-        {
-          "count": 1,
-          "name": "Swiftfoot Boots"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves"
-        },
-        {
-          "count": 1,
-          "name": "Mask of Memory"
-        },
-        {
-          "count": 1,
-          "name": "Mind Stone"
-        },
-        {
-          "count": 1,
-          "name": "Marble Diamond"
-        },
-        {
-          "count": 1,
-          "name": "Myriad Landscape"
-        },
-        {
-          "count": 1,
-          "name": "Rogue's Passage"
-        },
-        {
-          "count": 1,
-          "name": "War Room"
-        },
-        {
-          "count": 1,
-          "name": "Temple of the False God"
-        },
-        {
-          "count": 1,
-          "name": "Emeria, the Sky Ruin"
-        },
-        {
-          "count": 1,
-          "name": "Windbrisk Heights"
-        },
-        {
-          "count": 1,
-          "name": "Secluded Steppe"
-        },
-        {
-          "count": 1,
-          "name": "Drifting Meadow"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Path of Ancestry"
-        },
-        {
-          "count": 1,
-          "name": "Evolving Wilds"
-        },
-        {
-          "count": 1,
-          "name": "Terramorphic Expanse"
-        },
-        {
-          "count": 25,
-          "name": "Plains"
-        }
-      ],
-      "sideboard": []
-    },
-    {
-      "name": "Kaalia of the Vast",
-      "author": "MTGGoldfish",
-      "colors": [
-        "B",
-        "R",
-        "W"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Kaalia of the Vast"
-        },
-        {
-          "count": 1,
-          "name": "Master of Cruelties"
-        },
-        {
-          "count": 1,
-          "name": "Razaketh, the Foulblooded"
-        },
-        {
-          "count": 1,
-          "name": "Rune-Scarred Demon"
-        },
-        {
-          "count": 1,
-          "name": "Burning-Rune Demon"
-        },
-        {
-          "count": 1,
-          "name": "Bloodgift Demon"
-        },
-        {
-          "count": 1,
-          "name": "Demon of Dark Schemes"
-        },
-        {
-          "count": 1,
-          "name": "Desecration Demon"
-        },
-        {
-          "count": 1,
-          "name": "Ancient Copper Dragon"
-        },
-        {
-          "count": 1,
-          "name": "Ancient Gold Dragon"
-        },
-        {
-          "count": 1,
-          "name": "Ancient Brass Dragon"
-        },
-        {
-          "count": 1,
-          "name": "Balefire Dragon"
-        },
-        {
-          "count": 1,
-          "name": "Dragonlord Kolaghan"
-        },
-        {
-          "count": 1,
-          "name": "Adult Gold Dragon"
-        },
-        {
-          "count": 1,
-          "name": "Avacyn, Angel of Hope"
-        },
-        {
-          "count": 1,
-          "name": "Gisela, Blade of Goldnight"
-        },
-        {
-          "count": 1,
-          "name": "Gisela, the Broken Blade"
+          "name": "Anointed Procession"
         },
         {
           "count": 1,
@@ -1855,215 +1477,7 @@
         },
         {
           "count": 1,
-          "name": "Archangel of Tithes"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Despair"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Serenity"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Sanctions"
-        },
-        {
-          "count": 1,
-          "name": "Aurelia, the Warleader"
-        },
-        {
-          "count": 1,
-          "name": "Akroma, Angel of Fury"
-        },
-        {
-          "count": 1,
-          "name": "Akroma, Angel of Wrath"
-        },
-        {
-          "count": 1,
-          "name": "Demonic Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Vampiric Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Grim Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Diabolic Intent"
-        },
-        {
-          "count": 1,
-          "name": "Profane Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Infernal Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Entomb"
-        },
-        {
-          "count": 1,
-          "name": "Buried Alive"
-        },
-        {
-          "count": 1,
-          "name": "Reanimate"
-        },
-        {
-          "count": 1,
-          "name": "Animate Dead"
-        },
-        {
-          "count": 1,
-          "name": "Victimize"
-        },
-        {
-          "count": 1,
-          "name": "Living Death"
-        },
-        {
-          "count": 1,
-          "name": "Deflecting Swat"
-        },
-        {
-          "count": 1,
-          "name": "Teferi's Protection"
-        },
-        {
-          "count": 1,
-          "name": "Flawless Maneuver"
-        },
-        {
-          "count": 1,
-          "name": "Grand Abolisher"
-        },
-        {
-          "count": 1,
-          "name": "Esper Sentinel"
-        },
-        {
-          "count": 1,
-          "name": "Smothering Tithe"
-        },
-        {
-          "count": 1,
-          "name": "Phyrexian Arena"
-        },
-        {
-          "count": 1,
-          "name": "Swords to Plowshares"
-        },
-        {
-          "count": 1,
-          "name": "Path to Exile"
-        },
-        {
-          "count": 1,
-          "name": "Anguished Unmaking"
-        },
-        {
-          "count": 1,
-          "name": "Vindicate"
-        },
-        {
-          "count": 1,
-          "name": "Generous Gift"
-        },
-        {
-          "count": 1,
-          "name": "Chaos Warp"
-        },
-        {
-          "count": 1,
-          "name": "Damnation"
-        },
-        {
-          "count": 1,
-          "name": "Toxic Deluge"
-        },
-        {
-          "count": 1,
-          "name": "Austere Command"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Lotus Petal"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Indulgence"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Hierarchy"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Conviction"
-        },
-        {
-          "count": 1,
-          "name": "Rakdos Signet"
-        },
-        {
-          "count": 1,
-          "name": "Orzhov Signet"
-        },
-        {
-          "count": 1,
-          "name": "Boros Signet"
-        },
-        {
-          "count": 1,
-          "name": "Jeska's Will"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves"
-        },
-        {
-          "count": 1,
-          "name": "Swiftfoot Boots"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Exotic Orchard"
-        },
-        {
-          "count": 1,
-          "name": "Nomad Outpost"
-        },
-        {
-          "count": 1,
-          "name": "Blood Crypt"
-        },
-        {
-          "count": 1,
-          "name": "Sacred Foundry"
-        },
-        {
-          "count": 1,
-          "name": "Godless Shrine"
+          "name": "Archivist of Oghma"
         },
         {
           "count": 1,
@@ -2071,7 +1485,123 @@
         },
         {
           "count": 1,
-          "name": "Bloodstained Mire"
+          "name": "Authority of the Consuls"
+        },
+        {
+          "count": 1,
+          "name": "Avacyn, Angel of Hope"
+        },
+        {
+          "count": 1,
+          "name": "Battle Angels of Tyr"
+        },
+        {
+          "count": 1,
+          "name": "Bishop of Wings"
+        },
+        {
+          "count": 1,
+          "name": "Bruna, the Fading Light"
+        },
+        {
+          "count": 1,
+          "name": "Captain Marvel, Shooting Star"
+        },
+        {
+          "count": 1,
+          "name": "Caretaker's Talent"
+        },
+        {
+          "count": 1,
+          "name": "Cavern of Souls"
+        },
+        {
+          "count": 1,
+          "name": "Chronicle of Victory"
+        },
+        {
+          "count": 1,
+          "name": "Commander's Plate"
+        },
+        {
+          "count": 1,
+          "name": "Court of Grace"
+        },
+        {
+          "count": 1,
+          "name": "Delney, Streetwise Lookout"
+        },
+        {
+          "count": 1,
+          "name": "Deserted Temple"
+        },
+        {
+          "count": 1,
+          "name": "Divine Visitation"
+        },
+        {
+          "count": 1,
+          "name": "Elspeth Tirel"
+        },
+        {
+          "count": 1,
+          "name": "Elspeth, Storm Slayer"
+        },
+        {
+          "count": 1,
+          "name": "Emeria, the Sky Ruin"
+        },
+        {
+          "count": 1,
+          "name": "Enlightened Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Esper Sentinel"
+        },
+        {
+          "count": 1,
+          "name": "Exalted Sunborn"
+        },
+        {
+          "count": 1,
+          "name": "Exemplar of Light"
+        },
+        {
+          "count": 1,
+          "name": "Flawless Maneuver"
+        },
+        {
+          "count": 1,
+          "name": "Flooded Strand"
+        },
+        {
+          "count": 1,
+          "name": "Gisela, the Broken Blade"
+        },
+        {
+          "count": 1,
+          "name": "Hall of Heliod's Generosity"
+        },
+        {
+          "count": 1,
+          "name": "Halo Fountain"
+        },
+        {
+          "count": 1,
+          "name": "Land Tax"
+        },
+        {
+          "count": 1,
+          "name": "Linvala, Keeper of Silence"
+        },
+        {
+          "count": 1,
+          "name": "Luminarch Ascension"
+        },
+        {
+          "count": 1,
+          "name": "Lyra Dawnbringer"
         },
         {
           "count": 1,
@@ -2079,90 +1609,194 @@
         },
         {
           "count": 1,
-          "name": "Caves of Koilos"
+          "name": "Maskwood Nexus"
         },
         {
           "count": 1,
-          "name": "Battlefield Forge"
+          "name": "Mirrorpool"
         },
         {
           "count": 1,
-          "name": "Sulfurous Springs"
+          "name": "Monumental Henge"
         },
         {
           "count": 1,
-          "name": "Isolated Chapel"
+          "name": "Mox Amber"
         },
         {
           "count": 1,
-          "name": "Dragonskull Summit"
+          "name": "Myrel, Shield of Argive"
         },
         {
           "count": 1,
-          "name": "Clifftop Retreat"
+          "name": "Nesting Dovehawk"
         },
         {
           "count": 1,
-          "name": "Vault of Champions"
+          "name": "Nykthos, Shrine to Nyx"
         },
         {
           "count": 1,
-          "name": "Luxury Suite"
+          "name": "Ocelot Pride"
         },
         {
           "count": 1,
-          "name": "Temple of Silence"
+          "name": "Ojer Taq, Deepest Foundation"
         },
         {
           "count": 1,
-          "name": "Temple of Malice"
+          "name": "Oketra's Monument"
         },
         {
           "count": 1,
-          "name": "Temple of Triumph"
+          "name": "Orim's Chant"
         },
         {
           "count": 1,
-          "name": "Path of Ancestry"
+          "name": "Paradise Mantle"
         },
         {
           "count": 1,
-          "name": "Bojuka Bog"
+          "name": "Path to Exile"
         },
         {
           "count": 1,
-          "name": "Takenuma, Abandoned Mire"
+          "name": "Pearl Medallion"
         },
         {
-          "count": 1,
-          "name": "Evolving Wilds"
-        },
-        {
-          "count": 1,
-          "name": "Terramorphic Expanse"
-        },
-        {
-          "count": 4,
-          "name": "Swamp"
-        },
-        {
-          "count": 3,
+          "count": 14,
           "name": "Plains"
         },
         {
-          "count": 3,
-          "name": "Mountain"
+          "count": 1,
+          "name": "Prismatic Vista"
+        },
+        {
+          "count": 1,
+          "name": "Reliquary Tower"
+        },
+        {
+          "count": 1,
+          "name": "Resplendent Angel"
+        },
+        {
+          "count": 1,
+          "name": "Righteous Valkyrie"
+        },
+        {
+          "count": 1,
+          "name": "Roaming Throne"
+        },
+        {
+          "count": 1,
+          "name": "Sensei's Divining Top"
+        },
+        {
+          "count": 1,
+          "name": "Seraph Sanctuary"
+        },
+        {
+          "count": 1,
+          "name": "Serra Ascendant"
+        },
+        {
+          "count": 1,
+          "name": "Shadowspear"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Soul Warden"
+        },
+        {
+          "count": 1,
+          "name": "Soul's Attendant"
+        },
+        {
+          "count": 1,
+          "name": "Starnheim Aspirant"
+        },
+        {
+          "count": 1,
+          "name": "Stoneforge Mystic"
+        },
+        {
+          "count": 1,
+          "name": "Sword of Feast and Famine"
+        },
+        {
+          "count": 1,
+          "name": "Swords to Plowshares"
+        },
+        {
+          "count": 1,
+          "name": "Teferi's Protection"
+        },
+        {
+          "count": 1,
+          "name": "The Wind Crystal"
+        },
+        {
+          "count": 1,
+          "name": "Three Tree City"
+        },
+        {
+          "count": 1,
+          "name": "Throne of Eldraine"
+        },
+        {
+          "count": 1,
+          "name": "Trouble in Pairs"
+        },
+        {
+          "count": 1,
+          "name": "Urza's Saga"
+        },
+        {
+          "count": 1,
+          "name": "Valkyrie Harbinger"
+        },
+        {
+          "count": 1,
+          "name": "Wasteland"
+        },
+        {
+          "count": 1,
+          "name": "Well of Lost Dreams"
+        },
+        {
+          "count": 1,
+          "name": "Windbrisk Heights"
+        },
+        {
+          "count": 1,
+          "name": "Winds of Abandon"
+        },
+        {
+          "count": 1,
+          "name": "Windswept Heath"
+        },
+        {
+          "count": 1,
+          "name": "Witch Enchanter"
+        },
+        {
+          "count": 1,
+          "name": "Witch's Clinic"
         }
       ],
       "sideboard": []
     },
     {
-      "name": "Ashling, the Limitless",
+      "name": "The Ur-Dragon",
       "author": "MTGGoldfish",
       "colors": [
+        "U",
         "B",
         "G",
-        "U",
         "W",
         "R"
       ],
@@ -2172,263 +1806,203 @@
       "main": [
         {
           "count": 1,
-          "name": "Ashling, the Limitless"
+          "name": "The Ur-Dragon"
         },
         {
           "count": 1,
-          "name": "Fury"
+          "name": "Tiamat"
         },
         {
           "count": 1,
-          "name": "Belonging"
+          "name": "Dragonlord Ojutai"
         },
         {
           "count": 1,
-          "name": "Endurance"
+          "name": "Dragonlord Dromoka"
         },
         {
           "count": 1,
-          "name": "Shriekmaw"
+          "name": "Dragonlord Kolaghan"
         },
         {
           "count": 1,
-          "name": "Jubilation"
+          "name": "Hellkite Charger"
         },
         {
           "count": 1,
-          "name": "Risen Reef"
+          "name": "Hellkite Courser"
         },
         {
           "count": 1,
-          "name": "Subterfuge"
+          "name": "Scion of the Ur-Dragon"
         },
         {
           "count": 1,
-          "name": "Impulsivity"
+          "name": "Two-Headed Hellkite"
         },
         {
           "count": 1,
-          "name": "Lamentation"
+          "name": "Ureni of the Unwritten"
         },
         {
           "count": 1,
-          "name": "Mulldrifter"
+          "name": "Atarka, World Render"
         },
         {
           "count": 1,
-          "name": "Realmwalker"
+          "name": "Scalelord Reckoner"
         },
         {
           "count": 1,
-          "name": "Slithermuse"
+          "name": "Savage Ventmaw"
         },
         {
           "count": 1,
-          "name": "Flamebraider"
+          "name": "Korlessa, Scale Singer"
         },
         {
           "count": 1,
-          "name": "Ingot Chewer"
+          "name": "Miirym, Sentinel Wyrm"
         },
         {
           "count": 1,
-          "name": "Shimmercreep"
+          "name": "Thrakkus the Butcher"
         },
         {
           "count": 1,
-          "name": "Smokebraider"
+          "name": "Scion of Draco"
         },
         {
           "count": 1,
-          "name": "Faeburrow Elder"
+          "name": "Scourge of Valkas"
         },
         {
           "count": 1,
-          "name": "Bane of Progress"
+          "name": "Karrthus, Tyrant of Jund"
         },
         {
           "count": 1,
-          "name": "Horde of Notions"
+          "name": "Rith, Liberated Primeval"
         },
         {
           "count": 1,
-          "name": "Vernal Sovereign"
+          "name": "Thunderbreak Regent"
         },
         {
           "count": 1,
-          "name": "Eclipsed Flamekin"
+          "name": "Lathliss, Dragon Queen"
         },
         {
           "count": 1,
-          "name": "Mass of Mysteries"
+          "name": "Bladewing the Risen"
         },
         {
           "count": 1,
-          "name": "Titan of Industry"
+          "name": "Roaming Throne"
         },
         {
           "count": 1,
-          "name": "Cavalier of Thorns"
+          "name": "Morophon, the Boundless"
         },
         {
           "count": 1,
-          "name": "Foundation Breaker"
+          "name": "Sarkhan, Soul Aflame"
         },
         {
           "count": 1,
-          "name": "Maelstrom Wanderer"
+          "name": "Dragonologist"
         },
         {
           "count": 1,
-          "name": "Avenger of Zendikar"
+          "name": "Terror of the Peaks"
         },
         {
           "count": 1,
-          "name": "Greenwarden of Murasa"
+          "name": "Reality Shift"
         },
         {
           "count": 1,
-          "name": "Omnath, Locus of Rage"
+          "name": "Swords to Plowshares"
         },
         {
           "count": 1,
-          "name": "Yarok, the Desecrated"
+          "name": "Chaos Warp"
         },
         {
           "count": 1,
-          "name": "Incandescent Soulstoke"
+          "name": "Obscuring Haze"
         },
         {
           "count": 1,
-          "name": "Jegantha, the Wellspring"
+          "name": "Deadly Rollick"
         },
         {
           "count": 1,
-          "name": "Muldrotha, the Gravetide"
+          "name": "Kindred Summons"
         },
         {
           "count": 1,
-          "name": "Omnath, Locus of the Roil"
+          "name": "Kindred Dominance"
         },
         {
           "count": 1,
-          "name": "Selvala, Heart of the Wilds"
-        },
-        {
-          "count": 2,
-          "name": "Swamp"
-        },
-        {
-          "count": 8,
-          "name": "Forest"
-        },
-        {
-          "count": 2,
-          "name": "Island"
-        },
-        {
-          "count": 2,
-          "name": "Plains"
-        },
-        {
-          "count": 2,
-          "name": "Mountain"
+          "name": "Kindred Discovery"
         },
         {
           "count": 1,
-          "name": "Opal Palace"
+          "name": "Boros Charm"
         },
         {
           "count": 1,
-          "name": "Savage Lands"
+          "name": "Growth Spiral"
         },
         {
           "count": 1,
-          "name": "Command Tower"
+          "name": "Stubborn Denial"
         },
         {
           "count": 1,
-          "name": "Jungle Shrine"
+          "name": "An Offer You Can't Refuse"
         },
         {
           "count": 1,
-          "name": "Primal Beyond"
+          "name": "Crux of Fate"
         },
         {
           "count": 1,
-          "name": "Raging Ravine"
+          "name": "Bloodline Bidding"
         },
         {
           "count": 1,
-          "name": "Thriving Isle"
+          "name": "Majestic Genesis"
         },
         {
           "count": 1,
-          "name": "Thriving Moor"
+          "name": "Rishkar's Expertise"
         },
         {
           "count": 1,
-          "name": "Exotic Orchard"
+          "name": "Orb of Dragonkind"
         },
         {
           "count": 1,
-          "name": "Opulent Palace"
+          "name": "Jade Orb of Dragonkind"
         },
         {
           "count": 1,
-          "name": "Sodden Verdure"
+          "name": "Carnelian Orb of Dragonkind"
         },
         {
           "count": 1,
-          "name": "Thriving Bluff"
+          "name": "Chromatic Orrery"
         },
         {
           "count": 1,
-          "name": "Thriving Grove"
+          "name": "Chromatic Lantern"
         },
         {
           "count": 1,
-          "name": "Thriving Heath"
-        },
-        {
-          "count": 1,
-          "name": "Seaside Citadel"
-        },
-        {
-          "count": 1,
-          "name": "Ancient Ziggurat"
-        },
-        {
-          "count": 1,
-          "name": "Flamekin Village"
-        },
-        {
-          "count": 1,
-          "name": "Frontier Bivouac"
-        },
-        {
-          "count": 1,
-          "name": "Path of Ancestry"
-        },
-        {
-          "count": 1,
-          "name": "Rain-Slicked Copse"
-        },
-        {
-          "count": 1,
-          "name": "Sandsteppe Citadel"
-        },
-        {
-          "count": 1,
-          "name": "Secluded Courtyard"
-        },
-        {
-          "count": 1,
-          "name": "Unclaimed Territory"
-        },
-        {
-          "count": 1,
-          "name": "Abundant Countryside"
+          "name": "Thran Dynamo"
         },
         {
           "count": 1,
@@ -2440,79 +2014,332 @@
         },
         {
           "count": 1,
-          "name": "Fellwar Stone"
+          "name": "Dragon's Hoard"
         },
         {
           "count": 1,
-          "name": "Timeless Lotus"
+          "name": "Dragon Arch"
         },
         {
           "count": 1,
-          "name": "Chromatic Lantern"
+          "name": "Mox Jasper"
         },
         {
           "count": 1,
-          "name": "Crib Swap"
+          "name": "Urza's Incubator"
         },
         {
           "count": 1,
-          "name": "Path to Exile"
+          "name": "Patchwork Banner"
         },
         {
           "count": 1,
-          "name": "Reality Shift"
+          "name": "Lotus Petal"
         },
         {
           "count": 1,
-          "name": "Kindred Summons"
+          "name": "The Great Henge"
         },
         {
           "count": 1,
-          "name": "Return of the Wildspeaker"
+          "name": "Prismatic Undercurrents"
         },
         {
           "count": 1,
-          "name": "Cultivate"
+          "name": "Dracogenesis"
         },
         {
           "count": 1,
-          "name": "Distant Melody"
+          "name": "Sight of the Scalelords"
         },
         {
           "count": 1,
-          "name": "Kodama's Reach"
+          "name": "Dragon Tempest"
         },
         {
           "count": 1,
-          "name": "Blasphemous Act"
+          "name": "Temur Ascendancy"
         },
         {
           "count": 1,
-          "name": "Haunting Voyage"
+          "name": "Defense of the Heart"
         },
         {
           "count": 1,
-          "name": "Shatter the Sky"
+          "name": "Mirari's Wake"
         },
         {
           "count": 1,
-          "name": "Elemental Spectacle"
+          "name": "Sarkhan Unbroken"
         },
         {
           "count": 1,
-          "name": "Fertile Ground"
+          "name": "Command Tower"
         },
         {
           "count": 1,
-          "name": "Abundant Growth"
+          "name": "Cori Mountain Monastery"
         },
         {
           "count": 1,
-          "name": "Cream of the Crop"
+          "name": "Dalkovan Encampment"
         },
         {
           "count": 1,
-          "name": "Descendants' Fury"
+          "name": "Kishla Village"
+        },
+        {
+          "count": 1,
+          "name": "Great Arashin City"
+        },
+        {
+          "count": 1,
+          "name": "Command Bridge"
+        },
+        {
+          "count": 1,
+          "name": "Temple of the Dragon Queen"
+        },
+        {
+          "count": 1,
+          "name": "Cascading Cataracts"
+        },
+        {
+          "count": 1,
+          "name": "Maelstrom of the Spirit Dragon"
+        },
+        {
+          "count": 1,
+          "name": "Exotic Orchard"
+        },
+        {
+          "count": 1,
+          "name": "Multiversal Passage"
+        },
+        {
+          "count": 1,
+          "name": "Reliquary Tower"
+        },
+        {
+          "count": 1,
+          "name": "City of Brass"
+        },
+        {
+          "count": 1,
+          "name": "Cavern of Souls"
+        },
+        {
+          "count": 2,
+          "name": "Island"
+        },
+        {
+          "count": 3,
+          "name": "Swamp"
+        },
+        {
+          "count": 5,
+          "name": "Forest"
+        },
+        {
+          "count": 3,
+          "name": "Plains"
+        },
+        {
+          "count": 1,
+          "name": "Mistrise Village"
+        },
+        {
+          "count": 5,
+          "name": "Mountain"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "Beorn the Fierce",
+      "author": "MTGGoldfish",
+      "colors": [
+        "G"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Beorn the Fierce"
+        },
+        {
+          "count": 1,
+          "name": "Cavern of Souls"
+        },
+        {
+          "count": 1,
+          "name": "Disciple of Freyalise"
+        },
+        {
+          "count": 1,
+          "name": "Castle Garenbrig"
+        },
+        {
+          "count": 1,
+          "name": "Reliquary Tower"
+        },
+        {
+          "count": 1,
+          "name": "Three Tree City"
+        },
+        {
+          "count": 1,
+          "name": "Nykthos, Shrine to Nyx"
+        },
+        {
+          "count": 1,
+          "name": "Argoth, Sanctum of Nature"
+        },
+        {
+          "count": 1,
+          "name": "Boseiju, Who Endures"
+        },
+        {
+          "count": 1,
+          "name": "Evendo, Waking Haven"
+        },
+        {
+          "count": 1,
+          "name": "Oran-Rief, the Vastwood"
+        },
+        {
+          "count": 1,
+          "name": "War Room"
+        },
+        {
+          "count": 1,
+          "name": "Yavimaya, Cradle of Growth"
+        },
+        {
+          "count": 1,
+          "name": "Bonders' Enclave"
+        },
+        {
+          "count": 1,
+          "name": "Shifting Woodland"
+        },
+        {
+          "count": 1,
+          "name": "Yavimaya Hollow"
+        },
+        {
+          "count": 1,
+          "name": "Mutavault"
+        },
+        {
+          "count": 1,
+          "name": "Homeward Path"
+        },
+        {
+          "count": 1,
+          "name": "Strip Mine"
+        },
+        {
+          "count": 1,
+          "name": "Growing Rites of Itlimoc"
+        },
+        {
+          "count": 19,
+          "name": "Snow-Covered Forest"
+        },
+        {
+          "count": 1,
+          "name": "Burgeoning"
+        },
+        {
+          "count": 1,
+          "name": "Exploration"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Necklace of Girion"
+        },
+        {
+          "count": 1,
+          "name": "Herd Heirloom"
+        },
+        {
+          "count": 1,
+          "name": "Throne of Eldraine"
+        },
+        {
+          "count": 1,
+          "name": "Dancing from Dark to Dawn"
+        },
+        {
+          "count": 1,
+          "name": "Radagast of Rhosgobel"
+        },
+        {
+          "count": 1,
+          "name": "Little Bear"
+        },
+        {
+          "count": 1,
+          "name": "Ayula, Queen Among Bears"
+        },
+        {
+          "count": 1,
+          "name": "Goreclaw, Terror of Qal Sisma"
+        },
+        {
+          "count": 1,
+          "name": "Wilson, Refined Grizzly"
+        },
+        {
+          "count": 1,
+          "name": "Werebear"
+        },
+        {
+          "count": 1,
+          "name": "Owlbear Cub"
+        },
+        {
+          "count": 1,
+          "name": "Studious First-Year"
+        },
+        {
+          "count": 1,
+          "name": "Evercoat Ursine"
+        },
+        {
+          "count": 1,
+          "name": "Monster Manual"
+        },
+        {
+          "count": 1,
+          "name": "Greater Good"
+        },
+        {
+          "count": 1,
+          "name": "The Earth King"
+        },
+        {
+          "count": 1,
+          "name": "Surrak and Goreclaw"
+        },
+        {
+          "count": 1,
+          "name": "Rampaging Yao Guai"
+        },
+        {
+          "count": 1,
+          "name": "Emerald Medallion"
+        },
+        {
+          "count": 1,
+          "name": "Heroic Intervention"
         },
         {
           "count": 1,
@@ -2520,11 +2347,151 @@
         },
         {
           "count": 1,
+          "name": "Roaming Throne"
+        },
+        {
+          "count": 1,
+          "name": "Return of the Wildspeaker"
+        },
+        {
+          "count": 1,
+          "name": "Vastlands Scavenger"
+        },
+        {
+          "count": 1,
+          "name": "Worldly Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Urza's Incubator"
+        },
+        {
+          "count": 1,
+          "name": "Realmwalker"
+        },
+        {
+          "count": 1,
+          "name": "Allosaurus Shepherd"
+        },
+        {
+          "count": 1,
+          "name": "Chomping Changeling"
+        },
+        {
+          "count": 1,
+          "name": "Masked Vandal"
+        },
+        {
+          "count": 1,
+          "name": "Wrap in Vigor"
+        },
+        {
+          "count": 1,
+          "name": "The Great Henge"
+        },
+        {
+          "count": 1,
+          "name": "Rishkar's Expertise"
+        },
+        {
+          "count": 1,
+          "name": "Last March of the Ents"
+        },
+        {
+          "count": 1,
+          "name": "Life's Legacy"
+        },
+        {
+          "count": 1,
+          "name": "Witch's Clinic"
+        },
+        {
+          "count": 1,
+          "name": "Bear Umbra"
+        },
+        {
+          "count": 1,
           "name": "Springleaf Parade"
         },
         {
           "count": 1,
-          "name": "Hoofprints of the Stag"
+          "name": "Ohran Frostfang"
+        },
+        {
+          "count": 1,
+          "name": "The Earth Crystal"
+        },
+        {
+          "count": 1,
+          "name": "Fanatic of Rhonas"
+        },
+        {
+          "count": 1,
+          "name": "Swiftfoot Boots"
+        },
+        {
+          "count": 1,
+          "name": "Tribute to the World Tree"
+        },
+        {
+          "count": 1,
+          "name": "Selvala, Heart of the Wilds"
+        },
+        {
+          "count": 1,
+          "name": "Tamiyo's Safekeeping"
+        },
+        {
+          "count": 1,
+          "name": "Ram Through"
+        },
+        {
+          "count": 1,
+          "name": "Momentous Fall"
+        },
+        {
+          "count": 1,
+          "name": "Metallic Mimic"
+        },
+        {
+          "count": 1,
+          "name": "Ayula's Influence"
+        },
+        {
+          "count": 1,
+          "name": "Spirit of the Aldergard"
+        },
+        {
+          "count": 1,
+          "name": "Mother Bear"
+        },
+        {
+          "count": 1,
+          "name": "Ashcoat Bear"
+        },
+        {
+          "count": 1,
+          "name": "Caller of the Claw"
+        },
+        {
+          "count": 1,
+          "name": "Forest Bear"
+        },
+        {
+          "count": 1,
+          "name": "Bearscape"
+        },
+        {
+          "count": 1,
+          "name": "Silverback Elder"
+        },
+        {
+          "count": 1,
+          "name": "Ouroboroid"
+        },
+        {
+          "count": 1,
+          "name": "Lumra, Bellow of the Woods"
         }
       ],
       "sideboard": []
@@ -2542,7 +2509,131 @@
       "main": [
         {
           "count": 1,
-          "name": "An Unexpected Party"
+          "name": "Esper Sentinel"
+        },
+        {
+          "count": 1,
+          "name": "Axgard Cavalry"
+        },
+        {
+          "count": 1,
+          "name": "Fearless Liberator"
+        },
+        {
+          "count": 1,
+          "name": "Magda, Brazen Outlaw"
+        },
+        {
+          "count": 1,
+          "name": "Reckless Fireweaver"
+        },
+        {
+          "count": 1,
+          "name": "Combat Celebrant"
+        },
+        {
+          "count": 1,
+          "name": "Delney, Streetwise Lookout"
+        },
+        {
+          "count": 1,
+          "name": "Depala, Pilot Exemplar"
+        },
+        {
+          "count": 1,
+          "name": "Dwarven Recruiter"
+        },
+        {
+          "count": 1,
+          "name": "Fili and Kili, Joyous"
+        },
+        {
+          "count": 1,
+          "name": "Gloin, Dwarf Emissary"
+        },
+        {
+          "count": 1,
+          "name": "Professional Face-Breaker"
+        },
+        {
+          "count": 1,
+          "name": "Welcoming Vampire"
+        },
+        {
+          "count": 1,
+          "name": "Xorn"
+        },
+        {
+          "count": 1,
+          "name": "Fili the Pathfinder"
+        },
+        {
+          "count": 1,
+          "name": "Iroas, God of Victory"
+        },
+        {
+          "count": 1,
+          "name": "Roaming Throne"
+        },
+        {
+          "count": 1,
+          "name": "Smaug the Magnificent"
+        },
+        {
+          "count": 1,
+          "name": "Storm-Kiln Artist"
+        },
+        {
+          "count": 1,
+          "name": "Elesh Norn, Mother of Machines"
+        },
+        {
+          "count": 1,
+          "name": "Goldspan Dragon"
+        },
+        {
+          "count": 1,
+          "name": "Kiki-Jiki, Mirror Breaker"
+        },
+        {
+          "count": 1,
+          "name": "Terror of the Peaks"
+        },
+        {
+          "count": 1,
+          "name": "Thorin, Company's Leader"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Copper Dragon"
+        },
+        {
+          "count": 1,
+          "name": "Aurelia, the Warleader"
+        },
+        {
+          "count": 1,
+          "name": "Hellkite Charger"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Gold Dragon"
+        },
+        {
+          "count": 1,
+          "name": "Ori, Plate Stacker"
+        },
+        {
+          "count": 1,
+          "name": "Skullclamp"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Wayfarer's Bauble"
         },
         {
           "count": 1,
@@ -2550,19 +2641,147 @@
         },
         {
           "count": 1,
+          "name": "Boros Signet"
+        },
+        {
+          "count": 1,
+          "name": "Fellwar Stone"
+        },
+        {
+          "count": 1,
+          "name": "Lightning Greaves"
+        },
+        {
+          "count": 1,
+          "name": "Talisman of Conviction"
+        },
+        {
+          "count": 1,
+          "name": "Sword of Feast and Famine"
+        },
+        {
+          "count": 1,
+          "name": "Panharmonicon"
+        },
+        {
+          "count": 1,
+          "name": "The One Ring"
+        },
+        {
+          "count": 1,
+          "name": "Enlightened Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Ephemerate"
+        },
+        {
+          "count": 1,
+          "name": "Gods Willing"
+        },
+        {
+          "count": 1,
+          "name": "Path to Exile"
+        },
+        {
+          "count": 1,
+          "name": "Swords to Plowshares"
+        },
+        {
+          "count": 1,
+          "name": "Boros Charm"
+        },
+        {
+          "count": 1,
+          "name": "Deflecting Palm"
+        },
+        {
+          "count": 1,
+          "name": "Chaos Warp"
+        },
+        {
+          "count": 1,
+          "name": "Deflecting Swat"
+        },
+        {
+          "count": 1,
+          "name": "Flawless Maneuver"
+        },
+        {
+          "count": 1,
+          "name": "Generous Gift"
+        },
+        {
+          "count": 1,
+          "name": "Teferi's Protection"
+        },
+        {
+          "count": 1,
+          "name": "Unbreakable Formation"
+        },
+        {
+          "count": 1,
+          "name": "Wear // Tear"
+        },
+        {
+          "count": 1,
+          "name": "Gamble"
+        },
+        {
+          "count": 1,
+          "name": "Steelshaper's Gift"
+        },
+        {
+          "count": 1,
+          "name": "Vandalblast"
+        },
+        {
+          "count": 1,
+          "name": "Reforge the Soul"
+        },
+        {
+          "count": 1,
+          "name": "Gleaming Splendor"
+        },
+        {
+          "count": 1,
+          "name": "Impact Tremors"
+        },
+        {
+          "count": 1,
+          "name": "Aggravated Assault"
+        },
+        {
+          "count": 1,
+          "name": "Smothering Tithe"
+        },
+        {
+          "count": 1,
+          "name": "Sneak Attack"
+        },
+        {
+          "count": 1,
+          "name": "Trouble in Pairs"
+        },
+        {
+          "count": 1,
+          "name": "Cathars' Crusade"
+        },
+        {
+          "count": 1,
+          "name": "There and Back Again"
+        },
+        {
+          "count": 1,
+          "name": "Arid Mesa"
+        },
+        {
+          "count": 1,
           "name": "Battlefield Forge"
         },
         {
           "count": 1,
-          "name": "Bifur, Melodic Rider"
-        },
-        {
-          "count": 1,
-          "name": "Bilbo's Gambit"
-        },
-        {
-          "count": 1,
-          "name": "Blasphemous Act"
+          "name": "Bonders' Enclave"
         },
         {
           "count": 1,
@@ -2578,15 +2797,15 @@
         },
         {
           "count": 1,
-          "name": "Door of Destinies"
+          "name": "Den of the Bugbear"
         },
         {
           "count": 1,
-          "name": "Dusk // Dawn"
+          "name": "Dwarven Mine"
         },
         {
           "count": 1,
-          "name": "Earthquake"
+          "name": "Elegant Parlor"
         },
         {
           "count": 1,
@@ -2594,62 +2813,22 @@
         },
         {
           "count": 1,
-          "name": "Gleaming Splendor"
-        },
-        {
-          "count": 1,
-          "name": "Faithless Looting"
-        },
-        {
-          "count": 1,
-          "name": "Fell the Mighty"
-        },
-        {
-          "count": 1,
-          "name": "Fili and Kili, Joyous"
-        },
-        {
-          "count": 1,
-          "name": "Flowering of the White Tree"
-        },
-        {
-          "count": 1,
-          "name": "Forge Anew"
-        },
-        {
-          "count": 1,
           "name": "Furycalm Snarl"
         },
         {
           "count": 1,
-          "name": "Gimli of the Glittering Caves"
+          "name": "Inspiring Vantage"
         },
         {
           "count": 1,
-          "name": "Glittering Massif"
+          "name": "Minas Tirith"
         },
         {
           "count": 1,
-          "name": "Heirloom Blade"
+          "name": "Mistveil Plains"
         },
         {
-          "count": 1,
-          "name": "Herald's Horn"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves"
-        },
-        {
-          "count": 1,
-          "name": "Long-Lost Lances"
-        },
-        {
-          "count": 1,
-          "name": "Mithril Coat"
-        },
-        {
-          "count": 12,
+          "count": 5,
           "name": "Mountain"
         },
         {
@@ -2657,24 +2836,16 @@
           "name": "Needleverge Pathway"
         },
         {
-          "count": 1,
-          "name": "Orcrist, Goblin-cleaver"
-        },
-        {
-          "count": 1,
-          "name": "Ori, Plate Stacker"
-        },
-        {
-          "count": 1,
-          "name": "Path to Exile"
-        },
-        {
-          "count": 9,
+          "count": 3,
           "name": "Plains"
         },
         {
           "count": 1,
-          "name": "Radiant Summit"
+          "name": "Plaza of Heroes"
+        },
+        {
+          "count": 1,
+          "name": "Prismatic Vista"
         },
         {
           "count": 1,
@@ -2682,31 +2853,23 @@
         },
         {
           "count": 1,
+          "name": "Rustvale Bridge"
+        },
+        {
+          "count": 1,
           "name": "Sacred Foundry"
         },
         {
           "count": 1,
-          "name": "Sacred Peaks"
+          "name": "Secluded Courtyard"
         },
         {
           "count": 1,
-          "name": "Shadowspear"
+          "name": "Spectator Seating"
         },
         {
           "count": 1,
-          "name": "Shared Animosity"
-        },
-        {
-          "count": 1,
-          "name": "Shiny Impetus"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Spiteful Banditry"
+          "name": "Sunbaked Canyon"
         },
         {
           "count": 1,
@@ -2714,151 +2877,7 @@
         },
         {
           "count": 1,
-          "name": "Sunscorched Divide"
-        },
-        {
-          "count": 1,
-          "name": "Sword of the Animist"
-        },
-        {
-          "count": 1,
-          "name": "Swords to Plowshares"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Conviction"
-        },
-        {
-          "count": 1,
-          "name": "Taunt from the Rampart"
-        },
-        {
-          "count": 1,
-          "name": "Temple of Triumph"
-        },
-        {
-          "count": 1,
-          "name": "Terramorphic Expanse"
-        },
-        {
-          "count": 1,
-          "name": "The Arkenstone"
-        },
-        {
-          "count": 1,
-          "name": "The Misty Mountains Cold"
-        },
-        {
-          "count": 1,
-          "name": "The Reaver Cleaver"
-        },
-        {
-          "count": 1,
-          "name": "There and Back Again"
-        },
-        {
-          "count": 1,
-          "name": "Thorin Oakenshield"
-        },
-        {
-          "count": 1,
-          "name": "Thorin, Mountain-king"
-        },
-        {
-          "count": 1,
-          "name": "Turbulent Steppe"
-        },
-        {
-          "count": 1,
-          "name": "Unbreakable Formation"
-        },
-        {
-          "count": 1,
-          "name": "War of the Last Alliance"
-        },
-        {
-          "count": 1,
-          "name": "Bofur, Reliable Guardian"
-        },
-        {
-          "count": 1,
-          "name": "Iron Hills Blacksmith"
-        },
-        {
-          "count": 1,
-          "name": "Dain, Lord of the Iron Hills"
-        },
-        {
-          "count": 1,
-          "name": "Kili the Resourceful"
-        },
-        {
-          "count": 1,
-          "name": "Fili the Pathfinder"
-        },
-        {
-          "count": 1,
-          "name": "Dwarven Mauler"
-        },
-        {
-          "count": 1,
-          "name": "Gloin the Mighty"
-        },
-        {
-          "count": 1,
-          "name": "Balin, Loremaster"
-        },
-        {
-          "count": 1,
-          "name": "Dain Ironfoot"
-        },
-        {
-          "count": 1,
-          "name": "Dwalin, Weaponmaster"
-        },
-        {
-          "count": 1,
-          "name": "Dain's Company"
-        },
-        {
-          "count": 1,
-          "name": "Nori, Teller of Tales"
-        },
-        {
-          "count": 1,
-          "name": "Bombur, Gentle Dreamer"
-        },
-        {
-          "count": 1,
-          "name": "Dori, Bearer of Friends"
-        },
-        {
-          "count": 1,
-          "name": "Gimli, Counter of Kills"
-        },
-        {
-          "count": 1,
-          "name": "Vanquisher's Banner"
-        },
-        {
-          "count": 1,
-          "name": "The Lonely Mountain"
-        },
-        {
-          "count": 1,
-          "name": "The Eagles Are Coming!"
-        },
-        {
-          "count": 1,
-          "name": "Sting, Bilbo's Sword"
-        },
-        {
-          "count": 1,
-          "name": "The One Ring"
-        },
-        {
-          "count": 1,
-          "name": "Oin the Brave"
+          "name": "War Room"
         },
         {
           "count": 1,
@@ -2868,372 +2887,10 @@
       "sideboard": []
     },
     {
-      "name": "Lathril, Blade of the Elves",
+      "name": "Thranduil, the Elvenking",
       "author": "MTGGoldfish",
       "colors": [
-        "B",
-        "G"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Abrupt Decay"
-        },
-        {
-          "count": 1,
-          "name": "Fyndhorn Elves"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Assassin's Trophy"
-        },
-        {
-          "count": 1,
-          "name": "Bala Ged Recovery"
-        },
-        {
-          "count": 1,
-          "name": "Banner of Kinship"
-        },
-        {
-          "count": 1,
-          "name": "Beast Whisperer"
-        },
-        {
-          "count": 1,
-          "name": "Beast Within"
-        },
-        {
-          "count": 1,
-          "name": "Boggart Trawler"
-        },
-        {
-          "count": 1,
-          "name": "Bojuka Bog"
-        },
-        {
-          "count": 1,
-          "name": "Champions of the Perfect"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Darkbore Pathway"
-        },
-        {
-          "count": 1,
-          "name": "Deathcap Glade"
-        },
-        {
-          "count": 1,
-          "name": "Dwynen, Gilt-Leaf Daen"
-        },
-        {
-          "count": 1,
-          "name": "Eclipsed Realms"
-        },
-        {
-          "count": 1,
-          "name": "Eladamri, Korvecdal"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Archdruid"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Champion"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Mystic"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Warmaster"
-        },
-        {
-          "count": 1,
-          "name": "Fabled Passage"
-        },
-        {
-          "count": 1,
-          "name": "Fauna Shaman"
-        },
-        {
-          "count": 1,
-          "name": "Feed the Swarm"
-        },
-        {
-          "count": 1,
-          "name": "Fell the Profane"
-        },
-        {
-          "count": 1,
-          "name": "Necroskitter"
-        },
-        {
-          "count": 1,
-          "name": "Flourishing Defenses"
-        },
-        {
-          "count": 4,
-          "name": "Swamp"
-        },
-        {
-          "count": 1,
-          "name": "Formidable Speaker"
-        },
-        {
-          "count": 1,
-          "name": "Galadhrim Brigade"
-        },
-        {
-          "count": 1,
-          "name": "Generous Patron"
-        },
-        {
-          "count": 1,
-          "name": "Gilt-Leaf Palace"
-        },
-        {
-          "count": 1,
-          "name": "Glissa Sunslayer"
-        },
-        {
-          "count": 1,
-          "name": "Bloated Contaminator"
-        },
-        {
-          "count": 1,
-          "name": "Golgari Charm"
-        },
-        {
-          "count": 1,
-          "name": "Guardian Project"
-        },
-        {
-          "count": 1,
-          "name": "Ichor Rats"
-        },
-        {
-          "count": 1,
-          "name": "Heroic Intervention"
-        },
-        {
-          "count": 1,
-          "name": "Imperious Perfect"
-        },
-        {
-          "count": 1,
-          "name": "Circle of Dreams Druid"
-        },
-        {
-          "count": 1,
-          "name": "Infectious Inquiry"
-        },
-        {
-          "count": 1,
-          "name": "Ezuri, Renegade Leader"
-        },
-        {
-          "count": 1,
-          "name": "Lathril, Blade of the Elves"
-        },
-        {
-          "count": 1,
-          "name": "Leaf-Crowned Visionary"
-        },
-        {
-          "count": 1,
-          "name": "Llanowar Elves"
-        },
-        {
-          "count": 1,
-          "name": "Dionus, Elvish Archdruid"
-        },
-        {
-          "count": 1,
-          "name": "Llanowar Wastes"
-        },
-        {
-          "count": 1,
-          "name": "Lys Alana Huntmaster"
-        },
-        {
-          "count": 1,
-          "name": "Malakir Rebirth"
-        },
-        {
-          "count": 1,
-          "name": "Marwyn, the Nurturer"
-        },
-        {
-          "count": 1,
-          "name": "Massacre Girl, Known Killer"
-        },
-        {
-          "count": 1,
-          "name": "Morcant's Loyalist"
-        },
-        {
-          "count": 1,
-          "name": "Mutavault"
-        },
-        {
-          "count": 1,
-          "name": "Nature's Claim"
-        },
-        {
-          "count": 1,
-          "name": "Overgrown Tomb"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Vanguard"
-        },
-        {
-          "count": 1,
-          "name": "Evolution Sage"
-        },
-        {
-          "count": 1,
-          "name": "Allosaurus Shepherd"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Promenade"
-        },
-        {
-          "count": 1,
-          "name": "Priest of Titania"
-        },
-        {
-          "count": 1,
-          "name": "Prowess of the Fair"
-        },
-        {
-          "count": 1,
-          "name": "Reclamation Sage"
-        },
-        {
-          "count": 1,
-          "name": "Reliquary Tower"
-        },
-        {
-          "count": 1,
-          "name": "Secluded Courtyard"
-        },
-        {
-          "count": 1,
-          "name": "Selfless Safewright"
-        },
-        {
-          "count": 1,
-          "name": "Shaman of the Pack"
-        },
-        {
-          "count": 1,
-          "name": "Shamanic Revelation"
-        },
-        {
-          "count": 1,
-          "name": "Skemfar Avenger"
-        },
-        {
-          "count": 1,
-          "name": "Skemfar Elderhall"
-        },
-        {
-          "count": 1,
-          "name": "Skemfar Shadowsage"
-        },
-        {
-          "count": 1,
-          "name": "Smuggler's Surprise"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Tainted Strike"
-        },
-        {
-          "count": 1,
-          "name": "Three Tree City"
-        },
-        {
-          "count": 1,
-          "name": "Throne of the God-Pharaoh"
-        },
-        {
-          "count": 1,
-          "name": "Triumph of the Hordes"
-        },
-        {
-          "count": 1,
-          "name": "Twilight Mire"
-        },
-        {
-          "count": 1,
-          "name": "Unclaimed Territory"
-        },
-        {
-          "count": 1,
-          "name": "Underground Mortuary"
-        },
-        {
-          "count": 11,
-          "name": "Forest"
-        },
-        {
-          "count": 1,
-          "name": "Vanquisher's Banner"
-        },
-        {
-          "count": 1,
-          "name": "Verdant Catacombs"
-        },
-        {
-          "count": 1,
-          "name": "Vernal Fen"
-        },
-        {
-          "count": 1,
-          "name": "Viridian Corrupter"
-        },
-        {
-          "count": 1,
-          "name": "Wirewood Lodge"
-        },
-        {
-          "count": 1,
-          "name": "Craterhoof Behemoth"
-        },
-        {
-          "count": 1,
-          "name": "High Perfect Morcant"
-        }
-      ],
-      "sideboard": []
-    },
-    {
-      "name": "Hashaton, Scarab's Fist",
-      "author": "MTGGoldfish",
-      "colors": [
-        "W",
+        "G",
         "B",
         "U"
       ],
@@ -3243,71 +2900,191 @@
       "main": [
         {
           "count": 1,
-          "name": "Accursed Duneyard"
+          "name": "Elrond, Moon-Reader"
         },
         {
           "count": 1,
-          "name": "Agna Qel'a"
+          "name": "Thranduil, Sindarin Liege"
         },
         {
           "count": 1,
-          "name": "Angel of the Ruins"
+          "name": "Marwyn, the Nurturer"
         },
         {
           "count": 1,
-          "name": "Animate Dead"
+          "name": "Arwen, Weaver of Hope"
         },
         {
           "count": 1,
-          "name": "Arcane Denial"
+          "name": "Dionus, Elvish Archdruid"
         },
         {
           "count": 1,
-          "name": "Arcane Sanctum"
+          "name": "Lathril, Blade of the Elves"
         },
         {
           "count": 1,
-          "name": "Arcane Signet"
+          "name": "Tyvar, the Pummeler"
         },
         {
           "count": 1,
-          "name": "Archfiend of Ifnir"
+          "name": "Shadowheart, Dark Justiciar"
         },
         {
           "count": 1,
-          "name": "Archon of Cruelty"
+          "name": "High Perfect Morcant"
         },
         {
           "count": 1,
-          "name": "Ashen Rider"
+          "name": "Eladamri, Korvecdal"
         },
         {
           "count": 1,
-          "name": "Bitter Triumph"
+          "name": "Selvala, Heart of the Wilds"
         },
         {
           "count": 1,
-          "name": "Bojuka Bog"
+          "name": "Prime Speaker Vannifar"
         },
         {
           "count": 1,
-          "name": "Bone Miser"
+          "name": "Jarad, Golgari Lich Lord"
         },
         {
           "count": 1,
-          "name": "Gray Merchant of Asphodel"
+          "name": "Lluwen, Imperfect Naturalist"
         },
         {
           "count": 1,
-          "name": "Bontu's Monument"
+          "name": "Trystan, Callous Cultivator"
         },
         {
           "count": 1,
-          "name": "Collector's Vault"
+          "name": "Kagha, Shadow Archdruid"
         },
         {
           "count": 1,
-          "name": "Command Tower"
+          "name": "Elrond, Lord of Rivendell"
+        },
+        {
+          "count": 1,
+          "name": "Selfless Safewright"
+        },
+        {
+          "count": 1,
+          "name": "Thranduil's Company"
+        },
+        {
+          "count": 1,
+          "name": "Reclamation Sage"
+        },
+        {
+          "count": 1,
+          "name": "Silvan Reveler"
+        },
+        {
+          "count": 1,
+          "name": "Immaculate Magistrate"
+        },
+        {
+          "count": 1,
+          "name": "Zameck Guildmage"
+        },
+        {
+          "count": 1,
+          "name": "Deepwood Denizen"
+        },
+        {
+          "count": 1,
+          "name": "Iron-Shield Elf"
+        },
+        {
+          "count": 1,
+          "name": "Fauna Shaman"
+        },
+        {
+          "count": 1,
+          "name": "Aftermath Analyst"
+        },
+        {
+          "count": 1,
+          "name": "Elvish Archdruid"
+        },
+        {
+          "count": 1,
+          "name": "Priest of Titania"
+        },
+        {
+          "count": 1,
+          "name": "Incubation Druid"
+        },
+        {
+          "count": 1,
+          "name": "Deathbloom Ritualist"
+        },
+        {
+          "count": 1,
+          "name": "Woodland Weavemaster"
+        },
+        {
+          "count": 1,
+          "name": "Llanowar Elves"
+        },
+        {
+          "count": 1,
+          "name": "Elvish Mystic"
+        },
+        {
+          "count": 1,
+          "name": "Elves of Deep Shadow"
+        },
+        {
+          "count": 1,
+          "name": "Urborg Elf"
+        },
+        {
+          "count": 1,
+          "name": "Wood Elves"
+        },
+        {
+          "count": 1,
+          "name": "Tyvar, Jubilant Brawler"
+        },
+        {
+          "count": 1,
+          "name": "Dina's Guidance"
+        },
+        {
+          "count": 1,
+          "name": "Heroic Intervention"
+        },
+        {
+          "count": 1,
+          "name": "Assassin's Trophy"
+        },
+        {
+          "count": 1,
+          "name": "Abrupt Decay"
+        },
+        {
+          "count": 1,
+          "name": "Dismember"
+        },
+        {
+          "count": 1,
+          "name": "Pongify"
+        },
+        {
+          "count": 1,
+          "name": "Rapid Hybridization"
+        },
+        {
+          "count": 1,
+          "name": "Beast Within"
+        },
+        {
+          "count": 1,
+          "name": "Tear Asunder"
         },
         {
           "count": 1,
@@ -3315,195 +3092,43 @@
         },
         {
           "count": 1,
-          "name": "Cryptbreaker"
+          "name": "Swan Song"
         },
         {
           "count": 1,
-          "name": "Damn"
+          "name": "An Offer You Can't Refuse"
         },
         {
           "count": 1,
-          "name": "Dark Ritual"
+          "name": "Galadhrim Ambush"
         },
         {
           "count": 1,
-          "name": "Despark"
+          "name": "Raise the Palisade"
         },
         {
           "count": 1,
-          "name": "Drowned Catacomb"
+          "name": "Kindred Dominance"
         },
         {
           "count": 1,
-          "name": "Exotic Orchard"
+          "name": "Triumph of the Hordes"
         },
         {
           "count": 1,
-          "name": "Faithful Mending"
+          "name": "Overwhelming Stampede"
         },
         {
           "count": 1,
-          "name": "Fellwar Stone"
+          "name": "Exsanguinate"
         },
         {
           "count": 1,
-          "name": "Frantic Search"
+          "name": "Eldritch Evolution"
         },
         {
           "count": 1,
-          "name": "Geier Reach Sanitarium"
-        },
-        {
-          "count": 1,
-          "name": "Ghostly Pilferer"
-        },
-        {
-          "count": 1,
-          "name": "Glacial Fortress"
-        },
-        {
-          "count": 1,
-          "name": "Gleaming Overseer"
-        },
-        {
-          "count": 1,
-          "name": "Godless Shrine"
-        },
-        {
-          "count": 1,
-          "name": "Grave Titan"
-        },
-        {
-          "count": 1,
-          "name": "Hashaton, Scarab's Fist"
-        },
-        {
-          "count": 1,
-          "name": "Hullbreaker Horror"
-        },
-        {
-          "count": 1,
-          "name": "Isolated Chapel"
-        },
-        {
-          "count": 1,
-          "name": "Jin-Gitaxias, Core Augur"
-        },
-        {
-          "count": 1,
-          "name": "Key to the City"
-        },
-        {
-          "count": 1,
-          "name": "Kitsa, Otterball Elite"
-        },
-        {
-          "count": 1,
-          "name": "Ledger Shredder"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves"
-        },
-        {
-          "count": 1,
-          "name": "Likeness Looter"
-        },
-        {
-          "count": 1,
-          "name": "Living Death"
-        },
-        {
-          "count": 1,
-          "name": "Lotho, Corrupt Shirriff"
-        },
-        {
-          "count": 1,
-          "name": "Massacre Wurm"
-        },
-        {
-          "count": 1,
-          "name": "Matzalantli, the Great Door"
-        },
-        {
-          "count": 1,
-          "name": "Merfolk Looter"
-        },
-        {
-          "count": 1,
-          "name": "Metamorphosis Fanatic"
-        },
-        {
-          "count": 1,
-          "name": "Monument to Endurance"
-        },
-        {
-          "count": 1,
-          "name": "Mystic Remora"
-        },
-        {
-          "count": 1,
-          "name": "Nezahal, Primal Tide"
-        },
-        {
-          "count": 1,
-          "name": "Obsessive Stitcher"
-        },
-        {
-          "count": 1,
-          "name": "On Wings of Gold"
-        },
-        {
-          "count": 1,
-          "name": "Peregrine Drake"
-        },
-        {
-          "count": 1,
-          "name": "Persist"
-        },
-        {
-          "count": 1,
-          "name": "Psychic Frog"
-        },
-        {
-          "count": 1,
-          "name": "Putrid Imp"
-        },
-        {
-          "count": 1,
-          "name": "Raffine's Tower"
-        },
-        {
-          "count": 1,
-          "name": "Reanimate"
-        },
-        {
-          "count": 1,
-          "name": "Reliquary Tower"
-        },
-        {
-          "count": 1,
-          "name": "Renewed Solidarity"
-        },
-        {
-          "count": 1,
-          "name": "Rhet-Tomb Mystic"
-        },
-        {
-          "count": 1,
-          "name": "Rona, Herald of Invasion"
-        },
-        {
-          "count": 1,
-          "name": "Rootborn Defenses"
-        },
-        {
-          "count": 1,
-          "name": "Sink into Stupor"
-        },
-        {
-          "count": 1,
-          "name": "Skirge Familiar"
+          "name": "Bloodline Bidding"
         },
         {
           "count": 1,
@@ -3511,11 +3136,55 @@
         },
         {
           "count": 1,
-          "name": "Springleaf Drum"
+          "name": "Arcane Signet"
         },
         {
           "count": 1,
-          "name": "Spymaster's Vault"
+          "name": "Herald's Horn"
+        },
+        {
+          "count": 1,
+          "name": "Pride of the Perfect"
+        },
+        {
+          "count": 1,
+          "name": "Awaken the Honored Dead"
+        },
+        {
+          "count": 1,
+          "name": "Harald Unites the Elves"
+        },
+        {
+          "count": 1,
+          "name": "Morcant's Eyes"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Path of Ancestry"
+        },
+        {
+          "count": 1,
+          "name": "Eclipsed Realms"
+        },
+        {
+          "count": 1,
+          "name": "Unclaimed Territory"
+        },
+        {
+          "count": 1,
+          "name": "Secluded Courtyard"
+        },
+        {
+          "count": 1,
+          "name": "Exotic Orchard"
+        },
+        {
+          "count": 1,
+          "name": "Opulent Palace"
         },
         {
           "count": 1,
@@ -3523,35 +3192,410 @@
         },
         {
           "count": 1,
+          "name": "Sodden Verdure"
+        },
+        {
+          "count": 1,
+          "name": "Vernal Fen"
+        },
+        {
+          "count": 1,
+          "name": "Hinterland Harbor"
+        },
+        {
+          "count": 1,
+          "name": "Woodland Cemetery"
+        },
+        {
+          "count": 1,
+          "name": "Rejuvenating Springs"
+        },
+        {
+          "count": 1,
+          "name": "Drowned Catacomb"
+        },
+        {
+          "count": 1,
+          "name": "Deathcap Glade"
+        },
+        {
+          "count": 1,
+          "name": "Dreamroot Cascade"
+        },
+        {
+          "count": 1,
+          "name": "Shipwreck Marsh"
+        },
+        {
+          "count": 1,
+          "name": "Bojuka Bog"
+        },
+        {
+          "count": 1,
+          "name": "Shifting Woodland"
+        },
+        {
+          "count": 1,
+          "name": "Elven Passage"
+        },
+        {
+          "count": 1,
+          "name": "Fabled Passage"
+        },
+        {
+          "count": 1,
+          "name": "Evolving Wilds"
+        },
+        {
+          "count": 4,
+          "name": "Forest"
+        },
+        {
+          "count": 4,
+          "name": "Swamp"
+        },
+        {
+          "count": 4,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Thranduil, the Elvenking"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "Sauron, the Dark Lord",
+      "author": "MTGGoldfish",
+      "colors": [
+        "B",
+        "R",
+        "U"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "An Offer You Can't Refuse"
+        },
+        {
+          "count": 1,
+          "name": "Anger"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Denial"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
+          "name": "Azog, Moria's Ruin"
+        },
+        {
+          "count": 1,
+          "name": "Barad-dur"
+        },
+        {
+          "count": 1,
+          "name": "Bitter Downfall"
+        },
+        {
+          "count": 1,
+          "name": "Blasphemous Act"
+        },
+        {
+          "count": 1,
+          "name": "Blood Crypt"
+        },
+        {
+          "count": 1,
+          "name": "Book of Mazarbul"
+        },
+        {
+          "count": 1,
+          "name": "Call of the Ring"
+        },
+        {
+          "count": 1,
+          "name": "Cavern-Hoard Dragon"
+        },
+        {
+          "count": 1,
+          "name": "Choked Estuary"
+        },
+        {
+          "count": 1,
+          "name": "Claim the Precious"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Commander's Sphere"
+        },
+        {
+          "count": 1,
+          "name": "Corsairs of Umbar"
+        },
+        {
+          "count": 1,
+          "name": "Counterspell"
+        },
+        {
+          "count": 1,
+          "name": "Crumbling Necropolis"
+        },
+        {
+          "count": 1,
+          "name": "Dark Ritual"
+        },
+        {
+          "count": 1,
+          "name": "Dimir Signet"
+        },
+        {
+          "count": 1,
+          "name": "Dragonskull Summit"
+        },
+        {
+          "count": 1,
+          "name": "Dreadhorde Invasion"
+        },
+        {
+          "count": 1,
+          "name": "Drowned Catacomb"
+        },
+        {
+          "count": 1,
+          "name": "Dunland Crebain"
+        },
+        {
+          "count": 1,
+          "name": "Exotic Orchard"
+        },
+        {
+          "count": 1,
+          "name": "Faithless Looting"
+        },
+        {
+          "count": 1,
+          "name": "Feed the Swarm"
+        },
+        {
+          "count": 1,
+          "name": "Fellwar Stone"
+        },
+        {
+          "count": 1,
+          "name": "Fiery Inscription"
+        },
+        {
+          "count": 1,
+          "name": "Foray of Orcs"
+        },
+        {
+          "count": 1,
+          "name": "Foreboding Ruins"
+        },
+        {
+          "count": 1,
+          "name": "Frostboil Snarl"
+        },
+        {
+          "count": 1,
+          "name": "Gothmog, Morgul Lieutenant"
+        },
+        {
+          "count": 1,
+          "name": "Great Goblin, Foul-Hearted"
+        },
+        {
+          "count": 1,
+          "name": "Grishnakh, Brash Instigator"
+        },
+        {
+          "count": 1,
+          "name": "In the Darkness Bind Them"
+        },
+        {
+          "count": 5,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Living Death"
+        },
+        {
+          "count": 1,
+          "name": "March from the Black Gate"
+        },
+        {
+          "count": 1,
+          "name": "Mauhur, Uruk-hai Captain"
+        },
+        {
+          "count": 1,
+          "name": "Minas Morgul, Dark Fortress"
+        },
+        {
+          "count": 1,
+          "name": "Moria Scavenger"
+        },
+        {
+          "count": 1,
+          "name": "Mount Doom"
+        },
+        {
+          "count": 4,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "One Ring to Rule Them All"
+        },
+        {
+          "count": 1,
+          "name": "Orcish Bowmasters"
+        },
+        {
+          "count": 1,
+          "name": "Orcish Medicine"
+        },
+        {
+          "count": 1,
+          "name": "Orcish Siegemaster"
+        },
+        {
+          "count": 1,
+          "name": "Palantir of Orthanc"
+        },
+        {
+          "count": 1,
+          "name": "Path of Ancestry"
+        },
+        {
+          "count": 1,
+          "name": "Reanimate"
+        },
+        {
+          "count": 1,
+          "name": "Relic of Sauron"
+        },
+        {
+          "count": 1,
+          "name": "Ringsight"
+        },
+        {
+          "count": 1,
+          "name": "Rogue's Passage"
+        },
+        {
+          "count": 1,
+          "name": "Saruman, the White Hand"
+        },
+        {
+          "count": 1,
+          "name": "Saruman's Trickery"
+        },
+        {
+          "count": 1,
+          "name": "Sauron, Lord of the Rings"
+        },
+        {
+          "count": 1,
+          "name": "Sauron, the Dark Lord"
+        },
+        {
+          "count": 1,
+          "name": "Sauron, the Necromancer"
+        },
+        {
+          "count": 1,
+          "name": "Sauron's Ransom"
+        },
+        {
+          "count": 1,
+          "name": "Scourge of the Throne"
+        },
+        {
+          "count": 1,
+          "name": "Smoldering Marsh"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Soothing of Smeagol"
+        },
+        {
+          "count": 1,
+          "name": "Steam Vents"
+        },
+        {
+          "count": 1,
+          "name": "Sulfur Falls"
+        },
+        {
+          "count": 1,
+          "name": "Sulfurous Springs"
+        },
+        {
+          "count": 1,
+          "name": "Summons of Saruman"
+        },
+        {
+          "count": 1,
+          "name": "Sunken Hollow"
+        },
+        {
+          "count": 6,
+          "name": "Swamp"
+        },
+        {
+          "count": 1,
           "name": "Swan Song"
         },
         {
           "count": 1,
-          "name": "Swords to Plowshares"
+          "name": "Talisman of Creativity"
         },
         {
           "count": 1,
-          "name": "Takenuma, Abandoned Mire"
+          "name": "Talisman of Dominance"
         },
         {
           "count": 1,
-          "name": "Talisman of Hierarchy"
+          "name": "Talisman of Indulgence"
         },
         {
           "count": 1,
-          "name": "Talisman of Progress"
+          "name": "The Balrog of Moria"
         },
         {
           "count": 1,
-          "name": "The Underworld Cookbook"
+          "name": "The Black Gate"
         },
         {
           "count": 1,
-          "name": "Tireless Tribe"
+          "name": "The Great Goblin"
         },
         {
           "count": 1,
-          "name": "Tortured Existence"
+          "name": "The Mouth of Sauron"
+        },
+        {
+          "count": 1,
+          "name": "Too Greedily, Too Deep"
         },
         {
           "count": 1,
@@ -3559,23 +3603,23 @@
         },
         {
           "count": 1,
-          "name": "Undercity Sewers"
+          "name": "Treason of Isengard"
         },
         {
           "count": 1,
-          "name": "Unholy Grotto"
+          "name": "Treasure Nabber"
         },
         {
           "count": 1,
-          "name": "Valgavoth, Terror Eater"
+          "name": "Ugluk of the White Hand"
         },
         {
           "count": 1,
-          "name": "Victimize"
+          "name": "Underground River"
         },
         {
           "count": 1,
-          "name": "Vohar, Vodalian Desecrator"
+          "name": "Warg Rider"
         },
         {
           "count": 1,
@@ -3583,27 +3627,7 @@
         },
         {
           "count": 1,
-          "name": "Windfall"
-        },
-        {
-          "count": 1,
-          "name": "Wishclaw Talisman"
-        },
-        {
-          "count": 7,
-          "name": "Swamp"
-        },
-        {
-          "count": 5,
-          "name": "Island"
-        },
-        {
-          "count": 4,
-          "name": "Plains"
-        },
-        {
-          "count": 1,
-          "name": "Terramorphic Expanse"
+          "name": "Witch-king of Angmar"
         }
       ],
       "sideboard": []

--- a/client/public/feeds/mtggoldfish-modern.json
+++ b/client/public/feeds/mtggoldfish-modern.json
@@ -5,140 +5,9 @@
   "icon": "G",
   "format": "modern",
   "version": 1,
-  "updated": "2026-08-14T00:00:00Z",
+  "updated": "2026-08-15T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/modern",
   "decks": [
-    {
-      "name": "Boros Energy",
-      "author": "MTGGoldfish",
-      "colors": [
-        "R",
-        "W"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Elegant Parlor"
-        },
-        {
-          "count": 4,
-          "name": "Ajani, Nacatl Pariah"
-        },
-        {
-          "count": 4,
-          "name": "Seasoned Pyromancer"
-        },
-        {
-          "count": 3,
-          "name": "Flooded Strand"
-        },
-        {
-          "count": 4,
-          "name": "Arid Mesa"
-        },
-        {
-          "count": 2,
-          "name": "Dalkovan Encampment"
-        },
-        {
-          "count": 1,
-          "name": "Arena of Glory"
-        },
-        {
-          "count": 2,
-          "name": "Thraben Charm"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Bolt"
-        },
-        {
-          "count": 4,
-          "name": "Guide of Souls"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 4,
-          "name": "Voice of Victory"
-        },
-        {
-          "count": 4,
-          "name": "Ragavan, Nimble Pilferer"
-        },
-        {
-          "count": 4,
-          "name": "Galvanic Discharge"
-        },
-        {
-          "count": 3,
-          "name": "Ranger-Captain of Eos"
-        },
-        {
-          "count": 4,
-          "name": "Goblin Bombardment"
-        },
-        {
-          "count": 4,
-          "name": "Sacred Foundry"
-        },
-        {
-          "count": 4,
-          "name": "Ocelot Pride"
-        },
-        {
-          "count": 3,
-          "name": "Plains"
-        },
-        {
-          "count": 3,
-          "name": "Marsh Flats"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 2,
-          "name": "Sanctifier en-Vec"
-        },
-        {
-          "count": 1,
-          "name": "Rest in Peace"
-        },
-        {
-          "count": 1,
-          "name": "Vexing Bauble"
-        },
-        {
-          "count": 2,
-          "name": "Blood Moon"
-        },
-        {
-          "count": 2,
-          "name": "Deafening Silence"
-        },
-        {
-          "count": 2,
-          "name": "Orim's Chant"
-        },
-        {
-          "count": 2,
-          "name": "Wear // Tear"
-        },
-        {
-          "count": 1,
-          "name": "The Legend of Roku"
-        },
-        {
-          "count": 2,
-          "name": "Wrath of the Skies"
-        }
-      ]
-    },
     {
       "name": "Goryo's Vengeance",
       "author": "MTGGoldfish",
@@ -289,6 +158,137 @@
         {
           "count": 2,
           "name": "Quantum Riddler"
+        }
+      ]
+    },
+    {
+      "name": "Boros Energy",
+      "author": "MTGGoldfish",
+      "colors": [
+        "R",
+        "W"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Elegant Parlor"
+        },
+        {
+          "count": 4,
+          "name": "Ajani, Nacatl Pariah"
+        },
+        {
+          "count": 4,
+          "name": "Seasoned Pyromancer"
+        },
+        {
+          "count": 3,
+          "name": "Flooded Strand"
+        },
+        {
+          "count": 4,
+          "name": "Arid Mesa"
+        },
+        {
+          "count": 2,
+          "name": "Dalkovan Encampment"
+        },
+        {
+          "count": 1,
+          "name": "Arena of Glory"
+        },
+        {
+          "count": 2,
+          "name": "Thraben Charm"
+        },
+        {
+          "count": 1,
+          "name": "Lightning Bolt"
+        },
+        {
+          "count": 4,
+          "name": "Guide of Souls"
+        },
+        {
+          "count": 1,
+          "name": "Mountain"
+        },
+        {
+          "count": 4,
+          "name": "Voice of Victory"
+        },
+        {
+          "count": 4,
+          "name": "Ragavan, Nimble Pilferer"
+        },
+        {
+          "count": 4,
+          "name": "Galvanic Discharge"
+        },
+        {
+          "count": 3,
+          "name": "Ranger-Captain of Eos"
+        },
+        {
+          "count": 4,
+          "name": "Goblin Bombardment"
+        },
+        {
+          "count": 4,
+          "name": "Sacred Foundry"
+        },
+        {
+          "count": 4,
+          "name": "Ocelot Pride"
+        },
+        {
+          "count": 3,
+          "name": "Plains"
+        },
+        {
+          "count": 3,
+          "name": "Marsh Flats"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 2,
+          "name": "Sanctifier en-Vec"
+        },
+        {
+          "count": 1,
+          "name": "Rest in Peace"
+        },
+        {
+          "count": 1,
+          "name": "Vexing Bauble"
+        },
+        {
+          "count": 2,
+          "name": "Blood Moon"
+        },
+        {
+          "count": 2,
+          "name": "Deafening Silence"
+        },
+        {
+          "count": 2,
+          "name": "Orim's Chant"
+        },
+        {
+          "count": 2,
+          "name": "Wear // Tear"
+        },
+        {
+          "count": 1,
+          "name": "The Legend of Roku"
+        },
+        {
+          "count": 2,
+          "name": "Wrath of the Skies"
         }
       ]
     },
@@ -464,6 +464,132 @@
       ]
     },
     {
+      "name": "Mono-Green Eldrazi",
+      "author": "MTGGoldfish",
+      "colors": [
+        "G"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Gemstone Caverns"
+        },
+        {
+          "count": 2,
+          "name": "Ugin, Eye of the Storms"
+        },
+        {
+          "count": 4,
+          "name": "Slumbering Trudge"
+        },
+        {
+          "count": 4,
+          "name": "Ugin's Labyrinth"
+        },
+        {
+          "count": 2,
+          "name": "Ulamog, the Ceaseless Hunger"
+        },
+        {
+          "count": 1,
+          "name": "Dryad Arbor"
+        },
+        {
+          "count": 5,
+          "name": "Forest"
+        },
+        {
+          "count": 4,
+          "name": "Green Sun's Zenith"
+        },
+        {
+          "count": 4,
+          "name": "Eldrazi Temple"
+        },
+        {
+          "count": 1,
+          "name": "Cavern of Souls"
+        },
+        {
+          "count": 4,
+          "name": "Disciple of Freyalise"
+        },
+        {
+          "count": 4,
+          "name": "Kozilek's Command"
+        },
+        {
+          "count": 1,
+          "name": "Mosswort Bridge"
+        },
+        {
+          "count": 4,
+          "name": "Malevolent Rumble"
+        },
+        {
+          "count": 4,
+          "name": "Sowing Mycospawn"
+        },
+        {
+          "count": 4,
+          "name": "Emrakul, the Promised End"
+        },
+        {
+          "count": 2,
+          "name": "Drowner of Truth"
+        },
+        {
+          "count": 1,
+          "name": "Boseiju, Who Endures"
+        },
+        {
+          "count": 4,
+          "name": "Fanatic of Rhonas"
+        },
+        {
+          "count": 4,
+          "name": "Fight Rigging"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 2,
+          "name": "Endurance"
+        },
+        {
+          "count": 2,
+          "name": "Thought-Knot Seer"
+        },
+        {
+          "count": 1,
+          "name": "Gemstone Caverns"
+        },
+        {
+          "count": 3,
+          "name": "Chalice of the Void"
+        },
+        {
+          "count": 2,
+          "name": "Trinisphere"
+        },
+        {
+          "count": 3,
+          "name": "Force of Vigor"
+        },
+        {
+          "count": 1,
+          "name": "Dismember"
+        },
+        {
+          "count": 1,
+          "name": "Elder Gargaroth"
+        }
+      ]
+    },
+    {
       "name": "Affinity",
       "author": "MTGGoldfish",
       "colors": [
@@ -591,132 +717,6 @@
         {
           "count": 2,
           "name": "Mystical Dispute"
-        }
-      ]
-    },
-    {
-      "name": "Mono-Green Eldrazi",
-      "author": "MTGGoldfish",
-      "colors": [
-        "G"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Gemstone Caverns"
-        },
-        {
-          "count": 2,
-          "name": "Ugin, Eye of the Storms"
-        },
-        {
-          "count": 4,
-          "name": "Slumbering Trudge"
-        },
-        {
-          "count": 4,
-          "name": "Ugin's Labyrinth"
-        },
-        {
-          "count": 2,
-          "name": "Ulamog, the Ceaseless Hunger"
-        },
-        {
-          "count": 1,
-          "name": "Dryad Arbor"
-        },
-        {
-          "count": 5,
-          "name": "Forest"
-        },
-        {
-          "count": 4,
-          "name": "Green Sun's Zenith"
-        },
-        {
-          "count": 4,
-          "name": "Eldrazi Temple"
-        },
-        {
-          "count": 1,
-          "name": "Cavern of Souls"
-        },
-        {
-          "count": 4,
-          "name": "Disciple of Freyalise"
-        },
-        {
-          "count": 4,
-          "name": "Kozilek's Command"
-        },
-        {
-          "count": 1,
-          "name": "Mosswort Bridge"
-        },
-        {
-          "count": 4,
-          "name": "Malevolent Rumble"
-        },
-        {
-          "count": 4,
-          "name": "Sowing Mycospawn"
-        },
-        {
-          "count": 4,
-          "name": "Emrakul, the Promised End"
-        },
-        {
-          "count": 2,
-          "name": "Drowner of Truth"
-        },
-        {
-          "count": 1,
-          "name": "Boseiju, Who Endures"
-        },
-        {
-          "count": 4,
-          "name": "Fanatic of Rhonas"
-        },
-        {
-          "count": 4,
-          "name": "Fight Rigging"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 2,
-          "name": "Endurance"
-        },
-        {
-          "count": 2,
-          "name": "Thought-Knot Seer"
-        },
-        {
-          "count": 1,
-          "name": "Gemstone Caverns"
-        },
-        {
-          "count": 3,
-          "name": "Chalice of the Void"
-        },
-        {
-          "count": 2,
-          "name": "Trinisphere"
-        },
-        {
-          "count": 3,
-          "name": "Force of Vigor"
-        },
-        {
-          "count": 1,
-          "name": "Dismember"
-        },
-        {
-          "count": 1,
-          "name": "Elder Gargaroth"
         }
       ]
     },
@@ -1040,6 +1040,125 @@
       ]
     },
     {
+      "name": "Izzet Prowess",
+      "author": "MTGGoldfish",
+      "colors": [
+        "R",
+        "U"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 2,
+          "name": "Arid Mesa"
+        },
+        {
+          "count": 3,
+          "name": "Bloodstained Mire"
+        },
+        {
+          "count": 4,
+          "name": "Cori-Steel Cutter"
+        },
+        {
+          "count": 4,
+          "name": "Dragon's Rage Channeler"
+        },
+        {
+          "count": 4,
+          "name": "Expressive Iteration"
+        },
+        {
+          "count": 1,
+          "name": "Fiery Islet"
+        },
+        {
+          "count": 4,
+          "name": "Lava Dart"
+        },
+        {
+          "count": 4,
+          "name": "Lightning Bolt"
+        },
+        {
+          "count": 4,
+          "name": "Mishra's Bauble"
+        },
+        {
+          "count": 4,
+          "name": "Monastery Swiftspear"
+        },
+        {
+          "count": 3,
+          "name": "Mountain"
+        },
+        {
+          "count": 4,
+          "name": "Mutagenic Growth"
+        },
+        {
+          "count": 4,
+          "name": "Preordain"
+        },
+        {
+          "count": 3,
+          "name": "Scalding Tarn"
+        },
+        {
+          "count": 4,
+          "name": "Slickshot Show-Off"
+        },
+        {
+          "count": 3,
+          "name": "Steam Vents"
+        },
+        {
+          "count": 1,
+          "name": "Thundering Falls"
+        },
+        {
+          "count": 2,
+          "name": "Violent Urge"
+        },
+        {
+          "count": 2,
+          "name": "Wooded Foothills"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 4,
+          "name": "Consign to Memory"
+        },
+        {
+          "count": 2,
+          "name": "Meltdown"
+        },
+        {
+          "count": 2,
+          "name": "Spell Pierce"
+        },
+        {
+          "count": 1,
+          "name": "Spell Snare"
+        },
+        {
+          "count": 2,
+          "name": "Tormod's Crypt"
+        },
+        {
+          "count": 3,
+          "name": "Unholy Heat"
+        },
+        {
+          "count": 1,
+          "name": "Into the Flood Maw"
+        }
+      ]
+    },
+    {
       "name": "Eldrazi Tron",
       "author": "MTGGoldfish",
       "colors": [
@@ -1178,125 +1297,6 @@
         {
           "count": 1,
           "name": "Liquimetal Coating"
-        }
-      ]
-    },
-    {
-      "name": "Izzet Prowess",
-      "author": "MTGGoldfish",
-      "colors": [
-        "R",
-        "U"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 2,
-          "name": "Arid Mesa"
-        },
-        {
-          "count": 3,
-          "name": "Bloodstained Mire"
-        },
-        {
-          "count": 4,
-          "name": "Cori-Steel Cutter"
-        },
-        {
-          "count": 4,
-          "name": "Dragon's Rage Channeler"
-        },
-        {
-          "count": 4,
-          "name": "Expressive Iteration"
-        },
-        {
-          "count": 1,
-          "name": "Fiery Islet"
-        },
-        {
-          "count": 4,
-          "name": "Lava Dart"
-        },
-        {
-          "count": 4,
-          "name": "Lightning Bolt"
-        },
-        {
-          "count": 4,
-          "name": "Mishra's Bauble"
-        },
-        {
-          "count": 4,
-          "name": "Monastery Swiftspear"
-        },
-        {
-          "count": 3,
-          "name": "Mountain"
-        },
-        {
-          "count": 4,
-          "name": "Mutagenic Growth"
-        },
-        {
-          "count": 4,
-          "name": "Preordain"
-        },
-        {
-          "count": 3,
-          "name": "Scalding Tarn"
-        },
-        {
-          "count": 4,
-          "name": "Slickshot Show-Off"
-        },
-        {
-          "count": 3,
-          "name": "Steam Vents"
-        },
-        {
-          "count": 1,
-          "name": "Thundering Falls"
-        },
-        {
-          "count": 2,
-          "name": "Violent Urge"
-        },
-        {
-          "count": 2,
-          "name": "Wooded Foothills"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 4,
-          "name": "Consign to Memory"
-        },
-        {
-          "count": 2,
-          "name": "Meltdown"
-        },
-        {
-          "count": 2,
-          "name": "Spell Pierce"
-        },
-        {
-          "count": 1,
-          "name": "Spell Snare"
-        },
-        {
-          "count": 2,
-          "name": "Tormod's Crypt"
-        },
-        {
-          "count": 3,
-          "name": "Unholy Heat"
-        },
-        {
-          "count": 1,
-          "name": "Into the Flood Maw"
         }
       ]
     },

--- a/client/public/feeds/mtggoldfish-pioneer.json
+++ b/client/public/feeds/mtggoldfish-pioneer.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "pioneer",
   "version": 1,
-  "updated": "2026-08-14T00:00:00Z",
+  "updated": "2026-08-15T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/pioneer",
   "decks": [
     {
@@ -569,7 +569,7 @@
       "main": [
         {
           "count": 2,
-          "name": "The Wandering Emperor"
+          "name": "Essence Scatter"
         },
         {
           "count": 4,
@@ -612,7 +612,7 @@
           "name": "Memory Deluge"
         },
         {
-          "count": 4,
+          "count": 2,
           "name": "Island"
         },
         {
@@ -624,15 +624,15 @@
           "name": "Spell Snare"
         },
         {
-          "count": 2,
+          "count": 4,
           "name": "Deserted Beach"
         },
         {
-          "count": 2,
+          "count": 4,
           "name": "Temporary Lockdown"
         },
         {
-          "count": 2,
+          "count": 4,
           "name": "Supreme Verdict"
         },
         {
@@ -652,16 +652,12 @@
           "name": "Get Out"
         },
         {
-          "count": 4,
+          "count": 2,
           "name": "Get Lost"
         },
         {
-          "count": 2,
-          "name": "Ultima"
-        },
-        {
           "count": 4,
-          "name": "Quick Study"
+          "name": "Plunder the Trollshaws"
         }
       ],
       "sideboard": [
@@ -671,27 +667,19 @@
         },
         {
           "count": 4,
+          "name": "Three Steps Ahead"
+        },
+        {
+          "count": 4,
+          "name": "Quantum Riddler"
+        },
+        {
+          "count": 4,
           "name": "Beza, the Bounding Spring"
         },
         {
           "count": 2,
-          "name": "Minor Misstep"
-        },
-        {
-          "count": 2,
-          "name": "Emeritus of Ideation"
-        },
-        {
-          "count": 2,
-          "name": "Quantum Riddler"
-        },
-        {
-          "count": 2,
-          "name": "Spell Pierce"
-        },
-        {
-          "count": 2,
-          "name": "Test of Talents"
+          "name": "Get Lost"
         }
       ]
     },
@@ -1120,16 +1108,32 @@
       ],
       "main": [
         {
-          "count": 1,
-          "name": "Island"
+          "count": 4,
+          "name": "Floodpits Drowner"
         },
         {
-          "count": 1,
-          "name": "Island"
+          "count": 3,
+          "name": "Multiversal Passage"
+        },
+        {
+          "count": 3,
+          "name": "Moon-Circuit Hacker"
         },
         {
           "count": 4,
-          "name": "Watery Grave"
+          "name": "Gloomlake Verge"
+        },
+        {
+          "count": 1,
+          "name": "Otawara, Soaring City"
+        },
+        {
+          "count": 4,
+          "name": "Mutavault"
+        },
+        {
+          "count": 1,
+          "name": "Takenuma, Abandoned Mire"
         },
         {
           "count": 4,
@@ -1137,117 +1141,89 @@
         },
         {
           "count": 4,
-          "name": "Kaito, Bane of Nightmares"
-        },
-        {
-          "count": 1,
-          "name": "Go for the Throat"
-        },
-        {
-          "count": 2,
-          "name": "Fatal Push"
-        },
-        {
-          "count": 2,
-          "name": "Fatal Push"
+          "name": "Watery Grave"
         },
         {
           "count": 4,
-          "name": "Moon-Circuit Hacker"
+          "name": "Fatal Push"
         },
         {
           "count": 2,
-          "name": "Blade of the Oni"
-        },
-        {
-          "count": 1,
-          "name": "Otawara, Soaring City"
-        },
-        {
-          "count": 1,
-          "name": "Takenuma, Abandoned Mire"
-        },
-        {
-          "count": 3,
           "name": "Sheoldred, the Apocalypse"
-        },
-        {
-          "count": 4,
-          "name": "Spyglass Siren"
-        },
-        {
-          "count": 1,
-          "name": "Bitter Triumph"
-        },
-        {
-          "count": 4,
-          "name": "Floodpits Drowner"
-        },
-        {
-          "count": 1,
-          "name": "Nowhere to Run"
         },
         {
           "count": 4,
           "name": "Thoughtseize"
         },
         {
-          "count": 4,
-          "name": "Unholy Annex // Ritual Chamber"
+          "count": 2,
+          "name": "Island"
         },
         {
-          "count": 3,
-          "name": "Multiversal Passage"
+          "count": 2,
+          "name": "Mockingbird"
+        },
+        {
+          "count": 1,
+          "name": "Nowhere to Run"
         },
         {
           "count": 1,
           "name": "Swamp"
         },
         {
-          "count": 4,
-          "name": "Mutavault"
+          "count": 3,
+          "name": "Unholy Annex // Ritual Chamber"
         },
         {
           "count": 4,
-          "name": "Gloomlake Verge"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 2,
-          "name": "Disdainful Stroke"
-        },
-        {
-          "count": 2,
-          "name": "Duress"
-        },
-        {
-          "count": 1,
-          "name": "Spell Pierce"
-        },
-        {
-          "count": 2,
-          "name": "Languish"
-        },
-        {
-          "count": 2,
-          "name": "Graveyard Trespasser"
-        },
-        {
-          "count": 1,
-          "name": "Path of Peril"
-        },
-        {
-          "count": 1,
-          "name": "Gix's Command"
+          "name": "Faerie Miscreant"
         },
         {
           "count": 1,
           "name": "Bitter Triumph"
         },
         {
-          "count": 3,
+          "count": 4,
+          "name": "Kaito, Bane of Nightmares"
+        },
+        {
+          "count": 4,
+          "name": "Deep-Cavern Bat"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 1,
+          "name": "Bitter Triumph"
+        },
+        {
+          "count": 1,
+          "name": "Path of Peril"
+        },
+        {
+          "count": 2,
+          "name": "Languish"
+        },
+        {
+          "count": 4,
           "name": "Leyline of the Void"
+        },
+        {
+          "count": 2,
+          "name": "Disdainful Stroke"
+        },
+        {
+          "count": 1,
+          "name": "Sheoldred, the Apocalypse"
+        },
+        {
+          "count": 2,
+          "name": "Duress"
+        },
+        {
+          "count": 2,
+          "name": "Graveyard Trespasser"
         }
       ]
     },

--- a/client/public/feeds/mtggoldfish-standard.json
+++ b/client/public/feeds/mtggoldfish-standard.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "standard",
   "version": 1,
-  "updated": "2026-08-14T00:00:00Z",
+  "updated": "2026-08-15T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/standard",
   "decks": [
     {
@@ -857,68 +857,28 @@
       "name": "Dimir Midrange",
       "author": "MTGGoldfish",
       "colors": [
-        "B",
-        "U"
+        "U",
+        "B"
       ],
       "tags": [
         "metagame"
       ],
       "main": [
         {
+          "count": 5,
+          "name": "Island"
+        },
+        {
           "count": 2,
           "name": "Bitter Triumph"
         },
         {
-          "count": 3,
-          "name": "Dream Beavers"
-        },
-        {
-          "count": 2,
+          "count": 1,
           "name": "Spell Pierce"
-        },
-        {
-          "count": 3,
-          "name": "Enduring Curiosity"
-        },
-        {
-          "count": 3,
-          "name": "Floodpits Drowner"
-        },
-        {
-          "count": 4,
-          "name": "Kaito, Bane of Nightmares"
-        },
-        {
-          "count": 4,
-          "name": "Hidden Lair"
-        },
-        {
-          "count": 4,
-          "name": "Swamp"
-        },
-        {
-          "count": 2,
-          "name": "Restless Reef"
-        },
-        {
-          "count": 2,
-          "name": "Nowhere to Run"
         },
         {
           "count": 4,
           "name": "Requiting Hex"
-        },
-        {
-          "count": 2,
-          "name": "Soulstone Sanctuary"
-        },
-        {
-          "count": 2,
-          "name": "Shoot the Sheriff"
-        },
-        {
-          "count": 4,
-          "name": "Watery Grave"
         },
         {
           "count": 4,
@@ -926,57 +886,101 @@
         },
         {
           "count": 4,
-          "name": "Island"
+          "name": "Watery Grave"
+        },
+        {
+          "count": 3,
+          "name": "Swamp"
+        },
+        {
+          "count": 4,
+          "name": "Floodpits Drowner"
+        },
+        {
+          "count": 3,
+          "name": "Hidden Lair"
+        },
+        {
+          "count": 4,
+          "name": "Gloomlake Verge"
+        },
+        {
+          "count": 2,
+          "name": "Shoot the Sheriff"
+        },
+        {
+          "count": 4,
+          "name": "Dream Beavers"
+        },
+        {
+          "count": 4,
+          "name": "Enduring Curiosity"
         },
         {
           "count": 2,
           "name": "The Wondrous Wasp"
         },
         {
-          "count": 3,
-          "name": "Preacher of the Schism"
+          "count": 1,
+          "name": "Spell Snare"
         },
         {
           "count": 2,
           "name": "We Say Thee Nay!"
         },
         {
-          "count": 4,
-          "name": "Gloomlake Verge"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 2,
-          "name": "Day of Black Sun"
-        },
-        {
           "count": 2,
           "name": "Tishana's Tidebinder"
         },
         {
+          "count": 2,
+          "name": "Restless Reef"
+        },
+        {
+          "count": 4,
+          "name": "Kaito, Bane of Nightmares"
+        },
+        {
           "count": 1,
-          "name": "Negate"
+          "name": "Wan Shi Tong, Librarian"
         },
         {
           "count": 2,
-          "name": "Ghost Vacuum"
+          "name": "Soulstone Sanctuary"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 4,
+          "name": "Duress"
+        },
+        {
+          "count": 2,
+          "name": "Annul"
         },
         {
           "count": 1,
-          "name": "Vren, the Relentless"
+          "name": "Disdainful Stroke"
         },
         {
           "count": 2,
           "name": "Strategic Betrayal"
         },
         {
-          "count": 2,
-          "name": "Disdainful Stroke"
+          "count": 1,
+          "name": "Wan Shi Tong, Librarian"
         },
         {
-          "count": 3,
-          "name": "Duress"
+          "count": 1,
+          "name": "The Ooze"
+        },
+        {
+          "count": 2,
+          "name": "Raven Eagle"
+        },
+        {
+          "count": 2,
+          "name": "Flashfreeze"
         }
       ]
     },
@@ -993,48 +997,48 @@
       ],
       "main": [
         {
-          "count": 2,
-          "name": "Inti, Seneschal of the Sun"
-        },
-        {
-          "count": 1,
-          "name": "Tersa Lightshatter"
-        },
-        {
-          "count": 2,
-          "name": "Carnage, Crimson Chaos"
-        },
-        {
-          "count": 2,
-          "name": "Casey Jones, Vigilante"
+          "count": 4,
+          "name": "Blood Crypt"
         },
         {
           "count": 3,
-          "name": "Concealed Courtyard"
-        },
-        {
-          "count": 4,
-          "name": "Cool but Rude"
-        },
-        {
-          "count": 2,
-          "name": "Erode"
-        },
-        {
-          "count": 1,
-          "name": "Swamp"
-        },
-        {
-          "count": 4,
-          "name": "Hardened Academic"
-        },
-        {
-          "count": 2,
           "name": "Inspiring Vantage"
         },
         {
           "count": 4,
+          "name": "Godless Shrine"
+        },
+        {
+          "count": 2,
+          "name": "Concealed Courtyard"
+        },
+        {
+          "count": 1,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "Blazemire Verge"
+        },
+        {
+          "count": 3,
           "name": "Sacred Foundry"
+        },
+        {
+          "count": 4,
+          "name": "Starting Town"
+        },
+        {
+          "count": 4,
+          "name": "Bloodghast"
+        },
+        {
+          "count": 1,
+          "name": "Cecil, Dark Knight"
+        },
+        {
+          "count": 4,
+          "name": "Hardened Academic"
         },
         {
           "count": 4,
@@ -1045,74 +1049,168 @@
           "name": "Marauding Mako"
         },
         {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 3,
-          "name": "Practiced Offense"
-        },
-        {
-          "count": 2,
-          "name": "Requiting Hex"
-        },
-        {
           "count": 4,
           "name": "Moonshadow"
         },
         {
-          "count": 4,
-          "name": "Starting Town"
-        },
-        {
-          "count": 3,
-          "name": "Godless Shrine"
+          "count": 2,
+          "name": "Tersa Lightshatter"
         },
         {
           "count": 4,
-          "name": "Bloodghast"
+          "name": "Cool but Rude"
+        },
+        {
+          "count": 2,
+          "name": "Erode"
         },
         {
           "count": 4,
-          "name": "Blood Crypt"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 2,
-          "name": "Avatar's Wrath"
+          "name": "Practiced Offense"
         },
         {
           "count": 1,
-          "name": "Deathmark"
+          "name": "Carnage, Crimson Chaos"
         },
         {
           "count": 2,
-          "name": "Monument to Endurance"
-        },
-        {
-          "count": 2,
-          "name": "Abrade"
-        },
-        {
-          "count": 1,
-          "name": "Pyroclasm"
-        },
-        {
-          "count": 1,
           "name": "Requiting Hex"
         },
         {
           "count": 1,
-          "name": "Shoot the Sheriff"
+          "name": "Inti, Seneschal of the Sun"
+        },
+        {
+          "count": 1,
+          "name": "Swamp"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 1,
+          "name": "Ral Zarek, Guest Lecturer"
         },
         {
           "count": 3,
           "name": "Strategic Betrayal"
         },
         {
+          "count": 3,
+          "name": "Sheltered by Ghosts"
+        },
+        {
+          "count": 1,
+          "name": "Dawn's Truce"
+        },
+        {
           "count": 2,
           "name": "Voice of Victory"
+        },
+        {
+          "count": 2,
+          "name": "Requiting Hex"
+        },
+        {
+          "count": 1,
+          "name": "Deathmark"
+        },
+        {
+          "count": 1,
+          "name": "Molten Collapse"
+        },
+        {
+          "count": 1,
+          "name": "Inti, Seneschal of the Sun"
+        }
+      ]
+    },
+    {
+      "name": "Mono-Green Landfall",
+      "author": "MTGGoldfish",
+      "colors": [
+        "G"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 4,
+          "name": "Ba Sing Se"
+        },
+        {
+          "count": 4,
+          "name": "Esper Origins"
+        },
+        {
+          "count": 4,
+          "name": "Escape Tunnel"
+        },
+        {
+          "count": 4,
+          "name": "Fabled Passage"
+        },
+        {
+          "count": 4,
+          "name": "Icetill Explorer"
+        },
+        {
+          "count": 2,
+          "name": "Mole Man, Moloid Master"
+        },
+        {
+          "count": 4,
+          "name": "Sazh's Chocobo"
+        },
+        {
+          "count": 14,
+          "name": "Forest"
+        },
+        {
+          "count": 4,
+          "name": "Mightform Harmonizer"
+        },
+        {
+          "count": 2,
+          "name": "Sapling Nursery"
+        },
+        {
+          "count": 4,
+          "name": "Earthbender Ascension"
+        },
+        {
+          "count": 2,
+          "name": "Bristly Bill, Spine Sower"
+        },
+        {
+          "count": 4,
+          "name": "Llanowar Elves"
+        },
+        {
+          "count": 4,
+          "name": "Meltstrider's Resolve"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 2,
+          "name": "Surrak, Elusive Hunter"
+        },
+        {
+          "count": 4,
+          "name": "Soul-Guide Lantern"
+        },
+        {
+          "count": 4,
+          "name": "Mossborn Hydra"
+        },
+        {
+          "count": 1,
+          "name": "Sapling Nursery"
+        },
+        {
+          "count": 4,
+          "name": "Heritage Reclamation"
         }
       ]
     },
@@ -1211,96 +1309,6 @@
         {
           "count": 1,
           "name": "Sunspine Lynx"
-        }
-      ]
-    },
-    {
-      "name": "Mono-Green Landfall",
-      "author": "MTGGoldfish",
-      "colors": [
-        "G"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 4,
-          "name": "Ba Sing Se"
-        },
-        {
-          "count": 4,
-          "name": "Esper Origins"
-        },
-        {
-          "count": 4,
-          "name": "Escape Tunnel"
-        },
-        {
-          "count": 4,
-          "name": "Fabled Passage"
-        },
-        {
-          "count": 4,
-          "name": "Icetill Explorer"
-        },
-        {
-          "count": 2,
-          "name": "Mole Man, Moloid Master"
-        },
-        {
-          "count": 4,
-          "name": "Sazh's Chocobo"
-        },
-        {
-          "count": 14,
-          "name": "Forest"
-        },
-        {
-          "count": 4,
-          "name": "Mightform Harmonizer"
-        },
-        {
-          "count": 2,
-          "name": "Sapling Nursery"
-        },
-        {
-          "count": 4,
-          "name": "Earthbender Ascension"
-        },
-        {
-          "count": 2,
-          "name": "Bristly Bill, Spine Sower"
-        },
-        {
-          "count": 4,
-          "name": "Llanowar Elves"
-        },
-        {
-          "count": 4,
-          "name": "Meltstrider's Resolve"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 2,
-          "name": "Surrak, Elusive Hunter"
-        },
-        {
-          "count": 4,
-          "name": "Soul-Guide Lantern"
-        },
-        {
-          "count": 4,
-          "name": "Mossborn Hydra"
-        },
-        {
-          "count": 1,
-          "name": "Sapling Nursery"
-        },
-        {
-          "count": 4,
-          "name": "Heritage Reclamation"
         }
       ]
     }


### PR DESCRIPTION
Automated daily metagame feed refresh from MTGGoldfish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Data Updates**
  * Refreshed Modern, Pioneer, and Standard deck feeds with data dated August 15, 2026.
  * Updated deck rankings and card lists across all three formats.
  * Revised mainboards and sideboards for multiple decks, including Goryo’s Vengeance, Azorius Control, Dimir Midrange, and Mardu Discard.
  * Added or updated Mono-Green Landfall and Mono-Red Aggro entries in Standard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->