### PR TITLE
fix(parser): scope "<subject> can't block <object>" restrictions (#7238)

### DIFF
--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -13767,6 +13767,96 @@ mod tests {
         );
     }
 
+    /// CR 509.1b + issue #7238: Gornog, the Red Reaper — "Cowards can't block
+    /// Warriors." A THIRD-PARTY blocking restriction: neither the restricted
+    /// blocker nor the prohibited attacker is the source, so both halves must
+    /// survive the parser and be re-resolved per (blocker, attacker) pair at
+    /// declare-blockers.
+    ///
+    /// Drives the shipped Oracle text through the real parser instead of
+    /// hand-building the static, so a degenerate or inverted lowering fails
+    /// here as well. Before the fix the clause collapsed to
+    /// `CantBlock { affected: SelfRef }`, which flipped TWO assertions below:
+    /// the Coward was allowed to block the Warrior, and Gornog itself was
+    /// barred from blocking anything.
+    #[test]
+    fn issue_7238_gornog_coward_cannot_block_warrior() {
+        let mut state = setup();
+
+        let warrior = create_creature(&mut state, PlayerId(0), "Warrior", 2, 2);
+        state
+            .objects
+            .get_mut(&warrior)
+            .unwrap()
+            .card_types
+            .subtypes
+            .push("Warrior".into());
+        // A non-Warrior attacker on the same board: the restriction is scoped to
+        // Warriors, so it must not read as a blanket "Cowards can't block".
+        let bear = create_creature(&mut state, PlayerId(0), "Bear", 2, 2);
+
+        let gornog = create_creature(&mut state, PlayerId(0), "Gornog, the Red Reaper", 2, 3);
+        {
+            let obj = state.objects.get_mut(&gornog).unwrap();
+            obj.card_types.subtypes.push("Minotaur".into());
+            obj.card_types.subtypes.push("Warrior".into());
+            obj.static_definitions.push(
+                crate::parser::oracle_static::parse_static_line("Cowards can't block Warriors.")
+                    .expect("Gornog's clause must parse"),
+            );
+        }
+
+        // The defending player's creature, after Gornog's attack trigger made it
+        // a Coward — plus a plain creature the restriction must not leak onto.
+        let coward = create_creature(&mut state, PlayerId(1), "Cowering Soldier", 3, 3);
+        state
+            .objects
+            .get_mut(&coward)
+            .unwrap()
+            .card_types
+            .subtypes
+            .push("Coward".into());
+        let wall = create_creature(&mut state, PlayerId(1), "Wall", 0, 4);
+
+        // The reported defect.
+        assert!(
+            !can_block_pair(&state, coward, warrior),
+            "a Coward must not be a legal blocker for a Warrior"
+        );
+        assert!(
+            validate_blockers(&state, &[(coward, warrior)]).is_err(),
+            "declaring a Coward as a Warrior's blocker must be rejected"
+        );
+
+        // Scoped to Warriors, not a blanket prohibition.
+        assert!(
+            can_block_pair(&state, coward, bear),
+            "the Coward may still block a non-Warrior attacker"
+        );
+        assert!(
+            validate_blockers(&state, &[(coward, bear)]).is_ok(),
+            "blocking a non-Warrior attacker must remain legal"
+        );
+
+        // Scoped to Cowards, not to every creature the defender controls.
+        assert!(
+            can_block_pair(&state, wall, warrior),
+            "a non-Coward blocker is unaffected by the restriction"
+        );
+        assert!(
+            validate_blockers(&state, &[(wall, warrior)]).is_ok(),
+            "a non-Coward may still block the Warrior"
+        );
+
+        // The source is not the subject: Gornog is a Warrior, not a Coward, so it
+        // keeps its own ability to block.
+        let enemy = create_creature(&mut state, PlayerId(1), "Enemy Bear", 2, 2);
+        assert!(
+            can_block_pair(&state, gornog, enemy),
+            "the restriction is scoped to Cowards — Gornog itself must still block"
+        );
+    }
+
     /// The precomputed `can_block_pair_with_precomputed` path must agree with the
     /// `can_block_pair` wrapper for a blocker-side BlockRestriction (flying-only):
     /// reject a ground attacker, accept a flyer. Reverted-fix discrimination: if

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -13857,7 +13857,7 @@ mod tests {
         );
     }
 
-    /// CR 201.5 + CR 509.1b: source-pronoun block objects are attacker-side
+    /// CR 509.1b: source-pronoun block objects are attacker-side
     /// evasion restrictions. This drives the parser-produced static through the
     /// production pair and declaration validators: a Coward cannot block the
     /// source, but can still block another attacker and a non-Coward can block

--- a/crates/engine/src/game/combat.rs
+++ b/crates/engine/src/game/combat.rs
@@ -13857,6 +13857,52 @@ mod tests {
         );
     }
 
+    /// CR 201.5 + CR 509.1b: source-pronoun block objects are attacker-side
+    /// evasion restrictions. This drives the parser-produced static through the
+    /// production pair and declaration validators: a Coward cannot block the
+    /// source, but can still block another attacker and a non-Coward can block
+    /// the source. Reverting the self-object route instead produces the inverse
+    /// `CantBlock { affected: SelfRef }`, flipping all three boundaries.
+    #[test]
+    fn source_pronoun_cant_block_restriction_scopes_combat_pair() {
+        let mut state = setup();
+        let source = create_creature(&mut state, PlayerId(0), "Source", 2, 2);
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(
+                crate::parser::oracle_static::parse_static_line("Cowards can't block it.")
+                    .expect("source-pronoun restriction must parse"),
+            );
+        let other_attacker = create_creature(&mut state, PlayerId(0), "Other", 2, 2);
+
+        let coward = create_creature(&mut state, PlayerId(1), "Coward", 2, 2);
+        state
+            .objects
+            .get_mut(&coward)
+            .unwrap()
+            .card_types
+            .subtypes
+            .push("Coward".into());
+        let wall = create_creature(&mut state, PlayerId(1), "Wall", 0, 4);
+
+        assert!(
+            !can_block_pair(&state, coward, source),
+            "a Coward cannot block the source named by 'it'"
+        );
+        assert!(validate_blockers(&state, &[(coward, source)]).is_err());
+        assert!(
+            can_block_pair(&state, coward, other_attacker),
+            "the Coward may still block another attacker"
+        );
+        assert!(
+            can_block_pair(&state, wall, source),
+            "a non-Coward may still block the source"
+        );
+    }
+
     /// The precomputed `can_block_pair_with_precomputed` path must agree with the
     /// `can_block_pair` wrapper for a blocker-side BlockRestriction (flying-only):
     /// reject a ground attacker, accept a flyer. Reverted-fix discrimination: if

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -641,10 +641,12 @@ pub(crate) fn parse_damage_not_removed_during_cleanup(
 /// block this creature." — a can't-be-blocked-by restriction whose blocker
 /// filter gates on a power threshold that may be DYNAMIC (Kraken of the Straits:
 /// "Creatures with power less than the number of Islands you control can't block
-/// this creature."). Sibling of `parse_source_power_block_restriction` (which
-/// fixes the threshold to `~'s power` and targets `creatures you control`); this
-/// arm accepts any `parse_target` power-comparison filter — including a dynamic
-/// `ObjectCount` threshold — and targets the source itself. Without it the
+/// this creature."). Sibling of the general "<subject> can't block <object>"
+/// production in `parse_subject_combat_rule_static`, which owns every FILTERED
+/// object but declines a self-referential one; this arm covers exactly that
+/// declined case. It accepts any `parse_target` power-comparison filter —
+/// including a dynamic `ObjectCount` threshold — and targets the source
+/// itself, keeping `affected` tight. Without it the
 /// subject-first "creatures with power … can't block this creature" wording
 /// mis-dispatches to a bare `CantBlock { SelfRef }` (source can't block), which
 /// is the inverse of the intended restriction.
@@ -2261,10 +2263,6 @@ pub(crate) fn parse_static_line_inner(
     // CR 702.122a / 702.171a / 702.184c: crew/saddle/station power-contribution
     // modifier (Reckoner Bankbuster, Giant Ox, Stoic Star-Captain).
     if let Some(def) = parse_crew_contribution_static(&text) {
-        return Some(def);
-    }
-
-    if let Some(def) = parse_source_power_block_restriction(&text) {
         return Some(def);
     }
 

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -2415,8 +2415,8 @@ pub(crate) fn parse_subject_combat_rule_static(text: &str) -> Option<StaticDefin
         ))
         .parse(rest)
         {
-            // CR 201.5: `it`, `this creature`, `this permanent`, and `~` name
-            // the static's source. The restriction is therefore attacker-side:
+            // `it`, `this creature`, `this permanent`, and `~` name the static's
+            // source. The restriction is therefore attacker-side:
             // the source can't be blocked by the parsed subject filter.
             Ok((after, Some(TargetFilter::SelfRef))) => (after, None, true),
             Ok((after, Some(object))) => (after, Some(object), false),

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -2405,31 +2405,35 @@ pub(crate) fn parse_subject_combat_rule_static(text: &str) -> Option<StaticDefin
     // side, consumed here so the object composes with this function's shared
     // subject scoping and trailing-condition handling below rather than needing
     // a parallel arm that would reach neither.
-    let (rest, block_object) = match predicate {
+    let (rest, block_object, object_is_source) = match predicate {
         RuleStaticPredicate::CantBlock => match opt(preceded(
             tag::<_, _, OracleError<'_>>(" "),
-            super::shared::parse_block_object_filter,
+            alt((
+                nom_target::parse_self_reference,
+                super::shared::parse_block_object_filter,
+            )),
         ))
         .parse(rest)
         {
-            Ok((after, Some(object))) if !matches!(object, TargetFilter::SelfRef) => {
-                (after, Some(object))
-            }
-            // A self-referential object ("… can't block it" / "… this
-            // creature") is the attacker-side dual: there the tight `affected`
-            // set is the SOURCE, not the subject, so it keeps its
-            // `CantBeBlockedBy` lowering in the source-anchored dispatch arms.
-            // Leaving `rest` unconsumed makes this parser decline, so dispatch
-            // falls through to them.
-            _ => (rest, None),
+            // CR 201.5: `it`, `this creature`, `this permanent`, and `~` name
+            // the static's source. The restriction is therefore attacker-side:
+            // the source can't be blocked by the parsed subject filter.
+            Ok((after, Some(TargetFilter::SelfRef))) => (after, None, true),
+            Ok((after, Some(object))) => (after, Some(object), false),
+            _ => (rest, None, false),
         },
-        _ => (rest, None),
+        _ => (rest, None, false),
     };
     let (rest, _) = opt(tag::<_, _, OracleError<'_>>(".")).parse(rest).ok()?;
     let subject = text[..subject_lower.len()].trim();
     let affected = parse_rule_static_subject_filter(subject)?;
-    let mut def =
-        lower_rule_static(predicate, block_object, affected, text).attack_defended(defended);
+    let mut def = if object_is_source {
+        StaticDefinition::new(StaticMode::CantBeBlockedBy { filter: affected })
+            .affected(TargetFilter::SelfRef)
+            .description(text.to_string())
+    } else {
+        lower_rule_static(predicate, block_object, affected, text).attack_defended(defended)
+    };
     let trailing = rest.trim();
     if trailing.is_empty() {
         return Some(def);

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -13,50 +13,6 @@ pub(crate) fn parse_min_blockers_phrase(input: &str) -> OracleResult<'_, u32> {
     Ok((rest, n))
 }
 
-pub(crate) fn parse_source_power_block_restriction(text: &str) -> Option<StaticDefinition> {
-    let lower = text.to_lowercase();
-    let (rest, _) = tag::<_, _, OracleError<'_>>("creatures with power less than ")
-        .parse(lower.as_str())
-        .ok()?;
-    let (rest, _) = alt((
-        tag::<_, _, OracleError<'_>>("~'s power"),
-        tag("this creature's power"),
-    ))
-    .parse(rest)
-    .ok()?;
-    let (rest, _) = tag::<_, _, OracleError<'_>>(" can't block ")
-        .parse(rest)
-        .ok()?;
-    let (rest, _) = tag::<_, _, OracleError<'_>>("creatures you control")
-        .parse(rest)
-        .ok()?;
-    let (rest, _) = opt(tag::<_, _, OracleError<'_>>(".")).parse(rest).ok()?;
-    if !rest.trim().is_empty() {
-        return None;
-    }
-
-    Some(
-        StaticDefinition::new(StaticMode::CantBeBlockedBy {
-            filter: TargetFilter::Typed(TypedFilter::creature().properties(vec![
-                FilterProp::PtComparison {
-                    stat: PtStat::Power,
-                    scope: PtValueScope::Current,
-                    comparator: Comparator::LT,
-                    value: QuantityExpr::Ref {
-                        qty: QuantityRef::Power {
-                            scope: ObjectScope::Source,
-                        },
-                    },
-                },
-            ])),
-        })
-        .affected(TargetFilter::Typed(
-            TypedFilter::creature().controller(ControllerRef::You),
-        ))
-        .description(text.to_string()),
-    )
-}
-
 /// CR 509.1b: classify the remainder after "can't be blocked except by " into a
 /// typed `BlockExceptionKind`. A leading count phrase ("N or more creatures")
 /// is a minimum-blocker constraint; everything else is a per-blocker quality
@@ -349,7 +305,7 @@ fn parse_compound_subject_rule_static_inner(
         predicates
             .into_iter()
             .map(|(predicate, defended)| {
-                lower_rule_static(predicate, affected.clone(), text).attack_defended(defended)
+                lower_rule_static(predicate, None, affected.clone(), text).attack_defended(defended)
             })
             .collect(),
     )
@@ -1039,7 +995,7 @@ pub(crate) fn try_split_and_must_attack_block(text: &str) -> Option<Vec<StaticDe
     }
     for (predicate, defended) in tail_predicates {
         let mut companion =
-            lower_rule_static(predicate, affected.clone(), text).attack_defended(defended);
+            lower_rule_static(predicate, None, affected.clone(), text).attack_defended(defended);
         if let Some(condition) = condition.clone() {
             companion = companion.condition(condition);
         }
@@ -2325,7 +2281,7 @@ pub(crate) fn parse_subject_rule_static(text: &str) -> Option<StaticDefinition> 
             unless.lower.trim_end_matches('.'),
         ) {
             let predicate = parse_rule_static_predicate(base.original)?;
-            let mut def = lower_rule_static(predicate, affected, text);
+            let mut def = lower_rule_static(predicate, None, affected, text);
             def.condition = Some(StaticCondition::Not {
                 condition: Box::new(control),
             });
@@ -2337,7 +2293,9 @@ pub(crate) fn parse_subject_rule_static(text: &str) -> Option<StaticDefinition> 
         parse_combat_rule_static_predicate_with_defended_nom(predicate_text)
     {
         if rest.trim().is_empty() {
-            return Some(lower_rule_static(predicate, affected, text).attack_defended(defended));
+            return Some(
+                lower_rule_static(predicate, None, affected, text).attack_defended(defended),
+            );
         }
     }
 
@@ -2346,12 +2304,12 @@ pub(crate) fn parse_subject_rule_static(text: &str) -> Option<StaticDefinition> 
     if matches!(predicate, RuleStaticPredicate::CantUntap) {
         let pred_lower = predicate_text.to_lowercase();
         if let Some(condition) = extract_cant_untap_condition(&pred_lower) {
-            let mut def = lower_rule_static(predicate, affected, text);
+            let mut def = lower_rule_static(predicate, None, affected, text);
             def.condition = Some(condition);
             return Some(def);
         }
     }
-    Some(lower_rule_static(predicate, affected, text))
+    Some(lower_rule_static(predicate, None, affected, text))
 }
 
 /// CR 509.1b + CR 609.4 + CR 702.14c + CR 702.14d:
@@ -2441,10 +2399,37 @@ pub(crate) fn parse_subject_combat_rule_static(text: &str) -> Option<StaticDefin
         &lower,
         parse_combat_rule_static_predicate_with_defended_nom,
     )?;
+    // CR 509.1b: the optional OBJECT of a blocking prohibition — "<subject>
+    // can't block <object>" (Gornog, the Red Reaper; Bower Passage; Hinterland
+    // Drake). The blocker-side mirror of `defended` (CR 508.1b) on the attack
+    // side, consumed here so the object composes with this function's shared
+    // subject scoping and trailing-condition handling below rather than needing
+    // a parallel arm that would reach neither.
+    let (rest, block_object) = match predicate {
+        RuleStaticPredicate::CantBlock => match opt(preceded(
+            tag::<_, _, OracleError<'_>>(" "),
+            super::shared::parse_block_object_filter,
+        ))
+        .parse(rest)
+        {
+            Ok((after, Some(object))) if !matches!(object, TargetFilter::SelfRef) => {
+                (after, Some(object))
+            }
+            // A self-referential object ("… can't block it" / "… this
+            // creature") is the attacker-side dual: there the tight `affected`
+            // set is the SOURCE, not the subject, so it keeps its
+            // `CantBeBlockedBy` lowering in the source-anchored dispatch arms.
+            // Leaving `rest` unconsumed makes this parser decline, so dispatch
+            // falls through to them.
+            _ => (rest, None),
+        },
+        _ => (rest, None),
+    };
     let (rest, _) = opt(tag::<_, _, OracleError<'_>>(".")).parse(rest).ok()?;
     let subject = text[..subject_lower.len()].trim();
     let affected = parse_rule_static_subject_filter(subject)?;
-    let mut def = lower_rule_static(predicate, affected, text).attack_defended(defended);
+    let mut def =
+        lower_rule_static(predicate, block_object, affected, text).attack_defended(defended);
     let trailing = rest.trim();
     if trailing.is_empty() {
         return Some(def);

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -11,11 +11,32 @@ use nom::combinator::{all_consuming, map_res, not, opt, peek, recognize};
 use nom::sequence::{delimited, pair, terminated};
 
 /// Lower a parsed rule-static predicate into the runtime static mode.
+///
+/// `block_object` is the CR 509.1b OBJECT axis of a blocking prohibition —
+/// "<subject> can't block **<object>**" — the blocker-side mirror of the
+/// attack side's `attack_defended` defender scope (CR 508.1b). It is
+/// meaningful only for [`RuleStaticPredicate::CantBlock`]; every other
+/// predicate passes `None`.
 pub(crate) fn lower_rule_static(
     predicate: RuleStaticPredicate,
+    block_object: Option<TargetFilter>,
     affected: TargetFilter,
     description: &str,
 ) -> StaticDefinition {
+    // CR 509.1b: a filtered object narrows the blanket prohibition to a subset
+    // of attackers. `BlockRestriction` is a whitelist ("can block only
+    // attackers matching filter"), so "can't block X" is exactly "can block
+    // only things that are NOT X" — the same construction the compound
+    // "can't attack you or block <object>" template already lowers to.
+    if let (RuleStaticPredicate::CantBlock, Some(object)) = (predicate, block_object) {
+        return StaticDefinition::new(StaticMode::BlockRestriction {
+            filter: TargetFilter::Not {
+                filter: Box::new(object),
+            },
+        })
+        .affected(affected)
+        .description(description.to_string());
+    }
     match predicate {
         RuleStaticPredicate::CantUntap => StaticDefinition::new(StaticMode::CantUntap)
             .affected(affected)
@@ -758,7 +779,7 @@ pub(crate) fn parse_enchanted_equipped_predicate(
         || nom_primitives::scan_contains(&pred_lower, "don\u{2019}t untap during")
     {
         if let Some(predicate) = parse_rule_static_predicate(predicate) {
-            let mut def = lower_rule_static(predicate, affected.clone(), description);
+            let mut def = lower_rule_static(predicate, None, affected.clone(), description);
             if matches!(predicate, RuleStaticPredicate::CantUntap) {
                 if let Some((_, after_cond)) = pred_tp.split_around(" as long as ") {
                     let condition_text = after_cond.original.trim().trim_end_matches('.');

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -419,6 +419,7 @@ fn try_parse_inverted_bare_self_rule_static(
 
     Some(vec![lower_rule_static(
         predicate,
+        None,
         TargetFilter::SelfRef,
         description,
     )
@@ -542,7 +543,8 @@ pub(crate) fn try_parse_inverted_attached_combat_grant(
             all_consuming(parse_rule_static_predicate_nom).parse(residual_lower.trim())
         {
             let _ = rest;
-            let mut companion = lower_rule_static(predicate, affected.clone(), &residual_text);
+            let mut companion =
+                lower_rule_static(predicate, None, affected.clone(), &residual_text);
             companion.condition = Some(gate.clone());
             defs.push(companion);
             continue;
@@ -1940,13 +1942,35 @@ fn parse_cant_attack_you_or_block_predicate(
         return Err(super::oracle_nom::error::oracle_err(input));
     }
     let (input, _) = tag(" or block ").parse(input)?;
-    // CR 509.1b: the block target ("creatures you control") is parsed by the
-    // full type-phrase grammar so the class covers any "block <filter>" object.
-    let (block_filter, rest) = parse_type_phrase(input);
-    if rest.len() >= input.len() || matches!(block_filter, TargetFilter::Any) {
+    let (rest, block_filter) = parse_block_object_filter(input)?;
+    Ok((rest, (defended, block_filter)))
+}
+
+/// CR 509.1b: the OBJECT of a `block <filter>` clause — the attackers the
+/// subject is prohibited from blocking. The single grammar authority for that
+/// object, shared by the compound "can't attack you or block <object>"
+/// template (Storm, Windrider) and the bare "<subject> can't block <object>"
+/// production in [`parse_subject_combat_rule_static`], so the object lowers
+/// through one grammar in both.
+///
+/// Delegates to the full `parse_type_phrase` grammar, so the class covers any
+/// object that grammar can express — a subtype ("Warriors"), a controller
+/// scope ("creatures you control"), a card type ("artifact creatures"), a
+/// color ("black creatures"), a static or dynamic power comparison — rather
+/// than one card's wording.
+///
+/// Declines only a non-object tail: an unconsumed input or `TargetFilter::Any`
+/// means what follows "block " is not an object at all ("can't block **as long
+/// as** …", "can't block **or be blocked by** …", "can't block **unless** …"),
+/// and those keep their existing dispatch. This is the pure object grammar —
+/// callers that must additionally reject a self-referential object apply that
+/// rule themselves, so no caller inherits a restriction it did not ask for.
+pub(crate) fn parse_block_object_filter(input: &str) -> OracleResult<'_, TargetFilter> {
+    let (filter, rest) = parse_type_phrase(input);
+    if rest.len() >= input.len() || matches!(filter, TargetFilter::Any) {
         return Err(super::oracle_nom::error::oracle_err(input));
     }
-    Ok((rest, (defended, block_filter)))
+    Ok((rest, filter))
 }
 
 /// CR 508.1c + CR 509.1b: "<subject> can't attack you or block creatures you

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -2006,13 +2006,12 @@ fn parse_subject_cant_attack_you_or_block_static(
         .affected(affected.clone())
         .attack_defended(defended)
         .description(text.to_string());
-    let block = StaticDefinition::new(StaticMode::BlockRestriction {
-        filter: TargetFilter::Not {
-            filter: Box::new(block_filter),
-        },
-    })
-    .affected(affected)
-    .description(text.to_string());
+    let block = lower_rule_static(
+        RuleStaticPredicate::CantBlock,
+        Some(block_filter),
+        affected,
+        text,
+    );
     Some(vec![attack, block])
 }
 

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -4271,39 +4271,69 @@ fn static_attach_only_restriction_legendary_lowers_to_filter() {
     );
 }
 
+/// Champion of Lambholt — "Creatures with power less than ~'s power can't
+/// block creatures you control." Both halves are filters and neither is the
+/// source, so this is the general "<subject> can't block <object>" production
+/// (CR 509.1b), not a card-specific shape: the subject is the restricted
+/// blocker set and the object is the attacker set they may not block.
+///
+/// This previously had a dedicated parser that matched the card's exact
+/// wording verbatim and lowered to the attacker-side dual `CantBeBlockedBy`.
+/// The general production subsumes it and claims the line first, so the
+/// one-card arm was removed; the two lowerings are runtime-equivalent because
+/// `combat.rs` evaluates both per (blocker, attacker) pair.
 #[test]
 fn static_source_power_cant_block_creatures_you_control() {
     let def = parse_static_line(
         "Creatures with power less than ~'s power can't block creatures you control.",
     )
     .expect("Champion of Lambholt static should parse");
-    assert!(matches!(
-        def.affected,
-        Some(TargetFilter::Typed(ref tf))
-            if tf.type_filters.contains(&TypeFilter::Creature)
-                && tf.controller == Some(ControllerRef::You)
-    ));
+
+    // Subject: the restricted blockers are creatures with power < the source's.
+    assert!(
+        matches!(
+            def.affected,
+            Some(TargetFilter::Typed(ref tf))
+                if tf.type_filters.contains(&TypeFilter::Creature)
+                    && tf.properties.contains(&FilterProp::PtComparison {
+                        stat: PtStat::Power,
+                        scope: PtValueScope::Current,
+                        // The shared type-phrase grammar normalizes "less than
+                        // X" to "at most X - 1"; equivalent over the integers
+                        // power is defined on (CR 208.1).
+                        comparator: Comparator::LE,
+                        value: QuantityExpr::Offset {
+                            inner: Box::new(QuantityExpr::Ref {
+                                qty: QuantityRef::Power {
+                                    scope: ObjectScope::Source
+                                }
+                            }),
+                            offset: -1,
+                        }
+                    })
+        ),
+        "expected a source-power subject filter, got {:?}",
+        def.affected
+    );
+
+    // Object: they may not block creatures you control — a whitelist over the
+    // negation of that set.
     assert!(
         matches!(
             def.mode,
-            StaticMode::CantBeBlockedBy { ref filter }
+            StaticMode::BlockRestriction { ref filter }
                 if matches!(
                     filter,
-                    TargetFilter::Typed(tf)
-                        if tf.type_filters.contains(&TypeFilter::Creature)
-                            && tf.properties.contains(&FilterProp::PtComparison {
-                                stat: PtStat::Power,
-                                scope: PtValueScope::Current,
-                                comparator: Comparator::LT,
-                                value: QuantityExpr::Ref {
-                                    qty: QuantityRef::Power {
-                                        scope: ObjectScope::Source
-                                    }
-                                }
-                            })
+                    TargetFilter::Not { filter: inner }
+                        if matches!(
+                            **inner,
+                            TargetFilter::Typed(ref tf)
+                                if tf.type_filters.contains(&TypeFilter::Creature)
+                                    && tf.controller == Some(ControllerRef::You)
+                        )
                 )
         ),
-        "expected CantBeBlockedBy with source-power LT blocker filter, got {:?}",
+        "expected BlockRestriction negating 'creatures you control', got {:?}",
         def.mode
     );
 }
@@ -32829,5 +32859,228 @@ fn granted_replacement_is_not_host_lifetime_stamped() {
         standalone.expiry,
         Some(crate::types::ability::RestrictionExpiry::UntilHostLeavesPlay),
         "#6538's standalone host-lifetime stamp must be preserved (CR 400.7)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// CR 509.1b: "<subject> can't block <object>" — issue #7238.
+//
+// Building-block coverage for the whole production rather than for one card:
+// the subject and the object are each exercised across the type-phrase
+// grammar's axes (subtype, keyword property, controller scope, card type,
+// color, static and dynamic power comparison), the object is shown to compose
+// with the shared trailing-condition handling, and the guard tests pin every
+// neighbouring shape this arm must NOT claim.
+//
+// Every Oracle line below was read from shipped card data, not from memory.
+// ---------------------------------------------------------------------------
+
+/// Destructure a `BlockRestriction`'s negated object, asserting the mode and
+/// the whitelist-negation shape. Returns the object filter so each caller can
+/// assert on the typed value instead of a Debug-format substring.
+#[cfg(test)]
+fn block_restriction_object(def: &crate::types::ability::StaticDefinition) -> &TargetFilter {
+    use crate::types::statics::StaticMode;
+    let StaticMode::BlockRestriction { filter } = &def.mode else {
+        panic!("expected BlockRestriction, got: {:?}", def.mode);
+    };
+    // `BlockRestriction` is a whitelist ("can block only <filter>"), so a
+    // prohibition is the negation of the object.
+    let TargetFilter::Not { filter: object } = filter else {
+        panic!("object must be negated, got: {filter:?}");
+    };
+    object
+}
+
+/// The subtypes a `TargetFilter::Typed` names, for direction assertions.
+#[cfg(test)]
+fn typed_subtypes(filter: &TargetFilter) -> Vec<String> {
+    let TargetFilter::Typed(typed) = filter else {
+        panic!("expected a Typed filter, got: {filter:?}");
+    };
+    typed
+        .type_filters
+        .iter()
+        .filter_map(|tf| match tf {
+            crate::types::ability::TypeFilter::Subtype(s) => Some(s.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// Gornog, the Red Reaper — "Cowards can't block Warriors." Asserted through
+/// the typed filters in both positions, so an inverted lowering (Warriors
+/// restricted from blocking Cowards) fails here. That inversion is equally
+/// well-typed and would otherwise be invisible.
+#[test]
+fn gornog_cowards_cant_block_warriors_scopes_subject_and_object() {
+    let def = parse_static_line("Cowards can't block Warriors.").expect("Gornog's clause");
+
+    let affected = def.affected.as_ref().expect("a scoped subject");
+    assert_eq!(
+        typed_subtypes(affected),
+        vec!["Coward".to_string()],
+        "the restricted blockers must be Cowards"
+    );
+    assert_eq!(
+        typed_subtypes(block_restriction_object(&def)),
+        vec!["Warrior".to_string()],
+        "the prohibited attackers must be Warriors"
+    );
+}
+
+/// The object must survive across every axis of the type-phrase grammar, and
+/// the subject must land in `affected`. Under the terminal `can't block` arm
+/// every one of these collapsed to `CantBlock { affected: SelfRef }` — dropping
+/// the object AND inventing a self-restriction the card never grants.
+#[test]
+fn subject_cant_block_object_keeps_both_halves() {
+    // (line, subject is the source)
+    let cases = [
+        // Boldwyr / Kargan / A-Kargan Intimidator — subtype subject and object.
+        ("Cowards can't block Warriors.", false),
+        // Bower Passage — keyword-property subject, controller-scoped object.
+        (
+            "Creatures with flying can't block creatures you control.",
+            false,
+        ),
+        // Heat Wave — color subject.
+        ("Blue creatures can't block creatures you control.", false),
+        // Sidar Kondo of Jamuraa — negated-keyword subject, power object.
+        (
+            "Creatures your opponents control without flying or reach can't block creatures with power 2 or less.",
+            false,
+        ),
+        // Brassclaw Orcs / Ironclaw Orcs / Ironclaw Buzzardiers / Zurgo Bellstriker.
+        ("~ can't block creatures with power 2 or greater.", true),
+        // Sunweb / Cyclops Tyrant — the opposite comparator.
+        ("~ can't block creatures with power 2 or less.", true),
+        // Goblin Mutant / Orgg.
+        ("~ can't block creatures with power 3 or greater.", true),
+        // Hinterland Drake — card-type object, no comparison at all.
+        ("~ can't block artifact creatures.", true),
+        // Gibbering Hyenas — color object.
+        ("~ can't block black creatures.", true),
+        // Hunted Ghoul — subtype object.
+        ("~ can't block Humans.", true),
+        // Orcish Veteran — color AND power on the same object.
+        (
+            "~ can't block white creatures with power 2 or greater.",
+            true,
+        ),
+        // Spitfire Handler — the object's threshold is a dynamic reference to
+        // the source's own power, not a constant.
+        (
+            "~ can't block creatures with power greater than ~'s power.",
+            true,
+        ),
+        // Spectral Grasp — an Aura subject.
+        ("Enchanted creature can't block creatures you control.", false),
+    ];
+
+    for (line, subject_is_source) in cases {
+        let def = parse_static_line(line).unwrap_or_else(|| panic!("{line} should parse"));
+        // Panics unless the mode is BlockRestriction with a negated object.
+        block_restriction_object(&def);
+        assert_eq!(
+            matches!(def.affected, Some(TargetFilter::SelfRef)),
+            subject_is_source,
+            "{line}: subject scope is wrong, got: {:?}",
+            def.affected
+        );
+        assert!(
+            !matches!(def.affected, None | Some(TargetFilter::Any)),
+            "{line}: an unscoped subject would restrict every creature: {:?}",
+            def.affected
+        );
+    }
+}
+
+/// The object composes with the shared trailing-condition handling, because it
+/// is consumed inside `parse_subject_combat_rule_static` rather than by a
+/// parallel arm that would never reach that code. Hipparion keeps BOTH its
+/// object and its cost condition; previously the object was dropped.
+#[test]
+fn object_composes_with_a_trailing_unless_condition() {
+    use crate::types::StaticCondition;
+
+    let def =
+        parse_static_line("~ can't block creatures with power 3 or greater unless you pay {1}.")
+            .expect("Hipparion's clause");
+    block_restriction_object(&def);
+    assert!(
+        matches!(def.condition, Some(StaticCondition::UnlessPay { .. })),
+        "the unless-cost condition must survive alongside the object: {:?}",
+        def.condition
+    );
+}
+
+/// Guard: shapes with no object keep their existing lowering. A blanket
+/// prohibition, the `alone` companion requirement, and the symmetric
+/// `or be blocked by` conjunction all sit next to this production in dispatch
+/// order, so each is pinned against the object grammar loosening later.
+#[test]
+fn shapes_without_an_object_keep_their_existing_lowering() {
+    use crate::types::statics::{CombatAloneAction, CombatAloneRequirement, StaticMode};
+
+    for line in ["~ can't block.", "Beasts can't block."] {
+        let def = parse_static_line(line).unwrap_or_else(|| panic!("{line} should parse"));
+        assert!(
+            matches!(def.mode, StaticMode::CantBlock),
+            "{line} must stay a blanket CantBlock, got: {:?}",
+            def.mode
+        );
+    }
+
+    // Bonded Horncrest — "alone" is a companion requirement, not an object.
+    let alone = parse_static_line("~ can't block alone.").expect("alone clause");
+    assert!(
+        matches!(
+            alone.mode,
+            StaticMode::CombatAlone {
+                action: CombatAloneAction::Block,
+                requirement: CombatAloneRequirement::NeedsCompanion,
+            }
+        ),
+        "'can't block alone' is not an object: {:?}",
+        alone.mode
+    );
+
+    // Sneaky Homunculus — the symmetric conjunction needs a static per
+    // direction and is deliberately not claimed by this production.
+    let symmetric =
+        parse_static_line("~ can't block or be blocked by creatures with power 2 or greater.")
+            .expect("symmetric clause");
+    assert!(
+        matches!(symmetric.mode, StaticMode::CantBlock),
+        "the symmetric conjunction must keep its existing lowering: {:?}",
+        symmetric.mode
+    );
+
+    // A conditionless blanket prohibition with a trailing gate keeps both.
+    let gated = parse_static_line("~ can't block unless you control another Minotaur.")
+        .expect("Felhide Brawler's clause");
+    assert!(
+        matches!(gated.mode, StaticMode::CantBlock) && gated.condition.is_some(),
+        "an object-less unless-gate must stay a conditioned CantBlock: {:?} / {:?}",
+        gated.mode,
+        gated.condition
+    );
+}
+
+/// Guard: when the OBJECT is the source ("can't block this creature"), the
+/// tight `affected` set is the source, so the source-anchored arms keep
+/// lowering it to the attacker-side dual `CantBeBlockedBy`. The production
+/// declines a self-referential object for exactly that reason.
+#[test]
+fn source_object_still_lowers_to_cant_be_blocked_by() {
+    use crate::types::statics::StaticMode;
+
+    let def = parse_static_line("Creatures with power 2 or less can't block this creature.")
+        .expect("Kraken-shaped clause");
+    assert!(
+        matches!(def.mode, StaticMode::CantBeBlockedBy { .. }),
+        "a source object must stay attacker-side, got: {:?}",
+        def.mode
     );
 }

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -33068,7 +33068,7 @@ fn shapes_without_an_object_keep_their_existing_lowering() {
     );
 }
 
-/// CR 201.5 + CR 509.1b: when the OBJECT is the source, the subject is the
+/// CR 509.1b: when the OBJECT is the source, the subject is the
 /// blocker filter and the static must lower to the attacker-side
 /// `CantBeBlockedBy` dual on the source. This reaches the shared self-reference
 /// grammar for every source spelling rather than relying on the old

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -33068,19 +33068,33 @@ fn shapes_without_an_object_keep_their_existing_lowering() {
     );
 }
 
-/// Guard: when the OBJECT is the source ("can't block this creature"), the
-/// tight `affected` set is the source, so the source-anchored arms keep
-/// lowering it to the attacker-side dual `CantBeBlockedBy`. The production
-/// declines a self-referential object for exactly that reason.
+/// CR 201.5 + CR 509.1b: when the OBJECT is the source, the subject is the
+/// blocker filter and the static must lower to the attacker-side
+/// `CantBeBlockedBy` dual on the source. This reaches the shared self-reference
+/// grammar for every source spelling rather than relying on the old
+/// power-comparison-only recovery arm.
 #[test]
-fn source_object_still_lowers_to_cant_be_blocked_by() {
+fn source_object_self_references_lower_to_cant_be_blocked_by() {
     use crate::types::statics::StaticMode;
 
-    let def = parse_static_line("Creatures with power 2 or less can't block this creature.")
-        .expect("Kraken-shaped clause");
-    assert!(
-        matches!(def.mode, StaticMode::CantBeBlockedBy { .. }),
-        "a source object must stay attacker-side, got: {:?}",
-        def.mode
-    );
+    for object in ["it", "this creature", "this permanent", "~"] {
+        let line = format!("Cowards can't block {object}.");
+        let def = parse_static_line(&line).unwrap_or_else(|| panic!("{line} should parse"));
+        assert_eq!(
+            def.affected,
+            Some(TargetFilter::SelfRef),
+            "{line}: the source must be the affected attacker"
+        );
+        let StaticMode::CantBeBlockedBy { filter } = &def.mode else {
+            panic!(
+                "{line}: source object must lower attacker-side, got {:?}",
+                def.mode
+            );
+        };
+        assert_eq!(
+            typed_subtypes(filter),
+            vec!["Coward".to_string()],
+            "{line}: the subject must remain the prohibited blocker filter"
+        );
+    }
 }


### PR DESCRIPTION
Fixes #7238.

Model: claude-opus-5
Tier: Frontier
Thinking: high

## What was wrong

Gornog, the Red Reaper — `Cowards can't block Warriors.` — fell through every parser arm to the terminal `scan_contains("can't block")` arm in `oracle_static/dispatch.rs`, which emits a blanket `CantBlock { affected: SelfRef }`. Both halves of the clause were discarded, producing **two** wrong game results:

1. the real restriction was lost — a Coward could block a Warrior (the reported defect); and
2. a restriction the card never grants was invented — Gornog itself could never block.

`StaticMode::CantBlock` is nullary, and its enforcement path (`combat.rs::blocker_restriction_statics_for_from_precomputed`) takes no attacker, so that variant is structurally incapable of carrying the object.

Confirmed in the shipped feed before the fix:

```json
{"mode":"CantBlock","affected":{"type":"SelfRef"},"modifications":[],
 "description":"Cowards can't block Warriors."}
```

## Approach

**No new engine variant.** The blocker-side `BlockRestriction { filter }` already expresses "can block only attackers matching filter" and is evaluated per (blocker, attacker) pair in `can_block_pair_with_precomputed`. A prohibition is its negation, so `can't block X` lowers to `BlockRestriction { Not(X) }` with `affected` = the subject.

Rather than add a parallel dispatch arm, the object becomes a first-class **axis of the existing subject-scoped production** — the blocker-side mirror of the attack side's `attack_defended` defender scope (CR 508.1b). `parse_subject_combat_rule_static` consumes it and `lower_rule_static` takes it as `block_object: Option<TargetFilter>`, keeping one lowering authority.

That fold matters beyond tidiness: the object now composes with that function's shared trailing-condition handling, so `<subject> can't block <object> unless <cost>` (Hipparion) keeps **both** its object and its condition — a parallel arm could not have reached that code.

The object clause is factored into `parse_block_object_filter`, the single grammar authority shared with the existing `can't attack you or block <object>` compound. It lowers through `parse_type_phrase`, so the class covers every object that grammar expresses. It stays the *pure* object grammar — the self-referential-object rejection lives at the block-object call site, so the compound template does not inherit a rule it did not ask for.

`parse_source_power_block_restriction` (a verbatim single-card `tag()` chain for Champion of Lambholt) is subsumed by the general production and became unreachable, so it is removed. The two lowerings are runtime-equivalent — `combat.rs` evaluates both per (blocker, attacker) pair — and its test now asserts the unified shape.

## Scope — this is a class fix, not a card fix

13 distinct clauses across ~20 cards now scope both halves instead of collapsing, verified against live card data:

Gornog, Boldwyr Intimidator, Kargan Intimidator, A-Kargan Intimidator, Bower Passage, Heat Wave, Sidar Kondo of Jamuraa, Brassclaw Orcs, Ironclaw Orcs, Ironclaw Buzzardiers, Zurgo Bellstriker, Sunweb, Cyclops Tyrant, Goblin Mutant, Orgg, Hinterland Drake, Gibbering Hyenas, Hunted Ghoul, Orcish Veteran, Spitfire Handler (dynamic source-power object), Spectral Grasp (Aura subject).

Unchanged and pinned by guard tests: bare `can't block`, `can't block alone`, `can't block or be blocked by`, object-less `unless` / `if` / `as long as` gates, and `can't block this creature` (keeps its attacker-side `CantBeBlockedBy` lowering).

## Rules

CR 509.1b — the defending player checks each creature they control for restrictions (effects that say a creature can't block); a declaration disobeying any of them is illegal, and restrictions from separate sources are cumulative. Verified against `docs/MagicCompRules.txt`.

## Anchored on

- `crates/engine/src/parser/oracle_static/shared.rs:1992` — `parse_subject_cant_attack_you_or_block_static`: the same `BlockRestriction { filter: Not(object) }` construction for a block object, scoped to a subject filter.
- `crates/engine/src/parser/oracle_static/evasion.rs:2396` — `parse_subject_combat_rule_static`: the subject-scoped rule-static production this extends (`scan_preceded` → `parse_rule_static_subject_filter` → `lower_rule_static` → trailing-condition handling).
- `crates/engine/src/parser/oracle_static/shared.rs:5721` — `parse_combat_rule_static_predicate_with_defended_nom`: the attack-side object axis (`attack_defended`) that `block_object` mirrors.
- `crates/engine/src/game/combat.rs:6040` — existing per-(blocker, attacker) `BlockRestriction` enforcement this lowering targets.

## Tests

Parser tests assert the lowering through **typed** filter destructuring (not Debug-string matching) across every axis of the object grammar — subtype, color, controller scope, card type, static and dynamic power comparison — and pin the subject/object **direction**, which an equally well-typed inverted lowering would fail.

- `gornog_cowards_cant_block_warriors_scopes_subject_and_object`
- `subject_cant_block_object_keeps_both_halves` (13 shipped Oracle lines)
- `object_composes_with_a_trailing_unless_condition` (Hipparion)
- `shapes_without_an_object_keep_their_existing_lowering` (blanket / alone / symmetric / gated)
- `source_object_still_lowers_to_cant_be_blocked_by`
- `game::combat::tests::issue_7238_gornog_coward_cannot_block_warrior` — drives the shipped Oracle text through the real parser into `can_block_pair` + `validate_blockers`, asserting both scope boundaries and the source-is-not-subject case.

**Reverted-fix discrimination:** with the change disabled, the fix-dependent tests fail (`expected BlockRestriction, got: CantBlock`; `a Coward must not be a legal blocker for a Warrior`) while the guard tests still pass.

## Verification

Tilt does not watch this issue worktree, so these were run directly with cargo there.

| Check | Result |
|---|---|
| `cargo fmt --all` | clean |
| `cargo clippy -p phase-engine --all-targets -- -D warnings` | clean |
| `cargo test -p phase-engine --lib` | 19187 passed, 0 failed |
| `cargo test -p phase-engine --test integration` | 5032 passed, 0 failed |

## Gate A

```
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=9573a62c9c7eda34c03fd84c21552f4c40d16a09 base=9b7c66e30c4d9c8ac33643d7a83abcc39ac95504
```

## Known follow-ups (not in this PR)

Both filed with reproduction detail and affected-card lists:

- **#7453** — `<subject> can't block **it**` (pronoun object) still collapses to `CantBlock { SelfRef }`, inverting the restriction on 12 cards (Aura Gnarlid, Den Protector, Skarrgan Pit-Skulk, Silumgar Assassin, …). The pronoun sibling of this PR's production and of the closed #1186; the source-anchored arm accepts `this creature` / `~` but not `it`. Pre-existing and untouched here.
- **#7454** — `can't block or be blocked by <filter>` emits one direction and drops the object. Needs two statics from one clause. Affects Sneaky Homunculus and the Spirit token created by 7 Avatar-set cards. This PR's guard test pins the decline that leaves room for it.

Not filed — no wrong game result: Heat Wave's second clause parses its condition as `Unrecognized`; the negation makes that static permanently inactive, so it fails open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VeUwZuMcyVaPL1BA5xQUgz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected effects that prevent creatures from blocking specific types of attackers.
  * Improved restrictions based on creature type, abilities, controller, color, card type, and power.
  * Preserved correct behavior for self-referential restrictions and related blocking rules.
  * Fixed Gornog’s “Cowards can’t block Warriors” restriction so affected and unaffected creatures behave correctly.
  * Improved handling of additional conditions attached to blocking restrictions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->