### PR TITLE
Fix Sensei's Divining Top

### DIFF
--- a/crates/engine/src/game/effects/put_on_top.rs
+++ b/crates/engine/src/game/effects/put_on_top.rs
@@ -81,11 +81,13 @@ pub fn resolve(
     } else {
         ability.source_is_current(state)
     };
-    if ability.targets.is_empty()
-        && matches!(
-            target_filter,
-            TargetFilter::SelfRef | TargetFilter::None | TargetFilter::ParentTarget
-        )
+    let resolves_to_source = matches!(target_filter, TargetFilter::SelfRef)
+        || (ability.targets.is_empty()
+            && matches!(
+                target_filter,
+                TargetFilter::None | TargetFilter::ParentTarget
+            ));
+    if resolves_to_source
         && effective_targets == [crate::types::ability::TargetRef::Object(ability.source_id)]
         && !source_is_current
     {
@@ -875,6 +877,53 @@ mod tests {
         assert!(
             !state.players[0].library.contains(&obj_id),
             "the stale None fallback must not put the later object in the library"
+        );
+    }
+
+    /// CR 400.7: `SelfRef` always names the source even when an enclosing
+    /// chain propagated another target into this ability. A stale source must
+    /// therefore not move the later incarnation through that path either.
+    #[test]
+    fn test_put_on_top_stale_self_ref_ignores_propagated_targets() {
+        let mut state = GameState::new_two_player(42);
+        let obj_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        let propagated_target = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Propagated target".to_string(),
+            Zone::Battlefield,
+        );
+        let mut ability = ResolvedAbility::new(
+            Effect::PutAtLibraryPosition {
+                target: TargetFilter::SelfRef,
+                count: QuantityExpr::Fixed { value: 1 },
+                position: LibraryPosition::Top,
+            },
+            vec![TargetRef::Object(propagated_target)],
+            obj_id,
+            PlayerId(0),
+        );
+        ability.source_incarnation = Some(state.objects[&obj_id].incarnation);
+
+        let mut move_events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, obj_id, Zone::Graveyard, &mut move_events);
+        crate::game::zones::move_to_zone(&mut state, obj_id, Zone::Battlefield, &mut move_events);
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.objects[&obj_id].zone, Zone::Battlefield);
+        assert_eq!(state.objects[&propagated_target].zone, Zone::Battlefield);
+        assert!(
+            !state.players[0].library.contains(&obj_id),
+            "the stale SelfRef must not put the later object in the library"
         );
     }
 

--- a/crates/engine/src/game/effects/put_on_top.rs
+++ b/crates/engine/src/game/effects/put_on_top.rs
@@ -59,6 +59,23 @@ pub fn resolve(
         && ability.targets.is_empty()
         && ability.parent_target_missing_reason == Some(ParentTargetMissingReason::Dig);
 
+    // CR 400.7 + CR 113.7a: An activated ability's SelfRef must not follow a
+    // later object that reuses the source ID. Triggered abilities retain the
+    // trigger-aware SelfRef exceptions for their own departure successors.
+    let stale_self_ref = if ability.trigger_source.is_some() {
+        !ability.self_ref_is_current(state)
+    } else {
+        !ability.source_is_current(state)
+    };
+    if matches!(target_filter, TargetFilter::SelfRef) && stale_self_ref {
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::PutAtLibraryPosition,
+            source_id: ability.source_id,
+            subject: None,
+        });
+        return Ok(());
+    }
+
     // CR 608.2c + 603.10a: Delegate to the unified 3-tier dispatch
     // (`resolved_targets`). `SelfRef` always resolves to the source object;
     // `None` / `ParentTarget` fall back to the source only when

--- a/crates/engine/src/game/effects/put_on_top.rs
+++ b/crates/engine/src/game/effects/put_on_top.rs
@@ -70,7 +70,7 @@ pub fn resolve(
         crate::game::targeting::resolved_targets(ability, &target_filter, state)
     };
 
-    // CR 400.7 + CR 113.7a: A source-resolving empty SelfRef/ParentTarget must
+    // CR 400.7 + CR 113.7a: A source-resolving empty SelfRef/None/ParentTarget must
     // not follow a later object that reuses the source ID. This stays after
     // `resolved_targets`: an empty ParentTarget can instead resolve a real
     // event-context referent, which must not be mistaken for the source
@@ -84,7 +84,7 @@ pub fn resolve(
     if ability.targets.is_empty()
         && matches!(
             target_filter,
-            TargetFilter::SelfRef | TargetFilter::ParentTarget
+            TargetFilter::SelfRef | TargetFilter::None | TargetFilter::ParentTarget
         )
         && effective_targets == [crate::types::ability::TargetRef::Object(ability.source_id)]
         && !source_is_current
@@ -838,6 +838,44 @@ mod tests {
 
         assert!(!state.players[1].graveyard.contains(&obj_id));
         assert_eq!(state.players[1].library[0], obj_id);
+    }
+
+    /// CR 400.7: `None` uses the same empty-target source fallback as
+    /// `ParentTarget`; a stale activation cannot move a later incarnation.
+    #[test]
+    fn test_put_on_top_none_fallback_does_not_follow_new_source_incarnation() {
+        let mut state = GameState::new_two_player(42);
+        let obj_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        let mut ability = ResolvedAbility::new(
+            Effect::PutAtLibraryPosition {
+                target: TargetFilter::None,
+                count: QuantityExpr::Fixed { value: 1 },
+                position: LibraryPosition::Top,
+            },
+            vec![],
+            obj_id,
+            PlayerId(0),
+        );
+        ability.source_incarnation = Some(state.objects[&obj_id].incarnation);
+
+        let mut move_events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, obj_id, Zone::Graveyard, &mut move_events);
+        crate::game::zones::move_to_zone(&mut state, obj_id, Zone::Battlefield, &mut move_events);
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(state.objects[&obj_id].zone, Zone::Battlefield);
+        assert!(
+            !state.players[0].library.contains(&obj_id),
+            "the stale None fallback must not put the later object in the library"
+        );
     }
 
     /// End-to-end Avenging Angel-class pipeline test.

--- a/crates/engine/src/game/effects/put_on_top.rs
+++ b/crates/engine/src/game/effects/put_on_top.rs
@@ -59,23 +59,6 @@ pub fn resolve(
         && ability.targets.is_empty()
         && ability.parent_target_missing_reason == Some(ParentTargetMissingReason::Dig);
 
-    // CR 400.7 + CR 113.7a: An activated ability's SelfRef must not follow a
-    // later object that reuses the source ID. Triggered abilities retain the
-    // trigger-aware SelfRef exceptions for their own departure successors.
-    let stale_self_ref = if ability.trigger_source.is_some() {
-        !ability.self_ref_is_current(state)
-    } else {
-        !ability.source_is_current(state)
-    };
-    if matches!(target_filter, TargetFilter::SelfRef) && stale_self_ref {
-        events.push(GameEvent::EffectResolved {
-            kind: EffectKind::PutAtLibraryPosition,
-            source_id: ability.source_id,
-            subject: None,
-        });
-        return Ok(());
-    }
-
     // CR 608.2c + 603.10a: Delegate to the unified 3-tier dispatch
     // (`resolved_targets`). `SelfRef` always resolves to the source object;
     // `None` / `ParentTarget` fall back to the source only when
@@ -86,6 +69,33 @@ pub fn resolve(
     } else {
         crate::game::targeting::resolved_targets(ability, &target_filter, state)
     };
+
+    // CR 400.7 + CR 113.7a: A source-resolving empty SelfRef/ParentTarget must
+    // not follow a later object that reuses the source ID. This stays after
+    // `resolved_targets`: an empty ParentTarget can instead resolve a real
+    // event-context referent, which must not be mistaken for the source
+    // fallback. Triggered abilities retain the trigger-aware immediate-
+    // departure successor exceptions through `self_ref_is_current`.
+    let source_is_current = if ability.trigger_source.is_some() {
+        ability.self_ref_is_current(state)
+    } else {
+        ability.source_is_current(state)
+    };
+    if ability.targets.is_empty()
+        && matches!(
+            target_filter,
+            TargetFilter::SelfRef | TargetFilter::ParentTarget
+        )
+        && effective_targets == [crate::types::ability::TargetRef::Object(ability.source_id)]
+        && !source_is_current
+    {
+        events.push(GameEvent::EffectResolved {
+            kind: EffectKind::PutAtLibraryPosition,
+            source_id: ability.source_id,
+            subject: None,
+        });
+        return Ok(());
+    }
     // CR 608.2c: `effect_object_targets` forwards `ability.targets` verbatim
     // for non-slot filters. A dig hand-keep binds `ParentTarget` on the exile
     // tail but must not pre-fill a `TrackedSet` bottom pick with the kept card.
@@ -881,6 +891,74 @@ mod tests {
             "Avenging Angel should be on top of its owner's library"
         );
         assert!(!state.players[0].graveyard.contains(&angel_id));
+    }
+
+    /// CR 400.7: An LTB `ParentTarget` fallback names the object that died,
+    /// not a later object with the same storage ID. Drive the trigger through
+    /// the real zone-change, trigger, stack, and resolver pipeline, then move
+    /// the card back before the trigger resolves to prove the new object stays
+    /// on the battlefield.
+    #[test]
+    fn test_put_on_top_ltb_reentry_does_not_follow_new_object() {
+        use crate::game::stack::resolve_top;
+        use crate::game::triggers::process_triggers;
+        use crate::types::ability::{AbilityDefinition, AbilityKind, TriggerDefinition};
+        use crate::types::triggers::TriggerMode;
+
+        let mut state = GameState::new_two_player(42);
+        let angel_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Avenging Angel".to_string(),
+            Zone::Battlefield,
+        );
+
+        let mut trigger = TriggerDefinition::new(TriggerMode::ChangesZone);
+        trigger.origin = Some(Zone::Battlefield);
+        trigger.destination = Some(Zone::Graveyard);
+        trigger.valid_card = Some(TargetFilter::SelfRef);
+        trigger.trigger_zones = vec![Zone::Graveyard];
+        trigger.execute = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::PutAtLibraryPosition {
+                target: TargetFilter::ParentTarget,
+                count: QuantityExpr::Fixed { value: 1 },
+                position: LibraryPosition::Top,
+            },
+        )));
+        state
+            .objects
+            .get_mut(&angel_id)
+            .unwrap()
+            .trigger_definitions
+            .push(trigger);
+
+        let mut death_events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, angel_id, Zone::Graveyard, &mut death_events);
+        let died_incarnation = state.objects[&angel_id].incarnation;
+        process_triggers(&mut state, &death_events);
+        assert_eq!(state.stack.len(), 1, "LTB trigger did not reach the stack");
+
+        let mut reentry_events = Vec::new();
+        crate::game::zones::move_to_zone(
+            &mut state,
+            angel_id,
+            Zone::Battlefield,
+            &mut reentry_events,
+        );
+        assert_ne!(
+            state.objects[&angel_id].incarnation, died_incarnation,
+            "re-entering must create a new object incarnation"
+        );
+
+        let mut resolve_events = Vec::new();
+        resolve_top(&mut state, &mut resolve_events);
+        assert_eq!(state.objects[&angel_id].zone, Zone::Battlefield);
+        assert!(
+            !state.players[0].library.contains(&angel_id),
+            "the stale LTB trigger must not put the new object on top of the library"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -102,22 +102,22 @@ fn push_to_stack_with_firing(
         entry.kind,
         StackEntryKind::ActivatedAbility { .. } | StackEntryKind::TriggeredAbility { .. }
     ) {
+        if let Some(ability) = entry.ability_mut() {
+            // CR 400.7 + CR 113.7a: Capture the source incarnation for every
+            // activated or triggered ability, including non-transforming
+            // permanents. The transformation guard below has a narrower scope.
+            if ability.source_incarnation.is_none() {
+                ability
+                    .set_source_incarnation_recursive(source_ref.map(|source| source.incarnation));
+            }
+        }
+
         let source = state
             .objects
             .get(&entry.source_id)
             .filter(|object| object.back_face.is_some());
         let count = source.map(|object| object.transformation_count);
         if let Some(ability) = entry.ability_mut() {
-            // CR 608.2h + CR 113.7a: Every activated/triggered ability needs
-            // its source incarnation, not only a transforming source. Effects
-            // such as "~'s controller loses life" use it to read the source's
-            // current controller while it remains in its expected zone and its
-            // LKI controller after it leaves, without rebinding a re-entered
-            // object that reuses this storage id.
-            if ability.source_incarnation.is_none() {
-                ability
-                    .set_source_incarnation_recursive(source_ref.map(|source| source.incarnation));
-            }
             // CR 701.27f: delayed triggered abilities already carry their
             // creation-time generation and must not be restamped when fired.
             if ability.context.source_transformation_count.is_none() {

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1028,6 +1028,7 @@ mod tinybones_joins_up_multi_target;
 mod tobita_master_of_winds_flying_grant;
 mod tom_bombadil_lore_counter_gate;
 mod tombstone_stairwell_per_player_tokens;
+mod top_manifold_key_incarnation;
 mod top_of_library_mixed_permission;
 mod total_war_attacking_player_scope;
 mod tracked_set_anaphor_quantity_binds;

--- a/crates/engine/tests/integration/top_manifold_key_incarnation.rs
+++ b/crates/engine/tests/integration/top_manifold_key_incarnation.rs
@@ -13,7 +13,7 @@ use engine::types::zones::Zone;
 fn top_ability_does_not_follow_new_object_after_key_untaps_it() {
     fn contains_self_ref_library_placement(ability: &ResolvedAbility) -> bool {
         matches!(
-            ability.effect.as_ref(),
+            &ability.effect,
             Effect::PutAtLibraryPosition {
                 target: TargetFilter::SelfRef,
                 ..
@@ -29,7 +29,7 @@ fn top_ability_does_not_follow_new_object_after_key_untaps_it() {
     }
 
     fn contains_unimplemented(ability: &ResolvedAbility) -> bool {
-        matches!(ability.effect.as_ref(), Effect::Unimplemented { .. })
+        matches!(&ability.effect, Effect::Unimplemented { .. })
             || ability
                 .sub_ability
                 .as_deref()

--- a/crates/engine/tests/integration/top_manifold_key_incarnation.rs
+++ b/crates/engine/tests/integration/top_manifold_key_incarnation.rs
@@ -2,7 +2,7 @@
 //! activated abilities that remain on the stack across a zone change.
 
 use engine::game::scenario::{GameScenario, P0};
-use engine::types::ability::TargetRef;
+use engine::types::ability::{Effect, ResolvedAbility, TargetFilter, TargetRef};
 use engine::types::actions::GameAction;
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaType, ManaUnit};
@@ -11,6 +11,35 @@ use engine::types::zones::Zone;
 
 #[test]
 fn top_ability_does_not_follow_new_object_after_key_untaps_it() {
+    fn contains_self_ref_library_placement(ability: &ResolvedAbility) -> bool {
+        matches!(
+            ability.effect.as_ref(),
+            Effect::PutAtLibraryPosition {
+                target: TargetFilter::SelfRef,
+                ..
+            }
+        ) || ability
+            .sub_ability
+            .as_deref()
+            .is_some_and(contains_self_ref_library_placement)
+            || ability
+                .else_ability
+                .as_deref()
+                .is_some_and(contains_self_ref_library_placement)
+    }
+
+    fn contains_unimplemented(ability: &ResolvedAbility) -> bool {
+        matches!(ability.effect.as_ref(), Effect::Unimplemented { .. })
+            || ability
+                .sub_ability
+                .as_deref()
+                .is_some_and(contains_unimplemented)
+            || ability
+                .else_ability
+                .as_deref()
+                .is_some_and(contains_unimplemented)
+    }
+
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     scenario.with_library_top(
@@ -141,6 +170,17 @@ fn top_ability_does_not_follow_new_object_after_key_untaps_it() {
             .and_then(|ability| ability.source_incarnation),
         Some(first_incarnation),
         "the older Top ability must retain its original source incarnation"
+    );
+    let older_ability = runner.state().stack[0]
+        .ability()
+        .expect("the older Top activation must carry its resolved ability");
+    assert!(
+        contains_self_ref_library_placement(older_ability),
+        "the older Top activation must retain its parsed SelfRef library placement"
+    );
+    assert!(
+        !contains_unimplemented(older_ability),
+        "the older Top activation must not reach the stale-source guard through an unimplemented parse"
     );
     // CR 400.7 + CR 113.7a: The older ability draws Top as a new object. Its
     // stale SelfRef placement is a legal no-op, so the stack still settles.

--- a/crates/engine/tests/integration/top_manifold_key_incarnation.rs
+++ b/crates/engine/tests/integration/top_manifold_key_incarnation.rs
@@ -1,0 +1,159 @@
+//! CR 113.7a + CR 400.7 + CR 608.2c regression coverage for source-referential
+//! activated abilities that remain on the stack across a zone change.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+#[test]
+fn top_ability_does_not_follow_new_object_after_key_untaps_it() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(
+        P0,
+        &["Prepared Card A", "Prepared Card B", "Prepared Card C"],
+    );
+    scenario.with_mana_pool(
+        P0,
+        vec![ManaUnit::new(
+            ManaType::Colorless,
+            ObjectId(9_999),
+            false,
+            vec![],
+        )],
+    );
+
+    let top = scenario
+        .add_enchantment_from_oracle(
+            P0,
+            "Sensei's Divining Top",
+            "{1}: Look at the top three cards of your library, then put them back in any order.\n{T}: Draw a card, then put this artifact on top of its owner's library.",
+        )
+        .as_artifact()
+        .id();
+    let key = scenario
+        .add_enchantment_from_oracle(
+            P0,
+            "Manifold Key",
+            "{1}, {T}: Untap another target artifact.\n{3}, {T}: Target creature can't be blocked this turn.",
+        )
+        .as_artifact()
+        .id();
+
+    let mut runner = scenario.build();
+    let initial_hand_size = runner.state().players[0].hand.len();
+    let next_library_card = runner.state().players[0].library[1];
+
+    // CR 602.2b: Put the first Top activation on the stack and capture its
+    // source incarnation before the intervening Key activation resolves.
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: top,
+            ability_index: 1,
+        })
+        .expect("Top's first draw activation must be accepted");
+    let first_incarnation = runner.state().objects[&top].incarnation;
+    let first_ability_incarnation = runner.state().stack[0]
+        .ability()
+        .and_then(|ability| ability.source_incarnation);
+    assert_eq!(
+        first_ability_incarnation,
+        Some(first_incarnation),
+        "ordinary artifacts must capture their source incarnation on the stack"
+    );
+
+    // CR 602.2b: Activate Key in response, choose Top, pay {1}, and resolve
+    // only Key. The first Top activation remains underneath it.
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: key,
+            ability_index: 0,
+        })
+        .expect("Key's untap activation must be accepted");
+    if matches!(
+        runner.state().waiting_for,
+        engine::types::game_state::WaitingFor::TargetSelection { .. }
+    ) {
+        runner
+            .act(GameAction::ChooseTarget {
+                target: Some(TargetRef::Object(top)),
+            })
+            .expect("Key must be able to target Top");
+    }
+    assert!(
+        runner.state().stack.back().is_some_and(|entry| {
+            entry
+                .ability()
+                .is_some_and(|ability| ability.targets.contains(&TargetRef::Object(top)))
+        }),
+        "Key's stacked ability must target Top"
+    );
+    runner
+        .act(GameAction::PassPriority)
+        .expect("Key's mana payment or priority pass must be accepted");
+    assert_eq!(
+        runner.state().stack.len(),
+        2,
+        "Key must remain above Top's ability"
+    );
+    runner.resolve_top();
+    assert_eq!(
+        runner.state().stack.len(),
+        1,
+        "resolving Key must leave the first Top ability on the stack"
+    );
+    assert!(!runner.state().objects[&top].tapped, "Key must untap Top");
+
+    // CR 405.1 + CR 608.2c: Activate Top again, then resolve the newer
+    // activation first. It draws a card and puts the current Top object on top
+    // of the library, creating a new object incarnation.
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: top,
+            ability_index: 1,
+        })
+        .expect("Top's second draw activation must be accepted");
+    assert_eq!(
+        runner.state().stack.len(),
+        2,
+        "both Top abilities must be stacked"
+    );
+    runner.resolve_top();
+    assert_eq!(
+        runner.state().players[0].hand.len(),
+        initial_hand_size + 1,
+        "the newer Top ability must draw one prepared card"
+    );
+    assert_eq!(runner.state().objects[&top].zone, Zone::Library);
+    assert_eq!(runner.state().players[0].library[0], top);
+    assert_ne!(
+        runner.state().objects[&top].incarnation,
+        first_incarnation,
+        "moving Top to the library must create a new object"
+    );
+    assert_eq!(
+        runner.state().stack[0]
+            .ability()
+            .and_then(|ability| ability.source_incarnation),
+        Some(first_incarnation),
+        "the older Top ability must retain its original source incarnation"
+    );
+    // CR 400.7 + CR 113.7a: The older ability draws Top as a new object. Its
+    // stale SelfRef placement is a legal no-op, so the stack still settles.
+    runner.resolve_top();
+    assert!(
+        runner.state().stack.is_empty(),
+        "both Top abilities must resolve"
+    );
+    assert_eq!(
+        runner.state().players[0].hand.len(),
+        initial_hand_size + 2,
+        "the older Top ability must draw Top"
+    );
+    assert_eq!(runner.state().objects[&top].zone, Zone::Hand);
+    assert_eq!(runner.state().players[0].library[0], next_library_card);
+}


### PR DESCRIPTION
## Summary
Fixes stacked Sensei's Divining Top abilities when Manifold Key untaps Top between activations. Source incarnations are captured for ordinary permanents, and a stale SelfRef library-placement instruction now resolves as a legal no-op after the older ability draws the new Top object.

## Files changed
- crates/engine/src/game/stack.rs
- crates/engine/src/game/effects/put_on_top.rs
- crates/engine/tests/integration/main.rs
- crates/engine/tests/integration/top_manifold_key_incarnation.rs

## Track
Developer

## LLM
Model: GitHub Copilot (via GitHub Copilot; canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)
Method: /engine-implementer

## CR references
- CR 400.7 + CR 113.7a — source incarnation and ability independence across zone changes.
- CR 405.1 — source identity is captured at the stack boundary.
- CR 608.2c — instructions resolve in written order.
- CR 701.27f — transformation-generation guard remains separate from incarnation capture.

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — clean.
- `git diff --check` — clean.
- `cargo test -p phase-engine --test integration top_ability_does_not_follow_new_object_after_key_untaps_it` — passed.
- `cargo test -p phase-engine --test integration target_incarnation_revalidation` — 3 passed.
- `cargo test -p phase-engine --test integration delayed_parent_target_incarnation` — 8 passed.
- `cargo test -p phase-engine --quiet` — 5033 passed, 0 failed, 2 ignored; 7 additional tests ignored.
- `cargo clippy -p phase-engine --all-targets -- -D warnings` — clean.
- Local Phase UI — loaded from this branch at http://localhost:5173/; the requester manually tested the interaction before PR creation.

## Gate A
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=6ed0c4b29a34a4946c91b315abdb7f8e056674f9 base=2ae92459a95ff341681492792bf11189a20fb9d7

## Anchored on
- crates/engine/src/game/effects/change_zone.rs:621 — existing stale `SelfRef` guard emits `EffectResolved` and returns a legal no-op.
- crates/engine/src/game/effects/sacrifice.rs:185 — existing source-incarnation guard for stale self-referential effects.
- crates/engine/tests/integration/target_incarnation_revalidation.rs:23 — production-pipeline regression pattern for same-ID zone changes.

## Final review-impl
Final review-impl PASS head=6ed0c4b29a34a4946c91b315abdb7f8e056674f9

## Claimed parse impact
None.

## Scope Expansion
None.

## Validation Failures
None.

## CI Failures
None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of abilities whose source objects change zones before resolution.
  * Stale object references now resolve safely without affecting newer objects.
  * Activated and triggered abilities retain the correct source identity during resolution.
  * Fixed edge cases involving objects leaving and returning to play before an ability resolves.

* **Tests**
  * Added regression coverage for sequential activations involving Manifold Key and Sensei’s Divining Top.
  * Added coverage for leave-the-battlefield triggers with changing source objects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->