### PR TITLE
fix(parser): keep a token's literal name out of self-reference normalization

### DIFF
--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -13641,6 +13641,33 @@ fn effect_create_colored_token() {
     ));
 }
 
+/// CR 111.4: Kher Keep's activated ability sets the created token's literal
+/// name. This exercises the public `parse_oracle_text` entry point, including
+/// self-reference normalization before token-description lowering.
+#[test]
+fn kher_keep_preserves_literal_created_token_name() {
+    let parsed = parse_oracle_text(
+        "{1}{R}, {T}: Create a 0/1 red Kobold creature token named Kobolds of Kher Keep.",
+        "Kher Keep",
+        &[],
+        &["Land".to_string()],
+        &[],
+    );
+
+    assert_eq!(
+        parsed.abilities.len(),
+        1,
+        "Kher Keep must lower its activated ability: {parsed:#?}"
+    );
+    let Effect::Token { name, .. } = parsed.abilities[0].effect.as_ref() else {
+        panic!(
+            "Kher Keep must lower its activated ability to Token, got {:?}",
+            parsed.abilities[0].effect
+        );
+    };
+    assert_eq!(name, "Kobolds of Kher Keep");
+}
+
 #[test]
 fn effect_chain_create_distinct_token_sequence_preserves_second_token() {
     let def = parse_effect_chain(

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -1724,7 +1724,7 @@ fn unmask_card_name_keyword_action(text: String, originals: &[String]) -> String
 
 /// Which flavour of literal-name span a `"… named <X>"` prefix opens.
 ///
-/// CR 111.1 vs. CR 201.2: a **token**'s name is followed by the inline clauses
+/// A **token**'s name is followed by the inline clauses
 /// that define the token in place ("… with \"…\"", "… that's attacking",
 /// "… attached to …"), so its span ends at those clauses. A **card filter**'s
 /// name is not defined in place, and real card names contain exactly those
@@ -1756,8 +1756,8 @@ fn parse_card_named_literal_prefix(input: &str) -> OracleResult<'_, (usize, Name
             ("meld them into ".len(), NamedLiteralKind::CardFilter),
             tag("meld them into "),
         ),
-        // CR 111.1: the token-creation template always writes the noun "token"
-        // immediately before "named", whatever type words precede it ("create a
+        // The token-creation template writes the noun "token" immediately before
+        // "named", whatever type words precede it ("create a
         // legendary black Aura Curse enchantment token named Selenia's Curse").
         // Anchoring on that noun covers the whole class in one rule instead of
         // enumerating every type-word combination that can lead up to it.
@@ -1958,8 +1958,8 @@ fn parse_card_named_clause_boundary(input: &str) -> OracleResult<'_, ()> {
     value((), alt((tag("."), tag(":")))).parse(input)
 }
 
-/// CR 111.1: the clauses that define a freshly created token stand right behind
-/// its name and are not part of it. Terminating the token's literal span here
+/// The clauses that define a freshly created token stand right behind its name
+/// and are not part of it. Terminating the token's literal span here
 /// keeps the mask off the surrounding text, so a quoted granted body still gets
 /// its own self-reference normalization.
 ///
@@ -2031,9 +2031,10 @@ fn card_named_literal_span_len(lower: &str, kind: NamedLiteralKind) -> usize {
 /// cards like Emerald Collector's "Mox Emerald" into "Mox ~" or Kookus's
 /// "Keeper of Kookus" into "Keeper of ~".
 ///
-/// CR 111.1: token names are masked the same way — the name a card gives the
-/// token it creates is that token's literal name, never a reference back to the
-/// creating card, even when it embeds the creator's own name (Selenia, the
+/// CR 111.4: a spell or ability that creates a token sets its name. Token names
+/// are therefore masked the same way — the name a card gives the token is a
+/// literal name, never a reference back to the creating card, even when it
+/// embeds the creator's own name (Selenia, the
 /// Cursed Heart → "Selenia's Curse"; Volo, Itinerant Scholar → "Volo's
 /// Journal"). Their spans end at [`parse_token_named_literal_boundary`].
 fn mask_card_named_literal_spans(text: &str) -> (String, Vec<String>) {
@@ -2816,8 +2817,20 @@ mod tests {
     }
 
     #[test]
+    fn token_named_literal_prefix_classifies_plural_as_token() {
+        assert_eq!(
+            next_card_named_literal_prefix("create two tokens named kobolds of kher keep"),
+            Some((
+                "create two ".len(),
+                "tokens named ".len(),
+                NamedLiteralKind::Token
+            ))
+        );
+    }
+
+    #[test]
     fn normalize_token_named_literal_keeps_creator_name_inside_token_name() {
-        // CR 111.1: Selenia, the Cursed Heart names the token it creates
+        // CR 111.4: Selenia, the Cursed Heart names the token it creates
         // "Selenia's Curse". That is the token's own literal name, not a
         // self-reference — without the mask the comma-short-name strategy folds
         // it to "~'s Curse", the trailing `~` → card-name expansion turns that
@@ -2834,7 +2847,7 @@ mod tests {
 
     #[test]
     fn normalize_token_named_literal_keeps_full_card_name_inside_token_name() {
-        // CR 111.1: Kher Keep's token is literally named "Kobolds of Kher
+        // CR 111.4: Kher Keep's token is literally named "Kobolds of Kher
         // Keep" — the creator's *full* name inside the token's name. The
         // full-name strategy (a different branch than the comma-short one
         // above) must leave it alone.
@@ -2849,7 +2862,7 @@ mod tests {
 
     #[test]
     fn normalize_token_named_literal_span_ends_at_the_defining_with_clause() {
-        // CR 111.1: the span covers the name only. Ajani's "with \"…\"" clause
+        // The span covers the name only. Ajani's "with \"…\"" clause
         // stays outside it — proven by "this token" inside that clause still
         // folding to `~` (it would stay literal if the span had swallowed the
         // clause), while "Ajani's Pridemate" itself stays literal and line 3's

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -1722,7 +1722,23 @@ fn unmask_card_name_keyword_action(text: String, originals: &[String]) -> String
     result
 }
 
-fn parse_card_named_literal_prefix(input: &str) -> OracleResult<'_, usize> {
+/// Which flavour of literal-name span a `"… named <X>"` prefix opens.
+///
+/// CR 111.1 vs. CR 201.2: a **token**'s name is followed by the inline clauses
+/// that define the token in place ("… with \"…\"", "… that's attacking",
+/// "… attached to …"), so its span ends at those clauses. A **card filter**'s
+/// name is not defined in place, and real card names contain exactly those
+/// words ("Once More with Feeling", "All That Glitters") — ending its span
+/// there would truncate the name. The two therefore need different boundaries,
+/// which is why the prefix parser reports which one it matched instead of
+/// letting the caller guess from the text.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum NamedLiteralKind {
+    CardFilter,
+    Token,
+}
+
+fn parse_card_named_literal_prefix(input: &str) -> OracleResult<'_, (usize, NamedLiteralKind)> {
     alt((
         // CR 201.2a + CR 201.5c: a meld RESULT name ("meld them into Titania,
         // Gaea Incarnate") is a distinct object's literal name, not a self-ref to
@@ -1736,21 +1752,79 @@ fn parse_card_named_literal_prefix(input: &str) -> OracleResult<'_, usize> {
         // the instigator (Gisela → Brisela) are already clean; the mask is a no-op
         // for them. Improvement-only for the activated melds' result string
         // (Urza, Lord Protector) — their activated-meld runtime path is unchanged.
-        value("meld them into ".len(), tag("meld them into ")),
-        value("permanents named ".len(), tag("permanents named ")),
-        value("permanent named ".len(), tag("permanent named ")),
-        value("creatures named ".len(), tag("creatures named ")),
-        value("creature named ".len(), tag("creature named ")),
-        value("artifacts named ".len(), tag("artifacts named ")),
-        value("artifact named ".len(), tag("artifact named ")),
-        value("enchantments named ".len(), tag("enchantments named ")),
-        value("enchantment named ".len(), tag("enchantment named ")),
-        value("lands named ".len(), tag("lands named ")),
-        value("land named ".len(), tag("land named ")),
-        value("spells named ".len(), tag("spells named ")),
-        value("spell named ".len(), tag("spell named ")),
-        value("cards named ".len(), tag("cards named ")),
-        value("card named ".len(), tag("card named ")),
+        value(
+            ("meld them into ".len(), NamedLiteralKind::CardFilter),
+            tag("meld them into "),
+        ),
+        // CR 111.1: the token-creation template always writes the noun "token"
+        // immediately before "named", whatever type words precede it ("create a
+        // legendary black Aura Curse enchantment token named Selenia's Curse").
+        // Anchoring on that noun covers the whole class in one rule instead of
+        // enumerating every type-word combination that can lead up to it.
+        value(
+            ("tokens named ".len(), NamedLiteralKind::Token),
+            tag("tokens named "),
+        ),
+        value(
+            ("token named ".len(), NamedLiteralKind::Token),
+            tag("token named "),
+        ),
+        value(
+            ("permanents named ".len(), NamedLiteralKind::CardFilter),
+            tag("permanents named "),
+        ),
+        value(
+            ("permanent named ".len(), NamedLiteralKind::CardFilter),
+            tag("permanent named "),
+        ),
+        value(
+            ("creatures named ".len(), NamedLiteralKind::CardFilter),
+            tag("creatures named "),
+        ),
+        value(
+            ("creature named ".len(), NamedLiteralKind::CardFilter),
+            tag("creature named "),
+        ),
+        value(
+            ("artifacts named ".len(), NamedLiteralKind::CardFilter),
+            tag("artifacts named "),
+        ),
+        value(
+            ("artifact named ".len(), NamedLiteralKind::CardFilter),
+            tag("artifact named "),
+        ),
+        value(
+            ("enchantments named ".len(), NamedLiteralKind::CardFilter),
+            tag("enchantments named "),
+        ),
+        value(
+            ("enchantment named ".len(), NamedLiteralKind::CardFilter),
+            tag("enchantment named "),
+        ),
+        value(
+            ("lands named ".len(), NamedLiteralKind::CardFilter),
+            tag("lands named "),
+        ),
+        value(
+            ("land named ".len(), NamedLiteralKind::CardFilter),
+            tag("land named "),
+        ),
+        value(
+            ("spells named ".len(), NamedLiteralKind::CardFilter),
+            tag("spells named "),
+        ),
+        value(
+            ("spell named ".len(), NamedLiteralKind::CardFilter),
+            tag("spell named "),
+        ),
+        value(
+            ("cards named ".len(), NamedLiteralKind::CardFilter),
+            tag("cards named "),
+        ),
+        value(
+            ("card named ".len(), NamedLiteralKind::CardFilter),
+            tag("card named "),
+        ),
     ))
     .parse(input)
 }
@@ -1884,7 +1958,37 @@ fn parse_card_named_clause_boundary(input: &str) -> OracleResult<'_, ()> {
     value((), alt((tag("."), tag(":")))).parse(input)
 }
 
-fn parse_card_named_literal_boundary(input: &str) -> OracleResult<'_, ()> {
+/// CR 111.1: the clauses that define a freshly created token stand right behind
+/// its name and are not part of it. Terminating the token's literal span here
+/// keeps the mask off the surrounding text, so a quoted granted body still gets
+/// its own self-reference normalization.
+///
+/// Deliberately NOT applied to card-filter spans (see [`NamedLiteralKind`]): a
+/// bare comma is likewise excluded, because token names carry one
+/// ("Icingdeath, Frost Tongue").
+fn parse_token_named_literal_boundary(input: &str) -> OracleResult<'_, ()> {
+    let (input, _) = space1::<_, OracleError<'_>>(input)?;
+    let (input, _) = alt((
+        value((), (tag("with"), space1)),
+        value((), (tag("attached"), space1)),
+        value(
+            (),
+            (tag("that"), alt((value((), space1), value((), tag("'s "))))),
+        ),
+    ))
+    .parse(input)?;
+    Ok((input, ()))
+}
+
+fn parse_card_named_literal_boundary(input: &str, kind: NamedLiteralKind) -> OracleResult<'_, ()> {
+    match kind {
+        NamedLiteralKind::Token => {
+            if let Ok(found) = parse_token_named_literal_boundary(input) {
+                return Ok(found);
+            }
+        }
+        NamedLiteralKind::CardFilter => {}
+    }
     alt((
         parse_card_named_list_boundary,
         parse_card_named_zone_boundary,
@@ -1896,7 +2000,7 @@ fn parse_card_named_literal_boundary(input: &str) -> OracleResult<'_, ()> {
     .parse(input)
 }
 
-fn next_card_named_literal_prefix(lower: &str) -> Option<(usize, usize)> {
+fn next_card_named_literal_prefix(lower: &str) -> Option<(usize, usize, NamedLiteralKind)> {
     lower.char_indices().find_map(|(idx, _)| {
         let is_word_boundary = idx == 0
             || lower[..idx]
@@ -1906,15 +2010,15 @@ fn next_card_named_literal_prefix(lower: &str) -> Option<(usize, usize)> {
         is_word_boundary
             .then(|| parse_card_named_literal_prefix(&lower[idx..]).ok())
             .flatten()
-            .map(|(_, prefix_len)| (idx, prefix_len))
+            .map(|(_, (prefix_len, kind))| (idx, prefix_len, kind))
     })
 }
 
-fn card_named_literal_span_len(lower: &str) -> usize {
+fn card_named_literal_span_len(lower: &str, kind: NamedLiteralKind) -> usize {
     lower
         .char_indices()
         .find_map(|(idx, _)| {
-            parse_card_named_literal_boundary(&lower[idx..])
+            parse_card_named_literal_boundary(&lower[idx..], kind)
                 .is_ok()
                 .then_some(idx)
         })
@@ -1926,6 +2030,12 @@ fn card_named_literal_span_len(lower: &str) -> usize {
 /// while `normalize_card_name_refs` runs so first-word fallback cannot rewrite
 /// cards like Emerald Collector's "Mox Emerald" into "Mox ~" or Kookus's
 /// "Keeper of Kookus" into "Keeper of ~".
+///
+/// CR 111.1: token names are masked the same way — the name a card gives the
+/// token it creates is that token's literal name, never a reference back to the
+/// creating card, even when it embeds the creator's own name (Selenia, the
+/// Cursed Heart → "Selenia's Curse"; Volo, Itinerant Scholar → "Volo's
+/// Journal"). Their spans end at [`parse_token_named_literal_boundary`].
 fn mask_card_named_literal_spans(text: &str) -> (String, Vec<String>) {
     let lower = text.to_ascii_lowercase();
     let mut masked = String::with_capacity(text.len());
@@ -1933,9 +2043,9 @@ fn mask_card_named_literal_spans(text: &str) -> (String, Vec<String>) {
     let mut rest = text;
     let mut lower_rest = lower.as_str();
 
-    while let Some((idx, prefix_len)) = next_card_named_literal_prefix(lower_rest) {
+    while let Some((idx, prefix_len, kind)) = next_card_named_literal_prefix(lower_rest) {
         let name_start = idx + prefix_len;
-        let name_len = card_named_literal_span_len(&lower_rest[name_start..]);
+        let name_len = card_named_literal_span_len(&lower_rest[name_start..], kind);
         if name_len == 0 {
             masked.push_str(&rest[..name_start]);
             rest = &rest[name_start..];
@@ -2697,7 +2807,79 @@ mod tests {
         assert!(next_card_named_literal_prefix("nazgûlcard named mox emerald").is_none());
         assert_eq!(
             next_card_named_literal_prefix("nazgûl card named mox emerald"),
-            Some(("nazgûl ".len(), "card named ".len()))
+            Some((
+                "nazgûl ".len(),
+                "card named ".len(),
+                NamedLiteralKind::CardFilter
+            ))
+        );
+    }
+
+    #[test]
+    fn normalize_token_named_literal_keeps_creator_name_inside_token_name() {
+        // CR 111.1: Selenia, the Cursed Heart names the token it creates
+        // "Selenia's Curse". That is the token's own literal name, not a
+        // self-reference — without the mask the comma-short-name strategy folds
+        // it to "~'s Curse", the trailing `~` → card-name expansion turns that
+        // into "Selenia, the Cursed Heart's Curse", and the token-name clause
+        // parser then truncates at the injected comma to a bare "Selenia".
+        assert_eq!(
+            normalize_card_name_refs(
+                "When Selenia dies, create a legendary black Aura Curse enchantment token named Selenia's Curse attached to target opponent.",
+                "Selenia, the Cursed Heart",
+            ),
+            "When ~ dies, create a legendary black Aura Curse enchantment token named Selenia's Curse attached to target opponent."
+        );
+    }
+
+    #[test]
+    fn normalize_token_named_literal_keeps_full_card_name_inside_token_name() {
+        // CR 111.1: Kher Keep's token is literally named "Kobolds of Kher
+        // Keep" — the creator's *full* name inside the token's name. The
+        // full-name strategy (a different branch than the comma-short one
+        // above) must leave it alone.
+        assert_eq!(
+            normalize_card_name_refs(
+                "{1}{R}, {T}: Create a 0/1 red Kobold creature token named Kobolds of Kher Keep.",
+                "Kher Keep",
+            ),
+            "{1}{R}, {T}: Create a 0/1 red Kobold creature token named Kobolds of Kher Keep."
+        );
+    }
+
+    #[test]
+    fn normalize_token_named_literal_span_ends_at_the_defining_with_clause() {
+        // CR 111.1: the span covers the name only. Ajani's "with \"…\"" clause
+        // stays outside it — proven by "this token" inside that clause still
+        // folding to `~` (it would stay literal if the span had swallowed the
+        // clause), while "Ajani's Pridemate" itself stays literal and line 3's
+        // short name still normalizes.
+        assert_eq!(
+            normalize_card_name_refs(
+                "[+1]: You gain life equal to the number of creatures you control plus the number of planeswalkers you control.\n[−2]: Create a 2/2 white Cat Soldier creature token named Ajani's Pridemate with \"Whenever you gain life, put a +1/+1 counter on this token.\"\n[0]: If you have at least 15 life more than your starting life total, exile Ajani and each artifact and creature your opponents control.",
+                "Ajani, Strength of the Pride",
+            ),
+            "[+1]: You gain life equal to the number of creatures you control plus the number of planeswalkers you control.\n[−2]: Create a 2/2 white Cat Soldier creature token named Ajani's Pridemate with \"Whenever you gain life, put a +1/+1 counter on ~.\"\n[0]: If you have at least 15 life more than your starting life total, exile ~ and each artifact and creature your opponents control."
+        );
+    }
+
+    #[test]
+    fn normalize_token_boundaries_do_not_reach_card_filter_spans() {
+        // Counter-direction: "Once More with Feeling" is a CARD name that
+        // contains "with". Applying the token boundaries here would truncate the
+        // masked span to "Once More" and expose the rest — the reason
+        // [`NamedLiteralKind`] exists rather than one shared boundary set.
+        //
+        // This row does NOT discriminate: it is green with and without the
+        // token-prefix entries, because it pins the direction that must stay
+        // unchanged. It guards a later widening of the boundary set, not the
+        // bug this change fixes.
+        assert_eq!(
+            normalize_card_name_refs(
+                "A deck can have only one card named Once More with Feeling.",
+                "Once More with Feeling",
+            ),
+            "A deck can have only one card named Once More with Feeling."
         );
     }
 


### PR DESCRIPTION
CR 111.1: the name a card gives the token it creates is that token's own literal name, never a reference back to the creating card — even when it embeds the creator's name.

`mask_card_named_literal_spans` already protects such spans. Its prefix parser enumerated the noun forms by hand (`creature named `, `artifact named `, …) and `token named ` was not among them — the largest uncovered noun in the corpus:

| noun before ` named ` | occurrences | masked before |
|---|---:|---|
| `card` / `cards` | 282 | yes |
| **`token` / `tokens`** | **75** | **no** |
| `creature` / `creatures` | 50 | yes |
| `permanent` / `permanents` | 16 | yes |

Unmasked, the self-reference strategies rewrote the name. Kher Keep's token became `Kobolds of ~`. Selenia's became `~'s Curse`, which the trailing `~` → card-name expansion turned into `Selenia, the Cursed Heart's Curse`, and `parse_token_name_clause` then truncated at the injected comma to a bare `Selenia`.

Anchoring on the noun `token` covers the class in one rule: the token-creation template always writes it immediately before `named`, whatever type words precede it.

Token spans need different boundaries than card-filter spans — a token's name is followed by the clauses that define it in place (`with "…"`, `that's attacking`, `attached to …`), while real card names contain those same words (`Once More with Feeling`). The prefix parser therefore reports a typed `NamedLiteralKind` rather than letting the caller infer it, and only token spans end at those clauses. A bare comma is deliberately not a boundary: token names carry one (`Icingdeath, Frost Tongue`).

## Measurement

Full `oracle-gen` export before vs. after, all 35,795 cards — **9 differ, no others**:

| card | before | after |
|---|---|---|
| Selenia, the Cursed Heart | `Selenia` | `Selenia's Curse` |
| Kher Keep | `Kobolds of ~` | `Kobolds of Kher Keep` |
| The Rani | `Mark of ~` | `Mark of the Rani` |
| Ajani, Strength of the Pride | `Ajani` | `Ajani's Pridemate` |
| Koma, Cosmos Serpent | `Koma` | `Koma's Coil` |
| Koma, World-Eater | `Koma` | `Koma's Coil` |
| Goldmeadow Lookout | `Goldmeadow Lookout Harrier` | `Goldmeadow Harrier` |
| Llanowar Mentor | `Llanowar Mentor Elves` | `Llanowar Elves` |
| Smoke Spirits' Aid | description string only — the card stays `Unimplemented` | |

Counter-probe: with the two `token named ` prefix entries removed, three of the four new rows fail. The fourth (`normalize_token_boundaries_do_not_reach_card_filter_spans`) is green either way — it pins the card-filter direction against a later widening and is **not** evidence for this fix; its doc comment says so.

## Not covered

- The other naming shape, `create <Name>, a … token`: **9 cards** still carry a corrupted name (Volo, Itinerant Scholar → `~'s Journal`; Stangg and Stangg, Echo Warrior → `~ Twin`; Icingdeath, Frost Tyrant; Tamiyo, Compleated Sage; Black Lotus Lounge; Elemental, My Dear; Li'l Giri Saves the Day; Windmill Slam). That span has no noun anchor and needs the article guard `parse_named_token_preamble` already owns in `oracle_effect/token.rs`; duplicating it here would put the same question in two places. Happy to do it as a follow-up in that module.
- Token names containing a comma are still truncated by `parse_token_name_clause` (`Icingdeath, Frost Tongue` → `Icingdeath`).
- The `<noun> you control named <X>` position is also unmasked (24 occurrences — the noun before ` named ` is `control`, e.g. Volo's second line). Left alone here; it belongs to the card-filter side, not this fix.

## Notes

- `cargo test --workspace` is green except `mtgish-import::manifest_coverage`, which fails on `361e6f9a4` unchanged: it wants manifest entries for `ResolvedAbility.selected_target_incarnations` and `SpellContext.parent_target_iteration_members`. This branch touches one file, `crates/engine/src/parser/oracle_util.rs`.
- Related user-visible symptom: #5921 (closed) reported Kher Keep's tokens as blank blocks, resolved by the artless-token fallback tile in #6214 — that tile renders the token's name, which for this card read `Kobolds of ~`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved parsing of named literals to distinguish token names from card-filter names.
  - Added support for singular and plural token forms.
  - Improved handling of token names containing creator names, full card names, defining clauses, and Unicode characters.
  - Preserved correct parsing for card-filter names containing token-related words.
  - Fixed token names created by activated abilities, including “Kobolds of Kher Keep,” while preserving self-references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->