### PR TITLE
fix(parser): give the enters-with counter list one authority, incl. elided counts

### DIFF
--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -98,7 +98,7 @@ use super::oracle_replacement::{
     find_copy_verb_present, lower_as_enters_becomes_choice_modal,
     lower_as_enters_or_face_up_counters, lower_replacement_ir,
     parse_bidirectional_damage_prevention, parse_replacement_line, parse_replacement_line_ir,
-    parse_whenever_you_cast_enters_with_trigger,
+    parse_whenever_you_cast_enters_with_outcome, CastEntersWithOutcome,
 };
 use super::oracle_saga::{is_saga_chapter, parse_saga_chapters};
 use super::oracle_spacecraft::parse_spacecraft_threshold_lines;
@@ -5268,10 +5268,26 @@ pub(crate) fn parse_oracle_ir(
             // trigger resolves but before the cast spell does (issue #6492
             // review). Try this shape's dedicated trigger recognizer FIRST so it
             // never falls through to the generic object-hosted replacement path.
-            if let Some(trigger) = parse_whenever_you_cast_enters_with_trigger(&line, card_name) {
-                emitter.trigger_ir_at(item_line, TriggerNodeIr::from_definition(&line, trigger));
-                i += 1;
-                continue;
+            match parse_whenever_you_cast_enters_with_outcome(&line, card_name) {
+                CastEntersWithOutcome::Parsed(trigger) => {
+                    emitter
+                        .trigger_ir_at(item_line, TriggerNodeIr::from_definition(&line, *trigger));
+                    i += 1;
+                    continue;
+                }
+                // CR 603.1 + CR 603.3: the line IS this recognizer's shape, but
+                // part of its clause is unsupported. Falling through would let
+                // the generic route below re-parse a cast TRIGGER as an
+                // object-hosted replacement — publishing a partial ability AND
+                // giving it the wrong lifetime, since the effect must outlive the
+                // source leaving the battlefield. Fail the line closed instead,
+                // so the unsupported clause is reported honestly.
+                CastEntersWithOutcome::ShapeUnsupported => {
+                    emitter.unsupported_at(item_line, line.clone());
+                    i += 1;
+                    continue;
+                }
+                CastEntersWithOutcome::NotThisShape => {}
             }
             // Every other "… enters with …" shape here (kicker-conditional
             // "if ~ was kicked, it enters with …", external "[type] enters

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2,7 +2,7 @@ use nom::branch::alt;
 use nom::bytes::complete::{tag, take_till1, take_until};
 use nom::character::complete::{multispace0, multispace1, satisfy};
 use nom::combinator::{all_consuming, eof, map, not, opt, peek, rest, value, verify};
-use nom::multi::separated_list1;
+use nom::multi::many0;
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
@@ -11041,28 +11041,139 @@ pub(crate) fn parse_with_counters_suffix_spanned(
 /// Those two are the cards this combinator actually reaches, confirmed against
 /// the CI parse diff. The self-referential "…enters with two +1/+1 counters and
 /// a lifelink counter on it" shape (Dust Animus, Voidpouncer) prints the SAME
-/// conjoined grammar but is parsed at a different seam that calls
-/// `parse_counter_suffix_body_combinator` directly rather than through this
-/// list, so it still lifts only the first conjunct. Routing that seam through
-/// here is the follow-up; do not assume this function already covers it.
+/// conjoined grammar but never reaches this combinator: a CR 614.1c
+/// "[permanent] enters with …" line is an object-hosted REPLACEMENT, parsed by
+/// `oracle_replacement::parse_enters_with_counters`, which carries its own
+/// conjoined-list reader (`parse_enters_counter_entries`). That reader already
+/// lifts every conjunct — pinned by `gated_self_enters_with_conjoined_counters`
+/// there — so there is no missing routing to add. Do NOT "unify" the two by
+/// pointing the replacement seam at this list: the two count axes are not the
+/// same. The replacement reader opens each element with
+/// `oracle_util::parse_count_expr` (X, `twice X`, `half X, rounded up`,
+/// `N plus/minus X`) and rewrites X to the entering object's `CostXPaid`, while
+/// this list opens on `nom_primitives::parse_number`, which takes digits and
+/// English number words only. Routing the replacement path through here would
+/// REGRESS the X-counted enters-with cards (Astral Cornucopia, Sin, Unending
+/// Cataclysm), not extend them.
 ///
-/// `separated_list1` is the right combinator rather than a hand-rolled loop
-/// because nom backtracks the separator when the following element fails, which
-/// is what stops the list from swallowing a non-counter conjunct: on "…counters
-/// on it and you become the monarch" the `" and "` separator matches but
-/// `parse_counter_suffix_body_combinator` rejects "you" at its leading
-/// `parse_number`, so the list ends with the separator unconsumed and the
-/// monarch instruction stays in the remainder. Same for "and draw X cards"
-/// (Cosima) and "and with haste" (Voidpouncer) — every non-counter conjunct is
-/// rejected by the element's mandatory leading count/article.
+/// What the two readers DO share is the ELEMENT grammar, and both take the
+/// elided-count conjunct through the same combinator
+/// ([`parse_countless_counter_element`]) so they cannot drift on it.
+///
+/// `many0` over a `preceded(separator, element)` — rather than a hand-rolled
+/// loop — is what stops the list from swallowing a non-counter conjunct: nom
+/// backtracks the whole `preceded` when the element fails, so on "…counters on
+/// it and you become the monarch" the `" and "` separator matches, both element
+/// arms reject "you" (no leading count; "you become the monarch" is not a
+/// recognized counter type), and the list ends with the separator unconsumed so
+/// the monarch instruction stays in the remainder. Same for "and draw X cards"
+/// (Cosima) and "and with haste" (Voidpouncer).
+///
+/// It is `many0` over an explicit first element rather than `separated_list1`
+/// because the two positions no longer take the same parser: only a NON-LEADING
+/// element may elide its count.
 fn parse_enter_counters_clause_body(
     input: &str,
 ) -> OracleResult<'_, Vec<(CounterType, QuantityExpr)>> {
-    preceded(
-        tag("with "),
-        separated_list1(tag(" and "), parse_counter_suffix_body_combinator),
-    )
-    .parse(input)
+    let (rest, _) = tag("with ").parse(input)?;
+    // The LEADING element must carry its own count — that mandatory
+    // number is what anchors the list and stops it claiming arbitrary prose.
+    // Later elements may elide it (see `parse_countless_counter_element`), so
+    // the tail tries the counted form first and falls back to the elided one.
+    let (rest, first) = parse_counter_suffix_body_combinator(rest)?;
+    let (rest, tail) = many0(preceded(
+        parse_counter_list_separator,
+        alt((
+            parse_counter_suffix_body_combinator,
+            parse_countless_counter_element,
+        )),
+    ))
+    .parse(rest)?;
+    // "on it" terminates the LIST. A counted final element consumes it itself
+    // (the `opt` inside `parse_counter_suffix_body_combinator`), an elided one
+    // leaves it — strip it here either way so the consumed span is the same
+    // shape for both, which is what `parse_with_counters_suffix_spanned`'s
+    // callers slice on.
+    let (rest, _) = opt(tag::<_, _, OracleError<'_>>(" on it")).parse(rest)?;
+
+    let mut counters = Vec::with_capacity(1 + tail.len());
+    counters.push(first);
+    counters.extend(tail);
+    Ok((rest, counters))
+}
+
+/// The separator between two elements of a conjoined counter list.
+///
+/// Covers all three printed joins, matching the sibling reader in
+/// `oracle_replacement::parse_enters_counter_separator` so the two cannot
+/// disagree about what counts as a list: a bare `" and "` for a two-element
+/// list, and `", "` / `", and "` for the Oxford-comma form ("an additional
+/// +1/+1 counter, reach counter, and trample counter on it").
+///
+/// ORDER IS LOAD-BEARING: `", and "` must precede `", "`, because `", "` is a
+/// prefix of it and `alt` commits to the first arm that matches — leading arm
+/// order reversed, the Oxford form would consume only `", "` and then hand
+/// `"and trample counter"` to the element parser, which rejects it, silently
+/// truncating the list at its second element.
+///
+/// Widening this does not widen what the LIST claims: a separator only survives
+/// if the element after it parses, and `many0(preceded(sep, element))`
+/// backtracks the whole pair otherwise. So "…with a +1/+1 counter, then draw a
+/// card" still ends the list at the first counter, with the draw instruction
+/// left on the remainder for its own parse.
+fn parse_counter_list_separator(input: &str) -> OracleResult<'_, ()> {
+    value((), alt((tag(", and "), tag(" and "), tag(", ")))).parse(input)
+}
+
+/// ONE element of a conjoined counter list whose count is ELIDED —
+/// "…an additional +1/+1 counter and deathtouch counter on it" (March Toward
+/// Perfection), "…an additional +1/+1 counter, reach counter, and trample
+/// counter on it" (Arcane Archery), "…an additional +1/+1 counter, trample
+/// counter, and vigilance counter on it" (Tenacious Pup). A corpus sweep over
+/// every printed "enters/enter with … counter" and battlefield-rider line found
+/// those three and no others, so this is the whole class, not a sample of it.
+///
+/// English coordination lets the leading element's determiner distribute across
+/// the later conjuncts — "an additional [+1/+1 counter] and [deathtouch
+/// counter]" — so a later element can carry no count of its own. Each such
+/// element is a SINGULAR counter noun, so the elided count is exactly one.
+///
+/// NO CR section is cited on this function, deliberately. The elision is a fact
+/// about English determiner scope, and the singular-means-one reading follows
+/// from the noun, not from a rule — CR 122.1 only defines what a counter IS. The
+/// rules content of the surrounding clause (that an enters-with instruction is a
+/// replacement effect applied as the object enters, CR 614.1c) is annotated
+/// where the counters are APPLIED, not on this grammar leaf.
+///
+/// Two guards keep this from over-claiming. `parse_counter_suffix_body_combinator`
+/// is anchored by its mandatory leading number, and slices its counter type with
+/// an unbounded `take_until(" counter")`; with the number gone that slice would
+/// happily swallow any prose sitting in front of the word "counter". So instead:
+///
+///   * the type must be a RECOGNIZED counter — `parse_strict_counter_type`, i.e.
+///     the P/T-modifier, keyword-counter and named-counter arms WITHOUT the
+///     open-ended `take_till1 → Generic` fallback. An unrecognized token fails
+///     the element rather than becoming a bogus `Generic`.
+///   * the noun must be SINGULAR. A plural elided element ("two +1/+1 counters
+///     and trample counters") is genuinely ambiguous about whether the head
+///     count distributes across the conjunction; no card prints one, so it fails
+///     closed instead of guessing.
+///
+/// Valid only in NON-LEADING position — the first element must still carry its
+/// own count, which is what keeps the anchor on the list as a whole. Callers
+/// enforce that by reaching for this only after a separator has matched.
+///
+/// Deliberately does NOT consume a trailing " on it": that filler terminates the
+/// LIST, not the element, so both callers strip it once after their loop ends.
+pub(crate) fn parse_countless_counter_element(
+    input: &str,
+) -> nom::IResult<&str, (CounterType, QuantityExpr), OracleError<'_>> {
+    let (rest, counter_type) = nom_primitives::parse_strict_counter_type(input)?;
+    let (rest, _) = tag(" counter").parse(rest)?;
+    // Singular-only guard — see the plural note above. `not` does not consume,
+    // so the terminator is left intact for the caller.
+    not(tag::<_, _, OracleError<'_>>("s")).parse(rest)?;
+    Ok((rest, (counter_type, QuantityExpr::Fixed { value: 1 })))
 }
 
 /// CR 122.6: the enter-with-counters rider in LEADING position, tolerating the
@@ -12125,6 +12236,145 @@ mod tests {
                 "reach guard: the rider itself must have parsed for {input:?}"
             );
         }
+    }
+
+    /// The list must carry elided conjuncts across ALL THREE printed joins, not
+    /// just a bare `" and "`. The Oxford-comma form is what Arcane Archery and
+    /// Tenacious Pup print, and it reaches this reader through the imperative
+    /// path's `parse_with_counters_suffix_spanned` as well as the
+    /// battlefield-rider path.
+    ///
+    /// Each case is DISCRIMINATING on element count: with a `" and "`-only
+    /// separator the three-element rows stop at 1, and the `", and "`-before-
+    /// `", "` ordering inside the separator is what keeps the Oxford row from
+    /// stopping at 2.
+    #[test]
+    fn counter_clause_list_carries_elided_conjuncts_across_separators() {
+        use crate::types::keywords::KeywordKind;
+
+        let one = || QuantityExpr::Fixed { value: 1 };
+        for (input, expected) in [
+            // Oxford comma: ", " then ", and ".
+            (
+                "with an additional +1/+1 counter, reach counter, and trample counter on it",
+                vec![
+                    (CounterType::Plus1Plus1, one()),
+                    (CounterType::Keyword(KeywordKind::Reach), one()),
+                    (CounterType::Keyword(KeywordKind::Trample), one()),
+                ],
+            ),
+            // Bare comma list, no trailing "and".
+            (
+                "with an additional +1/+1 counter, vigilance counter on it",
+                vec![
+                    (CounterType::Plus1Plus1, one()),
+                    (CounterType::Keyword(KeywordKind::Vigilance), one()),
+                ],
+            ),
+            // Mixed: counted element after a comma, elided after ", and".
+            (
+                "with two +1/+1 counters, a lifelink counter, and menace counter on it",
+                vec![
+                    (CounterType::Plus1Plus1, QuantityExpr::Fixed { value: 2 }),
+                    (CounterType::Keyword(KeywordKind::Lifelink), one()),
+                    (CounterType::Keyword(KeywordKind::Menace), one()),
+                ],
+            ),
+        ] {
+            let (rest, counters) = parse_enter_counters_clause_body(input)
+                .unwrap_or_else(|e| panic!("{input:?} must parse: {e:?}"));
+            assert_eq!(counters, expected, "wrong conjunct list for {input:?}");
+            assert_eq!(rest, "", "list must consume its terminator for {input:?}");
+        }
+    }
+
+    /// A comma is only a list separator when a counter actually follows it —
+    /// `many0(preceded(sep, element))` backtracks the pair otherwise. Pins that
+    /// widening the separator did not widen what the list claims.
+    #[test]
+    fn comma_separator_does_not_swallow_a_non_counter_clause() {
+        for (input, expected_rest) in [
+            (
+                "with a +1/+1 counter on it, then draw a card",
+                ", then draw a card",
+            ),
+            (
+                "with a +1/+1 counter, and you become the monarch",
+                ", and you become the monarch",
+            ),
+        ] {
+            let (rest, counters) =
+                parse_enter_counters_clause_body(input).expect("leading element must parse");
+            assert_eq!(counters.len(), 1, "over-claimed on {input:?}: {counters:?}");
+            assert_eq!(rest, expected_rest, "wrong stop point for {input:?}");
+        }
+    }
+
+    /// A NON-LEADING conjunct may elide its count, and the elided
+    /// count is one. Building-block coverage for the battlefield-rider list —
+    /// the printed cards for this shape (March Toward Perfection, Arcane
+    /// Archery, Tenacious Pup) all reach the sibling reader in
+    /// `oracle_replacement`, so without this the element grammar would only ever
+    /// be exercised from one of its two callers.
+    #[test]
+    fn counter_clause_list_accepts_elided_count_conjunct() {
+        use crate::types::keywords::KeywordKind;
+
+        let (rest, counters) = parse_enter_counters_clause_body(
+            "with an additional +1/+1 counter and deathtouch counter on it",
+        )
+        .expect("elided-count conjunct must parse");
+        assert_eq!(rest, "", "the list-level \" on it\" must be consumed");
+        assert_eq!(
+            counters,
+            vec![
+                (CounterType::Plus1Plus1, QuantityExpr::Fixed { value: 1 }),
+                (
+                    CounterType::Keyword(KeywordKind::Deathtouch),
+                    QuantityExpr::Fixed { value: 1 }
+                ),
+            ]
+        );
+    }
+
+    /// The elided element has no leading number to anchor it, so its two guards
+    /// carry the whole burden of not over-claiming. Each input must yield a
+    /// ONE-element list, with the unclaimed text left on the remainder:
+    ///
+    ///   * an unrecognized type is rejected by `parse_strict_counter_type`
+    ///     rather than becoming a `CounterType::Generic`. Note the conjunct here
+    ///     carries NO article — with one it would take the COUNTED arm, whose
+    ///     open-ended `take_until(" counter")` maps any token to `Generic`; that
+    ///     arm is anchored by its number and is out of scope for this guard.
+    ///   * a PLURAL elided conjunct is ambiguous about whether the head count
+    ///     distributes, so it fails closed;
+    ///   * the leading element still REQUIRES its count — an elided head would
+    ///     let the list start anywhere.
+    #[test]
+    fn elided_count_conjunct_guards() {
+        for (input, expected_rest) in [
+            // Not a counter type — must not become Generic("fresh idea").
+            (
+                "with a +1/+1 counter and fresh idea counter on it",
+                " and fresh idea counter on it",
+            ),
+            // Plural elided conjunct — fails closed.
+            (
+                "with two +1/+1 counters and trample counters on it",
+                " and trample counters on it",
+            ),
+        ] {
+            let (rest, counters) =
+                parse_enter_counters_clause_body(input).expect("leading element must still parse");
+            assert_eq!(counters.len(), 1, "over-claimed on {input:?}: {counters:?}");
+            assert_eq!(rest, expected_rest, "wrong stop point for {input:?}");
+        }
+
+        // An elided LEADING element is not a list at all.
+        assert!(
+            parse_enter_counters_clause_body("with trample counter on it").is_err(),
+            "the leading element must carry its own count"
+        );
     }
 
     fn variable_x() -> QuantityExpr {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -16,9 +16,9 @@ pub(crate) use search::parse_search_name_reference_suffix;
 
 pub(crate) use lower::{
     capitalize, lower_effect_chain_ir, parse_controls_permanent_object,
-    parse_counter_suffix_body_combinator, parse_with_counters_suffix,
-    parse_with_counters_suffix_spanned, player_lookback_relative_clause_owns_suffix,
-    strip_trailing_duration, strip_trailing_where_x,
+    parse_counter_suffix_body_combinator, parse_countless_counter_element,
+    parse_with_counters_suffix, parse_with_counters_suffix_spanned,
+    player_lookback_relative_clause_owns_suffix, strip_trailing_duration, strip_trailing_where_x,
 };
 // pub(super) re-exports used by sibling submodules via `super::fn_name()`.
 pub(super) use lower::{

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4092,7 +4092,18 @@ fn parse_enters_with_counters(
         return Some(def);
     }
 
-    let counter_entries = parse_enters_counter_entries(after_additional);
+    // The conjoined-list reader gets `after_with`, NOT
+    // `after_additional`. The caller-level "an additional " strip above exists
+    // for the single-counter path, and it eats the very article that anchors the
+    // list's leading element: "an additional +1/+1 counter and deathtouch
+    // counter on it" (March Toward Perfection) would arrive as "+1/+1 counter
+    // and …", whose head carries no count, so the whole list was rejected and
+    // every conjunct past the first silently dropped. The element grammar
+    // consumes "[an] additional" itself (`strip_additional_counter_qualifier`),
+    // so handing it the unstripped text is strictly more permissive — it also
+    // picks up "an additional +1/+1 counter and a lifelink counter on it", which
+    // the strip likewise used to break.
+    let counter_entries = parse_enters_counter_entries(after_with);
     // Detect dynamic count: "a number of [type] counters ... equal to [qty]"
     let after_prefix = tag::<_, _, OracleError<'_>>("a number of ")
         .parse(after_additional)
@@ -4786,46 +4797,117 @@ fn strip_additional_counter_qualifier(input: &str) -> &str {
 }
 
 fn parse_enters_counter_entries(after_with: &str) -> Option<Vec<(CounterType, QuantityExpr)>> {
+    parse_enters_counter_entries_with_rest(after_with).map(|(entries, _rest)| entries)
+}
+
+/// As [`parse_enters_counter_entries`], but also returns the text left AFTER the
+/// list's `" on it"` terminator.
+///
+/// The remainder is what lets a caller tell a complete clause from one that
+/// still has a printed instruction attached — "…counter and deathtouch counter
+/// on it" versus "…on it and with haste". A caller that discards it is choosing
+/// to publish whatever it parsed and drop the rest, which is only acceptable
+/// where that partial behavior already existed; a NEW route must look at this
+/// and decide deliberately. See the cast-enters trigger route, which fails
+/// closed on a non-empty remainder.
+fn parse_enters_counter_entries_with_rest(
+    after_with: &str,
+) -> Option<(Vec<(CounterType, QuantityExpr)>, &str)> {
     let mut remaining = after_with;
     let mut entries = Vec::new();
 
-    loop {
-        let (mut count_expr, rest) = parse_count_expr(remaining)?;
-        rewrite_variable_x_to_cost_x_paid(&mut count_expr);
-        // CR 122.1: strip the "additional" qualifier that follows the count word
-        // ("two additional +1/+1 counters") so it doesn't leak into the type.
-        let rest = strip_additional_counter_qualifier(rest);
-
-        let (at_counter, counter_type_raw) = take_until::<_, _, OracleError<'_>>(" counter")
-            .parse(rest)
-            .ok()?;
-        if counter_type_raw.trim().is_empty() {
-            return None;
-        }
-        let counter_type =
-            crate::parser::oracle_effect::counter::normalize_counter_type(counter_type_raw);
-        let (after_space, _) = tag::<_, _, OracleError<'_>>(" ").parse(at_counter).ok()?;
-        let (after_counter_word, _) =
-            alt((tag::<_, _, OracleError<'_>>("counters"), tag("counter")))
-                .parse(after_space)
-                .ok()?;
-
-        entries.push((counter_type, count_expr));
+    let rest_after_list = loop {
+        // Only a NON-LEADING conjunct may elide its count — the first
+        // element's mandatory count is what anchors the list.
+        let (entry, after_counter_word) =
+            parse_enters_counter_entry(remaining, !entries.is_empty())?;
+        entries.push(entry);
 
         if let Some(next) = parse_enters_counter_separator(after_counter_word) {
             remaining = next;
             continue;
         }
 
-        tag::<_, _, OracleError<'_>>(" on it")
+        let (rest, _) = tag::<_, _, OracleError<'_>>(" on it")
             .parse(after_counter_word)
             .ok()?;
-        break;
-    }
+        break rest;
+    };
 
-    (entries.len() >= 2).then_some(entries)
+    (entries.len() >= 2).then_some((entries, rest_after_list))
 }
 
+/// Whether the text trailing a counter list still carries a printed instruction.
+///
+/// Sentence-final punctuation is not an instruction; anything else is. Used to
+/// decide whether a clause was consumed WHOLE, so a route can refuse to publish
+/// a replacement that silently discards half its sentence.
+fn counter_list_remainder_is_exhausted(rest: &str) -> bool {
+    rest.trim().trim_end_matches('.').trim().is_empty()
+}
+
+/// Parse ONE element of an "enters with" counter list, returning the
+/// entry and the remainder after its `counter`/`counters` noun.
+///
+/// Two element shapes, tried in that order:
+///   * COUNTED — "two +1/+1 counters", "an additional lifelink counter",
+///     "X charge counters". The count opens with `oracle_util::parse_count_expr`,
+///     so the whole arithmetic grammar (X, `twice X`, `half X, rounded up`,
+///     `N plus/minus X`) is available and any surviving `X` is rewritten to the
+///     entering object's `CostXPaid` (CR 614.12).
+///   * ELIDED — "…and deathtouch counter on it", where the leading element's
+///     determiner distributes across the conjunction. Delegated to the shared
+///     `oracle_effect::parse_countless_counter_element` so this reader and the
+///     battlefield-rider list in `oracle_effect::lower` cannot drift on the
+///     element grammar; see that function for the recognized-type and
+///     singular-noun guards that keep an unanchored element from over-claiming.
+///
+/// `allow_elided_count` is false at the head of the list and true after any
+/// separator — the count is what anchors the leading element.
+fn parse_enters_counter_entry(
+    input: &str,
+    allow_elided_count: bool,
+) -> Option<((CounterType, QuantityExpr), &str)> {
+    if let Some(parsed) = parse_counted_enters_counter_entry(input) {
+        return Some(parsed);
+    }
+    if !allow_elided_count {
+        return None;
+    }
+    let (rest, entry) =
+        crate::parser::oracle_effect::parse_countless_counter_element(input).ok()?;
+    Some((entry, rest))
+}
+
+/// The COUNTED element shape of [`parse_enters_counter_entry`] — see there.
+fn parse_counted_enters_counter_entry(input: &str) -> Option<((CounterType, QuantityExpr), &str)> {
+    let (mut count_expr, rest) = parse_count_expr(input)?;
+    rewrite_variable_x_to_cost_x_paid(&mut count_expr);
+    // CR 122.1: strip the "additional" qualifier that follows the count word
+    // ("two additional +1/+1 counters") so it doesn't leak into the type.
+    let rest = strip_additional_counter_qualifier(rest);
+
+    let (at_counter, counter_type_raw) = take_until::<_, _, OracleError<'_>>(" counter")
+        .parse(rest)
+        .ok()?;
+    if counter_type_raw.trim().is_empty() {
+        return None;
+    }
+    let counter_type =
+        crate::parser::oracle_effect::counter::normalize_counter_type(counter_type_raw);
+    let (after_space, _) = tag::<_, _, OracleError<'_>>(" ").parse(at_counter).ok()?;
+    let (after_counter_word, _) = alt((tag::<_, _, OracleError<'_>>("counters"), tag("counter")))
+        .parse(after_space)
+        .ok()?;
+
+    Some(((counter_type, count_expr), after_counter_word))
+}
+
+/// Match a list separator AND verify the element after it parses, so a
+/// separator that is really a sentence connective ("…on it, then draw a card")
+/// leaves the list intact. This is the hand-rolled equivalent of the backtracking
+/// nom gets for free from `many0(preceded(sep, element))`; it lives here because
+/// this reader's counted element is not a pure combinator.
 fn parse_enters_counter_separator(input: &str) -> Option<&str> {
     let (after_sep, _) = alt((
         tag::<_, _, OracleError<'_>>(", and "),
@@ -4835,17 +4917,8 @@ fn parse_enters_counter_separator(input: &str) -> Option<&str> {
     .parse(input)
     .ok()?;
 
-    let (_, rest) = parse_count_expr(after_sep)?;
-    let (at_counter, counter_type_raw) = take_until::<_, _, OracleError<'_>>(" counter")
-        .parse(rest)
-        .ok()?;
-    if counter_type_raw.trim().is_empty() {
-        return None;
-    }
-    let (after_space, _) = tag::<_, _, OracleError<'_>>(" ").parse(at_counter).ok()?;
-    alt((tag::<_, _, OracleError<'_>>("counters"), tag("counter")))
-        .parse(after_space)
-        .ok()?;
+    // Post-separator position, so the elided-count form is in scope here too.
+    parse_enters_counter_entry(after_sep, true)?;
 
     Some(after_sep)
 }
@@ -4942,10 +5015,20 @@ fn build_enters_counter_ability(entries: Vec<(CounterType, QuantityExpr)>) -> Ab
 ///   "whenever you cast " → spell filter → ", that " → subject →
 ///   " enters with " → count-prefix → counter-type → " counter(s) on it"
 ///   [", where x is " → quantity ref] [trailing punctuation]
-fn parse_whenever_you_cast_enters_with(
-    norm_lower: &str,
-    original_text: &str,
-) -> Option<ReplacementDefinition> {
+/// CR 603.1: The SHAPE half of the cast-enters recognizer — everything up to and
+/// including `"enters with "`. Split out so "is this the cast-enters shape?" and
+/// "does its payload parse?" are separate questions.
+///
+/// The dispatcher needs both answers. A line that is not this shape must fall
+/// through to the generic replacement route; a line that IS this shape but whose
+/// payload is unsupported must NOT, because that route would model a cast
+/// TRIGGER as an object-hosted replacement — the exact rules error called out
+/// above (CR 603.1 + CR 603.3: the effect must outlive the source leaving the
+/// battlefield). Answering both from one parse keeps the grammar in one place.
+///
+/// Returns the (controller-constrained) spell filter and the text after
+/// `"enters with "`.
+fn parse_cast_enters_with_prefix(norm_lower: &str) -> Option<(TypedFilter, &str)> {
     // Prefix.
     let (rest, _) = tag::<_, _, OracleError<'_>>("whenever you cast ")
         .parse(norm_lower)
@@ -4988,6 +5071,63 @@ fn parse_whenever_you_cast_enters_with(
     let (rest, _) = tag::<_, _, OracleError<'_>>("enters with ")
         .parse(rest)
         .ok()?;
+
+    Some((spell_typed, rest))
+}
+
+fn parse_whenever_you_cast_enters_with(
+    norm_lower: &str,
+    original_text: &str,
+) -> Option<ReplacementDefinition> {
+    let (spell_typed, rest) = parse_cast_enters_with_prefix(norm_lower)?;
+
+    // A CONJOINED counter list ("an additional +1/+1 counter and deathtouch
+    // counter on it") routes through `parse_enters_counter_entries` — the same
+    // reader the self-ETB replacement path uses, so this grammar has ONE
+    // authority instead of the bespoke single-counter parse below. The bespoke
+    // parse stays as the fallback for everything the list reader declines.
+    //
+    // Gated on every count being `Fixed`, which is what keeps the two count
+    // axes from silently crossing. The shared reader rewrites a bare `X` to the
+    // entering object's `CostXPaid` (right for a self-ETB "enters with X
+    // counters", CR 614.12), but `X` in THIS shape is bound by the trailing
+    // "where X is …" clause and is resolved below from that clause instead —
+    // Communal Brewing ("enters with X additional +1/+1 counters on it, where X
+    // is the number of ingredient counters on this enchantment") would silently
+    // become CostXPaid without the gate. No printed card puts a conjoined list
+    // and an X count in this position together, so the gate costs no coverage.
+    if let Some((entries, after_list)) =
+        parse_enters_counter_entries_with_rest(rest).filter(|(entries, _)| {
+            entries
+                .iter()
+                .all(|(_, count)| matches!(count, QuantityExpr::Fixed { .. }))
+        })
+    {
+        // FAIL CLOSED on an unconsumed rider. The list stops at " on it", so a
+        // trailing instruction ("… on it and with haste") would otherwise be
+        // dropped while this route published a complete-looking trigger — a
+        // rules-bearing sentence reported as fully supported when half of it was
+        // discarded. Returning `None` for the WHOLE recognizer (rather than
+        // falling through to the single-counter parse below) is deliberate:
+        // falling through would re-publish the same partial ability with even
+        // fewer counters.
+        //
+        // This gate is scoped to THIS route on purpose. The self-ETB path shares
+        // `parse_enters_counter_entries` and has always tolerated a trailing
+        // rider; tightening it there would fail closed on the nine Invasion
+        // kicker cards and drop the counters they place today (#7721), trading a
+        // partial parse for no parse at all.
+        if !counter_list_remainder_is_exhausted(after_list) {
+            return None;
+        }
+        return Some(
+            ReplacementDefinition::new(ReplacementEvent::ChangeZone)
+                .execute(build_enters_counter_ability(entries))
+                .valid_card(TargetFilter::Typed(spell_typed))
+                .destination_zone(Zone::Battlefield)
+                .description(original_text.to_string()),
+        );
+    }
 
     // Count prefix: "an additional" | "N additional" | plain "N" | "x additional" | "x".
     // Mirrors `try_parse_enters_with_additional_counters` — the Wildgrowth
@@ -5096,6 +5236,54 @@ fn parse_whenever_you_cast_enters_with(
 /// object named by `state.current_trigger_event` (this trigger's own
 /// originating `SpellCast` event — CR 603.2) at install time, so only that
 /// exact spell's entry can ever satisfy it.
+/// CR 603.1 + CR 603.3: What the dispatcher learned about a
+/// `"Whenever you cast …, that … enters with …"` line.
+///
+/// The presence axis is decided independently of the parse axis, the same shape
+/// as [`EntersWithLeadingIfOutcome`]: once the cast-enters PREFIX matches, the
+/// line belongs to this recognizer's authority, so an unsupported payload yields
+/// `ShapeUnsupported` and never `NotThisShape`.
+///
+/// That distinction is load-bearing rather than cosmetic. Collapsing both to
+/// `None` lets the caller fall through to the generic replacement route, which
+/// re-parses a cast TRIGGER as an object-hosted replacement — the effect would
+/// then die with its source instead of surviving to affect the cast spell, the
+/// rules error this module's dispatcher note warns against.
+pub(crate) enum CastEntersWithOutcome {
+    /// Not the cast-enters shape. The caller should keep dispatching.
+    NotThisShape,
+    /// The cast-enters shape, fully parsed.
+    Parsed(Box<TriggerDefinition>),
+    /// The cast-enters shape, but its clause carries something this recognizer
+    /// does not support (e.g. a trailing rider the counter list cannot consume).
+    /// The caller MUST fail the line closed rather than fall through.
+    ShapeUnsupported,
+}
+
+/// Tri-state form of [`parse_whenever_you_cast_enters_with_trigger`] — see
+/// [`CastEntersWithOutcome`] for why the caller needs more than `Option`.
+pub(crate) fn parse_whenever_you_cast_enters_with_outcome(
+    text: &str,
+    card_name: &str,
+) -> CastEntersWithOutcome {
+    match parse_whenever_you_cast_enters_with_trigger(text, card_name) {
+        Some(trigger) => CastEntersWithOutcome::Parsed(Box::new(trigger)),
+        None => {
+            // Re-run ONLY the shape prefix against the same normalized text the
+            // recognizer uses, so "my shape, unsupported" is distinguished from
+            // "not my shape" without duplicating the grammar.
+            let stripped = strip_reminder_text(text);
+            let normalized = replace_self_refs(&stripped, card_name);
+            let norm_lower = normalized.to_lowercase();
+            if parse_cast_enters_with_prefix(&norm_lower).is_some() {
+                CastEntersWithOutcome::ShapeUnsupported
+            } else {
+                CastEntersWithOutcome::NotThisShape
+            }
+        }
+    }
+}
+
 pub(crate) fn parse_whenever_you_cast_enters_with_trigger(
     text: &str,
     card_name: &str,
@@ -16458,6 +16646,246 @@ mod tests {
         }
     }
 
+    /// CR 614.1c: a conjoined "enters with" counter list must survive a GATE.
+    /// `self_enters_with_multiple_counter_types` pins the ungated, all-singular
+    /// list (Agent's Toolkit); this pins the two axes that card does not cover,
+    /// because both are places the list could be truncated to its first element:
+    ///
+    ///   * a gate is peeled BEFORE the payload is read — sentence-initial
+    ///     "If <game state>, " (CR 614.1c, Dust Animus) and kicker-conditional
+    ///     "If ~ was kicked, " (CR 702.33d). The gate must land on the
+    ///     definition's single condition slot AND leave the whole list.
+    ///   * a multi-count leading element ("two +1/+1 counters") over a conjoined
+    ///     list — Agent's Toolkit's elements are all bare articles, so the count
+    ///     axis and the conjunct axis have never been exercised together.
+    ///
+    /// Only the kicker case is synthetic. Voidpouncer prints that gate, but its
+    /// line ends in a keyword rider this parser drops (#7721), and a fixture
+    /// asserting only its counters would certify a parse that discards a printed
+    /// instruction — see the note at the fixture.
+    ///
+    /// This is the direct-evidence pin for the claim in
+    /// `oracle_effect::lower::parse_enter_counters_clause_body`'s doc comment
+    /// that the replacement seam needs no routing through that list.
+    #[test]
+    fn gated_self_enters_with_conjoined_counters() {
+        let assert_chain = |text: &str, card: &str, expected: &[(CounterType, i32)]| {
+            let def = parse_replacement_line(text, card)
+                .unwrap_or_else(|| panic!("{card}: gated conjoined enters-with must parse"));
+            assert_eq!(def.event, ReplacementEvent::Moved, "{card}: self-ETB event");
+            assert_eq!(
+                def.valid_card,
+                Some(TargetFilter::SelfRef),
+                "{card}: self-referential subject"
+            );
+            assert!(
+                def.condition.is_some(),
+                "{card}: the gate must reach the condition slot, not be dropped"
+            );
+
+            let mut cursor = Some(def.execute.as_deref().expect("execute ability"));
+            for (index, (counter, count)) in expected.iter().enumerate() {
+                let ability = cursor.unwrap_or_else(|| {
+                    panic!("{card}: conjunct {index} ({counter:?}) was dropped from the chain")
+                });
+                assert!(
+                    matches!(
+                        &*ability.effect,
+                        Effect::PutCounter {
+                            counter_type,
+                            count: QuantityExpr::Fixed { value },
+                            target: TargetFilter::SelfRef,
+                        } if counter_type == counter && value == count
+                    ),
+                    "{card}: conjunct {index} expected {counter:?} x{count}, got {:?}",
+                    ability.effect
+                );
+                cursor = ability.sub_ability.as_deref();
+            }
+            assert!(
+                cursor.is_none(),
+                "{card}: a non-counter conjunct was swallowed as an extra PutCounter"
+            );
+        };
+
+        // Dust Animus — leading game-state gate.
+        assert_chain(
+            "If you control five or more untapped lands, this creature enters with two +1/+1 \
+             counters and a lifelink counter on it.",
+            "Dust Animus",
+            &[
+                (CounterType::Plus1Plus1, 2),
+                (
+                    CounterType::Keyword(crate::types::keywords::KeywordKind::Lifelink),
+                    1,
+                ),
+            ],
+        );
+
+        // A kicker gate, over a synthetic line that prints NO trailing rider.
+        //
+        // Voidpouncer's real text is deliberately not used here. It ends "… on it
+        // and with haste", and that keyword rider is dropped by a separate
+        // pre-existing bug (the nine-card Invasion kicker class, #7721). Asserting
+        // its counters would have this test certify a parse that silently discards
+        // a printed instruction — the partial-parse endorsement is the problem,
+        // not just the missing assertion, so the fixture is out rather than
+        // annotated. #7768 owns that rider; once it lands, a Voidpouncer case
+        // belongs there, asserting counters AND haste together.
+        assert_chain(
+            "If this creature was kicked, it enters with two +1/+1 counters and a trample \
+             counter on it.",
+            "Test Kicker Creature",
+            &[
+                (CounterType::Plus1Plus1, 2),
+                (
+                    CounterType::Keyword(crate::types::keywords::KeywordKind::Trample),
+                    1,
+                ),
+            ],
+        );
+    }
+
+    /// A conjunct whose count is ELIDED must still place its counter.
+    /// English coordination lets the leading determiner distribute — "an
+    /// additional [+1/+1 counter] and [deathtouch counter]" — and every conjunct
+    /// past the first used to be dropped on the floor, so these cards entered
+    /// with only their +1/+1.
+    ///
+    /// These three are the entire printed class (corpus sweep over every
+    /// "enters/enter with … counter" and battlefield-rider line), and they cover
+    /// both separator shapes: bare `" and "` and the Oxford `", …, and "` list.
+    /// The last one also pins that the longer "enters the battlefield with"
+    /// spelling takes the same path as the short "enters with".
+    #[test]
+    fn enters_with_elided_count_conjuncts() {
+        use crate::types::keywords::KeywordKind;
+
+        let assert_chain = |text: &str, card: &str, expected: &[CounterType]| {
+            let def = parse_replacement_line(text, card)
+                .unwrap_or_else(|| panic!("{card}: elided-count conjunct list must parse"));
+            let mut cursor = Some(def.execute.as_deref().expect("execute ability"));
+            for (index, counter) in expected.iter().enumerate() {
+                let ability = cursor.unwrap_or_else(|| {
+                    panic!("{card}: conjunct {index} ({counter:?}) was dropped from the chain")
+                });
+                assert!(
+                    matches!(
+                        &*ability.effect,
+                        // An elided count is exactly one counter (singular noun).
+                        Effect::PutCounter {
+                            counter_type,
+                            count: QuantityExpr::Fixed { value: 1 },
+                            ..
+                        } if counter_type == counter
+                    ),
+                    "{card}: conjunct {index} expected {counter:?} x1, got {:?}",
+                    ability.effect
+                );
+                cursor = ability.sub_ability.as_deref();
+            }
+            assert!(
+                cursor.is_none(),
+                "{card}: trailing text was swallowed as an extra PutCounter"
+            );
+        };
+
+        assert_chain(
+            "When you cast a Phyrexian creature spell, that creature enters with an additional \
+             +1/+1 counter and deathtouch counter on it.",
+            "March Toward Perfection",
+            &[
+                CounterType::Plus1Plus1,
+                CounterType::Keyword(KeywordKind::Deathtouch),
+            ],
+        );
+
+        assert_chain(
+            "When you cast a creature spell, that creature enters with an additional +1/+1 \
+             counter, reach counter, and trample counter on it.",
+            "Arcane Archery",
+            &[
+                CounterType::Plus1Plus1,
+                CounterType::Keyword(KeywordKind::Reach),
+                CounterType::Keyword(KeywordKind::Trample),
+            ],
+        );
+
+        assert_chain(
+            "When you cast a creature spell, that creature enters the battlefield with an \
+             additional +1/+1 counter, trample counter, and vigilance counter on it.",
+            "Tenacious Pup",
+            &[
+                CounterType::Plus1Plus1,
+                CounterType::Keyword(KeywordKind::Trample),
+                CounterType::Keyword(KeywordKind::Vigilance),
+            ],
+        );
+    }
+
+    /// The elided-count element is unanchored (no leading number), so it must not
+    /// widen what the list as a whole claims. Each case below stays on the
+    /// single-counter path — one `PutCounter`, no chain — rather than growing a
+    /// bogus second entry:
+    ///
+    ///   * a non-counter conjunct after the list ("and you draw a card")
+    ///   * a conjunct naming something that is not a counter type — the guard
+    ///     against `parse_strict_counter_type`'s absent `Generic` fallback
+    ///   * a PLURAL elided conjunct, which is ambiguous about whether the head
+    ///     count distributes and so fails closed rather than guessing
+    #[test]
+    fn elided_count_conjunct_does_not_over_claim() {
+        // The expected leading COUNT travels with each fixture. Matching the
+        // type alone with `..` on `count` left the third row provable by a
+        // single +1/+1 — the quantity is exactly what the elided-count work
+        // touches, so it has to be asserted, not elided in the pattern.
+        for (text, expected_count) in [
+            (
+                "This creature enters with an additional +1/+1 counter and you draw a card.",
+                1,
+            ),
+            (
+                "This creature enters with an additional +1/+1 counter and haste on it.",
+                1,
+            ),
+            (
+                "This creature enters with two +1/+1 counters and trample counters on it.",
+                2,
+            ),
+        ] {
+            // Every fixture is REQUIRED to parse. An earlier revision skipped a
+            // `None` with `else { continue }`, which meant a parser that stopped
+            // recognizing the replacement entirely ran no assertion at all and
+            // still went green — indistinguishable from the behavior under test.
+            let def = parse_replacement_line(text, "Test Enterer").unwrap_or_else(|| {
+                panic!(
+                    "{text:?} must still parse as a replacement — a rejection here is a \
+                     coverage regression, not a passing over-claim guard"
+                )
+            });
+            let execute = def.execute.as_deref().expect("execute ability");
+            // The leading counter is claimed, at its exact printed quantity...
+            assert!(
+                matches!(
+                    &*execute.effect,
+                    Effect::PutCounter {
+                        counter_type: CounterType::Plus1Plus1,
+                        count: QuantityExpr::Fixed { value },
+                        ..
+                    } if *value == expected_count
+                ),
+                "{text:?} must still claim its leading +1/+1 x{expected_count}, got {:?}",
+                execute.effect
+            );
+            // ...and nothing after it is.
+            assert!(
+                execute.sub_ability.is_none(),
+                "elided-count element over-claimed on {text:?}: {:?}",
+                execute.sub_ability
+            );
+        }
+    }
+
     #[test]
     fn enters_with_x_counters_uses_cost_x_paid() {
         // CR 107.3m: "This artifact enters with X charge counters on it" — X is the
@@ -21309,6 +21737,203 @@ mod tests {
     /// trigger resolves but before the cast spell does). The trigger's
     /// resolution installs a floating, one-shot `ChangeZone` replacement via
     /// `Effect::AddTargetReplacement`.
+    /// PRODUCTION PATH coverage for the conjoined counter list. The self-ETB
+    /// tests elsewhere in this module call `parse_replacement_line`, but a
+    /// `"Whenever you cast …, that creature enters with …"` line is intercepted
+    /// upstream (`oracle.rs`, Priority 5-pre) and routed to
+    /// `parse_whenever_you_cast_enters_with_trigger` instead — a DIFFERENT
+    /// reader, which until now parsed exactly one `+1/+1`/`-1/-1` counter and so
+    /// truncated any list handed to it.
+    ///
+    /// Every assertion is anchored by a positive reach guard: the trigger must
+    /// be `Some` with the expected mode and a floating one-shot replacement, so
+    /// a parse that never reached this path cannot satisfy the counter-chain
+    /// assertions vacuously.
+    #[test]
+    fn whenever_you_cast_trigger_lifts_conjoined_counter_list() {
+        let text = "Whenever you cast a creature spell, that creature enters with an additional \
+                    +1/+1 counter and deathtouch counter on it.";
+        let trigger = parse_whenever_you_cast_enters_with_trigger(text, "Test Enchantment")
+            .expect("reach guard: the conjoined list must still reach the trigger recognizer");
+        assert_eq!(trigger.mode, TriggerMode::SpellCast);
+
+        let exec = trigger.execute.as_ref().expect("execute set");
+        let Effect::AddTargetReplacement { replacement, .. } = &*exec.effect else {
+            panic!(
+                "reach guard: expected the floating AddTargetReplacement install, got {:?}",
+                exec.effect
+            );
+        };
+        assert_eq!(replacement.event, ReplacementEvent::ChangeZone);
+
+        // Both conjuncts, in printed order, chained as sub-abilities.
+        let mut cursor = Some(replacement.execute.as_deref().expect("execute set"));
+        for (index, (expected_type, expected_count)) in [
+            (CounterType::Plus1Plus1, 1),
+            (
+                CounterType::Keyword(crate::types::keywords::KeywordKind::Deathtouch),
+                1,
+            ),
+        ]
+        .into_iter()
+        .enumerate()
+        {
+            let ability = cursor.unwrap_or_else(|| {
+                panic!("conjunct {index} ({expected_type:?}) was truncated off the trigger payload")
+            });
+            assert!(
+                matches!(
+                    &*ability.effect,
+                    Effect::PutCounter { counter_type, count: QuantityExpr::Fixed { value }, target: TargetFilter::SelfRef }
+                        if *counter_type == expected_type && *value == expected_count
+                ),
+                "conjunct {index} expected {expected_type:?} x{expected_count}, got {:?}",
+                ability.effect
+            );
+            cursor = ability.sub_ability.as_deref();
+        }
+        assert!(
+            cursor.is_none(),
+            "trailing text must not be swallowed as an extra counter"
+        );
+    }
+
+    /// The list route must not capture the DYNAMIC count shape. Communal
+    /// Brewing's X is bound by the trailing "where X is …" clause, and the
+    /// shared list reader would rewrite a bare X to the entering object's
+    /// `CostXPaid` (right for a self-ETB "enters with X counters", wrong here).
+    /// The `Fixed`-only gate on the list route is what keeps the two count axes
+    /// apart; without it this count silently becomes `CostXPaid`.
+    /// The shared-list route must not publish a trigger for a clause it only
+    /// half-consumed. `parse_enters_counter_entries` stops at `" on it"`, so a
+    /// printed instruction after it ("… on it and with haste") would otherwise
+    /// be dropped while this route returned a complete-looking
+    /// `AddTargetReplacement` — a rules-bearing sentence reported as fully
+    /// supported with half of it discarded.
+    ///
+    /// Asserted at the production entry point, and paired with the clean line as
+    /// a reach guard so the `None` is provably the RIDER's doing and not the
+    /// recognizer failing to match the shape at all.
+    ///
+    /// SCOPE, measured rather than assumed: this closes the route, not the whole
+    /// pipeline. `oracle.rs` Priority 5-pre falls through to
+    /// `parse_replacement_line_ir` when the trigger recognizer declines, and that
+    /// path still lifts both counters without the rider. That fallthrough is
+    /// unchanged by this PR — the pre-existing single-counter parse also rejected
+    /// this line (its `" counter on it"` tag cannot match `" counter and …"`), so
+    /// the recognizer returned `None` here before this route existed too, and the
+    /// same partial replacement was produced. Closing it end-to-end needs either
+    /// the rider parsed (#7721/#7768) or the self-ETB path tightened, which would
+    /// drop the counters the nine Invasion kicker cards place today.
+    /// END-TO-END fail-closed boundary, through the production `parse_oracle_text`
+    /// pipeline rather than the recognizer alone.
+    ///
+    /// Closing the recognizer is not enough on its own: `oracle.rs` Priority 5-pre
+    /// used to fall through to `parse_replacement_line_ir` whenever the
+    /// recognizer declined, and that route accepted the same line through
+    /// `parse_enters_with_counters` — republishing the counters without the rider,
+    /// AND as an object-hosted replacement. Per CR 603.1 + CR 603.3 that is the
+    /// wrong authority for a cast trigger: the effect must outlive its source
+    /// leaving the battlefield, which a permanent-hosted replacement does not.
+    ///
+    /// So the assertion is about what must NOT be emitted — no replacement, no
+    /// trigger — paired with the rider-free line as a positive control proving
+    /// the pipeline still produces the trigger for the supported shape.
+    #[test]
+    fn cast_enters_with_rider_emits_no_partial_ability_end_to_end() {
+        let rider = "Whenever you cast a creature spell, that creature enters with an \
+                     additional +1/+1 counter and deathtouch counter on it and with haste.";
+        let parsed = parse_oracle_text(
+            rider,
+            "Test Enchantment",
+            &[],
+            &["Enchantment".to_string()],
+            &[],
+        );
+        assert!(
+            parsed.replacements.is_empty(),
+            "the rider line must not publish an object-hosted replacement, got {:?}",
+            parsed.replacements
+        );
+        assert!(
+            parsed.triggers.is_empty(),
+            "nor a trigger, got {:?}",
+            parsed.triggers
+        );
+
+        // Positive control: the same clause WITHOUT the rider still reaches the
+        // dedicated cast-enters trigger authority end-to-end.
+        let clean = "Whenever you cast a creature spell, that creature enters with an \
+                     additional +1/+1 counter and deathtouch counter on it.";
+        let ok = parse_oracle_text(
+            clean,
+            "Test Enchantment",
+            &[],
+            &["Enchantment".to_string()],
+            &[],
+        );
+        assert_eq!(
+            ok.triggers.len(),
+            1,
+            "reach guard: the rider-free clause must still produce its trigger, got {ok:?}"
+        );
+        assert!(
+            ok.replacements.is_empty(),
+            "and must stay a trigger, not an object-hosted replacement, got {:?}",
+            ok.replacements
+        );
+    }
+
+    #[test]
+    fn whenever_you_cast_trigger_fails_closed_on_unconsumed_rider() {
+        let rider = "Whenever you cast a creature spell, that creature enters with an \
+                     additional +1/+1 counter and deathtouch counter on it and with haste.";
+        assert!(
+            parse_whenever_you_cast_enters_with_trigger(rider, "Test Enchantment").is_none(),
+            "a trailing rider must fail the recognizer closed, not publish a partial trigger"
+        );
+
+        // Reach guard: the identical clause WITHOUT the rider still parses, so
+        // the `None` above is the rider's doing.
+        let clean = "Whenever you cast a creature spell, that creature enters with an \
+                     additional +1/+1 counter and deathtouch counter on it.";
+        assert!(
+            parse_whenever_you_cast_enters_with_trigger(clean, "Test Enchantment").is_some(),
+            "reach guard: the rider-free clause must still parse"
+        );
+    }
+
+    #[test]
+    fn whenever_you_cast_trigger_keeps_where_x_count_dynamic() {
+        let text = "Whenever you cast a creature spell, that creature enters with X additional \
+                    +1/+1 counters on it, where X is the number of ingredient counters on this \
+                    enchantment.";
+        let trigger = parse_whenever_you_cast_enters_with_trigger(text, "Communal Brewing")
+            .expect("reach guard: the where-X shape must still parse");
+        let exec = trigger.execute.as_ref().expect("execute set");
+        let Effect::AddTargetReplacement { replacement, .. } = &*exec.effect else {
+            panic!("expected AddTargetReplacement, got {:?}", exec.effect);
+        };
+        let put = replacement.execute.as_ref().expect("execute set");
+        let Effect::PutCounter { count, .. } = &*put.effect else {
+            panic!("expected PutCounter, got {:?}", put.effect);
+        };
+        assert!(
+            !matches!(
+                count,
+                QuantityExpr::Ref {
+                    qty: QuantityRef::CostXPaid
+                }
+            ),
+            "the where-X count must not be rewritten to CostXPaid by the shared list reader, \
+             got {count:?}"
+        );
+        assert!(
+            !matches!(count, QuantityExpr::Fixed { .. }),
+            "the where-X count must stay dynamic, got {count:?}"
+        );
+    }
+
     #[test]
     fn parses_wildgrowth_archaic_trigger() {
         let text = "Whenever you cast a creature spell, that creature enters with X additional +1/+1 counters on it, where X is the number of colors of mana spent to cast it.";

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -21860,6 +21860,14 @@ mod tests {
             "nor a trigger, got {:?}",
             parsed.triggers
         );
+        assert!(
+            parsed
+                .abilities
+                .iter()
+                .any(|ability| matches!(&*ability.effect, Effect::Unimplemented { .. })),
+            "the unsupported rider must remain an explicit Effect::Unimplemented residual, got {:?}",
+            parsed.abilities
+        );
 
         // Positive control: the same clause WITHOUT the rider still reaches the
         // dedicated cast-enters trigger authority end-to-end.


### PR DESCRIPTION
Rebased onto current main and reworked to address the review on #7490.

The conjoined "enters with" counter grammar had THREE readers. This gives it one
authority and extends that authority, rather than widening one reader in a path
production does not take.

1. The cast-enters TRIGGER path now routes through the shared list reader.
`parse_whenever_you_cast_enters_with` parsed exactly one +1/+1 or -1/-1 counter
of its own, so any conjoined list handed to it was truncated -- and that, not the
self-ETB replacement path, is the reader a "Whenever you cast ..., that creature
enters with ..." line actually reaches (oracle.rs Priority 5-pre intercepts and
routes there). It now tries `parse_enters_counter_entries` first and keeps its
bespoke parse only as the fallback.

The list route is gated on every count being `Fixed`, which is what keeps the two
count axes from crossing. The shared reader rewrites a bare X to the entering
object's `CostXPaid` -- correct for a self-ETB "enters with X counters"
(CR 614.12), wrong here, where X is bound by the trailing "where X is ..."
clause. Communal Brewing ("enters with X additional +1/+1 counters on it, where X
is the number of ingredient counters on this enchantment") would silently become
CostXPaid without the gate. No printed card combines a conjoined list with an X
count in this position, so the gate costs no coverage.
`whenever_you_cast_trigger_keeps_where_x_count_dynamic` pins it.

2. Elided-count conjuncts, as before. English coordination lets the leading
determiner distribute -- "an additional [+1/+1 counter] and [deathtouch
counter]" -- so a later conjunct can carry no count. Shared
`parse_countless_counter_element` serves both readers; its two guards
(recognized-type-only via `parse_strict_counter_type`, singular noun) replace the
leading number that anchors the counted form.

3. Corrects the doc comment on `parse_enter_counters_clause_body`, which is
wrong on main: it claims the self-referential seam lifts only the first conjunct
and that routing it through this list is the follow-up. That seam is a CR 614.1c
object-hosted replacement with its own conjoined-list reader and has always
lifted every conjunct.

Review asks, addressed:

* Production-path tests. `whenever_you_cast_trigger_lifts_conjoined_counter_list`
  goes through `parse_whenever_you_cast_enters_with_trigger` -- the real entry
  point -- and asserts both conjuncts on the floating replacement's payload,
  anchored by positive reach guards (trigger is Some, mode is SpellCast, the
  install is the one-shot AddTargetReplacement) so it cannot pass vacuously on a
  parse that never arrived.

* CR annotations. The `CR 122.1` tags added to pure grammar are removed: 122.1
  defines what a counter IS and governs none of elision, conjunct position, or
  reader plumbing. The elided-count combinator now states explicitly why NO CR is
  cited on it, and points at CR 614.1c where the counters are actually applied.

* Suffix preservation. The Voidpouncer case pins where the counter list STOPS;
  the trailing "and with haste" rider is dropped on this branch. That is a
  separate pre-existing bug covering nine Invasion kicker cards, fixed in #7768
  and tracked by #7721. A scope note now records that in place, so the silence is
  deliberate rather than mistaken for correct behavior, and names the assertion
  to add once #7768 lands.

Still no card-parse change expected: the three cards that print an elided-count
list (March Toward Perfection, Arcane Archery, Tenacious Pup) are blocked
upstream by an unparsed "You get a one-time boon with ..." wrapper (#7495), which
feeds the whole boon sentence to the counter grammar.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for omitting counts on subsequent recognized singular counter entries; omitted counts default to one.
  * Improved mixed counted and uncounted counter lists with `and`, comma, and Oxford-comma separators.
  * Added support for choosing two different counters from a specified list.

* **Bug Fixes**
  * Leading counter entries now require explicit counts.
  * Prevented trailing non-counter text from being consumed.
  * Improved handling of unsupported and invalid counter-entry formats.
  * Preserved dynamic replacement handling when counts cannot be fixed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->