### PR TITLE
Fix for the back arrow not doing 1 dmg to non dragons

### DIFF
--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -807,6 +807,44 @@ impl GameScenario {
         builder
     }
 
+    /// CR 301.1: Add an artifact card to hand with abilities parsed from Oracle
+    /// text.
+    ///
+    /// Distinct from `add_spell_to_hand_from_oracle(..) + as_artifact()`: that
+    /// pair leaves the Sorcery core type in place, producing a card that
+    /// resolves to the graveyard as a spell and therefore never enters the
+    /// battlefield — so no ETB trigger fires. Any Equipment/artifact test that
+    /// needs an enters-the-battlefield ability must start here.
+    ///
+    /// Subtypes (e.g. Equipment, CR 301.5) are the caller's concern — chain
+    /// `.with_subtypes(..)` on the returned builder.
+    pub fn add_artifact_to_hand_from_oracle(
+        &mut self,
+        player: PlayerId,
+        name: &str,
+        oracle_text: &str,
+    ) -> CardBuilder<'_> {
+        let card_id = CardId(self.state.next_object_id);
+        let id = create_object(
+            &mut self.state,
+            card_id,
+            player,
+            name.to_string(),
+            Zone::Hand,
+        );
+        let obj = self.state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.base_card_types = obj.card_types.clone();
+        // CR 301.1: artifacts have no power/toughness unless they are also creatures.
+
+        let mut builder = CardBuilder {
+            state: &mut self.state,
+            id,
+        };
+        builder.from_oracle_text(oracle_text);
+        builder
+    }
+
     /// Add an instant or sorcery to a player's hand without Oracle text.
     ///
     /// Use `is_instant: true` for instants, `false` for sorceries.

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -10,10 +10,12 @@ use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
 use super::super::oracle_nom::bridge::{nom_on_lower, nom_parse_lower};
+use super::super::oracle_nom::condition as nom_condition;
 use super::super::oracle_nom::condition::{
     inject_controller_you, parse_cast_using_teamwork_phrase,
     parse_scoped_player_opponent_and_has_condition, parse_spell_target_superlative_suffix,
     parse_you_put_onto_battlefield_this_way_clause, parse_zone_changed_this_way_clause,
+    DamagedThisWayRecipient,
 };
 use super::super::oracle_nom::primitives as nom_primitives;
 use super::super::oracle_nom::quantity as nom_quantity;
@@ -5574,6 +5576,16 @@ pub(super) fn try_nom_condition_as_ability_condition(
         return Some(condition);
     }
 
+    // CR 120.3 + CR 608.2c: "a Dragon is dealt damage this way" — the plain-damage
+    // channel of the "this way" back-reference, tried immediately after its more
+    // specific `excess` sibling above (the `excess` token stops this arm's verb
+    // tag, so the two can never contend). Both are `all_consuming`, so neither can
+    // partially consume the other's clause.
+    if let Some(condition) = parse_previous_effect_typed_damage_recipient_condition(lower.as_str())
+    {
+        return Some(condition);
+    }
+
     if let Some(condition) = parse_die_result_condition(lower.as_str()) {
         return Some(condition);
     }
@@ -6702,33 +6714,101 @@ fn parse_previous_effect_excess_damage_condition(lower: &str) -> Option<AbilityC
     })
 }
 
-/// CR 120.3 + CR 608.2c: "a player is dealt damage this way" gates a rider
-/// on both the recipient and the damage event emitted by the preceding
-/// instruction. Deal-damage targets are either players or permanents, so a
-/// player target is represented by the negated permanent match; the total
-/// channel prevents the rider from firing when all damage was prevented.
-fn parse_previous_effect_player_damage_condition(lower: &str) -> Option<AbilityCondition> {
-    all_consuming(tag::<_, _, OracleError<'_>>(
-        "a player is dealt damage this way",
-    ))
-    .parse(lower)
-    .ok()?;
-    Some(AbilityCondition::And {
-        conditions: vec![
-            AbilityCondition::PreviousEffectAmount {
-                comparator: Comparator::GT,
-                rhs: QuantityExpr::Fixed { value: 0 },
-                channel: DamageChannel::Total,
-            },
-            AbilityCondition::Not {
-                condition: Box::new(AbilityCondition::TargetMatchesFilter {
-                    filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Permanent)),
-                    use_lki: true,
+/// CR 120.3 + CR 608.2c: "[recipient] is dealt damage this way" gates a rider on
+/// both the recipient and the damage event emitted by the preceding instruction.
+/// Recognition is delegated to [`nom_condition::parse_damaged_this_way_clause`],
+/// the single authority for this clause's grammar; this function owns only the
+/// lowering of the recipient axis into an `AbilityCondition`.
+fn parse_previous_effect_damage_recipient_condition(
+    lower: &str,
+) -> Option<DamagedThisWayRecipient> {
+    all_consuming(nom_condition::parse_damaged_this_way_clause)
+        .parse(lower)
+        .ok()
+        .map(|(_, recipient)| recipient)
+}
+
+/// CR 120.3 + CR 615.1: lower a parsed "dealt damage this way" recipient into the
+/// resolution-time gate.
+///
+/// Both arms conjoin `PreviousEffectAmount { GT 0, Total }`: CR 615.1 prevention
+/// shields can reduce the dealt amount to zero, in which case nothing "is dealt
+/// damage this way" and the rider must not fire.
+///
+/// Deal-damage targets are either players or permanents (CR 120.3), so the
+/// player arm is the *negated* permanent match while the typed arm is a positive
+/// filter match. The typed arm additionally conjoins
+/// [`AbilityCondition::HasObjectTarget`]: `TargetMatchesFilter` falls back to
+/// `TargetFilter::TriggeringSource` when the ability carries no object target
+/// (`game/effects/mod.rs`), which in a *triggered* ability would bind the
+/// anaphor to the ability's own source rather than to a damage recipient. `And`
+/// short-circuits, so the guard stops that fallback from ever being consulted
+/// when the damage landed on a player.
+fn previous_effect_damage_recipient_to_condition(
+    recipient: DamagedThisWayRecipient,
+) -> AbilityCondition {
+    let damage_was_dealt = AbilityCondition::PreviousEffectAmount {
+        comparator: Comparator::GT,
+        rhs: QuantityExpr::Fixed { value: 0 },
+        channel: DamageChannel::Total,
+    };
+    match recipient {
+        DamagedThisWayRecipient::Player => AbilityCondition::And {
+            conditions: vec![
+                damage_was_dealt,
+                AbilityCondition::Not {
+                    condition: Box::new(AbilityCondition::TargetMatchesFilter {
+                        filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Permanent)),
+                        use_lki: true,
+                        subject_slot: None,
+                    }),
+                },
+            ],
+        },
+        // CR 704.3 + CR 400.7: `use_lki: false`. The rider resolves inside the
+        // same resolution that dealt the damage, and state-based actions are
+        // checked only when a player would receive priority — so the damaged
+        // permanent has not been destroyed yet and is still the same object.
+        // There is no zone change, so last-known information never applies.
+        DamagedThisWayRecipient::Typed(filter) => AbilityCondition::And {
+            conditions: vec![
+                damage_was_dealt,
+                AbilityCondition::HasObjectTarget,
+                AbilityCondition::TargetMatchesFilter {
+                    filter,
+                    use_lki: false,
                     subject_slot: None,
-                }),
-            },
-        ],
-    })
+                },
+            ],
+        },
+    }
+}
+
+/// CR 120.3 + CR 608.2c: the player-recipient arm of the "dealt damage this way"
+/// gate. Kept as a distinct entry point because it is dispatched from the
+/// body-scoped call site rather than the general condition dispatcher — see the
+/// dispatch-asymmetry note on [`DamagedThisWayRecipient`].
+fn parse_previous_effect_player_damage_condition(lower: &str) -> Option<AbilityCondition> {
+    match parse_previous_effect_damage_recipient_condition(lower)? {
+        recipient @ DamagedThisWayRecipient::Player => {
+            Some(previous_effect_damage_recipient_to_condition(recipient))
+        }
+        DamagedThisWayRecipient::Typed(_) => None,
+    }
+}
+
+/// CR 120.3 + CR 608.2c: the typed-recipient arm of the "dealt damage this way"
+/// gate — "if a Dragon is dealt damage this way, destroy it" (The Black Arrow),
+/// "if a creature is dealt damage this way, …". Wired into the general condition
+/// dispatcher so it composes with any rider body; see the dispatch-asymmetry
+/// note on [`DamagedThisWayRecipient`] for why the player arm is not.
+fn parse_previous_effect_typed_damage_recipient_condition(lower: &str) -> Option<AbilityCondition> {
+    match parse_previous_effect_damage_recipient_condition(lower)? {
+        typed @ DamagedThisWayRecipient::Typed(_) => {
+            Some(previous_effect_damage_recipient_to_condition(typed))
+        }
+        DamagedThisWayRecipient::Player => None,
+    }
 }
 
 /// CR 701.8a + CR 608.2c: Vohar's drain checks the card discarded by the
@@ -8852,6 +8932,120 @@ mod tests {
             Some(AbilityCondition::Not { condition })
                 if matches!(*condition, AbilityCondition::SourceMatchesFilter { .. })
         ));
+    }
+
+    /// CR 120.3 + CR 608.2c: The Black Arrow — "If a Dragon is dealt damage this
+    /// way, destroy it." The Dragon gate must survive as a condition; dropping it
+    /// makes the rider destroy every damaged creature.
+    #[test]
+    fn leading_dragon_dealt_damage_this_way_gates_the_rider() {
+        let (condition, body) = strip_leading_general_conditional(
+            "If a Dragon is dealt damage this way, destroy it.",
+            &mut ParseContext::default(),
+        );
+        assert_eq!(body, "destroy it.");
+        let Some(AbilityCondition::And { conditions }) = condition else {
+            panic!("expected a conjunction gate, got {condition:?}");
+        };
+        // CR 615.1: fully prevented damage means nothing was dealt this way.
+        assert!(
+            conditions.contains(&AbilityCondition::PreviousEffectAmount {
+                comparator: Comparator::GT,
+                rhs: QuantityExpr::Fixed { value: 0 },
+                channel: DamageChannel::Total,
+            })
+        );
+        // Guards the `TargetMatchesFilter` fallback to the triggering source.
+        assert!(conditions.contains(&AbilityCondition::HasObjectTarget));
+        // CR 704.3 + CR 400.7: present tense, not LKI — SBAs have not run yet.
+        assert!(
+            conditions.iter().any(|condition| matches!(
+                condition,
+                AbilityCondition::TargetMatchesFilter {
+                    filter: TargetFilter::Typed(filter),
+                    use_lki: false,
+                    subject_slot: None,
+                } if filter.type_filters.iter().any(
+                    |f| matches!(f, TypeFilter::Subtype(s) if s.eq_ignore_ascii_case("Dragon"))
+                )
+            )),
+            "expected a Dragon recipient filter, got {conditions:?}"
+        );
+    }
+
+    /// The gate is parameterized over the recipient noun and independent of the
+    /// rider body — it is a condition production, not a per-card carve-out.
+    #[test]
+    fn leading_dealt_damage_this_way_covers_the_recipient_class() {
+        for (text, expected_body) in [
+            (
+                "If a creature is dealt damage this way, exile it.",
+                "exile it.",
+            ),
+            (
+                "If an artifact creature is dealt damage this way, destroy it.",
+                "destroy it.",
+            ),
+            (
+                "If a permanent is dealt damage this way, scry 1.",
+                "scry 1.",
+            ),
+        ] {
+            let (condition, body) =
+                strip_leading_general_conditional(text, &mut ParseContext::default());
+            assert_eq!(body, expected_body, "{text:?}");
+            assert!(
+                matches!(condition, Some(AbilityCondition::And { .. })),
+                "{text:?} must produce a gated rider, got {condition:?}"
+            );
+        }
+    }
+
+    /// The player arm keeps its own lowering (negated permanent match) and is not
+    /// claimed by the typed arm — Play with Fire's AST must be unchanged.
+    #[test]
+    fn player_dealt_damage_this_way_keeps_the_negated_permanent_shape() {
+        let condition =
+            parse_previous_effect_player_damage_condition("a player is dealt damage this way")
+                .expect("the player recipient must still lower");
+        let AbilityCondition::And { conditions } = condition else {
+            panic!("expected a conjunction gate");
+        };
+        assert!(conditions.iter().any(|condition| matches!(
+            condition,
+            AbilityCondition::Not { condition }
+                if matches!(condition.as_ref(), AbilityCondition::TargetMatchesFilter {
+                    filter: TargetFilter::Typed(filter),
+                    use_lki: true,
+                    ..
+                } if filter.type_filters == vec![TypeFilter::Permanent])
+        )));
+        assert!(
+            parse_previous_effect_typed_damage_recipient_condition(
+                "a player is dealt damage this way"
+            )
+            .is_none(),
+            "the typed arm must not claim the player recipient"
+        );
+    }
+
+    /// The `excess` channel is the lexically more specific sibling and keeps its
+    /// clause; the plain-damage arm must not shadow it.
+    #[test]
+    fn excess_damage_this_way_still_lowers_to_the_excess_channel() {
+        let (condition, body) = strip_leading_general_conditional(
+            "If a creature is dealt excess damage this way, draw a card.",
+            &mut ParseContext::default(),
+        );
+        assert_eq!(body, "draw a card.");
+        assert_eq!(
+            condition,
+            Some(AbilityCondition::PreviousEffectAmount {
+                comparator: Comparator::GT,
+                rhs: QuantityExpr::Fixed { value: 0 },
+                channel: DamageChannel::Excess,
+            })
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -18945,6 +18945,30 @@ mod tests {
                 "{input:?} must be a typed recipient, got {recipient:?}"
             );
         }
+
+        let (rest, recipient) =
+            parse_damaged_this_way_clause("a dragon or a wurm is dealt damage this way")
+                .expect("a disjunctive typed recipient must parse");
+        assert_eq!(rest, "", "the disjunctive recipient must be fully consumed");
+        let DamagedThisWayRecipient::Typed(TargetFilter::Or { filters }) = recipient else {
+            panic!("expected a disjunctive typed recipient, got {recipient:?}");
+        };
+        assert_eq!(
+            filters.len(),
+            2,
+            "both disjunctive subtype branches must remain"
+        );
+        for (filter, subtype) in filters.iter().zip(["Dragon", "Wurm"]) {
+            let TargetFilter::Typed(TypedFilter { type_filters, .. }) = filter else {
+                panic!("expected a typed {subtype} branch, got {filter:?}");
+            };
+            assert!(
+                type_filters.iter().any(
+                    |type_filter| matches!(type_filter, TypeFilter::Subtype(name) if name.eq_ignore_ascii_case(subtype))
+                ),
+                "expected the {subtype} subtype branch, got {type_filters:?}"
+            );
+        }
     }
 
     /// The `excess` channel keeps exclusive ownership of its clause: the

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -9290,6 +9290,109 @@ pub fn parse_zone_changed_this_way_clause_scoped(
     Ok((rest, (filter, negated)))
 }
 
+/// CR 120.3 + CR 608.2c: the recipient axis of a "… is dealt damage this way"
+/// back-reference. CR 120.3 splits damage results by whether the recipient is a
+/// player or a permanent, so the recipient is the parameter this grammar varies
+/// over — not a per-card literal.
+///
+/// The two arms lower to structurally different conditions (see
+/// `oracle_effect::conditions`): `Player` is the *absence* of an object
+/// recipient, `Typed` is a positive filter match on the object recipient.
+///
+/// DISPATCH ASYMMETRY (deliberate, grammatical — not a card carve-out): only
+/// the `Typed` arm is wired into the general condition dispatcher. The general
+/// dispatcher is reached through `clause_shell::peel_clause`, which strips the
+/// recognized condition head off the body. `Typed` riders have self-contained
+/// imperative bodies ("destroy it"), so peeling is harmless. `Player` riders are
+/// pronoun-headed ("they discard a card", "they can't gain life…") and the head
+/// is what supplies the pronoun's antecedent — `oracle_effect::subject`'s
+/// `strip_dealt_damage_this_way_player_anaphor` must see the *whole* sentence to
+/// bind the restriction to `ParentTarget` (Screaming Nemesis, Hordewing Skaab).
+/// Migrating the `Player` arm onto the general dispatcher requires first moving
+/// those pronoun-body recognizers off the un-peeled text.
+#[derive(Debug, Clone, PartialEq)]
+pub enum DamagedThisWayRecipient {
+    /// "a player is dealt damage this way" (Play with Fire, Screaming Nemesis).
+    Player,
+    /// "a Dragon / a creature / an artifact creature / a permanent is dealt
+    /// damage this way" (The Black Arrow).
+    Typed(TargetFilter),
+}
+
+/// CR 120.3 + CR 608.2c: Parse "[quantifier] [recipient] (is|are|was|were) dealt
+/// damage this way" — the recipient-anaphoric clause that gates a rider on who
+/// the parent instruction's damage actually landed on.
+///
+/// This is the plain-damage sibling of [`parse_zone_changed_this_way_clause`]
+/// (zone-change verbs) and of `parse_previous_effect_excess_damage_condition`
+/// (the `excess` channel). It shares the same article × subject × tense × verb
+/// axes, so a new recipient noun is a `parse_type_phrase` concern, not a new
+/// `tag` arm here.
+///
+/// `"dealt excess damage this way"` cannot match: the `excess` token stops the
+/// `"dealt damage"` verb tag, so the excess channel keeps exclusive ownership of
+/// its class.
+///
+/// No negation arm: no printed card says "isn't dealt damage this way", and the
+/// negated form's correct lowering is not a plain `Not` over the conjunction
+/// (the prevented-damage guard would invert with it). Fail closed instead.
+pub fn parse_damaged_this_way_clause(input: &str) -> OracleResult<'_, DamagedThisWayRecipient> {
+    // CR 608.2c: quantifier axis — shared verbatim with the zone-change sibling.
+    // "at least one" / "one or more" / bare article all encode the same
+    // existential "≥ 1 recipient" reading.
+    let (rest, _) = alt((
+        value((), tag::<_, _, OracleError<'_>>("at least one ")),
+        value((), tag("one or more ")),
+        parse_article,
+    ))
+    .parse(input)?;
+
+    // CR 120.3: recipient axis. The player arm is tried first so the typed arm's
+    // vacuity guard never has to reason about the word "player".
+    let (rest, recipient) = alt((
+        value(DamagedThisWayRecipient::Player, tag("player")),
+        parse_damaged_this_way_typed_recipient,
+    ))
+    .parse(rest)?;
+
+    // `parse_type_phrase` returns a slice of its input; trim any whitespace it
+    // left between the noun phrase and the tense verb so the next `tag` matches
+    // cleanly (same normalization the zone-change sibling performs).
+    let rest = rest.trim_start();
+
+    // tense: singular "is"/"was" + plural "are"/"were". Verb number is
+    // grammatically inert here — the condition is existential either way.
+    let (rest, _) = alt((
+        value((), tag::<_, _, OracleError<'_>>("is ")),
+        value((), tag("are ")),
+        value((), tag("was ")),
+        value((), tag("were ")),
+    ))
+    .parse(rest)?;
+
+    let (rest, _) = tag("dealt damage").parse(rest)?;
+    let (rest, _) = tag(" this way").parse(rest)?;
+    Ok((rest, recipient))
+}
+
+/// CR 120.3 + CR 205: the typed-recipient arm of [`parse_damaged_this_way_clause`].
+/// Delegates the noun phrase to [`parse_type_phrase`] — the declared authority for
+/// type/subtype phrases — and folds a `" or a [type]"` continuation through the
+/// shared [`fold_this_way_subject_disjunction`], so a disjunctive recipient sharing
+/// one verb ("a Dragon or a Wurm is dealt damage this way") stays one condition.
+fn parse_damaged_this_way_typed_recipient(
+    input: &str,
+) -> OracleResult<'_, DamagedThisWayRecipient> {
+    let (filter, after_filter) = parse_type_phrase(input);
+    // Fail closed on a vacuous or non-consuming parse, mirroring the zone-change
+    // sibling: `TargetFilter::Any` means the noun was not recognized at all.
+    if matches!(filter, TargetFilter::Any) || after_filter.len() == input.len() {
+        return Err(oracle_err(input));
+    }
+    let (filter, after_filter) = fold_this_way_subject_disjunction(filter, after_filter);
+    Ok((after_filter, DamagedThisWayRecipient::Typed(filter)))
+}
+
 /// CR 608.2c: the bare pronoun subject of a reflexive battlefield-entry
 /// back-reference — "it enters this way" (Pharika's Spawn, Silver Surfer).
 /// Delegates the pronoun set to [`parse_object_recipient_pronoun`], the declared
@@ -18790,6 +18893,75 @@ mod tests {
                 });
             assert_eq!(rest, ", x", "verb {verb} produced wrong remainder");
             assert!(!negated);
+        }
+    }
+
+    /// CR 120.3: the typed recipient arm — The Black Arrow's "if a Dragon is
+    /// dealt damage this way, destroy it".
+    #[test]
+    fn test_damaged_this_way_typed_recipient() {
+        let (rest, recipient) =
+            parse_damaged_this_way_clause("a dragon is dealt damage this way, destroy it").unwrap();
+        assert_eq!(rest, ", destroy it");
+        match recipient {
+            DamagedThisWayRecipient::Typed(TargetFilter::Typed(TypedFilter {
+                type_filters,
+                ..
+            })) => assert!(
+                type_filters.iter().any(
+                    |f| matches!(f, TypeFilter::Subtype(s) if s.eq_ignore_ascii_case("Dragon"))
+                ),
+                "expected Subtype Dragon, got {type_filters:?}"
+            ),
+            other => panic!("expected a typed recipient, got {other:?}"),
+        }
+    }
+
+    /// CR 120.3: the player recipient arm — Play with Fire / Screaming Nemesis.
+    /// Must not be swallowed by the typed arm.
+    #[test]
+    fn test_damaged_this_way_player_recipient() {
+        let (rest, recipient) =
+            parse_damaged_this_way_clause("a player is dealt damage this way, scry 1").unwrap();
+        assert_eq!(rest, ", scry 1");
+        assert_eq!(recipient, DamagedThisWayRecipient::Player);
+    }
+
+    /// The recipient axis is a `parse_type_phrase` concern, so the whole class
+    /// of nouns comes for free — plural verbs included.
+    #[test]
+    fn test_damaged_this_way_recipient_class() {
+        for input in [
+            "a creature is dealt damage this way",
+            "an artifact creature is dealt damage this way",
+            "a permanent is dealt damage this way",
+            "one or more creatures are dealt damage this way",
+        ] {
+            let (rest, recipient) = parse_damaged_this_way_clause(input)
+                .unwrap_or_else(|e| panic!("{input:?} must parse: {e:?}"));
+            assert_eq!(rest, "", "{input:?} must be fully consumed");
+            assert!(
+                matches!(recipient, DamagedThisWayRecipient::Typed(_)),
+                "{input:?} must be a typed recipient, got {recipient:?}"
+            );
+        }
+    }
+
+    /// The `excess` channel keeps exclusive ownership of its clause: the
+    /// `excess` token stops the plain-damage verb tag. Unrecognized nouns and a
+    /// missing recipient both fail closed.
+    #[test]
+    fn test_damaged_this_way_rejects_other_channels() {
+        for input in [
+            "a dragon is dealt excess damage this way",
+            "a thing is dealt damage this way",
+            "is dealt damage this way",
+            "a dragon was destroyed this way",
+        ] {
+            assert!(
+                parse_damaged_this_way_clause(input).is_err(),
+                "{input:?} must not be claimed by the plain-damage channel"
+            );
         }
     }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1028,6 +1028,7 @@ mod terra_herald_optional_prompt;
 mod terra_magical_adept_milled_enchantment;
 mod terror_of_the_peaks_issue_2911;
 mod teysa_wojek_investigate_per_opponent;
+mod the_black_arrow_dragon_gated_destroy;
 mod the_chain_veil_loyalty_grants;
 mod the_fourteenth_doctor_graveyard_copy;
 mod the_immortal_sun;

--- a/crates/engine/tests/integration/the_black_arrow_dragon_gated_destroy.rs
+++ b/crates/engine/tests/integration/the_black_arrow_dragon_gated_destroy.rs
@@ -187,6 +187,7 @@ fn cast_the_black_arrow(target: ArrowTarget, prevent_damage: bool) -> (Zone, u32
             "Dragon Shield".into(),
             Zone::Stack,
         );
+        // CR 615.1: Prevention effects apply as damage events happen.
         let prevention = ResolvedAbility::new(
             Effect::PreventDamage {
                 amount: PreventionAmount::All,

--- a/crates/engine/tests/integration/the_black_arrow_dragon_gated_destroy.rs
+++ b/crates/engine/tests/integration/the_black_arrow_dragon_gated_destroy.rs
@@ -218,6 +218,7 @@ fn cast_the_black_arrow(target: ArrowTarget, prevent_damage: bool) -> (Zone, u32
         ArrowTarget::Dragon | ArrowTarget::NonDragon => TargetRef::Object(victim),
     };
 
+    let mut settled = false;
     for _ in 0..32 {
         match runner.state().waiting_for.clone() {
             WaitingFor::TriggerTargetSelection { .. } | WaitingFor::TargetSelection { .. } => {
@@ -227,7 +228,10 @@ fn cast_the_black_arrow(target: ArrowTarget, prevent_damage: bool) -> (Zone, u32
                     })
                     .expect("selecting The Black Arrow's ETB target must succeed");
             }
-            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => {
+                settled = true;
+                break;
+            }
             WaitingFor::Priority { .. } => {
                 runner
                     .act(GameAction::PassPriority)
@@ -236,6 +240,10 @@ fn cast_the_black_arrow(target: ArrowTarget, prevent_damage: bool) -> (Zone, u32
             other => panic!("unexpected The Black Arrow prompt: {other:?}"),
         }
     }
+    assert!(
+        settled,
+        "The Black Arrow must fully resolve before inspecting the damage recipient"
+    );
 
     let state = runner.state();
     let (zone, damage) = state
@@ -336,6 +344,7 @@ fn a_permanent_rider_does_not_fall_back_to_its_creature_source_for_a_player_targ
         })
         .expect("casting the creature source must succeed");
 
+    let mut settled = false;
     for _ in 0..32 {
         match runner.state().waiting_for.clone() {
             WaitingFor::TriggerTargetSelection { .. } | WaitingFor::TargetSelection { .. } => {
@@ -345,7 +354,10 @@ fn a_permanent_rider_does_not_fall_back_to_its_creature_source_for_a_player_targ
                     })
                     .expect("selecting the player damage target must succeed");
             }
-            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => {
+                settled = true;
+                break;
+            }
             WaitingFor::Priority { .. } => {
                 runner
                     .act(GameAction::PassPriority)
@@ -354,6 +366,10 @@ fn a_permanent_rider_does_not_fall_back_to_its_creature_source_for_a_player_targ
             other => panic!("unexpected permanent-rider prompt: {other:?}"),
         }
     }
+    assert!(
+        settled,
+        "the permanent-rider source must fully resolve before inspecting the game state"
+    );
 
     assert_eq!(
         runner.state().players[P1.0 as usize].life,

--- a/crates/engine/tests/integration/the_black_arrow_dragon_gated_destroy.rs
+++ b/crates/engine/tests/integration/the_black_arrow_dragon_gated_destroy.rs
@@ -1,0 +1,249 @@
+//! The Black Arrow's ETB rider destroys the damaged permanent only when it is a
+//! Dragon.
+//!
+//! CR 120.3 + CR 608.2c: "If a Dragon is dealt damage this way, destroy it" is a
+//! back-reference gated on the *recipient* of the preceding damage instruction.
+//! Before the "dealt damage this way" damage channel existed in the condition
+//! grammar, the clause head was dropped and the rider lowered to an
+//! unconditional `Effect::Destroy { target: ParentTarget }` — killing every
+//! damaged creature.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::parser::oracle_ir::diagnostic::OracleDiagnostic;
+use engine::types::ability::{
+    AbilityCondition, Comparator, DamageChannel, Effect, QuantityExpr, TargetFilter, TargetRef,
+};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const THE_BLACK_ARROW: &str = "Flash\n\
+When The Black Arrow enters, it deals 1 damage to any target. \
+If a Dragon is dealt damage this way, destroy it.\n\
+Equipped creature gets +1/+1 and has reach.\n\
+Equip {1}";
+
+/// The damage recipient the ETB trigger is pointed at.
+enum ArrowTarget {
+    Dragon,
+    NonDragon,
+    Player,
+}
+
+#[test]
+fn the_black_arrow_parses_dragon_gated_destroy_rider() {
+    let parsed = parse_oracle_text(
+        THE_BLACK_ARROW,
+        "The Black Arrow",
+        &["Flash".into()],
+        &["Artifact".into()],
+        &["Equipment".into()],
+    );
+
+    assert!(
+        !parsed
+            .abilities
+            .iter()
+            .chain(
+                parsed
+                    .triggers
+                    .iter()
+                    .filter_map(|trigger| trigger.execute.as_deref()),
+            )
+            .any(|ability| matches!(*ability.effect, Effect::Unimplemented { .. })),
+        "no clause of The Black Arrow may fall back to Unimplemented: {parsed:?}"
+    );
+
+    let etb = parsed
+        .triggers
+        .first()
+        .expect("The Black Arrow must have an enters-the-battlefield trigger")
+        .execute
+        .as_deref()
+        .expect("the ETB trigger must have an effect");
+    let rider = etb
+        .sub_ability
+        .as_ref()
+        .expect("the damage clause must carry a conditional destroy rider");
+
+    assert!(
+        matches!(
+            *rider.effect,
+            Effect::Destroy {
+                target: TargetFilter::ParentTarget,
+                ..
+            }
+        ),
+        "the rider must destroy the damaged permanent: {:?}",
+        rider.effect
+    );
+
+    let Some(AbilityCondition::And { conditions }) = &rider.condition else {
+        panic!(
+            "the destroy rider must retain its Dragon gate: {:?}",
+            rider.condition
+        );
+    };
+
+    // CR 615.1: prevented damage means nothing was "dealt damage this way".
+    assert!(
+        conditions.iter().any(|condition| matches!(
+            condition,
+            AbilityCondition::PreviousEffectAmount {
+                comparator: Comparator::GT,
+                rhs: QuantityExpr::Fixed { value: 0 },
+                channel: DamageChannel::Total,
+            }
+        )),
+        "the rider must require damage to actually be dealt: {conditions:?}"
+    );
+    // Without this guard the filter match falls back to the trigger source, which
+    // in an ETB trigger is The Black Arrow itself.
+    assert!(
+        conditions
+            .iter()
+            .any(|condition| matches!(condition, AbilityCondition::HasObjectTarget)),
+        "the rider must require an object recipient: {conditions:?}"
+    );
+    // CR 704.3: SBAs never run mid-resolution, so the damaged Dragon is still the
+    // same battlefield object — present tense, not LKI.
+    assert!(
+        conditions.iter().any(|condition| matches!(
+            condition,
+            AbilityCondition::TargetMatchesFilter {
+                use_lki: false,
+                subject_slot: None,
+                ..
+            }
+        )),
+        "the rider must gate on the recipient's current characteristics: {conditions:?}"
+    );
+
+    assert!(
+        !parsed.parse_warnings.iter().any(|warning| matches!(
+            warning,
+            OracleDiagnostic::SwallowedClause { detector, .. } if detector == "Condition_If"
+        )),
+        "the represented Dragon gate must not be reported as swallowed: {:?}",
+        parsed.parse_warnings
+    );
+}
+
+/// Casts The Black Arrow, points its ETB damage at `target`, and returns
+/// `(victim_zone, victim_damage_marked, defending_player_life)`.
+fn cast_the_black_arrow(target: ArrowTarget) -> (Zone, u32, i32) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let subtypes = match target {
+        ArrowTarget::Dragon => vec!["Dragon"],
+        // A Bear is the control case: same toughness, no Dragon subtype.
+        ArrowTarget::NonDragon | ArrowTarget::Player => vec!["Bear"],
+    };
+    // Toughness 2 so 1 damage is never lethal on its own — any death must come
+    // from the rider, not from CR 704.5g.
+    let victim = scenario
+        .add_creature(P1, "Damage Recipient", 2, 2)
+        .with_subtypes(subtypes)
+        .id();
+
+    let arrow = scenario
+        .add_artifact_to_hand_from_oracle(P0, "The Black Arrow", THE_BLACK_ARROW)
+        .with_subtypes(vec!["Equipment"])
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![],
+            generic: 3,
+        })
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Colorless, ObjectId(9_901), false, vec![]),
+            ManaUnit::new(ManaType::Colorless, ObjectId(9_902), false, vec![]),
+            ManaUnit::new(ManaType::Colorless, ObjectId(9_903), false, vec![]),
+        ],
+    );
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&arrow].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: arrow,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting The Black Arrow must succeed");
+
+    let chosen = match target {
+        ArrowTarget::Player => TargetRef::Player(P1),
+        ArrowTarget::Dragon | ArrowTarget::NonDragon => TargetRef::Object(victim),
+    };
+
+    for _ in 0..32 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::TriggerTargetSelection { .. } | WaitingFor::TargetSelection { .. } => {
+                runner
+                    .act(GameAction::SelectTargets {
+                        targets: vec![chosen.clone()],
+                    })
+                    .expect("selecting The Black Arrow's ETB target must succeed");
+            }
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("passing priority must succeed");
+            }
+            other => panic!("unexpected The Black Arrow prompt: {other:?}"),
+        }
+    }
+
+    let state = runner.state();
+    let (zone, damage) = state
+        .objects
+        .get(&victim)
+        .map_or((Zone::Graveyard, 0), |object| {
+            (object.zone, object.damage_marked)
+        });
+    (zone, damage, state.players[P1.0 as usize].life)
+}
+
+#[test]
+fn the_black_arrow_destroys_a_damaged_dragon() {
+    let (zone, _, life) = cast_the_black_arrow(ArrowTarget::Dragon);
+    assert_eq!(
+        zone,
+        Zone::Graveyard,
+        "a Dragon dealt damage this way must be destroyed"
+    );
+    assert_eq!(life, 20, "damaging a creature must not change player life");
+}
+
+#[test]
+fn the_black_arrow_spares_a_damaged_non_dragon() {
+    let (zone, damage, life) = cast_the_black_arrow(ArrowTarget::NonDragon);
+    assert_eq!(
+        zone,
+        Zone::Battlefield,
+        "a non-Dragon dealt damage this way must survive — the destroy rider is Dragon-gated"
+    );
+    assert_eq!(damage, 1, "the non-Dragon must still take 1 damage");
+    assert_eq!(life, 20, "damaging a creature must not change player life");
+}
+
+#[test]
+fn the_black_arrow_damages_a_player_without_destroying_anything() {
+    let (zone, damage, life) = cast_the_black_arrow(ArrowTarget::Player);
+    assert_eq!(
+        zone,
+        Zone::Battlefield,
+        "damaging a player must not reach an untargeted creature"
+    );
+    assert_eq!(damage, 0, "the untargeted creature must take no damage");
+    assert_eq!(life, 19, "the targeted player must take 1 damage");
+}

--- a/crates/engine/tests/integration/the_black_arrow_dragon_gated_destroy.rs
+++ b/crates/engine/tests/integration/the_black_arrow_dragon_gated_destroy.rs
@@ -9,14 +9,16 @@
 //! damaged creature.
 
 use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::{effects, zones::create_object};
 use engine::parser::oracle::parse_oracle_text;
 use engine::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use engine::types::ability::{
-    AbilityCondition, Comparator, DamageChannel, Effect, QuantityExpr, TargetFilter, TargetRef,
+    AbilityCondition, Comparator, DamageChannel, Effect, PreventionAmount, PreventionScope,
+    QuantityExpr, ResolvedAbility, TargetFilter, TargetRef,
 };
 use engine::types::actions::GameAction;
 use engine::types::game_state::{CastPaymentMode, WaitingFor};
-use engine::types::identifiers::ObjectId;
+use engine::types::identifiers::{CardId, ObjectId};
 use engine::types::mana::{ManaCost, ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
@@ -26,6 +28,10 @@ When The Black Arrow enters, it deals 1 damage to any target. \
 If a Dragon is dealt damage this way, destroy it.\n\
 Equipped creature gets +1/+1 and has reach.\n\
 Equip {1}";
+
+const PERMANENT_DAMAGE_DRAW_RIDER: &str =
+    "When Permanent Rider Source enters, it deals 1 damage to any target. \
+If a permanent is dealt damage this way, draw a card.";
 
 /// The damage recipient the ETB trigger is pointed at.
 enum ArrowTarget {
@@ -135,7 +141,7 @@ fn the_black_arrow_parses_dragon_gated_destroy_rider() {
 
 /// Casts The Black Arrow, points its ETB damage at `target`, and returns
 /// `(victim_zone, victim_damage_marked, defending_player_life)`.
-fn cast_the_black_arrow(target: ArrowTarget) -> (Zone, u32, i32) {
+fn cast_the_black_arrow(target: ArrowTarget, prevent_damage: bool) -> (Zone, u32, i32) {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
 
@@ -169,6 +175,34 @@ fn cast_the_black_arrow(target: ArrowTarget) -> (Zone, u32, i32) {
     );
 
     let mut runner = scenario.build();
+    if prevent_damage {
+        assert!(
+            matches!(&target, ArrowTarget::Dragon),
+            "the prevention fixture must protect the Dragon target"
+        );
+        let shield = create_object(
+            runner.state_mut(),
+            CardId(9_903),
+            P1,
+            "Dragon Shield".into(),
+            Zone::Stack,
+        );
+        let prevention = ResolvedAbility::new(
+            Effect::PreventDamage {
+                amount: PreventionAmount::All,
+                amount_dynamic: None,
+                target: TargetFilter::ParentTarget,
+                scope: PreventionScope::AllDamage,
+                damage_source_filter: None,
+                prevention_duration: None,
+            },
+            vec![TargetRef::Object(victim)],
+            shield,
+            P1,
+        );
+        effects::resolve_ability_chain(runner.state_mut(), &prevention, &mut vec![], 0)
+            .expect("installing the Dragon prevention shield must succeed");
+    }
     let card_id = runner.state().objects[&arrow].card_id;
     runner
         .act(GameAction::CastSpell {
@@ -215,7 +249,7 @@ fn cast_the_black_arrow(target: ArrowTarget) -> (Zone, u32, i32) {
 
 #[test]
 fn the_black_arrow_destroys_a_damaged_dragon() {
-    let (zone, _, life) = cast_the_black_arrow(ArrowTarget::Dragon);
+    let (zone, _, life) = cast_the_black_arrow(ArrowTarget::Dragon, false);
     assert_eq!(
         zone,
         Zone::Graveyard,
@@ -226,7 +260,7 @@ fn the_black_arrow_destroys_a_damaged_dragon() {
 
 #[test]
 fn the_black_arrow_spares_a_damaged_non_dragon() {
-    let (zone, damage, life) = cast_the_black_arrow(ArrowTarget::NonDragon);
+    let (zone, damage, life) = cast_the_black_arrow(ArrowTarget::NonDragon, false);
     assert_eq!(
         zone,
         Zone::Battlefield,
@@ -238,7 +272,7 @@ fn the_black_arrow_spares_a_damaged_non_dragon() {
 
 #[test]
 fn the_black_arrow_damages_a_player_without_destroying_anything() {
-    let (zone, damage, life) = cast_the_black_arrow(ArrowTarget::Player);
+    let (zone, damage, life) = cast_the_black_arrow(ArrowTarget::Player, false);
     assert_eq!(
         zone,
         Zone::Battlefield,
@@ -246,4 +280,93 @@ fn the_black_arrow_damages_a_player_without_destroying_anything() {
     );
     assert_eq!(damage, 0, "the untargeted creature must take no damage");
     assert_eq!(life, 19, "the targeted player must take 1 damage");
+}
+
+#[test]
+fn the_black_arrow_does_not_destroy_a_dragon_when_damage_is_fully_prevented() {
+    let (zone, damage, life) = cast_the_black_arrow(ArrowTarget::Dragon, true);
+    assert_eq!(
+        damage, 0,
+        "the Dragon shield must fully prevent the ETB damage (reach-guard for the zero-damage boundary)"
+    );
+    assert_eq!(
+        zone,
+        Zone::Battlefield,
+        "a fully prevented damage event must not satisfy the Dragon destroy rider"
+    );
+    assert_eq!(life, 20, "the fixture damages a creature, never a player");
+}
+
+#[test]
+fn a_permanent_rider_does_not_fall_back_to_its_creature_source_for_a_player_target() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_card_to_library_top(P0, "Reach Guard Draw");
+    let source = scenario
+        .add_creature_to_hand_from_oracle(
+            P0,
+            "Permanent Rider Source",
+            1,
+            3,
+            PERMANENT_DAMAGE_DRAW_RIDER,
+        )
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![],
+            generic: 1,
+        })
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        vec![ManaUnit::new(
+            ManaType::Colorless,
+            ObjectId(9_904),
+            false,
+            vec![],
+        )],
+    );
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&source].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: source,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting the creature source must succeed");
+
+    for _ in 0..32 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::TriggerTargetSelection { .. } | WaitingFor::TargetSelection { .. } => {
+                runner
+                    .act(GameAction::SelectTargets {
+                        targets: vec![TargetRef::Player(P1)],
+                    })
+                    .expect("selecting the player damage target must succeed");
+            }
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => break,
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("passing priority must succeed");
+            }
+            other => panic!("unexpected permanent-rider prompt: {other:?}"),
+        }
+    }
+
+    assert_eq!(
+        runner.state().players[P1.0 as usize].life,
+        19,
+        "the player target must receive the ETB damage (reach-guard for the typed rider)"
+    );
+    assert_eq!(
+        runner.state().objects[&source].zone,
+        Zone::Battlefield,
+        "the source must be a permanent, so omitting HasObjectTarget would make the fallback match"
+    );
+    assert!(
+        runner.state().players[P0.0 as usize].hand.is_empty(),
+        "a player target must not satisfy the permanent rider through the creature source fallback"
+    );
 }


### PR DESCRIPTION
"The Black Arrow" was killing everything, not just dragons. This fixes that

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for interpreting “dealt damage this way” conditions involving players and specifically typed permanents.
  - Improved recognition of varied card-text phrasing, including plural types, articles, quantifiers, and disjunctive descriptions.
  - Added support for creating artifact cards from Oracle text in game scenarios.

- **Bug Fixes**
  - Corrected damage-dependent effects to require valid targets, positive damage, and matching permanent types.
  - Improved Dragon-gated destruction effects involving damaged Dragons, non-Dragons, and players.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->