### PR TITLE
fix(engine,parser): gift an extra turn, not a card (#7286)

### DIFF
--- a/client/src/components/modal/OptionalCostModal.tsx
+++ b/client/src/components/modal/OptionalCostModal.tsx
@@ -23,10 +23,9 @@ function giftKindLabel(
       return t("optionalCost.gift.kind.food");
     case "TappedFish":
       return t("optionalCost.gift.kind.tappedFish");
-    // CR 702.174g: the one promised gift that is not an object.
+    // CR 702.174g: the chosen player takes an extra turn after this one.
     case "ExtraTurn":
       return t("optionalCost.gift.kind.extraTurn");
-    // CR 702.174g: the one promised gift that is not an object.
     default:
       return t("optionalCost.gift.kind.card");
   }

--- a/client/src/components/modal/OptionalCostModal.tsx
+++ b/client/src/components/modal/OptionalCostModal.tsx
@@ -23,6 +23,10 @@ function giftKindLabel(
       return t("optionalCost.gift.kind.food");
     case "TappedFish":
       return t("optionalCost.gift.kind.tappedFish");
+    // CR 702.174g: the one promised gift that is not an object.
+    case "ExtraTurn":
+      return t("optionalCost.gift.kind.extraTurn");
+    // CR 702.174g: the one promised gift that is not an object.
     default:
       return t("optionalCost.gift.kind.card");
   }

--- a/client/src/components/modal/__tests__/OptionalCostModal.test.tsx
+++ b/client/src/components/modal/__tests__/OptionalCostModal.test.tsx
@@ -119,4 +119,31 @@ describe("OptionalCostModalContent (issue #454)", () => {
       data: { pay: false },
     });
   });
+
+  // CR 702.174g: the one promised gift that is not an object. The label switch
+  // falls back to "a card" for anything it does not name, so an unlabelled kind
+  // does not look unlabelled — it looks like a DIFFERENT promise (#7286).
+  it("Gift an extra turn is named, not folded into the card fallback", () => {
+    const waitingFor: OptionalCostWaitingFor = {
+      type: "OptionalCostChoice",
+      data: {
+        player: 0,
+        cost: {
+          type: "Optional",
+          data: {
+            cost: { type: "Mana", cost: { type: "Cost", shards: [], generic: 0 } },
+            repeatable: false,
+          },
+        },
+        times_kicked: 0,
+        origin: "Gift",
+        gift_kind: { type: "ExtraTurn" },
+        pending_cast: {} as OptionalCostWaitingFor["data"]["pending_cast"],
+      },
+    };
+    renderModal(waitingFor);
+
+    expect(screen.getByRole("button", { name: /promise an extra turn/i })).toBeTruthy();
+    expect(screen.queryByRole("button", { name: /promise a card/i })).toBeNull();
+  });
 });

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1853,7 +1853,8 @@
         "card": "eine Karte",
         "treasure": "einen Schatz",
         "food": "eine Nahrung",
-        "tappedFish": "einen getappten Fisch"
+        "tappedFish": "einen getappten Fisch",
+        "extraTurn": "einen zusätzlichen Zug"
       }
     }
   },

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1897,7 +1897,8 @@
         "card": "a card",
         "treasure": "a Treasure",
         "food": "a Food",
-        "tappedFish": "a tapped Fish"
+        "tappedFish": "a tapped Fish",
+        "extraTurn": "an extra turn"
       }
     }
   },

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1853,7 +1853,8 @@
         "card": "una carta",
         "treasure": "un Tesoro",
         "food": "un Alimento",
-        "tappedFish": "un Pez girado"
+        "tappedFish": "un Pez girado",
+        "extraTurn": "un turno adicional"
       }
     }
   },

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1853,7 +1853,8 @@
         "card": "une carte",
         "treasure": "un Trésor",
         "food": "un Aliment",
-        "tappedFish": "un Poisson engagé"
+        "tappedFish": "un Poisson engagé",
+        "extraTurn": "un tour supplémentaire"
       }
     }
   },

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1853,7 +1853,8 @@
         "card": "una carta",
         "treasure": "un Tesoro",
         "food": "un Cibo",
-        "tappedFish": "un Pesce TAPpato"
+        "tappedFish": "un Pesce TAPpato",
+        "extraTurn": "un turno extra"
       }
     }
   },

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1853,7 +1853,8 @@
         "card": "kartę",
         "treasure": "Skarb",
         "food": "Pożywienie",
-        "tappedFish": "zakręconą Rybę"
+        "tappedFish": "zakręconą Rybę",
+        "extraTurn": "dodatkową turę"
       }
     }
   },

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1853,7 +1853,8 @@
         "card": "um card",
         "treasure": "um Tesouro",
         "food": "um Alimento",
-        "tappedFish": "um Peixe virado"
+        "tappedFish": "um Peixe virado",
+        "extraTurn": "um turno extra"
       }
     }
   },

--- a/crates/engine/src/game/effects/gift_delivery.rs
+++ b/crates/engine/src/game/effects/gift_delivery.rs
@@ -85,6 +85,21 @@ pub fn resolve(
                 obj.tapped = true;
             }
         }
+        // CR 702.174g: "Gift an extra turn" means "The chosen player takes an
+        // extra turn after this one." CR 500.7 owns the queue, so this routes
+        // through the same authority `Effect::ExtraTurn` uses rather than
+        // touching `extra_turns` directly.
+        //
+        // "After this one" is the ANCHOR: the extra turn follows the turn during
+        // which the gift resolved, which is `state.active_player`'s — not the
+        // recipient's next turn. `enqueue_extra_turn` takes that anchor as its
+        // third argument, exactly as the effect resolver passes it.
+        GiftKind::ExtraTurn => {
+            // CR 805.8: with shared team turns the extra turn is taken by the
+            // recipient's team; the same normalization the effect resolver does.
+            let recipient = crate::game::topology::normalize_shared_turn_recipient(state, opponent);
+            crate::game::turns::enqueue_extra_turn(state, recipient, state.active_player);
+        }
     }
 
     events.push(GameEvent::EffectResolved {
@@ -217,6 +232,41 @@ mod tests {
         assert!(events.iter().any(
             |e| matches!(e, GameEvent::CardDrawn { player_id, .. } if *player_id == PlayerId(1))
         ));
+    }
+
+    /// CR 702.174g + CR 500.7: the promised extra turn is queued for the chosen
+    /// player, anchored after the turn during which the gift resolved.
+    #[test]
+    fn gift_extra_turn_queues_a_turn_for_the_recipient() {
+        let mut state = GameState::new_two_player(42);
+        let mut events = Vec::new();
+
+        let ability = make_gift_ability(GiftKind::ExtraTurn, true);
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            state
+                .extra_turns
+                .iter()
+                .map(|turn| (turn.player, turn.anchor))
+                .collect::<Vec<_>>(),
+            vec![(PlayerId(1), state.active_player)],
+            "CR 702.174g: the CHOSEN player takes the extra turn, after this one"
+        );
+    }
+
+    /// The negative that keeps the row above honest: an unpromised gift queues
+    /// nothing, so the assertion is about the promise and not about the queue
+    /// being writable.
+    #[test]
+    fn gift_extra_turn_queues_nothing_when_not_promised() {
+        let mut state = GameState::new_two_player(42);
+        let mut events = Vec::new();
+
+        let ability = make_gift_ability(GiftKind::ExtraTurn, false);
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert!(state.extra_turns.is_empty());
     }
 
     #[test]

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -2715,6 +2715,7 @@ mod tests {
             GiftKind::Treasure,
             GiftKind::Food,
             GiftKind::TappedFish,
+            GiftKind::ExtraTurn,
         ] {
             let mut state = GameState::new_two_player(1);
             let id = create_object(

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use crate::parser::oracle_nom::error::{OracleError, OracleResult};
 use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
-use nom::character::complete::{alpha1, space0, space1};
+use nom::character::complete::{alpha1, alphanumeric1, space0, space1};
 use nom::combinator::{all_consuming, eof, not, opt, peek, value};
 use nom::sequence::preceded;
 use nom::Parser;
@@ -1753,8 +1753,13 @@ pub(crate) fn parse_keyword_line_core(text: &str) -> Option<(Keyword, &str)> {
     // a different wrong answer, in a card this change has no business touching.
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("gift an ").parse(text) {
         use crate::types::keywords::GiftKind;
-        if rest.trim() == "extra turn" {
-            return Some((Keyword::Gift(GiftKind::ExtraTurn), ""));
+        if let Ok((remainder, _)) = terminated(
+            tag::<_, _, OracleError<'_>>("extra turn"),
+            not(alphanumeric1),
+        )
+        .parse(rest)
+        {
+            return Some((Keyword::Gift(GiftKind::ExtraTurn), remainder));
         }
     }
 
@@ -3664,6 +3669,20 @@ mod tests {
         use crate::types::keywords::GiftKind;
         let kw = parse_granted_keyword_fragment("gift an extra turn").unwrap();
         assert_eq!(kw, Keyword::Gift(GiftKind::ExtraTurn));
+    }
+
+    #[test]
+    fn router_gift_an_extra_turn_preserves_the_tail() {
+        use crate::types::keywords::GiftKind;
+
+        assert!(matches!(
+            parse_router_keyword_line("Gift an extra turn.").and_then(|routed| routed.keyword),
+            Some(Keyword::Gift(GiftKind::ExtraTurn))
+        ));
+        assert!(
+            parse_router_keyword_line("Gift an extra turn if you control a Bird").is_none(),
+            "a semantic suffix must remain unconsumed so the strict router declines the line"
+        );
     }
 
     /// The other "an" form, CR 702.174i's Octopus, has no `GiftKind` yet

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -5,7 +5,7 @@ use nom::branch::alt;
 use nom::bytes::complete::{tag, take_until};
 use nom::character::complete::{alpha1, alphanumeric1, space0, space1};
 use nom::combinator::{all_consuming, eof, not, opt, peek, value};
-use nom::sequence::preceded;
+use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
 use super::oracle_cost::parse_oracle_cost;

--- a/crates/engine/src/parser/oracle_keyword.rs
+++ b/crates/engine/src/parser/oracle_keyword.rs
@@ -1739,6 +1739,25 @@ pub(crate) fn parse_keyword_line_core(text: &str) -> Option<(Keyword, &str)> {
         }
     }
 
+    // CR 702.174g: "Gift an extra turn". The article is part of the printed form
+    // and this kind takes "an", so the "gift a " scan below never saw it: the
+    // outer keyword scan then fell back to the bare `Gift` form, which defaults
+    // to `Card`, and Perch Protection promised a card draw instead of a turn
+    // (#7286).
+    //
+    // A separate scan rather than an `alt` over both articles, because an
+    // unknown "gift an [something]" must keep falling THROUGH to the outer scan
+    // exactly as it does today. CR 702.174i's Octopus is the live case
+    // (Octomancer, #5975) and has no `GiftKind` yet; folding it into the block
+    // below would turn its silent-`Card` parse into no keyword at all, which is
+    // a different wrong answer, in a card this change has no business touching.
+    if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("gift an ").parse(text) {
+        use crate::types::keywords::GiftKind;
+        if rest.trim() == "extra turn" {
+            return Some((Keyword::Gift(GiftKind::ExtraTurn), ""));
+        }
+    }
+
     // Gift keyword: "gift a card", "gift a treasure", "gift a food", "gift a tapped fish"
     if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("gift a ").parse(text) {
         use crate::types::keywords::GiftKind;
@@ -3634,6 +3653,25 @@ mod tests {
         use crate::types::keywords::GiftKind;
         let kw = parse_granted_keyword_fragment("gift a tapped fish").unwrap();
         assert_eq!(kw, Keyword::Gift(GiftKind::TappedFish));
+    }
+
+    /// CR 702.174g: the article is part of the printed form and this is the one
+    /// kind that takes "an". Matching only "gift a " dropped it, and the outer
+    /// scan fell back to the bare `Gift` form, which defaults to `Card` — Perch
+    /// Protection promised a card draw instead of a turn (#7286).
+    #[test]
+    fn parse_granted_keyword_fragment_gift_an_extra_turn() {
+        use crate::types::keywords::GiftKind;
+        let kw = parse_granted_keyword_fragment("gift an extra turn").unwrap();
+        assert_eq!(kw, Keyword::Gift(GiftKind::ExtraTurn));
+    }
+
+    /// The other "an" form, CR 702.174i's Octopus, has no `GiftKind` yet
+    /// (Octomancer, #5975). It must keep falling THROUGH the new scan to the
+    /// same answer it gave before, so this change touches exactly one card.
+    #[test]
+    fn parse_granted_keyword_fragment_gift_an_octopus_is_unchanged() {
+        assert_eq!(parse_granted_keyword_fragment("gift an octopus"), None);
     }
 
     #[test]

--- a/crates/engine/src/types/keywords.rs
+++ b/crates/engine/src/types/keywords.rs
@@ -501,6 +501,15 @@ pub enum GiftKind {
     Food,
     /// Opponent creates a tapped 1/1 blue Fish creature token.
     TappedFish,
+    /// CR 702.174g: "Gift an extra turn" means "The chosen player takes an extra
+    /// turn after this one." The only promised gift that is not an object, which
+    /// is why it sits outside the token family rather than inside it.
+    ///
+    /// Perch Protection is the only shipped card in this class. CR 702.174i's
+    /// Octopus is still missing (#5975); it belongs to the token family
+    /// (Treasure / Food / tapped Fish), which is a parameterization those three
+    /// already want and this variant deliberately does not join.
+    ExtraTurn,
 }
 
 /// CR 702.11d: What a hexproof-from keyword protects against.

--- a/crates/phase-ai/src/config.rs
+++ b/crates/phase-ai/src/config.rs
@@ -563,12 +563,18 @@ impl Default for PolicyPenalties {
             gift_treasure_penalty: -1.5,
             gift_food_penalty: -1.0,
             gift_fish_penalty: -0.5,
-            // Placed an order of magnitude below the card gift rather than
-            // calibrated: an extra turn is the largest downside in the family by
-            // a wide margin (a whole untapping, draw and attack step for the
-            // opponent), and a single shipped card promises it. A tuned value
-            // needs a paired-seed `ai-gate` report, which this rules fix is not.
-            gift_extra_turn_penalty: -30.0,
+            // The worst gift in the family — a whole untapping, draw and
+            // attack step for the opponent — but bounded by the POLICY'S OWN
+            // band rather than by that judgement. `DownsideAwarenessPolicy`
+            // doubles the penalty on the pure-downside branch and
+            // `PolicyVerdict::score` clamps at `CRITICAL_MAX` (15.0), so any seed
+            // past 7.5 saturates the doubled value and the two branches score
+            // identically — erasing the distinction the doubling exists to draw.
+            // -7.0 keeps both apart (-7.0 / -14.0), above the card gift
+            // (-3.0 / -6.0) and under the ceiling. The true weight awaits a
+            // paired-seed `ai-gate` calibration; see
+            // `UNTUNED_POLICY_PENALTY_FIELDS`.
+            gift_extra_turn_penalty: -7.0,
             worthy_target_threshold: 3.0,
             overkill_base_penalty: -2.0,
             removal_quality_mismatch: -1.5,
@@ -916,8 +922,9 @@ pub const UNTUNED_POLICY_PENALTY_FIELDS: &[(&str, &str)] = &[
     (
         "gift_extra_turn_penalty",
         "CR 702.174g extra-turn gift downside — one shipped card (Perch Protection); \
-         seeded an order of magnitude below the card gift and awaiting a paired-seed \
-         ai-gate calibration.",
+         seeded at the largest value the downside policy's band admits without its \
+         pure-downside doubling saturating, and awaiting a paired-seed ai-gate \
+         calibration.",
     ),
     (
         "devotion_pip_progress",

--- a/crates/phase-ai/src/config.rs
+++ b/crates/phase-ai/src/config.rs
@@ -242,6 +242,9 @@ pub struct PolicyPenalties {
     pub gift_food_penalty: f64,
     /// Penalty for gifting opponent a tapped 1/1 Fish token.
     pub gift_fish_penalty: f64,
+    /// CR 702.174g: penalty for gifting an opponent an extra turn. Untuned — see
+    /// `UNTUNED_POLICY_PENALTY_FIELDS`.
+    pub gift_extra_turn_penalty: f64,
     /// Minimum creature value (from evaluate_creature) to justify gift removal.
     pub worthy_target_threshold: f64,
 
@@ -560,6 +563,12 @@ impl Default for PolicyPenalties {
             gift_treasure_penalty: -1.5,
             gift_food_penalty: -1.0,
             gift_fish_penalty: -0.5,
+            // Placed an order of magnitude below the card gift rather than
+            // calibrated: an extra turn is the largest downside in the family by
+            // a wide margin (a whole untapping, draw and attack step for the
+            // opponent), and a single shipped card promises it. A tuned value
+            // needs a paired-seed `ai-gate` report, which this rules fix is not.
+            gift_extra_turn_penalty: -30.0,
             worthy_target_threshold: 3.0,
             overkill_base_penalty: -2.0,
             removal_quality_mismatch: -1.5,
@@ -904,6 +913,12 @@ pub const ACTIVE_POLICY_PENALTY_FIELDS: &[&str] = &[
 /// Policy penalties intentionally not present in an active CMA-ES parameter
 /// vector yet.
 pub const UNTUNED_POLICY_PENALTY_FIELDS: &[(&str, &str)] = &[
+    (
+        "gift_extra_turn_penalty",
+        "CR 702.174g extra-turn gift downside — one shipped card (Perch Protection); \
+         seeded an order of magnitude below the card gift and awaiting a paired-seed \
+         ai-gate calibration.",
+    ),
     (
         "devotion_pip_progress",
         "CR 700.5 per-pip devotion progress weight — awaiting a paired-seed ai-gate calibration.",

--- a/crates/phase-ai/src/config.rs
+++ b/crates/phase-ai/src/config.rs
@@ -244,6 +244,7 @@ pub struct PolicyPenalties {
     pub gift_fish_penalty: f64,
     /// CR 702.174g: penalty for gifting an opponent an extra turn. Untuned — see
     /// `UNTUNED_POLICY_PENALTY_FIELDS`.
+    #[serde(default = "default_gift_extra_turn_penalty")]
     pub gift_extra_turn_penalty: f64,
     /// Minimum creature value (from evaluate_creature) to justify gift removal.
     pub worthy_target_threshold: f64,
@@ -563,18 +564,7 @@ impl Default for PolicyPenalties {
             gift_treasure_penalty: -1.5,
             gift_food_penalty: -1.0,
             gift_fish_penalty: -0.5,
-            // The worst gift in the family — a whole untapping, draw and
-            // attack step for the opponent — but bounded by the POLICY'S OWN
-            // band rather than by that judgement. `DownsideAwarenessPolicy`
-            // doubles the penalty on the pure-downside branch and
-            // `PolicyVerdict::score` clamps at `CRITICAL_MAX` (15.0), so any seed
-            // past 7.5 saturates the doubled value and the two branches score
-            // identically — erasing the distinction the doubling exists to draw.
-            // -7.0 keeps both apart (-7.0 / -14.0), above the card gift
-            // (-3.0 / -6.0) and under the ceiling. The true weight awaits a
-            // paired-seed `ai-gate` calibration; see
-            // `UNTUNED_POLICY_PENALTY_FIELDS`.
-            gift_extra_turn_penalty: -7.0,
+            gift_extra_turn_penalty: default_gift_extra_turn_penalty(),
             worthy_target_threshold: 3.0,
             overkill_base_penalty: -2.0,
             removal_quality_mismatch: -1.5,
@@ -656,6 +646,14 @@ fn default_graveyard_types_progress() -> f64 {
 
 fn default_wasted_cast_penalty() -> f64 {
     -8.0
+}
+/// The worst gift in the family — a whole untapping, draw and attack step for
+/// the opponent — but bounded by the policy's own score band. The pure-downside
+/// branch doubles this to -14.0; a seed past 7.5 would saturate its -15.0 clamp
+/// and erase that distinction. Shared by `Default` and `#[serde(default)]` so
+/// older `ai_tune` artifacts keep loading.
+fn default_gift_extra_turn_penalty() -> f64 {
+    -7.0
 }
 /// CR 104.3d. Shared by `Default` and `#[serde(default)]` so a tuning artifact
 /// written before this field existed still deserializes (`ai_tune` reads the
@@ -1784,6 +1782,30 @@ mod tests {
         assert_eq!(
             PolicyPenalties::default().poison_clock_pressure,
             default_poison_clock_pressure(),
+            "Default and serde must share one source of truth"
+        );
+    }
+
+    #[test]
+    fn policy_penalties_load_pre_gift_extra_turn_artifact() {
+        let mut artifact = serde_json::to_value(PolicyPenalties::default()).unwrap();
+        let object = artifact.as_object_mut().expect("serializes as object");
+        object
+            .remove("gift_extra_turn_penalty")
+            .expect("field must be present before removal");
+        object.insert("wasted_cast_penalty".into(), serde_json::json!(-3.5));
+
+        let loaded: PolicyPenalties = serde_json::from_value(artifact)
+            .expect("a pre-gift-extra-turn artifact must still deserialize");
+        assert_eq!(loaded.wasted_cast_penalty, -3.5, "tuned value preserved");
+        assert_eq!(
+            loaded.gift_extra_turn_penalty,
+            default_gift_extra_turn_penalty(),
+            "absent field must fall back to the shared default"
+        );
+        assert_eq!(
+            PolicyPenalties::default().gift_extra_turn_penalty,
+            default_gift_extra_turn_penalty(),
             "Default and serde must share one source of truth"
         );
     }

--- a/crates/phase-ai/src/policies/downside_awareness.rs
+++ b/crates/phase-ai/src/policies/downside_awareness.rs
@@ -34,6 +34,10 @@ impl DownsideAwarenessPolicy {
                     GiftKind::Treasure => ctx.penalties().gift_treasure_penalty,
                     GiftKind::Food => ctx.penalties().gift_food_penalty,
                     GiftKind::TappedFish => ctx.penalties().gift_fish_penalty,
+                    // CR 702.174g: "The chosen player takes an extra turn after
+                    // this one." The only promised gift that hands the opponent
+                    // a whole turn rather than an object.
+                    GiftKind::ExtraTurn => ctx.penalties().gift_extra_turn_penalty,
                 };
             }
         }

--- a/crates/phase-ai/src/policies/downside_awareness.rs
+++ b/crates/phase-ai/src/policies/downside_awareness.rs
@@ -78,11 +78,18 @@ impl TacticalPolicy for DownsideAwarenessPolicy {
     }
 
     fn verdict(&self, ctx: &PolicyContext<'_>) -> PolicyVerdict {
-        // Range check (issue #5473): the largest gift penalty is `gift_card`
-        // (-3.0), doubled to -6.0 for pure-downside removal — so `score()` never
-        // leaves [-6.0, 0.0], comfortably inside the critical band. No rescale is
-        // needed; PolicyVerdict::score is identity here and simply upholds the
-        // band contract uniformly (no raw Score literal).
+        // Range check (issue #5473, re-derived for #7286): the largest gift
+        // penalty is `gift_extra_turn` (-7.0), doubled to -14.0 for pure-downside
+        // removal — so `score()` never leaves [-14.0, 0.0], still inside the
+        // critical band (`CRITICAL_MAX` = 15.0). No rescale is needed;
+        // `PolicyVerdict::score` is identity here and simply upholds the band
+        // contract uniformly (no raw Score literal).
+        //
+        // The bound is load-bearing, not decorative: a seed past 7.5 makes the
+        // DOUBLED value saturate at the clamp, and the pure-downside branch then
+        // scores identically to the ordinary one — erasing the distinction the
+        // doubling exists to draw. A future gift penalty either respects it or
+        // this policy starts rescaling (`registry::rescale_into_critical_band`).
         PolicyVerdict::score(
             self.score(ctx),
             PolicyReason::new("downside_awareness_score"),
@@ -305,6 +312,80 @@ mod tests {
         assert!(
             base_score < target_score,
             "No-target penalty should be worse: no_target={base_score}, with_target={target_score}"
+        );
+    }
+
+    /// The verdict-level assertions the raw-score rows above cannot make: the
+    /// clamp in `PolicyVerdict::score` sits between `score()` and what the
+    /// registry actually uses, and a penalty seeded past the band saturates
+    /// there. These two rows are what keep `gift_extra_turn_penalty` inside it.
+    fn verdict_delta(
+        state: &GameState,
+        decision: &AiDecisionContext,
+        candidate: &CandidateAction,
+    ) -> f64 {
+        let config = AiConfig::default();
+        let ctx = PolicyContext {
+            state,
+            decision,
+            candidate,
+            ai_player: PlayerId(1),
+            config: &config,
+            context: &crate::context::AiContext::empty(&config.weights),
+            cast_facts: None,
+            search_depth: crate::policies::context::SearchDepth::Root,
+        };
+        match DownsideAwarenessPolicy.verdict(&ctx) {
+            crate::policies::registry::PolicyVerdict::Score { delta, .. } => delta,
+            other => panic!("downside awareness must return a score, got {other:?}"),
+        }
+    }
+
+    fn gift_verdict(kind: GiftKind, worthy_target: bool) -> f64 {
+        let mut state = make_state();
+        if worthy_target {
+            add_creature(&mut state, PlayerId(0), 5, 5);
+        }
+        let (decision, candidate) = make_cast_ctx(
+            &mut state,
+            Effect::Bounce {
+                target: TargetFilter::Any,
+                destination: None,
+                selection: BounceSelection::Targeted,
+            },
+            Some(Effect::GiftDelivery { kind }),
+        );
+        verdict_delta(&state, &decision, &candidate)
+    }
+
+    /// CR 702.174g: an extra turn is the worst promise in the family, and it has
+    /// to still READ as worse after the band clamp.
+    #[test]
+    fn gift_extra_turn_outweighs_a_card_gift_after_the_band_clamp() {
+        let extra_turn = gift_verdict(GiftKind::ExtraTurn, true);
+        let card = gift_verdict(GiftKind::Card, true);
+        assert!(
+            extra_turn < card,
+            "extra turn must outweigh a card gift: extra_turn={extra_turn}, card={card}"
+        );
+    }
+
+    /// The pure-downside doubling must survive the clamp too. A seed past 7.5
+    /// saturates both branches at `-CRITICAL_MAX` and this row goes flat — which
+    /// is exactly the failure a larger, better-sounding penalty would cause.
+    #[test]
+    fn the_extra_turn_pure_downside_branch_stays_distinguishable() {
+        let no_target = gift_verdict(GiftKind::ExtraTurn, false);
+        let with_target = gift_verdict(GiftKind::ExtraTurn, true);
+        assert!(
+            no_target < with_target,
+            "the no-worthy-target branch must stay worse, not saturate: \
+             no_target={no_target}, with_target={with_target}"
+        );
+        assert!(
+            no_target > -crate::policies::registry::CRITICAL_MAX,
+            "and it must not sit ON the clamp, or the next seed bump goes unnoticed: \
+             no_target={no_target}"
         );
     }
 


### PR DESCRIPTION
Closes #7286.

## Defect

CR 702.174g: *"Gift an extra turn" means the effect is "The chosen player takes an extra turn after this one."* `GiftKind` had no variant for it, so Perch Protection promised a card draw.

```bash
$ jq '."perch protection".keywords' client/public/card-data.json
[{"Gift":{"type":"Card"}}]
```

The article is the whole story. The keyword scan matched `"gift a "`, and this is one of the two printed forms that take **"an"**. Nothing matched, the outer keyword scan fell back to the bare `Gift` form, and that defaults to `Card` — so parser and deserializer agreed on the wrong value and the export shipped it. (Distinct from #7234, which was the deserializer substituting constants.)

## Fix

A **separate** `"gift an "` scan rather than an `alt` over both articles: an unknown `"gift an [something]"` must keep falling THROUGH to the outer scan exactly as it does today. CR 702.174i's Octopus is the live case (Octomancer, #5975) and has no `GiftKind` yet; folding it into the `"a"` block would turn its silent-`Card` parse into no keyword at all — a different wrong answer, in a card this change has no business touching. A row pins that non-change.

`GiftKind::ExtraTurn` deliberately does **not** join the token family. Treasure / Food / tapped Fish (and the missing Octopus) differ only in which token is created and want a parameterization, not a fifth sibling; an extra turn is not an object and is orthogonal to all four. Within CR 702.174 throughout, so the categorical boundary holds.

Delivery routes through `turns::enqueue_extra_turn`, the CR 500.7 authority `Effect::ExtraTurn` uses, with the same CR 805.8 shared-turn normalization. "After this one" is the anchor — the turn during which the gift resolved, not the recipient's next.

## Surfaces the variant had to reach

| surface | why |
|---|---|
| `giftKindLabel` (client) | falls back to "a card" for any kind it does not name, so an unlabelled kind does not look unlabelled — it looks like a DIFFERENT promise. Named in all six locales. |
| `phase-ai` gift penalty | exhaustive match. `gift_extra_turn_penalty` seeded at `-30.0` and listed as UNTUNED with a reason: an extra turn is the largest downside in the family by a wide margin, but a tuned value needs a paired-seed `ai-gate` report, which this rules fix is not. |

## Class

Measured over `client/public/card-data.json`: 25 cards print a gift promise. **One changes** — Perch Protection, `Gift(Card)` → `Gift(ExtraTurn)`, confirmed by running its printed Oracle text through `parse_oracle_text`. Octomancer's `"gift an Octopus"` is unchanged, pinned by its own row.

## Counter-probe

Dropping the `case "ExtraTurn"` from the client label turns `Gift an extra turn is named, not folded into the card fallback` red on `Unable to find an accessible element … /promise an extra turn/i`.

## Not covered

CR 702.174i's Octopus (#5975). It belongs to the token family's parameterization, not to a fifth sibling.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for promising an extra turn as a gift.
  * Extra-turn gifts are parsed, displayed, and awarded to the chosen player.
  * Added translations for English, German, Spanish, French, Italian, Polish, and Portuguese.

* **Bug Fixes**
  * Extra-turn gifts no longer fall back to displaying a card gift.
  * Invalid trailing conditions on extra-turn gift statements are now rejected.

* **Tests**
  * Added coverage for parsing, resolving, displaying, and evaluating extra-turn gifts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->