### PR TITLE
fix(ui): identify colorless decks and legend copies

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -1555,7 +1555,7 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
   });
 
   // Regression guard: the wire must carry legalActionsByObject, spellCosts,
-  // and engine-authored mana-payment shortcut actions
+  // engine-authored mana-payment shortcut actions, and derived copy views
   // across game_setup, state_update, and reconnect_ack. Dropping these fields
   // — even though the flat `legalActions` array still arrives — leaves guests
   // unable to click cards in their hand, because the frontend card-click
@@ -1578,6 +1578,8 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
       "42": { generic: 1, colored: { R: 1 } },
     };
     const manaPaymentShortcutActions: GameAction[] = [{ type: "PassPriority" }];
+    const copiedPermanents = [42];
+    const legendCandidateIdentities = { "42": "TokenCopy" as const };
     // Cast via `unknown` because the hoisted mock's default return is inferred
     // as `{ actions: never[]; autoPassRecommended: boolean }`, which would
     // reject our richer payload. The adapter consumes the full
@@ -1590,7 +1592,14 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     (mocks.getViewerSnapshot as unknown as {
       mockImplementation: (fn: (pid: number) => Promise<unknown>) => void;
     }).mockImplementation(async (pid: number) => ({
-      state: { filteredFor: pid, players: [] },
+      state: {
+        filteredFor: pid,
+        players: [],
+        derived: {
+          copied_permanents: copiedPermanents,
+          legend_candidate_identities: legendCandidateIdentities,
+        },
+      },
       actions: [
         { type: "CastSpell", data: { object_id: 42, targets: [] } },
         { type: "PlayLand", data: { object_id: 43 } },
@@ -1619,6 +1628,12 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
         legalActionsByObject?: Record<string, unknown>;
         spellCosts?: Record<string, unknown>;
         manaPaymentShortcutActions?: GameAction[];
+        state: {
+          derived?: {
+            copied_permanents?: number[];
+            legend_candidate_identities?: Record<string, string>;
+          };
+        };
       } =>
         typeof m === "object" && m !== null && (m as { type: string }).type === "game_setup",
     );
@@ -1626,6 +1641,8 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(setup!.legalActionsByObject).toEqual(legalActionsByObject);
     expect(setup!.spellCosts).toEqual(spellCosts);
     expect(setup!.manaPaymentShortcutActions).toEqual(manaPaymentShortcutActions);
+    expect(setup!.state.derived?.copied_permanents).toEqual(copiedPermanents);
+    expect(setup!.state.derived?.legend_candidate_identities).toEqual(legendCandidateIdentities);
     const playerToken = setup!.playerToken;
 
     // ── state_update ───────────────────────────────────────────────────────
@@ -1638,6 +1655,12 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
         legalActionsByObject?: Record<string, unknown>;
         spellCosts?: Record<string, unknown>;
         manaPaymentShortcutActions?: GameAction[];
+        state: {
+          derived?: {
+            copied_permanents?: number[];
+            legend_candidate_identities?: Record<string, string>;
+          };
+        };
       } =>
         typeof m === "object" && m !== null && (m as { type: string }).type === "state_update",
     );
@@ -1645,6 +1668,8 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(stateUpdate!.legalActionsByObject).toEqual(legalActionsByObject);
     expect(stateUpdate!.spellCosts).toEqual(spellCosts);
     expect(stateUpdate!.manaPaymentShortcutActions).toEqual(manaPaymentShortcutActions);
+    expect(stateUpdate!.state.derived?.copied_permanents).toEqual(copiedPermanents);
+    expect(stateUpdate!.state.derived?.legend_candidate_identities).toEqual(legendCandidateIdentities);
 
     // ── reconnect_ack ──────────────────────────────────────────────────────
     g1.simulateClose();
@@ -1663,6 +1688,12 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
         legalActionsByObject?: Record<string, unknown>;
         spellCosts?: Record<string, unknown>;
         manaPaymentShortcutActions?: GameAction[];
+        state: {
+          derived?: {
+            copied_permanents?: number[];
+            legend_candidate_identities?: Record<string, string>;
+          };
+        };
       } =>
         typeof m === "object" && m !== null && (m as { type: string }).type === "reconnect_ack",
     );
@@ -1670,6 +1701,8 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(ack!.legalActionsByObject).toEqual(legalActionsByObject);
     expect(ack!.spellCosts).toEqual(spellCosts);
     expect(ack!.manaPaymentShortcutActions).toEqual(manaPaymentShortcutActions);
+    expect(ack!.state.derived?.copied_permanents).toEqual(copiedPermanents);
+    expect(ack!.state.derived?.legend_candidate_identities).toEqual(legendCandidateIdentities);
   });
 
   it("keeps turn-controller auto-pass recommendations viewer-scoped on setup, update, and reconnect", async () => {

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2989,6 +2989,9 @@ export interface DebugLibraryCardView {
   name: string;
 }
 
+/** Engine-classified identity for a candidate in a legend-rule choice. */
+export type LegendCandidateIdentity = "Original" | "Copy" | "TokenCopy";
+
 /**
  * Engine-authored projections computed at each state snapshot. Rides
  * alongside GameState through every adapter path. Frontend components
@@ -3035,6 +3038,12 @@ export interface DerivedViews {
    * Face-down permanents are excluded per CR 708.2. Absent when empty.
    */
   copied_permanents?: ObjectId[];
+  /**
+   * CR 704.5j + CR 707.2 / CR 708.2: identity for every current legend-rule
+   * candidate. The choice modal renders this engine-authored map directly.
+   * Keyed by ObjectId-as-string and omitted when no legend choice is pending.
+   */
+  legend_candidate_identities?: Record<string, LegendCandidateIdentity>;
   /** Keyed by attacking commander's current controller (PlayerId as string). */
   commander_damage_by_attacker?: Record<string, CommanderDamageView[]>;
   /**

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -203,6 +203,11 @@ export class NativeEngineVersionMismatchError extends Error {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 32 — DerivedViews.legend_candidate_identities publishes the engine-authored
+ *      original/copy/token-copy identity for each active legend-rule choice. The
+ *      field is serde-optional, but the client deliberately no longer derives this
+ *      rules-sensitive identity from raw objects; an older server would silently
+ *      omit every choice identity.
  * 31 — WaitingFor::LoopShortcut publishes the engine-issued declaration, and
  *      InteractionResponseSpec::Shortcut publishes preview, the per-axis
  *      consequence of the offered count. Both are optional and neither type
@@ -255,7 +260,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 31;
+export const PROTOCOL_VERSION = 32;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/components/board/BattlefieldBackground.tsx
+++ b/client/src/components/board/BattlefieldBackground.tsx
@@ -17,7 +17,7 @@ function pickRandomImage(): string {
   return BATTLEFIELDS[Math.floor(Math.random() * BATTLEFIELDS.length)].image;
 }
 
-function resolveBackground(
+export function resolveBackground(
   boardBackground: BoardBackground,
   customUrl: string,
   deckColor: ManaColor | null,
@@ -37,9 +37,10 @@ function resolveBackground(
   }
 
   if (boardBackground === "auto-wubrg") {
-    // Lock in a color-matched image on first color detection (includes full deck)
-    if (deckColor && !lockedRef.current) {
-      lockedRef.current = getRandomBattlefield(deckColor).image;
+    // Lock in a color-matched image on first color detection (includes full deck).
+    // Colorless decks have no WUBRG color to match, so use the normal random pool.
+    if (!lockedRef.current) {
+      lockedRef.current = deckColor ? getRandomBattlefield(deckColor).image : pickRandomImage();
     }
     return lockedRef.current ? { kind: "image", src: lockedRef.current } : null;
   }

--- a/client/src/components/board/BattlefieldBackground.tsx
+++ b/client/src/components/board/BattlefieldBackground.tsx
@@ -20,7 +20,7 @@ function pickRandomImage(): string {
 export function resolveBackground(
   boardBackground: BoardBackground,
   customUrl: string,
-  deckColor: ManaColor | null,
+  deckColor: ManaColor | null | undefined,
   lockedRef: React.RefObject<string | null>,
 ): ResolvedBackground | null {
   if (boardBackground === "none") return null;
@@ -37,6 +37,8 @@ export function resolveBackground(
   }
 
   if (boardBackground === "auto-wubrg") {
+    if (deckColor === undefined) return null;
+
     // Lock in a color-matched image on first color detection (includes full deck).
     // Colorless decks have no WUBRG color to match, so use the normal random pool.
     if (!lockedRef.current) {
@@ -82,10 +84,10 @@ export function BattlefieldBackground() {
     // (lockedRef). For every other background mode, and on every action after
     // the lock, the result is discarded. Without this guard the scan re-ran on
     // every gameState change (mana tap, phase tick, priority pass) for nothing.
-    if (boardBackground !== "auto-wubrg" || lockedRef.current) return null;
-    if (!gameState) return null;
+    if (boardBackground !== "auto-wubrg" || lockedRef.current) return undefined;
+    if (!gameState) return undefined;
     const player = gameState.players[playerId];
-    if (!player) return null;
+    if (!player) return undefined;
     return getDeckDominantColor(
       player.library,
       player.hand,

--- a/client/src/components/board/__tests__/BattlefieldBackground.test.ts
+++ b/client/src/components/board/__tests__/BattlefieldBackground.test.ts
@@ -14,4 +14,16 @@ describe("resolveBackground", () => {
 
     expect(background).toEqual({ kind: "image", src: "/battlefield/air_angelic_sky.webp" });
   });
+
+  it("waits for deck data before locking a colored playmat", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const lock = { current: null };
+
+    expect(resolveBackground("auto-wubrg" as BoardBackground, "", undefined, lock)).toBeNull();
+
+    expect(resolveBackground("auto-wubrg" as BoardBackground, "", "Blue", lock)).toEqual({
+      kind: "image",
+      src: "/battlefield/water_moonlit_ocean_temple.webp",
+    });
+  });
 });

--- a/client/src/components/board/__tests__/BattlefieldBackground.test.ts
+++ b/client/src/components/board/__tests__/BattlefieldBackground.test.ts
@@ -1,0 +1,17 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { resolveBackground } from "../BattlefieldBackground";
+import type { BoardBackground } from "../../../stores/preferencesStore";
+
+describe("resolveBackground", () => {
+  afterEach(() => vi.restoreAllMocks());
+
+  it("selects a random playmat for colorless decks in auto-wubrg mode", () => {
+    vi.spyOn(Math, "random").mockReturnValue(0);
+    const lock = { current: null };
+
+    const background = resolveBackground("auto-wubrg" as BoardBackground, "", null, lock);
+
+    expect(background).toEqual({ kind: "image", src: "/battlefield/air_angelic_sky.webp" });
+  });
+});

--- a/client/src/components/menu/MyDecks.tsx
+++ b/client/src/components/menu/MyDecks.tsx
@@ -239,13 +239,12 @@ const DeckTile = memo(function DeckTile({ deckName, isActive, compatibility, onC
     const timer = setTimeout(() => setConfirmingDelete(false), 3000);
     return () => clearTimeout(timer);
   }, [confirmingDelete]);
-  const colors = compatibility?.color_identity?.length
-    ? compatibility.color_identity
-    : feedDeckOverride?.colors?.length
-      ? feedDeckOverride.colors
-      : preconDeckOverride
-        ? getPreconColorIdentity(preconDeckOverride)
-        : getDeckColorIdentity(deckName);
+  const colors = compatibility?.color_identity
+    ?? feedDeckOverride?.colors
+    ?? (preconDeckOverride
+      ? getPreconColorIdentity(preconDeckOverride)
+      : getDeckColorIdentity(deckName));
+  const colorPips = getDeckColorIdentityPips(colors);
   const count = feedDeckOverride
     ? feedDeckOverride.main.reduce((sum, e) => sum + e.count, 0)
     : preconDeckOverride
@@ -286,11 +285,13 @@ const DeckTile = memo(function DeckTile({ deckName, isActive, compatibility, onC
         {/* Color identity as actual Scryfall mana symbols, clustered top-right.
             A dark backing chip keeps the bright pips legible over any card art —
             without it the gold/white symbols wash out against light artwork. */}
-        <div className="absolute right-2 top-2 z-10 flex items-center gap-0.5 rounded-full bg-black/75 px-2 py-1 shadow-[0_2px_8px_rgba(0,0,0,0.6)] ring-1 ring-white/20 backdrop-blur-sm">
-          {getDeckColorIdentityPips(colors).map((color) => (
-            <ManaSymbol key={color} shard={color} size="xs" />
-          ))}
-        </div>
+        {colorPips && (
+          <div className="absolute right-2 top-2 z-10 flex items-center gap-0.5 rounded-full bg-black/75 px-2 py-1 shadow-[0_2px_8px_rgba(0,0,0,0.6)] ring-1 ring-white/20 backdrop-blur-sm">
+            {colorPips.map((color) => (
+              <ManaSymbol key={color} shard={color} size="xs" />
+            ))}
+          </div>
+        )}
 
         {/* Top-left: selected check only — the source label lives in the body so
             it never competes with the color-identity mana pips. Hover actions

--- a/client/src/components/menu/MyDecks.tsx
+++ b/client/src/components/menu/MyDecks.tsx
@@ -57,6 +57,7 @@ import { useSetSymbol } from "../../hooks/useSetSymbols";
 import {
   getDeckCardCount,
   getDeckColorIdentity,
+  getDeckColorIdentityPips,
   getRepresentativeCard,
   isBundledDeck,
 } from "./deckHelpers";
@@ -286,7 +287,7 @@ const DeckTile = memo(function DeckTile({ deckName, isActive, compatibility, onC
             A dark backing chip keeps the bright pips legible over any card art —
             without it the gold/white symbols wash out against light artwork. */}
         <div className="absolute right-2 top-2 z-10 flex items-center gap-0.5 rounded-full bg-black/75 px-2 py-1 shadow-[0_2px_8px_rgba(0,0,0,0.6)] ring-1 ring-white/20 backdrop-blur-sm">
-          {(colors.length ? colors : ["C"]).map((color) => (
+          {getDeckColorIdentityPips(colors).map((color) => (
             <ManaSymbol key={color} shard={color} size="xs" />
           ))}
         </div>

--- a/client/src/components/menu/__tests__/deckHelpers.test.ts
+++ b/client/src/components/menu/__tests__/deckHelpers.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from "vitest";
+
+import { getDeckColorIdentityPips } from "../deckHelpers";
+
+describe("getDeckColorIdentityPips", () => {
+  it("represents an empty color identity with the colorless mana symbol", () => {
+    expect(getDeckColorIdentityPips([])).toEqual(["C"]);
+  });
+
+  it("preserves colored identity symbols", () => {
+    expect(getDeckColorIdentityPips(["U", "R"])).toEqual(["U", "R"]);
+  });
+});

--- a/client/src/components/menu/__tests__/deckHelpers.test.ts
+++ b/client/src/components/menu/__tests__/deckHelpers.test.ts
@@ -10,4 +10,8 @@ describe("getDeckColorIdentityPips", () => {
   it("preserves colored identity symbols", () => {
     expect(getDeckColorIdentityPips(["U", "R"])).toEqual(["U", "R"]);
   });
+
+  it("does not label an unresolved identity as colorless", () => {
+    expect(getDeckColorIdentityPips(null)).toBeNull();
+  });
 });

--- a/client/src/components/menu/deckHelpers.ts
+++ b/client/src/components/menu/deckHelpers.ts
@@ -3,14 +3,6 @@ import { getDeckFeedOrigin, getCachedFeed } from "../../services/feedService";
 import type { ParsedDeck } from "../../services/deckParser";
 import { BASIC_LAND_NAMES } from "../../constants/game";
 
-export const COLOR_DOT_CLASS: Record<string, string> = {
-  W: "bg-amber-200",
-  U: "bg-blue-400",
-  B: "bg-gray-600",
-  R: "bg-red-500",
-  G: "bg-green-500",
-};
-
 export function loadDeck(deckName: string): ParsedDeck | null {
   return loadSavedDeck(deckName);
 }
@@ -23,6 +15,11 @@ export function getDeckColorIdentity(deckName: string): string[] {
     if (feedDeck) return feedDeck.colors;
   }
   return [];
+}
+
+/** Mana-symbol shards for a deck's color identity. Empty identities are colorless. */
+export function getDeckColorIdentityPips(colors: string[]): string[] {
+  return colors.length > 0 ? colors : ["C"];
 }
 
 export function getDeckCardCount(deckName: string): number {

--- a/client/src/components/menu/deckHelpers.ts
+++ b/client/src/components/menu/deckHelpers.ts
@@ -7,18 +7,19 @@ export function loadDeck(deckName: string): ParsedDeck | null {
   return loadSavedDeck(deckName);
 }
 
-export function getDeckColorIdentity(deckName: string): string[] {
+export function getDeckColorIdentity(deckName: string): string[] | null {
   const feedId = getDeckFeedOrigin(deckName);
   if (feedId) {
     const feed = getCachedFeed(feedId);
     const feedDeck = feed?.decks.find((d) => d.name === deckName);
     if (feedDeck) return feedDeck.colors;
   }
-  return [];
+  return null;
 }
 
-/** Mana-symbol shards for a deck's color identity. Empty identities are colorless. */
-export function getDeckColorIdentityPips(colors: string[]): string[] {
+/** Mana-symbol shards for a resolved deck identity. Empty identities are colorless. */
+export function getDeckColorIdentityPips(colors: string[] | null): string[] | null {
+  if (colors === null) return null;
   return colors.length > 0 ? colors : ["C"];
 }
 

--- a/client/src/components/menu/home/HomeDashboard.tsx
+++ b/client/src/components/menu/home/HomeDashboard.tsx
@@ -10,11 +10,13 @@ import { ManaSymbol } from "../../mana/ManaSymbol";
 import { useCardImage } from "../../../hooks/useCardImage";
 import { useResumables } from "../../../hooks/useResumables";
 import { useCardDataStore } from "../../../stores/cardDataStore";
+import { evaluateDeckCompatibility } from "../../../services/deckCompatibility";
 import {
   getDeckCardCount,
   getDeckColorIdentity,
   getDeckColorIdentityPips,
   getRepresentativeCard,
+  loadDeck,
 } from "../deckHelpers";
 
 interface ActionDef {
@@ -168,6 +170,7 @@ function ActiveDeckCard() {
   const { t } = useTranslation("menu");
   const navigate = useNavigate();
   const [name, setName] = useState<string | null>(null);
+  const [colors, setColors] = useState<string[] | null>(null);
   useEffect(() => setName(localStorage.getItem(ACTIVE_DECK_KEY)), []);
 
   // Resolve the deck's representative card so the card can show real art, the
@@ -178,6 +181,34 @@ function ActiveDeckCard() {
   const repCard = name && !randomDeckSelected ? getRepresentativeCard(name) : null;
   const { src: artSrc } = useCardImage(repCard ?? "", { size: "art_crop" });
 
+  useEffect(() => {
+    if (!name || randomDeckSelected) {
+      setColors(null);
+      return;
+    }
+
+    const catalogColors = getDeckColorIdentity(name);
+    if (catalogColors !== null) {
+      setColors(catalogColors);
+      return;
+    }
+
+    const deck = loadDeck(name);
+    if (!deck) {
+      setColors(null);
+      return;
+    }
+
+    let cancelled = false;
+    setColors(null);
+    void evaluateDeckCompatibility(deck, { summaryOnly: true }).then((result) => {
+      if (!cancelled) setColors(result.color_identity);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [name, randomDeckSelected]);
+
   if (!name) {
     return (
       <button type="button" onClick={() => navigate("/my-decks")} className={`${INFO_CARD} flex cursor-pointer flex-col items-start text-left transition-colors hover:border-hairline-hover`}>
@@ -187,7 +218,7 @@ function ActiveDeckCard() {
     );
   }
   const count = randomDeckSelected ? 0 : getDeckCardCount(name);
-  const colors = randomDeckSelected ? [] : getDeckColorIdentity(name);
+  const colorPips = randomDeckSelected ? null : getDeckColorIdentityPips(colors);
   return (
     <div
       role="button"
@@ -214,9 +245,9 @@ function ActiveDeckCard() {
         <div className={`${SECTION_LABEL} absolute left-3 top-2.5 z-10 drop-shadow-[0_1px_2px_rgba(0,0,0,0.7)]`}>
           {t("home.dashboard.activeDeck")}
         </div>
-        {!randomDeckSelected && (
+        {colorPips && (
           <div className="absolute right-2.5 top-2.5 z-10 flex items-center gap-0.5 rounded-full bg-black/75 px-2 py-1 shadow-[0_2px_8px_rgba(0,0,0,0.6)] ring-1 ring-white/20 backdrop-blur-sm">
-            {getDeckColorIdentityPips(colors).map((color) => <ManaSymbol key={color} shard={color} size="xs" />)}
+            {colorPips.map((color) => <ManaSymbol key={color} shard={color} size="xs" />)}
           </div>
         )}
       </div>

--- a/client/src/components/menu/home/HomeDashboard.tsx
+++ b/client/src/components/menu/home/HomeDashboard.tsx
@@ -13,6 +13,7 @@ import { useCardDataStore } from "../../../stores/cardDataStore";
 import {
   getDeckCardCount,
   getDeckColorIdentity,
+  getDeckColorIdentityPips,
   getRepresentativeCard,
 } from "../deckHelpers";
 
@@ -213,9 +214,9 @@ function ActiveDeckCard() {
         <div className={`${SECTION_LABEL} absolute left-3 top-2.5 z-10 drop-shadow-[0_1px_2px_rgba(0,0,0,0.7)]`}>
           {t("home.dashboard.activeDeck")}
         </div>
-        {colors.length > 0 && (
+        {!randomDeckSelected && (
           <div className="absolute right-2.5 top-2.5 z-10 flex items-center gap-0.5 rounded-full bg-black/75 px-2 py-1 shadow-[0_2px_8px_rgba(0,0,0,0.6)] ring-1 ring-white/20 backdrop-blur-sm">
-            {colors.map((c) => <ManaSymbol key={c} shard={c} size="xs" />)}
+            {getDeckColorIdentityPips(colors).map((color) => <ManaSymbol key={color} shard={color} size="xs" />)}
           </div>
         )}
       </div>

--- a/client/src/components/modal/CardChoiceModal.tsx
+++ b/client/src/components/modal/CardChoiceModal.tsx
@@ -2527,6 +2527,7 @@ function LegendChoiceModal({ data }: { data: ChooseLegend["data"] }) {
   const gameState = useGameStore((s) => s.gameState);
   const objects = gameState?.objects;
   const turnNumber = gameState?.turn_number;
+  const copiedPermanents = gameState?.derived?.copied_permanents ?? [];
   const hoverProps = useInspectHoverProps();
 
   if (!objects) return null;
@@ -2545,12 +2546,21 @@ function LegendChoiceModal({ data }: { data: ChooseLegend["data"] }) {
           const entryLabel = isCurrentTurnEntry
             ? t("cardChoice.legend.statusJustEntered")
             : t("cardChoice.legend.statusAlready");
+          const isTokenCopy =
+            !obj.face_down && obj.is_token === true && obj.display_source !== "Token";
+          const isCopy = isTokenCopy || (!obj.face_down && copiedPermanents.includes(id));
+          const identityLabel = isTokenCopy
+            ? t("cardChoice.legend.identityTokenCopy")
+            : isCopy
+              ? t("cardChoice.legend.identityCopy")
+              : t("cardChoice.legend.identityOriginal");
           return (
             <motion.button
               key={id}
               aria-label={t("cardChoice.legend.keepAria", {
                 name: obj.name,
                 status: entryLabel,
+                identity: identityLabel,
               })}
               className="relative rounded-lg transition hover:shadow-[0_0_16px_rgba(200,200,255,0.3)]"
               initial={{ opacity: 0, y: 60, scale: 0.85 }}
@@ -2567,13 +2577,20 @@ function LegendChoiceModal({ data }: { data: ChooseLegend["data"] }) {
                 size="normal"
                 className={CHOICE_CARD_IMAGE_CLASS}
               />
-              <div className="absolute top-2 left-1/2 -translate-x-1/2">
+              <div className="absolute top-2 left-1/2 flex -translate-x-1/2 flex-col items-center gap-1">
                 <span
                   className={`whitespace-nowrap rounded-full px-2 py-0.5 text-[11px] font-bold text-white shadow ${
                     isCurrentTurnEntry ? "bg-amber-500/95" : "bg-sky-700/95"
                   }`}
                 >
                   {entryLabel}
+                </span>
+                <span
+                  className={`whitespace-nowrap rounded-full px-2 py-0.5 text-[11px] font-bold text-white shadow ${
+                    isCopy ? "bg-indigo-600/95" : "bg-emerald-600/95"
+                  }`}
+                >
+                  {identityLabel}
                 </span>
               </div>
             </motion.button>

--- a/client/src/components/modal/CardChoiceModal.tsx
+++ b/client/src/components/modal/CardChoiceModal.tsx
@@ -2527,7 +2527,7 @@ function LegendChoiceModal({ data }: { data: ChooseLegend["data"] }) {
   const gameState = useGameStore((s) => s.gameState);
   const objects = gameState?.objects;
   const turnNumber = gameState?.turn_number;
-  const copiedPermanents = gameState?.derived?.copied_permanents ?? [];
+  const legendCandidateIdentities = gameState?.derived?.legend_candidate_identities;
   const hoverProps = useInspectHoverProps();
 
   if (!objects) return null;
@@ -2541,19 +2541,15 @@ function LegendChoiceModal({ data }: { data: ChooseLegend["data"] }) {
         {data.candidates.map((id, index) => {
           const obj = objects[id];
           if (!obj) return null;
+          const identity = legendCandidateIdentities?.[String(id)];
+          if (!identity) return null;
           const isCurrentTurnEntry =
             turnNumber != null && obj.entered_battlefield_turn === turnNumber;
           const entryLabel = isCurrentTurnEntry
             ? t("cardChoice.legend.statusJustEntered")
             : t("cardChoice.legend.statusAlready");
-          const isTokenCopy =
-            !obj.face_down && obj.is_token === true && obj.display_source !== "Token";
-          const isCopy = isTokenCopy || (!obj.face_down && copiedPermanents.includes(id));
-          const identityLabel = isTokenCopy
-            ? t("cardChoice.legend.identityTokenCopy")
-            : isCopy
-              ? t("cardChoice.legend.identityCopy")
-              : t("cardChoice.legend.identityOriginal");
+          const identityLabel = t(`cardChoice.legend.identity${identity}`);
+          const isCopy = identity !== "Original";
           return (
             <motion.button
               key={id}

--- a/client/src/components/modal/__tests__/LegendChoiceModal.test.tsx
+++ b/client/src/components/modal/__tests__/LegendChoiceModal.test.tsx
@@ -31,6 +31,8 @@ function makeState(): GameState {
     card_id: 11,
     name: "Thalia, Guardian of Thraben",
     entered_battlefield_turn: 2,
+    is_token: true,
+    display_source: "Card",
     card_types: {
       supertypes: ["Legendary"],
       core_types: ["Creature"],
@@ -73,11 +75,13 @@ describe("LegendChoiceModal", () => {
     cleanup();
   });
 
-  it("labels existing and newly entered legendary candidates", () => {
+  it("identifies the original and token-copy legend candidates", () => {
     render(<CardChoiceModal />);
 
     expect(screen.getByText("Already on battlefield")).toBeInTheDocument();
     expect(screen.getByText("Just entered")).toBeInTheDocument();
+    expect(screen.getByText("Original")).toBeInTheDocument();
+    expect(screen.getByText("Token copy")).toBeInTheDocument();
   });
 
   it("dispatches the selected legend to keep", () => {
@@ -85,7 +89,7 @@ describe("LegendChoiceModal", () => {
 
     fireEvent.click(
       screen.getByRole("button", {
-        name: "Keep Thalia, Guardian of Thraben (Just entered)",
+        name: "Keep Thalia, Guardian of Thraben (Token copy, Just entered)",
       }),
     );
 

--- a/client/src/components/modal/__tests__/LegendChoiceModal.test.tsx
+++ b/client/src/components/modal/__tests__/LegendChoiceModal.test.tsx
@@ -47,6 +47,12 @@ function makeState(): GameState {
     objects: buildObjectMap(existing, newCopy),
     next_object_id: 12,
     battlefield: [10, 11],
+    derived: {
+      legend_candidate_identities: {
+        "10": "Original",
+        "11": "TokenCopy",
+      },
+    },
     waiting_for: {
       type: "ChooseLegend",
       data: {

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -1633,7 +1633,10 @@
     "legend": {
       "title": "Legendenregel",
       "subtitle": "Wähle, welches „{{name}}“ du behältst",
-      "keepAria": "{{name}} behalten ({{status}})",
+      "keepAria": "{{name}} behalten ({{identity}}, {{status}})",
+      "identityOriginal": "Original",
+      "identityCopy": "Kopie",
+      "identityTokenCopy": "Spielsteinkopie",
       "statusJustEntered": "Gerade betreten",
       "statusAlready": "Bereits auf dem Schlachtfeld"
     },

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -1677,7 +1677,10 @@
     "legend": {
       "title": "Legend Rule",
       "subtitle": "Choose which \"{{name}}\" to keep",
-      "keepAria": "Keep {{name}} ({{status}})",
+      "keepAria": "Keep {{name}} ({{identity}}, {{status}})",
+      "identityOriginal": "Original",
+      "identityCopy": "Copy",
+      "identityTokenCopy": "Token copy",
       "statusJustEntered": "Just entered",
       "statusAlready": "Already on battlefield"
     },

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -1633,7 +1633,10 @@
     "legend": {
       "title": "Regla de leyendas",
       "subtitle": "Elige qué \"{{name}}\" conservar",
-      "keepAria": "Conservar {{name}} ({{status}})",
+      "keepAria": "Conservar {{name}} ({{identity}}, {{status}})",
+      "identityOriginal": "Original",
+      "identityCopy": "Copia",
+      "identityTokenCopy": "Copia de ficha",
       "statusJustEntered": "Acaba de entrar",
       "statusAlready": "Ya en el campo de batalla"
     },

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -1633,7 +1633,10 @@
     "legend": {
       "title": "Règle de la légende",
       "subtitle": "Choisissez quel(le) « {{name}} » garder",
-      "keepAria": "Garder {{name}} ({{status}})",
+      "keepAria": "Garder {{name}} ({{identity}}, {{status}})",
+      "identityOriginal": "Original",
+      "identityCopy": "Copie",
+      "identityTokenCopy": "Copie de jeton",
       "statusJustEntered": "Vient d'arriver",
       "statusAlready": "Déjà sur le champ de bataille"
     },

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -1633,7 +1633,10 @@
     "legend": {
       "title": "Regola delle leggende",
       "subtitle": "Scegli quale \"{{name}}\" tenere",
-      "keepAria": "Tieni {{name}} ({{status}})",
+      "keepAria": "Tieni {{name}} ({{identity}}, {{status}})",
+      "identityOriginal": "Originale",
+      "identityCopy": "Copia",
+      "identityTokenCopy": "Copia pedina",
       "statusJustEntered": "Appena entrata",
       "statusAlready": "Già sul campo di battaglia"
     },

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -1633,7 +1633,10 @@
     "legend": {
       "title": "Zasada legend",
       "subtitle": "Wybierz, którego „{{name}}” zatrzymać",
-      "keepAria": "Zatrzymaj {{name}} ({{status}})",
+      "keepAria": "Zatrzymaj {{name}} ({{identity}}, {{status}})",
+      "identityOriginal": "Oryginał",
+      "identityCopy": "Kopia",
+      "identityTokenCopy": "Kopia żetonu",
       "statusJustEntered": "Właśnie wszedł",
       "statusAlready": "Już na polu bitwy"
     },

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -1633,7 +1633,10 @@
     "legend": {
       "title": "Regra das Lendas",
       "subtitle": "Escolha qual \"{{name}}\" manter",
-      "keepAria": "Manter {{name}} ({{status}})",
+      "keepAria": "Manter {{name}} ({{identity}}, {{status}})",
+      "identityOriginal": "Original",
+      "identityCopy": "Cópia",
+      "identityTokenCopy": "Cópia de ficha",
       "statusJustEntered": "Acabou de entrar",
       "statusAlready": "Já está no campo de batalha"
     },

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -36,8 +36,8 @@ const viewerInteractionWithProducedMana = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v23", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(23);
+  it("pins the P2P wire protocol to v24", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(24);
   });
 
   it("defaults shortcut actions for a legacy payload created before the additive field", () => {
@@ -260,15 +260,15 @@ describe("encodeWireMessage / decodeWireMessage", () => {
   // and nothing about the version. Both halves here stamp LITERALS — a frame
   // built from WIRE_PROTOCOL_VERSION cannot tell a bumped client from an
   // unbumped one, which is why every other handshake fixture in the suite is
-  // useless as an instrument for a bump. Revert 23 → 22 and BOTH halves red:
-  // the v22 frame stops being refused, and the v23 frame stops being admitted.
-  // The admitting half is the reach-guard: without it "refuses v22" is also
+  // useless as an instrument for a bump. Revert 24 → 23 and BOTH halves red:
+  // the v23 frame stops being refused, and the v24 frame stops being admitted.
+  // The admitting half is the reach-guard: without it "refuses v23" is also
   // satisfied by a client that refuses everything.
-  it("refuses the previous wire protocol (v22) and admits its own (v23)", () => {
-    expect(() => validateMessage(setupFrameAt(22))).toThrow(/Wire protocol mismatch/);
-    expect(validateMessage(setupFrameAt(23))).toMatchObject({
+  it("refuses the previous wire protocol (v23) and admits its own (v24)", () => {
+    expect(() => validateMessage(setupFrameAt(23))).toThrow(/Wire protocol mismatch/);
+    expect(validateMessage(setupFrameAt(24))).toMatchObject({
       type: "game_setup",
-      wireProtocolVersion: 23,
+      wireProtocolVersion: 24,
     });
   });
 

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -91,6 +91,10 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *       and the state snapshot carries WaitingFor::LoopShortcut.declaration.
  *       Both are optional and parse on a v20 peer; the loss is silent, so the
  *       handshake is the only place the pairing can be refused.
+ *  24 — DerivedViews.legend_candidate_identities carries the engine-authored
+ *       copy identity required to label legend-rule choices. The field is
+ *       additive but the client no longer infers this identity from raw state,
+ *       so accepting a v23 peer would silently remove every choice option.
  *  20 — Serialized player-action completion provenance and modal continuations.
  *  19 — Added an action_noop acknowledgement for accepted transport no-ops.
  *  18 — DebugCardEntries added a serialized, private resolution frame for
@@ -123,7 +127,7 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *       sub-phase on WaitingFor::MulliganDecision; the MulliganBottomCards
  *       variant was removed
  */
-export const WIRE_PROTOCOL_VERSION = 23 as const;
+export const WIRE_PROTOCOL_VERSION = 24 as const;
 
 export type P2PMessage = P2PAuthorityWire & (
   | { type: "guest_deck"; deckData: unknown; displayName?: string; reservationToken?: string }

--- a/client/src/pages/GameSetupPage.tsx
+++ b/client/src/pages/GameSetupPage.tsx
@@ -252,7 +252,7 @@ export function GameSetupPage() {
     [activeDeckName],
   );
   const { src: deckArtSrc } = useCardImage(representativeCard ?? "", { size: "art_crop" });
-  const colors = selectedCompat?.color_identity ?? [];
+  const colorPips = getDeckColorIdentityPips(selectedCompat?.color_identity ?? null);
 
   return (
     <div className="menu-scene relative flex min-h-screen flex-col overflow-hidden">
@@ -407,11 +407,13 @@ export function GameSetupPage() {
                     </button>
                   </div>
                   <div className="mt-1 flex items-center gap-2">
-                    <div className="flex items-center gap-1 rounded-full bg-black/35 px-1.5 py-1 ring-1 ring-white/10">
-                      {getDeckColorIdentityPips(colors).map((color) => (
-                        <ManaSymbol key={color} shard={color} size="xs" />
-                      ))}
-                    </div>
+                    {colorPips && (
+                      <div className="flex items-center gap-1 rounded-full bg-black/35 px-1.5 py-1 ring-1 ring-white/10">
+                        {colorPips.map((color) => (
+                          <ManaSymbol key={color} shard={color} size="xs" />
+                        ))}
+                      </div>
+                    )}
                     <span className="text-xs text-gray-300">{t("gameSetup.deckPreview.cardCount", { count: deckCardCount })}</span>
                   </div>
                   {selectedCompat && (

--- a/client/src/pages/GameSetupPage.tsx
+++ b/client/src/pages/GameSetupPage.tsx
@@ -19,10 +19,11 @@ import { MenuPanel, MenuShell } from "../components/menu/MenuShell";
 import { MyDecks, StatusBadge } from "../components/menu/MyDecks";
 import { ModalPanelShell } from "../components/ui/ModalPanelShell";
 import {
-  COLOR_DOT_CLASS,
   getRepresentativeCard,
   getDeckCardCount,
+  getDeckColorIdentityPips,
 } from "../components/menu/deckHelpers";
+import { ManaSymbol } from "../components/mana/ManaSymbol";
 import { menuButtonClass } from "../components/menu/buttonStyles";
 import {
   ACTIVE_DECK_KEY,
@@ -407,15 +408,9 @@ export function GameSetupPage() {
                   </div>
                   <div className="mt-1 flex items-center gap-2">
                     <div className="flex items-center gap-1 rounded-full bg-black/35 px-1.5 py-1 ring-1 ring-white/10">
-                      {colors.map((c) => (
-                        <span
-                          key={c}
-                          className={`inline-block h-2.5 w-2.5 rounded-full ${COLOR_DOT_CLASS[c] ?? "bg-gray-400"}`}
-                        />
+                      {getDeckColorIdentityPips(colors).map((color) => (
+                        <ManaSymbol key={color} shard={color} size="xs" />
                       ))}
-                      {colors.length === 0 && (
-                        <span className="inline-block h-2.5 w-2.5 rounded-full bg-gray-500" />
-                      )}
                     </div>
                     <span className="text-xs text-gray-300">{t("gameSetup.deckPreview.cardCount", { count: deckCardCount })}</span>
                   </div>

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -18,7 +18,7 @@ use std::collections::{BTreeMap, BTreeSet, HashMap};
 use crate::analysis::resource::ResourceAxis;
 use crate::game::ability_utils::flatten_targets_in_chain;
 use crate::game::filter::{matches_target_filter, FilterContext};
-use crate::game::game_object::AttachTarget;
+use crate::game::game_object::{AttachTarget, DisplaySource};
 use crate::game::stack::{effective_stack_ability, stack_display_groups, StackDisplayGroup};
 use crate::types::ability::{
     ContinuousModification, Duration, GameRestriction, KeywordAction, ProhibitedActivity,
@@ -505,6 +505,20 @@ pub struct DebugLibraryCardView {
     pub name: String,
 }
 
+/// Engine-authored identity for a candidate in a legend-rule choice.
+///
+/// The frontend renders this value without inspecting token, copy-effect, or
+/// face-down state. `TokenCopy` takes precedence when a copied permanent spell
+/// resolved as a token; `Copy` is a live Layer 1a copy effect; `Original` is
+/// every other candidate, including a face-down object whose copy status must
+/// remain hidden.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum LegendCandidateIdentity {
+    Original,
+    Copy,
+    TokenCopy,
+}
+
 /// Engine-authored projections used by the display layer. Keep this struct
 /// small — every field becomes mandatory payload on every state snapshot
 /// the client receives. Add a new field only when the frontend would
@@ -569,6 +583,12 @@ pub struct DerivedViews {
     /// Sorted for stable serialization; absent when nothing is a copy.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub copied_permanents: Vec<ObjectId>,
+
+    /// The engine-classified identity for every current legend-rule candidate.
+    /// This is intentionally scoped to the active choice so the client can
+    /// label each option without deriving copy status from raw object fields.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub legend_candidate_identities: BTreeMap<ObjectId, LegendCandidateIdentity>,
 
     /// Commander damage grouped by the attacking commander's current
     /// controller. Each inner entry preserves per-commander identity so
@@ -1139,6 +1159,29 @@ pub fn derive_views(state: &GameState, viewer: Option<PlayerId>) -> DerivedViews
     // answer.
     views.copied_permanents.sort_unstable();
     views.cant_be_blocked.sort_unstable();
+
+    if let crate::types::game_state::WaitingFor::ChooseLegend { candidates, .. } =
+        &state.waiting_for
+    {
+        for &candidate_id in candidates {
+            let Some(candidate) = state.objects.get(&candidate_id) else {
+                continue;
+            };
+            let identity = if !candidate.face_down
+                && candidate.is_token
+                && candidate.display_source != DisplaySource::Token
+            {
+                LegendCandidateIdentity::TokenCopy
+            } else if !candidate.face_down && object_has_copy_effect(state, candidate_id) {
+                LegendCandidateIdentity::Copy
+            } else {
+                LegendCandidateIdentity::Original
+            };
+            views
+                .legend_candidate_identities
+                .insert(candidate_id, identity);
+        }
+    }
 
     // CR 702.40a: viewer-scoped prospective Storm copy counts (own hand only → leak-proof).
     if let Some(viewer) = viewer {
@@ -2515,7 +2558,6 @@ fn zone_label(zone: Option<Zone>) -> &'static str {
 mod tests {
     use super::*;
     use crate::game::combat::CombatState;
-    use crate::game::game_object::DisplaySource;
     use crate::game::triggers::{PendingTrigger, PendingTriggerContext};
     use crate::game::zones::create_object;
     use crate::types::ability::{
@@ -3170,6 +3212,18 @@ mod tests {
             "Phantasmal Image".into(),
             Zone::Battlefield,
         );
+        let token_copy = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(0),
+            "Reveillark".into(),
+            Zone::Battlefield,
+        );
+        {
+            let token = state.objects.get_mut(&token_copy).unwrap();
+            token.is_token = true;
+            token.display_source = DisplaySource::Card;
+        }
 
         let values = crate::game::printed_cards::intrinsic_copiable_values(
             state.objects.get(&original).unwrap(),
@@ -3187,6 +3241,11 @@ mod tests {
             }],
             None,
         );
+        state.waiting_for = crate::types::game_state::WaitingFor::ChooseLegend {
+            player: PlayerId(0),
+            legend_name: "Reveillark".into(),
+            candidates: vec![original, clone, token_copy],
+        };
 
         let views = derive_views(&state, None);
 
@@ -3195,6 +3254,15 @@ mod tests {
             vec![clone],
             "only the permanent the copy effect applies to is a copy; the \
              original it copied is not"
+        );
+        assert_eq!(
+            views.legend_candidate_identities,
+            BTreeMap::from([
+                (original, LegendCandidateIdentity::Original),
+                (clone, LegendCandidateIdentity::Copy),
+                (token_copy, LegendCandidateIdentity::TokenCopy),
+            ]),
+            "each legend-rule option receives an engine-authored identity"
         );
     }
 

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -43,6 +43,11 @@ pub enum ServerErrorCode {
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
 ///
+/// 32 — `DerivedViews::legend_candidate_identities` publishes the engine-authored
+///      original/copy/token-copy identity for each active legend-rule choice. The
+///      field is `#[serde(default)]`, but the client deliberately no longer derives
+///      this rules-sensitive identity from raw objects; an older server would
+///      silently omit every choice identity.
 /// 31 — `WaitingFor::LoopShortcut` publishes the engine-issued `declaration`, and
 ///      `InteractionResponseSpec::Shortcut` publishes `preview`, the per-axis
 ///      consequence of the offered count. Both are `Option` and neither type sets
@@ -94,7 +99,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 31;
+pub const PROTOCOL_VERSION: u32 = 32;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake. Lobby traffic has a one-version rollout window; full game servers
@@ -431,12 +436,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 31);
+        assert_eq!(PROTOCOL_VERSION, 32);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot
         // understand a success acknowledgment the submitting client awaits.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 30);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 31);
     }
 
     #[test]

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -2324,8 +2324,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_31() {
-        assert_eq!(PROTOCOL_VERSION, 31);
+    fn protocol_version_is_32() {
+        assert_eq!(PROTOCOL_VERSION, 32);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -2335,7 +2335,7 @@ mod tests {
     /// understand.
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
-    /// this guards — and this test reds while `protocol_version_is_31` stays
+    /// this guards — and this test reds while `protocol_version_is_32` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 31;
+const EXPECTED_PROTOCOL_VERSION = 32;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Automatic battlefield backgrounds now select a consistent image for colorless decks.
  - Deck color identities display using mana-symbol indicators across deck lists, dashboards, and game setup.
  - Legend-choice dialogs now distinguish original cards, copies, and token copies with visible badges and clearer accessible labels.
  - Added localized identity labels across supported languages.

- **Bug Fixes**
  - Improved colorless deck background handling and deck color indicator fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->