### PR TITLE
Raise hovered stack cards

### DIFF
--- a/client/src/components/stack/StackDisplay.tsx
+++ b/client/src/components/stack/StackDisplay.tsx
@@ -166,11 +166,14 @@ export function StackDisplay({
         right: `calc(env(safe-area-inset-right) + ${rightOffsetPx}px + var(--game-right-rail-offset, 0px))`,
       };
 
-  const entryStyles = displayStack.map((_, index) => ({
+  const entryStyles = displayStack.map((entry, index) => ({
     position: "absolute" as const,
     top: index * staggerY,
     left: index * staggerX,
-    zIndex: index + 1,
+    // Cards overlap to form the stack pile. Raise the inspected card above
+    // every sibling so its engine-provided targets, modes, and paid-cost chips
+    // remain readable even when it is below the top stack entry.
+    zIndex: entry.id === hoveredStackEntryId ? displayStack.length + 1 : index + 1,
   }));
 
   return (

--- a/client/src/components/stack/StackEntry.tsx
+++ b/client/src/components/stack/StackEntry.tsx
@@ -65,6 +65,7 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
   const { handlers: longPressHandlers, firedRef: longPressFired } = useLongPress(() => {
     inspectObject(entry.source_id);
     setPreviewSticky(true);
+    onHoverChange?.(true);
   });
 
   const sourceObj = objects?.[entry.source_id];

--- a/client/src/components/stack/__tests__/StackDisplay.test.tsx
+++ b/client/src/components/stack/__tests__/StackDisplay.test.tsx
@@ -1,0 +1,65 @@
+import { act, type CSSProperties, type ReactNode } from "react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import { StackDisplay } from "../StackDisplay.tsx";
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { buildGameState, buildStackEntry } from "../../../test/factories/gameStateFactory.ts";
+
+vi.mock("../StackEntry.tsx", () => ({
+  StackEntry: ({
+    entry,
+    onHoverChange,
+    style,
+  }: {
+    entry: { id: number };
+    onHoverChange?: (hovered: boolean) => void;
+    style?: CSSProperties;
+  }) => (
+    <button
+      type="button"
+      data-testid={`stack-entry-${entry.id}`}
+      style={style}
+      onMouseEnter={() => onHoverChange?.(true)}
+      onMouseLeave={() => onHoverChange?.(false)}
+    />
+  ),
+}));
+
+vi.mock("../StackTargetArcs.tsx", () => ({ StackTargetArcs: () => null }));
+
+vi.mock("../../flexlayout/DraggableWidget.tsx", () => ({
+  DraggableWidget: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+}));
+
+describe("StackDisplay", () => {
+  beforeEach(() => {
+    useGameStore.getState().reset();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("raises the hovered entry above every other card in the pile", () => {
+    const bottomEntry = buildStackEntry({ id: 10 });
+    const topEntry = buildStackEntry({ id: 20 });
+    const gameState = buildGameState({ stack: [bottomEntry, topEntry] });
+
+    act(() => {
+      useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+    });
+
+    render(<StackDisplay effectiveMultiplayerBoardLayout="focused" />);
+
+    const bottomCard = screen.getByTestId("stack-entry-10");
+    const topCard = screen.getByTestId("stack-entry-20");
+    expect(bottomCard).toHaveStyle({ zIndex: 1 });
+    expect(topCard).toHaveStyle({ zIndex: 2 });
+
+    fireEvent.mouseEnter(bottomCard);
+
+    expect(bottomCard).toHaveStyle({ zIndex: 3 });
+    expect(topCard).toHaveStyle({ zIndex: 2 });
+  });
+});

--- a/client/src/components/stack/__tests__/StackEntry.test.tsx
+++ b/client/src/components/stack/__tests__/StackEntry.test.tsx
@@ -106,6 +106,35 @@ describe("StackEntry", () => {
     expect(screen.queryByAltText("2")).not.toBeInTheDocument();
   });
 
+  it("raises its entry after a long press", () => {
+    vi.useFakeTimers();
+    const onHoverChange = vi.fn();
+    const entry = buildStackEntry({ id: 77, source_id: 42 });
+
+    render(
+      <StackEntry
+        entry={entry}
+        index={0}
+        isTop
+        cardSize={{ width: 120, height: 168 }}
+        onHoverChange={onHoverChange}
+      />,
+    );
+
+    fireEvent.pointerDown(document.querySelector('[data-stack-entry="77"]')!, {
+      button: 0,
+      clientX: 12,
+      clientY: 12,
+      isPrimary: true,
+      pointerId: 1,
+      pointerType: "touch",
+    });
+    act(() => vi.advanceTimersByTime(500));
+
+    expect(onHoverChange).toHaveBeenCalledWith(true);
+    vi.useRealTimers();
+  });
+
   it("offers Revoke for an AllCopies yield after the source token has ceased", () => {
     // CR 400.7 + CR 704.5d: a ceased token is gone from `objects`, so the entry
     // has no live source object to read a card_id from — the menu must match the


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Hovered stack cards now appear above overlapping cards, keeping targets, modes, and paid-cost details visible.

* **Tests**
  * Added coverage to verify correct card layering when inspecting stacked cards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->