### PR TITLE
chore: refresh metagame feeds

### DIFF
--- a/client/public/feeds/mtggoldfish-commander.json
+++ b/client/public/feeds/mtggoldfish-commander.json
@@ -5,15 +5,15 @@
   "icon": "G",
   "format": "commander",
   "version": 1,
-  "updated": "2026-08-19T00:00:00Z",
+  "updated": "2026-08-20T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/commander",
   "decks": [
     {
       "name": "Y'shtola, Night's Blessed",
       "author": "MTGGoldfish",
       "colors": [
-        "U",
         "W",
+        "U",
         "B"
       ],
       "tags": [
@@ -22,183 +22,7 @@
       "main": [
         {
           "count": 1,
-          "name": "Aetherize"
-        },
-        {
-          "count": 1,
-          "name": "Alisaie Leveilleur"
-        },
-        {
-          "count": 1,
-          "name": "Alphinaud Leveilleur"
-        },
-        {
-          "count": 1,
-          "name": "Anguished Unmaking"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Sanctum"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Archmage Emeritus"
-        },
-        {
-          "count": 1,
-          "name": "Austere Command"
-        },
-        {
-          "count": 1,
-          "name": "Authority of the Consuls"
-        },
-        {
-          "count": 1,
-          "name": "Baleful Strix"
-        },
-        {
-          "count": 1,
-          "name": "Bender's Waterskin"
-        },
-        {
-          "count": 1,
-          "name": "Black Mage's Rod"
-        },
-        {
-          "count": 1,
-          "name": "Blue Mage's Cane"
-        },
-        {
-          "count": 1,
-          "name": "Brainstorm"
-        },
-        {
-          "count": 1,
-          "name": "Circle of Power"
-        },
-        {
-          "count": 1,
-          "name": "Cleansing Nova"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Commander's Sphere"
-        },
-        {
-          "count": 1,
-          "name": "Cornered by Black Mages"
-        },
-        {
-          "count": 1,
-          "name": "Counterspell"
-        },
-        {
-          "count": 1,
-          "name": "Crushing Disappointment"
-        },
-        {
-          "count": 1,
-          "name": "Cut a Deal"
-        },
-        {
-          "count": 1,
-          "name": "Dig Through Time"
-        },
-        {
-          "count": 1,
-          "name": "Disallow"
-        },
-        {
-          "count": 1,
-          "name": "Emet-Selch of the Third Seat"
-        },
-        {
-          "count": 1,
-          "name": "Evolving Wilds"
-        },
-        {
-          "count": 1,
-          "name": "Exotic Orchard"
-        },
-        {
-          "count": 1,
-          "name": "Exsanguinate"
-        },
-        {
-          "count": 1,
-          "name": "Fandaniel, Telophoroi Ascian"
-        },
-        {
-          "count": 1,
-          "name": "Frantic Search"
-        },
-        {
-          "count": 1,
-          "name": "G'raha Tia, Scion Reborn"
-        },
-        {
-          "count": 1,
-          "name": "Ghostly Prison"
-        },
-        {
-          "count": 1,
-          "name": "Glacial Fortress"
-        },
-        {
-          "count": 1,
-          "name": "Hypnotic Sprite"
-        },
-        {
-          "count": 1,
-          "name": "Into the Story"
-        },
-        {
-          "count": 11,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Isolated Chapel"
-        },
-        {
-          "count": 1,
-          "name": "Krile Baldesion"
-        },
-        {
-          "count": 1,
-          "name": "Lingering Souls"
-        },
-        {
-          "count": 1,
-          "name": "Lyse Hext"
-        },
-        {
-          "count": 1,
-          "name": "Mana Sculpt"
-        },
-        {
-          "count": 1,
-          "name": "Mortify"
-        },
-        {
-          "count": 1,
-          "name": "Murderous Rider"
-        },
-        {
-          "count": 1,
-          "name": "Negate"
-        },
-        {
-          "count": 1,
-          "name": "Overkill"
+          "name": "Lethal Scheme"
         },
         {
           "count": 1,
@@ -206,131 +30,11 @@
         },
         {
           "count": 1,
-          "name": "Path of Ancestry"
-        },
-        {
-          "count": 1,
-          "name": "Path to Exile"
-        },
-        {
-          "count": 1,
-          "name": "Phyrexian Arena"
-        },
-        {
-          "count": 3,
-          "name": "Plains"
-        },
-        {
-          "count": 1,
-          "name": "Prairie Stream"
-        },
-        {
-          "count": 1,
-          "name": "Press the Enemy"
-        },
-        {
-          "count": 1,
-          "name": "Propaganda"
-        },
-        {
-          "count": 1,
-          "name": "Queza, Augur of Agonies"
-        },
-        {
-          "count": 1,
-          "name": "Read the Bones"
-        },
-        {
-          "count": 1,
-          "name": "Relic of Legends"
-        },
-        {
-          "count": 1,
-          "name": "Reliquary Tower"
-        },
-        {
-          "count": 1,
-          "name": "Risky Shortcut"
-        },
-        {
-          "count": 1,
-          "name": "Rogue's Passage"
-        },
-        {
-          "count": 1,
-          "name": "Sephiroth's Intervention"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Stormscape Familiar"
-        },
-        {
-          "count": 1,
-          "name": "Stroke of Midnight"
-        },
-        {
-          "count": 1,
-          "name": "Sublime Epiphany"
-        },
-        {
-          "count": 1,
-          "name": "Sunken Hollow"
-        },
-        {
-          "count": 7,
-          "name": "Swamp"
-        },
-        {
-          "count": 1,
-          "name": "Swiftfoot Boots"
-        },
-        {
-          "count": 1,
-          "name": "Swords to Plowshares"
-        },
-        {
-          "count": 1,
-          "name": "Syphon Mind"
-        },
-        {
-          "count": 1,
-          "name": "Temple of Deceit"
-        },
-        {
-          "count": 1,
-          "name": "Temple of Enlightenment"
-        },
-        {
-          "count": 1,
-          "name": "Temple of Silence"
-        },
-        {
-          "count": 1,
-          "name": "Temple of the False God"
-        },
-        {
-          "count": 1,
-          "name": "Thought Vessel"
-        },
-        {
-          "count": 1,
-          "name": "Torrential Gearhulk"
-        },
-        {
-          "count": 1,
-          "name": "Transpose"
-        },
-        {
-          "count": 1,
-          "name": "Treasure Cruise"
-        },
-        {
-          "count": 1,
           "name": "Unwind"
+        },
+        {
+          "count": 1,
+          "name": "Delney, Streetwise Lookout"
         },
         {
           "count": 1,
@@ -338,15 +42,347 @@
         },
         {
           "count": 1,
+          "name": "Vito, Thorn of the Dusk Rose"
+        },
+        {
+          "count": 1,
           "name": "Void Rend"
         },
         {
           "count": 1,
-          "name": "Wizard's Staff"
+          "name": "Circle of Power"
         },
         {
           "count": 1,
-          "name": "Y'shtola, Night's Blessed"
+          "name": "G'raha Tia, Scion Reborn"
+        },
+        {
+          "count": 1,
+          "name": "Archaeomancer's Map"
+        },
+        {
+          "count": 1,
+          "name": "Lotho, Corrupt Shirriff"
+        },
+        {
+          "count": 1,
+          "name": "Thought Vessel"
+        },
+        {
+          "count": 1,
+          "name": "Anguished Unmaking"
+        },
+        {
+          "count": 1,
+          "name": "Smothering Tithe"
+        },
+        {
+          "count": 1,
+          "name": "Observed Stasis"
+        },
+        {
+          "count": 1,
+          "name": "Exquisite Blood"
+        },
+        {
+          "count": 1,
+          "name": "Emet-Selch of the Third Seat"
+        },
+        {
+          "count": 1,
+          "name": "Black Market Connections"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Bender's Waterskin"
+        },
+        {
+          "count": 1,
+          "name": "Risky Shortcut"
+        },
+        {
+          "count": 1,
+          "name": "Archmage Emeritus"
+        },
+        {
+          "count": 1,
+          "name": "Baleful Strix"
+        },
+        {
+          "count": 1,
+          "name": "Counterspell"
+        },
+        {
+          "count": 1,
+          "name": "Rewind"
+        },
+        {
+          "count": 1,
+          "name": "Sigil of Sleep"
+        },
+        {
+          "count": 1,
+          "name": "Decanter of Endless Water"
+        },
+        {
+          "count": 1,
+          "name": "Toxic Deluge"
+        },
+        {
+          "count": 1,
+          "name": "Transpose"
+        },
+        {
+          "count": 1,
+          "name": "Talisman of Progress"
+        },
+        {
+          "count": 1,
+          "name": "Relic of Legends"
+        },
+        {
+          "count": 1,
+          "name": "Ghostly Prison"
+        },
+        {
+          "count": 1,
+          "name": "Ophidian Eye"
+        },
+        {
+          "count": 1,
+          "name": "Talisman of Hierarchy"
+        },
+        {
+          "count": 1,
+          "name": "Snuff Out"
+        },
+        {
+          "count": 1,
+          "name": "Sanguine Bond"
+        },
+        {
+          "count": 1,
+          "name": "Rhystic Study"
+        },
+        {
+          "count": 1,
+          "name": "Sheoldred, the Apocalypse"
+        },
+        {
+          "count": 1,
+          "name": "Authority of the Consuls"
+        },
+        {
+          "count": 1,
+          "name": "Irenicus's Vile Duplication"
+        },
+        {
+          "count": 1,
+          "name": "Stroke of Midnight"
+        },
+        {
+          "count": 1,
+          "name": "Helm of the Ghastlord"
+        },
+        {
+          "count": 1,
+          "name": "Talisman of Dominance"
+        },
+        {
+          "count": 1,
+          "name": "Dismember"
+        },
+        {
+          "count": 1,
+          "name": "Frantic Search"
+        },
+        {
+          "count": 1,
+          "name": "Deadly Rollick"
+        },
+        {
+          "count": 1,
+          "name": "Bolas's Citadel"
+        },
+        {
+          "count": 1,
+          "name": "Teferi, Time Raveler"
+        },
+        {
+          "count": 1,
+          "name": "Curiosity"
+        },
+        {
+          "count": 1,
+          "name": "Tataru Taru"
+        },
+        {
+          "count": 1,
+          "name": "Kambal, Consul of Allocation"
+        },
+        {
+          "count": 1,
+          "name": "Swords to Plowshares"
+        },
+        {
+          "count": 1,
+          "name": "Alisaie Leveilleur"
+        },
+        {
+          "count": 1,
+          "name": "Lyse Hext"
+        },
+        {
+          "count": 1,
+          "name": "Propaganda"
+        },
+        {
+          "count": 1,
+          "name": "Dig Through Time"
+        },
+        {
+          "count": 1,
+          "name": "Split Up"
+        },
+        {
+          "count": 1,
+          "name": "Alphinaud Leveilleur"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
+          "name": "Undermine"
+        },
+        {
+          "count": 1,
+          "name": "Enduring Tenacity"
+        },
+        {
+          "count": 1,
+          "name": "Polluted Delta"
+        },
+        {
+          "count": 1,
+          "name": "Flooded Strand"
+        },
+        {
+          "count": 1,
+          "name": "Windswept Heath"
+        },
+        {
+          "count": 1,
+          "name": "City of Brass"
+        },
+        {
+          "count": 1,
+          "name": "Fabled Passage"
+        },
+        {
+          "count": 1,
+          "name": "Verdant Catacombs"
+        },
+        {
+          "count": 1,
+          "name": "Drowned Catacomb"
+        },
+        {
+          "count": 1,
+          "name": "Hallowed Fountain"
+        },
+        {
+          "count": 1,
+          "name": "Scalding Tarn"
+        },
+        {
+          "count": 1,
+          "name": "Bloodstained Mire"
+        },
+        {
+          "count": 1,
+          "name": "Port Town"
+        },
+        {
+          "count": 1,
+          "name": "Watery Grave"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Reliquary Tower"
+        },
+        {
+          "count": 1,
+          "name": "Isolated Chapel"
+        },
+        {
+          "count": 1,
+          "name": "Godless Shrine"
+        },
+        {
+          "count": 1,
+          "name": "Exotic Orchard"
+        },
+        {
+          "count": 1,
+          "name": "Prismatic Vista"
+        },
+        {
+          "count": 1,
+          "name": "Prairie Stream"
+        },
+        {
+          "count": 1,
+          "name": "Glacial Fortress"
+        },
+        {
+          "count": 1,
+          "name": "Arid Mesa"
+        },
+        {
+          "count": 1,
+          "name": "Marsh Flats"
+        },
+        {
+          "count": 1,
+          "name": "Underground River"
+        },
+        {
+          "count": 1,
+          "name": "Sunken Hollow"
+        },
+        {
+          "count": 1,
+          "name": "Skycloud Expanse"
+        },
+        {
+          "count": 4,
+          "name": "Swamp"
+        },
+        {
+          "count": 4,
+          "name": "Island"
+        },
+        {
+          "count": 4,
+          "name": "Plains"
+        },
+        {
+          "count": 1,
+          "name": "Diabolic Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Y'shtola, Night's Blessed <borderless> [FIC] (F)"
         }
       ],
       "sideboard": []
@@ -363,39 +399,15 @@
       "main": [
         {
           "count": 1,
-          "name": "Ayula, Queen Among Bears"
+          "name": "Beorn the Fierce"
+        },
+        {
+          "count": 30,
+          "name": "Forest"
         },
         {
           "count": 1,
-          "name": "Goreclaw, Terror of Qal Sisma"
-        },
-        {
-          "count": 1,
-          "name": "Realmwalker"
-        },
-        {
-          "count": 1,
-          "name": "Ghalta, Primal Hunger"
-        },
-        {
-          "count": 1,
-          "name": "Thunderfoot Baloth"
-        },
-        {
-          "count": 1,
-          "name": "Soul of the Harvest"
-        },
-        {
-          "count": 1,
-          "name": "End-Raze Forerunners"
-        },
-        {
-          "count": 1,
-          "name": "Wilson, Refined Grizzly"
-        },
-        {
-          "count": 1,
-          "name": "Werebear"
+          "name": "Alpine Grizzly"
         },
         {
           "count": 1,
@@ -403,7 +415,55 @@
         },
         {
           "count": 1,
+          "name": "Ayula, Queen Among Bears"
+        },
+        {
+          "count": 1,
+          "name": "Balduvian Bears"
+        },
+        {
+          "count": 1,
           "name": "Bear Cub"
+        },
+        {
+          "count": 1,
+          "name": "Beorn, Reluctant Host"
+        },
+        {
+          "count": 1,
+          "name": "Bosco, Just a Bear"
+        },
+        {
+          "count": 1,
+          "name": "Casal, Lurkwood Pathfinder"
+        },
+        {
+          "count": 1,
+          "name": "Copper Host Crusher"
+        },
+        {
+          "count": 1,
+          "name": "Dragon-Scarred Bear"
+        },
+        {
+          "count": 1,
+          "name": "Drover Grizzly"
+        },
+        {
+          "count": 1,
+          "name": "Druid's Familiar"
+        },
+        {
+          "count": 1,
+          "name": "Evercoat Ursine"
+        },
+        {
+          "count": 1,
+          "name": "Forest Bear"
+        },
+        {
+          "count": 1,
+          "name": "Goreclaw, Terror of Qal Sisma"
         },
         {
           "count": 1,
@@ -411,11 +471,7 @@
         },
         {
           "count": 1,
-          "name": "Runeclaw Bear"
-        },
-        {
-          "count": 1,
-          "name": "Mother Bear"
+          "name": "Little Bear"
         },
         {
           "count": 1,
@@ -423,71 +479,103 @@
         },
         {
           "count": 1,
+          "name": "Owlbear Cub"
+        },
+        {
+          "count": 1,
+          "name": "Pale Bears"
+        },
+        {
+          "count": 1,
+          "name": "Rampaging Yao Guai"
+        },
+        {
+          "count": 1,
+          "name": "River Bear"
+        },
+        {
+          "count": 1,
+          "name": "Runeclaw Bear"
+        },
+        {
+          "count": 1,
+          "name": "Ruxa, Patient Professor"
+        },
+        {
+          "count": 1,
+          "name": "Striped Bears"
+        },
+        {
+          "count": 1,
+          "name": "Studious First-Year"
+        },
+        {
+          "count": 1,
+          "name": "Surrak and Goreclaw"
+        },
+        {
+          "count": 1,
+          "name": "Ursine Monstrosity"
+        },
+        {
+          "count": 1,
+          "name": "Vastlands Scavenger"
+        },
+        {
+          "count": 1,
           "name": "Vivien's Grizzly"
         },
         {
           "count": 1,
-          "name": "Woodland Changeling"
+          "name": "Werebear"
         },
         {
           "count": 1,
-          "name": "Webweaver Changeling"
+          "name": "Wilson, Refined Grizzly"
         },
         {
           "count": 1,
-          "name": "Changeling Titan"
+          "name": "Mosswort Bridge"
         },
         {
           "count": 1,
-          "name": "Guardian Gladewalker"
+          "name": "Nykthos, Shrine to Nyx"
         },
         {
           "count": 1,
-          "name": "Masked Vandal"
+          "name": "Three Tree City"
         },
         {
           "count": 1,
-          "name": "Bloodline Pretender"
+          "name": "Bala Ged Recovery"
         },
         {
           "count": 1,
-          "name": "Universal Automaton"
+          "name": "Bridgeworks Battle"
         },
         {
           "count": 1,
-          "name": "Garruk's Packleader"
+          "name": "Khalni Ambush"
         },
         {
           "count": 1,
-          "name": "Llanowar Elves"
+          "name": "Evendo, Waking Haven"
         },
         {
           "count": 1,
-          "name": "Elvish Mystic"
+          "name": "Path of Ancestry"
         },
         {
           "count": 1,
-          "name": "Fyndhorn Elves"
+          "name": "Command Beacon"
         },
         {
           "count": 1,
-          "name": "Arbor Elf"
+          "name": "Guardian Project"
         },
         {
           "count": 1,
-          "name": "Sakura-Tribe Elder"
-        },
-        {
-          "count": 1,
-          "name": "Wood Elves"
-        },
-        {
-          "count": 1,
-          "name": "Eternal Witness"
-        },
-        {
-          "count": 1,
-          "name": "Acidic Slime"
+          "name": "Obscuring Haze"
         },
         {
           "count": 1,
@@ -499,27 +587,7 @@
         },
         {
           "count": 1,
-          "name": "Patchwork Banner"
-        },
-        {
-          "count": 1,
-          "name": "Icon of Ancestry"
-        },
-        {
-          "count": 1,
-          "name": "Maskwood Nexus"
-        },
-        {
-          "count": 1,
-          "name": "Lifecrafter's Bestiary"
-        },
-        {
-          "count": 1,
-          "name": "Herald's Horn"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves"
+          "name": "Moss Diamond"
         },
         {
           "count": 1,
@@ -527,265 +595,7 @@
         },
         {
           "count": 1,
-          "name": "Elemental Bond"
-        },
-        {
-          "count": 1,
-          "name": "Beorn's Hospitality"
-        },
-        {
-          "count": 1,
-          "name": "Wild Growth"
-        },
-        {
-          "count": 1,
-          "name": "Utopia Sprawl"
-        },
-        {
-          "count": 1,
-          "name": "Fertile Ground"
-        },
-        {
-          "count": 1,
-          "name": "Snake Umbra"
-        },
-        {
-          "count": 1,
-          "name": "Rampant Growth"
-        },
-        {
-          "count": 1,
-          "name": "Nature's Lore"
-        },
-        {
-          "count": 1,
-          "name": "Three Visits"
-        },
-        {
-          "count": 1,
-          "name": "Cultivate"
-        },
-        {
-          "count": 1,
-          "name": "Kodama's Reach"
-        },
-        {
-          "count": 1,
-          "name": "Entish Restoration"
-        },
-        {
-          "count": 1,
-          "name": "Beast Within"
-        },
-        {
-          "count": 1,
-          "name": "Krosan Grip"
-        },
-        {
-          "count": 1,
-          "name": "Nature's Claim"
-        },
-        {
-          "count": 1,
-          "name": "Tamiyo's Safekeeping"
-        },
-        {
-          "count": 1,
-          "name": "Snakeskin Veil"
-        },
-        {
-          "count": 1,
-          "name": "Wrap in Vigor"
-        },
-        {
-          "count": 1,
-          "name": "Ram Through"
-        },
-        {
-          "count": 1,
-          "name": "Return of the Wildspeaker"
-        },
-        {
-          "count": 1,
-          "name": "Overwhelming Stampede"
-        },
-        {
-          "count": 1,
-          "name": "Bala Ged Recovery"
-        },
-        {
-          "count": 1,
-          "name": "Myriad Landscape"
-        },
-        {
-          "count": 1,
-          "name": "Blighted Woodland"
-        },
-        {
-          "count": 1,
-          "name": "Rogue's Passage"
-        },
-        {
-          "count": 1,
-          "name": "Path of Ancestry"
-        },
-        {
-          "count": 1,
-          "name": "Mosswort Bridge"
-        },
-        {
-          "count": 1,
-          "name": "Oran-Rief, the Vastwood"
-        },
-        {
-          "count": 1,
-          "name": "Tranquil Thicket"
-        },
-        {
-          "count": 29,
-          "name": "Forest"
-        },
-        {
-          "count": 1,
-          "name": "Beorn the Fierce"
-        }
-      ],
-      "sideboard": []
-    },
-    {
-      "name": "Trostani, Selesnya's Voice",
-      "author": "MTGGoldfish",
-      "colors": [
-        "G",
-        "W"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Archangel of Thune"
-        },
-        {
-          "count": 1,
-          "name": "Soul Warden"
-        },
-        {
-          "count": 1,
-          "name": "Vorinclex, Voice of Hunger"
-        },
-        {
-          "count": 1,
-          "name": "Shalai, Voice of Plenty"
-        },
-        {
-          "count": 1,
-          "name": "Rhys the Redeemed"
-        },
-        {
-          "count": 1,
-          "name": "Crested Sunmare"
-        },
-        {
-          "count": 1,
-          "name": "Seedborn Muse"
-        },
-        {
-          "count": 1,
-          "name": "Avacyn's Pilgrim"
-        },
-        {
-          "count": 1,
-          "name": "Birds of Paradise"
-        },
-        {
-          "count": 1,
-          "name": "Resplendent Angel"
-        },
-        {
-          "count": 1,
-          "name": "Voice of Resurgence"
-        },
-        {
-          "count": 1,
-          "name": "Sakura-Tribe Elder"
-        },
-        {
-          "count": 1,
-          "name": "Speaker of the Heavens"
-        },
-        {
-          "count": 1,
-          "name": "Llanowar Elves"
-        },
-        {
-          "count": 1,
-          "name": "Accomplished Alchemist"
-        },
-        {
-          "count": 1,
-          "name": "Felidar Sovereign"
-        },
-        {
-          "count": 1,
-          "name": "Ocelot Pride"
-        },
-        {
-          "count": 1,
-          "name": "Conclave Evangelist"
-        },
-        {
-          "count": 1,
-          "name": "Ojer Taq, Deepest Foundation"
-        },
-        {
-          "count": 1,
-          "name": "Exalted Sunborn"
-        },
-        {
-          "count": 1,
-          "name": "Valkyrie Harbinger"
-        },
-        {
-          "count": 1,
-          "name": "Fanatic of Rhonas"
-        },
-        {
-          "count": 1,
-          "name": "Eternal Witness"
-        },
-        {
-          "count": 1,
-          "name": "Arasta of the Endless Web"
-        },
-        {
-          "count": 1,
-          "name": "King Darien XLVIII"
-        },
-        {
-          "count": 1,
-          "name": "Trostani, Selesnya's Voice"
-        },
-        {
-          "count": 1,
-          "name": "Sundering Growth"
-        },
-        {
-          "count": 1,
-          "name": "Druid's Deliverance"
-        },
-        {
-          "count": 1,
-          "name": "Rootborn Defenses"
-        },
-        {
-          "count": 1,
-          "name": "Swords to Plowshares"
-        },
-        {
-          "count": 1,
-          "name": "Path to Exile"
+          "name": "The Great Henge"
         },
         {
           "count": 1,
@@ -797,71 +607,353 @@
         },
         {
           "count": 1,
-          "name": "Generous Gift"
+          "name": "Harmonize"
         },
         {
           "count": 1,
-          "name": "Akroma's Will"
+          "name": "Unnatural Growth"
         },
         {
           "count": 1,
-          "name": "Break Down"
+          "name": "Overwhelming Stampede"
         },
         {
           "count": 1,
-          "name": "Hour of Reckoning"
+          "name": "Growing Rites of Itlimoc"
         },
         {
           "count": 1,
-          "name": "Rampant Growth"
+          "name": "Beastmaster Ascension"
         },
         {
           "count": 1,
-          "name": "Cultivate"
+          "name": "Elemental Bond"
         },
         {
           "count": 1,
-          "name": "Finale of Devastation"
+          "name": "Archdruid's Charm"
         },
         {
           "count": 1,
-          "name": "Kodama's Reach"
+          "name": "Krosan Grip"
         },
         {
           "count": 1,
-          "name": "Farseek"
+          "name": "Fog"
         },
         {
           "count": 1,
-          "name": "Nature's Lore"
+          "name": "Tangle"
         },
         {
           "count": 1,
-          "name": "Camaraderie"
+          "name": "Beast Whisperer"
         },
         {
           "count": 1,
-          "name": "Triumph of the Hordes"
+          "name": "Ohran Frostfang"
         },
         {
           "count": 1,
-          "name": "Halo Fountain"
+          "name": "Tyvar's Stand"
         },
         {
           "count": 1,
-          "name": "Phyrexian Processor"
+          "name": "Legolas's Quick Reflexes"
         },
         {
           "count": 1,
-          "name": "Aetherflux Reservoir"
+          "name": "Ram Through"
         },
         {
           "count": 1,
-          "name": "Mimic Vat"
+          "name": "Smuggler's Surprise"
         },
         {
           "count": 1,
-          "name": "Skullclamp"
+          "name": "Inscription of Abundance"
+        },
+        {
+          "count": 1,
+          "name": "Strength of Will"
+        },
+        {
+          "count": 1,
+          "name": "Kindred Summons"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "Thorin, King of Durin's Folk",
+      "author": "MTGGoldfish",
+      "colors": [
+        "R",
+        "W"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Fili the Pathfinder"
+        },
+        {
+          "count": 1,
+          "name": "Thorin Oakenshield"
+        },
+        {
+          "count": 1,
+          "name": "Bifur, Melodic Rider"
+        },
+        {
+          "count": 1,
+          "name": "Fili and Kili, Joyous"
+        },
+        {
+          "count": 1,
+          "name": "Kili the Resourceful"
+        },
+        {
+          "count": 1,
+          "name": "Gloin, Dwarf Emissary"
+        },
+        {
+          "count": 1,
+          "name": "Magda, Brazen Outlaw"
+        },
+        {
+          "count": 1,
+          "name": "Gimli of the Glittering Caves"
+        },
+        {
+          "count": 1,
+          "name": "An Unexpected Party"
+        },
+        {
+          "count": 1,
+          "name": "Dain's Company"
+        },
+        {
+          "count": 1,
+          "name": "The Lonely Mountain"
+        },
+        {
+          "count": 1,
+          "name": "Orcrist, Goblin-cleaver"
+        },
+        {
+          "count": 1,
+          "name": "Thorin, Mountain-king"
+        },
+        {
+          "count": 1,
+          "name": "Thorin, King of Durin's Folk"
+        },
+        {
+          "count": 1,
+          "name": "Dain Ironfoot"
+        },
+        {
+          "count": 1,
+          "name": "The Arkenstone"
+        },
+        {
+          "count": 1,
+          "name": "Dain, Lord of the Iron Hills"
+        },
+        {
+          "count": 1,
+          "name": "Bofur, Reliable Guardian"
+        },
+        {
+          "count": 1,
+          "name": "Balin, Loremaster"
+        },
+        {
+          "count": 1,
+          "name": "Swords to Plowshares"
+        },
+        {
+          "count": 1,
+          "name": "Dwalin, Weaponmaster"
+        },
+        {
+          "count": 1,
+          "name": "Ori, Plate Stacker"
+        },
+        {
+          "count": 1,
+          "name": "Dori, Bearer of Friends"
+        },
+        {
+          "count": 1,
+          "name": "Dain of the Ancient Halls"
+        },
+        {
+          "count": 1,
+          "name": "Thorin, Company's Leader"
+        },
+        {
+          "count": 1,
+          "name": "Iron Hills Blacksmith"
+        },
+        {
+          "count": 1,
+          "name": "Smaug the Magnificent"
+        },
+        {
+          "count": 1,
+          "name": "Giott, King of the Dwarves"
+        },
+        {
+          "count": 1,
+          "name": "Nori, Teller of Tales"
+        },
+        {
+          "count": 1,
+          "name": "Bruenor Battlehammer"
+        },
+        {
+          "count": 1,
+          "name": "Dwarven Recruiter"
+        },
+        {
+          "count": 1,
+          "name": "Hammers of Moradin"
+        },
+        {
+          "count": 1,
+          "name": "Academy Manufactor"
+        },
+        {
+          "count": 1,
+          "name": "Xorn"
+        },
+        {
+          "count": 1,
+          "name": "Bombur, Gentle Dreamer"
+        },
+        {
+          "count": 1,
+          "name": "Dwarven Mauler"
+        },
+        {
+          "count": 1,
+          "name": "Path to Exile"
+        },
+        {
+          "count": 1,
+          "name": "Boros Charm"
+        },
+        {
+          "count": 1,
+          "name": "Untimely Malfunction"
+        },
+        {
+          "count": 1,
+          "name": "Bilbo's Gambit"
+        },
+        {
+          "count": 1,
+          "name": "Big Score"
+        },
+        {
+          "count": 1,
+          "name": "Unexpected Windfall"
+        },
+        {
+          "count": 1,
+          "name": "Chaos Warp"
+        },
+        {
+          "count": 1,
+          "name": "Blasphemous Act"
+        },
+        {
+          "count": 1,
+          "name": "The Reaver Cleaver"
+        },
+        {
+          "count": 1,
+          "name": "Diamond Pick-Axe"
+        },
+        {
+          "count": 1,
+          "name": "Bearded Axe"
+        },
+        {
+          "count": 1,
+          "name": "Bloodforged Battle-Axe"
+        },
+        {
+          "count": 1,
+          "name": "Mithril Coat"
+        },
+        {
+          "count": 1,
+          "name": "Sunforger"
+        },
+        {
+          "count": 1,
+          "name": "Lightning Greaves"
+        },
+        {
+          "count": 1,
+          "name": "Herald's Horn"
+        },
+        {
+          "count": 1,
+          "name": "Long-Lost Lances"
+        },
+        {
+          "count": 1,
+          "name": "Dwarven Mattock"
+        },
+        {
+          "count": 1,
+          "name": "Gloin the Mighty"
+        },
+        {
+          "count": 1,
+          "name": "Gleaming Splendor"
+        },
+        {
+          "count": 1,
+          "name": "The Misty Mountains Cold"
+        },
+        {
+          "count": 1,
+          "name": "Practiced Scrollsmith"
+        },
+        {
+          "count": 1,
+          "name": "The Eagles Are Coming!"
+        },
+        {
+          "count": 1,
+          "name": "Mines of Moria"
+        },
+        {
+          "count": 1,
+          "name": "Dwarven Mine"
+        },
+        {
+          "count": 1,
+          "name": "Dragon-Cursed Halls"
+        },
+        {
+          "count": 1,
+          "name": "Minas Tirith"
+        },
+        {
+          "count": 1,
+          "name": "Treasure Vault"
+        },
+        {
+          "count": 1,
+          "name": "Rogue's Passage"
         },
         {
           "count": 1,
@@ -873,91 +965,23 @@
         },
         {
           "count": 1,
-          "name": "Selesnya Signet"
+          "name": "Talisman of Conviction"
         },
         {
           "count": 1,
-          "name": "Mirari's Wake"
+          "name": "Boros Signet"
         },
         {
           "count": 1,
-          "name": "Parallel Lives"
+          "name": "Fellwar Stone"
         },
         {
-          "count": 1,
-          "name": "Anointed Procession"
+          "count": 11,
+          "name": "Mountain"
         },
         {
-          "count": 1,
-          "name": "Growing Rites of Itlimoc"
-        },
-        {
-          "count": 1,
-          "name": "Angelic Accord"
-        },
-        {
-          "count": 1,
-          "name": "Tribute to the World Tree"
-        },
-        {
-          "count": 1,
-          "name": "Song of the Worldsoul"
-        },
-        {
-          "count": 1,
-          "name": "Cathars' Crusade"
-        },
-        {
-          "count": 1,
-          "name": "Divine Visitation"
-        },
-        {
-          "count": 1,
-          "name": "Luminarch Ascension"
-        },
-        {
-          "count": 1,
-          "name": "Elspeth Tirel"
-        },
-        {
-          "count": 1,
-          "name": "Silverquill Lecturer"
-        },
-        {
-          "count": 1,
-          "name": "Bountiful Promenade"
-        },
-        {
-          "count": 7,
-          "name": "Forest"
-        },
-        {
-          "count": 7,
+          "count": 6,
           "name": "Plains"
-        },
-        {
-          "count": 1,
-          "name": "Sunpetal Grove"
-        },
-        {
-          "count": 1,
-          "name": "Sungrass Prairie"
-        },
-        {
-          "count": 1,
-          "name": "Lazotep Quarry"
-        },
-        {
-          "count": 1,
-          "name": "Overgrown Farmland"
-        },
-        {
-          "count": 1,
-          "name": "Grove of the Guardian"
-        },
-        {
-          "count": 1,
-          "name": "Gavony Township"
         },
         {
           "count": 1,
@@ -965,55 +989,748 @@
         },
         {
           "count": 1,
-          "name": "Canopy Vista"
+          "name": "Clifftop Retreat"
         },
         {
           "count": 1,
-          "name": "Reliquary Tower"
+          "name": "Battlefield Forge"
         },
         {
           "count": 1,
-          "name": "Vitu-Ghazi, the City-Tree"
+          "name": "Path of Ancestry"
         },
         {
           "count": 1,
-          "name": "Minas Tirith"
+          "name": "Sundown Pass"
         },
         {
           "count": 1,
-          "name": "Scavenger Grounds"
+          "name": "Sacred Foundry"
         },
         {
           "count": 1,
-          "name": "Fountainport"
+          "name": "Furycalm Snarl"
         },
         {
           "count": 1,
-          "name": "Abandoned Air Temple"
+          "name": "Rugged Prairie"
         },
         {
           "count": 1,
-          "name": "War Room"
+          "name": "Radiant Summit"
         },
         {
           "count": 1,
-          "name": "Command Beacon"
+          "name": "Iron Hills"
         },
         {
           "count": 1,
-          "name": "Bala Ged Recovery"
+          "name": "Spectator Seating"
         },
         {
           "count": 1,
-          "name": "Emeria's Call"
+          "name": "Sunbillow Verge"
         },
         {
           "count": 1,
-          "name": "Khalni Garden"
+          "name": "Legion Leadership"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "The Great Goblin",
+      "author": "MTGGoldfish",
+      "colors": [
+        "B",
+        "R"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "The Great Goblin"
         },
         {
           "count": 1,
-          "name": "Castle Ardenvale"
+          "name": "Conspicuous Snoop"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Recruiter"
+        },
+        {
+          "count": 1,
+          "name": "Kiki-Jiki, Mirror Breaker"
+        },
+        {
+          "count": 1,
+          "name": "Torch Courier"
+        },
+        {
+          "count": 1,
+          "name": "Putrid Goblin"
+        },
+        {
+          "count": 1,
+          "name": "Metallic Mimic"
+        },
+        {
+          "count": 1,
+          "name": "Skirk Prospector"
+        },
+        {
+          "count": 1,
+          "name": "Murderous Redcap"
+        },
+        {
+          "count": 1,
+          "name": "Chthonian Nightmare"
+        },
+        {
+          "count": 1,
+          "name": "Mana Vault"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Mox Diamond"
+        },
+        {
+          "count": 1,
+          "name": "Chrome Mox"
+        },
+        {
+          "count": 1,
+          "name": "Lotus Petal"
+        },
+        {
+          "count": 1,
+          "name": "Rite of Flame"
+        },
+        {
+          "count": 1,
+          "name": "Rain of Filth"
+        },
+        {
+          "count": 1,
+          "name": "Dark Ritual"
+        },
+        {
+          "count": 1,
+          "name": "Cabal Ritual"
+        },
+        {
+          "count": 1,
+          "name": "Simian Spirit Guide"
+        },
+        {
+          "count": 1,
+          "name": "Ragavan, Nimble Pilferer"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
+          "name": "Talisman of Indulgence"
+        },
+        {
+          "count": 1,
+          "name": "Orcish Bowmasters"
+        },
+        {
+          "count": 1,
+          "name": "Warren Soultrader"
+        },
+        {
+          "count": 1,
+          "name": "Crime Novelist"
+        },
+        {
+          "count": 1,
+          "name": "Imperial Recruiter"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Matron"
+        },
+        {
+          "count": 1,
+          "name": "Professional Face-Breaker"
+        },
+        {
+          "count": 1,
+          "name": "Birgi, God of Storytelling"
+        },
+        {
+          "count": 1,
+          "name": "Demonic Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Vampiric Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Imperial Seal"
+        },
+        {
+          "count": 1,
+          "name": "Diabolic Intent"
+        },
+        {
+          "count": 1,
+          "name": "Gamble"
+        },
+        {
+          "count": 1,
+          "name": "Wishclaw Talisman"
+        },
+        {
+          "count": 1,
+          "name": "Tainted Pact"
+        },
+        {
+          "count": 1,
+          "name": "Entomb"
+        },
+        {
+          "count": 1,
+          "name": "Reanimate"
+        },
+        {
+          "count": 1,
+          "name": "Doomsday"
+        },
+        {
+          "count": 1,
+          "name": "Shred Memory"
+        },
+        {
+          "count": 1,
+          "name": "Deflecting Swat"
+        },
+        {
+          "count": 1,
+          "name": "Red Elemental Blast"
+        },
+        {
+          "count": 1,
+          "name": "Pyroblast"
+        },
+        {
+          "count": 1,
+          "name": "Tibalt's Trickery"
+        },
+        {
+          "count": 1,
+          "name": "Deadly Rollick"
+        },
+        {
+          "count": 1,
+          "name": "Snuff Out"
+        },
+        {
+          "count": 1,
+          "name": "Lightning Bolt"
+        },
+        {
+          "count": 1,
+          "name": "Slaughter Pact"
+        },
+        {
+          "count": 1,
+          "name": "Bolt Bend"
+        },
+        {
+          "count": 1,
+          "name": "Imp's Mischief"
+        },
+        {
+          "count": 1,
+          "name": "Fire Covenant"
+        },
+        {
+          "count": 1,
+          "name": "Vandalblast"
+        },
+        {
+          "count": 1,
+          "name": "Defense Grid"
+        },
+        {
+          "count": 1,
+          "name": "Wheel of Fortune"
+        },
+        {
+          "count": 1,
+          "name": "Peer into the Abyss"
+        },
+        {
+          "count": 1,
+          "name": "The One Ring"
+        },
+        {
+          "count": 1,
+          "name": "Night's Whisper"
+        },
+        {
+          "count": 1,
+          "name": "Jeska's Will"
+        },
+        {
+          "count": 1,
+          "name": "Ad Nauseam"
+        },
+        {
+          "count": 1,
+          "name": "Necropotence"
+        },
+        {
+          "count": 1,
+          "name": "Badlands"
+        },
+        {
+          "count": 1,
+          "name": "Blood Crypt"
+        },
+        {
+          "count": 1,
+          "name": "Luxury Suite"
+        },
+        {
+          "count": 1,
+          "name": "Bloodstained Mire"
+        },
+        {
+          "count": 1,
+          "name": "Polluted Delta"
+        },
+        {
+          "count": 1,
+          "name": "Wooded Foothills"
+        },
+        {
+          "count": 1,
+          "name": "Arid Mesa"
+        },
+        {
+          "count": 1,
+          "name": "Scalding Tarn"
+        },
+        {
+          "count": 1,
+          "name": "Marsh Flats"
+        },
+        {
+          "count": 1,
+          "name": "Verdant Catacombs"
+        },
+        {
+          "count": 1,
+          "name": "Prismatic Vista"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "City of Brass"
+        },
+        {
+          "count": 1,
+          "name": "Mana Confluence"
+        },
+        {
+          "count": 1,
+          "name": "Exotic Orchard"
+        },
+        {
+          "count": 1,
+          "name": "Gemstone Caverns"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Tomb"
+        },
+        {
+          "count": 1,
+          "name": "Mount Doom"
+        },
+        {
+          "count": 1,
+          "name": "Agadeem's Awakening"
+        },
+        {
+          "count": 1,
+          "name": "Shatterskull Smashing"
+        },
+        {
+          "count": 9,
+          "name": "Swamp"
+        },
+        {
+          "count": 10,
+          "name": "Mountain"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "Thranduil, the Elvenking",
+      "author": "MTGGoldfish",
+      "colors": [],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Arcane Investigator [AFR]"
+        },
+        {
+          "count": 1,
+          "name": "Gnarlroot Trapper [ORI]"
+        },
+        {
+          "count": 1,
+          "name": "Skemfar Avenger [KHM] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Skemfar Shadowsage [KHM]"
+        },
+        {
+          "count": 1,
+          "name": "Gilt-Leaf Winnower [ORI]"
+        },
+        {
+          "count": 1,
+          "name": "Llanowar Elves [FDN]"
+        },
+        {
+          "count": 1,
+          "name": "Quirion Ranger [MH2]"
+        },
+        {
+          "count": 1,
+          "name": "Wirewood Symbiote [MH3]"
+        },
+        {
+          "count": 1,
+          "name": "Druid of the Cowl [AER]"
+        },
+        {
+          "count": 1,
+          "name": "Devoted Druid [NCC]"
+        },
+        {
+          "count": 1,
+          "name": "Incubation Druid [RNA]"
+        },
+        {
+          "count": 1,
+          "name": "Wirewood Herald [ONS]"
+        },
+        {
+          "count": 1,
+          "name": "Wirewood Elf [ONS]"
+        },
+        {
+          "count": 1,
+          "name": "Priest of Titania [MH3]"
+        },
+        {
+          "count": 1,
+          "name": "Wellwisher [C14]"
+        },
+        {
+          "count": 1,
+          "name": "Llanowar Visionary [M21]"
+        },
+        {
+          "count": 1,
+          "name": "Timberwatch Elf [C14]"
+        },
+        {
+          "count": 1,
+          "name": "Imperious Perfect [LRW]"
+        },
+        {
+          "count": 1,
+          "name": "Reclamation Sage [C20]"
+        },
+        {
+          "count": 1,
+          "name": "Sage of the Maze [M3C]"
+        },
+        {
+          "count": 1,
+          "name": "Farhaven Elf [CMR]"
+        },
+        {
+          "count": 1,
+          "name": "Elvish Archdruid [JMP]"
+        },
+        {
+          "count": 1,
+          "name": "Mul Daya Channelers [ROE]"
+        },
+        {
+          "count": 1,
+          "name": "Lys Alana Huntmaster [EMA]"
+        },
+        {
+          "count": 1,
+          "name": "Immaculate Magistrate [CMR]"
+        },
+        {
+          "count": 1,
+          "name": "Oakhame Adversary [ELD]"
+        },
+        {
+          "count": 1,
+          "name": "Wirewood Channeler [LGN]"
+        },
+        {
+          "count": 1,
+          "name": "Masked Admirers [C14]"
+        },
+        {
+          "count": 1,
+          "name": "Ulvenwald Oddity [VOW]"
+        },
+        {
+          "count": 1,
+          "name": "Temur Sabertooth [FRF]"
+        },
+        {
+          "count": 1,
+          "name": "Dwynen, Gilt-Leaf Daen [ORI]"
+        },
+        {
+          "count": 1,
+          "name": "Voice of the Woods [EVG]"
+        },
+        {
+          "count": 1,
+          "name": "Disciple of Freyalise [MH3]"
+        },
+        {
+          "count": 1,
+          "name": "Shaman of the Pack [ORI]"
+        },
+        {
+          "count": 1,
+          "name": "Morcant's Loyalist [ECL]"
+        },
+        {
+          "count": 1,
+          "name": "Harald, King of Skemfar <showcase> [KHM]"
+        },
+        {
+          "count": 1,
+          "name": "Lathril, Blade of the Elves [FDN]"
+        },
+        {
+          "count": 1,
+          "name": "Golgari Findbroker [GRN]"
+        },
+        {
+          "count": 1,
+          "name": "Garruk, Primal Hunter [M13]"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring [C21]"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet [C21]"
+        },
+        {
+          "count": 1,
+          "name": "Thousand-Year Elixir [LRW]"
+        },
+        {
+          "count": 1,
+          "name": "Serpent's Soul-Jar [KHC]"
+        },
+        {
+          "count": 1,
+          "name": "Syncopate [INR]"
+        },
+        {
+          "count": 1,
+          "name": "Negate [AER]"
+        },
+        {
+          "count": 1,
+          "name": "Eyeblight's Ending [LRW]"
+        },
+        {
+          "count": 1,
+          "name": "Heritage Reclamation [TDM]"
+        },
+        {
+          "count": 1,
+          "name": "Return of the Wildspeaker [AFC]"
+        },
+        {
+          "count": 1,
+          "name": "Putrefy [DGM]"
+        },
+        {
+          "count": 1,
+          "name": "Deathsprout [WAR]"
+        },
+        {
+          "count": 1,
+          "name": "Distant Melody [ECC]"
+        },
+        {
+          "count": 1,
+          "name": "Victimize [TDC]"
+        },
+        {
+          "count": 1,
+          "name": "Buried Alive [MH3]"
+        },
+        {
+          "count": 1,
+          "name": "Minions' Murmurs [TSR]"
+        },
+        {
+          "count": 1,
+          "name": "Eyeblight Massacre [CMR]"
+        },
+        {
+          "count": 1,
+          "name": "Green Sun's Twilight [ONE]"
+        },
+        {
+          "count": 1,
+          "name": "Genesis Wave [IMA]"
+        },
+        {
+          "count": 1,
+          "name": "Harmonize [DSC]"
+        },
+        {
+          "count": 1,
+          "name": "Shamanic Revelation [2XM]"
+        },
+        {
+          "count": 1,
+          "name": "Preposterous Proportions [FDN]"
+        },
+        {
+          "count": 1,
+          "name": "Freed from the Real [A25]"
+        },
+        {
+          "count": 1,
+          "name": "Reconnaissance Mission [IKO]"
+        },
+        {
+          "count": 1,
+          "name": "Prowess of the Fair [LRW]"
+        },
+        {
+          "count": 1,
+          "name": "Pride of the Perfect [CMR]"
+        },
+        {
+          "count": 1,
+          "name": "Morcant's Eyes [ECL]"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower [MKC]"
+        },
+        {
+          "count": 1,
+          "name": "Path of Ancestry [CMR]"
+        },
+        {
+          "count": 1,
+          "name": "Secluded Courtyard [FDN]"
+        },
+        {
+          "count": 1,
+          "name": "Opulent Palace [C17]"
+        },
+        {
+          "count": 1,
+          "name": "Dimir Aqueduct [OTC]"
+        },
+        {
+          "count": 1,
+          "name": "Simic Growth Chamber [AFC]"
+        },
+        {
+          "count": 1,
+          "name": "Golgari Rot Farm [ECC]"
+        },
+        {
+          "count": 1,
+          "name": "Dismal Backwater [M21]"
+        },
+        {
+          "count": 1,
+          "name": "Thornwood Falls [M21]"
+        },
+        {
+          "count": 1,
+          "name": "Jungle Hollow [M20]"
+        },
+        {
+          "count": 1,
+          "name": "Thriving Isle [AFC]"
+        },
+        {
+          "count": 1,
+          "name": "Thriving Moor [LCC]"
+        },
+        {
+          "count": 1,
+          "name": "Thriving Grove [JMP]"
+        },
+        {
+          "count": 1,
+          "name": "Foreboding Landscape [MH3]"
+        },
+        {
+          "count": 1,
+          "name": "Myriad Landscape <precon> [CMR]"
+        },
+        {
+          "count": 1,
+          "name": "Ash Barrens [C19]"
+        },
+        {
+          "count": 3,
+          "name": "Island <42> [DDI]"
+        },
+        {
+          "count": 4,
+          "name": "Swamp <281> [TDM]"
+        },
+        {
+          "count": 11,
+          "name": "Forest <266> [ELD]"
+        },
+        {
+          "count": 1,
+          "name": "Thranduil, the Elvenking <019f75e9-1734-746b-a9b6-739a7eee666e> [HOB]"
         }
       ],
       "sideboard": []
@@ -1349,10 +2066,13 @@
       "sideboard": []
     },
     {
-      "name": "Thorin, King of Durin's Folk",
+      "name": "The Ur-Dragon",
       "author": "MTGGoldfish",
       "colors": [
+        "G",
+        "U",
         "R",
+        "B",
         "W"
       ],
       "tags": [
@@ -1361,131 +2081,43 @@
       "main": [
         {
           "count": 1,
-          "name": "Academy Manufactor"
+          "name": "Path of Ancestry"
         },
         {
           "count": 1,
-          "name": "An Unexpected Party"
+          "name": "Lotus Field"
         },
         {
           "count": 1,
-          "name": "Ancient Den"
+          "name": "Cascading Cataracts"
+        },
+        {
+          "count": 2,
+          "name": "Forest"
+        },
+        {
+          "count": 2,
+          "name": "Island"
         },
         {
           "count": 1,
-          "name": "Arcane Signet"
+          "name": "Mystic Monastery"
+        },
+        {
+          "count": 4,
+          "name": "Mountain"
         },
         {
           "count": 1,
-          "name": "Balin, Loremaster"
+          "name": "Secluded Courtyard"
         },
         {
-          "count": 1,
-          "name": "Battlefield Forge"
+          "count": 2,
+          "name": "Swamp"
         },
         {
-          "count": 1,
-          "name": "Bearded Axe"
-        },
-        {
-          "count": 1,
-          "name": "Bifur, Melodic Rider"
-        },
-        {
-          "count": 1,
-          "name": "Big Score"
-        },
-        {
-          "count": 1,
-          "name": "Bilbo's Gambit"
-        },
-        {
-          "count": 1,
-          "name": "Blasphemous Act"
-        },
-        {
-          "count": 1,
-          "name": "Bloodforged Battle-Axe"
-        },
-        {
-          "count": 1,
-          "name": "Bofur, Reliable Guardian"
-        },
-        {
-          "count": 1,
-          "name": "Bombur, Gentle Dreamer"
-        },
-        {
-          "count": 1,
-          "name": "Boros Charm"
-        },
-        {
-          "count": 1,
-          "name": "Bruenor Battlehammer"
-        },
-        {
-          "count": 1,
-          "name": "Clifftop Retreat"
-        },
-        {
-          "count": 1,
-          "name": "Colossus Hammer"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Dori, Bearer of Friends"
-        },
-        {
-          "count": 1,
-          "name": "Dragon-Cursed Halls"
-        },
-        {
-          "count": 1,
-          "name": "Dwalin, Weaponmaster"
-        },
-        {
-          "count": 1,
-          "name": "Dwarven Mattock"
-        },
-        {
-          "count": 1,
-          "name": "Dwarven Mine"
-        },
-        {
-          "count": 1,
-          "name": "Dwarven Recruiter"
-        },
-        {
-          "count": 1,
-          "name": "Dwarven Shortsword"
-        },
-        {
-          "count": 1,
-          "name": "Dain Ironfoot"
-        },
-        {
-          "count": 1,
-          "name": "Dain of the Ancient Halls"
-        },
-        {
-          "count": 1,
-          "name": "Dain's Company"
-        },
-        {
-          "count": 1,
-          "name": "Dain, Lord of the Iron Hills"
-        },
-        {
-          "count": 1,
-          "name": "Embercleave"
-        },
-        {
-          "count": 1,
-          "name": "Evolving Wilds"
+          "count": 2,
+          "name": "Plains"
         },
         {
           "count": 1,
@@ -1493,155 +2125,75 @@
         },
         {
           "count": 1,
-          "name": "Fabled Passage"
+          "name": "Forbidden Orchard"
         },
         {
           "count": 1,
-          "name": "Furycalm Snarl"
+          "name": "Nomad Outpost"
         },
         {
           "count": 1,
-          "name": "Fili and Kili, Joyous"
+          "name": "Spara's Headquarters"
         },
         {
           "count": 1,
-          "name": "Fili the Pathfinder"
+          "name": "Haven of the Spirit Dragon"
         },
         {
           "count": 1,
-          "name": "Gimli of the Glittering Caves"
+          "name": "Temple of the Dragon Queen"
         },
         {
           "count": 1,
-          "name": "Giott, King of the Dwarves"
+          "name": "Evolving Wilds"
         },
         {
           "count": 1,
-          "name": "Gleaming Splendor"
+          "name": "Unclaimed Territory"
         },
         {
           "count": 1,
-          "name": "Gloin the Mighty"
+          "name": "Spire of Industry"
         },
         {
           "count": 1,
-          "name": "Gloin, Dwarf Emissary"
+          "name": "Command Tower"
         },
         {
           "count": 1,
-          "name": "Goldvein Pick"
+          "name": "Indatha Triome"
         },
         {
           "count": 1,
-          "name": "Great Furnace"
+          "name": "Ketria Triome"
         },
         {
           "count": 1,
-          "name": "Hammers of Moradin"
+          "name": "Zagoth Triome"
         },
         {
           "count": 1,
-          "name": "Herald's Horn"
+          "name": "Rockfall Vale"
         },
         {
           "count": 1,
-          "name": "Iron Hills Blacksmith"
+          "name": "Terramorphic Expanse"
         },
         {
           "count": 1,
-          "name": "Kili the Resourceful"
-        },
-        {
-          "count": 1,
-          "name": "Legion Leadership"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves"
-        },
-        {
-          "count": 1,
-          "name": "Long-Lost Lances"
-        },
-        {
-          "count": 1,
-          "name": "Magda, Brazen Outlaw"
-        },
-        {
-          "count": 1,
-          "name": "Minas Tirith"
-        },
-        {
-          "count": 1,
-          "name": "Mines of Moria"
-        },
-        {
-          "count": 1,
-          "name": "Mithril Coat"
-        },
-        {
-          "count": 8,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Nori, Teller of Tales"
-        },
-        {
-          "count": 1,
-          "name": "Orcrist, Goblin-cleaver"
-        },
-        {
-          "count": 1,
-          "name": "Ori, Plate Stacker"
-        },
-        {
-          "count": 1,
-          "name": "Patchwork Banner"
-        },
-        {
-          "count": 1,
-          "name": "Path of Ancestry"
+          "name": "Birds of Paradise"
         },
         {
           "count": 1,
           "name": "Path to Exile"
         },
         {
-          "count": 8,
-          "name": "Plains"
+          "count": 1,
+          "name": "Tamiyo's Safekeeping"
         },
         {
           "count": 1,
-          "name": "Radiant Summit"
-        },
-        {
-          "count": 1,
-          "name": "Rogue's Passage"
-        },
-        {
-          "count": 1,
-          "name": "Rugged Prairie"
-        },
-        {
-          "count": 1,
-          "name": "Seize the Spoils"
-        },
-        {
-          "count": 1,
-          "name": "Slayers' Stronghold"
-        },
-        {
-          "count": 1,
-          "name": "Smaug the Magnificent"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Sundown Pass"
+          "name": "Dig Up"
         },
         {
           "count": 1,
@@ -1649,59 +2201,255 @@
         },
         {
           "count": 1,
-          "name": "The Arkenstone"
+          "name": "Worldly Tutor"
         },
         {
           "count": 1,
-          "name": "The Lonely Mountain"
+          "name": "Goblin Anarchomancer"
         },
         {
           "count": 1,
-          "name": "The Misty Mountains Cold"
+          "name": "Farseek"
         },
         {
           "count": 1,
-          "name": "The Reaver Cleaver"
+          "name": "Eladamri's Call"
         },
         {
           "count": 1,
-          "name": "There and Back Again"
+          "name": "Lotus Cobra"
         },
         {
           "count": 1,
-          "name": "Thorin Oakenshield"
+          "name": "Rampant Growth"
         },
         {
           "count": 1,
-          "name": "Thorin, Company's Leader"
+          "name": "Despark"
         },
         {
           "count": 1,
-          "name": "Thorin, Mountain-king"
+          "name": "And They Shall Know No Fear"
         },
         {
           "count": 1,
-          "name": "Treasure Vault"
+          "name": "Once Upon a Time"
         },
         {
           "count": 1,
-          "name": "Unexpected Windfall"
+          "name": "Bloom Tender"
         },
         {
           "count": 1,
-          "name": "Windbrisk Heights"
+          "name": "Korlessa, Scale Singer"
         },
         {
           "count": 1,
-          "name": "Xorn"
+          "name": "Darksteel Mutation"
         },
         {
           "count": 1,
-          "name": "Oin the Brave"
+          "name": "Orb of Dragonkind"
         },
         {
           "count": 1,
-          "name": "Thorin, King of Durin's Folk"
+          "name": "Nature's Lore"
+        },
+        {
+          "count": 1,
+          "name": "Dragon Tempest"
+        },
+        {
+          "count": 1,
+          "name": "Temur Ascendancy"
+        },
+        {
+          "count": 1,
+          "name": "Herald's Horn"
+        },
+        {
+          "count": 1,
+          "name": "Domri, Anarch of Bolas"
+        },
+        {
+          "count": 1,
+          "name": "Urza's Incubator"
+        },
+        {
+          "count": 1,
+          "name": "Chromatic Lantern"
+        },
+        {
+          "count": 1,
+          "name": "Garruk's Uprising"
+        },
+        {
+          "count": 1,
+          "name": "Rhythm of the Wild"
+        },
+        {
+          "count": 1,
+          "name": "Rivaz of the Claw"
+        },
+        {
+          "count": 1,
+          "name": "Sarkhan, Soul Aflame"
+        },
+        {
+          "count": 1,
+          "name": "Sylvia Brightspear"
+        },
+        {
+          "count": 1,
+          "name": "Dragon's Hoard"
+        },
+        {
+          "count": 1,
+          "name": "Dragonspeaker Shaman"
+        },
+        {
+          "count": 1,
+          "name": "Dragonborn Champion"
+        },
+        {
+          "count": 1,
+          "name": "Chandra, Torch of Defiance"
+        },
+        {
+          "count": 1,
+          "name": "Sarkhan's Unsealing"
+        },
+        {
+          "count": 1,
+          "name": "Leyline Tyrant"
+        },
+        {
+          "count": 1,
+          "name": "Call the Spirit Dragons"
+        },
+        {
+          "count": 1,
+          "name": "Crux of Fate"
+        },
+        {
+          "count": 1,
+          "name": "Patriarch's Bidding"
+        },
+        {
+          "count": 1,
+          "name": "Goldspan Dragon"
+        },
+        {
+          "count": 1,
+          "name": "Scion of the Ur-Dragon"
+        },
+        {
+          "count": 1,
+          "name": "Iymrith, Desert Doom"
+        },
+        {
+          "count": 1,
+          "name": "Timeless Lotus"
+        },
+        {
+          "count": 1,
+          "name": "Dragonlord Ojutai"
+        },
+        {
+          "count": 1,
+          "name": "Scalelord Reckoner"
+        },
+        {
+          "count": 1,
+          "name": "Terror of the Peaks"
+        },
+        {
+          "count": 1,
+          "name": "Thrakkus the Butcher"
+        },
+        {
+          "count": 1,
+          "name": "Twinflame Tyrant"
+        },
+        {
+          "count": 1,
+          "name": "Two-Headed Hellkite"
+        },
+        {
+          "count": 1,
+          "name": "Hellkite Courser"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Copper Dragon"
+        },
+        {
+          "count": 1,
+          "name": "Dragonlord Dromoka"
+        },
+        {
+          "count": 1,
+          "name": "Lathliss, Dragon Queen"
+        },
+        {
+          "count": 1,
+          "name": "Miirym, Sentinel Wyrm"
+        },
+        {
+          "count": 1,
+          "name": "Dragonlord Silumgar"
+        },
+        {
+          "count": 1,
+          "name": "Stormscale Scion"
+        },
+        {
+          "count": 1,
+          "name": "Hellkite Tyrant"
+        },
+        {
+          "count": 1,
+          "name": "Atarka, World Render"
+        },
+        {
+          "count": 1,
+          "name": "Balefire Dragon"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Brass Dragon"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Gold Dragon"
+        },
+        {
+          "count": 1,
+          "name": "Old Gnawbone"
+        },
+        {
+          "count": 1,
+          "name": "Last March of the Ents"
+        },
+        {
+          "count": 1,
+          "name": "Dracogenesis"
+        },
+        {
+          "count": 1,
+          "name": "Utvara Hellkite"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Silver Dragon"
+        },
+        {
+          "count": 1,
+          "name": "The Great Henge"
+        },
+        {
+          "count": 1,
+          "name": "The Ur-Dragon"
         }
       ],
       "sideboard": []
@@ -2074,823 +2822,12 @@
       "sideboard": []
     },
     {
-      "name": "The Great Goblin",
-      "author": "MTGGoldfish",
-      "colors": [
-        "B",
-        "R"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Ad Nauseam"
-        },
-        {
-          "count": 1,
-          "name": "Agadeem's Awakening"
-        },
-        {
-          "count": 1,
-          "name": "Agatha's Soul Cauldron"
-        },
-        {
-          "count": 1,
-          "name": "Ancient Tomb"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Arena of Glory"
-        },
-        {
-          "count": 1,
-          "name": "Arid Mesa"
-        },
-        {
-          "count": 1,
-          "name": "Badlands"
-        },
-        {
-          "count": 1,
-          "name": "Beseech the Mirror"
-        },
-        {
-          "count": 1,
-          "name": "Blazemire Verge"
-        },
-        {
-          "count": 1,
-          "name": "Blood Crypt"
-        },
-        {
-          "count": 1,
-          "name": "Bloodstained Mire"
-        },
-        {
-          "count": 1,
-          "name": "Boggart Harbinger"
-        },
-        {
-          "count": 1,
-          "name": "Cabal Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Cavern of Souls"
-        },
-        {
-          "count": 1,
-          "name": "Chrome Mox"
-        },
-        {
-          "count": 1,
-          "name": "City of Brass"
-        },
-        {
-          "count": 1,
-          "name": "City of Traitors"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Conspicuous Snoop"
-        },
-        {
-          "count": 1,
-          "name": "Culling the Weak"
-        },
-        {
-          "count": 1,
-          "name": "Dark Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Defense Grid"
-        },
-        {
-          "count": 1,
-          "name": "Deflecting Swat"
-        },
-        {
-          "count": 1,
-          "name": "Demonic Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Desperate Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Diabolic Intent"
-        },
-        {
-          "count": 1,
-          "name": "Entomb"
-        },
-        {
-          "count": 1,
-          "name": "Final Fortune"
-        },
-        {
-          "count": 1,
-          "name": "First Day of Class"
-        },
-        {
-          "count": 1,
-          "name": "Flare of Duplication"
-        },
-        {
-          "count": 1,
-          "name": "Flashback"
-        },
-        {
-          "count": 1,
-          "name": "Fogwell's Gym"
-        },
-        {
-          "count": 1,
-          "name": "Gamble"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Bombardment"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Chirurgeon"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Engineer"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Lackey"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Matron"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Recruiter"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Sharpshooter"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Welder"
-        },
-        {
-          "count": 1,
-          "name": "Great Furnace"
-        },
-        {
-          "count": 1,
-          "name": "Grinding Station"
-        },
-        {
-          "count": 1,
-          "name": "Hanweir Battlements"
-        },
-        {
-          "count": 1,
-          "name": "Hexing Squelcher"
-        },
-        {
-          "count": 1,
-          "name": "Imperial Recruiter"
-        },
-        {
-          "count": 1,
-          "name": "Imperial Seal"
-        },
-        {
-          "count": 1,
-          "name": "Impulsive Pilferer"
-        },
-        {
-          "count": 1,
-          "name": "Infernal Plunge"
-        },
-        {
-          "count": 1,
-          "name": "Jeska's Will"
-        },
-        {
-          "count": 1,
-          "name": "Kiki-Jiki, Mirror Breaker"
-        },
-        {
-          "count": 1,
-          "name": "Lion's Eye Diamond"
-        },
-        {
-          "count": 1,
-          "name": "Lively Dirge"
-        },
-        {
-          "count": 1,
-          "name": "Lotus Petal"
-        },
-        {
-          "count": 1,
-          "name": "Luxury Suite"
-        },
-        {
-          "count": 1,
-          "name": "Mana Confluence"
-        },
-        {
-          "count": 1,
-          "name": "Mana Vault"
-        },
-        {
-          "count": 1,
-          "name": "Metallic Mimic"
-        },
-        {
-          "count": 1,
-          "name": "Mogg Fanatic"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Mox Amber"
-        },
-        {
-          "count": 1,
-          "name": "Mox Diamond"
-        },
-        {
-          "count": 1,
-          "name": "Mox Opal"
-        },
-        {
-          "count": 1,
-          "name": "Murderous Redcap"
-        },
-        {
-          "count": 1,
-          "name": "Necropotence"
-        },
-        {
-          "count": 1,
-          "name": "Orcish Bowmasters"
-        },
-        {
-          "count": 1,
-          "name": "Phyrexian Tower"
-        },
-        {
-          "count": 1,
-          "name": "Polluted Delta"
-        },
-        {
-          "count": 1,
-          "name": "Putrid Goblin"
-        },
-        {
-          "count": 1,
-          "name": "Pyre of Heroes"
-        },
-        {
-          "count": 1,
-          "name": "Pyretic Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Pyroblast"
-        },
-        {
-          "count": 1,
-          "name": "Ragavan, Nimble Pilferer"
-        },
-        {
-          "count": 1,
-          "name": "Raucous Theater"
-        },
-        {
-          "count": 1,
-          "name": "Reanimate"
-        },
-        {
-          "count": 1,
-          "name": "Redirect Lightning"
-        },
-        {
-          "count": 1,
-          "name": "Rite of Flame"
-        },
-        {
-          "count": 1,
-          "name": "Saw in Half"
-        },
-        {
-          "count": 1,
-          "name": "Scalding Tarn"
-        },
-        {
-          "count": 1,
-          "name": "Simian Spirit Guide"
-        },
-        {
-          "count": 1,
-          "name": "Skirk Prospector"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Springleaf Drum"
-        },
-        {
-          "count": 1,
-          "name": "Starting Town"
-        },
-        {
-          "count": 1,
-          "name": "Sulfurous Springs"
-        },
-        {
-          "count": 1,
-          "name": "Tainted Pact"
-        },
-        {
-          "count": 1,
-          "name": "Thran Vigil"
-        },
-        {
-          "count": 1,
-          "name": "Torch Courier"
-        },
-        {
-          "count": 1,
-          "name": "Treasonous Ogre"
-        },
-        {
-          "count": 1,
-          "name": "Underworld Breach"
-        },
-        {
-          "count": 1,
-          "name": "Vampiric Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Vexing Bauble"
-        },
-        {
-          "count": 1,
-          "name": "Warren Soultrader"
-        },
-        {
-          "count": 1,
-          "name": "Wheel of Fortune"
-        },
-        {
-          "count": 1,
-          "name": "Wishclaw Talisman"
-        },
-        {
-          "count": 1,
-          "name": "Wooded Foothills"
-        },
-        {
-          "count": 1,
-          "name": "The Great Goblin"
-        },
-        {
-          "count": 1,
-          "name": "Urborg, Tomb of Yawgmoth"
-        },
-        {
-          "count": 1,
-          "name": "Gemstone Caverns"
-        }
-      ],
-      "sideboard": []
-    },
-    {
-      "name": "The Ur-Dragon",
-      "author": "MTGGoldfish",
-      "colors": [
-        "G",
-        "B",
-        "U",
-        "W",
-        "R"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "The Ur-Dragon"
-        },
-        {
-          "count": 1,
-          "name": "Fist of Suns"
-        },
-        {
-          "count": 1,
-          "name": "Colossal Majesty"
-        },
-        {
-          "count": 1,
-          "name": "Earthquake Dragon"
-        },
-        {
-          "count": 1,
-          "name": "Frontier Bivouac"
-        },
-        {
-          "count": 1,
-          "name": "Hellkite Charger"
-        },
-        {
-          "count": 1,
-          "name": "Tatyova, Benthic Druid"
-        },
-        {
-          "count": 1,
-          "name": "Planar Bridge"
-        },
-        {
-          "count": 1,
-          "name": "Migration Path"
-        },
-        {
-          "count": 1,
-          "name": "Draconic Lore"
-        },
-        {
-          "count": 1,
-          "name": "Mox Amber"
-        },
-        {
-          "count": 1,
-          "name": "Slimefoot's Survey"
-        },
-        {
-          "count": 1,
-          "name": "Hoard-Smelter Dragon"
-        },
-        {
-          "count": 1,
-          "name": "Vivid Meadow"
-        },
-        {
-          "count": 1,
-          "name": "Sandsteppe Citadel"
-        },
-        {
-          "count": 1,
-          "name": "Crucible of Fire"
-        },
-        {
-          "count": 1,
-          "name": "Chart a Course"
-        },
-        {
-          "count": 1,
-          "name": "Intet, the Dreamer"
-        },
-        {
-          "count": 1,
-          "name": "Chromanticore"
-        },
-        {
-          "count": 1,
-          "name": "Crucible of the Spirit Dragon"
-        },
-        {
-          "count": 1,
-          "name": "Vivid Creek"
-        },
-        {
-          "count": 1,
-          "name": "Taigam, Ojutai Master"
-        },
-        {
-          "count": 1,
-          "name": "Sunscorch Regent"
-        },
-        {
-          "count": 1,
-          "name": "Territorial Hellkite"
-        },
-        {
-          "count": 1,
-          "name": "Dromoka, the Eternal"
-        },
-        {
-          "count": 1,
-          "name": "O-Kagachi, Vengeful Kami"
-        },
-        {
-          "count": 1,
-          "name": "Chromatic Lantern"
-        },
-        {
-          "count": 1,
-          "name": "Abundance"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Sanctum"
-        },
-        {
-          "count": 1,
-          "name": "Market Festival"
-        },
-        {
-          "count": 1,
-          "name": "Crosis, the Purger"
-        },
-        {
-          "count": 1,
-          "name": "Caves of Koilos"
-        },
-        {
-          "count": 1,
-          "name": "Kindred Discovery"
-        },
-        {
-          "count": 1,
-          "name": "Atarka, World Render"
-        },
-        {
-          "count": 1,
-          "name": "Ankle Shanker"
-        },
-        {
-          "count": 1,
-          "name": "Boneyard Scourge"
-        },
-        {
-          "count": 1,
-          "name": "Scourge of Valkas"
-        },
-        {
-          "count": 1,
-          "name": "Door to Nothingness"
-        },
-        {
-          "count": 1,
-          "name": "Circuitous Route"
-        },
-        {
-          "count": 1,
-          "name": "Herald's Horn"
-        },
-        {
-          "count": 1,
-          "name": "Nomad Outpost"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Ramos, Dragon Engine"
-        },
-        {
-          "count": 1,
-          "name": "Grow from the Ashes"
-        },
-        {
-          "count": 1,
-          "name": "Path of Ancestry"
-        },
-        {
-          "count": 1,
-          "name": "Kolaghan, the Storm's Fury"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Wasitora, Nekoru Queen"
-        },
-        {
-          "count": 1,
-          "name": "Cosmotronic Wave"
-        },
-        {
-          "count": 1,
-          "name": "Haven of the Spirit Dragon"
-        },
-        {
-          "count": 1,
-          "name": "Stone Quarry"
-        },
-        {
-          "count": 1,
-          "name": "Dragon Cultist"
-        },
-        {
-          "count": 1,
-          "name": "Curse of Opulence"
-        },
-        {
-          "count": 1,
-          "name": "Tyrant's Familiar"
-        },
-        {
-          "count": 1,
-          "name": "Steel Hellkite"
-        },
-        {
-          "count": 1,
-          "name": "Vivid Crag"
-        },
-        {
-          "count": 1,
-          "name": "Broodmate Dragon"
-        },
-        {
-          "count": 1,
-          "name": "Bladewing the Risen"
-        },
-        {
-          "count": 1,
-          "name": "Utvara Hellkite"
-        },
-        {
-          "count": 1,
-          "name": "Dragonlord's Servant"
-        },
-        {
-          "count": 1,
-          "name": "Jungle Shrine"
-        },
-        {
-          "count": 1,
-          "name": "Sunbird's Invocation"
-        },
-        {
-          "count": 1,
-          "name": "Dragonskull Summit"
-        },
-        {
-          "count": 1,
-          "name": "Glacial Fortress"
-        },
-        {
-          "count": 1,
-          "name": "Elemental Bond"
-        },
-        {
-          "count": 1,
-          "name": "Niv-Mizzet, Dracogenius"
-        },
-        {
-          "count": 1,
-          "name": "You're Confronted by Robbers"
-        },
-        {
-          "count": 1,
-          "name": "Dragon Tempest"
-        },
-        {
-          "count": 1,
-          "name": "Trailblazer's Boots"
-        },
-        {
-          "count": 1,
-          "name": "Farseek"
-        },
-        {
-          "count": 1,
-          "name": "Kamahl's Druidic Vow"
-        },
-        {
-          "count": 1,
-          "name": "Hinterland Harbor"
-        },
-        {
-          "count": 1,
-          "name": "Bounty of the Luxa"
-        },
-        {
-          "count": 1,
-          "name": "Silumgar, the Drifting Death"
-        },
-        {
-          "count": 1,
-          "name": "Woodland Cemetery"
-        },
-        {
-          "count": 1,
-          "name": "Kodama's Reach"
-        },
-        {
-          "count": 1,
-          "name": "Jade Orb of Dragonkind"
-        },
-        {
-          "count": 1,
-          "name": "Plaza of Heroes"
-        },
-        {
-          "count": 1,
-          "name": "Teneb, the Harvester"
-        },
-        {
-          "count": 1,
-          "name": "Sleep"
-        },
-        {
-          "count": 1,
-          "name": "Opulent Palace"
-        },
-        {
-          "count": 1,
-          "name": "Scalelord Reckoner"
-        },
-        {
-          "count": 1,
-          "name": "Righteous Authority"
-        },
-        {
-          "count": 1,
-          "name": "Response // Resurgence"
-        },
-        {
-          "count": 1,
-          "name": "Vanquisher's Banner"
-        },
-        {
-          "count": 1,
-          "name": "Savage Lands"
-        },
-        {
-          "count": 1,
-          "name": "Warstorm Surge"
-        },
-        {
-          "count": 1,
-          "name": "Vivid Grove"
-        },
-        {
-          "count": 1,
-          "name": "Vivid Marsh"
-        },
-        {
-          "count": 1,
-          "name": "Ojutai, Soul of Winter"
-        },
-        {
-          "count": 2,
-          "name": "Forest"
-        },
-        {
-          "count": 2,
-          "name": "Swamp"
-        },
-        {
-          "count": 2,
-          "name": "Island"
-        },
-        {
-          "count": 2,
-          "name": "Plains"
-        },
-        {
-          "count": 2,
-          "name": "Mountain"
-        }
-      ],
-      "sideboard": []
-    },
-    {
       "name": "Kaalia of the Vast",
       "author": "MTGGoldfish",
       "colors": [
         "R",
-        "W",
-        "B"
+        "B",
+        "W"
       ],
       "tags": [
         "metagame"
@@ -2902,35 +2839,103 @@
         },
         {
           "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Boros Signet"
-        },
-        {
-          "count": 1,
-          "name": "Commander's Sphere"
-        },
-        {
-          "count": 1,
-          "name": "Helm of the Host"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves"
-        },
-        {
-          "count": 1,
-          "name": "Orzhov Signet"
-        },
-        {
-          "count": 1,
-          "name": "Rakdos Signet"
-        },
-        {
-          "count": 1,
           "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Sheoldred, Whispering One"
+        },
+        {
+          "count": 1,
+          "name": "Blind Obedience"
+        },
+        {
+          "count": 1,
+          "name": "Swords to Plowshares"
+        },
+        {
+          "count": 1,
+          "name": "Demonic Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Smothering Tithe"
+        },
+        {
+          "count": 1,
+          "name": "Path to Exile"
+        },
+        {
+          "count": 1,
+          "name": "Chaos Warp"
+        },
+        {
+          "count": 1,
+          "name": "Faithless Looting"
+        },
+        {
+          "count": 1,
+          "name": "Jeska's Will"
+        },
+        {
+          "count": 1,
+          "name": "Armageddon"
+        },
+        {
+          "count": 1,
+          "name": "Obliterate"
+        },
+        {
+          "count": 1,
+          "name": "Rising of the Day"
+        },
+        {
+          "count": 1,
+          "name": "Grab the Prize"
+        },
+        {
+          "count": 1,
+          "name": "Final Vengeance"
+        },
+        {
+          "count": 1,
+          "name": "Ghastly Conscription"
+        },
+        {
+          "count": 1,
+          "name": "Haunting Voyage"
+        },
+        {
+          "count": 1,
+          "name": "Patriarch's Bidding"
+        },
+        {
+          "count": 1,
+          "name": "Draconic Intervention"
+        },
+        {
+          "count": 1,
+          "name": "Torment of Hailfire"
+        },
+        {
+          "count": 1,
+          "name": "Grievous Wound"
+        },
+        {
+          "count": 1,
+          "name": "Nevinyrral's Disk"
+        },
+        {
+          "count": 1,
+          "name": "Ruby Medallion"
+        },
+        {
+          "count": 1,
+          "name": "Pearl Medallion"
+        },
+        {
+          "count": 1,
+          "name": "Chromatic Lantern"
         },
         {
           "count": 1,
@@ -2938,107 +2943,99 @@
         },
         {
           "count": 1,
-          "name": "Talisman of Conviction"
+          "name": "Arcane Signet"
         },
         {
           "count": 1,
-          "name": "Talisman of Hierarchy"
+          "name": "Gleaming Splendor"
         },
         {
           "count": 1,
-          "name": "Battlefield Forge"
+          "name": "Fellwar Stone"
         },
         {
           "count": 1,
-          "name": "Bloodfell Caves"
+          "name": "Realm-Scorcher Hellkite"
         },
         {
           "count": 1,
-          "name": "Caves of Koilos"
+          "name": "Mirrorwing Dragon"
         },
         {
           "count": 1,
-          "name": "Clifftop Retreat"
+          "name": "Junji, the Midnight Sky"
         },
         {
           "count": 1,
-          "name": "Command Tower"
+          "name": "Terror of the Peaks"
         },
         {
           "count": 1,
-          "name": "Dragonskull Summit"
+          "name": "Obsidian Charmaw"
         },
         {
           "count": 1,
-          "name": "Evolving Wilds"
+          "name": "Manaform Hellkite"
         },
         {
           "count": 1,
-          "name": "Exotic Orchard"
+          "name": "Immersturm Predator"
         },
         {
           "count": 1,
-          "name": "Isolated Chapel"
-        },
-        {
-          "count": 5,
-          "name": "Mountain"
+          "name": "Drakuseth, Maw of Flames"
         },
         {
           "count": 1,
-          "name": "Nomad Outpost"
-        },
-        {
-          "count": 7,
-          "name": "Plains"
+          "name": "Silverquill, the Disputant"
         },
         {
           "count": 1,
-          "name": "Rogue's Passage"
+          "name": "Smaug the Magnificent"
         },
         {
           "count": 1,
-          "name": "Scoured Barrens"
+          "name": "Twinflame Tyrant"
         },
         {
           "count": 1,
-          "name": "Smoldering Marsh"
-        },
-        {
-          "count": 7,
-          "name": "Swamp"
+          "name": "Balefire Dragon"
         },
         {
           "count": 1,
-          "name": "Temple of Silence"
+          "name": "Apocalypse Demon"
         },
         {
           "count": 1,
-          "name": "Temple of Triumph"
+          "name": "Demonic Covenant"
         },
         {
           "count": 1,
-          "name": "Wind-Scarred Crag"
+          "name": "Dreadfeast Demon"
         },
         {
           "count": 1,
-          "name": "Aegis Angel"
+          "name": "Master of the Feast"
         },
         {
           "count": 1,
-          "name": "Akroma, Angel of Wrath"
+          "name": "Doomsday Excruciator"
+        },
+        {
+          "count": 1,
+          "name": "Rakdos, Patron of Chaos"
+        },
+        {
+          "count": 1,
+          "name": "Archangel of Wrath"
+        },
+        {
+          "count": 1,
+          "name": "Glorious Protector"
         },
         {
           "count": 1,
           "name": "Angel of the Ruins"
-        },
-        {
-          "count": 1,
-          "name": "Angelic Arbiter"
-        },
-        {
-          "count": 1,
-          "name": "Archfiend of Depravity"
         },
         {
           "count": 1,
@@ -3050,71 +3047,11 @@
         },
         {
           "count": 1,
+          "name": "Archangel Avacyn"
+        },
+        {
+          "count": 1,
           "name": "Avacyn, Angel of Hope"
-        },
-        {
-          "count": 1,
-          "name": "Balefire Dragon"
-        },
-        {
-          "count": 1,
-          "name": "Bloodgift Demon"
-        },
-        {
-          "count": 1,
-          "name": "Bruna, the Fading Light"
-        },
-        {
-          "count": 1,
-          "name": "Drakuseth, Maw of Flames"
-        },
-        {
-          "count": 1,
-          "name": "Drana and Linvala"
-        },
-        {
-          "count": 1,
-          "name": "Gisela, Blade of Goldnight"
-        },
-        {
-          "count": 1,
-          "name": "Harvester of Souls"
-        },
-        {
-          "count": 1,
-          "name": "Isshin, Two Heavens as One"
-        },
-        {
-          "count": 1,
-          "name": "Kaalia, Zenith Seeker"
-        },
-        {
-          "count": 1,
-          "name": "Liesa, Forgotten Archangel"
-        },
-        {
-          "count": 1,
-          "name": "Lord of the Void"
-        },
-        {
-          "count": 1,
-          "name": "Lyra Dawnbringer"
-        },
-        {
-          "count": 1,
-          "name": "Master of Cruelties"
-        },
-        {
-          "count": 1,
-          "name": "Rakdos, Patron of Chaos"
-        },
-        {
-          "count": 1,
-          "name": "Reya Dawnbringer"
-        },
-        {
-          "count": 1,
-          "name": "Rune-Scarred Demon"
         },
         {
           "count": 1,
@@ -3122,87 +3059,127 @@
         },
         {
           "count": 1,
-          "name": "Tariel, Reckoner of Souls"
+          "name": "Gisela, Blade of Goldnight"
         },
         {
           "count": 1,
-          "name": "Vilis, Broker of Blood"
+          "name": "Jet Medallion"
         },
         {
           "count": 1,
-          "name": "All-Out Assault"
+          "name": "Farewell"
+        },
+        {
+          "count": 5,
+          "name": "Mountain"
+        },
+        {
+          "count": 4,
+          "name": "Swamp"
+        },
+        {
+          "count": 4,
+          "name": "Plains"
         },
         {
           "count": 1,
-          "name": "Dragon Tempest"
+          "name": "Sword of Hearth and Home"
         },
         {
           "count": 1,
-          "name": "Phyrexian Arena"
+          "name": "Citadel Gate"
         },
         {
           "count": 1,
-          "name": "Windcrag Siege"
+          "name": "Thriving Heath"
         },
         {
           "count": 1,
-          "name": "Anguished Unmaking"
+          "name": "Thriving Bluff"
         },
         {
           "count": 1,
-          "name": "Boros Charm"
+          "name": "Thriving Moor"
         },
         {
           "count": 1,
-          "name": "Chaos Warp"
+          "name": "Drossforge Bridge"
         },
         {
           "count": 1,
-          "name": "Crackling Doom"
+          "name": "Jagged Barrens"
         },
         {
           "count": 1,
-          "name": "Dark Ritual"
+          "name": "Rakdos Guildgate"
         },
         {
           "count": 1,
-          "name": "Mortify"
+          "name": "Raucous Theater"
         },
         {
           "count": 1,
-          "name": "Path to Exile"
+          "name": "Goldmire Bridge"
         },
         {
           "count": 1,
-          "name": "Swords to Plowshares"
+          "name": "Forlorn Flats"
         },
         {
           "count": 1,
-          "name": "Blasphemous Act"
+          "name": "Shadowy Backstreet"
         },
         {
           "count": 1,
-          "name": "Demonic Counsel"
+          "name": "Orzhov Guildgate"
         },
         {
           "count": 1,
-          "name": "Diabolic Tutor"
+          "name": "Vault of Champions"
         },
         {
           "count": 1,
-          "name": "Night's Whisper"
+          "name": "Abraded Bluffs"
         },
         {
           "count": 1,
-          "name": "Read the Bones"
+          "name": "Rustvale Bridge"
         },
         {
           "count": 1,
-          "name": "Ruinous Ultimatum"
+          "name": "Elegant Parlor"
         },
         {
           "count": 1,
-          "name": "Sign in Blood"
+          "name": "Boros Guildgate"
+        },
+        {
+          "count": 1,
+          "name": "Crystal Grotto"
+        },
+        {
+          "count": 1,
+          "name": "Myriad Landscape"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Angelic Field Marshal"
+        },
+        {
+          "count": 1,
+          "name": "Black Dragon Gate"
+        },
+        {
+          "count": 1,
+          "name": "Teferi's Protection"
+        },
+        {
+          "count": 1,
+          "name": "Nomad Outpost"
         },
         {
           "count": 1,
@@ -3210,37 +3187,21 @@
         },
         {
           "count": 1,
-          "name": "Bloodthirster"
+          "name": "Savai Crystal"
         },
         {
           "count": 1,
-          "name": "Gisela, the Broken Blade"
-        },
-        {
-          "count": 1,
-          "name": "Land Tax"
-        },
-        {
-          "count": 1,
-          "name": "Damn"
-        },
-        {
-          "count": 1,
-          "name": "Archfiend of Despair"
-        },
-        {
-          "count": 1,
-          "name": "Mother of Runes"
+          "name": "Mardu Banner"
         }
       ],
       "sideboard": []
     },
     {
-      "name": "Thranduil, the Elvenking",
+      "name": "Nekusar, the Mindrazer",
       "author": "MTGGoldfish",
       "colors": [
-        "G",
         "U",
+        "R",
         "B"
       ],
       "tags": [
@@ -3249,179 +3210,107 @@
       "main": [
         {
           "count": 1,
-          "name": "Thranduil, the Elvenking"
+          "name": "Sol Ring"
         },
         {
           "count": 1,
-          "name": "Abomination of Llanowar"
+          "name": "Black Vise"
         },
         {
           "count": 1,
-          "name": "Arbor Elf"
+          "name": "Bloodletter Quill"
         },
         {
           "count": 1,
-          "name": "Beast Whisperer"
+          "name": "Barbed Wire"
         },
         {
           "count": 1,
-          "name": "Canopy Tactician"
+          "name": "Cursed Rack"
         },
         {
           "count": 1,
-          "name": "Circle of Dreams Druid"
+          "name": "Iron Maiden"
         },
         {
           "count": 1,
-          "name": "Deathrite Shaman"
+          "name": "Isolation Cell"
         },
         {
           "count": 1,
-          "name": "Devoted Druid"
+          "name": "Syr Konrad, the Grim"
         },
         {
           "count": 1,
-          "name": "Elves of Deep Shadow"
+          "name": "Mindslaver"
         },
         {
           "count": 1,
-          "name": "Elvish Archdruid"
+          "name": "Mirrorworks"
         },
         {
           "count": 1,
-          "name": "Elvish Harbinger"
+          "name": "Misers' Cage"
         },
         {
           "count": 1,
-          "name": "Elvish Mystic"
+          "name": "Paupers' Cage"
         },
         {
           "count": 1,
-          "name": "Elvish Reclaimer"
+          "name": "Psychogenic Probe"
         },
         {
           "count": 1,
-          "name": "Elvish Warmaster"
+          "name": "Razor Pendulum"
         },
         {
           "count": 1,
-          "name": "Essence Warden"
+          "name": "Scalding Tongs"
         },
         {
           "count": 1,
-          "name": "Ezuri, Renegade Leader"
+          "name": "Sculpting Steel"
         },
         {
           "count": 1,
-          "name": "Fauna Shaman"
+          "name": "Skullcage"
         },
         {
           "count": 1,
-          "name": "Fyndhorn Elves"
+          "name": "Talon of Pain"
         },
         {
           "count": 1,
-          "name": "Hermit Druid"
+          "name": "The Rack"
         },
         {
           "count": 1,
-          "name": "Immaculate Magistrate"
+          "name": "Thought Dissector"
         },
         {
           "count": 1,
-          "name": "Jarad, Golgari Lich Lord"
+          "name": "Thought Prison"
         },
         {
           "count": 1,
-          "name": "Lathril, Blade of the Elves"
+          "name": "Thumbscrews"
         },
         {
           "count": 1,
-          "name": "Llanowar Elves"
+          "name": "Torture Chamber"
         },
         {
           "count": 1,
-          "name": "Marwyn, the Nurturer"
+          "name": "Trepanation Blade"
         },
         {
           "count": 1,
-          "name": "Miara, Thorn of the Glade"
+          "name": "Umbilicus"
         },
         {
           "count": 1,
-          "name": "Necrotic Ooze"
-        },
-        {
-          "count": 1,
-          "name": "Priest of Titania"
-        },
-        {
-          "count": 1,
-          "name": "Quirion Ranger"
-        },
-        {
-          "count": 1,
-          "name": "Reclamation Sage"
-        },
-        {
-          "count": 1,
-          "name": "Shaman of the Pack"
-        },
-        {
-          "count": 1,
-          "name": "Skemfar Shadowsage"
-        },
-        {
-          "count": 1,
-          "name": "Springbloom Druid"
-        },
-        {
-          "count": 1,
-          "name": "Timberwatch Elf"
-        },
-        {
-          "count": 1,
-          "name": "Tireless Provisioner"
-        },
-        {
-          "count": 1,
-          "name": "Tyvar the Bellicose"
-        },
-        {
-          "count": 1,
-          "name": "Viridian Joiner"
-        },
-        {
-          "count": 1,
-          "name": "Wirewood Symbiote"
-        },
-        {
-          "count": 1,
-          "name": "Wolverine Riders"
-        },
-        {
-          "count": 1,
-          "name": "Tyvar, Jubilant Brawler"
-        },
-        {
-          "count": 1,
-          "name": "Abrupt Decay"
-        },
-        {
-          "count": 1,
-          "name": "Aetherize"
-        },
-        {
-          "count": 1,
-          "name": "Assassin's Trophy"
-        },
-        {
-          "count": 1,
-          "name": "Counterspell"
-        },
-        {
-          "count": 1,
-          "name": "Dark Petition"
+          "name": "Wheel of Torture"
         },
         {
           "count": 1,
@@ -3429,99 +3318,15 @@
         },
         {
           "count": 1,
-          "name": "Dig Through Time"
+          "name": "Fabricate"
         },
         {
           "count": 1,
-          "name": "Dread Return"
+          "name": "Painful Lesson"
         },
         {
           "count": 1,
-          "name": "Fact or Fiction"
-        },
-        {
-          "count": 1,
-          "name": "Final Parting"
-        },
-        {
-          "count": 1,
-          "name": "Golgari Charm"
-        },
-        {
-          "count": 1,
-          "name": "Read the Bones"
-        },
-        {
-          "count": 1,
-          "name": "Return of the Wildspeaker"
-        },
-        {
-          "count": 1,
-          "name": "Treasure Cruise"
-        },
-        {
-          "count": 1,
-          "name": "Unmarked Grave"
-        },
-        {
-          "count": 1,
-          "name": "Veil of Summer"
-        },
-        {
-          "count": 1,
-          "name": "Victimize"
-        },
-        {
-          "count": 1,
-          "name": "Animate Dead"
-        },
-        {
-          "count": 1,
-          "name": "Necromancy"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Ashes of the Fallen"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves"
-        },
-        {
-          "count": 1,
-          "name": "Skullclamp"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Swiftfoot Boots"
-        },
-        {
-          "count": 1,
-          "name": "Sword of the Paruns"
-        },
-        {
-          "count": 1,
-          "name": "Thousand-Year Elixir"
-        },
-        {
-          "count": 1,
-          "name": "Umbral Mantle"
-        },
-        {
-          "count": 1,
-          "name": "Bojuka Bog"
-        },
-        {
-          "count": 1,
-          "name": "Choked Estuary"
+          "name": "Cinder Barrens"
         },
         {
           "count": 1,
@@ -3529,19 +3334,7 @@
         },
         {
           "count": 1,
-          "name": "Darkwater Catacombs"
-        },
-        {
-          "count": 1,
-          "name": "Deathcap Glade"
-        },
-        {
-          "count": 1,
-          "name": "Drowned Catacomb"
-        },
-        {
-          "count": 5,
-          "name": "Forest"
+          "name": "Dismal Backwater"
         },
         {
           "count": 1,
@@ -3549,63 +3342,47 @@
         },
         {
           "count": 1,
-          "name": "Exotic Orchard"
+          "name": "Grixis Panorama"
         },
         {
           "count": 1,
-          "name": "Hinterland Harbor"
+          "name": "Highland Lake"
         },
         {
-          "count": 2,
+          "count": 7,
           "name": "Island"
         },
         {
           "count": 1,
-          "name": "Llanowar Wastes"
+          "name": "Izzet Guildgate"
+        },
+        {
+          "count": 7,
+          "name": "Mountain"
         },
         {
           "count": 1,
-          "name": "Myriad Landscape"
+          "name": "Rakdos Carnarium"
         },
         {
           "count": 1,
-          "name": "Necroblossom Snarl"
+          "name": "Rocky Tar Pit"
         },
         {
           "count": 1,
-          "name": "Opulent Palace"
+          "name": "Sulfurous Springs"
         },
         {
-          "count": 1,
-          "name": "Path of Ancestry"
-        },
-        {
-          "count": 1,
-          "name": "Sunken Hollow"
-        },
-        {
-          "count": 2,
+          "count": 13,
           "name": "Swamp"
         },
         {
           "count": 1,
-          "name": "Takenuma, Abandoned Mire"
+          "name": "Swiftwater Cliffs"
         },
         {
           "count": 1,
-          "name": "Temple of Deceit"
-        },
-        {
-          "count": 1,
-          "name": "Temple of Malady"
-        },
-        {
-          "count": 1,
-          "name": "Temple of Mystery"
-        },
-        {
-          "count": 1,
-          "name": "Terramorphic Expanse"
+          "name": "Transguild Promenade"
         },
         {
           "count": 1,
@@ -3613,15 +3390,127 @@
         },
         {
           "count": 1,
-          "name": "Vineglimmer Snarl"
+          "name": "Unknown Shores"
         },
         {
           "count": 1,
-          "name": "Woodland Cemetery"
+          "name": "Chamber of Manipulation"
         },
         {
           "count": 1,
-          "name": "Yavimaya Coast"
+          "name": "Citadel of Pain"
+        },
+        {
+          "count": 1,
+          "name": "Enslave"
+        },
+        {
+          "count": 1,
+          "name": "Fevered Visions"
+        },
+        {
+          "count": 1,
+          "name": "Leyline of Punishment"
+        },
+        {
+          "count": 1,
+          "name": "Mindmoil"
+        },
+        {
+          "count": 1,
+          "name": "Painful Quandary"
+        },
+        {
+          "count": 1,
+          "name": "Psychic Corrosion"
+        },
+        {
+          "count": 1,
+          "name": "Psychic Surgery"
+        },
+        {
+          "count": 1,
+          "name": "Soul Ransom"
+        },
+        {
+          "count": 1,
+          "name": "Theater of Horrors"
+        },
+        {
+          "count": 1,
+          "name": "Torture"
+        },
+        {
+          "count": 1,
+          "name": "Blood Artist"
+        },
+        {
+          "count": 1,
+          "name": "Callous Oppressor"
+        },
+        {
+          "count": 1,
+          "name": "Circu, Dimir Lobotomist"
+        },
+        {
+          "count": 1,
+          "name": "Harsh Mentor"
+        },
+        {
+          "count": 1,
+          "name": "Master of Cruelties"
+        },
+        {
+          "count": 1,
+          "name": "Mirko Vosk, Mind Drinker"
+        },
+        {
+          "count": 1,
+          "name": "Nin, the Pain Artist"
+        },
+        {
+          "count": 1,
+          "name": "Ob Nixilis, Unshackled"
+        },
+        {
+          "count": 1,
+          "name": "Psychosis Crawler"
+        },
+        {
+          "count": 1,
+          "name": "Rackling"
+        },
+        {
+          "count": 1,
+          "name": "Sheoldred, the Apocalypse"
+        },
+        {
+          "count": 1,
+          "name": "Viseling"
+        },
+        {
+          "count": 1,
+          "name": "Whipkeeper"
+        },
+        {
+          "count": 1,
+          "name": "Workshop Assistant"
+        },
+        {
+          "count": 1,
+          "name": "Yixlid Jailer"
+        },
+        {
+          "count": 1,
+          "name": "Ob Nixilis, the Hate-Twisted"
+        },
+        {
+          "count": 1,
+          "name": "Dominate"
+        },
+        {
+          "count": 1,
+          "name": "Nekusar, the Mindrazer"
         }
       ],
       "sideboard": []

--- a/client/public/feeds/mtggoldfish-modern.json
+++ b/client/public/feeds/mtggoldfish-modern.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "modern",
   "version": 1,
-  "updated": "2026-08-19T00:00:00Z",
+  "updated": "2026-08-20T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/modern",
   "decks": [
     {
@@ -612,140 +612,117 @@
       ]
     },
     {
-      "name": "Mono-Green Eldrazi",
+      "name": "Izzet Prowess",
       "author": "MTGGoldfish",
       "colors": [
-        "G"
+        "U",
+        "R"
       ],
       "tags": [
         "metagame"
       ],
       "main": [
         {
-          "count": 1,
-          "name": "Boseiju, Who Endures"
+          "count": 4,
+          "name": "Dragon's Rage Channeler"
         },
         {
           "count": 4,
-          "name": "Disciple of Freyalise"
-        },
-        {
-          "count": 1,
-          "name": "Drowner of Truth"
-        },
-        {
-          "count": 1,
-          "name": "Dryad Arbor"
+          "name": "Monastery Swiftspear"
         },
         {
           "count": 4,
-          "name": "Eldrazi Temple"
+          "name": "Slickshot Show-Off"
         },
         {
           "count": 4,
-          "name": "Emrakul, the Promised End"
+          "name": "Cori-Steel Cutter"
         },
         {
           "count": 4,
-          "name": "Fanatic of Rhonas"
+          "name": "Preordain"
         },
         {
           "count": 4,
-          "name": "Fight Rigging"
+          "name": "Mishra's Bauble"
         },
         {
           "count": 4,
-          "name": "Forest"
-        },
-        {
-          "count": 1,
-          "name": "Gemstone Caverns"
-        },
-        {
-          "count": 1,
-          "name": "Ghost Quarter"
+          "name": "Expressive Iteration"
         },
         {
           "count": 4,
-          "name": "Green Sun's Zenith"
+          "name": "Lightning Bolt"
         },
         {
           "count": 4,
-          "name": "Kozilek's Command"
+          "name": "Lava Dart"
         },
         {
           "count": 4,
-          "name": "Malevolent Rumble"
-        },
-        {
-          "count": 1,
-          "name": "Mosswort Bridge"
-        },
-        {
-          "count": 4,
-          "name": "Slumbering Trudge"
-        },
-        {
-          "count": 4,
-          "name": "Sowing Mycospawn"
-        },
-        {
-          "count": 1,
-          "name": "Turntimber Symbiosis"
-        },
-        {
-          "count": 4,
-          "name": "Ugin's Labyrinth"
+          "name": "Mutagenic Growth"
         },
         {
           "count": 2,
-          "name": "Ugin, Eye of the Storms"
+          "name": "Violent Urge"
         },
         {
-          "count": 2,
-          "name": "Ulamog, the Ceaseless Hunger"
+          "count": 3,
+          "name": "Steam Vents"
+        },
+        {
+          "count": 3,
+          "name": "Mountain"
         },
         {
           "count": 1,
-          "name": "Cavern of Souls"
+          "name": "Fiery Islet"
+        },
+        {
+          "count": 1,
+          "name": "Thundering Falls"
+        },
+        {
+          "count": 4,
+          "name": "Arid Mesa"
+        },
+        {
+          "count": 3,
+          "name": "Scalding Tarn"
+        },
+        {
+          "count": 3,
+          "name": "Bloodstained Mire"
         }
       ],
       "sideboard": [
         {
+          "count": 4,
+          "name": "Consign to Memory"
+        },
+        {
           "count": 3,
-          "name": "Chalice of the Void"
+          "name": "Spell Snare"
         },
         {
           "count": 1,
-          "name": "Chomping Changeling"
+          "name": "Spell Pierce"
         },
         {
           "count": 1,
-          "name": "Collector Ouphe"
+          "name": "Into the Flood Maw"
         },
         {
-          "count": 2,
-          "name": "Endurance"
-        },
-        {
-          "count": 2,
-          "name": "Force of Vigor"
+          "count": 3,
+          "name": "Unholy Heat"
         },
         {
           "count": 1,
-          "name": "Icetill Explorer"
-        },
-        {
-          "count": 1,
-          "name": "Keen-Eyed Curator"
+          "name": "Tormod's Crypt"
         },
         {
           "count": 2,
-          "name": "Thought-Knot Seer"
-        },
-        {
-          "count": 2,
-          "name": "Trinisphere"
+          "name": "Meltdown"
         }
       ]
     },
@@ -921,7 +898,7 @@
       ]
     },
     {
-      "name": "Izzet Prowess",
+      "name": "Affinity",
       "author": "MTGGoldfish",
       "colors": [
         "U",
@@ -933,23 +910,19 @@
       "main": [
         {
           "count": 4,
-          "name": "Dragon's Rage Channeler"
+          "name": "Kappa Cannoneer"
         },
         {
           "count": 4,
-          "name": "Monastery Swiftspear"
+          "name": "Pinnacle Emissary"
+        },
+        {
+          "count": 1,
+          "name": "Emry, Lurker of the Loch"
         },
         {
           "count": 4,
-          "name": "Slickshot Show-Off"
-        },
-        {
-          "count": 4,
-          "name": "Cori-Steel Cutter"
-        },
-        {
-          "count": 4,
-          "name": "Preordain"
+          "name": "Engineered Explosives"
         },
         {
           "count": 4,
@@ -957,81 +930,109 @@
         },
         {
           "count": 4,
-          "name": "Expressive Iteration"
+          "name": "Mox Opal"
         },
         {
           "count": 4,
-          "name": "Lightning Bolt"
+          "name": "Tormod's Crypt"
         },
         {
-          "count": 4,
-          "name": "Lava Dart"
+          "count": 3,
+          "name": "Claws of Gix"
         },
         {
-          "count": 4,
-          "name": "Mutagenic Growth"
+          "count": 1,
+          "name": "Pithing Needle"
+        },
+        {
+          "count": 1,
+          "name": "Shadowspear"
+        },
+        {
+          "count": 1,
+          "name": "Skateboard"
+        },
+        {
+          "count": 1,
+          "name": "Welding Jar"
         },
         {
           "count": 2,
-          "name": "Violent Urge"
-        },
-        {
-          "count": 3,
-          "name": "Steam Vents"
-        },
-        {
-          "count": 3,
-          "name": "Mountain"
+          "name": "Metallic Rebuke"
         },
         {
           "count": 1,
-          "name": "Fiery Islet"
-        },
-        {
-          "count": 1,
-          "name": "Thundering Falls"
+          "name": "Sink into Stupor"
         },
         {
           "count": 4,
-          "name": "Arid Mesa"
+          "name": "Preordain"
         },
         {
-          "count": 3,
-          "name": "Scalding Tarn"
+          "count": 4,
+          "name": "Urza's Saga"
         },
         {
-          "count": 3,
-          "name": "Bloodstained Mire"
+          "count": 4,
+          "name": "Weapons Manufacturing"
+        },
+        {
+          "count": 4,
+          "name": "Fiery Islet"
+        },
+        {
+          "count": 4,
+          "name": "Spirebluff Canal"
+        },
+        {
+          "count": 2,
+          "name": "Island"
+        },
+        {
+          "count": 2,
+          "name": "Shivan Reef"
+        },
+        {
+          "count": 1,
+          "name": "Steam Vents"
         }
       ],
       "sideboard": [
         {
-          "count": 4,
+          "count": 1,
+          "name": "Emry, Lurker of the Loch"
+        },
+        {
+          "count": 1,
+          "name": "Metallic Rebuke"
+        },
+        {
+          "count": 3,
           "name": "Consign to Memory"
         },
         {
-          "count": 3,
-          "name": "Spell Snare"
-        },
-        {
-          "count": 1,
-          "name": "Spell Pierce"
-        },
-        {
-          "count": 1,
-          "name": "Into the Flood Maw"
-        },
-        {
-          "count": 3,
-          "name": "Unholy Heat"
-        },
-        {
-          "count": 1,
-          "name": "Tormod's Crypt"
+          "count": 2,
+          "name": "Damping Sphere"
         },
         {
           "count": 2,
-          "name": "Meltdown"
+          "name": "Galvanic Blast"
+        },
+        {
+          "count": 2,
+          "name": "Swan Song"
+        },
+        {
+          "count": 2,
+          "name": "Whipflare"
+        },
+        {
+          "count": 1,
+          "name": "Blood Moon"
+        },
+        {
+          "count": 1,
+          "name": "Strix Serenade"
         }
       ]
     },
@@ -1183,169 +1184,30 @@
       ]
     },
     {
-      "name": "Affinity",
+      "name": "Mono-Green Eldrazi",
       "author": "MTGGoldfish",
       "colors": [
-        "U",
-        "R"
+        "G"
       ],
       "tags": [
         "metagame"
       ],
       "main": [
         {
-          "count": 4,
-          "name": "Kappa Cannoneer"
+          "count": 1,
+          "name": "Boseiju, Who Endures"
         },
         {
           "count": 4,
-          "name": "Pinnacle Emissary"
+          "name": "Disciple of Freyalise"
         },
         {
           "count": 1,
-          "name": "Emry, Lurker of the Loch"
-        },
-        {
-          "count": 4,
-          "name": "Engineered Explosives"
-        },
-        {
-          "count": 4,
-          "name": "Mishra's Bauble"
-        },
-        {
-          "count": 4,
-          "name": "Mox Opal"
-        },
-        {
-          "count": 4,
-          "name": "Tormod's Crypt"
-        },
-        {
-          "count": 3,
-          "name": "Claws of Gix"
+          "name": "Drowner of Truth"
         },
         {
           "count": 1,
-          "name": "Pithing Needle"
-        },
-        {
-          "count": 1,
-          "name": "Shadowspear"
-        },
-        {
-          "count": 1,
-          "name": "Skateboard"
-        },
-        {
-          "count": 1,
-          "name": "Welding Jar"
-        },
-        {
-          "count": 2,
-          "name": "Metallic Rebuke"
-        },
-        {
-          "count": 1,
-          "name": "Sink into Stupor"
-        },
-        {
-          "count": 4,
-          "name": "Preordain"
-        },
-        {
-          "count": 4,
-          "name": "Urza's Saga"
-        },
-        {
-          "count": 4,
-          "name": "Weapons Manufacturing"
-        },
-        {
-          "count": 4,
-          "name": "Fiery Islet"
-        },
-        {
-          "count": 4,
-          "name": "Spirebluff Canal"
-        },
-        {
-          "count": 2,
-          "name": "Island"
-        },
-        {
-          "count": 2,
-          "name": "Shivan Reef"
-        },
-        {
-          "count": 1,
-          "name": "Steam Vents"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 1,
-          "name": "Emry, Lurker of the Loch"
-        },
-        {
-          "count": 1,
-          "name": "Metallic Rebuke"
-        },
-        {
-          "count": 3,
-          "name": "Consign to Memory"
-        },
-        {
-          "count": 2,
-          "name": "Damping Sphere"
-        },
-        {
-          "count": 2,
-          "name": "Galvanic Blast"
-        },
-        {
-          "count": 2,
-          "name": "Swan Song"
-        },
-        {
-          "count": 2,
-          "name": "Whipflare"
-        },
-        {
-          "count": 1,
-          "name": "Blood Moon"
-        },
-        {
-          "count": 1,
-          "name": "Strix Serenade"
-        }
-      ]
-    },
-    {
-      "name": "Eldrazi Tron",
-      "author": "MTGGoldfish",
-      "colors": [
-        "B"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 2,
-          "name": "All Is Dust"
-        },
-        {
-          "count": 2,
-          "name": "Chalice of the Void"
-        },
-        {
-          "count": 4,
-          "name": "Devourer of Destiny"
-        },
-        {
-          "count": 2,
-          "name": "Dismember"
+          "name": "Dryad Arbor"
         },
         {
           "count": 4,
@@ -1353,113 +1215,269 @@
         },
         {
           "count": 4,
-          "name": "Expedition Map"
+          "name": "Emrakul, the Promised End"
         },
         {
           "count": 4,
-          "name": "Glaring Fleshraker"
+          "name": "Fanatic of Rhonas"
         },
         {
           "count": 4,
-          "name": "Karn, the Great Creator"
+          "name": "Fight Rigging"
+        },
+        {
+          "count": 4,
+          "name": "Forest"
+        },
+        {
+          "count": 1,
+          "name": "Gemstone Caverns"
+        },
+        {
+          "count": 1,
+          "name": "Ghost Quarter"
+        },
+        {
+          "count": 4,
+          "name": "Green Sun's Zenith"
         },
         {
           "count": 4,
           "name": "Kozilek's Command"
         },
         {
-          "count": 3,
-          "name": "Mind Stone"
-        },
-        {
-          "count": 2,
-          "name": "Sire of Seven Deaths"
+          "count": 4,
+          "name": "Malevolent Rumble"
         },
         {
           "count": 1,
-          "name": "Swamp"
+          "name": "Mosswort Bridge"
         },
         {
           "count": 4,
-          "name": "Thought-Knot Seer"
+          "name": "Slumbering Trudge"
         },
         {
-          "count": 3,
-          "name": "Ugin, Eye of the Storms"
+          "count": 4,
+          "name": "Sowing Mycospawn"
+        },
+        {
+          "count": 1,
+          "name": "Turntimber Symbiosis"
         },
         {
           "count": 4,
           "name": "Ugin's Labyrinth"
         },
         {
-          "count": 4,
-          "name": "Urza's Mine"
+          "count": 2,
+          "name": "Ugin, Eye of the Storms"
         },
         {
-          "count": 4,
-          "name": "Urza's Power Plant"
-        },
-        {
-          "count": 4,
-          "name": "Urza's Tower"
+          "count": 2,
+          "name": "Ulamog, the Ceaseless Hunger"
         },
         {
           "count": 1,
-          "name": "Wastes"
+          "name": "Cavern of Souls"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 3,
+          "name": "Chalice of the Void"
+        },
+        {
+          "count": 1,
+          "name": "Chomping Changeling"
+        },
+        {
+          "count": 1,
+          "name": "Collector Ouphe"
+        },
+        {
+          "count": 2,
+          "name": "Endurance"
+        },
+        {
+          "count": 2,
+          "name": "Force of Vigor"
+        },
+        {
+          "count": 1,
+          "name": "Icetill Explorer"
+        },
+        {
+          "count": 1,
+          "name": "Keen-Eyed Curator"
+        },
+        {
+          "count": 2,
+          "name": "Thought-Knot Seer"
+        },
+        {
+          "count": 2,
+          "name": "Trinisphere"
+        }
+      ]
+    },
+    {
+      "name": "Devoted Combo",
+      "author": "MTGGoldfish",
+      "colors": [
+        "G",
+        "B",
+        "W"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 2,
+          "name": "Agatha's Soul Cauldron"
+        },
+        {
+          "count": 4,
+          "name": "Badgermole Cub"
+        },
+        {
+          "count": 2,
+          "name": "Birds of Paradise"
+        },
+        {
+          "count": 1,
+          "name": "Boseiju, Who Endures"
+        },
+        {
+          "count": 1,
+          "name": "Craterhoof Behemoth"
+        },
+        {
+          "count": 4,
+          "name": "Delighted Halfling"
+        },
+        {
+          "count": 4,
+          "name": "Devoted Druid"
+        },
+        {
+          "count": 2,
+          "name": "Dryad Arbor"
+        },
+        {
+          "count": 1,
+          "name": "Duskwatch Recruiter"
+        },
+        {
+          "count": 1,
+          "name": "Fiend Artisan"
+        },
+        {
+          "count": 3,
+          "name": "Forest"
+        },
+        {
+          "count": 4,
+          "name": "Green Sun's Zenith"
+        },
+        {
+          "count": 1,
+          "name": "Lair of the Hydra"
+        },
+        {
+          "count": 4,
+          "name": "Leyline of Abundance"
+        },
+        {
+          "count": 4,
+          "name": "Nature's Rhythm"
+        },
+        {
+          "count": 1,
+          "name": "Nurturing Peatland"
+        },
+        {
+          "count": 2,
+          "name": "Ouroboroid"
+        },
+        {
+          "count": 2,
+          "name": "Overgrown Tomb"
+        },
+        {
+          "count": 1,
+          "name": "Shang-Chi, Master of Kung Fu"
+        },
+        {
+          "count": 1,
+          "name": "Temple Garden"
+        },
+        {
+          "count": 4,
+          "name": "Tyvar, Jubilant Brawler"
+        },
+        {
+          "count": 4,
+          "name": "Verdant Catacombs"
+        },
+        {
+          "count": 1,
+          "name": "Vizier of Remedies"
+        },
+        {
+          "count": 1,
+          "name": "Walking Ballista"
+        },
+        {
+          "count": 3,
+          "name": "Windswept Heath"
+        },
+        {
+          "count": 2,
+          "name": "Wooded Foothills"
         }
       ],
       "sideboard": [
         {
           "count": 1,
-          "name": "Chalice of the Void"
+          "name": "Collector Ouphe"
         },
         {
           "count": 1,
-          "name": "Cityscape Leveler"
+          "name": "Crystal Barricade"
         },
         {
           "count": 1,
-          "name": "Cursed Totem"
+          "name": "Drannith Magistrate"
         },
         {
-          "count": 1,
-          "name": "Disruptor Flute"
-        },
-        {
-          "count": 1,
-          "name": "Grafdigger's Cage"
-        },
-        {
-          "count": 1,
-          "name": "Liquimetal Coating"
-        },
-        {
-          "count": 1,
-          "name": "Soulless Jailer"
-        },
-        {
-          "count": 1,
-          "name": "The Stone Brain"
-        },
-        {
-          "count": 1,
-          "name": "Tormod's Crypt"
-        },
-        {
-          "count": 1,
-          "name": "Torpor Orb"
+          "count": 3,
+          "name": "Endurance"
         },
         {
           "count": 2,
-          "name": "Trinisphere"
+          "name": "Fade from History"
         },
         {
           "count": 2,
-          "name": "Warping Wail"
+          "name": "Fatal Push"
         },
         {
           "count": 1,
-          "name": "Ensnaring Bridge"
+          "name": "Grist, the Hunger Tide"
+        },
+        {
+          "count": 1,
+          "name": "Jennifer Walters"
+        },
+        {
+          "count": 1,
+          "name": "Outland Liberator"
+        },
+        {
+          "count": 2,
+          "name": "Vexing Bauble"
         }
       ]
     }

--- a/client/public/feeds/mtggoldfish-pioneer.json
+++ b/client/public/feeds/mtggoldfish-pioneer.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "pioneer",
   "version": 1,
-  "updated": "2026-08-19T00:00:00Z",
+  "updated": "2026-08-20T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/pioneer",
   "decks": [
     {
@@ -1188,11 +1188,12 @@
       ]
     },
     {
-      "name": "Dimir Midrange",
+      "name": "Jeskai Lessons",
       "author": "MTGGoldfish",
       "colors": [
-        "U",
-        "B"
+        "R",
+        "W",
+        "U"
       ],
       "tags": [
         "metagame"
@@ -1200,149 +1201,129 @@
       "main": [
         {
           "count": 4,
-          "name": "Fatal Push"
+          "name": "Abandon Attachments"
+        },
+        {
+          "count": 3,
+          "name": "Accumulate Wisdom"
+        },
+        {
+          "count": 4,
+          "name": "Firebending Lesson"
+        },
+        {
+          "count": 4,
+          "name": "Gran-Gran"
+        },
+        {
+          "count": 3,
+          "name": "Sacred Foundry"
+        },
+        {
+          "count": 4,
+          "name": "Steam Vents"
+        },
+        {
+          "count": 4,
+          "name": "Tablet of Discovery"
+        },
+        {
+          "count": 4,
+          "name": "Spirebluff Canal"
+        },
+        {
+          "count": 4,
+          "name": "Riverpyre Verge"
+        },
+        {
+          "count": 1,
+          "name": "Mistrise Village"
+        },
+        {
+          "count": 3,
+          "name": "Jeskai Revelation"
         },
         {
           "count": 2,
           "name": "Island"
         },
         {
-          "count": 1,
-          "name": "Swamp"
-        },
-        {
-          "count": 1,
-          "name": "Spell Pierce"
-        },
-        {
-          "count": 1,
-          "name": "Underground River"
-        },
-        {
-          "count": 3,
-          "name": "Darkslick Shores"
+          "count": 4,
+          "name": "Hallowed Fountain"
         },
         {
           "count": 4,
-          "name": "Mutavault"
-        },
-        {
-          "count": 1,
-          "name": "Go for the Throat"
-        },
-        {
-          "count": 1,
-          "name": "Urborg, Tomb of Yawgmoth"
+          "name": "Divide by Zero"
         },
         {
           "count": 4,
-          "name": "Faerie Miscreant"
+          "name": "It'll Quench Ya!"
         },
         {
           "count": 2,
-          "name": "Go for the Throat"
+          "name": "Thor, God of Thunder"
+        },
+        {
+          "count": 4,
+          "name": "Combustion Technique"
         },
         {
           "count": 1,
-          "name": "Darkslick Shores"
-        },
-        {
-          "count": 2,
-          "name": "Clearwater Pathway"
-        },
-        {
-          "count": 4,
-          "name": "Moon-Circuit Hacker"
+          "name": "Stormcarved Coast"
         },
         {
           "count": 1,
-          "name": "Otawara, Soaring City"
-        },
-        {
-          "count": 2,
-          "name": "Sheoldred, the Apocalypse"
-        },
-        {
-          "count": 4,
-          "name": "Mockingbird"
-        },
-        {
-          "count": 4,
-          "name": "Floodpits Drowner"
-        },
-        {
-          "count": 3,
-          "name": "Unholy Annex // Ritual Chamber"
-        },
-        {
-          "count": 4,
-          "name": "Watery Grave"
-        },
-        {
-          "count": 4,
-          "name": "Gloomlake Verge"
-        },
-        {
-          "count": 4,
-          "name": "Kaito, Bane of Nightmares"
-        },
-        {
-          "count": 3,
-          "name": "Thoughtseize"
+          "name": "Sundown Pass"
         }
       ],
       "sideboard": [
         {
           "count": 1,
-          "name": "Spell Pierce"
+          "name": "Boomerang Basics"
         },
         {
           "count": 1,
-          "name": "Duress"
+          "name": "Emeritus of Ideation"
         },
         {
           "count": 1,
-          "name": "Spell Snare"
+          "name": "Jeskai Revelation"
         },
         {
           "count": 1,
-          "name": "Disdainful Stroke"
+          "name": "Price of Freedom"
         },
         {
           "count": 1,
-          "name": "Thoughtseize"
+          "name": "Soulless Jailer"
         },
         {
           "count": 1,
-          "name": "Annul"
-        },
-        {
-          "count": 1,
-          "name": "Ashiok, Dream Render"
-        },
-        {
-          "count": 1,
-          "name": "Brazen Borrower"
+          "name": "Sokka's Haiku"
         },
         {
           "count": 2,
-          "name": "Mystical Dispute"
+          "name": "Improvisation Capstone"
         },
         {
           "count": 1,
-          "name": "Path of Peril"
+          "name": "Iroh's Demonstration"
         },
         {
           "count": 2,
-          "name": "Unlicensed Hearse"
+          "name": "Ral, Crackling Wit"
         },
         {
           "count": 1,
-          "name": "Anoint with Affliction"
+          "name": "Accumulate Wisdom"
         },
         {
           "count": 1,
-          "name": "Change the Equation"
+          "name": "Sphinx of the Final Word"
+        },
+        {
+          "count": 2,
+          "name": "Ghost Vacuum"
         }
       ]
     }

--- a/client/public/feeds/mtggoldfish-standard.json
+++ b/client/public/feeds/mtggoldfish-standard.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "standard",
   "version": 1,
-  "updated": "2026-08-19T00:00:00Z",
+  "updated": "2026-08-20T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/standard",
   "decks": [
     {
@@ -152,133 +152,6 @@
         {
           "count": 1,
           "name": "Flashfreeze"
-        }
-      ]
-    },
-    {
-      "name": "Izzet Spellementals",
-      "author": "MTGGoldfish",
-      "colors": [
-        "U",
-        "R"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 4,
-          "name": "Eddymurk Crab"
-        },
-        {
-          "count": 4,
-          "name": "Flow State"
-        },
-        {
-          "count": 2,
-          "name": "Get Out"
-        },
-        {
-          "count": 4,
-          "name": "Hearth Elemental"
-        },
-        {
-          "count": 2,
-          "name": "Impractical Joke"
-        },
-        {
-          "count": 1,
-          "name": "Multiversal Passage"
-        },
-        {
-          "count": 3,
-          "name": "Sunderflock"
-        },
-        {
-          "count": 4,
-          "name": "Prismari Charm"
-        },
-        {
-          "count": 4,
-          "name": "Spirebluff Canal"
-        },
-        {
-          "count": 1,
-          "name": "Stormcarved Coast"
-        },
-        {
-          "count": 4,
-          "name": "Steam Vents"
-        },
-        {
-          "count": 4,
-          "name": "Sleight of Hand"
-        },
-        {
-          "count": 4,
-          "name": "Opt"
-        },
-        {
-          "count": 2,
-          "name": "Traumatic Critique"
-        },
-        {
-          "count": 6,
-          "name": "Island"
-        },
-        {
-          "count": 2,
-          "name": "Spell Snare"
-        },
-        {
-          "count": 3,
-          "name": "Burst Lightning"
-        },
-        {
-          "count": 4,
-          "name": "Riverpyre Verge"
-        },
-        {
-          "count": 2,
-          "name": "Ghost Vacuum"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 1,
-          "name": "Broadside Barrage"
-        },
-        {
-          "count": 1,
-          "name": "Flashfreeze"
-        },
-        {
-          "count": 1,
-          "name": "Disdainful Stroke"
-        },
-        {
-          "count": 4,
-          "name": "Colorstorm Stallion"
-        },
-        {
-          "count": 2,
-          "name": "Slagstorm"
-        },
-        {
-          "count": 1,
-          "name": "Spell Snare"
-        },
-        {
-          "count": 2,
-          "name": "Spell Pierce"
-        },
-        {
-          "count": 2,
-          "name": "Ghost Vacuum"
-        },
-        {
-          "count": 1,
-          "name": "Sunderflock"
         }
       ]
     },
@@ -444,6 +317,243 @@
         {
           "count": 3,
           "name": "Duress"
+        }
+      ]
+    },
+    {
+      "name": "Izzet Spellementals",
+      "author": "MTGGoldfish",
+      "colors": [
+        "U",
+        "R"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 4,
+          "name": "Eddymurk Crab"
+        },
+        {
+          "count": 4,
+          "name": "Flow State"
+        },
+        {
+          "count": 2,
+          "name": "Get Out"
+        },
+        {
+          "count": 4,
+          "name": "Hearth Elemental"
+        },
+        {
+          "count": 2,
+          "name": "Impractical Joke"
+        },
+        {
+          "count": 1,
+          "name": "Multiversal Passage"
+        },
+        {
+          "count": 3,
+          "name": "Sunderflock"
+        },
+        {
+          "count": 4,
+          "name": "Prismari Charm"
+        },
+        {
+          "count": 4,
+          "name": "Spirebluff Canal"
+        },
+        {
+          "count": 1,
+          "name": "Stormcarved Coast"
+        },
+        {
+          "count": 4,
+          "name": "Steam Vents"
+        },
+        {
+          "count": 4,
+          "name": "Sleight of Hand"
+        },
+        {
+          "count": 4,
+          "name": "Opt"
+        },
+        {
+          "count": 2,
+          "name": "Traumatic Critique"
+        },
+        {
+          "count": 6,
+          "name": "Island"
+        },
+        {
+          "count": 2,
+          "name": "Spell Snare"
+        },
+        {
+          "count": 3,
+          "name": "Burst Lightning"
+        },
+        {
+          "count": 4,
+          "name": "Riverpyre Verge"
+        },
+        {
+          "count": 2,
+          "name": "Ghost Vacuum"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 1,
+          "name": "Broadside Barrage"
+        },
+        {
+          "count": 1,
+          "name": "Flashfreeze"
+        },
+        {
+          "count": 1,
+          "name": "Disdainful Stroke"
+        },
+        {
+          "count": 4,
+          "name": "Colorstorm Stallion"
+        },
+        {
+          "count": 2,
+          "name": "Slagstorm"
+        },
+        {
+          "count": 1,
+          "name": "Spell Snare"
+        },
+        {
+          "count": 2,
+          "name": "Spell Pierce"
+        },
+        {
+          "count": 2,
+          "name": "Ghost Vacuum"
+        },
+        {
+          "count": 1,
+          "name": "Sunderflock"
+        }
+      ]
+    },
+    {
+      "name": "Mono-Green Landfall",
+      "author": "MTGGoldfish",
+      "colors": [
+        "G"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 3,
+          "name": "Ba Sing Se"
+        },
+        {
+          "count": 3,
+          "name": "Mightform Harmonizer"
+        },
+        {
+          "count": 4,
+          "name": "Escape Tunnel"
+        },
+        {
+          "count": 4,
+          "name": "Fabled Passage"
+        },
+        {
+          "count": 1,
+          "name": "Meltstrider's Resolve"
+        },
+        {
+          "count": 2,
+          "name": "Keen-Eyed Curator"
+        },
+        {
+          "count": 1,
+          "name": "Surrak, Elusive Hunter"
+        },
+        {
+          "count": 4,
+          "name": "Llanowar Elves"
+        },
+        {
+          "count": 1,
+          "name": "Demolition Field"
+        },
+        {
+          "count": 4,
+          "name": "Sapling Nursery"
+        },
+        {
+          "count": 4,
+          "name": "Sazh's Chocobo"
+        },
+        {
+          "count": 4,
+          "name": "Icetill Explorer"
+        },
+        {
+          "count": 1,
+          "name": "Lumbering Worldwagon"
+        },
+        {
+          "count": 2,
+          "name": "Shared Roots"
+        },
+        {
+          "count": 4,
+          "name": "Esper Origins"
+        },
+        {
+          "count": 4,
+          "name": "Earthbender Ascension"
+        },
+        {
+          "count": 14,
+          "name": "Forest"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 1,
+          "name": "Leatherhead, Swamp Stalker"
+        },
+        {
+          "count": 2,
+          "name": "Surrak, Elusive Hunter"
+        },
+        {
+          "count": 3,
+          "name": "Torpor Orb"
+        },
+        {
+          "count": 2,
+          "name": "Meltstrider's Resolve"
+        },
+        {
+          "count": 1,
+          "name": "Keen-Eyed Curator"
+        },
+        {
+          "count": 2,
+          "name": "Warg Tactics"
+        },
+        {
+          "count": 4,
+          "name": "Mossborn Hydra"
         }
       ]
     },
@@ -726,116 +836,6 @@
         {
           "count": 2,
           "name": "Flashfreeze"
-        }
-      ]
-    },
-    {
-      "name": "Mono-Green Landfall",
-      "author": "MTGGoldfish",
-      "colors": [
-        "G"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 4,
-          "name": "Esper Origins"
-        },
-        {
-          "count": 3,
-          "name": "Ba Sing Se"
-        },
-        {
-          "count": 4,
-          "name": "Earthbender Ascension"
-        },
-        {
-          "count": 4,
-          "name": "Escape Tunnel"
-        },
-        {
-          "count": 4,
-          "name": "Fabled Passage"
-        },
-        {
-          "count": 1,
-          "name": "Meltstrider's Resolve"
-        },
-        {
-          "count": 2,
-          "name": "Keen-Eyed Curator"
-        },
-        {
-          "count": 1,
-          "name": "Surrak, Elusive Hunter"
-        },
-        {
-          "count": 3,
-          "name": "Mightform Harmonizer"
-        },
-        {
-          "count": 1,
-          "name": "Demolition Field"
-        },
-        {
-          "count": 4,
-          "name": "Sapling Nursery"
-        },
-        {
-          "count": 4,
-          "name": "Sazh's Chocobo"
-        },
-        {
-          "count": 14,
-          "name": "Forest"
-        },
-        {
-          "count": 4,
-          "name": "Llanowar Elves"
-        },
-        {
-          "count": 4,
-          "name": "Icetill Explorer"
-        },
-        {
-          "count": 1,
-          "name": "Lumbering Worldwagon"
-        },
-        {
-          "count": 2,
-          "name": "Shared Roots"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 1,
-          "name": "Leatherhead, Swamp Stalker"
-        },
-        {
-          "count": 2,
-          "name": "Surrak, Elusive Hunter"
-        },
-        {
-          "count": 4,
-          "name": "Mossborn Hydra"
-        },
-        {
-          "count": 3,
-          "name": "Torpor Orb"
-        },
-        {
-          "count": 2,
-          "name": "Meltstrider's Resolve"
-        },
-        {
-          "count": 1,
-          "name": "Keen-Eyed Curator"
-        },
-        {
-          "count": 2,
-          "name": "Warg Tactics"
         }
       ]
     },


### PR DESCRIPTION
Automated daily metagame feed refresh from MTGGoldfish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refreshed Modern decklists, including Izzet Prowess, Affinity, Mono-Green Eldrazi, and Devoted Combo.
  * Added a Jeskai Lessons decklist to the Pioneer feed.
  * Added a 4c Control decklist and updated Mono-Green Landfall in the Standard feed.

* **Updates**
  * Refreshed all affected feed timestamps to August 20, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->