### PR TITLE
fix(engine): fire the unlocked door's own trigger, and install both Room halves' door text (#7564)

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -792,15 +792,20 @@ fn handle_unlock_room_door(
                 "That door is already unlocked".to_string(),
             ));
         }
-        match door {
-            crate::game::game_object::RoomDoor::Left => obj.mana_cost.clone(),
-            crate::game::game_object::RoomDoor::Right => obj
-                .back_face
+        // CR 709.5e: the unlock cost is the locked HALF's mana cost. Doors are
+        // printed halves, not live/back slots — after the back half was cast
+        // (`modal_back_face`), the LIVE face is the right door and the left
+        // door's cost lives on `back_face`. `room::live_face_door` is the
+        // single orientation authority (same mapping as CR 709.5d entry).
+        if door == super::room::live_face_door(obj) {
+            obj.mana_cost.clone()
+        } else {
+            obj.back_face
                 .as_ref()
                 .map(|face| face.mana_cost.clone())
                 .ok_or_else(|| {
-                    EngineError::ActionNotAllowed("Room has no right door face".to_string())
-                })?,
+                    EngineError::ActionNotAllowed("Room has no second door face".to_string())
+                })?
         }
     };
 
@@ -20104,7 +20109,7 @@ mod stage2_injector_tests {
                 //   `:13210 ⇒ :13130`. It creates no CR 603.5 prompt either — a special
                 //   action does not use the stack (CR 116.1) — and the pinned line is again
                 //   the same `OptionalEffectChoice` construction, moved wholesale.
-                "game/engine.rs:13130".to_string(),
+                "game/engine.rs:13135".to_string(),
             ],
             "the five production producers, NAMED: the CR 603.5 gate in `resolve_chain_body` \
              plus the two repeated-optional-payment drivers, the per-player acceptance cursor \

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -1699,6 +1699,187 @@ fn unlock_room_door_special_action_marks_door_and_emits_trigger_event() {
     )));
 }
 
+/// CR 709.5h: unlocking a particular half triggers THAT half's "when you
+/// unlock this door" ability. The cast half (left, unlocked on entry) carries
+/// a GainLife-3 marker trigger; the locked right half carries GainLife 7.
+/// Paying the right door's unlock cost must put the RIGHT half's trigger on
+/// the stack — not re-fire the cast half's (Moldering Gym // Weight Room:
+/// paying Weight Room's {5}{G} ran Moldering Gym's land search a second time
+/// and Weight Room's ability never existed for the engine).
+#[test]
+fn unlocking_the_right_door_fires_the_right_halfs_trigger() {
+    let mut state = setup_game_at_main_phase();
+    let room = create_object(
+        &mut state,
+        CardId(901),
+        PlayerId(0),
+        "Moldering Gym".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&room).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        obj.card_types.subtypes.push("Room".to_string());
+        let front_trigger =
+            TriggerDefinition::new(TriggerMode::UnlockDoor).execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 3 },
+                    player: TargetFilter::Controller,
+                },
+            ));
+        obj.trigger_definitions.push(front_trigger.clone());
+        Arc::make_mut(&mut obj.base_trigger_definitions).push(front_trigger);
+        let mut back = room_back_face("Weight Room");
+        back.trigger_definitions
+            .push(
+                TriggerDefinition::new(TriggerMode::UnlockDoor).execute(AbilityDefinition::new(
+                    AbilityKind::Database,
+                    Effect::GainLife {
+                        amount: QuantityExpr::Fixed { value: 7 },
+                        player: TargetFilter::Controller,
+                    },
+                )),
+            );
+        obj.back_face = Some(back);
+        // The real ETB pipeline stamps and installs both halves' door text
+        // (`reset_for_battlefield_entry` → `install_room_door_text`).
+        obj.reset_for_battlefield_entry(1, 1);
+        // The front half was the cast half: its door entered unlocked.
+        obj.room_unlocks = Some(crate::game::game_object::RoomUnlockState {
+            left_unlocked: true,
+            right_unlocked: false,
+        });
+    }
+
+    apply_as_current(
+        &mut state,
+        GameAction::UnlockRoomDoor {
+            object_id: room,
+            door: RoomDoor::Right,
+        },
+    )
+    .unwrap();
+
+    let fired: Vec<i32> = state
+        .stack
+        .iter()
+        .filter_map(|entry| match &entry.kind {
+            StackEntryKind::TriggeredAbility { ability, .. } => match &ability.effect {
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value },
+                    ..
+                } => Some(*value),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        fired,
+        vec![7],
+        "CR 709.5h: the just-unlocked RIGHT half's trigger (marker 7) must fire, \
+         and the cast half's (marker 3) must not"
+    );
+}
+
+/// CR 709.5e + CR 709.5j: doors are PRINTED halves, not live/back slots.
+/// After the back half was cast (`modal_back_face`), the LEFT door's unlock
+/// cost is the back_face's mana cost and its trigger is the back_face's —
+/// `room::live_face_door` is the shared orientation authority. Before the fix
+/// the cost lookup read `obj.mana_cost` for Left unconditionally (the WRONG
+/// half once the faces swapped), and the trigger re-fired the live half.
+#[test]
+fn after_casting_the_back_half_the_left_door_uses_the_front_halfs_cost_and_trigger() {
+    let mut state = setup_game_at_main_phase();
+    let room = create_object(
+        &mut state,
+        CardId(902),
+        PlayerId(0),
+        "Weight Room".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&room).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        obj.card_types.subtypes.push("Room".to_string());
+        // The right (second printed) half was cast: faces are swapped.
+        obj.modal_back_face = true;
+        obj.mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::White],
+            generic: 0,
+        };
+        let live_trigger =
+            TriggerDefinition::new(TriggerMode::UnlockDoor).execute(AbilityDefinition::new(
+                AbilityKind::Database,
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 7 },
+                    player: TargetFilter::Controller,
+                },
+            ));
+        obj.trigger_definitions.push(live_trigger.clone());
+        Arc::make_mut(&mut obj.base_trigger_definitions).push(live_trigger);
+        let mut front = room_back_face("Moldering Gym");
+        front.mana_cost = ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 0,
+        };
+        front
+            .trigger_definitions
+            .push(
+                TriggerDefinition::new(TriggerMode::UnlockDoor).execute(AbilityDefinition::new(
+                    AbilityKind::Database,
+                    Effect::GainLife {
+                        amount: QuantityExpr::Fixed { value: 3 },
+                        player: TargetFilter::Controller,
+                    },
+                )),
+            );
+        obj.back_face = Some(front);
+        obj.reset_for_battlefield_entry(1, 1);
+        obj.room_unlocks = Some(crate::game::game_object::RoomUnlockState {
+            left_unlocked: false,
+            right_unlocked: true,
+        });
+    }
+    // Exactly the FRONT half's {G} in the pool: the unlock succeeds only if
+    // the Left door resolves to the back_face slot (the front-printed half).
+    state.players[0]
+        .mana_pool
+        .add(ManaUnit::new(ManaType::Green, ObjectId(0), false, vec![]));
+
+    apply_as_current(
+        &mut state,
+        GameAction::UnlockRoomDoor {
+            object_id: room,
+            door: RoomDoor::Left,
+        },
+    )
+    .expect("the left door's unlock cost is the front half's {G}");
+
+    assert!(state.objects[&room].room_unlocks.unwrap().left_unlocked);
+    let fired: Vec<i32> = state
+        .stack
+        .iter()
+        .filter_map(|entry| match &entry.kind {
+            StackEntryKind::TriggeredAbility { ability, .. } => match &ability.effect {
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value },
+                    ..
+                } => Some(*value),
+                _ => None,
+            },
+            _ => None,
+        })
+        .collect();
+    assert_eq!(
+        fired,
+        vec![3],
+        "CR 709.5h: the LEFT door's trigger is the front-printed half's (marker 3), \
+         not the live half's (marker 7)"
+    );
+}
+
 /// CR 106.6 + CR 116.2m + CR 709.5e: Smoky Lounge produces {R}{R} restricted
 /// to "cast Room spells and unlock doors". The door-unlock half lowers to
 /// `OnlyForSpecialAction(UnlockDoor)`; paying a Room's unlock cost routes

--- a/crates/engine/src/game/functioning_abilities.rs
+++ b/crates/engine/src/game/functioning_abilities.rs
@@ -417,6 +417,20 @@ pub fn active_trigger_definitions<'a>(
             .iter_all()
             .enumerate()
             .filter(move |(_, entry)| {
+                // CR 709.5: on the battlefield a locked half's rules text does
+                // not function — a door-stamped trigger contributes only while
+                // its Room half is unlocked. (CR 709.5h needs no exception:
+                // the designation is granted BEFORE the unlock event is
+                // matched, so the just-unlocked half already passes.) Off the
+                // battlefield there are no lock designations and both halves'
+                // text exists, so the gate applies only there.
+                if zone == Zone::Battlefield {
+                    if let Some(door) = entry.definition().room_door {
+                        if !obj.room_unlocks.unwrap_or_default().is_unlocked(door) {
+                            return false;
+                        }
+                    }
+                }
                 if zone == Zone::Command && !is_emblem {
                     return non_emblem_command_zone_trigger_functions(obj, entry.definition());
                 }

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -2518,11 +2518,7 @@ impl GameObject {
     /// see `room::live_face_door`). Idempotent: a `None` stamp is claimed
     /// once, and the other half is merged only while absent.
     fn install_room_door_text(&mut self) {
-        let live_door = if self.modal_back_face {
-            RoomDoor::Right
-        } else {
-            RoomDoor::Left
-        };
+        let live_door = crate::game::room::live_face_door(self);
         let other_door = match live_door {
             RoomDoor::Left => RoomDoor::Right,
             RoomDoor::Right => RoomDoor::Left,

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -2500,7 +2500,52 @@ impl GameObject {
         }
         if self.card_types.subtypes.iter().any(|s| s == "Room") {
             self.room_unlocks = Some(RoomUnlockState::default());
+            self.install_room_door_text();
         }
+    }
+
+    /// CR 709.5 + CR 709.5h: stamp each Room half's trigger definitions with
+    /// its door and install the OTHER half's triggers alongside the live
+    /// face's — into the BASE set, so layer recomputation and base
+    /// re-materialization preserve them. Which half's text currently
+    /// *functions* is then decided by the unlock designations
+    /// (`functioning_abilities::active_trigger_definitions`), not by face
+    /// residency; the unlock trigger matcher additionally fires a stamped
+    /// trigger only for its own door's event.
+    ///
+    /// The live face's door follows the cast orientation (`modal_back_face`
+    /// records that the right half is showing — the CR 709.5d mapping,
+    /// see `room::live_face_door`). Idempotent: a `None` stamp is claimed
+    /// once, and the other half is merged only while absent.
+    fn install_room_door_text(&mut self) {
+        let live_door = if self.modal_back_face {
+            RoomDoor::Right
+        } else {
+            RoomDoor::Left
+        };
+        let other_door = match live_door {
+            RoomDoor::Left => RoomDoor::Right,
+            RoomDoor::Right => RoomDoor::Left,
+        };
+        let base = Arc::make_mut(&mut self.base_trigger_definitions);
+        for definition in base.iter_mut() {
+            if definition.room_door.is_none() {
+                definition.room_door = Some(live_door);
+            }
+        }
+        if let Some(back) = &self.back_face {
+            if !base
+                .iter()
+                .any(|definition| definition.room_door == Some(other_door))
+            {
+                base.extend(back.trigger_definitions.iter_all().map(|printed| {
+                    let mut definition = printed.clone();
+                    definition.room_door = Some(other_door);
+                    definition
+                }));
+            }
+        }
+        self.materialize_base_trigger_definitions();
     }
 
     /// CR 613.1 + CR 400.7: Revert layer-derived characteristics to the object's

--- a/crates/engine/src/game/room.rs
+++ b/crates/engine/src/game/room.rs
@@ -67,6 +67,18 @@ pub(in crate::game) fn priority_unlock_room_door_announcements(
         .collect()
 }
 
+/// CR 709.5j + CR 709.5d: The door (printed half) the object's LIVE face is.
+/// `modal_back_face` records that the right (second printed) half was cast —
+/// the same mapping CR 709.5d entry-unlocking uses. Single authority: the
+/// unlock-cost lookup and the door-text install both resolve through this.
+pub fn live_face_door(obj: &crate::game::game_object::GameObject) -> RoomDoor {
+    if obj.modal_back_face {
+        RoomDoor::Right
+    } else {
+        RoomDoor::Left
+    }
+}
+
 /// CR 709.5j: A "door" is a half of a Room permanent. A Room has a left door
 /// always and a right door only if it has a back face (the second half of the
 /// split card). Returns the doors that actually exist for `object_id`.

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -2039,17 +2039,14 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
                         // CR 709.5d: a Room permanent enters with the unlocked
                         // designation for whichever half was cast as a spell — the
                         // right door when its right half was cast, otherwise the
-                        // left. `modal_back_face` (still set on the battlefield, see
-                        // zones.rs) records that the right half was the cast face.
-                        let cast_door = if state
+                        // left. `room::live_face_door` reads `modal_back_face`
+                        // (still set on the battlefield, see zones.rs), the shared
+                        // orientation authority with the unlock-cost lookup.
+                        let cast_door = state
                             .objects
                             .get(&entry.id)
-                            .is_some_and(|obj| obj.modal_back_face)
-                        {
-                            crate::game::game_object::RoomDoor::Right
-                        } else {
-                            crate::game::game_object::RoomDoor::Left
-                        };
+                            .map(super::room::live_face_door)
+                            .unwrap_or(crate::game::game_object::RoomDoor::Left);
                         super::room::unlock_door_designation(
                             state,
                             entry.id,

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -4618,10 +4618,18 @@ pub(super) fn match_unlock_door(
     if let GameEvent::RoomDoorUnlocked {
         player_id,
         object_id,
+        door,
         ..
     } = event
     {
-        *object_id == source_id && valid_player_matches(trigger, state, *player_id, source_context)
+        // CR 709.5h: an unlock ability triggers when ITS half gets the
+        // designation — a door-stamped trigger fires only for its own door's
+        // event (Moldering Gym's search must not re-fire when Weight Room
+        // unlocks). `None` (non-Room shapes, hand-built data) keeps the
+        // door-blind legacy match.
+        *object_id == source_id
+            && trigger.room_door.is_none_or(|stamped| stamped == *door)
+            && valid_player_matches(trigger, state, *player_id, source_context)
     } else {
         false
     }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -23620,6 +23620,13 @@ pub struct TriggerDefinition {
     /// controller (see `ClashResult::for_player` / `match_clash`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub clash_result: Option<ClashResult>,
+    /// CR 709.5 + CR 709.5h: The Room half (door) this trigger's printed text
+    /// lives on. Stamped when a split Room's two halves are wired onto a game
+    /// object; a door's trigger functions only while that half is unlocked,
+    /// and an unlock trigger fires only for its own door's event. `None` for
+    /// every non-Room trigger: no door gating.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub room_door: Option<crate::game::game_object::RoomDoor>,
 }
 
 /// CR 605.1b: Which aggregate mana output a mana-ability trigger requires.
@@ -24156,11 +24163,18 @@ impl TriggerDefinition {
             taps_for_mana_produced: None,
             mana_ability_produced: None,
             clash_result: None,
+            room_door: None,
         }
     }
 
     pub fn execute(mut self, ability: AbilityDefinition) -> Self {
         self.execute = Some(Box::new(ability));
+        self
+    }
+
+    /// CR 709.5: tag this trigger as living on the given Room half.
+    pub fn room_door(mut self, door: crate::game::game_object::RoomDoor) -> Self {
+        self.room_door = Some(door);
         self
     }
 
@@ -29488,6 +29502,7 @@ mod tests {
             taps_for_mana_produced: None,
             mana_ability_produced: None,
             clash_result: None,
+            room_door: None,
         };
         let json = serde_json::to_string(&trigger).unwrap();
         let deserialized: TriggerDefinition = serde_json::from_str(&json).unwrap();

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -29502,7 +29502,7 @@ mod tests {
             taps_for_mana_produced: None,
             mana_ability_produced: None,
             clash_result: None,
-            room_door: None,
+            room_door: Some(crate::game::game_object::RoomDoor::Left),
         };
         let json = serde_json::to_string(&trigger).unwrap();
         let deserialized: TriggerDefinition = serde_json::from_str(&json).unwrap();


### PR DESCRIPTION
Fixes the trigger rows of #7564 (statics/activated abilities/name merging stay open there).

**Problem.** Unlocking a Room's second door re-ran the cast half's unlock trigger, and the other half's ability never existed: `match_unlock_door` ignored the event's `door`, and only the cast face's trigger definitions were live (the other half's sat unused in `back_face`).

**Fix.**
- `TriggerDefinition.room_door` (serde-default `None`): the Room half a trigger's printed text lives on. Stamped at battlefield entry (`reset_for_battlefield_entry` → `install_room_door_text`), which also merges the back face's triggers into the BASE set so layer recomputation preserves them.
- CR 709.5 lock state decides what FUNCTIONS (`active_trigger_definitions` gate, battlefield only); CR 709.5h decides what FIRES (`match_unlock_door` compares the stamp to the event's door).
- `room::live_face_door`: single orientation authority (`modal_back_face` = the right half was cast — the CR 709.5d mapping). Also fixes a latent bug: the unlock-cost lookup mapped `Left => obj.mana_cost` unconditionally, demanding the WRONG half's cost after the back half was cast (CR 709.5e).

**Tests** (engine_tests):
| row | before | after |
|---|---|---|
| front cast, unlock Right | cast half re-fires (counter-probe: two triggers → order prompt) | ONLY the right half's trigger |
| back cast, unlock Left | wrong half's cost demanded; cast half re-fires | front half's cost paid; front half's trigger fires |

Counter-probes: door-blind matcher, empty install, and rigid cost mapping each flip a row red. CR 603.5 prompt census re-pinned (+5 lines in engine.rs, same producer).

**Measured** over card-data.json: 30 Room cards; 30 halves with unlock triggers, 18 halves whose further triggers now also respect lock state.

**Not covered** (#7564 stays open): statics (10 halves), activated abilities (2 halves), battlefield name merging. Recast face-choice loss found during verification is #7565 (fix in progress). Playtested live both directions (front-first and back-first) on Moldering Gym // Weight Room.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Room door unlocking so costs and triggers are resolved from the correct printed half.
  * Locked Room halves no longer activate their battlefield triggers.
  * Room spell resolution now consistently identifies the unlocked door.
  * Improved handling of door-specific triggers, including Rooms with a cast back half.

* **Tests**
  * Added regression coverage for Room door costs, unlocking, and trigger behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->