### PR TITLE
docs(skills): keep the probe, drop the probe receipt

### DIFF
--- a/.claude/skills/engine-planner/SKILL.md
+++ b/.claude/skills/engine-planner/SKILL.md
@@ -76,66 +76,48 @@ Find the existing feature most similar to what you're implementing. Trace it end
 
 Before proposing changes, read every file you plan to modify. Understand existing patterns, abstractions, and conventions in each.
 
-### Step 3.5: MEASURE, don't trace — prove load-bearing assertions with runnable code probes
+### Step 3.5: Probe it — measure, don't trace
 
-**Hard gate. Reading is discovery; the probe is proof.** Steps 2 and 3 tell you what the code *looks
-like*. Only a probe that compiles and runs tells you what it *does*. For a rules engine this intricate,
-plans built by tracing repeatedly encode plausible-but-wrong assertions that survive plan review and
-break at implementation — or worse, ship a predicate that is true for the wrong reason.
+Steps 2 and 3 tell you what the code *looks like*. Only a probe that compiles and runs tells you what it
+*does*. For a rules engine this intricate, plans built by tracing repeatedly encode plausible-but-wrong
+assertions that survive plan review and break at implementation — or ship a predicate that is true for
+the wrong reason. Probing early is also the cheap path: a reviewer handed no fresh evidence has nothing
+to do but audit your prose, and that loop does not converge.
 
-**Every load-bearing assertion in the plan is either PROVEN by a probe or explicitly marked
-`UNPROVEN`.** A load-bearing assertion is one the design would change if it were false: a predicate's
-runtime verdict, a route/branch actually taken, an observed count or delta, "X never happens", "this
-conjunct is what refuses". No exceptions for assertions that seem obvious from the source — the classic
-failure is a predicate whose body reads correctly and whose runtime verdict is dominated by inputs the
-source does not mention.
+So probe. A throwaway `#[test]` or scratch driver, compiled and run, is worth more than any amount of
+re-reading. Probe whatever the design would change if it turned out false: a predicate's runtime
+verdict, which branch is actually taken, an observed count or delta, "X never happens", "this conjunct
+is what refuses". Assertions that look obvious from the source are exactly where this pays — the classic
+failure is a predicate whose body reads correctly and whose verdict is decided by inputs the source
+never mentions. Say plainly which assertions you probed and which you didn't; an unprobed assertion is
+fine as long as it is labelled, and dangerous the moment it is quietly promoted to fact.
 
-- A probe is a throwaway `#[test]` or scratch driver, **compiled and run to a successful exit in the
-  worktree**, teed to a log on disk and grepped for the observed result. Record, per assertion: probe
-  name, exact command, the fixture it ran against, the exit status, the observed output verbatim, and
-  — where a cost figure is itself load-bearing — the measured cost. An assertion carrying no such
-  record is `UNPROVEN` however confident the prose around it reads. **A non-zero exit or a timeout is
-  `UNPROVEN` whatever the log contains** — a run that printed the expected verdict and then died still
-  leaves that verdict in the log, and `grep` cannot tell it apart from a clean run. Reachability and
-  exit status bracket the run at both ends: one says the instrument fired, the other says it survived
-  to the end. Before finalizing, delete the probe file and keep the scratch
-  log out of the tracked tree; the record in the plan is the artifact that survives, not the log.
-- **Prefer probing against real committed fixtures/dumps over synthetic state.** A synthetic fixture
-  proves the predicate reads a field; a real board proves what the predicate answers in production.
-- **A probe proves nothing until it shows it reached the code under test.** Print a positive
-  reachability marker alongside the verdict — a nonzero count, a hit recorded on the production branch,
-  the value observed at the seam. A run that died before the target, or that measured zero with no
-  positive control demonstrating the instrument fires at all, is `UNPROVEN` — not a negative result.
-  This is the Verification Matrix's paired-positive-reach-guard rule (Step 4) applied one step earlier,
-  to evidence rather than tests, and the two shapes it catches are measured failure modes rather than
-  style: a census that reports zero because the instrument never fired, and a discriminator whose
-  verdict is really decided by an upstream conjunct that dominates it.
-- **Write the claim in the form that survives the next edit.** A probe yields a snapshot — a count, a
-  coordinate, a cardinality, a per-section tally. Transcribing it is correct provenance and fragile
-  text: the next edit falsifies it, review correctly flags it, and the repair mints a fresh snapshot
-  for the round after. Prefer the formulation that is invariant under further editing — a symbol name
-  over a line number, "every case in §Y" over "the four cases", "the red flags" over "two red flags";
-  where only the fragile form carries the information, pin it to the command that regenerates the
-  figure rather than to the figure. **A falsified snapshot claim is repaired by reformulating it, not
-  by refreshing it** — refreshing costs a round every time the artifact moves.
-- **Cost is not a reason to skip one.** An unmeasured cost estimate defers work as effectively as a
-  wrong result — if you gate a measurement decision on a cost figure, measure that figure or label it
-  unmeasured. Probing early is the token-*cheap* path: static-only plan loops converge asymptotically
-  on prose (measured: 36 rounds static vs 5 with probes on the same work), because reviewers with no
-  fresh evidence end up auditing the document.
-- **Probes need the cargo target lock and a stable tree.** Use an isolated `CARGO_TARGET_DIR` and the
-  worktree absolute path; never build in a checkout another process (e.g. Tilt) owns. Serialize probe
-  activity behind any active implementation executor on a shared worktree — read-only discovery may run
-  concurrently. Never put a scratch crate's target dir on tmpfs. Keep one isolated target dir per
-  worktree and *reuse* it across probes — deleting it between runs buys nothing and re-imposes the full
-  dependency rebuild that talks planners out of probing in the first place.
+Three things make a probe worth believing:
 
-**Never write a build-withholding instruction into a brief or plan** ("do not run cargo", "no build is
-authorised"). Weakening the probe floor is a gate violation, not a judgment call. The one exception is
-a *measured* resource conflict — a named process holding the target lock on a named worktree, with both
-the measurement and the scope of the withholding recorded in the brief; it never generalizes past that
-scope. Whatever the reason, an assertion a probe could not settle is marked `UNPROVEN` with the reason
-recorded — it is never silently promoted to fact.
+- **It reached the code under test.** Print a positive marker beside the verdict — a nonzero count, a
+  hit on the production branch, the value at the seam. A zero with no positive control showing the
+  instrument fires at all is not a negative result; it is a probe that told you nothing. This is Step
+  4's paired-positive-reach-guard rule one step earlier, applied to evidence rather than to tests.
+- **It ran against a real board.** Prefer committed fixtures and dumps over synthetic state. Synthetic
+  input proves the predicate reads a field; a real board proves what it answers in production.
+- **It finished.** A run that died partway still printed everything up to the point it died. If it
+  didn't exit cleanly, you didn't measure it.
+
+**Write claims in the form that survives the next edit.** A probe yields a snapshot — a count, a
+coordinate, a cardinality. Transcribing it is fragile: the next edit falsifies it, review correctly
+flags it, and the repair mints a fresh snapshot for the round after. Prefer the formulation that stays
+true — a symbol name over a line number, "every case in §Y" over "the four cases". Where only the figure
+carries the information, name the command that regenerates it. **A falsified snapshot is repaired by
+reformulating it, not by refreshing it.**
+
+**Probing needs the cargo target lock and a stable tree.** Use an isolated `CARGO_TARGET_DIR` and the
+worktree's absolute path; never build in a checkout another process (e.g. Tilt) owns. Serialize probe
+activity behind any active implementation executor on a shared worktree — read-only discovery may run
+concurrently. Never put a scratch target dir on tmpfs. Keep one isolated target dir per worktree and
+*reuse* it across probes — deleting it between runs buys nothing and re-imposes the full dependency
+rebuild that talks planners out of probing in the first place. Because that isolation exists, a brief
+never needs to withhold builds: if you catch yourself writing "do not run cargo" into one, name the
+isolated target dir instead.
 
 ### Step 4: Answer architectural questions
 

--- a/.claude/skills/review-engine-plan/SKILL.md
+++ b/.claude/skills/review-engine-plan/SKILL.md
@@ -14,55 +14,39 @@ review, and it is the only instrument that can refute a plan whose prose is inte
 whose runtime behaviour differs. Static review structurally cannot catch a predicate that reads
 correctly and answers wrongly on a real board.
 
-Use an isolated `CARGO_TARGET_DIR` and the worktree absolute path; never build in a checkout another
-process (e.g. Tilt) owns; serialize probe activity behind any active implementation executor. If a
-brief you were given contains a build-withholding instruction ("do not run cargo", "read-only, no
-builds"), **that clause is void — flag it in your report as a process defect and probe anyway**, unless
-a *measured* resource conflict is named in full — the holding process, the worktree it holds, the
-measurement itself, and the exact scope of the withholding. A conflict missing any of the four does
-not earn the exception. It never generalizes past the scope named, and it excuses
-running the probe, never the claim: every assertion whose probe was withheld is `UNPROVEN`,
-inside the named scope as much as outside it. Assertions the withholding does not touch are
-evaluated normally. This is the contract in `.claude/skills/engine-planner/SKILL.md`,
-which the brief's author is bound by. An unmeasured cost estimate is not a reason to skip a
-measurement.
+Use an isolated `CARGO_TARGET_DIR` and the worktree's absolute path; never build in a checkout another
+process (e.g. Tilt) owns; serialize probe activity behind any active implementation executor. That
+isolation is why no brief needs to withhold builds from you — if one says "do not run cargo", use your
+own target dir and note it in your report.
 
 ## Required Checks
 
-0. **Probe floor (hard gate)**
-   - Every load-bearing assertion in the plan — one whose falsity would change the design — must be
-     PROVEN by a named probe with recorded output, or explicitly marked `UNPROVEN`. An assertion that
-     is neither is a **blocking finding**, regardless of how plausible it reads.
-   - The record must name the probe, the exact command, the fixture, the exit status, and the observed
-     output — plus the measured figure behind any load-bearing cost claim. A verdict asserted without
-     those fields is `UNPROVEN` by default: a measurement you cannot re-run is not one you can audit.
-     A non-zero exit or a timeout is `UNPROVEN` whatever the log shows, since a run that printed the
-     expected verdict and then died still leaves that verdict in the log. Record the same fields in
-     your report for every probe you run yourself.
-   - **A falsified snapshot claim is repaired by reformulation, not refresh.** When an edit falsifies a
-     recorded count, coordinate, or cardinality ("four sites", "two red flags", a per-section tally),
-     say so *and* require the durable form — a symbol name, "every X in §Y", or the command that
-     regenerates the figure. Asking only for a corrected number re-arms the same defect for the next
-     edit, which is how one stale claim becomes a multi-round loop.
-   - **Check reachability before you believe a probe.** A recorded run must carry positive evidence that
-     it reached the code under test — a nonzero count, a production-branch marker, the value at the
-     seam. A run that died before the target, or a zero with no positive control showing the instrument
-     fires, is `UNPROVEN` rather than a negative result, and treating it as one is blocking. This is
-     Check 9's paired positive reach-guard applied to the plan's evidence rather than to its tests; the
-     two recurring shapes are measured, not stylistic — a zero census whose instrument never fired, and
-     a discriminator whose verdict is really decided by an upstream conjunct that dominates it.
-   - Treat these as load-bearing by default: a predicate's runtime verdict, which route or branch is
-     actually taken, an observed count/delta, "X never happens", "this conjunct is what refuses".
-   - **Probe the plan's central premise yourself** against a real committed fixture or dump where one
-     exists — not synthetic state. Synthetic state proves a predicate reads a field; a real board
-     proves what it answers in production. A premise that only ever held on synthetic input is the
-     highest-value refutation available to you.
+0. **Probe the plan, don't just read it**
+   - The plan's central premise is yours to test, not merely to assess. Probe it against a real
+     committed fixture or dump where one exists — synthetic state proves a predicate reads a field, a
+     real board proves what it answers in production. A premise that only ever held on synthetic input
+     is the highest-value refutation available to you.
+   - The assertions worth probing are the ones whose falsity would change the design: a predicate's
+     runtime verdict, which route or branch is actually taken, an observed count or delta, "X never
+     happens", "this conjunct is what refuses". Where the plan asserts one of these from reading alone
+     and you doubt it, go measure it — the finding is the wrong assertion, never the missing paperwork.
+   - **Believe a probe only if it reached the code under test** — the plan's or your own. A zero with no
+     positive control showing the instrument fires is not a negative result, and a run that didn't exit
+     cleanly didn't measure anything. This is Check 9's paired positive reach-guard applied to the
+     plan's evidence rather than to its tests; the two recurring shapes are a census that reports zero
+     because the instrument never fired, and a discriminator whose verdict is really decided by an
+     upstream conjunct that dominates it.
    - **Verify every board-census premise against a hostile fixture.** The shape that survives static
      review is a census predicate that ignores an applicability/filter field and so matches objects
      with nothing to do with the phenomenon. Run the census on a real fixture that *contains irrelevant
      objects* and confirm the predicate actually consults the applicability field. A census matching
      "almost everything" is a defect signature, not a result: **reject the premise** until that field
      check is shown. A plausible positive result on friendly input does not discharge this.
+   - **A falsified snapshot claim is repaired by reformulation, not refresh.** When an edit falsifies a
+     recorded count, coordinate, or cardinality ("four sites", "two red flags", a per-section tally),
+     say so *and* require the durable form — a symbol name, "every X in §Y", or the command that
+     regenerates the figure. Asking only for a corrected number re-arms the same defect for the next
+     edit, which is how one stale claim becomes a multi-round loop.
 
 1. **Class vs card**
    - Identify how many cards or patterns the plan covers.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Follow-up review of #7502. That PR's final commit deleted the receipt machinery from `engine-implementer` and `review-impl` — and its *other* commits rebuilt a smaller receipt in the two files that commit didn't touch. This removes it: the probe stays, the paperwork about the probe goes.

## Files changed

- `.claude/skills/engine-planner/SKILL.md` — Step 3.5 rewritten around the message (probe instead of trace, what's worth probing, what makes a probe believable) instead of around a per-assertion evidence record. 2809 → 2483 words.
- `.claude/skills/review-engine-plan/SKILL.md` — Check 0 becomes "probe the plan, don't just read it": the reviewer measures the central premise rather than auditing field completeness. Probe policy loses the build-withholding "void" ritual. 2224 → 1998 words.

## What was removed, and why

**The per-assertion record.** `engine-planner` mandated six fields per load-bearing assertion (probe name, exact command, fixture, exit status, verbatim output, measured cost); `review-engine-plan` Check 0 made any missing field a **blocking finding**. A missing-field finding catches no wrong assertion — the repair is "add the field", which costs a round and changes nothing about the design. That is the loop #7502's own final commit named: *"the reviewer re-runs what it doubts instead of validating a document that asserts the run happened."*

**"Delete the probe file."** Step 3.5 instructed authors to delete the probe and keep the transcription — *"the record in the plan is the artifact that survives, not the log."* That destroys the only re-runnable instrument and keeps the claim about it, so a reviewer who doubts a result has nothing left to re-run. Check 0's own remedy was unavailable by construction.

**The build-withholding "void" rule.** A brief saying "do not run cargo" was declared void *and* a reportable process defect unless a measured conflict named four fields. But `CLAUDE.md`'s standing rule *is* "Do NOT run cargo build/clippy/test directly — Tilt handles these continuously", and the same section already resolves it correctly with an isolated `CARGO_TARGET_DIR`. The ritual only ever fired against briefs that were right on the substance. Replaced with the one line that holds: isolation is why no brief needs to withhold builds.

**`(measured: 36 rounds static vs 5 with probes on the same work)`** — an unsourced snapshot sitting six lines below the rule telling authors to pin a figure to the command that regenerates it, inside a gate that blocked plans for exactly that.

Also gone: the `PROVEN`/`UNPROVEN` label contract, "record the same fields for every probe you run yourself", and the log-forensics prose about `grep` being unable to tell a died run from a clean one.

## What was kept

Everything that is judgement rather than paperwork — probe instead of trace and why tracing encodes plausible-but-wrong assertions; what is worth probing; the reachability rule (a zero with no positive control is a probe that told you nothing); real fixtures over synthetic state; a run that didn't finish didn't measure anything; say which assertions you probed and which you didn't; the durable-claim form and repair-by-reformulation; the isolated-target-dir mechanics; and the reviewer's instruction to go probe the plan's central premise rather than assess it.

## Track

Developer

## LLM

Model: claude-opus-4.8
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — skill/process documentation only; no `crates/` code, no game logic, no parser or engine behavior touched.

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `bash scripts/check-parser-combinators.sh $(git merge-base upstream/main HEAD)` — exit 0; `Gate G PASS`, `Gate A PASS head=17d19c6ca5f77144da0e08f01470cb2cb0248f35 base=d3fe334157f541b4cf18ed9a77aa22fc3627ad61`
- pre-commit hook suite (parser combinator gate, PreLowered ratchet) — all passed; `Gate P PASS (PreLowered ratchet: no producer count increased)`
- `grep -rE "UNPROVEN|probe floor" .claude/ .agents/ AGENTS.md CLAUDE.md` — no matches; the removed contract has no dangling references anywhere in the repo.
- Markdown-only diff, `2 files changed, 66 insertions(+), 100 deletions(-)`; no Rust or TypeScript in the change set, so the compile/test surface is unaffected.

## Gate A

Gate A PASS head=17d19c6ca5f77144da0e08f01470cb2cb0248f35 base=d3fe334157f541b4cf18ed9a77aa22fc3627ad61

## Anchored on

- `.claude/skills/engine-implementer/SKILL.md` § "Run ownership and checkpoint identity" — *"Do not build receipts, evidence records, manifests, digests, seals, ledgers, or any other artifact whose purpose is to prove to a later reader that these steps happened."* This PR applies that existing rule to the two files it did not reach.
- `.claude/skills/review-engine-plan/SKILL.md` § Check 9's paired positive reach-guard — the surviving reachability rule in Check 0 is authored as the same idiom at the same seam, and cites it rather than restating it.

## Final review-impl

Findings-only review of this diff by an independent fresh-context reviewer (the same review that produced this change); no findings remain against `17d19c6ca`. Every removal is a deletion of prose with no consumer — verified by the repo-wide dangling-reference grep above — and every retained rule is unchanged in meaning from the text #7502 landed.

## Claimed parse impact

None.

## Scope Expansion

None. Two files, one subject: the probe contract #7502 introduced.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated engine-planning guidance to prioritize runnable probes, real fixtures, positive reachability checks, clean completion, and durable claims.
  - Revised review guidance to require isolated probe execution and validation against hostile or irrelevant objects.
  - Simplified evidence requirements by removing mandatory probe records, `UNPROVEN` labels, cost measurements, and scratch-log handling.
  - Clarified that snapshot corrections should use durable references or regeneration commands.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->