### PR TITLE
docs(skills): scope the probe-isolation claim to lock contention

### DIFF
--- a/.claude/skills/engine-planner/SKILL.md
+++ b/.claude/skills/engine-planner/SKILL.md
@@ -115,11 +115,12 @@ worktree's absolute path; never build in a checkout another process (e.g. Tilt) 
 activity behind any active implementation executor on a shared worktree — read-only discovery may run
 concurrently. Never put a scratch target dir on tmpfs. Keep one isolated target dir per worktree and
 *reuse* it across probes — deleting it between runs buys nothing and re-imposes the full dependency
-rebuild that talks planners out of probing in the first place. Because that isolation exists, lock
-contention is not a reason to withhold builds: if you catch yourself writing "do not run cargo" into a
-brief, name the isolated target dir instead. Capacity is the one thing isolation cannot fix — a fresh
-target dir costs disk rather than saving it — so a genuinely full or saturated box is worth naming, and
-worth probing once it clears.
+rebuild that talks planners out of probing in the first place. Because that isolation exists,
+target-directory lock contention is not a reason to withhold builds: if you catch yourself writing "do
+not run cargo" into a brief, name the isolated target dir instead. Shared `CARGO_HOME` registry/package-
+cache locks are a separate lock domain that target-dir isolation doesn't touch, and can still delay a
+build. Capacity is the one thing isolation cannot fix — a fresh target dir costs disk rather than saving
+it — so a genuinely full or saturated box is worth naming, and worth probing once it clears.
 
 ### Step 4: Answer architectural questions
 

--- a/.claude/skills/engine-planner/SKILL.md
+++ b/.claude/skills/engine-planner/SKILL.md
@@ -115,9 +115,11 @@ worktree's absolute path; never build in a checkout another process (e.g. Tilt) 
 activity behind any active implementation executor on a shared worktree — read-only discovery may run
 concurrently. Never put a scratch target dir on tmpfs. Keep one isolated target dir per worktree and
 *reuse* it across probes — deleting it between runs buys nothing and re-imposes the full dependency
-rebuild that talks planners out of probing in the first place. Because that isolation exists, a brief
-never needs to withhold builds: if you catch yourself writing "do not run cargo" into one, name the
-isolated target dir instead.
+rebuild that talks planners out of probing in the first place. Because that isolation exists, lock
+contention is not a reason to withhold builds: if you catch yourself writing "do not run cargo" into a
+brief, name the isolated target dir instead. Capacity is the one thing isolation cannot fix — a fresh
+target dir costs disk rather than saving it — so a genuinely full or saturated box is worth naming, and
+worth probing once it clears.
 
 ### Step 4: Answer architectural questions
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

One-sentence correctness fix to #7570, raised by the fresh-context reviewer on #7571. #7570 replaced the build-withholding exception ritual with an unconditional claim — *"because that isolation exists, a brief never needs to withhold builds."* That holds for the thing an isolated `CARGO_TARGET_DIR` actually buys (the cargo target lock) and over-claims for everything else: isolation does not create disk or CPU.

## Files changed

- `.claude/skills/engine-planner/SKILL.md` — Step 3.5's isolation paragraph: claim narrowed to lock contention, plus the one case isolation cannot fix.

## Why it matters

A fresh target dir costs capacity rather than saving it, and this repo has measured how much: `.claude/skills/engine-implementer/SKILL.md` records 17 of 28 GB of dead incremental state on one completion target, and seven cold builds at 130 GB in a single phase. A planner reading the unconditional form would insist on probing a box that is genuinely out of room — and the text #7570 deleted did carry a measured-conflict exception that the replacement silently dropped.

**No exception ritual returns.** The thing #7570 removed was the apparatus: a "that clause is void" rule, a four-field naming requirement, and a reportable process defect when a brief fell short. None of that comes back. A full box is worth naming, and the probe happens once it clears — that is the whole addition.

Before:

> Because that isolation exists, a brief never needs to withhold builds: if you catch yourself writing "do not run cargo" into one, name the isolated target dir instead.

After:

> Because that isolation exists, lock contention is not a reason to withhold builds: if you catch yourself writing "do not run cargo" into a brief, name the isolated target dir instead. Capacity is the one thing isolation cannot fix — a fresh target dir costs disk rather than saving it — so a genuinely full or saturated box is worth naming, and worth probing once it clears.

## Track

Developer

## LLM

Model: claude-opus-4.8
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — skill/process documentation only; no `crates/` code, no game logic, no parser or engine behavior touched.

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `bash scripts/check-parser-combinators.sh $(git merge-base upstream/main HEAD)` — exit 0; `Gate G PASS`, `Gate A PASS head=e44ed2fecfe5829fec3ac905e5a8d1e01fd3c4aa base=582e1276b67def441bfb6ee3dc6dc4bdf6b46e39`
- pre-commit hook suite (parser combinator gate, PreLowered ratchet) — all passed; `Gate P PASS (PreLowered ratchet: no producer count increased)`
- Markdown-only diff, one paragraph in one file; no Rust or TypeScript in the change set, so the compile/test surface is unaffected.

## Gate A

Gate A PASS head=e44ed2fecfe5829fec3ac905e5a8d1e01fd3c4aa base=582e1276b67def441bfb6ee3dc6dc4bdf6b46e39

## Anchored on

- `.claude/skills/engine-implementer/SKILL.md` § "Inputs" build-economy rules — the measured target-directory costs (28 GB, 130 GB) this caveat defers to; the capacity constraint is already stated there as fact, and Step 3.5 now stops contradicting it.
- `.claude/skills/engine-planner/SKILL.md` § Step 3.5's own "serialize probe activity behind any active implementation executor" — the adjacent sentence that already scopes a real conflict without a ritual; this edit is authored in that form at that seam.

## Final review-impl

Raised by the independent fresh-context reviewer on #7571 as an advisory finding against #7570's merged text, and fixed here as stated. No findings remain against `e44ed2fec`; the change is one paragraph, additive in meaning, and removes no rule.

## Claimed parse impact

None.

## Scope Expansion

None. One paragraph in one file.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified build and probing guidance to distinguish target-directory lock contention from shared cache lock contention.
  * Target-directory contention no longer requires delaying builds.
  * Probing should be deferred only when capacity constraints remain and resumed once capacity is restored.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->