### PR TITLE
Parse "untap each <type>" during each other player's untap step

### DIFF
--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -297,10 +297,10 @@ fn parse_untaps_during_each_other_players_untap_step(
     description: &str,
 ) -> Option<StaticDefinition> {
     // "Untap all/each <type> you control during each other player's untap
-    // step." — CR 502.3: "all" (Seedborn Muse) and "each" (Prop Room,
-    // Ivorytusk Fortress) quantify the same class in this position. Delegate
-    // the subject to `parse_type_phrase`, which handles the full range of
-    // type + controller + property phrases.
+    // step." — Seedborn Muse prints "all"; Prop Room and Ivorytusk Fortress
+    // print "each" for the same subject shape, so both tags share this arm.
+    // Delegate the subject to `parse_type_phrase`, which handles the full
+    // range of type + controller + property phrases.
     if let Some(rest) = nom_tag_tp(tp, "untap all ").or_else(|| nom_tag_tp(tp, "untap each ")) {
         let (filter, remainder) = parse_type_phrase(rest.original);
         let remainder_lower = remainder.to_lowercase();

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -296,10 +296,12 @@ fn parse_untaps_during_each_other_players_untap_step(
     tp: &TextPair<'_>,
     description: &str,
 ) -> Option<StaticDefinition> {
-    // "Untap all <type> you control during each other player's untap step."
-    // Delegate the subject to `parse_type_phrase`, which handles the full range
-    // of type + controller phrases.
-    if let Some(rest) = nom_tag_tp(tp, "untap all ") {
+    // "Untap all/each <type> you control during each other player's untap
+    // step." — CR 502.3: "all" (Seedborn Muse) and "each" (Prop Room,
+    // Ivorytusk Fortress) quantify the same class in this position. Delegate
+    // the subject to `parse_type_phrase`, which handles the full range of
+    // type + controller + property phrases.
+    if let Some(rest) = nom_tag_tp(tp, "untap all ").or_else(|| nom_tag_tp(tp, "untap each ")) {
         let (filter, remainder) = parse_type_phrase(rest.original);
         let remainder_lower = remainder.to_lowercase();
         let during_ok = nom_on_lower(

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -2343,11 +2343,11 @@ fn self_untap_during_each_other_untap_step_bender_waterskin() {
     }
 }
 
-/// CR 502.3 + CR 113.6: "Untap EACH <type> you control during each other
-/// player's untap step" — the "each" subject word must lower through the same
-/// Seedborn authority as "all". Before the fix the line fell through and the
-/// half's text did nothing in any game state (#7574: Prop Room; Ivorytusk
-/// Fortress additionally exercises the property-filter path of the subject).
+/// "Untap EACH <type> you control during each other player's untap step" —
+/// the "each" subject word must lower through the same Seedborn authority as
+/// "all". Before the fix the line fell through and the half's text did
+/// nothing in any game state (#7574: Prop Room; Ivorytusk Fortress
+/// additionally exercises the property-filter path of the subject).
 #[test]
 fn untap_each_during_each_other_untap_step_prop_room_and_ivorytusk() {
     // Prop Room — plain typed subject.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -2343,6 +2343,49 @@ fn self_untap_during_each_other_untap_step_bender_waterskin() {
     }
 }
 
+/// CR 502.3 + CR 113.6: "Untap EACH <type> you control during each other
+/// player's untap step" — the "each" subject word must lower through the same
+/// Seedborn authority as "all". Before the fix the line fell through and the
+/// half's text did nothing in any game state (#7574: Prop Room; Ivorytusk
+/// Fortress additionally exercises the property-filter path of the subject).
+#[test]
+fn untap_each_during_each_other_untap_step_prop_room_and_ivorytusk() {
+    // Prop Room — plain typed subject.
+    let def =
+        parse_static_line("Untap each creature you control during each other player's untap step.")
+            .expect("static def for Prop Room");
+    assert_eq!(def.mode, StaticMode::UntapsDuringEachOtherPlayersUntapStep);
+    match def.affected {
+        Some(TargetFilter::Typed(ref tf)) => {
+            assert_eq!(
+                tf.controller,
+                Some(crate::types::ability::ControllerRef::You)
+            );
+        }
+        ref other => panic!("expected Typed(you-control) affected filter, got {other:?}"),
+    }
+
+    // Ivorytusk Fortress — the subject carries a property filter.
+    let def = parse_static_line(
+        "Untap each creature you control with a +1/+1 counter on it during each other player's untap step.",
+    )
+    .expect("static def for Ivorytusk Fortress");
+    assert_eq!(def.mode, StaticMode::UntapsDuringEachOtherPlayersUntapStep);
+    match def.affected {
+        Some(TargetFilter::Typed(ref tf)) => {
+            assert_eq!(
+                tf.controller,
+                Some(crate::types::ability::ControllerRef::You)
+            );
+            assert!(
+                !tf.properties.is_empty(),
+                "the +1/+1-counter restriction must survive as a property filter"
+            );
+        }
+        ref other => panic!("expected Typed(you-control) affected filter, got {other:?}"),
+    }
+}
+
 /// CR 502.3 + CR 611.3a: Quest for Renewal — the inverted "As long as
 /// <condition>, untap all creatures you control during each other player's
 /// untap step" static. The comma-split rewrite formerly fell through to an


### PR DESCRIPTION
Fixes #7574

"Untap all <type> you control during each other player's untap step" (Seedborn Muse) parses; the "each" quantifier form fell through to `Effect::unimplemented`. The dispatch site now accepts both tags; the subject still delegates to `parse_type_phrase` (CR 502.3).

**Class measurement** — full double parse of `client/public/card-data.json` (35,797 entries), with vs. without the fix: exactly 2 cards change — Prop Room, Ivorytusk Fortress.

**Counter-probe:** with `.or_else(|| nom_tag_tp(tp, "untap each "))` removed, `untap_each_during_each_other_untap_step_prop_room_and_ivorytusk` fails (both cards parse to `Unimplemented`).

**What the test does not prove:** it is parser-level only. The runtime untap during other players' untap steps is the existing `StaticMode::UntapsDuringEachOtherPlayersUntapStep` path shared with the "all" form and unchanged here; Ivorytusk's "+1/+1 counter" property filter is asserted as parsed (`!properties.is_empty()`), not exercised at runtime.

**Remaining gap:** none within the "untap all/each" wording; the other Seedborn-corpus classes (e.g. #7575) remain separate issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing for effects that untap each qualifying permanent during other players’ untap steps.
  * Preserved controller and property filters, including effects involving +1/+1 counters.

* **Tests**
  * Added regression coverage for “untap each creature you control” effects and related card patterns.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->