### PR TITLE
fix(client): construct DraftAdapter per call so draft routes load

### DIFF
--- a/client/src/viewmodel/limitedPoolFilter.ts
+++ b/client/src/viewmodel/limitedPoolFilter.ts
@@ -1,3 +1,8 @@
+// `DraftAdapter` must be constructed inside a function, never at module
+// evaluation time: its bundled chunk assigns exports inside a top-level-await
+// (`__tla`) microtask, so the binding is still `undefined` while this module
+// evaluates and a module-scope `const adapter = new DraftAdapter()` throws
+// there. It carries no instance state, so constructing per call is free.
 import {
   DraftAdapter,
   type DraftCardInstance,
@@ -50,8 +55,6 @@ export function axisKinds(groups: DraftPoolGroup[]): DraftPoolGroupKind[] {
   return groups.map((group) => group.kind);
 }
 
-const adapter = new DraftAdapter();
-
 /**
  * Ask the engine which instances of `listing` the filter keeps, in listing
  * order. The display renders exactly this result. Classification happens
@@ -61,7 +64,7 @@ export function filterPoolListing(
   listing: DraftCardInstance[],
   filter: PoolFilter,
 ): Promise<string[]> {
-  return adapter.filterPoolListing(listing, filter);
+  return new DraftAdapter().filterPoolListing(listing, filter);
 }
 
 /**
@@ -72,5 +75,5 @@ export function filterPoolListing(
 export function fetchPoolFilterOptions(
   pool: DraftCardInstance[],
 ): Promise<PoolFilterOptions> {
-  return adapter.poolFilterOptions(pool);
+  return new DraftAdapter().poolFilterOptions(pool);
 }


### PR DESCRIPTION
`limitedPoolFilter.ts` built its `DraftAdapter` at module scope. The bundled
`draft-adapter` chunk is wrapped by vite-plugin-top-level-await (it contains a
dynamic `import("@wasm/draft")`), so its exports are assigned inside a `__tla`
microtask and the binding is still `undefined` while an importing module
evaluates. `LimitedDeckBuilder` therefore threw during evaluation, rejecting the
lazy `DraftPage` / `DraftPodPage` imports and taking `/draft/quick` and
`/draft-pod` down. Regression from #7546.

`chunkReloadHandler` calls `preventDefault()` on `vite:preloadError`, so vite's
`__vitePreload` swallowed the rejection and resolved the import to `undefined` —
which is why the failure surfaced as the misleading `can't access property
"DraftPage", t is undefined` rather than the real constructor error.

Construct at the call sites instead, matching the five existing sites in
`draftStore.ts`. `DraftAdapter` has no constructor and no instance fields, and
`ensureDraftWasm` caches the WASM module, so per-call allocation is free.

Verified on a production build: the bundle reports zero module-evaluation-time
uses of a top-level-await-wrapped chunk's exports (same-artifact pre-fix control:
one, at this site), and `/draft/quick?mode=cube` renders in a browser instead of
the error boundary.

Claude-Session: https://claude.ai/code/session_01DJgbxMGnPi6MFfGUe15Y3P
