### PR TITLE
fix(engine): freeze the prevention tally's order before it is parked

### DIFF
--- a/crates/engine/src/game/combat_damage.rs
+++ b/crates/engine/src/game/combat_damage.rs
@@ -1723,6 +1723,26 @@ pub(crate) fn apply_combat_damage(
     // prevention riders, and the CR 732.2a ring guard — lives in the drain, in
     // the order it has always been emitted, so a CR 616.1 pause can suspend it
     // without reordering it.
+    // Deterministic order: the tally arrives as a `HashMap`, but it is stored in
+    // `PendingCombatLifelink` (which is `Serialize`/`Deserialize`, so a parked
+    // batch must round-trip byte-identically) and Phase D fires one CR 615.5
+    // rider per entry IN THIS ORDER. A `HashMap`'s arbitrary iteration order
+    // would let the same batch serialize — and emit its rider events —
+    // differently across saves and AI clones. The ids are not `Ord`, so sort on
+    // their inner integers, exactly as `blocker_ids` is sorted above.
+    let mut prevention_tally: Vec<(AppliedReplacementKey, i32)> =
+        prevention_tally.into_iter().collect();
+    prevention_tally.sort_by_key(|(key, _)| match key {
+        AppliedReplacementKey::Object { source, index } => (0u8, source.0, *index, 0u8),
+        AppliedReplacementKey::Floating { index } => (1, 0, *index, 0),
+        AppliedReplacementKey::StepEndMana { index } => (2, 0, *index, 0),
+        AppliedReplacementKey::EntryControllerChoice {
+            source,
+            index,
+            controller,
+        } => (3, source.0, *index, controller.0),
+    });
+
     drain_combat_lifelink(
         state,
         PendingCombatLifelink {
@@ -1732,7 +1752,7 @@ pub(crate) fn apply_combat_damage(
                 .collect(),
             batch_events: events,
             damage_to_players,
-            prevention_tally: prevention_tally.into_iter().collect(),
+            prevention_tally,
             lives_before,
             sub_step,
         },

--- a/crates/engine/src/game/elimination.rs
+++ b/crates/engine/src/game/elimination.rs
@@ -1060,10 +1060,16 @@ fn do_eliminate(
     // there is no one for the owed CR 702.15b gain to be applied to. NO CR 800.4
     // SUBPART STATES THIS DIRECTLY — a sweep of 800.4 and 800.4a-800.4p returns no
     // mention of life at all, so this sentence carries no citation on purpose. The
-    // nearest analogues are CR 800.4e (combat damage that would be assigned to a
-    // player who has left the game isn't assigned) and CR 614.9 (damage redirected
-    // to or from a player who has left the game does nothing); BOTH are about
-    // damage rather than life gain and neither may be cited as authority here.
+    // nearest analogues are CR 800.4d (a triggered ability that would be controlled
+    // by a player who has left the game isn't put on the stack), CR 800.4e (combat
+    // damage that would be assigned to a player who has left the game isn't
+    // assigned), and CR 614.9 (damage redirected to or from a player who has left
+    // the game does nothing). 800.4d is the closest in SHAPE — an owed effect for a
+    // departed seat simply does not happen — but it is about triggered abilities,
+    // and the other two are about damage; NONE may be cited as authority for life
+    // gain. A re-sweep of 800.4 and 800.4a-800.4p confirms the enumerated subparts
+    // cover objects, control, creation, combat damage, costs, choices, information,
+    // and turns, and none of them life.
     //
     // Drop only THAT seat's owed lifelink gains — the rest of the batch belongs to
     // other controllers and must still land, and the batch itself must still


### PR DESCRIPTION
`replace_combat_damage_batch` returns the tally as a `HashMap`, but it is stored
in `PendingCombatLifelink` — which derives `Serialize`/`Deserialize`, so a parked
batch must round-trip byte-identically — and Phase D fires one CR 615.5 rider per
entry IN THAT ORDER. A `HashMap`'s arbitrary iteration order therefore let the
same batch serialize, and emit its rider events, differently across processes:
a save written by one run and replayed by another, or an AI clone diverging from
its parent. It is invisible to in-process testing, which sees one stable hash
seed per run.

Sort on the keys' inner integers (the ids are not `Ord`), matching the
`blocker_ids` sort already in this file for the same stated reason. The two
sibling fields are unaffected: `remaining` and `damage_to_players` are `Vec`s
built by push.

Also, no behaviour change: widen the nearest-analogue set for forfeiting a
departed seat's owed lifelink gain to include CR 800.4d, which is closer in shape
than the two damage rules already named — an owed effect for a departed seat
simply does not happen. It is still NOT cited as authority: a re-sweep confirms
CR 800.4 and 800.4a-800.4p cover objects, control, creation, combat damage,
costs, choices, information and turns, and none of them life.

Reported by CodeRabbit on #7582, whose engine work was superseded by #7581.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency in combat damage processing when multiple prevention effects are involved.
  - Lifelink-related combat results now follow a stable, predictable ordering, helping ensure repeatable outcomes across identical game states.
  - Corrected handling of life gain calculations when a player leaves the game during combat.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->