### PR TITLE
fix(engine,server-core): consume the ResolveAllReady latch on every transport

### DIFF
--- a/client/src/game/waitingForRegistry.ts
+++ b/client/src/game/waitingForRegistry.ts
@@ -34,8 +34,18 @@ export const HANDLED_WAITING_FOR_TYPES: ReadonlySet<WaitingFor["type"]> =
     // Active priority — passes via PassButton / mana payment / cast.
     "Priority",
     // Resolve All's explicit standing-pass authorization. The consent modal
-    // gathers each representative's response; its final Grant consumes Ready
-    // through the engine adapter before ordinary priority resumes.
+    // gathers each representative's response.
+    //
+    // `ResolveAllReady` is listed as handled even though it renders nothing,
+    // because whoever submits the FINAL Grant consumes it: this client via the
+    // modal, a browser-driven AI seat via `aiController`, and a server-driven
+    // AI seat via `server-core`'s own hand-off inside `run_ai`. The state has
+    // no acting player, and while the engine does still offer each grantor a
+    // `RevokeResolveAllConsent`, nothing here renders it — so a transport that
+    // reaches this state without one of those owners parks the game
+    // permanently, which is exactly what happened before the server grew its
+    // half. Any new transport that can mint a consent run owes a consumer here
+    // before this entry stays honest.
     "ResolveAllConsent",
     "ResolveAllReady",
     // CR 701.42 / CR 508.4: meld pair and attacking-entry destination dialogs.

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -14,7 +14,8 @@ use engine::ai_support::{
 use engine::database::legality::{any_ai_difficulty_is_cedh, validate_cedh_bracket};
 use engine::database::{CardDatabase, CardSearchQuery};
 use engine::game::engine::{
-    apply, apply_for_simulation, resolve_all_ready_is_authorized, resolve_all_ready_prefix,
+    apply, apply_for_simulation, recover_orphaned_resolve_all, resolve_all_ready_access,
+    resolve_all_ready_prefix, ResolveAllReadyAccess,
 };
 use engine::game::interaction::{bind_interaction_authority, submit_interaction};
 use engine::game::preview::{compute_preview_diff, preview_auto_payment_sources};
@@ -2197,6 +2198,10 @@ fn restore_game_state_inner(json_str: &str) -> Result<(), String> {
     backfill_legacy_debug_permissions(&mut state, restored.debug_permitted_was_serialized, false);
     finalize_public_state(&mut state);
     bind_interaction_session(&mut state);
+    // A snapshot written while a Resolve All latch was outstanding restores
+    // with no acting seat; the consumer that would have advanced it lived in
+    // the worker that produced the snapshot.
+    recover_orphaned_resolve_all(&mut state);
     GAME_STATE.with(|cell| cell.set(Some(state)));
     // Restoring (undo, or resuming a save from a fresh worker that never saw
     // `initialize_game`) invalidates any in-progress recording — the restored
@@ -2268,6 +2273,10 @@ pub fn resume_multiplayer_host_state(json_str: &str) -> Result<(), JsValue> {
 
     finalize_public_state(&mut state);
     bind_interaction_session(&mut state);
+    // Mirrors `server-core::GameSession::from_persisted`: a host that reloaded
+    // while a Resolve All latch was outstanding would otherwise resume into a
+    // state no seat can advance, with returning guests bound to a dead prompt.
+    recover_orphaned_resolve_all(&mut state);
 
     GAME_STATE.with(|cell| cell.set(Some(state)));
     MULTIPLAYER_MODE.with(|cell| cell.set(true));
@@ -3044,8 +3053,18 @@ pub fn resolve_all(
         // priority window. Keep the legacy payload parse as a wire-compatible
         // boundary while the consent action owns the authoritative cap.
         let _ = max_resolutions;
-        if !resolve_all_ready_is_authorized(state, requester) {
-            return Err(JsValue::from_str("Resolve All consent is not ready"));
+        // Reject only an unentitled caller. A latch whose frozen run has gone
+        // stale is still routed into the resolver, whose fail-closed
+        // invalidation restores ordinary priority — rejecting it here instead
+        // would leave the game parked with no acting player and, in practice,
+        // nothing any client offers the player to press.
+        // Exhaustive rather than an equality test: a future variant must be
+        // classified here instead of silently defaulting to allowed.
+        match resolve_all_ready_access(state, requester) {
+            ResolveAllReadyAccess::Refused => {
+                return Err(JsValue::from_str("Resolve All consent is not ready"));
+            }
+            ResolveAllReadyAccess::Admitted => {}
         }
         let mut result = resolve_all_ready_prefix(state, requester);
         // A Resolve All burst applies real actions directly via

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -76,8 +76,10 @@ use super::zone_pipeline::{self, ZoneMoveRequest, ZoneMoveResult};
 use super::zones;
 
 pub use super::engine_resolve_batch::{
-    resolve_all_fast_forward, resolve_all_ready_is_authorized, resolve_all_ready_prefix,
-    ResolveAllCallbackDecision, ResolveAllFastForwardResult,
+    pending_resolve_all_ready_requester, recover_orphaned_resolve_all, resolve_all_fast_forward,
+    resolve_all_ready_access, resolve_all_ready_prefix, resolve_all_ready_prefix_with,
+    ResolveAllCallbackDecision, ResolveAllContinuation, ResolveAllFastForwardResult,
+    ResolveAllReadyAccess,
 };
 
 #[derive(Debug, Clone, Error)]
@@ -20109,7 +20111,37 @@ mod stage2_injector_tests {
                 //   `:13210 ⇒ :13130`. It creates no CR 603.5 prompt either — a special
                 //   action does not use the stack (CR 116.1) — and the pinned line is again
                 //   the same `OptionalEffectChoice` construction, moved wholesale.
-                "game/engine.rs:13135".to_string(),
+                //   ResolveAllReady latch-consumption fix: `:13135 ⇒ :13137`, `+2`.
+                //   The `engine_resolve_batch` re-export block is the whole of it, and
+                //   the symbol delta is ENUMERATED rather than counted: the block goes
+                //   from 5 names to 10. Six arrive —
+                //   `pending_resolve_all_ready_requester`,
+                //   `recover_orphaned_resolve_all`, `resolve_all_ready_access`,
+                //   `resolve_all_ready_prefix_with`, `ResolveAllContinuation`,
+                //   `ResolveAllReadyAccess` — and exactly one leaves,
+                //   `resolve_all_ready_is_authorized`. rustfmt spends two more lines on
+                //   the result. (`ResolveAllReadyAuthority` is NOT in the departure
+                //   column, though a reader tracking this change's history may expect it
+                //   there: `git grep` finds ZERO occurrences of that name anywhere in the
+                //   base tree, so nothing it could have departed from ever held it. That
+                //   is the whole of what is measurable, and this note asserts no more —
+                //   how any earlier wording came to be is drafting history, which git
+                //   cannot answer. Stated because a note whose weight is "MEASURED" earns
+                //   nothing if its enumeration is taken on trust.)
+                //   MEASURED, never carried: `diff -u` on this file between the base tree
+                //   and the candidate has exactly ONE hunk above this producer,
+                //   `@@ -76,8 +76,10 @@` — that block alone. Identity re-established on
+                //   BOTH controls, not assumed: the line at `:13137` is sha256-identical
+                //   (`8a544e87…5cc7d63`) to the producer at `:13135` in the base tree,
+                //   and its offset from `begin_pending_trigger_target_selection` is STILL
+                //   134 — the control that discriminates when the same mint text occurs
+                //   at several coordinates in this crate.
+                //   A re-export mints nothing: it NAMES symbols. None of the Resolve All
+                //   entry points it exposes constructs a CR 603.5 modal — they consume or
+                //   repair a `ResolveAllReady` latch, which `acting_player()` reports as
+                //   having no actor at all. The PRODUCER half stays 5 and the partition
+                //   stays 5/8/28.
+                "game/engine.rs:13137".to_string(),
             ],
             "the five production producers, NAMED: the CR 603.5 gate in `resolve_chain_body` \
              plus the two repeated-optional-payment drivers, the per-player acceptance cursor \

--- a/crates/engine/src/game/engine_resolve_batch.rs
+++ b/crates/engine/src/game/engine_resolve_batch.rs
@@ -64,6 +64,41 @@ pub fn resolve_all_ready_prefix(
     state: &mut GameState,
     requester: PlayerId,
 ) -> ResolveAllFastForwardResult {
+    resolve_all_ready_prefix_with(state, requester, ResolveAllContinuation::AutoPassRemainder)
+}
+
+/// What to do with the remainder of the stack when the prefix proof stops
+/// short.
+///
+/// The two answers belong to different situations, not to a preference. A live
+/// session honors the requester's durable intent; a session being restored has
+/// nobody connected to observe an unattended run-out, so it hands an
+/// actionable state back and stops.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolveAllContinuation {
+    /// Install the ordinary `UntilStackEmpty` auto-pass and pass priority, so
+    /// the requester's standing intent to avoid manual passes survives a proof
+    /// that could not collapse the whole batch. The live-session answer.
+    AutoPassRemainder,
+    /// Stop at ordinary priority and install nothing.
+    ///
+    /// Used at restore. The auto-pass path resolves the remaining stack through
+    /// the ordinary pipeline, which can end the game — and a restore has no
+    /// socket attached and no caller positioned to emit a ranked result or a
+    /// terminal artifact, so a game that ended there would be registered as a
+    /// live session parked in `GameOver`. Handing priority back instead loses
+    /// nothing: the consent is discarded either way, and a reconnecting player
+    /// can simply ask for Resolve All again.
+    StopAtPriority,
+}
+
+/// [`resolve_all_ready_prefix`], with an explicit answer for the stack that the
+/// proof could not collapse.
+pub fn resolve_all_ready_prefix_with(
+    state: &mut GameState,
+    requester: PlayerId,
+    continuation: ResolveAllContinuation,
+) -> ResolveAllFastForwardResult {
     let total = state.stack.len() as u32;
     let mut events = Vec::new();
     let mut log_entries = Vec::new();
@@ -136,7 +171,7 @@ pub fn resolve_all_ready_prefix(
     // requester's durable intent to avoid manual priority passes. Continue
     // through the ordinary `UntilStackEmpty` engine path in that case.
     turn_control::invalidate_resolve_all_consent(state);
-    if proof_stopped {
+    if proof_stopped && continuation == ResolveAllContinuation::AutoPassRemainder {
         let mut fallback_events = Vec::new();
         match super::engine::install_until_stack_empty_auto_pass_and_pass_priority(
             state,
@@ -172,19 +207,149 @@ pub fn resolve_all_ready_prefix(
     }
 }
 
-/// Returns whether the frozen Ready consent run authorizes this requester.
-/// Transport callers must reject an unauthorized request before mutating the
-/// authoritative session; the resolver's fail-closed invalidation remains its
-/// defense-in-depth boundary.
-pub fn resolve_all_ready_requester_is_authorized(state: &GameState, requester: PlayerId) -> bool {
-    ready_consent_run(state, requester).is_some()
+/// Whether `requester` may hand the current `WaitingFor::ResolveAllReady`
+/// latch to [`resolve_all_ready_prefix`].
+///
+/// Deliberately one axis — entitlement — and not two. Whether the frozen run
+/// is still *coherent* with the live game is a second question, and it is
+/// answered inside [`resolve_all_ready_prefix`], which re-derives it and
+/// either collapses the consented prefix or repairs the latch back to
+/// priority. Returning that answer here as well would compute a decision at
+/// the transport, hand it to a caller with no use for it, and then recompute
+/// it in the callee — one decision spread across a layer boundary.
+///
+/// Callers that want to know which of the two happened should read
+/// [`ResolveAllFastForwardResult::items_resolved`], which the resolver already
+/// reports, rather than a pre-flight guess that may be stale by the time the
+/// resolver runs.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ResolveAllReadyAccess {
+    /// The resolver may run. Either the requester is one of the run's frozen
+    /// submitters, or no run bears this epoch at all — in which case there is
+    /// no submitter list left to check anyone against, and the resolver's
+    /// repair is the latch's only exit.
+    ///
+    /// Admitting the incoherent case is deliberate. The repair resolves
+    /// nothing, so it confers no advantage, and refusing every seat would make
+    /// an unadvanceable state permanent. It is still a mutation — it clears the
+    /// recorded priority passes — so a seat that did not start the run can
+    /// restart a pass cycle. That is the price of having any exit at all, and
+    /// the caller is token-authenticated at the transport regardless.
+    Admitted,
+    /// Not a Ready latch, or a run bearing this epoch exists and this requester
+    /// is not among its frozen submitters. Transports must reject without
+    /// mutating the session.
+    Refused,
 }
 
-/// Validates the frozen Phase-1 consent against the live topology before the
-/// Ready state is materialized. A changed controller, eliminated player, or
-/// stale requester fails closed without invoking a speculative callback.
-pub fn resolve_all_ready_is_authorized(state: &GameState, requester: PlayerId) -> bool {
-    ready_consent_run(state, requester).is_some()
+/// Single authority on whether `requester` may touch the current Ready latch.
+///
+/// A changed controller, eliminated player, or drifted priority cursor does
+/// NOT refuse: those are the engine's own bookkeeping going out of date rather
+/// than an unentitled caller, and the resolver's repair is the only exit from
+/// the latch.
+pub fn resolve_all_ready_access(state: &GameState, requester: PlayerId) -> ResolveAllReadyAccess {
+    let WaitingFor::ResolveAllReady { epoch } = &state.waiting_for else {
+        return ResolveAllReadyAccess::Refused;
+    };
+    // Without a run bearing this epoch there is no frozen submitter list, so no
+    // seat can prove ownership. Refusing every seat would brick the game.
+    let Some(run) = state
+        .resolve_all_consent_run
+        .as_ref()
+        .filter(|run| run.epoch == *epoch)
+    else {
+        return ResolveAllReadyAccess::Admitted;
+    };
+    if run
+        .participants
+        .iter()
+        .any(|participant| participant.authorized_submitter == requester)
+    {
+        ResolveAllReadyAccess::Admitted
+    } else {
+        ResolveAllReadyAccess::Refused
+    }
+}
+
+/// The frozen submitter who started a pending, consumable Ready latch.
+///
+/// `begin_resolve_all_consent` rotates the participant list so its first entry
+/// is the initiating representative, making `participants[0]` the run's own
+/// record of who asked for the batch. Callers that must drive the latch — the
+/// AI-seat hand-off on both the local and the server transport — read the
+/// requester from here instead of synthesizing one, so authorization stays
+/// frozen at proposal time exactly as `ResolveAllConsentRun` intends.
+///
+/// INITIATOR, NOT OWNER — the distinction has already cost one wrong test
+/// assertion. This names whoever called `BeginResolveAll`, which is frequently
+/// NOT the seat whose Grant completed the run. Ownership of a latch follows the
+/// FINAL Grant, because that submitter's client is the thing that will send
+/// `ResolveAll` for it, so this value must never be used to decide whose latch
+/// it is. `GameSession::run_ai` derives that from its own applied batch instead.
+///
+/// Why passing the initiator to [`resolve_all_ready_prefix_with`] is
+/// nonetheless right: there `requester` is a CREDENTIAL and nothing else,
+/// consumed once by `ready_consent_run` as a membership test over the frozen
+/// submitters, which the initiator always satisfies. Every seat-bearing
+/// decision downstream reads the run instead — the Priority restore and the
+/// proof-stopped auto-pass both use `run.priority_snapshot.waiting_player`, and
+/// the proof loop seeds passes for all participants. So which participant is
+/// handed in cannot change the outcome.
+///
+/// That is NOT true everywhere. In [`resolve_all_fast_forward`] the requester
+/// is behaviour-bearing: `actor == requester` auto-passes silently while other
+/// seats are routed through the caller's callback. Neither latch consumer goes
+/// through that path today; one that did would have to decide owner-vs-initiator
+/// on purpose rather than inherit this function's answer.
+pub fn pending_resolve_all_ready_requester(state: &GameState) -> Option<PlayerId> {
+    if !matches!(state.waiting_for, WaitingFor::ResolveAllReady { .. }) {
+        return None;
+    }
+    let requester = state
+        .resolve_all_consent_run
+        .as_ref()?
+        .participants
+        .first()?
+        .authorized_submitter;
+    ready_consent_run(state, requester)
+        .is_some()
+        .then_some(requester)
+}
+
+/// Discharge a `ResolveAllReady` latch carried by a state that is being
+/// restored, returning the batch when a prefix was collapsed.
+///
+/// Every restore seam owes this call, and the reason is structural rather than
+/// defensive. `ResolveAllReady` reports no acting player
+/// (`WaitingFor::acting_player` is `None` for it), so it is advanced only out
+/// of band, by whichever driver holds the submitting call's return value. That
+/// driver is in-memory and does not survive the process that created it.
+///
+/// The latch is not literally action-less: while its run is intact,
+/// `candidate_actions` offers each grantor a `RevokeResolveAllConsent`. But no
+/// client renders anything at `ResolveAllReady` — `ResolveAllConsentModal` is
+/// gated on `ResolveAllConsent` — so that escape is never presented to a human,
+/// and it disappears entirely once the run is gone. A restored latch is
+/// therefore unadvanceable in practice even where it is not in theory.
+///
+/// [`resolve_all_ready_prefix`] is the single authority for both outcomes, so
+/// this deliberately does not branch on which one applies. An intact unanimous
+/// run collapses to the prefix the players already consented to; an incoherent
+/// one repairs `waiting_for` back to priority together with the display and
+/// interaction-authority state that repair implies. Passing a seat that is not
+/// a participant reaches the repair branch by construction, which is why the
+/// fallback requester below needs no separate justification.
+pub fn recover_orphaned_resolve_all(state: &mut GameState) -> Option<ResolveAllFastForwardResult> {
+    if !matches!(state.waiting_for, WaitingFor::ResolveAllReady { .. }) {
+        return None;
+    }
+    let requester = pending_resolve_all_ready_requester(state).unwrap_or(state.priority_player);
+    Some(resolve_all_ready_prefix_with(
+        state,
+        requester,
+        ResolveAllContinuation::StopAtPriority,
+    ))
 }
 
 fn ready_consent_run(state: &GameState, requester: PlayerId) -> Option<&ResolveAllConsentRun> {

--- a/crates/engine/src/game/turn_control.rs
+++ b/crates/engine/src/game/turn_control.rs
@@ -403,10 +403,23 @@ pub fn resolve_all_granted_submitter(
 /// frozen representative set is no longer meaningful after elimination, so
 /// restart ordinary priority from a living representative instead of trying to
 /// repair the proposal in place.
+///
+/// The public consent state, not the private run, decides whether a repair is
+/// owed. An earlier form returned as soon as `take()` found no run, which made
+/// this a no-op in exactly the case it exists to fix — a consent `WaitingFor`
+/// left standing over a run that is already gone. Neither half of that pairing
+/// can advance: a run-less `ResolveAllReady` has no acting player AND — with
+/// no run to enumerate grantors from — not even the Revoke that an intact
+/// latch still offers, and a run-less `ResolveAllConsent` still offers its
+/// representative a Grant that `respond_resolve_all_consent` can only reject.
+/// Taking the run stays unconditional so the two fields cannot disagree
+/// afterwards.
+///
+/// CR 117.4: clearing the recorded passes restarts the pass cycle that the
+/// discarded consent state had suspended, so priority resumes from the
+/// repaired holder rather than from a partial round nobody can complete.
 pub fn invalidate_resolve_all_consent(state: &mut GameState) {
-    if state.resolve_all_consent_run.take().is_none() {
-        return;
-    }
+    state.resolve_all_consent_run = None;
     if !matches!(
         state.waiting_for,
         WaitingFor::ResolveAllConsent { .. } | WaitingFor::ResolveAllReady { .. }

--- a/crates/engine/tests/integration/resolve_all_consent.rs
+++ b/crates/engine/tests/integration/resolve_all_consent.rs
@@ -2,7 +2,11 @@
 
 use engine::ai_support::{candidate_actions, legal_actions_for_viewer};
 use engine::game::elimination::eliminate_player;
-use engine::game::engine::{apply, resolve_all_ready_prefix};
+use engine::game::engine::{
+    apply, pending_resolve_all_ready_requester, recover_orphaned_resolve_all,
+    resolve_all_ready_access, resolve_all_ready_prefix, resolve_all_ready_prefix_with,
+    ResolveAllContinuation, ResolveAllReadyAccess,
+};
 use engine::game::game_object::AttachTarget;
 use engine::game::interaction::{
     bind_interaction_authority, derive_viewer_interaction, resolve_interaction_response,
@@ -830,5 +834,347 @@ fn ready_consent_collapses_the_safe_prefix_before_a_stack_growing_resolution() {
     assert!(
         state.auto_pass.is_empty(),
         "a stack-growing resolution interrupts UntilStackEmpty instead of inheriting stale consent"
+    );
+}
+/// Drives a two-seat run to unanimous consent and returns the latched state.
+fn ready_two_seat_state() -> GameState {
+    let mut state = GameState::new(FormatConfig::free_for_all(), 2, 0x0C0F_FEE0);
+    state.stack.push_back(no_op_entry(1, P1));
+    apply(
+        &mut state,
+        P0,
+        GameAction::BeginResolveAll { max_resolutions: 1 },
+    )
+    .expect("priority holder may begin Resolve All consent");
+    let WaitingFor::ResolveAllConsent { epoch, .. } = state.waiting_for else {
+        panic!(
+            "expected a queued consent prompt, got {:?}",
+            state.waiting_for
+        );
+    };
+    apply(
+        &mut state,
+        P1,
+        GameAction::RespondResolveAllConsent {
+            epoch,
+            decision: ResolveAllConsentDecision::Grant,
+        },
+    )
+    .expect("the remaining representative may grant");
+    assert!(matches!(
+        state.waiting_for,
+        WaitingFor::ResolveAllReady { .. }
+    ));
+    state
+}
+
+/// The gate answers ONE question — entitlement — and coherence is answered
+/// elsewhere, by the resolver. This pins that separation from both sides: the
+/// gate's verdict does not move when coherence changes, and
+/// `pending_resolve_all_ready_requester` is what moves instead.
+#[test]
+fn ready_access_refuses_an_unentitled_seat_and_admits_an_incoherent_run() {
+    let mut state = ready_two_seat_state();
+    assert_eq!(
+        resolve_all_ready_access(&state, P0),
+        ResolveAllReadyAccess::Admitted
+    );
+    assert_eq!(
+        pending_resolve_all_ready_requester(&state),
+        Some(P0),
+        "the run's own first participant is the frozen requester"
+    );
+
+    // P0 is a seat at this two-player table; P2 is not, which is exactly the
+    // shape a forged or stale wire request takes: an id the run never froze.
+    assert_eq!(
+        resolve_all_ready_access(&state, P2),
+        ResolveAllReadyAccess::Refused
+    );
+
+    // An installed auto-pass makes the frozen priority snapshot no longer
+    // describe the live game. Entitlement is untouched by that — P0 is still a
+    // frozen submitter — so the gate must not move.
+    state.auto_pass.insert(
+        P1,
+        AutoPassMode::UntilStackEmpty {
+            initial_stack_len: 1,
+        },
+    );
+    assert_eq!(
+        resolve_all_ready_access(&state, P0),
+        ResolveAllReadyAccess::Admitted,
+        "coherence is not this gate's axis; refusing here would strand the latch"
+    );
+    assert_eq!(
+        pending_resolve_all_ready_requester(&state),
+        None,
+        "an incoherent run authorizes no unattended consumption"
+    );
+
+    // With no run at all there is no frozen submitter list, so there is nobody
+    // to check anyone against — including a seat that never was a participant.
+    // Refusing here is what would make the latch permanent.
+    state.resolve_all_consent_run = None;
+    assert_eq!(
+        resolve_all_ready_access(&state, P2),
+        ResolveAllReadyAccess::Admitted,
+        "a run-less latch has no owner to prove; the repair is its only exit"
+    );
+}
+
+/// A Ready latch has no acting player, and once its run is gone it has no
+/// Revoke either — `append_resolve_all_revocations` enumerates grantors from
+/// the run — so a run-less latch leaves the game with no exit whatsoever. The
+/// resolver must repair it rather than refuse, and resolve nothing doing so.
+#[test]
+fn a_ready_latch_with_no_run_repairs_to_priority_without_resolving() {
+    let mut state = ready_two_seat_state();
+    state.resolve_all_consent_run = None;
+    assert!(
+        state.waiting_for.acting_player().is_none(),
+        "the fixture must reproduce the no-actor property that makes this fatal"
+    );
+    assert_eq!(
+        resolve_all_ready_access(&state, P0),
+        ResolveAllReadyAccess::Admitted,
+        "no seat can prove ownership of a run-less latch, so none may be refused"
+    );
+
+    let result = resolve_all_ready_prefix(&mut state, P0);
+
+    assert_eq!(result.items_resolved, 0, "a repair resolves nothing");
+    assert_eq!(state.stack.len(), 1, "the stack entry survives the repair");
+    assert!(
+        matches!(state.waiting_for, WaitingFor::Priority { .. }),
+        "the repair must restore ordinary priority, got {:?}",
+        state.waiting_for
+    );
+    assert!(state.auto_pass.is_empty());
+}
+/// Recovery is the single obligation every restore seam owes, so it must be
+/// inert on the overwhelming majority of states, which carry no latch at all.
+#[test]
+fn recovery_is_inert_on_a_state_carrying_no_latch() {
+    let mut state = GameState::new(FormatConfig::free_for_all(), 2, 0x0C0F_FEE1);
+    state.stack.push_back(no_op_entry(1, P1));
+    let before = state.waiting_for.clone();
+
+    assert!(
+        recover_orphaned_resolve_all(&mut state).is_none(),
+        "no latch means nothing to discharge"
+    );
+    assert_eq!(state.waiting_for, before, "an inert call mutates nothing");
+    assert_eq!(state.stack.len(), 1);
+}
+
+/// A snapshot written while an intact unanimous run was outstanding is
+/// discharged rather than repaired: the players consented to this prefix
+/// before the snapshot existed, and the consent was frozen with it.
+#[test]
+fn recovery_discharges_an_intact_latch() {
+    let mut state = ready_two_seat_state();
+    assert_eq!(
+        pending_resolve_all_ready_requester(&state),
+        Some(P0),
+        "non-vacuity: the fixture must present a consumable latch"
+    );
+
+    let batch =
+        recover_orphaned_resolve_all(&mut state).expect("an intact latch must be discharged");
+
+    assert_eq!(batch.items_resolved, 1, "the consented prefix is collapsed");
+    assert!(state.stack.is_empty(), "the stack entry resolved");
+    assert!(
+        matches!(state.waiting_for, WaitingFor::Priority { .. }),
+        "discharging hands priority back, got {:?}",
+        state.waiting_for
+    );
+}
+
+/// Recovery must leave the interaction layer describing the state it produced,
+/// not the one it repaired away.
+///
+/// A snapshot taken while the latch was live carries one Revoke slot per
+/// grantor (see `ready_state_transport_materializes_each_grantors_frozen_revoke`),
+/// and every restore seam binds interaction authority BEFORE recovery runs.
+/// Repairing `waiting_for` alone would leave each grantor holding an
+/// affordance for a prompt that no longer exists, which
+/// `debug_assert_interaction_consistency` treats as a defect.
+#[test]
+fn recovery_of_an_incoherent_latch_re_derives_the_ready_era_slots() {
+    let mut state = ready_two_seat_state();
+    // The run is present and epoch-matching — so the slots below really are the
+    // Ready set — but the frozen priority snapshot no longer describes the live
+    // game, which is what makes the latch unconsumable.
+    state.auto_pass.insert(
+        P1,
+        AutoPassMode::UntilStackEmpty {
+            initial_stack_len: 1,
+        },
+    );
+    bind_interaction_authority(
+        &mut state,
+        InteractionSessionId("resolve-all-restore".to_string()),
+    )
+    .expect("Ready binds one slot per frozen grantor");
+    let ready_era_slots = state.active_interaction_slots.clone();
+    assert!(
+        !ready_era_slots.is_empty(),
+        "non-vacuity: the fixture must actually carry Ready-era slots"
+    );
+
+    let batch =
+        recover_orphaned_resolve_all(&mut state).expect("a latch is present, so recovery acts");
+
+    assert_eq!(
+        batch.items_resolved, 0,
+        "an incoherent run resolves nothing"
+    );
+    assert_eq!(state.stack.len(), 1, "the stack entry survives the repair");
+    assert!(
+        matches!(state.waiting_for, WaitingFor::Priority { .. }),
+        "recovery must restore ordinary priority, got {:?}",
+        state.waiting_for
+    );
+    assert_ne!(
+        state.active_interaction_slots, ready_era_slots,
+        "the Ready-era Revoke slots must not outlive the prompt they belong to"
+    );
+}
+/// A stack the prefix proof cannot finish, granted and ready. `CopySpell` grows
+/// the stack when it resolves, which is exactly what stops the proof — see
+/// `ready_consent_collapses_the_safe_prefix_before_a_stack_growing_resolution`.
+fn proof_stopping_ready_state() -> GameState {
+    let entry = |id, effect| StackEntry {
+        id: ObjectId(id),
+        source_id: ObjectId(id),
+        controller: P0,
+        kind: StackEntryKind::ActivatedAbility {
+            source_id: ObjectId(id),
+            ability: Box::new(ResolvedAbility::new(effect, vec![], ObjectId(id), P0)),
+        },
+    };
+    let mut state = GameState::new_two_player(48);
+    state.waiting_for = WaitingFor::Priority { player: P0 };
+    state.priority_player = P0;
+    state.stack = vec![
+        entry(
+            1,
+            Effect::CopySpell {
+                target: TargetFilter::SelfRef,
+                retarget: CopyRetargetPermission::KeepOriginalTargets,
+                copier: None,
+                additional_modifications: vec![],
+                starting_loyalty_from_casualty_sacrifice: false,
+            },
+        ),
+        entry(2, Effect::NoOp),
+        entry(3, Effect::NoOp),
+    ]
+    .into_iter()
+    .collect();
+    let epoch = begin(&mut state);
+    apply(
+        &mut state,
+        P1,
+        GameAction::RespondResolveAllConsent {
+            epoch,
+            decision: ResolveAllConsentDecision::Grant,
+        },
+    )
+    .expect("second representative grants");
+    state
+}
+
+/// The two continuations must actually differ, and only on the remainder.
+///
+/// A live session installs `UntilStackEmpty` so the requester's standing intent
+/// survives a proof that stopped short. A restore must not: that auto-pass
+/// resolves the rest of the stack through the ordinary pipeline, which can end
+/// the game — and a restore has no socket attached and no caller positioned to
+/// emit a ranked result or a terminal artifact, so the game would be registered
+/// live while parked in `GameOver`.
+#[test]
+fn the_restore_continuation_installs_no_auto_pass_where_the_live_one_does() {
+    let mut live = proof_stopping_ready_state();
+    let live_batch =
+        resolve_all_ready_prefix_with(&mut live, P0, ResolveAllContinuation::AutoPassRemainder);
+    assert!(
+        !live.auto_pass.is_empty(),
+        "non-vacuity: this fixture must reach the proof-stopped fallback at all"
+    );
+
+    let mut restored = proof_stopping_ready_state();
+    let restored_batch =
+        resolve_all_ready_prefix_with(&mut restored, P0, ResolveAllContinuation::StopAtPriority);
+
+    assert!(
+        restored.auto_pass.is_empty(),
+        "a restore must hand priority back, not run the remainder unattended"
+    );
+    assert!(
+        matches!(restored.waiting_for, WaitingFor::Priority { .. }),
+        "the restore continuation still yields an actionable state, got {:?}",
+        restored.waiting_for
+    );
+    assert_eq!(
+        restored_batch.items_resolved, 2,
+        "the consented prefix is collapsed either way; only the remainder differs"
+    );
+    assert!(
+        live_batch.items_resolved >= restored_batch.items_resolved,
+        "the live continuation may resolve more, never less"
+    );
+    assert!(
+        restored.resolve_all_consent_run.is_none(),
+        "the consent is discarded on both paths"
+    );
+}
+/// Revocation is per-grantor at the ENGINE boundary, not merely in what the
+/// transport offers.
+///
+/// `transport_surfaces_only_each_grantors_own_revoke_and_uses_exact_consent_choices`
+/// pins the surface — which actions a viewer is handed. It does not pin what
+/// `apply` accepts, and those are different contracts: a forged or replayed
+/// wire frame never passes through the transport's action list. The engine's
+/// authorization for this action is a per-TARGET check
+/// (`resolve_all_granted_submitter(state, epoch, representative) ==
+/// Some(actor)`), which no set-membership test over authorized submitters can
+/// express — a set says "you may act here", never "you may act on THIS
+/// representative's consent".
+#[test]
+fn a_grantor_may_revoke_only_its_own_consent_at_the_engine_boundary() {
+    let mut state = ready_two_seat_state();
+    let WaitingFor::ResolveAllReady { epoch } = state.waiting_for else {
+        panic!("fixture must be latched, got {:?}", state.waiting_for);
+    };
+
+    // Positive control first, so the negative below cannot pass because the
+    // action is simply unroutable at Ready: P1's own revoke is accepted.
+    let mut own = state.clone();
+    apply(
+        &mut own,
+        P1,
+        GameAction::RevokeResolveAllConsent {
+            epoch,
+            representative: P1,
+        },
+    )
+    .expect("a grantor may withdraw its own consent while the latch stands");
+
+    // The contract: P1 may not withdraw P0's consent, even though P1 is itself
+    // a frozen submitter of this very run.
+    assert!(
+        apply(
+            &mut state,
+            P1,
+            GameAction::RevokeResolveAllConsent {
+                epoch,
+                representative: P0,
+            },
+        )
+        .is_err(),
+        "one grantor must not be able to revoke another's consent"
     );
 }

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -1251,8 +1251,10 @@ pub fn fallback_action(
                 }
             )
         }),
-        // Ready has no acting player; the authorized frontend consumer starts
-        // the bounded prefix drain.
+        // Ready has no acting player, so no AI decision exists here. The
+        // authorized consumer starts the bounded prefix drain: the granting
+        // client on a local table, and `server-core`'s own `run_ai` hand-off
+        // when the final Grant came from a server-driven AI seat.
         WaitingFor::ResolveAllReady { .. } => None,
 
         // Priority is the only state where PassPriority is valid.

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -57,6 +57,7 @@ use server_core::game_action_payload_guard::guard_game_action_payload;
 use server_core::game_reconnect_guard::guard_game_reconnect;
 use server_core::game_state_snapshot_wire_guard::{
     guard_game_state_for_broadcast, guard_state_snapshot_broadcast, StateSnapshotParts,
+    MAX_RESOLVE_ALL_LOG_ENTRIES,
 };
 use server_core::interaction_payload_guard::guard_interaction_submission_payload;
 use server_core::legacy_deck_guard::guard_legacy_deck;
@@ -495,16 +496,11 @@ fn build_state_update_message(
     })
 }
 
-/// Resolve All can collect thousands of engine events. They are needed for
-/// authoritative transition bookkeeping, but replaying them in one wire frame
-/// defeats the batch path and breaches the snapshot payload guard. Preserve a
-/// bounded tail of engine-authored logs alongside the final, fully-derived
-/// state; the requester acknowledgement carries progress metadata separately.
-const MAX_RESOLVE_ALL_LOG_ENTRIES: usize = 128;
-
 /// Resolving the batch and then resuming normal AI play are one authoritative
 /// transition. Retain their engine-authored logs in that order while keeping
-/// the compact final snapshot bounded.
+/// the compact final snapshot bounded by
+/// [`MAX_RESOLVE_ALL_LOG_ENTRIES`], which `server-core` also applies to a batch
+/// its own AI hand-off collapses.
 fn resolve_all_log_tail(
     batch_log_entries: &[GameLogEntry],
     ai_results: &[RevisionedActionResult],

--- a/crates/server-core/src/game_state_snapshot_wire_guard.rs
+++ b/crates/server-core/src/game_state_snapshot_wire_guard.rs
@@ -29,6 +29,24 @@ pub const MAX_SNAPSHOT_SPELL_COSTS: usize = 1_000;
 /// Max total legal actions across all per-object buckets in one update.
 pub const MAX_SNAPSHOT_LEGAL_ACTIONS_BY_OBJECT_TOTAL: usize = MAX_ACTION_LIST_LEN;
 
+/// Max engine-authored log lines a collapsed Resolve All batch may attach to a
+/// single wire frame. Well under [`MAX_SNAPSHOT_LOG_ENTRIES`] because the guard
+/// rejects an over-budget frame outright rather than truncating it: a dropped
+/// frame would strand every client on the pre-batch state.
+pub const MAX_RESOLVE_ALL_LOG_ENTRIES: usize = 128;
+
+/// The bounded tail of one collapsed Resolve All batch's engine-authored logs.
+///
+/// A pathological stack produces thousands of entries. Applying the bound at
+/// the producer — rather than trusting the frame to fit — is what keeps the
+/// batch's final, fully-derived state deliverable.
+pub fn bounded_resolve_all_log_tail(mut entries: Vec<GameLogEntry>) -> Vec<GameLogEntry> {
+    if entries.len() > MAX_RESOLVE_ALL_LOG_ENTRIES {
+        entries.drain(..entries.len() - MAX_RESOLVE_ALL_LOG_ENTRIES);
+    }
+    entries
+}
+
 /// Borrowed snapshot components from an [`crate::session::ActionResult`]-shaped tuple.
 pub struct StateSnapshotParts<'a> {
     pub state: &'a GameState,
@@ -237,5 +255,30 @@ mod tests {
         }
         let err = guard_game_state_for_broadcast(&state).unwrap_err();
         assert!(err.contains("state.objects"));
+    }
+    /// The producer-side bound has to leave the frame *under* the guard, since
+    /// the guard rejects rather than truncates. Keeping the tail (not the head)
+    /// is what preserves the batch's most recent, user-visible outcome.
+    #[test]
+    fn resolve_all_log_tail_keeps_the_last_bounded_window() {
+        let entries: Vec<_> = (0..(MAX_RESOLVE_ALL_LOG_ENTRIES as u32 + 7))
+            .map(sample_log_entry)
+            .collect();
+        let last_seq = entries.last().expect("non-empty fixture").seq;
+
+        let tail = bounded_resolve_all_log_tail(entries);
+
+        assert_eq!(tail.len(), MAX_RESOLVE_ALL_LOG_ENTRIES);
+        assert_eq!(
+            tail.last().expect("bounded tail is non-empty").seq,
+            last_seq
+        );
+        assert!(tail.len() <= MAX_SNAPSHOT_LOG_ENTRIES);
+    }
+
+    #[test]
+    fn resolve_all_log_tail_leaves_a_short_batch_whole() {
+        let entries: Vec<_> = (0..3).map(sample_log_entry).collect();
+        assert_eq!(bounded_resolve_all_log_tail(entries.clone()), entries);
     }
 }

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -7,7 +7,8 @@ use engine::database::legality::{validate_cedh_bracket, CedhBracketError};
 use engine::database::CardDatabase;
 use engine::game::deck_loading::{DeckPayload, PlayerDeckPayload};
 use engine::game::engine::{
-    apply, resolve_all_ready_is_authorized, resolve_all_ready_prefix, start_game,
+    apply, pending_resolve_all_ready_requester, recover_orphaned_resolve_all,
+    resolve_all_ready_access, resolve_all_ready_prefix, start_game, ResolveAllReadyAccess,
 };
 use engine::game::interaction::{bind_interaction_authority, submit_interaction};
 use engine::game::layers::flush_layers;
@@ -23,7 +24,7 @@ use engine::game::{
 use engine::types::actions::{DebugAction, GameAction};
 use engine::types::events::GameEvent;
 use engine::types::format::FormatConfig;
-use engine::types::game_state::{GameState, PersistedGameState};
+use engine::types::game_state::{GameState, PersistedGameState, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::interaction::{InteractionSessionId, InteractionSubmission};
 use engine::types::log::GameLogEntry;
@@ -39,6 +40,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
 use crate::filter::filter_state_for_player;
+use crate::game_state_snapshot_wire_guard::bounded_resolve_all_log_tail;
 use crate::persist::{PersistedLobbyMeta, PersistedSession};
 use crate::protocol::PlayerSlotInfo;
 use crate::reconnect::ReconnectManager;
@@ -100,6 +102,12 @@ pub type RevisionedActionResult = (u64, ActionResult);
 /// The wire request is untrusted, but `0` remains the engine-defined uncapped
 /// sentinel; the active consent run, not this transport value, owns the cap.
 pub const MAX_RESOLVE_ALL_RESOLUTIONS: u32 = 5_000;
+
+/// Backstop on `run_ai`'s AI-play → collapse-latch → AI-play hand-off loop.
+/// `BeginResolveAll` is not an AI candidate action, so AI play alone cannot
+/// mint a second consent epoch and the loop terminates on its own; this only
+/// bounds the damage if that ever stops being true.
+const MAX_AI_RESOLVE_ALL_HANDOFFS: usize = 8;
 
 #[derive(Debug, Clone)]
 pub struct ResolveAllSummary {
@@ -264,9 +272,13 @@ pub struct GameSession {
     /// 1. `seed_debug_capability`, reachable only via `rebuild_pregame_state`,
     ///    which is called only from `start_game` and from `apply_seat_delta`.
     /// 2. `takeback::record_turn_rewind_point`, via
-    ///    [`GameSession::observe_transition`] — reached only from the four
+    ///    [`GameSession::observe_transition`] — reached only from the
     ///    authoritative transition handlers, all of which require a started
-    ///    game.
+    ///    game. Deliberately not a count: the tally here has been wrong before,
+    ///    and the property that matters is "every caller is post-start", which
+    ///    no number states. `recover_orphaned_resolve_all` is NOT one of them —
+    ///    it runs inside `from_persisted`, the placeholder window this fence
+    ///    warns about, and never calls `observe_transition`.
     /// 3. `takeback::offers_turn_rewind`, via `GameSession::rewind_options`
     ///    and `GameSession::request_takeback` — likewise post-start.
     ///
@@ -814,7 +826,11 @@ impl GameSession {
 
     /// Run AI actions and return per-action broadcast data.
     ///
-    /// Each entry contains: raw state snapshot, events, legal actions, and log entries.
+    /// Most entries are one AI action: raw state snapshot, events, legal actions,
+    /// and log entries. An entry may instead be a Resolve All collapse frame,
+    /// which carries no events and a bounded log tail — see
+    /// [`Self::consume_ai_granted_resolve_all`] for why the wire form differs
+    /// from what the session observes.
     /// The caller is responsible for filtering the state per-player before sending.
     /// Returns an empty vec if the session has no AI seats.
     ///
@@ -830,6 +846,76 @@ impl GameSession {
             return vec![];
         }
 
+        let mut transitions = Vec::new();
+        let mut handoffs = 0usize;
+        // One pass per Resolve All latch our own AI seats complete. Collapsing
+        // that batch hands priority back — possibly to another AI seat — so the
+        // ordinary hand-off has to run again, exactly as `handle_resolve_all`
+        // re-runs it after a client-requested batch. `BeginResolveAll` is not an
+        // AI candidate action, so only a human action can mint a further epoch
+        // and the loop cannot be re-entered by AI play alone; the iteration cap
+        // is a backstop, not the terminating argument.
+        for _ in 0..MAX_AI_RESOLVE_ALL_HANDOFFS {
+            let batch = self.run_ai_action_batch();
+            if batch.is_empty() {
+                break;
+            }
+            // POSITIVE evidence that the final Grant was ours: one of the
+            // actions we just applied left the game at Ready. Each entry's
+            // state is the post-action clone, so a latch minted by this batch
+            // is visible in the batch itself.
+            //
+            // This deliberately replaces the earlier proxy, "we acted at all".
+            // That proxy was correct only because no AI seat can act while a
+            // latch is standing, which in turn held only because
+            // `WaitingFor::acting_players()` is empty for `ResolveAllReady` —
+            // an invariant this module neither owns nor can enforce, and one
+            // there is active interest in changing.
+            //
+            // The residual assumption, stated rather than claimed away: a
+            // post-state of Ready means WE minted it only while no action can
+            // be applied AT Ready and leave the state AT Ready. That holds
+            // today because the sole reducer arm accepting an action at Ready
+            // is `RevokeResolveAllConsent`, which always restores the frozen
+            // priority snapshot and therefore always exits Ready. This is a
+            // strictly weaker dependency than the old one — it is a local,
+            // reducer-visible fact rather than a property of a foreign type —
+            // but it is not none. A Ready-preserving action (a confirm, a
+            // no-op, a preference action admitted here) would let an AI acting
+            // at a HUMAN's standing latch set this flag. If one is ever added,
+            // compare each entry against its predecessor instead: entry `i`
+            // minted the latch iff its post-state is Ready and the state before
+            // it was not Ready at that epoch.
+            let minted_here = batch.iter().any(|(_, (post_state, ..))| {
+                matches!(post_state.waiting_for, WaitingFor::ResolveAllReady { .. })
+            });
+            transitions.extend(batch);
+            if !minted_here {
+                break;
+            }
+            match self.consume_ai_granted_resolve_all() {
+                Some(collapsed) => transitions.push(collapsed),
+                None => break,
+            }
+            handoffs += 1;
+        }
+        // Reaching the cap means the terminating argument above is wrong: AI
+        // play alone minted more epochs than it can. `run_ai` returns with
+        // seats that may still be able to act and nothing left to re-drive
+        // them, which is the hang class this hand-off exists to prevent, so it
+        // must be diagnosable rather than silent.
+        if handoffs == MAX_AI_RESOLVE_ALL_HANDOFFS {
+            warn!(
+                game = %self.game_code,
+                cap = MAX_AI_RESOLVE_ALL_HANDOFFS,
+                "AI Resolve All hand-off hit its iteration cap"
+            );
+        }
+        transitions
+    }
+
+    /// One uninterrupted run of AI decisions from the current state.
+    fn run_ai_action_batch(&mut self) -> Vec<RevisionedActionResult> {
         let mut rng = rand::rng();
         let ai_session = self
             .ai_session
@@ -872,6 +958,90 @@ impl GameSession {
                 )
             })
             .collect()
+    }
+
+    /// Consumes a `WaitingFor::ResolveAllReady` latch this session's own AI
+    /// seats just completed.
+    ///
+    /// `ResolveAllReady` has no acting player (`WaitingFor::acting_player` is
+    /// `None`), so `run_ai_actions` stops the moment the last AI representative
+    /// grants, no seat is offered a legal action, and no client is prompted to
+    /// send `ClientMessage::ResolveAll`. Whoever submits the final Grant owes
+    /// the consumption: a human's client does it from its consent modal, and
+    /// the browser's local AI controller does it for a browser-driven seat.
+    /// A server-driven AI seat had no such owner, which parked solo-vs-AI
+    /// tables forever with an unresolvable stack.
+    ///
+    /// TWO gates, and only one of them is here. The caller requires positive
+    /// evidence that one of the AI actions it just applied minted the latch —
+    /// see [`Self::run_ai`]. This function adds only the presence of the latch
+    /// at the moment it runs.
+    ///
+    /// Ownership is what both gates are about. A latch belongs to whoever cast
+    /// its final Grant, because that submitter's own client is the thing that
+    /// will send `ResolveAll` for it. Consuming a human's latch here races that
+    /// client and returns their request as an error; declining our own strands
+    /// the game, since nothing renders `ResolveAllReady`.
+    ///
+    /// Worth recording what this gate is deliberately NOT built on.
+    /// `candidate_actions` does offer every grantor a
+    /// `RevokeResolveAllConsent` at Ready, so the candidate set is not empty;
+    /// the AI simply never sees it, because `run_ai_actions_bounded` selects
+    /// its actor from `WaitingFor::acting_players()`, which is empty for this
+    /// variant. That is a true fact about today's engine and a bad thing to
+    /// depend on — it belongs to a type this module does not own, and giving
+    /// `ResolveAllReady` an acting set is an actively discussed change. The
+    /// caller therefore reads its own batch rather than inferring ownership
+    /// from the driver's silence.
+    ///
+    /// It deliberately does NOT gate on the run still being coherent. That was
+    /// the shape of the original defect: `ready_consent_run` requires an empty
+    /// `auto_pass` and an exact priority-snapshot match, so any seat holding an
+    /// End Turn auto-pass makes every latch that turn incoherent — and an
+    /// incoherent latch is precisely the one with no other exit, since no
+    /// client renders anything at `ResolveAllReady`. Declining it here would
+    /// leave the hang this seam exists to close.
+    ///
+    /// Admit-and-repair instead, matching every other consumer
+    /// ([`Self::resolve_all_for_player`], wasm `resolve_all`, and
+    /// [`recover_orphaned_resolve_all`]): the resolver collapses a coherent
+    /// run and repairs an incoherent one back to ordinary priority.
+    fn consume_ai_granted_resolve_all(&mut self) -> Option<RevisionedActionResult> {
+        if !matches!(self.state.waiting_for, WaitingFor::ResolveAllReady { .. }) {
+            return None;
+        }
+        // Prefer the frozen run's own requester — `ResolveAllConsentRun` exists
+        // so a live turn-control change cannot rebind an already-issued
+        // authorization. When no requester can succeed, ANY seat reaches the
+        // repair branch by construction, which is the only exit left.
+        let requester =
+            pending_resolve_all_ready_requester(&self.state).unwrap_or(self.state.priority_player);
+        let batch = resolve_all_ready_prefix(&mut self.state, requester);
+        let (legal, spell_costs, by_object) = engine_legal_actions_full(&self.state);
+        let auto_pass = auto_pass_recommended(&self.state, &legal);
+        let revision = self.advance_state_revision();
+        let post_state = self.state.clone();
+        // Bookkeeping sees the batch whole; the wire frame does not. A collapse
+        // can author thousands of events and log lines, and
+        // `guard_state_snapshot_broadcast` rejects an over-budget frame instead
+        // of trimming it — shipping them unbounded would drop the very update
+        // that carries the post-batch state. Events go entirely: the Resolve All
+        // UI does not animate a batch on any transport (see
+        // `ResolveAllFastForwardResult`, and `handle_resolve_all`'s equivalent
+        // handling of a client-requested batch).
+        self.observe_transition(&batch.events, &post_state);
+        Some((
+            revision,
+            (
+                post_state,
+                Vec::new(),
+                legal,
+                bounded_resolve_all_log_tail(batch.log_entries),
+                auto_pass,
+                spell_costs,
+                by_object,
+            ),
+        ))
     }
 
     /// Recomputes the broadcast-ready fields (legal actions, auto-pass,
@@ -985,7 +1155,7 @@ impl GameSession {
 
         let rewind_game_number = state.game_number;
 
-        Ok(GameSession {
+        let mut session = GameSession {
             game_code: ps.game_code,
             full_runtime: None,
             state_revision: ps.state_revision,
@@ -1016,7 +1186,35 @@ impl GameSession {
             takeback_history: VecDeque::new(),
             turn_rewind_history: VecDeque::new(),
             rewind_game_number,
-        })
+        };
+        session.recover_orphaned_resolve_all();
+        Ok(session)
+    }
+
+    /// Discharges a `WaitingFor::ResolveAllReady` latch whose consumer did not
+    /// survive the process.
+    ///
+    /// The latch is consumed by whoever submitted its final Grant — a client
+    /// from its consent modal, or this session's own AI hand-off. Neither
+    /// outlives a restart, and the state itself offers no way out: it has no
+    /// acting player, every seat's legal-action set is empty, and no client
+    /// will volunteer `ClientMessage::ResolveAll` for a batch it never started.
+    /// A session restored into that state would be permanently unadvanceable.
+    ///
+    /// Running engine work at load time is deliberate and bounded: the consent
+    /// was already unanimous and its cap was frozen at `BeginResolveAll`, so
+    /// this discharges an authorization the players already gave rather than
+    /// making a new decision. Nothing can race it — no socket is attached yet.
+    fn recover_orphaned_resolve_all(&mut self) {
+        let Some(batch) = recover_orphaned_resolve_all(&mut self.state) else {
+            return;
+        };
+        warn!(
+            game = %self.game_code,
+            items_resolved = batch.items_resolved,
+            "discharged an orphaned Resolve All latch on session restore"
+        );
+        self.advance_state_revision();
     }
 }
 
@@ -1603,8 +1801,18 @@ impl SessionManager {
             );
         }
 
-        if !resolve_all_ready_is_authorized(&session.state, requester) {
-            return Err("Resolve All consent is not ready".to_string());
+        // Reject only an unentitled caller. A latch whose frozen run has gone
+        // stale is still routed into the resolver, whose fail-closed
+        // invalidation restores ordinary priority — rejecting it here instead
+        // would leave the game parked with no acting player and, in practice,
+        // nothing any client offers the player to press.
+        // Exhaustive rather than an equality test: a future variant must be
+        // classified here instead of silently defaulting to allowed.
+        match resolve_all_ready_access(&session.state, requester) {
+            ResolveAllReadyAccess::Refused => {
+                return Err("Resolve All consent is not ready".to_string());
+            }
+            ResolveAllReadyAccess::Admitted => {}
         }
 
         session.state.log_player_names = session.display_names.clone();
@@ -1953,11 +2161,14 @@ mod tests {
     use engine::game::interaction::derive_viewer_interaction;
     use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
     use engine::game::scenario_db::GameScenarioDbExt;
-    use engine::types::ability::TargetRef;
-    use engine::types::actions::PrecastCopyShortcutResponse;
+    use engine::types::ability::{Effect, ResolvedAbility, TargetRef};
+    use engine::types::actions::{PrecastCopyShortcutResponse, ResolveAllConsentDecision};
     use engine::types::card::CardFace;
     use engine::types::card_type::CardType;
-    use engine::types::game_state::{CastPaymentMode, PersistedGameState, WaitingFor};
+    use engine::types::game_state::{
+        AutoPassMode, CastPaymentMode, PersistedGameState, StackEntry, StackEntryKind,
+        TurnBoundary, WaitingFor,
+    };
     use engine::types::interaction::{
         InteractionAvailability, InteractionChoiceId, InteractionReasonCode, InteractionResponse,
         MAX_INTERACTION_LIST_LEN,
@@ -6116,5 +6327,462 @@ mod tests {
         mgr.sessions.get_mut(&code).unwrap().pending_takeback = None;
         mgr.handle_interaction(&code, acting_token, witness)
             .expect("with no pending takeback the same submission applies");
+    }
+
+    /// Parks a one-entry stack in front of a human seat that has already been
+    /// passed to, with the AI seat's pass for this cycle already recorded, so
+    /// the human's Resolve All has exactly one representative left to ask.
+    fn ai_table_awaiting_one_consent() -> (SessionManager, String, PlayerId) {
+        let mut mgr = SessionManager::new();
+        let (game_code, _token) = mgr.create_game(make_deck());
+        let ai_player = PlayerId(1);
+        let session = mgr
+            .sessions
+            .get_mut(&game_code)
+            .expect("a new game retains its session");
+        session.ai_seats.insert(ai_player);
+        session.ai_configs.insert(
+            ai_player,
+            phase_ai::config::create_config_for_players(AiDifficulty::Easy, Platform::Native, 2),
+        );
+        let stack_object = ObjectId(1);
+        session.state.active_player = ai_player;
+        session.state.priority_player = PlayerId(0);
+        session.state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+        session.state.priority_passes.insert(ai_player);
+        session.state.stack.push_back(StackEntry {
+            id: stack_object,
+            source_id: stack_object,
+            controller: PlayerId(0),
+            kind: StackEntryKind::ActivatedAbility {
+                source_id: stack_object,
+                ability: Box::new(ResolvedAbility::new(
+                    Effect::NoOp,
+                    Vec::new(),
+                    stack_object,
+                    PlayerId(0),
+                )),
+            },
+        });
+        (mgr, game_code, ai_player)
+    }
+
+    /// An AI-granted latch whose run is INCOHERENT is the one with no exit at
+    /// all, so it is the one the hand-off must not decline.
+    ///
+    /// `ready_consent_run` requires `auto_pass.is_empty()`, so a single seat
+    /// holding an End Turn auto-pass makes every latch minted that turn
+    /// incoherent. The hand-off previously read its requester through
+    /// `pending_resolve_all_ready_requester`, whose `?` propagates exactly that
+    /// coherence test — so it returned `None` here and left the latch standing:
+    /// no acting player, and no client that renders `ResolveAllReady`. This is
+    /// the reported hang, reachable from the ordinary End Turn button.
+    #[test]
+    fn run_ai_repairs_its_own_grant_when_the_frozen_run_is_incoherent() {
+        let (mut mgr, game_code, _ai_player) = ai_table_awaiting_one_consent();
+        let session = mgr
+            .sessions
+            .get_mut(&game_code)
+            .expect("the game retains its session");
+
+        apply(
+            &mut session.state,
+            PlayerId(0),
+            GameAction::BeginResolveAll { max_resolutions: 1 },
+        )
+        .expect("the priority holder may start Resolve All consent");
+        // Freeze the run first, THEN make the live game disagree with the
+        // snapshot it froze. `BeginResolveAll` has no auto-pass precondition,
+        // and `apply` exempts consent actions from clearing the actor's entry,
+        // so this is the ordinary End Turn shape and not a contrived state.
+        session.state.auto_pass.insert(
+            PlayerId(0),
+            AutoPassMode::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            },
+        );
+        assert!(
+            matches!(
+                session.state.waiting_for,
+                WaitingFor::ResolveAllConsent { .. }
+            ),
+            "the AI representative must still owe a consent response, got {:?}",
+            session.state.waiting_for
+        );
+
+        let transitions = session.run_ai();
+
+        // Non-vacuity, and the control this test genuinely needs: every
+        // assertion below is equally true of an AI that DECLINED and never
+        // minted a latch at all. This pins that a Ready latch was actually
+        // reached, by reading the grant's own broadcast frame.
+        assert!(
+            transitions
+                .iter()
+                .any(|(_, (broadcast_state, ..))| matches!(
+                    broadcast_state.waiting_for,
+                    WaitingFor::ResolveAllReady { .. }
+                )),
+            "no broadcast frame shows the AI's grant reaching a Ready latch"
+        );
+        assert!(
+            !matches!(
+                session.state.waiting_for,
+                WaitingFor::ResolveAllReady { .. }
+            ),
+            "an incoherent AI-granted latch must not survive its own hand-off, got {:?}",
+            session.state.waiting_for
+        );
+        assert!(
+            session.state.resolve_all_consent_run.is_none(),
+            "the repair discards the run it could not honor"
+        );
+    }
+
+    /// The regression this whole seam exists for: when the LAST Resolve All
+    /// consent comes from a server-driven AI seat, nothing else will ever
+    /// consume the resulting latch.
+    ///
+    /// `WaitingFor::ResolveAllReady` has no acting player, so `run_ai_actions`
+    /// stops there, every seat's legal-action set is empty, and no client is
+    /// prompted to send `ClientMessage::ResolveAll`. Before `run_ai` consumed
+    /// its own AI seats' grant, a solo-vs-AI table parked here permanently with
+    /// an unresolvable stack.
+    #[test]
+    fn run_ai_consumes_the_ready_latch_its_own_grant_produced() {
+        let (mut mgr, game_code, _ai_player) = ai_table_awaiting_one_consent();
+        let session = mgr
+            .sessions
+            .get_mut(&game_code)
+            .expect("the game retains its session");
+
+        apply(
+            &mut session.state,
+            PlayerId(0),
+            GameAction::BeginResolveAll { max_resolutions: 1 },
+        )
+        .expect("the priority holder may start Resolve All consent");
+        assert!(
+            matches!(
+                session.state.waiting_for,
+                WaitingFor::ResolveAllConsent { .. }
+            ),
+            "the AI representative must still owe a consent response, got {:?}",
+            session.state.waiting_for
+        );
+
+        let transitions = session.run_ai();
+
+        assert!(
+            !matches!(
+                session.state.waiting_for,
+                WaitingFor::ResolveAllReady { .. }
+            ),
+            "an AI-granted Ready latch must not survive its own hand-off"
+        );
+        assert!(
+            session.state.stack.is_empty(),
+            "the consented entry must have resolved, stack: {:?}",
+            session.state.stack
+        );
+        assert!(
+            session.state.resolve_all_consent_run.is_none(),
+            "one run authorizes one batch and must not outlive it"
+        );
+        // The collapse has to reach the wire as its own transition, or the
+        // client would render a state the server has already moved past.
+        // Anchored on the FIRST transition still carrying the stack: the loop's
+        // follow-up AI batch can append further transitions, so asserting only
+        // on the last one would pass without the collapse frame ever existing.
+        assert!(
+            transitions.len() >= 2,
+            "expected the AI grant and the collapsed batch, got {}",
+            transitions.len()
+        );
+        let (_, (granted_state, ..)) = transitions.first().expect("the AI grant transition");
+        assert_eq!(
+            granted_state.stack.len(),
+            1,
+            "the Grant itself resolves nothing; the collapse must be a later frame"
+        );
+        assert!(
+            transitions
+                .iter()
+                .any(|(_, (broadcast_state, ..))| broadcast_state.stack.is_empty()),
+            "no broadcast frame carried the post-collapse state"
+        );
+    }
+
+    /// A human submitting the final consent keeps owning the consumption: their
+    /// own client sends `ResolveAll`. `run_ai` must not race ahead of it, or
+    /// that client's request would come back as an error.
+    ///
+    /// The fixture drives all the way to a Ready latch the human produced, so
+    /// the assertion is about the "we acted in this call" gate and not about
+    /// the latch simply being absent — removing the gate turns this red.
+    #[test]
+    fn run_ai_leaves_a_human_granted_ready_latch_for_its_own_client() {
+        let (mut mgr, game_code, ai_player) = ai_table_awaiting_one_consent();
+        let session = mgr
+            .sessions
+            .get_mut(&game_code)
+            .expect("the game retains its session");
+        // Flip the roles: the AI opens the run (auto-granting itself) so the
+        // remaining representative is the human.
+        session.state.priority_player = ai_player;
+        session.state.waiting_for = WaitingFor::Priority { player: ai_player };
+        session.state.priority_passes.clear();
+        session.state.priority_passes.insert(PlayerId(0));
+
+        apply(
+            &mut session.state,
+            ai_player,
+            GameAction::BeginResolveAll { max_resolutions: 1 },
+        )
+        .expect("the priority holder may start Resolve All consent");
+        let WaitingFor::ResolveAllConsent {
+            epoch,
+            representative,
+        } = session.state.waiting_for
+        else {
+            panic!(
+                "expected a pending consent prompt, got {:?}",
+                session.state.waiting_for
+            );
+        };
+        assert_eq!(
+            representative,
+            PlayerId(0),
+            "the human must be the outstanding representative"
+        );
+
+        apply(
+            &mut session.state,
+            PlayerId(0),
+            GameAction::RespondResolveAllConsent {
+                epoch,
+                decision: ResolveAllConsentDecision::Grant,
+            },
+        )
+        .expect("the human representative may grant");
+        assert!(
+            matches!(
+                session.state.waiting_for,
+                WaitingFor::ResolveAllReady { .. }
+            ),
+            "the fixture must reach the latch, or the gate is untested"
+        );
+        // Non-vacuity, and a trap worth pinning: the latch really is
+        // consumable, so nothing about coherence is holding `run_ai` back.
+        // Note WHO it names — `pending_resolve_all_ready_requester` returns the
+        // run's INITIATOR (`participants[0]`, the seat that called
+        // `BeginResolveAll` — the AI here), NOT the seat whose Grant completed
+        // it (the human). Ownership of a latch follows the FINAL Grant, so this
+        // value can never be the gate: it says "an AI started this run", which
+        // is true in exactly the case `run_ai` must keep its hands off.
+        assert_eq!(
+            pending_resolve_all_ready_requester(&session.state),
+            Some(ai_player),
+            "the requester is the run's initiator, not its final grantor"
+        );
+
+        // SCOPE OF THIS TEST, measured rather than assumed. It pins the
+        // behavioural contract "run_ai never touches a latch that predates its
+        // own actions" — a gate keyed on latch-presence-at-entry instead of on
+        // batch contents turns all three assertions below red.
+        //
+        // It does NOT discriminate `minted_here` from the older `!batch
+        // .is_empty()` proxy, and cannot: the latch already stands at entry, so
+        // `acting_players()` is empty, so the batch is empty, so the
+        // `batch.is_empty()` break at the top of the loop fires before either
+        // predicate is read. Both mutations stay green here. The distinguishing
+        // input — a non-empty batch alongside a pre-existing latch — is
+        // unreachable precisely while `ResolveAllReady` has no acting set,
+        // which is the invariant the refinement exists to stop depending on.
+        // It becomes testable when that changes; until then, do not add a pin
+        // that only appears to cover it.
+        assert!(
+            session.run_ai().is_empty(),
+            "no AI seat may act at a latch with no acting player"
+        );
+        assert!(
+            matches!(
+                session.state.waiting_for,
+                WaitingFor::ResolveAllReady { .. }
+            ),
+            "a human-granted latch belongs to that human's client, got {:?}",
+            session.state.waiting_for
+        );
+        assert_eq!(
+            session.state.stack.len(),
+            1,
+            "run_ai must not collapse a batch it did not authorize"
+        );
+    }
+
+    /// A Ready latch whose frozen run is gone can prove no owner, so refusing
+    /// every seat would leave the game with no exit at all. Any seat may ask
+    /// for the repair, and the repair resolves nothing.
+    #[test]
+    fn resolve_all_for_player_repairs_a_ready_latch_with_no_run() {
+        let (mut mgr, game_code, ai_player) = ai_table_awaiting_one_consent();
+        let session = mgr
+            .sessions
+            .get_mut(&game_code)
+            .expect("the game retains its session");
+        apply(
+            &mut session.state,
+            PlayerId(0),
+            GameAction::BeginResolveAll { max_resolutions: 1 },
+        )
+        .expect("the priority holder may start Resolve All consent");
+        let WaitingFor::ResolveAllConsent { epoch, .. } = session.state.waiting_for else {
+            panic!("expected a pending consent prompt");
+        };
+        apply(
+            &mut session.state,
+            ai_player,
+            GameAction::RespondResolveAllConsent {
+                epoch,
+                decision: ResolveAllConsentDecision::Grant,
+            },
+        )
+        .expect("the AI representative may grant");
+        assert!(matches!(
+            session.state.waiting_for,
+            WaitingFor::ResolveAllReady { .. }
+        ));
+
+        // Strand the latch exactly as a dropped run would.
+        session.state.resolve_all_consent_run = None;
+        let token = session
+            .player_tokens
+            .first()
+            .cloned()
+            .expect("the host holds a token");
+
+        let (_, summary) = mgr
+            .resolve_all_for_player(&game_code, &token, 1)
+            .expect("a stranded latch is repaired, not rejected");
+        assert_eq!(
+            summary.items_resolved, 0,
+            "the repair must not resolve a stack entry"
+        );
+        let session = mgr.sessions.get(&game_code).expect("session survives");
+        assert!(
+            matches!(session.state.waiting_for, WaitingFor::Priority { .. }),
+            "the repair must restore ordinary priority, got {:?}",
+            session.state.waiting_for
+        );
+        assert_eq!(
+            session.state.stack.len(),
+            1,
+            "no stack entry may resolve through a repair"
+        );
+    }
+    /// A latch outlives the process that owed its consumption. Restoring a
+    /// session into `ResolveAllReady` would otherwise hand the players back a
+    /// game with no acting player and no client willing to send `ResolveAll` for
+    /// a batch it never started.
+    #[test]
+    fn restoring_a_session_discharges_an_orphaned_resolve_all_latch() {
+        let (mut mgr, game_code, ai_player) = ai_table_awaiting_one_consent();
+        let session = mgr
+            .sessions
+            .get_mut(&game_code)
+            .expect("the game retains its session");
+        apply(
+            &mut session.state,
+            PlayerId(0),
+            GameAction::BeginResolveAll { max_resolutions: 1 },
+        )
+        .expect("the priority holder may start Resolve All consent");
+        let WaitingFor::ResolveAllConsent { epoch, .. } = session.state.waiting_for else {
+            panic!("expected a pending consent prompt");
+        };
+        apply(
+            &mut session.state,
+            ai_player,
+            GameAction::RespondResolveAllConsent {
+                epoch,
+                decision: ResolveAllConsentDecision::Grant,
+            },
+        )
+        .expect("the AI representative may grant");
+        assert!(matches!(
+            session.state.waiting_for,
+            WaitingFor::ResolveAllReady { .. }
+        ));
+        let revision_before = session.state_revision;
+        let persisted = session.to_persisted();
+
+        let restored = GameSession::from_persisted(persisted, &CardDatabase::default())
+            .expect("the snapshot restores");
+
+        assert!(
+            !matches!(
+                restored.state.waiting_for,
+                WaitingFor::ResolveAllReady { .. }
+            ),
+            "an orphaned latch must not survive restore, got {:?}",
+            restored.state.waiting_for
+        );
+        assert!(
+            restored.state.stack.is_empty(),
+            "the consented entry must have resolved on restore"
+        );
+        assert!(restored.state.resolve_all_consent_run.is_none());
+        assert!(
+            restored.state_revision > revision_before,
+            "clients must not see changed content under an unchanged revision"
+        );
+    }
+
+    /// The restore repair must also cover a latch whose run is gone, where
+    /// there is no prefix to collapse and the only correct outcome is a return
+    /// to ordinary priority with the stack untouched.
+    #[test]
+    fn restoring_a_session_repairs_a_latch_whose_run_is_gone() {
+        let (mut mgr, game_code, ai_player) = ai_table_awaiting_one_consent();
+        let session = mgr
+            .sessions
+            .get_mut(&game_code)
+            .expect("the game retains its session");
+        apply(
+            &mut session.state,
+            PlayerId(0),
+            GameAction::BeginResolveAll { max_resolutions: 1 },
+        )
+        .expect("the priority holder may start Resolve All consent");
+        let WaitingFor::ResolveAllConsent { epoch, .. } = session.state.waiting_for else {
+            panic!("expected a pending consent prompt");
+        };
+        apply(
+            &mut session.state,
+            ai_player,
+            GameAction::RespondResolveAllConsent {
+                epoch,
+                decision: ResolveAllConsentDecision::Grant,
+            },
+        )
+        .expect("the AI representative may grant");
+        session.state.resolve_all_consent_run = None;
+        let persisted = session.to_persisted();
+
+        let restored = GameSession::from_persisted(persisted, &CardDatabase::default())
+            .expect("the snapshot restores");
+
+        assert!(
+            matches!(restored.state.waiting_for, WaitingFor::Priority { .. }),
+            "a run-less latch must repair to ordinary priority, got {:?}",
+            restored.state.waiting_for
+        );
+        assert_eq!(
+            restored.state.stack.len(),
+            1,
+            "nothing may resolve without a run to authorize it"
+        );
     }
 }


### PR DESCRIPTION
A server-driven AI seat casting the final Resolve All consent Grant produced
WaitingFor::ResolveAllReady with no consumer, stranding the game: no acting
player, zero legal actions, and a suppressed stuck-decision diagnostic.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Resolve All recovery when interrupted, restored, or left without an active owner.
  * Prevented valid Resolve All requests from becoming stuck in waiting states.
  * Improved access handling for admitted and refused participants.
  * Restored sessions now resume Resolve All processing more reliably.

* **Improvements**
  * AI-controlled gameplay now handles Resolve All handoffs and continuation more consistently.
  * Large Resolve All activity logs are capped while preserving the most recent entries.
  * Added broader coverage for recovery, restoration, authorization, and AI scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->