### PR TITLE
ci: assert the root Cargo.lock is in sync

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,8 +57,14 @@ jobs:
       - name: Check formatting
         run: cargo fmt --all -- --check
 
+      # `--locked` costs nothing here (this step already resolves the whole
+      # workspace) and asserts the committed root Cargo.lock is in sync with the
+      # manifests. Without it, dropping a crate leaves dead entries in the lock,
+      # every later cargo invocation silently rewrites the file, and Nightly
+      # Release dies on `cargo release`'s dirty-tree check -- which is exactly
+      # what #7556 did. `--locked` is already used for the Tauri manifest below.
       - name: Clippy
-        run: cargo clippy --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings
+        run: cargo clippy --locked --workspace --exclude phase-tauri --all-targets --features engine/proptest -- -D warnings
 
       - name: Interaction bindings are current
         run: ./scripts/check-interaction-bindings.sh --check


### PR DESCRIPTION
`--locked` on the existing workspace clippy invocation costs no extra CI time --
that step already resolves the whole workspace -- and turns silent lockfile drift
into a fast, explicit failure.

Without it, removing a crate leaves its dependency subtree stranded in
Cargo.lock, every later cargo invocation rewrites the file in place, and CI stays
green because no root-workspace command passed `--locked`. Nightly Release is
where it surfaces, because `cargo release --execute` aborts on a dirty tree:

    error: uncommitted changes detected, please resolve before release:
             Cargo.lock (Status(WT_MODIFIED))

That is exactly how #7556 (remove mtgish importer) broke three consecutive
nightlies before #7588 resynced the lock. `--locked` was already used for the
Tauri manifest; this extends the same guarantee to the root workspace.

Verified both directions against origin/main in an isolated worktree: with the
pre-#7588 lockfile the guarded command exits 101 in under two seconds on
"cannot update the lock file ... because --locked was passed", before compiling
anything; with the current lockfile it clears resolution and proceeds to compile
normally.

Claude-Session: https://claude.ai/code/session_01DJgbxMGnPi6MFfGUe15Y3P


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated continuous integration checks to verify that the committed dependency lockfile remains synchronized with project configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->