### PR TITLE
fix(engine): door-gate a Room permanent's battlefield name (#7564)

### DIFF
--- a/crates/engine/src/game/augment.rs
+++ b/crates/engine/src/game/augment.rs
@@ -398,7 +398,7 @@ fn merged_copiable_values(
         // An augment merge is a Host+Augment creature, never a Room — augment
         // is an Un-set mechanic with no Comprehensive Rules entry to cite.
         room_halves: None,
-        name_exception: false,
+        name_origin: Default::default(),
     };
 
     Some((

--- a/crates/engine/src/game/augment.rs
+++ b/crates/engine/src/game/augment.rs
@@ -398,6 +398,7 @@ fn merged_copiable_values(
         // An augment merge is a Host+Augment creature, never a Room — augment
         // is an Un-set mechanic with no Comprehensive Rules entry to cite.
         room_halves: None,
+        name_exception: false,
     };
 
     Some((

--- a/crates/engine/src/game/augment.rs
+++ b/crates/engine/src/game/augment.rs
@@ -395,6 +395,8 @@ fn merged_copiable_values(
         trigger_definitions: Arc::new(triggers),
         replacement_definitions: Arc::new(replacements),
         static_definitions: Arc::new(statics),
+        // CR 702.140: an augment merge is a Host+Augment creature — no Room halves.
+        room_halves: None,
     };
 
     Some((

--- a/crates/engine/src/game/augment.rs
+++ b/crates/engine/src/game/augment.rs
@@ -395,7 +395,8 @@ fn merged_copiable_values(
         trigger_definitions: Arc::new(triggers),
         replacement_definitions: Arc::new(replacements),
         static_definitions: Arc::new(statics),
-        // CR 702.140: an augment merge is a Host+Augment creature — no Room halves.
+        // An augment merge is a Host+Augment creature, never a Room — augment
+        // is an Un-set mechanic with no Comprehensive Rules entry to cite.
         room_halves: None,
     };
 

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -5170,7 +5170,7 @@ mod tests {
             replacement_definitions: std::sync::Arc::default(),
             static_definitions: std::sync::Arc::default(),
             room_halves: None,
-            name_exception: false,
+            name_origin: Default::default(),
         })
     }
 

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -5170,6 +5170,7 @@ mod tests {
             replacement_definitions: std::sync::Arc::default(),
             static_definitions: std::sync::Arc::default(),
             room_halves: None,
+            name_exception: false,
         })
     }
 

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -5169,6 +5169,7 @@ mod tests {
             trigger_definitions: std::sync::Arc::default(),
             replacement_definitions: std::sync::Arc::default(),
             static_definitions: std::sync::Arc::default(),
+            room_halves: None,
         })
     }
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -794,20 +794,21 @@ fn handle_unlock_room_door(
                 "That door is already unlocked".to_string(),
             ));
         }
-        // CR 709.5e: the unlock cost is the locked HALF's mana cost. Doors are
-        // printed halves, not live/back slots — after the back half was cast
-        // (`modal_back_face`), the LIVE face is the right door and the left
-        // door's cost lives on `back_face`. `room::live_face_door` is the
-        // single orientation authority (same mapping as CR 709.5d entry).
-        if door == super::room::live_face_door(obj) {
-            obj.mana_cost.clone()
-        } else {
-            obj.back_face
+        // CR 709.5e + CR 707.2: the unlock cost is the locked HALF's mana cost,
+        // read from the EFFECTIVE halves (printed order) — the copied snapshot
+        // when a copy effect applies, else the object's own printed halves
+        // (whose orientation `room::own_room_halves` resolves through
+        // `live_face_door`, the same CR 709.5d mapping as before).
+        let halves = super::room::effective_room_halves(obj);
+        match door {
+            crate::game::game_object::RoomDoor::Left => halves.left.mana_cost.clone(),
+            crate::game::game_object::RoomDoor::Right => halves
+                .right
                 .as_ref()
-                .map(|face| face.mana_cost.clone())
+                .map(|half| half.mana_cost.clone())
                 .ok_or_else(|| {
                     EngineError::ActionNotAllowed("Room has no second door face".to_string())
-                })?
+                })?,
         }
     };
 
@@ -20141,7 +20142,7 @@ mod stage2_injector_tests {
                 //   repair a `ResolveAllReady` latch, which `acting_player()` reports as
                 //   having no actor at all. The PRODUCER half stays 5 and the partition
                 //   stays 5/8/28.
-                "game/engine.rs:13137".to_string(),
+                "game/engine.rs:13138".to_string(),
             ],
             "the five production producers, NAMED: the CR 603.5 gate in `resolve_chain_body` \
              plus the two repeated-optional-payment drivers, the per-player acceptance cursor \

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -10513,7 +10513,7 @@ mod tests {
             replacement_definitions: std::sync::Arc::default(),
             static_definitions: std::sync::Arc::default(),
             room_halves: None,
-            name_exception: false,
+            name_origin: Default::default(),
         })
     }
 

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -10512,6 +10512,7 @@ mod tests {
             trigger_definitions: std::sync::Arc::default(),
             replacement_definitions: std::sync::Arc::default(),
             static_definitions: std::sync::Arc::default(),
+            room_halves: None,
         })
     }
 

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -10513,6 +10513,7 @@ mod tests {
             replacement_definitions: std::sync::Arc::default(),
             static_definitions: std::sync::Arc::default(),
             room_halves: None,
+            name_exception: false,
         })
     }
 

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -2111,6 +2111,201 @@ fn a_room_cast_from_its_right_half_keeps_printed_name_order() {
     );
 }
 
+/// Build a battlefield Room with a stamped front-half marker static, entered
+/// UNCAST (both doors locked, CR 709.5d) so its own text contributes nothing.
+fn uncast_room_with_front_marker(
+    state: &mut GameState,
+    card: u64,
+    front: &str,
+    back: &str,
+) -> ObjectId {
+    let room = create_object(
+        state,
+        CardId(card),
+        PlayerId(0),
+        front.to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&room).unwrap();
+    obj.card_types.core_types.push(CoreType::Enchantment);
+    obj.card_types.subtypes.push("Room".to_string());
+    // The copiable snapshot reads BASE characteristics — mirror the types
+    // there so the source is a Room in its copiable form too.
+    obj.base_card_types = obj.card_types.clone();
+    let front_static = StaticDefinition::new(StaticMode::AdditionalLandDrop { count: 2 });
+    obj.static_definitions.push(front_static.clone());
+    Arc::make_mut(&mut obj.base_static_definitions).push(front_static);
+    obj.back_face = Some(room_back_face(back));
+    obj.reset_for_battlefield_entry(1, 1);
+    room
+}
+
+/// CR 707.2 + CR 709.5 + CR 613.1a: an ordinary permanent under a copy effect
+/// of a Room takes the Room's COPIABLE form — both halves, door-gated. It has
+/// no unlocked designations of its own (designations are status, CR 709.5c),
+/// so it sits fully locked: no name, no functioning half text. Unlocking a
+/// door turns exactly that half on; copy expiry reverts everything.
+#[test]
+fn an_ordinary_permanent_copying_a_room_gains_its_door_gated_form() {
+    let mut state = setup_game_at_main_phase();
+    let source = uncast_room_with_front_marker(&mut state, 907, "Moldering Gym", "Weight Room");
+    let bear = create_object(
+        &mut state,
+        CardId(908),
+        PlayerId(0),
+        "Plain Bear".to_string(),
+        Zone::Battlefield,
+    );
+    state
+        .objects
+        .get_mut(&bear)
+        .unwrap()
+        .card_types
+        .core_types
+        .push(CoreType::Creature);
+
+    let values = crate::game::printed_cards::intrinsic_copiable_values(&state.objects[&source]);
+    let effect_id = state.add_transient_continuous_effect(
+        bear,
+        PlayerId(0),
+        crate::types::ability::Duration::Permanent,
+        TargetFilter::SpecificObject { id: bear },
+        vec![crate::types::ability::ContinuousModification::CopyValues {
+            values: Box::new(values),
+            display_source: crate::game::game_object::DisplaySource::Card,
+            printed_ref: None,
+            token_image_ref: None,
+        }],
+        None,
+    );
+    crate::game::layers::evaluate_layers(&mut state);
+
+    assert_eq!(
+        state.objects[&bear].name, "",
+        "CR 709.5c + CR 709.5: the copy has no unlocked designations, so it has \
+         neither half's name"
+    );
+    assert_eq!(
+        crate::game::static_abilities::additional_land_drops(&state, PlayerId(0)),
+        0,
+        "CR 709.5: both the source's and the copy's halves are locked — no text functions"
+    );
+
+    // CR 709.5e: the copy is a Room permanent; its controller may pay the
+    // locked LEFT half's (copied) cost to unlock it.
+    apply_as_current(
+        &mut state,
+        GameAction::UnlockRoomDoor {
+            object_id: bear,
+            door: RoomDoor::Left,
+        },
+    )
+    .unwrap();
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.objects[&bear].name, "Moldering Gym",
+        "CR 709.5c: the unlocked left half contributes exactly its own (copied) name"
+    );
+    assert_eq!(
+        crate::game::static_abilities::additional_land_drops(&state, PlayerId(0)),
+        2,
+        "CR 709.5 + CR 707.2: the copied, now-unlocked front half's static functions"
+    );
+
+    // Copy expiry: the bear reverts wholesale; the lingering designation is
+    // harmless on a non-Room.
+    state
+        .transient_continuous_effects
+        .retain(|e| e.id != effect_id);
+    crate::game::layers::mark_layers_full(&mut state);
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.objects[&bear].name, "Plain Bear",
+        "copy expiry restores the recipient's own name"
+    );
+    assert_eq!(
+        crate::game::static_abilities::additional_land_drops(&state, PlayerId(0)),
+        0,
+        "copy expiry takes the copied half text with it"
+    );
+}
+
+/// CR 707.2 + CR 709.5c: a Room under a copy effect of ANOTHER Room keeps its
+/// own designations (status) but shows the COPIED halves' names through them
+/// — and reverts to its own halves when the copy expires.
+#[test]
+fn a_room_under_a_copy_effect_shows_the_copied_rooms_halves() {
+    let mut state = setup_game_at_main_phase();
+    let source = uncast_room_with_front_marker(&mut state, 909, "Bright Hall", "Dim Cellar");
+    let room = create_object(
+        &mut state,
+        CardId(910),
+        PlayerId(0),
+        "Moldering Gym".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&room).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        obj.card_types.subtypes.push("Room".to_string());
+        obj.base_card_types = obj.card_types.clone();
+        obj.back_face = Some(room_back_face("Weight Room"));
+        obj.reset_for_battlefield_entry(1, 1);
+        // The front half was the cast half: its door entered unlocked.
+        obj.room_unlocks = Some(crate::game::game_object::RoomUnlockState {
+            left_unlocked: true,
+            right_unlocked: false,
+        });
+    }
+
+    let values = crate::game::printed_cards::intrinsic_copiable_values(&state.objects[&source]);
+    let effect_id = state.add_transient_continuous_effect(
+        room,
+        PlayerId(0),
+        crate::types::ability::Duration::Permanent,
+        TargetFilter::SpecificObject { id: room },
+        vec![crate::types::ability::ContinuousModification::CopyValues {
+            values: Box::new(values),
+            display_source: crate::game::game_object::DisplaySource::Card,
+            printed_ref: None,
+            token_image_ref: None,
+        }],
+        None,
+    );
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.objects[&room].name, "Bright Hall",
+        "CR 707.2 + CR 709.5c: the surviving left designation now shows the \
+         COPIED left half's name"
+    );
+
+    // CR 709.5e: unlock the right door — the copied right half's name joins.
+    apply_as_current(
+        &mut state,
+        GameAction::UnlockRoomDoor {
+            object_id: room,
+            door: RoomDoor::Right,
+        },
+    )
+    .unwrap();
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.objects[&room].name, "Bright Hall // Dim Cellar",
+        "CR 709.5: both designations show the copied halves in printed order"
+    );
+
+    // Copy expiry: designations persist (status), the OWN halves return.
+    state
+        .transient_continuous_effects
+        .retain(|e| e.id != effect_id);
+    crate::game::layers::mark_layers_full(&mut state);
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.objects[&room].name, "Moldering Gym // Weight Room",
+        "copy expiry restores the object's own halves under its surviving designations"
+    );
+}
+
 /// CR 106.6 + CR 116.2m + CR 709.5e: Smoky Lounge produces {R}{R} restricted
 /// to "cast Room spells and unlock doors". The door-unlock half lowers to
 /// `OnlyForSpecialAction(UnlockDoor)`; paying a Room's unlock cost routes
@@ -2136,11 +2331,14 @@ fn unlock_door_restricted_mana_pays_room_unlock_cost() {
         let obj = state.objects.get_mut(&room).unwrap();
         obj.card_types.subtypes.push("Room".to_string());
         obj.room_unlocks = Some(Default::default());
-        // CR 709.5e: left door's unlock cost is the object's mana cost ({R}).
+        // CR 709.5e: left door's unlock cost is the half's printed mana cost
+        // ({R}) — the half projection reads the BASE fields, as the card
+        // pipeline fills them.
         obj.mana_cost = ManaCost::Cost {
             shards: vec![crate::types::mana::ManaCostShard::Red],
             generic: 0,
         };
+        obj.base_mana_cost = obj.mana_cost.clone();
     }
 
     // Smoky Lounge's restricted {R}: only for casting Room spells OR unlocking
@@ -2410,12 +2608,14 @@ fn inquisitive_glimmer_reduces_room_unlock_cost() {
             let obj = state.objects.get_mut(&room).unwrap();
             obj.card_types.subtypes.push("Room".to_string());
             obj.room_unlocks = Some(Default::default());
-            // CR 709.5e: the left door's unlock cost is the object's mana
-            // cost — a flat {3} generic here.
+            // CR 709.5e: the left door's unlock cost is the half's printed
+            // mana cost — a flat {3} generic here, mirrored to BASE as the
+            // card pipeline fills it (the half projection reads base fields).
             obj.mana_cost = ManaCost::Cost {
                 shards: vec![],
                 generic: 3,
             };
+            obj.base_mana_cost = obj.mana_cost.clone();
         }
         if with_glimmer {
             let glimmer = create_object(

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -2478,6 +2478,83 @@ fn a_set_name_exception_survives_the_room_name_derivation() {
         state.objects[&bear2].name, "Wrong Turn",
         "CR 707.3 + CR 707.9b: the chained copy keeps the exception name —          the door gate must not rename it to a half string"
     );
+
+    // CR 613.1a: a LATER ordinary copy replaces the exception wholesale — the
+    // marker must reset with it, so the door gate applies again. The bear's
+    // left door is still unlocked from above, so the copied left name shows.
+    let plain = crate::game::printed_cards::intrinsic_copiable_values(&state.objects[&source]);
+    state.add_transient_continuous_effect(
+        bear,
+        PlayerId(0),
+        crate::types::ability::Duration::Permanent,
+        TargetFilter::SpecificObject { id: bear },
+        vec![crate::types::ability::ContinuousModification::CopyValues {
+            values: Box::new(plain),
+            display_source: crate::game::game_object::DisplaySource::Card,
+            printed_ref: None,
+            token_image_ref: None,
+        }],
+        None,
+    );
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.objects[&bear].name, "Bright Hall",
+        "CR 613.1a: the later ordinary copy resets the exception marker"
+    );
+}
+
+/// CR 707.9b: a MATERIALIZED duplicate of an exception-named Room copy keeps
+/// the exception through every LATER layer pass — `base_name_origin` restores
+/// the runtime marker at each Step-1 seed, so the door gate never renames it.
+#[test]
+fn a_materialized_exception_name_survives_later_layer_passes() {
+    let mut state = setup_game_at_main_phase();
+    let source = uncast_room_with_front_marker(&mut state, 918, "Bright Hall", "Dim Cellar");
+    let mut values = crate::game::printed_cards::intrinsic_copiable_values(&state.objects[&source]);
+    values.name = "Wrong Turn".to_string();
+    values.name_origin = crate::types::ability::CopiedNameOrigin::Exception;
+
+    let duplicate = create_object(
+        &mut state,
+        CardId(919),
+        PlayerId(0),
+        "Conjured".to_string(),
+        Zone::Battlefield,
+    );
+    crate::game::printed_cards::install_copiable_values_as_base(
+        state.objects.get_mut(&duplicate).unwrap(),
+        &values,
+    );
+
+    // A later full pass re-seeds from base — the exception must survive it.
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.objects[&duplicate].name, "Wrong Turn",
+        "CR 707.9b: the materialized exception is base state and outlives the pass"
+    );
+
+    // CR 709.5e: unlocking a door changes half text, never the exception name.
+    state.players[0]
+        .mana_pool
+        .add(crate::types::mana::ManaUnit::new(
+            crate::types::mana::ManaType::Green,
+            ObjectId(0),
+            false,
+            vec![],
+        ));
+    apply_as_current(
+        &mut state,
+        GameAction::UnlockRoomDoor {
+            object_id: duplicate,
+            door: RoomDoor::Left,
+        },
+    )
+    .unwrap();
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.objects[&duplicate].name, "Wrong Turn",
+        "CR 707.9b: the exception stays the final name after unlocking too"
+    );
 }
 
 /// CR 709.5b: a materialized duplicate of a Room (conjure — Endless Corridor

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -2132,6 +2132,13 @@ fn uncast_room_with_front_marker(
     // The copiable snapshot reads BASE characteristics — mirror the types
     // there so the source is a Room in its copiable form too.
     obj.base_card_types = obj.card_types.clone();
+    // CR 709.5e: give the LEFT half a real unlock cost ({1}) so a copy's
+    // unlock exercises the COPIED cost instead of succeeding for free.
+    obj.mana_cost = ManaCost::Cost {
+        shards: vec![],
+        generic: 1,
+    };
+    obj.base_mana_cost = obj.mana_cost.clone();
     let front_static = StaticDefinition::new(StaticMode::AdditionalLandDrop { count: 2 });
     obj.static_definitions.push(front_static.clone());
     Arc::make_mut(&mut obj.base_static_definitions).push(front_static);
@@ -2191,8 +2198,18 @@ fn an_ordinary_permanent_copying_a_room_gains_its_door_gated_form() {
         "CR 709.5: both the source's and the copy's halves are locked — no text functions"
     );
 
-    // CR 709.5e: the copy is a Room permanent; its controller may pay the
-    // locked LEFT half's (copied) cost to unlock it.
+    // CR 709.5e + CR 707.2: the copy is a Room permanent; its controller pays
+    // the locked LEFT half's COPIED cost ({1}) — fund exactly that much and
+    // assert the unlock consumes it, so a copy path that drops the half cost
+    // or defaults it to free fails here.
+    state.players[0]
+        .mana_pool
+        .add(crate::types::mana::ManaUnit::new(
+            crate::types::mana::ManaType::Green,
+            ObjectId(0),
+            false,
+            vec![],
+        ));
     apply_as_current(
         &mut state,
         GameAction::UnlockRoomDoor {
@@ -2201,6 +2218,11 @@ fn an_ordinary_permanent_copying_a_room_gains_its_door_gated_form() {
         },
     )
     .unwrap();
+    assert_eq!(
+        state.players[0].mana_pool.mana.len(),
+        0,
+        "CR 709.5e: the copied left half's {{1}} unlock cost must consume the mana"
+    );
     crate::game::layers::evaluate_layers(&mut state);
     assert_eq!(
         state.objects[&bear].name, "Moldering Gym",
@@ -2303,6 +2325,91 @@ fn a_room_under_a_copy_effect_shows_the_copied_rooms_halves() {
     assert_eq!(
         state.objects[&room].name, "Moldering Gym // Weight Room",
         "copy expiry restores the object's own halves under its surviving designations"
+    );
+}
+
+/// CR 707.3: an object copying an ALREADY-COPIED Room uses the new copiable
+/// values — the snapshot a later copy takes must carry the COPIED halves, not
+/// the recipient's printed ones.
+#[test]
+fn a_copy_of_an_already_copied_room_snapshots_the_copied_halves() {
+    let mut state = setup_game_at_main_phase();
+    let source = uncast_room_with_front_marker(&mut state, 911, "Bright Hall", "Dim Cellar");
+    let bear = create_object(
+        &mut state,
+        CardId(912),
+        PlayerId(0),
+        "Plain Bear".to_string(),
+        Zone::Battlefield,
+    );
+    let values = crate::game::printed_cards::intrinsic_copiable_values(&state.objects[&source]);
+    state.add_transient_continuous_effect(
+        bear,
+        PlayerId(0),
+        crate::types::ability::Duration::Permanent,
+        TargetFilter::SpecificObject { id: bear },
+        vec![crate::types::ability::ContinuousModification::CopyValues {
+            values: Box::new(values),
+            display_source: crate::game::game_object::DisplaySource::Card,
+            printed_ref: None,
+            token_image_ref: None,
+        }],
+        None,
+    );
+    crate::game::layers::evaluate_layers(&mut state);
+
+    // CR 707.3: the bear's CURRENT copiable values are the Room's — including
+    // the halves. `compute_current_copiable_values` is the snapshot every
+    // become-copy / conjure-duplicate resolution takes.
+    let snapshot = crate::game::layers::compute_current_copiable_values(&state, bear)
+        .expect("the bear exists");
+    let halves = snapshot
+        .room_halves
+        .expect("CR 707.3: the copied Room halves are part of the new copiable values");
+    assert_eq!(halves.left.name, "Bright Hall");
+    assert_eq!(
+        halves.right.as_ref().map(|half| half.name.as_str()),
+        Some("Dim Cellar")
+    );
+}
+
+/// CR 709.5b: a materialized duplicate of a Room (conjure — Endless Corridor
+/// conjures a duplicate of ITSELF) keeps both printed halves: the base slots
+/// hold the left half, a synthesized back face the right one, so
+/// `own_room_halves` round-trips identity, unlock costs, and door existence.
+#[test]
+fn a_materialized_duplicate_of_a_room_keeps_both_halves() {
+    let mut state = setup_game_at_main_phase();
+    let source = uncast_room_with_front_marker(&mut state, 913, "Bright Hall", "Dim Cellar");
+    let values = crate::game::printed_cards::intrinsic_copiable_values(&state.objects[&source]);
+
+    let duplicate = create_object(
+        &mut state,
+        CardId(914),
+        PlayerId(0),
+        "Conjured".to_string(),
+        Zone::Hand,
+    );
+    let obj = state.objects.get_mut(&duplicate).unwrap();
+    crate::game::printed_cards::install_copiable_values_as_base(obj, &values);
+
+    let halves = crate::game::room::own_room_halves(obj);
+    assert_eq!(
+        halves.left.name, "Bright Hall",
+        "CR 709.5b: the duplicate's base slots hold the left half"
+    );
+    assert_eq!(
+        halves.left.mana_cost,
+        ManaCost::Cost {
+            shards: vec![],
+            generic: 1,
+        },
+        "CR 709.5e: the left door's unlock cost survives materialization"
+    );
+    assert_eq!(
+        halves.right.as_ref().map(|half| half.name.as_str()),
+        Some("Dim Cellar"),
+        "CR 709.5b: the right half survives as the synthesized back face"
     );
 }
 

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -2368,8 +2368,115 @@ fn a_copy_of_an_already_copied_room_snapshots_the_copied_halves() {
         .expect("CR 707.3: the copied Room halves are part of the new copiable values");
     assert_eq!(halves.left.name, "Bright Hall");
     assert_eq!(
+        halves.left.mana_cost,
+        ManaCost::Cost {
+            shards: vec![],
+            generic: 1,
+        },
+        "CR 707.3: the copied left half's unlock cost is part of the new copiable values"
+    );
+    assert_eq!(
         halves.right.as_ref().map(|half| half.name.as_str()),
         Some("Dim Cellar")
+    );
+}
+
+/// CR 707.9b + CR 709.5: an "except its name is X" copy exception is part of
+/// the COPIABLE values and is the copy's final name — the Room door gate
+/// removes locked HALves' names, never a separate name exception. The
+/// exception also propagates through a chained copy (CR 707.3).
+#[test]
+fn a_set_name_exception_survives_the_room_name_derivation() {
+    let mut state = setup_game_at_main_phase();
+    let source = uncast_room_with_front_marker(&mut state, 915, "Bright Hall", "Dim Cellar");
+    let bear = create_object(
+        &mut state,
+        CardId(916),
+        PlayerId(0),
+        "Plain Bear".to_string(),
+        Zone::Battlefield,
+    );
+    let values = crate::game::printed_cards::intrinsic_copiable_values(&state.objects[&source]);
+    state.add_transient_continuous_effect(
+        bear,
+        PlayerId(0),
+        crate::types::ability::Duration::Permanent,
+        TargetFilter::SpecificObject { id: bear },
+        vec![
+            crate::types::ability::ContinuousModification::CopyValues {
+                values: Box::new(values),
+                display_source: crate::game::game_object::DisplaySource::Card,
+                printed_ref: None,
+                token_image_ref: None,
+            },
+            // CR 707.9b: the "except its name is X" rider follows CopyValues
+            // within the same effect, exactly as production installs it.
+            crate::types::ability::ContinuousModification::SetName {
+                name: "Wrong Turn".to_string(),
+            },
+        ],
+        None,
+    );
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.objects[&bear].name, "Wrong Turn",
+        "CR 707.9b: the name exception is the copy's final name — the door          gate must not erase it while both halves are locked"
+    );
+
+    // CR 709.5e: unlocking a door changes the half text, never the exception name.
+    state.players[0]
+        .mana_pool
+        .add(crate::types::mana::ManaUnit::new(
+            crate::types::mana::ManaType::Green,
+            ObjectId(0),
+            false,
+            vec![],
+        ));
+    apply_as_current(
+        &mut state,
+        GameAction::UnlockRoomDoor {
+            object_id: bear,
+            door: RoomDoor::Left,
+        },
+    )
+    .unwrap();
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.objects[&bear].name, "Wrong Turn",
+        "CR 707.9b: the exception stays the final name after unlocking too"
+    );
+
+    // CR 707.3: a chained copy sees the overridden name as a copiable value.
+    let bear2 = create_object(
+        &mut state,
+        CardId(917),
+        PlayerId(0),
+        "Second Bear".to_string(),
+        Zone::Battlefield,
+    );
+    let chained = crate::game::layers::compute_current_copiable_values(&state, bear)
+        .expect("the copy exists");
+    assert_eq!(
+        chained.name, "Wrong Turn",
+        "CR 707.9b: the exception is part of the snapshot a later copy takes"
+    );
+    state.add_transient_continuous_effect(
+        bear2,
+        PlayerId(0),
+        crate::types::ability::Duration::Permanent,
+        TargetFilter::SpecificObject { id: bear2 },
+        vec![crate::types::ability::ContinuousModification::CopyValues {
+            values: Box::new(chained),
+            display_source: crate::game::game_object::DisplaySource::Card,
+            printed_ref: None,
+            token_image_ref: None,
+        }],
+        None,
+    );
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.objects[&bear2].name, "Wrong Turn",
+        "CR 707.3 + CR 707.9b: the chained copy keeps the exception name —          the door gate must not rename it to a half string"
     );
 }
 

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -1995,6 +1995,122 @@ fn a_room_entering_uncast_has_no_functioning_static_until_unlocked() {
     );
 }
 
+/// CR 709.5: a locked half doesn't have its NAME. On the battlefield a Room's
+/// name is therefore the printed-order combination of its unlocked halves:
+/// neither → no name at all (CR 709.5d uncast entry), one → that half alone,
+/// both → "Left // Right". Re-locking (CR 709.5g) takes the name away again.
+#[test]
+fn a_rooms_battlefield_name_follows_its_unlock_designations() {
+    let mut state = setup_game_at_main_phase();
+    let room = create_object(
+        &mut state,
+        CardId(905),
+        PlayerId(0),
+        "Moldering Gym".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&room).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        obj.card_types.subtypes.push("Room".to_string());
+        obj.back_face = Some(room_back_face("Weight Room"));
+        // Entering uncast: `reset_for_battlefield_entry` leaves both doors
+        // locked (CR 709.5d — neither half was cast as a spell).
+        obj.reset_for_battlefield_entry(1, 1);
+    }
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.objects[&room].name, "",
+        "CR 709.5d + CR 709.5: with both doors locked the permanent has neither half's name"
+    );
+
+    apply_as_current(
+        &mut state,
+        GameAction::UnlockRoomDoor {
+            object_id: room,
+            door: RoomDoor::Left,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        state.objects[&room].name, "Moldering Gym",
+        "CR 709.5c: one unlocked half contributes exactly its own name"
+    );
+
+    apply_as_current(
+        &mut state,
+        GameAction::UnlockRoomDoor {
+            object_id: room,
+            door: RoomDoor::Right,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        state.objects[&room].name, "Moldering Gym // Weight Room",
+        "CR 709.5: a fully unlocked Room has both halves' names, in printed order"
+    );
+
+    // CR 709.5g: re-locking the left door takes its half's name away again.
+    assert!(crate::game::room::lock_door_designation(
+        &mut state,
+        room,
+        RoomDoor::Left
+    ));
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.objects[&room].name, "Weight Room",
+        "CR 709.5g: a re-locked half's name is gone; the right half's remains"
+    );
+}
+
+/// CR 709.5d: the same name rule with the RIGHT half cast — `modal_back_face`
+/// swaps the faces, so the live face is the right door and the back face slot
+/// holds the FIRST printed half. The combined name must keep printed order,
+/// not face residency ("Moldering Gym // Weight Room", never the reverse).
+#[test]
+fn a_room_cast_from_its_right_half_keeps_printed_name_order() {
+    let mut state = setup_game_at_main_phase();
+    let room = create_object(
+        &mut state,
+        CardId(906),
+        PlayerId(0),
+        "Weight Room".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&room).unwrap();
+        obj.card_types.core_types.push(CoreType::Enchantment);
+        obj.card_types.subtypes.push("Room".to_string());
+        obj.modal_back_face = true;
+        obj.back_face = Some(room_back_face("Moldering Gym"));
+        obj.reset_for_battlefield_entry(1, 1);
+        // The right (live) half was the cast half: its door entered unlocked.
+        obj.room_unlocks = Some(crate::game::game_object::RoomUnlockState {
+            left_unlocked: false,
+            right_unlocked: true,
+        });
+    }
+    crate::game::layers::evaluate_layers(&mut state);
+    assert_eq!(
+        state.objects[&room].name, "Weight Room",
+        "CR 709.5d: only the cast (right) half's name exists"
+    );
+
+    apply_as_current(
+        &mut state,
+        GameAction::UnlockRoomDoor {
+            object_id: room,
+            door: RoomDoor::Left,
+        },
+    )
+    .unwrap();
+    assert_eq!(
+        state.objects[&room].name, "Moldering Gym // Weight Room",
+        "CR 709.5: printed order wins — the left-printed half leads even though \
+         it lives in the back-face slot"
+    );
+}
+
 /// CR 106.6 + CR 116.2m + CR 709.5e: Smoky Lounge produces {R}{R} restricted
 /// to "cast Room spells and unlock doors". The door-unlock half lowers to
 /// `OnlyForSpecialAction(UnlockDoor)`; paying a Room's unlock cost routes

--- a/crates/engine/src/game/flip.rs
+++ b/crates/engine/src/game/flip.rs
@@ -252,7 +252,7 @@ pub(crate) fn flipped_normal_copiable_values(obj: &GameObject) -> Option<Copiabl
         // alternative characteristics share one face — never one of CR 709.5's
         // shared-type-line Room permanents, so there is no half data to carry.
         room_halves: None,
-        name_exception: false,
+        name_origin: Default::default(),
     })
 }
 

--- a/crates/engine/src/game/flip.rs
+++ b/crates/engine/src/game/flip.rs
@@ -248,6 +248,8 @@ pub(crate) fn flipped_normal_copiable_values(obj: &GameObject) -> Option<Copiabl
                 .collect(),
         ),
         static_definitions: Arc::new(normal_face.static_definitions.iter_all().cloned().collect()),
+        // CR 710.1: flip cards are single-faced permanents — no Room halves.
+        room_halves: None,
     })
 }
 

--- a/crates/engine/src/game/flip.rs
+++ b/crates/engine/src/game/flip.rs
@@ -252,6 +252,7 @@ pub(crate) fn flipped_normal_copiable_values(obj: &GameObject) -> Option<Copiabl
         // alternative characteristics share one face — never one of CR 709.5's
         // shared-type-line Room permanents, so there is no half data to carry.
         room_halves: None,
+        name_exception: false,
     })
 }
 

--- a/crates/engine/src/game/flip.rs
+++ b/crates/engine/src/game/flip.rs
@@ -248,7 +248,9 @@ pub(crate) fn flipped_normal_copiable_values(obj: &GameObject) -> Option<Copiabl
                 .collect(),
         ),
         static_definitions: Arc::new(normal_face.static_definitions.iter_all().cloned().collect()),
-        // CR 710.1: flip cards are single-faced permanents — no Room halves.
+        // CR 710.1 + CR 710.2: a flip card is a single card whose normal and
+        // alternative characteristics share one face — never one of CR 709.5's
+        // shared-type-line Room permanents, so there is no half data to carry.
         room_halves: None,
     })
 }

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1159,14 +1159,23 @@ pub struct GameObject {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub copied_room_halves: Option<crate::types::ability::RoomCopiableHalves>,
 
-    /// CR 707.9b: a Layer-1 copy-effect name EXCEPTION ("except its name is
-    /// X") applied to this object this pass — the exception is the copy's
-    /// final copiable name, so the Room door gate must not replace it.
-    /// Layer-derived: set by the `SetName` application arm (and by
-    /// `apply_copiable_values` when the snapshot carries a folded exception),
-    /// cleared by the Step-1 seed.
-    #[serde(default)]
-    pub layer1_name_exception: bool,
+    /// CR 707.9b: where the LAST Layer-1 copy naming of this object came
+    /// from this pass — `None` when no copy effect named it. An `Exception`
+    /// ("except its name is X") is the copy's final copiable name, so the
+    /// Room door gate must not replace it. Layer-derived: assigned by every
+    /// applied copy (`apply_copiable_values`) and by the `SetName` arm,
+    /// cleared by the Step-1 seed — a LATER ordinary copy therefore resets
+    /// an earlier exception (CR 613.1a timestamp order).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub layer1_name_origin: Option<crate::types::ability::CopiedNameOrigin>,
+
+    /// CR 707.9b: the BASE name's origin for a MATERIALIZED object (duplicate
+    /// conjure / copy-token creation of an exception-named copy) — persistent,
+    /// unlike the layer-derived marker above. The Step-1 seed restores the
+    /// runtime marker from this, so the exception outlives every later layer
+    /// pass. `None` for every ordinarily printed object.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub base_name_origin: Option<crate::types::ability::CopiedNameOrigin>,
 
     /// CR 716.3: Class enchantment level. Present only on Class permanents.
     /// Class level is NOT a counter (CR 716) — proliferate/counter manipulation must not interact.
@@ -1469,7 +1478,8 @@ fn _gameobject_partition_is_total(o: &GameObject) {
         case_state: _,
         room_unlocks: _,
         copied_room_halves: _,
-        layer1_name_exception: _,
+        layer1_name_origin: _,
+        base_name_origin: _,
         class_level: _,
         cast_from_zone: _,
         cast_controller: _,
@@ -2364,7 +2374,8 @@ impl GameObject {
             case_state: None,
             room_unlocks: None,
             copied_room_halves: None,
-            layer1_name_exception: false,
+            layer1_name_origin: None,
+            base_name_origin: None,
             class_level: None,
             cast_from_zone: None,
             cast_controller: None,

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -212,7 +212,7 @@ pub enum PhaseOutCause {
 
 /// Stored back-face data for double-faced cards (DFCs).
 /// Populated when a Transform-layout card enters the game.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Serialize, Deserialize)]
 pub struct BackFaceData {
     pub name: String,
     pub power: Option<i32>,

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1151,6 +1151,14 @@ pub struct GameObject {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub room_unlocks: Option<RoomUnlockState>,
 
+    /// CR 707.2 + CR 709.5b + CR 613.1a: the Room half data the winning
+    /// Layer-1a copy effect carried (`CopiableValues::room_halves`).
+    /// Layer-derived: set by `apply_copiable_values`, cleared by the Step-1
+    /// seed — so it expires with the copy effect. `room::effective_room_halves`
+    /// prefers it over the object's own printed halves.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub copied_room_halves: Option<crate::types::ability::RoomCopiableHalves>,
+
     /// CR 716.3: Class enchantment level. Present only on Class permanents.
     /// Class level is NOT a counter (CR 716) — proliferate/counter manipulation must not interact.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1451,6 +1459,7 @@ fn _gameobject_partition_is_total(o: &GameObject) {
         assigns_no_combat_damage: _,
         case_state: _,
         room_unlocks: _,
+        copied_room_halves: _,
         class_level: _,
         cast_from_zone: _,
         cast_controller: _,
@@ -2344,6 +2353,7 @@ impl GameObject {
             assigns_no_combat_damage: false,
             case_state: None,
             room_unlocks: None,
+            copied_room_halves: None,
             class_level: None,
             cast_from_zone: None,
             cast_controller: None,

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -1159,6 +1159,15 @@ pub struct GameObject {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub copied_room_halves: Option<crate::types::ability::RoomCopiableHalves>,
 
+    /// CR 707.9b: a Layer-1 copy-effect name EXCEPTION ("except its name is
+    /// X") applied to this object this pass — the exception is the copy's
+    /// final copiable name, so the Room door gate must not replace it.
+    /// Layer-derived: set by the `SetName` application arm (and by
+    /// `apply_copiable_values` when the snapshot carries a folded exception),
+    /// cleared by the Step-1 seed.
+    #[serde(default)]
+    pub layer1_name_exception: bool,
+
     /// CR 716.3: Class enchantment level. Present only on Class permanents.
     /// Class level is NOT a counter (CR 716) — proliferate/counter manipulation must not interact.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -1460,6 +1469,7 @@ fn _gameobject_partition_is_total(o: &GameObject) {
         case_state: _,
         room_unlocks: _,
         copied_room_halves: _,
+        layer1_name_exception: _,
         class_level: _,
         cast_from_zone: _,
         cast_controller: _,
@@ -2354,6 +2364,7 @@ impl GameObject {
             case_state: None,
             room_unlocks: None,
             copied_room_halves: None,
+            layer1_name_exception: false,
             class_level: None,
             cast_from_zone: None,
             cast_controller: None,

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2096,12 +2096,11 @@ fn derive_suspected_abilities(obj: &mut crate::game::game_object::GameObject) {
 /// separable at all).
 fn seed_live_characteristics_from_base(obj: &mut crate::game::game_object::GameObject) {
     obj.name = obj.base_name.clone();
-    // CR 709.5: a Room permanent's name is door-gated — a locked half doesn't
-    // have its name. Overrides the base seed on the battlefield only; the
-    // CR 708.2 face-down blanking below still wins where it applies.
-    if let Some(room_name) = crate::game::room::door_gated_battlefield_name(obj) {
-        obj.name = room_name;
-    }
+    // CR 707.2 + CR 613.1a: the copied Room half data is layer-derived — it
+    // survives only as long as a Layer-1a copy effect keeps re-applying it.
+    // (The door-gated Room NAME is derived at layer-1 exit, in
+    // `derive_room_battlefield_names`, from the post-copy effective form.)
+    obj.copied_room_halves = None;
     obj.power = obj.base_power;
     obj.toughness = obj.base_toughness;
     // CR 208.4b + CR 613.4b: layer 7b starts from the printed/copiable base;
@@ -2378,6 +2377,12 @@ pub fn evaluate_layers(state: &mut GameState) {
             seed_live_characteristics_from_base(obj);
         }
     }
+
+    // CR 709.5 + CR 707.2 + CR 613.1a: derive each battlefield Room's
+    // door-gated NAME from its EFFECTIVE, post-layer-1 form — after copies, so
+    // a copy shows the COPIED halves through its own designations. Placed
+    // after the 1b reseed so the face-down profile (CR 708.2a, no name) wins.
+    derive_room_battlefield_names(state, &bf_ids);
 
     // Both producers say the same thing: layer 1 can turn a non-generator into a
     // continuous static source mid-pass, and the top-of-pass index was built from
@@ -5116,6 +5121,25 @@ fn copy_sublayer_effect_id(
 /// does not promise: the guarantee is "no DETECTED perturbation", not "no
 /// population read is live". The residual blind spots are enumerated on
 /// `population_probe_blinded_by_entrant_characteristic_change`.
+/// CR 709.5 + CR 707.2 + CR 613.1a: derive each battlefield Room's door-gated
+/// NAME from its effective (post-Layer-1) form. A locked half doesn't have its
+/// name; the halves come from the copied snapshot when a copy applied, else
+/// from the object's own printed form (`room::door_gated_battlefield_name`).
+/// Face-down objects keep their CR 708.2a profile — no name to derive.
+fn derive_room_battlefield_names(state: &mut GameState, ids: &[ObjectId]) {
+    for id in ids {
+        let Some(obj) = state.objects.get_mut(id) else {
+            continue;
+        };
+        if obj.face_down {
+            continue;
+        }
+        if let Some(room_name) = crate::game::room::door_gated_battlefield_name(obj) {
+            obj.name = room_name;
+        }
+    }
+}
+
 fn apply_layers_incremental(state: &mut GameState, prepared: PreparedIncrementalFlush) {
     let PreparedIncrementalFlush {
         recipient_ids,
@@ -5155,6 +5179,9 @@ fn apply_layers_incremental(state: &mut GameState, prepared: PreparedIncremental
     }
 
     let recipient_vec: Vec<ObjectId> = recipient_ids.iter().copied().collect();
+    // CR 709.5 + CR 613.1a: same layer-1 exit derivation as the full pass —
+    // an entrant that is (or copies) a Room gets its door-gated name here.
+    derive_room_battlefield_names(state, &recipient_vec);
     let stickers_changed =
         crate::game::stickers::apply_battlefield_name_and_ability_stickers(state, &recipient_vec);
     // CR 613.2a + CR 613.2c: deliberately no copy disjunct on this rebuild, unlike
@@ -20098,6 +20125,7 @@ mod tests {
             trigger_definitions: Default::default(),
             replacement_definitions: Default::default(),
             static_definitions: Default::default(),
+            room_halves: None,
         };
         let _ = state.add_transient_continuous_effect(
             source,
@@ -22595,6 +22623,7 @@ mod tests {
                     trigger_definitions: Arc::new(Vec::new()),
                     replacement_definitions: Arc::new(Vec::new()),
                     static_definitions: Arc::new(Vec::new()),
+                    room_halves: None,
                 }),
                 display_source: Default::default(),
                 printed_ref: None,

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2096,6 +2096,12 @@ fn derive_suspected_abilities(obj: &mut crate::game::game_object::GameObject) {
 /// separable at all).
 fn seed_live_characteristics_from_base(obj: &mut crate::game::game_object::GameObject) {
     obj.name = obj.base_name.clone();
+    // CR 709.5: a Room permanent's name is door-gated — a locked half doesn't
+    // have its name. Overrides the base seed on the battlefield only; the
+    // CR 708.2 face-down blanking below still wins where it applies.
+    if let Some(room_name) = crate::game::room::door_gated_battlefield_name(obj) {
+        obj.name = room_name;
+    }
     obj.power = obj.base_power;
     obj.toughness = obj.base_toughness;
     // CR 208.4b + CR 613.4b: layer 7b starts from the printed/copiable base;

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2101,6 +2101,7 @@ fn seed_live_characteristics_from_base(obj: &mut crate::game::game_object::GameO
     // (The door-gated Room NAME is derived at layer-1 exit, in
     // `derive_room_battlefield_names`, from the post-copy effective form.)
     obj.copied_room_halves = None;
+    obj.layer1_name_exception = false;
     obj.power = obj.base_power;
     obj.toughness = obj.base_toughness;
     // CR 208.4b + CR 613.4b: layer 7b starts from the printed/copiable base;
@@ -5134,6 +5135,11 @@ fn derive_room_battlefield_names(state: &mut GameState, ids: &[ObjectId]) {
         if obj.face_down {
             continue;
         }
+        // CR 707.9b: a Layer-1 name EXCEPTION is the copy's final name —
+        // CR 709.5 removes locked HALves' names, never a separate exception.
+        if obj.layer1_name_exception {
+            continue;
+        }
         if let Some(room_name) = crate::game::room::door_gated_battlefield_name(obj) {
             obj.name = room_name;
         }
@@ -7789,6 +7795,9 @@ fn apply_continuous_effect_filtered(
             // follows `CopyValues` in `add_transient_continuous_effect`).
             ContinuousModification::SetName { name } => {
                 obj.name = name.clone();
+                // CR 707.9b: the exception is the copy's FINAL copiable name —
+                // `derive_room_battlefield_names` must leave it alone.
+                obj.layer1_name_exception = true;
             }
             // CR 612.8 + CR 613.1c: Literal name changes from continuous
             // effects apply in Layer 3 and are not copiable values.
@@ -8664,6 +8673,9 @@ pub(crate) fn compute_current_copiable_values(
             // source's name.
             ContinuousModification::SetName { name } => {
                 values.name = name.clone();
+                // CR 707.9b + CR 707.3: mark the fold so a later copy (and its
+                // Room name derivation) treats X as the final name.
+                values.name_exception = true;
             }
             // CR 707.9b + CR 306.5b: Starting loyalty is a copy-effect
             // characteristic exception. A later copy of this copy must see
@@ -20126,6 +20138,7 @@ mod tests {
             replacement_definitions: Default::default(),
             static_definitions: Default::default(),
             room_halves: None,
+            name_exception: false,
         };
         let _ = state.add_transient_continuous_effect(
             source,
@@ -22624,6 +22637,7 @@ mod tests {
                     replacement_definitions: Arc::new(Vec::new()),
                     static_definitions: Arc::new(Vec::new()),
                     room_halves: None,
+                    name_exception: false,
                 }),
                 display_source: Default::default(),
                 printed_ref: None,

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2101,7 +2101,9 @@ fn seed_live_characteristics_from_base(obj: &mut crate::game::game_object::GameO
     // (The door-gated Room NAME is derived at layer-1 exit, in
     // `derive_room_battlefield_names`, from the post-copy effective form.)
     obj.copied_room_halves = None;
-    obj.layer1_name_exception = false;
+    // CR 707.9b: restore the persistent base origin (materialized exception
+    // names); a Layer-1 copy application overwrites it within the pass.
+    obj.layer1_name_origin = obj.base_name_origin;
     obj.power = obj.base_power;
     obj.toughness = obj.base_toughness;
     // CR 208.4b + CR 613.4b: layer 7b starts from the printed/copiable base;
@@ -5136,8 +5138,8 @@ fn derive_room_battlefield_names(state: &mut GameState, ids: &[ObjectId]) {
             continue;
         }
         // CR 707.9b: a Layer-1 name EXCEPTION is the copy's final name —
-        // CR 709.5 removes locked HALves' names, never a separate exception.
-        if obj.layer1_name_exception {
+        // CR 709.5 removes locked HALVES' names, never a separate exception.
+        if obj.layer1_name_origin == Some(crate::types::ability::CopiedNameOrigin::Exception) {
             continue;
         }
         if let Some(room_name) = crate::game::room::door_gated_battlefield_name(obj) {
@@ -7797,7 +7799,7 @@ fn apply_continuous_effect_filtered(
                 obj.name = name.clone();
                 // CR 707.9b: the exception is the copy's FINAL copiable name —
                 // `derive_room_battlefield_names` must leave it alone.
-                obj.layer1_name_exception = true;
+                obj.layer1_name_origin = Some(crate::types::ability::CopiedNameOrigin::Exception);
             }
             // CR 612.8 + CR 613.1c: Literal name changes from continuous
             // effects apply in Layer 3 and are not copiable values.
@@ -8675,7 +8677,7 @@ pub(crate) fn compute_current_copiable_values(
                 values.name = name.clone();
                 // CR 707.9b + CR 707.3: mark the fold so a later copy (and its
                 // Room name derivation) treats X as the final name.
-                values.name_exception = true;
+                values.name_origin = crate::types::ability::CopiedNameOrigin::Exception;
             }
             // CR 707.9b + CR 306.5b: Starting loyalty is a copy-effect
             // characteristic exception. A later copy of this copy must see
@@ -20138,7 +20140,7 @@ mod tests {
             replacement_definitions: Default::default(),
             static_definitions: Default::default(),
             room_halves: None,
-            name_exception: false,
+            name_origin: Default::default(),
         };
         let _ = state.add_transient_continuous_effect(
             source,
@@ -22637,7 +22639,7 @@ mod tests {
                     replacement_definitions: Arc::new(Vec::new()),
                     static_definitions: Arc::new(Vec::new()),
                     room_halves: None,
-                    name_exception: false,
+                    name_origin: Default::default(),
                 }),
                 display_source: Default::default(),
                 printed_ref: None,

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -748,6 +748,26 @@ pub fn install_copiable_values_as_base(obj: &mut GameObject, values: &CopiableVa
     obj.base_static_definitions = Arc::clone(&values.static_definitions);
     obj.install_trigger_base_definitions(Arc::clone(&values.trigger_definitions))
         .expect("trigger base-set generation must not overflow");
+    // CR 709.5b: a materialized duplicate of a Room keeps both printed halves.
+    // The base slots hold the LEFT half and a synthesized back face the right
+    // one — identity only (name and door cost): the halves' TEXT rides in the
+    // door-stamped definition sets installed above, and `own_room_halves`
+    // re-derives printed order from this exact shape (`modal_back_face` false).
+    if let Some(halves) = &values.room_halves {
+        obj.name = halves.left.name.clone();
+        obj.base_name = halves.left.name.clone();
+        obj.mana_cost = halves.left.mana_cost.clone();
+        obj.base_mana_cost = halves.left.mana_cost.clone();
+        obj.modal_back_face = false;
+        obj.back_face = halves
+            .right
+            .as_ref()
+            .map(|right| crate::game::game_object::BackFaceData {
+                name: right.name.clone(),
+                mana_cost: right.mana_cost.clone(),
+                ..Default::default()
+            });
+    }
     obj.base_characteristics_initialized = true;
 }
 

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -763,8 +763,17 @@ pub fn install_copiable_values_as_base(obj: &mut GameObject, values: &CopiableVa
     // door-stamped definition sets installed above, and `own_room_halves`
     // re-derives printed order from this exact shape (`modal_back_face` false).
     if let Some(halves) = &values.room_halves {
-        obj.name = halves.left.name.clone();
-        obj.base_name = halves.left.name.clone();
+        // CR 707.9b: an exception-named copy ("except its name is X") keeps X
+        // as its copiable name even when materialized (reachable via
+        // Impossible Man copying a Room + Snowborn Simulacra / Vona de Iedo
+        // conjuring a duplicate of that permanent). The half identities still
+        // provide door existence and unlock costs. Which HALF name such an
+        // object would show per door is undefined by the CR; keeping X
+        // wholesale is the conservative reading.
+        if !values.name_exception {
+            obj.name = halves.left.name.clone();
+            obj.base_name = halves.left.name.clone();
+        }
         obj.mana_cost = halves.left.mana_cost.clone();
         obj.base_mana_cost = halves.left.mana_cost.clone();
         obj.modal_back_face = false;

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -533,6 +533,9 @@ pub fn intrinsic_copiable_values(obj: &GameObject) -> CopiableValues {
             .iter()
             .any(|s| s == "Room")
             .then(|| crate::game::room::own_room_halves(obj)),
+        // CR 707.9b exceptions are folded in by `compute_current_copiable_values`,
+        // never by the printed form.
+        name_exception: false,
     }
 }
 
@@ -644,6 +647,7 @@ pub(crate) fn copiable_values_from_face(result_face: &CardFace) -> CopiableValue
         replacement_definitions: Arc::new(result_face.replacements.clone()),
         // A format-pool face is never a Room half pair.
         room_halves: None,
+        name_exception: false,
         static_definitions: Arc::new(result_face.static_abilities.clone()),
     }
 }
@@ -712,6 +716,11 @@ pub fn apply_copiable_values(
     // CR 709.5b + CR 707.2: carry the copied Room half data. Layer-derived —
     // the Step-1 seed clears it, so it expires with this copy effect.
     obj.copied_room_halves = values.room_halves.clone();
+    // CR 707.9b + CR 707.3: a chained copy of an exception-named copy keeps
+    // the exception as its final name — the snapshot folded it into `name`.
+    if values.name_exception {
+        obj.layer1_name_exception = true;
+    }
 }
 
 /// Materialize copiable values onto a newly constructed object (for example a

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -535,7 +535,7 @@ pub fn intrinsic_copiable_values(obj: &GameObject) -> CopiableValues {
             .then(|| crate::game::room::own_room_halves(obj)),
         // CR 707.9b exceptions are folded in by `compute_current_copiable_values`,
         // never by the printed form.
-        name_exception: false,
+        name_origin: Default::default(),
     }
 }
 
@@ -647,7 +647,7 @@ pub(crate) fn copiable_values_from_face(result_face: &CardFace) -> CopiableValue
         replacement_definitions: Arc::new(result_face.replacements.clone()),
         // A format-pool face is never a Room half pair.
         room_halves: None,
-        name_exception: false,
+        name_origin: Default::default(),
         static_definitions: Arc::new(result_face.static_abilities.clone()),
     }
 }
@@ -716,11 +716,11 @@ pub fn apply_copiable_values(
     // CR 709.5b + CR 707.2: carry the copied Room half data. Layer-derived —
     // the Step-1 seed clears it, so it expires with this copy effect.
     obj.copied_room_halves = values.room_halves.clone();
-    // CR 707.9b + CR 707.3: a chained copy of an exception-named copy keeps
-    // the exception as its final name — the snapshot folded it into `name`.
-    if values.name_exception {
-        obj.layer1_name_exception = true;
-    }
+    // CR 707.9b + CR 707.3 + CR 613.1a: EVERY applied copy assigns the name
+    // origin — a later ordinary copy therefore resets an earlier exception,
+    // and a chained copy of an exception-named copy keeps the folded
+    // exception as its final name.
+    obj.layer1_name_origin = Some(values.name_origin);
 }
 
 /// Materialize copiable values onto a newly constructed object (for example a
@@ -770,7 +770,7 @@ pub fn install_copiable_values_as_base(obj: &mut GameObject, values: &CopiableVa
         // provide door existence and unlock costs. Which HALF name such an
         // object would show per door is undefined by the CR; keeping X
         // wholesale is the conservative reading.
-        if !values.name_exception {
+        if values.name_origin != crate::types::ability::CopiedNameOrigin::Exception {
             obj.name = halves.left.name.clone();
             obj.base_name = halves.left.name.clone();
         }
@@ -786,6 +786,11 @@ pub fn install_copiable_values_as_base(obj: &mut GameObject, values: &CopiableVa
                 ..Default::default()
             });
     }
+    // CR 707.9b: a folded name EXCEPTION is part of the materialized base —
+    // the Step-1 seed restores the runtime marker from this every pass.
+    obj.base_name_origin = (values.name_origin
+        == crate::types::ability::CopiedNameOrigin::Exception)
+        .then_some(crate::types::ability::CopiedNameOrigin::Exception);
     obj.base_characteristics_initialized = true;
 }
 

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -523,6 +523,16 @@ pub fn intrinsic_copiable_values(obj: &GameObject) -> CopiableValues {
         trigger_definitions: Arc::clone(&obj.base_trigger_definitions),
         replacement_definitions: copiable_replacement_definitions(obj),
         static_definitions: Arc::clone(&obj.base_static_definitions),
+        // CR 709.5 + CR 709.5b: a Room's per-half identities are copiable —
+        // the door-stamped defs above carry both halves' TEXT, this carries
+        // both halves' names and costs. `None` for every non-Room source
+        // (the base types are this snapshot's own Room gate).
+        room_halves: obj
+            .base_card_types
+            .subtypes
+            .iter()
+            .any(|s| s == "Room")
+            .then(|| crate::game::room::own_room_halves(obj)),
     }
 }
 
@@ -632,6 +642,8 @@ pub(crate) fn copiable_values_from_face(result_face: &CardFace) -> CopiableValue
         abilities: Arc::new(result_face.abilities.clone()),
         trigger_definitions: Arc::new(result_face.triggers.clone()),
         replacement_definitions: Arc::new(result_face.replacements.clone()),
+        // A format-pool face is never a Room half pair.
+        room_halves: None,
         static_definitions: Arc::new(result_face.static_abilities.clone()),
     }
 }
@@ -697,6 +709,9 @@ pub fn apply_copiable_values(
         .collect();
     obj.replacement_definitions = Arc::clone(&values.replacement_definitions).into();
     obj.static_definitions = Arc::clone(&values.static_definitions).into();
+    // CR 709.5b + CR 707.2: carry the copied Room half data. Layer-derived —
+    // the Step-1 seed clears it, so it expires with this copy effect.
+    obj.copied_room_halves = values.room_halves.clone();
 }
 
 /// Materialize copiable values onto a newly constructed object (for example a

--- a/crates/engine/src/game/room.rs
+++ b/crates/engine/src/game/room.rs
@@ -99,6 +99,39 @@ pub(crate) fn door_text_functions(
     obj.room_unlocks.unwrap_or_default().is_unlocked(door)
 }
 
+/// CR 709.5: on the battlefield a locked half doesn't have its NAME. A Room
+/// permanent's name is therefore the printed-order combination of its
+/// unlocked halves — both → "Left // Right", one → that half alone, neither →
+/// no name at all (CR 709.5d: an uncast Room enters fully locked). `None` for
+/// every object the rule doesn't reach (not a Room, not on the battlefield):
+/// callers keep their ordinary base-name seed.
+///
+/// Printed order comes from `live_face_door`, not face residency: after a
+/// right-half cast the back-face slot holds the FIRST printed half, and that
+/// name still leads the combination.
+pub(crate) fn door_gated_battlefield_name(
+    obj: &crate::game::game_object::GameObject,
+) -> Option<String> {
+    if obj.zone != Zone::Battlefield || !obj.card_types.subtypes.iter().any(|s| s == "Room") {
+        return None;
+    }
+    let unlocks = obj.room_unlocks.unwrap_or_default();
+    // CR 709.5j: the other printed half lives on `back_face` — absent on a
+    // Room printed without a second half, whose only door is the left one.
+    let back_name = obj.back_face.as_ref().map(|back| back.name.as_str());
+    let (left_name, right_name) = match live_face_door(obj) {
+        RoomDoor::Left => (Some(obj.base_name.as_str()), back_name),
+        RoomDoor::Right => (back_name, Some(obj.base_name.as_str())),
+    };
+    let left = left_name.filter(|_| unlocks.is_unlocked(RoomDoor::Left));
+    let right = right_name.filter(|_| unlocks.is_unlocked(RoomDoor::Right));
+    Some(match (left, right) {
+        (Some(left), Some(right)) => format!("{left} // {right}"),
+        (Some(half), None) | (None, Some(half)) => half.to_string(),
+        (None, None) => String::new(),
+    })
+}
+
 /// CR 709.5j: A "door" is a half of a Room permanent. A Room has a left door
 /// always and a right door only if it has a back face (the second half of the
 /// split card). Returns the doors that actually exist for `object_id`.
@@ -189,6 +222,9 @@ pub fn unlock_door_designation(
             door,
             fully_unlocked: outcome.fully_unlocked,
         });
+        // CR 709.5 + CR 613: a gained designation changes the door-gated name,
+        // a layer-derived characteristic — re-derive (mirror of transform.rs).
+        crate::game::layers::mark_layers_full(state);
     }
     outcome.changed
 }
@@ -207,5 +243,11 @@ pub fn lock_door_designation(state: &mut GameState, object_id: ObjectId, door: R
     }
 
     let room_state = obj.room_unlocks.get_or_insert_with(Default::default);
-    room_state.lock(door)
+    let changed = room_state.lock(door);
+    if changed {
+        // CR 709.5g + CR 613: a lost designation changes the door-gated name —
+        // re-derive layered characteristics (mirror of `unlock_door_designation`).
+        crate::game::layers::mark_layers_full(state);
+    }
+    changed
 }

--- a/crates/engine/src/game/room.rs
+++ b/crates/engine/src/game/room.rs
@@ -99,33 +99,86 @@ pub(crate) fn door_text_functions(
     obj.room_unlocks.unwrap_or_default().is_unlocked(door)
 }
 
+/// CR 709.5b + CR 707.2: the halves the object's OWN printed form provides, in
+/// printed order. Engine representation: the live face's identity sits in the
+/// `base_*` fields and the other printed half in the `back_face` slot;
+/// `live_face_door` (the single orientation authority) maps the two slots back
+/// to printed order. Room-ness is the CALLER's gate — every consumer
+/// (`effective_room_halves` behind the handlers' live-type checks, and the
+/// copiable snapshot behind its own base-type check) verifies the object is a
+/// Room before asking; deriving unconditionally keeps this a pure projection.
+pub(crate) fn own_room_halves(
+    obj: &crate::game::game_object::GameObject,
+) -> crate::types::ability::RoomCopiableHalves {
+    use crate::types::ability::{RoomCopiableHalves, RoomHalfIdentity};
+    let live = RoomHalfIdentity {
+        name: obj.base_name.clone(),
+        mana_cost: obj.base_mana_cost.clone(),
+    };
+    let back = obj.back_face.as_ref().map(|back| RoomHalfIdentity {
+        name: back.name.clone(),
+        mana_cost: back.mana_cost.clone(),
+    });
+    match live_face_door(obj) {
+        RoomDoor::Left => RoomCopiableHalves {
+            left: live,
+            right: back,
+        },
+        RoomDoor::Right => match back {
+            Some(back) => RoomCopiableHalves {
+                left: back,
+                right: Some(live),
+            },
+            // A right-cast orientation implies a printed left half; fall back
+            // defensively to the live half alone rather than inventing one.
+            None => RoomCopiableHalves {
+                left: live,
+                right: None,
+            },
+        },
+    }
+}
+
+/// CR 707.2 + CR 613.1a: the halves the object EFFECTIVELY has — the copied
+/// snapshot when a Layer-1a copy effect applied one (set by
+/// `apply_copiable_values`, cleared by the Step-1 seed, so it expires with the
+/// copy), else the object's own printed halves. Single authority for every
+/// per-half question: the door-gated name, door unlock costs, and which doors
+/// exist.
+pub(crate) fn effective_room_halves(
+    obj: &crate::game::game_object::GameObject,
+) -> crate::types::ability::RoomCopiableHalves {
+    obj.copied_room_halves
+        .clone()
+        .unwrap_or_else(|| own_room_halves(obj))
+}
+
 /// CR 709.5: on the battlefield a locked half doesn't have its NAME. A Room
 /// permanent's name is therefore the printed-order combination of its
 /// unlocked halves — both → "Left // Right", one → that half alone, neither →
 /// no name at all (CR 709.5d: an uncast Room enters fully locked). `None` for
-/// every object the rule doesn't reach (not a Room, not on the battlefield):
-/// callers keep their ordinary base-name seed.
+/// every object the rule doesn't reach (not a Room by its CURRENT, post-copy
+/// card types; not on the battlefield): callers keep their layer-derived name.
 ///
-/// Printed order comes from `live_face_door`, not face residency: after a
-/// right-half cast the back-face slot holds the FIRST printed half, and that
-/// name still leads the combination.
+/// CR 707.2: the halves come from `effective_room_halves`, so a copy shows the
+/// COPIED halves through its own designations (designations are status,
+/// CR 709.5c — they are never copied and they survive copy expiry).
 pub(crate) fn door_gated_battlefield_name(
     obj: &crate::game::game_object::GameObject,
 ) -> Option<String> {
     if obj.zone != Zone::Battlefield || !obj.card_types.subtypes.iter().any(|s| s == "Room") {
         return None;
     }
+    let halves = effective_room_halves(obj);
     let unlocks = obj.room_unlocks.unwrap_or_default();
-    // Engine representation: the other printed half lives in the `back_face`
-    // slot — absent on a Room printed without a second half, whose only door
-    // is the left one (see `existing_doors`).
-    let back_name = obj.back_face.as_ref().map(|back| back.name.as_str());
-    let (left_name, right_name) = match live_face_door(obj) {
-        RoomDoor::Left => (Some(obj.base_name.as_str()), back_name),
-        RoomDoor::Right => (back_name, Some(obj.base_name.as_str())),
-    };
-    let left = left_name.filter(|_| unlocks.is_unlocked(RoomDoor::Left));
-    let right = right_name.filter(|_| unlocks.is_unlocked(RoomDoor::Right));
+    let left = unlocks
+        .is_unlocked(RoomDoor::Left)
+        .then_some(halves.left.name.as_str());
+    let right = halves
+        .right
+        .as_ref()
+        .filter(|_| unlocks.is_unlocked(RoomDoor::Right))
+        .map(|half| half.name.as_str());
     Some(match (left, right) {
         (Some(left), Some(right)) => format!("{left} // {right}"),
         (Some(half), None) | (None, Some(half)) => half.to_string(),
@@ -138,10 +191,16 @@ pub(crate) fn door_gated_battlefield_name(
 /// split card). Returns the doors that actually exist for `object_id`.
 fn existing_doors(state: &GameState, object_id: ObjectId) -> Vec<RoomDoor> {
     match state.objects.get(&object_id) {
-        // CR 709.5j: the right door is the back face's half — absent on a Room
-        // printed without a second half.
-        Some(obj) if obj.back_face.is_some() => vec![RoomDoor::Left, RoomDoor::Right],
-        Some(_) => vec![RoomDoor::Left],
+        // CR 709.5j + CR 707.2: the right door is the second half's — read from
+        // the EFFECTIVE halves so a copy of a two-halved Room has both doors
+        // and a copy of a single-halved Room only the left one.
+        Some(obj) => {
+            if effective_room_halves(obj).right.is_some() {
+                vec![RoomDoor::Left, RoomDoor::Right]
+            } else {
+                vec![RoomDoor::Left]
+            }
+        }
         None => Vec::new(),
     }
 }

--- a/crates/engine/src/game/room.rs
+++ b/crates/engine/src/game/room.rs
@@ -116,8 +116,9 @@ pub(crate) fn door_gated_battlefield_name(
         return None;
     }
     let unlocks = obj.room_unlocks.unwrap_or_default();
-    // CR 709.5j: the other printed half lives on `back_face` — absent on a
-    // Room printed without a second half, whose only door is the left one.
+    // Engine representation: the other printed half lives in the `back_face`
+    // slot — absent on a Room printed without a second half, whose only door
+    // is the left one (see `existing_doors`).
     let back_name = obj.back_face.as_ref().map(|back| back.name.as_str());
     let (left_name, right_name) = match live_face_door(obj) {
         RoomDoor::Left => (Some(obj.base_name.as_str()), back_name),

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -25529,6 +25529,11 @@ pub struct CopiableValues {
     /// serialized snapshots, via the serde default).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub room_halves: Option<RoomCopiableHalves>,
+    /// CR 707.9b: true when `name` carries a folded copy-effect name
+    /// EXCEPTION ("except its name is X") — a later copy of this copy keeps
+    /// X as its final name, and the Room door gate must not replace it.
+    #[serde(default)]
+    pub name_exception: bool,
 }
 
 /// CR 707.2b + CR 707.2c + CR 111.1: A copiable-values snapshot latched when an

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -25483,6 +25483,28 @@ impl ReplacementDefinition {
 
 /// What modification a continuous effect applies to an object.
 /// Each variant knows its own layer implicitly.
+/// CR 709.5b + CR 707.2: one printed Room half's copiable identity — the name
+/// and mana cost the half contributes while unlocked (CR 709.5) and the cost
+/// its door demands to unlock (CR 709.5e).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoomHalfIdentity {
+    pub name: String,
+    pub mana_cost: ManaCost,
+}
+
+/// CR 709.5 + CR 709.5b + CR 707.2: a Room's half data as a copiable value —
+/// both printed halves in PRINTED order (the right half is absent on a Room
+/// printed without a second half). CR 709.5 makes the unlocked-half behavior
+/// and which half a characteristic is in part of the copiable values; this
+/// carries the per-half identities so a copy can derive its door-gated name
+/// and door costs from the COPIED form.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct RoomCopiableHalves {
+    pub left: RoomHalfIdentity,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub right: Option<RoomHalfIdentity>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct CopiableValues {
     pub name: String,
@@ -25501,6 +25523,12 @@ pub struct CopiableValues {
     pub trigger_definitions: Arc<Vec<TriggerDefinition>>,
     pub replacement_definitions: Arc<Vec<ReplacementDefinition>>,
     pub static_definitions: Arc<Vec<StaticDefinition>>,
+    /// CR 709.5 + CR 709.5b: present iff the copied object is a Room — the
+    /// per-half identities a copy needs to derive its door-gated name and
+    /// door costs. `None` for every non-Room source (and in pre-existing
+    /// serialized snapshots, via the serde default).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub room_halves: Option<RoomCopiableHalves>,
 }
 
 /// CR 707.2b + CR 707.2c + CR 111.1: A copiable-values snapshot latched when an

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -25529,11 +25529,22 @@ pub struct CopiableValues {
     /// serialized snapshots, via the serde default).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub room_halves: Option<RoomCopiableHalves>,
-    /// CR 707.9b: true when `name` carries a folded copy-effect name
-    /// EXCEPTION ("except its name is X") — a later copy of this copy keeps
-    /// X as its final name, and the Room door gate must not replace it.
+    /// CR 707.9b: where `name` came from — a folded copy-effect name
+    /// EXCEPTION ("except its name is X") stays the copy's final name: a
+    /// later copy of this copy keeps X (CR 707.3), and the Room door gate
+    /// must not replace it.
     #[serde(default)]
-    pub name_exception: bool,
+    pub name_origin: CopiedNameOrigin,
+}
+
+/// CR 707.9b: where a copy's NAME characteristic came from — the copied
+/// source's copiable name, or an "except its name is X" exception rider.
+/// The exception is the copy's FINAL name.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+pub enum CopiedNameOrigin {
+    #[default]
+    Source,
+    Exception,
 }
 
 /// CR 707.2b + CR 707.2c + CR 111.1: A copiable-values snapshot latched when an

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -28409,7 +28409,7 @@ mod tests {
             replacement_definitions: std::sync::Arc::default(),
             static_definitions: std::sync::Arc::default(),
             room_halves: None,
-            name_exception: false,
+            name_origin: Default::default(),
         })
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -28409,6 +28409,7 @@ mod tests {
             replacement_definitions: std::sync::Arc::default(),
             static_definitions: std::sync::Arc::default(),
             room_halves: None,
+            name_exception: false,
         })
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -28408,6 +28408,7 @@ mod tests {
             trigger_definitions: std::sync::Arc::default(),
             replacement_definitions: std::sync::Arc::default(),
             static_definitions: std::sync::Arc::default(),
+            room_halves: None,
         })
     }
 

--- a/crates/engine/src/types/layers.rs
+++ b/crates/engine/src/types/layers.rs
@@ -303,6 +303,7 @@ mod tests {
                     replacement_definitions: Default::default(),
                     static_definitions: Default::default(),
                     room_halves: None,
+                    name_exception: false,
                 }),
                 display_source: crate::game::game_object::DisplaySource::Card,
                 printed_ref: None,

--- a/crates/engine/src/types/layers.rs
+++ b/crates/engine/src/types/layers.rs
@@ -303,7 +303,7 @@ mod tests {
                     replacement_definitions: Default::default(),
                     static_definitions: Default::default(),
                     room_halves: None,
-                    name_exception: false,
+                    name_origin: Default::default(),
                 }),
                 display_source: crate::game::game_object::DisplaySource::Card,
                 printed_ref: None,

--- a/crates/engine/src/types/layers.rs
+++ b/crates/engine/src/types/layers.rs
@@ -302,6 +302,7 @@ mod tests {
                     trigger_definitions: Default::default(),
                     replacement_definitions: Default::default(),
                     static_definitions: Default::default(),
+                    room_halves: None,
                 }),
                 display_source: crate::game::game_object::DisplaySource::Card,
                 printed_ref: None,

--- a/crates/engine/tests/integration/combo_infinite_pile.rs
+++ b/crates/engine/tests/integration/combo_infinite_pile.rs
@@ -1312,7 +1312,7 @@ fn real_4p_mana_and_token_boundary_drains_mana_and_still_collapses() {
         replacement_definitions: std::sync::Arc::default(),
         static_definitions: std::sync::Arc::default(),
         room_halves: None,
-        name_exception: false,
+        name_origin: Default::default(),
     });
     state.register_pending_materialization(P0, PersistentAxisMaterialization::Tokens(profile));
 

--- a/crates/engine/tests/integration/combo_infinite_pile.rs
+++ b/crates/engine/tests/integration/combo_infinite_pile.rs
@@ -1311,6 +1311,7 @@ fn real_4p_mana_and_token_boundary_drains_mana_and_still_collapses() {
         trigger_definitions: std::sync::Arc::default(),
         replacement_definitions: std::sync::Arc::default(),
         static_definitions: std::sync::Arc::default(),
+        room_halves: None,
     });
     state.register_pending_materialization(P0, PersistentAxisMaterialization::Tokens(profile));
 

--- a/crates/engine/tests/integration/combo_infinite_pile.rs
+++ b/crates/engine/tests/integration/combo_infinite_pile.rs
@@ -1312,6 +1312,7 @@ fn real_4p_mana_and_token_boundary_drains_mana_and_still_collapses() {
         replacement_definitions: std::sync::Arc::default(),
         static_definitions: std::sync::Arc::default(),
         room_halves: None,
+        name_exception: false,
     });
     state.register_pending_materialization(P0, PersistentAxisMaterialization::Tokens(profile));
 


### PR DESCRIPTION
Fixes #7564 — the last open remainder (triggers landed in #7567, statics in #7573; the activated-ability slot has no member in the pool).

CR 709.5: on the battlefield a locked half doesn't have its NAME. The name is now the printed-order combination of the unlocked halves — both → "Left // Right", one → that half alone, neither (CR 709.5d uncast entry) → no name at all; re-locking (CR 709.5g) takes a name away again. Single authority `room::door_gated_battlefield_name`, applied where the layer pass seeds `name`; both designation writers now mark layers dirty (mirror of `transform.rs`).

**Tests** (`engine_tests.rs`): the four-designation walk (uncast → left → both → re-lock left) and the swapped-orientation walk (right half cast — printed order must not follow face residency). Both read the name after plain `UnlockRoomDoor` actions with **no manual layer pass**, so the dirty-marking is load-bearing: with `mark_layers_full` removed from `unlock_door_designation`, both fail on stale names.

**Class:** 0 of 35,797 cards reference a Room half name via "named" — rules fidelity and display only, no gameplay filter changes.

**What the tests do not prove:** client rendering. Playtested live instead (left-first, right-first, fully unlocked, re-locked) — the shown name tracks the designations.

**Remaining gaps:** a copy of a Room keeps its copied face name (layer-1 copy writes after this seed) and an object holding two names matches "named X" only as the combined string — no card in the pool exercises either today. A **recast** Room still shows a concatenated name until #7568 lands: the stale per-cast face state (#7565) feeds this gate a full printed name as `base_name`; verified locally that combining this branch with #7568 resolves it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Room battlefield names now update based on unlocked door halves.
  - Copy effects correctly display copied Room halves and names while preserving door unlock status.
  - Materialized Room copies preserve both halves, unlock costs, and synthesized right faces.
  - Locking or unlocking doors refreshes displayed Room information immediately.
  - Chained Room copies preserve “except its name is…” name overrides.

- **Bug Fixes**
  - Corrected Room naming with no, one, or both doors unlocked.
  - Room names now clear correctly when all door halves are locked.
  - Unlock costs correctly reflect copied Room halves.
  - Multiple copy effects preserve previously copied Room data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->