### PR TITLE
docs(engine): record why the paused combat-damage batch's WaitingFor is boxed

### DIFF
--- a/crates/engine/src/game/combat_damage.rs
+++ b/crates/engine/src/game/combat_damage.rs
@@ -1516,6 +1516,9 @@ pub(crate) enum CombatDamageBatch {
     /// paused source's own `LifeGain` and is the resume's authority.
     Paused {
         events: Vec<GameEvent>,
+        /// Boxed: `WaitingFor` is ~1720 bytes against `Complete`'s 24, so an
+        /// inline field would make every `Complete` return pay the pause's size
+        /// (`clippy::large_enum_variant`).
         waiting_for: Box<WaitingFor>,
     },
 }


### PR DESCRIPTION
`CombatDamageBatch::Paused` already carries its `WaitingFor` boxed (landed
with the CR 616.1 lifelink resume in #7581). Nothing recorded the reason, so
the indirection reads as arbitrary and a future edit could unbox it.

State it at the field: `WaitingFor` is ~1720 bytes against `Complete`'s 24,
so an inline field makes every ordinary `Complete` return pay the pause's
stack size — `clippy::large_enum_variant`, which is `-D warnings` in CI.
Matches the boxing already used for `pending_combat_lifelink`.

Comment only; no code change.

Claude-Session: https://claude.ai/code/session_013eDt2CTWnim1rkaqh7uqF1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added internal documentation clarifying how paused combat damage state is stored for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->