### PR TITLE
fix(lobby): give the preview channel its own lobby broker

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -595,10 +595,87 @@ jobs:
       CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
       SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY: ${{ secrets.SERVER_ARTIFACT_MINISIGN_PRIVATE_KEY }}
 
+  # ── Preview lobby Worker ───────────────────────────────────────────────────
+  # The preview channel's matchmaking broker (wrangler.toml [env.preview] ->
+  # Worker `phase-lobby-preview`, wss://lobby-preview.phase-rs.dev/ws). Deployed
+  # on EVERY staging deploy, which is the whole point: production's lobby only
+  # redeploys at release, so `main` drifts ahead of it and the two accept-windows
+  # ([PROTOCOL_VERSION-1, PROTOCOL_VERSION] on each side) go disjoint after two
+  # bumps. Redeploying preview in lockstep with the preview client keeps that
+  # pair aligned by construction. Production's `phase-lobby` is untouched here.
+  deploy-lobby-preview:
+    name: Deploy Preview Lobby Worker (Cloudflare)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.DEPLOY_SHA }}
+
+      - uses: actions-rust-lang/setup-rust-toolchain@v1
+        with:
+          targets: wasm32-unknown-unknown
+          cache-shared-key: rust-wasm
+          # broker-wasm needs its .cargo/config.toml
+          # [target.wasm32-unknown-unknown] shadow-stack rustflags; an env
+          # RUSTFLAGS would override them.
+          rustflags: ""
+
+      - uses: taiki-e/install-action@v2
+        with:
+          # Must match the pinned wasm-bindgen crate version in
+          # lobby-worker/broker-wasm/Cargo.toml (schema versions must be exact).
+          tool: wasm-bindgen-cli@0.2.121
+
+      - name: Cache binaryen
+        id: binaryen-cache
+        uses: actions/cache@v4
+        with:
+          path: binaryen-version_123
+          key: binaryen-123-x86_64-linux
+
+      - name: Install binaryen
+        if: steps.binaryen-cache.outputs.cache-hit != 'true'
+        run: curl -L https://github.com/WebAssembly/binaryen/releases/download/version_123/binaryen-version_123-x86_64-linux.tar.gz | tar xz
+
+      - name: Add binaryen to PATH
+        run: echo "$PWD/binaryen-version_123/bin" >> "$GITHUB_PATH"
+
+      - name: Deploy preview lobby Worker
+        uses: cloudflare/wrangler-action@v4
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          wranglerVersion: "4.113.0"
+          workingDirectory: lobby-worker
+          command: deploy --env preview
+
+      - name: Assert the preview lobby advertises this commit's protocol version
+        # Guards the exact regression this job exists to prevent: a preview
+        # client that cannot handshake with the preview lobby. Compares the
+        # deployed Worker's advertised protocol_version against the constant in
+        # the tree being deployed.
+        run: |
+          set -euo pipefail
+          expected=$(grep -oE 'pub const PROTOCOL_VERSION: u32 = [0-9]+' \
+            crates/lobby-broker/src/protocol.rs | grep -oE '[0-9]+$')
+          for attempt in 1 2 3 4 5 6 7 8 9 10; do
+            actual=$(curl -sS -m 15 https://lobby-preview.phase-rs.dev/health \
+              | jq -r '.protocol_version // empty' || true)
+            if [ "$actual" = "$expected" ]; then
+              echo "Preview lobby advertises protocol_version=$actual (matches tree)."
+              exit 0
+            fi
+            echo "Attempt $attempt: got '${actual:-<none>}', want '$expected'; retrying..."
+            sleep 10
+          done
+          echo "::error::Preview lobby advertises '${actual:-<none>}' but this commit speaks '$expected'."
+          exit 1
+
   # ── Frontend + Pages deploy (needs published data + server artifact + WASM) ─
   build-pages:
     name: Build & Deploy Pages
-    needs: [preview-inputs, card-data, build-wasm, preview-server]
+    needs: [preview-inputs, card-data, build-wasm, preview-server, deploy-lobby-preview]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     permissions:
@@ -681,7 +758,23 @@ jobs:
           SUPABASE_ANON_KEY: ${{ secrets.SUPABASE_ANON_KEY }}
           # First-party telemetry ingest (lobby Worker → Analytics Engine, see
           # docs/telemetry-proposal.md). Unset would compile telemetry to a no-op.
-          TELEMETRY_URL: "https://lobby.phase-rs.dev/telemetry"
+          TELEMETRY_URL: "https://lobby-preview.phase-rs.dev/telemetry"
+          # Preview talks to its OWN lobby Worker (wrangler.toml [env.preview]).
+          # A single lobby cannot serve both channels: ServerHello is sent
+          # unprompted before ClientHello, so the broker advertises one protocol
+          # number blind, and each client only accepts
+          # [PROTOCOL_VERSION-1, PROTOCOL_VERSION] of its OWN build. Two bumps on
+          # main after a release makes those windows disjoint and one cohort is
+          # always locked out. Splitting the deployment is what keeps preview
+          # usable while release stays pinned to the last tag.
+          #
+          # This sets OFFICIAL, not DEFAULT. DEFAULT is the self-hoster seam, and
+          # serverDetection.ts reads DEFAULT !== OFFICIAL as "self-hosted build",
+          # which would label the preview lobby "Self-hosted" AND offer an
+          # "Official" row pointing at the production lobby this build cannot
+          # handshake with. Setting OFFICIAL keeps DEFAULT === OFFICIAL, so the
+          # picker shows exactly one correct official entry.
+          OFFICIAL_MULTIPLAYER_SERVER_URL: "wss://lobby-preview.phase-rs.dev/ws"
         run: |
           cd client
           pnpm install --frozen-lockfile

--- a/client/src/config/__tests__/multiplayerServerUrls.test.ts
+++ b/client/src/config/__tests__/multiplayerServerUrls.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  PRODUCTION_MULTIPLAYER_SERVER_URL,
+  resolveMultiplayerServerUrls,
+} from "../multiplayerServerUrls";
+
+const PREVIEW = "wss://lobby-preview.phase-rs.dev/ws";
+const SELF_HOSTED = "wss://play.example.com/ws";
+
+/** Build an env reader from a plain map; unset names read as "" like
+ * vite.config.ts's own `envVar` does. */
+const env = (vars: Record<string, string>) => (name: string) => vars[name] ?? "";
+
+describe("resolveMultiplayerServerUrls", () => {
+  it("falls back to production when nothing is set (release build)", () => {
+    expect(resolveMultiplayerServerUrls(env({}))).toEqual({
+      official: PRODUCTION_MULTIPLAYER_SERVER_URL,
+      buildDefault: PRODUCTION_MULTIPLAYER_SERVER_URL,
+    });
+  });
+
+  // The regression guard. Setting OFFICIAL alone must ALSO move buildDefault:
+  // serverDetection reads `buildDefault !== official` as "self-hosted build",
+  // so leaving buildDefault on production would prepend a self-hosted preset
+  // and make the production lobby SERVER_PRESETS[0] — the default pick — for
+  // every preview user, which is the one broker a preview build cannot
+  // handshake with.
+  it("moves the build default with the official url (preview build)", () => {
+    const resolved = resolveMultiplayerServerUrls(
+      env({ OFFICIAL_MULTIPLAYER_SERVER_URL: PREVIEW }),
+    );
+    expect(resolved.official).toBe(PREVIEW);
+    expect(resolved.buildDefault).toBe(PREVIEW);
+    expect(resolved.buildDefault).not.toBe(PRODUCTION_MULTIPLAYER_SERVER_URL);
+  });
+
+  it("keeps the self-hoster seam: DEFAULT alone diverges from official", () => {
+    expect(
+      resolveMultiplayerServerUrls(env({ DEFAULT_MULTIPLAYER_SERVER_URL: SELF_HOSTED })),
+    ).toEqual({
+      official: PRODUCTION_MULTIPLAYER_SERVER_URL,
+      buildDefault: SELF_HOSTED,
+    });
+  });
+
+  it("lets an explicit DEFAULT win over the official url when both are set", () => {
+    expect(
+      resolveMultiplayerServerUrls(
+        env({
+          OFFICIAL_MULTIPLAYER_SERVER_URL: PREVIEW,
+          DEFAULT_MULTIPLAYER_SERVER_URL: SELF_HOSTED,
+        }),
+      ),
+    ).toEqual({ official: PREVIEW, buildDefault: SELF_HOSTED });
+  });
+
+  it("treats an empty string as unset", () => {
+    expect(
+      resolveMultiplayerServerUrls(
+        env({
+          OFFICIAL_MULTIPLAYER_SERVER_URL: "",
+          DEFAULT_MULTIPLAYER_SERVER_URL: "",
+        }),
+      ),
+    ).toEqual({
+      official: PRODUCTION_MULTIPLAYER_SERVER_URL,
+      buildDefault: PRODUCTION_MULTIPLAYER_SERVER_URL,
+    });
+  });
+});

--- a/client/src/config/multiplayerServer.ts
+++ b/client/src/config/multiplayerServer.ts
@@ -1,8 +1,27 @@
-export const OFFICIAL_MULTIPLAYER_SERVER_URL = "wss://lobby.phase-rs.dev/ws";
+/**
+ * The official lobby broker for THIS build's release channel.
+ *
+ * Channel-scoped rather than a single fixed address: the lobby advertises one
+ * protocol version blind (it sends `ServerHello` before the client's
+ * `ClientHello`), and a client only accepts a lobby within
+ * `[PROTOCOL_VERSION - 1, PROTOCOL_VERSION]` of its OWN build. Production's
+ * Worker redeploys only at release while preview rebuilds from `main`, so once
+ * `main` is two protocol bumps past the last tag those windows are disjoint and
+ * a single shared lobby must lock one channel out. Each channel therefore
+ * points at its own broker; `deploy.yml` sets this to the preview lobby.
+ *
+ * Defaults to the production lobby, so release and self-hosted builds are
+ * unchanged.
+ */
+export const OFFICIAL_MULTIPLAYER_SERVER_URL = __OFFICIAL_MULTIPLAYER_SERVER_URL__;
 export const DEFAULT_MULTIPLAYER_SERVER_URL = __DEFAULT_MULTIPLAYER_SERVER_URL__;
 
+/** Hosts we operate. Every channel's broker belongs here — `isOfficial…` gates
+ * the persisted-address migration, which treats an address on any of these as a
+ * deployment default rather than user intent. */
 const OFFICIAL_MULTIPLAYER_SERVER_HOSTS = new Set([
   "lobby.phase-rs.dev",
+  "lobby-preview.phase-rs.dev",
   "us.phase-rs.dev",
 ]);
 

--- a/client/src/config/multiplayerServerUrls.ts
+++ b/client/src/config/multiplayerServerUrls.ts
@@ -1,0 +1,42 @@
+// Build-time resolution of the two multiplayer-server URLs. Imported by
+// vite.config.ts AND vitest.config.ts so the resolution ORDER has one authority
+// — it is subtle enough that duplicating it produced a real defect (see below),
+// and a config file cannot import the define-consuming module it feeds.
+//
+// Deliberately define-free: this runs in the Node config context, where
+// `__DEFAULT_MULTIPLAYER_SERVER_URL__` and friends do not exist yet.
+
+/** Fallback for both URLs. Keeps release and self-hosted builds unchanged. */
+export const PRODUCTION_MULTIPLAYER_SERVER_URL = "wss://lobby.phase-rs.dev/ws";
+
+export interface MultiplayerServerUrls {
+  /** This channel's official broker. */
+  official: string;
+  /** What the bundle connects to by default. */
+  buildDefault: string;
+}
+
+/**
+ * Resolve both URLs from the build environment.
+ *
+ * `buildDefault` falls back to the RESOLVED `official`, never to
+ * {@link PRODUCTION_MULTIPLAYER_SERVER_URL} directly. That distinction is
+ * load-bearing: `serverDetection.ts` reads `buildDefault !== official` as "this
+ * is a self-hosted build" and prepends a self-hosted preset, which becomes
+ * `SERVER_PRESETS[0]` and therefore `DEFAULT_SERVER`. Chaining the fallback to
+ * the production constant would leave a preview build with
+ * `official` = preview but `buildDefault` = production, so the DEFAULT PICK
+ * would be the one broker that build cannot handshake with.
+ *
+ * @param readEnv returns "" or undefined for an unset variable.
+ */
+export function resolveMultiplayerServerUrls(
+  readEnv: (name: string) => string | undefined,
+): MultiplayerServerUrls {
+  const official =
+    readEnv("OFFICIAL_MULTIPLAYER_SERVER_URL") || PRODUCTION_MULTIPLAYER_SERVER_URL;
+  return {
+    official,
+    buildDefault: readEnv("DEFAULT_MULTIPLAYER_SERVER_URL") || official,
+  };
+}

--- a/client/src/services/__tests__/serverDetection.test.ts
+++ b/client/src/services/__tests__/serverDetection.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it } from "vitest";
 import {
   DEFAULT_MULTIPLAYER_SERVER_URL,
   OFFICIAL_MULTIPLAYER_SERVER_URL,
+  isOfficialMultiplayerServerUrl,
 } from "../../config/multiplayerServer";
 import {
   DEFAULT_SERVER,
@@ -24,6 +25,33 @@ describe("server defaults", () => {
         }),
       ]),
     );
+  });
+});
+
+describe("official server hosts", () => {
+  // Each release channel gets its own broker; both are ours, so both must read
+  // as official — that is what lets the persisted-address migration repoint a
+  // returning browser onto its own channel's lobby.
+  it("recognises every channel's lobby as official", () => {
+    expect(isOfficialMultiplayerServerUrl("wss://lobby.phase-rs.dev/ws")).toBe(true);
+    expect(isOfficialMultiplayerServerUrl("wss://lobby-preview.phase-rs.dev/ws")).toBe(
+      true,
+    );
+    expect(isOfficialMultiplayerServerUrl("wss://us.phase-rs.dev/ws")).toBe(true);
+  });
+
+  it("does not treat a self-hosted address as official", () => {
+    expect(isOfficialMultiplayerServerUrl("wss://play.example.com/ws")).toBe(false);
+    expect(isOfficialMultiplayerServerUrl("not a url")).toBe(false);
+  });
+
+  // A build whose default IS its official broker must not advertise a
+  // "self-hosted" preset — that row would otherwise become SERVER_PRESETS[0].
+  it("offers no self-hosted preset when the default is the official broker", () => {
+    if (DEFAULT_MULTIPLAYER_SERVER_URL !== OFFICIAL_MULTIPLAYER_SERVER_URL) return;
+    expect(SERVER_PRESETS).toHaveLength(1);
+    expect(SERVER_PRESETS[0].labelKey).toBe("serverPicker.official");
+    expect(DEFAULT_SERVER).toBe(OFFICIAL_MULTIPLAYER_SERVER_URL);
   });
 });
 

--- a/client/src/stores/__tests__/multiplayerStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerStore.test.ts
@@ -31,10 +31,12 @@ import {
   FORMAT_DEFAULTS,
   isServerCompatible,
   migrateOfficialServerAddress,
+  migratePersistedMultiplayerState,
   type HostingSettings,
   useMultiplayerStore,
 } from "../multiplayerStore";
 import { PROTOCOL_VERSION, type ServerInfo } from "../../adapter/ws-adapter";
+import { DEFAULT_MULTIPLAYER_SERVER_URL } from "../../config/multiplayerServer";
 import {
   clearWsSession,
   loadWsSession,
@@ -248,6 +250,52 @@ describe("multiplayerStore", () => {
         "wss://selfhost.example/ws",
       ),
     ).toBe("wss://play.example.com/ws");
+  });
+
+  // Every channel's broker is an official host. A returning preview browser
+  // holds a persisted PRODUCTION address, and detectServerUrl honours any
+  // stored address whose /health answers — production's does — so without this
+  // it stays pinned to a lobby its build cannot handshake with.
+  it("migrates the other channel's official lobby to this build's default", () => {
+    expect(
+      migrateOfficialServerAddress(
+        "wss://lobby.phase-rs.dev/ws",
+        "wss://lobby-preview.phase-rs.dev/ws",
+      ),
+    ).toBe("wss://lobby-preview.phase-rs.dev/ws");
+    expect(
+      migrateOfficialServerAddress(
+        "wss://lobby-preview.phase-rs.dev/ws",
+        "wss://lobby.phase-rs.dev/ws",
+      ),
+    ).toBe("wss://lobby.phase-rs.dev/ws");
+  });
+
+  it("re-runs the official-address migration for v2 stores (v2 -> v3)", () => {
+    expect(
+      migratePersistedMultiplayerState(
+        { serverAddress: "wss://lobby.phase-rs.dev/ws" },
+        2,
+      ),
+    ).toEqual({ serverAddress: DEFAULT_MULTIPLAYER_SERVER_URL });
+  });
+
+  it("leaves a user-typed address alone across the v3 migration", () => {
+    expect(
+      migratePersistedMultiplayerState(
+        { serverAddress: "wss://play.example.com/ws" },
+        2,
+      ),
+    ).toEqual({ serverAddress: "wss://play.example.com/ws" });
+  });
+
+  it("does not re-migrate a store already at v3", () => {
+    expect(
+      migratePersistedMultiplayerState(
+        { serverAddress: "wss://lobby.phase-rs.dev/ws" },
+        3,
+      ),
+    ).toEqual({ serverAddress: "wss://lobby.phase-rs.dev/ws" });
   });
 
   it("strips AI seats from team-based server host settings", async () => {

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -525,7 +525,7 @@ export function migratePersistedMultiplayerState(
 ): unknown {
   if (!persisted || typeof persisted !== "object") return persisted;
   const migrated = persisted as Record<string, unknown>;
-  if (version < 2) {
+  if (version < 3) {
     migrated.serverAddress = migrateOfficialServerAddress(
       migrated.serverAddress,
       DEFAULT_MULTIPLAYER_SERVER_URL,
@@ -1471,11 +1471,19 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
     }),
     {
       name: "phase-multiplayer",
-      version: 2,
+      version: 3,
       // v0/v1 → v2: official hosted lobby addresses are deployment defaults,
       // not user intent. A self-hosted build must move returning browsers from
       // the official lobby to its configured default while preserving explicit
       // custom/self-hosted addresses.
+      //
+      // v2 → v3: same rule, re-applied because the official set now spans a
+      // broker PER RELEASE CHANNEL. Without this bump a returning preview
+      // browser keeps its persisted production address, and detectServerUrl
+      // honours any stored address whose /health answers — production's does —
+      // so it would silently stay pinned to a lobby its build cannot handshake
+      // with. Re-running the same migration repoints it at this channel's
+      // broker; a user-typed non-official address is still preserved.
       migrate: migratePersistedMultiplayerState,
       partialize: (state) => ({
         playerId: state.playerId,

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -5,6 +5,7 @@ declare const __APP_VERSION__: string;
 declare const __BUILD_HASH__: string;
 declare const __ENGINE_FINGERPRINT__: string | undefined;
 declare const __ENGINE_WASM_URL__: string | undefined;
+declare const __OFFICIAL_MULTIPLAYER_SERVER_URL__: string;
 declare const __DEFAULT_MULTIPLAYER_SERVER_URL__: string;
 declare const __CARD_DATA_URL__: string;
 declare const __CARD_DATA_LOCALE_URL_TEMPLATE__: string;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -7,9 +7,10 @@ import tailwindcss from "@tailwindcss/vite";
 import wasm from "vite-plugin-wasm";
 import { VitePWA } from "vite-plugin-pwa";
 import { compression } from "vite-plugin-compression2";
+import { resolveMultiplayerServerUrls } from "./src/config/multiplayerServerUrls";
 import type { Plugin } from "vite";
 
-const OFFICIAL_MULTIPLAYER_SERVER_URL = "wss://lobby.phase-rs.dev/ws";
+
 
 // wasm-bindgen emits `import * as importN from "env"` for WASM host-environment
 // imports (LLVM intrinsics). These are provided at instantiation time by the JS
@@ -129,6 +130,7 @@ function dataFileDefines(mode: string): Record<string, string> {
   const envVar = (name: string): string =>
     process.env[name] ?? fileEnv[name] ?? "";
   const base = process.env.DATA_BASE_URL || "";
+  const multiplayerServers = resolveMultiplayerServerUrls(envVar);
   const defines: Record<string, string> = {
     __APP_VERSION__: JSON.stringify(workspaceVersion()),
     __BUILD_HASH__: JSON.stringify(gitHash()),
@@ -148,9 +150,16 @@ function dataFileDefines(mode: string): Record<string, string> {
     __GIT_REPO_URL__: JSON.stringify("https://github.com/phase-rs/phase"),
     __PREVIEW_SITE_URL__: JSON.stringify("https://preview.phase-rs.dev"),
     __RELEASE_SITE_URL__: JSON.stringify("https://phase-rs.dev"),
-    __DEFAULT_MULTIPLAYER_SERVER_URL__: JSON.stringify(
-      envVar("DEFAULT_MULTIPLAYER_SERVER_URL") || OFFICIAL_MULTIPLAYER_SERVER_URL,
-    ),
+    // Channel-scoped official lobby (deploy.yml points preview at its own
+    // broker). DEFAULT falls back to the RESOLVED official value, not the
+    // hardcoded constant — chaining to the constant would leave DEFAULT on
+    // production while OFFICIAL moved to preview, and serverDetection.ts keys
+    // "is this a self-hosted build?" off DEFAULT !== OFFICIAL. That mismatch
+    // would prepend a bogus self-hosted preset holding the production URL and
+    // make it SERVER_PRESETS[0] — i.e. the default pick would become the one
+    // lobby a preview client cannot handshake with.
+    __OFFICIAL_MULTIPLAYER_SERVER_URL__: JSON.stringify(multiplayerServers.official),
+    __DEFAULT_MULTIPLAYER_SERVER_URL__: JSON.stringify(multiplayerServers.buildDefault),
     // True only for tagged production releases (release.yml sets RELEASE_BUILD).
     // The staging deploy (deploy.yml) is also a production Vite build, so we
     // cannot key off import.meta.env.PROD — that would surface the "try the

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -1,6 +1,9 @@
 import path from "node:path";
 import type { Plugin } from "vite";
 import { defineConfig } from "vitest/config";
+import { resolveMultiplayerServerUrls } from "./src/config/multiplayerServerUrls";
+
+const multiplayerServers = resolveMultiplayerServerUrls((name) => process.env[name]);
 
 /**
  * Resolves the @wasm/* aliases to the real WASM build artifacts when present,
@@ -51,9 +54,9 @@ export default defineConfig({
     __APP_VERSION__: JSON.stringify("0.0.0-test"),
     __BUILD_HASH__: JSON.stringify("testhash"),
     __ENGINE_WASM_URL__: "undefined",
-    __DEFAULT_MULTIPLAYER_SERVER_URL__: JSON.stringify(
-      process.env.DEFAULT_MULTIPLAYER_SERVER_URL || "wss://lobby.phase-rs.dev/ws",
-    ),
+    // Same resolver vite.config.ts uses — the order is single-authority.
+    __OFFICIAL_MULTIPLAYER_SERVER_URL__: JSON.stringify(multiplayerServers.official),
+    __DEFAULT_MULTIPLAYER_SERVER_URL__: JSON.stringify(multiplayerServers.buildDefault),
     __GIT_REPO_URL__: JSON.stringify("https://github.com/phase-rs/phase"),
     __PREVIEW_SITE_URL__: JSON.stringify("https://preview.phase-rs.dev"),
     __RELEASE_SITE_URL__: JSON.stringify("https://phase-rs.dev"),

--- a/lobby-worker/wrangler.toml
+++ b/lobby-worker/wrangler.toml
@@ -116,3 +116,59 @@ ALLOWED_ORIGINS = "*"
 # [[routes]]
 # pattern = "lobby.phase-rs.dev"
 # custom_domain = true
+
+# ── Preview environment ────────────────────────────────────────────────────
+# A SECOND Worker script (`phase-lobby-preview`) with its own Durable Object
+# namespace, deployed from `main` on every staging deploy. It exists because one
+# lobby physically cannot serve two client channels:
+#
+#   `ServerHello` is sent unprompted on connect (lobby-do.ts), BEFORE the client
+#   sends `ClientHello` — see the `ws.onopen` comment in
+#   client/src/services/openPhaseSocket.ts. The server therefore advertises one
+#   protocol number, blind, to every caller. A released client accepts
+#   [PROTOCOL_VERSION-1, PROTOCOL_VERSION] of ITS OWN build; once `main` is two
+#   bumps ahead of the last release those two windows are disjoint and no single
+#   advertised number satisfies both. Splitting the deployment is the only fix
+#   that does not evict one channel to serve the other.
+#
+# Non-inheritable keys (vars, durable_objects, migrations, observability,
+# analytics_engine_datasets) MUST be restated here — Wrangler does not inherit
+# them into a named environment. `main` and [build] are inherited.
+[env.preview]
+name = "phase-lobby-preview"
+
+[[env.preview.durable_objects.bindings]]
+name = "LOBBY"
+class_name = "LobbyDO"
+
+# Independent DO namespace from production: the preview lobby lists preview
+# rooms only. Tag numbering is per-script, so this is also "v1".
+[[env.preview.migrations]]
+tag = "v1"
+new_sqlite_classes = ["LobbyDO"]
+
+[env.preview.observability]
+enabled = true
+head_sampling_rate = 1
+
+[env.preview.observability.logs]
+invocation_logs = false
+
+# Separate dataset so preview traffic never pollutes production telemetry.
+[[env.preview.analytics_engine_datasets]]
+binding = "TELEMETRY"
+dataset = "phase_telemetry_preview"
+
+[env.preview.vars]
+TURN_KEY_ID = "97c7984d6c155084f9d0fdf8090e02f8"
+TURN_TTL_SECONDS = "86400"
+ALLOWED_ORIGINS = "*"
+
+# Stable hostname for the preview channel. `custom_domain = true` makes Workers
+# provision the DNS record AND the TLS cert in the phase-rs.dev zone (already in
+# this Cloudflare account), so no manual CNAME is required. The preview client
+# build sets DEFAULT_MULTIPLAYER_SERVER_URL to wss://lobby-preview.phase-rs.dev/ws
+# — see the "Build frontend" step in .github/workflows/deploy.yml.
+[[env.preview.routes]]
+pattern = "lobby-preview.phase-rs.dev"
+custom_domain = true


### PR DESCRIPTION
The lobby advertises one protocol version blind — `ServerHello` is sent
unprompted on connect, before the client's `ClientHello` — and a client
accepts a lobby only within `[PROTOCOL_VERSION - 1, PROTOCOL_VERSION]` of
its OWN build. `PROTOCOL_VERSION` is shared with the full-game protocol, so
a `GameState` change the lobby never parses still slides that window.

Production's Worker redeploys only at release while preview rebuilds from
main, so main drifted two bumps past v0.59.0 (31 -> 33) and preview clients
began rejecting the live lobby outright. With shipped bundles hardcoding
their own windows, no single advertised number satisfies both cohorts:
release accepts [30,31], preview accepts [32,33]. Splitting the deployment
is the only fix that does not evict one channel to serve the other.

- wrangler.toml gains `[env.preview]` -> Worker `phase-lobby-preview` with
  its own DO namespace, telemetry dataset, and custom domain.
- deploy.yml redeploys that Worker on every staging deploy — the drift can
  only recur if the lobby and the client it serves fall out of lockstep —
  and asserts the deployed Worker advertises this tree's protocol version.
- `OFFICIAL_MULTIPLAYER_SERVER_URL` becomes a channel-scoped build define.
  deploy.yml sets OFFICIAL, not DEFAULT: `serverDetection` reads
  `DEFAULT !== OFFICIAL` as "self-hosted build", so setting DEFAULT would
  label the preview lobby "Self-hosted" and offer an "Official" row pointing
  at a lobby the build cannot handshake with. The resolution order is
  extracted to one module shared by vite and vitest config, because the
  DEFAULT fallback must chain to the RESOLVED official value — chaining it
  to the production constant instead makes the production lobby
  `SERVER_PRESETS[0]`, i.e. the default pick, for every preview user.
- persist version 2 -> 3 re-runs the official-address migration. Returning
  browsers hold a persisted production address and `detectServerUrl` honours
  any stored address whose `/health` answers — production's does — so
  without the bump the fix is silently inert for existing users.

Release and self-hosted builds are unchanged: every define bottoms out at
the production lobby.

Claude-Session: https://claude.ai/code/session_01W8FAcQ2gpCP7RNZnvtfe4B


---

## Deployment state

The companion Cloudflare Worker is **already deployed and live** — this PR is the client half.

| | protocol | status |
|---|---|---|
| `wss://lobby-preview.phase-rs.dev/ws` (`phase-lobby-preview`) | **33** | live, handshake-verified (`ServerHello` + `LobbyUpdate`) |
| `wss://lobby.phase-rs.dev/ws` (`phase-lobby`) | **31** | **deliberately untouched** — release cohort unaffected |

Production is intentionally left on 31. Shipped bundles hardcode their own accept-window, so release accepts `[30,31]` and preview accepts `[32,33]` — disjoint. Repointing production would fix preview by breaking every released user; splitting the deployment is the only option that breaks neither.

Once this lands, `deploy.yml` rebuilds the preview client against the preview lobby and the new `deploy-lobby-preview` job keeps the two in lockstep on every staging deploy.

## Verification

- `pnpm type-check` (incl. `protocol:check`) — clean
- `pnpm lint` — 0 errors (32 pre-existing warnings, none in changed files)
- full client vitest — **315 files / 2994 tests, 0 failures**
- revert-to-red on the `O1` guard: re-chaining the DEFAULT fallback to the production constant fails exactly one test (`moves the build default with the official url`) while the other four pass, confirming it discriminates rather than blanket-breaking
- the workflow's protocol assertion verified end-to-end: extracts `33` from the tree, live lobby reports `33`

## Out of scope

Protocol-version *semantics* — a lobby-owned version constant, and dropping the upper bound on the lobby handshake path so a newer client can always talk to an older lobby. That's the durable fix for the underlying churn and wants its own PR.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated preview multiplayer lobby with separate rooms and telemetry.
  * Preview builds now connect to the preview lobby and telemetry endpoints.
  * Multiplayer server configuration now adapts automatically to the deployment channel.
  * Official preview servers are recognized and shown correctly.

* **Bug Fixes**
  * Improved migration of saved multiplayer settings when switching between production and preview builds.
  * Preserved custom server addresses during settings migrations.

* **Tests**
  * Added coverage for server URL resolution, official server detection, and saved-state migrations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->