### PR TITLE
fix(lobby): stop declaring the preview custom domain in wrangler config

### DIFF
--- a/lobby-worker/wrangler.toml
+++ b/lobby-worker/wrangler.toml
@@ -164,11 +164,17 @@ TURN_KEY_ID = "97c7984d6c155084f9d0fdf8090e02f8"
 TURN_TTL_SECONDS = "86400"
 ALLOWED_ORIGINS = "*"
 
-# Stable hostname for the preview channel. `custom_domain = true` makes Workers
-# provision the DNS record AND the TLS cert in the phase-rs.dev zone (already in
-# this Cloudflare account), so no manual CNAME is required. The preview client
-# build sets DEFAULT_MULTIPLAYER_SERVER_URL to wss://lobby-preview.phase-rs.dev/ws
-# — see the "Build frontend" step in .github/workflows/deploy.yml.
-[[env.preview.routes]]
-pattern = "lobby-preview.phase-rs.dev"
-custom_domain = true
+# Stable hostname: lobby-preview.phase-rs.dev, already attached to this Worker
+# as a Cloudflare custom domain (DNS record + TLS cert auto-provisioned in the
+# phase-rs.dev zone). The preview client build points at
+# wss://lobby-preview.phase-rs.dev/ws — see the "Build frontend" step in
+# .github/workflows/deploy.yml.
+#
+# Deliberately NOT declared as a [[routes]] entry, matching the production
+# stanza above. Declaring it makes wrangler reconcile routes on every deploy,
+# which calls GET /zones/<id>/workers/routes — and the CI CLOUDFLARE_API_TOKEN
+# lacks the zone-level Workers Routes permission, so the deploy dies with
+# "Authentication error [code: 10000]" AFTER a ~7 minute wasm build. A custom
+# domain is a Cloudflare-side binding that persists across deploys on its own,
+# so omitting it here costs nothing and keeps CI deployable with the token it
+# has. Attach any future channel's domain out-of-band the same way.


### PR DESCRIPTION
Declaring `[[env.preview.routes]]` makes wrangler reconcile routes on every
deploy, which calls `GET /zones/<id>/workers/routes`. The CI
CLOUDFLARE_API_TOKEN has no zone-level Workers Routes permission, so the
staging deploy died with "Authentication error [code: 10000]" — and did so
only AFTER the ~7 minute wasm build, taking `build-pages` down with it
(it `needs:` this job), so the preview client was never repointed.

The production stanza already encodes the right pattern: its `[[routes]]`
block is commented out and `lobby.phase-rs.dev` serves it regardless. A
custom domain is a Cloudflare-side binding that persists across deploys on
its own. Verified by deploying `phase-lobby-preview` without the stanza:
`lobby-preview.phase-rs.dev` still resolves, still answers `/health` with
protocol_version 33, and still completes the WebSocket handshake.

The alternative fix is granting the CI token Zone -> Workers Routes, which
needs a dashboard change; matching the existing convention needs nothing.

Claude-Session: https://claude.ai/code/session_01W8FAcQ2gpCP7RNZnvtfe4B


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved preview deployment configuration to preserve the custom preview domain.
  * Prevented deployments from unintentionally modifying the domain’s external Cloudflare association.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->