### PR TITLE
fix(engine,parser): gate "this way" riders on the parent's actual outcome (#7598)

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -6445,7 +6445,12 @@ fn rw_ability_condition(x: &AbilityCondition) -> RwProfile {
         AbilityCondition::ScopedPlayerMatches { filter } => rw_player_filter(filter),
         AbilityCondition::TriggeringSpellTargetsFilter { filter: _ }
         | AbilityCondition::ZoneChangeObjectMatchesFilter { .. }
-        | AbilityCondition::ZoneChangedThisWay { filter: _ }
+        // `destination` reads the moved object's CURRENT zone — the same
+        // event-live read bucket as the ledger lookup itself.
+        | AbilityCondition::ZoneChangedThisWay {
+            filter: _,
+            destination: _,
+        }
         // CR 615.5: reads the prevented event's live damage-source object.
         | AbilityCondition::PostReplacementDamageSourceMatchesFilter { filter: _ }
         | AbilityCondition::CostPaidObjectMatchesFilter { filter: _ } => reads_event_live(),

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -2888,7 +2888,12 @@ fn scan_ability_condition(x: &AbilityCondition, mode: ScanMode) -> Axes {
             sibling: false,
             projected: true,
         },
-        AbilityCondition::ZoneChangedThisWay { filter } => {
+        // `destination` refines the same event-ledger read (the moved object's
+        // current zone) — no new axis beyond the `event: true` already set.
+        AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: _,
+        } => {
             let mut acc = Axes {
                 event: true,
                 sibling: false,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -4215,9 +4215,13 @@ fn fmt_ability_condition(cond: &AbilityCondition) -> String {
         AbilityCondition::FirstCombatPhaseOfTurn => "first combat phase of the turn".into(),
         AbilityCondition::FirstEndStepOfTurn => "first end step of the turn".into(),
         AbilityCondition::CurrentPhaseIs { .. } => "current phase matches".into(),
-        AbilityCondition::ZoneChangedThisWay { filter } => {
-            format!("{} changed zones this way", fmt_target(filter))
-        }
+        AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination,
+        } => match destination {
+            Some(zone) => format!("{} was put into {zone:?} this way", fmt_target(filter)),
+            None => format!("{} changed zones this way", fmt_target(filter)),
+        },
         AbilityCondition::CostPaidObjectMatchesFilter { filter } => {
             format!("cost-paid object is {}", fmt_target(filter))
         }
@@ -15500,6 +15504,7 @@ mod tests {
             (
                 AbilityCondition::ZoneChangedThisWay {
                     filter: TargetFilter::Any,
+                    destination: None,
                 },
                 "ZoneChangedThisWay",
             ),

--- a/crates/engine/src/game/effects/mill.rs
+++ b/crates/engine/src/game/effects/mill.rs
@@ -745,6 +745,7 @@ mod tests {
             );
             gain.condition = Some(AbilityCondition::ZoneChangedThisWay {
                 filter: TF::Typed(TypedFilter::new(TypeFilter::Subtype("Angel".to_string()))),
+                destination: None,
             });
             gain
         })

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -14890,6 +14890,39 @@ mod tests {
         .condition(AbilityCondition::WhenYouDo)
     }
 
+    /// CR 608.2c + CR 614.6: a destination-bound "this way" rider must not
+    /// see an object whose move was redirected away from its named arrival.
+    #[test]
+    fn zone_changed_this_way_requires_named_destination() {
+        let mut state = GameState::new_two_player(42);
+        let object = reflexive_test_creature(&mut state, PlayerId(0), "Test Creature");
+        state.last_zone_changed_ids = vec![object];
+        let ability = ResolvedAbility::new(
+            Effect::LoseLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+                target: None,
+            },
+            Vec::new(),
+            ObjectId(100),
+            PlayerId(0),
+        );
+        let condition = AbilityCondition::ZoneChangedThisWay {
+            filter: TargetFilter::Typed(TypedFilter::creature()),
+            destination: Some(Zone::Graveyard),
+        };
+
+        assert!(
+            !evaluate_condition(&condition, &state, &ability),
+            "a battlefield object does not satisfy a graveyard-bound rider"
+        );
+
+        state.objects.get_mut(&object).unwrap().zone = Zone::Graveyard;
+        assert!(
+            evaluate_condition(&condition, &state, &ability),
+            "the same tracked object satisfies the rider after arriving in the graveyard"
+        );
+    }
+
     #[test]
     fn targetless_reflexive_is_deferred_and_root_gate_is_consumed() {
         let mut state = GameState::new_two_player(42);

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3532,7 +3532,10 @@ fn condition_reads_filter_population(
         | AbilityCondition::ZoneChangeObjectMatchesFilter { filter, .. }
         | AbilityCondition::ControllerControlsMatching { filter }
         | AbilityCondition::ControllerControlledMatchingAsCast { filter }
-        | AbilityCondition::ZoneChangedThisWay { filter }
+        | AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: _,
+        }
         | AbilityCondition::CostPaidObjectMatchesFilter { filter } => has_filter(filter),
         AbilityCondition::RevealedHasCardType {
             additional_filter,
@@ -14203,13 +14206,24 @@ pub(crate) fn evaluate_condition(
         // CR 608.2c: "If a [noun] was [verb]ed this way" — check if any zone-changed
         // object matches the type filter. For optional-targeting parents with no targets
         // chosen, last_zone_changed_ids is empty → returns false.
-        AbilityCondition::ZoneChangedThisWay { filter } => {
+        AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination,
+        } => {
             // CR 107.3a + CR 601.2b: ability-context filter evaluation.
             let ctx = crate::game::filter::FilterContext::from_ability(ability);
-            state
-                .last_zone_changed_ids
-                .iter()
-                .any(|&id| crate::game::filter::matches_target_filter(state, id, filter, &ctx))
+            state.last_zone_changed_ids.iter().any(|&id| {
+                crate::game::filter::matches_target_filter(state, id, filter, &ctx)
+                    // CR 608.2c + CR 122.1h + CR 614.6: a destination-bound
+                    // wording ("put into a graveyard / dies this way") needs the
+                    // ARRIVAL, not just the move — a replacement that redirected
+                    // the object elsewhere defeats it. Current zone IS the
+                    // arrival zone here: nothing else runs between the parent
+                    // instruction and this evaluation.
+                    && destination.is_none_or(|zone| {
+                        state.objects.get(&id).is_some_and(|obj| obj.zone == zone)
+                    })
+            })
         }
         // CR 608.2k + CR 608.2h: the cost-paid object is a persistent untargeted
         // reference, so it reads CURRENT information while it is still in a
@@ -33050,7 +33064,10 @@ mod tests {
             AbilityCondition::CostPaidObjectMatchesFilter { filter: anaphor() },
             AbilityCondition::TriggeringSpellTargetsFilter { filter: anaphor() },
             AbilityCondition::ControllerControlledMatchingAsCast { filter: anaphor() },
-            AbilityCondition::ZoneChangedThisWay { filter: anaphor() },
+            AbilityCondition::ZoneChangedThisWay {
+                filter: anaphor(),
+                destination: None,
+            },
             AbilityCondition::PostReplacementDamageSourceMatchesFilter { filter: anaphor() },
             AbilityCondition::TargetSharesNameWithOtherExiledThisWay { target: anaphor() },
             AbilityCondition::ObjectsShareQuality {
@@ -33092,6 +33109,7 @@ mod tests {
         assert!(!condition_depends_on_last_created(
             &AbilityCondition::ZoneChangedThisWay {
                 filter: TargetFilter::LastZoneChanged,
+                destination: None,
             }
         ));
     }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -19357,9 +19357,9 @@ mod stage2_injector_tests {
                 // #7577 after merging upstream `07f5cfeb1`: all three producers
                 // move uniformly by -17. The census still reports exactly five
                 // production producers, and each remains in its named function.
-                "game/effects/mod.rs:7353".to_string(),
-                "game/effects/mod.rs:7430".to_string(),
-                "game/effects/mod.rs:11257".to_string(),
+                "game/effects/mod.rs:7356".to_string(),
+                "game/effects/mod.rs:7433".to_string(),
+                "game/effects/mod.rs:11260".to_string(),
                 // UNMOVED across the rebase, and that is itself evidence the SET did not
                 // move: a census that had gained or lost a producer would not leave this
                 // entry both byte-identical AND at the same coordinate.

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -924,7 +924,10 @@ pub(super) fn strip_if_you_do_conditional(text: &str) -> (Option<AbilityConditio
             let body_lower = strip_reflexive_conditional_body_separator(after_clause);
             let offset = text.len() - body_lower.len();
             return (
-                Some(AbilityCondition::ZoneChangedThisWay { filter }),
+                Some(AbilityCondition::ZoneChangedThisWay {
+                    filter,
+                    destination: None,
+                }),
                 text[offset..].to_string(),
             );
         }
@@ -942,17 +945,23 @@ pub(super) fn strip_if_you_do_conditional(text: &str) -> (Option<AbilityConditio
             let body_lower = strip_reflexive_conditional_body_separator(after_clause);
             let offset = text.len() - body_lower.len();
             return (
-                Some(AbilityCondition::ZoneChangedThisWay { filter }),
+                Some(AbilityCondition::ZoneChangedThisWay {
+                    filter,
+                    destination: None,
+                }),
                 text[offset..].to_string(),
             );
         }
-        if let Ok((after_clause, (filter, _negated))) =
+        if let Ok((after_clause, (filter, _negated, destination))) =
             nom_cond::parse_zone_changed_this_way_clause(rest)
         {
             let body_lower = strip_reflexive_conditional_body_separator(after_clause);
             let offset = text.len() - body_lower.len();
             return (
-                Some(AbilityCondition::ZoneChangedThisWay { filter }),
+                Some(AbilityCondition::ZoneChangedThisWay {
+                    filter,
+                    destination,
+                }),
                 text[offset..].to_string(),
             );
         }
@@ -968,7 +977,10 @@ pub(super) fn strip_if_you_do_conditional(text: &str) -> (Option<AbilityConditio
                 let body_lower = strip_reflexive_conditional_body_separator(after_clause);
                 let offset = text.len() - body_lower.len();
                 return (
-                    Some(AbilityCondition::ZoneChangedThisWay { filter }),
+                    Some(AbilityCondition::ZoneChangedThisWay {
+                        filter,
+                        destination: None,
+                    }),
                     text[offset..].to_string(),
                 );
             }
@@ -983,7 +995,10 @@ pub(super) fn strip_if_you_do_conditional(text: &str) -> (Option<AbilityConditio
                 let body_lower = strip_reflexive_conditional_body_separator(after_clause);
                 let offset = text.len() - body_lower.len();
                 return (
-                    Some(AbilityCondition::ZoneChangedThisWay { filter }),
+                    Some(AbilityCondition::ZoneChangedThisWay {
+                        filter,
+                        destination: None,
+                    }),
                     text[offset..].to_string(),
                 );
             }
@@ -1539,7 +1554,10 @@ pub(super) fn try_parse_moved_card_subtype_attach_followup(
     if !after_dot.trim().is_empty() {
         return None;
     }
-    let condition = AbilityCondition::ZoneChangedThisWay { filter };
+    let condition = AbilityCondition::ZoneChangedThisWay {
+        filter,
+        destination: None,
+    };
     let attach = Effect::Attach {
         attachment: TargetFilter::SelfRef,
         target: TargetFilter::ParentTarget,
@@ -5559,7 +5577,7 @@ pub(super) fn try_nom_condition_as_ability_condition(
     // `strip_if_you_do_conditional` uses — so prefix ("if a creature card is
     // exiled this way, …") and suffix ("… if at least one creature card was
     // exiled this way") forms produce the identical
-    // `AbilityCondition::ZoneChangedThisWay { filter }` representation.
+    // `AbilityCondition::ZoneChangedThisWay { filter, destination: None }` representation.
     if let Some(condition) = parse_outcome_this_way_condition(lower.as_str()) {
         return Some(condition);
     }
@@ -5753,6 +5771,7 @@ pub(super) fn try_nom_condition_as_ability_condition(
         return Some(AbilityCondition::Not {
             condition: Box::new(AbilityCondition::ZoneChangedThisWay {
                 filter: TargetFilter::Any,
+                destination: None,
             }),
         });
     }
@@ -6826,6 +6845,7 @@ fn parse_effect_discard_instant_or_sorcery_condition(lower: &str) -> Option<Abil
             TypeFilter::Instant,
             TypeFilter::Sorcery,
         ]))),
+        destination: None,
     })
 }
 
@@ -7155,14 +7175,20 @@ pub(super) fn parse_zone_change_object_has_keyword_condition(
 ///     unlocks the whole "if you put a [type] onto the battlefield this way,
 ///     [bonus]" fetch/ramp payoff class).
 fn parse_outcome_this_way_condition(lower: &str) -> Option<AbilityCondition> {
-    let (rest, (filter, negated)) = parse_zone_changed_this_way_clause(lower)
-        .or_else(|_| parse_you_put_onto_battlefield_this_way_clause(lower))
+    let (rest, (filter, negated, destination)) = parse_zone_changed_this_way_clause(lower)
+        .or_else(|_| {
+            parse_you_put_onto_battlefield_this_way_clause(lower)
+                .map(|(rest, (filter, negated))| (rest, (filter, negated, None)))
+        })
         .ok()?;
     if !rest.trim().is_empty() {
         return None;
     }
     Some(maybe_negate(
-        AbilityCondition::ZoneChangedThisWay { filter },
+        AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination,
+        },
         negated,
     ))
 }
@@ -7621,6 +7647,7 @@ mod tests {
         assert_eq!(body, "you gain 4 life");
         let Some(AbilityCondition::ZoneChangedThisWay {
             filter: TargetFilter::Typed(TypedFilter { type_filters, .. }),
+            destination: None,
         }) = cond
         else {
             panic!("expected ZoneChangedThisWay Artifact, got {cond:?}");
@@ -7639,6 +7666,7 @@ mod tests {
         assert_eq!(body, "you gain 2 life");
         let Some(AbilityCondition::ZoneChangedThisWay {
             filter: TargetFilter::Typed(TypedFilter { type_filters, .. }),
+            destination: None,
         }) = cond
         else {
             panic!("expected ZoneChangedThisWay Town, got {cond:?}");
@@ -7698,6 +7726,7 @@ mod tests {
         assert_eq!(body, "surveil 1");
         let Some(AbilityCondition::ZoneChangedThisWay {
             filter: TargetFilter::Typed(TypedFilter { properties, .. }),
+            destination: None,
         }) = cond
         else {
             panic!("expected ZoneChangedThisWay, got {cond:?}");
@@ -7717,6 +7746,7 @@ mod tests {
         );
         let Some(AbilityCondition::ZoneChangedThisWay {
             filter: TargetFilter::Or { filters },
+            destination: None,
         }) = cond
         else {
             panic!("expected ZoneChangedThisWay Or, got {cond:?}");
@@ -8581,7 +8611,11 @@ mod tests {
             "if at least one angel card is milled this way, you gain 4 life",
         );
         assert_eq!(body, "you gain 4 life");
-        let Some(AbilityCondition::ZoneChangedThisWay { filter }) = condition else {
+        let Some(AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: None,
+        }) = condition
+        else {
             panic!("expected ZoneChangedThisWay condition, got {condition:?}");
         };
         match filter {
@@ -8603,7 +8637,11 @@ mod tests {
             "if a hero enters this way, it enters with an additional +1/+1 counter on it",
         );
         assert_eq!(body, "it enters with an additional +1/+1 counter on it");
-        let Some(AbilityCondition::ZoneChangedThisWay { filter }) = condition else {
+        let Some(AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: None,
+        }) = condition
+        else {
             panic!("expected ZoneChangedThisWay condition, got {condition:?}");
         };
         match filter {
@@ -8622,7 +8660,11 @@ mod tests {
             "when you put one or more equipment onto the battlefield this way, you may attach one of them to a samurai you control",
         );
         assert_eq!(body, "you may attach one of them to a samurai you control");
-        let Some(AbilityCondition::ZoneChangedThisWay { filter }) = condition else {
+        let Some(AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: None,
+        }) = condition
+        else {
             panic!("expected ZoneChangedThisWay condition, got {condition:?}");
         };
         match filter {
@@ -8651,7 +8693,11 @@ mod tests {
             &mut ParseContext::default(),
         );
         assert_eq!(body, "you gain 4 life.");
-        let Some(AbilityCondition::ZoneChangedThisWay { filter }) = condition else {
+        let Some(AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: None,
+        }) = condition
+        else {
             panic!("expected ZoneChangedThisWay condition, got {condition:?}");
         };
         match filter {
@@ -8676,7 +8722,11 @@ mod tests {
         let condition =
             parse_outcome_this_way_condition("you put a creature onto the battlefield this way")
                 .expect("active-voice put gate must lower to ZoneChangedThisWay");
-        let AbilityCondition::ZoneChangedThisWay { filter } = condition else {
+        let AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: None,
+        } = condition
+        else {
             panic!("expected ZoneChangedThisWay condition, got {condition:?}");
         };
         match filter {
@@ -8704,7 +8754,11 @@ mod tests {
             "when you discard a card this way, target player mills cards equal to its mana value",
         );
         assert_eq!(body, "target player mills cards equal to its mana value");
-        let Some(AbilityCondition::ZoneChangedThisWay { filter }) = condition else {
+        let Some(AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: None,
+        }) = condition
+        else {
             panic!("expected ZoneChangedThisWay condition, got {condition:?}");
         };
         match filter {
@@ -8731,7 +8785,11 @@ mod tests {
             &mut ParseContext::default(),
         );
         assert_eq!(body, "You gain 2 life");
-        let Some(AbilityCondition::ZoneChangedThisWay { filter }) = condition else {
+        let Some(AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: None,
+        }) = condition
+        else {
             panic!("expected ZoneChangedThisWay condition, got {condition:?}");
         };
         let TargetFilter::Typed(TypedFilter { type_filters, .. }) = filter else {
@@ -8772,6 +8830,7 @@ mod tests {
                 Some(AbilityCondition::Not {
                     condition: Box::new(AbilityCondition::ZoneChangedThisWay {
                         filter: TargetFilter::Any,
+                        destination: None,
                     }),
                 }),
                 "expected Not {{ ZoneChangedThisWay {{ Any }} }} for {text:?}",
@@ -9926,7 +9985,10 @@ mod tests {
                 .expect("Iron Man Equipment attach follow-up must be recognized");
         assert!(!is_optional, "the attach itself is mandatory once gated");
         match cond {
-            AbilityCondition::ZoneChangedThisWay { filter } => match filter {
+            AbilityCondition::ZoneChangedThisWay {
+                filter,
+                destination: None,
+            } => match filter {
                 TargetFilter::Typed(t) => assert!(
                     t.type_filters.iter().any(|f| matches!(
                         f,

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -926,7 +926,7 @@ pub(super) fn strip_if_you_do_conditional(text: &str) -> (Option<AbilityConditio
             return (
                 Some(AbilityCondition::ZoneChangedThisWay {
                     filter,
-                    destination: None,
+                    destination: Some(Zone::Battlefield),
                 }),
                 text[offset..].to_string(),
             );
@@ -7178,7 +7178,7 @@ fn parse_outcome_this_way_condition(lower: &str) -> Option<AbilityCondition> {
     let (rest, (filter, negated, destination)) = parse_zone_changed_this_way_clause(lower)
         .or_else(|_| {
             parse_you_put_onto_battlefield_this_way_clause(lower)
-                .map(|(rest, (filter, negated))| (rest, (filter, negated, None)))
+                .map(|(rest, (filter, negated))| (rest, (filter, negated, Some(Zone::Battlefield))))
         })
         .ok()?;
     if !rest.trim().is_empty() {
@@ -7647,7 +7647,7 @@ mod tests {
         assert_eq!(body, "you gain 4 life");
         let Some(AbilityCondition::ZoneChangedThisWay {
             filter: TargetFilter::Typed(TypedFilter { type_filters, .. }),
-            destination: None,
+            destination: Some(Zone::Battlefield),
         }) = cond
         else {
             panic!("expected ZoneChangedThisWay Artifact, got {cond:?}");
@@ -7666,7 +7666,7 @@ mod tests {
         assert_eq!(body, "you gain 2 life");
         let Some(AbilityCondition::ZoneChangedThisWay {
             filter: TargetFilter::Typed(TypedFilter { type_filters, .. }),
-            destination: None,
+            destination: Some(Zone::Hand),
         }) = cond
         else {
             panic!("expected ZoneChangedThisWay Town, got {cond:?}");

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -8639,7 +8639,7 @@ mod tests {
         assert_eq!(body, "it enters with an additional +1/+1 counter on it");
         let Some(AbilityCondition::ZoneChangedThisWay {
             filter,
-            destination: None,
+            destination: Some(Zone::Battlefield),
         }) = condition
         else {
             panic!("expected ZoneChangedThisWay condition, got {condition:?}");
@@ -8662,7 +8662,7 @@ mod tests {
         assert_eq!(body, "you may attach one of them to a samurai you control");
         let Some(AbilityCondition::ZoneChangedThisWay {
             filter,
-            destination: None,
+            destination: Some(Zone::Battlefield),
         }) = condition
         else {
             panic!("expected ZoneChangedThisWay condition, got {condition:?}");
@@ -8695,7 +8695,7 @@ mod tests {
         assert_eq!(body, "you gain 4 life.");
         let Some(AbilityCondition::ZoneChangedThisWay {
             filter,
-            destination: None,
+            destination: Some(Zone::Battlefield),
         }) = condition
         else {
             panic!("expected ZoneChangedThisWay condition, got {condition:?}");
@@ -8724,7 +8724,7 @@ mod tests {
                 .expect("active-voice put gate must lower to ZoneChangedThisWay");
         let AbilityCondition::ZoneChangedThisWay {
             filter,
-            destination: None,
+            destination: Some(Zone::Battlefield),
         } = condition
         else {
             panic!("expected ZoneChangedThisWay condition, got {condition:?}");

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2000,7 +2000,13 @@ pub(super) fn fold_enters_this_way_counter_rider(def: &mut AbilityDefinition) {
         return;
     };
 
-    let Some(AbilityCondition::ZoneChangedThisWay { filter }) = sub.condition.clone() else {
+    // Entry-rider folding is destination-blind by construction: a
+    // destination-bound clause is never an ETB rider, so it passes through.
+    let Some(AbilityCondition::ZoneChangedThisWay {
+        filter,
+        destination: None,
+    }) = sub.condition.clone()
+    else {
         def.sub_ability = Some(sub);
         fold_enters_this_way_counter_rider(def.sub_ability.as_mut().unwrap());
         return;

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2000,6 +2000,8 @@ pub(super) fn fold_enters_this_way_counter_rider(def: &mut AbilityDefinition) {
         return;
     };
 
+    // CR 122.6: counters given as an object enters the battlefield use the
+    // same entry-counter representation as counters put on a battlefield object.
     // The parent is itself a battlefield-entry effect, so both legacy
     // destination-agnostic conditions and explicit battlefield-arrival
     // conditions describe this typed entry-counter slot. Other named

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2000,17 +2000,24 @@ pub(super) fn fold_enters_this_way_counter_rider(def: &mut AbilityDefinition) {
         return;
     };
 
-    // Entry-rider folding is destination-blind by construction: a
-    // destination-bound clause is never an ETB rider, so it passes through.
+    // The parent is itself a battlefield-entry effect, so both legacy
+    // destination-agnostic conditions and explicit battlefield-arrival
+    // conditions describe this typed entry-counter slot. Other named
+    // destinations must remain standalone riders.
     let Some(AbilityCondition::ZoneChangedThisWay {
         filter,
-        destination: None,
+        destination,
     }) = sub.condition.clone()
     else {
         def.sub_ability = Some(sub);
         fold_enters_this_way_counter_rider(def.sub_ability.as_mut().unwrap());
         return;
     };
+    if !matches!(destination, None | Some(Zone::Battlefield)) {
+        def.sub_ability = Some(sub);
+        fold_enters_this_way_counter_rider(def.sub_ability.as_mut().unwrap());
+        return;
+    }
 
     if let Effect::PutCounter {
         counter_type,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -722,7 +722,8 @@ fn rewrite_cant_rider_for_non_zone_change_parent(
             if matches!(
                 condition.as_ref(),
                 AbilityCondition::ZoneChangedThisWay {
-                    filter: TargetFilter::Any
+                    filter: TargetFilter::Any,
+                    destination: None,
                 }
             )
     );
@@ -791,6 +792,7 @@ fn rewrite_cost_paid_exiled_reflexive_for_effect_exile_parent(
     if prev_is_effect_exile {
         return Some(AbilityCondition::ZoneChangedThisWay {
             filter: filter.clone(),
+            destination: None,
         });
     }
     condition
@@ -28109,7 +28111,10 @@ fn rewrite_player_scope_refs(def: &mut AbilityDefinition) {
             | AbilityCondition::SourceMatchesFilter { filter }
             | AbilityCondition::ZoneChangeObjectMatchesFilter { filter, .. }
             | AbilityCondition::ControllerControlsMatching { filter }
-            | AbilityCondition::ZoneChangedThisWay { filter }
+            | AbilityCondition::ZoneChangedThisWay {
+                filter,
+                destination: _,
+            }
             | AbilityCondition::CostPaidObjectMatchesFilter { filter } => {
                 rewrite_filter_controller_to_scoped(filter);
             }
@@ -32694,7 +32699,10 @@ pub(crate) fn parse_effect_chain_ir(
                 let condition = AbilityCondition::And {
                     conditions: vec![
                         AbilityCondition::Not {
-                            condition: Box::new(AbilityCondition::ZoneChangedThisWay { filter }),
+                            condition: Box::new(AbilityCondition::ZoneChangedThisWay {
+                                filter,
+                                destination: None,
+                            }),
                         },
                         AbilityCondition::ScopedPlayerMatches { filter: scope },
                     ],

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -667,7 +667,10 @@ fn condition_uses_chosen_card_predicate(condition: &AbilityCondition) -> bool {
         | AbilityCondition::SourceMatchesFilter { filter }
         | AbilityCondition::ZoneChangeObjectMatchesFilter { filter, .. }
         | AbilityCondition::ControllerControlsMatching { filter }
-        | AbilityCondition::ZoneChangedThisWay { filter }
+        | AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: _,
+        }
         | AbilityCondition::CostPaidObjectMatchesFilter { filter } => {
             target_filter_uses_chosen_card_predicate(filter)
         }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -47091,7 +47091,7 @@ fn attach_just_moved_armored_skyhunter_dig_with_zone_changed_this_way() {
     match &attach.condition {
         Some(AbilityCondition::ZoneChangedThisWay {
             filter,
-            destination: None,
+            destination: Some(Zone::Battlefield),
         }) => match filter {
             TargetFilter::Typed(t) => assert!(
                 t.type_filters.iter().any(
@@ -47296,7 +47296,7 @@ fn attach_just_moved_gilgamesh_any_number_equipment_reflexive_attach() {
     match &attach.condition {
         Some(AbilityCondition::ZoneChangedThisWay {
             filter,
-            destination: None,
+            destination: Some(Zone::Battlefield),
         }) => match filter {
             TargetFilter::Typed(t) => assert!(
                 t.type_filters.iter().any(

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -47089,7 +47089,10 @@ fn attach_just_moved_armored_skyhunter_dig_with_zone_changed_this_way() {
         other => panic!("expected Attach sub_ability, got {other:?}"),
     }
     match &attach.condition {
-        Some(AbilityCondition::ZoneChangedThisWay { filter }) => match filter {
+        Some(AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: None,
+        }) => match filter {
             TargetFilter::Typed(t) => assert!(
                 t.type_filters.iter().any(
                     |f| matches!(f, TypeFilter::Subtype(s) if s.eq_ignore_ascii_case("Equipment"))
@@ -47149,7 +47152,10 @@ fn attach_just_moved_iron_man_put_from_hand_attach_equipment_to_source() {
     // Condition gates on the MOVED card's type (ZoneChangedThisWay), not the
     // ability's first target slot (the pre-fix TargetMatchesFilter bug).
     match &attach.condition {
-        Some(AbilityCondition::ZoneChangedThisWay { filter }) => match filter {
+        Some(AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: None,
+        }) => match filter {
             TargetFilter::Typed(t) => assert!(
                 t.type_filters.iter().any(
                     |f| matches!(f, TypeFilter::Subtype(s) if s.eq_ignore_ascii_case("Equipment"))
@@ -47205,7 +47211,10 @@ fn invincible_iron_man_trigger_parses_equipment_attach_via_parse_oracle_text() {
         other => panic!("expected Attach sub_ability, got {other:?}"),
     }
     match &attach.condition {
-        Some(AbilityCondition::ZoneChangedThisWay { filter }) => match filter {
+        Some(AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: None,
+        }) => match filter {
             TargetFilter::Typed(t) => assert!(t.type_filters.iter().any(
                 |f| matches!(f, TypeFilter::Subtype(s) if s.eq_ignore_ascii_case("Equipment"))
             )),
@@ -47285,7 +47294,10 @@ fn attach_just_moved_gilgamesh_any_number_equipment_reflexive_attach() {
         other => panic!("expected Attach sub_ability, got {other:?}"),
     }
     match &attach.condition {
-        Some(AbilityCondition::ZoneChangedThisWay { filter }) => match filter {
+        Some(AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: None,
+        }) => match filter {
             TargetFilter::Typed(t) => assert!(
                 t.type_filters.iter().any(
                     |f| matches!(f, TypeFilter::Subtype(s) if s.eq_ignore_ascii_case("Equipment"))
@@ -48456,7 +48468,8 @@ fn reflexive_sacrifice_this_way_taps_and_draws_that_many() {
     assert!(matches!(
         def.condition,
         Some(AbilityCondition::ZoneChangedThisWay {
-            filter: TargetFilter::Typed(TypedFilter { ref type_filters, .. })
+            filter: TargetFilter::Typed(TypedFilter { ref type_filters, .. }),
+            destination: None,
         }) if type_filters.iter().any(|f| matches!(f, TypeFilter::Artifact))
     ));
 

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -9171,7 +9171,9 @@ pub(crate) fn parse_unless_condition(input: &str) -> OracleResult<'_, StaticCond
 /// the consumed " this way" suffix (caller is responsible for stripping any
 /// trailing punctuation like ", " or "."). On `wasn't`/`was not` the negation
 /// is exposed via `negated`.
-pub fn parse_zone_changed_this_way_clause(input: &str) -> OracleResult<'_, (TargetFilter, bool)> {
+pub fn parse_zone_changed_this_way_clause(
+    input: &str,
+) -> OracleResult<'_, (TargetFilter, bool, Option<crate::types::zones::Zone>)> {
     parse_zone_changed_this_way_clause_scoped(input, ThisWayVerbScope::AnyZoneChange)
 }
 
@@ -9197,7 +9199,7 @@ pub enum ThisWayVerbScope {
 pub fn parse_zone_changed_this_way_clause_scoped(
     input: &str,
     scope: ThisWayVerbScope,
-) -> OracleResult<'_, (TargetFilter, bool)> {
+) -> OracleResult<'_, (TargetFilter, bool, Option<crate::types::zones::Zone>)> {
     // CR 608.2c: A "this way" conditional may be quantified. "at least one" /
     // "one or more" both mean "≥ 1", which the existential `.any()` semantics
     // of `ZoneChangedThisWay` already encode — they value-discard to unit. The
@@ -9210,6 +9212,11 @@ pub fn parse_zone_changed_this_way_clause_scoped(
         // "another "; `parse_type_phrase` maps it to `FilterProp::Another` so the
         // returned-this-way subject excludes the source.
         value((), nom::combinator::peek(tag("another "))),
+        // CR 608.2c: "that <type> … this way" (Saw in Half, Tuktuk Scrapper) —
+        // the anaphor names the parent's own moved object; the ledger holds
+        // exactly the parent's moves, so the existential over it is the same
+        // condition the article forms produce.
+        value((), tag("that ")),
         parse_article,
     ))
     .parse(input)?;
@@ -9245,7 +9252,23 @@ pub fn parse_zone_changed_this_way_clause_scoped(
         alt((tag::<_, _, OracleError<'_>>("enters"), tag("enter"))).parse(after_filter)
     {
         let (rest, _) = tag(" this way").parse(rest)?;
-        return Ok((rest, (filter, false)));
+        return Ok((rest, (filter, false, None)));
+    }
+
+    // CR 700.4: "dies this way" — present-tense and DESTINATION-BOUND: dying
+    // IS being put into a graveyard from the battlefield, so a CR 614.1
+    // replacement that redirects the arrival (CR 122.1h finality counters)
+    // defeats the clause. Non-entry verb, so only the general scope offers it.
+    if scope == ThisWayVerbScope::AnyZoneChange {
+        if let Ok((rest, _)) =
+            alt((tag::<_, _, OracleError<'_>>("dies"), tag("die"))).parse(after_filter)
+        {
+            let (rest, _) = tag(" this way").parse(rest)?;
+            return Ok((
+                rest,
+                (filter, false, Some(crate::types::zones::Zone::Graveyard)),
+            ));
+        }
     }
 
     // tense: singular "is"/"was" + plural "are"/"were". Verb number is
@@ -9269,25 +9292,41 @@ pub fn parse_zone_changed_this_way_clause_scoped(
     // " this way" suffix is the discriminator. Under
     // `ThisWayVerbScope::BattlefieldEntry` only the battlefield-entry verb is
     // offered; the non-entry zone-change verbs are withheld.
-    let (rest, _) = match scope {
+    let (rest, destination) = match scope {
         ThisWayVerbScope::AnyZoneChange => alt((
-            tag::<_, _, OracleError<'_>>("put onto the battlefield"),
-            tag("destroyed"),
-            tag("exiled"),
-            tag("sacrificed"),
-            tag("returned"),
-            tag("discarded"),
-            tag("milled"),
-            tag("countered"),
+            // CR 400.7: cause-bound zone-change verbs — the CAUSE names them,
+            // so a CR 614.6 redirect does not defeat the clause. No
+            // destination binding.
+            value(
+                None,
+                tag::<_, _, OracleError<'_>>("put onto the battlefield"),
+            ),
+            value(None, tag("destroyed")),
+            value(None, tag("exiled")),
+            value(None, tag("sacrificed")),
+            value(None, tag("returned")),
+            value(None, tag("discarded")),
+            value(None, tag("milled")),
+            value(None, tag("countered")),
+            // CR 608.2c + CR 122.1h + CR 614.6: destination-bound wording —
+            // the clause names the ARRIVAL zone, so a replacement that
+            // redirects the object elsewhere (finality counters: exile
+            // instead of the graveyard) defeats it.
+            value(
+                Some(crate::types::zones::Zone::Graveyard),
+                tag("put into a graveyard"),
+            ),
         ))
         .parse(rest)?,
-        ThisWayVerbScope::BattlefieldEntry => {
-            tag::<_, _, OracleError<'_>>("put onto the battlefield").parse(rest)?
-        }
+        ThisWayVerbScope::BattlefieldEntry => value(
+            None,
+            tag::<_, _, OracleError<'_>>("put onto the battlefield"),
+        )
+        .parse(rest)?,
     };
 
     let (rest, _) = tag(" this way").parse(rest)?;
-    Ok((rest, (filter, negated)))
+    Ok((rest, (filter, negated, destination)))
 }
 
 /// CR 120.3 + CR 608.2c: the recipient axis of a "… is dealt damage this way"
@@ -9452,7 +9491,7 @@ pub fn parse_entry_this_way_clause(input: &str) -> OracleResult<'_, (Option<Targ
     let (rest, subject) = alt((
         map(
             |i| parse_zone_changed_this_way_clause_scoped(i, ThisWayVerbScope::BattlefieldEntry),
-            |(filter, negated)| (Some(filter), negated),
+            |(filter, negated, _destination)| (Some(filter), negated),
         ),
         map(
             parse_you_put_onto_battlefield_this_way_clause,
@@ -9779,7 +9818,13 @@ pub fn parse_you_put_into_hand_this_way_condition(
         )));
     }
     let (rest, _) = tag("into your hand this way").parse(after_filter.trim_start())?;
-    Ok((rest, AbilityCondition::ZoneChangedThisWay { filter }))
+    Ok((
+        rest,
+        AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: None,
+        },
+    ))
 }
 
 /// CR 608.2c + CR 122.1: Parse "you put [counter type] counters on [N] [type]
@@ -9889,6 +9934,7 @@ pub fn parse_you_control_or_returned_this_way_condition(
                 },
                 AbilityCondition::ZoneChangedThisWay {
                     filter: returned_filter,
+                    destination: None,
                 },
             ],
         },
@@ -18763,7 +18809,7 @@ mod tests {
     /// baseline before extending to present tense / multi-word verbs.
     #[test]
     fn test_zone_changed_this_way_was_destroyed_top_level_type() {
-        let (rest, (filter, negated)) = parse_zone_changed_this_way_clause(
+        let (rest, (filter, negated, _destination)) = parse_zone_changed_this_way_clause(
             "an enchantment was destroyed this way, you lose 2 life",
         )
         .unwrap();
@@ -18781,7 +18827,7 @@ mod tests {
     /// Reborn Avenger's Hero rider after graveyard reanimation.
     #[test]
     fn test_zone_changed_this_way_hero_enters() {
-        let (rest, (filter, negated)) = parse_zone_changed_this_way_clause(
+        let (rest, (filter, negated, _destination)) = parse_zone_changed_this_way_clause(
             "a hero enters this way, it enters with an additional +1/+1 counter on it",
         )
         .unwrap();
@@ -18802,7 +18848,7 @@ mod tests {
     /// the Holy Relic / Stonehewer Giant case.
     #[test]
     fn test_zone_changed_this_way_is_put_onto_battlefield_equipment() {
-        let (rest, (filter, negated)) = parse_zone_changed_this_way_clause(
+        let (rest, (filter, negated, _destination)) = parse_zone_changed_this_way_clause(
             "an equipment is put onto the battlefield this way, you may attach it to a creature you control",
         )
         .unwrap();
@@ -18844,7 +18890,7 @@ mod tests {
     /// CR 303.4f: Aura subtype mirrors the Equipment branch — same combinator.
     #[test]
     fn test_zone_changed_this_way_is_put_onto_battlefield_aura() {
-        let (rest, (filter, negated)) = parse_zone_changed_this_way_clause(
+        let (rest, (filter, negated, _destination)) = parse_zone_changed_this_way_clause(
             "an aura is put onto the battlefield this way, do something",
         )
         .unwrap();
@@ -18867,7 +18913,7 @@ mod tests {
     /// "if a creature wasn't destroyed this way" patterns.
     #[test]
     fn test_zone_changed_this_way_wasnt_negated() {
-        let (rest, (_filter, negated)) =
+        let (rest, (_filter, negated, _destination)) =
             parse_zone_changed_this_way_clause("a creature wasn't destroyed this way, do x")
                 .unwrap();
         assert_eq!(rest, ", do x");
@@ -18888,8 +18934,8 @@ mod tests {
             "countered",
         ] {
             let input = format!("a creature was {verb} this way, x");
-            let (rest, (_filter, negated)) = parse_zone_changed_this_way_clause(&input)
-                .unwrap_or_else(|e| {
+            let (rest, (_filter, negated, _destination)) =
+                parse_zone_changed_this_way_clause(&input).unwrap_or_else(|e| {
                     panic!("verb {verb} failed to parse: {e:?}");
                 });
             assert_eq!(rest, ", x", "verb {verb} produced wrong remainder");
@@ -19003,7 +19049,7 @@ mod tests {
     /// existential `ZoneChangedThisWay` (≥ 1).
     #[test]
     fn test_zone_changed_this_way_at_least_one_subtype() {
-        let (rest, (filter, negated)) = parse_zone_changed_this_way_clause(
+        let (rest, (filter, negated, _destination)) = parse_zone_changed_this_way_clause(
             "at least one angel card is milled this way, you gain 4 life",
         )
         .unwrap();
@@ -19026,7 +19072,7 @@ mod tests {
     /// type + `nonland` negated-type prefix + **plural verb** "are".
     #[test]
     fn test_zone_changed_this_way_one_or_more_nonland_cards_plural() {
-        let (rest, (filter, negated)) = parse_zone_changed_this_way_clause(
+        let (rest, (filter, negated, _destination)) = parse_zone_changed_this_way_clause(
             "one or more nonland cards are exiled this way, you draw a card",
         )
         .unwrap();
@@ -19047,7 +19093,7 @@ mod tests {
     /// **plural verb** "are milled".
     #[test]
     fn test_zone_changed_this_way_one_or_more_cards_plural_milled() {
-        let (rest, (filter, negated)) = parse_zone_changed_this_way_clause(
+        let (rest, (filter, negated, _destination)) = parse_zone_changed_this_way_clause(
             "one or more cards are milled this way, you gain 1 life",
         )
         .unwrap();

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -9167,10 +9167,13 @@ pub(crate) fn parse_unless_condition(input: &str) -> OracleResult<'_, StaticCond
 /// so adding a new tense or verb is a single `tag` arm, not an O(N!)
 /// permutation expansion.
 ///
-/// Returns `(remainder, type_filter)` where `remainder` is the input after
-/// the consumed " this way" suffix (caller is responsible for stripping any
-/// trailing punctuation like ", " or "."). On `wasn't`/`was not` the negation
-/// is exposed via `negated`.
+/// Returns `(remainder, (type_filter, negated, destination))`, where
+/// `remainder` is the input after the consumed " this way" suffix (caller is
+/// responsible for stripping any trailing punctuation like ", " or ".").
+/// `destination` is `Some(zone)` for wording that names an arrival zone
+/// ("enters", "put onto the battlefield", "dies", or "put into a graveyard")
+/// and `None` for cause-bound verbs. On `wasn't`/`was not` the negation is
+/// exposed via `negated`.
 pub fn parse_zone_changed_this_way_clause(
     input: &str,
 ) -> OracleResult<'_, (TargetFilter, bool, Option<crate::types::zones::Zone>)> {
@@ -9252,7 +9255,7 @@ pub fn parse_zone_changed_this_way_clause_scoped(
         alt((tag::<_, _, OracleError<'_>>("enters"), tag("enter"))).parse(after_filter)
     {
         let (rest, _) = tag(" this way").parse(rest)?;
-        return Ok((rest, (filter, false, None)));
+        return Ok((rest, (filter, false, Some(Zone::Battlefield))));
     }
 
     // CR 700.4: "dies this way" — present-tense and DESTINATION-BOUND: dying
@@ -9294,11 +9297,11 @@ pub fn parse_zone_changed_this_way_clause_scoped(
     // offered; the non-entry zone-change verbs are withheld.
     let (rest, destination) = match scope {
         ThisWayVerbScope::AnyZoneChange => alt((
-            // CR 400.7: cause-bound zone-change verbs — the CAUSE names them,
-            // so a CR 614.6 redirect does not defeat the clause. No
-            // destination binding.
+            // CR 608.2c + CR 614.6: "put onto the battlefield" names the
+            // arrival, so a replacement that redirects the object elsewhere
+            // defeats the clause.
             value(
-                None,
+                Some(Zone::Battlefield),
                 tag::<_, _, OracleError<'_>>("put onto the battlefield"),
             ),
             value(None, tag("destroyed")),
@@ -9319,7 +9322,7 @@ pub fn parse_zone_changed_this_way_clause_scoped(
         ))
         .parse(rest)?,
         ThisWayVerbScope::BattlefieldEntry => value(
-            None,
+            Some(Zone::Battlefield),
             tag::<_, _, OracleError<'_>>("put onto the battlefield"),
         )
         .parse(rest)?,
@@ -9822,7 +9825,7 @@ pub fn parse_you_put_into_hand_this_way_condition(
         rest,
         AbilityCondition::ZoneChangedThisWay {
             filter,
-            destination: None,
+            destination: Some(Zone::Hand),
         },
     ))
 }
@@ -18809,12 +18812,13 @@ mod tests {
     /// baseline before extending to present tense / multi-word verbs.
     #[test]
     fn test_zone_changed_this_way_was_destroyed_top_level_type() {
-        let (rest, (filter, negated, _destination)) = parse_zone_changed_this_way_clause(
+        let (rest, (filter, negated, destination)) = parse_zone_changed_this_way_clause(
             "an enchantment was destroyed this way, you lose 2 life",
         )
         .unwrap();
         assert_eq!(rest, ", you lose 2 life");
         assert!(!negated);
+        assert_eq!(destination, None);
         match filter {
             TargetFilter::Typed(TypedFilter { type_filters, .. }) => {
                 assert_eq!(type_filters, vec![TypeFilter::Enchantment]);
@@ -18827,12 +18831,13 @@ mod tests {
     /// Reborn Avenger's Hero rider after graveyard reanimation.
     #[test]
     fn test_zone_changed_this_way_hero_enters() {
-        let (rest, (filter, negated, _destination)) = parse_zone_changed_this_way_clause(
+        let (rest, (filter, negated, destination)) = parse_zone_changed_this_way_clause(
             "a hero enters this way, it enters with an additional +1/+1 counter on it",
         )
         .unwrap();
         assert_eq!(rest, ", it enters with an additional +1/+1 counter on it");
         assert!(!negated);
+        assert_eq!(destination, Some(Zone::Battlefield));
         match filter {
             TargetFilter::Typed(TypedFilter { type_filters, .. }) => {
                 assert!(type_filters.iter().any(
@@ -18848,12 +18853,13 @@ mod tests {
     /// the Holy Relic / Stonehewer Giant case.
     #[test]
     fn test_zone_changed_this_way_is_put_onto_battlefield_equipment() {
-        let (rest, (filter, negated, _destination)) = parse_zone_changed_this_way_clause(
+        let (rest, (filter, negated, destination)) = parse_zone_changed_this_way_clause(
             "an equipment is put onto the battlefield this way, you may attach it to a creature you control",
         )
         .unwrap();
         assert_eq!(rest, ", you may attach it to a creature you control");
         assert!(!negated);
+        assert_eq!(destination, Some(Zone::Battlefield));
         match filter {
             TargetFilter::Typed(TypedFilter { type_filters, .. }) => {
                 assert!(type_filters.iter().any(
@@ -18890,12 +18896,13 @@ mod tests {
     /// CR 303.4f: Aura subtype mirrors the Equipment branch — same combinator.
     #[test]
     fn test_zone_changed_this_way_is_put_onto_battlefield_aura() {
-        let (rest, (filter, negated, _destination)) = parse_zone_changed_this_way_clause(
+        let (rest, (filter, negated, destination)) = parse_zone_changed_this_way_clause(
             "an aura is put onto the battlefield this way, do something",
         )
         .unwrap();
         assert_eq!(rest, ", do something");
         assert!(!negated);
+        assert_eq!(destination, Some(Zone::Battlefield));
         match filter {
             TargetFilter::Typed(TypedFilter { type_filters, .. }) => {
                 assert!(
@@ -18918,6 +18925,25 @@ mod tests {
                 .unwrap();
         assert_eq!(rest, ", do x");
         assert!(negated);
+    }
+
+    /// CR 700.4 + CR 614.6: arrival words bind the rider to the resulting
+    /// zone, while cause verbs intentionally remain destination-agnostic.
+    #[test]
+    fn test_zone_changed_this_way_destination_bound_verbs_and_anaphor() {
+        let (rest, (_filter, negated, destination)) =
+            parse_zone_changed_this_way_clause("that creature dies this way, draw a card").unwrap();
+        assert_eq!(rest, ", draw a card");
+        assert!(!negated);
+        assert_eq!(destination, Some(Zone::Graveyard));
+
+        let (rest, (_filter, negated, destination)) = parse_zone_changed_this_way_clause(
+            "that artifact is put into a graveyard this way, draw a card",
+        )
+        .unwrap();
+        assert_eq!(rest, ", draw a card");
+        assert!(!negated);
+        assert_eq!(destination, Some(Zone::Graveyard));
     }
 
     /// Every imperative verb in the `alt` chain must round-trip; this guards

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -513,7 +513,11 @@ fn spelunking_etb_put_cave_gains_life_conditionally() {
     }
     let gain = find_gain_life(etb).expect("the ETB chain must contain a GainLife node");
 
-    let Some(AbilityCondition::ZoneChangedThisWay { filter }) = &gain.condition else {
+    let Some(AbilityCondition::ZoneChangedThisWay {
+        filter,
+        destination: None,
+    }) = &gain.condition
+    else {
         panic!(
             "GainLife must be gated by ZoneChangedThisWay, got {:?}",
             gain.condition

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -515,7 +515,7 @@ fn spelunking_etb_put_cave_gains_life_conditionally() {
 
     let Some(AbilityCondition::ZoneChangedThisWay {
         filter,
-        destination: None,
+        destination: Some(Zone::Battlefield),
     }) = &gain.condition
     else {
         panic!(

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -21774,7 +21774,23 @@ pub enum AbilityCondition {
     /// Evaluated by checking `state.last_zone_changed_ids` against the filter.
     /// Handles both optional-targeting parents (empty targets → empty IDs → false)
     /// and mandatory parents (type filter check on moved objects).
-    ZoneChangedThisWay { filter: TargetFilter },
+    ///
+    /// `destination`: destination-bound wordings ("is put into a graveyard this
+    /// way"; "dies this way", CR 700.4) additionally require the moved object to
+    /// have ARRIVED in this zone — a replacement that redirects the arrival
+    /// (CR 122.1h finality counters: exile instead of the graveyard) defeats the
+    /// clause, because the replaced event never happened (CR 614.6).
+    /// Cause-bound wordings ("destroyed/sacrificed/exiled … this way") keep
+    /// `None`: the cause survives a redirect, the destination does not. The
+    /// check reads the object's CURRENT zone — the condition is evaluated in
+    /// the same resolution step as the parent instruction (CR 608.2c), before
+    /// any state-based action or trigger could move the object again, so the
+    /// current zone IS the arrival zone.
+    ZoneChangedThisWay {
+        filter: TargetFilter,
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        destination: Option<crate::types::zones::Zone>,
+    },
     /// CR 117.1 + CR 400.7j + CR 608.2k: "if you sacrificed/exiled/discarded a
     /// [filter] this way" checks the object paid as a cost for this resolving
     /// ability using its cost-payment-time public characteristics.

--- a/crates/engine/tests/integration/come_back_wrong_finality_counter.rs
+++ b/crates/engine/tests/integration/come_back_wrong_finality_counter.rs
@@ -1,0 +1,121 @@
+//! CR 122.1h + CR 608.2c: a death-contingent theft against a finality counter.
+//!
+//! Come Back Wrong — "Destroy target creature. If a creature card is put into
+//! a graveyard this way, return it to the battlefield under your control.
+//! Sacrifice it at the beginning of your next end step."
+//!
+//! Reported from a real game: Balustrade Wurm had returned from the graveyard
+//! via its Delirium ability, so it carried a finality counter (CR 122.1h: "If
+//! this permanent would be put into a graveyard from the battlefield, exile it
+//! instead."). The opponent's Come Back Wrong stole it anyway. The printed
+//! return is contingent on the creature card actually being PUT INTO A
+//! GRAVEYARD by the destruction — the finality replacement sends it to exile
+//! instead, so the contingency never happened and the caster must get nothing.
+//!
+//! Oracle text verified against `client/public/card-data.json`.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const COME_BACK_WRONG: &str = "Destroy target creature. If a creature card is put into a graveyard this way, return it to the battlefield under your control. Sacrifice it at the beginning of your next end step.";
+
+struct Theft {
+    prompts: Vec<String>,
+    zone: Option<Zone>,
+    controller: Option<engine::types::player::PlayerId>,
+}
+
+/// P0 casts Come Back Wrong at P1's bear and the resolution runs to an empty
+/// stack. `with_finality` is the whole variable: the counter decides whether
+/// the destruction's graveyard trip is replaced by exile (CR 122.1h).
+fn resolve_theft(with_finality: bool) -> Theft {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let bear = scenario
+        .add_creature_from_oracle(P1, "Doomed Bear", 2, 2, "")
+        .id();
+    if with_finality {
+        scenario.with_counter(bear, CounterType::Finality, 1);
+    }
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Come Back Wrong", false, COME_BACK_WRONG)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.cast(spell).commit();
+
+    let mut prompts = Vec::new();
+    let mut settled = false;
+    for _ in 0..40 {
+        let action = match runner.state().waiting_for.clone() {
+            WaitingFor::Priority { .. } if runner.state().stack.is_empty() => {
+                settled = true;
+                break;
+            }
+            WaitingFor::Priority { .. } => GameAction::PassPriority,
+            // The sorcery's single target slot: the bear is the only creature.
+            WaitingFor::TargetSelection { target_slots, .. } => GameAction::SelectTargets {
+                targets: target_slots
+                    .iter()
+                    .filter_map(|slot| slot.legal_targets.first().cloned())
+                    .collect(),
+            },
+            other => {
+                prompts.push(format!("PROMPT: {}", other.variant_name()));
+                break;
+            }
+        };
+        if runner.act(action).is_err() {
+            break;
+        }
+    }
+    assert!(
+        settled,
+        "the resolution must reach an empty stack — prompts seen: {prompts:?}"
+    );
+
+    let obj = runner
+        .state()
+        .objects
+        .values()
+        .find(|o| o.name == "Doomed Bear");
+    Theft {
+        prompts,
+        zone: obj.map(|o| o.zone),
+        controller: obj.map(|o| o.controller),
+    }
+}
+
+/// The report's case: with a finality counter the graveyard trip becomes
+/// exile (CR 122.1h), so "put into a graveyard this way" never happened —
+/// the caster gets nothing and the creature stays in exile.
+#[test]
+fn a_finality_counter_denies_the_death_contingent_theft() {
+    let theft = resolve_theft(true);
+    assert_eq!(
+        theft.zone,
+        Some(Zone::Exile),
+        "CR 122.1h: the destroyed creature must be exiled instead of dying, \
+         and the graveyard-contingent return must not resolve — prompts seen: {:?}",
+        theft.prompts
+    );
+}
+
+/// The positive twin: without the counter the creature dies into the
+/// graveyard, the contingency holds, and the caster steals it.
+#[test]
+fn without_a_finality_counter_the_theft_resolves() {
+    let theft = resolve_theft(false);
+    assert_eq!(
+        (theft.zone, theft.controller),
+        (Some(Zone::Battlefield), Some(P0)),
+        "the plain destruction dies into the graveyard and the return puts the \
+         creature onto the battlefield under the caster's control — prompts \
+         seen: {:?}",
+        theft.prompts
+    );
+}

--- a/crates/engine/tests/integration/issue_5268_invincible_iron_man.rs
+++ b/crates/engine/tests/integration/issue_5268_invincible_iron_man.rs
@@ -76,7 +76,10 @@ fn invincible_iron_man_trigger_parses_attach_to_source_not_self() {
         other => panic!("expected Attach sub, got {other:?}"),
     }
     match attach.condition.as_ref() {
-        Some(AbilityCondition::ZoneChangedThisWay { filter }) => match filter {
+        Some(AbilityCondition::ZoneChangedThisWay {
+            filter,
+            destination: None,
+        }) => match filter {
             TargetFilter::Typed(t) => assert!(t.type_filters.iter().any(
                 |f| matches!(f, TypeFilter::Subtype(s) if s.eq_ignore_ascii_case("Equipment"))
             )),

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -106,6 +106,7 @@ mod combat_damage_order_triggers_no_hang;
 mod combat_lifelink_replacement_ordering;
 mod combat_target_support;
 mod combo_infinite_pile;
+mod come_back_wrong_finality_counter;
 mod comeuppance;
 mod companion_special_action;
 mod consuming_vapors_life_gain_5925;

--- a/crates/engine/tests/integration/roots_of_wisdom_if_you_cant_draw.rs
+++ b/crates/engine/tests/integration/roots_of_wisdom_if_you_cant_draw.rs
@@ -199,6 +199,7 @@ fn bounce_then_gated_draw(source: ObjectId, controller: PlayerId) -> ResolvedAbi
         .condition(AbilityCondition::Not {
             condition: Box::new(AbilityCondition::ZoneChangedThisWay {
                 filter: TargetFilter::Any,
+                destination: None,
             }),
         }),
     )

--- a/crates/engine/tests/integration/vohar_discard_drain.rs
+++ b/crates/engine/tests/integration/vohar_discard_drain.rs
@@ -25,7 +25,11 @@ fn vohar_parses_effect_discard_condition() {
         .as_ref()
         .and_then(|discard| discard.sub_ability.as_ref())
         .expect("Vohar's loot ability must contain its drain rider");
-    let Some(AbilityCondition::ZoneChangedThisWay { filter }) = &drain.condition else {
+    let Some(AbilityCondition::ZoneChangedThisWay {
+        filter,
+        destination: None,
+    }) = &drain.condition
+    else {
         panic!(
             "Vohar must check the card discarded by the effect: {:?}",
             drain.condition


### PR DESCRIPTION
Fixes #7598

Reported live: Balustrade Wurm carried a finality counter (returned via its Delirium ability); the opponent's Come Back Wrong stole it anyway. CR 122.1h replaces the graveyard trip with exile, the replaced event never happened (CR 614.6), and the printed return is contingent on "If a creature card is put into a graveyard this way" — the caster must get nothing.

**Two seams, one authority each:**
- `AbilityCondition::ZoneChangedThisWay` gains `destination: Option<Zone>` (serde-default `None`: every existing producer keeps its meaning). The evaluation additionally requires the moved object to sit in the destination NOW — the condition runs in the same resolution step as the parent instruction (CR 608.2c), before any SBA or trigger can move the object again, so the current zone IS the arrival zone. Cause-bound verbs (destroyed / sacrificed / exiled / …) stay destination-blind: the cause survives a CR 614.6 redirect, the destination does not.
- The shared clause combinator (`parse_zone_changed_this_way_clause_scoped`) gains the "that <type>" subject anaphor, the active "dies" branch (CR 700.4 → destination Graveyard), and the passive "put into a graveyard" verb (→ destination Graveyard). Previously these clauses were swallowed and the riders ran unconditionally.

**Class** (Regel-13 double parse over `client/public/card-data.json`, 35,797 entries): **30 cards change, all gaining a previously swallowed or absent condition, 0 new `Unimplemented`** — the destroy-then-contingent family (Come Back Wrong, Saw in Half, Tuktuk Scrapper, Werewolf Ransacker, Cinder Cloud, Kaervek's Purge, Kalitas, …) and the "If that spell is countered this way, …" family (Hinder, Syncopate, Dissipate, Spelljack, Void Shatter, Faerie Trickery, …).

**Runtime regression** (`tests/integration/come_back_wrong_finality_counter.rs`): with a finality counter the destroyed creature ends in EXILE and the theft never resolves; without one the theft works (positive twin). Probes, both directions: removing the destination conjunct reads `left: Some(Battlefield)` — the reported theft; removing the parser verbs reverts all 30 cards.

**What the tests do not prove:** the 29 other class members' runtime behavior — their riders now carry the same condition through the same evaluation path the regression pins, but only Come Back Wrong is exercised end-to-end.

**Remaining gap:** "you put [a card] into your hand this way" keeps its pre-existing destination-blind lowering — hand arrivals have their own producer and no known redirect interaction in the pool; changing it here would have widened the blast radius without a driving card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added destination-aware “changed zones this way” conditions.
  * Supports destinations such as the battlefield, hand, and graveyard.
  * Destination-specific conditions verify that cards arrive in the stated zone while preserving redirected-movement behavior.

* **Bug Fixes**
  * Improved handling of destination-dependent effects and zone-change conditions.

* **Tests**
  * Added coverage for finality counters and related zone-change behavior.
  * Expanded parser and integration tests for destination-aware conditions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->