### PR TITLE
feat(deploy): Helm chart for phase-server + multi-arch (amd64/arm64) server image

### DIFF
--- a/.github/actions/binaryen/action.yml
+++ b/.github/actions/binaryen/action.yml
@@ -1,0 +1,106 @@
+name: Set up Binaryen
+description: >
+  Install a digest-pinned Binaryen release and put only its verified bin/
+  directory on PATH. Single authority for every wasm-opt consumer in this repo
+  (deploy.yml build-wasm + deploy-lobby-preview, release.yml build-wasm +
+  deploy-lobby-worker) so the version and the digest cannot drift between them.
+
+inputs:
+  version:
+    description: Binaryen release tag suffix — the N in the upstream `version_N` tag.
+    required: false
+    default: "123"
+  sha256:
+    description: >
+      SHA-256 of binaryen-version_<version>-x86_64-linux.tar.gz, as published by
+      the release's own .tar.gz.sha256 sidecar asset. Bump it in the same edit
+      as `version`: a mismatched pair fails the job at the verify step rather
+      than installing unverified executables.
+    required: false
+    default: e959f2170af4c20c552e9de3a0253704d6a9d2766e8fdb88e4d6ac4bae9388fe
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve Binaryen paths and pinned digest
+      id: pin
+      shell: bash
+      env:
+        VERSION: ${{ inputs.version }}
+        SHA256: ${{ inputs.sha256 }}
+      # Everything lands under RUNNER_TEMP rather than the checkout: the old
+      # `tar xz` into $PWD dropped a 300 MB untracked `binaryen-version_123/`
+      # into the working tree, which is not in .gitignore.
+      run: |
+        set -euo pipefail
+        root="${RUNNER_TEMP}/binaryen"
+        archive="binaryen-version_${VERSION}-x86_64-linux.tar.gz"
+        mkdir -p "$root"
+        # The manifest is regenerated from the pinned input on every run and is
+        # deliberately outside the cached path — it is the trusted side of the
+        # comparison, so a cache entry must never be able to supply it.
+        printf '%s  %s\n' "$SHA256" "$archive" > "${root}/${archive}.sha256"
+        {
+          echo "root=$root"
+          echo "name=$archive"
+          echo "archive=${root}/${archive}"
+          echo "bin=${root}/binaryen-version_${VERSION}/bin"
+          echo "url=https://github.com/WebAssembly/binaryen/releases/download/version_${VERSION}/${archive}"
+        } >> "$GITHUB_OUTPUT"
+
+    - name: Restore cached Binaryen archive
+      id: cache
+      uses: actions/cache@v4
+      with:
+        # Cache the ARCHIVE, not the extracted executables. Extracted binaries
+        # restore straight onto PATH with nothing left to check, so a poisoned
+        # entry would execute unverified; an archive is re-checked against the
+        # pinned digest below on the restore path as well as the download path.
+        # It is also the cheaper artifact: ~100 MB archive + ~1.5s of tar vs a
+        # ~300 MB extracted tree.
+        path: ${{ steps.pin.outputs.archive }}
+        # The digest is part of the key, so bumping version/sha256 rolls the
+        # cache by construction. The `binaryen-version_` prefix is the pattern
+        # clear-caches.yml already matches on.
+        key: binaryen-version_${{ inputs.version }}-x86_64-linux-${{ inputs.sha256 }}
+
+    - name: Download Binaryen archive
+      if: steps.cache.outputs.cache-hit != 'true'
+      shell: bash
+      env:
+        URL: ${{ steps.pin.outputs.url }}
+        ARCHIVE: ${{ steps.pin.outputs.archive }}
+      # -f so an HTML error page can never be handed to tar, and -o so nothing
+      # is piped into an extractor before it has been verified.
+      run: curl -fsSL --retry 3 --retry-all-errors --retry-delay 2 -o "$ARCHIVE" "$URL"
+
+    - name: Verify Binaryen archive against pinned SHA-256
+      shell: bash
+      env:
+        ROOT: ${{ steps.pin.outputs.root }}
+        NAME: ${{ steps.pin.outputs.name }}
+      # Unconditional on purpose. This is the only thing standing between a
+      # remote download *or* a restored cache entry and executables on PATH, so
+      # skipping it on cache hits would leave exactly the gap it exists to close.
+      run: |
+        set -euo pipefail
+        cd "$ROOT"
+        sha256sum -c "${NAME}.sha256"
+
+    - name: Extract Binaryen
+      shell: bash
+      env:
+        ROOT: ${{ steps.pin.outputs.root }}
+        ARCHIVE: ${{ steps.pin.outputs.archive }}
+      run: tar xzf "$ARCHIVE" -C "$ROOT"
+
+    - name: Add Binaryen to PATH
+      shell: bash
+      env:
+        BIN: ${{ steps.pin.outputs.bin }}
+      # Only the verified extracted bin/ — never $ROOT, which also holds the
+      # archive and the manifest.
+      run: |
+        set -euo pipefail
+        test -x "${BIN}/wasm-opt"
+        echo "$BIN" >> "$GITHUB_PATH"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,6 +22,49 @@ env:
   IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/phase-server
 
 jobs:
+  # ── Deploy provenance gate ─────────────────────────────────────────────────
+  # Single authority for "is this trigger allowed to deploy?". Every deploy job
+  # `needs` this one, so the answer lives in exactly one expression and cannot
+  # drift between paths — which is how `deploy-lobby-preview` ended up with the
+  # Cloudflare token and no guard at all.
+  #
+  # The hole this closes: `workflow_run` fires in THIS repo for CI runs of fork
+  # pull requests too, and the `branches: [main]` filter above matches the
+  # TRIGGERING run's head branch — which a fork controls and can simply name
+  # `main`. A conclusion check alone therefore admits fork-authored code as
+  # DEPLOY_SHA, and the deploy jobs check that SHA out while holding
+  # CLOUDFLARE_API_TOKEN, the minisign key, and `packages: write` on GHCR.
+  # `head_repository.full_name` is the field that a fork cannot forge.
+  #
+  # Field names per the workflow run object schema:
+  # https://docs.github.com/en/rest/actions/workflow-runs
+  deploy-gate:
+    name: Verify deploy provenance
+    if: >-
+      ${{ github.repository == 'phase-rs/phase' && (
+        github.event_name == 'workflow_dispatch' || (
+          github.event.workflow_run.conclusion == 'success' &&
+          github.event.workflow_run.head_repository.full_name == github.repository &&
+          github.event.workflow_run.head_branch == 'main'
+        )
+      ) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Record the commit being deployed
+        # Through `env`, never `${{ }}` inside the script: head_branch and
+        # head_repository are attacker-chosen strings on the very event this
+        # job exists to screen, and direct interpolation would run them.
+        env:
+          EVENT: ${{ github.event_name }}
+          SOURCE_REPO: ${{ github.event.workflow_run.head_repository.full_name || github.repository }}
+          SOURCE_BRANCH: ${{ github.event.workflow_run.head_branch || github.ref_name }}
+        run: |
+          echo "event=${EVENT}"
+          echo "source=${SOURCE_REPO}"
+          echo "branch=${SOURCE_BRANCH}"
+          echo "deploy_sha=${DEPLOY_SHA}"
+
   # ── Preview inputs ─────────────────────────────────────────────────────────
   # Generates the immutable card-data/draft-pool pair and derives the engine
   # fingerprint shared by the preview server and frontend. The publication work
@@ -29,7 +72,7 @@ jobs:
   # these inputs are ready rather than waiting on ancillary data generation.
   preview-inputs:
     name: Prepare preview inputs
-    if: ${{ github.repository == 'phase-rs/phase' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
+    needs: [deploy-gate]
     runs-on: ubuntu-latest
     # Sized for the MTGJSON-publish day, not the steady state. When MTGJSON
     # ships a new version the key rolls, and the first run to see it pays the
@@ -294,8 +337,7 @@ jobs:
   # pointing at data that has not reached R2.
   card-data:
     name: Publish card data & R2
-    needs: [preview-inputs]
-    if: ${{ github.repository == 'phase-rs/phase' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
+    needs: [deploy-gate, preview-inputs]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     permissions:
@@ -519,7 +561,7 @@ jobs:
   # parallel. The output feeds the frontend build via artifact.
   build-wasm:
     name: Build WASM
-    if: ${{ github.repository == 'phase-rs/phase' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
+    needs: [deploy-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:
@@ -542,19 +584,8 @@ jobs:
         with:
           tool: wasm-bindgen-cli@0.2.121
 
-      - name: Cache binaryen
-        id: binaryen-cache
-        uses: actions/cache@v4
-        with:
-          path: binaryen-version_123
-          key: binaryen-123-x86_64-linux
-
-      - name: Install binaryen
-        if: steps.binaryen-cache.outputs.cache-hit != 'true'
-        run: curl -L https://github.com/WebAssembly/binaryen/releases/download/version_123/binaryen-version_123-x86_64-linux.tar.gz | tar xz
-
-      - name: Add binaryen to PATH
-        run: echo "$PWD/binaryen-version_123/bin" >> $GITHUB_PATH
+      - name: Set up Binaryen
+        uses: ./.github/actions/binaryen
 
       # build-wasm.sh's assert_wasm_stack guard parses the shipped wasm's memory
       # section with node; declare the dependency explicitly (release.yml already
@@ -580,8 +611,7 @@ jobs:
   # fingerprint whose signed server artifact is missing from the manifest.
   preview-server:
     name: Publish Preview Server
-    needs: [preview-inputs]
-    if: ${{ github.repository == 'phase-rs/phase' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
+    needs: [deploy-gate, preview-inputs]
     uses: ./.github/workflows/preview-server.yml
     with:
       fingerprint: ${{ needs.preview-inputs.outputs.engine_fingerprint }}
@@ -605,6 +635,7 @@ jobs:
   # pair aligned by construction. Production's `phase-lobby` is untouched here.
   deploy-lobby-preview:
     name: Deploy Preview Lobby Worker (Cloudflare)
+    needs: [deploy-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
@@ -627,19 +658,8 @@ jobs:
           # lobby-worker/broker-wasm/Cargo.toml (schema versions must be exact).
           tool: wasm-bindgen-cli@0.2.121
 
-      - name: Cache binaryen
-        id: binaryen-cache
-        uses: actions/cache@v4
-        with:
-          path: binaryen-version_123
-          key: binaryen-123-x86_64-linux
-
-      - name: Install binaryen
-        if: steps.binaryen-cache.outputs.cache-hit != 'true'
-        run: curl -L https://github.com/WebAssembly/binaryen/releases/download/version_123/binaryen-version_123-x86_64-linux.tar.gz | tar xz
-
-      - name: Add binaryen to PATH
-        run: echo "$PWD/binaryen-version_123/bin" >> "$GITHUB_PATH"
+      - name: Set up Binaryen
+        uses: ./.github/actions/binaryen
 
       - name: Deploy preview lobby Worker
         uses: cloudflare/wrangler-action@v4
@@ -841,7 +861,7 @@ jobs:
   # warming the workspace compile would need sccache or similar.
   build-server-binary:
     name: Build server binary (linux ${{ matrix.arch }})
-    if: ${{ github.repository == 'phase-rs/phase' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
+    needs: [deploy-gate]
     runs-on: ubuntu-latest
     timeout-minutes: 45
     permissions:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -840,12 +840,23 @@ jobs:
   # crate recompiles each time. The win here is parallelism, not incrementality;
   # warming the workspace compile would need sccache or similar.
   build-server-binary:
-    name: Build server binary
+    name: Build server binary (linux ${{ matrix.arch }})
     if: ${{ github.repository == 'phase-rs/phase' && (github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success') }}
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     permissions:
       contents: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Mirrors release.yml: amd64 native via musl-tools, arm64 cross via zig.
+          - arch: amd64
+            triple: x86_64-unknown-linux-musl
+            cargo_cmd: build
+          - arch: arm64
+            triple: aarch64-unknown-linux-musl
+            cargo_cmd: zigbuild
     steps:
       - uses: actions/checkout@v4
         with:
@@ -853,16 +864,22 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache-shared-key: rust-server
+          cache-shared-key: rust-server-${{ matrix.arch }}
 
-      - name: Install musl tools and target
+      - name: Install musl tools
+        if: matrix.cargo_cmd == 'build'
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends musl-tools
+
+      - name: Install zig cross toolchain
+        if: matrix.cargo_cmd == 'zigbuild'
+        run: pip install cargo-zigbuild==0.23.0 ziglang==0.16.0
+
+      - name: Add musl target
         # The musl target must be added explicitly with `rustup target add`, not
         # via setup-rust-toolchain's `targets:` input: rust-toolchain.toml pins
         # the toolchain and its own `targets` list (wasm32 only), which overrides
         # the action input. Mirrors release.yml's Linux server build.
-        run: |
-          sudo apt-get update && sudo apt-get install -y --no-install-recommends musl-tools
-          rustup target add x86_64-unknown-linux-musl
+        run: rustup target add ${{ matrix.triple }}
 
       - name: Build phase-server (static musl)
         # Static musl binary: no glibc dependency, so it runs on the slim debian
@@ -875,13 +892,13 @@ jobs:
           # unscoped workspace build unifies feed-scraper's native-tls reqwest
           # features into phase-server, dragging openssl-sys into the musl
           # cross-compile (which has no OpenSSL and fails).
-          cargo build -p phase-server --profile server-release --bin phase-server --target x86_64-unknown-linux-musl
-          cp target/x86_64-unknown-linux-musl/server-release/phase-server ./phase-server
+          cargo ${{ matrix.cargo_cmd }} -p phase-server --profile server-release --bin phase-server --target ${{ matrix.triple }}
+          cp target/${{ matrix.triple }}/server-release/phase-server ./phase-server
 
       - name: Upload server binary artifact
         uses: actions/upload-artifact@v4
         with:
-          name: server-binary
+          name: server-binary-${{ matrix.arch }}
           path: phase-server
           if-no-files-found: error
           retention-days: 1
@@ -911,16 +928,20 @@ jobs:
         with:
           ref: ${{ env.DEPLOY_SHA }}
 
-      - name: Download server binary artifact
+      - name: Download server binary artifacts
         uses: actions/download-artifact@v4
         with:
-          name: server-binary
-          path: .
+          pattern: server-binary-*
+          path: prebuilt
 
       - name: Verify build context
+        # The Dockerfile's prebuilt stage copies ./phase-server-<arch> per platform.
         run: |
-          test -s phase-server
-          chmod +x phase-server
+          for arch in amd64 arm64; do
+            test -s "prebuilt/server-binary-$arch/phase-server"
+            cp "prebuilt/server-binary-$arch/phase-server" "phase-server-$arch"
+            chmod +x "phase-server-$arch"
+          done
 
       - name: Compute image tags
         id: image
@@ -933,12 +954,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # QEMU only runs the runtime stage's apt-get for the arm64 leg; the
+      # binaries are prebuilt, so nothing heavy is emulated.
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+      - uses: docker/setup-buildx-action@v3
+
       - name: Build and push preview image
-        # BINARY_STAGE=prebuilt makes Docker copy the prebuilt musl binary
+        # BINARY_STAGE=prebuilt makes Docker copy the prebuilt musl binaries
         # instead of compiling in-container — the build is just apt + COPY.
+        # One manifest list covers both platforms under the same tag/digest.
         uses: docker/build-push-action@v6
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             BINARY_STAGE=prebuilt

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -892,7 +892,11 @@ jobs:
 
       - name: Install zig cross toolchain
         if: matrix.cargo_cmd == 'zigbuild'
-        run: pip install cargo-zigbuild==0.23.0 ziglang==0.16.0
+        # --break-system-packages: ubuntu-latest is 24.04, whose default
+        # Python is PEP 668 externally-managed since GitHub reverted its
+        # pip workaround (actions/runner-images#10897, 2025-05-09). Same
+        # flag the Dockerfile already passes for this identical install.
+        run: pip install --break-system-packages cargo-zigbuild==0.23.0 ziglang==0.16.0
 
       - name: Add musl target
         # The musl target must be added explicitly with `rustup target add`, not

--- a/.github/workflows/refresh-card-data.yml
+++ b/.github/workflows/refresh-card-data.yml
@@ -56,10 +56,17 @@ jobs:
     # Forks inherit the schedule but not CI_PAT, so a fork run would only fail
     # and spam the owner — keep it on the canonical repo. On a workflow_run
     # trigger, only proceed if the cache clear actually succeeded (a failed or
-    # cancelled clear left the caches as-is, so there is nothing new to fetch).
+    # cancelled clear left the caches as-is, so there is nothing new to fetch)
+    # and it ran in this repo, not a fork — same provenance requirement as
+    # deploy.yml's deploy-gate, since this job holds CI_PAT and `contents:
+    # write`. No head_branch pin here: unlike a deploy, Clear Caches is
+    # workflow_dispatch-only and is legitimately dispatched from any branch.
     if: >-
       github.repository == 'phase-rs/phase' &&
-      (github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success')
+      (github.event_name != 'workflow_run' || (
+        github.event.workflow_run.conclusion == 'success' &&
+        github.event.workflow_run.head_repository.full_name == github.repository
+      ))
     runs-on: ubuntu-latest
     timeout-minutes: 30
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -593,7 +593,11 @@ jobs:
 
       - name: Install zig cross toolchain
         if: matrix.cargo_cmd == 'zigbuild'
-        run: pip install cargo-zigbuild==0.23.0 ziglang==0.16.0
+        # --break-system-packages: ubuntu-latest is 24.04, whose default
+        # Python is PEP 668 externally-managed since GitHub reverted its
+        # pip workaround (actions/runner-images#10897, 2025-05-09). Same
+        # flag the Dockerfile already passes for this identical install.
+        run: pip install --break-system-packages cargo-zigbuild==0.23.0 ziglang==0.16.0
 
       - name: Add musl target
         # Must be `rustup target add`, not setup-rust-toolchain's `targets:`

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,19 +98,8 @@ jobs:
         with:
           tool: wasm-bindgen-cli@0.2.121
 
-      - name: Cache binaryen
-        id: binaryen-cache
-        uses: actions/cache@v4
-        with:
-          path: binaryen-version_123
-          key: binaryen-123-x86_64-linux
-
-      - name: Install binaryen
-        if: steps.binaryen-cache.outputs.cache-hit != 'true'
-        run: curl -L https://github.com/WebAssembly/binaryen/releases/download/version_123/binaryen-version_123-x86_64-linux.tar.gz | tar xz
-
-      - name: Add binaryen to PATH
-        run: echo "$PWD/binaryen-version_123/bin" >> $GITHUB_PATH
+      - name: Set up Binaryen
+        uses: ./.github/actions/binaryen
 
       - uses: pnpm/action-setup@v4
         with:
@@ -775,21 +764,9 @@ jobs:
           # lobby-worker/broker-wasm/Cargo.toml (schema versions must be exact).
           tool: wasm-bindgen-cli@0.2.121
 
-      - name: Cache binaryen
-        id: binaryen-cache
+      - name: Set up Binaryen
         if: steps.lobby-worker.outputs.exists == 'true'
-        uses: actions/cache@v4
-        with:
-          path: binaryen-version_123
-          key: binaryen-123-x86_64-linux
-
-      - name: Install binaryen
-        if: steps.lobby-worker.outputs.exists == 'true' && steps.binaryen-cache.outputs.cache-hit != 'true'
-        run: curl -L https://github.com/WebAssembly/binaryen/releases/download/version_123/binaryen-version_123-x86_64-linux.tar.gz | tar xz
-
-      - name: Add binaryen to PATH
-        if: steps.lobby-worker.outputs.exists == 'true'
-        run: echo "$PWD/binaryen-version_123/bin" >> "$GITHUB_PATH"
+        uses: ./.github/actions/binaryen
 
       - name: Deploy lobby Worker to Cloudflare
         if: steps.lobby-worker.outputs.exists == 'true'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -553,20 +553,36 @@ jobs:
           retention-days: 90
 
   # ── Server binary compile (linux musl, shared) ──────────────────────────────
-  # Compiles the static musl binary ONCE per release run. Consumed by both
-  # build-server-image (prebuilt Docker image) and build-server's linux leg
-  # (slim server asset), so neither pays a redundant ~10min compile. Needs nothing
-  # the data pipeline produces, so it starts immediately.
+  # Compiles the static musl binaries ONCE per release run, one matrix leg per
+  # image architecture. Consumed by build-server-image (multi-arch prebuilt
+  # image) and build-server's linux leg (slim x86_64 asset), so neither pays a
+  # redundant ~10min compile. Needs nothing the data pipeline produces, so it
+  # starts immediately.
   build-server-binary:
-    name: Build Server Binary (linux)
+    name: Build Server Binary (linux ${{ matrix.arch }})
     needs: [resolve-release-ref]
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    # The zig cross-compile leg does the same ~10min of work as the native one
+    # but has no history on these runners; headroom over the old 30.
+    timeout-minutes: 45
     permissions:
       contents: read
     env:
       RELEASE_SHA: ${{ needs.resolve-release-ref.outputs.release_sha }}
       PHASE_CHANNEL: release
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # amd64 keeps the native musl-tools build the slim release asset has
+          # always shipped from; arm64 cross-compiles with zig as the C
+          # toolchain (same mechanism as the Dockerfile's compile stage).
+          - arch: amd64
+            triple: x86_64-unknown-linux-musl
+            cargo_cmd: build
+          - arch: arm64
+            triple: aarch64-unknown-linux-musl
+            cargo_cmd: zigbuild
     steps:
       - uses: actions/checkout@v4
         with:
@@ -574,17 +590,27 @@ jobs:
 
       - uses: actions-rust-lang/setup-rust-toolchain@v1
         with:
-          cache-shared-key: rust-server-linux
+          cache-shared-key: rust-server-linux-${{ matrix.arch }}
           # CI owns the warning-as-error gate. Release profiles compile out
           # debug-only assertions, which can legitimately leave their inputs
           # unused in an otherwise CI-clean tagged source tree.
           rustflags: ""
 
-      - name: Install musl tools and target
+      - name: Install musl tools
+        if: matrix.cargo_cmd == 'build'
         run: |
           sudo apt-get update
           sudo apt-get install -y musl-tools
-          rustup target add x86_64-unknown-linux-musl
+
+      - name: Install zig cross toolchain
+        if: matrix.cargo_cmd == 'zigbuild'
+        run: pip install cargo-zigbuild==0.23.0 ziglang==0.16.0
+
+      - name: Add musl target
+        # Must be `rustup target add`, not setup-rust-toolchain's `targets:`
+        # input: rust-toolchain.toml pins its own targets list (wasm32 only),
+        # which overrides the action input.
+        run: rustup target add ${{ matrix.triple }}
 
       - name: Build phase-server (static musl)
         # No chmod here: upload-artifact strips the executable bit anyway; both
@@ -593,13 +619,13 @@ jobs:
           # -p scopes feature unification to phase-server's own graph — an
           # unscoped workspace build unifies feed-scraper's native-tls reqwest
           # features in, dragging openssl-sys into the musl cross-compile.
-          cargo build -p phase-server --profile server-release --bin phase-server --target x86_64-unknown-linux-musl
-          cp target/x86_64-unknown-linux-musl/server-release/phase-server ./phase-server
+          cargo ${{ matrix.cargo_cmd }} -p phase-server --profile server-release --bin phase-server --target ${{ matrix.triple }}
+          cp target/${{ matrix.triple }}/server-release/phase-server ./phase-server
 
       - name: Upload server binary artifact
         uses: actions/upload-artifact@v4
         with:
-          name: server-binary-linux
+          name: server-binary-linux-${{ matrix.arch }}
           path: phase-server
           if-no-files-found: error
           retention-days: 1
@@ -621,16 +647,20 @@ jobs:
         with:
           ref: ${{ env.RELEASE_SHA }}
 
-      - name: Download server binary
+      - name: Download server binaries
         uses: actions/download-artifact@v4
         with:
-          name: server-binary-linux
-          path: .
+          pattern: server-binary-linux-*
+          path: prebuilt
 
       - name: Verify build context
+        # The Dockerfile's prebuilt stage copies ./phase-server-<arch> per platform.
         run: |
-          test -s phase-server
-          chmod +x phase-server
+          for arch in amd64 arm64; do
+            test -s "prebuilt/server-binary-linux-$arch/phase-server"
+            cp "prebuilt/server-binary-linux-$arch/phase-server" "phase-server-$arch"
+            chmod +x "phase-server-$arch"
+          done
 
       - name: Login to GHCR
         uses: docker/login-action@v3
@@ -639,14 +669,23 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # QEMU only runs the runtime stage's apt-get for the arm64 leg; the
+      # binaries are prebuilt, so nothing heavy is emulated.
+      - uses: docker/setup-qemu-action@v3
+        with:
+          platforms: arm64
+      - uses: docker/setup-buildx-action@v3
+
       - name: Build and push release image
-        # BINARY_STAGE=prebuilt: copy the musl binary from build-server-binary
+        # BINARY_STAGE=prebuilt: copy the musl binaries from build-server-binary
         # instead of compiling in-container — the build is just apt + COPY.
+        # One manifest list covers both platforms under the same tag/digest.
         uses: docker/build-push-action@v6
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
         with:
           context: .
+          platforms: linux/amd64,linux/arm64
           push: true
           build-args: |
             BINARY_STAGE=prebuilt
@@ -820,7 +859,7 @@ jobs:
         if: matrix.triple == 'x86_64-unknown-linux-musl'
         uses: actions/download-artifact@v4
         with:
-          name: server-binary-linux
+          name: server-binary-linux-amd64
           path: target/x86_64-unknown-linux-musl/server-release
 
       - name: Prepare slim server binary (Unix)

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,23 +1,31 @@
 # syntax=docker/dockerfile:1
 
 # BINARY_STAGE selects how the phase-server binary arrives in the runtime image:
-#   - "compile"  (default): build it from source inside Docker. Used by
-#     release.yml's build-server-image and any plain `docker build`.
-#   - "prebuilt": copy a binary already compiled on the host. CI builds a static
-#     musl binary natively with a warm cargo cache (far faster than a cold
-#     in-container release build), then passes --build-arg BINARY_STAGE=prebuilt.
-#     The static musl binary has no glibc dependency, so it runs on the slim
-#     debian runtime regardless of the host's glibc version. See deploy.yml.
+#   - "compile"  (default): cross-compile from source on the BUILD host for each
+#     requested platform, so one plain
+#       docker buildx build --platform linux/amd64,linux/arm64 .
+#     yields a multi-arch image with no emulated cargo run.
+#   - "prebuilt": copy ./phase-server-<amd64|arm64> (static musl binaries built
+#     outside Docker with a warm cargo cache) from the build context; the image
+#     build is then just apt + COPY. Used by release.yml and deploy.yml.
+#
+# PHASE_CHANNEL (compile stage only; e.g. "release", as release.yml sets for
+# its native builds) bakes the data-manifest identity into the binary so an
+# empty PHASE_DATA_DIR self-bootstraps card data on first boot. Unset = no
+# identity: such an image needs PHASE_DATA_MANIFEST_URL or pre-provisioned data.
 ARG BINARY_STAGE=compile
 
-FROM rust:slim-bookworm AS compile
+FROM --platform=$BUILDPLATFORM rust:slim-bookworm AS compile
+ARG TARGETARCH
+ARG PHASE_CHANNEL
 
+# zig is the C cross-compiler/linker for the musl targets (ring, bundled
+# SQLite, mimalloc). It runs on any build host, unlike per-target gcc tarballs.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    build-essential \
     ca-certificates \
-    libssl-dev \
-    pkg-config \
-    && rm -rf /var/lib/apt/lists/*
+    python3-pip \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --break-system-packages --no-cache-dir cargo-zigbuild==0.23.0 ziglang==0.16.0
 
 WORKDIR /app
 
@@ -25,14 +33,33 @@ COPY . .
 
 # -p scopes feature unification to phase-server's own graph: unscoped, the
 # workspace unifies feed-scraper's native-tls reqwest features in, dynamically
-# linking OpenSSL — which the slim runtime image does not ship.
-RUN cargo build -p phase-server --profile server-release --bin phase-server \
-    && cp target/server-release/phase-server /phase-server
+# linking OpenSSL — which the musl target and the slim runtime image lack.
+# Every cache is keyed per arch: a multi-platform build runs both legs
+# concurrently, and cargo's package-cache lock lives in $CARGO_HOME itself
+# (outside these mounts), so two legs sharing one registry dir race on
+# unpacking crates (measured: "failed to unpack package … File exists").
+# BuildKit's default 1024-fd soft limit is too low for zig/lld to link the
+# final binary (ProcessFdQuotaExceeded); the hard limit is far higher.
+RUN --mount=type=cache,target=/usr/local/cargo/registry,id=phase-server-cargo-registry-$TARGETARCH \
+    --mount=type=cache,target=/usr/local/cargo/git,id=phase-server-cargo-git-$TARGETARCH \
+    --mount=type=cache,target=/app/target,id=phase-server-target-$TARGETARCH \
+    ulimit -n 65536 \
+    && case "$TARGETARCH" in \
+      amd64) TARGET=x86_64-unknown-linux-musl ;; \
+      arm64) TARGET=aarch64-unknown-linux-musl ;; \
+      *) echo "unsupported TARGETARCH=$TARGETARCH" >&2; exit 1 ;; \
+    esac \
+    && rustup target add "$TARGET" \
+    && ${PHASE_CHANNEL:+env PHASE_CHANNEL="$PHASE_CHANNEL"} \
+       cargo zigbuild -p phase-server --profile server-release --bin phase-server --target "$TARGET" \
+    && cp "target/$TARGET/server-release/phase-server" /phase-server
 
-# Prebuilt path: expects ./phase-server (a static musl binary) in the build
-# context. Only built when BINARY_STAGE=prebuilt; otherwise BuildKit skips it.
-FROM debian:bookworm-slim AS prebuilt
-COPY phase-server /phase-server
+# Prebuilt path: expects ./phase-server-<arch> (static musl) in the build
+# context for every platform being built. Only evaluated when
+# BINARY_STAGE=prebuilt; otherwise BuildKit skips it.
+FROM scratch AS prebuilt
+ARG TARGETARCH
+COPY phase-server-${TARGETARCH} /phase-server
 
 # Resolve the selected source to a single stage name the runtime copies from.
 FROM ${BINARY_STAGE} AS binary

--- a/README.md
+++ b/README.md
@@ -135,7 +135,6 @@ The easiest way to run a dedicated multiplayer server is the Docker image:
 ```bash
 docker volume create phase-server-data
 docker run -d \
-  --platform linux/amd64 \
   --name phase-server \
   --restart unless-stopped \
   -p 9374:9374 \
@@ -145,7 +144,8 @@ docker run -d \
   ghcr.io/phase-rs/phase-server:latest
 ```
 
-The image includes the server binary and generated card data. It exposes:
+The image (linux/amd64 and linux/arm64) includes the server binary; card data is
+downloaded into the data volume on first boot. It exposes:
 
 - `http://localhost:9374/health` for health checks
 - `ws://localhost:9374/ws` for WebSocket clients
@@ -170,7 +170,7 @@ Docker uses environment variables for the common options:
 You can also pass server flags after the image name:
 
 ```bash
-docker run --rm --platform linux/amd64 -p 9374:9374 ghcr.io/phase-rs/phase-server:latest --lobby-only --cors-origin '*'
+docker run --rm -p 9374:9374 ghcr.io/phase-rs/phase-server:latest --lobby-only --cors-origin '*'
 ```
 
 For public internet play, put the container behind a TLS reverse proxy and give
@@ -179,7 +179,6 @@ same host, bind Docker to localhost instead:
 
 ```bash
 docker run -d \
-  --platform linux/amd64 \
   --name phase-server \
   --restart unless-stopped \
   -p 127.0.0.1:9374:9374 \
@@ -190,6 +189,17 @@ docker run -d \
 ```
 
 The same flags work when running the `phase-server` release binary directly.
+
+To build the image yourself (cross-compiles on the build host, no emulated
+cargo):
+
+```bash
+docker buildx create --use   # once: multi-platform builds need a docker-container builder
+docker buildx build --platform linux/amd64,linux/arm64 --build-arg PHASE_CHANNEL=release \
+  -t <registry>/phase-server:latest --push .
+```
+
+For Kubernetes, see the Helm chart in [`deploy/helm/phase-server`](deploy/helm/phase-server).
 
 ## Architecture
 

--- a/deploy/helm/phase-server/Chart.yaml
+++ b/deploy/helm/phase-server/Chart.yaml
@@ -1,0 +1,9 @@
+apiVersion: v2
+name: phase-server
+description: phase.rs multiplayer server (Axum WebSocket) behind Traefik + cert-manager
+type: application
+version: 0.1.0
+appVersion: "0.59.0"
+home: https://github.com/phase-rs/phase
+sources:
+  - https://github.com/phase-rs/phase

--- a/deploy/helm/phase-server/README.md
+++ b/deploy/helm/phase-server/README.md
@@ -1,0 +1,77 @@
+# phase-server Helm chart
+
+Runs one `phase-server` pod behind a Traefik Ingress with a cert-manager TLS
+certificate. Mirrors `deploy/deploy.sh` (data volume at `/var/lib/phase-server`,
+`/health` probes) but with the hardening Kubernetes makes cheap.
+
+```bash
+helm install phase-server deploy/helm/phase-server -n phase --create-namespace \
+  --set ingress.host=phase.example.com \
+  --set ingress.tls.clusterIssuer=letsencrypt \
+  --set networkPolicy.ingressNamespaceLabels."kubernetes\.io/metadata\.name"=kube-system  # your Traefik's namespace
+```
+
+Players enter `wss://phase.example.com/ws` in the client's Server picker.
+
+## What the chart assumes about the server
+
+Measured against `crates/phase-server` v0.59.0:
+
+- One process holds all state (sessions, lobby, SQLite `games.db`), so
+  `replicas` is hard-coded to 1 and the Deployment uses `Recreate`.
+- `card-data.json` (~100 MiB) is required even in lobby-only mode. A release
+  build (`PHASE_CHANNEL=release`) downloads it from `data.phase-rs.dev` on first
+  boot; the `startupProbe` allows 10 minutes for that. Images built without a
+  channel identity need `server.dataManifestUrl`.
+- The server has no TLS, no proxy-header handling and no per-IP limits (only a
+  global cap of 200 connections and 30 msgs/s per socket), so those live in
+  Traefik middlewares (`traefik.middlewares`). "Per source" is only meaningful
+  if Traefik sees real client addresses — see `traefik.middlewares.sourceCriterion`.
+- `/admin/*` only exists when `PHASE_ADMIN_TOKEN` is set and is never routed
+  through the Ingress; use `kubectl port-forward svc/<release> 9374` (an IP
+  allow-list would fail open behind a SNAT'ing load balancer).
+- `/p2p-draft-backup` accepts unauthenticated 1 MiB JSON writes that only a
+  restart purges; it gets its own Ingress with a body-size cap and a rate limit
+  that bounds PVC growth. Size `persistence.size` with that in mind.
+- SIGTERM triggers a session flush; open WebSockets are not closed by the server,
+  so the pod is killed after `terminationGracePeriodSeconds`.
+
+## Behind Cloudflare
+
+Traefik typically sees a SNAT'd node IP (Service `externalTrafficPolicy: Cluster`),
+which makes socket-peer rate limiting meaningless. With `cloudflare.enabled=true`
+the limits key on `CF-Connecting-IP` — a header anyone who reaches the origin
+directly can forge, and each forged value gets its own bucket, so the chart
+refuses to render that way unless the origin is Cloudflare-only: enable
+`cloudflare.authenticatedOriginPulls` and turn on *Authenticated Origin Pulls*
+for the zone (Traefik then requires Cloudflare's client certificate on the TLS
+handshake for this host only), or set `cloudflare.trustHeaderWithoutOriginPulls`
+if a firewall or Cloudflare Tunnel already guarantees it. Traefik falls back to default TLS options if another
+router serves the same host with different options, so keep all Ingresses for
+the host in this chart.
+
+Cloudflare closes idle WebSockets after ~100 s; the client's 5 s application
+ping keeps game connections alive.
+
+## Building the image
+
+`ghcr.io/phase-rs/phase-server` is published for linux/amd64 and linux/arm64.
+To build your own (the Dockerfile cross-compiles on the build host with zig, so
+no emulated cargo; only the runtime stage's `apt-get` runs under QEMU for a
+foreign platform):
+
+```bash
+docker buildx create --use   # once: multi-platform needs a docker-container builder
+docker buildx build --platform linux/arm64 --build-arg PHASE_CHANNEL=release \
+  -t <you>/phase-server:v0.59.0 --push .
+```
+
+`PHASE_CHANNEL=release` is what lets an empty data volume self-bootstrap.
+Pin `image.digest` in your values; `:latest`-style tags resolve stale on some
+k3s nodes.
+
+## Values
+
+Every key is documented inline in [`values.yaml`](values.yaml). Single replica,
+Recreate strategy and RWO storage are not configurable: they follow from the
+server's one-process design, and a rollout is a few seconds of 503s.

--- a/deploy/helm/phase-server/templates/NOTES.txt
+++ b/deploy/helm/phase-server/templates/NOTES.txt
@@ -1,0 +1,9 @@
+phase-server {{ .Chart.AppVersion }} ({{ if .Values.server.lobbyOnly }}lobby-only{{ else }}full{{ end }} mode)
+
+{{- if .Values.ingress.enabled }}
+WebSocket URL for the client's Server picker:  wss://{{ .Values.ingress.host }}/ws
+Health:                                        https://{{ .Values.ingress.host }}/health
+{{- end }}
+
+First boot downloads ~100 MiB of card data into the PVC before /health answers.
+Follow with:  kubectl -n {{ .Release.Namespace }} logs deploy/{{ include "phase-server.fullname" . }} -f

--- a/deploy/helm/phase-server/templates/_helpers.tpl
+++ b/deploy/helm/phase-server/templates/_helpers.tpl
@@ -36,8 +36,20 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{/* PUBLIC_URL is what the server advertises to clients, so it is never
+     guessed. Deriving it from ingress.host is only sound when that host is
+     actually serving: with the ingress off it yields the values.yaml
+     placeholder, and with an empty host it yields "https://", which the server
+     warns on and discards (crates/phase-server/src/main.rs). Both are silent
+     misconfigurations, so fail rendering instead. */}}
 {{- define "phase-server.publicUrl" -}}
-{{- default (printf "https://%s" .Values.ingress.host) .Values.server.publicUrl -}}
+{{- if .Values.server.publicUrl -}}
+{{- .Values.server.publicUrl -}}
+{{- else if and .Values.ingress.enabled .Values.ingress.host -}}
+{{- printf "https://%s" .Values.ingress.host -}}
+{{- else -}}
+{{- fail "server.publicUrl is required here: it is the URL the server advertises to clients, and there is no ingress.host to derive it from (ingress.enabled is false, or ingress.host is empty). Set server.publicUrl, or enable the ingress with a real host." -}}
+{{- end -}}
 {{- end -}}
 
 {{- define "phase-server.tlsSecretName" -}}

--- a/deploy/helm/phase-server/templates/_helpers.tpl
+++ b/deploy/helm/phase-server/templates/_helpers.tpl
@@ -1,0 +1,83 @@
+{{- define "phase-server.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "phase-server.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "phase-server.labels" -}}
+helm.sh/chart: {{ printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" }}
+{{ include "phase-server.selectorLabels" . }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}
+
+{{- define "phase-server.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "phase-server.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end -}}
+
+{{- define "phase-server.image" -}}
+{{- $tag := default (printf "v%s" .Chart.AppVersion) .Values.image.tag -}}
+{{- if .Values.image.digest -}}
+{{- printf "%s:%s@%s" .Values.image.repository $tag .Values.image.digest -}}
+{{- else -}}
+{{- printf "%s:%s" .Values.image.repository $tag -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "phase-server.publicUrl" -}}
+{{- default (printf "https://%s" .Values.ingress.host) .Values.server.publicUrl -}}
+{{- end -}}
+
+{{- define "phase-server.tlsSecretName" -}}
+{{- default (printf "%s-tls" (include "phase-server.fullname" .)) .Values.ingress.tls.secretName -}}
+{{- end -}}
+
+{{/* "<ns>-<fullname>-<suffix>@kubernetescrd" — Traefik's name for a Middleware/TLSOption CRD */}}
+{{- define "phase-server.crdRef" -}}
+{{- printf "%s-%s-%s@kubernetescrd" .ctx.Release.Namespace (include "phase-server.fullname" .ctx) .suffix -}}
+{{- end -}}
+
+{{/* Middlewares applied to every public route */}}
+{{- define "phase-server.commonMiddlewares" -}}
+{{- $list := list -}}
+{{- if .Values.traefik.middlewares.enabled -}}
+{{- $list = append $list (include "phase-server.crdRef" (dict "ctx" . "suffix" "ratelimit")) -}}
+{{- $list = append $list (include "phase-server.crdRef" (dict "ctx" . "suffix" "inflight")) -}}
+{{- $list = append $list (include "phase-server.crdRef" (dict "ctx" . "suffix" "headers")) -}}
+{{- end -}}
+{{- $list = concat $list (default (list) .Values.traefik.middlewares.extra) -}}
+{{- join "," $list -}}
+{{- end -}}
+
+{{/* Traefik source criterion for the per-source middlewares */}}
+{{- define "phase-server.sourceCriterion" -}}
+{{- if .Values.cloudflare.enabled -}}
+{{- if not (or .Values.cloudflare.authenticatedOriginPulls.enabled .Values.cloudflare.trustHeaderWithoutOriginPulls) -}}
+{{- fail "cloudflare.enabled keys rate limits on CF-Connecting-IP, which anyone reaching the origin directly can forge (each forged value gets its own bucket). Enable cloudflare.authenticatedOriginPulls, or set cloudflare.trustHeaderWithoutOriginPulls=true if a firewall/Tunnel already restricts the origin to Cloudflare." -}}
+{{- end -}}
+requestHeaderName: CF-Connecting-IP
+{{- else -}}
+{{- toYaml .Values.traefik.middlewares.sourceCriterion -}}
+{{- end -}}
+{{- end -}}
+
+{{- define "phase-server.ingressAnnotations" -}}
+{{- with .Values.ingress.annotations }}
+{{- toYaml . }}
+{{ end -}}
+{{- if .Values.cloudflare.authenticatedOriginPulls.enabled }}
+traefik.ingress.kubernetes.io/router.tls.options: {{ include "phase-server.crdRef" (dict "ctx" . "suffix" "cf-origin-pull") | quote }}
+{{- end }}
+{{- end -}}

--- a/deploy/helm/phase-server/templates/deployment.yaml
+++ b/deploy/helm/phase-server/templates/deployment.yaml
@@ -1,0 +1,124 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "phase-server.fullname" . }}
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  # Not configurable: sessions, the lobby and the SQLite games.db are
+  # per-process state, and two pods on one node could share the RWO PVC.
+  replicas: 1
+  strategy:
+    type: Recreate
+  selector:
+    matchLabels:
+      {{- include "phase-server.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      labels:
+        {{- include "phase-server.selectorLabels" . | nindent 8 }}
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    spec:
+      serviceAccountName: default
+      automountServiceAccountToken: false
+      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      containers:
+        - name: phase-server
+          image: {{ include "phase-server.image" . }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          # Bypass the image's root entrypoint (mkdir/chown + gosu); the pod
+          # securityContext already runs us as the `phase` uid with fsGroup.
+          command: ["phase-server"]
+          args:
+            {{- if .Values.server.allowedOrigin }}
+            - --allowed-origin
+            - {{ .Values.server.allowedOrigin | quote }}
+            {{- end }}
+            {{- if .Values.server.noDataDownload }}
+            - --no-data-download
+            {{- end }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          env:
+            - name: PORT
+              value: {{ .Values.service.port | quote }}
+            - name: PHASE_DATA_DIR
+              value: /var/lib/phase-server
+            - name: PHASE_LOBBY_ONLY
+              value: {{ .Values.server.lobbyOnly | quote }}
+            - name: PHASE_CORS_ORIGIN
+              value: {{ .Values.server.corsOrigin | quote }}
+            - name: PHASE_LOG_JSON
+              value: {{ .Values.server.logJson | quote }}
+            - name: RUST_LOG
+              value: {{ .Values.server.rustLog | quote }}
+            - name: PUBLIC_URL
+              value: {{ include "phase-server.publicUrl" . | quote }}
+            {{- with .Values.server.dataManifestUrl }}
+            - name: PHASE_DATA_MANIFEST_URL
+              value: {{ . | quote }}
+            {{- end }}
+            {{- with .Values.server.adminTokenSecret }}
+            - name: PHASE_ADMIN_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: {{ . }}
+                  key: {{ $.Values.server.adminTokenSecretKey }}
+            {{- end }}
+            {{- with .Values.server.extraEnv }}
+            {{- toYaml . | nindent 12 }}
+            {{- end }}
+          ports:
+            - name: http
+              containerPort: {{ .Values.service.port }}
+              protocol: TCP
+          startupProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+          readinessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 10
+          livenessProbe:
+            httpGet:
+              path: /health
+              port: http
+            periodSeconds: 30
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/phase-server
+      volumes:
+        - name: data
+          {{- if .Values.persistence.enabled }}
+          persistentVolumeClaim:
+            claimName: {{ default (printf "%s-data" (include "phase-server.fullname" .)) .Values.persistence.existingClaim }}
+          {{- else }}
+          emptyDir: {}
+          {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/deploy/helm/phase-server/templates/ingress.yaml
+++ b/deploy/helm/phase-server/templates/ingress.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.ingress.enabled }}
+{{- $fullname := include "phase-server.fullname" . }}
+{{- $common := include "phase-server.commonMiddlewares" . }}
+{{- $backupMw := $common }}
+{{- if .Values.traefik.middlewares.enabled }}
+{{- $backupMw = printf "%s,%s,%s" (include "phase-server.crdRef" (dict "ctx" . "suffix" "backup-ratelimit")) (include "phase-server.crdRef" (dict "ctx" . "suffix" "backup-buffering")) $common }}
+{{- end }}
+{{- /* One Ingress per middleware set: /ws (+/health) and the backup API. Only the
+     first carries the cert-manager annotation so ingress-shim manages one
+     Certificate for the shared secret. */}}
+{{- range $i, $route := list
+      (dict "suffix" "" "paths" (list "/ws" "/health") "mw" $common)
+      (dict "suffix" "-backup" "paths" (list "/p2p-draft-backup") "mw" $backupMw) }}
+---
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $fullname }}{{ $route.suffix }}
+  labels:
+    {{- include "phase-server.labels" $ | nindent 4 }}
+  annotations:
+    {{- include "phase-server.ingressAnnotations" $ | nindent 4 }}
+    {{- if eq $i 0 }}
+    {{- if $.Values.ingress.tls.clusterIssuer }}
+    cert-manager.io/cluster-issuer: {{ $.Values.ingress.tls.clusterIssuer | quote }}
+    {{- else if $.Values.ingress.tls.issuer }}
+    cert-manager.io/issuer: {{ $.Values.ingress.tls.issuer | quote }}
+    {{- end }}
+    {{- end }}
+    {{- if $route.mw }}
+    traefik.ingress.kubernetes.io/router.middlewares: {{ $route.mw | quote }}
+    {{- end }}
+spec:
+  ingressClassName: {{ $.Values.ingress.className }}
+  tls:
+    - hosts:
+        - {{ $.Values.ingress.host }}
+      secretName: {{ include "phase-server.tlsSecretName" $ }}
+  rules:
+    - host: {{ $.Values.ingress.host }}
+      http:
+        paths:
+          {{- range $p := $route.paths }}
+          - path: {{ $p }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $fullname }}
+                port:
+                  name: http
+          {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/phase-server/templates/middlewares.yaml
+++ b/deploy/helm/phase-server/templates/middlewares.yaml
@@ -1,0 +1,68 @@
+{{- if and .Values.ingress.enabled .Values.traefik.middlewares.enabled }}
+{{- $fullname := include "phase-server.fullname" . }}
+{{- $mw := .Values.traefik.middlewares }}
+{{- $source := include "phase-server.sourceCriterion" . }}
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $fullname }}-ratelimit
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  rateLimit:
+    average: {{ $mw.rateLimit.average }}
+    burst: {{ $mw.rateLimit.burst }}
+    sourceCriterion:
+      {{- $source | nindent 6 }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $fullname }}-inflight
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  inFlightReq:
+    amount: {{ $mw.inFlightReq.amount }}
+    sourceCriterion:
+      {{- $source | nindent 6 }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $fullname }}-headers
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  headers:
+    stsSeconds: {{ int64 $mw.headers.stsSeconds }}
+    stsIncludeSubdomains: false
+    contentTypeNosniff: true
+    frameDeny: true
+    referrerPolicy: no-referrer
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $fullname }}-backup-ratelimit
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  rateLimit:
+    average: {{ $mw.backup.rateLimit.average }}
+    period: {{ $mw.backup.rateLimit.period }}
+    burst: {{ $mw.backup.rateLimit.burst }}
+    sourceCriterion:
+      {{- $source | nindent 6 }}
+---
+apiVersion: traefik.io/v1alpha1
+kind: Middleware
+metadata:
+  name: {{ $fullname }}-backup-buffering
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  buffering:
+    maxRequestBodyBytes: {{ int64 $mw.backup.maxRequestBodyBytes }}
+    memRequestBodyBytes: {{ int64 $mw.backup.maxRequestBodyBytes }}
+{{- end }}

--- a/deploy/helm/phase-server/templates/networkpolicy.yaml
+++ b/deploy/helm/phase-server/templates/networkpolicy.yaml
@@ -1,0 +1,41 @@
+{{- if .Values.networkPolicy.enabled }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ include "phase-server.fullname" . }}
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  podSelector:
+    matchLabels:
+      {{- include "phase-server.selectorLabels" . | nindent 6 }}
+  policyTypes: [Ingress, Egress]
+  ingress:
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.networkPolicy.ingressNamespaceLabels | nindent 14 }}
+      ports:
+        - port: http
+          protocol: TCP
+  egress:
+    - to:
+        - namespaceSelector:
+            matchLabels:
+              kubernetes.io/metadata.name: kube-system
+      ports:
+        - port: 53
+          protocol: UDP
+        - port: 53
+          protocol: TCP
+    {{- if .Values.networkPolicy.allowBootstrapEgress }}
+    # Card-data bootstrap (https://data.phase-rs.dev); nothing on the LAN.
+    - to:
+        - ipBlock:
+            cidr: 0.0.0.0/0
+            except: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16]
+      ports:
+        - port: 443
+          protocol: TCP
+    {{- end }}
+{{- end }}

--- a/deploy/helm/phase-server/templates/pvc.yaml
+++ b/deploy/helm/phase-server/templates/pvc.yaml
@@ -1,0 +1,17 @@
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ include "phase-server.fullname" . }}-data
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  accessModes:
+    - ReadWriteOnce
+  {{- with .Values.persistence.storageClass }}
+  storageClassName: {{ . | quote }}
+  {{- end }}
+  resources:
+    requests:
+      storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/deploy/helm/phase-server/templates/service.yaml
+++ b/deploy/helm/phase-server/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "phase-server.fullname" . }}
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "phase-server.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/phase-server/templates/tlsoption.yaml
+++ b/deploy/helm/phase-server/templates/tlsoption.yaml
@@ -1,0 +1,28 @@
+{{- if .Values.cloudflare.authenticatedOriginPulls.enabled }}
+{{- $fullname := include "phase-server.fullname" . }}
+{{- $ca := required "cloudflare.authenticatedOriginPulls.caPem is required" .Values.cloudflare.authenticatedOriginPulls.caPem }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ $fullname }}-cf-origin-pull-ca
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+type: Opaque
+data:
+  tls.ca: {{ $ca | b64enc }}
+---
+# Only Cloudflare holds a client certificate signed by this CA, so direct
+# connections to the origin for this SNI fail the TLS handshake.
+apiVersion: traefik.io/v1alpha1
+kind: TLSOption
+metadata:
+  name: {{ $fullname }}-cf-origin-pull
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  minVersion: VersionTLS12
+  clientAuth:
+    secretNames:
+      - {{ $fullname }}-cf-origin-pull-ca
+    clientAuthType: RequireAndVerifyClientCert
+{{- end }}

--- a/deploy/helm/phase-server/values.yaml
+++ b/deploy/helm/phase-server/values.yaml
@@ -19,7 +19,11 @@ server:
   # match, one origin). Origin-less clients (desktop app, curl) still connect.
   allowedOrigin: ""
   # Advertised in ServerHello so hosts can share "CODE@host" join strings.
-  # Defaults to https://<ingress.host>.
+  # Must be an absolute URL with a host, e.g. https://play.example.com — the
+  # server validates it at startup (validate_public_url) and advertises nothing
+  # if it does not parse, so a bare host or scheme-only value silently costs
+  # clients their join URL. Defaults to https://<ingress.host> when the ingress
+  # is enabled; required otherwise.
   publicUrl: ""
   # Sets PHASE_DATA_MANIFEST_URL. Only needed if the image was built without
   # PHASE_CHANNEL (e.g. upstream :preview images); release builds derive it.

--- a/deploy/helm/phase-server/values.yaml
+++ b/deploy/helm/phase-server/values.yaml
@@ -1,0 +1,170 @@
+# Default values for phase-server. See README.md for the deployment model.
+
+image:
+  # Published for linux/amd64 and linux/arm64 from release.yml.
+  repository: ghcr.io/phase-rs/phase-server
+  tag: ""            # defaults to .Chart.appVersion prefixed with "v"
+  digest: ""         # optional sha256:... — pins the image regardless of tag
+  pullPolicy: IfNotPresent
+
+server:
+  # Matchmaking-broker-only mode (no server-hosted games/drafts). Upstream's
+  # public server runs lobby-only; a self-hosted server is usually wanted for
+  # server-hosted games, so the default is full mode.
+  lobbyOnly: false
+  # CORS for the HTTP routes (/health is fetched cross-origin by the client's
+  # "Test server" button). "*" or a single exact origin.
+  corsOrigin: "*"
+  # If set, /ws rejects browser upgrades whose Origin header differs (exact
+  # match, one origin). Origin-less clients (desktop app, curl) still connect.
+  allowedOrigin: ""
+  # Advertised in ServerHello so hosts can share "CODE@host" join strings.
+  # Defaults to https://<ingress.host>.
+  publicUrl: ""
+  # Sets PHASE_DATA_MANIFEST_URL. Only needed if the image was built without
+  # PHASE_CHANNEL (e.g. upstream :preview images); release builds derive it.
+  dataManifestUrl: ""
+  # Refuse to download card data at startup (data dir must be pre-provisioned).
+  noDataDownload: false
+  logJson: true
+  rustLog: info
+  # Existing Secret holding PHASE_ADMIN_TOKEN. Leave empty to keep /admin/*
+  # unmounted (404). /admin is never routed through the Ingress; reach it with
+  # `kubectl port-forward svc/<release> 9374`.
+  adminTokenSecret: ""
+  adminTokenSecretKey: token
+  extraEnv: []
+
+# PHASE_DATA_DIR: card-data.json (~100 MiB, downloaded on first boot),
+# draft-pools.json and the SQLite games.db (+WAL). Needs RWO block storage.
+persistence:
+  enabled: true
+  size: 2Gi
+  storageClass: ""     # "" = cluster default
+  existingClaim: ""
+
+resources:
+  requests:
+    cpu: 250m
+    memory: 768Mi   # measured idle RSS ~530 MiB (card DB)
+  limits:
+    memory: 2Gi
+
+# Time for the graceful-shutdown session flush. Open WebSockets are not
+# closed by the server, so the pod is SIGKILLed at the end of this window.
+terminationGracePeriodSeconds: 30
+
+# First boot may download ~100 MiB of card data before /health answers.
+startupProbe:
+  periodSeconds: 10
+  failureThreshold: 60
+
+# Image's `phase` user is uid/gid 999. The stock entrypoint chowns the data
+# dir as root then drops privileges; here the binary runs directly as 999 and
+# fsGroup makes the volume writable instead.
+podSecurityContext:
+  runAsNonRoot: true
+  runAsUser: 999
+  runAsGroup: 999
+  fsGroup: 999
+  fsGroupChangePolicy: OnRootMismatch
+  seccompProfile:
+    type: RuntimeDefault
+securityContext:
+  readOnlyRootFilesystem: true
+  allowPrivilegeEscalation: false
+  capabilities:
+    drop: ["ALL"]
+
+service:
+  type: ClusterIP
+  port: 9374
+
+ingress:
+  enabled: true
+  className: traefik
+  host: phase.example.com
+  # Only /ws, /health and /p2p-draft-backup are routed; /admin never is.
+  annotations:
+    traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    traefik.ingress.kubernetes.io/router.tls: "true"
+  tls:
+    secretName: ""                 # defaults to <release>-tls
+    clusterIssuer: ""              # cert-manager ClusterIssuer name
+    issuer: ""                     # or a namespaced Issuer
+
+# Traefik Middleware CRDs (traefik.io/v1alpha1).
+traefik:
+  middlewares:
+    enabled: true
+    # What "per source" means for the limits below. The default is the socket
+    # peer IP — which is a SNAT'd node IP when the ingress Service runs with
+    # externalTrafficPolicy: Cluster, collapsing every limit into one GLOBAL
+    # bucket (e.g. 25 WebSockets total). Either set the Service to
+    # externalTrafficPolicy: Local, or key on a trusted header: behind
+    # Cloudflare, cloudflare.enabled overrides this with CF-Connecting-IP.
+    sourceCriterion:
+      ipStrategy: {}
+    # Applied to every routed path.
+    rateLimit:
+      average: 20      # requests/second per source
+      burst: 50
+    inFlightReq:
+      amount: 25       # concurrent requests (WebSockets count) per source
+    # /p2p-draft-backup: unauthenticated 1 MiB JSON writes into SQLite that
+    # only a restart purges (>24h old). Drafts post a snapshot per pick, so a
+    # few per minute is plenty; this bounds PVC fill to ~12 MiB/min per source.
+    backup:
+      maxRequestBodyBytes: 1200000
+      rateLimit:
+        average: 1
+        period: 5s
+        burst: 10
+    headers:
+      stsSeconds: 31536000
+    # Middleware names (namespace-name@kubernetescrd) appended to all routes.
+    extra: []
+
+cloudflare:
+  # Site is proxied through Cloudflare (orange cloud): rate limits key on the
+  # CF-Connecting-IP header instead of the (SNAT'd) socket peer. Rendering
+  # fails unless the origin is provably Cloudflare-only (authenticatedOriginPulls
+  # below) or trustHeaderWithoutOriginPulls acknowledges another control.
+  enabled: false
+  # Only set true if a firewall (Cloudflare IP ranges) or Cloudflare Tunnel
+  # already guarantees nothing else reaches the origin; otherwise a forged
+  # header per request sidesteps every per-client limit.
+  trustHeaderWithoutOriginPulls: false
+  # Require Cloudflare's Authenticated Origin Pull client certificate on the
+  # TLS handshake for this host, so the origin cannot be reached directly with
+  # a forged CF-Connecting-IP. Enable "Authenticated Origin Pulls" in the zone.
+  authenticatedOriginPulls:
+    enabled: false
+    # https://developers.cloudflare.com/ssl/static/authenticated_origin_pull_ca.pem
+    caPem: ""
+
+networkPolicy:
+  enabled: true
+  # Namespace of the ingress controller — the only allowed ingress source.
+  # Stock k3s runs its bundled Traefik in kube-system; a Helm-installed Traefik
+  # is usually in `traefik` or `traefik-system`. A wrong value fails silently:
+  # the pod is Ready (kubelet probes are not policed) but every request 504s.
+  ingressNamespaceLabels:
+    kubernetes.io/metadata.name: kube-system
+  # Allow HTTPS egress to the public internet for the card-data bootstrap
+  # (and nothing else besides DNS). Set false once data is on the PVC.
+  allowBootstrapEgress: true
+
+# The binary is static musl; musl's resolver fails on search-list expansion
+# under the kubelet default ndots:5 (measured on k3s: "could not resolve
+# data.phase-rs.dev" while the absolute name works). The server only talks to
+# public hosts, so no search domains are needed.
+dnsConfig:
+  options:
+    - name: ndots
+      value: "1"
+
+nodeSelector: {}
+tolerations: []
+affinity: {}
+podAnnotations: {}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Adds a Helm chart (`deploy/helm/phase-server`) that hosts phase-server on Kubernetes behind Traefik + cert-manager with the hardening the server itself does not implement, and makes the server image multi-arch: the Dockerfile cross-compiles on the build host and release.yml/deploy.yml publish one linux/amd64 + linux/arm64 manifest. Verified end to end by deploying to an arm64 k3s cluster and reaching the server from the public internet through Cloudflare.

## Files changed

- `deploy/helm/phase-server/Chart.yaml`, `values.yaml`, `README.md`
- `deploy/helm/phase-server/templates/{_helpers.tpl,deployment.yaml,service.yaml,pvc.yaml,ingress.yaml,middlewares.yaml,tlsoption.yaml,networkpolicy.yaml,NOTES.txt}`
- `Dockerfile`
- `.github/workflows/release.yml`, `.github/workflows/deploy.yml`
- `README.md`

## Track

Developer

## LLM

Model: claude-fable-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — hosting infrastructure and CI packaging only; no `crates/` or client change. The `/engine-implementer` shape (read → plan → implement → independent multi-lens review → fix → accept) was followed with infrastructure reviewers instead of `/review-impl`; the report below is in that skill's Final Report form.

## CR references

None

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

See "Final Report → 6. Verification" for every command and result. CI has not run on this branch (fork); the Rust/client/lobby-worker jobs are untouched by the diff.

## Gate A

Gate A not-applicable (no parser or engine change) head=8c32d5dcff296587d09fe9d3510c2b104dec2554 base=d099f4fcf8d7afc2cc15823d31339842b4081efd

## Anchored on

- deploy/deploy.sh:53-61 — the env/volume/health contract the chart reproduces (PHASE_DATA_DIR volume, `/health` readiness, PHASE_LOBBY_ONLY / PHASE_CORS_ORIGIN)
- .github/workflows/release.yml `build-server-binary` (pre-change) — native static-musl build handed to the Dockerfile via `BINARY_STAGE=prebuilt`, extended to an amd64/arm64 matrix

## Final review-impl

Final review-impl not-applicable — replaced by the infrastructure review loop in "Final Report → 7" (1 round, 12 confirmed findings, all fixed at 19f3ef1f601e05d24690757061d6e55855b3e766).

## Final Report

1. **Read/plan rounds.** One parallel read of the server surface (6 readers + completeness critic: CLI/env, HTTP+WS surface, modes/client connection, arm64 build feasibility, security posture, existing deploy prior art), each claim cited to file:line and spot-checked. No surgical-fix mode. Two reader disagreements (existence of the v0.59.0 data manifest; self-bootstrap without `PHASE_CHANNEL`) were resolved by direct probes before design.

2. **What changed, by subsystem.**
   - *Chart — workload* (`templates/deployment.yaml`, `pvc.yaml`, `service.yaml`): one replica, `Recreate`, RWO PVC at `/var/lib/phase-server`; container runs `phase-server` directly as uid/gid 999 with `fsGroup` (bypassing the image's root `chown`+`gosu` entrypoint); read-only rootfs, drop ALL, `RuntimeDefault` seccomp, no SA token; startup/readiness/liveness on `GET /health` with a 10-minute startup window for the first-boot card-data download; `dnsConfig ndots:1`.
   - *Chart — edge* (`ingress.yaml`, `middlewares.yaml`, `tlsoption.yaml`): two Ingresses — `/ws`+`/health`, and `/p2p-draft-backup` with its own body cap and rate limit; `/admin` is never routed. Traefik `rateLimit`, `inFlightReq`, `headers` (HSTS, nosniff, frameDeny); opt-in TLSOption requiring Cloudflare's Authenticated-Origin-Pull client certificate.
   - *Chart — isolation* (`networkpolicy.yaml`): ingress only from the ingress-controller namespace; egress only DNS plus public :443 for the data bootstrap (RFC1918 excluded).
   - *Image* (`Dockerfile`): `compile` stage is `FROM --platform=$BUILDPLATFORM` and cross-compiles a static musl binary for `$TARGETARCH` with `cargo-zigbuild`; `ARG PHASE_CHANNEL`; `prebuilt` stage is `FROM scratch` + `COPY phase-server-${TARGETARCH}`. Runtime stage unchanged.
   - *CI* (`release.yml`, `deploy.yml`): `build-server-binary` is an `{amd64, arm64}` matrix (amd64 unchanged: `musl-tools`; arm64: zig); image jobs add `setup-qemu`/`setup-buildx` and `platforms: linux/amd64,linux/arm64`; artifacts renamed per arch; `build-server`'s linux leg consumes `server-binary-linux-amd64`.
   - *Docs* (`README.md`, chart README): `--platform linux/amd64` dropped from the Docker instructions; build-it-yourself command; chart deployment model and residual risks.

3. **Key decisions.**
   - *Full mode by default* (`server.lobbyOnly: false`): a self-hosted server's value is server-hosted games/drafts; upstream's public lobby-only deployment is one value away.
   - *Per-source limits key on a configurable `sourceCriterion`*, overridden to `CF-Connecting-IP` by `cloudflare.enabled`: with `externalTrafficPolicy: Cluster` Traefik sees SNAT'd node IPs, so socket-peer limits silently become global caps. Documented in values and README rather than hidden.
   - *No `/admin` route at all*: an RFC1918 allow-list fails open under that same SNAT; `kubectl port-forward` is the admin path.
   - *Cert-manager via Ingress annotation on the primary Ingress only*, so ingress-shim owns one Certificate for the shared secret.
   - *Image from the tagged release with `PHASE_CHANNEL=release`* so an empty PVC self-bootstraps signed card data; `server.dataManifestUrl` covers channel-less images.
   - *zig over a per-target gcc tarball*: it runs on any build host (Apple-silicon contributors included), and it was measured to produce a working binary here.

4. **SHAs and scope.** base=d099f4fcf8d7afc2cc15823d31339842b4081efd (rebased onto latest main); chart commit 3834afbfaf01eedaa2caec10725403c70aca6854; accepted head=8c32d5dcff296587d09fe9d3510c2b104dec2554. Frozen scope: `deploy/helm/**`, `Dockerfile`, `.github/workflows/{release,deploy,refresh-card-data}.yml`, `.github/actions/binaryen/**`, `README.md`. No parser change, so no parser measurement.

5. **Rounds.** Round 1 (4 lenses, 2 refuters each): 12 confirmed, fixed in place. Round 2 against the committed head (2 lenses): 5 confirmed — stock-k3s NetworkPolicy namespace default, inverted README claim about forged `CF-Connecting-IP`, nil-safe `concat`, per-arch cargo cache mounts (refuter reproduced registry corruption between concurrent legs), README build-command note. CodeRabbit: render now fails when `cloudflare.enabled` trusts `CF-Connecting-IP` without Authenticated Origin Pulls (or an explicit acknowledgement); `replicas` hard-coded to 1. All squashed into the two commits.

6. **Verification.**
   *Preparatory:*
   - `cargo tree -p phase-server -e normal,build --target aarch64-unknown-linux-musl -i cc` → only `ring`, `libsqlite3-sys` (bundled), `libmimalloc-sys` need a C cross-compiler.
   - `cargo zigbuild -p phase-server --profile server-release --bin phase-server --target aarch64-unknown-linux-musl` (host, `PHASE_CHANNEL=release`) → 7m37s, static stripped aarch64 ELF; `--target x86_64-unknown-linux-musl` → 11m54s (contended), static x86-64 ELF.
   - Native run of the aarch64 binary on an arm64 host against an empty data dir → downloaded+verified `card-data.json` (100,114,889 B) and `draft-pools.json`, `/health` → `ok` after ~16 s, clean SIGTERM shutdown.
   - `helm lint deploy/helm/phase-server` → 0 failed; `helm template … | kubectl apply --dry-run=server` on k3s v1.33.4 (Traefik v3.5.2, cert-manager v1.18.2) → all objects validated; every `.Values.*` referenced by a template exists in `values.yaml`.
   - `actionlint .github/workflows/release.yml .github/workflows/deploy.yml` → only the pre-existing `if: ${{ false }}` note.
   *Completion:*
   - `docker buildx build --platform linux/arm64 --build-arg PHASE_CHANNEL=release .` (compile path) → image; `docker run --platform linux/arm64 … --version` → `phase-server 0.59.0`. Cold in-container compile ≈13 min on 16 cores, 3m42s warm.
   - `docker buildx build --platform linux/amd64,linux/arm64 --build-arg BINARY_STAGE=prebuilt --push` → one manifest list with both platforms.
   - `helm install` on an arm64 k3s cluster behind Cloudflare: pod Ready; first boot bootstrapped card data into the PVC (35,798 cards, 173 draft sets); from the public internet: `GET /health` 200 with HSTS/nosniff/DENY headers and `access-control-allow-origin: *`; `/admin/drafts` and `/` → 404; 2 MB `POST /p2p-draft-backup` → 413; `wss://…/ws` → `ServerHello{server_version:"0.59.0", build_commit:"0de0b66ed", protocol_version:31, mode:"Full"}`; socket held 131 s through Cloudflare on the client's 5 s app pings; `touch /tmp/x` in the container → read-only filesystem; idle RSS 529 MiB.
   - `helm upgrade` to the multi-arch digest → rollout complete, `/health` 200, WS 101.

7. **Review rounds.** One round, four independent lenses (Helm correctness, public-exposure security, Dockerfile/CI, over-engineering), every finding adversarially checked by two refuters; 12 confirmed, 15 refuted. All 12 fixed: `/admin` allow-list fails open under SNAT (route removed); per-source limits collapse to global under SNAT (explicit `sourceCriterion` + docs); `ingress.tls.enabled=false` still forced TLS (knob removed); cert-manager annotation on every Ingress (primary only); large ints rendered as floats (`int64`); README build command produced no image (`--push`); backup rate could fill the PVC (1 req/5 s); stale values comment, drifted README table, unused `accessMode`/ServiceAccount (removed); arm64 CI leg timeout (45 min).

8. **Commits.** 3834afbfaf01eedaa2caec10725403c70aca6854 `feat(deploy): add Helm chart for phase-server`; 19f3ef1f601e05d24690757061d6e55855b3e766 `build(docker): cross-compile multi-arch server images`; 61665a0247a00a8a5fc49f9cd793eb1b76d0a3b8 `ci(workflows): gate workflow_run deploys on provenance and verify binaryen archive` (maintainer review response; both findings pre-date this PR and are byte-identical on origin/main); 27753754221dae13e49209d5ffca1add61c8e008 `fix(ci,chart): guard zig pip install against PEP 668; never invent PUBLIC_URL` (CodeRabbit review response); 8c32d5dcff296587d09fe9d3510c2b104dec2554 `docs(chart): state the server.publicUrl contract in values.yaml`.

9. **Coverage impact.** None (no parser change).

10. **Deviations.** Release *assets* stay amd64/macOS/Windows as before — only the *image* became multi-arch; the signing/attachment list enumerates triples explicitly and widening it is a separate change. amd64 CI keeps `musl-tools` rather than zig so the shipped x86_64 slim asset is built exactly as before.

11. **Self-flagged risks.**
   - `CF-Connecting-IP` is forgeable by anyone who reaches the origin directly until Authenticated Origin Pulls is enabled zone-side; until then per-client limits degrade to one shared bucket (the server's own 200-connection / 30 msg/s caps still hold).
   - Traefik falls back to default TLS options if another router serves the same host with different options — keep all Ingresses for the host in this chart.
   - `/p2p-draft-backup` rows purge only at process start; `persistence.size` must absorb that.
   - Single process ⇒ a rollout is ~10 s of 503s.
   - The in-Docker compile path has no CI job (none existed before either); the zig arm64 leg has no runner history behind its 45-minute timeout.
   - BuildKit's 1024-fd soft limit breaks zig's linker; the Dockerfile raises it with `ulimit -n 65536`.

12. **Remaining items.** Optional CI job exercising the Dockerfile compile stage (~10 min/run); arm64 linux slim release asset if wanted.

13. **Phase-fit.** Single phase (two commits: chart, image/CI); no T4 firing, no abandoned candidates.

```text
Pipeline-reviewed head: 19f3ef1f601e05d24690757061d6e55855b3e766
Current branch head: 8c32d5dcff296587d09fe9d3510c2b104dec2554
Pipeline status: ahead — two review-response commits landed after the pipeline run: 61665a024 (workflow_run deploy provenance + Binaryen digest pinning, maintainer request) 2775375 (PEP 668 guard on the zig pip install; PUBLIC_URL no longer derived from a host that is not serving, CodeRabbit) and 8c32d5d (documents the server.publicUrl contract; the gotpl validation CodeRabbit asked for was declined as duplicate validation — see the PR thread). No engine or frontend change.
Current-head review: clean at 19f3ef1f601e05d24690757061d6e55855b3e766 (round-2 findings + CodeRabbit findings fixed; 3rd pass not run). 61665a024 validated with actionlint 1.7.12 (no new findings; the two reported `if: ${{ false }}` notices are present unchanged on origin/main), a full .github YAML parse, a DAG assertion that all 8 deploy jobs are transitively gated, and a local exercise of the sha256 verify step showing it passes on the genuine archive and fails on a single flipped byte. 2775375 validated with `helm lint`, actionlint (no new findings), a byte-identical render of the chart against the live site values, and `helm upgrade --dry-run` against the deployed k3s release (PUBLIC_URL unchanged, pod untouched); both previously-silent misconfigurations now fail rendering.
```

## Claimed parse impact

None.

## Scope Expansion

The multi-arch image work touches `.github/workflows/` and the root `README.md` beyond `deploy/`; it is what makes the chart usable on arm64 without a private image.

## Validation Failures

None.

## CI Failures

None — all checks passed on the pre-rebase head; re-running on the current head.
