### PR TITLE
fix(protocol): give the lobby its own wire version, decoupled from the full game

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -650,26 +650,43 @@ jobs:
           workingDirectory: lobby-worker
           command: deploy --env preview
 
-      - name: Assert the preview lobby advertises this commit's protocol version
+      - name: Assert the preview lobby advertises this commit's protocol versions
         # Guards the exact regression this job exists to prevent: a preview
         # client that cannot handshake with the preview lobby. Compares the
-        # deployed Worker's advertised protocol_version against the constant in
-        # the tree being deployed.
+        # deployed Worker's advertised versions against the constants in the
+        # tree being deployed.
+        #
+        # BOTH numbers are checked, and they mean different things:
+        #   protocol_version       — the full-game surface. Only clients that
+        #                            predate lobby_protocol_version gate on it.
+        #   lobby_protocol_version — the lobby message set, and what every
+        #                            current client actually handshakes on.
+        # A stale deploy of either is a real incompatibility, so neither is
+        # allowed to drift from the tree.
         run: |
           set -euo pipefail
           expected=$(grep -oE 'pub const PROTOCOL_VERSION: u32 = [0-9]+' \
             crates/lobby-broker/src/protocol.rs | grep -oE '[0-9]+$')
+          expected_lobby=$(grep -oE 'pub const LOBBY_PROTOCOL_VERSION: u32 = [0-9]+' \
+            crates/lobby-broker/src/protocol.rs | grep -oE '[0-9]+$')
+          if [ -z "$expected" ] || [ -z "$expected_lobby" ]; then
+            echo "::error::Could not read protocol constants from the tree."
+            exit 1
+          fi
           for attempt in 1 2 3 4 5 6 7 8 9 10; do
-            actual=$(curl -sS -m 15 https://lobby-preview.phase-rs.dev/health \
-              | jq -r '.protocol_version // empty' || true)
-            if [ "$actual" = "$expected" ]; then
-              echo "Preview lobby advertises protocol_version=$actual (matches tree)."
+            health=$(curl -sS -m 15 https://lobby-preview.phase-rs.dev/health || true)
+            actual=$(printf '%s' "$health" | jq -r '.protocol_version // empty' || true)
+            actual_lobby=$(printf '%s' "$health" | jq -r '.lobby_protocol_version // empty' || true)
+            if [ "$actual" = "$expected" ] && [ "$actual_lobby" = "$expected_lobby" ]; then
+              echo "Preview lobby advertises protocol_version=$actual, lobby_protocol_version=$actual_lobby (both match tree)."
               exit 0
             fi
-            echo "Attempt $attempt: got '${actual:-<none>}', want '$expected'; retrying..."
+            echo "Attempt $attempt: got protocol='${actual:-<none>}' lobby='${actual_lobby:-<none>}';" \
+              "want protocol='$expected' lobby='$expected_lobby'; retrying..."
             sleep 10
           done
-          echo "::error::Preview lobby advertises '${actual:-<none>}' but this commit speaks '$expected'."
+          echo "::error::Preview lobby advertises protocol='${actual:-<none>}' lobby='${actual_lobby:-<none>}'," \
+            "but this commit speaks protocol='$expected' lobby='$expected_lobby'."
           exit 1
 
   # ── Frontend + Pages deploy (needs published data + server artifact + WASM) ─

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -272,11 +272,42 @@ export const PROTOCOL_VERSION = 33;
 export const MIN_SUPPORTED_SERVER_PROTOCOL = PROTOCOL_VERSION;
 
 /**
- * Lowest server protocol version this client accepts for lobby-only brokers.
- * LobbyOnly carries matchmaking metadata only, so it keeps a one-version
- * rollout window while Full servers stay current-only.
+ * Lowest server `protocol_version` this client accepts for lobby-only brokers
+ * that predate `lobby_protocol_version` — the LEGACY path only.
+ *
+ * Derived from PROTOCOL_VERSION, so it slides every time the full-game surface
+ * bumps. That is the defect LOBBY_PROTOCOL_VERSION below exists to fix; this
+ * constant survives only to keep already-deployed brokers reachable.
  */
 export const LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL = PROTOCOL_VERSION - 1;
+
+/**
+ * Wire version of the LOBBY message set, independent of PROTOCOL_VERSION.
+ * Must match `LOBBY_PROTOCOL_VERSION` in `crates/lobby-broker/src/protocol.rs`.
+ *
+ * Bump ONLY when a lobby message variant changes shape. A full-game bump must
+ * NOT move this number: no lobby variant carries GameState or GameAction, so
+ * full-game churn cannot break lobby traffic. Sharing one integer between the
+ * two surfaces is what took preview multiplayer down — PROTOCOL_VERSION moved
+ * twice for GameState-only changes and the derived lobby window went disjoint
+ * from the deployed broker's.
+ *
+ * 1 — Initial lobby-owned version, covering the lobby variant set unchanged
+ *     since #1880.
+ */
+export const LOBBY_PROTOCOL_VERSION = 1;
+
+/**
+ * Lowest broker LOBBY_PROTOCOL_VERSION this client accepts.
+ *
+ * There is deliberately NO ceiling. A broker newer than this client can only
+ * hurt it by sending a lobby variant the client does not know, and
+ * `handleMessage` already ignores unknown tags rather than tearing the session
+ * down. Refusing to connect at all would evict this client from a broker whose
+ * new variant it may never need — which is precisely how a protocol-bumping
+ * release used to strand every older desktop build.
+ */
+export const MIN_SUPPORTED_SERVER_LOBBY_PROTOCOL = 1;
 
 /** Identity advertised by the server in its `ServerHello`. */
 export interface ServerInfo {
@@ -284,9 +315,49 @@ export interface ServerInfo {
   buildCommit: string;
   protocolVersion: number;
   mode: "Full" | "LobbyOnly";
+  /** The server's LOBBY_PROTOCOL_VERSION, when it advertises one. `undefined`
+   * from brokers built before the lobby owned its own version — those are
+   * gated on `protocolVersion` instead. */
+  lobbyProtocolVersion?: number;
   /** Public base URL the server advertises for `<code>@<host>` join strings
    * (a tunnel/proxy URL), or undefined when the server has none to share. */
   publicUrl?: string;
+}
+
+/**
+ * Why this client cannot talk to `info`, or `null` when it can.
+ *
+ * SINGLE AUTHORITY for the protocol window. The handshake in
+ * `openPhaseSocket.ts` and the compatibility badge in `multiplayerStore.ts`
+ * both route through here, so a server can never be rejected by one and shown
+ * as usable by the other.
+ *
+ * Three policies, by surface:
+ *  - Full servers: exact match. GameState/GameAction payloads are neither
+ *    forward- nor backward-compatible across a bump.
+ *  - Lobby brokers advertising a lobby version: floor only, NO CEILING. See
+ *    {@link MIN_SUPPORTED_SERVER_LOBBY_PROTOCOL}.
+ *  - Lobby brokers that predate the field: the legacy one-version window on
+ *    `protocolVersion`, unchanged, so already-deployed brokers stay reachable.
+ */
+export function serverProtocolRejection(info: ServerInfo): string | null {
+  if (info.mode === "LobbyOnly" && info.lobbyProtocolVersion !== undefined) {
+    return info.lobbyProtocolVersion < MIN_SUPPORTED_SERVER_LOBBY_PROTOCOL
+      ? `Lobby protocol version ${info.lobbyProtocolVersion} is older than supported (client speaks ${LOBBY_PROTOCOL_VERSION}, min ${MIN_SUPPORTED_SERVER_LOBBY_PROTOCOL}).`
+      : null;
+  }
+
+  const minAccepted =
+    info.mode === "LobbyOnly"
+      ? LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL
+      : MIN_SUPPORTED_SERVER_PROTOCOL;
+  if (info.protocolVersion < minAccepted) {
+    return `Server protocol version ${info.protocolVersion} is older than supported (client speaks ${PROTOCOL_VERSION}, min ${minAccepted}). Please wait for the lobby to finish rolling out.`;
+  }
+  if (info.protocolVersion > PROTOCOL_VERSION) {
+    return `Server protocol version ${info.protocolVersion} is newer than this client (${PROTOCOL_VERSION}). Please refresh to update.`;
+  }
+  return null;
 }
 
 /** Events emitted by the WebSocketAdapter for UI state updates. */

--- a/client/src/config/multiplayerServer.ts
+++ b/client/src/config/multiplayerServer.ts
@@ -1,14 +1,18 @@
 /**
  * The official lobby broker for THIS build's release channel.
  *
- * Channel-scoped rather than a single fixed address: the lobby advertises one
- * protocol version blind (it sends `ServerHello` before the client's
- * `ClientHello`), and a client only accepts a lobby within
- * `[PROTOCOL_VERSION - 1, PROTOCOL_VERSION]` of its OWN build. Production's
- * Worker redeploys only at release while preview rebuilds from `main`, so once
- * `main` is two protocol bumps past the last tag those windows are disjoint and
- * a single shared lobby must lock one channel out. Each channel therefore
- * points at its own broker; `deploy.yml` sets this to the preview lobby.
+ * Channel-scoped rather than a single fixed address. The lobby advertises its
+ * versions blind (it sends `ServerHello` before the client's `ClientHello`), and
+ * clients built before `lobby_protocol_version` existed accept a lobby only
+ * within `[PROTOCOL_VERSION - 1, PROTOCOL_VERSION]` of their OWN build.
+ * Production's Worker redeploys only at release while preview rebuilds from
+ * `main`, so once `main` is two protocol bumps past the last tag those windows
+ * are disjoint and a single shared lobby must lock one channel out.
+ *
+ * `LOBBY_PROTOCOL_VERSION` (see `ws-adapter.ts`) removes that coupling for
+ * current builds, but already-deployed clients still gate on the shared number —
+ * so each channel keeps its own broker. `deploy.yml` sets this to the preview
+ * lobby.
  *
  * Defaults to the production lobby, so release and self-hosted builds are
  * unchanged.

--- a/client/src/services/__tests__/openPhaseSocket.test.ts
+++ b/client/src/services/__tests__/openPhaseSocket.test.ts
@@ -7,6 +7,7 @@ import {
 } from "../openPhaseSocket";
 import {
   LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL,
+  LOBBY_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
 } from "../../adapter/ws-adapter";
 
@@ -41,6 +42,7 @@ function helloFrame(
     build_commit: string;
     protocol_version: number;
     mode: "Full" | "LobbyOnly";
+    lobby_protocol_version: number;
   }> = {},
 ): string {
   return JSON.stringify({
@@ -119,6 +121,9 @@ describe("openPhaseSocket", () => {
     );
   });
 
+  // LEGACY PATH: this broker advertises no `lobby_protocol_version`, so the
+  // client falls back to the derived `protocol_version` window. Preserved
+  // verbatim so already-deployed brokers stay reachable.
   it("rejects LobbyOnly brokers older than the derived one-version window", async () => {
     const promise = openPhaseSocket("ws://test");
     const ws = MockWebSocket.instances[0];
@@ -130,6 +135,89 @@ describe("openPhaseSocket", () => {
       kind: "protocol_mismatch",
     });
     expect(ws.close).toHaveBeenCalled();
+  });
+
+
+  // ── Lobby-owned protocol version ────────────────────────────────────────
+
+  it("accepts a LobbyOnly broker with a stale full-game protocol when its lobby version is current", async () => {
+    // The regression this whole change exists for. `main` drifting two
+    // GameState-only bumps ahead of the deployed broker used to reject here
+    // with "Server protocol version N is older than supported".
+    const promise = openPhaseSocket("ws://test");
+    const ws = MockWebSocket.instances[0];
+    ws.deliverMessage(
+      helloFrame({
+        protocol_version: PROTOCOL_VERSION - 9,
+        mode: "LobbyOnly",
+        lobby_protocol_version: LOBBY_PROTOCOL_VERSION,
+      }),
+    );
+
+    const socket = await promise;
+    expect(socket.serverInfo.lobbyProtocolVersion).toBe(LOBBY_PROTOCOL_VERSION);
+    expect(ws.close).not.toHaveBeenCalled();
+  });
+
+  it("accepts a LobbyOnly broker whose lobby version is NEWER than this client", async () => {
+    // No ceiling on the lobby surface. This is the case that used to strand
+    // every older desktop build at each protocol-bumping release: the broker
+    // redeploys, the shipped client cannot, and an upper bound evicts it.
+    const promise = openPhaseSocket("ws://test");
+    const ws = MockWebSocket.instances[0];
+    ws.deliverMessage(
+      helloFrame({
+        protocol_version: PROTOCOL_VERSION,
+        mode: "LobbyOnly",
+        lobby_protocol_version: LOBBY_PROTOCOL_VERSION + 5,
+      }),
+    );
+
+    await expect(promise).resolves.toBeDefined();
+    expect(ws.close).not.toHaveBeenCalled();
+  });
+
+  it("still refuses a lobby broker below the lobby floor", async () => {
+    const promise = openPhaseSocket("ws://test");
+    const ws = MockWebSocket.instances[0];
+    ws.deliverMessage(
+      helloFrame({
+        mode: "LobbyOnly",
+        lobby_protocol_version: LOBBY_PROTOCOL_VERSION - 1,
+      }),
+    );
+
+    await expect(promise).rejects.toMatchObject({ kind: "protocol_mismatch" });
+    expect(ws.close).toHaveBeenCalled();
+  });
+
+  it("holds Full servers to an exact match even when they advertise a lobby version", async () => {
+    // A Full server runs the engine; GameState payloads are not compatible
+    // across a bump regardless of what it says about the lobby surface.
+    const promise = openPhaseSocket("ws://test");
+    const ws = MockWebSocket.instances[0];
+    ws.deliverMessage(
+      helloFrame({
+        protocol_version: PROTOCOL_VERSION - 1,
+        mode: "Full",
+        lobby_protocol_version: LOBBY_PROTOCOL_VERSION,
+      }),
+    );
+
+    await expect(promise).rejects.toMatchObject({ kind: "protocol_mismatch" });
+  });
+
+  it("always declares its own lobby protocol version in ClientHello", async () => {
+    // Sent unconditionally: brokers that predate the field ignore it, and a
+    // broker that understands it gates on this instead of protocol_version.
+    const promise = openPhaseSocket("ws://test");
+    const ws = MockWebSocket.instances[0];
+    ws.deliverMessage(helloFrame({ mode: "LobbyOnly" }));
+    await promise;
+
+    expect(ws.send).toHaveBeenCalledWith(
+      expect.stringContaining(`"lobby_protocol_version":${LOBBY_PROTOCOL_VERSION}`),
+    );
   });
 
   it("times out and closes the socket when ServerHello never arrives", async () => {

--- a/client/src/services/openPhaseSocket.ts
+++ b/client/src/services/openPhaseSocket.ts
@@ -1,7 +1,7 @@
 import {
-  LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL,
-  MIN_SUPPORTED_SERVER_PROTOCOL,
+  LOBBY_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
+  serverProtocolRejection,
   type ServerInfo,
 } from "../adapter/ws-adapter";
 
@@ -211,6 +211,7 @@ export function openPhaseSocket(
         build_commit: string;
         protocol_version: number;
         mode: "Full" | "LobbyOnly";
+        lobby_protocol_version?: number;
         public_url?: string;
       };
       const info: ServerInfo = {
@@ -218,29 +219,15 @@ export function openPhaseSocket(
         buildCommit: data.build_commit,
         protocolVersion: data.protocol_version,
         mode: data.mode,
+        lobbyProtocolVersion: data.lobby_protocol_version,
         publicUrl: data.public_url,
       };
 
-      const minAcceptedProtocol =
-        info.mode === "LobbyOnly"
-          ? LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL
-          : MIN_SUPPORTED_SERVER_PROTOCOL;
-
-      // Accept any server in [minAcceptedProtocol, PROTOCOL_VERSION]. Full
-      // servers are current-only for breaking game protocol releases; LobbyOnly
-      // brokers keep a one-version rollout window because they do not carry
-      // game-state/action payloads.
-      if (
-        info.protocolVersion < minAcceptedProtocol ||
-        info.protocolVersion > PROTOCOL_VERSION
-      ) {
-        const reason =
-          info.protocolVersion < minAcceptedProtocol
-            ? `Server protocol version ${info.protocolVersion} is older than supported (client speaks ${PROTOCOL_VERSION}, min ${minAcceptedProtocol}). Please wait for the lobby to finish rolling out.`
-            : `Server protocol version ${info.protocolVersion} is newer than this client (${PROTOCOL_VERSION}). Please refresh to update.`;
+      const rejection = serverProtocolRejection(info);
+      if (rejection) {
         settle(() => {
           ws.close();
-          reject(new HandshakeError("protocol_mismatch", reason, info));
+          reject(new HandshakeError("protocol_mismatch", rejection, info));
         });
         return;
       }
@@ -248,9 +235,14 @@ export function openPhaseSocket(
       const clientProtocolVersion =
         info.mode === "LobbyOnly" ? info.protocolVersion : PROTOCOL_VERSION;
 
-      // Send our ClientHello back. For LobbyOnly brokers in the rollout
-      // window, echo the accepted broker protocol so an older deployed worker
-      // does not reject a newer local-dev client as a future protocol.
+      // Send our ClientHello back.
+      //
+      // `protocol_version` echoes the broker's own number for LobbyOnly so a
+      // deployed worker on the LEGACY gate does not reject a newer client as a
+      // future protocol. `lobby_protocol_version` is always our own: a broker
+      // that understands it gates on that instead, which is what decouples the
+      // lobby handshake from full-game churn. Brokers that predate the field
+      // ignore it (nothing sets `deny_unknown_fields`).
       ws.send(
         JSON.stringify({
           type: "ClientHello",
@@ -258,6 +250,7 @@ export function openPhaseSocket(
             client_version: __APP_VERSION__,
             build_commit: __BUILD_HASH__,
             protocol_version: clientProtocolVersion,
+            lobby_protocol_version: LOBBY_PROTOCOL_VERSION,
           },
         }),
       );

--- a/client/src/stores/__tests__/multiplayerStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerStore.test.ts
@@ -35,7 +35,11 @@ import {
   type HostingSettings,
   useMultiplayerStore,
 } from "../multiplayerStore";
-import { PROTOCOL_VERSION, type ServerInfo } from "../../adapter/ws-adapter";
+import {
+  LOBBY_PROTOCOL_VERSION,
+  PROTOCOL_VERSION,
+  type ServerInfo,
+} from "../../adapter/ws-adapter";
 import { DEFAULT_MULTIPLAYER_SERVER_URL } from "../../config/multiplayerServer";
 import {
   clearWsSession,
@@ -184,18 +188,51 @@ describe("multiplayerStore", () => {
     expect(id2).toBe(id1);
   });
 
-  it("keeps LobbyOnly compatibility to the derived one-version rollout window", () => {
-    const server = (mode: ServerInfo["mode"], protocolVersion: number): ServerInfo => ({
-      version: "test",
-      buildCommit: "test",
-      mode,
-      protocolVersion,
-    });
+  const server = (
+    mode: ServerInfo["mode"],
+    protocolVersion: number,
+    lobbyProtocolVersion?: number,
+  ): ServerInfo => ({
+    version: "test",
+    buildCommit: "test",
+    mode,
+    protocolVersion,
+    lobbyProtocolVersion,
+  });
 
+  // LEGACY PATH: brokers that advertise no lobby version keep the derived
+  // one-version window, so already-deployed brokers stay reachable.
+  it("keeps LobbyOnly compatibility to the derived one-version rollout window", () => {
     expect(isServerCompatible(server("LobbyOnly", PROTOCOL_VERSION))).toBe(true);
     expect(isServerCompatible(server("LobbyOnly", PROTOCOL_VERSION - 1))).toBe(true);
     expect(isServerCompatible(server("LobbyOnly", PROTOCOL_VERSION - 2))).toBe(false);
     expect(isServerCompatible(server("Full", PROTOCOL_VERSION - 1))).toBe(false);
+  });
+
+  it("judges a lobby broker by its lobby version, not its full-game version", () => {
+    // The badge must agree with the handshake: a broker whose full-game number
+    // is many bumps stale is still fully usable when the lobby surface matches.
+    expect(
+      isServerCompatible(
+        server("LobbyOnly", PROTOCOL_VERSION - 9, LOBBY_PROTOCOL_VERSION),
+      ),
+    ).toBe(true);
+    // No ceiling — a newer broker must not strand this client.
+    expect(
+      isServerCompatible(
+        server("LobbyOnly", PROTOCOL_VERSION, LOBBY_PROTOCOL_VERSION + 5),
+      ),
+    ).toBe(true);
+    // The floor still bites.
+    expect(
+      isServerCompatible(
+        server("LobbyOnly", PROTOCOL_VERSION, LOBBY_PROTOCOL_VERSION - 1),
+      ),
+    ).toBe(false);
+    // Full servers ignore the lobby field entirely.
+    expect(
+      isServerCompatible(server("Full", PROTOCOL_VERSION - 1, LOBBY_PROTOCOL_VERSION)),
+    ).toBe(false);
   });
 
   it("persists displayName across store resets", () => {

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -10,11 +10,7 @@ import type {
   PlayerId,
 } from "../adapter/types";
 import { FORMAT_REGISTRY } from "../data/formatRegistry";
-import {
-  LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL,
-  PROTOCOL_VERSION,
-  type ServerInfo,
-} from "../adapter/ws-adapter";
+import { serverProtocolRejection, type ServerInfo } from "../adapter/ws-adapter";
 import {
   clearWsSession,
   loadWsSession,
@@ -495,12 +491,14 @@ export function isLobbyEntryCompatible(
   return hostBuildCommit === __BUILD_HASH__;
 }
 
-/** True when the client's wire-protocol can speak to the server's advertised mode. */
+/**
+ * True when the client's wire-protocol can speak to the server's advertised
+ * mode. Delegates to `serverProtocolRejection` — the same decision the
+ * handshake makes — so the compatibility badge can never disagree with whether
+ * the connection actually succeeds.
+ */
 export function isServerCompatible(info: ServerInfo | null): boolean {
-  if (!info) return false;
-  const minProtocol =
-    info.mode === "LobbyOnly" ? LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL : PROTOCOL_VERSION;
-  return info.protocolVersion >= minProtocol && info.protocolVersion <= PROTOCOL_VERSION;
+  return info !== null && serverProtocolRejection(info) === null;
 }
 
 // Build the FORMAT_DEFAULTS map from the engine-authored FORMAT_REGISTRY.

--- a/crates/lobby-broker/src/broker.rs
+++ b/crates/lobby-broker/src/broker.rs
@@ -147,6 +147,7 @@ impl Broker {
                 client_version,
                 build_commit,
                 protocol_version: _,
+                lobby_protocol_version: _,
             } => {
                 // The handshake gate (protocol-version check, first-frame
                 // enforcement) stays in the shell; by the time a ClientHello
@@ -741,6 +742,9 @@ pub fn server_hello(
         build_commit,
         protocol_version,
         mode,
+        // Always advertised by this build. `protocol_version` above stays on
+        // the full-game constant for clients that predate the lobby-owned one.
+        lobby_protocol_version: Some(crate::protocol::LOBBY_PROTOCOL_VERSION),
     }
 }
 
@@ -802,6 +806,7 @@ mod tests {
                 client_version: "0.1.0".into(),
                 build_commit: "abc".into(),
                 protocol_version: PROTOCOL_VERSION,
+                lobby_protocol_version: Some(crate::protocol::LOBBY_PROTOCOL_VERSION),
             },
             env,
         );

--- a/crates/lobby-broker/src/lib.rs
+++ b/crates/lobby-broker/src/lib.rs
@@ -31,8 +31,8 @@ pub use lobby::{
 };
 pub use protocol::{
     parse_lobby_client_message, DraftLobbyMetadata, LobbyClientMessage, LobbyGame,
-    LobbyServerMessage, ParsedFrame, ServerErrorCode, ServerMode, MIN_SUPPORTED_PROTOCOL,
-    PROTOCOL_VERSION,
+    LobbyServerMessage, ParsedFrame, ServerErrorCode, ServerMode, LOBBY_PROTOCOL_VERSION,
+    MIN_SUPPORTED_LOBBY_PROTOCOL, MIN_SUPPORTED_PROTOCOL, PROTOCOL_VERSION,
 };
 pub use reservation_auth::{
     conn_holds_reservation, consume_owned_reservation, release_owned_reservation,

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -104,9 +104,43 @@ pub enum ServerErrorCode {
 pub const PROTOCOL_VERSION: u32 = 33;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
-/// handshake. Lobby traffic has a one-version rollout window; full game servers
-/// may choose a stricter floor when state/action payloads change.
+/// handshake **from clients that predate [`LOBBY_PROTOCOL_VERSION`]** — the
+/// legacy path only. Lobby traffic has a one-version rollout window; full game
+/// servers may choose a stricter floor when state/action payloads change.
+///
+/// Being derived from [`PROTOCOL_VERSION`] is exactly the defect
+/// [`LOBBY_PROTOCOL_VERSION`] fixes: a `GameState`-only bump slides this floor
+/// even though no lobby message changed. It survives only so already-deployed
+/// clients stay reachable; new gating must use [`MIN_SUPPORTED_LOBBY_PROTOCOL`].
 pub const MIN_SUPPORTED_PROTOCOL: u32 = PROTOCOL_VERSION.saturating_sub(1);
+
+/// Wire-protocol version of the **lobby** message set ([`LobbyClientMessage`] /
+/// [`LobbyServerMessage`]), independent of [`PROTOCOL_VERSION`].
+///
+/// Bump ONLY when a lobby variant is added, removed, renamed, or has a field
+/// type changed. A full-game bump must NOT move this number: no lobby variant
+/// carries `GameState` or `GameAction`, so full-game churn cannot break lobby
+/// traffic.
+///
+/// Sharing one integer between the two surfaces is what took preview
+/// multiplayer down: `PROTOCOL_VERSION` moved twice for `GameState`-only
+/// changes, [`MIN_SUPPORTED_PROTOCOL`] is derived from it, and the deployed
+/// broker's window went disjoint from the shipped client's. This constant is
+/// the fix — it moves only for reasons the lobby can actually observe.
+///
+/// 1 — Initial lobby-owned version, covering the `LobbyClientMessage` /
+///     `LobbyServerMessage` variant sets, unchanged since #1880.
+pub const LOBBY_PROTOCOL_VERSION: u32 = 1;
+
+/// Lowest [`LOBBY_PROTOCOL_VERSION`] a broker accepts from a client.
+///
+/// There is deliberately **no upper bound**. A client newer than the broker can
+/// only fail by sending a lobby variant this broker does not know, and
+/// [`parse_lobby_client_message`] already answers that with an explicit
+/// [`ParsedFrame::UnknownTag`] rejection scoped to the offending frame. That is
+/// a loud, per-feature failure; refusing the whole connection instead evicts a
+/// client over a variant it may never send.
+pub const MIN_SUPPORTED_LOBBY_PROTOCOL: u32 = 1;
 
 /// Public-lobby view of a single registered game. Populated by the server,
 /// never by clients. Field shape mirrors the pre-extraction
@@ -193,6 +227,13 @@ pub enum LobbyClientMessage {
         client_version: String,
         build_commit: String,
         protocol_version: u32,
+        /// The client's [`LOBBY_PROTOCOL_VERSION`]. `None` from clients built
+        /// before the lobby owned its own version; those fall back to the
+        /// `protocol_version` window. Additive and optional, so an older broker
+        /// ignores it and an older client omits it — no `PROTOCOL_VERSION` bump
+        /// is required for either direction to keep parsing.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        lobby_protocol_version: Option<u32>,
     },
     SubscribeLobby,
     UnsubscribeLobby,
@@ -273,6 +314,11 @@ pub enum LobbyServerMessage {
         build_commit: String,
         protocol_version: u32,
         mode: ServerMode,
+        /// This broker's [`LOBBY_PROTOCOL_VERSION`]. Advertised alongside — not
+        /// instead of — `protocol_version`, which older clients still gate on
+        /// and which therefore must keep tracking the full-game constant.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        lobby_protocol_version: Option<u32>,
     },
     GameCreated {
         game_code: String,
@@ -435,6 +481,31 @@ fn json_string(s: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The two surfaces must not share a number. `scripts/check-protocol-version.mjs`
+    /// carries the structural half of this guard — it matches
+    /// `LOBBY_PROTOCOL_VERSION` only against a bare integer literal, so
+    /// re-deriving it from `PROTOCOL_VERSION` fails the cross-language gate
+    /// rather than silently re-coupling the lobby to full-game churn.
+    #[test]
+    fn lobby_protocol_version_is_independent_of_the_full_game_one() {
+        assert_eq!(LOBBY_PROTOCOL_VERSION, 1);
+        assert_eq!(MIN_SUPPORTED_LOBBY_PROTOCOL, 1);
+        assert_ne!(
+            LOBBY_PROTOCOL_VERSION, PROTOCOL_VERSION,
+            "the lobby must version its own message set, not alias the full-game one"
+        );
+        // A `const` block, not a runtime assert: both operands are constants, so
+        // this is decidable at compile time. A floor above the current version
+        // would refuse every client, and that should fail the BUILD rather than
+        // wait for someone to run the test suite.
+        const {
+            assert!(
+                MIN_SUPPORTED_LOBBY_PROTOCOL <= LOBBY_PROTOCOL_VERSION,
+                "a floor above the current version would refuse every client"
+            )
+        };
+    }
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -66,7 +66,8 @@ use server_core::lobby::RegisterGameRequest;
 use server_core::lobby_subscriber_wire_guard::guard_lobby_subscriber_capacity;
 use server_core::protocol::{
     build_commit, ClientMessage, RankedPlayerResult, ServerMessage, ServerMode,
-    LOBBY_MIN_SUPPORTED_PROTOCOL, MIN_SUPPORTED_PROTOCOL, PROTOCOL_VERSION,
+    LOBBY_MIN_SUPPORTED_PROTOCOL, LOBBY_PROTOCOL_VERSION, MIN_SUPPORTED_LOBBY_PROTOCOL,
+    MIN_SUPPORTED_PROTOCOL, PROTOCOL_VERSION,
 };
 use server_core::resolve_deck;
 use server_core::seat_mutation_wire_guard::guard_seat_mutation;
@@ -913,10 +914,60 @@ enum HelloGateOutcome {
     PassThrough,
 }
 
+/// Which protocol surface a server gates its handshake on.
+///
+/// A bare `RangeInclusive<u32>` could only express "between X and Y on
+/// `protocol_version`". The lobby needs a different shape entirely — a floor,
+/// no ceiling, read off a *different* wire field — so the policy is a type
+/// rather than a range.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum HelloAcceptance {
+    /// Full-game surface: `protocol_version` must land in this inclusive range.
+    /// Both ends matter — `GameState` and `GameAction` payloads are not
+    /// forward- or backward-compatible across a bump.
+    FullGame(std::ops::RangeInclusive<u32>),
+    /// Lobby surface. Gates on the client's `lobby_protocol_version` against
+    /// `lobby_floor` with **no ceiling**: a client newer than this broker can
+    /// only fail by sending a lobby variant the broker does not know, which
+    /// `parse_lobby_client_message` already rejects per-frame as an unknown
+    /// tag. Clients that predate the field fall back to `legacy_range` on
+    /// `protocol_version`, preserving the pre-existing behavior exactly.
+    Lobby {
+        lobby_floor: u32,
+        legacy_range: std::ops::RangeInclusive<u32>,
+    },
+}
+
+impl HelloAcceptance {
+    /// `None` when the hello is acceptable; `Some((client, server))` naming the
+    /// two versions to report when it is not.
+    fn reject(
+        &self,
+        protocol_version: u32,
+        lobby_protocol_version: Option<u32>,
+    ) -> Option<(u32, u32)> {
+        match self {
+            Self::FullGame(range) => {
+                (!range.contains(&protocol_version)).then(|| (protocol_version, *range.end()))
+            }
+            Self::Lobby {
+                lobby_floor,
+                legacy_range,
+            } => match lobby_protocol_version {
+                Some(client_lobby) => {
+                    (client_lobby < *lobby_floor).then_some((client_lobby, LOBBY_PROTOCOL_VERSION))
+                }
+                None => (!legacy_range.contains(&protocol_version))
+                    .then(|| (protocol_version, *legacy_range.end())),
+            },
+        }
+    }
+}
+
 fn classify_hello_gate(
     hello_received: bool,
     msg: &ClientMessage,
-    server_protocol_range: std::ops::RangeInclusive<u32>,
+    acceptance: HelloAcceptance,
 ) -> HelloGateOutcome {
     match (hello_received, msg) {
         (
@@ -925,16 +976,16 @@ fn classify_hello_gate(
                 client_version,
                 build_commit,
                 protocol_version,
+                lobby_protocol_version,
             },
         ) => {
-            // Accept any client in the supported range. The `server` field on
-            // RejectProtocol surfaces the *current* protocol version so the
-            // error message tells the client what to upgrade (or downgrade) to.
-            if !server_protocol_range.contains(protocol_version) {
-                HelloGateOutcome::RejectProtocol {
-                    client: *protocol_version,
-                    server: *server_protocol_range.end(),
-                }
+            // The `server` field on RejectProtocol surfaces the version this
+            // server speaks on whichever surface it gated, so the error message
+            // tells the client what to upgrade (or downgrade) to.
+            if let Some((client, server)) =
+                acceptance.reject(*protocol_version, *lobby_protocol_version)
+            {
+                HelloGateOutcome::RejectProtocol { client, server }
             } else if let Err(reason) = guard_client_hello(client_version, build_commit) {
                 HelloGateOutcome::RejectInvalidHello(reason)
             } else {
@@ -950,10 +1001,13 @@ fn classify_hello_gate(
     }
 }
 
-fn supported_protocol_range(mode: ServerMode) -> std::ops::RangeInclusive<u32> {
+fn hello_acceptance(mode: ServerMode) -> HelloAcceptance {
     match mode {
-        ServerMode::Full => MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
-        ServerMode::LobbyOnly => LOBBY_MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+        ServerMode::Full => HelloAcceptance::FullGame(MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION),
+        ServerMode::LobbyOnly => HelloAcceptance::Lobby {
+            lobby_floor: MIN_SUPPORTED_LOBBY_PROTOCOL,
+            legacy_range: LOBBY_MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+        },
     }
 }
 
@@ -2156,6 +2210,7 @@ async fn handle_socket(
         build_commit: build_commit().to_string(),
         protocol_version: PROTOCOL_VERSION,
         mode,
+        lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
         public_url,
     };
     if let Ok(json) = serde_json::to_string(&hello) {
@@ -2377,6 +2432,7 @@ fn to_server_message(m: lobby_broker::LobbyServerMessage) -> ServerMessage {
             build_commit,
             protocol_version,
             mode,
+            lobby_protocol_version,
         } => ServerMessage::ServerHello {
             server_version,
             build_commit,
@@ -2385,6 +2441,7 @@ fn to_server_message(m: lobby_broker::LobbyServerMessage) -> ServerMessage {
                 lobby_broker::ServerMode::Full => ServerMode::Full,
                 lobby_broker::ServerMode::LobbyOnly => ServerMode::LobbyOnly,
             },
+            lobby_protocol_version,
             // LobbyOnly brokers run no server-side game, so there is no
             // game-server URL to advertise for a `<code>@<host>` share string.
             public_url: None,
@@ -2456,10 +2513,12 @@ fn to_lobby_client_message(msg: &ClientMessage) -> Option<lobby_broker::LobbyCli
             client_version,
             build_commit,
             protocol_version,
+            lobby_protocol_version,
         } => L::ClientHello {
             client_version: client_version.clone(),
             build_commit: build_commit.clone(),
             protocol_version: *protocol_version,
+            lobby_protocol_version: *lobby_protocol_version,
         },
         ClientMessage::SubscribeLobby => L::SubscribeLobby,
         ClientMessage::UnsubscribeLobby => L::UnsubscribeLobby,
@@ -4476,7 +4535,7 @@ async fn handle_client_message(
     match classify_hello_gate(
         identity.client_hello.is_some(),
         &client_msg,
-        supported_protocol_range(mode),
+        hello_acceptance(mode),
     ) {
         HelloGateOutcome::Accept(info) => {
             info!(
@@ -8674,6 +8733,7 @@ mod issue_4548_full_create_tests {
                 client_version: env!("CARGO_PKG_VERSION").to_string(),
                 build_commit: build_commit().to_string(),
                 protocol_version: PROTOCOL_VERSION,
+                lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
             };
             socket
                 .send(WsMessage::Text(
@@ -8749,6 +8809,7 @@ mod issue_4548_full_create_tests {
                 client_version: env!("CARGO_PKG_VERSION").to_string(),
                 build_commit: build_commit().to_string(),
                 protocol_version: PROTOCOL_VERSION,
+                lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
             };
             socket
                 .send(WsMessage::Text(
@@ -8814,6 +8875,7 @@ mod issue_4548_full_create_tests {
                 client_version: env!("CARGO_PKG_VERSION").to_string(),
                 build_commit: build_commit().to_string(),
                 protocol_version: PROTOCOL_VERSION,
+                lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
             };
             socket
                 .send(WsMessage::Text(
@@ -8945,6 +9007,7 @@ mod game_submission_tests {
             client_version: env!("CARGO_PKG_VERSION").to_string(),
             build_commit: build_commit().to_string(),
             protocol_version: PROTOCOL_VERSION,
+            lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
         };
         socket
             .send(WsMessage::Text(
@@ -9261,6 +9324,7 @@ mod game_submission_tests {
                 client_version: env!("CARGO_PKG_VERSION").to_string(),
                 build_commit: build_commit().to_string(),
                 protocol_version: PROTOCOL_VERSION,
+                lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
             };
             socket
                 .send(WsMessage::Text(
@@ -9382,6 +9446,7 @@ mod mode_gate_tests {
                 client_version: "0.1.11".into(),
                 build_commit: "abc".into(),
                 protocol_version: PROTOCOL_VERSION,
+                lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
             },
             ClientMessage::SubscribeLobby,
             ClientMessage::UnsubscribeLobby,
@@ -9541,8 +9606,11 @@ mod handshake_tests {
                 client_version: "0.1.11".into(),
                 build_commit: "abc1234".into(),
                 protocol_version: PROTOCOL_VERSION,
+                // Legacy client: predates the lobby-owned version, so the
+                // gate must fall back to the `protocol_version` window.
+                lobby_protocol_version: None,
             },
-            MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+            hello_acceptance(ServerMode::Full),
         );
         assert_eq!(
             outcome,
@@ -9562,8 +9630,11 @@ mod handshake_tests {
                 client_version: "0.1.10".into(),
                 build_commit: "old1234".into(),
                 protocol_version: previous,
+                // Legacy client: predates the lobby-owned version, so the
+                // gate must fall back to the `protocol_version` window.
+                lobby_protocol_version: None,
             },
-            MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+            hello_acceptance(ServerMode::Full),
         );
         assert_eq!(
             outcome,
@@ -9583,10 +9654,105 @@ mod handshake_tests {
                 client_version: "0.1.10".into(),
                 build_commit: "old1234".into(),
                 protocol_version: previous,
+                // Legacy client: predates the lobby-owned version, so the
+                // gate must fall back to the `protocol_version` window.
+                lobby_protocol_version: None,
             },
-            LOBBY_MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+            hello_acceptance(ServerMode::LobbyOnly),
         );
         assert!(matches!(outcome, HelloGateOutcome::Accept(_)));
+    }
+
+    /// The regression this whole change exists for. A client whose full-game
+    /// `protocol_version` is many bumps behind the broker is still accepted,
+    /// because the lobby gates on the surface it actually speaks. Before the
+    /// split this was a `RejectProtocol` and it took preview multiplayer down.
+    #[test]
+    fn lobby_accepts_stale_full_game_protocol_when_lobby_version_current() {
+        let outcome = classify_hello_gate(
+            false,
+            &ClientMessage::ClientHello {
+                client_version: "0.1.0".into(),
+                build_commit: "old1234".into(),
+                // Far outside LOBBY_MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION.
+                protocol_version: PROTOCOL_VERSION.saturating_sub(9),
+                lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+            },
+            hello_acceptance(ServerMode::LobbyOnly),
+        );
+        assert!(matches!(outcome, HelloGateOutcome::Accept(_)));
+    }
+
+    /// No ceiling on the lobby surface: a client newer than this broker can
+    /// only fail by sending a lobby variant the broker does not know, and
+    /// `parse_lobby_client_message` rejects that per-frame as an unknown tag.
+    /// Evicting the whole connection would refuse a client over a variant it
+    /// may never send.
+    #[test]
+    fn lobby_accepts_future_lobby_protocol_version() {
+        let outcome = classify_hello_gate(
+            false,
+            &ClientMessage::ClientHello {
+                client_version: "9.9.9".into(),
+                build_commit: "future12".into(),
+                protocol_version: PROTOCOL_VERSION,
+                lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION + 5),
+            },
+            hello_acceptance(ServerMode::LobbyOnly),
+        );
+        assert!(matches!(outcome, HelloGateOutcome::Accept(_)));
+    }
+
+    /// The floor is still enforced — that is what a genuinely breaking lobby
+    /// change would raise.
+    #[test]
+    fn lobby_rejects_below_lobby_floor() {
+        let Some(below) = MIN_SUPPORTED_LOBBY_PROTOCOL.checked_sub(1) else {
+            // Floor is 0; nothing can sit below it. Nothing to assert.
+            return;
+        };
+        let outcome = classify_hello_gate(
+            false,
+            &ClientMessage::ClientHello {
+                client_version: "0.1.0".into(),
+                build_commit: "ancient1".into(),
+                protocol_version: PROTOCOL_VERSION,
+                lobby_protocol_version: Some(below),
+            },
+            hello_acceptance(ServerMode::LobbyOnly),
+        );
+        assert_eq!(
+            outcome,
+            HelloGateOutcome::RejectProtocol {
+                client: below,
+                server: LOBBY_PROTOCOL_VERSION,
+            }
+        );
+    }
+
+    /// A Full server must ignore the lobby field entirely — full-game payloads
+    /// are not compatible across a `PROTOCOL_VERSION` bump regardless of what
+    /// the client claims about the lobby surface.
+    #[test]
+    fn full_game_gate_ignores_lobby_protocol_version() {
+        let previous = PROTOCOL_VERSION.saturating_sub(1);
+        let outcome = classify_hello_gate(
+            false,
+            &ClientMessage::ClientHello {
+                client_version: "0.1.10".into(),
+                build_commit: "old1234".into(),
+                protocol_version: previous,
+                lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+            },
+            hello_acceptance(ServerMode::Full),
+        );
+        assert_eq!(
+            outcome,
+            HelloGateOutcome::RejectProtocol {
+                client: previous,
+                server: PROTOCOL_VERSION,
+            }
+        );
     }
 
     #[test]
@@ -9598,8 +9764,11 @@ mod handshake_tests {
                 client_version: "0.1.0".into(),
                 build_commit: "ancient1".into(),
                 protocol_version: too_old,
+                // Legacy client: predates the lobby-owned version, so the
+                // gate must fall back to the `protocol_version` window.
+                lobby_protocol_version: None,
             },
-            MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+            hello_acceptance(ServerMode::Full),
         );
         assert_eq!(
             outcome,
@@ -9618,8 +9787,11 @@ mod handshake_tests {
                 client_version: "0.1.11".into(),
                 build_commit: "abc1234".into(),
                 protocol_version: 0,
+                // Legacy client: predates the lobby-owned version, so the
+                // gate must fall back to the `protocol_version` window.
+                lobby_protocol_version: None,
             },
-            MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+            hello_acceptance(ServerMode::Full),
         );
         assert_eq!(
             outcome,
@@ -9638,8 +9810,11 @@ mod handshake_tests {
                 client_version: "0.2.0".into(),
                 build_commit: "def5678".into(),
                 protocol_version: PROTOCOL_VERSION + 1,
+                // Legacy client: predates the lobby-owned version, so the
+                // gate must fall back to the `protocol_version` window.
+                lobby_protocol_version: None,
             },
-            MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+            hello_acceptance(ServerMode::Full),
         );
         assert!(matches!(outcome, HelloGateOutcome::RejectProtocol { .. }));
     }
@@ -9652,8 +9827,11 @@ mod handshake_tests {
                 client_version: "v".repeat(MAX_TOKEN_LEN + 1),
                 build_commit: "abc1234".into(),
                 protocol_version: PROTOCOL_VERSION,
+                // Legacy client: predates the lobby-owned version, so the
+                // gate must fall back to the `protocol_version` window.
+                lobby_protocol_version: None,
             },
-            MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+            hello_acceptance(ServerMode::Full),
         );
         assert!(matches!(outcome, HelloGateOutcome::RejectInvalidHello(_)));
     }
@@ -9665,28 +9843,28 @@ mod handshake_tests {
             &ClientMessage::Action {
                 action: GameAction::PassPriority,
             },
-            MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+            hello_acceptance(ServerMode::Full),
         );
         assert_eq!(outcome, HelloGateOutcome::RejectHandshakeRequired);
 
         let outcome = classify_hello_gate(
             false,
             &ClientMessage::CreateGame { deck: empty_deck() },
-            MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+            hello_acceptance(ServerMode::Full),
         );
         assert_eq!(outcome, HelloGateOutcome::RejectHandshakeRequired);
 
         let outcome = classify_hello_gate(
             false,
             &ClientMessage::SubscribeLobby,
-            MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+            hello_acceptance(ServerMode::Full),
         );
         assert_eq!(outcome, HelloGateOutcome::RejectHandshakeRequired);
 
         let outcome = classify_hello_gate(
             false,
             &ClientMessage::Ping { timestamp: 1 },
-            MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+            hello_acceptance(ServerMode::Full),
         );
         assert_eq!(outcome, HelloGateOutcome::RejectHandshakeRequired);
     }
@@ -9699,8 +9877,11 @@ mod handshake_tests {
                 client_version: "0.1.11".into(),
                 build_commit: "abc1234".into(),
                 protocol_version: PROTOCOL_VERSION,
+                // Legacy client: predates the lobby-owned version, so the
+                // gate must fall back to the `protocol_version` window.
+                lobby_protocol_version: None,
             },
-            MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+            hello_acceptance(ServerMode::Full),
         );
         assert_eq!(outcome, HelloGateOutcome::IgnoreRedundantHello);
     }
@@ -9712,7 +9893,7 @@ mod handshake_tests {
             &ClientMessage::Action {
                 action: GameAction::PassPriority,
             },
-            MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION,
+            hello_acceptance(ServerMode::Full),
         );
         assert_eq!(outcome, HelloGateOutcome::PassThrough);
     }

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -25,8 +25,18 @@ pub const PROTOCOL_VERSION: u32 = lobby_broker::PROTOCOL_VERSION;
 /// game-state/action payload shape, so stale clients must not join full games.
 pub const MIN_SUPPORTED_PROTOCOL: u32 = PROTOCOL_VERSION;
 
-/// Minimum protocol version accepted by lobby-only brokers.
+/// Minimum protocol version accepted by lobby-only brokers from clients that
+/// predate the lobby-owned version. Derived from `PROTOCOL_VERSION`, so it
+/// slides on full-game churn — which is exactly why
+/// [`MIN_SUPPORTED_LOBBY_PROTOCOL`] exists. Legacy path only.
 pub const LOBBY_MIN_SUPPORTED_PROTOCOL: u32 = lobby_broker::MIN_SUPPORTED_PROTOCOL;
+
+/// Wire version of the lobby message set, independent of [`PROTOCOL_VERSION`].
+pub const LOBBY_PROTOCOL_VERSION: u32 = lobby_broker::LOBBY_PROTOCOL_VERSION;
+
+/// Lowest [`LOBBY_PROTOCOL_VERSION`] a lobby broker accepts. No upper bound —
+/// see `lobby_broker::protocol::MIN_SUPPORTED_LOBBY_PROTOCOL`.
+pub const MIN_SUPPORTED_LOBBY_PROTOCOL: u32 = lobby_broker::MIN_SUPPORTED_LOBBY_PROTOCOL;
 
 /// Git short-hash of the build. Emitted by `build.rs`; falls back to `"dev"`
 /// when git isn't available (containers, source tarballs).
@@ -142,6 +152,12 @@ pub enum ClientMessage {
         client_version: String,
         build_commit: String,
         protocol_version: u32,
+        /// The client's `lobby_broker::LOBBY_PROTOCOL_VERSION`. Only meaningful
+        /// against a `LobbyOnly` server; `None` from clients that predate the
+        /// lobby-owned version. See `lobby_broker::protocol` for why the lobby
+        /// versions its own message set separately from `PROTOCOL_VERSION`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        lobby_protocol_version: Option<u32>,
     },
     CreateGame {
         deck: DeckData,
@@ -369,6 +385,12 @@ pub enum ServerMessage {
         build_commit: String,
         protocol_version: u32,
         mode: ServerMode,
+        /// This server's `lobby_broker::LOBBY_PROTOCOL_VERSION`, advertised
+        /// alongside — never instead of — `protocol_version`, which clients
+        /// predating the lobby-owned version still gate on. Additive and
+        /// optional in both directions.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        lobby_protocol_version: Option<u32>,
         /// Public base URL clients should advertise when sharing a join code
         /// (e.g. `https://x.ngrok-free.app` from an embedded tunnel, or a
         /// `PUBLIC_URL` reverse proxy). Lets a host connected over `localhost`
@@ -1677,6 +1699,7 @@ mod tests {
             client_version: "0.1.11".to_string(),
             build_commit: "abc1234".to_string(),
             protocol_version: PROTOCOL_VERSION,
+            lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
@@ -1685,10 +1708,12 @@ mod tests {
                 client_version,
                 build_commit,
                 protocol_version,
+                lobby_protocol_version,
             } => {
                 assert_eq!(client_version, "0.1.11");
                 assert_eq!(build_commit, "abc1234");
                 assert_eq!(protocol_version, PROTOCOL_VERSION);
+                assert_eq!(lobby_protocol_version, Some(LOBBY_PROTOCOL_VERSION));
             }
             _ => panic!("wrong variant"),
         }
@@ -1701,6 +1726,7 @@ mod tests {
             build_commit: "abc1234".to_string(),
             protocol_version: PROTOCOL_VERSION,
             mode: ServerMode::Full,
+            lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
             public_url: Some("https://x.ngrok-free.app".to_string()),
         };
         let json = serde_json::to_string(&msg).unwrap();
@@ -1711,12 +1737,14 @@ mod tests {
                 build_commit,
                 protocol_version,
                 mode,
+                lobby_protocol_version,
                 public_url,
             } => {
                 assert_eq!(server_version, "0.1.11");
                 assert_eq!(build_commit, "abc1234");
                 assert_eq!(protocol_version, PROTOCOL_VERSION);
                 assert_eq!(mode, ServerMode::Full);
+                assert_eq!(lobby_protocol_version, Some(LOBBY_PROTOCOL_VERSION));
                 assert_eq!(public_url.as_deref(), Some("https://x.ngrok-free.app"));
             }
             _ => panic!("wrong variant"),
@@ -1733,10 +1761,17 @@ mod tests {
             build_commit: "abc1234".to_string(),
             protocol_version: PROTOCOL_VERSION,
             mode: ServerMode::LobbyOnly,
+            lobby_protocol_version: None,
             public_url: None,
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(!json.contains("public_url"), "None must be omitted: {json}");
+        // Same `skip_serializing_if` contract: a build that advertises no
+        // lobby version must be byte-identical to one that never had the field.
+        assert!(
+            !json.contains("lobby_protocol_version"),
+            "None must be omitted: {json}"
+        );
     }
 
     #[test]

--- a/crates/server-core/tests/lobby_wire_contract.rs
+++ b/crates/server-core/tests/lobby_wire_contract.rs
@@ -46,6 +46,7 @@ fn canonical_client_frames_parse_via_broker() {
         client_version: "0.1.0".into(),
         build_commit: "abc".into(),
         protocol_version: sc::PROTOCOL_VERSION,
+        lobby_protocol_version: Some(sc::LOBBY_PROTOCOL_VERSION),
     };
     let json = serde_json::to_string(&canonical).unwrap();
     match lb::parse_lobby_client_message(&json) {
@@ -53,10 +54,14 @@ fn canonical_client_frames_parse_via_broker() {
             lb::LobbyClientMessage::ClientHello {
                 client_version,
                 build_commit,
+                lobby_protocol_version,
                 ..
             } => {
                 assert_eq!(client_version, "0.1.0");
                 assert_eq!(build_commit, "abc");
+                // The additive field must survive the canonical -> broker
+                // parse; the broker gates on it.
+                assert_eq!(lobby_protocol_version, Some(lb::LOBBY_PROTOCOL_VERSION));
             }
             other => panic!("expected ClientHello, got {other:?}"),
         },
@@ -174,12 +179,14 @@ fn server_hello_mode_byte_identical() {
         build_commit: "abc".into(),
         protocol_version: lb::PROTOCOL_VERSION,
         mode: lb::ServerMode::LobbyOnly,
+        lobby_protocol_version: Some(lb::LOBBY_PROTOCOL_VERSION),
     };
     let sc_hello = sc::ServerMessage::ServerHello {
         server_version: "0.1.0".into(),
         build_commit: "abc".into(),
         protocol_version: sc::PROTOCOL_VERSION,
         mode: sc::ServerMode::LobbyOnly,
+        lobby_protocol_version: Some(sc::LOBBY_PROTOCOL_VERSION),
         // None + skip_serializing_if keeps the wire identical to the lobby
         // broker's ServerHello, which has no public_url field.
         public_url: None,

--- a/lobby-worker/broker-wasm/src/lib.rs
+++ b/lobby-worker/broker-wasm/src/lib.rs
@@ -253,6 +253,22 @@ pub fn protocol_version() -> u32 {
     PROTOCOL_VERSION
 }
 
+/// The **lobby** message-set version, independent of [`protocol_version`].
+/// The Worker advertises this on `ServerHello` and gates incoming
+/// `ClientHello` frames on it, so a full-game bump the broker never parses no
+/// longer slides the lobby's compatibility window.
+#[wasm_bindgen]
+pub fn lobby_protocol_version() -> u32 {
+    lobby_broker::LOBBY_PROTOCOL_VERSION
+}
+
+/// Lowest client lobby protocol this broker accepts. No ceiling — see
+/// `lobby_broker::protocol::MIN_SUPPORTED_LOBBY_PROTOCOL`.
+#[wasm_bindgen]
+pub fn min_supported_lobby_protocol() -> u32 {
+    lobby_broker::MIN_SUPPORTED_LOBBY_PROTOCOL
+}
+
 fn result_json(r: CallResult) -> String {
     serde_json::to_string(&r).expect("call result always serializes")
 }

--- a/lobby-worker/src/hello-gate.ts
+++ b/lobby-worker/src/hello-gate.ts
@@ -14,27 +14,36 @@ export interface ConnAttachment {
   reservations: unknown[];
 }
 
+/**
+ * What this broker accepts at the handshake. Mirrors the `HelloAcceptance::Lobby`
+ * arm in `crates/phase-server/src/main.rs`; the Worker is always a LobbyOnly
+ * broker, so the full-game arm has no counterpart here.
+ */
+export interface LobbyHelloPolicy {
+  /**
+   * The full-game protocol this broker advertises. Used ONLY for the legacy
+   * window, against clients built before the lobby owned its own version.
+   */
+  serverProtocolVersion: number;
+  /** The lobby message-set version this broker speaks. */
+  lobbyProtocolVersion: number;
+  /**
+   * Lowest client lobby protocol accepted. There is deliberately no ceiling —
+   * a client newer than this broker can only fail by sending a lobby variant
+   * the broker does not know, which the Rust core already rejects per-frame as
+   * an unknown tag rather than poisoning the connection.
+   */
+  minSupportedLobbyProtocol: number;
+}
+
 export function classifyHelloGate(
   helloReceived: boolean,
   frame: { type?: string; data?: Record<string, unknown> },
-  serverProtocolVersion: number,
+  policy: LobbyHelloPolicy,
 ): HelloGateOutcome {
-  const minSupportedProtocol = Math.max(0, serverProtocolVersion - 1);
   if (frame.type === "ClientHello") {
     if (!helloReceived) {
-      const protocolVersion = Number(frame.data?.protocol_version ?? 0);
-      if (
-        Number.isNaN(protocolVersion) ||
-        protocolVersion < minSupportedProtocol ||
-        protocolVersion > serverProtocolVersion
-      ) {
-        return {
-          kind: "reject_protocol",
-          client: protocolVersion,
-          server: serverProtocolVersion,
-        };
-      }
-      return { kind: "accept" };
+      return classifyClientHello(frame.data, policy);
     }
     return { kind: "ignore" };
   }
@@ -44,7 +53,47 @@ export function classifyHelloGate(
   return { kind: "pass" };
 }
 
-export function helloGateErrorMessage(outcome: HelloGateOutcome): string | null {
+function classifyClientHello(
+  data: Record<string, unknown> | undefined,
+  policy: LobbyHelloPolicy,
+): HelloGateOutcome {
+  const clientLobbyVersion = data?.lobby_protocol_version;
+  // Presence, not truthiness: a client that omits the field is on the legacy
+  // path, which is a different policy from one that sent 0.
+  if (
+    typeof clientLobbyVersion === "number" &&
+    !Number.isNaN(clientLobbyVersion)
+  ) {
+    return clientLobbyVersion < policy.minSupportedLobbyProtocol
+      ? {
+          kind: "reject_protocol",
+          client: clientLobbyVersion,
+          server: policy.lobbyProtocolVersion,
+        }
+      : { kind: "accept" };
+  }
+
+  // Legacy: the client predates the lobby-owned version, so all we can gate on
+  // is the shared full-game number and its one-version window.
+  const legacyMin = Math.max(0, policy.serverProtocolVersion - 1);
+  const protocolVersion = Number(data?.protocol_version ?? 0);
+  if (
+    Number.isNaN(protocolVersion) ||
+    protocolVersion < legacyMin ||
+    protocolVersion > policy.serverProtocolVersion
+  ) {
+    return {
+      kind: "reject_protocol",
+      client: protocolVersion,
+      server: policy.serverProtocolVersion,
+    };
+  }
+  return { kind: "accept" };
+}
+
+export function helloGateErrorMessage(
+  outcome: HelloGateOutcome,
+): string | null {
   switch (outcome.kind) {
     case "reject_handshake":
       return "ClientHello required before any other message";

--- a/lobby-worker/src/lobby-do.ts
+++ b/lobby-worker/src/lobby-do.ts
@@ -18,11 +18,18 @@
 // logic, the host language is a serialization boundary with zero game logic.
 
 import wasmModule from "../broker-wasm-pkg/broker_bg.wasm";
-import { initSync, protocol_version, WasmBroker } from "../broker-wasm-pkg/broker.js";
+import {
+  initSync,
+  lobby_protocol_version,
+  min_supported_lobby_protocol,
+  protocol_version,
+  WasmBroker,
+} from "../broker-wasm-pkg/broker.js";
 import {
   classifyHelloGate,
   helloGateErrorMessage,
   type ConnAttachment,
+  type LobbyHelloPolicy,
 } from "./hello-gate";
 import { moderationErrorForLobbyFrame } from "./name-filter";
 import {
@@ -43,6 +50,14 @@ import {
 initSync({ module: wasmModule });
 
 const PROTOCOL_VERSION = protocol_version();
+// The lobby's OWN message-set version. Independent of PROTOCOL_VERSION, which
+// tracks the full-game GameState/GameAction surface this broker never parses.
+const LOBBY_PROTOCOL_VERSION = lobby_protocol_version();
+const HELLO_POLICY: LobbyHelloPolicy = {
+  serverProtocolVersion: PROTOCOL_VERSION,
+  lobbyProtocolVersion: LOBBY_PROTOCOL_VERSION,
+  minSupportedLobbyProtocol: min_supported_lobby_protocol(),
+};
 const SERVER_VERSION = "lobby-rs";
 // build_commit is cosmetic for a LobbyOnly broker — the gameplay-relevant gate
 // is each room's host_build_commit (enforced inside the Rust core), not the
@@ -123,6 +138,7 @@ export class LobbyDO {
       return Response.json({
         mode: "LobbyOnly",
         protocol_version: PROTOCOL_VERSION,
+        lobby_protocol_version: LOBBY_PROTOCOL_VERSION,
         server_version: SERVER_VERSION,
       });
     }
@@ -165,7 +181,7 @@ export class LobbyDO {
     }
 
     const attachment = conn as ConnAttachment;
-    const gate = classifyHelloGate(attachment.client_hello != null, frame, PROTOCOL_VERSION);
+    const gate = classifyHelloGate(attachment.client_hello != null, frame, HELLO_POLICY);
     const gateError = helloGateErrorMessage(gate);
     if (gateError) {
       ws.send(JSON.stringify({ type: "Error", data: { message: gateError } }));
@@ -379,6 +395,10 @@ export class LobbyDO {
           build_commit: SERVER_BUILD_COMMIT,
           protocol_version: PROTOCOL_VERSION,
           mode: "LobbyOnly",
+          // Advertised ALONGSIDE protocol_version, never instead of it:
+          // clients built before the lobby owned a version still gate on that
+          // field, so it must keep tracking the full-game constant.
+          lobby_protocol_version: LOBBY_PROTOCOL_VERSION,
         },
       }),
     );

--- a/lobby-worker/test/hello-gate.test.mjs
+++ b/lobby-worker/test/hello-gate.test.mjs
@@ -3,35 +3,95 @@ import { test } from "node:test";
 
 import { classifyHelloGate } from "../src/hello-gate.ts";
 
+/** A broker speaking full-game protocol 11 and lobby protocol 1. */
+const POLICY = {
+  serverProtocolVersion: 11,
+  lobbyProtocolVersion: 1,
+  minSupportedLobbyProtocol: 1,
+};
+
+const hello = (data) => ({ type: "ClientHello", data });
+
+// ── Legacy path: clients that predate the lobby-owned version ──────────────
+// These must behave EXACTLY as they did before the split.
+
 test("rejects malformed protocol versions", () => {
-  assert.deepEqual(
-    classifyHelloGate(
-      false,
-      { type: "ClientHello", data: { protocol_version: "invalid" } },
-      11,
-    ),
-    { kind: "reject_protocol", client: Number.NaN, server: 11 },
-  );
+  assert.deepEqual(classifyHelloGate(false, hello({ protocol_version: "invalid" }), POLICY), {
+    kind: "reject_protocol",
+    client: Number.NaN,
+    server: 11,
+  });
 });
 
 test("accepts current and previous protocol versions", () => {
-  assert.deepEqual(
-    classifyHelloGate(false, { type: "ClientHello", data: { protocol_version: 10 } }, 11),
-    { kind: "accept" },
-  );
-  assert.deepEqual(
-    classifyHelloGate(false, { type: "ClientHello", data: { protocol_version: 11 } }, 11),
-    { kind: "accept" },
-  );
+  assert.deepEqual(classifyHelloGate(false, hello({ protocol_version: 10 }), POLICY), {
+    kind: "accept",
+  });
+  assert.deepEqual(classifyHelloGate(false, hello({ protocol_version: 11 }), POLICY), {
+    kind: "accept",
+  });
 });
 
 test("rejects versions outside the supported range", () => {
-  assert.deepEqual(
-    classifyHelloGate(false, { type: "ClientHello", data: { protocol_version: 9 } }, 11),
-    { kind: "reject_protocol", client: 9, server: 11 },
-  );
-  assert.deepEqual(
-    classifyHelloGate(false, { type: "ClientHello", data: { protocol_version: 12 } }, 11),
-    { kind: "reject_protocol", client: 12, server: 11 },
-  );
+  assert.deepEqual(classifyHelloGate(false, hello({ protocol_version: 9 }), POLICY), {
+    kind: "reject_protocol",
+    client: 9,
+    server: 11,
+  });
+  assert.deepEqual(classifyHelloGate(false, hello({ protocol_version: 12 }), POLICY), {
+    kind: "reject_protocol",
+    client: 12,
+    server: 11,
+  });
+});
+
+// ── Lobby path: clients that declare their lobby protocol ──────────────────
+
+test("a stale full-game protocol is accepted when the lobby version is current", () => {
+  // The exact shape that took preview multiplayer down: the client's full-game
+  // number is many bumps behind the broker, but the lobby surface they both
+  // speak is identical. Gating on protocol_version rejected this.
+  const frame = hello({ protocol_version: 2, lobby_protocol_version: 1 });
+  assert.deepEqual(classifyHelloGate(false, frame, POLICY), { kind: "accept" });
+});
+
+test("no ceiling: a lobby version newer than the broker is accepted", () => {
+  // An unknown lobby variant is already rejected per-frame by the Rust core, so
+  // refusing the whole connection would evict a client over a variant it may
+  // never send.
+  const frame = hello({ protocol_version: 11, lobby_protocol_version: 99 });
+  assert.deepEqual(classifyHelloGate(false, frame, POLICY), { kind: "accept" });
+});
+
+test("the lobby floor is still enforced", () => {
+  const frame = hello({ protocol_version: 11, lobby_protocol_version: 0 });
+  assert.deepEqual(classifyHelloGate(false, frame, { ...POLICY, minSupportedLobbyProtocol: 2 }), {
+    kind: "reject_protocol",
+    client: 0,
+    server: 1,
+  });
+});
+
+test("lobby_protocol_version 0 is a declaration, not an absent field", () => {
+  // Presence, not truthiness. A client declaring 0 takes the lobby path (and is
+  // accepted at floor 0); only an ABSENT field falls back to the legacy window.
+  // Conflating the two would route a declaring client through a protocol_version
+  // check it deliberately opted out of.
+  const frame = hello({ protocol_version: 2, lobby_protocol_version: 0 });
+  assert.deepEqual(classifyHelloGate(false, frame, { ...POLICY, minSupportedLobbyProtocol: 0 }), {
+    kind: "accept",
+  });
+});
+
+// ── Frame ordering, unchanged by the split ────────────────────────────────
+
+test("non-hello frames before the handshake are rejected", () => {
+  assert.deepEqual(classifyHelloGate(false, { type: "SubscribeLobby" }, POLICY), {
+    kind: "reject_handshake",
+  });
+});
+
+test("a redundant hello is ignored and regular frames pass through", () => {
+  assert.deepEqual(classifyHelloGate(true, hello({}), POLICY), { kind: "ignore" });
+  assert.deepEqual(classifyHelloGate(true, { type: "SubscribeLobby" }, POLICY), { kind: "pass" });
 });

--- a/lobby-worker/wrangler.toml
+++ b/lobby-worker/wrangler.toml
@@ -124,12 +124,20 @@ ALLOWED_ORIGINS = "*"
 #
 #   `ServerHello` is sent unprompted on connect (lobby-do.ts), BEFORE the client
 #   sends `ClientHello` — see the `ws.onopen` comment in
-#   client/src/services/openPhaseSocket.ts. The server therefore advertises one
-#   protocol number, blind, to every caller. A released client accepts
-#   [PROTOCOL_VERSION-1, PROTOCOL_VERSION] of ITS OWN build; once `main` is two
-#   bumps ahead of the last release those two windows are disjoint and no single
-#   advertised number satisfies both. Splitting the deployment is the only fix
-#   that does not evict one channel to serve the other.
+#   client/src/services/openPhaseSocket.ts. The server therefore advertises its
+#   version numbers blind, to every caller, with no idea who is asking.
+#
+#   Clients built before `lobby_protocol_version` existed accept only
+#   [PROTOCOL_VERSION-1, PROTOCOL_VERSION] of THEIR OWN build. Once `main` is two
+#   bumps ahead of the last release those windows are disjoint and no single
+#   advertised number satisfies both channels at once.
+#
+# `LOBBY_PROTOCOL_VERSION` (crates/lobby-broker/src/protocol.rs) since fixes the
+# ROOT cause for every client built after it: the lobby now versions its own
+# message set, so full-game churn no longer slides the lobby window and current
+# clients are no longer evicted by a release they did not install. This split
+# remains necessary regardless — it is what keeps ALREADY-DEPLOYED clients on the
+# legacy gate reachable, and it isolates preview DO state from production's.
 #
 # Non-inheritable keys (vars, durable_objects, migrations, observability,
 # analytics_engine_datasets) MUST be restated here — Wrangler does not inherit

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -4,6 +4,10 @@ import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
 const EXPECTED_PROTOCOL_VERSION = 33;
+// The LOBBY message-set version. Deliberately separate from the full-game
+// number above and deliberately NOT derived from it: a GameState-only bump must
+// not move the lobby's compatibility window. See the assertions at the bottom.
+const EXPECTED_LOBBY_PROTOCOL_VERSION = 1;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);
@@ -64,7 +68,7 @@ requirePattern(
 );
 requirePattern(
   workerHelloGateSource,
-  /const\s+minSupportedProtocol\s*=\s*Math\.max\(0,\s*serverProtocolVersion\s*-\s*1\)\s*;/,
+  /const\s+legacyMin\s*=\s*Math\.max\(0,\s*policy\.serverProtocolVersion\s*-\s*1\)\s*;/,
   "lobby-worker/src/hello-gate.ts",
 );
 
@@ -81,6 +85,70 @@ if (
 ) {
   console.error(
     `Protocol version must remain ${EXPECTED_PROTOCOL_VERSION}: Rust=${rustVersion}, client=${clientVersion}`,
+  );
+  process.exit(1);
+}
+
+// ── Lobby protocol: a SEPARATE surface with its own version ────────────────
+//
+// `PROTOCOL_VERSION` versions the full-game GameState/GameAction wire surface.
+// The lobby broker parses none of that, yet its accept-window used to be
+// derived from that same number — so a GameState-only bump slid the lobby
+// window and stranded every already-deployed client. These assertions keep the
+// two surfaces genuinely independent.
+
+const rustLobbyVersion = extractVersion(
+  rustSource,
+  /pub\s+const\s+LOBBY_PROTOCOL_VERSION\s*:\s*u32\s*=\s*(\d+)\s*;/,
+  "crates/lobby-broker/src/protocol.rs",
+);
+const clientLobbyVersion = extractVersion(
+  clientSource,
+  /export\s+const\s+LOBBY_PROTOCOL_VERSION\s*=\s*(\d+)\s*;/,
+  "client/src/adapter/ws-adapter.ts",
+);
+const rustLobbyFloor = extractVersion(
+  rustSource,
+  /pub\s+const\s+MIN_SUPPORTED_LOBBY_PROTOCOL\s*:\s*u32\s*=\s*(\d+)\s*;/,
+  "crates/lobby-broker/src/protocol.rs",
+);
+const clientLobbyFloor = extractVersion(
+  clientSource,
+  /export\s+const\s+MIN_SUPPORTED_SERVER_LOBBY_PROTOCOL\s*=\s*(\d+)\s*;/,
+  "client/src/adapter/ws-adapter.ts",
+);
+
+// The structural invariant, and the reason this block exists. Each of the four
+// regexes above requires a bare integer literal on the right-hand side, so a
+// future edit to `LOBBY_PROTOCOL_VERSION = PROTOCOL_VERSION - 1` (or any other
+// expression) fails to match and trips "Could not find protocol version"
+// rather than silently re-coupling the two surfaces.
+
+if (rustLobbyVersion !== clientLobbyVersion) {
+  console.error(
+    `Lobby protocol version mismatch: Rust=${rustLobbyVersion}, client=${clientLobbyVersion}`,
+  );
+  process.exit(1);
+}
+
+if (rustLobbyFloor !== clientLobbyFloor) {
+  console.error(
+    `Lobby protocol floor mismatch: Rust=${rustLobbyFloor}, client=${clientLobbyFloor}`,
+  );
+  process.exit(1);
+}
+
+if (rustLobbyVersion !== EXPECTED_LOBBY_PROTOCOL_VERSION) {
+  console.error(
+    `Lobby protocol version must remain ${EXPECTED_LOBBY_PROTOCOL_VERSION}: got ${rustLobbyVersion}. ` +
+      `Bump it ONLY for a LobbyClientMessage/LobbyServerMessage shape change — never for a full-game bump.`,
+  );
+  process.exit(1);
+}
+
+if (rustLobbyFloor > rustLobbyVersion) {
+  console.error(
+    `Lobby floor ${rustLobbyFloor} exceeds the lobby version ${rustLobbyVersion}: no client could connect.`,
   );
   process.exit(1);
 }


### PR DESCRIPTION
## The defect

`lobby_broker::PROTOCOL_VERSION` versions the **full-game** `GameState`/`GameAction`
surface. The lobby's accept-window was *derived* from it:

```rust
pub const MIN_SUPPORTED_PROTOCOL: u32 = PROTOCOL_VERSION.saturating_sub(1);
```

mirrored client-side as `LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL = PROTOCOL_VERSION - 1`.

No lobby message carries `GameState` — `LobbyClientMessage`'s 9 variants have been
unchanged since #1880 — yet **every** `GameState`-only bump slid the lobby's window.
#7553 and #7577 (both pure engine changes) pushed `main` two bumps past the deployed
broker and took preview multiplayer down. The same mechanism evicts every older
desktop build at each protocol-bumping release.

The preview/release broker split (#7596) stopped the *deploy-cadence* half. This is
the root cause.

## The fix

`LOBBY_PROTOCOL_VERSION = 1`, bumped **only** when a `LobbyClientMessage` /
`LobbyServerMessage` changes shape. Advertised on `ServerHello`, declared on
`ClientHello`, as an additive `Option<u32>` with `skip_serializing_if`.

**Nothing already deployed breaks.** Peers that predate the field keep the legacy
`protocol_version` window verbatim; nothing sets `deny_unknown_fields` in either
direction, and the byte-identity contract test (`server_hello_mode_byte_identical`)
still holds. The brokers keep advertising `protocol_version` unchanged for them.

### No ceiling on the lobby surface, both sides

A peer newer than its counterpart can only fail by sending a variant the other
doesn't know — and that is already handled loudly and *per-frame*:

- server side: `parse_lobby_client_message` → `ParsedFrame::UnknownTag`, an explicit
  rejection of that frame;
- client side: `handleMessage`'s switch has no `default:` arm, so an unknown tag is
  ignored rather than tearing the session down.

An upper bound converts that per-feature degradation into a whole-connection
eviction. That is precisely what stranded old clients, so it's gone. The **floor**
stays — it's what a genuinely breaking lobby change would raise.

## Notable

- `classify_hello_gate`'s `RangeInclusive<u32>` becomes a typed `HelloAcceptance`.
  A range can express "between X and Y"; it cannot express "floor only, no ceiling,
  read off a *different* wire field". Full-game servers keep exact-match — `GameState`
  payloads are not compatible across a bump, and `full_game_gate_ignores_lobby_protocol_version`
  pins that.
- `serverProtocolRejection` (ws-adapter.ts) is now the **single authority** for the
  client window. The handshake and `multiplayerStore`'s compatibility badge both route
  through it, so they can no longer disagree about whether a server is usable.
- `scripts/check-protocol-version.mjs` gains the structural guard: it matches the lobby
  constants only against **bare integer literals**, so re-deriving one from
  `PROTOCOL_VERSION` fails the cross-language gate instead of silently re-coupling the
  surfaces. Verified out-of-tree — mutating to `PROTOCOL_VERSION.saturating_sub(32)`
  fails with `Could not find protocol version in crates/lobby-broker/src/protocol.rs`.
- Presence vs. truthiness: `lobby_protocol_version: 0` is a *declaration* and takes the
  lobby path; only an **absent** field falls back to the legacy window. Pinned by a test.
- The preview deploy assertion now checks both advertised numbers.

## Verification

| | |
|---|---|
| Rust (shipped tree, cherry-picked onto `origin/main`) | 587 tests, `cargo check --all-targets` clean |
| Rust (dev tree) | clippy `-D warnings` clean across the three crates |
| lobby-worker | 59 tests, `tsc --noEmit` clean |
| client | 3000 tests, `type-check` + `lint` (0 errors) |
| wasm32 | `scripts/build-broker-wasm.sh` → 320K, bindings expose both new fns |

**Mutation probes** (each restored and sha-verified):

| Mutation | Result |
|---|---|
| Rust: lobby arm ignores `lobby_protocol_version` (pre-fix semantics) | exactly 2 targeted reds, other 2 green |
| Rust: re-add an upper bound | exactly 1 targeted red |
| Client: ignore `lobbyProtocolVersion` | exactly 3 targeted reds |
| Client: re-add the upper bound | exactly 2 targeted reds |

## Still not fixed (cannot be)

An **already-deployed** client gates on `protocol_version` and knows nothing about the
new field, so it is still evicted when the shared number drifts. Nothing shipped can
reach it — which is why the preview/release broker split stays. That gap closes as old
builds age out; every client built from this commit onward is permanently immune.

## Scope

Full-game protocol semantics are untouched: `PROTOCOL_VERSION` stays 33,
`MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`, and
`full_game_floor_is_current_only_not_a_rollout_window` still passes unchanged.

https://claude.ai/code/session_01W8FAcQ2gpCP7RNZnvtfe4B


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added independent lobby protocol versioning, allowing lobby services to remain compatible when full-game protocols change.
  * Lobby connections now advertise and validate dedicated compatibility information.
  * Newer lobby protocol versions are accepted, while outdated versions below the supported minimum are rejected.

* **Bug Fixes**
  * Preserved compatibility for legacy clients and brokers.
  * Improved deployment checks and error reporting for protocol mismatches.

* **Documentation**
  * Updated multiplayer and preview-environment guidance for lobby protocol compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->