### PR TITLE
fix(draft): let the reducer derive the pairing round, unsticking round two

### DIFF
--- a/client/src/adapter/__tests__/p2pDraftHostAdvanceRound.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftHostAdvanceRound.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock only DraftAdapter's constructor — the rest of the module (notably
+// EMPTY_DRAFT_POOL_GROUPS, which p2p-draft-host imports at module scope) must
+// stay real, so the factory spreads the original module.
+vi.mock("../draft-adapter", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../draft-adapter")>();
+  return {
+    ...actual,
+    DraftAdapter: vi.fn().mockImplementation(function () {
+      return {};
+    }),
+  };
+});
+
+import { P2PDraftHost, type DraftHostEvent } from "../p2p-draft-host";
+import { EMPTY_DRAFT_POOL_GROUPS } from "../draft-adapter";
+import type { DraftPlayerView, PairingView } from "../draft-adapter";
+
+function pairing(round: number, table: number): PairingView {
+  return {
+    round,
+    table,
+    seat_a: 0,
+    name_a: "Host",
+    seat_b: 1,
+    name_b: "Guest",
+    match_id: `r${round}-t${table}`,
+    status: "Pending",
+    winner_seat: null,
+    score_a: null,
+    score_b: null,
+  };
+}
+
+/** Fully shaped so `isBotSeatFromView` (which reads `view.seats`) cannot throw. */
+function viewForRound(round: number): DraftPlayerView {
+  return {
+    status: "MatchInProgress",
+    kind: "Premier",
+    current_pack_number: 3,
+    pick_number: 14,
+    pass_direction: "Left",
+    current_pack: null,
+    pool: [],
+    draft_effects: [],
+    pool_groups: EMPTY_DRAFT_POOL_GROUPS,
+    seats: [],
+    cards_per_pack: 14,
+    pack_count: 3,
+    min_deck_size: 40,
+    addable_cards: [],
+    timer_remaining_ms: null,
+    standings: [],
+    current_round: round,
+    tournament_format: "Swiss",
+    pod_policy: "Casual",
+    pairings: [pairing(round, 0)],
+    match_config: { match_type: "Bo1" },
+  };
+}
+
+describe("P2PDraftHost.advanceRound", () => {
+  it("pairs the NEXT round after advancing, reading the round back from the engine", async () => {
+    const host = new P2PDraftHost(
+      { id: "host" } as never,
+      () => () => {},
+      { type: "Set", data: { set_pool_json: "{}" } } as never,
+      "Premier",
+      8,
+      "Host",
+      "Swiss",
+      "Casual",
+    );
+
+    // The engine's contract: `AdvanceRound` does NOT bump `current_round`;
+    // only pairing generation commits the next one.
+    let round = 1;
+    const adapter = (host as unknown as { adapter: Record<string, unknown> })
+      .adapter;
+    adapter.advanceRound = vi.fn(async () => viewForRound(round));
+    adapter.generatePairings = vi.fn(async () => {
+      round += 1;
+      return viewForRound(round);
+    });
+    adapter.getViewForSeat = vi.fn(async () => viewForRound(round));
+
+    // Instance-level stub shadows the prototype method; both launch loops call
+    // it via `this.`, so no match dispatch (and no `exportSession`) is reached.
+    (
+      host as unknown as { dispatchMatchLaunch: () => Promise<void> }
+    ).dispatchMatchLaunch = vi.fn(async () => {});
+
+    const events: DraftHostEvent[] = [];
+    host.onEvent((event) => events.push(event));
+
+    await host.advanceRound();
+
+    // REVERT-FAILING ASSERTION: pre-fix the host passed `view.current_round`
+    // (still 1) back into `generatePairings`, so this emitted round 1.
+    const pairingsGenerated = events.find((e) => e.type === "pairingsGenerated");
+    expect(pairingsGenerated).toBeDefined();
+    expect(pairingsGenerated).toMatchObject({ round: 2 });
+
+    // The event itself is still emitted (it just no longer carries a round).
+    expect(events.some((e) => e.type === "roundAdvanced")).toBe(true);
+
+    // Reach-guard for this negative: the `pairingsGenerated` assertion above
+    // can only pass if generatePairings ran to completion, so an empty error
+    // list here is a real negative rather than a vacuous one.
+    expect(events.filter((e) => e.type === "error")).toEqual([]);
+  });
+});

--- a/client/src/adapter/draft-adapter.ts
+++ b/client/src/adapter/draft-adapter.ts
@@ -496,9 +496,9 @@ export class DraftAdapter {
     return wasm.get_view_for_seat(0) as DraftPlayerView;
   }
 
-  async generatePairings(round: number): Promise<DraftPlayerView> {
+  async generatePairings(): Promise<DraftPlayerView> {
     return this.applyActionAndGetHostView(
-      JSON.stringify({ type: "GeneratePairings", data: { round } }),
+      JSON.stringify({ type: "GeneratePairings" }),
     );
   }
 

--- a/client/src/adapter/draftPodHostAdapter.ts
+++ b/client/src/adapter/draftPodHostAdapter.ts
@@ -55,7 +55,7 @@ export type DraftPodHostEvent =
   | { type: "pairingsGenerated"; round: number; pairings: PairingView[] }
   | { type: "matchStart"; launch: DraftMatchLaunch }
   | { type: "matchResultReceived"; matchId: string; winnerSeat: number | null }
-  | { type: "roundAdvanced"; newRound: number }
+  | { type: "roundAdvanced" }
   | { type: "timerExpired" }
   | {
       type: "bo3SideboardPrompt";
@@ -341,7 +341,7 @@ export class DraftPodHostAdapter {
         break;
       case "roundAdvanced":
         this.setStatus("pairing");
-        this.emit({ type: "roundAdvanced", newRound: event.newRound });
+        this.emit({ type: "roundAdvanced" });
         break;
       case "timerExpired":
         this.emit({ type: "timerExpired" });
@@ -420,9 +420,9 @@ export class DraftPodHostAdapter {
 
   // ── Match coordination ──────────────────────────────────────────────
 
-  async generatePairings(round: number): Promise<void> {
+  async generatePairings(): Promise<void> {
     if (!this.host) throw new Error("Host not initialized");
-    await this.host.generatePairings(round);
+    await this.host.generatePairings();
   }
 
   async advanceRound(): Promise<void> {

--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -82,7 +82,7 @@ export type DraftHostEvent =
   | { type: "pairingsGenerated"; round: number; pairings: PairingView[] }
   | { type: "matchStart"; launch: DraftMatchLaunch }
   | { type: "matchResultReceived"; matchId: string; winnerSeat: number | null }
-  | { type: "roundAdvanced"; newRound: number }
+  | { type: "roundAdvanced" }
   | { type: "timerExpired" }
   | {
       type: "bo3SideboardPrompt";
@@ -744,7 +744,7 @@ export class P2PDraftHost {
       const hostView = await this.adapter.getViewForSeat(0);
       if (hostView.seats.every((s) => s.has_submitted_deck || s.is_bot)) {
         this.emit({ type: "allDecksSubmitted" });
-        await this.generatePairings(1);
+        await this.generatePairings();
       }
 
       if (seat === 0) return view;
@@ -996,12 +996,15 @@ export class P2PDraftHost {
   // ── Match coordination ────────────────────────────────────────────────
 
   /**
-   * Generate pairings for a given round and dispatch match start messages.
+   * Generate the next round's pairings and dispatch match start messages.
+   * The engine decides which round that is; we read it back off the view.
    * Called after all decks are submitted or after round advancement.
    */
-  async generatePairings(round: number): Promise<void> {
+  async generatePairings(): Promise<void> {
     try {
-      const view = await this.adapter.generatePairings(round);
+      const view = await this.adapter.generatePairings();
+      // The engine owns the round. Read it back; never compute it here.
+      const round = view.current_round;
       const launchablePairings = view.pairings.filter((pairing) =>
         pairing.round === round &&
         (pairing.status === "Pending" || pairing.status === "InProgress")
@@ -1039,6 +1042,7 @@ export class P2PDraftHost {
       this.emit({ type: "viewUpdated", view: latestView });
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
+      console.error(`[P2PDraftHost] generatePairings failed:`, message);
       this.emit({ type: "error", message: `Failed to generate pairings: ${message}` });
     }
   }
@@ -1343,10 +1347,9 @@ export class P2PDraftHost {
    */
   async advanceRound(): Promise<void> {
     try {
-      const view = await this.adapter.advanceRound();
-      const newRound = view.current_round;
-      this.emit({ type: "roundAdvanced", newRound });
-      await this.generatePairings(newRound);
+      await this.adapter.advanceRound();
+      this.emit({ type: "roundAdvanced" });
+      await this.generatePairings();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       this.emit({ type: "error", message: `Failed to advance round: ${message}` });
@@ -1964,7 +1967,7 @@ export class P2PDraftHost {
       if (view.status === "MatchInProgress") {
         await this.dispatchMatchLaunchesForSeat(view, 0);
       } else if (view.status === "Pairing" && view.pairings.length === 0) {
-        await this.generatePairings(view.current_round + 1);
+        await this.generatePairings();
         return this.adapter.getViewForSeat(0);
       }
 

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -1132,7 +1132,9 @@ function handleHostEvent(event: DraftPodHostEvent, set: SetFn): void {
       break;
     case "roundAdvanced":
       disposeMatchAdapter(set);
-      set({ phase: "pairing", currentRound: event.newRound });
+      // `currentRound` is engine-owned: `viewUpdated` and `pairingsGenerated`
+      // both write it from engine state moments later.
+      set({ phase: "pairing" });
       saveDraftPodProgress("pairing");
       break;
     case "roundComplete":

--- a/crates/draft-core/src/session.rs
+++ b/crates/draft-core/src/session.rs
@@ -12,6 +12,17 @@ use crate::types::*;
 use crate::validation::validate_limited_deck;
 
 impl DraftSession {
+    /// The round that pairings may next be generated for.
+    ///
+    /// Single authority. `AdvanceRound` deliberately leaves `current_round`
+    /// untouched — it only opens the `Pairing` window — so `current_round` is
+    /// always the last round whose pairings exist, and generating pairings is
+    /// what commits the next one. Private on purpose: callers outside this
+    /// module must not re-derive it.
+    fn next_pairing_round(&self) -> u8 {
+        self.current_round + 1
+    }
+
     /// Create a new draft session in Lobby status.
     ///
     /// Timestamps are set to 0 -- callers set them externally since the pure
@@ -145,7 +156,7 @@ pub fn apply(
             card_instance_ids,
         ),
         DraftAction::SubmitDeck { seat, main_deck } => apply_submit_deck(session, seat, main_deck),
-        DraftAction::GeneratePairings { round } => apply_generate_pairings(session, round),
+        DraftAction::GeneratePairings => apply_generate_pairings(session),
         DraftAction::ReportMatchResult {
             match_id,
             winner_seat,
@@ -186,10 +197,7 @@ fn ensure_match_record(
 /// Swiss round count for an 8-player pod.
 const SWISS_ROUNDS: u8 = 3;
 
-fn apply_generate_pairings(
-    session: &mut DraftSession,
-    round: u8,
-) -> Result<Vec<DraftDelta>, DraftError> {
+fn apply_generate_pairings(session: &mut DraftSession) -> Result<Vec<DraftDelta>, DraftError> {
     // Guard: valid status for pairing generation
     let valid = matches!(
         session.status,
@@ -213,12 +221,9 @@ fn apply_generate_pairings(
             actual: session.seats.len() as u8,
         });
     }
-    if round != session.current_round + 1 {
-        return Err(DraftError::InvalidTransition {
-            from: session.status,
-            action: "GeneratePairings".to_string(),
-        });
-    }
+    // Single authority. The round is derived, never supplied, so the old
+    // `round != current_round + 1` guard is unreachable and is gone.
+    let round = session.next_pairing_round();
 
     let mut rng =
         ChaCha20Rng::seed_from_u64(session.config.rng_seed ^ (round as u64 * 0xDEAD_BEEF));
@@ -1256,12 +1261,7 @@ mod tests {
         let (mut session, _) = test_session(8);
         session.status = DraftStatus::Deckbuilding;
 
-        let deltas = apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        let deltas = apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         assert!(deltas.contains(&DraftDelta::PairingsGenerated { round: 1 }));
         assert!(deltas.contains(&DraftDelta::TransitionedTo {
@@ -1294,12 +1294,7 @@ mod tests {
             };
         }
 
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let round_pairings: Vec<_> = session.pairings.iter().filter(|p| p.round == 1).collect();
         assert_eq!(round_pairings.len(), 4);
@@ -1319,12 +1314,7 @@ mod tests {
         session.seats[7] = DraftSeat::Bot {
             name: "Bot 7".to_string(),
         };
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
         let pairing = session
             .pairings
             .iter()
@@ -1352,11 +1342,7 @@ mod tests {
         session.status = DraftStatus::Deckbuilding;
         session.config.tournament_format = TournamentFormat::SingleElimination;
 
-        let result = apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        );
+        let result = apply(&mut session, DraftAction::GeneratePairings, None);
 
         assert!(matches!(
             result,
@@ -1376,12 +1362,7 @@ mod tests {
         session.status = DraftStatus::Deckbuilding;
 
         // Generate round 1
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         // Record all round 1 pairings as opponent pairs
         let round1_pairs: Vec<[PlayerId; 2]> = session
@@ -1409,12 +1390,7 @@ mod tests {
         session.status = DraftStatus::RoundComplete;
 
         // Generate round 2
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 2 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let round2_pairs: Vec<[PlayerId; 2]> = session
             .pairings
@@ -1465,12 +1441,7 @@ mod tests {
         let mut session = DraftSession::new(config, seats, "SE-TEST".to_string());
         session.status = DraftStatus::Deckbuilding;
 
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let pairings: Vec<_> = session.pairings.iter().filter(|p| p.round == 1).collect();
         assert_eq!(pairings.len(), 4);
@@ -1509,12 +1480,7 @@ mod tests {
         let mut session = DraftSession::new(config, seats, "SE-TEST".to_string());
         session.status = DraftStatus::Deckbuilding;
 
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         for (match_id, winner_seat) in [("r1-t0", 7), ("r1-t1", 6), ("r1-t2", 2), ("r1-t3", 4)] {
             apply(
@@ -1531,12 +1497,7 @@ mod tests {
         assert_eq!(session.status, DraftStatus::RoundComplete);
 
         apply(&mut session, DraftAction::AdvanceRound, None).unwrap();
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 2 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let pairings: Vec<_> = session.pairings.iter().filter(|p| p.round == 2).collect();
         assert_eq!(pairings.len(), 2);
@@ -1550,12 +1511,7 @@ mod tests {
         session.status = DraftStatus::Deckbuilding;
         session.config.tournament_format = TournamentFormat::SingleElimination;
 
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let result = apply(
             &mut session,
@@ -1577,12 +1533,7 @@ mod tests {
         let (mut session, _) = test_session(8);
         session.status = DraftStatus::Deckbuilding;
 
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let pairing = session
             .pairings
@@ -1627,12 +1578,7 @@ mod tests {
         let (mut session, _) = test_session(8);
         session.status = DraftStatus::Deckbuilding;
 
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let pairing = session
             .pairings
@@ -1687,12 +1633,7 @@ mod tests {
         let (mut session, _) = test_session(8);
         session.status = DraftStatus::Deckbuilding;
 
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let pairing = session
             .pairings
@@ -1742,12 +1683,7 @@ mod tests {
         let (mut session, _) = test_session(8);
         session.status = DraftStatus::Deckbuilding;
 
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let results: Vec<(String, u8)> = session
             .pairings
@@ -1801,12 +1737,7 @@ mod tests {
         let (mut session, _) = test_session(8);
         session.status = DraftStatus::Deckbuilding;
 
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let results: Vec<(String, u8)> = session
             .pairings
@@ -1828,12 +1759,7 @@ mod tests {
         }
 
         apply(&mut session, DraftAction::AdvanceRound, None).unwrap();
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 2 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let result = apply(
             &mut session,
@@ -1855,12 +1781,7 @@ mod tests {
         let (mut session, _) = test_session(8);
         session.status = DraftStatus::Deckbuilding;
 
-        apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let results: Vec<(String, u8)> = session
             .pairings
@@ -1957,11 +1878,7 @@ mod tests {
     fn test_generate_pairings_wrong_status() {
         let (mut session, _) = test_session(8);
         // session is in Lobby status
-        let result = apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        );
+        let result = apply(&mut session, DraftAction::GeneratePairings, None);
         assert!(matches!(
             result,
             Err(DraftError::InvalidTransition {
@@ -2076,7 +1993,7 @@ mod tests {
         // Odd pod -> exactly one player takes a bye each round.
         let (mut session, _) = test_session(3);
         session.status = DraftStatus::Deckbuilding; // satisfy the pairing-generation guard
-        apply_generate_pairings(&mut session, 1).unwrap();
+        apply_generate_pairings(&mut session).unwrap();
 
         // Three players: one two-player pairing plus one bye.
         assert_eq!(
@@ -2113,11 +2030,9 @@ mod tests {
             );
         }
 
+        // With the round guard gone, a RoundComplete session generates the NEXT round.
         session.status = DraftStatus::RoundComplete;
-        assert!(matches!(
-            apply_generate_pairings(&mut session, 1),
-            Err(DraftError::InvalidTransition { .. })
-        ));
+        apply_generate_pairings(&mut session).expect("round two generates from RoundComplete");
         assert_eq!(
             session
                 .pairings
@@ -2125,7 +2040,16 @@ mod tests {
                 .filter(|pairing| pairing.round == 1)
                 .count(),
             1,
-            "replaying a completed round must not append pairings",
+            "generating round two must not append to round one",
+        );
+        assert_eq!(
+            session
+                .pairings
+                .iter()
+                .filter(|pairing| pairing.round == 2)
+                .count(),
+            1,
+            "a three-player pod pairs exactly one table in round two",
         );
         assert_eq!(
             session
@@ -2133,7 +2057,7 @@ mod tests {
                 .get(&bye)
                 .map(|record| record.match_wins),
             Some(1),
-            "replaying a completed round must not award the bye twice",
+            "the round-one bye is not re-credited by round-two generation",
         );
     }
 }

--- a/crates/draft-core/src/types.rs
+++ b/crates/draft-core/src/types.rs
@@ -356,9 +356,9 @@ pub enum DraftAction {
         seat: u8,
         main_deck: Vec<String>,
     },
-    GeneratePairings {
-        round: u8,
-    },
+    /// Generate the next round's pairings. Carries no round: the reducer is the
+    /// single authority for which round that is (`DraftSession::next_pairing_round`).
+    GeneratePairings,
     ReportMatchResult {
         match_id: String,
         /// None = draw.

--- a/crates/draft-core/src/view.rs
+++ b/crates/draft-core/src/view.rs
@@ -1765,12 +1765,7 @@ mod tests {
         session.status = DraftStatus::Deckbuilding;
 
         // Generate pairings
-        session::apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        session::apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let winner_pid = session
             .pairings
@@ -1814,12 +1809,7 @@ mod tests {
             name: "Bot 7".to_string(),
         };
 
-        session::apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        session::apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let view = filter_for_player(&session, 0);
         let bot_standing = view
@@ -1852,12 +1842,7 @@ mod tests {
         let (mut session, _) = test_session(8);
         session.status = DraftStatus::Deckbuilding;
 
-        session::apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        session::apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let view = filter_for_player(&session, 0);
         assert_eq!(view.pairings.len(), 4);
@@ -1873,12 +1858,7 @@ mod tests {
         let (mut session, _) = test_session(8);
         session.status = DraftStatus::Deckbuilding;
 
-        session::apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        session::apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let pairing = session
             .pairings
@@ -1911,12 +1891,7 @@ mod tests {
         let (mut session, _) = test_session(8);
         session.status = DraftStatus::Deckbuilding;
 
-        session::apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        session::apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let pairing = session
             .pairings
@@ -2008,12 +1983,7 @@ mod tests {
         let (mut session, _) = test_session(8);
         session.status = DraftStatus::Deckbuilding;
 
-        session::apply(
-            &mut session,
-            DraftAction::GeneratePairings { round: 1 },
-            None,
-        )
-        .unwrap();
+        session::apply(&mut session, DraftAction::GeneratePairings, None).unwrap();
 
         let view = filter_for_spectator(&session, SpectatorVisibility::Public);
         assert_eq!(view.pairings.len(), 4);

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1120,7 +1120,7 @@ fn guard_full_create_game_settings_inbound(
 fn client_forbidden_draft_action_reason(action: &draft_core::types::DraftAction) -> Option<String> {
     use draft_core::types::DraftAction;
     match action {
-        DraftAction::GeneratePairings { .. } => {
+        DraftAction::GeneratePairings => {
             Some("GeneratePairings is server-internal; not allowed from client".to_string())
         }
         DraftAction::SetSeatConnected { .. } => {
@@ -9980,7 +9980,7 @@ mod handshake_tests {
         // Regression coverage: this rejection predates GH #1254 and must
         // continue to fire. GeneratePairings is server-internal because
         // match spawning now drives it after deck submission.
-        let action = draft_core::types::DraftAction::GeneratePairings { round: 1 };
+        let action = draft_core::types::DraftAction::GeneratePairings;
         let reason = client_forbidden_draft_action_reason(&action);
         assert!(reason.is_some());
         assert!(reason.unwrap().contains("server-internal"));

--- a/crates/server-core/src/draft_action_payload_guard.rs
+++ b/crates/server-core/src/draft_action_payload_guard.rs
@@ -57,7 +57,7 @@ pub fn guard_draft_action_payload(action: &DraftAction) -> Result<(), String> {
         }
         DraftAction::StartDraft
         | DraftAction::AdvanceRound
-        | DraftAction::GeneratePairings { .. }
+        | DraftAction::GeneratePairings
         | DraftAction::SetSeatConnected { .. } => {}
     }
     Ok(())

--- a/crates/server-core/src/draft_session.rs
+++ b/crates/server-core/src/draft_session.rs
@@ -521,13 +521,10 @@ impl DraftSessionManager {
         if session.session.status != DraftStatus::Pairing {
             return Ok(());
         }
-        let round = session.session.current_round.max(1);
-        draft_core::session::apply(
-            &mut session.session,
-            DraftAction::GeneratePairings { round },
-            None,
-        )
-        .map_err(|e| format!("GeneratePairings failed: {e}"))?;
+        // The reducer derives the round (`DraftSession::next_pairing_round`);
+        // deriving it here is what made round 2 unreachable.
+        draft_core::session::apply(&mut session.session, DraftAction::GeneratePairings, None)
+            .map_err(|e| format!("GeneratePairings failed: {e}"))?;
         Ok(())
     }
 
@@ -785,7 +782,7 @@ fn authorize_client_draft_action(seat: usize, action: DraftAction) -> Result<Dra
         // generate pairings, report results, or replace a seat with a bot.
         DraftAction::StartDraft
         | DraftAction::AdvanceRound
-        | DraftAction::GeneratePairings { .. }
+        | DraftAction::GeneratePairings
         | DraftAction::ReportMatchResult { .. }
         | DraftAction::ReplaceSeatWithBot { .. } => {
             if seat == DRAFT_HOST_SEAT {

--- a/crates/server-core/src/harness.rs
+++ b/crates/server-core/src/harness.rs
@@ -194,6 +194,69 @@ mod tests {
         ));
     }
 
+    /// A completed Swiss round must be followed by round two.
+    ///
+    /// `AdvanceRound` deliberately leaves `current_round` at the round just
+    /// finished; only pairing generation commits the next one. Any caller that
+    /// derives the round itself gets this wrong (it did: `current_round.max(1)`
+    /// pinned every pod to round one forever).
+    #[test]
+    fn advance_round_then_generate_pairs_round_two() {
+        let mut h = TournamentHarness::new_premier_draft();
+        h.start();
+        h.run_all_picks();
+        h.submit_all_decks();
+
+        h.manager
+            .ensure_pairings_generated(&h.draft_code)
+            .expect("round one pairings");
+        assert_eq!(h.status(), DraftStatus::MatchInProgress);
+
+        let round_one: Vec<(String, u8)> = h.manager.sessions[&h.draft_code]
+            .session
+            .pairings
+            .iter()
+            .filter(|p| p.round == 1)
+            .map(|p| (p.match_id.clone(), p.players[0].0))
+            .collect();
+        assert_eq!(round_one.len(), 4, "an 8-player pod pairs four tables");
+
+        for (match_id, winner_seat) in round_one {
+            h.manager
+                .apply_system_action(
+                    &h.draft_code,
+                    DraftAction::ReportMatchResult {
+                        match_id,
+                        winner_seat: Some(winner_seat),
+                    },
+                    None,
+                )
+                .expect("report round one result");
+        }
+        assert_eq!(h.status(), DraftStatus::RoundComplete);
+
+        h.manager
+            .apply_system_action(&h.draft_code, DraftAction::AdvanceRound, None)
+            .expect("advance round");
+        assert_eq!(h.status(), DraftStatus::Pairing);
+
+        // REVERT-FAILING ASSERTION. Pre-fix `ensure_pairings_generated` derives
+        // `current_round.max(1) == 1`, the guard rejects `1 != 1 + 1`, and this
+        // `.expect` panics.
+        h.manager
+            .ensure_pairings_generated(&h.draft_code)
+            .expect("round two pairings");
+
+        let view = h.manager.sessions[&h.draft_code].view_for_seat(0);
+        assert_eq!(view.current_round, 2, "generation commits round two");
+        assert_eq!(
+            view.pairings.len(),
+            4,
+            "the view exposes the four round-two tables",
+        );
+        assert_eq!(h.status(), DraftStatus::MatchInProgress);
+    }
+
     #[test]
     fn disconnect_and_reconnect_during_drafting() {
         let mut h = TournamentHarness::new_premier_draft();


### PR DESCRIPTION
## The bug

A draft pod finished round 1. The host clicked **Start Next Round** and nothing happened — the pod sat on the Tournament Pairings screen with both round-1 matches showing Complete and only an "End Draft" button visible.

## Root cause

`DraftAction::GeneratePairings` carried a `round: u8` that **four call sites each derived independently** as `current_round + 1`. Two derived it wrong:

| Site | Derivation | Correct? |
|---|---|---|
| `p2p-draft-host.ts` deck-submit path | `generatePairings(1)` | accidentally — `current_round == 0` there |
| `p2p-draft-host.ts` `advanceRound` | pre-advance `view.current_round` | **no** |
| `p2p-draft-host.ts` resume path | `view.current_round + 1` | yes |
| `draft_session.rs` `ensure_pairings_generated` | `current_round.max(1)` | **no** for round ≥ 2 |

`apply_advance_round` deliberately leaves `current_round` untouched — it only opens the `Pairing` window, and `compute_pairing_views`, `apply_report_match_result` and match spawning all depend on that. So `current_round + 1` was the only legal argument the action could ever carry, and both wrong sites pinned a pod to round 1 forever.

The reducer rejected the call with `InvalidTransition`, and that rejection was swallowed into a store `error` field that **no component mounted in the pairing phase reads** — which is why it failed silently. Server-hosted pods stalled identically via `.max(1)`.

## The fix

Make `GeneratePairings` a unit variant and derive the round inside the reducer via a new private `DraftSession::next_pairing_round()`. This makes the wrong call **unrepresentable** rather than merely rejected, so the now-unreachable `round != current_round + 1` guard is deleted (the status and single-elimination pod-size guards keep their precedence — the derivation replaced the guard in place). The client no longer computes the round at all; it reads the committed value back off the engine view, per the display-layer rule in CLAUDE.md.

Net −191/+263, of which the new test file is +113.

## Tests

Both were confirmed **red before the fix and green after**:

- `server-core harness::advance_round_then_generate_pairs_round_two` — drives the real manager through report-results → `AdvanceRound` → generate. Pre-fix it panics with the production error verbatim: `GeneratePairings failed: invalid transition from Pairing: GeneratePairings`. Its round-1 leg passes both before and after by design, which is what proves it discriminates round-2 behaviour specifically.
- `p2pDraftHostAdvanceRound.test.ts` — asserts the host emits round 2 (pre-fix: 1) and emits no `error` event.

## Known wire break

A stale client sending `{"type":"GeneratePairings","data":{"round":2}}` no longer deserializes. This is unobservable on every live path — the only producer (`draft-adapter.ts`) ships in the same browser bundle as its wasm consumer so no version skew is possible; `phase-server` rejects client-sent `GeneratePairings` either way (now one layer earlier); and no persisted state replays actions. Stating it rather than letting it be discovered.

## Deliberately deferred (each would need its own change)

- **`StandingsTable` round heading is off by one** at `MatchInProgressView` and `CompleteView` (correct at the other two render sites). `StandingsTable` takes no props and self-sources the round from the store, so fixing it means editing that component — a 13th path and a second testable behaviour.
- **No error surface during the pairing phase.** `store.error` is written but has only two consumers, at the lobby and deckbuilding. This is what made the bug invisible; a `console.error` is added at the swallow point as a stopgap.
- **Host-resume recovery branch can't fire** (`p2p-draft-host.ts`, pre-existing, byte-identical to base): it is gated on `pairings.length === 0`, but `compute_pairing_views` returns empty only when `current_round == 0`, so after `AdvanceRound` the branch is skipped. Same symptom, different mechanism; untouched by this change.

https://claude.ai/code/session_0118J576jjG9stoucpv5vvyN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Pairings are now generated automatically for the correct upcoming round, reducing the risk of mismatched round selections.
  * Drafts can progress smoothly from completed rounds into the next pairing phase.
  * Round updates now rely on the latest draft state, keeping displayed round information and pairing status synchronized.

* **Bug Fixes**
  * Improved error handling and event updates during pairing generation.
  * Fixed round progression scenarios, including continued Swiss rounds and bye handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->