### PR TITLE
fix(engine,parser): manifest a card from your hand (Scroll of Fate)

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -5111,6 +5111,7 @@ fn rw_effect(
         Effect::Manifest {
             target: _,
             count,
+            object_source,
             enters_under: _,
             profile: _,
         } => {
@@ -5119,6 +5120,15 @@ fn rw_effect(
             p.writes_membership_external_census.merge(Census::Any);
             p.writes_membership_external_zones.merge(ZoneSpan::Any);
             p.merge(rw_quantity_expr(count));
+            // CR 701.40a: `object_source` (Some) names already-chosen objects
+            // being manifested — a membership WRITE target. The membership
+            // write is already maximal-conservative (Census/Zone Any) above;
+            // flag its D5 / member-bound referents (mirrors the `Cloak` arm
+            // below).
+            if let Some(src) = object_source {
+                flag_legacy_write_target(&mut p, src);
+                flag_member_bound_write_target(&mut p, src);
+            }
             (p, None)
         }
         Effect::ManifestDread => {

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1644,12 +1644,16 @@ fn scan_effect(x: &Effect, mode: ScanMode) -> Axes {
         Effect::Manifest {
             target,
             count,
+            object_source,
             enters_under,
             profile: _,
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(target, target_ctx, mode));
             acc = acc.or(scan_quantity_expr(count, mode));
+            if let Some(f) = object_source {
+                acc = acc.or(scan_target_filter(f, target_ctx, mode));
+            }
             if let Some(x) = enters_under {
                 acc = acc.or(scan_controller_ref(x));
             }

--- a/crates/engine/src/game/effects/manifest.rs
+++ b/crates/engine/src/game/effects/manifest.rs
@@ -19,15 +19,17 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (target, count, profile, enters_under) = match &ability.effect {
+    let (target, count, object_source, profile, enters_under) = match &ability.effect {
         Effect::Manifest {
             target,
             count,
+            object_source,
             profile,
             enters_under,
         } => (
             target.clone(),
             resolve_quantity_with_targets(state, count, ability).max(0) as usize,
+            object_source.clone(),
             profile.clone(),
             enters_under.clone(),
         ),
@@ -58,26 +60,52 @@ pub fn resolve(
     // manifest default (CR 701.40a).
     let profile = profile.unwrap_or_else(crate::types::ability::FaceDownProfile::vanilla_2_2);
 
-    // CR 701.40e: Manifest cards one at a time
-    for _ in 0..count {
-        // CR 701.40a: Resolve the top card of the library owner's library, then
-        // manifest it through the shared morph infrastructure, routing the
-        // effect-specified profile and the optional controller override.
-        let object_id = match crate::game::morph::top_library_object(state, player) {
-            Ok(id) => id,
-            // The library owner has no cards left — stop manifesting.
-            Err(_) => break,
-        };
-        crate::game::morph::manifest_card(
-            state,
-            player,
-            object_id,
-            ability.source_id,
-            profile.clone(),
-            controller,
-            events,
-        )
-        .map_err(|e| EffectError::MissingParam(format!("{e}")))?;
+    match object_source {
+        // CR 701.40a: Manifest explicit objects forwarded onto
+        // `ability.targets` by a parent `ChooseFromZone` (Scroll of Fate's
+        // "manifest a card from your hand"). Those cards live in a
+        // non-battlefield zone, so `manifest_card` is a real move (CR 608.2c —
+        // later instructions read the earlier selection). Mirrors the
+        // `Cloak.object_source` branch, minus the ward profile.
+        Some(filter) => {
+            let object_ids = super::effect_object_targets(&filter, &ability.targets);
+            for object_id in object_ids {
+                crate::game::morph::manifest_card(
+                    state,
+                    player,
+                    object_id,
+                    ability.source_id,
+                    profile.clone(),
+                    controller,
+                    events,
+                )
+                .map_err(|e| EffectError::MissingParam(format!("{e}")))?;
+            }
+        }
+        // CR 701.40e: Manifest cards one at a time
+        None => {
+            for _ in 0..count {
+                // CR 701.40a: Resolve the top card of the library owner's
+                // library, then manifest it through the shared morph
+                // infrastructure, routing the effect-specified profile and the
+                // optional controller override.
+                let object_id = match crate::game::morph::top_library_object(state, player) {
+                    Ok(id) => id,
+                    // The library owner has no cards left — stop manifesting.
+                    Err(_) => break,
+                };
+                crate::game::morph::manifest_card(
+                    state,
+                    player,
+                    object_id,
+                    ability.source_id,
+                    profile.clone(),
+                    controller,
+                    events,
+                )
+                .map_err(|e| EffectError::MissingParam(format!("{e}")))?;
+            }
+        }
     }
 
     events.push(GameEvent::EffectResolved {
@@ -104,6 +132,7 @@ mod tests {
             Effect::Manifest {
                 target: TargetFilter::Controller,
                 count: QuantityExpr::Fixed { value: count },
+                object_source: None,
                 profile: None,
                 enters_under: None,
             },
@@ -122,6 +151,7 @@ mod tests {
             Effect::Manifest {
                 target: target_filter,
                 count: QuantityExpr::Fixed { value: count },
+                object_source: None,
                 profile: None,
                 enters_under: None,
             },
@@ -421,6 +451,7 @@ mod tests {
             Effect::Manifest {
                 target: TargetFilter::TriggeringPlayer,
                 count: QuantityExpr::Fixed { value: 2 },
+                object_source: None,
                 profile: Some(profile),
                 enters_under: Some(crate::types::ability::ControllerRef::You),
             },

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -18134,6 +18134,7 @@ mod tests {
             Effect::Manifest {
                 target: TargetFilter::ParentTargetController,
                 count: QuantityExpr::Fixed { value: 1 },
+                object_source: None,
                 profile: None,
                 enters_under: None,
             },

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -722,10 +722,12 @@ impl GameScenario {
             Zone::Battlefield,
         );
         let ts = self.state.next_timestamp();
+        let entered_turn = self.state.turn_number.saturating_sub(1);
         let obj = self.state.objects.get_mut(&id).unwrap();
         obj.card_types.core_types.push(CoreType::Artifact);
         obj.base_card_types = obj.card_types.clone();
         obj.timestamp = ts;
+        obj.entered_battlefield_turn = Some(entered_turn);
         // A pre-existing permanent (entered on a prior turn), matching the
         // enchantment/land builders (CR 302.6 gates only creatures).
         obj.summoning_sick = false;

--- a/crates/engine/src/game/scenario.rs
+++ b/crates/engine/src/game/scenario.rs
@@ -703,6 +703,41 @@ impl GameScenario {
         builder
     }
 
+    /// CR 301.1: Add an artifact to the battlefield with abilities parsed from
+    /// Oracle text. Mirrors [`Self::add_enchantment_from_oracle`]; needed when
+    /// an artifact's own registered activated ability (not a cast) is under
+    /// test — e.g. Scroll of Fate's "{T}: Manifest a card from your hand."
+    pub fn add_artifact_from_oracle(
+        &mut self,
+        player: PlayerId,
+        name: &str,
+        oracle_text: &str,
+    ) -> CardBuilder<'_> {
+        let card_id = CardId(self.state.next_object_id);
+        let id = create_object(
+            &mut self.state,
+            card_id,
+            player,
+            name.to_string(),
+            Zone::Battlefield,
+        );
+        let ts = self.state.next_timestamp();
+        let obj = self.state.objects.get_mut(&id).unwrap();
+        obj.card_types.core_types.push(CoreType::Artifact);
+        obj.base_card_types = obj.card_types.clone();
+        obj.timestamp = ts;
+        // A pre-existing permanent (entered on a prior turn), matching the
+        // enchantment/land builders (CR 302.6 gates only creatures).
+        obj.summoning_sick = false;
+
+        let mut builder = CardBuilder {
+            state: &mut self.state,
+            id,
+        };
+        builder.from_oracle_text(oracle_text);
+        builder
+    }
+
     /// CR 306.1 + CR 306.5b: Add a planeswalker to the battlefield with its
     /// loyalty abilities parsed from Oracle text and `loyalty` loyalty counters
     /// already on it.

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -7296,6 +7296,7 @@ pub(super) fn lower_put_ast(ast: PutImperativeAst) -> Effect {
         } => Effect::Manifest {
             target,
             count,
+            object_source: None,
             profile,
             enters_under,
         },
@@ -10693,10 +10694,37 @@ pub(super) fn parse_imperative_family_ast(
                 Some(ImperativeFamilyAst::Manifest {
                     target,
                     count,
+                    from_zone: None,
                     enters_under,
                 })
             } else {
-                None
+                // CR 701.40a: "manifest a card from your hand" (Scroll of
+                // Fate) — the manifest twin of the cloak from-hand form below:
+                // the controller chooses a hand card, lowered to a
+                // `ChooseFromZone` parent + `Manifest` sub-chain in
+                // `lower_imperative_family_ast`.
+                let from_hand = all_consuming((
+                    tag::<_, _, OracleError<'_>>("manifest "),
+                    alt((tag("a card"), tag("one card"))),
+                    tag(" from your hand"),
+                    opt(tag(".")),
+                ))
+                .parse(lower.trim())
+                .is_ok();
+
+                if from_hand {
+                    Some(ImperativeFamilyAst::Manifest {
+                        target: TargetFilter::Controller,
+                        count: QuantityExpr::Fixed { value: 1 },
+                        from_zone: Some(Zone::Hand),
+                        // CR 110.2a: the imperative "you" subject manifests, so
+                        // the card enters under the instruction controller's
+                        // control.
+                        enters_under: Some(ControllerRef::You),
+                    })
+                } else {
+                    None
+                }
             }
         }
         // CR 701.58a: "cloak the top card of your library" / "cloak the top N
@@ -12780,6 +12808,44 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
                 },
             ))
         }
+        // CR 701.40a: "manifest a card from your hand" (Scroll of Fate). The
+        // manifest twin of the cloak from-hand arm below: the controller
+        // chooses a card from their hand — delegated to the `ChooseFromZone`
+        // building block — then manifests it. The `Manifest` sub-ability reads
+        // the chosen card from `object_source` (`ParentTarget`, resolved
+        // against the `ability.targets` the choose forwards — CR 608.2c: later
+        // instructions read the earlier selection). Intercepted here because a
+        // bare Effect cannot express the parent + sub chain — only
+        // `ParsedEffectClause` can.
+        ImperativeFamilyAst::Manifest {
+            target,
+            count,
+            from_zone: Some(zone),
+            enters_under,
+        } => {
+            let mut clause = parsed_clause(Effect::ChooseFromZone {
+                count: 1,
+                zone,
+                additional_zones: Vec::new(),
+                zone_owner: ZoneOwner::Controller,
+                filter: None,
+                chooser: Chooser::Controller,
+                up_to: false,
+                selection: crate::types::ability::CardSelectionMode::Chosen,
+                constraint: None,
+            });
+            clause.sub_ability = Some(Box::new(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Manifest {
+                    target,
+                    count,
+                    object_source: Some(TargetFilter::ParentTarget),
+                    profile: None,
+                    enters_under,
+                },
+            )));
+            clause
+        }
         // CR 701.58a: "cloak a card from your hand" (Vannifar). The controller
         // chooses a card from their hand — delegated to the `ChooseFromZone`
         // building block — then cloaks it (CR 701.58a). The `Cloak` sub-ability
@@ -13059,13 +13125,19 @@ fn lower_imperative_family_effect(ast: ImperativeFamilyAst) -> Effect {
         // carries no effect-specified face-down profile; `enters_under` records
         // the instruction-controller default. The put-form manifest may also
         // seed an effect-specified profile (see `lower_put_ast`).
+        // CR 701.40a: Manifest the top card(s) of a library. The from-hand
+        // form (`from_zone: Some`) is intercepted upstream in
+        // `lower_imperative_family_ast` (Cloak pattern); only the library-top
+        // source reaches here.
         ImperativeFamilyAst::Manifest {
             target,
             count,
             enters_under,
+            ..
         } => Effect::Manifest {
             target,
             count,
+            object_source: None,
             profile: None,
             enters_under,
         },

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -21264,6 +21264,7 @@ fn lower_subject_predicate_ast(
                 return parsed_clause(Effect::Manifest {
                     target: affected,
                     count,
+                    object_source: None,
                     profile: None,
                     enters_under: None,
                 });

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -11953,7 +11953,7 @@ fn effect_manifest_a_card_from_your_hand_lowers_to_choose_from_zone_then_manifes
         matches!(
             sub.effect.as_ref(),
             Effect::Manifest {
-                object_source: Some(_),
+                object_source: Some(TargetFilter::ParentTarget),
                 enters_under: Some(ControllerRef::You),
                 ..
             }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -11926,6 +11926,45 @@ fn effect_cloak_a_card_from_your_hand_lowers_to_choose_from_zone_then_cloak() {
 }
 
 #[test]
+fn effect_manifest_a_card_from_your_hand_lowers_to_choose_from_zone_then_manifest() {
+    // CR 701.40a: Scroll of Fate's "Manifest a card from your hand" is NOT a
+    // library-top manifest — it is the manifest twin of Vannifar's cloak form
+    // above: a ChooseFromZone{Hand} parent whose Manifest sub-ability
+    // manifests the chosen object. Reverting the from-hand parser alt() drops
+    // it to Effect::Unimplemented → this fails.
+    let def = parse_effect_chain("Manifest a card from your hand", AbilityKind::Spell);
+    assert!(
+        matches!(
+            def.effect.as_ref(),
+            Effect::ChooseFromZone {
+                count: 1,
+                zone: Zone::Hand,
+                ..
+            }
+        ),
+        "expected ChooseFromZone{{Hand,count:1}} parent, got: {:?}",
+        def.effect
+    );
+    let sub = def
+        .sub_ability
+        .as_ref()
+        .expect("from-hand manifest must chain a Manifest sub-ability");
+    assert!(
+        matches!(
+            sub.effect.as_ref(),
+            Effect::Manifest {
+                object_source: Some(_),
+                enters_under: Some(ControllerRef::You),
+                ..
+            }
+        ),
+        "sub-ability must be Manifest with an explicit object_source and the \
+         CR 110.2a manifester-controls entry (enters_under: You), got: {:?}",
+        sub.effect
+    );
+}
+
+#[test]
 fn turn_face_up_then_conditional_put_keeps_follow_up_clause() {
     // CR 406.3 + CR 701.20a: Clone Shell / Summoner's Egg dies-trigger effect. The
     // "turn the exiled card face up" clause must NOT swallow the trailing
@@ -12071,6 +12110,7 @@ fn effect_put_top_onto_battlefield_face_down_lowers_to_manifest() {
     let Effect::Manifest {
         target,
         count,
+        object_source: None,
         profile,
         enters_under,
     } = &*def.effect
@@ -12094,6 +12134,7 @@ fn effect_put_top_onto_battlefield_face_down_lowers_to_manifest() {
             Effect::Manifest {
                 target: TargetFilter::Controller,
                 count: QuantityExpr::Fixed { value: 1 },
+                object_source: None,
                 profile: Some(_),
                 enters_under: None,
             }
@@ -12136,6 +12177,7 @@ fn effect_direct_manifest_top_library_parses_controller_override_only_for_impera
             Effect::Manifest {
                 target: TargetFilter::Controller,
                 count: QuantityExpr::Fixed { value: 1 },
+                object_source: None,
                 enters_under: Some(ControllerRef::You),
                 profile: None,
             }
@@ -12150,6 +12192,7 @@ fn effect_direct_manifest_top_library_parses_controller_override_only_for_impera
             Effect::Manifest {
                 target: TargetFilter::Controller,
                 count: QuantityExpr::Fixed { value: 2 },
+                object_source: None,
                 enters_under: Some(ControllerRef::You),
                 profile: None,
             }
@@ -12172,6 +12215,7 @@ fn effect_direct_manifest_top_library_parses_controller_override_only_for_impera
             Effect::Manifest {
                 target: TargetFilter::TriggeringPlayer,
                 count: QuantityExpr::Fixed { value: 1 },
+                object_source: None,
                 enters_under: Some(ControllerRef::You),
                 profile: None,
             }
@@ -12188,6 +12232,7 @@ fn effect_direct_manifest_top_library_parses_controller_override_only_for_impera
             Effect::Manifest {
                 target: TargetFilter::Controller,
                 count: QuantityExpr::Fixed { value: 1 },
+                object_source: None,
                 enters_under: Some(ControllerRef::You),
                 profile: None,
             }

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -747,6 +747,13 @@ pub(crate) enum ImperativeFamilyAst {
     Manifest {
         target: TargetFilter,
         count: QuantityExpr,
+        /// CR 701.40a: Source discriminant, mirroring `Cloak.from_zone`:
+        /// `None` manifests the top `count` cards of `target`'s library;
+        /// `Some(zone)` manifests a card the controller chooses from that zone
+        /// (Scroll of Fate's "manifest a card from your hand"), which lowers
+        /// to a `ChooseFromZone` parent + `Manifest { object_source }`
+        /// sub-chain.
+        from_zone: Option<Zone>,
         /// CR 110.2a: Direct imperative manifest defaults to the instruction's
         /// controller; subject-predicate forms leave this unset so the subject's
         /// library owner controls the manifested card.

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -17485,25 +17485,20 @@ impl Effect {
             // is always the origin.
             | Effect::Seek { .. } => true,
 
-            // `Effect::Manifest` is TRUE because the ENGINE's manifest is always
-            // top-of-library (all 24 `"type":"Manifest"` nodes in
-            // `data/card-data.json`, each "manifest the top card of your
-            // library"; Ghastly Conscription's
-            // manifest-from-a-graveyard-pile routes to `ChangeZoneAll` instead),
-            // NOT because CR 701.40a says so — CR 701.40a names no source zone
-            // ("Put that card onto the battlefield face down"), and CR 701.40e
-            // ("If an effect instructs a player to manifest multiple cards from
-            // their library ...") and CR 701.40f ("it remains in its previous
-            // zone") together imply non-library sources are legal. A CR-derived
-            // verdict would have to be conditional; there is no source field to
-            // condition on.
-            //
-            // THIS ARM BECOMES WRONG the moment a card manifests from hand,
-            // graveyard, or exile AND parses to this variant. That change arrives
-            // as a new nested/source STRUCT FIELD — field access, not a match arm
-            // — and therefore compiles silently. If you are adding a source field
-            // to `Effect::Manifest`, make this arm conditional in the same commit.
-            Effect::Manifest { .. } => true,
+            // CR 701.40a names no source zone ("Put that card onto the
+            // battlefield face down"), so the verdict is conditional on the
+            // variant's own source axis, mirroring the `Cloak` arm below:
+            // `object_source: None` is the library-top default (every
+            // library-form card text), a real library move. `Some(filter)`
+            // names explicit objects chosen upstream (Scroll of Fate's
+            // "manifest a card from your hand") — the verdict follows the
+            // filter's zones, so a from-hand manifest is NOT a library move
+            // and must not reject an otherwise valid mana ability under the
+            // CR 605.1a classifier.
+            Effect::Manifest { object_source, .. } => match object_source {
+                None => true,
+                Some(filter) => filter.extract_zones().contains(&Zone::Library),
+            },
 
             // No CR entry exists: "heist" does not appear anywhere in
             // `docs/MagicCompRules.txt` (verified case-insensitively). Do not

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -14992,6 +14992,18 @@ pub enum Effect {
     Manifest {
         target: TargetFilter,
         count: QuantityExpr,
+        /// CR 701.40a: The objects to manifest. `None` (serde default) is the
+        /// library-top source — the resolver manifests the top `count` cards
+        /// of `target`'s library one at a time (CR 701.40e). `Some(filter)`
+        /// names explicit objects already chosen upstream (Scroll of Fate's
+        /// "manifest a card from your hand"): the objects are resolved from
+        /// the resolving ability's `targets` via `effect_object_targets`,
+        /// which a preceding `Effect::ChooseFromZone` populated. Kept off
+        /// `target_filter()` so manifest stays a non-targeted keyword action
+        /// (the object selection is the parent `ChooseFromZone`'s
+        /// responsibility). Mirrors `Cloak.object_source`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        object_source: Option<TargetFilter>,
         /// CR 708.2a: Effect-specified face-down characteristics override
         /// ("They're 2/2 Cyberman artifact creatures."). `None` = the vanilla
         /// 2/2 manifest default (CR 701.40a). The put-clause seeds

--- a/crates/engine/tests/integration/issue_2890_reality_shift.rs
+++ b/crates/engine/tests/integration/issue_2890_reality_shift.rs
@@ -131,6 +131,7 @@ fn reality_shift_manifest_resolves_via_effect_context_object_snapshot() {
         Effect::Manifest {
             target: engine::types::ability::TargetFilter::ParentTargetController,
             count: QuantityExpr::Fixed { value: 1 },
+            object_source: None,
             profile: None,
             enters_under: None,
         },

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -977,6 +977,7 @@ mod scarab_god_regression;
 mod scholarship_sponsor;
 mod screaming_nemesis_combat_damage_multi_trigger;
 mod screaming_nemesis_life_lock;
+mod scroll_of_fate_manifest_from_hand;
 mod scythecat_cub_second_resolution;
 mod search_delivery_observer_dedup;
 mod season_points_budget_modal;

--- a/crates/engine/tests/integration/scroll_of_fate_manifest_from_hand.rs
+++ b/crates/engine/tests/integration/scroll_of_fate_manifest_from_hand.rs
@@ -1,0 +1,161 @@
+//! Discriminating runtime regression for **Scroll of Fate** —
+//! "{T}: Manifest a card from your hand."
+//!
+//! Unlike "manifest the top card of your library" (CR 701.40a library-top
+//! source), Scroll of Fate manifests a card the controller *chooses from
+//! hand* — the twin of Vannifar's supported "Cloak a card from your hand"
+//! (see `vannifar_cloak_from_hand.rs`). It lowers to a
+//! `ChooseFromZone { zone: Hand }` parent whose `Manifest` sub-ability turns
+//! the CHOSEN card face down — reading the pick the choose forwarded onto the
+//! resolving ability's `targets` (CR 608.2c), never the top of the library.
+//!
+//! This drives the SAME production path the runtime uses:
+//! `resolve_ability_chain` -> `WaitingFor::ChooseFromZoneChoice` ->
+//! `engine::game::apply(SelectCards)` -> `drain_pending_continuation` ->
+//! `manifest::resolve`.
+//!
+//! DISCRIMINATORS (anti-hollow-win):
+//! - hand card A is manifested (face-down 2/2, leaving the hand); the
+//!   distinguishable library-top card B is UNTOUCHED. A library-top "fix"
+//!   would manifest B and leave A in hand — the assertions flip.
+//! - the manifested card has NO ward: a lazy reuse of the cloak profile
+//!   (CR 701.58a grants ward {2}) instead of the manifest profile
+//!   (CR 701.40a: vanilla 2/2) fails the keyword assertion.
+//!
+//! CR 701.40a: Manifest — face-down 2/2 creature, turn face up any time for
+//! its mana cost if it's a creature card.
+//! CR 608.2c: the Manifest sub-ability reads the chosen card the choose
+//! forwarded.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameScenario, P0};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, Effect};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+#[test]
+fn scroll_of_fate_manifests_chosen_hand_card_leaving_library_top_untouched() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // The card the controller will choose from hand.
+    let hand_a = scenario
+        .add_creature_to_hand(P0, "Hand Creature A", 3, 3)
+        .id();
+    // A distinguishable card sitting on top of P0's library — the library-top
+    // source a hollow (library-top) fix would wrongly manifest instead.
+    let library_b = scenario.add_card_to_library_top(P0, "Library Card B");
+    // The permanent that owns the ability (source of the manifest).
+    let source = scenario.add_creature(P0, "Manifest Source", 1, 1).id();
+
+    let mut runner = scenario.build();
+
+    // Parser path the real card uses: the ChooseFromZone{Hand} + Manifest
+    // sub-chain.
+    let def = parse_effect_chain("Manifest a card from your hand", AbilityKind::Spell);
+    assert!(
+        matches!(
+            def.effect.as_ref(),
+            Effect::ChooseFromZone {
+                zone: Zone::Hand,
+                ..
+            }
+        ),
+        "from-hand manifest must lower to ChooseFromZone{{Hand}}, got {:?}",
+        def.effect
+    );
+    let sub = def
+        .sub_ability
+        .as_ref()
+        .expect("from-hand manifest chains a Manifest sub-ability");
+    assert!(
+        matches!(sub.effect.as_ref(), Effect::Manifest { .. }),
+        "sub-ability must manifest the chosen object, got {:?}",
+        sub.effect
+    );
+
+    // Resolve through the production resolver — raises the interactive choose.
+    let ability = build_resolved_from_def(&def, source, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("ChooseFromZone-then-Manifest chain must resolve to a prompt");
+
+    // PRODUCTION STEP: the choose offers the hand card (A), never the library
+    // card (B). Reverting the parse yields Unimplemented — no prompt — and this
+    // WaitingFor match panics.
+    match &runner.state().waiting_for {
+        WaitingFor::ChooseFromZoneChoice { player, cards, .. } => {
+            assert_eq!(*player, P0, "the controller makes the choose");
+            assert!(
+                cards.contains(&hand_a),
+                "the hand card must be offered, got {cards:?}"
+            );
+            assert!(
+                !cards.contains(&library_b),
+                "the library-top card must NOT be a from-hand candidate"
+            );
+        }
+        other => panic!(
+            "\"Manifest a card from your hand\" must raise ChooseFromZoneChoice, got {other:?}"
+        ),
+    }
+
+    // PRODUCTION STEP: answer with A through the same handler GameRunner uses.
+    engine::game::apply(
+        runner.state_mut(),
+        P0,
+        GameAction::SelectCards {
+            cards: vec![hand_a],
+        },
+    )
+    .expect("selecting the offered hand card must be a legal answer");
+
+    // DISCRIMINATOR — the CHOSEN hand card A is manifested.
+    let a = &runner.state().objects[&hand_a];
+    assert_eq!(
+        a.zone,
+        Zone::Battlefield,
+        "A must be manifested onto the battlefield"
+    );
+    assert!(a.face_down, "A must be face down");
+    assert_eq!(a.power, Some(2), "manifested A is a 2/2");
+    assert_eq!(a.toughness, Some(2), "manifested A is a 2/2");
+    // DISCRIMINATOR — manifest is NOT cloak: the CR 701.40a profile grants no
+    // ward. A lazy reuse of `cloaked_2_2` (CR 701.58a) fails here.
+    assert!(
+        !a.keywords
+            .iter()
+            .any(|keyword| matches!(keyword, Keyword::Ward(_))),
+        "a manifested card must NOT have ward (that is cloak, CR 701.58a), got {:?}",
+        a.keywords
+    );
+
+    // A LEFT the hand.
+    let p0 = runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P0)
+        .expect("P0 exists");
+    assert!(
+        !p0.hand.contains(&hand_a),
+        "the manifested card must leave the hand"
+    );
+
+    // DISCRIMINATOR — the library-top card B is UNTOUCHED (still face up,
+    // still on top of the library). A hollow library-top fix would have
+    // manifested B here.
+    let b = &runner.state().objects[&library_b];
+    assert_eq!(b.zone, Zone::Library, "B must stay in the library");
+    assert!(!b.face_down, "B must remain face up");
+    assert_eq!(
+        p0.library.front(),
+        Some(&library_b),
+        "B must remain on top of the library"
+    );
+}

--- a/crates/engine/tests/integration/scroll_of_fate_manifest_from_hand.rs
+++ b/crates/engine/tests/integration/scroll_of_fate_manifest_from_hand.rs
@@ -26,6 +26,8 @@
 //! forwarded.
 
 use engine::game::scenario::{GameScenario, P0};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::AbilityKind;
 use engine::types::actions::GameAction;
 use engine::types::card_type::CoreType;
 use engine::types::game_state::WaitingFor;
@@ -167,5 +169,37 @@ fn scroll_of_fate_activated_ability_manifests_a_chosen_noncreature_hand_card() {
         p0.library.front(),
         Some(&library_b),
         "B must remain on top of the library"
+    );
+}
+
+#[test]
+fn from_hand_manifest_is_not_a_library_move_for_the_mana_ability_classifier() {
+    // CR 605.1a: the mana-ability classifier rejects abilities that could
+    // move cards to or from a library. Scroll of Fate's chain reads the HAND
+    // on both levels — the `ChooseFromZone { Hand }` parent and the
+    // `Manifest { object_source: Some(ParentTarget) }` sub-ability — so
+    // neither may classify as a library move. Reverting the classifier's
+    // Manifest arm to an unconditional `true` fails the sub-ability line.
+    let def = parse_effect_chain("Manifest a card from your hand", AbilityKind::Spell);
+    assert!(
+        !def.effect.moves_card_to_or_from_library(),
+        "ChooseFromZone{{Hand}} must not classify as a library move"
+    );
+    let sub = def
+        .sub_ability
+        .as_ref()
+        .expect("from-hand manifest chains a Manifest sub-ability");
+    assert!(
+        !sub.effect.moves_card_to_or_from_library(),
+        "a from-hand Manifest (object_source: Some) must not classify as a \
+         library move (CR 605.1a)"
+    );
+
+    // Control — the library-top default stays a real library move.
+    let top = parse_effect_chain("Manifest the top card of your library.", AbilityKind::Spell);
+    assert!(
+        top.effect.moves_card_to_or_from_library(),
+        "the library-top manifest (object_source: None) must stay classified \
+         as a library move"
     );
 }

--- a/crates/engine/tests/integration/scroll_of_fate_manifest_from_hand.rs
+++ b/crates/engine/tests/integration/scroll_of_fate_manifest_from_hand.rs
@@ -148,7 +148,7 @@ fn scroll_of_fate_activated_ability_manifests_a_chosen_noncreature_hand_card() {
     );
     assert!(
         a.color.is_empty(),
-        "a manifested card is colorless (CR 708.2a), got {:?}",
+        "a manifested card is colorless (CR 701.40a + CR 202.2b), got {:?}",
         a.color
     );
     assert!(

--- a/crates/engine/tests/integration/scroll_of_fate_manifest_from_hand.rs
+++ b/crates/engine/tests/integration/scroll_of_fate_manifest_from_hand.rs
@@ -31,7 +31,7 @@ use engine::game::ability_utils::build_resolved_from_def;
 use engine::game::effects::resolve_ability_chain;
 use engine::game::scenario::{GameScenario, P0};
 use engine::parser::oracle_effect::parse_effect_chain;
-use engine::types::ability::{AbilityKind, Effect};
+use engine::types::ability::{AbilityKind, Effect, TargetFilter};
 use engine::types::actions::GameAction;
 use engine::types::game_state::WaitingFor;
 use engine::types::keywords::Keyword;
@@ -74,8 +74,14 @@ fn scroll_of_fate_manifests_chosen_hand_card_leaving_library_top_untouched() {
         .as_ref()
         .expect("from-hand manifest chains a Manifest sub-ability");
     assert!(
-        matches!(sub.effect.as_ref(), Effect::Manifest { .. }),
-        "sub-ability must manifest the chosen object, got {:?}",
+        matches!(
+            sub.effect.as_ref(),
+            Effect::Manifest {
+                object_source: Some(TargetFilter::ParentTarget),
+                ..
+            }
+        ),
+        "sub-ability must manifest the chosen object (object_source: Some(ParentTarget)), got {:?}",
         sub.effect
     );
 

--- a/crates/engine/tests/integration/scroll_of_fate_manifest_from_hand.rs
+++ b/crates/engine/tests/integration/scroll_of_fate_manifest_from_hand.rs
@@ -1,127 +1,117 @@
-//! Discriminating runtime regression for **Scroll of Fate** —
+//! Card-level regression for **Scroll of Fate** —
 //! "{T}: Manifest a card from your hand."
 //!
-//! Unlike "manifest the top card of your library" (CR 701.40a library-top
-//! source), Scroll of Fate manifests a card the controller *chooses from
-//! hand* — the twin of Vannifar's supported "Cloak a card from your hand"
-//! (see `vannifar_cloak_from_hand.rs`). It lowers to a
-//! `ChooseFromZone { zone: Hand }` parent whose `Manifest` sub-ability turns
-//! the CHOSEN card face down — reading the pick the choose forwarded onto the
-//! resolving ability's `targets` (CR 608.2c), never the top of the library.
-//!
-//! This drives the SAME production path the runtime uses:
-//! `resolve_ability_chain` -> `WaitingFor::ChooseFromZoneChoice` ->
-//! `engine::game::apply(SelectCards)` -> `drain_pending_continuation` ->
-//! `manifest::resolve`.
+//! Drives the REAL registered ability end to end (maintainer round 1: no
+//! synthetic `parse_effect_chain` + generic resolver): the artifact is built
+//! from its printed Oracle text, its activated ability is activated through
+//! `GameAction::ActivateAbility`, the `{T}` cost is paid (CR 602.2b), the
+//! ability resolves off the stack, and the interactive
+//! `WaitingFor::ChooseFromZoneChoice` is answered through
+//! `GameAction::SelectCards` — the exact path the client takes.
 //!
 //! DISCRIMINATORS (anti-hollow-win):
-//! - hand card A is manifested (face-down 2/2, leaving the hand); the
-//!   distinguishable library-top card B is UNTOUCHED. A library-top "fix"
-//!   would manifest B and leave A in hand — the assertions flip.
-//! - the manifested card has NO ward: a lazy reuse of the cloak profile
-//!   (CR 701.58a grants ward {2}) instead of the manifest profile
-//!   (CR 701.40a: vanilla 2/2) fails the keyword assertion.
+//! - the chosen hand card is a NONCREATURE (a plain sorcery): CR 701.40a must
+//!   still convert it to a face-down vanilla 2/2 CREATURE. Omitting the
+//!   noncreature conversion fails the full-profile assertions below.
+//! - the complete manifest profile is pinned: empty name, exactly the
+//!   `[Creature]` core type (the printed Sorcery type is hidden), no
+//!   subtypes/supertypes, 2/2, `ManaCost::NoCost`, and NO keywords — a lazy
+//!   reuse of cloak's `cloaked_2_2` (ward {2}, CR 701.58a) fails here.
+//! - the distinguishable library-top card B is UNTOUCHED: a hollow
+//!   library-top fix would manifest B and leave A in hand.
 //!
-//! CR 701.40a: Manifest — face-down 2/2 creature, turn face up any time for
-//! its mana cost if it's a creature card.
+//! CR 701.40a: Manifest — face-down 2/2 creature with no text, no name, no
+//! subtypes, and no mana cost.
 //! CR 608.2c: the Manifest sub-ability reads the chosen card the choose
 //! forwarded.
 
-use engine::game::ability_utils::build_resolved_from_def;
-use engine::game::effects::resolve_ability_chain;
 use engine::game::scenario::{GameScenario, P0};
-use engine::parser::oracle_effect::parse_effect_chain;
-use engine::types::ability::{AbilityKind, Effect, TargetFilter};
 use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
 use engine::types::game_state::WaitingFor;
-use engine::types::keywords::Keyword;
+use engine::types::mana::ManaCost;
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
 
 #[test]
-fn scroll_of_fate_manifests_chosen_hand_card_leaving_library_top_untouched() {
+fn scroll_of_fate_activated_ability_manifests_a_chosen_noncreature_hand_card() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
 
-    // The card the controller will choose from hand.
+    // NONCREATURE hand card: a plain sorcery with no creature side.
     let hand_a = scenario
-        .add_creature_to_hand(P0, "Hand Creature A", 3, 3)
+        .add_spell_to_hand_from_oracle(P0, "Plain Sorcery A", false, "Draw a card.")
         .id();
     // A distinguishable card sitting on top of P0's library — the library-top
     // source a hollow (library-top) fix would wrongly manifest instead.
     let library_b = scenario.add_card_to_library_top(P0, "Library Card B");
-    // The permanent that owns the ability (source of the manifest).
-    let source = scenario.add_creature(P0, "Manifest Source", 1, 1).id();
+    // The REAL card: battlefield artifact with its registered activated
+    // ability parsed from the printed Oracle text.
+    let scroll = scenario
+        .add_artifact_from_oracle(P0, "Scroll of Fate", "{T}: Manifest a card from your hand.")
+        .id();
 
     let mut runner = scenario.build();
 
-    // Parser path the real card uses: the ChooseFromZone{Hand} + Manifest
-    // sub-chain.
-    let def = parse_effect_chain("Manifest a card from your hand", AbilityKind::Spell);
+    // PRODUCTION STEP: activate the registered ability — index 0 is the
+    // card's only ability. A parse regression (Unimplemented) makes the
+    // activation illegal and this expect panics.
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: scroll,
+            ability_index: 0,
+        })
+        .expect("Scroll of Fate's registered ability must be activatable");
+
+    // CR 602.2b: the {T} activation cost is paid on activation, before
+    // resolution.
     assert!(
-        matches!(
-            def.effect.as_ref(),
-            Effect::ChooseFromZone {
-                zone: Zone::Hand,
-                ..
-            }
-        ),
-        "from-hand manifest must lower to ChooseFromZone{{Hand}}, got {:?}",
-        def.effect
-    );
-    let sub = def
-        .sub_ability
-        .as_ref()
-        .expect("from-hand manifest chains a Manifest sub-ability");
-    assert!(
-        matches!(
-            sub.effect.as_ref(),
-            Effect::Manifest {
-                object_source: Some(TargetFilter::ParentTarget),
-                ..
-            }
-        ),
-        "sub-ability must manifest the chosen object (object_source: Some(ParentTarget)), got {:?}",
-        sub.effect
+        runner.state().objects[&scroll].tapped,
+        "activating {{T}}: … must tap Scroll of Fate"
     );
 
-    // Resolve through the production resolver — raises the interactive choose.
-    let ability = build_resolved_from_def(&def, source, P0);
-    let mut events = Vec::new();
-    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
-        .expect("ChooseFromZone-then-Manifest chain must resolve to a prompt");
-
-    // PRODUCTION STEP: the choose offers the hand card (A), never the library
-    // card (B). Reverting the parse yields Unimplemented — no prompt — and this
-    // WaitingFor match panics.
-    match &runner.state().waiting_for {
-        WaitingFor::ChooseFromZoneChoice { player, cards, .. } => {
-            assert_eq!(*player, P0, "the controller makes the choose");
-            assert!(
-                cards.contains(&hand_a),
-                "the hand card must be offered, got {cards:?}"
-            );
-            assert!(
-                !cards.contains(&library_b),
-                "the library-top card must NOT be a from-hand candidate"
-            );
+    // Let the ability resolve off the stack (CR 608): pass priority until the
+    // resolution raises the interactive choose.
+    let mut reached_choice = false;
+    for _ in 0..16 {
+        match &runner.state().waiting_for {
+            WaitingFor::ChooseFromZoneChoice { player, cards, .. } => {
+                // PRODUCTION STEP: the choose offers the hand card (A), never
+                // the library card (B).
+                assert_eq!(*player, P0, "the controller makes the choose");
+                assert!(
+                    cards.contains(&hand_a),
+                    "the hand card must be offered, got {cards:?}"
+                );
+                assert!(
+                    !cards.contains(&library_b),
+                    "the library-top card must NOT be a from-hand candidate"
+                );
+                reached_choice = true;
+                break;
+            }
+            _ => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("pass priority toward the ability's resolution");
+            }
         }
-        other => panic!(
-            "\"Manifest a card from your hand\" must raise ChooseFromZoneChoice, got {other:?}"
-        ),
     }
+    assert!(
+        reached_choice,
+        "resolving Scroll of Fate's ability must raise ChooseFromZoneChoice, got {:?}",
+        runner.state().waiting_for
+    );
 
-    // PRODUCTION STEP: answer with A through the same handler GameRunner uses.
-    engine::game::apply(
-        runner.state_mut(),
-        P0,
-        GameAction::SelectCards {
+    // PRODUCTION STEP: answer with A through the same handler the client uses.
+    runner
+        .act(GameAction::SelectCards {
             cards: vec![hand_a],
-        },
-    )
-    .expect("selecting the offered hand card must be a legal answer");
+        })
+        .expect("selecting the offered hand card must be a legal answer");
 
-    // DISCRIMINATOR — the CHOSEN hand card A is manifested.
+    // DISCRIMINATOR — the CHOSEN noncreature hand card A is manifested with
+    // the COMPLETE CR 701.40a profile.
     let a = &runner.state().objects[&hand_a];
     assert_eq!(
         a.zone,
@@ -129,15 +119,30 @@ fn scroll_of_fate_manifests_chosen_hand_card_leaving_library_top_untouched() {
         "A must be manifested onto the battlefield"
     );
     assert!(a.face_down, "A must be face down");
+    assert_eq!(a.name, "", "a face-down card has no name (CR 701.40a)");
+    assert_eq!(
+        a.card_types.core_types,
+        vec![CoreType::Creature],
+        "the face-down body is exactly a Creature — the printed Sorcery type \
+         is hidden (CR 708.2a)"
+    );
+    assert!(
+        a.card_types.supertypes.is_empty() && a.card_types.subtypes.is_empty(),
+        "a face-down card has no super-/subtypes (CR 701.40a), got {:?}",
+        a.card_types
+    );
     assert_eq!(a.power, Some(2), "manifested A is a 2/2");
     assert_eq!(a.toughness, Some(2), "manifested A is a 2/2");
-    // DISCRIMINATOR — manifest is NOT cloak: the CR 701.40a profile grants no
-    // ward. A lazy reuse of `cloaked_2_2` (CR 701.58a) fails here.
+    assert_eq!(
+        a.mana_cost,
+        ManaCost::NoCost,
+        "a face-down card has no mana cost (CR 701.40a)"
+    );
+    // DISCRIMINATOR — manifest is NOT cloak: no keywords at all, in
+    // particular no ward {2} (CR 701.58a).
     assert!(
-        !a.keywords
-            .iter()
-            .any(|keyword| matches!(keyword, Keyword::Ward(_))),
-        "a manifested card must NOT have ward (that is cloak, CR 701.58a), got {:?}",
+        a.keywords.is_empty(),
+        "a manifested card has no abilities/keywords (CR 701.40a), got {:?}",
         a.keywords
     );
 
@@ -154,8 +159,7 @@ fn scroll_of_fate_manifests_chosen_hand_card_leaving_library_top_untouched() {
     );
 
     // DISCRIMINATOR — the library-top card B is UNTOUCHED (still face up,
-    // still on top of the library). A hollow library-top fix would have
-    // manifested B here.
+    // still on top of the library).
     let b = &runner.state().objects[&library_b];
     assert_eq!(b.zone, Zone::Library, "B must stay in the library");
     assert!(!b.face_down, "B must remain face up");

--- a/crates/engine/tests/integration/scroll_of_fate_manifest_from_hand.rs
+++ b/crates/engine/tests/integration/scroll_of_fate_manifest_from_hand.rs
@@ -31,7 +31,8 @@ use engine::types::ability::AbilityKind;
 use engine::types::actions::GameAction;
 use engine::types::card_type::CoreType;
 use engine::types::game_state::WaitingFor;
-use engine::types::mana::ManaCost;
+use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaCost, ManaCostShard};
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
 
@@ -43,6 +44,11 @@ fn scroll_of_fate_activated_ability_manifests_a_chosen_noncreature_hand_card() {
     // NONCREATURE hand card: a plain sorcery with no creature side.
     let hand_a = scenario
         .add_spell_to_hand_from_oracle(P0, "Plain Sorcery A", false, "Draw a card.")
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue],
+            generic: 2,
+        })
+        .with_keyword(Keyword::Flash)
         .id();
     // A distinguishable card sitting on top of P0's library — the library-top
     // source a hollow (library-top) fix would wrongly manifest instead.
@@ -139,6 +145,16 @@ fn scroll_of_fate_activated_ability_manifests_a_chosen_noncreature_hand_card() {
         a.mana_cost,
         ManaCost::NoCost,
         "a face-down card has no mana cost (CR 701.40a)"
+    );
+    assert!(
+        a.color.is_empty(),
+        "a manifested card is colorless (CR 708.2a), got {:?}",
+        a.color
+    );
+    assert!(
+        a.abilities.is_empty(),
+        "a manifested card has no abilities (CR 701.40a), got {:?}",
+        a.abilities
     );
     // DISCRIMINATOR — manifest is NOT cloak: no keywords at all, in
     // particular no ward {2} (CR 701.58a).


### PR DESCRIPTION
Fixes #7608

**Card:** Scroll of Fate — `{T}: Manifest a card from your hand.` — rejected as unsupported: the imperative parser's `manifest` branch only knew `manifest dread` and `manifest the top … of your library`.

## Fix — mirror of the supported cloak twin

`cloak a card from your hand` (Vannifar, Evolved Enigma) is fully built: a from-hand recognizer arm, a lowering intercept to a `ChooseFromZone { zone: Hand }` parent with a `Cloak { object_source: Some(ParentTarget) }` sub-ability, and a resolver branch reading the chosen objects via `effect_object_targets`. CR 701.58a (cloak) and CR 701.40a (manifest) share this exact shape — 701.40a says "To manifest **a card**, turn it face down", with no library restriction; the library-top wording lives in the card texts, not the rule. This PR mirrors each cloak piece on the manifest side:

- `oracle_ir/ast.rs`: `ImperativeFamilyAst::Manifest` gains `from_zone: Option<Zone>` (the cloak source discriminant).
- `oracle_effect/imperative.rs`: from-hand recognizer arm in the `"manifest"` dispatch (`manifest (a|one) card from your hand`), and the lowering intercept building the `ChooseFromZone` parent + `Manifest` sub-chain. The library-top arm is untouched.
- `types/ability.rs`: `Effect::Manifest` gains `object_source: Option<TargetFilter>` (serde default `None` = the library-top source), doc-mirroring `Cloak.object_source`.
- `effects/manifest.rs`: resolver branches on `object_source` — `Some(filter)` manifests the chosen objects through the same `morph::manifest_card` authority (no ward; the profile stays the CR 701.40a vanilla 2/2), `None` keeps the existing library loop verbatim.
- `ability_rw.rs` / `ability_scan.rs`: the Manifest arms mirror the Cloak arms' `object_source` handling (membership write-target flags / target-filter scan).

## Class (Rule-13 double parse, full 35,798-card corpus)

Parsed the whole corpus with and without the fix; the diff is **exactly one card**: `scroll of fate` (`Unimplemented` → activated `{T}` ability with the `ChooseFromZone{Hand}` + `Manifest{object_source: ParentTarget, enters_under: You}` chain). No other card's parse changes.

**Remaining gap (out of scope):** Kozilek, the Broken Reality — `up to two target players each manifest two cards from their hands` — is the targeted per-player form with a draw rider; it needs target/per-player machinery this PR deliberately does not touch, and its parse is unchanged by this diff.

## Tests

- Parser: `effect_manifest_a_card_from_your_hand_lowers_to_choose_from_zone_then_manifest` (red before the fix: `Effect::Unimplemented`).
- Integration: `scroll_of_fate_manifest_from_hand.rs` drives the production path (`resolve_ability_chain` → `WaitingFor::ChooseFromZoneChoice` → `apply(SelectCards)`) and discriminates three ways: the chosen hand card is manifested as a face-down 2/2, the library top stays untouched (kills a hollow library-top fix), and the manifested card has **no ward** (kills a lazy reuse of the cloak profile). A probe emptying the resolver's chosen-object branch flips the test red.
- Existing manifest parse pins tightened with `object_source: None` — the library form must stay `None`.

What the tests don't prove: hidden-information handling in the client (which hand card was chosen is visible to the chooser only) is exercised by the shared face-down infrastructure, not asserted here; and the paused/interrupted mid-manifest path (replacement choices during the zone move) relies on the same `manifest_card` authority the library path already uses.

Full suites green: 19,532 lib + 5,337 integration, clippy clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for manifesting a card from your hand.
  * Players can choose a hand card to manifest, entering play face down as a 2/2 Creature without a mana cost, name, or additional keywords.
  * Existing library-top manifest behavior remains supported.

* **Bug Fixes**
  * Improved handling of selected manifest targets during parsing and resolution.
  * Correctly distinguishes hand-based manifesting from library moves.
  * Corrected artifact battlefield entry timing in game scenarios.

* **Tests**
  * Added coverage for parsing, selection, resolution, and manifest behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->