### PR TITLE
refactor(engine): pass the typed cost-move boundary into the counter-addition resume

### DIFF
--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -1324,8 +1324,10 @@ fn pay_ability_cost_inner(
         // resources rule and says nothing about an effect-as-cost.) Resolve the
         // effect on the source before the ability's own effect fires. The shared
         // support predicate admits only deterministic source-counter and
-        // fixed-mana forms, so this never opens a player-choice prompt
-        // mid-payment.
+        // fixed-mana forms, so the effect shape itself asks the payer nothing.
+        // A replacement on the resulting event can still require a player
+        // choice, which parks the payment as `Paused` in the `PutCounter` arm
+        // below.
         AbilityCost::EffectCost { effect } => {
             use crate::types::ability::Effect;
             match effect.as_ref() {
@@ -1344,7 +1346,8 @@ fn pay_ability_cost_inner(
                     // reject the prevented case before executing it.
                     //
                     // The gate is `replacement::mandatory_prevention_applies`
-                    // (CR 614.6): a candidate definition on the governing event
+                    // (CR 614.17: "some effects state that something can't
+                    // happen"): a candidate definition on the governing event
                     // whose `quantity_modification` is `Prevent` and whose mode
                     // is not optional. Only that pair can reach this refusal.
                     // CR 614.17c ("if an event can't happen, it can only be
@@ -1502,10 +1505,11 @@ fn pay_ability_cost_inner(
         //
         // CR 614.17b is the rule ("if an event can't happen, a player can't
         // choose to pay a cost that includes that event"). The gate that reaches
-        // it is `replacement::mandatory_prevention_applies` (CR 614.6): a
-        // candidate definition on the governing event whose
-        // `quantity_modification` is `Prevent` and whose mode is not optional —
-        // not a semantic can't-effect test. CR 614.17c is why the CR 616.1
+        // it is `replacement::mandatory_prevention_applies` (CR 614.17:
+        // "some effects state that something can't happen"): a candidate
+        // definition on the governing event whose `quantity_modification`
+        // is `Prevent` and whose mode is not optional — not a semantic
+        // can't-effect test. CR 614.17c is why the CR 616.1
         // ordering step never intervenes: an impossible event "can only be
         // replaced by a self-replacement effect … other replacement and/or
         // prevention effects can't modify or replace it", so

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -1363,9 +1363,12 @@ fn pay_ability_cost_inner(
                     // (CR 118.12). The two legs partition the space; they do not
                     // disagree.
                     //
-                    // CR 614.17b + CR 119.8 (analogue): the CHOICE is refused upstream, at every
-                    // site that consumes `resolution_cost_includes_impossible_event`. This arm is
-                    // retained as defense in depth for the CR 614.17a mid-window case.
+                    // CR 614.17b + CR 119.8 (analogue): the CHOICE is refused upstream at every
+                    // RESOLUTION-scope site that consumes
+                    // `resolution_cost_includes_impossible_event`, but that predicate is never
+                    // consulted at `PaymentScope::Activation` — `is_payable_for_activation` admits
+                    // every `EffectCost` unconditionally, and `can_pay` dry-runs this arm — so here
+                    // it is the only CR 614.17b gate an activated counter cost meets.
                     let prevented = self_counter_placement_is_prohibited(
                         state,
                         player,
@@ -2076,6 +2079,9 @@ pub(crate) fn resolution_cost_includes_impossible_event(
                 ..
             } => false,
             // `supports_effect_cost_payment` refuses every other effect-cost shape upstream.
+            // CR 614.17b: widening that predicate to admit a further counter-placing shape owes a
+            // matching arm here in the same change, or the new shape answers "no impossible event"
+            // and silently loses this refusal.
             _ => false,
         },
         // Prohibition is the De Morgan dual of payability: `can_pay_resolution` answers
@@ -3504,7 +3510,7 @@ mod tests {
             "a Composite with no counter component must not be prohibited"
         );
 
-        // (ii) Step 3c's fold: the payability oracle follows the leaves.
+        // (ii) The payability oracle follows the leaves.
         assert!(
             !can_pay(&scenario.state, P0, src, &counter_composite, &scope),
             "can_pay must refuse a Composite whose payment includes an impossible event"

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -1343,7 +1343,10 @@ fn pay_ability_cost_inner(
                     // needs that distinction only for continuation; payment must
                     // reject the prevented case before executing it.
                     //
-                    // Only a MANDATORY can't-effect can reach this refusal.
+                    // The gate is `replacement::mandatory_prevention_applies`
+                    // (CR 614.6): a candidate definition on the governing event
+                    // whose `quantity_modification` is `Prevent` and whose mode
+                    // is not optional. Only that pair can reach this refusal.
                     // CR 614.17c ("if an event can't happen, it can only be
                     // replaced by a self-replacement effect … other replacement
                     // and/or prevention effects can't modify or replace it") is
@@ -1498,10 +1501,14 @@ fn pay_ability_cost_inner(
         // bypassed for free.
         //
         // CR 614.17b is the rule ("if an event can't happen, a player can't
-        // choose to pay a cost that includes that event"), and CR 614.17c is why
-        // only a MANDATORY can't-effect can reach it: an impossible event "can
-        // only be replaced by a self-replacement effect … other replacement
-        // and/or prevention effects can't modify or replace it", so
+        // choose to pay a cost that includes that event"). The gate that reaches
+        // it is `replacement::mandatory_prevention_applies` (CR 614.6): a
+        // candidate definition on the governing event whose
+        // `quantity_modification` is `Prevent` and whose mode is not optional —
+        // not a semantic can't-effect test. CR 614.17c is why the CR 616.1
+        // ordering step never intervenes: an impossible event "can only be
+        // replaced by a self-replacement effect … other replacement and/or
+        // prevention effects can't modify or replace it", so
         // `replacement::pipeline_loop` short-circuits it ahead of any CR 616.1
         // prompt. A CR 616.1 ordering choice instead returns `NeedsChoice`
         // below, parks, and is settled as PAID by

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -1355,33 +1355,24 @@ fn pay_ability_cost_inner(
                     // and/or prevention effects can't modify or replace it") is
                     // implemented by `replacement::pipeline_loop`'s
                     // short-circuit, which fires ahead of any CR 616.1 ordering
-                    // prompt. An ordering choice instead returns
-                    // `CounterAdditionPreview::ChoiceRequired`, falls through,
-                    // parks, and is settled as PAID by
+                    // prompt. Its `AddCounter` replacement choice — a single
+                    // optional candidate, or a CR 616.1 ordering — instead
+                    // returns `CounterAdditionPreview::ChoiceRequired`, falls
+                    // through, parks, and is settled as PAID by
                     // `engine_payment_choices::resume_counter_addition_unless_payment`
                     // (CR 118.12). The two legs partition the space; they do not
                     // disagree.
                     //
-                    // Known deviation, recorded not fixed: CR 614.17b's subject
-                    // is the CHOICE ("a player can't choose to pay"), while this
-                    // engine enforces it at the payment event — `PayUnlessCost
-                    // { pay: true }` stays legal and fails here. The
-                    // rules-correct seam is the CR 119.8 analogue
-                    // (`static_abilities::player_cant_pay_life_as_cost` /
-                    // `PayLifeCostResult::Prohibited`): refuse the choice, not
-                    // the settle. Same observable, wrong seam.
-                    let prevented = state.objects.get(&source_id).is_some_and(|object| {
-                        matches!(
-                            super::effects::counters::preview_counter_addition(
-                                state,
-                                player,
-                                ObjectIncarnationRef::from_object(object),
-                                counter_type.clone(),
-                                count.unsigned_abs(),
-                            ),
-                            Some(super::effects::counters::CounterAdditionPreview::Prevented)
-                        )
-                    });
+                    // CR 614.17b + CR 119.8 (analogue): the CHOICE is refused upstream, at every
+                    // site that consumes `resolution_cost_includes_impossible_event`. This arm is
+                    // retained as defense in depth for the CR 614.17a mid-window case.
+                    let prevented = self_counter_placement_is_prohibited(
+                        state,
+                        player,
+                        source_id,
+                        counter_type.clone(),
+                        counter_cost_count(count),
+                    );
                     if prevented {
                         return Ok(payment_failed(
                             "Counter-placement cost prevented by a replacement effect",
@@ -1392,7 +1383,7 @@ fn pay_ability_cost_inner(
                         player,
                         source_id,
                         counter_type.clone(),
-                        count.unsigned_abs(),
+                        counter_cost_count(count),
                         events,
                     ) {
                         return Ok(PaymentOutcome::Paused {
@@ -1514,11 +1505,14 @@ fn pay_ability_cost_inner(
         // replaced by a self-replacement effect … other replacement and/or
         // prevention effects can't modify or replace it", so
         // `replacement::pipeline_loop` short-circuits it ahead of any CR 616.1
-        // prompt. A CR 616.1 ordering choice instead returns `NeedsChoice`
-        // below, parks, and is settled as PAID by
+        // prompt. Its `AddCounter` replacement choice — a single optional
+        // candidate, or a CR 616.1 ordering — instead returns `NeedsChoice`,
+        // parks, and is settled as PAID by
         // `engine_payment_choices::resume_counter_addition_unless_payment`
-        // (CR 118.12). Same partition as the `EffectCost`/`PutCounter` arm
-        // above, whose header records the CR 614.17b seam deviation once.
+        // (CR 118.12). Same partition as the `EffectCost`/`PutCounter` cost
+        // arm. `resolution_cost_includes_impossible_event` refuses the CHOICE
+        // at every site that consumes it, so this refusal is defense in depth
+        // for the CR 614.17a mid-window case rather than the only gate.
         AbilityCost::GetPlayerCounters {
             counter_kind,
             count,
@@ -1811,10 +1805,10 @@ fn pay_ability_cost_inner(
     Ok(PaymentOutcome::Paid)
 }
 
-/// CR 118.3 + CR 601.2h: The single affordability authority. Returns whether
+/// CR 118.3 + CR 601.2h: The single payability authority. Returns whether
 /// `payer` could pay `cost` right now in the active [`PaymentScope`].
 ///
-/// Activation scope reproduces the A2 aggregate (relocated from
+/// Activation scope reproduces the aggregate (relocated from
 /// `casting::can_pay_ability_cost_now`): the [`AbilityCost::is_payable`]
 /// choice-eligibility/resource gate plus a clone-and-dry-run of
 /// `pay_ability_cost_inner`, which is the affordability oracle for every
@@ -1829,10 +1823,11 @@ fn pay_ability_cost_inner(
 /// Composite containing a Waterbend leg, so gating on the class would wrongly
 /// suppress the dry run that checks the `{T}` leg's tapped-source state.
 ///
-/// Resolution scope answers CR 118.12 affordability: a resource/eligibility
-/// match per `AbilityCost` (relocated from the deleted
-/// `effects::pay::can_pay_resolution_ability_cost`, A3). It is exhaustive with
-/// no wildcard so a new `AbilityCost` variant forces a deliberate decision.
+/// Resolution scope answers CR 118.12 payability per `AbilityCost` (relocated
+/// from the deleted `effects::pay::can_pay_resolution_ability_cost`): a resource
+/// match, plus — for the two counter-placement arms — CR 614.17b event
+/// possibility. It is exhaustive with no wildcard so a new `AbilityCost` variant
+/// forces a deliberate decision.
 pub(crate) fn can_pay(
     state: &GameState,
     payer: PlayerId,
@@ -1982,10 +1977,167 @@ pub(crate) fn supported_at_resolution(cost: &AbilityCost) -> bool {
     }
 }
 
-/// CR 118.3 + CR 118.12: Resolution-time affordability (relocated A3). A player
-/// can't pay a cost without the resources to pay it fully; used as the
-/// `Composite` pre-flight so the resolver never commits a sub-cost before
-/// discovering a later sub-cost is unpayable. Exhaustive over `AbilityCost`.
+/// CR 614.17b: would a mandatory can't-effect stop this player-counter gain?
+fn player_counter_gain_is_prohibited(
+    state: &GameState,
+    payer: PlayerId,
+    counter_kind: crate::types::player::PlayerCounterKind,
+    count: u32,
+) -> bool {
+    super::effects::player_counter::preview_player_counter_addition(
+        state,
+        payer,
+        payer,
+        counter_kind,
+        count,
+    )
+    .is_prohibited()
+}
+
+/// CR 614.17b: object-counter sibling, for the `EffectCost`/`PutCounter{SelfRef}` shape.
+fn self_counter_placement_is_prohibited(
+    state: &GameState,
+    payer: PlayerId,
+    source_id: ObjectId,
+    counter_type: crate::types::counter::CounterType,
+    count: u32,
+) -> bool {
+    state.objects.get(&source_id).is_some_and(|object| {
+        super::effects::counters::preview_counter_addition(
+            state,
+            payer,
+            ObjectIncarnationRef::from_object(object),
+            counter_type,
+            count,
+        )
+        .is_some_and(super::effects::counters::CounterAdditionPreview::is_prohibited)
+    })
+}
+
+/// CR 118.5 + CR 702.24a: how many counters a resolution-time counter cost
+/// places, from its resolved `QuantityExpr`.
+///
+/// Single authority on purpose. The choice-time predicate
+/// (`resolution_cost_includes_impossible_event`) and the payment path
+/// (`pay_ability_cost_inner`) must preview the SAME count: if they disagree, a
+/// count the predicate reads as 0 short-circuits both previews to
+/// `Applied { count: 0 }`, the pay branch is offered, and the payment then
+/// refuses it — the exact offered-then-rejected defect CR 614.17b forbids.
+fn counter_cost_count(resolved: i32) -> u32 {
+    resolved.unsigned_abs()
+}
+
+/// CR 614.17b: "If an event can't happen, a player can't choose to pay a cost
+/// that includes that event." Answers exactly that, for a resolution-time cost.
+///
+/// NOT an affordability test. CR 118.3 (resources) is answered by `can_pay`; an
+/// unaffordable cost may still legally be CHOSEN, because the unless-payment
+/// window exists so the payer can produce the resources (CR 118.2: "the player
+/// paying the cost has a chance to activate mana abilities"; CR 117.1d: mana
+/// abilities may be activated "whenever a rule or effect asks for a mana
+/// payment"). An impossible event admits no such window.
+///
+/// The verdict comes from the live replacement pipeline
+/// (`replacement::pipeline_loop`'s CR 614.17c short-circuit via
+/// `mandatory_prevention_applies`), reached through the read-only
+/// `preview_*_counter_addition` primitives — never from a per-card test.
+pub(crate) fn resolution_cost_includes_impossible_event(
+    state: &GameState,
+    payer: PlayerId,
+    cost: &AbilityCost,
+    ability: &ResolvedAbility,
+) -> bool {
+    use crate::types::ability::Effect;
+    match cost {
+        // CR 614.17b + CR 702.21a + CR 122.1: Ward's player-counter cost places the event.
+        AbilityCost::GetPlayerCounters {
+            counter_kind,
+            count,
+        } => player_counter_gain_is_prohibited(state, payer, *counter_kind, *count),
+        AbilityCost::EffectCost { effect } => match effect.as_ref() {
+            // CR 614.17b + CR 702.24a: cumulative upkeep's source-counter effect-cost shape.
+            Effect::PutCounter {
+                counter_type,
+                count,
+                target: TargetFilter::SelfRef,
+            } => {
+                let resolved = resolve_quantity_with_targets(state, count, ability);
+                self_counter_placement_is_prohibited(
+                    state,
+                    payer,
+                    ability.source_id,
+                    counter_type.clone(),
+                    counter_cost_count(resolved),
+                )
+            }
+            // CR 118.1: producing mana performs no counter placement, so nothing to prohibit.
+            Effect::Mana {
+                produced: crate::types::ability::ManaProduction::Fixed { .. },
+                ..
+            } => false,
+            // `supports_effect_cost_payment` refuses every other effect-cost shape upstream.
+            _ => false,
+        },
+        // Prohibition is the De Morgan dual of payability: `can_pay_resolution` answers
+        // `Composite` with `.all()` and `OneOf` with `.any()`; this predicate answers them
+        // with `.any()` and `.all()`. Copying one arm from the other is a rules bug in
+        // whichever direction it is copied.
+        // CR 614.17b: every component must be paid, so a cost that INCLUDES an impossible
+        // component is itself unchoosable.
+        AbilityCost::Composite { costs } => costs
+            .iter()
+            .any(|c| resolution_cost_includes_impossible_event(state, payer, c, ability)),
+        // CR 614.17b + CR 118.12a: exactly one option is paid, so the cost is unchoosable
+        // only if EVERY option includes an impossible event.
+        // Only the offending index is refused at the pick; whether the WHOLE disjunctive
+        // cost is unchoosable is this arm's question — `.all()`, not `.any()`.
+        AbilityCost::OneOf { costs } => costs
+            .iter()
+            .all(|c| resolution_cost_includes_impossible_event(state, payer, c, ability)),
+        // CR 702.24a: `expand_per_counter` resolves this into a concrete cost before the
+        // predicate is consulted.
+        AbilityCost::PerCounter { .. } => false,
+        // No counter-placement event is performed while paying any remaining variant.
+        AbilityCost::Mana { .. }
+        | AbilityCost::ManaDynamic { .. }
+        | AbilityCost::Tap
+        | AbilityCost::Untap
+        | AbilityCost::Loyalty { .. }
+        | AbilityCost::Sacrifice(_)
+        | AbilityCost::PayLife { .. }
+        | AbilityCost::Discard { .. }
+        | AbilityCost::Exile { .. }
+        | AbilityCost::ExileMaterials { .. }
+        | AbilityCost::CollectEvidence { .. }
+        | AbilityCost::ExileWithAggregate { .. }
+        | AbilityCost::TapCreatures { .. }
+        | AbilityCost::RemoveCounter { .. }
+        | AbilityCost::PayEnergy { .. }
+        | AbilityCost::PaySpeed { .. }
+        | AbilityCost::ReturnToHand { .. }
+        | AbilityCost::Unattach
+        | AbilityCost::UnattachFrom { .. }
+        | AbilityCost::Mill { .. }
+        | AbilityCost::Exert
+        | AbilityCost::Blight { .. }
+        | AbilityCost::Reveal { .. }
+        | AbilityCost::Behold { .. }
+        | AbilityCost::Waterbend { .. }
+        | AbilityCost::NinjutsuFamily { .. }
+        | AbilityCost::KeywordCostOfCastSpell { .. }
+        | AbilityCost::Unimplemented { .. } => false,
+    }
+}
+
+/// CR 118.3 + CR 118.12: resolution-time payability. A player can't pay a cost
+/// without the resources to pay it fully; used as the `Composite` pre-flight so
+/// the resolver never commits a sub-cost before discovering a later sub-cost is
+/// unpayable. Exhaustive over `AbilityCost`.
+///
+/// CR 614.17b: the counter-placement arms additionally refuse a cost whose
+/// payment includes an event a mandatory can't-effect forbids — impossibility,
+/// not affordability. `resolution_cost_includes_impossible_event` owns that
+/// question; this function only folds its answer into those two leaves.
 fn can_pay_resolution(
     state: &GameState,
     payer: PlayerId,
@@ -2106,14 +2258,23 @@ fn can_pay_resolution(
         AbilityCost::OneOf { costs } => costs
             .iter()
             .any(|cost| can_pay_resolution(state, payer, cost, ability)),
-        // CR 702.21a + CR 122.1: Always payable — no resource/eligibility
-        // limit on giving yourself more counters (poison's ten-or-more loss
-        // condition is a separate SBA, not a payment-time affordability gate).
-        AbilityCost::GetPlayerCounters { .. } => true,
-        // CR 118.3: Every deterministic effect-cost payment admitted by the
-        // shared support predicate is offerable; its resolver handles any
+        // CR 118.3 + CR 104.3d: no RESOURCE limit on giving yourself counters — the
+        // ten-or-more poison loss condition is a state-based action, not a
+        // payment-time affordability gate.
+        // CR 614.17b: the one bar is a mandatory can't-effect on the counter
+        // placement, which `resolution_cost_includes_impossible_event` answers.
+        AbilityCost::GetPlayerCounters {
+            counter_kind,
+            count,
+        } => !player_counter_gain_is_prohibited(state, payer, *counter_kind, *count),
+        // CR 118.3: every deterministic effect-cost payment admitted by the shared
+        // support predicate has the resources to be paid; its resolver handles any
         // replacement effects while paying it.
-        AbilityCost::EffectCost { .. } if cost.supports_effect_cost_payment() => true,
+        // CR 614.17b: it is offerable only if paying it does not require an event a
+        // mandatory can't-effect forbids.
+        AbilityCost::EffectCost { .. } if cost.supports_effect_cost_payment() => {
+            !resolution_cost_includes_impossible_event(state, payer, cost, ability)
+        }
         // Variants below have no resolution-time payment arm
         // (`supported_at_resolution` is the shared membership authority).
         // Refusing here is the conservative affordability answer (treat as
@@ -3213,6 +3374,170 @@ mod tests {
         assert!(
             !scenario.state.objects.get(&src).unwrap().tapped,
             "Tap at Resolution must not tap the source"
+        );
+    }
+
+    /// Installs a synthetic MANDATORY `Prevent`-on-`AddCounter` replacement
+    /// scoped `AnyPlayer` on a fresh P0 permanent — the unit-side sibling of
+    /// `serpent_society_ward_poison_cost.rs`'s installers. No printed card
+    /// produces an OPTIONAL `AddCounter` replacement, and CR 614.17c
+    /// short-circuits every MANDATORY one ahead of the CR 616.1 prompt.
+    fn install_any_player_counter_prohibition(scenario: &mut GameScenario) {
+        let source = scenario.add_creature(P0, "Poison Warden", 1, 1).id();
+        let mut def = crate::types::ability::ReplacementDefinition::new(
+            crate::types::replacements::ReplacementEvent::AddCounter,
+        );
+        def.mode = crate::types::ability::ReplacementMode::Mandatory;
+        def.quantity_modification = Some(crate::types::ability::QuantityModification::Prevent);
+        def.valid_player = Some(crate::types::ability::ReplacementPlayerScope::AnyPlayer);
+        let reps = vec![def];
+        let obj = scenario.state.objects.get_mut(&source).unwrap();
+        obj.replacement_definitions = reps.clone().into();
+        obj.base_replacement_definitions = std::sync::Arc::new(reps);
+    }
+
+    /// CR 614.17b: the aggregate arms of
+    /// `resolution_cost_includes_impossible_event`, pinned from both sides.
+    ///
+    /// `Composite` is `.any()` — CR 614.17b's "a cost that INCLUDES that event"
+    /// — and `OneOf` is `.all()`, because CR 118.12a pays exactly one option, so
+    /// a disjunctive cost is unchoosable only when EVERY option is. The two are
+    /// the De Morgan dual of `can_pay_resolution`'s `.all()` / `.any()`.
+    ///
+    /// Affordability is held CONSTANT across the pair: every leg is affordable
+    /// at life 20, and the row asserts the life totals so that stays true.
+    ///
+    /// Revert probe: writing the `OneOf` arm as `.any()` makes `mixed_oneof`
+    /// answer `true` and fails assertion (iii) on the same board that keeps
+    /// `counter_composite` answering `true`.
+    #[test]
+    fn resolution_cost_prohibition_covers_composite_and_disjunctive_shapes() {
+        use crate::types::player::PlayerCounterKind;
+
+        let poison5 = AbilityCost::GetPlayerCounters {
+            counter_kind: PlayerCounterKind::Poison,
+            count: 5,
+        };
+        let poison3 = AbilityCost::GetPlayerCounters {
+            counter_kind: PlayerCounterKind::Poison,
+            count: 3,
+        };
+        let pay_life_1 = AbilityCost::PayLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+        };
+        let counter_composite = AbilityCost::Composite {
+            costs: vec![poison5.clone(), pay_life_1.clone()],
+        };
+        let control_composite = AbilityCost::Composite {
+            costs: vec![pay_life_1.clone(), pay_life_1.clone()],
+        };
+        let mixed_oneof = AbilityCost::OneOf {
+            costs: vec![poison5.clone(), pay_life_1.clone()],
+        };
+        let all_impossible_oneof = AbilityCost::OneOf {
+            costs: vec![poison5, poison3],
+        };
+
+        let mut scenario = GameScenario::new();
+        let src = scenario.add_creature(P0, "Source", 1, 1).id();
+        let ability = ResolvedAbility::new(
+            Effect::PutCounter {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::SelfRef,
+            },
+            Vec::new(),
+            src,
+            P0,
+        );
+        let scope = PaymentScope::Resolution {
+            ability: &ability,
+            cost_move_root: ResolutionCostMoveRoot::EffectPayCost,
+        };
+
+        // (v) + (vi) CLEAN board: the instrument fires only on the prohibition,
+        // and every leg is affordable at life 20.
+        assert_eq!(
+            scenario.state.players[P0.0 as usize].life, 20,
+            "affordability is held constant across the pair"
+        );
+        for (name, cost) in [
+            ("counter_composite", &counter_composite),
+            ("control_composite", &control_composite),
+            ("mixed_oneof", &mixed_oneof),
+            ("all_impossible_oneof", &all_impossible_oneof),
+        ] {
+            assert!(
+                !resolution_cost_includes_impossible_event(&scenario.state, P0, cost, &ability),
+                "{name} must not be prohibited on a clean board"
+            );
+            assert!(
+                can_pay(&scenario.state, P0, src, cost, &scope),
+                "{name} must be payable on a clean board"
+            );
+        }
+
+        install_any_player_counter_prohibition(&mut scenario);
+        assert_eq!(
+            scenario.state.players[P0.0 as usize].life, 20,
+            "installing the prohibition must not change affordability"
+        );
+
+        // (i) `Composite` INCLUDES an impossible component ⇒ prohibited.
+        assert!(
+            resolution_cost_includes_impossible_event(
+                &scenario.state,
+                P0,
+                &counter_composite,
+                &ability
+            ),
+            "a Composite including a prohibited counter gain must be prohibited"
+        );
+        // Control cost: same board, same prohibition, same affordability.
+        assert!(
+            !resolution_cost_includes_impossible_event(
+                &scenario.state,
+                P0,
+                &control_composite,
+                &ability
+            ),
+            "a Composite with no counter component must not be prohibited"
+        );
+
+        // (ii) Step 3c's fold: the payability oracle follows the leaves.
+        assert!(
+            !can_pay(&scenario.state, P0, src, &counter_composite, &scope),
+            "can_pay must refuse a Composite whose payment includes an impossible event"
+        );
+        assert!(
+            can_pay(&scenario.state, P0, src, &control_composite, &scope),
+            "can_pay must still accept the control Composite"
+        );
+
+        // (iii) The `.any()`-leak guard: one payable option keeps the whole
+        // disjunctive cost choosable (CR 118.12a).
+        assert!(
+            !resolution_cost_includes_impossible_event(&scenario.state, P0, &mixed_oneof, &ability),
+            "a OneOf with one payable option must not be prohibited"
+        );
+        assert!(
+            can_pay(&scenario.state, P0, src, &mixed_oneof, &scope),
+            "a OneOf with one payable option must stay payable"
+        );
+
+        // (iv) Its paired opposite: every option impossible ⇒ prohibited.
+        assert!(
+            resolution_cost_includes_impossible_event(
+                &scenario.state,
+                P0,
+                &all_impossible_oneof,
+                &ability
+            ),
+            "a OneOf whose every option is impossible must be prohibited"
+        );
+        assert!(
+            !can_pay(&scenario.state, P0, src, &all_impossible_oneof, &scope),
+            "a OneOf whose every option is impossible must not be payable"
         );
     }
 }

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -1318,10 +1318,14 @@ fn pay_ability_cost_inner(
         AbilityCost::ExileMaterials { .. } => {}
         // Waterbend cost was already paid via ManaPayment before reaching pay_ability_cost.
         AbilityCost::Waterbend { .. } => {}
-        // CR 118.3: An effect performed as a cost. Resolve the effect on the
-        // source before the ability's own effect fires. The shared support
-        // predicate admits only deterministic source-counter and fixed-mana
-        // forms, so this never opens a player-choice prompt mid-payment.
+        // CR 118.1: An effect performed as a cost — "a cost is an action or
+        // payment necessary to take another action … to pay a cost, a player
+        // carries out the instructions specified". (NOT CR 118.3, which is the
+        // resources rule and says nothing about an effect-as-cost.) Resolve the
+        // effect on the source before the ability's own effect fires. The shared
+        // support predicate admits only deterministic source-counter and
+        // fixed-mana forms, so this never opens a player-choice prompt
+        // mid-payment.
         AbilityCost::EffectCost { effect } => {
             use crate::types::ability::Effect;
             match effect.as_ref() {
@@ -1331,11 +1335,35 @@ fn pay_ability_cost_inner(
                     target: TargetFilter::SelfRef,
                 } => {
                     let count = resolve_cost_quantity(state, count, player, source_id, scope);
-                    // CR 118.3: A prevented counter placement pays none of this
-                    // cost. The shared add primitive reports both a delivered
-                    // and prevented event as complete because effect resolution
+                    // CR 614.17b: "If an event can't happen, a player can't
+                    // choose to pay a cost that includes that event" — a
+                    // prevented counter placement pays none of this cost. The
+                    // shared add primitive reports both a delivered and
+                    // prevented event as complete because effect resolution
                     // needs that distinction only for continuation; payment must
                     // reject the prevented case before executing it.
+                    //
+                    // Only a MANDATORY can't-effect can reach this refusal.
+                    // CR 614.17c ("if an event can't happen, it can only be
+                    // replaced by a self-replacement effect … other replacement
+                    // and/or prevention effects can't modify or replace it") is
+                    // implemented by `replacement::pipeline_loop`'s
+                    // short-circuit, which fires ahead of any CR 616.1 ordering
+                    // prompt. An ordering choice instead returns
+                    // `CounterAdditionPreview::ChoiceRequired`, falls through,
+                    // parks, and is settled as PAID by
+                    // `engine_payment_choices::resume_counter_addition_unless_payment`
+                    // (CR 118.12). The two legs partition the space; they do not
+                    // disagree.
+                    //
+                    // Known deviation, recorded not fixed: CR 614.17b's subject
+                    // is the CHOICE ("a player can't choose to pay"), while this
+                    // engine enforces it at the payment event — `PayUnlessCost
+                    // { pay: true }` stays legal and fails here. The
+                    // rules-correct seam is the CR 119.8 analogue
+                    // (`static_abilities::player_cant_pay_life_as_cost` /
+                    // `PayLifeCostResult::Prohibited`): refuse the choice, not
+                    // the settle. Same observable, wrong seam.
                     let prevented = state.objects.get(&source_id).is_some_and(|object| {
                         matches!(
                             super::effects::counters::preview_counter_addition(
@@ -1468,6 +1496,18 @@ fn pay_ability_cost_inner(
         // resolved), a cost that silently gives zero counters must not be
         // mistaken for having actually been paid, or Ward's deterrent is
         // bypassed for free.
+        //
+        // CR 614.17b is the rule ("if an event can't happen, a player can't
+        // choose to pay a cost that includes that event"), and CR 614.17c is why
+        // only a MANDATORY can't-effect can reach it: an impossible event "can
+        // only be replaced by a self-replacement effect … other replacement
+        // and/or prevention effects can't modify or replace it", so
+        // `replacement::pipeline_loop` short-circuits it ahead of any CR 616.1
+        // prompt. A CR 616.1 ordering choice instead returns `NeedsChoice`
+        // below, parks, and is settled as PAID by
+        // `engine_payment_choices::resume_counter_addition_unless_payment`
+        // (CR 118.12). Same partition as the `EffectCost`/`PutCounter` arm
+        // above, whose header records the CR 614.17b seam deviation once.
         AbilityCost::GetPlayerCounters {
             counter_kind,
             count,

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -2020,6 +2020,24 @@ fn self_counter_placement_is_prohibited(
 /// CR 118.5 + CR 702.24a: how many counters a resolution-time counter cost
 /// places, from its resolved `QuantityExpr`.
 ///
+/// CR 107.1b: "If a calculation that would determine the result of an effect
+/// yields a negative number, zero is used instead, unless that effect doubles,
+/// triples, or sets to a specific value a player's life total or the power
+/// and/or toughness of a creature or creature card." A counter count is in
+/// none of those exception classes, so a negative resolved quantity places
+/// ZERO counters — never its magnitude, which would turn a cost that performs
+/// no event into one that places counters the rules never asked for.
+///
+/// The resolver really can hand this function a negative value: `fold_compose`
+/// evaluates `QuantityExpr::Offset` as an unfloored `inner + offset` and
+/// `QuantityExpr::Multiply` with a signed factor, so any cost quantity whose
+/// dynamic inner falls below its offset arrives here negative. `ClampMin` is
+/// the *expression-level* opt-in to the same rule; a cost consumer cannot
+/// assume its quantity was built with one.
+///
+/// `.max(0)` is the clamp every other resolved-quantity consumer in this file
+/// uses (`Discard`, `PayLife`, `PayEnergy`, the dynamic generic mana cost).
+///
 /// Single authority on purpose. The choice-time predicate
 /// (`resolution_cost_includes_impossible_event`) and the payment path
 /// (`pay_ability_cost_inner`) must preview the SAME count: if they disagree, a
@@ -2027,7 +2045,7 @@ fn self_counter_placement_is_prohibited(
 /// `Applied { count: 0 }`, the pay branch is offered, and the payment then
 /// refuses it — the exact offered-then-rejected defect CR 614.17b forbids.
 fn counter_cost_count(resolved: i32) -> u32 {
-    resolved.unsigned_abs()
+    u32::try_from(resolved.max(0)).unwrap_or(0)
 }
 
 /// CR 614.17b: "If an event can't happen, a player can't choose to pay a cost
@@ -2079,9 +2097,14 @@ pub(crate) fn resolution_cost_includes_impossible_event(
                 ..
             } => false,
             // `supports_effect_cost_payment` refuses every other effect-cost shape upstream.
-            // CR 614.17b: widening that predicate to admit a further counter-placing shape owes a
-            // matching arm here in the same change, or the new shape answers "no impossible event"
-            // and silently loses this refusal.
+            // CR 614.17b: this arm swallows ANY widening of that predicate, not just a further
+            // counter-placing one, so admitting any new effect-cost shape owes a matching arm
+            // here in the same change — otherwise the new shape answers "no impossible event"
+            // and silently loses this refusal. An `EffectCost { LoseLife }` shape is the nearest
+            // example: CR 119.8 ("a cost that involves having that player pay life can't be
+            // paid") is the direct analogue, and nothing else catches it, because
+            // `can_pay_resolution` reaches that refusal only through `can_pay_life_cost` from its
+            // `AbilityCost::PayLife` arm, which an effect-cost never matches.
             _ => false,
         },
         // Prohibition is the De Morgan dual of payability: `can_pay_resolution` answers

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -3546,4 +3546,69 @@ mod tests {
             "a OneOf whose every option is impossible must not be payable"
         );
     }
+
+    /// CR 614.17b: "If an event can't happen, a player can't choose to pay a
+    /// cost that includes that event" — at `PaymentScope::Activation`.
+    ///
+    /// Wall of Roots' mana ability costs `EffectCost { PutCounter { SelfRef } }`;
+    /// Solemnity's second sentence is a CR 614.17 can't-effect on exactly that
+    /// placement. Activation never consults
+    /// `resolution_cost_includes_impossible_event` and
+    /// `is_payable_for_activation` admits every `EffectCost` unconditionally, so
+    /// the refusal inside the payment arm is the only answer available here.
+    ///
+    /// Revert probe: rewriting that arm's `let prevented =
+    /// self_counter_placement_is_prohibited(…)` as `let prevented = false` makes
+    /// the payer answer `Paid` on a board where the counter is prevented, failing
+    /// (ii) and (iii).
+    #[test]
+    fn activation_self_counter_cost_under_solemnity_is_refused() {
+        let mut scenario = GameScenario::new();
+        let wall = scenario.add_creature(P0, "Wall of Roots", 0, 5).id();
+        let cost = AbilityCost::EffectCost {
+            effect: Box::new(Effect::PutCounter {
+                counter_type: CounterType::PowerToughness {
+                    power: 0,
+                    toughness: -1,
+                },
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::SelfRef,
+            }),
+        };
+
+        // (i) Reach guard: the same cost on the same board is payable before the
+        // prohibition exists, so (ii) and (iii) cannot pass upstream of the arm.
+        assert!(
+            can_pay_activation(&scenario.state, wall, &cost),
+            "an unprohibited self-counter activation cost must be payable"
+        );
+
+        scenario.add_enchantment_from_oracle(
+            P0,
+            "Solemnity",
+            "Players can't get counters.\n\
+             Counters can't be put on artifacts, creatures, enchantments, or lands.",
+        );
+
+        // (ii) The ability is no longer activatable.
+        assert!(
+            !can_pay_activation(&scenario.state, wall, &cost),
+            "a prevented counter placement must make the activation cost unpayable"
+        );
+
+        // (iii) CR 601.2h: the payer refuses rather than reporting a cost whose
+        // event the replacement swallowed.
+        let refused = pay_ability_cost_for_activation(
+            &mut scenario.state,
+            P0,
+            wall,
+            &cost,
+            Some(0),
+            &mut Vec::new(),
+        );
+        assert!(
+            matches!(refused, Err(EngineError::ActionNotAllowed(_))),
+            "a prevented counter-placement cost must refuse activation, got {refused:?}"
+        );
+    }
 }

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -120,6 +120,17 @@ pub enum CounterAdditionPreview {
     Unsupported,
 }
 
+impl CounterAdditionPreview {
+    /// CR 614.17b: object-counter sibling of
+    /// `PlayerCounterAdditionPreview::is_prohibited`, which owns the partition's
+    /// prose. `ChoiceRequired` here means what this enum's own variant doc already
+    /// says — "Replacement ordering or an optional replacement needs this player's
+    /// choice" — and is deliberately NOT a prohibition.
+    pub fn is_prohibited(self) -> bool {
+        matches!(self, CounterAdditionPreview::Prevented)
+    }
+}
+
 /// Preview an object-counter addition through the real replacement pipeline.
 ///
 /// Returns `None` when `target` no longer identifies the same object

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -11323,7 +11323,7 @@ fn resolve_chain_body(
         // rest ride along in `WaitingFor::UnlessPayment.remaining`.
         let unless_payers =
             resolve_unless_payers(state, ability_for_unless.as_ref(), &unless_pay.payer);
-        if let Some((&payer, remaining_payers)) = unless_payers.split_first() {
+        if !unless_payers.is_empty() {
             // CR 118.4 + CR 107.3c: Resolve a dynamic-generic mana cost into a
             // fixed `Mana { cost }` BEFORE entering the prompt — the runtime
             // payment site only handles static AbilityCost variants.
@@ -11428,7 +11428,29 @@ fn resolve_chain_body(
                 }
                 // Non-counter unless-modified effects: pre-fold behavior was
                 // to fall through and execute the effect.
-            } else {
+                // CR 614.17b: "If an event can't happen, a player can't choose to pay a cost
+                // that includes that event." The CR 118.12a poll's HEAD is the first payer for
+                // whom paying this cost does NOT require an impossible event; when nobody
+                // qualifies, control falls out of this chain and the unless-effect resolves,
+                // exactly as the CR 118.6 unpayable-cost branch in this same chain already does.
+                //
+                // CR 614.17a: only the HEAD is filtered. `remaining` receives the untouched
+                // POSITIONAL tail from the head onward, never a re-derived list, so a
+                // prohibition that lifts mid-window cannot have silently removed a LATER payer
+                // from the poll — `finish_unless_payment` re-asks the question live at each
+                // re-emit. (Payers ahead of the head were asked and could not choose to pay.)
+            } else if let Some((&payer, remaining_payers)) = unless_payers
+                .iter()
+                .position(|p| {
+                    !crate::game::costs::resolution_cost_includes_impossible_event(
+                        state,
+                        *p,
+                        &resolved_cost,
+                        ability,
+                    )
+                })
+                .and_then(|head| unless_payers[head..].split_first())
+            {
                 let mut pending = ability.clone();
                 pending.unless_pay = None;
                 // CR 118.12a: A disjunctive unless-cost (`OneOf`) surfaces a

--- a/crates/engine/src/game/effects/pay.rs
+++ b/crates/engine/src/game/effects/pay.rs
@@ -274,19 +274,23 @@ pub(crate) fn scale_mana_cost(base: &ManaCost, times: u32) -> ManaCost {
 /// authority (`game::costs`). The duplicate
 /// Mana/ManaDynamic/PayLife/PayEnergy/Composite/Discard payment arms that used
 /// to live here were folded into `costs::pay_ability_cost_for_resolution`
-/// (cost-payment unification, Phase 2); the resolution-time affordability match
-/// that used to live here (`can_pay_resolution_ability_cost`, A3) was folded
-/// into `costs::can_pay` with `PaymentScope::Resolution` (Phase 5).
+/// (cost-payment unification); the resolution-time payability match
+/// that used to live here (`can_pay_resolution_ability_cost`) was folded
+/// into `costs::can_pay` with `PaymentScope::Resolution`.
 ///
 /// CR 601.2h: only the multi-cost `Composite` shape is pre-gated through the
-/// affordability authority — it is the one with cross-sub-cost atomicity
+/// payability authority — it is the one with cross-sub-cost atomicity
 /// ("partial payments are not allowed"), so a `Composite` must never commit one
 /// sub-cost before discovering a later sub-cost is unpayable. A *singleton* cost
 /// needs no pre-gate: the authority's own internal pre-flight + `Failed` mapping
 /// is exactly equivalent, and pre-gating it would re-run the board-scale auto-tap
-/// planner and re-resolve the `QuantityExpr` a second time (Phase 4 deferred
+/// planner and re-resolve the `QuantityExpr` a second time (a deferred
 /// perf fix). The authority's outcome maps to the resolution-scope failure
 /// channel (`cost_payment_failed_flag`).
+///
+/// CR 614.17b: after the counter-placement fold, this pre-gate can also refuse a
+/// `Composite` whose payment would include an event a mandatory can't-effect
+/// forbids, not only one the payer cannot afford.
 fn resolve_ability_cost_payment(
     state: &mut GameState,
     ability: &ResolvedAbility,
@@ -309,7 +313,7 @@ fn resolve_ability_cost_payment(
         state.cost_payment_failed_flag = true;
         return Ok(PaymentOutcome::Failed {
             reason: PaymentFailure {
-                reason: "resolution-time cost not affordable (pre-gate)".to_string(),
+                reason: "resolution-time cost not payable (pre-gate)".to_string(),
             },
         });
     }

--- a/crates/engine/src/game/effects/player_counter.rs
+++ b/crates/engine/src/game/effects/player_counter.rs
@@ -110,6 +110,26 @@ pub enum PlayerCounterAdditionPreview {
     Unsupported,
 }
 
+impl PlayerCounterAdditionPreview {
+    /// CR 614.17b + CR 614.17: `true` only for an actual can't-effect — a
+    /// MANDATORY `QuantityModification::Prevent` on the governing
+    /// `ReplacementEvent::AddCounter`, which `replacement::pipeline_loop`
+    /// short-circuits per CR 614.17c ahead of any replacement choice.
+    /// A player can't CHOOSE to pay a cost that includes such an event.
+    ///
+    /// Deliberately `false` for every other variant. `ChoiceRequired` (a single
+    /// optional candidate, or a CR 616.1 ordering), `Transformed` and
+    /// `Unsupported` are replacements that merely MODIFY an otherwise chosen
+    /// payment (CR 118.11: "the cost has still been paid"), so they stay
+    /// payable, park, and settle PAID via
+    /// `engine_payment_choices::resume_counter_addition_unless_payment`
+    /// (CR 118.12). Inside the engine this accessor is the single place
+    /// `PlayerCounterAdditionPreview`'s prohibition partition is decided.
+    pub fn is_prohibited(self) -> bool {
+        matches!(self, PlayerCounterAdditionPreview::Prevented)
+    }
+}
+
 /// Preview a player-counter addition through the real replacement pipeline,
 /// without mutating live game state.
 ///

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -6533,8 +6533,10 @@ pub(crate) fn drain_pending_cost_move_resume(
         // opponent's Solemnity would prevent the counters) must still complete the
         // parked activation instead of wedging, so `LoyaltyActivation` is eligible
         // at the Prevented boundary as well. Counter-addition unless payments
-        // are eligible here too: a prevented counter placement fails the cost
-        // (CR 118.3) and must resolve the pending unless branch, not wedge.
+        // are eligible here too: whether a prevented placement leaves that
+        // payment paid or failed is `resume_counter_addition_unless_payment`'s
+        // call, argued in its own header; either way the pending unless branch
+        // must resolve here, not wedge.
         CostMoveDrainBoundary::ReplacementPrevented { .. } => matches!(
             state.pending_cost_move_resume,
             Some(
@@ -6626,11 +6628,7 @@ pub(crate) fn drain_pending_cost_move_resume(
         state.pending_cost_move_resume,
         Some(PendingCostMoveResume::CounterAdditionUnlessPayment { .. })
     ) {
-        engine_payment_choices::resume_counter_addition_unless_payment(
-            state,
-            events,
-            matches!(boundary, CostMoveDrainBoundary::ReplacementDelivered { .. }),
-        )?
+        engine_payment_choices::resume_counter_addition_unless_payment(state, events, boundary)?
     } else if matches!(
         state.pending_cost_move_resume,
         Some(PendingCostMoveResume::RandomDiscardUnlessPayment(..))
@@ -21448,5 +21446,68 @@ mod resolving_carrier_settle_tests {
                 "{described}"
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod cost_move_drain_priority_boundary_tests {
+    use super::{drain_pending_cost_move_resume, CostMoveDrainBoundary};
+    use crate::types::ability::{AbilityCost, Effect, ResolvedAbility, TargetFilter};
+    use crate::types::game_state::{GameState, PendingCostMoveResume};
+    use crate::types::identifiers::ObjectId;
+    use crate::types::mana::ManaCost;
+    use crate::types::player::PlayerId;
+
+    /// `engine_payment_choices::resume_counter_addition_unless_payment` maps
+    /// `CostMoveDrainBoundary::PriorityBoundary` to `unreachable!`, and nothing but
+    /// this eligibility table makes that true: it admits only `DelveManaPayment` and
+    /// `ManaAbilityPayment` at that boundary. Nothing else in the crate pinned that
+    /// premise, so widening the table would leave the suite green and abort a live
+    /// session instead.
+    ///
+    /// This pins the guard, not the panic. A `#[should_panic]` row would assert the
+    /// panic is *reachable*, which is the inverse of the invariant. Admitting
+    /// `CounterAdditionUnlessPayment` at `PriorityBoundary` turns this row red: the
+    /// root takes the parked continuation and panics before it can return `Ok(None)`.
+    #[test]
+    fn a_parked_counter_addition_unless_payment_is_never_drained_at_the_priority_boundary() {
+        let mut state = GameState::new_two_player(42);
+        state.pending_cost_move_resume =
+            Some(PendingCostMoveResume::CounterAdditionUnlessPayment {
+                cost: AbilityCost::Mana {
+                    cost: ManaCost::generic(2),
+                },
+                pending_effect: Box::new(ResolvedAbility::new(
+                    Effect::TargetOnly {
+                        target: TargetFilter::Any,
+                    },
+                    vec![],
+                    ObjectId(60),
+                    PlayerId(0),
+                )),
+                trigger_event: None,
+                effect_description: None,
+                remaining: Vec::new(),
+            });
+        let mut events = Vec::new();
+
+        let drained = drain_pending_cost_move_resume(
+            &mut state,
+            &mut events,
+            CostMoveDrainBoundary::PriorityBoundary,
+        );
+
+        assert!(
+            matches!(drained, Ok(None)),
+            "the priority boundary must not drain a counter-addition unless-payment"
+        );
+        assert!(
+            matches!(
+                state.pending_cost_move_resume,
+                Some(PendingCostMoveResume::CounterAdditionUnlessPayment { .. })
+            ),
+            "the continuation must stay parked for the replacement boundary that owns it"
+        );
+        assert!(events.is_empty(), "an ineligible drain must emit no events");
     }
 }

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -2065,69 +2065,95 @@ pub(super) fn resume_ward_sacrifice_payment(
     }
 }
 
-/// CR 118.12 + CR 122.1 + CR 614.1 + CR 616.1: Resume a counter-addition
-/// unless-payment after its `AddCounter` replacement choice settled. The typed
-/// `CostMoveDrainBoundary` the replacement pipeline resolved to IS the payment
-/// verdict, matched exhaustively here rather than collapsed to a flag at the
-/// dispatcher: `ReplacementDelivered` = the counters were actually added = paid;
-/// `ReplacementPrevented` = a replacement completely replaced the placement
-/// (CR 614.1) = failed. That `Prevented → Failed` arm is the engine's established
-/// internal contract, not a CR derivation: it mirrors the
-/// `PlayerCounterAdditionOutcome` Applied/Prevented ↔ Paid/Failed match in
-/// `costs::pay_ability_cost_for_resolution`, which is the immediate (unpaused)
-/// leg of this same payment — the two legs must agree. Recorded, not settled:
-/// CR 118.11 ("the actions performed when paying a cost may be modified by
-/// effects … the cost has still been paid") points the other way for the
-/// prevented arm, and reconciling it is a behavior change across both legs, not
-/// a resume-site fix.
-/// `PriorityBoundary` is unreachable: `drain_pending_cost_move_resume` admits only
+/// CR 118.12a + CR 702.21a + CR 702.24a: Resume a counter-addition unless-payment
+/// after the CR 616.1 replacement choice that paused it mid-cost settled. Two cost
+/// authorities park here, and a reader who thinks this is Ward-only will mis-scope
+/// the next change: `AbilityCost::GetPlayerCounters` (Ward's player-counter
+/// payment, CR 702.21a) and the source-counter / fixed-mana `AbilityCost::
+/// EffectCost` used by cumulative upkeep (CR 702.24a). Both are CR 118.12a
+/// "[do something] unless [a player does something else]" grammar.
+///
+/// CR 118.12: BOTH replacement outcomes settle the payment PAID. The "if they
+/// do / don't" clause "checks whether the player chose to pay an optional cost or
+/// started to pay a mandatory cost, **regardless of what events actually
+/// occurred**", and that choice was latched at `PayUnlessCost { pay: true }`
+/// before the replacement pipeline was ever consulted — indeed the parked record
+/// this function consumes is constructed ONLY on the `pay = true` path, so its
+/// mere existence IS the record of the choice. CR 118.11 corroborates: "the
+/// actions performed when paying a cost may be modified by effects … the cost has
+/// still been paid." CR 118.12 is stated first deliberately: it is the leg that
+/// closes the "but nothing was actually performed" objection which CR 118.11
+/// alone leaves open.
+///
+/// CR 614.17c is why the prevented arm here is always a genuine CR 614.1
+/// replacement and never a can't-effect: an event that can't happen "can only be
+/// replaced by a self-replacement effect (see rule 614.15). Other replacement
+/// and/or prevention effects can't modify or replace it." `replacement::
+/// pipeline_loop` implements that literally — a MANDATORY prohibition
+/// (`mandatory_prevention_applies`, which ends `&& !replacement_mode_is_optional`)
+/// short-circuits to `Prevented` at the top of every loop iteration, ahead of any
+/// CR 616.1 prompt, so it never parks and never reaches this root. Scope it
+/// honestly: that short-circuit is gated on `is_counter_placement_event`, i.e. it
+/// covers the COUNTER sub-shape only (`AddCounter` and `MoveCounter{Add}`). The
+/// two legs therefore agree rather than conflict — `costs.rs` sees only
+/// can't-effects (CR 614.17b ⇒ unpaid) and this root sees only replacements
+/// (CR 118.12 ⇒ paid).
+///
+/// The mana sub-shape of `EffectCost` needs its own, structural reason and is NOT
+/// covered by CR 614.17c: `Effect::Mana { produced: Fixed }` cannot park at all,
+/// because `costs.rs`'s arm calls
+/// `mana_payment::produce_mana_with_attributes_from_source_quality`, which returns
+/// mana units rather than a `PaymentOutcome` and swallows `NeedsChoice` in its
+/// `_ =>` fallback.
+///
+/// The exhaustive `match` on `CostMoveDrainBoundary` is kept as an ELIGIBILITY
+/// ASSERTION, not a verdict producer. It holds `PriorityBoundary` at
+/// `unreachable!` — `drain_pending_cost_move_resume` admits only
 /// `DelveManaPayment`/`ManaAbilityPayment` at that boundary and dispatches both
-/// ahead of this root. Interpreting the boundary here rather than at the call site
-/// is deliberate — the sibling `resume_random_discard_unless_payment` maps the very
-/// same boundaries differently (it ignores them, per CR 118.12), so each root must
-/// own its own mapping.
-/// Delegates to the same `finish_unless_payment` tail every other unless-cost shape
-/// uses, so the guarded ability is settled exactly once, either way, instead of the
-/// game resetting to bare priority with its fate undetermined.
+/// ahead of this root — and it turns any future widening of the boundary enum or
+/// of that eligibility table into a compile error at the one site whose rules
+/// reasoning would have to be re-derived.
+///
+/// Interpreting the boundary here rather than at the dispatcher is deliberate: the
+/// sibling `resume_random_discard_unless_payment` maps the very same boundaries
+/// differently (it ignores them, per CR 118.12), and copying one root's mapping
+/// into the other is exactly what shipped the Balduvian Horde bug. Each root owns
+/// its own mapping.
+///
+/// This settles through `finish_successful_unless_payment`, NOT
+/// `finish_unless_payment`. The latter is the DECLINE tail: its work is gated on
+/// `!pay || payment_failed`, so a paid resume routed through it kept only the
+/// `set_active_priority` guard and `resume_pending_continuation_if_priority` while
+/// skipping `EffectResolved`, the `IfAPlayerDoes` alternative-outcome sub and the
+/// `SequentialSibling` chain — and, because this root discarded the `ActionResult`
+/// it returned while `action_result` had already `std::mem::take`n the buffer, it
+/// silently discarded the whole reducer step's events as well.
 pub(super) fn resume_counter_addition_unless_payment(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
     boundary: CostMoveDrainBoundary,
 ) -> Result<WaitingFor, EngineError> {
     let Some(PendingCostMoveResume::CounterAdditionUnlessPayment {
-        cost,
         pending_effect,
         trigger_event,
-        effect_description,
-        remaining,
+        ..
     }) = state.pending_cost_move_resume.take()
     else {
         unreachable!("counter-addition unless-payment resume requires its typed continuation")
     };
-    // CR 614.1: `ReplacementPrevented` is the completely-replaced placement (the
-    // header argues its mapping and `PriorityBoundary`'s unreachability). Taking
-    // the boundary by type means a future widening of that eligibility table fails
-    // loudly here instead of silently defaulting to an unpaid cost.
-    let payment_failed = match boundary {
-        CostMoveDrainBoundary::ReplacementDelivered { .. } => false,
-        CostMoveDrainBoundary::ReplacementPrevented { .. } => true,
+    // CR 118.12: whichever way the replacement settled, the payer already chose
+    // to pay. The boundary is no longer a verdict — it is an ELIGIBILITY
+    // ASSERTION. See the header for why a can't-effect never arrives here, and
+    // why a future widening of the boundary enum or of the eligibility table must
+    // fail to compile at this site rather than silently pick a verdict.
+    match boundary {
+        CostMoveDrainBoundary::ReplacementDelivered { .. }
+        | CostMoveDrainBoundary::ReplacementPrevented { .. } => {}
         CostMoveDrainBoundary::PriorityBoundary => {
             unreachable!("counter-addition unless-payment is not eligible at the priority boundary")
         }
-    };
-    finish_unless_payment(
-        state,
-        true,
-        payment_failed,
-        cost,
-        pending_effect,
-        trigger_event,
-        effect_description,
-        remaining,
-        None,
-        events,
-    )?;
-    Ok(state.waiting_for.clone())
+    }
+    finish_successful_unless_payment(state, &pending_effect, &trigger_event, events)
 }
 
 /// CR 701.9b + CR 118.12 + CR 616.1: Resume a RANDOM unless-discard after the

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -889,9 +889,10 @@ pub(super) fn handle_unless_payment(
                     // `remaining` once `add_player_counter_with_replacement`
                     // overwrites `state.waiting_for` with the ReplacementChoice
                     // prompt below — so the choice's resolution can settle
-                    // this exact Ward payment (via `finish_unless_payment`,
-                    // resumed by `resume_counter_addition_unless_payment`)
-                    // instead of leaving it orphaned at bare Priority.
+                    // this exact Ward payment (via
+                    // `resume_counter_addition_unless_payment`, which settles
+                    // it through `finish_successful_unless_payment`) instead of
+                    // leaving it orphaned at bare Priority.
                     PaymentOutcome::Paused { .. } => {
                         state.pending_cost_move_resume =
                             Some(PendingCostMoveResume::CounterAdditionUnlessPayment {
@@ -1484,15 +1485,17 @@ pub(super) fn handle_unless_payment(
     )
 }
 
-/// CR 118.12 + CR 118.12a: The shared paid/failed epilogue for every
+/// CR 118.12 + CR 118.12a: The DECLINED-or-FAILED epilogue for every
 /// unless-cost shape — poll re-emit for "unless any player pays", resolve the
 /// guarded ability's chain when the cost is unpaid/failed, and settle
-/// priority/continuations either way. Extracted from `handle_unless_payment`'s
-/// own tail so a cost shape that pauses on a nested replacement choice mid-payment
+/// priority/continuations. Its body is gated on `!pay || payment_failed`, and
+/// its sole caller (`handle_unless_payment`) reaches it only under that same
+/// condition: a payment that succeeds returns ahead of this call through
+/// `finish_successful_unless_payment`. That paid epilogue is also where a cost
+/// shape that pauses on a nested replacement choice mid-payment
 /// (`AbilityCost::GetPlayerCounters`, via
-/// `PendingCostMoveResume::CounterAdditionUnlessPayment`) can resume through
-/// EXACTLY this same logic once the choice resolves, instead of duplicating it
-/// and risking drift between the immediate and deferred paths.
+/// `PendingCostMoveResume::CounterAdditionUnlessPayment`) settles once the
+/// choice resolves.
 #[allow(clippy::too_many_arguments)]
 fn finish_unless_payment(
     state: &mut GameState,

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -23,7 +23,7 @@ use super::costs::{self, PaymentOutcome};
 use super::effects;
 use super::engine::{
     handle_tap_land_for_mana, handle_untap_land_for_mana, resume_pending_continuation_if_priority,
-    EngineError,
+    CostMoveDrainBoundary, EngineError,
 };
 use super::engine_priority;
 use super::mana_abilities;
@@ -890,7 +890,7 @@ pub(super) fn handle_unless_payment(
                     // overwrites `state.waiting_for` with the ReplacementChoice
                     // prompt below — so the choice's resolution can settle
                     // this exact Ward payment (via `finish_unless_payment`,
-                    // resumed by `resume_get_player_counters_unless_payment`)
+                    // resumed by `resume_counter_addition_unless_payment`)
                     // instead of leaving it orphaned at bare Priority.
                     PaymentOutcome::Paused { .. } => {
                         state.pending_cost_move_resume =
@@ -2065,20 +2065,34 @@ pub(super) fn resume_ward_sacrifice_payment(
     }
 }
 
-/// CR 118.12 + CR 122.1 + CR 616.1: Resume a counter-addition unless-payment
-/// after its `AddCounter` replacement choice settled. `payment_succeeded` comes
-/// from the exact boundary the replacement pipeline resolved to
-/// (`CostMoveDrainBoundary::ReplacementDelivered` = the counters were actually
-/// added = paid; `ReplacementPrevented` = a replacement fully suppressed the
-/// placement = failed — mirroring `PlayerCounterAdditionOutcome`'s established
-/// Applied/Prevented ↔ Paid/Failed mapping for the immediate-payment case).
-/// Delegates to the same `finish_unless_payment` tail every other unless-cost
-/// shape uses, so the Ward-guarded ability is settled exactly once, either way,
-/// instead of the game resetting to bare priority with its fate undetermined.
+/// CR 118.12 + CR 122.1 + CR 614.1 + CR 616.1: Resume a counter-addition
+/// unless-payment after its `AddCounter` replacement choice settled. The typed
+/// `CostMoveDrainBoundary` the replacement pipeline resolved to IS the payment
+/// verdict, matched exhaustively here rather than collapsed to a flag at the
+/// dispatcher: `ReplacementDelivered` = the counters were actually added = paid;
+/// `ReplacementPrevented` = a replacement completely replaced the placement
+/// (CR 614.1) = failed. That `Prevented → Failed` arm is the engine's established
+/// internal contract, not a CR derivation: it mirrors the
+/// `PlayerCounterAdditionOutcome` Applied/Prevented ↔ Paid/Failed match in
+/// `costs::pay_ability_cost_for_resolution`, which is the immediate (unpaused)
+/// leg of this same payment — the two legs must agree. Recorded, not settled:
+/// CR 118.11 ("the actions performed when paying a cost may be modified by
+/// effects … the cost has still been paid") points the other way for the
+/// prevented arm, and reconciling it is a behavior change across both legs, not
+/// a resume-site fix.
+/// `PriorityBoundary` is unreachable: `drain_pending_cost_move_resume` admits only
+/// `DelveManaPayment`/`ManaAbilityPayment` at that boundary and dispatches both
+/// ahead of this root. Interpreting the boundary here rather than at the call site
+/// is deliberate — the sibling `resume_random_discard_unless_payment` maps the very
+/// same boundaries differently (it ignores them, per CR 118.12), so each root must
+/// own its own mapping.
+/// Delegates to the same `finish_unless_payment` tail every other unless-cost shape
+/// uses, so the guarded ability is settled exactly once, either way, instead of the
+/// game resetting to bare priority with its fate undetermined.
 pub(super) fn resume_counter_addition_unless_payment(
     state: &mut GameState,
     events: &mut Vec<GameEvent>,
-    payment_succeeded: bool,
+    boundary: CostMoveDrainBoundary,
 ) -> Result<WaitingFor, EngineError> {
     let Some(PendingCostMoveResume::CounterAdditionUnlessPayment {
         cost,
@@ -2090,10 +2104,21 @@ pub(super) fn resume_counter_addition_unless_payment(
     else {
         unreachable!("counter-addition unless-payment resume requires its typed continuation")
     };
+    // CR 614.1: `ReplacementPrevented` is the completely-replaced placement (the
+    // header argues its mapping and `PriorityBoundary`'s unreachability). Taking
+    // the boundary by type means a future widening of that eligibility table fails
+    // loudly here instead of silently defaulting to an unpaid cost.
+    let payment_failed = match boundary {
+        CostMoveDrainBoundary::ReplacementDelivered { .. } => false,
+        CostMoveDrainBoundary::ReplacementPrevented { .. } => true,
+        CostMoveDrainBoundary::PriorityBoundary => {
+            unreachable!("counter-addition unless-payment is not eligible at the priority boundary")
+        }
+    };
     finish_unless_payment(
         state,
         true,
-        !payment_succeeded,
+        payment_failed,
         cost,
         pending_effect,
         trigger_event,

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -570,6 +570,30 @@ pub(super) fn handle_unless_payment_choose_cost(
                     costs.len()
                 ))
             })?;
+            // CR 614.17b: "If an event can't happen, a player can't choose to pay a cost
+            // that includes that event." The prohibition attaches to CHOOSING, so an
+            // impossible branch is refused at the pick, before it is accumulated — not at
+            // the collapse that follows the last pick. The difference is not cosmetic: for
+            // a `Composite{[OneOf; N]}` cumulative-upkeep expansion (CR 702.24a) this arm
+            // surfaces the NEXT prompt and returns `Ok`, so a refusal deferred to
+            // `handle_unless_payment` would accept the prohibited pick, record it in
+            // `chosen`, and leave the player unable to take the legal branch of a prompt
+            // they have already answered. CR 702.24a: "either the entire set of costs is
+            // paid, or none of them is paid. Partial payments aren't allowed."
+            if crate::game::costs::resolution_cost_includes_impossible_event(
+                state,
+                player,
+                &picked,
+                pending_effect.as_ref(),
+            ) {
+                return Err(EngineError::InvalidAction(
+                    "CR 614.17b: a player can't choose to pay a cost that includes an event that can't happen"
+                        .to_string(),
+                ));
+            }
+            // strict-failure: CR 118.12a disjunctive unless-costs with a counter branch are
+            // refused at the pick, not removed from the offered `costs` list;
+            // `legal_actions` already excludes the refused index.
             // CR 702.24a + CR 118.12: If more disjunctive prompts remain
             // (cumulative-upkeep `OneOf × N` expansion), accumulate this pick
             // and surface the next prompt without paying anything yet.
@@ -766,6 +790,27 @@ pub(super) fn handle_unless_payment(
     // CR 118.12a: Preserved for the "unless any player pays" poll re-emit —
     // `cost` itself is moved by the `match cost` below on the pay path.
     let poll_cost = cost.clone();
+
+    // CR 614.17b + CR 614.17a: re-check on the LIVE board. A can't-effect must
+    // exist when the event occurs, and this window admits mana abilities
+    // (CR 117.1d / CR 118.2), so the board can change between the prompt and this
+    // answer. Refusing the CHOICE — not the settle — is the rules-correct seam,
+    // mirroring the CR 119.8 analogue (`life_costs::can_pay_life_cost` is the
+    // choice-time half; `PayLifeCostResult::Prohibited` is the payment-time half).
+    // Only the pay branch is refused; `PayUnlessCost { pay: false }` stays legal.
+    if pay
+        && costs::resolution_cost_includes_impossible_event(
+            state,
+            player,
+            &cost,
+            pending_effect.as_ref(),
+        )
+    {
+        return Err(EngineError::InvalidAction(
+            "CR 614.17b: a player can't choose to pay a cost that includes an event that can't happen"
+                .to_string(),
+        ));
+    }
 
     let mut payment_failed = !pay;
     let post_action_event_start = None;
@@ -1510,13 +1555,27 @@ fn finish_unless_payment(
     events: &mut Vec<GameEvent>,
 ) -> Result<ActionResult, EngineError> {
     if !pay || payment_failed {
+        // CR 614.17b + CR 614.17a: the CR 118.12a poll re-emit re-asks eligibility on
+        // the LIVE board, so a prohibition that appears mid-poll skips the payer it
+        // reaches instead of offering that payer a choice the rules forbid.
         // CR 118.12a: "[Effect] unless any player pays ..." poll — when the
         // current player declines (or cannot pay) and more players remain,
         // prompt the next player in APNAP order rather than resolving the
         // effect. The first player to pay prevents the effect; only when every
         // polled player has declined does the effect resolve (once). Mirrors
         // the `OpponentMayChoice` decline-branch poll re-emit.
-        if let Some((&next, rest)) = remaining.split_first() {
+        if let Some((&next, rest)) = remaining
+            .iter()
+            .position(|p| {
+                !costs::resolution_cost_includes_impossible_event(
+                    state,
+                    *p,
+                    &poll_cost,
+                    pending_effect.as_ref(),
+                )
+            })
+            .and_then(|head| remaining[head..].split_first())
+        {
             state.waiting_for = WaitingFor::UnlessPayment {
                 player: next,
                 cost: poll_cost,
@@ -2069,7 +2128,8 @@ pub(super) fn resume_ward_sacrifice_payment(
 }
 
 /// CR 118.12a + CR 702.21a + CR 702.24a: Resume a counter-addition unless-payment
-/// after the CR 616.1 replacement choice that paused it mid-cost settled. Two cost
+/// after its `AddCounter` replacement choice — a single optional candidate or a
+/// CR 616.1 ordering — that paused it mid-cost settled. Two cost
 /// authorities park here, and a reader who thinks this is Ward-only will mis-scope
 /// the next change: `AbilityCost::GetPlayerCounters` (Ward's player-counter
 /// payment, CR 702.21a) and the source-counter / fixed-mana `AbilityCost::
@@ -2171,8 +2231,9 @@ pub(super) fn resume_counter_addition_unless_payment(
 /// authorized before the replacement is ever consulted. A redirect (Library of
 /// Leng) and a prevention alike leave that choice intact.
 ///
-/// The earlier `Delivered → Paid` / `Prevented → Failed` mapping was copied from
-/// `resume_counter_addition_unless_payment` rather than derived from CR 118.12;
+/// The earlier `Delivered → Paid` / `Prevented → Failed` mapping was the mapping
+/// `resume_counter_addition_unless_payment` then had, rather than one derived
+/// from CR 118.12;
 /// under it, an applicable replacement preventing the first move would sacrifice
 /// Balduvian Horde out from under a player who had paid.
 ///
@@ -4134,6 +4195,290 @@ mod tests {
         assert_eq!(
             state.players[0].life, 20,
             "gain-life effect suppressed by payment"
+        );
+    }
+
+    /// Installs a synthetic MANDATORY `Prevent`-on-`AddCounter` replacement on a
+    /// fresh permanent controlled by `controller`, scoped by `scope`.
+    ///
+    /// CR 614.17c: a MANDATORY prohibition is short-circuited by
+    /// `replacement::pipeline_loop` ahead of any CR 616.1 ordering prompt. No
+    /// printed card produces an OPTIONAL `AddCounter` replacement, so a
+    /// synthetic definition is the only route to this state.
+    ///
+    /// `scope` and `controller` are the two typed axes, so `You`-scoped and
+    /// `AnyPlayer`-scoped fixtures share one definition site.
+    fn install_mandatory_counter_prevention(
+        state: &mut GameState,
+        scope: crate::types::ability::ReplacementPlayerScope,
+        controller: PlayerId,
+    ) {
+        let source = create_object(
+            state,
+            CardId(9201),
+            controller,
+            "Mandatory Poison Warden".to_string(),
+            Zone::Battlefield,
+        );
+        let mut def = crate::types::ability::ReplacementDefinition::new(
+            crate::types::replacements::ReplacementEvent::AddCounter,
+        );
+        def.mode = crate::types::ability::ReplacementMode::Mandatory;
+        def.quantity_modification = Some(crate::types::ability::QuantityModification::Prevent);
+        def.valid_player = Some(scope);
+        let reps = vec![def];
+        let obj = state.objects.get_mut(&source).unwrap();
+        obj.replacement_definitions = reps.clone().into();
+        obj.base_replacement_definitions = Arc::new(reps);
+    }
+
+    /// CR 614.17b + CR 614.17a + CR 118.12a: the poll re-emit re-asks
+    /// eligibility on the live board, so a payer who cannot CHOOSE to pay is
+    /// skipped rather than prompted.
+    ///
+    /// The prohibition is scoped `You` on a P1-controlled permanent, so only P1
+    /// is prohibited and the prompted head P0 is not — which keeps this
+    /// hand-built prompt consistent with what the interceptor would construct.
+    ///
+    /// Revert probe: without the re-emit filter, P1 is prompted and the pending
+    /// `GainLife(4)` never resolves, so P0's life stays at 20.
+    #[test]
+    fn unless_pay_poll_skips_a_payer_who_cannot_choose_to_pay() {
+        use crate::game::effects::player_counter::preview_player_counter_addition;
+        use crate::types::ability::ReplacementPlayerScope;
+        use crate::types::player::PlayerCounterKind;
+
+        let mut state = GameState::new_two_player(42);
+        state.players[0].life = 20;
+        state.players[1].life = 20;
+        install_mandatory_counter_prevention(&mut state, ReplacementPlayerScope::You, PlayerId(1));
+
+        // Reach guards: the prohibition really was installed AND is correctly
+        // scoped. Without them, the skip this row asserts is satisfiable by a
+        // fixture that installed nothing at all.
+        assert!(
+            preview_player_counter_addition(
+                &state,
+                PlayerId(1),
+                PlayerId(1),
+                PlayerCounterKind::Poison,
+                5,
+            )
+            .is_prohibited(),
+            "the `You`-scoped prohibition must bite its own controller"
+        );
+        assert!(
+            !preview_player_counter_addition(
+                &state,
+                PlayerId(0),
+                PlayerId(0),
+                PlayerCounterKind::Poison,
+                5,
+            )
+            .is_prohibited(),
+            "the `You`-scoped prohibition must not bite P0"
+        );
+
+        let pending = ResolvedAbility::new(gain_life(4), vec![], ObjectId(100), PlayerId(0));
+        state.waiting_for = WaitingFor::UnlessPayment {
+            player: PlayerId(0),
+            cost: AbilityCost::GetPlayerCounters {
+                counter_kind: PlayerCounterKind::Poison,
+                count: 5,
+            },
+            pending_effect: Box::new(pending),
+            trigger_event: None,
+            effect_description: None,
+            remaining: vec![PlayerId(1)],
+        };
+
+        let mut events = Vec::new();
+        let wf = state.waiting_for.clone();
+        handle_unless_payment(&mut state, wf, false, &mut events).expect("poll advance");
+
+        assert!(
+            !matches!(&state.waiting_for, WaitingFor::UnlessPayment { player, .. } if *player == PlayerId(1)),
+            "a payer who cannot choose to pay must not be prompted, got {:?}",
+            state.waiting_for
+        );
+        assert_eq!(
+            state.players[0].life, 24,
+            "the pending effect must resolve exactly once when nobody else qualifies"
+        );
+    }
+
+    /// The control leg of `unless_pay_poll_skips_a_payer_who_cannot_choose_to_pay`:
+    /// the identical poll on the identical board with a `PayLife` cost, which no
+    /// counter prohibition can reach. P1 IS re-emitted and the effect does not
+    /// resolve mid-poll.
+    ///
+    /// Written as its own `#[test]` so a failure names which leg broke.
+    #[test]
+    fn unless_pay_poll_control_cost_still_re_emits_for_the_next_payer() {
+        use crate::types::ability::ReplacementPlayerScope;
+
+        let mut state = GameState::new_two_player(42);
+        state.players[0].life = 20;
+        state.players[1].life = 20;
+        install_mandatory_counter_prevention(&mut state, ReplacementPlayerScope::You, PlayerId(1));
+
+        let pending = ResolvedAbility::new(gain_life(4), vec![], ObjectId(100), PlayerId(0));
+        state.waiting_for = WaitingFor::UnlessPayment {
+            player: PlayerId(0),
+            cost: AbilityCost::PayLife {
+                amount: QuantityExpr::Fixed { value: 1 },
+            },
+            pending_effect: Box::new(pending),
+            trigger_event: None,
+            effect_description: None,
+            remaining: vec![PlayerId(1)],
+        };
+
+        let mut events = Vec::new();
+        let wf = state.waiting_for.clone();
+        handle_unless_payment(&mut state, wf, false, &mut events).expect("poll advance");
+
+        assert!(
+            matches!(&state.waiting_for, WaitingFor::UnlessPayment { player, .. } if *player == PlayerId(1)),
+            "a cost no prohibition can reach must still re-emit for P1, got {:?}",
+            state.waiting_for
+        );
+        assert_eq!(
+            state.players[0].life, 20,
+            "the effect must not resolve mid-poll"
+        );
+    }
+
+    /// CR 614.17b: a prohibited BRANCH of a disjunctive unless-cost is refused
+    /// AT THE PICK, before it is accumulated into `chosen`.
+    ///
+    /// CR 702.24a: the `Composite{[OneOf; N]}` shape `expand_per_counter`
+    /// produces at two age counters surfaces the NEXT prompt and returns `Ok`,
+    /// so a refusal deferred to the collapse would accept the prohibited pick,
+    /// record it, and leave the player unable to take the legal branch of a
+    /// prompt they had already answered — "either the entire set of costs is
+    /// paid, or none of them is paid."
+    ///
+    /// Revert probe: without the gate, `pick(0)` returns `Ok` and `chosen`
+    /// contains the prohibited `GetPlayerCounters` branch.
+    #[test]
+    fn unless_pay_choose_cost_refuses_a_prohibited_branch_at_the_pick() {
+        use crate::game::effects::player_counter::preview_player_counter_addition;
+        use crate::types::ability::ReplacementPlayerScope;
+        use crate::types::actions::{GameAction, UnlessCostBranch};
+        use crate::types::player::PlayerCounterKind;
+
+        let pick = |index: usize| GameAction::ChooseUnlessCostBranch {
+            choice: UnlessCostBranch::Pay { index },
+        };
+        let poison = AbilityCost::GetPlayerCounters {
+            counter_kind: PlayerCounterKind::Poison,
+            count: 5,
+        };
+        let life = AbilityCost::PayLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+        };
+
+        let build = || {
+            let mut state = GameState::new_two_player(42);
+            state.players[0].life = 20;
+            state.players[1].life = 20;
+            // MANDATORY `Prevent`-on-`AddCounter`, scope `AnyPlayer`, on a
+            // P0-controlled permanent — so P0, the prompted player, IS
+            // prohibited.
+            install_mandatory_counter_prevention(
+                &mut state,
+                ReplacementPlayerScope::AnyPlayer,
+                PlayerId(0),
+            );
+            // Reach guard, asserted BEFORE the prompt so a broken install
+            // cannot pass silently.
+            assert!(
+                preview_player_counter_addition(
+                    &state,
+                    PlayerId(0),
+                    PlayerId(0),
+                    PlayerCounterKind::Poison,
+                    5,
+                )
+                .is_prohibited(),
+                "the prohibition must bite the prompted player"
+            );
+            state.waiting_for = WaitingFor::UnlessPaymentChooseCost {
+                player: PlayerId(0),
+                costs: vec![poison.clone(), life.clone()],
+                pending_effect: Box::new(ResolvedAbility::new(
+                    gain_life(4),
+                    vec![],
+                    ObjectId(100),
+                    PlayerId(0),
+                )),
+                trigger_event: None,
+                effect_description: None,
+                remaining_choices: vec![vec![poison.clone(), life.clone()]],
+                chosen: vec![],
+            };
+            state
+        };
+
+        // (i) index 0 is the impossible branch.
+        let mut state = build();
+        assert!(
+            crate::game::engine::apply_as_current(&mut state, pick(0)).is_err(),
+            "picking the prohibited branch must be refused"
+        );
+        // (iii) the refusal happens BEFORE `chosen.push`.
+        assert!(
+            matches!(
+                &state.waiting_for,
+                WaitingFor::UnlessPaymentChooseCost { chosen, .. } if chosen.is_empty()
+            ),
+            "the refused pick must not be accumulated, got {:?}",
+            state.waiting_for
+        );
+        // (iv) the legality surface agrees, with two in-vector controls.
+        let legal = crate::ai_support::legal_actions(&state);
+        assert!(
+            !legal.contains(&pick(0)),
+            "the prohibited index must not be offered, got {legal:?}"
+        );
+        assert!(
+            legal.contains(&pick(1)),
+            "the payable index must still be offered, got {legal:?}"
+        );
+        assert!(
+            legal.contains(&GameAction::ChooseUnlessCostBranch {
+                choice: UnlessCostBranch::Decline
+            }),
+            "declining must still be offered, got {legal:?}"
+        );
+
+        // (ii) CONTROL: the same call at index 1, same board, same prompt.
+        let mut control = build();
+        crate::game::engine::apply_as_current(&mut control, pick(1))
+            .expect("the payable branch must still be accepted");
+        assert!(
+            matches!(
+                &control.waiting_for,
+                WaitingFor::UnlessPaymentChooseCost { chosen, .. }
+                    if chosen.as_slice() == [life.clone()]
+            ),
+            "the accepted pick must be accumulated, got {:?}",
+            control.waiting_for
+        );
+
+        // (v) The stranding, positive form: after the refusal the payable route
+        // is still reachable and the prompt advances to the second round.
+        crate::game::engine::apply_as_current(&mut state, pick(1))
+            .expect("the payable branch is still reachable after the refusal");
+        assert!(
+            matches!(
+                &state.waiting_for,
+                WaitingFor::UnlessPaymentChooseCost { chosen, remaining_choices, .. }
+                    if chosen.as_slice() == [life.clone()] && remaining_choices.is_empty()
+            ),
+            "the prompt must advance to the second round with the payable pick recorded, got {:?}",
+            state.waiting_for
         );
     }
 }

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6773,8 +6773,13 @@ pub enum PendingCostMoveResume {
     /// CR 118.12 + CR 122.1 + CR 616.1: A counter-addition unless-cost paused
     /// on a replacement choice. Covers Ward's player-counter payment and the
     /// source-counter `EffectCost` used by cumulative upkeep. Retains the full
-    /// `WaitingFor::UnlessPayment` payload so Applied completes payment and a
-    /// prevented placement fails it instead of orphaning the pending ability.
+    /// `WaitingFor::UnlessPayment` payload so the parked payment is settled
+    /// instead of orphaning the pending ability. CR 118.12: BOTH replacement
+    /// outcomes complete the payment — the "if they don't" clause checks whether
+    /// the player chose to pay, "regardless of what events actually occurred",
+    /// and this record's mere existence IS that choice (it is constructed only
+    /// on the `pay = true` path). The mapping is argued at its consumer,
+    /// `engine_payment_choices::resume_counter_addition_unless_payment`.
     #[serde(alias = "GetPlayerCountersUnlessPayment")]
     CounterAdditionUnlessPayment {
         #[serde(deserialize_with = "crate::types::ability::deserialize_ability_cost_compat")]

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6772,9 +6772,11 @@ pub enum PendingCostMoveResume {
     },
     /// CR 118.12 + CR 122.1 + CR 616.1: A counter-addition unless-cost paused
     /// on a replacement choice. Covers Ward's player-counter payment and the
-    /// source-counter `EffectCost` used by cumulative upkeep. Retains the full
-    /// `WaitingFor::UnlessPayment` payload so the parked payment is settled
-    /// instead of orphaning the pending ability. CR 118.12: BOTH replacement
+    /// source-counter `EffectCost` used by cumulative upkeep. The resume reads
+    /// `pending_effect` and `trigger_event` to settle the parked payment
+    /// instead of orphaning the pending ability; `cost`, `effect_description`
+    /// and `remaining` complete the serialized checkpoint payload and are read
+    /// on no resume path. CR 118.12: BOTH replacement
     /// outcomes complete the payment — the "if they don't" clause checks whether
     /// the player chose to pay, "regardless of what events actually occurred",
     /// and this record's mere existence IS that choice (it is constructed only

--- a/crates/engine/tests/integration/issue_7234_cumulative_upkeep_effect_cost.rs
+++ b/crates/engine/tests/integration/issue_7234_cumulative_upkeep_effect_cost.rs
@@ -2,9 +2,10 @@
 //! effect costs after card-data/save-state deserialization.
 
 use engine::game::scenario::{GameScenario, P0};
-use engine::types::ability::{AbilityCost, Effect, QuantityExpr, TargetFilter};
+use engine::types::ability::{AbilityCost, Effect, EffectKind, QuantityExpr, TargetFilter};
 use engine::types::actions::GameAction;
 use engine::types::counter::CounterType;
+use engine::types::events::GameEvent;
 use engine::types::game_state::WaitingFor;
 use engine::types::keywords::Keyword;
 use engine::types::phase::Phase;
@@ -12,6 +13,13 @@ use engine::types::zones::Zone;
 
 const ABOROTH_ORACLE: &str =
     "Cumulative upkeep—Put a -1/-1 counter on this creature. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)";
+
+const VORINCLEX_ORACLE: &str = "Trample, haste\n\
+If you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.\n\
+If an opponent would put one or more counters on a permanent or player, they put half that many of each of those kinds of counters on that permanent or player instead, rounded down.";
+
+const DOC_SAMSON_ORACLE: &str = "If you would put one or more counters on a permanent you control, put that many plus one of each of those kinds of counters on that permanent instead.\n\
+{T}: Add X mana of any one color, where X is Doc Samson's power.";
 
 /// CR 702.24a: Card-data and saved games use the externally tagged keyword
 /// form. A typed Aboroth effect cost must not be replaced by a zero-mana cost.
@@ -90,5 +98,210 @@ fn aboroth_cumulative_upkeep_scales_and_pays_source_counter_effect_cost() {
         aboroth_object.counters.get(&CounterType::Minus1Minus1),
         Some(&2),
         "paying the cumulative cost must place one -1/-1 counter for each age counter"
+    );
+}
+
+/// CR 702.24a + CR 616.1 + CR 118.12: Aboroth's cumulative upkeep is an
+/// `AbilityCost::EffectCost` — the *second* unless-payment park site, the
+/// sibling of Ward's `AbilityCost::GetPlayerCounters` site. When two printed
+/// replacement effects both modify the counter placement the payer is paying
+/// WITH, CR 616.1 makes the payer order them, and the payment PARKS mid-cost on
+/// `PendingCostMoveResume::CounterAdditionUnlessPayment`.
+///
+/// CR 616.1 genuinely applies here because the two modifications do not commute
+/// on the placement's count: Vorinclex is multiplicative (`Times{2}`) and Doc
+/// Samson is additive (`Plus{1}`), so a 3-counter cost settles at 3 → 6 → 7 with
+/// Vorinclex first and 3 → 4 → 8 with Doc Samson first.
+///
+/// CR 118.12: whichever order is chosen, the cost is PAID — the "if they don't"
+/// clause "checks whether the player chose to pay an optional cost … regardless
+/// of what events actually occurred", and the choice was latched at
+/// `PayUnlessCost { pay: true }`, before the replacement pipeline was consulted.
+/// CR 118.11 corroborates: a cost whose payment actions were modified is still
+/// paid. So the guarded "sacrifice it" never happens.
+///
+/// `GameEvent::EffectResolved { kind: EffectKind::Sacrifice, .. }` here means
+/// "the cumulative-upkeep ability finished resolving", NOT that Aboroth was
+/// sacrificed. The paired `zone == Zone::Battlefield` assertion is what proves
+/// the permanent survived.
+#[test]
+fn aboroth_cumulative_upkeep_payment_ordered_by_two_replacements_is_still_paid() {
+    // Both CR 616.1 orderings are driven inline in one test function rather than
+    // through a parameterised helper: the ordering IS the axis under test, and a
+    // single function keeps the ordering assertions beside the counter totals
+    // they explain.
+    for (index, expected_minus_counters) in [(0usize, 7u32), (1usize, 8u32)] {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::Untap);
+        scenario.add_creature_from_oracle(
+            P0,
+            "Vorinclex, Monstrous Raider",
+            6,
+            6,
+            VORINCLEX_ORACLE,
+        );
+        scenario.add_creature_from_oracle(
+            P0,
+            "Doc Samson, Super Psychiatrist",
+            3,
+            6,
+            DOC_SAMSON_ORACLE,
+        );
+        let aboroth = scenario
+            .add_creature_from_oracle(P0, "Aboroth", 9, 9, ABOROTH_ORACLE)
+            .id();
+        let mut runner = scenario.build();
+
+        runner.auto_advance_to_main_phase();
+        runner.advance_until_stack_empty();
+
+        // CR 702.24a + CR 616.1: the AGE counter placement is itself modified by
+        // both permanents, so the very first prompt is the ordering choice.
+        // Answering it with Vorinclex first makes the age total 1 → 2 → 3.
+        assert_replacement_choice_between_vorinclex_and_doc_samson(
+            &runner,
+            "the age-counter placement must raise the CR 616.1 ordering prompt",
+        );
+        runner
+            .act(GameAction::ChooseReplacement { index: 0 })
+            .expect("ordering the age-counter replacements must be legal");
+        runner.advance_until_stack_empty();
+
+        // Reach guard: the cost really is the `EffectCost` shape (the second park
+        // site), and it scaled with the modified age total.
+        match &runner.state().waiting_for {
+            WaitingFor::UnlessPayment { player, cost, .. } => {
+                assert_eq!(
+                    *player, P0,
+                    "the cumulative-upkeep payer is Aboroth's controller"
+                );
+                assert!(
+                    matches!(
+                        cost,
+                        AbilityCost::EffectCost { effect } if matches!(
+                            effect.as_ref(),
+                            Effect::PutCounter {
+                                counter_type: CounterType::Minus1Minus1,
+                                count: QuantityExpr::Fixed { value: 3 },
+                                target: TargetFilter::SelfRef,
+                            }
+                        )
+                    ),
+                    "the modified age total must scale the effect cost to three -1/-1 counters, got {cost:?}"
+                );
+            }
+            other => panic!("expected Aboroth's cumulative-upkeep payment prompt, got {other:?}"),
+        }
+
+        runner
+            .act(GameAction::PayUnlessCost { pay: true })
+            .expect("choosing to pay Aboroth's counter cost must be legal");
+
+        // CR 616.1: the payment itself parks mid-cost on a replacement-ordering
+        // choice. This is the assertion that proves the `EffectCost` park site is
+        // reached at all.
+        assert!(
+            runner.state().pending_cost_move_resume.is_some(),
+            "paying the effect cost must park the unless-payment continuation"
+        );
+        assert_replacement_choice_between_vorinclex_and_doc_samson(
+            &runner,
+            "the payment's own counter placement must raise the CR 616.1 ordering prompt",
+        );
+
+        let result = runner
+            .act(GameAction::ChooseReplacement { index })
+            .expect("ordering the payment's replacements must be legal");
+
+        // CR 118.12: the resume settles through the PAID epilogue, so the
+        // cumulative-upkeep ability finishes resolving and the whole reducer
+        // step's event buffer survives. Membership, not order: at index 1 the two
+        // `ReplacementApplied` events arrive Doc Samson first.
+        assert!(
+            result.events.iter().any(|event| matches!(
+                event,
+                GameEvent::EffectResolved {
+                    kind: EffectKind::Sacrifice,
+                    source_id,
+                    ..
+                } if *source_id == aboroth
+            )),
+            "a paid cumulative upkeep must emit the guarded ability's EffectResolved, got {:?}",
+            result.events
+        );
+        assert!(
+            result.events.iter().any(|event| matches!(
+                event,
+                GameEvent::CounterAdded {
+                    object_id,
+                    counter_type: CounterType::Minus1Minus1,
+                    count,
+                    ..
+                } if *object_id == aboroth && *count == expected_minus_counters
+            )),
+            "the counters the payer actually paid with must reach the event log, got {:?}",
+            result.events
+        );
+
+        runner.advance_until_stack_empty();
+
+        let aboroth_object = runner
+            .state()
+            .objects
+            .get(&aboroth)
+            .expect("Aboroth remains a known object");
+        assert_eq!(
+            aboroth_object.zone,
+            Zone::Battlefield,
+            "CR 118.12: a paid cumulative upkeep must not sacrifice the permanent"
+        );
+        assert_eq!(
+            aboroth_object.counters.get(&CounterType::Minus1Minus1),
+            Some(&expected_minus_counters),
+            "ordering index {index} must settle the modified counter total"
+        );
+        assert_eq!(
+            aboroth_object.counters.get(&CounterType::Age),
+            Some(&3),
+            "the age placement was modified by both replacements (1 → 2 → 3)"
+        );
+    }
+}
+
+/// Reach guard shared by both CR 616.1 prompts in the row above: the prompt is
+/// the payer's, and it names both printed replacement sources. Asserted by
+/// MEMBERSHIP rather than by index, because the candidate order differs between
+/// the two prompts — an ordering drift must fail loudly, not silently re-index.
+fn assert_replacement_choice_between_vorinclex_and_doc_samson(
+    runner: &engine::game::scenario::GameRunner,
+    context: &str,
+) {
+    let WaitingFor::ReplacementChoice {
+        player,
+        candidate_count,
+        ref candidates,
+    } = runner.state().waiting_for
+    else {
+        panic!("{context}, got {:?}", runner.state().waiting_for);
+    };
+    assert_eq!(
+        player, P0,
+        "{context}: the affected permanent's controller chooses"
+    );
+    assert_eq!(
+        candidate_count, 2,
+        "{context}: both replacements are candidates"
+    );
+    let names: Vec<&str> = candidates
+        .iter()
+        .map(|candidate| candidate.source_name.as_str())
+        .collect();
+    assert!(
+        names.contains(&"Vorinclex, Monstrous Raider"),
+        "{context}: Vorinclex must be a candidate, got {names:?}"
+    );
+    assert!(
+        names.contains(&"Doc Samson, Super Psychiatrist"),
+        "{context}: Doc Samson must be a candidate, got {names:?}"
     );
 }

--- a/crates/engine/tests/integration/issue_7234_cumulative_upkeep_effect_cost.rs
+++ b/crates/engine/tests/integration/issue_7234_cumulative_upkeep_effect_cost.rs
@@ -14,6 +14,9 @@ use engine::types::zones::Zone;
 const ABOROTH_ORACLE: &str =
     "Cumulative upkeep—Put a -1/-1 counter on this creature. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)";
 
+const SOLEMNITY_ORACLE: &str = "Players can't get counters.\n\
+Counters can't be put on artifacts, creatures, enchantments, or lands.";
+
 const VORINCLEX_ORACLE: &str = "Trample, haste\n\
 If you would put one or more counters on a permanent or player, put twice that many of each of those kinds of counters on that permanent or player instead.\n\
 If an opponent would put one or more counters on a permanent or player, they put half that many of each of those kinds of counters on that permanent or player instead, rounded down.";
@@ -303,5 +306,84 @@ fn assert_replacement_choice_between_vorinclex_and_doc_samson(
     assert!(
         names.contains(&"Doc Samson, Super Psychiatrist"),
         "{context}: Doc Samson must be a candidate, got {names:?}"
+    );
+}
+
+/// CR 614.17b + CR 702.24a: the object-counter leg of "a player can't choose to
+/// pay a cost that includes an event that can't happen".
+///
+/// Aboroth's cumulative upkeep is an `AbilityCost::EffectCost` whose payment
+/// puts a -1/-1 counter on Aboroth itself. Solemnity's second sentence —
+/// "Counters can't be put on artifacts, creatures, enchantments, or lands." —
+/// is a CR 614.17 can't-effect on exactly that placement, so the pay branch is
+/// never offered and CR 702.24a's "sacrifice it" happens instead.
+///
+/// Revert probe: without the choice-time refusal the prompt is
+/// `WaitingFor::UnlessPayment { cost: EffectCost { PutCounter M1M1 SelfRef } }`
+/// and Aboroth stays on the battlefield, failing both the `Priority` assertion
+/// and the `Zone::Graveyard` assertion.
+#[test]
+fn aboroth_with_an_age_counter_under_solemnity_cannot_choose_to_pay() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Untap);
+    scenario.add_enchantment_from_oracle(P0, "Solemnity", SOLEMNITY_ORACLE);
+    let aboroth = scenario
+        .add_creature_from_oracle(P0, "Aboroth", 9, 9, ABOROTH_ORACLE)
+        .id();
+    // Control: an ordinary creature with no cumulative upkeep. The mechanism
+    // under test cannot sacrifice it, so it must NOT reach the graveyard.
+    let control = scenario.add_creature(P0, "Control Bear", 2, 2).id();
+    // Without a library the suppressed prompt lets the turn run into the Draw
+    // step, P0 decks out, and EVERY P0 object is exiled — which satisfies a
+    // `!= Battlefield` assertion for the control creature too.
+    scenario.with_library_top(P0, &["Filler A", "Filler B", "Filler C"]);
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&aboroth)
+        .expect("Aboroth exists")
+        .counters
+        .insert(CounterType::Age, 1);
+
+    // Aboroth's upkeep cost only materialises at >= 1 age counter.
+    runner.auto_advance_to_main_phase();
+    runner.advance_until_stack_empty();
+
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { player } if player == P0),
+        "the prohibited pay branch must leave no unless-payment prompt, got {:?}",
+        runner.state().waiting_for
+    );
+    let legal = engine::ai_support::legal_actions(runner.state());
+    assert!(
+        !legal.is_empty(),
+        "the action vector must still be live, got {legal:?}"
+    );
+    assert!(
+        !legal.contains(&GameAction::PayUnlessCost { pay: true }),
+        "paying a -1/-1 counter cost must not be legal under Solemnity, got {legal:?}"
+    );
+
+    // CR 702.24a: an unpaid cumulative upkeep sacrifices the permanent.
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&aboroth)
+            .map(|obj| obj.zone)
+            .expect("Aboroth object still exists"),
+        Zone::Graveyard,
+        "an unpayable cumulative upkeep must sacrifice Aboroth"
+    );
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&control)
+            .map(|obj| obj.zone)
+            .expect("the control creature still exists"),
+        Zone::Battlefield,
+        "the control creature has no cumulative upkeep and must not be sacrificed"
     );
 }

--- a/crates/engine/tests/integration/issue_7234_cumulative_upkeep_effect_cost.rs
+++ b/crates/engine/tests/integration/issue_7234_cumulative_upkeep_effect_cost.rs
@@ -1,15 +1,19 @@
 //! GitHub issue #7234 — Cumulative upkeep must pay typed source-counter
 //! effect costs after card-data/save-state deserialization.
 
-use engine::game::scenario::{GameScenario, P0};
-use engine::types::ability::{AbilityCost, Effect, EffectKind, QuantityExpr, TargetFilter};
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::ability::{
+    AbilityCost, Effect, EffectKind, PlayerScope, QuantityExpr, QuantityRef, TargetFilter,
+};
 use engine::types::actions::GameAction;
 use engine::types::counter::CounterType;
 use engine::types::events::GameEvent;
 use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
 use engine::types::keywords::Keyword;
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
+use std::sync::Arc;
 
 const ABOROTH_ORACLE: &str =
     "Cumulative upkeep—Put a -1/-1 counter on this creature. (At the beginning of your upkeep, put an age counter on this permanent, then sacrifice it unless you pay its upkeep cost for each age counter on it.)";
@@ -385,5 +389,293 @@ fn aboroth_with_an_age_counter_under_solemnity_cannot_choose_to_pay() {
             .expect("the control creature still exists"),
         Zone::Battlefield,
         "the control creature has no cumulative upkeep and must not be sacrificed"
+    );
+}
+
+/// The quantity used by the two CR 107.1b rows below: `HandSize(controller) - 2`,
+/// which resolves to -2 while the payer's hand is empty.
+///
+/// `QuantityExpr::Offset` is the shape chosen over `Multiply { factor: -1, .. }`
+/// because it is the one the resolver can drive negative from ordinary board
+/// state: `fold_compose` evaluates it as an unfloored `inner + offset`, so any
+/// cost quantity whose dynamic inner falls below its offset arrives at the
+/// payment negative. Negative-offset `Offset` nodes are ordinary parser output
+/// ("X minus one"); a negative `Multiply` factor is real too, but every producer
+/// of one is a power/toughness or life-direction sign, never a counter count.
+fn hand_size_minus_two() -> QuantityExpr {
+    QuantityExpr::Offset {
+        inner: Box::new(QuantityExpr::Ref {
+            qty: QuantityRef::HandSize {
+                player: PlayerScope::Controller,
+            },
+        }),
+        offset: -2,
+    }
+}
+
+/// Replaces the counter count inside `source`'s OWN synthesized cumulative-upkeep
+/// cost, leaving every other part of the production trigger — the age-counter
+/// tick, the `PerCounter` wrapper, the payer, the sacrifice branch — exactly as
+/// the trigger synthesizer emitted it. The prompt, the choice-time payability
+/// answer and the payment therefore all come from production code; only the leaf
+/// quantity is fixture data.
+///
+/// The quantity is SYNTHETIC, stated as a predicate rather than as a card list:
+/// no printed card's counter cost resolves to a negative number, so the value has
+/// to be installed. The rows below pin the rules-correct answer for the shape,
+/// not the behavior of any printed card.
+///
+/// The `expect` is a reach guard: if synthesis stops emitting this cost shape the
+/// rows fail loudly instead of quietly pinning nothing.
+fn install_cumulative_upkeep_count(runner: &mut GameRunner, source: ObjectId, count: QuantityExpr) {
+    let object = runner
+        .state_mut()
+        .objects
+        .get_mut(&source)
+        .expect("the cumulative-upkeep source exists");
+    let slot = Arc::make_mut(&mut object.base_trigger_definitions)
+        .iter_mut()
+        .filter_map(|trigger| trigger.execute.as_mut())
+        .filter_map(|execute| execute.sub_ability.as_mut())
+        .filter_map(|branch| branch.unless_pay.as_mut())
+        .find_map(|unless| match &mut unless.cost {
+            AbilityCost::PerCounter { base, .. } => match base.as_mut() {
+                AbilityCost::EffectCost { effect } => match effect.as_mut() {
+                    Effect::PutCounter { count, .. } => Some(count),
+                    _ => None,
+                },
+                _ => None,
+            },
+            _ => None,
+        })
+        .expect("the synthesized cumulative upkeep carries a per-counter PutCounter effect cost");
+    *slot = count;
+    object.materialize_base_trigger_definitions();
+}
+
+/// Asserts that the live unless-payment prompt is the payer's and carries
+/// `expected` as its counter-cost quantity — the reach guard both rows below
+/// need, because a prompt carrying a different quantity would make everything
+/// downstream of it prove nothing.
+fn assert_unless_payment_carries_count(runner: &GameRunner, expected: &QuantityExpr) {
+    match &runner.state().waiting_for {
+        WaitingFor::UnlessPayment { player, cost, .. } => {
+            assert_eq!(
+                *player, P0,
+                "the cumulative-upkeep payer is the permanent's controller"
+            );
+            assert!(
+                matches!(
+                    cost,
+                    AbilityCost::EffectCost { effect } if matches!(
+                        effect.as_ref(),
+                        Effect::PutCounter {
+                            counter_type: CounterType::Minus1Minus1,
+                            count,
+                            target: TargetFilter::SelfRef,
+                        } if count == expected
+                    )
+                ),
+                "the unless-payment cost must carry the installed quantity, got {cost:?}"
+            );
+        }
+        other => panic!("expected the cumulative-upkeep payment prompt, got {other:?}"),
+    }
+}
+
+/// CR 107.1b: a counter cost whose quantity resolves NEGATIVE places ZERO
+/// counters, not its magnitude.
+///
+/// "If a calculation that would determine the result of an effect yields a
+/// negative number, zero is used instead, unless that effect doubles, triples,
+/// or sets to a specific value a player's life total or the power and/or
+/// toughness of a creature or creature card." A counter count is in none of
+/// those exception classes, so -2 is simply 0.
+///
+/// The whole path is production: the synthesized cumulative-upkeep trigger
+/// emits `WaitingFor::UnlessPayment`, `PayUnlessCost { pay: true }` goes through
+/// `apply()`, and the payment resolves the quantity itself. Only the leaf
+/// quantity is installed — see `install_cumulative_upkeep_count`, which also
+/// records why the shape is synthetic.
+///
+/// Revert probe: reading the resolved quantity as `resolved.unsigned_abs()`
+/// instead of clamping it at zero makes the payment place TWO -1/-1 counters,
+/// failing the last assertion. The three assertions above it hold in BOTH
+/// directions on purpose — they are reach guards, not discriminators.
+#[test]
+fn cumulative_upkeep_negative_counter_cost_quantity_places_no_counters() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Untap);
+    let aboroth = scenario
+        .add_creature_from_oracle(P0, "Aboroth", 9, 9, ABOROTH_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+    install_cumulative_upkeep_count(&mut runner, aboroth, hand_size_minus_two());
+
+    // Control on the fixture's own premise: the installed quantity is negative
+    // only because the payer's hand is empty when the upkeep resolves. Asserting
+    // it here makes a future scenario default that deals an opening hand fail
+    // loudly rather than silently turn the cost positive.
+    assert!(
+        runner.state().players[P0.0 as usize].hand.is_empty(),
+        "the installed quantity resolves to -2 only while the payer's hand is empty"
+    );
+
+    // No age counter is pre-installed, so the upkeep tick makes exactly one and
+    // the per-counter expansion's x1 scaling returns the quantity unchanged.
+    runner.auto_advance_to_main_phase();
+    runner.advance_until_stack_empty();
+
+    // Reach guard (i): the negative quantity is what the production prompt
+    // actually carries into the payment.
+    assert_unless_payment_carries_count(&runner, &hand_size_minus_two());
+
+    // Reach guard (ii): CR 614.17b did not refuse the choice. A zero-counter cost
+    // includes no counter-placement event, so there is nothing for a can't-effect
+    // to forbid and the pay branch is offered.
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("a cost that places no counters must remain choosable");
+    runner.advance_until_stack_empty();
+
+    let aboroth_object = runner
+        .state()
+        .objects
+        .get(&aboroth)
+        .expect("Aboroth remains a known object");
+    // Reach guard (iii): the cost was PAID, not declined. CR 702.24a sacrifices a
+    // permanent whose cumulative upkeep goes unpaid, so surviving on the
+    // battlefield with the ticked age counter is what proves the payment ran at
+    // all — without it the counter assertion below would pass vacuously.
+    assert_eq!(
+        aboroth_object.zone,
+        Zone::Battlefield,
+        "a paid cumulative upkeep must not sacrifice Aboroth"
+    );
+    assert_eq!(
+        aboroth_object.counters.get(&CounterType::Age),
+        Some(&1),
+        "the upkeep tick places exactly one age counter"
+    );
+
+    // CR 107.1b: the discriminator. `unsigned_abs()` places two counters here.
+    assert_eq!(
+        aboroth_object
+            .counters
+            .get(&CounterType::Minus1Minus1)
+            .copied()
+            .unwrap_or(0),
+        0,
+        "a counter cost resolving to -2 must place zero counters, not two"
+    );
+}
+
+/// CR 614.17b + CR 107.1b: because a NEGATIVE counter cost places zero counters,
+/// a counter prohibition must not make it unchoosable.
+///
+/// "If an event can't happen, a player can't choose to pay a cost that includes
+/// that event." A zero-counter cost includes no counter-placement event —
+/// `preview_counter_addition` answers `count == 0` with `Applied { count: 0 }`
+/// before consulting the replacement pipeline — so Solemnity has nothing to
+/// forbid and the pay branch stays on the table.
+///
+/// The board is held identical to
+/// `aboroth_with_an_age_counter_under_solemnity_cannot_choose_to_pay`, whose
+/// POSITIVE count makes the same Solemnity refusal CORRECT and sacrifices
+/// Aboroth. Moving only the quantity is what makes this row about the count
+/// rather than about Solemnity.
+///
+/// That identical board includes the PRE-INSTALLED age counter, which this row
+/// needs to reach the payment at all: Solemnity prevents the upkeep's own
+/// age-counter tick, so on a board with none the per-counter expansion runs at
+/// n = 0 and CR 702.24a's "for each age counter on it" leaves no cost instance
+/// to pay — the unless-effect resolves with no prompt and the count under test
+/// is never reached. The age assertion below pins that mechanism rather than
+/// leaving it to a comment.
+///
+/// One assertion is deliberately absent. "Aboroth has no -1/-1 counters" is
+/// vacuous on this board: Solemnity would prevent the placement anyway, and the
+/// shared add primitive reports a prevented placement as complete, so that
+/// assertion passes with the clamp and without it. The discriminators are the
+/// three assertions that the CHOICE survives.
+///
+/// Revert probe: reading the resolved quantity as `resolved.unsigned_abs()`
+/// makes the choice-time predicate preview a TWO-counter placement, Solemnity
+/// forbids it, the prompt is suppressed, and Aboroth is sacrificed — failing the
+/// prompt, legality, and `Zone::Battlefield` assertions.
+#[test]
+fn cumulative_upkeep_negative_counter_cost_quantity_stays_choosable_under_solemnity() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Untap);
+    scenario.add_enchantment_from_oracle(P0, "Solemnity", SOLEMNITY_ORACLE);
+    let aboroth = scenario
+        .add_creature_from_oracle(P0, "Aboroth", 9, 9, ABOROTH_ORACLE)
+        .id();
+    // A suppressed prompt would let the turn run into the Draw step; without a
+    // library P0 decks out and every P0 object is exiled, which would blur the
+    // reverted-direction failure. The library keeps that failure legible.
+    scenario.with_library_top(P0, &["Filler A", "Filler B", "Filler C"]);
+    let mut runner = scenario.build();
+    install_cumulative_upkeep_count(&mut runner, aboroth, hand_size_minus_two());
+    // CR 702.24a: the upkeep cost only materialises at >= 1 age counter, and
+    // Solemnity prevents the tick that would otherwise place the first one.
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&aboroth)
+        .expect("Aboroth exists")
+        .counters
+        .insert(CounterType::Age, 1);
+
+    assert!(
+        runner.state().players[P0.0 as usize].hand.is_empty(),
+        "the installed quantity resolves to -2 only while the payer's hand is empty"
+    );
+
+    runner.auto_advance_to_main_phase();
+    runner.advance_until_stack_empty();
+
+    // The mechanism this row rests on, asserted rather than assumed: Solemnity
+    // prevents the upkeep's own age-counter tick, so the total stays at the
+    // pre-installed 1 and the cost materialises from that one counter. A 2 here
+    // would mean the tick was not prevented and the cost scaled, which would make
+    // the prompt guard below assert against the wrong quantity.
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&aboroth)
+            .and_then(|object| object.counters.get(&CounterType::Age)),
+        Some(&1),
+        "Solemnity must prevent the age tick, leaving the pre-installed counter as the whole cost"
+    );
+
+    // CR 614.17b, discriminator (i): the prompt is emitted at all. With a positive
+    // count on this exact board it is not — that is the sibling row.
+    assert_unless_payment_carries_count(&runner, &hand_size_minus_two());
+
+    // CR 614.17b, discriminator (ii): the pay branch is offered.
+    let legal = engine::ai_support::legal_actions(runner.state());
+    assert!(
+        legal.contains(&GameAction::PayUnlessCost { pay: true }),
+        "a cost that places no counters includes no prohibited event, so paying \
+         must stay legal under Solemnity, got {legal:?}"
+    );
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("a cost that places no counters must remain choosable under Solemnity");
+    runner.advance_until_stack_empty();
+
+    // CR 702.24a, discriminator (iii): the cost was payable and paid, so the
+    // guarded "sacrifice it" never happens.
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&aboroth)
+            .map(|object| object.zone)
+            .expect("Aboroth remains a known object"),
+        Zone::Battlefield,
+        "a choosable, paid cumulative upkeep must not sacrifice Aboroth"
     );
 }

--- a/crates/engine/tests/integration/issue_7234_cumulative_upkeep_effect_cost.rs
+++ b/crates/engine/tests/integration/issue_7234_cumulative_upkeep_effect_cost.rs
@@ -601,8 +601,10 @@ fn cumulative_upkeep_negative_counter_cost_quantity_places_no_counters() {
 ///
 /// Revert probe: reading the resolved quantity as `resolved.unsigned_abs()`
 /// makes the choice-time predicate preview a TWO-counter placement, Solemnity
-/// forbids it, the prompt is suppressed, and Aboroth is sacrificed — failing the
-/// prompt, legality, and `Zone::Battlefield` assertions.
+/// forbids it, the prompt is suppressed, and Aboroth is sacrificed. The row
+/// aborts at the age-counter guard, which goes red because CR 122.2 cleared
+/// that counter with the sacrifice rather than because the tick ran; the three
+/// discriminators below it are unreachable in that direction.
 #[test]
 fn cumulative_upkeep_negative_counter_cost_quantity_stays_choosable_under_solemnity() {
     let mut scenario = GameScenario::new();

--- a/crates/engine/tests/integration/serpent_society_ward_poison_cost.rs
+++ b/crates/engine/tests/integration/serpent_society_ward_poison_cost.rs
@@ -317,7 +317,7 @@ fn serpent_society_ward_solemnity_makes_the_payment_unchoosable_and_counters_the
             .objects
             .get(&serpent_society)
             .is_some_and(|obj| obj.zone == engine::types::zones::Zone::Battlefield),
-        "a prevented player-counter payment must be treated as a FAILED cost, countering the targeting spell exactly like a declined payment — Serpent Society must survive"
+        "CR 614.17b: a payment whose own event can't happen is never chosen, so an unpaid Ward counters the targeting spell and Serpent Society survives"
     );
     assert!(
         !runner.state().stack.iter().any(|entry| entry.id == destroy),

--- a/crates/engine/tests/integration/serpent_society_ward_poison_cost.rs
+++ b/crates/engine/tests/integration/serpent_society_ward_poison_cost.rs
@@ -977,9 +977,9 @@ fn serpent_society_ward_mandatory_prohibition_wins_over_an_optional_replacement(
 /// P1 payer, so the Ward prompt is unaffected.
 ///
 /// Passes before and after the change by construction. It exists to fail if the
-/// partition is drawn wrong — an implementer widening `is_prohibited()` past
-/// `Prevented`, or reading the replacement definition directly instead of going
-/// through the previews and thereby dropping the player-scope check.
+/// partition is drawn wrong — an implementer reading the replacement definition
+/// directly instead of going through the previews, and thereby dropping the
+/// player-scope check.
 #[test]
 fn serpent_society_ward_prohibition_scoped_to_the_source_controller_leaves_the_payer_alone() {
     let mut scenario = GameScenario::new();

--- a/crates/engine/tests/integration/serpent_society_ward_poison_cost.rs
+++ b/crates/engine/tests/integration/serpent_society_ward_poison_cost.rs
@@ -13,10 +13,11 @@
 //!     ten or more poison counters loses the game (a separate SBA, not
 //!     exercised by this test).
 
+use engine::game::effects::player_counter::preview_player_counter_addition;
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::game::zones::create_object;
 use engine::types::ability::{
-    EffectKind, QuantityModification, ReplacementDefinition, ReplacementMode,
+    AbilityCost, EffectKind, QuantityModification, ReplacementDefinition, ReplacementMode,
     ReplacementPlayerScope,
 };
 use engine::types::actions::GameAction;
@@ -223,30 +224,32 @@ fn serpent_society_ward_payment_that_reaches_ten_poison_loses_the_game() {
 }
 
 /// CR 122.1 + CR 614.17 + CR 702.21a: Solemnity's "Players can't get
-/// counters" is a CR 614.17 can't-effect, not a CR 614.1 replacement, and it
-/// makes Ward's poison-counter cost a FAILED payment rather than a free bypass.
-/// Before this fix, `add_player_counter_with_replacement` reported `Prevented`
-/// as if it were a paid cost, so the targeting opponent's spell would
-/// incorrectly continue resolving even though no poison was actually given —
-/// nullifying Ward's entire deterrent for free.
+/// counters" is a CR 614.17 can't-effect, not a CR 614.1 replacement, so
+/// Ward's poison-counter cost includes an event that can't happen.
 ///
-/// CR 614.17c is why this row never reaches the deferred settle at all: an
-/// event that can't happen "can only be replaced by a self-replacement effect …
-/// Other replacement and/or prevention effects can't modify or replace it", so
+/// CR 614.17b: "If an event can't happen, a player can't choose to pay a cost
+/// that includes that event." The pay branch is therefore never offered — the
+/// engine suppresses the prompt rather than accepting the choice and failing
+/// the payment afterwards.
+///
+/// CR 614.17c is why no replacement prompt intervenes: an event that can't
+/// happen "can only be replaced by a self-replacement effect … Other
+/// replacement and/or prevention effects can't modify or replace it", so
 /// `replacement::pipeline_loop` short-circuits a MANDATORY prohibition ahead of
-/// any CR 616.1 ordering prompt. The payment is therefore decided synchronously
-/// inside `costs::pay_ability_cost_for_resolution` (CR 614.17b: a player can't
-/// pay a cost that includes an event that can't happen) and never parks. That
-/// is what makes this row the over-reach discriminator: if the payment ever did
-/// park, `resume_counter_addition_unless_payment` would settle it PAID under
-/// CR 118.12 and this row's premise would be wrong — so the synchronous settle
-/// is asserted below, not just the final board.
+/// any CR 616.1 ordering prompt and nothing parks.
+///
+/// CR 702.21a: the board outcome is unchanged by the seam move — an unpaid Ward
+/// still counters the targeting spell, and Serpent Society survives.
+///
+/// Revert probe: restoring the pay branch re-emits
+/// `WaitingFor::UnlessPayment { player: P1, cost: GetPlayerCounters }`, which
+/// fails the `Priority { player: P1 }` assertion.
 ///
 /// Solemnity's real Oracle text is "Players can't get counters." /
 /// "Counters can't be put on artifacts, creatures, enchantments, or lands." —
 /// only the first (relevant) sentence is used in this fixture.
 #[test]
-fn serpent_society_ward_payment_prevented_by_solemnity_counters_the_spell() {
+fn serpent_society_ward_solemnity_makes_the_payment_unchoosable_and_counters_the_spell() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     scenario
@@ -272,25 +275,36 @@ fn serpent_society_ward_payment_prevented_by_solemnity_counters_the_spell() {
         .commit();
     runner.advance_until_stack_empty();
 
-    runner
-        .act(GameAction::PayUnlessCost { pay: true })
-        .expect("attempting to pay Ward's poison-counter cost must be a legal action even when Solemnity prevents the actual counter gain");
+    // CR 614.17b: no unless-payment prompt is ever emitted for a payer whose
+    // payment would include an impossible event.
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { player } if player == P1),
+        "the prohibited pay branch must leave no unless-payment prompt, got {:?}",
+        runner.state().waiting_for
+    );
+    let legal = engine::ai_support::legal_actions(runner.state());
+    assert!(
+        !legal.contains(&GameAction::PayUnlessCost { pay: true }),
+        "paying Ward's poison-counter cost must not be legal under Solemnity, got {legal:?}"
+    );
+    // Control on the same vector: a dead `legal_actions` would satisfy the
+    // `!contains(pay: true)` assertion for the wrong reason.
+    assert!(
+        legal.contains(&GameAction::PassPriority),
+        "the action vector must still be live, got {legal:?}"
+    );
+    assert!(
+        runner.act(GameAction::PayUnlessCost { pay: true }).is_err(),
+        "submitting the refused choice directly must also be rejected"
+    );
 
     // CR 614.17c: a mandatory "players can't get counters" effect is
-    // short-circuited ahead of any CR 616.1 ordering prompt, so this payment is
-    // settled synchronously and never parks.
+    // short-circuited ahead of any CR 616.1 ordering prompt, so nothing parks.
     assert!(
         runner.state().pending_cost_move_resume.is_none(),
         "a mandatory can't-effect must not park a cost-move resume, got {:?}",
         runner.state().pending_cost_move_resume
     );
-    assert!(
-        matches!(runner.state().waiting_for, WaitingFor::Priority { player } if player == P1),
-        "the Solemnity-prevented payment settles synchronously, got {:?}",
-        runner.state().waiting_for
-    );
-
-    runner.advance_until_stack_empty();
 
     assert_eq!(
         runner.state().players[P1.0 as usize].poison_counters,
@@ -573,5 +587,475 @@ fn serpent_society_ward_optional_counter_prevention_declined_pays_the_cost_and_r
             .get(&serpent_society)
             .is_none_or(|obj| obj.zone != Zone::Battlefield),
         "a successfully paid Ward cost must let the targeted destroy spell resolve"
+    );
+}
+
+/// CR 702.21a: the single-variable partner of
+/// `serpent_society_ward_solemnity_makes_the_payment_unchoosable_and_counters_the_spell`
+/// — the identical board with Solemnity absent.
+///
+/// Reach guard, not a discriminator: it passes before and after the CR 614.17b
+/// change. Its job is to make that row's "no prompt / no `pay: true`"
+/// assertions non-vacuous, by showing this fixture does reach the prompt and
+/// does offer both branches when nothing forbids the counter event.
+#[test]
+fn serpent_society_ward_without_solemnity_offers_the_pay_branch() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let serpent_society = scenario
+        .add_creature_from_oracle(P0, "The Serpent Society", 3, 4, SERPENT_SOCIETY)
+        .id();
+    let destroy = scenario
+        .add_spell_to_hand_from_oracle(P1, "Destroy Spell", true, "Destroy target creature.")
+        .id();
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P1;
+        state.waiting_for = WaitingFor::Priority { player: P1 };
+    }
+
+    runner
+        .cast(destroy)
+        .target_objects(&[serpent_society])
+        .commit();
+    runner.advance_until_stack_empty();
+
+    assert!(
+        matches!(
+            &runner.state().waiting_for,
+            WaitingFor::UnlessPayment { player, cost, .. }
+                if *player == P1
+                    && matches!(
+                        cost,
+                        AbilityCost::GetPlayerCounters {
+                            counter_kind: PlayerCounterKind::Poison,
+                            count: 5,
+                        }
+                    )
+        ),
+        "with nothing prohibiting the counter event the Ward prompt must exist, got {:?}",
+        runner.state().waiting_for
+    );
+    let legal = engine::ai_support::legal_actions(runner.state());
+    assert!(
+        legal.contains(&GameAction::PayUnlessCost { pay: true }),
+        "the pay branch must be offered when the counter event can happen, got {legal:?}"
+    );
+    assert!(
+        legal.contains(&GameAction::PayUnlessCost { pay: false }),
+        "the decline branch must be offered too, got {legal:?}"
+    );
+
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("the opponent pays Ward's poison-counter cost");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().players[P1.0 as usize].poison_counters,
+        5,
+        "paying must give the targeting opponent five poison counters"
+    );
+    assert!(
+        runner
+            .state()
+            .objects
+            .get(&serpent_society)
+            .is_none_or(|obj| obj.zone != Zone::Battlefield),
+        "paying must let the targeted destroy spell resolve"
+    );
+}
+
+/// Installs a synthetic MANDATORY "players can't get counters" replacement on a
+/// fresh P0 permanent, scoped by `ReplacementPlayerScope`.
+///
+/// The mandatory sibling of `install_optional_player_counter_prevention`: every
+/// parameter is preserved verbatim except `mode` (`ReplacementMode::Mandatory`)
+/// and `valid_player` (`Some(scope)`). `valid_card` stays `None` for the reason
+/// that helper's doc records.
+///
+/// CR 614.17c: a MANDATORY prohibition is short-circuited by
+/// `replacement::pipeline_loop` ahead of any CR 616.1 ordering prompt, which is
+/// why these rows never reach a replacement choice.
+///
+/// `scope` is the typed axis rather than one helper per scope, so the `You` and
+/// `AnyPlayer` fixtures share one definition site.
+fn install_mandatory_player_counter_prevention(
+    state: &mut engine::types::game_state::GameState,
+    scope: ReplacementPlayerScope,
+) {
+    let source = create_object(
+        state,
+        CardId(9102),
+        P0,
+        "Mandatory Poison Warden".to_string(),
+        Zone::Battlefield,
+    );
+    let mut def = ReplacementDefinition::new(ReplacementEvent::AddCounter);
+    def.mode = ReplacementMode::Mandatory;
+    def.quantity_modification = Some(QuantityModification::Prevent);
+    def.valid_player = Some(scope);
+    let reps = vec![def];
+    let obj = state.objects.get_mut(&source).unwrap();
+    obj.replacement_definitions = reps.clone().into();
+    obj.base_replacement_definitions = Arc::new(reps);
+}
+
+/// Reaches the Ward prompt with nothing prohibiting the counter event, then
+/// installs a mandatory prohibition while the prompt is live.
+///
+/// CR 614.17a: a can't-effect must exist when the event occurs, so the answer
+/// is re-checked on the LIVE board rather than latched when the prompt was
+/// built. The prompt survives; only the pay branch is refused, and the decline
+/// branch stays legal (CR 118.12a).
+///
+/// Revert probe: without the reducer-side re-check, `PayUnlessCost { pay: true }`
+/// stays legal after the install and `act(pay: true)` returns `Ok`, failing both
+/// the `!legal.contains(pay: true)` and the `is_err()` assertions.
+#[test]
+fn serpent_society_ward_prohibition_arriving_mid_window_removes_the_pay_branch() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let serpent_society = scenario
+        .add_creature_from_oracle(P0, "The Serpent Society", 3, 4, SERPENT_SOCIETY)
+        .id();
+    let destroy = scenario
+        .add_spell_to_hand_from_oracle(P1, "Destroy Spell", true, "Destroy target creature.")
+        .id();
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P1;
+        state.waiting_for = WaitingFor::Priority { player: P1 };
+    }
+
+    runner
+        .cast(destroy)
+        .target_objects(&[serpent_society])
+        .commit();
+    runner.advance_until_stack_empty();
+
+    // Positive reach guard: the prompt exists before the prohibition arrives.
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::UnlessPayment { .. }),
+        "the fixture must reach the Ward prompt before the prohibition is installed, got {:?}",
+        runner.state().waiting_for
+    );
+    let legal_before = engine::ai_support::legal_actions(runner.state());
+    assert!(
+        legal_before.contains(&GameAction::PayUnlessCost { pay: true }),
+        "the pay branch must be offered before the prohibition arrives, got {legal_before:?}"
+    );
+
+    install_mandatory_player_counter_prevention(
+        runner.state_mut(),
+        ReplacementPlayerScope::AnyPlayer,
+    );
+
+    // CR 614.17a: the prompt itself survives — only the CHOICE is refused.
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::UnlessPayment { .. }),
+        "the prompt must survive a mid-window prohibition, got {:?}",
+        runner.state().waiting_for
+    );
+    let legal = engine::ai_support::legal_actions(runner.state());
+    assert!(
+        !legal.contains(&GameAction::PayUnlessCost { pay: true }),
+        "the pay branch must be refused on the live board, got {legal:?}"
+    );
+    // Control on the same vector: a member the mechanism must NOT remove.
+    assert!(
+        legal.contains(&GameAction::PayUnlessCost { pay: false }),
+        "the decline branch must stay legal (CR 118.12a), got {legal:?}"
+    );
+    assert!(
+        runner.act(GameAction::PayUnlessCost { pay: true }).is_err(),
+        "the reducer must refuse a pay choice that includes an impossible event"
+    );
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::UnlessPayment { .. }),
+        "the refused action must not consume the prompt, got {:?}",
+        runner.state().waiting_for
+    );
+
+    runner
+        .act(GameAction::PayUnlessCost { pay: false })
+        .expect("declining stays legal after the pay branch is refused");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().players[P1.0 as usize].poison_counters,
+        0,
+        "declining must give no poison counters"
+    );
+    assert!(
+        runner
+            .state()
+            .objects
+            .get(&serpent_society)
+            .is_some_and(|obj| obj.zone == Zone::Battlefield),
+        "an unpaid Ward must counter the targeting spell, so Serpent Society survives"
+    );
+    assert!(
+        !runner.state().stack.iter().any(|entry| entry.id == destroy),
+        "the countered spell must be removed from the stack"
+    );
+}
+
+/// CR 614.17c: two MANDATORY prohibitions on the same `AddCounter` event.
+///
+/// An event that can't happen "can only be replaced by a self-replacement
+/// effect", so `replacement::pipeline_loop` short-circuits ahead of the CR 616.1
+/// ordering step: two sources produce one refusal, never an ordering prompt.
+/// The single-source form of the same board is
+/// `serpent_society_ward_solemnity_makes_the_payment_unchoosable_and_counters_the_spell`,
+/// which is this row's single-variable control — if this row passed with two
+/// sources while that one failed with one, the gate would be counting sources
+/// rather than short-circuiting.
+#[test]
+fn serpent_society_ward_two_mandatory_prohibitions_still_refuse_once_without_ordering() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let serpent_society = scenario
+        .add_creature_from_oracle(P0, "The Serpent Society", 3, 4, SERPENT_SOCIETY)
+        .id();
+    let destroy = scenario
+        .add_spell_to_hand_from_oracle(P1, "Destroy Spell", true, "Destroy target creature.")
+        .id();
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P1;
+        state.waiting_for = WaitingFor::Priority { player: P1 };
+    }
+    install_mandatory_player_counter_prevention(
+        runner.state_mut(),
+        ReplacementPlayerScope::AnyPlayer,
+    );
+    install_mandatory_player_counter_prevention(
+        runner.state_mut(),
+        ReplacementPlayerScope::AnyPlayer,
+    );
+
+    runner
+        .cast(destroy)
+        .target_objects(&[serpent_society])
+        .commit();
+    runner.advance_until_stack_empty();
+
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { player } if player == P1),
+        "two mandatory prohibitions must leave the pay branch unchoosable, got {:?}",
+        runner.state().waiting_for
+    );
+    // CR 614.17c: no ordering prompt over an impossible event.
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::ReplacementChoice { .. }
+        ),
+        "a mandatory prohibition must short-circuit ahead of any CR 616.1 ordering, got {:?}",
+        runner.state().waiting_for
+    );
+    let legal = engine::ai_support::legal_actions(runner.state());
+    assert!(
+        !legal.contains(&GameAction::PayUnlessCost { pay: true }),
+        "the pay branch must not be offered, got {legal:?}"
+    );
+    assert!(
+        legal.contains(&GameAction::PassPriority),
+        "the action vector must still be live, got {legal:?}"
+    );
+
+    assert_eq!(
+        runner.state().players[P1.0 as usize].poison_counters,
+        0,
+        "no poison counters may be given"
+    );
+    assert!(
+        runner.state().pending_cost_move_resume.is_none(),
+        "nothing may park, got {:?}",
+        runner.state().pending_cost_move_resume
+    );
+    assert!(
+        runner
+            .state()
+            .objects
+            .get(&serpent_society)
+            .is_some_and(|obj| obj.zone == Zone::Battlefield),
+        "an unpaid Ward must counter the targeting spell"
+    );
+    assert!(
+        !runner.state().stack.iter().any(|entry| entry.id == destroy),
+        "the countered spell must be removed from the stack"
+    );
+}
+
+/// CR 614.17c: one MANDATORY and one OPTIONAL prohibition on the same
+/// `AddCounter` event — the mandatory one wins ahead of any choice.
+///
+/// Control: `serpent_society_ward_optional_counter_prevention_accepted_…` and
+/// `…_declined_…` show the same optional source ALONE parks and settles PAID
+/// under CR 118.12. Same board, same optional source, one variable — the
+/// mandatory sibling. So "no park" here is caused by the mandatory prohibition,
+/// not by the fixture failing to install anything.
+#[test]
+fn serpent_society_ward_mandatory_prohibition_wins_over_an_optional_replacement() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let serpent_society = scenario
+        .add_creature_from_oracle(P0, "The Serpent Society", 3, 4, SERPENT_SOCIETY)
+        .id();
+    let destroy = scenario
+        .add_spell_to_hand_from_oracle(P1, "Destroy Spell", true, "Destroy target creature.")
+        .id();
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P1;
+        state.waiting_for = WaitingFor::Priority { player: P1 };
+    }
+    install_mandatory_player_counter_prevention(
+        runner.state_mut(),
+        ReplacementPlayerScope::AnyPlayer,
+    );
+    install_optional_player_counter_prevention(runner.state_mut());
+
+    runner
+        .cast(destroy)
+        .target_objects(&[serpent_society])
+        .commit();
+    runner.advance_until_stack_empty();
+
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { player } if player == P1),
+        "the mandatory prohibition must make the pay branch unchoosable, got {:?}",
+        runner.state().waiting_for
+    );
+    // The optional park is never entered.
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::ReplacementChoice { .. }
+        ),
+        "the optional replacement must not be offered, got {:?}",
+        runner.state().waiting_for
+    );
+    assert!(
+        runner.state().pending_cost_move_resume.is_none(),
+        "the optional park must never be entered, got {:?}",
+        runner.state().pending_cost_move_resume
+    );
+    let legal = engine::ai_support::legal_actions(runner.state());
+    assert!(
+        !legal.contains(&GameAction::PayUnlessCost { pay: true }),
+        "the pay branch must not be offered, got {legal:?}"
+    );
+    assert!(
+        legal.contains(&GameAction::PassPriority),
+        "the action vector must still be live, got {legal:?}"
+    );
+
+    assert_eq!(
+        runner.state().players[P1.0 as usize].poison_counters,
+        0,
+        "no poison counters may be given"
+    );
+    assert!(
+        !runner.state().stack.iter().any(|entry| entry.id == destroy),
+        "the countered spell must be removed from the stack"
+    );
+}
+
+/// CR 614.17b + the replacement player-scope gate: a prohibition scoped
+/// `ReplacementPlayerScope::You` on a P0-controlled source bites P0, not the
+/// P1 payer, so the Ward prompt is unaffected.
+///
+/// Passes before and after the change by construction. It exists to fail if the
+/// partition is drawn wrong — an implementer widening `is_prohibited()` past
+/// `Prevented`, or reading the replacement definition directly instead of going
+/// through the previews and thereby dropping the player-scope check.
+#[test]
+fn serpent_society_ward_prohibition_scoped_to_the_source_controller_leaves_the_payer_alone() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let serpent_society = scenario
+        .add_creature_from_oracle(P0, "The Serpent Society", 3, 4, SERPENT_SOCIETY)
+        .id();
+    let destroy = scenario
+        .add_spell_to_hand_from_oracle(P1, "Destroy Spell", true, "Destroy target creature.")
+        .id();
+    let mut runner = scenario.build();
+    {
+        let state = runner.state_mut();
+        state.active_player = P1;
+        state.priority_player = P1;
+        state.waiting_for = WaitingFor::Priority { player: P1 };
+    }
+    install_mandatory_player_counter_prevention(runner.state_mut(), ReplacementPlayerScope::You);
+
+    // Paired reach guard: the prohibition really was installed AND really does
+    // bite somebody — its partner is the same call for the payer.
+    assert!(
+        preview_player_counter_addition(runner.state(), P0, P0, PlayerCounterKind::Poison, 5)
+            .is_prohibited(),
+        "a `You`-scoped prohibition on a P0 source must bite P0"
+    );
+    assert!(
+        !preview_player_counter_addition(runner.state(), P1, P1, PlayerCounterKind::Poison, 5)
+            .is_prohibited(),
+        "a `You`-scoped prohibition on a P0 source must not bite P1"
+    );
+
+    runner
+        .cast(destroy)
+        .target_objects(&[serpent_society])
+        .commit();
+    runner.advance_until_stack_empty();
+
+    assert!(
+        matches!(
+            &runner.state().waiting_for,
+            WaitingFor::UnlessPayment { player, cost, .. }
+                if *player == P1
+                    && matches!(
+                        cost,
+                        AbilityCost::GetPlayerCounters {
+                            counter_kind: PlayerCounterKind::Poison,
+                            count: 5,
+                        }
+                    )
+        ),
+        "P1 must still be prompted, got {:?}",
+        runner.state().waiting_for
+    );
+    let legal = engine::ai_support::legal_actions(runner.state());
+    assert!(
+        legal.contains(&GameAction::PayUnlessCost { pay: true }),
+        "the pay branch must still be offered to the unaffected payer, got {legal:?}"
+    );
+
+    runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("the unaffected payer may pay Ward's cost");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().players[P1.0 as usize].poison_counters,
+        5,
+        "paying must give the unaffected payer five poison counters"
+    );
+    assert!(
+        runner
+            .state()
+            .objects
+            .get(&serpent_society)
+            .is_none_or(|obj| obj.zone != Zone::Battlefield),
+        "paying must let the targeted destroy spell resolve"
     );
 }

--- a/crates/engine/tests/integration/serpent_society_ward_poison_cost.rs
+++ b/crates/engine/tests/integration/serpent_society_ward_poison_cost.rs
@@ -16,9 +16,11 @@
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::game::zones::create_object;
 use engine::types::ability::{
-    QuantityModification, ReplacementDefinition, ReplacementMode, ReplacementPlayerScope,
+    EffectKind, QuantityModification, ReplacementDefinition, ReplacementMode,
+    ReplacementPlayerScope,
 };
 use engine::types::actions::GameAction;
+use engine::types::events::GameEvent;
 use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::CardId;
 use engine::types::phase::Phase;
@@ -221,14 +223,28 @@ fn serpent_society_ward_payment_that_reaches_ten_poison_loses_the_game() {
 }
 
 /// CR 122.1 + CR 614.17 + CR 702.21a: Solemnity's "Players can't get
-/// counters" replacement must make Ward's poison-counter cost a FAILED
-/// payment, not a free bypass. Before this fix, `add_player_counter_with_
-/// replacement` reported `Prevented` as if it were a paid cost, so the
-/// targeting opponent's spell would incorrectly continue resolving even
-/// though no poison was actually given — nullifying Ward's entire deterrent
-/// for free. Solemnity's real Oracle text is "Players can't get counters.
-/// Prevent all damage that would be dealt to permanents by sources with
-/// counters on them." — only the first (relevant) sentence is used here.
+/// counters" is a CR 614.17 can't-effect, not a CR 614.1 replacement, and it
+/// makes Ward's poison-counter cost a FAILED payment rather than a free bypass.
+/// Before this fix, `add_player_counter_with_replacement` reported `Prevented`
+/// as if it were a paid cost, so the targeting opponent's spell would
+/// incorrectly continue resolving even though no poison was actually given —
+/// nullifying Ward's entire deterrent for free.
+///
+/// CR 614.17c is why this row never reaches the deferred settle at all: an
+/// event that can't happen "can only be replaced by a self-replacement effect …
+/// Other replacement and/or prevention effects can't modify or replace it", so
+/// `replacement::pipeline_loop` short-circuits a MANDATORY prohibition ahead of
+/// any CR 616.1 ordering prompt. The payment is therefore decided synchronously
+/// inside `costs::pay_ability_cost_for_resolution` (CR 614.17b: a player can't
+/// pay a cost that includes an event that can't happen) and never parks. That
+/// is what makes this row the over-reach discriminator: if the payment ever did
+/// park, `resume_counter_addition_unless_payment` would settle it PAID under
+/// CR 118.12 and this row's premise would be wrong — so the synchronous settle
+/// is asserted below, not just the final board.
+///
+/// Solemnity's real Oracle text is "Players can't get counters." /
+/// "Counters can't be put on artifacts, creatures, enchantments, or lands." —
+/// only the first (relevant) sentence is used in this fixture.
 #[test]
 fn serpent_society_ward_payment_prevented_by_solemnity_counters_the_spell() {
     let mut scenario = GameScenario::new();
@@ -259,6 +275,21 @@ fn serpent_society_ward_payment_prevented_by_solemnity_counters_the_spell() {
     runner
         .act(GameAction::PayUnlessCost { pay: true })
         .expect("attempting to pay Ward's poison-counter cost must be a legal action even when Solemnity prevents the actual counter gain");
+
+    // CR 614.17c: a mandatory "players can't get counters" effect is
+    // short-circuited ahead of any CR 616.1 ordering prompt, so this payment is
+    // settled synchronously and never parks.
+    assert!(
+        runner.state().pending_cost_move_resume.is_none(),
+        "a mandatory can't-effect must not park a cost-move resume, got {:?}",
+        runner.state().pending_cost_move_resume
+    );
+    assert!(
+        matches!(runner.state().waiting_for, WaitingFor::Priority { player } if player == P1),
+        "the Solemnity-prevented payment settles synchronously, got {:?}",
+        runner.state().waiting_for
+    );
+
     runner.advance_until_stack_empty();
 
     assert_eq!(
@@ -289,6 +320,28 @@ fn serpent_society_ward_payment_prevented_by_solemnity_counters_the_spell() {
 /// so the real Ward -> `GetPlayerCounters` -> `add_player_counter_with_
 /// replacement` -> `replace_event` path discovers it naturally (a production
 /// setup, not a hand-constructed `WaitingFor`).
+///
+/// Why synthetic, stated as a predicate rather than a card list: no printed card
+/// produces an OPTIONAL `AddCounter` replacement. Every definition matching
+/// `event == "AddCounter"` in `client/public/card-data.json` is `Mandatory`
+/// (33 of 33 at time of writing; regenerate with
+/// `jq '[.[] | (.replacements // [])[] | select(.event=="AddCounter") | .mode.type] | group_by(.) | map({m:.[0],n:length})' client/public/card-data.json`).
+/// Combined with CR 614.17c — which short-circuits every MANDATORY prohibition
+/// ahead of the CR 616.1 prompt — this synthetic definition is the only route to
+/// `CostMoveDrainBoundary::ReplacementPrevented` at the counter-addition resume
+/// root, which is real-card-dead today.
+///
+/// The field set is load-bearing, and this is the single site that owns the
+/// reason. `object_replacement_candidate_applies` (`game/replacement.rs`)
+/// consults `repl_def.valid_card` for EVERY event kind, including player
+/// placements, whenever it is `Some`; `replacement_valid_card_matches` resolves
+/// an `AddCounter` event through `ProposedEvent::affected_object_id`, which is
+/// `CounterPlacement::object_id` — `None` for a player placement — and then
+/// `.unwrap_or(false)`. So a definition carrying a `valid_card` filter is
+/// EXCLUDED from a player counter placement, and the candidate predicate for
+/// this fixture's event is `valid_player.is_some() && valid_card.is_none()`
+/// (plus the counter-type matcher, the condition, and the mode). `valid_card` is
+/// therefore left `None` here deliberately, not by omission.
 fn install_optional_player_counter_prevention(state: &mut engine::types::game_state::GameState) {
     let source = create_object(
         state,
@@ -319,11 +372,27 @@ fn install_optional_player_counter_prevention(state: &mut engine::types::game_st
 /// guarded "counter the spell" outcome permanently undetermined: the
 /// targeting spell was neither countered nor allowed to resolve.
 ///
-/// Accept branch: the optional replacement prevents the counter placement
-/// (`PlayerCounterAdditionOutcome::Prevented`) — a FAILED Ward payment, so the
-/// targeting spell must be countered, exactly like the Solemnity test above.
+/// Accept branch, and the discriminating `ReplacementPrevented` case: the payer
+/// ACCEPTS the optional prevention, so the counter placement is completely
+/// replaced (CR 614.6 — "if an event is replaced, it never happens") and zero
+/// poison counters are given.
+///
+/// CR 118.12 is why the Ward cost is nevertheless PAID: the "if they don't"
+/// clause "checks whether the player chose to pay an optional cost … regardless
+/// of what events actually occurred", and that choice was latched at
+/// `PayUnlessCost { pay: true }` — before the replacement pipeline was ever
+/// consulted. CR 118.11 corroborates: a cost whose payment actions were modified
+/// is still paid. So the targeting spell RESOLVES and Serpent Society dies.
+///
+/// This fixture — not the Solemnity row above — is the only route to
+/// `CostMoveDrainBoundary::ReplacementPrevented` at the counter-addition resume
+/// root. Solemnity's MANDATORY can't-effect is short-circuited by CR 614.17c
+/// before any CR 616.1 prompt exists, so it is settled synchronously in
+/// `costs.rs` (CR 614.17b) and never parks. Only an OPTIONAL prevention that the
+/// payer accepts can carry a prevented placement into this resume.
 #[test]
-fn serpent_society_ward_optional_counter_prevention_accepted_counters_the_spell() {
+fn serpent_society_ward_optional_counter_prevention_accepted_still_pays_the_ward_cost_and_resolves_the_spell(
+) {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     let serpent_society = scenario
@@ -373,27 +442,48 @@ fn serpent_society_ward_optional_counter_prevention_accepted_counters_the_spell(
         "an Optional replacement offers accept (0) and decline (1)"
     );
 
-    runner
+    let result = runner
         .act(GameAction::ChooseReplacement { index: 0 })
         .expect("accepting the optional prevention must be a legal replacement choice");
+
     runner.advance_until_stack_empty();
 
     assert_eq!(
         runner.state().players[P1.0 as usize].poison_counters,
         0,
-        "the accepted prevention must stop the poison counters from being given"
+        "CR 614.6: the accepted prevention must stop the poison counters from being given"
     );
+    // The maintainer's required discriminator: the payer chose to pay, so under
+    // CR 118.12 the Ward cost is PAID even though the placement was replaced away.
+    // Before the fix this arm mapped `ReplacementPrevented` to a failed payment
+    // and countered the spell instead.
     assert!(
         runner
             .state()
             .objects
             .get(&serpent_society)
-            .is_some_and(|obj| obj.zone == Zone::Battlefield),
-        "a prevented player-counter payment must be treated as a FAILED cost, countering the targeting spell — Serpent Society must survive"
+            .is_none_or(|obj| obj.zone != Zone::Battlefield),
+        "CR 118.12: a prevented placement on a chosen-to-pay cost is still a PAID cost — the targeting spell must resolve and remove Serpent Society from the battlefield"
     );
     assert!(
         !runner.state().stack.iter().any(|entry| entry.id == destroy),
-        "the countered spell must be removed from the stack, not left stranded"
+        "the targeting spell must leave the stack by RESOLVING, not be left stranded"
+    );
+
+    // CR 118.12: the resume settles through the PAID epilogue, so Ward's guarded
+    // ability finishes resolving and the whole reducer step's event buffer
+    // survives instead of being discarded by the decline tail. Asserted on the
+    // events captured from the `ChooseReplacement` act above.
+    assert!(
+        result.events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: EffectKind::Counter,
+                ..
+            }
+        )),
+        "a paid Ward cost must emit the guarded ability's EffectResolved, got {:?}",
+        result.events
     );
 }
 
@@ -436,9 +526,39 @@ fn serpent_society_ward_optional_counter_prevention_declined_pays_the_cost_and_r
         );
     };
 
-    runner
+    let result = runner
         .act(GameAction::ChooseReplacement { index: 1 })
         .expect("declining the optional prevention must be a legal replacement choice");
+
+    // CR 118.12: the deferred paid settle must emit exactly what the immediate
+    // paid leg emits — the counters the payer actually took, and the guarded
+    // ability's completion. Before the fix this reducer step returned NO events
+    // at all: the resume routed through the decline tail, whose `ActionResult` is
+    // discarded while `action_result` has already drained the event buffer.
+    assert!(
+        result.events.iter().any(|event| matches!(
+            event,
+            GameEvent::PlayerCounterChanged {
+                player,
+                counter_kind: PlayerCounterKind::Poison,
+                delta: 5,
+            } if *player == P1
+        )),
+        "the poison counters the payer actually took must reach the event log, got {:?}",
+        result.events
+    );
+    assert!(
+        result.events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: EffectKind::Counter,
+                ..
+            }
+        )),
+        "a paid Ward cost must emit the guarded ability's EffectResolved, got {:?}",
+        result.events
+    );
+
     runner.advance_until_stack_empty();
 
     assert_eq!(


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Two rounds, one seam. The first fixed a *settle* mapping; the maintainer's second review expanded it into the
rule that governs the whole prompt: **CR 614.17b — "If an event can't happen, a player can't choose to pay a
cost that includes that event."** Both are in here.

**Round 1 — the settle.** `resume_counter_addition_unless_payment` mapped
`CostMoveDrainBoundary::ReplacementPrevented` to a failed payment. CR 118.12 says the opposite: an "unless that
player pays" cost checks whether the player *chose* to pay, "regardless of what events actually occurred", and
CR 118.11 adds that a cost is still paid when a replacement modifies the actions performed to pay it. A player
who accepted the prompt and then had the placement replaced has paid. Both replacement boundaries now settle
through `finish_successful_unless_payment`. That also fixed a live and completely silent defect: the resume
discarded the `ActionResult` returned by `finish_unless_payment` after `action_result` had already
`std::mem::take`n the event buffer, so a parked counter payment emitted nothing at all — no `CounterAdded`, no
`EffectResolved`, nothing for the event log, the game log or the animation layer.

**Round 2 — the choice.** Settling a *paid* payment correctly does not help if the prompt should never have
offered the pay branch. A mandatory can't-effect makes the pay branch unavailable **at choice time**, not a
payment that fails later. This adds the missing predicate and wires it at the two scopes that lacked it:

- `costs::resolution_cost_includes_impossible_event` — a new `pub(crate)` predicate that answers, for one payer
  and one cost, "does paying this require an event a can't-effect forbids?" It matches `AbilityCost`
  **exhaustively with no wildcard arm**, so a new cost shape fails to compile here rather than silently
  answering "no impossible event". `Composite` uses `.any()` (CR 601.2h: partial payments are not allowed, so
  one impossible sub-cost poisons the whole); `OneOf` uses `.all()` (a disjunction is refused only when every
  branch is impossible).
- `effects/mod.rs` — the CR 118.12a poll's **head** is now the first payer for whom paying does not require an
  impossible event. When nobody qualifies, control falls out of the chain and the unless-effect resolves,
  exactly as the CR 118.6 unpayable-cost branch in that same chain already does. Only the head is filtered, and
  `remaining` receives the untouched **positional** tail, so a prohibition that lifts mid-window cannot have
  silently dropped a later payer — `finish_unless_payment` re-asks the question live at each re-emit
  (CR 614.17a).
- `PlayerCounterAdditionPreview::is_prohibited` / `CounterAdditionPreview::is_prohibited` — one named accessor
  each, and the player-counter one owns the partition's prose. `true` only for `Prevented`, a *mandatory*
  `QuantityModification::Prevent` that `replacement::pipeline_loop` short-circuits ahead of any replacement
  choice per CR 614.17c. Deliberately `false` for `ChoiceRequired`, `Transformed` and `Unsupported`: those are
  replacements that merely **modify** an otherwise chosen payment (CR 118.11), so they stay payable, park, and
  settle paid through round 1's fix (CR 118.12). Those two accessors are the single place that partition is
  decided; before this change the same test was open-coded at the call sites with no name.

**Round 3 — the count.** Maintainer review of the pushed head found that `counter_cost_count` mapped a negative
resolved `QuantityExpr` through `unsigned_abs()`, so a cost whose quantity resolved to `-N` placed **N** counters
and could be refused under a counter prohibition. CR 107.1b requires zero when a calculation that determines the
result of an effect yields a negative number, and a counter count is in none of that rule's exception classes.
The resolver really reaches this: `Offset` is an unfloored `inner + offset` and `Multiply` carries a signed
factor, so any cost quantity whose dynamic inner falls below its offset arrives negative. `ClampMin` is the
*expression-level* opt-in to the same rule, which a cost consumer cannot assume was used. The helper now clamps
with `.max(0)` — the idiom every other resolved-quantity consumer in that file already applies, which is what
made the counter path the lone outlier rather than the house style.

Two rows drive a negative resolved quantity through the real unless-payment path rather than asserting on the
helper: one pins the payment site, one the choice-time predicate on a board where a prohibition is live. Both are
red against `unsigned_abs()`. The cost shape is synthetic and says so — no printed card's counter cost resolves
negative — so the rows pin a rules-correct behaviour rather than implying a card reaches it.

The earlier revision of this branch declined the round-1 change on the grounds that this root and the immediate,
unpaused leg in `costs::pay_ability_cost_for_resolution` map one boundary vocabulary and must agree. They do not
have to, because they never see the same inputs. CR 614.17c is the partition: `pipeline_loop` short-circuits a
counter-placement event to prevented before any CR 616.1 prompt when the applicable replacement is mandatory,
and its predicate ends `&& !replacement_mode_is_optional(&def.mode)`. A mandatory can't-effect settles
synchronously and never parks; only an optional replacement reaches this root. The immediate leg sees
can't-effects and correctly reports them unpaid; this root sees replacements and correctly reports them paid.

The typed boundary parameter, the exhaustive match and the `PriorityBoundary` `unreachable!` all stay. The match
is no longer a verdict; it is an eligibility assertion, so a fourth variant or a widened eligibility table still
fails to compile here rather than silently picking an answer — and the `unreachable!` premise, which nothing in
the crate pinned, now has a guard row of its own
(`a_parked_counter_addition_unless_payment_is_never_drained_at_the_priority_boundary`). It pins the *guard*, not
the panic: a `#[should_panic]` row would assert the panic is reachable, which is the inverse of the invariant.

### The activation scope, disclosed plainly

`PaymentScope::Activation` never consults the new predicate. `is_payable_for_activation` admits every
`EffectCost` unconditionally, and `can_pay` dry-runs the payment arm instead — so for an activated ability whose
cost is `EffectCost { PutCounter { SelfRef } }` (Wall of Roots and its class), the refusal inside that arm in
`pay_ability_cost_inner` is **the only CR 614.17b gate the cost meets**. That arm is pre-existing; this round
folded it onto the new `counter_cost_count` helper, and the review found it labelled "defense in depth" — a
label that would have made it cheap to delete. It is now labelled for what it is, **and it is pinned**:
`activation_self_counter_cost_under_solemnity_is_refused` asserts the ability is payable on a clean board,
unpayable once Solemnity is out, and that `pay_ability_cost_for_activation` returns `Err(ActionNotAllowed)`.
Neutering the arm to `let prevented = false` turns that row red — measured in both directions, not asserted.

That row drives the payment authority directly rather than a `GameAction::ActivateAbility` through `apply()`, so
it does not additionally pin the call sites' wiring. Stated as a limit of the row rather than smoothed over.

### On the reconciliation asked for at `engine_payment_choices.rs:2095-2110`

The rule, once: CR 118.12 with CR 118.11 — the cost is paid when the player chose to pay, whatever the
replacement did to the resulting events.

Both roots now implement it. `resume_random_discard_unless_payment` already did, and the cited lines are that
statement: it takes no boundary argument by design, because the replacement's outcome deliberately does not
decide whether the cost was paid. This change makes `resume_counter_addition_unless_payment` agree, evidenced by
the renamed ward row and by the cumulative-upkeep row below. The other two unless-payment roots,
`resume_ward_sacrifice_payment` and `resume_unless_bounce_cost_move`, already settle paid regardless of
boundary, so all four now converge.

`:2095-2110` itself is not edited, on purpose: threading the boundary into the random-discard root is precisely
the change that shipped the Balduvian Horde bug, and the comment there exists to prevent its return. The
historical sentence in that doc that named a mapping this round removes is corrected in place rather than left
to a follow-up.

## Files changed

- `crates/engine/src/game/costs.rs` — the new `resolution_cost_includes_impossible_event` predicate (exhaustive,
  no wildcard); the `counter_cost_count` helper the activation arm folds onto, clamped at zero per CR 107.1b;
  the activation-scope refusal's doc; unit rows for the predicate's `Composite`/`OneOf` shapes and for the
  activation refusal
- `crates/engine/src/game/engine_payment_choices.rs` — round 1's settle fix and its doc header; the payability
  wiring at the prompt roots
- `crates/engine/src/game/effects/mod.rs` — the CR 118.12a poll head skips payers whose payment would require an
  impossible event
- `crates/engine/src/game/effects/player_counter.rs` — `PlayerCounterAdditionPreview::is_prohibited`, the
  authority for the prohibition partition
- `crates/engine/src/game/effects/counters.rs` — `CounterAdditionPreview::is_prohibited`, its object-counter
  sibling
- `crates/engine/src/game/effects/pay.rs` — the resolution pre-gate's doc, and its failure literal renamed
  `not affordable (pre-gate)` → `not payable (pre-gate)`, because the pre-gate now refuses impossible events and
  not only unaffordable ones
- `crates/engine/src/game/engine.rs` — the typed `CostMoveDrainBoundary` is passed into the resume instead of a
  derived bool; the eligibility table's comment; a new guard row for the `PriorityBoundary` `unreachable!`
- `crates/engine/src/types/game_state.rs` — comment only: the parked variant's doc, including which of its
  fields any resume path actually reads
- `crates/engine/tests/integration/serpent_society_ward_poison_cost.rs` — the prevented-placement regression and
  the CR 614.17b prompt rows
- `crates/engine/tests/integration/issue_7234_cumulative_upkeep_effect_cost.rs` — the second park site, its
  Solemnity refusal row, and the two negative-quantity rows

## Track

Developer

## LLM

Model: Claude Opus 5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

Added or touched: `CR 104.3d`, `CR 107.1b`, `CR 117.1d`, `CR 118.1`, `CR 118.2`, `CR 118.5`, `CR 118.6`,
`CR 118.11`, `CR 118.12`, `CR 118.12a`, `CR 119.8`, `CR 122.1`, `CR 122.2`, `CR 601.2h`, `CR 614.1`,
`CR 614.6`, `CR 614.17`, `CR 614.17a`, `CR 614.17b`, `CR 614.17c`, `CR 616.1`, `CR 702.21a`, `CR 702.24a`.

Every one was grepped in `docs/MagicCompRules.txt` and each rule's *subject* read against the claim it anchors,
not merely confirmed to exist. Two controls, because a bad instrument here fails toward reassurance: liveness
first (`wc -l` 9359, `^704.5a` → 2 hits, `^999.999` → 0 hits), and then the predicate itself — the obvious
`^<number> ` misses every top-level rule, which prints as `118.1.` with a trailing period, so the sweep runs
`^<number>[. ]` with its negative control re-run on the widened form (`^999\.9[. ]` → 0). All 23 listed above resolve, one hit each.

`CR 118.3` is retracted in three places and re-cited nowhere. It is the *resources* rule — a player can't pay a
cost without the resources to pay it — and it says nothing about a payment whose event a replacement modified,
nor about one a can't-effect forbids. `CR 118.1` carries the effect-as-cost claim; `CR 614.17b` with
`CR 614.17c` carries the can't-effect refusal.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the reviewed head `ccd58ed9c`. The committed head differs from it
      by a rebase only: all ten changed files are byte-identical across it (measured, with a control), and
      the full verification suite was re-run at the committed head rather than inherited.
- [x] Both anchors cite existing analogous code at the same seam.

Run in an isolated detached worktree at the committed head, never in the Tilt-owned checkout, with an isolated
`CARGO_HOME`/`CARGO_TARGET_DIR` and `CARGO_INCREMENTAL=0`. The job stamps `HEAD`, `PWD` and a tracked-dirty
count before it starts — `HEAD=fcf6fec60 … dirty=0` — so these cannot be results for a different or a modified
tree. Every leg below was re-run from scratch at `fcf6fec60`; nothing was inherited from the head before it. The
branch was then rebased again onto `4849e5123` — a CI-and-docs-only commit touching no crate — giving `f35fa163f`,
across which all ten changed files are again byte-identical (measured). That second rebase was made to refresh
the parse-diff artifact against a moving baseline, and changed no file this suite exercises.

- `cargo fmt --all -- --check` — `FMT_EXIT=0`. A clean run writes nothing, so that exit code alone cannot be
  told apart from "never ran"; the same checker was therefore run in the same job over a deliberately
  misformatted **copy of this candidate's own `costs.rs`**, taken with `git show fcf6fec60:…` — `FMTCTL_EXIT=1`.
  The control ran on a copy outside the worktree, never on a tracked file.
- `cargo clippy --workspace --all-targets -- -D warnings` — `CLIPPY_EXIT=0`, `Finished dev profile … in 9m 49s`,
  with its own `Compiling phase-engine` line in that run's log (`--all-targets` builds the test targets, so the
  engine compiles rather than merely being checked).
- `cargo test -p phase-engine --lib` — `ok. 19607 passed; 0 failed; 6 ignored; 0 filtered out; finished in
  51.78s`, `LIB_EXIT=0`.
- `cargo test -p phase-engine --test integration` (full, unfiltered) — `ok. 5381 passed; 0 failed; 2 ignored;
  0 filtered out; finished in 485.57s`, `INTEG_EXIT=0`.
- `cargo test -p phase-ai` — `AI_EXIT=0`, 19 result rows, every one `ok`, 2198 passed and 0 failed in total;
  largest row `ok. 2097 passed; 0 failed; 8 ignored`. Zero `test result: FAILED` in any of the three test logs,
  with a positive control confirming that pattern can match.

`HEAD` was re-checked after the job and still read `fcf6fec6090e05a70732701dc0da01381224e565` with a
tracked-dirty count of 0, so no leg straddled a moving or edited tree. Each log was also confirmed to name this
worktree's own path, because `/tmp` is shared with other lanes on this machine and a stale file there would
otherwise read as a result.

**The evidence that matters is not that the new rows pass — it is that they fail without the fix.** Each was run
against a tree with the production change reverted and the tests kept, and each mutation was restored
byte-exactly (sha256 of the restored file compared against the recorded baseline) before the next run:

| Production mutation (tests kept, restored byte-exactly after) | `--lib` | `--test integration` |
|---|---|---|
| Round 1's settle reverted (`Prevented` → failed payment) | — | the two ward rows and the Aboroth ordering row FAIL, two of them reporting `got []` |
| Both `is_prohibited()` accessors widened to admit `ChoiceRequired` | `ok. 19558; 0 failed` — **no lib row sits on this side, which is itself the measurement** | `FAILED. 5364 passed; 3 failed` — the two optional-prevention ward rows (player-counter accessor) and the Aboroth two-replacement row (object-counter accessor) |
| `counter_cost_count`'s body → `0` | `FAILED. 19557 passed; 1 failed` — `wall_of_roots_effect_cost_adds_green` | `FAILED. 5364 passed; 3 failed` — three Aboroth rows |
| The predicate's grouped 27-variant `=> false` arm → `=> true` | `FAILED. 19510 passed; 48 failed` across 4 modules | `FAILED. 5316 passed; 51 failed` across 22 files |
| The activation arm's `self_counter_placement_is_prohibited(…)` → `false` | `FAILED. 0 passed; 1 failed` — `activation_self_counter_cost_under_solemnity_is_refused` | — |
| *(unmutated candidate)* | `ok. 19559 passed; 0 failed` | `ok. 5367 passed; 0 failed` |

The fourth row is **deliberately over-broad** and is reported as such: inverting a whole catch-all makes every
non-counter unless-cost answer "includes an impossible event", so its 99 reddened rows measure the predicate's
runtime reach, not 99 discriminators for this change. The rows that discriminate this change are the other four.
`serpent_society_ward_solemnity_makes_the_payment_unchoosable_and_counters_the_spell` is the one that must
**not** move under round 1's mutation: Solemnity is a mandatory can't-effect, it never reaches that resume, and
it must keep countering the spell. Green on both sides is the evidence round 1 did not over-reach into the
can't-effect path.

Those revert probes ran in a separate isolated worktree rather than through Tilt, because Tilt watches a
different checkout and continuously rebuilds it; a mutation probe needs a tree that nothing else is rebuilding,
and a restore that preserves mtime would let cargo skip the rebuild and re-run the mutated binary. Each
mutation was authored against the code as it stood at that probe's tip and is named here by the state it
produced, not the state it replaced — this PR's own clamp rewrote one of the mutated bodies mid-round. Every probe
log is checked for its own `Compiling phase-engine` line for that reason, and every "0 occurrences" claim in
this PR carries a positive control proving the instrument can see a hit.

**(a) The requested prevented-placement regression** asserts the targeting spell resolves and removes the
permanent, and that `poison == 0` still holds — the counters really were prevented (CR 614.6) and the cost was
still paid (CR 118.12).

**(b) The second park site.** The same mapping is reached from `AbilityCost::EffectCost`, where the guarded
effect is a cumulative upkeep's "sacrifice it". That site had no coverage at all. The new row drives Aboroth's
upkeep with Vorinclex and Doc Samson both applicable, so the CR 616.1 ordering prompt is real rather than
synthetic, and asserts the sacrifice resolves under either ordering while the counter totals correctly differ.
Assertions are by membership, not position, because the two `ReplacementApplied` events arrive in the order the
payer chose.

**(c) The silent-settle reproduction.** Measured on printed cards at both park sites and both replacement
orderings: **0 events before the fix, 4 after** — `ReplacementApplied` ×2, `CounterAdded`, and
`EffectResolved{Sacrifice}`. The two ward rows independently reported `got []` at the unfixed tree.

**(d) The CR 614.17b prompt rows.** Both scopes, and both directions at each:
`serpent_society_ward_without_solemnity_offers_the_pay_branch` is the reach guard for
`…solemnity_makes_the_payment_unchoosable_and_counters_the_spell`;
`…two_mandatory_prohibitions_still_refuse_once_without_ordering` pins that a second prohibition does not turn
the refusal into a CR 616.1 ordering prompt; `…prohibition_arriving_mid_window_removes_the_pay_branch` covers
the CR 614.17a live re-ask; `…prohibition_scoped_to_the_source_controller_leaves_the_payer_alone` pins the
player-scope check; `aboroth_with_an_age_counter_under_solemnity_cannot_choose_to_pay` is the same rule at the
`EffectCost` park site; `activation_self_counter_cost_under_solemnity_is_refused` is the activation scope.

**(e) On the review feedback.** The maintainer's round-1 `[HIGH]` and CodeRabbit's Major are the same finding,
and the fix implements CodeRabbit's posted patch — three-arm match retained, `PriorityBoundary` still
`unreachable!`, both replacement arms settling through `finish_successful_unless_payment`. Its second claim,
that the `ReplacementDelivered` path was already silently skipping the paid epilogue, reproduces: see (c). The
maintainer's round-2 blocker — a mandatory can't-effect must make the pay branch unavailable at choice time — is
the whole of round 2 above. Nothing was declined.

**The prevented arm of the settle is not reachable by any printed card today** — every printed `AddCounter`
replacement definition surveyed is mandatory, so no printed card reaches it through a prompt. The
optional-prevention row covers it with a synthetic warden; the cumulative-upkeep row covers the same fix on a
path printed cards do reach. Both are stated plainly rather than one standing in for the other.

## Gate A

Gate A PASS head=f35fa163ff060980e06828e9cfa55464f3325e43 base=4849e5123325b9380fa3c68a7a33111248f4a409

**This PASS is vacuous, and saying so is the point.** Gate A scopes to `crates/engine/src/parser`, and this
change touches zero files there, so the gate's input set is empty by construction rather than by the gate
looking and finding nothing. The instrument prints `PASS` either way, so the count is measured separately and
with a control: `git diff --name-only 4849e5123 f35fa163f -- crates/engine/src/parser/` → **0 files**; the same
command over a range that does touch the parser (base 80 commits earlier on `main`) → **24 files**, and the gate
still passes there. The instrument works and can see parser files; it simply has nothing to say about this
change.

## Anchored on

- `crates/engine/src/game/life_costs.rs:186` — `can_pay_life_cast_or_activation_cost` consults the named
  predicate `player_cant_pay_life_as_cost` (`game/static_abilities.rs:1388`) *before* the choice rather than
  letting the payment fail afterwards: the existing CR 614.17b-shaped refusal in this engine.
  `resolution_cost_includes_impossible_event` is that same shape generalized to the counter-placing cost shapes.
- `crates/engine/src/game/engine_payment_choices.rs:2204` — `resume_random_discard_unless_payment`, the sibling root
  drained at the same boundaries, which already settles paid regardless of boundary per CR 118.12. Round 1 makes
  the fourth root agree with it instead of diverging.

## Final review-impl

Final review-impl PASS head=ccd58ed9c1337eaf42b49817dc76d7558aee5c58

That review ran in `/engine-implementer` delta mode over the fix round answering the previous round's single
`[LOW]`. It returned `Completion Gate: PASS`, `Maintainer-Simulation Gate: PASS`, and **no findings**.

**The reviewed SHA is not the pushed SHA, and the difference is a rebase, not an edit.** After the review,
`main` moved twice, the branch was rebased onto each, and the head became `f35fa163ff060980e06828e9cfa55464f3325e43`.
All ten changed files are byte-identical across that rebase — each file's blob hash at `ccd58ed9c` compared
against its blob hash at `f35fa163f`, with a control confirming the comparison can see a difference (a file
`main` touched in the same span correctly reported as differing). The reviewed *content* is therefore the
pushed content. What a rebase can break is not the diff but its interaction with the new base, so the full
verification suite above was re-run from scratch at `fcf6fec60` rather than inherited.

The reviewer re-derived rather than accepted the load-bearing claims. It verified CR 122.2 at
`docs/MagicCompRules.txt:1200` with both controls, then checked that the engine actually implements it that way
— `zones.rs:67-71` and `:261`, where `counters_persist_on_move` defaults to clearing and the object is mutated
in place, so it survives with an emptied counter map. It confirmed the guard precedes the discriminators it
claims are unreachable by reading source order, and found the claim witnessed by an already-green sibling row on
the identical board.

It also recorded what it set out to catch and could not: it expected `cargo clippy` without `--all-targets`,
which would have left the only changed file unlinted, and refuted that against the script; and it checked the
worktree against the candidate blob itself rather than trusting the job's stamp. Two of its findings are
corrections to this PR's own evidence rather than to its code, and both are stated here rather than quietly
dropped: an earlier added-line figure in the working notes did not reproduce (the sweep's verdict survived
independent re-derivation, which found one more sound site than the original sweep did), and the
comment-only classifier used to justify one suite skip was measured as fail-open on string-literal
continuation lines — so that skip rests on six lines read directly, not on the classifier. The repo already
owns the correct primitive for that job (`source_census::code`).

## Pipeline report

```text
Pipeline-reviewed head: ccd58ed9c1337eaf42b49817dc76d7558aee5c58
Current branch head: f35fa163ff060980e06828e9cfa55464f3325e43
Pipeline status: current (rebase-only delta; all ten changed blobs byte-identical, measured)
Current-head review: clean at ccd58ed9c1337eaf42b49817dc76d7558aee5c58
```

## Claimed parse impact

None. Zero files under `crates/engine/src/parser/` are in the diff, and nothing here detects, dispatches or
classifies Oracle text. The test fixtures hand verbatim Oracle text to the production parser unmodified.

## Scope Expansion

Four things this change deliberately does not do, each real and each left for separate work:

- CR 616.1 ordering is never offered for mana replacements: the mana producer returns a plain vector and
  swallows the `NeedsChoice` result in a catch-all arm, leaving a live pending-replacement record with no prompt
  raised and every applicable mana replacement dropped. Reachable today by two of Contamination, Infernal
  Darkness and Ritual of Subdual plus any land tapped for mana.
- Doc Samson's parsed replacement carries no card filter where the printed text says "a permanent you control",
  so it is wider than the card — a parser scoping defect surfaced while building the fixture.
- `EffectResolved { kind: Sacrifice }` is emitted for a guarded effect on a paid cumulative upkeep even though
  the permanent is not sacrificed. Pre-existing and shared with the immediate leg, and engine-internal: nothing
  in the frontend renders it, so it cannot surface as a misleading log line.
- **The UI residue, disclosed rather than fixed.** `UnlessPaymentPanel` renders Pay whenever the prompt exists;
  in the live re-check window the engine refuses an illegal `pay:true` with `Err` — the button can outlive its
  legality; reachability of that window is not measured either way; follow-up registered. The same holds for
  `UnlessPaymentChooseCostModal`, which renders one option per entry of `waitingFor.data.costs` and never
  consults `legalActions`: a branch the engine refuses under CR 614.17b is still drawn. Engine-side legality is
  correct and measured (`legal_actions` excludes that index); the panel simply does not read it. Same follow-up,
  no frontend change in this PR.

The engine's own comment-correctness items raised on the first revision — the `CR 118.3` mis-anchors, the
`costs.rs` claim that effect-cost payment never opens a mid-payment prompt, and the incomplete park-site
enumeration in `finish_unless_payment`'s header — are corrected in this PR rather than deferred.

## Validation Failures

None.

## CI Failures

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved replacement-effect handling during cumulative upkeep and counter-based payments.
  - Fixed payment resolution when replacement effects add or prevent counters, including optional and mandatory prevention.
  - Prevented payment continuations from resuming prematurely at priority boundaries.
  - Blocked payment choices when required events cannot occur and skipped ineligible payers.
  - Correctly handles zero or negative counter costs and resolves affected abilities, destruction effects, and counter totals.

- **Tests**
  - Added coverage for replacement ordering, ward poison-counter costs, cumulative upkeep, prevention scenarios, and boundary behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


