### PR TITLE
feat(server,chart): /metrics endpoint and opt-in StatefulSet scale-out with demand-driven autoscaling

### DIFF
--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -2,6 +2,7 @@ mod admin;
 mod data_bootstrap;
 mod draft_pools;
 mod logging;
+mod metrics;
 mod persistence;
 
 use std::collections::HashMap;
@@ -670,9 +671,42 @@ fn build_spectator_state_update_message(
 /// lobby-only mode without re-parsing CLI state.
 type Mode = ServerMode;
 
-/// Server-wide limits to prevent resource exhaustion and abuse.
-const MAX_CONNECTIONS: u32 = 200;
-const MAX_GAMES: usize = 100;
+/// Server-wide limits to prevent resource exhaustion and abuse. These are the
+/// defaults; an operator running many small replicas behind a load balancer can
+/// lower them per process with `--max-connections` / `--max-games`.
+const DEFAULT_MAX_CONNECTIONS: u32 = 200;
+const DEFAULT_MAX_GAMES: usize = 100;
+/// Admission limits for this process, resolved once from the CLI at startup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct Limits {
+    max_connections: u32,
+    max_games: usize,
+}
+
+impl Default for Limits {
+    fn default() -> Self {
+        Self {
+            max_connections: DEFAULT_MAX_CONNECTIONS,
+            max_games: DEFAULT_MAX_GAMES,
+        }
+    }
+}
+
+/// Ambient per-process context every admission decision needs: what the limits
+/// are, and where a refusal gets counted. Threaded through the socket handlers
+/// rather than held in a global so tests can drive a handler at a small cap
+/// without perturbing the rest of the suite.
+#[derive(Clone, Default)]
+struct ServerContext {
+    limits: Limits,
+    /// Ordinal of this replica within its StatefulSet, from `--replica-ordinal`.
+    /// Carried only to be exposed as `phase_replica_ordinal`: an autoscaler
+    /// needs it to name the highest replica still holding players, and PromQL
+    /// has no way to turn a label back into a number.
+    replica_ordinal: Option<u32>,
+    metrics: Arc<metrics::ServerMetrics>,
+}
+
 // The lobby-only broker capacity cap (`MAX_LOBBY_ENTRIES`) now lives in
 // `lobby_broker::broker` — the broker enforces it inside `handle`.
 const RATE_LIMIT_MESSAGES: u32 = 30;
@@ -805,6 +839,29 @@ struct Cli {
     /// drift between host and server.
     #[arg(long, env = "PHASE_LOBBY_ONLY")]
     lobby_only: bool,
+
+    /// Maximum concurrent WebSocket connections before upgrades are refused
+    /// with 503. Lower it when running several small replicas behind a load
+    /// balancer so one process cannot absorb the whole fleet's traffic.
+    #[arg(long, default_value_t = DEFAULT_MAX_CONNECTIONS, env = "PHASE_MAX_CONNECTIONS")]
+    max_connections: u32,
+
+    /// Maximum concurrent game sessions before CreateGame is refused.
+    #[arg(long, default_value_t = DEFAULT_MAX_GAMES, env = "PHASE_MAX_GAMES")]
+    max_games: usize,
+
+    /// Serve Prometheus metrics on this port, on a second listener bound to
+    /// `--bind`. Unset (the default) means no metrics listener at all: the
+    /// gauges describe capacity and occupancy, which belongs to the operator
+    /// rather than to anyone who can reach the public port.
+    #[arg(long, env = "PHASE_METRICS_PORT")]
+    metrics_port: Option<u16>,
+
+    /// This process's ordinal within a replica set, exposed as the
+    /// `phase_replica_ordinal` metric. A scale-in policy needs it to identify
+    /// the highest-numbered replica that still has players on it.
+    #[arg(long, env = "PHASE_REPLICA_ORDINAL")]
+    replica_ordinal: Option<u32>,
 
     /// Public base URL to advertise to clients for sharing join codes (e.g.
     /// `https://play.example.com` when running behind a TLS reverse proxy or
@@ -1212,6 +1269,20 @@ async fn serve() {
         ServerMode::Full
     };
     info!(?mode, "server mode selected");
+    let server_context = ServerContext {
+        limits: Limits {
+            max_connections: cli.max_connections,
+            max_games: cli.max_games,
+        },
+        replica_ordinal: cli.replica_ordinal,
+        metrics: Arc::new(metrics::ServerMetrics::default()),
+    };
+    info!(
+        max_connections = server_context.limits.max_connections,
+        max_games = server_context.limits.max_games,
+        replica_ordinal = ?server_context.replica_ordinal,
+        "admission limits resolved"
+    );
     let data_path = cli.data_dir.as_path();
     let dev_fixture = dev_fixture_enabled();
     if bootstrap_required(data_path, dev_fixture) {
@@ -1721,7 +1792,7 @@ async fn serve() {
         app = mount_admin_routes(app, token);
     }
 
-    let app = app.layer(cors).with_state(AppState {
+    let app_state = AppState {
         sessions: state,
         draft_sessions,
         draft_pools,
@@ -1734,14 +1805,51 @@ async fn serve() {
         draft_spectators,
         game_spectators,
         mode,
+        context: server_context,
         public_url: advertised_public_url,
         allowed_origin: cli.allowed_origin.clone(),
-    });
+    };
+
+    let app = app.layer(cors).with_state(app_state.clone());
+
+    // Rejected before anything binds. Left alone this surfaces later as "address
+    // in use" on one of the two listeners, which reads like a stale process
+    // rather than the configuration error it is.
+    assert!(
+        cli.metrics_port != Some(cli.port),
+        "--metrics-port {} is also --port; give the metrics listener its own port",
+        cli.port
+    );
 
     let listener = tokio::net::TcpListener::bind((cli.bind, cli.port))
         .await
         .expect("failed to bind");
     info!(bind = %cli.bind, port = %cli.port, "phase-server listening");
+
+    // A second listener, only when asked for, and only once the public one holds
+    // its port: metrics are strictly additive, so nothing about them may be the
+    // reason the game server fails to start.
+    if let Some(metrics_port) = cli.metrics_port {
+        match tokio::net::TcpListener::bind((cli.bind, metrics_port)).await {
+            Ok(metrics_listener) => {
+                info!(bind = %cli.bind, port = metrics_port, "serving Prometheus metrics on /metrics");
+                tokio::spawn(async move {
+                    let router = Router::new()
+                        .route("/metrics", get(metrics::handler))
+                        .with_state(app_state);
+                    if let Err(error) = axum::serve(metrics_listener, router).await {
+                        error!(%error, "metrics listener stopped");
+                    }
+                });
+            }
+            Err(error) => error!(
+                %error,
+                port = metrics_port,
+                "failed to bind metrics port; continuing without metrics"
+            ),
+        }
+    }
+
     axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal(cli.exit_on_stdin_close))
         .await
@@ -1872,9 +1980,11 @@ mod lifecycle_tests {
     use clap::Parser;
     use tokio::sync::Mutex;
 
+    use url::Url;
+
     use super::{
         bootstrap_required, origin_is_allowed, prune_game_connections, select_card_data_source,
-        CardDataSource, Cli, SharedConnections,
+        validate_public_url, CardDataSource, Cli, SharedConnections,
     };
 
     #[test]
@@ -1918,6 +2028,52 @@ mod lifecycle_tests {
             select_card_data_source(temp.path(), true).expect("explicit fixture source"),
             CardDataSource::DevFixture(temp.path().join("mtgjson/test_fixture.json"))
         );
+    }
+
+    /// `PUBLIC_URL` is advertised verbatim to clients and becomes the host half
+    /// of every `CODE@host` share string, so the boundary check is what stops a
+    /// typo from being handed out as a join address.
+    #[test]
+    fn public_url_is_accepted_only_as_an_absolute_url_with_a_host() {
+        assert_eq!(
+            validate_public_url("https://play.example.com"),
+            Some("https://play.example.com".to_string())
+        );
+        assert_eq!(
+            validate_public_url("https://play.example.com/"),
+            Some("https://play.example.com".to_string()),
+            "a trailing slash is trimmed so the join string is not doubled"
+        );
+        assert_eq!(
+            validate_public_url("http://localhost:9374"),
+            Some("http://localhost:9374".to_string())
+        );
+
+        // Whitespace survives `Url::parse`, so without an explicit trim the
+        // padded value is advertised verbatim and ends up inside the
+        // "CODE@host" string a player copies out.
+        assert_eq!(
+            validate_public_url("  https://play.example.com/  "),
+            Some("https://play.example.com".to_string())
+        );
+        assert_eq!(
+            validate_public_url("\thttps://play.example.com\n"),
+            Some("https://play.example.com".to_string())
+        );
+
+        // A bare host is the likeliest operator mistake: it is not a URL.
+        assert_eq!(validate_public_url("phase.example.com"), None);
+        assert_eq!(validate_public_url("   "), None);
+        assert_eq!(validate_public_url("https://"), None);
+        assert_eq!(validate_public_url(""), None);
+
+        // These parse cleanly and still have no host. They are what separates
+        // the real guard from an `Url::parse(..).is_ok()` check, which would
+        // accept both and advertise them to clients.
+        assert!(Url::parse("mailto:someone@example.com").is_ok());
+        assert_eq!(validate_public_url("mailto:someone@example.com"), None);
+        assert!(Url::parse("file:///var/lib/phase-server").is_ok());
+        assert_eq!(validate_public_url("file:///var/lib/phase-server"), None);
     }
 
     #[tokio::test]
@@ -2032,8 +2188,12 @@ async fn require_admin_auth(expected: Arc<str>, request: Request, next: Next) ->
 /// rather than advertised to clients verbatim. Returns the URL with any
 /// trailing slash trimmed.
 fn validate_public_url(raw: &str) -> Option<String> {
-    match Url::parse(raw) {
-        Ok(u) if u.host_str().is_some() => Some(raw.trim_end_matches('/').to_string()),
+    // `Url::parse` tolerates surrounding whitespace, so returning `raw` would
+    // advertise it verbatim in ServerHello and bake it into the "CODE@host"
+    // share string.
+    let trimmed = raw.trim();
+    match Url::parse(trimmed) {
+        Ok(u) if u.host_str().is_some() => Some(trimmed.trim_end_matches('/').to_string()),
         _ => {
             warn!(value = %raw, "ignoring malformed PUBLIC_URL (need an absolute URL with a host)");
             None
@@ -2094,6 +2254,8 @@ struct AppState {
     draft_spectators: SharedDraftSpectators,
     game_spectators: SharedGameSpectators,
     mode: Mode,
+    /// Limits, replica identity and the rejection counters. See [`ServerContext`].
+    context: ServerContext,
     /// Public base URL advertised in `ServerHello` (from `--public-url`/an
     /// embedded ngrok tunnel), or `None` when the server has no reachable
     /// address to share. Cloned per connection at greet time only.
@@ -2124,15 +2286,23 @@ async fn ws_handler(
             origin = ?headers.get(http::header::ORIGIN),
             "rejecting WebSocket handshake from disallowed Origin"
         );
+        app_state
+            .context
+            .metrics
+            .record_reject(metrics::RejectReason::OriginNotAllowed);
         return (http::StatusCode::FORBIDDEN, "WebSocket Origin not allowed").into_response();
     }
     let current = app_state.player_count.load(Ordering::Relaxed);
-    if current >= MAX_CONNECTIONS {
+    if current >= app_state.context.limits.max_connections {
         warn!(
             online_count = current,
-            limit = MAX_CONNECTIONS,
+            limit = app_state.context.limits.max_connections,
             "connection limit reached, rejecting"
         );
+        app_state
+            .context
+            .metrics
+            .record_reject(metrics::RejectReason::ConnectionLimit);
         return (http::StatusCode::SERVICE_UNAVAILABLE, "Server full").into_response();
     }
 
@@ -2152,6 +2322,7 @@ async fn ws_handler(
                 app_state.draft_spectators,
                 app_state.game_spectators,
                 app_state.mode,
+                app_state.context,
                 app_state.public_url,
             )
         })
@@ -2173,6 +2344,7 @@ async fn handle_socket(
     draft_spectators: SharedDraftSpectators,
     game_spectators: SharedGameSpectators,
     mode: Mode,
+    context: ServerContext,
     public_url: Option<String>,
 ) {
     let (tx, mut rx) = mpsc::unbounded_channel::<ServerMessage>();
@@ -2277,6 +2449,7 @@ async fn handle_socket(
                             &tx,
                             &mut identity,
                             mode,
+                            &context,
                         )
                         .instrument(span)
                         .await;
@@ -4529,6 +4702,7 @@ async fn handle_client_message(
     tx: &mpsc::UnboundedSender<ServerMessage>,
     identity: &mut SocketIdentity,
     mode: Mode,
+    context: &ServerContext,
 ) {
     // Handshake gate: ClientHello must be the first message. See
     // `classify_hello_gate` for the full truth table.
@@ -4671,8 +4845,14 @@ async fn handle_client_message(
             }
             {
                 let mgr = state.lock().await;
-                if mgr.sessions.len() >= MAX_GAMES {
-                    warn!(limit = MAX_GAMES, "max games reached, rejecting CreateGame");
+                if mgr.sessions.len() >= context.limits.max_games {
+                    warn!(
+                        limit = context.limits.max_games,
+                        "max games reached, rejecting CreateGame"
+                    );
+                    context
+                        .metrics
+                        .record_reject(metrics::RejectReason::GameLimit);
                     let msg = ServerMessage::error(
                         "Server is at game capacity, please try again later".to_string(),
                     );
@@ -5289,11 +5469,14 @@ async fn handle_client_message(
 
             {
                 let mgr = state.lock().await;
-                if mgr.sessions.len() >= MAX_GAMES {
+                if mgr.sessions.len() >= context.limits.max_games {
                     warn!(
-                        limit = MAX_GAMES,
+                        limit = context.limits.max_games,
                         "max games reached, rejecting CreateGameWithSettings"
                     );
+                    context
+                        .metrics
+                        .record_reject(metrics::RejectReason::GameLimit);
                     let msg = ServerMessage::error(
                         "Server is at game capacity, please try again later".to_string(),
                     );
@@ -8687,6 +8870,7 @@ mod issue_4548_full_create_tests {
                 draft_spectators: Arc::new(Mutex::new(HashMap::new())),
                 game_spectators: Arc::new(Mutex::new(HashMap::new())),
                 mode: ServerMode::Full,
+                context: ServerContext::default(),
                 public_url: None,
                 allowed_origin: None,
             });
@@ -10201,7 +10385,7 @@ mod admin_auth_tests {
 
     use super::{
         admin_request_authorized, draft_pools, mount_admin_routes, persistence, tokens_match,
-        AppState, ServerMode,
+        AppState, ServerContext, ServerMode,
     };
 
     const TOKEN: &str = "s3cr3t-admin-token";
@@ -10225,6 +10409,7 @@ mod admin_auth_tests {
             draft_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
             game_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
             mode: ServerMode::Full,
+            context: ServerContext::default(),
             public_url: None,
             allowed_origin: None,
         }
@@ -10368,7 +10553,7 @@ mod p2p_backup_delete_tests {
     use tokio::sync::Mutex;
     use url::Url;
 
-    use super::{admin, draft_pools, persistence, AppState, ServerMode};
+    use super::{admin, draft_pools, persistence, AppState, ServerContext, ServerMode};
 
     const DRAFT_CODE: &str = "BACK01";
     const HOST_PEER: &str = "peer-host-owner";
@@ -10394,6 +10579,7 @@ mod p2p_backup_delete_tests {
             draft_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
             game_spectators: Arc::new(Mutex::new(std::collections::HashMap::new())),
             mode: ServerMode::Full,
+            context: ServerContext::default(),
             public_url: None,
             allowed_origin: None,
         }
@@ -10571,5 +10757,369 @@ mod p2p_backup_delete_tests {
             "backup must be removed after authorized DELETE"
         );
         server.abort();
+    }
+}
+
+#[cfg(test)]
+mod metrics_tests {
+    use std::collections::HashMap;
+    use std::sync::atomic::AtomicU32;
+    use std::sync::Arc;
+    use std::time::Duration;
+
+    use axum::routing::get;
+    use axum::Router;
+    use engine::database::CardDatabase;
+    use engine::game::deck_loading::PlayerDeckPayload;
+    use futures_util::SinkExt;
+    use futures_util::StreamExt;
+    use lobby_broker::Broker;
+    use server_core::draft_session::DraftSessionManager;
+    use server_core::protocol::{ClientMessage, DeckData, ServerMessage};
+    use server_core::session::SessionManager;
+    use tokio::sync::{mpsc, Mutex};
+    use tokio_tungstenite::tungstenite::Message as WsMessage;
+
+    use super::metrics::{self, RejectReason};
+    use super::{
+        build_commit, draft_pools, persistence, AppState, Limits, ServerContext, ServerMode,
+        LOBBY_PROTOCOL_VERSION, PROTOCOL_VERSION,
+    };
+
+    fn app_state(temp_dir: &tempfile::TempDir, context: ServerContext) -> AppState {
+        let game_db = Arc::new(
+            persistence::GameDb::open(
+                &temp_dir.path().join("games.db"),
+                persistence::SessionRetention::Multiplayer,
+            )
+            .expect("game db"),
+        );
+        AppState {
+            sessions: Arc::new(Mutex::new(SessionManager::new())),
+            draft_sessions: Arc::new(Mutex::new(DraftSessionManager::new())),
+            draft_pools: Arc::new(draft_pools::DraftPools::default()),
+            connections: Arc::new(Mutex::new(HashMap::new())),
+            db: Arc::new(CardDatabase::default()),
+            lobby: Arc::new(Mutex::new(Broker::new())),
+            lobby_subscribers: Arc::new(Mutex::new(Vec::new())),
+            player_count: Arc::new(AtomicU32::new(0)),
+            game_db,
+            draft_spectators: Arc::new(Mutex::new(HashMap::new())),
+            game_spectators: Arc::new(Mutex::new(HashMap::new())),
+            mode: ServerMode::Full,
+            context,
+            public_url: None,
+            allowed_origin: None,
+        }
+    }
+
+    /// A sender whose receiver has been dropped — exactly what a departed
+    /// socket leaves behind in `connections`, since the disconnect path does
+    /// not remove the entry.
+    fn dead_sender() -> mpsc::UnboundedSender<ServerMessage> {
+        let (tx, rx) = mpsc::unbounded_channel();
+        drop(rx);
+        tx
+    }
+
+    async fn spawn(app_state: AppState) -> (String, tokio::task::JoinHandle<()>) {
+        let app = Router::new()
+            .route("/ws", get(super::ws_handler))
+            .route("/metrics", get(metrics::handler))
+            .with_state(app_state);
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .expect("bind test server");
+        let addr = listener.local_addr().expect("local addr");
+        let handle = tokio::spawn(async move {
+            axum::serve(listener, app).await.expect("test server");
+        });
+        (addr.to_string(), handle)
+    }
+
+    /// Occupancy is the metric a scale-in decision reads, so it must track live
+    /// sockets rather than map membership. Both wrong implementations are
+    /// represented here: `sessions.len()` would answer 3 and `connections.len()`
+    /// would answer 2, while only one game actually has a human on it.
+    #[tokio::test]
+    async fn occupancy_counts_only_games_holding_a_live_socket() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let state = app_state(&temp, ServerContext::default());
+
+        let (occupied, abandoned, empty) = {
+            let mut mgr = state.sessions.lock().await;
+            let (a, _) = mgr.create_game(PlayerDeckPayload::default());
+            let (b, _) = mgr.create_game(PlayerDeckPayload::default());
+            let (c, _) = mgr.create_game(PlayerDeckPayload::default());
+            (a, b, c)
+        };
+
+        let (live_tx, _live_rx) = mpsc::unbounded_channel();
+        let (retired_tx, _retired_rx) = mpsc::unbounded_channel();
+        {
+            let mut conns = state.connections.lock().await;
+            conns.insert(
+                occupied.clone(),
+                HashMap::from([(engine::types::player::PlayerId(0), live_tx)]),
+            );
+            // A player who left: the key survives, the channel does not.
+            conns.insert(
+                abandoned.clone(),
+                HashMap::from([(engine::types::player::PlayerId(0), dead_sender())]),
+            );
+            // A game that was retired while its connection entry lingered:
+            // must not be counted, and must not be invented as an active game.
+            conns.insert(
+                "RETIRED".to_string(),
+                HashMap::from([(engine::types::player::PlayerId(0), retired_tx)]),
+            );
+        }
+        assert!(!empty.is_empty(), "third game code was created");
+
+        let snapshot = metrics::collect(&state).await;
+        assert_eq!(snapshot.games_active, 3);
+        assert_eq!(snapshot.games_with_connected_humans, 1);
+    }
+
+    /// A game watched only by a spectator still pins this replica: the
+    /// spectator socket lives in a different map from player connections.
+    #[tokio::test]
+    async fn a_spectator_only_game_counts_as_occupied() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let state = app_state(&temp, ServerContext::default());
+
+        let code = {
+            let mut mgr = state.sessions.lock().await;
+            let (code, _) = mgr.create_game(PlayerDeckPayload::default());
+            code
+        };
+
+        // Baseline: no sockets at all, so the game is not occupied. Without
+        // this the assertion below could pass on an implementation that counts
+        // every session.
+        assert_eq!(
+            metrics::collect(&state).await.games_with_connected_humans,
+            0
+        );
+
+        let (spectator_tx, _spectator_rx) = mpsc::unbounded_channel();
+        state
+            .game_spectators
+            .lock()
+            .await
+            .insert(code, vec![spectator_tx]);
+
+        let snapshot = metrics::collect(&state).await;
+        assert_eq!(snapshot.games_active, 1);
+        assert_eq!(snapshot.games_with_connected_humans, 1);
+    }
+
+    /// Refusing an upgrade at the connection cap must be visible to a scraper,
+    /// and an ordinary connect must not look like a refusal.
+    #[tokio::test]
+    async fn connection_cap_refusal_is_counted_but_an_accepted_socket_is_not() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let context = ServerContext {
+            limits: Limits {
+                max_connections: 1,
+                ..Limits::default()
+            },
+            ..ServerContext::default()
+        };
+        let counters = context.metrics.clone();
+        let state = app_state(&temp, context);
+        let player_count = state.player_count.clone();
+        let (addr, server) = spawn(state).await;
+
+        let outcome = tokio::time::timeout(Duration::from_secs(5), async {
+            // Control: the first socket is admitted. This proves the endpoint
+            // works, so the refusal below is the cap and not a broken server.
+            let (mut socket, response) =
+                tokio_tungstenite::connect_async(format!("ws://{addr}/ws"))
+                    .await
+                    .expect("first connect is admitted");
+            assert_eq!(response.status().as_u16(), 101);
+            let hello = recv(&mut socket).await;
+            assert!(
+                matches!(hello, ServerMessage::ServerHello { .. }),
+                "admitted socket got {hello:?}"
+            );
+            assert_eq!(counters.reject_count(RejectReason::ConnectionLimit), 0);
+
+            // The gate reads `player_count`, which the accepted socket
+            // increments from its own task; wait for that rather than racing it.
+            while player_count.load(std::sync::atomic::Ordering::Relaxed) < 1 {
+                tokio::time::sleep(Duration::from_millis(10)).await;
+            }
+
+            let refused = tokio_tungstenite::connect_async(format!("ws://{addr}/ws"))
+                .await
+                .expect_err("second connect is over the cap");
+            match refused {
+                tokio_tungstenite::tungstenite::Error::Http(response) => {
+                    assert_eq!(response.status().as_u16(), 503);
+                }
+                other => panic!("expected an HTTP 503, got {other:?}"),
+            }
+            assert_eq!(counters.reject_count(RejectReason::ConnectionLimit), 1);
+            // Only the reason that fired moves.
+            assert_eq!(counters.reject_count(RejectReason::GameLimit), 0);
+            assert_eq!(counters.reject_count(RejectReason::OriginNotAllowed), 0);
+        })
+        .await;
+        server.abort();
+        outcome.expect("connection cap test timed out");
+    }
+
+    /// `--max-games` has to bind at the real `CreateGame` path, not just exist
+    /// as a field. Driven over a websocket so the whole production route runs.
+    #[tokio::test]
+    async fn create_game_past_the_cap_is_refused_and_counted() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let context = ServerContext {
+            limits: Limits {
+                max_games: 1,
+                ..Limits::default()
+            },
+            ..ServerContext::default()
+        };
+        let counters = context.metrics.clone();
+        let (addr, server) = spawn(app_state(&temp, context)).await;
+
+        let outcome = tokio::time::timeout(Duration::from_secs(10), async {
+            let first = create_game(&addr, "Alice").await;
+            assert!(
+                matches!(first, ServerMessage::GameCreated { .. }),
+                "the first create is under the cap, got {first:?}"
+            );
+            assert_eq!(counters.reject_count(RejectReason::GameLimit), 0);
+
+            let second = create_game(&addr, "Bob").await;
+            match second {
+                ServerMessage::Error { ref message, .. } => {
+                    assert!(
+                        message.contains("game capacity"),
+                        "unexpected error text: {message}"
+                    );
+                }
+                other => panic!("expected a capacity error, got {other:?}"),
+            }
+            assert_eq!(counters.reject_count(RejectReason::GameLimit), 1);
+        })
+        .await;
+        server.abort();
+        outcome.expect("max-games test timed out");
+    }
+
+    #[tokio::test]
+    async fn metrics_endpoint_serves_prometheus_text() {
+        let temp = tempfile::tempdir().expect("temp dir");
+        let context = ServerContext {
+            replica_ordinal: Some(2),
+            ..ServerContext::default()
+        };
+        let (addr, server) = spawn(app_state(&temp, context)).await;
+
+        let response = reqwest::get(format!("http://{addr}/metrics"))
+            .await
+            .expect("scrape /metrics");
+        assert_eq!(response.status(), 200);
+        assert_eq!(
+            response
+                .headers()
+                .get(reqwest::header::CONTENT_TYPE)
+                .and_then(|value| value.to_str().ok()),
+            Some("text/plain; version=0.0.4; charset=utf-8")
+        );
+        let body = response.text().await.expect("body");
+        server.abort();
+
+        for family in [
+            "phase_connections",
+            "phase_connections_capacity",
+            "phase_games_active",
+            "phase_games_with_connected_humans",
+            "phase_games_capacity",
+            "phase_drafts_active",
+            "phase_drafts_with_connected_humans",
+            "phase_replica_ordinal",
+            "phase_admission_rejects_total",
+            "phase_build_info",
+        ] {
+            assert!(
+                body.contains(&format!("# TYPE {family} ")),
+                "{family} missing from scrape:\n{body}"
+            );
+        }
+        assert!(body.contains("phase_replica_ordinal 2\n"));
+        assert!(body.contains(&format!(
+            "phase_connections_capacity {}\n",
+            super::DEFAULT_MAX_CONNECTIONS
+        )));
+    }
+
+    async fn recv<S>(socket: &mut tokio_tungstenite::WebSocketStream<S>) -> ServerMessage
+    where
+        S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+    {
+        match socket.next().await.expect("frame").expect("ok frame") {
+            WsMessage::Text(text) => serde_json::from_str(&text).expect("server message"),
+            other => panic!("expected text, got {other:?}"),
+        }
+    }
+
+    /// Connect, handshake, and send one `CreateGameWithSettings`; returns the
+    /// first message that is not the handshake echo or a slot broadcast.
+    async fn create_game(addr: &str, display_name: &str) -> ServerMessage {
+        let (mut socket, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/ws"))
+            .await
+            .expect("connect");
+        assert!(matches!(
+            recv(&mut socket).await,
+            ServerMessage::ServerHello { .. }
+        ));
+
+        let hello = ClientMessage::ClientHello {
+            client_version: env!("CARGO_PKG_VERSION").to_string(),
+            build_commit: build_commit().to_string(),
+            protocol_version: PROTOCOL_VERSION,
+            lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+        };
+        socket
+            .send(WsMessage::Text(
+                serde_json::to_string(&hello).expect("hello json").into(),
+            ))
+            .await
+            .expect("send hello");
+
+        let create = ClientMessage::CreateGameWithSettings {
+            deck: DeckData::default(),
+            display_name: display_name.to_string(),
+            public: true,
+            password: None,
+            timer_seconds: None,
+            player_count: 2,
+            match_config: Default::default(),
+            ai_seats: Vec::new(),
+            format_config: None,
+            room_name: None,
+            host_peer_id: None,
+            draft_metadata: None,
+            start_when_full: true,
+            ranked: false,
+        };
+        socket
+            .send(WsMessage::Text(
+                serde_json::to_string(&create).expect("create json").into(),
+            ))
+            .await
+            .expect("send create");
+
+        loop {
+            match recv(&mut socket).await {
+                ServerMessage::PlayerSlotsUpdate { .. } | ServerMessage::PlayerCount { .. } => {}
+                other => return other,
+            }
+        }
     }
 }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -2292,19 +2292,35 @@ async fn ws_handler(
             .record_reject(metrics::RejectReason::OriginNotAllowed);
         return (http::StatusCode::FORBIDDEN, "WebSocket Origin not allowed").into_response();
     }
-    let current = app_state.player_count.load(Ordering::Relaxed);
-    if current >= app_state.context.limits.max_connections {
-        warn!(
-            online_count = current,
-            limit = app_state.context.limits.max_connections,
-            "connection limit reached, rejecting"
-        );
+    // Reserved in the same atomic operation that tests it. A load, then a check,
+    // then an increment further down admits every handshake that raced into the
+    // gap, so a cap of N can be overshot by however many arrive together.
+    //
+    // `Relaxed` throughout, as everywhere else on this counter: the read-modify
+    // -write is atomic whatever the ordering, and no other state is published
+    // through it — the value is only ever compared against the cap.
+    let reserved =
         app_state
-            .context
-            .metrics
-            .record_reject(metrics::RejectReason::ConnectionLimit);
-        return (http::StatusCode::SERVICE_UNAVAILABLE, "Server full").into_response();
-    }
+            .player_count
+            .fetch_update(Ordering::Relaxed, Ordering::Relaxed, |online| {
+                (online < app_state.context.limits.max_connections).then_some(online + 1)
+            });
+    let online_count = match reserved {
+        Ok(previous) => previous + 1,
+        Err(current) => {
+            warn!(
+                online_count = current,
+                limit = app_state.context.limits.max_connections,
+                "connection limit reached, rejecting"
+            );
+            app_state
+                .context
+                .metrics
+                .record_reject(metrics::RejectReason::ConnectionLimit);
+            return (http::StatusCode::SERVICE_UNAVAILABLE, "Server full").into_response();
+        }
+    };
+    let slot = ConnectionSlot::new(app_state.player_count.clone());
 
     ws.max_message_size(MAX_WS_MESSAGE_BYTES)
         .on_upgrade(move |socket| {
@@ -2324,9 +2340,45 @@ async fn ws_handler(
                 app_state.mode,
                 app_state.context,
                 app_state.public_url,
+                online_count,
+                slot,
             )
         })
         .into_response()
+}
+
+/// A connection slot reserved before the WebSocket upgrade.
+///
+/// `ws_handler` reserves atomically so racing handshakes cannot overshoot the
+/// cap, but the upgrade may never reach `handle_socket` — axum drops the
+/// callback when the handshake fails — and a reservation leaked that way would
+/// wedge the server one slot below capacity forever. Dropping the guard
+/// releases it. `handle_socket` disarms it and owns the release from then on,
+/// because that path also has to broadcast the new count, which `Drop` cannot.
+struct ConnectionSlot {
+    player_count: SharedPlayerCount,
+    armed: bool,
+}
+
+impl ConnectionSlot {
+    fn new(player_count: SharedPlayerCount) -> Self {
+        Self {
+            player_count,
+            armed: true,
+        }
+    }
+
+    fn disarm(mut self) {
+        self.armed = false;
+    }
+}
+
+impl Drop for ConnectionSlot {
+    fn drop(&mut self) {
+        if self.armed {
+            self.player_count.fetch_sub(1, Ordering::Relaxed);
+        }
+    }
 }
 
 #[allow(clippy::too_many_arguments)]
@@ -2346,10 +2398,15 @@ async fn handle_socket(
     mode: Mode,
     context: ServerContext,
     public_url: Option<String>,
+    online_count: u32,
+    slot: ConnectionSlot,
 ) {
     let (tx, mut rx) = mpsc::unbounded_channel::<ServerMessage>();
 
-    let count = player_count.fetch_add(1, Ordering::Relaxed) + 1;
+    // The slot was reserved before the upgrade; from here the two `fetch_sub`
+    // paths below own the release, so the guard must not also fire.
+    slot.disarm();
+    let count = online_count;
     info!(online_count = count, "client connected");
     broadcast_player_count(&lobby_subscribers, count).await;
 
@@ -2944,6 +3001,7 @@ struct MultiplayerSessionRequest {
     public: bool,
     password: Option<String>,
     host_tx: mpsc::UnboundedSender<ServerMessage>,
+    context: ServerContext,
 }
 
 /// Phases 1–2 of the `CreateGameWithSettings` full multiplayer path.
@@ -2981,11 +3039,25 @@ async fn create_and_connect_multiplayer_session(
         public,
         password,
         host_tx,
+        context,
     } = req;
 
     // Phase 1 ── state lock; released at end of block.
     let (game_code, player_token, initial_player_count, full_key) = {
         let mut mgr = state.lock().await;
+        // Sole capacity check for the multiplayer path, under the lock that
+        // inserts — see the `CreateGame` arm for why it cannot move ahead of
+        // deck resolution.
+        if mgr.sessions.len() >= context.limits.max_games {
+            warn!(
+                limit = context.limits.max_games,
+                "max games reached, rejecting CreateGameWithSettings"
+            );
+            context
+                .metrics
+                .record_reject(metrics::RejectReason::GameLimit);
+            return Err("Server is at game capacity, please try again later".to_string());
+        }
         let (game_code, player_token) = mgr.create_game_n_players(
             resolved,
             display_name.clone(),
@@ -4843,25 +4915,6 @@ async fn handle_client_message(
                 }
                 return;
             }
-            {
-                let mgr = state.lock().await;
-                if mgr.sessions.len() >= context.limits.max_games {
-                    warn!(
-                        limit = context.limits.max_games,
-                        "max games reached, rejecting CreateGame"
-                    );
-                    context
-                        .metrics
-                        .record_reject(metrics::RejectReason::GameLimit);
-                    let msg = ServerMessage::error(
-                        "Server is at game capacity, please try again later".to_string(),
-                    );
-                    if let Ok(json) = serde_json::to_string(&msg) {
-                        let _ = socket.send(Message::text(json)).await;
-                    }
-                    return;
-                }
-            }
             let resolved = match resolve_deck(db, &deck) {
                 Ok(entries) => entries,
                 Err(e) => {
@@ -4875,6 +4928,27 @@ async fn handle_client_message(
             };
 
             let mut mgr = state.lock().await;
+            // The only capacity check on this path, and deliberately so: it
+            // holds `mgr` through the insert below. Checking before
+            // `resolve_deck` instead would release the lock in between and let
+            // every create that raced into that window past a stale count.
+            if mgr.sessions.len() >= context.limits.max_games {
+                drop(mgr);
+                warn!(
+                    limit = context.limits.max_games,
+                    "max games reached, rejecting CreateGame"
+                );
+                context
+                    .metrics
+                    .record_reject(metrics::RejectReason::GameLimit);
+                let msg = ServerMessage::error(
+                    "Server is at game capacity, please try again later".to_string(),
+                );
+                if let Ok(json) = serde_json::to_string(&msg) {
+                    let _ = socket.send(Message::text(json)).await;
+                }
+                return;
+            }
             let (game_code, player_token) = mgr.create_game(resolved);
             let full_key = match game_db.create_full_session_key(&game_code) {
                 Ok(key) => key,
@@ -5467,25 +5541,6 @@ async fn handle_client_message(
                 }
             };
 
-            {
-                let mgr = state.lock().await;
-                if mgr.sessions.len() >= context.limits.max_games {
-                    warn!(
-                        limit = context.limits.max_games,
-                        "max games reached, rejecting CreateGameWithSettings"
-                    );
-                    context
-                        .metrics
-                        .record_reject(metrics::RejectReason::GameLimit);
-                    let msg = ServerMessage::error(
-                        "Server is at game capacity, please try again later".to_string(),
-                    );
-                    if let Ok(json) = serde_json::to_string(&msg) {
-                        let _ = socket.send(Message::text(json)).await;
-                    }
-                    return;
-                }
-            }
             let resolved = match resolve_deck(db, &deck) {
                 Ok(entries) => entries,
                 Err(e) => {
@@ -5601,6 +5656,22 @@ async fn handle_client_message(
                 // --- AI game path: create, start, and run initial AI actions ---
                 let (game_code, player_token, full_key, game_started_msg) = {
                     let mut mgr = state.lock().await;
+                    // Sole capacity check for the AI path, under the lock that
+                    // inserts — see the `CreateGame` arm for why it cannot move
+                    // ahead of deck resolution.
+                    if mgr.sessions.len() >= context.limits.max_games {
+                        warn!(
+                            limit = context.limits.max_games,
+                            "max games reached, rejecting CreateGameWithSettings"
+                        );
+                        context
+                            .metrics
+                            .record_reject(metrics::RejectReason::GameLimit);
+                        let _ = tx.send(ServerMessage::error(
+                            "Server is at game capacity, please try again later".to_string(),
+                        ));
+                        return;
+                    }
                     let (game_code, player_token) = match mgr.create_game_with_ai(
                         resolved,
                         display_name.clone(),
@@ -5724,6 +5795,7 @@ async fn handle_client_message(
                             public,
                             password: password.clone(), // original still needed for Phase 3
                             host_tx: tx.clone(),
+                            context: context.clone(),
                         },
                     )
                     .await
@@ -10349,6 +10421,7 @@ mod issue_4548_deadlock_tests {
                 public: false,
                 password: None,
                 host_tx: tx,
+                context: ServerContext::default(),
             },
         )
         .await
@@ -10774,16 +10847,17 @@ mod metrics_tests {
     use futures_util::SinkExt;
     use futures_util::StreamExt;
     use lobby_broker::Broker;
+    use phase_ai::config::AiDifficulty;
     use server_core::draft_session::DraftSessionManager;
-    use server_core::protocol::{ClientMessage, DeckData, ServerMessage};
+    use server_core::protocol::{AiSeatRequest, ClientMessage, DeckData, ServerMessage};
     use server_core::session::SessionManager;
     use tokio::sync::{mpsc, Mutex};
     use tokio_tungstenite::tungstenite::Message as WsMessage;
 
     use super::metrics::{self, RejectReason};
     use super::{
-        build_commit, draft_pools, persistence, AppState, Limits, ServerContext, ServerMode,
-        LOBBY_PROTOCOL_VERSION, PROTOCOL_VERSION,
+        build_commit, draft_pools, persistence, AppState, ConnectionSlot, Limits, ServerContext,
+        ServerMode, SharedPlayerCount, LOBBY_PROTOCOL_VERSION, PROTOCOL_VERSION,
     };
 
     fn app_state(temp_dir: &tempfile::TempDir, context: ServerContext) -> AppState {
@@ -11068,9 +11142,12 @@ mod metrics_tests {
         }
     }
 
-    /// Connect, handshake, and send one `CreateGameWithSettings`; returns the
-    /// first message that is not the handshake echo or a slot broadcast.
-    async fn create_game(addr: &str, display_name: &str) -> ServerMessage {
+    type TestSocket = tokio_tungstenite::WebSocketStream<
+        tokio_tungstenite::MaybeTlsStream<tokio::net::TcpStream>,
+    >;
+
+    /// Connect and complete the handshake, leaving the socket ready to create.
+    async fn connect_and_hello(addr: &str) -> TestSocket {
         let (mut socket, _) = tokio_tungstenite::connect_async(format!("ws://{addr}/ws"))
             .await
             .expect("connect");
@@ -11091,35 +11168,262 @@ mod metrics_tests {
             ))
             .await
             .expect("send hello");
+        socket
+    }
 
-        let create = ClientMessage::CreateGameWithSettings {
-            deck: DeckData::default(),
+    /// Send one create request; returns the first message that is not a slot or
+    /// count broadcast.
+    async fn send_create(socket: &mut TestSocket, request: ClientMessage) -> ServerMessage {
+        socket
+            .send(WsMessage::Text(
+                serde_json::to_string(&request).expect("create json").into(),
+            ))
+            .await
+            .expect("send create");
+
+        loop {
+            match recv(socket).await {
+                ServerMessage::PlayerSlotsUpdate { .. } | ServerMessage::PlayerCount { .. } => {}
+                other => return other,
+            }
+        }
+    }
+
+    fn settings_request(
+        display_name: &str,
+        deck: DeckData,
+        ai_seats: Vec<AiSeatRequest>,
+    ) -> ClientMessage {
+        ClientMessage::CreateGameWithSettings {
+            deck,
             display_name: display_name.to_string(),
             public: true,
             password: None,
             timer_seconds: None,
             player_count: 2,
             match_config: Default::default(),
-            ai_seats: Vec::new(),
+            ai_seats,
             format_config: None,
             room_name: None,
             host_peer_id: None,
             draft_metadata: None,
             start_when_full: true,
             ranked: false,
-        };
-        socket
-            .send(WsMessage::Text(
-                serde_json::to_string(&create).expect("create json").into(),
-            ))
-            .await
-            .expect("send create");
+        }
+    }
 
-        loop {
-            match recv(&mut socket).await {
-                ServerMessage::PlayerSlotsUpdate { .. } | ServerMessage::PlayerCount { .. } => {}
-                other => return other,
+    async fn create_game(addr: &str, display_name: &str) -> ServerMessage {
+        let mut socket = connect_and_hello(addr).await;
+        send_create(
+            &mut socket,
+            settings_request(display_name, DeckData::default(), Vec::new()),
+        )
+        .await
+    }
+
+    /// Connects every client and gets it through the handshake first, then
+    /// releases them all into one simultaneous create.
+    ///
+    /// The barrier is what makes the caller discriminating: creates that arrive
+    /// spread out are serialized by the sessions lock, so a path that checks
+    /// capacity, releases the lock, and inserts later would look correct by
+    /// luck. Releasing them together puts every racer inside that window.
+    async fn race_creates(addr: &str, requests: Vec<ClientMessage>) -> Vec<ServerMessage> {
+        let barrier = Arc::new(tokio::sync::Barrier::new(requests.len()));
+        let mut racers = Vec::new();
+        for request in requests {
+            let mut socket = connect_and_hello(addr).await;
+            let barrier = barrier.clone();
+            racers.push(tokio::spawn(async move {
+                barrier.wait().await;
+                send_create(&mut socket, request).await
+            }));
+        }
+
+        let mut replies = Vec::new();
+        for racer in racers {
+            replies.push(racer.await.expect("create task"));
+        }
+        replies
+    }
+
+    fn tally(replies: &[ServerMessage], path: &str) -> (u64, u64) {
+        let mut created = 0;
+        let mut refused = 0;
+        for reply in replies {
+            match reply {
+                ServerMessage::GameCreated { .. } | ServerMessage::GameStarted { .. } => {
+                    created += 1
+                }
+                ServerMessage::Error { message, .. } if message.contains("game capacity") => {
+                    refused += 1
+                }
+                other => panic!("{path}: unexpected reply {other:?}"),
             }
         }
+        (created, refused)
+    }
+
+    /// The cap has to be enforced by the same atomic step that takes the slot.
+    /// Loading `player_count`, comparing it, and incrementing after the upgrade
+    /// admits every handshake that raced into the gap, so a cap of one is
+    /// overshot by however many arrive together.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_upgrades_cannot_exceed_the_connection_cap() {
+        const RACERS: u64 = 8;
+        let temp = tempfile::tempdir().expect("temp dir");
+        let context = ServerContext {
+            limits: Limits {
+                max_connections: 1,
+                ..Limits::default()
+            },
+            ..ServerContext::default()
+        };
+        let counters = context.metrics.clone();
+        let state = app_state(&temp, context);
+        let player_count = state.player_count.clone();
+        let (addr, server) = spawn(state).await;
+
+        let barrier = Arc::new(tokio::sync::Barrier::new(RACERS as usize));
+        let mut racers = Vec::new();
+        for _ in 0..RACERS {
+            let addr = addr.clone();
+            let barrier = barrier.clone();
+            racers.push(tokio::spawn(async move {
+                barrier.wait().await;
+                tokio_tungstenite::connect_async(format!("ws://{addr}/ws")).await
+            }));
+        }
+
+        let outcome = tokio::time::timeout(Duration::from_secs(30), async {
+            let mut admitted = Vec::new();
+            let mut refused = 0u64;
+            for racer in racers {
+                match racer.await.expect("connect task") {
+                    Ok((socket, response)) => {
+                        assert_eq!(response.status().as_u16(), 101);
+                        // Held open: a socket that closed would give its slot
+                        // back and hide an over-admission from the count below.
+                        admitted.push(socket);
+                    }
+                    Err(tokio_tungstenite::tungstenite::Error::Http(response)) => {
+                        assert_eq!(response.status().as_u16(), 503);
+                        refused += 1;
+                    }
+                    Err(other) => panic!("expected an HTTP 503, got {other:?}"),
+                }
+            }
+            (admitted.len() as u64, refused)
+        })
+        .await;
+        server.abort();
+
+        let (admitted, refused) = outcome.expect("connection race timed out");
+        assert_eq!(admitted, 1, "more than one racer took the single slot");
+        assert_eq!(refused, RACERS - 1);
+        assert_eq!(
+            player_count.load(std::sync::atomic::Ordering::Relaxed),
+            1,
+            "reservations outnumber the cap"
+        );
+        assert_eq!(
+            counters.reject_count(RejectReason::ConnectionLimit),
+            RACERS - 1
+        );
+    }
+
+    /// Every full-mode creation path must check capacity under the same lock
+    /// acquisition that inserts the session. All three are driven here over the
+    /// real websocket route, because each reaches a different insert:
+    /// `create_game`, `create_game_with_ai`, and `create_game_n_players`.
+    #[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+    async fn concurrent_creates_cannot_exceed_the_game_cap() {
+        const RACERS: u64 = 8;
+        for path in [
+            "create_game",
+            "create_game_n_players",
+            "create_game_with_ai",
+        ] {
+            let temp = tempfile::tempdir().expect("temp dir");
+            let context = ServerContext {
+                limits: Limits {
+                    max_games: 1,
+                    ..Limits::default()
+                },
+                ..ServerContext::default()
+            };
+            let counters = context.metrics.clone();
+            let state = app_state(&temp, context);
+            let sessions = state.sessions.clone();
+            let (addr, server) = spawn(state).await;
+
+            let deck = DeckData::default();
+            let requests = (0..RACERS)
+                .map(|racer| match path {
+                    "create_game" => ClientMessage::CreateGame { deck: deck.clone() },
+                    "create_game_with_ai" => settings_request(
+                        &format!("racer{racer}"),
+                        deck.clone(),
+                        vec![AiSeatRequest {
+                            seat_index: 1,
+                            difficulty: AiDifficulty::Medium,
+                            deck_name: None,
+                            deck: None,
+                        }],
+                    ),
+                    _ => settings_request(&format!("racer{racer}"), deck.clone(), Vec::new()),
+                })
+                .collect();
+
+            let outcome =
+                tokio::time::timeout(Duration::from_secs(30), race_creates(&addr, requests)).await;
+            server.abort();
+            let replies = outcome.unwrap_or_else(|_| panic!("{path}: create race timed out"));
+
+            let (created, refused) = tally(&replies, path);
+            assert_eq!(
+                created, 1,
+                "{path}: more than one create took the last slot"
+            );
+            assert_eq!(refused, RACERS - 1, "{path}");
+            let survivor = {
+                let mgr = sessions.lock().await;
+                assert_eq!(mgr.sessions.len(), 1, "{path}: sessions past the cap");
+                mgr.sessions
+                    .values()
+                    .next()
+                    .expect("one session")
+                    .ai_seats
+                    .len()
+            };
+            // Which insert actually ran: only `create_game_with_ai` seats an AI.
+            // Without this the AI case would silently exercise the multiplayer
+            // path if seat validation ever rejected the request.
+            assert_eq!(
+                survivor,
+                usize::from(path == "create_game_with_ai"),
+                "{path}: wrong creation path ran"
+            );
+            assert_eq!(
+                counters.reject_count(RejectReason::GameLimit),
+                RACERS - 1,
+                "{path}"
+            );
+        }
+    }
+
+    /// A reservation whose upgrade never reaches `handle_socket` has to be
+    /// given back, or the server sits one slot below capacity for good.
+    /// Disarming is what hands that release to `handle_socket` instead.
+    #[test]
+    fn a_dropped_connection_slot_releases_its_reservation() {
+        let counter: SharedPlayerCount = Arc::new(AtomicU32::new(1));
+
+        drop(ConnectionSlot::new(counter.clone()));
+        assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 0);
+
+        counter.store(1, std::sync::atomic::Ordering::Relaxed);
+        ConnectionSlot::new(counter.clone()).disarm();
+        assert_eq!(counter.load(std::sync::atomic::Ordering::Relaxed), 1);
     }
 }

--- a/crates/phase-server/src/metrics.rs
+++ b/crates/phase-server/src/metrics.rs
@@ -1,0 +1,488 @@
+//! Prometheus text exposition for the counters an autoscaler needs.
+//!
+//! Served on its own listener (`--metrics-port`), never on the public port: the
+//! numbers here describe capacity and occupancy, which is operator information
+//! rather than something a player should be able to read through the ingress.
+//!
+//! Hand-rolled rather than pulled from a client crate. The exposition format is
+//! a handful of lines, the process has exactly one registry, and every value is
+//! read live from state the server already holds — a registry abstraction would
+//! only add a second place for a counter to drift out of sync.
+//!
+//! The occupancy gauges (`phase_games_with_connected_humans`,
+//! `phase_drafts_with_connected_humans`) exist for one decision: a StatefulSet
+//! always removes its highest ordinal, so an autoscaler must be able to ask
+//! "does *this* replica still hold someone?" before it is allowed to shrink.
+
+use std::collections::HashSet;
+use std::fmt::Write as _;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+use axum::extract::State;
+use axum::response::IntoResponse;
+
+use crate::{AppState, ServerMode};
+
+/// Prometheus' text exposition content type (the format this module writes).
+const CONTENT_TYPE: &str = "text/plain; version=0.0.4; charset=utf-8";
+
+/// Why the server refused a connection or a game at admission.
+///
+/// A typed reason rather than a `&str` label so the exposition and the
+/// increment sites cannot disagree about the spelling of a label value.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RejectReason {
+    /// `ws_handler` refused the upgrade: `phase_connections` was at capacity.
+    ConnectionLimit,
+    /// A `CreateGame*` was refused: the session map was at capacity.
+    GameLimit,
+    /// `ws_handler` refused the upgrade: the `Origin` header was not allowed.
+    OriginNotAllowed,
+}
+
+impl RejectReason {
+    /// Every variant, in exposition order. Exhaustively matched in
+    /// [`ServerMetrics::reject_count`], so a new variant fails to compile until
+    /// it is counted and listed here.
+    const ALL: [Self; 3] = [
+        Self::ConnectionLimit,
+        Self::GameLimit,
+        Self::OriginNotAllowed,
+    ];
+
+    fn label(self) -> &'static str {
+        match self {
+            Self::ConnectionLimit => "connection_limit",
+            Self::GameLimit => "game_limit",
+            Self::OriginNotAllowed => "origin_not_allowed",
+        }
+    }
+}
+
+/// Process-wide counters that cannot be recovered by reading live state.
+///
+/// Everything else in [`Snapshot`] is sampled from the session/connection maps
+/// at scrape time; rejections leave no trace there, so they are counted here.
+#[derive(Debug, Default)]
+pub struct ServerMetrics {
+    connection_limit: AtomicU64,
+    game_limit: AtomicU64,
+    origin_not_allowed: AtomicU64,
+}
+
+impl ServerMetrics {
+    fn counter(&self, reason: RejectReason) -> &AtomicU64 {
+        match reason {
+            RejectReason::ConnectionLimit => &self.connection_limit,
+            RejectReason::GameLimit => &self.game_limit,
+            RejectReason::OriginNotAllowed => &self.origin_not_allowed,
+        }
+    }
+
+    pub fn record_reject(&self, reason: RejectReason) {
+        self.counter(reason).fetch_add(1, Ordering::Relaxed);
+    }
+
+    pub fn reject_count(&self, reason: RejectReason) -> u64 {
+        self.counter(reason).load(Ordering::Relaxed)
+    }
+}
+
+/// Build identity, mirroring what `ServerHello` advertises to clients.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BuildInfo {
+    pub version: String,
+    pub commit: String,
+    pub mode: &'static str,
+}
+
+impl BuildInfo {
+    pub fn current(mode: ServerMode) -> Self {
+        Self {
+            version: env!("CARGO_PKG_VERSION").to_string(),
+            commit: server_core::protocol::build_commit().to_string(),
+            mode: match mode {
+                ServerMode::Full => "full",
+                ServerMode::LobbyOnly => "lobby_only",
+            },
+        }
+    }
+}
+
+/// One scrape's worth of values. Separated from both collection and rendering
+/// so the exposition can be asserted byte-for-byte against known numbers.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Snapshot {
+    pub connections: u32,
+    pub connections_capacity: u32,
+    pub games_active: usize,
+    pub games_with_connected_humans: usize,
+    pub games_capacity: usize,
+    pub drafts_active: usize,
+    pub drafts_with_connected_humans: usize,
+    /// This replica's ordinal within its StatefulSet, when the operator set
+    /// one. `None` omits the gauge entirely — a single-process deployment has
+    /// no ordinal, and emitting a placeholder would make "ordinal 0" ambiguous.
+    pub replica_ordinal: Option<u32>,
+    pub rejects: Vec<(RejectReason, u64)>,
+    pub build: BuildInfo,
+}
+
+/// Sample every gauge from live server state.
+///
+/// Each mutex is taken and released on its own. The scrape must not hold two at
+/// once: the game loop takes `sessions` and `connections` together in places,
+/// and a scrape that acquired them in the other order would be a lock-ordering
+/// edge introduced purely by observability.
+pub async fn collect(app: &AppState) -> Snapshot {
+    let (games_active, game_codes) = {
+        let mgr = app.sessions.lock().await;
+        let codes: HashSet<String> = mgr.sessions.keys().cloned().collect();
+        (mgr.sessions.len(), codes)
+    };
+
+    let (drafts_active, draft_codes, drafts_with_seated_humans) = {
+        let mgr = app.draft_sessions.lock().await;
+        let codes: HashSet<String> = mgr.sessions.keys().cloned().collect();
+        let seated: HashSet<String> = mgr
+            .sessions
+            .iter()
+            .filter(|(_, session)| session.connected.iter().any(|connected| *connected))
+            .map(|(code, _)| code.clone())
+            .collect();
+        (mgr.sessions.len(), codes, seated)
+    };
+
+    // A disconnect does not remove the player's sender from `connections` (the
+    // socket may reconnect into the same slot), so presence of a key proves
+    // nothing. The socket task owns the receiver, so `is_closed()` flipping is
+    // what actually tracks "someone is on the other end" — the same test the
+    // spectator pruning helpers use.
+    let games_with_live_players = live_keys(&*app.connections.lock().await, |players| {
+        players.values().any(|tx| !tx.is_closed())
+    });
+    let games_with_live_spectators = live_keys(&*app.game_spectators.lock().await, |senders| {
+        senders.iter().any(|tx| !tx.is_closed())
+    });
+    let drafts_with_live_spectators = live_keys(&*app.draft_spectators.lock().await, |watchers| {
+        watchers.iter().any(|(_, tx)| !tx.is_closed())
+    });
+
+    // Intersect with the live session maps: `connections` and the spectator
+    // maps can still hold an entry for a game that has already been retired.
+    let games_with_connected_humans = game_codes
+        .iter()
+        .filter(|code| {
+            games_with_live_players.contains(*code) || games_with_live_spectators.contains(*code)
+        })
+        .count();
+    let drafts_with_connected_humans = draft_codes
+        .iter()
+        .filter(|code| {
+            drafts_with_seated_humans.contains(*code) || drafts_with_live_spectators.contains(*code)
+        })
+        .count();
+
+    Snapshot {
+        connections: app.player_count.load(Ordering::Relaxed),
+        connections_capacity: app.context.limits.max_connections,
+        games_active,
+        games_with_connected_humans,
+        games_capacity: app.context.limits.max_games,
+        drafts_active,
+        drafts_with_connected_humans,
+        replica_ordinal: app.context.replica_ordinal,
+        rejects: RejectReason::ALL
+            .iter()
+            .map(|&reason| (reason, app.context.metrics.reject_count(reason)))
+            .collect(),
+        build: BuildInfo::current(app.mode),
+    }
+}
+
+/// Keys of `map` whose value holds at least one still-open sender.
+fn live_keys<V>(
+    map: &std::collections::HashMap<String, V>,
+    any_open: impl Fn(&V) -> bool,
+) -> HashSet<String> {
+    map.iter()
+        .filter(|(_, value)| any_open(value))
+        .map(|(key, _)| key.clone())
+        .collect()
+}
+
+/// Escape a Prometheus label value: backslash, double quote and newline.
+fn escape_label(value: &str) -> String {
+    let mut out = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '\\' => out.push_str("\\\\"),
+            '"' => out.push_str("\\\""),
+            '\n' => out.push_str("\\n"),
+            _ => out.push(ch),
+        }
+    }
+    out
+}
+
+fn gauge(out: &mut String, name: &str, help: &str, value: impl std::fmt::Display) {
+    let _ = writeln!(out, "# HELP {name} {help}");
+    let _ = writeln!(out, "# TYPE {name} gauge");
+    let _ = writeln!(out, "{name} {value}");
+}
+
+/// Render a snapshot as Prometheus text exposition.
+pub fn render(snapshot: &Snapshot) -> String {
+    let mut out = String::new();
+
+    gauge(
+        &mut out,
+        "phase_connections",
+        "Currently open WebSocket connections.",
+        snapshot.connections,
+    );
+    gauge(
+        &mut out,
+        "phase_connections_capacity",
+        "Connections this process admits before refusing upgrades.",
+        snapshot.connections_capacity,
+    );
+    gauge(
+        &mut out,
+        "phase_games_active",
+        "Game sessions held by this process.",
+        snapshot.games_active,
+    );
+    gauge(
+        &mut out,
+        "phase_games_with_connected_humans",
+        "Game sessions with at least one live player or spectator socket.",
+        snapshot.games_with_connected_humans,
+    );
+    gauge(
+        &mut out,
+        "phase_games_capacity",
+        "Game sessions this process admits before refusing CreateGame.",
+        snapshot.games_capacity,
+    );
+    gauge(
+        &mut out,
+        "phase_drafts_active",
+        "Draft sessions held by this process.",
+        snapshot.drafts_active,
+    );
+    gauge(
+        &mut out,
+        "phase_drafts_with_connected_humans",
+        "Draft sessions with at least one connected seat or live spectator socket.",
+        snapshot.drafts_with_connected_humans,
+    );
+    if let Some(ordinal) = snapshot.replica_ordinal {
+        gauge(
+            &mut out,
+            "phase_replica_ordinal",
+            "Ordinal of this replica within its StatefulSet.",
+            ordinal,
+        );
+    }
+
+    let _ = writeln!(
+        &mut out,
+        "# HELP phase_admission_rejects_total Connections and games refused at admission."
+    );
+    let _ = writeln!(&mut out, "# TYPE phase_admission_rejects_total counter");
+    for (reason, count) in &snapshot.rejects {
+        let _ = writeln!(
+            &mut out,
+            "phase_admission_rejects_total{{reason=\"{}\"}} {count}",
+            reason.label()
+        );
+    }
+
+    let _ = writeln!(
+        &mut out,
+        "# HELP phase_build_info Build identity of this process; the value is always 1."
+    );
+    let _ = writeln!(&mut out, "# TYPE phase_build_info gauge");
+    let _ = writeln!(
+        &mut out,
+        "phase_build_info{{version=\"{}\",commit=\"{}\",mode=\"{}\"}} 1",
+        escape_label(&snapshot.build.version),
+        escape_label(&snapshot.build.commit),
+        escape_label(snapshot.build.mode),
+    );
+
+    out
+}
+
+/// `GET /metrics` on the metrics listener.
+pub async fn handler(State(app): State<AppState>) -> impl IntoResponse {
+    let body = render(&collect(&app).await);
+    ([(http::header::CONTENT_TYPE, CONTENT_TYPE)], body)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn snapshot() -> Snapshot {
+        Snapshot {
+            connections: 7,
+            connections_capacity: 200,
+            games_active: 4,
+            games_with_connected_humans: 2,
+            games_capacity: 100,
+            drafts_active: 1,
+            drafts_with_connected_humans: 1,
+            replica_ordinal: Some(3),
+            rejects: vec![
+                (RejectReason::ConnectionLimit, 5),
+                (RejectReason::GameLimit, 0),
+                (RejectReason::OriginNotAllowed, 2),
+            ],
+            build: BuildInfo {
+                version: "1.2.3".to_string(),
+                commit: "abc123".to_string(),
+                mode: "full",
+            },
+        }
+    }
+
+    /// The exposition is a wire contract a scraper parses, so assert the whole
+    /// body rather than probing for substrings: a renamed metric, a dropped
+    /// TYPE line or a value read from the wrong field all fail here.
+    #[test]
+    fn render_emits_every_family_with_its_values() {
+        let expected = concat!(
+            "# HELP phase_connections Currently open WebSocket connections.\n",
+            "# TYPE phase_connections gauge\n",
+            "phase_connections 7\n",
+            "# HELP phase_connections_capacity Connections this process admits before refusing upgrades.\n",
+            "# TYPE phase_connections_capacity gauge\n",
+            "phase_connections_capacity 200\n",
+            "# HELP phase_games_active Game sessions held by this process.\n",
+            "# TYPE phase_games_active gauge\n",
+            "phase_games_active 4\n",
+            "# HELP phase_games_with_connected_humans Game sessions with at least one live player or spectator socket.\n",
+            "# TYPE phase_games_with_connected_humans gauge\n",
+            "phase_games_with_connected_humans 2\n",
+            "# HELP phase_games_capacity Game sessions this process admits before refusing CreateGame.\n",
+            "# TYPE phase_games_capacity gauge\n",
+            "phase_games_capacity 100\n",
+            "# HELP phase_drafts_active Draft sessions held by this process.\n",
+            "# TYPE phase_drafts_active gauge\n",
+            "phase_drafts_active 1\n",
+            "# HELP phase_drafts_with_connected_humans Draft sessions with at least one connected seat or live spectator socket.\n",
+            "# TYPE phase_drafts_with_connected_humans gauge\n",
+            "phase_drafts_with_connected_humans 1\n",
+            "# HELP phase_replica_ordinal Ordinal of this replica within its StatefulSet.\n",
+            "# TYPE phase_replica_ordinal gauge\n",
+            "phase_replica_ordinal 3\n",
+            "# HELP phase_admission_rejects_total Connections and games refused at admission.\n",
+            "# TYPE phase_admission_rejects_total counter\n",
+            "phase_admission_rejects_total{reason=\"connection_limit\"} 5\n",
+            "phase_admission_rejects_total{reason=\"game_limit\"} 0\n",
+            "phase_admission_rejects_total{reason=\"origin_not_allowed\"} 2\n",
+            "# HELP phase_build_info Build identity of this process; the value is always 1.\n",
+            "# TYPE phase_build_info gauge\n",
+            "phase_build_info{version=\"1.2.3\",commit=\"abc123\",mode=\"full\"} 1\n",
+        );
+
+        assert_eq!(render(&snapshot()), expected);
+    }
+
+    /// `None` must drop the family entirely. Emitting `phase_replica_ordinal 0`
+    /// for an un-ordinalled process would be indistinguishable from ordinal 0,
+    /// and the scale-in floor is computed from exactly that number.
+    #[test]
+    fn replica_ordinal_family_is_absent_when_the_process_has_no_ordinal() {
+        let with_ordinal = render(&snapshot());
+        let without = render(&Snapshot {
+            replica_ordinal: None,
+            ..snapshot()
+        });
+
+        assert!(with_ordinal.contains("phase_replica_ordinal 3\n"));
+        assert!(!without.contains("phase_replica_ordinal"));
+        // Nothing else moved: the two renders differ by exactly the three lines.
+        assert_eq!(
+            with_ordinal.lines().count() - without.lines().count(),
+            3,
+            "removing the ordinal must drop only its HELP/TYPE/value lines"
+        );
+    }
+
+    /// A commit label is operator-supplied build metadata; unescaped `"` would
+    /// terminate the label value and corrupt every following series in the
+    /// scrape, so the escaping is load-bearing rather than cosmetic.
+    #[test]
+    fn label_values_escape_backslash_quote_and_newline() {
+        assert_eq!(escape_label(r#"a"b"#), r#"a\"b"#);
+        assert_eq!(escape_label(r"a\b"), r"a\\b");
+        assert_eq!(escape_label("a\nb"), r"a\nb");
+        assert_eq!(escape_label("plain-0.1.2"), "plain-0.1.2");
+
+        let rendered = render(&Snapshot {
+            build: BuildInfo {
+                version: "1.0".to_string(),
+                commit: "we\"ird\\ni".to_string(),
+                mode: "full",
+            },
+            ..snapshot()
+        });
+        assert!(
+            rendered
+                .contains(r#"phase_build_info{version="1.0",commit="we\"ird\\ni",mode="full"} 1"#),
+            "escaped label missing from:\n{rendered}"
+        );
+    }
+
+    #[test]
+    fn every_reject_reason_gets_its_own_line_in_the_render() {
+        // `label` and `counter` match exhaustively, so a new variant breaks
+        // their compilation — but nothing forces it into `ALL`, and a variant
+        // missing from `ALL` is simply absent from /metrics. This match is that
+        // reminder: adding a variant stops compiling here.
+        match RejectReason::ConnectionLimit {
+            RejectReason::ConnectionLimit
+            | RejectReason::GameLimit
+            | RejectReason::OriginNotAllowed => {}
+        }
+        assert_eq!(RejectReason::ALL.len(), 3);
+
+        let body = render(&Snapshot {
+            rejects: RejectReason::ALL
+                .iter()
+                .map(|reason| (*reason, 0))
+                .collect(),
+            ..snapshot()
+        });
+
+        for reason in RejectReason::ALL {
+            let line = format!(
+                "phase_admission_rejects_total{{reason=\"{}\"}} 0",
+                reason.label()
+            );
+            assert_eq!(
+                body.matches(&line).count(),
+                1,
+                "{} should appear exactly once in:\n{body}",
+                reason.label()
+            );
+        }
+    }
+
+    #[test]
+    fn recorded_rejections_are_counted_per_reason() {
+        let metrics = ServerMetrics::default();
+        metrics.record_reject(RejectReason::ConnectionLimit);
+        metrics.record_reject(RejectReason::ConnectionLimit);
+        metrics.record_reject(RejectReason::OriginNotAllowed);
+
+        assert_eq!(metrics.reject_count(RejectReason::ConnectionLimit), 2);
+        assert_eq!(metrics.reject_count(RejectReason::OriginNotAllowed), 1);
+        // Untouched reasons must not move: one shared counter behind all three
+        // labels would still pass the two assertions above.
+        assert_eq!(metrics.reject_count(RejectReason::GameLimit), 0);
+    }
+}

--- a/deploy/helm/phase-server/Chart.yaml
+++ b/deploy/helm/phase-server/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: phase-server
 description: phase.rs multiplayer server (Axum WebSocket) behind Traefik + cert-manager
 type: application
-version: 0.1.0
+version: 0.2.0
 appVersion: "0.59.0"
 home: https://github.com/phase-rs/phase
 sources:

--- a/deploy/helm/phase-server/README.md
+++ b/deploy/helm/phase-server/README.md
@@ -176,15 +176,50 @@ volume:
 ```bash
 PV=$(kubectl -n phase get pvc <release>-data -o jsonpath='{.spec.volumeName}')
 kubectl patch pv "$PV" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
-kubectl -n phase delete pvc <release>-data          # PV survives; it is Retain now
-kubectl patch pv "$PV" -p '{"spec":{"claimRef":null}}'
-# then create a PVC named data-<release>-0 with the same storageClass/size,
-# bound to "$PV" via spec.volumeName, before running `helm upgrade`.
+kubectl -n phase scale deploy/<release> --replicas=0        # release the volume
+kubectl patch pv "$PV" --type=json -p='[{"op":"remove","path":"/spec/claimRef"}]'
+
+# Create the claim FIRST, pointing at the PV, then let the bind happen. Setting
+# the PV's claimRef to a claim that does not exist yet moves it to `Released`,
+# and a Released PV will not bind to anything.
+kubectl -n phase apply -f - <<YAML
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata: {name: data-<release>-0, namespace: phase}
+spec:
+  accessModes: [ReadWriteOnce]
+  storageClassName: <same as before>
+  volumeName: $PV
+  resources: {requests: {storage: <same as before>}}
+YAML
 ```
+
+The old `<release>-data` claim is left behind in `Lost` — keep it until ordinal 0
+is up on the adopted data, then delete it.
 
 The chart marks the old claim `helm.sh/resource-policy: keep`, so the upgrade
 itself will not delete it — but a `Delete` reclaim policy on the PV still will
-once the claim goes, which is why the `Retain` patch comes first.
+once the claim goes, which is why the `Retain` patch comes first. Helm reads that
+annotation from the **live** object, so a release installed before chart 0.2.0
+needs it applied by hand first:
+
+```bash
+kubectl -n phase annotate pvc <release>-data helm.sh/resource-policy=keep --overwrite
+```
+
+**The TLS secret changes owner.** On the Ingress path cert-manager's ingress-shim
+creates a Certificate named after the *secret*; this chart creates one named after
+the *release*, and both want the same secret. cert-manager will not overwrite a
+secret whose `cert-manager.io/certificate-name` annotation names a different
+Certificate — it reports `IncorrectCertificate` and then does nothing: no
+CertificateRequest, no Events. The ordinal hosts stay on the old single-SAN
+certificate and an edge proxy answers 526 while the entry host keeps working, which
+looks like a DNS problem and is not. Hand the secret over once:
+
+```bash
+kubectl -n phase annotate secret <release>-tls \
+  cert-manager.io/certificate-name=<release> --overwrite
+```
 
 ## Autoscaling
 

--- a/deploy/helm/phase-server/README.md
+++ b/deploy/helm/phase-server/README.md
@@ -71,6 +71,30 @@ chart still installs on a cluster with no prometheus-operator. Set
 `networkPolicy.enabled`, `metrics.scrapeNamespaceLabels` must name the
 scraper's namespace or the target is simply down while the pod stays healthy.
 
+### With kube-prometheus-stack
+
+That chart defaults every selector to "only objects carrying my own release
+label":
+
+```yaml
+prometheus:
+  prometheusSpec:
+    podMonitorSelectorNilUsesHelmValues: false
+    ruleSelectorNilUsesHelmValues: false
+```
+
+Left at the default, Prometheus ignores this chart's `PodMonitor` and
+`PrometheusRule` — silently. Nothing errors; `phase:wanted_replicas` simply
+never exists, the HPA reports the metric as unavailable, and the deployment
+looks healthy throughout. Either set the two keys above, or add the release
+label the operator expects via `metrics.podMonitor.labels` and
+`autoscaling.prometheusRule.labels`.
+
+Also give Prometheus a `retentionSize`, not just a `retention`. With node-local
+storage (k3s `local-path`, hostPath) the volume is the node's root filesystem,
+and a retention window sized for a quiet week fills the disk during a busy one —
+which evicts pods, this chart's included.
+
 ## Behind Cloudflare
 
 Traefik typically sees a SNAT'd node IP (Service `externalTrafficPolicy: Cluster`),
@@ -138,8 +162,9 @@ per ordinal (or a wildcard) pointing at the same ingress.
 **Middlewares.** `traefik.middlewares.extra` is the Ingress *annotation* syntax
 (`<ns>-<name>@kubernetescrd`), which the IngressRoute CRD provider rejects — and
 a bad reference makes Traefik drop the whole route rather than fail loudly. With
-`scaleOut.enabled` the chart refuses to render if `extra` is set; list extras
-under `scaleOut.extraMiddlewareRefs` as `{name, namespace}` instead.
+`scaleOut.enabled` the chart refuses to render if `extra` is set — whatever
+`traefik.middlewares.enabled` says, because the value is dropped either way —
+so list extras under `scaleOut.extraMiddlewareRefs` as `{name, namespace}`.
 
 ### Migrating an existing single-pod release
 
@@ -162,6 +187,11 @@ itself will not delete it — but a `Delete` reclaim policy on the PV still will
 once the claim goes, which is why the `Retain` patch comes first.
 
 ## Autoscaling
+
+The HPA renders whether or not prometheus-operator is installed, but the
+`PrometheusRule` does not — so on a cluster without the CRDs the external
+metric never exists and the HPA sits at `FailedGetExternalMetric`. Install the
+operator (and prometheus-adapter) before turning autoscaling on.
 
 `autoscaling.enabled` (which requires `scaleOut.enabled`) adds a
 `PrometheusRule` and an HPA. The **policy lives in the recording rule**, not in

--- a/deploy/helm/phase-server/README.md
+++ b/deploy/helm/phase-server/README.md
@@ -228,10 +228,14 @@ kubectl -n phase annotate secret <release>-tls \
 
 ## Autoscaling
 
-The HPA renders whether or not prometheus-operator is installed, but the
-`PrometheusRule` does not — so on a cluster without the CRDs the external
-metric never exists and the HPA sits at `FailedGetExternalMetric`. Install the
-operator (and prometheus-adapter) before turning autoscaling on.
+Turning autoscaling on without the prometheus-operator CRDs is a render-time
+error, not a silent one. The HPA's only source of `phase:wanted_replicas` is the
+`PrometheusRule`, which needs `monitoring.coreos.com/v1`; installing the HPA
+without it would leave it at `FailedGetExternalMetric` forever, so the chart
+refuses to render that combination. Install the operator (and prometheus-adapter)
+before turning autoscaling on — or, if you produce the recording rule yourself,
+set `autoscaling.prometheusRule.enabled=false` and supply it externally (see
+`examples/prometheus-adapter-values.yaml`); that path needs no operator at all.
 
 `autoscaling.enabled` (which requires `scaleOut.enabled`) adds a
 `PrometheusRule` and an HPA. The **policy lives in the recording rule**, not in

--- a/deploy/helm/phase-server/README.md
+++ b/deploy/helm/phase-server/README.md
@@ -176,7 +176,12 @@ volume:
 ```bash
 PV=$(kubectl -n phase get pvc <release>-data -o jsonpath='{.spec.volumeName}')
 kubectl patch pv "$PV" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
-kubectl -n phase scale deploy/<release> --replicas=0        # release the volume
+kubectl -n phase scale deploy/<release> --replicas=0
+# `scale` returns immediately. Wait for the pod to be GONE before touching the
+# volume: rebinding it while the old process still has games.db open is exactly
+# the two-writers case the per-ordinal claims exist to prevent.
+kubectl -n phase wait --for=delete pod -l app.kubernetes.io/name=phase-server --timeout=120s
+
 kubectl patch pv "$PV" --type=json -p='[{"op":"remove","path":"/spec/claimRef"}]'
 
 # Create the claim FIRST, pointing at the PV, then let the bind happen. Setting

--- a/deploy/helm/phase-server/README.md
+++ b/deploy/helm/phase-server/README.md
@@ -35,6 +35,41 @@ Measured against `crates/phase-server` v0.59.0:
   that bounds PVC growth. Size `persistence.size` with that in mind.
 - SIGTERM triggers a session flush; open WebSockets are not closed by the server,
   so the pod is killed after `terminationGracePeriodSeconds`.
+- `PUBLIC_URL` is what the server advertises in `ServerHello`, and it is what a
+  host's client turns into a `CODE@host` share string. It must be an absolute
+  URL with a host (`https://play.example.com`); the server validates it at
+  startup and advertises *nothing* if it does not parse, which costs players
+  their join links without failing the pod. `server.publicUrl` sets it
+  explicitly; otherwise it is derived from `ingress.host`, and rendering fails
+  when neither is available rather than guessing a URL.
+
+## Metrics
+
+`metrics.enabled` starts a second listener (`PHASE_METRICS_PORT`) serving
+Prometheus text at `/metrics`. It is a separate container port on purpose: the
+gauges describe capacity and occupancy, and nothing routes them through the
+Ingress.
+
+| Metric | |
+|---|---|
+| `phase_connections` / `phase_connections_capacity` | open sockets against the cap that returns 503 |
+| `phase_games_active` / `phase_games_capacity` | sessions against the cap that refuses `CreateGame` |
+| `phase_games_with_connected_humans` | sessions with at least one live player *or spectator* socket |
+| `phase_drafts_active` / `phase_drafts_with_connected_humans` | the same pair for server-hosted drafts |
+| `phase_replica_ordinal` | this replica's ordinal, when one was set |
+| `phase_admission_rejects_total{reason}` | refusals by `connection_limit`, `game_limit`, `origin_not_allowed` |
+| `phase_build_info{version,commit,mode}` | build identity, always `1` |
+
+The occupancy gauges count *live sockets*, not map entries — a player who
+disconnected leaves their entry behind, and the reconnect grace keeps the
+session alive, so "sessions" and "sessions someone is on" are different numbers.
+
+Discovery is a `PodMonitor` (per-pod, so each replica reports its own
+occupancy), rendered only when `monitoring.coreos.com/v1` is present so the
+chart still installs on a cluster with no prometheus-operator. Set
+`metrics.annotations=true` for the `prometheus.io/*` fallback. With
+`networkPolicy.enabled`, `metrics.scrapeNamespaceLabels` must name the
+scraper's namespace or the target is simply down while the pod stays healthy.
 
 ## Behind Cloudflare
 
@@ -52,6 +87,117 @@ the host in this chart.
 
 Cloudflare closes idle WebSockets after ~100 s; the client's 5 s application
 ping keeps game connections alive.
+
+## Scaling out
+
+`scaleOut.enabled` replaces the single Deployment with a StatefulSet: one pod,
+one PVC and one hostname per ordinal.
+
+**Why not `replicas: N` on the Deployment.** Every process owns its own SQLite
+`games.db`, and two processes on one database is destructive rather than merely
+racy: the second restores every live game at boot, arms a 120 s reconnect grace
+it never had, and its reaper then retires the rows the first process is still
+playing — after which the owning process has its snapshots rejected and cannot
+write results. `volumeClaimTemplates` is what makes that impossible.
+
+**How a player reaches the right pod.** Each ordinal advertises its own
+hostname as `PUBLIC_URL`, so a game created on ordinal 1 produces the share
+string `CODE@phase-1.example.com`, and a friend joining by code dials that host
+and lands on the pod holding the game. The entry host (`ingress.host`) balances
+new arrivals across ready pods with a sticky cookie.
+
+**The sticky cookie is load-bearing, and it is a third-party cookie.** A host's
+own game socket is re-opened against the stored entry address after the game
+starts, not against the pod it was already talking to, so without the cookie
+that socket can land on the wrong pod. Traefik sets it on the 101 response with
+`sameSite: none; secure`, which Chrome and Firefox honour and Safari (and
+anything blocking third-party cookies) does not — those browsers get a
+`(N-1)/N` chance of losing the host's own reconnect. Verify on a two-replica
+canary before trusting it:
+
+```bash
+curl -i -N -H 'Connection: Upgrade' -H 'Upgrade: websocket' \
+  -H 'Sec-WebSocket-Version: 13' -H 'Sec-WebSocket-Key: dGhlIHNhbXBsZSBub25jZQ==' \
+  https://phase.example.com/ws | grep -i set-cookie
+```
+
+The upstream fix is a client change — derived sockets dialling the
+`public_url` from their own `ServerHello` instead of the global server address —
+which removes the cookie dependency entirely. Until that lands, treat scale-out
+as requiring third-party cookies.
+
+**DNS and certificates.** Ordinal hostnames must sit at the *same* DNS level as
+the entry host (`phase-0.example.com`, not `0.phase.example.com`). Behind a CDN
+this is not cosmetic: a wildcard edge certificate covers exactly one label, so a
+proxied second-level name is served a certificate that does not match it.
+`scaleOut.tls` issues one cert-manager `Certificate` covering the entry host and
+every ordinal host — IngressRoute is not an Ingress, so cert-manager's
+ingress-shim cannot derive it from an annotation. You still need a DNS record
+per ordinal (or a wildcard) pointing at the same ingress.
+
+**Middlewares.** `traefik.middlewares.extra` is the Ingress *annotation* syntax
+(`<ns>-<name>@kubernetescrd`), which the IngressRoute CRD provider rejects — and
+a bad reference makes Traefik drop the whole route rather than fail loudly. With
+`scaleOut.enabled` the chart refuses to render if `extra` is set; list extras
+under `scaleOut.extraMiddlewareRefs` as `{name, namespace}` instead.
+
+### Migrating an existing single-pod release
+
+The Deployment's claim is `<release>-data`; the StatefulSet wants
+`data-<release>-0`. **Before upgrading**, either accept a fresh ordinal 0 (it
+re-downloads card data and starts with no saved games) or adopt the existing
+volume:
+
+```bash
+PV=$(kubectl -n phase get pvc <release>-data -o jsonpath='{.spec.volumeName}')
+kubectl patch pv "$PV" -p '{"spec":{"persistentVolumeReclaimPolicy":"Retain"}}'
+kubectl -n phase delete pvc <release>-data          # PV survives; it is Retain now
+kubectl patch pv "$PV" -p '{"spec":{"claimRef":null}}'
+# then create a PVC named data-<release>-0 with the same storageClass/size,
+# bound to "$PV" via spec.volumeName, before running `helm upgrade`.
+```
+
+The chart marks the old claim `helm.sh/resource-policy: keep`, so the upgrade
+itself will not delete it — but a `Delete` reclaim policy on the PV still will
+once the claim goes, which is why the `Retain` patch comes first.
+
+## Autoscaling
+
+`autoscaling.enabled` (which requires `scaleOut.enabled`) adds a
+`PrometheusRule` and an HPA. The **policy lives in the recording rule**, not in
+the HPA, because the binding constraint cannot be written as a utilisation
+target: a StatefulSet always removes its *highest* ordinal, so scaling in is
+only safe when that particular ordinal has nobody on it. The rule takes the
+maximum of three terms —
+
+| term | meaning |
+|---|---|
+| `source="games"` | games packed to `targetUtilization` of a replica's capacity |
+| `source="connections"` | the same against the socket cap, which binds first for multiplayer tables |
+| `source="occupied_floor"` | highest ordinal still holding a human, plus one |
+
+— clamps it to `[minReplicas, scaleOut.replicaMax]`, and records it as
+`phase:wanted_replicas`. The HPA then reads that through prometheus-adapter as
+an **External** metric with `target.type: AverageValue, averageValue: "1"`.
+`AverageValue` is required: the `Value` path multiplies by the current replica
+count, so a metric that already *is* the desired count would compound.
+
+Requires prometheus-operator (for the `PrometheusRule` and `PodMonitor`) and
+prometheus-adapter — see
+[`examples/prometheus-adapter-values.yaml`](examples/prometheus-adapter-values.yaml).
+Only one phase-server release per namespace: the rule aggregates by namespace.
+
+Two things worth knowing before reading the graph:
+
+- The HPA acts only outside its ~10% tolerance band, so treat
+  `phase:wanted_replicas` as authoritative for real moves, not for exact
+  equality at every instant.
+- "Occupied" means *a socket task is alive*. The server sends no keepalive and
+  applies no read timeout, so a half-open TCP connection keeps its ordinal
+  pinned until the proxy tears it down. Scale-in is deliberately conservative
+  here: a pod that is killed preserves its games on its PVC for 24 h and
+  restores them if the ordinal returns, whereas a pod held drained loses
+  disconnected players' games to the 120 s reaper.
 
 ## Building the image
 

--- a/deploy/helm/phase-server/examples/prometheus-adapter-values.yaml
+++ b/deploy/helm/phase-server/examples/prometheus-adapter-values.yaml
@@ -1,0 +1,41 @@
+# Example values for prometheus-community/prometheus-adapter, to expose the
+# chart's recording rule to the HPA as an external metric.
+#
+#   helm install prometheus-adapter prometheus-community/prometheus-adapter \
+#     -n monitoring -f prometheus-adapter-values.yaml
+#
+# Without an adapter the HPA has nothing to read: Kubernetes ships no
+# external.metrics.k8s.io provider of its own. Check it is wired up with
+#
+#   kubectl get --raw \
+#     "/apis/external.metrics.k8s.io/v1beta1/namespaces/<ns>/phase_wanted_replicas"
+#
+# The rename is deliberate. `phase:wanted_replicas` is the Prometheus recording
+# rule (the colon is the convention for a recorded series); `phase_wanted_replicas`
+# is the metric name the HPA asks for, because a colon is not valid in a
+# Kubernetes metric name. Keep `autoscaling.recordName` and
+# `autoscaling.metricName` in the chart matching the two halves below.
+
+prometheus:
+  # Adjust to your kube-prometheus-stack release name and namespace.
+  url: http://prometheus-operated.monitoring.svc
+  port: 9090
+
+rules:
+  # The stock rule set maps container CPU/memory. None of it is needed here, and
+  # leaving it on makes the adapter re-scan a lot of series it will never serve.
+  default: false
+  external:
+    - seriesQuery: '{__name__="phase:wanted_replicas"}'
+      resources:
+        # Associate the series with the namespace it carries, so the adapter can
+        # answer the namespaced External Metrics API path the HPA calls.
+        overrides:
+          namespace:
+            resource: namespace
+      name:
+        matches: "^phase:wanted_replicas$"
+        as: "phase_wanted_replicas"
+      # `service` must survive the aggregation: the HPA selects on it, so that
+      # two releases cannot read each other's answer.
+      metricsQuery: 'max(<<.Series>>{<<.LabelMatchers>>}) by (namespace, service)'

--- a/deploy/helm/phase-server/templates/NOTES.txt
+++ b/deploy/helm/phase-server/templates/NOTES.txt
@@ -4,6 +4,19 @@ phase-server {{ .Chart.AppVersion }} ({{ if .Values.server.lobbyOnly }}lobby-onl
 WebSocket URL for the client's Server picker:  wss://{{ .Values.ingress.host }}/ws
 Health:                                        https://{{ .Values.ingress.host }}/health
 {{- end }}
+{{- if .Values.scaleOut.enabled }}
+
+Each ordinal is also reachable on its own hostname, which is what a shared
+"CODE@host" string resolves to:
+{{- range $i := until (int .Values.scaleOut.replicaMax) }}
+  {{ $.Values.scaleOut.scheme | default "https" }}://{{ include "phase-server.ordinalHost" (dict "ctx" $ "ordinal" $i) }}
+{{- end }}
+{{- end }}
 
 First boot downloads ~100 MiB of card data into the PVC before /health answers.
+{{- if .Values.scaleOut.enabled }}
+Every ordinal does this into its own volume, so a scale-up is not instant.
+Follow with:  kubectl -n {{ .Release.Namespace }} logs statefulset/{{ include "phase-server.fullname" . }} -f
+{{- else }}
 Follow with:  kubectl -n {{ .Release.Namespace }} logs deploy/{{ include "phase-server.fullname" . }} -f
+{{- end }}

--- a/deploy/helm/phase-server/templates/_helpers.tpl
+++ b/deploy/helm/phase-server/templates/_helpers.tpl
@@ -347,3 +347,25 @@ tolerations:
   {{- toYaml . | nindent 2 }}
 {{- end }}
 {{- end -}}
+
+{{/*
+Whether each monitor will actually render: the value asks for it AND the cluster
+can hold the kind.
+
+Single authority on purpose. `prometheusrule.yaml` fails the render unless a
+scrape target exists, and testing only the value there let a cluster with the
+PrometheusRule CRD but neither monitor CRD render the rule and the HPA with
+nothing scraping the raw gauges. Empty string is false, so callers can use
+`if (include ...)`.
+*/}}
+{{- define "phase-server.podMonitorRenders" -}}
+{{- if and .Values.metrics.enabled .Values.metrics.podMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") -}}
+true
+{{- end -}}
+{{- end -}}
+
+{{- define "phase-server.serviceMonitorRenders" -}}
+{{- if and .Values.metrics.enabled .Values.metrics.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") -}}
+true
+{{- end -}}
+{{- end -}}

--- a/deploy/helm/phase-server/templates/_helpers.tpl
+++ b/deploy/helm/phase-server/templates/_helpers.tpl
@@ -145,6 +145,9 @@ traefik.ingress.kubernetes.io/router.tls.options: {{ include "phase-server.crdRe
 {{- $tmpl := .Values.scaleOut.ordinalHostTemplate -}}
 {{- if not $tmpl -}}
 {{- $host := required "ingress.host is required for scaleOut: it is the entry hostname the ordinal hostnames are derived from." .Values.ingress.host -}}
+{{- if not (contains "." $host) -}}
+{{- fail (printf "ingress.host %q has a single label, so no ordinal hostname can be derived from it (the result would be %q, which nothing resolves and no certificate covers). Give ingress.host a domain, or set scaleOut.ordinalHostTemplate explicitly." $host (printf "%s-0." $host)) -}}
+{{- end -}}
 {{- $parts := splitn "." 2 $host -}}
 {{- $tmpl = printf "%s-{ordinal}.%s" $parts._0 $parts._1 -}}
 {{- end -}}

--- a/deploy/helm/phase-server/templates/_helpers.tpl
+++ b/deploy/helm/phase-server/templates/_helpers.tpl
@@ -214,7 +214,7 @@ containers:
             ;;
         esac
         export PHASE_REPLICA_ORDINAL="$ordinal"
-        export PUBLIC_URL="{{ printf "%s://%s" (.Values.scaleOut.scheme | default "https") (index $split 0) }}${ordinal}{{ index $split 1 }}"
+        export PUBLIC_URL="${PHASE_ORDINAL_URL_PREFIX}${ordinal}${PHASE_ORDINAL_URL_SUFFIX}"
         echo "phase-server ordinal ${ordinal}, advertising ${PUBLIC_URL}"
         exec phase-server "$@"
       - --
@@ -252,6 +252,15 @@ containers:
         valueFrom:
           fieldRef:
             fieldPath: metadata.name
+      {{- /* The two halves of the ordinal URL arrive as env values, not spliced
+           into the shell above: a value carrying a quote or `$(...)` would
+           otherwise land inside a double-quoted string and be parsed as shell.
+           Env values are plain YAML, so the shell never parses them. */}}
+      {{- $split := splitList "{ordinal}" (include "phase-server.ordinalHostTemplate" .) }}
+      - name: PHASE_ORDINAL_URL_PREFIX
+        value: {{ printf "%s://%s" (.Values.scaleOut.scheme | default "https") (index $split 0) | quote }}
+      - name: PHASE_ORDINAL_URL_SUFFIX
+        value: {{ index $split 1 | quote }}
       {{- else }}
       - name: PUBLIC_URL
         value: {{ include "phase-server.publicUrl" . | quote }}

--- a/deploy/helm/phase-server/templates/_helpers.tpl
+++ b/deploy/helm/phase-server/templates/_helpers.tpl
@@ -93,3 +93,245 @@ requestHeaderName: CF-Connecting-IP
 traefik.ingress.kubernetes.io/router.tls.options: {{ include "phase-server.crdRef" (dict "ctx" . "suffix" "cf-origin-pull") | quote }}
 {{- end }}
 {{- end -}}
+
+{{/* Pod annotations: the operator's own, plus the prometheus.io/* trio when
+     metrics.annotations is set (for scrapers that discover by annotation
+     rather than by PodMonitor/ServiceMonitor). */}}
+{{- define "phase-server.podAnnotations" -}}
+{{- $annotations := default (dict) .Values.podAnnotations -}}
+{{- if and .Values.metrics.enabled .Values.metrics.annotations -}}
+{{- $annotations = merge (dict
+      "prometheus.io/scrape" "true"
+      "prometheus.io/port" (printf "%v" .Values.metrics.port)
+      "prometheus.io/path" .Values.metrics.path) $annotations -}}
+{{- end -}}
+{{- with $annotations }}
+{{- toYaml . }}
+{{- end }}
+{{- end -}}
+
+{{/* Middleware references for an IngressRoute.
+
+     NOT interchangeable with `phase-server.commonMiddlewares`: that helper emits
+     Traefik's *annotation* syntax (`<ns>-<name>@kubernetescrd`), which the CRD
+     provider rejects — `@` is not legal in `routes[].middlewares[].name`, and a
+     namespace-qualified reference additionally needs `allowCrossNamespace` on
+     the Traefik install. A bad reference does not fail loudly: Traefik drops the
+     whole route, so the host simply stops answering.
+
+     Same namespace as the IngressRoute, so `namespace:` is left off. */}}
+{{- define "phase-server.middlewareRefs" -}}
+{{- $fullname := include "phase-server.fullname" . -}}
+{{- if .Values.traefik.middlewares.enabled }}
+- name: {{ $fullname }}-ratelimit
+- name: {{ $fullname }}-inflight
+- name: {{ $fullname }}-headers
+{{- end }}
+{{- range .Values.scaleOut.extraMiddlewareRefs }}
+- name: {{ .name }}
+  {{- with .namespace }}
+  namespace: {{ . }}
+  {{- end }}
+{{- end }}
+{{- end -}}
+
+{{/* The resolved per-ordinal hostname template, containing {ordinal} once.
+
+     The default keeps ordinals at the SAME DNS level as the entry host
+     (`phase-1.example.com`, not `1.phase.example.com`). A wildcard edge
+     certificate covers exactly one label, so a proxied second-level name would
+     be served a certificate that does not match it. */}}
+{{- define "phase-server.ordinalHostTemplate" -}}
+{{- $tmpl := .Values.scaleOut.ordinalHostTemplate -}}
+{{- if not $tmpl -}}
+{{- $host := required "ingress.host is required for scaleOut: it is the entry hostname the ordinal hostnames are derived from." .Values.ingress.host -}}
+{{- $parts := splitn "." 2 $host -}}
+{{- $tmpl = printf "%s-{ordinal}.%s" $parts._0 $parts._1 -}}
+{{- end -}}
+{{- if ne (len (splitList "{ordinal}" $tmpl)) 2 -}}
+{{- fail (printf "scaleOut.ordinalHostTemplate must contain the literal {ordinal} placeholder exactly once; got %q" $tmpl) -}}
+{{- end -}}
+{{- $tmpl -}}
+{{- end -}}
+
+{{/* Hostname for one ordinal: dict "ctx" $ "ordinal" <n> */}}
+{{- define "phase-server.ordinalHost" -}}
+{{- $split := splitList "{ordinal}" (include "phase-server.ordinalHostTemplate" .ctx) -}}
+{{- printf "%s%v%s" (index $split 0) .ordinal (index $split 1) -}}
+{{- end -}}
+
+{{/* Every hostname this release answers on: entry host plus one per ordinal. */}}
+{{- define "phase-server.allHosts" -}}
+{{- $ctx := . -}}
+{{- $hosts := list (required "ingress.host is required for scaleOut." .Values.ingress.host) -}}
+{{- range $i := until (int .Values.scaleOut.replicaMax) -}}
+{{- $hosts = append $hosts (include "phase-server.ordinalHost" (dict "ctx" $ctx "ordinal" $i)) -}}
+{{- end -}}
+{{- toYaml $hosts -}}
+{{- end -}}
+
+{{/* The pod spec, shared by the Deployment (scaleOut off) and the StatefulSet
+     (scaleOut on) so the two cannot drift. The differences are real and few:
+     the StatefulSet derives PUBLIC_URL and PHASE_REPLICA_ORDINAL from its pod
+     ordinal at start-up, and takes its data volume from volumeClaimTemplates
+     instead of a single shared claim. */}}
+{{- define "phase-server.podSpec" -}}
+{{- $scaleOut := .Values.scaleOut.enabled -}}
+serviceAccountName: default
+automountServiceAccountToken: false
+terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+securityContext:
+  {{- toYaml .Values.podSecurityContext | nindent 2 }}
+{{- with .Values.dnsConfig }}
+dnsConfig:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+containers:
+  - name: phase-server
+    image: {{ include "phase-server.image" . }}
+    imagePullPolicy: {{ .Values.image.pullPolicy }}
+    # Bypass the image's root entrypoint (mkdir/chown + gosu); the pod
+    # securityContext already runs us as the `phase` uid with fsGroup.
+    {{- if $scaleOut }}
+    # Each ordinal advertises its OWN hostname: a game's share string is
+    # CODE@<public_url host>, which is what lets a friend joining by code reach
+    # the pod that actually holds the game. `--` is $0 so the chart's flags in
+    # `args` arrive as "$@".
+    {{- $split := splitList "{ordinal}" (include "phase-server.ordinalHostTemplate" .) }}
+    command:
+      - /bin/sh
+      - -c
+      - |
+        set -eu
+        ordinal="${POD_NAME##*-}"
+        case "$ordinal" in
+          ''|*[!0-9]*)
+            echo "cannot derive a StatefulSet ordinal from POD_NAME=$POD_NAME" >&2
+            exit 1
+            ;;
+        esac
+        export PHASE_REPLICA_ORDINAL="$ordinal"
+        export PUBLIC_URL="{{ printf "%s://%s" (.Values.scaleOut.scheme | default "https") (index $split 0) }}${ordinal}{{ index $split 1 }}"
+        echo "phase-server ordinal ${ordinal}, advertising ${PUBLIC_URL}"
+        exec phase-server "$@"
+      - --
+    {{- else }}
+    command: ["phase-server"]
+    {{- end }}
+    {{- /* Emitted even when empty, matching the pre-scaleOut template byte for
+         byte. Under the scaleOut shell wrapper an absent list is still correct:
+         `$@` expands to nothing and the exec runs with no extra flags. */}}
+    args:
+      {{- if .Values.server.allowedOrigin }}
+      - --allowed-origin
+      - {{ .Values.server.allowedOrigin | quote }}
+      {{- end }}
+      {{- if .Values.server.noDataDownload }}
+      - --no-data-download
+      {{- end }}
+    securityContext:
+      {{- toYaml .Values.securityContext | nindent 6 }}
+    env:
+      - name: PORT
+        value: {{ .Values.service.port | quote }}
+      - name: PHASE_DATA_DIR
+        value: /var/lib/phase-server
+      - name: PHASE_LOBBY_ONLY
+        value: {{ .Values.server.lobbyOnly | quote }}
+      - name: PHASE_CORS_ORIGIN
+        value: {{ .Values.server.corsOrigin | quote }}
+      - name: PHASE_LOG_JSON
+        value: {{ .Values.server.logJson | quote }}
+      - name: RUST_LOG
+        value: {{ .Values.server.rustLog | quote }}
+      {{- if $scaleOut }}
+      - name: POD_NAME
+        valueFrom:
+          fieldRef:
+            fieldPath: metadata.name
+      {{- else }}
+      - name: PUBLIC_URL
+        value: {{ include "phase-server.publicUrl" . | quote }}
+      {{- end }}
+      {{- if .Values.metrics.enabled }}
+      {{- if eq (int .Values.metrics.port) (int .Values.service.port) }}
+      {{- fail "metrics.port must differ from service.port: they are two listeners in one pod, and the loser gets \"address in use\"." }}
+      {{- end }}
+      - name: PHASE_METRICS_PORT
+        value: {{ .Values.metrics.port | quote }}
+      {{- end }}
+      {{- with .Values.server.maxConnections }}
+      - name: PHASE_MAX_CONNECTIONS
+        value: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.server.maxGames }}
+      - name: PHASE_MAX_GAMES
+        value: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.server.dataManifestUrl }}
+      - name: PHASE_DATA_MANIFEST_URL
+        value: {{ . | quote }}
+      {{- end }}
+      {{- with .Values.server.adminTokenSecret }}
+      - name: PHASE_ADMIN_TOKEN
+        valueFrom:
+          secretKeyRef:
+            name: {{ . }}
+            key: {{ $.Values.server.adminTokenSecretKey }}
+      {{- end }}
+      {{- with .Values.server.extraEnv }}
+      {{- toYaml . | nindent 6 }}
+      {{- end }}
+    ports:
+      - name: http
+        containerPort: {{ .Values.service.port }}
+        protocol: TCP
+      {{- if .Values.metrics.enabled }}
+      - name: metrics
+        containerPort: {{ .Values.metrics.port }}
+        protocol: TCP
+      {{- end }}
+    startupProbe:
+      httpGet:
+        path: /health
+        port: http
+      periodSeconds: {{ .Values.startupProbe.periodSeconds }}
+      failureThreshold: {{ .Values.startupProbe.failureThreshold }}
+    readinessProbe:
+      httpGet:
+        path: /health
+        port: http
+      periodSeconds: 10
+    livenessProbe:
+      httpGet:
+        path: /health
+        port: http
+      periodSeconds: 30
+    resources:
+      {{- toYaml .Values.resources | nindent 6 }}
+    volumeMounts:
+      - name: data
+        mountPath: /var/lib/phase-server
+{{- if not $scaleOut }}
+volumes:
+  - name: data
+    {{- if .Values.persistence.enabled }}
+    persistentVolumeClaim:
+      claimName: {{ default (printf "%s-data" (include "phase-server.fullname" .)) .Values.persistence.existingClaim }}
+    {{- else }}
+    emptyDir: {}
+    {{- end }}
+{{- end }}
+{{- with .Values.nodeSelector }}
+nodeSelector:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.affinity }}
+affinity:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- with .Values.tolerations }}
+tolerations:
+  {{- toYaml . | nindent 2 }}
+{{- end }}
+{{- end -}}

--- a/deploy/helm/phase-server/templates/certificate.yaml
+++ b/deploy/helm/phase-server/templates/certificate.yaml
@@ -1,0 +1,35 @@
+{{- if and .Values.scaleOut.enabled .Values.scaleOut.tls.enabled .Values.ingress.enabled }}
+{{- /* The Ingress path lets cert-manager's ingress-shim derive a Certificate
+     from an annotation, but IngressRoute is not an Ingress, so with scaleOut
+     the chart owns the Certificate directly. One certificate covers the entry
+     host and every ordinal host, into the same secret both route kinds use. */}}
+{{- $issuer := "" }}
+{{- $issuerKind := "" }}
+{{- if .Values.ingress.tls.clusterIssuer }}
+{{- $issuer = .Values.ingress.tls.clusterIssuer }}
+{{- $issuerKind = "ClusterIssuer" }}
+{{- else if .Values.ingress.tls.issuer }}
+{{- $issuer = .Values.ingress.tls.issuer }}
+{{- $issuerKind = "Issuer" }}
+{{- else }}
+{{- fail "scaleOut.tls.enabled needs ingress.tls.clusterIssuer or ingress.tls.issuer: IngressRoute has no cert-manager annotation to derive a Certificate from. Set one, or set scaleOut.tls.enabled=false and provide the secret yourself." }}
+{{- end }}
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: {{ include "phase-server.fullname" . }}
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  secretName: {{ include "phase-server.tlsSecretName" . }}
+  issuerRef:
+    name: {{ $issuer }}
+    kind: {{ $issuerKind }}
+  dnsNames:
+    {{- if .Values.scaleOut.tls.wildcardDnsName }}
+    - {{ .Values.ingress.host | quote }}
+    - {{ .Values.scaleOut.tls.wildcardDnsName | quote }}
+    {{- else }}
+    {{- include "phase-server.allHosts" . | nindent 4 }}
+    {{- end }}
+{{- end }}

--- a/deploy/helm/phase-server/templates/deployment.yaml
+++ b/deploy/helm/phase-server/templates/deployment.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.scaleOut.enabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -5,6 +6,8 @@ metadata:
   labels:
     {{- include "phase-server.labels" . | nindent 4 }}
 spec:
+  {{- /* `scaleOut.enabled` is the supported way to run more than one replica;
+       it gives every ordinal its own claim. */}}
   # Not configurable: sessions, the lobby and the SQLite games.db are
   # per-process state, and two pods on one node could share the RWO PVC.
   replicas: 1
@@ -17,108 +20,10 @@ spec:
     metadata:
       labels:
         {{- include "phase-server.selectorLabels" . | nindent 8 }}
-      {{- with .Values.podAnnotations }}
+      {{- with (include "phase-server.podAnnotations" .) }}
       annotations:
-        {{- toYaml . | nindent 8 }}
+        {{- . | nindent 8 }}
       {{- end }}
     spec:
-      serviceAccountName: default
-      automountServiceAccountToken: false
-      terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
-      securityContext:
-        {{- toYaml .Values.podSecurityContext | nindent 8 }}
-      {{- with .Values.dnsConfig }}
-      dnsConfig:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      containers:
-        - name: phase-server
-          image: {{ include "phase-server.image" . }}
-          imagePullPolicy: {{ .Values.image.pullPolicy }}
-          # Bypass the image's root entrypoint (mkdir/chown + gosu); the pod
-          # securityContext already runs us as the `phase` uid with fsGroup.
-          command: ["phase-server"]
-          args:
-            {{- if .Values.server.allowedOrigin }}
-            - --allowed-origin
-            - {{ .Values.server.allowedOrigin | quote }}
-            {{- end }}
-            {{- if .Values.server.noDataDownload }}
-            - --no-data-download
-            {{- end }}
-          securityContext:
-            {{- toYaml .Values.securityContext | nindent 12 }}
-          env:
-            - name: PORT
-              value: {{ .Values.service.port | quote }}
-            - name: PHASE_DATA_DIR
-              value: /var/lib/phase-server
-            - name: PHASE_LOBBY_ONLY
-              value: {{ .Values.server.lobbyOnly | quote }}
-            - name: PHASE_CORS_ORIGIN
-              value: {{ .Values.server.corsOrigin | quote }}
-            - name: PHASE_LOG_JSON
-              value: {{ .Values.server.logJson | quote }}
-            - name: RUST_LOG
-              value: {{ .Values.server.rustLog | quote }}
-            - name: PUBLIC_URL
-              value: {{ include "phase-server.publicUrl" . | quote }}
-            {{- with .Values.server.dataManifestUrl }}
-            - name: PHASE_DATA_MANIFEST_URL
-              value: {{ . | quote }}
-            {{- end }}
-            {{- with .Values.server.adminTokenSecret }}
-            - name: PHASE_ADMIN_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: {{ . }}
-                  key: {{ $.Values.server.adminTokenSecretKey }}
-            {{- end }}
-            {{- with .Values.server.extraEnv }}
-            {{- toYaml . | nindent 12 }}
-            {{- end }}
-          ports:
-            - name: http
-              containerPort: {{ .Values.service.port }}
-              protocol: TCP
-          startupProbe:
-            httpGet:
-              path: /health
-              port: http
-            periodSeconds: {{ .Values.startupProbe.periodSeconds }}
-            failureThreshold: {{ .Values.startupProbe.failureThreshold }}
-          readinessProbe:
-            httpGet:
-              path: /health
-              port: http
-            periodSeconds: 10
-          livenessProbe:
-            httpGet:
-              path: /health
-              port: http
-            periodSeconds: 30
-          resources:
-            {{- toYaml .Values.resources | nindent 12 }}
-          volumeMounts:
-            - name: data
-              mountPath: /var/lib/phase-server
-      volumes:
-        - name: data
-          {{- if .Values.persistence.enabled }}
-          persistentVolumeClaim:
-            claimName: {{ default (printf "%s-data" (include "phase-server.fullname" .)) .Values.persistence.existingClaim }}
-          {{- else }}
-          emptyDir: {}
-          {{- end }}
-      {{- with .Values.nodeSelector }}
-      nodeSelector:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.affinity }}
-      affinity:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
-      {{- with .Values.tolerations }}
-      tolerations:
-        {{- toYaml . | nindent 8 }}
-      {{- end }}
+      {{- include "phase-server.podSpec" . | nindent 6 }}
+{{- end }}

--- a/deploy/helm/phase-server/templates/hpa.yaml
+++ b/deploy/helm/phase-server/templates/hpa.yaml
@@ -2,6 +2,12 @@
 {{- if not .Values.scaleOut.enabled }}
 {{- fail "autoscaling.enabled requires scaleOut.enabled: the plain Deployment is pinned to one replica because a second process on the same games.db is destructive." }}
 {{- end }}
+{{- if lt (int .Values.autoscaling.minReplicas) 1 }}
+{{- fail (printf "autoscaling.minReplicas must be at least 1; got %v. An HPA cannot scale a workload it is allowed to take to zero replicas." .Values.autoscaling.minReplicas) }}
+{{- end }}
+{{- if gt (int .Values.autoscaling.minReplicas) (int .Values.scaleOut.replicaMax) }}
+{{- fail (printf "autoscaling.minReplicas (%v) exceeds scaleOut.replicaMax (%v), which becomes the HPA's maxReplicas: the API server rejects an HPA whose minReplicas is above its maxReplicas, so the release installs and the autoscaler never appears." .Values.autoscaling.minReplicas .Values.scaleOut.replicaMax) }}
+{{- end }}
 {{- if not .Values.metrics.enabled }}
 {{- fail "autoscaling.enabled requires metrics.enabled: the recording rule reads phase_games_active and friends, so without the metrics port the HPA reports FailedGetExternalMetric forever and never scales." }}
 {{- end }}

--- a/deploy/helm/phase-server/templates/hpa.yaml
+++ b/deploy/helm/phase-server/templates/hpa.yaml
@@ -1,0 +1,58 @@
+{{- if .Values.autoscaling.enabled }}
+{{- if not .Values.scaleOut.enabled }}
+{{- fail "autoscaling.enabled requires scaleOut.enabled: the plain Deployment is pinned to one replica because a second process on the same games.db is destructive." }}
+{{- end }}
+{{- if not .Values.metrics.enabled }}
+{{- fail "autoscaling.enabled requires metrics.enabled: the recording rule reads phase_games_active and friends, so without the metrics port the HPA reports FailedGetExternalMetric forever and never scales." }}
+{{- end }}
+{{- /* `AverageValue`, not `Value`, and the difference is not cosmetic.
+
+     The external-metric path for `Value` computes
+     `ceil(metric / target * currentReplicas)` — it multiplies by the replica
+     count, so a metric that already IS the desired replica count compounds
+     (1 replica wanting 2 -> 2, then 2 wanting 2 -> 4). `AverageValue` uses the
+     per-pod calculator, `ceil(metric / targetPerPod)`, which ignores the
+     current count. With a target of 1 the HPA therefore follows
+     `phase:wanted_replicas` exactly, and all the policy stays in the rule.
+
+     Caveat worth knowing: the HPA's ~10% tolerance means it acts on the metric
+     only outside that band, so treat the rule as authoritative for real moves
+     rather than for exact equality at every instant. */}}
+apiVersion: autoscaling/v2
+kind: HorizontalPodAutoscaler
+metadata:
+  name: {{ include "phase-server.fullname" . }}
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  scaleTargetRef:
+    apiVersion: apps/v1
+    kind: StatefulSet
+    name: {{ include "phase-server.fullname" . }}
+  minReplicas: {{ .Values.autoscaling.minReplicas }}
+  maxReplicas: {{ .Values.scaleOut.replicaMax }}
+  metrics:
+    - type: External
+      external:
+        metric:
+          name: {{ .Values.autoscaling.metricName }}
+          selector:
+            matchLabels:
+              service: {{ include "phase-server.fullname" . }}
+        target:
+          type: AverageValue
+          averageValue: "1"
+  behavior:
+    scaleDown:
+      stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleDown.stabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+    scaleUp:
+      stabilizationWindowSeconds: {{ .Values.autoscaling.behavior.scaleUp.stabilizationWindowSeconds }}
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
+{{- end }}

--- a/deploy/helm/phase-server/templates/ingress.yaml
+++ b/deploy/helm/phase-server/templates/ingress.yaml
@@ -1,5 +1,15 @@
-{{- if .Values.ingress.enabled }}
+{{- /* scaleOut arrives in a later commit; testing the map first keeps this file
+     renderable on its own, and `.Values.scaleOut.enabled` alone is a nil
+     dereference until then. `default` does not help — it still dereferences. */}}
+{{- $scaleOut := false }}
+{{- if .Values.scaleOut }}{{- $scaleOut = .Values.scaleOut.enabled }}{{- end }}
+{{- if and .Values.ingress.enabled (not $scaleOut) }}
 {{- $fullname := include "phase-server.fullname" . }}
+{{- /* Both the rule host and the TLS SAN come from this one value. Empty renders
+     `host:` and a `tls.hosts` entry of "", which Traefik accepts as a catch-all
+     router and cert-manager turns into a Certificate with no dnsNames — a silent
+     misconfiguration, so fail rendering instead. */}}
+{{- $host := required "ingress.host is required when ingress.enabled is true (it is the hostname the router matches and the certificate is issued for)." .Values.ingress.host }}
 {{- $common := include "phase-server.commonMiddlewares" . }}
 {{- $backupMw := $common }}
 {{- if .Values.traefik.middlewares.enabled }}
@@ -34,10 +44,10 @@ spec:
   ingressClassName: {{ $.Values.ingress.className }}
   tls:
     - hosts:
-        - {{ $.Values.ingress.host }}
+        - {{ $host }}
       secretName: {{ include "phase-server.tlsSecretName" $ }}
   rules:
-    - host: {{ $.Values.ingress.host }}
+    - host: {{ $host }}
       http:
         paths:
           {{- range $p := $route.paths }}

--- a/deploy/helm/phase-server/templates/ingressroute.yaml
+++ b/deploy/helm/phase-server/templates/ingressroute.yaml
@@ -1,0 +1,86 @@
+{{- if and .Values.scaleOut.enabled .Values.ingress.enabled }}
+{{- $fullname := include "phase-server.fullname" . }}
+{{- $host := required "ingress.host is required when ingress.enabled is true (it is the entry hostname the router matches and the certificate is issued for)." .Values.ingress.host }}
+{{- $mw := include "phase-server.middlewareRefs" . }}
+{{- if .Values.traefik.middlewares.extra }}
+{{- fail "traefik.middlewares.extra uses Traefik's annotation syntax (\"<ns>-<name>@kubernetescrd\"), which the IngressRoute CRD provider rejects — Traefik would drop the whole route. With scaleOut.enabled, list extra middlewares under scaleOut.extraMiddlewareRefs as {name, namespace} instead." }}
+{{- end }}
+{{- /* Entry route. It deliberately targets the ordinary ClusterIP Service
+     rather than a Weighted TraefikService over the per-ordinal Services:
+     ordinals above the live replica count have no endpoints, and a weighted
+     service keeps sending its share of new connections to them. Traefik's
+     load balancer takes the Service's *ready endpoints* as its children
+     (nativeLB defaults to false), so membership follows scaling for free.
+
+     The sticky cookie is what keeps a browser on the pod that minted its game,
+     which matters because the host's own post-GameStarted socket redials the
+     entry address rather than the pod it was already talking to. */}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ $fullname }}
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  entryPoints:
+    - {{ .Values.scaleOut.entryPoint | default "websecure" }}
+  routes:
+    - kind: Rule
+      match: Host(`{{ $host }}`)
+      {{- with $mw | trim }}
+      middlewares:
+        {{- . | nindent 8 }}
+      {{- end }}
+      services:
+        - name: {{ $fullname }}
+          port: {{ .Values.service.port }}
+          {{- if .Values.scaleOut.sticky.enabled }}
+          sticky:
+            cookie:
+              name: {{ .Values.scaleOut.sticky.name }}
+              secure: {{ .Values.scaleOut.sticky.secure }}
+              httpOnly: {{ .Values.scaleOut.sticky.httpOnly }}
+              sameSite: {{ .Values.scaleOut.sticky.sameSite }}
+              maxAge: {{ int64 .Values.scaleOut.sticky.maxAge }}
+          {{- end }}
+  tls:
+    secretName: {{ include "phase-server.tlsSecretName" . }}
+    {{- if .Values.cloudflare.authenticatedOriginPulls.enabled }}
+    options:
+      name: {{ $fullname }}-cf-origin-pull
+    {{- end }}
+{{- range $i := until (int .Values.scaleOut.replicaMax) }}
+---
+{{- /* Per-ordinal route. This is the routing key that actually works today:
+     the server advertises its own host in ServerHello, the client turns that
+     into a "CODE@host" share string, and a friend joining by code dials this
+     host — landing on the pod that holds the game. No stickiness here; the
+     hostname already names the pod. */}}
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: {{ $fullname }}-{{ $i }}
+  labels:
+    {{- include "phase-server.labels" $ | nindent 4 }}
+    phase-server/ordinal: {{ $i | quote }}
+spec:
+  entryPoints:
+    - {{ $.Values.scaleOut.entryPoint | default "websecure" }}
+  routes:
+    - kind: Rule
+      match: Host(`{{ include "phase-server.ordinalHost" (dict "ctx" $ "ordinal" $i) }}`)
+      {{- with $mw | trim }}
+      middlewares:
+        {{- . | nindent 8 }}
+      {{- end }}
+      services:
+        - name: {{ $fullname }}-{{ $i }}
+          port: {{ $.Values.service.port }}
+  tls:
+    secretName: {{ include "phase-server.tlsSecretName" $ }}
+    {{- if $.Values.cloudflare.authenticatedOriginPulls.enabled }}
+    options:
+      name: {{ $fullname }}-cf-origin-pull
+    {{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/phase-server/templates/ingressroute.yaml
+++ b/deploy/helm/phase-server/templates/ingressroute.yaml
@@ -2,6 +2,14 @@
 {{- $fullname := include "phase-server.fullname" . }}
 {{- $host := required "ingress.host is required when ingress.enabled is true (it is the entry hostname the router matches and the certificate is issued for)." .Values.ingress.host }}
 {{- $mw := include "phase-server.middlewareRefs" . }}
+{{- /* Every route below terminates TLS unconditionally, so an advertised
+     `http://` ordinal URL names an address this chart does not serve. `http`
+     stays legal with ingress.enabled=false, where the chart renders no route
+     and the operator owns the edge. */}}
+{{- $scheme := .Values.scaleOut.scheme | default "https" }}
+{{- if ne $scheme "https" }}
+{{- fail (printf "scaleOut.scheme is %q, but every IngressRoute this chart renders terminates TLS, so each ordinal would advertise a URL the chart's own route does not serve. Leave it https, or set ingress.enabled=false and route to the ordinal Services yourself." $scheme) }}
+{{- end }}
 {{- if .Values.traefik.middlewares.extra }}
 {{- fail "traefik.middlewares.extra uses Traefik's annotation syntax (\"<ns>-<name>@kubernetescrd\"), which the IngressRoute CRD provider rejects — Traefik would drop the whole route. With scaleOut.enabled, list extra middlewares under scaleOut.extraMiddlewareRefs as {name, namespace} instead." }}
 {{- end }}

--- a/deploy/helm/phase-server/templates/networkpolicy.yaml
+++ b/deploy/helm/phase-server/templates/networkpolicy.yaml
@@ -18,6 +18,15 @@ spec:
       ports:
         - port: http
           protocol: TCP
+    {{- if .Values.metrics.enabled }}
+    - from:
+        - namespaceSelector:
+            matchLabels:
+              {{- toYaml .Values.metrics.scrapeNamespaceLabels | nindent 14 }}
+      ports:
+        - port: metrics
+          protocol: TCP
+    {{- end }}
   egress:
     - to:
         - namespaceSelector:

--- a/deploy/helm/phase-server/templates/podmonitor.yaml
+++ b/deploy/helm/phase-server/templates/podmonitor.yaml
@@ -1,11 +1,17 @@
 {{- if .Values.metrics.enabled }}
-{{- /* Gated on the CRD rather than on a value: installing a PodMonitor without
+{{- /* Gated on the CRD rather than on a value: installing a monitor without
      prometheus-operator makes `helm install` fail on an unknown kind, and the
      operator is usually somebody else's release. `metrics.annotations` is the
-     fallback discovery path when these CRDs are absent. */}}
-{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+     fallback discovery path when these CRDs are absent.
+
+     Each kind is tested by resource, not by API group. A partial operator
+     install can register one and not the other, and a group-level test then
+     renders the missing kind anyway — failing at apply on something the chart
+     could have known was unavailable. */}}
 {{- $fullname := include "phase-server.fullname" . }}
-{{- if .Values.metrics.podMonitor.enabled }}
+{{- $podMonitor := and .Values.metrics.podMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
+{{- $serviceMonitor := and .Values.metrics.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") }}
+{{- if $podMonitor }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor
 metadata:
@@ -27,8 +33,8 @@ spec:
       path: {{ .Values.metrics.path }}
       interval: {{ .Values.metrics.interval }}
 {{- end }}
-{{- if .Values.metrics.serviceMonitor.enabled }}
-{{- if .Values.metrics.podMonitor.enabled }}
+{{- if $serviceMonitor }}
+{{- if $podMonitor }}
 ---
 {{- end }}
 apiVersion: monitoring.coreos.com/v1
@@ -48,6 +54,5 @@ spec:
     - port: metrics
       path: {{ .Values.metrics.path }}
       interval: {{ .Values.metrics.interval }}
-{{- end }}
 {{- end }}
 {{- end }}

--- a/deploy/helm/phase-server/templates/podmonitor.yaml
+++ b/deploy/helm/phase-server/templates/podmonitor.yaml
@@ -1,0 +1,53 @@
+{{- if .Values.metrics.enabled }}
+{{- /* Gated on the CRD rather than on a value: installing a PodMonitor without
+     prometheus-operator makes `helm install` fail on an unknown kind, and the
+     operator is usually somebody else's release. `metrics.annotations` is the
+     fallback discovery path when these CRDs are absent. */}}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- $fullname := include "phase-server.fullname" . }}
+{{- if .Values.metrics.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ $fullname }}
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+    {{- with .Values.metrics.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  # Per-pod targets, so every replica reports its own occupancy. A Service-level
+  # scrape would load-balance across pods and make the per-ordinal gauges
+  # meaningless.
+  selector:
+    matchLabels:
+      {{- include "phase-server.selectorLabels" . | nindent 6 }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: {{ .Values.metrics.path }}
+      interval: {{ .Values.metrics.interval }}
+{{- end }}
+{{- if .Values.metrics.serviceMonitor.enabled }}
+{{- if .Values.metrics.podMonitor.enabled }}
+---
+{{- end }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ $fullname }}
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+    {{- with .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      {{- include "phase-server.selectorLabels" . | nindent 6 }}
+  endpoints:
+    - port: metrics
+      path: {{ .Values.metrics.path }}
+      interval: {{ .Values.metrics.interval }}
+{{- end }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/phase-server/templates/podmonitor.yaml
+++ b/deploy/helm/phase-server/templates/podmonitor.yaml
@@ -9,8 +9,8 @@
      renders the missing kind anyway — failing at apply on something the chart
      could have known was unavailable. */}}
 {{- $fullname := include "phase-server.fullname" . }}
-{{- $podMonitor := and .Values.metrics.podMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PodMonitor") }}
-{{- $serviceMonitor := and .Values.metrics.serviceMonitor.enabled (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/ServiceMonitor") }}
+{{- $podMonitor := include "phase-server.podMonitorRenders" . }}
+{{- $serviceMonitor := include "phase-server.serviceMonitorRenders" . }}
 {{- if $podMonitor }}
 apiVersion: monitoring.coreos.com/v1
 kind: PodMonitor

--- a/deploy/helm/phase-server/templates/prometheusrule.yaml
+++ b/deploy/helm/phase-server/templates/prometheusrule.yaml
@@ -8,7 +8,17 @@
 {{- fail "autoscaling.enabled with autoscaling.prometheusRule.enabled needs the PrometheusRule CRD (monitoring.coreos.com/v1/PrometheusRule), which this cluster does not have — checking the resource rather than the API group, because a partial operator install can register PodMonitor without it: the HPA reads phase:wanted_replicas, this rule is its only producer, and an HPA without it stays in FailedGetExternalMetric. Install the operator, or set autoscaling.prometheusRule.enabled=false and supply the recording rule yourself (see deploy/helm/phase-server/examples/prometheus-adapter-values.yaml)." }}
 {{- end }}
 {{- $fullname := include "phase-server.fullname" . }}
-{{- $sel := printf "namespace=%q" .Release.Namespace }}
+{{- /* Two selectors, because the raw gauges and this group's own output carry
+     different labels. Raw gauges are per-pod, so they are narrowed to THIS
+     StatefulSet's ordinals — filtering on namespace alone would sum a second
+     release in the same namespace into every demand term, and each HPA would
+     then scale on combined load and refuse scale-in because the OTHER release
+     had an occupied top ordinal. The intermediate `phase:replica_demand`
+     series aggregate `by (namespace)` and so have no `pod`; they carry
+     `service` instead, which also stops two releases colliding on one
+     recording-rule name. */}}
+{{- $raw := printf "namespace=%q,pod=~\"^%s-[0-9]+$\"" .Release.Namespace $fullname }}
+{{- $sel := printf "namespace=%q,service=%q" .Release.Namespace $fullname }}
 {{- $target := .Values.autoscaling.targetUtilization }}
 {{- if or (le (float64 $target) 0.0) (gt (float64 $target) 1.0) }}
 {{- fail (printf "autoscaling.targetUtilization must be greater than 0 and at most 1; got %v. At 0 or below the divisor collapses to clamp_min(...,1), so demand becomes the raw game count and the rule asks for replicaMax immediately." $target) }}
@@ -51,22 +61,24 @@ spec:
         - record: phase:replica_demand
           expr: |
             ceil(
-              sum by (namespace) (phase_games_active{ {{- $sel -}} })
-              / clamp_min({{ $target }} * max by (namespace) (phase_games_capacity{ {{- $sel -}} }), 1)
+              sum by (namespace) (phase_games_active{ {{- $raw -}} })
+              / clamp_min({{ $target }} * max by (namespace) (phase_games_capacity{ {{- $raw -}} }), 1)
             )
           labels:
             source: games
+            service: {{ $fullname }}
 
         # The same question against the socket cap, which binds first for
         # multiplayer tables: 100 two-player games is already 200 sockets.
         - record: phase:replica_demand
           expr: |
             ceil(
-              sum by (namespace) (phase_connections{ {{- $sel -}} })
-              / clamp_min({{ $target }} * max by (namespace) (phase_connections_capacity{ {{- $sel -}} }), 1)
+              sum by (namespace) (phase_connections{ {{- $raw -}} })
+              / clamp_min({{ $target }} * max by (namespace) (phase_connections_capacity{ {{- $raw -}} }), 1)
             )
           labels:
             source: connections
+            service: {{ $fullname }}
 
         # The floor that makes scale-in safe: the highest ordinal still holding
         # a human, plus one. `> bool 0` turns occupancy into 1/0, so the product
@@ -80,17 +92,18 @@ spec:
         - record: phase:replica_demand
           expr: |
             max by (namespace) (
-              phase_replica_ordinal{ {{- $sel -}} }
+              phase_replica_ordinal{ {{- $raw -}} }
               * on (namespace, pod) group_left ()
                 (
                   (
-                    phase_games_with_connected_humans{ {{- $sel -}} }
-                    + phase_drafts_with_connected_humans{ {{- $sel -}} }
+                    phase_games_with_connected_humans{ {{- $raw -}} }
+                    + phase_drafts_with_connected_humans{ {{- $raw -}} }
                   ) > bool 0
                 )
             ) + 1
           labels:
             source: occupied_floor
+            service: {{ $fullname }}
 
         # The answer the HPA reads. One series per namespace.
         - record: {{ .Values.autoscaling.recordName }}

--- a/deploy/helm/phase-server/templates/prometheusrule.yaml
+++ b/deploy/helm/phase-server/templates/prometheusrule.yaml
@@ -23,8 +23,12 @@
 {{- if or (le (float64 $target) 0.0) (gt (float64 $target) 1.0) }}
 {{- fail (printf "autoscaling.targetUtilization must be greater than 0 and at most 1; got %v. At 0 or below the divisor collapses to clamp_min(...,1), so demand becomes the raw game count and the rule asks for replicaMax immediately." $target) }}
 {{- end }}
-{{- if not (or .Values.metrics.podMonitor.enabled .Values.metrics.serviceMonitor.enabled) }}
-{{- fail "autoscaling.enabled needs metrics.podMonitor.enabled or metrics.serviceMonitor.enabled: the occupied-ordinal rule joins on (namespace, pod), and only operator discovery labels targets with `pod`. Annotation scraping names it `kubernetes_pod_name`, so the join silently matches nothing and the scale-in floor disappears." }}
+{{- /* Asks whether a monitor will RENDER, not whether one was requested: the
+     emitters also need their own CRD, so a cluster carrying the PrometheusRule
+     CRD but neither monitor CRD would otherwise render this rule and the HPA
+     with nothing scraping the gauges they read. */}}
+{{- if not (or (include "phase-server.podMonitorRenders" .) (include "phase-server.serviceMonitorRenders" .)) }}
+{{- fail "autoscaling.enabled needs a monitor that will actually render: metrics.podMonitor.enabled or metrics.serviceMonitor.enabled, AND the matching CRD (monitoring.coreos.com/v1/PodMonitor or .../ServiceMonitor) present on the cluster. Without one nothing scrapes phase_games_active and friends, so this rule produces no phase:wanted_replicas and the HPA stays in FailedGetExternalMetric. Annotation scraping does not substitute: the occupied-ordinal rule joins on (namespace, pod), and only operator discovery labels targets with `pod` — annotations name it `kubernetes_pod_name`, so the join silently matches nothing and the scale-in floor disappears." }}
 {{- end }}
 {{- /* The scaling POLICY lives here rather than in the HPA.
 

--- a/deploy/helm/phase-server/templates/prometheusrule.yaml
+++ b/deploy/helm/phase-server/templates/prometheusrule.yaml
@@ -3,6 +3,9 @@
 {{- $fullname := include "phase-server.fullname" . }}
 {{- $sel := printf "namespace=%q" .Release.Namespace }}
 {{- $target := .Values.autoscaling.targetUtilization }}
+{{- if or (le (float64 $target) 0.0) (gt (float64 $target) 1.0) }}
+{{- fail (printf "autoscaling.targetUtilization must be greater than 0 and at most 1; got %v. At 0 or below the divisor collapses to clamp_min(...,1), so demand becomes the raw game count and the rule asks for replicaMax immediately." $target) }}
+{{- end }}
 {{- if not (or .Values.metrics.podMonitor.enabled .Values.metrics.serviceMonitor.enabled) }}
 {{- fail "autoscaling.enabled needs metrics.podMonitor.enabled or metrics.serviceMonitor.enabled: the occupied-ordinal rule joins on (namespace, pod), and only operator discovery labels targets with `pod`. Annotation scraping names it `kubernetes_pod_name`, so the join silently matches nothing and the scale-in floor disappears." }}
 {{- end }}

--- a/deploy/helm/phase-server/templates/prometheusrule.yaml
+++ b/deploy/helm/phase-server/templates/prometheusrule.yaml
@@ -1,0 +1,96 @@
+{{- if and .Values.autoscaling.enabled .Values.autoscaling.prometheusRule.enabled }}
+{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- $fullname := include "phase-server.fullname" . }}
+{{- $sel := printf "namespace=%q" .Release.Namespace }}
+{{- $target := .Values.autoscaling.targetUtilization }}
+{{- if not (or .Values.metrics.podMonitor.enabled .Values.metrics.serviceMonitor.enabled) }}
+{{- fail "autoscaling.enabled needs metrics.podMonitor.enabled or metrics.serviceMonitor.enabled: the occupied-ordinal rule joins on (namespace, pod), and only operator discovery labels targets with `pod`. Annotation scraping names it `kubernetes_pod_name`, so the join silently matches nothing and the scale-in floor disappears." }}
+{{- end }}
+{{- /* The scaling POLICY lives here rather than in the HPA.
+
+     An HPA can only express "keep this ratio". The binding constraint for a
+     StatefulSet is different in kind: scale-in always removes the HIGHEST
+     ordinal, so shrinking is safe only when that particular ordinal has nobody
+     on it — a fact about one replica, not an aggregate. Encoding it as a
+     recording rule makes the HPA a follower of a number that already accounts
+     for it (see hpa.yaml, which targets an AverageValue of 1).
+
+     Three demand terms are recorded under one metric name with a `source`
+     label, then aggregated: PromQL has no element-wise max of two vectors, and
+     `max by (namespace)` over the shared name is how you get one. Rules inside
+     a group evaluate in order, so the last rule sees the three above it.
+
+     One release per namespace: the terms aggregate by namespace, so two
+     phase-server releases sharing one would be summed into a single answer. */}}
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: {{ $fullname }}
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+    {{- with .Values.autoscaling.prometheusRule.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  groups:
+    - name: {{ $fullname }}.autoscaling
+      interval: {{ .Values.autoscaling.interval }}
+      rules:
+        # How many replicas the current game load needs, at the target packing
+        # fraction. clamp_min guards a divide-by-zero while no pod is reporting.
+        - record: phase:replica_demand
+          expr: |
+            ceil(
+              sum by (namespace) (phase_games_active{ {{- $sel -}} })
+              / clamp_min({{ $target }} * max by (namespace) (phase_games_capacity{ {{- $sel -}} }), 1)
+            )
+          labels:
+            source: games
+
+        # The same question against the socket cap, which binds first for
+        # multiplayer tables: 100 two-player games is already 200 sockets.
+        - record: phase:replica_demand
+          expr: |
+            ceil(
+              sum by (namespace) (phase_connections{ {{- $sel -}} })
+              / clamp_min({{ $target }} * max by (namespace) (phase_connections_capacity{ {{- $sel -}} }), 1)
+            )
+          labels:
+            source: connections
+
+        # The floor that makes scale-in safe: the highest ordinal still holding
+        # a human, plus one. `> bool 0` turns occupancy into 1/0, so the product
+        # is either that pod's ordinal or zero; with nobody anywhere the max is
+        # 0 and the floor is 1. Spectators and drafts count — both pin a pod.
+        #
+        # The `+` is a strict-label vector match, so a pod appearing on only one
+        # side drops out and understates the floor. Safe here only because both
+        # gauges come from the same /metrics exposition and are always emitted
+        # together; that stops being true if either becomes conditional.
+        - record: phase:replica_demand
+          expr: |
+            max by (namespace) (
+              phase_replica_ordinal{ {{- $sel -}} }
+              * on (namespace, pod) group_left ()
+                (
+                  (
+                    phase_games_with_connected_humans{ {{- $sel -}} }
+                    + phase_drafts_with_connected_humans{ {{- $sel -}} }
+                  ) > bool 0
+                )
+            ) + 1
+          labels:
+            source: occupied_floor
+
+        # The answer the HPA reads. One series per namespace.
+        - record: {{ .Values.autoscaling.recordName }}
+          expr: |
+            clamp(
+              max by (namespace) (phase:replica_demand{ {{- $sel -}} }),
+              {{ .Values.autoscaling.minReplicas }},
+              {{ .Values.scaleOut.replicaMax }}
+            )
+          labels:
+            service: {{ $fullname }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/phase-server/templates/prometheusrule.yaml
+++ b/deploy/helm/phase-server/templates/prometheusrule.yaml
@@ -1,5 +1,12 @@
 {{- if and .Values.autoscaling.enabled .Values.autoscaling.prometheusRule.enabled }}
-{{- if .Capabilities.APIVersions.Has "monitoring.coreos.com/v1" }}
+{{- /* Skipping the rule here while hpa.yaml still renders would install an HPA
+     whose only metric producer is missing: `phase:wanted_replicas` comes from
+     this rule and nowhere else, so the HPA would sit in FailedGetExternalMetric
+     forever. Annotation scraping does not cover it either — that discovers the
+     raw gauges, not the recording rule. Fail at render instead. */}}
+{{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
+{{- fail "autoscaling.enabled with autoscaling.prometheusRule.enabled needs the prometheus-operator CRDs (monitoring.coreos.com/v1), which this cluster does not have: the HPA reads phase:wanted_replicas, this rule is its only producer, and an HPA without it stays in FailedGetExternalMetric. Install the operator, or set autoscaling.prometheusRule.enabled=false and supply the recording rule yourself (see deploy/helm/phase-server/examples/prometheus-adapter-values.yaml)." }}
+{{- end }}
 {{- $fullname := include "phase-server.fullname" . }}
 {{- $sel := printf "namespace=%q" .Release.Namespace }}
 {{- $target := .Values.autoscaling.targetUtilization }}
@@ -95,5 +102,4 @@ spec:
             )
           labels:
             service: {{ $fullname }}
-{{- end }}
 {{- end }}

--- a/deploy/helm/phase-server/templates/prometheusrule.yaml
+++ b/deploy/helm/phase-server/templates/prometheusrule.yaml
@@ -4,8 +4,8 @@
      this rule and nowhere else, so the HPA would sit in FailedGetExternalMetric
      forever. Annotation scraping does not cover it either — that discovers the
      raw gauges, not the recording rule. Fail at render instead. */}}
-{{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1") }}
-{{- fail "autoscaling.enabled with autoscaling.prometheusRule.enabled needs the prometheus-operator CRDs (monitoring.coreos.com/v1), which this cluster does not have: the HPA reads phase:wanted_replicas, this rule is its only producer, and an HPA without it stays in FailedGetExternalMetric. Install the operator, or set autoscaling.prometheusRule.enabled=false and supply the recording rule yourself (see deploy/helm/phase-server/examples/prometheus-adapter-values.yaml)." }}
+{{- if not (.Capabilities.APIVersions.Has "monitoring.coreos.com/v1/PrometheusRule") }}
+{{- fail "autoscaling.enabled with autoscaling.prometheusRule.enabled needs the PrometheusRule CRD (monitoring.coreos.com/v1/PrometheusRule), which this cluster does not have — checking the resource rather than the API group, because a partial operator install can register PodMonitor without it: the HPA reads phase:wanted_replicas, this rule is its only producer, and an HPA without it stays in FailedGetExternalMetric. Install the operator, or set autoscaling.prometheusRule.enabled=false and supply the recording rule yourself (see deploy/helm/phase-server/examples/prometheus-adapter-values.yaml)." }}
 {{- end }}
 {{- $fullname := include "phase-server.fullname" . }}
 {{- $sel := printf "namespace=%q" .Release.Namespace }}

--- a/deploy/helm/phase-server/templates/pvc.yaml
+++ b/deploy/helm/phase-server/templates/pvc.yaml
@@ -1,10 +1,14 @@
-{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) }}
+{{- if and .Values.persistence.enabled (not .Values.persistence.existingClaim) (not .Values.scaleOut.enabled) }}
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
   name: {{ include "phase-server.fullname" . }}-data
   labels:
     {{- include "phase-server.labels" . | nindent 4 }}
+  annotations:
+    # Switching to scaleOut stops rendering this claim. Without `keep`, Helm
+    # would delete it on that upgrade and take games.db with it.
+    helm.sh/resource-policy: keep
 spec:
   accessModes:
     - ReadWriteOnce

--- a/deploy/helm/phase-server/templates/service-ordinals.yaml
+++ b/deploy/helm/phase-server/templates/service-ordinals.yaml
@@ -1,0 +1,51 @@
+{{- if .Values.scaleOut.enabled }}
+{{- $fullname := include "phase-server.fullname" . }}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullname }}-headless
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  # The StatefulSet's governing Service: gives every pod a stable DNS name and
+  # is not used for routing.
+  clusterIP: None
+  publishNotReadyAddresses: true
+  ports:
+    - name: http
+      port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+    {{- end }}
+  selector:
+    {{- include "phase-server.selectorLabels" . | nindent 4 }}
+{{- range $i := until (int .Values.scaleOut.replicaMax) }}
+---
+{{- /* One Service per ordinal, selecting exactly that pod. Templated for every
+     ordinal up to replicaMax rather than the current replica count, so a new
+     replica is routable the moment it is Ready. An ordinal that does not exist
+     yet simply has no endpoints. */}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $fullname }}-{{ $i }}
+  labels:
+    {{- include "phase-server.labels" $ | nindent 4 }}
+    phase-server/ordinal: {{ $i | quote }}
+spec:
+  type: ClusterIP
+  ports:
+    - name: http
+      port: {{ $.Values.service.port }}
+      targetPort: http
+      protocol: TCP
+  selector:
+    {{- include "phase-server.selectorLabels" $ | nindent 4 }}
+    statefulset.kubernetes.io/pod-name: {{ $fullname }}-{{ $i }}
+{{- end }}
+{{- end }}

--- a/deploy/helm/phase-server/templates/service.yaml
+++ b/deploy/helm/phase-server/templates/service.yaml
@@ -11,5 +11,11 @@ spec:
       port: {{ .Values.service.port }}
       targetPort: http
       protocol: TCP
+    {{- if .Values.metrics.enabled }}
+    - name: metrics
+      port: {{ .Values.metrics.port }}
+      targetPort: metrics
+      protocol: TCP
+    {{- end }}
   selector:
     {{- include "phase-server.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/phase-server/templates/statefulset.yaml
+++ b/deploy/helm/phase-server/templates/statefulset.yaml
@@ -1,0 +1,55 @@
+{{- if .Values.scaleOut.enabled }}
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: {{ include "phase-server.fullname" . }}
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+spec:
+  serviceName: {{ include "phase-server.fullname" . }}-headless
+  {{- /* Helm re-applies spec.replicas on every upgrade, so templating it while
+       an HPA owns the field would reset the autoscaler's decision — including
+       the occupancy floor that keeps a busy top ordinal alive. Leave the field
+       out entirely and let the HPA own it. */}}
+  {{- if not .Values.autoscaling.enabled }}
+  replicas: {{ .Values.scaleOut.replicas }}
+  {{- end }}
+  podManagementPolicy: {{ .Values.scaleOut.podManagementPolicy }}
+  updateStrategy:
+    type: RollingUpdate
+  selector:
+    matchLabels:
+      {{- include "phase-server.selectorLabels" . | nindent 6 }}
+  {{- with .Values.scaleOut.persistentVolumeClaimRetentionPolicy }}
+  persistentVolumeClaimRetentionPolicy:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  template:
+    metadata:
+      labels:
+        {{- include "phase-server.selectorLabels" . | nindent 8 }}
+      {{- with (include "phase-server.podAnnotations" .) }}
+      annotations:
+        {{- . | nindent 8 }}
+      {{- end }}
+    spec:
+      {{- include "phase-server.podSpec" . | nindent 6 }}
+  volumeClaimTemplates:
+    {{- /* One claim per ordinal. This is the whole reason for a StatefulSet:
+         two processes sharing one games.db is destructive — the second restores
+         every live game at boot and its reaper later retires the rows the first
+         is still playing. */}}
+    - metadata:
+        name: data
+        labels:
+          {{- include "phase-server.labels" . | nindent 10 }}
+      spec:
+        accessModes:
+          - ReadWriteOnce
+        {{- with .Values.persistence.storageClass }}
+        storageClassName: {{ . | quote }}
+        {{- end }}
+        resources:
+          requests:
+            storage: {{ .Values.persistence.size }}
+{{- end }}

--- a/deploy/helm/phase-server/templates/statefulset.yaml
+++ b/deploy/helm/phase-server/templates/statefulset.yaml
@@ -1,4 +1,10 @@
 {{- if .Values.scaleOut.enabled }}
+{{- if lt (int .Values.scaleOut.replicaMax) 1 }}
+{{- fail (printf "scaleOut.replicaMax must be at least 1; got %v" .Values.scaleOut.replicaMax) }}
+{{- end }}
+{{- if and (not .Values.autoscaling.enabled) (gt (int .Values.scaleOut.replicas) (int .Values.scaleOut.replicaMax)) }}
+{{- fail (printf "scaleOut.replicas (%v) exceeds scaleOut.replicaMax (%v): ordinal Services and IngressRoutes are only templated for 0..replicaMax-1, so the extra pods would hold games nobody can join by ordinal hostname." .Values.scaleOut.replicas .Values.scaleOut.replicaMax) }}
+{{- end }}
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:

--- a/deploy/helm/phase-server/values.yaml
+++ b/deploy/helm/phase-server/values.yaml
@@ -37,6 +37,11 @@ server:
   # `kubectl port-forward svc/<release> 9374`.
   adminTokenSecret: ""
   adminTokenSecretKey: token
+  # Per-process admission caps (PHASE_MAX_CONNECTIONS / PHASE_MAX_GAMES). Empty
+  # keeps the server's own defaults (200 / 100). Lower them when running many
+  # small replicas so one process cannot absorb the whole fleet's traffic.
+  maxConnections: ""
+  maxGames: ""
   extraEnv: []
 
 # PHASE_DATA_DIR: card-data.json (~100 MiB, downloaded on first boot),
@@ -146,6 +151,123 @@ cloudflare:
     enabled: false
     # https://developers.cloudflare.com/ssl/static/authenticated_origin_pull_ca.pem
     caPem: ""
+
+# Horizontal scale-out: one StatefulSet, with a PVC and a hostname per ordinal.
+#
+# Why a StatefulSet and not `replicas: N`: every process owns its own games.db,
+# and two processes on one database is destructive — the second restores every
+# live game at boot, arms a reconnect grace it never had, and its reaper then
+# retires the rows the first process is still playing. `volumeClaimTemplates` is
+# what makes that impossible.
+#
+# Routing: the entry host balances across ready pods with a sticky cookie, and
+# each ordinal additionally answers on its own hostname. A game's share string
+# is CODE@<the minting pod's host>, so joining by code reaches the right pod.
+# See README "Scaling out" before enabling this.
+scaleOut:
+  enabled: false
+  # Services, IngressRoutes and certificate SANs are templated for ordinals
+  # 0..replicaMax-1 up front, so a new replica is routable the moment it is
+  # Ready. Raising this is a chart upgrade; an autoscaler only moves within it.
+  replicaMax: 3
+  # Starting replica count. Ignored when autoscaling.enabled — Helm would
+  # otherwise rewrite spec.replicas on every upgrade and undo the autoscaler.
+  replicas: 1
+  # Per-ordinal hostname; must contain {ordinal} exactly once. Empty derives
+  # `<first-label>-{ordinal}.<rest>` from ingress.host (phase.example.com ->
+  # phase-0.example.com). Keep ordinals at the SAME DNS level as the entry host:
+  # a wildcard edge certificate covers one label, so a second-level name gets a
+  # certificate that does not match it.
+  ordinalHostTemplate: ""
+  # Scheme for the advertised PUBLIC_URL of each ordinal.
+  scheme: https
+  # OrderedReady serialises first boot, and each pod downloads ~100 MiB of card
+  # data before it is Ready, so N pods would take N x that.
+  podManagementPolicy: Parallel
+  # Keep every ordinal's games.db when the set shrinks or the release is
+  # removed: a dead ordinal's PVC is what lets its games come back.
+  persistentVolumeClaimRetentionPolicy:
+    whenScaled: Retain
+    whenDeleted: Retain
+  sticky:
+    # Pins a browser to the pod that minted its game, which is what keeps the
+    # host's own derived sockets on that pod. It is a third-party cookie on a
+    # 101 response — see the README caveat before relying on it.
+    enabled: true
+    name: phase_server_pod
+    sameSite: none
+    secure: true
+    httpOnly: true
+    maxAge: 86400
+  # Extra Middlewares for the IngressRoutes, as {name, namespace} objects.
+  # traefik.middlewares.extra is the *annotation* syntax
+  # ("<ns>-<name>@kubernetescrd"), which the CRD provider rejects, so scaleOut
+  # takes its extras here instead.
+  extraMiddlewareRefs: []
+  tls:
+    # A cert-manager Certificate covering the entry host and every ordinal host,
+    # using ingress.tls.clusterIssuer / issuer.
+    enabled: true
+    secretName: ""      # defaults to <release>-tls, shared with the Ingress path
+    # Issue one wildcard SAN (e.g. "*.example.com") instead of one SAN per
+    # ordinal. Only helps if your edge/DNS actually wants a wildcard.
+    wildcardDnsName: ""
+
+# Demand-driven replica count for scaleOut, as a Prometheus recording rule plus
+# an HPA that follows it. The POLICY lives in the rule, not in the HPA: a
+# StatefulSet always removes its highest ordinal, so shrinking is only safe when
+# that ordinal has nobody on it, and that condition cannot be expressed as a
+# utilisation target. Needs prometheus-operator (for the PrometheusRule) and
+# prometheus-adapter (to expose the result as an external metric) — see
+# examples/prometheus-adapter-values.yaml.
+autoscaling:
+  enabled: false
+  minReplicas: 1
+  # Pack games to this fraction of a replica's phase_games_capacity before
+  # asking for another one.
+  targetUtilization: 0.7
+  # Name the recording rule writes, and the external metric the HPA reads.
+  # They differ because prometheus-adapter renames on the way through.
+  recordName: "phase:wanted_replicas"
+  metricName: phase_wanted_replicas
+  # Rule group evaluation interval.
+  interval: 15s
+  prometheusRule:
+    enabled: true
+    labels: {}       # e.g. a Prometheus `release` selector
+  behavior:
+    scaleDown:
+      # Long by default: scaling in is only ever gated on the top ordinal being
+      # empty, and a flap would kill a pod that just took a game.
+      stabilizationWindowSeconds: 600
+    scaleUp:
+      stabilizationWindowSeconds: 60
+
+# Prometheus metrics on a second container port (PHASE_METRICS_PORT). These
+# gauges describe capacity and occupancy — operator information — so the port is
+# never routed through the Ingress; scrape it in-cluster.
+metrics:
+  enabled: false
+  port: 9464
+  path: /metrics
+  interval: 30s
+  # PodMonitor/ServiceMonitor are only rendered when the prometheus-operator
+  # CRDs are installed; without them the chart falls back to nothing, so set
+  # metrics.annotations for annotation-based scrapers.
+  podMonitor:
+    enabled: true
+    labels: {}         # extra labels, e.g. a Prometheus `release` selector
+  serviceMonitor:
+    enabled: false
+    labels: {}
+  # prometheus.io/{scrape,port,path} pod annotations, for scrapers that discover
+  # by annotation rather than by CRD.
+  annotations: false
+  # Namespace of the scraper. Only meaningful when networkPolicy.enabled: the
+  # policy denies everything else, so a wrong value here means "up 0" with a
+  # healthy pod.
+  scrapeNamespaceLabels:
+    kubernetes.io/metadata.name: monitoring
 
 networkPolicy:
   enabled: true

--- a/deploy/helm/phase-server/values.yaml
+++ b/deploy/helm/phase-server/values.yaml
@@ -208,7 +208,8 @@ scaleOut:
     # A cert-manager Certificate covering the entry host and every ordinal host,
     # using ingress.tls.clusterIssuer / issuer.
     enabled: true
-    secretName: ""      # defaults to <release>-tls, shared with the Ingress path
+    # No secretName here: `ingress.tls.secretName` is the single authority and
+    # this path reuses it, so a second knob could only disagree with it.
     # Issue one wildcard SAN (e.g. "*.example.com") instead of one SAN per
     # ordinal. Only helps if your edge/DNS actually wants a wildcard.
     wildcardDnsName: ""

--- a/deploy/helm/phase-server/values.yaml
+++ b/deploy/helm/phase-server/values.yaml
@@ -179,7 +179,9 @@ scaleOut:
   # a wildcard edge certificate covers one label, so a second-level name gets a
   # certificate that does not match it.
   ordinalHostTemplate: ""
-  # Scheme for the advertised PUBLIC_URL of each ordinal.
+  # Scheme for the advertised PUBLIC_URL of each ordinal. Must stay https while
+  # ingress.enabled is true: the IngressRoutes this chart renders all terminate
+  # TLS, so http would advertise an address the chart's own route does not serve.
   scheme: https
   # OrderedReady serialises first boot, and each pod downloads ~100 MiB of card
   # data before it is Ready, so N pods would take N x that.


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Adds a `/metrics` endpoint to phase-server and an opt-in scale-out path to `deploy/helm/phase-server`, so one release can run several server pods behind one hostname without ever putting two processes on one `games.db`. Default values render **byte-identical** to `main`; everything new is behind `scaleOut.enabled`, `metrics.enabled` and `autoscaling.enabled`, all `false`.

The interesting part is not the HPA. A StatefulSet always removes its **highest ordinal**, so scaling in is safe only when *that specific pod* has nobody on it — a fact about one replica, which no utilisation target can express. The policy therefore lives in a Prometheus recording rule that already accounts for it, and the HPA is a follower with a target of 1. Verified end to end on an arm64 k3s cluster through Cloudflare, including the case that matters: a load signal saying "shrink to 1" being correctly overruled by one player on the top ordinal.

Also carries four small fixes harvested from review of #7603.

## Files changed

- `crates/phase-server/src/metrics.rs` (new), `crates/phase-server/src/main.rs`
- `deploy/helm/phase-server/templates/{statefulset,service-ordinals,ingressroute,certificate,podmonitor,prometheusrule,hpa}.yaml` (new)
- `deploy/helm/phase-server/templates/{_helpers.tpl,deployment,ingress,pvc,service,networkpolicy,NOTES.txt}`
- `deploy/helm/phase-server/{values.yaml,README.md,Chart.yaml}`, `examples/prometheus-adapter-values.yaml` (new)
- `.github/workflows/clear-caches.yml`, `.github/workflows/helm-chart.yml` (new)
- `.claude/skills/project-reference/SKILL.md` (env-var registry)

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: adapted — this is hosting infrastructure plus one self-contained server module; there is no engine, parser or client change. The `/engine-implementer` shape (read → plan → independent plan review → implement → independent implementation review → fix → accept) was followed with infrastructure reviewers in place of `/review-impl`, and this report is in that skill's Final Report form. The plan review returned 3 blockers and 7 should-fixes; the implementation review returned 0 blockers, 5 should-fixes and 5 nits. All are fixed and folded into their originating commits.

## CR references

None — no game-rules code is touched.

## Verification

- [x] `cargo test -p phase-server` and `cargo clippy -p phase-server --all-targets -- -D warnings` clean at head.
- [x] Default-values render byte-identical to `main` apart from one intentional 4-line annotation.
- [x] Every commit renders the chart standalone.
- [x] Deployed to a live arm64 k3s cluster and exercised through Cloudflare.

CI is running on this PR. Green so far: card data, frontend, lobby worker, WASM, security scan, CodeRabbit, and
**`helm lint + template`** — the workflow this PR adds, passing on its own first run, including its assertion that the
chart still renders with no prometheus-operator CRDs. The Rust jobs were still in flight when this was written.
Two workflow files are touched; each is alone in its own commit so the diff can be judged in isolation.

## Anchored on

- `deploy/helm/phase-server/templates/deployment.yaml:39-40` (pre-change) — the `command: ["phase-server"]` + pod-`securityContext` contract, which the shared `podSpec` helper now serves to both the Deployment and the StatefulSet unchanged.
- `crates/phase-server/src/main.rs:272` (pre-change) — `UnboundedSender::is_closed()` already used as the liveness test for a socket task; the occupancy gauges reuse it rather than inventing a second notion of "connected".

## Final Report

**1. Review rounds.** Plan review: 1 round, 3 blockers + 7 should-fixes + 10 nits, all resolved before implementation. Implementation review: 1 round, **0 blockers**, 5 should-fixes, 5 nits — all fixed. The reviewer independently reproduced byte-identity, rendered five configurations, and ran `promtool check rules` and `promtool test rules` over 8 scenarios.

**2. What changed, by subsystem.**

*Server* (`metrics.rs`, `main.rs`). A second listener on `PHASE_METRICS_PORT`, off unless set, serving Prometheus text 0.0.4. Hand-rolled exposition — the counters are three atomics and the gauges are computed per scrape, so a client crate would add a dependency and a registry to save about forty lines. Gauges cover connections, games, drafts and their capacities; `phase_games_with_connected_humans` and `phase_drafts_with_connected_humans` count *live sockets*, not map entries. `phase_admission_rejects_total{reason}` and `phase_build_info` round it out. `MAX_CONNECTIONS`/`MAX_GAMES` become `PHASE_MAX_CONNECTIONS`/`PHASE_MAX_GAMES` with unchanged defaults.

*Chart — scale-out.* `scaleOut.enabled` swaps the Deployment for a StatefulSet with `volumeClaimTemplates`, giving every ordinal its own PVC; adds a headless Service, a per-ordinal Service and IngressRoute matching `Host(phase-<n>.example.com)`, and an entry IngressRoute with a sticky cookie. Each pod derives its ordinal from the downward-API `POD_NAME` and exports its own `PUBLIC_URL`. Routes are templated for `0..replicaMax-1` up front, so a new replica is routable the moment it is Ready.

*Chart — metrics and autoscaling.* PodMonitor/ServiceMonitor gated on the operator CRDs with a `prometheus.io/*` fallback; a PrometheusRule carrying the policy; an HPA reading the result as an external metric.

**3. Key decisions.**

- *The policy is a recording rule.* Three demand terms are recorded under one metric name with a `source` label, then aggregated — PromQL has no element-wise max of two vectors, and `max by (namespace)` over a shared name is how you get one. The terms are separately readable, which is what made the live scale-in test legible.
- *`AverageValue`, not `Value`.* The external-metric path for `Value` computes `ceil(metric / target * currentReplicas)`; a metric that already *is* the desired count would compound (1 replica wanting 2 → 2, then 2 wanting 2 → 4). `AverageValue` uses the per-pod calculator and ignores the current count.
- *No `replicas` on the StatefulSet when autoscaling is on.* Helm re-applies `spec.replicas` on every upgrade; templating it would drag the set back to the chart's default and delete pods holding games. Verified live: a `helm upgrade` while the HPA held 3 left `.spec.replicas` at 3.
- *Occupancy uses `is_closed()`.* A disconnected player's entry stays in the map during the reconnect grace, so "sessions" and "sessions someone is on" are different numbers — and only the second is safe to scale in on.
- *List-form middleware refs.* `traefik.middlewares.extra` is the Ingress *annotation* syntax, which the IngressRoute CRD provider rejects by dropping the whole route. The chart refuses to render rather than silently discarding a rate limit.

**4. SHAs and scope.** Base `c50cfe4c7a43c52f2ae537005b93a6b401ed9dd4`. Head `a85d4ce21b118c6a8fe19f7afa0595951fbba4b4`. 8 commits, +2296/-137 across 23 files; largest commit 763 lines of chart.

**5. Parser measurement.** Not applicable — no parser change.

**6. Verification.**

*Preparatory.* `cargo fmt --all`; `cargo clippy -p phase-server --all-targets -- -D warnings` → exit 0, no warnings; `cargo test -p phase-server` → **143 passed, 0 failed** (11 new); `helm lint` clean on both paths; `actionlint` clean on both workflows.

*Byte-identity.* Rendering the chart at default values against `main`'s, with the chart-version label normalised, differs by exactly the four lines that add `helm.sh/resource-policy: keep` to the old PVC. Two near-misses were caught this way and fixed: a YAML comment that rendered into the manifest, and dropping an empty `args:` key.

*Per-commit rendering.* Every commit's chart renders standalone. Two did not at first — `ingress.yaml` read `.Values.scaleOut.enabled` before `values.yaml` had the key. Worth recording that `default false .Values.scaleOut.enabled` does **not** fix this (the argument is evaluated before `default` sees it) and sprig's `dig` cannot take `.Values` at all (`interface {} is common.Values, not map[string]interface {}`); testing the map first does.

*Guards, by their messages rather than exit codes.* `autoscaling` without `metrics` fails from `hpa.yaml`; `autoscaling` without a Monitor fails from `prometheusrule.yaml`; `metrics.port == service.port` fails from the pod spec; `traefik.middlewares.extra` under scaleOut fails from `ingressroute.yaml`; empty `ingress.host` fails from `ingress.yaml`.

*Mutation testing.* Five non-interacting mutations, each predicted to break exactly one test: `137 passed; 5 failed`, and the five were exactly the five predicted. The two that matter are dropping the spectator term and replacing `!tx.is_closed()` with `true` — the scale-in safety property. A sixth, from the reviewer (union instead of intersection on the session map), also broke exactly one test.

*Artifact.* The built binary was run, not just inspected: `PHASE_MAX_CONNECTIONS=11 PHASE_MAX_GAMES=7 PHASE_REPLICA_ORDINAL=2` produced `phase_connections_capacity 11`, `phase_games_capacity 7`, `phase_replica_ordinal 2` and a `build_info` commit matching the branch tip.

*Live cluster (arm64 k3s, through Cloudflare).* An existing single-pod release was migrated to the scale-out path with its PV adopted into `data-<release>-0`. Ordinal hostnames returned **503** before their pods existed and 200 within seconds of Ready. The WebSocket upgrade carries the cookie:

```
HTTP/1.1 101 Switching Protocols
Set-Cookie: phase_server_pod=…; Path=/; Max-Age=86400; HttpOnly; Secure; SameSite=None
```

Games were driven by a real protocol-33 client. With one held socket and one stale session on the same pod: `phase_games_active = 2`, `phase_games_with_connected_humans = 1` — the distinction the design rests on, visible in production. `phase_admission_rejects_total{reason="game_limit"} = 1` matched the client's "Server is at game capacity" reply. `wanted_replicas` went 1 → 2 → 3 and the HPA followed, each ordinal taking its own PV.

The scale-in test, with a single held socket on the **top** ordinal:

```
phase:replica_demand  games=1  connections=1  occupied_floor=3
phase:wanted_replicas 3
```

Both load terms say shrink to 1; the answer is 3, because scaling in would delete the pod with the player on it.

Restarting an ordinal restored its own games from its own volume: `"restoring persisted session" game="BJI0JS"`, `"restored active games from disk" count=1`.

*Real client, real browser.* A human ran the actual game client against the entry host. Both halves of the canary now
pass in Chromium:

- **Routing.** The share string came out as `CPGAIL@phase-0.meanphysicist.com` — **carrying the ordinal host, not the
  entry host**. The server advertises its own `PUBLIC_URL` in `ServerHello`, the client folds it into the `CODE@host`
  string, and a friend joining by that code dials the pod that actually holds the game. A second browser profile joined
  by that string and played the game out.
- **Sticky cookie.** The browser-dependent half is confirmed: after the host's socket dropped mid-game, its next socket
  landed on the same pod and the server logged `hosting reconnect succeeded game=JUCH5M player=PlayerId(0)`. That
  lookup only succeeds against the pod holding the session, so the host's later sockets did stay on that pod.

*Desktop client, same stack.* The **Tauri desktop client** also hosts and joins against this stack successfully. It
initially could not: its lobby socket reached the pod normally (the server logged the `CreateGameWithSettings` and
`LookupJoinTarget`) while no `JoinGameWithPassword` or `Reconnect` ever arrived, because only the game socket resolves
its URL through `detectServerUrl()` (`client/src/services/serverDetection.ts`), which probes
`http://localhost:9374/health` first and returns `ws://localhost:9374/ws` if anything answers — so on a developer
machine running a local server it silently attached there instead. With that local server stopped, the desktop client
hosts and joins this stack normally. The probe is a vestigial leftover from a deleted sidecar, predates this branch, and
is fixed client-side in #7687. Nothing about it is server- or chart-side.

*Log noise, pre-existing.* Real-client sessions emit bursts of `WARN Full snapshot was no longer current …
SupersededOrRetired` shortly after a game is created. This is the fence working as designed, not a fault:
`persist_full_session_async` dispatches every snapshot through `tokio::task::spawn_blocking`, so concurrent saves finish
out of order and any whose `mutation_revision` no longer leads is rejected — the newest state still wins. It is not new
here: `crates/phase-server/src/persistence.rs` and `persist_full_session_async` are byte-identical (sha256) between this
branch and its base `c50cfe4c7`, and both binaries emit zero such warnings across the same driven flows. It is benign in
practice — a host reconnect succeeded 120 ms before one burst, and games kept applying the other player's actions after
theirs.

**7. Implementation-review rounds.** 1 round at `fc3108277`, 0 blockers, clean after fixes.

**8. Commits.** Eight, each a self-contained partition; the two workflow files are alone in their own commits.

**9. Coverage impact.** None — no parser change.

**10. Deviations from plan.** The per-ordinal wildcard DNS record was replaced by three explicit first-level CNAMEs: an edge wildcard certificate covers exactly one label, so `phase-0.phase.example.com` would have been served a certificate that does not match it. Confirmed against a live edge certificate, not documentation. The client-side change that would remove the sticky-cookie dependency is deliberately **not** here; it belongs with the client.

**11. Risks and judgment calls.**

- **The sticky cookie is third-party** when the client is served from a different origin than the server, so Safari and other ITP browsers will not keep it. The consequence is bounded — a host's own derived socket may land on a different pod — and the real fix is client-side, which this PR does not touch. Documented in the README.
- **Autoscaling without the operator CRDs is now a render-time failure**, not a documented footgun. The HPA's only producer of `phase:wanted_replicas` is the `PrometheusRule`, so installing one without the other yields a permanent `FailedGetExternalMetric`. The operator-free path stays open through `autoscaling.prometheusRule.enabled=false` for externally supplied recording rules, and CI asserts both halves.
- ~~One release per namespace~~ — **fixed in review.** The rules now narrow the raw per-pod gauges to this StatefulSet's ordinals (`pod=~"^<fullname>-[0-9]+$"`) and label the intermediate series with `service`, so two autoscaled releases in one namespace render disjoint selectors instead of summing into one answer.
- **`replicaMax` is a chart-upgrade-time bound.** Raising it re-renders Services, IngressRoutes and certificate SANs; the autoscaler only moves within it.

**12. Remaining items.** A follow-up for the client so a host's post-`GameStarted` socket redials the pod that minted the game rather than the entry host, which would make the sticky cookie unnecessary.

**13. Phase-fit verdict.** Single phase; no abandoned candidates.

## Claimed parse impact

None.

## Scope Expansion

Four fixes harvested from review of #7603 are included: the `clear-caches` workflow (its patterns matched nothing, so it deleted 0 of ~740 caches while reporting success), `required` on `ingress.host`, tests for `validate_public_url` plus a trim fix, and README coverage of `server.publicUrl`.

## Validation Failures

None. Both review steps ran against a fresh context holding only the artifact under review.

## CI Failures

None observed; CI has not run on this fork branch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Prometheus metrics for capacity, occupancy, replica status, and admission refusals.
  * Added configurable connection and game admission limits.
  * Added Helm support for StatefulSet-based scale-out, per-replica routing, persistence, TLS, and sticky traffic.
  * Added optional Prometheus monitoring and autoscaling configuration.
* **Bug Fixes**
  * Public URLs now handle surrounding whitespace and trailing slashes consistently.
  * Added validation for incompatible or incomplete deployment settings.
* **Documentation**
  * Expanded deployment, scaling, monitoring, autoscaling, TLS, and migration guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->



