### PR TITLE
fix(client): let a stack spell be clicked when a copy needs a new target

### DIFF
--- a/client/src/components/stack/StackEntry.tsx
+++ b/client/src/components/stack/StackEntry.tsx
@@ -9,12 +9,13 @@ import { UnimplementedMechanicsBadge } from "../card/UnimplementedMechanicsBadge
 import { useCardImage } from "../../hooks/useCardImage.ts";
 import { useIsMobile } from "../../hooks/useIsMobile.ts";
 import { useLongPress } from "../../hooks/useLongPress.ts";
-import { usePlayerId } from "../../hooks/usePlayerId.ts";
+import { useCanActForWaitingState, usePlayerId } from "../../hooks/usePlayerId.ts";
 import { useSeatColor } from "../../hooks/useSeatColor.ts";
 import { dispatchAction } from "../../game/dispatch.ts";
 import { cardImageLookup, tokenFiltersForObject } from "../../services/cardImageLookup.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
+import { getWaitingForObjectChoiceIds } from "../../viewmodel/gameStateView.ts";
 import { renderDescription } from "../../utils/description.ts";
 import { ManaCostPips } from "../mana/ManaCostPips.tsx";
 import { PopoverMenu } from "../menu/PopoverMenu.tsx";
@@ -51,7 +52,8 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
   const isMobile = useIsMobile();
   const playerId = usePlayerId();
   const objects = useGameStore((s) => s.gameState?.objects);
-  const waitingFor = useGameStore((s) => s.gameState?.waiting_for);
+  const waitingFor = useGameStore((s) => s.waitingFor);
+  const canActForWaitingState = useCanActForWaitingState();
   const pendingCast = useGameStore((s) => s.gameState?.pending_cast);
   const inspectObject = useUiStore((s) => s.inspectObject);
 
@@ -171,23 +173,16 @@ export function StackEntry({ entry, index, isTop, isPending, cardSize, style, on
   const controllerInitial =
     entry.controller === playerId ? t("stack.controllerInitialYou") : t("stack.controllerInitialOpp", { seat: entry.controller });
 
-  // Targeting: check if this stack entry is a valid target for the current selection
-  const isHumanTargetSelection =
-    (waitingFor?.type === "TargetSelection" || waitingFor?.type === "TriggerTargetSelection")
-    && waitingFor.data.player === playerId;
-  // CR 115.7: A single-target retarget can redirect to another spell/ability on
-  // the stack (Bolt Bend on a counterspell), so stack entries are click targets.
-  const isRetargetChoice = waitingFor?.type === "RetargetChoice"
-    && waitingFor.data.player === playerId
-    && waitingFor.data.scope.type === "Single";
-  const currentTargetRefs = isHumanTargetSelection
-    ? (waitingFor.data.selection?.current_legal_targets ?? [])
-    : isRetargetChoice
-      ? waitingFor.data.legal_new_targets
-      : [];
-  const isValidTarget = (isHumanTargetSelection || isRetargetChoice) && currentTargetRefs.some(
-    (target) => "Object" in target && target.Object === entry.id,
-  );
+  // Targeting: whether the engine is currently asking THIS seat to choose an
+  // object and this stack entry is one of the choices. `getWaitingForObjectChoiceIds`
+  // is the single WaitingFor -> choosable-ObjectId authority the battlefield,
+  // zones, and attachment dialogs already read; the stack reads it too, so every
+  // variant whose engine-authored legal set can name a stack object lights up
+  // here without a per-variant branch — CR 115.7 retargets (Bolt Bend onto a
+  // counterspell), CR 707.10c "may choose new targets for the copy", and plain
+  // CR 601.2c target announcement alike.
+  const isValidTarget =
+    canActForWaitingState && getWaitingForObjectChoiceIds(waitingFor).includes(entry.id);
 
   // Ring style: targeting glow overrides default ring
   const ringClass = isValidTarget

--- a/client/src/components/stack/__tests__/StackEntry.test.tsx
+++ b/client/src/components/stack/__tests__/StackEntry.test.tsx
@@ -4,13 +4,20 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 
 import { StackEntry } from "../StackEntry.tsx";
 import { useGameStore } from "../../../stores/gameStore.ts";
+import { useUiStore } from "../../../stores/uiStore.ts";
 import type { GameState, StackEntry as StackEntryType } from "../../../adapter/types.ts";
 import { buildGameObject, buildObjectMap } from "../../../test/factories/gameObjectFactory.ts";
 import {
   buildChooseXValueWaitingFor,
+  buildCopyTargetSlot,
   buildGameState,
   buildPendingCast,
+  buildPriorityWaitingFor,
   buildStackEntry,
+  buildTargetSelectionProgress,
+  copyRetargetWaitingForFactory,
+  retargetChoiceWaitingForFactory,
+  targetSelectionWaitingForFactory,
 } from "../../../test/factories/gameStateFactory.ts";
 
 vi.mock("../../../hooks/useCardImage.ts", () => ({
@@ -32,6 +39,10 @@ describe("StackEntry", () => {
   beforeEach(() => {
     useGameStore.getState().reset();
     dispatchActionMock.mockClear();
+    // `uiStore` is a module singleton with no `reset()` action, so
+    // `inspectedObjectId` otherwise leaks across rows and a row that never
+    // clicks can inherit a prior row's value and pass vacuously.
+    useUiStore.setState({ inspectedObjectId: null });
   });
 
   afterEach(() => {
@@ -463,5 +474,187 @@ describe("StackEntry", () => {
     render(<StackEntry entry={entry} index={0} isTop cardSize={{ width: 120, height: 168 }} />);
 
     expect(screen.queryByTestId("unimplemented-mechanics-badge")).not.toBeInTheDocument();
+  });
+
+  // The stack must be a click surface for EVERY engine prompt whose legal set can
+  // name a stack object, not just the two variants this component used to
+  // hand-roll. `getWaitingForObjectChoiceIds` is the single authority; these rows
+  // assert shapes, never card names, so they cover the class rather than a card.
+  describe("stack entry targeting", () => {
+    const CARD_SIZE = { width: 120, height: 168 };
+    const ENTRY_ID = 162;
+    const SOURCE_ID = 199;
+
+    // `handleClick` inspects `entry.source_id`, not `entry.id`, so the two are
+    // pinned to distinct values: an assertion on 199 also catches a regression
+    // that swapped the call to `inspectObject(entry.id)`.
+    const buildEntry = () =>
+      buildStackEntry({ id: ENTRY_ID, source_id: SOURCE_ID, controller: 1 });
+
+    const node = () => document.querySelector(`[data-stack-entry="${ENTRY_ID}"]`)!;
+    // The ring class lives on the inner sized card div, not the motion wrapper.
+    const ringHost = () => node().querySelector("div.overflow-hidden")!;
+
+    const mount = (entry: StackEntryType, waitingFor: GameState["waiting_for"]) => {
+      const gameState = createGameState({ stack: [entry], waiting_for: waitingFor });
+      act(() => {
+        useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+      });
+      render(<StackEntry entry={entry} index={0} isTop cardSize={CARD_SIZE} />);
+    };
+
+    const objectSlot = () =>
+      buildCopyTargetSlot({ legal_alternatives: [{ Object: ENTRY_ID }] });
+
+    // Row 1 — the reported defect. A copy's only legal new target is a spell on
+    // the stack (CR 707.10c "may choose new targets for the copy"). Before the
+    // fix nothing on the stack was clickable and the prompt had no cancel, so
+    // the game soft-locked.
+    it("lights a stack entry the engine offers as a copy's new target and dispatches the choice", () => {
+      const entry = buildEntry();
+      mount(
+        entry,
+        copyRetargetWaitingForFactory.withData({ target_slots: [objectSlot()] }).build(),
+      );
+
+      expect(ringHost().className).toContain("ring-cyan-300");
+
+      fireEvent.click(node());
+
+      expect(dispatchActionMock).toHaveBeenCalledWith({
+        type: "ChooseTarget",
+        data: { target: { Object: ENTRY_ID } },
+      });
+    });
+
+    // Row 2 — paired reach-guard for rows 1/3/4: without it, a change that lit
+    // every stack entry unconditionally would pass all three positives. The
+    // prompt is addressed to the other seat, so this seat neither glows nor
+    // dispatches, and the click falls through to plain inspect.
+    it("leaves a stack entry inert when the engine is asking a different seat to choose", () => {
+      const entry = buildEntry();
+      mount(
+        entry,
+        copyRetargetWaitingForFactory
+          .forPlayer(1)
+          .withData({ target_slots: [objectSlot()] })
+          .build(),
+      );
+
+      expect(ringHost().className).not.toContain("ring-cyan-300");
+
+      fireEvent.click(node());
+
+      expect(dispatchActionMock).not.toHaveBeenCalled();
+      expect(useUiStore.getState().inspectedObjectId).toBe(SOURCE_ID);
+    });
+
+    // Row 3 — behavior preservation: plain target announcement (CR 601.2c) kept
+    // working through the rewrite.
+    it("keeps lighting a stack entry named by an ordinary target selection", () => {
+      const entry = buildEntry();
+      mount(
+        entry,
+        targetSelectionWaitingForFactory
+          .withData({
+            selection: buildTargetSelectionProgress({
+              current_legal_targets: [{ Object: ENTRY_ID }],
+            }),
+          })
+          .build(),
+      );
+
+      expect(ringHost().className).toContain("ring-cyan-300");
+
+      fireEvent.click(node());
+
+      expect(dispatchActionMock).toHaveBeenCalledWith({
+        type: "ChooseTarget",
+        data: { target: { Object: ENTRY_ID } },
+      });
+    });
+
+    // Row 4 — behavior preservation: CR 115.7 single-target retarget (Bolt Bend
+    // redirecting onto a counterspell) is still board-resolved.
+    it("keeps lighting a stack entry named by a single-target retarget", () => {
+      const entry = buildEntry();
+      mount(
+        entry,
+        retargetChoiceWaitingForFactory
+          .withData({ legal_new_targets: [{ Object: ENTRY_ID }] })
+          .build(),
+      );
+
+      expect(ringHost().className).toContain("ring-cyan-300");
+
+      fireEvent.click(node());
+
+      expect(dispatchActionMock).toHaveBeenCalledWith({
+        type: "ChooseTarget",
+        data: { target: { Object: ENTRY_ID } },
+      });
+    });
+
+    // Row 5 — hostile: an `All`-scope retarget stays modal-resolved. Guards the
+    // selector's `scope` narrowing, which the deleted inline block also had.
+    it("does not light a stack entry for an all-scope retarget, which stays modal", () => {
+      const entry = buildEntry();
+      mount(
+        entry,
+        retargetChoiceWaitingForFactory
+          .withData({
+            scope: { type: "All" },
+            legal_new_targets: [{ Object: ENTRY_ID }],
+          })
+          .build(),
+      );
+
+      expect(ringHost().className).not.toContain("ring-cyan-300");
+    });
+
+    // Row 6 — hostile: a prompt that names no objects at all. Paired guard for
+    // the non-target click path; the `beforeEach` uiStore reset is what makes
+    // this discriminate its own click rather than inheriting row 2's value.
+    it("falls back to inspect when the current prompt names no objects", () => {
+      const entry = buildEntry();
+      mount(entry, buildPriorityWaitingFor());
+
+      expect(ringHost().className).not.toContain("ring-cyan-300");
+
+      fireEvent.click(node());
+
+      expect(dispatchActionMock).not.toHaveBeenCalled();
+      expect(useUiStore.getState().inspectedObjectId).toBe(SOURCE_ID);
+    });
+
+    // Row 7 — prompt lifecycle. At least one of this component's two prompt
+    // observers must read the store's live `waitingFor` rather than the
+    // snapshot's `gameState.waiting_for`, or a resolved prompt keeps glowing.
+    it("drops the targeting glow when the live prompt ends, even while the snapshot still carries it", () => {
+      const entry = buildEntry();
+      mount(
+        entry,
+        targetSelectionWaitingForFactory
+          .withData({
+            selection: buildTargetSelectionProgress({
+              current_legal_targets: [{ Object: ENTRY_ID }],
+            }),
+          })
+          .build(),
+      );
+
+      // Reach-guard: this fixture really does glow, so the assertion below is
+      // measuring the lifecycle and not a prompt that never lit up.
+      expect(ringHost().className).toContain("ring-cyan-300");
+
+      act(() => {
+        useGameStore.setState({ waitingFor: { type: "GameOver", data: { winner: 0 } } });
+      });
+
+      expect(ringHost().className).not.toContain("ring-cyan-300");
+      // Non-vacuity: the snapshot deliberately still holds the old prompt, so
+      // the two fields have genuinely diverged and the glow followed the live one.
+      expect(useGameStore.getState().gameState?.waiting_for?.type).toBe("TargetSelection");
+    });
   });
 });

--- a/client/src/test/factories/gameStateFactory.ts
+++ b/client/src/test/factories/gameStateFactory.ts
@@ -1,6 +1,7 @@
 import { Factory } from "fishery";
 
 import type {
+  CopyTargetSlot,
   FormatConfig,
   GameAction,
   GameObject,
@@ -35,6 +36,8 @@ type AssistPaymentWaitingFor = Extract<WaitingFor, { type: "AssistPayment" }>;
 type CastOfferWaitingFor = Extract<WaitingFor, { type: "CastOffer" }>;
 type LoopShortcutWaitingFor = Extract<WaitingFor, { type: "LoopShortcut" }>;
 type RespondToShortcutWaitingFor = Extract<WaitingFor, { type: "RespondToShortcut" }>;
+type CopyRetargetWaitingFor = Extract<WaitingFor, { type: "CopyRetarget" }>;
+type RetargetChoiceWaitingFor = Extract<WaitingFor, { type: "RetargetChoice" }>;
 type WaitingForWithData = Extract<WaitingFor, { data: object }>;
 
 /**
@@ -218,6 +221,16 @@ export const buildTargetSelectionSlot = (
   return { ...targetSelectionSlotFactory.build(), ...overrides };
 };
 
+export const copyTargetSlotFactory = Factory.define<CopyTargetSlot>(() => ({
+  legal_alternatives: [],
+}));
+
+export const buildCopyTargetSlot = (
+  overrides: Partial<CopyTargetSlot> = {},
+): CopyTargetSlot => {
+  return { ...copyTargetSlotFactory.build(), ...overrides };
+};
+
 export const targetSelectionProgressFactory =
   Factory.define<TargetSelectionProgress>(() => ({
     current_slot: 0,
@@ -265,6 +278,45 @@ export const buildTriggerTargetSelectionWaitingFor = (
   overrides: Partial<TriggerTargetSelectionWaitingFor> = {},
 ): TriggerTargetSelectionWaitingFor => {
   return triggerTargetSelectionWaitingForFactory.withData(overrides.data ?? {}).build();
+};
+
+export class CopyRetargetWaitingForFactory extends PlayerWaitingForFactory<CopyRetargetWaitingFor> {}
+
+export const copyRetargetWaitingForFactory =
+  CopyRetargetWaitingForFactory.define((): CopyRetargetWaitingFor => ({
+    type: "CopyRetarget",
+    data: {
+      player: 0,
+      copy_id: 1,
+      current_slot: 0,
+      target_slots: [buildCopyTargetSlot()],
+    },
+  }));
+
+export const buildCopyRetargetWaitingFor = (
+  overrides: Partial<CopyRetargetWaitingFor> = {},
+): CopyRetargetWaitingFor => {
+  return copyRetargetWaitingForFactory.withData(overrides.data ?? {}).build();
+};
+
+export class RetargetChoiceWaitingForFactory extends PlayerWaitingForFactory<RetargetChoiceWaitingFor> {}
+
+export const retargetChoiceWaitingForFactory =
+  RetargetChoiceWaitingForFactory.define((): RetargetChoiceWaitingFor => ({
+    type: "RetargetChoice",
+    data: {
+      player: 0,
+      stack_entry_index: 0,
+      scope: { type: "Single" },
+      current_targets: [],
+      legal_new_targets: [],
+    },
+  }));
+
+export const buildRetargetChoiceWaitingFor = (
+  overrides: Partial<RetargetChoiceWaitingFor> = {},
+): RetargetChoiceWaitingFor => {
+  return retargetChoiceWaitingForFactory.withData(overrides.data ?? {}).build();
 };
 
 export class ChooseXValueWaitingForFactory extends PlayerWaitingForFactory<ChooseXValueWaitingFor> {}


### PR DESCRIPTION
A copied spell whose only legal target is a spell on the stack could not be
answered: `StackEntry` hand-rolled its own targetable-object check that knew
only `TargetSelection`, `TriggerTargetSelection` and single-scope
`RetargetChoice`, so a `CopyRetarget` prompt (CR 707.10c) lit nothing and a
click fell through to inspect. With no cancel affordance for that prompt the
game was unrecoverable — reported as Counterspell copied off Isochron Scepter,
where the one legal alternative was the opponent's spell on the stack.

Read the shared authority instead. `getWaitingForObjectChoiceIds` is the single
`WaitingFor` -> choosable-`ObjectId` mapping that the battlefield, zones and
attachment dialogs already consume; the stack was the last object-bearing
surface still on a private derivation. Consuming it removes a per-variant
branch rather than adding one, so every variant whose engine-authored legal set
can name a stack object now works with no further edit here.

Two latent defects close as a consequence, both measured:
- a spectator saw the targeting glow on a stack entry addressed to seat 0,
  because `usePlayerId()` returns seat 0 for a spectator by design and the
  inline `data.player === playerId` compare therefore passed. The click was
  dead — `dispatch.ts` returns early for `gameMode === "spectate"`, so nothing
  reached the engine — and it also swallowed the `inspectObject` card-preview
  fallback, which is the affordance a spectator actually wants;
- a `turn_decision_controller` seat was locked out of a prompt it was
  authorised to answer.
`useCanActForWaitingState()` is the canonical actor gate and handles both.
Reading the store's live `waitingFor` rather than the snapshot's also keeps the
glow from surviving `GameOver`, which writes that field alone.

Claude-Session: https://claude.ai/code/session_01LC5MnFWa3NwmqcFTECw96K


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stack interactions for copy-retargeting, ordinary target selection, and single-target retargeting prompts.
  * Ensured only the appropriate player can select targets.
  * Prevented highlighting for non-targeting or all-scope prompts.
  * Cleared targeting highlights when an active prompt ends, even if displayed game data is stale.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->