### PR TITLE
fix(client): stop the desktop game socket hijacking onto a local phase-server

### DIFF
--- a/client/src/services/__tests__/serverDetection.test.ts
+++ b/client/src/services/__tests__/serverDetection.test.ts
@@ -1,13 +1,15 @@
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import {
   DEFAULT_MULTIPLAYER_SERVER_URL,
   OFFICIAL_MULTIPLAYER_SERVER_URL,
   isOfficialMultiplayerServerUrl,
 } from "../../config/multiplayerServer";
+import { useMultiplayerStore } from "../../stores/multiplayerStore";
 import {
   DEFAULT_SERVER,
   SERVER_PRESETS,
+  detectServerUrl,
   formatJoinShare,
   mixedContentBlockReason,
   parseJoinCode,
@@ -52,6 +54,34 @@ describe("official server hosts", () => {
     expect(SERVER_PRESETS).toHaveLength(1);
     expect(SERVER_PRESETS[0].labelKey).toBe("serverPicker.official");
     expect(DEFAULT_SERVER).toBe(OFFICIAL_MULTIPLAYER_SERVER_URL);
+  });
+});
+
+describe("detectServerUrl", () => {
+  const CHOSEN = "wss://play.example.com/ws";
+
+  afterEach(() => {
+    delete (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__;
+    vi.unstubAllGlobals();
+  });
+
+  // The desktop shell talks to its own native engine over a Tauri IPC bridge on
+  // an ephemeral port, so a reachable localhost phase-server is always someone
+  // else's and must never displace the server the player picked.
+  it("keeps the chosen server in the desktop shell even when localhost answers", async () => {
+    (window as unknown as Record<string, unknown>).__TAURI_INTERNALS__ = {};
+    const fetchSpy = vi.fn(() => Promise.resolve(new Response("ok", { status: 200 })));
+    vi.stubGlobal("fetch", fetchSpy);
+    useMultiplayerStore.setState({ serverAddress: CHOSEN });
+
+    await expect(detectServerUrl()).resolves.toBe(CHOSEN);
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("falls back to this build's default when no valid address is stored", async () => {
+    useMultiplayerStore.setState({ serverAddress: "" });
+
+    await expect(detectServerUrl()).resolves.toBe(DEFAULT_SERVER);
   });
 });
 

--- a/client/src/services/serverDetection.ts
+++ b/client/src/services/serverDetection.ts
@@ -1,4 +1,3 @@
-import { isTauri } from "./platform";
 import { useMultiplayerStore } from "../stores/multiplayerStore";
 import {
   DEFAULT_MULTIPLAYER_SERVER_URL,
@@ -59,33 +58,19 @@ export function isValidWebSocketUrl(value: string): boolean {
 }
 
 /**
- * Detect the best WebSocket server URL by trying in order:
- * 1. Tauri sidecar on localhost
- * 2. Last-used server address from store
- * 3. Default production server
+ * The server a game socket must open on: the address the player chose — server
+ * picker, or the host carried in a `CODE@host` join code — falling back to this
+ * build's default when nothing valid is stored.
+ *
+ * Reachability is deliberately not consulted. The desktop shell reaches its own
+ * native engine over a Tauri IPC bridge (`services/nativeEngineSocket.ts`) on an
+ * ephemeral port, never through a URL from here, so probing localhost can only
+ * capture an unrelated phase-server and silently override the player's choice.
+ *
+ * Stays `async` for its awaiting callers; there is nothing left to wait for.
  */
 export async function detectServerUrl(): Promise<string> {
-  // Step 1: If running in Tauri, check localhost sidecar
-  if (isTauri()) {
-    const sidecarUrl = await tryHealthCheck(`http://localhost:${DEFAULT_PORT}/health`);
-    if (sidecarUrl) {
-      return `ws://localhost:${DEFAULT_PORT}/ws`;
-    }
-  }
-
-  // Step 2: Try the stored server address
   const stored = useMultiplayerStore.getState().serverAddress;
-  if (stored && isValidWebSocketUrl(stored)) {
-    const httpUrl = wsUrlToHealthUrl(stored);
-    if (httpUrl) {
-      const reachable = await tryHealthCheck(httpUrl);
-      if (reachable) {
-        return stored;
-      }
-    }
-  }
-
-  // Step 3: Fall back to stored address or default production server
   return isValidWebSocketUrl(stored) ? stored : DEFAULT_SERVER;
 }
 
@@ -190,8 +175,9 @@ export function formatJoinShare(code: string, publicUrl: string): string | null 
  * browser blocks it before the handshake is ever attempted, so the failure is
  * otherwise indistinguishable from an unreachable server. Loopback hosts are
  * exempt: browsers treat `localhost`/`127.0.0.1` as potentially trustworthy, so
- * `ws://localhost` is permitted even from an HTTPS origin (this is the Tauri
- * sidecar path). Outside a browser (`window` undefined) nothing is blocked.
+ * `ws://localhost` is permitted even from an HTTPS origin — which is what makes
+ * a `CODE@localhost:9374` join code work. Outside a browser (`window`
+ * undefined) nothing is blocked.
  */
 export function mixedContentBlockReason(serverAddress: string): string | null {
   const url = parseWebSocketUrl(serverAddress);
@@ -209,27 +195,4 @@ export function mixedContentBlockReason(serverAddress: string): string | null {
     `Host phase-server behind HTTPS — a wss:// reverse proxy or tunnel (ngrok, Cloudflare, Caddy) — ` +
     `or open the app over http://.`
   );
-}
-
-/** Convert ws:// URL to http:// health check URL. */
-function wsUrlToHealthUrl(wsUrl: string): string | null {
-  if (!isValidWebSocketUrl(wsUrl)) {
-    return null;
-  }
-  return wsUrl
-    .replace(/^ws:\/\//, "http://")
-    .replace(/^wss:\/\//, "https://")
-    .replace(/\/ws\/?$/, "/health");
-}
-
-async function tryHealthCheck(url: string): Promise<boolean> {
-  try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), 2000);
-    const response = await fetch(url, { signal: controller.signal });
-    clearTimeout(timeoutId);
-    return response.ok;
-  } catch {
-    return false;
-  }
 }

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -1478,10 +1478,10 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
       // v2 → v3: same rule, re-applied because the official set now spans a
       // broker PER RELEASE CHANNEL. Without this bump a returning preview
       // browser keeps its persisted production address, and detectServerUrl
-      // honours any stored address whose /health answers — production's does —
-      // so it would silently stay pinned to a lobby its build cannot handshake
-      // with. Re-running the same migration repoints it at this channel's
-      // broker; a user-typed non-official address is still preserved.
+      // honours any valid stored address, so it would silently stay pinned to a
+      // lobby its build cannot handshake with. Re-running the same migration
+      // repoints it at this channel's broker; a user-typed non-official address
+      // is still preserved.
       migrate: migratePersistedMultiplayerState,
       partialize: (state) => ({
         playerId: state.playerId,


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

The desktop shell cannot play on a remote phase-server whenever the machine also runs a phase-server on port 9374: `detectServerUrl()` probes `http://localhost:9374/health` when `isTauri()` is true and returns `ws://localhost:9374/ws` on a hit, so the game socket — and only the game socket — abandons the server the player chose. That probe served the bundled sidecar, which #6266 removed; the probe outlived it. This deletes it, and with it a stored-address health check that provably could not change the result.

## Files changed

- `client/src/services/serverDetection.ts`
- `client/src/services/__tests__/serverDetection.test.ts`
- `client/src/stores/multiplayerStore.ts` (comment only — the persisted-address migration rationale cited the removed `/health` behaviour)

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — client-only fix in `client/src/services/`; no `crates/` change, no parser or rules logic.

## CR references

None

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `tsc -b --noEmit` (client) — exit 0
- `eslint client/src/services/serverDetection.ts client/src/services/__tests__/serverDetection.test.ts` — exit 0
- `vitest run` (whole client suite) — 314 files passed, 3 skipped; 2983 tests passed, 12 todo, 0 failed
- Discrimination check — the new regression test run against `origin/main`'s `serverDetection.ts`: `AssertionError: expected 'ws://localhost:9374/ws' to be 'wss://play.example.com/ws'`, `Tests 1 failed | 23 passed`
- End-to-end falsification, run by the reporting user on the affected machine — with the local phase-server on 9374 stopped and nothing else changed, the desktop app joined the remote game normally

Rust checks were not run: the diff touches no `crates/` path, no `Cargo.toml`, and no card data. CI on this branch is a fork run.

## Gate A

Gate A PASS head=5be39df16e29e8c857e30cb1c0a3eeffe56929d2 base=875986b14edb36499dfcdd16319ef18f34dc66f8

## Anchored on

- client/src/stores/multiplayerStore.ts:655 — `openPhaseSocket(get().serverAddress)`: every other socket (lobby, lookup, host/pregame) opens on the chosen address with no reachability probing. The game socket now matches its siblings instead of re-deriving a URL.
- client/src/providers/GameProvider.tsx:1658 and client/src/adapter/p2p-adapter.ts:220 — `socketFactory: () => new NativeEngineSocket()`: the desktop's own engine is reached over the shell's IPC bridge, never through a URL from `serverDetection.ts`. This is the pattern that made the localhost probe dead code.

## Final review-impl

Final review-impl not-applicable — no `crates/` change. An independent read-only review of the committed diff was run before this PR opened; result recorded in "Final Report → 4".

## Claimed parse impact

None.

## Scope Expansion

The stored-address health check (former step 2) was removed alongside the defect. It is not an independent change of behaviour: it returned `stored`, and the fallback below it returns `stored` for the same input set (`stored && isValidWebSocketUrl(stored)` ⊂ `isValidWebSocketUrl(stored)`), so it could not alter the result — it only spent up to 2s of `fetch` timeout before every online connect. Removing it leaves `tryHealthCheck` and `wsUrlToHealthUrl` with no callers, so they go too. Declared here because it enlarges the diff beyond the one-branch defect.

## Validation Failures

None.

## CI Failures

None.

## Final Report

### 1. The defect

`client/src/services/serverDetection.ts` before this change:

```ts
export async function detectServerUrl(): Promise<string> {
  if (isTauri()) {                                          // step 1
    const sidecarUrl = await tryHealthCheck(`http://localhost:${DEFAULT_PORT}/health`);
    if (sidecarUrl) return `ws://localhost:${DEFAULT_PORT}/ws`;
  }
  const stored = useMultiplayerStore.getState().serverAddress;
  if (stored && isValidWebSocketUrl(stored)) {              // step 2
    /* health check */ if (reachable) return stored;
  }
  return isValidWebSocketUrl(stored) ? stored : DEFAULT_SERVER;   // step 3
}
```

`GameProvider.tsx:1199` resolves the game socket as `import.meta.env.VITE_WS_URL ?? await detectServerUrl()`, and `VITE_WS_URL` is set nowhere in the repo, so the game socket always goes through this function. Every other socket dials `serverAddress` directly (`multiplayerStore.ts:655`). In a desktop shell on a machine running any phase-server on 9374, that split sends the game socket to the local server while the lobby, lookup and pregame sockets reach the chosen one.

Observed against a self-hosted server, with the server's own log as the witness:

- Desktop host: lobby and pregame sockets arrive; on `GameStarted` the pregame socket closes as designed and the post-`GameStarted` game socket never arrives. The client shows "waiting for game" and a reconnect error.
- Desktop joiner: `LookupJoinTarget` → `JoinTargetInfo` arrive; `JoinGameWithPassword` never does. The client shows "connection failed".
- Browser, same server, same codes: both sides connect and play.

### 2. Why it exists

`git log -- client/src/services/serverDetection.ts` → `97e376ac9` (#6266, "ship/thin shell phase 1"), whose body reads "A.7-A.8 sidecar removal" and "C.5 removes the development sidecar build/install path". That commit deleted `client/src/services/sidecar.ts` (117 lines, `spawnSidecar(port = 9374)`) and touched `serverDetection.ts` only to move one import:

```diff
-import { isTauri } from "./sidecar";
+import { isTauri } from "./platform";
```

The probe body survived the removal of the thing it probed for. Today's desktop engine is a different mechanism: `client/src-tauri/src/native_engine.rs` reserves an ephemeral port (`reserve_port()` binds `127.0.0.1:0`) and the webview reaches it over the shell-owned IPC bridge (`native_bridge.rs`, `services/nativeEngineSocket.ts`), never through a URL from `serverDetection.ts`. So step 1 can no longer find anything the app itself started — only an unrelated server.

The failure is silent rather than loud because a local phase-server on a matching protocol version completes the handshake. Probing a local dev server directly:

```
<< ServerHello {"server_version":"0.60.0","protocol_version":33,"mode":"Full", ...}
>> JoinGameWithPassword {"game_code":"L22YK7", ...}
<< Error {"message":"Game not found in lobby: L22YK7"}
```

A protocol mismatch would have produced the version-mismatch prompt; a match produces "connection failed" with no explanation.

### 3. The change

`detectServerUrl()` becomes the selector it always was behind the probes:

```ts
export async function detectServerUrl(): Promise<string> {
  const stored = useMultiplayerStore.getState().serverAddress;
  return isValidWebSocketUrl(stored) ? stored : DEFAULT_SERVER;
}
```

The signature stays `async`: both call sites and `GameProvider.nativeEngine.test.tsx`'s mock await it, and making it synchronous would ripple into that mock for no behavioural gain. `mixedContentBlockReason`'s docstring, which cited "the Tauri sidecar path" as the reason loopback is exempt from mixed-content blocking, now cites what actually depends on that exemption: a `CODE@localhost:9374` join code.

### 4. Review

An independent read-only pass over the committed diff checked the seam, the call sites, and whether removing the stored-address health check could change any outcome. `detectServerUrl` is the seam: it is the single authority for the game socket's URL, so the fix removes the override where it happens rather than compensating downstream. One finding, fixed in this commit: the persisted-address migration comment in `multiplayerStore.ts` justified itself with "detectServerUrl honours any stored address whose /health answers", which this change makes untrue; it now reads "honours any valid stored address". No other findings.

### 5. Tests

`client/src/services/__tests__/serverDetection.test.ts` gains a `detectServerUrl` block. The regression test sets `window.__TAURI_INTERNALS__` — what the real `isTauri()` reads, so no module mock stands between the test and the predicate — and stubs `fetch` to answer 200 for anything, reproducing a machine with a phase-server on 9374.

Discriminating: run against `origin/main`'s `serverDetection.ts` it fails with the production symptom.

```
× keeps the chosen server in the desktop shell even when localhost answers
AssertionError: expected 'ws://localhost:9374/ws' to be 'wss://play.example.com/ws'
Tests  1 failed | 23 passed (24)
```

Non-vacuous: it asserts a concrete URL and `expect(fetchSpy).not.toHaveBeenCalled()`, which pins the "no probing" half of the change — a re-added probe fails one assertion or the other. The second test in the block (default when nothing is stored) is a contract test, not a regression test; it passes on both revisions.

### 6. Follow-up, not in this PR

`HostControlTile.tsx:444-447` fires `showToast("join link copied")` unconditionally after `void navigator.clipboard?.writeText(joinShare)`, so the toast claims success when the clipboard API is absent or the write rejects — which is what a Linux desktop shell reports (the tooltip renders the join link, the click copies nothing). Nine other call sites use `navigator.clipboard.writeText` the same way. That belongs in its own change, at a shared helper rather than at this one button.

### 7. Verification

```
tsc -b --noEmit                        exit 0
eslint <both changed files>            exit 0
vitest run (whole client suite)        314 files passed | 3 skipped, 2983 passed | 12 todo, 0 failed
./scripts/check-parser-combinators.sh  Gate A PASS head=5be39df16… base=875986b14…
```
