### PR TITLE
Fix Grub's Command

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -34746,6 +34746,24 @@ fn try_fold_token_repeat_into_count(effect: &mut Effect, qty: &QuantityExpr) -> 
 /// (the put-continuation is an ordinary zone change), `Some(caused_by)` when one
 /// is. Verb arms are composed with `alt(tag(...))`, scanned at word boundaries,
 /// so the dimension is a single combinator rather than enumerated permutations.
+fn parse_tracked_anaphor_suffix(
+    input: &str,
+) -> nom::IResult<&str, Option<ThisWayCause>, OracleError<'_>> {
+    alt((
+        value(
+            Some(ThisWayCause::Exiled),
+            tag::<_, _, OracleError<'_>>("exiled this way"),
+        ),
+        value(Some(ThisWayCause::Sacrificed), tag("sacrificed this way")),
+        value(Some(ThisWayCause::Destroyed), tag("destroyed this way")),
+        value(Some(ThisWayCause::Milled), tag("milled this way")),
+        value(Some(ThisWayCause::Discarded), tag("discarded this way")),
+        value(Some(ThisWayCause::Returned), tag("returned this way")),
+        value(None, tag("revealed this way")),
+    ))
+    .parse(input)
+}
+
 fn tracked_anaphor_cause(before_lower: &str, is_dig_anaphor: bool) -> Option<Option<ThisWayCause>> {
     // A dig-style "from among …" anaphor is always a selection set.
     if is_dig_anaphor {
@@ -34754,21 +34772,18 @@ fn tracked_anaphor_cause(before_lower: &str, is_dig_anaphor: bool) -> Option<Opt
     // CR 608.2c: each verb phrase maps to the producer action that made the
     // member part of the set. `None` = selection set (reveal); `Some(cause)` =
     // a producer keyword action.
-    nom_primitives::scan_at_word_boundaries(before_lower, |input| {
-        alt((
-            value(
-                Some(ThisWayCause::Exiled),
-                tag::<_, _, OracleError<'_>>("exiled this way"),
-            ),
-            value(Some(ThisWayCause::Sacrificed), tag("sacrificed this way")),
-            value(Some(ThisWayCause::Destroyed), tag("destroyed this way")),
-            value(Some(ThisWayCause::Milled), tag("milled this way")),
-            value(Some(ThisWayCause::Discarded), tag("discarded this way")),
-            value(Some(ThisWayCause::Returned), tag("returned this way")),
-            value(None, tag("revealed this way")),
-        ))
-        .parse(input)
-    })
+    nom_primitives::scan_at_word_boundaries(before_lower, parse_tracked_anaphor_suffix)
+}
+
+/// Extract the member phrase before a tracked-set producer suffix, preserving
+/// the cause parsed by the same suffix vocabulary as `tracked_anaphor_cause`.
+/// The caller supplies text after the mass quantifier, so `each Goblin card
+/// milled this way` becomes `Goblin card` before `parse_target` sees it.
+fn tracked_anaphor_member_prefix(target_text: &str) -> Option<(&str, Option<ThisWayCause>)> {
+    let lower = target_text.to_ascii_lowercase();
+    let (prefix, caused_by, _) =
+        nom_primitives::scan_preceded(&lower, parse_tracked_anaphor_suffix)?;
+    Some((target_text[..prefix.len()].trim_end(), caused_by))
 }
 
 #[cfg(test)]
@@ -34853,31 +34868,28 @@ fn try_parse_put_zone_change_parts(
             // (see `parse_total_mana_value_target_constraint` in `lower.rs`).
             let stripped_mv = strip_total_mana_value_target_phrase(target_text);
             let target_text: &str = stripped_mv.as_deref().unwrap_or(target_text);
-            // CR 608.2c: Keep the full quantified noun phrase for tracked-set
-            // anaphors ("each Goblin card milled this way") so `parse_target`
-            // can parse the member filter before the producer-action suffix.
-            // The mass classification still applies; only the target-parser
-            // input differs. Non-anaphoric mass moves retain the existing
-            // quantifier stripping used by the Rise of the Dark Realms class.
+            // CR 608.2c: Strip the mass quantifier before parsing the member
+            // filter. For tracked-set anaphors, also strip the producer-action
+            // suffix ("Goblin card milled this way") using the same generic
+            // suffix vocabulary that determines `caused_by`.
             let tracked_caused_by =
                 tracked_anaphor_cause(before.lower, from_among_anaphor.is_some());
             // CR 400.7 + CR 110.2a: Mass put-onto-battlefield text moves every
             // matching object from the origin zone. Strip the mass quantifier
             // before target parsing so the filter mirrors the `return all`
-            // dispatcher. Tracked-set anaphors keep it so the shared parser can
-            // retain the member restriction while consuming the anaphor.
+            // dispatcher.
             let (is_mass, target_text) = if let Some((_, rest)) =
                 nom_on_lower(target_text, &target_text.to_ascii_lowercase(), |input| {
                     value((), alt((tag("all "), tag("each ")))).parse(input)
                 }) {
-                (
-                    true,
-                    if tracked_caused_by.is_some() {
-                        target_text
-                    } else {
-                        rest
-                    },
-                )
+                let target_text = if let Some(expected_cause) = tracked_caused_by {
+                    tracked_anaphor_member_prefix(rest)
+                        .filter(|(_, actual_cause)| *actual_cause == expected_cause)
+                        .map_or(rest, |(prefix, _)| prefix)
+                } else {
+                    rest
+                };
+                (true, target_text)
             } else {
                 (false, target_text)
             };

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -34853,15 +34853,30 @@ fn try_parse_put_zone_change_parts(
             // (see `parse_total_mana_value_target_constraint` in `lower.rs`).
             let stripped_mv = strip_total_mana_value_target_phrase(target_text);
             let target_text: &str = stripped_mv.as_deref().unwrap_or(target_text);
+            // CR 608.2c: Keep the full quantified noun phrase for tracked-set
+            // anaphors ("each Goblin card milled this way") so `parse_target`
+            // can parse the member filter before the producer-action suffix.
+            // The mass classification still applies; only the target-parser
+            // input differs. Non-anaphoric mass moves retain the existing
+            // quantifier stripping used by the Rise of the Dark Realms class.
+            let tracked_caused_by =
+                tracked_anaphor_cause(before.lower, from_among_anaphor.is_some());
             // CR 400.7 + CR 110.2a: Mass put-onto-battlefield text moves every
             // matching object from the origin zone. Strip the mass quantifier
             // before target parsing so the filter mirrors the `return all`
-            // dispatcher instead of relying on parse_target to re-strip it.
+            // dispatcher. Tracked-set anaphors keep it so the shared parser can
+            // retain the member restriction while consuming the anaphor.
             let (is_mass, target_text) = if let Some((_, rest)) =
                 nom_on_lower(target_text, &target_text.to_ascii_lowercase(), |input| {
                     value((), alt((tag("all "), tag("each ")))).parse(input)
                 }) {
-                (true, rest)
+                (
+                    true,
+                    tracked_caused_by
+                        .is_some()
+                        .then_some(target_text)
+                        .unwrap_or(rest),
+                )
             } else {
                 (false, target_text)
             };
@@ -34926,8 +34941,6 @@ fn try_parse_put_zone_change_parts(
             // action-agnostic (`None`). Binding to the action (not the zone)
             // keeps a sacrifice redirected to Exile by a replacement counted.
             // The outer `Option` is the tracked-anaphor flag.
-            let tracked_caused_by =
-                tracked_anaphor_cause(before.lower, from_among_anaphor.is_some());
             let is_tracked_anaphor = tracked_caused_by.is_some();
             let target = match tracked_caused_by {
                 Some(caused_by) => TargetFilter::TrackedSetFiltered {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -34746,24 +34746,6 @@ fn try_fold_token_repeat_into_count(effect: &mut Effect, qty: &QuantityExpr) -> 
 /// (the put-continuation is an ordinary zone change), `Some(caused_by)` when one
 /// is. Verb arms are composed with `alt(tag(...))`, scanned at word boundaries,
 /// so the dimension is a single combinator rather than enumerated permutations.
-fn parse_tracked_anaphor_suffix(
-    input: &str,
-) -> nom::IResult<&str, Option<ThisWayCause>, OracleError<'_>> {
-    alt((
-        value(
-            Some(ThisWayCause::Exiled),
-            tag::<_, _, OracleError<'_>>("exiled this way"),
-        ),
-        value(Some(ThisWayCause::Sacrificed), tag("sacrificed this way")),
-        value(Some(ThisWayCause::Destroyed), tag("destroyed this way")),
-        value(Some(ThisWayCause::Milled), tag("milled this way")),
-        value(Some(ThisWayCause::Discarded), tag("discarded this way")),
-        value(Some(ThisWayCause::Returned), tag("returned this way")),
-        value(None, tag("revealed this way")),
-    ))
-    .parse(input)
-}
-
 fn tracked_anaphor_cause(before_lower: &str, is_dig_anaphor: bool) -> Option<Option<ThisWayCause>> {
     // A dig-style "from among …" anaphor is always a selection set.
     if is_dig_anaphor {
@@ -34772,18 +34754,21 @@ fn tracked_anaphor_cause(before_lower: &str, is_dig_anaphor: bool) -> Option<Opt
     // CR 608.2c: each verb phrase maps to the producer action that made the
     // member part of the set. `None` = selection set (reveal); `Some(cause)` =
     // a producer keyword action.
-    nom_primitives::scan_at_word_boundaries(before_lower, parse_tracked_anaphor_suffix)
-}
-
-/// Extract the member phrase before a tracked-set producer suffix, preserving
-/// the cause parsed by the same suffix vocabulary as `tracked_anaphor_cause`.
-/// The caller supplies text after the mass quantifier, so `each Goblin card
-/// milled this way` becomes `Goblin card` before `parse_target` sees it.
-fn tracked_anaphor_member_prefix(target_text: &str) -> Option<(&str, Option<ThisWayCause>)> {
-    let lower = target_text.to_ascii_lowercase();
-    let (prefix, caused_by, _) =
-        nom_primitives::scan_preceded(&lower, parse_tracked_anaphor_suffix)?;
-    Some((target_text[..prefix.len()].trim_end(), caused_by))
+    nom_primitives::scan_at_word_boundaries(before_lower, |input| {
+        alt((
+            value(
+                Some(ThisWayCause::Exiled),
+                tag::<_, _, OracleError<'_>>("exiled this way"),
+            ),
+            value(Some(ThisWayCause::Sacrificed), tag("sacrificed this way")),
+            value(Some(ThisWayCause::Destroyed), tag("destroyed this way")),
+            value(Some(ThisWayCause::Milled), tag("milled this way")),
+            value(Some(ThisWayCause::Discarded), tag("discarded this way")),
+            value(Some(ThisWayCause::Returned), tag("returned this way")),
+            value(None, tag("revealed this way")),
+        ))
+        .parse(input)
+    })
 }
 
 #[cfg(test)]
@@ -34868,38 +34853,18 @@ fn try_parse_put_zone_change_parts(
             // (see `parse_total_mana_value_target_constraint` in `lower.rs`).
             let stripped_mv = strip_total_mana_value_target_phrase(target_text);
             let target_text: &str = stripped_mv.as_deref().unwrap_or(target_text);
-            // CR 608.2c: Strip the mass quantifier before parsing the member
-            // filter. For tracked-set anaphors, also strip the producer-action
-            // suffix ("Goblin card milled this way") using the same generic
-            // suffix vocabulary that determines `caused_by`.
-            let tracked_caused_by =
-                tracked_anaphor_cause(before.lower, from_among_anaphor.is_some());
             // CR 400.7 + CR 110.2a: Mass put-onto-battlefield text moves every
             // matching object from the origin zone. Strip the mass quantifier
             // before target parsing so the filter mirrors the `return all`
-            // dispatcher.
-            let (is_mass, target_text) =
-                if nom_on_lower(before.original.trim(), before.lower.trim(), |input| {
+            // dispatcher instead of relying on parse_target to re-strip it.
+            let (is_mass, target_text) = if let Some((_, rest)) =
+                nom_on_lower(target_text, &target_text.to_ascii_lowercase(), |input| {
                     value((), alt((tag("all "), tag("each ")))).parse(input)
-                })
-                .is_some()
-                {
-                    let target_text =
-                        nom_on_lower(target_text, &target_text.to_ascii_lowercase(), |input| {
-                            value((), alt((tag("all "), tag("each ")))).parse(input)
-                        })
-                        .map_or(target_text, |(_, rest)| rest);
-                    let target_text = if let Some(expected_cause) = tracked_caused_by {
-                        tracked_anaphor_member_prefix(target_text)
-                            .filter(|(_, actual_cause)| *actual_cause == expected_cause)
-                            .map_or(target_text, |(prefix, _)| prefix)
-                    } else {
-                        target_text
-                    };
-                    (true, target_text)
-                } else {
-                    (false, target_text)
-                };
+                }) {
+                (true, rest)
+            } else {
+                (false, target_text)
+            };
             let up_to = parse_up_to_one_target_prefix(before.lower) || choice_count.is_some();
             // CR 608.2c + CR 608.2k + CR 406.6 + CR 607.2a: a bare plural
             // anaphor whose antecedent is the trigger's linked-exile pool
@@ -34961,6 +34926,8 @@ fn try_parse_put_zone_change_parts(
             // action-agnostic (`None`). Binding to the action (not the zone)
             // keeps a sacrifice redirected to Exile by a replacement counted.
             // The outer `Option` is the tracked-anaphor flag.
+            let tracked_caused_by =
+                tracked_anaphor_cause(before.lower, from_among_anaphor.is_some());
             let is_tracked_anaphor = tracked_caused_by.is_some();
             let target = match tracked_caused_by {
                 Some(caused_by) => TargetFilter::TrackedSetFiltered {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -34872,10 +34872,11 @@ fn try_parse_put_zone_change_parts(
                 }) {
                 (
                     true,
-                    tracked_caused_by
-                        .is_some()
-                        .then_some(target_text)
-                        .unwrap_or(rest),
+                    if tracked_caused_by.is_some() {
+                        target_text
+                    } else {
+                        rest
+                    },
                 )
             } else {
                 (false, target_text)

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -34878,21 +34878,28 @@ fn try_parse_put_zone_change_parts(
             // matching object from the origin zone. Strip the mass quantifier
             // before target parsing so the filter mirrors the `return all`
             // dispatcher.
-            let (is_mass, target_text) = if let Some((_, rest)) =
-                nom_on_lower(target_text, &target_text.to_ascii_lowercase(), |input| {
+            let (is_mass, target_text) =
+                if nom_on_lower(before.original.trim(), before.lower.trim(), |input| {
                     value((), alt((tag("all "), tag("each ")))).parse(input)
-                }) {
-                let target_text = if let Some(expected_cause) = tracked_caused_by {
-                    tracked_anaphor_member_prefix(rest)
-                        .filter(|(_, actual_cause)| *actual_cause == expected_cause)
-                        .map_or(rest, |(prefix, _)| prefix)
+                })
+                .is_some()
+                {
+                    let target_text =
+                        nom_on_lower(target_text, &target_text.to_ascii_lowercase(), |input| {
+                            value((), alt((tag("all "), tag("each ")))).parse(input)
+                        })
+                        .map_or(target_text, |(_, rest)| rest);
+                    let target_text = if let Some(expected_cause) = tracked_caused_by {
+                        tracked_anaphor_member_prefix(target_text)
+                            .filter(|(_, actual_cause)| *actual_cause == expected_cause)
+                            .map_or(target_text, |(prefix, _)| prefix)
+                    } else {
+                        target_text
+                    };
+                    (true, target_text)
                 } else {
-                    rest
+                    (false, target_text)
                 };
-                (true, target_text)
-            } else {
-                (false, target_text)
-            };
             let up_to = parse_up_to_one_target_prefix(before.lower) || choice_count.is_some();
             // CR 608.2c + CR 608.2k + CR 406.6 + CR 607.2a: a bare plural
             // anaphor whose antecedent is the trigger's linked-exile pool

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -5679,6 +5679,7 @@ pub(super) fn parse_dig_from_among(
             (rest, true, is_reveal)
         } else if let Ok((rest, is_reveal)) = alt((
             value(false, tag::<_, _, OracleError<'_>>("put ")),
+            value(false, tag("puts ")),
             value(true, tag("reveal ")),
             value(false, tag("return ")),
         ))
@@ -5793,6 +5794,7 @@ pub(super) fn parse_dig_from_among(
             value(false, tag("you may put ")),
             value(false, tag("you may return ")),
             value(false, tag("put ")),
+            value(false, tag("puts ")),
             value(true, tag("reveal ")),
             value(false, tag("return ")),
         ))

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -29,7 +29,7 @@ use crate::types::ability::{
     FaceDownProfile, FilterProp, ForEachCategoryAction, LibraryPosition, ManaSpendRestriction,
     MultiTargetSpec, ObjectScope, PermissionGrantee, PlayerFilter, PtValue, QuantityExpr,
     QuantityRef, RevealUntilDisposition, SpellStackToGraveyardReplacement, StaticDefinition,
-    TargetChoiceTiming, TargetFilter, TypeFilter, TypedFilter,
+    TargetChoiceTiming, TargetFilter, ThisWayCause, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::CoreType;
 use crate::types::counter::CounterType;
@@ -4300,6 +4300,7 @@ pub(super) fn apply_clause_continuation(
             enter_tapped,
             enters_attacking,
             reveal_verb,
+            caused_by,
         } => {
             // CR 608.2c: the "from among those cards" continuation patches the
             // earlier "look at the top N" instruction. When a transparent
@@ -4550,7 +4551,7 @@ pub(super) fn apply_clause_continuation(
                                     // selection anaphor over a single-producer
                                     // set — zone-agnostic (every member is in the
                                     // mill destination already).
-                                    caused_by: None,
+                                    caused_by,
                                 },
                                 enters_under,
                                 enter_tapped: crate::types::zones::EtbTapState::from_legacy_bool(
@@ -4585,7 +4586,7 @@ pub(super) fn apply_clause_continuation(
                                     filter: Box::new(card_filter),
                                     // Selection anaphor over the single milled
                                     // set — zone-agnostic (see the `All` arm).
-                                    caused_by: None,
+                                    caused_by,
                                 },
                                 owner_library: false,
                                 enter_transformed: false,
@@ -5774,6 +5775,7 @@ pub(super) fn parse_dig_from_among(
             enter_tapped,
             enters_attacking,
             reveal_verb,
+            caused_by: Some(ThisWayCause::Milled),
         });
     }
 
@@ -5880,6 +5882,7 @@ pub(super) fn parse_dig_from_among(
             enter_tapped,
             enters_attacking,
             reveal_verb,
+            caused_by: None,
         });
     }
 
@@ -5944,6 +5947,7 @@ pub(super) fn parse_dig_from_among(
                 enter_tapped,
                 enters_attacking,
                 reveal_verb: false,
+                caused_by: None,
             });
         }
     }
@@ -7026,6 +7030,7 @@ pub(super) fn parse_followup_continuation_ast(
                 enters_attacking: false,
                 // "put one of those cards onto the battlefield" — a put, not a reveal.
                 reveal_verb: false,
+                caused_by: None,
             })
         }
         // "You may put one of those cards back on top of your library" after
@@ -7049,6 +7054,7 @@ pub(super) fn parse_followup_continuation_ast(
                 enters_attacking: false,
                 // "put one ... back on top" — a put, not a reveal.
                 reveal_verb: false,
+                caused_by: None,
             })
         }
         // "put them back in any order" after Dig means all looked-at cards
@@ -10246,6 +10252,7 @@ mod tests {
                 enter_tapped: false,
                 enters_attacking: false,
                 reveal_verb: false,
+                caused_by: None,
             })
         );
     }
@@ -10272,6 +10279,7 @@ mod tests {
                 enter_tapped: false,
                 enters_attacking: false,
                 reveal_verb: false,
+                caused_by: None,
             })
         );
     }
@@ -10303,6 +10311,7 @@ mod tests {
                 enter_tapped: false,
                 enters_attacking: false,
                 reveal_verb: false,
+                caused_by: None,
             })
         );
     }
@@ -10328,6 +10337,7 @@ mod tests {
                 enter_tapped: false,
                 enters_attacking: false,
                 reveal_verb: false,
+                caused_by: None,
             })
         );
     }
@@ -10353,6 +10363,7 @@ mod tests {
                 enter_tapped: false,
                 enters_attacking: false,
                 reveal_verb: false,
+                caused_by: None,
             })
         );
     }
@@ -10380,6 +10391,7 @@ mod tests {
                     enter_tapped: false,
                     enters_attacking: false,
                     reveal_verb: false,
+                    caused_by: None,
                 }),
                 "{text}"
             );
@@ -10655,6 +10667,7 @@ mod tests {
                 enter_tapped: false,
                 enters_attacking: false,
                 reveal_verb: false,
+                caused_by: None,
             },
             AbilityKind::Spell,
             &env,
@@ -10929,6 +10942,7 @@ mod tests {
                 enter_tapped: false,
                 enters_attacking: false,
                 reveal_verb: false,
+                caused_by: None,
             },
             AbilityKind::Spell,
             &env,
@@ -10979,6 +10993,7 @@ mod tests {
                 enter_tapped: false,
                 enters_attacking: false,
                 reveal_verb: false,
+                caused_by: None,
             },
             AbilityKind::Spell,
             &env,
@@ -11047,6 +11062,7 @@ mod tests {
                 enter_tapped: false,
                 enters_attacking: false,
                 reveal_verb: false,
+                caused_by: None,
             },
             AbilityKind::Spell,
             &env,
@@ -12076,6 +12092,7 @@ mod tests {
                 enter_tapped: false,
                 enters_attacking: false,
                 reveal_verb: false,
+                caused_by: None,
             })
         );
     }

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -10643,6 +10643,30 @@ mod tests {
     }
 
     #[test]
+    fn conjugated_puts_from_among_preserves_selection_cause() {
+        let dig = make_dig_effect();
+        let result = parse_followup_continuation_ast(
+            "Puts each creature card from among them into your hand.",
+            &dig,
+            &mut ParseContext::default(),
+        );
+        let Some(ContinuationAst::DigFromAmong {
+            quantity,
+            filter,
+            destination,
+            caused_by,
+            ..
+        }) = result
+        else {
+            panic!("expected DigFromAmong continuation, got {result:?}");
+        };
+        assert_eq!(quantity, PutCount::All);
+        assert!(matches!(filter, TargetFilter::Typed(_)), "got {filter:?}");
+        assert_eq!(destination, Some(Zone::Hand));
+        assert_eq!(caused_by, None);
+    }
+
+    #[test]
     fn dig_any_number_from_among_lowers_to_up_to_all_seen_cards() {
         let mut defs = vec![AbilityDefinition::new(
             AbilityKind::Spell,

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -7267,6 +7267,7 @@ fn target_player_mills_then_puts_milled_goblins_into_hand() {
         Effect::Mill {
             count: QuantityExpr::Fixed { value: 5 },
             target: TargetFilter::Player,
+            ..
         }
     ));
 

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -7256,6 +7256,49 @@ fn effect_chain_unless_target_controller_pays_mana() {
 }
 
 #[test]
+fn target_player_mills_then_puts_milled_goblins_into_hand() {
+    let def = parse_effect_chain(
+        "Target player mills five cards, then puts each Goblin card milled this way into their hand.",
+        AbilityKind::Spell,
+    );
+
+    assert!(matches!(
+        def.effect.as_ref(),
+        Effect::Mill {
+            count: QuantityExpr::Fixed { value: 5 },
+            target: TargetFilter::Player,
+        }
+    ));
+
+    let follow_up = def
+        .sub_ability
+        .as_deref()
+        .expect("Mill must chain to the Goblin return effect");
+    let Effect::ChangeZoneAll {
+        destination,
+        target:
+            TargetFilter::TrackedSetFiltered {
+                caused_by: Some(ThisWayCause::Milled),
+                filter,
+                ..
+            },
+        ..
+    } = follow_up.effect.as_ref()
+    else {
+        panic!(
+            "expected the second chain node to return milled Goblin cards, got {:?}",
+            follow_up.effect
+        );
+    };
+    assert_eq!(*destination, Zone::Hand);
+    assert!(matches!(
+        filter.as_ref(),
+        TargetFilter::Typed(TypedFilter { type_filters, .. })
+            if type_filters.contains(&TypeFilter::Subtype("Goblin".to_string()))
+    ));
+}
+
+#[test]
 fn effect_chain_unless_target_controller_pays_life() {
     let def = parse_effect_chain(
         "Tap target creature unless its controller pays 2 life",

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -10,7 +10,7 @@ use crate::types::ability::{
     ManaProduction, ManaSpendRestriction, ManaTargetRole, ModalSelectionConstraint,
     OutsideGameSourcePool, PlayerFilter, PtStat, PtValue, QuantityExpr, SearchDestinationSplit,
     SearchSelectionConstraint, SpellStackToGraveyardReplacement, StaticCondition, StaticDefinition,
-    SubAbilityLink, TargetFilter,
+    SubAbilityLink, TargetFilter, ThisWayCause,
 };
 use crate::types::card_type::Supertype;
 use crate::types::counter::CounterType;
@@ -457,6 +457,11 @@ pub(crate) enum ContinuationAst {
         /// cards route to a fixed library position (Fertile Thicket).
         #[serde(default)]
         reveal_verb: bool,
+        /// CR 608.2c: The producer action named by an explicit tracked-set suffix
+        /// such as "milled this way". Generic "from among" selection remains
+        /// action-agnostic (`None`).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        caused_by: Option<ThisWayCause>,
     },
     /// CR 708.2a + CR 205.1a: "They're N/M [types] [subtypes] creatures." after a
     /// put-face-down clause — refines the preceding face-down move's profile.

--- a/crates/engine/tests/integration/grubs_command_tracked_set_filter.rs
+++ b/crates/engine/tests/integration/grubs_command_tracked_set_filter.rs
@@ -1,0 +1,81 @@
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{AbilityKind, ResolvedAbility, TargetRef};
+use engine::types::card_type::CoreType;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaColor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const ORACLE: &str =
+    "Target player mills five cards, then puts each Goblin card milled this way into their hand.";
+
+fn mark_goblin(runner: &mut GameRunner, id: ObjectId) {
+    let object = runner.state_mut().objects.get_mut(&id).unwrap();
+    object.card_types.core_types = vec![CoreType::Creature];
+    object.card_types.subtypes = vec!["Goblin".to_string()];
+    object.base_card_types = object.card_types.clone();
+}
+
+fn mark_non_goblin(runner: &mut GameRunner, id: ObjectId) {
+    let object = runner.state_mut().objects.get_mut(&id).unwrap();
+    object.card_types.core_types = vec![CoreType::Sorcery];
+    object.card_types.subtypes.clear();
+    object.base_card_types = object.card_types.clone();
+}
+
+#[test]
+fn grubs_command_moves_only_milled_goblins_to_hand() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // add_card_to_library_top inserts at index 0, so these calls seed the
+    // library in the order Goblin, non-Goblin, Goblin, non-Goblin, non-Goblin.
+    let non_goblin_c = scenario.add_card_to_library_top(P1, "Non-Goblin C");
+    let non_goblin_b = scenario.add_card_to_library_top(P1, "Non-Goblin B");
+    let goblin_b = scenario.add_card_to_library_top(P1, "Goblin B");
+    let non_goblin_a = scenario.add_card_to_library_top(P1, "Non-Goblin A");
+    let goblin_a = scenario.add_card_to_library_top(P1, "Goblin A");
+
+    // A battlefield Goblin is the negative control for an unscoped subtype
+    // filter: it must not be moved by the follow-up effect.
+    let battlefield_goblin = scenario
+        .add_creature(P1, "Battlefield Goblin", 1, 1)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    let source = scenario.add_basic_land(P0, ManaColor::Black).id();
+
+    let mut runner = scenario.build();
+    for id in [goblin_a, goblin_b] {
+        mark_goblin(&mut runner, id);
+    }
+    for id in [non_goblin_a, non_goblin_b, non_goblin_c] {
+        mark_non_goblin(&mut runner, id);
+    }
+
+    assert_eq!(runner.state().players[1].library.len(), 5);
+
+    let definition = parse_effect_chain(ORACLE, AbilityKind::Spell);
+    let ability = ResolvedAbility {
+        targets: vec![TargetRef::Player(P1)],
+        ..build_resolved_from_def(&definition, source, P0)
+    };
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("Grubs Command effect chain should resolve");
+
+    assert_eq!(runner.state().players[1].hand.len(), 2);
+    for id in [goblin_a, goblin_b] {
+        assert_eq!(runner.state().objects[&id].zone, Zone::Hand);
+    }
+    assert_eq!(runner.state().players[1].graveyard.len(), 3);
+    for id in [non_goblin_a, non_goblin_b, non_goblin_c] {
+        assert_eq!(runner.state().objects[&id].zone, Zone::Graveyard);
+    }
+    assert_eq!(
+        runner.state().objects[&battlefield_goblin].zone,
+        Zone::Battlefield
+    );
+}

--- a/crates/engine/tests/integration/grubs_command_tracked_set_filter.rs
+++ b/crates/engine/tests/integration/grubs_command_tracked_set_filter.rs
@@ -11,6 +11,11 @@ const GRUBS_COMMAND_ORACLE: &str = "Choose two —\n\
     • Destroy target artifact or creature.\n\
     • Target player mills five cards, then puts each Goblin card milled this way into their hand.";
 
+// Grub's Command is a synthetic fixture sourced from issue #7500's complete
+// four-mode Oracle text because it is not present in the checked MTGJSON
+// corpus. The fixture still builds a full card definition and exercises the
+// normal cast/modal/target/stack pipeline.
+
 fn mark_goblin(runner: &mut GameRunner, id: ObjectId) {
     let object = runner.state_mut().objects.get_mut(&id).unwrap();
     object.card_types.core_types = vec![CoreType::Creature];

--- a/crates/engine/tests/integration/grubs_command_tracked_set_filter.rs
+++ b/crates/engine/tests/integration/grubs_command_tracked_set_filter.rs
@@ -1,16 +1,15 @@
-use engine::game::ability_utils::build_resolved_from_def;
-use engine::game::effects::resolve_ability_chain;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
-use engine::parser::oracle_effect::parse_effect_chain;
-use engine::types::ability::{AbilityKind, ResolvedAbility, TargetRef};
 use engine::types::card_type::CoreType;
 use engine::types::identifiers::ObjectId;
-use engine::types::mana::ManaColor;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
 
-const ORACLE: &str =
-    "Target player mills five cards, then puts each Goblin card milled this way into their hand.";
+const GRUBS_COMMAND_ORACLE: &str = "Choose two —\n\
+    • Create a token that's a copy of target Goblin you control.\n\
+    • Creatures target player controls get +1/+1 and gain haste until end of turn.\n\
+    • Destroy target artifact or creature.\n\
+    • Target player mills five cards, then puts each Goblin card milled this way into their hand.";
 
 fn mark_goblin(runner: &mut GameRunner, id: ObjectId) {
     let object = runner.state_mut().objects.get_mut(&id).unwrap();
@@ -27,7 +26,7 @@ fn mark_non_goblin(runner: &mut GameRunner, id: ObjectId) {
 }
 
 #[test]
-fn grubs_command_moves_only_milled_goblins_to_hand() {
+fn grubs_command_cast_moves_only_milled_goblins_to_hand() {
     let mut scenario = GameScenario::new_n_player(2, 42);
     scenario.at_phase(Phase::PreCombatMain);
 
@@ -39,13 +38,23 @@ fn grubs_command_moves_only_milled_goblins_to_hand() {
     let non_goblin_a = scenario.add_card_to_library_top(P1, "Non-Goblin A");
     let goblin_a = scenario.add_card_to_library_top(P1, "Goblin A");
 
-    // A battlefield Goblin is the negative control for an unscoped subtype
-    // filter: it must not be moved by the follow-up effect.
+    // This Goblin is a scope control for the tracked-set filter. Mode 1 also
+    // pumps P1's creatures, so only its zone is relevant to this assertion.
     let battlefield_goblin = scenario
         .add_creature(P1, "Battlefield Goblin", 1, 1)
         .with_subtypes(vec!["Goblin"])
         .id();
-    let source = scenario.add_basic_land(P0, ManaColor::Black).id();
+    let grubs_command = scenario
+        .add_spell_to_hand_from_oracle(P0, "Grub's Command", false, GRUBS_COMMAND_ORACLE)
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Black, ManaCostShard::Red],
+            generic: 3,
+        })
+        .id();
+    for _ in 0..4 {
+        scenario.add_basic_land(P0, ManaColor::Black);
+    }
+    scenario.add_basic_land(P0, ManaColor::Red);
 
     let mut runner = scenario.build();
     for id in [goblin_a, goblin_b] {
@@ -55,27 +64,22 @@ fn grubs_command_moves_only_milled_goblins_to_hand() {
         mark_non_goblin(&mut runner, id);
     }
 
-    assert_eq!(runner.state().players[1].library.len(), 5);
+    let outcome = runner
+        .cast(grubs_command)
+        .modes(&[1, 3])
+        .target_players(&[P1])
+        .resolve();
 
-    let definition = parse_effect_chain(ORACLE, AbilityKind::Spell);
-    let ability = ResolvedAbility {
-        targets: vec![TargetRef::Player(P1)],
-        ..build_resolved_from_def(&definition, source, P0)
-    };
-    let mut events = Vec::new();
-    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
-        .expect("Grubs Command effect chain should resolve");
-
-    assert_eq!(runner.state().players[1].hand.len(), 2);
+    assert_eq!(outcome.state().players[1].hand.len(), 2);
     for id in [goblin_a, goblin_b] {
-        assert_eq!(runner.state().objects[&id].zone, Zone::Hand);
+        assert_eq!(outcome.state().objects[&id].zone, Zone::Hand);
     }
-    assert_eq!(runner.state().players[1].graveyard.len(), 3);
+    assert_eq!(outcome.state().players[1].graveyard.len(), 3);
     for id in [non_goblin_a, non_goblin_b, non_goblin_c] {
-        assert_eq!(runner.state().objects[&id].zone, Zone::Graveyard);
+        assert_eq!(outcome.state().objects[&id].zone, Zone::Graveyard);
     }
     assert_eq!(
-        runner.state().objects[&battlefield_goblin].zone,
+        outcome.state().objects[&battlefield_goblin].zone,
         Zone::Battlefield
     );
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -292,6 +292,7 @@ mod graveyard_to_hand_activation_zone;
 mod greater_good_activation;
 mod green_suns_zenith_regression;
 mod griffin_rider_conditional_self_buff;
+mod grubs_command_tracked_set_filter;
 mod hag_noxious_nightmares_menace_grant;
 mod halana_alena_partners_where_x;
 mod harrow_regression;


### PR DESCRIPTION
## Summary

Fix issue #7500 at the existing Dig continuation seam. The parser now recognizes the conjugated mass continuation, parses only the member phrase `Goblin card`, preserves `ThisWayCause::Milled`, and lowers the result to a typed `TrackedSetFiltered` `ChangeZoneAll`. The separate singular `ChangeZone` tracked-set runtime defect remains out of scope.

## Files changed

- `crates/engine/src/parser/oracle_effect/sequence.rs`
- `crates/engine/src/parser/oracle_effect/tests.rs`
- `crates/engine/src/parser/oracle_ir/ast.rs`
- `crates/engine/tests/integration/grubs_command_tracked_set_filter.rs`
- `crates/engine/tests/integration/main.rs`

## Track

Developer

## LLM

Model: GPT Luna 5.6
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

CR 608.2c; CR 701.17c; CR 701.20a/CR 701.20e.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — PASS.
- `git diff --check` — PASS.
- Exact-head GitHub CI run `32638218286` — PASS: parser regression, production cast-path regression, clippy/parser gate, all Rust shards, card-data/parse diff, frontend, WASM, and aggregate Rust checks.
- `./scripts/check-parser-combinators.sh upstream/main` — PASS; exact Gate A output below.
- Final read-only `/review-impl` — PASS, no findings, exact head below.
- The local warmed-cache parser command was environment-terminated by rustc with signal 15 (SIGTERM) before the test binary ran; GitHub exact-head CI executed and passed the targeted parser and production integration tests.

## Gate A

Gate A PASS head=9588d94bb620953a97f384e0504c0bb73ed6cf43 base=d6d28370c09242182488cac72e16e5a84941885f

## Anchored on

- `crates/engine/src/parser/oracle_effect/sequence.rs:5625` — existing Dig continuation parser and member-filter authority.
- `crates/engine/src/parser/oracle_effect/sequence.rs:5682` — same-seam mass tracked-anaphor grammar, including the generic `puts` verb.
- `crates/engine/src/parser/oracle_effect/sequence.rs:4544` — existing `ChangeZoneAll` lowering for mass milled continuations.
- `crates/engine/tests/integration/issue_3301_izzet_charm_counter.rs:81` — modal spell cast/commit/resolve pattern.
- `crates/engine/tests/integration/wheel_and_deal.rs:65` — player targets carried through the scenario cast pipeline.

## Final review-impl

Final review-impl PASS head=9588d94bb620953a97f384e0504c0bb73ed6cf43

## Claimed parse impact

The SHA-bound parse-diff artifact for head `9588d94bb620953a97f384e0504c0bb73ed6cf43` against base `d6d28370c09242182488cac72e16e5a84941885f` reports exactly 1 affected card and 2 signatures:

- **Grub's Command** — removes `ChangeZone (target=tracked set #0 matching any target, to=hand)` and adds `ChangeZoneAll (from=graveyard, target=tracked set #0 matching Goblin, to=hand)`.

No unrelated corpus cards changed.

## Scope Expansion

None. The runtime regression uses a complete synthetic Grub's Command card definition because the card is absent from the checked MTGJSON corpus; it does not claim registered card-data coverage, but it does exercise the normal card-definition → hand → cast → modal selection → player target → stack → resolution pipeline. The destination-ambiguous `returned this way`/Bounced issue, the separate singular `ChangeZone` defect, and the unrelated bare `puts ... of them` continuation remain unclaimed and out of scope.

## Validation Failures

None unresolved. The only incomplete local heavy check was the warmed-cache Rust command terminated by rustc SIGTERM before the test binary ran; the exact-head GitHub CI replacements passed.

## CI Failures

None. Exact-head GitHub CI run `32638218286` is green.