### PR TITLE
ci(workflows): Helm chart CI + clear-caches fix + phase-server env-var docs (split from #7614, for maintainer review)

### DIFF
--- a/.claude/skills/project-reference/SKILL.md
+++ b/.claude/skills/project-reference/SKILL.md
@@ -264,6 +264,10 @@ State is filtered per-player (`filter_state_for_player`) to hide opponent's hand
 - `PHASE_LOG_DIR` — Log directory for phase-server. When set, logs to files instead of stdout (main log: `<dir>/phase-server.log`, per-game logs: `<dir>/games/<code>.log`)
 - `PHASE_CORS_ORIGIN` — Custom CORS origin for phase-server (default: allows common dev ports)
 - `PHASE_LOG_JSON` — Enable JSON-formatted log output for phase-server
+- `PHASE_MAX_CONNECTIONS` — phase-server concurrent WebSocket cap before upgrades get 503 (default `200`; `--max-connections`)
+- `PHASE_MAX_GAMES` — phase-server concurrent game-session cap before `CreateGame` is refused (default `100`; `--max-games`)
+- `PHASE_METRICS_PORT` — When set, phase-server serves Prometheus metrics at `/metrics` on a second listener on this port (`--metrics-port`). Unset means no metrics listener; keep it off the public port
+- `PHASE_REPLICA_ORDINAL` — This process's ordinal within a replica set, exposed as the `phase_replica_ordinal` gauge so an autoscaler can identify the highest replica still holding players (`--replica-ordinal`)
 
 ## GitHub / git CLI (automation)
 

--- a/.github/workflows/clear-caches.yml
+++ b/.github/workflows/clear-caches.yml
@@ -24,7 +24,8 @@ on:
           - scryfall
           - binaryen
           - rust
-          - pnpm
+          - node
+          - cardgen
           - all
 
 permissions:
@@ -35,39 +36,71 @@ jobs:
   clear:
     name: Delete matching caches
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # sccache alone runs to hundreds of entries and each delete is one API call.
+    timeout-minutes: 30
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GH_REPO: ${{ github.repository }}
     steps:
+      # Prefixes must match keys that actually exist. `gh cache list --key` is a
+      # PREFIX match, so each pattern below is the shortest prefix covering its
+      # whole family:
+      #   * Rust toolchain caches are written by actions-rust-lang/setup-rust-toolchain,
+      #     which prefixes every key `v0-rust-` — a bare `rust-` matches nothing.
+      #   * sccache is the Rust compilation cache and dominates the repo quota, so
+      #     "clear rust" means both families.
+      #   * the pnpm store key is `node-cache-Linux-x64-pnpm-…`; `node-cache-` covers
+      #     that and the npm variant beside it.
+      #   * `binaryen-` covers both the current `binaryen-version_…` keys and the
+      #     older `binaryen-<ver>-<arch>` ones.
       - name: Resolve cache key prefixes
         id: prefixes
         run: |
           case "${{ inputs.target }}" in
             mtgjson)  echo "patterns=mtgjson- scryfall-" >> "$GITHUB_OUTPUT" ;;
             scryfall) echo "patterns=mtgjson- scryfall-" >> "$GITHUB_OUTPUT" ;;
-            binaryen) echo "patterns=binaryen-version_" >> "$GITHUB_OUTPUT" ;;
-            rust)     echo "patterns=rust-" >> "$GITHUB_OUTPUT" ;;
-            pnpm)     echo "patterns=node-cache-Linux-pnpm-" >> "$GITHUB_OUTPUT" ;;
-            all)      echo "patterns=mtgjson- scryfall- binaryen-version_ rust- node-cache-Linux-pnpm-" >> "$GITHUB_OUTPUT" ;;
+            binaryen) echo "patterns=binaryen-" >> "$GITHUB_OUTPUT" ;;
+            rust)     echo "patterns=v0-rust- sccache/" >> "$GITHUB_OUTPUT" ;;
+            node)     echo "patterns=node-cache-" >> "$GITHUB_OUTPUT" ;;
+            cardgen)  echo "patterns=cardgen-" >> "$GITHUB_OUTPUT" ;;
+            all)      echo "patterns=mtgjson- scryfall- binaryen- v0-rust- sccache/ node-cache- cardgen-" >> "$GITHUB_OUTPUT" ;;
           esac
 
+      # A single list call is capped by --limit, and families here run to hundreds
+      # of entries (sccache alone), so one pass would delete a slice and report
+      # success. Re-list until a pass finds nothing, and stop early if a pass
+      # makes no progress so an undeletable key cannot spin forever.
       - name: Delete caches
         run: |
           set -euo pipefail
           deleted=0
           for prefix in ${{ steps.prefixes.outputs.patterns }}; do
             echo "::group::Caches matching '$prefix'"
-            # gh cache list prints: ID  KEY  SIZE  REF  LAST_ACCESSED
-            keys=$(gh cache list --limit 100 --key "$prefix" --json key --jq '.[].key' || true)
-            if [ -z "$keys" ]; then
-              echo "(none)"
-            else
+            before_prefix=$deleted
+            while :; do
+              # No `|| true`: a failed list would come back empty, break the
+              # loop, and report success having deleted nothing — the same
+              # silent no-op this workflow is being fixed for.
+              keys=$(gh cache list --limit 1000 --key "$prefix" --json key --jq '.[].key')
+              if [ -z "$keys" ]; then
+                break
+              fi
+              before_pass=$deleted
               while IFS= read -r key; do
-                echo "Deleting: $key"
-                gh cache delete "$key" && deleted=$((deleted + 1)) || echo "  (already gone)"
+                # </dev/null: gh would otherwise consume the rest of the key
+                # list from this loop's stdin and delete only the first one.
+                if gh cache delete "$key" </dev/null >/dev/null 2>&1; then
+                  deleted=$((deleted + 1))
+                else
+                  echo "  not deletable, skipping: $key"
+                fi
               done <<< "$keys"
-            fi
+              if [ "$deleted" -eq "$before_pass" ]; then
+                echo "  no progress in a full pass; stopping this prefix"
+                break
+              fi
+            done
+            echo "  removed $((deleted - before_prefix)) for '$prefix'"
             echo "::endgroup::"
           done
           echo "Deleted $deleted cache entr$([ $deleted -eq 1 ] && echo y || echo ies)."

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -93,7 +93,10 @@ jobs:
                --namespace phase -f /tmp/scaleout.yaml > /tmp/no-crd.yaml 2>/tmp/no-crd.err; then
             echo "expected the render to fail without monitoring.coreos.com/v1"; exit 1
           fi
-          grep -q 'prometheus-operator CRDs' /tmp/no-crd.err
+          # Match the capability the guard names, not its prose: the message
+          # has already been reworded once, and this assertion silently stopped
+          # matching it.
+          grep -q 'monitoring.coreos.com/v1/PrometheusRule' /tmp/no-crd.err
 
       # The escape hatch stays open: with prometheusRule.enabled=false the operator
       # is not required at all, because the recording rule is supplied externally

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -161,3 +161,30 @@ jobs:
             --api-versions monitoring.coreos.com/v1/ServiceMonitor > /tmp/scheme-noingress.yaml
           if grep -q 'kind: IngressRoute' /tmp/scheme-noingress.yaml; then echo "unexpected 'kind: IngressRoute' in /tmp/scheme-noingress.yaml"; exit 1; fi
           grep -q 'value: "http://phase-"' /tmp/scheme-noingress.yaml
+
+      # The HPA reads `phase:wanted_replicas`, the PrometheusRule produces it,
+      # and the rule reads gauges only a PodMonitor or ServiceMonitor scrapes.
+      # A partial operator install can register the rule's CRD and neither
+      # monitor's, so the chart must refuse rather than ship an HPA that can
+      # never get its metric.
+      - name: helm template (autoscaling without a monitor CRD) must fail
+        run: |
+          if helm template phase-server deploy/helm/phase-server \
+               --namespace phase -f /tmp/scaleout.yaml \
+               --api-versions monitoring.coreos.com/v1 \
+               --api-versions monitoring.coreos.com/v1/PrometheusRule \
+               > /tmp/no-monitor.yaml 2>/tmp/no-monitor.err; then
+            echo "expected the render to fail with no PodMonitor or ServiceMonitor CRD"; exit 1
+          fi
+          grep -q 'monitor that will actually render' /tmp/no-monitor.err
+
+          # Control: adding only the PodMonitor kind clears it, so the guard
+          # tracks the missing CRD rather than refusing autoscaling outright.
+          helm template phase-server deploy/helm/phase-server \
+            --namespace phase -f /tmp/scaleout.yaml \
+            --api-versions monitoring.coreos.com/v1 \
+            --api-versions monitoring.coreos.com/v1/PrometheusRule \
+            --api-versions monitoring.coreos.com/v1/PodMonitor > /tmp/with-monitor.yaml
+          grep -q 'kind: PodMonitor' /tmp/with-monitor.yaml
+          grep -q 'kind: PrometheusRule' /tmp/with-monitor.yaml
+          grep -q 'kind: HorizontalPodAutoscaler' /tmp/with-monitor.yaml

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -1,0 +1,108 @@
+name: Helm chart
+
+# Lint and render deploy/helm/phase-server. The chart has no CI coverage
+# otherwise, and its failure mode is quiet: a template that renders invalid or
+# empty YAML only shows up at `helm upgrade` time on someone's cluster.
+#
+# No secrets, no cluster: this only runs `helm lint` and `helm template`.
+
+on:
+  pull_request:
+    paths:
+      - 'deploy/helm/**'
+      - '.github/workflows/helm-chart.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'deploy/helm/**'
+      - '.github/workflows/helm-chart.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  render:
+    name: helm lint + template
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      # Pinned by commit SHA: a mutable tag can be force-pushed under us.
+      # This job only reads the tree, so it needs no credentials left on disk.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4
+        with:
+          persist-credentials: false
+
+      - uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4
+        with:
+          version: v3.16.3
+
+      - name: helm lint (default values)
+        run: helm lint deploy/helm/phase-server
+
+      - name: helm template (default values)
+        run: |
+          helm template phase-server deploy/helm/phase-server \
+            --namespace phase > /tmp/default.yaml
+          test -s /tmp/default.yaml
+
+      # The opt-in paths render entirely different workloads (StatefulSet,
+      # IngressRoutes, PrometheusRule, HPA), so a default-values render alone
+      # would leave most of the chart untested.
+      - name: helm template (scale-out + metrics + autoscaling)
+        run: |
+          cat > /tmp/scaleout.yaml <<'EOF'
+          ingress:
+            host: phase.example.com
+            tls:
+              clusterIssuer: letsencrypt
+          scaleOut:
+            enabled: true
+            replicaMax: 3
+          metrics:
+            enabled: true
+          autoscaling:
+            enabled: true
+          EOF
+          helm lint deploy/helm/phase-server -f /tmp/scaleout.yaml
+          helm template phase-server deploy/helm/phase-server \
+            --namespace phase -f /tmp/scaleout.yaml \
+            --api-versions monitoring.coreos.com/v1 \
+            --api-versions monitoring.coreos.com/v1/PrometheusRule > /tmp/scaleout-render.yaml
+          test -s /tmp/scaleout-render.yaml
+          grep -q 'kind: StatefulSet' /tmp/scaleout-render.yaml
+          grep -q 'kind: HorizontalPodAutoscaler' /tmp/scaleout-render.yaml
+          grep -q 'kind: PrometheusRule' /tmp/scaleout-render.yaml
+
+      # With no prometheus-operator CRDs the operator path must FAIL rather than
+      # render: hpa.yaml would otherwise install an HPA whose only producer of
+      # `phase:wanted_replicas` — the PrometheusRule — was silently skipped.
+      - name: helm template (scale-out, no operator CRDs) must fail
+        run: |
+          if helm template phase-server deploy/helm/phase-server \
+               --namespace phase -f /tmp/scaleout.yaml > /tmp/no-crd.yaml 2>/tmp/no-crd.err; then
+            echo "expected the render to fail without monitoring.coreos.com/v1"; exit 1
+          fi
+          grep -q 'prometheus-operator CRDs' /tmp/no-crd.err
+
+      # The escape hatch stays open: with prometheusRule.enabled=false the operator
+      # is not required at all, because the recording rule is supplied externally
+      # (prometheus-adapter externalRules). That must still render on a bare cluster.
+      - name: helm template (scale-out, external recording rule, no CRDs)
+        run: |
+          helm template phase-server deploy/helm/phase-server \
+            --namespace phase -f /tmp/scaleout.yaml \
+            --set autoscaling.prometheusRule.enabled=false > /tmp/no-crd.yaml
+          test -s /tmp/no-crd.yaml
+          grep -q 'kind: StatefulSet' /tmp/no-crd.yaml
+          grep -q 'kind: HorizontalPodAutoscaler' /tmp/no-crd.yaml
+          if grep -q 'kind: PodMonitor' /tmp/no-crd.yaml; then echo "unexpected 'kind: PodMonitor' in /tmp/no-crd.yaml"; exit 1; fi
+          if grep -q 'kind: PrometheusRule' /tmp/no-crd.yaml; then echo "unexpected 'kind: PrometheusRule' in /tmp/no-crd.yaml"; exit 1; fi
+
+      # Guards the chart's central safety property: the default path must stay a
+      # single-replica Deployment, and scale-out must give every ordinal its own
+      # claim. Two processes on one games.db is destructive.
+      - name: assert the storage invariants
+        run: |
+          grep -q 'replicas: 1' /tmp/default.yaml
+          grep -q 'volumeClaimTemplates' /tmp/scaleout-render.yaml
+          if grep -q 'kind: Deployment' /tmp/scaleout-render.yaml; then echo "unexpected 'kind: Deployment' in /tmp/scaleout-render.yaml"; exit 1; fi

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -117,3 +117,47 @@ jobs:
           grep -q 'replicas: 1' /tmp/default.yaml
           grep -q 'volumeClaimTemplates' /tmp/scaleout-render.yaml
           if grep -q 'kind: Deployment' /tmp/scaleout-render.yaml; then echo "unexpected 'kind: Deployment' in /tmp/scaleout-render.yaml"; exit 1; fi
+
+      # `scaleOut.scheme` names the URL each ordinal advertises, and the client
+      # turns that string into the "CODE@host" share link a friend dials. Every
+      # IngressRoute the chart renders terminates TLS, so `http` is refused
+      # while the chart owns the edge — and stays legal when it does not.
+      - name: helm template (scale-out, advertised scheme)
+        run: |
+          if helm template phase-server deploy/helm/phase-server \
+               --namespace phase -f /tmp/scaleout.yaml \
+               --set scaleOut.scheme=http \
+               --api-versions monitoring.coreos.com/v1 \
+               --api-versions monitoring.coreos.com/v1/PrometheusRule \
+               --api-versions monitoring.coreos.com/v1/PodMonitor \
+               --api-versions monitoring.coreos.com/v1/ServiceMonitor \
+               > /tmp/scheme-http.yaml 2>/tmp/scheme-http.err; then
+            echo "expected http to be refused while the chart renders TLS routes"; exit 1
+          fi
+          grep -q 'scaleOut.scheme' /tmp/scheme-http.err
+
+          # Control: the guard has to fire on the contradiction, not on the
+          # knob. Without this the case above would pass on a chart that
+          # rejected every scheme.
+          helm template phase-server deploy/helm/phase-server \
+            --namespace phase -f /tmp/scaleout.yaml \
+            --set scaleOut.scheme=https \
+            --api-versions monitoring.coreos.com/v1 \
+            --api-versions monitoring.coreos.com/v1/PrometheusRule \
+            --api-versions monitoring.coreos.com/v1/PodMonitor \
+            --api-versions monitoring.coreos.com/v1/ServiceMonitor > /tmp/scheme-https.yaml
+          # One entry route plus one per ordinal, at scaleOut.replicaMax 3 above.
+          routes=$(grep -c 'kind: IngressRoute' /tmp/scheme-https.yaml)
+          test "$routes" -eq 4
+
+          # No chart-managed route means the operator owns the edge, so the
+          # advertised scheme is theirs to choose.
+          helm template phase-server deploy/helm/phase-server \
+            --namespace phase -f /tmp/scaleout.yaml \
+            --set scaleOut.scheme=http --set ingress.enabled=false \
+            --api-versions monitoring.coreos.com/v1 \
+            --api-versions monitoring.coreos.com/v1/PrometheusRule \
+            --api-versions monitoring.coreos.com/v1/PodMonitor \
+            --api-versions monitoring.coreos.com/v1/ServiceMonitor > /tmp/scheme-noingress.yaml
+          if grep -q 'kind: IngressRoute' /tmp/scheme-noingress.yaml; then echo "unexpected 'kind: IngressRoute' in /tmp/scheme-noingress.yaml"; exit 1; fi
+          grep -q 'value: "http://phase-"' /tmp/scheme-noingress.yaml

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -117,6 +117,10 @@ jobs:
       # claim. Two processes on one games.db is destructive.
       - name: assert the storage invariants
         run: |
+          # The kind, not just the count: `replicas: 1` alone would still pass
+          # if the default path became a single-replica StatefulSet, which is
+          # the shape this invariant exists to keep it out of.
+          grep -q 'kind: Deployment' /tmp/default.yaml
           grep -q 'replicas: 1' /tmp/default.yaml
           grep -q 'volumeClaimTemplates' /tmp/scaleout-render.yaml
           if grep -q 'kind: Deployment' /tmp/scaleout-render.yaml; then echo "unexpected 'kind: Deployment' in /tmp/scaleout-render.yaml"; exit 1; fi

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -64,14 +64,25 @@ jobs:
             enabled: true
           EOF
           helm lint deploy/helm/phase-server -f /tmp/scaleout.yaml
+          # Every kind the chart gates on, not just the group: the templates
+          # test `APIVersions.Has` per resource, and a real cluster's discovery
+          # populates both forms. Passing only the group renders no monitors at
+          # all, which the assertions below would let pass silently.
+          # `serviceMonitor` is off by default, so it is enabled here to cover
+          # the second gate.
           helm template phase-server deploy/helm/phase-server \
             --namespace phase -f /tmp/scaleout.yaml \
+            --set metrics.serviceMonitor.enabled=true \
             --api-versions monitoring.coreos.com/v1 \
-            --api-versions monitoring.coreos.com/v1/PrometheusRule > /tmp/scaleout-render.yaml
+            --api-versions monitoring.coreos.com/v1/PrometheusRule \
+            --api-versions monitoring.coreos.com/v1/PodMonitor \
+            --api-versions monitoring.coreos.com/v1/ServiceMonitor > /tmp/scaleout-render.yaml
           test -s /tmp/scaleout-render.yaml
           grep -q 'kind: StatefulSet' /tmp/scaleout-render.yaml
           grep -q 'kind: HorizontalPodAutoscaler' /tmp/scaleout-render.yaml
           grep -q 'kind: PrometheusRule' /tmp/scaleout-render.yaml
+          grep -q 'kind: PodMonitor' /tmp/scaleout-render.yaml
+          grep -q 'kind: ServiceMonitor' /tmp/scaleout-render.yaml
 
       # With no prometheus-operator CRDs the operator path must FAIL rather than
       # render: hpa.yaml would otherwise install an HPA whose only producer of


### PR DESCRIPTION
:robot: _AI text below_ :robot:

Split out of #7614 at maintainer request: that PR touches `.claude/skills/**` and `.github/workflows/**`, which are hard-stop paths on the contributor merge path. This PR carries **only** those three files so they can be reviewed in isolation; #7614 keeps the server and Helm-chart work and no longer touches either surface.

## ⚠️ Merge after #7614

`helm-chart.yml` renders the chart **as #7614 leaves it**. Two of its steps assert behaviour introduced there — that autoscaling without the `PrometheusRule` CRD *fails* to render, and that the operator-free path still renders. Against today's `main` those steps fail, because the chart has no scale-out or autoscaling yet. This ordering is real and I have not tried to paper over it: making the step tolerant of both old and new behaviour would turn it into an assertion that passes either way, which is worse than a stated dependency.

Until this lands, #7614 has no chart CI at all.

## What's here

**`clear-caches.yml` — the targets matched almost nothing.** Measured against `phase-rs/phase` on 2026-08-22 via `gh api --paginate /repos/phase-rs/phase/actions/caches`: 796 caches, 8.1 GiB against a 10 GiB ceiling.

| target | pattern | matched |
|---|---|---|
| `rust` | `rust-` | 0 — real prefix is `v0-rust-` (17, 3.48 GiB) |
| `pnpm` | `node-cache-Linux-pnpm-` | 0 — real key embeds `-x64` (2, 0.22 GiB) |
| `binaryen` | `binaryen-version_` | 1 — misses legacy `binaryen-<ver>` |

788 caches / 8.01 GiB were unreachable by any target including `all`, dominated by `sccache/` (725) and `v0-rust-` (17). "Clear rust caches" deleted nothing while the quota stayed full. Fixing the prefixes alone would have introduced a *new* silent failure: `gh cache list --limit 100` caps a pass at 100 entries (measured), so a working `rust` target would delete 100 of 725 and report success. The delete step now re-lists until a pass finds nothing and stops early if a pass makes no progress. `gh cache list` also lost its `|| true`, which made a failed list read as "no matching caches" and report success having deleted nothing.

**`helm-chart.yml` — the chart had no CI.** `helm lint` plus four renders: defaults; scale-out with metrics and autoscaling; the same values with the `PrometheusRule` CRD absent (must fail); and the operator-free path with an externally supplied recording rule (must render). The renders then assert the storage invariant — default stays a single-replica Deployment, scale-out gives every ordinal its own claim — because two processes on one `games.db` is destructive.

Forbidden-resource assertions are `if grep -q X; then exit 1; fi`, not `! grep -q X`. A `!`-negated command is exempt from `set -e`, so the negated form never failed the step and every "must not contain" assertion was vacuous. Verified against bash directly:

```
$ cat t.sh
set -e
! grep -q 'kind: PodMonitor' has.yaml
echo "AFTER"
$ bash t.sh; echo "exit=$?"
AFTER            # step continued despite the forbidden resource being present
exit=0
```

Actions are pinned by commit SHA rather than mutable tag, and the checkout gets `persist-credentials: false` (the job only reads the tree). Worth a maintainer opinion: this makes it the **only** SHA-pinned workflow in the repo — `.github/workflows/*.yml` currently has 148 tag-pinned `uses:` lines and 0 SHA-pinned, and `persist-credentials` appears nowhere. Happy to switch to tag pins for consistency, or treat this as step one of a repo-wide change. Your call.

**`SKILL.md` — four lines of env-var documentation.** `PHASE_MAX_CONNECTIONS`, `PHASE_MAX_GAMES`, `PHASE_METRICS_PORT`, `PHASE_REPLICA_ORDINAL` are read by phase-server but were missing from the `PHASE_*` list. Documentation only — no instruction or agent-behaviour change. If this is acceptable back in #7614 I'll move it there and drop it here.

## Verification

`actionlint` clean. Every step's shell logic executed against #7614's chart: scale-out render contains StatefulSet + HPA + PrometheusRule; the no-CRD render fails with an error naming the CRD; the external-rule render succeeds with zero PrometheusRule/PodMonitor; and the rewritten assertion form was confirmed to fire on a resource that *is* present.


## Update (41f0b8063): kept in step with #7614's per-kind monitor gating

#7614 now gates `podmonitor.yaml` per resource (`monitoring.coreos.com/v1/PodMonitor`
and `.../ServiceMonitor` tested separately) rather than by API group, because a
partial operator install otherwise renders a kind that is not installed and
fails at apply.

That made this workflow's `--api-versions` flags stale: passing only the group
form, the scale-out render produces **zero** PodMonitors — measured against
#7614's chart. The step asserted only StatefulSet, HPA and PrometheusRule, so it
would have gone green on a render that silently dropped both monitors.

Both kind forms are now passed and **both are asserted**, so the flags are
load-bearing rather than decorative. `metrics.serviceMonitor.enabled` is `false`
by default, so the render sets it to reach the second gate. Verified against
#7614's chart: with the old flags `kind: PodMonitor` count is 0 (the new
assertion fails); with the new flags PodMonitor, ServiceMonitor and
PrometheusRule are each present once.

This is maintenance to keep B consistent with A. The ordering coupling stated
above is unchanged: these steps still require #7614's chart to be merged first.


## Update (498b4688d): cover both advertised scale-out schemes

#7614 now refuses `scaleOut.scheme: http` while the chart renders its own TLS
routes — the advertised ordinal URL becomes the client's `CODE@host` share
link, so `http` would name an address nothing serves. Nothing here exercised
that guard.

Three cases:

| case | expected |
|---|---|
| `scheme=http`, chart ingress on | render fails, and the error names `scaleOut.scheme` |
| `scheme=https`, chart ingress on | renders one entry route + one per ordinal (4 at `replicaMax: 3`) |
| `scheme=http`, `ingress.enabled=false` | renders no IngressRoute, advertises `http://phase-` |

The https case is what keeps the first honest: without it the step would pass on
a chart that rejected every scheme, not just the contradictory one.

Verified by running the step verbatim against #7614's chart — passes there, and
fails with `expected http to be refused while the chart renders TLS routes` when
run against the same chart at the commit before the guard landed.


## Update (6ca194da2): reject autoscaling with no monitor CRD

#7614 gained a guard for a hole its own per-kind monitor gating opened: a
cluster carrying `monitoring.coreos.com/v1/PrometheusRule` but neither monitor
CRD rendered the recording rule and the External-metric HPA with nothing
scraping the gauges they read. Nothing here caught it.

The must-fail case renders with exactly those capabilities. The control adds
only the PodMonitor kind and asserts PodMonitor, PrometheusRule and HPA all
render — without it the step would pass on a chart that refused autoscaling
outright rather than one that tracks the missing CRD.

Verified by running the step verbatim against #7614's chart: passes at
`042faac29`, and fails at `c7bd28600` (the commit before the guard) with
`expected the render to fail with no PodMonitor or ServiceMonitor CRD`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Added configuration guidance for server connections, game limits, Prometheus metrics, and replica reporting, including defaults and endpoint behavior.

- **Deployment**
  - Expanded Helm chart validation for scaling, TLS ingress, storage, autoscaling, monitoring, and configuration safeguards.

- **Maintenance**
  - Improved automated cache cleanup reliability, including support for larger cache sets and resilient deletion handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->