### PR TITLE
fix(client): report whether a clipboard copy actually happened

### DIFF
--- a/client/src/components/chrome/DebugPanel.tsx
+++ b/client/src/components/chrome/DebugPanel.tsx
@@ -18,6 +18,7 @@ import { useGameStore } from "../../stores/gameStore";
 import { getPlayerDisplayName } from "../../stores/multiplayerStore";
 import { useUiStore } from "../../stores/uiStore";
 import { DebugActions } from "./DebugActions";
+import { copyText } from "../../services/copyText";
 
 const SCROLL_THRESHOLD = 40; // px from bottom to count as "at bottom"
 
@@ -220,9 +221,10 @@ export function DebugPanel({
       setStatus({ type: "error", message: "No console entries to copy" });
       return;
     }
-    navigator.clipboard.writeText(formatEntries(visibleEntries))
-      .then(() => setStatus({ type: "success", message: `Copied ${visibleEntries.length} entries` }))
-      .catch(() => setStatus({ type: "error", message: "Failed to copy console" }));
+    void copyText(formatEntries(visibleEntries)).then((copied) =>
+      setStatus(copied
+        ? { type: "success", message: `Copied ${visibleEntries.length} entries` }
+        : { type: "error", message: "Failed to copy console" }));
   }, [visibleEntries, formatEntries]);
 
   const handleExportZip = useCallback(() => {

--- a/client/src/components/chrome/HostControlTile.tsx
+++ b/client/src/components/chrome/HostControlTile.tsx
@@ -14,6 +14,7 @@ import { useAiDeckCatalog } from "../../services/aiDeckCatalog";
 import { formatJoinShare } from "../../services/serverDetection";
 import { expandParsedDeck } from "../../services/deckParser";
 import { SelectField } from "../ui/SelectField";
+import { copyText } from "../../services/copyText";
 
 const AI_DIFFICULTIES = ["Easy", "Medium", "Hard", "VeryHard"] as const;
 const RANDOM_DECK: DeckChoice = { type: "Random" };
@@ -443,11 +444,12 @@ export function HostControlTile() {
             onClick={() => {
               if (joinShare) {
                 // Server-run host: copy the reachable `<code>@<host>` join link.
-                void navigator.clipboard?.writeText(joinShare);
-                showToast(t("hostControl.joinLinkCopied"));
+                void copyText(joinShare).then((copied) => {
+                  if (copied) showToast(t("hostControl.joinLinkCopied"));
+                });
               } else if (location.pathname.startsWith("/game/") && hostGameCode) {
                 // P2P host in-game: the bare code (friends join via direct code).
-                void navigator.clipboard?.writeText(hostGameCode);
+                void copyText(hostGameCode);
               } else {
                 navigate("/multiplayer");
               }

--- a/client/src/components/chrome/__tests__/HostControlTile.test.tsx
+++ b/client/src/components/chrome/__tests__/HostControlTile.test.tsx
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { MemoryRouter } from "react-router";
 
 import { HostControlTile } from "../HostControlTile";
@@ -81,5 +81,62 @@ describe("HostControlTile", () => {
 
     expect(screen.queryByText("Team 1")).not.toBeInTheDocument();
     expect(screen.queryByText("Team 2")).not.toBeInTheDocument();
+  });
+
+  describe("join-link copy", () => {
+    const realClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+
+    function renderWithJoinLink(showToast: (message: string) => void) {
+      useMultiplayerStore.setState({
+        hostGameCode: "ABCD1",
+        hostingStatus: "waiting",
+        hostSession: {
+          formatConfig: FORMAT_DEFAULTS.Standard,
+          timerSeconds: null,
+          matchType: "Bo1",
+        },
+        playerSlots: [],
+        serverInfo: {
+          version: "0.60.0",
+          buildCommit: "abc1234",
+          protocolVersion: 33,
+          mode: "Full",
+          publicUrl: "https://play.example.com",
+        },
+        showToast,
+      });
+      render(
+        <MemoryRouter initialEntries={["/multiplayer"]}>
+          <HostControlTile />
+        </MemoryRouter>,
+      );
+      return screen.getByTitle(/ABCD1@play\.example\.com/);
+    }
+
+    afterEach(() => {
+      if (realClipboard) Object.defineProperty(navigator, "clipboard", realClipboard);
+      Reflect.deleteProperty(document, "execCommand");
+    });
+
+    it("confirms only when the clipboard actually took the link", async () => {
+      Object.defineProperty(navigator, "clipboard", {
+        value: { writeText: () => Promise.resolve() },
+        configurable: true,
+      });
+      const showToast = vi.fn();
+
+      fireEvent.click(renderWithJoinLink(showToast));
+      await vi.waitFor(() => expect(showToast).toHaveBeenCalledWith("Join link copied"));
+
+      cleanup();
+      // Same click, a webview that cannot write: no confirmation may appear.
+      Object.defineProperty(navigator, "clipboard", { value: undefined, configurable: true });
+      Object.defineProperty(document, "execCommand", { value: () => false, configurable: true });
+      const silentToast = vi.fn();
+
+      fireEvent.click(renderWithJoinLink(silentToast));
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      expect(silentToast).not.toHaveBeenCalled();
+    });
   });
 });

--- a/client/src/components/controls/CardCoverageDashboard.tsx
+++ b/client/src/components/controls/CardCoverageDashboard.tsx
@@ -7,6 +7,7 @@ import { useSetList, type SetMeta } from "../../hooks/useSetList";
 import { FORMAT_REGISTRY } from "../../data/formatRegistry";
 import { scryfallLegalityKey } from "../../services/scryfall";
 import { SelectField } from "../ui/SelectField";
+import { copyText } from "../../services/copyText";
 
 // Supported handlers are now derived from the coverage export, not a hardcoded list.
 // See `extractHandlerUsage` below — a handler is listed iff the parser produces it
@@ -1644,7 +1645,8 @@ function CopyButton({ text, label, className = "" }: { text: string; label: stri
   const [copied, setCopied] = useState(false);
 
   const handleCopy = useCallback(() => {
-    navigator.clipboard.writeText(text).then(() => {
+    void copyText(text).then((ok) => {
+      if (!ok) return;
       setCopied(true);
       setTimeout(() => setCopied(false), 1500);
     });

--- a/client/src/components/deck-builder/DeckList.tsx
+++ b/client/src/components/deck-builder/DeckList.tsx
@@ -16,6 +16,7 @@ import { mouseHoverPreview } from "./hoverPreview";
 import type { CardHoverHandler } from "./hoverPreview";
 import { groupAccent, groupKey, groupOrder, groupTitleKey, type GroupMode } from "./deckGrouping";
 import { isMaybeboardPolicy, useSideboardPolicy } from "./useSideboardPolicy";
+import { copyText } from "../../services/copyText";
 
 interface DeckListProps {
   deck: ParsedDeck;
@@ -193,7 +194,7 @@ export function DeckList({
   };
 
   const handleCopyToClipboard = async () => {
-    await navigator.clipboard.writeText(exportText);
+    if (!(await copyText(exportText))) return;
     setCopied(true);
     setTimeout(() => setCopied(false), 2000);
   };

--- a/client/src/components/draft/DraftPodLobby.tsx
+++ b/client/src/components/draft/DraftPodLobby.tsx
@@ -24,6 +24,7 @@ import { menuButtonClass } from "../menu/buttonStyles";
 import { useMultiplayerDraftStore } from "../../stores/multiplayerDraftStore";
 import { useDraftPodStore } from "../../stores/draftPodStore";
 import { BotIndicator } from "./BotIndicator";
+import { copyText } from "../../services/copyText";
 
 // ── Seat Card ─────────────────────────────────────────────────────────
 
@@ -177,9 +178,7 @@ export function DraftPodLobby({ onLeave }: DraftPodLobbyProps) {
 
   const handleCopyCode = useCallback(() => {
     if (roomCode) {
-      navigator.clipboard.writeText(roomCode).catch(() => {
-        // Clipboard API may not be available
-      });
+      void copyText(roomCode);
     }
   }, [roomCode]);
 

--- a/client/src/components/log/GameLogPanel.tsx
+++ b/client/src/components/log/GameLogPanel.tsx
@@ -20,6 +20,7 @@ import {
   uniqueTurns,
 } from "../../viewmodel/logSearch.ts";
 import { LogEntry } from "./LogEntry.tsx";
+import { copyText } from "../../services/copyText";
 
 const EMPTY_LOG: GameLogEntry[] = [];
 const LOG_PANEL_WIDTH_PX = 320;
@@ -246,12 +247,7 @@ export function GameLogPanel() {
         return `${context}: ${segmentsToPlainText(entry.segments)}`;
       })
       .join("\n");
-    try {
-      await navigator.clipboard.writeText(text);
-      reportCopyStatus("success");
-    } catch {
-      reportCopyStatus("failure");
-    }
+    reportCopyStatus((await copyText(text)) ? "success" : "failure");
   };
 
   const filterSummary = t("log.filterSummary", { count: filteredEntries.length });

--- a/client/src/components/modal/EngineLostModal.tsx
+++ b/client/src/components/modal/EngineLostModal.tsx
@@ -6,6 +6,7 @@ import { onEngineLost, onEngineSlow } from "../../game/engineRecovery";
 import { exportGameStateDebugZip } from "../../services/gameStateExport";
 import { useGameStore } from "../../stores/gameStore";
 import type { GameState } from "../../adapter/types";
+import { copyText } from "../../services/copyText";
 
 /**
  * Layer 3 fallback for engine state loss — the user-facing prompt.
@@ -106,16 +107,14 @@ export function EngineLostModal() {
   const diagnostic = buildDiagnostic(snapshot);
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(diagnostic);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
-    } catch {
-      // Clipboard API can fail in insecure contexts. Fall back to opening
-      // a prompt so the user can copy manually rather than leaving them
-      // stuck — the whole point of this modal is making the report easy.
+    if (!(await copyText(diagnostic))) {
+      // Fall back to a prompt so the user can copy manually rather than being
+      // left stuck — the whole point of this modal is making the report easy.
       window.prompt(t("engineLost.copyPrompt"), diagnostic);
+      return;
     }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
   };
 
   const handleExport = async () => {

--- a/client/src/components/modal/UnhandledWaitingForModal.tsx
+++ b/client/src/components/modal/UnhandledWaitingForModal.tsx
@@ -5,6 +5,7 @@ import type { TFunction } from "i18next";
 import { useGameStore } from "../../stores/gameStore";
 import { useCanActForWaitingState } from "../../hooks/usePlayerId";
 import { isWaitingForHandled } from "../../game/waitingForRegistry";
+import { copyText } from "../../services/copyText";
 
 /**
  * Safety net for orphan `WaitingFor` states the frontend has no modal for.
@@ -53,13 +54,12 @@ export function UnhandledWaitingForModal({
   const diagnostic = buildDiagnostic(waitingFor);
 
   const handleCopy = async () => {
-    try {
-      await navigator.clipboard.writeText(diagnostic);
-      setCopied(true);
-      window.setTimeout(() => setCopied(false), 2000);
-    } catch {
+    if (!(await copyText(diagnostic))) {
       window.prompt(t("unhandledWaitingFor.copyPrompt"), diagnostic);
+      return;
     }
+    setCopied(true);
+    window.setTimeout(() => setCopied(false), 2000);
   };
 
   const reportUrl = buildReportUrl(waitingFor.type, diagnostic, t);

--- a/client/src/services/__tests__/copyText.test.ts
+++ b/client/src/services/__tests__/copyText.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { copyText } from "../copyText";
+
+const realClipboard = Object.getOwnPropertyDescriptor(navigator, "clipboard");
+
+function setClipboard(value: unknown): void {
+  Object.defineProperty(navigator, "clipboard", { value, configurable: true });
+}
+
+function setExecCommand(impl: (() => boolean) | undefined): void {
+  Object.defineProperty(document, "execCommand", { value: impl, configurable: true });
+}
+
+afterEach(() => {
+  if (realClipboard) Object.defineProperty(navigator, "clipboard", realClipboard);
+  else Reflect.deleteProperty(navigator, "clipboard");
+  Reflect.deleteProperty(document, "execCommand");
+  Reflect.deleteProperty(window, "__TAURI_INTERNALS__");
+  vi.restoreAllMocks();
+});
+
+describe("copyText", () => {
+  it("writes through the async clipboard when it works", async () => {
+    const writeText = vi.fn(() => Promise.resolve());
+    setClipboard({ writeText });
+
+    await expect(copyText("join-me")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalledWith("join-me");
+  });
+
+  // tauri#5835: the WebKitGTK webview can have no `navigator.clipboard` at all.
+  it("falls back when the async clipboard is absent", async () => {
+    setClipboard(undefined);
+    const exec = vi.fn(() => true);
+    setExecCommand(exec);
+
+    await expect(copyText("join-me")).resolves.toBe(true);
+    expect(exec).toHaveBeenCalledWith("copy");
+  });
+
+  // tauri#10835: present, but the write never lands.
+  it("falls back when the async clipboard rejects", async () => {
+    const writeText = vi.fn(() => Promise.reject(new Error("denied")));
+    setClipboard({ writeText });
+    const exec = vi.fn(() => true);
+    setExecCommand(exec);
+
+    await expect(copyText("join-me")).resolves.toBe(true);
+    expect(writeText).toHaveBeenCalled();
+    expect(exec).toHaveBeenCalledWith("copy");
+  });
+
+  it("reports false when neither path can write", async () => {
+    setClipboard(undefined);
+    setExecCommand(() => false);
+
+    await expect(copyText("join-me")).resolves.toBe(false);
+  });
+
+  it("reports false when the fallback itself throws", async () => {
+    setClipboard(undefined);
+    setExecCommand(() => {
+      throw new Error("unsupported");
+    });
+
+    await expect(copyText("join-me")).resolves.toBe(false);
+  });
+
+  // In the shell the write has to land while the click is still on the stack:
+  // `execCommand` is gated on user activation, and an awaited rejection resumes
+  // a task too late for that.
+  it("copies synchronously inside the desktop shell", async () => {
+    Object.defineProperty(window, "__TAURI_INTERNALS__", { value: {}, configurable: true });
+    const writeText = vi.fn(() => Promise.reject(new Error("denied")));
+    setClipboard({ writeText });
+    const exec = vi.fn(() => true);
+    setExecCommand(exec);
+
+    const pending = copyText("join-me");
+    expect(exec).toHaveBeenCalledWith("copy");
+
+    await expect(pending).resolves.toBe(true);
+    expect(writeText).not.toHaveBeenCalled();
+  });
+
+  it("hands the text to the fallback and leaves no element behind", async () => {
+    setClipboard(undefined);
+    let selected: string | null = null;
+    setExecCommand(() => {
+      selected = document.querySelector("textarea")?.value ?? null;
+      return true;
+    });
+
+    await expect(copyText("join-me")).resolves.toBe(true);
+    expect(selected).toBe("join-me");
+    expect(document.querySelector("textarea")).toBeNull();
+  });
+});

--- a/client/src/services/copyText.ts
+++ b/client/src/services/copyText.ts
@@ -1,0 +1,58 @@
+import { isTauri } from "./platform";
+
+/**
+ * Copy `text` to the clipboard, reporting whether the write actually happened.
+ * Callers that assume success paint a "copied" confirmation over a clipboard
+ * that never changed, so the result is returned rather than thrown away.
+ *
+ * Inside the desktop shell the synchronous path goes first. The WebKitGTK
+ * webview Tauri uses on Linux may have no `navigator.clipboard` at all
+ * (tauri#5835), and when it has one the write can still fail — but `await`ing
+ * that rejection resumes in a later task, while `execCommand("copy")` is only
+ * honoured while the user's gesture is still on the stack. A fallback reached
+ * through the rejection therefore arrives too late to write anything. Browsers
+ * keep the async API first, where it is the supported path and is not gated on
+ * activation this way.
+ */
+export async function copyText(text: string): Promise<boolean> {
+  if (isTauri() && legacyCopy(text)) {
+    return true;
+  }
+  try {
+    // Reaching through a missing `navigator.clipboard` throws synchronously
+    // here, so one catch covers both "absent" and "rejected".
+    await navigator.clipboard.writeText(text);
+    return true;
+  } catch {
+    return legacyCopy(text);
+  }
+}
+
+function legacyCopy(text: string): boolean {
+  if (typeof document === "undefined") return false;
+
+  const area = document.createElement("textarea");
+  area.value = text;
+  area.setAttribute("readonly", "");
+  // `execCommand("copy")` copies the selection, and an element that is
+  // `display:none` or detached cannot hold one — so it has to be in the
+  // document and merely invisible.
+  area.style.position = "fixed";
+  area.style.top = "0";
+  area.style.left = "0";
+  area.style.opacity = "0";
+  area.style.pointerEvents = "none";
+  // `select()` takes focus in a real engine; hand it back so copying does not
+  // knock the user out of whatever they were typing in.
+  const previous = document.activeElement;
+  document.body.appendChild(area);
+  try {
+    area.select();
+    return document.execCommand("copy");
+  } catch {
+    return false;
+  } finally {
+    area.remove();
+    if (previous instanceof HTMLElement) previous.focus();
+  }
+}

--- a/client/src/services/gameStateExport.ts
+++ b/client/src/services/gameStateExport.ts
@@ -2,6 +2,7 @@ import { strToU8, zipSync } from "fflate";
 
 import type { GameState } from "../adapter/types.ts";
 import { useGameStore } from "../stores/gameStore.ts";
+import { copyText } from "./copyText";
 
 interface GameStateDebugSnapshot {
   gameState: GameState;
@@ -46,7 +47,9 @@ export function serializeGameStateDebugSnapshot(gameState: GameState, pretty = f
 }
 
 export async function copyGameStateDebugSnapshot(gameState: GameState): Promise<void> {
-  await navigator.clipboard.writeText(serializeGameStateDebugSnapshot(gameState, true));
+  if (!(await copyText(serializeGameStateDebugSnapshot(gameState, true)))) {
+    throw new Error("Clipboard write failed");
+  }
 }
 
 export async function exportGameStateDebugZip(gameState: GameState): Promise<string> {


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Ten call sites called `navigator.clipboard.writeText` and assumed it worked. In the WebKitGTK webview the Tauri shell uses on Linux it often does not, so the desktop join-link button renders the link in its tooltip, paints "Join link copied", and leaves the clipboard untouched. One `copyText()` service now owns the write, reports whether it landed, and — inside the shell — takes the synchronous path first, because a fallback reached through an awaited rejection runs too late to copy anything.

## Files changed

- `client/src/services/copyText.ts` (new)
- `client/src/services/__tests__/copyText.test.ts` (new)
- `client/src/services/gameStateExport.ts`
- `client/src/components/chrome/HostControlTile.tsx`, `client/src/components/chrome/__tests__/HostControlTile.test.tsx`
- `client/src/components/chrome/DebugPanel.tsx`
- `client/src/components/log/GameLogPanel.tsx`
- `client/src/components/deck-builder/DeckList.tsx`
- `client/src/components/controls/CardCoverageDashboard.tsx`
- `client/src/components/draft/DraftPodLobby.tsx`
- `client/src/components/modal/UnhandledWaitingForModal.tsx`
- `client/src/components/modal/EngineLostModal.tsx`

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — client-only change in `client/src/services` and its callers; no `crates/` change, no parser or rules logic.

## CR references

None

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `tsc -b --noEmit` (client) — exit 0
- `eslint` over every changed file — exit 0
- `vitest run` (whole client suite) — 318 files (315 passed, 3 skipped), 2989 passed, 0 failed
- Discrimination, `copyText` ordering — with the async-first draft of `copyText.ts` restored, `copies synchronously inside the desktop shell` fails: `AssertionError: expected "vi.fn()" to be called with arguments: [ 'copy' ]`
- Discrimination, caller — with the pre-change `HostControlTile.tsx` restored, `confirms only when the clipboard actually took the link` fails (`1 failed | 1 passed`) and passes again on restore

Rust checks were not run: the diff touches no `crates/` path, no `Cargo.toml`, and no card data.

## Gate A

Gate A PASS head=e606c8799ccc46a90e4112f4e1c68c36a885c7e7 base=875986b14edb36499dfcdd16319ef18f34dc66f8

## Anchored on

- client/src/services/audioHealth.ts:21-40 — the same shape for the same class of problem: a service that names a WebKitGTK-on-Linux defect, branches on `isTauri()`, and returns a verdict its callers act on rather than throwing.
- client/src/services/openExternal.ts:16-22 — an `isTauri()`-gated service that routes around a webview limitation, with the upstream issue numbers carried in the docstring. Same directory, same naming, same one-exported-function shape.

## Claimed parse impact

None.

## Scope Expansion

Nine call sites beyond the reported button were routed through the helper. They fail identically in the same webview, and fixing only the reported one would leave the rest silently broken — including the two crash-report modals, whose manual-copy prompt previously depended on the write *throwing*.

## Validation Failures

None.

## CI Failures

None.

## Final Report

### 1. The defect

`HostControlTile.tsx` (before):

```ts
void navigator.clipboard?.writeText(joinShare);
showToast(t("hostControl.joinLinkCopied"));
```

The toast is unconditional. `navigator.clipboard` being absent, and the returned promise rejecting, are both swallowed — `?.` yields `undefined` for the first and `void` discards the second. Reported from a Linux desktop shell: hovering the button shows the join link, clicking it copies nothing.

Nine other sites share the pattern in weaker forms: `CardCoverageDashboard.tsx` had a `.then()` with no `catch` (an unhandled rejection on failure), `DraftPodLobby.tsx` swallowed the rejection deliberately, and `UnhandledWaitingForModal.tsx` / `EngineLostModal.tsx` reached their manual-copy `window.prompt` only via `catch` — so a write that resolved without copying, or one that never rejected, left the user with no way to get the diagnostic out.

### 2. Why the webview fails, and what is actually measured

Two failure modes:

- **Absent.** `navigator.clipboard` is undefined in the WebKitGTK webview ([tauri#5835](https://github.com/tauri-apps/tauri/issues/5835), filed against Ubuntu 22.04 with `enable_clipboard_access()` set). Here the property access throws synchronously.
- **Present but not writing.** The shell loads `https://app.phase-rs.dev` — a secure context — so a current WebKitGTK does define `navigator.clipboard`, and the write can fail at the platform layer instead.

The second mode is what makes ordering load-bearing, and it is the part of this change that rests on reasoning rather than a measurement in the shell. `await navigator.clipboard.writeText(...)` settles from platform I/O, so its rejection resumes in a **later task**; `document.execCommand("copy")` is honoured only while the user's gesture is still on the stack. A fallback reached through the rejection therefore cannot write, even though it is the correct fallback. So inside the shell the synchronous path runs **first**, and the async API stays first everywhere else, where it is the supported path and is not gated this way.

Stated plainly: that WebKitGTK rejects the write here is an inference from the reported symptom plus the ordering argument, not something measured inside the running shell. What *is* measured is the ordering itself — the test below fails on the async-first draft and passes on this one — and that the confirmation no longer appears without a successful write. If the platform write turns out to succeed after all, this change costs nothing; if `execCommand` is also refused, the button becomes honest rather than functional and the two diagnostic modals still gain a manual-copy path they did not have.

### 3. The change

`client/src/services/copyText.ts`:

```ts
export async function copyText(text: string): Promise<boolean> {
  if (isTauri() && legacyCopy(text)) {
    return true;
  }
  try {
    await navigator.clipboard.writeText(text);
    return true;
  } catch {
    return legacyCopy(text);
  }
}
```

One `catch` covers both failure modes, because reaching through a missing `navigator.clipboard` throws synchronously inside the async function. `legacyCopy` selects an off-screen textarea, runs `execCommand("copy")`, restores the previously focused element, and removes the textarea in a `finally`; it returns `false` rather than throwing when there is no `document`, so the `void copyText(...)` call sites cannot produce an unhandled rejection.

Callers act on the answer: the join-link toast fires only on a real copy, the two diagnostic modals fall back to their manual-copy prompt on `false` (covering the silent mode, not just the throwing one), and `CardCoverageDashboard`'s button no longer leaks a rejection. `copyGameStateDebugSnapshot` keeps its throwing contract so its three `.then/.catch` callers are untouched. No new i18n strings: the join-link failure path is silence, which keeps seven locale files out of the diff.

The shell-side alternative, `@tauri-apps/plugin-clipboard-manager`, is the wrong layer. It needs a Rust dependency, a plugin init and a new capability entry, so it ships only in a **shell release** — while this fix ships with the remote content the shell loads and reaches every installed shell on the next `app.phase-rs.dev` deploy. `services/nativeEngine.ts` documents that asymmetry: the shell updates far less often than the content, and the content is written to tolerate older shells.

### 4. Review

An independent pass reproduced the gates, mutation-checked the tests, and confirmed the caller test discriminates against the pre-change component. Three findings, all fixed here:

1. **Ordering (merge-gating).** The first draft was async-first everywhere, so on the rejecting path `execCommand` ran after the awaited rejection — off the gesture stack, where it cannot write. Fixed by the `isTauri()` synchronous-first branch, and pinned by a test.
2. **Citation.** The draft also cited tauri#10835; that issue is a plugin ACL misconfiguration, not a silent `navigator.clipboard` failure. Dropped. tauri#5835 was re-verified and kept.
3. **Focus.** `select()` moves focus in a real engine (happy-dom does not, so no test can catch it). The previously focused element is now restored in the `finally`.

### 5. Tests

`copyText.test.ts`, 7 cases: success through the async API; fallback when the API is absent; fallback when it rejects; `false` when neither path writes; `false` when the fallback itself throws; the fallback receives the right text and leaves no element in the DOM; and the ordering case — under `window.__TAURI_INTERNALS__` with a rejecting `writeText`, `execCommand` must already have been called **before** the returned promise is awaited, and `writeText` must not be called at all.

`HostControlTile.test.tsx` gains one case carrying both halves, so the negative cannot pass vacuously: a working clipboard must toast `Join link copied`, then the same click with no clipboard and `execCommand` returning `false` must produce no toast.

Both discrimination checks are in "Verification" above.

### 6. Verification

```
tsc -b --noEmit                        exit 0
eslint <every changed file>            exit 0
vitest run (whole client suite)        318 files (315 passed, 3 skipped), 2989 passed, 0 failed
./scripts/check-parser-combinators.sh  Gate A PASS head=e606c8799ccc46a90e4112f4e1c68c36a885c7e7 base=875986b14edb36499dfcdd16319ef18f34dc66f8
```
