### PR TITLE
fix(draft): publish the engine's next pairing round and surface pod errors

### DIFF
--- a/client/src/adapter/__tests__/draftPodAdapter.test.ts
+++ b/client/src/adapter/__tests__/draftPodAdapter.test.ts
@@ -134,6 +134,7 @@ function mockView(status: string): DraftPlayerView {
     timer_remaining_ms: null,
     standings: [],
     current_round: 0,
+    next_pairing_round: 1,
     tournament_format: "Swiss",
     pod_policy: "Competitive",
     pairings: [],

--- a/client/src/adapter/__tests__/p2pDraftHostAdvanceRound.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftHostAdvanceRound.test.ts
@@ -53,6 +53,7 @@ function viewForRound(round: number): DraftPlayerView {
     timer_remaining_ms: null,
     standings: [],
     current_round: round,
+    next_pairing_round: round + 1,
     tournament_format: "Swiss",
     pod_policy: "Casual",
     pairings: [pairing(round, 0)],

--- a/client/src/adapter/__tests__/p2pDraftHostResume.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftHostResume.test.ts
@@ -143,9 +143,11 @@ describe("P2PDraftHost.restoreFromPersisted — pairing-window recovery", () => 
     // REVERT-FAILING ASSERTION: pre-fix the predicate also required
     // `view.pairings.length === 0`, so this branch was dead for every round >= 1.
     expect(adapter.generatePairings).toHaveBeenCalled();
-    // The caller (`draftPodHostAdapter`) emits this view and derives host status
-    // from it; a stale `Pairing` view here strands the user on the pairing screen.
-    expect(adapter.getViewForSeat).toHaveBeenCalled();
+    // The caller (`draftPodHostAdapter:236-240`) emits this view and derives host
+    // status from it, so a stale `Pairing` return strands the user on the pairing
+    // screen. Asserting the returned *status*, not that `getViewForSeat` was
+    // called: `generatePairings()` already calls it twice internally
+    // (`p2p-draft-host.ts:1022,1036`), so a call-count assertion is vacuous here.
     expect(restored?.status).toBe("MatchInProgress");
   });
 

--- a/client/src/adapter/__tests__/p2pDraftHostResume.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftHostResume.test.ts
@@ -1,0 +1,184 @@
+import { describe, expect, it, vi } from "vitest";
+
+// Mock only DraftAdapter's constructor — the rest of the module (notably
+// EMPTY_DRAFT_POOL_GROUPS, which p2p-draft-host imports at module scope) must
+// stay real, so the factory spreads the original module.
+vi.mock("../draft-adapter", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../draft-adapter")>();
+  return {
+    ...actual,
+    DraftAdapter: vi.fn().mockImplementation(function () {
+      return {};
+    }),
+  };
+});
+
+import { P2PDraftHost } from "../p2p-draft-host";
+import { EMPTY_DRAFT_POOL_GROUPS } from "../draft-adapter";
+import type { DraftPlayerView, PairingView } from "../draft-adapter";
+import type { PersistedDraftHostSession } from "../../services/draftPersistence";
+
+function pairing(round: number, table: number): PairingView {
+  return {
+    round,
+    table,
+    seat_a: 0,
+    name_a: "Host",
+    seat_b: 1,
+    name_b: "Guest",
+    match_id: `r${round}-t${table}`,
+    status: "Pending",
+    winner_seat: null,
+    score_a: null,
+    score_b: null,
+  };
+}
+
+/** Fully shaped so `isBotSeatFromView` (which reads `view.seats`) cannot throw. */
+function viewFor(
+  status: DraftPlayerView["status"],
+  round: number,
+  pairings: PairingView[],
+): DraftPlayerView {
+  return {
+    status,
+    kind: "Premier",
+    current_pack_number: 3,
+    pick_number: 14,
+    pass_direction: "Left",
+    current_pack: null,
+    pool: [],
+    draft_effects: [],
+    pool_groups: EMPTY_DRAFT_POOL_GROUPS,
+    seats: [],
+    cards_per_pack: 14,
+    pack_count: 3,
+    min_deck_size: 40,
+    addable_cards: [],
+    timer_remaining_ms: null,
+    standings: [],
+    current_round: round,
+    next_pairing_round: round + 1,
+    tournament_format: "Swiss",
+    pod_policy: "Casual",
+    pairings,
+    match_config: { match_type: "Bo1" },
+  };
+}
+
+/**
+ * `seatTokens: {}` is load-bearing: a non-empty map makes `restoreFromPersisted`
+ * arm a 5-minute grace timer per guest seat and pause the host, leaving dangling
+ * timers behind. Empty leaves `disconnectedSeats` at 0 — no timer, no pause.
+ * `settlementOutbox` / `matchBindings` / `bo3State` are left unset so the
+ * recovery loops are no-ops.
+ */
+function persistedSession(): PersistedDraftHostSession {
+  return {
+    persistenceId: "resume-test",
+    roomCode: "ABCDE",
+    kind: "Premier",
+    podSize: 8,
+    hostDisplayName: "Host",
+    tournamentFormat: "Swiss",
+    podPolicy: "Casual",
+    seatTokens: {},
+    seatNames: { 0: "Host" },
+    kickedTokens: [],
+    draftStarted: true,
+    draftCode: "draft-12345678",
+    draftSessionJson: '{"status":"Pairing"}',
+    poolInput: { type: "Set", data: { set_pool_json: "{}" } },
+  };
+}
+
+function makeHost(restoredView: DraftPlayerView) {
+  const host = new P2PDraftHost(
+    { id: "host" } as never,
+    () => () => {},
+    { type: "Set", data: { set_pool_json: "{}" } } as never,
+    "Premier",
+    8,
+    "Host",
+    "Swiss",
+    "Casual",
+  );
+
+  const adapter = (host as unknown as { adapter: Record<string, unknown> })
+    .adapter;
+  adapter.importSession = vi.fn(async () => restoredView);
+  adapter.generatePairings = vi.fn(async () =>
+    viewFor("MatchInProgress", restoredView.current_round + 1, [
+      pairing(restoredView.current_round + 1, 0),
+    ]),
+  );
+  adapter.getViewForSeat = vi.fn(async () =>
+    viewFor("MatchInProgress", restoredView.current_round + 1, [
+      pairing(restoredView.current_round + 1, 0),
+    ]),
+  );
+
+  // Instance-level stubs shadow the prototype methods; both launch paths call
+  // them via `this.`, so no real match dispatch (and no `exportSession`) runs.
+  (
+    host as unknown as { dispatchMatchLaunch: () => Promise<void> }
+  ).dispatchMatchLaunch = vi.fn(async () => {});
+  (
+    host as unknown as { dispatchMatchLaunchesForSeat: () => Promise<void> }
+  ).dispatchMatchLaunchesForSeat = vi.fn(async () => {});
+
+  return { host, adapter };
+}
+
+describe("P2PDraftHost.restoreFromPersisted — pairing-window recovery", () => {
+  it("regenerates pairings when resuming in the Pairing window at round >= 1", async () => {
+    // The measured production state: `AdvanceRound` leaves `current_round` at 1
+    // and the previous round's pairings still filter through the view.
+    const { host, adapter } = makeHost(
+      viewFor("Pairing", 1, [pairing(1, 0)]),
+    );
+
+    await host.restoreFromPersisted(persistedSession());
+
+    // REVERT-FAILING ASSERTION: pre-fix the predicate also required
+    // `view.pairings.length === 0`, so this branch was dead for every round >= 1.
+    expect(adapter.generatePairings).toHaveBeenCalled();
+  });
+
+  it("regenerates pairings when resuming at round 0 with no pairings yet", async () => {
+    // Paired positive control: this passes both before and after the fix. Its
+    // job is to prove the harness actually reaches the branch — `importSession`
+    // resolves, the `draftSessionJson` guard passes, and the spy is wired — so
+    // the case above failing cannot mean "the test never got there".
+    const { host, adapter } = makeHost(viewFor("Pairing", 0, []));
+
+    await host.restoreFromPersisted(persistedSession());
+
+    expect(adapter.generatePairings).toHaveBeenCalled();
+  });
+
+  it("does not regenerate pairings when resuming mid-match", async () => {
+    const { host, adapter } = makeHost(
+      viewFor("MatchInProgress", 1, [pairing(1, 0)]),
+    );
+
+    await host.restoreFromPersisted(persistedSession());
+
+    // Reach-guard: a "not called" result cannot be satisfied by the method
+    // bailing out before the branch.
+    expect(adapter.importSession).toHaveBeenCalled();
+    expect(adapter.generatePairings).not.toHaveBeenCalled();
+  });
+
+  it("does not regenerate pairings when resuming with the round complete", async () => {
+    // Proves the fix did not broaden to "any non-MatchInProgress status".
+    const { host, adapter } = makeHost(
+      viewFor("RoundComplete", 1, [pairing(1, 0)]),
+    );
+
+    await host.restoreFromPersisted(persistedSession());
+
+    expect(adapter.importSession).toHaveBeenCalled();
+    expect(adapter.generatePairings).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/adapter/__tests__/p2pDraftHostResume.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftHostResume.test.ts
@@ -138,11 +138,15 @@ describe("P2PDraftHost.restoreFromPersisted — pairing-window recovery", () => 
       viewFor("Pairing", 1, [pairing(1, 0)]),
     );
 
-    await host.restoreFromPersisted(persistedSession());
+    const restored = await host.restoreFromPersisted(persistedSession());
 
     // REVERT-FAILING ASSERTION: pre-fix the predicate also required
     // `view.pairings.length === 0`, so this branch was dead for every round >= 1.
     expect(adapter.generatePairings).toHaveBeenCalled();
+    // The caller (`draftPodHostAdapter`) emits this view and derives host status
+    // from it; a stale `Pairing` view here strands the user on the pairing screen.
+    expect(adapter.getViewForSeat).toHaveBeenCalled();
+    expect(restored?.status).toBe("MatchInProgress");
   });
 
   it("regenerates pairings when resuming at round 0 with no pairings yet", async () => {

--- a/client/src/adapter/__tests__/server-draft-adapter.test.ts
+++ b/client/src/adapter/__tests__/server-draft-adapter.test.ts
@@ -77,6 +77,7 @@ function createMockDraftView(overrides: Partial<DraftPlayerView> = {}): DraftPla
     timer_remaining_ms: null,
     standings: [],
     current_round: 0,
+    next_pairing_round: 1,
     tournament_format: "Swiss",
     pod_policy: "Competitive",
     pairings: [],

--- a/client/src/adapter/draft-adapter.ts
+++ b/client/src/adapter/draft-adapter.ts
@@ -223,7 +223,11 @@ export interface DraftPlayerView {
   timer_remaining_ms: number | null;
   standings: StandingEntry[];
   current_round: number;
-  /** Engine-derived round that pairings may next be generated for. Always >= 1. */
+  /**
+   * Engine-derived round that pairings may next be generated for. Always >= 1.
+   * Published unconditionally, so on a `Complete` pod it names a round that can
+   * never be generated — read `current_round` there instead.
+   */
   next_pairing_round: number;
   tournament_format: TournamentFormat;
   pod_policy: PodPolicy;

--- a/client/src/adapter/draft-adapter.ts
+++ b/client/src/adapter/draft-adapter.ts
@@ -223,6 +223,8 @@ export interface DraftPlayerView {
   timer_remaining_ms: number | null;
   standings: StandingEntry[];
   current_round: number;
+  /** Engine-derived round that pairings may next be generated for. Always >= 1. */
+  next_pairing_round: number;
   tournament_format: TournamentFormat;
   pod_policy: PodPolicy;
   pairings: PairingView[];

--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -1967,10 +1967,12 @@ export class P2PDraftHost {
       if (view.status === "MatchInProgress") {
         await this.dispatchMatchLaunchesForSeat(view, 0);
       } else if (view.status === "Pairing") {
-        // `apply_advance_round` is the engine's only writer of `Pairing`, and
-        // generating pairings immediately leaves it for `MatchInProgress`. So
-        // `Pairing` already means "the pairings this window exists to produce do
-        // not exist yet".
+        // Two engine sites write `Pairing`: `apply_submit_deck` opens the
+        // round-0 window once all decks are in, and `apply_advance_round` opens
+        // each later one. Neither has generated the pairings the window exists
+        // to produce — `apply_generate_pairings` is what generates them, and it
+        // immediately leaves for `MatchInProgress`. So `Pairing` always means
+        // "not generated yet".
         // `view.pairings` still holds the *previous* round's pairings here
         // (`compute_pairing_views` filters on `current_round`, which
         // `AdvanceRound` deliberately does not bump), so testing it for

--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -1966,7 +1966,21 @@ export class P2PDraftHost {
 
       if (view.status === "MatchInProgress") {
         await this.dispatchMatchLaunchesForSeat(view, 0);
-      } else if (view.status === "Pairing" && view.pairings.length === 0) {
+      } else if (view.status === "Pairing") {
+        // `apply_advance_round` is the engine's only writer of `Pairing`, and
+        // generating pairings immediately leaves it for `MatchInProgress`. So
+        // `Pairing` already means "the pairings this window exists to produce do
+        // not exist yet".
+        // `view.pairings` still holds the *previous* round's pairings here
+        // (`compute_pairing_views` filters on `current_round`, which
+        // `AdvanceRound` deliberately does not bump), so testing it for
+        // emptiness made this branch dead for every round after the first.
+        //
+        // Widening it cannot generate a round twice: generating sets status to
+        // `MatchInProgress`, so this branch cannot fire again for the same
+        // round; and `AdvanceRound` requires `RoundComplete`, which the final
+        // round never enters (it transitions straight to `Complete`), so there
+        // is no round past the last one for this branch to invent.
         await this.generatePairings();
         return this.adapter.getViewForSeat(0);
       }
@@ -2081,6 +2095,7 @@ export class P2PDraftHost {
       timer_remaining_ms: null,
       standings: [],
       current_round: 0,
+      next_pairing_round: 1,
       tournament_format: "Swiss",
       pod_policy: "Competitive",
       pairings: [],

--- a/client/src/components/draft/PodErrorBanner.tsx
+++ b/client/src/components/draft/PodErrorBanner.tsx
@@ -8,7 +8,16 @@ import { useMultiplayerDraftStore } from "../../stores/multiplayerDraftStore";
  * Self-sources from the store, matching `StandingsTable`'s convention on this
  * surface, and renders `store.error` verbatim — the string is composed by the
  * host adapter and is not i18n'd. Reuses the red banner treatment already in
- * `DraftPodLobby` and the `role="status"` shape of the pause banner.
+ * `DraftPodLobby`, and `LimitedDeckBuilder`'s `role="alert"` treatment of this
+ * same store field — the pause banner's `role="status"` is the wrong precedent,
+ * because a paused draft is a status and a failed action is not.
+ *
+ * `store.error` is write-once: nothing clears it on a phase transition, so an
+ * error raised in `betweenGames` (which has no banner of its own) surfaces on
+ * the *next* pod screen and rides along until the host's next
+ * `pairingsGenerated` supersedes it or the user dismisses it. Deliberate — the
+ * alternative is the BASE behaviour, where those errors were invisible
+ * everywhere. A scoped phase-transition clearing rule is the real fix.
  */
 export function PodErrorBanner() {
   const { t } = useTranslation("common");
@@ -19,7 +28,7 @@ export function PodErrorBanner() {
 
   return (
     <div
-      role="status"
+      role="alert"
       data-testid="pod-error-banner"
       className="flex items-start gap-3 rounded-lg border border-red-400/20 bg-red-400/5 px-4 py-3 text-sm text-red-300"
     >

--- a/client/src/components/draft/PodErrorBanner.tsx
+++ b/client/src/components/draft/PodErrorBanner.tsx
@@ -1,0 +1,37 @@
+import { useTranslation } from "react-i18next";
+
+import { useMultiplayerDraftStore } from "../../stores/multiplayerDraftStore";
+
+/**
+ * Dismissible error banner for the pod tournament phases.
+ *
+ * Self-sources from the store, matching `StandingsTable`'s convention on this
+ * surface, and renders `store.error` verbatim — the string is composed by the
+ * host adapter and is not i18n'd. Reuses the red banner treatment already in
+ * `DraftPodLobby` and the `role="status"` shape of the pause banner.
+ */
+export function PodErrorBanner() {
+  const { t } = useTranslation("common");
+  const error = useMultiplayerDraftStore((s) => s.error);
+  const clearError = useMultiplayerDraftStore((s) => s.clearError);
+
+  if (!error) return null;
+
+  return (
+    <div
+      role="status"
+      data-testid="pod-error-banner"
+      className="flex items-start gap-3 rounded-lg border border-red-400/20 bg-red-400/5 px-4 py-3 text-sm text-red-300"
+    >
+      <span className="min-w-0 flex-1">{error}</span>
+      <button
+        type="button"
+        onClick={clearError}
+        aria-label={t("actions.close")}
+        className="shrink-0 text-lg leading-none text-red-300/70 transition-colors hover:text-red-200"
+      >
+        &times;
+      </button>
+    </div>
+  );
+}

--- a/client/src/components/draft/PodErrorBanner.tsx
+++ b/client/src/components/draft/PodErrorBanner.tsx
@@ -17,7 +17,10 @@ import { useMultiplayerDraftStore } from "../../stores/multiplayerDraftStore";
  * the *next* pod screen and rides along until the host's next
  * `pairingsGenerated` supersedes it or the user dismisses it. Deliberate — the
  * alternative is the BASE behaviour, where those errors were invisible
- * everywhere. A scoped phase-transition clearing rule is the real fix.
+ * everywhere. A scoped phase-transition clearing rule is the real fix; until
+ * then, note that `role="alert"` re-announces a latched error at every pod
+ * phase change, because each phase view mounts its own instance of this
+ * component.
  */
 export function PodErrorBanner() {
   const { t } = useTranslation("common");

--- a/client/src/components/draft/StandingsTable.tsx
+++ b/client/src/components/draft/StandingsTable.tsx
@@ -61,8 +61,21 @@ export function StandingsTable() {
   const { t } = useTranslation("draft");
   const standings = useMultiplayerDraftStore((s) => s.standings);
   const currentRound = useMultiplayerDraftStore((s) => s.currentRound);
+  const nextPairingRound = useMultiplayerDraftStore((s) => s.nextPairingRound);
+  const phase = useMultiplayerDraftStore((s) => s.phase);
   const localSeat = useMultiplayerDraftStore((s) => s.seatIndex);
   const pairings = useMultiplayerDraftStore((s) => s.pairings);
+
+  // Between rounds the standings are labelled with the round about to be played;
+  // during a match and at the end they name the round on the board. Both numbers
+  // are engine-supplied — `currentRound` and `nextPairingRound` (the published
+  // answer of `DraftSession::next_pairing_round`) — so nothing is computed here.
+  // Keyed on `phase`, not `view.status`: `view` lags a beat behind `phase` at
+  // `roundAdvanced`, and `standings` is only ever written by a `viewUpdated`
+  // that writes `phase` and `currentRound` in the same `set()` — so by the time
+  // this component renders at all, the three are mutually consistent.
+  const round =
+    phase === "pairing" || phase === "roundComplete" ? nextPairingRound : currentRound;
 
   if (standings.length === 0) return null;
 
@@ -78,7 +91,7 @@ export function StandingsTable() {
   return (
     <div className="rounded-[20px] border border-white/10 bg-black/18 p-4 shadow-[0_18px_54px_rgba(0,0,0,0.22)] backdrop-blur-md">
       <h3 className="text-lg font-medium text-white mb-3">
-        {t("standings.title", { round: currentRound + 1 })}
+        {t("standings.title", { round })}
       </h3>
       <table className="w-full text-sm text-white/80">
         <thead>

--- a/client/src/components/draft/__tests__/LimitedDeckBuilder.test.tsx
+++ b/client/src/components/draft/__tests__/LimitedDeckBuilder.test.tsx
@@ -164,6 +164,7 @@ const TEST_VIEW: BuilderView = {
   timer_remaining_ms: null,
   standings: [],
   current_round: 0,
+  next_pairing_round: 1,
   tournament_format: "Swiss",
   pod_policy: "Competitive",
   pairings: [],

--- a/client/src/components/draft/__tests__/PackDisplay.pod.test.tsx
+++ b/client/src/components/draft/__tests__/PackDisplay.pod.test.tsx
@@ -58,6 +58,7 @@ const view: DraftPlayerView = {
   timer_remaining_ms: null,
   standings: [],
   current_round: 0,
+  next_pairing_round: 1,
   tournament_format: "Swiss",
   pod_policy: "Competitive",
   pairings: [],

--- a/client/src/components/draft/__tests__/SealedPackOpening.test.tsx
+++ b/client/src/components/draft/__tests__/SealedPackOpening.test.tsx
@@ -77,6 +77,7 @@ const VIEW: DraftPlayerView = {
   timer_remaining_ms: null,
   standings: [],
   current_round: 0,
+  next_pairing_round: 1,
   tournament_format: "Swiss",
   pod_policy: "Competitive",
   pairings: [],

--- a/client/src/network/__tests__/draftProtocol.test.ts
+++ b/client/src/network/__tests__/draftProtocol.test.ts
@@ -10,8 +10,8 @@ import type { DraftP2PMessage } from "../draftProtocol";
 
 describe("draftProtocol", () => {
   describe("DRAFT_PROTOCOL_VERSION", () => {
-    it("is version 11", () => {
-      expect(DRAFT_PROTOCOL_VERSION).toBe(11);
+    it("is version 12", () => {
+      expect(DRAFT_PROTOCOL_VERSION).toBe(12);
     });
   });
 

--- a/client/src/network/draftProtocol.ts
+++ b/client/src/network/draftProtocol.ts
@@ -42,8 +42,9 @@ import type {
  *   9 — add engine-owned limited-pool presentation groups
  *  10 — add authenticated draft-effect pick actions
  *  11 — instance-addressable pool entries (`instance_ids`) + engine rarity axis
+ *  12 — publish the engine-derived next pairing round on the player view
  */
-export const DRAFT_PROTOCOL_VERSION = 11 as const;
+export const DRAFT_PROTOCOL_VERSION = 12 as const;
 
 /**
  * Typed reason for a draft pause, used over the wire and on the i18n key path.

--- a/client/src/pages/DraftPodPage.tsx
+++ b/client/src/pages/DraftPodPage.tsx
@@ -25,6 +25,7 @@ import { HostControls } from "../components/draft/HostControls";
 import { LimitedDeckBuilder } from "../components/draft/LimitedDeckBuilder";
 import { PackDisplay } from "../components/draft/PackDisplay";
 import { PickTimer } from "../components/draft/PickTimer";
+import { PodErrorBanner } from "../components/draft/PodErrorBanner";
 import { PoolPanel } from "../components/draft/PoolPanel";
 import { ScoreBadge } from "../components/draft/ScoreBadge";
 import { SeatStatusRing } from "../components/draft/SeatStatusRing";
@@ -422,6 +423,7 @@ function PairingPhaseView() {
   const { t } = useTranslation("draft");
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 py-8">
+      <PodErrorBanner />
       <h2 className="text-center text-xl font-medium text-white">
         {t("podPhaseView.tournamentPairings")}
       </h2>
@@ -447,6 +449,7 @@ function MatchInProgressView() {
 
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 py-8">
+      <PodErrorBanner />
       <h2 className="text-center text-xl font-medium text-white">
         {t("podPhaseView.matchesInProgress")}
       </h2>
@@ -509,6 +512,7 @@ function RoundCompleteView() {
 
   return (
     <div className="mx-auto flex w-full max-w-2xl flex-col gap-6 py-8">
+      <PodErrorBanner />
       <h2 className="text-center text-xl font-medium text-white">
         {t("podPhaseView.roundComplete")}
       </h2>

--- a/client/src/pages/__tests__/DraftPodPage.podError.test.tsx
+++ b/client/src/pages/__tests__/DraftPodPage.podError.test.tsx
@@ -1,0 +1,126 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { DraftPodPage } from "../DraftPodPage";
+
+const { draftState } = vi.hoisted(() => ({
+  draftState: {
+    phase: "pairing",
+    error: null as string | null,
+    clearError: vi.fn(),
+    currentRound: 2,
+    nextPairingRound: 3,
+    standings: [],
+    pairings: [],
+    seatIndex: 0,
+    view: { tournament_format: "Swiss" },
+    matchPairing: null,
+    startMatch: vi.fn(),
+    leave: vi.fn(),
+    mainDeck: [],
+    landCounts: {},
+    addToDeck: vi.fn(),
+    removeFromDeck: vi.fn(),
+    setLandCount: vi.fn(),
+    submitDeck: vi.fn(),
+  },
+}));
+
+vi.mock("../../stores/multiplayerDraftStore", () => ({
+  useMultiplayerDraftStore: (selector: (state: typeof draftState) => unknown) => selector(draftState),
+}));
+
+vi.mock("../../stores/draftPodStore", () => ({
+  useDraftPodStore: (selector: (state: { reset: () => void; resumeHostedPod: () => void }) => unknown) => selector({
+    reset: vi.fn(),
+    resumeHostedPod: vi.fn(),
+  }),
+}));
+
+vi.mock("../../components/chrome/ScreenChrome", () => ({ ScreenChrome: () => null }));
+vi.mock("../../components/menu/MenuShell", () => ({ MenuShell: ({ children }: { children: ReactNode }) => <>{children}</> }));
+vi.mock("../../components/draft/HostControls", () => ({ HostControls: () => null }));
+vi.mock("../../components/draft/LimitedDeckBuilder", () => ({ LimitedDeckBuilder: () => <div data-testid="limited-deck-builder" /> }));
+vi.mock("../../components/draft/ScoreBadge", () => ({ ScoreBadge: () => <div data-testid="score-badge" /> }));
+
+function renderPage() {
+  return render(<MemoryRouter><DraftPodPage /></MemoryRouter>);
+}
+
+const ERROR_TEXT = "Failed to advance round: pairing generation failed";
+
+describe("DraftPodPage pod error banner", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    draftState.error = null;
+    draftState.clearError.mockClear();
+  });
+
+  it("surfaces the store error in the pairing phase", () => {
+    draftState.phase = "pairing";
+    draftState.error = ERROR_TEXT;
+    renderPage();
+
+    // Reach-guard: the phase view itself mounted, so an absent banner is a
+    // real absence rather than a failed render.
+    expect(screen.getByText("Tournament Pairings")).toBeInTheDocument();
+    // REVERT-FAILING ASSERTION: at BASE nothing in this view reads `s.error`.
+    expect(screen.getByText(/Failed to advance round/)).toBeInTheDocument();
+  });
+
+  it("surfaces the store error while a match is in progress", () => {
+    draftState.phase = "matchInProgress";
+    draftState.error = ERROR_TEXT;
+    renderPage();
+
+    expect(screen.getByText("Waiting for match results...")).toBeInTheDocument();
+    expect(screen.getByText(/Failed to advance round/)).toBeInTheDocument();
+  });
+
+  it("surfaces the store error on the round-complete screen", () => {
+    draftState.phase = "roundComplete";
+    draftState.error = ERROR_TEXT;
+    renderPage();
+
+    expect(screen.getByText("Round Complete")).toBeInTheDocument();
+    expect(screen.getByText(/Failed to advance round/)).toBeInTheDocument();
+  });
+
+  it("renders no banner when there is no error", () => {
+    draftState.phase = "pairing";
+    draftState.error = null;
+    renderPage();
+
+    expect(screen.getByText("Tournament Pairings")).toBeInTheDocument();
+    expect(screen.queryByText(/Failed to advance round/)).toBeNull();
+    expect(screen.queryByTestId("pod-error-banner")).toBeNull();
+  });
+
+  it("does not double-surface the error during deckbuilding", () => {
+    // Deckbuilding already surfaces `store.error` through `LimitedDeckBuilder`'s
+    // `submissionError`. Asserted on the banner's own testid, NOT on a text
+    // count: the harness mocks the deck builder out, so the count would be zero.
+    draftState.phase = "deckbuilding";
+    draftState.error = "boom";
+    renderPage();
+
+    expect(screen.getByTestId("limited-deck-builder")).toBeInTheDocument();
+    expect(screen.queryByTestId("pod-error-banner")).toBeNull();
+  });
+
+  it("clears the error through the store when dismissed", async () => {
+    const user = userEvent.setup();
+    draftState.phase = "pairing";
+    draftState.error = ERROR_TEXT;
+    renderPage();
+
+    expect(screen.getByTestId("pod-error-banner")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Close" }));
+
+    expect(draftState.clearError).toHaveBeenCalled();
+  });
+});

--- a/client/src/pages/__tests__/DraftPodPage.standingsRound.test.tsx
+++ b/client/src/pages/__tests__/DraftPodPage.standingsRound.test.tsx
@@ -1,0 +1,136 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import type { ReactNode } from "react";
+import { MemoryRouter } from "react-router";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { DraftPodPage } from "../DraftPodPage";
+
+const { draftState } = vi.hoisted(() => ({
+  draftState: {
+    phase: "matchInProgress",
+    currentRound: 2,
+    nextPairingRound: 3,
+    // `game_wins`/`game_losses` are not decoration: `formatGwp` sums them, and
+    // if they are absent the row renders `NaN%` instead of `-`.
+    standings: [
+      {
+        seat_index: 0,
+        display_name: "Alice",
+        match_wins: 2,
+        match_losses: 0,
+        game_wins: 4,
+        game_losses: 1,
+      },
+    ],
+    pairings: [],
+    seatIndex: 0,
+    view: { tournament_format: "Swiss" },
+    matchPairing: null,
+    startMatch: vi.fn(),
+    leave: vi.fn(),
+  },
+}));
+
+vi.mock("../../stores/multiplayerDraftStore", () => ({
+  useMultiplayerDraftStore: (selector: (state: typeof draftState) => unknown) => selector(draftState),
+}));
+
+vi.mock("../../stores/draftPodStore", () => ({
+  useDraftPodStore: (selector: (state: { reset: () => void; resumeHostedPod: () => void }) => unknown) => selector({
+    reset: vi.fn(),
+    resumeHostedPod: vi.fn(),
+  }),
+}));
+
+vi.mock("../../components/chrome/ScreenChrome", () => ({ ScreenChrome: () => null }));
+vi.mock("../../components/menu/MenuShell", () => ({ MenuShell: ({ children }: { children: ReactNode }) => <>{children}</> }));
+vi.mock("../../components/draft/HostControls", () => ({ HostControls: () => null }));
+vi.mock("../../components/draft/LimitedDeckBuilder", () => ({ LimitedDeckBuilder: () => <div data-testid="limited-deck-builder" /> }));
+vi.mock("../../components/draft/ScoreBadge", () => ({ ScoreBadge: () => <div data-testid="score-badge" /> }));
+
+function renderPage() {
+  return render(<MemoryRouter><DraftPodPage /></MemoryRouter>);
+}
+
+/**
+ * Paired positive reach-guard for every case below: `StandingsTable`
+ * early-returns `null` when `standings` is empty, so without proof that the
+ * table body rendered, a missing heading is indistinguishable from a component
+ * that never rendered at all.
+ */
+function expectStandingsRowRendered() {
+  expect(screen.getByText("Alice")).toBeInTheDocument();
+  expect(screen.getByText("2-0")).toBeInTheDocument();
+}
+
+describe("DraftPodPage standings round heading", () => {
+  afterEach(cleanup);
+
+  it("names the in-progress round during a match", () => {
+    draftState.phase = "matchInProgress";
+    draftState.currentRound = 2;
+    draftState.nextPairingRound = 3;
+    renderPage();
+
+    // REVERT-FAILING ASSERTION: pre-fix the component rendered
+    // `currentRound + 1` = 3 at this site.
+    expect(
+      screen.getByRole("heading", { name: "Standings — Round 2" }),
+    ).toBeInTheDocument();
+    expectStandingsRowRendered();
+  });
+
+  it("names the upcoming round in the pairing window", () => {
+    // Preservation guard: green at BASE and green after. Its job is to prove the
+    // fix preserved the two already-correct sites rather than flipping all four.
+    draftState.phase = "pairing";
+    draftState.currentRound = 2;
+    draftState.nextPairingRound = 3;
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", { name: "Standings — Round 3" }),
+    ).toBeInTheDocument();
+    expectStandingsRowRendered();
+  });
+
+  it("names the upcoming round when the round is complete", () => {
+    // The second preservation guard — the fourth render site.
+    draftState.phase = "roundComplete";
+    draftState.currentRound = 2;
+    draftState.nextPairingRound = 3;
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", { name: "Standings — Round 3" }),
+    ).toBeInTheDocument();
+    expectStandingsRowRendered();
+  });
+
+  it("names the in-progress round from the stale window pairingsGenerated leaves", () => {
+    // The store state `pairingsGenerated` deliberately produces: `viewUpdated`
+    // for round 2 left `nextPairingRound: 3`, then `pairingsGenerated` advanced
+    // `currentRound` to 3 without touching it. A stale-window rendering guard.
+    draftState.phase = "matchInProgress";
+    draftState.currentRound = 3;
+    draftState.nextPairingRound = 3;
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", { name: "Standings — Round 3" }),
+    ).toBeInTheDocument();
+    expectStandingsRowRendered();
+  });
+
+  it("names the final round on the completed pod screen", () => {
+    draftState.phase = "complete";
+    draftState.currentRound = 3;
+    draftState.nextPairingRound = 4;
+    renderPage();
+
+    expect(
+      screen.getByRole("heading", { name: "Standings — Round 3" }),
+    ).toBeInTheDocument();
+    expectStandingsRowRendered();
+  });
+});

--- a/client/src/stores/__tests__/multiplayerDraftStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerDraftStore.test.ts
@@ -223,7 +223,7 @@ describe("multiplayerDraftStore", () => {
       expect(state.view).toBe(view);
     });
 
-    it("advances currentRound on pairingsGenerated and leaves nextPairingRound to viewUpdated", async () => {
+    it("pairingsGenerated advances currentRound, leaves nextPairingRound to viewUpdated, and supersedes the error", async () => {
       await useMultiplayerDraftStore.getState().hostDraft({
         poolInput: { type: "Set", data: { set_pool_json: "{}" } },
         kind: "Premier",
@@ -241,6 +241,15 @@ describe("multiplayerDraftStore", () => {
         next_pairing_round: 3,
       };
       capturedHostEventHandler!({ type: "viewUpdated", view });
+      // Reach-guard: prove the error is live before the boundary, so a null
+      // afterwards cannot mean "it was never set".
+      capturedHostEventHandler!({
+        type: "error",
+        message: "Failed to advance round",
+      });
+      expect(useMultiplayerDraftStore.getState().error).toBe(
+        "Failed to advance round",
+      );
       capturedHostEventHandler!({ type: "pairingsGenerated", round: 3, pairings: [] });
 
       const state = useMultiplayerDraftStore.getState();
@@ -254,6 +263,11 @@ describe("multiplayerDraftStore", () => {
       // inlined `nextPairingRound: event.round + 1` to that handler — the
       // TypeScript re-derivation this work exists to abolish — yields 4 here.
       expect(state.nextPairingRound).toBe(3);
+      // REVERT-FAILING: drop `error: null` from the `pairingsGenerated` handler
+      // and this goes red. A successful round boundary supersedes the banner the
+      // failed attempt raised — without it the retry that WORKED still shows
+      // "Failed to advance round".
+      expect(state.error).toBeNull();
     });
 
     it("handles host-seat Bo3 prompt messages", async () => {

--- a/client/src/stores/__tests__/multiplayerDraftStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerDraftStore.test.ts
@@ -100,6 +100,7 @@ function mockView(status: string): DraftPlayerView {
     timer_remaining_ms: null,
     standings: [],
     current_round: 0,
+    next_pairing_round: 1,
     tournament_format: "Swiss",
     pod_policy: "Competitive",
     pairings: [],
@@ -220,6 +221,39 @@ describe("multiplayerDraftStore", () => {
       const state = useMultiplayerDraftStore.getState();
       expect(state.phase).toBe("matchInProgress");
       expect(state.view).toBe(view);
+    });
+
+    it("advances currentRound on pairingsGenerated and leaves nextPairingRound to viewUpdated", async () => {
+      await useMultiplayerDraftStore.getState().hostDraft({
+        poolInput: { type: "Set", data: { set_pool_json: "{}" } },
+        kind: "Premier",
+        podSize: 8,
+        hostDisplayName: "Host",
+        tournamentFormat: "Swiss",
+        podPolicy: "Competitive",
+      });
+
+      // The host's real round boundary: the engine view for round 2 arrives
+      // first, then pairing generation commits round 3.
+      const view = {
+        ...mockView("MatchInProgress"),
+        current_round: 2,
+        next_pairing_round: 3,
+      };
+      capturedHostEventHandler!({ type: "viewUpdated", view });
+      capturedHostEventHandler!({ type: "pairingsGenerated", round: 3, pairings: [] });
+
+      const state = useMultiplayerDraftStore.getState();
+      // Reach-guards: both events were demonstrably delivered, so a wrong
+      // `nextPairingRound` cannot be confused with "no event reached the store".
+      expect(state.view).toBe(view);
+      expect(state.phase).toBe("matchInProgress");
+      expect(state.currentRound).toBe(3);
+      // `pairingsGenerated` writes only the round it owns. The `3 / 3` relation
+      // is the deliberate window, not an accident: anyone later adding an
+      // inlined `nextPairingRound: event.round + 1` to that handler — the
+      // TypeScript re-derivation this work exists to abolish — yields 4 here.
+      expect(state.nextPairingRound).toBe(3);
     });
 
     it("handles host-seat Bo3 prompt messages", async () => {

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -109,6 +109,7 @@ interface MultiplayerDraftState {
   timerRemainingMs: number | null;
   standings: StandingEntry[];
   currentRound: number;
+  nextPairingRound: number;
   pairings: PairingView[];
   /** Full deck submitted during deckbuilding (mainDeck + lands). */
   submittedDeck: string[];
@@ -146,6 +147,8 @@ interface MultiplayerDraftActions {
   submitPickWithDraftEffect: (effectCardInstanceId: string, cardInstanceIds: string[]) => Promise<void>;
   /** Both: select a card (UI highlight before confirming pick). */
   selectCard: (cardInstanceId: string | null) => void;
+  /** Both: dismiss the current error banner. */
+  clearError: () => void;
   /** Both: confirm the currently selected card as pick. */
   confirmPick: () => Promise<void>;
   /** Both: pick a card from the current pack using a deterministic draft heuristic. */
@@ -497,6 +500,7 @@ const initialState: MultiplayerDraftState = {
   timerRemainingMs: null,
   standings: [],
   currentRound: 0,
+  nextPairingRound: 1,
   pairings: [],
   submittedDeck: [],
   matchPairing: null,
@@ -601,6 +605,8 @@ export const useMultiplayerDraftStore = create<
   selectCard: (cardInstanceId) => {
     set({ selectedCard: cardInstanceId });
   },
+
+  clearError: () => set({ error: null }),
 
   confirmPick: async () => {
     const { selectedCard, submitPick } = get();
@@ -1090,6 +1096,7 @@ function handleHostEvent(event: DraftPodHostEvent, set: SetFn): void {
         timerRemainingMs: event.view.timer_remaining_ms ?? null,
         standings: event.view.standings ?? [],
         currentRound: event.view.current_round ?? 0,
+        nextPairingRound: event.view.next_pairing_round ?? 1,
         pairings: event.view.pairings ?? [],
       });
       {
@@ -1123,7 +1130,16 @@ function handleHostEvent(event: DraftPodHostEvent, set: SetFn): void {
       set({ paused: false, pauseReason: null });
       break;
     case "pairingsGenerated":
-      set({ phase: "matchInProgress", currentRound: event.round, pairings: event.pairings });
+      // Host-only supersession: `advanceRound()` emits its own failure as
+      // `error`, so a successful retry of that exact operation clears the
+      // banner. Guests have no `pairingsGenerated` handler, so for them
+      // `clearError` (the banner's dismiss control) is the only clearing path.
+      set({
+        phase: "matchInProgress",
+        currentRound: event.round,
+        pairings: event.pairings,
+        error: null,
+      });
       saveDraftPodProgress("matchInProgress");
       break;
     case "matchStart":
@@ -1228,6 +1244,7 @@ function handleGuestEvent(event: DraftPodGuestEvent, set: SetFn): void {
         timerRemainingMs: event.view.timer_remaining_ms ?? null,
         standings: event.view.standings ?? [],
         currentRound: event.view.current_round ?? 0,
+        nextPairingRound: event.view.next_pairing_round ?? 1,
         pairings: event.view.pairings ?? [],
       });
       break;

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -1132,8 +1132,11 @@ function handleHostEvent(event: DraftPodHostEvent, set: SetFn): void {
     case "pairingsGenerated":
       // Host-only supersession: `advanceRound()` emits its own failure as
       // `error`, so a successful retry of that exact operation clears the
-      // banner. Guests have no `pairingsGenerated` handler, so for them
-      // `clearError` (the banner's dismiss control) is the only clearing path.
+      // banner. This clears *any* live error, not just that one — accepted,
+      // because `pairingsGenerated` fires once per round boundary, so anything
+      // it erases has already had a full round on screen. Guests have no
+      // `pairingsGenerated` handler, so for them `clearError` (the banner's
+      // dismiss control) is the only clearing path.
       set({
         phase: "matchInProgress",
         currentRound: event.round,

--- a/crates/draft-core/src/session.rs
+++ b/crates/draft-core/src/session.rs
@@ -17,9 +17,10 @@ impl DraftSession {
     /// Single authority. `AdvanceRound` deliberately leaves `current_round`
     /// untouched — it only opens the `Pairing` window — so `current_round` is
     /// always the last round whose pairings exist, and generating pairings is
-    /// what commits the next one. Private on purpose: callers outside this
-    /// module must not re-derive it.
-    fn next_pairing_round(&self) -> u8 {
+    /// what commits the next one. Crate-internal on purpose: `view.rs`
+    /// publishes its answer on `DraftPlayerView` so clients read it rather than
+    /// re-deriving it; callers outside this crate must never recompute it.
+    pub(crate) fn next_pairing_round(&self) -> u8 {
         self.current_round + 1
     }
 

--- a/crates/draft-core/src/view.rs
+++ b/crates/draft-core/src/view.rs
@@ -271,6 +271,10 @@ pub struct DraftPlayerView {
     pub standings: Vec<StandingEntry>,
     /// Current tournament round (0 = not started).
     pub current_round: u8,
+    /// The round pairings may next be generated for. Engine-derived from the
+    /// single authority (`DraftSession::next_pairing_round`) so clients never
+    /// recompute it. Always >= 1.
+    pub next_pairing_round: u8,
     /// Tournament format from config.
     pub tournament_format: TournamentFormat,
     /// Pod policy from config.
@@ -510,6 +514,7 @@ pub fn filter_for_player(session: &DraftSession, seat_index: u8) -> DraftPlayerV
         timer_remaining_ms: None,
         standings,
         current_round: session.current_round,
+        next_pairing_round: session.next_pairing_round(),
         tournament_format: session.config.tournament_format,
         pod_policy: session.config.pod_policy,
         pairings,
@@ -1834,6 +1839,9 @@ mod tests {
         assert_eq!(view.tournament_format, TournamentFormat::Swiss);
         assert_eq!(view.pod_policy, PodPolicy::Competitive);
         assert_eq!(view.current_round, 0);
+        // Pins the engine's `>= 1` guarantee at the lobby state. NOT
+        // discriminating on its own: a hard-coded `1` satisfies it too.
+        assert_eq!(view.next_pairing_round, 1);
         assert!(view.timer_remaining_ms.is_none());
     }
 
@@ -1846,6 +1854,8 @@ mod tests {
 
         let view = filter_for_player(&session, 0);
         assert_eq!(view.pairings.len(), 4);
+        assert_eq!(view.current_round, 1);
+        assert_eq!(view.next_pairing_round, 2);
         for pv in &view.pairings {
             assert_eq!(pv.round, 1);
             assert_eq!(pv.status, PairingStatus::Pending);

--- a/crates/draft-core/src/view.rs
+++ b/crates/draft-core/src/view.rs
@@ -273,7 +273,10 @@ pub struct DraftPlayerView {
     pub current_round: u8,
     /// The round pairings may next be generated for. Engine-derived from the
     /// single authority (`DraftSession::next_pairing_round`) so clients never
-    /// recompute it. Always >= 1.
+    /// recompute it. Always >= 1. Published unconditionally, so once `status`
+    /// is `Complete` it names a round that can never be generated
+    /// (`apply_generate_pairings` accepts only `Deckbuilding`/`Pairing`/
+    /// `RoundComplete`) — read `current_round` on a finished pod.
     pub next_pairing_round: u8,
     /// Tournament format from config.
     pub tournament_format: TournamentFormat,

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -2184,6 +2184,7 @@ mod tests {
             timer_remaining_ms: Some(5000),
             standings: Vec::new(),
             current_round: 0,
+            next_pairing_round: 1,
             tournament_format: TournamentFormat::Swiss,
             pod_policy: PodPolicy::Competitive,
             pairings: Vec::new(),


### PR DESCRIPTION
The three follow-ups deferred from #7607, which fixed a draft pod where clicking **Start Next Round** silently did nothing.

## F1 — the standings heading named the wrong round

`StandingsTable` computed `currentRound + 1`. That is right between rounds and wrong once a round is on the board, so `MatchInProgressView` and `CompleteView` were each off by one while the other two sites were correct.

The engine now publishes `next_pairing_round` on `DraftPlayerView`, sourced from `DraftSession::next_pairing_round()` — the same single authority #7607 introduced, widened to `pub(crate)` for exactly one cross-module consumer. `StandingsTable` selects between it and `current_round` by phase. Nothing is computed in the client.

## F2 — the pod phases had no error surface

`store.error` was written but no component mounted during `pairing` / `matchInProgress` / `roundComplete` read it. That is why #7607's bug presented as "nothing happened" rather than as an error: the reducer's `InvalidTransition` was caught, emitted, and rendered nowhere.

`PodErrorBanner` renders it on those three screens, dismissible through a new `clearError`, and a successful round boundary supersedes it.

## F3 — the host-resume recovery branch was dead

`restoreFromPersisted` gated its recovery on `status === "Pairing" && view.pairings.length === 0`. `compute_pairing_views` filters on `current_round`, which `AdvanceRound` deliberately does not bump, so after a round advance the array still held the *previous* round's pairings and the branch never fired past round 1.

The status test alone is necessary and sufficient. Two engine sites write `Pairing` — `apply_submit_deck` opens the round-0 window, `apply_advance_round` opens each later one — and neither has generated the pairings the window exists to produce. `apply_generate_pairings` generates them and immediately leaves for `MatchInProgress`, so the branch cannot fire twice for one round; `AdvanceRound` requires `RoundComplete`, which the final round never enters (it goes straight to `Complete`), so there is no round past the last for it to invent.

## Wire change

`DRAFT_PROTOCOL_VERSION` 11 → 12. `next_pairing_round` is a required field, and TS field additions are normally read with a `?? default`; without the bump a stale host and a new guest would connect successfully and the guest would silently render "Standings — Round 1" at every round. The bump converts that into a refused connection naming both versions. A silent wrong number is worse than a loud refusal.

This constant is P2P-only and is not covered by `scripts/check-protocol-version.mjs`, which guards `PROTOCOL_VERSION` and `LOBBY_PROTOCOL_VERSION`.

## Tests

Discriminating tests for each claim, each verified to fail on revert rather than merely to pass:

- `view_pairings_for_current_round` (draft-core) — asserts the published `next_pairing_round`; measured to fail `left: 1, right: 2` when the authority call is replaced.
- `DraftPodPage.standingsRound.test.tsx` — three reverting cases (`matchInProgress`, the stale window `pairingsGenerated` leaves, `complete`) plus two preservation guards that are green on both sides, labelled as such.
- `DraftPodPage.podError.test.tsx` — the three phases, a no-error case, a deckbuilding no-double-surface case, and dismissal.
- `p2pDraftHostResume.test.ts` — the round ≥ 1 revert case, a round-0 positive control proving the harness reaches the branch, and two hostile statuses asserting no regeneration.
- `multiplayerDraftStore.test.ts` — pins the `pairingsGenerated` / `viewUpdated` window and the error supersession, the latter mutation-verified.

One coverage limit, stated rather than left to be found: `next_pairing_round` is today numerically `current_round + 1`, so no runtime test separates the authority call from an inlined form. That rests on inspection, plus the structural tell that the `pub(crate)` widening would otherwise have no consumer.

## Known behaviour change

`store.error` is write-once. Errors raised in `betweenGames` — which has no banner of its own — now surface on the *next* pod screen and ride along until the host's next `pairingsGenerated` supersedes them or the user dismisses them. In a Bo3 that span reaches game 2 → a second `betweenGames` → game 3 → `roundComplete` → `pairing`. This is deliberate and still strictly better than the previous behaviour, where those errors were invisible everywhere; a scoped phase-transition clearing rule is the real fix and is recorded at the component.

## Not addressed

- `apply_advance_round` still inlines `session.current_round + 1` for its delta. Pre-existing, in-crate, and outside this change's scope — all three review rounds agreed.
- The heading string now carries two meanings across phases. The arithmetic is correct at every site and the `roundComplete` heading-vs-table mismatch predates this change; keeping it was a deliberate product decision.


https://claude.ai/code/session_0118J576jjG9stoucpv5vvyN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added accurate upcoming-round labels throughout draft standings.
  * Draft views now expose the next pairing round for consistent client displays.
  * Added dismissible error banners for multiplayer draft issues, with support across key draft phases.
  * Added error clearing after successful pairing generation.

* **Bug Fixes**
  * Restored drafts now correctly regenerate pairings during the pairing phase.
  * Improved recovery handling for stale or missing pairings.
  * Updated the draft protocol version to support the new round information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->