### PR TITLE
fix(engine,parser): target players each manifest from their hands (Kozilek, the Broken Reality)

### DIFF
--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -54,14 +54,34 @@ pub fn resolve(
     // candidate scan. Building block for Breach the Multiverse.
     // CR 102.2: `EachOpponent` is the same iteration with the controller
     // excluded ("for each OTHER player" — Kaya, Spirits' Justice).
-    if matches!(zone_owner, ZoneOwner::EachPlayer | ZoneOwner::EachOpponent) {
-        let players = if matches!(zone_owner, ZoneOwner::EachOpponent) {
-            crate::game::players::apnap_order(state)
+    if matches!(
+        zone_owner,
+        ZoneOwner::EachPlayer | ZoneOwner::EachOpponent | ZoneOwner::EachTargetedPlayer
+    ) {
+        let players = match zone_owner {
+            ZoneOwner::EachOpponent => crate::game::players::apnap_order(state)
                 .into_iter()
                 .filter(|&p| p != ability.controller)
-                .collect()
-        } else {
-            crate::game::players::apnap_order(state)
+                .collect(),
+            // CR 115.1 + CR 101.4: the iterated set is the ability's CHOSEN
+            // `Player` targets, walked in APNAP order. CR 601.2c: an "up to N"
+            // selection may be empty — the loop then disposes immediately and
+            // the parked continuation runs with an empty tracked set.
+            ZoneOwner::EachTargetedPlayer => {
+                let chosen: Vec<PlayerId> = ability
+                    .targets
+                    .iter()
+                    .filter_map(|t| match t {
+                        TargetRef::Player(pid) => Some(*pid),
+                        _ => None,
+                    })
+                    .collect();
+                crate::game::players::apnap_order(state)
+                    .into_iter()
+                    .filter(|pid| chosen.contains(pid))
+                    .collect()
+            }
+            _ => crate::game::players::apnap_order(state),
         };
         // No pick has accumulated yet — the first one must start a fresh set.
         return prompt_next_each_player(state, ability, players, false, events);
@@ -733,7 +753,13 @@ fn prompt_next_each_player(
         // CR 101.4 + CR 608.2c: For "for each player, choose ...", the spell's controller is
         // the chooser regardless of whose zone is scanned (Breach the
         // Multiverse). `Chooser::Opponent` would route to an opponent; honor it.
-        let choosing_player = resolve_chooser(state, ability, chooser);
+        // `Chooser::OwningPlayer` binds the choice to THIS iteration's owner —
+        // each player picks from their own (hidden) zone (Kozilek, the Broken
+        // Reality: "target players each manifest two cards from their hands").
+        let choosing_player = match chooser {
+            Chooser::OwningPlayer => owner,
+            _ => resolve_chooser(state, ability, chooser),
+        };
 
         // CR 608.2: The per-player frame is inserted above the continuation
         // that runs after every player has chosen. Capture the live trigger
@@ -1025,10 +1051,12 @@ fn resolve_zone_owner(
         // CR 101.4: `EachPlayer` / `EachOpponent` resolve a *set* of zone
         // owners, not one — they are handled by `prompt_next_each_player`, which
         // scans each iterated player's zone directly and never routes here.
-        ZoneOwner::EachPlayer | ZoneOwner::EachOpponent => Err(EffectError::MissingParam(
-            "ChooseFromZone EachPlayer/EachOpponent resolves per-player, not via single owner"
-                .to_string(),
-        )),
+        ZoneOwner::EachPlayer | ZoneOwner::EachOpponent | ZoneOwner::EachTargetedPlayer => {
+            Err(EffectError::MissingParam(
+                "ChooseFromZone Each* zone owners resolve per-player, not via single owner"
+                    .to_string(),
+            ))
+        }
         // CR 400.1: `AllOwners` scans a zone shared across EVERY owner, not a
         // single one — it is handled by the early return in
         // `collect_direct_zone_cards` and never routes through this
@@ -1108,6 +1136,18 @@ fn resolve_chooser(state: &GameState, ability: &ResolvedAbility, chooser: Choose
                 .next()
                 .unwrap_or(ability.controller)
         }
+        // CR 608.2c: the resolved zone owner makes the choice. Under an
+        // `Each*` zone owner the per-iteration loop passes the iterated owner
+        // directly (`prompt_next_each_player`) and never routes here; the
+        // single-owner forms resolve through the shared zone-owner authority,
+        // failing closed to the controller (CR 608.2d: an impossible choice is
+        // not offered).
+        Chooser::OwningPlayer => match &ability.effect {
+            Effect::ChooseFromZone { zone_owner, .. } => {
+                resolve_zone_owner(state, ability, *zone_owner).unwrap_or(ability.controller)
+            }
+            _ => ability.controller,
+        },
     }
 }
 

--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -631,13 +631,12 @@ pub(crate) fn resolve_random_in_chain(
         _ => return false,
     };
 
-    // CR 608.2d: `Each` is the one zone owner with no single candidate pool —
-    // it resolves one prompt per player — so it cannot be answered here, and a
-    // per-player random pick is unbuilt. No parse produces the combination (of
-    // the 43 cards whose text carries per-player wording, none say "at
-    // random"), so the guard lives in this function rather than in a hand-kept
-    // list: without it the error reads as an empty pool and the chain silently
-    // does nothing. Release behavior is unchanged.
+    // CR 608.2d: `Each` has no single candidate pool, and a per-player random
+    // pick is unbuilt. No parse produces the combination (of the 43 cards whose
+    // text carries per-player wording, none say "at random"), so rather than
+    // build speculative machinery the pool authority rejects the owner up front
+    // and this arm keeps the rejection loud instead of reading it as an empty
+    // pool. Release behavior is a no-op resolution, as before.
     let cards = match resolve_candidate_cards(
         state,
         ability,
@@ -884,6 +883,17 @@ fn collect_player_zone_cards(
 /// 2. The latest non-empty tracked set from any prior publish in this game.
 /// 3. Explicit `TargetRef::Object` targets on the ability.
 /// 4. Direct zone scan (`zone` + `additional_zones`).
+///
+/// CR 101.4: a per-player [`ZoneOwner::Each`] has no single pool at all — it
+/// resolves one prompt per player through `prompt_next_each_player` — so it is
+/// rejected here rather than deeper in the owner resolution. The rejection has
+/// to precede the tracked-set fast paths above: those return before the owner
+/// is ever read, which would otherwise hand a per-player choice the whole
+/// global or prior-chain set. No caller reaches this with `Each` on a supported
+/// path (`resolve` returns to the per-player iteration first, and
+/// `resolve_with_choosing_player` is only entered from below that return), so
+/// the arm exists to keep an unsupported combination loud instead of silently
+/// answered.
 fn resolve_candidate_cards(
     state: &GameState,
     ability: &ResolvedAbility,
@@ -892,6 +902,12 @@ fn resolve_candidate_cards(
     zone_owner: ZoneOwner,
     filter: Option<&TargetFilter>,
 ) -> Result<Vec<ObjectId>, EffectError> {
+    if matches!(zone_owner, ZoneOwner::Each(_)) {
+        return Err(EffectError::MissingParam(
+            "ChooseFromZone Each resolves per-player and has no single candidate pool".to_string(),
+        ));
+    }
+
     if let Some(cards) = chain_tracked_set_cards(state) {
         return Ok(retain_matching_candidates(state, ability, cards, filter));
     }

--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -1011,8 +1011,10 @@ fn per_player_iteration_population(
     let apnap = crate::game::players::apnap_order(state);
     match scope {
         PerPlayerScope::AllPlayers => apnap,
-        // CR 102.2: "each OTHER player" excludes the controller.
-        PerPlayerScope::Opponents => apnap
+        // CR 102.3: "each OTHER player" is every player but the controller.
+        // Deliberately not `players::opponents`: that set is team-relative and
+        // excludes a teammate, whom this wording includes.
+        PerPlayerScope::OtherPlayers => apnap
             .into_iter()
             .filter(|&p| p != ability.controller)
             .collect(),
@@ -3430,7 +3432,7 @@ mod tests {
                 count: 1,
                 zone: Zone::Battlefield,
                 additional_zones: Vec::new(),
-                zone_owner: ZoneOwner::Each(PerPlayerScope::Opponents),
+                zone_owner: ZoneOwner::Each(PerPlayerScope::OtherPlayers),
                 filter: None,
                 chooser: Chooser::Controller,
                 up_to: true,
@@ -3511,7 +3513,7 @@ mod tests {
                 count: 1,
                 zone: Zone::Battlefield,
                 additional_zones: Vec::new(),
-                zone_owner: ZoneOwner::Each(PerPlayerScope::Opponents),
+                zone_owner: ZoneOwner::Each(PerPlayerScope::OtherPlayers),
                 filter: None,
                 chooser: Chooser::Controller,
                 up_to: true,

--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -52,7 +52,7 @@ pub fn resolve(
     // accumulating each pick into the chain's tracked set. Routed here before
     // the single-pool path so the per-player prompts never collapse into one
     // candidate scan. Building block for Breach the Multiverse.
-    // CR 102.2: `EachOpponent` is the same iteration with the controller
+    // CR 102.3: `Each(OtherPlayers)` is the same iteration with the controller
     // excluded ("for each OTHER player" — Kaya, Spirits' Justice).
     if let ZoneOwner::Each(scope) = zone_owner {
         let players = per_player_iteration_population(state, ability, scope);
@@ -631,15 +631,30 @@ pub(crate) fn resolve_random_in_chain(
         _ => return false,
     };
 
-    let cards = resolve_candidate_cards(
+    // CR 608.2d: `Each` is the one zone owner with no single candidate pool —
+    // it resolves one prompt per player — so it cannot be answered here, and a
+    // per-player random pick is unbuilt. No parse produces the combination (of
+    // the 43 cards whose text carries per-player wording, none say "at
+    // random"), so the guard lives in this function rather than in a hand-kept
+    // list: without it the error reads as an empty pool and the chain silently
+    // does nothing. Release behavior is unchanged.
+    let cards = match resolve_candidate_cards(
         state,
         ability,
         zone,
         &additional_zones,
         zone_owner,
         filter.as_ref(),
-    )
-    .unwrap_or_default();
+    ) {
+        Ok(cards) => cards,
+        Err(_) => {
+            debug_assert!(
+                !matches!(zone_owner, ZoneOwner::Each(_)),
+                "a random ChooseFromZone with a per-player zone owner has no resolution path"
+            );
+            Vec::new()
+        }
+    };
 
     // CR 609.3: An empty pool (or count 0) does nothing; the chain then skips
     // any continuation that depends on the missing pick.

--- a/crates/engine/src/game/effects/choose_from_zone.rs
+++ b/crates/engine/src/game/effects/choose_from_zone.rs
@@ -4,7 +4,7 @@ use crate::game::filter::{matches_target_filter, FilterContext};
 use crate::game::players;
 use crate::types::ability::{
     ChooseFromZoneConstraint, Chooser, Effect, EffectError, EffectKind, ForEachCategoryAction,
-    ParentTargetMissingReason, ResolvedAbility, TargetFilter, TargetRef, ZoneOwner,
+    ParentTargetMissingReason, PerPlayerScope, ResolvedAbility, TargetFilter, TargetRef, ZoneOwner,
 };
 use crate::types::card_type::CoreType;
 use crate::types::events::GameEvent;
@@ -54,35 +54,8 @@ pub fn resolve(
     // candidate scan. Building block for Breach the Multiverse.
     // CR 102.2: `EachOpponent` is the same iteration with the controller
     // excluded ("for each OTHER player" — Kaya, Spirits' Justice).
-    if matches!(
-        zone_owner,
-        ZoneOwner::EachPlayer | ZoneOwner::EachOpponent | ZoneOwner::EachTargetedPlayer
-    ) {
-        let players = match zone_owner {
-            ZoneOwner::EachOpponent => crate::game::players::apnap_order(state)
-                .into_iter()
-                .filter(|&p| p != ability.controller)
-                .collect(),
-            // CR 115.1 + CR 101.4: the iterated set is the ability's CHOSEN
-            // `Player` targets, walked in APNAP order. CR 601.2c: an "up to N"
-            // selection may be empty — the loop then disposes immediately and
-            // the parked continuation runs with an empty tracked set.
-            ZoneOwner::EachTargetedPlayer => {
-                let chosen: Vec<PlayerId> = ability
-                    .targets
-                    .iter()
-                    .filter_map(|t| match t {
-                        TargetRef::Player(pid) => Some(*pid),
-                        _ => None,
-                    })
-                    .collect();
-                crate::game::players::apnap_order(state)
-                    .into_iter()
-                    .filter(|pid| chosen.contains(pid))
-                    .collect()
-            }
-            _ => crate::game::players::apnap_order(state),
-        };
+    if let ZoneOwner::Each(scope) = zone_owner {
+        let players = per_player_iteration_population(state, ability, scope);
         // No pick has accumulated yet — the first one must start a fresh set.
         return prompt_next_each_player(state, ability, players, false, events);
     }
@@ -1027,6 +1000,43 @@ fn collect_direct_zone_cards(
         .collect())
 }
 
+/// CR 101.4: The players a [`ZoneOwner::Each`] iteration walks, in APNAP order.
+/// One authority for every population leaf, so a new leaf is a match arm here
+/// rather than a new `ZoneOwner` sibling.
+fn per_player_iteration_population(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    scope: PerPlayerScope,
+) -> Vec<PlayerId> {
+    let apnap = crate::game::players::apnap_order(state);
+    match scope {
+        PerPlayerScope::AllPlayers => apnap,
+        // CR 102.2: "each OTHER player" excludes the controller.
+        PerPlayerScope::Opponents => apnap
+            .into_iter()
+            .filter(|&p| p != ability.controller)
+            .collect(),
+        // CR 115.1: the iterated set is the ability's CHOSEN `Player` targets.
+        // CR 601.2c: an "up to N" selection may be empty — the loop then
+        // disposes immediately and the parked continuation runs with an empty
+        // tracked set.
+        PerPlayerScope::TargetedPlayers => {
+            let chosen: Vec<PlayerId> = ability
+                .targets
+                .iter()
+                .filter_map(|t| match t {
+                    TargetRef::Player(pid) => Some(*pid),
+                    _ => None,
+                })
+                .collect();
+            apnap
+                .into_iter()
+                .filter(|pid| chosen.contains(pid))
+                .collect()
+        }
+    }
+}
+
 fn resolve_zone_owner(
     state: &GameState,
     ability: &ResolvedAbility,
@@ -1051,12 +1061,12 @@ fn resolve_zone_owner(
         // CR 101.4: `EachPlayer` / `EachOpponent` resolve a *set* of zone
         // owners, not one — they are handled by `prompt_next_each_player`, which
         // scans each iterated player's zone directly and never routes here.
-        ZoneOwner::EachPlayer | ZoneOwner::EachOpponent | ZoneOwner::EachTargetedPlayer => {
-            Err(EffectError::MissingParam(
-                "ChooseFromZone Each* zone owners resolve per-player, not via single owner"
-                    .to_string(),
-            ))
-        }
+        // CR 101.4: `Each` resolves a *set* of zone owners, not one — it is
+        // handled by `prompt_next_each_player`, which scans each iterated
+        // player's zone directly and never routes here.
+        ZoneOwner::Each(_) => Err(EffectError::MissingParam(
+            "ChooseFromZone Each resolves per-player, not via a single owner".to_string(),
+        )),
         // CR 400.1: `AllOwners` scans a zone shared across EVERY owner, not a
         // single one — it is handled by the early return in
         // `collect_direct_zone_cards` and never routes through this
@@ -3420,7 +3430,7 @@ mod tests {
                 count: 1,
                 zone: Zone::Battlefield,
                 additional_zones: Vec::new(),
-                zone_owner: ZoneOwner::EachOpponent,
+                zone_owner: ZoneOwner::Each(PerPlayerScope::Opponents),
                 filter: None,
                 chooser: Chooser::Controller,
                 up_to: true,
@@ -3501,7 +3511,7 @@ mod tests {
                 count: 1,
                 zone: Zone::Battlefield,
                 additional_zones: Vec::new(),
-                zone_owner: ZoneOwner::EachOpponent,
+                zone_owner: ZoneOwner::Each(PerPlayerScope::Opponents),
                 filter: None,
                 chooser: Chooser::Controller,
                 up_to: true,
@@ -3600,7 +3610,7 @@ mod tests {
                     count: 1,
                     zone: Zone::Graveyard,
                     additional_zones: Vec::new(),
-                    zone_owner: ZoneOwner::EachPlayer,
+                    zone_owner: ZoneOwner::Each(PerPlayerScope::AllPlayers),
                     filter: None,
                     chooser: Chooser::Controller,
                     up_to: false,
@@ -3674,7 +3684,7 @@ mod tests {
                     count: 1,
                     zone: Zone::Graveyard,
                     additional_zones: Vec::new(),
-                    zone_owner: ZoneOwner::EachPlayer,
+                    zone_owner: ZoneOwner::Each(PerPlayerScope::AllPlayers),
                     filter: None,
                     chooser: Chooser::Controller,
                     up_to: false,

--- a/crates/engine/src/game/effects/manifest.rs
+++ b/crates/engine/src/game/effects/manifest.rs
@@ -1,5 +1,5 @@
 use crate::game::quantity::resolve_quantity_with_targets;
-use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility};
+use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility, TargetFilter};
 use crate::types::events::GameEvent;
 use crate::types::game_state::GameState;
 
@@ -61,6 +61,53 @@ pub fn resolve(
     let profile = profile.unwrap_or_else(crate::types::ability::FaceDownProfile::vanilla_2_2);
 
     match object_source {
+        // CR 701.40a + CR 101.4: Manifest the chain's accumulated TRACKED SET —
+        // the per-player picks an `Each*`-owned `ChooseFromZone` collected
+        // ("up to two target players each manifest two cards from their
+        // hands", Kozilek, the Broken Reality). Unlike Cloak's tracked-set arm
+        // (Expose the Culprit), the members live in non-battlefield zones
+        // (their owners' hands), so `manifest_card` is a real move with no
+        // exile dance. `controller: None` keeps the CR 701.40a owner default —
+        // each card enters under the control of the player who chose it from
+        // their own hand.
+        Some(TargetFilter::TrackedSet { .. }) => {
+            // CR 608.2c: bind the `TrackedSetId(0)` sentinel to the chain's
+            // published pick set (mirrors the Cloak arm).
+            let member_ids: Vec<crate::types::identifiers::ObjectId> =
+                match crate::game::targeting::resolve_tracked_set_sentinel(
+                    state,
+                    TargetFilter::TrackedSet {
+                        id: crate::types::identifiers::TrackedSetId(0),
+                    },
+                ) {
+                    TargetFilter::TrackedSet { id } => state
+                        .tracked_object_sets
+                        .get(&id)
+                        .cloned()
+                        .unwrap_or_default(),
+                    _ => Vec::new(),
+                };
+            // CR 608.2c: the chain's referent now changes hands — the picks
+            // have been read, and what follows ("for each card manifested this
+            // way") must count the MANIFESTED cards, not the chosen ones. Rebind
+            // to a fresh chain set so the shared post-effect publisher records
+            // exactly the manifest results; leaving the pick set in place would
+            // double-count every card (mirrors the fresh-set rebind in
+            // `choose_from_zone::drain_active_per_player_zone_choice`).
+            super::publish_fresh_tracked_set(state, Vec::new());
+            for object_id in member_ids {
+                crate::game::morph::manifest_card(
+                    state,
+                    player,
+                    object_id,
+                    ability.source_id,
+                    profile.clone(),
+                    controller,
+                    events,
+                )
+                .map_err(|e| EffectError::MissingParam(format!("{e}")))?;
+            }
+        }
         // CR 701.40a: Manifest explicit objects forwarded onto
         // `ability.targets` by a parent `ChooseFromZone` (Scroll of Fate's
         // "manifest a card from your hand"). Those cards live in a

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -10414,8 +10414,21 @@ fn resolve_chain_body(
     // rider (Court of Cunning — "each mill two … mills ten instead") clears
     // `multi_target` and changes the effect's target filter, which would
     // otherwise skip this branch and resolve only the first chosen player.
+    // CR 101.4: An effect that ALREADY iterates the chosen player targets on
+    // its own (`ChooseFromZone { zone_owner: EachTargetedPlayer }`) is not a
+    // single-player-recipient handler, so it needs no missing iteration layer —
+    // and must not get one: splitting it per player would give each iteration
+    // its own chain tracked set, breaking the single accumulated "this way" set
+    // its sub-chain reads (Kozilek, the Broken Reality).
     if ability.multi_target.is_some()
         && effect_target_filter(&ability.effect).is_some_and(is_multi_target_player_filter)
+        && !matches!(
+            ability.effect,
+            Effect::ChooseFromZone {
+                zone_owner: crate::types::ability::ZoneOwner::EachTargetedPlayer,
+                ..
+            }
+        )
     {
         let chosen_players: Vec<PlayerId> = ability
             .targets

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -10425,7 +10425,7 @@ fn resolve_chain_body(
         && !matches!(
             ability.effect,
             Effect::ChooseFromZone {
-                zone_owner: crate::types::ability::ZoneOwner::EachTargetedPlayer,
+                zone_owner: crate::types::ability::ZoneOwner::Each(_),
                 ..
             }
         )

--- a/crates/engine/src/game/effects/vote.rs
+++ b/crates/engine/src/game/effects/vote.rs
@@ -717,7 +717,8 @@ mod tests {
     use super::*;
     use crate::game::zones::create_object;
     use crate::types::ability::{
-        AbilityKind, CardSelectionMode, Chooser, TargetFilter, VoteVisibility, ZoneOwner,
+        AbilityKind, CardSelectionMode, Chooser, PerPlayerScope, TargetFilter, VoteVisibility,
+        ZoneOwner,
     };
     use crate::types::actions::GameAction;
     use crate::types::identifiers::{CardId, ObjectId};
@@ -1163,7 +1164,7 @@ mod tests {
                     count: 1,
                     zone: Zone::Graveyard,
                     additional_zones: Vec::new(),
-                    zone_owner: ZoneOwner::EachPlayer,
+                    zone_owner: ZoneOwner::Each(PerPlayerScope::AllPlayers),
                     filter: None,
                     chooser: Chooser::Controller,
                     up_to: false,

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -19360,7 +19360,7 @@ mod stage2_injector_tests {
                 // production producers, and each remains in its named function.
                 "game/effects/mod.rs:7356".to_string(),
                 "game/effects/mod.rs:7433".to_string(),
-                "game/effects/mod.rs:11260".to_string(),
+                "game/effects/mod.rs:11273".to_string(),
                 // UNMOVED across the rebase, and that is itself evidence the SET did not
                 // move: a census that had gained or lost a producer would not leave this
                 // entry both byte-identical AND at the same coordinate.

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -4694,11 +4694,13 @@ fn parse_controlled_battlefield_body(
 /// optionally zero via "up to one"), accumulated into the chain's tracked set,
 /// then ALL chosen permanents are exiled (`ChangeZoneAll { TrackedSet }`).
 ///
-/// "for each player" iterates every player (`ZoneOwner::Each(PerPlayerScope::AllPlayers)`); "for each
-/// other player" excludes the controller (`ZoneOwner::Each(PerPlayerScope::Opponents)`). Emitted as
-/// a `ChooseFromZone { EachPlayer/EachOpponent }` clause with the mass-exile as
-/// its `sub_ability`, mirroring how the choose-only cards chain a separate
-/// "exile those" sentence.
+/// CR 101.4: "for each player" iterates every player in APNAP order
+/// (`PerPlayerScope::AllPlayers`). CR 102.3: "for each other player" is the same
+/// walk with the controller removed (`PerPlayerScope::OtherPlayers`) — every
+/// player except you, teammates included, which is why this is not the
+/// team-relative opponent set. Emitted as a `ChooseFromZone { Each(..) }` clause
+/// with the mass-exile as its `sub_ability`, mirroring how the choose-only cards
+/// chain a separate "exile those" sentence.
 pub(super) fn parse_for_each_player_exile_controlled(
     lower: &str,
     ctx: &mut ParseContext,
@@ -4707,11 +4709,11 @@ pub(super) fn parse_for_each_player_exile_controlled(
 
     let (after_prefix, iter_scope) = alt((
         value(
-            ZoneOwner::Each(PerPlayerScope::Opponents),
+            ZoneOwner::Each(PerPlayerScope::OtherPlayers),
             tag::<_, _, E>("for each other player, "),
         ),
         value(
-            ZoneOwner::Each(PerPlayerScope::Opponents),
+            ZoneOwner::Each(PerPlayerScope::OtherPlayers),
             tag("for each other player "),
         ),
         value(

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -39,8 +39,8 @@ use crate::types::ability::{
     CardSelectionMode, CategoryChooserScope, ChoiceType, Chooser, ContinuousModification,
     ControlWindow, ControllerRef, CopyRetargetPermission, CounterAdjustment, DigSource, DoorLockOp,
     Duration, Effect, EffectScope, FaceDownProfile, FilterProp, ForceBlockAttackerRef,
-    GrantedAbilityScope, LibraryPosition, MultiTargetSpec, OutsideGameSourcePool, PlayerScope,
-    PreventionAmount, PreventionScope, PtStat, PtValue, QuantityExpr, QuantityRef,
+    GrantedAbilityScope, LibraryPosition, MultiTargetSpec, OutsideGameSourcePool, PerPlayerScope,
+    PlayerScope, PreventionAmount, PreventionScope, PtStat, PtValue, QuantityExpr, QuantityRef,
     ReassembleControlMode, SearchSelectionConstraint, StaticDefinition, StickerTicketCostPayment,
     TapStateChange, TargetFilter, TargetSelectionMode, ThisWayCause, TypeFilter, TypedFilter,
     ZoneOwner,
@@ -4597,7 +4597,7 @@ pub(super) fn parse_for_each_player_choose_from_zone(
         return Some(ChooseImperativeAst::FromZone {
             count,
             zones,
-            zone_owner: ZoneOwner::EachPlayer,
+            zone_owner: ZoneOwner::Each(PerPlayerScope::AllPlayers),
             filter,
             chooser,
             up_to,
@@ -4694,8 +4694,8 @@ fn parse_controlled_battlefield_body(
 /// optionally zero via "up to one"), accumulated into the chain's tracked set,
 /// then ALL chosen permanents are exiled (`ChangeZoneAll { TrackedSet }`).
 ///
-/// "for each player" iterates every player (`ZoneOwner::EachPlayer`); "for each
-/// other player" excludes the controller (`ZoneOwner::EachOpponent`). Emitted as
+/// "for each player" iterates every player (`ZoneOwner::Each(PerPlayerScope::AllPlayers)`); "for each
+/// other player" excludes the controller (`ZoneOwner::Each(PerPlayerScope::Opponents)`). Emitted as
 /// a `ChooseFromZone { EachPlayer/EachOpponent }` clause with the mass-exile as
 /// its `sub_ability`, mirroring how the choose-only cards chain a separate
 /// "exile those" sentence.
@@ -4707,12 +4707,21 @@ pub(super) fn parse_for_each_player_exile_controlled(
 
     let (after_prefix, iter_scope) = alt((
         value(
-            ZoneOwner::EachOpponent,
+            ZoneOwner::Each(PerPlayerScope::Opponents),
             tag::<_, _, E>("for each other player, "),
         ),
-        value(ZoneOwner::EachOpponent, tag("for each other player ")),
-        value(ZoneOwner::EachPlayer, tag("for each player, ")),
-        value(ZoneOwner::EachPlayer, tag("for each player ")),
+        value(
+            ZoneOwner::Each(PerPlayerScope::Opponents),
+            tag("for each other player "),
+        ),
+        value(
+            ZoneOwner::Each(PerPlayerScope::AllPlayers),
+            tag("for each player, "),
+        ),
+        value(
+            ZoneOwner::Each(PerPlayerScope::AllPlayers),
+            tag("for each player "),
+        ),
     ))
     .parse(lower)
     .ok()?;

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -110,15 +110,15 @@ use crate::types::ability::{
     EffectScope, FilterProp, GameRestriction, GuessSubject, IntensityScope, IterationKindBinding,
     KeeperConstraint, LibraryPosition, ManaProduction, ManaSpendPermission, ManaTargetRole,
     MultiTargetSpec, NumberDistinctness, ObjectProperty, ObjectScope, OriginConstraint,
-    PerpetualModification, PlayPermissionInvalidation, PlayerChoiceDistinctness, PlayerFilter,
-    PlayerRelation, PlayerScope, PreventionAmount, PreventionScope, ProhibitedActivity, PtValue,
-    QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition, RestrictionExpiry,
-    RestrictionPlayerScope, RevealUntilDisposition, RoundingMode, SharedQuality,
-    SharedQualityRelation, SiblingCondition, SkipScope, SpellStackToGraveyardReplacement,
-    StaticCondition, StaticDefinition, StepSkipTarget, SubAbilityLink, TapStateChange,
-    TargetFilter, TargetSelectionMode, ThisWayCause, TrackedAnaphorSource, TriggerCondition,
-    TriggerDefinition, TurnGate, TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition,
-    WheneverEventExpiry, ZoneOwner,
+    PerPlayerScope, PerpetualModification, PlayPermissionInvalidation, PlayerChoiceDistinctness,
+    PlayerFilter, PlayerRelation, PlayerScope, PreventionAmount, PreventionScope,
+    ProhibitedActivity, PtValue, QuantityExpr, QuantityRef, ReplacementCondition,
+    ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope, RevealUntilDisposition,
+    RoundingMode, SharedQuality, SharedQualityRelation, SiblingCondition, SkipScope,
+    SpellStackToGraveyardReplacement, StaticCondition, StaticDefinition, StepSkipTarget,
+    SubAbilityLink, TapStateChange, TargetFilter, TargetSelectionMode, ThisWayCause,
+    TrackedAnaphorSource, TriggerCondition, TriggerDefinition, TurnGate, TypeFilter, TypedFilter,
+    UnlessPayModifier, UntilCondition, WheneverEventExpiry, ZoneOwner,
 };
 #[cfg(test)]
 use crate::types::ability::{AttackScope, AttackSubject};
@@ -21363,7 +21363,7 @@ fn lower_subject_predicate_ast(
             // manifest[s] <N> card[s] from their hand[s]" (Kozilek, the Broken
             // Reality). Each targeted player picks the cards from their OWN
             // hidden hand during resolution: a `ChooseFromZone` iterated over
-            // the chosen player targets (`ZoneOwner::EachTargetedPlayer`),
+            // the chosen player targets (`ZoneOwner::Each(PerPlayerScope::TargetedPlayers)`),
             // each iteration's choice made by that owner
             // (`Chooser::OwningPlayer`), accumulating the picks into the
             // chain's tracked set. The `Manifest` sub-ability then manifests
@@ -21404,7 +21404,9 @@ fn lower_subject_predicate_ast(
                                 // `targets` to that one player — so the
                                 // per-iteration zone is simply "the
                                 // targeted player's".
-                                zone_owner: crate::types::ability::ZoneOwner::EachTargetedPlayer,
+                                zone_owner: crate::types::ability::ZoneOwner::Each(
+                                    PerPlayerScope::TargetedPlayers,
+                                ),
                                 filter: None,
                                 chooser: crate::types::ability::Chooser::OwningPlayer,
                                 up_to: false,

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -21359,6 +21359,79 @@ fn lower_subject_predicate_ast(
                     enters_under: None,
                 });
             }
+            // CR 701.40a + CR 101.4 + CR 608.2c: "<target players> [each]
+            // manifest[s] <N> card[s] from their hand[s]" (Kozilek, the Broken
+            // Reality). Each targeted player picks the cards from their OWN
+            // hidden hand during resolution: a `ChooseFromZone` iterated over
+            // the chosen player targets (`ZoneOwner::EachTargetedPlayer`),
+            // each iteration's choice made by that owner
+            // (`Chooser::OwningPlayer`), accumulating the picks into the
+            // chain's tracked set. The `Manifest` sub-ability then manifests
+            // the accumulated set — each card under its chooser's control
+            // (CR 701.40a owner default) — and a trailing "for each card
+            // manifested this way" rider reads `TrackedSetSize`. Gated to the
+            // targeted-player subject; other from-hand subjects stay honest
+            // gaps.
+            if matches!(affected, TargetFilter::Player) {
+                if let Ok((after_verb, _)) =
+                    alt((tag::<_, _, OracleError<'_>>("manifest "), tag("manifests ")))
+                        .parse(pred_lower.as_str())
+                {
+                    if let Ok((after_count, n)) = nom_primitives::parse_number.parse(after_verb) {
+                        let from_their_hand = all_consuming((
+                            alt((tag::<_, _, OracleError<'_>>(" cards"), tag(" card"))),
+                            tag(" from their hand"),
+                            opt(tag("s")),
+                            opt(tag(".")),
+                        ))
+                        .parse(after_count)
+                        .is_ok();
+                        if from_their_hand {
+                            // CR 115.1 + CR 601.2c: the
+                            // `EachTargetedPlayer` choose declares the player
+                            // slots itself (see `Effect::target_filter`) and
+                            // iterates them in APNAP order, accumulating every
+                            // player's picks into ONE chain tracked set that
+                            // the manifest sub-chain then consumes.
+                            let mut clause = parsed_clause(Effect::ChooseFromZone {
+                                count: n,
+                                zone: Zone::Hand,
+                                additional_zones: Vec::new(),
+                                // CR 115.1 + CR 101.4: the shared
+                                // multi-target PLAYER fan-out already
+                                // resolves this chain once per chosen
+                                // player in APNAP order, narrowing
+                                // `targets` to that one player — so the
+                                // per-iteration zone is simply "the
+                                // targeted player's".
+                                zone_owner: crate::types::ability::ZoneOwner::EachTargetedPlayer,
+                                filter: None,
+                                chooser: crate::types::ability::Chooser::OwningPlayer,
+                                up_to: false,
+                                selection: crate::types::ability::CardSelectionMode::Chosen,
+                                constraint: None,
+                            });
+                            clause.sub_ability = Some(Box::new(AbilityDefinition::new(
+                                AbilityKind::Spell,
+                                Effect::Manifest {
+                                    target: affected.clone(),
+                                    count: QuantityExpr::Fixed { value: n as i32 },
+                                    object_source: Some(TargetFilter::TrackedSet {
+                                        id: crate::types::identifiers::TrackedSetId(0),
+                                    }),
+                                    profile: None,
+                                    enters_under: None,
+                                },
+                            )));
+                            // CR 115.1d: the subject phrase's target count
+                            // ("up to two target players") opens both slots.
+                            clause.multi_target = multi_target.clone();
+                            clause.optional = subject.is_optional;
+                            return clause;
+                        }
+                    }
+                }
+            }
             // NOTE (issue #6505, review follow-up): the predicate is lowered with
             // NO parse-time relative-scope pin. An earlier revision pinned
             // `relative_player_scope = ScopedPlayer` around this whole call, which

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -11407,7 +11407,7 @@ mod tests {
     #[test]
     fn breach_multiverse_assembles_per_player_reanimation_chain() {
         use super::super::parse_effect_chain;
-        use crate::types::ability::ZoneOwner;
+        use crate::types::ability::{PerPlayerScope, ZoneOwner};
 
         let def = parse_effect_chain(
             "Each player mills ten cards. For each player, choose a creature or planeswalker card in that player's graveyard. Put those cards onto the battlefield under your control. Then each creature you control becomes a Phyrexian in addition to its other types.",
@@ -11465,7 +11465,7 @@ mod tests {
         assert_eq!(*zone, Zone::Graveyard);
         assert_eq!(
             *zone_owner,
-            ZoneOwner::EachPlayer,
+            ZoneOwner::Each(PerPlayerScope::AllPlayers),
             "BLOCKER: 'for each player ... in that player's graveyard' must iterate every player"
         );
         assert_eq!(

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -11988,10 +11988,81 @@ fn kozilek_target_players_each_manifest_two_from_their_hands_parses() {
         .execute
         .as_ref()
         .expect("the cast trigger must carry a body");
-    let debug = format!("{execute:?}");
+
+    // CR 115.1 + CR 101.4 + CR 608.2c: the head is the per-player hand
+    // choose — two cards, from HAND, iterated over the chosen player TARGETS,
+    // each pick made by that player (not the caster).
     assert!(
-        !debug.contains("Unimplemented"),
-        "the per-player from-hand manifest must lower to a real chain, got: {debug}"
+        matches!(
+            execute.effect.as_ref(),
+            Effect::ChooseFromZone {
+                count: 2,
+                zone: Zone::Hand,
+                zone_owner: ZoneOwner::EachTargetedPlayer,
+                chooser: Chooser::OwningPlayer,
+                up_to: false,
+                ..
+            }
+        ),
+        "expected the per-player from-hand choose, got: {:?}",
+        execute.effect
+    );
+    // CR 115.1d: both "up to two target players" slots.
+    assert_eq!(
+        execute.multi_target,
+        Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 2 })),
+        "the up-to-two player target slots must survive onto the clause"
+    );
+
+    // CR 701.40a: the sub-chain manifests the accumulated picks.
+    let manifest = execute
+        .sub_ability
+        .as_ref()
+        .expect("the choose must chain a Manifest sub-ability");
+    assert!(
+        matches!(
+            manifest.effect.as_ref(),
+            Effect::Manifest {
+                target: TargetFilter::Player,
+                count: QuantityExpr::Fixed { value: 2 },
+                object_source: Some(TargetFilter::TrackedSet { .. }),
+                enters_under: None,
+                ..
+            }
+        ),
+        "the sub-ability must manifest the chain's tracked picks under their \
+         own owners' control, got: {:?}",
+        manifest.effect
+    );
+
+    // CR 608.2c: the pre-existing "for each card manifested this way, you
+    // draw a card" rider still rides behind the manifest, counting the
+    // chain's tracked set.
+    let draw = manifest
+        .sub_ability
+        .as_ref()
+        .expect("the draw rider must survive behind the manifest");
+    assert!(
+        matches!(
+            draw.effect.as_ref(),
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+                ..
+            }
+        ),
+        "expected the one-card draw rider, got: {:?}",
+        draw.effect
+    );
+    assert!(
+        matches!(
+            draw.repeat_for,
+            Some(QuantityExpr::Ref {
+                qty: QuantityRef::TrackedSetSize
+            })
+        ),
+        "the rider must repeat once per tracked (manifested) card, got: {:?}",
+        draw.repeat_for
     );
 }
 

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -11965,6 +11965,37 @@ fn effect_manifest_a_card_from_your_hand_lowers_to_choose_from_zone_then_manifes
 }
 
 #[test]
+fn kozilek_target_players_each_manifest_two_from_their_hands_parses() {
+    // CR 701.40a: "up to two target players each manifest two cards from
+    // their hands" (Kozilek, the Broken Reality). The subject machinery
+    // already captures the up-to-two player multi-target and the
+    // "For each card manifested this way, you draw a card" rider
+    // (repeat_for: TrackedSetSize); only the per-player from-hand manifest
+    // predicate must lower to a real effect chain. Reverting the predicate
+    // arm drops it to Effect::Unimplemented → this fails.
+    let parsed = parse_oracle_text(
+        "When you cast this spell, up to two target players each manifest two cards from their hands. For each card manifested this way, you draw a card.",
+        "Kozilek, the Broken Reality",
+        &[],
+        &["Creature".to_string()],
+        &["Eldrazi".to_string()],
+    );
+    let trigger = parsed
+        .triggers
+        .first()
+        .expect("the cast trigger must parse");
+    let execute = trigger
+        .execute
+        .as_ref()
+        .expect("the cast trigger must carry a body");
+    let debug = format!("{execute:?}");
+    assert!(
+        !debug.contains("Unimplemented"),
+        "the per-player from-hand manifest must lower to a real chain, got: {debug}"
+    );
+}
+
+#[test]
 fn turn_face_up_then_conditional_put_keeps_follow_up_clause() {
     // CR 406.3 + CR 701.20a: Clone Shell / Summoner's Egg dies-trigger effect. The
     // "turn the exiled card face up" clause must NOT swallow the trailing

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -11998,7 +11998,7 @@ fn kozilek_target_players_each_manifest_two_from_their_hands_parses() {
             Effect::ChooseFromZone {
                 count: 2,
                 zone: Zone::Hand,
-                zone_owner: ZoneOwner::EachTargetedPlayer,
+                zone_owner: ZoneOwner::Each(PerPlayerScope::TargetedPlayers),
                 chooser: Chooser::OwningPlayer,
                 up_to: false,
                 // CR 608.2d: each player CHOOSES — a regression to a random

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -12001,6 +12001,9 @@ fn kozilek_target_players_each_manifest_two_from_their_hands_parses() {
                 zone_owner: ZoneOwner::EachTargetedPlayer,
                 chooser: Chooser::OwningPlayer,
                 up_to: false,
+                // CR 608.2d: each player CHOOSES — a regression to a random
+                // or non-choice selection mode must fail here.
+                selection: CardSelectionMode::Chosen,
                 ..
             }
         ),
@@ -12025,7 +12028,11 @@ fn kozilek_target_players_each_manifest_two_from_their_hands_parses() {
             Effect::Manifest {
                 target: TargetFilter::Player,
                 count: QuantityExpr::Fixed { value: 2 },
-                object_source: Some(TargetFilter::TrackedSet { .. }),
+                // CR 608.2c: the manifest must consume THIS chain's picks —
+                // the `TrackedSetId(0)` sentinel the choose publishes into.
+                object_source: Some(TargetFilter::TrackedSet {
+                    id: TrackedSetId(0)
+                }),
                 enters_under: None,
                 ..
             }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -183,7 +183,7 @@ mod trigger_occurrence_tests {
     }
 }
 
-/// CR 101.4 + CR 102.2 + CR 115.1: Which players a [`ZoneOwner::Each`]
+/// CR 101.4 + CR 102.3 + CR 115.1: Which players a [`ZoneOwner::Each`]
 /// iteration walks, in APNAP order. This is the population axis of the
 /// per-player iteration — the machinery (one parked choice per player,
 /// accumulating into the chain's tracked set) is identical for every leaf, so
@@ -193,9 +193,15 @@ pub enum PerPlayerScope {
     /// CR 101.4: every player in the game.
     #[default]
     AllPlayers,
-    /// CR 102.2: every opponent of the ability's controller (the controller is
-    /// excluded).
-    Opponents,
+    /// CR 102.3: every player OTHER than the ability's controller — the
+    /// population of "for each other player" (Kaya, Spirits' Justice).
+    /// Deliberately NOT "each opponent": CR 102.3 makes a teammate one of the
+    /// "other players on their team" while excluding them from that player's
+    /// opponents, so in a team format a teammate belongs in this population and
+    /// would be wrongly dropped by `players::opponents`. An opponent-scoped
+    /// population is a different leaf, to be added here (resolved through
+    /// `players::opponents`) when a card's wording asks for one.
+    OtherPlayers,
     /// CR 115.1: every player chosen as a `Player` target of the resolving
     /// ability. CR 601.2c: an "up to N" selection may be empty, which disposes
     /// the iteration immediately.
@@ -238,7 +244,7 @@ pub enum ZoneOwner {
     /// regardless of who owns each card — and Koh typically exiles *opponents'*
     /// creatures, so gating to the controller's own exiled cards empties the
     /// pool. This is the single-pool owner-agnostic leaf of the scope axis:
-    /// distinct from [`ZoneOwner::Each(PerPlayerScope::AllPlayers)`]/[`ZoneOwner::Each(PerPlayerScope::Opponents)`],
+    /// distinct from [`ZoneOwner::Each(PerPlayerScope::AllPlayers)`]/[`ZoneOwner::Each(PerPlayerScope::OtherPlayers)`],
     /// which iterate one prompt per player and accumulate into a tracked set —
     /// this raises ONE prompt over the whole-zone union. Mirrors the
     /// `ScopedPlayer`-on-Battlefield branch in `collect_direct_zone_cards`
@@ -276,7 +282,10 @@ impl From<ZoneOwnerRepr> for ZoneOwner {
             ZoneOwnerRepr::Each(scope) => ZoneOwner::Each(scope),
             ZoneOwnerRepr::AllOwners => ZoneOwner::AllOwners,
             ZoneOwnerRepr::EachPlayer => ZoneOwner::Each(PerPlayerScope::AllPlayers),
-            ZoneOwnerRepr::EachOpponent => ZoneOwner::Each(PerPlayerScope::Opponents),
+            // The legacy name said "Opponent", but the only wording that ever
+            // produced it is "for each other player" — CR 102.3 keeps those
+            // apart, so the migration maps it onto the population it always had.
+            ZoneOwnerRepr::EachOpponent => ZoneOwner::Each(PerPlayerScope::OtherPlayers),
             ZoneOwnerRepr::EachTargetedPlayer => ZoneOwner::Each(PerPlayerScope::TargetedPlayers),
         }
     }
@@ -311,7 +320,7 @@ mod zone_owner_migration_tests {
             ),
             (
                 "\"EachOpponent\"",
-                ZoneOwner::Each(PerPlayerScope::Opponents),
+                ZoneOwner::Each(PerPlayerScope::OtherPlayers),
             ),
             (
                 "\"EachTargetedPlayer\"",
@@ -28811,7 +28820,7 @@ mod tests {
             ZoneOwner::Opponent,
             ZoneOwner::ScopedPlayer,
             ZoneOwner::Each(PerPlayerScope::AllPlayers),
-            ZoneOwner::Each(PerPlayerScope::Opponents),
+            ZoneOwner::Each(PerPlayerScope::OtherPlayers),
             ZoneOwner::Each(PerPlayerScope::TargetedPlayers),
             ZoneOwner::AllOwners,
         ] {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -46,6 +46,12 @@ pub enum Chooser {
     /// An opponent of the controller makes the choice (CR 608.2e).
     /// In 2-player, the single opponent. In multiplayer, controller chooses which opponent.
     Opponent,
+    /// CR 608.2c + CR 101.4: The player whose zone is being scanned makes the
+    /// choice — the per-iteration owner under an `Each*` zone owner (each
+    /// targeted player picks from their OWN hand, hidden from everyone else:
+    /// Kozilek, the Broken Reality), or the single resolved zone owner
+    /// otherwise.
+    OwningPlayer,
 }
 
 #[cfg(test)]
@@ -208,6 +214,13 @@ pub enum ZoneOwner {
     /// Kaya, Spirits' Justice's −2 ("For each other player, exile up to one
     /// target creature that player controls").
     EachOpponent,
+    /// CR 101.4 + CR 115.1 + CR 608.2c: Every player chosen as a `Player`
+    /// TARGET of the resolving ability owns a referenced zone, iterated in
+    /// APNAP order — the targeted-set leaf of the per-player iteration axis,
+    /// same accumulate-into-tracked-set machinery as [`ZoneOwner::EachPlayer`].
+    /// Building block for "up to two target players each manifest two cards
+    /// from their hands" (Kozilek, the Broken Reality).
+    EachTargetedPlayer,
     /// CR 400.1 + CR 607.2a: The referenced zone is scanned across ALL owners —
     /// ownership imposes no restriction, and the effect's `TargetFilter`
     /// performs every bit of scoping. Used when the candidate pool's membership
@@ -16823,6 +16836,17 @@ impl Effect {
 
     pub fn target_filter(&self) -> Option<&TargetFilter> {
         match self {
+            // CR 115.1 + CR 601.2c: a `ChooseFromZone` is normally a resolution
+            // CHOICE with no stack-declared target — EXCEPT the
+            // `EachTargetedPlayer` iteration, whose iterated set IS the
+            // ability's chosen player targets ("up to two target players each
+            // manifest two cards from their hands"). That form must declare the
+            // player slots so the targets exist to iterate.
+            Effect::ChooseFromZone {
+                zone_owner: ZoneOwner::EachTargetedPlayer,
+                ..
+            } => Some(&TargetFilter::Player),
+            Effect::ChooseFromZone { .. } => None,
             // --- Effects with a `target: TargetFilter` field ---
             Effect::DealDamage { target, .. }
             // CR 115.1 + CR 725.1: "target opponent becomes the monarch". The
@@ -17221,7 +17245,6 @@ impl Effect {
             // enters, choose a creature" is an as-enters replacement CHOICE picked
             // via `WaitingFor::CopyTargetChoice`, never a stack-declared target.
             | Effect::ChoosePermanent { .. }
-            | Effect::ChooseFromZone { .. }
             | Effect::ForEachCategory { .. }
             | Effect::ChooseAndSacrificeRest { .. }
             | Effect::EachPlayerCopyChosen { .. }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -183,9 +183,29 @@ mod trigger_occurrence_tests {
     }
 }
 
+/// CR 101.4 + CR 102.2 + CR 115.1: Which players a [`ZoneOwner::Each`]
+/// iteration walks, in APNAP order. This is the population axis of the
+/// per-player iteration — the machinery (one parked choice per player,
+/// accumulating into the chain's tracked set) is identical for every leaf, so
+/// the population is a parameter rather than a sibling variant.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum PerPlayerScope {
+    /// CR 101.4: every player in the game.
+    #[default]
+    AllPlayers,
+    /// CR 102.2: every opponent of the ability's controller (the controller is
+    /// excluded).
+    Opponents,
+    /// CR 115.1: every player chosen as a `Player` target of the resolving
+    /// ability. CR 601.2c: an "up to N" selection may be empty, which disposes
+    /// the iteration immediately.
+    TargetedPlayers,
+}
+
 /// CR 400.1 + CR 608.2c: Which player's zone supplies cards for a direct
 /// zone choice during resolution.
 #[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[serde(from = "ZoneOwnerRepr", into = "ZoneOwnerRepr")]
 pub enum ZoneOwner {
     /// The controller of the spell/ability owns the referenced zone.
     #[default]
@@ -199,28 +219,14 @@ pub enum ZoneOwner {
     /// pool is "permanents owned by the voter". For Battlefield, filters
     /// by `obj.owner` (ownership) rather than `obj.controller` (control).
     ScopedPlayer,
-    /// CR 101.4 + CR 608.2c: Every player owns a referenced zone, iterated in
-    /// APNAP order. A `ChooseFromZone { zone_owner: EachPlayer }` parks one
-    /// choice per player, drawing candidates from THAT player's zone, and
-    /// accumulates each pick into the resolution chain's tracked object set.
-    /// Building block for Breach the Multiverse ("For each player, choose a
-    /// creature or planeswalker card in that player's graveyard").
-    EachPlayer,
-    /// CR 101.4 + CR 102.2 + CR 608.2c: Every OPPONENT of the controller owns a
-    /// referenced zone, iterated in APNAP order (the controller is excluded).
-    /// The each-opponent leaf of the per-player iteration axis — same
-    /// accumulate-into-tracked-set machinery as [`ZoneOwner::EachPlayer`], but
-    /// the controller's own permanents are never offered. Building block for
-    /// Kaya, Spirits' Justice's −2 ("For each other player, exile up to one
-    /// target creature that player controls").
-    EachOpponent,
-    /// CR 101.4 + CR 115.1 + CR 608.2c: Every player chosen as a `Player`
-    /// TARGET of the resolving ability owns a referenced zone, iterated in
-    /// APNAP order — the targeted-set leaf of the per-player iteration axis,
-    /// same accumulate-into-tracked-set machinery as [`ZoneOwner::EachPlayer`].
-    /// Building block for "up to two target players each manifest two cards
-    /// from their hands" (Kozilek, the Broken Reality).
-    EachTargetedPlayer,
+    /// CR 101.4 + CR 608.2c: A per-player iteration — one choice per player of
+    /// the named population, parked in APNAP order, each pick accumulating into
+    /// the resolution chain's tracked object set. The population is the
+    /// variant's own parameter rather than a separate sibling per population
+    /// (Breach the Multiverse iterates every player; Kaya, Spirits' Justice
+    /// every other player; Kozilek, the Broken Reality the chosen player
+    /// targets).
+    Each(PerPlayerScope),
     /// CR 400.1 + CR 607.2a: The referenced zone is scanned across ALL owners —
     /// ownership imposes no restriction, and the effect's `TargetFilter`
     /// performs every bit of scoping. Used when the candidate pool's membership
@@ -232,13 +238,111 @@ pub enum ZoneOwner {
     /// regardless of who owns each card — and Koh typically exiles *opponents'*
     /// creatures, so gating to the controller's own exiled cards empties the
     /// pool. This is the single-pool owner-agnostic leaf of the scope axis:
-    /// distinct from [`ZoneOwner::EachPlayer`]/[`ZoneOwner::EachOpponent`],
+    /// distinct from [`ZoneOwner::Each(PerPlayerScope::AllPlayers)`]/[`ZoneOwner::Each(PerPlayerScope::Opponents)`],
     /// which iterate one prompt per player and accumulate into a tracked set —
     /// this raises ONE prompt over the whole-zone union. Mirrors the
     /// `ScopedPlayer`-on-Battlefield branch in `collect_direct_zone_cards`
     /// (scan broadly, let the filter narrow), but with no owner restriction at
     /// all.
     AllOwners,
+}
+
+/// Serialized form of [`ZoneOwner`], carrying the pre-parameterization unit
+/// names so stored data (game states, generated card data) written before the
+/// per-player population became a parameter still deserializes. Only the
+/// parameterized `Each` form is ever WRITTEN; the three legacy names are
+/// read-only inputs that map onto it.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize)]
+enum ZoneOwnerRepr {
+    Controller,
+    TargetedPlayer,
+    Opponent,
+    ScopedPlayer,
+    Each(PerPlayerScope),
+    AllOwners,
+    // ---- legacy names (deserialize-only) ----
+    EachPlayer,
+    EachOpponent,
+    EachTargetedPlayer,
+}
+
+impl From<ZoneOwnerRepr> for ZoneOwner {
+    fn from(repr: ZoneOwnerRepr) -> Self {
+        match repr {
+            ZoneOwnerRepr::Controller => ZoneOwner::Controller,
+            ZoneOwnerRepr::TargetedPlayer => ZoneOwner::TargetedPlayer,
+            ZoneOwnerRepr::Opponent => ZoneOwner::Opponent,
+            ZoneOwnerRepr::ScopedPlayer => ZoneOwner::ScopedPlayer,
+            ZoneOwnerRepr::Each(scope) => ZoneOwner::Each(scope),
+            ZoneOwnerRepr::AllOwners => ZoneOwner::AllOwners,
+            ZoneOwnerRepr::EachPlayer => ZoneOwner::Each(PerPlayerScope::AllPlayers),
+            ZoneOwnerRepr::EachOpponent => ZoneOwner::Each(PerPlayerScope::Opponents),
+            ZoneOwnerRepr::EachTargetedPlayer => ZoneOwner::Each(PerPlayerScope::TargetedPlayers),
+        }
+    }
+}
+
+impl From<ZoneOwner> for ZoneOwnerRepr {
+    fn from(owner: ZoneOwner) -> Self {
+        match owner {
+            ZoneOwner::Controller => ZoneOwnerRepr::Controller,
+            ZoneOwner::TargetedPlayer => ZoneOwnerRepr::TargetedPlayer,
+            ZoneOwner::Opponent => ZoneOwnerRepr::Opponent,
+            ZoneOwner::ScopedPlayer => ZoneOwnerRepr::ScopedPlayer,
+            ZoneOwner::Each(scope) => ZoneOwnerRepr::Each(scope),
+            ZoneOwner::AllOwners => ZoneOwnerRepr::AllOwners,
+        }
+    }
+}
+
+#[cfg(test)]
+mod zone_owner_migration_tests {
+    use super::*;
+
+    /// The three pre-parameterization unit names must still deserialize onto
+    /// the parameterized `Each` form — stored game states and generated card
+    /// data written before the refactor carry them.
+    #[test]
+    fn legacy_per_player_zone_owner_names_migrate_onto_the_parameterized_form() {
+        for (legacy, expected) in [
+            (
+                "\"EachPlayer\"",
+                ZoneOwner::Each(PerPlayerScope::AllPlayers),
+            ),
+            (
+                "\"EachOpponent\"",
+                ZoneOwner::Each(PerPlayerScope::Opponents),
+            ),
+            (
+                "\"EachTargetedPlayer\"",
+                ZoneOwner::Each(PerPlayerScope::TargetedPlayers),
+            ),
+        ] {
+            let parsed: ZoneOwner = serde_json::from_str(legacy)
+                .unwrap_or_else(|e| panic!("legacy {legacy} must still deserialize: {e}"));
+            assert_eq!(parsed, expected, "legacy {legacy} maps onto {expected:?}");
+        }
+    }
+
+    /// Only the parameterized form is ever written, and it round-trips.
+    #[test]
+    fn parameterized_zone_owner_round_trips_and_is_the_only_written_form() {
+        let owner = ZoneOwner::Each(PerPlayerScope::TargetedPlayers);
+        let json = serde_json::to_string(&owner).expect("serialize");
+        assert_eq!(
+            json, "{\"Each\":\"TargetedPlayers\"}",
+            "the parameterized form is what gets written"
+        );
+        assert_eq!(
+            serde_json::from_str::<ZoneOwner>(&json).expect("round trip"),
+            owner
+        );
+        // The non-iterating leaves are unchanged unit names.
+        assert_eq!(
+            serde_json::to_string(&ZoneOwner::Controller).expect("serialize"),
+            "\"Controller\""
+        );
+    }
 }
 
 /// CR 105.1 + CR 205.2: A fixed, closed enumeration whose members an effect
@@ -16843,7 +16947,7 @@ impl Effect {
             // manifest two cards from their hands"). That form must declare the
             // player slots so the targets exist to iterate.
             Effect::ChooseFromZone {
-                zone_owner: ZoneOwner::EachTargetedPlayer,
+                zone_owner: ZoneOwner::Each(PerPlayerScope::TargetedPlayers),
                 ..
             } => Some(&TargetFilter::Player),
             Effect::ChooseFromZone { .. } => None,
@@ -28693,12 +28797,12 @@ mod tests {
         assert!(OriginConstraint::Any.matches_from(&Some(Zone::Battlefield)));
     }
 
-    /// CR 101.4 + CR 608.2c (issue #3302): `ZoneOwner::EachPlayer` is a shared
+    /// CR 101.4 + CR 608.2c (issue #3302): `ZoneOwner::Each(PerPlayerScope::AllPlayers)` is a shared
     /// serialized engine type (card-data export, WASM/IPC transport). A
     /// serialize→deserialize round-trip must reproduce the exact variant so a
-    /// Breach the Multiverse `ChooseFromZone { zone_owner: EachPlayer }` survives
-    /// the wire. Every variant is checked so adding `EachPlayer` did not perturb
-    /// the others' tags.
+    /// Breach the Multiverse `ChooseFromZone { zone_owner: Each(AllPlayers) }`
+    /// survives the wire. Every variant is checked so parameterizing the
+    /// per-player population did not perturb the other variants' tags.
     #[test]
     fn zone_owner_serde_round_trips_each_variant() {
         for owner in [
@@ -28706,8 +28810,9 @@ mod tests {
             ZoneOwner::TargetedPlayer,
             ZoneOwner::Opponent,
             ZoneOwner::ScopedPlayer,
-            ZoneOwner::EachPlayer,
-            ZoneOwner::EachOpponent,
+            ZoneOwner::Each(PerPlayerScope::AllPlayers),
+            ZoneOwner::Each(PerPlayerScope::Opponents),
+            ZoneOwner::Each(PerPlayerScope::TargetedPlayers),
             ZoneOwner::AllOwners,
         ] {
             let json = serde_json::to_string(&owner).expect("ZoneOwner serializes");
@@ -28715,14 +28820,18 @@ mod tests {
                 serde_json::from_str(&json).expect("ZoneOwner deserializes");
             assert_eq!(round_tripped, owner, "round-trip must preserve {owner:?}");
         }
-        // The new variant's external tag is its identifier (default enum repr).
+        // The per-player form now carries its population as a parameter, so
+        // its wire shape is the tagged `Each` variant. The pre-parameterization
+        // unit name still DESERIALIZES onto it (see
+        // `zone_owner_migration_tests`), which is what keeps stored data
+        // readable.
         assert_eq!(
-            serde_json::to_string(&ZoneOwner::EachPlayer).unwrap(),
-            "\"EachPlayer\""
+            serde_json::to_string(&ZoneOwner::Each(PerPlayerScope::AllPlayers)).unwrap(),
+            "{\"Each\":\"AllPlayers\"}"
         );
         assert_eq!(
             serde_json::from_str::<ZoneOwner>("\"EachPlayer\"").unwrap(),
-            ZoneOwner::EachPlayer
+            ZoneOwner::Each(PerPlayerScope::AllPlayers)
         );
     }
 

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -4554,9 +4554,9 @@ mod tests {
     use crate::game::scenario::GameScenario;
     use crate::types::ability::{
         AbilityDefinition, AbilityKind, CardSelectionMode, Chooser, CopyChooseScope, Effect,
-        EffectKind, ForEachCategoryAction, IterationCategory, PostReplacementContinuation,
-        QuantityExpr, RepeatContinuation, ReplacementDefinition, SpellContext, TargetFilter,
-        ZoneOwner,
+        EffectKind, ForEachCategoryAction, IterationCategory, PerPlayerScope,
+        PostReplacementContinuation, QuantityExpr, RepeatContinuation, ReplacementDefinition,
+        SpellContext, TargetFilter, ZoneOwner,
     };
     use crate::types::actions::GameAction;
     use crate::types::game_state::{
@@ -6447,7 +6447,7 @@ mod tests {
                 count: 1,
                 zone: Zone::Graveyard,
                 additional_zones: Vec::new(),
-                zone_owner: ZoneOwner::EachPlayer,
+                zone_owner: ZoneOwner::Each(PerPlayerScope::AllPlayers),
                 filter: None,
                 chooser: Chooser::Controller,
                 up_to: true,

--- a/crates/engine/tests/integration/kaya_spirits_justice_per_opponent_exile.rs
+++ b/crates/engine/tests/integration/kaya_spirits_justice_per_opponent_exile.rs
@@ -131,7 +131,7 @@ fn scan_minus_two_chain(parsed: &engine::parser::oracle::ParsedAbilities) -> (bo
     while let Some(def) = node {
         match &*def.effect {
             Effect::ChooseFromZone {
-                zone_owner: ZoneOwner::Each(PerPlayerScope::Opponents),
+                zone_owner: ZoneOwner::Each(PerPlayerScope::OtherPlayers),
                 ..
             } => found_each_opponent = true,
             Effect::Unimplemented { .. } => found_unimplemented = true,
@@ -220,7 +220,7 @@ fn non_target_form_still_parses_to_each_opponent_exile_chain() {
     let mut found_chain = false;
     while let Some(def) = node {
         if let Effect::ChooseFromZone {
-            zone_owner: ZoneOwner::Each(PerPlayerScope::Opponents),
+            zone_owner: ZoneOwner::Each(PerPlayerScope::OtherPlayers),
             up_to: true,
             ..
         } = &*def.effect

--- a/crates/engine/tests/integration/kaya_spirits_justice_per_opponent_exile.rs
+++ b/crates/engine/tests/integration/kaya_spirits_justice_per_opponent_exile.rs
@@ -35,7 +35,7 @@
 
 use engine::game::scenario::{GameRunner, GameScenario};
 use engine::parser::oracle::parse_oracle_text;
-use engine::types::ability::{Effect, ZoneOwner};
+use engine::types::ability::{Effect, PerPlayerScope, ZoneOwner};
 use engine::types::actions::GameAction;
 use engine::types::game_state::{CastPaymentMode, WaitingFor};
 use engine::types::identifiers::ObjectId;
@@ -131,7 +131,7 @@ fn scan_minus_two_chain(parsed: &engine::parser::oracle::ParsedAbilities) -> (bo
     while let Some(def) = node {
         match &*def.effect {
             Effect::ChooseFromZone {
-                zone_owner: ZoneOwner::EachOpponent,
+                zone_owner: ZoneOwner::Each(PerPlayerScope::Opponents),
                 ..
             } => found_each_opponent = true,
             Effect::Unimplemented { .. } => found_unimplemented = true,
@@ -220,7 +220,7 @@ fn non_target_form_still_parses_to_each_opponent_exile_chain() {
     let mut found_chain = false;
     while let Some(def) = node {
         if let Effect::ChooseFromZone {
-            zone_owner: ZoneOwner::EachOpponent,
+            zone_owner: ZoneOwner::Each(PerPlayerScope::Opponents),
             up_to: true,
             ..
         } = &*def.effect

--- a/crates/engine/tests/integration/kozilek_broken_reality_manifest_from_hands.rs
+++ b/crates/engine/tests/integration/kozilek_broken_reality_manifest_from_hands.rs
@@ -118,12 +118,16 @@ fn kozilek_cast_trigger_manifests_two_from_each_targeted_players_hand() {
     // cards, in APNAP order.
     let mut p0_chose = false;
     let mut p1_chose = false;
+    // CR 101.4: record the order the prompts arrive in — the active player
+    // (P0) must be asked first.
+    let mut prompt_order: Vec<engine::types::player::PlayerId> = Vec::new();
     for _ in 0..24 {
         if p0_chose && p1_chose {
             break;
         }
         match runner.state().waiting_for.clone() {
             WaitingFor::ChooseFromZoneChoice { player, cards, .. } => {
+                prompt_order.push(player);
                 if player == P0 {
                     // DISCRIMINATOR — P0's prompt offers only P0's hand.
                     assert!(
@@ -170,6 +174,14 @@ fn kozilek_cast_trigger_manifests_two_from_each_targeted_players_hand() {
         p0_chose && p1_chose,
         "both targeted players must get their own hand choice, got {:?}",
         runner.state().waiting_for
+    );
+    // DISCRIMINATOR — CR 101.4: simultaneous choices are made in APNAP order,
+    // so the active player is prompted FIRST. Branching on `player` alone
+    // would accept either order; this pins it.
+    assert_eq!(
+        prompt_order,
+        vec![P0, P1],
+        "the per-player hand choices must arrive in APNAP order (active player first)"
     );
 
     // Let the manifest + draw tail finish.

--- a/crates/engine/tests/integration/kozilek_broken_reality_manifest_from_hands.rs
+++ b/crates/engine/tests/integration/kozilek_broken_reality_manifest_from_hands.rs
@@ -13,7 +13,7 @@
 //! DISCRIMINATORS (anti-hollow-win):
 //! - each player's choice prompt offers ONLY that player's hand (P0's prompt
 //!   never contains P1's cards and vice versa — the per-iteration
-//!   `ZoneOwner::EachTargetedPlayer` scoping).
+//!   `ZoneOwner::Each(PerPlayerScope::TargetedPlayers)` scoping).
 //! - each manifested card enters under ITS OWN player's control — the
 //!   opponent's manifests must NOT land under the caster's control
 //!   (CR 701.40a: the manifesting player puts the card onto the battlefield).

--- a/crates/engine/tests/integration/kozilek_broken_reality_manifest_from_hands.rs
+++ b/crates/engine/tests/integration/kozilek_broken_reality_manifest_from_hands.rs
@@ -1,0 +1,256 @@
+//! Card-level regression for **Kozilek, the Broken Reality** —
+//! "When you cast this spell, up to two target players each manifest two
+//! cards from their hands. For each card manifested this way, you draw a
+//! card."
+//!
+//! Drives the REAL registered cast trigger end to end: the creature is built
+//! from its printed Oracle text, cast through `GameAction::CastSpell`, the
+//! cast trigger's up-to-two player targets are chosen through
+//! `GameAction::SelectTargets`, and each targeted player answers their OWN
+//! `WaitingFor::ChooseFromZoneChoice` in APNAP order — the exact path the
+//! client takes.
+//!
+//! DISCRIMINATORS (anti-hollow-win):
+//! - each player's choice prompt offers ONLY that player's hand (P0's prompt
+//!   never contains P1's cards and vice versa — the per-iteration
+//!   `ZoneOwner::EachTargetedPlayer` scoping).
+//! - each manifested card enters under ITS OWN player's control — the
+//!   opponent's manifests must NOT land under the caster's control
+//!   (CR 701.40a: the manifesting player puts the card onto the battlefield).
+//! - the "for each card manifested this way" rider draws exactly the number
+//!   of accumulated picks (4), read from the chain's tracked set.
+//!
+//! CR 701.40a: Manifest — face-down 2/2 creature.
+//! CR 101.4: multiple players making choices do so in APNAP order.
+//! CR 601.2c + CR 115.1d: "up to two target players" is a multi-target
+//! selection bound when the trigger goes on the stack.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const KOZILEK_ORACLE: &str = "When you cast this spell, up to two target players each manifest two cards from their hands. For each card manifested this way, you draw a card.\nOther colorless creatures you control get +3/+2.";
+
+#[test]
+fn kozilek_cast_trigger_manifests_two_from_each_targeted_players_hand() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P0's hand: Kozilek plus two pickable cards (creature + noncreature mix).
+    let koz = scenario
+        .add_creature_to_hand_from_oracle(P0, "Kozilek, the Broken Reality", 9, 9, KOZILEK_ORACLE)
+        .id();
+    let a1 = scenario.add_creature_to_hand(P0, "P0 Pick One", 3, 3).id();
+    let a2 = scenario
+        .add_spell_to_hand_from_oracle(P0, "P0 Pick Two", false, "Draw a card.")
+        .id();
+    // P1's hand: two pickable cards.
+    let b1 = scenario.add_creature_to_hand(P1, "P1 Pick One", 4, 4).id();
+    let b2 = scenario.add_creature_to_hand(P1, "P1 Pick Two", 1, 1).id();
+    // P0 needs library cards for the four rider draws.
+    for i in 0..6 {
+        scenario.add_card_to_library_top(P0, &format!("P0 Library {i}"));
+    }
+
+    let mut runner = scenario.build();
+
+    let koz_card_id = runner.state().objects[&koz].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: koz,
+            card_id: koz_card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast Kozilek, the Broken Reality");
+
+    // The cast trigger goes on the stack and asks for its up-to-two player
+    // targets. A parse regression (Unimplemented body) never raises the
+    // selection — the loop below then panics.
+    let mut chosen = 0;
+    for _ in 0..16 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::TriggerTargetSelection {
+                target_slots,
+                selection,
+                ..
+            } => {
+                // CR 115.1d: answer one "up to two target players" slot at a
+                // time, picking P0 first and P1 second.
+                let want = if chosen == 0 { P0 } else { P1 };
+                let slot = &target_slots[selection.current_slot];
+                let choice = slot
+                    .legal_targets
+                    .iter()
+                    .find(|t| **t == TargetRef::Player(want))
+                    .cloned();
+                assert!(
+                    choice.is_some(),
+                    "player {want:?} must be a legal target of the cast trigger, got {:?}",
+                    slot.legal_targets
+                );
+                runner
+                    .act(GameAction::ChooseTarget { target: choice })
+                    .expect("choosing a targeted player must be accepted");
+                chosen += 1;
+                if chosen == 2 {
+                    break;
+                }
+            }
+            _ => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("advance toward the cast trigger's target selection");
+            }
+        }
+    }
+    assert_eq!(
+        chosen,
+        2,
+        "the cast trigger must offer both player target slots, got {:?}",
+        runner.state().waiting_for
+    );
+
+    // Resolve the trigger: each targeted player picks two of their OWN hand
+    // cards, in APNAP order.
+    let mut p0_chose = false;
+    let mut p1_chose = false;
+    for _ in 0..24 {
+        if p0_chose && p1_chose {
+            break;
+        }
+        match runner.state().waiting_for.clone() {
+            WaitingFor::ChooseFromZoneChoice { player, cards, .. } => {
+                if player == P0 {
+                    // DISCRIMINATOR — P0's prompt offers only P0's hand.
+                    assert!(
+                        cards.contains(&a1) && cards.contains(&a2),
+                        "P0's own hand cards must be offered, got {cards:?}"
+                    );
+                    assert!(
+                        !cards.contains(&b1) && !cards.contains(&b2),
+                        "P1's hand must NOT appear in P0's choice, got {cards:?}"
+                    );
+                    runner
+                        .act(GameAction::SelectCards {
+                            cards: vec![a1, a2],
+                        })
+                        .expect("P0 picks both hand cards");
+                    p0_chose = true;
+                } else {
+                    assert_eq!(player, P1, "only the two targeted players choose");
+                    // DISCRIMINATOR — P1's prompt offers only P1's hand.
+                    assert!(
+                        cards.contains(&b1) && cards.contains(&b2),
+                        "P1's own hand cards must be offered, got {cards:?}"
+                    );
+                    assert!(
+                        !cards.contains(&a1) && !cards.contains(&a2),
+                        "P0's hand must NOT appear in P1's choice, got {cards:?}"
+                    );
+                    runner
+                        .act(GameAction::SelectCards {
+                            cards: vec![b1, b2],
+                        })
+                        .expect("P1 picks both hand cards");
+                    p1_chose = true;
+                }
+            }
+            _ => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("advance toward the per-player hand choices");
+            }
+        }
+    }
+    assert!(
+        p0_chose && p1_chose,
+        "both targeted players must get their own hand choice, got {:?}",
+        runner.state().waiting_for
+    );
+
+    // Let the manifest + draw tail finish.
+    runner.advance_until_stack_empty();
+
+    // All four picks are manifested face-down creatures.
+    for (id, label) in [(a1, "a1"), (a2, "a2"), (b1, "b1"), (b2, "b2")] {
+        let obj = &runner.state().objects[&id];
+        assert_eq!(
+            obj.zone,
+            Zone::Battlefield,
+            "{label} must be manifested onto the battlefield"
+        );
+        assert!(obj.face_down, "{label} must be face down");
+        assert_eq!(obj.base_power, Some(2), "{label} is a printed-over 2/2");
+        assert_eq!(obj.base_toughness, Some(2), "{label} is a printed-over 2/2");
+    }
+    // DISCRIMINATOR — control follows the manifesting player (CR 701.40a), and
+    // Kozilek's own static ("Other colorless creatures you control get +3/+2")
+    // proves it independently of the `controller` field: a face-down card is
+    // colorless (CR 202.2b), so the CASTER's two manifests are pumped to 5/4
+    // while the opponent's stay 2/2. A resolver that put every manifest under
+    // the caster's control would pump all four.
+    assert_eq!(
+        runner.state().objects[&a1].controller,
+        P0,
+        "P0's manifests enter under P0's control"
+    );
+    assert_eq!(
+        runner.state().objects[&b1].controller,
+        P1,
+        "P1's manifests enter under P1's control — not the caster's"
+    );
+    assert_eq!(runner.state().objects[&b2].controller, P1);
+    assert_eq!(
+        (
+            runner.state().objects[&a1].power,
+            runner.state().objects[&a1].toughness
+        ),
+        (Some(5), Some(4)),
+        "the caster's colorless manifest gets Kozilek's +3/+2"
+    );
+    assert_eq!(
+        (
+            runner.state().objects[&b1].power,
+            runner.state().objects[&b1].toughness
+        ),
+        (Some(2), Some(2)),
+        "the opponent's manifest is NOT pumped — it is not a creature P0 controls"
+    );
+
+    // Kozilek itself resolved onto the battlefield.
+    assert_eq!(
+        runner.state().objects[&koz].zone,
+        Zone::Battlefield,
+        "Kozilek resolves normally after its cast trigger"
+    );
+
+    // DISCRIMINATOR — the rider drew one card per manifested card: 4 draws.
+    // P0's hand: emptied by the cast (Kozilek) and both picks, then +4 draws.
+    let p0 = runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P0)
+        .expect("P0 exists");
+    assert_eq!(
+        p0.hand.len(),
+        4,
+        "P0 draws exactly one card per manifested card (4), got hand {:?}",
+        p0.hand
+    );
+    let p1 = runner
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P1)
+        .expect("P1 exists");
+    assert_eq!(
+        p1.hand.len(),
+        0,
+        "P1's hand is emptied by their two picks and draws nothing"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -796,6 +796,7 @@ mod kiora_self_library_peek_cast;
 mod knighthood_first_strike_grant;
 mod knollspine_dragon_target_damage_draw;
 mod kodama_anti_recursion_intervening_if;
+mod kozilek_broken_reality_manifest_from_hands;
 mod krark_clan_ironworks_castability;
 mod krark_thumb_coin_flip;
 mod kroxa_titan_nonland_discard_life_loss;


### PR DESCRIPTION
Fixes #7691

**Card:** Kozilek, the Broken Reality — "When you cast this spell, up to two target players each manifest two cards from their hands. For each card manifested this way, you draw a card."

Playtested on a local build: the cast trigger did nothing at all. Everything around the body already parsed (`TriggerMode::SpellCast`, the up-to-two player `multi_target`, the `repeat_for: TrackedSetSize` draw rider); only the predicate was `Effect::Unimplemented`, so the whole trigger resolved to nothing. This is the per-player counterpart of the single-player from-hand manifest added for Scroll of Fate (#7609), which named this card as its remaining gap.

## Shape

The card is a per-player hidden-zone choice feeding one accumulated "this way" set — the Breach the Multiverse shape (`ChooseFromZone { zone_owner: Each* }` → sub-ability over the chain's tracked set), with two leaves added to existing axes:

- **`ZoneOwner::EachTargetedPlayer`** — the targeted-set leaf of the per-player iteration axis (next to `EachPlayer` / `EachOpponent`): the iterated set is the ability's chosen `Player` targets, walked in APNAP order (CR 101.4). CR 601.2c: an "up to N" selection may be empty, which disposes the iteration immediately.
- **`Chooser::OwningPlayer`** — the choice is made by the player whose zone is scanned, so each targeted player picks from their **own hidden hand** rather than the caster choosing for everyone (CR 608.2c).

Two existing authorities needed one arm each:

- `Effect::target_filter()` now answers `Some(Player)` for `ChooseFromZone { zone_owner: EachTargetedPlayer }` (all other `ChooseFromZone` forms stay `None`, unchanged). Without declared player slots there are no targets to iterate.
- The multi-target **player fan-out** (`effects/mod.rs`) excludes that same form. Its own doc says it is "the missing iteration layer" for *single-player-recipient* handlers (Discard/Mill/LoseLife); this effect already iterates the chosen players itself. Left in, the fan-out split the chain per player, so each iteration got its **own** chain tracked set — the sub-chain then read only the last player's picks.
- `effects/manifest.rs` gains the tracked-set source arm (mirroring `Cloak`'s, minus the exile dance — these cards are in hands, so `manifest_card` is a plain move), and rebinds to a **fresh** chain set before manifesting: the chain's referent changes from "the chosen cards" to "the cards manifested this way", and without the rebind the shared post-effect publisher appends the manifests to the pick set, double-counting every card (the rider then drew 8 instead of 4).

`controller: None` keeps the CR 701.40a owner default, so each card enters under the control of the player who chose it.

## Class (Rule-13 double parse, full 35,798-card corpus)

Parsed the whole corpus with and without the parser arm; the diff is **exactly one card** — `kozilek, the broken reality`:

```
without:  {"type":"Unimplemented","name":"manifest","description":"manifest two cards from their hands"}
with:     {"type":"ChooseFromZone","count":2,"zone":"Hand","zone_owner":"EachTargetedPlayer","chooser":"OwningPlayer","up_to":false}
          + sub Manifest { object_source: TrackedSet(0), count: 2 }
          + the pre-existing Draw rider (repeat_for: TrackedSetSize), unchanged
```

No other card's parse changes — the new arm is gated to a `TargetFilter::Player` subject, so other from-hand subjects stay honest gaps.

## Tests

`kozilek_broken_reality_manifest_from_hands.rs` drives the printed card end to end: cast → `TriggerTargetSelection` (both player slots answered via `ChooseTarget`) → each player's own `ChooseFromZoneChoice` → manifests + rider draws.

Discriminators:
- each prompt offers **only** that player's hand (P0's never contains P1's cards, and vice versa);
- control follows the manifesting player — asserted twice, once on the `controller` field and once **behaviourally**: a face-down card is colorless (CR 202.2b), so Kozilek's own "Other colorless creatures you control get +3/+2" pumps the **caster's** two manifests to 5/4 while the opponent's stay 2/2. A resolver that put every manifest under the caster's control pumps all four;
- the rider draws exactly one card per manifested card (4), which fails at 8 if the tracked-set rebind is dropped.

Probe: disabling the new parser arm turns the test red at the target-selection step.

Full suites green (19,533 lib + 5,339 integration), clippy clean. The CR 603.5 prompt-census pin was re-pinned for a line shift (same producer: `WaitingFor::OptionalEffectChoice`).

What the tests don't prove: the client-side hiding of each player's hand during their prompt rides on the shared `ChooseFromZoneChoice` visibility path and is not asserted here; and multiplayer beyond two seats is covered only by the APNAP ordering the iteration inherits, not by a dedicated three-player regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for effects that let each targeted player manifest cards from their own hand.
  * Players choose from their own hands in APNAP order, with selections tracked separately.
  * Manifested cards become face-down creatures controlled by the appropriate player.
  * “Each other player” effects now include teammates while excluding only the controller.

* **Bug Fixes**
  * Improved per-player zone ownership and multi-player effect resolution.

* **Tests**
  * Added parser and end-to-end coverage for multi-player manifest effects, draws, and related stat bonuses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->