### PR TITLE
fix(client): render commander art from printed_ref, and default the board to split

### DIFF
--- a/client/src/components/zone/CommanderCardZone.tsx
+++ b/client/src/components/zone/CommanderCardZone.tsx
@@ -11,6 +11,7 @@ import { useCardImage } from "../../hooks/useCardImage.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
 import { getPlayerId, useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import { useDragToCast } from "../../hooks/useDragToCast.ts";
+import { cardImageLookup } from "../../services/cardImageLookup.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import {
@@ -20,6 +21,7 @@ import {
 } from "../../viewmodel/cardActionChoice.ts";
 import { CASTABLE_AFFORDANCE_ACTIVE } from "../../viewmodel/castableAffordance.ts";
 import { commandZoneLeaders } from "../../viewmodel/commanderColumn.ts";
+import { CardArtFallback } from "../card/CardArtFallback.tsx";
 import { ManaCostPips } from "../mana/ManaCostPips.tsx";
 
 interface CommanderCardZoneProps {
@@ -76,7 +78,20 @@ function CommanderCard({
   );
   const inspectObject = useUiStore((s) => s.inspectObject);
   const setPendingAbilityChoice = useUiStore((s) => s.setPendingAbilityChoice);
-  const { src } = useCardImage(commander.name, { size: "normal" });
+  // Canonical art path (services/cardImageLookup): resolve by the engine's
+  // `printed_ref.oracle_id` + face name, exactly as every other object surface
+  // (PermanentCard, StackEntry, GraveyardPile, CardPreview) does. The bare
+  // `commander.name` lookup this replaced is documented as the legacy fallback
+  // for objects carrying no `printed_ref` — command-zone leaders always carry
+  // one — and it indexes faces numerically, so a leader whose active face is
+  // not Scryfall's front resolved to the wrong face's art.
+  const imageLookup = cardImageLookup(commander);
+  const { src, isLoading } = useCardImage(imageLookup.name, {
+    size: "normal",
+    faceIndex: imageLookup.faceIndex,
+    oracleId: imageLookup.oracleId,
+    faceName: imageLookup.faceName,
+  });
   const { handlers: hoverHandlers, firedRef } = useCardHover(commander.id);
   const tax = commander.commander_tax ?? 0;
 
@@ -235,7 +250,15 @@ function CommanderCard({
     >
       {/* Card image */}
       <div className="relative h-full w-full overflow-hidden rounded-lg border border-amber-400/60 shadow-md">
-        {src ? (
+        {/* Three-state art contract, mirroring StackEntry: a pulsing skeleton
+            while resolution is in flight, the shared name tile only once we know
+            there is no art, then the image. Collapsing the first two — the bare
+            name tile stood in for BOTH — made the multi-second
+            `scryfall-data.json` fetch look like permanently broken commander
+            art, which is how it got reported. */}
+        {isLoading ? (
+          <div className="h-full w-full animate-pulse bg-gray-700" />
+        ) : src ? (
           <img
             src={src}
             alt={commander.name}
@@ -243,9 +266,9 @@ function CommanderCard({
             draggable={false}
           />
         ) : (
-          <div className="flex h-full w-full items-center justify-center bg-gray-700 text-[10px] text-gray-400">
-            {commander.name}
-          </div>
+          /* `artCrop` centres and wraps the name; `fullCard` top-aligns and
+             truncates it, which this tile is too narrow to read. */
+          <CardArtFallback name={commander.name} variant="artCrop" className="h-full w-full" />
         )}
 
         {/* Translucent overlay — amber tint, lighter when actionable (castable

--- a/client/src/components/zone/__tests__/CommanderCardZone.test.tsx
+++ b/client/src/components/zone/__tests__/CommanderCardZone.test.tsx
@@ -23,8 +23,18 @@ vi.mock("../../../game/dispatch.ts", () => ({
 
 // Keep the test hermetic: the card-image hook otherwise fires a dev-server
 // asset fetch (localhost:3000) that has nothing to do with the affordance.
+// `vi.hoisted` because the `vi.mock` factory is hoisted above module-scope
+// `const`s and would otherwise read them in their TDZ.
+const cardImage = vi.hoisted(() => ({
+  calls: [] as Array<{ name: string; options?: Record<string, unknown> }>,
+  result: { src: null as string | null, isLoading: false },
+}));
+
 vi.mock("../../../hooks/useCardImage.ts", () => ({
-  useCardImage: () => ({ src: null }),
+  useCardImage: (name: string, options?: Record<string, unknown>) => {
+    cardImage.calls.push({ name, options });
+    return cardImage.result;
+  },
 }));
 
 const COMMANDER_ID = 101;
@@ -267,5 +277,85 @@ describe("CommanderCardZone activation gate", () => {
     expect(live).toHaveAttribute("title", "Cast Mock Commander — double-click or drag to play");
     fireEvent.click(live);
     expect(dispatchAction).toHaveBeenCalledTimes(1);
+  });
+});
+
+/**
+ * The command dock is the one board surface that used to resolve art from the
+ * bare card name and render a single name tile for BOTH "still resolving" and
+ * "no art exists". Reported as commander art never rendering: `scryfall-data.json`
+ * is tens of MB, and for its whole download the dock showed a name with no
+ * picture — indistinguishable from permanently broken art.
+ */
+describe("CommanderCardZone art resolution", () => {
+  const ORACLE_ID = "6d3ca5cb-781d-4608-b7f1-38c020536376";
+  const ART_URL = "https://cards.scryfall.io/normal/front/8/f/kefka.jpg";
+
+  function seedWithPrintedRef() {
+    const commander = buildCommanderGameObject({
+      id: COMMANDER_ID,
+      name: "Kefka, Court Mage",
+      printed_ref: { oracle_id: ORACLE_ID, face_name: "Kefka, Court Mage" },
+    });
+    const gameState = makeState(commander);
+    useGameStore.setState({
+      gameMode: "local",
+      gameState,
+      waitingFor: gameState.waiting_for,
+      legalActions: [],
+      legalActionsByObject: {},
+      spellCosts: {},
+    });
+  }
+
+  beforeEach(() => {
+    cardImage.calls.length = 0;
+    cardImage.result = { src: null, isLoading: false };
+    seedWithPrintedRef();
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("resolves art through the engine's printed_ref rather than the card name", () => {
+    render(<CommanderCardZone playerId={0} />);
+
+    // The name path is the documented legacy fallback for objects with no
+    // printed_ref; a command-zone leader always has one, and only the oracle-id
+    // path picks the right face for a leader whose active face is not the front.
+    expect(cardImage.calls[0].options).toMatchObject({
+      oracleId: ORACLE_ID,
+      faceName: "Kefka, Court Mage",
+    });
+  });
+
+  it("does not show the no-art name tile while resolution is still in flight", () => {
+    cardImage.result = { src: null, isLoading: true };
+    render(<CommanderCardZone playerId={0} />);
+
+    // The regression: the name tile rendered during the whole scryfall-data
+    // fetch, reading as "this commander has no art" rather than "art is
+    // loading". Assert on the rendered NAME TEXT — the pre-fix tile was a plain
+    // <div>, so a role-based query would have been null under both versions.
+    expect(screen.queryByText("Kefka, Court Mage")).toBeNull();
+  });
+
+  it("shows the shared name tile once resolution finishes with no art", () => {
+    cardImage.result = { src: null, isLoading: false };
+    render(<CommanderCardZone playerId={0} />);
+
+    // Named art tile, not bare text: CardArtFallback carries role/aria-label so
+    // assistive tech announces an artless commander the way every other board
+    // surface does.
+    expect(screen.getByRole("img", { name: "Kefka, Court Mage" })).toBeInTheDocument();
+    expect(screen.getByText("Kefka, Court Mage")).toBeInTheDocument();
+  });
+
+  it("renders the resolved art", () => {
+    cardImage.result = { src: ART_URL, isLoading: false };
+    render(<CommanderCardZone playerId={0} />);
+
+    expect(screen.getByAltText("Kefka, Court Mage")).toHaveAttribute("src", ART_URL);
   });
 });

--- a/client/src/stores/__tests__/preferencesStore.test.ts
+++ b/client/src/stores/__tests__/preferencesStore.test.ts
@@ -24,7 +24,7 @@ describe("preferencesStore", () => {
         sfxMuted: false,
         musicMuted: false,
         masterMuted: false,
-        multiplayerBoardLayout: "focused",
+        multiplayerBoardLayout: "split",
         aiSeats: [{ difficulty: "Medium", deckId: "Random" }],
         aiBracketFilter: [],
       });
@@ -40,7 +40,10 @@ describe("preferencesStore", () => {
     expect(state.followActiveOpponent).toBe(false);
     expect(state.logDefaultState).toBe("closed");
     expect(state.boardBackground).toBe("auto-wubrg");
-    expect(state.multiplayerBoardLayout).toBe("focused");
+    // Read the store's real initialization snapshot (the getInitialState idiom
+    // used below): the shared beforeEach writes its own defaults snapshot, so a
+    // getState() read here would assert that snapshot, not buildDefaultPreferences().
+    expect(usePreferencesStore.getInitialState().multiplayerBoardLayout).toBe("split");
     expect(state.aiSeats).toEqual([{ difficulty: "Medium", deckId: "Random" }]);
     expect(state.priorityPassingMode).toBe("Standard");
   });
@@ -96,11 +99,13 @@ describe("preferencesStore", () => {
   });
 
   it("setMultiplayerBoardLayout updates multiplayer board layout", () => {
+    // Set the NON-default value: "split" is the default, so asserting it here
+    // would pass with the setter deleted.
     act(() => {
-      usePreferencesStore.getState().setMultiplayerBoardLayout("split");
+      usePreferencesStore.getState().setMultiplayerBoardLayout("focused");
     });
 
-    expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("split");
+    expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("focused");
   });
 
   it("setFollowActiveOpponent updates the value", () => {
@@ -590,7 +595,7 @@ describe("preferencesStore", () => {
     expect(usePreferencesStore.getState().aiBracketFilter).toEqual([]);
   });
 
-  it("v20 → v21 migration defaults multiplayerBoardLayout to focused", () => {
+  it("v20 → v21 migration keeps pre-existing stores on the focused layout", () => {
     localStorage.setItem(
       "phase-preferences",
       JSON.stringify({

--- a/client/src/stores/preferencesStore.ts
+++ b/client/src/stores/preferencesStore.ts
@@ -302,7 +302,7 @@ function buildDefaultPreferences(): PreferencesState {
     showCardPreviewFooter: true,
     stackDockSide: "right",
     opponentHudDensity: "comfortable",
-    multiplayerBoardLayout: "focused",
+    multiplayerBoardLayout: "split",
     aiSeats: [defaultAiSeat()],
     cedhMode: false,
     aiArchetypeFilter: "Any",
@@ -825,8 +825,11 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       // v19 → v20: Add collapseLands/collapseSupport; legacy stores default to
       //          "auto" (the prior threshold-driven collapse) via the shallow
       //          merge, so existing users see no behavior change.
-      // v20 → v21: Add multiplayerBoardLayout; legacy stores default to
-      //          "focused", preserving the current focused-opponent layout.
+      // v20 → v21: Add multiplayerBoardLayout; legacy stores are pinned to
+      //          "focused", preserving the layout they were already playing on.
+      //          Load-bearing now that the fresh-store default is "split": this
+      //          block is what keeps the new default a NEW-user default rather
+      //          than a layout swap under existing players.
       // v21 → v22: Add telemetryEnabled; legacy stores default to `true` (opt-out,
       //          identity-free crash & usage telemetry) via the shallow merge —
       //          no explicit migration block needed (see flexLayout precedent).
@@ -995,6 +998,9 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
           };
         }
 
+        // Pin, not merge: the fresh-store default is "split", so letting a
+        // pre-v21 store fall through to the shallow merge would move existing
+        // players off the layout they have been using.
         if (version < 21) {
           migrated = { ...migrated, multiplayerBoardLayout: "focused" };
         }


### PR DESCRIPTION
Two client changes from one bug report: commander art showing as a name with no picture, and new players landing on the focused (legacy-reading) multiplayer layout.

## 1. Command-zone art — `fix(client)`

**Resolve by `printed_ref`, not by name.** The command dock was the only board surface resolving art from the bare card name, bypassing `cardImageLookup`. Every other object surface (`PermanentCard`, `StackEntry`, `GraveyardPile`, `CardPreview`) routes through the engine's `printed_ref.oracle_id` + face name, which `services/scryfall.ts` documents as canonical; the name path is the legacy fallback for objects carrying no `printed_ref`, and command-zone leaders always carry one. The name path also indexes faces numerically, so a leader whose active face is not Scryfall's front resolved to the wrong face's art.

**Split the loading state from the no-art state.** The dock never read `isLoading`, so one name-only tile stood for both "art is still resolving" and "this card has no art". `scryfall-data.json` is tens of MB; for its whole download a commander showed a name and no picture — indistinguishable from permanently broken art, and reported as exactly that.

Reproduced against the reporter's exported game state with that fetch delayed: the tile held the name-only fallback for the entire 15s window, then filled in the moment the file landed.

Adopts `StackEntry`'s three-state contract — skeleton while resolving → shared `CardArtFallback` only once we know there is no art → image. That also drops a hand-rolled duplicate of `CardArtFallback`, so an artless commander now carries the same `role`/`aria-label` as every other surface.

Ruled out along the way (measured, not assumed): both reported cards resolve by name *and* by oracle id in the local and production `scryfall-data.json`, both CDN URLs return 200, the active art chain produces valid URLs, and all 315 `printed_ref`-carrying objects in the reporter's state resolve on both paths. A *permanent* failure was not reproduced — these are the two real defects the symptom exposed.

## 2. Split layout as the default — `feat(client)`

Flips the fresh-store `multiplayerBoardLayout` default to `"split"`.

**New-user default only.** `persist` has no `partialize`, so every existing store already carries an explicit value and keeps it. The `version < 21` migration block pinning pre-v21 stores to `"focused"` becomes load-bearing for that guarantee rather than incidental — documented at both the changelog comment and the block itself. Actively moving existing players onto split would need a new migration version and is deliberately not done here.

## Test-quality note

Two assertions in `preferencesStore.test.ts` were vacuous and are fixed:

- `has correct default values` read `getState()`, which returns the snapshot its own `beforeEach` writes — flipping the real default left all 47 tests green. Now reads `getInitialState()`, the idiom the card-preview-footer test already uses for this exact reason.
- The setter test stored the value that is now the default, so it would have passed with the setter deleted. Points at the non-default value instead.

## Verification

- Tilt `check-frontend` + `test-frontend` green and fresh.
- Non-vacuity probe run on every new assertion: three of the four new `CommanderCardZone` tests go red against the pre-fix component (the fourth is a deliberate control), and the layout-default assertion goes red with the default reverted.

https://claude.ai/code/session_01QHohvzbqcXsZQTZg35eVis

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved commander card art loading with visible loading indicators and fallback artwork when images are unavailable.
  * New players now start with the multiplayer board using the split layout.

* **Bug Fixes**
  * Existing players retain their previously selected multiplayer layout after updating.
  * Commander cards now correctly display available artwork based on card and face information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->