### PR TITLE
fix(client): give player targeting one authority, as the object axis has

### DIFF
--- a/client/src/components/board/OpponentSeatHeader.tsx
+++ b/client/src/components/board/OpponentSeatHeader.tsx
@@ -1,13 +1,14 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useState } from "react";
 import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 import type { PlayerId } from "../../adapter/types.ts";
-import { usePerspectivePlayerId } from "../../hooks/usePlayerId.ts";
+import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import { usePlayerDesignations } from "../../hooks/usePlayerDesignations.ts";
 import { getSeatColor } from "../../hooks/useSeatColor.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { getOpponentDisplayName, useMultiplayerStore } from "../../stores/multiplayerStore.ts";
+import { getWaitingForPlayerChoiceIds } from "../../viewmodel/gameStateView.ts";
 import { LifeTotal } from "../controls/LifeTotal.tsx";
 import {
   CityBlessingBadge,
@@ -34,7 +35,6 @@ interface OpponentSeatHeaderProps {
 
 export function OpponentSeatHeader({ playerId, compact = false, onKickPlayer }: OpponentSeatHeaderProps) {
   const { t } = useTranslation("game");
-  const myId = usePerspectivePlayerId();
   const [kickOpen, setKickOpen] = useState(false);
   const gameState = useGameStore((s) => s.gameState);
   const waitingFor = useGameStore((s) => s.waitingFor);
@@ -47,33 +47,11 @@ export function OpponentSeatHeader({ playerId, compact = false, onKickPlayer }: 
   const player = gameState?.players[playerId];
   const label = getOpponentDisplayName(playerId);
 
-  const currentLegalTargets = useMemo(() => {
-    if (
-      (waitingFor?.type === "TargetSelection" || waitingFor?.type === "TriggerTargetSelection")
-      && waitingFor.data.player === myId
-    ) {
-      return waitingFor.data.selection?.current_legal_targets ?? [];
-    }
-    if (waitingFor?.type === "CopyRetarget" && waitingFor.data.player === myId) {
-      const slot = waitingFor.data.target_slots[waitingFor.data.current_slot ?? 0];
-      return slot?.legal_alternatives ?? [];
-    }
-    if (
-      waitingFor?.type === "RetargetChoice"
-      && waitingFor.data.player === myId
-      && waitingFor.data.scope.type === "Single"
-    ) {
-      return waitingFor.data.legal_new_targets;
-    }
-    if (waitingFor?.type === "ReturnAsAuraTarget" && waitingFor.data.player === myId) {
-      return waitingFor.data.legal_targets;
-    }
-    return [];
-  }, [myId, waitingFor]);
-
-  const isValidPlayerTarget = currentLegalTargets.some(
-    (target) => "Player" in target && target.Player === playerId,
-  );
+  const canActForWaitingState = useCanActForWaitingState();
+  // Same authority + actor gate as PlayerHud / OpponentHud — this header is the
+  // split-board seat surface, so it must offer exactly the same seats.
+  const isValidPlayerTarget =
+    canActForWaitingState && getWaitingForPlayerChoiceIds(waitingFor).includes(playerId);
   const isTheirTurn = gameState?.active_player === playerId;
   const isUnderAttack = gameState?.combat?.attackers.some(
     (attacker) => attacker.attack_target.type === "Player" && attacker.attack_target.data === playerId,

--- a/client/src/components/board/__tests__/OpponentSeatHeader.test.tsx
+++ b/client/src/components/board/__tests__/OpponentSeatHeader.test.tsx
@@ -42,7 +42,12 @@ function createGameState(waitingFor: WaitingFor) {
 
 describe("OpponentSeatHeader", () => {
   beforeEach(() => {
-    useMultiplayerStore.setState({ activePlayerId: 0 });
+    // `useCanActForWaitingState` short-circuits on EITHER `gameMode === "spectate"`
+    // OR `isSpectator`, and the two live in different module-singleton stores that
+    // persist across tests in this file. Both are reset here, not only in
+    // `afterEach`, so one spectator row cannot make every later seated row inert.
+    useMultiplayerStore.setState({ activePlayerId: 0, isSpectator: false });
+    useGameStore.setState({ gameMode: null });
   });
 
   afterEach(() => {
@@ -120,5 +125,87 @@ describe("OpponentSeatHeader", () => {
     render(<OpponentSeatHeader playerId={1} />);
 
     expect(screen.getByTitle("This player's turn is next.")).toHaveTextContent("Next Up");
+  });
+
+  // V8 — the actor-gate fix on the split-board seat surface. The target
+  // `<button>` renders only when `isValidPlayerTarget`, which is now
+  // `useCanActForWaitingState() && getWaitingForPlayerChoiceIds(waitingFor).includes(playerId)`.
+  // `dispatch.ts` silently refuses a spectator's action, so offering the control
+  // at all is a false live-looking affordance. The two seated targeting tests
+  // above are this row's reach guards.
+  it("offers no target control to a spectating client", () => {
+    const dispatch = vi.fn();
+    const waitingFor = targetSelectionWaitingFor([1]);
+    useMultiplayerStore.setState({ isSpectator: true });
+    useGameStore.setState({
+      dispatch,
+      gameMode: "spectate",
+      gameState: createGameState(waitingFor),
+      waitingFor,
+    });
+
+    render(<OpponentSeatHeader playerId={1} />);
+
+    fireEvent.click(screen.getByTestId("opponent-seat-header-1"));
+
+    expect(screen.queryByRole("button", { name: "Target Opp 2" })).not.toBeInTheDocument();
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  // V12 row (c) — CR 723.1 turn control; CR 723.3: only control of the player
+  // changes, so a controlled player is still the active player.
+  // Real seat 0 pilots seat 1's turn, so
+  // the perspective seat is 1 and seat 0 is rendered as an *opponent* header.
+  // The prompt is addressed to seat 0 and offers seat 0: the actor gate resolves
+  // the real seat and accepts, and the membership test resolves the rendered
+  // seat and matches. The old per-surface `data.player === usePerspectivePlayerId()`
+  // test refused this, so no surface offered the seat and no click could answer.
+  describe("under a turn-control effect (CR 723.1 / CR 723.3)", () => {
+    function turnControlState(waitingFor: WaitingFor) {
+      return {
+        ...createGameState(waitingFor),
+        turn_decision_controller: 0,
+        active_player: 1,
+      };
+    }
+
+    it("offers the real seat that the perspective seat sees as an opponent", () => {
+      const dispatch = vi.fn();
+      const waitingFor = targetSelectionWaitingFor([0]);
+      useGameStore.setState({
+        dispatch,
+        gameState: turnControlState(waitingFor),
+        waitingFor,
+      });
+
+      render(<OpponentSeatHeader playerId={0} />);
+
+      fireEvent.click(screen.getByRole("button", { name: "Target Opp 1" }));
+
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "ChooseTarget",
+        data: { target: { Player: 0 } },
+      });
+    });
+
+    // Paired negative: the same turn-control state where the engine names a seat
+    // this header does not render. Without it, the row above could pass because
+    // every header became clickable under turn control.
+    it("stays inert when the engine names a seat this header does not render", () => {
+      const dispatch = vi.fn();
+      const waitingFor = targetSelectionWaitingFor([1]);
+      useGameStore.setState({
+        dispatch,
+        gameState: turnControlState(waitingFor),
+        waitingFor,
+      });
+
+      render(<OpponentSeatHeader playerId={0} />);
+
+      fireEvent.click(screen.getByTestId("opponent-seat-header-0"));
+
+      expect(screen.queryByRole("button", { name: "Target Opp 1" })).not.toBeInTheDocument();
+      expect(dispatch).not.toHaveBeenCalled();
+    });
   });
 });

--- a/client/src/components/hud/OpponentHud.tsx
+++ b/client/src/components/hud/OpponentHud.tsx
@@ -3,7 +3,7 @@ import { createPortal } from "react-dom";
 import { useTranslation } from "react-i18next";
 
 import type { PlayerId } from "../../adapter/types.ts";
-import { usePerspectivePlayerId } from "../../hooks/usePlayerId.ts";
+import { useCanActForWaitingState, usePerspectivePlayerId } from "../../hooks/usePlayerId.ts";
 import { useTurnStatus } from "../../hooks/useTurnStatus.ts";
 import { usePlayerDesignations } from "../../hooks/usePlayerDesignations.ts";
 import { getSeatColor } from "../../hooks/useSeatColor.ts";
@@ -14,7 +14,13 @@ import { getOpponentDisplayName, useMultiplayerStore } from "../../stores/multip
 import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { partitionByType } from "../../viewmodel/battlefieldProps.ts";
-import { getOpponentIds, isOneOnOne, resolveFocusedOpponent } from "../../viewmodel/gameStateView.ts";
+import {
+  getOpponentIds,
+  getWaitingForClickTargetRefs,
+  getWaitingForPlayerChoiceIds,
+  isOneOnOne,
+  resolveFocusedOpponent,
+} from "../../viewmodel/gameStateView.ts";
 import { LifeTotal } from "../controls/LifeTotal.tsx";
 import { ManaPoolSummary } from "./ManaPoolSummary.tsx";
 import { ScoreBadge } from "../draft/ScoreBadge.tsx";
@@ -159,42 +165,21 @@ export function OpponentHud({
 
   const waitingFor = useGameStore((s) => s.waitingFor);
   const dispatch = useGameStore((s) => s.dispatch);
-  const isHumanTargetSelection =
-    (waitingFor?.type === "TargetSelection" || waitingFor?.type === "TriggerTargetSelection")
-    && waitingFor.data.player === playerId;
-  const isCopyRetargetForMe = waitingFor?.type === "CopyRetarget" && waitingFor.data.player === playerId;
-  // CR 115.7: A single-target retarget (Bolt Bend) is chosen on the board, so
-  // opponents are legal click targets when they appear in `legal_new_targets`.
-  const isRetargetChoiceForMe = waitingFor?.type === "RetargetChoice"
-    && waitingFor.data.player === playerId
-    && waitingFor.data.scope.type === "Single";
-  // CR 303.4g + CR 115.1: a returned / non-spell Aura that enchants a player
-  // (a Curse) is hosted by a board pick — opponents are legal click hosts when
-  // they appear in `legal_targets`.
-  const isReturnAsAuraForMe = waitingFor?.type === "ReturnAsAuraTarget"
-    && waitingFor.data.player === playerId;
-  const isTargeting = isHumanTargetSelection || isCopyRetargetForMe || isRetargetChoiceForMe || isReturnAsAuraForMe;
-  const currentLegalTargets = useMemo(() => {
-    if (isHumanTargetSelection) {
-      return waitingFor.data.selection?.current_legal_targets ?? [];
-    }
-    if (isCopyRetargetForMe) {
-      const slot = waitingFor.data.target_slots[waitingFor.data.current_slot ?? 0];
-      return slot?.legal_alternatives ?? [];
-    }
-    if (isRetargetChoiceForMe) {
-      return waitingFor.data.legal_new_targets;
-    }
-    if (isReturnAsAuraForMe) {
-      return waitingFor.data.legal_targets;
-    }
-    return [];
-  }, [isHumanTargetSelection, isCopyRetargetForMe, isRetargetChoiceForMe, isReturnAsAuraForMe, waitingFor]);
+  const canActForWaitingState = useCanActForWaitingState();
+  // `null` = the engine is not asking THIS client to click a target; `[]` = it is
+  // asking but nothing is legal yet. `isTargeting` needs that distinction, which
+  // is why the refs authority is read here rather than a length check. Two tab
+  // behaviours ride on it: the peek popover's targeting presentation (legal
+  // targets sorted to the front, cyan ring) and `showIncomingOnHover`, which
+  // decides whether hovering an attacking tab shows threats or the board peek.
+  const clickTargetRefs = useMemo(
+    () => (canActForWaitingState ? getWaitingForClickTargetRefs(waitingFor) : null),
+    [canActForWaitingState, waitingFor],
+  );
+  const isTargeting = clickTargetRefs !== null;
   const validPlayerTargetIds = useMemo(
-    () => currentLegalTargets
-      .filter((tgt): tgt is { Player: number } => "Player" in tgt)
-      .map((tgt) => tgt.Player),
-    [currentLegalTargets],
+    () => (canActForWaitingState ? getWaitingForPlayerChoiceIds(waitingFor) : []),
+    [canActForWaitingState, waitingFor],
   );
   // Object targets grouped by their controller, so each `OpponentTab` can
   // show only that opponent's legal targets in the peek popover. The set
@@ -203,7 +188,7 @@ export function OpponentHud({
   const legalObjectTargetsByController = useMemo(() => {
     const map = new Map<PlayerId, ObjectId[]>();
     if (!objectsMapForTargets) return map;
-    for (const tgt of currentLegalTargets) {
+    for (const tgt of clickTargetRefs ?? []) {
       if (!("Object" in tgt)) continue;
       const obj = objectsMapForTargets[tgt.Object];
       if (!obj) continue;
@@ -212,7 +197,7 @@ export function OpponentHud({
       map.set(obj.controller, list);
     }
     return map;
-  }, [currentLegalTargets, objectsMapForTargets]);
+  }, [clickTargetRefs, objectsMapForTargets]);
 
   const handlePlayerTarget = useCallback(
     (targetPlayerId: number) => {

--- a/client/src/components/hud/PlayerHud.tsx
+++ b/client/src/components/hud/PlayerHud.tsx
@@ -1,13 +1,14 @@
 import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 
-import { usePerspectivePlayerId } from "../../hooks/usePlayerId.ts";
+import { useCanActForWaitingState, usePerspectivePlayerId } from "../../hooks/usePlayerId.ts";
 import { usePlayerDesignations } from "../../hooks/usePlayerDesignations.ts";
 import { useSeatColor } from "../../hooks/useSeatColor.ts";
 import { useIsCompactHeight } from "../../hooks/useIsCompactHeight.ts";
 import { useIsMobile } from "../../hooks/useIsMobile.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { getPlayerDisplayName, useMultiplayerStore } from "../../stores/multiplayerStore.ts";
+import { getWaitingForPlayerChoiceIds } from "../../viewmodel/gameStateView.ts";
 import { ScoreBadge } from "../draft/ScoreBadge.tsx";
 import { ManualManaToggle } from "../board/ManualManaToggle.tsx";
 import { UndoButton } from "../board/UndoButton.tsx";
@@ -44,30 +45,16 @@ export function PlayerHud() {
   const isCompactHeight = useIsCompactHeight();
   const compact = isMobile || isCompactHeight;
 
-  const isHumanTargetSelection =
-    (waitingFor?.type === "TargetSelection" || waitingFor?.type === "TriggerTargetSelection")
-    && waitingFor.data.player === playerId;
-  const isCopyRetargetForMe = waitingFor?.type === "CopyRetarget" && waitingFor.data.player === playerId;
-  const copyRetargetCurrentSlotHasMe = isCopyRetargetForMe && (() => {
-    const slot = waitingFor.data.target_slots[waitingFor.data.current_slot ?? 0];
-    return (slot?.legal_alternatives ?? []).some((t) => "Player" in t && t.Player === playerId);
-  })();
-  // CR 115.7: A single-target retarget (Bolt Bend on a spell aimed at a player)
-  // can redirect to this player — same board-click path as normal targeting.
-  const retargetChoiceHasMe = waitingFor?.type === "RetargetChoice"
-    && waitingFor.data.player === playerId
-    && waitingFor.data.scope.type === "Single"
-    && waitingFor.data.legal_new_targets.some((t) => "Player" in t && t.Player === playerId);
-  // CR 303.4g + CR 115.1: a returned / non-spell Aura that can enchant a player
-  // (a Curse) is hosted by a board pick — the picker's controller may attach it
-  // to this player when they appear in `legal_targets`. Click dispatches the
-  // same `ChooseTarget { Player }` the engine accepts (engine.rs ~2984).
-  const returnAsAuraHasMe = waitingFor?.type === "ReturnAsAuraTarget"
-    && waitingFor.data.player === playerId
-    && waitingFor.data.legal_targets.some((t) => "Player" in t && t.Player === playerId);
-  const isValidTarget = (isHumanTargetSelection && (waitingFor.data.selection?.current_legal_targets ?? []).some(
-    (target) => "Player" in target && target.Player === playerId,
-  )) || copyRetargetCurrentSlotHasMe || retargetChoiceHasMe || returnAsAuraHasMe;
+  const canActForWaitingState = useCanActForWaitingState();
+  // CR 115.1: the engine's legal set can name this seat. `getWaitingForPlayerChoiceIds`
+  // is the single WaitingFor -> choosable-PlayerId authority every seat-rendering
+  // surface reads, so a new player-targetable prompt lights this HUD up without a
+  // per-variant branch here. The hook resolves the REAL seat (may this client
+  // answer?); `playerId` is the RENDERED seat (did the engine name it?). CR 723:
+  // under a turn-control effect these are different players, and both questions
+  // still have to be answered.
+  const isValidTarget =
+    canActForWaitingState && getWaitingForPlayerChoiceIds(waitingFor).includes(playerId);
 
   const handleTargetClick = useCallback(() => {
     if (isValidTarget) {

--- a/client/src/components/hud/__tests__/OpponentHud.test.tsx
+++ b/client/src/components/hud/__tests__/OpponentHud.test.tsx
@@ -1,5 +1,5 @@
 import { act } from "react";
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import type { GameState, TargetRef, WaitingFor } from "../../../adapter/types.ts";
@@ -11,6 +11,7 @@ import { useUiStore } from "../../../stores/uiStore.ts";
 import {
   buildGameObject,
   buildObjectMap,
+  gameObjectFactory,
 } from "../../../test/factories/gameObjectFactory.ts";
 import {
   buildCommanderFormatConfig,
@@ -22,6 +23,7 @@ import {
   buildTargetSelectionProgress,
   buildTargetSelectionSlot,
   buildTargetSelectionWaitingFor,
+  targetSelectionWaitingForFactory,
 } from "../../../test/factories/gameStateFactory.ts";
 
 function setViewportWidth(width: number) {
@@ -54,10 +56,14 @@ describe("OpponentHud", () => {
   beforeEach(() => {
     setViewportWidth(1024);
     localStorage.clear();
-    useMultiplayerStore.setState({ activePlayerId: 0 });
-    usePreferencesStore.setState({ followActiveOpponent: false });
+    // `useCanActForWaitingState` short-circuits on EITHER `gameMode === "spectate"`
+    // OR `isSpectator`, and the two live in different module-singleton stores that
+    // persist across tests in this file. Both are reset here, not only in
+    // `afterEach`, so one spectator row cannot make every later seated row inert.
+    useMultiplayerStore.setState({ activePlayerId: 0, isSpectator: false });
+    usePreferencesStore.setState({ followActiveOpponent: false, battlefieldPeekOnHover: false });
     useUiStore.setState({ focusedOpponent: 1 });
-    useGameStore.setState({ gameState: createGameState() });
+    useGameStore.setState({ gameState: createGameState(), gameMode: null, waitingFor: null });
   });
 
   afterEach(() => {
@@ -535,5 +541,283 @@ describe("OpponentHud", () => {
     expect(document.querySelector('[data-player-hud="3"]')).toBeTruthy();
     expect(screen.queryByRole("button", { name: /Opp 2/ })).toBeNull();
     expect(screen.queryByRole("button", { name: /OUT/i })).toBeNull();
+  });
+
+  // ── The player axis reads one authority behind one actor gate ─────────────
+  //
+  // `OpponentHud` now derives `clickTargetRefs` (the raw `TargetRef[] | null`)
+  // and `validPlayerTargetIds` (its player projection) from
+  // `getWaitingForClickTargetRefs` / `getWaitingForPlayerChoiceIds`, both gated
+  // on `useCanActForWaitingState()`.
+
+  /** A `TargetSelection` addressed to the local seat with the given legal set. */
+  function targetingLocalSeat(legal: TargetRef[]): WaitingFor {
+    return targetSelectionWaitingForFactory
+      .withData({
+        selection: buildTargetSelectionProgress({ current_legal_targets: legal }),
+        target_slots: [buildTargetSelectionSlot({ legal_targets: legal })],
+        pending_cast: buildPendingCast(),
+      })
+      .forPlayer(0)
+      .build();
+  }
+
+  // V8 row 2 — the multiplayer tab. `OpponentHud` exposes the `Target <name>`
+  // accessible name only on an ALREADY-FOCUSED tab (the two-click FFA model), so
+  // seat 1 is pre-focused in `beforeEach`; without that the assertion would pass
+  // with or without the fix. The four seated FFA-disambiguation tests above are
+  // this row's reach guards.
+  it("offers no target commit on a multiplayer tab to a spectating client", () => {
+    const dispatch = vi.fn().mockResolvedValue([]);
+    const wf = targetingLocalSeat([{ Player: 1 }]);
+    act(() => {
+      useMultiplayerStore.setState({ isSpectator: true });
+      useUiStore.setState({ focusedOpponent: 1 });
+      useGameStore.setState({
+        dispatch,
+        gameMode: "spectate",
+        gameState: createGameState({ waiting_for: wf }),
+        waitingFor: wf,
+      });
+    });
+
+    render(<OpponentHud />);
+
+    expect(screen.queryByRole("button", { name: "Target Opp 2" })).toBeNull();
+    fireEvent.click(screen.getByRole("button", { name: /Opp 2/ }));
+    expect(dispatch).not.toHaveBeenCalled();
+  });
+
+  // V8 row 3 — the 1v1 pill, the fourth seat surface. `HudPlate` renders a
+  // `<button>` when it has an `onClick` and a `<div>` otherwise, so
+  // `[data-hud-plate]`'s tagName reads `isValidTarget` directly. Two live seats
+  // means `isMultiplayer` is false and exactly one plate renders.
+  describe("1v1 opponent pill", () => {
+    function mountOneOnOne(waitingFor: WaitingFor) {
+      const dispatch = vi.fn().mockResolvedValue([]);
+      act(() => {
+        useGameStore.setState({
+          dispatch,
+          gameState: createGameState({
+            players: buildPlayers([
+              { id: 0, life: 20 },
+              { id: 1, life: 20 },
+            ]),
+            seat_order: [0, 1],
+            format_config: buildFormatConfig(),
+            waiting_for: waitingFor,
+          }),
+          waitingFor,
+        });
+      });
+      render(<OpponentHud />);
+      return { dispatch };
+    }
+
+    it("offers the opponent pill to the seated player", () => {
+      const { dispatch } = mountOneOnOne(targetingLocalSeat([{ Player: 1 }]));
+
+      const plates = document.querySelectorAll("[data-hud-plate]");
+      expect(plates).toHaveLength(1);
+      expect(plates[0].tagName).toBe("BUTTON");
+
+      fireEvent.click(plates[0]);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "ChooseTarget",
+        data: { target: { Player: 1 } },
+      });
+    });
+
+    it("offers no pill affordance to a spectating client", () => {
+      act(() => {
+        useMultiplayerStore.setState({ isSpectator: true });
+        useGameStore.setState({ gameMode: "spectate" });
+      });
+      const { dispatch } = mountOneOnOne(targetingLocalSeat([{ Player: 1 }]));
+
+      const plates = document.querySelectorAll("[data-hud-plate]");
+      expect(plates).toHaveLength(1);
+      expect(plates[0].tagName).toBe("DIV");
+
+      fireEvent.click(plates[0]);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+  });
+
+  // V9 / V10 / V13 — the two OTHER consumers of the rewritten derivation, both
+  // inside `OpponentTab`: `legalObjectTargetsByController` (which now iterates
+  // `clickTargetRefs ?? []`) and `isTargeting` (now `clickTargetRefs !== null`).
+  //
+  // MANDATORY `await`: `PortaledPopover` holds `pos === null` until a
+  // `requestAnimationFrame` callback fires and returns `null` until then, so on
+  // the tick `fireEvent.mouseEnter` returns NEITHER popover is in the DOM. A
+  // synchronous read is a uniform false that makes the positives fail and the
+  // negatives pass vacuously. Every assertion below — negatives included — comes
+  // after an `await screen.findByText(...)` for the popover the row expects.
+  describe("opponent tab hover popovers", () => {
+    // Seat 1 is focused by `beforeEach`, so seat 2 is the non-focused tab these
+    // rows hover. Distinct names keep the three cards individually addressable.
+    const ALPHA = 401;
+    const BETA = 402;
+    const GAMMA = 403;
+
+    function boardOfSeatTwo() {
+      return {
+        battlefield: [ALPHA, BETA, GAMMA],
+        objects: buildObjectMap(
+          gameObjectFactory.creature(1, 1).onBattlefield().ownedBy(2)
+            .withId(ALPHA).named("Alpha Bear").build(),
+          gameObjectFactory.creature(2, 2).onBattlefield().ownedBy(2)
+            .withId(BETA).named("Beta Bear").build(),
+          gameObjectFactory.creature(3, 3).onBattlefield().ownedBy(2)
+            .withId(GAMMA).named("Gamma Bear").build(),
+        ),
+      };
+    }
+
+    function mountBoard(waitingFor: WaitingFor, overrides: Partial<GameState> = {}) {
+      act(() => {
+        usePreferencesStore.setState({ battlefieldPeekOnHover: true });
+        useGameStore.setState({
+          gameState: createGameState({
+            ...boardOfSeatTwo(),
+            waiting_for: waitingFor,
+            ...overrides,
+          }),
+          waitingFor,
+        });
+      });
+      render(<OpponentHud />);
+    }
+
+    const hoverSeatTwoTab = () =>
+      fireEvent.mouseEnter(screen.getByRole("button", { name: /Opp 3/ }));
+
+    /**
+     * The peeked cards in render order, read through the P/T tile the popover
+     * itself renders from `objects[group.ids[0]]`.
+     *
+     * Deliberately NOT read through `CardImage`'s "Loading {{name}}" aria-label:
+     * `useCardImage` resolves asynchronously and caches by name across tests in
+     * the same file, so which `CardImage` branch is mounted (loading placeholder
+     * vs `<img alt>` vs artless text tile) depends on test ORDER. [measured] the
+     * label-based read passed in isolation and failed third-in-file. The P/T
+     * tile is owned by the popover and is unaffected by art resolution, so the
+     * three Bears carry distinct P/T (Alpha 1/1, Beta 2/2, Gamma 3/3) purely to
+     * make group order legible here.
+     */
+    const peekedPT = (popover: HTMLElement) =>
+      within(popover).getAllByText(/^\d+\/\d+$/).map((el) => el.textContent);
+
+    const openPeek = async () => {
+      hoverSeatTwoTab();
+      // MANDATORY await: PortaledPopover returns null until a rAF sets position.
+      const heading = await screen.findByText("Opp 3's board");
+      return heading.parentElement as HTMLElement;
+    };
+
+    const ALPHA_PT = "1/1";
+    const BETA_PT = "2/2";
+    const GAMMA_PT = "3/3";
+
+    // V9 — `legalObjectTargetsByController` still reaches the popover and still
+    // reorders it. This is the only reachable observable that reads
+    // `legalTargetIds`: the " (not targetable)" legend needs > 12 permanents.
+    it("sorts a legal object target to the front of the peek popover", async () => {
+      mountBoard(targetingLocalSeat([{ Object: GAMMA }]));
+
+      expect(peekedPT(await openPeek())).toEqual([GAMMA_PT, ALPHA_PT, BETA_PT]);
+    });
+
+    // Second positive: a different legal id gives a different order, so the sort
+    // tracks the specific id rather than applying a fixed permutation.
+    it("sorts whichever object the engine made legal to the front", async () => {
+      mountBoard(targetingLocalSeat([{ Object: BETA }]));
+
+      expect(peekedPT(await openPeek())).toEqual([BETA_PT, ALPHA_PT, GAMMA_PT]);
+    });
+
+    // Reach guard: with no targeting in progress the popover keeps battlefield
+    // order, proving the reordering above is caused by the targeting state and
+    // not by the fixture.
+    it("keeps battlefield order when no targeting is in progress", async () => {
+      mountBoard(buildPriorityWaitingFor({ data: { player: 2 } }));
+
+      expect(peekedPT(await openPeek())).toEqual([ALPHA_PT, BETA_PT, GAMMA_PT]);
+    });
+
+    // ── V10 / V13: `isTargeting` picks which popover opens ──────────────────
+    // `showIncomingOnHover` is `hasIncoming && !isFocused && !isTargeting`, so
+    // with an attacker on the hovered tab it is `isTargeting` alone that decides.
+    function withIncomingAttacker(): Partial<GameState> {
+      return {
+        combat: {
+          attackers: [
+            { object_id: ALPHA, defending_player: 0, attack_target: { type: "Player", data: 0 } },
+          ],
+          blocker_assignments: {},
+          blocker_to_attacker: {},
+          blockers_declared_by: [],
+          pending_blocker_declaration_events: [],
+          damage_assignments: {},
+          first_strike_done: false,
+          damage_step_index: null,
+          pending_damage: [],
+          regular_damage_done: false,
+        },
+      };
+    }
+
+    // V10 — the row that justifies the `TargetRef[] | null` return type. The
+    // legal set is EMPTY, so a `(clickTargetRefs ?? []).length > 0` reading of
+    // `isTargeting` would open the incoming popover instead.
+    it("treats a live prompt with an empty legal set as targeting", async () => {
+      mountBoard(targetingLocalSeat([]), withIncomingAttacker());
+
+      hoverSeatTwoTab();
+      await screen.findByText("Opp 3's board");
+
+      expect(screen.queryAllByText(/incoming from/)).toHaveLength(0);
+    });
+
+    // Reach guard for V10: the same fixture with no prompt opens the incoming
+    // popover, so the row above is about the gate rather than about a fixture
+    // that renders nothing. Queried by `/incoming from/`, not `⚔×`: the
+    // always-present attacker badge carries the same `⚔×` prefix.
+    it("opens the incoming-attackers popover when no prompt is live", async () => {
+      mountBoard(buildPriorityWaitingFor({ data: { player: 2 } }), withIncomingAttacker());
+
+      hoverSeatTwoTab();
+      await screen.findByText(/incoming from/);
+
+      expect(screen.queryByText("Opp 3's board")).toBeNull();
+    });
+
+    // V13 — the spectator-only relaxation `showIncomingOnHover` inherits from the
+    // new gate. A spectator is not targeting, so the threat-surfacing overlay
+    // should no longer be suppressed on their screen. Row (a) below is the
+    // seated reach guard, proving the fixture really does produce `hasIncoming`
+    // on a hoverable non-focused tab.
+    it("suppresses the incoming popover for the seated player who is targeting", async () => {
+      mountBoard(targetingLocalSeat([{ Player: 2 }]), withIncomingAttacker());
+
+      hoverSeatTwoTab();
+      await screen.findByText("Opp 3's board");
+
+      expect(screen.queryAllByText(/incoming from/)).toHaveLength(0);
+    });
+
+    it("shows the incoming popover to a spectator during the same prompt", async () => {
+      act(() => {
+        useMultiplayerStore.setState({ isSpectator: true });
+        useGameStore.setState({ gameMode: "spectate" });
+      });
+      mountBoard(targetingLocalSeat([{ Player: 2 }]), withIncomingAttacker());
+
+      hoverSeatTwoTab();
+      await screen.findByText(/incoming from/);
+
+      expect(screen.queryByText("Opp 3's board")).toBeNull();
+    });
   });
 });

--- a/client/src/components/hud/__tests__/PlayerHud.test.tsx
+++ b/client/src/components/hud/__tests__/PlayerHud.test.tsx
@@ -135,7 +135,7 @@ describe("PlayerHud", () => {
       });
     });
 
-    // CR 115.7: a single-target retarget (Bolt Bend, Redirect) is answered by a
+    // CR 115.7: a single-target retarget (Bolt Bend, Misdirection) is answered by a
     // HUD click.
     it("offers the seat for RetargetChoice(Single)", () => {
       const { dispatch } = mount(

--- a/client/src/components/hud/__tests__/PlayerHud.test.tsx
+++ b/client/src/components/hud/__tests__/PlayerHud.test.tsx
@@ -1,16 +1,30 @@
 import { act } from "react";
-import { cleanup, render, screen } from "@testing-library/react";
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { GameState, TargetRef, WaitingFor } from "../../../adapter/types.ts";
 import { useGameStore } from "../../../stores/gameStore.ts";
 import { useMultiplayerStore } from "../../../stores/multiplayerStore.ts";
-import { buildGameState } from "../../../test/factories/gameStateFactory.ts";
+import {
+  buildCopyTargetSlot,
+  buildGameState,
+  buildTargetSelectionProgress,
+  buildTargetSelectionSlot,
+  copyRetargetWaitingForFactory,
+  retargetChoiceWaitingForFactory,
+  returnAsAuraTargetWaitingForFactory,
+  targetSelectionWaitingForFactory,
+} from "../../../test/factories/gameStateFactory.ts";
 import { PlayerHud } from "../PlayerHud.tsx";
 
 describe("PlayerHud", () => {
   beforeEach(() => {
-    useMultiplayerStore.setState({ activePlayerId: 0 });
-    useGameStore.setState({ gameState: buildGameState() });
+    // `useCanActForWaitingState` short-circuits on EITHER `gameMode === "spectate"`
+    // OR `isSpectator`, and the two live in different module-singleton stores that
+    // persist across tests in this file. Both are reset here, not only in
+    // `afterEach`, so one spectator row cannot make every later seated row inert.
+    useMultiplayerStore.setState({ activePlayerId: 0, isSpectator: false });
+    useGameStore.setState({ gameState: buildGameState(), gameMode: null, waitingFor: null });
   });
 
   afterEach(() => {
@@ -60,5 +74,191 @@ describe("PlayerHud", () => {
     render(<PlayerHud />);
 
     expect(screen.getByTitle("This player's turn is next.")).toHaveTextContent("Next Up");
+  });
+
+  // ── The player-target affordance: one authority + one actor gate ──────────
+  //
+  // `isValidTarget` is now
+  // `useCanActForWaitingState() && getWaitingForPlayerChoiceIds(waitingFor).includes(playerId)`.
+  // `HudPlate` renders a `<button>` when it has an `onClick` and a `<div>`
+  // otherwise (HudPlate.tsx), so `[data-hud-plate]`'s tagName reads
+  // `isValidTarget` directly.
+  describe("player-target affordance", () => {
+    const plateTag = () => document.querySelector("[data-hud-plate]")?.tagName;
+
+    function mount(waitingFor: WaitingFor, gameState: GameState = buildGameState()) {
+      const dispatch = vi.fn().mockResolvedValue([]);
+      act(() => {
+        useGameStore.setState({ dispatch, gameState, waitingFor });
+      });
+      render(<PlayerHud />);
+      return { dispatch };
+    }
+
+    const legal = (players: number[]): TargetRef[] => players.map((p) => ({ Player: p }));
+
+    function targetSelection(players: number[], forPlayer = 0) {
+      return targetSelectionWaitingForFactory
+        .withData({
+          selection: buildTargetSelectionProgress({ current_legal_targets: legal(players) }),
+          target_slots: [buildTargetSelectionSlot({ legal_targets: legal(players) })],
+        })
+        .forPlayer(forPlayer)
+        .build();
+    }
+
+    // V6 — one row per distinct `case` body in the authority. The
+    // `TargetSelection` / `TriggerTargetSelection` body is one shared arm and is
+    // covered by the seated reach guard in the spectator block below.
+
+    // CR 707.10c: the copy's controller retargets the slot the engine is asking
+    // about, so the offer must follow `current_slot`.
+    it("offers the seat for CopyRetarget's current slot", () => {
+      const { dispatch } = mount(
+        copyRetargetWaitingForFactory
+          .withData({
+            current_slot: 1,
+            target_slots: [
+              buildCopyTargetSlot({ legal_alternatives: legal([1]) }),
+              buildCopyTargetSlot({ legal_alternatives: legal([0]) }),
+            ],
+          })
+          .forPlayer(0)
+          .build(),
+      );
+
+      expect(plateTag()).toBe("BUTTON");
+      fireEvent.click(document.querySelector("[data-hud-plate]")!);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "ChooseTarget",
+        data: { target: { Player: 0 } },
+      });
+    });
+
+    // CR 115.7: a single-target retarget (Bolt Bend, Redirect) is answered by a
+    // HUD click.
+    it("offers the seat for RetargetChoice(Single)", () => {
+      const { dispatch } = mount(
+        retargetChoiceWaitingForFactory
+          .withData({ scope: { type: "Single" }, legal_new_targets: legal([0]) })
+          .forPlayer(0)
+          .build(),
+      );
+
+      expect(plateTag()).toBe("BUTTON");
+      fireEvent.click(document.querySelector("[data-hud-plate]")!);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "ChooseTarget",
+        data: { target: { Player: 0 } },
+      });
+    });
+
+    // CR 303.4: an Aura enters attached to an object OR a player, so a Curse can
+    // name this seat as its host.
+    it("offers the seat for ReturnAsAuraTarget", () => {
+      const { dispatch } = mount(
+        returnAsAuraTargetWaitingForFactory
+          .withData({ legal_targets: legal([0]) })
+          .forPlayer(0)
+          .build(),
+      );
+
+      expect(plateTag()).toBe("BUTTON");
+      fireEvent.click(document.querySelector("[data-hud-plate]")!);
+      expect(dispatch).toHaveBeenCalledWith({
+        type: "ChooseTarget",
+        data: { target: { Player: 0 } },
+      });
+    });
+
+    // The negative sibling of the shared TargetSelection arm: the engine offers a
+    // DIFFERENT seat, so this HUD stays inert.
+    it("does not offer the seat when the engine names a different player", () => {
+      const { dispatch } = mount(targetSelection([1]));
+
+      expect(plateTag()).toBe("DIV");
+      fireEvent.click(document.querySelector("[data-hud-plate]")!);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    // V7 — the fix. `dispatch.ts` silently refuses a spectator's action, so
+    // offering the affordance at all is a false live-looking control.
+    it("gives a spectating client no affordance, and the seated client the same fixture as a reach guard", () => {
+      const seated = mount(targetSelection([0]));
+      expect(plateTag()).toBe("BUTTON");
+      fireEvent.click(document.querySelector("[data-hud-plate]")!);
+      expect(seated.dispatch).toHaveBeenCalledWith({
+        type: "ChooseTarget",
+        data: { target: { Player: 0 } },
+      });
+      cleanup();
+
+      const dispatch = vi.fn().mockResolvedValue([]);
+      act(() => {
+        useMultiplayerStore.setState({ isSpectator: true });
+        useGameStore.setState({
+          dispatch,
+          gameMode: "spectate",
+          gameState: buildGameState(),
+          waitingFor: targetSelection([0]),
+        });
+      });
+      render(<PlayerHud />);
+
+      expect(plateTag()).toBe("DIV");
+      fireEvent.click(document.querySelector("[data-hud-plate]")!);
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    // The multiplayer-spectator shape the old inline gate also missed: a
+    // spectator whose `gameMode` is still null but whose seat is spectating.
+    it("gives an isSpectator client no affordance even when gameMode is null", () => {
+      act(() => {
+        useMultiplayerStore.setState({ isSpectator: true });
+      });
+      const { dispatch } = mount(targetSelection([0]));
+
+      expect(plateTag()).toBe("DIV");
+      expect(dispatch).not.toHaveBeenCalled();
+    });
+
+    // V12 — CR 723.1 turn control (a player controls another player for that
+    // player's whole turn), and CR 723.3: only control of the player changes —
+    // a controlled player is still the active player. So
+    // `useCanActForWaitingState` resolves the REAL
+    // seat (`usePlayerId`), the membership test resolves the RENDERED seat
+    // (`usePerspectivePlayerId`), and under `turn_decision_controller` these are
+    // two different players. Both rows assert the rendered seat so a future
+    // change to `usePerspectivePlayerId` cannot make them pass for the wrong
+    // reason.
+    describe("under a turn-control effect (CR 723.1 / CR 723.3)", () => {
+      const turnControlState = () =>
+        buildGameState({ turn_decision_controller: 0, active_player: 1 });
+
+      it("offers the piloted seat when the engine names it", () => {
+        // Real seat 0 pilots seat 1's turn, so this HUD renders seat 1. The
+        // prompt is addressed to seat 0 (`data.player`) and offers seat 1.
+        const { dispatch } = mount(targetSelection([1], 0), turnControlState());
+
+        expect(document.querySelector("[data-player-hud]")?.getAttribute("data-player-hud"))
+          .toBe("1");
+        expect(plateTag()).toBe("BUTTON");
+        fireEvent.click(document.querySelector("[data-hud-plate]")!);
+        expect(dispatch).toHaveBeenCalledWith({
+          type: "ChooseTarget",
+          data: { target: { Player: 1 } },
+        });
+      });
+
+      it("stays inert when the engine names the real seat this HUD does not render", () => {
+        const { dispatch } = mount(targetSelection([0], 0), turnControlState());
+
+        expect(document.querySelector("[data-player-hud]")?.getAttribute("data-player-hud"))
+          .toBe("1");
+        expect(plateTag()).toBe("DIV");
+        fireEvent.click(document.querySelector("[data-hud-plate]")!);
+        expect(dispatch).not.toHaveBeenCalled();
+      });
+    });
   });
 });

--- a/client/src/test/factories/gameStateFactory.ts
+++ b/client/src/test/factories/gameStateFactory.ts
@@ -38,6 +38,7 @@ type LoopShortcutWaitingFor = Extract<WaitingFor, { type: "LoopShortcut" }>;
 type RespondToShortcutWaitingFor = Extract<WaitingFor, { type: "RespondToShortcut" }>;
 type CopyRetargetWaitingFor = Extract<WaitingFor, { type: "CopyRetarget" }>;
 type RetargetChoiceWaitingFor = Extract<WaitingFor, { type: "RetargetChoice" }>;
+type ReturnAsAuraTargetWaitingFor = Extract<WaitingFor, { type: "ReturnAsAuraTarget" }>;
 type WaitingForWithData = Extract<WaitingFor, { data: object }>;
 
 /**
@@ -317,6 +318,27 @@ export const buildRetargetChoiceWaitingFor = (
   overrides: Partial<RetargetChoiceWaitingFor> = {},
 ): RetargetChoiceWaitingFor => {
   return retargetChoiceWaitingForFactory.withData(overrides.data ?? {}).build();
+};
+
+export class ReturnAsAuraTargetWaitingForFactory
+  extends PlayerWaitingForFactory<ReturnAsAuraTargetWaitingFor> {}
+
+export const returnAsAuraTargetWaitingForFactory =
+  ReturnAsAuraTargetWaitingForFactory.define((): ReturnAsAuraTargetWaitingFor => ({
+    type: "ReturnAsAuraTarget",
+    data: {
+      player: 0,
+      source_id: 1,
+      returned_id: 2,
+      legal_targets: [],
+      pending_effect: null,
+    },
+  }));
+
+export const buildReturnAsAuraTargetWaitingFor = (
+  overrides: Partial<ReturnAsAuraTargetWaitingFor> = {},
+): ReturnAsAuraTargetWaitingFor => {
+  return returnAsAuraTargetWaitingForFactory.withData(overrides.data ?? {}).build();
 };
 
 export class ChooseXValueWaitingForFactory extends PlayerWaitingForFactory<ChooseXValueWaitingFor> {}

--- a/client/src/viewmodel/__tests__/gameStateView.test.ts
+++ b/client/src/viewmodel/__tests__/gameStateView.test.ts
@@ -1061,7 +1061,7 @@ describe("getWaitingForPlayerChoiceIds", () => {
     expect(getWaitingForObjectChoiceIds(wf)).toEqual([7]);
   });
 
-  // CR 115.7: Bolt Bend / Redirect retarget a single-target spell by a click.
+  // CR 115.7: Bolt Bend / Misdirection retarget a single-target spell by a click.
   it("projects RetargetChoice(Single) player refs", () => {
     const wf = retargetChoiceWaitingForFactory
       .withData({ scope: { type: "Single" }, legal_new_targets: MIXED_LEGAL })

--- a/client/src/viewmodel/__tests__/gameStateView.test.ts
+++ b/client/src/viewmodel/__tests__/gameStateView.test.ts
@@ -1,15 +1,30 @@
 import { describe, expect, it } from "vitest";
 
-import type { GameAction, GameObject, GameState, PlayerId, WaitingFor } from "../../adapter/types";
+import type {
+  GameAction,
+  GameObject,
+  GameState,
+  PlayerId,
+  TargetRef,
+  WaitingFor,
+} from "../../adapter/types";
 import {
   buildGameObject,
   buildGameObjectWithCoreTypes,
   buildObjectMap,
 } from "../../test/factories/gameObjectFactory";
 import {
+  buildCopyTargetSlot,
   buildGameState,
   buildGameStateWithoutSeatOrder,
   buildPlayers,
+  buildTargetSelectionProgress,
+  buildTargetSelectionSlot,
+  copyRetargetWaitingForFactory,
+  retargetChoiceWaitingForFactory,
+  returnAsAuraTargetWaitingForFactory,
+  targetSelectionWaitingForFactory,
+  triggerTargetSelectionWaitingForFactory,
 } from "../../test/factories/gameStateFactory";
 import {
   boardChoiceSelectedPower,
@@ -21,7 +36,9 @@ import {
   getOpponentIds,
   getSeatCount,
   getVisibleBoardPlayerIds,
+  getWaitingForClickTargetRefs,
   getWaitingForObjectChoiceIds,
+  getWaitingForPlayerChoiceIds,
   isFaceDownExileCardVisibleToViewer,
   isOneOnOne,
   isSplitBoardActive,
@@ -727,5 +744,491 @@ describe("isFaceDownExileCardVisibleToViewer", () => {
 
     expect(isFaceDownExileCardVisibleToViewer(state, visible, 1)).toBe(true);
     expect(isFaceDownExileCardVisibleToViewer(state, hidden, 0)).toBe(false);
+  });
+});
+
+// ── The player axis of the click-target authority ────────────────────────────
+//
+// `getWaitingForClickTargetRefs` is the single WaitingFor -> engine-authored
+// `TargetRef[]` authority, and `getWaitingForPlayerChoiceIds` is its player-axis
+// projection. Every seat-rendering surface (PlayerHud, OpponentHud's 1v1 pill
+// and multiplayer tabs, OpponentSeatHeader) reads the projection instead of
+// hand-rolling a per-variant derivation.
+
+/** Every fixture below mixes an object ref and a player ref so a `flatMap` that
+ * forgot to narrow, or narrowed on the wrong key, cannot pass. */
+const MIXED_LEGAL: TargetRef[] = [{ Object: 7 }, { Player: 1 }];
+
+/**
+ * Every `WaitingFor` variant, mapped to the fixture that pins how the two
+ * click-target authorities treat it. This map is the drift gate the
+ * two-switch design owes: `Record<WaitingFor["type"], …>` is total, so the
+ * day `types.ts` gains a variant, `pnpm run type-check` fails here until
+ * someone records what the player axis does with it. A variant added to
+ * `getWaitingForObjectChoiceIds` alone can no longer land behind a green
+ * suite.
+ *
+ * `NO_TARGET_REF_LEGAL_SET` records a checked claim: the variant carries no
+ * `TargetRef[]` legal set at all, so neither authority can name a player for
+ * it. Before writing it, apply the two-criteria test in
+ * `getWaitingForClickTargetRefs`'s doc comment.
+ *
+ * The `NO_TARGET_REF_LEGAL_SET` entries are SKIPPED at runtime — they exist
+ * only for the compile-time gate. The map's size is not a runtime coverage
+ * number; the 11 `PartitionFixture` entries are.
+ */
+const NO_TARGET_REF_LEGAL_SET = "no-TargetRef-legal-set" as const;
+
+interface PartitionFixture {
+  waitingFor: WaitingFor;
+  /** The engine-authored legal list the two authorities must partition. */
+  legal: TargetRef[];
+}
+
+const PARTITION_FIXTURES: Record<
+  WaitingFor["type"],
+  PartitionFixture | typeof NO_TARGET_REF_LEGAL_SET
+> = {
+  // ── The 11 `TargetRef`-bearing variants ────────────────────────────────
+  TargetSelection: {
+    waitingFor: targetSelectionWaitingForFactory
+      .withData({
+        selection: buildTargetSelectionProgress({ current_legal_targets: MIXED_LEGAL }),
+        target_slots: [buildTargetSelectionSlot({ legal_targets: MIXED_LEGAL })],
+      })
+      .forPlayer(0)
+      .build(),
+    legal: MIXED_LEGAL,
+  },
+  TriggerTargetSelection: {
+    waitingFor: triggerTargetSelectionWaitingForFactory
+      .withData({
+        selection: buildTargetSelectionProgress({ current_legal_targets: MIXED_LEGAL }),
+        target_slots: [buildTargetSelectionSlot({ legal_targets: MIXED_LEGAL })],
+      })
+      .forPlayer(0)
+      .build(),
+    legal: MIXED_LEGAL,
+  },
+  CopyRetarget: {
+    waitingFor: copyRetargetWaitingForFactory
+      .withData({
+        current_slot: 0,
+        target_slots: [buildCopyTargetSlot({ legal_alternatives: MIXED_LEGAL })],
+      })
+      .forPlayer(0)
+      .build(),
+    legal: MIXED_LEGAL,
+  },
+  // Only the `Single`-scope shape belongs here: a `Record` keyed on `type`
+  // cannot hold two entries for one variant, so the `All`-scope pair is
+  // asserted by its own `it` below.
+  RetargetChoice: {
+    waitingFor: retargetChoiceWaitingForFactory
+      .withData({ scope: { type: "Single" }, legal_new_targets: MIXED_LEGAL })
+      .forPlayer(0)
+      .build(),
+    legal: MIXED_LEGAL,
+  },
+  ReturnAsAuraTarget: {
+    waitingFor: returnAsAuraTargetWaitingForFactory
+      .withData({ legal_targets: MIXED_LEGAL })
+      .forPlayer(0)
+      .build(),
+    legal: MIXED_LEGAL,
+  },
+  // ── Dialog-only by design: answered by a DIFFERENT GameAction ──────────
+  // Answered by `DistributeAmong { distribution }` — a click carries no amount.
+  DistributeAmong: {
+    waitingFor: {
+      type: "DistributeAmong",
+      data: { player: 0, total: 3, targets: MIXED_LEGAL, unit: { type: "Damage" } },
+    },
+    legal: MIXED_LEGAL,
+  },
+  // Answered by `SelectTargets { targets }` — CR 701.34a chooses an any-size
+  // subset of permanents and/or players, which a single click cannot express.
+  ProliferateChoice: {
+    waitingFor: { type: "ProliferateChoice", data: { player: 0, eligible: MIXED_LEGAL } },
+    legal: MIXED_LEGAL,
+  },
+  // Shares ProliferateModal and the same `SelectTargets` subset dispatch.
+  TimeTravelChoice: {
+    waitingFor: {
+      type: "TimeTravelChoice",
+      data: { player: 0, eligible: MIXED_LEGAL, phase: "Remove" },
+    },
+    legal: MIXED_LEGAL,
+  },
+  // Shares ProliferateModal; `SelectTargets` subset.
+  ChooseObjectsSelection: {
+    waitingFor: { type: "ChooseObjectsSelection", data: { player: 0, eligible: MIXED_LEGAL } },
+    legal: MIXED_LEGAL,
+  },
+  // Answered by an ORDERED `SelectTargets` (first pick is copied, second
+  // scales) — a click carries no order.
+  EachPlayerCopyChosenSelection: {
+    waitingFor: {
+      type: "EachPlayerCopyChosenSelection",
+      data: {
+        player: 0,
+        eligible: MIXED_LEGAL,
+        min: 1,
+        max: 2,
+        choose_filter: {},
+        source_id: 1,
+        source_controller: 0,
+        remaining_players: [],
+        all_choices: [],
+        scoped_players: [0],
+      },
+    },
+    legal: MIXED_LEGAL,
+  },
+  // Answered by `ChooseBranch { index }`; `parent_targets` is continuation
+  // context the modal never reads.
+  ChooseOneOfBranch: {
+    waitingFor: {
+      type: "ChooseOneOfBranch",
+      data: { player: 0, controller: 0, source_id: 1, branches: [], parent_targets: MIXED_LEGAL },
+    },
+    legal: MIXED_LEGAL,
+  },
+  // ── Everything else carries no `TargetRef[]` legal set at all ──────────
+  DeclareAttackers: NO_TARGET_REF_LEGAL_SET,
+  DeclareBlockers: NO_TARGET_REF_LEGAL_SET,
+  Priority: NO_TARGET_REF_LEGAL_SET,
+  ResolveAllConsent: NO_TARGET_REF_LEGAL_SET,
+  ResolveAllReady: NO_TARGET_REF_LEGAL_SET,
+  MeldPairChoice: NO_TARGET_REF_LEGAL_SET,
+  MeldAttackTargetChoice: NO_TARGET_REF_LEGAL_SET,
+  EntryAttackTargetChoice: NO_TARGET_REF_LEGAL_SET,
+  ActivationCostOneOfChoice: NO_TARGET_REF_LEGAL_SET,
+  MulliganDecision: NO_TARGET_REF_LEGAL_SET,
+  OpeningHandBottomCards: NO_TARGET_REF_LEGAL_SET,
+  ManaPayment: NO_TARGET_REF_LEGAL_SET,
+  ManaSourceSelection: NO_TARGET_REF_LEGAL_SET,
+  ChooseXValue: NO_TARGET_REF_LEGAL_SET,
+  PayAmountChoice: NO_TARGET_REF_LEGAL_SET,
+  GameOver: NO_TARGET_REF_LEGAL_SET,
+  ReplacementChoice: NO_TARGET_REF_LEGAL_SET,
+  EntryControllerChoice: NO_TARGET_REF_LEGAL_SET,
+  OrderTriggers: NO_TARGET_REF_LEGAL_SET,
+  CopyTargetChoice: NO_TARGET_REF_LEGAL_SET,
+  ExploreChoice: NO_TARGET_REF_LEGAL_SET,
+  EquipTarget: NO_TARGET_REF_LEGAL_SET,
+  CrewVehicle: NO_TARGET_REF_LEGAL_SET,
+  StationTarget: NO_TARGET_REF_LEGAL_SET,
+  SaddleMount: NO_TARGET_REF_LEGAL_SET,
+  ScryChoice: NO_TARGET_REF_LEGAL_SET,
+  ArrangePlanarDeckTopChoice: NO_TARGET_REF_LEGAL_SET,
+  RedistributeLifeTotals: NO_TARGET_REF_LEGAL_SET,
+  CoinFlipKeepChoice: NO_TARGET_REF_LEGAL_SET,
+  DigChoice: NO_TARGET_REF_LEGAL_SET,
+  SurveilChoice: NO_TARGET_REF_LEGAL_SET,
+  RevealChoice: NO_TARGET_REF_LEGAL_SET,
+  SearchChoice: NO_TARGET_REF_LEGAL_SET,
+  SearchPartitionChoice: NO_TARGET_REF_LEGAL_SET,
+  OutsideGameChoice: NO_TARGET_REF_LEGAL_SET,
+  BetweenGamesSideboard: NO_TARGET_REF_LEGAL_SET,
+  BetweenGamesChoosePlayDraw: NO_TARGET_REF_LEGAL_SET,
+  NamedChoice: NO_TARGET_REF_LEGAL_SET,
+  OpponentGuess: NO_TARGET_REF_LEGAL_SET,
+  SpellbookDraft: NO_TARGET_REF_LEGAL_SET,
+  DamageSourceChoice: NO_TARGET_REF_LEGAL_SET,
+  ModeChoice: NO_TARGET_REF_LEGAL_SET,
+  AbilityModeChoice: NO_TARGET_REF_LEGAL_SET,
+  DiscardToHandSize: NO_TARGET_REF_LEGAL_SET,
+  OptionalCostChoice: NO_TARGET_REF_LEGAL_SET,
+  CostTypeChoice: NO_TARGET_REF_LEGAL_SET,
+  SpliceOffer: NO_TARGET_REF_LEGAL_SET,
+  DefilerPayment: NO_TARGET_REF_LEGAL_SET,
+  CastOffer: NO_TARGET_REF_LEGAL_SET,
+  ModalFaceChoice: NO_TARGET_REF_LEGAL_SET,
+  AlternativeCastChoice: NO_TARGET_REF_LEGAL_SET,
+  MutateMergeChoice: NO_TARGET_REF_LEGAL_SET,
+  CipherEncodeChoice: NO_TARGET_REF_LEGAL_SET,
+  CastingVariantChoice: NO_TARGET_REF_LEGAL_SET,
+  ChoosePermanentTypeSlot: NO_TARGET_REF_LEGAL_SET,
+  MultiTargetSelection: NO_TARGET_REF_LEGAL_SET,
+  MiracleReveal: NO_TARGET_REF_LEGAL_SET,
+  PayCost: NO_TARGET_REF_LEGAL_SET,
+  BlightChoice: NO_TARGET_REF_LEGAL_SET,
+  PayManaAbilityMana: NO_TARGET_REF_LEGAL_SET,
+  ChooseManaColor: NO_TARGET_REF_LEGAL_SET,
+  CollectEvidenceChoice: NO_TARGET_REF_LEGAL_SET,
+  HarmonizeTapChoice: NO_TARGET_REF_LEGAL_SET,
+  OptionalEffectChoice: NO_TARGET_REF_LEGAL_SET,
+  PairChoice: NO_TARGET_REF_LEGAL_SET,
+  OpponentMayChoice: NO_TARGET_REF_LEGAL_SET,
+  LoopShortcut: NO_TARGET_REF_LEGAL_SET,
+  RespondToShortcut: NO_TARGET_REF_LEGAL_SET,
+  PrecastCopyShortcutOffer: NO_TARGET_REF_LEGAL_SET,
+  RespondToPrecastCopyShortcut: NO_TARGET_REF_LEGAL_SET,
+  UnlessPayment: NO_TARGET_REF_LEGAL_SET,
+  UnlessPaymentChooseCost: NO_TARGET_REF_LEGAL_SET,
+  WardDiscardChoice: NO_TARGET_REF_LEGAL_SET,
+  WardSacrificeChoice: NO_TARGET_REF_LEGAL_SET,
+  UnlessBounceChoice: NO_TARGET_REF_LEGAL_SET,
+  ChooseRingBearer: NO_TARGET_REF_LEGAL_SET,
+  RevealUntilKeptChoice: NO_TARGET_REF_LEGAL_SET,
+  RepeatDecision: NO_TARGET_REF_LEGAL_SET,
+  TopOrBottomChoice: NO_TARGET_REF_LEGAL_SET,
+  PopulateChoice: NO_TARGET_REF_LEGAL_SET,
+  CompanionReveal: NO_TARGET_REF_LEGAL_SET,
+  ChooseLegend: NO_TARGET_REF_LEGAL_SET,
+  CommanderZoneChoice: NO_TARGET_REF_LEGAL_SET,
+  BattleProtectorChoice: NO_TARGET_REF_LEGAL_SET,
+  TributeChoice: NO_TARGET_REF_LEGAL_SET,
+  CombatTaxPayment: NO_TARGET_REF_LEGAL_SET,
+  UntapChoice: NO_TARGET_REF_LEGAL_SET,
+  ChooseUntapSubset: NO_TARGET_REF_LEGAL_SET,
+  ExertChoice: NO_TARGET_REF_LEGAL_SET,
+  EnlistChoice: NO_TARGET_REF_LEGAL_SET,
+  PhyrexianPayment: NO_TARGET_REF_LEGAL_SET,
+  AssignCombatDamage: NO_TARGET_REF_LEGAL_SET,
+  AssignBlockerDamage: NO_TARGET_REF_LEGAL_SET,
+  MoveCountersDistribution: NO_TARGET_REF_LEGAL_SET,
+  RemoveCountersChoice: NO_TARGET_REF_LEGAL_SET,
+  ChooseFromZoneChoice: NO_TARGET_REF_LEGAL_SET,
+  BeholdChoice: NO_TARGET_REF_LEGAL_SET,
+  EffectZoneChoice: NO_TARGET_REF_LEGAL_SET,
+  DrawnThisTurnTopdeckChoice: NO_TARGET_REF_LEGAL_SET,
+  AssistChoosePlayer: NO_TARGET_REF_LEGAL_SET,
+  AssistPayment: NO_TARGET_REF_LEGAL_SET,
+  ConniveDiscard: NO_TARGET_REF_LEGAL_SET,
+  DiscardChoice: NO_TARGET_REF_LEGAL_SET,
+  ManifestDreadChoice: NO_TARGET_REF_LEGAL_SET,
+  LearnChoice: NO_TARGET_REF_LEGAL_SET,
+  ClashChooseOpponent: NO_TARGET_REF_LEGAL_SET,
+  ChooseFromZoneOpponentChooser: NO_TARGET_REF_LEGAL_SET,
+  ChooseAnnouncingOpponent: NO_TARGET_REF_LEGAL_SET,
+  ChooseGiftRecipient: NO_TARGET_REF_LEGAL_SET,
+  ClashCardPlacement: NO_TARGET_REF_LEGAL_SET,
+  VoteChoice: NO_TARGET_REF_LEGAL_SET,
+  ChooseDungeon: NO_TARGET_REF_LEGAL_SET,
+  ChooseDungeonRoom: NO_TARGET_REF_LEGAL_SET,
+  SpecializeColor: NO_TARGET_REF_LEGAL_SET,
+  ChooseRoomDoor: NO_TARGET_REF_LEGAL_SET,
+  CategoryChoice: NO_TARGET_REF_LEGAL_SET,
+  KeepWithinTotalPowerChoice: NO_TARGET_REF_LEGAL_SET,
+  KeepExactPermanentsChoice: NO_TARGET_REF_LEGAL_SET,
+  SeparatePilesChooseOpponent: NO_TARGET_REF_LEGAL_SET,
+  SeparatePilesPartition: NO_TARGET_REF_LEGAL_SET,
+  SeparatePilesChoice: NO_TARGET_REF_LEGAL_SET,
+};
+
+describe("getWaitingForPlayerChoiceIds", () => {
+  // V1 — one `it` per `case` body, each on a MIXED list so the object half is
+  // proven to be dropped rather than coincidentally absent.
+  it("projects TargetSelection player refs and leaves the object refs to the object axis", () => {
+    const wf = targetSelectionWaitingForFactory
+      .withData({
+        selection: buildTargetSelectionProgress({ current_legal_targets: MIXED_LEGAL }),
+        target_slots: [buildTargetSelectionSlot({ legal_targets: MIXED_LEGAL })],
+      })
+      .forPlayer(0)
+      .build();
+
+    expect(getWaitingForPlayerChoiceIds(wf)).toEqual([1]);
+    expect(getWaitingForObjectChoiceIds(wf)).toEqual([7]);
+  });
+
+  it("projects TriggerTargetSelection player refs", () => {
+    const wf = triggerTargetSelectionWaitingForFactory
+      .withData({
+        selection: buildTargetSelectionProgress({ current_legal_targets: MIXED_LEGAL }),
+        target_slots: [buildTargetSelectionSlot({ legal_targets: MIXED_LEGAL })],
+      })
+      .forPlayer(0)
+      .build();
+
+    expect(getWaitingForPlayerChoiceIds(wf)).toEqual([1]);
+    expect(getWaitingForObjectChoiceIds(wf)).toEqual([7]);
+  });
+
+  // CR 707.10c: the copy's controller retargets one slot at a time.
+  it("projects CopyRetarget player refs", () => {
+    const wf = copyRetargetWaitingForFactory
+      .withData({
+        current_slot: 0,
+        target_slots: [buildCopyTargetSlot({ legal_alternatives: MIXED_LEGAL })],
+      })
+      .forPlayer(0)
+      .build();
+
+    expect(getWaitingForPlayerChoiceIds(wf)).toEqual([1]);
+    expect(getWaitingForObjectChoiceIds(wf)).toEqual([7]);
+  });
+
+  // CR 115.7: Bolt Bend / Redirect retarget a single-target spell by a click.
+  it("projects RetargetChoice(Single) player refs", () => {
+    const wf = retargetChoiceWaitingForFactory
+      .withData({ scope: { type: "Single" }, legal_new_targets: MIXED_LEGAL })
+      .forPlayer(0)
+      .build();
+
+    expect(getWaitingForPlayerChoiceIds(wf)).toEqual([1]);
+    expect(getWaitingForObjectChoiceIds(wf)).toEqual([7]);
+  });
+
+  // CR 303.4: an Aura enters attached to an object OR a player, so this legal
+  // list genuinely mixes both axes in production.
+  it("projects ReturnAsAuraTarget player refs", () => {
+    const wf = returnAsAuraTargetWaitingForFactory
+      .withData({ legal_targets: MIXED_LEGAL })
+      .forPlayer(0)
+      .build();
+
+    expect(getWaitingForPlayerChoiceIds(wf)).toEqual([1]);
+    expect(getWaitingForObjectChoiceIds(wf)).toEqual([7]);
+  });
+
+  it("returns [] for a null or absent waiting state", () => {
+    expect(getWaitingForPlayerChoiceIds(null)).toEqual([]);
+    expect(getWaitingForPlayerChoiceIds(undefined)).toEqual([]);
+    expect(getWaitingForClickTargetRefs(null)).toBeNull();
+  });
+
+  // V4 — the slot axis. The two slots offer DIFFERENT seats, so reading slot 0
+  // unconditionally is observable rather than coincidentally equal.
+  it("reads CopyRetarget's current slot, not slot 0", () => {
+    const wf = copyRetargetWaitingForFactory
+      .withData({
+        current_slot: 1,
+        target_slots: [
+          buildCopyTargetSlot({ legal_alternatives: [{ Player: 3 }] }),
+          buildCopyTargetSlot({ legal_alternatives: [{ Player: 1 }] }),
+        ],
+      })
+      .forPlayer(0)
+      .build();
+
+    expect(getWaitingForPlayerChoiceIds(wf)).toEqual([1]);
+  });
+
+  it("falls back to CopyRetarget slot 0 when current_slot is omitted", () => {
+    const wf = copyRetargetWaitingForFactory
+      .withData({
+        target_slots: [
+          buildCopyTargetSlot({ legal_alternatives: [{ Player: 3 }] }),
+          buildCopyTargetSlot({ legal_alternatives: [{ Player: 1 }] }),
+        ],
+      })
+      .forPlayer(0)
+      .build();
+    delete wf.data.current_slot;
+
+    expect(getWaitingForPlayerChoiceIds(wf)).toEqual([3]);
+  });
+
+  // V3 — an `All`-scope retarget is not a click prompt at all: the engine has no
+  // `ChooseTarget` apply arm for it, and RetargetChoiceModal keeps its pointer
+  // events for the confirm button. The paired `Single` positive on the IDENTICAL
+  // payload proves the exclusion keys on the scope, not on the whole variant.
+  it("excludes RetargetChoice(All) while accepting the identical Single payload", () => {
+    const allScope = retargetChoiceWaitingForFactory
+      .withData({ scope: { type: "All" }, legal_new_targets: MIXED_LEGAL })
+      .forPlayer(0)
+      .build();
+    const singleScope = retargetChoiceWaitingForFactory
+      .withData({ scope: { type: "Single" }, legal_new_targets: MIXED_LEGAL })
+      .forPlayer(0)
+      .build();
+
+    expect(getWaitingForClickTargetRefs(allScope)).toBeNull();
+    expect(getWaitingForPlayerChoiceIds(allScope)).toEqual([]);
+    expect(getWaitingForPlayerChoiceIds(singleScope)).toEqual([1]);
+  });
+});
+
+// V5 — the six dialog-only variants. Each carries `{Player: 1}` in its own
+// `TargetRef[]` field, and a `TargetSelection` built from the IDENTICAL list
+// returns `[1]`, so the exclusion is proven to key on the variant rather than on
+// the list contents.
+describe("getWaitingForPlayerChoiceIds — dialog-only variants", () => {
+  const DIALOG_ONLY = [
+    "DistributeAmong",
+    "ProliferateChoice",
+    "TimeTravelChoice",
+    "ChooseObjectsSelection",
+    "EachPlayerCopyChosenSelection",
+    "ChooseOneOfBranch",
+  ] as const;
+
+  it.each(DIALOG_ONLY)("excludes %s (answered by a different GameAction)", (variant) => {
+    const fixture = PARTITION_FIXTURES[variant];
+    if (fixture === NO_TARGET_REF_LEGAL_SET) throw new Error(`${variant} must have a fixture`);
+
+    expect(fixture.legal).toContainEqual({ Player: 1 });
+    expect(getWaitingForClickTargetRefs(fixture.waitingFor)).toBeNull();
+    expect(getWaitingForPlayerChoiceIds(fixture.waitingFor)).toEqual([]);
+  });
+
+  it("returns [1] for a TargetSelection built from the identical legal list", () => {
+    expect(
+      getWaitingForPlayerChoiceIds(
+        targetSelectionWaitingForFactory
+          .withData({
+            selection: buildTargetSelectionProgress({ current_legal_targets: MIXED_LEGAL }),
+            target_slots: [buildTargetSelectionSlot({ legal_targets: MIXED_LEGAL })],
+          })
+          .forPlayer(0)
+          .build(),
+      ),
+    ).toEqual([1]);
+  });
+});
+
+// V2 — the partition rule, total over every fixture in the map. The compile-time
+// half of this gate is the `Record<WaitingFor["type"], …>` key set itself.
+describe("the two click-target authorities partition the engine's legal list", () => {
+  const entries = Object.entries(PARTITION_FIXTURES).flatMap(([type, fixture]) =>
+    fixture === NO_TARGET_REF_LEGAL_SET ? [] : [[type, fixture] as const],
+  );
+
+  it("covers every TargetRef-bearing variant", () => {
+    expect(entries.map(([type]) => type).sort()).toEqual(
+      [
+        "ChooseObjectsSelection",
+        "ChooseOneOfBranch",
+        "CopyRetarget",
+        "DistributeAmong",
+        "EachPlayerCopyChosenSelection",
+        "ProliferateChoice",
+        "RetargetChoice",
+        "ReturnAsAuraTarget",
+        "TargetSelection",
+        "TimeTravelChoice",
+        "TriggerTargetSelection",
+      ].sort(),
+    );
+  });
+
+  it.each(entries)("partitions %s", (_type, fixture) => {
+    // Every fixture must be non-degenerate: a legal list with only one axis
+    // could not tell a correct partition from a broken one.
+    expect(fixture.legal.some((ref) => "Object" in ref)).toBe(true);
+    expect(fixture.legal.some((ref) => "Player" in ref)).toBe(true);
+
+    const refs = getWaitingForClickTargetRefs(fixture.waitingFor);
+    const objects = getWaitingForObjectChoiceIds(fixture.waitingFor);
+    const players = getWaitingForPlayerChoiceIds(fixture.waitingFor);
+
+    if (refs === null) {
+      // Not a click prompt: neither axis may offer anything, even though the
+      // engine's list is non-empty and names both an object and a player.
+      expect(objects).toEqual([]);
+      expect(players).toEqual([]);
+      return;
+    }
+
+    expect(refs).toEqual(fixture.legal);
+    expect(objects).toEqual(
+      fixture.legal.flatMap((ref) => ("Object" in ref ? [ref.Object] : [])),
+    );
+    expect(players).toEqual(
+      fixture.legal.flatMap((ref) => ("Player" in ref ? [ref.Player] : [])),
+    );
   });
 });

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -213,7 +213,7 @@ export function getWaitingForClickTargetRefs(
       return slot?.legal_alternatives ?? [];
     }
     case "RetargetChoice":
-      // CR 115.7: a single-target retarget (Bolt Bend, Redirect) is answered by a
+      // CR 115.7: a single-target retarget (Bolt Bend, Misdirection) is answered by a
       // board/HUD click. An `All`-scope retarget keeps RetargetChoiceModal, whose
       // confirm button needs pointer events, and the engine has no `ChooseTarget`
       // arm for it — so it is not a click prompt at all.
@@ -266,7 +266,7 @@ export function getWaitingForObjectChoiceIds(
       return (slot?.legal_alternatives ?? []).flatMap((t) => "Object" in t ? [t.Object] : []);
     }
     case "RetargetChoice":
-      // CR 115.7: Single-target retargets (Bolt Bend, Redirect) are resolved by
+      // CR 115.7: Single-target retargets (Bolt Bend, Misdirection) are resolved by
       // a board click; multi-target (`All`-scope) retargets keep the dialog.
       if (waitingFor.data.scope.type !== "Single") return [];
       return waitingFor.data.legal_new_targets.flatMap((target) =>

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -5,6 +5,7 @@ import type {
   ObjectCounterDisplay,
   ObjectId,
   PlayerId,
+  TargetRef,
   WaitingFor,
 } from "../adapter/types";
 import type { MultiplayerBoardLayout } from "../stores/preferencesStore";
@@ -155,6 +156,100 @@ export function isObjectReportableToViewer(
   return gameState != null && (obj.display_visible_to_viewer ?? false);
 }
 
+/**
+ * The engine-authored legal set for a prompt the player answers with ONE
+ * `GameAction::ChooseTarget` carrying a single `TargetRef` — CR 115.1: "the
+ * targets are object(s) and/or player(s) the spell or ability will affect."
+ *
+ * Returns `null` when `waitingFor` is not such a prompt, so a caller can tell
+ * "no click-targeting is in progress" from "click-targeting is in progress and
+ * nothing is legal yet". Same applicable-or-not convention as
+ * `getBoardChoiceView`, which `DialogHost` consumes as `!= null`.
+ *
+ * Membership needs BOTH halves; do not widen on either alone:
+ *   1. the engine has a `GameAction::ChooseTarget` apply arm for the variant, and
+ *   2. its legal-set field is typed `TargetRef[]`, so it can name a player.
+ *
+ * The other `ChooseTarget` variants carry `ObjectId[]` and therefore cannot name
+ * a player — `CopyTargetChoice.valid_targets`, `ExploreChoice.choosable`,
+ * `PopulateChoice.valid_tokens` (the engine's populate arm matches
+ * `TargetRef::Object` outright). They stay in `getWaitingForObjectChoiceIds`.
+ *
+ * Prompts answered by a DIFFERENT action are dialog-only by design and stay out.
+ * Each already renders its player rows in its own modal, so nothing is
+ * unreachable — only the click path differs:
+ *   - `DistributeAmong`   -> `DistributeAmong { distribution }`; a click carries
+ *                            no amount (DistributeAmongModal).
+ *   - `ProliferateChoice` -> `SelectTargets`; CR 701.34a chooses any-size subset
+ *     `TimeTravelChoice`     of permanents and/or players (ProliferateModal).
+ *     `ChooseObjectsSelection`
+ *   - `EachPlayerCopyChosenSelection` -> `SelectTargets`, ORDERED (first pick is
+ *                            copied, second scales); a click carries no order.
+ *   - `ChooseOneOfBranch` -> `ChooseBranch { index }`; `parent_targets` is
+ *                            continuation context the modal never reads.
+ * All of the above are host-wrapped (absent from
+ * `DialogHost.CLICK_THROUGH_WAITING_FOR_TYPES`), so a HUD glow beneath their
+ * `fixed inset-0` host could not be clicked even if it were offered.
+ *
+ * NOTE: `getWaitingForObjectChoiceIds` below keeps its own switch over a
+ * superset of these arms. The two must agree on every shared arm, and neither
+ * may silently gain an arm the other lacks. `PARTITION_FIXTURES` in
+ * `gameStateView.test.ts` is a `Record<WaitingFor["type"], …>`, so adding a
+ * variant to `WaitingFor` fails `pnpm run type-check` until that map records
+ * what the player axis does with it. Apply the two-criteria test above before
+ * answering that compile error.
+ */
+export function getWaitingForClickTargetRefs(
+  waitingFor: WaitingFor | null | undefined,
+): TargetRef[] | null {
+  switch (waitingFor?.type) {
+    case "TargetSelection":
+    case "TriggerTargetSelection":
+      return waitingFor.data.selection?.current_legal_targets ?? [];
+    case "CopyRetarget": {
+      // CR 707.10c: the copy's controller may choose new targets, one slot at a
+      // time — read the slot the engine is currently asking about.
+      const slot = waitingFor.data.target_slots[waitingFor.data.current_slot ?? 0];
+      return slot?.legal_alternatives ?? [];
+    }
+    case "RetargetChoice":
+      // CR 115.7: a single-target retarget (Bolt Bend, Redirect) is answered by a
+      // board/HUD click. An `All`-scope retarget keeps RetargetChoiceModal, whose
+      // confirm button needs pointer events, and the engine has no `ChooseTarget`
+      // arm for it — so it is not a click prompt at all.
+      return waitingFor.data.scope.type === "Single"
+        ? waitingFor.data.legal_new_targets
+        : null;
+    case "ReturnAsAuraTarget":
+      // CR 303.4: an Aura enters attached to an object OR a player, so this list
+      // mixes both. The engine owns which hosts are legal; the client only routes
+      // each ref to the surface that can render it.
+      return waitingFor.data.legal_targets;
+    default:
+      return null;
+  }
+}
+
+/**
+ * The players the engine is currently offering as click targets — the
+ * player-axis sibling of `getWaitingForObjectChoiceIds`, and the single
+ * authority for every surface that renders a seat (PlayerHud, OpponentHud's 1v1
+ * pill and multiplayer tabs, OpponentSeatHeader).
+ *
+ * Pair it with `useCanActForWaitingState()` at the call site: this function says
+ * WHICH players are legal, the hook says WHETHER this client may answer. The two
+ * resolve different seats on purpose — the hook against the real seat, the
+ * membership test against the rendered seat — and under a CR 723 turn-control
+ * effect those differ. See `usePerspectivePlayerId`.
+ */
+export function getWaitingForPlayerChoiceIds(
+  waitingFor: WaitingFor | null | undefined,
+): PlayerId[] {
+  return (getWaitingForClickTargetRefs(waitingFor) ?? []).flatMap((target) =>
+    "Player" in target ? [target.Player] : [],
+  );
+}
+
 export function getWaitingForObjectChoiceIds(
   waitingFor: WaitingFor | null | undefined,
 ): ObjectId[] {
@@ -184,7 +279,9 @@ export function getWaitingForObjectChoiceIds(
     case "ReturnAsAuraTarget":
       // CR 303.4 / CR 115.1: `legal_targets` is a TargetRef[] of object hosts
       // *and* players (Curse / enchant-player Auras). Only object hosts glow on
-      // the board; player hosts are handled by PlayerHud/OpponentHud glow.
+      // the board; player hosts are projected by
+      // `getWaitingForPlayerChoiceIds` above, which every seat-rendering
+      // surface reads.
       return waitingFor.data.legal_targets.flatMap((target) =>
         "Object" in target ? [target.Object] : [],
       );


### PR DESCRIPTION
The sibling of #7685. That PR converged the **object** targeting axis onto `getWaitingForObjectChoiceIds` after a forked derivation soft-locked a real player's game — an engine prompt whose only legal target was a spell on the stack, on a surface that had never been taught about `CopyRetarget`. The **player** axis was deliberately left out of scope there, and still had the same shape.

`PlayerHud`, `OpponentHud` and `OpponentSeatHeader` each hand-rolled their own `WaitingFor` → legal-player-ref derivation: five near-identical per-variant branches apiece, each gating on an inline `waitingFor.data.player === myId`. They could not share the object authority, which returns `ObjectId[]` and drops every `{ Player: … }` ref by construction.

## What this does

Adds `getWaitingForClickTargetRefs(waitingFor): TargetRef[] | null` and its `getWaitingForPlayerChoiceIds` projection beside the object authority, and converts all three call sites onto it plus `useCanActForWaitingState()`. The four production files are a net deletion; the volume is the test net that keeps the forks deleted.

**Membership is engine-grounded, not inferred from shape:** a variant belongs iff the engine has a `GameAction::ChooseTarget` apply arm for it **and** its legal-set field is `TargetRef[]`. That intersection is exactly five variants — re-derived independently three times, most recently by enumerating all 8 apply arms against all 11 `TargetRef`-bearing members of the 132-variant union. The six other `TargetRef`-bearing variants stay out with the reason annotated per arm: each answers a different action (`SelectTargets` subset, `DistributeAmong` amounts, `ChooseBranch` index), none reaches `isClickThroughWaitingFor` or `getBoardChoiceView`, and each already renders its player rows in its own modal.

## Two latent defects close as a consequence

- **Spectator false affordance.** `usePlayerId()` returns seat 0 for a spectator by design, so the inline test passed, the plate rendered as a `button`, and `dispatch.ts` then refused the click — a dead affordance that also swallowed the card-preview fallback.
- **`turn_decision_controller` lockout** (CR 723.1, CR 723.3). The controlling seat is now offered the targets it may legally choose, on all three surfaces rather than none. This widening is deliberate and enumerated as exactly {case 2, case 5b}, pinned by paired negatives in both directions.

## The drift guard

A `Record<WaitingFor["type"], …>` fixture map makes the two authorities' partition a **compile-time** obligation rather than a convention. Verified both ways: a new union member yields exactly one `TS2741` (and nothing else in the client catches it); a bogus key yields exactly one `TS2353`. The gate is `pnpm run type-check`, not vitest.

Residual, stated honestly: the map catches a new *variant*, not a careless *editor* who answers the compile error with `NO_TARGET_REF_LEGAL_SET` without applying the two-criteria test. That obligation is written into both doc comments.

## Verification

Full client suite on this branch, rebased onto current `main`: **318 files / 3067 tests passed, 0 failed**; `pnpm run type-check` and `pnpm run lint` (0 errors) clean. The four in-scope suites went 82 → 131 tests. Thirteen revert probes by the implementer plus ten by reviewers, all reproduced; five semantic mutation probes hunting vacuous tests each reddened exactly the rows they should.

## Known, deliberately out of scope

- `TargetingOverlay.tsx` carries a fifth instance of the Redirect citation error the second commit fixes. Another agent has uncommitted work in that file; left for a follow-up.
- Two pre-existing comments in `OpponentSeatHeader.tsx` and `OpponentHud.tsx` cite Faith's Fetters and Dictate of Kruphix as player-attached Aura examples. Both are wrong (Faith's Fetters reads "Enchant permanent"; Dictate of Kruphix is not an Aura). Pre-existing and outside this diff.
- `waitingForRegistry.ts` still carries the same stale surface-list comment.

## Pipeline report

Plan review: 4 rounds (2 → 1 → 0 → 0 blocking), three independent reviewers, one round in surgical-fix mode. Every finding across the loop was a Verification Matrix defect; the design was never contested. Implementation review: 2 rounds (1 MED / 1 LOW → 0 findings).

```
Pipeline-reviewed head: 1eb9ac8a3155e6528ac2a2c90935a53e0b1a5bc9
Current branch head:    06e8141b73f9cdb2404b9910c033b5ba66fd9c1d
Pipeline status:        historical — cherry-picked onto a newer origin/main (6da6dc3bc2)
Current-head review:    none
```

All nine file blobs at the current head are byte-identical to the reviewed candidate, and the completion gates were re-run at this head; no `/review-impl` pass was run against this exact SHA.

https://claude.ai/code/session_01LC5MnFWa3NwmqcFTECw96K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved targeting controls for target-selection, retargeting, and Aura attachment prompts.
  - Added clearer handling of valid player and object targets across player and opponent displays.
  - Spectator views no longer show or allow interactive target controls.
  - Added support for returning objects as Aura targets.

- **Bug Fixes**
  - Prevented invalid target selections and ensured turn-control effects only enable the correct seat.
  - Improved target sorting, empty selections, and incoming-attacker popover behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->