### PR TITLE
docs: custom format engine design proposal (discussion #5312)

### DIFF
--- a/docs/proposals/custom-format-engine/CONTEXT.md
+++ b/docs/proposals/custom-format-engine/CONTEXT.md
@@ -163,13 +163,17 @@ cited PLAN.md sections for the actual schema/wiring changes.
    value (CLAUDE.md's `Option<ControllerRef>` example). See PLAN.md §1 and §3.
 2. **`StructuralRules` was missing behavior-bearing `FormatConfig` fields
    (real, confirmed).** Re-read `FormatConfig`'s full field list
-   (`types/format.rs:174-212`) directly rather than from memory. Fixed:
-   `StructuralRules` now includes `command_zone`, `commander_damage_threshold`,
-   and `archenemy_player` (all independently meaningful, not derived).
-   `uses_commander` is derived as `commander_damage_threshold.is_some()`
-   rather than stored redundantly. `supplies_fixed_deck` is always `false`
-   for `Custom` (no custom-format use case for an auto-supplied deck exists;
-   flagged, not silently dropped, if that need ever arises).
+   (`types/format.rs:174-212`) directly rather than from memory. Fixed at the
+   time: `StructuralRules` now includes `command_zone`,
+   `commander_damage_threshold`, and `archenemy_player` (all independently
+   meaningful, not derived). `uses_commander` is derived as
+   `commander_damage_threshold.is_some()` rather than stored redundantly.
+   `supplies_fixed_deck` is always `false` for `Custom` (no custom-format use
+   case for an auto-supplied deck exists; flagged, not silently dropped, if
+   that need ever arises). **Superseded by round 3, points 3 and 4 below**:
+   `archenemy_player` turned out to be the wrong kind of field to save at all
+   (removed, not just added-then-kept) and the `uses_commander` derivation
+   above was itself incomplete (missing the `command_zone` conjunct).
    `allow_debug_actions` is correctly excluded — its own doc comment says
    it is "orthogonal to format," a session capability flag, not format
    identity. **New finding**: `sideboard_policy` is not a `FormatConfig`
@@ -236,7 +240,129 @@ cited PLAN.md sections for the actual schema/wiring changes.
    "(37)" but enumerates 44 names in RESEARCH.md — recounted directly against
    the verbatim list and fixed to "(44)" in both RESEARCH.md and PLAN.md §2.
 
-## Confirmed (verified against source this session)
+## Maintainer review round 3 — CHANGES_REQUESTED, addressed
+
+matthewevans re-reviewed round 2's fix (commit `b6cf09b89`) and found the
+round-2 fix itself incomplete or wrong on five points. All five are addressed
+below, each re-verified directly against the cited engine source this
+session (not from memory, and not just accepting the review at face value —
+every claim below was independently confirmed against the actual code before
+being treated as correct).
+
+1. **Round 2's mana-burn fix gated the wrong operation (real, confirmed —
+   the most substantive miss).** Round 2 only gated the LIFE-LOSS check to
+   real phase-group boundaries; it left the underlying `EmptyManaPool` event
+   firing (and draining the pool) on **every** `Phase` transition, exactly as
+   before. Since the pool empties every step regardless, there is no unspent
+   mana left BY THE TIME a phase-group boundary is reached — round 2's flag
+   check would have fired against an already-empty pool and done nothing.
+   Also confirmed: `state.phase = next` (`turns.rs`, in `enter_phase`) is set
+   near the *top* of the function, so any code running after it that reads
+   `state.phase` sees the destination, not the phase being left — a
+   "current vs. next" check placed carelessly would silently compare the
+   wrong pair.
+
+   **Real fix, reusing an existing mechanism rather than inventing pool
+   suppression from scratch.** The engine already has exactly the needed
+   shape: `ManaExpiry` (`types/mana.rs:1509`) has `EndOfTurn` and
+   `EndOfCombat` variants — `EndOfCombat`'s own doc comment: "Mana persists
+   through combat steps but drains at EndCombat → PostCombatMain," used by
+   Firebending. That is precisely "persist through this phase's internal
+   steps, drain at the real phase-group boundary," already built and
+   tested — just special-cased to the Combat phase-group only. The fix
+   generalizes it rather than inventing something new: add
+   `ManaExpiry::EndOfPhaseGroup` (a third variant, not five new
+   `EndOfBeginning`/`EndOfPrecombatMain`/etc. variants — it resolves against
+   whichever phase-group is active when checked, exactly as `EndOfCombat`
+   and `EndOfTurn` already do without parameterizing which combat/turn).
+   When a format's `LegacyRuleSet.mana_burn` is set, newly-added mana units
+   are tagged `expiry: Some(EndOfPhaseGroup)` instead of `None`. The existing
+   expiry-clearing logic (the generalization of
+   `clear_expired_end_of_combat_retention_markers`) converts them to
+   ordinary (`None`-expiry) units once the phase-group actually changes,
+   letting them flow into that transition's *already-firing* `EmptyManaPool`
+   event as `Drop` decisions — the same event the engine unconditionally
+   fires every transition, so no new suppression path is needed. Because
+   under this scheme nothing drops except at real phase-group boundaries,
+   the drop count at that point *is* the burn amount — apply it as **life
+   loss** (not damage, per round 2's already-verified CR finding) at the
+   same point the pipeline already aggregates the Yurlok-class check,
+   independent of it. This also resolves the "life loss can defer through
+   replacement handling" concern: it reuses the *same* aggregation point the
+   pipeline already uses for pauses/choices (Kruphix/Horizon Stone), rather
+   than adding a second, unsynchronized computation. See PLAN.md §4.
+2. **`StructuralRules.sideboard_policy` had no accessor or migration path
+   (real, confirmed).** `GameFormat::sideboard_policy()` (`format.rs:270`) is
+   an exhaustive match over the ~23 built-in variants with no access to
+   `FormatConfig` — it cannot read `custom_rules` even in principle, so a
+   `Custom(_)` arm there can only be `unreachable!()` with a doc comment
+   pointing elsewhere. The two production consumers
+   (`deck_loading.rs:681`, `match_flow.rs:357`, confirmed by direct read —
+   and any other call site of `.format.sideboard_policy()` found by a repo
+   grep at implementation time, not just these two) call that method
+   directly, so a saved format's policy would be silently ignored exactly as
+   flagged. Fixed: a new canonical accessor,
+   `FormatConfig::sideboard_policy(&self) -> SideboardPolicy`, with a
+   `GameFormat::Custom(_)` arm reading
+   `self.custom_rules.as_ref().expect(...).structural.sideboard_policy` and
+   every other format delegating to `self.format.sideboard_policy()`. All
+   current call sites migrate from `state.format_config.format
+   .sideboard_policy()` to `state.format_config.sideboard_policy()`. See
+   PLAN.md §1 and §3.
+3. **`archenemy_player: Option<PlayerId>` must not be a saveable structural
+   field (real, confirmed).** Read `FormatConfig::archenemy_player()` and
+   `validate_for_player_count` (`format.rs:658-670`) directly: the seat index
+   is derived from `topology()` for the CURRENT game and is validated against
+   THAT game's actual player count (`archenemy.0 >= player_count` → error). A
+   value persisted in a reusable saved format could reference a seat that
+   doesn't exist, or a different player, in a later game with different
+   seating. Fixed: removed `archenemy_player` from `StructuralRules`
+   entirely — Axis A does not support the Archenemy one-vs-many topology at
+   all (it is a different `FormatTopology` shape, not an independent config
+   knob layered on `IndividualSeats`, which is what FFA-style Axis A targets).
+   This is an explicit scope exclusion, not a silent drop — a future
+   topology-aware design would need its own analysis, out of scope here. See
+   PLAN.md §1.
+4. **`uses_commander` derivation used only one of two required conditions
+   (real, confirmed).** Read `GameFormat::uses_commander()`
+   (`format.rs:365-380`) directly: for built-in formats it's a hardcoded
+   per-variant match, but its own doc comment states the actual INVARIANT it
+   encodes — true "for every format whose `FormatConfig` has both
+   `command_zone: true` and a non-`None` `commander_damage_threshold`."
+   Round 2's derivation used the threshold alone, dropping the
+   `command_zone` conjunct. Fixed: for `GameFormat::Custom`,
+   `FormatConfig.uses_commander` is computed at construction time (in
+   `from_lobby_config` / preset constructors, since `GameFormat`'s own
+   method has no access to `FormatConfig` fields to check either condition)
+   as `structural.command_zone && structural.commander_damage_threshold
+   .is_some()` — both conditions, matching the stated invariant exactly.
+   Added a test for the mismatched cases (`command_zone: true` alone,
+   `commander_damage_threshold: Some(_)` alone) asserting `false` for each.
+   See PLAN.md §1 and §6.
+5. **Declared policies that are unenforced or unresolved must block
+   registration, not just exist as data (real, confirmed, two parts).**
+   - `ReprintPolicy` is declared on `LegalityRules` but never consumed
+     anywhere in §3's evaluator algorithm — a card passes the pool check
+     based on legal-set membership alone, regardless of which `ReprintPolicy`
+     the preset declares. This connects to, rather than duplicates, the
+     already-flagged Open item 2 (printing/frame-data gap): enforcement needs
+     that same engine-vs-frontend printing cross-reference work.
+   - `LegendRuleScope::PreM14AnyController` was already flagged (see the
+     "Lost Legacy 606" note below) as a possible conflation of two different
+     historical mechanics under one name — an immediate "bury on resolution"
+     era (Legends 1994) versus a later, still-pre-M14 continuous SBA-based
+     global check — never resolved via dedicated rules-history research.
+   - **New rule this round, to prevent this class of gap recurring**: a
+     preset must not be registered/exposed as a selectable format until
+     every legality/legacy field it declares is BOTH fully specified AND
+     actually consumed by the evaluator/engine at an authoritative seam.
+     Concretely: `swedish_old_school()` (phase 1) must not ship as
+     selectable until its own still-open reprint-policy question (Open item
+     6, above) resolves, since it declares a `ReprintPolicy` today with no
+     enforcement path. No phase-2 EC preset may ship claiming
+     `LegendRuleScope::PreM14AnyController` until that conflation resolves —
+     moot today since all four default it to `Modern`, but binding on any
+     future preset that would turn it on. See PLAN.md §2 and §7.
 
 - **`GameFormat` is a closed `Copy` enum** with ~23 variants, threaded through
   many exhaustive matches (`legality_format`, `sideboard_policy`,
@@ -415,7 +541,7 @@ cited PLAN.md sections for the actual schema/wiring changes.
   Summarized in RESEARCH.md §7 (Analogous Trace).
 - **Swedish Old School 93/94 ruleset**, fetched this session (2026-07-15) from
   `http://oldschool-mtg.blogspot.com/p/banrestriction.html` — the primary
-  source for legal sets, the empty banned list, the 23-card restricted list,
+  source for legal sets, the empty banned list, the 25-card restricted list,
   the ante-card carve-out, and the (absent) legacy-rules mentions used above.
 
 ## Relationship to adjacent work — scope boundaries (do NOT accommodate here)

--- a/docs/proposals/custom-format-engine/CONTEXT.md
+++ b/docs/proposals/custom-format-engine/CONTEXT.md
@@ -1,0 +1,447 @@
+---
+phase: 58-custom-format-engine
+doc: CONTEXT
+subsystem: engine-formats
+status: research-and-design (no implementation)
+tags: [format, custom-format, old-school, middle-school, classic-magic, legacy-rules]
+---
+
+# Phase 58 — Custom ("Design Your Own") Format Engine — CONTEXT
+
+## Why this matters
+
+phase.rs today models formats as a **closed, compile-time `GameFormat` enum**
+(`crates/engine/src/types/format.rs`). That is exactly the right shape for the
+fixed roster of *official* formats (Standard, Commander, Premodern, …): typed,
+exhaustively matched, audited, version-controlled. It is the *wrong* shape for
+**player/operator-authored custom formats**, whose card pools, banned/restricted
+lists, and alternate-rule toggles are open-ended data that must not require an
+engine recompile and a new enum variant per format.
+
+The goal of this phase is to design a **general, data-driven custom-format
+layer** that coexists with the closed enum, and to validate that layer by
+expressing **four Eternal Central (EC) retro formats as bundled preset data on
+top of it**:
+
+- Old School 93-94
+- Old School 95
+- Middle School
+- Classic Magic
+
+The four EC formats are the *proof*, not the *point*. The deliverable that
+survives is the general engine; the four formats are its first four data
+instances. Per this repo's CLAUDE.md "build for the class, not the card"
+principle, we build the format *class*, then instantiate the four as data — we
+do **not** hardcode four new `GameFormat` variants.
+
+## Maintainer input — resolves the delivery-surface question (Open item 1)
+
+A maintainer (matthewevans), given an informal, non-technical description of
+this proposal, independently converged on: *"Something like 'FFA that's super
+flexible and you can save a configuration as a custom format?'"* — i.e., start
+from the existing flexible multiplayer format (Free-for-All), let a host tune
+its knobs freely in the lobby they already use, and add a "save this as a
+custom format" action, rather than picturing a from-scratch format-authoring
+tool.
+
+This does **not** replace the schema below — it resolves *which axis is the
+primary entry point* and confirms delivery surface (c) over (b)-first. The
+custom-format schema (§ below, PLAN.md §1) always had two axes; this input
+corrects an emphasis mistake in how they were sequenced:
+
+- **Axis A — structural/match config**: `starting_life`, `min_players`/
+  `max_players`, `deck_size`, `singleton`, `range_of_influence`, `team_based`.
+  These are **already `FormatConfig` fields today**
+  (`crates/engine/src/types/format.rs:174-202`) and **already partially
+  exposed** in the existing multiplayer lobby
+  (`client/src/components/lobby/HostSetup.tsx` — starting life, player count,
+  deck size are already host-adjustable there for a chosen built-in
+  `GameFormat`). This is exactly what "FFA that's super flexible" names. The
+  original PLAN.md draft treated this axis as an inherited afterthought
+  ("structural params reuse `FormatConfig`'s existing fields (life/deck/etc.)")
+  rather than a first-class part of `CustomFormatRules` — that was the gap.
+- **Axis B — legality/era-rules config**: `legal_sets`, `banned`, `restricted`,
+  `reprint_policy`, `LegacyRuleSet` (mana burn, damage-on-stack, pre-M10 Wish,
+  legend-rule scope). This is genuinely new data with no existing UI surface,
+  and it's what actually makes the four EC formats *rules-correct* — no amount
+  of tuning Axis A knobs produces a faithful Old School 93-94. This axis keeps
+  every finding already in RESEARCH.md/CONTEXT.md/PLAN.md; none of that work
+  is discarded.
+
+**Resolution of Open item 1**: ship (c) — one `CustomFormatDef`/
+`CustomFormatRules` schema — but enter it through Axis A first, via the
+*existing* lobby (`HostSetup.tsx` + "save as custom format"), not a new
+designer screen and not (b)-first typed-preset-only delivery. The four EC
+formats remain the validating case for Axis B and may still ship as audited
+typed presets (a banned list should be curated, not free-typed by a player),
+but they are no longer the thing that must land *before* anything else is
+useful — the Axis A save-flow is smaller, ships independently, and is useful
+to every casual multiplayer table, not just old-school players. See PLAN.md §1
+and §7 for the schema and sequencing changes this implies.
+
+## Confirmed (verified against source this session)
+
+- **`GameFormat` is a closed `Copy` enum** with ~23 variants, threaded through
+  many exhaustive matches (`legality_format`, `sideboard_policy`,
+  `grants_free_first_mulligan`, `uses_commander`, `supplies_fixed_deck`,
+  `label`, `for_format`, plus `deck_validation.rs::format_compatibility_check`).
+  Verified `format.rs` in full. Adding an *additive* variant is the established
+  extension pattern (see the `GameFormat::Limited` prior art, phase 53).
+- **Legality today is externally sourced per-card.** `card_db.rs:109` calls
+  `normalize_legalities(&entry.legalities)`; the raw map comes from MTGJSON
+  `AtomicCard.legalities` via the export binary (`bin/oracle_gen.rs:778`,
+  `883`). `LegalityFormat::from_key` (`legality.rs:69`) **drops any key it does
+  not recognize**. There is **no** `oldschool` / `middleschool` / `classic`
+  variant in `LegalityFormat`, so even MTGJSON's `oldschool` key (if present) is
+  silently discarded today. The existing test at `legality.rs:293-297`
+  explicitly documents that unknown keys like `"oldschool"` are dropped. →
+  **None of the four EC formats have any signal in the current pipeline.**
+  Confirmed by reading `legality.rs`, `card_db.rs`, and `oracle_gen.rs`.
+- **`set_gating.rs` does NOT fit** as a format-restriction mechanism. Confirmed
+  by reading it in full: it is a `GATED_SETS`-env-var-driven, *generation-time*
+  pre-release embargo tool that overrides a card's legalities to
+  `all_formats_banned()`. It is narrow deployment tooling, not a runtime,
+  general, per-format card-pool mechanism. Useful only as a *rough shape
+  reference* for "how this codebase does deployment-level config", not an
+  architecture to copy.
+- **Set-membership data exists and is the right key.**
+  `CardDatabase::printings_for(name) -> Option<&[String]>` (`card_db.rs:227`)
+  returns the set codes a card was printed in. This is the building block a
+  set-list-driven custom format needs.
+- **`DeckCopyLimit::UpTo(1)` is the WRONG layer for a format restricted list**
+  (see RESEARCH.md §4). The correct existing building block is the
+  format-level restricted-list enforcer `restricted_copy_violations`
+  (`deck_validation.rs:2462`), which already implements the CR 100.2b 1-copy
+  ceiling generically.
+- **Mana burn is small; "damage uses the stack" is large.** Verified hook
+  points (RESEARCH.md §5). Mana burn is a localized addition at the mana-pool
+  drop site. "Damage uses the stack" is a fundamental reversal of CR 510.2 and a
+  deep combat/stack/priority rework.
+- **Legend-rule scope change is REAL and the engine is hardcoded to modern; a
+  legacy flag is SMALL — but no EC preset uses it.** Fully investigated
+  (RESEARCH.md §10). The legend rule (introduced by *Legends* 1994, legal in
+  93-94/95) was **global / any-controller** through 2013, then M14 (2013-07-13)
+  made it **per-controller + choice** (current CR 704.5j,
+  `MagicCompRules.txt:5510`). The engine's `check_legend_rule`
+  (`sba.rs:902-956`) is hardcoded to the modern per-controller-with-choice form
+  (loops per player, filters `controller == player_id`, pauses with
+  `WaitingFor::ChooseLegend`). Re-adding the pre-M14 global-choiceless form is
+  SMALL — it mirrors the existing `check_world_rule` (`sba.rs:1348`) shape and
+  reuses the shared SBA departure mover. Modeled as a typed
+  `LegendRuleScope { Modern, PreM14AnyController }` enum on `LegacyRuleSet` (not a
+  bool). **HONEST CAVEAT:** EC's published rulesets do **not** list a legend-rule
+  reversion (their only legacy exceptions are mana burn / damage-on-stack /
+  wish), so all four EC presets default to `Modern`; the scope enum ships as a
+  *general* historical-rules axis (like Block Constructed's `mana_burn`), not an
+  EC-preset behavior. Planeswalker uniqueness needs no flag — the four pools end
+  at Scourge (2003) and planeswalkers postdate that (Lorwyn 2007). The
+  planeswalker-uniqueness → legend-rule fold happened at **Ixalan (2017-09-28)**,
+  not Dominaria 2018.
+- **Pre-M10 Wish templating is small and is a REAL functional difference.**
+  Fully investigated (RESEARCH.md §9). It reverts the M10 change that made exile
+  an in-game zone (CR 400.11/400.11a): pre-M10, Wishes could retrieve an owned
+  card removed from the game, not just from the sideboard. The engine already
+  implements the modern (post-M10) Wish cycle generically
+  (`Effect::SearchOutsideGame`, `OutsideGameSourcePool::Sideboard`) AND already
+  implements owned-face-up-exile retrieval for the Karn/Coax class
+  (`SideboardAndFaceUpExile` + tested collector/mover in
+  `search_outside_game.rs`). The legacy flag is therefore a one-line pool-widening
+  at one existing resolver hook — SMALL, not the "Medium" the first pass guessed.
+  Flag renamed `pre_m10_wish_templating` → `pre_m10_wish_reaches_exile` (it is a
+  pool-scope toggle, not a wording change).
+
+## Open (needs a human decision — do NOT resolve unilaterally)
+
+1. ~~**Delivery surface**~~ — **RESOLVED**, see "Maintainer input" section
+   above: (c), entered via Axis A (structural config) through the existing
+   lobby first, Axis B (legality/legacy-rules) as audited presets validating
+   the same schema. PLAN.md §1 and §7 updated accordingly.
+2. **Reprint-policy fidelity — corrected/sharpened this round.** The original
+   framing ("no frame/art metadata per printing, full stop") was too
+   pessimistic. There are **two disjoint printing systems in this codebase
+   today, and only one of them lacks frame data**:
+   - **Engine/MTGJSON side** (`CardDatabase::printings_for`,
+     `crates/engine/src/database/card_db.rs:227`): a bare `Vec<String>` of set
+     codes, sourced from MTGJSON `AtomicCards.json`
+     (`crates/engine/src/database/mtgjson.rs:78`). This format is
+     structurally oracle-level, not printing-level — frame/border/full-art
+     data **cannot** exist here; this is a schema-level absence, not a
+     dropped-field ingestion gap. Confirmed empirically: `printings_for()`'s
+     order is alphabetical-by-set-code (e.g. `10E` before `AKH`), not
+     chronological — "pick the oldest legal printing" cannot use this order
+     as-is.
+   - **Frontend/Scryfall side** (`client/src/services/scryfall.ts`,
+     `scryfall-printings.json` generated by
+     `scripts/gen-scryfall-printings.sh`): a fully-built, **already-working**
+     printing system with real per-printing `released_at`, `border_color`,
+     `frame_effects`, `full_art`, `collector_number` — sourced from Scryfall's
+     bulk data, not MTGJSON. `pickOldestPrinting()`
+     (`client/src/services/scryfall.ts:136`) already implements "pick the
+     oldest printing" as working code, and `preferencesStore.ts`'s
+     `ArtChainEntry` (a typed union: `{type:"oldest"}` /
+     `{type:"prefer_borderless"}` / etc., with a real v5→v6 migration
+     upgrading a flat enum into this richer chain type) is a per-player
+     cosmetic preference for exactly this.
+   - **These two systems are completely disconnected** — they only share an
+     oracle-id join key. The frontend's printing/frame system has no
+     awareness of format legality; the engine's legality system has no
+     printing/frame data. **The actual gap is not "no frame data exists,"
+     it's "the frame data that exists has never been cross-referenced against
+     format/legal-set data."**
+   - Confirmed no per-user printing choice flows through the engine at all
+     today: `printings_for()` has zero WASM/frontend call sites
+     (`grep -rn "printings_for" crates/` → only an offline coverage tool and
+     a test). `GameObject`/`PrintedCardRef`
+     (`crates/engine/src/types/card.rs:76`) carries oracle_id + face_name
+     only, never a set code.
+   - Release-date data for a set-code→date join **already exists**
+     (`SetCatalog`/`SetMeta.release_date`,
+     `crates/engine/src/database/set_catalog.rs:78`, loaded from MTGJSON's
+     `SetList.json`) and is even already projected to the frontend for an
+     unrelated purpose (`client/public/set-list.json`, deck-builder set
+     filter). So an "oldest legal printing" ordering is a **wiring problem**,
+     not a new-data-acquisition problem — cheaper than true frame-level
+     enforcement, which would need Scryfall's frame fields cross-referenced
+     against the format's legal-set list, and a decision on whether that
+     cross-reference is new engine-owned derived state (per "engine owns all
+     logic") or an extension of the frontend's existing cosmetic
+     `ArtChainEntry` preference system seeded by the format (a real
+     architectural fork — see PLAN.md's new `PrintingDefault` note). Whether
+     the approximation (set-code-list membership only) is acceptable for v1,
+     or whether the Scryfall-engine cross-reference should be built, is a
+     product decision.
+3. **Classic Magic B&R cadence.** EC updates Classic's banlist twice yearly
+   (Jan 1 / Jul 1). Bundled-preset data is version-controlled, so updates are
+   ordinary edits — but whether we want a dated/versioned banlist history is
+   open.
+4. **Draw/tiebreaker resolution mechanics** (generalizing the Chaos Orb
+   tiebreaker and the foreign-card-identification convention above): both are
+   instances of a "how does this table resolve an otherwise-undecided
+   outcome" hook, not an in-game rule. Confirmed via grep (`crates/draft-core`,
+   `server-core`) that phase.rs has **no match-level concept at all today** —
+   no best-of-N, no tournament round, no draw/tiebreak state machine; the
+   engine models single games only. So this genuinely has two different
+   shapes depending on a product decision this doc should not make
+   unilaterally: (a) a **tournament-level policy** ("draws are not permitted;
+   play resolves until decided," which needs no new state, since it's just a
+   procedural rule about what happens after a game/match ends) or (b) a
+   **per-format-configurable "how to decide a draw" hook**, which would
+   require inventing a match/round concept above the single-game engine
+   first — a materially larger scope than this custom-format engine. Given
+   no match-level structure exists, this is flagged as **out of scope for
+   the custom-format engine itself** and, if ever pursued, belongs to a
+   separate, later "tournament/match structure" design, not bundled into
+   `CustomFormatDef`/`LegacyRuleSet` here.
+
+## Source data
+
+- **Authoritative EC ruleset**, re-verified this session (2026-07-07) against
+  `https://github.com/northern-information/lordsofthepit.com/blob/main/src/pages/formats.md`
+  (raw fetched). Full verbatim card lists captured in RESEARCH.md §1.
+- **Prior art**: `GameFormat::Limited` planning cycle, phase 53. Retrieved via
+  `git show 80404a98b:.planning/phases/53-limited-draft-core/53-01-SUMMARY.md`.
+  Summarized in RESEARCH.md §7 (Analogous Trace).
+
+## Relationship to adjacent work — scope boundaries (do NOT accommodate here)
+
+- **Vanguard (CR 902) is orthogonal to this design — do not entangle them.**
+  GitHub issue phase-rs/phase#5056 ("Implement the Vanguard variant (CR 902)")
+  requests Vanguard support; verified **still OPEN and unaddressed**
+  (`gh issue view 5056 --json state` → `"OPEN"`, 2026-07-07). Vanguard is
+  genuinely unimplemented (no `CoreType::Vanguard`, no `GameFormat::Vanguard`, no
+  Vanguard cards in `card-data.json`). Per the issue's own analysis, phase.rs
+  already implements **three of the four** CR "nontraditional card lives in the
+  command zone" casual variants — Planechase (CR 901, `game/planechase.rs`),
+  Commander (CR 903, `game/commander.rs`), Archenemy (CR 904, `game/archenemy.rs`)
+  — and Vanguard (CR 902) is "structurally the simplest of the four… a per-player,
+  game-long static modifier plus a command-zone ability source, which is a strict
+  subset of what archenemy.rs/planechase.rs already do." **Vanguard therefore
+  belongs to the existing command-zone-supplemental-card family, NOT to the
+  `CustomFormatDef`/`LegacyRuleSet` mechanism designed here.** The two are
+  independent: this custom-format engine neither depends on nor blocks Vanguard,
+  and this design does **not** need to accommodate it. Flagged so a reader does
+  not mistakenly try to fold Vanguard into the custom-format layer.
+
+- **Duplicate-check pass against all open upstream issues/branches (2026-07-07,
+  before taking this to the maintainer).** Searched `phase-rs/phase` open
+  issues/PRs and all `origin` branch names for: format, old school, block
+  constructed, legendary rule, mana burn, damage stack, wish, vanguard, audio,
+  video, voice chat, webrtc, spectator, watch game, replay, commentary,
+  microphone/camera. Findings:
+  - **No duplicate or conflicting open issue/PR/branch exists for this
+    custom-format-engine design, the audio/video-chat design (phase 59), or
+    the watch-game-mode design (phase 60).** Clear to proceed to the
+    maintainer conversation on all three without a collision risk.
+  - **phase-rs/phase#5056 (Vanguard)** — already covered above, confirmed
+    still open, confirmed orthogonal.
+  - **phase-rs/phase#5169 ("New Format Plan: Dandan"), OPEN, created
+    2026-07-06 (one day before this check) — worth reading before the
+    maintainer conversation, not a duplicate.** An unclaimed (no linked PR,
+    no "token" claimed in comments), extremely detailed community-authored
+    engine-planner-style implementation plan for a NEW `GameFormat::Dandan`
+    shared-library format (both players draw from one shared 80-card library
+    + graveyard; a real Wizards Secret Lair promo format). This is a
+    **different actual format** from anything in this design (not an EC
+    retro format, no legal-sets/banlist/legacy-rules axis) — but it is the
+    **same class of upstream activity**: another contributor extending
+    `GameFormat`/`FormatConfig` right now. Two things worth surfacing to the
+    maintainer alongside this design:
+    1. It's live precedent for how the maintainer currently accepts new
+       formats: **one bespoke `GameFormat` enum variant + `FormatConfig`
+       constructor per format**, not a generic data-driven mechanism. That's
+       a legitimate approach for a format needing genuinely new engine
+       *behavior* (Dandan needs new shared-zone/deal-order/ownership
+       machinery no config toggle could express) — and is exactly why this
+       design proposes `GameFormat::Custom` only for the *configuration*
+       axis (legal sets, banned/restricted lists, era-rule toggles), not as
+       a replacement for bespoke variants when a format needs new behavior.
+       **Dandan's own plan already argues for `SharedZones` as a reusable
+       building block** ("future shared-deck formats reuse the same
+       `SharedZones` descriptor"), and that generality is not hypothetical:
+       verified via WebSearch (`eternalcentral.com/type4`, plus a Riptide Lab
+       forum thread grouping "Cubelets, Dandân, and other shared deck
+       formats" together) that **Type 4** — a real, decades-old casual
+       format (unlimited mana, no lands, one spell/turn, chaos targeting,
+       last-player-standing) — has a documented variant where "all players
+       use the Type 4 card pool as a shared library," structurally the same
+       zone-sharing shape as Dandan. Type 4's *other* rules (infinite mana,
+       no lands) are unrelated to this design and out of scope, but it's a
+       second real, named format that would want the exact `SharedZones`/
+       `library_of`/`graveyard_of` building block Dandan's plan proposes —
+       reinforcing that it's worth building generally rather than
+       Dandan-specifically, consistent with "build for the class."
+       Worth confirming the maintainer sees these as complementary, not
+       competing, approaches.
+    2. No technical overlap or conflict either way: Dandan's shared-zone
+       accessors and interleaved dealer touch `types/game_state.rs`/
+       `mulligan.rs`/`zones.rs`; this design's touch points
+       (`types/format.rs`, `game/deck_validation.rs`, a new
+       `evaluate_custom_format`) are additive to the same `GameFormat` enum
+       but do not share implementation surface.
+  - **phase-rs/phase#4613 ("Add action-based game replay system"), OPEN,
+    created 2026-06-29 — related-but-distinct from phase 60 (watch-game
+    mode), not a duplicate.** Requests deterministic post-hoc replay
+    export/scrub (record a finished/in-progress local game, load it later,
+    step through in a read-only viewer) — a different use case from phase
+    60's live spectating (phase 60 found spectator mode already fully
+    implemented and live). Both land on a similar "read-only board view" UI
+    surface, so worth a one-line cross-reference in phase 60's docs, but
+    they solve different problems and neither blocks the other.
+  - No open issue or branch name relates to audio/video/voice/webrtc chat,
+    or to spectator/watch-game mode as a feature request (consistent with
+    phase 60's finding that spectator mode already shipped without a
+    tracking issue ever being filed for it).
+
+## Additional validation example — Classic Legacy / "Lost Legacy" (community, non-EC)
+
+A fifth real-world community format, independent of Eternal Central, that
+further validates the schema's generality. Two distinct sources, both
+user-provided this session — kept separate since they describe two different
+things under overlapping branding:
+
+- **Classic Legacy** (`https://classiclegacymtg.com/`, fetched 2026-07-07):
+  Alpha through Rise of the Eldrazi (2010). **No restricted list at all** — a
+  57-card banned list only (all five Moxes, Black Lotus, Ancestral Recall,
+  Demonic Tutor, Yawgmoth's Will, Tinker, etc. are fully **banned**, not
+  restricted-to-1 the way EC's 93-94 treats them). Explicitly states three
+  rules deltas from current Comprehensive Rules: "The London Mulligan is
+  used" (i.e. explicitly the *modern* default, not an old-style mulligan),
+  "There is NO mana burn," and "Combat damage does not use the stack."
+  **This is structurally the inverse of EC's Middle School/Classic Magic**:
+  an old, broad card pool paired with entirely *modern* choices on every
+  `LegacyRuleSet` axis. That is a stronger decoupling proof than Block
+  Constructed (§ above) — it shows card-pool era and legacy-rules flags are
+  not just independently *toggleable in principle*, a real, currently-run
+  community format actually uses that independence (old pool + modern
+  rules), not only the "old pool + old rules" combination the four EC
+  presets happen to use. No new `LegacyRuleSet` field is needed to support
+  it — it is fully expressible by *not* setting any of the flags already
+  designed, on a broader `legal_sets` list.
+- **"Lost Legacy 606"** (a dated tab titled "Lost Legacy" / ref. `606`,
+  user-pasted content from a linked Google Sheet at
+  `docs.google.com/spreadsheets/.../1rf9U9k93_.../htmlview#gid=0` — the sheet
+  itself is a JS-rendered app and was **not** independently fetchable;
+  content below is transcribed as pasted by the user, not independently
+  re-verified against the live sheet). Labelled "(Legacy June 2006 - Pre
+  Coldsnap)", sets "Alpha - Dissension/9th Ed., + Portals and Starter" — a
+  **dated historical snapshot** of what tournament Legacy looked like at a
+  specific point in time, distinct from the single fixed "Classic Legacy"
+  ruleset above. This suggests the source project maintains *multiple*
+  dated snapshots (naming pattern implies `606` = "2006, month 06"), which
+  is an interesting further validation of "format as data" (a snapshot is
+  just another `CustomFormatDef` instance with its own `legal_sets` cutoff
+  and its own banned list) — **noted as a potential future direction, not
+  investigated further and not in scope for the four-EC-preset MVP.**
+
+  Rules deltas listed for this specific snapshot, and how each maps to what
+  is already designed (or explicitly does not):
+  - "Wishes can retrieve exiled cards" — **independently confirms**
+    RESEARCH.md §9's pre-M10 Wish finding via a second, unrelated source.
+  - "Mana Burn is in effect" + "Mana empties at end of phase" — **confirms**
+    the mana-burn hook point already identified (RESEARCH.md §5): the
+    "empties at end of phase" phrasing matches the engine's actual
+    step/phase-boundary pool-emptying mechanism almost exactly.
+  - "Damage uses the stack" — same as EC Middle School/Classic Magic,
+    already modeled.
+  - **"Same Legends are buried on resolution"** — this is the legend rule,
+    described using **pre-2004 templating** ("bury" was a distinct keyword
+    action for "destroy, cannot be regenerated" before being folded into
+    plain "destroy" templating around 2004). The phrase "on resolution" is
+    a potentially significant additional data point for RESEARCH.md §10's
+    `LegendRuleScope::PreM14AnyController`: it may indicate the *original*
+    legend rule was not a continuously-checked state-based action the way
+    both the modern rule and the currently-designed `PreM14AnyController`
+    variant are, but instead resolved as an immediate effect at the moment
+    a legendary permanent entered (or a spell/ability finished resolving).
+    **This needs a follow-up rules-history check before being treated as
+    confirmed** — flagged here rather than silently folded into §10's
+    existing SMALL-effort estimate, since a genuinely different resolution
+    *timing* (immediate effect vs. SBA) could change that estimate.
+  - **"CMC of split card in hand is X or X not the total"** — a real
+    historical difference in how split cards' mana value was calculated
+    outside the stack, but the precise mechanic and the years it applied
+    are **not verified this session** (nothing in RESEARCH.md addresses
+    this). Recorded as an **open flag candidate, not yet designed** —
+    do not add a `LegacyRuleSet` field for this without first verifying the
+    actual historical rule via an authoritative source, per this project's
+    "verify before annotating" discipline.
+  - **"Draws determined by foreign card identification"** — resolved via
+    direct user explanation (not independently re-verified against an
+    external source, per this doc's provenance discipline): each player
+    shows their opponent an obscure card printed in a non-English language;
+    the cards are shown back and forth, and the first player to fail to
+    correctly identify/name the shown card loses. This reads as a
+    paper-tournament social/anti-counterfeiting convention — a
+    knowledge-based substitute for a coin flip or the Chaos Orb tiebreaker
+    (see the EC "tied match" ruling above), not an in-game rule. It has no
+    engine-relevant behavior: phase.rs already needs its own standard
+    mechanism for resolving "who plays first" / breaking ties, and this is
+    simply how humans did that at the table in an old-school paper-Magic
+    setting. **No `LegacyRuleSet` flag needed for this.**
+  - "Current Oracle on all cards" and "Reprints OK" — policy statements
+    about which printing/wording to use, not engine-modelable rules deltas;
+    same category as the already-noted reprint-fidelity open question
+    (Open item 2, above).
+  - "Proxies must be identifiable at arms length" — physical-tournament
+    logistics with zero gameplay/engine relevance. **Explicitly out of
+    engine scope**, noted only so a future reader does not wonder why it
+    was dropped.
+
+## Stretch goal (explicitly lower priority — do not design in depth)
+
+- **Eternal Chaos** (a Lords-of-the-Pit variant on top of 93-94, NOT an
+  EC-defined format): in-match booster-pack tutoring, a dynamically-built
+  sideboard from opened packs, and a pre-match "Gentleman's Agreement" banlist.
+  Depends on 93-94 already existing **plus** a genuinely new in-match
+  pack-opening mechanic. Sequenced last; see PLAN.md §8.
+  **Confirmed via WebSearch:** this in-match pack-opening mechanic is,
+  structurally, exactly what the real card **Booster Tutor** (Unhinged;
+  Oracle: "Open a sealed Magic booster pack, reveal the cards, and put one
+  of them into your hand.") needs — open-a-pack, reveal, pick-one-to-hand.
+  Whichever gets built first (the card's effect handler, generically, vs.
+  the Eternal Chaos mechanic) is the reusable building block for the other;
+  they should not be designed or implemented twice. Note the card's own
+  effect is narrower (put one card into hand, not "build a sideboard from
+  everything opened") — Eternal Chaos's dynamic-sideboard-from-packs piece
+  is an additional layer on top of the same open-a-pack primitive, not a
+  1:1 match.

--- a/docs/proposals/custom-format-engine/CONTEXT.md
+++ b/docs/proposals/custom-format-engine/CONTEXT.md
@@ -581,6 +581,43 @@ Two new, narrower points remained:
    keep/reduce `ReprintPolicy` to non-selectable/deferred metadata" branch
    review round 5 explicitly offered as acceptable. See PLAN.md §3 and §7.
 
+## Maintainer review round 6 — CHANGES_REQUESTED, addressed
+
+matthewevans re-reviewed round 5's fix (commit `21a0a03b`) and confirmed the
+singleton fix landed correctly — "now correctly use the existing
+parameterized copy-limit helper" — with one remaining architecture
+contract flagged as ambiguous, correctly:
+
+1. **`ReprintPolicy` was left in an internally contradictory state (real,
+   confirmed — round 5's fix was itself the bug this round found).** Round
+   5 resolved `reprint_policy` to "documentation metadata, never consumed"
+   but left the FIELD sitting inside `LegalityRules` (part of
+   `CustomFormatRules`, the resolved payload that travels in
+   `FormatConfig.custom_rules` and gets enforced) while a nearby comment
+   from round 1 still said it "gates LEGALITY." Those are two incompatible
+   claims about the same field's contract in the same document — a
+   struct's shape is itself a claim ("this travels with and is part of the
+   enforced ruleset"), and no amount of comment-level disclaiming changes
+   what the type says. Resolved structurally, not documentarily: moved
+   `reprint_policy` out of `CustomFormatRules`/`LegalityRules` entirely,
+   onto a newly-sketched `CustomFormatDef` struct (previously only
+   described in prose as "display metadata + CustomFormatRules," which is
+   exactly the ambiguity that let this happen — round 6 gives it an actual
+   type), alongside `label`/`short_label`/`description`. This is one of the
+   two resolutions matthewevans offered ("move the declared intent to
+   preset/document metadata outside `CustomFormatRules`/`LegalityRules`"),
+   chosen over the other (building real engine-owned printing enforcement
+   and gating registration on it) for the same reason round 5 already
+   established: this document's own original research (RESEARCH.md §3)
+   already showed the field's actual behavior is fully absorbed by
+   `legal_sets` curation, so building separate enforcement would duplicate
+   logic that already exists elsewhere. Every preset sketch, the
+   preset-readiness gate's scope description, and the registry-gate
+   reasoning were updated to reflect the field's new home — the gate no
+   longer needs to "exempt" `reprint_policy`, since it isn't on the
+   resolved-rules struct for the gate to see at all. See PLAN.md §1, §2,
+   §3, and §7.
+
 ## Open (needs a human decision — do NOT resolve unilaterally)
 
 1. ~~**Delivery surface**~~ — **RESOLVED**, see "Maintainer input" section

--- a/docs/proposals/custom-format-engine/CONTEXT.md
+++ b/docs/proposals/custom-format-engine/CONTEXT.md
@@ -61,12 +61,17 @@ corrects an emphasis mistake in how they were sequenced:
   ("structural params reuse `FormatConfig`'s existing fields (life/deck/etc.)")
   rather than a first-class part of `CustomFormatRules` — that was the gap.
 - **Axis B — legality/era-rules config**: `legal_sets`, `banned`, `restricted`,
-  `reprint_policy`, `LegacyRuleSet` (mana burn, damage-on-stack, pre-M10 Wish,
+  `LegacyRuleSet` (mana burn, damage-on-stack, pre-M10 Wish,
   legend-rule scope). This is genuinely new data with no existing UI surface,
   and it's what actually makes the four EC formats *rules-correct* — no amount
   of tuning Axis A knobs produces a faithful Old School 93-94. This axis keeps
   every finding already in RESEARCH.md/CONTEXT.md/PLAN.md; none of that work
-  is discarded.
+  is discarded. (`reprint_policy` is deliberately NOT listed here — as of
+  maintainer review round 6, it lives on `CustomFormatDef`'s display-metadata
+  side, not inside the resolved `CustomFormatRules` Axis A/B split at all.
+  This paragraph originally listed it alongside the real Axis B fields when
+  it was first written in round 1, before that move — flagged by maintainer
+  review round 7 as a stale cross-reference and fixed here.)
 
 **Resolution of Open item 1**: ship (c) — one `CustomFormatDef`/
 `CustomFormatRules` schema — but enter it through Axis A first, via the
@@ -617,6 +622,32 @@ contract flagged as ambiguous, correctly:
    longer needs to "exempt" `reprint_policy`, since it isn't on the
    resolved-rules struct for the gate to see at all. See PLAN.md §1, §2,
    §3, and §7.
+
+## Maintainer review round 7 — CHANGES_REQUESTED, addressed
+
+matthewevans re-reviewed round 6's fix (commit `5098e4bd`) and confirmed:
+"Moving `ReprintPolicy` out of the resolved rules payload correctly resolves
+the prior semantic contradiction" — the structural move itself was right.
+One construction gap remained:
+
+1. **Lobby-created formats had no legitimate `reprint_policy` value (real,
+   confirmed).** Round 6 made `CustomFormatDef.reprint_policy` a required
+   `ReprintPolicy` (not `Option`), but `from_lobby_config(name,
+   &FormatConfig)` has no source for one — a lobby save has no authored
+   paper-format reprint intent at all (it isn't modeling any published
+   ruleset), so forcing any of the three real variants onto it would be
+   fabricated metadata, not an honest gap the way `legal_sets: None` etc.
+   already are for the same reason. Fixed: `reprint_policy:
+   Option<ReprintPolicy>` — `None` for `from_lobby_config` (and, for now,
+   for `swedish_old_school()` pending Open item 6), `Some(_)` with a real,
+   sourced value for every other Axis B preset. Same `Option<T>`-over-
+   forcing-a-value pattern this proposal already uses for `legal_sets` and
+   `range_of_influence` — not a new convention introduced for this one
+   field. Also fixed a stale cross-reference this round caught: CONTEXT.md's
+   original round-1 "Axis B" field list still named `reprint_policy`
+   alongside the genuinely resolved-legality fields, unchanged since before
+   round 6 moved it. See PLAN.md §1, §2, and §6 for the schema, preset, and
+   test changes.
 
 ## Open (needs a human decision — do NOT resolve unilaterally)
 

--- a/docs/proposals/custom-format-engine/CONTEXT.md
+++ b/docs/proposals/custom-format-engine/CONTEXT.md
@@ -433,6 +433,87 @@ being treated as correct).
   Flag renamed `pre_m10_wish_templating` → `pre_m10_wish_reaches_exile` (it is a
   pool-scope toggle, not a wording change).
 
+## Maintainer review round 4 — CHANGES_REQUESTED, addressed
+
+matthewevans re-reviewed round 3's fix (commit `e1c6c1912`) and opened with
+"several earlier design issues are improved" — none of round 3's five points
+were re-flagged, confirming each was genuinely resolved rather than
+resurfacing. Four new/deeper points were raised. Per direct instruction this
+round, every point across ALL FOUR review rounds was re-audited against
+current source before treating anything as settled — this surfaced one
+additional real gap (`deck_validation.rs`'s `DeckCompatibilityRequest
+.selected_format`) that nobody, including this document, had named yet.
+
+1. **Custom format context handling was partial, and a malformed payload
+   could panic (real, confirmed — the most substantive miss).** Round 3's
+   `FormatConfig::sideboard_policy()` used `.expect("Custom format must
+   carry custom_rules")` — a production panic path if `custom_rules` is
+   ever `None` while `format == Custom(_)`. It also migrated only 2 call
+   sites; a full grep this round for every non-test consumer of
+   `.sideboard_policy()` / `.uses_commander()` on a bare `GameFormat` found
+   SEVEN files: `companion.rs` (4 sites — round 4's own citation),
+   `deck_loading.rs` (2), `match_flow.rs` (2), and, found independently this
+   round and not named by any review, `deck_validation.rs` (5 sites,
+   including `DeckCompatibilityRequest.selected_format: Option<GameFormat>`
+   itself — a request struct with no `FormatConfig`/`custom_rules` field at
+   all, meaning even a corrected accessor couldn't have helped these call
+   sites without a signature change). Fixed: (a) fallible validation of the
+   `format`/`custom_rules` invariant at every construction/ingestion point,
+   rejecting inconsistent values before they can exist, so nothing
+   downstream needs `.expect()`; (b) `sideboard_policy` becomes a STORED
+   FIELD on `FormatConfig` — matching the pattern `uses_commander` and
+   `supplies_fixed_deck` already use (confirmed via `format.rs:1512-1513`'s
+   own consistency test), not a new pattern; (c) every real consumer
+   migrates to read the resolved field, with signatures widened wherever
+   they currently only carry a bare `GameFormat`. See PLAN.md §1.
+2. **`from_lobby_config`'s `sideboard_policy` source was never actually
+   specified (real, confirmed).** Round 3 added the field and the round-3
+   accessor, but never stated how the conversion itself computes the value
+   from a bare `&FormatConfig`. Fixed: explicit —
+   `config.format.sideboard_policy()`, valid because `from_lobby_config`'s
+   precondition is that its input's `format` is always built-in (re-saving
+   an already-custom format is out of scope). See PLAN.md §2.
+3. **`LegacyRuleSet`'s booleans should be typed enums, and no preset may
+   ship in a "playable with a caveat" state (real, confirmed — the second
+   part is a genuine scope tightening, not a bug fix).** `mana_burn`,
+   `damage_uses_stack`, and `pre_m10_wish_reaches_exile` were bools; per
+   CLAUDE.md's own bool-vs-enum principle each names a real two-value
+   historical space (an obsolete pre-removal form vs. modern absence), so
+   each becomes a typed enum (`ManaBurnPolicy`, `CombatDamageTiming`,
+   `WishOutsideGameScope`) mirroring `LegendRuleScope`'s existing shape.
+   Separately and more consequentially: this document's own §8/RESEARCH.md
+   §6 said Middle School / Classic Magic would be "playable-with-caveat"
+   until damage-on-stack lands. **Retracted, not merely superseded** — the
+   preset-readiness gate (§7) now explicitly forbids any partial-fidelity
+   registration. Real consequence: those two EC presets cannot ship as
+   selectable until the LARGE combat-timing rework is fully done, full
+   stop, not available-now-with-a-documented-gap as originally planned. See
+   PLAN.md §1 and §7.
+4. **Version-skew handling and `ReprintPolicy` enforcement both needed a
+   concrete resolution, not a flag (real, confirmed).** Rounds 2-3 correctly
+   identified both gaps but explicitly deferred designing them ("not
+   designed in depth here"). Round 4 required an actual answer for each:
+   - Version skew: this engine already has a working protocol-version gate
+     (`server-core/src/protocol.rs`'s `PROTOCOL_VERSION` /
+     `MIN_SUPPORTED_PROTOCOL`, confirmed this session to already "refuse to
+     proceed on mismatch"). Resolution: bump `PROTOCOL_VERSION` when
+     `GameFormat::Custom` ships, so an incompatible client is rejected at
+     the EXISTING handshake gate — reusing proven infrastructure rather than
+     inventing a custom-format-specific negotiation layer.
+   - `ReprintPolicy` enforcement: two resolution paths, either sufficient —
+     the general engine-vs-frontend printing cross-reference (Open item 2),
+     or a one-preset verification pass scoped just to
+     `swedish_old_school()`'s own restricted-list cards. Until either lands,
+     the preset-readiness gate keeps this preset (and any other declaring a
+     non-trivial `ReprintPolicy`) unregistered — the "explicitly narrow the
+     proposal" branch review round 4 offered as an acceptable alternative to
+     building the full model immediately.
+   - Also fixed: two stale `pre_m10_wish_templating` references in
+     RESEARCH.md (lines 417/442) that survived since round 1 despite
+     PLAN.md already using the canonical `pre_m10_wish_reaches_exile` name
+     throughout — a pure terminology-reconciliation miss, now consistent
+     everywhere.
+
 ## Open (needs a human decision — do NOT resolve unilaterally)
 
 1. ~~**Delivery surface**~~ — **RESOLVED**, see "Maintainer input" section

--- a/docs/proposals/custom-format-engine/CONTEXT.md
+++ b/docs/proposals/custom-format-engine/CONTEXT.md
@@ -100,7 +100,9 @@ first slice to something with **zero new legacy-rule engine work**:
   - **Legal sets**: Alpha, Beta, Unlimited, Arabian Nights, Antiquities,
     Legends, The Dark, "Summer Magic" — the same era pool EC's 93-94 uses.
   - **Banned list**: empty — no card is fully banned under Swedish rules.
-  - **Restricted list** (verbatim, 23 cards, one-copy maximum): Ancestral
+  - **Restricted list** (verbatim, 25 cards, one-copy maximum — corrected
+    from an initial miscount of 23 flagged by review; recounted directly
+    against the enumerated names below): Ancestral
     Recall, Balance, Black Lotus, Braingeyser, Channel, Chaos Orb, Contract
     from Below, Darkpact, Demonic Tutor, Library of Alexandria, Mana Drain,
     Mind Twist, Mishra's Workshop, Mox Emerald, Mox Jet, Mox Pearl, Mox Ruby,
@@ -144,6 +146,95 @@ wiring those require. This is a re-sequencing, not a scope cut — all four EC
 formats and the full legacy-rules axis remain the target; they simply move to
 a phase 2 that ships once the schema and Axis A/Axis B mechanics are already
 proven end-to-end by something smaller and testable.
+
+## Maintainer review round 2 — CHANGES_REQUESTED, addressed
+
+matthewevans reviewed the previous head and requested changes on five
+design-correctness grounds. All five are addressed in this revision; see the
+cited PLAN.md sections for the actual schema/wiring changes.
+
+1. **Axis-A unrestricted-legality bug (real, confirmed).** The evaluator design
+   (PLAN.md §3) checked "legal iff a printing's set ∈ `legal_sets`" — an empty
+   `Vec` (Axis A's default, since a lobby-saved format sets no restriction)
+   makes every card fail, not none. Fixed: `legal_sets` is now
+   `Option<Vec<SetCode>>` — `None` means unrestricted (every card passes the
+   pool check), `Some(list)` means restricted to that list, matching this
+   repo's own convention of using `Option<T>` over an ambiguous sentinel
+   value (CLAUDE.md's `Option<ControllerRef>` example). See PLAN.md §1 and §3.
+2. **`StructuralRules` was missing behavior-bearing `FormatConfig` fields
+   (real, confirmed).** Re-read `FormatConfig`'s full field list
+   (`types/format.rs:174-212`) directly rather than from memory. Fixed:
+   `StructuralRules` now includes `command_zone`, `commander_damage_threshold`,
+   and `archenemy_player` (all independently meaningful, not derived).
+   `uses_commander` is derived as `commander_damage_threshold.is_some()`
+   rather than stored redundantly. `supplies_fixed_deck` is always `false`
+   for `Custom` (no custom-format use case for an auto-supplied deck exists;
+   flagged, not silently dropped, if that need ever arises).
+   `allow_debug_actions` is correctly excluded — its own doc comment says
+   it is "orthogonal to format," a session capability flag, not format
+   identity. **New finding**: `sideboard_policy` is not a `FormatConfig`
+   field at all — it's a `GameFormat` *method*
+   (`format.rs:270`, `fn sideboard_policy(self) -> SideboardPolicy`), so
+   `GameFormat::Custom` has no derivation source for it the way built-in
+   formats do. `StructuralRules` gains an explicit `sideboard_policy` field
+   to fill that gap. See PLAN.md §1.
+3. **No identity/persistence/transport contract for a lobby-saved format
+   (real, confirmed — the largest gap).** The original design conflated two
+   different identity concerns: (a) how a resolved ruleset is agreed on by
+   both peers *in one active game*, and (b) how a *named, reusable* saved
+   format persists for one player across many future games. (a) was already
+   solved — `FormatConfig.custom_rules` carries the full resolved
+   `CustomFormatRules` payload, not a lookup key, so a peer never needs to
+   already know a format by ID to play it. (b) was never designed. Resolved
+   by explicitly separating them: the engine's `CustomFormatId` stays a
+   lightweight, `Copy`, per-`GameState` transport tag (stable/well-known only
+   for the registry-backed EC/Swedish presets; an ad-hoc lobby save can use a
+   fixed sentinel value, since the full payload — not the ID — is what
+   travels and is interpreted). A player's "my saved formats" library is a
+   **client-side-only** concern (local storage / profile-scoped, its own
+   name+identity, never an engine or WASM type) that packages a
+   `CustomFormatRules` value at game-start time. This also resolves the
+   version-skew question: an older client that doesn't know the
+   `GameFormat::Custom` enum variant at all can't be rescued by
+   `serde(default)` on the payload (the failure is at the enum-variant level,
+   not the payload level) — flagged as a real, explicit compatibility check
+   the lobby-join flow needs (reject with a clear message, don't crash on
+   deserialization), not something this schema revision can silently fix.
+   See PLAN.md §1 (new subsection) and §7.
+4. **Mana-burn behavioral/timing error (real, confirmed against this engine's
+   own code and CR text, and against direct correction: mana burn keys off
+   crossing a real MTG *phase* boundary, not the engine's finer-grained
+   `Phase` enum, which flattens MTG's steps and phases into one 11-variant
+   list — e.g. `DeclareAttackers` → `DeclareBlockers` is a step transition
+   within the Combat phase, not a phase-end, even though the engine's own
+   `Phase` enum treats every one of those as a variant transition).**
+   Verified two things directly this session, not from memory:
+   - `docs/MagicCompRules.txt:8278` (the obsolete-rules glossary): "unspent
+     mana caused a player to **lose life**" — life loss, not damage. The
+     original PLAN.md/RESEARCH.md draft's "deal that many damage" framing
+     was wrong.
+   - The engine already has a generic, existing mechanism for exactly this
+     shape: `player_unspent_mana_loss_causes_life_loss`
+     (`static_abilities.rs:1237`, backed by `StaticMode::UnspentManaLossCausesLifeLoss`)
+     is checked inside `apply_empty_mana_pool_event` (`turns.rs`, doc comment:
+     "CR 106.4 + CR 703.4q: Apply the final replacement-ordered mana
+     dispositions as the step or phase ends, then apply one aggregate
+     Yurlok-class life-loss event") — this fires on **every** `Phase` enum
+     transition (both true steps and true phases, per modern CR 500.5),
+     which is correct for the existing Yurlok-class static ability but too
+     fine-grained for old-school mana burn, which must fire only when
+     actually leaving one of the 5 real MTG phases (Beginning, Precombat
+     Main, Combat, Postcombat Main, Ending) — not on every step within one.
+   See PLAN.md §4 for the corrected wiring: a phase-group boundary check
+   gating a *second*, independent contribution to the same life-loss event
+   mechanism, alongside (not merged into) the existing Yurlok-class check.
+5. **Preset data inconsistencies (real, confirmed and fixed).** Swedish Old
+   School's restricted list was mislabeled "23 cards" when 25 are actually
+   enumerated (fixed above); PLAN.md's `swedish_old_school()` sketch had
+   dropped "Summer Magic" from the legal-sets list that this document already
+   stated (fixed in PLAN.md §2). Classic Magic's restricted list was labeled
+   "(37)" but enumerates 44 names in RESEARCH.md — recounted directly against
+   the verbatim list and fixed to "(44)" in both RESEARCH.md and PLAN.md §2.
 
 ## Confirmed (verified against source this session)
 

--- a/docs/proposals/custom-format-engine/CONTEXT.md
+++ b/docs/proposals/custom-format-engine/CONTEXT.md
@@ -715,16 +715,52 @@ different, deeper-history finding:
    axis at all, even though CONTEXT.md's own item 2 (above) already flagged
    it as a live, unresolved "needs a human decision" item. The plan and the
    open-items list had drifted out of sync with each other.
-   **Resolved directly this round, in discussion, not left open**: see item
-   2 above (now resolved) and PLAN.md §1's "RESOLVED — round 10" note.
-   Legality enforcement is not extended (no engine data exists to enforce
-   foil/frame against, and that's permanent, not a placeholder); the source
-   rules' spirit is instead honored by making `ArtChainEntry`'s existing
-   `{type: "oldest"}` per-player preference `legal_sets`-aware — general to
-   every format, zero engine change, not gated on `ReprintPolicy`. The
-   registration gate for Old School 93-94/95 is unchanged from §8 (mana
-   burn only) since printing fidelity is now explicitly a display concern,
-   not a legality one.
+   **Resolved this round as follows — SUPERSEDED by round 11 below, kept
+   here as the accurate historical record, not deleted:** legality
+   enforcement not extended; the source rules' spirit honored instead by
+   making `ArtChainEntry`'s existing `{type: "oldest"}` preference
+   `legal_sets`-aware. Round 11 correctly rejected this — a display
+   preference isn't a legality resolution — so this specific fix does not
+   ship as part of resolving item 2; see round 11 below for what actually
+   resolved it.
+
+## Maintainer review round 11 — CHANGES_REQUESTED, addressed
+
+matthewevans re-reviewed round 10's fix (commit `673e22366`) and rejected
+its resolution directly:
+
+1. **A display default cannot resolve a legality claim (real, confirmed —
+   round 10's fix was itself the gap this round found).** "[T]he proposal
+   replaces a source legality requirement with an optional display
+   preference, so the EC Old School presets remain eligible for selection
+   without rules-faithful printing enforcement... do not treat an optional
+   rendering preference as a legality resolution." Correct: making
+   `ArtChainEntry` legal-set-aware is a genuine, worthwhile improvement, but
+   it's cosmetic — nothing stops a player from submitting a deck with a
+   wrong-printing card regardless of what the client renders.
+   **Resolved directly in discussion, not by picking one of the two options
+   matthewevans offered (gate on future enforcement, or explicitly downgrade
+   the claim) — a third answer grounded in existing precedent:** confirmed
+   this round that `GameFormat::Premodern`'s legality
+   (`LegalityFormat::Premodern`, `format.rs:243`) is oracle-card-level
+   only — no built-in format in this engine has EVER checked printing,
+   frame, border, or foil, and `PrintedCardRef` (the actual runtime card
+   identity, `card.rs:89-92`) has no set-code field for any format. So
+   `legal_sets` membership isn't an old-school-specific approximation
+   needing a gate or a caveat — it's this engine's one existing legality
+   model, applied identically to a new format the same way it's already
+   applied to every format that shipped before this proposal. The
+   registration gate for Old School 93-94/95 reverts to §8's pre-round-10
+   state (mana burn only). The round-10 `ArtChainEntry` display fix is
+   retracted from this proposal (a real idea, but belongs in its own
+   proposal, not used to paper over a legality question that no longer
+   needs it). Genuine per-card printing selection (briefly surveyed, not
+   designed: the deck-builder already has `PrintingPickerModal.tsx` and a
+   `DeckEntry.sourcePrinting` field that's currently discarded before
+   reaching the engine, `client/src/services/deckParser.ts:5-9,45-73`) is
+   confirmed as a real, moderate-lift, but separate future feature, general
+   to every format — also not designed here. See PLAN.md §1's "RESOLVED —
+   round 11" note for the full argument and §6 for the test this adds.
 
 ## Open (needs a human decision — do NOT resolve unilaterally)
 
@@ -732,26 +768,34 @@ different, deeper-history finding:
    above: (c), entered via Axis A (structural config) through the existing
    lobby first, Axis B (legality/legacy-rules) as audited presets validating
    the same schema. PLAN.md §1 and §7 updated accordingly.
-2. ~~**Reprint-policy fidelity**~~ — **RESOLVED, round 10** (maintainer
-   review flagged the rollout registering Old School 93-94/95 with no gate
-   tied to this gap; resolved directly, not left open): legality stays
-   `legal_sets`-membership-only, permanently, not pending further work —
-   foil/frame data doesn't exist anywhere in the engine's card database to
-   enforce against. The source rules' printing-fidelity intent is instead
-   honored by a DISPLAY fix, general to every format: `ArtChainEntry`'s
-   existing `{type: "oldest"}` per-player preference mode becomes
-   `legal_sets`-aware (restricts candidate printings to the active format's
-   legal set list before picking the oldest, when one is declared), fixing
-   a real gap where "oldest printing" could mean a promo/non-tournament
-   printing the format doesn't even recognize (e.g. Chronicles' City of
-   Brass reprint is fine, its Junior Super Series promo printing is not).
-   Zero engine change, zero new `ArtChainEntry` variant, not gated on
-   `ReprintPolicy` — see PLAN.md §1's "RESOLVED — round 10" note for the
-   full design and why (a) new engine-owned printing-derived state was not
-   chosen over (b) extending the existing frontend preference system. The
-   original framing below ("no frame/art metadata per printing, full stop")
-   was too pessimistic and is kept for its still-accurate research, not as
-   a live open question:
+2. ~~**Reprint-policy fidelity**~~ — **RESOLVED, round 11** (round 10's
+   attempt to resolve this via a display fix was directly rejected by
+   round 11's review — a cosmetic default isn't a legality resolution; see
+   round 10/11 log entries above for the full back-and-forth). **Final
+   resolution: `legal_sets` membership is not an approximation of Old
+   School 93-94/95's legality — it's the exact same oracle-card-level
+   legality model every format in this engine already uses.** Confirmed
+   directly: `GameFormat::Premodern`'s legality check
+   (`LegalityFormat::Premodern`, `crates/engine/src/types/format.rs:243`)
+   and every other built-in format's are ALL oracle-card-level only; no
+   format anywhere in this engine has ever checked printing, frame, or
+   foil, and the runtime card identity (`PrintedCardRef`, `card.rs:89-92`)
+   has no set-code field for any of them. There is no inconsistency to gate
+   Old School 93-94/95 against, because no format in this engine does more
+   than what `legal_sets` already gives them. Registration reverts to §8's
+   original gate (mana burn only, no new blocking axis). Two real ideas
+   surfaced along the way are explicitly deferred as separate, future,
+   general (not old-school-specific) proposals, not designed further here:
+   (a) a legal-set-aware `ArtChainEntry` display default (round 10's fix,
+   retracted from THIS proposal but not abandoned as an idea), and (b)
+   genuine per-card printing selection in the deck builder — briefly
+   surveyed, confirmed as a moderate plumbing lift reusing existing
+   components (`PrintingPickerModal.tsx`, `DeckEntry.sourcePrinting`), not
+   a from-scratch feature, but out of scope here. See PLAN.md §1's
+   "RESOLVED — round 11" note for the full argument. The original framing
+   below ("no frame/art metadata per printing, full stop") was too
+   pessimistic and is kept for its still-accurate research, not as a live
+   open question:
    - **Engine/MTGJSON side** (`CardDatabase::printings_for`,
      `crates/engine/src/database/card_db.rs:227`): a bare `Vec<String>` of set
      codes, sourced from MTGJSON `AtomicCards.json`
@@ -794,15 +838,16 @@ different, deeper-history finding:
      filter). So an "oldest legal printing" ordering is a **wiring problem**,
      not a new-data-acquisition problem — cheaper than true frame-level
      enforcement.
-   - **Decided, round 10**: the legal-set-membership approximation is
-     permanent for LEGALITY (no engine-owned frame/foil enforcement will be
-     built — there's no data to enforce against), paired with a real,
-     general DISPLAY fix (Scryfall's already-existing frame/`released_at`
-     data, cross-referenced against the active format's `legal_sets`, via
-     the frontend's existing `ArtChainEntry` preference system rather than
-     new engine-owned derived state) — see PLAN.md §1's "RESOLVED — round
-     10" note for the full design. This is no longer an open product
-     decision.
+   - **Decided, round 11 (supersedes round 10's framing on this line):**
+     `legal_sets` membership is not an approximation at all — it's the
+     identical oracle-card-level legality model `Premodern` and every other
+     format in this engine already uses (`LegalityFormat::Premodern`,
+     `format.rs:243`; no format anywhere checks printing/frame/foil). No
+     further engine work is gated on or expected for this dimension. The
+     display fix and real printing-selection ideas above are both real and
+     worth pursuing, but as their own separate, general proposals — not as
+     part of resolving this item. See PLAN.md §1's "RESOLVED — round 11"
+     note. This is no longer an open product decision.
 3. **Classic Magic B&R cadence.** EC updates Classic's banlist twice yearly
    (Jan 1 / Jul 1). Bundled-preset data is version-controlled, so updates are
    ordinary edits — but whether we want a dated/versioned banlist history is

--- a/docs/proposals/custom-format-engine/CONTEXT.md
+++ b/docs/proposals/custom-format-engine/CONTEXT.md
@@ -848,6 +848,46 @@ its resolution directly:
      worth pursuing, but as their own separate, general proposals — not as
      part of resolving this item. See PLAN.md §1's "RESOLVED — round 11"
      note. This is no longer an open product decision.
+   - **Correction — round 12: it WAS still an open product decision, and
+     round 11's premise didn't survive the maintainer's follow-up review of
+     this exact resolution.** The maintainer correctly rejected "no format
+     checks printing/frame/foil" as sufficient justification here: Premodern
+     never claimed a printing-level requirement in the first place, so it
+     stopping at set-code membership isn't an approximation of anything.
+     Old School 93-94/95's own cited source (RESEARCH.md §1) explicitly DOES
+     require non-foil original-frame/art reprints — `legal_sets` genuinely
+     falls short of that specific stated rule, regardless of what every
+     other format does or doesn't check.
+   - **Final resolution, round 12 (a real product decision, made
+     deliberately rather than resolved away by precedent):** decline to
+     build engine-owned printing/frame enforcement — confirmed above that
+     the engine's and frontend's printing systems are disconnected and
+     wiring them is a genuine, moderate-lift, general future feature, not
+     an old-school-specific one. Instead, accept the set-code-only
+     approximation on the grounds that it's genuinely acceptable for THIS
+     engine, not merely convenient: in a digital-only client, a printing's
+     frame/border/foil status has zero gameplay consequence — two printings
+     with identical Oracle text are identical for every rules purpose the
+     engine cares about. The paper community's frame/art requirement serves
+     an anti-counterfeiting/provenance function specific to a physical
+     table, which has no digital equivalent. Declining to model that purely
+     cosmetic, paper-specific concern is a legitimate scope decision — but
+     presenting the approximation as full fidelity would not be, which is
+     why this is disclosed structurally rather than left as a rejected
+     framing repeated with different words: `CustomFormatDef` gains a
+     `printing_fidelity: PrintingFidelity` field (new enum:
+     `NotApplicable` / `SetCodeApproximation`), required and paired with
+     `reprint_policy` at construction time (enforced by a registry gate and
+     a test, not a doc comment — see PLAN.md §1's "round 12" note near the
+     `CustomFormatDef` struct, §6's new test, and §7's second gate). Every
+     preset with `reprint_policy: Some(_)` — the four EC formats — must set
+     `printing_fidelity: SetCodeApproximation` and disclose the limitation
+     in its player-facing `description`. This is the maintainer's own
+     second offered resolution ("explicitly scope the presets as an
+     oracle-card/set-code approximation"), made structural rather than
+     documentary, and it is now genuinely closed — not by analogy to what
+     other formats don't check, but by disclosing what this format's own
+     stricter rule isn't getting.
 3. **Classic Magic B&R cadence.** EC updates Classic's banlist twice yearly
    (Jan 1 / Jul 1). Bundled-preset data is version-controlled, so updates are
    ordinary edits — but whether we want a dated/versioned banlist history is

--- a/docs/proposals/custom-format-engine/CONTEXT.md
+++ b/docs/proposals/custom-format-engine/CONTEXT.md
@@ -649,16 +649,109 @@ One construction gap remained:
    round 6 moved it. See PLAN.md §1, §2, and §6 for the schema, preset, and
    test changes.
 
+## Maintainer review round 8 — CHANGES_REQUESTED, addressed
+
+matthewevans re-reviewed round 7's fix (commit `83eabc081`) and confirmed
+`Option<ReprintPolicy>` "correctly gives lobby saves an honest `None`
+value," with one construction gap remaining:
+
+1. **`from_lobby_config` had no defined rule for `label`/`short_label`/
+   `description` (real, confirmed).** `CustomFormatDef` requires all three
+   non-optionally since round 6, but the constructor's signature (`name` +
+   `&FormatConfig`) never specified how `short_label`/`description` are
+   derived. Fixed: `label = name` directly; `short_label` = `name`'s first 3
+   alphanumeric characters uppercased (the same convention the frontend
+   already independently falls back to for any unrecognized format,
+   `format.slice(0, 3).toUpperCase()` in `GameListItem.tsx` and others — not
+   a new convention); `description` via a new
+   `derive_structural_description(&StructuralRules)` helper mirroring
+   built-in formats' existing comma-joined structural phrasing. Empty/
+   whitespace-only `name` is rejected, consistent with round 2's "reject
+   explicitly rather than silently drop data" posture. See PLAN.md §1 and
+   §6.
+
+## Maintainer review round 9 — CHANGES_REQUESTED, addressed
+
+matthewevans re-reviewed round 8's fix (commit `9698d1ac5`) and found the
+round-8 fix incomplete at a deeper level:
+
+1. **`CustomFormatDef`'s display metadata never reaches a running game
+   (real, confirmed).** `SavedCustomFormat.name` is client-local-only by
+   round 2's own identity design and never enters
+   `CustomFormatRules`/`FormatConfig.custom_rules` — so once a game starts,
+   there is no name to read. Worse than a missing-data problem:
+   `GameFormat::label(self) -> &'static str` (`format.rs:395`) cannot
+   return `CustomFormatDef.label` (a `String`) regardless of what's threaded
+   in — a signature problem. Fixed: `label()` becomes
+   `Cow<'static, str>`-returning; built-in variants unchanged
+   (`Cow::Borrowed`); `Custom(id)` resolves via a `custom_format_registry()`
+   lookup by id — a hit (Axis B, stable registry id) returns the real name,
+   a miss (Axis A's ad-hoc sentinel id, never registered) returns a fixed
+   `"Custom Format"` fallback. No new wire surface added; the real
+   player-chosen name for an ad-hoc save stays exactly where round 2 always
+   said it lives — the local picker, never promised at runtime.
+2. **Second, independently-found instance of the same root cause.**
+   `FormatConfig::for_format(bare GameFormat)` (`format.rs:1056`) is called
+   for `.deck_size` at two real `deck_validation.rs` sites (confirmed by
+   direct grep, not the doc comment's stale claimed "lobby broker" caller,
+   which doesn't exist in the codebase today), silently returning a wrong
+   default size for `Custom`. Fixed identically to the existing
+   `sideboard_policy`/`uses_commander` pattern: an `unreachable!()` guard
+   arm, with both call sites migrated to read
+   `custom_rules.structural.deck_size` when present. See PLAN.md §1 and §6
+   for both fixes and their required tests.
+
+## Maintainer review round 10 — CHANGES_REQUESTED, addressed
+
+matthewevans re-reviewed round 9's fix (commit `6ec2f2adc`) and raised a
+different, deeper-history finding:
+
+1. **The rollout registers Old School 93-94/95 with no gate tied to their
+   own source rules' printing-fidelity requirement (real, confirmed).**
+   RESEARCH.md:34 cites the actual EC source: "non-foil reprints with
+   original frame + art." `legal_sets` (set-code membership) cannot express
+   this, and PLAN.md §8 schedules these two presets as registerable once
+   mana burn lands alone — with no gate acknowledging the printing-fidelity
+   axis at all, even though CONTEXT.md's own item 2 (above) already flagged
+   it as a live, unresolved "needs a human decision" item. The plan and the
+   open-items list had drifted out of sync with each other.
+   **Resolved directly this round, in discussion, not left open**: see item
+   2 above (now resolved) and PLAN.md §1's "RESOLVED — round 10" note.
+   Legality enforcement is not extended (no engine data exists to enforce
+   foil/frame against, and that's permanent, not a placeholder); the source
+   rules' spirit is instead honored by making `ArtChainEntry`'s existing
+   `{type: "oldest"}` per-player preference `legal_sets`-aware — general to
+   every format, zero engine change, not gated on `ReprintPolicy`. The
+   registration gate for Old School 93-94/95 is unchanged from §8 (mana
+   burn only) since printing fidelity is now explicitly a display concern,
+   not a legality one.
+
 ## Open (needs a human decision — do NOT resolve unilaterally)
 
 1. ~~**Delivery surface**~~ — **RESOLVED**, see "Maintainer input" section
    above: (c), entered via Axis A (structural config) through the existing
    lobby first, Axis B (legality/legacy-rules) as audited presets validating
    the same schema. PLAN.md §1 and §7 updated accordingly.
-2. **Reprint-policy fidelity — corrected/sharpened this round.** The original
-   framing ("no frame/art metadata per printing, full stop") was too
-   pessimistic. There are **two disjoint printing systems in this codebase
-   today, and only one of them lacks frame data**:
+2. ~~**Reprint-policy fidelity**~~ — **RESOLVED, round 10** (maintainer
+   review flagged the rollout registering Old School 93-94/95 with no gate
+   tied to this gap; resolved directly, not left open): legality stays
+   `legal_sets`-membership-only, permanently, not pending further work —
+   foil/frame data doesn't exist anywhere in the engine's card database to
+   enforce against. The source rules' printing-fidelity intent is instead
+   honored by a DISPLAY fix, general to every format: `ArtChainEntry`'s
+   existing `{type: "oldest"}` per-player preference mode becomes
+   `legal_sets`-aware (restricts candidate printings to the active format's
+   legal set list before picking the oldest, when one is declared), fixing
+   a real gap where "oldest printing" could mean a promo/non-tournament
+   printing the format doesn't even recognize (e.g. Chronicles' City of
+   Brass reprint is fine, its Junior Super Series promo printing is not).
+   Zero engine change, zero new `ArtChainEntry` variant, not gated on
+   `ReprintPolicy` — see PLAN.md §1's "RESOLVED — round 10" note for the
+   full design and why (a) new engine-owned printing-derived state was not
+   chosen over (b) extending the existing frontend preference system. The
+   original framing below ("no frame/art metadata per printing, full stop")
+   was too pessimistic and is kept for its still-accurate research, not as
+   a live open question:
    - **Engine/MTGJSON side** (`CardDatabase::printings_for`,
      `crates/engine/src/database/card_db.rs:227`): a bare `Vec<String>` of set
      codes, sourced from MTGJSON `AtomicCards.json`
@@ -700,15 +793,16 @@ One construction gap remained:
      unrelated purpose (`client/public/set-list.json`, deck-builder set
      filter). So an "oldest legal printing" ordering is a **wiring problem**,
      not a new-data-acquisition problem — cheaper than true frame-level
-     enforcement, which would need Scryfall's frame fields cross-referenced
-     against the format's legal-set list, and a decision on whether that
-     cross-reference is new engine-owned derived state (per "engine owns all
-     logic") or an extension of the frontend's existing cosmetic
-     `ArtChainEntry` preference system seeded by the format (a real
-     architectural fork — see PLAN.md's new `PrintingDefault` note). Whether
-     the approximation (set-code-list membership only) is acceptable for v1,
-     or whether the Scryfall-engine cross-reference should be built, is a
-     product decision.
+     enforcement.
+   - **Decided, round 10**: the legal-set-membership approximation is
+     permanent for LEGALITY (no engine-owned frame/foil enforcement will be
+     built — there's no data to enforce against), paired with a real,
+     general DISPLAY fix (Scryfall's already-existing frame/`released_at`
+     data, cross-referenced against the active format's `legal_sets`, via
+     the frontend's existing `ArtChainEntry` preference system rather than
+     new engine-owned derived state) — see PLAN.md §1's "RESOLVED — round
+     10" note for the full design. This is no longer an open product
+     decision.
 3. **Classic Magic B&R cadence.** EC updates Classic's banlist twice yearly
    (Jan 1 / Jul 1). Bundled-preset data is version-controlled, so updates are
    ordinary edits — but whether we want a dated/versioned banlist history is

--- a/docs/proposals/custom-format-engine/CONTEXT.md
+++ b/docs/proposals/custom-format-engine/CONTEXT.md
@@ -79,6 +79,72 @@ useful — the Axis A save-flow is smaller, ships independently, and is useful
 to every casual multiplayer table, not just old-school players. See PLAN.md §1
 and §7 for the schema and sequencing changes this implies.
 
+## Further narrowing Axis B's MVP — Swedish Old School over the four EC formats
+
+The follow-up ask: building `LegacyRuleSet` end-to-end (mana burn drop-site
+hook, the damage-uses-the-stack combat rework, pre-M10 Wish exile access,
+legend-rule scope) is real engine work with real risk, and doing all of it up
+front makes the MVP harder to test, not easier. Two formats narrow Axis B's
+first slice to something with **zero new legacy-rule engine work**:
+
+- **Premodern needs no work at all.** It is already a native, working
+  `GameFormat` (`FormatConfig::premodern()`) — fully modern rules, a
+  set-window-restricted legal pool. It validates nothing new about this
+  design; it's cited here only as an existing precedent for "old(er) card
+  pool + entirely modern rules," the same shape Swedish Old School turns out
+  to have.
+- **Swedish Old School 93/94** — a *different, real ruleset* from the four EC
+  formats already researched, independently verified this session via
+  `oldschool-mtg.blogspot.com/p/banrestriction.html` (fetched directly, not
+  from memory):
+  - **Legal sets**: Alpha, Beta, Unlimited, Arabian Nights, Antiquities,
+    Legends, The Dark, "Summer Magic" — the same era pool EC's 93-94 uses.
+  - **Banned list**: empty — no card is fully banned under Swedish rules.
+  - **Restricted list** (verbatim, 23 cards, one-copy maximum): Ancestral
+    Recall, Balance, Black Lotus, Braingeyser, Channel, Chaos Orb, Contract
+    from Below, Darkpact, Demonic Tutor, Library of Alexandria, Mana Drain,
+    Mind Twist, Mishra's Workshop, Mox Emerald, Mox Jet, Mox Pearl, Mox Ruby,
+    Mox Sapphire, Regrowth, Sol Ring, Strip Mine, Tempest Efreet, Time Walk,
+    Timetwister, Wheel of Fortune — a **different list from EC's 93-94**, not
+    a duplicate (confirms Axis B's `restricted: Vec<CardName>` shape needs to
+    be a real per-format list, not a shared constant).
+  - **Ante cards**: "must be removed before play unless the tournament is
+    specifically played for ante" (Bronze Tablet, Contract from Below,
+    Darkpact, Demonic Attorney, Jeweled Bird, Rebirth, Tempest Efreet) — a
+    third list-shaped rule distinct from banned/restricted, **not yet modeled
+    anywhere in this schema**. Flagged as a real gap to resolve at
+    implementation time (likely a third named list, or folded into `banned`
+    conditionally on an `ante_enabled` toggle this proposal does not yet
+    have) — do not silently drop it.
+  - **Reprint policy**: the primary source does **not** state one explicitly
+    (only "Only English versions are allowed in Oldschool") — a secondary
+    source (`mtgoldframe.com`) claims no Revised-or-later reprints are
+    allowed, but that was **not** independently confirmed against the primary
+    rules page this session. Do not encode `ReprintPolicy::OriginalPrintingsOnly`
+    for this preset without re-verifying against the primary source or asking
+    the community directly — flagged open, not resolved.
+  - **Legacy rules**: the primary source makes **no mention** of mana burn,
+    damage-on-the-stack, old Wish templating, or a modified legend rule —
+    the plain reading is that Swedish Old School uses fully **modern** rules
+    on the restricted-era pool. This is structurally the same shape as the
+    already-documented **Classic Legacy** validation example (above): old
+    card pool, modern rule engine, `LegacyRuleSet` at its all-`false`/
+    `Modern` defaults. It is a *second* independent confirmation that
+    card-pool era and legacy-rules toggles are properly decoupled axes, and
+    the cheapest possible Axis B instance to build and test — no
+    `LegacyRuleSet` engine wiring is exercised at all.
+
+**Revised sequencing implication** (see PLAN.md §8): Phase 1 ships the general
+engine + Axis A lobby-save + **Swedish Old School as the only new Axis B
+preset**, with `LegacyRuleSet` fields present in the schema (so the type is
+future-proof) but never exercised by anything Phase 1 actually ships. Phase 2
+is the four EC formats (which genuinely need mana burn, and for Middle
+School/Classic Magic, damage-on-the-stack) plus the `LegacyRuleSet` engine
+wiring those require. This is a re-sequencing, not a scope cut — all four EC
+formats and the full legacy-rules axis remain the target; they simply move to
+a phase 2 that ships once the schema and Axis A/Axis B mechanics are already
+proven end-to-end by something smaller and testable.
+
 ## Confirmed (verified against source this session)
 
 - **`GameFormat` is a closed `Copy` enum** with ~23 variants, threaded through
@@ -232,6 +298,21 @@ and §7 for the schema and sequencing changes this implies.
    the custom-format engine itself** and, if ever pursued, belongs to a
    separate, later "tournament/match structure" design, not bundled into
    `CustomFormatDef`/`LegacyRuleSet` here.
+5. **Ante-card handling (new, from the Swedish Old School preset).** "Must be
+   removed before play unless the tournament is specifically played for ante"
+   is a *third* list-shaped rule, distinct from banned (illegal outright) and
+   restricted (legal, max 1) — the schema has no slot for it today. Needs a
+   decision: a third named list on `LegalityRules`, or folding it into
+   `banned` gated by a new `ante_enabled: bool`/toggle. Low urgency (only 7
+   cards; ante itself has no in-engine support and none is proposed here), but
+   should not be silently dropped when the preset ships.
+6. **Swedish Old School's reprint policy is unconfirmed.** Only "English
+   versions are allowed" is stated by the primary source
+   (`oldschool-mtg.blogspot.com/p/banrestriction.html`); a secondary source's
+   "no Revised-or-later reprints" claim was not independently verified this
+   session. Do not encode `ReprintPolicy::OriginalPrintingsOnly` for this
+   preset without re-confirming against the primary source or the community
+   directly.
 
 ## Source data
 
@@ -241,6 +322,10 @@ and §7 for the schema and sequencing changes this implies.
 - **Prior art**: `GameFormat::Limited` planning cycle, phase 53. Retrieved via
   `git show 80404a98b:.planning/phases/53-limited-draft-core/53-01-SUMMARY.md`.
   Summarized in RESEARCH.md §7 (Analogous Trace).
+- **Swedish Old School 93/94 ruleset**, fetched this session (2026-07-15) from
+  `http://oldschool-mtg.blogspot.com/p/banrestriction.html` — the primary
+  source for legal sets, the empty banned list, the 23-card restricted list,
+  the ante-card carve-out, and the (absent) legacy-rules mentions used above.
 
 ## Relationship to adjacent work — scope boundaries (do NOT accommodate here)
 

--- a/docs/proposals/custom-format-engine/CONTEXT.md
+++ b/docs/proposals/custom-format-engine/CONTEXT.md
@@ -514,6 +514,73 @@ additional real gap (`deck_validation.rs`'s `DeckCompatibilityRequest
      throughout — a pure terminology-reconciliation miss, now consistent
      everywhere.
 
+## Automated review pass (CodeRabbit) on the round-4 commit, addressed
+
+Between round 4 and round 5, CodeRabbit (automated, not matthewevans) found
+5 things on the round-4 commit, at least 3 real: (1) round 4's own rename to
+`wish_scope: WishOutsideGameScope` didn't propagate to the
+`search_outside_game` pseudocode, which still read the round-1
+`pre_m10_wish_reaches_exile` bool name — a mistake introduced in the very
+same round-4 commit that fixed the OTHER stale reference; (2)
+`sideboard_policy`/`uses_commander` are plain serialized `FormatConfig`
+fields that could diverge from `custom_rules` on a malformed payload — real
+for built-in formats today too, not just Custom, so the fallible-validation
+check was widened to cover both; (3) `DeckCompatibilityRequest` needs the
+FULL `CustomFormatRules` at its Custom-dispatch call site, not the lighter
+facts-only struct sufficient for `companion.rs`; (4) only `PROTOCOL_VERSION`
+was bumped, not the separate `LOBBY_PROTOCOL_VERSION` that actually gates
+the lobby handshake where format selection happens; (5)
+`CombatDamageTiming::OnStack`'s doc comment mischaracterized historical
+combat damage as a triggered ability rather than damage-as-a-stack-object
+(RESEARCH.md §6 already had this right). Also strengthened the
+preset-readiness gate from a documented convention into an actual
+`custom_format_registry()`-level technical check, addressing a stricter
+CodeRabbit reading without fully adopting its more extreme "remove
+`ReprintPolicy`" suggestion, which went beyond what matthewevans himself had
+asked for. See PLAN.md for the actual fixes.
+
+## Maintainer review round 5 — CHANGES_REQUESTED, addressed
+
+matthewevans re-reviewed the commit that included both round-4's fixes and
+the CodeRabbit-finding fixes above (head `4ce7df01e`) and opened with: "The
+proposal now resolves the previously-requested custom-context, typed-policy,
+compatibility, and no-caveated-preset concerns" — confirming round 4 in full.
+Two new, narrower points remained:
+
+1. **`StructuralRules.singleton` was declared but never enforced (real,
+   confirmed).** The field existed since round 2's full-fidelity fix, but
+   §3's deck-legality algorithm always called `copy_limit_violations(db,
+   &counts, 4)` — never reading `singleton` at all — and there was no test
+   for it. Fixed: `copy_limit_violations(db, &counts, if
+   rules.structural.singleton { 1 } else { 4 })`. This is parameterizing an
+   EXISTING call, not new logic — confirmed this round that every built-in
+   singleton format already calls this same helper with `1`
+   (`deck_validation.rs:929,1096,1335,1668,2215`) and the helper's own
+   existing tests already prove card-intrinsic overrides (Relentless
+   Rats/Nazgûl-shaped "any number" cards) compose correctly under a `1`
+   limit — no new override-preservation logic needed, just reading the
+   field. See PLAN.md §3 and §6.
+2. **The registry gate covered only `LegacyRuleSet`'s four axes, not
+   `ReprintPolicy` (real, confirmed — but the fix is a reframing, not a
+   broadening).** Round 4's `IMPLEMENTED_LEGACY_AXES` mechanism was scoped
+   to `LegacyRuleSet` only, so a preset could still register while declaring
+   an unenforced `ReprintPolicy`. Rather than extending the gate to a field
+   never designed to be independently enforceable, re-read this document's
+   own original research (RESEARCH.md §3, written before any review round):
+   it already concluded `ReprintPolicy`'s actual behavior is fully absorbed
+   into `legal_sets` curation (a reprint in a non-legal set is already
+   excluded by plain set-membership) and flagged only the finer frame/art
+   distinction as a real, separate gap — which Open item 2 already tracks.
+   Resolution: `reprint_policy` is documentation metadata, deliberately not
+   consumed by the evaluator and deliberately NOT part of the
+   registration-gate's enforcement surface, which only needs to cover
+   fields that are actually behavior-bearing. `swedish_old_school()` is
+   still gated on Open item 6 (getting the metadata value right so it
+   doesn't mislead a future maintainer), but that's a documentation-accuracy
+   blocker now, not a missing-enforcement one. This satisfies the "or
+   keep/reduce `ReprintPolicy` to non-selectable/deferred metadata" branch
+   review round 5 explicitly offered as acceptable. See PLAN.md §3 and §7.
+
 ## Open (needs a human decision — do NOT resolve unilaterally)
 
 1. ~~**Delivery surface**~~ — **RESOLVED**, see "Maintainer input" section

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -271,7 +271,23 @@ See §7 for where each one is surfaced to a player.
 (`CustomFormatDef` = display metadata + `CustomFormatRules`; the registry hands
 the frontend labels/short-labels/descriptions just like `FormatMetadata`.)
 
-## 2. Parameterizing the four EC formats as data (not four blocks)
+## 2. Parameterizing the formats as data (not N blocks)
+
+**Phase 1 preset — `swedish_old_school()` (see CONTEXT.md's "Further narrowing
+Axis B's MVP").** This is the first Axis B preset to actually ship, chosen
+because it needs zero `LegacyRuleSet` engine wiring:
+
+- `swedish_old_school()` — sets = [LEA, LEB, 2ED, ARN, ATQ, LEG, DRK] (verify
+  MTGJSON codes at implementation time, same caveat as below); banned = [] (a
+  genuinely empty list — the schema must support this, not assume non-empty);
+  restricted = [23 names, verbatim in CONTEXT.md]; legacy = default (all
+  `false`/`Modern` — no mana burn, no damage-on-stack, no Wish/legend-rule
+  reversion). Ante-card handling and reprint policy are open per CONTEXT.md
+  items 5–6; do not encode either without resolving those first.
+
+**Phase 2 presets — the four EC formats**, unchanged from the original design,
+now explicitly sequenced after phase 1 (§8) since they need the
+`LegacyRuleSet` wiring in §4:
 
 The four formats form an incremental chain. Express it with builder-style reuse,
 mirroring how `FormatConfig::pioneer()` spreads `..Self::standard()`:
@@ -316,7 +332,13 @@ name-set sourcing. `GameFormat::Custom` gets one arm in
 custom formats don't use the external legality table). `sideboard_policy`,
 `label`, `for_format`, etc. each get a `Custom` arm reading the resolved def.
 
-## 4. Legacy rules wiring
+## 4. Legacy rules wiring — Phase 2 (not needed for the Swedish Old School preset)
+
+Everything in this section is deferred to phase 2 (§8) — the phase-1 preset
+(`swedish_old_school()`, §2) exercises none of it, by design, since the
+Swedish ruleset makes no mention of any of these rules and uses fully modern
+defaults. This section is unchanged from the original design and remains the
+correct plan for phase 2's four EC-format presets.
 
 - **Mana burn** (`LegacyRuleSet.mana_burn`): at the step-end drop site
   (`types/mana.rs:1707`), tally dropped units per player; after the drain, if
@@ -430,30 +452,44 @@ correct.
 
 ## 8. Sequencing
 
+**Phase 1 — general engine + the smallest end-to-end slice.** Deliberately
+excludes all `LegacyRuleSet` engine wiring; ships something real and testable
+first.
+
 1. **General engine** — `CustomFormatId`, `CustomFormatRules` (with
    `StructuralRules` + `LegalityRules` sub-structs, §1), `ReprintPolicy`,
-   `LegacyRuleSet`, `GameFormat::Custom` variant + all match arms,
-   `FormatConfig.custom_rules`, `evaluate_custom_format` reusing existing
-   enforcers, registry export. (Compiler-guided, mirrors phase 53.)
+   `LegacyRuleSet` (present in the schema, unused by anything phase 1 ships),
+   `GameFormat::Custom` variant + all match arms, `FormatConfig.custom_rules`,
+   `evaluate_custom_format` reusing existing enforcers, registry export.
+   (Compiler-guided, mirrors phase 53.)
 2. **Axis A lobby save** — `CustomFormatDef::from_lobby_config`, a "save as
    custom format" action on `HostSetup.tsx`, and a load path so a saved
    `CustomFormatDef` appears as a selectable format on return visits. Small
-   frontend-plus-plumbing slice; ships before the EC formats and is useful on
-   its own to any casual table. Validates the schema's Axis A end from a real
-   UI, ahead of Axis B.
-3. **Four EC formats as data (Axis B)** — the four `CustomFormatDef`
-   constructors + registry entries + preset-integrity tests. Validates the
-   engine's Axis B from step 1; can proceed in parallel with step 2 since they
-   touch disjoint fields of the same schema.
-4. **Mana burn** — `LegacyRuleSet.mana_burn` at the drop-site hook. Small.
+   frontend-plus-plumbing slice; useful on its own to any casual table.
+   Validates the schema's Axis A end from a real UI.
+3. **`swedish_old_school()` preset (Axis B, phase 1)** — the one Axis B
+   preset that needs zero legacy-rules wiring (§2). Validates the engine's
+   Axis B end (legal-set membership, empty banned list, the 23-name
+   restricted list) without touching §4 at all. Resolve CONTEXT.md items 5–6
+   (ante-card handling, reprint policy) before finalizing this preset's
+   constructor. Can proceed in parallel with step 2 — disjoint fields of the
+   same schema.
+
+**Phase 2 — the four EC formats + the legacy-rules engine work they need.**
+Ships once phase 1 has proven the schema and both axes end-to-end.
+
+4. **Four EC formats as data (Axis B)** — the four `CustomFormatDef`
+   constructors + registry entries + preset-integrity tests (§2).
+5. **Mana burn** — `LegacyRuleSet.mana_burn` at the drop-site hook. Small.
    Enables full fidelity for 93-94 / 95 and partial for Middle School / Classic.
-5. **Pre-M10 Wish exile access** (`pre_m10_wish_reaches_exile`) — SMALL
+6. **Pre-M10 Wish exile access** (`pre_m10_wish_reaches_exile`) — SMALL
    (RESEARCH §9); one-line pool-widening at `search_outside_game.rs:72`, gated by
    the flag, reusing the existing tested face-up-exile collector/mover. Can land
-   with or just after mana burn (step 4).
-6. **Damage uses the stack** — LARGE; its own sub-project; likely post-MVP.
-   Middle School / Classic are playable-with-caveat until it lands.
-7. **Eternal Chaos (stretch)** — depends on 93-94 existing (step 3) **plus** a
+   with or just after mana burn (step 5).
+7. **Damage uses the stack** — LARGE; its own sub-project; likely post-MVP
+   even within phase 2. Middle School / Classic are playable-with-caveat
+   until it lands.
+8. **Eternal Chaos (stretch)** — depends on 93-94 existing (step 4) **plus** a
    genuinely new in-match pack-opening mechanic (Booster Tutor / Opening
    Ceremony / Summon the Pack + tutor-from-opened-packs errata + pack-based
    sideboard). Not designed here; flagged as a follow-on that is mostly a new

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -574,7 +574,10 @@ custom_format_registry() -> Vec<CustomFormatDef>   // parallel to GameFormat::re
 **Lobby saves (Axis A)** produce the identical `CustomFormatDef` shape from a
 different origin — a name plus the live `FormatConfig` a host just finished
 tuning, with `legality` left at defaults (`legal_sets: None`, empty
-banned/restricted, default `LegacyRuleSet`):
+banned/restricted, default `LegacyRuleSet`) and `reprint_policy: None`
+(maintainer review round 7 — a lobby save has no authored paper-format
+reprint intent to declare; see the `CustomFormatDef` struct above for the
+full reasoning):
 
 ```text
 CustomFormatDef::from_lobby_config(name: String, config: &FormatConfig) -> CustomFormatDef
@@ -617,16 +620,28 @@ CustomFormatDef {
     label: String,                      // "Swedish Old School 93/94", parallel to FormatMetadata
     short_label: String,
     description: String,
-    reprint_policy: ReprintPolicy,      // MOVED HERE per round 6 — authoring
-                                        // intent/documentation for a human,
-                                        // never read by evaluate_custom_format
-                                        // or anything else engine-side. Lives
-                                        // beside label/description because
-                                        // it belongs to the same "describes
-                                        // the preset for a reader" category
-                                        // as they do, not beside legal_sets/
-                                        // banned/restricted/legacy, which
-                                        // ARE all genuinely enforced.
+    reprint_policy: Option<ReprintPolicy>,  // REVISED per maintainer review
+                                        // round 7: MUST be Option, not a bare
+                                        // ReprintPolicy — round 6 moved the
+                                        // field but missed that an Axis-A
+                                        // lobby save has no authored paper-
+                                        // format reprint intent at all (it
+                                        // isn't modeling any published
+                                        // ruleset), so none of the three real
+                                        // variants would be honest for it.
+                                        // `None` = "no reprint intent to
+                                        // declare" (every Axis A lobby save);
+                                        // `Some(policy)` = a real, sourced
+                                        // paper-format intent (every Axis B
+                                        // preset — old_school_93_94(),
+                                        // old_school_95(), middle_school(),
+                                        // classic_magic(), swedish_old_school()
+                                        // all set this explicitly; see §2).
+                                        // Same `Option<T>`-over-forcing-a-value
+                                        // pattern this proposal already uses
+                                        // for `legal_sets` (§1) and
+                                        // `range_of_influence` — not a new
+                                        // convention.
 }
 ```
 
@@ -666,8 +681,13 @@ not appear as a selectable format until that item resolves:
   restrict the pool); restricted = [**25** names, verbatim in CONTEXT.md —
   corrected this round from a "23" miscount]; legacy = default (all
   `false`/`Modern` — no mana burn, no damage-on-stack, no Wish/legend-rule
-  reversion). Ante-card handling and reprint policy are open per CONTEXT.md
-  items 5–6; do not encode either without resolving those first.
+  reversion). `reprint_policy` (on `CustomFormatDef`): `None` for now — NOT
+  a value pending confirmation, but the genuinely correct value until
+  CONTEXT.md Open item 6 resolves (there is no confirmed authored intent to
+  declare yet; `None` says exactly that, distinctly from a lobby save's
+  permanent `None`, which has no intent to declare, period). Ante-card
+  handling remains open per Open item 5 separately; do not encode either
+  without resolving its own item first.
 
 **Phase 2 presets — the four EC formats**, unchanged from the original design,
 now explicitly sequenced after phase 1 (§8) since they need the
@@ -681,8 +701,9 @@ mirroring how `FormatConfig::pioneer()` spreads `..Self::standard()`:
   `{ mana_burn: ManaBurnPolicy::Obsolete, ..default }` (damage timing and
   Wish scope stay `Modern`/`PostM10SideboardOnly` — EC's 93-94 lists mana
   burn as its only legacy exception). `reprint_policy` (on `CustomFormatDef`):
-  `AllowSpecialReprintSets` — RESEARCH.md's §1 subsection for this format
-  explicitly includes CE/ICE as legal reprint sources within `legal_sets`.
+  `Some(AllowSpecialReprintSets)` — RESEARCH.md's §1 subsection for this
+  format explicitly includes CE/ICE as legal reprint sources within
+  `legal_sets`.
 - `old_school_95()` — `let mut d = old_school_93_94(); d.legal_sets.extend([4ED,
   ICE, CHR, REN, HML]); d.restricted.extend([Demonic Consultation, Mana Crypt]);
   d.banned.extend([Amulet of Quoz, Timmerian Fiends]; legacy unchanged`.
@@ -690,7 +711,7 @@ mirroring how `FormatConfig::pioneer()` spreads `..Self::standard()`:
   []; banned = [25 names]; legacy = `{ mana_burn: ManaBurnPolicy::Obsolete,
   damage_timing: CombatDamageTiming::OnStack, wish_scope:
   WishOutsideGameScope::PreM10ReachesExile }`. `reprint_policy` (on the
-  `CustomFormatDef`, not `rules` — round 6): `AllowAnyPrinting`. **Per the
+  `CustomFormatDef`, not `rules` — round 6): `Some(AllowAnyPrinting)`. **Per the
   preset-readiness gate (§7, tightened this round): this preset may not be
   registered until `CombatDamageTiming::OnStack` (§4/§6, LARGE) is fully
   implemented — no partial/caveated exposure.**
@@ -700,8 +721,8 @@ mirroring how `FormatConfig::pioneer()` spreads `..Self::standard()`:
   `{ mana_burn: ManaBurnPolicy::Obsolete, damage_timing:
   CombatDamageTiming::OnStack, wish_scope:
   WishOutsideGameScope::PreM10ReachesExile }`. `reprint_policy` (on the
-  `CustomFormatDef`): `OriginalPrintingsOnly`. **Same registration block as
-  Middle School** — not selectable until `CombatDamageTiming::OnStack` lands.
+  `CustomFormatDef`): `Some(OriginalPrintingsOnly)`. **Same registration block
+  as Middle School** — not selectable until `CombatDamageTiming::OnStack` lands.
 
 Set codes must be verified against the engine's `set_catalog` (MTGJSON codes)
 during implementation — the codes above are the expected MTGJSON codes but
@@ -956,6 +977,16 @@ legality logic on the client.
   guarantee (`evaluate_custom_format` takes `&CustomFormatRules`, which has
   no such field to accidentally read) — the runtime test exists to catch a
   future regression that reintroduces the field in the wrong place.
+- **`reprint_policy` is `Option`, and every constructor sets the correct arm**
+  (new — maintainer review round 7): `CustomFormatDef::from_lobby_config`
+  always produces `reprint_policy: None` — assert this directly, not just
+  that construction succeeds, so a future edit can't silently start
+  fabricating a value for an Axis A save. Each of the five Axis B
+  constructors (`old_school_93_94`, `old_school_95`, `middle_school`,
+  `classic_magic`, and `swedish_old_school` once Open item 6 resolves)
+  produces `Some(_)` with its own specific documented variant — five
+  separate assertions, not one shared "is `Some`" check, so a copy-paste
+  preset that forgets to set its own value is caught.
 - Set-membership legality: assert cards from in-pool and out-of-pool sets pass /
   fail — for arbitrary set lists, not just the four presets.
 - **`legal_sets: None` accepts every card** (new — maintainer review round 2,

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -546,6 +546,13 @@ the frontend labels/short-labels/descriptions just like `FormatMetadata`.)
 
 ## 2. Parameterizing the formats as data (not N blocks)
 
+**Every card list, count, and rule below is sourced, not invented — see
+RESEARCH.md §1 for the full per-format citation, repeated here inline so this
+section stands on its own for anyone auditing the actual preset data without
+cross-referencing another file:**
+- Swedish Old School: `http://oldschool-mtg.blogspot.com/p/banrestriction.html` (RESEARCH.md §1, "Swedish Old School 93/94" subsection).
+- The four EC formats: `raw.githubusercontent.com/northern-information/lordsofthepit.com/main/src/pages/formats.md` (RESEARCH.md §1, EC ruleset header).
+
 **Phase 1 preset — `swedish_old_school()` (see CONTEXT.md's "Further narrowing
 Axis B's MVP").** This is the first Axis B preset targeted, chosen because it
 needs zero `LegacyRuleSet` engine wiring. **Registration is currently blocked

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -592,6 +592,56 @@ independently-meaningful `FormatConfig` field), it must reject explicitly
 rather than silently drop data. The `CustomFormatId` this constructor
 allocates is the ad-hoc sentinel described above, not a registry-stable ID.
 
+**`label`/`short_label`/`description` construction rule (maintainer review
+round 8) — the one gap this constructor still had.** Round 6 gave
+`CustomFormatDef` a real struct sketch requiring these three fields (see
+above); this constructor's signature (`name` + `&FormatConfig`) never
+specified how a lobby save produces `short_label` or `description`, and
+those two aren't optional — the registry hands them to the frontend exactly
+like `FormatMetadata` already does for built-in formats
+(`crates/engine/src/types/format.rs:24-34`), so an unspecified derivation
+means the Axis-A factory has no defined complete output. Fixed by deriving
+both from `name`/`config` alone — never inventing user-facing rules
+metadata a lobby host didn't provide:
+- `label: name` directly — unchanged from what was already implied.
+- `short_label`: the first 3 alphanumeric characters of `name.trim()`,
+  uppercased. This is not a new UI convention — it's the existing
+  `FormatMetadata.short_label` contract (a fixed 3-character code,
+  load-bearing for the badge width in `GameListItem.tsx`) applied via the
+  *same* derivation the frontend already falls back to today for any
+  format it doesn't recognize (`format.slice(0, 3).toUpperCase()`, present
+  independently in `GameListItem.tsx`, `StatsPanel.tsx`, and
+  `CardCoverageDashboard.tsx`). Moving that derivation into
+  `from_lobby_config` means the engine now supplies a real value for every
+  Axis-A format instead of the frontend silently computing one — per
+  CLAUDE.md's "the engine owns all logic," this was arguably a latent
+  frontend-computes-derived-data gap even before Axis A existed, now closed
+  as a side effect of fixing this finding. Edge case, explicitly allowed:
+  a name with fewer than 3 alphanumeric characters yields a shorter code
+  (there is no meaningful 3-character abbreviation to invent for e.g. a
+  2-character name) — this is a deliberate, documented deviation from the
+  "always exactly 3" convention every hand-curated built-in entry happens
+  to satisfy, not a silent violation of it. `from_lobby_config` rejects an
+  empty `name.trim()` outright (no format to label at all), consistent with
+  the existing "reject explicitly rather than silently drop data" posture
+  from round 2 above.
+- `description`: generated from `StructuralRules` alone via a new
+  `derive_structural_description(&StructuralRules) -> String` helper —
+  Matt's suggested "engine-provided structural description" option. Mirrors
+  the existing built-in phrasing style (`"100-card singleton, 2–4 players"`
+  for Commander, `"Tournament 1v1 Commander, 30 life"` for DuelCommander —
+  both short comma-joined structural fragments, no terminal punctuation)
+  by composing from the same fields those hand-authored strings already
+  describe: deck size + singleton, player count/range, starting life, and
+  `command_zone`/`team_based` when set. E.g. `deck_size: 60, singleton:
+  false, min_players: max_players: 2, starting_life: 20` → `"60-card,
+  2-player, 20 life"`. This is Axis A only — Axis B presets keep their
+  existing hand-authored descriptions unchanged; `derive_structural_description`
+  exists because Axis A has no human curator to write one. Exact wording
+  is an implementation-time polish detail (the shape — which fields
+  contribute and in what order — is the part this design commits to), not
+  an architectural question this proposal needs to settle further.
+
 **`sideboard_policy`'s specific source, made explicit (maintainer review
 round 4, point 2 — round 3 added the field but never stated this)**:
 `structural.sideboard_policy: config.format.sideboard_policy()`. This is a
@@ -1088,6 +1138,15 @@ legality logic on the client.
   mechanism, not a specific saved format's values. Does NOT include
   `archenemy_player` (removed per round 3, CONTEXT.md point 3 — not part of
   `StructuralRules` at all).
+- **NEW — maintainer review round 8**: the same round-trip test also
+  asserts `label == name` verbatim, `short_label` is `name`'s first 3
+  alphanumeric characters uppercased (plus a dedicated case for a
+  fewer-than-3-alphanumeric-character name, asserting the shorter code
+  rather than a panic or silent padding), an empty/whitespace-only `name`
+  is rejected rather than producing an empty `label`, and
+  `derive_structural_description` produces a non-empty, config-derived
+  string for at least two distinct `StructuralRules` values (proving it
+  actually reads the config rather than returning a constant).
 
 ## 7. Delivery surface — RESOLVED via maintainer input, see CONTEXT.md "Maintainer input"
 

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -319,9 +319,19 @@ StructuralRules {
 // `None` = unrestricted (every card passes the pool check), `Some(list)` =
 // restricted to `list`. This is the same `Option<T>`-over-ambiguous-sentinel
 // pattern CLAUDE.md already prescribes elsewhere in this codebase.
+// REVISED per maintainer review round 6: `reprint_policy` is REMOVED from
+// this struct entirely (not just documented-as-inert-in-place, which round
+// 5 tried and round 6 correctly rejected as an unresolved contradiction —
+// a field can't sit inside `CustomRules`/`LegalityRules`, structurally
+// implying it's part of the resolved, engine-consumed ruleset, while a
+// comment beside it insists it's inert metadata nobody reads. Those are
+// incompatible claims about the same field's contract, not a documented
+// nuance). It moves to `CustomFormatDef`'s metadata side, below — the
+// resolved `CustomFormatRules` payload (this struct, embedded in
+// `FormatConfig.custom_rules`, is what actually travels over the wire and
+// gets enforced) now contains ONLY genuinely behavior-bearing fields.
 LegalityRules {
     legal_sets: Option<Vec<SetCode>>,   // None = unrestricted; Some(list) = pool membership
-    reprint_policy: ReprintPolicy,
     banned: Vec<CardName>,              // fully illegal
     restricted: Vec<CardName>,          // legal, max 1 (CR 100.2b path)
     legacy: LegacyRuleSet,
@@ -405,24 +415,29 @@ LegalityRules {
 // every other breaking wire change — not a new, custom-format-specific
 // negotiation layer.
 
-// REVISED per maintainer review round 5 (§3/§7 have the full reasoning):
-// this enum is documentation metadata, NOT consumed by `evaluate_custom_format`
-// at all. Its intended behavior is already fully absorbed by `legal_sets`
-// curation (a reprint outside `legal_sets` is already excluded by plain
-// set-membership); the one thing it can't capture — frame/art-level
-// fidelity — is Open item 2's gap, not this enum's job to close. Kept as a
-// typed enum (not deleted) purely so a preset's authored intent is
-// machine-readable for whoever eventually builds Open item 2, not because
-// anything reads it today.
-ReprintPolicy {
-    OriginalPrintingsOnly,              // 93-94 / Classic intent (see limitation)
-    AllowSpecialReprintSets,            // CE/ICE/world-champ/proof set codes included in legal_sets
-    AllowAnyPrinting,                   // Middle School "begrudgingly"
-}
+// `ReprintPolicy` — round 5 resolved this to "documentation metadata, not
+// consumed by the evaluator" but round 6 correctly caught that leaving the
+// FIELD inside `LegalityRules` while saying so in a comment is an
+// unresolved contradiction: the struct's own shape says "this is part of
+// the resolved, engine-consumed ruleset," and the prose says the opposite.
+// Round 6 picks the first of matthewevans's two offered resolutions
+// (rather than the alternative — building real engine-owned printing
+// enforcement and gating registration on it): the field MOVES to
+// `CustomFormatDef` (display/authoring metadata), fully OUT of
+// `CustomFormatRules`/`LegalityRules` (the resolved, wire-traveling,
+// engine-consumed payload). See the `CustomFormatDef` struct later in this
+// section for where it lives now. Its behavior is still fully absorbed by
+// `legal_sets` curation (a reprint outside `legal_sets` is already excluded
+// by plain set-membership) — the one thing it can't capture, frame/art-level
+// fidelity, is Open item 2's gap, not this enum's job to close. Kept as a
+// typed enum (not deleted, not a bool) purely so a preset's authored intent
+// stays machine-readable for whoever eventually builds Open item 2.
 
 // NOT YET DESIGNED — flagged, not resolved, per CONTEXT.md open item #2.
-// `ReprintPolicy` above gates LEGALITY (which printings are legal to play).
-// A user follow-up asks for a sibling, independent axis: DISPLAY DEFAULT
+// `ReprintPolicy` (now on `CustomFormatDef`, not `LegalityRules`) documents
+// a preset's REPRINT INTENT for a human reading it; it does not gate
+// legality — legal-set membership alone does that (§3). A user follow-up
+// asks for a sibling, independent axis: DISPLAY DEFAULT
 // (which specific legal printing's frame/art renders by default when a card
 // is added to a deck under this format) — e.g. an old-rules format should
 // default old-frame Alpha/Beta art over a modern reprint's, without forcing
@@ -590,8 +605,38 @@ and the same `GameFormat::Custom(CustomFormatId)` variant — there is exactly
 one runtime representation of "a custom format," authored two different ways.
 See §7 for where each one is surfaced to a player.
 
-(`CustomFormatDef` = display metadata + `CustomFormatRules`; the registry hands
-the frontend labels/short-labels/descriptions just like `FormatMetadata`.)
+**`CustomFormatDef` — given an actual struct sketch this round (round 6);
+previously only described in prose as "display metadata + CustomFormatRules,"
+which is exactly the ambiguity that let `reprint_policy` end up in the wrong
+place):**
+
+```text
+CustomFormatDef {
+    rules: CustomFormatRules,           // the resolved, engine-consumed, wire-traveling payload
+                                        // (§1 above) — genuinely behavior-bearing fields ONLY
+    label: String,                      // "Swedish Old School 93/94", parallel to FormatMetadata
+    short_label: String,
+    description: String,
+    reprint_policy: ReprintPolicy,      // MOVED HERE per round 6 — authoring
+                                        // intent/documentation for a human,
+                                        // never read by evaluate_custom_format
+                                        // or anything else engine-side. Lives
+                                        // beside label/description because
+                                        // it belongs to the same "describes
+                                        // the preset for a reader" category
+                                        // as they do, not beside legal_sets/
+                                        // banned/restricted/legacy, which
+                                        // ARE all genuinely enforced.
+}
+```
+
+The registry (`custom_format_registry() -> Vec<CustomFormatDef>`) hands the
+frontend labels/short-labels/descriptions just like `FormatMetadata` already
+does for built-in formats — unchanged from the original design. What changed
+is only where `reprint_policy` sits: previously a field on `LegalityRules`
+(implying it travels with and is enforced by the resolved ruleset); now a
+field on `CustomFormatDef` alongside the other purely-descriptive fields,
+never serialized into `FormatConfig.custom_rules` at all.
 
 ## 2. Parameterizing the formats as data (not N blocks)
 
@@ -631,27 +676,31 @@ now explicitly sequenced after phase 1 (§8) since they need the
 The four formats form an incremental chain. Express it with builder-style reuse,
 mirroring how `FormatConfig::pioneer()` spreads `..Self::standard()`:
 
-- `old_school_93_94()` — base: sets = [LEA, LEB, 2ED, CED, CEI, ARN, ATQ, 3ED,
-  LEG, DRK, FEM]; restricted = [22 names]; banned = [7 names]; legacy =
+- `old_school_93_94()` — `rules`: sets = [LEA, LEB, 2ED, CED, CEI, ARN, ATQ,
+  3ED, LEG, DRK, FEM]; restricted = [22 names]; banned = [7 names]; legacy =
   `{ mana_burn: ManaBurnPolicy::Obsolete, ..default }` (damage timing and
   Wish scope stay `Modern`/`PostM10SideboardOnly` — EC's 93-94 lists mana
-  burn as its only legacy exception).
+  burn as its only legacy exception). `reprint_policy` (on `CustomFormatDef`):
+  `AllowSpecialReprintSets` — RESEARCH.md's §1 subsection for this format
+  explicitly includes CE/ICE as legal reprint sources within `legal_sets`.
 - `old_school_95()` — `let mut d = old_school_93_94(); d.legal_sets.extend([4ED,
   ICE, CHR, REN, HML]); d.restricted.extend([Demonic Consultation, Mana Crypt]);
   d.banned.extend([Amulet of Quoz, Timmerian Fiends]; legacy unchanged`.
-- `middle_school()` — sets = Fourth Edition..Scourge; restricted = []; banned =
-  [25 names]; reprint = AllowAnyPrinting; legacy = `{ mana_burn:
-  ManaBurnPolicy::Obsolete, damage_timing: CombatDamageTiming::OnStack,
-  wish_scope: WishOutsideGameScope::PreM10ReachesExile }`. **Per the
+- `middle_school()` — `rules`: sets = Fourth Edition..Scourge; restricted =
+  []; banned = [25 names]; legacy = `{ mana_burn: ManaBurnPolicy::Obsolete,
+  damage_timing: CombatDamageTiming::OnStack, wish_scope:
+  WishOutsideGameScope::PreM10ReachesExile }`. `reprint_policy` (on the
+  `CustomFormatDef`, not `rules` — round 6): `AllowAnyPrinting`. **Per the
   preset-readiness gate (§7, tightened this round): this preset may not be
   registered until `CombatDamageTiming::OnStack` (§4/§6, LARGE) is fully
   implemented — no partial/caveated exposure.**
-- `classic_magic()` — sets = Alpha..Scourge; restricted = [**44** names —
-  corrected this round from a "37" mislabel; recounted directly against
-  RESEARCH.md's verbatim list]; banned = [11 names]; reprint =
-  OriginalPrintingsOnly; legacy = `{ mana_burn: ManaBurnPolicy::Obsolete,
-  damage_timing: CombatDamageTiming::OnStack, wish_scope:
-  WishOutsideGameScope::PreM10ReachesExile }`. **Same registration block as
+- `classic_magic()` — `rules`: sets = Alpha..Scourge; restricted = [**44**
+  names — corrected this round from a "37" mislabel; recounted directly
+  against RESEARCH.md's verbatim list]; banned = [11 names]; legacy =
+  `{ mana_burn: ManaBurnPolicy::Obsolete, damage_timing:
+  CombatDamageTiming::OnStack, wish_scope:
+  WishOutsideGameScope::PreM10ReachesExile }`. `reprint_policy` (on the
+  `CustomFormatDef`): `OriginalPrintingsOnly`. **Same registration block as
   Middle School** — not selectable until `CombatDamageTiming::OnStack` lands.
 
 Set codes must be verified against the engine's `set_catalog` (MTGJSON codes)
@@ -709,32 +758,41 @@ Option<GameFormat>` (§1's audit) cannot supply `deck_size`/`singleton` any
 more than it could supply `legal_sets`/`banned`/`restricted` — the same
 signature-widening fix from §1 covers this too, not a separate mechanism.
 
-**`ReprintPolicy` is deliberately NON-behavior-bearing metadata, not a
-registration-blocking gap (RESOLVED — maintainer review round 5; supersedes
-rounds 3/4's framing of this as an unenforced gate).** Round 5 correctly
-caught that the round-4 registry gate (`IMPLEMENTED_LEGACY_AXES`, §7) covers
-only `LegacyRuleSet`'s four axes and was never extended to `ReprintPolicy` —
-a preset could still register while declaring a policy this algorithm
-doesn't enforce. Rather than broadening the gate to a field that was never
-designed to be independently enforceable, this document's OWN original
-research already answered this (RESEARCH.md §3, written before any of the
-four review rounds): "model reprint policy as *which set codes are in the
-legal list*, and flag frame/art-level fidelity as a known limitation."
-That is: `ReprintPolicy`'s actual behavior is already fully absorbed into
-`legal_sets` curation (a modern reprint of an old card lives in a set code
-simply not present in `legal_sets`, so it's excluded by step 2 alone,
-requiring no separate enforcement) — the ONLY thing `ReprintPolicy` cannot
-capture is the finer frame/art-level distinction (e.g. "old-bordered
-original only" vs. "any printing from a legal set"), which is the SAME gap
-Open item 2 already tracks. Accordingly: `reprint_policy` is documentation
-metadata for a human auditing a preset's intent, deliberately not consumed
-by `evaluate_custom_format`, and NOT part of the preset-readiness gate's
-enforcement surface — the gate only needs to cover fields that are actually
-behavior-bearing, which `LegacyRuleSet`'s four axes are and
-`reprint_policy` is not. `swedish_old_school()` is still gated on CONTEXT.md
-Open item 6 (getting the metadata VALUE right, since an inaccurate label
-could mislead a future maintainer who builds real enforcement later), but
-that is a documentation-accuracy blocker, not a missing-enforcement one.
+**`ReprintPolicy` is metadata on `CustomFormatDef`, not a field on
+`CustomFormatRules`/`LegalityRules` at all (RESOLVED — maintainer review
+round 6; supersedes round 5's "leave it in place, document it as inert"
+attempt, which round 6 correctly rejected as an internal contradiction — a
+field can't structurally sit inside the resolved, engine-consumed ruleset
+while a comment insists nothing consumes it).**
+
+History: round 4's registry gate (`IMPLEMENTED_LEGACY_AXES`, §7) covered only
+`LegacyRuleSet`'s four axes and was never extended to `ReprintPolicy`; round
+5 tried to resolve this by declaring `reprint_policy` non-behavior-bearing
+via a comment while leaving the field inside `LegalityRules` — round 6
+correctly caught that this is two incompatible claims about the same field
+(its position says "resolved ruleset," its comment says "never read"). The
+actual fix is structural, not documentary: `reprint_policy` MOVED to
+`CustomFormatDef` (§1's struct sketch) — the display/authoring-metadata side
+that already exists for `label`/`short_label`/`description` — fully out of
+`CustomFormatRules`, which now contains only genuinely behavior-bearing
+fields. This is one of the two resolutions matthewevans offered (move it to
+metadata outside `CustomFormatRules`/`LegalityRules`) rather than the other
+(build real engine-owned printing enforcement and gate registration on it).
+
+This document's OWN original research already explains why the metadata-only
+answer is correct, not just convenient (RESEARCH.md §3, written before any
+review round): "model reprint policy as *which set codes are in the legal
+list*, and flag frame/art-level fidelity as a known limitation." That is:
+`ReprintPolicy`'s actual behavior is already fully absorbed into `legal_sets`
+curation (a modern reprint of an old card lives in a set code simply not
+present in `legal_sets`, so it's excluded by step 2 alone) — the ONLY thing
+it can't capture is the finer frame/art-level distinction, which is Open
+item 2's gap, not this field's job. `swedish_old_school()` is still gated on
+CONTEXT.md Open item 6 (getting the metadata VALUE right, since an
+inaccurate label could mislead a future maintainer), but that's now cleanly
+a documentation-accuracy blocker on a metadata field — not a
+missing-enforcement gap on a rules field, which is exactly the contradiction
+round 6 caught.
 
 `legality_format()` returns `None` for `Custom` (no `LegalityFormat` mapping —
 custom formats don't use the external legality table). `label`, `for_format`,
@@ -888,6 +946,16 @@ legality logic on the client.
 
 ## 6. Testing (building-block level, per CLAUDE.md)
 
+- **`reprint_policy` has no effect on evaluation** (new — maintainer review
+  round 6): two synthetic `CustomFormatDef` values with identical `rules`
+  (`CustomFormatRules`) but different `reprint_policy` metadata must produce
+  IDENTICAL `evaluate_custom_format` results — proving the field is truly
+  inert for legality purposes, not just absent from the struct by
+  convention. Since `reprint_policy` isn't a field on `CustomFormatRules` at
+  all after the round-6 move, this is also implicitly a compile-time
+  guarantee (`evaluate_custom_format` takes `&CustomFormatRules`, which has
+  no such field to accidentally read) — the runtime test exists to catch a
+  future regression that reintroduces the field in the wrong place.
 - Set-membership legality: assert cards from in-pool and out-of-pool sets pass /
   fail — for arbitrary set lists, not just the four presets.
 - **`legal_sets: None` accepts every card** (new — maintainer review round 2,
@@ -1063,19 +1131,25 @@ failure, not a silently-ignored doc-comment warning. This is the concrete
 mechanism §6's "actually enforced, not just documented" test targets.
 
 **Gate scope, precisely (maintainer review round 5 caught that this wasn't
-stated precisely enough): `IMPLEMENTED_LEGACY_AXES` covers exactly
-`LegacyRuleSet`'s four axes — `mana_burn`, `damage_timing`, `wish_scope`,
-`legend_rule_scope` — because those are the only fields on
-`CustomFormatRules` today that are BOTH independently declarable AND
-intended to be behavior-bearing.** It does NOT cover `reprint_policy` (§3
-resolves why: deliberately non-behavior-bearing metadata, not an
-unenforced axis) and there is no ante-card field to cover yet (CONTEXT.md
-Open item 5 — no schema slot exists). If a future field is ever added with
-real behavior attached (an enforced `ReprintPolicy`, an ante-list), it must
-be added to this gate in the SAME change that adds the field — the gate's
-job is to cover every behavior-bearing field that exists, and it is a
-review-time checklist item whenever `CustomFormatRules`/`LegacyRuleSet`
-gains a member, not a one-time list to write and forget.
+stated precisely enough; round 6's `reprint_policy` relocation, §1/§3, makes
+it precise by construction rather than by exemption): `IMPLEMENTED_LEGACY_AXES`
+covers exactly `LegacyRuleSet`'s four axes — `mana_burn`, `damage_timing`,
+`wish_scope`, `legend_rule_scope` — because those are now the ONLY fields on
+`CustomFormatRules` that are independently declarable AND behavior-bearing.**
+`reprint_policy` doesn't need an exemption from this gate anymore — it isn't
+on `CustomFormatRules` at all after round 6's move to `CustomFormatDef`, so
+there's nothing there for the gate to either cover or exempt. There is no
+ante-card field to cover yet either (CONTEXT.md Open item 5 — no schema slot
+exists). If a future field is ever added to `CustomFormatRules` with real
+behavior attached (an ante-list, say), it must be added to this gate in the
+SAME change — the gate's job is to cover every behavior-bearing field on the
+RESOLVED RULES struct, and it is a review-time checklist item whenever
+`CustomFormatRules`/`LegacyRuleSet` gains a member, not a one-time list to
+write and forget. A field that's purely descriptive (like `reprint_policy`
+now) belongs on `CustomFormatDef` instead, outside this gate's scope by
+construction — round 6's actual lesson: when a field doesn't cleanly belong
+in the gate's coverage, that's a signal it may be in the wrong struct, not
+just missing from the gate.
 - `swedish_old_school()` (phase 1) is BLOCKED from registration by
   CONTEXT.md Open item 6 alone — the reprint-policy metadata VALUE needs
   confirming against the primary source before shipping, so a future
@@ -1101,11 +1175,12 @@ excludes all `LegacyRuleSet` engine wiring; ships something real and testable
 first.
 
 1. **General engine** — `CustomFormatId`, `CustomFormatRules` (with
-   `StructuralRules` + `LegalityRules` sub-structs, §1), `ReprintPolicy`,
-   `LegacyRuleSet` (present in the schema, unused by anything phase 1 ships),
-   `GameFormat::Custom` variant + all match arms, `FormatConfig.custom_rules`,
-   `evaluate_custom_format` reusing existing enforcers, registry export.
-   (Compiler-guided, mirrors phase 53.)
+   `StructuralRules` + `LegalityRules` sub-structs, §1) plus `LegacyRuleSet`
+   (present in the schema, unused by anything phase 1 ships),
+   `CustomFormatDef` (with `ReprintPolicy` as its metadata field, §1 —
+   NOT part of `CustomFormatRules`), `GameFormat::Custom` variant + all
+   match arms, `FormatConfig.custom_rules`, `evaluate_custom_format` reusing
+   existing enforcers, registry export. (Compiler-guided, mirrors phase 53.)
 2. **Axis A lobby save** — `CustomFormatDef::from_lobby_config`, a "save as
    custom format" action on `HostSetup.tsx`, and a load path so a saved
    `CustomFormatDef` appears as a selectable format on return visits. Small

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -505,6 +505,20 @@ LegalityRules {
 // stays machine-readable for whoever eventually builds Open item 2.
 
 // RESOLVED — round 11, maintainer review + direct follow-up discussion.
+// **PARTIALLY SUPERSEDED — round 12 (see the `printing_fidelity` note near
+// the `CustomFormatDef` struct later in this section for the current
+// resolution).** Round 11's registration-gate conclusion below (no new
+// blocking axis, `IMPLEMENTED_LEGACY_AXES`/mana burn only) still holds — no
+// engine-owned printing predicate is being built, per the maintainer's own
+// second offered option, exercised in round 12. What's retracted is the
+// PREMISE that `legal_sets`-only enforcement is therefore not an
+// approximation of anything: the maintainer's later review of this exact
+// resolution correctly rejected that framing (an existing format with no
+// documented printing requirement, Premodern included, isn't a
+// rules-correctness argument for a new preset whose OWN source rule is
+// stricter). Read this block for its still-accurate research on what the
+// engine does and doesn't check; read round 12's note for what the
+// proposal actually resolves to disclose about that gap.
 // SUPERSEDES round 10's resolution below (retracted, not layered on top —
 // round 11's review correctly rejected it): round 10 tried to answer
 // CONTEXT.md open item #2 by pairing "legal_sets is the whole legality
@@ -805,8 +819,79 @@ CustomFormatDef {
                                         // for `legal_sets` (§1) and
                                         // `range_of_influence` — not a new
                                         // convention.
+    printing_fidelity: PrintingFidelity,    // NEW — round 12, maintainer
+                                        // review (repeated rejection of the
+                                        // round-11 "same model as Premodern"
+                                        // framing — see §1's round-12 note
+                                        // below for the full argument).
+                                        // Required on every `CustomFormatDef`,
+                                        // no default: whichever variant
+                                        // applies must be an explicit
+                                        // authoring decision, exactly like
+                                        // `reprint_policy` above.
+}
+
+enum PrintingFidelity {
+    /// This preset's `reprint_policy` is `None` — no source paper-format
+    /// reprint intent is declared (every Axis A lobby save; `swedish_old_school()`
+    /// until CONTEXT.md Open item 6 resolves its own `reprint_policy` value).
+    /// There is nothing to approximate because nothing is being claimed.
+    NotApplicable,
+    /// This preset's `reprint_policy` is `Some(_)` — a real, sourced paper-format
+    /// reprint intent IS declared, but the engine enforces it only at set-code
+    /// membership (`legal_sets`, §3) — the same granularity every format in this
+    /// engine, built-in or custom, has ever enforced (round 11's finding, still
+    /// true). It does NOT enforce printing/frame/border/foil, which some source
+    /// rulesets (Old School 93-94/95 among them, RESEARCH.md §1) state as a real
+    /// requirement. `description` MUST disclose this in player-facing text (§6's
+    /// preset-integrity test enforces the pairing, not just the field's presence).
+    SetCodeApproximation,
 }
 ```
+
+**Why this field exists — round 12, maintainer review (supersedes round 11's
+framing below, which is kept for its still-accurate research, not as the
+resolution):** round 11 argued that `legal_sets` membership isn't an
+approximation of Old School 93-94/95's legality at all, because no format in
+this engine — Premodern included — has ever enforced more than set-code
+membership. The maintainer's review of that exact resolution correctly
+rejected it on a second look: **an existing format with no documented
+printing-level requirement is not a rules-correctness argument for a NEW
+preset whose OWN documented source rule is stricter.** `Premodern` never
+claimed frame/art fidelity in the first place, so it enforcing only set codes
+is not an approximation of anything — nothing is missing relative to its own
+source. Old School 93-94/95's own cited source (RESEARCH.md §1) explicitly
+requires non-foil reprints with original frame and art; `legal_sets`
+membership genuinely falls short of that specific, stated requirement, and
+round 11's "no format does more" observation, while accurate, doesn't change
+what this format's own source rule says.
+
+**The product decision (round 12, maintainer's second offered option, taken
+deliberately over the first):** do not build engine-owned printing/frame
+enforcement — CONTEXT.md's Open item 2 survey already scoped that as a real,
+separate, moderate-lift feature (the engine and frontend printing systems are
+disconnected today; wiring them is a genuine, general, future project, not
+specific to Old School). Instead, accept the set-code-only approximation
+explicitly, and require every preset that makes it to disclose it in its own
+player-facing `description` rather than only in a developer-facing doc
+comment. The reasoning this proposal rests that acceptance on, distinct from
+round 11's now-superseded analogy: **in a digital-only client, a printing's
+frame, border, and foil status have no gameplay consequence at all** — a
+card with identical Oracle text is identical for every rules purpose the
+engine cares about, regardless of which physical printing it "represents."
+The frame/art requirement exists in the paper community's own ruleset for a
+reason that has no digital equivalent — provenance and anti-counterfeiting
+at a physical table — not because the alternate-frame printing plays
+differently. Declining to model a purely cosmetic, paper-specific concern is
+a legitimate product scope decision; silently presenting the approximation
+as full fidelity is not, which is why `printing_fidelity` and its
+disclosure requirement exist as a typed, tested construction-time
+requirement rather than a comment. This directly satisfies the maintainer's
+second offered resolution ("explicitly scope the presets as an oracle-card/
+set-code approximation") without the first (build the predicate) — the
+`PrintingFidelity::SetCodeApproximation` label on every affected preset IS
+that explicit scoping, made structural rather than a documented convention
+this proposal's own §7 principle would otherwise reject.
 
 The registry (`custom_format_registry() -> Vec<CustomFormatDef>`) hands the
 frontend labels/short-labels/descriptions just like `FormatMetadata` already
@@ -814,7 +899,11 @@ does for built-in formats — unchanged from the original design. What changed
 is only where `reprint_policy` sits: previously a field on `LegalityRules`
 (implying it travels with and is enforced by the resolved ruleset); now a
 field on `CustomFormatDef` alongside the other purely-descriptive fields,
-never serialized into `FormatConfig.custom_rules` at all.
+never serialized into `FormatConfig.custom_rules` at all. `printing_fidelity`
+sits beside it for the same reason (§1's round-12 note above): both are
+authoring-time, player-facing disclosures about what a preset's `rules`
+payload does and does not enforce, never part of the wire-traveling,
+engine-consumed struct.
 
 ## 2. Parameterizing the formats as data (not N blocks)
 
@@ -848,7 +937,11 @@ not appear as a selectable format until that item resolves:
   a value pending confirmation, but the genuinely correct value until
   CONTEXT.md Open item 6 resolves (there is no confirmed authored intent to
   declare yet; `None` says exactly that, distinctly from a lobby save's
-  permanent `None`, which has no intent to declare, period). Ante-card
+  permanent `None`, which has no intent to declare, period). `printing_fidelity`
+  (NEW — round 12): `NotApplicable`, following directly from `reprint_policy:
+  None` per §1's pairing rule — revisit alongside Open item 6, since resolving
+  that item to a real `Some(_)` value also flips this to
+  `SetCodeApproximation` with a matching `description` update. Ante-card
   handling remains open per Open item 5 separately; do not encode either
   without resolving its own item first.
 
@@ -866,15 +959,29 @@ mirroring how `FormatConfig::pioneer()` spreads `..Self::standard()`:
   burn as its only legacy exception). `reprint_policy` (on `CustomFormatDef`):
   `Some(AllowSpecialReprintSets)` — RESEARCH.md's §1 subsection for this
   format explicitly includes CE/ICE as legal reprint sources within
-  `legal_sets`.
-- `old_school_95()` — `let mut d = old_school_93_94(); d.legal_sets.extend([4ED,
+  `legal_sets`. `printing_fidelity` (NEW — round 12): `SetCodeApproximation`
+  — this format's source rule requires non-foil original-frame/art reprints
+  (RESEARCH.md §1) and the engine enforces only set-code membership (§1's
+  round-12 note); `description` MUST state this (e.g. "Legality is approximated
+  at the set-code level; original-printing frame/foil is not enforced.").
+- `old_school_95()` — `let mut d = old_school_93_94(); d.legal_sets.get_or_insert_with(Vec::new).extend([4ED,
   ICE, CHR, REN, HML]); d.restricted.extend([Demonic Consultation, Mana Crypt]);
-  d.banned.extend([Amulet of Quoz, Timmerian Fiends]; legacy unchanged`.
+  d.banned.extend([Amulet of Quoz, Timmerian Fiends]; legacy unchanged`. **Fixed
+  this round (maintainer review, CodeRabbit finding): `legal_sets` is
+  `Option<Vec<SetCode>>` (§1), not a bare `Vec` — `.extend()` cannot be called
+  on it directly. `get_or_insert_with(Vec::new)` extends the base's `Some(...)`
+  vector in place (its only legal state per `old_school_93_94()`'s own
+  construction — a restricted-pool preset never leaves this `None`) while
+  still being correct if a future refactor ever changed that invariant, rather
+  than assuming it silently.** `printing_fidelity`: inherited `SetCodeApproximation`
+  from the base `d` — same source requirement, same enforcement gap.
 - `middle_school()` — `rules`: sets = Fourth Edition..Scourge; restricted =
   []; banned = [25 names]; legacy = `{ mana_burn: ManaBurnPolicy::Obsolete,
   damage_timing: CombatDamageTiming::OnStack, wish_scope:
   WishOutsideGameScope::PreM10ReachesExile }`. `reprint_policy` (on the
-  `CustomFormatDef`, not `rules` — round 6): `Some(AllowAnyPrinting)`. **Per the
+  `CustomFormatDef`, not `rules` — round 6): `Some(AllowAnyPrinting)`.
+  `printing_fidelity` (NEW — round 12): `SetCodeApproximation`, same
+  disclosure requirement as Old School above. **Per the
   preset-readiness gate (§7, tightened this round): this preset may not be
   registered until `CombatDamageTiming::OnStack` (§4/§6, LARGE) is fully
   implemented — no partial/caveated exposure.**
@@ -884,7 +991,9 @@ mirroring how `FormatConfig::pioneer()` spreads `..Self::standard()`:
   `{ mana_burn: ManaBurnPolicy::Obsolete, damage_timing:
   CombatDamageTiming::OnStack, wish_scope:
   WishOutsideGameScope::PreM10ReachesExile }`. `reprint_policy` (on the
-  `CustomFormatDef`): `Some(OriginalPrintingsOnly)`. **Same registration block
+  `CustomFormatDef`): `Some(OriginalPrintingsOnly)`. `printing_fidelity`
+  (NEW — round 12): `SetCodeApproximation`, same disclosure requirement.
+  **Same registration block
   as Middle School** — not selectable until `CombatDamageTiming::OnStack` lands.
 
 Set codes must be verified against the engine's `set_catalog` (MTGJSON codes)
@@ -1162,6 +1271,22 @@ legality logic on the client.
   produces `Some(_)` with its own specific documented variant — five
   separate assertions, not one shared "is `Some`" check, so a copy-paste
   preset that forgets to set its own value is caught.
+- **`printing_fidelity` is paired with `reprint_policy`, and disclosed in
+  `description`, for every registered preset** (new — maintainer review
+  round 12, §1's new field): for every `CustomFormatDef` `custom_format_registry()`
+  would return, assert `def.reprint_policy.is_some() == matches!(def.printing_fidelity,
+  PrintingFidelity::SetCodeApproximation)` — the two fields must never
+  disagree (a `Some(_)` reprint intent with `NotApplicable` fidelity would
+  silently claim full fidelity; a `None` reprint intent with
+  `SetCodeApproximation` would disclose a limitation for a format that never
+  claimed the stricter requirement in the first place). For every preset
+  whose `printing_fidelity` is `SetCodeApproximation` (today: `old_school_93_94`,
+  `old_school_95`, `middle_school`, `classic_magic`), additionally assert
+  `description` contains a substring disclosing the set-code-only
+  approximation — not merely that the enum variant is set, so a future
+  preset can't satisfy the pairing check while leaving the player-facing
+  text silent about it. This is the technical mechanism the round-12 note
+  in §1 promises — the disclosure is enforced, not a documented convention.
 - Set-membership legality: assert cards from in-pool and out-of-pool sets pass /
   fail — for arbitrary set lists, not just the four presets.
 - **`legal_sets: None` accepts every card** (new — maintainer review round 2,
@@ -1409,6 +1534,20 @@ now) belongs on `CustomFormatDef` instead, outside this gate's scope by
 construction — round 6's actual lesson: when a field doesn't cleanly belong
 in the gate's coverage, that's a signal it may be in the wrong struct, not
 just missing from the gate.
+
+**A second, separate construction-time gate — round 12, `CustomFormatDef`
+metadata, not `CustomFormatRules`:** `custom_format_registry()` additionally
+rejects (build-time or startup-check, same choice as above) any def where
+`reprint_policy.is_some() != matches!(printing_fidelity,
+PrintingFidelity::SetCodeApproximation)`, and any `SetCodeApproximation` def
+whose `description` doesn't disclose the limitation (§6's test is this same
+check, run offline). This is deliberately a DIFFERENT gate from
+`IMPLEMENTED_LEGACY_AXES` — it does not block registration on unimplemented
+engine work (there is none to wait for; §1's round-12 note explains why no
+printing predicate is being built), it blocks on an authoring omission
+(a preset that declares reprint intent but forgets to disclose the known
+approximation, or vice versa). Both gates independently apply to the same
+four EC presets; neither substitutes for the other.
 - `swedish_old_school()` (phase 1) is BLOCKED from registration by
   CONTEXT.md Open item 6 alone — the reprint-policy metadata VALUE needs
   confirming against the primary source before shipping, so a future

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -504,74 +504,85 @@ LegalityRules {
 // typed enum (not deleted, not a bool) purely so a preset's authored intent
 // stays machine-readable for whoever eventually builds Open item 2.
 
-// RESOLVED — round 10, maintainer review + direct follow-up discussion.
-// CONTEXT.md open item #2 asked whether the legal-set-membership
-// approximation (frame/art/foil never enforced) is acceptable for v1, or
-// whether the frontend/engine printing cross-reference should be built.
-// Round 10's review sharpened this into a real objection: the rollout (§8)
-// registers Old School 93-94/95 once mana burn lands, with no gate at all
-// tied to their SOURCE rules' printing-fidelity requirement
-// (RESEARCH.md:34, "non-foil reprints with original frame + art").
+// RESOLVED — round 11, maintainer review + direct follow-up discussion.
+// SUPERSEDES round 10's resolution below (retracted, not layered on top —
+// round 11's review correctly rejected it): round 10 tried to answer
+// CONTEXT.md open item #2 by pairing "legal_sets is the whole legality
+// check" with a display-only fix (`ArtChainEntry` becoming legal-set-aware)
+// framed as resolving the source rules' printing-fidelity requirement.
+// matthewevans's round-11 review correctly rejected this: "an optional
+// rendering preference [is not] a legality resolution" — a cosmetic default
+// cannot satisfy a rules-correctness claim, and the rollout still registered
+// Old School 93-94/95 without addressing that the schema literally cannot
+// express their source rule's printing/foil requirement.
 //
-// Resolution reached this round, confirmed directly, not left as a
-// maintainer-only decision:
-//   1. **Legality enforcement is NOT extended to cover this, and that's
-//      final, not a placeholder.** Foil status and frame/border are not
-//      tracked anywhere in MTGJSON/`CardDatabase` (CONTEXT.md item 2's own
-//      research already established this — oracle-level data only). There
-//      is no engine-owned data to enforce against, and building one is out
-//      of scope for this proposal. `legal_sets` membership remains the
-//      WHOLE legality check, unchanged from every prior round. The
-//      registration gate for Old School 93-94/95 stays exactly as §8
-//      already has it — keyed to `IMPLEMENTED_LEGACY_AXES`/mana burn only,
-//      no new blocking axis added.
-//   2. **What actually resolves the spirit of the source rules is a DISPLAY
-//      feature, not a legality feature — general to every format, not
-//      Custom-specific.** `preferencesStore.ts`'s existing `ArtChainEntry`
-//      already has an `{type: "oldest"}` mode (CONTEXT.md item 2's research)
-//      that shows a card's globally-oldest printing — this pre-dates this
-//      proposal and is unrelated to any format's legality. The gap: it does
-//      not know about the ACTIVE FORMAT's `legal_sets` at all, so "oldest
-//      printing" can be a printing the current format doesn't even
-//      recognize as legal (a promo/judge-gift printing, for instance — a
-//      real, concrete example: Chronicles' City of Brass reprint is a
-//      legitimate reprint many old-school rulesets allow, but its Junior
-//      Super Series promo printing is not, despite being the same card).
-//      Fix: make `{type: "oldest"}`'s resolution legal-set-aware — when the
-//      active format has `legal_sets: Some(list)`, restrict the candidate
-//      printings to `list` before picking the earliest by `released_at`;
-//      when `legal_sets: None` (every built-in format today, and Axis-A
-//      lobby saves), behavior is byte-for-byte unchanged from today, since
-//      there is no format-imposed set restriction to respect and any
-//      printing of a legal card is already equally tournament-legal. This
-//      is a fix to one existing preference mode's resolution logic, not a
-//      new `ArtChainEntry` variant, and not gated on `ReprintPolicy` at
-//      all — `legal_sets` alone drives it, so it benefits EVERY format that
-//      declares a restricted printing pool, not just the three Axis-B
-//      presets that happen to set a `ReprintPolicy` value.
-//   3. **Stays a per-player preference, not a forced override.** A player
-//      who wants to see a specific printing (their own foil, a different
-//      art) keeps that choice under `ArtChainEntry`'s other modes;
-//      `{type: "oldest"}` becoming legal-set-aware only changes what THAT
-//      mode itself resolves to, exactly like any other bug-fix to an
-//      existing preference's resolution logic.
-//   4. **Zero engine change required.** `legal_sets` is already available
-//      client-side via the resolved `FormatConfig`/registry (both axes);
-//      the frontend already has the full Scryfall printing dataset
-//      (`scryfall-printings.json`) and `pickOldestPrinting()`. This is
-//      exactly option (b) CONTEXT.md's original two-way fork offered,
-//      chosen over (a) (new engine-owned derived state) because it reuses
-//      an existing, working, tested system rather than building a parallel
-//      one — consistent with "reuse existing building blocks."
+// The actual resolution, reached in direct discussion rather than picked
+// unilaterally, is simpler than either round 10's or the two options
+// matthewevans offered (gate on future enforcement, or explicitly downgrade
+// the claim) — it's a THIRD answer, grounded in existing precedent rather
+// than a new policy call:
+//
+// **`legal_sets` membership is not an approximation of Old School 93-94/95's
+// legality — it is the exact same legality model every format in this
+// engine already uses, built-in or custom, with zero exceptions.**
+// Confirmed directly against the actual source this round:
+// `GameFormat::Premodern => Some(LegalityFormat::Premodern)`
+// (`crates/engine/src/types/format.rs:243`) is an oracle-card-level check —
+// "does this card name have a legal printing," full stop. No built-in
+// format (Premodern included, and Standard/Modern/Legacy/etc. via the same
+// `LegalityFormat` mechanism) has EVER checked which specific printing,
+// frame, border, or foil status a card uses. `PrintedCardRef { oracle_id,
+// face_name }` (`crates/engine/src/types/card.rs:89-92`) — the actual
+// runtime card identity used everywhere a legal deck is played — has no
+// set-code field at all, for any format. So "legal_sets membership only" is
+// not old-school-specific caveated exposure; it is this engine's ONE
+// existing, consistent legality model, applied identically to a fourth
+// (fifth, sixth...) format the same way it's already applied to every one
+// that shipped before this proposal. There is no inconsistency to gate
+// against, because there is no format anywhere in this engine that does
+// more than this.
+//
+// This means: **the registration gate for Old School 93-94/95 reverts to
+// exactly what §8 had before round 10 — keyed to
+// `IMPLEMENTED_LEGACY_AXES`/mana burn only, no new blocking axis.** Nothing
+// about their legality model needs to wait on unscoped future work, because
+// nothing about it falls short of the standard every other format in this
+// engine already meets.
+//
+// **The display-fix material from round 10 is retracted from this
+// proposal, not merged with this resolution — confirmed directly, not
+// this document's unilateral call.** Making a per-player display
+// preference legal-set-aware is a real, worthwhile idea, but it belongs in
+// its own proposal (a general frontend/`ArtChainEntry` enhancement, not
+// scoped to or gated by this custom-format-engine work) rather than being
+// used to paper over a legality question this resolution no longer needs
+// papered over. Tracked as a follow-up idea, not designed further here —
+// see CONTEXT.md's open items.
+//
+// **Genuine per-card printing selection (a player declaring which specific
+// printing/set — not frame/foil, which stays purely cosmetic even on
+// platforms that track it, e.g. Arena/MTGO's foil is a rendering/collection
+// attribute, not a format-legality one) is a separate, real, larger future
+// feature, also NOT designed or scoped here.** Briefly surveyed this round
+// for awareness, not design: the deck-builder already has the needed UI
+// shape (`PrintingPickerModal.tsx`, `client/src/components/deck-builder/`)
+// and a client-side type that already carries printing detail on import
+// (`DeckEntry.sourcePrinting`, `client/src/services/deckParser.ts:5-9`) —
+// but that detail is explicitly discarded at the `expandParsedDeck`
+// boundary (`deckParser.ts:45-73`) before it ever reaches
+// `PlayerDeckList`/`PrintedCardRef` (which have no printing field to receive
+// it). Building this for real would be a moderate plumbing lift reusing
+// existing components, not a from-scratch feature — but it is general to
+// EVERY format (nothing about it is old-school-specific) and is explicitly
+// out of scope for this proposal, which changes nothing about how decklists
+// identify cards.
 //
 // `ReprintPolicy`'s three variants (`AllowSpecialReprintSets`,
-// `AllowAnyPrinting`, `OriginalPrintingsOnly`, §2) remain exactly what round
-// 6/7 already resolved them to be — authoring-intent documentation metadata
-// on `CustomFormatDef`, consumed by nothing. This resolution deliberately
-// does NOT wire them into the display fix above; `legal_sets` alone is a
-// sufficient and simpler driver, and conflating the two would resurrect
-// exactly the "field whose consumption story keeps changing" pattern
-// rounds 5-7 already spent three rounds correcting.
+// `AllowAnyPrinting`, `OriginalPrintingsOnly`, §2) are UNCHANGED by this
+// resolution — still exactly what round 6/7 resolved them to be:
+// authoring-intent documentation metadata on `CustomFormatDef`, consumed by
+// nothing, kept machine-readable for whichever of the two future features
+// above eventually gets built.
 
 // REVISED per maintainer review round 4 (CONTEXT.md point 3): every axis
 // below is now a typed enum, not a bool — `legend_rule_scope` already was;
@@ -1292,24 +1303,19 @@ legality logic on the client.
     otherwise silently fall back to — the concrete regression test for the
     deck-size correctness bug this round's audit found, not just the
     display-label issue Matt's review text quoted.
-- **NEW — maintainer review round 10 (`ArtChainEntry`'s `{type: "oldest"}`
-  becomes `legal_sets`-aware, §1)**:
-  - A card with printings both inside and outside a format's declared
-    `legal_sets` resolves to the oldest printing WITHIN `legal_sets` when
-    `{type: "oldest"}` is active — not the card's globally-oldest printing —
-    the direct regression test for the Chronicles-vs-promo-printing gap
-    this round's discussion identified.
-  - The same resolution with `legal_sets: None` (every built-in format,
-    and Axis-A lobby saves) returns byte-identical output to today's
-    pre-round-10 `{type: "oldest"}` behavior — proving the fix is additive
-    and doesn't regress the existing preference for formats with no set
-    restriction.
-  - A card with NO printings inside `legal_sets` at all (a data
-    inconsistency — the card is nominally legal per some other printing
-    check, but every one of its Scryfall-side printings sits outside the
-    declared set list) falls back to the pre-fix global-oldest behavior
-    rather than panicking or rendering nothing — the explicit degenerate
-    case this design must not leave undefined.
+- **NEW — maintainer review round 11 (§1's Premodern-precedent
+  resolution)**: a dedicated test asserting `old_school_93_94()`/
+  `old_school_95()`'s legality evaluation path is the SAME function
+  (`evaluate_custom_format`'s pool-legality step, §3) that every other
+  `legal_sets`-bearing format already goes through — not a special-cased
+  arm — and a comparison-style test confirming `Premodern`'s own legality
+  check (`LegalityFormat::Premodern`) and a `legal_sets`-restricted Custom
+  format both accept ANY printing of a card whose name/oracle-id has a
+  legal printing, with neither rejecting on set/frame/foil grounds — proving
+  the two models are genuinely equivalent in what they check, not just
+  similar in spirit. (The round-10 `ArtChainEntry` display test is removed,
+  not superseded in place — that feature is out of scope for this proposal,
+  see §1.)
 
 ## 7. Delivery surface — RESOLVED via maintainer input, see CONTEXT.md "Maintainer input"
 

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -120,27 +120,65 @@ CustomFormatRules {                     // the resolved ruleset payload
 
 // Axis A — "FFA that's super flexible" (maintainer framing, see CONTEXT.md
 // "Maintainer input"). Every field here already exists on `FormatConfig`
-// (`types/format.rs:174-202`) and several are already host-adjustable today in
+// (`types/format.rs:174-212` — the full struct, re-read directly for this
+// revision, not from memory) and several are already host-adjustable today in
 // `client/src/components/lobby/HostSetup.tsx` for a chosen built-in
 // `GameFormat` — this struct is a NAMED, SAVEABLE snapshot of that same
 // knob set, not new game-rule surface. This is the axis the lobby "save as
 // custom format" action captures.
+//
+// REVISED per maintainer review round 2 (CONTEXT.md point 2): the first-pass
+// version of this struct dropped several behavior-bearing `FormatConfig`
+// fields. Full accounting against the real struct:
+//   - Included below: every FIELD that is independently meaningful and not
+//     derivable from something else already in this struct.
+//   - `uses_commander: bool` — NOT included as a stored field. It is derived
+//     as `commander_damage_threshold.is_some()` at read time, mirroring how
+//     it already mirrors `GameFormat` for built-in formats. Storing it
+//     separately would let it drift out of sync with the threshold.
+//   - `supplies_fixed_deck: bool` — NOT included. Always `false` for
+//     `GameFormat::Custom`; no custom-format use case for an engine-supplied
+//     fixed deck exists today. Flagged, not silently dropped, if that need
+//     ever arises (it would need its own design, analogous to Momir's
+//     Madness).
+//   - `allow_debug_actions: bool` — deliberately EXCLUDED. Its own doc
+//     comment states it is "orthogonal to format" — a session capability
+//     flag, not format identity. Belongs on `FormatConfig` directly, set
+//     independently of which format (built-in or custom) is chosen.
+//   - `sideboard_policy` — NEW finding: this is NOT a `FormatConfig` field.
+//     It's a `GameFormat` method (`format.rs:270`,
+//     `fn sideboard_policy(self) -> SideboardPolicy`), computed from the
+//     enum variant for built-in formats. `GameFormat::Custom` has no such
+//     derivation source, so `StructuralRules` must carry it explicitly.
 StructuralRules {
     starting_life: i32,
     min_players: u8,
     max_players: u8,
     deck_size: u16,
     singleton: bool,
+    command_zone: bool,
+    commander_damage_threshold: Option<u8>,
     range_of_influence: Option<Box<RangeOfInfluenceConfig>>,  // mirrors FormatConfig's field exactly
     team_based: bool,
+    archenemy_player: Option<PlayerId>,
+    sideboard_policy: SideboardPolicy,  // new — no derivation source for Custom, see note above
 }
 
 // Axis B — legality/era-rules. Genuinely new data; no existing UI surface.
 // This is what makes the four EC formats rules-correct; kept exactly as
 // originally designed, just now named as its own struct rather than sharing
 // `CustomFormatRules`'s top level with Axis A undifferentiated.
+//
+// REVISED per maintainer review round 2 (CONTEXT.md point 1): `legal_sets`
+// was a bare `Vec<SetCode>`, which cannot distinguish "no set restriction"
+// (Axis A's default) from "restricted to the empty set" (which would reject
+// every card) — the evaluator (§3) checked membership unconditionally, so an
+// empty Vec silently rejected everything. `Option<Vec<SetCode>>` fixes this:
+// `None` = unrestricted (every card passes the pool check), `Some(list)` =
+// restricted to `list`. This is the same `Option<T>`-over-ambiguous-sentinel
+// pattern CLAUDE.md already prescribes elsewhere in this codebase.
 LegalityRules {
-    legal_sets: Vec<SetCode>,           // set codes; membership = pool legality
+    legal_sets: Option<Vec<SetCode>>,   // None = unrestricted; Some(list) = pool membership
     reprint_policy: ReprintPolicy,
     banned: Vec<CardName>,              // fully illegal
     restricted: Vec<CardName>,          // legal, max 1 (CR 100.2b path)
@@ -149,12 +187,61 @@ LegalityRules {
 
 // A format saved from the lobby ("FFA, but I bumped starting life to 30 and
 // capped it at 4 players") sets `structural` and leaves `legality` at
-// defaults (no set restriction, no legacy rules) — a fully valid
-// `CustomFormatRules` value. The four EC formats set `legality` to real data
-// and `structural` to sane multiplayer/duel defaults. Neither axis requires
-// the other to be present; this is the orthogonality Block Constructed
-// already proved for `LegacyRuleSet` (§ below), now proved a second time
-// between Axis A and Axis B.
+// defaults (`legal_sets: None`, no legacy rules) — a fully valid
+// `CustomFormatRules` value that legitimately places no restriction on the
+// card pool. The four EC formats set `legality` to real data (`legal_sets:
+// Some([...])`) and `structural` to sane multiplayer/duel defaults. Neither
+// axis requires the other to be present; this is the orthogonality Block
+// Constructed already proved for `LegacyRuleSet` (§ below), now proved a
+// second time between Axis A and Axis B — and the `Option` fix above is what
+// makes Axis A's "no restriction" case a real, correctly-representable value
+// rather than an accidental illegal state.
+
+// --- Identity, persistence, and transport (new — maintainer review round 2,
+// CONTEXT.md point 3) ---
+//
+// The original design conflated two different identity concerns under one
+// `CustomFormatId`. Separating them:
+//
+//   (a) AGREEMENT WITHIN ONE GAME — already solved. `FormatConfig.custom_rules`
+//       (below) carries the full resolved `CustomFormatRules` VALUE, not a
+//       lookup key. A peer receiving a host's `FormatConfig` gets the entire
+//       ruleset directly — no registry lookup, no need to "already know" a
+//       custom format by ID. This was already correct; it just wasn't stated
+//       explicitly enough to distinguish from (b).
+//   (b) A PLAYER'S REUSABLE SAVED FORMAT — was never designed. This is a
+//       CLIENT-SIDE-ONLY concern:
+//
+// SavedCustomFormat {                 // client-local only — NOT an engine or WASM type
+//     local_id: Uuid,                 // or any locally-unique key; never sent over the wire
+//     name: String,                   // player-chosen display name
+//     rules: CustomFormatRules,       // the exact payload a game-start packages into FormatConfig
+// }
+//
+// A player's "my saved formats" list lives in local storage / a user
+// profile, entirely outside the engine. The engine never learns about
+// "saved format #3" — it only ever receives a fully-resolved
+// `CustomFormatRules` value at game-start time, exactly as it already does
+// for the four EC/Swedish presets. `CustomFormatId` therefore stays what it
+// was always designed to be: a lightweight, `Copy`, per-`GameState`
+// transport tag. Well-known, stable IDs matter only for the registry-backed
+// presets (so both peers' registries can label the same preset the same
+// way); an ad-hoc lobby-saved format can use a single reserved sentinel ID,
+// since the ID itself carries no meaning once the full payload travels with
+// it.
+//
+// VERSION SKEW (flagged, not fully resolved here): an older client that has
+// never heard of the `GameFormat::Custom` enum variant at all cannot be
+// rescued by `#[serde(default)]` on `custom_rules` — the failure happens at
+// the enum-variant level during deserialization of `format: GameFormat`
+// itself, before any field-level default ever applies. This is the same
+// class of risk any new `GameFormat` variant already carries, but custom
+// formats make it far more frequent in practice (a new custom format can be
+// created at any time, not just at a client release). The lobby-join flow
+// needs an explicit compatibility check — reject with a clear "this game
+// needs a custom-format-capable client" message — rather than relying on
+// deserialization to fail gracefully. Not designed in depth here; flagged as
+// a real requirement for whoever implements the lobby-join handshake.
 
 ReprintPolicy {                         // enum — enforceable today only at set-code granularity
     OriginalPrintingsOnly,              // 93-94 / Classic intent (see limitation)
@@ -257,11 +344,21 @@ custom_format_registry() -> Vec<CustomFormatDef>   // parallel to GameFormat::re
 
 **Lobby saves (Axis A)** produce the identical `CustomFormatDef` shape from a
 different origin — a name plus the live `FormatConfig` a host just finished
-tuning, with `legality` left at defaults:
+tuning, with `legality` left at defaults (`legal_sets: None`, empty
+banned/restricted, default `LegacyRuleSet`):
 
 ```text
 CustomFormatDef::from_lobby_config(name: String, config: &FormatConfig) -> CustomFormatDef
 ```
+
+Per maintainer review round 2 (CONTEXT.md point 2): this conversion must
+capture every `StructuralRules` field from the live `FormatConfig` — full
+fidelity, not a partial snapshot. If a future caller ever invokes this from a
+`FormatConfig` state this conversion cannot faithfully represent (there is
+none identified today, since `StructuralRules` now mirrors every
+independently-meaningful `FormatConfig` field), it must reject explicitly
+rather than silently drop data. The `CustomFormatId` this constructor
+allocates is the ad-hoc sentinel described above, not a registry-stable ID.
 
 Both paths converge on the same `custom_rules: Option<CustomFormatRules>` field
 and the same `GameFormat::Custom(CustomFormatId)` variant — there is exactly
@@ -277,10 +374,15 @@ the frontend labels/short-labels/descriptions just like `FormatMetadata`.)
 Axis B's MVP").** This is the first Axis B preset to actually ship, chosen
 because it needs zero `LegacyRuleSet` engine wiring:
 
-- `swedish_old_school()` — sets = [LEA, LEB, 2ED, ARN, ATQ, LEG, DRK] (verify
-  MTGJSON codes at implementation time, same caveat as below); banned = [] (a
-  genuinely empty list — the schema must support this, not assume non-empty);
-  restricted = [23 names, verbatim in CONTEXT.md]; legacy = default (all
+- `swedish_old_school()` — sets = `Some([LEA, LEB, 2ED, ARN, ATQ, LEG, DRK,
+  SUM])` (verify MTGJSON codes at implementation time, same caveat as below —
+  `SUM` for "Summer Magic" is a placeholder pending that verification; fixed
+  this round to include Summer Magic, which CONTEXT.md's legal-sets list
+  already named but this preset sketch had dropped); banned = `[]` (a
+  genuinely empty list — the schema must support this, not assume non-empty,
+  and `legal_sets: Some(...)` here — never `None` — since this preset DOES
+  restrict the pool); restricted = [**25** names, verbatim in CONTEXT.md —
+  corrected this round from a "23" miscount]; legacy = default (all
   `false`/`Modern` — no mana burn, no damage-on-stack, no Wish/legend-rule
   reversion). Ante-card handling and reprint policy are open per CONTEXT.md
   items 5–6; do not encode either without resolving those first.
@@ -300,7 +402,9 @@ mirroring how `FormatConfig::pioneer()` spreads `..Self::standard()`:
 - `middle_school()` — sets = Fourth Edition..Scourge; restricted = []; banned =
   [25 names]; reprint = AllowAnyPrinting; legacy = {mana_burn, damage_uses_stack,
   pre_m10_wish_reaches_exile}.
-- `classic_magic()` — sets = Alpha..Scourge; restricted = [37 names]; banned =
+- `classic_magic()` — sets = Alpha..Scourge; restricted = [**44** names —
+  corrected this round from a "37" mislabel; recounted directly against
+  RESEARCH.md's verbatim list]; banned =
   [11 names]; reprint = OriginalPrintingsOnly; legacy = {mana_burn,
   damage_uses_stack, pre_m10_wish_reaches_exile}.
 
@@ -315,9 +419,15 @@ time by a unit test that asserts every banned/restricted name resolves in the
 `evaluate_custom_format(db, request, rules) -> CompatibilityCheck`:
 
 1. Structural checks (deck size, sideboard) via existing `FormatConfig` fields.
-2. Pool legality: for each card, `db.printings_for(name)`; legal iff any
-   printing's set code ∈ `rules.legal_sets`. Else → illegal ("not legal in
-   <format>"), reusing the existing `illegal_cards` accumulation shape.
+2. Pool legality: `match &rules.legal_sets { None => every card passes this
+   check (no set restriction — Axis A's default), Some(sets) => for each
+   card, db.printings_for(name); legal iff any printing's set code ∈ sets,
+   else → illegal ("not legal in <format>"), reusing the existing
+   `illegal_cards` accumulation shape }`. **Fixed per maintainer review round
+   2** (CONTEXT.md point 1): the prior version checked membership
+   unconditionally against a bare `Vec`, so an empty Vec (Axis A's actual
+   default) rejected every card instead of none. The `None` arm is the
+   correctness-critical addition — test both arms independently (§6).
 3. Banned: name ∈ `rules.banned` → illegal (distinct "banned" label).
 4. Restricted: name ∈ `rules.restricted` → insert into `restricted_canonical`,
    then call the **existing** `restricted_copy_violations` (CR 100.2b, `<= 1`).
@@ -340,12 +450,50 @@ Swedish ruleset makes no mention of any of these rules and uses fully modern
 defaults. This section is unchanged from the original design and remains the
 correct plan for phase 2's four EC-format presets.
 
-- **Mana burn** (`LegacyRuleSet.mana_burn`): at the step-end drop site
-  (`types/mana.rs:1707`), tally dropped units per player; after the drain, if
-  the flag is set, deal that many damage to the owner and emit a new
-  `GameEvent::ManaBurn { player_id, amount }`. Annotate as a pre-M10 rule
-  removed by the M10 update (cite the obsolete-glossary entry
-  `MagicCompRules.txt:8277`). ~Small; no new state machine.
+- **Mana burn** (`LegacyRuleSet.mana_burn`) — **REWRITTEN per maintainer review
+  round 2** (CONTEXT.md point 4); the original "deal damage at the step-end
+  drop site" framing was wrong on two independent axes, both verified this
+  session:
+  - **Life loss, not damage.** `docs/MagicCompRules.txt:8278` (obsolete-rules
+    glossary): "unspent mana caused a player to **lose life**." Damage and
+    life loss are behaviorally different in this engine (damage can be
+    prevented/redirected and triggers "dealt damage" abilities; life loss
+    does neither) — this is not a cosmetic wording choice.
+  - **Phase-boundary, not every `Phase` enum transition.** The engine's own
+    `Phase` enum (`types/phase.rs`) flattens all of MTG's steps AND phases
+    into one 11-variant list (e.g. `DeclareAttackers`, `DeclareBlockers`,
+    `CombatDamage` are three separate `Phase` variants, all within the single
+    real MTG "Combat" phase). Modern CR 500.5 empties the mana pool at every
+    one of these transitions, and the engine's existing
+    `apply_empty_mana_pool_event` (`turns.rs`) already fires on every one via
+    `player_unspent_mana_loss_causes_life_loss`
+    (`static_abilities.rs:1237`, backed by `StaticMode::UnspentManaLossCausesLifeLoss`
+    — an existing, generic "Yurlok-class" mechanism for a card-granted
+    version of this same shape). That per-transition granularity is correct
+    for the existing card-granted static ability, but old-school mana burn
+    must fire only when actually **leaving one of the 5 real MTG phases**
+    (Beginning, Precombat Main, Combat, Postcombat Main, Ending) — not on
+    every step within one.
+
+  **Design**: add a small `fn phase_group(p: Phase) -> PhaseGroup` mapping
+  (a 5-variant enum grouping the 11 `Phase` variants by their real MTG
+  phase — mirrors the ad-hoc `in_combat` bool `turns.rs` already computes
+  inline for combat-duration tracking, generalized to all 5 groups). At the
+  same `apply_empty_mana_pool_event` call site, when `LegacyRuleSet.mana_burn`
+  is set AND `phase_group(current) != phase_group(next)` (a genuine
+  phase-group boundary, not an intra-phase step transition), apply a
+  **second, independent** life-loss contribution for that player's dropped
+  mana units — alongside, not merged into, the existing
+  `player_unspent_mana_loss_causes_life_loss` check, since the two have
+  different triggers (a format-level flag vs. a card-granted static ability)
+  and could theoretically both apply to the same event. Emit a
+  `GameEvent::ManaBurn { player_id, amount }` for the format-level
+  contribution specifically, so it stays distinguishable from a Yurlok-class
+  event in tests and in any future "why did I lose life" UI surface.
+  Annotate as a pre-M10 rule removed by the M10 update (cite the
+  obsolete-glossary entry `MagicCompRules.txt:8277-8278`). Still small — one
+  new grouping helper, one new gated life-loss contribution at an existing
+  call site, no new state machine.
 - **Pre-M10 Wish exile access** (`pre_m10_wish_reaches_exile`): fully traced in
   RESEARCH §9. This is a REAL functional difference (not wording-only): pre-M10,
   the "removed from the game" zone counted as *outside the game*, so a Wish could
@@ -394,18 +542,39 @@ legality logic on the client.
 
 - Set-membership legality: assert cards from in-pool and out-of-pool sets pass /
   fail — for arbitrary set lists, not just the four presets.
+- **`legal_sets: None` accepts every card** (new — maintainer review round 2,
+  CONTEXT.md point 1): a synthetic `CustomFormatRules` with `legal_sets: None`
+  must legalize a card from an arbitrary, otherwise-never-configured set —
+  the discriminating case that catches the empty-`Vec`-rejects-everything
+  regression directly. Paired with the existing `Some(list)` restricted case
+  above so both arms of the `Option` are independently covered, not just the
+  restricted one.
 - Restricted path: 2 copies of a restricted-list name flags; 1 copy passes —
   driven by a synthetic def, proving the general mechanism.
-- Preset integrity: every banned/restricted name in all four presets resolves in
-  the DB; each preset's `legacy` matches the EC spec.
-- Mana burn: unspent N mana at step end deals N with flag on, 0 with flag off —
-  tests the flag+hook, not a specific card.
+- Preset integrity: every banned/restricted name in all four EC presets plus
+  `swedish_old_school()` resolves in the DB; each preset's `legacy` matches
+  its source ruleset; each preset's stated list *count* in a doc comment
+  matches `.len()` of the actual list (guards against the round-2 23-vs-25 /
+  37-vs-44 class of mislabeling recurring silently).
+- **Mana burn phase-boundary gating** (revised — maintainer review round 2,
+  CONTEXT.md point 4): with `LegacyRuleSet.mana_burn` set, unspent mana at a
+  transition WITHIN one MTG phase (e.g. `DeclareAttackers` → `DeclareBlockers`,
+  same `PhaseGroup::Combat`) must NOT cause life loss; unspent mana at a
+  transition CROSSING a phase-group boundary (e.g. `EndCombat` →
+  `PostCombatMain`) must cause life loss equal to the unspent amount. Assert
+  life loss specifically (not damage — no `GameEvent::DamageDealt`, no
+  prevention-shield interaction). With the flag off, neither transition
+  causes any loss. Tests the flag + phase-group hook generically, not a
+  specific card.
 - Serde round-trip of `FormatConfig` with `Some(custom_rules)` and `None`.
 - `CustomFormatDef::from_lobby_config`: a `FormatConfig` with non-default
-  `starting_life`/`max_players`/`deck_size`/`range_of_influence`/`team_based`
-  round-trips into a `CustomFormatRules.structural` that matches field-for-
-  field, with `legality` at its defaults — the general Axis-A save mechanism,
-  not a specific saved format's values.
+  `starting_life`/`max_players`/`deck_size`/`range_of_influence`/`team_based`/
+  `command_zone`/`commander_damage_threshold`/`archenemy_player`/
+  `sideboard_policy` round-trips into a `CustomFormatRules.structural` that
+  matches field-for-field, with `legality` at its defaults (`legal_sets:
+  None`) — the general Axis-A save mechanism, not a specific saved format's
+  values. Include a case with `commander_damage_threshold: Some(_)` asserting
+  the derived `uses_commander` reads `true` without being stored separately.
 
 ## 7. Delivery surface — RESOLVED via maintainer input, see CONTEXT.md "Maintainer input"
 

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -504,43 +504,74 @@ LegalityRules {
 // typed enum (not deleted, not a bool) purely so a preset's authored intent
 // stays machine-readable for whoever eventually builds Open item 2.
 
-// NOT YET DESIGNED — flagged, not resolved, per CONTEXT.md open item #2.
-// `ReprintPolicy` (now on `CustomFormatDef`, not `LegalityRules`) documents
-// a preset's REPRINT INTENT for a human reading it; it does not gate
-// legality — legal-set membership alone does that (§3). A user follow-up
-// asks for a sibling, independent axis: DISPLAY DEFAULT
-// (which specific legal printing's frame/art renders by default when a card
-// is added to a deck under this format) — e.g. an old-rules format should
-// default old-frame Alpha/Beta art over a modern reprint's, without forcing
-// the player to manually pick a printing every time.
+// RESOLVED — round 10, maintainer review + direct follow-up discussion.
+// CONTEXT.md open item #2 asked whether the legal-set-membership
+// approximation (frame/art/foil never enforced) is acceptable for v1, or
+// whether the frontend/engine printing cross-reference should be built.
+// Round 10's review sharpened this into a real objection: the rollout (§8)
+// registers Old School 93-94/95 once mana burn lands, with no gate at all
+// tied to their SOURCE rules' printing-fidelity requirement
+// (RESEARCH.md:34, "non-foil reprints with original frame + art").
 //
-// Per CONTEXT.md's corrected finding: this is NOT the same gap as
-// ReprintPolicy's set-code-membership approximation. Legality (engine/MTGJSON,
-// set-codes only) and frame/art data (frontend/Scryfall, already has
-// released_at/border_color/frame_effects/full_art via `scryfall-printings.json`
-// + `preferencesStore`'s `ArtChainEntry`) are two disjoint systems today that
-// have never been cross-referenced. Building this means either (a) new
-// engine-owned derived state — a WASM-exposed "preferred printing for name X
-// given format Y" API, reusing `SetCatalog`/`SetMeta.release_date` (already
-// loaded, already projected to `client/public/set-list.json` for an unrelated
-// purpose) for chronological ordering — or (b) extending the frontend's
-// existing `ArtChainEntry` cosmetic-preference chain with a new variant seeded
-// by the format's reprint policy, treating this as display preference rather
-// than engine-derived game state. (a) fits "engine owns all logic" more
-// cleanly; (b) reuses a system that already does exactly this job for
-// individual players today. This fork needs the same maintainer conversation
-// as the rest of this design — do not build either without it.
+// Resolution reached this round, confirmed directly, not left as a
+// maintainer-only decision:
+//   1. **Legality enforcement is NOT extended to cover this, and that's
+//      final, not a placeholder.** Foil status and frame/border are not
+//      tracked anywhere in MTGJSON/`CardDatabase` (CONTEXT.md item 2's own
+//      research already established this — oracle-level data only). There
+//      is no engine-owned data to enforce against, and building one is out
+//      of scope for this proposal. `legal_sets` membership remains the
+//      WHOLE legality check, unchanged from every prior round. The
+//      registration gate for Old School 93-94/95 stays exactly as §8
+//      already has it — keyed to `IMPLEMENTED_LEGACY_AXES`/mana burn only,
+//      no new blocking axis added.
+//   2. **What actually resolves the spirit of the source rules is a DISPLAY
+//      feature, not a legality feature — general to every format, not
+//      Custom-specific.** `preferencesStore.ts`'s existing `ArtChainEntry`
+//      already has an `{type: "oldest"}` mode (CONTEXT.md item 2's research)
+//      that shows a card's globally-oldest printing — this pre-dates this
+//      proposal and is unrelated to any format's legality. The gap: it does
+//      not know about the ACTIVE FORMAT's `legal_sets` at all, so "oldest
+//      printing" can be a printing the current format doesn't even
+//      recognize as legal (a promo/judge-gift printing, for instance — a
+//      real, concrete example: Chronicles' City of Brass reprint is a
+//      legitimate reprint many old-school rulesets allow, but its Junior
+//      Super Series promo printing is not, despite being the same card).
+//      Fix: make `{type: "oldest"}`'s resolution legal-set-aware — when the
+//      active format has `legal_sets: Some(list)`, restrict the candidate
+//      printings to `list` before picking the earliest by `released_at`;
+//      when `legal_sets: None` (every built-in format today, and Axis-A
+//      lobby saves), behavior is byte-for-byte unchanged from today, since
+//      there is no format-imposed set restriction to respect and any
+//      printing of a legal card is already equally tournament-legal. This
+//      is a fix to one existing preference mode's resolution logic, not a
+//      new `ArtChainEntry` variant, and not gated on `ReprintPolicy` at
+//      all — `legal_sets` alone drives it, so it benefits EVERY format that
+//      declares a restricted printing pool, not just the three Axis-B
+//      presets that happen to set a `ReprintPolicy` value.
+//   3. **Stays a per-player preference, not a forced override.** A player
+//      who wants to see a specific printing (their own foil, a different
+//      art) keeps that choice under `ArtChainEntry`'s other modes;
+//      `{type: "oldest"}` becoming legal-set-aware only changes what THAT
+//      mode itself resolves to, exactly like any other bug-fix to an
+//      existing preference's resolution logic.
+//   4. **Zero engine change required.** `legal_sets` is already available
+//      client-side via the resolved `FormatConfig`/registry (both axes);
+//      the frontend already has the full Scryfall printing dataset
+//      (`scryfall-printings.json`) and `pickOldestPrinting()`. This is
+//      exactly option (b) CONTEXT.md's original two-way fork offered,
+//      chosen over (a) (new engine-owned derived state) because it reuses
+//      an existing, working, tested system rather than building a parallel
+//      one — consistent with "reuse existing building blocks."
 //
-// Whatever shape it takes, per CLAUDE.md's bool-vs-enum rule (and consistent
-// with ReprintPolicy itself being a 3-way enum, not a bool), a bare
-// `use_old_frame: bool` field would be the wrong shape. If/when designed, this
-// should be a typed axis analogous to `ArtChainEntry` — sketch only, NOT a
-// final design:
-//   PrintingDefault {
-//       Newest,                   // today's implicit behavior
-//       OldestLegal,              // oldest printing within this format's legal_sets
-//       SpecificSet(SetCode),     // pin to one set's frame (e.g. "Alpha only" preset)
-//   }
+// `ReprintPolicy`'s three variants (`AllowSpecialReprintSets`,
+// `AllowAnyPrinting`, `OriginalPrintingsOnly`, §2) remain exactly what round
+// 6/7 already resolved them to be — authoring-intent documentation metadata
+// on `CustomFormatDef`, consumed by nothing. This resolution deliberately
+// does NOT wire them into the display fix above; `legal_sets` alone is a
+// sufficient and simpler driver, and conflating the two would resurrect
+// exactly the "field whose consumption story keeps changing" pattern
+// rounds 5-7 already spent three rounds correcting.
 
 // REVISED per maintainer review round 4 (CONTEXT.md point 3): every axis
 // below is now a typed enum, not a bool — `legend_rule_scope` already was;
@@ -1261,6 +1292,24 @@ legality logic on the client.
     otherwise silently fall back to — the concrete regression test for the
     deck-size correctness bug this round's audit found, not just the
     display-label issue Matt's review text quoted.
+- **NEW — maintainer review round 10 (`ArtChainEntry`'s `{type: "oldest"}`
+  becomes `legal_sets`-aware, §1)**:
+  - A card with printings both inside and outside a format's declared
+    `legal_sets` resolves to the oldest printing WITHIN `legal_sets` when
+    `{type: "oldest"}` is active — not the card's globally-oldest printing —
+    the direct regression test for the Chronicles-vs-promo-printing gap
+    this round's discussion identified.
+  - The same resolution with `legal_sets: None` (every built-in format,
+    and Axis-A lobby saves) returns byte-identical output to today's
+    pre-round-10 `{type: "oldest"}` behavior — proving the fix is additive
+    and doesn't regress the existing preference for formats with no set
+    restriction.
+  - A card with NO printings inside `legal_sets` at all (a data
+    inconsistency — the card is nominally legal per some other printing
+    check, but every one of its Scryfall-side printings sits outside the
+    declared set list) falls back to the pre-fix global-oldest behavior
+    rather than panicking or rendering nothing — the explicit degenerate
+    case this design must not leave undefined.
 
 ## 7. Delivery surface — RESOLVED via maintainer input, see CONTEXT.md "Maintainer input"
 

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -39,14 +39,16 @@ are a clean proof that the design's two axes — the legal-set-code list vs. the
 `LegacyRuleSet` era-rule flags — are properly orthogonal, not entangled:
 
 - A **modern-era block** needs *only* the legal-set-code axis with **all
-  `LegacyRuleSet` flags false / defaulted** (`mana_burn: false`,
-  `damage_uses_stack: false`, `pre_m10_wish_reaches_exile: false`,
-  `legend_rule_scope: Modern`). It is a `CustomFormatDef` that is purely a
-  set-list restriction.
+  `LegacyRuleSet` axes at their `Modern`/default variant** (`mana_burn:
+  ManaBurnPolicy::Modern`, `damage_timing: CombatDamageTiming::Modern`,
+  `wish_scope: WishOutsideGameScope::PostM10SideboardOnly`,
+  `legend_rule_scope: LegendRuleScope::Modern`). It is a `CustomFormatDef`
+  that is purely a set-list restriction.
 - A **pre-M10-era block** (a block from before the 2010 "M10" rules update)
-  would set `mana_burn: true` (and potentially `pre_m10_wish_reaches_exile` /
-  `legend_rule_scope` depending on the exact era) via the **same** mechanism —
-  proving `LegacyRuleSet` is *not* special-cased to the four EC presets but is a
+  would set `mana_burn: ManaBurnPolicy::Obsolete` (and potentially
+  `wish_scope: WishOutsideGameScope::PreM10ReachesExile` / `legend_rule_scope`
+  depending on the exact era) via the **same** mechanism — proving
+  `LegacyRuleSet` is *not* special-cased to the four EC presets but is a
   genuinely general axis any format opts into based on which era's rules it
   represents. The four EC formats are simply the first four consumers of an axis
   that is open to Block Constructed and any future era format alike.
@@ -164,15 +166,15 @@ CustomFormatRules {                     // the resolved ruleset payload
 //     topology at all (a different `FormatTopology` shape, not a config knob
 //     on top of `IndividualSeats`) — explicit scope exclusion, not a silent
 //     drop; a topology-aware design is its own future project.
-//   - `sideboard_policy` — this is NOT a `FormatConfig` field. It's a
+//   - `sideboard_policy` — NOT a `FormatConfig` field today; it's a
 //     `GameFormat` method (`format.rs:270`,
 //     `fn sideboard_policy(self) -> SideboardPolicy`), computed from the
 //     enum variant for built-in formats, with no `FormatConfig` access to
-//     check anything for `Custom`. `StructuralRules` carries it explicitly;
-//     see the new `FormatConfig::sideboard_policy()` accessor and consumer
-//     migration below (maintainer review round 3, CONTEXT.md point 2) —
-//     round 2 added this field but never specified how anything would
-//     actually READ it for a Custom format, which was itself a gap.
+//     check anything for `Custom`. `StructuralRules` carries the DECLARED
+//     value explicitly; `FormatConfig` gains a matching STORED field (not a
+//     method — see the fallible-validation section below, maintainer
+//     review round 4, which also explains why round 3's method-plus-
+//     `.expect()` design was itself wrong, not just incomplete).
 StructuralRules {
     starting_life: i32,
     min_players: u8,
@@ -183,39 +185,97 @@ StructuralRules {
     commander_damage_threshold: Option<u8>,
     range_of_influence: Option<Box<RangeOfInfluenceConfig>>,  // mirrors FormatConfig's field exactly
     team_based: bool,
-    sideboard_policy: SideboardPolicy,  // no derivation source for Custom, see note above
+    sideboard_policy: SideboardPolicy,  // the DECLARED value for this custom format;
+                                        // FormatConfig.sideboard_policy (a stored field,
+                                        // see the fallible-validation note below) is the
+                                        // RESOLVED value every consumer actually reads —
+                                        // same two-layer shape as uses_commander already has
 }
 
-// --- sideboard_policy accessor and consumer migration (new — maintainer
-// review round 3, CONTEXT.md point 2) ---
+// --- Fallible validation + resolved-context threading (REWRITTEN —
+// maintainer review round 4, CONTEXT.md point 1; round 3's `.expect()`-based
+// accessor was itself wrong, not just incomplete) ---
 //
-// `GameFormat::sideboard_policy(self) -> SideboardPolicy` (`format.rs:270`)
-// is an exhaustive match over the built-in variants with NO access to
-// `FormatConfig` — a `Custom(_)` arm there can only be
-// `unreachable!("call FormatConfig::sideboard_policy() instead")`, since the
-// real answer lives in `custom_rules`, which this method cannot see. The
-// correct authority is one level up:
+// Round 3 added `FormatConfig::sideboard_policy()` as a METHOD with an
+// `.expect("Custom format must carry custom_rules")` arm, and migrated two
+// call sites. Both were mistakes:
+//   (a) `.expect()` panics in production if `custom_rules` is ever `None`
+//       while `format == Custom(_)` — a malformed/inconsistent value should
+//       be rejected where it enters the system, not allowed to exist and
+//       panic downstream wherever it's read.
+//   (b) Two call sites were nowhere near enough. A full audit this round
+//       (grep for every real, non-test consumer of `.uses_commander()` /
+//       `.sideboard_policy()` on a bare `GameFormat`) found SEVEN files:
+//       `game/companion.rs` (4 sites: `companion_offers`/
+//       `companion_starting_deck`-adjacent code at lines 193, 205, 254, 388),
+//       `game/deck_loading.rs` (681, 697), `game/match_flow.rs` (64, 357),
+//       `game/deck_validation.rs` (98, 1881, 1922, 2273, 2320). Round 3 found
+//       none of `companion.rs`'s four; maintainer review round 4 caught one
+//       of them (`companion.rs:252-260`) directly.
 //
-// impl FormatConfig {
-//     pub fn sideboard_policy(&self) -> SideboardPolicy {
-//         match self.format {
-//             GameFormat::Custom(_) => self.custom_rules.as_ref()
-//                 .expect("Custom format must carry custom_rules")
-//                 .structural.sideboard_policy,
-//             other => other.sideboard_policy(),
-//         }
-//     }
-// }
+// **Deeper finding this round, beyond what was flagged**: several of these
+// functions don't take `&FormatConfig` at all — they take a bare
+// `format: GameFormat` parameter (`companion_offers`,
+// `companion_starting_deck`, and — found independently this round, not
+// previously flagged by anyone — `deck_validation.rs`'s
+// `DeckCompatibilityRequest.selected_format: Option<GameFormat>`, threaded
+// through `companion_candidates`, `quick_constructed_check`'s caller, and
+// the format-dispatch `match` in the ~1900-2300 line range). A method-only
+// fix on `FormatConfig` cannot help these — there is no `FormatConfig` in
+// scope at all, only the bare enum. This is the real reason "add an
+// accessor and migrate the two call sites I already knew about" was never
+// going to be sufficient — the actual shape of the problem is that several
+// engine call paths were designed assuming `GameFormat` alone carries all
+// necessary information, which is true for every built-in format and false
+// for `Custom`.
 //
-// Every current call site of `state.format_config.format.sideboard_policy()`
-// — confirmed this session at `game/deck_loading.rs:681` and
-// `game/match_flow.rs:357`; a repo-wide grep for the same pattern at
-// implementation time catches any others — migrates to
-// `state.format_config.sideboard_policy()`. Round 2 added the field to
-// `StructuralRules` but never specified this accessor or the migration,
-// which is why a saved format's sideboard policy would have been silently
-// ignored (both existing consumers would keep reading a meaningless
-// built-in-format answer for `GameFormat::Custom`).
+// **Fix — validated ingestion + resolved fields, not per-call-site patches:**
+//
+// 1. `FormatConfig` construction/deserialization gains fallible validation
+//    of the `format`/`custom_rules` invariant:
+//    `format == GameFormat::Custom(id) ⟺ custom_rules == Some(rules) &&
+//    rules.id == id`. Every constructor (`from_lobby_config`, preset
+//    constructors, and the WASM/network deserialization boundary) goes
+//    through one `fn validate_custom_rules_consistency(&FormatConfig) ->
+//    Result<(), FormatConfigError>` check. A malformed value is rejected at
+//    the boundary — never constructed, never sent, never silently accepted
+//    — so nothing downstream needs to guard against it, and no consumer
+//    needs `.expect()`/`.unwrap()` on `custom_rules`.
+// 2. `sideboard_policy` becomes a STORED FIELD on `FormatConfig`
+//    (`pub sideboard_policy: SideboardPolicy`), computed once at
+//    construction — this MATCHES the existing pattern `uses_commander` and
+//    `supplies_fixed_deck` already use (both are stored fields on
+//    `FormatConfig`, computed at construction time and kept in sync by a
+//    dedicated test, `format.rs:1512`/`:1513` — confirmed this round, not
+//    assumed), not a new pattern invented for this feature. For built-in
+//    formats, construction sets it from `format.sideboard_policy()`; for
+//    `Custom`, from `custom_rules.structural.sideboard_policy` — same shape
+//    as how `uses_commander`/`supplies_fixed_deck` are already populated.
+// 3. Every call site above migrates from calling `.sideboard_policy()` /
+//    `.uses_commander()` on a bare `GameFormat` to reading the STORED FIELD
+//    on the `FormatConfig` (or `DeckCompatibilityRequest`) it already has —
+//    or, where the current signature only carries a bare `GameFormat`
+//    (`companion_offers`, `companion_starting_deck`,
+//    `DeckCompatibilityRequest.selected_format`), the signature widens to
+//    carry the resolved fields (either the whole `&FormatConfig`, or a
+//    small `ResolvedFormatFacts { uses_commander: bool, sideboard_policy:
+//    SideboardPolicy }` copy-type, whichever is less invasive at each call
+//    site — a per-site judgment call for implementation, not resolved here,
+//    but the fields themselves are already validated and computed by step 1
+//    regardless of which shape carries them).
+// 4. This list is the one confirmed by direct grep this session — treat it
+//    as the discovered floor, not a ceiling. Before implementation, run the
+//    same audit this repo's `add-engine-variant` skill already prescribes
+//    for any new enum variant: search for every consumer of `GameFormat`
+//    (not just these two methods) and confirm each one either doesn't need
+//    Custom-awareness (rare — most branch on behavior) or is migrated.
+//
+// `GameFormat::sideboard_policy(self)` and `GameFormat::uses_commander(self)`
+// themselves keep their exhaustive match over built-in variants; each gains
+// a `Custom(_) => unreachable!("read FormatConfig.sideboard_policy /
+// .uses_commander instead — GameFormat alone cannot resolve this")` arm,
+// documented as a guard against exactly the mistake round 3 made, not a
+// path any correct caller should reach.
 
 // Axis B — legality/era-rules. Genuinely new data; no existing UI surface.
 // This is what makes the four EC formats rules-correct; kept exactly as
@@ -283,18 +343,30 @@ LegalityRules {
 // since the ID itself carries no meaning once the full payload travels with
 // it.
 //
-// VERSION SKEW (flagged, not fully resolved here): an older client that has
-// never heard of the `GameFormat::Custom` enum variant at all cannot be
-// rescued by `#[serde(default)]` on `custom_rules` — the failure happens at
-// the enum-variant level during deserialization of `format: GameFormat`
-// itself, before any field-level default ever applies. This is the same
-// class of risk any new `GameFormat` variant already carries, but custom
-// formats make it far more frequent in practice (a new custom format can be
-// created at any time, not just at a client release). The lobby-join flow
-// needs an explicit compatibility check — reject with a clear "this game
-// needs a custom-format-capable client" message — rather than relying on
-// deserialization to fail gracefully. Not designed in depth here; flagged as
-// a real requirement for whoever implements the lobby-join handshake.
+// VERSION SKEW — CONCRETE MODEL (round 4, maintainer review point 4; rounds
+// 2-3 flagged this without designing it). An older client that has never
+// heard of the `GameFormat::Custom` enum variant at all cannot be rescued by
+// `#[serde(default)]` on `custom_rules` — the failure happens at the
+// enum-variant level during deserialization of `format: GameFormat` itself,
+// before any field-level default ever applies.
+//
+// This reuses EXISTING infrastructure rather than inventing a new
+// negotiation protocol: `server-core/src/protocol.rs` already defines
+// `PROTOCOL_VERSION` / `MIN_SUPPORTED_PROTOCOL` / `LOBBY_PROTOCOL_VERSION`
+// (currently `PROTOCOL_VERSION = 33`), checked at connection establishment
+// with its own doc comment stating it "refuses to proceed on mismatch" —
+// confirmed this session, not assumed. The fix: bump `PROTOCOL_VERSION` in
+// the same release that ships `GameFormat::Custom`. A client below the new
+// `MIN_SUPPORTED_PROTOCOL` is rejected at THIS EXISTING handshake gate,
+// before it ever attempts to deserialize a `FormatConfig` carrying a variant
+// it doesn't know — the same mechanism that already protects every other
+// protocol-breaking change, not a custom-format-specific negotiation layer.
+// This is deliberately narrower than "negotiate custom-format support as an
+// independent capability": it ties custom-format support to the same
+// coarse-grained protocol version every other breaking wire change already
+// uses, which is consistent with how this codebase handles compatibility
+// today rather than introducing a new, finer-grained capability-negotiation
+// concept alongside it.
 
 ReprintPolicy {                         // enum — enforceable today only at set-code granularity
     OriginalPrintingsOnly,              // 93-94 / Classic intent (see limitation)
@@ -338,20 +410,60 @@ ReprintPolicy {                         // enum — enforceable today only at se
 //       SpecificSet(SetCode),     // pin to one set's frame (e.g. "Alpha only" preset)
 //   }
 
+// REVISED per maintainer review round 4 (CONTEXT.md point 3): every axis
+// below is now a typed enum, not a bool — `legend_rule_scope` already was;
+// the other three are converted for consistency and because CLAUDE.md's
+// own bool-vs-enum principle applies here: each names a REAL two-value
+// historical space (a pre-removal form vs. the modern absence of the rule),
+// not an arbitrary on/off switch, and a typed variant is self-documenting at
+// every call site (`ManaBurnPolicy::Obsolete` reads correctly; `mana_burn:
+// true` requires the reader to already know which direction "true" points).
+// This mirrors `LegendRuleScope`'s existing shape rather than introducing a
+// new convention.
 LegacyRuleSet {                         // INDEPENDENT era-rule axes (RESEARCH §8, §10)
-    mana_burn: bool,
-    damage_uses_stack: bool,
-    pre_m10_wish_reaches_exile: bool,   // RESEARCH §9: Wishes reach owned face-up
-                                        // exile (pre-M10 "removed from the game").
-                                        // NOTE: renamed from the first-pass
-                                        // placeholder `pre_m10_wish_templating`
-                                        // — it is a functional POOL-SCOPE toggle,
-                                        // not a wording/templating change.
+    mana_burn: ManaBurnPolicy,
+    damage_timing: CombatDamageTiming,
+    wish_scope: WishOutsideGameScope,
     legend_rule_scope: LegendRuleScope, // RESEARCH §10: modern per-controller
                                         // (default) vs pre-M14 any-controller.
-                                        // A typed enum, NOT a bool (the historical
-                                        // space is not a clean binary and this
-                                        // leaves room without a later refactor).
+                                        // Already a typed enum since round 1 —
+                                        // the historical space is not a clean
+                                        // binary and this leaves room without
+                                        // a later refactor. Same reasoning now
+                                        // applied to the three siblings above.
+}
+
+ManaBurnPolicy {                        // RESEARCH §5
+    Modern,                             // no mana burn (removed post-M10). DEFAULT.
+    Obsolete,                            // life loss for unspent mana at real
+                                        // phase-group boundaries (§4's ManaExpiry
+                                        // design). EC/Swedish target era.
+}
+
+CombatDamageTiming {                    // RESEARCH §6
+    Modern,                             // CR 510.2: simultaneous, does not use
+                                        // the stack. DEFAULT.
+    OnStack,                            // pre-modern: combat damage was a
+                                        // triggered ability that used the
+                                        // stack, giving players a priority
+                                        // window between assignment and
+                                        // dealing. LARGE — see §4 and §8.
+}
+
+WishOutsideGameScope {                  // RESEARCH §9
+    PostM10SideboardOnly,               // modern CR 400.11/400.11a: "outside
+                                        // the game" is not a zone; only the
+                                        // sideboard is reachable. DEFAULT.
+    PreM10ReachesExile,                 // pre-M10: a Wish could retrieve an
+                                        // owned card that had been removed
+                                        // from the game (today's exile).
+                                        // Renamed from the first-pass
+                                        // placeholder name during round 1;
+                                        // canonical everywhere in this
+                                        // proposal, including RESEARCH.md
+                                        // (fixed this round — two stale
+                                        // references to the old name had
+                                        // survived there since round 1).
 }
 
 LegendRuleScope {                       // RESEARCH §10: legend-rule controller scope
@@ -413,6 +525,17 @@ independently-meaningful `FormatConfig` field), it must reject explicitly
 rather than silently drop data. The `CustomFormatId` this constructor
 allocates is the ad-hoc sentinel described above, not a registry-stable ID.
 
+**`sideboard_policy`'s specific source, made explicit (maintainer review
+round 4, point 2 — round 3 added the field but never stated this)**:
+`structural.sideboard_policy: config.format.sideboard_policy()`. This is a
+valid, direct call because `from_lobby_config`'s precondition is that
+`config.format` is always a BUILT-IN `GameFormat` at the moment this runs —
+saving a custom format FROM an already-custom format (re-saving a save) is
+out of scope for this design and not offered by the lobby UI; if that need
+ever arises it requires its own resolution path (reading the source's
+already-resolved `FormatConfig.sideboard_policy` field instead of calling
+the method), not assumed to fall out of this constructor for free.
+
 Both paths converge on the same `custom_rules: Option<CustomFormatRules>` field
 and the same `GameFormat::Custom(CustomFormatId)` variant — there is exactly
 one runtime representation of "a custom format," authored two different ways.
@@ -452,18 +575,27 @@ The four formats form an incremental chain. Express it with builder-style reuse,
 mirroring how `FormatConfig::pioneer()` spreads `..Self::standard()`:
 
 - `old_school_93_94()` — base: sets = [LEA, LEB, 2ED, CED, CEI, ARN, ATQ, 3ED,
-  LEG, DRK, FEM]; restricted = [22 names]; banned = [7 names]; legacy = {mana_burn}.
+  LEG, DRK, FEM]; restricted = [22 names]; banned = [7 names]; legacy =
+  `{ mana_burn: ManaBurnPolicy::Obsolete, ..default }` (damage timing and
+  Wish scope stay `Modern`/`PostM10SideboardOnly` — EC's 93-94 lists mana
+  burn as its only legacy exception).
 - `old_school_95()` — `let mut d = old_school_93_94(); d.legal_sets.extend([4ED,
   ICE, CHR, REN, HML]); d.restricted.extend([Demonic Consultation, Mana Crypt]);
   d.banned.extend([Amulet of Quoz, Timmerian Fiends]; legacy unchanged`.
 - `middle_school()` — sets = Fourth Edition..Scourge; restricted = []; banned =
-  [25 names]; reprint = AllowAnyPrinting; legacy = {mana_burn, damage_uses_stack,
-  pre_m10_wish_reaches_exile}.
+  [25 names]; reprint = AllowAnyPrinting; legacy = `{ mana_burn:
+  ManaBurnPolicy::Obsolete, damage_timing: CombatDamageTiming::OnStack,
+  wish_scope: WishOutsideGameScope::PreM10ReachesExile }`. **Per the
+  preset-readiness gate (§7, tightened this round): this preset may not be
+  registered until `CombatDamageTiming::OnStack` (§4/§6, LARGE) is fully
+  implemented — no partial/caveated exposure.**
 - `classic_magic()` — sets = Alpha..Scourge; restricted = [**44** names —
   corrected this round from a "37" mislabel; recounted directly against
-  RESEARCH.md's verbatim list]; banned =
-  [11 names]; reprint = OriginalPrintingsOnly; legacy = {mana_burn,
-  damage_uses_stack, pre_m10_wish_reaches_exile}.
+  RESEARCH.md's verbatim list]; banned = [11 names]; reprint =
+  OriginalPrintingsOnly; legacy = `{ mana_burn: ManaBurnPolicy::Obsolete,
+  damage_timing: CombatDamageTiming::OnStack, wish_scope:
+  WishOutsideGameScope::PreM10ReachesExile }`. **Same registration block as
+  Middle School** — not selectable until `CombatDamageTiming::OnStack` lands.
 
 Set codes must be verified against the engine's `set_catalog` (MTGJSON codes)
 during implementation — the codes above are the expected MTGJSON codes but
@@ -495,17 +627,19 @@ This reuses four existing helpers verbatim and adds only the set-membership +
 name-set sourcing. `GameFormat::Custom` gets one arm in
 `format_compatibility_check` routing to `evaluate_custom_format`.
 
-**Honest gap, flagged by maintainer review round 3 (CONTEXT.md point 5):**
+**Honest gap, flagged by maintainer review rounds 3 and 4 (CONTEXT.md point
+5; round 4 demanded a concrete resolution, not just a flag):**
 `rules.reprint_policy` is declared on `LegalityRules` but **not consumed by
 any step above** — a card passes step 2 based on legal-set membership alone,
-regardless of which `ReprintPolicy` the preset declares. This is the same gap
-as the already-flagged Open item 2 (printing/frame-data gap): real
-enforcement needs the engine-vs-frontend printing cross-reference that item
-already describes, not new work invented here. Per the new preset-readiness
-rule (CONTEXT.md point 5, §7): no preset may be registered as selectable
-while declaring a `ReprintPolicy` this algorithm doesn't enforce — this
-blocks `swedish_old_school()` specifically until Open items 2 and 6 resolve
-(see §7).
+regardless of which `ReprintPolicy` the preset declares. Per the tightened
+preset-readiness gate (§7), no preset may register while declaring a
+`ReprintPolicy` this algorithm doesn't enforce. Two independent resolution
+paths, either sufficient (§7 has the full reasoning): the general
+engine-vs-frontend printing cross-reference (Open item 2) landing, or a
+one-preset verification pass confirming no problematic reprints exist within
+that specific preset's `legal_sets` window. This blocks `swedish_old_school()`
+specifically until one of those two paths completes, plus Open item 6
+(reprint-policy value itself unconfirmed).
 
 `legality_format()` returns `None` for `Custom` (no `LegalityFormat` mapping —
 custom formats don't use the external legality table). `label`, `for_format`,
@@ -602,28 +736,39 @@ correct plan for phase 2's four EC-format presets.
   and clearing-logic wiring, not just a life-loss check at an existing call
   site) but still small and, critically, reuses a proven pattern rather than
   adding a new one.
-- **Pre-M10 Wish exile access** (`pre_m10_wish_reaches_exile`): fully traced in
-  RESEARCH §9. This is a REAL functional difference (not wording-only): pre-M10,
-  the "removed from the game" zone counted as *outside the game*, so a Wish could
-  retrieve an owned card that had been removed from the game (modern: exile); the
-  M10 update (CR 400.11/400.11a — "outside the game is not a zone"; only the
-  sideboard is outside the game) removed this. The engine already implements the
-  modern (post-M10) Wish cycle generically as `Effect::SearchOutsideGame` with
-  `source_pool: OutsideGameSourcePool::Sideboard` (`types/ability.rs:246`), and
-  already implements owned-face-up-exile retrieval for the Karn/Coax class via
+- **Pre-M10 Wish exile access** (`wish_scope: WishOutsideGameScope`, renamed
+  from the placeholder `pre_m10_wish_reaches_exile` bool during round 1 —
+  same field, now typed): fully traced in RESEARCH §9. This is a REAL
+  functional difference (not wording-only): pre-M10, the "removed from the
+  game" zone counted as *outside the game*, so a Wish could retrieve an
+  owned card that had been removed from the game (modern: exile); the M10
+  update (CR 400.11/400.11a — "outside the game is not a zone"; only the
+  sideboard is outside the game) removed this. The engine already
+  implements the modern (post-M10) Wish cycle generically as
+  `Effect::SearchOutsideGame` with `source_pool:
+  OutsideGameSourcePool::Sideboard` (`types/ability.rs:246`), and already
+  implements owned-face-up-exile retrieval for the Karn/Coax class via
   `OutsideGameSourcePool::SideboardAndFaceUpExile` + the tested
-  `collect_face_up_exile_candidates` collector and `put_face_up_exile_into` mover
-  (`game/effects/search_outside_game.rs:72,105,141`). **SMALL** (revise the prior
-  "Medium"): the only change is a one-line pool-widening at the existing resolver
-  hook (`search_outside_game.rs:72`) — when the flag on
-  `GameState.format_config` (`types/game_state.rs:6787`) is set, treat a
-  `Sideboard`-pool search as if it were `SideboardAndFaceUpExile`. No parser
-  change (the flag is a runtime-resolution concern, not a parse concern), no new
-  effect/state/WaitingFor, full reuse of the tested collector/mover. Annotate as
-  a legacy rule reverting the M10 change (cite CR 400.11 / 400.11a / 701.23j).
-- **Damage uses the stack** (`damage_uses_stack`): LARGE (RESEARCH §6). Its own
-  sub-project; likely out of MVP. Gated by the flag so Middle School / Classic
-  are playable without it (with a documented fidelity caveat) until it lands.
+  `collect_face_up_exile_candidates` collector and `put_face_up_exile_into`
+  mover (`game/effects/search_outside_game.rs:72,105,141`). **SMALL**
+  (revise the prior "Medium"): the only change is a one-line pool-widening
+  at the existing resolver hook (`search_outside_game.rs:72`) — when
+  `wish_scope == PreM10ReachesExile` on `GameState.format_config`
+  (`types/game_state.rs:6787`), treat a `Sideboard`-pool search as if it
+  were `SideboardAndFaceUpExile`. No parser change (this is a
+  runtime-resolution concern, not a parse concern), no new
+  effect/state/WaitingFor, full reuse of the tested collector/mover.
+  Annotate as a legacy rule reverting the M10 change (cite CR 400.11 /
+  400.11a / 701.23j).
+- **Combat damage timing** (`damage_timing: CombatDamageTiming`, renamed
+  from `damage_uses_stack: bool` this round): LARGE (RESEARCH §6). Its own
+  sub-project. **Per the tightened preset-readiness gate (§7, maintainer
+  review round 4, point 3): no preset may register while declaring
+  `CombatDamageTiming::OnStack` until this fully lands — there is no
+  "playable with a caveat" tier.** This is a real, meaningful timeline
+  consequence: Middle School and Classic Magic (both require `OnStack`) are
+  blocked from ever being selectable until this LARGE item ships, not
+  available-with-a-caveat in the interim as the original sequencing implied.
 - **Legend-rule scope** (`legend_rule_scope`): SMALL (RESEARCH §10). The pre-M14
   form is *simpler* than the modern one — global (group same-named legendaries
   across all controllers, no `obj.controller == player_id` filter) and choiceless
@@ -667,7 +812,7 @@ legality logic on the client.
 - **Mana burn — pool persistence AND life loss** (revised again — maintainer
   review round 3, CONTEXT.md point 1; round 2's version only tested the
   life-loss gate and would have passed against the wrong mechanism):
-  - With `LegacyRuleSet.mana_burn` set, unspent mana added during
+  - With `mana_burn: ManaBurnPolicy::Obsolete`, unspent mana added during
     `DeclareAttackers` must still be present (not dropped, no life loss) at
     `DeclareBlockers` (a transition WITHIN `PhaseGroup::Combat`) — asserts
     the pool itself persists via `ManaExpiry::EndOfPhaseGroup`, not just that
@@ -687,19 +832,45 @@ legality logic on the client.
     actually dropped after that choice resolves, proving the life-loss
     application reuses the pipeline's existing pause/resume point rather
     than computing before the choice is known.
-- **`FormatConfig::sideboard_policy()` accessor** (new — maintainer review
-  round 3, CONTEXT.md point 2): a `Custom`-format `FormatConfig` with
-  `structural.sideboard_policy: Forbidden` must make `deck_loading.rs`'s
-  sideboard-dropping behavior and `match_flow.rs`'s max-sideboard-size
-  computation both observe `Forbidden` via the new accessor — a regression
-  test pinned to the two migrated call sites specifically, not just the
-  accessor's return value in isolation, so a future revert of the migration
-  (reverting to `.format.sideboard_policy()`) fails visibly.
+- **Fallible `custom_rules` validation, not `.expect()`** (new — maintainer
+  review round 4, CONTEXT.md point 1; supersedes round 3's accessor-only
+  test): a `FormatConfig` with `format: GameFormat::Custom(id)` and
+  `custom_rules: None` must be REJECTED by
+  `validate_custom_rules_consistency` at construction/ingestion, not
+  accepted and later panic wherever `sideboard_policy`/`uses_commander` is
+  read. Same for `custom_rules: Some(rules)` where `rules.id != id`. Both
+  are constructed-then-rejected cases, proving the invariant is enforced at
+  the boundary, not merely documented.
+- **Every real consumer reads the resolved `FormatConfig` field, not the
+  bare-`GameFormat` method** (new — maintainer review round 4, expanding
+  round 3's two-call-site test to the full audited list): for a `Custom`
+  format with `sideboard_policy: Forbidden`, assert `deck_loading.rs`'s
+  sideboard-dropping, `match_flow.rs`'s max-sideboard-size, AND
+  `companion.rs`'s `companion_offers` sideboard-slot branch (the consumer
+  round 3 missed and maintainer review round 4 caught directly) all observe
+  `Forbidden` — three call sites pinned specifically, not just the field's
+  value in isolation, so a future regression to any one of them fails
+  visibly. Same shape for `uses_commander` across its own five real
+  call sites (§1's audit list).
 - **`uses_commander` requires both conditions** (new — maintainer review
   round 3, CONTEXT.md point 4): `command_zone: true` alone (no threshold) and
   `commander_damage_threshold: Some(_)` alone (no command zone) both derive
   `uses_commander: false`; only both together derive `true` — the exact
   mismatched-combination cases the review asked for.
+- **Preset-readiness gate is actually enforced, not just documented** (new —
+  maintainer review round 4, CONTEXT.md point 5 / "no caveated exposure"): a
+  synthetic preset declaring `damage_timing: CombatDamageTiming::OnStack`
+  before that engine support exists must be rejected by the registry/format
+  list at registration time (not merely "not recommended in a doc comment")
+  — the concrete test that proves `middle_school()`/`classic_magic()` cannot
+  silently become selectable by a future author who skips reading §7.
+- **Protocol-version compatibility** (new — maintainer review round 4,
+  CONTEXT.md point 4, version-skew design): a client below the
+  bumped `MIN_SUPPORTED_PROTOCOL` is rejected at the existing hello/handshake
+  gate when the host's `FormatConfig.format` is `Custom` — reusing whatever
+  test harness already covers `protocol_version` mismatch rejection
+  (`server-core/src/protocol.rs`'s existing tests), extended with a
+  Custom-format case rather than a new mechanism.
 - Serde round-trip of `FormatConfig` with `Some(custom_rules)` and `None`.
 - `CustomFormatDef::from_lobby_config`: a `FormatConfig` with non-default
   `starting_life`/`max_players`/`deck_size`/`range_of_influence`/`team_based`/
@@ -753,18 +924,37 @@ legacy rules) is unaffected in scope or design — this only changes what ships
 *first* and *how a player reaches Axis A*, not what Axis B needs to be
 correct.
 
-**Preset-readiness gate (new — maintainer review round 3, CONTEXT.md point
-5).** A preset (Axis B typed constructor OR an Axis A lobby save that sets
-non-default `legality`) must not be registered/exposed as a selectable format
-until every legality/legacy field it declares is BOTH fully specified AND
-actually consumed by the evaluator/engine at an authoritative seam — not
-merely present as a struct field. This is a general rule, not a one-off:
+**Preset-readiness gate (introduced round 3, TIGHTENED round 4 — CONTEXT.md
+points 5 and, this round, the "no caveated exposure" rule from maintainer
+review round 4 point 3).** A preset (Axis B typed constructor OR an Axis A
+lobby save that sets non-default `legality`) must not be registered/exposed
+as a selectable format until every legality/legacy field it declares is BOTH
+fully specified AND actually consumed by the evaluator/engine at an
+authoritative seam — not merely present as a struct field. **Round 4
+tightens this further: there is no intermediate "playable with a fidelity
+caveat" state.** A preset is either fully correct for every axis it declares,
+or it does not appear as a selectable format at all. This directly overrides
+this document's own earlier "Middle School / Classic Magic are
+playable-with-caveat until damage-on-stack lands" framing (§4, §8) — that
+framing is retracted, not merely superseded.
 - `swedish_old_school()` (phase 1) is currently BLOCKED from registration by
-  this rule: it declares a `ReprintPolicy`, which §3 confirms is not yet
-  enforced, and CONTEXT.md's Open item 6 confirms the specific policy value
-  is itself unconfirmed against the primary source. Both must resolve before
-  this preset ships as selectable, even though the engine-level schema and
-  evaluator work (§1, §3) can and should land first.
+  this rule on TWO independent grounds: it declares a `ReprintPolicy`, which
+  §3 confirms is not yet enforced by the evaluator at all, and CONTEXT.md's
+  Open item 6 confirms the specific policy value is itself unconfirmed
+  against the primary source. **Resolution path — either is sufficient**:
+  (a) Open item 2's general engine-vs-frontend printing cross-reference
+  lands, making `ReprintPolicy` enforcement real for every preset at once; or
+  (b) a preset-specific verification pass confirms Swedish Old School's
+  particular restricted-list cards have no problematic reprints *within its
+  own `legal_sets` window* that plain legal-set membership wouldn't already
+  exclude — a materially smaller, one-preset check that could unblock this
+  specific preset without waiting on the general system. Neither path is
+  assumed to succeed without doing it; this document does not assert the
+  gap is moot for Swedish specifically without that verification.
+- `middle_school()` and `classic_magic()` (phase 2) are BLOCKED from
+  registration until `CombatDamageTiming::OnStack` (§4, LARGE) is fully
+  implemented — both declare it, and per the no-caveated-exposure rule
+  neither may register while any declared axis is unimplemented.
 - No phase-2 EC preset may declare `LegendRuleScope::PreM14AnyController`
   until the historical conflation flagged in CONTEXT.md/RESEARCH.md resolves.
   Moot today (all four EC presets default this to `Modern`), but binding on
@@ -802,17 +992,25 @@ first.
 **Phase 2 — the four EC formats + the legacy-rules engine work they need.**
 Ships once phase 1 has proven the schema and both axes end-to-end.
 
-4. **Four EC formats as data (Axis B)** — the four `CustomFormatDef`
-   constructors + registry entries + preset-integrity tests (§2).
-5. **Mana burn** — `LegacyRuleSet.mana_burn` at the drop-site hook. Small.
-   Enables full fidelity for 93-94 / 95 and partial for Middle School / Classic.
-6. **Pre-M10 Wish exile access** (`pre_m10_wish_reaches_exile`) — SMALL
-   (RESEARCH §9); one-line pool-widening at `search_outside_game.rs:72`, gated by
-   the flag, reusing the existing tested face-up-exile collector/mover. Can land
-   with or just after mana burn (step 5).
-7. **Damage uses the stack** — LARGE; its own sub-project; likely post-MVP
-   even within phase 2. Middle School / Classic are playable-with-caveat
-   until it lands.
+4. **`old_school_93_94()` / `old_school_95()` as data (Axis B)** — these two
+   `CustomFormatDef` constructors + registry entries + preset-integrity
+   tests (§2). **Registerable once step 5 (mana burn) lands** — neither
+   needs `CombatDamageTiming::OnStack`, so neither is blocked by step 7.
+5. **Mana burn** — `LegacyRuleSet.mana_burn` (`ManaBurnPolicy`) at the
+   transition/empty-pool seam (§4's `ManaExpiry::EndOfPhaseGroup` design).
+   Small. Unlocks step 4's registration.
+6. **Pre-M10 Wish exile access** (`wish_scope: WishOutsideGameScope`) —
+   SMALL (RESEARCH §9); one-line pool-widening at
+   `search_outside_game.rs:72`, gated by the enum value, reusing the
+   existing tested face-up-exile collector/mover. Can land with or just
+   after mana burn (step 5).
+7. **Combat damage timing (`CombatDamageTiming::OnStack`)** — LARGE; its own
+   sub-project; likely the last thing to land in phase 2. **Per the
+   tightened preset-readiness gate (§7): `middle_school()` and
+   `classic_magic()`'s `CustomFormatDef` constructors and tests can be
+   written and land in source alongside step 4, but neither may be
+   registered/exposed as selectable until this step is fully done — no
+   "playable with a caveat" interim state.**
 8. **Eternal Chaos (stretch)** — depends on 93-94 existing (step 4) **plus** a
    genuinely new in-match pack-opening mechanic (Booster Tutor / Opening
    Ceremony / Summon the Pack + tutor-from-opened-packs errata + pack-based

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -241,6 +241,28 @@ StructuralRules {
 //    the boundary — never constructed, never sent, never silently accepted
 //    — so nothing downstream needs to guard against it, and no consumer
 //    needs `.expect()`/`.unwrap()` on `custom_rules`.
+//
+//    **Widened this round (caught by an automated review pass, and a real
+//    finding, not overreach — see below): `sideboard_policy` and
+//    `uses_commander` are PLAIN serialized fields on `FormatConfig` today
+//    (confirmed: `#[serde(default)]` on `supplies_fixed_deck`, no field has
+//    `#[serde(skip)]`), meaning a hand-crafted or corrupted wire payload
+//    could already set `format: GameFormat::Commander` with
+//    `uses_commander: false` and nothing validates the two agree — for
+//    BUILT-IN formats, today, before this proposal touches anything. Adding
+//    a Custom-only consistency check would leave that pre-existing gap
+//    exactly as wide as it already is, just alongside a narrower one for
+//    Custom. Since this validation function is the natural place to close
+//    it, `validate_custom_rules_consistency` checks derived-field agreement
+//    for EVERY format, not only `Custom`: `sideboard_policy ==
+//    (match format { Custom(_) => custom_rules.structural.sideboard_policy,
+//    other => other.sideboard_policy() })`, and the equivalent for
+//    `uses_commander` and `supplies_fixed_deck`. This is a small, genuine
+//    improvement to existing behavior that falls out of building the
+//    Custom-format check correctly, not scope creep invented for its own
+//    sake — flag it to whoever reviews the implementation as a
+//    pre-existing-gap fix bundled with new work, in case that combination
+//    needs its own sign-off.
 // 2. `sideboard_policy` becomes a STORED FIELD on `FormatConfig`
 //    (`pub sideboard_policy: SideboardPolicy`), computed once at
 //    construction — this MATCHES the existing pattern `uses_commander` and
@@ -253,16 +275,23 @@ StructuralRules {
 //    as how `uses_commander`/`supplies_fixed_deck` are already populated.
 // 3. Every call site above migrates from calling `.sideboard_policy()` /
 //    `.uses_commander()` on a bare `GameFormat` to reading the STORED FIELD
-//    on the `FormatConfig` (or `DeckCompatibilityRequest`) it already has —
-//    or, where the current signature only carries a bare `GameFormat`
-//    (`companion_offers`, `companion_starting_deck`,
-//    `DeckCompatibilityRequest.selected_format`), the signature widens to
-//    carry the resolved fields (either the whole `&FormatConfig`, or a
-//    small `ResolvedFormatFacts { uses_commander: bool, sideboard_policy:
-//    SideboardPolicy }` copy-type, whichever is less invasive at each call
-//    site — a per-site judgment call for implementation, not resolved here,
-//    but the fields themselves are already validated and computed by step 1
-//    regardless of which shape carries them).
+//    on the `FormatConfig` it already has. Two shapes, not a free per-site
+//    choice (tightened this round — a real distinction, not overreach):
+//    - `companion_offers` / `companion_starting_deck` genuinely only need
+//      the two derived facts (`uses_commander`, `sideboard_policy`), not the
+//      full ruleset — a small `ResolvedFormatFacts { uses_commander: bool,
+//      sideboard_policy: SideboardPolicy }` copy-type is the right, minimal
+//      widening for these two.
+//    - `DeckCompatibilityRequest.selected_format` is DIFFERENT: its own
+//      dispatch `match` routes to `evaluate_custom_format` (§3) for
+//      `Custom`, which needs `legal_sets`/`banned`/`restricted` — the FULL
+//      `CustomFormatRules`, not just two derived booleans. A facts-only
+//      struct would leave this call site unable to actually evaluate
+//      Custom-format deck legality at all. This request struct needs either
+//      the whole `&FormatConfig` or an explicit
+//      `custom_rules: Option<CustomFormatRules>` field alongside
+//      `selected_format`, resolved via a validated registry/config lookup
+//      before Custom dispatch — not the lighter facts struct.
 // 4. This list is the one confirmed by direct grep this session — treat it
 //    as the discovered floor, not a ceiling. Before implementation, run the
 //    same audit this repo's `add-engine-variant` skill already prescribes
@@ -352,21 +381,29 @@ LegalityRules {
 //
 // This reuses EXISTING infrastructure rather than inventing a new
 // negotiation protocol: `server-core/src/protocol.rs` already defines
-// `PROTOCOL_VERSION` / `MIN_SUPPORTED_PROTOCOL` / `LOBBY_PROTOCOL_VERSION`
-// (currently `PROTOCOL_VERSION = 33`), checked at connection establishment
-// with its own doc comment stating it "refuses to proceed on mismatch" —
-// confirmed this session, not assumed. The fix: bump `PROTOCOL_VERSION` in
-// the same release that ships `GameFormat::Custom`. A client below the new
-// `MIN_SUPPORTED_PROTOCOL` is rejected at THIS EXISTING handshake gate,
-// before it ever attempts to deserialize a `FormatConfig` carrying a variant
-// it doesn't know — the same mechanism that already protects every other
-// protocol-breaking change, not a custom-format-specific negotiation layer.
-// This is deliberately narrower than "negotiate custom-format support as an
-// independent capability": it ties custom-format support to the same
-// coarse-grained protocol version every other breaking wire change already
-// uses, which is consistent with how this codebase handles compatibility
-// today rather than introducing a new, finer-grained capability-negotiation
-// concept alongside it.
+// `PROTOCOL_VERSION` / `MIN_SUPPORTED_PROTOCOL` (currently
+// `PROTOCOL_VERSION = 33`) AND a SEPARATE `LOBBY_PROTOCOL_VERSION` /
+// `MIN_SUPPORTED_LOBBY_PROTOCOL` pair — its own doc comment states this is
+// "the wire version of the lobby message set, independent of
+// `PROTOCOL_VERSION`" (confirmed this session, not assumed). Both are
+// checked at their respective handshakes with a "refuses to proceed on
+// mismatch" doc comment.
+//
+// **Bump BOTH, not just `PROTOCOL_VERSION`** (caught by an automated review
+// pass — a real refinement, not just style): format selection itself
+// happens during LOBBY setup, before a game's `FormatConfig` ever crosses
+// the general game-state wire, so `LOBBY_PROTOCOL_VERSION` /
+// `MIN_SUPPORTED_LOBBY_PROTOCOL` is the handshake that actually needs to
+// reject an incompatible client — an old broker/client could otherwise get
+// past the lobby handshake and only fail later, at general `FormatConfig`
+// deserialization, with a worse failure mode than a clean upfront rejection.
+// Bump `PROTOCOL_VERSION` too, since a custom format's resolved
+// `CustomFormatRules` payload does cross the general game-state wire once
+// the game itself starts. The fix: bump both constants in the same release
+// that ships `GameFormat::Custom`, using the existing lobby-handshake and
+// general-handshake validation symbols exactly as they already work for
+// every other breaking wire change — not a new, custom-format-specific
+// negotiation layer.
 
 ReprintPolicy {                         // enum — enforceable today only at set-code granularity
     OriginalPrintingsOnly,              // 93-94 / Classic intent (see limitation)
@@ -443,11 +480,14 @@ ManaBurnPolicy {                        // RESEARCH §5
 CombatDamageTiming {                    // RESEARCH §6
     Modern,                             // CR 510.2: simultaneous, does not use
                                         // the stack. DEFAULT.
-    OnStack,                            // pre-modern: combat damage was a
-                                        // triggered ability that used the
-                                        // stack, giving players a priority
-                                        // window between assignment and
-                                        // dealing. LARGE — see §4 and §8.
+    OnStack,                            // pre-modern (pre-6th-edition): assigned
+                                        // combat damage was itself placed ON
+                                        // THE STACK as a stack object — NOT a
+                                        // triggered ability — giving players a
+                                        // priority window between assignment
+                                        // and dealing before it resolved. A
+                                        // reversal of CR 510.2's control flow.
+                                        // LARGE — see §4 and §8.
 }
 
 WishOutsideGameScope {                  // RESEARCH §9
@@ -944,6 +984,21 @@ or it does not appear as a selectable format at all. This directly overrides
 this document's own earlier "Middle School / Classic Magic are
 playable-with-caveat until damage-on-stack lands" framing (§4, §8) — that
 framing is retracted, not merely superseded.
+
+**This must be a technical gate, not a documented convention (sharpened by
+an automated review pass — correct to push on, since "don't register it, per
+this doc" is not itself an enforcement mechanism a future author is bound
+by).** `custom_format_registry()` — the function `custom_format_registry() ->
+Vec<CustomFormatDef>` already named in §1 — validates every preset it would
+return against a small static capability table (e.g. `const
+IMPLEMENTED_LEGACY_AXES: &[...]`, populated as each axis in §4 actually
+lands) BEFORE including it in the returned list. A preset declaring an axis
+not yet in that table is dropped from the registry (or the registry
+construction fails a debug assertion / startup check, implementation's
+choice) — a future author who adds `middle_school()` before
+`CombatDamageTiming::OnStack` lands gets a build-time or startup-time
+failure, not a silently-ignored doc-comment warning. This is the concrete
+mechanism §6's "actually enforced, not just documented" test targets.
 - `swedish_old_school()` (phase 1) is currently BLOCKED from registration by
   this rule on TWO independent grounds: it declares a `ReprintPolicy`, which
   §3 confirms is not yet enforced by the evaluator at all, and CONTEXT.md's

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -382,6 +382,77 @@ LegalityRules {
 // since the ID itself carries no meaning once the full payload travels with
 // it.
 //
+// RUNTIME DISPLAY IDENTITY (round 9, maintainer review) — the gap: §7's
+// claim below ("`label`, `for_format`, etc. each get a `Custom` arm reading
+// the resolved def") is WRONG for an Axis-A save, and the two functions'
+// signatures make it wrong in two DIFFERENT ways, not one:
+//   - `GameFormat::label(self) -> &'static str` (crates/engine/src/types/
+//     format.rs:395) cannot return owned, per-save `String` data (`label`
+//     on `CustomFormatDef`, round 6) from a `&'static str`-returning
+//     function no matter what's threaded in — this is a signature problem,
+//     not just a missing-context problem.
+//   - Even with the right signature, there is no "the resolved def" to read
+//     for Axis A specifically: (a) above already establishes
+//     `SavedCustomFormat.name` is client-local-only and never enters
+//     `CustomFormatRules`/`FormatConfig.custom_rules`, so a peer holding a
+//     live `GameState` mid-match has ONLY the rules payload — no name, no
+//     lookup key back to the saving client's local storage. This is
+//     different from Axis B: a registry-backed preset's `GameFormat::
+//     Custom(id)` carries a STABLE id every peer's `custom_format_registry()`
+//     already has an entry for (see (a)/(b) above), so a real name IS
+//     resolvable there without transporting anything extra.
+//
+// RESOLUTION — axis-differentiated, no new wire surface (Matt's option (b),
+// not (a) — deliberately, not by default): adding a `custom_label` field to
+// `FormatConfig` would re-open the exact wire-compatibility/version-skew
+// surface round 1's CodeRabbit pass and this section's VERSION SKEW note
+// already treat as a real cost, for a purely cosmetic value. Axis A's own
+// design already decided the engine "never learns about 'saved format #3'"
+// (above) — extending that same boundary to the display NAME, not just the
+// identity, is the consistent reading of that decision, not a new one:
+//   - `GameFormat::label(self) -> Cow<'static, str>` (signature change,
+//     REQUIRED regardless of axis, since `CustomFormatDef.label: String` can
+//     never satisfy `&'static str`): built-in variants return
+//     `Cow::Borrowed(...)` unchanged — zero behavior change for all 21
+//     existing variants. `Custom(id)`: look up `custom_format_registry()` by
+//     `id`; a HIT (Axis B) returns `Cow::Owned(def.label.clone())` — the
+//     real preset name, genuinely resolvable, no transport gap. A MISS
+//     (Axis A's ad-hoc sentinel id, never registered) returns
+//     `Cow::Borrowed("Custom Format")` — a fixed, honest, generic runtime
+//     label. The real player-chosen name stays exactly where round 2 always
+//     said it lives: the local `SavedCustomFormat`/lobby picker, never
+//     promised at runtime for an ad-hoc save. `short_label`/`description`
+//     need NO equivalent fix — both are registry/picker-time-only data (§2's
+//     `custom_format_registry()` → frontend picker), never read by a
+//     runtime engine function the way `label`/`for_format` are; this gap is
+//     specific to those two pre-existing bare-`GameFormat` functions, not a
+//     property of display metadata in general.
+//   - **Second, independently-found instance of the same root cause**:
+//     `FormatConfig::for_format(format: GameFormat) -> Self`
+//     (`format.rs:1056`) has exactly two real callers today, both in
+//     `deck_validation.rs` (lines 1075, 2256 — confirmed by direct grep this
+//     round, not assumed from the doc comment's claimed "lobby broker"
+//     caller, which does not exist anywhere in the codebase today; flag
+//     that stale doc comment for correction too), both reading
+//     `.deck_size` off the returned default config. For `Custom`, `for_format`
+//     has the identical problem as `label` did before round 3/4's
+//     `sideboard_policy`/`uses_commander` fix: a bare id has no default
+//     structural rules to reconstruct (Axis A has none at all; Axis B's are
+//     real but `for_format`'s own doc comment already accepts "customizations
+//     not recovered" for built-ins, so a registry-default lookup would be a
+//     silently-approximate answer for a value — `deck_size` — that's supposed
+//     to be exact for deck-legality gating). Fix identically to
+//     `sideboard_policy`: `for_format` gains a `Custom(_) => unreachable!("for_format
+//     cannot resolve an ad-hoc Custom format's deck_size — read
+//     custom_rules.structural.deck_size from the resolved request/config
+//     instead")` arm, and both `deck_validation.rs` call sites migrate to
+//     prefer `request.custom_rules.as_ref().map(|r|
+//     usize::from(r.structural.deck_size))` when present, falling back to
+//     `for_format` only for genuine built-in formats — the exact same
+//     two-tier shape §1's `sideboard_policy` fix already established for
+//     `DeckCompatibilityRequest`, extended to cover `deck_size` (a site the
+//     original round-4 audit's line list did not separately enumerate).
+//
 // VERSION SKEW — CONCRETE MODEL (round 4, maintainer review point 4; rounds
 // 2-3 flagged this without designing it). An older client that has never
 // heard of the `GameFormat::Custom` enum variant at all cannot be rescued by
@@ -866,12 +937,24 @@ missing-enforcement gap on a rules field, which is exactly the contradiction
 round 6 caught.
 
 `legality_format()` returns `None` for `Custom` (no `LegalityFormat` mapping —
-custom formats don't use the external legality table). `label`, `for_format`,
-etc. each get a `Custom` arm reading the resolved def. `sideboard_policy` is
-the one exception to "add a `Custom` arm on the `GameFormat` method" — see the
-dedicated accessor design in §1: the correct arm lives on `FormatConfig::
-sideboard_policy()`, not on `GameFormat::sideboard_policy()` itself, since the
-latter has no access to `custom_rules`.
+custom formats don't use the external legality table). **REVISED — round 9,
+maintainer review; the previous text here ("`label`, `for_format`, etc. each
+get a `Custom` arm reading the resolved def") was wrong and is retracted, not
+refined — see §1's "Runtime display identity" for why "the resolved def" does
+not exist to read at runtime for an Axis-A save.** `sideboard_policy` and
+`uses_commander` are NOT "add a `Custom` arm on the `GameFormat` method" —
+the correct arm lives on `FormatConfig::sideboard_policy()`, not
+`GameFormat::sideboard_policy()`, since the latter has no access to
+`custom_rules` (§1). `label` and `for_format` follow the same "the bare enum
+cannot resolve this" shape, generalized: `label` becomes
+`Cow<'static, str>`-returning with a registry-lookup-or-generic-fallback
+`Custom` arm (§1), and `for_format` gets the same `unreachable!()` guard
+`sideboard_policy`/`uses_commander` already use, with its two real callers
+migrated to read `custom_rules.structural.deck_size` directly (§1). No
+`GameFormat` method gains a `Custom` arm that "reads the resolved def" — none
+of them have one to read; every fix here is either a registry lookup keyed
+by a stable id (Axis B only) or a caller migration to a type that actually
+carries `custom_rules` (both axes).
 
 ## 4. Legacy rules wiring — Phase 2 (not needed for the Swedish Old School preset)
 
@@ -1147,6 +1230,37 @@ legality logic on the client.
   `derive_structural_description` produces a non-empty, config-derived
   string for at least two distinct `StructuralRules` values (proving it
   actually reads the config rather than returning a constant).
+- **NEW — maintainer review round 9 (runtime display identity, §1)**:
+  - `GameFormat::label()` for a registry-backed Axis-B id (e.g.
+    `old_school_93_94()`'s id) returns `Cow::Owned` matching that preset's
+    real `CustomFormatDef.label` — proving the registry lookup actually
+    fires, not just that the function compiles.
+  - `GameFormat::label()` for an Axis-A sentinel id (never present in
+    `custom_format_registry()`) returns exactly `"Custom Format"` — the
+    documented generic fallback, not a panic, not an empty string, and
+    critically NOT the saving player's original chosen name (proving the
+    boundary is actually honored, since silently leaking the name back in
+    would look like a fix while re-opening the exact "resolved def doesn't
+    exist here" gap this round closes).
+    `GameFormat::label()` for every existing built-in variant still returns
+    the identical `&'static str` value as before this change (a
+    `Cow::Borrowed` equality check against the pre-round-9 constants) —
+    proving the signature change is genuinely behavior-preserving for the
+    21 existing variants, not just source-compatible.
+  - `FormatConfig::for_format(GameFormat::Custom(_))` — a dedicated test
+    asserting this panics via the documented `unreachable!()` (matching the
+    existing `sideboard_policy`/`uses_commander` guard-arm test pattern,
+    §1/§3), i.e. proving no caller path can silently receive a
+    wrong-but-plausible default `deck_size` for a Custom format.
+  - `evaluate_selected_format`'s deck-size check (`deck_validation.rs:1075`
+    and the sibling call at `:2256`) with a `DeckCompatibilityRequest`
+    carrying `custom_rules` for an Axis-A lobby save with `deck_size: 30`
+    (a value distinct from every built-in format's — confirmed by direct
+    check against `format.rs`'s constructors, which range over 40/50/60/100
+    only) rejects a 60-card deck sized to the default `for_format` would
+    otherwise silently fall back to — the concrete regression test for the
+    deck-size correctness bug this round's audit found, not just the
+    display-label issue Matt's review text quoted.
 
 ## 7. Delivery surface — RESOLVED via maintainer input, see CONTEXT.md "Maintainer input"
 

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -964,17 +964,34 @@ mirroring how `FormatConfig::pioneer()` spreads `..Self::standard()`:
   (RESEARCH.md §1) and the engine enforces only set-code membership (§1's
   round-12 note); `description` MUST state this (e.g. "Legality is approximated
   at the set-code level; original-printing frame/foil is not enforced.").
-- `old_school_95()` — `let mut d = old_school_93_94(); d.legal_sets.get_or_insert_with(Vec::new).extend([4ED,
-  ICE, CHR, REN, HML]); d.restricted.extend([Demonic Consultation, Mana Crypt]);
-  d.banned.extend([Amulet of Quoz, Timmerian Fiends]; legacy unchanged`. **Fixed
-  this round (maintainer review, CodeRabbit finding): `legal_sets` is
-  `Option<Vec<SetCode>>` (§1), not a bare `Vec` — `.extend()` cannot be called
-  on it directly. `get_or_insert_with(Vec::new)` extends the base's `Some(...)`
-  vector in place (its only legal state per `old_school_93_94()`'s own
-  construction — a restricted-pool preset never leaves this `None`) while
-  still being correct if a future refactor ever changed that invariant, rather
-  than assuming it silently.** `printing_fidelity`: inherited `SetCodeApproximation`
-  from the base `d` — same source requirement, same enforcement gap.
+- `old_school_95()` — `let mut d = old_school_93_94();
+  d.rules.legality.legal_sets.get_or_insert_with(Vec::new).extend([4ED, ICE,
+  CHR, REN, HML]); d.rules.legality.restricted.extend([Demonic Consultation,
+  Mana Crypt]); d.rules.legality.banned.extend([Amulet of Quoz, Timmerian
+  Fiends]); legacy unchanged`. **Fixed this round (maintainer review): two
+  independent bugs in the earlier sketch, both against §1's own declared
+  schema —**
+  1. **Nesting.** `legal_sets`/`restricted`/`banned` are not fields on
+     `CustomFormatDef` (`d`) at all — they live at `d.rules.legality.*`
+     (`CustomFormatDef.rules: CustomFormatRules`, `CustomFormatRules.legality:
+     LegalityRules`, §1). The prior sketch accessed `d.legal_sets` etc.
+     directly, which does not compile against the struct this proposal itself
+     defines. Every mutation now composes through the real path.
+  2. **`Option` handling.** `legal_sets` is `Option<Vec<SetCode>>` (§1), not a
+     bare `Vec` — `.extend()` cannot be called on it directly.
+     `get_or_insert_with(Vec::new)` extends the base's `Some(...)` vector in
+     place (its only legal state per `old_school_93_94()`'s own construction
+     — a restricted-pool preset never leaves this `None`) while still being
+     correct if a future refactor ever changed that invariant, rather than
+     assuming it silently.
+
+  `printing_fidelity`: inherited `SetCodeApproximation` from the base `d` —
+  same source requirement, same enforcement gap. **New preset-inheritance
+  test (§6):** asserts `old_school_95()`'s resolved `rules.legality` contains
+  every `old_school_93_94()` set/restricted/banned entry PLUS exactly its own
+  five/two/two declared additions — not just that the extra entries are
+  present, so a future edit can't silently drop or duplicate the inherited
+  93-94 base while adding 95's deltas.
 - `middle_school()` — `rules`: sets = Fourth Edition..Scourge; restricted =
   []; banned = [25 names]; legacy = `{ mana_burn: ManaBurnPolicy::Obsolete,
   damage_timing: CombatDamageTiming::OnStack, wish_scope:
@@ -1317,6 +1334,18 @@ legality logic on the client.
   its source ruleset; each preset's stated list *count* in a doc comment
   matches `.len()` of the actual list (guards against the round-2 23-vs-25 /
   37-vs-44 class of mislabeling recurring silently).
+- **`old_school_95()` correctly inherits `old_school_93_94()`'s base and adds
+  only its own delta** (new — maintainer review round 12): assert
+  `old_school_95().rules.legality.legal_sets` is `Some(_)` containing every
+  set in `old_school_93_94().rules.legality.legal_sets` PLUS exactly the
+  five declared additions (4ED, ICE, CHR, REN, HML) — not a superset check
+  alone, an exact-set comparison, so a future edit can't silently drop an
+  inherited entry while still passing a "contains my new sets" assertion.
+  Mirrored for `restricted` (93-94's list plus exactly Demonic Consultation
+  and Mana Crypt) and `banned` (93-94's list plus exactly Amulet of Quoz and
+  Timmerian Fiends). This is also where a `d.rules.legality.*`-vs-`d.*`
+  nesting regression (§2's round-12 fix) would be caught mechanically,
+  rather than only by inspection.
 - **Mana burn — pool persistence AND life loss** (revised again — maintainer
   review round 3, CONTEXT.md point 1; round 2's version only tested the
   life-loss gate and would have passed against the wrong mechanism):

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -132,10 +132,19 @@ CustomFormatRules {                     // the resolved ruleset payload
 // fields. Full accounting against the real struct:
 //   - Included below: every FIELD that is independently meaningful and not
 //     derivable from something else already in this struct.
-//   - `uses_commander: bool` — NOT included as a stored field. It is derived
-//     as `commander_damage_threshold.is_some()` at read time, mirroring how
-//     it already mirrors `GameFormat` for built-in formats. Storing it
-//     separately would let it drift out of sync with the threshold.
+//   - `uses_commander: bool` — NOT a stored field here. REVISED per
+//     maintainer review round 3 (CONTEXT.md point 4): `GameFormat::
+//     uses_commander()` (`format.rs:365-380`) is a hardcoded per-variant
+//     match with no access to `FormatConfig`, but its doc comment states
+//     the real invariant it encodes — true for every format whose
+//     `FormatConfig` has BOTH `command_zone: true` AND a non-`None`
+//     `commander_damage_threshold` (round 2 wrongly used the threshold
+//     alone). `FormatConfig.uses_commander` for `GameFormat::Custom` is
+//     computed at construction time (`from_lobby_config` / preset
+//     constructors) as `structural.command_zone &&
+//     structural.commander_damage_threshold.is_some()` — both conditions,
+//     matching the stated invariant exactly. Never stored redundantly on
+//     `StructuralRules` itself.
 //   - `supplies_fixed_deck: bool` — NOT included. Always `false` for
 //     `GameFormat::Custom`; no custom-format use case for an engine-supplied
 //     fixed deck exists today. Flagged, not silently dropped, if that need
@@ -145,11 +154,25 @@ CustomFormatRules {                     // the resolved ruleset payload
 //     comment states it is "orthogonal to format" — a session capability
 //     flag, not format identity. Belongs on `FormatConfig` directly, set
 //     independently of which format (built-in or custom) is chosen.
-//   - `sideboard_policy` — NEW finding: this is NOT a `FormatConfig` field.
-//     It's a `GameFormat` method (`format.rs:270`,
+//   - `archenemy_player: Option<PlayerId>` — REMOVED per maintainer review
+//     round 3 (CONTEXT.md point 3). It is a per-GAME seat index derived from
+//     `topology()` and validated against THAT game's player count
+//     (`FormatConfig::archenemy_player()` + `validate_for_player_count`,
+//     `format.rs:658-670`) — persisting it in a reusable saved format could
+//     reference a seat that doesn't exist, or a different player, next time
+//     it's loaded. Axis A does not support the Archenemy one-vs-many
+//     topology at all (a different `FormatTopology` shape, not a config knob
+//     on top of `IndividualSeats`) — explicit scope exclusion, not a silent
+//     drop; a topology-aware design is its own future project.
+//   - `sideboard_policy` — this is NOT a `FormatConfig` field. It's a
+//     `GameFormat` method (`format.rs:270`,
 //     `fn sideboard_policy(self) -> SideboardPolicy`), computed from the
-//     enum variant for built-in formats. `GameFormat::Custom` has no such
-//     derivation source, so `StructuralRules` must carry it explicitly.
+//     enum variant for built-in formats, with no `FormatConfig` access to
+//     check anything for `Custom`. `StructuralRules` carries it explicitly;
+//     see the new `FormatConfig::sideboard_policy()` accessor and consumer
+//     migration below (maintainer review round 3, CONTEXT.md point 2) —
+//     round 2 added this field but never specified how anything would
+//     actually READ it for a Custom format, which was itself a gap.
 StructuralRules {
     starting_life: i32,
     min_players: u8,
@@ -160,9 +183,39 @@ StructuralRules {
     commander_damage_threshold: Option<u8>,
     range_of_influence: Option<Box<RangeOfInfluenceConfig>>,  // mirrors FormatConfig's field exactly
     team_based: bool,
-    archenemy_player: Option<PlayerId>,
-    sideboard_policy: SideboardPolicy,  // new — no derivation source for Custom, see note above
+    sideboard_policy: SideboardPolicy,  // no derivation source for Custom, see note above
 }
+
+// --- sideboard_policy accessor and consumer migration (new — maintainer
+// review round 3, CONTEXT.md point 2) ---
+//
+// `GameFormat::sideboard_policy(self) -> SideboardPolicy` (`format.rs:270`)
+// is an exhaustive match over the built-in variants with NO access to
+// `FormatConfig` — a `Custom(_)` arm there can only be
+// `unreachable!("call FormatConfig::sideboard_policy() instead")`, since the
+// real answer lives in `custom_rules`, which this method cannot see. The
+// correct authority is one level up:
+//
+// impl FormatConfig {
+//     pub fn sideboard_policy(&self) -> SideboardPolicy {
+//         match self.format {
+//             GameFormat::Custom(_) => self.custom_rules.as_ref()
+//                 .expect("Custom format must carry custom_rules")
+//                 .structural.sideboard_policy,
+//             other => other.sideboard_policy(),
+//         }
+//     }
+// }
+//
+// Every current call site of `state.format_config.format.sideboard_policy()`
+// — confirmed this session at `game/deck_loading.rs:681` and
+// `game/match_flow.rs:357`; a repo-wide grep for the same pattern at
+// implementation time catches any others — migrates to
+// `state.format_config.sideboard_policy()`. Round 2 added the field to
+// `StructuralRules` but never specified this accessor or the migration,
+// which is why a saved format's sideboard policy would have been silently
+// ignored (both existing consumers would keep reading a meaningless
+// built-in-format answer for `GameFormat::Custom`).
 
 // Axis B — legality/era-rules. Genuinely new data; no existing UI surface.
 // This is what makes the four EC formats rules-correct; kept exactly as
@@ -371,8 +424,12 @@ the frontend labels/short-labels/descriptions just like `FormatMetadata`.)
 ## 2. Parameterizing the formats as data (not N blocks)
 
 **Phase 1 preset — `swedish_old_school()` (see CONTEXT.md's "Further narrowing
-Axis B's MVP").** This is the first Axis B preset to actually ship, chosen
-because it needs zero `LegacyRuleSet` engine wiring:
+Axis B's MVP").** This is the first Axis B preset targeted, chosen because it
+needs zero `LegacyRuleSet` engine wiring. **Registration is currently blocked
+by the preset-readiness gate (§7)** — its `ReprintPolicy` is unenforced by §3
+and its specific value is unconfirmed (CONTEXT.md Open item 6) — so the
+engine/schema work below can and should land in phase 1, but this preset does
+not appear as a selectable format until those two items resolve:
 
 - `swedish_old_school()` — sets = `Some([LEA, LEB, 2ED, ARN, ATQ, LEG, DRK,
   SUM])` (verify MTGJSON codes at implementation time, same caveat as below —
@@ -438,9 +495,25 @@ This reuses four existing helpers verbatim and adds only the set-membership +
 name-set sourcing. `GameFormat::Custom` gets one arm in
 `format_compatibility_check` routing to `evaluate_custom_format`.
 
+**Honest gap, flagged by maintainer review round 3 (CONTEXT.md point 5):**
+`rules.reprint_policy` is declared on `LegalityRules` but **not consumed by
+any step above** — a card passes step 2 based on legal-set membership alone,
+regardless of which `ReprintPolicy` the preset declares. This is the same gap
+as the already-flagged Open item 2 (printing/frame-data gap): real
+enforcement needs the engine-vs-frontend printing cross-reference that item
+already describes, not new work invented here. Per the new preset-readiness
+rule (CONTEXT.md point 5, §7): no preset may be registered as selectable
+while declaring a `ReprintPolicy` this algorithm doesn't enforce — this
+blocks `swedish_old_school()` specifically until Open items 2 and 6 resolve
+(see §7).
+
 `legality_format()` returns `None` for `Custom` (no `LegalityFormat` mapping —
-custom formats don't use the external legality table). `sideboard_policy`,
-`label`, `for_format`, etc. each get a `Custom` arm reading the resolved def.
+custom formats don't use the external legality table). `label`, `for_format`,
+etc. each get a `Custom` arm reading the resolved def. `sideboard_policy` is
+the one exception to "add a `Custom` arm on the `GameFormat` method" — see the
+dedicated accessor design in §1: the correct arm lives on `FormatConfig::
+sideboard_policy()`, not on `GameFormat::sideboard_policy()` itself, since the
+latter has no access to `custom_rules`.
 
 ## 4. Legacy rules wiring — Phase 2 (not needed for the Swedish Old School preset)
 
@@ -450,50 +523,85 @@ Swedish ruleset makes no mention of any of these rules and uses fully modern
 defaults. This section is unchanged from the original design and remains the
 correct plan for phase 2's four EC-format presets.
 
-- **Mana burn** (`LegacyRuleSet.mana_burn`) — **REWRITTEN per maintainer review
-  round 2** (CONTEXT.md point 4); the original "deal damage at the step-end
-  drop site" framing was wrong on two independent axes, both verified this
-  session:
-  - **Life loss, not damage.** `docs/MagicCompRules.txt:8278` (obsolete-rules
-    glossary): "unspent mana caused a player to **lose life**." Damage and
-    life loss are behaviorally different in this engine (damage can be
-    prevented/redirected and triggers "dealt damage" abilities; life loss
-    does neither) — this is not a cosmetic wording choice.
-  - **Phase-boundary, not every `Phase` enum transition.** The engine's own
-    `Phase` enum (`types/phase.rs`) flattens all of MTG's steps AND phases
-    into one 11-variant list (e.g. `DeclareAttackers`, `DeclareBlockers`,
-    `CombatDamage` are three separate `Phase` variants, all within the single
-    real MTG "Combat" phase). Modern CR 500.5 empties the mana pool at every
-    one of these transitions, and the engine's existing
-    `apply_empty_mana_pool_event` (`turns.rs`) already fires on every one via
-    `player_unspent_mana_loss_causes_life_loss`
-    (`static_abilities.rs:1237`, backed by `StaticMode::UnspentManaLossCausesLifeLoss`
-    — an existing, generic "Yurlok-class" mechanism for a card-granted
-    version of this same shape). That per-transition granularity is correct
-    for the existing card-granted static ability, but old-school mana burn
-    must fire only when actually **leaving one of the 5 real MTG phases**
-    (Beginning, Precombat Main, Combat, Postcombat Main, Ending) — not on
-    every step within one.
+- **Mana burn** (`LegacyRuleSet.mana_burn`) — **REWRITTEN AGAIN per
+  maintainer review round 3** (CONTEXT.md point 1). Round 2 fixed the
+  life-loss-not-damage half but got the mechanism wrong: it gated only the
+  LIFE-LOSS check to phase-group boundaries while leaving the pool-emptying
+  itself firing on every `Phase` transition — so by the time a phase-group
+  boundary was reached, the pool had already been silently drained at the
+  prior intra-phase-group step, with nothing left to burn. Two things
+  verified directly this session that the round-2 fix missed:
+  - **Life loss, not damage** (unchanged from round 2, still correct):
+    `docs/MagicCompRules.txt:8278` (obsolete-rules glossary): "unspent mana
+    caused a player to **lose life**." Damage and life loss are behaviorally
+    different in this engine (damage can be prevented/redirected and
+    triggers "dealt damage" abilities; life loss does neither).
+  - **The pool itself must persist across intra-phase-group steps, not just
+    skip the burn check.** The engine's `Phase` enum (`types/phase.rs`)
+    flattens MTG's steps AND phases into one 11-variant list (e.g.
+    `DeclareAttackers`/`DeclareBlockers`/`CombatDamage` are three separate
+    `Phase` variants inside the single real "Combat" phase); modern CR 500.5
+    empties the pool at every one of them, and `turns.rs`'s `enter_phase`
+    sets `state.phase = next` near the top of the function — so anything
+    checking "current vs. next" phase after that line sees the destination
+    on both sides unless it captured the pre-transition value first.
 
-  **Design**: add a small `fn phase_group(p: Phase) -> PhaseGroup` mapping
-  (a 5-variant enum grouping the 11 `Phase` variants by their real MTG
-  phase — mirrors the ad-hoc `in_combat` bool `turns.rs` already computes
-  inline for combat-duration tracking, generalized to all 5 groups). At the
-  same `apply_empty_mana_pool_event` call site, when `LegacyRuleSet.mana_burn`
-  is set AND `phase_group(current) != phase_group(next)` (a genuine
-  phase-group boundary, not an intra-phase step transition), apply a
-  **second, independent** life-loss contribution for that player's dropped
-  mana units — alongside, not merged into, the existing
-  `player_unspent_mana_loss_causes_life_loss` check, since the two have
-  different triggers (a format-level flag vs. a card-granted static ability)
-  and could theoretically both apply to the same event. Emit a
-  `GameEvent::ManaBurn { player_id, amount }` for the format-level
-  contribution specifically, so it stays distinguishable from a Yurlok-class
-  event in tests and in any future "why did I lose life" UI surface.
+  **Design — reuses an existing mechanism instead of inventing pool
+  suppression.** The engine already has exactly this shape:
+  `ManaExpiry` (`types/mana.rs:1509`) has `EndOfTurn` and `EndOfCombat`
+  variants; `EndOfCombat`'s own doc comment reads "Mana persists through
+  combat steps but drains at EndCombat → PostCombatMain," used by
+  Firebending — literally "persist through this phase's internal steps,
+  drain at the real phase-group boundary," already built, tested, and
+  working, just special-cased to the Combat phase-group. The fix
+  generalizes it:
+  1. Add `ManaExpiry::EndOfPhaseGroup` — a **third** variant, not five new
+     per-phase-group variants (`EndOfBeginning`, `EndOfPrecombatMain`, …).
+     Like `EndOfCombat` and `EndOfTurn`, it does not parameterize which
+     phase-group; it resolves contextually against whichever one is active
+     when checked, via the same `fn phase_group(p: Phase) -> PhaseGroup`
+     mapping round 2 introduced (5 variants: Beginning, PrecombatMain,
+     Combat, PostcombatMain, Ending — generalizing the ad-hoc `in_combat`
+     bool `turns.rs` already computes inline).
+  2. Where mana units are constructed (`types/mana.rs`, the `ManaUnit`
+     construction sites currently setting `expiry: None`), when the active
+     format's `LegacyRuleSet.mana_burn` is set, construct with
+     `expiry: Some(ManaExpiry::EndOfPhaseGroup)` instead.
+  3. Extend the existing expiry-clearing logic (the generalization of
+     `clear_expired_end_of_combat_retention_markers`, called from
+     `enter_phase` where the pre-transition phase is still available before
+     `state.phase = next` overwrites it) to detect a real phase-group
+     crossing and convert those units to ordinary (`None`-expiry) units —
+     exactly mirroring how `EndOfCombat` units convert at `EndCombat` →
+     `PostCombatMain` today. Converted units flow into that SAME
+     transition's already-firing `EmptyManaPool` event as `Drop`
+     decisions — no new event, no suppressed event, the existing
+     unconditional per-transition drain does the work once the units are no
+     longer expiry-protected.
+  4. Because units tagged `EndOfPhaseGroup` never enter the Drop path except
+     at a real phase-group crossing (by construction — an intra-phase-group
+     transition's `clear_expired_...` pass leaves them untouched, mirroring
+     exactly how live `EndOfCombat` units are excluded from Drop mid-combat
+     today), the drop count a `mana_burn` player has at ANY transition where
+     drops occur *is* the burn amount — no separate "was this a boundary"
+     branch needed at the life-loss application point itself. Apply that
+     count as **life loss** (`GameEvent::ManaBurn { player_id, amount }`,
+     distinguishable from a Yurlok-class event), computed at the SAME
+     aggregation point `apply_empty_mana_pool_event` already uses for the
+     existing `player_unspent_mana_loss_causes_life_loss` (Yurlok-class)
+     check — independent of it, since a format flag and a card-granted
+     static ability are different triggers that could theoretically both
+     apply to the same event — and AFTER any player choice the drain pauses
+     for (Kruphix/Horizon Stone `Keep` dispositions), reusing the pipeline's
+     existing pause/resume continuation rather than adding a second,
+     unsynchronized computation point (this resolves the "life loss can
+     defer through replacement handling" concern directly).
   Annotate as a pre-M10 rule removed by the M10 update (cite the
-  obsolete-glossary entry `MagicCompRules.txt:8277-8278`). Still small — one
-  new grouping helper, one new gated life-loss contribution at an existing
-  call site, no new state machine.
+  obsolete-glossary entry `MagicCompRules.txt:8277-8278`). Slightly larger
+  than round 2's estimate (a new `ManaExpiry` variant + its construction-site
+  and clearing-logic wiring, not just a life-loss check at an existing call
+  site) but still small and, critically, reuses a proven pattern rather than
+  adding a new one.
 - **Pre-M10 Wish exile access** (`pre_m10_wish_reaches_exile`): fully traced in
   RESEARCH §9. This is a REAL functional difference (not wording-only): pre-M10,
   the "removed from the game" zone counted as *outside the game*, so a Wish could
@@ -556,25 +664,51 @@ legality logic on the client.
   its source ruleset; each preset's stated list *count* in a doc comment
   matches `.len()` of the actual list (guards against the round-2 23-vs-25 /
   37-vs-44 class of mislabeling recurring silently).
-- **Mana burn phase-boundary gating** (revised — maintainer review round 2,
-  CONTEXT.md point 4): with `LegacyRuleSet.mana_burn` set, unspent mana at a
-  transition WITHIN one MTG phase (e.g. `DeclareAttackers` → `DeclareBlockers`,
-  same `PhaseGroup::Combat`) must NOT cause life loss; unspent mana at a
-  transition CROSSING a phase-group boundary (e.g. `EndCombat` →
-  `PostCombatMain`) must cause life loss equal to the unspent amount. Assert
-  life loss specifically (not damage — no `GameEvent::DamageDealt`, no
-  prevention-shield interaction). With the flag off, neither transition
-  causes any loss. Tests the flag + phase-group hook generically, not a
-  specific card.
+- **Mana burn — pool persistence AND life loss** (revised again — maintainer
+  review round 3, CONTEXT.md point 1; round 2's version only tested the
+  life-loss gate and would have passed against the wrong mechanism):
+  - With `LegacyRuleSet.mana_burn` set, unspent mana added during
+    `DeclareAttackers` must still be present (not dropped, no life loss) at
+    `DeclareBlockers` (a transition WITHIN `PhaseGroup::Combat`) — asserts
+    the pool itself persists via `ManaExpiry::EndOfPhaseGroup`, not just that
+    a life-loss check was skipped.
+  - That same unspent mana, carried untouched through every step of Combat,
+    must be dropped AND cause life loss equal to the full accumulated amount
+    at the `EndCombat` → `PostCombatMain` transition (crossing a phase-group
+    boundary) — a single discriminating test proving both the persistence
+    and the eventual burn, not two independently-passable halves.
+  - Assert life loss specifically (no `GameEvent::DamageDealt`, no
+    prevention-shield interaction).
+  - With the flag off, mana empties at every transition exactly as today
+    (regression guard against changing default behavior).
+  - A pause case: unspent mana at a real phase-group boundary where a
+    `Keep`-disposition replacement effect (Kruphix/Horizon Stone-shaped
+    synthetic def) also applies — burn amount reflects only the units
+    actually dropped after that choice resolves, proving the life-loss
+    application reuses the pipeline's existing pause/resume point rather
+    than computing before the choice is known.
+- **`FormatConfig::sideboard_policy()` accessor** (new — maintainer review
+  round 3, CONTEXT.md point 2): a `Custom`-format `FormatConfig` with
+  `structural.sideboard_policy: Forbidden` must make `deck_loading.rs`'s
+  sideboard-dropping behavior and `match_flow.rs`'s max-sideboard-size
+  computation both observe `Forbidden` via the new accessor — a regression
+  test pinned to the two migrated call sites specifically, not just the
+  accessor's return value in isolation, so a future revert of the migration
+  (reverting to `.format.sideboard_policy()`) fails visibly.
+- **`uses_commander` requires both conditions** (new — maintainer review
+  round 3, CONTEXT.md point 4): `command_zone: true` alone (no threshold) and
+  `commander_damage_threshold: Some(_)` alone (no command zone) both derive
+  `uses_commander: false`; only both together derive `true` — the exact
+  mismatched-combination cases the review asked for.
 - Serde round-trip of `FormatConfig` with `Some(custom_rules)` and `None`.
 - `CustomFormatDef::from_lobby_config`: a `FormatConfig` with non-default
   `starting_life`/`max_players`/`deck_size`/`range_of_influence`/`team_based`/
-  `command_zone`/`commander_damage_threshold`/`archenemy_player`/
-  `sideboard_policy` round-trips into a `CustomFormatRules.structural` that
-  matches field-for-field, with `legality` at its defaults (`legal_sets:
-  None`) — the general Axis-A save mechanism, not a specific saved format's
-  values. Include a case with `commander_damage_threshold: Some(_)` asserting
-  the derived `uses_commander` reads `true` without being stored separately.
+  `command_zone`/`commander_damage_threshold`/`sideboard_policy` round-trips
+  into a `CustomFormatRules.structural` that matches field-for-field, with
+  `legality` at its defaults (`legal_sets: None`) — the general Axis-A save
+  mechanism, not a specific saved format's values. Does NOT include
+  `archenemy_player` (removed per round 3, CONTEXT.md point 3 — not part of
+  `StructuralRules` at all).
 
 ## 7. Delivery surface — RESOLVED via maintainer input, see CONTEXT.md "Maintainer input"
 
@@ -619,6 +753,23 @@ legacy rules) is unaffected in scope or design — this only changes what ships
 *first* and *how a player reaches Axis A*, not what Axis B needs to be
 correct.
 
+**Preset-readiness gate (new — maintainer review round 3, CONTEXT.md point
+5).** A preset (Axis B typed constructor OR an Axis A lobby save that sets
+non-default `legality`) must not be registered/exposed as a selectable format
+until every legality/legacy field it declares is BOTH fully specified AND
+actually consumed by the evaluator/engine at an authoritative seam — not
+merely present as a struct field. This is a general rule, not a one-off:
+- `swedish_old_school()` (phase 1) is currently BLOCKED from registration by
+  this rule: it declares a `ReprintPolicy`, which §3 confirms is not yet
+  enforced, and CONTEXT.md's Open item 6 confirms the specific policy value
+  is itself unconfirmed against the primary source. Both must resolve before
+  this preset ships as selectable, even though the engine-level schema and
+  evaluator work (§1, §3) can and should land first.
+- No phase-2 EC preset may declare `LegendRuleScope::PreM14AnyController`
+  until the historical conflation flagged in CONTEXT.md/RESEARCH.md resolves.
+  Moot today (all four EC presets default this to `Modern`), but binding on
+  any future preset.
+
 ## 8. Sequencing
 
 **Phase 1 — general engine + the smallest end-to-end slice.** Deliberately
@@ -638,11 +789,15 @@ first.
    Validates the schema's Axis A end from a real UI.
 3. **`swedish_old_school()` preset (Axis B, phase 1)** — the one Axis B
    preset that needs zero legacy-rules wiring (§2). Validates the engine's
-   Axis B end (legal-set membership, empty banned list, the 23-name
+   Axis B end (legal-set membership, empty banned list, the 25-name
    restricted list) without touching §4 at all. Resolve CONTEXT.md items 5–6
    (ante-card handling, reprint policy) before finalizing this preset's
-   constructor. Can proceed in parallel with step 2 — disjoint fields of the
-   same schema.
+   constructor. **Registration as a selectable format is gated separately
+   (§7's preset-readiness gate)** on `ReprintPolicy` enforcement landing in
+   §3 — the constructor and its tests can land in this step, but do not wire
+   it into the format-selection UI/registry as choosable until that gate
+   clears. Can proceed in parallel with step 2 — disjoint fields of the same
+   schema.
 
 **Phase 2 — the four EC formats + the legacy-rules engine work they need.**
 Ships once phase 1 has proven the schema and both axes end-to-end.

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -405,7 +405,16 @@ LegalityRules {
 // every other breaking wire change — not a new, custom-format-specific
 // negotiation layer.
 
-ReprintPolicy {                         // enum — enforceable today only at set-code granularity
+// REVISED per maintainer review round 5 (§3/§7 have the full reasoning):
+// this enum is documentation metadata, NOT consumed by `evaluate_custom_format`
+// at all. Its intended behavior is already fully absorbed by `legal_sets`
+// curation (a reprint outside `legal_sets` is already excluded by plain
+// set-membership); the one thing it can't capture — frame/art-level
+// fidelity — is Open item 2's gap, not this enum's job to close. Kept as a
+// typed enum (not deleted) purely so a preset's authored intent is
+// machine-readable for whoever eventually builds Open item 2, not because
+// anything reads it today.
+ReprintPolicy {
     OriginalPrintingsOnly,              // 93-94 / Classic intent (see limitation)
     AllowSpecialReprintSets,            // CE/ICE/world-champ/proof set codes included in legal_sets
     AllowAnyPrinting,                   // Middle School "begrudgingly"
@@ -596,10 +605,11 @@ cross-referencing another file:**
 **Phase 1 preset — `swedish_old_school()` (see CONTEXT.md's "Further narrowing
 Axis B's MVP").** This is the first Axis B preset targeted, chosen because it
 needs zero `LegacyRuleSet` engine wiring. **Registration is currently blocked
-by the preset-readiness gate (§7)** — its `ReprintPolicy` is unenforced by §3
-and its specific value is unconfirmed (CONTEXT.md Open item 6) — so the
+by CONTEXT.md Open item 6** — its `ReprintPolicy` metadata VALUE is
+unconfirmed against the primary source (not an enforcement gap — see §3's
+resolution: `ReprintPolicy` is documentation, not a gated axis) — so the
 engine/schema work below can and should land in phase 1, but this preset does
-not appear as a selectable format until those two items resolve:
+not appear as a selectable format until that item resolves:
 
 - `swedish_old_school()` — sets = `Some([LEA, LEB, 2ED, ARN, ATQ, LEG, DRK,
   SUM])` (verify MTGJSON codes at implementation time, same caveat as below —
@@ -654,7 +664,9 @@ time by a unit test that asserts every banned/restricted name resolves in the
 
 `evaluate_custom_format(db, request, rules) -> CompatibilityCheck`:
 
-1. Structural checks (deck size, sideboard) via existing `FormatConfig` fields.
+1. Structural checks (deck size, sideboard) via existing `FormatConfig` fields
+   — parameterized by `rules.structural.deck_size` (not a hardcoded 60, per
+   maintainer review round 5's finding below).
 2. Pool legality: `match &rules.legal_sets { None => every card passes this
    check (no set restriction — Axis A's default), Some(sets) => for each
    card, db.printings_for(name); legal iff any printing's set code ∈ sets,
@@ -667,26 +679,62 @@ time by a unit test that asserts every banned/restricted name resolves in the
 3. Banned: name ∈ `rules.banned` → illegal (distinct "banned" label).
 4. Restricted: name ∈ `rules.restricted` → insert into `restricted_canonical`,
    then call the **existing** `restricted_copy_violations` (CR 100.2b, `<= 1`).
-5. Default 4-copy limit + card-intrinsic overrides via the **existing**
-   `copy_limit_violations`.
+5. Copy limit: `copy_limit_violations(db, &counts, if rules.structural.singleton
+   { 1 } else { 4 })` — **FIXED per maintainer review round 5** (see below);
+   the field existed on `StructuralRules` since round 2 but step 5 never read
+   it, always calling the helper with a hardcoded `4`. `copy_limit_violations`
+   ALREADY takes this exact parameter — every built-in singleton format
+   (Commander, Brawl, etc.) already calls it with `1`
+   (`deck_validation.rs:929,1096,1335,1668,2215`, confirmed this round, not
+   assumed) and every non-singleton format with `4`
+   (`:447,535,643,2054`) — this is parameterizing an existing call, not new
+   logic. Card-intrinsic overrides (`DeckCopyLimit::UpTo(n)`, "any number"
+   cards like Relentless Rats/Nazgûl) are already handled generically inside
+   `copy_limit_violations` regardless of the format-level limit passed in —
+   confirmed via its own existing tests
+   (`deck_validation.rs:3916-3941`, e.g. `Nazgûl` with limit `1` still passes
+   at 9 copies) — no new "preserve overrides" logic needed, the helper
+   already composes correctly.
 
 This reuses four existing helpers verbatim and adds only the set-membership +
-name-set sourcing. `GameFormat::Custom` gets one arm in
+name-set sourcing, now correctly parameterized by every `StructuralRules`
+field the algorithm needs (`deck_size`, `singleton`) rather than assuming
+built-in-format defaults. `GameFormat::Custom` gets one arm in
 `format_compatibility_check` routing to `evaluate_custom_format`.
 
-**Honest gap, flagged by maintainer review rounds 3 and 4 (CONTEXT.md point
-5; round 4 demanded a concrete resolution, not just a flag):**
-`rules.reprint_policy` is declared on `LegalityRules` but **not consumed by
-any step above** — a card passes step 2 based on legal-set membership alone,
-regardless of which `ReprintPolicy` the preset declares. Per the tightened
-preset-readiness gate (§7), no preset may register while declaring a
-`ReprintPolicy` this algorithm doesn't enforce. Two independent resolution
-paths, either sufficient (§7 has the full reasoning): the general
-engine-vs-frontend printing cross-reference (Open item 2) landing, or a
-one-preset verification pass confirming no problematic reprints exist within
-that specific preset's `legal_sets` window. This blocks `swedish_old_school()`
-specifically until one of those two paths completes, plus Open item 6
-(reprint-policy value itself unconfirmed).
+**Maintainer review round 5 finding, addressed above**: this whole algorithm
+requires the VALIDATED `FormatConfig`/resolved `CustomFormatRules` as input —
+confirmed again that `DeckCompatibilityRequest.selected_format:
+Option<GameFormat>` (§1's audit) cannot supply `deck_size`/`singleton` any
+more than it could supply `legal_sets`/`banned`/`restricted` — the same
+signature-widening fix from §1 covers this too, not a separate mechanism.
+
+**`ReprintPolicy` is deliberately NON-behavior-bearing metadata, not a
+registration-blocking gap (RESOLVED — maintainer review round 5; supersedes
+rounds 3/4's framing of this as an unenforced gate).** Round 5 correctly
+caught that the round-4 registry gate (`IMPLEMENTED_LEGACY_AXES`, §7) covers
+only `LegacyRuleSet`'s four axes and was never extended to `ReprintPolicy` —
+a preset could still register while declaring a policy this algorithm
+doesn't enforce. Rather than broadening the gate to a field that was never
+designed to be independently enforceable, this document's OWN original
+research already answered this (RESEARCH.md §3, written before any of the
+four review rounds): "model reprint policy as *which set codes are in the
+legal list*, and flag frame/art-level fidelity as a known limitation."
+That is: `ReprintPolicy`'s actual behavior is already fully absorbed into
+`legal_sets` curation (a modern reprint of an old card lives in a set code
+simply not present in `legal_sets`, so it's excluded by step 2 alone,
+requiring no separate enforcement) — the ONLY thing `ReprintPolicy` cannot
+capture is the finer frame/art-level distinction (e.g. "old-bordered
+original only" vs. "any printing from a legal set"), which is the SAME gap
+Open item 2 already tracks. Accordingly: `reprint_policy` is documentation
+metadata for a human auditing a preset's intent, deliberately not consumed
+by `evaluate_custom_format`, and NOT part of the preset-readiness gate's
+enforcement surface — the gate only needs to cover fields that are actually
+behavior-bearing, which `LegacyRuleSet`'s four axes are and
+`reprint_policy` is not. `swedish_old_school()` is still gated on CONTEXT.md
+Open item 6 (getting the metadata VALUE right, since an inaccurate label
+could mislead a future maintainer who builds real enforcement later), but
+that is a documentation-accuracy blocker, not a missing-enforcement one.
 
 `legality_format()` returns `None` for `Custom` (no `LegalityFormat` mapping —
 custom formats don't use the external legality table). `label`, `for_format`,
@@ -851,6 +899,20 @@ legality logic on the client.
   restricted one.
 - Restricted path: 2 copies of a restricted-list name flags; 1 copy passes —
   driven by a synthetic def, proving the general mechanism.
+- **Singleton copy limit is actually parameterized, not defaulted** (new —
+  maintainer review round 5): a synthetic `CustomFormatRules` with
+  `structural.singleton: true` flags 2 copies of an arbitrary non-basic,
+  non-"any number" card and accepts 1 — proving step 5 reads
+  `structural.singleton` rather than always calling
+  `copy_limit_violations(..., 4)`. Paired with a `singleton: false` case
+  accepting up to 4, so both branches of the parameter are covered, not just
+  the new one. A third case reuses an existing card-intrinsic override
+  (Relentless Rats-shaped "any number" card, or a `DeckCopyLimit::UpTo(n)`
+  card) under `singleton: true` and confirms the override still applies —
+  proving `copy_limit_violations` composes the format limit and the
+  card-intrinsic override correctly for Custom exactly as it already does
+  for built-in singleton formats (Commander etc.), not a new interaction to
+  design.
 - Preset integrity: every banned/restricted name in all four EC presets plus
   `swedish_old_school()` resolves in the DB; each preset's `legacy` matches
   its source ruleset; each preset's stated list *count* in a doc comment
@@ -999,24 +1061,34 @@ choice) — a future author who adds `middle_school()` before
 `CombatDamageTiming::OnStack` lands gets a build-time or startup-time
 failure, not a silently-ignored doc-comment warning. This is the concrete
 mechanism §6's "actually enforced, not just documented" test targets.
-- `swedish_old_school()` (phase 1) is currently BLOCKED from registration by
-  this rule on TWO independent grounds: it declares a `ReprintPolicy`, which
-  §3 confirms is not yet enforced by the evaluator at all, and CONTEXT.md's
-  Open item 6 confirms the specific policy value is itself unconfirmed
-  against the primary source. **Resolution path — either is sufficient**:
-  (a) Open item 2's general engine-vs-frontend printing cross-reference
-  lands, making `ReprintPolicy` enforcement real for every preset at once; or
-  (b) a preset-specific verification pass confirms Swedish Old School's
-  particular restricted-list cards have no problematic reprints *within its
-  own `legal_sets` window* that plain legal-set membership wouldn't already
-  exclude — a materially smaller, one-preset check that could unblock this
-  specific preset without waiting on the general system. Neither path is
-  assumed to succeed without doing it; this document does not assert the
-  gap is moot for Swedish specifically without that verification.
+
+**Gate scope, precisely (maintainer review round 5 caught that this wasn't
+stated precisely enough): `IMPLEMENTED_LEGACY_AXES` covers exactly
+`LegacyRuleSet`'s four axes — `mana_burn`, `damage_timing`, `wish_scope`,
+`legend_rule_scope` — because those are the only fields on
+`CustomFormatRules` today that are BOTH independently declarable AND
+intended to be behavior-bearing.** It does NOT cover `reprint_policy` (§3
+resolves why: deliberately non-behavior-bearing metadata, not an
+unenforced axis) and there is no ante-card field to cover yet (CONTEXT.md
+Open item 5 — no schema slot exists). If a future field is ever added with
+real behavior attached (an enforced `ReprintPolicy`, an ante-list), it must
+be added to this gate in the SAME change that adds the field — the gate's
+job is to cover every behavior-bearing field that exists, and it is a
+review-time checklist item whenever `CustomFormatRules`/`LegacyRuleSet`
+gains a member, not a one-time list to write and forget.
+- `swedish_old_school()` (phase 1) is BLOCKED from registration by
+  CONTEXT.md Open item 6 alone — the reprint-policy metadata VALUE needs
+  confirming against the primary source before shipping, so a future
+  maintainer doesn't inherit an inaccurate label. This is a documentation-
+  accuracy blocker, not a missing-enforcement one (see §3's resolution) —
+  it does not require `IMPLEMENTED_LEGACY_AXES` coverage, since
+  `reprint_policy` was never meant to be in that gate's scope.
 - `middle_school()` and `classic_magic()` (phase 2) are BLOCKED from
   registration until `CombatDamageTiming::OnStack` (§4, LARGE) is fully
   implemented — both declare it, and per the no-caveated-exposure rule
-  neither may register while any declared axis is unimplemented.
+  neither may register while any declared axis is unimplemented. This one
+  DOES require `IMPLEMENTED_LEGACY_AXES` coverage, since `damage_timing` is
+  a real `LegacyRuleSet` axis.
 - No phase-2 EC preset may declare `LegendRuleScope::PreM14AnyController`
   until the historical conflation flagged in CONTEXT.md/RESEARCH.md resolves.
   Moot today (all four EC presets default this to `Modern`), but binding on
@@ -1043,13 +1115,14 @@ first.
    preset that needs zero legacy-rules wiring (§2). Validates the engine's
    Axis B end (legal-set membership, empty banned list, the 25-name
    restricted list) without touching §4 at all. Resolve CONTEXT.md items 5–6
-   (ante-card handling, reprint policy) before finalizing this preset's
-   constructor. **Registration as a selectable format is gated separately
-   (§7's preset-readiness gate)** on `ReprintPolicy` enforcement landing in
-   §3 — the constructor and its tests can land in this step, but do not wire
-   it into the format-selection UI/registry as choosable until that gate
-   clears. Can proceed in parallel with step 2 — disjoint fields of the same
-   schema.
+   (ante-card handling, reprint policy VALUE) before finalizing this
+   preset's constructor. **Registration as a selectable format is gated on
+   Open item 6 alone** (the metadata value, per §3/§7 — `ReprintPolicy` is
+   not part of `IMPLEMENTED_LEGACY_AXES` since it isn't behavior-bearing) —
+   the constructor and its tests can land in this step, but don't wire it
+   into the format-selection UI/registry as choosable until that item
+   resolves. Can proceed in parallel with step 2 — disjoint fields of the
+   same schema.
 
 **Phase 2 — the four EC formats + the legacy-rules engine work they need.**
 Ships once phase 1 has proven the schema and both axes end-to-end.

--- a/docs/proposals/custom-format-engine/PLAN.md
+++ b/docs/proposals/custom-format-engine/PLAN.md
@@ -1,0 +1,469 @@
+---
+phase: 58-custom-format-engine
+doc: PLAN
+subsystem: engine-formats
+status: research-and-design (no implementation)
+tags: [format, custom-format, legacy-rules, mana-burn]
+---
+
+# Phase 58 — PLAN
+
+Design-only. No code is written in this phase. Below is the proposed
+architecture, the custom-vs-built-in coexistence design, the delivery-surface
+recommendation, and the sequencing.
+
+## Mandatory architectural sections
+
+### Pattern Coverage — build for the class, not the four formats
+
+Every element below handles the *category* "data-driven format", not the four
+EC formats specifically:
+
+- **`CustomFormatDef`** is one schema instantiated N times. The four EC formats
+  are four values; a future "my playgroup's Old-School-plus-Portal" is the
+  N+1th value with zero engine change.
+- **Legal-set membership** is `printings ∩ legal_sets ≠ ∅` — works for any set
+  list, not four hardcoded pools.
+- **Restricted/banned enforcement** reuses the *format-general* CR 100.2b
+  enforcer (`restricted_copy_violations`) and the illegal-card path, sourced
+  from name lists — works for any list.
+- **`LegacyRuleSet`** is three independent rule-module toggles — works for any
+  future era-rule combination, not "old rules on/off".
+
+No arm anywhere may read `if format == OldSchool93_94`. Behavior is driven by
+the resolved `CustomFormatDef` data only.
+
+**Block Constructed — validation that the two axes are genuinely decoupled.**
+"Block Constructed" formats (legality restricted to the sets of one block/era)
+are a clean proof that the design's two axes — the legal-set-code list vs. the
+`LegacyRuleSet` era-rule flags — are properly orthogonal, not entangled:
+
+- A **modern-era block** needs *only* the legal-set-code axis with **all
+  `LegacyRuleSet` flags false / defaulted** (`mana_burn: false`,
+  `damage_uses_stack: false`, `pre_m10_wish_reaches_exile: false`,
+  `legend_rule_scope: Modern`). It is a `CustomFormatDef` that is purely a
+  set-list restriction.
+- A **pre-M10-era block** (a block from before the 2010 "M10" rules update)
+  would set `mana_burn: true` (and potentially `pre_m10_wish_reaches_exile` /
+  `legend_rule_scope` depending on the exact era) via the **same** mechanism —
+  proving `LegacyRuleSet` is *not* special-cased to the four EC presets but is a
+  genuinely general axis any format opts into based on which era's rules it
+  represents. The four EC formats are simply the first four consumers of an axis
+  that is open to Block Constructed and any future era format alike.
+
+**Legal-set list is a plain arbitrary `Vec<SetCode>`, not a "block" enum.**
+Real-world Block Constructed formats have sometimes been legal only for a
+*subset* of a block's sets (not always the full canonical block), so the legal-
+set mechanism is modeled as a plain arbitrary list of set codes (`legal_sets:
+Vec<SetCode>`, §1) rather than any higher-level "block" abstraction tied to
+WotC's own block groupings. Arbitrary subsets fall out of a plain list for free
+— no "block" type, no special-casing, and a format author can include exactly
+the set codes they want. (This also matches the EC formats, whose pools are
+hand-curated set lists that include special reprint sets like CE/ICE and do not
+map onto any single WotC block.)
+
+### Building Blocks — reused, not reinvented
+
+| Need | Existing block reused | Location |
+|------|----------------------|----------|
+| Structural game params (life, deck size, players, sideboard) | `FormatConfig` | `types/format.rs` |
+| Set codes per card | `CardDatabase::printings_for` | `card_db.rs:227` |
+| Format-level 1-copy ceiling (CR 100.2b) | `restricted_copy_violations` + `restricted_canonical` set | `deck_validation.rs:2462` / `:373` |
+| 4-copy default + card-intrinsic overrides (CR 100.2a) | `copy_limit_violations` | `deck_validation.rs:2412` |
+| Illegal-card reporting | existing `illegal_cards` accumulation | `deck_validation.rs:372-406` |
+| Step-end unspent-mana drop (mana-burn hook) | `apply_empty_mana_pool_decisions` Drop arm | `types/mana.rs:1707` |
+| Format registry → frontend | `GameFormat::registry()` / `FormatMetadata` | `format.rs:326` |
+
+New building blocks introduced (all general): `CustomFormatDef`,
+`CustomFormatId`, `ReprintPolicy`, `LegacyRuleSet`, and a
+`custom_format_registry()` of bundled presets.
+
+### Logic Placement — engine owns everything
+
+All of it lives in the `engine` crate. Deck legality, set-membership checks,
+banned/restricted enforcement, and legacy-rule behavior are engine logic. The
+frontend receives the resolved `CustomFormatDef` (or a display projection of it)
+via the existing registry/WASM export and *renders* it — it never re-derives
+legality. This matches "the engine owns all logic / the frontend is a display
+layer".
+
+### Extension vs Creation
+
+We **extend** the existing format system, we do not fork it:
+- One additive `GameFormat::Custom(CustomFormatId)` variant (mirrors the
+  `GameFormat::Limited` additive-variant precedent).
+- `FormatConfig` gains an `Option<CustomFormatRules>` payload — additive field,
+  `None` for all official formats, serde-default so existing serialized configs
+  round-trip.
+- Deck validation gains one match arm that routes `Custom` to a new
+  `evaluate_custom_format` that *calls the existing* copy-limit and restricted
+  enforcers with a data-sourced name set.
+
+### Analogous Trace
+
+`GameFormat::Limited` (phase 53) — see RESEARCH.md §7. We follow its
+compiler-guided "extend every exhaustive match" method exactly, and we inherit
+its lesson that there are two match sites (`format.rs` + `deck_validation.rs`).
+
+## 1. Schema — the general custom-format layer
+
+```text
+CustomFormatId(u16)                     // Copy handle; keeps GameFormat: Copy
+
+GameFormat::Custom(CustomFormatId)      // one additive, typed variant
+
+CustomFormatRules {                     // the resolved ruleset payload
+    id: CustomFormatId,
+    structural: StructuralRules,        // Axis A — see below; first-class, not inherited
+    legality: LegalityRules,            // Axis B — legal_sets/banned/restricted/legacy
+}
+
+// Axis A — "FFA that's super flexible" (maintainer framing, see CONTEXT.md
+// "Maintainer input"). Every field here already exists on `FormatConfig`
+// (`types/format.rs:174-202`) and several are already host-adjustable today in
+// `client/src/components/lobby/HostSetup.tsx` for a chosen built-in
+// `GameFormat` — this struct is a NAMED, SAVEABLE snapshot of that same
+// knob set, not new game-rule surface. This is the axis the lobby "save as
+// custom format" action captures.
+StructuralRules {
+    starting_life: i32,
+    min_players: u8,
+    max_players: u8,
+    deck_size: u16,
+    singleton: bool,
+    range_of_influence: Option<Box<RangeOfInfluenceConfig>>,  // mirrors FormatConfig's field exactly
+    team_based: bool,
+}
+
+// Axis B — legality/era-rules. Genuinely new data; no existing UI surface.
+// This is what makes the four EC formats rules-correct; kept exactly as
+// originally designed, just now named as its own struct rather than sharing
+// `CustomFormatRules`'s top level with Axis A undifferentiated.
+LegalityRules {
+    legal_sets: Vec<SetCode>,           // set codes; membership = pool legality
+    reprint_policy: ReprintPolicy,
+    banned: Vec<CardName>,              // fully illegal
+    restricted: Vec<CardName>,          // legal, max 1 (CR 100.2b path)
+    legacy: LegacyRuleSet,
+}
+
+// A format saved from the lobby ("FFA, but I bumped starting life to 30 and
+// capped it at 4 players") sets `structural` and leaves `legality` at
+// defaults (no set restriction, no legacy rules) — a fully valid
+// `CustomFormatRules` value. The four EC formats set `legality` to real data
+// and `structural` to sane multiplayer/duel defaults. Neither axis requires
+// the other to be present; this is the orthogonality Block Constructed
+// already proved for `LegacyRuleSet` (§ below), now proved a second time
+// between Axis A and Axis B.
+
+ReprintPolicy {                         // enum — enforceable today only at set-code granularity
+    OriginalPrintingsOnly,              // 93-94 / Classic intent (see limitation)
+    AllowSpecialReprintSets,            // CE/ICE/world-champ/proof set codes included in legal_sets
+    AllowAnyPrinting,                   // Middle School "begrudgingly"
+}
+
+// NOT YET DESIGNED — flagged, not resolved, per CONTEXT.md open item #2.
+// `ReprintPolicy` above gates LEGALITY (which printings are legal to play).
+// A user follow-up asks for a sibling, independent axis: DISPLAY DEFAULT
+// (which specific legal printing's frame/art renders by default when a card
+// is added to a deck under this format) — e.g. an old-rules format should
+// default old-frame Alpha/Beta art over a modern reprint's, without forcing
+// the player to manually pick a printing every time.
+//
+// Per CONTEXT.md's corrected finding: this is NOT the same gap as
+// ReprintPolicy's set-code-membership approximation. Legality (engine/MTGJSON,
+// set-codes only) and frame/art data (frontend/Scryfall, already has
+// released_at/border_color/frame_effects/full_art via `scryfall-printings.json`
+// + `preferencesStore`'s `ArtChainEntry`) are two disjoint systems today that
+// have never been cross-referenced. Building this means either (a) new
+// engine-owned derived state — a WASM-exposed "preferred printing for name X
+// given format Y" API, reusing `SetCatalog`/`SetMeta.release_date` (already
+// loaded, already projected to `client/public/set-list.json` for an unrelated
+// purpose) for chronological ordering — or (b) extending the frontend's
+// existing `ArtChainEntry` cosmetic-preference chain with a new variant seeded
+// by the format's reprint policy, treating this as display preference rather
+// than engine-derived game state. (a) fits "engine owns all logic" more
+// cleanly; (b) reuses a system that already does exactly this job for
+// individual players today. This fork needs the same maintainer conversation
+// as the rest of this design — do not build either without it.
+//
+// Whatever shape it takes, per CLAUDE.md's bool-vs-enum rule (and consistent
+// with ReprintPolicy itself being a 3-way enum, not a bool), a bare
+// `use_old_frame: bool` field would be the wrong shape. If/when designed, this
+// should be a typed axis analogous to `ArtChainEntry` — sketch only, NOT a
+// final design:
+//   PrintingDefault {
+//       Newest,                   // today's implicit behavior
+//       OldestLegal,              // oldest printing within this format's legal_sets
+//       SpecificSet(SetCode),     // pin to one set's frame (e.g. "Alpha only" preset)
+//   }
+
+LegacyRuleSet {                         // INDEPENDENT era-rule axes (RESEARCH §8, §10)
+    mana_burn: bool,
+    damage_uses_stack: bool,
+    pre_m10_wish_reaches_exile: bool,   // RESEARCH §9: Wishes reach owned face-up
+                                        // exile (pre-M10 "removed from the game").
+                                        // NOTE: renamed from the first-pass
+                                        // placeholder `pre_m10_wish_templating`
+                                        // — it is a functional POOL-SCOPE toggle,
+                                        // not a wording/templating change.
+    legend_rule_scope: LegendRuleScope, // RESEARCH §10: modern per-controller
+                                        // (default) vs pre-M14 any-controller.
+                                        // A typed enum, NOT a bool (the historical
+                                        // space is not a clean binary and this
+                                        // leaves room without a later refactor).
+}
+
+LegendRuleScope {                       // RESEARCH §10: legend-rule controller scope
+    Modern,                             // CR 704.5j: per-controller + choice (post-2013-07 M14).
+                                        // DEFAULT — all four EC presets use this.
+    PreM14AnyController,                // pre-M14: same-named legends across ALL
+                                        // controllers all go to owners' graveyards,
+                                        // choiceless (Sixth-Edition "both die" form).
+}
+```
+
+**Why `legend_rule_scope` is a general axis, not an EC-preset behavior.** RESEARCH
+§10 establishes the legend-rule scope change (Legends 1994 / pre-M14 = global,
+any-controller; M14 2013-07 = per-controller + choice) is a REAL functional
+difference — but **none of the four EC presets turn it on** (EC's published rules
+list mana burn / damage-on-stack / wish as their only legacy exceptions, never a
+legend-rule reversion), so all four set `LegendRuleScope::Modern`. It is included
+as a general historical-rules axis the engine can express for other era/custom
+formats — exactly the orthogonality Block Constructed proves for `mana_burn`
+(see the note below). Planeswalker uniqueness needs **no** flag: the four EC
+pools top out at Scourge (2003) and planeswalkers postdate that (Lorwyn 2007),
+so no EC-legal card is a planeswalker (RESEARCH §10c).
+
+**Where the payload lives.** `FormatConfig` gains
+`custom_rules: Option<CustomFormatRules>` (serde `#[serde(default,
+skip_serializing_if = "Option::is_none")]`). Because `FormatConfig` is already
+the per-game config carried on `GameState` and serialized across the WASM/P2P
+boundaries, embedding the resolved ruleset there means **no global mutable
+registry** is needed at runtime — deck validation and the mana-burn hook both
+read it from the config they already hold. `GameFormat` stays `Copy` (the heavy
+`Vec`s live in `FormatConfig`, which is `Clone`, not the enum).
+
+**Bundled presets (Axis B)** are typed constructors, exactly analogous to
+`FormatConfig::premodern()`:
+
+```text
+CustomFormatDef::old_school_93_94() -> CustomFormatDef
+CustomFormatDef::old_school_95()    -> extends 93-94's set/list Vecs
+CustomFormatDef::middle_school()    -> restricted empty, larger banned
+CustomFormatDef::classic_magic()    -> own combined lists
+custom_format_registry() -> Vec<CustomFormatDef>   // parallel to GameFormat::registry()
+```
+
+**Lobby saves (Axis A)** produce the identical `CustomFormatDef` shape from a
+different origin — a name plus the live `FormatConfig` a host just finished
+tuning, with `legality` left at defaults:
+
+```text
+CustomFormatDef::from_lobby_config(name: String, config: &FormatConfig) -> CustomFormatDef
+```
+
+Both paths converge on the same `custom_rules: Option<CustomFormatRules>` field
+and the same `GameFormat::Custom(CustomFormatId)` variant — there is exactly
+one runtime representation of "a custom format," authored two different ways.
+See §7 for where each one is surfaced to a player.
+
+(`CustomFormatDef` = display metadata + `CustomFormatRules`; the registry hands
+the frontend labels/short-labels/descriptions just like `FormatMetadata`.)
+
+## 2. Parameterizing the four EC formats as data (not four blocks)
+
+The four formats form an incremental chain. Express it with builder-style reuse,
+mirroring how `FormatConfig::pioneer()` spreads `..Self::standard()`:
+
+- `old_school_93_94()` — base: sets = [LEA, LEB, 2ED, CED, CEI, ARN, ATQ, 3ED,
+  LEG, DRK, FEM]; restricted = [22 names]; banned = [7 names]; legacy = {mana_burn}.
+- `old_school_95()` — `let mut d = old_school_93_94(); d.legal_sets.extend([4ED,
+  ICE, CHR, REN, HML]); d.restricted.extend([Demonic Consultation, Mana Crypt]);
+  d.banned.extend([Amulet of Quoz, Timmerian Fiends]; legacy unchanged`.
+- `middle_school()` — sets = Fourth Edition..Scourge; restricted = []; banned =
+  [25 names]; reprint = AllowAnyPrinting; legacy = {mana_burn, damage_uses_stack,
+  pre_m10_wish_reaches_exile}.
+- `classic_magic()` — sets = Alpha..Scourge; restricted = [37 names]; banned =
+  [11 names]; reprint = OriginalPrintingsOnly; legacy = {mana_burn,
+  damage_uses_stack, pre_m10_wish_reaches_exile}.
+
+Set codes must be verified against the engine's `set_catalog` (MTGJSON codes)
+during implementation — the codes above are the expected MTGJSON codes but
+must be confirmed, not assumed. Card names are validated at preset-construction
+time by a unit test that asserts every banned/restricted name resolves in the
+`CardDatabase` (guards against typos silently no-op'ing a ban).
+
+## 3. Deck-legality algorithm (engine, data-driven)
+
+`evaluate_custom_format(db, request, rules) -> CompatibilityCheck`:
+
+1. Structural checks (deck size, sideboard) via existing `FormatConfig` fields.
+2. Pool legality: for each card, `db.printings_for(name)`; legal iff any
+   printing's set code ∈ `rules.legal_sets`. Else → illegal ("not legal in
+   <format>"), reusing the existing `illegal_cards` accumulation shape.
+3. Banned: name ∈ `rules.banned` → illegal (distinct "banned" label).
+4. Restricted: name ∈ `rules.restricted` → insert into `restricted_canonical`,
+   then call the **existing** `restricted_copy_violations` (CR 100.2b, `<= 1`).
+5. Default 4-copy limit + card-intrinsic overrides via the **existing**
+   `copy_limit_violations`.
+
+This reuses four existing helpers verbatim and adds only the set-membership +
+name-set sourcing. `GameFormat::Custom` gets one arm in
+`format_compatibility_check` routing to `evaluate_custom_format`.
+
+`legality_format()` returns `None` for `Custom` (no `LegalityFormat` mapping —
+custom formats don't use the external legality table). `sideboard_policy`,
+`label`, `for_format`, etc. each get a `Custom` arm reading the resolved def.
+
+## 4. Legacy rules wiring
+
+- **Mana burn** (`LegacyRuleSet.mana_burn`): at the step-end drop site
+  (`types/mana.rs:1707`), tally dropped units per player; after the drain, if
+  the flag is set, deal that many damage to the owner and emit a new
+  `GameEvent::ManaBurn { player_id, amount }`. Annotate as a pre-M10 rule
+  removed by the M10 update (cite the obsolete-glossary entry
+  `MagicCompRules.txt:8277`). ~Small; no new state machine.
+- **Pre-M10 Wish exile access** (`pre_m10_wish_reaches_exile`): fully traced in
+  RESEARCH §9. This is a REAL functional difference (not wording-only): pre-M10,
+  the "removed from the game" zone counted as *outside the game*, so a Wish could
+  retrieve an owned card that had been removed from the game (modern: exile); the
+  M10 update (CR 400.11/400.11a — "outside the game is not a zone"; only the
+  sideboard is outside the game) removed this. The engine already implements the
+  modern (post-M10) Wish cycle generically as `Effect::SearchOutsideGame` with
+  `source_pool: OutsideGameSourcePool::Sideboard` (`types/ability.rs:246`), and
+  already implements owned-face-up-exile retrieval for the Karn/Coax class via
+  `OutsideGameSourcePool::SideboardAndFaceUpExile` + the tested
+  `collect_face_up_exile_candidates` collector and `put_face_up_exile_into` mover
+  (`game/effects/search_outside_game.rs:72,105,141`). **SMALL** (revise the prior
+  "Medium"): the only change is a one-line pool-widening at the existing resolver
+  hook (`search_outside_game.rs:72`) — when the flag on
+  `GameState.format_config` (`types/game_state.rs:6787`) is set, treat a
+  `Sideboard`-pool search as if it were `SideboardAndFaceUpExile`. No parser
+  change (the flag is a runtime-resolution concern, not a parse concern), no new
+  effect/state/WaitingFor, full reuse of the tested collector/mover. Annotate as
+  a legacy rule reverting the M10 change (cite CR 400.11 / 400.11a / 701.23j).
+- **Damage uses the stack** (`damage_uses_stack`): LARGE (RESEARCH §6). Its own
+  sub-project; likely out of MVP. Gated by the flag so Middle School / Classic
+  are playable without it (with a documented fidelity caveat) until it lands.
+- **Legend-rule scope** (`legend_rule_scope`): SMALL (RESEARCH §10). The pre-M14
+  form is *simpler* than the modern one — global (group same-named legendaries
+  across all controllers, no `obj.controller == player_id` filter) and choiceless
+  (all members of a ≥2 group go to owners' graveyards, no `WaitingFor::ChooseLegend`),
+  which is exactly the shape of the existing `check_world_rule` (`sba.rs:1348`,
+  CR 704.5k). The change is one branch at the top of `check_legend_rule`
+  (`sba.rs:902`) selecting global-choiceless vs the current per-controller-choice
+  path based on the resolved `GameState.format_config` scope, reusing the shared
+  `move_sba_departing_permanent` mover (`sba.rs:618`) and the unchanged
+  `legend_rule_exempt_with_gate` filter (`sba.rs:880`). No new WaitingFor, no new
+  mover, no new state machine. **Not used by any of the four EC presets** (all
+  default to `Modern`); shipped as the general historical-rules axis. Annotate as
+  a legacy rule reverting the M14 change (cite CR 704.5j).
+
+## 5. Frontend
+
+The `custom_format_registry()` is exposed through the same WASM export path as
+`GameFormat::registry()`; the client renders custom formats in the picker from
+engine data (label, short-label, description, group). A new `FormatGroup`
+variant (e.g. `Retro` or `Custom`) may be added for visual clustering. No
+legality logic on the client.
+
+## 6. Testing (building-block level, per CLAUDE.md)
+
+- Set-membership legality: assert cards from in-pool and out-of-pool sets pass /
+  fail — for arbitrary set lists, not just the four presets.
+- Restricted path: 2 copies of a restricted-list name flags; 1 copy passes —
+  driven by a synthetic def, proving the general mechanism.
+- Preset integrity: every banned/restricted name in all four presets resolves in
+  the DB; each preset's `legacy` matches the EC spec.
+- Mana burn: unspent N mana at step end deals N with flag on, 0 with flag off —
+  tests the flag+hook, not a specific card.
+- Serde round-trip of `FormatConfig` with `Some(custom_rules)` and `None`.
+- `CustomFormatDef::from_lobby_config`: a `FormatConfig` with non-default
+  `starting_life`/`max_players`/`deck_size`/`range_of_influence`/`team_based`
+  round-trips into a `CustomFormatRules.structural` that matches field-for-
+  field, with `legality` at its defaults — the general Axis-A save mechanism,
+  not a specific saved format's values.
+
+## 7. Delivery surface — RESOLVED via maintainer input, see CONTEXT.md "Maintainer input"
+
+Previously framed as a three-way (a) UI / (b) config / (c) both choice with a
+(b)-first recommendation. **Resolved to (c), entered through Axis A via the
+existing lobby, not a new designer screen and not (b)-first.** The three
+options below are kept for the record; the recommendation that follows
+supersedes the original one.
+
+- **(a) Player-facing designer UI.** A from-scratch client screen to author a
+  format interactively. *Rejected as the entry point* — unnecessarily large
+  (persistence, sharing/import, validation UX all designed before anything
+  ships) when the near-identical capability already has a home.
+- **(b) Operator/preset config.** Formats delivered as bundled, version-
+  controlled preset data (the four EC formats as `CustomFormatDef`
+  constructors), optionally extendable by a self-hosted instance via a config
+  the server loads at startup. *Changes:* schema + presets + one
+  deck-validation arm + the registry export. Presets are typed Rust
+  constructors, audited like `FormatConfig::premodern()`. Still the right
+  shape for Axis B (a banned list should be curated, not free-typed by a
+  player) — no longer the *first* thing to ship, just Axis B's delivery shape.
+- **(c) Both, one schema, Axis-A-first.** Extend the existing lobby
+  (`HostSetup.tsx`) with a "save as custom format" action once a host has
+  tuned `starting_life`/player count/`deck_size`/`range_of_influence`/
+  `team_based`/`singleton` to taste — this calls
+  `CustomFormatDef::from_lobby_config(name, &config)` and registers the
+  result. Axis B ships via (b)'s typed presets, on the same schema, in
+  parallel or immediately after.
+
+**Recommendation: ship (c), Axis-A-first.** Reasoning: (1) a "save" button on a
+screen that already exposes most of Axis A's fields is a *much* smaller slice
+than a new designer UI — no new persistence design, no new sharing mechanism
+beyond whatever the lobby already does for a format choice, no new
+multiplayer-agreement problem (the host's `FormatConfig` is already
+authoritative and transmitted today). (2) It's useful to every casual
+multiplayer table immediately, not gated behind the four EC formats being
+finished. (3) It still fully validates the schema — `CustomFormatDef` is the
+single source of truth whichever path authors it, so the four EC presets
+remain a straightforward Axis B addition on the identical type, not a
+redesign. (4) The harder, genuinely-new Axis B work (legal sets, banned lists,
+legacy rules) is unaffected in scope or design — this only changes what ships
+*first* and *how a player reaches Axis A*, not what Axis B needs to be
+correct.
+
+## 8. Sequencing
+
+1. **General engine** — `CustomFormatId`, `CustomFormatRules` (with
+   `StructuralRules` + `LegalityRules` sub-structs, §1), `ReprintPolicy`,
+   `LegacyRuleSet`, `GameFormat::Custom` variant + all match arms,
+   `FormatConfig.custom_rules`, `evaluate_custom_format` reusing existing
+   enforcers, registry export. (Compiler-guided, mirrors phase 53.)
+2. **Axis A lobby save** — `CustomFormatDef::from_lobby_config`, a "save as
+   custom format" action on `HostSetup.tsx`, and a load path so a saved
+   `CustomFormatDef` appears as a selectable format on return visits. Small
+   frontend-plus-plumbing slice; ships before the EC formats and is useful on
+   its own to any casual table. Validates the schema's Axis A end from a real
+   UI, ahead of Axis B.
+3. **Four EC formats as data (Axis B)** — the four `CustomFormatDef`
+   constructors + registry entries + preset-integrity tests. Validates the
+   engine's Axis B from step 1; can proceed in parallel with step 2 since they
+   touch disjoint fields of the same schema.
+4. **Mana burn** — `LegacyRuleSet.mana_burn` at the drop-site hook. Small.
+   Enables full fidelity for 93-94 / 95 and partial for Middle School / Classic.
+5. **Pre-M10 Wish exile access** (`pre_m10_wish_reaches_exile`) — SMALL
+   (RESEARCH §9); one-line pool-widening at `search_outside_game.rs:72`, gated by
+   the flag, reusing the existing tested face-up-exile collector/mover. Can land
+   with or just after mana burn (step 4).
+6. **Damage uses the stack** — LARGE; its own sub-project; likely post-MVP.
+   Middle School / Classic are playable-with-caveat until it lands.
+7. **Eternal Chaos (stretch)** — depends on 93-94 existing (step 3) **plus** a
+   genuinely new in-match pack-opening mechanic (Booster Tutor / Opening
+   Ceremony / Summon the Pack + tutor-from-opened-packs errata + pack-based
+   sideboard). Not designed here; flagged as a follow-on that is mostly a new
+   *mechanic*, only lightly a new *format*.
+
+## Risks / open items
+
+- **Set-code verification** against `set_catalog` at implementation time (codes
+  in §2 are expected-but-unconfirmed MTGJSON codes).
+- **Reprint-policy fidelity** limited to set-code granularity (RESEARCH §3) —
+  frame/art enforcement needs new per-printing data; flagged for the user.
+- **Damage-uses-the-stack** effort is genuinely large and not fully scoped here;
+  do not commit it to MVP without a dedicated combat-rework spike.

--- a/docs/proposals/custom-format-engine/README.md
+++ b/docs/proposals/custom-format-engine/README.md
@@ -10,17 +10,23 @@ four new `GameFormat` enum variants.
 Originating discussion: [phase-rs/phase#5312](https://github.com/phase-rs/phase/discussions/5312).
 
 - **CONTEXT.md** — why this matters, what's already confirmed against the
-  current codebase, open questions, and how a maintainer's informal framing
+  current codebase, open questions, how a maintainer's informal framing
   ("FFA that's super flexible and you can save a configuration as a custom
-  format") resolved the delivery-surface question.
+  format") resolved the delivery-surface question, and why Swedish Old School
+  93/94 (a distinct, real ruleset — different restricted list, no mana burn)
+  became the phase-1 preset instead of the four EC formats.
 - **RESEARCH.md** — the detailed investigation: current `GameFormat`/
   `FormatConfig` architecture, the four EC formats' verbatim rules, legacy
   rules deltas (mana burn, damage-on-the-stack, pre-M10 Wish, the legend
   rule's historical scope change), and cross-checks against other in-flight
   format work.
 - **PLAN.md** — the proposed schema (`CustomFormatRules` split into a
-  structural `StructuralRules` axis and a legality `LegalityRules` axis),
-  how the four EC formats parameterize as data, and the sequencing.
+  structural `StructuralRules` axis and a legality `LegalityRules` axis), how
+  formats parameterize as data, and the two-phase sequencing (§8): phase 1 is
+  the schema + an existing-lobby "save as custom format" action + Swedish Old
+  School (needs no legacy-rules engine work at all); phase 2 is the four EC
+  formats plus the legacy-rules wiring (mana burn, damage-on-the-stack, wish,
+  legend rule) they need.
 
 This is intended as a discussion artifact for maintainer review, not a
 ready-to-merge implementation plan. Feedback on the schema shape and the

--- a/docs/proposals/custom-format-engine/README.md
+++ b/docs/proposals/custom-format-engine/README.md
@@ -1,0 +1,27 @@
+# Custom ("Design Your Own") Format Engine — Design Proposal
+
+**Status:** research and design only — no engine or frontend code in this PR.
+
+This is a design proposal for a general, data-driven custom-format layer,
+motivated by wanting to support four Eternal Central retro formats (Old
+School 93-94, Old School 95, Middle School, Classic Magic) without hardcoding
+four new `GameFormat` enum variants.
+
+Originating discussion: [phase-rs/phase#5312](https://github.com/phase-rs/phase/discussions/5312).
+
+- **CONTEXT.md** — why this matters, what's already confirmed against the
+  current codebase, open questions, and how a maintainer's informal framing
+  ("FFA that's super flexible and you can save a configuration as a custom
+  format") resolved the delivery-surface question.
+- **RESEARCH.md** — the detailed investigation: current `GameFormat`/
+  `FormatConfig` architecture, the four EC formats' verbatim rules, legacy
+  rules deltas (mana burn, damage-on-the-stack, pre-M10 Wish, the legend
+  rule's historical scope change), and cross-checks against other in-flight
+  format work.
+- **PLAN.md** — the proposed schema (`CustomFormatRules` split into a
+  structural `StructuralRules` axis and a legality `LegalityRules` axis),
+  how the four EC formats parameterize as data, and the sequencing.
+
+This is intended as a discussion artifact for maintainer review, not a
+ready-to-merge implementation plan. Feedback on the schema shape and the
+delivery-surface recommendation (§7 of PLAN.md) is the main ask.

--- a/docs/proposals/custom-format-engine/RESEARCH.md
+++ b/docs/proposals/custom-format-engine/RESEARCH.md
@@ -476,7 +476,7 @@ direct access to it.
 
 ```text
 if source_pool.includes_face_up_exile()
-    || state.format_config.custom_rules's legacy.pre_m10_wish_reaches_exile flag is set
+    || state.format_config.custom_rules's legacy.wish_scope == WishOutsideGameScope::PreM10ReachesExile
 {
     choices.extend(collect_face_up_exile_candidates(state, ability, filter));
 }
@@ -501,13 +501,20 @@ the M10 change* — cite CR 400.11 / 400.11a (the modern boundary being relaxed)
 and CR 701.23j, exactly as mana burn cites the obsolete-glossary entry. The flag
 does **not** implement current CR; it deliberately re-enables removed behavior.
 
-**Naming history (resolved — canonical name is `pre_m10_wish_reaches_exile`
-everywhere in this proposal, including the pseudocode above).** The
-first-pass placeholder name, `pre_m10_wish_templating`, mislabeled a
-*functional pool-scope* toggle as a *wording* one. Flagged by maintainer
-review as a stale reference still appearing in this file when it was
-already reconciled in PLAN.md — fixed here to match. This is not a no-op /
-wording-only flag; it is a real, testable pool-widening.
+**Naming history (resolved — canonical field is `wish_scope:
+WishOutsideGameScope`, its `PreM10ReachesExile` variant is what this section
+means throughout, including the pseudocode above).** Two renames, both
+tracked here so a reader hitting an old name in a stray comment isn't
+confused: the first-pass placeholder `pre_m10_wish_templating` (a bool)
+mislabeled a *functional pool-scope* toggle as a *wording* one, so it became
+`pre_m10_wish_reaches_exile` (still a bool) during round 1. That name was
+itself superseded during the round-4 typed-enum conversion (CONTEXT.md
+"Maintainer review round 4," point 3) — the field is `wish_scope` and the
+type is `WishOutsideGameScope` now. An intermediate maintainer-review pass
+fixed this section's references to the ROUND-1 rename but missed that the
+ROUND-4 rename needed the same reconciliation — caught by an automated
+review pass on the following commit and fixed here in the same pass. This is
+not a no-op / wording-only flag; it is a real, testable pool-widening.
 
 ## 10. Legend rule — historical scope change is REAL; engine hardcodes modern; flag is SMALL
 

--- a/docs/proposals/custom-format-engine/RESEARCH.md
+++ b/docs/proposals/custom-format-engine/RESEARCH.md
@@ -245,10 +245,12 @@ gating a side-effect on an unconditionally-firing event:**
   and dealing; the immediate-dealing path is load-bearing across thousands of
   lines and hundreds of tests. This is plausibly a multi-week combat rework and
   should be treated as its own sub-project, gated behind
-  `LegacyRuleSet.damage_uses_stack`, and very likely **out of the initial MVP**.
-  Middle School and Classic Magic are still *playable* without it (with a
-  documented rules-fidelity caveat) since it only changes response windows in
-  combat.
+  `LegacyRuleSet.damage_timing: CombatDamageTiming::OnStack`, and very likely
+  **out of the initial MVP**. **Per PLAN.md §7's preset-readiness gate
+  (tightened in maintainer review round 4): Middle School and Classic Magic
+  may NOT be registered as selectable formats until this fully lands — there
+  is no "playable without it, with a caveat" interim state.** This retracts
+  the framing this section originally had.
 
 ## 7. Analogous Trace — `GameFormat::Limited` (phase 53 prior art)
 
@@ -414,7 +416,7 @@ direct access to it.
 
 ```text
 if source_pool.includes_face_up_exile()
-    || state.format_config pre_m10_wish_templating flag is set
+    || state.format_config.custom_rules's legacy.pre_m10_wish_reaches_exile flag is set
 {
     choices.extend(collect_face_up_exile_candidates(state, ability, filter));
 }
@@ -439,11 +441,13 @@ the M10 change* — cite CR 400.11 / 400.11a (the modern boundary being relaxed)
 and CR 701.23j, exactly as mana burn cites the obsolete-glossary entry. The flag
 does **not** implement current CR; it deliberately re-enables removed behavior.
 
-**Naming caveat:** `pre_m10_wish_templating` mislabels a *functional pool-scope*
-toggle as a *wording* one. A clearer name is `pre_m10_wish_reaches_exile` (or
-`wish_reaches_removed_from_game`) — it names the actual behavior (Wishes reach
-owned face-up exile). See PLAN naming note. This is not a no-op / wording-only
-flag; it is a real, testable pool-widening.
+**Naming history (resolved — canonical name is `pre_m10_wish_reaches_exile`
+everywhere in this proposal, including the pseudocode above).** The
+first-pass placeholder name, `pre_m10_wish_templating`, mislabeled a
+*functional pool-scope* toggle as a *wording* one. Flagged by maintainer
+review as a stale reference still appearing in this file when it was
+already reconciled in PLAN.md — fixed here to match. This is not a no-op /
+wording-only flag; it is a real, testable pool-widening.
 
 ## 10. Legend rule — historical scope change is REAL; engine hardcodes modern; flag is SMALL
 

--- a/docs/proposals/custom-format-engine/RESEARCH.md
+++ b/docs/proposals/custom-format-engine/RESEARCH.md
@@ -147,69 +147,80 @@ Read `deck_validation.rs` copy-limit + restricted paths in full.
 - **Finding:** reuse `restricted_copy_violations` (the enforcement path), NOT
   `DeckCopyLimit::UpTo`. Correct the task's framing accordingly.
 
-## 5. Mana burn — SMALL; hook point identified (REVISED — maintainer review round 2)
+## 5. Mana burn — hook point identified (REVISED TWICE — maintainer review rounds 2 and 3)
 
-The first pass of this section got two things wrong, both flagged by
-maintainer review and both re-verified directly this session:
+The first pass got two things wrong (round 2 fixed both in the *description*
+but not fully in the *mechanism*); round 2's fix itself was then found
+incomplete (round 3). Both rounds' findings, current state only:
 
-- **It's life loss, not damage.** Modern CR: **mana burn is obsolete.**
-  `docs/MagicCompRules.txt:8277-8278` glossary "Mana Burn (Obsolete)": "Older
-  versions of the rules stated that unspent mana caused a player to **lose
-  life**… That rule no longer exists." (Removed by the 2010 "M10" rules
-  update.) Life loss and damage are behaviorally distinct in this engine
-  (damage can be prevented/redirected and fires "dealt damage" triggers; life
-  loss does neither) — the original "deal that many damage" framing below was
-  wrong, not just imprecisely worded.
-- **It's per real MTG phase, not per engine `Phase` transition.** The
-  engine's `Phase` enum (`types/phase.rs`) is a flat 11-variant list that
-  represents BOTH MTG's 5 real phases and their internal steps as siblings
-  (e.g. `DeclareAttackers`, `DeclareBlockers`, `CombatDamage` are three
-  separate `Phase` variants, all inside the single real "Combat" phase).
-  Modern CR 500.5 empties the mana pool at every one of these transitions —
-  correct for the modern rule — but mana burn (verified directly: it applies
-  at end of **phase**, not at every step within one) must fire only when
-  actually crossing from one real MTG phase into another.
+- **It's life loss, not damage** (round 2, still correct). Modern CR: **mana
+  burn is obsolete.** `docs/MagicCompRules.txt:8277-8278` glossary "Mana Burn
+  (Obsolete)": "Older versions of the rules stated that unspent mana caused a
+  player to **lose life**… That rule no longer exists." (Removed by the 2010
+  "M10" rules update.) Life loss and damage are behaviorally distinct in this
+  engine (damage can be prevented/redirected and fires "dealt damage"
+  triggers; life loss does neither).
+- **It's per real MTG phase, not per engine `Phase` transition — and this
+  requires the mana POOL to persist across intra-phase-group steps, not just
+  the burn CHECK to skip them (round 2 only did the latter; round 3 caught
+  that this is insufficient).** The engine's `Phase` enum (`types/phase.rs`)
+  is a flat 11-variant list representing BOTH MTG's 5 real phases and their
+  internal steps as siblings (e.g. `DeclareAttackers`, `DeclareBlockers`,
+  `CombatDamage` are three separate `Phase` variants, all inside the single
+  real "Combat" phase). Modern CR 500.5 empties the mana pool at **every**
+  one of these transitions unconditionally — round 2 left this unconditional
+  draining untouched and only gated the life-loss side-effect to phase-group
+  boundaries, which means by the time a phase-group boundary was reached the
+  pool had already been silently emptied at the prior intra-phase-group step,
+  with nothing left to burn.
 
-Corrected findings:
+**Corrected mechanism (round 3) — reuses an existing pattern instead of
+gating a side-effect on an unconditionally-firing event:**
 
-- The engine already fully models unspent-mana emptying at every `Phase`
-  transition: `turns.rs:264` "CR 500.5: Mana pools empty between
-  phases/steps", routed through `enter_phase` →
-  `drain_pending_phase_transition_progress` (`turns.rs:295`) → a
-  `ProposedEvent::EmptyManaPool` replacement pipeline (`turns.rs:379`) →
-  `apply_empty_mana_pool_decisions` (`types/mana.rs:1692`) →
-  `apply_empty_mana_pool_event` (`turns.rs`), whose own doc comment already
-  says "CR 106.4 + CR 703.4q: Apply the final replacement-ordered mana
-  dispositions as the step or phase ends, then apply one aggregate
-  Yurlok-class life-loss event."
-- **The engine already has a generic life-loss mechanism for exactly this
-  shape**, not previously connected to this design:
-  `player_unspent_mana_loss_causes_life_loss` (`static_abilities.rs:1237`,
-  backed by `StaticMode::UnspentManaLossCausesLifeLoss`) is checked inside
-  `apply_empty_mana_pool_event` on every `Phase` transition. This is correct
-  for the card-granted (Yurlok-class) version of this ability, which fires
-  every time ANY mana pool empties, at full modern CR 500.5 granularity. It
-  is the wrong granularity for a format-level `mana_burn` flag, which must
-  gate on real-phase boundaries only.
-- **The exact hook point for the format-level flag**: the same
-  `apply_empty_mana_pool_event` call site, gated additionally on a new
-  `fn phase_group(p: Phase) -> PhaseGroup` mapping (5 variants: Beginning,
-  PrecombatMain, Combat, PostcombatMain, Ending — grouping the 11 `Phase`
-  variants by which real MTG phase they belong to; generalizes the ad-hoc
-  `in_combat` bool `turns.rs` already computes inline for combat-duration
-  tracking). When `LegacyRuleSet.mana_burn` is set and `phase_group(current)
-  != phase_group(next)`, apply a second, independent life-loss contribution
-  for that player's dropped mana units (same `UnitDisposition::Drop` arm,
-  `types/mana.rs:1707-1716`, already counts units post-replacement) —
-  alongside, not merged into, the existing Yurlok-class check, since a format
-  flag and a card-granted static ability are different triggers that could
-  both legitimately apply to the same event.
-- **Size: still small.** One new grouping helper, one new gated life-loss
-  contribution at an existing call site, a distinguishable
-  `GameEvent::ManaBurn { player_id, amount }` for the format-level
-  contribution. No new state machine. The infra (per-unit disposition, APNAP
-  drain, replacement pipeline, the Yurlok-class life-loss event shape) already
-  exists — this reuses it rather than inventing a parallel damage path.
+- The engine already has a generic mana-persistence mechanism for exactly
+  this shape: `ManaExpiry` (`types/mana.rs:1509`) has `EndOfTurn` and
+  `EndOfCombat` variants. `EndOfCombat`'s own doc comment: "Mana persists
+  through combat steps but drains at EndCombat → PostCombatMain," used by
+  Firebending — i.e. "persist through this phase's internal steps, drain at
+  the real phase-group boundary," already built and tested, just
+  special-cased to the Combat phase-group. Units carrying an active expiry
+  are excluded from the `Drop` disposition entirely
+  (`turns.rs`, the `u.expiry.is_none()` filter feeding
+  `UnitDecision` construction) — they never reach the empty-pool pipeline
+  while their duration is live.
+- **The fix generalizes this**, rather than gating the life-loss check on an
+  event that already ran unconditionally: add `ManaExpiry::EndOfPhaseGroup`
+  (one new variant, not five per-phase-group ones — it resolves contextually
+  against whichever phase-group is active, exactly as `EndOfCombat`/
+  `EndOfTurn` already do without parameterizing which combat/turn). Mana
+  added while `LegacyRuleSet.mana_burn` is set is tagged with this expiry
+  instead of `None` at construction. The existing expiry-clearing logic
+  (`turns.rs`'s generalization of
+  `clear_expired_end_of_combat_retention_markers`, which already runs where
+  the pre-transition phase is still available — `state.phase = next` doesn't
+  overwrite it until later in `enter_phase`) converts these units to
+  ordinary (`None`-expiry) units only when a real phase-group crossing is
+  detected, at which point they flow into that SAME transition's
+  already-firing `EmptyManaPool` event as `Drop` decisions.
+- Because units never reach `Drop` except at a real phase-group crossing (by
+  construction, mirroring exactly how live `EndOfCombat` units are excluded
+  mid-combat today), the drop count at any transition where a `mana_burn`
+  player's units DO drop *is* the burn amount — apply it as life loss at the
+  same aggregation point `apply_empty_mana_pool_event` already uses for the
+  existing `player_unspent_mana_loss_causes_life_loss` (Yurlok-class,
+  `static_abilities.rs:1237`, `StaticMode::UnspentManaLossCausesLifeLoss`)
+  check, independent of it (a format flag and a card-granted static ability
+  are different triggers that could both apply to the same event), and after
+  any pause the drain takes for a player choice (Kruphix/Horizon Stone `Keep`
+  dispositions) — reusing the pipeline's existing pause/resume point rather
+  than computing before the choice is known.
+- **Size: still small, slightly larger than round 2's estimate.** One new
+  `ManaExpiry` variant, its construction-site tagging, and its
+  clearing-logic wiring — plus the life-loss application at the existing
+  aggregation point, distinguishable via `GameEvent::ManaBurn { player_id,
+  amount }`. No new state machine; reuses the per-unit disposition, APNAP
+  drain, and replacement-pipeline infra that already exists for
+  `EndOfCombat`/`EndOfTurn` and the Yurlok-class check.
 
 ## 6. "Damage uses the stack" — LARGE / deep; honest assessment
 

--- a/docs/proposals/custom-format-engine/RESEARCH.md
+++ b/docs/proposals/custom-format-engine/RESEARCH.md
@@ -57,7 +57,10 @@ during the match.
 
 ### Classic Magic
 - **Legal sets:** Alpha through Scourge (1993–2003) — the full pre-Mirrodin pool.
-- **Restricted (37):** Ancestral Recall, Balance, Black Lotus, Black Vise,
+- **Restricted (44 — corrected this round; the prior "(37)" label
+  disagreed with the enumerated list below, flagged by maintainer review
+  round 2 and recounted directly against this list):** Ancestral Recall,
+  Balance, Black Lotus, Black Vise,
   Braingeyser, Burning Wish, Channel, Demonic Consultation, Demonic Tutor, Fact
   or Fiction, Fastbond, Flash, Gush, Imperial Seal, Library of Alexandria,
   Lion's Eye Diamond, Lotus Petal, Mana Crypt, Mana Vault, Memory Jar, Maze of
@@ -65,7 +68,8 @@ during the match.
   Pearl, Mox Ruby, Mox Sapphire, Mystical Tutor, Necropotence, Regrowth,
   Shahrazad, Sol Ring, Strip Mine, Stroke of Genius, Time Walk, Timetwister,
   Tolarian Academy, Vampiric Tutor, Wheel of Fortune, Windfall, Yawgmoth's
-  Bargain, Yawgmoth's Will. (List as published; count the entries as canonical.)
+  Bargain, Yawgmoth's Will (44 names — the stated count and the enumerated
+  list must agree; see PLAN.md §6's new preset-integrity test requiring this).
 - **Banned:** Amulet of Quoz, Bronze Tablet, Chaos Orb, Contract from Below,
   Darkpact, Demonic Attorney, Falling Star, Jeweled Bird, Rebirth, Tempest
   Efreet, Timmerian Fiends.
@@ -143,32 +147,69 @@ Read `deck_validation.rs` copy-limit + restricted paths in full.
 - **Finding:** reuse `restricted_copy_violations` (the enforcement path), NOT
   `DeckCopyLimit::UpTo`. Correct the task's framing accordingly.
 
-## 5. Mana burn — SMALL; hook point identified
+## 5. Mana burn — SMALL; hook point identified (REVISED — maintainer review round 2)
 
-- Modern CR: **mana burn is obsolete.** `docs/MagicCompRules.txt:8277-8278`
-  glossary "Mana Burn (Obsolete)": "Older versions of the rules stated that
-  unspent mana caused a player to lose life… That rule no longer exists."
-  (Removed by the 2010 "M10" rules update.) So implementing it is adding an
-  *optional legacy rule* absent from current CR — annotate as pre-M10/removed,
-  citing the obsolete-glossary entry.
-- The engine already fully models unspent-mana emptying at step/phase
-  boundaries: `turns.rs:264` "CR 500.5: Mana pools empty between phases/steps",
-  routed through `enter_phase` → `drain_pending_phase_transition_progress`
-  (`turns.rs:295`) → a `ProposedEvent::EmptyManaPool` replacement pipeline
-  (`turns.rs:379`) → `apply_empty_mana_pool_decisions` (`types/mana.rs:1692`).
-- **The exact hook point** is the `UnitDisposition::Drop` arm
-  (`types/mana.rs:1707-1716`): each dropped unit is `player.mana_pool.mana
-  .remove(...)` and emits `GameEvent::ManaPoolEmptied`. Mana burn = count the
-  units actually dropped for a player during a step-end empty and, when the
-  active `LegacyRuleSet.mana_burn` flag is set, deal that many damage to that
-  player's owner at that same point.
-- **Size: small.** One flag check + a damage application at (or just after) the
-  drop site, plus a `GameEvent` for the burn. No new state machine. The infra
-  (per-unit disposition, APNAP drain, replacement pipeline) already exists.
-  Care needed: burn is per *point of unspent mana*, counted after replacement
-  effects (Kruphix/Horizon Stone `Keep` dispositions) have run — the Drop-arm
-  count already reflects that, which is why the drop site (not the pre-pipeline
-  pool) is the correct hook.
+The first pass of this section got two things wrong, both flagged by
+maintainer review and both re-verified directly this session:
+
+- **It's life loss, not damage.** Modern CR: **mana burn is obsolete.**
+  `docs/MagicCompRules.txt:8277-8278` glossary "Mana Burn (Obsolete)": "Older
+  versions of the rules stated that unspent mana caused a player to **lose
+  life**… That rule no longer exists." (Removed by the 2010 "M10" rules
+  update.) Life loss and damage are behaviorally distinct in this engine
+  (damage can be prevented/redirected and fires "dealt damage" triggers; life
+  loss does neither) — the original "deal that many damage" framing below was
+  wrong, not just imprecisely worded.
+- **It's per real MTG phase, not per engine `Phase` transition.** The
+  engine's `Phase` enum (`types/phase.rs`) is a flat 11-variant list that
+  represents BOTH MTG's 5 real phases and their internal steps as siblings
+  (e.g. `DeclareAttackers`, `DeclareBlockers`, `CombatDamage` are three
+  separate `Phase` variants, all inside the single real "Combat" phase).
+  Modern CR 500.5 empties the mana pool at every one of these transitions —
+  correct for the modern rule — but mana burn (verified directly: it applies
+  at end of **phase**, not at every step within one) must fire only when
+  actually crossing from one real MTG phase into another.
+
+Corrected findings:
+
+- The engine already fully models unspent-mana emptying at every `Phase`
+  transition: `turns.rs:264` "CR 500.5: Mana pools empty between
+  phases/steps", routed through `enter_phase` →
+  `drain_pending_phase_transition_progress` (`turns.rs:295`) → a
+  `ProposedEvent::EmptyManaPool` replacement pipeline (`turns.rs:379`) →
+  `apply_empty_mana_pool_decisions` (`types/mana.rs:1692`) →
+  `apply_empty_mana_pool_event` (`turns.rs`), whose own doc comment already
+  says "CR 106.4 + CR 703.4q: Apply the final replacement-ordered mana
+  dispositions as the step or phase ends, then apply one aggregate
+  Yurlok-class life-loss event."
+- **The engine already has a generic life-loss mechanism for exactly this
+  shape**, not previously connected to this design:
+  `player_unspent_mana_loss_causes_life_loss` (`static_abilities.rs:1237`,
+  backed by `StaticMode::UnspentManaLossCausesLifeLoss`) is checked inside
+  `apply_empty_mana_pool_event` on every `Phase` transition. This is correct
+  for the card-granted (Yurlok-class) version of this ability, which fires
+  every time ANY mana pool empties, at full modern CR 500.5 granularity. It
+  is the wrong granularity for a format-level `mana_burn` flag, which must
+  gate on real-phase boundaries only.
+- **The exact hook point for the format-level flag**: the same
+  `apply_empty_mana_pool_event` call site, gated additionally on a new
+  `fn phase_group(p: Phase) -> PhaseGroup` mapping (5 variants: Beginning,
+  PrecombatMain, Combat, PostcombatMain, Ending — grouping the 11 `Phase`
+  variants by which real MTG phase they belong to; generalizes the ad-hoc
+  `in_combat` bool `turns.rs` already computes inline for combat-duration
+  tracking). When `LegacyRuleSet.mana_burn` is set and `phase_group(current)
+  != phase_group(next)`, apply a second, independent life-loss contribution
+  for that player's dropped mana units (same `UnitDisposition::Drop` arm,
+  `types/mana.rs:1707-1716`, already counts units post-replacement) —
+  alongside, not merged into, the existing Yurlok-class check, since a format
+  flag and a card-granted static ability are different triggers that could
+  both legitimately apply to the same event.
+- **Size: still small.** One new grouping helper, one new gated life-loss
+  contribution at an existing call site, a distinguishable
+  `GameEvent::ManaBurn { player_id, amount }` for the format-level
+  contribution. No new state machine. The infra (per-unit disposition, APNAP
+  drain, replacement pipeline, the Yurlok-class life-loss event shape) already
+  exists — this reuses it rather than inventing a parallel damage path.
 
 ## 6. "Damage uses the stack" — LARGE / deep; honest assessment
 

--- a/docs/proposals/custom-format-engine/RESEARCH.md
+++ b/docs/proposals/custom-format-engine/RESEARCH.md
@@ -21,6 +21,7 @@ Summon the Pack restricted to 1) plus errata allowing tutoring from packs opened
 during the match.
 
 ### Old School 93-94
+- **Source:** `raw.githubusercontent.com/northern-information/lordsofthepit.com/main/src/pages/formats.md`, fetched 2026-07-07 (same fetch as the section header above — repeated here so this format's data is independently checkable without scrolling to a shared citation).
 - **Legal sets:** Alpha, Beta, Unlimited, Collector's Edition, International
   Collector's Edition, Arabian Nights, Antiquities, Revised, Legends, The Dark,
   Fallen Empires.
@@ -36,6 +37,8 @@ during the match.
   and a "no draws" 50-minute Chaos-Orb tiebreaker — tournament-ops, not engine.)
 
 ### Old School 95
+- **Source:** same fetch as Old School 93-94, above — 95 is published on the
+  same page as an incremental extension of 93-94's own lists.
 - **Legal sets:** all of 93-94 **plus** Fourth Edition, Ice Age, Chronicles,
   Renaissance, Homelands.
 - **Restricted:** 93-94's list **plus** Demonic Consultation, Mana Crypt.
@@ -43,6 +46,7 @@ during the match.
 - **Legacy rules:** mana burn only.
 
 ### Middle School
+- **Source:** same fetch as Old School 93-94, above.
 - **Legal sets:** Fourth Edition through Scourge (1995–2003).
 - **Restricted:** NONE. Instead, 25 cards fully **banned:** Amulet of Quoz,
   Balance, Brainstorm, Bronze Tablet, Channel, Dark Ritual, Demonic
@@ -56,6 +60,7 @@ during the match.
   templating (all three).
 
 ### Classic Magic
+- **Source:** same fetch as Old School 93-94, above.
 - **Legal sets:** Alpha through Scourge (1993–2003) — the full pre-Mirrodin pool.
 - **Restricted (44 — corrected this round; the prior "(37)" label
   disagreed with the enumerated list below, flagged by maintainer review
@@ -83,6 +88,61 @@ Built on 93-94 base; adds Booster Tutor ×4, Opening Ceremony ×4, Summon the Pa
 ×1; errata to tutor from packs opened during the match; sideboard = packs;
 one new pack cracked between games; all pack cards removed after match; optional
 per-match "Gentleman's Agreement" banlist.
+
+### Swedish Old School 93/94 (the phase-1 target preset — see CONTEXT.md)
+
+**A different, real ruleset from the four EC formats above — not the same
+source, not a duplicate.** Given its own section here, matching the EC
+formats' treatment, because it's the actual first preset this proposal ships
+(§2/§8) and deserves the same direct, checkable citation.
+
+- **Source:** `http://oldschool-mtg.blogspot.com/p/banrestriction.html`,
+  fetched directly this session (2026-07-15) via `WebFetch`, not from
+  memory or a secondary summary. Distinct from the EC ruleset above — Sweden
+  is the historical origin community for "Old School 93/94" as a movement,
+  and its published rules differ from EC's in real, substantive ways (see
+  below), not just presentation.
+- **Legal sets:** Alpha, Beta, Unlimited, Arabian Nights, Antiquities,
+  Legends, The Dark, "Summer Magic" (a distinct, small 1994 print run — its
+  MTGJSON set code is unconfirmed pending implementation-time verification,
+  same caveat PLAN.md §2 already carries for every set code in this
+  proposal).
+  - Also stated by this source: **"Only English versions are allowed in
+    Oldschool"** — a language restriction with no current engine
+    representation; not modeled by this proposal (out of scope, same as the
+    already-noted physical-tournament logistics in the Classic
+    Legacy/"Lost Legacy" section below).
+- **Banned:** NONE — the source states no card is fully banned under the
+  Swedish ruleset, a genuinely empty list (distinct from EC's 93-94, which
+  bans 7 named cards).
+- **Restricted (25, one-copy maximum):** Ancestral Recall, Balance, Black
+  Lotus, Braingeyser, Channel, Chaos Orb, Contract from Below, Darkpact,
+  Demonic Tutor, Library of Alexandria, Mana Drain, Mind Twist, Mishra's
+  Workshop, Mox Emerald, Mox Jet, Mox Pearl, Mox Ruby, Mox Sapphire,
+  Regrowth, Sol Ring, Strip Mine, Tempest Efreet, Time Walk, Timetwister,
+  Wheel of Fortune — a **different 25-name list from EC's 93-94's 22-name
+  list above** (compare directly: EC includes Recall and Time Vault, absent
+  here; Swedish includes Contract from Below, Darkpact, Demonic Tutor,
+  Library of Alexandria, and Mishra's Workshop, absent from EC's list) —
+  confirms this is a genuinely independent ruleset, not a re-presentation of
+  EC's.
+- **Ante cards** (a THIRD list-shaped rule, distinct from banned/restricted —
+  see CONTEXT.md Open item 5): "must be removed before play unless the
+  tournament is specifically played for ante" — Bronze Tablet, Contract
+  from Below, Darkpact, Demonic Attorney, Jeweled Bird, Rebirth, Tempest
+  Efreet.
+- **Reprint policy:** NOT stated by this source beyond "Only English
+  versions are allowed" — see CONTEXT.md Open item 6. A secondary source
+  (`mtgoldframe.com`) claims no Revised-or-later reprints are allowed, but
+  that claim was not independently verified against this primary source and
+  must not be encoded without doing so.
+- **Legacy rules:** NO mention of mana burn, damage-on-the-stack, old Wish
+  templating, or a modified legend rule anywhere in this source — the plain
+  reading is fully modern rules on a restricted-era card pool, confirmed by
+  the ABSENCE of any of the legacy-rule language the EC sections above all
+  state explicitly for their own formats. This is why `swedish_old_school()`
+  (PLAN.md §2) sets every `LegacyRuleSet` axis to its `Modern` default and
+  needs none of §4's engine wiring.
 
 ## 2. Legality-pipeline gap — CONFIRMED absent
 

--- a/docs/proposals/custom-format-engine/RESEARCH.md
+++ b/docs/proposals/custom-format-engine/RESEARCH.md
@@ -1,0 +1,545 @@
+---
+phase: 58-custom-format-engine
+doc: RESEARCH
+subsystem: engine-formats
+status: research-and-design (no implementation)
+---
+
+# Phase 58 — RESEARCH
+
+All findings below are from reading source this session. File:line citations
+are given; where a search found nothing relevant that is stated explicitly.
+
+## 1. EC ruleset (re-verified 2026-07-07, raw GitHub fetch)
+
+Fetched `raw.githubusercontent.com/northern-information/lordsofthepit.com/main/src/pages/formats.md`.
+Matches the 2026-07-07 background with two clarifications: (a) 93-94's and 95's
+**legal-set lists explicitly include Collector's Edition + International
+Collector's Edition** as reprint sources; (b) Eternal Chaos's mechanic is
+implemented via three "boostie" cards (Booster Tutor ×4, Opening Ceremony ×4,
+Summon the Pack restricted to 1) plus errata allowing tutoring from packs opened
+during the match.
+
+### Old School 93-94
+- **Legal sets:** Alpha, Beta, Unlimited, Collector's Edition, International
+  Collector's Edition, Arabian Nights, Antiquities, Revised, Legends, The Dark,
+  Fallen Empires.
+- **Restricted (1 copy):** Ancestral Recall, Balance, Black Lotus, Braingeyser,
+  Chaos Orb, Channel, Demonic Tutor, Library of Alexandria, Mana Drain, Mind
+  Twist, Mox Emerald, Mox Jet, Mox Pearl, Mox Ruby, Mox Sapphire, Recall,
+  Regrowth, Sol Ring, Time Vault, Time Walk, Timetwister, Wheel of Fortune.
+- **Banned:** Bronze Tablet, Contract from Below, Darkpact, Demonic Attorney,
+  Jeweled Bird, Rebirth, Tempest Efreet.
+- **Reprint policy:** non-foil reprints with original frame + art, any language;
+  no proxies.
+- **Legacy rules:** mana burn only. (Plus Chaos Orb / Falling Star flip Oracle,
+  and a "no draws" 50-minute Chaos-Orb tiebreaker — tournament-ops, not engine.)
+
+### Old School 95
+- **Legal sets:** all of 93-94 **plus** Fourth Edition, Ice Age, Chronicles,
+  Renaissance, Homelands.
+- **Restricted:** 93-94's list **plus** Demonic Consultation, Mana Crypt.
+- **Banned:** 93-94's list **plus** Amulet of Quoz, Timmerian Fiends.
+- **Legacy rules:** mana burn only.
+
+### Middle School
+- **Legal sets:** Fourth Edition through Scourge (1995–2003).
+- **Restricted:** NONE. Instead, 25 cards fully **banned:** Amulet of Quoz,
+  Balance, Brainstorm, Bronze Tablet, Channel, Dark Ritual, Demonic
+  Consultation, Flash, Goblin Recruiter, Imperial Seal, Jeweled Bird, Mana
+  Crypt, Mana Vault, Memory Jar, Mind's Desire, Mind Twist, Rebirth, Strip Mine,
+  Tempest Efreet, Timmerian Fiends, Tolarian Academy, Vampiric Tutor, Windfall,
+  Yawgmoth's Bargain, Yawgmoth's Will.
+- **Reprint policy:** permissive — CE/ICE, world-championship, artist proofs,
+  and even modern-bordered reprints "begrudgingly" allowed.
+- **Legacy rules:** mana burn **AND** damage-uses-the-stack **AND** pre-M10 wish
+  templating (all three).
+
+### Classic Magic
+- **Legal sets:** Alpha through Scourge (1993–2003) — the full pre-Mirrodin pool.
+- **Restricted (37):** Ancestral Recall, Balance, Black Lotus, Black Vise,
+  Braingeyser, Burning Wish, Channel, Demonic Consultation, Demonic Tutor, Fact
+  or Fiction, Fastbond, Flash, Gush, Imperial Seal, Library of Alexandria,
+  Lion's Eye Diamond, Lotus Petal, Mana Crypt, Mana Vault, Memory Jar, Maze of
+  Ith, Merchant Scroll, Mind Twist, Mind's Desire, Mox Emerald, Mox Jet, Mox
+  Pearl, Mox Ruby, Mox Sapphire, Mystical Tutor, Necropotence, Regrowth,
+  Shahrazad, Sol Ring, Strip Mine, Stroke of Genius, Time Walk, Timetwister,
+  Tolarian Academy, Vampiric Tutor, Wheel of Fortune, Windfall, Yawgmoth's
+  Bargain, Yawgmoth's Will. (List as published; count the entries as canonical.)
+- **Banned:** Amulet of Quoz, Bronze Tablet, Chaos Orb, Contract from Below,
+  Darkpact, Demonic Attorney, Falling Star, Jeweled Bird, Rebirth, Tempest
+  Efreet, Timmerian Fiends.
+- **Reprint policy:** old-bordered cards only; new-border of any kind illegal
+  (proxy or not).
+- **Legacy rules:** mana burn AND damage-uses-the-stack AND wish-cycle
+  restoration. B&R twice yearly (Jan 1 / Jul 1).
+
+### Eternal Chaos (stretch — not designed in depth)
+Built on 93-94 base; adds Booster Tutor ×4, Opening Ceremony ×4, Summon the Pack
+×1; errata to tutor from packs opened during the match; sideboard = packs;
+one new pack cracked between games; all pack cards removed after match; optional
+per-match "Gentleman's Agreement" banlist.
+
+## 2. Legality-pipeline gap — CONFIRMED absent
+
+- `card_db.rs:109` — `let normalized = normalize_legalities(&entry.legalities);`
+  is the single ingest site. Source is MTGJSON `AtomicCard.legalities`
+  (`oracle_gen.rs:778/814/883`).
+- `LegalityFormat` (`legality.rs:12-28`) has 15 variants; **none** are
+  oldschool/middleschool/classic. `from_key` (`legality.rs:69-88`) returns
+  `None` for any unlisted key, and `normalize_legalities` (`legality.rs:125-137`)
+  `continue`s past `None` — the key is dropped.
+- The test at `legality.rs:286-313` uses `"oldschool"`-shaped names as the
+  canonical example of "unknown keys are dropped".
+- **Conclusion:** the four EC formats have zero per-card legality signal in the
+  pipeline, and even if MTGJSON published one for `oldschool` it wouldn't
+  survive normalization today. The custom-format engine must define its own
+  legal-set-code + banned/restricted-name mechanism and must NOT depend on
+  external per-card legality data. This is *correct* — Scryfall/MTGJSON cannot
+  be relied on to track player-authored custom formats.
+
+## 3. Set-membership + reprint policy — building block confirmed, one data gap
+
+- `CardDatabase::printings_for(name) -> Option<&[String]>` (`card_db.rs:227-230`)
+  returns set codes; backed by `printings_index` populated from the export
+  `printings` field (`card_db.rs:101-103`).
+- **This is the enforceable legality key**: a card is pool-legal for a custom
+  format iff at least one of its printings' set codes is in the format's
+  `legal_sets` list.
+- **Data gap:** printings are *set codes only* — there is **no per-printing
+  frame/border/art metadata** in the runtime DB. So "original frame/art only"
+  (93-94) vs "old-border only" (Classic) vs "modern border begrudgingly allowed"
+  (Middle School) are **not fully distinguishable** from current data. However,
+  set-code membership is a *good approximation*: a modern reprint of an Alpha
+  card lives in a modern set code, which is simply not in `legal_sets`, so it is
+  excluded automatically. The reprint-policy nuance mainly affects special
+  reprint set codes (CE/ICE/world-championship/artist-proof), which are
+  themselves distinct set codes and can be added/omitted from `legal_sets` per
+  format. **Recommendation:** model reprint policy as *which set codes are in the
+  legal list*, and flag frame/art-level fidelity as a known limitation (needs a
+  new per-printing data field if we ever want to enforce it precisely).
+
+## 4. `DeckCopyLimit::UpTo(1)` reuse — feasible for the ceiling, WRONG layer for the source
+
+Read `deck_validation.rs` copy-limit + restricted paths in full.
+
+- `DeckCopyLimit` (`format.rs:100-105`) is a **card-intrinsic** override: it
+  models what an individual card's *own rules text* says ("A deck can have up to
+  N cards named ~", "only one copy"). It is resolved per-card from
+  `face.deck_copy_limit` / Oracle text in `copy_limit_violations`
+  (`deck_validation.rs:2412-2449`, esp. the `UpTo(n)` arm at 2434-2435).
+- A format **restricted list** is a *format-level policy*, not a property of the
+  card. Overloading `DeckCopyLimit::UpTo(1)` to carry it would conflate two
+  abstraction layers — exactly the smell CLAUDE.md's "separate abstraction
+  layers in enum design" warns against. (It would also break for a card that has
+  BOTH a real intrinsic limit and a format restriction.)
+- **The right existing building block already exists**:
+  `restricted_copy_violations` (`deck_validation.rs:2462-2485`) enforces the CR
+  100.2b `<= 1` ceiling **format-generally**, driven by a `restricted_canonical:
+  HashSet<String>` of names. Today that set is populated from
+  `LegalityStatus::Restricted` (`deck_validation.rs:388-390`). For a custom
+  format we simply populate the *same* set from the format's restricted-name
+  list, and reuse the *same* enforcer. Zero new copy-limit concept needed.
+- **Finding:** reuse `restricted_copy_violations` (the enforcement path), NOT
+  `DeckCopyLimit::UpTo`. Correct the task's framing accordingly.
+
+## 5. Mana burn — SMALL; hook point identified
+
+- Modern CR: **mana burn is obsolete.** `docs/MagicCompRules.txt:8277-8278`
+  glossary "Mana Burn (Obsolete)": "Older versions of the rules stated that
+  unspent mana caused a player to lose life… That rule no longer exists."
+  (Removed by the 2010 "M10" rules update.) So implementing it is adding an
+  *optional legacy rule* absent from current CR — annotate as pre-M10/removed,
+  citing the obsolete-glossary entry.
+- The engine already fully models unspent-mana emptying at step/phase
+  boundaries: `turns.rs:264` "CR 500.5: Mana pools empty between phases/steps",
+  routed through `enter_phase` → `drain_pending_phase_transition_progress`
+  (`turns.rs:295`) → a `ProposedEvent::EmptyManaPool` replacement pipeline
+  (`turns.rs:379`) → `apply_empty_mana_pool_decisions` (`types/mana.rs:1692`).
+- **The exact hook point** is the `UnitDisposition::Drop` arm
+  (`types/mana.rs:1707-1716`): each dropped unit is `player.mana_pool.mana
+  .remove(...)` and emits `GameEvent::ManaPoolEmptied`. Mana burn = count the
+  units actually dropped for a player during a step-end empty and, when the
+  active `LegacyRuleSet.mana_burn` flag is set, deal that many damage to that
+  player's owner at that same point.
+- **Size: small.** One flag check + a damage application at (or just after) the
+  drop site, plus a `GameEvent` for the burn. No new state machine. The infra
+  (per-unit disposition, APNAP drain, replacement pipeline) already exists.
+  Care needed: burn is per *point of unspent mana*, counted after replacement
+  effects (Kruphix/Horizon Stone `Keep` dispositions) have run — the Drop-arm
+  count already reflects that, which is why the drop site (not the pre-pipeline
+  pool) is the correct hook.
+
+## 6. "Damage uses the stack" — LARGE / deep; honest assessment
+
+- Modern combat damage is **simultaneous and explicitly does NOT use the
+  stack**: `docs/MagicCompRules.txt:2406` "CR 510.2 … This turn-based action
+  doesn't use the stack. No player has the chance to cast spells or activate
+  abilities between the time combat damage is assigned and the time it's dealt."
+- The engine implements exactly this modern model in
+  `game/combat_damage.rs` (**3,658 lines**) as a simultaneous batch
+  (`resolve_combat_damage`, `combat_damage.rs:102`; batch/replacement machinery
+  throughout — see the "batch" references at 814/832/862/926). `combat.rs` is a
+  further 10,821 lines. `engine_combat.rs::handle_assign_combat_damage`
+  (`engine_combat.rs:538`) drives assignment then calls
+  `resolve_combat_damage` immediately — there is **no intermediate
+  priority/stack round** between assignment and dealing.
+- Pre-6th-edition "damage on the stack" put assigned combat damage **on the
+  stack as a stack object** that players could respond to before it resolved.
+  That is a *reversal of CR 510.2's control flow* and touches the combat step
+  state machine, the stack, and priority passing — not a leaf value.
+- **Size: large, and I will not guess a smaller number to look complete.** There
+  is no existing hook-point for interposing priority between damage assignment
+  and dealing; the immediate-dealing path is load-bearing across thousands of
+  lines and hundreds of tests. This is plausibly a multi-week combat rework and
+  should be treated as its own sub-project, gated behind
+  `LegacyRuleSet.damage_uses_stack`, and very likely **out of the initial MVP**.
+  Middle School and Classic Magic are still *playable* without it (with a
+  documented rules-fidelity caveat) since it only changes response windows in
+  combat.
+
+## 7. Analogous Trace — `GameFormat::Limited` (phase 53 prior art)
+
+From `git show 80404a98b:.planning/phases/53-limited-draft-core/53-01-SUMMARY.md`:
+
+Adding `GameFormat::Limited` was a single, tightly-scoped TDD change:
+- Added `Limited` to `FormatGroup` and `GameFormat`.
+- Added `FormatConfig::limited()` (40-card, 20 life, 2-player).
+- Extended **all** exhaustive match arms: `legality_format` (`None`),
+  `sideboard_policy` (`Unlimited`), `label`, `for_format`, plus the registry.
+- The one "surprise" was a second exhaustive match in
+  `deck_validation.rs::format_compatibility_check` that also required an arm —
+  the compiler caught it (non-exhaustive match error), and it was added as a
+  pass-through.
+- RED→GREEN→(no REFACTOR); 8 new tests; full engine suite stayed green.
+
+**Lessons this phase inherits:**
+1. An additive `GameFormat` variant is a well-trodden, compiler-guided path —
+   every exhaustive match is a checklist the compiler enforces.
+2. There are **two** exhaustive-match sites to remember: `format.rs` and
+   `deck_validation.rs`. Grep for `match .*format` / `GameFormat::` before
+   assuming five arms.
+3. Structural params (life/deck/players) live in `FormatConfig`; legality is a
+   separate axis (`legality_format` → `LegalityFormat`). Our custom layer must
+   respect that separation but *replace* the `LegalityFormat` axis with a
+   set-list + name-list payload, because custom formats have no `LegalityFormat`.
+
+## 8. Idiomatic-Rust note on the legacy-rules axis
+
+Mana burn, damage-uses-stack, and pre-M10 wish templating are **independent**
+binary rule-modules (93-94 = burn only; Middle School/Classic = burn + stack +
+wish). They are not mutually exclusive and not orderable, so an `enum` is the
+*wrong* model (it cannot express "burn + wish, no stack" without enumerating
+2^N combinations). The idiomatic model is a small struct of documented `bool`
+fields (or `bitflags`), each gating one independent rules module — this is the
+one place a bool cluster is correct precisely because each axis is a separate
+CR-era toggle. This satisfies CLAUDE.md's intent ("mana burn and
+damage-uses-stack do NOT travel together… never a single old-rules boolean")
+while staying honest that the members are independent switches, not a
+parameterization of one axis.
+
+## 9. Pre-M10 Wish templating — SMALL (building block already exists); REAL functional difference
+
+This flag was named in §8 and the `LegacyRuleSet` struct but never investigated
+in the first pass. This section closes that gap with the same rigor as §5/§6.
+
+### 9a. What the EC ruleset actually requires (re-fetched 2026-07-07)
+
+Re-fetched `raw.githubusercontent.com/northern-information/lordsofthepit.com/main/src/pages/formats.md`.
+Both Middle School and Classic Magic restore the Judgment Wish cycle to
+pre-M10 function, worded verbatim as:
+
+> "…Cunning Wish, Burning Wish, Living Wish, Death Wish, and Golden Wish were
+> originally able to find an appropriate card that had either been removed from
+> the game, or was located in your sideboard. The Wish cycle functionality has
+> been restored to allow this."
+
+So the required behavior is explicit: a Wish may retrieve a matching card the
+player owns **that has been removed from the game** (modern: exile), in
+addition to the sideboard.
+
+### 9b. What the M10 (Magic 2010, July 2009) update actually changed — REAL, not wording-only
+
+The M10 rules update renamed the **"removed from the game" zone to "exile"** and
+made exile a *defined in-game zone*. Sources:
+
+- MTG Wiki "Wish" / Magic Judges rules tips (`blogs.magicjudges.org/rulestips/2013/01/you-cant-burning-wish-for-exiled-cards/`):
+  "the exile zone is a zone in the game, those cards aren't outside of the game,
+  so you can no longer Wish for those cards." Before M10, Wishes could acquire
+  a card from the sideboard **or** a card that had been "removed from the game";
+  after M10, only the sideboard qualifies.
+- Current CR confirms the *modern* boundary this flag reverts:
+  - `docs/MagicCompRules.txt:1982` — **CR 400.11**: "An object is outside the
+    game if it isn't in any of the game's zones. **Outside the game is not a
+    zone.**"
+  - `docs/MagicCompRules.txt:1984` — **CR 400.11a**: "Cards in a player's
+    sideboard are outside the game."
+  - `docs/MagicCompRules.txt:3486` — **CR 701.23j**: "If an effect instructs a
+    player to search outside the game for a card, that player may choose an
+    appropriate card they own from outside the game."
+  - Exile (CR 406) is a normal in-game zone, so exiled cards are *not* "outside
+    the game" and are ineligible for a modern Wish.
+
+**Verdict: this is a genuine functional / gameplay difference, NOT a
+wording-only templating change.** It changes the *set of legal choices offered
+during resolution*: a card exiled during the game (e.g. by the Wish's own
+"Exile ~" clause, by cycling/foretell-era effects, by an opponent's exile
+removal, etc.) is a legal Wish target pre-M10 and an illegal one post-M10. That
+is directly observable at the table, so the engine must model it — it is not a
+no-op flag. (The label "templating" in the flag name is therefore a slight
+misnomer; see §9e and the PLAN naming note.)
+
+### 9c. phase.rs already implements the Wish cycle — in modern (post-M10) form
+
+The engine has a full, general outside-the-game search effect, and the M10
+distinction is already a first-class typed axis:
+
+- **`Effect::SearchOutsideGame { filter, count, reveal, destination, source_pool }`**
+  (`types/ability.rs:10347-10356`).
+- **`OutsideGameSourcePool`** (`types/ability.rs:246-260`) is exactly the M10
+  boundary as a typed enum:
+  - `Sideboard` (default) — "CR 400.11a: Tournament sideboard / casual
+    outside-the-game collection." This is the **post-M10 Wish** pool.
+  - `SideboardAndFaceUpExile` — "CR 400.11a + CR 406.3: Sideboard plus matching
+    owned face-up exile." Used today for the modern **Karn, the Great Creator /
+    Coax from the Blind Eternities** class, whose Oracle text has an explicit
+    "…or choose a face-up … card you own in exile" disjunction.
+  - Helper `includes_face_up_exile()` (`ability.rs:257-259`).
+- **Parser** (`parser/oracle_effect/imperative.rs:2711-2818`,
+  `parse_search_and_creation_ast`): "reveal/play/cast a … card you own from
+  outside the game" lowers to `SearchOutsideGame`. A single-branch wording gets
+  `source_pool: Sideboard`; only the explicit second "…or choose a face-up …
+  in exile" branch (`parse_face_up_exile_branch`, `imperative.rs:2763-2768`)
+  produces `SideboardAndFaceUpExile`. Wish-cycle cards therefore parse to the
+  **sideboard-only (post-M10)** pool today, verified by tests:
+  - `parse_outside_game_wish_reveal_to_hand` (`imperative.rs:12312`),
+    `parse_outside_game_legacy_single_branch_still_works` (`:12461`),
+    `parse_outside_game_wish_play_from_sideboard` (`:12489`, the M19 "Wish"
+    card end-to-end through `parse_oracle_text`).
+  - `swallow_check.rs:4331` `optional_you_may_accepts_wishboard_creature_or_land…`
+    parses **Living Wish** by name; `swallow_check.rs:4143` parses a Burning-Wish-
+    shaped sorcery fetch. Karn is contrasted at `swallow_check.rs:4349`.
+- **Resolver** (`game/effects/search_outside_game.rs`): `resolve` builds the
+  sideboard candidate list (`:36-67`, CR 400.11a) and — **only when
+  `source_pool.includes_face_up_exile()`** (`:72`) — appends
+  `collect_face_up_exile_candidates` (`:105-135`), which already selects exile
+  objects the controller **owns** and that are **face-up** (`face_down` filtered
+  out at `:122`) and match the filter. Movement into hand/destination is handled
+  by `put_face_up_exile_into` (`:141-186`) through the standard `ChangeZone`
+  pipeline. This is the entire pre-M10 retrieval mechanism, already built and
+  tested (`karn_minus_two_pulls_face_up_exile_artifact_to_hand`,
+  `search_outside_game.rs:654`).
+
+Searched `crates/engine` for `burning wish|cunning wish|living wish|golden
+wish|death wish|glittering wish` — matches only in `search_outside_game.rs`
+(test scaffolding names) and `swallow_check.rs` (Living Wish parse test); no
+per-card special-casing anywhere. The class is handled generically by the
+`SearchOutsideGame` parser pattern, so the real named cards
+(Burning/Cunning/Living/Golden/Death Wish) parse via the same path when present
+in the generated `card-data.json`.
+
+### 9d. Why the modern face-up-exile pool is a rules-faithful model of pre-M10 RFG
+
+Pre-M10 "removed from the game" cards that a Wish could fetch were, in practice,
+exactly *cards the player owns that are visible* — you cannot choose a card you
+don't own, and hidden (face-down) removed cards were never eligible Wish
+targets. That is precisely what `collect_face_up_exile_candidates` already
+enforces (`owner == controller` + `!face_down`). So the pre-M10 rule is
+faithfully expressed by *widening a Wish-class search's effective pool to the
+already-existing `SideboardAndFaceUpExile` behavior* — no new candidate-
+collection logic, no new zone, no new movement path.
+
+### 9e. Hook point and size — SMALL (revise PLAN's "Medium")
+
+`GameState` already carries the resolved format config:
+`GameState.format_config: FormatConfig` (`types/game_state.rs:6787`), and PLAN
+§1 places `LegacyRuleSet` under `FormatConfig.custom_rules`. The resolver has
+direct access to it.
+
+**The entire change is one flag check at one existing hook.** In
+`search_outside_game::resolve`, the exile-append condition at
+`search_outside_game.rs:72` becomes, in effect:
+
+```text
+if source_pool.includes_face_up_exile()
+    || state.format_config pre_m10_wish_templating flag is set
+{
+    choices.extend(collect_face_up_exile_candidates(state, ability, filter));
+}
+```
+
+That is: when the legacy flag is on, treat a Wish-class (`Sideboard`) search as
+if it were `SideboardAndFaceUpExile`. No parser change (the parser can't know
+the format anyway — the flag is a *runtime resolution* concern, not a parse
+concern), no new effect, no new state, no new WaitingFor variant, and full reuse
+of the tested face-up-exile collector and mover.
+
+**Size: SMALL — and materially smaller than PLAN §4's current "Medium"
+estimate.** The Medium framing predated discovering that
+`SideboardAndFaceUpExile` + `collect_face_up_exile_candidates` already implement
+the retrieval end-to-end. This should be re-classified alongside mana burn
+(§5) as a small, well-contained addition; unlike damage-on-stack (§6) it touches
+no state machine.
+
+**One CR-annotation note for implementation:** the pre-M10 behavior predates the
+current CR 400.11 zone model, so annotate the flag as a *legacy rule reverting
+the M10 change* — cite CR 400.11 / 400.11a (the modern boundary being relaxed)
+and CR 701.23j, exactly as mana burn cites the obsolete-glossary entry. The flag
+does **not** implement current CR; it deliberately re-enables removed behavior.
+
+**Naming caveat:** `pre_m10_wish_templating` mislabels a *functional pool-scope*
+toggle as a *wording* one. A clearer name is `pre_m10_wish_reaches_exile` (or
+`wish_reaches_removed_from_game`) — it names the actual behavior (Wishes reach
+owned face-up exile). See PLAN naming note. This is not a no-op / wording-only
+flag; it is a real, testable pool-widening.
+
+## 10. Legend rule — historical scope change is REAL; engine hardcodes modern; flag is SMALL
+
+The "legend rule" (colloquially "the legend rule") was introduced by the
+*Legends* set (1994) — a set legal in EC's Old School 93-94 and 95 — and its
+governing rule has a documented history of change. Investigated with the same
+rigor as §5/§6/§9. All dates/wordings below are web-verified (not from memory);
+the current CR wording is verified directly against
+`docs/MagicCompRules.txt` in this checkout.
+
+### 10a. What the rule said at each point in history (web-verified)
+
+Sources: WotC "Legendary Rule Change" (magic.wizards.com, 2013-05-23, via the
+2013-07 M14 rules-tips summary); MTG Wiki "Legendary/Legend rule"; Magic Judges
+rules-tips "M14 Rules changes! Legendary permanents"
+(blogs.magicjudges.org/rulestips/2013/07/m14-rules-changes-legendary-permanents/).
+
+- **Legends (1994) → pre-M14 (through 2013): NOT per-controller — global.** If
+  two or more legendary permanents with the *same name* were on the battlefield,
+  they were affected **regardless of which player(s) controlled them**. The exact
+  mechanic shifted across eras (early "first legend in play trumps / newest is
+  denied"; Sixth Edition 1999 unified it across all legendary permanent types
+  with the "both go to the graveyard" form; *Champions of Kamigawa* 2004 changed
+  it to a "nullification" variant), but the invariant across every pre-M14 form
+  is that **same-named legends interacted across controllers** — two different
+  players could not each keep their own copy of the same legendary permanent.
+- **Magic 2014 (effective 2013-07-13, the M14 prerelease): today's
+  per-controller rule.** Rewritten so that only when *a single player* controls
+  two or more legendary permanents with the same name does that player choose one
+  to keep and put the rest into their owners' graveyards; it **does not** affect
+  same-named legendaries controlled by *different* players. This is the version
+  the engine implements (see §10c).
+- **Ixalan (effective 2017-09-28, day before release; NOT Dominaria 2018):
+  planeswalker uniqueness folded into the legend rule.** Before Ixalan,
+  planeswalkers used a separate **"planeswalker uniqueness rule"** keyed on
+  planeswalker *type* (a player couldn't control two planeswalkers sharing a
+  type, e.g. two different "Jace" cards). Ixalan removed that rule, gave all
+  past/present/future planeswalkers the `legendary` supertype via Oracle errata,
+  and made them subject to the *name*-based legend rule instead. (The task's
+  "around 2018's Dominaria" guess is **incorrect** — the correct set/date is
+  Ixalan, 2017-09-28. Dominaria 2018 is unrelated to this change.)
+
+### 10b. Current CR wording — verified against `docs/MagicCompRules.txt`
+
+The legend rule is a **state-based action**, CR **704.5j** (verified by grep;
+the number is not guessed):
+
+- `docs/MagicCompRules.txt:5510` — **CR 704.5j**: "If two or more legendary
+  permanents with the same name are controlled by the same player, that player
+  chooses one of them, and the rest are put into their owners' graveyards. This
+  is called the 'legend rule.'" (Note "**by the same player**" — the modern
+  per-controller scope, in the rule text itself.)
+- `docs/MagicCompRules.txt:8187-8188` — glossary "Legend Rule": "…causes a
+  player who controls two or more legendary permanents with the same name to put
+  all but one into their owners' graveyards."
+- `docs/MagicCompRules.txt:1459` — **CR 205.4d** cross-references 704.5j.
+- **Planeswalker uniqueness is confirmed obsolete in the current CR:**
+  `docs/MagicCompRules.txt:1721` — **CR 306.4**: "Previously, planeswalkers were
+  subject to a 'planeswalker uniqueness rule'… This rule has been removed and
+  planeswalker cards printed before this change have received errata… to have the
+  legendary supertype… they are subject to the 'legend rule' (see rule 704.5j)."
+  And `docs/MagicCompRules.txt:8580-8581` — glossary "Planeswalker Uniqueness
+  Rule (Obsolete)".
+- (Contrast: the world rule, CR 704.5k, `docs/MagicCompRules.txt:5512`, is a
+  distinct global/choiceless SBA — a useful structural precedent, see §10d.)
+
+### 10c. Is it a REAL functional difference? — YES
+
+**Verdict: a genuine functional / gameplay difference, not wording-only** — same
+class as mana burn (§5) and pre-M10 Wish (§9). Under the pre-M14 rule, two
+*different* players could **not** simultaneously keep two copies of the same
+legendary permanent (the second to resolve, or both, would be put into the
+graveyard as an SBA — no controller kept one). Under the modern rule each player
+independently keeps one. This changes the *set of legal board states*, directly
+observable at the table (e.g. a mirror-match where both players resolve the same
+legend: pre-M14, both die; modern, each keeps one). It is not a no-op flag.
+
+**Relevance to the four EC presets — HONEST CAVEAT.** EC's published rulesets
+(§1, re-fetched 2026-07-07) list their legacy-rule exceptions explicitly per
+format (93-94/95 = mana burn only; Middle School / Classic = mana burn +
+damage-on-stack + wish). **None of the four lists a legend-rule reversion**, so
+the four EC presets play the *modern* legend rule and set this flag to its
+default. The legend-rule scope is therefore a **general historical-rules axis**
+the custom-format engine should be able to express (exactly the orthogonality
+argument Block Constructed makes for `mana_burn`, PLAN note), **not** a behavior
+any of the four current presets turns on. Do not silently flip it on for the EC
+presets. Two further points confirm the EC-scope impact is minimal today:
+(i) *planeswalker uniqueness is entirely moot for these formats* — all four pools
+top out at Scourge (2003), and planeswalkers did not exist until Lorwyn (2007),
+so no EC-legal card is a planeswalker and no separate planeswalker-uniqueness
+flag is needed for this project; (ii) the legend-rule scope difference only
+manifests in cross-controller same-name mirrors, which are rare in singleton-ish
+retro metagames but *are* legal board states, so modeling it is correct-for-the-
+class even if the four presets default it off.
+
+### 10d. Engine implementation — HARDCODED to the modern (per-controller) rule
+
+Searched `crates/engine/src/game/` for "legend"; the SBA lives in `sba.rs`.
+
+- **`check_legend_rule` (`sba.rs:902-956`) is unambiguously per-controller.** It
+  loops **per player** (`for player_idx in 0..state.players.len()`, `:910`),
+  filters candidates to `obj.controller == player_id` (`:920`), groups by name
+  **within that one controller's permanents** (`by_name`, `:935-940`), and for
+  any name with ≥2 pauses with `WaitingFor::ChooseLegend { player, legend_name,
+  candidates }` (`:950-954`) so the controller *chooses* one to keep. Both the
+  cross-controller-independence and the player-choice are the modern M14 rule.
+  Annotated CR 704.5j at `:167`, `:899`, `:924`.
+- The exemption path is separate and reusable: `legend_rule_exempt` /
+  `legend_rule_exempt_with_gate` (`sba.rs:864-897`) consult the
+  `LegendRuleDoesntApply` static (Mirror Gallery / Sakashima / Mirror Box); it is
+  the single authority and already gates the candidate filter (`:926`).
+- **No legacy scope toggle exists anywhere** — there is no flag, enum, or config
+  read in `check_legend_rule`; the per-controller behavior is structural.
+
+### 10e. Size of re-adding the pre-M14 (any-controller) rule as a legacy flag — SMALL
+
+The pre-M14 form is actually *structurally simpler* than the modern one: it is
+**global** (one group per name across all controllers) and **choiceless** (all
+same-named legendaries in a ≥2 group go to their owners' graveyards, no player
+selection, no `WaitingFor`). The engine **already has this exact shape** in
+`check_world_rule` (`sba.rs:1348`, CR 704.5k — global, choiceless) and
+`check_role_uniqueness` (`sba.rs:1190`), and it already has the SBA-departure
+mover used by every SBA (`move_sba_departing_permanent`, CR 704.5 zone-pipeline
+mover at `sba.rs:618`). So the change is:
+
+1. Add a scope field to `LegacyRuleSet` (PLAN §1) — a **typed enum**, not a bool
+   (per CLAUDE.md "typed enum over raw bool"), because the historical space has
+   more than a clean binary and a typed enum leaves room without a later refactor:
+   `LegendRuleScope { Modern, PreM14AnyController }` (default `Modern`).
+2. Branch once at the top of `check_legend_rule`: when the resolved
+   `GameState.format_config` legacy scope is `PreM14AnyController`, build the
+   name groups **without** the `obj.controller == player_id` filter (all
+   controllers) and, for any ≥2 group, route every member through the existing
+   `move_sba_departing_permanent` — mirroring `check_world_rule`'s
+   global-choiceless structure — instead of pausing with `WaitingFor::ChooseLegend`.
+   The `legend_rule_exempt_with_gate` filter is reused unchanged.
+
+No new WaitingFor variant, no new mover, no new state machine, full reuse of the
+world-rule choiceless-global precedent and the shared SBA departure pipeline.
+**Size: SMALL** — comparable to mana burn (§5) and pre-M10 Wish (§9); materially
+smaller than damage-on-stack (§6). The only design nuance is scoping the enum:
+model just `Modern` vs a single consolidated `PreM14AnyController` "all
+same-named copies across all controllers go to the graveyard" form (the Sixth-
+Edition "both die" version, which is the one that changes cross-controller legal
+board states); do **not** attempt to reproduce the era-specific "first-in
+trumps" / Kamigawa "nullification" micro-variants — they are out of scope and a
+future enum variant can carry them if a format ever needs one. Because the flag
+re-enables a rule the current CR replaced (M14), annotate it as a *legacy rule
+reverting the M14 change* and cite CR 704.5j (the modern boundary being relaxed),
+exactly as mana burn cites the obsolete-glossary entry and the Wish flag cites
+CR 400.11.


### PR DESCRIPTION
## Summary

Design proposal (research + plan, **no engine or frontend code**) for a general, data-driven custom-format layer — motivated by wanting to support four Eternal Central retro formats (Old School 93-94, Old School 95, Middle School, Classic Magic) without hardcoding four new `GameFormat` enum variants.

Follows up on the discussion at #5312. A maintainer's informal framing of the idea ("FFA that's super flexible and you can save a configuration as a custom format?") directly shaped this revision — see `docs/proposals/custom-format-engine/CONTEXT.md`'s "Maintainer input" section for how that resolved the delivery-surface question.

- `CustomFormatRules` splits into two independent axes:
  - **`StructuralRules`** — starting life, player count, deck size, range of influence, team-based, singleton. These already exist as `FormatConfig` fields and are already partially host-adjustable in the multiplayer lobby (`HostSetup.tsx`) — this is the "flexible FFA" axis.
  - **`LegalityRules`** — legal sets, banned/restricted lists, and legacy-era rule toggles (mana burn, damage-on-the-stack, pre-M10 Wish exile access, legend-rule scope). This is what makes the four EC formats rules-correct.
- Recommended delivery: ship a "save as custom format" action on the existing lobby first (validates Axis A immediately, useful to any casual table), with the four EC formats shipping as audited typed presets on the identical schema (Axis B) in parallel.

## What's in this PR

- `docs/proposals/custom-format-engine/README.md` — orientation + links
- `docs/proposals/custom-format-engine/CONTEXT.md` — why this matters, confirmed findings, open questions, maintainer-input resolution
- `docs/proposals/custom-format-engine/RESEARCH.md` — detailed investigation (current architecture, EC formats' verbatim rules, legacy-rules deltas, cross-checks against other in-flight format work)
- `docs/proposals/custom-format-engine/PLAN.md` — proposed schema, EC-format parameterization, sequencing

## Test plan

N/A — documentation/design proposal only, opened for maintainer review before any implementation work begins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive design documentation for configurable custom game formats.
  * Documented Swedish Old School 93/94 as the first planned preset, followed by additional retro formats.
  * Clarified lobby configuration, saved-format identity, validation, compatibility, legality pools, restricted cards, reprints, sideboards, and historical rules.
  * Documented mana-expiry behavior, commander requirements, preset readiness criteria, implementation limitations, and phased delivery plans.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## AI-contributor disclosure

Model: claude-sonnet-5
Tier: Frontier
Thinking: default (reasoning_effort=40 for this session; not elevated to a high/max setting)

Gate A (combinator-purity script) and Gate B (pattern anchoring, `docs/AI-CONTRIBUTOR.md` §0.1.2) are not applicable to this PR — it contains no engine/parser Rust code, only documentation (a design proposal). No `.claude/skills/**`, `.claude/agents/**`, `CLAUDE.md`, `AGENTS.md`, or `docs/AI-CONTRIBUTOR.md` paths are touched by this PR's current head.
