### PR TITLE
fix(engine): announce a per-opponent fanout's pinned opponent, don't prompt

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -6079,6 +6079,52 @@ fn build_target_selection_progress_for_ability(
         );
     }
 
+    // CR 115.10a: "Just because an object or player is being affected by a spell or
+    // ability doesn't make that object or player a target … Unless that object or
+    // player is identified by the word 'target'…". The `SpecificPlayer` half of a
+    // per-opponent target fanout (`collect_per_opponent_target_fanout_specs`) is a
+    // BINDER: it is pinned to one player by construction so the following object
+    // slot's `ControllerRef::TargetPlayer` scope resolves ("that player's
+    // graveyard"). The opponent is affected but never identified by "target" —
+    // Diluvian Primordial's "target" attaches to the card. CR 115.1d: only the card
+    // slot is an announced target. Announce the pinned player on the controller's
+    // behalf and advance, so the first prompt they see is the real choice.
+    //
+    // Same conjunction `legal_targets_for_selected_slot` already uses to identify a
+    // binder (fanout predicate + `SpecificPlayer` filter) — not a looser
+    // filter-shape test, so an ordinary pinned-player slot on a non-fanout ability
+    // still prompts.
+    //
+    // CR 115.6: `!slot.optional` — declining an optional slot is a real choice the
+    // controller owns ("may allow zero targets to be chosen"), so an optional slot
+    // is never a non-choice even with a singleton legal set.
+    // CR 601.2c + CR 115.1: `chooser.is_none()` — a slot announced by another player
+    // is not the controller's to auto-resolve.
+    if is_per_opponent_target_fanout(ability) && !slot.optional && slot.chooser.is_none() {
+        if let Some(TargetSlotSpec {
+            filter: TargetFilter::SpecificPlayer { id },
+            ..
+        }) = specs.get(current_slot)
+        {
+            // `TargetRef` is NOT `Copy`, so `== [pinned]` would MOVE `pinned` into
+            // the array literal and make the `push` below E0382. `from_ref`
+            // borrows instead, and allocates nothing.
+            let pinned = TargetRef::Player(*id);
+            if current_legal_targets == std::slice::from_ref(&pinned) {
+                let mut bound_slots = selected_slots;
+                bound_slots.push(Some(pinned));
+                return build_target_selection_progress_for_ability(
+                    state,
+                    ability,
+                    target_slots,
+                    constraints,
+                    current_slot + 1,
+                    bound_slots,
+                );
+            }
+        }
+    }
+
     Ok(TargetSelectionProgress {
         current_slot,
         selected_slots,
@@ -12108,23 +12154,15 @@ mod tests {
             .legal_targets
             .contains(&TargetRef::Object(caster_creature)));
 
+        // CR 115.10a: the pinned binder is announced by the engine, so the walk
+        // opens on the first object slot with the binder already bound.
         let progress =
             begin_target_selection_for_ability(&state, &ability, &slots, &[]).expect("selection");
+        assert_eq!(progress.current_slot, 1);
         assert_eq!(
-            progress.current_legal_targets,
-            vec![TargetRef::Player(PlayerId(1))]
+            progress.selected_slots,
+            vec![Some(TargetRef::Player(PlayerId(1)))]
         );
-        let TargetSelectionAdvance::InProgress(progress) = choose_target_for_ability(
-            &state,
-            &ability,
-            &slots,
-            &[],
-            &progress,
-            Some(TargetRef::Player(PlayerId(1))),
-        )
-        .expect("forced first player target should be accepted") else {
-            panic!("expected first object slot");
-        };
         assert_eq!(
             progress.current_legal_targets,
             vec![TargetRef::Object(opponent_one_creature)]
@@ -12173,17 +12211,11 @@ mod tests {
 
         let progress =
             begin_target_selection_for_ability(&state, &ability, &slots, &[]).expect("selection");
-        let TargetSelectionAdvance::InProgress(progress) = choose_target_for_ability(
-            &state,
-            &ability,
-            &slots,
-            &[],
-            &progress,
-            Some(TargetRef::Player(PlayerId(1))),
-        )
-        .expect("hidden player constraint should bypass player targeting protection") else {
-            panic!("expected first object slot");
-        };
+        assert_eq!(
+            progress.selected_slots,
+            vec![Some(TargetRef::Player(PlayerId(1)))],
+            "the auto-announced binder still bypasses player targeting protection"
+        );
         assert_eq!(
             progress.current_legal_targets,
             vec![TargetRef::Object(opponent_creature)]
@@ -12229,17 +12261,6 @@ mod tests {
 
         let progress =
             begin_target_selection_for_ability(&state, &ability, &slots, &[]).expect("selection");
-        let TargetSelectionAdvance::InProgress(progress) = choose_target_for_ability(
-            &state,
-            &ability,
-            &slots,
-            &[],
-            &progress,
-            Some(TargetRef::Player(PlayerId(1))),
-        )
-        .expect("hidden player slot should be accepted") else {
-            panic!("expected object slot");
-        };
         assert_eq!(
             progress.current_legal_targets,
             vec![TargetRef::Object(unprotected_enchantment)]
@@ -12384,31 +12405,9 @@ mod tests {
             &slots,
             &[],
             &progress,
-            Some(TargetRef::Player(PlayerId(1))),
-        )
-        .expect("first hidden player slot should be accepted") else {
-            panic!("expected first object slot");
-        };
-        let TargetSelectionAdvance::InProgress(progress) = choose_target_for_ability(
-            &state,
-            &ability,
-            &slots,
-            &[],
-            &progress,
             Some(TargetRef::Object(opponent_one_creature)),
         )
         .expect("first object slot should be accepted") else {
-            panic!("expected second hidden player slot");
-        };
-        let TargetSelectionAdvance::InProgress(progress) = choose_target_for_ability(
-            &state,
-            &ability,
-            &slots,
-            &[],
-            &progress,
-            Some(TargetRef::Player(PlayerId(2))),
-        )
-        .expect("second hidden player slot should be accepted") else {
             panic!("expected second object slot");
         };
         let TargetSelectionAdvance::InProgress(progress) = choose_target_for_ability(
@@ -12429,6 +12428,202 @@ mod tests {
                 .current_legal_targets
                 .contains(&TargetRef::Player(PlayerId(1))),
             "trailing non-fanout target slot should fall through to normal target recompute"
+        );
+    }
+
+    /// Shared board for the two `chooser` rows: a MANDATORY per-opponent fanout
+    /// with exactly one opponent, who controls exactly one legal permanent. The
+    /// two rows are separate `#[test]` functions with their own verdicts and
+    /// differ only in the binder slot's `chooser`.
+    fn per_opponent_binder_chooser_fixture() -> (
+        GameState,
+        ResolvedAbility,
+        Vec<TargetSelectionSlot>,
+        ObjectId,
+    ) {
+        let mut state = GameState::new_two_player(42);
+        let opponent_creature = create_creature(&mut state, PlayerId(1), CardId(1), "Opp One");
+        let ability = per_opponent_gain_control_ability();
+        let slots = build_target_slots(&state, &ability).expect("target slots should build");
+        (state, ability, slots, opponent_creature)
+    }
+
+    /// CR 601.2c + CR 115.1: a slot another player announces is never the
+    /// controller's to auto-resolve, even when it is a structurally pinned
+    /// per-opponent binder. Paired negative for
+    /// `binder_slot_without_a_chooser_is_autofilled`.
+    #[test]
+    fn binder_slot_with_a_foreign_chooser_is_not_autofilled() {
+        let (state, ability, mut slots, _) = per_opponent_binder_chooser_fixture();
+        assert!(is_per_opponent_target_fanout(&ability));
+        assert_eq!(slots.len(), 2);
+        assert_eq!(slots[0].legal_targets, vec![TargetRef::Player(PlayerId(1))]);
+        assert!(
+            !slots[0].optional,
+            "the fixture must satisfy every conjunct except `chooser`"
+        );
+
+        slots[0].chooser = Some(PlayerId(1));
+        let progress =
+            begin_target_selection_for_ability(&state, &ability, &slots, &[]).expect("selection");
+        assert_eq!(
+            progress.current_slot, 0,
+            "a chooser-stamped binder remains an announced step for that player"
+        );
+        assert_eq!(
+            progress.current_legal_targets,
+            vec![TargetRef::Player(PlayerId(1))]
+        );
+    }
+
+    /// CR 115.10a: the same fixture with no foreign chooser — the pinned
+    /// opponent is announced by the engine and the walk opens on the object
+    /// slot. Sibling positive for
+    /// `binder_slot_with_a_foreign_chooser_is_not_autofilled`.
+    #[test]
+    fn binder_slot_without_a_chooser_is_autofilled() {
+        let (state, ability, slots, opponent_creature) = per_opponent_binder_chooser_fixture();
+        assert_eq!(slots.len(), 2);
+        assert!(slots[0].chooser.is_none());
+        assert_eq!(slots[0].legal_targets, vec![TargetRef::Player(PlayerId(1))]);
+
+        let progress =
+            begin_target_selection_for_ability(&state, &ability, &slots, &[]).expect("selection");
+        assert_eq!(
+            progress.current_slot, 1,
+            "the pinned binder is announced on the controller's behalf"
+        );
+        assert_eq!(
+            progress.selected_slots,
+            vec![Some(TargetRef::Player(PlayerId(1)))]
+        );
+        assert_eq!(
+            progress.current_legal_targets,
+            vec![TargetRef::Object(opponent_creature)]
+        );
+    }
+
+    /// CR 603.3d: a REQUIRED binder with no legal player still removes the
+    /// ability from the stack. The auto-fill block is deliberately ordered
+    /// after the empty-legal-set block, so this path is byte-identical to its
+    /// pre-auto-fill behavior.
+    #[test]
+    fn binder_with_no_legal_player_still_reports_no_legal_combinations() {
+        let mut state = GameState::new_two_player(42);
+        create_creature(&mut state, PlayerId(1), CardId(1), "Opp One");
+        let ability = per_opponent_gain_control_ability();
+
+        let mut slots = build_target_slots(&state, &ability).expect("target slots should build");
+        assert_eq!(slots.len(), 2);
+        assert_eq!(slots[0].legal_targets, vec![TargetRef::Player(PlayerId(1))]);
+        assert!(!slots[0].optional);
+
+        // CR 800.4: the sole opponent leaves the game after the slots were
+        // built. The fanout then yields no spec at all, and the stale required
+        // binder slot has no legal player left.
+        state
+            .players
+            .iter_mut()
+            .find(|player| player.id == PlayerId(1))
+            .expect("opponent seat")
+            .is_eliminated = true;
+        slots[0].legal_targets.clear();
+
+        let error = begin_target_selection_for_ability(&state, &ability, &slots, &[])
+            .expect_err("a required binder with no legal player must not be auto-filled");
+        assert!(
+            matches!(&error, EngineError::ActionNotAllowed(message)
+                if message == "No legal target combinations available"),
+            "expected the CR 603.3d no-legal-combination error, got {error:?}"
+        );
+    }
+
+    /// CR 115.10a does NOT apply to an ordinary singleton target: "destroy
+    /// target creature" identifies the creature by the word "target", so the
+    /// controller still announces it even when exactly one is legal. Negative
+    /// control for the class boundary — the general "any mandatory singleton
+    /// auto-fills" rule is explicitly not implemented.
+    #[test]
+    fn a_lone_legal_creature_for_destroy_target_creature_still_prompts() {
+        let mut state = GameState::new_two_player(42);
+        let lone_creature = create_creature(&mut state, PlayerId(1), CardId(1), "Lone Creature");
+        let ability = ResolvedAbility::new(
+            Effect::Destroy {
+                target: TargetFilter::Typed(TypedFilter::creature()),
+                cant_regenerate: false,
+            },
+            vec![],
+            ObjectId(900),
+            PlayerId(0),
+        );
+        assert!(!is_per_opponent_target_fanout(&ability));
+
+        let slots = build_target_slots(&state, &ability).expect("target slots should build");
+        assert_eq!(slots.len(), 1);
+        assert!(!slots[0].optional);
+        assert!(slots[0].chooser.is_none());
+        let progress =
+            begin_target_selection_for_ability(&state, &ability, &slots, &[]).expect("selection");
+        assert_eq!(
+            progress.current_slot, 0,
+            "the word `target` attaches to the creature, so the controller announces it"
+        );
+        assert_eq!(
+            progress.current_legal_targets,
+            vec![TargetRef::Object(lone_creature)]
+        );
+
+        // Reach guard: the same shape with a genuine choice also prompts at
+        // slot 0, so the singleton assertion above is not the only branch.
+        let second_creature =
+            create_creature(&mut state, PlayerId(1), CardId(2), "Second Creature");
+        let slots = build_target_slots(&state, &ability).expect("target slots should build");
+        let progress =
+            begin_target_selection_for_ability(&state, &ability, &slots, &[]).expect("selection");
+        assert_eq!(progress.current_slot, 0);
+        assert!(progress
+            .current_legal_targets
+            .contains(&TargetRef::Object(second_creature)));
+    }
+
+    /// CR 115.10a is scoped to the per-opponent fanout BINDER, not to every
+    /// pinned-player slot. A mandatory `SpecificPlayer` slot on a NON-fanout
+    /// ability is a real announced target and still prompts — this is the row
+    /// that separates the adopted `is_per_opponent_target_fanout` gate from a
+    /// filter-shape-only predicate.
+    #[test]
+    fn mandatory_specific_player_slot_on_a_non_fanout_ability_still_prompts() {
+        let state = GameState::new(FormatConfig::standard(), 3, 42);
+        let pinned = PlayerId(1);
+        let ability = ResolvedAbility::new(
+            Effect::TargetOnly {
+                target: TargetFilter::SpecificPlayer { id: pinned },
+            },
+            vec![],
+            ObjectId(900),
+            PlayerId(0),
+        );
+        assert!(!ability.optional_targeting);
+        assert!(ability.multi_target.is_none());
+        assert!(!is_per_opponent_target_fanout(&ability));
+
+        // Reach guard: the fixture satisfies every conjunct of the auto-fill
+        // guard EXCEPT the fanout gate — mandatory, unchoosered, singleton.
+        let slots = build_target_slots(&state, &ability).expect("target slots should build");
+        assert_eq!(slots.len(), 1);
+        assert!(!slots[0].optional);
+        assert!(slots[0].chooser.is_none());
+        assert_eq!(slots[0].legal_targets, vec![TargetRef::Player(pinned)]);
+
+        let progress =
+            begin_target_selection_for_ability(&state, &ability, &slots, &[]).expect("selection");
+        assert_eq!(
+            progress.current_slot, 0,
+            "a pinned-player slot outside the fanout class is still announced by the controller"
+        );
+        assert_eq!(
+            progress.current_legal_targets,
+            vec![TargetRef::Player(pinned)]
         );
     }
 

--- a/crates/engine/tests/integration/diluvian_primordial_6754.rs
+++ b/crates/engine/tests/integration/diluvian_primordial_6754.rs
@@ -50,13 +50,10 @@ fn advance_to_free_cast_window(runner: &mut GameRunner) {
     panic!("Diluvian Primordial never opened its free-cast window");
 }
 
+// CR 115.10a: the per-opponent binder slots are pinned by construction and are
+// announced by the engine, so the controller submits only the card targets.
 fn choose_paired_targets(runner: &mut GameRunner, p1_card: ObjectId, p2_card: ObjectId) {
-    for target in [
-        TargetRef::Player(P1),
-        TargetRef::Object(p1_card),
-        TargetRef::Player(P2),
-        TargetRef::Object(p2_card),
-    ] {
+    for target in [TargetRef::Object(p1_card), TargetRef::Object(p2_card)] {
         runner
             .act(GameAction::ChooseTarget {
                 target: Some(target),
@@ -78,7 +75,7 @@ fn assert_no_unimplemented_effects(ability: &AbilityDefinition) {
     }
 }
 
-/// CR 115.1a + CR 608.2g + CR 614.1a: The real cast/trigger pipeline chooses
+/// CR 115.1d + CR 608.2g + CR 614.1a: The real cast/trigger pipeline chooses
 /// one card per opponent, snapshots exactly those cards into FreeCastWindow,
 /// casts one at zero mana, re-offers only the remaining approved card, then
 /// exiles the successfully cast spell while declined and unselected cards stay
@@ -262,7 +259,7 @@ fn diluvian_primordial_drops_removed_pair_without_graveyard_substitution() {
     }
 }
 
-/// CR 115.1a + CR 603.3d + CR 608.2g: An opponent with no legal instant or
+/// CR 115.1d + CR 603.3d + CR 608.2g: An opponent with no legal instant or
 /// sorcery target contributes no paired slots, but that omission must not
 /// suppress another opponent's independently selected target or its normal
 /// cast pipeline.
@@ -308,7 +305,11 @@ fn diluvian_primordial_skips_targetless_opponent_and_casts_other_selected_spell(
     advance_to_trigger_target_selection(&mut runner);
 
     match runner.state().waiting_for.clone() {
-        WaitingFor::TriggerTargetSelection { target_slots, .. } => {
+        WaitingFor::TriggerTargetSelection {
+            target_slots,
+            selection,
+            ..
+        } => {
             assert_eq!(
                 target_slots.len(),
                 2,
@@ -319,16 +320,21 @@ fn diluvian_primordial_skips_targetless_opponent_and_casts_other_selected_spell(
                 target_slots[1].legal_targets,
                 vec![TargetRef::Object(p2_selected), TargetRef::Object(p2_extra)]
             );
+            // CR 115.10a: the binder slot still exists, but the engine
+            // announces it — the first prompt is the card, not the opponent.
+            assert_eq!(selection.current_slot, 1);
+            assert_eq!(
+                selection.current_legal_targets,
+                vec![TargetRef::Object(p2_selected), TargetRef::Object(p2_extra)]
+            );
         }
         other => panic!("expected Diluvian target selection, got {other:?}"),
     }
-    for target in [TargetRef::Player(P2), TargetRef::Object(p2_selected)] {
-        runner
-            .act(GameAction::ChooseTarget {
-                target: Some(target),
-            })
-            .expect("P2's paired target must remain selectable when P1 has none");
-    }
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(p2_selected)),
+        })
+        .expect("P2's paired target must remain selectable when P1 has none");
     advance_to_free_cast_window(&mut runner);
     match runner.state().waiting_for.clone() {
         WaitingFor::CastOffer {
@@ -403,13 +409,11 @@ fn diluvian_primordial_defers_sibling_after_open_free_cast_window() {
         })
         .expect("casting Diluvian Primordial must succeed");
     advance_to_trigger_target_selection(&mut runner);
-    for target in [TargetRef::Player(P1), TargetRef::Object(selected)] {
-        runner
-            .act(GameAction::ChooseTarget {
-                target: Some(target),
-            })
-            .expect("Diluvian's paired target must be legal");
-    }
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(selected)),
+        })
+        .expect("Diluvian's paired target must be legal");
     advance_to_free_cast_window(&mut runner);
 
     assert_eq!(
@@ -473,13 +477,11 @@ fn diluvian_primordial_uncastable_selected_spell_stays_in_graveyard_and_runs_tai
         })
         .expect("casting Diluvian Primordial must succeed");
     advance_to_trigger_target_selection(&mut runner);
-    for target in [TargetRef::Player(P1), TargetRef::Object(selected)] {
-        runner
-            .act(GameAction::ChooseTarget {
-                target: Some(target),
-            })
-            .expect("the selected uncastable spell must still be a legal Diluvian pair");
-    }
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(selected)),
+        })
+        .expect("the selected uncastable spell must still be a legal Diluvian pair");
     runner.advance_until_stack_empty();
 
     assert!(

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -925,6 +925,7 @@ mod pass_priority_structural_legality;
 mod peer_into_the_abyss;
 mod peerless_recycling_gift_recipient;
 mod pendrell_flux_unless_pay_own_cost;
+mod per_opponent_binder_autofill;
 mod perrie_the_pulverizer_attack_trigger_6219;
 mod peter_parker_modal_back_face_cast;
 mod phantom_general_token_anthem;

--- a/crates/engine/tests/integration/per_opponent_binder_autofill.rs
+++ b/crates/engine/tests/integration/per_opponent_binder_autofill.rs
@@ -1,0 +1,255 @@
+//! CR 115.10a: the `SpecificPlayer` half of a per-opponent target fanout is a
+//! structurally pinned BINDER, not a target. The engine announces it on the
+//! controller's behalf, so the first prompt the controller sees is the real
+//! choice — the card in that opponent's graveyard.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastOfferKind, CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::PlayerId;
+
+const P2: PlayerId = PlayerId(2);
+const P3: PlayerId = PlayerId(3);
+const DILUVIAN_ORACLE: &str = "Flying\nWhen this creature enters, for each opponent, you may cast up to one target instant or sorcery card from that player's graveyard without paying its mana cost. If a spell cast this way would be put into a graveyard, exile it instead.";
+
+fn advance_to_trigger_target_selection(runner: &mut GameRunner) {
+    for _ in 0..32 {
+        match runner.state().waiting_for {
+            WaitingFor::TriggerTargetSelection { .. } => return,
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("priority pass while reaching the Diluvian trigger");
+            }
+            ref other => panic!("unexpected state while reaching the Diluvian trigger: {other:?}"),
+        }
+    }
+    panic!("Diluvian Primordial ETB never reached its target prompt");
+}
+
+fn advance_to_free_cast_window(runner: &mut GameRunner) {
+    for _ in 0..32 {
+        match runner.state().waiting_for {
+            WaitingFor::CastOffer {
+                kind: CastOfferKind::FreeCastWindow { .. },
+                ..
+            } => return,
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("priority pass while resolving the Diluvian trigger");
+            }
+            ref other => panic!("unexpected state while reaching the Diluvian window: {other:?}"),
+        }
+    }
+    panic!("Diluvian Primordial never opened its free-cast window");
+}
+
+fn cast_diluvian(runner: &mut GameRunner, primordial: ObjectId) {
+    let card_id = runner.state().objects[&primordial].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: primordial,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting Diluvian Primordial must succeed");
+}
+
+fn seed_controller_mana(scenario: &mut GameScenario) {
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(
+        P0,
+        vec![ManaUnit::new(
+            ManaType::Colorless,
+            ObjectId(0),
+            false,
+            vec![],
+        )],
+    );
+}
+
+/// CR 115.10a + CR 115.1d: the reported shape — 4-player Commander, controller
+/// plus three opponents, one of whom has an empty graveyard. Diluvian's word
+/// "target" attaches to the instant or sorcery card, never to the opponent, so
+/// the opponent slot is announced by the engine and the FIRST prompt the
+/// controller sees is the object slot.
+#[test]
+fn four_player_fanout_first_prompt_is_the_object_slot() {
+    let mut scenario = GameScenario::new_n_player(4, 42);
+    seed_controller_mana(&mut scenario);
+    let primordial = scenario
+        .add_creature_to_hand_from_oracle(P0, "Diluvian Primordial", 5, 5, DILUVIAN_ORACLE)
+        .with_mana_cost(ManaCost::generic(1))
+        .id();
+    // P1's graveyard stays empty: that opponent contributes no slots at all.
+    let p2_selected = scenario
+        .add_spell_to_graveyard(P2, "P2 Selected", true)
+        .from_oracle_text("Draw a card.")
+        .id();
+    let p2_extra = scenario
+        .add_spell_to_graveyard(P2, "P2 Extra", false)
+        .from_oracle_text("Draw a card.")
+        .id();
+    let p3_selected = scenario
+        .add_spell_to_graveyard(P3, "P3 Selected", true)
+        .from_oracle_text("Draw a card.")
+        .id();
+
+    let mut runner = scenario.build();
+    cast_diluvian(&mut runner, primordial);
+    advance_to_trigger_target_selection(&mut runner);
+
+    match runner.state().waiting_for.clone() {
+        WaitingFor::TriggerTargetSelection {
+            target_slots,
+            selection,
+            ..
+        } => {
+            // Reach guard: the binder slots still exist and each still carries
+            // exactly the one pinned opponent. Calibrated against the measured
+            // BASE repro (slot count 4, slot 0 legal = [Player(P2)]).
+            assert_eq!(
+                target_slots.len(),
+                4,
+                "P1 has no instant or sorcery, so only P2's and P3's pairs are built"
+            );
+            assert_eq!(target_slots[0].legal_targets, vec![TargetRef::Player(P2)]);
+            assert!(!target_slots[0].optional);
+            assert_eq!(target_slots[2].legal_targets, vec![TargetRef::Player(P3)]);
+
+            // The discriminating pair: the walk opens on the object slot, and
+            // what it offers is the card, never the opponent.
+            assert_eq!(
+                selection.current_slot, 1,
+                "the pinned opponent is announced by the engine, not prompted"
+            );
+            assert_eq!(
+                selection.current_legal_targets,
+                vec![TargetRef::Object(p2_selected), TargetRef::Object(p2_extra)],
+                "the first prompt offers P2's graveyard cards"
+            );
+            assert!(
+                !selection
+                    .current_legal_targets
+                    .iter()
+                    .any(|target| matches!(target, TargetRef::Player(_))),
+                "CR 115.10a: an affected-but-untargeted opponent is never offered as a choice"
+            );
+            assert_eq!(
+                selection.selected_slots,
+                vec![Some(TargetRef::Player(P2))],
+                "the auto-filled binder is announced into the walk exactly as a click would be"
+            );
+            let _ = p3_selected;
+        }
+        other => panic!("expected the Diluvian target prompt, got {other:?}"),
+    }
+}
+
+/// CR 601.2c + CR 115.3: the engine-announced binder lands in `ability.targets`
+/// at the binder's own index, so each opponent's object slot is scoped to that
+/// opponent's own graveyard and the resolved free-cast pool is the two selected
+/// cards — one per opponent, with no cross-binding.
+#[test]
+fn autofilled_binder_survives_into_the_fanout_target_vector() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    seed_controller_mana(&mut scenario);
+    let primordial = scenario
+        .add_creature_to_hand_from_oracle(P0, "Diluvian Primordial", 5, 5, DILUVIAN_ORACLE)
+        .with_mana_cost(ManaCost::generic(1))
+        .id();
+    let p1_selected = scenario
+        .add_spell_to_graveyard(P1, "P1 Selected", true)
+        .from_oracle_text("Draw a card.")
+        .id();
+    let p1_extra = scenario
+        .add_spell_to_graveyard(P1, "P1 Extra", false)
+        .from_oracle_text("Draw a card.")
+        .id();
+    let p2_selected = scenario
+        .add_spell_to_graveyard(P2, "P2 Selected", true)
+        .from_oracle_text("Draw a card.")
+        .id();
+    let p2_extra = scenario
+        .add_spell_to_graveyard(P2, "P2 Extra", false)
+        .from_oracle_text("Draw a card.")
+        .id();
+
+    let mut runner = scenario.build();
+    cast_diluvian(&mut runner, primordial);
+    advance_to_trigger_target_selection(&mut runner);
+
+    match runner.state().waiting_for.clone() {
+        WaitingFor::TriggerTargetSelection {
+            target_slots,
+            selection,
+            ..
+        } => {
+            assert_eq!(target_slots.len(), 4);
+            assert_eq!(selection.current_slot, 1);
+            assert_eq!(
+                selection.current_legal_targets,
+                vec![TargetRef::Object(p1_selected), TargetRef::Object(p1_extra)],
+                "P1's binder is bound, so its object slot is scoped to P1's graveyard"
+            );
+        }
+        other => panic!("expected the Diluvian target prompt, got {other:?}"),
+    }
+
+    // Submit ONLY object refs — the binder halves are the engine's to announce.
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(p1_selected)),
+        })
+        .expect("P1's graveyard card must be selectable without announcing P1");
+
+    match runner.state().waiting_for.clone() {
+        WaitingFor::TriggerTargetSelection { selection, .. } => {
+            assert_eq!(
+                selection.current_slot, 3,
+                "P2's binder is announced too, so the walk lands on P2's object slot"
+            );
+            assert_eq!(
+                selection.current_legal_targets,
+                vec![TargetRef::Object(p2_selected), TargetRef::Object(p2_extra)],
+                "no cross-binding: the second object slot is scoped to P2's own graveyard"
+            );
+        }
+        other => panic!("expected P2's object prompt, got {other:?}"),
+    }
+
+    runner
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(p2_selected)),
+        })
+        .expect("P2's graveyard card must be selectable without announcing P2");
+    advance_to_free_cast_window(&mut runner);
+
+    match runner.state().waiting_for.clone() {
+        WaitingFor::CastOffer {
+            kind:
+                CastOfferKind::FreeCastWindow {
+                    member_pool,
+                    remaining_casts,
+                    ..
+                },
+            ..
+        } => {
+            // Reach guard first: a pool that is empty because the trigger was
+            // dropped fails here before the pool assertion can pass vacuously.
+            assert_eq!(remaining_casts, 2, "both pairs reached resolution");
+            assert_eq!(
+                member_pool,
+                vec![p1_selected, p2_selected],
+                "one card from each opponent's own graveyard"
+            );
+        }
+        other => panic!("expected the Diluvian FreeCastWindow, got {other:?}"),
+    }
+}


### PR DESCRIPTION
A 4-player Commander player cast Diluvian Primordial and reported the game
had hung: "it just choose first oppent but i cant choose anyone." It had not
hung — the engine was waiting for a target on a slot that has exactly one
legal value by construction, so every click was rejected as illegal.

"For each opponent" fans out into alternating Player/Object target slots. The
Player half is a BINDER: it exists only so the following object slot's
`ControllerRef::TargetPlayer` scope resolves ("that player's graveyard"), and
`collect_per_opponent_target_fanout_specs` pins it to one player when it
builds the pair. CR 115.10a — the opponent is affected but is never identified
by the word "target", so it is not a target; Diluvian's "target" attaches to
the card. CR 115.1d: only the card slot is an announced target.

Announce the pinned player on the controller's behalf and advance, so the
first prompt they see is the real choice. The recursion means consecutive
binders (an opponent with no instant or sorcery in their graveyard contributes
no object slot) collapse in one pass rather than re-prompting.

The gate is the same conjunction `legal_targets_for_selected_slot` already
uses to recognise a binder — `is_per_opponent_target_fanout` plus a
`SpecificPlayer` filter — not a looser filter-shape test, so an ordinary
pinned-player slot on a non-fanout ability still prompts. Two further
conjuncts keep real choices with their owner: CR 115.6 `!slot.optional`
(declining an optional target is a choice, even with a singleton legal set)
and CR 601.2c + CR 115.1 `chooser.is_none()` (a slot another player announces
is not the controller's to auto-resolve).

Also corrects two CR 115.1a citations to CR 115.1d — 115.1a scopes to instant
and sorcery spells, and Diluvian's ETB is a triggered ability.

Tests: five new inline tests in the fanout cluster and two integration tests
covering a 4-seat board and the multi-authority walk. Two are design
discriminators verified by mutation rather than by base-vs-patched — deleting
either the fanout conjunct or the chooser conjunct reddens a named assertion.

Claude-Session: https://claude.ai/code/session_013eDt2CTWnim1rkaqh7uqF1


---

## Validation provenance

Gates were measured on the candidate commit in an isolated worktree, against base `e12334b9`:

| gate | result |
|---|---|
| `clippy` | exit 0, zero warnings |
| `test-engine` | 24924 / 24924 |
| `test-ai` | 2196 / 2196 |

`origin/main` has since moved 9 commits past that base, so those gates are carried forward rather
than re-measured here. What licenses carrying them:

- `crates/engine/src/game/ability_utils.rs` — the only non-test file this PR changes — has **0**
  commits against it in that span, and the cherry-pick applied it with no merge at all.
- Of the 2 commits that did touch `crates/engine/`, only `450119dc7a` (Scroll of Fate) touches
  `types/ability.rs`, and it adds a field to `Effect::Manifest` without altering `TargetSlotSpec`,
  `TargetRef`, or `TargetFilter::SpecificPlayer` — the three types this change depends on.

**Not run:** the independent implementation-review round (`/review-impl`). CI and the merge queue
re-validate from scratch.

https://claude.ai/code/session_013eDt2CTWnim1rkaqh7uqF1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved per-opponent targeting so mandatory opponent selections are filled automatically when appropriate.
  * Target selection now prompts for the relevant card directly and skips opponents without valid targets.
  * Preserved correct opponent-specific targeting and free-cast results for multi-opponent effects.

* **Tests**
  * Added and updated integration coverage for automatic opponent selection, graveyard targeting, deferred effects, and uncastable spells.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->