### PR TITLE
fix(draft): scope a pod error to the phase that raised it

### DIFF
--- a/client/src/components/draft/PodErrorBanner.tsx
+++ b/client/src/components/draft/PodErrorBanner.tsx
@@ -12,15 +12,13 @@ import { useMultiplayerDraftStore } from "../../stores/multiplayerDraftStore";
  * same store field — the pause banner's `role="status"` is the wrong precedent,
  * because a paused draft is a status and a failed action is not.
  *
- * `store.error` is write-once: nothing clears it on a phase transition, so an
- * error raised in `betweenGames` (which has no banner of its own) surfaces on
- * the *next* pod screen and rides along until the host's next
- * `pairingsGenerated` supersedes it or the user dismisses it. Deliberate — the
- * alternative is the BASE behaviour, where those errors were invisible
- * everywhere. A scoped phase-transition clearing rule is the real fix; until
- * then, note that `role="alert"` re-announces a latched error at every pod
- * phase change, because each phase view mounts its own instance of this
- * component.
+ * `store.error` is scoped to the phase it was raised in:
+ * `clearErrorOnPhaseChange` in `multiplayerDraftStore` retires it when the pod
+ * changes phase, for both roles. So this banner never outlives its own screen,
+ * and the `role="alert"` remount that each phase view performs cannot
+ * re-announce a stale error — after a transition there is nothing to announce.
+ * Within a phase the error persists across unrelated `viewUpdated` broadcasts;
+ * dismissal is the clearing path there.
  */
 export function PodErrorBanner() {
   const { t } = useTranslation("common");
@@ -33,14 +31,14 @@ export function PodErrorBanner() {
     <div
       role="alert"
       data-testid="pod-error-banner"
-      className="flex items-start gap-3 rounded-lg border border-red-400/20 bg-red-400/5 px-4 py-3 text-sm text-red-300"
+      className="flex w-full items-start gap-3 rounded-lg border border-red-400/20 bg-red-400/5 px-4 py-3 text-sm text-red-300"
     >
       <span className="min-w-0 flex-1">{error}</span>
       <button
         type="button"
         onClick={clearError}
         aria-label={t("actions.close")}
-        className="shrink-0 text-lg leading-none text-red-300/70 transition-colors hover:text-red-200"
+        className="min-h-11 min-w-11 shrink-0 text-lg leading-none text-red-300/70 transition-colors hover:text-red-200"
       >
         &times;
       </button>

--- a/client/src/components/draft/PodErrorBanner.tsx
+++ b/client/src/components/draft/PodErrorBanner.tsx
@@ -14,7 +14,7 @@ import { useMultiplayerDraftStore } from "../../stores/multiplayerDraftStore";
  *
  * `store.error` is scoped to the phase it was raised in:
  * `clearErrorOnPhaseChange` in `multiplayerDraftStore` retires it when the pod
- * changes phase, for both roles. So this banner never outlives its own screen,
+ * changes phase, for both roles. So this banner never outlives its own phase,
  * and the `role="alert"` remount that each phase view performs cannot
  * re-announce a stale error — after a transition there is nothing to announce.
  * Within a phase the error persists across unrelated `viewUpdated` broadcasts;

--- a/client/src/pages/DraftPodPage.tsx
+++ b/client/src/pages/DraftPodPage.tsx
@@ -545,6 +545,7 @@ function BetweenGamesView() {
     const timerSec = timerRemainingMs != null ? Math.ceil(timerRemainingMs / 1000) : null;
     return (
       <div className="mx-auto flex w-full max-w-md flex-col items-center gap-6 py-8">
+        <PodErrorBanner />
         <h2 className="text-xl font-medium text-white">{t("betweenGames.game", { number: playDrawPrompt.gameNumber })}</h2>
         <ScoreBadge score={playDrawPrompt.score} player={seatIndex === 0 ? 0 : 1} size="md" />
         <p className="text-sm text-white/60">{t("betweenGames.lostPreviousGame")}</p>
@@ -573,6 +574,7 @@ function BetweenGamesView() {
   if (sideboardSubmitted) {
     return (
       <div className="mx-auto flex w-full max-w-md flex-col items-center gap-6 py-8">
+        <PodErrorBanner />
         <h2 className="text-xl font-medium text-white">{t("betweenGames.sideboarding")}</h2>
         {sideboardPrompt && (
           <ScoreBadge score={sideboardPrompt.score} player={seatIndex === 0 ? 0 : 1} size="md" />
@@ -597,6 +599,7 @@ function BetweenGamesView() {
 
     return (
       <div className="mx-auto flex w-full max-w-4xl flex-col gap-4 py-8">
+        <PodErrorBanner />
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-3">
             <h2 className="text-xl font-medium text-white">
@@ -629,6 +632,7 @@ function BetweenGamesView() {
   // Fallback — should not reach here
   return (
     <div className="mx-auto flex w-full max-w-md flex-col items-center gap-6 py-8">
+      <PodErrorBanner />
       <p className="text-sm text-white/60">{t("betweenGames.preparingNext")}</p>
     </div>
   );

--- a/client/src/pages/__tests__/DraftPodPage.betweenGames.test.tsx
+++ b/client/src/pages/__tests__/DraftPodPage.betweenGames.test.tsx
@@ -6,17 +6,40 @@ import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { DraftPodPage } from "../DraftPodPage";
 
+// The store declares these shapes inline and anonymously
+// (`multiplayerDraftStore.ts`), so there is no named type to import and the
+// harness declares its own. Without the annotations TypeScript infers
+// `playDrawPrompt: null` and a non-nullable `sideboardPrompt`, and branch
+// selection needs the opposite of both. Type aliases are erased, so declaring
+// them above `vi.hoisted` does not disturb the hoist.
+type Score = { p0_wins: number; p1_wins: number; draws: number };
+type SideboardPrompt = {
+  matchId: string;
+  gameNumber: number;
+  score: Score;
+  loserSeat: number | null;
+  timerMs: number;
+} | null;
+type PlayDrawPrompt = {
+  matchId: string;
+  gameNumber: number;
+  score: Score;
+  timerMs: number;
+} | null;
+
 const { draftState } = vi.hoisted(() => ({
   draftState: {
     phase: "betweenGames",
+    error: null as string | null,
+    clearError: vi.fn(),
     sideboardPrompt: {
       matchId: "bo3-1",
       gameNumber: 2,
       score: { p0_wins: 1, p1_wins: 0, draws: 0 },
       loserSeat: 1,
       timerMs: 60_000,
-    },
-    playDrawPrompt: null,
+    } as SideboardPrompt,
+    playDrawPrompt: null as PlayDrawPrompt,
     sideboardSubmitted: false,
     seatIndex: 0,
     timerRemainingMs: 60_000,
@@ -49,6 +72,8 @@ function renderPage() {
   return render(<MemoryRouter><DraftPodPage /></MemoryRouter>);
 }
 
+const ERROR_TEXT = "Sideboard timer expired without a registered deck";
+
 describe("DraftPodPage betweenGames", () => {
   afterEach(cleanup);
 
@@ -63,7 +88,9 @@ describe("DraftPodPage betweenGames", () => {
     draftState.playDrawPrompt = null;
     draftState.sideboardSubmitted = false;
     draftState.submittedDeck = ["Plains", "Island"];
+    draftState.error = null;
     draftState.submitSideboard.mockClear();
+    draftState.clearError.mockClear();
   });
 
   it("renders the live sideboard prompt and submits its current deck through the store authority", async () => {
@@ -84,5 +111,63 @@ describe("DraftPodPage betweenGames", () => {
     expect(screen.getByText("Waiting for opponent to submit sideboard...")).toBeInTheDocument();
     expect(screen.getByText("Plains, Island")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Submit Sideboard" })).toBeNull();
+  });
+
+  // Both `betweenGames` error emitters (`autoSubmitSideboards`,
+  // `submitDefaultIntergameCommand` in `p2p-draft-host.ts`) ABORT the intergame
+  // progression, so the screen the user is left on is whichever branch the
+  // prompt state happened to be in. Every branch therefore has to surface it.
+  it.each<[string, () => void, string]>([
+    [
+      "play/draw",
+      () => {
+        draftState.playDrawPrompt = {
+          matchId: "bo3-1",
+          gameNumber: 2,
+          score: { p0_wins: 1, p1_wins: 0, draws: 0 },
+          timerMs: 60_000,
+        };
+      },
+      "Game 2",
+    ],
+    [
+      "sideboard-submitted",
+      () => {
+        draftState.sideboardSubmitted = true;
+      },
+      "Sideboarding",
+    ],
+    [
+      "sideboard-editing",
+      () => {},
+      "Sideboard — Game 2",
+    ],
+    [
+      "fallback",
+      () => {
+        draftState.sideboardPrompt = null;
+      },
+      "Preparing next game...",
+    ],
+  ])("surfaces a live pod error on the %s branch", (_branch, setup, branchText) => {
+    setup();
+    draftState.error = ERROR_TEXT;
+    renderPage();
+
+    // Reach-guard: the intended branch rendered, so a missing banner below is a
+    // real absence and not a fixture that routed somewhere else.
+    expect(screen.getByText(branchText)).toBeInTheDocument();
+    // REVERT-FAILING: drop this branch's `<PodErrorBanner />` and this row goes
+    // red — `getByTestId` throws on absence.
+    expect(screen.getByTestId("pod-error-banner")).toBeInTheDocument();
+    expect(screen.getByText(ERROR_TEXT)).toBeInTheDocument();
+  });
+
+  it("renders no banner when there is no live error", () => {
+    renderPage();
+
+    // Same reach-guard, so the absence below is a real absence.
+    expect(screen.getByText("Sideboard — Game 2")).toBeInTheDocument();
+    expect(screen.queryByTestId("pod-error-banner")).toBeNull();
   });
 });

--- a/client/src/pages/__tests__/DraftPodPage.betweenGames.test.tsx
+++ b/client/src/pages/__tests__/DraftPodPage.betweenGames.test.tsx
@@ -4,26 +4,28 @@ import type { ReactNode } from "react";
 import { MemoryRouter } from "react-router";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import type { MatchScore } from "../../adapter/types";
 import { DraftPodPage } from "../DraftPodPage";
 
-// The store declares these shapes inline and anonymously
-// (`multiplayerDraftStore.ts`), so there is no named type to import and the
-// harness declares its own. Without the annotations TypeScript infers
-// `playDrawPrompt: null` and a non-nullable `sideboardPrompt`, and branch
-// selection needs the opposite of both. Type aliases are erased, so declaring
-// them above `vi.hoisted` does not disturb the hoist.
-type Score = { p0_wins: number; p1_wins: number; draws: number };
+// The store declares the two prompt objects inline and anonymously
+// (`multiplayerDraftStore.ts`), and `MultiplayerDraftState` is not exported, so
+// indexed access is unavailable and the harness declares its own. Their `score`
+// field is the exported `MatchScore` — imported rather than re-declared, so the
+// fixture cannot drift from the type it stands in for. Without the annotations
+// TypeScript infers `playDrawPrompt: null` and a non-nullable `sideboardPrompt`,
+// and branch selection needs the opposite of both. Type aliases are erased, so
+// declaring them above `vi.hoisted` does not disturb the hoist.
 type SideboardPrompt = {
   matchId: string;
   gameNumber: number;
-  score: Score;
+  score: MatchScore;
   loserSeat: number | null;
   timerMs: number;
 } | null;
 type PlayDrawPrompt = {
   matchId: string;
   gameNumber: number;
-  score: Score;
+  score: MatchScore;
   timerMs: number;
 } | null;
 

--- a/client/src/stores/__tests__/multiplayerDraftStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerDraftStore.test.ts
@@ -223,7 +223,7 @@ describe("multiplayerDraftStore", () => {
       expect(state.view).toBe(view);
     });
 
-    it("pairingsGenerated advances currentRound, leaves nextPairingRound to viewUpdated, and supersedes the error", async () => {
+    it("pairingsGenerated advances currentRound, leaves nextPairingRound to viewUpdated, and the phase change retires the error", async () => {
       await useMultiplayerDraftStore.getState().hostDraft({
         poolInput: { type: "Set", data: { set_pool_json: "{}" } },
         kind: "Premier",
@@ -233,10 +233,12 @@ describe("multiplayerDraftStore", () => {
         podPolicy: "Competitive",
       });
 
-      // The host's real round boundary: the engine view for round 2 arrives
-      // first, then pairing generation commits round 3.
+      // The host's real round boundary, in the order the adapter emits it: the
+      // round-2 view lands on the round-complete screen, the failed attempt
+      // raises the banner, and the retry's `roundAdvanced` opens the pairing
+      // window before pairing generation commits round 3.
       const view = {
-        ...mockView("MatchInProgress"),
+        ...mockView("RoundComplete"),
         current_round: 2,
         next_pairing_round: 3,
       };
@@ -250,6 +252,10 @@ describe("multiplayerDraftStore", () => {
       expect(useMultiplayerDraftStore.getState().error).toBe(
         "Failed to advance round",
       );
+      // The retry. `roundAdvanced` is what moves the phase off `roundComplete`,
+      // and that transition is what retires the banner — one step before
+      // `pairingsGenerated`, and for guests as well as the host.
+      capturedHostEventHandler!({ type: "roundAdvanced" });
       capturedHostEventHandler!({ type: "pairingsGenerated", round: 3, pairings: [] });
 
       const state = useMultiplayerDraftStore.getState();
@@ -263,10 +269,9 @@ describe("multiplayerDraftStore", () => {
       // inlined `nextPairingRound: event.round + 1` to that handler — the
       // TypeScript re-derivation this work exists to abolish — yields 4 here.
       expect(state.nextPairingRound).toBe(3);
-      // REVERT-FAILING: drop `error: null` from the `pairingsGenerated` handler
-      // and this goes red. A successful round boundary supersedes the banner the
-      // failed attempt raised — without it the retry that WORKED still shows
-      // "Failed to advance round".
+      // REVERT-FAILING: remove the `clearErrorOnPhaseChange` wrap and this goes
+      // red with "Failed to advance round" — the retry that WORKED would still
+      // show the failed attempt's banner.
       expect(state.error).toBeNull();
     });
 
@@ -475,6 +480,97 @@ describe("multiplayerDraftStore", () => {
       const state = useMultiplayerDraftStore.getState();
       expect(state.phase).toBe("kicked");
       expect(state.error).toBe("AFK");
+    });
+
+    it("retires a guest error when the phase changes, and only then", async () => {
+      await useMultiplayerDraftStore.getState().joinDraft({
+        roomCode: "ABCDE",
+        displayName: "Alice",
+      });
+
+      capturedGuestEventHandler!({
+        type: "viewUpdated",
+        view: mockView("MatchInProgress"),
+      });
+      capturedGuestEventHandler!({
+        type: "error",
+        message: "Failed to start match",
+      });
+      // Reach-guard: the error is live before any of the three steps below, so
+      // a null at the end cannot mean "it was never set".
+      expect(useMultiplayerDraftStore.getState().error).toBe(
+        "Failed to start match",
+      );
+
+      // (i) A same-phase broadcast must NOT clear. `viewUpdated` fires on every
+      // pick, seat change and timer sync; clearing on the mere presence of a
+      // `phase` key would erase an error the user has not read.
+      capturedGuestEventHandler!({
+        type: "viewUpdated",
+        view: mockView("MatchInProgress"),
+      });
+      expect(useMultiplayerDraftStore.getState().phase).toBe("matchInProgress");
+      expect(useMultiplayerDraftStore.getState().error).toBe(
+        "Failed to start match",
+      );
+
+      // (ii) A payload that names no phase at all must NOT clear.
+      capturedGuestEventHandler!({
+        type: "lobbyUpdate",
+        seats: [],
+        joined: 2,
+        total: 8,
+      });
+      expect(useMultiplayerDraftStore.getState().joined).toBe(2);
+      expect(useMultiplayerDraftStore.getState().error).toBe(
+        "Failed to start match",
+      );
+
+      // (iii) A real phase change retires it.
+      capturedGuestEventHandler!({
+        type: "viewUpdated",
+        view: mockView("RoundComplete"),
+      });
+
+      const state = useMultiplayerDraftStore.getState();
+      // Reach-guard: the clearing event was delivered and applied.
+      expect(state.phase).toBe("roundComplete");
+      // REVERT-FAILING: remove the `clearErrorOnPhaseChange` wrap and this goes
+      // red — a guest error raised in one phase would ride along into the next.
+      expect(state.error).toBeNull();
+    });
+
+    it("clears a stale message when the guest enters a message-less error phase, but not one that follows the flip", async () => {
+      await useMultiplayerDraftStore.getState().joinDraft({
+        roomCode: "ABCDE",
+        displayName: "Alice",
+      });
+
+      capturedGuestEventHandler!({ type: "error", message: "gone" });
+      // Reach-guard, as above.
+      expect(useMultiplayerDraftStore.getState().error).toBe("gone");
+
+      // `reconnectFailed`'s shape: the adapter flips status to `error` and the
+      // event that follows carries no message, so nothing replaces the stale
+      // string. Attributing an unrelated earlier failure to a failed reconnect
+      // is worse than the page's own generic copy — accepted, and pinned here.
+      capturedGuestEventHandler!({ type: "statusChanged", status: "error" });
+
+      expect(useMultiplayerDraftStore.getState().phase).toBe("error");
+      // REVERT-FAILING: remove the wrap and "gone" survives into the error screen.
+      expect(useMultiplayerDraftStore.getState().error).toBeNull();
+
+      // The sibling ordering both `initialize()` catches use — status flip
+      // first, message second — must leave the message intact.
+      capturedGuestEventHandler!({
+        type: "statusChanged",
+        status: "matchInProgress",
+      });
+      capturedGuestEventHandler!({ type: "error", message: "boom" });
+
+      const state = useMultiplayerDraftStore.getState();
+      expect(state.phase).toBe("matchInProgress");
+      expect(state.error).toBe("boom");
     });
   });
 

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -532,13 +532,16 @@ const initialState: MultiplayerDraftState = {
  * fails and succeeds while `phase` is already `matchInProgress`. Dismissal
  * (`clearError`) remains the clearing path for that case.
  *
- * Also not covered: `betweenGames` has no `DraftPlayerView.status` of its own
- * (`phaseForDraftViewStatus` never returns it — the phase is written only by
- * the bo3 prompt arms), so any `viewUpdated` broadcast during a Bo3 intergame
- * window flips the phase to `matchInProgress` and retires the error with it.
- * A seat dropping mid-window is enough. The intergame screen is lost in that
- * interleaving either way, which is pre-existing, so this narrows where those
- * two emitters are visible rather than restoring the old latch.
+ * Also not covered: `betweenGames` has no `DraftPlayerView.status` of its own.
+ * `phaseForDraftViewStatus` never returns it; the phase is reached through the
+ * bo3 sideboard-prompt paths — `handleBetweenGamesPrompt` and the two
+ * `bo3SideboardPrompt` arms. So any `viewUpdated` broadcast during a Bo3
+ * intergame window flips the phase to `matchInProgress` and retires the error
+ * with it; a seat dropping mid-window is enough. The intergame screen is lost
+ * in that interleaving either way, which is pre-existing, so this narrows where
+ * the intergame errors ("Sideboard timer expired without a registered deck",
+ * "Intergame timeout lacks launch authority") are visible rather than restoring
+ * the old latch.
  *
  * Scope: this wraps the *initializer's* setter, so it covers every write made
  * inside this module. It is not zustand middleware and does not rebind

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -12,7 +12,7 @@
  * projects their events into reactive Zustand state for the React UI.
  */
 
-import { create } from "zustand";
+import { create, type StateCreator } from "zustand";
 
 import type {
   DraftCardInstance,
@@ -510,11 +510,64 @@ const initialState: MultiplayerDraftState = {
   sideboardSubmitted: false,
 };
 
+/**
+ * Single authority for how long a pod error lives.
+ *
+ * An error belongs to the phase it was raised in; a *change* of phase retires
+ * it. Wrapping the store's setter — rather than writing `error: null` into each
+ * success arm — gives one rule for both roles: guests write `phase` from many
+ * arms of `handleGuestEvent` and cleared it at none, while the host had a
+ * single ad-hoc supersession on `pairingsGenerated`.
+ *
+ * Two properties are load-bearing and neither is incidental:
+ *
+ * - It fires only when `phase` actually *changes*. `viewUpdated` writes `phase`
+ *   on every broadcast — a pick, a seat connecting, a timer sync — so clearing
+ *   on the mere presence of the key would erase an error the user has not read.
+ *   That form was considered and rejected when this banner was introduced.
+ * - The incoming payload wins. `kicked` and `hostLeft` write `phase` and `error`
+ *   in one `set()`; spreading the payload last preserves the reason they carry.
+ *
+ * Not covered, deliberately: a retry that does not change phase — `startMatch`
+ * fails and succeeds while `phase` is already `matchInProgress`. Dismissal
+ * (`clearError`) remains the clearing path for that case.
+ *
+ * Scope: this wraps the *initializer's* setter, so it covers every write made
+ * inside this module. It is not zustand middleware and does not rebind
+ * `api.setState`, so `useMultiplayerDraftStore.setState(…)` bypasses the rule.
+ * That is fine today — production has no such call site (only tests do) — but a
+ * future production write through `setState` would not be phase-scoped.
+ */
+function clearErrorOnPhaseChange(set: SetFn): SetFn {
+  return (partial) =>
+    set((state) => {
+      const next = typeof partial === "function" ? partial(state) : partial;
+      return next.phase === undefined || next.phase === state.phase
+        ? next
+        : { error: null, ...next };
+    });
+}
+
+/** Applies {@link clearErrorOnPhaseChange} to the store's setter.
+ *
+ * Borrows the `create<T>()(middleware(initializer))` *shape* from `gameStore`,
+ * but it is not zustand middleware: it wraps only the initializer's `set`, so
+ * external `useMultiplayerDraftStore.setState(…)` calls are not phase-scoped.
+ * No production code does that (tests do); see `clearErrorOnPhaseChange`. */
+function phaseScopedError(
+  initializer: (
+    set: SetFn,
+    get: () => MultiplayerDraftState & MultiplayerDraftActions,
+  ) => MultiplayerDraftState & MultiplayerDraftActions,
+): StateCreator<MultiplayerDraftState & MultiplayerDraftActions> {
+  return (set, get) => initializer(clearErrorOnPhaseChange(set), get);
+}
+
 // ── Store ──────────────────────────────────────────────────────────────
 
 export const useMultiplayerDraftStore = create<
   MultiplayerDraftState & MultiplayerDraftActions
->()((set, get) => ({
+>()(phaseScopedError((set, get) => ({
   ...initialState,
 
   hostDraft: async (config) => {
@@ -1016,7 +1069,7 @@ export const useMultiplayerDraftStore = create<
     disposeMatchAdapter(set);
     set(initialState);
   },
-}));
+})));
 
 // ── Event handlers ─────────────────────────────────────────────────────
 
@@ -1130,18 +1183,14 @@ function handleHostEvent(event: DraftPodHostEvent, set: SetFn): void {
       set({ paused: false, pauseReason: null });
       break;
     case "pairingsGenerated":
-      // Host-only supersession: `advanceRound()` emits its own failure as
-      // `error`, so a successful retry of that exact operation clears the
-      // banner. This clears *any* live error, not just that one — accepted,
-      // because `pairingsGenerated` fires once per round boundary, so anything
-      // it erases has already had a full round on screen. Guests have no
-      // `pairingsGenerated` handler, so for them `clearError` (the banner's
-      // dismiss control) is the only clearing path.
+      // No `error: null` here. `clearErrorOnPhaseChange` retires the banner one
+      // step earlier, when `roundAdvanced` / `statusChanged("pairing")` moves the
+      // phase off `roundComplete` — and it does the same for guests, which this
+      // host-only arm never could.
       set({
         phase: "matchInProgress",
         currentRound: event.round,
         pairings: event.pairings,
-        error: null,
       });
       saveDraftPodProgress("matchInProgress");
       break;

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -522,7 +522,7 @@ const initialState: MultiplayerDraftState = {
  * Two properties are load-bearing and neither is incidental:
  *
  * - It fires only when `phase` actually *changes*. `viewUpdated` writes `phase`
- *   on every broadcast — a pick, a seat connecting, a timer sync — so clearing
+ *   on every broadcast — a pick, a seat connecting, a seat dropping — so clearing
  *   on the mere presence of the key would erase an error the user has not read.
  *   That form was considered and rejected when this banner was introduced.
  * - The incoming payload wins. `kicked` and `hostLeft` write `phase` and `error`
@@ -531,6 +531,14 @@ const initialState: MultiplayerDraftState = {
  * Not covered, deliberately: a retry that does not change phase — `startMatch`
  * fails and succeeds while `phase` is already `matchInProgress`. Dismissal
  * (`clearError`) remains the clearing path for that case.
+ *
+ * Also not covered: `betweenGames` has no `DraftPlayerView.status` of its own
+ * (`phaseForDraftViewStatus` never returns it — the phase is written only by
+ * the bo3 prompt arms), so any `viewUpdated` broadcast during a Bo3 intergame
+ * window flips the phase to `matchInProgress` and retires the error with it.
+ * A seat dropping mid-window is enough. The intergame screen is lost in that
+ * interleaving either way, which is pre-existing, so this narrows where those
+ * two emitters are visible rather than restoring the old latch.
  *
  * Scope: this wraps the *initializer's* setter, so it covers every write made
  * inside this module. It is not zustand middleware and does not rebind
@@ -1185,7 +1193,8 @@ function handleHostEvent(event: DraftPodHostEvent, set: SetFn): void {
     case "pairingsGenerated":
       // No `error: null` here. `clearErrorOnPhaseChange` retires the banner one
       // step earlier, when `roundAdvanced` / `statusChanged("pairing")` moves the
-      // phase off `roundComplete` — and it does the same for guests, which this
+      // phase into `pairing` — off `roundComplete` at a round boundary, off
+      // `deckbuilding` at round 0 — and it does the same for guests, which this
       // host-only arm never could.
       set({
         phase: "matchInProgress",

--- a/crates/draft-core/src/session.rs
+++ b/crates/draft-core/src/session.rs
@@ -586,7 +586,7 @@ fn apply_advance_round(session: &mut DraftSession) -> Result<Vec<DraftDelta>, Dr
         });
     }
 
-    let new_round = session.current_round + 1;
+    let new_round = session.next_pairing_round();
     session.status = DraftStatus::Pairing;
 
     Ok(vec![DraftDelta::RoundAdvanced { new_round }])


### PR DESCRIPTION
Residuals after #7696, including the two CodeRabbit findings it picked up.

## A pod error now belongs to the phase that raised it

`store.error` was effectively write-once. #7696 gave the host a single ad-hoc supersession (`pairingsGenerated` set `error: null`); guests write `phase` from many arms of `handleGuestEvent` and cleared the error at **none**, so a guest's banner survived the rest of the match unless they dismissed it by hand.

CodeRabbit's suggestion was to mirror `error: null` onto the guest's success arms. That works, and it is one clearing site per arm per role, growing forever, with no authority. Instead the store's setter is wrapped once — **an error belongs to the phase it was raised in, and a change of phase retires it** — so every write inside the module routes through one rule, host and guest alike, and #7696's supersession is *deleted* rather than left as a second authority. The phase has already moved by the time `pairingsGenerated` arrives, via `roundAdvanced`.

Two clauses are load-bearing, and both are pinned by their own mutation-verified assertion:

- It fires only on a **changed** phase. `viewUpdated` writes `phase` on every broadcast — a pick, a seat connecting, a seat dropping — so clearing on the key's mere presence would erase an error the user has not read. That form was considered and rejected in #7696.
- The **incoming payload wins** (`{ error: null, ...next }`), so `kicked` and `hostLeft`, which write `phase` and `error` in one `set()`, keep their reason.

The wrapper is not zustand middleware and does not rebind `api.setState`, so an external `useMultiplayerDraftStore.setState` would bypass it. There are no such production call sites today (six hits, all tests); that is documented at the code rather than claimed as impossible.

## `betweenGames` had no error surface at all

Both intergame emitters abort their progression — one `continue`s past a seat, the other `return`s before taking launch authority. With no banner mounted in `BetweenGamesView`, "Intergame timeout lacks launch authority" was visible on **no screen**. The banner is now in all four branches.

This is why the two land together: the clearing rule retires the latch that was previously the only way such an error ever reached a display, so shipping it alone would have made a silent failure quieter.

One limitation is documented rather than left to be found: `betweenGames` has no `DraftPlayerView.status` of its own, so any view broadcast during a Bo3 window flips the phase and retires the error with it. The intergame screen is lost in that interleaving regardless — pre-existing, and untouched here.

## Two smaller fixes on the same surface

- The dismiss control gets a 44pt hit area, per the `client/src/**` rule. `min-h-11 min-w-11` is copied verbatim from the nearest sibling `×` control in `GameLogPanel`.
- The banner's root gets `w-full`. Three of the four new containers carry `items-center` and would otherwise shrink-wrap it into a centred pill.

Neither is testable here — jsdom performs no layout, and the repo has no browser harness. Both are recorded as uncovered rather than implied.

## `apply_advance_round` calls the authority

#7696 made `DraftSession::next_pairing_round()` the single authority for `current_round + 1` and widened it to `pub(crate)` on those grounds; this in-crate site still recomputed it by hand. The delta it feeds, `DraftDelta::RoundAdvanced { new_round }`, is a published wire type, so a future non-`+1` authority would have diverged here silently. No test or lint can see the difference today — the two expressions are numerically identical — so this is a structural fix, and the existing `RoundAdvanced { new_round: 2 }` assertion is a preservation guard, not a discriminator.

## Verification

Every behavioural claim has a test that fails when the change is reverted, and each was proven non-vacuous by mutating the production line it guards and confirming *that* assertion reddens — vitest reports only the first failure, so an earlier passing assertion can otherwise mask which line does the work.

Both conjuncts of the rule are pinned separately: dropping `=== state.phase` reddens the same-phase case, dropping `=== undefined` reddens the phase-less-payload case. Removing any one of the four `betweenGames` mounts reddens exactly one `it.each` row, so no mount is double-covered.

Four things are covered by no test and are stated as such rather than implied: the touch target and `w-full` (no layout in jsdom), the Rust unification (numerically identical expressions), and `MultiplayerPage`'s fallback render — that last one is *uncovered*, not undiscriminable.

## Not addressed

The pre-existing `viewUpdated` clobber of the client-only `betweenGames` phase. Fixing it needs its own exit design, and the alternative — exempting `betweenGames` from the rule — would put an ad-hoc case inside the single authority and restore the latch this removes.


https://claude.ai/code/session_0118J576jjG9stoucpv5vvyN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Pod connection and error banners now appear throughout the between-games flow.
  * Errors persist during updates within the same draft phase and clear when the phase changes.
  * Explicitly reported errors continue to display correctly.
  * Error banners now span the available width, with a larger, more accessible close button.

* **Tests**
  * Added coverage for error visibility across between-game states and phase transition behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->