### PR TITLE
fix(draft): derive the Bo3 intergame screen instead of storing it as a phase

### DIFF
--- a/client/src/components/draft/__tests__/HostControls.test.tsx
+++ b/client/src/components/draft/__tests__/HostControls.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * Host administration controls read the POD SESSION phase, not the local
+ * client's screen.
+ *
+ * `HostControls` administers the pod; `draftPodScreen` is a local, per-viewer
+ * rendering concern (a viewer can hide the Bo3 intergame overlay without the pod
+ * changing at all). Gating a host control on whether the host personally happens
+ * to be sideboarding — still less on whether they have hidden that screen — would
+ * be the same layering error the derived-screen change removes, inverted.
+ *
+ * Every fixture below carries a LIVE `sideboardPrompt` alongside
+ * `phase: "matchInProgress"`, so the two authorities disagree
+ * (`draftPodScreen(fixture) === "betweenGames"`). Without that, swapping
+ * `HostControls`'s `s.phase` selector to `draftPodScreen` — exactly the silent
+ * move this file exists to catch — would leave every row green.
+ */
+
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { HostControls } from "../HostControls";
+
+const { draftState } = vi.hoisted(() => ({
+  draftState: {
+    role: "host" as string | null,
+    phase: "matchInProgress",
+    paused: false,
+    sideboardPrompt: {
+      matchId: "m1",
+      gameNumber: 2,
+      score: { p0_wins: 1, p1_wins: 0, draws: 0 },
+      loserSeat: 1,
+      timerMs: 0,
+    } as unknown,
+    playDrawPrompt: null as unknown,
+    view: {
+      pod_policy: "Casual",
+      seats: [
+        { seat_index: 1, display_name: "Alice", is_bot: false, connected: true },
+      ],
+    } as unknown,
+    pairings: [
+      {
+        round: 1,
+        table: 1,
+        seat_a: 0,
+        name_a: "Host",
+        seat_b: 1,
+        name_b: "Alice",
+        match_id: "m1",
+        status: "InProgress",
+        winner_seat: null,
+        score_a: 1,
+        score_b: 0,
+      },
+    ],
+    advanceRound: vi.fn(),
+    requestPause: vi.fn(),
+    requestResume: vi.fn(),
+    overrideMatchResult: vi.fn(),
+    replaceSeatWithBot: vi.fn(),
+    leave: vi.fn(),
+  },
+}));
+
+// The spread keeps the real `draftPodScreen` / `intergamePromptKey` exports
+// resolvable, so a future edit importing one into `HostControls` runs against
+// the shipped rule rather than throwing on a missing export.
+vi.mock("../../../stores/multiplayerDraftStore", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../stores/multiplayerDraftStore")>()),
+  useMultiplayerDraftStore: (selector: (state: typeof draftState) => unknown) => selector(draftState),
+}));
+
+vi.mock("../../../stores/draftPodStore", () => ({
+  useDraftPodStore: (selector: (state: { reset: () => void }) => unknown) => selector({ reset: vi.fn() }),
+}));
+
+vi.mock("react-router", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("react-router")>()),
+  useNavigate: () => vi.fn(),
+}));
+
+describe("HostControls", () => {
+  afterEach(cleanup);
+
+  beforeEach(() => {
+    draftState.role = "host";
+    draftState.phase = "matchInProgress";
+    draftState.sideboardPrompt = {
+      matchId: "m1",
+      gameNumber: 2,
+      score: { p0_wins: 1, p1_wins: 0, draws: 0 },
+      loserSeat: 1,
+      timerMs: 0,
+    };
+  });
+
+  // H1a — pinning row (not red-first: the fixture states `phase` directly). It
+  // records the DECISION that this gate reads the pod-session phase.
+  it("keeps Override match result available during the Bo3 intergame window", () => {
+    render(<HostControls />);
+
+    // REVERT-FAILING: narrow `showOverride` to exclude `matchInProgress`, or swap
+    // the component's `s.phase` selector to `draftPodScreen`.
+    expect(screen.getByText("Override Result")).toBeInTheDocument();
+  });
+
+  // H1b — its own row: one row asserting both predicates could not say which moved.
+  it("keeps Kick / replace seat available during the Bo3 intergame window", () => {
+    render(<HostControls />);
+
+    // REVERT-FAILING: narrow `showKickReplace` to exclude `matchInProgress`, or
+    // swap the component's `s.phase` selector to `draftPodScreen`.
+    expect(screen.getByText("Kick + Replace")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: "Replace Alice with Bot" })).toBeInTheDocument();
+  });
+
+  // H2 — sibling/negative. The Pause control is the paired positive, so the two
+  // absences are real absences rather than a component that returned `null` for
+  // an unrelated reason (the `role !== "host"` early return, or the all-false one).
+  it("hides both controls outside a match, while still rendering the drafting control", () => {
+    draftState.phase = "drafting";
+    draftState.sideboardPrompt = null;
+    render(<HostControls />);
+
+    expect(screen.getByRole("button", { name: "Pause Draft" })).toBeInTheDocument();
+    expect(screen.queryByText("Override Result")).toBeNull();
+    expect(screen.queryByText("Kick + Replace")).toBeNull();
+  });
+
+  // H3 — the role gate. Reach-guard: the same fixture rendered Override in H1a.
+  it("renders nothing for a guest", () => {
+    draftState.role = "guest";
+    const { container } = render(<HostControls />);
+
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  // H4 — the host never loses its pod-level release on this screen. This is what
+  // makes "the overlay holds until the host acts or the pod session moves" true
+  // rather than "holds indefinitely".
+  it("keeps End Draft available on the intergame screen and while drafting", () => {
+    render(<HostControls />);
+    // REVERT-FAILING: add `"matchInProgress"` to `showEndDraft`'s exclusion list.
+    expect(screen.getByRole("button", { name: "End Draft" })).toBeInTheDocument();
+
+    cleanup();
+    draftState.phase = "drafting";
+    draftState.sideboardPrompt = null;
+    render(<HostControls />);
+    expect(screen.getByRole("button", { name: "End Draft" })).toBeInTheDocument();
+  });
+});

--- a/client/src/i18n/locales/de/draft.json
+++ b/client/src/i18n/locales/de/draft.json
@@ -373,7 +373,11 @@
     "sideboardGame": "Sideboard — Spiel {{number}}",
     "sideboardHint": "Nimm Sideboard-Änderungen vor und reiche dann ein. Dein Pool ist unten verfügbar.",
     "submitSideboard": "Sideboard einreichen",
-    "preparingNext": "Nächstes Spiel wird vorbereitet..."
+    "preparingNext": "Nächstes Spiel wird vorbereitet...",
+    "hideOverlay": "Diesen Bildschirm ausblenden",
+    "showOverlay": "Diesen Bildschirm anzeigen",
+    "hiddenNotice": "Das Sideboarding ist für dieses Spiel weiterhin offen.",
+    "hiddenNoticePlayDraw": "Für dieses Spiel steht die Wahl zwischen Spielen und Ziehen noch aus."
   },
   "podComplete": {
     "title": "Draft abgeschlossen",

--- a/client/src/i18n/locales/en/draft.json
+++ b/client/src/i18n/locales/en/draft.json
@@ -373,7 +373,11 @@
     "sideboardGame": "Sideboard — Game {{number}}",
     "sideboardHint": "Make sideboard changes, then submit. Your pool is available below.",
     "submitSideboard": "Submit Sideboard",
-    "preparingNext": "Preparing next game..."
+    "preparingNext": "Preparing next game...",
+    "hideOverlay": "Hide this screen",
+    "showOverlay": "Show this screen",
+    "hiddenNotice": "Sideboarding is still open for this game.",
+    "hiddenNoticePlayDraw": "A play or draw choice is still open for this game."
   },
   "podComplete": {
     "title": "Draft Complete",

--- a/client/src/i18n/locales/es/draft.json
+++ b/client/src/i18n/locales/es/draft.json
@@ -373,7 +373,11 @@
     "sideboardGame": "Banquillo — Partida {{number}}",
     "sideboardHint": "Haz cambios en el banquillo y luego envía los datos. Tu selección está disponible a continuación.",
     "submitSideboard": "Enviar banquillo",
-    "preparingNext": "Preparando la siguiente partida..."
+    "preparingNext": "Preparando la siguiente partida...",
+    "hideOverlay": "Ocultar esta pantalla",
+    "showOverlay": "Mostrar esta pantalla",
+    "hiddenNotice": "El banquillo sigue abierto para esta partida.",
+    "hiddenNoticePlayDraw": "Aún queda por elegir entre jugar o robar en esta partida."
   },
   "podComplete": {
     "title": "Draft completado",

--- a/client/src/i18n/locales/fr/draft.json
+++ b/client/src/i18n/locales/fr/draft.json
@@ -373,7 +373,11 @@
     "sideboardGame": "Réserve — Partie {{number}}",
     "sideboardHint": "Effectuez vos changements de réserve, puis soumettez. Votre pool est disponible ci-dessous.",
     "submitSideboard": "Soumettre la réserve",
-    "preparingNext": "Préparation de la partie suivante..."
+    "preparingNext": "Préparation de la partie suivante...",
+    "hideOverlay": "Masquer cet écran",
+    "showOverlay": "Afficher cet écran",
+    "hiddenNotice": "La réserve est encore ouverte pour cette partie.",
+    "hiddenNoticePlayDraw": "Un choix « jouer ou piocher » est encore en attente pour cette partie."
   },
   "podComplete": {
     "title": "Draft terminé",

--- a/client/src/i18n/locales/it/draft.json
+++ b/client/src/i18n/locales/it/draft.json
@@ -373,7 +373,11 @@
     "sideboardGame": "Sideboard — Partita {{number}}",
     "sideboardHint": "Apporta modifiche alla sideboard, poi invia. Il tuo pool è disponibile qui sotto.",
     "submitSideboard": "Invia sideboard",
-    "preparingNext": "Preparazione della prossima partita..."
+    "preparingNext": "Preparazione della prossima partita...",
+    "hideOverlay": "Nascondi questa schermata",
+    "showOverlay": "Mostra questa schermata",
+    "hiddenNotice": "La sideboard è ancora aperta per questa partita.",
+    "hiddenNoticePlayDraw": "La scelta se giocare o pescare è ancora in sospeso per questa partita."
   },
   "podComplete": {
     "title": "Draft completato",

--- a/client/src/i18n/locales/pl/draft.json
+++ b/client/src/i18n/locales/pl/draft.json
@@ -373,7 +373,11 @@
     "sideboardGame": "Karty boczne — Gra {{number}}",
     "sideboardHint": "Wprowadź zmiany w kartach bocznych, a potem zatwierdź. Twoja pula jest dostępna poniżej.",
     "submitSideboard": "Zatwierdź karty boczne",
-    "preparingNext": "Przygotowywanie następnej gry..."
+    "preparingNext": "Przygotowywanie następnej gry...",
+    "hideOverlay": "Ukryj ten ekran",
+    "showOverlay": "Pokaż ten ekran",
+    "hiddenNotice": "Wymiana kart bocznych jest wciąż otwarta w tej grze.",
+    "hiddenNoticePlayDraw": "W tej grze wciąż trzeba wybrać: zagrywasz czy dobierasz."
   },
   "podComplete": {
     "title": "Draft zakończony",

--- a/client/src/i18n/locales/pt/draft.json
+++ b/client/src/i18n/locales/pt/draft.json
@@ -373,7 +373,11 @@
     "sideboardGame": "Sideboard — Jogo {{number}}",
     "sideboardHint": "Faça as alterações no sideboard e depois envie. Seu pool está disponível abaixo.",
     "submitSideboard": "Enviar Sideboard",
-    "preparingNext": "Preparando o próximo jogo..."
+    "preparingNext": "Preparando o próximo jogo...",
+    "hideOverlay": "Ocultar esta tela",
+    "showOverlay": "Mostrar esta tela",
+    "hiddenNotice": "O sideboard ainda está aberto para este jogo.",
+    "hiddenNoticePlayDraw": "Ainda há uma escolha de jogar ou comprar pendente para este jogo."
   },
   "podComplete": {
     "title": "Draft Concluído",

--- a/client/src/pages/DraftPodPage.tsx
+++ b/client/src/pages/DraftPodPage.tsx
@@ -34,8 +34,10 @@ import { StandingsTable } from "../components/draft/StandingsTable";
 import { menuButtonClass } from "../components/menu/buttonStyles";
 import { MenuShell } from "../components/menu/MenuShell";
 import {
+  draftPodScreen,
+  intergamePromptKey,
   useMultiplayerDraftStore,
-  type MultiplayerDraftPhase,
+  type DraftPodScreen,
 } from "../stores/multiplayerDraftStore";
 import { useDraftPodStore } from "../stores/draftPodStore";
 
@@ -528,7 +530,7 @@ function RoundCompleteView() {
 
 // ── Between Games View (Bo3) ─────────────────────────────────────────
 
-function BetweenGamesView() {
+function BetweenGamesView({ onDismiss }: { onDismiss: () => void }) {
   const { t } = useTranslation("draft");
   const sideboardPrompt = useMultiplayerDraftStore((s) => s.sideboardPrompt);
   const playDrawPrompt = useMultiplayerDraftStore((s) => s.playDrawPrompt);
@@ -566,6 +568,9 @@ function BetweenGamesView() {
             {t("betweenGames.drawFirst")}
           </button>
         </div>
+        <button onClick={onDismiss} className={menuButtonClass({ tone: "neutral", size: "xs" })}>
+          {t("betweenGames.hideOverlay")}
+        </button>
       </div>
     );
   }
@@ -588,6 +593,9 @@ function BetweenGamesView() {
           </p>
         )}
         <div className="h-6 w-6 animate-spin rounded-full border-2 border-white/20 border-t-emerald-400" />
+        <button onClick={onDismiss} className={menuButtonClass({ tone: "neutral", size: "xs" })}>
+          {t("betweenGames.hideOverlay")}
+        </button>
       </div>
     );
   }
@@ -625,15 +633,25 @@ function BetweenGamesView() {
         >
           {t("betweenGames.submitSideboard")}
         </button>
+        <button onClick={onDismiss} className={menuButtonClass({ tone: "neutral", size: "xs" })}>
+          {t("betweenGames.hideOverlay")}
+        </button>
       </div>
     );
   }
 
-  // Fallback — should not reach here
+  // Fallback — unreachable BY CONSTRUCTION, and retained only for the function's
+  // totality: `draftPodScreen` answers `"betweenGames"` only when
+  // `sideboardPrompt !== null`, and the `sideboardSubmitted` branch above fires
+  // before this one. It keeps the banner and the dismiss control so it cannot
+  // become a dead end if the rule ever widens.
   return (
     <div className="mx-auto flex w-full max-w-md flex-col items-center gap-6 py-8">
       <PodErrorBanner />
       <p className="text-sm text-white/60">{t("betweenGames.preparingNext")}</p>
+        <button onClick={onDismiss} className={menuButtonClass({ tone: "neutral", size: "xs" })}>
+          {t("betweenGames.hideOverlay")}
+        </button>
     </div>
   );
 }
@@ -766,10 +784,13 @@ function PodErrorView({
 // ── Phase-based Content ───────────────────────────────────────────────
 
 function phaseContent(
-  phase: MultiplayerDraftPhase,
+  screen: DraftPodScreen,
   onLeave: () => void,
+  onDismissOverlay: () => void,
 ): React.ReactNode {
-  switch (phase) {
+  // No `default` arm: `tsc` is what makes a future `DraftPodScreen` member
+  // impossible to forget here.
+  switch (screen) {
     case "idle":
     case "connecting":
       return <PodSetup />;
@@ -780,7 +801,7 @@ function phaseContent(
     case "deckbuilding":
       return <PodDeckBuilder />;
     case "betweenGames":
-      return <BetweenGamesView />;
+      return <BetweenGamesView onDismiss={onDismissOverlay} />;
     case "pairing":
       return <PairingPhaseView />;
     case "matchInProgress":
@@ -792,14 +813,22 @@ function phaseContent(
     case "error":
     case "kicked":
     case "hostLeft":
-      return <PodErrorView phase={phase} onLeave={onLeave} />;
+      return <PodErrorView phase={screen} onLeave={onLeave} />;
   }
 }
 
 // ── Page ───────────────────────────────────────────────────────────────
 
 export function DraftPodPage() {
+  const { t } = useTranslation("draft");
   const phase = useMultiplayerDraftStore((s) => s.phase);
+  const screen = useMultiplayerDraftStore(draftPodScreen);
+  const promptKey = useMultiplayerDraftStore(intergamePromptKey);
+  // Selects the banner's copy and nothing else. A fourth primitive selector
+  // rather than a substring test on `promptKey`, whose shape is
+  // `intergamePromptKey`'s business.
+  const playDrawPending = useMultiplayerDraftStore((s) => s.playDrawPrompt !== null);
+  const [dismissedPromptKey, setDismissedPromptKey] = useState<string | null>(null);
   const leave = useMultiplayerDraftStore((s) => s.leave);
   const resetPod = useDraftPodStore((s) => s.reset);
   const resumeHostedPod = useDraftPodStore((s) => s.resumeHostedPod);
@@ -817,6 +846,16 @@ export function DraftPodPage() {
     navigate("/");
   }, [leave, resetPod, navigate]);
 
+  // A dismissal is scoped to the prompt it was made about, so it expires by
+  // construction when the next game's prompt — or the same game's play/draw
+  // decision — arrives: no effect, no cleanup, and no latch that could outlive
+  // the window it was hiding.
+  const overlayDismissed = promptKey !== null && promptKey === dismissedPromptKey;
+  const visibleScreen: DraftPodScreen = overlayDismissed ? phase : screen;
+
+  // `showBack` stays on `phase`: it is `idle`/`connecting` only — both of which
+  // `draftPodScreen` returns verbatim — and it is a session-level affordance,
+  // not a screen-level one.
   const showBack = phase === "idle" || phase === "connecting";
 
   return (
@@ -827,7 +866,30 @@ export function DraftPodPage() {
           out-of-match surface. Each phase view renders its own heading, so no
           MenuShell title is passed. */}
       <MenuShell layout="stacked">
-        <div className="flex w-full flex-col">{phaseContent(phase, handleLeave)}</div>
+        {/* Gated on `screen`, not `visibleScreen`, so it appears exactly while a
+            live overlay is being suppressed and disappears the instant either
+            conjunct releases — no separate teardown. `draftPodScreen` answers
+            `"betweenGames"` only when `phase === "matchInProgress"`, so the
+            screen underneath is provably `MatchInProgressView` and nothing else. */}
+        {screen === "betweenGames" && overlayDismissed && (
+          <div
+            role="status"
+            className="mb-3 flex items-center justify-between gap-3 rounded-xl border border-amber-400/25 bg-amber-400/10 px-4 py-2"
+          >
+            <span className="text-sm text-white/70">
+              {t(playDrawPending ? "betweenGames.hiddenNoticePlayDraw" : "betweenGames.hiddenNotice")}
+            </span>
+            <button
+              onClick={() => setDismissedPromptKey(null)}
+              className={menuButtonClass({ tone: "neutral", size: "xs" })}
+            >
+              {t("betweenGames.showOverlay")}
+            </button>
+          </div>
+        )}
+        <div className="flex w-full flex-col">
+          {phaseContent(visibleScreen, handleLeave, () => setDismissedPromptKey(promptKey))}
+        </div>
       </MenuShell>
 
       <HostControls />

--- a/client/src/pages/__tests__/DraftPodPage.betweenGames.test.tsx
+++ b/client/src/pages/__tests__/DraftPodPage.betweenGames.test.tsx
@@ -31,9 +31,22 @@ type PlayDrawPrompt = {
 
 const { draftState } = vi.hoisted(() => ({
   draftState: {
-    phase: "betweenGames",
+    // `matchInProgress` is the production phase for the whole Bo3 match, games
+    // included — the intergame screen is DERIVED by `draftPodScreen` from this
+    // plus a live `sideboardPrompt`, not stored in `phase`.
+    phase: "matchInProgress",
     error: null as string | null,
     clearError: vi.fn(),
+    // Non-null on purpose: `matchPairing` is written on `matchStart` and cleared
+    // only by `disposeMatchAdapter`/`leave`, neither of which fires inside the
+    // intergame window — so `matchPairing === null` is a state production cannot
+    // be in, and it is what the suppression destination reads.
+    matchPairing: {
+      type: "HumanHost",
+      matchId: "bo3-1",
+      opponentName: "Opp",
+    },
+    startMatch: vi.fn(),
     sideboardPrompt: {
       matchId: "bo3-1",
       gameNumber: 2,
@@ -53,7 +66,10 @@ const { draftState } = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("../../stores/multiplayerDraftStore", () => ({
+// The spread keeps the REAL `draftPodScreen` / `intergamePromptKey`, so these
+// rows pin the shipped rule rather than a re-implementation in the mock.
+vi.mock("../../stores/multiplayerDraftStore", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../stores/multiplayerDraftStore")>()),
   useMultiplayerDraftStore: (selector: (state: typeof draftState) => unknown) => selector(draftState),
 }));
 
@@ -69,6 +85,10 @@ vi.mock("../../components/menu/MenuShell", () => ({ MenuShell: ({ children }: { 
 vi.mock("../../components/draft/HostControls", () => ({ HostControls: () => null }));
 vi.mock("../../components/draft/LimitedDeckBuilder", () => ({ LimitedDeckBuilder: () => <div data-testid="limited-deck-builder" /> }));
 vi.mock("../../components/draft/ScoreBadge", () => ({ ScoreBadge: () => <div data-testid="score-badge" /> }));
+// Mocking the COMPONENT — not padding the fixture with `standings`/`currentRound`
+// — is what isolates the unit under test (the page's routing) while keeping the
+// suppression destination renderable.
+vi.mock("../../components/draft/StandingsTable", () => ({ StandingsTable: () => <div data-testid="standings-table" /> }));
 
 function renderPage() {
   return render(<MemoryRouter><DraftPodPage /></MemoryRouter>);
@@ -93,6 +113,9 @@ describe("DraftPodPage betweenGames", () => {
     draftState.error = null;
     draftState.submitSideboard.mockClear();
     draftState.clearError.mockClear();
+    draftState.choosePlayDraw.mockClear();
+    draftState.leave.mockClear();
+    draftState.startMatch.mockClear();
   });
 
   it("renders the live sideboard prompt and submits its current deck through the store authority", async () => {
@@ -144,13 +167,6 @@ describe("DraftPodPage betweenGames", () => {
       () => {},
       "Sideboard — Game 2",
     ],
-    [
-      "fallback",
-      () => {
-        draftState.sideboardPrompt = null;
-      },
-      "Preparing next game...",
-    ],
   ])("surfaces a live pod error on the %s branch", (_branch, setup, branchText) => {
     setup();
     draftState.error = ERROR_TEXT;
@@ -171,5 +187,153 @@ describe("DraftPodPage betweenGames", () => {
     // Same reach-guard, so the absence below is a real absence.
     expect(screen.getByText("Sideboard — Game 2")).toBeInTheDocument();
     expect(screen.queryByTestId("pod-error-banner")).toBeNull();
+  });
+
+  // ── The local exit ───────────────────────────────────────────────────
+  //
+  // Removing the clobber also removes an accidental escape some users relied on
+  // when the host's intergame orchestration deadlocks. These rows pin the
+  // deliberate replacement: a component-scoped render suppression keyed to the
+  // prompt's identity, plus a persistent banner offering the way back. It nulls
+  // no store field, so the sideboard can still be submitted the moment the
+  // viewer returns.
+  const PLAY_DRAW_PROMPT: PlayDrawPrompt = {
+    matchId: "bo3-1",
+    gameNumber: 2,
+    score: { p0_wins: 1, p1_wins: 0, draws: 0 },
+    timerMs: 10_000,
+  };
+
+  it.each<[string, () => void, string]>([
+    [
+      "play/draw",
+      () => {
+        draftState.playDrawPrompt = PLAY_DRAW_PROMPT;
+      },
+      "Game 2",
+    ],
+    [
+      "sideboard-submitted",
+      () => {
+        draftState.sideboardSubmitted = true;
+      },
+      "Sideboarding",
+    ],
+    ["sideboard-editing", () => {}, "Sideboard — Game 2"],
+  ])("lets the viewer set the overlay aside from the %s branch", async (_branch, setup, branchText) => {
+    setup();
+    const user = userEvent.setup();
+    renderPage();
+
+    // Reach-guard: the intended branch rendered, so a missing button below would
+    // be a real absence rather than a fixture that routed elsewhere.
+    expect(screen.getByText(branchText)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Hide this screen" }));
+
+    // REVERT-FAILING: delete this branch's dismiss `<button>`, or no-op the
+    // page's `onDismissOverlay`, and the overlay stays on screen.
+    expect(screen.queryByText(branchText)).toBeNull();
+    // Paired positive: the suppression routed somewhere real, not to a blank tree.
+    expect(screen.getByTestId("standings-table")).toBeInTheDocument();
+  });
+
+  it("dismisses without calling any store action", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    // Reach-guard for three negatives: the branch really rendered and the control
+    // really was clicked, so the three absences below are real absences and not a
+    // page that rendered nothing. Deliberately NOT asserting the suppression here
+    // — this row's job is to say whether the click was destructive, and a row
+    // asserting two independent propositions cannot say which one moved.
+    expect(screen.getByText("Sideboard — Game 2")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Hide this screen" }));
+
+    // REVERT-FAILING: wire `onDismiss` to a handler that also calls `onLeave`.
+    // `leave(true)` is the destructive path — on the host it closes every guest
+    // session while sending no `draft_host_left`.
+    expect(draftState.leave).not.toHaveBeenCalled();
+    expect(draftState.submitSideboard).not.toHaveBeenCalled();
+    expect(draftState.choosePlayDraw).not.toHaveBeenCalled();
+  });
+
+  it("offers the way back while a live overlay is suppressed", async () => {
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(screen.getByText("Sideboard — Game 2")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Hide this screen" }));
+
+    // REVERT-FAILING: delete the banner block, or only its `<button>`.
+    expect(screen.getByText("Sideboarding is still open for this game.")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Show this screen" }));
+
+    expect(screen.getByText("Sideboard — Game 2")).toBeInTheDocument();
+    expect(screen.queryByText("Sideboarding is still open for this game.")).toBeNull();
+  });
+
+  it("expires the dismissal when the next game's prompt arrives", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderPage();
+
+    expect(screen.getByText("Sideboard — Game 2")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Hide this screen" }));
+
+    // Reach-guard: the overlay really is hidden before the prompt swap.
+    expect(screen.getByTestId("standings-table")).toBeInTheDocument();
+    expect(screen.queryByText("Sideboard — Game 2")).toBeNull();
+
+    draftState.sideboardPrompt = {
+      matchId: "bo3-1",
+      gameNumber: 3,
+      score: { p0_wins: 1, p1_wins: 1, draws: 0 },
+      loserSeat: 0,
+      timerMs: 60_000,
+    };
+    rerender(<MemoryRouter><DraftPodPage /></MemoryRouter>);
+
+    // REVERT-FAILING: weaken `overlayDismissed` to `dismissedPromptKey !== null`
+    // — the dismissal becomes a latch that outlives the window it was hiding.
+    expect(screen.getByText("Sideboard — Game 3")).toBeInTheDocument();
+  });
+
+  it("does not carry the dismissal over to the same game's play/draw decision", async () => {
+    const user = userEvent.setup();
+    const { rerender } = renderPage();
+
+    expect(screen.getByText("Sideboard — Game 2")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Hide this screen" }));
+
+    expect(screen.getByTestId("standings-table")).toBeInTheDocument();
+    expect(screen.queryByText("Sideboard — Game 2")).toBeNull();
+
+    // Exactly what `bo3ChoosePlayDraw` does: set `playDrawPrompt` and leave
+    // `sideboardPrompt` alone. The pod host sends both prompts of one window with
+    // the SAME `matchId` and `gameNumber`, so only the prompt-type component of
+    // the key can tell the two decisions apart.
+    draftState.playDrawPrompt = PLAY_DRAW_PROMPT;
+    rerender(<MemoryRouter><DraftPodPage /></MemoryRouter>);
+
+    // REVERT-FAILING: drop the `#${… ? "pd" : "sb"}` component from
+    // `intergamePromptKey` and a sideboard dismissal silently suppresses a live
+    // 10-second play/draw decision that auto-chooses on expiry.
+    expect(screen.getByText("Game 2")).toBeInTheDocument();
+  });
+
+  it("names the decision the banner is hiding", async () => {
+    draftState.playDrawPrompt = PLAY_DRAW_PROMPT;
+    const user = userEvent.setup();
+    renderPage();
+
+    expect(screen.getByText("Game 2")).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: "Hide this screen" }));
+    // Reach-guard: the overlay really is suppressed.
+    expect(screen.getByTestId("standings-table")).toBeInTheDocument();
+
+    // REVERT-FAILING: make the banner's copy unconditional. The paired negative
+    // pins the SELECTION, not merely the presence of a string.
+    expect(screen.getByText("A play or draw choice is still open for this game.")).toBeInTheDocument();
+    expect(screen.queryByText("Sideboarding is still open for this game.")).toBeNull();
   });
 });

--- a/client/src/pages/__tests__/DraftPodPage.podError.test.tsx
+++ b/client/src/pages/__tests__/DraftPodPage.podError.test.tsx
@@ -10,6 +10,7 @@ const { draftState } = vi.hoisted(() => ({
   draftState: {
     phase: "pairing",
     sideboardPrompt: null,
+    playDrawPrompt: null,
     error: null as string | null,
     clearError: vi.fn(),
     currentRound: 2,

--- a/client/src/pages/__tests__/DraftPodPage.podError.test.tsx
+++ b/client/src/pages/__tests__/DraftPodPage.podError.test.tsx
@@ -9,6 +9,7 @@ import { DraftPodPage } from "../DraftPodPage";
 const { draftState } = vi.hoisted(() => ({
   draftState: {
     phase: "pairing",
+    sideboardPrompt: null,
     error: null as string | null,
     clearError: vi.fn(),
     currentRound: 2,
@@ -29,7 +30,8 @@ const { draftState } = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("../../stores/multiplayerDraftStore", () => ({
+vi.mock("../../stores/multiplayerDraftStore", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../stores/multiplayerDraftStore")>()),
   useMultiplayerDraftStore: (selector: (state: typeof draftState) => unknown) => selector(draftState),
 }));
 

--- a/client/src/pages/__tests__/DraftPodPage.standingsRound.test.tsx
+++ b/client/src/pages/__tests__/DraftPodPage.standingsRound.test.tsx
@@ -9,6 +9,7 @@ const { draftState } = vi.hoisted(() => ({
   draftState: {
     phase: "matchInProgress",
     sideboardPrompt: null,
+    playDrawPrompt: null,
     currentRound: 2,
     nextPairingRound: 3,
     // `game_wins`/`game_losses` are not decoration: `formatGwp` sums them, and

--- a/client/src/pages/__tests__/DraftPodPage.standingsRound.test.tsx
+++ b/client/src/pages/__tests__/DraftPodPage.standingsRound.test.tsx
@@ -8,6 +8,7 @@ import { DraftPodPage } from "../DraftPodPage";
 const { draftState } = vi.hoisted(() => ({
   draftState: {
     phase: "matchInProgress",
+    sideboardPrompt: null,
     currentRound: 2,
     nextPairingRound: 3,
     // `game_wins`/`game_losses` are not decoration: `formatGwp` sums them, and
@@ -31,7 +32,8 @@ const { draftState } = vi.hoisted(() => ({
   },
 }));
 
-vi.mock("../../stores/multiplayerDraftStore", () => ({
+vi.mock("../../stores/multiplayerDraftStore", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../stores/multiplayerDraftStore")>()),
   useMultiplayerDraftStore: (selector: (state: typeof draftState) => unknown) => selector(draftState),
 }));
 

--- a/client/src/stores/__tests__/multiplayerDraftStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerDraftStore.test.ts
@@ -773,9 +773,14 @@ describe("multiplayerDraftStore", () => {
       expect(useMultiplayerDraftStore.getState().sideboardPrompt).not.toBeNull();
       expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
 
-      // REVERT-FAILING (at the rule assertion): restore `"betweenGames"` to
-      // `MultiplayerDraftPhase` and write it at the host enter site, and each of
-      // the three writes below destroys the overlay again.
+      // The rule these rows pin — "a status write cannot clobber the overlay" —
+      // is enforced by `tsc`, not by a runtime line, so restoring the BASE
+      // clobber leaves S1 and S2 GREEN: the assertion is on the SCREEN, which
+      // `draftPodScreen` re-derives from the still-live `sideboardPrompt`
+      // regardless of what the clobber did to `phase`. (Measured.)
+      // REVERT-FAILING, unique to S1+S2: add `sideboardPrompt: null` to both
+      // `bo3ChoosePlayDraw` arms — that breaks the nesting invariant asserted
+      // just above, which is what licenses keying the screen on one field.
       capturedHostEventHandler!({ type: "viewUpdated", view: mockView("MatchInProgress") });
       expect(useMultiplayerDraftStore.getState().phase).toBe("matchInProgress");
       expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
@@ -791,6 +796,8 @@ describe("multiplayerDraftStore", () => {
 
     // S2 — the same statement on the guest handler, which is a physically
     // separate switch a per-site guard would have had to be remembered in twice.
+    // Shares S1's killer (see the annotation there); the guest `bo3ChoosePlayDraw`
+    // arm is the half of it this row covers.
     it("holds the overlay across every guest status write", async () => {
       await enterOverlay("guest");
 

--- a/client/src/stores/__tests__/multiplayerDraftStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerDraftStore.test.ts
@@ -13,7 +13,7 @@ import {
   type DraftPodScreen,
 } from "../multiplayerDraftStore";
 import type { DraftPlayerView } from "../../adapter/draft-adapter";
-import { DraftPauseReason } from "../../network/draftProtocol";
+import { DraftPauseReason, type DraftMatchLaunch } from "../../network/draftProtocol";
 
 // ── Mocks ──────────────────────────────────────────────────────────────
 
@@ -1001,6 +1001,77 @@ describe("multiplayerDraftStore", () => {
       expect(state.error).toBe("boom");
       expect(state.phase).toBe("matchInProgress");
       expect(draftPodScreen(state)).toBe("betweenGames");
+    });
+
+    // S9 — pins the safety property that a dismissable overlay depends on:
+    // dismissing it routes the page back to the in-match view, whose
+    // `startMatch` button is therefore reachable mid-window.
+    //
+    // Nothing at that call site guards it. The property is structural, in the
+    // store: `matchAdapter` is written to `null` in exactly two places —
+    // `disposeMatchAdapter`, whose single `set()` also nulls `matchPairing`,
+    // `sideboardPrompt` and `playDrawPrompt`, and `initialState`, where the
+    // prompts are null too. So a live prompt implies a live adapter, and
+    // `startMatch`'s `if (matchAdapter) return gameId` short-circuits ahead of
+    // every branch that could build a second adapter or send a start request.
+    // The one state with `matchPairing` live and `matchAdapter` null is the
+    // window before the adapter is first built, where no prompt exists.
+    //
+    // Two reviewers have now read this seam as a live hazard, so the
+    // short-circuit is load-bearing documentation as much as code — pin it.
+    it("starts no second match while a match adapter is live", async () => {
+      await enterOverlay("host");
+      const matchPairing: DraftMatchLaunch = {
+        type: "HumanHost",
+        matchId: "bo3-1",
+        matchRoomCode: "MATCH",
+        round: 1,
+        localSeat: 0,
+        opponentSeat: 1,
+        opponentName: "Alice",
+        matchHostPeerId: "peer-0",
+        deckPayload: {
+          player: { main_deck: [], sideboard: [], commander: [] },
+          opponent: { main_deck: [], sideboard: [], commander: [] },
+          ai_decks: [],
+        },
+        matchConfig: { match_type: "Bo3" },
+        binding: {
+          podId: "pod-1",
+          matchId: "bo3-1",
+          round: 1,
+          sessionKey: "session",
+          lease: "lease",
+          nonce: "nonce",
+          revision: 1,
+          matchAuthoritySeat: 0,
+        },
+      };
+      const adapter = { dispose() {} };
+      useMultiplayerDraftStore.setState({ matchPairing, matchAdapter: adapter });
+
+      // Reach-guards. `startMatch` returns `null` on `!matchPairing` one line
+      // above the short-circuit, so without the first of these the row could
+      // pass while measuring that early return instead; without the second it
+      // would measure adapter construction.
+      const before = useMultiplayerDraftStore.getState();
+      expect(before.matchPairing).toBe(matchPairing);
+      expect(before.matchAdapter).toBe(adapter);
+      expect(before.sideboardPrompt).not.toBeNull();
+
+      const gameId = await useMultiplayerDraftStore.getState().startMatch();
+
+      const state = useMultiplayerDraftStore.getState();
+      // REVERT-FAILING (measured): delete `if (matchAdapter) return gameId;`
+      // from `startMatch` and this is the only red row in the whole client
+      // suite — control falls into the HumanHost arm, tries to stand up a
+      // second P2P host, and `startMatch` returns `null` out of its catch
+      // instead of the id of the match already in progress.
+      expect(gameId).toBe("draft-match-bo3-1");
+      expect(state.matchAdapter).toBe(adapter);
+      expect(state.sideboardPrompt).toBe(before.sideboardPrompt);
+      expect(state.playDrawPrompt).toBeNull();
+      expect(state.error).toBeNull();
     });
   });
 });

--- a/client/src/stores/__tests__/multiplayerDraftStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerDraftStore.test.ts
@@ -7,7 +7,11 @@
 
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { useMultiplayerDraftStore } from "../multiplayerDraftStore";
+import {
+  draftPodScreen,
+  useMultiplayerDraftStore,
+  type DraftPodScreen,
+} from "../multiplayerDraftStore";
 import type { DraftPlayerView } from "../../adapter/draft-adapter";
 import { DraftPauseReason } from "../../network/draftProtocol";
 
@@ -694,6 +698,302 @@ describe("multiplayerDraftStore", () => {
       expect(state.role).toBeNull();
       expect(state.phase).toBe("idle");
       expect(state.roomCode).toBeNull();
+    });
+  });
+
+  // ── Bo3 intergame overlay lifetime ───────────────────────────────────
+  //
+  // The overlay is no longer a `MultiplayerDraftPhase` member. `draftPodScreen`
+  // derives it from two live store fields, so a status writer cannot clobber it
+  // (conjunct 1 stays true) and a prompt clear releases it (conjunct 2).
+  //
+  // Production precondition, reproduced by every fixture below: the phase is
+  // ALREADY `matchInProgress` when a prompt arrives — the host writes it in
+  // `startMatch` before the match adapter that emits the prompt exists, and the
+  // guest writes it on `matchStart`. That is why the three enter sites write no
+  // `phase` at all.
+  describe("intergame overlay lifetime", () => {
+    const SIDEBOARD_PROMPT = {
+      type: "bo3SideboardPrompt",
+      matchId: "bo3-1",
+      gameNumber: 2,
+      score: { p0_wins: 1, p1_wins: 0, draws: 0 },
+      loserSeat: 1,
+      timerMs: 60_000,
+    };
+
+    async function hostInMatch(): Promise<void> {
+      await useMultiplayerDraftStore.getState().hostDraft({
+        poolInput: { type: "Set", data: { set_pool_json: "{}" } },
+        kind: "Traditional",
+        podSize: 8,
+        hostDisplayName: "Host",
+        tournamentFormat: "Swiss",
+        podPolicy: "Competitive",
+      });
+      capturedHostEventHandler!({ type: "statusChanged", status: "matchInProgress" });
+    }
+
+    async function guestInMatch(): Promise<void> {
+      await useMultiplayerDraftStore.getState().joinDraft({
+        roomCode: "ABCDE",
+        displayName: "Alice",
+      });
+      capturedGuestEventHandler!({ type: "statusChanged", status: "matchInProgress" });
+    }
+
+    async function enterOverlay(role: "host" | "guest"): Promise<void> {
+      if (role === "host") {
+        await hostInMatch();
+        capturedHostEventHandler!(SIDEBOARD_PROMPT);
+      } else {
+        await guestInMatch();
+        capturedGuestEventHandler!(SIDEBOARD_PROMPT);
+      }
+    }
+
+    // S1 — the five status writers cannot clobber the overlay (host arms).
+    it("holds the overlay across every host status write", async () => {
+      await enterOverlay("host");
+
+      // Reach-guard: the fixture really is in the intergame window.
+      expect(useMultiplayerDraftStore.getState().sideboardPrompt).not.toBeNull();
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+
+      // The nesting that licenses keying the screen on `sideboardPrompt` alone:
+      // `bo3ChoosePlayDraw` sets `playDrawPrompt` and leaves `sideboardPrompt`
+      // set, so a `playDrawPrompt` disjunct would be unreachable.
+      capturedHostEventHandler!({
+        type: "bo3ChoosePlayDraw",
+        matchId: "bo3-1",
+        gameNumber: 2,
+        score: { p0_wins: 1, p1_wins: 0, draws: 0 },
+        timerMs: 10_000,
+      });
+      expect(useMultiplayerDraftStore.getState().sideboardPrompt).not.toBeNull();
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+
+      // REVERT-FAILING (at the rule assertion): restore `"betweenGames"` to
+      // `MultiplayerDraftPhase` and write it at the host enter site, and each of
+      // the three writes below destroys the overlay again.
+      capturedHostEventHandler!({ type: "viewUpdated", view: mockView("MatchInProgress") });
+      expect(useMultiplayerDraftStore.getState().phase).toBe("matchInProgress");
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+
+      capturedHostEventHandler!({ type: "statusChanged", status: "matchInProgress" });
+      expect(useMultiplayerDraftStore.getState().phase).toBe("matchInProgress");
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+
+      capturedHostEventHandler!({ type: "draftStarted", view: mockView("MatchInProgress") });
+      expect(useMultiplayerDraftStore.getState().phase).toBe("matchInProgress");
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+    });
+
+    // S2 — the same statement on the guest handler, which is a physically
+    // separate switch a per-site guard would have had to be remembered in twice.
+    it("holds the overlay across every guest status write", async () => {
+      await enterOverlay("guest");
+
+      expect(useMultiplayerDraftStore.getState().sideboardPrompt).not.toBeNull();
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+
+      capturedGuestEventHandler!({
+        type: "bo3ChoosePlayDraw",
+        matchId: "bo3-1",
+        gameNumber: 2,
+        score: { p0_wins: 1, p1_wins: 0, draws: 0 },
+        timerMs: 10_000,
+      });
+      expect(useMultiplayerDraftStore.getState().sideboardPrompt).not.toBeNull();
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+
+      capturedGuestEventHandler!({ type: "viewUpdated", view: mockView("MatchInProgress") });
+      expect(useMultiplayerDraftStore.getState().phase).toBe("matchInProgress");
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+
+      capturedGuestEventHandler!({ type: "statusChanged", status: "matchInProgress" });
+      expect(useMultiplayerDraftStore.getState().phase).toBe("matchInProgress");
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+    });
+
+    // S3 — the multi-authority hostile fixture: a live prompt (authority 2 says
+    // "overlay") against a session that has moved on (authority 1 says
+    // "tournament over" / "kicked" / "host left" / "abandoned"). Conjunct 1 wins,
+    // and the prompt is asserted STILL set so the release is attributable to it.
+    it.each<[string, "host" | "guest", () => void, DraftPodScreen]>([
+      [
+        "host viewUpdated(Complete)",
+        "host",
+        () => capturedHostEventHandler!({ type: "viewUpdated", view: mockView("Complete") }),
+        "complete",
+      ],
+      [
+        "host viewUpdated(Abandoned)",
+        "host",
+        () => capturedHostEventHandler!({ type: "viewUpdated", view: mockView("Abandoned") }),
+        "error",
+      ],
+      [
+        "guest kicked",
+        "guest",
+        () => capturedGuestEventHandler!({ type: "kicked", reason: "AFK" }),
+        "kicked",
+      ],
+      [
+        "guest hostLeft",
+        "guest",
+        () => capturedGuestEventHandler!({ type: "hostLeft", reason: "Host left the draft" }),
+        "hostLeft",
+      ],
+    ])("releases the overlay when the pod session moves on: %s", async (_name, role, deliver, expected) => {
+      await enterOverlay(role);
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+
+      deliver();
+
+      const state = useMultiplayerDraftStore.getState();
+      // REVERT-FAILING: delete `state.phase === "matchInProgress" &&` from
+      // `draftPodScreen` and this row answers `"betweenGames"` instead.
+      expect(state.sideboardPrompt).not.toBeNull();
+      expect(draftPodScreen(state)).toBe(expected);
+    });
+
+    // S4 — conjunct 2: the next Bo3 game releases the overlay, and does so
+    // WITHOUT a phase move (asserted), so the release is the prompt clear.
+    it.each<[string, "host" | "guest", () => void]>([
+      [
+        "host bo3GameStarted",
+        "host",
+        () => capturedHostEventHandler!({ type: "bo3GameStarted", matchId: "bo3-1", gameNumber: 2 }),
+      ],
+      [
+        "host bo3GameStart",
+        "host",
+        () =>
+          capturedHostEventHandler!({
+            type: "bo3GameStart",
+            matchId: "bo3-1",
+            gameNumber: 2,
+            firstPlayerSeat: 0,
+          }),
+      ],
+      [
+        "guest bo3GameStart",
+        "guest",
+        () =>
+          capturedGuestEventHandler!({
+            type: "bo3GameStart",
+            matchId: "bo3-1",
+            gameNumber: 2,
+            firstPlayerSeat: 0,
+          }),
+      ],
+    ])("releases the overlay when the next Bo3 game starts: %s", async (_name, role, deliver) => {
+      await enterOverlay(role);
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+
+      deliver();
+
+      const state = useMultiplayerDraftStore.getState();
+      // REVERT-FAILING: drop this arm's `sideboardPrompt: null` write and the
+      // screen stays `"betweenGames"` forever.
+      expect(state.sideboardPrompt).toBeNull();
+      expect(state.playDrawPrompt).toBeNull();
+      expect(state.phase).toBe("matchInProgress");
+      expect(draftPodScreen(state)).toBe("matchInProgress");
+    });
+
+    // S5 — the pre-existing `roundComplete` stranding is released for free.
+    // `disposeMatchAdapter` clears both prompts and writes no `phase`, so at BASE
+    // the overlay's phase survived its own data.
+    it("releases the overlay when roundComplete disposes the match adapter", async () => {
+      await enterOverlay("host");
+      useMultiplayerDraftStore.setState({ matchAdapter: { dispose() {} } });
+
+      // Reach-guard: `disposeMatchAdapter`'s clearing `set` is inside
+      // `if (state.matchAdapter)`, so without an adapter this row would measure
+      // the early return instead.
+      expect(useMultiplayerDraftStore.getState().matchAdapter).not.toBeNull();
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+
+      capturedHostEventHandler!({ type: "roundComplete" });
+
+      const state = useMultiplayerDraftStore.getState();
+      // REVERT-FAILING: drop `sideboardPrompt: null` from `disposeMatchAdapter`.
+      expect(state.sideboardPrompt).toBeNull();
+      expect(state.playDrawPrompt).toBeNull();
+      expect(state.phase).toBe("matchInProgress");
+      expect(draftPodScreen(state)).toBe("matchInProgress");
+    });
+
+    // S6 — error lifetime at the overlay ENTER. Entering is not a phase
+    // transition any more, so an unread error survives it; a real boundary still
+    // retires it.
+    it("keeps an unread error across the overlay enter and retires it at the real boundary", async () => {
+      await hostInMatch();
+      capturedHostEventHandler!({ type: "error", message: "boom" });
+
+      // Reach-guard: the error is live and the phase is settled BEFORE the enter.
+      expect(useMultiplayerDraftStore.getState().error).toBe("boom");
+      expect(useMultiplayerDraftStore.getState().phase).toBe("matchInProgress");
+
+      capturedHostEventHandler!(SIDEBOARD_PROMPT);
+
+      // (i) REVERT-FAILING: re-add `phase: "betweenGames"` at the host enter site
+      // and this clears — the enter was counted as a phase change at BASE.
+      expect(useMultiplayerDraftStore.getState().error).toBe("boom");
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+
+      // (ii) The paired positive: `clearErrorOnPhaseChange` still fires at a real
+      // phase boundary. Note `sideboardPrompt` is still set here, so this row also
+      // reddens if conjunct 1 is deleted from `draftPodScreen`.
+      capturedHostEventHandler!({ type: "viewUpdated", view: mockView("RoundComplete") });
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("roundComplete");
+      expect(useMultiplayerDraftStore.getState().error).toBeNull();
+    });
+
+    // S7 — accepted delta, pinned: the Bo3 game BOUNDARY no longer retires an
+    // unread error, because `bo3GameStarted` writes a phase equal to the current
+    // one. At BASE this was a `betweenGames → matchInProgress` transition.
+    it("keeps an unread error across the Bo3 game boundary", async () => {
+      await hostInMatch();
+      capturedHostEventHandler!({ type: "error", message: "boom" });
+      capturedHostEventHandler!(SIDEBOARD_PROMPT);
+
+      // Reach-guards.
+      expect(useMultiplayerDraftStore.getState().error).toBe("boom");
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+
+      capturedHostEventHandler!({ type: "bo3GameStarted", matchId: "bo3-1", gameNumber: 2 });
+
+      // PINNING: an equal-phase write must not retire an unread error. Drop the
+      // `next.phase === state.phase` disjunct in `clearErrorOnPhaseChange` and
+      // this goes red.
+      expect(useMultiplayerDraftStore.getState().error).toBe("boom");
+      expect(useMultiplayerDraftStore.getState().phase).toBe("matchInProgress");
+    });
+
+    // S8 — the same proposition at the entry point #7705's doc block names: a
+    // `viewUpdated` broadcast DURING the window (a seat dropping mid-window is
+    // enough). At BASE the broadcast flipped the phase off `betweenGames` and
+    // took the banner with it.
+    it("keeps an unread error across a status broadcast during the window", async () => {
+      await hostInMatch();
+      capturedHostEventHandler!(SIDEBOARD_PROMPT);
+      capturedHostEventHandler!({ type: "error", message: "boom" });
+
+      // Reach-guards.
+      expect(useMultiplayerDraftStore.getState().error).toBe("boom");
+      expect(draftPodScreen(useMultiplayerDraftStore.getState())).toBe("betweenGames");
+
+      capturedHostEventHandler!({ type: "viewUpdated", view: mockView("MatchInProgress") });
+
+      const state = useMultiplayerDraftStore.getState();
+      // PINNING, and the overlay is asserted intact so the row cannot pass by
+      // having destroyed it.
+      expect(state.error).toBe("boom");
+      expect(state.phase).toBe("matchInProgress");
+      expect(draftPodScreen(state)).toBe("betweenGames");
     });
   });
 });

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -66,6 +66,17 @@ import { FORMAT_DEFAULTS } from "./multiplayerStore";
 
 export type DraftRole = "host" | "guest";
 
+/**
+ * The pod SESSION's phase.
+ *
+ * Every member is the projection of an engine or adapter session status — the
+ * union of the ranges of `phaseForDraftViewStatus`, `hostStatusToPhase` and
+ * `guestStatusToPhase`. Nothing else belongs here.
+ *
+ * The Bo3 intergame window is deliberately NOT a member: the pod session is
+ * `MatchInProgress` for the whole match, individual games included. See
+ * {@link DraftPodScreen} and {@link draftPodScreen}.
+ */
 export type MultiplayerDraftPhase =
   | "idle"
   | "connecting"
@@ -74,12 +85,92 @@ export type MultiplayerDraftPhase =
   | "deckbuilding"
   | "pairing"
   | "matchInProgress"
-  | "betweenGames"
   | "roundComplete"
   | "complete"
   | "error"
   | "kicked"
   | "hostLeft";
+
+/**
+ * The screen the pod UI shows.
+ *
+ * Every member but `betweenGames` is a `MultiplayerDraftPhase` — the projection
+ * of the pod session's engine/adapter status. `betweenGames` is not a sibling of
+ * `matchInProgress`: the pod session is `MatchInProgress` for the whole match,
+ * individual games included, so the Bo3 intergame window is a refinement *within*
+ * that phase, not an alternative to it. Keeping it out of `MultiplayerDraftPhase`
+ * is what stops the five status writers (`statusChanged`, `viewUpdated`,
+ * `draftStarted` on the host; `statusChanged`, `viewUpdated` on the guest) from
+ * overwriting it — the clobber is no longer a rule to remember, it is a value
+ * `tsc` refuses to accept.
+ */
+export type DraftPodScreen = MultiplayerDraftPhase | "betweenGames";
+
+/**
+ * Single authority for which pod screen the store's state calls for.
+ *
+ * The overlay is called for exactly while BOTH hold:
+ *   1. the pod session is still in a match (`phase === "matchInProgress"`), and
+ *   2. an intergame prompt is live (`sideboardPrompt !== null`).
+ *
+ * Conjunct 1 is released by every writer that moves the pod session on — round
+ * boundary, tournament end, `Abandoned`, adapter error, `kicked`, `hostLeft`,
+ * `leave`, `reset`. Conjunct 2 is released by the four writers that end the
+ * window: `bo3GameStarted`, host `bo3GameStart`, guest `bo3GameStart`, and
+ * `disposeMatchAdapter`.
+ *
+ * Conjunct 2 is an inference from a proxy, and the proxy's lifecycle has a hole:
+ * nothing closes the window when the pod host's intergame orchestration
+ * deadlocks. Do NOT "fix" that by latching a flag — a latch is what the phase
+ * member was and what stranded the user. The deadlock's release is the viewer's,
+ * via `DraftPodPage`'s local overlay dismissal, which suppresses the *rendering*
+ * without touching this state.
+ *
+ * Keyed on `sideboardPrompt` alone, not `sideboardPrompt || playDrawPrompt`,
+ * because `playDrawPrompt` is strictly nested inside it: the writers that set it
+ * (`bo3ChoosePlayDraw`, host and guest) leave `sideboardPrompt` untouched, all
+ * three writers that set `sideboardPrompt` null `playDrawPrompt`, and every
+ * writer that clears one clears both. A `playDrawPrompt !== null` disjunct would
+ * be unreachable, so no test could discriminate it. The nesting is pinned
+ * directly instead — see the store tests.
+ */
+export function draftPodScreen(
+  state: Pick<MultiplayerDraftState, "phase" | "sideboardPrompt">,
+): DraftPodScreen {
+  return state.phase === "matchInProgress" && state.sideboardPrompt !== null
+    ? "betweenGames"
+    : state.phase;
+}
+
+/**
+ * Stable identity of the live intergame prompt, or `null` when none is live.
+ *
+ * Exists so a viewer's decision to hide the overlay can be scoped to the prompt
+ * it was made about. Returning a primitive keeps it usable as a zustand selector
+ * without `useShallow`.
+ *
+ * The third component is not redundant. One intergame window delivers TWO
+ * prompts, and they carry the same `matchId` and the same `gameNumber`:
+ * `transitionToPlayDraw` (`p2p-draft-host.ts`) sends the play/draw prompt with
+ * `gameNumber: state.gameNumber`, and `bo3ChoosePlayDraw` sets `playDrawPrompt`
+ * while leaving `sideboardPrompt` set. Without the discriminator a dismissal
+ * made about sideboarding would carry straight over and suppress the play/draw
+ * decision — a different decision, on a 10-second timer that auto-chooses
+ * (`startPlayDrawTimer` -> `autoChoosePlayDraw`).
+ *
+ * Note that `playDrawPrompt`'s nesting inside `sideboardPrompt` has OPPOSITE
+ * consequences at the two layers, and both are deliberate: `draftPodScreen`
+ * keys on `sideboardPrompt` alone because the nesting means there is only one
+ * screen answer, while this key must discriminate the prompt type precisely
+ * because the nesting means the two prompts otherwise share an identity.
+ */
+export function intergamePromptKey(
+  state: Pick<MultiplayerDraftState, "sideboardPrompt" | "playDrawPrompt">,
+): string | null {
+  return state.sideboardPrompt
+    ? `${state.sideboardPrompt.matchId}#${state.sideboardPrompt.gameNumber}#${state.playDrawPrompt ? "pd" : "sb"}`
+    : null;
+}
 
 export interface PairingInfo {
   round: number;
@@ -532,16 +623,22 @@ const initialState: MultiplayerDraftState = {
  * fails and succeeds while `phase` is already `matchInProgress`. Dismissal
  * (`clearError`) remains the clearing path for that case.
  *
- * Also not covered: `betweenGames` has no `DraftPlayerView.status` of its own.
- * `phaseForDraftViewStatus` never returns it; the phase is reached through the
- * bo3 sideboard-prompt paths — `handleBetweenGamesPrompt` and the two
- * `bo3SideboardPrompt` arms. So any `viewUpdated` broadcast during a Bo3
- * intergame window flips the phase to `matchInProgress` and retires the error
- * with it; a seat dropping mid-window is enough. The intergame screen is lost
- * in that interleaving either way, which is pre-existing, so this narrows where
- * the intergame errors ("Sideboard timer expired without a registered deck",
- * "Intergame timeout lacks launch authority") are visible rather than restoring
- * the old latch.
+ * The Bo3 intergame window is no longer a phase at all — it is derived by
+ * `draftPodScreen` from (`phase`, `sideboardPrompt`), and the three enter sites
+ * (`handleBetweenGamesPrompt` and the two `bo3SideboardPrompt` arms) write no
+ * `phase`. Three consequences for this rule, all intended:
+ *
+ * - Entering the window is not a transition, so an unread error survives it.
+ * - Neither is any `viewUpdated`/`statusChanged`/`draftStarted` broadcast
+ *   *during* the window: the phase is already `matchInProgress`, so a seat
+ *   dropping mid-window no longer retires the banner. That narrowing was this
+ *   block's own complaint and is now gone.
+ * - Nor is the Bo3 game *boundary*: `bo3GameStarted` and the two `bo3GameStart`
+ *   arms write `phase: "matchInProgress"` into a state whose phase is already
+ *   `matchInProgress`, so the equal-phase short-circuit below returns `next`
+ *   unchanged. An error raised earlier in the match therefore rides into game 2
+ *   until the pod phase actually moves. This is a deliberate delta, not a bug;
+ *   `clearError` remains the user's dismissal path.
  *
  * Scope: this wraps the *initializer's* setter, so it covers every write made
  * inside this module. It is not zustand middleware and does not rebind
@@ -1043,8 +1140,11 @@ export const useMultiplayerDraftStore = create<
   },
 
   handleBetweenGamesPrompt: (prompt) => {
+    // No `phase` write: entering the overlay is not a phase transition. The pod
+    // session is already `matchInProgress` here (`startMatch` writes it before
+    // the match adapter that emits this prompt exists), and the screen is
+    // derived by `draftPodScreen` from this prompt.
     set({
-      phase: "betweenGames",
       sideboardPrompt: {
         matchId: prompt.matchId,
         gameNumber: prompt.gameNumber,
@@ -1247,8 +1347,9 @@ function handleHostEvent(event: DraftPodHostEvent, set: SetFn): void {
       saveDraftPodProgress("matchInProgress");
       break;
     case "bo3SideboardPrompt":
+      // No `phase` write — see `draftPodScreen`. The pod session is already
+      // `matchInProgress` when a prompt arrives.
       set({
-        phase: "betweenGames",
         sideboardPrompt: {
           matchId: event.matchId,
           gameNumber: event.gameNumber,
@@ -1367,8 +1468,9 @@ function handleGuestEvent(event: DraftPodGuestEvent, set: SetFn): void {
     case "reconnectFailed":
       break;
     case "bo3SideboardPrompt":
+      // No `phase` write — see `draftPodScreen`. The pod session is already
+      // `matchInProgress` when a prompt arrives.
       set({
-        phase: "betweenGames",
         sideboardPrompt: {
           matchId: event.matchId,
           gameNumber: event.gameNumber,


### PR DESCRIPTION
`betweenGames` is the one `MultiplayerDraftPhase` member no status mapping produces — the pod session is `MatchInProgress` for a whole match, individual games included. Storing a client-only overlay in the field that holds the engine's session projection meant every status-derived write destroyed it: five arms across both roles, none of them wrong, each writing the true session status into the field that holds the session status.

**The visible defect:** during Bo3 sideboarding, any broadcast view took the sideboard screen away from every player in the pod. `reportMatchResult` → `broadcastViews` makes that ordinary play in a pod of four or more, with no network fault involved.

## The fix

Remove `"betweenGames"` from the union and derive the screen from `phase === "matchInProgress" && sideboardPrompt !== null`. No writer is guarded — the clobber becomes inexpressible to `tsc` rather than checked at each site, so a sixth writer cannot reintroduce it by forgetting a guard.

That clobber was also the only thing that ever released a stranded guest: the guest event handler has no teardown path, and in a Casual pod there is no sideboard timer (`timerMs = podPolicy === "Competitive" ? 60_000 : 0`), so an opponent closing their tab opens a window nothing will ever close. Removing an accidental escape hatch requires a deliberate one, so `DraftPodPage` gains component-scoped render suppression keyed to prompt identity (`matchId#gameNumber#{sb|pd}`). It self-expires when the next prompt arrives rather than latching, discriminates the sideboard prompt from the play/draw decision that reuses its match and game number, and leaves `sideboardPrompt` untouched so the sideboard stays submittable. A persistent banner offers the way back.

**Also fixed, as a consequence rather than a separate change:** `roundComplete` during the overlay nulled both prompts without writing a phase, leaving the user on a dead fallback branch with no control that exits.

## Verification

| Gate | Result |
|---|---|
| `npx vitest run` (full client suite) | 3099 passed / 0 failed |
| `pnpm run type-check` | clean (incl. protocol-version sync gate) |
| `pnpm run lint` | 0 errors; 32 pre-existing warnings, 0 in touched files |

No Rust changed. New rows are red-first at base and mutation-checked: each load-bearing line reddens the row that claims it.

## Shipped deliberately

- Three `clearErrorOnPhaseChange` lifetime deltas, all *lengthening* error visibility; each pinned. Those rows are **pinning**, not revert-failing.
- `timerRemainingMs` nulling on the pod host — cosmetic, recorded.
- `draftPodScreen` tests `!== null` while `intergamePromptKey` tests truthiness. They diverge only on `undefined`, which the non-optional declaration makes `tsc`-forbidden; defending it would be a fallback for an impossible state.

https://claude.ai/code/session_0118J576jjG9stoucpv5vvyN


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added the ability to hide the between-games overlay while continuing to view the underlying match screen.
  - Added a banner to restore the overlay and indicate whether sideboarding or play/draw selection is pending.
  - Overlay visibility now updates appropriately as matches progress and new decisions begin.
- **Localization**
  - Added translated overlay controls and status messages in English, German, Spanish, French, Italian, Polish, and Portuguese.
- **Bug Fixes**
  - Host controls now remain available and display correctly during between-games screens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->