### PR TITLE
docs(client): cite an Aura that can actually enchant a player

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1029,9 +1029,10 @@ export interface GameObject {
   damage_marked: number;
   dealt_deathtouch_damage: boolean;
   /** Mirrors engine `Option<AttachTarget>`: null when unattached, otherwise
-   *  a tagged-union pointing at either an Object host (Equipment/most Auras)
-   *  or a Player host (Curse cycle, Faith's Fetters-class). FE consumers must
-   *  inspect `.type` before reading `.data`; do not treat as a bare ObjectId. */
+   *  a tagged-union pointing at either an Object host (Equipment, Faith's
+   *  Fetters, most Auras) or a Player host (Curse cycle, Paradox Haze — the
+   *  `Enchant player` class). FE consumers must inspect `.type` before
+   *  reading `.data`; do not treat as a bare ObjectId. */
   attached_to: AttachTarget | null;
   attachments: ObjectId[];
   paired_with?: ObjectId | null;

--- a/client/src/components/board/OpponentSeatHeader.tsx
+++ b/client/src/components/board/OpponentSeatHeader.tsx
@@ -159,8 +159,8 @@ export function OpponentSeatHeader({ playerId, compact = false, onKickPlayer }: 
               tooltips fire — except while targeting, where the target button
               must win. Mirrors the avatar's pointer-events gating above. */}
           <div className={`flex min-w-0 max-w-[9rem] shrink items-center justify-end gap-0.5 overflow-hidden ${badgeScale} [&>*]:origin-right ${isValidPlayerTarget ? "pointer-events-none" : "pointer-events-auto"}`}>
-            {/* Player-attached Auras (Curse cycle, Faith's Fetters, Dictate of
-                Kruphix…). Reads the engine's `auras_attached_to_player`
+            {/* Player-attached Auras (Curse cycle, Paradox Haze — anything
+                with `Enchant player`). Reads the engine's `auras_attached_to_player`
                 projection; brings the split seat header to parity with the
                 legacy 1v1/tab HUDs, which already surface curses. */}
             <EnchantmentsBadge playerId={playerId} />

--- a/client/src/components/hud/EnchantmentsBadge.tsx
+++ b/client/src/components/hud/EnchantmentsBadge.tsx
@@ -22,7 +22,7 @@ const HOVER_CLOSE_DELAY_MS = 80;
 
 /**
  * Trailing-row HUD badge that surfaces player-attached Auras (Curse cycle,
- * Faith's Fetters, Dictate of Kruphix, etc.) without disturbing the plate
+ * Paradox Haze — anything with `Enchant player`) without disturbing the plate
  * layout. Slots into the same row as Monarch/Initiative/Counter badges
  * because, semantically, "this player is enchanted" belongs to the same
  * vocabulary of imposed-state indicators.

--- a/client/src/components/hud/OpponentHud.tsx
+++ b/client/src/components/hud/OpponentHud.tsx
@@ -628,7 +628,7 @@ function OpponentTab({
   // Hoisted above the early return (rules-of-hooks).
   const designations = usePlayerDesignations(playerId);
 
-  // Player-attached Auras (Curses, Faith's Fetters, Dictate of Kruphix…).
+  // Player-attached Auras (Curses, Paradox Haze — anything with `Enchant player`).
   // Surfaced as a corner badge so it stays visible in both density modes and
   // never competes with the inline `statusCluster` for width on 3-4 player
   // rails. Hover → portaled `AurasHoverPreview`

--- a/client/src/game/waitingForRegistry.ts
+++ b/client/src/game/waitingForRegistry.ts
@@ -113,7 +113,8 @@ export const HANDLED_WAITING_FOR_TYPES: ReadonlySet<WaitingFor["type"]> =
     "ExploreChoice",
     // CR 303.4 + CR 115.1: return-as-Aura / non-spell Aura entry host pick.
     // Resolved on the board (object hosts) or via player HUD glow (Curse /
-    // enchant-player Auras) — see TargetingOverlay + PlayerHud/OpponentHud.
+    // enchant-player Auras). Legal picks come from `getWaitingForClickTargetRefs`
+    // (viewmodel/gameStateView.ts), which every click surface reads.
     "ReturnAsAuraTarget",
     "EquipTarget",
     "CrewVehicle",


### PR DESCRIPTION
Four surfaces named **Faith's Fetters** and **Dictate of Kruphix** as examples of player-attached Auras. Neither can be one, per the engine's own parsed card data:

| Card | `Enchant` keyword in `card-data.json` | |
|---|---|---|
| Faith's Fetters | `Typed { type_filters: ["Permanent"] }` | can never attach to a player |
| Dictate of Kruphix | *(none; `subtypes: []`, keywords `["Flash"]`)* | not an Aura at all |
| Paradox Haze | `Player` | verified non-Curse member of the class |

In `adapter/types.ts` the error was inverted rather than merely wrong: Faith's Fetters was cited on the **Player** side of the `AttachTarget` union while its filter puts it on the **Object** side. It now sits with Equipment, where it belongs.

Each site now names the rule the example stood in for — "anything with `Enchant player`" — alongside Paradox Haze, so the comment stays true as the card pool grows.

Also repoints `waitingForRegistry`'s `ReturnAsAuraTarget` note at `getWaitingForClickTargetRefs` instead of listing click surfaces; that list had already gone stale by omitting `OpponentSeatHeader`.

### Validation

- **Comment-only**, mechanically verified: after stripping block/line/JSX comments, the token stream of all five files is identical to the merge base. The checker was positive-controlled (it does flag a real one-character code edit).
- `check-frontend` green locally on a build gated to have *started after* the last edit (an earlier build straddled the edits and was discarded as evidence).
- The full local suite was **not** re-run on this branch. The diff cannot affect type-check or tests, and `types.ts` here differs from my local tree only because two unshipped Commander Draft commits touch that file; the cherry-pick correctly excluded them. CI validates the rest.

https://claude.ai/code/session_01LC5MnFWa3NwmqcFTECw96K

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified descriptions of player-attached effects, including Curses, Curse cycles, and Paradox Haze.
  * Documented how valid aura targets are selected and used across click interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->