### PR TITLE
fix(engine): defer revealed search card conditions

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3600,14 +3600,16 @@ fn condition_reads_filter_population(
 /// selection result object* — the found/revealed card that a `SearchLibrary`
 /// injects as the continuation target only after the player responds
 /// (`engine_resolution_choices.rs`, `cont.chain.targets = continuation_targets`).
-/// A `TargetMatchesFilter` gate on "that card" ("the revealed card is the chosen
-/// type") cannot be evaluated until then, so it must be deferred WITH its
-/// condition rather than eagerly read against absent targets. Recurses And/Or/Not
-/// like the sibling `condition_depends_on_effect_performed` predicate. Predicate
-/// helper, not rule-implementing code — the CR annotation lives at the gate.
+/// A `TargetMatchesFilter` or `RevealedHasCardType` gate on "that card" ("the
+/// revealed card is the chosen type" / "if it's a land card") cannot be evaluated
+/// until then, so it must be deferred WITH its condition rather than eagerly read
+/// against an absent result. Recurses And/Or/Not like the sibling
+/// `condition_depends_on_effect_performed` predicate. Predicate helper, not
+/// rule-implementing code — the CR annotation lives at the gate.
 fn condition_depends_on_result_object(condition: &AbilityCondition) -> bool {
     match condition {
-        AbilityCondition::TargetMatchesFilter { .. } => true,
+        AbilityCondition::TargetMatchesFilter { .. }
+        | AbilityCondition::RevealedHasCardType { .. } => true,
         AbilityCondition::Not { condition } => condition_depends_on_result_object(condition),
         AbilityCondition::And { conditions } | AbilityCondition::Or { conditions } => {
             conditions.iter().any(condition_depends_on_result_object)

--- a/crates/engine/tests/integration/archdruids_charm_search_destination.rs
+++ b/crates/engine/tests/integration/archdruids_charm_search_destination.rs
@@ -1,0 +1,143 @@
+//! Archdruid's Charm — mode one searches either a creature or land, then uses
+//! the found card's type to choose its destination.
+//!
+//! Oracle: "Choose one —
+//! • Search your library for a creature or land card and reveal it. Put it onto
+//! the battlefield tapped if it's a land card. Otherwise, put it into your hand.
+//! Then shuffle.
+//! • Put a +1/+1 counter on target creature you control. It deals damage equal
+//! to its power to target creature you don't control.
+//! • Exile target artifact or enchantment."
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::game::zones::create_object;
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const ARCHDRUIDS_CHARM_ORACLE: &str = "Choose one —\n\
+• Search your library for a creature or land card and reveal it. Put it onto the battlefield tapped if it's a land card. Otherwise, put it into your hand. Then shuffle.\n\
+• Put a +1/+1 counter on target creature you control. It deals damage equal to its power to target creature you don't control.\n\
+• Exile target artifact or enchantment.";
+
+fn green_cost() -> ManaCost {
+    ManaCost::Cost {
+        shards: vec![
+            ManaCostShard::Green,
+            ManaCostShard::Green,
+            ManaCostShard::Green,
+        ],
+        generic: 0,
+    }
+}
+
+fn green_mana_pool() -> Vec<ManaUnit> {
+    (0..3)
+        .map(|index| ManaUnit::new(ManaType::Green, ObjectId(9_000 + index), false, vec![]))
+        .collect()
+}
+
+fn add_library_card(runner: &mut GameRunner, name: &str, card_type: CoreType) -> ObjectId {
+    let card_id = CardId(runner.state().next_object_id);
+    let id = create_object(
+        runner.state_mut(),
+        card_id,
+        P0,
+        name.to_string(),
+        Zone::Library,
+    );
+    let object = runner
+        .state_mut()
+        .objects
+        .get_mut(&id)
+        .expect("new library card must exist");
+    object.card_types.core_types.push(card_type);
+    object.base_card_types = object.card_types.clone();
+    id
+}
+
+fn setup() -> (GameRunner, ObjectId, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let charm = scenario
+        .add_spell_to_hand_from_oracle(P0, "Archdruid's Charm", true, ARCHDRUIDS_CHARM_ORACLE)
+        .with_mana_cost(green_cost())
+        .id();
+    scenario.with_mana_pool(P0, green_mana_pool());
+
+    let mut runner = scenario.build();
+    let creature = add_library_card(&mut runner, "Llanowar Elves", CoreType::Creature);
+    let land = add_library_card(&mut runner, "Forest", CoreType::Land);
+    (runner, charm, creature, land)
+}
+
+fn resolve_mode_one_to_search(
+    runner: &mut GameRunner,
+    charm: ObjectId,
+    creature: ObjectId,
+    land: ObjectId,
+) {
+    let outcome = runner.cast(charm).modes(&[0]).resolve();
+    let WaitingFor::SearchChoice { cards, .. } = outcome.final_waiting_for() else {
+        panic!(
+            "Archdruid's Charm mode one must reach SearchChoice, got {:?}",
+            outcome.final_waiting_for()
+        );
+    };
+    assert!(
+        cards.contains(&creature) && cards.contains(&land),
+        "the creature-or-land search must offer both library cards, got {cards:?}"
+    );
+    assert!(
+        runner.state().players[P0.0 as usize]
+            .mana_pool
+            .mana
+            .is_empty(),
+        "casting Archdruid's Charm must spend its exact {{G}}{{G}}{{G}} cost"
+    );
+}
+
+#[test]
+fn mode_one_puts_the_selected_land_onto_the_battlefield_tapped() {
+    let (mut runner, charm, creature, land) = setup();
+    resolve_mode_one_to_search(&mut runner, charm, creature, land);
+
+    // CR 701.23a + CR 608.2c: select the search result, then resolve the
+    // conditional continuation against that selected card.
+    runner
+        .act(GameAction::SelectCards { cards: vec![land] })
+        .expect("select the land from Archdruid's Charm's search");
+
+    let state = runner.state();
+    assert_eq!(state.objects[&land].zone, Zone::Battlefield);
+    assert!(
+        state.objects[&land].tapped,
+        "the selected land enters tapped"
+    );
+    assert_eq!(state.objects[&creature].zone, Zone::Library);
+    assert!(matches!(state.waiting_for, WaitingFor::Priority { player } if player == P0));
+}
+
+#[test]
+fn mode_one_puts_the_selected_creature_into_hand_not_the_battlefield() {
+    let (mut runner, charm, creature, land) = setup();
+    resolve_mode_one_to_search(&mut runner, charm, creature, land);
+
+    // CR 701.23a + CR 608.2c: select the search result, then resolve the
+    // conditional continuation against that selected card.
+    runner
+        .act(GameAction::SelectCards {
+            cards: vec![creature],
+        })
+        .expect("select the creature from Archdruid's Charm's search");
+
+    let state = runner.state();
+    assert_eq!(state.objects[&creature].zone, Zone::Hand);
+    assert_ne!(state.objects[&creature].zone, Zone::Battlefield);
+    assert_eq!(state.objects[&land].zone, Zone::Library);
+    assert!(matches!(state.waiting_for, WaitingFor::Priority { player } if player == P0));
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -32,6 +32,7 @@ mod another_round_repeat;
 mod anya_merciless_angel_5920;
 mod april_oneil_card_types_among_spells_cast;
 mod arashin_sovereign_self_tuck;
+mod archdruids_charm_search_destination;
 mod archmage_ascension_gated_draw_replacement;
 mod archnemesis_you_attack_enchanted_player;
 mod arcum_weathervane_supertype_removal;


### PR DESCRIPTION
Pipeline-reviewed head: c63ecdb4eb1eee2e77a7517964fb7f0db2a838e3
Current branch head: b677f919af14e7847cda30c64323afdc91d079ce
Pipeline status: historical — cherry-picked onto origin/main for merge-queue shipping
Current-head review: none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved card-search behavior so revealed card types are correctly evaluated before applying search outcomes.
  - Archdruid’s Charm now correctly supports searching for creatures and lands, with selected cards placed in the appropriate destinations and lands entering tapped.

- **Bug Fixes**
  - Fixed deferred condition checks during card-reveal searches to ensure valid results are handled correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->