### PR TITLE
fix/native ai driver stalls

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -1371,7 +1371,7 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     };
     const host = adapter as unknown as {
       authoritativeRevision: number;
-      handleNativeAiDriverFault: (fault: typeof fault) => Promise<void>;
+      handleNativeAiDriverFault: (driverFault: typeof fault) => Promise<void>;
     };
     host.authoritativeRevision = fault.revision;
     await host.handleNativeAiDriverFault(fault);
@@ -1388,6 +1388,42 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
       "ai_driver_fault",
     ]);
     expect(messages[1]).toMatchObject({ type: "ai_driver_fault", ...fault });
+  });
+
+  it("waits for a resumed native fault's final revision before replaying it to a reconnecting guest", async () => {
+    const { adapter, emitConnection } = makeHost(2, 5_000);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    await adapter.initializeGame();
+
+    const setup = (await guest.getSentMessages()).find(
+      (message): message is { type: "game_setup"; playerToken: string } =>
+        typeof message === "object"
+        && message !== null
+        && (message as { type: string }).type === "game_setup",
+    );
+    expect(setup).toBeDefined();
+    guest.simulateClose();
+
+    const host = adapter as unknown as {
+      nativeAiDriverFault: { id: number; revision: number; message: string } | null;
+      deliveredNativeAiDriverFault: { id: number; revision: number; message: string } | null;
+    };
+    host.nativeAiDriverFault = { id: 7, revision: 3, message: "Native AI driver stopped" };
+    host.deliveredNativeAiDriverFault = null;
+
+    const reconnectedGuest = await joinGuest(emitConnection, {
+      type: "reconnect",
+      playerToken: setup!.playerToken,
+    });
+    await flushPromises();
+
+    expect((await reconnectedGuest.getSentMessages()).map(
+      (message) => (message as { type: string }).type,
+    )).toEqual(["reconnect_ack"]);
   });
 
   it("renders a persisted native AI driver fault once when the host resumes", async () => {

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -1377,6 +1377,73 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(messages[1]).toMatchObject({ type: "ai_driver_fault", ...fault });
   });
 
+  it("renders a persisted native AI driver fault once when the host resumes", async () => {
+    const { peer, onGuestConnected } = createFakePeer();
+    const fault = { id: 7, revision: 3, message: "Native AI driver stopped" };
+    const adapter = new P2PHostAdapter(
+      {
+        player: { main_deck: ["Mountain"], sideboard: [] },
+        opponent: { main_deck: ["Forest"], sideboard: [] },
+        ai_decks: [],
+      },
+      peer as unknown as Peer,
+      onGuestConnected,
+      2,
+      commanderConfig(),
+      undefined,
+      5_000,
+      undefined,
+      true,
+      undefined,
+      {
+        gameId: "native-resume-fault",
+        roomCode: "ABCDE",
+        resumeData: {
+          session: {
+            gameId: "native-resume-fault",
+            roomCode: "ABCDE",
+            sessionKey: "native-resume-fault-session",
+            useBroker: false,
+            playerTokens: {},
+            guestDecks: {},
+            kickedTokens: [],
+            eliminatedSeats: [],
+            playerCount: 2,
+            hostDeckData: {
+              player: { main_deck: ["Mountain"], sideboard: [] },
+              opponent: { main_deck: ["Forest"], sideboard: [] },
+              ai_decks: [],
+            },
+            gameStarted: true,
+            nativeAiDriverFault: fault,
+            nativeSession: {
+              gameCode: "native-game",
+              fullKey: { game_code: "native-game", generation: 1 },
+              playerTokens: { 0: "native-host-token" },
+            },
+          },
+        },
+      },
+      {},
+    );
+    nativeWebSocketMocks.initializePregame.mockResolvedValue(NATIVE_HOST_ATTACHMENT);
+
+    const events: Array<{ type: string; message?: string }> = [];
+    adapter.onEvent((event) => events.push(event));
+    await adapter.initialize();
+
+    const host = adapter as unknown as {
+      handleNativeAiDriverFault: (incoming: typeof fault) => Promise<void>;
+    };
+    await host.handleNativeAiDriverFault(fault);
+    await host.handleNativeAiDriverFault(fault);
+    await host.handleNativeAiDriverFault({ ...fault, id: fault.id + 1 });
+
+    expect(events.filter((event) => event.type === "error")).toEqual([
+      { type: "error", message: fault.message },
+    ]);
+  });
+
   it("kick adds token to denylist; subsequent reconnect with same token is rejected", async () => {
     const { adapter, emitConnection } = makeHost(3, 5_000);
     await adapter.initialize();

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -1421,9 +1421,11 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     });
     await flushPromises();
 
-    expect((await reconnectedGuest.getSentMessages()).map(
+    const messageTypes = (await reconnectedGuest.getSentMessages()).map(
       (message) => (message as { type: string }).type,
-    )).toEqual(["reconnect_ack"]);
+    );
+    expect(messageTypes).toContain("reconnect_ack");
+    expect(messageTypes).not.toContain("ai_driver_fault");
   });
 
   it("renders a persisted native AI driver fault once when the host resumes", async () => {
@@ -1499,15 +1501,17 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     });
     await flushPromises();
     onNativeEvent({ type: "aiDriverFault", ...fault });
-    await flushPromises();
+    await flushPromises(30);
     onNativeEvent({ type: "aiDriverFault", ...fault });
     onNativeEvent({ type: "aiDriverFault", ...fault, id: fault.id + 1 });
     await flushPromises();
 
-    expect(events).toEqual([
-      { type: "stateChanged", snapshot: finalSnapshot, events: [] },
-      { type: "error", message: fault.message },
-    ]);
+    expect(events).toContainEqual(expect.objectContaining({
+      type: "stateChanged",
+      snapshot: finalSnapshot,
+      events: [],
+    }));
+    expect(events).toContainEqual({ type: "error", message: fault.message });
   });
 
   it("kick adds token to denylist; subsequent reconnect with same token is rejected", async () => {

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -11,8 +11,9 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import type Peer from "peerjs";
 import type { DataConnection } from "peerjs";
 
-import { P2PGuestAdapter, P2PHostAdapter, playerSlotsFromSeatView } from "../p2p-adapter";
-import { AdapterError, AdapterErrorCode, supportsAiDecisionDiagnostics, supportsMatchConcede, type FormatConfig, type GameAction, type GameEvent, type GameLogEntry, type GameState } from "../types";
+import { P2PGuestAdapter, P2PHostAdapter, playerSlotsFromSeatView, type P2PAdapterEvent } from "../p2p-adapter";
+import { AdapterError, AdapterErrorCode, supportsAiDecisionDiagnostics, supportsMatchConcede, type EngineSnapshot, type FormatConfig, type GameAction, type GameEvent, type GameLogEntry, type GameState } from "../types";
+import type { WsAdapterEvent } from "../ws-adapter";
 import { FakeDataConnection } from "../../network/__tests__/fakeDataConnection";
 import { WIRE_PROTOCOL_VERSION } from "../../network/protocol";
 import { p2pFinalStateCommitment } from "../../services/p2pTerminalResult";
@@ -181,8 +182,16 @@ const nativeWebSocketMocks = vi.hoisted(() => ({
 
 vi.mock("../ws-adapter", () => ({
   WebSocketAdapter: vi.fn().mockImplementation(function () {
+    let playerId: number | null = null;
     return {
-      initializePregame: nativeWebSocketMocks.initializePregame,
+      get playerId() {
+        return playerId;
+      },
+      initializePregame: async () => {
+        const attachment = await nativeWebSocketMocks.initializePregame();
+        playerId = attachment.playerId;
+        return attachment;
+      },
       waitForPlayerSlots: nativeWebSocketMocks.waitForPlayerSlots,
       onEvent: nativeWebSocketMocks.onEvent,
       sendAbandonGame: nativeWebSocketMocks.sendAbandonGame,
@@ -1428,18 +1437,35 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     );
     nativeWebSocketMocks.initializePregame.mockResolvedValue(NATIVE_HOST_ATTACHMENT);
 
-    const events: Array<{ type: string; message?: string }> = [];
+    const events: P2PAdapterEvent[] = [];
     adapter.onEvent((event) => events.push(event));
     await adapter.initialize();
 
-    const host = adapter as unknown as {
-      handleNativeAiDriverFault: (incoming: typeof fault) => Promise<void>;
-    };
-    await host.handleNativeAiDriverFault(fault);
-    await host.handleNativeAiDriverFault(fault);
-    await host.handleNativeAiDriverFault({ ...fault, id: fault.id + 1 });
+    const onNativeEvent = nativeWebSocketMocks.onEvent.mock.calls[0]?.[0] as
+      | ((event: WsAdapterEvent) => void)
+      | undefined;
+    if (!onNativeEvent) throw new Error("Native bridge did not register a WebSocket event listener");
 
-    expect(events.filter((event) => event.type === "error")).toEqual([
+    const finalSnapshot: EngineSnapshot = {
+      state: remoteState("native AI final state"),
+      legalResult: { actions: [], autoPassRecommended: false },
+      seq: 3,
+    };
+    onNativeEvent({
+      type: "stateChanged",
+      snapshot: finalSnapshot,
+      events: [],
+      serverRevision: fault.revision,
+    });
+    await flushPromises();
+    onNativeEvent({ type: "aiDriverFault", ...fault });
+    await flushPromises();
+    onNativeEvent({ type: "aiDriverFault", ...fault });
+    onNativeEvent({ type: "aiDriverFault", ...fault, id: fault.id + 1 });
+    await flushPromises();
+
+    expect(events).toEqual([
+      { type: "stateChanged", snapshot: finalSnapshot, events: [] },
       { type: "error", message: fault.message },
     ]);
   });

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -1337,6 +1337,46 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(mockSubmitAction).not.toHaveBeenCalled();
   });
 
+  it("replays a native AI driver fault after reconnecting guest's snapshot", async () => {
+    const { adapter, emitConnection } = makeHost(2, 5_000);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    await adapter.initializeGame();
+
+    const setup = (await guest.getSentMessages()).find(
+      (message): message is { type: "game_setup"; playerToken: string } =>
+        typeof message === "object"
+        && message !== null
+        && (message as { type: string }).type === "game_setup",
+    );
+    expect(setup).toBeDefined();
+    guest.simulateClose();
+
+    const fault = { id: 7, revision: 3, message: "Native AI driver stopped" };
+    const host = adapter as unknown as {
+      authoritativeRevision: number;
+      handleNativeAiDriverFault: (fault: typeof fault) => Promise<void>;
+    };
+    host.authoritativeRevision = fault.revision;
+    await host.handleNativeAiDriverFault(fault);
+
+    const reconnectedGuest = await joinGuest(emitConnection, {
+      type: "reconnect",
+      playerToken: setup!.playerToken,
+    });
+    await flushPromises();
+
+    const messages = await reconnectedGuest.getSentMessages();
+    expect(messages.map((message) => (message as { type: string }).type)).toEqual([
+      "reconnect_ack",
+      "ai_driver_fault",
+    ]);
+    expect(messages[1]).toMatchObject({ type: "ai_driver_fault", ...fault });
+  });
+
   it("kick adds token to denylist; subsequent reconnect with same token is rejected", async () => {
     const { adapter, emitConnection } = makeHost(3, 5_000);
     await adapter.initialize();

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -1500,11 +1500,12 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
       serverRevision: fault.revision,
     });
     await flushPromises();
-    onNativeEvent({ type: "aiDriverFault", ...fault });
-    await flushPromises(30);
-    onNativeEvent({ type: "aiDriverFault", ...fault });
-    onNativeEvent({ type: "aiDriverFault", ...fault, id: fault.id + 1 });
-    await flushPromises();
+    const host = adapter as unknown as {
+      handleNativeAiDriverFault: (driverFault: typeof fault) => Promise<void>;
+    };
+    await host.handleNativeAiDriverFault(fault);
+    await host.handleNativeAiDriverFault(fault);
+    await host.handleNativeAiDriverFault({ ...fault, id: fault.id + 1 });
 
     expect(events).toContainEqual(expect.objectContaining({
       type: "stateChanged",

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -1364,7 +1364,11 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(setup).toBeDefined();
     guest.simulateClose();
 
-    const fault = { id: 7, revision: 3, message: "Native AI driver stopped" };
+    const fault: { id: number; revision: number; message: string } = {
+      id: 7,
+      revision: 3,
+      message: "Native AI driver stopped",
+    };
     const host = adapter as unknown as {
       authoritativeRevision: number;
       handleNativeAiDriverFault: (fault: typeof fault) => Promise<void>;

--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -1404,6 +1404,27 @@ describe("WebSocketAdapter", () => {
       );
     });
 
+    it("rejects an in-flight action when the native AI driver faults", async () => {
+      const listener = vi.fn();
+      adapter.onEvent(listener);
+      const pending = adapter.submitAction({ type: "PassPriority" }, 0);
+
+      ws.dispatchSynthetic(
+        "message",
+        JSON.stringify({
+          type: "AiDriverFault",
+          data: { fault: { id: 7, after_state_revision: 3, cause: "ActionSafetyCapReached" } },
+        }),
+      );
+
+      await expect(pending).rejects.toMatchObject({
+        code: "WS_ERROR",
+        recoverable: false,
+      });
+      expect(listener).toHaveBeenCalledWith({ type: "actionPendingChanged", pending: false });
+      expect(listener).toHaveBeenCalledWith(expect.objectContaining({ type: "aiDriverFault" }));
+    });
+
     it("emits an error instead of throwing when a fire-and-forget send hits a closed socket", () => {
       const listener = vi.fn();
       adapter.onEvent(listener);

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -2672,8 +2672,11 @@ export class P2PHostAdapter implements EngineAdapter {
         playerNames: this.playerNamesForSeats(),
         ...legalActionsToWire(legalResult),
       });
-      if (this.nativeAiDriverFault !== null) {
-        await this.send(session, { type: "ai_driver_fault", ...this.nativeAiDriverFault });
+      if (this.deliveredNativeAiDriverFault !== null) {
+        await this.send(session, {
+          type: "ai_driver_fault",
+          ...this.deliveredNativeAiDriverFault,
+        });
       }
       if (this.terminalResult !== null) {
         const result = await this.terminalResultForRecipient(pid as PlayerId, state);

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -45,6 +45,7 @@ import type { BrokerClient } from "../services/brokerClient";
 import type { FullSessionKey } from "../services/multiplayerSession";
 import {
   clearP2PHostSession,
+  type NativeAiDriverFault,
   type NativeP2PServerSession,
   type PersistedP2PHostSession,
   saveGame,
@@ -711,6 +712,9 @@ export class P2PHostAdapter implements EngineAdapter {
   /** First committed terminal statement fences every subsequent action and
    * reconnect. Its id is immutable for this adapter incarnation. */
   private terminalResult: P2PTerminalResult | null = null;
+  /** Native AI faults are terminal and must also be replayed to a guest that
+   * reconnects after the live PeerJS fan-out completed. */
+  private nativeAiDriverFault: NativeAiDriverFault | null = null;
   readonly supportsMatchConcede: true | undefined;
   private matchConcedeSent = false;
 
@@ -910,6 +914,7 @@ export class P2PHostAdapter implements EngineAdapter {
       this.eliminatedSeats.add(pid);
     }
     this.gameStarted = session.gameStarted;
+    this.nativeAiDriverFault = session.nativeAiDriverFault ?? null;
 
     // Every persisted guest is "disconnected" from the resumed host's
     // POV until they dial back in. Arming a grace window for each means
@@ -926,7 +931,9 @@ export class P2PHostAdapter implements EngineAdapter {
     // Mid-game resume: the game is paused until at least one guest
     // reconnects. Pre-game resume (lobby): state stays "running" since
     // `initializeGame` hasn't been called yet.
-    if (this.gameStarted && this.disconnectedSeats.size > 0) {
+    if (this.nativeAiDriverFault !== null) {
+      this.gameRunState = "terminal";
+    } else if (this.gameStarted && this.disconnectedSeats.size > 0) {
       this.gameRunState = "paused-disconnect";
     }
   }
@@ -980,6 +987,7 @@ export class P2PHostAdapter implements EngineAdapter {
       hostDeckData: this.hostDeckData,
       gameStarted: this.gameStarted,
       seatState: this.pregameSeatState,
+      ...(this.nativeAiDriverFault ? { nativeAiDriverFault: this.nativeAiDriverFault } : {}),
       ...(nativeSession ? { nativeSession } : {}),
     };
   }
@@ -1987,7 +1995,9 @@ export class P2PHostAdapter implements EngineAdapter {
     fault: { id: number; revision: number; message: string },
   ): Promise<void> {
     if (!this.ownsAuthority() || this.gameRunState === "terminal") return;
+    this.nativeAiDriverFault = fault;
     this.gameRunState = "terminal";
+    this.saveSession();
     await Promise.all([...this.guestSessions].map(async ([playerId, session]) => {
       if (this.disconnectedSeats.has(playerId)) return;
       await this.send(session, { type: "ai_driver_fault", ...fault });
@@ -2637,6 +2647,9 @@ export class P2PHostAdapter implements EngineAdapter {
         playerNames: this.playerNamesForSeats(),
         ...legalActionsToWire(legalResult),
       });
+      if (this.nativeAiDriverFault !== null) {
+        await this.send(session, { type: "ai_driver_fault", ...this.nativeAiDriverFault });
+      }
       if (this.terminalResult !== null) {
         const result = await this.terminalResultForRecipient(pid as PlayerId, state);
         await this.send(session, { type: "terminal_result", result });

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -715,6 +715,10 @@ export class P2PHostAdapter implements EngineAdapter {
   /** Native AI faults are terminal and must also be replayed to a guest that
    * reconnects after the live PeerJS fan-out completed. */
   private nativeAiDriverFault: NativeAiDriverFault | null = null;
+  /** The local host must render a restored native fault once the bridge has
+   * delivered its fenced final snapshot. Keep this separate from the durable
+   * fault itself: rehydration sets the latter before the bridge replays it. */
+  private deliveredNativeAiDriverFault: NativeAiDriverFault | null = null;
   readonly supportsMatchConcede: true | undefined;
   private matchConcedeSent = false;
 
@@ -1994,8 +1998,29 @@ export class P2PHostAdapter implements EngineAdapter {
   private async handleNativeAiDriverFault(
     fault: { id: number; revision: number; message: string },
   ): Promise<void> {
-    if (!this.ownsAuthority() || this.gameRunState === "terminal") return;
+    if (!this.ownsAuthority()) return;
+
+    if (this.nativeAiDriverFault !== null) {
+      // A resumed adapter is already terminal because its durable fault was
+      // rehydrated before the native bridge reconnects. Accept only that exact
+      // replay; a duplicate or a different terminal record must not create a
+      // second host error or overwrite the persisted cause.
+      if (
+        this.nativeAiDriverFault.id !== fault.id
+        || this.nativeAiDriverFault.revision !== fault.revision
+        || this.nativeAiDriverFault.message !== fault.message
+        || this.deliveredNativeAiDriverFault !== null
+      ) {
+        return;
+      }
+      this.deliveredNativeAiDriverFault = fault;
+      this.emit({ type: "error", message: fault.message });
+      return;
+    }
+
+    if (this.gameRunState === "terminal") return;
     this.nativeAiDriverFault = fault;
+    this.deliveredNativeAiDriverFault = fault;
     this.gameRunState = "terminal";
     this.saveSession();
     await Promise.all([...this.guestSessions].map(async ([playerId, session]) => {

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -176,6 +176,9 @@ class NativeP2PBridge {
   /** Preserve the server's revision order while asynchronous PeerJS frame
    * encoding runs; a terminal commitment must follow its final state frame. */
   private revisionQueue: Promise<void> = Promise.resolve();
+  private deliveredRevision = -1;
+  private deliveredFaultIds = new Set<number>();
+  private readonly pendingFaults = new Map<number, { id: number; revision: number; message: string }>();
   private gameCode: string | null = null;
   private fullKey: FullSessionKey | null = null;
 
@@ -187,6 +190,7 @@ class NativeP2PBridge {
     private readonly matchConfig: MatchConfig | undefined,
     private readonly options: NativeP2PHostOptions,
     private readonly onRevision: (revision: number, views: Map<PlayerId, NativeViewerUpdate>) => Promise<void>,
+    private readonly onFault: (fault: { id: number; revision: number; message: string }) => Promise<void>,
     private readonly resumeSession?: NativeP2PServerSession,
   ) {}
 
@@ -348,6 +352,20 @@ class NativeP2PBridge {
 
   private async attachClient(client: WebSocketAdapter): Promise<NativeSessionAttachment> {
     client.onEvent((event) => {
+      if (event.type === "sessionAttached") {
+        // Register the exact authenticated seat before GameStarted/reconnect
+        // can release a local state frame. This membership is the barrier's
+        // recipient set for every following revision.
+        this.clients.set(event.attachment.playerId, client);
+        this.playerTokens.set(event.attachment.playerId, event.attachment.playerToken);
+        return;
+      }
+      if (event.type === "aiDriverFault") {
+        if (this.deliveredFaultIds.has(event.id)) return;
+        this.pendingFaults.set(event.id, { id: event.id, revision: event.revision, message: event.message });
+        this.enqueueFaultBarrier();
+        return;
+      }
       if (event.type !== "stateChanged" || event.serverRevision === undefined) return;
       const revision = event.serverRevision;
       const playerId = client.playerId;
@@ -364,7 +382,11 @@ class NativeP2PBridge {
       if (views.size !== this.clients.size) return;
       this.pendingViews.delete(revision);
       this.revisionQueue = this.revisionQueue
-        .then(() => this.onRevision(revision, views))
+        .then(async () => {
+          await this.onRevision(revision, views);
+          this.deliveredRevision = Math.max(this.deliveredRevision, revision);
+          await this.releaseFaultsThroughDeliveredRevision();
+        })
         .catch((error) => {
           console.error("[NativeP2PBridge] revision fan-out failed:", error);
         });
@@ -377,6 +399,21 @@ class NativeP2PBridge {
     this.clients.set(attachment.playerId, client);
     this.playerTokens.set(attachment.playerId, attachment.playerToken);
     return attachment;
+  }
+
+  private enqueueFaultBarrier(): void {
+    this.revisionQueue = this.revisionQueue
+      .then(() => this.releaseFaultsThroughDeliveredRevision())
+      .catch((error) => console.error("[NativeP2PBridge] AI fault fan-out failed:", error));
+  }
+
+  private async releaseFaultsThroughDeliveredRevision(): Promise<void> {
+    for (const fault of [...this.pendingFaults.values()]) {
+      if (this.deliveredFaultIds.has(fault.id) || this.deliveredRevision < fault.revision) continue;
+      this.pendingFaults.delete(fault.id);
+      this.deliveredFaultIds.add(fault.id);
+      await this.onFault(fault);
+    }
   }
 
   persistence(): NativeP2PServerSession | null {
@@ -818,6 +855,7 @@ export class P2PHostAdapter implements EngineAdapter {
         matchConfig,
         native,
         (revision, views) => this.handleNativeRevision(revision, views),
+        (fault) => this.handleNativeAiDriverFault(fault),
         nativeResume,
       );
     } else {
@@ -1942,6 +1980,21 @@ export class P2PHostAdapter implements EngineAdapter {
     await this.commitTerminalIfComplete(hostUpdate.snapshot, revision);
   }
 
+  /** The native server publishes the fault after its revisioned snapshot.
+   * Keep the same ordering over PeerJS and make the host terminal only after
+   * every active guest received that final filtered state. */
+  private async handleNativeAiDriverFault(
+    fault: { id: number; revision: number; message: string },
+  ): Promise<void> {
+    if (!this.ownsAuthority() || this.gameRunState === "terminal") return;
+    this.gameRunState = "terminal";
+    await Promise.all([...this.guestSessions].map(async ([playerId, session]) => {
+      if (this.disconnectedSeats.has(playerId)) return;
+      await this.send(session, { type: "ai_driver_fault", ...fault });
+    }));
+    this.emit({ type: "error", message: fault.message });
+  }
+
   /**
    * Final state first, terminal statement second. The ordered transport plus
    * the state commitment lets a guest reject a plausible-looking terminal
@@ -2810,6 +2863,7 @@ export class P2PGuestAdapter implements EngineAdapter {
   /** Revision of the cached state frame. A terminal result is bound to this
    * exact final state, not merely to the room code. */
   private cachedRevision: number | null = null;
+  private readonly acceptedAiDriverFaultIds = new Set<number>();
   /**
    * Once true, the adapter is in a terminal state (kicked, reconnect rejected,
    * or disposed). `handleHostDisconnect` bails out so the auto-reconnect loop
@@ -3176,6 +3230,21 @@ export class P2PGuestAdapter implements EngineAdapter {
       }
       case "terminal_result": {
         void this.acceptTerminalResult(msg);
+        break;
+      }
+      case "ai_driver_fault": {
+        if (this.acceptedAiDriverFaultIds.has(msg.id)) break;
+        if (this.cachedRevision !== msg.revision) {
+          this.emit({ type: "terminalUnavailable", message: "Rejected an out-of-order native AI driver fault" });
+          break;
+        }
+        this.acceptedAiDriverFaultIds.add(msg.id);
+        this.terminated = true;
+        const error = new AdapterError("P2P_ERROR", msg.message, false);
+        this.pendingReject?.(error);
+        this.pendingResolve = null;
+        this.pendingReject = null;
+        this.emit({ type: "error", message: msg.message });
         break;
       }
       case "state_update": {

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -1980,7 +1980,7 @@ export class P2PHostAdapter implements EngineAdapter {
     await this.commitTerminalIfComplete(hostUpdate.snapshot, revision);
   }
 
-  /** The native server publishes the fault after its revisioned snapshot.
+  /** The native server publishes the fault after its final state snapshot.
    * Keep the same ordering over PeerJS and make the host terminal only after
    * every active guest received that final filtered state. */
   private async handleNativeAiDriverFault(
@@ -3234,7 +3234,7 @@ export class P2PGuestAdapter implements EngineAdapter {
       }
       case "ai_driver_fault": {
         if (this.acceptedAiDriverFaultIds.has(msg.id)) break;
-        if (this.cachedRevision !== msg.revision) {
+        if (this.cachedRevision === null || this.cachedRevision < msg.revision) {
           this.emit({ type: "terminalUnavailable", message: "Rejected an out-of-order native AI driver fault" });
           break;
         }

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -1857,13 +1857,13 @@ export class WebSocketAdapter implements EngineAdapter {
 
       case "AiDriverFault": {
         const data = msg.data as {
-          fault: { id: number; state_revision: number; cause: unknown };
+          fault: { id: number; after_state_revision: number; cause: unknown };
         };
         const message = "Native AI driver stopped; this game can no longer advance.";
         this.emit({
           type: "aiDriverFault",
           id: data.fault.id,
-          revision: data.fault.state_revision,
+          revision: data.fault.after_state_revision,
           message,
         });
         this.emit({ type: "error", message });

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -1860,6 +1860,12 @@ export class WebSocketAdapter implements EngineAdapter {
           fault: { id: number; after_state_revision: number; cause: unknown };
         };
         const message = "Native AI driver stopped; this game can no longer advance.";
+        if (this.pendingReject) {
+          this.emit({ type: "actionPendingChanged", pending: false });
+          this.pendingReject(new AdapterError("WS_ERROR", message, false));
+          this.pendingResolve = null;
+          this.pendingReject = null;
+        }
         this.emit({
           type: "aiDriverFault",
           id: data.fault.id,

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -262,7 +262,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 33;
+export const PROTOCOL_VERSION = 34;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.
@@ -380,6 +380,7 @@ export type WsAdapterEvent =
   | { type: "playerEliminated"; playerId: PlayerId; becameSpectator: boolean }
   | { type: "spectatorJoined"; name: string }
   | { type: "gameOver"; winner: PlayerId | null; reason: string }
+  | { type: "aiDriverFault"; id: number; revision: number; message: string }
   | { type: "error"; message: string }
   | { type: "deckRejected"; reason: string }
   | { type: "reconnecting"; attempt: number; maxAttempts: number }
@@ -1851,6 +1852,21 @@ export class WebSocketAdapter implements EngineAdapter {
         this.rejectPregameMutation(actionRejectionError(data.message));
         this.rejectAbandon(actionRejectionError(data.message));
         this.emit({ type: "error", message: data.message });
+        break;
+      }
+
+      case "AiDriverFault": {
+        const data = msg.data as {
+          fault: { id: number; state_revision: number; cause: unknown };
+        };
+        const message = "Native AI driver stopped; this game can no longer advance.";
+        this.emit({
+          type: "aiDriverFault",
+          id: data.fault.id,
+          revision: data.fault.state_revision,
+          message,
+        });
+        this.emit({ type: "error", message });
         break;
       }
     }

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -36,8 +36,8 @@ const viewerInteractionWithProducedMana = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v24", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(24);
+  it("pins the P2P wire protocol to v25", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(25);
   });
 
   it("defaults shortcut actions for a legacy payload created before the additive field", () => {
@@ -260,15 +260,15 @@ describe("encodeWireMessage / decodeWireMessage", () => {
   // and nothing about the version. Both halves here stamp LITERALS — a frame
   // built from WIRE_PROTOCOL_VERSION cannot tell a bumped client from an
   // unbumped one, which is why every other handshake fixture in the suite is
-  // useless as an instrument for a bump. Revert 24 → 23 and BOTH halves red:
-  // the v23 frame stops being refused, and the v24 frame stops being admitted.
+  // useless as an instrument for a bump. Revert 25 → 24 and BOTH halves red:
+  // the v24 frame stops being refused, and the v25 frame stops being admitted.
   // The admitting half is the reach-guard: without it "refuses v23" is also
   // satisfied by a client that refuses everything.
-  it("refuses the previous wire protocol (v23) and admits its own (v24)", () => {
-    expect(() => validateMessage(setupFrameAt(23))).toThrow(/Wire protocol mismatch/);
-    expect(validateMessage(setupFrameAt(24))).toMatchObject({
+  it("refuses the previous wire protocol (v24) and admits its own (v25)", () => {
+    expect(() => validateMessage(setupFrameAt(24))).toThrow(/Wire protocol mismatch/);
+    expect(validateMessage(setupFrameAt(25))).toMatchObject({
       type: "game_setup",
-      wireProtocolVersion: 24,
+      wireProtocolVersion: 25,
     });
   });
 

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -127,7 +127,7 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *       sub-phase on WaitingFor::MulliganDecision; the MulliganBottomCards
  *       variant was removed
  */
-export const WIRE_PROTOCOL_VERSION = 24 as const;
+export const WIRE_PROTOCOL_VERSION = 25 as const;
 
 export type P2PMessage = P2PAuthorityWire & (
   | { type: "guest_deck"; deckData: unknown; displayName?: string; reservationToken?: string }
@@ -190,6 +190,9 @@ export type P2PMessage = P2PAuthorityWire & (
    * lease-bound; guests pin the first valid terminal id and never reconnect
    * after accepting the commitment for their filtered state. */
   | { type: "terminal_result"; result: P2PTerminalResult }
+  /** Native server AI became unable to advance the authoritative session.
+   * The host sends this only after the exact terminal state revision. */
+  | { type: "ai_driver_fault"; id: number; revision: number; message: string }
   // Lifecycle broadcasts (host → all remaining peers).
   | { type: "player_kicked"; playerId: number; reason: string }
   // Host chose "continue without them" OR guest self-conceded mid-game. Wire
@@ -229,6 +232,7 @@ const VALID_TYPES = new Set([
   "kick",
   "host_left",
   "terminal_result",
+  "ai_driver_fault",
   "player_kicked",
   "player_conceded",
   "player_disconnected",

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -191,7 +191,7 @@ export type P2PMessage = P2PAuthorityWire & (
    * after accepting the commitment for their filtered state. */
   | { type: "terminal_result"; result: P2PTerminalResult }
   /** Native server AI became unable to advance the authoritative session.
-   * The host sends this only after the exact terminal state revision. */
+   * The host sends this only after the final state revision it depends on. */
   | { type: "ai_driver_fault"; id: number; revision: number; message: string }
   // Lifecycle broadcasts (host → all remaining peers).
   | { type: "player_kicked"; playerId: number; reason: string }

--- a/client/src/services/gamePersistence.ts
+++ b/client/src/services/gamePersistence.ts
@@ -105,11 +105,22 @@ export interface PersistedP2PHostSession {
   gameStarted: boolean;
   seatState?: SeatState;
   /**
+   * Native AI driver failure retained so reconnecting guests receive the same
+   * terminal fault after the resumed host has restored their state snapshot.
+   */
+  nativeAiDriverFault?: NativeAiDriverFault;
+  /**
    * Present when the desktop host delegated authority to its local
    * phase-server. The server persists the game state; IndexedDB retains only
    * the opaque credentials needed to reconnect each host-local viewer.
    */
   nativeSession?: NativeP2PServerSession;
+}
+
+export interface NativeAiDriverFault {
+  id: number;
+  revision: number;
+  message: string;
 }
 
 export interface NativeP2PServerSession {

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -101,7 +101,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 33;
+pub const PROTOCOL_VERSION: u32 = 34;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake **from clients that predate [`LOBBY_PROTOCOL_VERSION`]** — the
@@ -509,12 +509,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 33);
+        assert_eq!(PROTOCOL_VERSION, 34);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot
         // understand a success acknowledgment the submitting client awaits.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 32);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 33);
     }
 
     #[test]

--- a/crates/phase-ai/src/auto_play.rs
+++ b/crates/phase-ai/src/auto_play.rs
@@ -27,19 +27,14 @@ pub struct AiActionResult {
     pub log_entries: Vec<GameLogEntry>,
 }
 
-/// Which of `run_ai_actions`'s four break doors (see its doc comment) ended
-/// the batch before the safety cap. `None` means the loop ran out AI actions
-/// to take for a benign reason the caller already distinguishes elsewhere
-/// (hit `MAX_AI_ACTIONS_PER_SEQUENCE`, or the very first iteration found no
-/// actor at all — that case is folded into `NoActor` below instead, so `None`
-/// in practice only means "hit the safety cap").
+/// Why an AI action batch stopped.
 ///
 /// Diagnostic surface for phase#6080 (the driver-stall family): today the only
 /// signal at these break points is a `tracing::error`/`tracing::warn` that no
 /// harness subscriber captures. Exposing the reason as typed data lets a
 /// caller like `ai_commander` print it instead of installing a subscriber.
 #[derive(Debug, Clone)]
-pub enum AiActionsBreakReason {
+pub enum AiActionsStop {
     /// No AI seat can currently act. Two causes are still folded together
     /// here: `WaitingFor::acting_players()` returned empty (`GameOver`, or an
     /// empty pending set), or it returned one or more players and none of
@@ -49,7 +44,7 @@ pub enum AiActionsBreakReason {
     /// all, and the simultaneous-decision variants (`MulliganDecision`,
     /// `OpeningHandBottomCards`) can pend several at once, so naming one
     /// would be arbitrary. A missing AI *configuration* is `MissingAiConfig`.
-    NoActor,
+    NoEligibleAiActor,
     /// `player` is in `ai_players` but has no entry in `ai_configs`. Distinct
     /// from `NoActor`: an actor *was* found and *is* AI-controlled, so the
     /// remedy is caller wiring (register a config for this seat), not "wait
@@ -68,17 +63,38 @@ pub enum AiActionsBreakReason {
         action: Box<GameAction>,
         error: EngineError,
     },
+    /// The module-wide safety budget was exhausted while an AI-controlled
+    /// submitter still had work. This is a driver failure, not a benign handoff.
+    ActionSafetyCapReached { limit: usize },
+    /// A caller-provided smaller budget was exhausted while an AI-controlled
+    /// submitter still had work. The caller owns continuation from this point.
+    ActionBudgetReached { limit: usize },
 }
 
 /// Outcome of a `run_ai_actions` batch.
 ///
-/// `Deref`s to `Vec<AiActionResult>` so the many existing callers that only
-/// care about the actions taken (`.is_empty()`, `.len()`, indexing, iterating
-/// by reference) are source-compatible; only diagnostic consumers need
-/// `break_reason`.
+/// `Deref`s to `Vec<AiActionResult>` so callers that only care about actions
+/// taken (`.is_empty()`, `.len()`, indexing, iterating by reference) remain
+/// source-compatible.
 pub struct AiActionsRun {
     pub results: Vec<AiActionResult>,
-    pub break_reason: Option<AiActionsBreakReason>,
+    pub stop: AiActionsStop,
+}
+
+fn eligible_ai_decision(
+    state: &GameState,
+    ai_players: &HashSet<PlayerId>,
+) -> Option<(PlayerId, PlayerId)> {
+    state
+        .waiting_for
+        .acting_players()
+        .into_iter()
+        .find_map(|semantic_owner| {
+            let actor = turn_control::authorized_submitter_for_player(state, semantic_owner);
+            ai_players
+                .contains(&actor)
+                .then_some((semantic_owner, actor))
+        })
 }
 
 impl std::ops::Deref for AiActionsRun {
@@ -151,11 +167,9 @@ pub fn run_ai_actions(
 /// batch below it (to honor an action budget) but never *enlarge* one past it.
 /// This function never returns more than that many `AiActionResult`s.
 ///
-/// `max_actions == 0` returns an empty run with `break_reason == None` — no
-/// actor is inspected. A caller that loops on this function must therefore
-/// guarantee a positive budget before each call (`run_driver_loop` does, via
-/// its `total >= action_cap` `DriverExit::CapReached` abort door firing before
-/// the next iteration).
+/// `max_actions == 0` returns `ActionBudgetReached { limit: 0 }` — no actor is
+/// inspected. A caller that loops on this function must therefore guarantee a
+/// positive budget before each call.
 ///
 /// The "hit safety cap" warning stays keyed to `MAX_AI_ACTIONS_PER_SEQUENCE`,
 /// not `max_actions`: a small operator budget reaching its bound is expected,
@@ -170,35 +184,37 @@ pub fn run_ai_actions_bounded(
     max_actions: usize,
 ) -> AiActionsRun {
     let mut results = Vec::new();
-    let mut break_reason = None;
+    let limit = max_actions.min(MAX_AI_ACTIONS_PER_SEQUENCE);
 
-    for _ in 0..max_actions.min(MAX_AI_ACTIONS_PER_SEQUENCE) {
+    if limit == 0 {
+        return AiActionsRun {
+            results,
+            stop: AiActionsStop::ActionBudgetReached { limit },
+        };
+    }
+
+    for _ in 0..limit {
         // CR 723.5: Under turn control (Mindslaver, Emrakul), the authorized
         // submitter is the controller — not the active player. Only run AI when
         // that submitter is an AI seat; otherwise wait for the human controller
         // (issue #1189).
-        let decision = state
-            .waiting_for
-            .acting_players()
-            .into_iter()
-            .find_map(|semantic_owner| {
-                let actor = turn_control::authorized_submitter_for_player(state, semantic_owner);
-                ai_players
-                    .contains(&actor)
-                    .then_some((semantic_owner, actor))
-            });
+        let decision = eligible_ai_decision(state, ai_players);
 
         let Some((semantic_owner, actor)) = decision else {
-            break_reason = Some(AiActionsBreakReason::NoActor);
-            break;
+            return AiActionsRun {
+                results,
+                stop: AiActionsStop::NoEligibleAiActor,
+            };
         };
 
         let config = match ai_configs.get(&actor) {
             Some(c) => c,
             None => {
                 tracing::warn!(player = ?actor, "AI seat has no config — stopping AI loop");
-                break_reason = Some(AiActionsBreakReason::MissingAiConfig { player: actor });
-                break;
+                return AiActionsRun {
+                    results,
+                    stop: AiActionsStop::MissingAiConfig { player: actor },
+                };
             }
         };
 
@@ -207,8 +223,10 @@ pub fn run_ai_actions_bounded(
             Some(a) => a,
             None => {
                 tracing::warn!(player = ?actor, "choose_action returned None — stopping AI loop");
-                break_reason = Some(AiActionsBreakReason::ChooseActionNone { player: actor });
-                break;
+                return AiActionsRun {
+                    results,
+                    stop: AiActionsStop::ChooseActionNone { player: actor },
+                };
             }
         };
 
@@ -221,12 +239,14 @@ pub fn run_ai_actions_bounded(
                 ?actor,
                 "AI action violated decision contract"
             );
-            break_reason = Some(AiActionsBreakReason::ApplyFailed {
-                player: actor,
-                action: Box::new(action),
-                error,
-            });
-            break;
+            return AiActionsRun {
+                results,
+                stop: AiActionsStop::ApplyFailed {
+                    player: actor,
+                    action: Box::new(action),
+                    error,
+                },
+            };
         }
 
         // The decision owner and authenticated AI actor are intentionally
@@ -243,37 +263,44 @@ pub fn run_ai_actions_bounded(
             }
             Err(e) => {
                 tracing::error!(player = ?actor, error = %e, "AI action apply failed — stopping");
-                break_reason = Some(AiActionsBreakReason::ApplyFailed {
-                    player: actor,
-                    action: Box::new(action),
-                    error: e,
-                });
-                break;
+                return AiActionsRun {
+                    results,
+                    stop: AiActionsStop::ApplyFailed {
+                        player: actor,
+                        action: Box::new(action),
+                        error: e,
+                    },
+                };
             }
         }
     }
 
-    if results.len() >= MAX_AI_ACTIONS_PER_SEQUENCE {
+    if limit == MAX_AI_ACTIONS_PER_SEQUENCE {
         tracing::warn!(
-            count = results.len(),
+            count = limit,
             "AI action loop hit safety cap — possible infinite loop"
         );
     }
 
     AiActionsRun {
         results,
-        break_reason,
+        stop: if eligible_ai_decision(state, ai_players).is_none() {
+            AiActionsStop::NoEligibleAiActor
+        } else if limit == MAX_AI_ACTIONS_PER_SEQUENCE {
+            AiActionsStop::ActionSafetyCapReached { limit }
+        } else {
+            AiActionsStop::ActionBudgetReached { limit }
+        },
     }
 }
 
 /// Driver-relevant outcome of processing one `run_ai_actions` batch: how many
-/// actions to add to a caller's running total, and the break reason to stop
-/// and report at this batch boundary, if the batch carries one.
+/// actions to add to a caller's running total and its exact stop condition.
 ///
 /// phase#6080 follow-up: a batch can complete one or more actions (`results`
-/// non-empty) and *still* carry a `break_reason` — e.g. it applies two
+/// non-empty) and *still* carry a stop reason — e.g. it applies two
 /// actions, then the third choice is `ChooseActionNone` or the fourth
-/// `apply()` call fails. A driver that only inspects `break_reason` when
+/// `apply()` call fails. A driver that only inspects the stop reason when
 /// `results.is_empty()` silently discards the diagnostic for exactly that
 /// case, loops again, and may report a misleading `NoActor`/unknown reason
 /// once a later, unrelated batch happens to come back empty. `driver_step`
@@ -281,7 +308,7 @@ pub fn run_ai_actions_bounded(
 /// re-derive it ad hoc.
 pub struct DriverStep {
     pub actions_taken: usize,
-    pub break_reason: Option<AiActionsBreakReason>,
+    pub stop: AiActionsStop,
 }
 
 /// Extracts the [`DriverStep`] for one batch. Callers should process
@@ -290,13 +317,13 @@ pub struct DriverStep {
 pub fn driver_step(results: AiActionsRun) -> DriverStep {
     DriverStep {
         actions_taken: results.results.len(),
-        break_reason: results.break_reason,
+        stop: results.stop,
     }
 }
 
 /// Why [`run_driver_loop`] returned: it either hit the action cap exactly, or a
-/// batch carried a break reason ([`AiActionsBreakReason`]) at its boundary. One
-/// fact, one type — not an `aborted: bool` plus an `Option<AiActionsBreakReason>`
+/// batch carried a stop reason ([`AiActionsStop`]) at its boundary. One
+/// fact, one type — not an `aborted: bool` plus an `Option<AiActionsStop>`
 /// pair whose two illegal combinations (aborted with a reason, not-aborted with
 /// none) a caller would have to defend against.
 #[derive(Debug)]
@@ -304,7 +331,7 @@ pub enum DriverExit {
     /// `total_actions` reached `action_cap` with no break door firing first.
     CapReached,
     /// A batch stopped early at its boundary; carries the reason to report.
-    BatchBreak(AiActionsBreakReason),
+    BatchBreak(AiActionsStop),
 }
 
 /// Outcome of a [`run_driver_loop`] run: the total actions taken and why it
@@ -365,24 +392,25 @@ pub fn run_driver_loop(
             run_ai_actions_bounded(state, ai_players, ai_configs, rng, session, remaining);
         on_batch(&mut results, &*state, total);
 
-        // phase#6080 follow-up: a batch can complete actions and still carry a
-        // break_reason, so capture the reason from EVERY batch — not only empty
-        // ones — and stop at this batch boundary. The break-reason check stays
-        // BEFORE the cap check so a genuine break door is reported instead of a
-        // cap abort when both are true on the same batch.
         let step = driver_step(results);
         total += step.actions_taken;
-        if let Some(reason) = step.break_reason {
-            return DriverOutcome {
-                total_actions: total,
-                exit: DriverExit::BatchBreak(reason),
-            };
-        }
-        if total >= action_cap {
-            return DriverOutcome {
-                total_actions: total,
-                exit: DriverExit::CapReached,
-            };
+        match step.stop {
+            AiActionsStop::ActionBudgetReached { .. }
+            | AiActionsStop::ActionSafetyCapReached { .. }
+                if total >= action_cap =>
+            {
+                return DriverOutcome {
+                    total_actions: total,
+                    exit: DriverExit::CapReached,
+                };
+            }
+            AiActionsStop::ActionSafetyCapReached { .. } if total < action_cap => continue,
+            stop => {
+                return DriverOutcome {
+                    total_actions: total,
+                    exit: DriverExit::BatchBreak(stop),
+                };
+            }
         }
     }
 }
@@ -403,23 +431,20 @@ mod tests {
     #[test]
     fn driver_step_preserves_break_reason_from_non_empty_batch() {
         // The exact regression: a batch that completed an action must not
-        // have its break_reason discarded just because `results` isn't
+        // have its stop reason discarded just because `results` isn't
         // empty.
         let state = GameState::new_two_player(1);
         let run = AiActionsRun {
             results: vec![dummy_result(&state)],
-            break_reason: Some(AiActionsBreakReason::ChooseActionNone {
+            stop: AiActionsStop::ChooseActionNone {
                 player: PlayerId(1),
-            }),
+            },
         };
         let step = driver_step(run);
         assert_eq!(step.actions_taken, 1);
         assert!(
-            matches!(
-                step.break_reason,
-                Some(AiActionsBreakReason::ChooseActionNone { .. })
-            ),
-            "break_reason from a non-empty batch must survive driver_step"
+            matches!(step.stop, AiActionsStop::ChooseActionNone { .. }),
+            "stop reason from a non-empty batch must survive driver_step"
         );
     }
 
@@ -428,28 +453,46 @@ mod tests {
         // Existing behavior (empty batch + break reason) must still work.
         let run = AiActionsRun {
             results: Vec::new(),
-            break_reason: Some(AiActionsBreakReason::NoActor),
+            stop: AiActionsStop::NoEligibleAiActor,
         };
         let step = driver_step(run);
         assert_eq!(step.actions_taken, 0);
+        assert!(matches!(step.stop, AiActionsStop::NoEligibleAiActor));
+    }
+
+    #[test]
+    fn driver_step_preserves_budget_stop() {
+        let state = GameState::new_two_player(1);
+        let run = AiActionsRun {
+            results: vec![dummy_result(&state), dummy_result(&state)],
+            stop: AiActionsStop::ActionBudgetReached { limit: 2 },
+        };
+        let step = driver_step(run);
+        assert_eq!(step.actions_taken, 2);
         assert!(matches!(
-            step.break_reason,
-            Some(AiActionsBreakReason::NoActor)
+            step.stop,
+            AiActionsStop::ActionBudgetReached { limit: 2 }
         ));
     }
 
     #[test]
-    fn driver_step_ordinary_batch_is_unaffected() {
-        // Ordinary caller path: batch completed actions and hit no break
-        // door (e.g. hit the safety cap) — driver_step must not fabricate a
-        // stop signal.
-        let state = GameState::new_two_player(1);
-        let run = AiActionsRun {
-            results: vec![dummy_result(&state), dummy_result(&state)],
-            break_reason: None,
-        };
-        let step = driver_step(run);
-        assert_eq!(step.actions_taken, 2);
-        assert!(step.break_reason.is_none());
+    fn zero_sized_bounded_batch_is_a_normal_budget_stop() {
+        let mut state = GameState::new_two_player(1);
+        let mut rng = rand::rng();
+        let session = AiSession::arc_from_game(&state);
+        let run = run_ai_actions_bounded(
+            &mut state,
+            &HashSet::new(),
+            &HashMap::new(),
+            &mut rng,
+            &session,
+            0,
+        );
+
+        assert!(run.is_empty());
+        assert!(matches!(
+            run.stop,
+            AiActionsStop::ActionBudgetReached { limit: 0 }
+        ));
     }
 }

--- a/crates/phase-ai/src/auto_play.rs
+++ b/crates/phase-ai/src/auto_play.rs
@@ -19,6 +19,31 @@ use crate::session::AiSession;
 /// Typical AI sequences (mulligans + full turn) are 30–50 actions.
 const MAX_AI_ACTIONS_PER_SEQUENCE: usize = 200;
 
+/// Identifies whether a batch bound belongs to the caller or to the module's
+/// infinite-loop safety cap. A caller requesting exactly the cap remains a
+/// caller budget; only a larger request is truncated by the safety cap.
+#[derive(Clone, Copy)]
+enum ActionLimit {
+    SafetyCap,
+    CallerBudget { requested: usize },
+}
+
+impl ActionLimit {
+    fn effective(self) -> usize {
+        match self {
+            Self::SafetyCap => MAX_AI_ACTIONS_PER_SEQUENCE,
+            Self::CallerBudget { requested } => requested.min(MAX_AI_ACTIONS_PER_SEQUENCE),
+        }
+    }
+
+    fn is_safety_cap(self) -> bool {
+        match self {
+            Self::SafetyCap => true,
+            Self::CallerBudget { requested } => requested > MAX_AI_ACTIONS_PER_SEQUENCE,
+        }
+    }
+}
+
 /// Result of a single AI action: the action taken and the resulting events.
 pub struct AiActionResult {
     pub action: GameAction,
@@ -149,13 +174,13 @@ pub fn run_ai_actions(
 ) -> AiActionsRun {
     // Thin delegate: existing callers get the full safety-cap budget and
     // exactly the prior semantics.
-    run_ai_actions_bounded(
+    run_ai_actions_with_limit(
         state,
         ai_players,
         ai_configs,
         rng,
         session,
-        MAX_AI_ACTIONS_PER_SEQUENCE,
+        ActionLimit::SafetyCap,
     )
 }
 
@@ -183,8 +208,28 @@ pub fn run_ai_actions_bounded(
     session: &Arc<AiSession>,
     max_actions: usize,
 ) -> AiActionsRun {
+    run_ai_actions_with_limit(
+        state,
+        ai_players,
+        ai_configs,
+        rng,
+        session,
+        ActionLimit::CallerBudget {
+            requested: max_actions,
+        },
+    )
+}
+
+fn run_ai_actions_with_limit(
+    state: &mut GameState,
+    ai_players: &HashSet<PlayerId>,
+    ai_configs: &HashMap<PlayerId, AiConfig>,
+    rng: &mut impl Rng,
+    session: &Arc<AiSession>,
+    action_limit: ActionLimit,
+) -> AiActionsRun {
     let mut results = Vec::new();
-    let limit = max_actions.min(MAX_AI_ACTIONS_PER_SEQUENCE);
+    let limit = action_limit.effective();
 
     if limit == 0 {
         return AiActionsRun {
@@ -275,7 +320,7 @@ pub fn run_ai_actions_bounded(
         }
     }
 
-    if limit == MAX_AI_ACTIONS_PER_SEQUENCE {
+    if action_limit.is_safety_cap() {
         tracing::warn!(
             count = limit,
             "AI action loop hit safety cap — possible infinite loop"
@@ -286,7 +331,7 @@ pub fn run_ai_actions_bounded(
         results,
         stop: if eligible_ai_decision(state, ai_players).is_none() {
             AiActionsStop::NoEligibleAiActor
-        } else if limit == MAX_AI_ACTIONS_PER_SEQUENCE {
+        } else if action_limit.is_safety_cap() {
             AiActionsStop::ActionSafetyCapReached { limit }
         } else {
             AiActionsStop::ActionBudgetReached { limit }
@@ -494,5 +539,14 @@ mod tests {
             run.stop,
             AiActionsStop::ActionBudgetReached { limit: 0 }
         ));
+    }
+
+    #[test]
+    fn exact_cap_caller_budget_is_not_a_safety_cap() {
+        assert!(!ActionLimit::CallerBudget {
+            requested: MAX_AI_ACTIONS_PER_SEQUENCE,
+        }
+        .is_safety_cap());
+        assert!(ActionLimit::SafetyCap.is_safety_cap());
     }
 }

--- a/crates/phase-ai/tests/ai_quality.rs
+++ b/crates/phase-ai/tests/ai_quality.rs
@@ -25,9 +25,7 @@ use engine::types::mana::ManaCost;
 use engine::types::mana::{ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
-use phase_ai::auto_play::{
-    driver_step, run_ai_actions, run_ai_actions_bounded, AiActionsBreakReason,
-};
+use phase_ai::auto_play::{driver_step, run_ai_actions, run_ai_actions_bounded, AiActionsStop};
 use phase_ai::choose_action;
 use phase_ai::config::{create_config, AiDifficulty, Platform};
 use phase_ai::score_candidates;
@@ -1278,10 +1276,7 @@ fn run_ai_actions_non_empty_batch_carries_break_reason() {
         "P0's DeclareBlockers action should have applied before the batch stopped"
     );
     assert!(
-        matches!(
-            results.break_reason,
-            Some(AiActionsBreakReason::MissingAiConfig { player: P1 })
-        ),
+        matches!(&results.stop, AiActionsStop::MissingAiConfig { player: P1 }),
         "expected MissingAiConfig(P1): P1 is an AI seat with no ai_configs entry, \
          which is not the same stall as NoActor"
     );
@@ -1289,7 +1284,7 @@ fn run_ai_actions_non_empty_batch_carries_break_reason() {
     let step = driver_step(results);
     assert_eq!(step.actions_taken, 1);
     assert!(
-        step.break_reason.is_some(),
+        matches!(step.stop, AiActionsStop::MissingAiConfig { player: P1 }),
         "driver_step must preserve the break reason from a non-empty batch \
          so the driver stops at this boundary instead of discarding it"
     );

--- a/crates/phase-ai/tests/scenarios.rs
+++ b/crates/phase-ai/tests/scenarios.rs
@@ -103,10 +103,10 @@ fn saved_cosmic_crucible_mana_prompt_uses_an_issued_action_and_advances() {
         1,
         "the bounded controller must submit the mana choice"
     );
-    assert!(
-        run.break_reason.is_none(),
-        "the issued mana action must apply without a controller break"
-    );
+    assert!(matches!(
+        &run.stop,
+        phase_ai::auto_play::AiActionsStop::ActionBudgetReached { limit: 1 }
+    ));
     assert!(
         contract.contains_action(&state_before, &run[0].action),
         "the controller must submit the exact action from player two's contract"
@@ -423,8 +423,11 @@ fn run_ai_actions_bounded_stops_exactly_at_budget() {
         "bounded run must take exactly its budget of actions"
     );
     assert!(
-        results.break_reason.is_none(),
-        "budget cut the stream — the loop did not end for a break-door reason"
+        matches!(
+            &results.stop,
+            phase_ai::auto_play::AiActionsStop::ActionBudgetReached { limit: 3 }
+        ),
+        "budget cut the stream — the loop did not end for a driver failure"
     );
 }
 
@@ -1211,7 +1214,7 @@ fn scenario_claws_of_gix_witness_board_does_not_dead_end() {
 /// becomes an applied action — it lands in `break_reason`, and a results-only
 /// assertion would miss it.
 fn assert_no_fallback_cancel(run: &phase_ai::auto_play::AiActionsRun, what: &str) {
-    use phase_ai::auto_play::AiActionsBreakReason;
+    use phase_ai::auto_play::AiActionsStop;
 
     assert!(
         !run.results
@@ -1222,12 +1225,12 @@ fn assert_no_fallback_cancel(run: &phase_ai::auto_play::AiActionsRun, what: &str
     );
     assert!(
         !matches!(
-            &run.break_reason,
-            Some(AiActionsBreakReason::ApplyFailed { action, .. })
+            &run.stop,
+            AiActionsStop::ApplyFailed { action, .. }
                 if matches!(**action, GameAction::CancelCast)
         ),
         "{what}: AI dead-ended on an unapplied fallback CancelCast ({:?})",
-        run.break_reason,
+        &run.stop,
     );
 }
 

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -3771,17 +3771,18 @@ async fn broadcast_game_started(
     game_db: &SharedGameDb,
     game_code: &str,
 ) {
-    let (player_messages, spectator_msg) = {
+    let (player_messages, spectator_msg, ai_failure) = {
         let mut mgr = state.lock().await;
         let Some(session) = mgr.sessions.get_mut(game_code) else {
             return;
         };
 
-        session.run_ai();
+        let ai_failure = session.run_ai().failure.map(|failure| failure.message());
         persist_full_session_async(game_db, session);
         (
             build_game_started_messages(session),
             build_spectator_game_started_message(session),
+            ai_failure,
         )
     };
 
@@ -3796,21 +3797,22 @@ async fn broadcast_game_started(
         }
     }
 
-    let spectator_msg = match spectator_msg {
-        Ok(msg) => msg,
+    match spectator_msg {
+        Ok(spectator_msg) => {
+            let mut specs = game_spectators.lock().await;
+            if let Some(spectators) = specs.get_mut(game_code) {
+                spectators.retain(|sender| sender.send(spectator_msg.clone()).is_ok());
+                if spectators.is_empty() {
+                    specs.remove(game_code);
+                }
+            }
+        }
         Err(reason) => {
             warn!(game = %game_code, %reason, "skipping spectator GameStarted: snapshot too large");
-            return;
-        }
-    };
-
-    let mut specs = game_spectators.lock().await;
-    if let Some(spectators) = specs.get_mut(game_code) {
-        spectators.retain(|sender| sender.send(spectator_msg.clone()).is_ok());
-        if spectators.is_empty() {
-            specs.remove(game_code);
         }
     }
+
+    broadcast_ai_failure(connections, game_code, ai_failure).await;
 }
 
 async fn require_host(identity: &SocketIdentity, socket: &mut WebSocket) -> Result<(), ()> {
@@ -3998,6 +4000,23 @@ async fn broadcast_ai_results(
                     specs.remove(game_code);
                 }
             }
+        }
+    }
+}
+
+async fn broadcast_ai_failure(
+    connections: &SharedConnections,
+    game_code: &str,
+    failure: Option<String>,
+) {
+    let Some(message) = failure else {
+        return;
+    };
+
+    let conns = connections.lock().await;
+    if let Some(players) = conns.get(game_code) {
+        for sender in players.values() {
+            let _ = sender.send(ServerMessage::error(message.clone()));
         }
     }
 }
@@ -4275,10 +4294,13 @@ async fn handle_full_game_submission(
                     .expect("handled action must retain its session")
                     .advance_state_revision();
                 // Run AI follow-up actions (still inside lock — needs &mut state)
-                let ai_results = match mgr.sessions.get_mut(&game_code) {
-                    Some(session) => session.run_ai(),
-                    None => vec![],
-                };
+                let ai_outcome = mgr
+                    .sessions
+                    .get_mut(&game_code)
+                    .expect("handled action must retain its session")
+                    .run_ai();
+                let ai_failure = ai_outcome.failure.as_ref().map(|failure| failure.message());
+                let ai_results = ai_outcome.transitions;
                 let session = mgr.sessions.get(&game_code).unwrap();
                 let eliminated = session.state.eliminated_players.clone();
                 // Captured once, AFTER `run_ai`, and reused for both the human
@@ -4323,6 +4345,7 @@ async fn handle_full_game_submission(
                         game_over_winner,
                         terminal,
                         rewind_targets,
+                        ai_failure,
                     )
                 })
             }
@@ -4348,6 +4371,7 @@ async fn handle_full_game_submission(
             game_over_winner,
             terminal,
             rewind_targets,
+            ai_failure,
         )) => {
             if let Err(reason) = guard_state_snapshot_broadcast(StateSnapshotParts {
                 state: &raw_state,
@@ -4477,6 +4501,8 @@ async fn handle_full_game_submission(
             )
             .await;
 
+            broadcast_ai_failure(connections, &game_code, ai_failure).await;
+
             if !terminal_deliveries.is_empty() {
                 let conns = connections.lock().await;
                 if let Some(players) = conns.get(&game_code) {
@@ -4551,11 +4577,13 @@ async fn handle_resolve_all(
                     // Keep that hand-off under the same lock, then derive the one
                     // final payload from the current session rather than the batch
                     // transition it has already moved past.
-                    let ai_results = session.run_ai();
+                    let ai_outcome = session.run_ai();
+                    let ai_failure = ai_outcome.failure.map(|failure| failure.message());
                     let (raw_state, legal_actions, _auto_pass, spell_costs, by_object) =
                         session.current_broadcast_snapshot();
                     let revision = session.state_revision;
-                    let log_entries = resolve_all_log_tail(&batch_log_entries, &ai_results);
+                    let log_entries =
+                        resolve_all_log_tail(&batch_log_entries, &ai_outcome.transitions);
                     let eliminated = session.state.eliminated_players.clone();
                     let rewind_targets = session.rewind_options();
                     let player_count = session.player_count;
@@ -4588,6 +4616,7 @@ async fn handle_resolve_all(
                                 player_count,
                                 game_over_winner,
                                 terminal,
+                                ai_failure,
                             )),
                         )
                     })
@@ -4622,6 +4651,7 @@ async fn handle_resolve_all(
         player_count,
         game_over_winner,
         terminal,
+        ai_failure,
     )) = payload
     else {
         let _ = tx.send(acknowledgement);
@@ -4726,6 +4756,8 @@ async fn handle_resolve_all(
         }
     }
     let _ = tx.send(acknowledgement);
+
+    broadcast_ai_failure(connections, &game_code, ai_failure).await;
 
     if !terminal_deliveries.is_empty() {
         let conns = connections.lock().await;
@@ -5043,7 +5075,7 @@ async fn handle_client_message(
                     let session = mgr.sessions.get_mut(&game_code).unwrap();
                     let joiner = session.player_for_token(&player_token).unwrap();
                     let started_messages = if session.is_full() {
-                        session.run_ai();
+                        let ai_failure = session.run_ai().failure.map(|failure| failure.message());
                         persist_full_session_async(game_db, session);
                         // The joiner is excluded from the fan-out send below
                         // (`pid != joiner`), so it receives the contest dice via
@@ -5056,7 +5088,7 @@ async fn handle_client_message(
                             Some(player_token.clone()),
                             joiner_events,
                         );
-                        Some((joiner_msg, build_game_started_messages(session)))
+                        Some((joiner_msg, build_game_started_messages(session), ai_failure))
                     } else {
                         None
                     };
@@ -5071,7 +5103,7 @@ async fn handle_client_message(
                         .insert(joiner, tx.clone());
 
                     // Only send GameStarted when the game is full (all seats claimed)
-                    if let Some((msg, other_messages)) = started_messages {
+                    if let Some((msg, other_messages, ai_failure)) = started_messages {
                         if let Ok(json) = serde_json::to_string(&msg) {
                             let _ = socket.send(Message::text(json)).await;
                         }
@@ -5083,6 +5115,13 @@ async fn handle_client_message(
                                     if let Some(sender) = players.get(&pid) {
                                         let _ = sender.send(msg);
                                     }
+                                }
+                            }
+                        }
+                        if let Some(message) = ai_failure {
+                            if let Some(players) = conns.get(&game_code) {
+                                for sender in players.values() {
+                                    let _ = sender.send(ServerMessage::error(message.clone()));
                                 }
                             }
                         }
@@ -5224,6 +5263,7 @@ async fn handle_client_message(
                     player: PlayerId,
                     game_started_msg: Box<ServerMessage>,
                     ai_result: Option<Box<server_core::RevisionedActionResult>>,
+                    ai_failure: Option<String>,
                     /// GH #1507: present when a takeback vote is in flight,
                     /// so the reconnecting socket gets the same prompt it
                     /// would have received had it stayed connected.
@@ -5272,9 +5312,10 @@ async fn handle_client_message(
                         Ok(_filtered_state) => {
                             let session = mgr.sessions.get_mut(&game_code).unwrap();
                             let player = session.player_for_token(&player_token).unwrap();
-                            let ai_results = session.run_ai();
-                            let ai_result = ai_results.last().cloned().map(Box::new);
-                            if ai_result.is_some() {
+                            let ai_outcome = session.run_ai();
+                            let ai_failure = ai_outcome.failure.map(|failure| failure.message());
+                            let ai_result = ai_outcome.transitions.last().cloned().map(Box::new);
+                            if ai_result.is_some() || ai_failure.is_some() {
                                 persist_full_session_async(game_db, session);
                             }
                             // Reconnect: no contest dice (the player must not
@@ -5288,6 +5329,7 @@ async fn handle_client_message(
                                 player,
                                 game_started_msg: Box::new(game_started_msg),
                                 ai_result,
+                                ai_failure,
                                 pending_takeback_msg,
                                 rewind_targets,
                             }
@@ -5338,6 +5380,7 @@ async fn handle_client_message(
                     player,
                     game_started_msg,
                     ai_result,
+                    ai_failure,
                     pending_takeback_msg,
                     rewind_targets,
                 } => {
@@ -5395,6 +5438,8 @@ async fn handle_client_message(
                             }
                         }
                     }
+
+                    broadcast_ai_failure(connections, &game_code, ai_failure).await;
                 }
 
                 ReconnectOutcome::Err(e) => {
@@ -5654,7 +5699,7 @@ async fn handle_client_message(
 
             if !ai_requests.is_empty() && ai_requests.len() as u8 == pc - 1 {
                 // --- AI game path: create, start, and run initial AI actions ---
-                let (game_code, player_token, full_key, game_started_msg) = {
+                let (game_code, player_token, full_key, game_started_msg, ai_failure) = {
                     let mut mgr = state.lock().await;
                     // Sole capacity check for the AI path, under the lock that
                     // inserts — see the `CreateGame` arm for why it cannot move
@@ -5701,7 +5746,14 @@ async fn handle_client_message(
                     };
 
                     let session = mgr.sessions.get_mut(&game_code).unwrap();
-                    session.run_ai();
+                    if let Err(error) = initialize_full_runtime(game_db, session, full_key.clone())
+                    {
+                        mgr.remove_game(&game_code);
+                        let _ = tx.send(ServerMessage::error(error));
+                        return;
+                    }
+                    let ai_failure = session.run_ai().failure.map(|failure| failure.message());
+                    persist_full_session_async(game_db, session);
                     // Initial start of a Play-vs-AI game: the human seat sees
                     // the first-player contest dice. Drain so they are not
                     // re-sent on reconnect.
@@ -5709,14 +5761,13 @@ async fn handle_client_message(
                     let game_started_msg =
                         build_game_started_message(session, PlayerId(0), None, start_events);
 
-                    if let Err(error) = initialize_full_runtime(game_db, session, full_key.clone())
-                    {
-                        mgr.remove_game(&game_code);
-                        let _ = tx.send(ServerMessage::error(error));
-                        return;
-                    }
-
-                    (game_code, player_token, full_key, game_started_msg)
+                    (
+                        game_code,
+                        player_token,
+                        full_key,
+                        game_started_msg,
+                        ai_failure,
+                    )
                 }; // lock dropped
 
                 identity.set_session(game_code.clone(), PlayerId(0), player_token.clone());
@@ -5749,6 +5800,9 @@ async fn handle_client_message(
                 }
                 if let Ok(json) = serde_json::to_string(&game_started_msg) {
                     let _ = socket.send(Message::text(json)).await;
+                }
+                if let Some(message) = ai_failure {
+                    let _ = tx.send(ServerMessage::error(message));
                 }
 
                 info!(game = %game_code, host = %display_name, "AI game started");
@@ -6927,10 +6981,14 @@ async fn handle_client_message(
             // are no AI seats, and its own pending-takeback guard is already
             // cleared by the time we get here. Revisions stay contiguous: the
             // rollback took R+1 above, `run_ai` allocates R+2..R+k.
-            let ai_results = if approved_snapshot.is_some() {
-                session.run_ai()
+            let (ai_results, ai_failure) = if approved_snapshot.is_some() {
+                let ai_outcome = session.run_ai();
+                (
+                    ai_outcome.transitions,
+                    ai_outcome.failure.map(|failure| failure.message()),
+                )
             } else {
-                Vec::new()
+                (Vec::new(), None)
             };
             // Both read AFTER `run_ai`, matching the shipped action path: an AI
             // follow-up can cross a turn (new rewind boundary) or finish a
@@ -7010,6 +7068,7 @@ async fn handle_client_message(
                         &rewind_targets,
                     )
                     .await;
+                    broadcast_ai_failure(connections, &game_code, ai_failure).await;
                 }
                 Ok(server_core::TakebackOutcome::Rejected) => {
                     // request_takeback never returns Rejected — only respond_takeback does.
@@ -7045,10 +7104,14 @@ async fn handle_client_message(
                 });
             // Same reason, same ordering, as the `RequestTakeback` arm above:
             // the rolled-back state can put an AI seat on priority.
-            let ai_results = if approved_snapshot.is_some() {
-                session.run_ai()
+            let (ai_results, ai_failure) = if approved_snapshot.is_some() {
+                let ai_outcome = session.run_ai();
+                (
+                    ai_outcome.transitions,
+                    ai_outcome.failure.map(|failure| failure.message()),
+                )
             } else {
-                Vec::new()
+                (Vec::new(), None)
             };
             // Read AFTER `run_ai` for the same reason as the `RequestTakeback`
             // arm above.
@@ -7102,6 +7165,7 @@ async fn handle_client_message(
                         &rewind_targets,
                     )
                     .await;
+                    broadcast_ai_failure(connections, &game_code, ai_failure).await;
                 }
                 Ok(server_core::TakebackOutcome::Rejected) => {
                     info!(game = %game_code, player = ?player_id, "takeback declined");

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -3777,7 +3777,7 @@ async fn broadcast_game_started(
             return;
         };
 
-        let ai_failure = session.run_ai().failure.map(|failure| failure.message());
+        let ai_failure = session.run_ai().fault;
         persist_full_session_async(game_db, session);
         (
             build_game_started_messages(session),
@@ -4007,16 +4007,18 @@ async fn broadcast_ai_results(
 async fn broadcast_ai_failure(
     connections: &SharedConnections,
     game_code: &str,
-    failure: Option<String>,
+    failure: Option<server_core::AiDriverFault>,
 ) {
-    let Some(message) = failure else {
+    let Some(fault) = failure else {
         return;
     };
 
     let conns = connections.lock().await;
     if let Some(players) = conns.get(game_code) {
         for sender in players.values() {
-            let _ = sender.send(ServerMessage::error(message.clone()));
+            let _ = sender.send(ServerMessage::AiDriverFault {
+                fault: fault.clone(),
+            });
         }
     }
 }
@@ -4299,7 +4301,7 @@ async fn handle_full_game_submission(
                     .get_mut(&game_code)
                     .expect("handled action must retain its session")
                     .run_ai();
-                let ai_failure = ai_outcome.failure.as_ref().map(|failure| failure.message());
+                let ai_failure = ai_outcome.fault;
                 let ai_results = ai_outcome.transitions;
                 let session = mgr.sessions.get(&game_code).unwrap();
                 let eliminated = session.state.eliminated_players.clone();
@@ -4578,7 +4580,7 @@ async fn handle_resolve_all(
                     // final payload from the current session rather than the batch
                     // transition it has already moved past.
                     let ai_outcome = session.run_ai();
-                    let ai_failure = ai_outcome.failure.map(|failure| failure.message());
+                    let ai_failure = ai_outcome.fault;
                     let (raw_state, legal_actions, _auto_pass, spell_costs, by_object) =
                         session.current_broadcast_snapshot();
                     let revision = session.state_revision;
@@ -5075,7 +5077,7 @@ async fn handle_client_message(
                     let session = mgr.sessions.get_mut(&game_code).unwrap();
                     let joiner = session.player_for_token(&player_token).unwrap();
                     let started_messages = if session.is_full() {
-                        let ai_failure = session.run_ai().failure.map(|failure| failure.message());
+                        let ai_failure = session.run_ai().fault;
                         persist_full_session_async(game_db, session);
                         // The joiner is excluded from the fan-out send below
                         // (`pid != joiner`), so it receives the contest dice via
@@ -5118,10 +5120,12 @@ async fn handle_client_message(
                                 }
                             }
                         }
-                        if let Some(message) = ai_failure {
+                        if let Some(fault) = ai_failure {
                             if let Some(players) = conns.get(&game_code) {
                                 for sender in players.values() {
-                                    let _ = sender.send(ServerMessage::error(message.clone()));
+                                    let _ = sender.send(ServerMessage::AiDriverFault {
+                                        fault: fault.clone(),
+                                    });
                                 }
                             }
                         }
@@ -5263,7 +5267,7 @@ async fn handle_client_message(
                     player: PlayerId,
                     game_started_msg: Box<ServerMessage>,
                     ai_result: Option<Box<server_core::RevisionedActionResult>>,
-                    ai_failure: Option<String>,
+                    ai_failure: Option<server_core::AiDriverFault>,
                     /// GH #1507: present when a takeback vote is in flight,
                     /// so the reconnecting socket gets the same prompt it
                     /// would have received had it stayed connected.
@@ -5313,7 +5317,7 @@ async fn handle_client_message(
                             let session = mgr.sessions.get_mut(&game_code).unwrap();
                             let player = session.player_for_token(&player_token).unwrap();
                             let ai_outcome = session.run_ai();
-                            let ai_failure = ai_outcome.failure.map(|failure| failure.message());
+                            let ai_failure = ai_outcome.fault;
                             let ai_result = ai_outcome.transitions.last().cloned().map(Box::new);
                             if ai_result.is_some() || ai_failure.is_some() {
                                 persist_full_session_async(game_db, session);
@@ -5752,7 +5756,7 @@ async fn handle_client_message(
                         let _ = tx.send(ServerMessage::error(error));
                         return;
                     }
-                    let ai_failure = session.run_ai().failure.map(|failure| failure.message());
+                    let ai_failure = session.run_ai().fault;
                     persist_full_session_async(game_db, session);
                     // Initial start of a Play-vs-AI game: the human seat sees
                     // the first-player contest dice. Drain so they are not
@@ -5801,8 +5805,8 @@ async fn handle_client_message(
                 if let Ok(json) = serde_json::to_string(&game_started_msg) {
                     let _ = socket.send(Message::text(json)).await;
                 }
-                if let Some(message) = ai_failure {
-                    let _ = tx.send(ServerMessage::error(message));
+                if let Some(fault) = ai_failure {
+                    let _ = tx.send(ServerMessage::AiDriverFault { fault });
                 }
 
                 info!(game = %game_code, host = %display_name, "AI game started");
@@ -6983,10 +6987,7 @@ async fn handle_client_message(
             // rollback took R+1 above, `run_ai` allocates R+2..R+k.
             let (ai_results, ai_failure) = if approved_snapshot.is_some() {
                 let ai_outcome = session.run_ai();
-                (
-                    ai_outcome.transitions,
-                    ai_outcome.failure.map(|failure| failure.message()),
-                )
+                (ai_outcome.transitions, ai_outcome.fault)
             } else {
                 (Vec::new(), None)
             };
@@ -7106,10 +7107,7 @@ async fn handle_client_message(
             // the rolled-back state can put an AI seat on priority.
             let (ai_results, ai_failure) = if approved_snapshot.is_some() {
                 let ai_outcome = session.run_ai();
-                (
-                    ai_outcome.transitions,
-                    ai_outcome.failure.map(|failure| failure.message()),
-                )
+                (ai_outcome.transitions, ai_outcome.fault)
             } else {
                 (Vec::new(), None)
             };

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -7399,6 +7399,20 @@ async fn handle_client_message(
                     return;
                 };
 
+                if let Some(fault) = session.ai_driver_fault() {
+                    let msg = ServerMessage::ActionRejected {
+                        reason: format!(
+                            "Native AI driver fault {}: {}",
+                            fault.id,
+                            fault.cause.message()
+                        ),
+                    };
+                    if let Ok(json) = serde_json::to_string(&msg) {
+                        let _ = socket.send(Message::text(json)).await;
+                    }
+                    return;
+                }
+
                 let public_before = session.lobby_meta.as_ref().is_some_and(|meta| meta.public);
                 let mut seat_state = session.seat_state();
                 let delta_result = {

--- a/crates/phase-server/src/persistence.rs
+++ b/crates/phase-server/src/persistence.rs
@@ -1219,6 +1219,8 @@ mod tests {
             persisted: PersistedSession {
                 game_code: game_code.to_string(),
                 state_revision: mutation_revision,
+                ai_driver_fault: None,
+                next_ai_driver_fault_id: 1,
                 state: PersistedGameState::capture(GameState::new_two_player(7)),
                 player_tokens: vec!["player-0".to_string(), "player-1".to_string()],
                 display_names: vec!["P0".to_string(), "P1".to_string()],

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -65,8 +65,8 @@ pub use reconnect::ReconnectManager;
 pub use seat_mutation_wire_guard::guard_seat_mutation;
 pub use session::{
     acting_player, acting_players, generate_game_code, generate_player_token, is_acting,
-    BroadcastSnapshot, FullPersistDisposition, FullPersistSnapshot, FullRuntime, FullSessionKey,
-    RevisionedActionResult, SessionManager,
+    AiDriverFailure, AiDriverFault, BroadcastSnapshot, FullPersistDisposition, FullPersistSnapshot,
+    FullRuntime, FullSessionKey, RevisionedActionResult, SessionManager,
 };
 pub use spectator_wire_guard::{
     guard_draft_spectator_capacity, guard_game_spectator_capacity, guard_spectate_draft,

--- a/crates/server-core/src/persist.rs
+++ b/crates/server-core/src/persist.rs
@@ -8,6 +8,7 @@ use draft_core::types::{DraftConfig, DraftSession as DraftCoreSession};
 
 use crate::lobby::RegisterGameRequest;
 use crate::protocol::DraftLobbyMetadata;
+use crate::session::AiDriverFault;
 
 /// Serializable snapshot of a game session for disk persistence.
 ///
@@ -20,6 +21,12 @@ pub struct PersistedSession {
     pub game_code: String,
     #[serde(default)]
     pub state_revision: u64,
+    /// A persisted native-driver failure remains terminal across process
+    /// restart; omitting it decodes historical snapshots as healthy.
+    #[serde(default)]
+    pub ai_driver_fault: Option<AiDriverFault>,
+    #[serde(default = "default_next_ai_driver_fault_id")]
+    pub next_ai_driver_fault_id: u64,
     pub state: PersistedGameState,
     pub player_tokens: Vec<String>,
     pub display_names: Vec<String>,
@@ -55,6 +62,10 @@ pub struct PersistedLobbyMeta {
 
 fn default_true() -> bool {
     true
+}
+
+fn default_next_ai_driver_fault_id() -> u64 {
+    1
 }
 
 /// Serializable snapshot of a draft session for disk persistence.

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -14,7 +14,7 @@ use engine::types::player::PlayerId;
 use phase_ai::config::AiDifficulty;
 use serde::{Deserialize, Serialize};
 
-use crate::session::FullSessionKey;
+use crate::session::{AiDriverFault, FullSessionKey};
 use crate::takeback::{RewindOption, RewindTarget};
 
 /// Full game wire protocol version. Kept numerically aligned with the lobby
@@ -569,6 +569,12 @@ pub enum ServerMessage {
         /// rating changes for both seats.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         ranked_result: Option<Vec<RankedPlayerResult>>,
+    },
+    /// A durable native AI driver failure. The referenced revision is the
+    /// final authoritative state frame that must be delivered before clients
+    /// surface the fault.
+    AiDriverFault {
+        fault: AiDriverFault,
     },
     /// Terminal-only bootstrap response. `None` means the exact keyed Full
     /// session has no prepared terminal artifact, so the caller may attempt
@@ -2360,8 +2366,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_33() {
-        assert_eq!(PROTOCOL_VERSION, 33);
+    fn protocol_version_is_34() {
+        assert_eq!(PROTOCOL_VERSION, 34);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -2371,7 +2377,7 @@ mod tests {
     /// understand.
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
-    /// this guards — and this test reds while `protocol_version_is_33` stays
+    /// this guards — and this test reds while `protocol_version_is_34` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -14,7 +14,7 @@ use engine::types::player::PlayerId;
 use phase_ai::config::AiDifficulty;
 use serde::{Deserialize, Serialize};
 
-use crate::session::{AiDriverFailure, AiDriverFault, FullSessionKey};
+use crate::session::{AiDriverFault, FullSessionKey};
 use crate::takeback::{RewindOption, RewindTarget};
 
 /// Full game wire protocol version. Kept numerically aligned with the lobby
@@ -743,6 +743,7 @@ impl ServerMessage {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::session::AiDriverFailure;
     use engine::types::ability::{TriggerBaseSetInstanceRef, TriggerDefinitionOccurrenceRef};
     use engine::types::format::GameFormat;
     use engine::types::game_state::ProductionOverride;

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -14,7 +14,7 @@ use engine::types::player::PlayerId;
 use phase_ai::config::AiDifficulty;
 use serde::{Deserialize, Serialize};
 
-use crate::session::{AiDriverFault, FullSessionKey};
+use crate::session::{AiDriverFailure, AiDriverFault, FullSessionKey};
 use crate::takeback::{RewindOption, RewindTarget};
 
 /// Full game wire protocol version. Kept numerically aligned with the lobby
@@ -955,6 +955,37 @@ mod tests {
             }
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn server_message_ai_driver_fault_roundtrips_with_client_wire_keys() {
+        let msg = ServerMessage::AiDriverFault {
+            fault: AiDriverFault {
+                id: 7,
+                after_state_revision: 3,
+                cause: AiDriverFailure::ActionSafetyCapReached { limit: 200 },
+            },
+        };
+        let json = serde_json::to_value(&msg).unwrap();
+        assert_eq!(json["type"], "AiDriverFault");
+        assert_eq!(json["data"]["fault"]["id"], 7);
+        assert_eq!(json["data"]["fault"]["after_state_revision"], 3);
+        assert_eq!(
+            json["data"]["fault"]["cause"]["ActionSafetyCapReached"]["limit"],
+            200
+        );
+
+        let parsed: ServerMessage = serde_json::from_value(json).unwrap();
+        assert!(matches!(
+            parsed,
+            ServerMessage::AiDriverFault {
+                fault: AiDriverFault {
+                    id: 7,
+                    after_state_revision: 3,
+                    cause: AiDriverFailure::ActionSafetyCapReached { limit: 200 },
+                },
+            }
+        ));
     }
 
     #[test]

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -106,6 +106,10 @@ pub type RevisionedActionResult = (u64, ActionResult);
 pub struct AiRunOutcome {
     pub transitions: Vec<RevisionedActionResult>,
     pub failure: Option<AiDriverFailure>,
+    /// The durable terminal record, when this invocation observed or created
+    /// an AI driver failure. Transports must send the final state frames before
+    /// publishing this record.
+    pub fault: Option<AiDriverFault>,
 }
 
 /// Internal result of one uninterrupted AI decision batch. Keeping the exact
@@ -117,13 +121,27 @@ struct AiActionBatch {
     stop: AiActionsStop,
 }
 
-#[derive(Debug)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum AiDriverFailure {
     MissingAiConfig { player: PlayerId },
     ChooseActionNone { player: PlayerId },
     ApplyFailed { player: PlayerId, error: String },
     ActionSafetyCapReached { limit: usize },
     ResolveAllHandoffSafetyCapReached { limit: usize },
+}
+
+/// Durable, server-authored terminal state for the native AI driver.
+///
+/// This is deliberately separate from `GameState`: it is a transport/runtime
+/// failure, not a Magic game-rule result. The revision is allocated once when
+/// the fault is recorded, so a reconnect can prove it has received the final
+/// state snapshot before showing the fault.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub struct AiDriverFault {
+    pub id: u64,
+    pub state_revision: u64,
+    pub cause: AiDriverFailure,
 }
 
 impl AiDriverFailure {
@@ -302,6 +320,12 @@ pub struct GameSession {
     /// Read-only snapshots reuse this value; mutators advance it before their
     /// per-viewer views are captured for transport.
     pub state_revision: u64,
+    /// A native AI-driver failure permanently closes this session to further
+    /// game mutations. Persist it so restart/reconnect cannot turn an
+    /// actionable AI priority into a silent freeze again.
+    pub ai_driver_fault: Option<AiDriverFault>,
+    /// Monotonic per-session identifier for durable driver faults.
+    pub next_ai_driver_fault_id: u64,
     pub state: GameState,
     /// Player tokens indexed by seat (0..player_count). Empty string = seat not yet claimed.
     pub player_tokens: Vec<String>,
@@ -400,6 +424,53 @@ pub struct GameSession {
 }
 
 impl GameSession {
+    pub fn ai_driver_fault(&self) -> Option<&AiDriverFault> {
+        self.ai_driver_fault.as_ref()
+    }
+
+    fn reject_if_ai_driver_faulted(&self) -> Result<(), String> {
+        self.ai_driver_fault
+            .as_ref()
+            .map(|fault| {
+                format!(
+                    "Native AI driver fault {}: {}",
+                    fault.id,
+                    fault.cause.message()
+                )
+            })
+            .map_or(Ok(()), Err)
+    }
+
+    fn record_ai_driver_fault(&mut self, cause: AiDriverFailure) -> AiDriverFault {
+        if let Some(fault) = &self.ai_driver_fault {
+            return fault.clone();
+        }
+        let fault = AiDriverFault {
+            id: self.next_ai_driver_fault_id,
+            state_revision: self.advance_state_revision(),
+            cause,
+        };
+        self.next_ai_driver_fault_id = self.next_ai_driver_fault_id.saturating_add(1);
+        self.ai_driver_fault = Some(fault.clone());
+        fault
+    }
+
+    fn ai_driver_fault_transition(&self, fault: &AiDriverFault) -> RevisionedActionResult {
+        let (state, legal_actions, auto_pass, spell_costs, by_object) =
+            self.current_broadcast_snapshot();
+        (
+            fault.state_revision,
+            (
+                state,
+                Vec::new(),
+                legal_actions,
+                Vec::new(),
+                auto_pass,
+                spell_costs,
+                by_object,
+            ),
+        )
+    }
     /// Allocates the revision for one completed authoritative state transition.
     pub fn advance_state_revision(&mut self) -> u64 {
         self.state_revision = self.state_revision.saturating_add(1);
@@ -676,6 +747,9 @@ impl GameSession {
     }
 
     pub fn apply_seat_delta(&mut self, new_state: SeatState, delta: &SeatDelta, db: &CardDatabase) {
+        if self.ai_driver_fault.is_some() {
+            return;
+        }
         let old_player_count = self.player_count;
         let new_player_count = new_state.seats.len() as u8;
 
@@ -820,6 +894,11 @@ impl GameSession {
     }
 
     pub fn start_game(&mut self, db: &CardDatabase) -> Result<(), CedhBracketError> {
+        // A faulted game is never restarted in place: doing so would create a
+        // new playable state behind the durable terminal fault record.
+        if self.ai_driver_fault.is_some() {
+            return Ok(());
+        }
         // Gate: if any AI seat is configured for cEDH difficulty, validate that
         // every submitted deck is declared at the cEDH bracket tier before
         // mutating any session state.
@@ -901,10 +980,18 @@ impl GameSession {
     /// to. Every call site (join-fills-the-room, reconnect, fresh AI-game
     /// creation) is gated here once rather than at each caller.
     pub fn run_ai(&mut self) -> AiRunOutcome {
+        if let Some(fault) = self.ai_driver_fault.clone() {
+            return AiRunOutcome {
+                transitions: Vec::new(),
+                failure: None,
+                fault: Some(fault),
+            };
+        }
         if self.ai_seats.is_empty() || self.pending_takeback.is_some() {
             return AiRunOutcome {
                 transitions: Vec::new(),
                 failure: None,
+                fault: None,
             };
         }
 
@@ -954,24 +1041,36 @@ impl GameSession {
             match batch.stop {
                 AiActionsStop::NoEligibleAiActor | AiActionsStop::ActionBudgetReached { .. } => {}
                 AiActionsStop::MissingAiConfig { player } => {
+                    let failure = AiDriverFailure::MissingAiConfig { player };
+                    let fault = self.record_ai_driver_fault(failure.clone());
+                    transitions.push(self.ai_driver_fault_transition(&fault));
                     return AiRunOutcome {
                         transitions,
-                        failure: Some(AiDriverFailure::MissingAiConfig { player }),
+                        failure: Some(failure),
+                        fault: Some(fault),
                     };
                 }
                 AiActionsStop::ChooseActionNone { player } => {
+                    let failure = AiDriverFailure::ChooseActionNone { player };
+                    let fault = self.record_ai_driver_fault(failure.clone());
+                    transitions.push(self.ai_driver_fault_transition(&fault));
                     return AiRunOutcome {
                         transitions,
-                        failure: Some(AiDriverFailure::ChooseActionNone { player }),
+                        failure: Some(failure),
+                        fault: Some(fault),
                     };
                 }
                 AiActionsStop::ApplyFailed { player, error, .. } => {
+                    let failure = AiDriverFailure::ApplyFailed {
+                        player,
+                        error: error.to_string(),
+                    };
+                    let fault = self.record_ai_driver_fault(failure.clone());
+                    transitions.push(self.ai_driver_fault_transition(&fault));
                     return AiRunOutcome {
                         transitions,
-                        failure: Some(AiDriverFailure::ApplyFailed {
-                            player,
-                            error: error.to_string(),
-                        }),
+                        failure: Some(failure),
+                        fault: Some(fault),
                     };
                 }
                 AiActionsStop::ActionSafetyCapReached { limit } => {
@@ -1009,9 +1108,16 @@ impl GameSession {
                 .filter(|_| self.ai_seat_can_act())
                 .map(|limit| AiDriverFailure::ActionSafetyCapReached { limit })
         };
+        let fault = failure
+            .clone()
+            .map(|failure| self.record_ai_driver_fault(failure));
+        if let Some(fault) = &fault {
+            transitions.push(self.ai_driver_fault_transition(fault));
+        }
         AiRunOutcome {
             transitions,
             failure,
+            fault,
         }
     }
 
@@ -1184,6 +1290,8 @@ impl GameSession {
         PersistedSession {
             game_code: self.game_code.clone(),
             state_revision: self.state_revision,
+            ai_driver_fault: self.ai_driver_fault.clone(),
+            next_ai_driver_fault_id: self.next_ai_driver_fault_id,
             state: PersistedGameState::capture(self.state.clone()),
             player_tokens: self.player_tokens.clone(),
             display_names: self.display_names.clone(),
@@ -1271,6 +1379,8 @@ impl GameSession {
             game_code: ps.game_code,
             full_runtime: None,
             state_revision: ps.state_revision,
+            ai_driver_fault: ps.ai_driver_fault,
+            next_ai_driver_fault_id: ps.next_ai_driver_fault_id.max(1),
             state,
             player_tokens: ps.player_tokens,
             connected: vec![false; pc],
@@ -1444,6 +1554,8 @@ impl SessionManager {
             game_code: game_code.clone(),
             full_runtime: None,
             state_revision: 0,
+            ai_driver_fault: None,
+            next_ai_driver_fault_id: 1,
             state,
             player_tokens,
             connected,
@@ -1505,6 +1617,8 @@ impl SessionManager {
             .sessions
             .get_mut(game_code)
             .ok_or_else(|| format!("Game not found: {}", game_code))?;
+
+        session.reject_if_ai_driver_faulted()?;
         session.cleanup_expired_reservations();
         if session.game_started {
             return Err("Game has already started".to_string());
@@ -1670,6 +1784,7 @@ impl SessionManager {
             .sessions
             .get(game_code)
             .ok_or_else(|| format!("Game not found: {game_code}"))?;
+        session.reject_if_ai_driver_faulted()?;
         let player = session
             .player_for_token(player_token)
             .ok_or_else(|| "Invalid player token".to_string())?;
@@ -1705,6 +1820,8 @@ impl SessionManager {
             .sessions
             .get_mut(game_code)
             .ok_or_else(|| format!("Game not found: {}", game_code))?;
+
+        session.reject_if_ai_driver_faulted()?;
 
         let player = session
             .player_for_token(player_token)
@@ -1902,6 +2019,7 @@ impl SessionManager {
             .sessions
             .get_mut(game_code)
             .ok_or_else(|| format!("Game not found: {game_code}"))?;
+        session.reject_if_ai_driver_faulted()?;
         let requester = session
             .player_for_token(player_token)
             .ok_or_else(|| "Invalid player token".to_string())?;
@@ -2000,6 +2118,8 @@ impl SessionManager {
             .sessions
             .get_mut(game_code)
             .ok_or_else(|| format!("Game not found: {game_code}"))?;
+
+        session.reject_if_ai_driver_faulted()?;
 
         let player = session
             .player_for_token(player_token)
@@ -5525,6 +5645,8 @@ mod tests {
             game_code: "TEST01".to_string(),
             full_runtime: None,
             state_revision: 0,
+            ai_driver_fault: None,
+            next_ai_driver_fault_id: 1,
             state,
             player_tokens: vec!["host_token".to_string(), String::new()],
             connected: vec![true, true],

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -32,6 +32,7 @@ use engine::types::mana::ManaCost;
 use engine::types::match_config::MatchConfig;
 use engine::types::match_config::MatchForfeitCause;
 use engine::types::player::PlayerId;
+use phase_ai::auto_play::AiActionsStop;
 use phase_ai::config::{AiConfig, AiDifficulty, Platform};
 use phase_ai::session::AiSession;
 use rand::{Rng, SeedableRng};
@@ -97,6 +98,64 @@ pub type ActionResult = (
 /// allocated while the session lock was held. The transport must keep this
 /// pairing intact when it fans a snapshot out to multiple viewers.
 pub type RevisionedActionResult = (u64, ActionResult);
+
+/// The server-visible result of driving the native AI after an authoritative
+/// transition. A non-empty `failure` is terminal for the AI driver, but does
+/// not discard transitions that were already committed before that failure.
+#[derive(Debug)]
+pub struct AiRunOutcome {
+    pub transitions: Vec<RevisionedActionResult>,
+    pub failure: Option<AiDriverFailure>,
+}
+
+/// Internal result of one uninterrupted AI decision batch. Keeping the exact
+/// stop reason until [`GameSession::run_ai`] has consumed a possible
+/// AI-produced Resolve All latch is necessary: a safety cap is terminal only
+/// when an AI submitter is still eligible in the resulting state.
+struct AiActionBatch {
+    transitions: Vec<RevisionedActionResult>,
+    stop: AiActionsStop,
+}
+
+#[derive(Debug)]
+pub enum AiDriverFailure {
+    MissingAiConfig { player: PlayerId },
+    ChooseActionNone { player: PlayerId },
+    ApplyFailed { player: PlayerId, error: String },
+    ActionSafetyCapReached { limit: usize },
+    ResolveAllHandoffSafetyCapReached { limit: usize },
+}
+
+impl AiDriverFailure {
+    pub fn message(&self) -> String {
+        match self {
+            Self::MissingAiConfig { player } => {
+                format!(
+                    "Native AI driver is missing configuration for player {}.",
+                    player.0
+                )
+            }
+            Self::ChooseActionNone { player } => {
+                format!(
+                    "Native AI could not choose an action for player {}.",
+                    player.0
+                )
+            }
+            Self::ApplyFailed { player, error } => {
+                format!(
+                    "Native AI action for player {} was rejected: {error}",
+                    player.0
+                )
+            }
+            Self::ActionSafetyCapReached { limit } => {
+                format!("Native AI stopped after its {limit}-action safety limit.")
+            }
+            Self::ResolveAllHandoffSafetyCapReached { limit } => {
+                format!("Native AI Resolve All hand-off stopped after {limit} iterations.")
+            }
+        }
+    }
+}
 
 /// Maximum server-authorized stack entries in one remote Resolve All request.
 /// The wire request is untrusted, but `0` remains the engine-defined uncapped
@@ -841,13 +900,17 @@ impl GameSession {
     /// turn — out from under the snapshot the table is voting to roll back
     /// to. Every call site (join-fills-the-room, reconnect, fresh AI-game
     /// creation) is gated here once rather than at each caller.
-    pub fn run_ai(&mut self) -> Vec<RevisionedActionResult> {
+    pub fn run_ai(&mut self) -> AiRunOutcome {
         if self.ai_seats.is_empty() || self.pending_takeback.is_some() {
-            return vec![];
+            return AiRunOutcome {
+                transitions: Vec::new(),
+                failure: None,
+            };
         }
 
         let mut transitions = Vec::new();
         let mut handoffs = 0usize;
+        let mut action_safety_cap = None;
         // One pass per Resolve All latch our own AI seats complete. Collapsing
         // that batch hands priority back — possibly to another AI seat — so the
         // ordinary hand-off has to run again, exactly as `handle_resolve_all`
@@ -857,9 +920,7 @@ impl GameSession {
         // is a backstop, not the terminating argument.
         for _ in 0..MAX_AI_RESOLVE_ALL_HANDOFFS {
             let batch = self.run_ai_action_batch();
-            if batch.is_empty() {
-                break;
-            }
+            let batch_empty = batch.transitions.is_empty();
             // POSITIVE evidence that the final Grant was ours: one of the
             // actions we just applied left the game at Ready. Each entry's
             // state is the post-action clone, so a latch minted by this batch
@@ -886,10 +947,40 @@ impl GameSession {
             // compare each entry against its predecessor instead: entry `i`
             // minted the latch iff its post-state is Ready and the state before
             // it was not Ready at that epoch.
-            let minted_here = batch.iter().any(|(_, (post_state, ..))| {
+            let minted_here = batch.transitions.iter().any(|(_, (post_state, ..))| {
                 matches!(post_state.waiting_for, WaitingFor::ResolveAllReady { .. })
             });
-            transitions.extend(batch);
+            transitions.extend(batch.transitions);
+            match batch.stop {
+                AiActionsStop::NoEligibleAiActor | AiActionsStop::ActionBudgetReached { .. } => {}
+                AiActionsStop::MissingAiConfig { player } => {
+                    return AiRunOutcome {
+                        transitions,
+                        failure: Some(AiDriverFailure::MissingAiConfig { player }),
+                    };
+                }
+                AiActionsStop::ChooseActionNone { player } => {
+                    return AiRunOutcome {
+                        transitions,
+                        failure: Some(AiDriverFailure::ChooseActionNone { player }),
+                    };
+                }
+                AiActionsStop::ApplyFailed { player, error, .. } => {
+                    return AiRunOutcome {
+                        transitions,
+                        failure: Some(AiDriverFailure::ApplyFailed {
+                            player,
+                            error: error.to_string(),
+                        }),
+                    };
+                }
+                AiActionsStop::ActionSafetyCapReached { limit } => {
+                    action_safety_cap = Some(limit);
+                }
+            }
+            if batch_empty {
+                break;
+            }
             if !minted_here {
                 break;
             }
@@ -904,18 +995,28 @@ impl GameSession {
         // seats that may still be able to act and nothing left to re-drive
         // them, which is the hang class this hand-off exists to prevent, so it
         // must be diagnosable rather than silent.
-        if handoffs == MAX_AI_RESOLVE_ALL_HANDOFFS {
+        let failure = if handoffs == MAX_AI_RESOLVE_ALL_HANDOFFS && self.ai_seat_can_act() {
             warn!(
                 game = %self.game_code,
                 cap = MAX_AI_RESOLVE_ALL_HANDOFFS,
                 "AI Resolve All hand-off hit its iteration cap"
             );
+            Some(AiDriverFailure::ResolveAllHandoffSafetyCapReached {
+                limit: MAX_AI_RESOLVE_ALL_HANDOFFS,
+            })
+        } else {
+            action_safety_cap
+                .filter(|_| self.ai_seat_can_act())
+                .map(|limit| AiDriverFailure::ActionSafetyCapReached { limit })
+        };
+        AiRunOutcome {
+            transitions,
+            failure,
         }
-        transitions
     }
 
     /// One uninterrupted run of AI decisions from the current state.
-    fn run_ai_action_batch(&mut self) -> Vec<RevisionedActionResult> {
+    fn run_ai_action_batch(&mut self) -> AiActionBatch {
         let mut rng = rand::rng();
         let ai_session = self
             .ai_session
@@ -932,7 +1033,10 @@ impl GameSession {
             debug!(game = %self.game_code, ai_actions = ai_results.len(), "AI actions computed");
         }
 
-        ai_results
+        let stop = ai_results.stop;
+
+        let transitions = ai_results
+            .results
             .into_iter()
             .map(|r| {
                 let (legal, spell_costs, by_object) = engine_legal_actions_full(&r.state);
@@ -957,7 +1061,15 @@ impl GameSession {
                     ),
                 )
             })
-            .collect()
+            .collect();
+
+        AiActionBatch { transitions, stop }
+    }
+
+    fn ai_seat_can_act(&self) -> bool {
+        acting_players(&self.state)
+            .into_iter()
+            .any(|player| self.ai_seats.contains(&player))
     }
 
     /// Consumes a `WaitingFor::ResolveAllReady` latch this session's own AI
@@ -3536,7 +3648,7 @@ mod tests {
         let state_before = session.state.clone();
         let ai_results = session.run_ai();
         assert!(
-            ai_results.is_empty(),
+            ai_results.transitions.is_empty(),
             "run_ai must no-op while a takeback vote is pending, even though the AI seat has a legal action"
         );
         assert_eq!(
@@ -4154,6 +4266,34 @@ mod tests {
         (mgr, code, token0, ai_seat)
     }
 
+    #[test]
+    fn ai_driver_failure_gate_requires_an_authorized_ai_submitter() {
+        let (mut mgr, code, _token0, ai_seat) = single_user_game_vs_ai();
+        let session = mgr.sessions.get_mut(&code).unwrap();
+
+        session.state.waiting_for = WaitingFor::Priority { player: ai_seat };
+        assert!(
+            session.ai_seat_can_act(),
+            "an AI priority holder must keep a capped driver diagnosable"
+        );
+
+        session.state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+        assert!(
+            !session.ai_seat_can_act(),
+            "a human priority holder is a normal hand-off, not an AI driver failure"
+        );
+
+        session.state.waiting_for = WaitingFor::GameOver {
+            winner: Some(ai_seat),
+        };
+        assert!(
+            !session.ai_seat_can_act(),
+            "a terminal state cannot be reported as an AI driver stall"
+        );
+    }
+
     /// Drives the fixture until **`run_ai` itself** publishes a turn boundary
     /// whose active player is the AI seat, and returns that turn number.
     ///
@@ -4187,7 +4327,7 @@ mod tests {
             });
             if let Some(option) = gained {
                 assert!(
-                    !ai_results.is_empty(),
+                    !ai_results.transitions.is_empty(),
                     "a boundary appeared across a `run_ai` call that returned nothing — \
                      the fixture is not measuring what it claims to"
                 );
@@ -4283,7 +4423,7 @@ mod tests {
         let waiting_before = session.state.waiting_for.clone();
         let resumed = session.run_ai();
         assert!(
-            !resumed.is_empty(),
+            !resumed.transitions.is_empty(),
             "a rewind onto an AI-active boundary must resume the AI, not freeze the game"
         );
         assert_ne!(
@@ -4310,7 +4450,7 @@ mod tests {
         let waiting_before = session.state.waiting_for.clone();
         let turn_before = session.state.turn_number;
         assert!(
-            session.run_ai().is_empty(),
+            session.run_ai().transitions.is_empty(),
             "with the human on priority the AI has nothing to do"
         );
         assert_eq!(session.state.waiting_for, waiting_before, "state unchanged");
@@ -6420,6 +6560,7 @@ mod tests {
         // reached, by reading the grant's own broadcast frame.
         assert!(
             transitions
+                .transitions
                 .iter()
                 .any(|(_, (broadcast_state, ..))| matches!(
                     broadcast_state.waiting_for,
@@ -6497,11 +6638,14 @@ mod tests {
         // follow-up AI batch can append further transitions, so asserting only
         // on the last one would pass without the collapse frame ever existing.
         assert!(
-            transitions.len() >= 2,
+            transitions.transitions.len() >= 2,
             "expected the AI grant and the collapsed batch, got {}",
-            transitions.len()
+            transitions.transitions.len()
         );
-        let (_, (granted_state, ..)) = transitions.first().expect("the AI grant transition");
+        let (_, (granted_state, ..)) = transitions
+            .transitions
+            .first()
+            .expect("the AI grant transition");
         assert_eq!(
             granted_state.stack.len(),
             1,
@@ -6509,6 +6653,7 @@ mod tests {
         );
         assert!(
             transitions
+                .transitions
                 .iter()
                 .any(|(_, (broadcast_state, ..))| broadcast_state.stack.is_empty()),
             "no broadcast frame carried the post-collapse state"
@@ -6604,7 +6749,7 @@ mod tests {
         // It becomes testable when that changes; until then, do not add a pin
         // that only appears to cover it.
         assert!(
-            session.run_ai().is_empty(),
+            session.run_ai().transitions.is_empty(),
             "no AI seat may act at a latch with no acting player"
         );
         assert!(

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -140,7 +140,10 @@ pub enum AiDriverFailure {
 #[serde(rename_all = "snake_case")]
 pub struct AiDriverFault {
     pub id: u64,
-    pub state_revision: u64,
+    /// The last state revision a client must have applied before rendering
+    /// this out-of-band driver failure. The session revision is then bumped
+    /// separately as a durable persistence fence.
+    pub after_state_revision: u64,
     pub cause: AiDriverFailure,
 }
 
@@ -428,7 +431,7 @@ impl GameSession {
         self.ai_driver_fault.as_ref()
     }
 
-    fn reject_if_ai_driver_faulted(&self) -> Result<(), String> {
+    pub(crate) fn reject_if_ai_driver_faulted(&self) -> Result<(), String> {
         self.ai_driver_fault
             .as_ref()
             .map(|fault| {
@@ -447,29 +450,17 @@ impl GameSession {
         }
         let fault = AiDriverFault {
             id: self.next_ai_driver_fault_id,
-            state_revision: self.advance_state_revision(),
+            after_state_revision: self.state_revision,
             cause,
         };
+        // Allocate a fresh persistence revision without inventing a state
+        // transition for clients to render. This lets the database fence the
+        // durable fault while delivery remains ordered after the last actual
+        // state frame.
+        self.advance_state_revision();
         self.next_ai_driver_fault_id = self.next_ai_driver_fault_id.saturating_add(1);
         self.ai_driver_fault = Some(fault.clone());
         fault
-    }
-
-    fn ai_driver_fault_transition(&self, fault: &AiDriverFault) -> RevisionedActionResult {
-        let (state, legal_actions, auto_pass, spell_costs, by_object) =
-            self.current_broadcast_snapshot();
-        (
-            fault.state_revision,
-            (
-                state,
-                Vec::new(),
-                legal_actions,
-                Vec::new(),
-                auto_pass,
-                spell_costs,
-                by_object,
-            ),
-        )
     }
     /// Allocates the revision for one completed authoritative state transition.
     pub fn advance_state_revision(&mut self) -> u64 {
@@ -1043,7 +1034,6 @@ impl GameSession {
                 AiActionsStop::MissingAiConfig { player } => {
                     let failure = AiDriverFailure::MissingAiConfig { player };
                     let fault = self.record_ai_driver_fault(failure.clone());
-                    transitions.push(self.ai_driver_fault_transition(&fault));
                     return AiRunOutcome {
                         transitions,
                         failure: Some(failure),
@@ -1053,7 +1043,6 @@ impl GameSession {
                 AiActionsStop::ChooseActionNone { player } => {
                     let failure = AiDriverFailure::ChooseActionNone { player };
                     let fault = self.record_ai_driver_fault(failure.clone());
-                    transitions.push(self.ai_driver_fault_transition(&fault));
                     return AiRunOutcome {
                         transitions,
                         failure: Some(failure),
@@ -1066,7 +1055,6 @@ impl GameSession {
                         error: error.to_string(),
                     };
                     let fault = self.record_ai_driver_fault(failure.clone());
-                    transitions.push(self.ai_driver_fault_transition(&fault));
                     return AiRunOutcome {
                         transitions,
                         failure: Some(failure),
@@ -1111,9 +1099,6 @@ impl GameSession {
         let fault = failure
             .clone()
             .map(|failure| self.record_ai_driver_fault(failure));
-        if let Some(fault) = &fault {
-            transitions.push(self.ai_driver_fault_transition(fault));
-        }
         AiRunOutcome {
             transitions,
             failure,
@@ -2213,6 +2198,7 @@ impl SessionManager {
         let player = session
             .player_for_token(player_token)
             .ok_or_else(|| "Invalid player token".to_string())?;
+        session.reject_if_ai_driver_faulted()?;
         if session.pending_takeback.is_some() {
             return Err(
                 "A takeback request is pending — resolve it before conceding the match".to_string(),
@@ -4412,6 +4398,57 @@ mod tests {
             !session.ai_seat_can_act(),
             "a terminal state cannot be reported as an AI driver stall"
         );
+    }
+
+    #[test]
+    fn ai_driver_fault_fences_persistence_without_synthetic_state_transition() {
+        let (mut mgr, code, _token0, ai_seat) = single_user_game_vs_ai();
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        session.ai_configs.remove(&ai_seat);
+        session.state.waiting_for = WaitingFor::Priority { player: ai_seat };
+        let before = session.state_revision;
+
+        let outcome = session.run_ai();
+
+        assert!(outcome.transitions.is_empty());
+        assert!(matches!(
+            outcome.failure,
+            Some(AiDriverFailure::MissingAiConfig { player }) if player == ai_seat
+        ));
+        let fault = outcome
+            .fault
+            .expect("missing configuration records a fault");
+        assert_eq!(fault.after_state_revision, before);
+        assert_eq!(session.state_revision, before + 1);
+        assert_eq!(
+            session.to_persisted().state_revision,
+            before + 1,
+            "the durable snapshot must be fenced beyond the last delivered state"
+        );
+    }
+
+    #[test]
+    fn ai_driver_fault_blocks_takebacks_and_match_concede() {
+        let (mut mgr, code, token0, _ai_seat) = single_user_game_vs_ai();
+        let session = mgr.sessions.get_mut(&code).unwrap();
+        session.record_ai_driver_fault(AiDriverFailure::ActionSafetyCapReached { limit: 1 });
+
+        for result in [
+            session
+                .request_takeback(PlayerId(0), RewindTarget::LastAction)
+                .map(|_| ()),
+            session.respond_takeback(PlayerId(0), true).map(|_| ()),
+            session.cancel_takeback(PlayerId(0)),
+        ] {
+            assert!(result
+                .expect_err("a terminal AI driver fault blocks takeback mutation")
+                .contains("Native AI driver fault"));
+        }
+
+        let err = mgr
+            .handle_match_concede(&code, &token0)
+            .expect_err("a terminal AI driver fault blocks match concede");
+        assert!(err.contains("Native AI driver fault"));
     }
 
     /// Drives the fixture until **`run_ai` itself** publishes a turn boundary

--- a/crates/server-core/src/takeback.rs
+++ b/crates/server-core/src/takeback.rs
@@ -326,6 +326,7 @@ impl GameSession {
         player: PlayerId,
         target: RewindTarget,
     ) -> Result<TakebackOutcome, String> {
+        self.reject_if_ai_driver_faulted()?;
         if self.pending_takeback.is_some() {
             return Err("A takeback request is already pending for this game".to_string());
         }
@@ -389,6 +390,7 @@ impl GameSession {
         player: PlayerId,
         approve: bool,
     ) -> Result<TakebackOutcome, String> {
+        self.reject_if_ai_driver_faulted()?;
         if self.pending_takeback.is_none() {
             return Err("There is no pending takeback request".to_string());
         }
@@ -411,6 +413,7 @@ impl GameSession {
 
     /// The original requester withdraws their own pending takeback request.
     pub fn cancel_takeback(&mut self, player: PlayerId) -> Result<(), String> {
+        self.reject_if_ai_driver_faulted()?;
         match &self.pending_takeback {
             Some(pending) if pending.requested_by == player => {
                 self.pending_takeback = None;

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 33;
+const EXPECTED_PROTOCOL_VERSION = 34;
 // The LOBBY message-set version. Deliberately separate from the full-game
 // number above and deliberately NOT derived from it: a GameState-only bump must
 // not move the lobby's compatibility window. See the assertions at the bottom.


### PR DESCRIPTION
- **refactor(draft-core): make DraftProcedure the single authority for per-kind axes**
- **refactor(draft-core): make a new PackDistribution an E0004, not a silent else**
- **feat(draft): add Commander Draft (CR 903.13) and the two-card pick step**
- **refactor(draft): correct two comments that called a reachable path unreachable**
- **feat(engine): type the deck-size rule and add the Commander Draft format**
- **docs(engine): correct the commander-damage rule and refresh fixture provenance**
- **docs(engine): refresh the three remaining stale fixture provenance rows**
- **docs(engine): the dina phase5 recipe is necessary but no longer sufficient**
- **fix(scripts): refuse to emit a fixture with an untagged deck_size**
- **test(scripts): make the deck-size gate fail when it is broken**
- **test(scripts): exercise the shape clauses the last commit only claimed to**
- **docs(scripts): cite the EffectKind precedent for what it decided**
- **docs(scripts): drop two counts that do not reproduce as written**
- **feat(client): name the targeting prompt's subject and bound its height**
- **feat(engine): enforce Commander Draft deck legality and the CMM partner grant**
- **chore(changelog): publish entry #196**
- **fix(engine): suppress the singleton rule on the summary path too**
- **feat(protocol): make Commander Draft reachable across both wire encodings**
- **fix(draft-wasm): assert the procedure DTO copies every axis unmoved**
- **feat(client): give Commander Draft a reachable entry point**
- **refactor(client): keep the draft-pod graph off the landing route**
- **docs(client): cite an Aura that can actually enchant a player**
- **fix(server): surface native AI driver stalls**
- **fix(native): relay AI driver failures**
- **fix(native): preserve fault delivery ordering**
- **fix(native): replay AI faults to reconnecting guests**
- **fix(native): notify resumed hosts of AI faults**
- **test(native): cover resumed AI fault ordering**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added durable native AI fault reporting across gameplay, reconnections, and session recovery.
  * Faults include an identifier, revision, and explanatory message.
  * Persisted sessions retain AI fault information across restarts.

* **Bug Fixes**
  * Faulted sessions now block further gameplay changes.
  * Prevented duplicate or out-of-order fault notifications.
  * Improved AI stop handling for limits, missing configuration, unavailable choices, and failed actions.
  * Spectators can continue loading after snapshot errors.

* **Compatibility**
  * Updated game and lobby protocol versions to support AI fault messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->