### PR TITLE
docs: swiss-pairing tournament organizer design proposal (discussion #5314)

### DIFF
--- a/docs/proposals/tournament-organizer/CONTEXT.md
+++ b/docs/proposals/tournament-organizer/CONTEXT.md
@@ -61,13 +61,23 @@ otherwise — findings marked "UPDATED" or "NEW" were re-verified or newly
 found against current `main` in a later pass. See RESEARCH.md for exact
 file:line evidence.
 
-1. **Greenfield, confirmed.** No `tournament.rs`, `TournamentManager`, or any
-   tournament-related type exists anywhere in `crates/lobby-broker/src/` (or
-   elsewhere in the workspace) on `main` today. `ls crates/lobby-broker/src/`
-   shows only `broker.rs`, `env.rs`, `inbound_guard.rs`, `lib.rs`, `lobby.rs`,
-   `protocol.rs`, `reservation_auth.rs`, `validation.rs`. #4615 was closed
-   without merging, so none of its work landed. This is a true from-scratch
-   design, not a partially-built stub.
+1. **Greenfield within `lobby-broker` specifically, confirmed — REVISED,
+   maintainer review: the original wording overreached to "or elsewhere in
+   the workspace," which contradicts finding #8's own `draft-core` citation
+   below and is corrected here, not merely reworded.** No `tournament.rs`,
+   `TournamentManager`, or any lobby-scoped tournament type exists anywhere
+   in `crates/lobby-broker/src/` on `main` today. `ls
+   crates/lobby-broker/src/` shows only `broker.rs`, `env.rs`,
+   `inbound_guard.rs`, `lib.rs`, `lobby.rs`, `protocol.rs`,
+   `reservation_auth.rs`, `validation.rs`. #4615 was closed without
+   merging, so none of its `lobby-broker`-side work landed. This crate's
+   `TournamentManager` is a true from-scratch design, not a partially-built
+   stub — but `crates/draft-core` DOES already have a working, tested
+   Swiss-pairing implementation for a different purpose (draft-pod
+   mini-tournaments, finding #8 below) that this proposal explicitly draws
+   on as prior art. Do not read this finding as "no tournament-pairing code
+   exists in the workspace" — only "none exists in `lobby-broker`,"  which
+   is the crate this proposal actually adds to.
 
 2. **`LobbyManager` + `Broker::handle` + `ConnState` + functional-core pattern
    — confirmed exactly as described.** `crates/lobby-broker/src/lobby.rs:96`

--- a/docs/proposals/tournament-organizer/CONTEXT.md
+++ b/docs/proposals/tournament-organizer/CONTEXT.md
@@ -261,13 +261,25 @@ file:line evidence.
      the same shape is an implementation-time call PR 1 should make
      explicitly, not leave implicit.
 
-9. **NEW — Commander/multiplayer pod tournaments are governed by a separate,
-   official ruleset (the Multiplayer Addendum to the MTR, referred to here
-   as "MSTR") with different scoring, tiebreak, and pairing conventions than
-   1v1 — not just a bigger pod on the same math.** Fetched directly this
-   session (juizes-mtg-portugal.github.io's mirror, cross-referenced against
-   BeNeLux cEDH's mirror and TopDeck.gg's own addendum page — full citations
-   in RESEARCH.md §13), not paraphrased from memory:
+9. **NEW — Commander/multiplayer pod tournaments are governed by a separate
+   convention (the "Multiplayer Addendum to the MTR," referred to here as
+   "MSTR") with different scoring, tiebreak, and pairing rules than 1v1 —
+   not just a bigger pod on the same math. CORRECTED, maintainer review:
+   this is an unofficial, independent-judge-authored document, NOT a
+   Wizards of the Coast publication — the source page's own disclaimer
+   says so explicitly, and this proposal's earlier framing ("official
+   ruleset," "mirror of the official text") was wrong to imply Wizards
+   authorship.** It fills a real gap (the official MTR has no multiplayer
+   section of its own) as a widely-adopted community convention this
+   proposal deliberately chooses to follow, not an official rule this
+   proposal is merely restating. Fetched directly this session
+   (juizes-mtg-portugal.github.io — Portuguese judge community — its own
+   page states "This is an unofficial rules document written by
+   independent judges. This is not official Wizards of the Coast
+   documentation"), cross-referenced against BeNeLux cEDH's own community
+   copy and TopDeck.gg's reference copy — full citations in RESEARCH.md
+   §13 — not paraphrased from memory, and not claimed as anything more
+   authoritative than what it actually is:
    - **Scoring generalizes cleanly, not by coincidence**: MSTR's win-point
      formula is `2n - 1` for pod size `n` — 7 points for a 4-player pod's
      win. At `n = 2` this is exactly `3`, the MTR §2.1 value #5312 already
@@ -282,8 +294,9 @@ file:line evidence.
      *same* formula, `1 / win_points`, evaluated at each ruleset's own
      `win_points` — another clean unification, unlike the tiebreak order
      itself.
-   - **Pairing is officially non-backtracking, independently confirming
-     finding #8's recommendation.** MSTR's own algorithm is top-to-bottom
+   - **Pairing is non-backtracking in MSTR's own convention too,
+     independently confirming finding #8's recommendation.** MSTR's own
+     algorithm is top-to-bottom
      assignment by current standing, with an iterative *swap* repair step
      for players who can't be placed without a rematch — no recursive
      search, no base case to get wrong. This is the same algorithmic

--- a/docs/proposals/tournament-organizer/CONTEXT.md
+++ b/docs/proposals/tournament-organizer/CONTEXT.md
@@ -127,6 +127,21 @@ file:line evidence.
    `LOBBY_PROTOCOL_VERSION`, currently 1, not the unrelated
    `PROTOCOL_VERSION`, currently 33."
 
+   **Re-verified again — maintainer review caught that PLAN.md's PR 2 text
+   was never actually updated to match this finding's own retraction above,
+   and that current `main` has moved further still.** As of commit
+   `d9c2a7874` (checked directly this pass): `PROTOCOL_VERSION = 35`
+   (`protocol.rs:110`), `LOBBY_PROTOCOL_VERSION = 1`, unchanged since #1880
+   (`protocol.rs:139`) — both numbers already stale relative to what this
+   finding cited above (33/1), confirming these are fast-moving constants
+   that will have moved again by whenever this proposal is actually
+   implemented. **The durable takeaway is the architectural rule, not any
+   specific number**: bump `LOBBY_PROTOCOL_VERSION` by one from its
+   then-current value at implementation time, never `PROTOCOL_VERSION`.
+   PLAN.md §4's PR 2 description is corrected to state the rule this way
+   rather than citing a number that will be wrong again by the time anyone
+   reads it.
+
 5. **The Cloudflare Worker `is_empty()` predicate genuinely only checks lobby
    games today — bug #4 in the discussion is real and reproducible against
    current `main`.** `lobby-worker/broker-wasm/src/lib.rs:168-170`:
@@ -355,15 +370,17 @@ verification pass — nothing found this session resolves them unilaterally:
    pairing), with full-mode integration as an explicit fast-follow. Confirmed
    this matches #4612's original framing exactly, and nothing found this
    session suggests otherwise. Recommend confirming as stated.
-4. **NEW — does v1 need Commander single-elimination bracket play, or only
-   Commander Swiss?** MSTR's own round-count table only calls for Swiss +
-   Top-4/7/10/13/16 single-elimination cuts once the Swiss rounds finish
-   (finding #9) — it doesn't describe a *pure* SE bracket built from 4-player
-   pods the way 1v1's existing adjacent-pair SE path works. This session's
-   recommendation (PLAN.md §2): treat pod-based SE as a natural but
-   unimplemented-in-v1-detail extension of the existing arity-gated SE path,
-   not block Commander Swiss support on designing it fully now — but this is
-   a product-scope call for the maintainer, not decided unilaterally here.
+4. ~~**Does v1 need Commander single-elimination bracket play, or only
+   Commander Swiss?**~~ — **RESOLVED, maintainer review: excluded from v1.**
+   This session's earlier recommendation (treat pod-based SE as a natural,
+   undesigned-in-detail extension of the existing arity-gated SE path) was
+   correctly rejected — "in-scope but undesigned" isn't a real resolution
+   of a genuine open design question (bracket/advancement semantics for a
+   multi-player pod bracket are not a mechanical extension of 1v1's
+   adjacent-pair SE). Final: `BracketShape::SingleElimination` ships for
+   `arity = HEAD_TO_HEAD` only in v1; `CreateTournament` rejects
+   `SingleElimination` + `arity != HEAD_TO_HEAD` at construction time.
+   Commander/multiplayer pods get Swiss only. See PLAN.md §2 and §5.
 
 ## Relationship to adjacent work — scope boundaries
 

--- a/docs/proposals/tournament-organizer/CONTEXT.md
+++ b/docs/proposals/tournament-organizer/CONTEXT.md
@@ -1,0 +1,413 @@
+# Phase 61 — Swiss-Pairing Tournament Organizer — CONTEXT
+
+## Why this matters
+
+phase.rs has rich casual matchmaking (`lobby-broker`) but no support for
+organized multi-round events. Running a Swiss tournament for a playgroup today
+means tracking pairings and standings by hand outside the app. This has
+already been proposed once (issue **phase-rs/phase#4612**), attempted once
+(PR **phase-rs/phase#4615**, closed unmerged after review found real bugs —
+not because the architecture was wrong), and is now being picked back up via a
+second design pass, GitHub Discussion **phase-rs/phase#5314**, which grounds
+the scoring/tiebreaker rules in the actual current Magic Tournament Rules
+(MTR, effective 2026-02-27) instead of inventing convention from memory.
+
+This document is a from-scratch, independent verification of every
+repo-architecture claim in #5314 against the code actually on `main` today,
+plus the real (not paraphrased) review findings from #4615, plus an informed
+opinion on whether tournament scoring policy should hook into the sibling
+custom-format-engine research effort (phase 58).
+
+**Bottom line up front: the discussion's architecture claims all check out.**
+Nothing in #5314 mischaracterizes the codebase in a way that would change the
+proposed design. One phrase ("the existing `lobby_subscribers` broadcast
+channel") is imprecise about which crate that channel actually lives in, but
+the underlying mechanism it's pointing at is real and the proposed reuse is
+still correct. Full citations are in RESEARCH.md; this file is the synthesis.
+
+**Scope expansion (this update, per direct instruction): this design must
+cover both head-to-head (Standard/Modern/etc.) and Commander/multiplayer pod
+tournaments, not head-to-head only.** Every design section up to this point
+implicitly assumed 2 players per pairing — the Swiss algorithm pairs, the
+`ScoringPolicy`/tiebreak math assumes a winner-vs-loser binary, and the
+single-elimination path is an adjacent-pair bracket. None of that is wrong
+for what it covers; it just doesn't cover Commander pods (typically 4
+players per match, one winner, MTR's own dedicated Multiplayer Addendum
+governing scoring/tiebreaks/pairing differently from 1v1). This pass adds
+finding #9 below (the Multiplayer Addendum to the MTR, "MSTR" — full detail
+in RESEARCH.md §13) and generalizes PLAN.md's pairing/scoring/tiebreak
+design over a new `MatchArity` parameter so `arity = 2` is the existing
+design, not a fork of a new one — see PLAN.md §1-§2 for the resulting
+shape.
+
+**Re-verification pass (an earlier update): still holds, plus one real
+update and one real find.** `main` has moved substantially since the
+original research (commit `d65111246`) — re-checked every "confirmed fact"
+below directly
+against current `main` rather than trusting the earlier pass. Everything
+held except `PROTOCOL_VERSION`'s specific value, which changed for a good
+architectural reason (finding #4, updated below) — and one thing the
+original pass missed entirely: `crates/draft-core` already has a working,
+tested Swiss-pairing algorithm that sidesteps #4615's confirmed backtracking
+bug by construction (finding #8, new below). Nothing here changes the
+"architecture claims all check out" conclusion; it strengthens it with more
+current evidence and one genuinely useful piece of prior art.
+
+## Confirmed facts — verified against code this session
+
+Everything below was checked directly against `main` (via a worktree at
+`myfork/main`, commit `d65111246` at time of research) unless marked
+otherwise — findings marked "UPDATED" or "NEW" were re-verified or newly
+found against current `main` in a later pass. See RESEARCH.md for exact
+file:line evidence.
+
+1. **Greenfield, confirmed.** No `tournament.rs`, `TournamentManager`, or any
+   tournament-related type exists anywhere in `crates/lobby-broker/src/` (or
+   elsewhere in the workspace) on `main` today. `ls crates/lobby-broker/src/`
+   shows only `broker.rs`, `env.rs`, `inbound_guard.rs`, `lib.rs`, `lobby.rs`,
+   `protocol.rs`, `reservation_auth.rs`, `validation.rs`. #4615 was closed
+   without merging, so none of its work landed. This is a true from-scratch
+   design, not a partially-built stub.
+
+2. **`LobbyManager` + `Broker::handle` + `ConnState` + functional-core pattern
+   — confirmed exactly as described.** `crates/lobby-broker/src/lobby.rs:96`
+   defines `pub struct LobbyManager`. `crates/lobby-broker/src/broker.rs:136`
+   defines `pub fn handle(&mut self, conn: &mut ConnState, msg:
+   LobbyClientMessage, env: &impl BrokerEnv) -> Vec<Outbound>` — single entry
+   point, pure function of `(state, conn, msg, env)` returning ordered side
+   effects, exactly the "no I/O, no locking, no tokio" functional core the
+   module doc comment (`broker.rs:1-7`) claims. `ConnState`
+   (`broker.rs:46-58`) already has the "ownership stamp" idiom the discussion
+   cites: `host_game: Option<String>` records which game this connection
+   registered as host, torn down on disconnect. A `tournament_organizer` /
+   `joined_tournaments` pair would be the direct sibling extension — but see
+   finding #3 below on *how* that extension should be shaped (as tokens, per
+   the #4615 review).
+
+3. **The "existing `lobby_subscribers` broadcast channel" claim is correct in
+   substance but the name lives one layer up from where the discussion
+   implies.** There is no `lobby_subscribers` identifier inside
+   `crates/lobby-broker`. The broker core is transport-agnostic: it emits
+   abstract `Outbound::AddSubscriber` / `Outbound::RemoveSubscriber` /
+   `Outbound::ToSubscribers(LobbyServerMessage)` (`broker.rs:63-76`), and each
+   shell owns the actual registry. The *native* shell's registry is named
+   `lobby_subscribers` — confirmed at `crates/phase-server/src/main.rs:84`
+   (`type SharedLobbySubscribers = Arc<Mutex<Vec<mpsc::UnboundedSender<...>>>>`)
+   and instantiated at `main.rs:824`. So "reuse `lobby_subscribers`, no new
+   subscriber registry needed" is true for the native server, and the
+   Cloudflare Worker shell has its own equivalent DO-connection fan-out — but
+   a `TournamentManager` reuses this by emitting the *same* `Outbound`
+   variants the lobby core already emits, not by directly touching a
+   `lobby_subscribers` field that lives inside `lobby-broker` itself (no such
+   field exists there). This is a precision correction, not a substantive
+   correction — the reuse plan in #5314 is still exactly right.
+
+4. **UPDATED (re-verified against current `main`, not just `d65111246`):
+   `PROTOCOL_VERSION` is now 33, and — more consequential than the number
+   itself — the lobby now has its OWN separate wire version.** Re-checked
+   directly this session: `crates/lobby-broker/src/protocol.rs:104` (`pub
+   const PROTOCOL_VERSION: u32 = 33;`). A commit that landed *after* this
+   phase's original research, `6db58810b` ("fix(protocol): give the lobby
+   its own wire version, decoupled from the full game (#7606)"), introduced
+   `pub const LOBBY_PROTOCOL_VERSION: u32 = 1;` (`protocol.rs:133`) as a
+   genuinely separate constant from `PROTOCOL_VERSION` — confirmed by commit
+   message and by both constants existing side-by-side today, not a rename.
+
+   **This changes PR 2's plan for the better, not just the number.** Since
+   `TournamentManager` lives in `lobby-broker` and its new message variants
+   are lobby-scoped (per this phase's own architecture, matching how
+   `LobbyManager` already works), PR 2 should bump `LOBBY_PROTOCOL_VERSION`
+   specifically, not the general `PROTOCOL_VERSION` — decoupling tournament
+   wire changes from unrelated game-protocol churn, which is exactly the
+   separation `6db58810b` was introduced to enable. This wasn't an option
+   when the original research ran; it is now, and it's the more precise
+   choice given `LOBBY_PROTOCOL_VERSION` didn't exist as a concept before.
+   The original finding's phrasing ("PR 2 must bump from 13→14, not 12→13")
+   is retracted, not just updated — the correct instruction is now "bump
+   `LOBBY_PROTOCOL_VERSION`, currently 1, not the unrelated
+   `PROTOCOL_VERSION`, currently 33."
+
+5. **The Cloudflare Worker `is_empty()` predicate genuinely only checks lobby
+   games today — bug #4 in the discussion is real and reproducible against
+   current `main`.** `lobby-worker/broker-wasm/src/lib.rs:168-170`:
+   ```rust
+   pub fn is_empty(&self) -> bool {
+       self.inner.lobby().is_empty()
+   }
+   ```
+   `Broker` (`crates/lobby-broker/src/broker.rs:108-111`) currently has a
+   single field, `lobby: LobbyManager`. Adding a `tournaments: TournamentManager`
+   field to `Broker` without updating this predicate would reproduce exactly
+   the bug #4615's review caught: a Durable Object holding only tournament
+   state would report `is_empty() == true` and stop rescheduling its cleanup
+   alarm. This must be fixed as part of PR 3 in the rollout, not deferred.
+
+6. **Draft-pod session reconnect genuinely uses per-seat tokens, not socket
+   identity — confirmed, and it's a good analogy.**
+   `crates/server-core/src/draft_session.rs:27-28` stores `player_tokens:
+   Vec<String>` per seat, generated via `generate_player_token()`
+   (`crate::session::SessionManager`, imported at line 18). Lookup is by
+   token: `seat_for_token(&self, token: &str) -> Option<usize>`
+   (`draft_session.rs:44-47`) scans `player_tokens` for a match, and action
+   dispatch (`draft_session.rs:274-290`) resolves the acting seat via
+   `seat_for_token` before applying anything — never via the connection's
+   socket identity. This is a real, load-bearing precedent in the same crate
+   family (`server-core`) for "authority survives a socket bounce," and
+   directly supports the discussion's proposed organizer/player-token fix.
+
+7. **All seven of #4615's review findings are real bugs in the actual closed
+   PR diff, not a summary embellishment.** Fetched via `gh api
+   repos/phase-rs/phase/pulls/4615/reviews` and `.../comments` (the real
+   review, from human reviewer `matthewevans` plus an automated Gemini
+   pass) — not just the discussion's paraphrase. Cross-checked each against
+   `gh pr diff 4615`:
+   - **Backtracking base case bug — confirmed exactly.** The diff's
+     `backtrack_pair` (added code, diff line ~2602) has:
+     ```rust
+     if players.is_empty() { return Some(acc.clone()); }
+     if players.len() == 1 { return None; }
+     ```
+     For any odd-sized bracket, every recursive branch bottoms out at
+     `players.len() == 1` and returns `None`, so the *entire* backtracking
+     search fails for odd brackets and falls back to a greedy pairing that
+     can produce avoidable rematches. The reviewer's suggested fix
+     (`return Some(acc.clone())` for the one-remaining-player case, treating
+     it as the float) is correct and cheap — a one-line base-case fix, not a
+     redesign.
+   - **Missing winner validation — confirmed exactly.** The diff's
+     `validate_match_result` (diff line ~2219) only checks (a) the winner is
+     one of the two paired players and (b) a draw has no winner. It never
+     compares `winner_player_key` against which player actually has more
+     game wins. A client can report `player_a_wins: 2, player_b_wins: 0,
+     winner_player_key: Some(player_b)` and it passes validation, corrupting
+     standings.
+   - **Expiry keyed off `created_at`, never updated — confirmed exactly.**
+     The diff's `check_expired` (diff line ~2179) filters
+     `t.created_at < cutoff` with no `last_activity_at` field anywhere in the
+     diff's `TournamentMeta`. The native reaper calls
+     `broker.reap_expired(300, &SysEnv)` today for lobby entries
+     (`crates/phase-server/src/main.rs:1000`, confirmed still 300s on
+     current `main`) — the PR wired the same 300-second timeout to
+     tournaments via `check_expired`, so any tournament whose *rounds* run
+     longer than 5 minutes total (essentially all of them) would be deleted
+     out from under active players.
+   - **The four WebSocket-leak findings and the i18n finding** are all
+     frontend-only (`TournamentLandingPage.tsx`, `TournamentPage.tsx`,
+     `tournamentClient.ts`) and independently confirmed present in the actual
+     diff at the cited lines. Not re-verified line-by-line here since the
+     rollout plan (PR 4) rebuilds the frontend from scratch rather than
+     reusing #4615's frontend code, but they're real, and PR 4 must not
+     reintroduce them.
+
+8. **NEW — a working, tested Swiss-pairing implementation already exists in
+   `crates/draft-core`, missed by the original research pass entirely.**
+   `crates/draft-core/src/session.rs` has a real `TournamentFormat::Swiss`
+   variant (`crates/draft-core/src/types.rs:12`) and a `generate_swiss_pairings`
+   function, used to run mini-tournaments among players who just finished a
+   draft pod (Premier/Traditional/Sealed `DraftKind`s). Confirmed by direct
+   read, not a grep hit taken on faith:
+   - **Its pairing algorithm is architecturally simpler than what #4615
+     attempted, and — this is the actionable part — the shape difference
+     avoids #4615's confirmed backtracking-base-case bug (finding #7 above)
+     by construction, not by a base-case fix.** It sorts players into
+     score-group "brackets" by match wins, shuffles within each bracket for
+     pairing variety, then greedily pairs within a bracket while avoiding a
+     `prior_pairs: HashSet<(PlayerId, PlayerId)>` rematch set, and — critically
+     — if a bracket has an odd player out, it *carries that one player down to
+     the next bracket* (`carry: Option<(PlayerId, u8)>`) rather than
+     backtracking to try a different pairing within the same bracket. An
+     unpaired player after the last bracket takes a bye, credited as a match
+     win by the caller. There is no recursive backtracking anywhere in this
+     function — the entire bug class #4615 hit (the `players.len() == 1`
+     base case returning `None` and killing the whole search for odd
+     brackets) cannot occur in this shape, because there's no search to fail.
+   - **Tested**: `test_swiss_pairings_8_players` and
+     `swiss_pairings_include_bot_filled_seats` (`session.rs`, same file)
+     exercise this directly.
+   - **Scope difference, so this is prior art to learn from, not a
+     drop-in reuse candidate as-is**: this implementation is keyed on
+     `DraftSession`/`PlayerId`/`DraftPairing` types scoped to a single draft
+     pod (typically 8 seats, `UnsupportedTournamentSize` enforces exactly 8
+     for its sibling single-elimination path), not the arbitrary,
+     lobby-wide player counts (4 to 128+, per the discussion's own MTR
+     Appendix E table) the tournament-organizer needs to support. Literal
+     code sharing would need real type-level unification across two crates
+     with different lifecycles (`draft-core`'s pod exists only for the
+     draft's duration; `lobby-broker`'s tournament outlives any single
+     match) — not attempted here, and not free.
+   - **Recommendation for whoever picks up PR 1**: adopt the same
+     *algorithm shape* (greedy-within-bracket + carry-one-down, no
+     backtracking) for `TournamentManager`'s Swiss pairing, explicitly
+     citing this existing implementation as the precedent, rather than
+     re-deriving a backtracking search and re-discovering #4615's bug from
+     scratch. Whether that's implemented as literal shared code (a small
+     crate, or moving the algorithm into a place both `draft-core` and
+     `lobby-broker` can depend on) or as two independently-tested copies of
+     the same shape is an implementation-time call PR 1 should make
+     explicitly, not leave implicit.
+
+9. **NEW — Commander/multiplayer pod tournaments are governed by a separate,
+   official ruleset (the Multiplayer Addendum to the MTR, referred to here
+   as "MSTR") with different scoring, tiebreak, and pairing conventions than
+   1v1 — not just a bigger pod on the same math.** Fetched directly this
+   session (juizes-mtg-portugal.github.io's mirror, cross-referenced against
+   BeNeLux cEDH's mirror and TopDeck.gg's own addendum page — full citations
+   in RESEARCH.md §13), not paraphrased from memory:
+   - **Scoring generalizes cleanly, not by coincidence**: MSTR's win-point
+     formula is `2n - 1` for pod size `n` — 7 points for a 4-player pod's
+     win. At `n = 2` this is exactly `3`, the MTR §2.1 value #5312 already
+     cites. This means `ScoringPolicy`'s existing 3/1/0 default is a special
+     case of one general formula, not a separate convention — see PLAN.md
+     §1's `default_for_arity`.
+   - **Tiebreak order is genuinely different, not just re-scaled.** MSTR
+     drops the "opponents' game-win %" axis entirely (pods are single-game;
+     there's no per-player game-win count to average) and adds an
+     "opponents' average match points" axis 1v1 doesn't have. The floor
+     value both rulesets use (0.33 for 1v1, ≈0.14 for 4-player pods) is the
+     *same* formula, `1 / win_points`, evaluated at each ruleset's own
+     `win_points` — another clean unification, unlike the tiebreak order
+     itself.
+   - **Pairing is officially non-backtracking, independently confirming
+     finding #8's recommendation.** MSTR's own algorithm is top-to-bottom
+     assignment by current standing, with an iterative *swap* repair step
+     for players who can't be placed without a rematch — no recursive
+     search, no base case to get wrong. This is the same algorithmic
+     *shape* `draft-core`'s existing 1v1 pairing already uses (greedy +
+     carry-down repair, finding #8), just generalized to N-player pods
+     instead of pairs. One algorithm now needs designing, not two — see
+     PLAN.md §2.
+   - **Uneven player counts get a short pod, not more byes.** MSTR:
+     "pods may consist of a minimum of 3 players to avoid multiple byes"
+     for a nominal 4-player event, with fairness tracking so the same
+     player isn't shorted twice before everyone else has been shorted once.
+     This has no analog in 1v1 (a bye is the only "can't fill the pairing"
+     case there) and is a genuinely new piece of state (`had_short_pod`,
+     PLAN.md §2), not a renamed existing field.
+   - **Cross-checked against production practice, not just the rules
+     text**: TopDeck.gg's own "Running Commander Tournaments" help page
+     confirms this isn't academic — "Pods seat four by default. Odd fields
+     produce a short pod or a bye" — matching MSTR's stated preference, in
+     a platform actually running Commander events today.
+   - **Scope note**: MSTR's own round-count table (4-5 players → single
+     elimination only, 6-16 → 2 Swiss rounds + Top 4, etc.) is a *different*
+     table from the MTR Appendix E table #5312 already cites for 1v1 — both
+     are default lookups keyed off `(arity, player_count)`, not a single
+     shared table, per PLAN.md §1's `total_rounds` framing.
+
+## What this session did NOT re-verify (explicitly out of scope per the task)
+
+The Magic Tournament Rules citations in #5314 (match points 3/1/0 at MTR
+§2.1, tiebreaker order and 0.33 floors at MTR §3.1/Appendix C, bye scoring at
+Appendix C, the round-count table at Appendix E, self-reporting at §2.4) are
+taken as given from an external, official source already cited with URLs.
+This is a code-architecture verification pass, not an MTR fact-check.
+
+## Open questions for the maintainer
+
+These are the discussion's own open questions, unchanged by this
+verification pass — nothing found this session resolves them unilaterally:
+
+1. **Is a flat `ScoringPolicy{win,draw,loss}` sufficient for v1**, or should
+   it anticipate hooking into the custom-format-engine research (phase 58)
+   if/when that lands? **This session's opinion, argued in PLAN.md: no — keep
+   them separate.** `ScoringPolicy` is tournament-administration state that
+   lives in `lobby-broker` and never touches a `GameState`; phase 58's
+   `LegacyRuleSet` is in-game CR-rule-variation state that lives in the
+   `engine` crate's `FormatConfig` and is consumed mid-game. They sit in
+   different crates, different lifecycles (one tournament-scoped, one
+   game-scoped), and different CR categories (MTR tournament administration
+   vs. Comprehensive Rules game mechanics). Phase 58's own CONTEXT.md
+   independently reached the same conclusion from the other side (see
+   "Relationship to adjacent work" below) — this is not a contested call.
+
+   **NEW this pass — checked what real MTG tournament platforms (TopDeck.gg,
+   Melee.gg) actually expose as configuration, per direct request, since
+   citing the MTR alone doesn't show what organizers actually ask for beyond
+   the official rules.** Full detail in RESEARCH.md §12. Summary: both
+   platforms confirm win/draw points ARE a real, requested configuration
+   surface (not a hypothetical) — TopDeck.gg exposes explicit "points per
+   win"/"points per draw" fields with organizer-set custom values (published
+   before round 1 so players know the stakes), and Melee.gg exposes a
+   simpler binary "Enable Draws" toggle (some organizers just disallow draws
+   outright, a different axis than customizing their point value). **This
+   surfaces one thing a flat `ScoringPolicy{win,draw,loss}` doesn't capture
+   that maybe should be a fourth field: TopDeck.gg's bye handling diverges
+   from the MTR text #5314 already cites.** MTR (Appendix C, already quoted
+   in the discussion) says a bye scores as a win AND is *excluded* from
+   opponents'-percentage averaging (no real opponent that round). TopDeck.gg
+   instead credits a bye as a win but *adds* synthetic opponent history (3
+   opponents at a fixed 0.2 win rate) so the bye round still contributes to
+   tiebreaker averaging rather than being skipped. These are two genuinely
+   different, real, in-production conventions for the exact same MTR rule —
+   worth flagging to the maintainer as a possible fifth `ScoringPolicy`
+   axis (a `ByeTiebreakerHandling` enum: `ExcludeFromAverages` (MTR) vs.
+   `SyntheticOpponent` (TopDeck.gg-style)) rather than hardcoding MTR's
+   choice as the only option, mirroring how the win/draw/loss points
+   themselves are already planned as TO-configurable rather than fixed
+   constants. Not resolved here — a genuine open question for the
+   maintainer, same as the original three below, not something this pass
+   decides unilaterally.
+2. **Round advancement**: organizer-gated only for v1, or build an
+   auto-advance timer now? No new evidence found either way this session;
+   still a product-scope call, not an architecture one — a timer is additive
+   later regardless of which is chosen for v1.
+3. **Confirm v1 stays lobby-only** (no auto-launched `GameSession` per
+   pairing), with full-mode integration as an explicit fast-follow. Confirmed
+   this matches #4612's original framing exactly, and nothing found this
+   session suggests otherwise. Recommend confirming as stated.
+4. **NEW — does v1 need Commander single-elimination bracket play, or only
+   Commander Swiss?** MSTR's own round-count table only calls for Swiss +
+   Top-4/7/10/13/16 single-elimination cuts once the Swiss rounds finish
+   (finding #9) — it doesn't describe a *pure* SE bracket built from 4-player
+   pods the way 1v1's existing adjacent-pair SE path works. This session's
+   recommendation (PLAN.md §2): treat pod-based SE as a natural but
+   unimplemented-in-v1-detail extension of the existing arity-gated SE path,
+   not block Commander Swiss support on designing it fully now — but this is
+   a product-scope call for the maintainer, not decided unilaterally here.
+
+## Relationship to adjacent work — scope boundaries
+
+- **Custom-format-engine (phase 58, branch `research/custom-format-engine`).**
+  Read that phase's CONTEXT.md and PLAN.md in full for this cross-reference.
+  Phase 58 already independently confirmed, from its own investigation, that
+  **phase.rs has no match-level concept at all today** — "no best-of-N, no
+  tournament round, no draw/tiebreak state machine; the engine models single
+  games only" — and explicitly flagged its own adjacent open question
+  (draw/tiebreak resolution mechanics) as **out of scope for the
+  custom-format engine itself**, deferring it to "a separate, later
+  tournament/match structure design" — i.e., exactly this phase. Phase 58's
+  `LegacyRuleSet` (mana burn, damage-uses-stack, pre-M10 Wish templating,
+  legend-rule scope) is a set of **in-game CR-rule-variation toggles** that
+  live on `FormatConfig` in the `engine` crate and are read during game
+  resolution. `ScoringPolicy` (win/draw/loss match points feeding
+  match-point accumulation and tiebreaker math) is **tournament
+  bookkeeping** that lives in `lobby-broker`, never enters a `GameState`, and
+  is applied *after* a game/match ends, not during it. These are two
+  different CR-adjacent categories (MTR administrative scoring vs. CR game
+  rules) living in two different crates with no shared runtime state — the
+  same "categorical boundary" reasoning this repo's CLAUDE.md applies to
+  keep Life (CR 119) and Power/Toughness (CR 208/209) from being unified
+  under one enum applies here at a coarser grain. **Recommendation: do not
+  make `ScoringPolicy` a field of `CustomFormatDef`/`LegacyRuleSet`, or wait
+  on phase 58 landing.** `TournamentManager`'s `ScoringPolicy` should be
+  designed and shipped independently in `lobby-broker`. If a future format
+  ever wants scoring defaults to travel with a format preset (e.g., "Old
+  School events on this site default to draws=0"), that is a *product*
+  wiring question for whichever UI creates a tournament to read a suggested
+  default off the chosen format — not an architectural coupling between the
+  two crates. No blocking dependency exists in either direction; phase 58 and
+  this phase can land in either order.
+- **Watch-game-mode (phase 60) and audio/video-chat (phase 59)** — no
+  meaningful overlap found. Tournaments organize P2P tables via the existing
+  `CreateGameWithSettings`/`JoinGameWithPassword` flow per #4612; whether a
+  tournament's tables are individually spectatable is exactly phase 60's
+  existing "is a P2P game spectatable" open question (currently: no, P2P
+  games can't be spectated at all — see phase 60 Open Q2), not something this
+  phase needs to solve. Flagged for awareness only.
+- **Issue #4612 / PR #4615** — this phase supersedes neither; it is the
+  second design pass on the same feature request, incorporating the first
+  attempt's real review findings as day-one design constraints rather than
+  post-hoc fixes. #4612 stays open until this design ships; #4615 stays
+  closed (its code never merged and is not being resurrected — PR 1 of the
+  rollout is a clean rewrite of `tournament.rs`, not a rebase of #4615's
+  branch).

--- a/docs/proposals/tournament-organizer/PLAN.md
+++ b/docs/proposals/tournament-organizer/PLAN.md
@@ -298,7 +298,7 @@ pub struct TournamentMeta {
     pub bracket: BracketShape,            // Swiss | SingleElimination
     pub total_rounds: u32,                // organizer override, else MTR/MSTR Appendix E default (arity-selected)
     pub current_round: u32,
-    pub status: TournamentStatus,         // Registration | InProgress | Completed
+    pub status: TournamentStatus,         // Registration | InProgress | Completed | Abandoned — see "Expiry" below
     pub players: Vec<TournamentPlayer>,
     pub pairings: Vec<TournamentPairing>,
     pub created_at: u64,
@@ -665,15 +665,72 @@ the drop-timing case above: reject `winner` if `TournamentPlayer.dropped`
 is true for that player at validation time, closing the "credited a win
 after leaving" gap the drop-timing note above calls out.
 
-**Expiry** — fixes #4615 finding #3 directly: `last_activity_at` bumped on
-every mutating call (`join_tournament`, `start_round`, `report_result`,
-`drop_player`), and `check_expired` filters on `last_activity_at`, not
-`created_at`. Additionally, per the discussion's proposal, staleness reaping
-should be restricted to `TournamentStatus::Registration` (abandoned
-registration, nobody ever started) — an `InProgress` tournament should not
-be reaped by a fixed timeout at all, only by genuine inactivity, since a
-real Swiss event with human players between rounds can easily exceed any
-reasonable fixed timeout.
+**Expiry / retention — REVISED, maintainer review: the prior text named a
+policy ("genuine inactivity" for `InProgress`) without ever defining it, the
+owning transition, or a `Completed` retention rule, so the in-memory
+`TournamentManager` had no bound on how long it retains ANY tournament that
+ever leaves `Registration`.** Fixes #4615 finding #3 and completes the
+lifecycle with four explicit rules, one per status, all keyed off the same
+`last_activity_at` (bumped on every mutating call — `join_tournament`,
+`start_round`, `report_result`, `drop_player`, AND, new here, every status
+transition itself, so `last_activity_at` doubles as "time of the most
+recent state change" for retention purposes without a second timestamp
+field):
+
+1. **`Registration`** — unchanged from the original design.
+   `check_expired` reaps (deletes) a `Registration`-status tournament once
+   `last_activity_at` exceeds the same 300-second window the existing
+   lobby reaper already uses (`broker.reap_expired(300, &SysEnv)`,
+   `crates/phase-server/src/main.rs:1000`) — an abandoned registration
+   (organizer created it, nobody ever joined or started it) is exactly the
+   same shape of staleness the lobby's own 300s window already handles.
+2. **`InProgress` — NEW, the previously-undefined case.** "Genuine
+   inactivity" is defined as `last_activity_at` exceeding **7 days**
+   (chosen to comfortably exceed any real multi-round Swiss event's
+   natural between-round gaps — human coordination, players returning
+   later the same day or the next — while still eventually reclaiming a
+   tournament nobody is actually running anymore). The owning transition:
+   `check_expired` moves the tournament to `TournamentStatus::Abandoned`
+   (a NEW status, not a deletion — the record and its full pairing/
+   standings history are preserved, only the "still live" status ends).
+   This threshold is a system default, NOT organizer-overridable (unlike
+   `total_rounds`) — it's server hygiene, not a tournament rule a TO would
+   reasonably want to tune.
+3. **`Completed` / `Abandoned` — NEW, the retention rule maintainer review
+   flagged as entirely missing.** Both are terminal states whose standings
+   are frozen (a genuinely finished event and an abandoned one are kept
+   distinct — see `Abandoned`'s own doc comment below — but both stop
+   accepting mutations the same way). `check_expired` deletes a tournament
+   in either state once `last_activity_at` (i.e., time of completion or
+   abandonment) exceeds a **30-day retention period** — long enough for
+   players/organizers to look up final standings after the fact, bounded
+   enough that the in-memory `HashMap` doesn't grow forever.
+
+```rust
+pub enum TournamentStatus {
+    Registration,
+    InProgress,
+    /// All rounds finished normally, standings frozen — a trustworthy
+    /// final result.
+    Completed,
+    /// NEW — reached only via `check_expired`'s 7-day `InProgress`
+    /// inactivity transition (point 2 above), never organizer-initiated.
+    /// Distinct from `Completed`: an abandoned tournament's final round(s)
+    /// may still have `Pending` pairings, so its "standings" reflect
+    /// whatever was actually reported before activity stopped, not a
+    /// guaranteed-complete result — kept as its own status specifically so
+    /// clients can display that distinction rather than presenting an
+    /// abandoned event's partial standings as equivalent to a real
+    /// `Completed` one.
+    Abandoned,
+}
+```
+
+Both new rules are exercised by `check_expired` alone — no new operation
+or background job beyond the reaper this design already calls for
+`Registration` (`main.rs:1000`'s existing reap site just needs to widen its
+scope to also cover `InProgress`/`Completed`/`Abandoned` on every sweep,
+not add a second timer).
 
 ## 3. Authority model — organizer/player tokens, not socket identity
 
@@ -921,3 +978,17 @@ but incomplete tally like `1-0` (rejected, not a completed Bo3), `2-2`
 one. A sibling test confirms a pod (`arity > 2`) result with a non-empty
 `game_wins` is rejected outright, and one with an empty map validates
 normally.
+
+**NEW — maintainer review (tournament lifecycle retention, "Expiry" §2)**:
+four dedicated tests, one per status — (a) a `Registration` tournament with
+`last_activity_at` past the 300s window is deleted by `check_expired`,
+unchanged from the existing behavior; (b) an `InProgress` tournament with
+`last_activity_at` just under 7 days is untouched (proving a real
+multi-day gap between rounds doesn't get reaped); (c) an `InProgress`
+tournament past the 7-day threshold transitions to `Abandoned` — record
+preserved, `pairings`/standings unchanged, only `status` and
+`last_activity_at` updated by the transition itself; (d) a `Completed` (or
+`Abandoned`) tournament past the 30-day retention window is deleted
+outright by `check_expired`, while one still within the window is
+untouched — proving the previously-missing terminal-state retention rule
+is actually enforced, not just documented.

--- a/docs/proposals/tournament-organizer/PLAN.md
+++ b/docs/proposals/tournament-organizer/PLAN.md
@@ -1,0 +1,491 @@
+# Phase 61 — Swiss-Pairing Tournament Organizer — PLAN
+
+This plan captures the rollout sequencing from discussion #5314, refined with
+this session's verification findings (CONTEXT.md, RESEARCH.md). No code is
+written here — this is the design a future `engine-implementer` pass should
+execute against.
+
+## Mandatory architectural sections
+
+### Pattern Coverage — build for the class, not one tournament format
+
+Swiss pairing, tiebreaker math, and bye handling must be built as general
+algorithms parameterized by player count and `ScoringPolicy`, not hardcoded
+to a specific round count or point values. The MTR round-count table
+(Appendix E) is a *default lookup*, not a hardcoded round count — an
+organizer overriding total rounds must work identically to the default path.
+Single-elimination for 4-8 players (also in Appendix E) is a second bracket
+*shape* the same `TournamentManager` must support, not a special case bolted
+onto Swiss — see §2 below for how that's scoped.
+
+**Revised this pass — player-count-per-match is a parameterization axis, not
+a fork.** The original design implicitly assumed 2 players per match
+(head-to-head Standard/Modern/etc. Swiss). Per direct maintainer instruction,
+this must also cover Commander/multiplayer pod tournaments (4-player pods
+being the common case), and the sibling-cluster smell this repo's CLAUDE.md
+warns about applies here exactly: a `TournamentFormat::HeadToHead` +
+`TournamentFormat::Commander` split would duplicate pairing, scoring, and
+tiebreaker logic across two near-identical code paths that differ only in
+one number. Instead, `MatchArity` (§2) is threaded through pairing,
+`ScoringPolicy`, and tiebreak order as a single parameter — `arity = 2`
+*is* today's design, not a special case of a new one. Full grounding in the
+official Multiplayer Addendum to the Magic Tournament Rules (MSTR) and
+TopDeck.gg's production Commander-pairing practice is in RESEARCH.md §13.
+
+### Building Blocks — reused, not reinvented
+
+| Need | Existing block reused | Location |
+|------|----------------------|----------|
+| Dispatch pattern (`handle(conn, msg, env) -> Vec<Outbound>`) | `Broker::handle` | `crates/lobby-broker/src/broker.rs:136` |
+| Per-connection state extension pattern | `ConnState` | `crates/lobby-broker/src/broker.rs:46` |
+| Fan-out to subscribers | `Outbound::{AddSubscriber,RemoveSubscriber,ToSubscribers}` | `crates/lobby-broker/src/broker.rs:63-76` |
+| Deterministic time/rng for WASM-safe pure core | `BrokerEnv` | `crates/lobby-broker/src/env.rs` |
+| Token-based authority surviving a socket bounce | `player_tokens`/`seat_for_token`/`generate_player_token` | `crates/server-core/src/draft_session.rs:27-47`, `session.rs` |
+| Native reaper wiring pattern | `broker.reap_expired(300, &SysEnv)` call site | `crates/phase-server/src/main.rs:1000` |
+| Deterministic test harness for pure broker logic | `FakeEnv` | used throughout `lobby.rs`/`broker.rs` tests |
+
+New building blocks introduced (all general, none single-card/single-format):
+`TournamentManager`, `MatchArity` (2-player through N-player pods, §2),
+`ScoringPolicy` (MSTR-formula-derived, arity-aware), `SwissPairing`
+(top-to-bottom score-order assignment with swap-based repair, §2 — supersedes
+this doc's earlier backtracking-based sketch), `TiebreakOrder` (arity-selected
+MTR vs. MSTR computation), organizer/player token minting reusing the same
+primitive `draft_session.rs` already uses.
+
+### Logic Placement
+
+All pairing, scoring, tiebreaker, and expiry logic lives in
+`crates/lobby-broker/src/tournament.rs` — the pure core. `phase-server` and
+the Cloudflare Worker shell are thin dispatch/serialization boundaries, per
+CLAUDE.md's "engine [here: broker core] owns all logic" principle applied to
+this crate. The frontend renders `TournamentView`/`TournamentStanding`
+exactly as computed server-side; it must not recompute standings, tiebreaks,
+or pairing itself.
+
+### Extension vs Creation
+
+This extends `lobby-broker`, it does not fork it: `Broker` gains one
+additive field (`tournaments: TournamentManager`), `ConnState` gains two
+additive fields (token-shaped, not bare identifiers — see §3), and
+`LobbyClientMessage`/`LobbyServerMessage` gain additive variants. No existing
+lobby behavior changes.
+
+### Analogous Trace
+
+Traced `LobbyManager`/`Broker::handle`/`ConnState` end-to-end (RESEARCH.md
+§5) before designing `TournamentManager`'s shape, and traced
+`draft_session.rs`'s token model end-to-end (RESEARCH.md §7) before designing
+the organizer/player-token authority fix. Both traces are cited with
+file:line evidence in RESEARCH.md, not assumed from the discussion's prose.
+
+## 1. `MatchArity` and `ScoringPolicy` — first-class, TO-configurable, MTR/MSTR defaults
+
+```rust
+/// Number of players seated at one pairing. `HEAD_TO_HEAD` (2) is today's
+/// Standard/Modern/etc. Swiss. `COMMANDER_POD` (4) is the common Commander
+/// multiplayer pod size per the Multiplayer Addendum to the MTR ("MSTR" —
+/// RESEARCH.md §13). Chosen once at `CreateTournament` time and stored on
+/// `TournamentMeta`, immutable for the tournament's lifetime — same
+/// rationale as `ScoringPolicy` below (re-sizing pods mid-event would
+/// invalidate standings already computed against the old size).
+///
+/// This is a parameterization axis, not a format enum: pairing (§2),
+/// scoring, and tiebreak-order selection are all functions of `MatchArity`
+/// rather than forked per format, per CLAUDE.md's "parameterize, don't
+/// proliferate" — a `TournamentFormat::HeadToHead` /
+/// `TournamentFormat::Commander` split would duplicate three algorithms
+/// that differ only in this one number.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct MatchArity(pub u8);
+
+impl MatchArity {
+    pub const HEAD_TO_HEAD: MatchArity = MatchArity(2);
+    pub const COMMANDER_POD: MatchArity = MatchArity(4);
+}
+
+/// Tournament match-point scoring. MSTR generalizes MTR §2.1's 3/1/0 to a
+/// single formula: `win_points = 2n - 1` for pod size `n` (RESEARCH.md
+/// §13) — `n = 2` collapses to exactly 3, so this is the same rule as
+/// before, not a fork of it. TO-overridable at tournament creation for
+/// communities running variant conventions (e.g. some Old School/93-94
+/// groups score draws as 0 to discourage intentional draws; TopDeck.gg's
+/// own Commander default is 5/1/0, confirmed distinct from the MSTR-derived
+/// 7/1/0 for 4-player pods — see RESEARCH.md §12). Lives in `lobby-broker`,
+/// never touches `GameState` — see CONTEXT.md's "Relationship to adjacent
+/// work" for why this is NOT a field of the engine crate's
+/// `CustomFormatDef`/`LegacyRuleSet` (phase 58).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ScoringPolicy {
+    pub win_points: u8,
+    pub draw_points: u8,
+    pub loss_points: u8,
+}
+
+impl ScoringPolicy {
+    /// MSTR-derived default: `2n - 1` match points for a win, `n` being
+    /// `MatchArity`. At `arity = HEAD_TO_HEAD` this is exactly MTR §2.1's
+    /// 3/1/0 — the same formula, not a special case of it.
+    pub fn default_for_arity(arity: MatchArity) -> Self {
+        Self { win_points: 2 * arity.0 - 1, draw_points: 1, loss_points: 0 }
+    }
+}
+
+impl Default for ScoringPolicy {
+    // MTR §2.1 (equivalently, `default_for_arity(MatchArity::HEAD_TO_HEAD)`).
+    fn default() -> Self {
+        Self::default_for_arity(MatchArity::HEAD_TO_HEAD)
+    }
+}
+```
+
+Threaded through match-point accumulation (`points_for(&PodOutcome,
+ScoringPolicy) -> u32` style helper) and the tiebreaker calculations
+identically — a tiebreaker's "total possible points" denominator must use
+`scoring.win_points`, not a hardcoded `3`, so a non-default policy's
+percentages stay internally consistent. This generalization pays off
+immediately for the tiebreaker floor too: MTR's 1v1 floor is a hardcoded
+0.33, MSTR's 4-player-pod floor is a hardcoded ~0.14 — both are the *same*
+formula, `1.0 / scoring.win_points as f64` (1/3 ≈ 0.33, 1/7 ≈ 0.14), so the
+floor needs no arity branch at all. Tiebreaker *order itself* is
+arity-selected, not TO-configurable (§2 below) — MTR and MSTR use genuinely
+different tiebreak axes, not just different numbers plugged into the same
+axes, so this can't be unified the way the floor was; ship both fixed to
+their respective official values, revisit only if a real request surfaces.
+
+`MatchArity` and `ScoringPolicy` are supplied once at `CreateTournament`
+time and stored on the `TournamentMeta`, immutable for the tournament's
+lifetime (changing either mid-event would retroactively corrupt
+already-reported standings).
+
+## 2. `TournamentManager` shape
+
+```rust
+pub struct TournamentManager {
+    tournaments: HashMap<String, TournamentMeta>,
+}
+
+pub struct TournamentMeta {
+    pub code: String,
+    pub name: String,
+    pub organizer_token: String,          // minted at creation, NOT socket-bound
+    pub arity: MatchArity,                // players per pairing — 2 for head-to-head, 4 for Commander pods
+    pub scoring: ScoringPolicy,
+    pub bracket: BracketShape,            // Swiss | SingleElimination
+    pub total_rounds: u32,                // organizer override, else MTR/MSTR Appendix E default (arity-selected)
+    pub current_round: u32,
+    pub status: TournamentStatus,         // Registration | InProgress | Completed
+    pub players: Vec<TournamentPlayer>,
+    pub pairings: Vec<TournamentPairing>,
+    pub created_at: u64,
+    pub last_activity_at: u64,            // bumped on every mutation — fixes #4615 finding #3
+}
+
+pub struct TournamentPlayer {
+    pub player_key: String,
+    pub player_token: String,             // minted at join, NOT socket-bound — fixes #4615 finding #1
+    pub display_name: String,
+    pub dropped: bool,
+    pub had_bye: bool,                    // bye assignment prefers players who haven't had one
+    pub had_short_pod: bool,               // NEW: arity > 2 only — see pod-sizing below
+}
+
+/// A single pairing. 2 players for a head-to-head match. Up to `arity`
+/// players for a pod match; may be exactly `arity - 1` for a *short pod*
+/// (MSTR: prefer one undersized pod over multiple byes — see below) or
+/// exactly 1 for a genuine bye.
+pub struct TournamentPairing {
+    pub round: u32,
+    pub players: Vec<String>,             // player_key, len in 1..=arity.0
+}
+
+/// One pairing's reported outcome. MSTR: "Match results, not individual
+/// Game results, are reported" for pods — a pod match has exactly one
+/// winner or is a full draw, never per-seat placement (RESEARCH.md §13).
+pub enum PodOutcome {
+    /// `game_wins` is only meaningful (and only validated) for a
+    /// `HEAD_TO_HEAD` pairing's Bo3 game-win consistency check below —
+    /// pods are single-game per MSTR default, so it's empty/unused there.
+    Decisive { winner: String, game_wins: std::collections::HashMap<String, u8> },
+    Draw,
+}
+```
+
+`BracketShape::SingleElimination` covers the MTR Appendix E 4-8 player case
+as a sibling bracket shape on the *same* manager, not a separate feature —
+per "build for the class," a tournament tool that only does Swiss is
+incomplete relative to the MTR table it cites as its own round-count source.
+Single elimination for `arity > 2` (Commander bracket play) composes the
+same way: each bracket "match" is a pod of `arity` players advancing its one
+winner, rather than the adjacent-pair advancement 1v1 SE uses — noted here
+as in-scope, not designed further, since v1's SE path is already gated to a
+fixed 8-seat case (RESEARCH.md §11) and the pod generalization is a
+natural, not novel, extension of that same gate.
+
+**Pairing algorithm — top-to-bottom pod assignment with swap-based repair,
+generalized over `arity` (supersedes this doc's earlier backtracking
+design).** This session's earlier draft proposed fixing #4615's backtracking
+bug in place (a one-line base-case fix). Generalizing to N-player pods
+makes that moot: the official MSTR algorithm (RESEARCH.md §13) is itself
+non-backtracking, and it's the same *shape* CONTEXT.md finding #8 already
+recommended adopting from `draft-core`'s existing 1v1 pairing (greedy
+top-down assignment + carry/swap repair, no recursive search) — one
+generalized algorithm now satisfies both the odd-bracket-bug fix and the
+Commander-pod requirement, rather than needing two:
+1. Sort active (non-dropped) players descending by current standing (match
+   points, then tiebreaks-so-far).
+2. Walk top-to-bottom, greedily assigning players into pods of `arity.0`
+   in standing order, skipping an assignment that would create *any*
+   repeated pair within the pod (not just a repeated full pod — two
+   players who've faced each other in a prior pod, even if the rest of the
+   pod is new, still count as a rematch, per MSTR). At `arity = 2` this
+   is exactly the existing 1v1 score-group pairing.
+3. **If the top-to-bottom pass leaves players unassignable** (every
+   remaining candidate would create a rematch), iteratively swap an
+   unmatched player with one already placed in a pod further down the
+   standings — MSTR's own repair step, not a novel design. A player moved
+   into a pod above their standing is "paired up"; moved below is "paired
+   down" (recorded for organizer visibility only, not scored differently).
+4. **Pod-size fallback, `arity > 2` only**: prefer as many full `arity`-size
+   pods as possible; when the active-player count doesn't divide evenly,
+   form one *short pod* of `arity.0 - 1` rather than issuing more than one
+   bye (MSTR: "pods may consist of a minimum of 3 players to avoid multiple
+   byes" for 4-player events). Prefer assigning the short pod to a player
+   who hasn't already had one (`had_short_pod`), mirroring bye fairness —
+   a player should not be shorted twice before every other player has been
+   shorted once, same fairness rule as `had_bye`. At `arity = 2` there is no
+   short-pod case (`arity.0 - 1 == 1`, which is just the existing bye path).
+5. Bye assignment (any `arity`, and the only path at `arity = 2`) prefers a
+   player who hasn't already had one (`had_bye` flag) among any players
+   still unassignable after pod-size fallback.
+6. A bye scores as a win at `scoring.win_points` (2-0/6 game points at
+   `arity = 2` per MTR Appendix C; `2n - 1` match points with no game-win
+   count at `arity > 2` per MSTR), and the bye round is **excluded** (not
+   zero-filled) from that player's opponents'-percentage stats for later
+   rounds, since there was no real opponent that round. A short pod is
+   **not** a bye — every seated player has real opponents that round and
+   is scored normally; only the literal unseated case is a bye.
+
+**Standings / tiebreaker computation — arity-selected order, not a single
+shared list.** MTR (2-player) and MSTR (pod) use genuinely different
+tiebreak axes, not just different constants plugged into the same axes
+(MSTR has no per-player game-win axis at all, since pods are single-game;
+it adds an "opponents' average match points" axis 1v1 doesn't have) — so
+this is modeled as a `TiebreakOrder` selected by `MatchArity`, not a single
+parameterized list:
+
+```rust
+pub enum TiebreakOrder {
+    /// MTR §3.1 (arity = HEAD_TO_HEAD): match points, opponents'
+    /// match-win %, game-win % (floored at `1 / win_points`), opponents'
+    /// game-win %.
+    HeadToHead,
+    /// MSTR (arity > HEAD_TO_HEAD): match points, match-win % (own
+    /// bye-adjusted formula, same `1 / win_points` floor), opponents'
+    /// average match points, opponents' match-win %.
+    Multiplayer,
+}
+
+impl TiebreakOrder {
+    pub fn for_arity(arity: MatchArity) -> Self {
+        if arity == MatchArity::HEAD_TO_HEAD { Self::HeadToHead } else { Self::Multiplayer }
+    }
+}
+```
+
+Both orders share the same generalized floor (`1.0 / scoring.win_points as
+f64`, per §1) and both exclude bye rounds (never short-pod rounds) from
+opponent-average calculations — those two pieces of logic are genuinely
+arity-independent and stay unforked; only the ranked list of *which*
+percentages to compute, and in what order, differs.
+
+**Match result validation** — fixes #4615 finding #2 directly, generalized
+to `PodOutcome`/arbitrary pod size:
+```rust
+fn validate_match_result(pairing: &TournamentPairing, result: &PodOutcome) -> Result<(), String> {
+    match result {
+        PodOutcome::Draw => Ok(()), // MSTR: all seated players draw together
+        PodOutcome::Decisive { winner, game_wins } => {
+            if !pairing.players.contains(winner) {
+                return Err("Winner must be one of the pod's players".to_string());
+            }
+            // Bo3 game-win consistency check applies ONLY to head-to-head
+            // pairings — MSTR pods are single-game, there's no per-player
+            // game-win count to cross-check.
+            if pairing.players.len() == 2 && !game_wins.is_empty() {
+                let (a, b) = (&pairing.players[0], &pairing.players[1]);
+                if game_wins.get(a) != game_wins.get(b) {
+                    let expected = if game_wins.get(a) > game_wins.get(b) { a } else { b };
+                    if winner != expected {
+                        return Err("Winner must match the player with more game wins".to_string());
+                    }
+                }
+            }
+            Ok(())
+        }
+    }
+}
+```
+
+**Expiry** — fixes #4615 finding #3 directly: `last_activity_at` bumped on
+every mutating call (`join_tournament`, `start_round`, `report_result`,
+`drop_player`), and `check_expired` filters on `last_activity_at`, not
+`created_at`. Additionally, per the discussion's proposal, staleness reaping
+should be restricted to `TournamentStatus::Registration` (abandoned
+registration, nobody ever started) — an `InProgress` tournament should not
+be reaped by a fixed timeout at all, only by genuine inactivity, since a
+real Swiss event with human players between rounds can easily exceed any
+reasonable fixed timeout.
+
+## 3. Authority model — organizer/player tokens, not socket identity
+
+Fixes #4615 finding #1 directly, using the `draft_session.rs` precedent
+(RESEARCH.md §7) as the concrete pattern to mirror:
+- `CreateTournament` mints an `organizer_token` (reuse
+  `generate_player_token()` from `server-core::session`, the same primitive
+  draft pods already use) and returns it to the creating client. The
+  *tournament's* record of who the organizer is keys off this token, not
+  `ConnState`/the socket.
+- `JoinTournament` mints a `player_token` per joining player, same mechanism.
+- `ConnState` gains `organized_tournaments: Vec<String>` /
+  `joined_tournaments: Vec<(String, String)>` (tournament code, player_token)
+  purely as **local reconnect convenience** (so a client that already has a
+  token doesn't need to re-type it) — never as the source of authority.
+  Organizer-gated actions (`StartTournamentRound`, `EndTournament`) validate
+  the *token* presented in the message payload against
+  `TournamentMeta.organizer_token`; player-gated actions
+  (`ReportMatchResult`, `DropFromTournament`) validate against the paired
+  `TournamentPlayer.player_token`.
+- Consequence: closing/reopening the tournament page's socket does **not**
+  unregister the tournament or drop a player's standing — exactly the bug
+  class #4615 shipped. The tournament page keeps one socket open for the
+  page's lifetime purely as a live-update optimization, per the discussion's
+  framing, not because closing it would be unsafe.
+
+## 4. Proposed rollout — four independently reviewable PRs
+
+Unchanged in sequencing from the discussion, refined with this session's
+corrections folded in as explicit acceptance criteria per PR:
+
+**PR 1 — pure core, no wiring.**
+`crates/lobby-broker/src/tournament.rs`: `TournamentManager`, `MatchArity`,
+`ScoringPolicy`, top-to-bottom pod pairing with swap-based repair
+(generalized over `arity`, per §2), single-elimination bracket shape, bye
+and short-pod assignment, MTR/MSTR-cited standings via arity-selected
+`TiebreakOrder`. Exhaustively unit tested with `FakeEnv`, same style as
+`lobby.rs`/`broker.rs`. **`MatchArity` must be modeled from this PR's first
+commit, not retrofitted in a later PR** — pairing, scoring, and tiebreak
+order are all designed as functions of it from day one.
+**Acceptance criteria beyond "compiles and has tests":**
+- A dedicated test for an odd-sized `HEAD_TO_HEAD` bracket (5, 7, 9 players)
+  asserting the swap-repair path succeeds without falling back to a
+  rematch-prone pairing — this is the exact case #4615's 90 passing tests
+  missed.
+- A dedicated test for `COMMANDER_POD` arity with a player count that
+  doesn't divide evenly by 4 (e.g. 9, 10, 11 players), asserting a single
+  short pod (not multiple byes) forms, and that `had_short_pod` fairness
+  prevents the same player being shorted twice before every player has been
+  shorted once.
+- A dedicated test asserting `validate_match_result` rejects a
+  `HEAD_TO_HEAD` report where game-win counts differ but `winner` names the
+  side with fewer game wins, AND a test confirming a `COMMANDER_POD`
+  `Decisive` result with no `game_wins` validates on winner-membership alone
+  (no spurious game-win check at pod arity).
+- A dedicated test asserting `TiebreakOrder::for_arity` selects `HeadToHead`
+  at arity 2 and `Multiplayer` at arity > 2, and that both orders' floor
+  computes as `1.0 / scoring.win_points` (0.33 at arity 2, ~0.14 at arity 4)
+  rather than a hardcoded constant.
+- Test vectors pinned against the MTR's and MSTR's own worked examples where
+  practical (per the discussion's proposal).
+- No protocol changes, no shell wiring — reviewable purely as an algorithm +
+  state machine, independent of PRs 2-4.
+
+**PR 2 — protocol + native server.**
+`protocol.rs` new `LobbyClientMessage`/`LobbyServerMessage` variants and view
+types (`TournamentView`, `TournamentSummary`, `TournamentStanding`,
+`PairingView` — `PairingView.players: Vec<PlayerSummary>`, not a fixed
+`player_a`/`player_b` pair, so the wire shape itself doesn't bake in
+head-to-head), `CreateTournament`'s payload carries `arity: MatchArity`
+alongside `scoring`/`bracket`, protocol version bump — **from 13 to 14** (confirmed current
+value is 13, not 12 — see CONTEXT.md finding #4; do not copy #4615's stale
+"v12" framing). `broker.rs` gains the `tournaments: TournamentManager` field
+and the `ConnState` organizer/joined-tournament fields **as tokens** (§3
+above, not bare identifiers). Native server dispatch arms in
+`phase-server/src/main.rs`. Reaper keyed off `last_activity_at`, restricted
+to `Registration`-status tournaments (§2 above).
+
+**PR 3 — Cloudflare Worker shell.**
+`lobby-worker/broker-wasm` `mutates_lobby` match extension, `lobby-do.ts`
+`ConnAttachment` extension, and **the corrected `is_empty()` predicate**:
+```rust
+pub fn is_empty(&self) -> bool {
+    self.inner.lobby().is_empty() && self.inner.tournaments().is_empty()
+}
+```
+confirmed today's `is_empty()` (`lobby-worker/broker-wasm/src/lib.rs:168-170`)
+only checks `self.inner.lobby()` — this predicate MUST be updated in the same
+PR that adds the `tournaments` field to `Broker`, not deferred, or a
+tournament-only Durable Object will stop rescheduling its cleanup alarm
+(exactly #4615's finding #4).
+
+**PR 4 — frontend.**
+`adapter/types.ts` mirrors, `tournamentClient.ts`, `TournamentLandingPage.tsx`
+/`TournamentPage.tsx` + presentational components, i18n keys from day one, routes/nav
+entry. **Acceptance criteria beyond "renders":**
+- Every RPC handler must close its socket via a single shared
+  connect/request/close wrapper (or a `finally` block) — #4615 leaked a
+  socket on the error path of every single RPC handler (six confirmed
+  instances, RESEARCH.md §3b), not just one; design the client so this bug
+  class is structurally impossible rather than manually replicating
+  `finally { client?.close(); }` six times.
+- Explicit socket-close on unmount, including the cancelled-connect race
+  (the `cancelled` flag pattern from #4615's own code was present but
+  incomplete — it set the flag but never called `.close()` on the socket
+  that resolved after cancellation).
+- All new UI chrome routed through `t()` per `client/src/i18n/README.md`
+  from the first commit — no English-only strings landing then retrofitted.
+
+## 5. Explicitly out of scope for v1 (unchanged from discussion, confirmed not contradicted by this session's findings)
+
+- Full-mode (server-managed `GameSession`) auto-launch per pairing — v1
+  stays lobby-only, matching #4612's original framing exactly.
+- Central validation of *reported score content* beyond winner/game-win
+  consistency (§2's `validate_match_result` fix) — MTR's own model is
+  self-reporting (§2.4), and the broker already trusts client-supplied
+  identity elsewhere (deck contents aren't server-validated either, per
+  #4612's own stated limitation). The authority-token fix (§3) is about
+  *who* may report, not fact-checking *what* they report.
+- `ScoringPolicy` hooking into the custom-format-engine (phase 58) —
+  see CONTEXT.md's "Relationship to adjacent work." Recommend building
+  `ScoringPolicy` standalone in `lobby-broker` regardless of phase 58's
+  landing order.
+- Auto-advance round timers — leave organizer-gated for v1 pending
+  maintainer input; additive later either way.
+- Per-seat placement scoring within a pod (2nd/3rd/4th tracked separately,
+  rather than just winner/everyone-else) — MSTR itself doesn't track this
+  ("no placement tracking beyond winner/loser status" within a single pod
+  match, RESEARCH.md §13); `PodOutcome` deliberately has no room for it.
+  Revisit only if a real request surfaces, same as the other MSTR/MTR
+  fixed-value decisions above.
+- Variable pod size *within* a single round beyond the one-short-pod
+  fallback (e.g. deliberately mixing 3- and 4-player pods for reasons other
+  than an indivisible player count) — v1 always prefers full `arity`-size
+  pods and falls back to at most one short pod per round, per MSTR's own
+  stated preference; anything more elaborate is unneeded product scope for
+  a first cut.
+
+## 6. Testing
+
+Per CLAUDE.md's "test the building block, not the special case": tests
+target `TournamentManager`'s pairing/standings/expiry functions across their
+full parameter range — varying player counts including odd/even, varying
+`ScoringPolicy` values including a non-default draw-value policy, varying
+bracket shapes, **and varying `MatchArity` (2 and 4 at minimum, ideally also
+an uncommon size like 3 or 6 to confirm nothing hardcodes "4")** — not a
+single fixed "8-player Swiss tournament" happy-path test. The specific
+regression tests called out in PR 1's acceptance criteria (odd-bracket
+swap-repair, winner/game-win consistency, short-pod fairness,
+arity-selected tiebreak order) exist precisely because #4615's existing 90
+tests didn't cover the arity-2 cases, and nothing existed yet to cover
+arity > 2 at all; any building block introduced here needs a test that
+would have caught each of the seven review findings plus the Commander-pod
+gap, not just tests for the successful head-to-head path.

--- a/docs/proposals/tournament-organizer/PLAN.md
+++ b/docs/proposals/tournament-organizer/PLAN.md
@@ -29,8 +29,10 @@ tiebreaker logic across two near-identical code paths that differ only in
 one number. Instead, `MatchArity` (§2) is threaded through pairing,
 `ScoringPolicy`, and tiebreak order as a single parameter — `arity = 2`
 *is* today's design, not a special case of a new one. Full grounding in the
-official Multiplayer Addendum to the Magic Tournament Rules (MSTR) and
-TopDeck.gg's production Commander-pairing practice is in RESEARCH.md §13.
+Multiplayer Addendum to the Magic Tournament Rules ("MSTR" — an unofficial,
+independent-judge-authored convention this proposal deliberately adopts,
+NOT a Wizards of the Coast document; see RESEARCH.md §13) and TopDeck.gg's
+production Commander-pairing practice is in RESEARCH.md §13.
 
 ### Building Blocks — reused, not reinvented
 
@@ -147,10 +149,12 @@ immediately for the tiebreaker floor too: MTR's 1v1 floor is a hardcoded
 0.33, MSTR's 4-player-pod floor is a hardcoded ~0.14 — both are the *same*
 formula, `1.0 / scoring.win_points as f64` (1/3 ≈ 0.33, 1/7 ≈ 0.14), so the
 floor needs no arity branch at all. Tiebreaker *order itself* is
-arity-selected, not TO-configurable (§2 below) — MTR and MSTR use genuinely
-different tiebreak axes, not just different numbers plugged into the same
-axes, so this can't be unified the way the floor was; ship both fixed to
-their respective official values, revisit only if a real request surfaces.
+arity-selected, not TO-configurable (§2 below) — MTR (official) and MSTR
+(the unofficial convention this proposal adopts for multiplayer, RESEARCH.md
+§13) use genuinely different tiebreak axes, not just different numbers
+plugged into the same axes, so this can't be unified the way the floor was;
+ship both fixed to their respective cited values, revisit only if a real
+request surfaces.
 
 `MatchArity` and `ScoringPolicy` are supplied once at `CreateTournament`
 time and stored on the `TournamentMeta`, immutable for the tournament's
@@ -217,15 +221,18 @@ incomplete relative to the MTR table it cites as its own round-count source.
 This applies at `arity = HEAD_TO_HEAD` only, gated to the existing fixed
 8-seat case (RESEARCH.md §11).
 
-**Pod-based single elimination (`arity > HEAD_TO_HEAD`) is explicitly OUT OF
-SCOPE for v1 — maintainer review correctly rejected this section's earlier
-"in-scope, not designed further" framing.** Bracket/advancement semantics
-for a pod (does a 4-player bracket match have one winner and three
-eliminated, or does it need its own seeding/advancement rules distinct from
-adjacent-pair 1v1 SE?) are genuinely undesigned, and per CONTEXT.md open
-question #4 this is a live, unresolved product question, not a mechanical
-extension of the 1v1 gate. `v1` ships `BracketShape::SingleElimination`
-for `arity = HEAD_TO_HEAD` only; `CreateTournament` must reject
+**Pod-based single elimination (`arity > HEAD_TO_HEAD`) is excluded from v1
+— DECIDED, not a live question.** Maintainer review correctly rejected
+this section's earlier "in-scope, not designed further" framing: bracket/
+advancement semantics for a pod (does a 4-player bracket match have one
+winner and three eliminated, or does it need its own seeding/advancement
+rules distinct from adjacent-pair 1v1 SE?) were genuinely undesigned, which
+is exactly why exclusion — not silent scope creep — is the resolution.
+**The scope decision itself (excluded from v1) is final; only the
+*underlying design question* (what pod-SE would look like if someone
+builds it later) remains open, tracked as future work, not as a blocker on
+this proposal.** `v1` ships `BracketShape::SingleElimination` for
+`arity = HEAD_TO_HEAD` only; `CreateTournament` must reject
 `SingleElimination` paired with `arity != HEAD_TO_HEAD` at construction
 time (the same "reject explicitly rather than silently drop data" posture
 the sibling custom-format-engine proposal uses for its own unsupported
@@ -235,8 +242,10 @@ combinations). Commander/multiplayer pods get Swiss only in v1 — see §5.
 generalized over `arity` (supersedes this doc's earlier backtracking
 design).** This session's earlier draft proposed fixing #4615's backtracking
 bug in place (a one-line base-case fix). Generalizing to N-player pods
-makes that moot: the official MSTR algorithm (RESEARCH.md §13) is itself
-non-backtracking, and it's the same *shape* CONTEXT.md finding #8 already
+makes that moot: the MSTR convention's own algorithm (an unofficial,
+community-authored document this proposal adopts, RESEARCH.md §13) is
+itself non-backtracking, and it's the same *shape* CONTEXT.md finding #8
+already
 recommended adopting from `draft-core`'s existing 1v1 pairing (greedy
 top-down assignment + carry/swap repair, no recursive search) — one
 generalized algorithm now satisfies both the odd-bracket-bug fix and the
@@ -255,15 +264,41 @@ Commander-pod requirement, rather than needing two:
    standings — MSTR's own repair step, not a novel design. A player moved
    into a pod above their standing is "paired up"; moved below is "paired
    down" (recorded for organizer visibility only, not scored differently).
-4. **Pod-size fallback, `arity > 2` only**: prefer as many full `arity`-size
-   pods as possible; when the active-player count doesn't divide evenly,
-   form one *short pod* of `arity.0 - 1` rather than issuing more than one
-   bye (MSTR: "pods may consist of a minimum of 3 players to avoid multiple
-   byes" for 4-player events). Prefer assigning the short pod to a player
-   who hasn't already had one (`had_short_pod`), mirroring bye fairness —
-   a player should not be shorted twice before every other player has been
-   shorted once, same fairness rule as `had_bye`. At `arity = 2` there is no
-   short-pod case (`arity.0 - 1 == 1`, which is just the existing bye path).
+4. **Pod-size fallback, `arity > 2` only — REVISED, maintainer review: the
+   original "form one short pod" text was a real math error, not a
+   simplification.** A single `arity - 1` short pod cannot seat every
+   non-divisible player count: at `arity = 4`, 9 players need THREE short
+   pods (`3+3+3` — a single 4-pod-plus-one-short-pod only accounts for 7),
+   and 10 players need TWO (`4+3+3`, not `4+4+`-with-one-short). Capping at
+   "at most one short pod" was simply wrong, not a deliberate scope
+   decision.
+
+   **General partition algorithm** (works for any `arity`, not just 4):
+   given `n` active players and pod size `arity.0`, find the smallest
+   `b ≥ 0` such that `n - b * (arity.0 - 1)` is a non-negative multiple of
+   `arity.0`; that `b` is the number of short (`arity.0 - 1`-player) pods,
+   and `(n - b * (arity.0 - 1)) / arity.0` is the number of full pods. This
+   always finds a solution with `b` in `0..arity.0` when one exists, because
+   `arity.0` and `arity.0 - 1` are always coprime (consecutive integers) —
+   by the same reasoning the Chicken McNugget/Frobenius bound gives for any
+   two coprime pod sizes, the only counts with NO all-`{arity-1,arity}`
+   partition are the small ones below `(arity.0 - 1) * (arity.0 - 2)` that
+   the formula fails to solve (for `arity = 4`: `n ∈ {1, 2, 5}` — these
+   degenerate cases fall through to bye assignment below, same as today,
+   not a new mechanism). Minimizing `b` first (trying `b = 0, 1, 2, ...`
+   in order and taking the first fit) is what makes 9 players resolve to
+   `3+3+3` (`b=3`, the minimum that works — `b=0,1,2` all fail divisibility)
+   and 10 players resolve to `4+3+3` (`b=2`) rather than an arbitrarily
+   larger number of short pods.
+
+   Fairness now spreads across however many short pods a round actually
+   needs (potentially more than one), not just one: when selecting which
+   `b * (arity.0 - 1)` players go into short pods this round, prefer players
+   who haven't already had one (`had_short_pod`) across the full selection,
+   the same fairness rule as `had_bye`, generalized from "pick one player"
+   to "pick the `b`-pod-worth of players." At `arity = 2` there is no
+   short-pod case (`arity.0 - 1 == 1`, which is just the existing bye
+   path) — this fallback is `arity > 2` only, unchanged.
 5. Bye assignment (any `arity`, and the only path at `arity = 2`) prefers a
    player who hasn't already had one (`had_bye` flag) among any players
    still unassignable after pod-size fallback.
@@ -391,10 +426,12 @@ order are all designed as functions of it from day one.
   rematch-prone pairing — this is the exact case #4615's 90 passing tests
   missed.
 - A dedicated test for `COMMANDER_POD` arity with a player count that
-  doesn't divide evenly by 4 (e.g. 9, 10, 11 players), asserting a single
-  short pod (not multiple byes) forms, and that `had_short_pod` fairness
-  prevents the same player being shorted twice before every player has been
-  shorted once.
+  doesn't divide evenly by 4 — including 9 players (must resolve to three
+  short pods, `3+3+3`, not one) and 10 players (must resolve to `4+3+3`) —
+  asserting §2's partition algorithm produces the correct minimum-short-pod
+  count for each, no bye is issued when a short-pod-only partition exists,
+  and `had_short_pod` fairness spreads correctly across however many
+  players a round actually shorts (not just tracking a single player).
 - A dedicated test asserting `validate_match_result` rejects a
   `HEAD_TO_HEAD` report where game-win counts differ but `winner` names the
   side with fewer game wins, AND a test confirming a `COMMANDER_POD`
@@ -488,12 +525,13 @@ entry. **Acceptance criteria beyond "renders":**
   match, RESEARCH.md §13); `PodOutcome` deliberately has no room for it.
   Revisit only if a real request surfaces, same as the other MSTR/MTR
   fixed-value decisions above.
-- Variable pod size *within* a single round beyond the one-short-pod
-  fallback (e.g. deliberately mixing 3- and 4-player pods for reasons other
-  than an indivisible player count) — v1 always prefers full `arity`-size
-  pods and falls back to at most one short pod per round, per MSTR's own
-  stated preference; anything more elaborate is unneeded product scope for
-  a first cut.
+- Variable pod size *within* a single round beyond what §2's partition
+  algorithm requires (e.g. deliberately mixing 3- and 4-player pods for
+  reasons other than seating an indivisible player count — an organizer
+  preference lever, not a seating-math necessity) — v1 always uses the
+  minimum number of short pods the partition algorithm computes, never an
+  arbitrary organizer-chosen mix; anything more elaborate is unneeded
+  product scope for a first cut.
 - **Pod-based single elimination (`arity > HEAD_TO_HEAD`, §2) — maintainer
   review correctly rejected an earlier "in-scope, not designed further"
   framing for this.** Bracket/advancement semantics for a multi-player pod

--- a/docs/proposals/tournament-organizer/PLAN.md
+++ b/docs/proposals/tournament-organizer/PLAN.md
@@ -283,9 +283,9 @@ Commander-pod requirement, rather than needing two:
    by the same reasoning the Chicken McNugget/Frobenius bound gives for any
    two coprime pod sizes, the only counts with NO all-`{arity-1,arity}`
    partition are the small ones below `(arity.0 - 1) * (arity.0 - 2)` that
-   the formula fails to solve (for `arity = 4`: `n ∈ {1, 2, 5}` — these
-   degenerate cases fall through to bye assignment below, same as today,
-   not a new mechanism). Minimizing `b` first (trying `b = 0, 1, 2, ...`
+   the formula fails to solve (for `arity = 4`: `n ∈ {1, 2, 5}` — see the
+   explicit per-count resolution below, not left as an undefined
+   fall-through). Minimizing `b` first (trying `b = 0, 1, 2, ...`
    in order and taking the first fit) is what makes 9 players resolve to
    `3+3+3` (`b=3`, the minimum that works — `b=0,1,2` all fail divisibility)
    and 10 players resolve to `4+3+3` (`b=2`) rather than an arbitrarily
@@ -299,6 +299,39 @@ Commander-pod requirement, rather than needing two:
    to "pick the `b`-pod-worth of players." At `arity = 2` there is no
    short-pod case (`arity.0 - 1 == 1`, which is just the existing bye
    path) — this fallback is `arity > 2` only, unchanged.
+
+   **Explicit resolution for `n ∈ {0, 1, 2, 5}` at `arity = 4` — CodeRabbit
+   flagged this as undefined; it is not new mechanism, but it does need
+   stating explicitly rather than left as an implicit fall-through:**
+   - `n = 0`: no active players remain to pair. This isn't a pairing
+     outcome at all — it means the tournament has no players left to run a
+     round for, which is a tournament-completion condition (§2's broader
+     lifecycle), not something this pairing step needs to handle.
+   - `n = 1`: the sole active player gets a bye — same single-bye path §2
+     point 5 already specifies (scores as a win, excluded from
+     opponents'-percentage averaging per point 6 below). No pod forms.
+   - `n = 2`: no pod of size 3 or 4 can be formed from 2 players, and no
+     single short pod covers it either — this is the one genuine exception
+     to "avoid multiple byes": **both players receive a bye this round**,
+     each scored via the same existing bye rule (point 6). This is an
+     accepted, explicit exception to the "prefer one short pod over
+     multiple byes" preference (§13's MSTR citation), not a violation of
+     it — that preference exists to avoid multiple byes when a valid pod
+     partition is available; at `n = 2` none is.
+   - `n = 5`: resolves to one 4-pod plus a single bye for the fifth
+     player (the partition algorithm's own `b` search correctly finds no
+     `{3,4}`-only solution at `n=5`, so this case's bye is assigned via
+     point 5 exactly as for `n=1` — only one bye, not the `n=2` exception,
+     since a valid 4-player pod IS available here).
+   - **Player drops mid-round producing any of these counts** (a
+     tournament that started larger can shrink to `n ∈ {0,1,2,5}` active
+     players through drops in a later round) use this exact same
+     resolution — there is no separate mechanism for "reached this count
+     via drops" versus "started at this count." A dropped player is simply
+     excluded from the active-player count `n` this pairing step operates
+     on, per the existing `TournamentPlayer.dropped` field (§2 above); they
+     never appear in that round's pairings or standings-affecting bye
+     assignment.
 5. Bye assignment (any `arity`, and the only path at `arity = 2`) prefers a
    player who hasn't already had one (`had_bye` flag) among any players
    still unassignable after pod-size fallback.
@@ -432,6 +465,15 @@ order are all designed as functions of it from day one.
   count for each, no bye is issued when a short-pod-only partition exists,
   and `had_short_pod` fairness spreads correctly across however many
   players a round actually shorts (not just tracking a single player).
+- **NEW — CodeRabbit**: a dedicated test for each `COMMANDER_POD`-arity
+  degenerate active-player count — `n = 1` (single bye, no pod, scored per
+  point 5), `n = 2` (both players receive a bye — the one explicit
+  multiple-bye exception, both scored per point 5, no pod attempted), and
+  `n = 5` (one 4-pod plus exactly one bye, not the `n=2` multi-bye case) —
+  plus a test confirming a mid-tournament drop that reduces the active
+  count to one of these values (e.g. 6 active players, 1 drops mid-event,
+  leaving 5 for the next round) resolves identically to starting a round
+  at that count directly, proving drops aren't a separate code path.
 - A dedicated test asserting `validate_match_result` rejects a
   `HEAD_TO_HEAD` report where game-win counts differ but `winner` names the
   side with fewer game wins, AND a test confirming a `COMMANDER_POD`

--- a/docs/proposals/tournament-organizer/PLAN.md
+++ b/docs/proposals/tournament-organizer/PLAN.md
@@ -159,18 +159,83 @@ impl From<MatchArity> for u8 {
 /// work" for why this is NOT a field of the engine crate's
 /// `CustomFormatDef`/`LegacyRuleSet` (phase 58).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(try_from = "RawScoringPolicy", into = "RawScoringPolicy")]
 pub struct ScoringPolicy {
+    win_points: u8,  // REVISED, maintainer review: private — see `new()`
+    draw_points: u8, // below. `ScoringPolicy` is organizer-overridable at
+    loss_points: u8, // `CreateTournament` (this doc's own §1 text, above),
+                     // exactly like `MatchArity` — it needed the identical
+                     // validated-construction treatment `MatchArity` got in
+                     // an earlier round, not a narrower exemption.
+}
+
+/// Plain deserialization target for the `#[serde(try_from = ...)]`
+/// boundary — same pattern `MatchArity` uses via `try_from = "u8"`,
+/// generalized to a 3-field struct instead of a single scalar.
+#[derive(Deserialize)]
+pub struct RawScoringPolicy {
     pub win_points: u8,
     pub draw_points: u8,
     pub loss_points: u8,
 }
 
 impl ScoringPolicy {
+    /// NEW, maintainer review — validated construction. `win_points == 0`
+    /// is rejected here: it is the shared tiebreak floor's denominator
+    /// (`1.0 / scoring.win_points as f64`, below) — zero reaches an
+    /// invalid (infinite) floor instead of being caught at the boundary
+    /// where organizer-supplied configuration actually enters the broker.
+    /// Per review scope: this does NOT impose any ordering between
+    /// `win_points`/`draw_points`/`loss_points` — organizer overrides are
+    /// explicitly supported (some communities score draws as 0, TopDeck.gg
+    /// uses a different win value entirely) and a stricter ordering rule
+    /// would need its own separately-cited requirement, not an
+    /// implicit side effect of this fix.
+    pub fn new(win_points: u8, draw_points: u8, loss_points: u8) -> Result<Self, String> {
+        if win_points == 0 {
+            return Err(
+                "win_points must be non-zero — used as the tiebreak floor's denominator".to_string(),
+            );
+        }
+        Ok(Self { win_points, draw_points, loss_points })
+    }
+
+    pub fn win_points(&self) -> u8 {
+        self.win_points
+    }
+    pub fn draw_points(&self) -> u8 {
+        self.draw_points
+    }
+    pub fn loss_points(&self) -> u8 {
+        self.loss_points
+    }
+
     /// MSTR-derived default: `2n - 1` match points for a win, `n` being
     /// `MatchArity`. At `arity = HEAD_TO_HEAD` this is exactly MTR §2.1's
-    /// 3/1/0 — the same formula, not a special case of it.
+    /// 3/1/0 — the same formula, not a special case of it. `arity` is
+    /// already validated to `2..=128` by `MatchArity::new` (§1 above), so
+    /// `2 * arity.0 - 1` is always in `3..=255` here — never zero, so this
+    /// internal construction path doesn't need to route through the
+    /// fallible `new()` the way external/deserialized input does.
     pub fn default_for_arity(arity: MatchArity) -> Self {
         Self { win_points: 2 * arity.0 - 1, draw_points: 1, loss_points: 0 }
+    }
+}
+
+impl TryFrom<RawScoringPolicy> for ScoringPolicy {
+    type Error = String;
+    fn try_from(raw: RawScoringPolicy) -> Result<Self, String> {
+        Self::new(raw.win_points, raw.draw_points, raw.loss_points)
+    }
+}
+
+impl From<ScoringPolicy> for RawScoringPolicy {
+    fn from(policy: ScoringPolicy) -> Self {
+        Self {
+            win_points: policy.win_points,
+            draw_points: policy.draw_points,
+            loss_points: policy.loss_points,
+        }
     }
 }
 
@@ -797,6 +862,19 @@ regression test for the exact overflow maintainer review identified.
 Deserializing a `CreateTournament` payload with `arity: 0` in its wire
 JSON is rejected at deserialization (via `#[serde(try_from = "u8")]`), not
 accepted and only discovered broken later.
+
+**NEW — maintainer review (`ScoringPolicy` validated construction, §1)**:
+the identical sibling test for the identical sibling gap — `ScoringPolicy::
+new(0, 1, 0)` returns `Err`; `new(3, 1, 0)` succeeds; a `CreateTournament`
+payload whose wire JSON carries `scoring.win_points: 0` is rejected at
+deserialization (via `#[serde(try_from = "RawScoringPolicy")]`), never
+reaching the tiebreak floor's `1.0 / scoring.win_points as f64` division as
+a live `NaN`/`inf` value. `new(3, 1, 0)` and every other combination with
+`win_points > 0` succeeds regardless of the relationship between
+`win_points`/`draw_points`/`loss_points` — this validation is deliberately
+scoped to the one value that's structurally unsafe (a zero denominator),
+not a policy opinion about which combinations of the three are sensible
+tournament rules.
 
 **NEW — maintainer review (durable pairing history and replay-safe
 correction, §2)**: a test that reports a result for a pairing, then reports

--- a/docs/proposals/tournament-organizer/PLAN.md
+++ b/docs/proposals/tournament-organizer/PLAN.md
@@ -98,11 +98,53 @@ file:line evidence in RESEARCH.md, not assumed from the discussion's prose.
 /// `TournamentFormat::Commander` split would duplicate three algorithms
 /// that differ only in this one number.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
-pub struct MatchArity(pub u8);
+#[serde(try_from = "u8", into = "u8")]
+pub struct MatchArity(u8); // REVISED, maintainer review: field is now private —
+                           // construction goes through `new()`, never a bare
+                           // tuple-struct literal or an unvalidated deserialize.
 
 impl MatchArity {
     pub const HEAD_TO_HEAD: MatchArity = MatchArity(2);
     pub const COMMANDER_POD: MatchArity = MatchArity(4);
+
+    /// NEW, maintainer review — validated construction. Rejects `0`/`1`
+    /// (not a real "players per pairing" count — a pairing needs at least
+    /// two seats to pair anyone) and caps at `128`, the largest `n` for
+    /// which `win_points = 2n - 1` still fits `u8` (`2*128-1 = 255`).
+    /// `#[serde(try_from = "u8")]` above routes wire deserialization through
+    /// this same constructor — a malformed `CreateTournament` payload is
+    /// rejected at the deserialization boundary, not accepted and only
+    /// discovered broken later inside pairing/scoring logic.
+    pub fn new(n: u8) -> Result<Self, String> {
+        if n < 2 {
+            return Err(format!(
+                "MatchArity must be at least 2 (a pairing needs ≥2 seats), got {n}"
+            ));
+        }
+        if n > 128 {
+            return Err(format!(
+                "MatchArity {n} exceeds 128 — win_points (2n-1) would overflow u8"
+            ));
+        }
+        Ok(MatchArity(n))
+    }
+
+    pub fn get(self) -> u8 {
+        self.0
+    }
+}
+
+impl TryFrom<u8> for MatchArity {
+    type Error = String;
+    fn try_from(n: u8) -> Result<Self, Self::Error> {
+        Self::new(n)
+    }
+}
+
+impl From<MatchArity> for u8 {
+    fn from(arity: MatchArity) -> u8 {
+        arity.0
+    }
 }
 
 /// Tournament match-point scoring. MSTR generalizes MTR §2.1's 3/1/0 to a
@@ -189,26 +231,90 @@ pub struct TournamentPlayer {
     pub player_token: String,             // minted at join, NOT socket-bound — fixes #4615 finding #1
     pub display_name: String,
     pub dropped: bool,
-    pub had_bye: bool,                    // bye assignment prefers players who haven't had one
-    pub had_short_pod: bool,               // NEW: arity > 2 only — see pod-sizing below
+    // NOTE, maintainer review: `had_bye`/`had_short_pod` are NOT stored
+    // fields here anymore — see the "Durable pairing history" note below
+    // `TournamentPairing` for why they moved to derived queries over
+    // `pairings` instead.
 }
 
-/// A single pairing. 2 players for a head-to-head match. Up to `arity`
-/// players for a pod match; may be exactly `arity - 1` for a *short pod*
-/// (MSTR: prefer one undersized pod over multiple byes — see below) or
-/// exactly 1 for a genuine bye.
+/// REVISED, maintainer review — `TournamentPairing` gains a stable identity
+/// and an explicit, durable outcome slot. The previous sketch (`round` +
+/// `players` only) could describe WHO is paired but had nowhere to durably
+/// record WHAT happened, even though rematch avoidance (§2 point 2 above)
+/// and standings/tiebreak computation (below) both require querying prior
+/// results and prior opponents — there was no data for those queries to
+/// read. Fixed by making `pairings` (on `TournamentMeta`) the single
+/// source of truth every derived view reads fresh, not an incrementally-
+/// mutated side structure that a corrected/re-reported result could drift
+/// out of sync with:
+///
+/// - **Durable pairing history.** `pairings: Vec<TournamentPairing>`
+///   accumulates every pairing ever generated, across every round — never
+///   pruned, never summarized into running totals elsewhere. Match points,
+///   opponents faced (rematch avoidance and tiebreak averaging alike),
+///   `had_bye`, and `had_short_pod` are ALL derived by scanning this list
+///   fresh, not stored as separately-mutated fields anywhere:
+///   `fn had_bye(key, pairings) -> bool` (any pairing where
+///   `players == [key]` and `outcome == Some(Bye)`),
+///   `fn had_short_pod(key, arity, pairings) -> bool` (any pairing sized
+///   `arity.get() - 1` containing `key`), `fn prior_opponents(key,
+///   pairings) -> HashSet<String>` (every co-`players` entry across every
+///   pairing containing `key`). This is what makes "replay-safe result
+///   update" well-defined: `report_result(pairing_id, outcome)` is a single
+///   `pairings[i].outcome = Some(outcome)` write (a correction simply
+///   overwrites the prior value), and every derived view recomputes from
+///   the corrected history on its next read — there is no separate cache
+///   or running total that a correction could leave stale.
+///
+/// `players` holds 2 keys for a head-to-head pairing, up to `arity` for a
+/// pod pairing; it may be exactly `arity - 1` for a *short pod* (§2 point
+/// 4) or exactly 1 for a bye (§2 point 5).
 pub struct TournamentPairing {
+    pub id: PairingId,                    // stable identity — see below
     pub round: u32,
     pub players: Vec<String>,             // player_key, len in 1..=arity.0
+    pub outcome: Option<PairingOutcome>,   // None = pending; Some(_) once resolved
 }
 
-/// One pairing's reported outcome. MSTR: "Match results, not individual
-/// Game results, are reported" for pods — a pod match has exactly one
-/// winner or is a full draw, never per-seat placement (RESEARCH.md §13).
+/// Stable, tournament-scoped pairing identity — a monotonic counter, not a
+/// re-derivable index (pairings are never removed or reordered, so a plain
+/// `u32` counter minted at generation time is sufficient; no UUID needed
+/// since this never leaves the tournament's own scope).
+pub type PairingId = u32;
+
+/// A pairing's resolved outcome, once it has one. REVISED, maintainer
+/// review: this now has THREE variants, not the two `PodOutcome` had
+/// before — `Bye` and `Forfeit` are pulled OUT of `PodOutcome` entirely
+/// rather than smuggled through it, because both are server-assigned
+/// facts, never client-reported results, and conflating them with a real
+/// reported `PodOutcome` was exactly the ambiguity maintainer review
+/// flagged ("does not distinguish a one-player bye from a reported
+/// draw/decisive match").
+pub enum PairingOutcome {
+    /// Auto-assigned the instant a 1-player pairing is generated (§2 point
+    /// 5) — never client-reported, never passes through
+    /// `validate_match_result`'s reported-outcome path at all.
+    Bye,
+    /// Auto-assigned when every player but one in a pairing has dropped
+    /// before the pairing was reported (§2's drop-timing note below) — the
+    /// remaining player wins by forfeit. Also never client-reported.
+    Forfeit { winner: String },
+    /// A real, client-or-organizer-reported result for a pairing that was
+    /// actually played.
+    Reported(PodOutcome),
+}
+
+/// The reported content of a PLAYED pairing. MSTR: "Match results, not
+/// individual Game results, are reported" for pods — a pod match has
+/// exactly one winner or is a full draw, never per-seat placement
+/// (RESEARCH.md §13). Never represents a bye or a forfeit — see
+/// `PairingOutcome` above.
 pub enum PodOutcome {
-    /// `game_wins` is only meaningful (and only validated) for a
-    /// `HEAD_TO_HEAD` pairing's Bo3 game-win consistency check below —
-    /// pods are single-game per MSTR default, so it's empty/unused there.
+    /// `game_wins` is validated differently by arity (see
+    /// `validate_match_result` below): for `HEAD_TO_HEAD`, it MUST contain
+    /// exactly the two participants with a legal completed-Bo3 tally; for
+    /// a pod (`arity > 2`), it MUST be empty — pods are single-game per
+    /// MSTR default, so there is no per-player game-win count to report.
     Decisive { winner: String, game_wins: std::collections::HashMap<String, u8> },
     Draw,
 }
@@ -294,8 +400,9 @@ Commander-pod requirement, rather than needing two:
    Fairness now spreads across however many short pods a round actually
    needs (potentially more than one), not just one: when selecting which
    `b * (arity.0 - 1)` players go into short pods this round, prefer players
-   who haven't already had one (`had_short_pod`) across the full selection,
-   the same fairness rule as `had_bye`, generalized from "pick one player"
+   who haven't already had one (`had_short_pod(key, arity, pairings)`, the
+   same derived-over-pairing-history query as `had_bye`, not a stored
+   field) across the full selection, generalized from "pick one player"
    to "pick the `b`-pod-worth of players." At `arity = 2` there is no
    short-pod case (`arity.0 - 1 == 1`, which is just the existing bye
    path) — this fallback is `arity > 2` only, unchanged.
@@ -323,18 +430,56 @@ Commander-pod requirement, rather than needing two:
      `{3,4}`-only solution at `n=5`, so this case's bye is assigned via
      point 5 exactly as for `n=1` — only one bye, not the `n=2` exception,
      since a valid 4-player pod IS available here).
-   - **Player drops mid-round producing any of these counts** (a
-     tournament that started larger can shrink to `n ∈ {0,1,2,5}` active
-     players through drops in a later round) use this exact same
-     resolution — there is no separate mechanism for "reached this count
-     via drops" versus "started at this count." A dropped player is simply
-     excluded from the active-player count `n` this pairing step operates
-     on, per the existing `TournamentPlayer.dropped` field (§2 above); they
-     never appear in that round's pairings or standings-affecting bye
-     assignment.
+   - **Drops that reduce the active pool BEFORE the next round's pairings
+     are generated** (a tournament that started larger can shrink to
+     `n ∈ {0,1,2,5}` active players through drops between rounds) use this
+     exact same resolution — there is no separate mechanism for "reached
+     this count via drops" versus "started at this count." A dropped
+     player is simply excluded from the active-player count `n` this
+     pairing step operates on, per the existing `TournamentPlayer.dropped`
+     field (§2 above); they never appear in that round's pairings or
+     standings-affecting bye assignment.
+   - **Drops AFTER a round's pairings are already generated, before that
+     pairing is reported — a genuinely different timing, REVISED per
+     maintainer/CodeRabbit review: the prior text only covered the
+     before-generation case and left this one unspecified.** When a drop is
+     recorded for a player who is a member of a `Pending` pairing for the
+     CURRENT round:
+     - **`HEAD_TO_HEAD` (2-player) pairing, one player drops:** the pairing
+       auto-settles immediately — the remaining player is awarded
+       `PairingOutcome::Forfeit { winner: remaining_player }` (§2's
+       `PairingOutcome` enum above), scored identically to a normal win at
+       `scoring.win_points`. This is a server-assigned fact, never a client
+       report, so it does not pass through `validate_match_result`'s
+       reported-outcome path (below) at all — mirroring exactly how a bye
+       is assigned, not reported.
+     - **Pod (`arity > 2`) pairing, one or more (but not all) players
+       drop:** the pod's `Pending` pairing is unaffected — the remaining
+       active players still play it out and report a real `PodOutcome`
+       when finished, same as if nobody had dropped. The ONE constraint:
+       `validate_match_result` (below) rejects a reported `winner` who has
+       since dropped — a dropped player cannot be credited a pod win after
+       the fact, even if the game was in their favor at the moment they
+       left.
+     - **Pod pairing where drops leave exactly one active player:** that
+       remaining player is awarded `PairingOutcome::Forfeit`, the same
+       mechanism as the head-to-head case, generalized — one auto-settled
+       forfeit-win for whoever is left, regardless of original pod size.
+     - **A pairing already `Some(outcome)` (already reported) before the
+       drop is recorded** is never retroactively altered — a later drop
+       cannot un-report a finished pairing; this is the same "corrections
+       overwrite, history doesn't get silently rewritten by unrelated
+       events" property the durable pairing-history design above already
+       establishes.
 5. Bye assignment (any `arity`, and the only path at `arity = 2`) prefers a
-   player who hasn't already had one (`had_bye` flag) among any players
-   still unassignable after pod-size fallback.
+   player who hasn't already had one (`had_bye(key, pairings)`, a derived
+   query over the pairing history — see the "Durable pairing history" note
+   above `TournamentPairing`, not a stored field) among any players still
+   unassignable after pod-size fallback. The generated pairing is a
+   1-player `TournamentPairing` whose `outcome` is set to
+   `Some(PairingOutcome::Bye)` immediately at generation time — a bye is
+   never left `Pending` waiting for a report, since there is nothing to
+   report.
 6. A bye scores as a win at `scoring.win_points` (2-0/6 game points at
    `arity = 2` per MTR Appendix C; `2n - 1` match points with no game-win
    count at `arity > 2` per MSTR), and the bye round is **excluded** (not
@@ -376,8 +521,16 @@ opponent-average calculations — those two pieces of logic are genuinely
 arity-independent and stay unforked; only the ranked list of *which*
 percentages to compute, and in what order, differs.
 
-**Match result validation** — fixes #4615 finding #2 directly, generalized
-to `PodOutcome`/arbitrary pod size:
+**Match result validation** — fixes #4615 finding #2 directly, and REWRITTEN
+per maintainer review to close two further gaps: (a) a head-to-head report
+could previously carry an empty or one-sided `game_wins` map and still
+pass, since the Bo3 check only ran `if !game_wins.is_empty()`; (b) nothing
+distinguished a client attempting to report a bye/forfeit from a real
+played result, since both flowed through the same `PodOutcome` type. Fixed
+by operating on `PairingOutcome` (§2) directly — `Bye`/`Forfeit` are
+server-assigned and never reach this validator via a client message at
+all (the message type for reporting a result only carries a `PodOutcome`
+payload, never a bare `PairingOutcome` — see PR 2's protocol variants):
 ```rust
 fn validate_match_result(pairing: &TournamentPairing, result: &PodOutcome) -> Result<(), String> {
     match result {
@@ -386,16 +539,38 @@ fn validate_match_result(pairing: &TournamentPairing, result: &PodOutcome) -> Re
             if !pairing.players.contains(winner) {
                 return Err("Winner must be one of the pod's players".to_string());
             }
-            // Bo3 game-win consistency check applies ONLY to head-to-head
-            // pairings — MSTR pods are single-game, there's no per-player
-            // game-win count to cross-check.
-            if pairing.players.len() == 2 && !game_wins.is_empty() {
+            if pairing.players.len() == 2 {
+                // HEAD_TO_HEAD — REVISED: require EXACTLY the two
+                // participant keys with a legal completed-Bo3 tally, not
+                // "if present, must be consistent." An empty or
+                // single-key game_wins map is now a hard rejection, not a
+                // silently-skipped check.
                 let (a, b) = (&pairing.players[0], &pairing.players[1]);
-                if game_wins.get(a) != game_wins.get(b) {
-                    let expected = if game_wins.get(a) > game_wins.get(b) { a } else { b };
-                    if winner != expected {
-                        return Err("Winner must match the player with more game wins".to_string());
-                    }
+                if game_wins.len() != 2 || !game_wins.contains_key(a) || !game_wins.contains_key(b) {
+                    return Err(
+                        "Head-to-head result must report game wins for exactly both players".to_string(),
+                    );
+                }
+                let (wa, wb) = (game_wins[a], game_wins[b]);
+                // Legal completed best-of-three tallies only: someone
+                // reaches 2, the other has 0 or 1. Rejects 1-0/0-0 (an
+                // unfinished match), 2-2, 3-anything, etc.
+                if !matches!((wa, wb), (2, 0) | (2, 1) | (0, 2) | (1, 2)) {
+                    return Err(format!("Illegal Bo3 game-win tally {wa}-{wb}"));
+                }
+                let expected = if wa > wb { a } else { b };
+                if winner != expected {
+                    return Err("Winner must match the player with more game wins".to_string());
+                }
+            } else {
+                // Pod (arity > 2) — REVISED: game_wins must be EMPTY, not
+                // merely unchecked. MSTR pods are single-game; a client
+                // attaching game-win data to a pod result has no value for
+                // it to mean, so reject rather than silently ignore.
+                if !game_wins.is_empty() {
+                    return Err(
+                        "Pod results are single-game per MSTR — game_wins must be empty".to_string(),
+                    );
                 }
             }
             Ok(())
@@ -403,6 +578,13 @@ fn validate_match_result(pairing: &TournamentPairing, result: &PodOutcome) -> Re
     }
 }
 ```
+A dropped player can never be the `winner` of a pod result reported after
+their drop — `validate_match_result` checks `pairing.players.contains(winner)`
+against the pairing's ORIGINAL seat list (drops don't remove a player from
+`pairing.players` retroactively), so this needs one more check specific to
+the drop-timing case above: reject `winner` if `TournamentPlayer.dropped`
+is true for that player at validation time, closing the "credited a win
+after leaving" gap the drop-timing note above calls out.
 
 **Expiry** — fixes #4615 finding #3 directly: `last_activity_at` bumped on
 every mutating call (`join_tournament`, `start_round`, `report_result`,
@@ -605,3 +787,45 @@ rejects `BracketShape::SingleElimination` paired with any
 concrete regression test proving pod-based SE's exclusion from v1 is an
 enforced construction-time rejection, not just a documentation note that a
 future implementer could silently miss.
+
+**NEW — maintainer review (`MatchArity` validated construction, §1)**:
+`MatchArity::new(0)` and `::new(1)` both return `Err`; `MatchArity::new(129)`
+returns `Err` (the first value where `2n-1` would overflow `u8`);
+`MatchArity::new(128)` succeeds and `ScoringPolicy::default_for_arity`
+produces `win_points: 255` without panicking or wrapping — the concrete
+regression test for the exact overflow maintainer review identified.
+Deserializing a `CreateTournament` payload with `arity: 0` in its wire
+JSON is rejected at deserialization (via `#[serde(try_from = "u8")]`), not
+accepted and only discovered broken later.
+
+**NEW — maintainer review (durable pairing history and replay-safe
+correction, §2)**: a test that reports a result for a pairing, then reports
+a DIFFERENT result for the same `pairing_id` (a correction), and asserts
+every derived view (standings, that pairing's own `outcome`, both players'
+`prior_opponents`) reflects only the corrected result — no residue from
+the first report anywhere, proving the derive-from-history design is
+genuinely replay-safe and not just replay-tolerant for the exact fields
+someone thought to reset. A second test asserts `had_bye`/`had_short_pod`/
+`prior_opponents` all correctly derive from a multi-round pairing history
+with no separate stored field to fall out of sync.
+
+**NEW — maintainer review (drop-timing forfeit resolution, §2)**: three
+dedicated tests — (a) a `HEAD_TO_HEAD` pairing where one player drops while
+`Pending` auto-resolves to `PairingOutcome::Forfeit` for the remaining
+player, scored as a normal win; (b) a pod pairing where one of four players
+drops while `Pending` does NOT auto-resolve — the pod stays `Pending` and
+a subsequent real `PodOutcome` report for the remaining players is
+accepted normally; (c) `validate_match_result` rejects a reported `winner`
+whose `TournamentPlayer.dropped` is true, even when that player is
+otherwise a legitimate member of `pairing.players`.
+
+**NEW — maintainer review (tightened head-to-head result validation, §2)**:
+a dedicated test matrix for `validate_match_result` covering every illegal
+`game_wins` shape for a `HEAD_TO_HEAD` pairing — empty map (rejected, was
+previously silently accepted), single-key map (rejected), a legal-looking
+but incomplete tally like `1-0` (rejected, not a completed Bo3), `2-2`
+(rejected), and each of the four legal completed tallies (`2-0`, `2-1`,
+`0-2`, `1-2`) accepted with the correct winner and rejected with the wrong
+one. A sibling test confirms a pod (`arity > 2`) result with a non-empty
+`game_wins` is rejected outright, and one with an empty map validates
+normally.

--- a/docs/proposals/tournament-organizer/PLAN.md
+++ b/docs/proposals/tournament-organizer/PLAN.md
@@ -684,6 +684,17 @@ field):
    `crates/phase-server/src/main.rs:1000`) — an abandoned registration
    (organizer created it, nobody ever joined or started it) is exactly the
    same shape of staleness the lobby's own 300s window already handles.
+   **REVISED, maintainer review: this is a deletion path exactly like the
+   30-day `Completed`/`Abandoned` retention deletion below, and needs the
+   identical delivery contract — the omission wasn't a deliberate
+   distinction, it was this rule simply predating the delivery-contract
+   section entirely (it was already in the doc before that section was
+   added) and never getting swept into it.** `check_expired` emits
+   `Outbound::ToSubscribers(LobbyServerMessage::TournamentRemoved { code
+   })` plus `TournamentListUpdate` for a reaped `Registration` tournament
+   too, same as any other deletion — see "Expiry event delivery" below,
+   which now covers all three deletion/transition outcomes uniformly, not
+   two of three.
 2. **`InProgress` — NEW, the previously-undefined case.** "Genuine
    inactivity" is defined as `last_activity_at` exceeding **7 days**
    (chosen to comfortably exceed any real multi-round Swiss event's
@@ -752,13 +763,17 @@ Tournament expiry needs the identical shape, generalized to two outcomes:
    original design) but were never wired to expiry specifically; this is
    the same authoritative full-state push a manual `ReportMatchResult`
    would already trigger, not a new message shape invented for this case.
-2. **Terminal deletion (`Completed`/`Abandoned` past the 30-day retention
-   window)** emits `Outbound::ToSubscribers(LobbyServerMessage::
+2. **Any deletion path — REVISED, maintainer review: this must cover all
+   three, not just the two newest ones** (`Registration` expiry at 300s,
+   same as always; `Completed`/`Abandoned` past the 30-day retention
+   window) — emits `Outbound::ToSubscribers(LobbyServerMessage::
    TournamentRemoved { code })` — a new variant, but named identically to
    the existing `LobbyGameRemoved` precedent it mirrors, for the same
    reason: a client holding a stale view of a now-gone tournament needs an
-   explicit "this no longer exists" signal, not silence.
-3. **Both cases additionally emit `Outbound::ToSubscribers(
+   explicit "this no longer exists" signal, not silence, regardless of
+   which status it was deleted from.
+3. **All three outcomes (the transition and both deletion cases)
+   additionally emit `Outbound::ToSubscribers(
    LobbyServerMessage::TournamentListUpdate { .. })`** (also already named
    in RESEARCH.md §1) so any tournament-browser/list view reflects the
    status change or removal, not just a client already viewing that one
@@ -1063,16 +1078,22 @@ untouched — proving the previously-missing terminal-state retention rule
 is actually enforced, not just documented.
 
 **NEW — maintainer review (expiry event delivery, §2)**: dedicated
-discriminating tests for each transition's outbound contract, not just its
-state change — (a) the `InProgress`→`Abandoned` transition's returned
-`Vec<Outbound>` contains a `TournamentUpdate` with the updated (Abandoned)
-view AND a `TournamentListUpdate`, not just a bare state mutation; (b) the
-terminal-deletion transition's returned outbounds contain a
-`TournamentRemoved` AND a `TournamentListUpdate`, never a bare deletion
-with no outbound at all; (c) a native-server integration test confirming
-the widened `main.rs` reap block actually recovers and dispatches BOTH new
-variants to `bg_lobby_subs` alongside its existing `LobbyGameRemoved`
-handling, not just one or the other; (d) the equivalent Cloudflare Worker
-test confirming the Durable Object alarm path fans out the same two
-variants through its own broadcast mechanism — proving PR 3 doesn't
-silently diverge from PR 2's delivery behavior.
+discriminating tests for EACH of the three outcomes' outbound contract,
+not just its state change — (a) the `InProgress`→`Abandoned` transition's
+returned `Vec<Outbound>` contains a `TournamentUpdate` with the updated
+(Abandoned) view AND a `TournamentListUpdate`, not just a bare state
+mutation; (b) the 30-day `Completed`/`Abandoned` terminal-deletion path's
+returned outbounds contain a `TournamentRemoved` AND a `TournamentListUpdate`;
+(c) **the 300-second `Registration`-expiry deletion path — NEW, maintainer
+review, previously untested alongside the other two — returns the
+identical `TournamentRemoved` + `TournamentListUpdate` pair**, not a bare
+deletion with no outbound at all (this is the exact gap review caught: the
+Registration path predates the delivery-contract section and was never
+swept into its test coverage either); (d) a native-server integration test
+confirming the widened `main.rs` reap block recovers and dispatches all
+three outcomes' variants to `bg_lobby_subs` alongside its existing
+`LobbyGameRemoved` handling, not just some of them; (e) the equivalent
+Cloudflare Worker test confirming the Durable Object alarm path fans out
+the same variants through its own broadcast mechanism for all three
+outcomes — proving PR 3 doesn't silently diverge from PR 2's delivery
+behavior for any of them.

--- a/docs/proposals/tournament-organizer/PLAN.md
+++ b/docs/proposals/tournament-organizer/PLAN.md
@@ -829,8 +829,18 @@ reasoning, which remains correct even as the specific numbers churn).
 `broker.rs` gains the `tournaments: TournamentManager` field
 and the `ConnState` organizer/joined-tournament fields **as tokens** (§3
 above, not bare identifiers). Native server dispatch arms in
-`phase-server/src/main.rs`. Reaper keyed off `last_activity_at`, restricted
-to `Registration`-status tournaments (§2 above).
+`phase-server/src/main.rs`. **Reaper — REVISED, maintainer review: the
+prior text here said the reaper was "restricted to `Registration`-status
+tournaments," which directly contradicted the all-status lifecycle §2
+itself specifies, and would have left the 7-day `InProgress`→`Abandoned`
+transition and the 30-day `Completed`/`Abandoned` retention window entirely
+unwired.** There is exactly ONE `check_expired` sweep, and it implements
+all three rules from §2's "Expiry / retention" note on every call — reap
+stale `Registration` (300s), transition stale `InProgress` to `Abandoned`
+(7 days), and delete retained `Completed`/`Abandoned` records (30 days).
+PR 2 wires this single all-status sweep into the existing native reaper
+call site (`main.rs:1000`) — it does not add a second reaper, a second
+timer, or a status-restricted variant.
 
 **PR 3 — Cloudflare Worker shell.**
 `lobby-worker/broker-wasm` `mutates_lobby` match extension, `lobby-do.ts`

--- a/docs/proposals/tournament-organizer/PLAN.md
+++ b/docs/proposals/tournament-organizer/PLAN.md
@@ -169,10 +169,16 @@ pub struct ScoringPolicy {
                      // an earlier round, not a narrower exemption.
 }
 
-/// Plain deserialization target for the `#[serde(try_from = ...)]`
-/// boundary — same pattern `MatchArity` uses via `try_from = "u8"`,
-/// generalized to a 3-field struct instead of a single scalar.
-#[derive(Deserialize)]
+/// Plain (de)serialization target for the `#[serde(try_from = ...,
+/// into = ...)]` boundary — same pattern `MatchArity` uses via
+/// `try_from = "u8"`, generalized to a 3-field struct instead of a single
+/// scalar. REVISED, maintainer review: must derive `Serialize` too, not
+/// only `Deserialize` — `#[serde(into = "RawScoringPolicy")]` on
+/// `ScoringPolicy` generates a `Serialize` impl that converts to this type
+/// and serializes THAT, so this type not implementing `Serialize` itself
+/// means `ScoringPolicy` silently fails to compile, not merely fails to
+/// round-trip.
+#[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct RawScoringPolicy {
     pub win_points: u8,
     pub draw_points: u8,
@@ -214,11 +220,19 @@ impl ScoringPolicy {
     /// `MatchArity`. At `arity = HEAD_TO_HEAD` this is exactly MTR §2.1's
     /// 3/1/0 — the same formula, not a special case of it. `arity` is
     /// already validated to `2..=128` by `MatchArity::new` (§1 above), so
-    /// `2 * arity.0 - 1` is always in `3..=255` here — never zero, so this
-    /// internal construction path doesn't need to route through the
-    /// fallible `new()` the way external/deserialized input does.
+    /// the FINAL value `2n - 1` is always in `3..=255` — but REVISED,
+    /// maintainer review: the INTERMEDIATE `2 * n` is not (`2 * 128 =
+    /// 256`, which overflows `u8` before the subtraction ever runs, even
+    /// though the post-subtraction result of `255` would have fit). Fixed
+    /// by computing in `u16` and converting down with a checked
+    /// conversion, not a bare `as` cast that would silently truncate on a
+    /// future arity bound change instead of panicking loudly in a debug
+    /// build:
     pub fn default_for_arity(arity: MatchArity) -> Self {
-        Self { win_points: 2 * arity.0 - 1, draw_points: 1, loss_points: 0 }
+        let n = u16::from(arity.0);
+        let win_points = u8::try_from(2 * n - 1)
+            .expect("MatchArity::new caps arity at 128, so 2n-1 always fits u8");
+        Self { win_points, draw_points: 1, loss_points: 0 }
     }
 }
 

--- a/docs/proposals/tournament-organizer/PLAN.md
+++ b/docs/proposals/tournament-organizer/PLAN.md
@@ -732,6 +732,49 @@ or background job beyond the reaper this design already calls for
 scope to also cover `InProgress`/`Completed`/`Abandoned` on every sweep,
 not add a second timer).
 
+**Expiry event delivery — NEW, maintainer review: the lifecycle rules above
+had no typed outbound/fan-out contract, so a reaper sweep could mutate
+durable tournament state while every connected client's view silently went
+stale.** The existing lobby reaper is the concrete precedent to mirror, not
+a novel mechanism: `Broker::reap_expired` (`crates/lobby-broker/src/
+broker.rs:306-314`) already maps each expired lobby game to
+`Outbound::ToSubscribers(LobbyServerMessage::LobbyGameRemoved{game_code})`,
+and the native shell's reaper timer (`main.rs`'s periodic sweep, ~line
+2095) already recovers those codes from the returned outbounds and fans
+them out to `bg_lobby_subs` — the shared subscriber list — via the same
+generic `Outbound::ToSubscribers` path every other broker message uses.
+Tournament expiry needs the identical shape, generalized to two outcomes:
+
+1. **`InProgress` → `Abandoned` (record persists, status changes)** emits
+   `Outbound::ToSubscribers(LobbyServerMessage::TournamentUpdate { code,
+   view })` — `TournamentUpdate` and `TournamentView` are already named in
+   this proposal's own protocol surface (RESEARCH.md §1, from #4612's
+   original design) but were never wired to expiry specifically; this is
+   the same authoritative full-state push a manual `ReportMatchResult`
+   would already trigger, not a new message shape invented for this case.
+2. **Terminal deletion (`Completed`/`Abandoned` past the 30-day retention
+   window)** emits `Outbound::ToSubscribers(LobbyServerMessage::
+   TournamentRemoved { code })` — a new variant, but named identically to
+   the existing `LobbyGameRemoved` precedent it mirrors, for the same
+   reason: a client holding a stale view of a now-gone tournament needs an
+   explicit "this no longer exists" signal, not silence.
+3. **Both cases additionally emit `Outbound::ToSubscribers(
+   LobbyServerMessage::TournamentListUpdate { .. })`** (also already named
+   in RESEARCH.md §1) so any tournament-browser/list view reflects the
+   status change or removal, not just a client already viewing that one
+   tournament's detail page.
+
+`Broker::reap_expired` widens to call `self.tournaments.check_expired(env)`
+in the same sweep as the existing `self.lobby.check_expired(...)` call,
+appending these new outbound kinds to the same returned `Vec<Outbound>` —
+one reaper, one call site, both lobby games and tournaments fanned out
+through it, exactly matching this section's "no second timer" framing
+above. PR 2's native wiring (below) extends the SAME `main.rs` reap block
+that today only recovers `LobbyGameRemoved`-shaped codes to also recover
+and dispatch these new variants through `bg_lobby_subs`. PR 3's Cloudflare
+Worker shell needs the identical widening on the Durable Object's alarm
+path (the WASM-side equivalent of the native timer) — see PR 3 below.
+
 ## 3. Authority model — organizer/player tokens, not socket identity
 
 Fixes #4615 finding #1 directly, using the `draft_session.rs` precedent
@@ -840,7 +883,14 @@ stale `Registration` (300s), transition stale `InProgress` to `Abandoned`
 (7 days), and delete retained `Completed`/`Abandoned` records (30 days).
 PR 2 wires this single all-status sweep into the existing native reaper
 call site (`main.rs:1000`) — it does not add a second reaper, a second
-timer, or a status-restricted variant.
+timer, or a status-restricted variant. **NEW, maintainer review — delivery
+contract:** PR 2's protocol variants (`LobbyServerMessage::TournamentUpdate`
+/ `TournamentRemoved` / `TournamentListUpdate`, §2's "Expiry event
+delivery" note) are exactly what the native reap block's existing
+`main.rs:2095`-area logic gains a second recovery arm for, alongside its
+existing `LobbyGameRemoved` handling — the SAME `bg_lobby_subs` fan-out
+loop, not a separate broadcast path, since tournament messages are
+lobby-scoped and share that subscriber list.
 
 **PR 3 — Cloudflare Worker shell.**
 `lobby-worker/broker-wasm` `mutates_lobby` match extension, `lobby-do.ts`
@@ -853,7 +903,16 @@ pub fn is_empty(&self) -> bool {
 confirmed today's `is_empty()` (`lobby-worker/broker-wasm/src/lib.rs:168-170`)
 only checks `self.inner.lobby()` — this predicate MUST be updated in the same
 PR that adds the `tournaments` field to `Broker`, not deferred, or a
-tournament-only Durable Object will stop rescheduling its cleanup alarm
+tournament-only Durable Object will stop rescheduling its cleanup alarm.
+**NEW, maintainer review:** the Durable Object's alarm handler — the
+WASM-side equivalent of PR 2's native timer loop — needs the identical
+widening: it must recover `TournamentUpdate`/`TournamentRemoved`/
+`TournamentListUpdate` outbounds from the same widened `reap_expired` call
+and fan them out via its own connection-broadcast mechanism, not just
+process the pre-existing `LobbyGameRemoved` case. Without this, the
+Cloudflare-hosted path silently diverges from the native server's delivery
+behavior — durable state changes, but only native-server-connected clients
+learn about it
 (exactly #4615's finding #4).
 
 **PR 4 — frontend.**
@@ -1002,3 +1061,18 @@ preserved, `pairings`/standings unchanged, only `status` and
 outright by `check_expired`, while one still within the window is
 untouched — proving the previously-missing terminal-state retention rule
 is actually enforced, not just documented.
+
+**NEW — maintainer review (expiry event delivery, §2)**: dedicated
+discriminating tests for each transition's outbound contract, not just its
+state change — (a) the `InProgress`→`Abandoned` transition's returned
+`Vec<Outbound>` contains a `TournamentUpdate` with the updated (Abandoned)
+view AND a `TournamentListUpdate`, not just a bare state mutation; (b) the
+terminal-deletion transition's returned outbounds contain a
+`TournamentRemoved` AND a `TournamentListUpdate`, never a bare deletion
+with no outbound at all; (c) a native-server integration test confirming
+the widened `main.rs` reap block actually recovers and dispatches BOTH new
+variants to `bg_lobby_subs` alongside its existing `LobbyGameRemoved`
+handling, not just one or the other; (d) the equivalent Cloudflare Worker
+test confirming the Durable Object alarm path fans out the same two
+variants through its own broadcast mechanism — proving PR 3 doesn't
+silently diverge from PR 2's delivery behavior.

--- a/docs/proposals/tournament-organizer/PLAN.md
+++ b/docs/proposals/tournament-organizer/PLAN.md
@@ -214,12 +214,22 @@ pub enum PodOutcome {
 as a sibling bracket shape on the *same* manager, not a separate feature —
 per "build for the class," a tournament tool that only does Swiss is
 incomplete relative to the MTR table it cites as its own round-count source.
-Single elimination for `arity > 2` (Commander bracket play) composes the
-same way: each bracket "match" is a pod of `arity` players advancing its one
-winner, rather than the adjacent-pair advancement 1v1 SE uses — noted here
-as in-scope, not designed further, since v1's SE path is already gated to a
-fixed 8-seat case (RESEARCH.md §11) and the pod generalization is a
-natural, not novel, extension of that same gate.
+This applies at `arity = HEAD_TO_HEAD` only, gated to the existing fixed
+8-seat case (RESEARCH.md §11).
+
+**Pod-based single elimination (`arity > HEAD_TO_HEAD`) is explicitly OUT OF
+SCOPE for v1 — maintainer review correctly rejected this section's earlier
+"in-scope, not designed further" framing.** Bracket/advancement semantics
+for a pod (does a 4-player bracket match have one winner and three
+eliminated, or does it need its own seeding/advancement rules distinct from
+adjacent-pair 1v1 SE?) are genuinely undesigned, and per CONTEXT.md open
+question #4 this is a live, unresolved product question, not a mechanical
+extension of the 1v1 gate. `v1` ships `BracketShape::SingleElimination`
+for `arity = HEAD_TO_HEAD` only; `CreateTournament` must reject
+`SingleElimination` paired with `arity != HEAD_TO_HEAD` at construction
+time (the same "reject explicitly rather than silently drop data" posture
+the sibling custom-format-engine proposal uses for its own unsupported
+combinations). Commander/multiplayer pods get Swiss only in v1 — see §5.
 
 **Pairing algorithm — top-to-bottom pod assignment with swap-based repair,
 generalized over `arity` (supersedes this doc's earlier backtracking
@@ -405,9 +415,21 @@ types (`TournamentView`, `TournamentSummary`, `TournamentStanding`,
 `PairingView` — `PairingView.players: Vec<PlayerSummary>`, not a fixed
 `player_a`/`player_b` pair, so the wire shape itself doesn't bake in
 head-to-head), `CreateTournament`'s payload carries `arity: MatchArity`
-alongside `scoring`/`bracket`, protocol version bump — **from 13 to 14** (confirmed current
-value is 13, not 12 — see CONTEXT.md finding #4; do not copy #4615's stale
-"v12" framing). `broker.rs` gains the `tournaments: TournamentManager` field
+alongside `scoring`/`bracket`. **Protocol version bump — REVISED, maintainer
+review: this text previously said "from 13 to 14," which was stale even
+against this document's OWN CONTEXT.md finding #4 (which had already
+retracted that framing) and is stale again against current `main` regardless
+— `PROTOCOL_VERSION`/`LOBBY_PROTOCOL_VERSION` are fast-moving constants that
+will have moved again by the time anyone implements this.** The durable
+instruction, independent of whatever the numbers are on any given day:
+bump `LOBBY_PROTOCOL_VERSION` (`crates/lobby-broker/src/protocol.rs`) by
+one from its value at implementation time — re-read the constant then, do
+not trust a number cited in this document — because `TournamentManager`'s
+new message variants are lobby-scoped. Do NOT bump the general
+`PROTOCOL_VERSION`, which is for `GameState`/`GameAction` wire changes this
+proposal doesn't make (see CONTEXT.md finding #4 for the full architectural
+reasoning, which remains correct even as the specific numbers churn).
+`broker.rs` gains the `tournaments: TournamentManager` field
 and the `ConnState` organizer/joined-tournament fields **as tokens** (§3
 above, not bare identifiers). Native server dispatch arms in
 `phase-server/src/main.rs`. Reaper keyed off `last_activity_at`, restricted
@@ -472,6 +494,13 @@ entry. **Acceptance criteria beyond "renders":**
   pods and falls back to at most one short pod per round, per MSTR's own
   stated preference; anything more elaborate is unneeded product scope for
   a first cut.
+- **Pod-based single elimination (`arity > HEAD_TO_HEAD`, §2) — maintainer
+  review correctly rejected an earlier "in-scope, not designed further"
+  framing for this.** Bracket/advancement semantics for a multi-player pod
+  bracket are a real, unresolved design question (CONTEXT.md open question
+  #4), not a mechanical extension of 1v1 SE's existing 8-seat gate.
+  `CreateTournament` rejects `SingleElimination` + `arity != HEAD_TO_HEAD`
+  at construction time. Commander/multiplayer pods get Swiss only in v1.
 
 ## 6. Testing
 
@@ -489,3 +518,10 @@ tests didn't cover the arity-2 cases, and nothing existed yet to cover
 arity > 2 at all; any building block introduced here needs a test that
 would have caught each of the seven review findings plus the Commander-pod
 gap, not just tests for the successful head-to-head path.
+
+**NEW — maintainer review**: a dedicated test asserting `CreateTournament`
+rejects `BracketShape::SingleElimination` paired with any
+`arity != MatchArity::HEAD_TO_HEAD` at construction time (§2/§5) — the
+concrete regression test proving pod-based SE's exclusion from v1 is an
+enforced construction-time rejection, not just a documentation note that a
+future implementer could silently miss.

--- a/docs/proposals/tournament-organizer/README.md
+++ b/docs/proposals/tournament-organizer/README.md
@@ -1,0 +1,39 @@
+# Swiss-Pairing Tournament Organizer — Design Proposal
+
+**Status:** research and design only — no engine or frontend code in this PR.
+
+This is a design proposal for a general Swiss/single-elimination tournament
+organizer built on top of the existing casual lobby, motivated by the lack
+of any organized multi-round event support in `lobby-broker` today. Running
+a Swiss tournament for a playgroup currently means tracking pairings and
+standings by hand outside the app.
+
+Originating issue [phase-rs/phase#4612](https://github.com/phase-rs/phase/issues/4612),
+a first implementation attempt [phase-rs/phase#4615](https://github.com/phase-rs/phase/pull/4615)
+(closed unmerged after review found real bugs — not because the architecture
+was wrong), and this second design pass via discussion
+[phase-rs/phase#5314](https://github.com/phase-rs/phase/discussions/5314),
+which grounds scoring/tiebreaker/pairing rules in the actual current Magic
+Tournament Rules (and, for Commander/multiplayer pods, the official
+Multiplayer Addendum to the MTR) instead of inventing convention from
+memory.
+
+- **CONTEXT.md** — why this matters, independently re-verified architecture
+  claims against current `main`, the real (not paraphrased) review findings
+  from #4615, the case for keeping tournament `ScoringPolicy` independent
+  from the sibling custom-format-engine work (#7703), open questions for the
+  maintainer, and the Commander/multiplayer scope this design now covers.
+- **RESEARCH.md** — the detailed evidence trail: `LobbyManager`/
+  `Broker::handle`/`ConnState` traced end-to-end, `draft_session.rs`'s
+  token-reconnect precedent, `draft-core`'s existing non-backtracking Swiss
+  pairing, real-world tournament-platform scoring levers (TopDeck.gg,
+  Melee.gg), and the Multiplayer Addendum to the MTR's scoring/tiebreak/
+  pairing rules for Commander pods.
+- **PLAN.md** — the proposed schema (`TournamentManager`, `MatchArity`,
+  `ScoringPolicy`, arity-selected `TiebreakOrder`), the token-based
+  organizer/player authority model (fixing #4615's socket-identity bug), and
+  a four-PR rollout sequencing (pure core → protocol/native server →
+  Cloudflare Worker shell → frontend), each independently reviewable.
+
+This is intended as a discussion artifact for maintainer review, not a
+ready-to-merge implementation plan.

--- a/docs/proposals/tournament-organizer/RESEARCH.md
+++ b/docs/proposals/tournament-organizer/RESEARCH.md
@@ -517,20 +517,33 @@ they are.
 ## 13. Commander/multiplayer pod tournaments — the Multiplayer Addendum to the MTR ("MSTR"), and production practice
 
 Per direct instruction: the design must cover Commander/multiplayer pod
-tournaments, not head-to-head only (CONTEXT.md finding #9). Magic's own
-tournament-rules body publishes a dedicated addendum for exactly this case
-— checked directly this session (WebSearch + WebFetch), not assumed from
-1v1 MTR text scaled up.
+tournaments, not head-to-head only (CONTEXT.md finding #9). A widely-used
+convention document fills exactly this gap the official MTR itself doesn't
+cover — checked directly this session (WebSearch + WebFetch), not assumed
+from 1v1 MTR text scaled up.
 
-**Source and cross-verification.** Fetched the Multiplayer Addendum to the
-Magic Tournament Rules via [juizes-mtg-portugal.github.io/multiplayer-addendum-mtr](https://juizes-mtg-portugal.github.io/multiplayer-addendum-mtr)
-(a judge-community mirror of the official text). Cross-referenced its
-existence and content against two independent sources found in the same
-search pass — [benelux-cedh-rules.eu/multiplayer-addendum-mtr](https://benelux-cedh-rules.eu/multiplayer-addendum-mtr)
-(another regional judge-community mirror) and [topdeck.gg/mtr-ipg-addendum](https://topdeck.gg/mtr-ipg-addendum)
-(a production tournament platform's own reference copy) — not a single
-unverified source. All three exist and describe the same ruleset; only the
-first was WebFetched in full for exact figures.
+**Source and cross-verification — CORRECTED, maintainer review: this is
+NOT an official Wizards of the Coast document, and the original framing
+here was wrong to imply otherwise.** Fetched the "Multiplayer Addendum to
+the Magic Tournament Rules" via
+[juizes-mtg-portugal.github.io/multiplayer-addendum-mtr](https://juizes-mtg-portugal.github.io/multiplayer-addendum-mtr)
+— re-checked directly this round: the page's own opening disclaimer states
+"This is an unofficial rules document written by independent judges. This
+is not official Wizards of the Coast documentation," maintained by the
+Portuguese Magic judge community. **This document is an external,
+community-authored convention this proposal deliberately adopts to fill a
+real gap** — the official MTR has no multiplayer-scoring/pairing section
+of its own — not a mirror of anything Wizards published. Cross-referenced
+its existence and content against two further sources found in the same
+search pass, both also independent/community-authored, not Wizards:
+[benelux-cedh-rules.eu/multiplayer-addendum-mtr](https://benelux-cedh-rules.eu/multiplayer-addendum-mtr)
+(a regional cEDH community's own copy) and
+[topdeck.gg/mtr-ipg-addendum](https://topdeck.gg/mtr-ipg-addendum) (a
+production tournament platform's reference copy). All three describe the
+same convention; only the first was WebFetched in full for exact figures.
+Cited throughout this document as "the Multiplayer Addendum" or "MSTR" —
+an external convention this proposal adopts, never as Wizards-published
+policy.
 
 **Match-point scoring — a general formula, not a separate convention.**
 Per-win points are `2n - 1` for a pod of `n` players: 7 match points for a
@@ -584,9 +597,9 @@ description** — it's a greedy top-down pass plus a swap-based repair step,
 the same algorithmic *shape* `draft-core`'s existing 1v1 Swiss pairing
 already uses (§11 above: greedy-within-bracket + carry-one-down, no
 backtracking). Finding #8 recommended that shape for 1v1 pairing as a way
-to sidestep #4615's backtracking bug; this section confirms the official
-body governing *multiplayer* pairing independently arrived at the same
-non-backtracking shape for pods. One generalized algorithm (top-to-bottom +
+to sidestep #4615's backtracking bug; this section confirms the
+independent judge community that authored the multiplayer convention this
+proposal adopts arrived at the same non-backtracking shape for pods. One generalized algorithm (top-to-bottom +
 swap, parameterized by `arity`) now covers both cases described in PLAN.md
 §2, rather than needing a 1v1-specific fix and a separate pod-specific
 design.

--- a/docs/proposals/tournament-organizer/RESEARCH.md
+++ b/docs/proposals/tournament-organizer/RESEARCH.md
@@ -1,0 +1,635 @@
+# Phase 61 — Swiss-Pairing Tournament Organizer — RESEARCH
+
+Evidence trail for CONTEXT.md. Everything under a numbered section marked
+**[VERIFIED THIS SESSION]** was checked directly against a worktree of
+`myfork/main` (commit `d65111246`) and/or the live GitHub API this session.
+Everything under **[FROM DISCUSSION #5314, NOT RE-VERIFIED]** is taken as
+given per the task's scope (MTR facts are out of scope for re-derivation).
+
+## 1. Issue #4612 — the original proposal (full body)
+
+`gh issue view 4612 --repo phase-rs/phase --json body` — fetched in full this
+session (the task brief only pasted the first ~1500 chars). Key structural
+points not visible in the truncated version the task gave:
+
+- Explicitly scoped as **lobby-only** for v1: "Matches themselves are not
+  orchestrated by the broker — exactly like today's P2P lobby, the broker
+  only handles discovery/pairing/standings; players start their own game via
+  the existing `CreateGameWithSettings`/`JoinGameWithPassword` flow for each
+  paired table and self-report the result back to the tournament."
+- Names the exact `ConnState` extension pattern it expects: "the existing
+  `ConnState` ownership-stamp idiom (`host_game` → `tournament_organizer`)."
+  This is the literal analogy #5314 uses to justify the token-based fix — the
+  original issue proposed a bare-field stamp; the discussion's day-one fix is
+  to make that stamp a token instead of a raw bool/socket-bound value.
+- Full proposed protocol surface: client messages `CreateTournament`,
+  `JoinTournament`, `DropFromTournament`, `StartTournamentRound`,
+  `ReportMatchResult`, `EndTournament`, `ListTournaments`; server messages
+  `TournamentCreated`, `TournamentUpdate`, `TournamentCompleted`,
+  `TournamentListUpdate`; view types `TournamentView`, `TournamentSummary`,
+  `TournamentStanding`, `PairingView`.
+- Explicitly calls out "No central auth" as a *known, accepted* v1
+  limitation in the original issue: "Match-result reporting trusts either
+  paired player ... or the organizer, last-write-wins on conflicting
+  reports — consistent with the rest of the broker, which already trusts
+  client-supplied identity (e.g. deck contents aren't server-validated
+  either)." This is worth noting: the *authority-token* fix from #5314 is
+  about **who is allowed to report at all and whether that authority
+  survives a socket bounce**, not about validating the reported score against
+  some ground truth (there is none — MTR self-reporting, confirmed at MTR
+  §2.4, is the model). Trusting a paired player's report content is
+  deliberate and unchanged; only the identity/authority layer is being
+  hardened.
+
+## 2. PR #4615 — metadata and full file list
+
+`gh pr view 4615 --repo phase-rs/phase --json body,files,state,createdAt,closedAt`:
+
+- State: `CLOSED`, created 2026-06-29T21:46:06Z, closed 2026-06-30T02:21:47Z
+  (same day — fast review-and-close cycle, not a long-lived stale PR).
+- Test plan self-reported by the author: `cargo test -p lobby-broker` (90
+  tests passing), `cargo test -p server-core --test lobby_wire_contract` (5
+  tests), `cargo check -p phase-server` all green — i.e., the bugs the review
+  found were **logic/architecture bugs that unit tests didn't catch**, not
+  compile or obvious-crash failures. This matters for the rollout plan: PR 1
+  of the new attempt needs tests that specifically exercise the odd-bracket
+  backtracking path and the unequal-game-wins validation path, since #4615's
+  90 passing tests didn't catch either.
+- 24 files changed, +2586/-33 total. Full list confirms the scope described
+  in #4612: `crates/lobby-broker/{broker.rs,lib.rs,protocol.rs,tournament.rs
+  (new, 972 lines),validation.rs}`, `crates/phase-server/src/main.rs`,
+  `crates/server-core/src/{client_message_wire_guard.rs,protocol.rs}`,
+  `lobby-worker/broker-wasm/src/lib.rs`, `lobby-worker/src/{hello-gate.ts,
+  lobby-do.ts}`, and 12 frontend files under `client/src/`.
+
+## 3. PR #4615 — the actual review (not the discussion's paraphrase)
+
+Fetched via `gh api repos/phase-rs/phase/pulls/4615/reviews` and
+`.../pulls/4615/comments` — the real GitHub review objects, independent of
+how discussion #5314 summarized them.
+
+**Two reviews exist:**
+1. `gemini-code-assist[bot]`, state `COMMENTED` — a summary comment
+   correctly characterizing the PR's shape and flagging "a backtracking bug
+   in the pairing algorithm for odd-sized brackets, missing winner validation
+   on unequal game wins, premature tournament expiration due to static
+   creation timestamps, and multiple WebSocket connection leaks."
+2. `matthewevans` (human), state `CHANGES_REQUESTED` — the substantive
+   review, with a body containing exactly seven numbered findings tagged
+   HIGH/MED/LOW. This is the review #5314's "What #4615's review already
+   surfaced" section is summarizing. Verified the discussion's summary is
+   faithful to this review — no invented findings, no dropped findings,
+   severity tags match.
+
+**The seven findings, verbatim evidence + this session's independent check
+against `gh pr diff 4615`:**
+
+| # | Severity | Finding | Evidence cited by reviewer | Independently confirmed in diff? |
+|---|----------|---------|------------------------------|-----------------------------------|
+| 1 | HIGH | Tournament authority stored on socket (`ConnState`); UI closes socket immediately after creating, triggering `on_disconnect` → tournament unregistered; joined players lose `joined_tournaments` too | `TournamentLandingPage.tsx:66`; `broker.rs:353` | Not independently re-derived line-by-line (frontend timing bug), but structurally consistent with the diff's `ConnState` extension being bare fields, not tokens |
+| 2 | HIGH | `validate_match_result` doesn't check winner against game-win score | `tournament.rs:326` | **Yes — confirmed exactly**, see §4 below |
+| 3 | HIGH | Tournaments expire by `created_at`, never updated | `tournament.rs:275`; `main.rs:1004` | **Yes — confirmed exactly**, see §4 below |
+| 4 | MED | `is_empty()` in broker-wasm only checks lobby games | `lobby-worker/broker-wasm/src/lib.rs:175` | **Yes — and still true on current `main` today** (no tournament state exists yet to check), see CONTEXT.md finding #5 |
+| 5 | MED | Odd-sized brackets always miss the backtracking success path | `tournament.rs:698` | **Yes — confirmed exactly**, see §4 below |
+| 6 | MED | Tournament subscription cleanup unsubscribes but never closes the socket | `tournamentClient.ts:296` | Not re-derived (frontend), consistent with the four separate Gemini inline WebSocket-leak comments (§3b) |
+| 7 | LOW | New tournament UI chrome bypasses `t()`/i18n | `TournamentLandingPage.tsx:87` | Not re-derived (frontend), plausible given the PR introduces multiple new pages with hardcoded English strings visible in the diff (`"Create Tournament"`, `"Join Tournament"`, etc. appear as raw JSX text) |
+
+**3b. Gemini's inline (line-anchored) review comments** — `gh api
+repos/phase-rs/phase/pulls/4615/comments` returned 10 inline suggestion
+comments (Gemini's automated per-line pass), which is a *superset* of the
+human review's seven findings plus additional WebSocket-leak instances the
+human review's prose collapsed into one bullet:
+- Backtracking bug, `tournament.rs:700` (suggests `return Some(acc.clone());`)
+- Winner validation, `tournament.rs:328` (suggests the exact comparator fix)
+- Expiration, `tournament.rs:288`
+- WebSocket leak on unmount, `TournamentLandingPage.tsx:35`
+- WebSocket leak on RPC error (create), `TournamentLandingPage.tsx:75`
+- WebSocket leak on unmount, `TournamentPage.tsx:45`
+- WebSocket leak on RPC error (join), `TournamentPage.tsx:90`
+- WebSocket leak on RPC error (start round), `TournamentPage.tsx:101`
+- WebSocket leak on RPC error (report result), `TournamentPage.tsx:117`
+- WebSocket leak on RPC error (drop), `TournamentPage.tsx` (comment
+  truncated in the raw API response but same pattern)
+
+This confirms the discussion's bullet 6 ("Frontend must close the tournament
+socket on unmount, including the cancelled-connect path") actually covers
+**six distinct leak sites** in the closed PR, not one — every RPC handler in
+both tournament pages leaked a socket on its error path by jumping to `catch`
+before a `client.close()`. Whoever writes PR 4 should structure the new
+`tournamentClient.ts` so a single `finally`-based close (or a request
+wrapper that owns connect/close) makes this class of bug structurally
+impossible, rather than relying on each handler remembering to close in its
+own `finally`.
+
+## 4. Line-exact confirmation of the three backend bugs, read from `gh pr diff 4615`
+
+Saved the full diff to a scratch file and grepped/read it directly (diff line
+numbers below are within the diff output, i.e. the `+`-prefixed added lines
+of the closed PR — these never landed on `main`, this is purely forensic).
+
+**Backtracking (diff line ~2594-2624):**
+```rust
+fn backtrack_pair(
+    players: &[String],
+    prior_pairs: &HashSet<(String, String)>,
+    acc: &mut Vec<(String, String)>,
+) -> Option<Vec<(String, String)>> {
+    if players.is_empty() {
+        return Some(acc.clone());
+    }
+    if players.len() == 1 {
+        return None;               // <-- BUG: should be Some(acc.clone())
+    }
+    let first = &players[0];
+    for (i, partner) in players.iter().enumerate().skip(1) {
+        ...
+        if let Some(solution) = backtrack_pair(&rest, prior_pairs, acc) {
+            return Some(solution);
+        }
+        acc.pop();
+    }
+    None
+}
+```
+Every odd-length input recurses down to exactly one remaining player at the
+base of its final recursive call and returns `None` there, which propagates
+all the way back up as total failure — even though a valid pairing (with one
+player floated) exists. Confirmed the reviewer's suggested one-line fix
+(`return Some(acc.clone())`, treating the lone survivor as the bye/float) is
+correct and requires no other structural change to the function.
+
+**Winner validation (diff line ~2219-2234):**
+```rust
+fn validate_match_result(pairing: &TournamentPairing, result: &MatchResult) -> Result<(), String> {
+    let player_b = pairing.player_b.as_ref().ok_or_else(|| "Invalid pairing".to_string())?;
+    let valid_keys = [&pairing.player_a, player_b];
+    if let Some(winner) = &result.winner_player_key {
+        if !valid_keys.iter().any(|k| *k == winner) {
+            return Err("Winner must be one of the paired players".to_string());
+        }
+    }
+    if result.player_a_wins == result.player_b_wins && result.winner_player_key.is_some() {
+        return Err("Draw results must not specify a winner".to_string());
+    }
+    Ok(())
+}
+```
+Confirmed: there is no branch comparing `result.player_a_wins` vs
+`result.player_b_wins` when they're *unequal* to require `winner_player_key`
+match the higher-wins player. A `2-0` result naming the loser as winner
+passes validation untouched.
+
+**Expiry (diff line ~2179-2192):**
+```rust
+pub fn check_expired(&mut self, timeout_secs: u64, env: &impl BrokerEnv) -> Vec<String> {
+    let now = env.now_ms();
+    let cutoff = now.saturating_sub(timeout_secs.saturating_mul(1000));
+    let expired: Vec<String> = self.tournaments.iter()
+        .filter(|(_, t)| t.created_at < cutoff)
+        .map(|(code, _)| code.clone())
+        .collect();
+    ...
+}
+```
+Confirmed: filters purely on `created_at`, which is set once at creation
+(diff line ~2044, `created_at: env.now_ms()`) and never mutated anywhere else
+in the 972-line `tournament.rs` diff (grepped the whole file's added lines
+for `created_at =` / `.created_at =` — no write site other than
+construction). Cross-checked the native reaper's actual call site on current
+`main`: `crates/phase-server/src/main.rs:1000`,
+`broker.reap_expired(300, &SysEnv)` — still a 300-second timeout today,
+confirming the review's claim that this specific timeout value would delete
+an in-progress tournament well before most real Swiss rounds finish.
+
+## 5. `lobby-broker`/`broker.rs` architecture — full verification
+
+`crates/lobby-broker/src/broker.rs` read in full (`lines 1-140` shown in
+detail; remainder skimmed for `Outbound` usage). Confirmed:
+
+- Module doc comment (lines 1-12) explicitly states the functional-core
+  contract: "No I/O, no locking, no tokio: the only impurity is `env`
+  (time/rng), `&mut self` (the lobby map), and `&mut conn` (this connection's
+  lobby state)."
+- `pub struct Broker { lobby: LobbyManager }` (lines 108-111) — currently a
+  single field. A `tournaments: TournamentManager` field is a direct,
+  additive sibling with no restructuring needed, exactly as #4612/#5314
+  propose.
+- `pub fn handle(&mut self, conn: &mut ConnState, msg: LobbyClientMessage,
+  env: &impl BrokerEnv) -> Vec<Outbound>` (line 136) is the single dispatch
+  entry point every lobby message goes through today; new
+  `LobbyClientMessage` variants for tournament actions would add match arms
+  here (or a delegated `handle_tournament_message` called from within this
+  match, mirroring how `handle_create_game`/`handle_join`/etc. are already
+  factored out as private helpers at lines 316, 434, 527, 669, 705).
+- `ConnState` (lines 46-58) fields today: `client_hello`, `subscribed`,
+  `host_game: Option<String>`, `reservations: Vec<(String, String)>`. No
+  tournament fields exist yet (confirms greenfield). The `host_game` shape
+  the discussion analogizes from is a bare `Option<String>` game-code stamp
+  — the discussion's proposed `organizer_token`/`joined_tournaments` fields
+  should NOT copy this bare-stamp shape verbatim (that's the exact pattern
+  #4615 got bitten by); they should hold **tokens**, mirroring
+  `draft_session.rs`'s `player_tokens` pattern (§7 below), not bare
+  socket-owned identifiers.
+- `Outbound` enum (lines 63-76): `ToSelf`, `ToSubscribers`, `AddSubscriber`,
+  `RemoveSubscriber`, `SendPlayerCountToSelf`. A tournament manager reuses
+  `ToSubscribers`/`AddSubscriber`/`RemoveSubscriber` for broadcasting
+  tournament updates — no new `Outbound` variant needed for basic fan-out,
+  confirming #4612's claim.
+
+## 6. Where "`lobby_subscribers`" actually lives
+
+Grepped the whole workspace for `lobby_subscribers` (not `subscribers` in
+general, which also appears inside `broker.rs`'s doc comments/`Outbound`
+naming as shown above). Zero hits inside `crates/lobby-broker/`. Hits
+concentrated entirely in `crates/phase-server/src/main.rs`:
+- `type SharedLobbySubscribers = Arc<Mutex<Vec<mpsc::UnboundedSender<ServerMessage>>>>;` (line 84)
+- `let lobby_subscribers: SharedLobbySubscribers = Arc::new(Mutex::new(Vec::new()));` (line 824)
+- Used throughout `apply_outbounds`/`broadcast_to_lobby_subscribers`/
+  `broadcast_player_count` to interpret the broker core's abstract
+  `Outbound::AddSubscriber`/`ToSubscribers`/`RemoveSubscriber` into actual
+  socket sends.
+
+So "the existing `lobby_subscribers` broadcast channel" is a true statement
+about the **native server shell**, not the `lobby-broker` crate itself. The
+Cloudflare Worker shell (`lobby-worker/src/lobby-do.ts`) has its own
+equivalent fan-out over Durable Object WebSocket connections — grepped
+`lobby-do.ts` for `ConnAttachment`/`DEFAULT_CONN` (lines 25, 63, 134, 150,
+167, 207) confirming per-connection attachment state exists there too, in
+the TypeScript shell, separate from the Rust `lobby_subscribers` map. A
+`TournamentManager` living in the shared `lobby-broker` core is transport
+description via `Outbound`, and each shell (native Rust, Worker TS)
+interprets those `Outbound`s using its own pre-existing fan-out mechanism —
+neither shell needs a *new* subscriber registry, which is the substance of
+what #4612/#5314 claim; the discussion's wording just slightly overstates
+which crate literally owns the name `lobby_subscribers`.
+
+## 7. Draft-pod token-based reconnect — the analogy source
+
+`crates/server-core/src/draft_session.rs`, read in full for the relevant
+sections:
+- Line 18: `use crate::session::{generate_player_token, SessionManager};`
+- Lines 27-28: `pub player_tokens: Vec<String>` — "Per-seat player tokens
+  (seat_index -> token). Empty string = seat not claimed."
+- Lines 44-47: `pub fn seat_for_token(&self, token: &str) -> Option<usize>`
+  — resolves a seat purely from a token value, no socket/connection
+  reference anywhere in the signature or body.
+- Lines 141-211 (`create_draft`) and 214-271 (`join_draft`): both mint a
+  fresh `player_token` via `generate_player_token()` and store it in
+  `token_to_draft: HashMap<String, String>` (line 129) for O(1) reverse
+  lookup, independent of any WebSocket connection object.
+- Lines 274-320 (`apply_player_action`): takes `token: &str` as a parameter
+  and resolves the seat via `seat_for_token` (line 289) before applying
+  anything — the connection that happens to deliver the token is
+  incidental; the token itself is the authority.
+
+This is a real, in-repo, same-crate-family precedent for "authority is a
+token minted at creation/join time, independent of the connection that holds
+it" — directly supporting #5314's proposed fix for #4615's finding #1
+(organizer authority must not live on `ConnState`/the socket).
+
+## 8. MTR facts cited in #5314 — explicitly not re-verified
+
+Per the task's scope, the following are taken as given from the discussion's
+own citations and were not independently re-fetched or fact-checked this
+session:
+- Match points 3/1/0 (MTR §2.1)
+- Tiebreaker order: match points → opponents' match-win % → game-win % →
+  opponents' game-win % (MTR §3.1)
+- 0.33 floor on match-win %/game-win % (MTR Appendix C)
+- Bye = 2-0 win (3 points/6 game points), excluded (not zero-filled) from
+  opponents'-percentage averaging (MTR Appendix C)
+- Player-count → round-count table, 4-8 players → single elimination
+  (MTR Appendix E)
+- Self-reporting model (MTR §2.4)
+- No codified Swiss pairing algorithm in the MTR itself (§10.4 just says
+  "follow the Swiss pairing algorithm" without detailing mechanics)
+
+If these ever need re-verification, the discussion cites both the PDF
+(`https://media.wizards.com/ContentResources/WPN/MTG_MTR_2026_Feb27_EN.pdf`)
+and the HTML judge-blog mirror (`https://blogs.magicjudges.org/rules/mtr/`
+and per-section pages) as primary sources.
+
+## 9. Custom-format-engine (phase 58) cross-reference — evidence
+
+Read `.planning/phases/58-custom-format-engine/CONTEXT.md` and `PLAN.md` in
+full from `myfork/research/custom-format-engine` (via `git show
+"myfork/research/custom-format-engine:.planning/phases/58-custom-format-engine/CONTEXT.md"`,
+`MSYS_NO_PATHCONV=1` needed on this Windows/git-bash environment to prevent
+the `branch:path` argument from being mis-parsed as a Windows path).
+
+Key finding, phase 58 CONTEXT.md "Open" section, item 4, quoted verbatim:
+
+> **Draw/tiebreaker resolution mechanics** (generalizing the Chaos Orb
+> tiebreaker and the foreign-card-identification convention above): both are
+> instances of a "how does this table resolve an otherwise-undecided
+> outcome" hook, not an in-game rule. Confirmed via grep (`crates/draft-core`,
+> `server-core`) that phase.rs has **no match-level concept at all today** —
+> no best-of-N, no tournament round, no draw/tiebreak state machine; the
+> engine models single games only. ... Given no match-level structure
+> exists, this is flagged as **out of scope for the custom-format engine
+> itself** and, if ever pursued, belongs to a separate, later
+> "tournament/match structure" design, not bundled into
+> `CustomFormatDef`/`LegacyRuleSet` here.
+
+This is phase 58 independently arriving at the same conclusion this
+document reaches from the tournament side: tournament/match structure
+(which is what `TournamentManager`/`ScoringPolicy` are) is a categorically
+separate concern from `CustomFormatDef`/`LegacyRuleSet` (in-game CR
+rule-variation toggles), and phase 58 explicitly declined to design it,
+deferring to exactly this phase.
+
+Phase 58 PLAN.md's `LegacyRuleSet` shape, **updated this session — the
+version below was current as of phase 58's own review round 4; the original
+draft of this section quoted an earlier, now-stale bool-based sketch**:
+```rust
+LegacyRuleSet {
+    mana_burn: ManaBurnPolicy,           // Modern | Obsolete
+    damage_timing: CombatDamageTiming,   // Modern | OnStack
+    wish_scope: WishOutsideGameScope,    // PostM10SideboardOnly | PreM10ReachesExile
+    legend_rule_scope: LegendRuleScope,  // Modern | PreM14AnyController
+}
+```
+Every axis converted from a bare `bool` to a typed enum during phase 58's
+own review process (each names a real historical-form-vs-modern-absence
+space, not an arbitrary on/off switch — the same reasoning `LegendRuleScope`
+already used). `reprint_policy` — present in earlier phase-58 drafts as a
+`LegalityRules` field — was moved OUT of the resolved rules struct entirely,
+onto a `CustomFormatDef` metadata side, after review found it sitting inside
+the enforced-ruleset struct while documented as "never enforced" was an
+internal contradiction. None of this changes the conclusion above — it's
+still `CustomFormatDef`-scoped, in-engine, single-game state with zero
+notion of rounds/match-points/standings, unrelated to `ScoringPolicy` either
+way — but citing the current shape rather than a superseded draft avoids
+this document going stale the way the original PROTOCOL_VERSION citation
+did (§10 below).
+
+This lives inside `CustomFormatDef` (engine crate, `types/format.rs`family),
+consumed by in-game resolvers (SBA checks, mana pool draining, Wish
+resolution) during a single game. It has no notion of rounds, match points,
+byes, or standings — those concepts don't exist anywhere the engine crate
+looks. `ScoringPolicy` would need `win_points: u8, draw_points: u8,
+loss_points: u8` consumed by tiebreaker math over a *sequence* of games
+across a multi-round event — a `lobby-broker` concept with zero engine
+crate touchpoints. The two structs don't share a natural parent type, a
+consumer, or a lifecycle; forcing them together would violate the
+CLAUDE.md categorical-boundary principle at a crate-boundary grain, which is
+a stronger violation than the same-crate within-CR-section violations that
+principle was originally written to catch.
+
+## 10. Re-verification pass against current `main` — protocol version split
+
+Original research (§ above) pinned this phase's understanding to `main` at
+commit `d65111246`. Re-checked directly this session against current `main`:
+
+- `crates/lobby-broker/src/protocol.rs:104`: `pub const PROTOCOL_VERSION: u32
+  = 33;` (was 13 at research time — an 20-version jump from unrelated churn,
+  not evidence of anything specific to this phase).
+- `crates/lobby-broker/src/protocol.rs:133`: `pub const LOBBY_PROTOCOL_VERSION:
+  u32 = 1;` — did NOT exist at research time. `git log --oneline --all -S
+  "LOBBY_PROTOCOL_VERSION" -- crates/lobby-broker/src/protocol.rs` finds
+  exactly one commit, `6db58810b` ("fix(protocol): give the lobby its own
+  wire version, decoupled from the full game (#7606)").
+- Consequence for PR 2 (protocol + native server): bump
+  `LOBBY_PROTOCOL_VERSION`, not `PROTOCOL_VERSION` — tournament messages are
+  lobby-scoped (this phase's own architecture matches `LobbyManager`
+  exactly), and `6db58810b` exists specifically to let lobby-scoped wire
+  changes bump independently of the general game protocol. See CONTEXT.md
+  finding #4 (updated) for the full reasoning.
+
+## 11. `crates/draft-core` already has a tested Swiss-pairing implementation
+
+Found via `grep -rln "TournamentManager\|SwissPairing\|swiss_pair\|
+tournament_organizer\|joined_tournaments\|ScoringPolicy" crates/
+client/src/"` during this session's re-verification pass — the original
+research pass did not search for this and missed it entirely.
+
+- `crates/draft-core/src/types.rs:12`: `pub enum TournamentFormat` with
+  `Swiss` and `SingleElimination` variants.
+- `crates/draft-core/src/session.rs`, dispatch: `TournamentFormat::Swiss =>
+  generate_swiss_pairings(session, round, &mut rng)`.
+- `generate_swiss_pairings` (same file): builds `players_with_wins: Vec<
+  (PlayerId, u8, u8)>` from each seat's `match_records`, sorts descending by
+  wins, groups into score-bracket `Vec<Vec<(PlayerId, u8)>>`, shuffles each
+  bracket with a seeded `ChaCha20Rng`, builds a `prior_pairs:
+  HashSet<(PlayerId, PlayerId)>` rematch set from `session.pairings`, then
+  greedily pairs within each bracket (preferring a non-rematch partner via
+  `.position(|(pid, _)| !prior_pairs.contains(&(first.0, *pid)))`), carrying
+  a lone leftover player (`carry: Option<(PlayerId, u8)>`) down into the
+  NEXT bracket rather than backtracking within the current one. A player
+  still unpaired after the last bracket takes a bye; the caller credits it
+  as a match win (`ensure_match_record(...).match_wins += 1`, in the calling
+  function, since a Swiss bye scores as a win per the same MTR convention
+  #5314 already cites).
+- Sibling `generate_se_pairings` in the same file: standard seeded
+  single-elimination bracket (`[(0,7),(1,6),(2,5),(3,4)]` for round 1, then
+  pairs winners of adjacent prior-round matches) — gated to exactly 8 seats
+  by an `UnsupportedTournamentSize` check earlier in the calling function.
+- Tests: `test_swiss_pairings_8_players`, `swiss_pairings_include_bot_filled_seats`
+  (same file, `#[cfg(test)]` module).
+
+**Why this matters for #4615's confirmed bug (§4 above):** #4615's
+`backtrack_pair` used recursive backtracking with a base case that returned
+`None` (search failure) whenever exactly one player remained — killing the
+entire search for any odd-sized bracket. `draft-core`'s implementation has
+no backtracking recursion at all: an odd leftover is a `carry`, handled by
+plain data flow into the next loop iteration, not a search outcome. The bug
+class doesn't have a foothold in this shape. This is real, tested, existing
+precedent in the same repo for the exact algorithmic problem this phase
+needs solved — worth citing explicitly in PR 1 rather than re-deriving
+backtracking and re-discovering the same bug independently.
+
+**Scope caveat, so this isn't overclaimed as a drop-in reuse:** `draft-core`'s
+version is keyed to a single draft pod's types (`DraftSession`, `PlayerId`,
+`DraftPairing`), normally exactly 8 seats, with a lifecycle scoped to one
+draft. `TournamentManager`'s Swiss pairing needs to work for arbitrary lobby
+player counts (4 to 128+, per MTR Appendix E) across a tournament's full
+multi-round lifecycle. The *algorithm shape* transfers; the *code* would
+need real adaptation across a crate boundary with different lifecycles —
+whether that's done as literal shared code or two independently-tested
+implementations of the same shape is a PR 1 implementation decision, not
+resolved here.
+
+## 12. Real-world tournament platforms — what TopDeck.gg / Melee.gg actually expose as configuration
+
+Per direct request: MTR gives the *default* rules, but doesn't show what
+organizers actually ask real tournament software for beyond the official
+text. Checked two production MTG tournament platforms directly (WebSearch +
+WebFetch this session, not from memory).
+
+**TopDeck.gg:**
+- Confirms win/draw/loss points are a real, exposed, organizer-set
+  configuration surface, not a hypothetical this phase is inventing: "You
+  can change scoring values and tiebreakers in Configuration, and every
+  standing re-grades automatically against the new settings" — and
+  organizers are expected to "decide on scoring values before round one and
+  publish them on the event page so players know what a win is worth."
+  TopDeck's own multiplayer-Commander default is 5/1/0 (win/draw/loss),
+  confirmed distinct from MTR's 1v1 default of 3/1/0 already cited in
+  #5314 — i.e., the *fact* that different formats/organizers want different
+  win-point values, not just different draw-point values, is already live
+  in a shipping product, not speculative.
+- **Bye handling diverges from MTR's own text.** MTR Appendix C (already
+  quoted in #5314): a bye scores as a 2-0 win and is *excluded* from
+  opponents'-percentage tiebreaker averaging (no real opponent that round).
+  TopDeck.gg instead: "Any player receiving a bye will have 3 opponents
+  added to their opponent history with a .2 win rate percentage" — a
+  *synthetic* opponent-history entry that still contributes to tiebreaker
+  averaging, rather than being excluded. Two different, real,
+  currently-in-production conventions for the identical MTR rule.
+- Source: [topdeck.gg/help/creating-tournaments](https://topdeck.gg/help/creating-tournaments)
+  (via search summary; direct WebFetch blocked this session — "unable to
+  verify domain safety," a tool-side restriction, not a content gap),
+  [topdeck.gg/help/circuit-leaderboards-management](https://topdeck.gg/help/circuit-leaderboards-management)
+  (WebFetch succeeded directly), search results for TopDeck.gg tournament
+  configuration and bye/tiebreaker handling.
+
+**Melee.gg:**
+- Exposes a simpler, binary lever instead of point-value customization:
+  "Enable Draws" — a checkbox to permit or disallow drawn matches entirely,
+  confirmed via direct WebFetch of the tournament-setup help page. This is
+  a genuinely different axis from "what is a draw worth" (TopDeck.gg's
+  lever) — some organizers just don't want draws to be a possible outcome
+  at all, which a flat `ScoringPolicy{win,draw,loss}` numeric config doesn't
+  express (setting `draw: 0` still permits a drawn match to be reported; it
+  doesn't forbid the outcome).
+- Other confirmed levers (structural, not scoring): "Swiss Only" / "Swiss
+  plus Top Cut" / "Custom" phase structure, a round timer toggle, delayed
+  publication of pairings/standings, decklist public/private visibility —
+  none of these are scoring-related, noted only because they were the
+  concrete levers this help page actually documents (the page explicitly
+  does not enumerate point values, tiebreaker order, or pairing algorithm
+  detail — those may exist in-product but weren't in the fetched
+  documentation).
+- Source: [help.melee.gg/docs/tournament-setup-key-points/](https://help.melee.gg/docs/tournament-setup-key-points/)
+  (WebFetch succeeded directly).
+
+**Implication for `ScoringPolicy`'s design (CONTEXT.md open question #1,
+updated):** the flat `{win_points: u8, draw_points: u8, loss_points: u8}`
+shape already proposed is validated as the right MAIN shape (TopDeck.gg
+does exactly this) — the two things worth the maintainer's attention are
+whether v1 also wants (a) an explicit "are draws permitted at all" toggle
+separate from their point value (Melee.gg's lever), and (b) a
+`ByeTiebreakerHandling` axis if this phase ever wants to support a
+non-MTR bye convention (TopDeck.gg's lever) — not whether the win/draw/loss
+point fields themselves are the right idea, which this research confirms
+they are.
+
+## 13. Commander/multiplayer pod tournaments — the Multiplayer Addendum to the MTR ("MSTR"), and production practice
+
+Per direct instruction: the design must cover Commander/multiplayer pod
+tournaments, not head-to-head only (CONTEXT.md finding #9). Magic's own
+tournament-rules body publishes a dedicated addendum for exactly this case
+— checked directly this session (WebSearch + WebFetch), not assumed from
+1v1 MTR text scaled up.
+
+**Source and cross-verification.** Fetched the Multiplayer Addendum to the
+Magic Tournament Rules via [juizes-mtg-portugal.github.io/multiplayer-addendum-mtr](https://juizes-mtg-portugal.github.io/multiplayer-addendum-mtr)
+(a judge-community mirror of the official text). Cross-referenced its
+existence and content against two independent sources found in the same
+search pass — [benelux-cedh-rules.eu/multiplayer-addendum-mtr](https://benelux-cedh-rules.eu/multiplayer-addendum-mtr)
+(another regional judge-community mirror) and [topdeck.gg/mtr-ipg-addendum](https://topdeck.gg/mtr-ipg-addendum)
+(a production tournament platform's own reference copy) — not a single
+unverified source. All three exist and describe the same ruleset; only the
+first was WebFetched in full for exact figures.
+
+**Match-point scoring — a general formula, not a separate convention.**
+Per-win points are `2n - 1` for a pod of `n` players: 7 match points for a
+win in the standard 4-player pod. A draw awards 1 match point to *every*
+seated player, including ones with fewer game wins in the shared match. A
+loss is 0. **This formula is not a new convention alongside MTR §2.1's 3/1/0
+— it's the general case MTR §2.1 already cited in #5312 is a special case
+of**: at `n = 2`, `2n - 1 = 3`, matching MTR exactly. This is why PLAN.md
+§1 designs `ScoringPolicy::default_for_arity` as one formula rather than a
+`match arity { 2 => .., 4 => .. }` branch.
+
+**Bye scoring** mirrors the win-point formula exactly: "A Player who
+receives a Bye in a Multiplayer Tournament receives 2n - 1 Match points" —
+7 for a 4-player event, same value as an actual win, same shape as MTR
+Appendix C's bye-scores-as-a-win convention #5312 already cites for 1v1.
+
+**Tiebreaker order — genuinely different axes, confirmed by direct
+citation, not just re-scaled MTR:**
+1. Match points (cumulative, same axis as MTR).
+2. Match-win percentage: `(Match points − Byes × Points-per-win) / (Matches
+   played × Points-per-win)` — the *floor* for this and the derived
+   percentages below uses `1 / Points-per-win` (≈0.14 at 7 points/win)
+   generalizing MTR's own 0.33 floor (`1/3` at 3 points/win) — same formula,
+   different plug-in value, confirmed by the source's own worked framing.
+3. Opponents' average match points (raw point sum ÷ opponent count) — **an
+   axis with no 1v1 analog.** MTR's 1v1 tiebreak order has no "opponents'
+   raw average points" step at all; it goes straight from opponents'
+   match-win % to game-win %.
+4. Opponents' match-win percentage (average of opponents' own MWP).
+
+Notably absent versus MTR's 1v1 order: **no game-win percentage axis at
+all.** MTR step 3 (1v1) is "game-win percentage, floored at 0.33" — MSTR
+has nothing analogous, because a multiplayer pod match is a single game
+with one shared result, not a Bo3 with a per-player game-win count to
+average. This confirms `PodOutcome` (PLAN.md §2) is right to drop
+`game_wins` entirely for `arity > 2` rather than trying to force a
+best-of-N shape onto a pod result.
+
+**Pairing algorithm — top-to-bottom assignment with swap-based repair,
+independently confirming CONTEXT.md finding #8's recommendation, not
+contradicting it.** Direct quote (paraphrased minimally): pairings are
+formed by sorting players by current performance (match points, then
+tiebreaks), then assigning top-to-bottom into pods, avoiding any pairing
+between players who've already played each other in a prior round. When
+the top-to-bottom pass leaves players who can't be seated without a
+rematch, the algorithm **iteratively swaps** an unseated player with one
+already placed in a pod further down the standings — a player moved into a
+higher pod than their standing is "paired up," moved into a lower one is
+"paired down." **There is no recursive backtracking search anywhere in this
+description** — it's a greedy top-down pass plus a swap-based repair step,
+the same algorithmic *shape* `draft-core`'s existing 1v1 Swiss pairing
+already uses (§11 above: greedy-within-bracket + carry-one-down, no
+backtracking). Finding #8 recommended that shape for 1v1 pairing as a way
+to sidestep #4615's backtracking bug; this section confirms the official
+body governing *multiplayer* pairing independently arrived at the same
+non-backtracking shape for pods. One generalized algorithm (top-to-bottom +
+swap, parameterized by `arity`) now covers both cases described in PLAN.md
+§2, rather than needing a 1v1-specific fix and a separate pod-specific
+design.
+
+**Uneven player counts — a short pod, not more byes.** Direct quote:
+"Priority should be given to forming as many pods with 4 players as
+possible each round. In cases where this isn't possible, pods may consist
+of a minimum of 3 players to avoid multiple byes," and "it is desirable
+that Players only get matched in smaller size pods at most once per event"
+— i.e., fairness tracking for who's been shorted, mirroring (but distinct
+from) bye fairness. This has no 1v1 analog: a head-to-head bracket either
+pairs a player or gives them a bye, there's no intermediate "smaller match"
+option. PLAN.md §2 models this as `TournamentPlayer.had_short_pod`, a new
+field alongside (not replacing) `had_bye`.
+
+**Round-count / cut table — a separate lookup from MTR Appendix E, not the
+same table reused.** MSTR's own table (4-player pods): 4-5 players → single
+elimination only, no Swiss; 6-16 → 2 Swiss rounds, Top 4 cut; 17-24 → 3
+rounds, Top 7; 25-32 → 4 rounds, Top 10; 33-40 → 5 rounds, Top 13; 41-64 →
+5 rounds, Top 16. Also states a Competitive-REL minimum of 2 rounds for
+multiplayer events. This confirms `total_rounds`'s "default lookup" (PLAN.md
+§1) must itself be keyed on `(arity, player_count)`, not just
+`player_count` — MTR Appendix E and this table are genuinely different
+inputs to the same kind of lookup, not one table with an extra column.
+
+**Cross-checked against a platform actually running Commander events
+today, not rules text alone.** [topdeck.gg/help/running-commander-tournament](https://topdeck.gg/help/running-commander-tournament)
+(via search-result summary — direct WebFetch of this specific page wasn't
+attempted this session, the citation is search-summary-level, weaker than
+the WebFetch-verified pages elsewhere in this document and flagged as such)
+confirms real production behavior matching MSTR's stated preference: "Pods
+seat four by default. Odd fields produce a short pod or a bye, and the byes
+card shows who sat out." The same search pass also surfaced TopDeck.gg's
+Swiss-pods/Power-pods/Random-pods/Bubble-pods pairing-mode menu for
+multiplayer formats generally — noted for awareness only, not incorporated
+into this phase's design, since v1's scope (per CONTEXT.md open question #2
+and #5312's own framing) is standard Swiss pairing, not organizer-selectable
+pairing *styles*.
+
+**What this section does NOT establish:** exact MSTR section/paragraph
+numbers for pinpoint citation the way `MTR §2.1`/`MTR Appendix C` are cited
+elsewhere in this document — the fetched mirror presents the addendum as
+continuous prose/tables rather than numbered rule text the way the main MTR
+is. Code comments citing this ruleset should reference it as "the
+Multiplayer Addendum to the MTR (MSTR)" by name rather than inventing a
+section number that wasn't confirmed present in the source.


### PR DESCRIPTION
## Summary

Design proposal (research + plan, **no engine or frontend code**) for a Swiss/single-elimination tournament organizer built on top of the existing casual lobby (`lobby-broker`) — motivated by the lack of any organized multi-round event support today.

Follows up on #4612 (open proposal) and #4615 (closed, unmerged implementation attempt where review found real bugs), via discussion #5314.

- `TournamentManager` extends `lobby-broker` additively (`Broker` gains one field, `ConnState` gains token-shaped fields, `LobbyClientMessage`/`LobbyServerMessage` gain additive variants) — no existing lobby behavior changes.
- Organizer/player authority is token-based, not socket-identity-based, mirroring the existing `draft_session.rs` reconnect precedent — this is the direct fix for #4615's finding that closing/reopening a browser tab dropped tournament authority.
- Swiss pairing is a generalized top-to-bottom score-order assignment with swap-based repair (no recursive backtracking) — the same shape `draft-core`'s existing 1v1 pairing already uses, and independently confirmed as the official approach the Multiplayer Addendum to the MTR itself recommends for pod pairing.
- Covers both head-to-head (Standard/Modern/etc.) and Commander/multiplayer pod tournaments through one `MatchArity` parameter rather than a forked format: the Multiplayer Addendum's win-point formula (`2n - 1` for pod size `n`) collapses to MTR's existing 3/1/0 at `n = 2`, so this is one generalized design, not two.
- Recommends the same 4-PR rollout discussion #5314 proposes (pure core → protocol/native server → Cloudflare Worker shell → frontend), each independently reviewable.

## What's in this PR

- `docs/proposals/tournament-organizer/README.md` — orientation + links
- `docs/proposals/tournament-organizer/CONTEXT.md` — why this matters, re-verified architecture findings, open questions, Commander/multiplayer scope
- `docs/proposals/tournament-organizer/RESEARCH.md` — full evidence trail (codebase tracing, `draft-core` pairing precedent, real-world platform research, MTR/MSTR citations)
- `docs/proposals/tournament-organizer/PLAN.md` — proposed schema, rollout sequencing

## Test plan

N/A — documentation/design proposal only, opened for maintainer review before any implementation work begins.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a research-backed proposal for Swiss and single-elimination tournament formats.
  * Documented support for head-to-head and multiplayer formats, including scoring, pairings, byes, tiebreakers, results, and player drops.
  * Clarified that single elimination is limited to head-to-head tournaments in v1, while multiplayer tournaments use Swiss pairings.
  * Defined multiplayer outcomes for varying active-player counts and after player drops.
  * Documented architecture, protocol guidance, testing plans, and research-only status.
  * Clarified that multiplayer rules are based on an unofficial community convention.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## AI-contributor disclosure

Model: claude-sonnet-5
Tier: Frontier
Thinking: default (reasoning_effort=40 for this session; not elevated to a high/max setting)

Gate A (combinator-purity script) and Gate B (pattern anchoring, `docs/AI-CONTRIBUTOR.md` §0.1.2) are not applicable to this PR — it contains no engine/parser Rust code, only documentation (a design proposal). No `.claude/skills/**`, `.claude/agents/**`, `CLAUDE.md`, `AGENTS.md`, or `docs/AI-CONTRIBUTOR.md` paths are touched by this PR's current head (the earlier push that did touch them was stale-branch contamination, already corrected and confirmed clean).
