### PR TITLE
fix(engine): stamp Duration::Permanent on the reanimator-Aura ETB self-grant (CR 611.2a)

### DIFF
--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -42486,10 +42486,23 @@ fn animate_dead_grant_survives_cleanup_then_ordinary_removal_still_sacrifices() 
     assert_eq!(state.objects[&creature_id].zone, Zone::Battlefield);
 
     // Force-remove the Aura via an unrelated effect (NOT the duration bug),
-    // then resolve the delayed leaves-battlefield trigger using the CORRECT
-    // function for Effect::CreateDelayedTrigger-created abilities (CR 603.7).
+    // routed through the real replacement-aware zone pipeline (CR 614) rather
+    // than a direct `zones::move_to_zone` call — a departure replacement could
+    // otherwise prevent or modify this move, and this test must observe the
+    // same event stream production would emit. Then resolve the delayed
+    // leaves-battlefield trigger using the CORRECT function for
+    // Effect::CreateDelayedTrigger-created abilities (CR 603.7).
     let mut events = Vec::new();
-    zones::move_to_zone(&mut state, aura_id, Zone::Graveyard, &mut events);
+    let move_result = zone_pipeline::move_object(
+        &mut state,
+        ZoneMoveRequest::effect(aura_id, Zone::Graveyard, aura_id),
+        &mut events,
+    );
+    assert!(
+        matches!(move_result, ZoneMoveResult::Done),
+        "unrelated-effect removal must complete synchronously with no pending \
+         replacement choice for this simple removal"
+    );
     crate::game::triggers::check_delayed_triggers(&mut state, &events);
     assert_eq!(
         state.stack.len(),

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -42346,6 +42346,171 @@ fn necromancy_delayed_sacrifice_when_leaves() {
     );
 }
 
+/// CR 611.2a regression (this fix): the reanimator-Aura's re-targeted Enchant
+/// grant has no stated duration and must last until the Aura leaves the
+/// battlefield (CR 611.2a: "no duration stated" = "until end of game"), not
+/// merely until end of turn. Proves the grant survives a REAL cleanup step —
+/// the actual reported bug ("reanimated creature spuriously sacrificed one
+/// turn after reanimating").
+///
+/// LIVE-REVERT EVIDENCE: reverting `duration: Some(Duration::Permanent)` to
+/// `duration: None` in `build_aura_attach_clause` makes the grant default to
+/// Duration::UntilEndOfTurn, so `execute_cleanup`'s `prune_end_of_turn_effects`
+/// drops the re-targeted Enchant restriction, the Aura's Enchant restriction
+/// reverts to the original graveyard-card restriction, and the final
+/// `check_state_based_actions` pass sacrifices the Aura to its owner's
+/// graveyard under CR 704.5m — the post-cleanup assertions below fail.
+#[test]
+fn animate_dead_keyword_swap_survives_cleanup_step() {
+    use crate::game::game_object::AttachTarget;
+
+    let (mut state, aura_id, creature_id) = reanimate_grizzly_via_animate_dead();
+
+    assert!(
+        state.battlefield.contains(&aura_id),
+        "precondition: Aura on battlefield before cleanup"
+    );
+    assert_eq!(
+        state.objects[&creature_id].zone,
+        Zone::Battlefield,
+        "precondition: creature on battlefield before cleanup"
+    );
+
+    let mut cleanup_events = Vec::new();
+    let waiting = crate::game::turns::execute_cleanup(&mut state, &mut cleanup_events);
+    assert!(
+        waiting.is_none(),
+        "reach-guard: cleanup must run the end-of-turn pruning path (empty \
+         hand, no discard-to-hand-size needed), not divert into a WaitingFor \
+         branch; got {waiting:?}"
+    );
+
+    let mut sba_events = Vec::new();
+    crate::game::sba::check_state_based_actions(&mut state, &mut sba_events);
+    assert!(
+        state.battlefield.contains(&aura_id),
+        "Aura must survive a real cleanup step (CR 611.2a: unstated duration \
+         is permanent, not until-end-of-turn)"
+    );
+    assert_eq!(
+        state.objects[&aura_id].attached_to,
+        Some(AttachTarget::Object(creature_id)),
+        "Aura must remain attached to the reanimated creature after cleanup"
+    );
+    assert_eq!(
+        state.objects[&creature_id].zone,
+        Zone::Battlefield,
+        "reanimated creature must remain on the battlefield after cleanup \
+         (must not be spuriously sacrificed one turn after reanimating)"
+    );
+}
+
+/// CR 611.2a regression (this fix), GrantOnly shape: mirrors
+/// `animate_dead_keyword_swap_survives_cleanup_step` for Necromancy's
+/// subtype+keyword grant (rather than Animate Dead's remove+add swap).
+#[test]
+fn necromancy_grant_shape_survives_cleanup_step() {
+    use crate::game::game_object::AttachTarget;
+
+    let (mut state, necromancy_id, creature_id) = reanimate_grizzly_via_necromancy();
+
+    assert!(
+        state.battlefield.contains(&necromancy_id),
+        "precondition: Necromancy on battlefield before cleanup"
+    );
+    assert_eq!(
+        state.objects[&creature_id].zone,
+        Zone::Battlefield,
+        "precondition: creature on battlefield before cleanup"
+    );
+
+    let mut cleanup_events = Vec::new();
+    let waiting = crate::game::turns::execute_cleanup(&mut state, &mut cleanup_events);
+    assert!(
+        waiting.is_none(),
+        "reach-guard: cleanup must run the end-of-turn pruning path; got {waiting:?}"
+    );
+
+    let mut sba_events = Vec::new();
+    crate::game::sba::check_state_based_actions(&mut state, &mut sba_events);
+    assert!(
+        state.battlefield.contains(&necromancy_id),
+        "Necromancy must survive a real cleanup step (CR 611.2a)"
+    );
+    assert!(
+        state.objects[&necromancy_id]
+            .card_types
+            .subtypes
+            .contains(&"Aura".to_string()),
+        "Necromancy must remain an Aura after cleanup (AddSubtype grant not pruned)"
+    );
+    assert!(
+        state.objects[&necromancy_id]
+            .keywords
+            .iter()
+            .any(|k| matches!(k, Keyword::Enchant(_))),
+        "Necromancy must retain its Enchant keyword after cleanup"
+    );
+    assert_eq!(
+        state.objects[&necromancy_id].attached_to,
+        Some(AttachTarget::Object(creature_id)),
+        "Necromancy must remain attached to the reanimated creature after cleanup"
+    );
+    assert_eq!(
+        state.objects[&creature_id].zone,
+        Zone::Battlefield,
+        "reanimated creature must remain on the battlefield after cleanup"
+    );
+}
+
+/// CR 611.2a + CR 603.7 + CR 704.5m composed regression: proves the grant
+/// surviving a real cleanup step does NOT interfere with the pre-existing,
+/// fix-independent ordinary removal-triggered delayed sacrifice (CR 603.7)
+/// when the Aura is later force-removed by an unrelated effect.
+#[test]
+fn animate_dead_grant_survives_cleanup_then_ordinary_removal_still_sacrifices() {
+    let (mut state, aura_id, creature_id) = reanimate_grizzly_via_animate_dead();
+
+    let mut cleanup_events = Vec::new();
+    let waiting = crate::game::turns::execute_cleanup(&mut state, &mut cleanup_events);
+    assert!(
+        waiting.is_none(),
+        "reach-guard: cleanup ran cleanly; got {waiting:?}"
+    );
+    let mut sba_events = Vec::new();
+    crate::game::sba::check_state_based_actions(&mut state, &mut sba_events);
+    assert!(
+        state.battlefield.contains(&aura_id),
+        "reach-guard: Aura survives cleanup (this fix) before we test removal"
+    );
+    assert_eq!(state.objects[&creature_id].zone, Zone::Battlefield);
+
+    // Force-remove the Aura via an unrelated effect (NOT the duration bug),
+    // then resolve the delayed leaves-battlefield trigger using the CORRECT
+    // function for Effect::CreateDelayedTrigger-created abilities (CR 603.7).
+    let mut events = Vec::new();
+    zones::move_to_zone(&mut state, aura_id, Zone::Graveyard, &mut events);
+    crate::game::triggers::check_delayed_triggers(&mut state, &events);
+    assert_eq!(
+        state.stack.len(),
+        1,
+        "the delayed leaves-battlefield sacrifice must be on the stack"
+    );
+
+    let mut sac_events = Vec::new();
+    stack::resolve_top(&mut state, &mut sac_events);
+    assert!(
+        !state.battlefield.contains(&creature_id),
+        "reanimated creature must still be sacrificed when the Aura leaves, \
+         even after having survived a cleanup step first"
+    );
+    assert_eq!(
+        state.objects[&creature_id].zone,
+        Zone::Graveyard,
+        "sacrificed creature must go to its owner's graveyard"
+    );
+}
+
 /// CR 608.2b regression (issue #640): if the ETB trigger's chosen target leaves
 /// the graveyard before the trigger resolves, the trigger is removed from the
 /// stack and does nothing — Necromancy stays a plain (non-Aura) Enchantment with

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -14195,11 +14195,29 @@ fn build_aura_attach_clause(
         },
     )
     .sub_ability(delayed);
-    // CR 613.1d + CR 613.1f + CR 611.2a: the Aura's own layer-4/6 continuous
-    // grant with no stated duration lasts until end of game (CR 611.2a).
+    // CR 611.2a: no stated duration on this continuous grant means "lasts
+    // until the end of the game" — Duration::Permanent. Setting this
+    // explicitly is REQUIRED: game/effects/effect.rs's
+    // `ability.duration.or(duration).unwrap_or(Duration::UntilEndOfTurn)`
+    // would otherwise default it to UntilEndOfTurn, and
+    // game/layers.rs::prune_end_of_turn_effects would drop the re-targeted
+    // Enchant restriction at the next cleanup step — un-swapping it back to
+    // the original graveyard-card restriction and causing the Aura to fail
+    // CR 704.5m (not attached to a legal object) on the very next SBA check,
+    // sacrificing the reanimated creature one turn after it entered. Mirrors
+    // the Borg artifact-creature retype (oracle_effect/imperative.rs:12245-
+    // 12262) and the "becomes" continuous effect (oracle_replacement.rs:2492-
+    // 2506) — both explicit `Some(Duration::Permanent)` for the identical
+    // reason. Unlike those two call sites, this ability is not also given a
+    // `.duration(Duration::Permanent)` builder call: `GenericEffect`'s struct
+    // field alone drives the fallback in effect.rs, so the builder-level
+    // duration (which governs a different, ability-level concern) is
+    // correctly left unset here — the two precedents' redundant builder call
+    // is harmless but not required, and this fix intentionally does not
+    // mirror it.
     // `OriginalSource` references the Aura even though this node's
     // source_id is rebound to the creature by the parent ChangeZone's
-    // forward_result. `duration: None` — an unstated-duration continuous grant.
+    // forward_result.
     //
     // Swap shape (Animate Dead / Dance of the Dead, already printed as Auras):
     // remove the printed Enchant restriction and add the post-reanimation one
@@ -14224,7 +14242,7 @@ fn build_aura_attach_clause(
             static_abilities: vec![StaticDefinition::continuous()
                 .affected(TargetFilter::OriginalSource)
                 .modifications(modifications)],
-            duration: None,
+            duration: Some(Duration::Permanent),
             target: None,
             end_cost: None,
         },

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -27250,7 +27250,7 @@ fn assert_reanimator_chain(oracle: &str, card_name: &str, expect_tapped: bool) {
         "{card_name}: enter_tapped state ({enter_tapped:?})",
     );
 
-    // Node 2: GenericEffect keyword swap referencing OriginalSource, no duration.
+    // Node 2: GenericEffect keyword swap referencing OriginalSource, stamped to Duration::Permanent (CR 611.2a).
     let generic = root
         .sub_ability
         .as_deref()
@@ -27267,8 +27267,9 @@ fn assert_reanimator_chain(oracle: &str, card_name: &str, expect_tapped: bool) {
         );
     };
     assert_eq!(
-        *duration, None,
-        "{card_name}: keyword-swap grant has no stated duration"
+        *duration,
+        Some(Duration::Permanent),
+        "{card_name}: keyword-swap grant is stamped to Duration::Permanent (CR 611.2a)"
     );
     assert_eq!(
         static_abilities.len(),
@@ -27469,7 +27470,7 @@ fn necromancy_etb_lowers_to_reanimator_grant_chain_640() {
     );
 
     // Node 2: GenericEffect grants (not swaps) — AddSubtype{Aura} + AddKeyword,
-    // referencing OriginalSource, no duration.
+    // referencing OriginalSource, stamped to Duration::Permanent (CR 611.2a).
     let generic = root
         .sub_ability
         .as_deref()
@@ -27485,7 +27486,11 @@ fn necromancy_etb_lowers_to_reanimator_grant_chain_640() {
             generic.effect
         );
     };
-    assert_eq!(*duration, None, "Necromancy: grant has no stated duration");
+    assert_eq!(
+        *duration,
+        Some(Duration::Permanent),
+        "Necromancy: grant is stamped to Duration::Permanent (CR 611.2a)"
+    );
     assert_eq!(static_abilities.len(), 1, "Necromancy: one grant static");
     let sd = &static_abilities[0];
     assert_eq!(


### PR DESCRIPTION
Animate Dead / Dance of the Dead's Enchant-restriction keyword swap and
Necromancy's Enchant-restriction grant (both built by the shared
build_aura_attach_clause constructor) stated no duration, so the effect
resolver defaulted them to Duration::UntilEndOfTurn instead of CR 611.2a's
"lasts until the game ends" semantics. At the next cleanup step the grant was
pruned, the Aura's Enchant restriction reverted to its printed
graveyard-only filter, the reanimated creature (now on the battlefield) no
longer matched it, and CR 704.5m's illegal-attachment SBA swept the Aura and
sacrificed the reanimated creature — one turn after reanimating, with no
removal spell, combat, or player action involved. Confirmed against a real
game-state export from a live game.

Fix: stamp duration: Some(Duration::Permanent) at the one shared
construction site, covering both the Swap shape (Animate Dead, Dance of the
Dead) and the GrantOnly shape (Necromancy) in a single change, mirroring the
existing Duration::Permanent precedents for unstated-duration CR 611.2a
grants elsewhere in the parser. Updates the three parser-shape tests whose
assertions depended on the old (buggy) None value, and adds three new
runtime regression tests that drive a real cleanup step through the
production turns::execute_cleanup entry point — proven reverted-fix-
discriminating, each failing with a distinct symptom when the fix is
reverted.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NQ1bpYEt331DvjqPLSFJEH


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed reanimated creatures losing granted abilities or properties during cleanup.
  * Ensured reanimation Auras remain attached and creatures remain on the battlefield after cleanup.
  * Preserved delayed sacrifice behavior when a reanimation Aura is later removed.
  * Corrected permanent-duration handling for keyword and generic grants so these effects persist as intended.
  * Improved consistency for Animate Dead and Necromancy interactions across cleanup and subsequent Aura removal.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->