### PR TITLE
ship/adapt multiplayer layout to viewport

### DIFF
--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -831,6 +831,8 @@ export type CastChoice = { type: "Cast" } | { type: "Decline" };
 
 export type AutoMayChoice = { type: "Accept" } | { type: "Decline" };
 
+export type MayTriggerAutoChoiceScope = { type: "ExactInstance" } | { type: "SameCard" };
+
 export type MayTriggerOrigin =
   | { type: "Definition"; definition_ref: TriggerDefinitionRef }
   | { type: "Printed"; trigger_index: number }
@@ -842,17 +844,32 @@ export interface MayTriggerAutoChoiceKey {
   origin: MayTriggerOrigin;
 }
 
+export interface PrintedCardRef {
+  oracle_id: string;
+  face_name: string;
+}
+
+export type MayTriggerAutoChoiceSelector =
+  | {
+      type: "ExactInstance";
+      data: { player: PlayerId; source_id: ObjectId; origin: MayTriggerOrigin };
+    }
+  | {
+      type: "SameCard";
+      data: { player: PlayerId; printed_ref: PrintedCardRef; printed_occurrence: number };
+    };
+
 export interface MayTriggerAutoChoiceRecord {
-  key: MayTriggerAutoChoiceKey;
+  selector: MayTriggerAutoChoiceSelector;
   choice: AutoMayChoice;
 }
 
 // CR 603.5: The mutation a `SetMayTriggerAutoChoice` action performs on the
 // acting player's stored "don't ask again" auto-choices for optional ("may")
-// triggers. `Remove` echoes a stored key verbatim; `ClearAll` drops every
+// triggers. `Remove` echoes a stored selector verbatim; `ClearAll` drops every
 // stored auto-choice belonging to the acting player.
 export type MayTriggerAutoChoiceOp =
-  | { type: "Remove"; data: { key: MayTriggerAutoChoiceKey } }
+  | { type: "Remove"; data: { selector: MayTriggerAutoChoiceSelector } }
   | { type: "ClearAll" };
 
 // CR 603.3b: A live `OrderTriggers` answer is the only way to save a
@@ -1829,7 +1846,7 @@ export type WaitingFor =
     }
   | { type: "CollectEvidenceChoice"; data: { player: PlayerId; minimum_mana_value: number; cards: ObjectId[]; resume: unknown } }
   | { type: "HarmonizeTapChoice"; data: { player: PlayerId; eligible_creatures: ObjectId[]; pending_cast: PendingCast } }
-  | { type: "OptionalEffectChoice"; data: { player: PlayerId; source_id: ObjectId; description?: string; may_trigger_key?: MayTriggerAutoChoiceKey } }
+  | { type: "OptionalEffectChoice"; data: { player: PlayerId; source_id: ObjectId; description?: string; may_trigger_key?: MayTriggerAutoChoiceKey; same_card_may_trigger_choice_available?: boolean } }
   | { type: "PairChoice"; data: { player: PlayerId; source_id: ObjectId; choices: ObjectId[] } }
   | { type: "OpponentMayChoice"; data: { player: PlayerId; source_id: ObjectId; description?: string; remaining: PlayerId[] } }
   | { type: "LoopShortcut"; data: { proposer: PlayerId; predicted_winner: PlayerId | null; certificate: LoopCertificate; schema: ShortcutDecisionSchema } }
@@ -2341,7 +2358,7 @@ export type GameAction =
   | { type: "CastSpellAsWebSlinging"; data: { hand_object: ObjectId; card_id: CardId; creature_to_return: ObjectId; payment_mode?: CastPaymentMode } }
   | { type: "ActivateNinjutsu"; data: { ninjutsu_object_id: ObjectId; creature_to_return: ObjectId } }
   | { type: "DecideOptionalEffect"; data: { accept: boolean } }
-  | { type: "DecideOptionalEffectAndRemember"; data: { choice: AutoMayChoice } }
+  | { type: "DecideOptionalEffectAndRemember"; data: { choice: AutoMayChoice; scope?: MayTriggerAutoChoiceScope } }
   | { type: "PayUnlessCost"; data: { pay: boolean } }
   // CR 118.12a: Choose a branch of a disjunctive unless-cost. The
   // discriminant is `Decline` (effect happens) or `Pay { index }` (the

--- a/client/src/components/board/MayTriggerAutoChoiceList.tsx
+++ b/client/src/components/board/MayTriggerAutoChoiceList.tsx
@@ -1,6 +1,6 @@
 import { useTranslation } from "react-i18next";
 
-import type { MayTriggerAutoChoiceKey } from "../../adapter/types.ts";
+import type { MayTriggerAutoChoiceSelector } from "../../adapter/types.ts";
 import { dispatchAction } from "../../game/dispatch.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { PopoverMenu } from "../menu/PopoverMenu.tsx";
@@ -13,7 +13,7 @@ import { PopoverMenu } from "../menu/PopoverMenu.tsx";
  * `PriorityYieldList` so the action rail height stays constant no matter how
  * many auto-choices accumulate. Purely a display + dispatch surface: the engine
  * owns the state (redacted per-viewer in `may_trigger_auto_choices`), enforces
- * actor scoping on the write, and each remove echoes the stored key verbatim.
+ * actor scoping on the write, and each remove echoes the stored selector verbatim.
  */
 export function MayTriggerAutoChoiceList() {
   const { t } = useTranslation("game");
@@ -22,16 +22,7 @@ export function MayTriggerAutoChoiceList() {
 
   if (!choices || choices.length === 0) return null;
 
-  const rowKey = (key: MayTriggerAutoChoiceKey) => {
-    switch (key.origin.type) {
-      case "Printed":
-        return `${key.player}-${key.source_id}-p${key.origin.trigger_index}`;
-      case "Keyword":
-        return `${key.player}-${key.source_id}-k${key.origin.keyword}`;
-      case "Definition":
-        return `${key.player}-${key.source_id}-d${JSON.stringify(key.origin.definition_ref)}`;
-    }
-  };
+  const rowKey = (selector: MayTriggerAutoChoiceSelector) => JSON.stringify(selector);
 
   return (
     <PopoverMenu
@@ -79,7 +70,9 @@ export function MayTriggerAutoChoiceList() {
           <ul className="flex flex-col">
             {choices.map((record) => {
               const sourceName =
-                objects?.[record.key.source_id]?.name ??
+                (record.selector.type === "ExactInstance"
+                  ? objects?.[record.selector.data.source_id]?.name
+                  : record.selector.data.printed_ref.face_name) ??
                 t("mayTriggerAutoChoice.sourceFallback");
               const decision =
                 record.choice.type === "Accept"
@@ -87,7 +80,7 @@ export function MayTriggerAutoChoiceList() {
                   : t("mayTriggerAutoChoice.decline");
               return (
                 <li
-                  key={rowKey(record.key)}
+                  key={rowKey(record.selector)}
                   className="flex items-center justify-between gap-2 px-3 py-1.5"
                 >
                   <span className="truncate text-sm text-gray-200">
@@ -102,7 +95,7 @@ export function MayTriggerAutoChoiceList() {
                     onClick={() =>
                       dispatchAction({
                         type: "SetMayTriggerAutoChoice",
-                        data: { op: { type: "Remove", data: { key: record.key } } },
+                        data: { op: { type: "Remove", data: { selector: record.selector } } },
                       })
                     }
                   >

--- a/client/src/components/board/__tests__/MayTriggerAutoChoiceList.test.tsx
+++ b/client/src/components/board/__tests__/MayTriggerAutoChoiceList.test.tsx
@@ -13,10 +13,13 @@ vi.mock("../../../game/dispatch.ts", () => ({ dispatchAction: dispatchActionMock
 
 function record(sourceId: number, accept: boolean): MayTriggerAutoChoiceRecord {
   return {
-    key: {
-      player: 0,
-      source_id: sourceId,
-      origin: { type: "Printed", trigger_index: 0 },
+    selector: {
+      type: "ExactInstance",
+      data: {
+        player: 0,
+        source_id: sourceId,
+        origin: { type: "Printed", trigger_index: 0 },
+      },
     },
     choice: { type: accept ? "Accept" : "Decline" },
   };
@@ -71,7 +74,7 @@ describe("MayTriggerAutoChoiceList", () => {
     expect(screen.getByText("Remove")).toBeInTheDocument();
   });
 
-  it("dispatches a Remove that echoes the stored key verbatim", () => {
+  it("dispatches a Remove that echoes the stored selector verbatim", () => {
     seed([record(50, true)]);
     render(<MayTriggerAutoChoiceList />);
 
@@ -84,10 +87,13 @@ describe("MayTriggerAutoChoiceList", () => {
         op: {
           type: "Remove",
           data: {
-            key: {
-              player: 0,
-              source_id: 50,
-              origin: { type: "Printed", trigger_index: 0 },
+            selector: {
+              type: "ExactInstance",
+              data: {
+                player: 0,
+                source_id: 50,
+                origin: { type: "Printed", trigger_index: 0 },
+              },
             },
           },
         },

--- a/client/src/components/chrome/GameMenu.tsx
+++ b/client/src/components/chrome/GameMenu.tsx
@@ -29,6 +29,9 @@ interface GameMenuProps {
   onToggleAiHand: () => void;
   multiplayerBoardLayout?: MultiplayerBoardLayout;
   onToggleMultiplayerBoardLayout?: () => void;
+  showMultiplayerSplitLayoutNudge?: boolean;
+  onTryMultiplayerSplitLayout?: () => void;
+  onDismissMultiplayerSplitLayoutNudge?: () => void;
   onSettingsClick: () => void;
   onHelpClick: () => void;
   onConcede?: () => void;
@@ -59,6 +62,9 @@ export function GameMenu({
   onToggleAiHand,
   multiplayerBoardLayout,
   onToggleMultiplayerBoardLayout,
+  showMultiplayerSplitLayoutNudge = false,
+  onTryMultiplayerSplitLayout,
+  onDismissMultiplayerSplitLayoutNudge,
   onSettingsClick,
   onHelpClick,
   onConcede,
@@ -169,6 +175,37 @@ export function GameMenu({
               }}
             />
           )}
+          {showMultiplayerSplitLayoutNudge &&
+            onTryMultiplayerSplitLayout &&
+            onDismissMultiplayerSplitLayoutNudge && (
+              <div className="mx-2 mb-1 rounded-md border border-cyan-300/20 bg-cyan-300/8 px-3 py-2">
+                <p className="text-xs leading-4 text-slate-200">
+                  {t("gameMenu.multiplayerSplitLayoutNudge.message")}
+                </p>
+                <div className="mt-2 flex justify-end gap-2">
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onDismissMultiplayerSplitLayoutNudge();
+                      setOpen(false);
+                    }}
+                    className="rounded px-2 py-1 text-xs font-semibold text-slate-300 transition-colors hover:bg-white/10 hover:text-white"
+                  >
+                    {t("gameMenu.multiplayerSplitLayoutNudge.dismiss")}
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => {
+                      onTryMultiplayerSplitLayout();
+                      setOpen(false);
+                    }}
+                    className="rounded bg-cyan-300 px-2 py-1 text-xs font-semibold text-slate-950 transition-colors hover:bg-cyan-200"
+                  >
+                    {t("gameMenu.multiplayerSplitLayoutNudge.trySplit")}
+                  </button>
+                </div>
+              </div>
+            )}
           <div className="my-1 border-t border-gray-700/70" />
           <MenuSectionLabel label={t("gameMenu.sections.tools")} />
           {showReportCard && onReportCardClick && (

--- a/client/src/components/chrome/__tests__/GameMenu.test.tsx
+++ b/client/src/components/chrome/__tests__/GameMenu.test.tsx
@@ -72,6 +72,31 @@ describe("GameMenu", () => {
     expect(screen.getByRole("button", { name: "Switch to split table view Legacy" })).toBeInTheDocument();
   });
 
+  it("routes the split-layout nudge through its supplied callbacks", () => {
+    const onTryMultiplayerSplitLayout = vi.fn();
+    const onDismissMultiplayerSplitLayoutNudge = vi.fn();
+    renderGameMenu({
+      showMultiplayerSplitLayoutNudge: true,
+      onTryMultiplayerSplitLayout,
+      onDismissMultiplayerSplitLayoutNudge,
+    });
+
+    fireEvent.click(screen.getByRole("button", { name: "Game menu" }));
+    fireEvent.click(screen.getByRole("button", { name: "Try split view" }));
+
+    expect(onTryMultiplayerSplitLayout).toHaveBeenCalledOnce();
+    expect(onDismissMultiplayerSplitLayoutNudge).not.toHaveBeenCalled();
+  });
+
+  it("hides the split-layout nudge without its complete callback contract", () => {
+    renderGameMenu({ showMultiplayerSplitLayoutNudge: true });
+
+    fireEvent.click(screen.getByRole("button", { name: "Game menu" }));
+
+    expect(screen.queryByRole("button", { name: "Try split view" })).toBeNull();
+    expect(screen.queryByRole("button", { name: "Not now" })).toBeNull();
+  });
+
   it("opens sandbox tools from the collapsed menu", () => {
     const onSandboxToolsClick = vi.fn();
     renderGameMenu({ showSandboxTools: true, onSandboxToolsClick });

--- a/client/src/components/modal/OptionalEffectModal.tsx
+++ b/client/src/components/modal/OptionalEffectModal.tsx
@@ -22,9 +22,11 @@ export function OptionalEffectModalContent({
 }: OptionalEffectModalProps) {
   const { t } = useTranslation("game");
   const [remember, setRemember] = useState(false);
+  const [sameCard, setSameCard] = useState(false);
 
   useEffect(() => {
     setRemember(false);
+    setSameCard(false);
   }, [waitingFor]);
 
   const sourceObj = objects?.[waitingFor.data.source_id];
@@ -32,6 +34,9 @@ export function OptionalEffectModalContent({
   const description = waitingFor.data.description as string | undefined;
   const canRemember =
     waitingFor.type === "OptionalEffectChoice" && waitingFor.data.may_trigger_key != null;
+  const sameCardAvailable =
+    waitingFor.type === "OptionalEffectChoice" &&
+    waitingFor.data.same_card_may_trigger_choice_available === true;
 
   return (
     <ChoiceModal
@@ -48,7 +53,10 @@ export function OptionalEffectModalContent({
         if (remember && canRemember) {
           dispatch({
             type: "DecideOptionalEffectAndRemember",
-            data: { choice: { type: accept ? "Accept" : "Decline" } },
+            data: {
+              choice: { type: accept ? "Accept" : "Decline" },
+              scope: { type: sameCard ? "SameCard" : "ExactInstance" },
+            },
           });
           return;
         }
@@ -56,15 +64,34 @@ export function OptionalEffectModalContent({
       }}
       footer={
         canRemember ? (
-          <label className="flex items-center gap-2 rounded-[10px] border border-white/8 bg-black/20 px-3 py-2 text-sm text-slate-200">
-            <input
-              type="checkbox"
-              checked={remember}
-              onChange={(event) => setRemember(event.currentTarget.checked)}
-              className="h-4 w-4 accent-cyan-400"
-            />
-            <span>{t("optionalEffect.dontAskAgain")}</span>
-          </label>
+          <div className="space-y-2 rounded-[10px] border border-white/8 bg-black/20 px-3 py-2 text-sm text-slate-200">
+            <label className="flex items-center gap-2">
+              <input
+                type="checkbox"
+                checked={remember}
+                onChange={(event) => {
+                  setRemember(event.currentTarget.checked);
+                  if (!event.currentTarget.checked) setSameCard(false);
+                }}
+                className="h-4 w-4 accent-cyan-400"
+              />
+              <span>{t("optionalEffect.dontAskAgain")}</span>
+            </label>
+            {sameCardAvailable && (
+              <label className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  checked={sameCard}
+                  onChange={(event) => {
+                    setSameCard(event.currentTarget.checked);
+                    if (event.currentTarget.checked) setRemember(true);
+                  }}
+                  className="h-4 w-4 accent-cyan-400"
+                />
+                <span>{t("optionalEffect.dontAskAgainForSameCard")}</span>
+              </label>
+            )}
+          </div>
         ) : undefined
       }
     />

--- a/client/src/components/modal/__tests__/OptionalEffectModal.test.tsx
+++ b/client/src/components/modal/__tests__/OptionalEffectModal.test.tsx
@@ -8,6 +8,7 @@ type OptionalEffectWaitingFor = Extract<WaitingFor, { type: "OptionalEffectChoic
 
 function optionalWaitingFor(
   mayTriggerKey?: OptionalEffectWaitingFor["data"]["may_trigger_key"],
+  sameCardAvailable = false,
 ): OptionalEffectWaitingFor {
   return {
     type: "OptionalEffectChoice",
@@ -16,6 +17,7 @@ function optionalWaitingFor(
       source_id: 100,
       description: "You may gain 1 life.",
       may_trigger_key: mayTriggerKey,
+      same_card_may_trigger_choice_available: sameCardAvailable,
     },
   };
 }
@@ -75,7 +77,7 @@ describe("OptionalEffectModalContent", () => {
 
     expect(dispatch).toHaveBeenCalledWith({
       type: "DecideOptionalEffectAndRemember",
-      data: { choice: { type: "Accept" } },
+      data: { choice: { type: "Accept" }, scope: { type: "ExactInstance" } },
     });
 
     cleanup();
@@ -92,7 +94,50 @@ describe("OptionalEffectModalContent", () => {
 
     expect(declineDispatch).toHaveBeenCalledWith({
       type: "DecideOptionalEffectAndRemember",
-      data: { choice: { type: "Decline" } },
+      data: { choice: { type: "Decline" }, scope: { type: "ExactInstance" } },
     });
+  });
+
+  it("shows the engine-gated same-card checkbox and dispatches that scope", () => {
+    const dispatch = renderModal(
+      optionalWaitingFor(
+        {
+          player: 0,
+          source_id: 100,
+          origin: { type: "Printed", trigger_index: 0 },
+        },
+        true,
+      ),
+    );
+
+    fireEvent.click(screen.getByLabelText("Apply this to every copy of this card"));
+    fireEvent.click(screen.getByRole("button", { name: "Yes" }));
+
+    expect(dispatch).toHaveBeenCalledWith({
+      type: "DecideOptionalEffectAndRemember",
+      data: { choice: { type: "Accept" }, scope: { type: "SameCard" } },
+    });
+  });
+
+  it("resets the same-card checkbox for each prompt", () => {
+    const keyed = {
+      player: 0,
+      source_id: 100,
+      origin: { type: "Printed", trigger_index: 0 },
+    };
+    const { rerender } = render(
+      <OptionalEffectModalContent waitingFor={optionalWaitingFor(keyed, true)} dispatch={vi.fn()} />,
+    );
+
+    fireEvent.click(screen.getByLabelText("Apply this to every copy of this card"));
+    expect(screen.getByLabelText("Apply this to every copy of this card")).toBeChecked();
+
+    rerender(
+      <OptionalEffectModalContent
+        waitingFor={{ ...optionalWaitingFor(keyed, true), data: { ...optionalWaitingFor(keyed, true).data, source_id: 101 } }}
+        dispatch={vi.fn()}
+      />,
+    );
+    expect(screen.getByLabelText("Apply this to every copy of this card")).not.toBeChecked();
   });
 });

--- a/client/src/components/modal/__tests__/OptionalEffectModal.test.tsx
+++ b/client/src/components/modal/__tests__/OptionalEffectModal.test.tsx
@@ -120,7 +120,7 @@ describe("OptionalEffectModalContent", () => {
   });
 
   it("resets the same-card checkbox for each prompt", () => {
-    const keyed = {
+    const keyed: NonNullable<OptionalEffectWaitingFor["data"]["may_trigger_key"]> = {
       player: 0,
       source_id: 100,
       origin: { type: "Printed", trigger_index: 0 },

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -84,6 +84,11 @@
     "boardLayoutLegacy": "Legacy",
     "switchToSplitView": "Zur geteilten Tischansicht wechseln",
     "switchToLegacyView": "Zur fokussierten Legacy-Ansicht wechseln",
+    "multiplayerSplitLayoutNudge": {
+      "message": "Mit der geteilten Tischansicht siehst du alle Gegner gleichzeitig.",
+      "trySplit": "Geteilte Ansicht ausprobieren",
+      "dismiss": "Jetzt nicht"
+    },
     "helpShortcuts": "Hilfe & Tastenkürzel",
     "showAiHand": "KI-Hand anzeigen",
     "hideAiHand": "KI-Hand verbergen",

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -2126,7 +2126,8 @@
     "title": "{{name}} - Optionaler Effekt",
     "yes": "Ja",
     "no": "Nein",
-    "dontAskAgain": "Dieses Spiel nicht mehr fragen"
+    "dontAskAgain": "Dieses Spiel nicht mehr fragen",
+    "dontAskAgainForSameCard": "Auf jede Kopie dieser Karte anwenden"
   },
   "topOrBottom": {
     "cardFallback": "Card",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -84,6 +84,11 @@
     "boardLayoutLegacy": "Legacy",
     "switchToSplitView": "Switch to split table view",
     "switchToLegacyView": "Switch to legacy focused view",
+    "multiplayerSplitLayoutNudge": {
+      "message": "See every opponent at once with split table view.",
+      "trySplit": "Try split view",
+      "dismiss": "Not now"
+    },
     "helpShortcuts": "Help & Shortcuts",
     "showAiHand": "Show AI Hand",
     "hideAiHand": "Hide AI Hand",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -2170,7 +2170,8 @@
     "title": "{{name}} - Optional Effect",
     "yes": "Yes",
     "no": "No",
-    "dontAskAgain": "Don't ask again this game"
+    "dontAskAgain": "Don't ask again this game",
+    "dontAskAgainForSameCard": "Apply this to every copy of this card"
   },
   "topOrBottom": {
     "cardFallback": "Card",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -84,6 +84,11 @@
     "boardLayoutLegacy": "Legacy",
     "switchToSplitView": "Cambiar a vista de mesa dividida",
     "switchToLegacyView": "Cambiar a vista legacy enfocada",
+    "multiplayerSplitLayoutNudge": {
+      "message": "Ve a todos los oponentes a la vez con la vista de mesa dividida.",
+      "trySplit": "Probar vista dividida",
+      "dismiss": "Ahora no"
+    },
     "helpShortcuts": "Ayuda y atajos",
     "showAiHand": "Mostrar la mano de la IA",
     "hideAiHand": "Ocultar la mano de la IA",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -2126,7 +2126,8 @@
     "title": "{{name}} - Efecto opcional",
     "yes": "Sí",
     "no": "No",
-    "dontAskAgain": "No volver a preguntar en esta partida"
+    "dontAskAgain": "No volver a preguntar en esta partida",
+    "dontAskAgainForSameCard": "Aplicar a cada copia de esta carta"
   },
   "topOrBottom": {
     "cardFallback": "Card",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -84,6 +84,11 @@
     "boardLayoutLegacy": "Legacy",
     "switchToSplitView": "Passer à la vue table divisée",
     "switchToLegacyView": "Passer à la vue legacy focalisée",
+    "multiplayerSplitLayoutNudge": {
+      "message": "Voyez tous les adversaires à la fois avec la vue table divisée.",
+      "trySplit": "Essayer la vue divisée",
+      "dismiss": "Pas maintenant"
+    },
     "helpShortcuts": "Aide et raccourcis",
     "showAiHand": "Afficher la main de l'IA",
     "hideAiHand": "Masquer la main de l'IA",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -2126,7 +2126,8 @@
     "title": "{{name}} - Effet facultatif",
     "yes": "Oui",
     "no": "Non",
-    "dontAskAgain": "Ne plus demander pendant cette partie"
+    "dontAskAgain": "Ne plus demander pendant cette partie",
+    "dontAskAgainForSameCard": "Appliquer à chaque exemplaire de cette carte"
   },
   "topOrBottom": {
     "cardFallback": "Card",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -84,6 +84,11 @@
     "boardLayoutLegacy": "Legacy",
     "switchToSplitView": "Passa alla vista tavolo diviso",
     "switchToLegacyView": "Passa alla vista legacy focalizzata",
+    "multiplayerSplitLayoutNudge": {
+      "message": "Vedi tutti gli avversari insieme con la vista tavolo diviso.",
+      "trySplit": "Prova la vista divisa",
+      "dismiss": "Non ora"
+    },
     "helpShortcuts": "Aiuto e scorciatoie",
     "showAiHand": "Mostra mano IA",
     "hideAiHand": "Nascondi mano IA",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -2126,7 +2126,8 @@
     "title": "{{name}} - Effetto facoltativo",
     "yes": "Sì",
     "no": "No",
-    "dontAskAgain": "Non chiedere di nuovo in questa partita"
+    "dontAskAgain": "Non chiedere di nuovo in questa partita",
+    "dontAskAgainForSameCard": "Applica a ogni copia di questa carta"
   },
   "topOrBottom": {
     "cardFallback": "Card",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -84,6 +84,11 @@
     "boardLayoutLegacy": "Legacy",
     "switchToSplitView": "Przełącz na widok podzielonego stołu",
     "switchToLegacyView": "Przełącz na skupiony widok legacy",
+    "multiplayerSplitLayoutNudge": {
+      "message": "Zobacz wszystkich przeciwników naraz w widoku podzielonego stołu.",
+      "trySplit": "Wypróbuj widok podzielony",
+      "dismiss": "Nie teraz"
+    },
     "helpShortcuts": "Pomoc i skróty",
     "showAiHand": "Pokaż rękę AI",
     "hideAiHand": "Ukryj rękę AI",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -2126,7 +2126,8 @@
     "title": "{{name}} - Efekt opcjonalny",
     "yes": "Tak",
     "no": "Nie",
-    "dontAskAgain": "Nie pytaj ponownie w tej grze"
+    "dontAskAgain": "Nie pytaj ponownie w tej grze",
+    "dontAskAgainForSameCard": "Zastosuj do każdej kopii tej karty"
   },
   "topOrBottom": {
     "cardFallback": "Karta",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -84,6 +84,11 @@
     "boardLayoutLegacy": "Legacy",
     "switchToSplitView": "Alternar para visualização de mesa dividida",
     "switchToLegacyView": "Alternar para visualização legacy focada",
+    "multiplayerSplitLayoutNudge": {
+      "message": "Veja todos os oponentes de uma vez na visualização de mesa dividida.",
+      "trySplit": "Experimentar visualização dividida",
+      "dismiss": "Agora não"
+    },
     "helpShortcuts": "Ajuda e Atalhos",
     "showAiHand": "Mostrar Mão da IA",
     "hideAiHand": "Ocultar Mão da IA",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -2126,7 +2126,8 @@
     "title": "{{name}} - Efeito Opcional",
     "yes": "Sim",
     "no": "Não",
-    "dontAskAgain": "Não perguntar novamente neste jogo"
+    "dontAskAgain": "Não perguntar novamente neste jogo",
+    "dontAskAgainForSameCard": "Aplicar a todas as cópias desta carta"
   },
   "topOrBottom": {
     "cardFallback": "Card",

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -158,7 +158,6 @@ import { clearPromptOverlayState } from "../game/sessionCleanup.ts";
 import { clearGame, hasRemoteHumans, loadActiveGame, useGameStore } from "../stores/gameStore.ts";
 import { useUiStore } from "../stores/uiStore.ts";
 import { usePreferencesStore } from "../stores/preferencesStore.ts";
-import type { MultiplayerBoardLayout } from "../stores/preferencesStore.ts";
 import {
   FORMAT_DEFAULTS,
   getOpponentDisplayName,
@@ -187,6 +186,7 @@ import {
   getSeatCount,
   getWaitingForObjectChoiceIds,
   isSplitBoardActive,
+  resolveMultiplayerBoardLayout,
   resolveFocusedOpponent,
   shouldRenderFocusedOpponentTopRow,
   type ZoneViewerTarget,
@@ -952,6 +952,12 @@ function GamePageContent({
   const cardReportDialogOpen = useUiStore((s) => s.cardReportDialogOpen);
   const multiplayerBoardLayout = usePreferencesStore((s) => s.multiplayerBoardLayout);
   const setMultiplayerBoardLayout = usePreferencesStore((s) => s.setMultiplayerBoardLayout);
+  const multiplayerSplitLayoutNudgeDismissed = usePreferencesStore(
+    (s) => s.multiplayerSplitLayoutNudgeDismissed,
+  );
+  const setMultiplayerSplitLayoutNudgeDismissed = usePreferencesStore(
+    (s) => s.setMultiplayerSplitLayoutNudgeDismissed,
+  );
   const debugPanelOpen = useUiStore((s) => s.debugPanelOpen);
   const debugClickModeButtonVisible = useUiStore((s) => s.debugClickModeButtonVisible);
   const toggleDebugClickModeButtonVisible = useUiStore(
@@ -990,10 +996,15 @@ function GamePageContent({
   const activeOpponentId =
     resolveFocusedOpponent(focusedOpponent, opponents) ?? opponents[0] ?? null;
   const seatCount = getSeatCount(gameState);
-  const effectiveMultiplayerBoardLayout: MultiplayerBoardLayout =
+  const resolvedMultiplayerBoardLayout = resolveMultiplayerBoardLayout(
+    multiplayerBoardLayout,
+    seatCount,
+    isMobile,
+  );
+  const effectiveMultiplayerBoardLayout =
     seatCount > 2 && canActForWaitingState && getBoardChoiceView(waitingFor, objects)?.intent === "untap"
       ? "split"
-      : multiplayerBoardLayout;
+      : resolvedMultiplayerBoardLayout;
   const splitBoardActive = isSplitBoardActive(effectiveMultiplayerBoardLayout, seatCount);
   const renderFocusedOpponentTopRow = shouldRenderFocusedOpponentTopRow(
     effectiveMultiplayerBoardLayout,
@@ -1002,6 +1013,17 @@ function GamePageContent({
   const handleToggleMultiplayerBoardLayout = useCallback(() => {
     setMultiplayerBoardLayout(multiplayerBoardLayout === "split" ? "focused" : "split");
   }, [multiplayerBoardLayout, setMultiplayerBoardLayout]);
+  const handleTryMultiplayerSplitLayout = useCallback(() => {
+    setMultiplayerBoardLayout("split");
+  }, [setMultiplayerBoardLayout]);
+  const handleDismissMultiplayerSplitLayoutNudge = useCallback(() => {
+    setMultiplayerSplitLayoutNudgeDismissed(true);
+  }, [setMultiplayerSplitLayoutNudgeDismissed]);
+  const showMultiplayerSplitLayoutNudge =
+    seatCount > 2 &&
+    !isMobile &&
+    multiplayerBoardLayout === "focused" &&
+    !multiplayerSplitLayoutNudgeDismissed;
   const gridTemplateRows = splitBoardActive ? splitGridTemplateRows : focusedGridTemplateRows;
   const handleKickPlayer = useCallback((pid: number) => {
     const adapter = useGameStore.getState().adapter as
@@ -1626,6 +1648,13 @@ function GamePageContent({
         onToggleAiHand={() => setShowAiHand((v) => !v)}
         multiplayerBoardLayout={seatCount > 2 ? multiplayerBoardLayout : undefined}
         onToggleMultiplayerBoardLayout={seatCount > 2 ? handleToggleMultiplayerBoardLayout : undefined}
+        showMultiplayerSplitLayoutNudge={showMultiplayerSplitLayoutNudge}
+        onTryMultiplayerSplitLayout={
+          showMultiplayerSplitLayoutNudge ? handleTryMultiplayerSplitLayout : undefined
+        }
+        onDismissMultiplayerSplitLayoutNudge={
+          showMultiplayerSplitLayoutNudge ? handleDismissMultiplayerSplitLayoutNudge : undefined
+        }
         onSettingsClick={() => setPreferencesOpen({})}
         onHelpClick={() => setHelpSheetOpen(true)}
         onConcede={onShowConcedeDialog}

--- a/client/src/pages/ReplayPage.tsx
+++ b/client/src/pages/ReplayPage.tsx
@@ -10,7 +10,10 @@ import { MenuParticles } from "../components/menu/MenuParticles";
 import { MenuPanel } from "../components/menu/MenuShell";
 import { menuButtonClass } from "../components/menu/buttonStyles";
 import { useReplayStore } from "../stores/replayStore";
+import { useGameStore } from "../stores/gameStore";
 import { usePreferencesStore } from "../stores/preferencesStore";
+import { useIsMobile } from "../hooks/useIsMobile";
+import { getSeatCount, resolveMultiplayerBoardLayout } from "../viewmodel/gameStateView";
 
 /**
  * Stand-alone replay viewer. Deliberately does NOT use `GameProvider` /
@@ -34,6 +37,13 @@ export function ReplayPage() {
   const unload = useReplayStore((s) => s.unload);
   const isLoaded = useReplayStore((s) => s.adapter !== null);
   const multiplayerBoardLayout = usePreferencesStore((s) => s.multiplayerBoardLayout);
+  const isMobile = useIsMobile();
+  const gameState = useGameStore((s) => s.gameState);
+  const effectiveMultiplayerBoardLayout = resolveMultiplayerBoardLayout(
+    multiplayerBoardLayout,
+    getSeatCount(gameState),
+    isMobile,
+  );
 
   useEffect(() => unload, [unload]);
 
@@ -122,7 +132,7 @@ export function ReplayPage() {
         </button>
       </div>
       <div className="relative z-10 flex min-h-0 flex-1 flex-col">
-        <GameBoard effectiveMultiplayerBoardLayout={multiplayerBoardLayout} />
+        <GameBoard effectiveMultiplayerBoardLayout={effectiveMultiplayerBoardLayout} />
       </div>
       <ReplayControls />
     </div>

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -32,8 +32,9 @@ let capturedFormatConfig: FormatConfig | undefined;
 let capturedOnWsEvent: ((event: WsAdapterEvent) => void) | undefined;
 let capturedOnP2PEvent: ((event: P2PAdapterEvent) => void) | undefined;
 
-const { mockClearPromptOverlayState, mockSetGameState, storeOverrides } = vi.hoisted(() => ({
+const { mockClearPromptOverlayState, mockIsMobile, mockSetGameState, storeOverrides } = vi.hoisted(() => ({
   mockClearPromptOverlayState: vi.fn(),
+  mockIsMobile: vi.fn(() => false),
   mockSetGameState: vi.fn(),
   // Mutable slice of the mocked game store. Defaults match the previous
   // hardcoded values, so every pre-existing test is unaffected; tests that
@@ -194,7 +195,7 @@ vi.mock("../../hooks/usePlayerId", () => ({
 }));
 
 vi.mock("../../hooks/useIsMobile", () => ({
-  useIsMobile: () => false,
+  useIsMobile: () => mockIsMobile(),
   useIsCompactHeight: () => false,
 }));
 
@@ -307,7 +308,11 @@ beforeEach(() => {
   storeOverrides.gameState = null;
   storeOverrides.gameMode = null;
   storeOverrides.waitingFor = null;
-  usePreferencesStore.setState({ multiplayerBoardLayout: "focused" });
+  mockIsMobile.mockReturnValue(false);
+  usePreferencesStore.setState({
+    multiplayerBoardLayout: "focused",
+    multiplayerSplitLayoutNudgeDismissed: true,
+  });
   capturedConcedeDialogProps = undefined;
   vi.clearAllMocks();
 });
@@ -460,6 +465,7 @@ describe("GamePage — cEDH bracket-violation blocking modal", () => {
 
 describe("GamePage — multiplayer board layout during board choices", () => {
   it("forces split visibility for an authorized untap choice at a three-player table", () => {
+    mockIsMobile.mockReturnValue(true);
     const untapCandidate = gameObjectFactory
       .creature(2, 2)
       .onBattlefield()
@@ -499,6 +505,98 @@ describe("GamePage — multiplayer board layout during board choices", () => {
 
     expect(screen.getByTestId("game-board-layout")).toHaveAttribute("data-layout", "focused");
   });
+
+  it("resolves a raw split preference to focused on mobile outside an untap choice", () => {
+    mockIsMobile.mockReturnValue(true);
+    usePreferencesStore.setState({ multiplayerBoardLayout: "split" });
+    const permanent = gameObjectFactory
+      .creature(2, 2)
+      .onBattlefield()
+      .withId(10)
+      .ownedBy(0)
+      .build();
+    const gameState = gameStateFactory
+      .withPlayers(0, 1, 2)
+      .withObjects(permanent)
+      .priority(0)
+      .build();
+    storeOverrides.gameState = gameState;
+    storeOverrides.waitingFor = gameState.waiting_for;
+
+    renderGamePage();
+
+    expect(screen.getByTestId("game-board-layout")).toHaveAttribute("data-layout", "focused");
+  });
+
+  it("offers the wide focused-layout nudge without writing preferences on render", () => {
+    const permanent = gameObjectFactory
+      .creature(2, 2)
+      .onBattlefield()
+      .withId(10)
+      .ownedBy(0)
+      .build();
+    const gameState = gameStateFactory
+      .withPlayers(0, 1, 2)
+      .withObjects(permanent)
+      .priority(0)
+      .build();
+    storeOverrides.gameState = gameState;
+    storeOverrides.waitingFor = gameState.waiting_for;
+    usePreferencesStore.setState({
+      multiplayerBoardLayout: "focused",
+      multiplayerSplitLayoutNudgeDismissed: false,
+    });
+
+    renderGamePage();
+
+    expect(capturedGameMenuProps?.showMultiplayerSplitLayoutNudge).toBe(true);
+    expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("focused");
+    expect(usePreferencesStore.getState().multiplayerSplitLayoutNudgeDismissed).toBe(false);
+
+    act(() => (capturedGameMenuProps?.onTryMultiplayerSplitLayout as () => void)());
+    expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("split");
+    expect(usePreferencesStore.getState().multiplayerSplitLayoutNudgeDismissed).toBe(false);
+  });
+
+  it("dismisses the nudge without changing the raw layout", () => {
+    const gameState = gameStateFactory.withPlayers(0, 1, 2).priority(0).build();
+    storeOverrides.gameState = gameState;
+    storeOverrides.waitingFor = gameState.waiting_for;
+    usePreferencesStore.setState({
+      multiplayerBoardLayout: "focused",
+      multiplayerSplitLayoutNudgeDismissed: false,
+    });
+
+    renderGamePage();
+
+    act(() => (capturedGameMenuProps?.onDismissMultiplayerSplitLayoutNudge as () => void)());
+
+    expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("focused");
+    expect(usePreferencesStore.getState().multiplayerSplitLayoutNudgeDismissed).toBe(true);
+  });
+
+  it.each([
+    ["mobile", true, "focused", false],
+    ["raw split", false, "split", false],
+    ["dismissed focused", false, "focused", true],
+  ] as const)(
+    "withholds the nudge for a %s cohort",
+    (_cohort, isMobile, multiplayerBoardLayout, multiplayerSplitLayoutNudgeDismissed) => {
+      const gameState = gameStateFactory.withPlayers(0, 1, 2).priority(0).build();
+      storeOverrides.gameState = gameState;
+      storeOverrides.waitingFor = gameState.waiting_for;
+      mockIsMobile.mockReturnValue(isMobile);
+      usePreferencesStore.setState({
+        multiplayerBoardLayout,
+        multiplayerSplitLayoutNudgeDismissed,
+      });
+
+      renderGamePage();
+
+      expect(capturedGameMenuProps?.showMultiplayerSplitLayoutNudge).toBe(false);
+      expect(capturedGameMenuProps?.onTryMultiplayerSplitLayout).toBeUndefined();
+    },
+  );
 });
 
 describe("GamePage — toast surface", () => {

--- a/client/src/stores/__tests__/preferencesStore.test.ts
+++ b/client/src/stores/__tests__/preferencesStore.test.ts
@@ -25,6 +25,7 @@ describe("preferencesStore", () => {
         musicMuted: false,
         masterMuted: false,
         multiplayerBoardLayout: "split",
+        multiplayerSplitLayoutNudgeDismissed: true,
         aiSeats: [{ difficulty: "Medium", deckId: "Random" }],
         aiBracketFilter: [],
       });
@@ -44,6 +45,7 @@ describe("preferencesStore", () => {
     // used below): the shared beforeEach writes its own defaults snapshot, so a
     // getState() read here would assert that snapshot, not buildDefaultPreferences().
     expect(usePreferencesStore.getInitialState().multiplayerBoardLayout).toBe("split");
+    expect(usePreferencesStore.getInitialState().multiplayerSplitLayoutNudgeDismissed).toBe(true);
     expect(state.aiSeats).toEqual([{ difficulty: "Medium", deckId: "Random" }]);
     expect(state.priorityPassingMode).toBe("Standard");
   });
@@ -106,6 +108,15 @@ describe("preferencesStore", () => {
     });
 
     expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("focused");
+  });
+
+  it("updates the multiplayer split-layout nudge dismissal independently", () => {
+    act(() => {
+      usePreferencesStore.getState().setMultiplayerSplitLayoutNudgeDismissed(false);
+    });
+
+    expect(usePreferencesStore.getState().multiplayerSplitLayoutNudgeDismissed).toBe(false);
+    expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("split");
   });
 
   it("setFollowActiveOpponent updates the value", () => {
@@ -612,4 +623,27 @@ describe("preferencesStore", () => {
 
     expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("focused");
   });
+
+  it.each([
+    ["focused", false],
+    ["split", true],
+  ] as const)(
+    "v29 → v30 preserves raw %s layout and sets nudge dismissal to %s",
+    (multiplayerBoardLayout, multiplayerSplitLayoutNudgeDismissed) => {
+      localStorage.setItem(
+        "phase-preferences",
+        JSON.stringify({ state: { multiplayerBoardLayout }, version: 29 }),
+      );
+
+      act(() => {
+        usePreferencesStore.persist.rehydrate();
+      });
+
+      const state = usePreferencesStore.getState();
+      expect(state.multiplayerBoardLayout).toBe(multiplayerBoardLayout);
+      expect(state.multiplayerSplitLayoutNudgeDismissed).toBe(
+        multiplayerSplitLayoutNudgeDismissed,
+      );
+    },
+  );
 });

--- a/client/src/stores/preferencesStore.ts
+++ b/client/src/stores/preferencesStore.ts
@@ -303,6 +303,7 @@ function buildDefaultPreferences(): PreferencesState {
     stackDockSide: "right",
     opponentHudDensity: "comfortable",
     multiplayerBoardLayout: "split",
+    multiplayerSplitLayoutNudgeDismissed: true,
     aiSeats: [defaultAiSeat()],
     cedhMode: false,
     aiArchetypeFilter: "Any",
@@ -395,6 +396,8 @@ interface PreferencesState {
   opponentHudDensity: OpponentHudDensity;
   /** Multiplayer board presentation: one focused opponent, or all opponent seats. */
   multiplayerBoardLayout: MultiplayerBoardLayout;
+  /** Whether the legacy-focused-layout split-view offer has been dismissed. */
+  multiplayerSplitLayoutNudgeDismissed: boolean;
   aiSeats: AiSeatPref[];
   /** Table-wide cEDH toggle. When true, every AI opponent plays at cEDH
    *  (bracket 5) regardless of its per-seat difficulty, and the AI/human deck
@@ -433,6 +436,7 @@ interface PreferencesActions {
   setStackDockSide: (side: StackDockSide) => void;
   setOpponentHudDensity: (density: OpponentHudDensity) => void;
   setMultiplayerBoardLayout: (layout: MultiplayerBoardLayout) => void;
+  setMultiplayerSplitLayoutNudgeDismissed: (dismissed: boolean) => void;
   setLogDefaultState: (state: LogDefaultState) => void;
   setBoardBackground: (bg: BoardBackground) => void;
   setCustomBackgroundUrl: (url: string) => void;
@@ -572,6 +576,8 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       setStackDockSide: (side) => set({ stackDockSide: side }),
       setOpponentHudDensity: (density) => set({ opponentHudDensity: density }),
       setMultiplayerBoardLayout: (layout) => set({ multiplayerBoardLayout: layout }),
+      setMultiplayerSplitLayoutNudgeDismissed: (dismissed) =>
+        set({ multiplayerSplitLayoutNudgeDismissed: dismissed }),
       setLogDefaultState: (state) => set({ logDefaultState: state }),
       setBoardBackground: (bg) => set({ boardBackground: bg }),
       setCustomBackgroundUrl: (url) => set({ customBackgroundUrl: url.trim() }),
@@ -785,7 +791,7 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
     }),
     {
       name: "phase-preferences",
-      version: 29,
+      version: 30,
       // v0 → v1: flat aiDifficulty + aiDeckName become aiSeats[0].
       // v1 → v2: discrete animationSpeed/combatPacing enums become numeric
       //          animationSpeedMultiplier/combatPacingMultiplier.
@@ -1028,6 +1034,19 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
               legacy === "Smart" || legacy === "SkipLowUseWindows"
                 ? "SkipLowUseWindows"
                 : "Standard",
+          };
+        }
+
+        // v29 → v30: Existing focused-layout profiles are the conservative
+        // nudge cohort. The old store cannot distinguish a deliberate focused
+        // setting from the pre-split default, so offer without changing the
+        // raw preference; existing split profiles and all fresh v30 profiles
+        // remain dismissed.
+        if (version < 30) {
+          migrated = {
+            ...migrated,
+            multiplayerSplitLayoutNudgeDismissed:
+              migrated.multiplayerBoardLayout !== "focused",
           };
         }
 

--- a/client/src/viewmodel/__tests__/gameStateView.test.ts
+++ b/client/src/viewmodel/__tests__/gameStateView.test.ts
@@ -42,6 +42,7 @@ import {
   isFaceDownExileCardVisibleToViewer,
   isOneOnOne,
   isSplitBoardActive,
+  resolveMultiplayerBoardLayout,
   resolveFocusedOpponent,
   shouldRenderFocusedOpponentTopRow,
 } from "../gameStateView";
@@ -153,6 +154,13 @@ describe("getVisibleBoardPlayerIds", () => {
 });
 
 describe("split board ownership helpers", () => {
+  it("resolves split only at desktop multiplayer widths", () => {
+    expect(resolveMultiplayerBoardLayout("split", 3, true)).toBe("focused");
+    expect(resolveMultiplayerBoardLayout("split", 3, false)).toBe("split");
+    expect(resolveMultiplayerBoardLayout("split", 2, false)).toBe("focused");
+    expect(resolveMultiplayerBoardLayout("focused", 4, false)).toBe("focused");
+  });
+
   it("activates split layout only for 3+ player games", () => {
     expect(isSplitBoardActive("split", 4)).toBe(true);
     expect(isSplitBoardActive("split", 2)).toBe(false);

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -61,6 +61,19 @@ export function isOneOnOne(gameState: GameState | null): boolean {
   return getSeatCount(gameState) === 2;
 }
 
+/**
+ * Resolves the display layout without mutating the persisted raw preference.
+ * Split view needs at least three seats and a desktop-width viewport; a
+ * focused preference is always honored.
+ */
+export function resolveMultiplayerBoardLayout(
+  layout: MultiplayerBoardLayout,
+  seatCount: number,
+  isMobile: boolean,
+): MultiplayerBoardLayout {
+  return layout === "split" && seatCount > 2 && !isMobile ? "split" : "focused";
+}
+
 export function isSplitBoardActive(
   layout: MultiplayerBoardLayout,
   seatCount: number,

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -2242,11 +2242,31 @@ pub fn legal_actions_full(state: &GameState) -> LegalActionsFull {
         actions.extend([
             GameAction::DecideOptionalEffectAndRemember {
                 choice: AutoMayChoice::Accept,
+                scope: crate::types::game_state::MayTriggerAutoChoiceScope::ExactInstance,
             },
             GameAction::DecideOptionalEffectAndRemember {
                 choice: AutoMayChoice::Decline,
+                scope: crate::types::game_state::MayTriggerAutoChoiceScope::ExactInstance,
             },
         ]);
+        if matches!(
+            &state.waiting_for,
+            WaitingFor::OptionalEffectChoice {
+                same_card_may_trigger_choice_available: true,
+                ..
+            }
+        ) {
+            actions.extend([
+                GameAction::DecideOptionalEffectAndRemember {
+                    choice: AutoMayChoice::Accept,
+                    scope: crate::types::game_state::MayTriggerAutoChoiceScope::SameCard,
+                },
+                GameAction::DecideOptionalEffectAndRemember {
+                    choice: AutoMayChoice::Decline,
+                    scope: crate::types::game_state::MayTriggerAutoChoiceScope::SameCard,
+                },
+            ]);
+        }
     }
 
     // Build spell costs map. The frontend display layer needs the

--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -11301,6 +11301,7 @@ mod tests {
                     source_id: on_board[0],
                     description: None,
                     may_trigger_key: None,
+                    same_card_may_trigger_choice_available: false,
                 },
                 true,
             ),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -7245,7 +7245,9 @@ pub(crate) fn stored_may_answer(
     ability: &ResolvedAbility,
 ) -> Option<AutoMayChoice> {
     let gate = upfront_optional_gate(state, ability, OptionalFeasibility::Probe)?;
-    state.may_trigger_auto_choice(gate.key.as_ref()?)
+    let key = gate.key.as_ref()?;
+    let same_card = state.same_card_may_trigger_auto_choice_selector(key);
+    state.may_trigger_auto_choice_for_prompt(key, same_card.as_ref())
 }
 
 /// CR 603.12a + CR 608.2c: True when this ability is a "you may pay {cost} up to
@@ -7360,6 +7362,7 @@ fn drive_sequential_repeated_optional_payment(
         source_id: ability.source_id,
         description: ability.description.clone(),
         may_trigger_key: None,
+        same_card_may_trigger_choice_available: false,
     };
     Ok(())
 }
@@ -7437,6 +7440,7 @@ pub(super) fn resolve_repeated_optional_payment_choice(
                     source_id,
                     description,
                     may_trigger_key: None,
+                    same_card_may_trigger_choice_available: false,
                 };
                 return Ok(());
             }
@@ -11240,8 +11244,13 @@ fn resolve_chain_body(
         // authority with `Probe` and run the feasibility clone a second time, which is the
         // exact defect `OptionalFeasibility` exists to prevent. Same key, same store, same
         // answer, one probe.
+        let same_card_may_trigger_choice_available = may_trigger_key
+            .as_ref()
+            .is_some_and(|key| state.may_trigger_same_card_choice_available(key));
         if let Some(ref key) = may_trigger_key {
-            if let Some(choice) = state.may_trigger_auto_choice(key) {
+            let same_card = state.same_card_may_trigger_auto_choice_selector(key);
+            if let Some(choice) = state.may_trigger_auto_choice_for_prompt(key, same_card.as_ref())
+            {
                 resolve_optional_effect_decision(
                     state,
                     ability.clone(),
@@ -11277,6 +11286,7 @@ fn resolve_chain_body(
                     source_id: ability.source_id,
                     description,
                     may_trigger_key,
+                    same_card_may_trigger_choice_available,
                 },
             )
             .map_err(|error| EffectError::InvalidParam(error.to_string()))?;

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -7246,8 +7246,7 @@ pub(crate) fn stored_may_answer(
 ) -> Option<AutoMayChoice> {
     let gate = upfront_optional_gate(state, ability, OptionalFeasibility::Probe)?;
     let key = gate.key.as_ref()?;
-    let same_card = state.same_card_may_trigger_auto_choice_selector(key);
-    state.may_trigger_auto_choice_for_prompt(key, same_card.as_ref())
+    state.may_trigger_auto_choice_for_live_prompt(key)
 }
 
 /// CR 603.12a + CR 608.2c: True when this ability is a "you may pay {cost} up to
@@ -11248,9 +11247,7 @@ fn resolve_chain_body(
             .as_ref()
             .is_some_and(|key| state.may_trigger_same_card_choice_available(key));
         if let Some(ref key) = may_trigger_key {
-            let same_card = state.same_card_may_trigger_auto_choice_selector(key);
-            if let Some(choice) = state.may_trigger_auto_choice_for_prompt(key, same_card.as_ref())
-            {
+            if let Some(choice) = state.may_trigger_auto_choice_for_live_prompt(key) {
                 resolve_optional_effect_decision(
                     state,
                     ability.clone(),
@@ -14854,9 +14851,9 @@ mod tests {
         ChosenCounterCountCondition, Comparator, ContinuousModification, ControllerRef,
         DamageChannel, DelayedTriggerCondition, Duration, EffectKind, EffectScope, FilterProp,
         ManaSpendPermission, ObjectProperty, PermissionGrantee, PlayerFilter, PlayerScope, PtValue,
-        QuantityExpr, QuantityRef, SpellContext, StaticDefinition, TapStateChange, TargetFilter,
-        TargetRef, TargetSelectionMode, TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition,
-        ZoneOwner,
+        QuantityExpr, QuantityRef, SpellContext, StaticDefinition, SubAbilityLink, TapStateChange,
+        TargetFilter, TargetRef, TargetSelectionMode, TriggerDefinition, TypeFilter, TypedFilter,
+        UnlessPayModifier, UntilCondition, ZoneOwner,
     };
     use crate::types::actions::GameAction;
     use crate::types::card::CardFace;
@@ -14865,17 +14862,19 @@ mod tests {
     use crate::types::format::FormatConfig;
     use crate::types::game_state::{
         AutoMayChoice, CastingVariant, ExileLink, ExileLinkKind, LKISnapshot, LinkedExileSnapshot,
-        MayTriggerAutoChoiceKey, MayTriggerOrigin, StackEntry, StackEntryKind, ZoneChangeRecord,
+        MayTriggerAutoChoiceKey, MayTriggerAutoChoiceScope, MayTriggerOrigin, StackEntry,
+        StackEntryKind, ZoneChangeRecord,
     };
     use crate::types::identifiers::{
         CardId, DelayedTriggerInstanceId, DelayedTriggerOrigin, DelayedTriggerToken, ObjectId,
         TrackedSetId, TriggerFiring,
     };
     use crate::types::keywords::Keyword;
+    use crate::types::keywords::KeywordKind;
     use crate::types::mana::{ManaColor, ManaCost, ManaType, ManaUnit};
     use crate::types::phase::Phase;
     use crate::types::player::{PlayerCounterKind, PlayerId};
-    use crate::types::resolution::ResolutionStateWire;
+    use crate::types::resolution::{OptionalEffectFrame, ResolutionStateWire};
     use crate::types::statics::CastFrequency;
     use crate::types::triggers::TriggerMode;
     use crate::types::zones::Zone;
@@ -16813,6 +16812,150 @@ mod tests {
 
         assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
         assert_eq!(state.players[0].life, 20);
+    }
+
+    #[test]
+    fn same_card_remembered_may_choice_uses_live_printed_identity_and_continues() {
+        let printed_ref = crate::types::card::PrintedCardRef {
+            oracle_id: "same-card-may-trigger".to_string(),
+            face_name: "Shared Trigger".to_string(),
+        };
+        let mut state = GameState::new_two_player(42);
+        let add_source = |state: &mut GameState, card_id: CardId| {
+            let source_id = create_object(
+                state,
+                card_id,
+                PlayerId(0),
+                "Shared Trigger".to_string(),
+                Zone::Battlefield,
+            );
+            let source = state.objects.get_mut(&source_id).unwrap();
+            source.printed_ref = Some(printed_ref.clone());
+            source.base_printed_ref = Some(printed_ref.clone());
+            source.push_printed_trigger(TriggerDefinition::new(TriggerMode::ChangesZone));
+            let definition_ref = source.trigger_definition_ref(&source.trigger_definitions[0]);
+            MayTriggerAutoChoiceKey {
+                player: PlayerId(0),
+                source_id,
+                origin: MayTriggerOrigin::Definition { definition_ref },
+            }
+        };
+        let first_key = add_source(&mut state, CardId(101));
+        let second_key = add_source(&mut state, CardId(202));
+
+        let continuation = |source_id| {
+            let mut ability = ResolvedAbility::new(
+                Effect::GainLife {
+                    amount: QuantityExpr::Fixed { value: 2 },
+                    player: TargetFilter::Controller,
+                },
+                vec![],
+                source_id,
+                PlayerId(0),
+            );
+            ability.sub_link = SubAbilityLink::ContinuationStep;
+            ability
+        };
+        let mut first = optional_gain_life(first_key.source_id, PlayerId(0), 1);
+        first.sub_ability = Some(Box::new(continuation(first_key.source_id)));
+        state.push_optional_effect_frame(OptionalEffectFrame {
+            ability: Box::new(first),
+            trigger_event: None,
+            trigger_events: Vec::new(),
+            trigger_match_count: None,
+        });
+        state.waiting_for = WaitingFor::OptionalEffectChoice {
+            player: PlayerId(0),
+            source_id: first_key.source_id,
+            description: None,
+            may_trigger_key: Some(first_key.clone()),
+            same_card_may_trigger_choice_available: true,
+        };
+
+        crate::game::engine::apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::DecideOptionalEffectAndRemember {
+                choice: AutoMayChoice::Accept,
+                scope: MayTriggerAutoChoiceScope::SameCard,
+            },
+        )
+        .expect("a live direct printed trigger accepts same-card remembering");
+        assert_eq!(state.players[0].life, 23, "first continuation resolves");
+        assert!(matches!(
+            state.may_trigger_auto_choices.as_slice(),
+            [crate::types::game_state::MayTriggerAutoChoiceRecord {
+                selector: crate::types::game_state::MayTriggerAutoChoiceSelector::SameCard { .. },
+                choice: AutoMayChoice::Accept,
+            }]
+        ));
+
+        let mut second = optional_gain_life(second_key.source_id, PlayerId(0), 1);
+        second.sub_ability = Some(Box::new(continuation(second_key.source_id)));
+        second.set_may_trigger_origin_recursive(second_key.origin.clone());
+        resolve_ability_chain(&mut state, &second, &mut Vec::new(), 0)
+            .expect("same-card answer resolves the second physical card automatically");
+        assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
+        assert_eq!(
+            state.players[0].life, 26,
+            "automatic second continuation resolves"
+        );
+
+        let reject_forged_same_card = |state: &mut GameState, key: MayTriggerAutoChoiceKey| {
+            state.push_optional_effect_frame(OptionalEffectFrame {
+                ability: Box::new(optional_gain_life(key.source_id, PlayerId(0), 1)),
+                trigger_event: None,
+                trigger_events: Vec::new(),
+                trigger_match_count: None,
+            });
+            state.waiting_for = WaitingFor::OptionalEffectChoice {
+                player: PlayerId(0),
+                source_id: key.source_id,
+                description: None,
+                may_trigger_key: Some(key),
+                same_card_may_trigger_choice_available: true,
+            };
+            assert!(
+                crate::game::engine::apply(
+                    state,
+                    PlayerId(0),
+                    GameAction::DecideOptionalEffectAndRemember {
+                        choice: AutoMayChoice::Accept,
+                        scope: MayTriggerAutoChoiceScope::SameCard,
+                    },
+                )
+                .is_err(),
+                "the engine must re-derive same-card eligibility rather than trust the prompt flag"
+            );
+        };
+
+        let mut keyword_state = state.clone();
+        reject_forged_same_card(
+            &mut keyword_state,
+            MayTriggerAutoChoiceKey {
+                player: PlayerId(0),
+                source_id: first_key.source_id,
+                origin: MayTriggerOrigin::Keyword {
+                    keyword: KeywordKind::Flying,
+                },
+            },
+        );
+
+        let mut copied_state = state.clone();
+        copied_state
+            .objects
+            .get_mut(&second_key.source_id)
+            .unwrap()
+            .is_copy = true;
+        reject_forged_same_card(&mut copied_state, second_key.clone());
+
+        let mut stale_state = state;
+        stale_state
+            .objects
+            .get_mut(&first_key.source_id)
+            .unwrap()
+            .incarnation += 1;
+        reject_forged_same_card(&mut stale_state, first_key);
     }
 
     #[test]

--- a/crates/engine/src/game/effects/scoped_library_search.rs
+++ b/crates/engine/src/game/effects/scoped_library_search.rs
@@ -454,6 +454,7 @@ fn advance_acceptance(
         source_id,
         description,
         may_trigger_key: None,
+        same_card_may_trigger_choice_available: false,
     };
     Ok(())
 }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -18690,7 +18690,7 @@ mod stage2_injector_tests {
 
         assert_eq!(
             producers.len() + readers.len() + in_test,
-            41,
+            44,
             "CR 603.5 prompt census drifted. A new PRODUCER must have its recipient bound \
              somewhere — the mint's conjunct (a) covers exactly ONE of them. A new READER is \
              the benign case (U4's own consumption arm was one).\n\
@@ -18698,19 +18698,19 @@ mod stage2_injector_tests {
         );
         assert_eq!(
             (producers.len(), readers.len(), in_test),
-            (5, 8, 28),
-            "the partition, not just the total: five PRODUCTION producers, eight PRODUCTION \
-             readers (they read `state.waiting_for` and never write it), 28 `#[cfg(test)]` lines.\nproducers={producers:#?}\n\
+            (5, 9, 30),
+            "the partition, not just the total: five PRODUCTION producers, nine PRODUCTION \
+             readers (they read `state.waiting_for` and never write it), 30 `#[cfg(test)]` lines.\nproducers={producers:#?}\n\
              readers={readers:#?}"
         );
         assert_eq!(
             producers,
             vec![
-                "game/effects/mod.rs::drive_sequential_repeated_optional_payment {player:ability.controller,source_id:ability.source_id,description:ability.description.clone(),may_trigger_key:None}".to_string(),
-                "game/effects/mod.rs::resolve_chain_body {player:prompt_player,source_id:ability.source_id,description,may_trigger_key}".to_string(),
-                "game/effects/mod.rs::resolve_repeated_optional_payment_choice {player,source_id,description,may_trigger_key:None}".to_string(),
-                "game/effects/scoped_library_search.rs::advance_acceptance {player,source_id,description,may_trigger_key:None}".to_string(),
-                "game/engine.rs::begin_pending_trigger_target_selection {player,source_id,description:trigger_description,may_trigger_key}".to_string(),
+                "game/effects/mod.rs::drive_sequential_repeated_optional_payment {player:ability.controller,source_id:ability.source_id,description:ability.description.clone(),may_trigger_key:None,same_card_may_trigger_choice_available:false}".to_string(),
+                "game/effects/mod.rs::resolve_chain_body {player:prompt_player,source_id:ability.source_id,description,may_trigger_key,same_card_may_trigger_choice_available}".to_string(),
+                "game/effects/mod.rs::resolve_repeated_optional_payment_choice {player,source_id,description,may_trigger_key:None,same_card_may_trigger_choice_available:false}".to_string(),
+                "game/effects/scoped_library_search.rs::advance_acceptance {player,source_id,description,may_trigger_key:None,same_card_may_trigger_choice_available:false}".to_string(),
+                "game/engine.rs::begin_pending_trigger_target_selection {player,source_id,description:trigger_description,may_trigger_key,same_card_may_trigger_choice_available}".to_string(),
             ],
             "the five production producers, each keyed by its ENCLOSING FUNCTION and the \
              CONSTRUCTION it mints, compared as a sorted MULTISET, so a sixth mint inside one \

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -3105,7 +3105,7 @@ fn entry_announces(
     .filter(|gate| {
         gate.key
             .as_ref()
-            .is_none_or(|key| state.may_trigger_auto_choice(key).is_none())
+            .is_none_or(|key| state.may_trigger_auto_choice_for_live_prompt(key).is_none())
     })
     .map(|_| DecisionSlot::may(source.clone()));
     let mut slots = super::ability_utils::build_target_slots(state, ability).ok()?;
@@ -13119,10 +13119,7 @@ pub(super) fn begin_pending_trigger_target_selection(
                     .as_ref()
                     .is_some_and(|key| state.may_trigger_same_card_choice_available(key));
                 if let Some(ref key) = may_trigger_key {
-                    let same_card = state.same_card_may_trigger_auto_choice_selector(key);
-                    if let Some(choice) =
-                        state.may_trigger_auto_choice_for_prompt(key, same_card.as_ref())
-                    {
+                    if let Some(choice) = state.may_trigger_auto_choice_for_live_prompt(key) {
                         match choice {
                             AutoMayChoice::Decline => {
                                 drop_mid_construction_pending_trigger(state);

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -6970,9 +6970,11 @@ pub(super) fn resume_delve_mana_payment(state: &mut GameState) -> WaitingFor {
 enum AutoPassDecision {
     /// No active auto-pass — leave the loop and let the frontend take over.
     Exit,
-    /// Auto-pass completed or was interrupted (opponent action, phase stop,
-    /// stack terminator). Clear the flag and exit.
+    /// Auto-pass completed at a terminal stop. Clear the flag and exit.
     Finish,
+    /// Pause this auto-pass run without clearing the session. The next normal
+    /// action boundary will re-enter the loop and re-evaluate the same mode.
+    Break,
     /// Continue passing priority for this iteration.
     Pass,
 }
@@ -7006,7 +7008,9 @@ fn priority_auto_pass_decision(state: &GameState, player: PlayerId) -> AutoPassD
             let opponent_on_stack = state.stack.last().is_some_and(|top| {
                 top.controller != player && !state.is_priority_yielded(player, top)
             });
-            if opponent_on_stack || state.phase_stop_hit(player) {
+            if opponent_on_stack {
+                AutoPassDecision::Break
+            } else if state.phase_stop_hit(player) {
                 AutoPassDecision::Finish
             } else {
                 AutoPassDecision::Pass
@@ -7325,6 +7329,7 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) -> bool 
                         state.auto_pass.remove(&player);
                         break;
                     }
+                    AutoPassDecision::Break => break,
                     AutoPassDecision::Pass => {}
                 }
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -8001,12 +8001,9 @@ fn apply_action(
     // player can only mutate their own preferences regardless of the payload.
     if let GameAction::SetMayTriggerAutoChoice { op } = &action {
         match op {
-            MayTriggerAutoChoiceOp::Remove { key } => {
-                let actor_key = MayTriggerAutoChoiceKey {
-                    player: actor,
-                    ..key.clone()
-                };
-                state.remove_may_trigger_auto_choice(&actor_key);
+            MayTriggerAutoChoiceOp::Remove { selector } => {
+                let actor_selector = selector.for_player(actor);
+                state.remove_may_trigger_auto_choice_selector(&actor_selector);
             }
             MayTriggerAutoChoiceOp::ClearAll => {
                 state.clear_may_trigger_auto_choices(actor);
@@ -9832,11 +9829,12 @@ fn apply_action(
         }
         (
             waiting_for @ WaitingFor::OptionalEffectChoice { .. },
-            GameAction::DecideOptionalEffectAndRemember { choice },
-        ) => engine_payment_choices::handle_optional_effect_choice_and_remember(
+            GameAction::DecideOptionalEffectAndRemember { choice, scope },
+        ) => engine_payment_choices::handle_optional_effect_choice_and_remember_with_scope(
             state,
             waiting_for.clone(),
             choice,
+            scope,
             &mut events,
         )?,
         // CR 608.2d: Opponent decided on "any opponent may" effect.
@@ -13117,8 +13115,14 @@ pub(super) fn begin_pending_trigger_target_selection(
                     source_id,
                     origin,
                 });
+                let same_card_may_trigger_choice_available = may_trigger_key
+                    .as_ref()
+                    .is_some_and(|key| state.may_trigger_same_card_choice_available(key));
                 if let Some(ref key) = may_trigger_key {
-                    if let Some(choice) = state.may_trigger_auto_choice(key) {
+                    let same_card = state.same_card_may_trigger_auto_choice_selector(key);
+                    if let Some(choice) =
+                        state.may_trigger_auto_choice_for_prompt(key, same_card.as_ref())
+                    {
                         match choice {
                             AutoMayChoice::Decline => {
                                 drop_mid_construction_pending_trigger(state);
@@ -13145,6 +13149,7 @@ pub(super) fn begin_pending_trigger_target_selection(
                     source_id,
                     description: trigger_description,
                     may_trigger_key,
+                    same_card_may_trigger_choice_available,
                 }));
             }
 
@@ -19182,6 +19187,7 @@ mod stage2_injector_tests {
             source_id: src,
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
         (state, src)
     }

--- a/crates/engine/src/game/engine_auto_pass_decision_tests.rs
+++ b/crates/engine/src/game/engine_auto_pass_decision_tests.rs
@@ -40,6 +40,10 @@ fn is_finish(d: &AutoPassDecision) -> bool {
     matches!(d, AutoPassDecision::Finish)
 }
 
+fn is_break(d: &AutoPassDecision) -> bool {
+    matches!(d, AutoPassDecision::Break)
+}
+
 fn priority_state() -> GameState {
     let mut state = GameState::new_two_player(42);
     state.turn_number = 1;
@@ -204,7 +208,7 @@ fn until_end_of_turn_passes_through_empty_stack_without_phase_stop() {
 }
 
 #[test]
-fn until_end_of_turn_finishes_on_opponent_stack_activity() {
+fn until_end_of_turn_breaks_on_unyielded_opponent_stack_activity() {
     // Opponent spell/trigger on top must interrupt auto-pass so the player
     // always gets a chance to respond.
     let mut state = GameState::default();
@@ -215,7 +219,75 @@ fn until_end_of_turn_finishes_on_opponent_stack_activity() {
             until: TurnBoundary::EndOfCurrentTurn,
         },
     );
-    assert!(is_finish(&priority_auto_pass_decision(&state, PlayerId(0))));
+    assert!(is_break(&priority_auto_pass_decision(&state, PlayerId(0))));
+    assert!(
+        state.auto_pass.contains_key(&PlayerId(0)),
+        "the decision itself must leave the turn-boundary session armed"
+    );
+}
+
+#[test]
+fn turn_boundary_session_resumes_after_opponent_stack_entry_resolves() {
+    let mut state = priority_state();
+    push_simple_stack_entry(&mut state, 7_000, PlayerId(1));
+    state.auto_pass.insert(
+        PlayerId(0),
+        AutoPassMode::UntilTurnBoundary {
+            until: TurnBoundary::EndOfCurrentTurn,
+        },
+    );
+
+    let mut paused = ActionResult {
+        events: Vec::new(),
+        waiting_for: state.waiting_for.clone(),
+        log_entries: Vec::new(),
+    };
+    let advanced_before_response = run_auto_pass_loop(&mut state, &mut paused);
+
+    assert!(
+        !advanced_before_response,
+        "reach guard: the unyielded opponent entry stops this run before priority passes"
+    );
+    assert!(matches!(
+        paused.waiting_for,
+        WaitingFor::Priority {
+            player: PlayerId(0)
+        }
+    ));
+    assert_eq!(state.stack.len(), 1);
+    assert!(
+        state.auto_pass.contains_key(&PlayerId(0)),
+        "the interrupted turn-boundary session remains armed while the player responds"
+    );
+
+    let after_local_pass = apply(&mut state, PlayerId(0), GameAction::PassPriority).unwrap();
+    assert!(matches!(
+        after_local_pass.waiting_for,
+        WaitingFor::Priority {
+            player: PlayerId(1)
+        }
+    ));
+
+    let after_resolution = apply(&mut state, PlayerId(1), GameAction::PassPriority).unwrap();
+
+    assert!(
+        after_resolution
+            .events
+            .iter()
+            .any(|event| matches!(event, GameEvent::StackResolved { .. })),
+        "reach guard: the opponent entry resolved through the production priority pipeline"
+    );
+    assert!(state.stack.is_empty());
+    assert!(matches!(
+        after_resolution.waiting_for,
+        WaitingFor::Priority {
+            player: PlayerId(1)
+        }
+    ));
+    assert!(
+        state.auto_pass.contains_key(&PlayerId(0)),
+        "the ordinary post-resolution action boundary re-enters auto-pass without clearing the session"
+    );
 }
 
 #[test]
@@ -305,9 +377,9 @@ fn begin_combat_phase_stop_interrupts_auto_pass_with_usable_priority() {
 }
 
 /// V8: the per-window interrupt logic is boundary-agnostic. A
-/// `MyNextTurnStart` session must Pass/Finish in exactly the same windows as
+/// `MyNextTurnStart` session must Pass/Break/Finish in exactly the same windows as
 /// the `EndOfCurrentTurn` sessions above (empty stack → Pass, opponent stack →
-/// Finish, phase stop → Finish). This composes with CR 117.3d yield handling
+/// Break, phase stop → Finish). This composes with CR 117.3d yield handling
 /// (unchanged) and guards against the decision arm ever branching on `until`.
 #[test]
 fn my_next_turn_start_window_behavior_matches_end_of_current_turn() {
@@ -323,11 +395,11 @@ fn my_next_turn_start_window_behavior_matches_end_of_current_turn() {
     empty.auto_pass.insert(PlayerId(0), mode);
     assert!(is_pass(&priority_auto_pass_decision(&empty, PlayerId(0))));
 
-    // Opponent-controlled top-of-stack → Finish.
+    // Opponent-controlled top-of-stack → Break.
     let mut opp = GameState::default();
     opp.stack.push_back(stack_entry(PlayerId(1)));
     opp.auto_pass.insert(PlayerId(0), mode);
-    assert!(is_finish(&priority_auto_pass_decision(&opp, PlayerId(0))));
+    assert!(is_break(&priority_auto_pass_decision(&opp, PlayerId(0))));
 
     // User-flagged phase stop → Finish.
     let mut stopped = GameState {

--- a/crates/engine/src/game/engine_exile_return_tests.rs
+++ b/crates/engine/src/game/engine_exile_return_tests.rs
@@ -666,6 +666,7 @@ fn exile_return_occurs_before_a_pending_resolution_choice() {
         source_id,
         description: Some("Search your library for a land card".to_string()),
         may_trigger_key: None,
+        same_card_may_trigger_choice_available: false,
     };
     let default_wf = WaitingFor::Priority {
         player: PlayerId(1),

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -6,7 +6,8 @@ use crate::types::ability::{
 };
 use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::{
-    ActionResult, AutoMayChoice, GameState, PendingContinuation, PendingCostMoveResume, WaitingFor,
+    ActionResult, AutoMayChoice, GameState, MayTriggerAutoChoiceScope,
+    MayTriggerAutoChoiceSelector, PendingContinuation, PendingCostMoveResume, WaitingFor,
     WardSacrificePaymentResume,
 };
 use crate::types::identifiers::ObjectId;
@@ -175,14 +176,33 @@ fn handle_optional_effect_choice_inner(
     Ok(state.waiting_for.clone())
 }
 
+#[cfg(test)]
 pub(super) fn handle_optional_effect_choice_and_remember(
     state: &mut GameState,
     waiting_for: WaitingFor,
     choice: AutoMayChoice,
     events: &mut Vec<GameEvent>,
 ) -> Result<WaitingFor, EngineError> {
+    handle_optional_effect_choice_and_remember_with_scope(
+        state,
+        waiting_for,
+        choice,
+        MayTriggerAutoChoiceScope::ExactInstance,
+        events,
+    )
+}
+
+pub(super) fn handle_optional_effect_choice_and_remember_with_scope(
+    state: &mut GameState,
+    waiting_for: WaitingFor,
+    choice: AutoMayChoice,
+    scope: MayTriggerAutoChoiceScope,
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
     let WaitingFor::OptionalEffectChoice {
+        player,
         may_trigger_key: Some(key),
+        same_card_may_trigger_choice_available,
         ..
     } = waiting_for
     else {
@@ -190,7 +210,25 @@ pub(super) fn handle_optional_effect_choice_and_remember(
             "Optional effect cannot be remembered".to_string(),
         ));
     };
-    state.set_may_trigger_auto_choice(key, choice);
+    let selector = match scope {
+        MayTriggerAutoChoiceScope::ExactInstance => MayTriggerAutoChoiceSelector::exact(key),
+        MayTriggerAutoChoiceScope::SameCard => {
+            if !same_card_may_trigger_choice_available {
+                return Err(EngineError::InvalidAction(
+                    "Same-card optional effect cannot be remembered".to_string(),
+                ));
+            }
+            state
+                .same_card_may_trigger_auto_choice_selector(&key)
+                .filter(|selector| selector.player() == player)
+                .ok_or_else(|| {
+                    EngineError::InvalidAction(
+                        "Same-card optional effect identity is no longer valid".to_string(),
+                    )
+                })?
+        }
+    };
+    state.set_may_trigger_auto_choice_selector(selector, choice);
     handle_optional_effect_choice(state, matches!(choice, AutoMayChoice::Accept), events)
 }
 
@@ -2443,6 +2481,7 @@ mod tests {
             source_id: ObjectId(100),
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
 
         let mut events = Vec::new();
@@ -2474,6 +2513,7 @@ mod tests {
             source_id: ObjectId(100),
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
 
         let mut events = Vec::new();
@@ -2511,6 +2551,7 @@ mod tests {
             source_id: ObjectId(100),
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
 
         let mut events = Vec::new();
@@ -2545,6 +2586,7 @@ mod tests {
             source_id: ObjectId(100),
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
 
         let mut events = Vec::new();
@@ -2577,6 +2619,7 @@ mod tests {
             source_id: ObjectId(100),
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
 
         let mut events = Vec::new();
@@ -2608,6 +2651,7 @@ mod tests {
             source_id: ObjectId(100),
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
 
         let mut events = Vec::new();
@@ -2639,6 +2683,7 @@ mod tests {
             source_id,
             description: None,
             may_trigger_key: Some(key.clone()),
+            same_card_may_trigger_choice_available: false,
         };
 
         let mut events = Vec::new();
@@ -2649,6 +2694,7 @@ mod tests {
                 source_id,
                 description: None,
                 may_trigger_key: Some(key.clone()),
+                same_card_may_trigger_choice_available: false,
             },
             AutoMayChoice::Accept,
             &mut events,
@@ -2673,6 +2719,7 @@ mod tests {
                 source_id: ObjectId(100),
                 description: None,
                 may_trigger_key: None,
+                same_card_may_trigger_choice_available: false,
             },
             AutoMayChoice::Accept,
             &mut events,

--- a/crates/engine/src/game/engine_phase_trigger_regression_tests.rs
+++ b/crates/engine/src/game/engine_phase_trigger_regression_tests.rs
@@ -2119,6 +2119,7 @@ fn optional_effect_choice_accept_preserves_nested_effect_zone_choice_continuatio
         source_id,
         description: None,
         may_trigger_key: None,
+        same_card_may_trigger_choice_available: false,
     };
 
     let result = apply_as_current(

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -3273,7 +3273,7 @@ fn actor_scoped_preferences_do_not_advance_active_auto_pass() {
                 state
                     .may_trigger_auto_choices
                     .iter()
-                    .all(|record| record.key.player != PlayerId(1)),
+                    .all(|record| record.selector.player() != PlayerId(1)),
                 "SetMayTriggerAutoChoice::ClearAll must clear the actor's choices"
             ),
             GameAction::SetTriggerOrderTemplate { .. } => assert!(
@@ -3541,7 +3541,9 @@ fn set_may_trigger_auto_choice_remove_revokes_actor_choice() {
         &mut state,
         PlayerId(0),
         GameAction::SetMayTriggerAutoChoice {
-            op: MayTriggerAutoChoiceOp::Remove { key },
+            op: MayTriggerAutoChoiceOp::Remove {
+                selector: crate::types::game_state::MayTriggerAutoChoiceSelector::exact(key),
+            },
         },
     )
     .expect("SetMayTriggerAutoChoice is legal in any state");
@@ -3586,7 +3588,7 @@ fn set_may_trigger_auto_choice_clear_all_is_actor_scoped() {
         "ClearAll drops only the acting player's auto-choices"
     );
     assert_eq!(
-        state.may_trigger_auto_choices[0].key.player,
+        state.may_trigger_auto_choices[0].selector.player(),
         PlayerId(1),
         "another player's auto-choice survives an actor's ClearAll"
     );
@@ -3622,7 +3624,9 @@ fn set_may_trigger_auto_choice_remove_cannot_target_another_player() {
         PlayerId(1),
         GameAction::SetMayTriggerAutoChoice {
             op: MayTriggerAutoChoiceOp::Remove {
-                key: p0_key.clone(),
+                selector: crate::types::game_state::MayTriggerAutoChoiceSelector::exact(
+                    p0_key.clone(),
+                ),
             },
         },
     )

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -3700,8 +3700,9 @@ fn set_trigger_order_template_clear_all_is_actor_scoped() {
     );
 }
 
-/// CR 117.3d: an `UntilEndOfTurn` auto-pass session normally ends (Finish) when
-/// an opponent-controlled trigger tops the stack, so the player can respond.
+/// CR 117.3d: an `UntilEndOfTurn` auto-pass session pauses (Break) when an
+/// opponent-controlled trigger tops the stack, so the player can respond while
+/// retaining the session for after the stack entry resolves.
 /// A matching yield keeps the session auto-passing (Pass) through that trigger;
 /// a non-yielded opponent trigger still Finishes.
 #[test]
@@ -3716,13 +3717,13 @@ fn until_end_of_turn_yielded_opponent_top_passes_not_finishes() {
     let source = ObjectId(500);
     push_token_trigger(&mut state, source, PlayerId(1), Some(4), Some(CardId(77)));
 
-    // Without a yield: the opponent trigger ends the session.
+    // Without a yield: the opponent trigger pauses the session.
     assert!(
         matches!(
             priority_auto_pass_decision(&state, PlayerId(0)),
-            AutoPassDecision::Finish
+            AutoPassDecision::Break
         ),
-        "reach-guard: an un-yielded opponent top finishes the session"
+        "reach-guard: an un-yielded opponent top pauses the session"
     );
 
     // With a matching yield: keep auto-passing through it.
@@ -3742,7 +3743,7 @@ fn until_end_of_turn_yielded_opponent_top_passes_not_finishes() {
         "CR 117.3d: a matching yield keeps the UntilEndOfTurn session passing"
     );
 
-    // A different, non-yielded opponent trigger still finishes.
+    // A different, non-yielded opponent trigger still pauses.
     state.stack.clear();
     push_token_trigger(
         &mut state,
@@ -3754,9 +3755,9 @@ fn until_end_of_turn_yielded_opponent_top_passes_not_finishes() {
     assert!(
         matches!(
             priority_auto_pass_decision(&state, PlayerId(0)),
-            AutoPassDecision::Finish
+            AutoPassDecision::Break
         ),
-        "a non-yielded opponent trigger still finishes the session"
+        "a non-yielded opponent trigger still pauses the session"
     );
 }
 

--- a/crates/engine/src/game/interaction.rs
+++ b/crates/engine/src/game/interaction.rs
@@ -30,8 +30,8 @@ use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::game_state::{
     ActionResult, AutoMayChoice, CastPaymentMode, CastingVariant, CombatDamageAssignmentMode,
     ConvokeMode, CounterCostChoice, CounterMoveChoice, CounterRemoveChoice, GameState, ManaChoice,
-    ManaChoiceContext, ManaChoicePrompt, OutsideGameChoiceSource, PayCostKind, PileSide,
-    PtDirection, ShardChoice, ShardOptions, TargetEffectDetail, WaitingFor,
+    ManaChoiceContext, ManaChoicePrompt, MayTriggerAutoChoiceScope, OutsideGameChoiceSource,
+    PayCostKind, PileSide, PtDirection, ShardChoice, ShardOptions, TargetEffectDetail, WaitingFor,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::interaction::{
@@ -4176,6 +4176,13 @@ fn auto_may_choice_code(choice: AutoMayChoice) -> &'static str {
     }
 }
 
+fn auto_may_scope_code(scope: MayTriggerAutoChoiceScope) -> &'static str {
+    match scope {
+        MayTriggerAutoChoiceScope::ExactInstance => "exactInstance",
+        MayTriggerAutoChoiceScope::SameCard => "sameCard",
+    }
+}
+
 fn dungeon_code(dungeon: DungeonId) -> &'static str {
     match dungeon {
         DungeonId::LostMineOfPhandelver => "lostMineOfPhandelver",
@@ -4822,10 +4829,14 @@ fn project_action_payload(
                 push_value_surface(surfaces, InteractionRoleCode::Splice, "decline");
             }
         }
-        GameAction::DecideOptionalEffectAndRemember { choice } => push_value_surface(
+        GameAction::DecideOptionalEffectAndRemember { choice, scope } => push_value_surface(
             surfaces,
             InteractionRoleCode::Choice,
-            auto_may_choice_code(*choice),
+            format!(
+                "{}:{}",
+                auto_may_choice_code(*choice),
+                auto_may_scope_code(*scope)
+            ),
         ),
         GameAction::ChooseUnlessCostBranch { choice } => match choice {
             UnlessCostBranch::Decline => {

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -3907,7 +3907,7 @@ fn optional_ability_is_inert_under_auto_choice(
         source_id: ability.source_id,
         origin,
     };
-    match state.may_trigger_auto_choice(&key) {
+    match state.may_trigger_auto_choice_for_live_prompt(&key) {
         Some(AutoMayChoice::Decline) => ability.sub_ability.is_none(),
         Some(AutoMayChoice::Accept) => {
             ability_has_no_legal_resolution_targets(state, ability, trigger_event)

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -15489,6 +15489,7 @@ pub mod tests {
             source_id,
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
 
         let mut events_out = Vec::new();
@@ -34708,6 +34709,7 @@ pub mod tests {
                 source_id: ObjectId(1),
                 description: None,
                 may_trigger_key: None,
+                same_card_may_trigger_choice_available: false,
             },
             WaitingFor::AbilityModeChoice {
                 player: PlayerId(0),
@@ -35236,6 +35238,7 @@ pub mod tests {
                 source_id: observer,
                 description: Some("paused".to_string()),
                 may_trigger_key: None,
+                same_card_may_trigger_choice_available: false,
             }
         };
         (state, events)

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -5681,7 +5681,7 @@ fn pending_trigger_is_auto_inert_noop(state: &mut GameState, ctx: &PendingTrigge
         source_id: pending.ability.source_id,
         origin,
     };
-    match state.may_trigger_auto_choice(&key) {
+    match state.may_trigger_auto_choice_for_live_prompt(&key) {
         Some(AutoMayChoice::Decline) => true,
         Some(AutoMayChoice::Accept) => pending_trigger_has_no_legal_resolution_targets(state, ctx),
         None => false,

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1661,7 +1661,7 @@ pub fn filter_state_for_viewer(state: &GameState, viewer: PlayerId) -> GameState
         .retain(|pid, _| *pid == viewer);
     filtered
         .may_trigger_auto_choices
-        .retain(|record| record.key.player == viewer);
+        .retain(|record| record.selector.player() == viewer);
     // CR 723.4: "If information about an object in the game would be visible to the player
     // being controlled, it's visible to both that player and the player controlling them."
     // The pin vector's other carriers already answer "may this viewer see it" with this same
@@ -3044,7 +3044,10 @@ mod tests {
         let filtered = filter_state_for_viewer(&state, PlayerId(0));
 
         assert_eq!(filtered.may_trigger_auto_choices.len(), 1);
-        assert_eq!(filtered.may_trigger_auto_choices[0].key.player, PlayerId(0));
+        assert_eq!(
+            filtered.may_trigger_auto_choices[0].selector.player(),
+            PlayerId(0)
+        );
     }
 
     /// CR 603.3b: saved trigger-ordering templates are per-player private preference
@@ -6531,6 +6534,7 @@ mod tests {
             source_id: hidden,
             description: Some("Accepted triggered mana may".to_string()),
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
         (state, MARKER)
     }

--- a/crates/engine/src/types/action_stable_order.rs
+++ b/crates/engine/src/types/action_stable_order.rs
@@ -660,11 +660,18 @@ fn cmp_payload(a: &GameAction, b: &GameAction) -> Ordering {
             };
             cmp_val(a0, b0)
         }
-        GameAction::DecideOptionalEffectAndRemember { choice: a0 } => {
-            let GameAction::DecideOptionalEffectAndRemember { choice: b0 } = b else {
+        GameAction::DecideOptionalEffectAndRemember {
+            choice: a0,
+            scope: a1,
+        } => {
+            let GameAction::DecideOptionalEffectAndRemember {
+                choice: b0,
+                scope: b1,
+            } = b
+            else {
                 unreachable!("cmp_payload: same-variant invariant");
             };
-            cmp_val(a0, b0)
+            cmp_val(a0, b0).then_with(|| cmp_val(a1, b1))
         }
         GameAction::PayUnlessCost { pay: a0 } => {
             let GameAction::PayUnlessCost { pay: b0 } = b else {
@@ -1701,7 +1708,9 @@ mod tests {
     use crate::types::actions::{
         MayTriggerAutoChoiceOp, PrecastCopyShortcutResponse, ResolveAllConsentDecision,
     };
-    use crate::types::game_state::{EndEffectGroupId, MayTriggerAutoChoiceKey, MayTriggerOrigin};
+    use crate::types::game_state::{
+        EndEffectGroupId, MayTriggerAutoChoiceKey, MayTriggerAutoChoiceSelector, MayTriggerOrigin,
+    };
     use crate::types::identifiers::ObjectId;
     use crate::types::mana::{ManaCost, ManaCostShard};
     use crate::types::player::PlayerId;
@@ -1800,20 +1809,20 @@ mod tests {
         assert_distinct_order(
             GameAction::SetMayTriggerAutoChoice {
                 op: MayTriggerAutoChoiceOp::Remove {
-                    key: MayTriggerAutoChoiceKey {
+                    selector: MayTriggerAutoChoiceSelector::exact(MayTriggerAutoChoiceKey {
                         player: PlayerId(0),
                         source_id: ObjectId(1),
                         origin: MayTriggerOrigin::Printed { trigger_index: 0 },
-                    },
+                    }),
                 },
             },
             GameAction::SetMayTriggerAutoChoice {
                 op: MayTriggerAutoChoiceOp::Remove {
-                    key: MayTriggerAutoChoiceKey {
+                    selector: MayTriggerAutoChoiceSelector::exact(MayTriggerAutoChoiceKey {
                         player: PlayerId(0),
                         source_id: ObjectId(2),
                         origin: MayTriggerOrigin::Printed { trigger_index: 0 },
-                    },
+                    }),
                 },
             },
         );

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -5,7 +5,8 @@ use super::counter::CounterType;
 use super::game_state::{
     AutoMayChoice, AutoPassRequest, CastPaymentMode, CombatDamageAssignmentMode,
     CompanionDeclaration, CounterCostChoice, CounterMoveChoice, CounterRemoveChoice,
-    MayTriggerAutoChoiceKey, PriorityPassingMode, ShardChoice, YieldScope, YieldTarget,
+    MayTriggerAutoChoiceScope, MayTriggerAutoChoiceSelector, PriorityPassingMode, ShardChoice,
+    YieldScope, YieldTarget,
 };
 use super::identifiers::{CardId, ObjectId};
 use super::keywords::Keyword;
@@ -556,6 +557,8 @@ pub enum GameAction {
     },
     DecideOptionalEffectAndRemember {
         choice: AutoMayChoice,
+        #[serde(default)]
+        scope: MayTriggerAutoChoiceScope,
     },
     /// CR 118.12: Pay or decline an "unless pays" cost (e.g., Mana Leak, No More Lies).
     PayUnlessCost {
@@ -999,12 +1002,14 @@ pub enum PriorityYieldOp {
 
 /// CR 603.5: The mutation a `GameAction::SetMayTriggerAutoChoice` performs on the
 /// acting player's stored "don't ask again" auto-choices for optional ("may")
-/// triggers. `Remove` echoes a stored key verbatim; `ClearAll` drops every stored
+/// triggers. `Remove` echoes a stored selector verbatim; `ClearAll` drops every stored
 /// auto-choice belonging to the acting player.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Serialize, Deserialize)]
 #[serde(tag = "type", content = "data")]
 pub enum MayTriggerAutoChoiceOp {
-    Remove { key: MayTriggerAutoChoiceKey },
+    Remove {
+        selector: MayTriggerAutoChoiceSelector,
+    },
     ClearAll,
 }
 

--- a/crates/engine/src/types/card.rs
+++ b/crates/engine/src/types/card.rs
@@ -85,7 +85,7 @@ fn is_zero(v: &u32) -> bool {
     *v == 0
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
 pub struct PrintedCardRef {
     pub oracle_id: String,
     pub face_name: String,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -18,8 +18,8 @@ use super::ability::{
     ModalChoice, PermanentEntryMode, PileSource, QuantityExpr, ResolvedAbility,
     SearchDestinationSplit, SearchOrderingHint, SearchSelectionConstraint, StackAbilityKind,
     StaticCondition, TapCreaturesAggregate, TargetFilter, TargetRef, ThisWayCause,
-    TriggerBaseSetInstanceRef, TriggerCondition, TriggerDefinition, TriggerDefinitionRef,
-    TriggerEntry,
+    TriggerBaseSetInstanceRef, TriggerCondition, TriggerDefinition, TriggerDefinitionOccurrenceRef,
+    TriggerDefinitionRef, TriggerEntry,
 };
 use super::attribution::ObjectAttribution;
 use super::card::{CardFace, PrintedCardRef, TokenImageRef};
@@ -1844,9 +1844,141 @@ pub struct MayTriggerAutoChoiceKey {
     pub origin: MayTriggerOrigin,
 }
 
+/// CR 603.5: The breadth of a stored optional-trigger answer. Exact instance
+/// remains the default; same-card is only accepted when the live prompt proves
+/// its direct printed provenance.
+#[derive(
+    Debug, Clone, Copy, Default, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize,
+)]
+#[serde(tag = "type")]
+pub enum MayTriggerAutoChoiceScope {
+    #[default]
+    ExactInstance,
+    SameCard,
+}
+
+/// CR 603.5: The identity of a persisted optional-trigger answer.
+///
+/// `SameCard` deliberately carries a printed reference rather than `CardId`:
+/// `CardId` identifies one physical object, while `PrintedCardRef` identifies
+/// the printed face shared by physical copies. The `printed_occurrence` keeps
+/// independently functioning printed triggers separate.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize)]
+#[serde(tag = "type", content = "data")]
+pub enum MayTriggerAutoChoiceSelector {
+    ExactInstance {
+        player: PlayerId,
+        source_id: ObjectId,
+        origin: MayTriggerOrigin,
+    },
+    SameCard {
+        player: PlayerId,
+        printed_ref: PrintedCardRef,
+        printed_occurrence: usize,
+    },
+}
+
+impl MayTriggerAutoChoiceSelector {
+    pub fn player(&self) -> PlayerId {
+        match self {
+            Self::ExactInstance { player, .. } | Self::SameCard { player, .. } => *player,
+        }
+    }
+
+    pub fn for_player(&self, player: PlayerId) -> Self {
+        match self {
+            Self::ExactInstance {
+                source_id, origin, ..
+            } => Self::ExactInstance {
+                player,
+                source_id: *source_id,
+                origin: origin.clone(),
+            },
+            Self::SameCard {
+                printed_ref,
+                printed_occurrence,
+                ..
+            } => Self::SameCard {
+                player,
+                printed_ref: printed_ref.clone(),
+                printed_occurrence: *printed_occurrence,
+            },
+        }
+    }
+
+    pub fn exact(key: MayTriggerAutoChoiceKey) -> Self {
+        Self::ExactInstance {
+            player: key.player,
+            source_id: key.source_id,
+            origin: key.origin,
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", content = "data")]
+enum MayTriggerAutoChoiceSelectorTagged {
+    ExactInstance {
+        player: PlayerId,
+        source_id: ObjectId,
+        origin: MayTriggerOrigin,
+    },
+    SameCard {
+        player: PlayerId,
+        printed_ref: PrintedCardRef,
+        printed_occurrence: usize,
+    },
+}
+
+impl From<MayTriggerAutoChoiceSelectorTagged> for MayTriggerAutoChoiceSelector {
+    fn from(value: MayTriggerAutoChoiceSelectorTagged) -> Self {
+        match value {
+            MayTriggerAutoChoiceSelectorTagged::ExactInstance {
+                player,
+                source_id,
+                origin,
+            } => Self::ExactInstance {
+                player,
+                source_id,
+                origin,
+            },
+            MayTriggerAutoChoiceSelectorTagged::SameCard {
+                player,
+                printed_ref,
+                printed_occurrence,
+            } => Self::SameCard {
+                player,
+                printed_ref,
+                printed_occurrence,
+            },
+        }
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum MayTriggerAutoChoiceSelectorWire {
+    Tagged(MayTriggerAutoChoiceSelectorTagged),
+    LegacyExact(MayTriggerAutoChoiceKey),
+}
+
+impl<'de> Deserialize<'de> for MayTriggerAutoChoiceSelector {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        match MayTriggerAutoChoiceSelectorWire::deserialize(deserializer)? {
+            MayTriggerAutoChoiceSelectorWire::Tagged(selector) => Ok(selector.into()),
+            MayTriggerAutoChoiceSelectorWire::LegacyExact(key) => Ok(Self::exact(key)),
+        }
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct MayTriggerAutoChoiceRecord {
-    pub key: MayTriggerAutoChoiceKey,
+    /// `key` is accepted only to deserialize pre-selector persisted records.
+    #[serde(alias = "key")]
+    pub selector: MayTriggerAutoChoiceSelector,
     pub choice: AutoMayChoice,
 }
 
@@ -12105,6 +12237,11 @@ pub enum WaitingFor {
         description: Option<String>,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         may_trigger_key: Option<MayTriggerAutoChoiceKey>,
+        /// Engine-issued capability for the optional same-card scope. This is
+        /// deliberately a boolean: clients cannot construct or inspect the
+        /// private printed selector used to persist the answer.
+        #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+        same_card_may_trigger_choice_available: bool,
     },
     /// CR 702.95a + CR 608.2d: Soulbond partner choice made while the PairWith
     /// effect resolves. The listed objects are legal choices, not targets.
@@ -22058,11 +22195,73 @@ impl GameState {
         self.next_timestamp = self.next_timestamp.max(timestamp.saturating_add(1));
     }
 
+    /// CR 603.5: Derive the only same-card selector the engine may issue for a
+    /// live optional-trigger prompt. Every provenance or identity mismatch
+    /// fails closed; clients only receive availability, never this selector.
+    pub fn same_card_may_trigger_auto_choice_selector(
+        &self,
+        key: &MayTriggerAutoChoiceKey,
+    ) -> Option<MayTriggerAutoChoiceSelector> {
+        let MayTriggerOrigin::Definition { definition_ref } = &key.origin else {
+            return None;
+        };
+        let TriggerDefinitionOccurrenceRef::Printed { printed_index, .. } =
+            &definition_ref.occurrence
+        else {
+            return None;
+        };
+        if definition_ref.source.object_id != key.source_id {
+            return None;
+        }
+        let source = self.objects.get(&key.source_id)?;
+        if source.incarnation != definition_ref.source.incarnation
+            || !source.is_represented_by_a_card()
+            || !source
+                .trigger_definitions
+                .iter_all()
+                .any(|entry| source.trigger_definition_ref(entry) == *definition_ref)
+        {
+            return None;
+        }
+        Some(MayTriggerAutoChoiceSelector::SameCard {
+            player: key.player,
+            printed_ref: source.base_printed_ref.clone()?,
+            printed_occurrence: *printed_index,
+        })
+    }
+
+    pub fn may_trigger_same_card_choice_available(&self, key: &MayTriggerAutoChoiceKey) -> bool {
+        self.same_card_may_trigger_auto_choice_selector(key)
+            .is_some()
+    }
+
+    /// CR 603.5: Legacy exact-instance lookup. Kept as the compatibility
+    /// boundary for callers that deliberately know only the old key shape.
     pub fn may_trigger_auto_choice(&self, key: &MayTriggerAutoChoiceKey) -> Option<AutoMayChoice> {
+        let selector = MayTriggerAutoChoiceSelector::exact(key.clone());
         self.may_trigger_auto_choices
             .iter()
-            .find(|record| record.key == *key)
+            .find(|record| record.selector == selector)
             .map(|record| record.choice)
+    }
+
+    /// CR 603.5: Exact-instance preferences always win over same-card
+    /// preferences. The caller supplies a selector only after the live prompt
+    /// proved it eligible, so malformed persisted same-card entries never
+    /// manufacture authority.
+    pub fn may_trigger_auto_choice_for_prompt(
+        &self,
+        exact: &MayTriggerAutoChoiceKey,
+        same_card: Option<&MayTriggerAutoChoiceSelector>,
+    ) -> Option<AutoMayChoice> {
+        self.may_trigger_auto_choice(exact).or_else(|| {
+            same_card.and_then(|selector| {
+                self.may_trigger_auto_choices
+                    .iter()
+                    .find(|record| record.selector == *selector)
+                    .map(|record| record.choice)
+            })
+        })
     }
 
     pub fn set_may_trigger_auto_choice(
@@ -22070,15 +22269,23 @@ impl GameState {
         key: MayTriggerAutoChoiceKey,
         choice: AutoMayChoice,
     ) {
+        self.set_may_trigger_auto_choice_selector(MayTriggerAutoChoiceSelector::exact(key), choice);
+    }
+
+    pub fn set_may_trigger_auto_choice_selector(
+        &mut self,
+        selector: MayTriggerAutoChoiceSelector,
+        choice: AutoMayChoice,
+    ) {
         if let Some(record) = self
             .may_trigger_auto_choices
             .iter_mut()
-            .find(|record| record.key == key)
+            .find(|record| record.selector == selector)
         {
             record.choice = choice;
         } else {
             self.may_trigger_auto_choices
-                .push(MayTriggerAutoChoiceRecord { key, choice });
+                .push(MayTriggerAutoChoiceRecord { selector, choice });
         }
     }
 
@@ -22086,15 +22293,24 @@ impl GameState {
     /// optional ("may") trigger. The key already scopes to one player, source,
     /// and origin.
     pub fn remove_may_trigger_auto_choice(&mut self, key: &MayTriggerAutoChoiceKey) {
+        self.remove_may_trigger_auto_choice_selector(&MayTriggerAutoChoiceSelector::exact(
+            key.clone(),
+        ));
+    }
+
+    pub fn remove_may_trigger_auto_choice_selector(
+        &mut self,
+        selector: &MayTriggerAutoChoiceSelector,
+    ) {
         self.may_trigger_auto_choices
-            .retain(|record| record.key != *key);
+            .retain(|record| record.selector != *selector);
     }
 
     /// CR 603.5: Revoke all stored "don't ask again" auto-choices belonging to
     /// `player` for optional ("may") triggers.
     pub fn clear_may_trigger_auto_choices(&mut self, player: PlayerId) {
         self.may_trigger_auto_choices
-            .retain(|record| record.key.player != player);
+            .retain(|record| record.selector.player() != player);
     }
 
     /// CR 603.3b: upsert a trigger-ordering [`DecisionTemplate`], replacing any existing
@@ -24549,6 +24765,7 @@ mod forced_cascade_window_tests {
                     source_id: ObjectId(1),
                     description: None,
                     may_trigger_key: None,
+                    same_card_may_trigger_choice_available: false,
                 },
             ),
             (
@@ -25310,6 +25527,7 @@ mod tests {
         CardId, DelayedTriggerInstanceId, DelayedTriggerOrigin, DelayedTriggerToken,
     };
     use crate::types::resolved_commands::ResolvedDelayedTriggerCommand;
+    use crate::types::triggers::TriggerMode;
 
     #[test]
     fn persisted_legacy_tap_effects_migrate_only_effect_payloads() {
@@ -31594,7 +31812,116 @@ mod tests {
             deserialized.may_trigger_auto_choice(&key),
             Some(AutoMayChoice::Accept)
         );
+        assert!(matches!(
+            deserialized.may_trigger_auto_choices[0].selector,
+            MayTriggerAutoChoiceSelector::ExactInstance { .. }
+        ));
         assert_eq!(state, deserialized);
+    }
+
+    #[test]
+    fn may_trigger_auto_choice_selector_decodes_legacy_key_and_keeps_scopes_independent() {
+        let legacy: MayTriggerAutoChoiceRecord = serde_json::from_value(serde_json::json!({
+            "key": {
+                "player": 0,
+                "source_id": 5,
+                "origin": { "type": "Printed", "trigger_index": 1 }
+            },
+            "choice": { "type": "Accept" }
+        }))
+        .expect("legacy record decodes");
+        assert!(matches!(
+            legacy.selector,
+            MayTriggerAutoChoiceSelector::ExactInstance {
+                player: PlayerId(0),
+                source_id: ObjectId(5),
+                ..
+            }
+        ));
+
+        let exact = MayTriggerAutoChoiceKey {
+            player: PlayerId(0),
+            source_id: ObjectId(5),
+            origin: MayTriggerOrigin::Printed { trigger_index: 1 },
+        };
+        let same = MayTriggerAutoChoiceSelector::SameCard {
+            player: PlayerId(0),
+            printed_ref: PrintedCardRef {
+                oracle_id: "same-card".to_string(),
+                face_name: "Same Card".to_string(),
+            },
+            printed_occurrence: 1,
+        };
+        let mut state = GameState::new_two_player(42);
+        state.set_may_trigger_auto_choice_selector(same.clone(), AutoMayChoice::Decline);
+        state.set_may_trigger_auto_choice(exact.clone(), AutoMayChoice::Accept);
+        assert_eq!(
+            state.may_trigger_auto_choice_for_prompt(&exact, Some(&same)),
+            Some(AutoMayChoice::Accept),
+            "exact-instance choices take precedence over same-card choices"
+        );
+        state.remove_may_trigger_auto_choice(&exact);
+        assert_eq!(
+            state.may_trigger_auto_choice_for_prompt(&exact, Some(&same)),
+            Some(AutoMayChoice::Decline),
+            "removing an exact-instance record leaves the same-card record intact"
+        );
+    }
+
+    #[test]
+    fn same_card_may_trigger_selector_uses_printed_ref_not_per_object_card_id() {
+        let printed_ref = PrintedCardRef {
+            oracle_id: "shared-oracle-id".to_string(),
+            face_name: "Shared Face".to_string(),
+        };
+        let mut state = GameState::new_two_player(42);
+        let make_source = |object_id, card_id| {
+            let mut source = GameObject::new(
+                object_id,
+                card_id,
+                PlayerId(0),
+                "Shared Face".to_string(),
+                Zone::Battlefield,
+            );
+            source.printed_ref = Some(printed_ref.clone());
+            source.base_printed_ref = Some(printed_ref.clone());
+            source.push_printed_trigger(TriggerDefinition::new(TriggerMode::ChangesZone));
+            source
+        };
+        let first = make_source(ObjectId(10), CardId(101));
+        let first_ref = first.trigger_definition_ref(&first.trigger_definitions[0]);
+        let second = make_source(ObjectId(11), CardId(202));
+        let second_ref = second.trigger_definition_ref(&second.trigger_definitions[0]);
+        state.objects.insert(ObjectId(10), first);
+        state.objects.insert(ObjectId(11), second);
+
+        let first_key = MayTriggerAutoChoiceKey {
+            player: PlayerId(0),
+            source_id: ObjectId(10),
+            origin: MayTriggerOrigin::Definition {
+                definition_ref: first_ref,
+            },
+        };
+        let second_key = MayTriggerAutoChoiceKey {
+            player: PlayerId(0),
+            source_id: ObjectId(11),
+            origin: MayTriggerOrigin::Definition {
+                definition_ref: second_ref,
+            },
+        };
+        let first_selector = state
+            .same_card_may_trigger_auto_choice_selector(&first_key)
+            .expect("direct printed trigger on a real card is eligible");
+        let second_selector = state
+            .same_card_may_trigger_auto_choice_selector(&second_key)
+            .expect("another physical copy with the same printed ref is eligible");
+        assert_eq!(first_selector, second_selector);
+
+        state.set_may_trigger_auto_choice_selector(first_selector, AutoMayChoice::Decline);
+        assert_eq!(
+            state.may_trigger_auto_choice_for_prompt(&second_key, Some(&second_selector)),
+            Some(AutoMayChoice::Decline)
+        );
     }
 
     #[test]

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -22264,6 +22264,17 @@ impl GameState {
         })
     }
 
+    /// CR 603.5: Resolve a stored answer for a live prompt. Same-card
+    /// preferences are eligible only when this exact live key derives an
+    /// engine-authorized selector; exact-instance choices always win.
+    pub fn may_trigger_auto_choice_for_live_prompt(
+        &self,
+        key: &MayTriggerAutoChoiceKey,
+    ) -> Option<AutoMayChoice> {
+        let same_card = self.same_card_may_trigger_auto_choice_selector(key);
+        self.may_trigger_auto_choice_for_prompt(key, same_card.as_ref())
+    }
+
     pub fn set_may_trigger_auto_choice(
         &mut self,
         key: MayTriggerAutoChoiceKey,

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -6018,6 +6018,7 @@ mod tests {
             source_id: ObjectId(100),
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
         let mut repeated = restore_v1_repeated_optional_payment_fixture(
             repeated,
@@ -6044,6 +6045,7 @@ mod tests {
             source_id: ObjectId(102),
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
         let mut optional = restore_v1_optional_effect_fixture(
             optional,
@@ -7360,6 +7362,7 @@ mod tests {
             source_id: ObjectId(151),
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
         let mut buried_optional_frames = ResolutionStack::default();
         buried_optional_frames.push_inner(ResolutionFrame::OptionalEffect(OptionalEffectFrame {

--- a/crates/engine/tests/integration/cr733_resolved_frame_transition.rs
+++ b/crates/engine/tests/integration/cr733_resolved_frame_transition.rs
@@ -201,6 +201,7 @@ fn direct_choice_install_rejects_a_second_optional_owner_atomically() {
         source_id: ObjectId(100),
         description: None,
         may_trigger_key: None,
+        same_card_may_trigger_choice_available: false,
     };
     let first_frame = optional_effect_frame(&state);
     state
@@ -218,6 +219,7 @@ fn direct_choice_install_rejects_a_second_optional_owner_atomically() {
                 source_id: ObjectId(101),
                 description: None,
                 may_trigger_key: None,
+                same_card_may_trigger_choice_available: false,
             },
         ),
         Err(ResolutionStackError::MultipleDirectChoiceOwners)

--- a/crates/engine/tests/integration/optional_effect_remember_legal_actions.rs
+++ b/crates/engine/tests/integration/optional_effect_remember_legal_actions.rs
@@ -86,7 +86,7 @@ fn keyed_optional_effect_exposes_and_resolves_remember_choices() {
     apply_as_current(&mut state, accept).expect("remembered accept must be legal");
     assert_eq!(state.players[0].life, 21);
     assert!(state.may_trigger_auto_choices.iter().any(|record| {
-        record.selector == MayTriggerAutoChoiceSelector::exact(key)
+        record.selector == MayTriggerAutoChoiceSelector::exact(key.clone())
             && record.choice == AutoMayChoice::Accept
     }));
 }

--- a/crates/engine/tests/integration/optional_effect_remember_legal_actions.rs
+++ b/crates/engine/tests/integration/optional_effect_remember_legal_actions.rs
@@ -85,11 +85,8 @@ fn keyed_optional_effect_exposes_and_resolves_remember_choices() {
 
     apply_as_current(&mut state, accept).expect("remembered accept must be legal");
     assert_eq!(state.players[0].life, 21);
-    assert!(state
-        .may_trigger_auto_choices
-        .iter()
-        .any(|record| {
-            record.selector == MayTriggerAutoChoiceSelector::exact(key)
-                && record.choice == AutoMayChoice::Accept
-        }));
+    assert!(state.may_trigger_auto_choices.iter().any(|record| {
+        record.selector == MayTriggerAutoChoiceSelector::exact(key)
+            && record.choice == AutoMayChoice::Accept
+    }));
 }

--- a/crates/engine/tests/integration/optional_effect_remember_legal_actions.rs
+++ b/crates/engine/tests/integration/optional_effect_remember_legal_actions.rs
@@ -8,7 +8,8 @@ use engine::game::zones::create_object;
 use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
 use engine::types::actions::GameAction;
 use engine::types::game_state::{
-    AutoMayChoice, GameState, MayTriggerAutoChoiceKey, MayTriggerOrigin, WaitingFor,
+    AutoMayChoice, GameState, MayTriggerAutoChoiceKey, MayTriggerAutoChoiceScope,
+    MayTriggerAutoChoiceSelector, MayTriggerOrigin, WaitingFor,
 };
 use engine::types::identifiers::CardId;
 use engine::types::player::PlayerId;
@@ -34,6 +35,7 @@ fn keyed_optional_effect_exposes_and_resolves_remember_choices() {
         source_id,
         description: None,
         may_trigger_key: Some(key.clone()),
+        same_card_may_trigger_choice_available: false,
     };
     let mut ability = ResolvedAbility::new(
         Effect::GainLife {
@@ -54,9 +56,11 @@ fn keyed_optional_effect_exposes_and_resolves_remember_choices() {
 
     let accept = GameAction::DecideOptionalEffectAndRemember {
         choice: AutoMayChoice::Accept,
+        scope: MayTriggerAutoChoiceScope::ExactInstance,
     };
     let decline = GameAction::DecideOptionalEffectAndRemember {
         choice: AutoMayChoice::Decline,
+        scope: MayTriggerAutoChoiceScope::ExactInstance,
     };
     let actions = legal_actions(&state);
     assert!(
@@ -84,5 +88,8 @@ fn keyed_optional_effect_exposes_and_resolves_remember_choices() {
     assert!(state
         .may_trigger_auto_choices
         .iter()
-        .any(|record| record.key == key && record.choice == AutoMayChoice::Accept));
+        .any(|record| {
+            record.selector == MayTriggerAutoChoiceSelector::exact(key)
+                && record.choice == AutoMayChoice::Accept
+        }));
 }

--- a/crates/manabrew-compat/src/lib.rs
+++ b/crates/manabrew-compat/src/lib.rs
@@ -5509,6 +5509,7 @@ mod tests {
             source_id: ObjectId(1),
             description: Some("Draw a card?".to_string()),
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         });
         let json = serde_json::to_value(build_prompt(&prepared, &lookup).unwrap()).unwrap();
         assert_eq!(json["input"]["type"], "chooseBoolean");

--- a/crates/phase-ai/src/policies/anti_self_harm.rs
+++ b/crates/phase-ai/src/policies/anti_self_harm.rs
@@ -5568,6 +5568,7 @@ mod tests {
             source_id,
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
 
         let config = AiConfig::default();
@@ -5624,6 +5625,7 @@ mod tests {
             source_id,
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
         assert!(matches!(
             optional_effect_accept_verdict(&state),
@@ -5646,6 +5648,7 @@ mod tests {
             source_id,
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
         assert!(matches!(
             optional_effect_accept_verdict(&state),
@@ -5668,6 +5671,7 @@ mod tests {
             source_id,
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
         assert!(matches!(
             optional_effect_accept_verdict(&state),
@@ -5701,6 +5705,7 @@ mod tests {
             source_id,
             description: None,
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
         assert!(matches!(
             optional_effect_accept_verdict(&state),

--- a/crates/phase-ai/src/policies/sacrifice_value.rs
+++ b/crates/phase-ai/src/policies/sacrifice_value.rs
@@ -681,6 +681,7 @@ mod tests {
             source_id: source,
             description: Some("You may sacrifice a creature. If you do, draw a card.".to_string()),
             may_trigger_key: None,
+            same_card_may_trigger_choice_available: false,
         };
         (state, source)
     }


### PR DESCRIPTION
- **feat(ui): adapt multiplayer layout to viewport**
- **fix(engine): retain turn-boundary auto-pass**
- **feat(engine): remember may choices by printed card**
- **fix(engine): apply remembered choices across copies**
