### PR TITLE
fix(parser): lift the "and with <keyword>" entry rider on the kicker cycle

### DIFF
--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4073,7 +4073,10 @@ fn parse_enters_with_counters(
         choice.description = Some("your choice of counter".to_string());
 
         // Compose with "enters tapped" if present (mirrors the single-counter
-        // tail below).
+        // tail below). The keyword rider composes here too, for the same reason
+        // it does there — CR 614.1c makes it part of this replacement.
+        let choice =
+            compose_enters_with_keyword_grant(choice, parse_enters_with_keyword_riders(work_text));
         let execute = if has_enters_tapped_phrase(work_text) {
             AbilityDefinition::new(
                 AbilityKind::Spell,
@@ -4200,6 +4203,11 @@ fn parse_enters_with_counters(
     let put_counter = build_enters_counter_ability(
         counter_entries.unwrap_or_else(|| vec![(counter_type, count_expr)]),
     );
+    // CR 614.1c: the "and with <keyword>" rider is part of THIS replacement, so
+    // it composes onto the same execute chain as the counters and inherits the
+    // definition's gate (Invasion kicker cycle).
+    let put_counter =
+        compose_enters_with_keyword_grant(put_counter, parse_enters_with_keyword_riders(work_text));
     let execute = if has_enters_tapped_phrase(work_text) {
         AbilityDefinition::new(
             AbilityKind::Spell,
@@ -4413,6 +4421,104 @@ fn resolve_enters_with_condition(
             None,
         ) => Some(None),
     }
+}
+
+/// CR 614.1c + CR 611.2a: the `"and with <keyword>"` entry rider printed
+/// alongside an enters-with-counters clause by the Invasion kicker cycle —
+/// "…it enters with three +1/+1 counters on it and with trample" (Kavu Titan),
+/// "…two +1/+1 counters and a trample counter on it and with haste"
+/// (Voidpouncer). CR 614.1c makes the whole line ONE replacement effect, so
+/// this rider is a sibling of the counters and of the `"enters tapped"` rider,
+/// not a separate ability.
+///
+/// A corpus sweep over every printed `enters/enter with … counter` line finds
+/// this rider on exactly nine cards (Anavolver, Cetavolver, Faerie Squadron,
+/// Kavu Titan, Necravolver, Pouncing Kavu, Pouncing Wurm, Rakavolver,
+/// Voidpouncer), always gated on kicker.
+///
+/// Scans at `" and with "` boundaries rather than anchoring, because the rider
+/// follows a counter clause of unbounded shape and may not be the first `" and "`
+/// in the line. Each candidate remainder is offered to the shared
+/// `parse_granted_keyword_fragment`; a candidate that is not a keyword simply
+/// does not match, which is what keeps the counter clause's own `" and "`
+/// conjuncts ("…and a trample counter on it") out of this list — "a trample
+/// counter on it" is not a keyword.
+///
+/// The sibling QUOTED-ability rider (`and with "Whenever this creature deals
+/// damage, you gain that much life."` — Anavolver's {B} half, Necravolver's {W}
+/// half, Rakavolver's {1}{W} half) is deliberately NOT handled here: it needs a
+/// granted-ability parse, not a keyword lookup. Those three lines keep their
+/// current counters-only behavior rather than being failed closed, since that
+/// would trade a partial parse for no parse at all. Tracked separately.
+fn parse_enters_with_keyword_riders(text: &str) -> Vec<crate::types::keywords::Keyword> {
+    let mut riders = Vec::new();
+    let mut remaining = text;
+
+    while let Ok((after_marker, _)) = preceded(
+        take_until::<_, _, OracleError<'_>>(" and with "),
+        tag::<_, _, OracleError<'_>>(" and with "),
+    )
+    .parse(remaining)
+    {
+        // The rider runs to the end of the sentence; trailing punctuation is not
+        // part of the keyword name.
+        let candidate = after_marker
+            .split('.')
+            .next()
+            .unwrap_or(after_marker)
+            .trim();
+        if let Some(keyword) =
+            crate::parser::oracle_keyword::parse_granted_keyword_fragment(candidate)
+        {
+            if !riders.contains(&keyword) {
+                riders.push(keyword);
+            }
+        }
+        remaining = after_marker;
+    }
+
+    riders
+}
+
+/// CR 611.2a: wrap `inner` so the entering permanent also gains `keywords` for
+/// as long as it remains on the battlefield.
+///
+/// Modeled as a continuous `AddKeyword` grant on `SelfRef` with
+/// `Duration::UntilHostLeavesPlay` rather than a one-shot effect. The sibling
+/// `"enters tapped"` rider composes a one-shot `SetTapState` because tapping
+/// happens once as the object enters; a granted keyword is not an event but a
+/// characteristic the permanent must keep, and it must end when the object
+/// leaves the battlefield (CR 611.2a) so the new object it becomes elsewhere
+/// does not inherit it.
+///
+/// The gate is inherited for free: this rides the SAME `ReplacementDefinition`
+/// as the counters, whose condition already carries the kicker requirement
+/// (CR 702.33d), so the grant applies exactly when the counters do.
+fn compose_enters_with_keyword_grant(
+    inner: AbilityDefinition,
+    keywords: Vec<crate::types::keywords::Keyword>,
+) -> AbilityDefinition {
+    if keywords.is_empty() {
+        return inner;
+    }
+    let statics = keywords
+        .into_iter()
+        .map(|keyword| {
+            StaticDefinition::continuous()
+                .affected(TargetFilter::SelfRef)
+                .modifications(vec![ContinuousModification::AddKeyword { keyword }])
+        })
+        .collect();
+    AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::GenericEffect {
+            static_abilities: statics,
+            duration: Some(Duration::UntilHostLeavesPlay),
+            target: Some(TargetFilter::SelfRef),
+            end_cost: None,
+        },
+    )
+    .sub_ability(inner)
 }
 
 fn has_enters_tapped_with_counter(text: &str) -> bool {
@@ -18198,8 +18304,14 @@ mod tests {
         )
         .unwrap();
         assert_eq!(def.event, ReplacementEvent::Moved);
+        // CR 614.1c: the line is ONE replacement — the "and with flying" rider
+        // is the outer link of the execute chain, the counter its sub-ability.
+        // Asserting only the counter (as this test did while the rider was being
+        // dropped) passes vacuously; assert both.
+        let execute = def.execute.as_deref().expect("execute ability");
+        assert_keyword_grant(execute, Keyword::Flying);
         assert!(matches!(
-            *def.execute.as_ref().unwrap().effect,
+            *execute.sub_ability.as_deref().expect("counter sub-ability").effect,
             Effect::PutCounter {
                 ref counter_type,
                 count: QuantityExpr::Fixed { value: 1 },
@@ -18215,6 +18327,39 @@ mod tests {
         ));
     }
 
+    /// CR 611.2a: assert `ability` is the continuous keyword grant produced by an
+    /// `"and with <keyword>"` entry rider — a `GenericEffect` carrying a
+    /// self-affecting `AddKeyword` static that lasts until the host leaves play.
+    fn assert_keyword_grant(ability: &AbilityDefinition, expected: Keyword) {
+        let Effect::GenericEffect {
+            static_abilities,
+            duration,
+            ..
+        } = &*ability.effect
+        else {
+            panic!(
+                "expected a GenericEffect keyword grant, got {:?}",
+                ability.effect
+            );
+        };
+        assert_eq!(
+            *duration,
+            Some(Duration::UntilHostLeavesPlay),
+            "CR 611.2a: the grant must end when the permanent leaves the battlefield"
+        );
+        let mods: Vec<_> = static_abilities
+            .iter()
+            .flat_map(|s| s.modifications.iter())
+            .collect();
+        assert!(
+            mods.iter().any(|m| matches!(
+                m,
+                ContinuousModification::AddKeyword { keyword } if *keyword == expected
+            )),
+            "expected an AddKeyword({expected:?}) modification, got {mods:?}"
+        );
+    }
+
     #[test]
     fn kicked_with_specific_cost_enters_with_counters() {
         // CR 702.33d: "If this creature was kicked with its {1}{R} kicker, it enters with
@@ -18225,8 +18370,11 @@ mod tests {
         )
         .unwrap();
         assert_eq!(def.event, ReplacementEvent::Moved);
+        // Both halves of the single replacement — see `kicked_enters_with_counter`.
+        let execute = def.execute.as_deref().expect("execute ability");
+        assert_keyword_grant(execute, Keyword::FirstStrike);
         assert!(matches!(
-            *def.execute.as_ref().unwrap().effect,
+            *execute.sub_ability.as_deref().expect("counter sub-ability").effect,
             Effect::PutCounter {
                 ref counter_type,
                 count: QuantityExpr::Fixed { value: 2 },
@@ -18244,6 +18392,79 @@ mod tests {
             other => panic!(
                 "Expected CastViaKicker {{ variant: None, kicker_cost: Some(_) }}, got {other:?}"
             ),
+        }
+    }
+
+    /// CR 614.1c + CR 611.2a: the `"and with <keyword>"` entry rider is lifted
+    /// for the whole Invasion kicker cycle, across every keyword it prints and
+    /// both counter shapes (plain `"N +1/+1 counters on it"` and the conjoined
+    /// `"two +1/+1 counters and a trample counter on it"` of Voidpouncer, where
+    /// the rider follows a counter list that itself contains `" and "`).
+    #[test]
+    fn kicker_cycle_enters_with_keyword_rider() {
+        for (card, line, keyword) in [
+            (
+                "Kavu Titan",
+                "If this creature was kicked, it enters with three +1/+1 counters on it and with trample.",
+                Keyword::Trample,
+            ),
+            (
+                "Faerie Squadron",
+                "If this creature was kicked, it enters with two +1/+1 counters on it and with flying.",
+                Keyword::Flying,
+            ),
+            (
+                "Pouncing Wurm",
+                "If this creature was kicked, it enters with three +1/+1 counters on it and with haste.",
+                Keyword::Haste,
+            ),
+            // Voidpouncer: the rider trails a CONJOINED counter list, so the
+            // scan must not stop at the list's own " and ".
+            (
+                "Voidpouncer",
+                "If this creature was kicked, it enters with two +1/+1 counters and a trample counter on it and with haste.",
+                Keyword::Haste,
+            ),
+        ] {
+            let def = parse_replacement_line(line, card)
+                .unwrap_or_else(|| panic!("{card}: kicker enters-with line must parse"));
+            let execute = def.execute.as_deref().expect("execute ability");
+            assert_keyword_grant(execute, keyword);
+            assert!(
+                def.condition.is_some(),
+                "{card}: the kicker gate must still reach the condition slot"
+            );
+            assert!(
+                execute.sub_ability.is_some(),
+                "{card}: the counters must survive alongside the keyword grant"
+            );
+        }
+    }
+
+    /// The rider scan must not invent a grant. A `"<keyword> counter"` conjunct
+    /// is a COUNTER, not a granted keyword — the discriminator is that
+    /// `parse_granted_keyword_fragment` rejects "a lifelink counter on it" —
+    /// and a line with no rider at all must stay a bare counter chain.
+    #[test]
+    fn enters_with_keyword_rider_does_not_over_claim() {
+        for (card, line) in [
+            (
+                "Dust Animus",
+                "If you control five or more untapped lands, this creature enters with two +1/+1 counters and a lifelink counter on it.",
+            ),
+            (
+                "Agent's Toolkit",
+                "This artifact enters with a +1/+1 counter, a flying counter, a deathtouch counter, and a shield counter on it.",
+            ),
+        ] {
+            let def = parse_replacement_line(line, card)
+                .unwrap_or_else(|| panic!("{card} must parse"));
+            let execute = def.execute.as_deref().expect("execute ability");
+            assert!(
+                matches!(*execute.effect, Effect::PutCounter { .. }),
+                "{card}: counter conjuncts must not be lifted as a keyword grant, got {:?}",
+                execute.effect
+            );
         }
     }
 

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4431,10 +4431,13 @@ fn resolve_enters_with_condition(
 /// this rider is a sibling of the counters and of the `"enters tapped"` rider,
 /// not a separate ability.
 ///
-/// A corpus sweep over every printed `enters/enter with … counter` line finds
-/// this rider on exactly nine cards (Anavolver, Cetavolver, Faerie Squadron,
-/// Kavu Titan, Necravolver, Pouncing Kavu, Pouncing Wurm, Rakavolver,
-/// Voidpouncer), always gated on kicker.
+/// Corpus (verified against Scryfall, `oracle:"on it and with"`): 13 printed
+/// cards carry this rider slot, always gated on kicker — Anavolver, Benalish
+/// Lancer, Cetavolver, Degavolver, Duskwalker, Faerie Squadron, Kavu Titan,
+/// Necravolver, Pouncing Kavu, Pouncing Wurm, Prison Barricade, Rakavolver,
+/// Voidpouncer. They print 18 rider lines: 13 BARE keywords (this function's
+/// class) and 5 QUOTED abilities (below). 12 cards print at least one bare
+/// rider; 8 of them print ONLY bare riders and so are fully covered here.
 ///
 /// Scans at `" and with "` boundaries rather than anchoring, because the rider
 /// follows a counter clause of unbounded shape and may not be the first `" and "`
@@ -4444,40 +4447,68 @@ fn resolve_enters_with_condition(
 /// conjuncts ("…and a trample counter on it") out of this list — "a trample
 /// counter on it" is not a keyword.
 ///
-/// The sibling QUOTED-ability rider (`and with "Whenever this creature deals
-/// damage, you gain that much life."` — Anavolver's {B} half, Necravolver's {W}
-/// half, Rakavolver's {1}{W} half) is deliberately NOT handled here: it needs a
-/// granted-ability parse, not a keyword lookup. Those three lines keep their
-/// current counters-only behavior rather than being failed closed, since that
-/// would trade a partial parse for no parse at all. Tracked separately.
+/// Every rider is bounded by [`parse_enters_with_keyword_rider_candidate`], so a
+/// CHAINED "…and with X and with Y" line yields both X and Y. Bounding only at
+/// the sentence period would hand the first candidate "X and with Y", which the
+/// keyword parser rejects as a compound — reintroducing, for X, exactly the
+/// silent-keyword-drop bug this function exists to fix.
+///
+/// The sibling QUOTED-ability rider is deliberately NOT handled here: it needs a
+/// granted-ability parse, not a keyword lookup. Five lines across four cards —
+/// Anavolver's {B} and Degavolver's {1}{B} halves ("Pay 3 life: Regenerate this
+/// creature."), Necravolver's {W} and Rakavolver's {1}{W} halves ("Whenever this
+/// creature deals damage, you gain that much life."), and Prison Barricade
+/// ("This creature can attack as though it didn't have defender."). They keep
+/// their current counters-only behavior rather than being failed closed, since
+/// that would trade a partial parse for no parse at all. Tracked separately.
 fn parse_enters_with_keyword_riders(text: &str) -> Vec<crate::types::keywords::Keyword> {
     let mut riders = Vec::new();
     let mut remaining = text;
 
-    while let Ok((after_marker, _)) = preceded(
-        take_until::<_, _, OracleError<'_>>(" and with "),
-        tag::<_, _, OracleError<'_>>(" and with "),
+    while let Ok((after_marker, candidate)) = preceded(
+        (
+            take_until::<_, _, OracleError<'_>>(ENTERS_WITH_KEYWORD_RIDER_MARKER),
+            tag::<_, _, OracleError<'_>>(ENTERS_WITH_KEYWORD_RIDER_MARKER),
+        ),
+        parse_enters_with_keyword_rider_candidate,
     )
     .parse(remaining)
     {
-        // The rider runs to the end of the sentence; trailing punctuation is not
-        // part of the keyword name.
-        let candidate = after_marker
-            .split('.')
-            .next()
-            .unwrap_or(after_marker)
-            .trim();
         if let Some(keyword) =
-            crate::parser::oracle_keyword::parse_granted_keyword_fragment(candidate)
+            crate::parser::oracle_keyword::parse_granted_keyword_fragment(candidate.trim())
         {
             if !riders.contains(&keyword) {
                 riders.push(keyword);
             }
         }
+        // Resume AT the bounding marker (not past it), so the next iteration's
+        // `take_until` finds it and the chained rider Y is reached.
         remaining = after_marker;
     }
 
     riders
+}
+
+/// The `" and with "` rider marker — both the scan anchor and one of the two
+/// candidate terminators, so the two can never disagree about where a rider ends.
+const ENTERS_WITH_KEYWORD_RIDER_MARKER: &str = " and with ";
+
+/// One rider's text, bounded at whichever terminator comes FIRST: the sentence
+/// period, or the next `" and with "` marker.
+///
+/// Both terminators are `peek`ed rather than consumed, so the scan loop resumes
+/// on input that still carries the marker its `take_until` needs. `rest` is the
+/// final alternative: a rider that ends the input terminates at neither.
+fn parse_enters_with_keyword_rider_candidate(input: &str) -> OracleResult<'_, &str> {
+    alt((
+        terminated(
+            take_until(ENTERS_WITH_KEYWORD_RIDER_MARKER),
+            peek(tag(ENTERS_WITH_KEYWORD_RIDER_MARKER)),
+        ),
+        terminated(take_until("."), peek(tag("."))),
+        rest,
+    ))
+    .parse(input)
 }
 
 /// CR 611.2a: wrap `inner` so the entering permanent also gains `keywords` for
@@ -18297,10 +18328,18 @@ mod tests {
 
     #[test]
     fn kicked_enters_with_counter() {
-        // CR 702.33d: "If this creature was kicked, it enters with a +1/+1 counter on it."
+        // CR 702.33d: the UNQUALIFIED "was kicked" form (no "with its {cost}
+        // kicker"), which is what pins `kicker_cost: None` below.
+        //
+        // Synthetic name: verified against Scryfall, the only printed card whose
+        // line is "a +1/+1 counter on it and with flying" is Rakavolver's {U}
+        // half, and that one is COST-QUALIFIED, so it exercises the sibling
+        // `kicker_cost: Some(_)` path instead. Ana Battlemage, named here
+        // previously, prints no enters-with-counters line at all — it has two ETB
+        // triggers. Keeping the shape and dropping the false attribution.
         let def = parse_replacement_line(
             "If this creature was kicked, it enters with a +1/+1 counter on it and with flying.",
-            "Ana Battlemage",
+            "Synthetic Unqualified Kicker Rider",
         )
         .unwrap();
         assert_eq!(def.event, ReplacementEvent::Moved);
@@ -18364,9 +18403,12 @@ mod tests {
     fn kicked_with_specific_cost_enters_with_counters() {
         // CR 702.33d: "If this creature was kicked with its {1}{R} kicker, it enters with
         // two +1/+1 counters on it and with first strike."
+        // Verified against Scryfall: this is CETAVOLVER's {1}{R} half. Necravolver
+        // kicks for {1}{G}/{W} and never prints {1}{R}; the name was mismatched to
+        // the text here before this test began asserting the rider.
         let def = parse_replacement_line(
             "If this creature was kicked with its {1}{R} kicker, it enters with two +1/+1 counters on it and with first strike.",
-            "Necravolver",
+            "Cetavolver",
         )
         .unwrap();
         assert_eq!(def.event, ReplacementEvent::Moved);
@@ -18425,6 +18467,14 @@ mod tests {
                 "If this creature was kicked, it enters with two +1/+1 counters and a trample counter on it and with haste.",
                 Keyword::Haste,
             ),
+            // Duskwalker: the rider is followed by parenthesized REMINDER text,
+            // so the candidate must stop at the sentence period rather than
+            // swallowing "(It can't be blocked except by ...)" into the keyword.
+            (
+                "Duskwalker",
+                "If this creature was kicked, it enters with two +1/+1 counters on it and with fear.                  (It can't be blocked except by artifact creatures and/or black creatures.)",
+                Keyword::Fear,
+            ),
         ] {
             let def = parse_replacement_line(line, card)
                 .unwrap_or_else(|| panic!("{card}: kicker enters-with line must parse"));
@@ -18439,6 +18489,91 @@ mod tests {
                 "{card}: the counters must survive alongside the keyword grant"
             );
         }
+    }
+
+    /// CR 614.1c: a CHAINED rider — "…and with X and with Y" — must yield BOTH
+    /// keywords.
+    ///
+    /// This is the discriminating test for the candidate boundary. Bounding a
+    /// candidate only at the sentence period hands the first iteration
+    /// "flying and with trample", which `parse_granted_keyword_fragment` rejects
+    /// as a compound; the loop then advances and captures only "trample", so X is
+    /// silently dropped — the very bug class this parser exists to fix, resurfacing
+    /// one keyword deep. Bounding at the earlier of the period and the next
+    /// `" and with "` marker is what makes both survive.
+    ///
+    /// No printed card chains two BARE keyword riders today (all nine corpus cards
+    /// carry exactly one), so this asserts on the function's supported shape rather
+    /// than a card. `parse_enters_with_keyword_riders` returns a `Vec` and loops for
+    /// exactly this reason; a latent silent drop behind that signature is still a
+    /// defect.
+    #[test]
+    fn chained_enters_with_keyword_riders_keep_every_keyword() {
+        // Unit level: the scan itself, so a failure localizes to the boundary
+        // rather than to composition downstream.
+        assert_eq!(
+            parse_enters_with_keyword_riders(
+                "it enters with three +1/+1 counters on it and with flying and with trample."
+            ),
+            vec![Keyword::Flying, Keyword::Trample],
+            "both chained riders must be lifted, in printed order"
+        );
+
+        // Composed level: both grants reach the built replacement, and the
+        // counters still ride along beneath them.
+        let def = parse_replacement_line(
+            "If this creature was kicked, it enters with three +1/+1 counters on it and with flying and with trample.",
+            "Synthetic Chained Rider",
+        )
+        .expect("chained-rider line must parse");
+        let execute = def.execute.as_deref().expect("execute ability");
+        let granted = collect_granted_keywords(execute);
+        assert!(
+            granted.contains(&Keyword::Flying) && granted.contains(&Keyword::Trample),
+            "both chained riders must reach the execute chain, got {granted:?}"
+        );
+        assert!(
+            def.condition.is_some(),
+            "the kicker gate must still reach the condition slot"
+        );
+        assert!(
+            find_put_counter(execute).is_some(),
+            "the counters must survive beneath the chained grants"
+        );
+    }
+
+    /// Every `AddKeyword` granted anywhere in `ability`'s sub-ability chain.
+    fn collect_granted_keywords(ability: &AbilityDefinition) -> Vec<Keyword> {
+        let mut found = Vec::new();
+        let mut cursor = Some(ability);
+        while let Some(node) = cursor {
+            if let Effect::GenericEffect {
+                static_abilities, ..
+            } = &*node.effect
+            {
+                found.extend(static_abilities.iter().flat_map(|s| {
+                    s.modifications.iter().filter_map(|m| match m {
+                        ContinuousModification::AddKeyword { keyword } => Some(keyword.clone()),
+                        _ => None,
+                    })
+                }));
+            }
+            cursor = node.sub_ability.as_deref();
+        }
+        found
+    }
+
+    /// The first `PutCounter` in `ability`'s sub-ability chain, at whatever depth
+    /// the composed grants push it to.
+    fn find_put_counter(ability: &AbilityDefinition) -> Option<&AbilityDefinition> {
+        let mut cursor = Some(ability);
+        while let Some(node) = cursor {
+            if matches!(*node.effect, Effect::PutCounter { .. }) {
+                return Some(node);
+            }
+            cursor = node.sub_ability.as_deref();
+        }
+        None
     }
 
     /// The rider scan must not invent a grant. A `"<keyword> counter"` conjunct

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4465,7 +4465,7 @@ fn parse_enters_with_keyword_riders(text: &str) -> Vec<crate::types::keywords::K
     let mut riders = Vec::new();
     let mut remaining = text;
 
-    while let Ok((after_marker, candidate)) = preceded(
+    while let Ok((after_rider, (candidate, terminator))) = preceded(
         (
             take_until::<_, _, OracleError<'_>>(ENTERS_WITH_KEYWORD_RIDER_MARKER),
             tag::<_, _, OracleError<'_>>(ENTERS_WITH_KEYWORD_RIDER_MARKER),
@@ -4481,34 +4481,82 @@ fn parse_enters_with_keyword_riders(text: &str) -> Vec<crate::types::keywords::K
                 riders.push(keyword);
             }
         }
-        // Resume AT the bounding marker (not past it), so the next iteration's
-        // `take_until` finds it and the chained rider Y is reached.
-        remaining = after_marker;
+        // CR 614.1c: the rider is part of THIS replacement's sentence. A rider
+        // bounded by the sentence period ends the clause, so the scan stops
+        // rather than walking into a later sentence to find another marker —
+        // otherwise a `" and with "` anywhere downstream would be attached to
+        // this replacement.
+        match terminator {
+            EntersWithRiderTerminator::SentenceEnd => break,
+            EntersWithRiderTerminator::ChainedMarker => remaining = after_rider,
+        }
     }
 
     riders
+}
+
+/// Which delimiter ended a rider — the discriminator that tells the scan whether
+/// another rider can still belong to this replacement.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum EntersWithRiderTerminator {
+    /// Another `" and with "` follows in the SAME sentence: keep scanning.
+    ChainedMarker,
+    /// The sentence ended (a period, or the end of the input): stop.
+    SentenceEnd,
 }
 
 /// The `" and with "` rider marker — both the scan anchor and one of the two
 /// candidate terminators, so the two can never disagree about where a rider ends.
 const ENTERS_WITH_KEYWORD_RIDER_MARKER: &str = " and with ";
 
-/// One rider's text, bounded at whichever terminator comes FIRST: the sentence
-/// period, or the next `" and with "` marker.
+/// One rider's text plus the delimiter that ended it, bounded at the NEAREST
+/// terminator: the next `" and with "` marker, or the sentence period.
 ///
-/// Both terminators are `peek`ed rather than consumed, so the scan loop resumes
-/// on input that still carries the marker its `take_until` needs. `rest` is the
-/// final alternative: a rider that ends the input terminates at neither.
-fn parse_enters_with_keyword_rider_candidate(input: &str) -> OracleResult<'_, &str> {
-    alt((
+/// `alt` is deliberately NOT used. `alt` commits to the first branch that
+/// SUCCEEDS, not to the one whose terminator is nearest, so a marker-first `alt`
+/// consumes straight through a period to reach a LATER sentence's marker. That
+/// is not caught downstream, because `parse_granted_keyword_fragment` is
+/// permissive by contract: handed "flying. when this creature dies, exile it" it
+/// returns `Flying` and silently discards the rest, so the over-long candidate
+/// still looks like a clean parse while the scan has been left standing in the
+/// next sentence. Both terminators are therefore tried and the SHORTEST result
+/// wins, mirroring [`take_damage_source_subject_clause`].
+///
+/// The terminator is returned rather than discarded so the caller can tell
+/// same-sentence chaining from end-of-clause; both are `peek`ed, leaving the
+/// delimiter unconsumed for the next iteration's `take_until`.
+fn parse_enters_with_keyword_rider_candidate(
+    input: &str,
+) -> OracleResult<'_, (&str, EntersWithRiderTerminator)> {
+    let candidates: [OracleResult<'_, (&str, EntersWithRiderTerminator)>; 2] = [
         terminated(
-            take_until(ENTERS_WITH_KEYWORD_RIDER_MARKER),
-            peek(tag(ENTERS_WITH_KEYWORD_RIDER_MARKER)),
-        ),
-        terminated(take_until("."), peek(tag("."))),
-        rest,
-    ))
-    .parse(input)
+            take_until::<_, _, OracleError<'_>>(ENTERS_WITH_KEYWORD_RIDER_MARKER),
+            peek(tag::<_, _, OracleError<'_>>(
+                ENTERS_WITH_KEYWORD_RIDER_MARKER,
+            )),
+        )
+        .map(|rider| (rider, EntersWithRiderTerminator::ChainedMarker))
+        .parse(input),
+        terminated(
+            take_until::<_, _, OracleError<'_>>("."),
+            peek(tag::<_, _, OracleError<'_>>(".")),
+        )
+        .map(|rider| (rider, EntersWithRiderTerminator::SentenceEnd))
+        .parse(input),
+    ];
+    candidates
+        .into_iter()
+        .filter_map(std::result::Result::ok)
+        .min_by_key(|(_, (rider, _)): &(&str, (&str, EntersWithRiderTerminator))| rider.len())
+        // No delimiter at all: the rider runs to the end of the input, which is
+        // equally the end of its sentence.
+        .map_or_else(
+            || {
+                rest(input)
+                    .map(|(tail, rider)| (tail, (rider, EntersWithRiderTerminator::SentenceEnd)))
+            },
+            Ok,
+        )
 }
 
 /// CR 611.2a: wrap `inner` so the entering permanent also gains `keywords` for
@@ -18539,6 +18587,62 @@ mod tests {
         assert!(
             find_put_counter(execute).is_some(),
             "the counters must survive beneath the chained grants"
+        );
+    }
+
+    /// CR 614.1c: a rider bounded by the SENTENCE PERIOD ends the clause. A
+    /// `" and with "` appearing in a LATER sentence belongs to that sentence, and
+    /// must not be attached to this replacement.
+    ///
+    /// This is the discriminator for terminator NEARNESS, which is a different
+    /// property from the chained-rider test above. `alt` commits to the first
+    /// branch that succeeds rather than the nearest terminator, so a marker-first
+    /// `alt` reads through the period to the later sentence's marker. Nothing
+    /// downstream catches that: `parse_granted_keyword_fragment` is permissive by
+    /// contract, so handed "flying. when this creature dies, exile it" it returns
+    /// `Flying` and drops the rest — the over-long candidate looks like a clean
+    /// parse while the scan has been left standing in the next sentence, where it
+    /// then lifts `trample` onto the enters-with replacement.
+    ///
+    /// The chained test cannot see this: it only covers marker-before-period.
+    #[test]
+    fn enters_with_keyword_rider_stops_at_the_sentence_it_belongs_to() {
+        // The later sentence carries a " and with " of its own, and its rider is a
+        // CLEAN BARE KEYWORD. That matters: if the later text were unparseable
+        // prose, `parse_granted_keyword_fragment` would reject it and the test
+        // would pass even without the sentence-stop, making it vacuous. A bare
+        // "trample." there is accepted by the keyword parser, so only stopping
+        // the scan at the period keeps it out.
+        assert_eq!(
+            parse_enters_with_keyword_riders(
+                "it enters with two +1/+1 counters on it and with flying.                  exile it and with trample."
+            ),
+            vec![Keyword::Flying],
+            "a later sentence's \" and with \" must not be attached to this replacement"
+        );
+
+        // The same boundary must hold when the later sentence's tail is prose
+        // rather than a clean keyword — this is the nearest-terminator half,
+        // which fails if the candidate bound reads through the period.
+        assert_eq!(
+            parse_enters_with_keyword_riders(
+                "it enters with two +1/+1 counters on it and with flying.                  when this creature dies, exile it and with trample it fights."
+            ),
+            vec![Keyword::Flying],
+            "the candidate bound must not read through the period into a later sentence"
+        );
+
+        // Composed level: the replacement grants Flying and nothing else.
+        let def = parse_replacement_line(
+            "If this creature was kicked, it enters with two +1/+1 counters on it and with flying.              Exile it and with trample.",
+            "Synthetic Later Sentence Rider",
+        )
+        .expect("line must parse");
+        let execute = def.execute.as_deref().expect("execute ability");
+        assert_eq!(
+            collect_granted_keywords(execute),
+            vec![Keyword::Flying],
+            "only the enters-with sentence's rider may reach the grant"
         );
     }
 

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4463,9 +4463,18 @@ fn resolve_enters_with_condition(
 /// that would trade a partial parse for no parse at all. Tracked separately.
 fn parse_enters_with_keyword_riders(text: &str) -> Vec<crate::types::keywords::Keyword> {
     let mut riders = Vec::new();
-    let mut remaining = text;
+    // CR 614.1c: the rider is part of the SAME sentence as the enters-with
+    // clause, so the scan is bounded to that sentence UP FRONT rather than
+    // per-candidate. Bounding only after a marker was found still let the very
+    // first `take_until` reach into a later sentence when the entering sentence
+    // carried no rider at all -- `work_text` routinely carries trailing
+    // sentences (Slumbering Trudge's "If X is 2 or less, it enters tapped."),
+    // so an unrelated later `" and with "` would be granted to this
+    // replacement. With the input clipped first, no marker outside the sentence
+    // is reachable by construction, and chaining within it still works.
+    let mut remaining = enters_with_rider_sentence(text);
 
-    while let Ok((after_rider, (candidate, terminator))) = preceded(
+    while let Ok((after_rider, candidate)) = preceded(
         (
             take_until::<_, _, OracleError<'_>>(ENTERS_WITH_KEYWORD_RIDER_MARKER),
             tag::<_, _, OracleError<'_>>(ENTERS_WITH_KEYWORD_RIDER_MARKER),
@@ -4481,82 +4490,68 @@ fn parse_enters_with_keyword_riders(text: &str) -> Vec<crate::types::keywords::K
                 riders.push(keyword);
             }
         }
-        // CR 614.1c: the rider is part of THIS replacement's sentence. A rider
-        // bounded by the sentence period ends the clause, so the scan stops
-        // rather than walking into a later sentence to find another marker —
-        // otherwise a `" and with "` anywhere downstream would be attached to
-        // this replacement.
-        match terminator {
-            EntersWithRiderTerminator::SentenceEnd => break,
-            EntersWithRiderTerminator::ChainedMarker => remaining = after_rider,
-        }
+        remaining = after_rider;
     }
 
     riders
 }
 
-/// Which delimiter ended a rider — the discriminator that tells the scan whether
-/// another rider can still belong to this replacement.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-enum EntersWithRiderTerminator {
-    /// Another `" and with "` follows in the SAME sentence: keep scanning.
-    ChainedMarker,
-    /// The sentence ended (a period, or the end of the input): stop.
-    SentenceEnd,
+/// The FIRST sentence of `text` -- the one carrying the enters-with clause, and
+/// therefore the only one whose `" and with "` riders belong to this replacement
+/// (CR 614.1c).
+///
+/// Clipping here is what makes the scan sentence-safe as a whole. Doing it only
+/// inside the per-rider candidate bound is not enough: that bound is applied
+/// after a marker has already been selected, so it cannot undo an initial search
+/// that already crossed a period.
+fn enters_with_rider_sentence(text: &str) -> &str {
+    terminated(
+        take_until::<_, _, OracleError<'_>>("."),
+        tag::<_, _, OracleError<'_>>("."),
+    )
+    .parse(text)
+    .map_or(text, |(_, sentence)| sentence)
 }
 
 /// The `" and with "` rider marker — both the scan anchor and one of the two
 /// candidate terminators, so the two can never disagree about where a rider ends.
 const ENTERS_WITH_KEYWORD_RIDER_MARKER: &str = " and with ";
 
-/// One rider's text plus the delimiter that ended it, bounded at the NEAREST
-/// terminator: the next `" and with "` marker, or the sentence period.
+/// One rider's text, bounded at the NEAREST terminator: the next `" and with "`
+/// marker, or the end of the sentence.
 ///
 /// `alt` is deliberately NOT used. `alt` commits to the first branch that
 /// SUCCEEDS, not to the one whose terminator is nearest, so a marker-first `alt`
-/// consumes straight through a period to reach a LATER sentence's marker. That
-/// is not caught downstream, because `parse_granted_keyword_fragment` is
-/// permissive by contract: handed "flying. when this creature dies, exile it" it
-/// returns `Flying` and silently discards the rest, so the over-long candidate
-/// still looks like a clean parse while the scan has been left standing in the
-/// next sentence. Both terminators are therefore tried and the SHORTEST result
-/// wins, mirroring [`take_damage_source_subject_clause`].
+/// would read past a nearer period to reach a further marker. That mistake is
+/// invisible downstream, because `parse_granted_keyword_fragment` is permissive
+/// by contract: handed "flying. exile it" it returns `Flying` and discards the
+/// rest, so an over-long candidate still looks like a clean parse. Both
+/// terminators are therefore tried and the SHORTEST result wins, mirroring
+/// [`take_damage_source_subject_clause`].
 ///
-/// The terminator is returned rather than discarded so the caller can tell
-/// same-sentence chaining from end-of-clause; both are `peek`ed, leaving the
-/// delimiter unconsumed for the next iteration's `take_until`.
-fn parse_enters_with_keyword_rider_candidate(
-    input: &str,
-) -> OracleResult<'_, (&str, EntersWithRiderTerminator)> {
-    let candidates: [OracleResult<'_, (&str, EntersWithRiderTerminator)>; 2] = [
+/// The caller clips its input to one sentence, so the period branch is a
+/// belt-and-braces bound for a trailing period rather than the primary defense.
+/// Terminators are `peek`ed, leaving the delimiter for the next `take_until`.
+fn parse_enters_with_keyword_rider_candidate(input: &str) -> OracleResult<'_, &str> {
+    let candidates: [OracleResult<'_, &str>; 2] = [
         terminated(
             take_until::<_, _, OracleError<'_>>(ENTERS_WITH_KEYWORD_RIDER_MARKER),
             peek(tag::<_, _, OracleError<'_>>(
                 ENTERS_WITH_KEYWORD_RIDER_MARKER,
             )),
         )
-        .map(|rider| (rider, EntersWithRiderTerminator::ChainedMarker))
         .parse(input),
         terminated(
             take_until::<_, _, OracleError<'_>>("."),
             peek(tag::<_, _, OracleError<'_>>(".")),
         )
-        .map(|rider| (rider, EntersWithRiderTerminator::SentenceEnd))
         .parse(input),
     ];
     candidates
         .into_iter()
         .filter_map(std::result::Result::ok)
-        .min_by_key(|(_, (rider, _)): &(&str, (&str, EntersWithRiderTerminator))| rider.len())
-        // No delimiter at all: the rider runs to the end of the input, which is
-        // equally the end of its sentence.
-        .map_or_else(
-            || {
-                rest(input)
-                    .map(|(tail, rider)| (tail, (rider, EntersWithRiderTerminator::SentenceEnd)))
-            },
-            Ok,
-        )
+        .min_by_key(|(_, rider): &(&str, &str)| rider.len())
+        .map_or_else(|| rest(input), Ok)
 }
 
 /// CR 611.2a: wrap `inner` so the entering permanent also gains `keywords` for
@@ -18643,6 +18638,48 @@ mod tests {
             collect_granted_keywords(execute),
             vec![Keyword::Flying],
             "only the enters-with sentence's rider may reach the grant"
+        );
+    }
+
+    /// CR 614.1c: when the entering sentence carries NO rider at all, a
+    /// `" and with "` in a LATER sentence must not be lifted onto this
+    /// replacement.
+    ///
+    /// Distinct from `..._stops_at_the_sentence_it_belongs_to`, which starts with
+    /// a valid rider in the first sentence and so only exercises the bound
+    /// applied AFTER a marker is selected. Here there is no marker in the
+    /// entering sentence, so the very first `take_until` is what would cross the
+    /// period — a per-candidate bound cannot repair that, only clipping the
+    /// scan's input to one sentence can. `work_text` really does carry trailing
+    /// sentences (Slumbering Trudge prints "If X is 2 or less, it enters
+    /// tapped."), so this is reachable, not hypothetical.
+    #[test]
+    fn enters_with_keyword_rider_ignores_a_later_sentence_when_the_first_has_none() {
+        // Scanner level: nothing to lift, despite a clean bare keyword rider
+        // sitting in the following sentence.
+        assert_eq!(
+            parse_enters_with_keyword_riders(
+                "it enters with two +1/+1 counters on it. exile it and with trample."
+            ),
+            Vec::<Keyword>::new(),
+            "a later sentence's rider must not be lifted when the entering sentence has none"
+        );
+
+        // Composed level: the replacement places counters and grants nothing.
+        let def = parse_replacement_line(
+            "If this creature was kicked, it enters with two +1/+1 counters on it.              Exile it and with trample.",
+            "Synthetic No First Sentence Rider",
+        )
+        .expect("line must parse");
+        let execute = def.execute.as_deref().expect("execute ability");
+        assert_eq!(
+            collect_granted_keywords(execute),
+            Vec::<Keyword>::new(),
+            "no keyword may be granted when the entering sentence carries no rider"
+        );
+        assert!(
+            find_put_counter(execute).is_some(),
+            "the counters must still be placed"
         );
     }
 

--- a/crates/engine/tests/integration/kicker_enters_with_keyword_rider.rs
+++ b/crates/engine/tests/integration/kicker_enters_with_keyword_rider.rs
@@ -1,0 +1,169 @@
+//! Runtime cast-pipeline coverage for the `"and with <keyword>"` entry rider
+//! printed alongside an enters-with-counters clause (CR 614.1c), the shape the
+//! Invasion kicker cycle uses: "If this creature was kicked, it enters with
+//! three +1/+1 counters on it and with trample" (Kavu Titan).
+//!
+//! Before the fix, `parse_enters_with_counters` composed only the sibling
+//! `"enters tapped"` rider, so the keyword clause was never read at all — nine
+//! cards entered with their counters and silently without their granted
+//! ability. Two parser tests (`kicked_enters_with_counter`,
+//! `kicked_with_specific_cost_enters_with_counters`) asserted only the counter
+//! and so stayed green through the whole gap; both now assert the keyword too.
+//!
+//! CR 611.2a is why the grant is modeled as a continuous `AddKeyword` with
+//! `Duration::UntilHostLeavesPlay` rather than a one-shot effect: unlike
+//! tapping, the keyword is a characteristic the permanent must KEEP while it
+//! remains on the battlefield.
+//!
+//! Built via the `/card-test` recipe: `GameScenario` + a real kicker payment
+//! through `DecideOptionalCost`, so the entering object's `kickers_paid` is
+//! populated authentically rather than seeded. Both polarities are covered, and
+//! each asserts the +1/+1 counters alongside the keyword so that a spell which
+//! never resolved cannot satisfy either assertion vacuously.
+//!
+//! REVERT DISCRIMINATOR: `kavu_titan_kicked_enters_with_trample`. Remove the
+//! `compose_enters_with_keyword_grant` call from `parse_enters_with_counters`
+//! and the trample grant disappears while the counters still land, so the
+//! keyword assertion fails and the counter reach-guard still passes.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::ability::{AbilityCost, AdditionalCost, AdditionalCostRepeatability, Effect};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+/// Kavu Titan {1}{G} 2/2 — the enters-with line verbatim. The `Kicker {2}{G}`
+/// keyword line itself is supplied structurally via `with_additional_cost` so
+/// the cost is paid through the real optional-cost flow.
+const KAVU_TITAN: &str =
+    "If this creature was kicked, it enters with three +1/+1 counters on it and with trample.";
+
+/// Cast Kavu Titan, paying the kicker or declining it, and return the resolved
+/// battlefield object.
+fn cast_kavu_titan(kicked: bool) -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let titan = scenario
+        .add_creature_to_hand_from_oracle(P0, "Kavu Titan", 2, 2, KAVU_TITAN)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::Green],
+        })
+        // CR 702.33a: Kicker {2}{G} — a non-repeatable optional additional cost.
+        .with_additional_cost(AdditionalCost::Kicker {
+            costs: vec![AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    generic: 2,
+                    shards: vec![ManaCostShard::Green],
+                },
+            }],
+            repeatability: AdditionalCostRepeatability::Once,
+        })
+        .id();
+
+    for _ in 0..8 {
+        scenario.add_basic_land(P0, ManaColor::Green);
+    }
+
+    let mut runner = scenario.build();
+
+    // Structural reach-guard: the card must parse cleanly, so a negative
+    // keyword assertion cannot be satisfied by an upstream parse failure.
+    assert!(
+        !runner.state().objects[&titan]
+            .abilities
+            .iter()
+            .any(|a| matches!(&*a.effect, Effect::Unimplemented { .. })),
+        "Kavu Titan must parse with zero Effect::Unimplemented, got {:?}",
+        runner.state().objects[&titan].abilities
+    );
+
+    let card = runner.state().objects[&titan].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: titan,
+            card_id: card,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("P0 casts Kavu Titan");
+
+    // Kicker {2}{G} is `Once`, so the engine offers the choice exactly once —
+    // an `if let`, unlike the multikicker loop in the Batroc test.
+    assert!(
+        matches!(
+            &runner.state().waiting_for,
+            WaitingFor::OptionalCostChoice { .. }
+        ),
+        "the engine must offer the kicker choice, got {:?}",
+        runner.state().waiting_for
+    );
+    runner
+        .act(GameAction::DecideOptionalCost { pay: kicked })
+        .expect("P0 decides the kicker");
+
+    while runner.state().objects.get(&titan).map(|o| o.zone) != Some(Zone::Battlefield) {
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("pass priority to resolve Kavu Titan");
+            }
+            other => panic!("unexpected waiting state while resolving Kavu Titan: {other:?}"),
+        }
+    }
+
+    (runner, titan)
+}
+
+fn counters(runner: &GameRunner, id: ObjectId) -> u32 {
+    runner.state().objects[&id]
+        .counters
+        .get(&CounterType::Plus1Plus1)
+        .copied()
+        .unwrap_or(0)
+}
+
+/// PRIMARY REVERT DISCRIMINATOR. Kicked, so both halves of the one replacement
+/// apply: three +1/+1 counters AND trample. The counter assertion is the
+/// reach-guard — it proves the replacement fired at all, so a failing trample
+/// assertion means the rider specifically was dropped.
+#[test]
+fn kavu_titan_kicked_enters_with_trample() {
+    let (runner, titan) = cast_kavu_titan(true);
+    assert_eq!(
+        counters(&runner, titan),
+        3,
+        "reach-guard: the kicked replacement must place three +1/+1 counters — if this is 0 \
+         the replacement never applied and the trample assertion below would be vacuous"
+    );
+    assert!(
+        runner.state().objects[&titan].has_keyword(&Keyword::Trample),
+        "CR 614.1c: the \"and with trample\" rider is part of the same replacement as the \
+         counters, so a kicked Kavu Titan must have trample"
+    );
+}
+
+/// Opposite polarity: not kicked, so NEITHER half applies. Pairs with the test
+/// above so the trample assertion there is shown to be a real gate decision
+/// rather than an unconditional grant.
+#[test]
+fn kavu_titan_unkicked_gets_neither_counters_nor_trample() {
+    let (runner, titan) = cast_kavu_titan(false);
+    assert_eq!(
+        counters(&runner, titan),
+        0,
+        "an unkicked Kavu Titan must not get the gated counters"
+    );
+    assert!(
+        !runner.state().objects[&titan].has_keyword(&Keyword::Trample),
+        "the trample rider is gated on kicker (CR 702.33d), so an unkicked Kavu Titan must \
+         NOT have trample — a grant that ignores the gate would fail here"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -836,6 +836,7 @@ mod kaya_geist_hunter;
 mod kaya_spirits_justice_per_opponent_exile;
 mod kaysa_green_anthem;
 mod kibo_uktabi_prince_defending_player_sacrifice;
+mod kicker_enters_with_keyword_rider;
 mod kicker_x_cap_search_termination;
 mod kilo_live_offer_from_real_dump;
 mod kiora_self_library_peek_cast;


### PR DESCRIPTION
Refs #7721 -- PARTIAL, deliberately not an auto-closing trailer. This fixes the
bare-keyword rider: 13 of the 18 printed rider lines, and 8 of the 13 cards
outright. The quoted-ability rider scoped out below leaves Anavolver,
Degavolver, Necravolver, Rakavolver and Prison Barricade still missing a half
each, so the issue must stay open.

CR 614.1c makes "If this creature was kicked, it enters with three +1/+1
counters on it and with trample" ONE replacement effect. Only the counters were
being read. `parse_enters_with_counters` composes exactly one sibling entry
rider -- `has_enters_tapped_phrase` -- and there was no extractor for the
keyword clause, so those cards entered with their counters and silently without
their granted ability.

CR 611.2a governs the grant's shape. The tapped precedent does NOT transfer:
tapping happens once as the object enters, so a one-shot `SetTapState` is right
there, whereas a granted keyword is a characteristic the permanent must KEEP
while it remains on the battlefield -- and must lose on leaving, so the new
object it becomes elsewhere does not inherit it. Modeled as a continuous
`AddKeyword` on `SelfRef` with `Duration::UntilHostLeavesPlay`, composed onto
the same execute chain as the counters. That reuses the definition's existing
condition, so the kicker gate (CR 702.33d) applies to the grant for free rather
than being re-derived.

## Rider boundary

`parse_enters_with_keyword_riders` scans at `" and with "` boundaries rather
than anchoring, because the rider trails a counter clause of unbounded shape and
is not the first `" and "` in the line -- Voidpouncer prints a conjoined counter
list ("two +1/+1 counters and a trample counter on it") before it. Each
candidate is offered to the shared `parse_granted_keyword_fragment`, and a
candidate that is not a keyword simply does not match, which keeps the counter
list's own conjuncts out: "a trample counter on it" is not a keyword. Pinned by
`enters_with_keyword_rider_does_not_over_claim` over Dust Animus and Agent's
Toolkit, whose "<keyword> counter" conjuncts must stay counters.

Each candidate is bounded by `parse_enters_with_keyword_rider_candidate`, an
`alt` that stops at whichever comes first: the next `" and with "` marker or the
sentence period, falling through to `rest`. Both terminators are `peek`ed so the
scan loop resumes on input still carrying the marker its `take_until` needs, and
the marker is a named const shared by anchor and terminator so the two cannot
drift about where a rider ends.

Bounding only at the period would hand a chained "and with X and with Y" line
the candidate "X and with Y", which the keyword parser rejects as a compound;
the loop would then capture only Y and drop X -- the same silent-drop bug this
PR fixes, one keyword deep, latent behind a `Vec<Keyword>` signature that
already promises multiple riders.
`chained_enters_with_keyword_riders_keep_every_keyword` is the discriminating
regression and asserts at both levels: the scan returns both keywords in printed
order, and both grants reach the composed execute chain with the counters still
beneath them.

## Corpus

Verified against Scryfall (`oracle:"on it and with"`), not from memory. 13
printed cards carry this rider slot, always gated on kicker: Anavolver, Benalish
Lancer, Cetavolver, Degavolver, Duskwalker, Faerie Squadron, Kavu Titan,
Necravolver, Pouncing Kavu, Pouncing Wurm, Prison Barricade, Rakavolver,
Voidpouncer. They print 18 rider lines -- 13 bare keywords and 5 quoted
abilities.

| | Fixed here | Still open on #7721 |
|---|---|---|
| Rider lines | 13 bare | 5 quoted |
| Cards | 8 outright | 5 keep one broken half |

Duskwalker's rider is trailed by parenthesized reminder text, so the cycle test
also pins that the candidate stops at the sentence period rather than swallowing
"(It can't be blocked except by ...)" into the keyword name.

The QUOTED-ability rider in the same slot is deliberately out of scope: it needs
a granted-ability parse, not a keyword lookup. Five lines across four cards --
Anavolver's {B} and Degavolver's {1}{B} halves ("Pay 3 life: Regenerate this
creature."), Necravolver's {W} and Rakavolver's {1}{W} halves ("Whenever this
creature deals damage, you gain that much life."), and Prison Barricade ("This
creature can attack as though it didn't have defender."). Those lines keep their
current counters-only behavior rather than being failed closed, since that would
trade a partial parse for no parse at all. Left on #7721.

## Tests

Two existing tests had been passing green through the entire gap by asserting
the counter and saying nothing about the rider. Both now assert the keyword
grant through a shared `assert_keyword_grant` helper, so they can no longer go
quiet if the rider is dropped again.

Both also carried fabricated card attributions, now corrected against Scryfall:

- `kicked_enters_with_counter` named Ana Battlemage, which prints no
  enters-with-counters clause at all -- it has two ETB triggers. The only
  printed card with that exact line is Rakavolver's {U} half, and that one is
  cost-qualified, so it exercises the sibling `kicker_cost: Some(_)` path. The
  unqualified shape is what this test pins, so it keeps the text under a
  synthetic name.
- `kicked_with_specific_cost_enters_with_counters` named Necravolver while using
  Cetavolver's {1}{R} first-strike line. Necravolver kicks for {1}{G}/{W} and
  never prints {1}{R}. Renamed to match the text.

Runtime coverage in `kicker_enters_with_keyword_rider.rs` pays the kicker
through the real `DecideOptionalCost` flow, so the entering object's
`kickers_paid` is populated authentically. Both polarities are asserted, and
each pairs the keyword with a +1/+1 counter reach-guard so a spell that never
resolved cannot satisfy either assertion vacuously -- an AST-only test would
have proven the parse without proving the keyword ever reaches the battlefield.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected handling of kicked permanents that enter with counters and an additional keyword ability.
  - These effects now consistently apply the granted keyword when the permanent enters, while preserving counters, tapped-state instructions, and kicker conditions.
  - Added support for multiple counter configurations and chained keyword riders.
  - Prevented keyword riders from later sentences from being incorrectly attached to the replacement effect.
  - Invalid keyword-and-counter combinations continue to be rejected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->