### PR TITLE
fix(engine): let a face-down creature spell match its own cost reduction

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2738,22 +2738,11 @@ pub(super) fn build_spell_meta(
         // CR 708.4 + CR 702.37c / CR 702.168b: `is_face_down` means "this spell is
         // being CAST FACE DOWN" (morph/disguise — paying {3} to cast as a 2/2
         // face-down creature spell), NOT merely "the object has `face_down = true`".
-        // Those differ: foretell (CR 702.143a), hideaway, and other exile/library
-        // concealment set `obj.face_down = true` while the card waits in exile, yet
-        // such a card is CAST FACE UP (CR 702.143c). So this must NOT be sourced from
-        // raw `obj.face_down` — a foretold face-up cast would wrongly satisfy the
-        // `OnlyForFaceDownSpell` spend restriction (Tin Street Gossip).
-        //
-        // The discriminator is `face_down && back_face.is_some()`: `continue_cast_face_down`
-        // is the ONLY path that reaches a spell payment (`PaymentContext::Spell`) with a
-        // blanked object — it turns the object face down via `apply_face_down_entry_profile`,
-        // which stashes the real card in `back_face` (CR 708.2 copiable-value blank). A
-        // foretold/hideaway object keeps `back_face = None` (its real characteristics are
-        // intact in exile — it is not blanked), so it reads `false` here. Manifest/cloak
-        // objects are face-down permanents put onto the battlefield by effects, never cast
-        // through spell payment, so they never build a `PaymentContext::Spell`. Guarded by
+        // `spell_is_cast_face_down` is the single authority for that distinction and
+        // carries the full CR argument; the spell-filter projection asks the same
+        // question there, so the two seams cannot answer it differently. Guarded by
         // `build_spell_meta_for_foretold_card_is_not_face_down` (casting_tests.rs).
-        is_face_down: obj.face_down && obj.back_face.is_some(),
+        is_face_down: obj.spell_is_cast_face_down(),
         // CR 601.2g / CR 118.3: Hogaak-style "you can't spend mana to cast this
         // spell" — the mana-payment eligibility layer makes real pool mana
         // ineligible when set, so only convoke/delve stand-ins can pay.
@@ -10385,7 +10374,47 @@ fn can_afford_face_down_cast(
     let mut simulated = state.clone();
     let profile = face_down_cast_profile(state, object_id);
     super::zone_pipeline::apply_face_down_entry_profile(&mut simulated, object_id, &profile);
-    can_pay_cost_after_auto_tap(&simulated, player, object_id, cost)
+    let effective = effective_face_down_cast_cost(&simulated, player, object_id, cost);
+    can_pay_cost_after_auto_tap(&simulated, player, object_id, &effective)
+}
+
+/// CR 601.2f + CR 702.37c / CR 702.168b: The {3} face-down cast cost AFTER cost
+/// modification — the single authority for what a face-down cast actually costs
+/// before payment, shared by the affordability gate and the cast offer the player
+/// is shown.
+///
+/// `prepare_spell_cast` runs the same modifier passes on the real cast, so anything
+/// that reads the raw {3} disagrees with what the player is charged. A "face-down
+/// creature spells cost {N} less" static (Kadena, Dream Chisel, Obscuring Aether)
+/// can take it to {0}, which must be both castable with an empty pool and displayed
+/// as {0} rather than {3} — the frontend renders the number the engine hands it.
+///
+/// `state` must ALREADY carry the blanked face-down object (the caller's
+/// `apply_face_down_entry_profile` clone), because that is what makes a
+/// face-down-filtered reduction match here the same way it will during the cast.
+fn effective_face_down_cast_cost(
+    blanked_state: &GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+    cost: &crate::types::mana::ManaCost,
+) -> crate::types::mana::ManaCost {
+    apply_cost_modifiers_to_base(blanked_state, player, object_id, cost.clone())
+        .unwrap_or_else(|| cost.clone())
+}
+
+/// Offer-side sibling of [`effective_face_down_cast_cost`]: takes the UNBLANKED
+/// live state, applies the same face-down profile the real cast will, and returns
+/// the cost to show in the `AlternativeCastChoice` menu.
+fn displayed_face_down_cast_cost(
+    state: &GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+    cost: &crate::types::mana::ManaCost,
+) -> crate::types::mana::ManaCost {
+    let mut simulated = state.clone();
+    let profile = face_down_cast_profile(state, object_id);
+    super::zone_pipeline::apply_face_down_entry_profile(&mut simulated, object_id, &profile);
+    effective_face_down_cast_cost(&simulated, player, object_id, cost)
 }
 
 /// CR 708.4 + CR 708.2a: True when the {3} face-down cast is PERMITTED — castable
@@ -12462,7 +12491,16 @@ pub fn handle_cast_spell_with_payment_mode(
                         payment_mode,
                         keyword: crate::types::game_state::AlternativeCastKeyword::FaceDown,
                         normal_cost,
-                        alternative_cost: Some(face_down_cost),
+                        // CR 601.2f: show what the face-down cast will actually
+                        // cost. The client renders this number verbatim, so handing
+                        // it the unmodified {3} while charging {0} (Kadena, Dream
+                        // Chisel) would make the menu contradict the payment.
+                        alternative_cost: Some(displayed_face_down_cast_cost(
+                            state,
+                            player,
+                            object_id,
+                            &face_down_cost,
+                        )),
                         alternative_additional_cost: None,
                         alternative_additional_cost_description: None,
                     });
@@ -21193,10 +21231,12 @@ fn is_blocked_by_per_turn_cast_limit_for(
                 // shared cast-record authority so a fused split spell's mana value /
                 // colors reflect both halves for the per-turn cast-limit filter.
                 // Pre-payment (marker not yet set) the caller supplies `fused`.
-                let current_record = super::restrictions::spell_cast_record_for(
+                // Live seam: `live_spell_cast_record_for` states the face-down cast
+                // (CR 708.4) the object evidences, so this filter and the cost-modifier
+                // filter cannot answer `FilterProp::FaceDown` differently.
+                let current_record = super::restrictions::live_spell_cast_record_for(
                     spell_obj,
                     spell_obj.zone,
-                    crate::types::game_state::CastingVariant::Normal,
                     fused,
                 );
                 if !super::filter::spell_record_matches_filter(

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -7548,6 +7548,28 @@ pub(super) fn apply_cost_modifiers_to_base(
     object_id: ObjectId,
     base: ManaCost,
 ) -> Option<ManaCost> {
+    // Projection callers with no committed casting method (the per-keyword offer
+    // blocks, the Bargain recompute). CR 601.2f + CR 702.102b: `None` keeps the
+    // front-half projection for split cards — the Fuse candidate routes through
+    // the real `CastingVariant::Fuse` prepare instead — and a variant-conditional
+    // modifier (`StaticCondition::CastingAsVariant`) stays inapplicable until a
+    // casting method is committed.
+    apply_cost_modifiers_to_base_for_variant(state, player, object_id, base, None, None)
+}
+
+/// Variant-aware core of [`apply_cost_modifiers_to_base`]: a projection that has
+/// already COMMITTED to a casting method threads that method and its elected
+/// permission through, so `StaticCondition::CastingAsVariant` modifiers and the
+/// elected `PlayFromExile` grant's `cast_cost_raise` apply exactly as they do in
+/// the real cast's `apply_all_cost_modifiers` call (CR 601.2b + CR 601.2f).
+pub(super) fn apply_cost_modifiers_to_base_for_variant(
+    state: &GameState,
+    player: PlayerId,
+    object_id: ObjectId,
+    base: ManaCost,
+    casting_variant: Option<CastingVariant>,
+    casting_permission_index: Option<CastingPermissionIndex>,
+) -> Option<ManaCost> {
     let obj = state.objects.get(&object_id)?;
     let mut mana_cost = base;
     // CR 903.8: Commanders cast from the command zone incur a tax.
@@ -7568,14 +7590,14 @@ pub(super) fn apply_cost_modifiers_to_base(
             }
         }
     }
-    // CR 601.2f + CR 702.102b: This recompute path is exercised only after an
-    // *additional* cost (Bargain) is declared (`recompute_pending_cast_cost`).
-    // Fuse and Bargain never co-occur — no printed split card carries Bargain — so
-    // this path is Fuse-unreachable and `None` (front-half) is exact. Were a fused
-    // recompute ever to reach here, the `fused_split_spell` marker would already be
-    // set by finalization and `spell_cast_record_for`'s OR-gate would still yield
-    // the combined projection, so this is not a silent front-half leak either way.
-    apply_all_cost_modifiers(state, player, object_id, &mut mana_cost, None, None);
+    apply_all_cost_modifiers(
+        state,
+        player,
+        object_id,
+        &mut mana_cost,
+        casting_variant,
+        casting_permission_index,
+    );
     Some(mana_cost)
 }
 
@@ -10398,8 +10420,29 @@ fn effective_face_down_cast_cost(
     object_id: ObjectId,
     cost: &crate::types::mana::ManaCost,
 ) -> crate::types::mana::ManaCost {
-    apply_cost_modifiers_to_base(blanked_state, player, object_id, cost.clone())
-        .unwrap_or_else(|| cost.clone())
+    // CR 601.2b + CR 601.2f: elect the SAME casting permission the real
+    // face-down prepare will elect (`selected_object_cast_permission_index`
+    // with the explicit `FaceDown` variant). With no variant the election
+    // infers Foretell first for a foretold exile card, while the real cast
+    // routes through `PlayFromExile` — and only that grant carries a
+    // `cast_cost_raise`, so the projections would price different casts.
+    let casting_permission_index = blanked_state.objects.get(&object_id).and_then(|obj| {
+        selected_object_cast_permission_index(
+            blanked_state,
+            obj,
+            player,
+            Some(CastingVariant::FaceDown),
+        )
+    });
+    apply_cost_modifiers_to_base_for_variant(
+        blanked_state,
+        player,
+        object_id,
+        cost.clone(),
+        Some(CastingVariant::FaceDown),
+        casting_permission_index,
+    )
+    .unwrap_or_else(|| cost.clone())
 }
 
 /// Offer-side sibling of [`effective_face_down_cast_cost`]: takes the UNBLANKED

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -4401,12 +4401,7 @@ fn spell_cast_record_from_object(spell_obj: &GameObject) -> SpellCastRecord {
 /// split spell whose `fused_split_spell` marker is not yet set; the non-`_for`
 /// entry delegates with `fused = false`.
 fn spell_cast_record_from_object_for(spell_obj: &GameObject, fused: bool) -> SpellCastRecord {
-    crate::game::restrictions::spell_cast_record_for(
-        spell_obj,
-        spell_obj.zone,
-        crate::types::game_state::CastingVariant::Normal,
-        fused,
-    )
+    crate::game::restrictions::live_spell_cast_record_for(spell_obj, spell_obj.zone, fused)
 }
 
 #[derive(Clone, Copy)]
@@ -4790,6 +4785,16 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         // cost contained an `{X}` shard at cast time.
         FilterProp::HasXInManaCost => record.has_x_in_cost,
         FilterProp::WasKicked => record.was_kicked,
+        // CR 708.4: A face-down spell is a real spell on the stack, not a
+        // battlefield-only state — a morph/megamorph/disguise card cast face down
+        // IS a face-down 2/2 creature spell (CR 702.37c / CR 702.168b). The record
+        // states that as the cast variant, both in the ledger (announced by
+        // `record_spell_cast_from_zone`) and at the live seams
+        // (`live_spell_cast_record_for`), so "face-down creature spells you cast"
+        // resolves here instead of failing closed.
+        FilterProp::FaceDown => {
+            record.cast_variant == crate::types::game_state::CastingVariant::FaceDown
+        }
         FilterProp::HasXInActivationCost => false,
         // CR 605.1: Spell-cast records snapshot the spell object, not the
         // object's ability list. Fail closed for history predicates.
@@ -4893,7 +4898,6 @@ fn spell_record_matches_property(record: &SpellCastRecord, prop: &FilterProp) ->
         // CR 122.6: A spell on the stack hasn't received counters as a
         // permanent — fail closed against the spell-cast snapshot.
         | FilterProp::CountersPutOnThisTurn { .. }
-        | FilterProp::FaceDown
         | FilterProp::Transformed
         | FilterProp::TargetsOnly { .. }
         | FilterProp::Targets { .. }

--- a/crates/engine/src/game/game_object.rs
+++ b/crates/engine/src/game/game_object.rs
@@ -2012,6 +2012,37 @@ impl GameObject {
         }
     }
 
+    /// CR 708.4 + CR 702.37c / CR 702.168b: Whether the SPELL this object
+    /// represents is being cast FACE DOWN — a morph/megamorph/disguise card put
+    /// on the stack as a blank 2/2 creature spell for {3} — as opposed to merely
+    /// carrying `face_down = true`.
+    ///
+    /// Those differ, and the difference is why this must not read raw
+    /// `face_down`: CR 702.143a exiles a foretold card "from their hand face
+    /// down" and then lets its owner cast it — hideaway and other exile/library
+    /// concealment work the same way — so `face_down` is set while the card
+    /// waits in exile, yet nothing grants that cast the CR 708.4 permission to
+    /// be turned face down, and the spell goes on the stack face up. The
+    /// discriminator is
+    /// `face_down && back_face.is_some()`: `continue_cast_face_down` is the only
+    /// path that presents a spell with a blanked object, because it turns the
+    /// object face down through `apply_face_down_entry_profile`, which stashes
+    /// the real card in `back_face` (CR 708.2 copiable-value blank). A
+    /// foretold/hideaway object keeps `back_face = None` — its characteristics
+    /// are intact in exile, it is not blanked — and a DFC / adventure / transform
+    /// object carries `back_face` with `face_down = false`, so neither side
+    /// reads `true` here. Manifest and cloak objects are face-down permanents put
+    /// onto the battlefield by effects, never cast, so they never reach a spell
+    /// seam at all.
+    ///
+    /// Single authority for that question: the restricted-mana payment seam
+    /// (`build_spell_meta` → `SpellMeta::is_face_down`, CR 106.6) and the
+    /// spell-filter projection (`spell_cast_record_from_object_for`) both ask
+    /// here rather than each re-deriving it.
+    pub fn spell_is_cast_face_down(&self) -> bool {
+        self.face_down && self.back_face.is_some()
+    }
+
     /// CR 702.102b + CR 709.4d: Restore the combined card types and colors of
     /// a fused split spell after a characteristic reset. The fusion marker is
     /// cast-state, while the union is a derived stack characteristic and must

--- a/crates/engine/src/game/restrictions.rs
+++ b/crates/engine/src/game/restrictions.rs
@@ -213,6 +213,30 @@ pub fn record_spell_cast(
     );
 }
 
+/// CR 708.4: Project a spell-cast record for a LIVE per-spell filter seam, which
+/// has no announced cast variant to record.
+///
+/// The ledger writes the variant its caller announced (`record_spell_cast_from_zone`).
+/// The live seams — cost modifiers (CR 601.2f) and per-turn cast limits — filter a
+/// spell mid-cast and can only state what the object itself evidences, so they
+/// asked for `CastingVariant::Normal` and `FilterProp::FaceDown` had nothing to
+/// read. A face-down cast is the one variant the object does evidence before it
+/// is filtered: `apply_face_down_entry_profile` has already blanked it
+/// (CR 708.2), which is what [`GameObject::spell_is_cast_face_down`] reads. Every
+/// other variant stays `Normal` here — this states a fact, it does not guess one.
+pub(crate) fn live_spell_cast_record_for(
+    obj: &GameObject,
+    from_zone: Zone,
+    fused_hint: bool,
+) -> SpellCastRecord {
+    let cast_variant = if obj.spell_is_cast_face_down() {
+        crate::types::game_state::CastingVariant::FaceDown
+    } else {
+        crate::types::game_state::CastingVariant::Normal
+    };
+    spell_cast_record_for(obj, from_zone, cast_variant, fused_hint)
+}
+
 /// The single fuse-aware authority for spell-cast record projection. `fused_hint` is the caller's
 /// pre-payment determination that the projected spell is a fused split spell
 /// (CR 702.102b), for seams that know the `CastingVariant::Fuse` intent before the

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -345,7 +345,16 @@ pub(crate) fn apply_zone_exit_cleanup(
             // while it remains in exile. Once it changes zones, the new object
             // is no longer a foretold card.
             obj_mut.foretold = false;
-            obj_mut.face_down = false;
+            // CR 708.4: a spell CAST face down (morph/disguise via an exile
+            // permission) is turned face down as part of the cast and keeps
+            // that status on the stack. Only the exile-zone face-down
+            // designation ends here (foretold/hideaway cards, which stash no
+            // identity in `back_face`); the cast is the one exile exit whose
+            // destination is the stack and whose object carries the cast
+            // stash (`spell_is_cast_face_down`, #5171's discriminator).
+            if !(to == Zone::Stack && obj_mut.spell_is_cast_face_down()) {
+                obj_mut.face_down = false;
+            }
             obj_mut.casting_permissions.retain(|p| {
                 !matches!(
                     p,

--- a/crates/engine/tests/integration/face_down_spell_cost_filter.rs
+++ b/crates/engine/tests/integration/face_down_spell_cost_filter.rs
@@ -1,0 +1,312 @@
+//! CR 601.2f + CR 708.4: a cost-modifier static filtered on "face-down creature
+//! spells" must reduce the {3} a morph/megamorph/disguise card pays to be cast
+//! face down (CR 702.37c / CR 702.168b).
+//!
+//! Class (measured against `card-data.json`, 3 cards): Kadena, Slinking Sorcerer
+//! ("The first face-down creature spell you cast each turn costs {3} less to
+//! cast"), Dream Chisel and Obscuring Aether ("Face-down creature spells you
+//! cast cost {1} less to cast"). All three parse into a `StaticMode::ModifyCost`
+//! whose `spell_filter` carries `FilterProp::FaceDown`.
+//!
+//! Before the fix that filter could never match: the live cost seam projects the
+//! spell into a `SpellCastRecord`, and `FilterProp::FaceDown` failed closed
+//! against that record — grouped with battlefield-only predicates, although
+//! CR 708.4 puts a face-down spell on the stack as a real spell. The reduction
+//! was therefore dead for every card in the class.
+//!
+//! These tests drive the real cast pipeline (`GameAction::CastSpell` →
+//! `continue_cast_face_down` → cost calculation → mana payment) and read the
+//! mana left unspent, so they measure what a player pays.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::game_state::CastPaymentMode;
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+/// Kadena's Oracle text, parsed by the engine rather than hand-built, so the
+/// test fails if the parser stops producing the filtered reduction.
+const KADENA_TEXT: &str =
+    "The first face-down creature spell you cast each turn costs {3} less to cast.";
+/// Dream Chisel / Obscuring Aether — the unconditional half of the class.
+const DREAM_CHISEL_TEXT: &str = "Face-down creature spells you cast cost {1} less to cast.";
+
+fn colorless(n: usize) -> Vec<ManaUnit> {
+    (0..n)
+        .map(|_| ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+fn cast(runner: &mut engine::game::scenario::GameRunner, spell: ObjectId) -> bool {
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .is_ok()
+}
+
+fn unspent(runner: &engine::game::scenario::GameRunner) -> usize {
+    runner.state().players[0].mana_pool.total()
+}
+
+/// CR 601.2f + CR 708.4: the reduction reaches the face-down cast.
+///
+/// The morph card's printed cost is {5} and the pool holds 3, so the only legal
+/// cast is the {3} face-down one (CR 702.37c) — which Kadena must reduce to {0}.
+///
+/// Discriminating: without the fix `FilterProp::FaceDown` fails closed against
+/// the spell-cast record, the reduction never applies, and the 3 mana are spent.
+#[test]
+fn a_face_down_creature_spell_gets_kadenas_reduction() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Snake Sorcerer", 3, 3, KADENA_TEXT);
+    let morph = scenario
+        .add_creature_to_hand(P0, "Secret Beast", 4, 5)
+        .with_keyword(Keyword::Morph(ManaCost::generic(4)))
+        .with_mana_cost(ManaCost::generic(5))
+        .id();
+    scenario.with_mana_pool(P0, colorless(3));
+    let mut runner = scenario.build();
+
+    assert!(cast(&mut runner, morph), "the face-down cast must be legal");
+    assert!(
+        runner.state().objects[&morph].face_down
+            && runner.state().objects[&morph].zone == Zone::Stack,
+        "reach-guard: the spell must be on the stack FACE DOWN, not cast face up"
+    );
+    assert_eq!(
+        unspent(&runner),
+        3,
+        "Kadena must reduce the {{3}} face-down cost to {{0}}"
+    );
+}
+
+/// CR 601.2f: Dream Chisel / Obscuring Aether — the same class without the
+/// once-per-turn condition. {3} face-down cost minus {1} leaves {2}.
+///
+/// Discriminating in the same way, and it separates the two halves of the fix:
+/// this one needs only the `spell_filter` to match, no ledger read.
+#[test]
+fn dream_chisels_unconditional_reduction_reaches_a_face_down_spell() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Chisel Bearer", 2, 2, DREAM_CHISEL_TEXT);
+    let morph = scenario
+        .add_creature_to_hand(P0, "Secret Beast", 4, 5)
+        .with_keyword(Keyword::Morph(ManaCost::generic(4)))
+        .with_mana_cost(ManaCost::generic(5))
+        .id();
+    scenario.with_mana_pool(P0, colorless(3));
+    let mut runner = scenario.build();
+
+    assert!(cast(&mut runner, morph), "the face-down cast must be legal");
+    assert_eq!(
+        unspent(&runner),
+        1,
+        "a {{1}} reduction must leave 1 of the 3 mana unspent"
+    );
+}
+
+/// CR 601.2f + CR 604.1: "the FIRST face-down creature spell you cast each turn"
+/// — the second one that turn pays in full. The reduction is a static ability,
+/// so its "first each turn" condition is simply true or false at the moment the
+/// total cost is determined.
+///
+/// This is the ledger half. Kadena's condition counts face-down creature spells
+/// cast this turn and requires zero; that count reads the same
+/// `FilterProp::FaceDown` predicate against the stored cast records, so before
+/// the fix it was permanently 0 and the condition was accidentally always true.
+///
+/// The pair of assertions is what discriminates, not either alone: a fix that
+/// simply always applied the reduction would let BOTH casts through for free and
+/// leave mana unspent; the unfixed engine cannot pay for the second cast at all.
+#[test]
+fn only_the_first_face_down_spell_each_turn_is_reduced() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Snake Sorcerer", 3, 3, KADENA_TEXT);
+    let first = scenario
+        .add_creature_to_hand(P0, "Secret Beast", 4, 5)
+        .with_keyword(Keyword::Morph(ManaCost::generic(4)))
+        .with_mana_cost(ManaCost::generic(5))
+        .id();
+    let second = scenario
+        .add_creature_to_hand(P0, "Second Beast", 4, 5)
+        .with_keyword(Keyword::Morph(ManaCost::generic(4)))
+        .with_mana_cost(ManaCost::generic(5))
+        .id();
+    // Exactly enough for a reduced first cast ({0}) plus a full second one ({3}).
+    scenario.with_mana_pool(P0, colorless(3));
+    let mut runner = scenario.build();
+
+    assert!(
+        cast(&mut runner, first),
+        "the first face-down cast must be legal"
+    );
+    assert_eq!(
+        unspent(&runner),
+        3,
+        "the FIRST face-down spell is the reduced one"
+    );
+
+    // CR 302.1: a creature spell is cast at sorcery speed, so the first one has
+    // to leave the stack before the second can be cast at all.
+    runner.resolve_top();
+
+    assert!(
+        cast(&mut runner, second),
+        "the second face-down cast must still be payable from the untouched pool"
+    );
+    assert_eq!(
+        unspent(&runner),
+        0,
+        "the SECOND face-down spell that turn pays the full {{3}}"
+    );
+}
+
+/// CR 601.2f + CR 702.37c: the reduced cost must also be what the OFFER is
+/// judged against. Kadena takes the {3} face-down cost to {0}, so the cast has to
+/// be legal with an EMPTY mana pool — the player-visible form of the same rule.
+///
+/// Playtest find: "eigentlich müsste ich auch mit 0 Mana auf dem Feld eine
+/// Morph/Disguise wirken können". `can_afford_face_down_cast` asks whether the
+/// fixed {3} is payable, so if that question is put before the reduction the
+/// engine withholds a cast the player is entitled to make.
+#[test]
+fn kadena_lets_a_face_down_creature_be_cast_with_an_empty_pool() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Snake Sorcerer", 3, 3, KADENA_TEXT);
+    let morph = scenario
+        .add_creature_to_hand(P0, "Secret Beast", 4, 5)
+        .with_keyword(Keyword::Morph(ManaCost::generic(4)))
+        .with_mana_cost(ManaCost::generic(5))
+        .id();
+    // No mana at all.
+    let mut runner = scenario.build();
+    assert_eq!(unspent(&runner), 0, "reach-guard: the pool starts empty");
+
+    assert!(
+        cast(&mut runner, morph),
+        "a {{0}} face-down cast must be legal with no mana available"
+    );
+    assert!(
+        runner.state().objects[&morph].face_down
+            && runner.state().objects[&morph].zone == Zone::Stack,
+        "the creature must reach the stack face down"
+    );
+}
+
+/// CR 601.2f: the cast offer must SHOW the reduced cost, not the printed {3}.
+///
+/// The client renders `alternative_cost` verbatim (the frontend is a display
+/// layer and must not recompute game state), so a menu that says {3} while the
+/// payment takes {0} is an engine defect, not a rendering one.
+#[test]
+fn the_face_down_offer_shows_the_reduced_cost() {
+    use engine::types::game_state::WaitingFor;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Snake Sorcerer", 3, 3, KADENA_TEXT);
+    let morph = scenario
+        .add_creature_to_hand(P0, "Secret Beast", 4, 5)
+        .with_keyword(Keyword::Morph(ManaCost::generic(4)))
+        .with_mana_cost(ManaCost::generic(5))
+        .id();
+    // Enough for the printed {5} too, so the player is given the CHOICE menu
+    // rather than being routed straight into the face-down cast.
+    scenario.with_mana_pool(P0, colorless(5));
+    let mut runner = scenario.build();
+
+    assert!(cast(&mut runner, morph), "the cast must be accepted");
+    match &runner.state().waiting_for {
+        WaitingFor::AlternativeCastChoice {
+            alternative_cost: Some(cost),
+            ..
+        } => assert_eq!(
+            cost.mana_value(),
+            0,
+            "Kadena takes the face-down cast to {{0}}; the offer must say so, got {cost:?}"
+        ),
+        other => panic!("expected the face-down AlternativeCastChoice, got {other:?}"),
+    }
+}
+
+/// PROBE (playtest question, not a claim of this fix): CR 702.37c prices the
+/// face-down cast at a fixed GENERIC {3}, so mana of any color pays it — 3 Islands
+/// must cast a green morph creature face down. Pinned here because the offer gate
+/// now runs cost modifiers, and nothing in that change may narrow which mana counts.
+#[test]
+fn off_color_mana_pays_the_generic_face_down_cost() {
+    use engine::types::mana::ManaCostShard;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let morph = scenario
+        .add_creature_to_hand(P0, "Ainok Survivalist", 2, 1)
+        .with_keyword(Keyword::Morph(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 1,
+        }))
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Green],
+            generic: 1,
+        })
+        .id();
+    // Three BLUE mana: the printed {1}{G} is unpayable, the generic {3} is not.
+    scenario.with_mana_pool(
+        P0,
+        (0..3)
+            .map(|_| ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]))
+            .collect(),
+    );
+    let mut runner = scenario.build();
+
+    assert!(
+        cast(&mut runner, morph),
+        "CR 702.37c: the {{3}} face-down cost is generic — off-color mana pays it"
+    );
+    assert!(
+        runner.state().objects[&morph].face_down,
+        "the cast must be the FACE-DOWN one, not the printed {{1}}{{G}}"
+    );
+    assert_eq!(unspent(&runner), 0, "all three blue mana pay the {{3}}");
+}
+
+/// Positive counter-direction: the filter must not leak onto face-up casts.
+///
+/// A creature without morph is cast face up for its printed {2}; Kadena's
+/// "face-down creature spell" filter must leave it alone. Over-application would
+/// show up as unspent mana here.
+#[test]
+fn a_face_up_creature_spell_is_not_reduced() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Snake Sorcerer", 3, 3, KADENA_TEXT);
+    let plain = scenario
+        .add_creature_to_hand(P0, "Plain Bear", 2, 2)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    scenario.with_mana_pool(P0, colorless(2));
+    let mut runner = scenario.build();
+
+    assert!(cast(&mut runner, plain), "the face-up cast must be legal");
+    assert!(
+        !runner.state().objects[&plain].face_down,
+        "reach-guard: a creature without morph is cast FACE UP"
+    );
+    assert_eq!(
+        unspent(&runner),
+        0,
+        "a face-up creature spell must pay its full {{2}}"
+    );
+}

--- a/crates/engine/tests/integration/face_down_spell_cost_filter.rs
+++ b/crates/engine/tests/integration/face_down_spell_cost_filter.rs
@@ -310,3 +310,111 @@ fn a_face_up_creature_spell_is_not_reduced() {
         "a face-up creature spell must pay its full {{2}}"
     );
 }
+
+/// Helper for the exile-parity pair below: a morph creature in EXILE that is
+/// both foretold (castable face up for {1}) and granted `PlayFromExile` with a
+/// {2} `cast_cost_raise`. The explicit face-down election routes through
+/// `PlayFromExile` (CR 601.2a-b), so the real face-down cast pays {3}+{2}={5};
+/// a variant-less projection infers Foretell first and would price {3}.
+fn exile_morph_with_competing_permissions(
+    pool: usize,
+) -> (engine::game::scenario::GameRunner, ObjectId) {
+    use engine::types::ability::{CastingPermission, Duration};
+    use engine::types::statics::CastFrequency;
+    use engine::types::zones::EtbTapState;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let morph = scenario
+        .add_creature_to_exile(P0, "Foretold Beast", 4, 5)
+        .with_keyword(Keyword::Morph(ManaCost::generic(4)))
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
+    scenario.with_mana_pool(P0, colorless(pool));
+    let mut runner = scenario.build();
+    let obj = runner.state_mut().objects.get_mut(&morph).unwrap();
+    obj.casting_permissions.push(CastingPermission::Foretold {
+        cost: ManaCost::generic(1),
+        turn_foretold: 0,
+    });
+    obj.casting_permissions
+        .push(CastingPermission::PlayFromExile {
+            duration: Duration::UntilEndOfTurn,
+            granted_to: P0,
+            frequency: CastFrequency::Unlimited,
+            source_id: None,
+            invalidation: None,
+            exiled_by_ability_controller: None,
+            mana_spend_permission: None,
+            card_filter: None,
+            single_use_group: None,
+            single_use: false,
+            cast_cost_raise: Some(ManaCost::generic(2)),
+            land_enter_tapped: EtbTapState::Unspecified,
+        });
+    (runner, morph)
+}
+
+/// CR 601.2a-b + CR 601.2f: the face-down OFFER from exile must be priced by the
+/// permission the real cast elects. The menu has to show {3}+{2}={5} (the
+/// `PlayFromExile` raise), and choosing it has to charge exactly that.
+///
+/// Discriminating: a variant-less projection infers the Foretold permission
+/// (no raise) and displays {3} while the payment takes {5}.
+#[test]
+fn the_face_down_offer_from_exile_prices_the_play_from_exile_raise() {
+    use engine::types::actions::AlternativeCastDecision;
+    use engine::types::game_state::{AlternativeCastKeyword, WaitingFor};
+
+    let (mut runner, morph) = exile_morph_with_competing_permissions(5);
+
+    assert!(cast(&mut runner, morph), "the cast must be accepted");
+    match &runner.state().waiting_for {
+        WaitingFor::AlternativeCastChoice {
+            keyword: AlternativeCastKeyword::FaceDown,
+            alternative_cost: Some(cost),
+            ..
+        } => assert_eq!(
+            cost.mana_value(),
+            5,
+            "the offer must price the PlayFromExile raise: {{3}}+{{2}}, got {cost:?}"
+        ),
+        other => panic!("expected the face-down AlternativeCastChoice, got {other:?}"),
+    }
+    runner
+        .act(GameAction::ChooseAlternativeCast {
+            choice: AlternativeCastDecision::Alternative,
+        })
+        .expect("the priced face-down cast must complete");
+    assert!(
+        runner.state().objects[&morph].face_down
+            && runner.state().objects[&morph].zone == Zone::Stack,
+        "the spell must be on the stack face down"
+    );
+    assert_eq!(
+        unspent(&runner),
+        0,
+        "the displayed {{5}} is what is charged"
+    );
+}
+
+/// CR 601.2f: the same board with only 3 mana — the real face-down cost {5} is
+/// NOT payable, so the face-down offer must be withheld and the cast must fall
+/// through to the legal face-up Foretell cast for {1}.
+///
+/// Discriminating: the variant-less projection prices {3}, offers/auto-routes
+/// the face-down cast, and the payment then fails — the accepted action dies.
+#[test]
+fn an_unpayable_exile_raise_withholds_the_face_down_offer() {
+    let (mut runner, morph) = exile_morph_with_competing_permissions(3);
+
+    assert!(
+        cast(&mut runner, morph),
+        "the cast must be accepted (face up via Foretell)"
+    );
+    assert!(
+        runner.state().objects[&morph].zone == Zone::Stack
+            && !runner.state().objects[&morph].face_down,
+        "with the {{5}} unpayable the legal cast is the FACE-UP foretell one"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -235,6 +235,7 @@ mod extract_power_each_player_exile;
 mod exuberant_wolfbear_base_pt_target;
 mod eyetwitch_learn_decline_lesson;
 mod face_down_cause_marker;
+mod face_down_spell_cost_filter;
 mod fact_or_fiction_pile_separation;
 mod fantastic_four_bounded_loop;
 mod fateful_handoff_target_mana_value_draw;


### PR DESCRIPTION
Fixes #7769.

**Defect.** CR 708.4 puts a face-down spell on the stack as a real spell, but the live cost seam projects the spell into a `SpellCastRecord`, and `FilterProp::FaceDown` failed closed against that record — grouped with battlefield-only predicates. "Face-down creature spells you cast cost {N} less" never matched anything.

**Fix (three parts).**
1. `GameObject::spell_is_cast_face_down()` — #5171's discriminator (`face_down && back_face.is_some()`, exact against foretell/hideaway and printed DFC back faces) as a named method; the restricted-mana payment seam (`build_spell_meta`) and the filter projection now ask the same authority.
2. `restrictions::live_spell_cast_record_for` — the two live projections (filter.rs, cast-limit filter) hardcoded `CastingVariant::Normal`; they now report the variant the object itself evidences. `FilterProp::FaceDown` reads `cast_variant == FaceDown`.
3. `effective_face_down_cast_cost` / `displayed_face_down_cast_cost` — the offer was judged (and displayed) against the printed {3}; it now runs the same modifier passes as the real cast, so a reduction to {0} is castable with an empty pool and the `AlternativeCastChoice` menu carries the reduced cost.

**Class** (measured against card-data.json): 3 cards — Kadena, Slinking Sorcerer; Dream Chisel; Obscuring Aether.

**Tests.** 7 regressions in `tests/integration/face_down_spell_cost_filter.rs`. Counter-proof: with `FilterProp::FaceDown` back to `false`, three fail (`left: 0, right: 3`); with the offer-side modifier pass removed, `kadena_lets_a_face_down_creature_be_cast_with_an_empty_pool` fails alone. `a_face_up_creature_spell_is_not_reduced` and `off_color_mana_pays_the_generic_face_down_cost` pin behaviour, they do not evidence this fix. Full suites: `--lib` 19552, `--test integration` 5367, 0 failed. Playtested: first face-down cast free under Kadena, the second costs {3} again.

**Not covered.**
- A morph card whose printed cost is unaffordable is still not offered at all — own defect in candidate generation, filed as #7770 with measurements.
- `zone_change_record_matches_property` still fails closed on `FilterProp::FaceDown`; no measured card needs a face-down predicate against a zone-change snapshot.
- The per-turn cast-limit filter is routed through the same authority for consistency; 0 cards carry `FilterProp::FaceDown` in a cast restriction, so that half changes no card's behaviour today.
- The offer resolves modifiers with no casting-variant context — exact for this class (the object evidences the variant); 5 cards use a variant-keyed reduction, all Flashback, none reachable from a face-down offer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Face-down spells now consistently recognize their casting state without affecting concealed cards or face-down permanents.
  * Cost reductions and increases now correctly affect affordability, alternative costs, and displayed casting options, including reductions to zero.
  * Face-down spells cast from exile now retain their status on the stack, while other face-down exile designations clear correctly.

* **Tests**
  * Added coverage for cost modifiers, payment options, first-per-turn restrictions, alternative costs, exile permissions, and face-up spells remaining unaffected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->