### PR TITLE
fix: normalize catalog-token self-references before parsing

### DIFF
--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -4370,6 +4370,12 @@ fn catalog_rules_text_abilities(
     Vec<ContinuousModification>,
     Vec<String>,
 ) {
+    // CR 201.5 + CR 201.5a: A card's Oracle text uses its name to refer to
+    // itself, and a granted ability that refers to its granter by name refers
+    // only to that specific granter. Token catalog rules text is parsed
+    // independently of `parse_oracle_ir`'s single entry point, so it needs its
+    // own `normalize_card_name_refs` pass here, mirroring `parse_oracle_ir`'s
+    // call in `oracle.rs`.
     let rules_text = crate::parser::oracle_util::normalize_card_name_refs(rules_text, card_name);
     let mut static_definitions = Vec::new();
     let mut modifications = Vec::new();
@@ -4395,6 +4401,10 @@ fn catalog_rules_text_abilities(
             );
         }
     }
+    // CR 201.5a: catch any residual `GRANTING_SELF_PLACEHOLDER` left in the
+    // parsed statics'/modifications' display `description`s, mirroring
+    // `scrub_granting_placeholder_descriptions`'s whole-tree sweep in
+    // `oracle.rs` for this independent parse entry point.
     for def in &mut static_definitions {
         crate::parser::oracle::scrub_static_descriptions(def);
     }
@@ -8855,12 +8865,31 @@ mod tests {
     /// the granted ability's description before it ever reaches the host.
     ///
     /// Revert-to-red: reverting the `card_name` threading in
-    /// `catalog_rules_text_abilities` (Step 2) makes the sacrifice cost bind
-    /// to the host instead of Rock — `host` would be sacrificed (and,
-    /// being a nontoken permanent, land observably in the graveyard) while
-    /// Rock would stay on the battlefield untouched; reverting only the
-    /// scrub pass (Step 1) would leave the raw placeholder character in the
-    /// description instead.
+    /// `catalog_rules_text_abilities` (Step 2) does NOT bind the sacrifice
+    /// cost to the host. Verified empirically (temporarily disabling the
+    /// `normalize_card_name_refs` call and printing the resulting cost): it
+    /// produces a generic, UNBOUND
+    /// `AbilityCost::Sacrifice(SacrificeCost { target: Typed(TypedFilter {
+    /// type_filters: [], controller: None, properties: [] }), .. })` that
+    /// matches any permanent, not a host-bound `SelfRef`. Because that filter
+    /// is unconstrained, `pay_with(&[rock_id])` below still succeeds even
+    /// under the reverted code (Rock trivially satisfies "any permanent"),
+    /// and the runtime activate/pay/resolve assertions still pass — they
+    /// exercise that the grant-and-activate mechanism works end-to-end (a
+    /// real but separate property), not the granter-binding regression
+    /// itself. The pre-activation `TargetFilter` equality assertion
+    /// immediately below is the one check in this test that is actually
+    /// load-bearing for this regression.
+    ///
+    /// For the placeholder-leak assertion: Rock's granted ability is a
+    /// granted *activated* ability, routed through `parse_quoted_ability`
+    /// (`oracle_static/grammar.rs`), which already calls its own
+    /// `sanitize_granting_placeholder` independent of the two scrub loops
+    /// added to `catalog_rules_text_abilities` in this diff — so disabling
+    /// only those two loops does not reproduce a leak here. See
+    /// `catalog_synthetic_equipment_grant_trigger_scrub_removes_placeholder`
+    /// for the case (a granted TRIGGER, with no independent scrubber) that
+    /// actually exercises the new scrub loops.
     #[test]
     fn catalog_toggo_rock_sacrifice_cost_binds_to_rock_not_host() {
         use crate::game::scenario::{GameScenario, P0, P1};
@@ -8941,6 +8970,90 @@ mod tests {
             outcome.zone_of(host),
             Zone::Battlefield,
             "the equipped creature survives"
+        );
+    }
+
+    /// CR 201.5a: proves the two `scrub_static_descriptions` /
+    /// `scrub_modification_descriptions` loops at the end of
+    /// `catalog_rules_text_abilities` actually do something. Rock's own test
+    /// above (a granted *activated* ability, routed through
+    /// `parse_quoted_ability`) is scrubbed independently by that grammar's own
+    /// `sanitize_granting_placeholder` call and does not exercise these two
+    /// loops. A granted *trigger* has no such independent scrubber, so this
+    /// synthetic Equipment's granted "Whenever this creature attacks,
+    /// sacrifice <self>" trigger — parsed via `parse_static_line_multi` →
+    /// `classify_quoted_inner`'s `GrantTrigger` branch, never touching
+    /// `parse_quoted_ability` — is the case that actually needs the new
+    /// scrub loops.
+    ///
+    /// Revert-to-red: commenting out the two scrub loops (while leaving
+    /// `normalize_card_name_refs` intact) leaves the raw
+    /// `GRANTING_SELF_PLACEHOLDER` char in the granted trigger's
+    /// `description`, flipping the no-leak assertion below to a failure.
+    #[test]
+    fn catalog_synthetic_equipment_grant_trigger_scrub_removes_placeholder() {
+        let (static_definitions, _modifications, unparsed_lines) = catalog_rules_text_abilities(
+            "Equipped creature has \"Whenever this creature attacks, sacrifice Ember Golem.\"",
+            "Ember Golem",
+        );
+        assert!(
+            unparsed_lines.is_empty(),
+            "line must fully parse, got unparsed: {unparsed_lines:?}"
+        );
+
+        fn find_grant_trigger(def: &StaticDefinition) -> Option<&TriggerDefinition> {
+            def.modifications.iter().find_map(|m| match m {
+                ContinuousModification::GrantTrigger { trigger } => Some(trigger.as_ref()),
+                _ => None,
+            })
+        }
+
+        let trigger = static_definitions
+            .iter()
+            .find_map(find_grant_trigger)
+            .unwrap_or_else(|| {
+                panic!(
+                    "quoted \"Whenever ...\" body must parse to a GrantTrigger, \
+                     got {static_definitions:?}"
+                )
+            });
+
+        let sacrifices_granter = trigger.execute.as_deref().is_some_and(|def| {
+            matches!(
+                *def.effect,
+                Effect::Sacrifice {
+                    target: TargetFilter::GrantingObject,
+                    ..
+                }
+            )
+        });
+        assert!(
+            sacrifices_granter,
+            "the granted trigger's sacrifice effect must target the GRANTING object \
+             (the equipment itself), got {trigger:?}"
+        );
+
+        // NOTE: check the actual `description` fields directly, NOT a
+        // `{:?}`-formatted dump of the tree — `Debug` escapes the raw private-use
+        // char to the literal text `\u{e0002}`, so searching a Debug string for
+        // the real character is always false regardless of whether scrubbing ran.
+        let placeholder = crate::parser::oracle_util::GRANTING_SELF_PLACEHOLDER;
+        let leaked = static_definitions.iter().any(|def| {
+            def.description
+                .as_deref()
+                .is_some_and(|d| d.contains(placeholder))
+                || def.modifications.iter().any(|m| match m {
+                    ContinuousModification::GrantTrigger { trigger } => trigger
+                        .description
+                        .as_deref()
+                        .is_some_and(|d| d.contains(placeholder)),
+                    _ => false,
+                })
+        });
+        assert!(
+            !leaked,
+            "the new scrub loops must remove the raw placeholder char from the \
+             granted trigger's description, got {static_definitions:#?}"
         );
     }
 

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -157,7 +157,7 @@ fn materialize_catalog_token_payload(
     materialized.source = TokenAbilitySource::CatalogRulesText;
     materialized.rules_text = Some(rules_text.to_string());
     let (static_definitions, modifications, unparsed_lines) =
-        catalog_rules_text_abilities(rules_text);
+        catalog_rules_text_abilities(rules_text, &preset.body.display_name);
     materialized.static_definitions = static_definitions;
     materialized.unparsed_rules_text_lines = unparsed_lines;
 
@@ -4364,11 +4364,13 @@ fn apply_token_ability_payload(obj: &mut GameObject, materialized: TokenAbilityM
 
 fn catalog_rules_text_abilities(
     rules_text: &str,
+    card_name: &str,
 ) -> (
     Vec<StaticDefinition>,
     Vec<ContinuousModification>,
     Vec<String>,
 ) {
+    let rules_text = crate::parser::oracle_util::normalize_card_name_refs(rules_text, card_name);
     let mut static_definitions = Vec::new();
     let mut modifications = Vec::new();
     let mut unparsed_lines = Vec::new();
@@ -4392,6 +4394,12 @@ fn catalog_rules_text_abilities(
                     .map(normalized_token_static_definition),
             );
         }
+    }
+    for def in &mut static_definitions {
+        crate::parser::oracle::scrub_static_descriptions(def);
+    }
+    for modification in &mut modifications {
+        crate::parser::oracle::scrub_modification_descriptions(modification);
     }
     (static_definitions, modifications, unparsed_lines)
 }
@@ -8448,6 +8456,7 @@ mod tests {
              This creature can't block.\n\
              {T}: Add {G}.\n\
              When this creature dies, you gain 1 life.",
+            "Test Card",
         );
         assert!(unparsed_lines.is_empty());
 
@@ -8480,6 +8489,102 @@ mod tests {
                 ContinuousModification::GrantTrigger { .. }
             )),
             "trigger rules text must route to GrantTrigger, got {modifications:?}"
+        );
+    }
+
+    /// Revert-to-red: removing the `card_name` threading in
+    /// `catalog_rules_text_abilities` reverts this to `TriggerMode::Unknown`
+    /// with the raw text, since the bare "galactus attacks..." subject
+    /// matches no recognized pattern and falls through to the terminal
+    /// fallback.
+    #[test]
+    fn catalog_galactus_preset_trigger_subject_normalizes() {
+        let (_statics, modifications, _unparsed_lines) = catalog_rules_text_abilities(
+            "Flying, trample\nWhenever Galactus attacks, destroy target land.",
+            "Galactus",
+        );
+
+        assert!(
+            modifications.iter().any(|modification| matches!(
+                modification,
+                ContinuousModification::GrantTrigger { trigger }
+                    if trigger.mode == TriggerMode::Attacks
+                        && trigger.valid_card == Some(TargetFilter::SelfRef)
+            )),
+            "card-name subject in an attack trigger must normalize to a \
+             self-referential TriggerMode::Attacks, got {modifications:?}"
+        );
+    }
+
+    /// Revert-to-red: without normalization, no `StaticDefinition` is
+    /// produced for this line at all (`parse_self_color_subject`'s `alt()`
+    /// doesn't match the bare name "Mechtitan"), and the CDA silently
+    /// vanishes into an inert `GrantAbility` instead.
+    #[test]
+    fn catalog_mechtitan_preset_cda_subject_normalizes() {
+        let (static_definitions, _modifications, _unparsed_lines) = catalog_rules_text_abilities(
+            "Mechtitan is all colors.\nFlying, vigilance, trample, lifelink, haste",
+            "Mechtitan",
+        );
+
+        assert!(
+            static_definitions.iter().any(|def| {
+                def.characteristic_defining
+                    && def.affected == Some(TargetFilter::SelfRef)
+                    && def.modifications.iter().any(|modification| matches!(
+                        modification,
+                        ContinuousModification::SetColor { colors }
+                            if colors.len() == 5
+                    ))
+            }),
+            "card-name subject in a CDA color-setting static must normalize to a \
+             self-referential characteristic-defining SetColor{{all 5 colors}}, got {static_definitions:?}"
+        );
+    }
+
+    /// Revert-to-red: without normalization, the effect's target is
+    /// `TargetFilter::Any` (the unconsumed literal name falls through
+    /// `parse_target`'s terminal fallback), meaning the token would copy
+    /// any legal target instead of itself.
+    #[test]
+    fn catalog_council_of_reeds_preset_copy_effect_normalizes() {
+        let (_statics, modifications, _unparsed_lines) = catalog_rules_text_abilities(
+            "The \"legend rule\" doesn't apply to creatures you control.\n\
+             At the beginning of combat on your turn, if you've cast a noncreature \
+             spell this turn, create a token that's a copy of Council of Reeds.\n\
+             (This token's mana cost is {2}{U}.)",
+            "Council of Reeds",
+        );
+
+        fn ability_has_self_copy(def: &AbilityDefinition) -> bool {
+            matches!(
+                *def.effect,
+                Effect::CopyTokenOf {
+                    target: TargetFilter::SelfRef,
+                    ..
+                }
+            ) || def
+                .sub_ability
+                .as_deref()
+                .is_some_and(ability_has_self_copy)
+                || def
+                    .else_ability
+                    .as_deref()
+                    .is_some_and(ability_has_self_copy)
+                || def.mode_abilities.iter().any(ability_has_self_copy)
+        }
+
+        assert!(
+            modifications.iter().any(|modification| matches!(
+                modification,
+                ContinuousModification::GrantTrigger { trigger }
+                    if trigger
+                        .execute
+                        .as_deref()
+                        .is_some_and(ability_has_self_copy)
+            )),
+            "card-name copy-of subject must normalize to a self-referential \
+             CopyTokenOf, got {modifications:?}"
         );
     }
 
@@ -8740,6 +8845,103 @@ mod tests {
         assert!(equip
             .activation_restrictions
             .contains(&ActivationRestriction::AsSorcery));
+    }
+
+    /// CR 201.5a end-to-end proof: Toggo's Rock grants the equipped creature
+    /// "{1}, {T}, Sacrifice Rock: This creature deals 2 damage to any
+    /// target." Rock (the card literally named in the cost) must be the
+    /// object sacrificed — not the host it's equipped to — and the scrub
+    /// pass (Step 1) must have removed the raw placeholder character from
+    /// the granted ability's description before it ever reaches the host.
+    ///
+    /// Revert-to-red: reverting the `card_name` threading in
+    /// `catalog_rules_text_abilities` (Step 2) makes the sacrifice cost bind
+    /// to the host instead of Rock — `host` would be sacrificed (and,
+    /// being a nontoken permanent, land observably in the graveyard) while
+    /// Rock would stay on the battlefield untouched; reverting only the
+    /// scrub pass (Step 1) would leave the raw placeholder character in the
+    /// description instead.
+    #[test]
+    fn catalog_toggo_rock_sacrifice_cost_binds_to_rock_not_host() {
+        use crate::game::scenario::{GameScenario, P0, P1};
+        use crate::types::mana::{ManaType, ManaUnit};
+
+        fn sacrifice_target(cost: &AbilityCost) -> Option<&TargetFilter> {
+            match cost {
+                AbilityCost::Sacrifice(sac) => Some(&sac.target),
+                AbilityCost::Composite { costs } | AbilityCost::OneOf { costs } => {
+                    costs.iter().find_map(sacrifice_target)
+                }
+                _ => None,
+            }
+        }
+
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        scenario.with_mana_pool(
+            P0,
+            vec![ManaUnit::new(ManaType::White, ObjectId(0), false, vec![])],
+        );
+        let host = scenario.add_creature(P0, "Bearer", 2, 2).id();
+
+        let mut runner = scenario.build();
+        let rock_id = build_catalog_token(
+            runner.state_mut(),
+            "Rock",
+            "1657233e-c9e1-54ff-aa5a-6e2e2846be42",
+        );
+        {
+            let st = runner.state_mut();
+            st.objects.get_mut(&rock_id).unwrap().attached_to = Some(AttachTarget::Object(host));
+            st.layers_dirty.mark_full();
+        }
+        crate::game::layers::evaluate_layers(runner.state_mut());
+
+        let idx = runner.state().objects[&host]
+            .abilities
+            .iter()
+            .position(|a| a.cost.as_ref().and_then(sacrifice_target).is_some())
+            .expect("host must carry Rock's granted sacrifice-cost ability after evaluate_layers");
+
+        assert_eq!(
+            runner.state().objects[&host].abilities[idx]
+                .cost
+                .as_ref()
+                .and_then(sacrifice_target),
+            Some(&TargetFilter::SpecificObject { id: rock_id }),
+            "CR 201.5a: the sacrifice cost must target Rock (the granting object), not the host"
+        );
+        assert!(
+            !runner.state().objects[&host].abilities[idx]
+                .description
+                .as_deref()
+                .unwrap_or_default()
+                .contains(crate::parser::oracle_util::GRANTING_SELF_PLACEHOLDER),
+            "granted ability description must not leak the raw placeholder char"
+        );
+
+        let outcome = runner
+            .activate(host, idx)
+            .target_player(P1)
+            .pay_with(&[rock_id])
+            .resolve();
+
+        // CR 111.7 + CR 704.5d: Rock is a token, so once it's sacrificed off the
+        // battlefield it ceases to exist as a state-based action and is purged
+        // from `state.objects` entirely — it never sits observably in the
+        // graveyard the way a card-backed permanent would (contrast
+        // `deconstruction_hammer_sacrifice_hits_the_equipment_not_the_host`,
+        // whose Hammer is a real card and persists at `zone_of == Graveyard`).
+        assert!(
+            !outcome.state().objects.contains_key(&rock_id),
+            "Rock (the object actually named in the cost) must be sacrificed and, \
+             being a token, cease to exist"
+        );
+        assert_eq!(
+            outcome.zone_of(host),
+            Zone::Battlefield,
+            "the equipped creature survives"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -7293,6 +7293,9 @@ pub(crate) fn scrub_modification_descriptions(modification: &mut ContinuousModif
         ContinuousModification::GrantStaticAbility { definition } => {
             scrub_static_descriptions(definition)
         }
+        ContinuousModification::GrantReplacement { replacement } => {
+            scrub_replacement_descriptions(replacement)
+        }
         _ => {}
     }
 }

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -7296,7 +7296,65 @@ pub(crate) fn scrub_modification_descriptions(modification: &mut ContinuousModif
         ContinuousModification::GrantReplacement { replacement } => {
             scrub_replacement_descriptions(replacement)
         }
-        _ => {}
+        // Remaining modifications carry no nested ability/trigger/static/
+        // replacement description to scrub — mirrors the exhaustive-match
+        // model in `ability_visit.rs`'s `visit_continuous_mod_scoped`, minus
+        // that walker's `CopyValues` recursion (it copies P/T/color/type
+        // values from a source, not a description-bearing structure, so it
+        // has nothing for this scrubber to reach).
+        ContinuousModification::GrantAllActivatedAbilitiesOf { .. }
+        | ContinuousModification::GrantAllTriggeredAbilitiesOf { .. }
+        | ContinuousModification::CopyValues { .. }
+        | ContinuousModification::CopyChosen
+        | ContinuousModification::SetName { .. }
+        | ContinuousModification::SetTextName { .. }
+        | ContinuousModification::AddPower { .. }
+        | ContinuousModification::AddToughness { .. }
+        | ContinuousModification::SetPower { .. }
+        | ContinuousModification::SetToughness { .. }
+        | ContinuousModification::AddKeyword { .. }
+        | ContinuousModification::AddKeywordWithDerivedCost { .. }
+        | ContinuousModification::RemoveKeyword { .. }
+        | ContinuousModification::RemoveAllAbilities
+        | ContinuousModification::AddType { .. }
+        | ContinuousModification::RemoveType { .. }
+        | ContinuousModification::AddSubtype { .. }
+        | ContinuousModification::RemoveSubtype { .. }
+        | ContinuousModification::SetCardTypes { .. }
+        | ContinuousModification::RemoveAllSubtypes { .. }
+        | ContinuousModification::SetDynamicPower { .. }
+        | ContinuousModification::SetDynamicToughness { .. }
+        | ContinuousModification::SetPowerDynamic { .. }
+        | ContinuousModification::SetToughnessDynamic { .. }
+        | ContinuousModification::AddDynamicPower { .. }
+        | ContinuousModification::AddDynamicToughness { .. }
+        | ContinuousModification::AddDynamicKeyword { .. }
+        | ContinuousModification::AddAllCreatureTypes
+        | ContinuousModification::AddAllBasicLandTypes
+        | ContinuousModification::AddAllLandTypes
+        | ContinuousModification::AddChosenSubtype { .. }
+        | ContinuousModification::AddChosenColor { .. }
+        | ContinuousModification::RemoveChosenKeyword
+        | ContinuousModification::AddChosenKeyword
+        | ContinuousModification::SetColor { .. }
+        | ContinuousModification::AddColor { .. }
+        | ContinuousModification::AddStaticMode { .. }
+        | ContinuousModification::SwitchPowerToughness
+        | ContinuousModification::AssignDamageFromToughness
+        | ContinuousModification::AssignDamageAsThoughUnblocked
+        | ContinuousModification::AssignNoCombatDamage
+        | ContinuousModification::ChangeController
+        | ContinuousModification::SetBasicLandType { .. }
+        | ContinuousModification::SetChosenBasicLandType
+        | ContinuousModification::SetChosenName
+        | ContinuousModification::RetainPrintedTriggerFromSource { .. }
+        | ContinuousModification::RetainPrintedAbilityFromSource { .. }
+        | ContinuousModification::RetainAllOtherAbilitiesFromSource
+        | ContinuousModification::AddSupertype { .. }
+        | ContinuousModification::RemoveSupertype { .. }
+        | ContinuousModification::AddCounterOnEnter { .. }
+        | ContinuousModification::SetStartingLoyalty { .. }
+        | ContinuousModification::RemoveManaCost => {}
     }
 }
 

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -7277,19 +7277,23 @@ fn scrub_trigger_descriptions(trig: &mut TriggerDefinition) {
     }
 }
 
-fn scrub_static_descriptions(st: &mut StaticDefinition) {
+pub(crate) fn scrub_static_descriptions(st: &mut StaticDefinition) {
     scrub_description(&mut st.description);
     for modification in st.modifications.iter_mut() {
-        match modification {
-            ContinuousModification::GrantAbility { definition } => {
-                scrub_ability_descriptions(definition)
-            }
-            ContinuousModification::GrantTrigger { trigger } => scrub_trigger_descriptions(trigger),
-            ContinuousModification::GrantStaticAbility { definition } => {
-                scrub_static_descriptions(definition)
-            }
-            _ => {}
+        scrub_modification_descriptions(modification);
+    }
+}
+
+pub(crate) fn scrub_modification_descriptions(modification: &mut ContinuousModification) {
+    match modification {
+        ContinuousModification::GrantAbility { definition } => {
+            scrub_ability_descriptions(definition)
         }
+        ContinuousModification::GrantTrigger { trigger } => scrub_trigger_descriptions(trigger),
+        ContinuousModification::GrantStaticAbility { definition } => {
+            scrub_static_descriptions(definition)
+        }
+        _ => {}
     }
 }
 

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -26105,3 +26105,40 @@ fn bound_delayed_recalls_are_not_demoted() {
         );
     }
 }
+
+/// CR 201.5a: `scrub_modification_descriptions`'s `GrantReplacement` arm must
+/// reach the nested `ReplacementDefinition`'s description, the same as its
+/// `GrantAbility`/`GrantTrigger`/`GrantStaticAbility` siblings. The production
+/// `GrantReplacement` producer (`leave_battlefield_exile_replacement`) never
+/// carries a description today, so this is a direct unit test of the scrub
+/// function itself rather than an end-to-end parse, proving the sweep is
+/// complete for the day a producer does attach one (or a self-referencing
+/// granted "would leave the battlefield" rider is added).
+///
+/// Revert-to-red: removing the `GrantReplacement` arm (falling through to the
+/// wildcard `_ => {}`) leaves the raw placeholder character in the nested
+/// definition's description, flipping the assertion below to a failure.
+#[test]
+fn scrub_modification_descriptions_reaches_grant_replacement() {
+    let mut replacement = ReplacementDefinition::new(ReplacementEvent::Moved);
+    replacement.description = Some(format!(
+        "If {GRANTING_SELF_PLACEHOLDER} would leave the battlefield, exile it instead."
+    ));
+    let mut modification = ContinuousModification::GrantReplacement {
+        replacement: Box::new(replacement),
+    };
+    scrub_modification_descriptions(&mut modification);
+    let ContinuousModification::GrantReplacement { replacement } = &modification else {
+        panic!("expected GrantReplacement to survive scrubbing unchanged in shape");
+    };
+    assert!(
+        !replacement
+            .description
+            .as_deref()
+            .unwrap()
+            .contains(GRANTING_SELF_PLACEHOLDER),
+        "the scrub loop must remove the raw placeholder char from a granted \
+         replacement's description, got {:?}",
+        replacement.description
+    );
+}


### PR DESCRIPTION
## Summary

Catalog-preset tokens (rules text sourced from `known-tokens.toml`, not from `parse_oracle_text` on a real card) skipped `normalize_card_name_refs` before parsing, so a token whose granted ability self-references its own name — e.g. Rock's "Sacrifice Rock" — never resolved correctly and bound to the wrong object.

## Files changed

- `crates/engine/src/game/effects/token.rs`
- `crates/engine/src/parser/oracle.rs`

## Track

Developer

## LLM

Model: claude-sonnet-5
Tier: Frontier
Thinking: medium (session reasoning_effort=40/100; not manually elevated for this task — noting accurately per §0.1's advisory field rather than claiming "high")

## Implementation method (required)

Method: /engine-implementer

Full pipeline run: 3 rounds of independent plan review (round 1 found unsupported corpus-coverage claims; round 2 added traced representative-sibling tests but was found to rest on a falsified counterexample plus an untested self-reference position, and a test-placement compile blocker; round 3 closed both with live-traced/probed evidence and passed clean), followed by implementation, then 2 rounds of independent `/review-impl` (round 1 found 3 MED findings — missing CR annotation, a vacuous placeholder-leak test, an inaccurate revert-to-red doc comment; round 2 independently re-verified all 3 resolutions from scratch, including compiling a standalone Rust program to confirm a `Debug`-escaping claim and performing live reverts to reproduce both the pass and fail states — clean, no further findings).

## CR references

CR 111.7, CR 201.5, CR 201.5a, CR 704.5d — all verified against `docs/MagicCompRules.txt` before citing.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — clean, no changes.
- `cargo clippy -p phase-engine --all-targets -- -D warnings` — clean, zero warnings.
- `cargo test -p phase-engine` — 24974 passed, 0 failed, 15 ignored (pre-existing/unrelated), 0 measured, across all four binaries (lib unit tests, `tests/integration/main.rs`, `coverage_parse_diff`, `set_check`) — run against the exact committed head below.
- `cargo coverage` — exit 0, no new gaps; not applicable to this change's code path (it audits `client/public/card-data.json`, generated from MTGJSON real-card Oracle text — this diff only touches catalog-token parsing in `token.rs`, which that pipeline never reads).
- `cargo semantic-audit` — exit 0, no crash, aggregate findings unchanged in shape; same not-applicable reasoning as `cargo coverage` above (catalog tokens are not audited "cards").
- `./scripts/check-parser-combinators.sh` — see `## Gate A` below.

## Gate A

Gate A PASS head=ffd177385a2b49c777d3927c87661b540ba8005f base=7514e8f758ee59f25f7652f9bafd5da1af230f9a

## Anchored on

- `crates/engine/src/parser/oracle.rs:4228` — `parse_oracle_ir`'s existing `normalize_card_name_refs(oracle_text, card_name)` call, the single-entry-point normalization pattern this diff mirrors for the catalog-token pipeline's own entry point (`catalog_rules_text_abilities`).
- `crates/engine/src/parser/oracle.rs:7255` / `:7273` — the existing `scrub_ability_descriptions`/`scrub_trigger_descriptions` per-item scrub functions, whose shape (`fn(&mut T)`, one match arm per grantable kind) the new `scrub_modification_descriptions` (extracted from `scrub_static_descriptions`'s existing match arm) directly follows.
- `crates/engine/src/game/effects/token.rs:4388-4390` — `catalog_rules_text_abilities`'s pre-existing calls into `parser::oracle_static::parse_static_line_multi`/`classify_quoted_inner`, the already-established "this game-layer dispatcher calls directly into `parser::*`" pattern the new `parser::oracle_util::normalize_card_name_refs` call and the new `parser::oracle::scrub_*` calls extend.

## Final review-impl

Final review-impl PASS head=ffd177385a2b49c777d3927c87661b540ba8005f

Second independent review round, run against `1a7c7128d..f602ad366` (the fix round) and the full `7514e8f75..f602ad366` diff, verified from scratch rather than trusting prior self-reports: reran the full test suite against the exact committed candidate (24974 passed, 0 failed); independently re-derived that CR 201.4b (mirrored from the pre-existing, unmodified `oracle.rs:4220` citation, itself a real but out-of-scope latent doc bug) is wrong and CR 201.5/201.5a is correct, by grepping `docs/MagicCompRules.txt` directly; independently reverted the two new scrub loops in a scratch worktree and reproduced the new placeholder-leak test's failure (raw `\u{e0002}` visible in the trigger's description) and its pass on restore; independently compiled a standalone Rust program to confirm `format!("{:?}", ...)` escapes the private-use placeholder character (proving the first test draft's Debug-based assertion really was vacuous); independently reverted the `card_name` threading and inspected the actual produced `AbilityCost` to confirm the corrected doc comment's claimed shape (an unbound `Typed` filter, not a host-bound one); confirmed the sole production caller of `catalog_rules_text_abilities` is unchanged (`materialize_catalog_token_payload`); confirmed no scope creep. One new LOW finding, out of scope for this PR: `oracle.rs:4220`'s pre-existing `CR 201.4b` citation is itself wrong (should be `CR 201.5`) — predates this diff, left untouched per scope discipline, worth a trivial separate follow-up.

## Claimed parse impact

None for real-card Oracle text. This diff's `normalize_card_name_refs` call is new to the catalog-token (`known-tokens.toml`) parsing path only — `parse_oracle_text`'s existing real-card entry point and its call to `normalize_card_name_refs` are unmodified.

Within the catalog-token corpus specifically: an exhaustive scan of `known-tokens.toml` found ~30 unique token display names whose `rules_text` self-references their own name. This fix is the first time that text gets any self-reference normalization at all, so — beyond Rock's targeted bug fix — it also corrects previously-silent mis-parses for at least two other catalog tokens exercised by new tests in this diff: **Galactus**'s token ("Whenever Galactus attacks...") now correctly binds `TriggerMode::Attacks` with a self-bound subject instead of silently falling to `TriggerMode::Unknown` (never firing); **Mechtitan**'s token ("Mechtitan is all colors.") now produces a real characteristic-defining static instead of silently vanishing into an inert ability. **Tarmogoyf**'s token was independently confirmed unaffected (its CDA parser is subject-blind by construction). The remaining ~25 catalog-token names in that corpus were not individually re-verified against their specific handler code — flagged as a named, non-blocking residual risk in the underlying plan/review record; the full engine test suite (including all existing tests referencing any of those tokens) passes with 0 failures.

## Scope Expansion

None. Two files, both required by the fix: `token.rs` (the bug's actual location) and `oracle.rs` (visibility bump + a pure extraction of pre-existing logic, needed so the catalog-token path can reach the same placeholder-scrub authority every other entry point already has).

## Validation Failures

None.

## CI Failures

None. (Local `./scripts/setup.sh --agent` bootstrap hit one unrelated environment gap — `wasm-bindgen` CLI not installed, failing only the WASM build step — which is orthogonal to this Rust-engine-only change; `client/public/card-data.json` was already generated successfully before that step ran, so `cargo coverage`/`cargo semantic-audit` above ran against real data.)
