### PR TITLE
docs(engine): cite the right CR rule for `non-` negation

### DIFF
--- a/crates/engine/src/bin/set_check.rs
+++ b/crates/engine/src/bin/set_check.rs
@@ -125,7 +125,7 @@ struct SnapshotEntry {
     gap_count: usize,
 }
 
-/// CR 205.4b: A basic land has the Basic supertype and the Land card type.
+/// CR 205.4c: Any land with the supertype "basic" is a basic land.
 /// Excluded from deck filtering since decks list them in bulk and they carry
 /// no parser surface.
 fn is_basic_land(face: &CardFace) -> bool {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -26670,7 +26670,7 @@ fn type_str_to_target_filter(s: &str) -> Option<TargetFilter> {
         return Some(TargetFilter::Typed(TypedFilter::new(ct)));
     }
 
-    // CR 205.4b: Negated types — "nonland", "noncreature", etc.
+    // CR 205.2a: Negated card types — "nonland", "noncreature", etc.
     if let Some(negated) = s.strip_prefix("non") {
         // Card type negation
         let inner = match negated {

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -7732,7 +7732,7 @@ fn apply_damage_source_qualifier(
     if let Some(color) = parse_color_word(qualifier) {
         props.push(FilterProp::HasColor { color });
     } else if let Ok((rest, _)) = tag::<_, _, OracleError<'_>>("non").parse(qualifier) {
-        // CR 205.4b: "noncreature" qualifier — negation via TypeFilter::Non.
+        // CR 205.2a: "noncreature" qualifier — card-type negation via TypeFilter::Non.
         if tag::<_, _, OracleError<'_>>("token")
             .parse(rest)
             .is_ok_and(|(after, _)| after.is_empty())

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -2501,7 +2501,9 @@ pub fn parse_type_phrase_with_ctx<'a>(
         pos += color_len;
     }
 
-    // CR 205.4b: Parse one or more comma-separated negation prefixes.
+    // CR 109.3: Parse one or more comma-separated negation prefixes. A `non-`
+    // prefix negates exactly one characteristic — card type, subtype, supertype,
+    // or color — and `classify_negation` routes it to the layer that owns it.
     // "noncreature, nonland permanent" → [Non(Creature), Non(Land)] in type_filters
     // "nonartifact, nonblack creature" → Non(Artifact) in type_filters, NotColor("Black") in properties
     //
@@ -3141,7 +3143,7 @@ pub fn parse_type_phrase_with_ctx<'a>(
         }
     }
 
-    // CR 205.3 + CR 205.4b: "that isn't a <Subtype>" relative-clause negation.
+    // CR 205.3: "that isn't a <Subtype>" relative-clause negation.
     // Checked before `parse_that_clause_suffix` so the subtype exclusion short-circuits
     // the generic that-clause branch (which does not recognize subtype negation).
     if let Some((neg_tfs, consumed)) = parse_that_isnt_subtype_suffix(&lower[pos..]) {
@@ -3910,7 +3912,9 @@ enum NegationResult {
     Prop(FilterProp),
 }
 
-/// CR 205.4b: Classify a negated word by semantic layer.
+/// CR 109.3: Classify a negated word by semantic layer. Card type, subtype,
+/// supertype, and color are distinct characteristics, so each negation must be
+/// routed to the one it belongs to.
 /// `parse_non_prefix` strips "non"/"non-" and lowercases, so `negated` is e.g. "black", "basic", "creature".
 fn classify_negation(negated: &str) -> NegationResult {
     if tag::<_, _, OracleError<'_>>("token")
@@ -3955,7 +3959,7 @@ fn classify_negation(negated: &str) -> NegationResult {
         "snow" => NegationResult::Prop(FilterProp::NotSupertype {
             value: Supertype::Snow,
         }),
-        // CR 205.4b: Type/subtype negation → TypeFilter::Non
+        // CR 205.2a + CR 205.3: Card-type / subtype negation → TypeFilter::Non
         _ => {
             let inner = match negated {
                 "creature" => TypeFilter::Creature,
@@ -4017,7 +4021,7 @@ pub(crate) fn starts_with_type_word(text: &str) -> bool {
             return true;
         }
     }
-    // CR 205.4b: Negated type prefix: "noncreature spell", "nonland permanent",
+    // CR 205.2a + CR 205.3: Negated type prefix: "noncreature spell", "nonland permanent",
     // "non-Saga token" (Good King Mog XII chapter II — issue #3294), and
     // negated-adjective compounds like "nontoken modified creature" (Akki
     // Ember-Keeper / issue #3677 class) or "nontoken legendary permanent"
@@ -8101,7 +8105,7 @@ fn parse_except_continuity_exemption_suffix(text: &str) -> Option<(FilterProp, u
     ))
 }
 
-/// CR 205.3 + CR 205.4b: "that isn't a <Subtype>" / "that's not a <Subtype>"
+/// CR 205.3: "that isn't a <Subtype>" / "that's not a <Subtype>"
 /// relative-clause negation suffix. Returns negated type filters to append to
 /// the enclosing target's `neg_type_filters`. Mirrors the `non-<Subtype>`
 /// prefix pattern but expressed as a trailing relative clause
@@ -14280,7 +14284,7 @@ mod tests {
 
     #[test]
     fn nonartifact_nonblack_creature() {
-        // CR 205.4b: "nonartifact" → Non(Artifact) in type_filters, "nonblack" → NotColor in properties
+        // CR 205.2a + CR 105.2: "nonartifact" → Non(Artifact) in type_filters, "nonblack" → NotColor in properties
         let (f, rest) = parse_type_phrase("nonartifact, nonblack creature");
         assert_eq!(
             f,
@@ -17940,7 +17944,7 @@ mod tests {
         assert!(tf.type_filters.contains(&TypeFilter::Creature));
     }
 
-    /// CR 205.2a + CR 205.4b: "noncreature artifact" — negation followed by a
+    /// CR 205.2a: "noncreature artifact" — negation followed by a
     /// concrete core type. The Non(Creature) negation should land in
     /// type_filters alongside Artifact.
     #[test]
@@ -18435,7 +18439,7 @@ mod tests {
         ));
     }
 
-    /// CR 205.3 + CR 205.4b: "target attacking Vampire that isn't a Demon" — the
+    /// CR 205.3: "target attacking Vampire that isn't a Demon" — the
     /// subtype-negation relative clause must append `Non(Subtype("Demon"))` to
     /// the target's type filters so a Vampire Demon is rejected.
     #[test]

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -9302,7 +9302,7 @@ fn trigger_you_cast_legendary_creature_spell() {
     );
 }
 
-/// CR 205.2a + CR 205.4b + CR 601.2: "whenever you cast a noncreature
+/// CR 205.2a + CR 601.2: "whenever you cast a noncreature
 /// artifact spell" — Non(Creature) + Artifact conjunction.
 #[test]
 fn trigger_you_cast_noncreature_artifact_spell() {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -26180,8 +26180,8 @@ pub enum ContinuousModification {
     /// CR 205.4 + CR 707.9d: Add a supertype to the affected object's
     /// supertypes (e.g., Sarkhan, Soul Aflame: "it's legendary in addition
     /// to its other types"). Idempotent: pushing an already-present supertype
-    /// is a no-op. Applied at Layer 4 (CR 613.1d) because supertypes are
-    /// types per CR 205.4b.
+    /// is a no-op. Applied at Layer 4 (CR 613.1d), which covers card type,
+    /// subtype, and supertype changes alike.
     AddSupertype {
         supertype: Supertype,
     },

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -4262,7 +4262,7 @@ pub enum TypeFilter {
     Permanent,
     Card,
     Any,
-    /// CR 205.4b: Negation — matches objects whose type does NOT match the inner filter.
+    /// CR 205.2a + CR 205.3: Negation — matches objects whose type does NOT match the inner filter.
     /// "noncreature" → `Non(Box::new(Creature))`, "non-Human" → `Non(Box::new(Subtype("Human")))`
     Non(Box<TypeFilter>),
     /// CR 205.3: Matches objects with a specific subtype (creature type, land type, etc.).
@@ -5005,7 +5005,7 @@ pub enum FilterProp {
     /// stack object's static printed modality (`obj.modal.is_some()`), a printed
     /// characteristic present from object creation.
     Modal,
-    /// CR 205.4b: Matches objects that do NOT have a specific color.
+    /// CR 105.2: Matches objects that do NOT have a specific color.
     /// Parallel to `HasColor` — used for "nonblack", "nonwhite" in negation stacks.
     NotColor {
         color: ManaColor,

--- a/crates/engine/src/types/layers.rs
+++ b/crates/engine/src/types/layers.rs
@@ -145,6 +145,9 @@ impl ContinuousModification {
             | ContinuousModification::RemoveAllAbilities
             | ContinuousModification::AddStaticMode { .. }
             | ContinuousModification::GrantStaticAbility { .. } => Layer::Ability,
+            // CR 613.1d (Layer 4): type-changing effects cover an object's card
+            // type, subtype, and/or supertype alike. Every arm below changes one
+            // of those three, so they all resolve in the same layer.
             ContinuousModification::AddType { .. }
             | ContinuousModification::RemoveType { .. }
             | ContinuousModification::SetCardTypes { .. }
@@ -158,7 +161,7 @@ impl ContinuousModification {
             | ContinuousModification::AddAllLandTypes
             | ContinuousModification::AddChosenSubtype { .. }
             | ContinuousModification::SetBasicLandType { .. }
-            | ContinuousModification::SetChosenBasicLandType => Layer::Type, // CR 613.1d + CR 205.4b
+            | ContinuousModification::SetChosenBasicLandType => Layer::Type,
             // CR 122.1 + CR 614.1c: One-shot counter placement at copy
             // resolution. Consumed by the BecomeCopy / CopyTokenOf resolvers
             // before any continuous-effect machinery is reached. Reaching this


### PR DESCRIPTION
Follow-up to the deferred item on [#7472](https://github.com/phase-rs/phase/pull/7472#issuecomment-5388839692).

## Problem

`CR 205.4b` reads:

> An object's supertype is independent of its card type and subtype, even though some supertypes are closely identified with specific card types. Changing an object's card types or subtypes won't change its supertypes. […]

It is the supertype-independence rule. It was being cited for two things it does not say:

1. **`non-` negation** — the rule says nothing about negation at all.
2. **"supertypes belong in the type layer"** — 205.4b says supertypes are *independent* of card type and subtype, which is close to the opposite claim.

A wrong CR number is worse than none: it reads as "verified" against a rule that does not cover the code.

## Commit 1 — negation sites

Per-site calls, not a sweep — as flagged on #7472, the correct rule depends on **which characteristic** is being negated. `CR 109.3` enumerates them (name, mana cost, color, …, card type, subtype, supertype, …), and the parser's negation path is precisely a dispatch across that list.

| Negation | Example | Citation |
|---|---|---|
| Card type | `noncreature`, `nonland`, `nonartifact` | `CR 205.2a` |
| Subtype | `non-Saga`, `that isn't a Demon` | `CR 205.3` |
| Color | `nonblack`, `nonwhite` | `CR 105.2` |
| Layer dispatch | `classify_negation`, the stacked-prefix loop | `CR 109.3` |
| Supertype | `nonbasic`, `nonlegendary`, `nonsnow` | `CR 205.4a` — already correct, untouched |

14 sites across 5 files:

- `parser/oracle_target.rs` — 9 (the set counted on #7472)
- `types/ability.rs` — 2 (`TypeFilter::Non`, `FilterProp::NotColor`)
- `parser/oracle_effect/mod.rs`, `parser/oracle_replacement.rs`, `parser/oracle_trigger_tests.rs` — 1 each

The #7472 thread scoped this to `oracle_target.rs`; the same misattribution turned out to sit in four more files, including the `TypeFilter::Non` and `FilterProp::NotColor` variant docs — arguably the most load-bearing spots, since they define the types the parser emits. Fixing 9 of 14 would have left the citation untrustworthy, so the whole negation class is covered.

## Commit 2 — Layer-4 sites

`CR 613.1d` already states that Layer 4 covers "an object's card type, subtype, and/or supertype", so it is self-sufficient wherever it appears; the `+ CR 205.4b` pairing added nothing and asserted the wrong thing.

- **`types/layers.rs`** — the `Layer::Type` match arm spans card types, subtypes *and* supertypes (`AddType` … `SetChosenBasicLandType`), so `CR 613.1d` alone is correct. Promoted the trailing `//` to a described comment block, per the CR annotation rules in CLAUDE.md.
- **`types/ability.rs`** (`AddSupertype`) — dropped the same trailing clause. Its `RemoveSupertype` sibling directly below already reads just "Applied at Layer 4 (CR 613.1d)"; the pair is now consistent.
- **`bin/set_check.rs`** — `CR 205.4c` ("Any land with the supertype 'basic' is a basic land") states `is_basic_land`'s predicate exactly, where `205.4b` did not.

## Result

All 16 `CR 205.4b` citations left in the crate genuinely refer to supertype independence — snow-source layering, world/legend SBA base-characteristic reads, and the supertype grant/removal parser paths.

## Verification

- Every citation used (`105.2`, `109.3`, `205.2a`, `205.3`, `205.4b`, `205.4c`, `601.2`, `613.1d`) grepped against `docs/MagicCompRules.txt`.
- `cargo fmt --all --check` clean.
- `cargo check -p phase-engine --all-targets` clean.
- Comment-only diff — no behavior change, no card movement, no coverage delta.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing for “from among” counter lists and reordered counter-selection wording.
  * Correctly handles permanent-duration effects for aura reanimation and related generic effects.
  * Improved power and toughness distribution across alternative card-type conditions, limiting assignments to eligible creature-related conditions.
  * Prevents misplaced power/toughness effects from being removed when they can be reassigned appropriately.

* **Documentation**
  * Updated rules references and clarified guidance for card types, basic lands, and type-changing effects.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->