### PR TITLE
docs(client): name Misdirection, not Redirect, as the single-target retarget

### DIFF
--- a/client/src/components/targeting/TargetingOverlay.tsx
+++ b/client/src/components/targeting/TargetingOverlay.tsx
@@ -93,7 +93,7 @@ export function TargetingOverlay() {
   // CHOICE (not a target), but the action shape mirrors ExploreChoice
   // (`GameAction::ChooseTarget` with the chosen ObjectId).
   const isReturnAsAuraTarget = waitingFor?.type === "ReturnAsAuraTarget";
-  // CR 115.7: Single-target retargets (Bolt Bend, Redirect) are picked on the
+  // CR 115.7: Single-target retargets (Bolt Bend, Misdirection) are picked on the
   // board through this overlay; multi-target retargets keep the dialog.
   const isRetargetChoice = waitingFor?.type === "RetargetChoice" && waitingFor.data.scope.type === "Single";
   // CR 115.7: Name the spell/ability being retargeted (the entry the redirect

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1943,7 +1943,7 @@ function GamePageContent({
         {/* Ability choice picker (planeswalkers, multi-ability permanents) */}
         <AbilityChoiceModal />
 
-        {/* Player-attached Aura viewer (Curse cycle, Faith's Fetters, etc.).
+        {/* Player-attached Aura viewer (Curse cycle, Paradox Haze, etc.).
             Mounted here — not from inside HudPlate where the badge lives —
             so the dialog's `fixed inset-0` shell anchors to the viewport
             instead of HudPlate's transform-CB bounding box. */}


### PR DESCRIPTION
`TargetingOverlay` gates on `waitingFor.data.scope.type === "Single"`, but cited **Redirect** as an example of that branch. Verified against MTGJSON:

| Card | Oracle text | Scope |
|---|---|---|
| Redirect | "You may **choose new targets** for target spell." | **All** — CR 115.7d |
| Misdirection | "**Change the target** of target spell **with a single target**." | Single — CR 115.7a |
| Bolt Bend | "**Change the target** of target spell or ability **with a single target**." | Single — CR 115.7a |

Redirect is the All-scope branch this overlay deliberately does *not* handle, so it was the one card that couldn't illustrate the gate. Both CR subsections were confirmed present in `docs/MagicCompRules.txt` (lines 863 and 869).

Also drops the last surviving Faith's Fetters citation, in GamePage's mounting comment for `PlayerEnchantmentsDialog`. Faith's Fetters is `Enchant { Typed { type_filters: ["Permanent"] } }` and can never attach to a player; Paradox Haze is `Enchant { Player }`.

These two files were held back from #7701 and #7710 because they carried another agent's uncommitted work at the time; that work has since landed, so both were clean.

### Validation

- **Comment-only**, mechanically verified: after stripping block/line/JSX comments, the token stream of both files is identical to the merge base. Checker positive-controlled against a one-character code edit.
- Blobs on this branch are byte-identical to the reviewed local commit.
- Full local suite not re-run; the diff cannot reach the type-checker. CI validates.

https://claude.ai/code/session_01LC5MnFWa3NwmqcFTECw96K