### PR TITLE
fix(client): correct a false type-safety claim and the es/pt target-noun composition

### DIFF
--- a/client/src/components/targeting/TargetingOverlay.tsx
+++ b/client/src/components/targeting/TargetingOverlay.tsx
@@ -41,9 +41,18 @@ type TargetNounKey =
   | "targeting.nounTarget";
 
 /**
- * CR 109.1: every engine object category gets a noun. TOTAL by construction —
- * a `Record` over the mirror union, so adding a category engine-side without a
- * client noun is a type error at `pnpm run type-check`, not a runtime fallback.
+ * CR 109.1: every engine object category gets a noun. TOTAL over the mirror
+ * union — a `Record`, so widening the union without adding a noun here is a
+ * type error at `pnpm run type-check`, not a runtime fallback.
+ *
+ * That totality stops at the language boundary, and this comment used to claim
+ * otherwise. The union above is hand-written: `derived_views.rs` carries no
+ * `ts_rs` binding (the crate does have one, on `types/interaction.rs` —
+ * `DerivedViews` deliberately does not use it), so adding a
+ * `TargetObjectCategory` variant engine-side compiles, leaves the union
+ * untouched, keeps this `Record` total, and ships green while the engine emits
+ * a category no key covers. Widening the enum means widening the union in the
+ * same change; nothing mechanical will remind you.
  *
  * The VALUE type is `TargetNounKey`, not `string`: `t()` accepts a plain
  * `string` in this repo, so a mistyped key would otherwise ship green and

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -788,7 +788,7 @@
     "nounPlaneswalker": "planeswalker",
     "nounTargetPermanent": "permanente objetivo",
     "nounTarget": "objetivo",
-    "nounOrPlayer": "{{noun}} o jugador",
+    "nounOrPlayer": "{{noun}} o un jugador",
     "confirmTap": "Confirmar giro ({{selected}}/{{count}})",
     "keepCurrentTargets": "Conservar objetivos actuales",
     "skip": "Omitir",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -788,7 +788,7 @@
     "nounPlaneswalker": "planeswalker",
     "nounTargetPermanent": "permanente alvo",
     "nounTarget": "alvo",
-    "nounOrPlayer": "{{noun}} ou jogador",
+    "nounOrPlayer": "{{noun}} ou um jogador",
     "confirmTap": "Confirmar Virar ({{selected}}/{{count}})",
     "keepCurrentTargets": "Manter Alvos Atuais",
     "skip": "Pular",

--- a/client/src/i18n/resources.test.ts
+++ b/client/src/i18n/resources.test.ts
@@ -141,9 +141,26 @@ describe("targeting article agreement (#7692)", () => {
     });
   });
 
-  // German is DECLINED on the record (three-way gender has no two-way bracket
-  // analogue) and Polish carries no article. Pinned so the decline is a decision
-  // in the tree, not an omission a later reader repairs by guessing.
+  // Both DECLINED, for different reasons, and neither decline means "correct".
+  //
+  // de: the it/pt bracket hedge has no analogue here — `eine` is feminine, not
+  // ungendered, and three-way gender has no two-way bracket. So `one` disagrees
+  // with every masculine or neuter noun: `nounPlaneswalker`, `nounPlayer`,
+  // `nounSpell` and `nounTarget` all render "eine <masc/neut>". #7692 WIDENED
+  // that cost rather than creating it — `nounPlaneswalker` was effectively
+  // unreachable before, because the old client-side inference tested "no Land"
+  // ahead of the planeswalker branch, so an ordinary planeswalker rendered
+  // `nounNonlandPermanent`, which is feminine and agreed. Repairing German needs
+  // case-aware phrasing (`one` and `upToOne` do not even govern the same case),
+  // not a bracket. Not attempted here.
+  //
+  // pl: `one` carries no article and IS correct, which is the half pinned below.
+  // `upToOne` is not — "do jednego" governs the genitive while every noun value
+  // is nominative, so all of them are ungrammatical there. Deliberately left
+  // unpinned: pinning a string that is known-wrong would record it as intended.
+  //
+  // Pinned so each decline is a decision in the tree, not an omission a later
+  // reader repairs by guessing.
   it("leaves the de and pl articles untouched", () => {
     expect(resources.de.game).toMatchObject({ targeting: { one: "eine {{target}}" } });
     expect(resources.pl.game).toMatchObject({ targeting: { one: "{{target}}" } });


### PR DESCRIPTION
Follow-ups from the #7692 run's integration review. All three are accuracy
fixes; no behaviour changes beyond two Spanish/Portuguese UI strings.

1. TargetingOverlay.tsx claimed the `TARGET_NOUN_KEY` Record made "adding a
   category engine-side without a client noun ... a type error at
   `pnpm run type-check`". It does not. The Record is total over the
   hand-written TS mirror union, and nothing generates that union from the Rust
   enum: `crates/engine/src/game/derived_views.rs` carries zero `ts_rs`
   occurrences, while the crate does have the binding elsewhere
   (`types/interaction.rs`, 61 occurrences) — so `DerivedViews` opts out
   deliberately. Adding `TargetObjectCategory::Land` compiles, leaves the union
   untouched, keeps the Record total, and ships green while the engine emits a
   category no key covers. The same comment block already said the union "is
   hand-written and so is checked against itself", so it contradicted itself
   internally. `derived_views.rs` states the true position ("no generated
   binding to force agreement"); the TS side now matches it.

   This matters because the charter deferred the Land/Battle/StackAbility
   categories ON that guarantee. A deferral resting on a mechanism that does not
   exist is the part worth fixing.

2. es/pt `nounOrPlayer` composed into a misparse. Both locales render
   `nounNonlandPermanent` as a relative clause, so "{{noun}} o jugador" gave
   "un(a) permanente que no sea tierra o jugador" — "a permanent that is neither
   a land nor a player". Adding the article ("o un jugador" / "ou um jogador")
   blocks attachment into the clause. en/fr use a compound adjective rather than
   a relative clause and have no attachment point, so they were already safe.
   Reachable from any CR 115.4 "any target" offer on a mixed board.

3. The de/pl decline rationales in resources.test.ts read as "these locales are
   fine". They are not. German's `one` is feminine, not ungendered, so it
   disagrees with four of seven nouns; #7692 widened that cost by making
   `nounPlaneswalker` reachable at all (the old inference tested "no Land" ahead
   of the planeswalker branch, so ordinary planeswalkers rendered the feminine
   `nounNonlandPermanent` and agreed by accident). Polish `one` is genuinely
   correct, but `upToOne` governs the genitive against nominative nouns. The
   comments now say which half each pin covers; `pl.upToOne` is left unpinned on
   purpose, since pinning a known-wrong string records it as intended.

German repair needs case-aware phrasing rather than the it/pt bracket hedge and
is not attempted here.

Claude-Session: https://claude.ai/code/session_013eDt2CTWnim1rkaqh7uqF1


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Localization**
  * Improved Spanish targeting text by adding the correct article before “player.”
  * Improved Portuguese targeting text by adding the correct article before “player,” resulting in more natural phrasing.

* **Documentation**
  * Clarified internal guidance for maintaining targeting categories and language-specific grammar tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->