### PR TITLE
fix(client): gate the lobby handshake on the surface, not the server mode

### DIFF
--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -332,7 +332,20 @@ export interface ServerInfo {
 }
 
 /**
- * Why this client cannot talk to `info`, or `null` when it can.
+ * Which protocol surface a socket is opened for.
+ *
+ * The surface is a property of the CALLER's intent, not of the server: a `Full`
+ * server serves both. `ClientMessage::SubscribeLobby` and friends are "always
+ * allowed" in either server mode (`reject_if_disabled` in
+ * `crates/phase-server/src/main.rs`), and the whole lobby frame set —
+ * `LobbyClientMessage` / `LobbyServerMessage` in
+ * `crates/lobby-broker/src/protocol.rs` — carries no `GameState` and no
+ * `GameAction`. That is what lets the two surfaces version independently.
+ */
+export type ProtocolSurface = "full" | "lobby";
+
+/**
+ * Why this client cannot talk to `info` on `surface`, or `null` when it can.
  *
  * SINGLE AUTHORITY for the protocol window. The handshake in
  * `openPhaseSocket.ts` and the compatibility badge in `multiplayerStore.ts`
@@ -340,24 +353,37 @@ export interface ServerInfo {
  * as usable by the other.
  *
  * Three policies, by surface:
- *  - Full servers: exact match. GameState/GameAction payloads are neither
+ *  - Full-game surface: exact match. GameState/GameAction payloads are neither
  *    forward- nor backward-compatible across a bump.
- *  - Lobby brokers advertising a lobby version: floor only, NO CEILING. See
- *    {@link MIN_SUPPORTED_SERVER_LOBBY_PROTOCOL}.
- *  - Lobby brokers that predate the field: the legacy one-version window on
- *    `protocolVersion`, unchanged, so already-deployed brokers stay reachable.
+ *  - Lobby surface, server advertising a lobby version: floor only, NO CEILING.
+ *    See {@link MIN_SUPPORTED_SERVER_LOBBY_PROTOCOL}.
+ *  - Lobby surface, server predating the field: the legacy one-version window
+ *    on `protocolVersion`, unchanged, so already-deployed brokers stay
+ *    reachable.
+ *
+ * The surface comes from the caller, never from `info.mode`. A `Full` server
+ * serves the lobby too, so reading the mode alone refuses a lobby socket to a
+ * server whose `lobbyProtocolVersion` matches and whose only incompatibility is
+ * with a game that socket will never carry — which a browser can only report as
+ * "unreachable", not as "a version you cannot play on".
  */
-export function serverProtocolRejection(info: ServerInfo): string | null {
-  if (info.mode === "LobbyOnly" && info.lobbyProtocolVersion !== undefined) {
+export function serverProtocolRejection(
+  info: ServerInfo,
+  surface: ProtocolSurface = "full",
+): string | null {
+  // A `LobbyOnly` server has no full-game surface at all, so every socket to
+  // one is a lobby socket whatever the caller asked for.
+  const onLobbySurface = surface === "lobby" || info.mode === "LobbyOnly";
+
+  if (onLobbySurface && info.lobbyProtocolVersion !== undefined) {
     return info.lobbyProtocolVersion < MIN_SUPPORTED_SERVER_LOBBY_PROTOCOL
       ? `Lobby protocol version ${info.lobbyProtocolVersion} is older than supported (client speaks ${LOBBY_PROTOCOL_VERSION}, min ${MIN_SUPPORTED_SERVER_LOBBY_PROTOCOL}).`
       : null;
   }
 
-  const minAccepted =
-    info.mode === "LobbyOnly"
-      ? LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL
-      : MIN_SUPPORTED_SERVER_PROTOCOL;
+  const minAccepted = onLobbySurface
+    ? LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL
+    : MIN_SUPPORTED_SERVER_PROTOCOL;
   if (info.protocolVersion < minAccepted) {
     return `Server protocol version ${info.protocolVersion} is older than supported (client speaks ${PROTOCOL_VERSION}, min ${minAccepted}). Please wait for the lobby to finish rolling out.`;
   }

--- a/client/src/services/__tests__/brokerClient.test.ts
+++ b/client/src/services/__tests__/brokerClient.test.ts
@@ -7,6 +7,7 @@ import {
   subscribeLobbyOver,
 } from "../brokerClient";
 import type { LobbyGame } from "../../adapter/types";
+import { PROTOCOL_VERSION, type ServerInfo } from "../../adapter/ws-adapter";
 
 class MockWebSocket extends EventTarget {
   static OPEN = 1;
@@ -28,7 +29,10 @@ class MockWebSocket extends EventTarget {
   }
 }
 
-function makePhaseSocket(ws: MockWebSocket): PhaseSocket {
+function makePhaseSocket(
+  ws: MockWebSocket,
+  serverInfo: Partial<ServerInfo> = {},
+): PhaseSocket {
   return {
     ws: ws as unknown as WebSocket,
     serverInfo: {
@@ -36,6 +40,7 @@ function makePhaseSocket(ws: MockWebSocket): PhaseSocket {
       buildCommit: "test",
       protocolVersion: 1,
       mode: "LobbyOnly",
+      ...serverInfo,
     },
     close: () => ws.close(),
   };
@@ -51,6 +56,61 @@ beforeEach(() => {
       }
     });
   }
+});
+
+describe("resolveGuestOver full-game surface guard", () => {
+  // `JoinGameWithPassword` is the one frame a lobby-surface socket sends that a
+  // `Full` server answers off its server-run game path — `SessionAttached` plus
+  // a serialized `StateUpdate`. A client that cannot speak the server's
+  // full-game protocol must not put it on the wire at all: by the time a reply
+  // arrived the server would already have attached a session.
+  it("refuses to send on a Full server this client cannot play on", async () => {
+    const ws = new MockWebSocket();
+    const socket = makePhaseSocket(ws, {
+      mode: "Full",
+      protocolVersion: PROTOCOL_VERSION - 2,
+    });
+
+    const result = await resolveGuestOver(socket, "ABC123");
+
+    expect(result).toMatchObject({ ok: false, reason: "build_mismatch" });
+    // The assertion that matters: nothing reached the wire, so no session can
+    // have been attached and no game state can have been streamed back.
+    expect(ws.send).not.toHaveBeenCalled();
+  });
+
+  it("still sends on a Full server this client CAN play on", async () => {
+    // Non-vacuity pair for the refusal above: same code path, same frame, and
+    // only the server's full-game protocol differs.
+    const ws = new MockWebSocket();
+    const socket = makePhaseSocket(ws, {
+      mode: "Full",
+      protocolVersion: PROTOCOL_VERSION,
+    });
+
+    void resolveGuestOver(socket, "ABC123");
+
+    expect(ws.send).toHaveBeenCalledWith(
+      expect.stringContaining('"type":"JoinGameWithPassword"'),
+    );
+  });
+
+  it("still sends to a LobbyOnly broker whose full-game protocol is stale", async () => {
+    // The broker cannot run a game at all, so its full-game number says nothing
+    // about this frame. Guarding on it would break the P2P join path this PR
+    // exists to keep working.
+    const ws = new MockWebSocket();
+    const socket = makePhaseSocket(ws, {
+      mode: "LobbyOnly",
+      protocolVersion: PROTOCOL_VERSION - 9,
+    });
+
+    void resolveGuestOver(socket, "ABC123");
+
+    expect(ws.send).toHaveBeenCalledWith(
+      expect.stringContaining('"type":"JoinGameWithPassword"'),
+    );
+  });
 });
 
 describe("resolveGuestOver", () => {

--- a/client/src/services/__tests__/brokerClient.test.ts
+++ b/client/src/services/__tests__/brokerClient.test.ts
@@ -79,6 +79,39 @@ describe("resolveGuestOver full-game surface guard", () => {
     expect(ws.send).not.toHaveBeenCalled();
   });
 
+  // The remedy is not cosmetic: a stale SERVER cannot be fixed by reloading the
+  // page, and telling a self-hoster to refresh sends them down a dead end. The
+  // pair pins each direction against the other's advice.
+  it("tells a stale server's guest to update the SERVER, not to refresh", async () => {
+    const ws = new MockWebSocket();
+    const socket = makePhaseSocket(ws, {
+      mode: "Full",
+      protocolVersion: PROTOCOL_VERSION - 2,
+    });
+
+    const result = await resolveGuestOver(socket, "ABC123");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toContain("The server needs updating");
+    expect(result.message).not.toContain("Refresh");
+  });
+
+  it("tells a stale client's guest to refresh, not to update the server", async () => {
+    const ws = new MockWebSocket();
+    const socket = makePhaseSocket(ws, {
+      mode: "Full",
+      protocolVersion: PROTOCOL_VERSION + 2,
+    });
+
+    const result = await resolveGuestOver(socket, "ABC123");
+
+    expect(result.ok).toBe(false);
+    if (result.ok) return;
+    expect(result.message).toContain("Refresh to update this client");
+    expect(result.message).not.toContain("server needs updating");
+  });
+
   it("still sends on a Full server this client CAN play on", async () => {
     // Non-vacuity pair for the refusal above: same code path, same frame, and
     // only the server's full-game protocol differs.

--- a/client/src/services/__tests__/brokerClient.test.ts
+++ b/client/src/services/__tests__/brokerClient.test.ts
@@ -59,79 +59,33 @@ beforeEach(() => {
 });
 
 describe("resolveGuestOver full-game surface guard", () => {
-  // `JoinGameWithPassword` is the one frame a lobby-surface socket sends that a
-  // `Full` server answers off its server-run game path — `SessionAttached` plus
-  // a serialized `StateUpdate`. A client that cannot speak the server's
-  // full-game protocol must not put it on the wire at all: by the time a reply
-  // arrived the server would already have attached a session.
-  it("refuses to send on a Full server this client cannot play on", async () => {
+  // This resolver asks for `PeerInfo`. A `Full` server never publishes a P2P
+  // row — both of its lobby registrations hardcode `host_peer_id:
+  // String::new()` — so it has no peer id to return, and it answers this frame
+  // off its server-run join path instead: `SessionAttached` + `StateUpdate`,
+  // neither of which the listener handles. Sending would seat the guest
+  // server-side and then time out as `connection_lost`. Refusing is
+  // unconditional on mode so a relaxed lobby handshake can never carry a
+  // full-game join.
+  it.each([
+    ["version-mismatched", PROTOCOL_VERSION - 2],
+    ["version-compatible", PROTOCOL_VERSION],
+  ])("refuses to send to a %s Full server", async (_label, protocolVersion) => {
     const ws = new MockWebSocket();
-    const socket = makePhaseSocket(ws, {
-      mode: "Full",
-      protocolVersion: PROTOCOL_VERSION - 2,
-    });
+    const socket = makePhaseSocket(ws, { mode: "Full", protocolVersion });
 
     const result = await resolveGuestOver(socket, "ABC123");
 
-    expect(result).toMatchObject({ ok: false, reason: "build_mismatch" });
+    expect(result.ok).toBe(false);
     // The assertion that matters: nothing reached the wire, so no session can
     // have been attached and no game state can have been streamed back.
     expect(ws.send).not.toHaveBeenCalled();
   });
 
-  // The remedy is not cosmetic: a stale SERVER cannot be fixed by reloading the
-  // page, and telling a self-hoster to refresh sends them down a dead end. The
-  // pair pins each direction against the other's advice.
-  it("tells a stale server's guest to update the SERVER, not to refresh", async () => {
-    const ws = new MockWebSocket();
-    const socket = makePhaseSocket(ws, {
-      mode: "Full",
-      protocolVersion: PROTOCOL_VERSION - 2,
-    });
-
-    const result = await resolveGuestOver(socket, "ABC123");
-
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.message).toContain("The server needs updating");
-    expect(result.message).not.toContain("Refresh");
-  });
-
-  it("tells a stale client's guest to refresh, not to update the server", async () => {
-    const ws = new MockWebSocket();
-    const socket = makePhaseSocket(ws, {
-      mode: "Full",
-      protocolVersion: PROTOCOL_VERSION + 2,
-    });
-
-    const result = await resolveGuestOver(socket, "ABC123");
-
-    expect(result.ok).toBe(false);
-    if (result.ok) return;
-    expect(result.message).toContain("Refresh to update this client");
-    expect(result.message).not.toContain("server needs updating");
-  });
-
-  it("still sends on a Full server this client CAN play on", async () => {
-    // Non-vacuity pair for the refusal above: same code path, same frame, and
-    // only the server's full-game protocol differs.
-    const ws = new MockWebSocket();
-    const socket = makePhaseSocket(ws, {
-      mode: "Full",
-      protocolVersion: PROTOCOL_VERSION,
-    });
-
-    void resolveGuestOver(socket, "ABC123");
-
-    expect(ws.send).toHaveBeenCalledWith(
-      expect.stringContaining('"type":"JoinGameWithPassword"'),
-    );
-  });
-
   it("still sends to a LobbyOnly broker whose full-game protocol is stale", async () => {
-    // The broker cannot run a game at all, so its full-game number says nothing
-    // about this frame. Guarding on it would break the P2P join path this PR
-    // exists to keep working.
+    // The broker cannot run a game, so its full-game number says nothing about
+    // this frame and it is the one server kind that can answer with `PeerInfo`.
+    // Guarding it would break the P2P join path this PR exists to keep working.
     const ws = new MockWebSocket();
     const socket = makePhaseSocket(ws, {
       mode: "LobbyOnly",

--- a/client/src/services/__tests__/brokerClient.test.ts
+++ b/client/src/services/__tests__/brokerClient.test.ts
@@ -92,11 +92,17 @@ describe("resolveGuestOver full-game surface guard", () => {
       protocolVersion: PROTOCOL_VERSION - 9,
     });
 
-    void resolveGuestOver(socket, "ABC123");
+    const result = resolveGuestOver(socket, "ABC123");
 
     expect(ws.send).toHaveBeenCalledWith(
       expect.stringContaining('"type":"JoinGameWithPassword"'),
     );
+
+    ws.fireClose();
+    await expect(result).resolves.toMatchObject({
+      ok: false,
+      reason: "connection_lost",
+    });
   });
 });
 

--- a/client/src/services/__tests__/openPhaseSocket.test.ts
+++ b/client/src/services/__tests__/openPhaseSocket.test.ts
@@ -191,7 +191,7 @@ describe("openPhaseSocket", () => {
     expect(ws.close).toHaveBeenCalled();
   });
 
-  it("holds Full servers to an exact match even when they advertise a lobby version", async () => {
+  it("holds the full-game surface to an exact match even when the server advertises a lobby version", async () => {
     // A Full server runs the engine; GameState payloads are not compatible
     // across a bump regardless of what it says about the lobby surface.
     const promise = openPhaseSocket("ws://test");
@@ -205,6 +205,83 @@ describe("openPhaseSocket", () => {
     );
 
     await expect(promise).rejects.toMatchObject({ kind: "protocol_mismatch" });
+  });
+
+  // The self-hosted case: a `Full` server pinned to a released image sits behind
+  // a client built from main. Its lobby surface is current, so browsing must
+  // work; only PLAYING on it is refused, by the exact-match test above.
+  it("reaches a Full server's lobby surface when its full-game protocol is stale", async () => {
+    const staleHello = helloFrame({
+      protocol_version: PROTOCOL_VERSION - 2,
+      mode: "Full",
+      lobby_protocol_version: LOBBY_PROTOCOL_VERSION,
+    });
+
+    // Same server, same frame, default surface: still refused. Without this the
+    // assertion below could pass on a server this client would have accepted
+    // anyway, proving nothing about the surface parameter.
+    const fullSurface = openPhaseSocket("ws://test");
+    MockWebSocket.instances[0].deliverMessage(staleHello);
+    await expect(fullSurface).rejects.toMatchObject({ kind: "protocol_mismatch" });
+
+    const lobbySurface = openPhaseSocket("ws://test", { surface: "lobby" });
+    const ws = MockWebSocket.instances[1];
+    ws.deliverMessage(staleHello);
+    const socket = await lobbySurface;
+
+    expect(socket.serverInfo.protocolVersion).toBe(PROTOCOL_VERSION - 2);
+    // The echo is what an already-deployed server gates on: it has no surface
+    // field to branch on, so a hello carrying this client's own newer number
+    // would be rejected outright.
+    expect(ws.send).toHaveBeenCalledWith(
+      expect.stringContaining(`"protocol_version":${PROTOCOL_VERSION - 2}`),
+    );
+    expect(ws.send).not.toHaveBeenCalledWith(
+      expect.stringContaining(`"protocol_version":${PROTOCOL_VERSION}`),
+    );
+    // ...while still declaring the surface version a lobby-aware server gates on.
+    expect(ws.send).toHaveBeenCalledWith(
+      expect.stringContaining(`"lobby_protocol_version":${LOBBY_PROTOCOL_VERSION}`),
+    );
+  });
+
+  it("still refuses a lobby-surface socket below the lobby floor", async () => {
+    // The surface parameter widens the window it is measured against; it does
+    // not waive the measurement.
+    const promise = openPhaseSocket("ws://test", { surface: "lobby" });
+    const ws = MockWebSocket.instances[0];
+    ws.deliverMessage(
+      helloFrame({
+        protocol_version: PROTOCOL_VERSION,
+        mode: "Full",
+        lobby_protocol_version: LOBBY_PROTOCOL_VERSION - 1,
+      }),
+    );
+
+    await expect(promise).rejects.toMatchObject({ kind: "protocol_mismatch" });
+  });
+
+  // LEGACY PATH on the lobby surface: a server advertising no lobby version
+  // says nothing about its lobby frames, so the derived one-version window on
+  // `protocol_version` is all there is to go on.
+  it("falls back to the derived window on the lobby surface when no lobby version is advertised", async () => {
+    const withinWindow = openPhaseSocket("ws://test", { surface: "lobby" });
+    MockWebSocket.instances[0].deliverMessage(
+      helloFrame({
+        protocol_version: LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL,
+        mode: "Full",
+      }),
+    );
+    await expect(withinWindow).resolves.toBeDefined();
+
+    const belowWindow = openPhaseSocket("ws://test", { surface: "lobby" });
+    MockWebSocket.instances[1].deliverMessage(
+      helloFrame({
+        protocol_version: LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL - 1,
+        mode: "Full",
+      }),
+    );
+    await expect(belowWindow).rejects.toMatchObject({ kind: "protocol_mismatch" });
   });
 
   it("always declares its own lobby protocol version in ClientHello", async () => {

--- a/client/src/services/brokerClient.ts
+++ b/client/src/services/brokerClient.ts
@@ -6,11 +6,7 @@ import type {
   MatchConfig,
   PeerInfo,
 } from "../adapter/types";
-import {
-  PROTOCOL_VERSION,
-  serverProtocolRejection,
-  type ServerInfo,
-} from "../adapter/ws-adapter";
+import type { ServerInfo } from "../adapter/ws-adapter";
 import {
   HandshakeError,
   openPhaseSocket,
@@ -292,36 +288,33 @@ export function resolveGuestOver(
 
   return new Promise<ResolveResult>((resolve) => {
     // SINGLE AUTHORITY for putting `JoinGameWithPassword` on the wire, and the
-    // one frame a lobby-surface socket sends that a `Full` server can answer
-    // with a full-game payload: it skips the broker branch
-    // (`crates/phase-server/src/main.rs`, `if matches!(mode, ServerMode::LobbyOnly)`),
-    // attaches a session and replies `SessionAttached` + `StateUpdate`. Those
-    // are not `LobbyServerMessage` variants, so the lobby surface's independence
-    // does not cover them and a relaxed handshake must not carry this frame.
+    // only frame a lobby-surface socket sends that a `Full` server can answer
+    // off its server-run game path.
     //
-    // Refuse before `send` rather than after: the hazard is the server attaching
-    // a session at all, which has already happened by the time a reply could be
-    // filtered. Browsing the lobby on such a server stays available — only
-    // joining through it is refused.
+    // This resolver asks for `PeerInfo` — the peer id of a P2P host. A `Full`
+    // server has none to give: both of its lobby registrations hardcode
+    // `host_peer_id: String::new()` ("Full-mode server runs the engine itself —
+    // no PeerJS peer is involved"), so every row it publishes carries
+    // `is_p2p: false` and no caller should route a Full server's code here.
+    //
+    // Sending anyway would be worse than useless. The frame skips the broker
+    // branch on a `Full` server (`if matches!(mode, ServerMode::LobbyOnly)` in
+    // `crates/phase-server/src/main.rs`), attaches a session, and replies
+    // `SessionAttached` + `StateUpdate` — neither of which the listener below
+    // handles, so the promise would hang to its timeout and report
+    // `connection_lost` AFTER the server had already seated the guest. Refusing
+    // every `Full` server, not merely the version-mismatched ones, is what makes
+    // "a relaxed lobby socket never carries a full-game join" unconditional.
+    // Browsing such a server's lobby stays available; only joining through this
+    // resolver is refused.
     if (serverInfo.mode === "Full") {
-      if (serverProtocolRejection(serverInfo, "full")) {
-        // Which side is behind decides what the player can actually do about
-        // it, so the two directions cannot share one instruction: refreshing
-        // fixes a stale CLIENT and does nothing for a stale SERVER. The two
-        // cases are exhaustive — a rejection on the full-game surface means
-        // `protocolVersion` is outside an exact-match window, so it is strictly
-        // below or strictly above this client's.
-        const remedy =
-          serverInfo.protocolVersion < PROTOCOL_VERSION
-            ? "The server needs updating"
-            : "Refresh to update this client";
-        resolve({
-          ok: false,
-          reason: "build_mismatch",
-          message: `This server runs game protocol ${serverInfo.protocolVersion}; this client speaks ${PROTOCOL_VERSION}, so joining a game on it would desync. ${remedy} — you can still browse this server's lobby.`,
-        });
-        return;
-      }
+      resolve({
+        ok: false,
+        reason: "error",
+        message:
+          "This server runs its own games, so it has no peer-to-peer room to join.",
+      });
+      return;
     }
     if (ws.readyState !== WebSocket.OPEN) {
       resolve({

--- a/client/src/services/brokerClient.ts
+++ b/client/src/services/brokerClient.ts
@@ -106,7 +106,7 @@ export async function openBrokerClient(
   wsUrl: string,
   opts: OpenBrokerOptions = {},
 ): Promise<BrokerClient> {
-  const socket = await openPhaseSocket(wsUrl, opts);
+  const socket = await openPhaseSocket(wsUrl, { ...opts, surface: "lobby" });
   if (socket.serverInfo.mode !== "LobbyOnly") {
     socket.close();
     throw new HandshakeError(

--- a/client/src/services/brokerClient.ts
+++ b/client/src/services/brokerClient.ts
@@ -6,7 +6,11 @@ import type {
   MatchConfig,
   PeerInfo,
 } from "../adapter/types";
-import type { ServerInfo } from "../adapter/ws-adapter";
+import {
+  PROTOCOL_VERSION,
+  serverProtocolRejection,
+  type ServerInfo,
+} from "../adapter/ws-adapter";
 import {
   HandshakeError,
   openPhaseSocket,
@@ -107,6 +111,10 @@ export async function openBrokerClient(
   opts: OpenBrokerOptions = {},
 ): Promise<BrokerClient> {
   const socket = await openPhaseSocket(wsUrl, { ...opts, surface: "lobby" });
+  // Load-bearing for surface safety, not just for API shape: `registerHost`
+  // sends `CreateGameWithSettings`, which a `Full` server answers by creating a
+  // server-run game and streaming its state. Refusing every non-`LobbyOnly`
+  // server here is what keeps that frame off a lobby-surface socket.
   if (socket.serverInfo.mode !== "LobbyOnly") {
     socket.close();
     throw new HandshakeError(
@@ -279,10 +287,33 @@ export function resolveGuestOver(
   password?: string,
   opts: ResolveGuestOptions = {},
 ): Promise<ResolveResult> {
-  const { ws } = socket;
+  const { ws, serverInfo } = socket;
   const { signal, timeoutMs = 10_000 } = opts;
 
   return new Promise<ResolveResult>((resolve) => {
+    // SINGLE AUTHORITY for putting `JoinGameWithPassword` on the wire, and the
+    // one frame a lobby-surface socket sends that a `Full` server can answer
+    // with a full-game payload: it skips the broker branch
+    // (`crates/phase-server/src/main.rs`, `if matches!(mode, ServerMode::LobbyOnly)`),
+    // attaches a session and replies `SessionAttached` + `StateUpdate`. Those
+    // are not `LobbyServerMessage` variants, so the lobby surface's independence
+    // does not cover them and a relaxed handshake must not carry this frame.
+    //
+    // Refuse before `send` rather than after: the hazard is the server attaching
+    // a session at all, which has already happened by the time a reply could be
+    // filtered. Browsing the lobby on such a server stays available — only
+    // joining through it is refused.
+    if (serverInfo.mode === "Full") {
+      const fullGameRejection = serverProtocolRejection(serverInfo, "full");
+      if (fullGameRejection) {
+        resolve({
+          ok: false,
+          reason: "build_mismatch",
+          message: `This server runs game protocol ${serverInfo.protocolVersion}; this client speaks ${PROTOCOL_VERSION}. Refresh to update — you can still browse this server's lobby.`,
+        });
+        return;
+      }
+    }
     if (ws.readyState !== WebSocket.OPEN) {
       resolve({
         ok: false,

--- a/client/src/services/brokerClient.ts
+++ b/client/src/services/brokerClient.ts
@@ -304,12 +304,21 @@ export function resolveGuestOver(
     // filtered. Browsing the lobby on such a server stays available — only
     // joining through it is refused.
     if (serverInfo.mode === "Full") {
-      const fullGameRejection = serverProtocolRejection(serverInfo, "full");
-      if (fullGameRejection) {
+      if (serverProtocolRejection(serverInfo, "full")) {
+        // Which side is behind decides what the player can actually do about
+        // it, so the two directions cannot share one instruction: refreshing
+        // fixes a stale CLIENT and does nothing for a stale SERVER. The two
+        // cases are exhaustive — a rejection on the full-game surface means
+        // `protocolVersion` is outside an exact-match window, so it is strictly
+        // below or strictly above this client's.
+        const remedy =
+          serverInfo.protocolVersion < PROTOCOL_VERSION
+            ? "The server needs updating"
+            : "Refresh to update this client";
         resolve({
           ok: false,
           reason: "build_mismatch",
-          message: `This server runs game protocol ${serverInfo.protocolVersion}; this client speaks ${PROTOCOL_VERSION}. Refresh to update — you can still browse this server's lobby.`,
+          message: `This server runs game protocol ${serverInfo.protocolVersion}; this client speaks ${PROTOCOL_VERSION}, so joining a game on it would desync. ${remedy} — you can still browse this server's lobby.`,
         });
         return;
       }

--- a/client/src/services/openPhaseSocket.ts
+++ b/client/src/services/openPhaseSocket.ts
@@ -61,10 +61,10 @@ export interface OpenOptions<T extends PhaseSocketTransport = WebSocket> {
    * `Full` server answers `JoinGameWithPassword` and `CreateGameWithSettings`
    * from its server-run game path with `SessionAttached`/`StateUpdate`, which
    * are not `LobbyServerMessage` variants at all. Those two frames are gated in
-   * `brokerClient.ts` — `resolveGuestOver` refuses them on a `Full` server this
-   * client cannot play on, and `openBrokerClient` accepts only `LobbyOnly`
-   * servers. Server-run hosting, joining, drafts and spectating each open their
-   * own socket and must keep the default.
+   * `brokerClient.ts` — `resolveGuestOver` refuses every `Full` server, and
+   * `openBrokerClient` accepts only `LobbyOnly` ones. Server-run hosting,
+   * joining, drafts and spectating each open their own socket and must keep the
+   * default.
    */
   surface?: ProtocolSurface;
 }

--- a/client/src/services/openPhaseSocket.ts
+++ b/client/src/services/openPhaseSocket.ts
@@ -56,10 +56,15 @@ export interface OpenOptions<T extends PhaseSocketTransport = WebSocket> {
    * conservative choice: a caller that has not thought about it gets the
    * exact-match full-game window.
    *
-   * Pass `"lobby"` ONLY for a socket that will carry lobby frames exclusively
-   * (`LobbyClientMessage` in `crates/lobby-broker/src/protocol.rs`). Server-run
-   * hosting, joining, drafts and spectating each open their own socket and must
-   * keep the default.
+   * Pass `"lobby"` ONLY for a socket that can never elicit a full-game reply.
+   * Sending `LobbyClientMessage` variants is necessary but NOT sufficient: a
+   * `Full` server answers `JoinGameWithPassword` and `CreateGameWithSettings`
+   * from its server-run game path with `SessionAttached`/`StateUpdate`, which
+   * are not `LobbyServerMessage` variants at all. Those two frames are gated in
+   * `brokerClient.ts` — `resolveGuestOver` refuses them on a `Full` server this
+   * client cannot play on, and `openBrokerClient` accepts only `LobbyOnly`
+   * servers. Server-run hosting, joining, drafts and spectating each open their
+   * own socket and must keep the default.
    */
   surface?: ProtocolSurface;
 }
@@ -257,9 +262,9 @@ export function openPhaseSocket(
       // in `crates/phase-server/src/main.rs` holds every socket a `Full` server
       // accepts to `MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION` — the echo is
       // therefore this client's only way to declare the socket lobby-only, and
-      // the one that reaches servers already deployed. Sound because the
-      // surface carries no `GameState`/`GameAction` frame in either direction;
-      // see {@link OpenOptions.surface}.
+      // the one that reaches servers already deployed. Sound only because the
+      // caller keeps its side of {@link OpenOptions.surface} — a `Full` server
+      // will still answer a game frame sent over this socket.
       //
       // `lobby_protocol_version` is always our own: a server that understands
       // it gates on that instead, which is what decouples the lobby handshake

--- a/client/src/services/openPhaseSocket.ts
+++ b/client/src/services/openPhaseSocket.ts
@@ -2,6 +2,7 @@ import {
   LOBBY_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
   serverProtocolRejection,
+  type ProtocolSurface,
   type ServerInfo,
 } from "../adapter/ws-adapter";
 
@@ -50,6 +51,17 @@ export interface OpenOptions<T extends PhaseSocketTransport = WebSocket> {
    * browser's direct `new WebSocket(url)` behavior.
    */
   socketFactory?: PhaseSocketFactory<T>;
+  /**
+   * Which protocol surface this socket will carry. Defaults to `"full"`, the
+   * conservative choice: a caller that has not thought about it gets the
+   * exact-match full-game window.
+   *
+   * Pass `"lobby"` ONLY for a socket that will carry lobby frames exclusively
+   * (`LobbyClientMessage` in `crates/lobby-broker/src/protocol.rs`). Server-run
+   * hosting, joining, drafts and spectating each open their own socket and must
+   * keep the default.
+   */
+  surface?: ProtocolSurface;
 }
 
 export class HandshakeError extends Error {
@@ -80,7 +92,8 @@ export class HandshakeError extends Error {
  * Opens a WebSocket to `wsUrl`, waits for `ServerHello`, sends `ClientHello`,
  * and resolves with a ready-to-use `PhaseSocket`. Mode-agnostic: works for
  * both `Full` and `LobbyOnly` servers — callers that need to gate on mode
- * inspect `serverInfo.mode` themselves.
+ * inspect `serverInfo.mode` themselves. `opts.surface` selects which protocol
+ * window the handshake is held to; see {@link OpenOptions.surface}.
  *
  * Failure modes (all result in the returned promise rejecting with a
  * `HandshakeError` and the underlying socket being closed):
@@ -102,7 +115,7 @@ export function openPhaseSocket(
   wsUrl: string,
   opts: OpenOptions<PhaseSocketTransport> = {},
 ): Promise<PhaseSocket<PhaseSocketTransport>> {
-  const { signal, timeoutMs = 5000 } = opts;
+  const { signal, timeoutMs = 5000, surface = "full" } = opts;
 
   return new Promise<PhaseSocket<PhaseSocketTransport>>((resolve, reject) => {
     if (signal?.aborted) {
@@ -223,7 +236,7 @@ export function openPhaseSocket(
         publicUrl: data.public_url,
       };
 
-      const rejection = serverProtocolRejection(info);
+      const rejection = serverProtocolRejection(info, surface);
       if (rejection) {
         settle(() => {
           ws.close();
@@ -232,17 +245,26 @@ export function openPhaseSocket(
         return;
       }
 
-      const clientProtocolVersion =
-        info.mode === "LobbyOnly" ? info.protocolVersion : PROTOCOL_VERSION;
+      const onLobbySurface = surface === "lobby" || info.mode === "LobbyOnly";
+      const clientProtocolVersion = onLobbySurface
+        ? info.protocolVersion
+        : PROTOCOL_VERSION;
 
       // Send our ClientHello back.
       //
-      // `protocol_version` echoes the broker's own number for LobbyOnly so a
-      // deployed worker on the LEGACY gate does not reject a newer client as a
-      // future protocol. `lobby_protocol_version` is always our own: a broker
-      // that understands it gates on that instead, which is what decouples the
-      // lobby handshake from full-game churn. Brokers that predate the field
-      // ignore it (nothing sets `deny_unknown_fields`).
+      // `protocol_version` echoes the server's own number on the lobby surface.
+      // `ClientHello` carries no surface field, so `HelloAcceptance::FullGame`
+      // in `crates/phase-server/src/main.rs` holds every socket a `Full` server
+      // accepts to `MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION` — the echo is
+      // therefore this client's only way to declare the socket lobby-only, and
+      // the one that reaches servers already deployed. Sound because the
+      // surface carries no `GameState`/`GameAction` frame in either direction;
+      // see {@link OpenOptions.surface}.
+      //
+      // `lobby_protocol_version` is always our own: a server that understands
+      // it gates on that instead, which is what decouples the lobby handshake
+      // from full-game churn. Servers that predate the field ignore it (nothing
+      // sets `deny_unknown_fields`).
       ws.send(
         JSON.stringify({
           type: "ClientHello",

--- a/client/src/stores/__tests__/multiplayerStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerStore.test.ts
@@ -46,6 +46,7 @@ import {
   loadWsSession,
   saveWsSession,
 } from "../../services/multiplayerSession";
+import { openPhaseSocket, withReconnect } from "../../services/openPhaseSocket";
 
 const p2pMocks = vi.hoisted(() => ({
   hostDestroy: vi.fn(),
@@ -233,6 +234,46 @@ describe("multiplayerStore", () => {
     expect(
       isServerCompatible(server("Full", PROTOCOL_VERSION - 1, LOBBY_PROTOCOL_VERSION)),
     ).toBe(false);
+  });
+
+  // Guards the wiring, not the window: `serverProtocolRejection` can be
+  // surface-aware and the lobby still unreachable if the one socket that
+  // browses it forgets to say which surface it is on.
+  it("opens the shared subscription socket on the lobby surface", async () => {
+    const socket = {
+      serverInfo: {
+        version: "test",
+        buildCommit: "test",
+        mode: "Full" as const,
+        protocolVersion: PROTOCOL_VERSION - 2,
+        lobbyProtocolVersion: LOBBY_PROTOCOL_VERSION,
+      },
+      ws: { readyState: 1, addEventListener: vi.fn(), removeEventListener: vi.fn(), send: vi.fn() },
+      close: vi.fn(),
+    };
+    vi.mocked(withReconnect).mockImplementationOnce((factory, opts) => {
+      let current: Awaited<ReturnType<typeof factory>> | null = null;
+      // The real implementation notifies from an async continuation, after it
+      // has returned the handle the store stores. Reproduce that ordering —
+      // notifying synchronously would find no handle to read `current()` from.
+      void (async () => {
+        current = await factory(0);
+        opts?.onStateChange?.("open");
+      })();
+      return { current: () => current, close: vi.fn() };
+    });
+    vi.mocked(openPhaseSocket).mockResolvedValueOnce(
+      socket as unknown as Awaited<ReturnType<typeof openPhaseSocket>>,
+    );
+
+    const opened = await useMultiplayerStore.getState().ensureSubscriptionSocket();
+
+    expect(opened).toBe(socket);
+    expect(openPhaseSocket).toHaveBeenCalledWith(
+      "ws://localhost:8787",
+      expect.objectContaining({ surface: "lobby" }),
+    );
+    useMultiplayerStore.getState().closeSubscriptionSocket();
   });
 
   it("persists displayName across store resets", () => {

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -497,10 +497,12 @@ export function isLobbyEntryCompatible(
 }
 
 /**
- * True when the client's wire-protocol can speak to the server's advertised
- * mode. Delegates to `serverProtocolRejection` — the same decision the
+ * True when the client's wire-protocol can speak to `info` on the FULL-GAME
+ * surface — the surface that decides whether a game can actually be played.
+ * Delegates to `serverProtocolRejection` — the same decision the game
  * handshake makes — so the compatibility badge can never disagree with whether
- * the connection actually succeeds.
+ * the connection actually succeeds. A `LobbyOnly` server has no full-game
+ * surface, so it is judged on its lobby version instead.
  */
 export function isServerCompatible(info: ServerInfo | null): boolean {
   return info !== null && serverProtocolRejection(info) === null;
@@ -1300,7 +1302,13 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
 
           subscriptionReconnect = withReconnect(
             () =>
-              openPhaseSocket(addr).catch((err) => {
+              // The shared subscription socket carries lobby frames only —
+              // `SubscribeLobby`, the join-target RPCs, `PlayerCount`. Declaring
+              // the surface keeps it usable against a server whose full-game
+              // protocol has drifted from this build's, which is the whole point
+              // of versioning the lobby separately. Server-run hosting and
+              // joining open their own sockets and keep the exact-match window.
+              openPhaseSocket(addr, { surface: "lobby" }).catch((err) => {
                 // Protocol mismatch is not retryable — surface the toast
                 // on the *first* handshake attempt, then let
                 // `withReconnect` treat subsequent attempts as plain


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Pointing a client at a self-hosted `phase-server` that is one full-game protocol
bump behind it makes the multiplayer page report **"Matchmaking unreachable"**,
even though the server's lobby surface is perfectly compatible with that client.

`LOBBY_PROTOCOL_VERSION` exists precisely so the lobby can version independently
of `GameState`/`GameAction` churn, but `serverProtocolRejection` consulted it
only when `mode === "LobbyOnly"`. A `Full` server serves the lobby too, so it was
judged solely on its full-game number and the lobby socket was refused outright.

The fix makes the protocol surface a **caller-declared** `ProtocolSurface`
(`"full" | "lobby"`) rather than something inferred from the server's mode.

## Root cause

`LobbyView` → `multiplayerStore.subscribeLobby` → `ensureSubscriptionSocket` →
`openPhaseSocket`. When the handshake is refused, `subscribeLobby` resolves
`null`, `LobbyView` calls `onServerOffline`, and `MultiplayerPage` renders
`ServerOfflinePrompt` — whose `en` title is literally "Matchmaking unreachable".

Measured `ServerHello` from a self-hosted server running the released
`ghcr.io/phase-rs/phase-server:v0.61.0` image:

```json
{"server_version":"0.61.0","build_commit":"0bc7d7e","protocol_version":33,
 "mode":"Full","lobby_protocol_version":1,
 "public_url":"https://phase-0.meanphysicist.com"}
```

The client is at `PROTOCOL_VERSION = 35` / `MIN_SUPPORTED_SERVER_PROTOCOL = 35`.
Because `mode` is `Full`, the advertised `lobby_protocol_version: 1` — which
matches this client exactly — was ignored and the socket rejected.

Both halves of the gate bite, and both were measured live against that server
over a raw TLS WebSocket:

| `ClientHello` sent | Server response |
|---|---|
| `protocol_version: 35, lobby_protocol_version: 1` | `Error: Protocol version mismatch (client=35 server=33)`, then the follow-up `SubscribeLobby` is answered with `ClientHello required before any other message` |
| `protocol_version: 33, lobby_protocol_version: 1` | accepted → `LobbyUpdate` + `PlayerCount` flow normally |

So the client-side window had to widen **and** the `ClientHello` had to stop
announcing a number the deployed server refuses.

## What changed

- **`ws-adapter.ts`** — new exported `ProtocolSurface = "full" | "lobby"`.
  `serverProtocolRejection(info, surface = "full")` now selects the window by
  surface. A `LobbyOnly` server still forces the lobby surface: it has no
  full-game surface at all, so every socket to one is a lobby socket. Every
  pre-existing policy is unchanged at the default argument.
- **`openPhaseSocket.ts`** — `OpenOptions.surface`, defaulting to the
  conservative `"full"`. On the lobby surface the `ClientHello` echoes the
  server's `protocol_version`, generalizing what the `LobbyOnly` path already
  did. This is what reaches servers already deployed: `ClientHello` has no
  surface field, so `HelloAcceptance::FullGame` holds every socket a `Full`
  server accepts to its own exact window, and the echo is the client's only way
  to declare the socket lobby-only. `lobby_protocol_version` remains always this
  client's own.
- **`multiplayerStore.ts`** — the shared subscription socket declares
  `surface: "lobby"`. Its `isServerCompatible` doc now names the surface it
  judges.
- **`brokerClient.ts`** — `openBrokerClient` declares `surface: "lobby"`
  (behaviour-identical, since it already requires `LobbyOnly`; the intent is now
  explicit rather than incidental).

Nothing else declares the new surface. Server-run hosting
(`openServerHostSocket`), joining (`WebSocketAdapter`), drafts
(`ServerDraftAdapter`) and spectating each open their own socket and keep the
exact-match full-game window — so a version pair that cannot play is still
refused, at the point where a game would actually start, with the existing
protocol-mismatch toast instead of a misleading "unreachable".

## Why this is sound, not a loosened gate

The lobby surface is decoupled by construction, not by assertion: the frames the
subscription socket sends are exactly `LobbyClientMessage`
(`SubscribeLobby`, `UnsubscribeLobby`, `JoinGameWithPassword`,
`LookupJoinTarget`, `Ping`, `UpdateLobbyMetadata`, `UnregisterLobby`,
`CreateGameWithSettings`), and the frames it receives are exactly
`LobbyServerMessage`. **No variant on either side carries `GameState` or
`GameAction`**, and `reject_if_disabled` in `crates/phase-server/src/main.rs`
already lists the lobby frames as allowed in both server modes.

No server-side change is included, deliberately: `ClientHello` carries no
surface field, so a `Full` server cannot distinguish "browsing" from "playing".
Adding one would buy nothing until every deployed server upgraded, whereas the
client-side echo works against servers in the wild today — which is the case
that is actually broken.

## Verification

**Live, against the real self-hosted server, driving the unmodified module**
(`openPhaseSocket.ts` under vitest with Node's global `WebSocket`):

- `openPhaseSocket(url, { surface: "lobby" })` resolves against
  `protocolVersion: 33 / mode: Full` while the client speaks 35, and
  `SubscribeLobby` returns `LobbyUpdate` — the user-visible bug is gone.
- `openPhaseSocket(url)` (default full-game surface) against the **same** server
  still rejects with `kind: "protocol_mismatch"` — playing on a mismatched
  server is still refused.

**Unit tests** (`openPhaseSocket.test.ts`, `multiplayerStore.test.ts`):

- `reaches a Full server's lobby surface when its full-game protocol is stale` —
  the reported case. Asserts the socket resolves, that the `ClientHello` echoes
  `protocol_version: PROTOCOL_VERSION - 2`, that it does **not** send this
  client's own number, and that it still declares
  `lobby_protocol_version`. Self-pairing: the same hello on the default surface
  is asserted to reject in the same test, so the assertion cannot pass against a
  server this client would have accepted anyway.
- `still refuses a lobby-surface socket below the lobby floor` — the surface
  widens the window it is measured against, it does not waive the measurement.
- `falls back to the derived window on the lobby surface when no lobby version is
  advertised` — asserts both directions of the legacy boundary
  (`LOBBY_MIN_SUPPORTED_SERVER_PROTOCOL` resolves, one below rejects).
- `holds the full-game surface to an exact match even when the server advertises
  a lobby version` — the pre-existing test, renamed to name the surface rather
  than the server mode; it still pins the exact-match policy.
- `opens the shared subscription socket on the lobby surface` — guards the
  wiring, not the window: the gate can be surface-aware and the lobby still
  unreachable if the one socket that browses it forgets to declare its surface.

**Non-vacuity, measured.** Each production change was mutated back
independently and the suite re-run; every mutation was caught by the test that
targets it, and the boundary tests fail in both directions:

| Mutation | Result |
|---|---|
| `serverProtocolRejection` ignores `surface` | 3 failures — one "resolved instead of rejecting", one "rejected instead of resolving" |
| `ClientHello` stops echoing on the lobby surface | echo assertion fails |
| subscription socket drops `surface: "lobby"` | store wiring test fails |

**Gate:** full client suite `3134 passed / 320 files` (exit 0),
`tsc -b --noEmit` clean, `eslint` clean on all touched files,
`scripts/check-protocol-version.mjs` (the TS↔Rust cross-language protocol gate)
passes.

## Notes

- No protocol-version bump: no wire shape changed. `PROTOCOL_VERSION` stays 35
  and `LOBBY_PROTOCOL_VERSION` stays 1.
- Beyond self-hosting, this also covers the official deployment during a rolling
  release, when client and server are briefly a bump apart — the case the
  `LOBBY_PROTOCOL_VERSION` doc comment cites as having "took preview multiplayer
  down". The lobby now stays browsable through the window instead of reporting
  the server as unreachable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved compatibility for lobby connections across supported protocol versions.
  * Added lobby-specific protocol negotiation for compatible servers.
  * Multiplayer subscription connections now retain their handles through reconnects and can be closed reliably.

* **Bug Fixes**
  * Prevented valid lobby connections from being rejected due to stale or newer protocol versions.
  * Preserved strict protocol matching for full-game connections.
  * Prevented join requests from being sent to full-game servers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->