### PR TITLE
fix(client): keep priority controls during auto-pass

### DIFF
--- a/client/src/components/board/ActionButton.tsx
+++ b/client/src/components/board/ActionButton.tsx
@@ -369,7 +369,7 @@ export function ActionButton() {
           </>
         )}
 
-        {mode === "priority-stack" && !isEndingTurn && (
+        {mode === "priority-stack" && (
           <>
             {canCompanionToHand && (
               <button

--- a/client/src/components/board/__tests__/ActionButton.test.tsx
+++ b/client/src/components/board/__tests__/ActionButton.test.tsx
@@ -150,6 +150,27 @@ describe("ActionButton", () => {
     expect(screen.getByRole("button", { name: "Resolve" })).toBeInTheDocument();
   });
 
+  it("keeps priority actions available when end-of-turn auto-pass pauses for an opponent's stack object", () => {
+    useGameStore.setState({
+      gameMode: "online",
+      gameState: {
+        ...createGameState(priorityPrompt()),
+        phase: "PostCombatMain",
+        active_player: 0,
+        stack: [spellStackEntry(1)],
+      },
+      waitingFor: priorityPrompt(),
+      legalActions: [],
+    });
+    useMultiplayerStore.setState({ activePlayerId: 0, actionPending: false });
+
+    render(<ActionButton />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Resolve" }));
+    expect(vi.mocked(dispatchAction)).toHaveBeenCalledWith({ type: "PassPriority" });
+    expect(screen.getByRole("button", { name: "Auto-Passing to End Step..." })).toBeInTheDocument();
+  });
+
   it("disables resolve controls while Resolve All is draining", () => {
     useGameStore.setState({
       gameMode: "online",
@@ -290,6 +311,7 @@ describe("ActionButton", () => {
 
     const cancel = screen.getByRole("button", { name: "Resolving Stack..." });
     expect(cancel).toBeEnabled();
+    expect(screen.queryByRole("button", { name: "Resolve" })).not.toBeInTheDocument();
     fireEvent.click(cancel);
     expect(vi.mocked(dispatchAction)).toHaveBeenCalledWith({ type: "CancelAutoPass" });
   });


### PR DESCRIPTION
## Summary
- Keep the existing priority-stack controls visible when an engine-owned UntilTurnBoundary session pauses for an opponent-controlled stack object.
- Preserve cancellation and UntilStackEmpty cancel-only behavior.

## Validation
- `pnpm exec vitest run src/components/board/__tests__/ActionButton.test.tsx`
- `pnpm run type-check`
- `pnpm lint` (pre-existing warnings only)
- Full frontend suite remains blocked by unrelated DraftPodPage mock failures.

Pipeline-reviewed head: 5e2c5fa4825d6258be1c4e131047eefd8904292e
Current branch head: e1e3508967c5e3453ddd6683b3777ccfac3a7175
Pipeline status: historical — cherry-picked onto origin/main for shipment
Current-head review: clean at 5e2c5fa4825d6258be1c4e131047eefd8904292e

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Priority actions now remain available when end-of-turn auto-pass pauses for an opponent-controlled stack item.
  * Resolve and Resolve All controls continue to work during this state.
  * The auto-pass indicator is displayed while priority is paused.
  * Resolve is correctly hidden during an active “until stack empty” auto-pass session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->