### PR TITLE
feat(parser,engine): lower the origin-zone alternative-cost grant (Warped Space)

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2232,13 +2232,15 @@ pub(super) fn pending_cast_origin_zone_for(state: &GameState, object_id: ObjectI
 }
 
 /// CR 601.2a: The cast's origin zone as grant filters must see it — the
-/// persisted origin first ([`spell_cast_origin`], which owns the stack
+/// IN-FLIGHT pending-cast record first (the current cast's own truth), the
+/// persisted origin second ([`spell_cast_origin`], which owns the stack
 /// ability-context vs. permanent-object storage split and survives
-/// `finalize_cast`), the transient pending-cast record second, the object's
-/// current zone last. Single chain shared by the keyword-grant walkers and
-/// the alternative-cost grant, so a zone-less grant (Rooftop Storm) keeps
-/// matching a hand cast — and an origin-scoped grant its exile cast — when
-/// re-asked after finalize, for permanents and instants/sorceries alike.
+/// `finalize_cast`), the object's current zone last. Single chain shared by
+/// the keyword-grant walkers and the alternative-cost grant, so a zone-less
+/// grant (Rooftop Storm) keeps matching a hand cast — and an origin-scoped
+/// grant its exile cast — when re-asked after finalize, for permanents and
+/// instants/sorceries alike, while a NEW cast never inherits a previous
+/// cast's stamp.
 pub(super) fn spell_cast_origin_zone(
     state: &GameState,
     spell_obj: &crate::game::game_object::GameObject,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2231,18 +2231,19 @@ pub(super) fn pending_cast_origin_zone_for(state: &GameState, object_id: ObjectI
     None
 }
 
-/// CR 601.2a: The cast's origin zone as grant filters must see it —
-/// `cast_from_zone` first (stamped during `finalize_cast` and persisting
-/// through the SpellCast event), the transient pending-cast record second,
-/// the object's current zone last. Single chain shared by the keyword-grant
-/// walkers and the alternative-cost grant, so a zone-less grant (Rooftop
-/// Storm) keeps matching a hand cast when it is re-asked after finalize.
+/// CR 601.2a: The cast's origin zone as grant filters must see it — the
+/// persisted origin first ([`spell_cast_origin`], which owns the stack
+/// ability-context vs. permanent-object storage split and survives
+/// `finalize_cast`), the transient pending-cast record second, the object's
+/// current zone last. Single chain shared by the keyword-grant walkers and
+/// the alternative-cost grant, so a zone-less grant (Rooftop Storm) keeps
+/// matching a hand cast — and an origin-scoped grant its exile cast — when
+/// re-asked after finalize, for permanents and instants/sorceries alike.
 pub(super) fn spell_cast_origin_zone(
     state: &GameState,
     spell_obj: &crate::game::game_object::GameObject,
 ) -> Zone {
-    spell_obj
-        .cast_from_zone
+    spell_cast_origin(state, spell_obj.id)
         .or_else(|| pending_cast_origin_zone_for(state, spell_obj.id))
         .unwrap_or(spell_obj.zone)
 }

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2212,7 +2212,7 @@ pub(crate) fn spell_cast_origin(state: &GameState, object_id: ObjectId) -> Optio
     state.objects.get(&object_id).and_then(|o| o.cast_from_zone)
 }
 
-/// CR 601.2a + CR 603.4: Look up the pre-announcement zone for a spell that
+/// CR 601.2a: Look up the pre-announcement zone for a spell that
 /// is currently mid-cast. `obj.zone` stays at the origin until `finalize_cast`
 /// performs the Hand→Stack move itself, but should the ordering ever change
 /// this fallback preserves correctness for filters like "spells you cast from
@@ -2466,12 +2466,6 @@ pub(super) struct GrantedSpellAlternativeCost {
     /// (As Foretold), so the caller records the per-turn slot at `finalize_cast`.
     /// `None` for `Unlimited` grants (Fist of Suns, Rooftop Storm, Jodah).
     pub(super) once_per_turn_source: Option<ObjectId>,
-    /// CR 118.9 + CR 601.2a (#7575): true when the grant's `affected` filter
-    /// itself constrains the cast's ORIGIN zone (`InZone`/`InAnyZone` — Warped
-    /// Space's "a spell you cast from exile"). Such a grant must reach an
-    /// authorized cast from that zone, so the alternative-cost offer's
-    /// hand-only default does not apply to it.
-    pub(super) origin_zone_scoped: bool,
 }
 
 pub(super) fn granted_spell_alternative_cost(
@@ -2516,23 +2510,40 @@ pub(super) fn granted_spell_alternative_cost_for(
             continue;
         }
 
-        let matches = def.affected.as_ref().is_none_or(|filter| {
-            super::filter::spell_object_matches_filter_from_state_for(
-                state,
-                spell_obj,
-                origin_zone,
-                caster,
-                filter,
-                source_obj.id,
-                &state.all_creature_types,
-                fused,
-            )
-        });
+        // CR 118.9 + CR 601.2a (#7575): the offer's default reach is hand
+        // casts. For a NON-hand origin the match must come THROUGH a branch
+        // that itself constrains the cast's origin zone (Warped Space's "a
+        // spell you cast from exile") — a mixed `Or` whose unscoped branch
+        // matched must not unlock the non-hand reach, and a filterless grant
+        // ("spells you cast") is zone-less by definition. Zone-less grants
+        // (Rooftop Storm class) therefore keep their hand-only reach.
+        let matches = if origin_zone == Zone::Hand {
+            def.affected.as_ref().is_none_or(|filter| {
+                super::filter::spell_object_matches_filter_from_state_for(
+                    state,
+                    spell_obj,
+                    origin_zone,
+                    caster,
+                    filter,
+                    source_obj.id,
+                    &state.all_creature_types,
+                    fused,
+                )
+            })
+        } else {
+            def.affected.as_ref().is_some_and(|filter| {
+                matches_via_origin_scoped_branch(
+                    state,
+                    spell_obj,
+                    origin_zone,
+                    caster,
+                    filter,
+                    source_obj.id,
+                    fused,
+                )
+            })
+        };
         if matches {
-            let origin_zone_scoped = def
-                .affected
-                .as_ref()
-                .is_some_and(filter_constrains_origin_zone);
             return Some(GrantedSpellAlternativeCost {
                 // CR 107.3c + CR 118.9: A static's alternative cost can bind X
                 // to the affected spell's mana value (Kentaro). Concretize the
@@ -2543,7 +2554,6 @@ pub(super) fn granted_spell_alternative_cost_for(
                 timing_permission: *timing_permission,
                 once_per_turn_source: (*frequency == CastFrequency::OncePerTurn)
                     .then_some(source_obj.id),
-                origin_zone_scoped,
             });
         }
     }
@@ -2551,24 +2561,142 @@ pub(super) fn granted_spell_alternative_cost_for(
     None
 }
 
-/// CR 118.9 + CR 601.2a: Whether a grant's `affected` filter carries an
-/// origin-zone constraint (`InZone`/`InAnyZone`) on any positive leaf. The
-/// spell-filter path compares those props against the cast's ORIGIN zone, so
-/// their presence is the grant's own statement "I apply to casts from that
-/// zone". `Not` legs are skipped: a negated zone is an exclusion, not a scope.
-fn filter_constrains_origin_zone(filter: &TargetFilter) -> bool {
+/// CR 118.9 + CR 601.2a: Whether this cast matches the grant's `affected`
+/// filter THROUGH a branch that itself constrains the cast's ORIGIN zone
+/// (`InZone`/`InAnyZone` — Warped Space's "a spell you cast from exile").
+///
+/// This is a per-cast question, not a whole-filter presence bit:
+/// `Or(hand-scoped, Creature)` matched by an exile Creature through the
+/// unscoped branch is NOT an origin-scoped match, so the non-hand
+/// alternative-cost reach stays closed for that cast. `Not` is an exclusion,
+/// never a scope.
+///
+/// Exhaustive by design — no wildcard arm: a future filter variant that can
+/// nest a zone constraint must be classified here explicitly instead of
+/// silently falling into the hand-only default.
+fn matches_via_origin_scoped_branch(
+    state: &GameState,
+    spell_obj: &GameObject,
+    origin_zone: Zone,
+    caster: PlayerId,
+    filter: &TargetFilter,
+    source_id: ObjectId,
+    fused: bool,
+) -> bool {
+    let full_match = |f: &TargetFilter| {
+        super::filter::spell_object_matches_filter_from_state_for(
+            state,
+            spell_obj,
+            origin_zone,
+            caster,
+            f,
+            source_id,
+            &state.all_creature_types,
+            fused,
+        )
+    };
     match filter {
-        TargetFilter::Typed(typed) => typed.properties.iter().any(|prop| {
-            matches!(
-                prop,
-                crate::types::ability::FilterProp::InZone { .. }
-                    | crate::types::ability::FilterProp::InAnyZone { .. }
+        TargetFilter::Typed(typed) => {
+            typed.properties.iter().any(|prop| {
+                matches!(
+                    prop,
+                    crate::types::ability::FilterProp::InZone { .. }
+                        | crate::types::ability::FilterProp::InAnyZone { .. }
+                )
+            }) && full_match(filter)
+        }
+        // A disjunction is origin-scoped only through a branch that is.
+        TargetFilter::Or { filters } => filters.iter().any(|f| {
+            matches_via_origin_scoped_branch(
+                state,
+                spell_obj,
+                origin_zone,
+                caster,
+                f,
+                source_id,
+                fused,
             )
         }),
-        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
-            filters.iter().any(filter_constrains_origin_zone)
+        // A conjunction must match as a whole AND carry some leg that is an
+        // origin-scoped match in its own right (recursing keeps a mixed `Or`
+        // nested under `And` honest too).
+        TargetFilter::And { filters } => {
+            full_match(filter)
+                && filters.iter().any(|f| {
+                    matches_via_origin_scoped_branch(
+                        state,
+                        spell_obj,
+                        origin_zone,
+                        caster,
+                        f,
+                        source_id,
+                        fused,
+                    )
+                })
         }
-        _ => false,
+        TargetFilter::TrackedSetFiltered { filter: inner, .. } => {
+            full_match(filter)
+                && matches_via_origin_scoped_branch(
+                    state,
+                    spell_obj,
+                    origin_zone,
+                    caster,
+                    inner,
+                    source_id,
+                    fused,
+                )
+        }
+        // A negated zone prop is an exclusion, not an origin scope.
+        TargetFilter::Not { .. } => false,
+        TargetFilter::None
+        | TargetFilter::Any
+        | TargetFilter::Player
+        | TargetFilter::Controller
+        | TargetFilter::SourceController
+        | TargetFilter::ControllerAndControlledPermanents { .. }
+        | TargetFilter::Opponent
+        | TargetFilter::SelfRef
+        | TargetFilter::GrantingObject
+        | TargetFilter::SourceOrPaired
+        | TargetFilter::StackAbility { .. }
+        | TargetFilter::StackSpell
+        | TargetFilter::SpecificObject { .. }
+        | TargetFilter::SpecificPlayer { .. }
+        | TargetFilter::PlayerWhoChoseLabel { .. }
+        | TargetFilter::Neighbor { .. }
+        | TargetFilter::ScopedPlayer
+        | TargetFilter::AttachedTo
+        | TargetFilter::LastCreated
+        | TargetFilter::LastRevealed
+        | TargetFilter::LastZoneChanged
+        | TargetFilter::CostPaidObject
+        | TargetFilter::ChosenCard
+        | TargetFilter::TrackedSet { .. }
+        | TargetFilter::ExiledBySource
+        | TargetFilter::ExiledCardByIndex { .. }
+        | TargetFilter::TriggeringSpellController
+        | TargetFilter::TriggeringSpellOwner
+        | TargetFilter::TriggeringPlayer
+        | TargetFilter::TriggeringSource
+        | TargetFilter::EventTarget
+        | TargetFilter::TriggeringSourceController
+        | TargetFilter::ParentTarget
+        | TargetFilter::ParentTargetSlot { .. }
+        | TargetFilter::ParentTargetController
+        | TargetFilter::ParentTargetOwner
+        | TargetFilter::SourceChosenPlayer
+        | TargetFilter::OriginalController
+        | TargetFilter::OriginalSource
+        | TargetFilter::PostReplacementSourceController
+        | TargetFilter::PostReplacementDamageSource
+        | TargetFilter::PostReplacementDamageTarget
+        | TargetFilter::PostReplacementDamageTargetOwner
+        | TargetFilter::DefendingPlayer
+        | TargetFilter::HasChosenName
+        | TargetFilter::ChosenDamageSource { .. }
+        | TargetFilter::Named { .. }
+        | TargetFilter::Owner
+        | TargetFilter::AllPlayers => false,
     }
 }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2243,8 +2243,13 @@ pub(super) fn spell_cast_origin_zone(
     state: &GameState,
     spell_obj: &crate::game::game_object::GameObject,
 ) -> Zone {
-    spell_cast_origin(state, spell_obj.id)
-        .or_else(|| pending_cast_origin_zone_for(state, spell_obj.id))
+    // The IN-FLIGHT cast's record outranks the persisted stamp: the stamp is
+    // written at finalize, so during a NEW cast it can only describe a
+    // PREVIOUS cast of this object — a graveyard recast must not inherit a
+    // stale hand origin. Post-finalize the pending record is gone and the
+    // persisted authority answers.
+    pending_cast_origin_zone_for(state, spell_obj.id)
+        .or_else(|| spell_cast_origin(state, spell_obj.id))
         .unwrap_or(spell_obj.zone)
 }
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2231,6 +2231,22 @@ pub(super) fn pending_cast_origin_zone_for(state: &GameState, object_id: ObjectI
     None
 }
 
+/// CR 601.2a: The cast's origin zone as grant filters must see it —
+/// `cast_from_zone` first (stamped during `finalize_cast` and persisting
+/// through the SpellCast event), the transient pending-cast record second,
+/// the object's current zone last. Single chain shared by the keyword-grant
+/// walkers and the alternative-cost grant, so a zone-less grant (Rooftop
+/// Storm) keeps matching a hand cast when it is re-asked after finalize.
+pub(super) fn spell_cast_origin_zone(
+    state: &GameState,
+    spell_obj: &crate::game::game_object::GameObject,
+) -> Zone {
+    spell_obj
+        .cast_from_zone
+        .or_else(|| pending_cast_origin_zone_for(state, spell_obj.id))
+        .unwrap_or(spell_obj.zone)
+}
+
 /// Collect the keywords granted to `object_id` by `CastWithKeyword` statics
 /// (CR 604.1). `fused` projects a pre-payment fused split spell with its COMBINED
 /// characteristics (CR 702.102b) so `CastWithKeyword` `affected` filters keyed on
@@ -2247,14 +2263,8 @@ fn granted_spell_keywords_for(
         return Vec::new();
     };
 
-    // CR 601.2a: Prefer cast_from_zone (stamped during finalize_cast and persists
-    // through SpellCast event) over pending_cast_origin_zone_for (transient and
-    // cleared after finalize_cast). This ensures origin zone is available when
-    // triggers are processed for filters like "InZone { zone: Hand }".
-    let origin_zone = spell_obj
-        .cast_from_zone
-        .or_else(|| pending_cast_origin_zone_for(state, object_id))
-        .unwrap_or(spell_obj.zone);
+    // CR 601.2a: single origin-zone chain (see `spell_cast_origin_zone`).
+    let origin_zone = spell_cast_origin_zone(state, spell_obj);
 
     let mut keywords = Vec::new();
     // CR 702.26b + CR 604.1: Functioning gate owned by
@@ -2324,10 +2334,8 @@ fn granted_spell_keyword_instances_for(
         return Vec::new();
     };
 
-    let origin_zone = spell_obj
-        .cast_from_zone
-        .or_else(|| pending_cast_origin_zone_for(state, object_id))
-        .unwrap_or(spell_obj.zone);
+    // CR 601.2a: single origin-zone chain (see `spell_cast_origin_zone`).
+    let origin_zone = spell_cast_origin_zone(state, spell_obj);
 
     let mut keywords = Vec::new();
     for (source_obj, def) in super::functioning_abilities::game_active_statics(state) {
@@ -2487,7 +2495,10 @@ pub(super) fn granted_spell_alternative_cost_for(
     fused: bool,
 ) -> Option<GrantedSpellAlternativeCost> {
     let spell_obj = state.objects.get(&object_id)?;
-    let origin_zone = pending_cast_origin_zone_for(state, object_id).unwrap_or(spell_obj.zone);
+    // CR 601.2a: same origin chain as the keyword-grant walkers, so a re-ask
+    // after finalize (cast_from_zone stamped, pending cleared) still sees the
+    // true origin instead of Zone::Stack.
+    let origin_zone = spell_cast_origin_zone(state, spell_obj);
 
     // CR 604.1: Functioning gate owned by `game_active_statics`.
     for (source_obj, def) in super::functioning_abilities::game_active_statics(state) {

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2217,7 +2217,7 @@ pub(crate) fn spell_cast_origin(state: &GameState, object_id: ObjectId) -> Optio
 /// performs the Hand→Stack move itself, but should the ordering ever change
 /// this fallback preserves correctness for filters like "spells you cast from
 /// exile have convoke" that must evaluate against the pre-announcement zone.
-fn pending_cast_origin_zone_for(state: &GameState, object_id: ObjectId) -> Option<Zone> {
+pub(super) fn pending_cast_origin_zone_for(state: &GameState, object_id: ObjectId) -> Option<Zone> {
     if let Some(pc) = state.waiting_for.pending_cast_ref() {
         if pc.object_id == object_id {
             return Some(pc.origin_zone);
@@ -2466,6 +2466,12 @@ pub(super) struct GrantedSpellAlternativeCost {
     /// (As Foretold), so the caller records the per-turn slot at `finalize_cast`.
     /// `None` for `Unlimited` grants (Fist of Suns, Rooftop Storm, Jodah).
     pub(super) once_per_turn_source: Option<ObjectId>,
+    /// CR 118.9 + CR 601.2a (#7575): true when the grant's `affected` filter
+    /// itself constrains the cast's ORIGIN zone (`InZone`/`InAnyZone` — Warped
+    /// Space's "a spell you cast from exile"). Such a grant must reach an
+    /// authorized cast from that zone, so the alternative-cost offer's
+    /// hand-only default does not apply to it.
+    pub(super) origin_zone_scoped: bool,
 }
 
 pub(super) fn granted_spell_alternative_cost(
@@ -2523,6 +2529,10 @@ pub(super) fn granted_spell_alternative_cost_for(
             )
         });
         if matches {
+            let origin_zone_scoped = def
+                .affected
+                .as_ref()
+                .is_some_and(filter_constrains_origin_zone);
             return Some(GrantedSpellAlternativeCost {
                 // CR 107.3c + CR 118.9: A static's alternative cost can bind X
                 // to the affected spell's mana value (Kentaro). Concretize the
@@ -2533,11 +2543,33 @@ pub(super) fn granted_spell_alternative_cost_for(
                 timing_permission: *timing_permission,
                 once_per_turn_source: (*frequency == CastFrequency::OncePerTurn)
                     .then_some(source_obj.id),
+                origin_zone_scoped,
             });
         }
     }
 
     None
+}
+
+/// CR 118.9 + CR 601.2a: Whether a grant's `affected` filter carries an
+/// origin-zone constraint (`InZone`/`InAnyZone`) on any positive leaf. The
+/// spell-filter path compares those props against the cast's ORIGIN zone, so
+/// their presence is the grant's own statement "I apply to casts from that
+/// zone". `Not` legs are skipped: a negated zone is an exclusion, not a scope.
+fn filter_constrains_origin_zone(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(typed) => typed.properties.iter().any(|prop| {
+            matches!(
+                prop,
+                crate::types::ability::FilterProp::InZone { .. }
+                    | crate::types::ability::FilterProp::InAnyZone { .. }
+            )
+        }),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(filter_constrains_origin_zone)
+        }
+        _ => false,
+    }
 }
 
 pub(crate) fn effective_spell_keywords(

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -23992,4 +23992,71 @@ its replicate cost was paid.)\nDraw a card.";
             "the exile-scoped grant must keep matching the finalized exile cast"
         );
     }
+
+    /// #7782 round 3 (order): during a NEW cast the pending record outranks a
+    /// stale `cast_from_zone` stamp from a PREVIOUS cast — a graveyard recast
+    /// with a leftover Hand stamp must not receive a zone-less (hand-reach)
+    /// grant. Discriminating: with the persisted stamp consulted first, the
+    /// stale Hand origin wins and the grant leaks.
+    #[test]
+    fn a_pending_recast_outranks_a_stale_cast_from_zone_stamp() {
+        use crate::types::ability::{Effect, ResolvedAbility, StaticDefinition};
+        use crate::types::game_state::PendingCast;
+
+        let mut state = GameState::new_two_player(42);
+        let caster = PlayerId(0);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            caster,
+            "Rooftop Host".to_string(),
+            Zone::Battlefield,
+        );
+        let grant = StaticDefinition::new(StaticMode::CastWithAlternativeCost {
+            cost: AbilityCost::Mana {
+                cost: ManaCost::zero(),
+            },
+            timing_permission: None,
+            frequency: crate::types::statics::CastFrequency::Unlimited,
+        })
+        .affected(TargetFilter::Typed(
+            TypedFilter::card().controller(ControllerRef::You),
+        ));
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(grant);
+
+        let recast = create_object(
+            &mut state,
+            CardId(2),
+            caster,
+            "Graveyard Recast".to_string(),
+            Zone::Graveyard,
+        );
+        let card_id = state.objects[&recast].card_id;
+        {
+            let obj = state.objects.get_mut(&recast).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            // Stale stamp from a previous hand cast (constructed directly to
+            // isolate the ordering; the zone-exit cleanup normally clears it).
+            obj.cast_from_zone = Some(Zone::Hand);
+        }
+        let mut pending = PendingCast::new(
+            recast,
+            card_id,
+            ResolvedAbility::new(Effect::NoOp, Vec::new(), recast, caster),
+            ManaCost::generic(4),
+        );
+        pending.origin_zone = Zone::Graveyard;
+        state.pending_cast = Some(Box::new(pending));
+
+        assert_eq!(
+            payable_spell_alternative_cost(&state, caster, recast),
+            None,
+            "the in-flight graveyard origin must outrank the stale Hand stamp"
+        );
+    }
 }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -841,17 +841,10 @@ pub(crate) fn payable_spell_alternative_cost_details(
 
     // CR 118.9 + CR 601.2f: A permanent-granted alternative MANA cost (Rooftop
     // Storm, Fist of Suns, Jodah) applies when no self-referential option does.
+    // CR 118.9 + CR 601.2a (#7575): zone reach is decided INSIDE
+    // `granted_spell_alternative_cost` — hand casts match normally, a non-hand
+    // origin only through an origin-scoped filter branch.
     let granted = super::casting::granted_spell_alternative_cost(state, player, object_id)?;
-    // CR 118.9 + CR 601.2a (#7575): the offer's default reach is hand casts.
-    // A grant whose own filter constrains the ORIGIN zone (Warped Space: "a
-    // spell you cast from exile") has already matched this cast's origin, so
-    // it reaches that authorized non-hand cast. Zone-LESS grants (Rooftop
-    // Storm class) keep the hand-only default: widening them to
-    // permission-authorized graveyard/exile casts is a separate, measured
-    // change, not a side effect of this one.
-    if origin_zone != Zone::Hand && !granted.origin_zone_scoped {
-        return None;
-    }
     spell_alternative_cost_is_payable(state, player, object_id, &granted.cost).then_some(
         PayableSpellAlternativeCost {
             cost: granted.cost,
@@ -23738,6 +23731,165 @@ its replicate cost was paid.)\nDraw a card.";
                 cost: ManaCost::zero()
             }),
             "the exile-scoped {{0}} grant must reach a card in exile"
+        );
+    }
+
+    /// #7575 review (mixed `Or`): a cast matching only the UNSCOPED branch of
+    /// a mixed filter must not unlock the non-hand reach — while the same
+    /// branch keeps working for a hand cast (default reach).
+    #[test]
+    fn a_mixed_or_grant_stays_hand_only_for_the_unscoped_branch() {
+        use crate::types::ability::{FilterProp, StaticDefinition};
+
+        let mut state = GameState::new_two_player(42);
+        let caster = PlayerId(0);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            caster,
+            "Mixed Grant Host".to_string(),
+            Zone::Battlefield,
+        );
+        let mut hand_scoped = TypedFilter::card().controller(ControllerRef::You);
+        hand_scoped
+            .properties
+            .push(FilterProp::InZone { zone: Zone::Hand });
+        let grant = StaticDefinition::new(StaticMode::CastWithAlternativeCost {
+            cost: AbilityCost::Mana {
+                cost: ManaCost::zero(),
+            },
+            timing_permission: None,
+            frequency: crate::types::statics::CastFrequency::Unlimited,
+        })
+        .affected(TargetFilter::Or {
+            filters: vec![
+                TargetFilter::Typed(hand_scoped),
+                TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+            ],
+        });
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(grant);
+
+        let exiled = create_object(
+            &mut state,
+            CardId(2),
+            caster,
+            "Exiled Creature".to_string(),
+            Zone::Exile,
+        );
+        state
+            .objects
+            .get_mut(&exiled)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        assert_eq!(
+            payable_spell_alternative_cost(&state, caster, exiled),
+            None,
+            "the exile cast matches only the unscoped creature branch — hand-only reach"
+        );
+
+        let hand = create_object(
+            &mut state,
+            CardId(3),
+            caster,
+            "Hand Creature".to_string(),
+            Zone::Hand,
+        );
+        state
+            .objects
+            .get_mut(&hand)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        assert_eq!(
+            payable_spell_alternative_cost(&state, caster, hand),
+            Some(AbilityCost::Mana {
+                cost: ManaCost::zero()
+            }),
+            "the same unscoped branch keeps its default hand reach"
+        );
+    }
+
+    /// #7575 review (stack origin): once the object sits ON the stack, the
+    /// pending cast's recorded origin drives the exile-scoped grant — an
+    /// exile origin receives it, a graveyard origin (zone mismatch) does not.
+    #[test]
+    fn the_pending_cast_origin_drives_the_exile_scoped_grant() {
+        use crate::types::ability::{Effect, FilterProp, ResolvedAbility, StaticDefinition};
+        use crate::types::game_state::PendingCast;
+
+        let mut state = GameState::new_two_player(42);
+        let caster = PlayerId(0);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            caster,
+            "Warped Host".to_string(),
+            Zone::Battlefield,
+        );
+        let mut typed = TypedFilter::card().controller(ControllerRef::You);
+        typed
+            .properties
+            .push(FilterProp::InZone { zone: Zone::Exile });
+        let grant = StaticDefinition::new(StaticMode::CastWithAlternativeCost {
+            cost: AbilityCost::Mana {
+                cost: ManaCost::zero(),
+            },
+            timing_permission: None,
+            frequency: crate::types::statics::CastFrequency::Unlimited,
+        })
+        .affected(TargetFilter::Typed(typed));
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(grant);
+
+        let spell = create_object(
+            &mut state,
+            CardId(2),
+            caster,
+            "Mid-Cast Spell".to_string(),
+            Zone::Stack,
+        );
+        let card_id = state.objects[&spell].card_id;
+        state
+            .objects
+            .get_mut(&spell)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        let mut pending = PendingCast::new(
+            spell,
+            card_id,
+            ResolvedAbility::new(Effect::NoOp, Vec::new(), spell, caster),
+            ManaCost::generic(4),
+        );
+        pending.origin_zone = Zone::Exile;
+        state.pending_cast = Some(Box::new(pending));
+        assert_eq!(
+            payable_spell_alternative_cost(&state, caster, spell),
+            Some(AbilityCost::Mana {
+                cost: ManaCost::zero()
+            }),
+            "an exile-origin pending cast on the stack must receive the exile-scoped grant"
+        );
+
+        state.pending_cast.as_mut().unwrap().origin_zone = Zone::Graveyard;
+        assert_eq!(
+            payable_spell_alternative_cost(&state, caster, spell),
+            None,
+            "a graveyard-origin pending cast is a zone mismatch for the exile-scoped grant"
         );
     }
 }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -781,9 +781,13 @@ pub(crate) fn payable_spell_alternative_cost_details(
     object_id: ObjectId,
 ) -> Option<PayableSpellAlternativeCost> {
     let obj = state.objects.get(&object_id)?;
-    if obj.zone != Zone::Hand || obj.controller != player {
+    if obj.controller != player {
         return None;
     }
+    // CR 601.2a: the offer is scoped by the cast's ORIGIN zone (the object may
+    // already sit on the stack when a pending cast re-asks).
+    let origin_zone =
+        super::casting::pending_cast_origin_zone_for(state, object_id).unwrap_or(obj.zone);
     // This prompt reuses `AdditionalCost::Choice`, so keep it to pure
     // alternative/free-cast cards until the pending-cast flow can compose
     // alternative and additional costs in one CR 601.2f total-cost pass.
@@ -799,33 +803,38 @@ pub(crate) fn payable_spell_alternative_cost_details(
     // is not a CR-mandated precedence; honoring full controller choice across a
     // self-option and one or more grants needs a multi-alternative choice
     // surface and is a known limitation tracked for follow-up.
-    let self_option = obj.casting_options.iter().find_map(|option| {
-        if option.condition.as_ref().is_some_and(|condition| {
-            !restrictions::evaluate_condition(state, player, object_id, condition)
-        }) {
-            return None;
-        }
-        let cost = match option.kind {
-            SpellCastingOptionKind::AlternativeCost => option.cost.clone()?,
-            SpellCastingOptionKind::CastWithoutManaCost => AbilityCost::Mana {
-                cost: ManaCost::NoCost,
-            },
-            SpellCastingOptionKind::AsThoughHadFlash | SpellCastingOptionKind::CastAdventure => {
+    let self_option = (origin_zone == Zone::Hand)
+        .then(|| obj.casting_options.iter())
+        .into_iter()
+        .flatten()
+        .find_map(|option| {
+            if option.condition.as_ref().is_some_and(|condition| {
+                !restrictions::evaluate_condition(state, player, object_id, condition)
+            }) {
                 return None;
             }
-        };
-        if spell_alternative_cost_is_payable(state, player, object_id, &cost) {
-            Some(PayableSpellAlternativeCost {
-                cost,
-                timing_permission: None,
-                // CR 118.9: a spell's own printed alternative cost carries no
-                // per-turn grant slot to consume.
-                once_per_turn_source: None,
-            })
-        } else {
-            None
-        }
-    });
+            let cost = match option.kind {
+                SpellCastingOptionKind::AlternativeCost => option.cost.clone()?,
+                SpellCastingOptionKind::CastWithoutManaCost => AbilityCost::Mana {
+                    cost: ManaCost::NoCost,
+                },
+                SpellCastingOptionKind::AsThoughHadFlash
+                | SpellCastingOptionKind::CastAdventure => {
+                    return None;
+                }
+            };
+            if spell_alternative_cost_is_payable(state, player, object_id, &cost) {
+                Some(PayableSpellAlternativeCost {
+                    cost,
+                    timing_permission: None,
+                    // CR 118.9: a spell's own printed alternative cost carries no
+                    // per-turn grant slot to consume.
+                    once_per_turn_source: None,
+                })
+            } else {
+                None
+            }
+        });
     if self_option.is_some() {
         return self_option;
     }
@@ -833,6 +842,16 @@ pub(crate) fn payable_spell_alternative_cost_details(
     // CR 118.9 + CR 601.2f: A permanent-granted alternative MANA cost (Rooftop
     // Storm, Fist of Suns, Jodah) applies when no self-referential option does.
     let granted = super::casting::granted_spell_alternative_cost(state, player, object_id)?;
+    // CR 118.9 + CR 601.2a (#7575): the offer's default reach is hand casts.
+    // A grant whose own filter constrains the ORIGIN zone (Warped Space: "a
+    // spell you cast from exile") has already matched this cast's origin, so
+    // it reaches that authorized non-hand cast. Zone-LESS grants (Rooftop
+    // Storm class) keep the hand-only default: widening them to
+    // permission-authorized graveyard/exile casts is a separate, measured
+    // change, not a side effect of this one.
+    if origin_zone != Zone::Hand && !granted.origin_zone_scoped {
+        return None;
+    }
     spell_alternative_cost_is_payable(state, player, object_id, &granted.cost).then_some(
         PayableSpellAlternativeCost {
             cost: granted.cost,
@@ -23662,5 +23681,63 @@ its replicate cost was paid.)\nDraw a card.";
         assert_eq!(state.objects[&blue].zone, Zone::Hand);
         assert!(state.stack.iter().any(|entry| entry.source_id == march));
         assert_eq!(state.players[0].mana_pool.total(), 0);
+    }
+
+    /// PROBE #7575: an exile-scoped grant (InZone{Exile} on the affected
+    /// filter) must reach a card in exile.
+    #[test]
+    fn granted_alternative_cost_reaches_an_exile_scoped_cast() {
+        use crate::types::ability::{FilterProp, StaticDefinition};
+
+        let mut state = GameState::new_two_player(42);
+        let caster = PlayerId(0);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            caster,
+            "Warped Host".to_string(),
+            Zone::Battlefield,
+        );
+        let mut typed = TypedFilter::card().controller(ControllerRef::You);
+        typed
+            .properties
+            .push(FilterProp::InZone { zone: Zone::Exile });
+        let grant = StaticDefinition::new(StaticMode::CastWithAlternativeCost {
+            cost: AbilityCost::Mana {
+                cost: ManaCost::zero(),
+            },
+            timing_permission: None,
+            frequency: crate::types::statics::CastFrequency::OncePerTurn,
+        })
+        .affected(TargetFilter::Typed(typed));
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(grant);
+
+        let exiled = create_object(
+            &mut state,
+            CardId(2),
+            caster,
+            "Exiled Bear".to_string(),
+            Zone::Exile,
+        );
+        state
+            .objects
+            .get_mut(&exiled)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+
+        assert_eq!(
+            payable_spell_alternative_cost(&state, caster, exiled),
+            Some(AbilityCost::Mana {
+                cost: ManaCost::zero()
+            }),
+            "the exile-scoped {{0}} grant must reach a card in exile"
+        );
     }
 }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -786,8 +786,7 @@ pub(crate) fn payable_spell_alternative_cost_details(
     }
     // CR 601.2a: the offer is scoped by the cast's ORIGIN zone (the object may
     // already sit on the stack when a pending cast re-asks).
-    let origin_zone =
-        super::casting::pending_cast_origin_zone_for(state, object_id).unwrap_or(obj.zone);
+    let origin_zone = super::casting::spell_cast_origin_zone(state, obj);
     // This prompt reuses `AdditionalCost::Choice`, so keep it to pure
     // alternative/free-cast cards until the pending-cast flow can compose
     // alternative and additional costs in one CR 601.2f total-cost pass.
@@ -23890,6 +23889,107 @@ its replicate cost was paid.)\nDraw a card.";
             payable_spell_alternative_cost(&state, caster, spell),
             None,
             "a graveyard-origin pending cast is a zone mismatch for the exile-scoped grant"
+        );
+    }
+
+    /// #7782 round 2 (CodeRabbit): after `finalize_cast` the pending record is
+    /// gone and `cast_from_zone` is the surviving origin authority. A re-ask
+    /// must still see the true origin — a zone-less grant keeps matching the
+    /// finalized hand cast, and the exile-scoped grant the finalized exile
+    /// cast.
+    #[test]
+    fn the_stamped_cast_from_zone_survives_finalize_for_the_grant() {
+        use crate::types::ability::{FilterProp, StaticDefinition};
+
+        let mut state = GameState::new_two_player(42);
+        let caster = PlayerId(0);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            caster,
+            "Rooftop Host".to_string(),
+            Zone::Battlefield,
+        );
+        let grant = StaticDefinition::new(StaticMode::CastWithAlternativeCost {
+            cost: AbilityCost::Mana {
+                cost: ManaCost::zero(),
+            },
+            timing_permission: None,
+            frequency: crate::types::statics::CastFrequency::Unlimited,
+        })
+        .affected(TargetFilter::Typed(
+            TypedFilter::card().controller(ControllerRef::You),
+        ));
+        state
+            .objects
+            .get_mut(&source)
+            .unwrap()
+            .static_definitions
+            .push(grant);
+
+        let finalized = create_object(
+            &mut state,
+            CardId(2),
+            caster,
+            "Finalized Hand Cast".to_string(),
+            Zone::Stack,
+        );
+        {
+            let obj = state.objects.get_mut(&finalized).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.cast_from_zone = Some(Zone::Hand);
+        }
+        assert_eq!(
+            payable_spell_alternative_cost(&state, caster, finalized),
+            Some(AbilityCost::Mana {
+                cost: ManaCost::zero()
+            }),
+            "the zone-less grant must keep matching the finalized hand cast"
+        );
+
+        let mut typed = TypedFilter::card().controller(ControllerRef::You);
+        typed
+            .properties
+            .push(FilterProp::InZone { zone: Zone::Exile });
+        let exile_grant = StaticDefinition::new(StaticMode::CastWithAlternativeCost {
+            cost: AbilityCost::Mana {
+                cost: ManaCost::zero(),
+            },
+            timing_permission: None,
+            frequency: crate::types::statics::CastFrequency::Unlimited,
+        })
+        .affected(TargetFilter::Typed(typed));
+        let exile_source = create_object(
+            &mut state,
+            CardId(3),
+            caster,
+            "Warped Host".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&exile_source)
+            .unwrap()
+            .static_definitions
+            .push(exile_grant);
+        let exile_finalized = create_object(
+            &mut state,
+            CardId(4),
+            caster,
+            "Finalized Exile Cast".to_string(),
+            Zone::Stack,
+        );
+        {
+            let obj = state.objects.get_mut(&exile_finalized).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.cast_from_zone = Some(Zone::Exile);
+        }
+        assert_eq!(
+            payable_spell_alternative_cost(&state, caster, exile_finalized),
+            Some(AbilityCost::Mana {
+                cost: ManaCost::zero()
+            }),
+            "the exile-scoped grant must keep matching the finalized exile cast"
         );
     }
 }

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -338,19 +338,7 @@ pub(crate) fn apply_zone_exit_cleanup(
         // restored into the graveyard.
         crate::game::flip::revert_flip_on_zone_exit(obj_mut);
 
-        // CR 400.7: a zone change makes a new object with no memory of its
-        // cast. The `cast_from_zone` stamp (written at finalize for
-        // "was it cast from …" consumers) survives only onto the STACK (the
-        // cast itself) and onto the BATTLEFIELD (resolution — battlefield
-        // readers consume it there); every other destination clears it so a
-        // later recast from another zone cannot inherit a stale origin.
-        // The battlefield already owns its two resets
-        // (`reset_for_battlefield_entry`, restored from `CastLinkSnapshot`
-        // for genuine cast resolutions, and `reset_for_battlefield_exit`);
-        // this covers the remaining stack-exit window.
-        if to != Zone::Stack && to != Zone::Battlefield {
-            obj_mut.cast_from_zone = None;
-        }
+        clear_cast_origin_off_provenance_zones(obj_mut, to);
 
         // CR 400.7 + CR 113.6e: Clear exile-based casting permissions when leaving exile
         // (prevents re-casting if the card returns to exile via a different effect).
@@ -863,6 +851,24 @@ pub fn resolve_and_apply_zone_change(
 
 /// Installs one recorded transition core without a replacement consult, query,
 /// timestamp allocation, or incarnation allocation.
+/// CR 400.7: the narrow `cast_from_zone` lifetime — the stamp survives only
+/// onto the STACK (the cast itself) and onto the BATTLEFIELD (whose entry
+/// reset + `CastLinkSnapshot` restore own it there,
+/// `reset_for_battlefield_entry`/`_exit`). Every other destination clears it,
+/// so a spell leaving the stack countered/fizzled/resolved-to-graveyard
+/// cannot hand a stale origin to a later recast. ONE primitive shared by the
+/// live transition cleanup and the resolved-zone-change replay applier, so
+/// replay equivalence holds by construction rather than by two hand-kept
+/// conditions.
+pub(crate) fn clear_cast_origin_off_provenance_zones(
+    obj: &mut crate::game::game_object::GameObject,
+    to: Zone,
+) {
+    if to != Zone::Stack && to != Zone::Battlefield {
+        obj.cast_from_zone = None;
+    }
+}
+
 pub fn apply_resolved_zone_change(
     state: &mut GameState,
     command: &ResolvedZoneChangeCommand,
@@ -946,6 +952,8 @@ pub fn apply_resolved_zone_change(
         );
     } else {
         object.incarnation = command.resulting_incarnation;
+        // CR 400.7: same cast-origin lifetime as the live transition cleanup.
+        clear_cast_origin_off_provenance_zones(object, command.to);
     }
     if object.incarnation != command.resulting_incarnation {
         return Err(
@@ -4366,6 +4374,49 @@ mod tests {
         assert_eq!(obj.name, "Front Face", "must show front face in graveyard");
         assert_eq!(obj.power, Some(1), "power must revert to front face");
         assert_eq!(obj.card_types.core_types, vec![CoreType::Creature]);
+    }
+
+    /// #7782 round 4: the REPLAY applier must install the same cast-origin
+    /// lifetime as the live path — a replayed stamped Stack → Graveyard
+    /// command clears the stamp exactly like the live transition did.
+    #[test]
+    fn a_replayed_stack_exit_clears_the_stamp_like_the_live_one() {
+        let mut live = setup();
+        let id = create_object(
+            &mut live,
+            CardId(7783),
+            PlayerId(0),
+            "Replayed Spell".to_string(),
+            Zone::Stack,
+        );
+        live.objects.get_mut(&id).unwrap().cast_from_zone = Some(Zone::Hand);
+        let mut replayed = live.clone();
+
+        let record = crate::types::game_state::ZoneChangeRecord::test_minimal(
+            id,
+            Some(Zone::Stack),
+            Zone::Graveyard,
+        );
+        let command = resolve_and_apply_zone_change(
+            &mut live,
+            id,
+            Zone::Stack,
+            Zone::Graveyard,
+            PlayerId(0),
+            record,
+        )
+        .expect("live transition must resolve");
+        assert_eq!(
+            live.objects[&id].cast_from_zone, None,
+            "reach-guard: the live transition clears the stamp"
+        );
+
+        apply_resolved_zone_change(&mut replayed, &command)
+            .expect("replaying the recorded command must succeed");
+        assert_eq!(
+            replayed.objects[&id].cast_from_zone, None,
+            "the replayed transition must clear the stamp exactly like the live one"
+        );
     }
 
     /// #7782 round 3: a spell leaving the STACK for a non-battlefield zone

--- a/crates/engine/src/game/zones.rs
+++ b/crates/engine/src/game/zones.rs
@@ -338,6 +338,20 @@ pub(crate) fn apply_zone_exit_cleanup(
         // restored into the graveyard.
         crate::game::flip::revert_flip_on_zone_exit(obj_mut);
 
+        // CR 400.7: a zone change makes a new object with no memory of its
+        // cast. The `cast_from_zone` stamp (written at finalize for
+        // "was it cast from …" consumers) survives only onto the STACK (the
+        // cast itself) and onto the BATTLEFIELD (resolution — battlefield
+        // readers consume it there); every other destination clears it so a
+        // later recast from another zone cannot inherit a stale origin.
+        // The battlefield already owns its two resets
+        // (`reset_for_battlefield_entry`, restored from `CastLinkSnapshot`
+        // for genuine cast resolutions, and `reset_for_battlefield_exit`);
+        // this covers the remaining stack-exit window.
+        if to != Zone::Stack && to != Zone::Battlefield {
+            obj_mut.cast_from_zone = None;
+        }
+
         // CR 400.7 + CR 113.6e: Clear exile-based casting permissions when leaving exile
         // (prevents re-casting if the card returns to exile via a different effect).
         if from == Zone::Exile {
@@ -4352,6 +4366,32 @@ mod tests {
         assert_eq!(obj.name, "Front Face", "must show front face in graveyard");
         assert_eq!(obj.power, Some(1), "power must revert to front face");
         assert_eq!(obj.card_types.core_types, vec![CoreType::Creature]);
+    }
+
+    /// #7782 round 3: a spell leaving the STACK for a non-battlefield zone
+    /// (countered / fizzled / instant to the graveyard) must lose its
+    /// `cast_from_zone` stamp (CR 400.7 — a new object has no memory of its
+    /// cast), so a later recast from another zone cannot inherit the stale
+    /// origin. The battlefield legs are owned by `reset_for_battlefield_entry`
+    /// / `_exit` and their `CastLinkSnapshot` restore.
+    #[test]
+    fn the_cast_from_zone_stamp_dies_off_stack_and_battlefield() {
+        let mut state = setup();
+        let id = create_object(
+            &mut state,
+            CardId(7782),
+            PlayerId(0),
+            "Stamped Spell".to_string(),
+            Zone::Stack,
+        );
+        state.objects.get_mut(&id).unwrap().cast_from_zone = Some(Zone::Hand);
+
+        let mut events = Vec::new();
+        move_to_zone(&mut state, id, Zone::Graveyard, &mut events);
+        assert_eq!(
+            state.objects[&id].cast_from_zone, None,
+            "a spell leaving the stack for the graveyard must lose the stamp (CR 400.7)"
+        );
     }
 
     /// CR 708.9: A face-down permanent is revealed when it leaves the battlefield.

--- a/crates/engine/src/parser/oracle_static/cost_mod.rs
+++ b/crates/engine/src/parser/oracle_static/cost_mod.rs
@@ -453,6 +453,17 @@ pub(crate) fn parse_spells_alternative_cost(text: &str) -> Option<StaticDefiniti
     let type_prefix_original = subject.original[..type_prefix_lower.len()].trim();
     let after_spells = after_spells_lower.trim();
 
+    // CR 601.2a + CR 118.9: optional origin-zone qualifier on the subject — "a
+    // spell you cast from exile" (Warped Space, Dragon's Smile, Tlincalli
+    // Hunter), "a colorless spell you cast from your hand" (Darksteel
+    // Monolith). Shared zone authority with the keyword-grant subject walk;
+    // the runtime filter compares the cast's origin zone.
+    let (after_spells, zone_filter) =
+        match super::keyword_grant::parse_cast_origin_zone_qualifier(after_spells) {
+            Some((rest, prop)) => (rest, Some(prop)),
+            None => (after_spells, None),
+        };
+
     let parsed_cost = parse_oracle_cost(cost_slice);
     if !supported_alternative_cast_cost(&parsed_cost) {
         return None;
@@ -499,13 +510,32 @@ pub(crate) fn parse_spells_alternative_cost(text: &str) -> Option<StaticDefiniti
 
     // CR 118.9: a bare leading article ("a"/"an") with no type word — "a spell you
     // cast" (As Foretold) — scopes to any spell, same as the no-prefix case.
-    let base_filter = if matches!(type_prefix_lower.trim(), "" | "a" | "an") {
-        TargetFilter::Typed(TypedFilter::card())
+    let (base_filter, color_props) = if matches!(type_prefix_lower.trim(), "" | "a" | "an") {
+        (TargetFilter::Typed(TypedFilter::card()), Vec::new())
     } else {
-        parse_type_phrase(type_prefix_original).0
+        // CR 601.2a: singular subjects carry an article before the type word —
+        // "a creature spell", "a colorless spell" — peel it before the type
+        // phrase so the article is not read as a type word.
+        let peeled = opt(alt((tag::<_, _, VE<'_>>("a "), tag("an "))))
+            .parse(type_prefix_original)
+            .map_or(type_prefix_original, |(rest, _)| rest);
+        // CR 105.2: peel a color-quality prefix ("colorless spell" — Darksteel
+        // Monolith) via the shared authority — `parse_type_phrase` drops the
+        // word, which would silently over-broaden the grant to any spell. The
+        // helper expects the word with its trailing space, so re-pad the
+        // trimmed prefix slice.
+        let padded = format!("{peeled} ");
+        let (rest_padded, color_prop) = super::shared::peel_color_quality_prefix(&padded);
+        let rest = rest_padded.trim();
+        let base = if rest.is_empty() {
+            TargetFilter::Typed(TypedFilter::card())
+        } else {
+            parse_type_phrase(rest).0
+        };
+        (base, color_prop.into_iter().collect::<Vec<_>>())
     };
     let affected =
-        apply_spell_keyword_subject_constraints(base_filter, None, mv_filter, Vec::new());
+        apply_spell_keyword_subject_constraints(base_filter, zone_filter, mv_filter, color_props);
 
     Some(
         StaticDefinition::new(StaticMode::CastWithAlternativeCost {

--- a/crates/engine/src/parser/oracle_static/cost_mod.rs
+++ b/crates/engine/src/parser/oracle_static/cost_mod.rs
@@ -515,22 +515,29 @@ pub(crate) fn parse_spells_alternative_cost(text: &str) -> Option<StaticDefiniti
     } else {
         // CR 601.2a: singular subjects carry an article before the type word —
         // "a creature spell", "a colorless spell" — peel it before the type
-        // phrase so the article is not read as a type word.
-        let peeled = opt(alt((tag::<_, _, VE<'_>>("a "), tag("an "))))
-            .parse(type_prefix_original)
-            .map_or(type_prefix_original, |(rest, _)| rest);
+        // phrase so the article is not read as a type word. Grammar tokens are
+        // matched on the LOWERCASE view (mixed-case input must not skip the
+        // peel); only the preserved type tail hands the original-case slice on.
+        let prefix_lower = type_prefix_lower.trim();
+        let after_article = opt(alt((tag::<_, _, VE<'_>>("a "), tag("an "))))
+            .parse(prefix_lower)
+            .map_or(prefix_lower, |(rest, _)| rest);
         // CR 105.2: peel a color-quality prefix ("colorless spell" — Darksteel
         // Monolith) via the shared authority — `parse_type_phrase` drops the
         // word, which would silently over-broaden the grant to any spell. The
         // helper expects the word with its trailing space, so re-pad the
         // trimmed prefix slice.
-        let padded = format!("{peeled} ");
+        let padded = format!("{after_article} ");
         let (rest_padded, color_prop) = super::shared::peel_color_quality_prefix(&padded);
         let rest = rest_padded.trim();
         let base = if rest.is_empty() {
             TargetFilter::Typed(TypedFilter::card())
         } else {
-            parse_type_phrase(rest).0
+            // End-anchored original tail: the peels only removed a prefix, so
+            // the remaining type words are the last `rest.len()` bytes of the
+            // trimmed original slice (the TextPair length-mapping convention).
+            let tail = &type_prefix_original[type_prefix_original.len() - rest.len()..];
+            parse_type_phrase(tail).0
         };
         (base, color_prop.into_iter().collect::<Vec<_>>())
     };

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -414,15 +414,10 @@ pub(crate) fn parse_spells_have_keyword(tp: &TextPair<'_>, text: &str) -> Option
         // correctly. Each qualifier consumes its own bytes.
         let mut cursor = after_spells;
 
-        // Parse optional zone qualifier: "from exile", "from your graveyard"
-        let zone_filter = if let Ok((rest, zone)) = alt((
-            value(Zone::Exile, tag::<_, _, VE<'_>>("from exile")),
-            value(Zone::Hand, tag("from your hand")),
-        ))
-        .parse(cursor)
-        {
-            cursor = rest.trim_start();
-            Some(FilterProp::InZone { zone })
+        // Parse optional zone qualifier via the shared authority below.
+        let zone_filter = if let Some((rest, prop)) = parse_cast_origin_zone_qualifier(cursor) {
+            cursor = rest;
+            Some(prop)
         } else {
             None
         };
@@ -678,6 +673,23 @@ pub(crate) fn parse_cast_as_though_flash_static(
         .description(text.to_string())
         .active_zones(vec![Zone::Battlefield]),
     )
+}
+
+/// CR 601.2a: Optional origin-zone qualifier on a "spell(s) you cast" subject —
+/// "from exile" / "from your hand". Single authority for the recognized zone
+/// list, shared by the keyword-grant subject walk and the alternative-cost
+/// grant lowering (`parse_spells_alternative_cost`). The runtime spell-filter
+/// path compares `FilterProp::InZone` against the cast's ORIGIN zone
+/// (`spell_object_matches_filter_inner`), so the lowered prop means "cast from
+/// that zone", not "currently in that zone".
+pub(crate) fn parse_cast_origin_zone_qualifier(input: &str) -> Option<(&str, FilterProp)> {
+    alt((
+        value(Zone::Exile, tag::<_, _, OracleError<'_>>("from exile")),
+        value(Zone::Hand, tag("from your hand")),
+    ))
+    .parse(input)
+    .ok()
+    .map(|(rest, zone)| (rest.trim_start(), FilterProp::InZone { zone }))
 }
 
 pub(crate) fn apply_spell_keyword_subject_constraints(

--- a/crates/engine/src/parser/oracle_static/keyword_grant.rs
+++ b/crates/engine/src/parser/oracle_static/keyword_grant.rs
@@ -4,6 +4,8 @@
 use super::prelude::*;
 #[allow(unused_imports)]
 use super::support::*;
+use nom::character::complete::alphanumeric1;
+use nom::combinator::not;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub(crate) enum RuleStaticPredicate {
@@ -683,10 +685,15 @@ pub(crate) fn parse_cast_as_though_flash_static(
 /// (`spell_object_matches_filter_inner`), so the lowered prop means "cast from
 /// that zone", not "currently in that zone".
 pub(crate) fn parse_cast_origin_zone_qualifier(input: &str) -> Option<(&str, FilterProp)> {
-    alt((
-        value(Zone::Exile, tag::<_, _, OracleError<'_>>("from exile")),
-        value(Zone::Hand, tag("from your hand")),
-    ))
+    // Word boundary: "from exile" must not accept "from exiled..." (the repo's
+    // parser doctrine — near-miss tokens reject, PR #7543's pattern).
+    terminated(
+        alt((
+            value(Zone::Exile, tag::<_, _, OracleError<'_>>("from exile")),
+            value(Zone::Hand, tag("from your hand")),
+        )),
+        not(alphanumeric1),
+    )
     .parse(input)
     .ok()
     .map(|(rest, zone)| (rest.trim_start(), FilterProp::InZone { zone }))

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1323,7 +1323,7 @@ fn parse_spells_have_quoted_keyword_list(text: &str) -> Option<Vec<StaticDefinit
 /// "multicolored") from a lowercase subject, returning the remainder and the
 /// matching `FilterProp::ColorCount` (CR 105.2). Mirrors the color-quality
 /// prefixes `oracle_target` recognizes before a type word.
-fn peel_color_quality_prefix(subject: &str) -> (&str, Option<FilterProp>) {
+pub(crate) fn peel_color_quality_prefix(subject: &str) -> (&str, Option<FilterProp>) {
     alt((
         value(
             FilterProp::ColorCount {

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -33246,3 +33246,120 @@ fn source_object_self_references_lower_to_cant_be_blocked_by() {
         );
     }
 }
+
+/// CR 118.9 + CR 601.2a (#7575): Warped Space — a once-per-turn {0}
+/// alternative for "a spell you cast from exile". The origin-zone qualifier
+/// lowers to `FilterProp::InZone { Exile }`, which the runtime spell-filter
+/// path compares against the cast's origin zone.
+#[test]
+fn alt_cost_warped_space_once_per_turn_from_exile() {
+    let def = parse_spells_alternative_cost(
+        "Once each turn, you may pay {0} rather than pay the mana cost for a spell you cast from exile.",
+    )
+    .expect("Warped Space must parse to a CastWithAlternativeCost static");
+    match &def.mode {
+        StaticMode::CastWithAlternativeCost {
+            cost, frequency, ..
+        } => {
+            assert_eq!(
+                *cost,
+                AbilityCost::Mana {
+                    cost: crate::types::mana::ManaCost::zero()
+                }
+            );
+            assert_eq!(*frequency, CastFrequency::OncePerTurn);
+        }
+        other => panic!("expected CastWithAlternativeCost, got {other:?}"),
+    }
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert_eq!(tf.controller, Some(ControllerRef::You));
+            assert!(
+                tf.properties
+                    .contains(&FilterProp::InZone { zone: Zone::Exile }),
+                "expected InZone(Exile) origin-zone prop, got {:?}",
+                tf.properties
+            );
+        }
+        other => panic!("expected Typed(spell you cast from exile), got {other:?}"),
+    }
+}
+
+/// CR 118.9 + CR 601.2a (#7575): Tlincalli Hunter — the same shape with a type
+/// prefix: "a creature spell you cast from exile". Article peeled, type kept,
+/// zone qualifier kept.
+#[test]
+fn alt_cost_tlincalli_hunter_creature_from_exile() {
+    let def = parse_spells_alternative_cost(
+        "Once each turn, you may pay {0} rather than pay the mana cost for a creature spell you cast from exile.",
+    )
+    .expect("Tlincalli Hunter must parse");
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert!(
+                tf.type_filters.contains(&TypeFilter::Creature),
+                "expected Creature type filter, got {:?}",
+                tf.type_filters
+            );
+            assert!(
+                tf.properties
+                    .contains(&FilterProp::InZone { zone: Zone::Exile }),
+                "expected InZone(Exile), got {:?}",
+                tf.properties
+            );
+        }
+        other => panic!("expected Typed(creature spell from exile), got {other:?}"),
+    }
+}
+
+/// CR 118.9 + CR 601.2a (#7575): Darksteel Monolith — "a colorless spell you
+/// cast from your hand". The color word must survive as a constraint (an
+/// over-broad any-spell filter would grant free colored casts), and the zone
+/// must be Hand.
+#[test]
+fn alt_cost_darksteel_monolith_colorless_from_hand() {
+    let def = parse_spells_alternative_cost(
+        "Once each turn, you may pay {0} rather than pay the mana cost for a colorless spell you cast from your hand.",
+    )
+    .expect("Darksteel Monolith must parse");
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert!(
+                tf.properties
+                    .contains(&FilterProp::InZone { zone: Zone::Hand }),
+                "expected InZone(Hand), got {:?}",
+                tf.properties
+            );
+            assert!(
+                tf.properties.contains(&FilterProp::ColorCount {
+                    comparator: Comparator::EQ,
+                    count: 0,
+                }),
+                "the colorless constraint (ColorCount EQ 0, CR 105.2) must survive lowering, got {tf:?}"
+            );
+        }
+        other => panic!("expected Typed(colorless spell from hand), got {other:?}"),
+    }
+}
+
+/// PIN (green before #7575, Regel 5): As Foretold's zone-less line keeps
+/// parsing unchanged — once-per-turn frequency, no InZone prop.
+#[test]
+fn alt_cost_as_foretold_stays_zone_free() {
+    let def = parse_spells_alternative_cost(
+        "Once each turn, you may pay {0} rather than pay the mana cost for a spell you cast.",
+    )
+    .expect("As Foretold must keep parsing");
+    match &def.affected {
+        Some(TargetFilter::Typed(tf)) => {
+            assert!(
+                !tf.properties
+                    .iter()
+                    .any(|p| matches!(p, FilterProp::InZone { .. })),
+                "no origin-zone prop may appear on the zone-less line, got {:?}",
+                tf.properties
+            );
+        }
+        other => panic!("expected Typed(any spell), got {other:?}"),
+    }
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1112,6 +1112,7 @@ mod vrestin_menoptra_leader_5949;
 mod waiting_for_actor_authority_census;
 mod ward_of_bones_relative_count_cast_prohibition;
 mod ward_of_bones_relative_count_land_prohibition;
+mod warped_space_alt_cost_from_exile;
 mod wedding_announcement_transform;
 mod wedding_ring_etb_token_copy;
 mod well_of_lost_dreams_may_pay_x;

--- a/crates/engine/tests/integration/warped_space_alt_cost_from_exile.rs
+++ b/crates/engine/tests/integration/warped_space_alt_cost_from_exile.rs
@@ -101,7 +101,10 @@ fn warped_space_lets_one_exile_cast_pay_zero_each_turn() {
         "the spell must reach the stack having paid {{0}}"
     );
 
-    // CR 302.1: creature spells need an empty stack; resolve before the probe.
+    // CR 117.1a: a noninstant spell is cast only while the stack is empty, so
+    // resolve the first cast before the second probe. (CR 302.1 is the
+    // hand-specific creature rule; the exile permission replaces the zone,
+    // CR 101.1, not the cadence.)
     runner.resolve_top();
 
     // CR 118.9 + CR 601.2b: "Once each turn" — the slot is spent, the second
@@ -112,9 +115,12 @@ fn warped_space_lets_one_exile_cast_pay_zero_each_turn() {
     );
 }
 
-/// PIN (green before the fix too, Regel 5): the grant is scoped to casts FROM
-/// EXILE — a hand cast with an empty pool must stay rejected while the grant
-/// is active. Guards the InZone prop against being dropped or over-broadened.
+/// The grant is scoped to casts FROM EXILE — a hand cast with an empty pool
+/// must stay rejected while the SAME fixture's exile cast succeeds through the
+/// grant. The positive half is the reach guard: it proves the static parsed
+/// and is live (not `Unimplemented`), so the hand rejection measures the
+/// origin-zone filter rather than a parser failure. Order matters: the hand
+/// probe runs FIRST, while the once-per-turn slot is provably unspent.
 #[test]
 fn warped_space_does_not_reach_a_hand_cast() {
     let mut scenario = GameScenario::new();
@@ -124,10 +130,101 @@ fn warped_space_does_not_reach_a_hand_cast() {
         .add_creature_to_hand(P0, "Hand Bear", 2, 2)
         .with_mana_cost(ManaCost::generic(4))
         .id();
+    let exiled = scenario
+        .add_creature_to_exile(P0, "Exile Control", 2, 2)
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
     let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&exiled)
+        .unwrap()
+        .casting_permissions
+        .push(exile_permission());
 
     assert!(
         !cast(&mut runner, hand),
         "an exile-scoped grant must not admit a hand cast with an empty pool"
+    );
+
+    // Positive reach guard: the same grant, same turn, unspent slot — the
+    // exile cast must go through for {0}.
+    assert!(
+        cast(&mut runner, exiled),
+        "reach-guard: the fixture's exile cast must be admitted by the grant"
+    );
+    runner
+        .act(GameAction::DecideOptionalCost { pay: true })
+        .expect("the {0} alternative must be acceptable");
+    assert_eq!(
+        runner.state().objects[&exiled].zone,
+        Zone::Stack,
+        "reach-guard: the exile cast reaches the stack through the live grant"
+    );
+}
+
+/// #7575 review: "Once each turn" must RESET at the next turn — an
+/// implementation that consumes the grant permanently would pass the same-turn
+/// denial alone. Advance through a full turn cycle back to the caster and
+/// prove the {0} choice is available again.
+#[test]
+fn the_once_per_turn_slot_resets_on_the_next_turn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_enchantment_from_oracle(P0, "Warped Static Host", WARPED_SPACE_TEXT);
+    let first = scenario
+        .add_creature_to_exile(P0, "First Exile", 2, 2)
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
+    let second = scenario
+        .add_creature_to_exile(P0, "Second Exile", 2, 2)
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
+    let mut runner = scenario.build();
+    for id in [first, second] {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .casting_permissions
+            .push(exile_permission());
+    }
+
+    assert!(cast(&mut runner, first), "the first cast must be admitted");
+    runner
+        .act(GameAction::DecideOptionalCost { pay: true })
+        .expect("the {0} alternative must be acceptable");
+    runner.resolve_top();
+    assert!(
+        !cast(&mut runner, second),
+        "reach-guard: the slot is spent for the rest of this turn"
+    );
+
+    // A full turn cycle: the opponent's turn, then back to the caster.
+    let mut events = Vec::new();
+    engine::game::turns::start_next_turn(runner.state_mut(), &mut events);
+    engine::game::turns::start_next_turn(runner.state_mut(), &mut events);
+    let state = runner.state_mut();
+    state.phase = Phase::PreCombatMain;
+    state.priority_player = P0;
+    state.waiting_for = WaitingFor::Priority { player: P0 };
+
+    assert!(
+        cast(&mut runner, second),
+        "the once-per-turn slot must be fresh on the caster's next turn"
+    );
+    match &runner.state().waiting_for {
+        WaitingFor::OptionalCostChoice { .. } => {}
+        other => panic!("expected the fresh {{0}} choice, got {other:?}"),
+    }
+    runner
+        .act(GameAction::DecideOptionalCost { pay: true })
+        .expect("the fresh {0} alternative must be payable");
+    assert_eq!(
+        runner.state().objects[&second].zone,
+        Zone::Stack,
+        "the second exile cast pays {{0}} on the new turn"
     );
 }

--- a/crates/engine/tests/integration/warped_space_alt_cost_from_exile.rs
+++ b/crates/engine/tests/integration/warped_space_alt_cost_from_exile.rs
@@ -1,0 +1,133 @@
+//! CR 118.9 + CR 601.2a (#7575): "Once each turn, you may pay {0} rather than
+//! pay the mana cost for a spell you cast from exile." (Warped Space) lowered
+//! its whole line to `Effect::Unimplemented`: `parse_spells_alternative_cost`
+//! strict-failed on the origin-zone qualifier after "spell you cast".
+//!
+//! Class (measured against card-data.json, 4 cards, all Unimplemented before
+//! the fix): Warped Space, Dragon's Smile, Tlincalli Hunter ("from exile"),
+//! Darksteel Monolith ("a colorless spell you cast from your hand").
+//!
+//! The runtime needed no change: `granted_spell_alternative_cost` evaluates the
+//! `affected` filter through the spell-filter path, whose
+//! `FilterProp::InZone` arm compares the cast's ORIGIN zone. These tests host
+//! the static on a plain enchantment — Room door gating is #7573's merged
+//! concern, not this one.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{CastingPermission, Duration};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::statics::CastFrequency;
+use engine::types::zones::{EtbTapState, Zone};
+
+const WARPED_SPACE_TEXT: &str = "Once each turn, you may pay {0} rather than pay the mana cost for a spell you cast from exile.";
+
+fn exile_permission() -> CastingPermission {
+    CastingPermission::PlayFromExile {
+        duration: Duration::UntilEndOfTurn,
+        granted_to: P0,
+        frequency: CastFrequency::Unlimited,
+        source_id: None,
+        invalidation: None,
+        exiled_by_ability_controller: None,
+        mana_spend_permission: None,
+        card_filter: None,
+        single_use_group: None,
+        single_use: false,
+        cast_cost_raise: None,
+        land_enter_tapped: EtbTapState::Unspecified,
+    }
+}
+
+fn cast(runner: &mut engine::game::scenario::GameRunner, spell: ObjectId) -> bool {
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .is_ok()
+}
+
+/// CR 118.9 + CR 601.2b: the first exile cast each turn may pay {0} — with an
+/// EMPTY pool and an unpayable printed {4}, the cast must succeed through the
+/// grant. The second exile cast that turn gets no choice and dies unpaid.
+///
+/// Discriminating: before the fix the line is Unimplemented, no grant exists,
+/// and the first cast is rejected outright.
+#[test]
+fn warped_space_lets_one_exile_cast_pay_zero_each_turn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_enchantment_from_oracle(P0, "Warped Static Host", WARPED_SPACE_TEXT);
+    let first = scenario
+        .add_creature_to_exile(P0, "First Exile", 2, 2)
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
+    let second = scenario
+        .add_creature_to_exile(P0, "Second Exile", 2, 2)
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
+    let mut runner = scenario.build();
+    for id in [first, second] {
+        runner
+            .state_mut()
+            .objects
+            .get_mut(&id)
+            .unwrap()
+            .casting_permissions
+            .push(exile_permission());
+    }
+
+    assert!(
+        cast(&mut runner, first),
+        "the {{0}} grant must admit the cast with an empty pool"
+    );
+    match &runner.state().waiting_for {
+        WaitingFor::OptionalCostChoice { .. } => {}
+        other => panic!("expected the {{0}}-vs-printed OptionalCostChoice, got {other:?}"),
+    }
+    runner
+        .act(GameAction::DecideOptionalCost { pay: true })
+        .expect("accepting the {0} alternative must succeed");
+    assert_eq!(
+        runner.state().objects[&first].zone,
+        Zone::Stack,
+        "the spell must reach the stack having paid {{0}}"
+    );
+
+    // CR 302.1: creature spells need an empty stack; resolve before the probe.
+    runner.resolve_top();
+
+    // CR 118.9 + CR 601.2b: "Once each turn" — the slot is spent, the second
+    // exile cast gets no {0} choice, and with an empty pool it must die.
+    assert!(
+        !cast(&mut runner, second),
+        "the second exile cast this turn must not get the spent {{0}} slot"
+    );
+}
+
+/// PIN (green before the fix too, Regel 5): the grant is scoped to casts FROM
+/// EXILE — a hand cast with an empty pool must stay rejected while the grant
+/// is active. Guards the InZone prop against being dropped or over-broadened.
+#[test]
+fn warped_space_does_not_reach_a_hand_cast() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_enchantment_from_oracle(P0, "Warped Static Host", WARPED_SPACE_TEXT);
+    let hand = scenario
+        .add_creature_to_hand(P0, "Hand Bear", 2, 2)
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
+    let mut runner = scenario.build();
+
+    assert!(
+        !cast(&mut runner, hand),
+        "an exile-scoped grant must not admit a hand cast with an empty pool"
+    );
+}


### PR DESCRIPTION
Fixes #7575.

**Defect.** "Once each turn, you may pay {0} rather than pay the mana cost for a spell you cast from exile." lowered to `Effect::Unimplemented`: `parse_spells_alternative_cost` strict-failed on the origin-zone qualifier after "spell you cast".

**Parser.** The zone qualifier the keyword-grant subject walk already recognizes ("from exile" / "from your hand" → `FilterProp::InZone`) is now one shared authority (`parse_cast_origin_zone_qualifier`) used by both paths; the alternative-cost lowering consumes it before the mana-value gate and fills the `zone_filter` slot `apply_spell_keyword_subject_constraints` already carries. Singular subjects peel their article (nom combinators), and a color-quality word routes through the shared `peel_color_quality_prefix` — `parse_type_phrase` drops it, which would have silently over-broadened Darksteel Monolith's grant to any spell.

**Engine.** `payable_spell_alternative_cost_details` gated ALL granted alternative costs to hand casts. A grant whose own `affected` filter constrains the cast's origin zone has already matched that origin, so it now reaches the authorized non-hand cast; the gate reads `pending_cast_origin_zone_for`, not the object's current zone. Zone-LESS grants (Rooftop Storm, Fist of Suns, Jodah, As Foretold) keep their hand-only reach unchanged — widening them to permission-authorized graveyard/exile casts is CR-plausible (CR 118.9) but a separate, separately measured change.

**Class** (all 35,798 cards double-parsed, fix in vs. out): exactly 4 cards change — Warped Space, Dragon's Smile, Tlincalli Hunter ("from exile"), Darksteel Monolith ("a colorless spell you cast from your hand"). All four lowered to Unimplemented before.

**Counter-proofs** (abort-guarded probes, run separately): parser half removed → the three zone unit tests and the exile integration test fail, the zone-less pins stay green; engine half removed → parser tests stay green, exactly the exile integration test fails.

**Tests.** 4 parser unit tests (incl. an As Foretold zone-less pin and the colorless-constraint guard), 1 grant unit probe, 2 integration tests (empty-pool exile cast pays {0} via `OptionalCostChoice`, the second cast that turn is denied; a hand cast stays out of the exile-scoped grant's reach). Suites: fmt 0, clippy 0, `--lib` 19606, `--test integration` 5374, 0 failed.

**Not covered.**
- `payable_spell_alternative_cost_for_timing` keeps its hand-only gate; no timing-permission grant in the class carries a zone scope.
- The choice arm still fires only for `CastingVariant::Normal` casts; a face-down or otherwise variant-elected exile cast gets no {0} choice (no measured card needs it).
- Room door gating is #7573's merged concern; the tests host the static on a plain enchantment.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Alternative casting costs can now depend on a spell’s origin zone, including exile and hand.
  * Origin qualifiers can be combined with creature, color, and once-per-turn restrictions.
  * Origin-specific grants support eligible non-hand casts while preserving hand-only restrictions.

* **Bug Fixes**
  * Improved mixed-case cost parsing and rejection of invalid origin phrases.
  * Preserved unrestricted “spell you cast” behavior.
  * Corrected stale cast-origin information after spells change zones.

* **Tests**
  * Added coverage for origin parsing, exile-based casting, and cast-origin tracking.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->