### PR TITLE
fix(client): give a version-skewed P2P guest a diagnosis instead of a hang

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -484,7 +484,9 @@ const NATIVE_GUEST_ATTACHMENT = {
 
 async function joinGuest(
   emitConnection: (c: DataConnection) => void,
-  msg: { type: "guest_deck"; deckData: unknown } | { type: "reconnect"; playerToken: string },
+  msg:
+    | { type: "guest_deck"; deckData: unknown; wireProtocolVersion?: number }
+    | { type: "reconnect"; playerToken: string; wireProtocolVersion?: number },
 ): Promise<FakeOpenableConnection> {
   const conn = new FakeOpenableConnection();
   emitConnection(conn as unknown as DataConnection);
@@ -2624,5 +2626,188 @@ describe("P2PHostAdapter — shared-engine ownership", () => {
     await expect(adapter.submitAction({ type: "PassPriority" }, 0)).rejects.toThrow(
       "P2P host adapter has been disposed",
     );
+  });
+});
+
+describe("P2P wire-protocol version gate", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  const setupFrameAt = (wireProtocolVersion: number) => ({
+    type: "game_setup" as const,
+    wireProtocolVersion,
+    assignedPlayerId: 1,
+    playerToken: "seat-token",
+    state: remoteState("setup"),
+    events: [],
+    legalActions: [],
+    autoPassRecommended: false,
+    manaPaymentShortcutActions: [],
+  });
+
+  function makeGuest(
+    conn: FakeDataConnection = new FakeDataConnection(),
+    peer?: unknown,
+    existingPlayerToken?: string,
+  ) {
+    const adapter = new P2PGuestAdapter(
+      { player: { main_deck: [], sideboard: [] } },
+      (peer ?? createFakePeer().peer) as unknown as Peer,
+      "host-peer",
+      conn as unknown as DataConnection,
+      existingPlayerToken,
+    );
+    const emitted = vi.fn();
+    adapter.onEvent(emitted);
+    return { conn, adapter, emitted };
+  }
+
+  const sentOfType = async (conn: FakeDataConnection, type: string) =>
+    (await conn.getSentMessages()).find(
+      (m) => typeof m === "object" && m !== null && (m as { type: string }).type === type,
+    ) as { type: string; reason?: string; wireProtocolVersion?: number } | undefined;
+
+  // Relocated here from `protocol.test.ts`, where this pair guarded
+  // `validateMessage`. The version rule now lives solely in
+  // `P2PGuestAdapter.handleHostMessage`, so an instrument pointed at the
+  // validator would guard nothing; this one points at the adapter's DECISION.
+  // The frame also traverses the real validator on the way in — this file's
+  // decode stub ends in `real.validateMessage` — so a regression that put the
+  // check back into the transport would surface here as the refusing half
+  // never emitting.
+  //
+  // Both halves stamp LITERALS. A frame built from WIRE_PROTOCOL_VERSION
+  // cannot tell a bumped client from an unbumped one, which is why every
+  // other handshake fixture in the suite is useless as an instrument for a
+  // bump. Revert 26 → 25 and BOTH halves red: the v25 frame stops being
+  // refused, and the v26 frame stops being admitted. The admitting half is
+  // the reach-guard — without it "refuses v25" is also satisfied by a client
+  // that refuses everything.
+  it("refuses the previous wire protocol (v25) and admits its own (v26)", async () => {
+    const refusing = makeGuest();
+    await refusing.adapter.initialize();
+    await refusing.conn.simulateData(setupFrameAt(25));
+
+    await expect(refusing.adapter.initializeGame()).rejects.toMatchObject({
+      code: "P2P_REJECTED",
+      message: expect.stringContaining("Wire protocol mismatch"),
+    });
+    expect(refusing.emitted).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "reconnectFailed" }),
+    );
+
+    const admitting = makeGuest();
+    await admitting.adapter.initialize();
+    await admitting.conn.simulateData(setupFrameAt(26));
+
+    await expect(admitting.adapter.initializeGame()).resolves.toBeDefined();
+    expect(admitting.emitted).not.toHaveBeenCalledWith(
+      expect.objectContaining({ type: "reconnectFailed" }),
+    );
+  });
+
+  // Derived, not a literal: this gate tests "unequal", not any particular
+  // version, so it must not become a second bump tripwire. The literal-stamped
+  // instrument is the guest-side pair above.
+  const SKEWED_GUEST_VERSION = WIRE_PROTOCOL_VERSION + 1;
+
+  it("refuses a guest whose first contact stamps a different wire version", async () => {
+    const { adapter, emitConnection } = makeHost(2);
+    await adapter.initialize();
+
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+      wireProtocolVersion: SKEWED_GUEST_VERSION,
+    });
+
+    const rejected = await sentOfType(guest, "reconnect_rejected");
+    expect(rejected).toBeDefined();
+    // Mirrors the guest-side wording so both peers read the same sentence.
+    expect(rejected!.reason).toBe(
+      `Wire protocol mismatch: guest sent v${SKEWED_GUEST_VERSION}, this host speaks v${WIRE_PROTOCOL_VERSION}. Refresh both windows.`,
+    );
+    expect(guest.open).toBe(false);
+    expect(await sentOfType(guest, "game_setup")).toBeUndefined();
+    adapter.dispose();
+  });
+
+  // The discriminator for "absent means admit". Without it this gate is
+  // indistinguishable from one that treats a missing field as a mismatch —
+  // which would refuse every guest on an older bundle, including the ones
+  // that pair fine today.
+  it("admits a guest that stamps no wire version at all", async () => {
+    const { adapter, emitConnection } = makeHost(2);
+    await adapter.initialize();
+
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    await adapter.initializeGame();
+
+    expect(await sentOfType(guest, "reconnect_rejected")).toBeUndefined();
+    expect(guest.open).toBe(true);
+    expect(await sentOfType(guest, "game_setup")).toBeDefined();
+    adapter.dispose();
+  });
+
+  // The two first-contact stamp sites, asserted on the OUTBOUND frame. Neither
+  // was covered before: deleting either stamp left the whole suite green,
+  // because a guest that fails to stamp is indistinguishable from an older
+  // bundle and the host's absent-means-admit branch swallows it silently. A
+  // refactor dropping the `guest_deck` stamp would turn Unit 2 into a no-op
+  // for every fresh join — the common path — with nothing red.
+  it("stamps the wire version on both first-contact guest messages", async () => {
+    const fresh = makeGuest();
+    await fresh.adapter.initialize();
+    // `initialize` does not await its own send: `peer.ts` queues the encode,
+    // and `getSentMessages` drains decode-side work only. Flush the queue
+    // before reading, or the frame has not reached `conn.send` yet.
+    await vi.advanceTimersByTimeAsync(0);
+    const guestDeck = await sentOfType(fresh.conn, "guest_deck");
+    expect(guestDeck).toBeDefined();
+    expect(guestDeck!.wireProtocolVersion).toBe(WIRE_PROTOCOL_VERSION);
+
+    const resuming = makeGuest(new FakeDataConnection(), undefined, "prior-token");
+    await resuming.adapter.initialize();
+    await vi.advanceTimersByTimeAsync(0);
+    const reconnect = await sentOfType(resuming.conn, "reconnect");
+    expect(reconnect).toBeDefined();
+    expect(reconnect!.wireProtocolVersion).toBe(WIRE_PROTOCOL_VERSION);
+  });
+
+  // The third stamp site: a guest that drops and comes back through
+  // `attemptReconnect` must still carry the version, or every reconnection
+  // after a transient blip would look like an old bundle to the host.
+  it("stamps the wire version on a reconnect after a transient drop", async () => {
+    const initialConn = new FakeDataConnection();
+    const rejoinConn = new FakeOpenableConnection();
+    const peer = {
+      on() {},
+      off() {},
+      destroy() {},
+      connect: () => rejoinConn,
+    };
+    const { adapter, conn } = makeGuest(initialConn, peer);
+    await adapter.initialize();
+    await conn.simulateData(setupFrameAt(WIRE_PROTOCOL_VERSION));
+    await adapter.initializeGame();
+
+    conn.simulateClose();
+    // Drain the first backoff step, then complete the WebRTC open handshake
+    // the reconnect path awaits.
+    await vi.advanceTimersByTimeAsync(1_000);
+    rejoinConn.fireOpen();
+    await vi.advanceTimersByTimeAsync(0);
+
+    const reconnect = await sentOfType(rejoinConn, "reconnect");
+    expect(reconnect).toBeDefined();
+    expect(reconnect!.wireProtocolVersion).toBe(WIRE_PROTOCOL_VERSION);
+    adapter.dispose();
   });
 });

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -1507,6 +1507,40 @@ export class P2PHostAdapter implements EngineAdapter {
       identified = true;
       unsub();
 
+      // Host-side wire-version gate. A guest that stamps a version unequal
+      // to ours cannot be paired, so refuse it here — before a seat or a deck
+      // is allocated — through the rejection affordance this gate already
+      // has. `reconnect_rejected` is `{ type, reason }` only, so even a guest
+      // on an older bundle can decode it.
+      //
+      // ABSENT MEANS ADMIT. The version is bumped only on a
+      // non-backward-compatible change, so {guests on an older bundle}
+      // strictly contains {guests that are wire-incompatible}: an absent
+      // field reports bundle age, not incompatibility, and refusing on it
+      // would drop guests that pair fine today with a reason that is
+      // factually false for them. The consequence, stated rather than
+      // implied: this host cannot distinguish a compatible old bundle from
+      // an incompatible one. `P2PGuestAdapter.handleHostMessage` is the
+      // authority for the latter. This mirrors the call `acceptsHostAuthority`
+      // already makes for its own additive stamp. What this gate buys is
+      // prospective: once both sides ship, every future bump is caught
+      // host-side at first contact.
+      const guestVersion =
+        msg.type === "guest_deck" || msg.type === "reconnect" ? msg.wireProtocolVersion : undefined;
+      if (guestVersion !== undefined && guestVersion !== WIRE_PROTOCOL_VERSION) {
+        // Reaches the refused guest's user RAW, the same way the guest-side
+        // reason at `handleHostMessage` does. `i18n/README.md` asks for `t()`
+        // on frontend-authored strings; this one is new text on that raw path
+        // and is written unkeyed deliberately, to match the incumbent
+        // wording rather than split the pair. Noted, not fixed: the raw-string
+        // path is pre-existing and out of scope here.
+        const reason = `Wire protocol mismatch: guest sent v${guestVersion}, this host speaks v${WIRE_PROTOCOL_VERSION}. Refresh both windows.`;
+        traceAdapter("Host", "first-message-version-mismatch", { type: msg.type, guestVersion });
+        void this.send(session, { type: "reconnect_rejected", reason });
+        session.close("Wire protocol mismatch");
+        return;
+      }
+
       if (msg.type === "reconnect") {
         traceAdapter("Host", "first-message", { type: msg.type });
         this.handleReconnect(session, msg.playerToken, msg.sessionKey);
@@ -2970,6 +3004,7 @@ export class P2PGuestAdapter implements EngineAdapter {
       this.send({
         type: "reconnect",
         playerToken: this.playerToken,
+        wireProtocolVersion: WIRE_PROTOCOL_VERSION,
         ...(this.authority ? { sessionKey: this.authority.sessionKey } : {}),
       });
     } else {
@@ -2979,6 +3014,7 @@ export class P2PGuestAdapter implements EngineAdapter {
         deckData: this.deckData,
         displayName: this.displayName,
         reservationToken: this.reservationToken,
+        wireProtocolVersion: WIRE_PROTOCOL_VERSION,
       });
     }
   }
@@ -3189,9 +3225,27 @@ export class P2PGuestAdapter implements EngineAdapter {
     // PEER_ID_PREFIX bump prevents *room discovery* across mismatched
     // bundles, but a same-version-prefix-different-message-shape change
     // would slip past it — that's what this guards.
+    //
+    // This is the SOLE guest-side enforcement point for the rule.
+    // `validateMessage` once checked it too, one layer lower: it threw from
+    // inside `decodeWireMessage`, and `peer.ts` warns-and-drops on a decode
+    // throw, so the frame died in the transport and this branch was dead code
+    // for the case it was written for. A lower layer cannot surface the
+    // mismatch — rejecting `gameSetupPromise` and emitting `reconnectFailed`
+    // both need adapter state the transport has no access to.
     if (msg.type === "game_setup" || msg.type === "reconnect_ack") {
-      if (msg.wireProtocolVersion !== WIRE_PROTOCOL_VERSION) {
-        const reason = `Wire protocol mismatch: host sent v${msg.wireProtocolVersion}, this client speaks v${WIRE_PROTOCOL_VERSION}. Refresh both windows.`;
+      // Read through a widened local: these two messages DECLARE the field at
+      // the literal `typeof WIRE_PROTOCOL_VERSION`, so comparing `msg.…`
+      // directly narrows `msg` to `never` in the mismatch branch and the
+      // interpolation below stops compiling. The runtime value is whatever the
+      // host actually sent, which is the entire point of the check.
+      const hostVersion: number = msg.wireProtocolVersion;
+      if (hostVersion !== WIRE_PROTOCOL_VERSION) {
+        // This reason reaches the user RAW: rejectGameSetup → AdapterError
+        // → GameProvider's error toast. `i18n/README.md` asks for `t()` on
+        // frontend-authored strings; this path predates that and is left as
+        // found — the violation is pre-existing and out of scope here.
+        const reason = `Wire protocol mismatch: host sent v${hostVersion}, this client speaks v${WIRE_PROTOCOL_VERSION}. Refresh both windows.`;
         console.error("[P2PGuestAdapter]", reason);
         this.terminated = true;
         this.rejectGameSetup(reason);
@@ -3498,6 +3552,7 @@ export class P2PGuestAdapter implements EngineAdapter {
         this.send({
           type: "reconnect",
           playerToken: this.playerToken,
+          wireProtocolVersion: WIRE_PROTOCOL_VERSION,
           ...(this.authority ? { sessionKey: this.authority.sessionKey } : {}),
         });
       }

--- a/client/src/network/__tests__/peer.test.ts
+++ b/client/src/network/__tests__/peer.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi } from "vitest";
 
+import { buildGameState } from "../../test/factories/gameStateFactory";
 import { createPeerSession } from "../peer";
 import { validateMessage } from "../protocol";
 import type { P2PMessage } from "../protocol";
@@ -234,5 +235,36 @@ describe("PeerSession", () => {
     expect(onDisconnect).toHaveBeenCalledTimes(1);
     expect(onDisconnect).toHaveBeenCalledWith("Channel send failed");
     errorSpy.mockRestore();
+  });
+
+  // A wire-version skew must TRAVERSE the transport, not die inside it. This
+  // file mocks nothing, so the REAL `encodeWireMessage`/`decodeWireMessage`
+  // and the real binary framing run end to end — the one place in the suite
+  // where that is true. A `game_setup` stamped with a stale version used to
+  // throw inside `decodeWireMessage` and be swallowed by the decode `catch`
+  // above: frame dropped, channel open, nothing downstream told, guest hung.
+  // The version rule now lives solely in the adapter, so the frame must
+  // arrive at an `onMessage` handler for that rule to be able to run at all.
+  it("delivers a stale-wire-version game_setup to the message handler", async () => {
+    const { conn, session } = createTestSession();
+    const handler = vi.fn();
+    session.onMessage(handler);
+
+    await conn.simulateData({
+      type: "game_setup",
+      wireProtocolVersion: 25,
+      assignedPlayerId: 1,
+      playerToken: "token-123",
+      state: buildGameState(),
+      events: [],
+      legalActions: [],
+      manaPaymentShortcutActions: [],
+    });
+
+    expect(handler).toHaveBeenCalledTimes(1);
+    expect(handler).toHaveBeenCalledWith(
+      expect.objectContaining({ type: "game_setup", wireProtocolVersion: 25 }),
+    );
+    session.close();
   });
 });

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -240,38 +240,6 @@ describe("encodeWireMessage / decodeWireMessage", () => {
     await expect(decodeWireMessage(new Uint8Array())).rejects.toThrow(/empty/);
   });
 
-  const setupFrameAt = (wireProtocolVersion: number) => ({
-    type: "game_setup",
-    wireProtocolVersion,
-    assignedPlayerId: 1,
-    playerToken: "token-123",
-    state: buildGameState(),
-    events: [],
-    legalActions: [],
-    manaPaymentShortcutActions: [],
-  });
-
-  it("rejects stale setup wire protocol versions", () => {
-    expect(() => validateMessage(setupFrameAt(4))).toThrow(/Wire protocol mismatch/);
-  });
-
-  // The ADJACENT-peer pairing, which the far-stale v4 row above cannot exercise:
-  // 4 is refused whatever this client speaks, so that row proves the mechanism
-  // and nothing about the version. Both halves here stamp LITERALS — a frame
-  // built from WIRE_PROTOCOL_VERSION cannot tell a bumped client from an
-  // unbumped one, which is why every other handshake fixture in the suite is
-  // useless as an instrument for a bump. Revert 26 → 25 and BOTH halves red:
-  // the v25 frame stops being refused, and the v26 frame stops being admitted.
-  // The admitting half is the reach-guard: without it "refuses v25" is also
-  // satisfied by a client that refuses everything.
-  it("refuses the previous wire protocol (v25) and admits its own (v26)", () => {
-    expect(() => validateMessage(setupFrameAt(25))).toThrow(/Wire protocol mismatch/);
-    expect(validateMessage(setupFrameAt(26))).toMatchObject({
-      type: "game_setup",
-      wireProtocolVersion: 26,
-    });
-  });
-
   // (e) Compressed payload still gates through validateMessage so unknown
   // message types are rejected, not silently passed through.
   it("decode runs validateMessage — unknown type rejected", async () => {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -79,6 +79,20 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  * in-band and surface an actionable "refresh both windows" message instead
  * of silently corrupting state.
  *
+ * A host → guest mismatch is enforced in exactly ONE place:
+ * `P2PGuestAdapter.handleHostMessage` (`adapter/p2p-adapter.ts`).
+ * `validateMessage` below deliberately does NOT check it. A throw from there
+ * propagates out of `decodeWireMessage` into the `catch` in `peer.ts`, which
+ * warns and drops the frame — so the host's `game_setup` never reaches the
+ * adapter, the setup promise never settles and the guest hangs on the
+ * connecting screen with no layer able to tell the user. Only the adapter
+ * holds the state needed to perform the response.
+ *
+ * The guest → host direction has its own single site: guests stamp this version
+ * on `guest_deck` / `reconnect`, and `P2PHostAdapter`'s first-contact gate
+ * refuses a stamped mismatch. That field is optional and an absent one is
+ * admitted; see the gate for why.
+ *
  * Bumps to date:
  *  26 — DerivedViews.current_target_kind publishes the engine's CR 115.1
  *       classification of the live target announcement. The field is optional
@@ -135,7 +149,12 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
 export const WIRE_PROTOCOL_VERSION = 26 as const;
 
 export type P2PMessage = P2PAuthorityWire & (
-  | { type: "guest_deck"; deckData: unknown; displayName?: string; reservationToken?: string }
+  // `wireProtocolVersion` is optional on both first-contact guest messages:
+  // guests on an older bundle cannot stamp it, and the host admits those.
+  // Typed `number` rather than `typeof WIRE_PROTOCOL_VERSION` on purpose —
+  // the literal type would narrow the host's "present and unequal" branch
+  // to `never`.
+  | { type: "guest_deck"; deckData: unknown; displayName?: string; reservationToken?: string; wireProtocolVersion?: number }
   | ({
       type: "game_setup";
       wireProtocolVersion: typeof WIRE_PROTOCOL_VERSION;
@@ -168,7 +187,7 @@ export type P2PMessage = P2PAuthorityWire & (
   /** Protected by a draft-installed match capability on the host. */
   | { type: "match_concede" }
   // Reconnect: guest presents prior token; host accepts (with fresh state) or rejects.
-  | { type: "reconnect"; playerToken: string; sessionKey?: P2PSessionKey }
+  | { type: "reconnect"; playerToken: string; sessionKey?: P2PSessionKey; wireProtocolVersion?: number }
   | ({
       type: "reconnect_ack";
       wireProtocolVersion: typeof WIRE_PROTOCOL_VERSION;
@@ -257,14 +276,6 @@ export function validateMessage(raw: unknown): P2PMessage {
   const msg = raw as { type: string };
   if (!VALID_TYPES.has(msg.type)) {
     throw new Error(`Invalid message type: ${msg.type}`);
-  }
-  if (msg.type === "game_setup" || msg.type === "reconnect_ack") {
-    const versioned = raw as { wireProtocolVersion?: unknown };
-    if (versioned.wireProtocolVersion !== WIRE_PROTOCOL_VERSION) {
-      throw new Error(
-        `Wire protocol mismatch: host sent v${String(versioned.wireProtocolVersion)}, this client speaks v${WIRE_PROTOCOL_VERSION}`,
-      );
-    }
   }
   return raw as P2PMessage;
 }


### PR DESCRIPTION
A guest whose bundle speaks a different P2P wire version than the host sat on
the connecting screen indefinitely with nothing on screen explaining why. The
adapter already had a complete, correct branch for exactly this case —
`handleHostMessage` sets `terminated`, rejects the setup promise, and emits
"Wire protocol mismatch: ... Refresh both windows." It was dead code.

The rule was enforced in TWO places. `validateMessage` checked the same
condition one layer lower and threw; `decodeWireMessage` propagated the throw;
and `peer.ts` catches decode failures with a `console.warn` and drops the frame.
So `game_setup` never reached the adapter, `gameSetupPromise` never settled,
`terminated` stayed false, and the reconnect loop kept the "reconnecting"
indicator up forever — the same "the game is hung and won't say why" report
class as #7692.

Two authorities for one rule, where the earlier silently disabled the later.
The fix is to delete the duplicate, not to add a discriminator: the transport
cannot perform the response in either direction — the guest side needs
`rejectGameSetup` plus an emit, the host side needs `reconnect_rejected` plus
`session.close`, and both require adapter state the transport has no access to.
`protocol.ts`'s own doc comment already said the adapter was the intended site.

Also adds the missing half. `guest_deck` and `reconnect` carried no version at
all, so a skewed guest was admitted and then hung. Both now stamp it and the
host's first-contact gate refuses a mismatch before a seat or deck is allocated,
using the rejection affordance already there. `reconnect_rejected` is
`{ type, reason }` only, so even an older bundle can decode the refusal.

An ABSENT version means ADMIT, deliberately. The version is bumped only on a
non-backward-compatible change, so {guests on an older bundle} strictly contains
{guests that are wire-incompatible}: absence reports bundle age, not
incompatibility. Refusing on it would drop guests that pair fine today, with a
reason that is factually false for them — and would have refused all 59 existing
unstamped sends in the test suite. This mirrors the call `acceptsHostAuthority`
already makes for its own additive stamp. What the host gate buys is
prospective: once both sides ship, every future bump is caught at first contact.

No WIRE_PROTOCOL_VERSION bump: the repo's criterion scopes bumps to the binary
wire format or the shape of `game_setup`/`reconnect_ack`, and this touches
neither. A bump would also be inert, since an older guest never stamps the field
and is admitted on absence regardless of its value.

Not fixed, and not claimed to be: an already-deployed pre-fix guest still hangs
against a new host. The channel to tell it exists, but no reliable host-side
trigger does — a healthy guest sends nothing back on `game_setup`, so there is
no ack to time out, and ping/pong carry no version and are answered below the
adapter. Type-set skew is likewise still open: two peers can share a version and
differ in message types (`e71861e873` added `match_concede` without a bump), and
an unknown type still warns-and-drops. Both are distinct pre-existing classes
from the version-mismatch hang and are left for their own change.

Every behavioural claim here has a test that goes red when the behaviour is
reverted, verified by deletion rather than by reading: each of the three stamp
sites, the host gate, the absent-admits discriminator, and both halves of the
relocated version instrument. That instrument moved from `validateMessage` to
the adapter and kept its adjacent-pair literal-stamped form, so a client that
bumps the constant without updating the pins still reds.

Claude-Session: https://claude.ai/code/session_013eDt2CTWnim1rkaqh7uqF1
