### PR TITLE
fix(client): keep resolve-all sessions cancel-only

### DIFF
--- a/client/src/components/board/ActionButton.tsx
+++ b/client/src/components/board/ActionButton.tsx
@@ -369,7 +369,7 @@ export function ActionButton() {
           </>
         )}
 
-        {mode === "priority-stack" && (
+        {mode === "priority-stack" && !isResolvingStack && (
           <>
             {canCompanionToHand && (
               <button

--- a/client/src/components/board/__tests__/ActionButton.test.tsx
+++ b/client/src/components/board/__tests__/ActionButton.test.tsx
@@ -316,6 +316,29 @@ describe("ActionButton", () => {
     expect(vi.mocked(dispatchAction)).toHaveBeenCalledWith({ type: "CancelAutoPass" });
   });
 
+  it("keeps UntilStackEmpty cancel-only when the local player holds priority", () => {
+    useGameStore.setState({
+      gameMode: "online",
+      gameState: {
+        ...createGameState(priorityPrompt()),
+        phase: "PostCombatMain",
+        active_player: 0,
+        auto_pass: { 0: { type: "UntilStackEmpty", initial_stack_len: 1 } },
+        stack: [spellStackEntry(1)],
+      },
+      waitingFor: priorityPrompt(),
+      legalActions: [],
+      isResolvingAll: false,
+    });
+    useMultiplayerStore.setState({ activePlayerId: 0, actionPending: false });
+
+    render(<ActionButton />);
+
+    expect(screen.getByRole("button", { name: "Resolving Stack..." })).toBeEnabled();
+    expect(screen.queryByRole("button", { name: "Resolve" })).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Resolve All" })).not.toBeInTheDocument();
+  });
+
   it("no longer client-gates Confirm/Skip on a must-attack creature (engine is the authority)", () => {
     const target = { type: "Player", data: 1 } as const;
     const wf: WaitingFor = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated stack-resolution controls to prevent conflicting actions while the stack is resolving.
  * Players now see only the available “Resolving Stack…” cancellation control during an active auto-pass session.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->