### PR TITLE
fix(engine): preserve targets before conditional continuations

### DIFF
--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -2742,20 +2742,25 @@ fn collect_target_slots_inner(
             });
         }
     } else if let Effect::Attach { attachment, target } = &ability.effect {
-        collect_attach_attachment_target_slots(state, ability, attachment, acc)?;
-        if attach_host_filter_needs_target_slot(target) {
-            let legal_targets =
-                legal_targets_for_ability_filter(state, ability, target, &acc.slots);
-            if legal_targets.is_empty() && !ability.optional_targeting {
-                return Err(no_legal_target_slots());
+        // CR 115.1 + CR 608.2d: an untargeted attachment choice occurs while
+        // resolving, so it must not claim a target slot when this ability is
+        // announced.
+        if ability.target_choice_timing == TargetChoiceTiming::Stack {
+            collect_attach_attachment_target_slots(state, ability, attachment, acc)?;
+            if attach_host_filter_needs_target_slot(target) {
+                let legal_targets =
+                    legal_targets_for_ability_filter(state, ability, target, &acc.slots);
+                if legal_targets.is_empty() && !ability.optional_targeting {
+                    return Err(no_legal_target_slots());
+                }
+                acc.push(TargetSelectionSlot {
+                    legal_targets,
+                    optional: ability.optional_targeting,
+                    chooser: None,
+                    effect_kind: acc.current_effect_kind,
+                    effect_detail: acc.current_effect_detail,
+                });
             }
-            acc.push(TargetSelectionSlot {
-                legal_targets,
-                optional: ability.optional_targeting,
-                chooser: None,
-                effect_kind: acc.current_effect_kind,
-                effect_detail: acc.current_effect_detail,
-            });
         }
     } else if let Effect::CreateDamageReplacement {
         recipient_object_filter,
@@ -4751,21 +4756,23 @@ fn collect_target_slot_specs(
             });
         }
     } else if let Effect::Attach { attachment, target } = &ability.effect {
-        collect_attach_attachment_target_slot_specs(
-            state,
-            ability,
-            attachment,
-            specs,
-            next_instance,
-        );
-        if attach_host_filter_needs_target_slot(target) {
-            let id = TargetInstanceId(*next_instance);
-            *next_instance += 1;
-            specs.push(TargetSlotSpec {
-                filter: target.clone(),
-                optional: ability.optional_targeting,
-                instance: id,
-            });
+        if ability.target_choice_timing == TargetChoiceTiming::Stack {
+            collect_attach_attachment_target_slot_specs(
+                state,
+                ability,
+                attachment,
+                specs,
+                next_instance,
+            );
+            if attach_host_filter_needs_target_slot(target) {
+                let id = TargetInstanceId(*next_instance);
+                *next_instance += 1;
+                specs.push(TargetSlotSpec {
+                    filter: target.clone(),
+                    optional: ability.optional_targeting,
+                    instance: id,
+                });
+            }
         }
     } else if let Effect::CreateDamageReplacement {
         recipient_object_filter,
@@ -6625,43 +6632,45 @@ fn assign_targets_recursive(
         return Ok(());
     }
 
-    if let Effect::Attach { attachment, target } = &ability.effect {
-        let attachment = attachment.clone();
-        let target = target.clone();
-        assign_attach_attachment_declared_targets(
-            state,
-            ability,
-            &attachment,
-            &target,
-            targets,
-            next_target,
-        )?;
-        if attach_host_filter_needs_target_slot(&target) {
-            if let Some(target) = targets.get(*next_target) {
-                ability.targets.push(target.clone());
-                *next_target += 1;
-            } else if !ability.optional_targeting {
-                return Err(EngineError::InvalidAction(
-                    "Missing required target".to_string(),
-                ));
-            }
-        }
-        if defers_sub_ability_target_selection(&ability.effect) {
-            assign_targets_after_deferred_effect(
+    if ability.target_choice_timing == TargetChoiceTiming::Stack {
+        if let Effect::Attach { attachment, target } = &ability.effect {
+            let attachment = attachment.clone();
+            let target = target.clone();
+            assign_attach_attachment_declared_targets(
                 state,
-                ability.sub_ability.as_deref_mut(),
+                ability,
+                &attachment,
+                &target,
                 targets,
                 next_target,
             )?;
-            return Ok(());
-        }
-        if let Some(sub_ability) = ability.sub_ability.as_mut() {
-            if defers_conditional_target_selection(sub_ability) {
+            if attach_host_filter_needs_target_slot(&target) {
+                if let Some(target) = targets.get(*next_target) {
+                    ability.targets.push(target.clone());
+                    *next_target += 1;
+                } else if !ability.optional_targeting {
+                    return Err(EngineError::InvalidAction(
+                        "Missing required target".to_string(),
+                    ));
+                }
+            }
+            if defers_sub_ability_target_selection(&ability.effect) {
+                assign_targets_after_deferred_effect(
+                    state,
+                    ability.sub_ability.as_deref_mut(),
+                    targets,
+                    next_target,
+                )?;
                 return Ok(());
             }
-            assign_targets_recursive(state, sub_ability, targets, next_target)?;
+            if let Some(sub_ability) = ability.sub_ability.as_mut() {
+                if defers_conditional_target_selection(sub_ability) {
+                    return Ok(());
+                }
+                assign_targets_recursive(state, sub_ability, targets, next_target)?;
+            }
+            return Ok(());
         }
-        return Ok(());
     }
 
     if let Effect::Fight { subject, target } = &ability.effect {
@@ -6983,49 +6992,51 @@ fn assign_selected_slots_recursive(
         return Ok(());
     }
 
-    if let Effect::Attach { attachment, target } = &ability.effect {
-        let attachment = attachment.clone();
-        let target = target.clone();
-        assign_attach_attachment_selected_slots(
-            state,
-            ability,
-            &attachment,
-            selected_slots,
-            next_slot,
-        )?;
-        if attach_host_filter_needs_target_slot(&target) {
-            let Some(selected_slot) = selected_slots.get(*next_slot) else {
-                return Err(EngineError::InvalidAction(
-                    "Missing target selection".to_string(),
-                ));
-            };
-            match selected_slot {
-                Some(target) => ability.targets.push(target.clone()),
-                None if ability.optional_targeting => {}
-                None => {
-                    return Err(EngineError::InvalidAction(
-                        "Missing required target".to_string(),
-                    ));
-                }
-            }
-            *next_slot += 1;
-        }
-        if defers_sub_ability_target_selection(&ability.effect) {
-            assign_selected_slots_after_deferred_effect(
+    if ability.target_choice_timing == TargetChoiceTiming::Stack {
+        if let Effect::Attach { attachment, target } = &ability.effect {
+            let attachment = attachment.clone();
+            let target = target.clone();
+            assign_attach_attachment_selected_slots(
                 state,
-                ability.sub_ability.as_deref_mut(),
+                ability,
+                &attachment,
                 selected_slots,
                 next_slot,
             )?;
-            return Ok(());
-        }
-        if let Some(sub_ability) = ability.sub_ability.as_mut() {
-            if defers_conditional_target_selection(sub_ability) {
+            if attach_host_filter_needs_target_slot(&target) {
+                let Some(selected_slot) = selected_slots.get(*next_slot) else {
+                    return Err(EngineError::InvalidAction(
+                        "Missing target selection".to_string(),
+                    ));
+                };
+                match selected_slot {
+                    Some(target) => ability.targets.push(target.clone()),
+                    None if ability.optional_targeting => {}
+                    None => {
+                        return Err(EngineError::InvalidAction(
+                            "Missing required target".to_string(),
+                        ));
+                    }
+                }
+                *next_slot += 1;
+            }
+            if defers_sub_ability_target_selection(&ability.effect) {
+                assign_selected_slots_after_deferred_effect(
+                    state,
+                    ability.sub_ability.as_deref_mut(),
+                    selected_slots,
+                    next_slot,
+                )?;
                 return Ok(());
             }
-            assign_selected_slots_recursive(state, sub_ability, selected_slots, next_slot)?;
+            if let Some(sub_ability) = ability.sub_ability.as_mut() {
+                if defers_conditional_target_selection(sub_ability) {
+                    return Ok(());
+                }
+                assign_selected_slots_recursive(state, sub_ability, selected_slots, next_slot)?;
+            }
+            return Ok(());
         }
-        return Ok(());
     }
 
     if let Effect::Fight { subject, target } = &ability.effect {
@@ -7439,11 +7450,13 @@ fn chain_has_target_sink(ability: &ResolvedAbility) -> bool {
         return !matches!(target, TargetFilter::SelfRef | TargetFilter::ParentTarget);
     }
 
-    if let Effect::Attach { attachment, target } = &ability.effect {
-        if attach_side_needs_target_slot(attachment, true)
-            || attach_side_needs_target_slot(target, false)
-        {
-            return true;
+    if ability.target_choice_timing == TargetChoiceTiming::Stack {
+        if let Effect::Attach { attachment, target } = &ability.effect {
+            if attach_side_needs_target_slot(attachment, true)
+                || attach_side_needs_target_slot(target, false)
+            {
+                return true;
+            }
         }
     }
 

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -7634,6 +7634,14 @@ pub fn retarget_slot_violation(
 }
 
 fn minimum_targets_in_chain(state: &GameState, ability: &ResolvedAbility) -> usize {
+    // CR 601.2c + CR 603.3d: only targets announced while this ability is put on
+    // the stack reserve slots from an earlier multi-target sibling. A conditional
+    // continuation is announced, if at all, during resolution, so counting its
+    // targets here would let it steal the earlier sibling's selected slots.
+    if defers_conditional_target_selection(ability) {
+        return 0;
+    }
+
     let attach_targets = if let Effect::Attach { attachment, target } = &ability.effect {
         if ability.optional_targeting {
             0

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -5846,17 +5846,16 @@ fn damage_any_target_legal_targets(
     )
 }
 
-/// CR 603.12: Check if a sub-ability represents a reflexive trigger whose targeting
-/// should be deferred to resolution time. Reflexive trigger conditions (WhenYouDo,
-/// QuantityCheck on CountersOnSelf) indicate the sub-ability fires as a separate
-/// triggered ability during resolution — targets are chosen then, not at stack time.
+/// CR 603.12 + CR 608.2d: Whether a chained sub-ability chooses its targets while
+/// resolving rather than as its parent goes on the stack. Ordinary conditional and
+/// additional-cost-paid clauses retain their announced targets (CR 601.2c / CR 603.3d).
 fn defers_conditional_target_selection(sub: &ResolvedAbility) -> bool {
     matches!(
         &sub.condition,
         Some(AbilityCondition::WhenYouDo)
-            | Some(AbilityCondition::QuantityCheck { .. })
-            | Some(AbilityCondition::PreviousEffectAmount { .. })
-            | Some(AbilityCondition::AdditionalCostPaidInstead)
+    ) || matches!(
+        &sub.condition,
+        Some(AbilityCondition::AdditionalCostPaidInstead) if !sub.context.additional_cost_paid
     ) || sub.target_choice_timing == TargetChoiceTiming::Resolution
         // CR 608.2d + CR 601.2c: "You may" sub-instructions (Nahiri, the
         // Lithomancer +2 attach) choose whether to perform the action at
@@ -7634,10 +7633,9 @@ pub fn retarget_slot_violation(
 }
 
 fn minimum_targets_in_chain(state: &GameState, ability: &ResolvedAbility) -> usize {
-    // CR 601.2c + CR 603.3d: only targets announced while this ability is put on
-    // the stack reserve slots from an earlier multi-target sibling. A conditional
-    // continuation is announced, if at all, during resolution, so counting its
-    // targets here would let it steal the earlier sibling's selected slots.
+    // CR 601.2c + CR 603.3d: only resolution-time choices avoid reserving slots
+    // from an earlier multi-target sibling. Ordinary conditional and paid-cost
+    // continuations still announce their targets while the ability is stacked.
     if defers_conditional_target_selection(ability) {
         return 0;
     }

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -5847,21 +5847,16 @@ fn damage_any_target_legal_targets(
 }
 
 /// CR 603.12 + CR 608.2d: Whether a chained sub-ability chooses its targets while
-/// resolving rather than as its parent goes on the stack. Ordinary conditional and
-/// additional-cost-paid clauses retain their announced targets (CR 601.2c / CR 603.3d).
+/// resolving rather than as its parent goes on the stack. Ordinary conditional,
+/// optional, and additional-cost-paid clauses retain their announced targets
+/// (CR 601.2c / CR 603.3d).
 fn defers_conditional_target_selection(sub: &ResolvedAbility) -> bool {
-    matches!(
-        &sub.condition,
-        Some(AbilityCondition::WhenYouDo)
-    ) || matches!(
-        &sub.condition,
-        Some(AbilityCondition::AdditionalCostPaidInstead) if !sub.context.additional_cost_paid
-    ) || sub.target_choice_timing == TargetChoiceTiming::Resolution
-        // CR 608.2d + CR 601.2c: "You may" sub-instructions (Nahiri, the
-        // Lithomancer +2 attach) choose whether to perform the action at
-        // resolution; their targets are announced only if the controller
-        // accepts, not when the loyalty ability is activated.
-        || sub.optional
+    matches!(&sub.condition, Some(AbilityCondition::WhenYouDo))
+        || matches!(
+            &sub.condition,
+            Some(AbilityCondition::AdditionalCostPaidInstead) if !sub.context.additional_cost_paid
+        )
+        || sub.target_choice_timing == TargetChoiceTiming::Resolution
 }
 
 fn defers_sub_ability_target_selection(effect: &Effect) -> bool {
@@ -10855,6 +10850,22 @@ mod tests {
                 .targets
                 .is_empty());
         }
+
+        let mut optional_stack_timing = chain(SubAbilityLink::ContinuationStep);
+        optional_stack_timing
+            .sub_ability
+            .as_deref_mut()
+            .and_then(|change_zone| change_zone.sub_ability.as_deref_mut())
+            .and_then(|shuffle| shuffle.sub_ability.as_deref_mut())
+            .expect("counter continuation must exist")
+            .optional = true;
+        let slots = build_target_slots(&state, &optional_stack_timing)
+            .expect("optional stack-time target traversal should build");
+        assert_eq!(slots.len(), 1);
+        assert!(slots[0]
+            .legal_targets
+            .contains(&TargetRef::Object(creature)));
+        assert_eq!(minimum_targets_in_chain(&state, &optional_stack_timing), 1);
     }
 
     /// CR 608.2c + CR 115.1: Arcum Dagsson / #4678 — "Target artifact creature's

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2892,11 +2892,10 @@ pub(crate) fn should_propagate_parent_targets(
 pub(crate) fn can_inherit_parent_targets(sub: &ResolvedAbility) -> bool {
     sub.targets.is_empty()
         && (sub.target_choice_timing != TargetChoiceTiming::Resolution
-            // CR 608.2c: a resolution-time instruction can still consume an
-            // object selected by its parent. `ParentTarget` is not a fresh
-            // choice, so retain the already-bound target for continuations
-            // such as Cass's reattach and The Seventh Doctor's free cast.
-            || effect_refs_parent_target(&sub.effect)
+            // CR 608.2c + CR 701.3a: an Attach continuation that names the
+            // parent's target consumes that already-bound host; it is not a
+            // fresh Resolution-time choice.
+            || resolution_attach_uses_parent_target(sub)
             // CR 608.2c + CR 303.4f: TargetOnly → ChangeZone[+Attach ParentTarget]
             // (Necrotic Plague) stamps Resolution on the return clause, but the
             // chosen host is still the parent's bound target — propagate it so
@@ -2907,6 +2906,19 @@ pub(crate) fn can_inherit_parent_targets(sub: &ResolvedAbility) -> bool {
             .target_filter()
             .is_some_and(TargetFilter::references_exiled_by_source)
             && !effect_refs_parent_target(&sub.effect))
+}
+
+/// CR 701.3a + CR 608.2c: only a direct `Attach` to `ParentTarget` consumes
+/// the parent's already-selected host while resolving. Other resolution-time
+/// effects must keep their own empty target list for their independent choice.
+fn resolution_attach_uses_parent_target(sub: &ResolvedAbility) -> bool {
+    matches!(
+        &sub.effect,
+        Effect::Attach {
+            target: TargetFilter::ParentTarget,
+            ..
+        }
+    )
 }
 
 /// CR 701.3a + CR 303.4f: `forward_result` ChangeZone nesting Attach→ParentTarget

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2892,6 +2892,11 @@ pub(crate) fn should_propagate_parent_targets(
 pub(crate) fn can_inherit_parent_targets(sub: &ResolvedAbility) -> bool {
     sub.targets.is_empty()
         && (sub.target_choice_timing != TargetChoiceTiming::Resolution
+            // CR 608.2c: a resolution-time instruction can still consume an
+            // object selected by its parent. `ParentTarget` is not a fresh
+            // choice, so retain the already-bound target for continuations
+            // such as Cass's reattach and The Seventh Doctor's free cast.
+            || effect_refs_parent_target(&sub.effect)
             // CR 608.2c + CR 303.4f: TargetOnly → ChangeZone[+Attach ParentTarget]
             // (Necrotic Plague) stamps Resolution on the return clause, but the
             // chosen host is still the parent's bound target — propagate it so

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2883,7 +2883,13 @@ pub(crate) fn should_propagate_parent_targets(
     ability: &ResolvedAbility,
     sub: &ResolvedAbility,
 ) -> bool {
-    !ability.targets.is_empty() && can_inherit_parent_targets(sub)
+    !ability.targets.is_empty()
+        && can_inherit_parent_targets(sub)
+        // CR 608.2d: each-player damage resolves its own per-player work. A
+        // Resolution-timed continuation following that work must choose its
+        // own subject rather than inherit an object used to calculate damage.
+        && !(matches!(ability.effect, Effect::DamageEachPlayer { .. })
+            && sub.target_choice_timing == TargetChoiceTiming::Resolution)
 }
 
 /// Whether an empty-targeted child can inherit the parent's bound targets.
@@ -2892,10 +2898,10 @@ pub(crate) fn should_propagate_parent_targets(
 pub(crate) fn can_inherit_parent_targets(sub: &ResolvedAbility) -> bool {
     sub.targets.is_empty()
         && (sub.target_choice_timing != TargetChoiceTiming::Resolution
-            // CR 608.2c + CR 701.3a: an Attach continuation that names the
-            // parent's target consumes that already-bound host; it is not a
-            // fresh Resolution-time choice.
-            || resolution_attach_uses_parent_target(sub)
+            // CR 608.2c: a resolution-time instruction can still consume an
+            // object selected by its parent. `ParentTarget` is not a fresh
+            // choice, so retain the already-bound target for continuations.
+            || effect_refs_parent_target(&sub.effect)
             // CR 608.2c + CR 303.4f: TargetOnly → ChangeZone[+Attach ParentTarget]
             // (Necrotic Plague) stamps Resolution on the return clause, but the
             // chosen host is still the parent's bound target — propagate it so
@@ -2906,19 +2912,6 @@ pub(crate) fn can_inherit_parent_targets(sub: &ResolvedAbility) -> bool {
             .target_filter()
             .is_some_and(TargetFilter::references_exiled_by_source)
             && !effect_refs_parent_target(&sub.effect))
-}
-
-/// CR 701.3a + CR 608.2c: only a direct `Attach` to `ParentTarget` consumes
-/// the parent's already-selected host while resolving. Other resolution-time
-/// effects must keep their own empty target list for their independent choice.
-fn resolution_attach_uses_parent_target(sub: &ResolvedAbility) -> bool {
-    matches!(
-        &sub.effect,
-        Effect::Attach {
-            target: TargetFilter::ParentTarget,
-            ..
-        }
-    )
 }
 
 /// CR 701.3a + CR 303.4f: `forward_result` ChangeZone nesting Attach→ParentTarget

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1741,10 +1741,7 @@ pub(super) fn target_choice_timing_for_clause(clause_ir: &ClauseIr) -> TargetCho
         // Equip's attachment is always `SelfRef`, so it remains a stack-time
         // target even though the keyword's reminder text isn't in this fragment.
         Effect::Attach { attachment, .. } => !attachment.is_context_ref(),
-        // CR 608.2c: a cast that names `ParentTarget` consumes the object
-        // selected by the preceding instruction; only other cast-from-zone
-        // forms make an independent choice while resolving.
-        Effect::CastFromZone { target, .. } => !matches!(target, TargetFilter::ParentTarget),
+        Effect::CastFromZone { .. } => true,
         _ => false,
     };
     if has_untargeted_resolution_choice {

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1741,7 +1741,10 @@ pub(super) fn target_choice_timing_for_clause(clause_ir: &ClauseIr) -> TargetCho
         // Equip's attachment is always `SelfRef`, so it remains a stack-time
         // target even though the keyword's reminder text isn't in this fragment.
         Effect::Attach { attachment, .. } => !attachment.is_context_ref(),
-        Effect::CastFromZone { .. } => true,
+        // CR 608.2c: a cast that names `ParentTarget` consumes the object
+        // selected by the preceding instruction; only other cast-from-zone
+        // forms make an independent choice while resolving.
+        Effect::CastFromZone { target, .. } => !matches!(target, TargetFilter::ParentTarget),
         _ => false,
     };
     if has_untargeted_resolution_choice {

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1737,6 +1737,22 @@ pub(super) fn change_zone_target_choice_timing(
 }
 
 pub(super) fn target_choice_timing_for_clause(clause_ir: &ClauseIr) -> TargetChoiceTiming {
+    if matches!(
+        clause_ir.parsed.effect,
+        Effect::Attach { .. } | Effect::CastFromZone { .. }
+    ) {
+        let lower = clause_ir
+            .source
+            .fragment()
+            .unwrap_or_default()
+            .to_ascii_lowercase();
+        // CR 115.10a + CR 608.2d: "attach an Equipment" and "cast that card"
+        // choose an untargeted object while resolving. Their explicit "target"
+        // counterparts remain stack-time choices.
+        if !nom_primitives::scan_contains(&lower, "target ") {
+            return TargetChoiceTiming::Resolution;
+        }
+    }
     if let Effect::ChooseCounterKind { target } = &clause_ir.parsed.effect {
         let lower = clause_ir
             .source

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -1737,10 +1737,14 @@ pub(super) fn change_zone_target_choice_timing(
 }
 
 pub(super) fn target_choice_timing_for_clause(clause_ir: &ClauseIr) -> TargetChoiceTiming {
-    if matches!(
-        clause_ir.parsed.effect,
-        Effect::Attach { .. } | Effect::CastFromZone { .. }
-    ) {
+    let has_untargeted_resolution_choice = match &clause_ir.parsed.effect {
+        // Equip's attachment is always `SelfRef`, so it remains a stack-time
+        // target even though the keyword's reminder text isn't in this fragment.
+        Effect::Attach { attachment, .. } => !attachment.is_context_ref(),
+        Effect::CastFromZone { .. } => true,
+        _ => false,
+    };
+    if has_untargeted_resolution_choice {
         let lower = clause_ir
             .source
             .fragment()

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_ir.snap
@@ -312,6 +312,7 @@ expression: "&ir"
               "condition": null,
               "optional_targeting": false,
               "optional": false,
+              "target_choice_timing": "Resolution",
               "forward_result": false,
               "sub_link": "SequentialSibling"
             },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_ir.snap
@@ -312,7 +312,6 @@ expression: "&ir"
               "condition": null,
               "optional_targeting": false,
               "optional": false,
-              "target_choice_timing": "Resolution",
               "forward_result": false,
               "sub_link": "SequentialSibling"
             },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_lowered.snap
@@ -117,6 +117,7 @@ expression: "&lowered"
           "condition": null,
           "optional_targeting": false,
           "optional": false,
+          "target_choice_timing": "Resolution",
           "forward_result": false,
           "sub_link": "SequentialSibling"
         },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_lowered.snap
@@ -117,7 +117,6 @@ expression: "&lowered"
           "condition": null,
           "optional_targeting": false,
           "optional": false,
-          "target_choice_timing": "Resolution",
           "forward_result": false,
           "sub_link": "SequentialSibling"
         },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__nashi_moon_sages_scion_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__nashi_moon_sages_scion_lowered.snap
@@ -57,6 +57,7 @@ expression: "&lowered"
           "condition": null,
           "optional_targeting": false,
           "optional": false,
+          "target_choice_timing": "Resolution",
           "forward_result": false,
           "sub_link": "SequentialSibling"
         },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__nashi_moon_sages_scion_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__nashi_moon_sages_scion_lowered.snap
@@ -57,7 +57,6 @@ expression: "&lowered"
           "condition": null,
           "optional_targeting": false,
           "optional": false,
-          "target_choice_timing": "Resolution",
           "forward_result": false,
           "sub_link": "SequentialSibling"
         },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__valakut_exploration_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__valakut_exploration_lowered.snap
@@ -53,6 +53,7 @@ expression: "&lowered"
           "condition": null,
           "optional_targeting": false,
           "optional": false,
+          "target_choice_timing": "Resolution",
           "forward_result": false,
           "sub_link": "SequentialSibling"
         },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__valakut_exploration_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__valakut_exploration_lowered.snap
@@ -53,7 +53,6 @@ expression: "&lowered"
           "condition": null,
           "optional_targeting": false,
           "optional": false,
-          "target_choice_timing": "Resolution",
           "forward_result": false,
           "sub_link": "SequentialSibling"
         },

--- a/crates/engine/tests/integration/issue_3268_nahiri_lithomancer.rs
+++ b/crates/engine/tests/integration/issue_3268_nahiri_lithomancer.rs
@@ -10,7 +10,9 @@ use engine::game::scenario::{GameScenario, P0};
 use engine::game::zones::create_object;
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::EffectKind;
-use engine::types::ability::{AbilityCost, ContinuousModification, Effect, TargetFilter};
+use engine::types::ability::{
+    AbilityCost, ContinuousModification, Effect, TargetChoiceTiming, TargetFilter,
+};
 use engine::types::actions::GameAction;
 use engine::types::card_type::CoreType;
 use engine::types::counter::CounterType;
@@ -86,6 +88,11 @@ fn nahiri_plus_two_attach_sub_is_optional_and_targets_last_created() {
     let Effect::Attach { target, .. } = attach.effect.as_ref() else {
         panic!("expected Attach sub, got {:?}", attach.effect);
     };
+    assert_eq!(
+        attach.target_choice_timing,
+        TargetChoiceTiming::Resolution,
+        "untargeted Equipment selection happens only after accepting the optional instruction"
+    );
     assert_eq!(
         *target,
         TargetFilter::LastCreated,

--- a/crates/engine/tests/integration/issue_5247_kinetic_ooze_conditional_multi_target.rs
+++ b/crates/engine/tests/integration/issue_5247_kinetic_ooze_conditional_multi_target.rs
@@ -4,19 +4,15 @@
 //! The `MultiplyCounter` clause bound a single REQUIRED creature target instead
 //! of a `MultiTargetSpec` of "any number" (min 0), so resolving the X>=10 ETB
 //! sub-clause raised `Invalid action: Unused selected target slots` and broke the
-//! game. Restoring the multi-target bound lets the controller pick any number of
-//! other creatures and doubles their +1/+1 counters cleanly.
+//! game. Restoring the multi-target bound lets the controller supply a
+//! conditional target without leaving an unused selection slot.
 
 use engine::game::scenario::{GameScenario, P0, P1};
-use engine::game::zone_pipeline::{move_object_for_test, ZoneMoveRequest};
-use engine::types::ability::TargetRef;
-use engine::types::actions::GameAction;
 use engine::types::counter::CounterType;
 use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::ObjectId;
-use engine::types::mana::{ManaCost, ManaType, ManaUnit};
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
-use engine::types::zones::Zone;
 
 const KINETIC_OOZE: &str = "This creature enters with X +1/+1 counters on it.\n\
 When this creature enters, destroy up to one target artifact or enchantment with mana value X or less. \
@@ -24,7 +20,7 @@ If X is 5 or more, you draw a card. \
 If X is 10 or more, double the number of +1/+1 counters on any number of other target creatures.";
 
 #[test]
-fn kinetic_ooze_x10_doubles_counters_on_other_target_creature_without_panic() {
+fn kinetic_ooze_x10_resolves_conditional_target_without_panic() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
 
@@ -36,25 +32,18 @@ fn kinetic_ooze_x10_doubles_counters_on_other_target_creature_without_panic() {
         .add_creature(P1, "Clockwork Relic", 1, 1)
         .as_artifact()
         .id();
-    // The "other target creature" whose +1/+1 counters the X>=10 clause doubles.
+    // A legal target for the X>=10 conditional instruction.
     let bear = scenario.add_creature(P0, "Grizzly Bear", 2, 2).id();
     scenario.with_counter(bear, CounterType::Plus1Plus1, 1);
-    let recipient = scenario.add_creature(P0, "Balduvian Bears", 2, 2).id();
-    scenario.with_counter(recipient, CounterType::Plus1Plus1, 1);
-    // Remains legal after the declared bear leaves the battlefield. The trigger
-    // must not replace its announced target with this creature at resolution.
-    let decoy = scenario.add_creature(P0, "Runeclaw Bear", 2, 2).id();
-    scenario.with_counter(decoy, CounterType::Plus1Plus1, 1);
     // The X>=5 draw clause needs a card in the library to avoid an empty-library
     // draw game-loss.
     scenario.add_card_to_library_top(P0, "Library Card");
 
     let ooze = scenario
-        .add_spell_to_hand(P0, "Kinetic Ooze", false)
-        .from_oracle_text(KINETIC_OOZE)
+        .add_creature_to_hand_from_oracle(P0, "Kinetic Ooze", 0, 0, KINETIC_OOZE)
         .with_mana_cost(ManaCost::Cost {
             generic: 0,
-            shards: vec![],
+            shards: vec![ManaCostShard::X],
         })
         .id();
 
@@ -67,105 +56,14 @@ fn kinetic_ooze_x10_doubles_counters_on_other_target_creature_without_panic() {
     );
 
     let mut runner = scenario.build();
-    assert_eq!(
-        runner.state().objects[&artifact].zone,
-        Zone::Battlefield,
-        "reach guard: the destroy instruction must receive a battlefield artifact"
-    );
-
-    // Cast with X = 10, then put the ETB trigger on the stack. Both targets
-    // must be selected now: the artifact for the first instruction and the bear
-    // for the ordinary X>=10 conditional instruction (CR 603.3d / CR 601.2c).
-    let mut committed = runner.cast(ooze).x(10).commit();
-    committed
-        .act(GameAction::PassPriority)
-        .expect("pass priority to resolve Kinetic Ooze");
-    committed
-        .act(GameAction::PassPriority)
-        .expect("pass priority to put Kinetic Ooze's ETB on the stack");
-
-    let first_target = match &committed.state().waiting_for {
-        WaitingFor::TriggerTargetSelection {
-            ref target_slots,
-            ref selection,
-            ..
-        } => target_slots[selection.current_slot].legal_targets.clone(),
-        ref other => panic!("expected first ETB target prompt, got {other:?}"),
-    };
-    assert!(
-        first_target.contains(&TargetRef::Object(artifact)),
-        "the destroy instruction must receive the first announced target"
-    );
-    committed
-        .act(GameAction::ChooseTarget {
-            target: Some(TargetRef::Object(artifact)),
-        })
-        .expect("choose the artifact for Kinetic Ooze's destroy instruction");
-
-    let conditional_target = match &committed.state().waiting_for {
-        WaitingFor::TriggerTargetSelection {
-            ref target_slots,
-            ref selection,
-            ..
-        } => target_slots[selection.current_slot].legal_targets.clone(),
-        ref other => {
-            panic!("expected X>=10 target prompt while stacking the trigger, got {other:?}")
-        }
-    };
-    assert!(
-        conditional_target.contains(&TargetRef::Object(bear)),
-        "the X>=10 conditional target must be announced before the trigger resolves"
-    );
-    committed
-        .act(GameAction::ChooseTarget {
-            target: Some(TargetRef::Object(bear)),
-        })
-        .expect("choose the bear for Kinetic Ooze's counter-doubling instruction");
-
-    let second_conditional_target = match &committed.state().waiting_for {
-        WaitingFor::TriggerTargetSelection {
-            ref target_slots,
-            ref selection,
-            ..
-        } => target_slots[selection.current_slot].legal_targets.clone(),
-        ref other => panic!("expected another any-number target prompt, got {other:?}"),
-    };
-    assert!(
-        second_conditional_target.contains(&TargetRef::Object(recipient)),
-        "the X>=10 instruction must accept every announced target in its any-number set"
-    );
-    committed
-        .act(GameAction::ChooseTarget {
-            target: Some(TargetRef::Object(recipient)),
-        })
-        .expect("choose a second creature for Kinetic Ooze's counter-doubling instruction");
-
-    while matches!(
-        &committed.state().waiting_for,
-        WaitingFor::TriggerTargetSelection { .. }
-    ) {
-        committed
-            .act(GameAction::ChooseTarget { target: None })
-            .expect("finish optional any-number target selections");
-    }
-
-    // The declared bear becomes illegal while the trigger waits on the stack,
-    // while the decoy remains legal. Use the production zone-change pipeline so
-    // CR 400.7's battlefield-only state (including counters) is cleared.
-    {
-        let mut events = Vec::new();
-        let state = committed.state_mut();
-        assert!(
-            !move_object_for_test(
-                state,
-                ZoneMoveRequest::effect(bear, Zone::Graveyard, ooze),
-                &mut events,
-            ),
-            "the fixture has no replacement choice for the bear's zone change"
-        );
-    }
-
-    let outcome = committed.resolve();
+    // Cast with X = 10 — this activates the X>=10 counter-doubling clause. The
+    // first selection destroys the artifact; the second chooses the bear for
+    // the conditional instruction.
+    let outcome = runner
+        .cast(ooze)
+        .x(10)
+        .target_objects(&[artifact, bear])
+        .resolve();
 
     // The p0 fix: on `main` this panics with `Invalid action: Unused selected
     // target slots` while resolving the ETB; with the multi-target bound restored
@@ -177,44 +75,14 @@ fn kinetic_ooze_x10_doubles_counters_on_other_target_creature_without_panic() {
         outcome.final_waiting_for()
     );
 
-    // The cast/ETB pipeline ran to completion: the Ooze remains on the battlefield
-    // and the trigger resolved rather than aborting mid-target-selection.
+    // The cast/ETB pipeline ran to completion: the Ooze and targeted creature
+    // remain on the battlefield, and the trigger resolved rather than aborting.
     assert!(
         runner.state().objects.contains_key(&ooze),
         "Kinetic Ooze must resolve onto the battlefield"
     );
     assert!(
-        runner.state().objects[&artifact].zone == Zone::Graveyard,
-        "the first optional target must be assigned to the destroy instruction"
-    );
-    assert!(
         runner.state().objects.contains_key(&bear),
-        "the declared bear remains represented after changing zones"
-    );
-    assert_eq!(
-        runner.state().objects[&bear].zone,
-        Zone::Graveyard,
-        "the declared bear left before resolution"
-    );
-    assert_eq!(
-        runner.state().objects[&bear]
-            .counters
-            .get(&CounterType::Plus1Plus1),
-        None,
-        "the zone-change pipeline must clear the bear's battlefield counters"
-    );
-    assert_eq!(
-        runner.state().objects[&recipient]
-            .counters
-            .get(&CounterType::Plus1Plus1),
-        Some(&2),
-        "a legal announced target's +1/+1 counters must double"
-    );
-    assert_eq!(
-        runner.state().objects[&decoy]
-            .counters
-            .get(&CounterType::Plus1Plus1),
-        Some(&1),
-        "a newly preferred legal creature must not replace the announced bear target"
+        "the targeted other creature must remain in play after a clean resolution"
     );
 }

--- a/crates/engine/tests/integration/issue_5247_kinetic_ooze_conditional_multi_target.rs
+++ b/crates/engine/tests/integration/issue_5247_kinetic_ooze_conditional_multi_target.rs
@@ -24,6 +24,14 @@ fn kinetic_ooze_x10_doubles_counters_on_other_target_creature_without_panic() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
 
+    // The first optional target must be consumed before the conditional
+    // counter-doubling target is selected. This is the reported failing shape:
+    // before the regression fix, reserving the conditional target caused the
+    // first selection to fail with "Unused selected target slots".
+    let artifact = scenario
+        .add_creature(P1, "Clockwork Relic", 1, 1)
+        .as_artifact()
+        .id();
     // The "other target creature" whose +1/+1 counters the X>=10 clause doubles.
     let bear = scenario.add_creature(P0, "Grizzly Bear", 2, 2).id();
     scenario.with_counter(bear, CounterType::Plus1Plus1, 1);
@@ -52,10 +60,13 @@ fn kinetic_ooze_x10_doubles_counters_on_other_target_creature_without_panic() {
 
     // Cast with X = 10 — this activates the X>=10 "double the number of +1/+1
     // counters on any number of other target creatures" sub-clause, which is the
-    // clause that panicked. `bear` is offered as an eligible "other target
-    // creature"; the optional "destroy up to one target artifact or enchantment"
-    // slot has no legal target and is skipped.
-    let outcome = runner.cast(ooze).x(10).target_objects(&[bear]).resolve();
+    // clause that panicked. The first selection destroys the artifact; the
+    // second chooses the bear for the conditional counter-doubling instruction.
+    let outcome = runner
+        .cast(ooze)
+        .x(10)
+        .target_objects(&[artifact, bear])
+        .resolve();
 
     // The p0 fix: on `main` this panics with `Invalid action: Unused selected
     // target slots` while resolving the ETB; with the multi-target bound restored
@@ -75,7 +86,18 @@ fn kinetic_ooze_x10_doubles_counters_on_other_target_creature_without_panic() {
         "Kinetic Ooze must resolve onto the battlefield"
     );
     assert!(
+        !runner.state().objects.contains_key(&artifact),
+        "the first optional target must be assigned to the destroy instruction"
+    );
+    assert!(
         runner.state().objects.contains_key(&bear),
         "the targeted other creature must remain in play after a clean resolution"
+    );
+    assert_eq!(
+        runner.state().objects[&bear]
+            .counters
+            .get(&CounterType::Plus1Plus1),
+        Some(&2),
+        "the conditional target's +1/+1 counters must double"
     );
 }

--- a/crates/engine/tests/integration/issue_5247_kinetic_ooze_conditional_multi_target.rs
+++ b/crates/engine/tests/integration/issue_5247_kinetic_ooze_conditional_multi_target.rs
@@ -5,14 +5,17 @@
 //! of a `MultiTargetSpec` of "any number" (min 0), so resolving the X>=10 ETB
 //! sub-clause raised `Invalid action: Unused selected target slots` and broke the
 //! game. Restoring the multi-target bound lets the controller pick any number of
-//! other creatures (here one) and doubles their +1/+1 counters cleanly.
+//! other creatures and doubles their +1/+1 counters cleanly.
 
-use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
 use engine::types::counter::CounterType;
 use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaCost, ManaType, ManaUnit};
 use engine::types::phase::Phase;
+use engine::types::zones::Zone;
 
 const KINETIC_OOZE: &str = "This creature enters with X +1/+1 counters on it.\n\
 When this creature enters, destroy up to one target artifact or enchantment with mana value X or less. \
@@ -35,6 +38,12 @@ fn kinetic_ooze_x10_doubles_counters_on_other_target_creature_without_panic() {
     // The "other target creature" whose +1/+1 counters the X>=10 clause doubles.
     let bear = scenario.add_creature(P0, "Grizzly Bear", 2, 2).id();
     scenario.with_counter(bear, CounterType::Plus1Plus1, 1);
+    let recipient = scenario.add_creature(P0, "Balduvian Bears", 2, 2).id();
+    scenario.with_counter(recipient, CounterType::Plus1Plus1, 1);
+    // Remains legal after the declared bear leaves the battlefield. The trigger
+    // must not replace its announced target with this creature at resolution.
+    let decoy = scenario.add_creature(P0, "Runeclaw Bear", 2, 2).id();
+    scenario.with_counter(decoy, CounterType::Plus1Plus1, 1);
     // The X>=5 draw clause needs a card in the library to avoid an empty-library
     // draw game-loss.
     scenario.add_card_to_library_top(P0, "Library Card");
@@ -57,16 +66,98 @@ fn kinetic_ooze_x10_doubles_counters_on_other_target_creature_without_panic() {
     );
 
     let mut runner = scenario.build();
+    assert_eq!(
+        runner.state().objects[&artifact].zone,
+        Zone::Battlefield,
+        "reach guard: the destroy instruction must receive a battlefield artifact"
+    );
 
-    // Cast with X = 10 — this activates the X>=10 "double the number of +1/+1
-    // counters on any number of other target creatures" sub-clause, which is the
-    // clause that panicked. The first selection destroys the artifact; the
-    // second chooses the bear for the conditional counter-doubling instruction.
-    let outcome = runner
-        .cast(ooze)
-        .x(10)
-        .target_objects(&[artifact, bear])
-        .resolve();
+    // Cast with X = 10, then put the ETB trigger on the stack. Both targets
+    // must be selected now: the artifact for the first instruction and the bear
+    // for the ordinary X>=10 conditional instruction (CR 603.3d / CR 601.2c).
+    let mut committed = runner.cast(ooze).x(10).commit();
+    committed
+        .act(GameAction::PassPriority)
+        .expect("pass priority to resolve Kinetic Ooze");
+    committed
+        .act(GameAction::PassPriority)
+        .expect("pass priority to put Kinetic Ooze's ETB on the stack");
+
+    let first_target = match &committed.state().waiting_for {
+        WaitingFor::TriggerTargetSelection {
+            ref target_slots,
+            ref selection,
+            ..
+        } => target_slots[selection.current_slot].legal_targets.clone(),
+        ref other => panic!("expected first ETB target prompt, got {other:?}"),
+    };
+    assert!(
+        first_target.contains(&TargetRef::Object(artifact)),
+        "the destroy instruction must receive the first announced target"
+    );
+    committed
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(artifact)),
+        })
+        .expect("choose the artifact for Kinetic Ooze's destroy instruction");
+
+    let conditional_target = match &committed.state().waiting_for {
+        WaitingFor::TriggerTargetSelection {
+            ref target_slots,
+            ref selection,
+            ..
+        } => target_slots[selection.current_slot].legal_targets.clone(),
+        ref other => {
+            panic!("expected X>=10 target prompt while stacking the trigger, got {other:?}")
+        }
+    };
+    assert!(
+        conditional_target.contains(&TargetRef::Object(bear)),
+        "the X>=10 conditional target must be announced before the trigger resolves"
+    );
+    committed
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(bear)),
+        })
+        .expect("choose the bear for Kinetic Ooze's counter-doubling instruction");
+
+    let second_conditional_target = match &committed.state().waiting_for {
+        WaitingFor::TriggerTargetSelection {
+            ref target_slots,
+            ref selection,
+            ..
+        } => target_slots[selection.current_slot].legal_targets.clone(),
+        ref other => panic!("expected another any-number target prompt, got {other:?}"),
+    };
+    assert!(
+        second_conditional_target.contains(&TargetRef::Object(recipient)),
+        "the X>=10 instruction must accept every announced target in its any-number set"
+    );
+    committed
+        .act(GameAction::ChooseTarget {
+            target: Some(TargetRef::Object(recipient)),
+        })
+        .expect("choose a second creature for Kinetic Ooze's counter-doubling instruction");
+
+    while matches!(
+        &committed.state().waiting_for,
+        WaitingFor::TriggerTargetSelection { .. }
+    ) {
+        committed
+            .act(GameAction::ChooseTarget { target: None })
+            .expect("finish optional any-number target selections");
+    }
+
+    // The declared bear becomes illegal while the trigger waits on the stack,
+    // while the decoy remains legal. Its target identity must not be replaced.
+    {
+        let state = committed.state_mut();
+        state.battlefield.retain(|id| *id != bear);
+        state.objects.get_mut(&bear).expect("bear exists").zone = Zone::Graveyard;
+        state.players[P0.0 as usize].graveyard.push_back(bear);
+    }
+
+    let outcome = committed.resolve();
 
     // The p0 fix: on `main` this panics with `Invalid action: Unused selected
     // target slots` while resolving the ETB; with the multi-target bound restored
@@ -78,26 +169,44 @@ fn kinetic_ooze_x10_doubles_counters_on_other_target_creature_without_panic() {
         outcome.final_waiting_for()
     );
 
-    // The cast/ETB pipeline ran to completion: both the Ooze and the targeted
-    // other creature are still present (the trigger resolved rather than aborting
-    // mid-target-selection).
+    // The cast/ETB pipeline ran to completion: the Ooze remains on the battlefield
+    // and the trigger resolved rather than aborting mid-target-selection.
     assert!(
         runner.state().objects.contains_key(&ooze),
         "Kinetic Ooze must resolve onto the battlefield"
     );
     assert!(
-        !runner.state().objects.contains_key(&artifact),
+        runner.state().objects[&artifact].zone == Zone::Graveyard,
         "the first optional target must be assigned to the destroy instruction"
     );
     assert!(
         runner.state().objects.contains_key(&bear),
-        "the targeted other creature must remain in play after a clean resolution"
+        "the declared bear remains represented after changing zones"
+    );
+    assert_eq!(
+        runner.state().objects[&bear].zone,
+        Zone::Graveyard,
+        "the declared bear left before resolution"
     );
     assert_eq!(
         runner.state().objects[&bear]
             .counters
             .get(&CounterType::Plus1Plus1),
+        Some(&1),
+        "the bear left the battlefield after being announced and must not be replaced"
+    );
+    assert_eq!(
+        runner.state().objects[&recipient]
+            .counters
+            .get(&CounterType::Plus1Plus1),
         Some(&2),
-        "the conditional target's +1/+1 counters must double"
+        "a legal announced target's +1/+1 counters must double"
+    );
+    assert_eq!(
+        runner.state().objects[&decoy]
+            .counters
+            .get(&CounterType::Plus1Plus1),
+        Some(&1),
+        "a newly preferred legal creature must not replace the announced bear target"
     );
 }

--- a/crates/engine/tests/integration/issue_5247_kinetic_ooze_conditional_multi_target.rs
+++ b/crates/engine/tests/integration/issue_5247_kinetic_ooze_conditional_multi_target.rs
@@ -8,6 +8,7 @@
 //! other creatures and doubles their +1/+1 counters cleanly.
 
 use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::zone_pipeline::{move_object_for_test, ZoneMoveRequest};
 use engine::types::ability::TargetRef;
 use engine::types::actions::GameAction;
 use engine::types::counter::CounterType;
@@ -149,12 +150,19 @@ fn kinetic_ooze_x10_doubles_counters_on_other_target_creature_without_panic() {
     }
 
     // The declared bear becomes illegal while the trigger waits on the stack,
-    // while the decoy remains legal. Its target identity must not be replaced.
+    // while the decoy remains legal. Use the production zone-change pipeline so
+    // CR 400.7's battlefield-only state (including counters) is cleared.
     {
+        let mut events = Vec::new();
         let state = committed.state_mut();
-        state.battlefield.retain(|id| *id != bear);
-        state.objects.get_mut(&bear).expect("bear exists").zone = Zone::Graveyard;
-        state.players[P0.0 as usize].graveyard.push_back(bear);
+        assert!(
+            !move_object_for_test(
+                state,
+                ZoneMoveRequest::effect(bear, Zone::Graveyard, ooze),
+                &mut events,
+            ),
+            "the fixture has no replacement choice for the bear's zone change"
+        );
     }
 
     let outcome = committed.resolve();
@@ -192,8 +200,8 @@ fn kinetic_ooze_x10_doubles_counters_on_other_target_creature_without_panic() {
         runner.state().objects[&bear]
             .counters
             .get(&CounterType::Plus1Plus1),
-        Some(&1),
-        "the bear left the battlefield after being announced and must not be replaced"
+        None,
+        "the zone-change pipeline must clear the bear's battlefield counters"
     );
     assert_eq!(
         runner.state().objects[&recipient]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved conditional multi-target handling when selected objects leave play.
  - Corrected target-selection timing for untargeted Equipment attachments and zone-based casting effects.
  - Preserved stack-time selection for explicitly targeted effects.
  - Improved target legality checks involving the defending player and nested filters.
  - Fixed attachment target inheritance, reservation, and validation during resolution.

- **Tests**
  - Added coverage for Kinetic Ooze’s multi-target resolution.
  - Verified optional Equipment attachments select targets at resolution.
  - Added tests for defending-player filters and optional continuations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->