### PR TITLE
chore: refresh metagame feeds

### DIFF
--- a/client/public/feeds/mtggoldfish-commander.json
+++ b/client/public/feeds/mtggoldfish-commander.json
@@ -5,16 +5,16 @@
   "icon": "G",
   "format": "commander",
   "version": 1,
-  "updated": "2026-08-23T00:00:00Z",
+  "updated": "2026-08-24T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/commander",
   "decks": [
     {
       "name": "Y'shtola, Night's Blessed",
       "author": "MTGGoldfish",
       "colors": [
-        "W",
         "U",
-        "B"
+        "B",
+        "W"
       ],
       "tags": [
         "metagame"
@@ -22,199 +22,11 @@
       "main": [
         {
           "count": 1,
-          "name": "Adarkar Wastes"
+          "name": "Y'shtola, Night's Blessed"
         },
         {
           "count": 1,
-          "name": "Anguished Unmaking"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Sanctum"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Archivist of Oghma"
-        },
-        {
-          "count": 1,
-          "name": "Baleful Mastery"
-        },
-        {
-          "count": 1,
-          "name": "Blessing of Leeches"
-        },
-        {
-          "count": 1,
-          "name": "Choked Estuary"
-        },
-        {
-          "count": 1,
-          "name": "Chromatic Lantern"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Counterspell"
-        },
-        {
-          "count": 1,
-          "name": "Cryptic Command"
-        },
-        {
-          "count": 1,
-          "name": "Curiosity"
-        },
-        {
-          "count": 1,
-          "name": "Dain, Lord of the Iron Hills"
-        },
-        {
-          "count": 1,
-          "name": "Darkslick Shores"
-        },
-        {
-          "count": 1,
-          "name": "Delney, Streetwise Lookout"
-        },
-        {
-          "count": 1,
-          "name": "Dig Through Time"
-        },
-        {
-          "count": 1,
-          "name": "Dismember"
-        },
-        {
-          "count": 1,
-          "name": "Dissipate"
-        },
-        {
-          "count": 1,
-          "name": "Drannith Magistrate"
-        },
-        {
-          "count": 1,
-          "name": "Drowned Catacomb"
-        },
-        {
-          "count": 1,
-          "name": "Evolving Wilds"
-        },
-        {
-          "count": 1,
-          "name": "Exotic Orchard"
-        },
-        {
-          "count": 1,
-          "name": "Eye of Nidhogg"
-        },
-        {
-          "count": 1,
-          "name": "Fabled Passage"
-        },
-        {
-          "count": 1,
-          "name": "Faerie Mastermind"
-        },
-        {
-          "count": 1,
-          "name": "Fellwar Stone"
-        },
-        {
-          "count": 1,
-          "name": "Final Judgment"
-        },
-        {
-          "count": 1,
-          "name": "Flooded Strand"
-        },
-        {
-          "count": 1,
-          "name": "Ghostly Prison"
-        },
-        {
-          "count": 1,
-          "name": "Gift of Immortality"
-        },
-        {
-          "count": 1,
-          "name": "Glacial Fortress"
-        },
-        {
-          "count": 1,
-          "name": "Gleaming Bastion"
-        },
-        {
-          "count": 1,
-          "name": "Grand Abolisher"
-        },
-        {
-          "count": 1,
-          "name": "Hallowed Fountain"
-        },
-        {
-          "count": 1,
-          "name": "Hobbit Hole"
-        },
-        {
-          "count": 1,
-          "name": "Hullbreaker Horror"
-        },
-        {
-          "count": 1,
-          "name": "Inkshield"
-        },
-        {
-          "count": 4,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Isolated Chapel"
-        },
-        {
-          "count": 1,
-          "name": "Kambal, Consul of Allocation"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves"
-        },
-        {
-          "count": 1,
-          "name": "Lotho, Corrupt Shirriff"
-        },
-        {
-          "count": 1,
-          "name": "Lyse Hext"
-        },
-        {
-          "count": 1,
-          "name": "Mortify"
-        },
-        {
-          "count": 1,
-          "name": "Murderous Rider"
-        },
-        {
-          "count": 1,
-          "name": "Mystic Remora"
-        },
-        {
-          "count": 1,
-          "name": "Observed Stasis"
-        },
-        {
-          "count": 1,
-          "name": "Ophidian Eye"
+          "name": "Emet-Selch of the Third Seat"
         },
         {
           "count": 1,
@@ -222,91 +34,11 @@
         },
         {
           "count": 1,
-          "name": "Path of Ancestry"
-        },
-        {
-          "count": 4,
-          "name": "Plains"
+          "name": "Vindicate"
         },
         {
           "count": 1,
-          "name": "Port Town"
-        },
-        {
-          "count": 1,
-          "name": "Propaganda"
-        },
-        {
-          "count": 1,
-          "name": "Psychic Frog"
-        },
-        {
-          "count": 1,
-          "name": "Raffine's Tower"
-        },
-        {
-          "count": 1,
-          "name": "Reflecting Pool"
-        },
-        {
-          "count": 1,
-          "name": "Relic of Legends"
-        },
-        {
-          "count": 1,
-          "name": "Restricted Office // Lecture Hall"
-        },
-        {
-          "count": 1,
-          "name": "Rewind"
-        },
-        {
-          "count": 1,
-          "name": "Scavenger Grounds"
-        },
-        {
-          "count": 1,
-          "name": "Seachrome Coast"
-        },
-        {
-          "count": 1,
-          "name": "Shadowy Backstreet"
-        },
-        {
-          "count": 1,
-          "name": "Shineshadow Snarl"
-        },
-        {
-          "count": 1,
-          "name": "Sigil of Sleep"
-        },
-        {
-          "count": 1,
-          "name": "Snuff Out"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Solitary Confinement"
-        },
-        {
-          "count": 1,
-          "name": "Starfall Invocation"
-        },
-        {
-          "count": 1,
-          "name": "Sublime Epiphany"
-        },
-        {
-          "count": 1,
-          "name": "Surveillance Room"
-        },
-        {
-          "count": 2,
-          "name": "Swamp"
+          "name": "Void Rend"
         },
         {
           "count": 1,
@@ -314,7 +46,23 @@
         },
         {
           "count": 1,
-          "name": "Sygg, River Cutthroat"
+          "name": "Propaganda"
+        },
+        {
+          "count": 1,
+          "name": "Snuff Out"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
+          "name": "Relic of Legends"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
         },
         {
           "count": 1,
@@ -330,35 +78,67 @@
         },
         {
           "count": 1,
-          "name": "Tataru Taru"
+          "name": "Thought Vessel"
         },
         {
           "count": 1,
-          "name": "Teferi's Protection"
+          "name": "Command Tower"
         },
         {
           "count": 1,
-          "name": "The Queen of Dale"
+          "name": "Island"
         },
         {
           "count": 1,
-          "name": "Toxic Deluge"
+          "name": "Swamp"
         },
         {
           "count": 1,
-          "name": "Transpose"
+          "name": "Plains"
         },
         {
           "count": 1,
-          "name": "Twilight Prophet"
+          "name": "Curiosity"
         },
         {
           "count": 1,
-          "name": "Underground River"
+          "name": "Tandem Lookout"
         },
         {
           "count": 1,
-          "name": "Undermine"
+          "name": "Ophidian Eye"
+        },
+        {
+          "count": 1,
+          "name": "Delney, Streetwise Lookout"
+        },
+        {
+          "count": 1,
+          "name": "Roaming Throne"
+        },
+        {
+          "count": 1,
+          "name": "Helm of the Ghastlord"
+        },
+        {
+          "count": 1,
+          "name": "Dismember"
+        },
+        {
+          "count": 1,
+          "name": "Beseech the Mirror"
+        },
+        {
+          "count": 1,
+          "name": "Lotus Petal"
+        },
+        {
+          "count": 1,
+          "name": "Dark Ritual"
+        },
+        {
+          "count": 1,
+          "name": "Frantic Search"
         },
         {
           "count": 1,
@@ -366,19 +146,183 @@
         },
         {
           "count": 1,
-          "name": "Valkyrie's Call"
+          "name": "Rewind"
         },
         {
           "count": 1,
-          "name": "Vindicate"
+          "name": "Treachery"
         },
         {
           "count": 1,
-          "name": "Voice of Victory"
+          "name": "Fierce Guardianship"
         },
         {
           "count": 1,
-          "name": "Void Rend"
+          "name": "Misdirection"
+        },
+        {
+          "count": 1,
+          "name": "Force of Negation"
+        },
+        {
+          "count": 1,
+          "name": "Esper Sentinel"
+        },
+        {
+          "count": 1,
+          "name": "Disrupting Shoal"
+        },
+        {
+          "count": 1,
+          "name": "Shining Shoal"
+        },
+        {
+          "count": 1,
+          "name": "Sickening Shoal"
+        },
+        {
+          "count": 1,
+          "name": "Mother of Runes"
+        },
+        {
+          "count": 1,
+          "name": "Giver of Runes"
+        },
+        {
+          "count": 1,
+          "name": "Teferi's Protection"
+        },
+        {
+          "count": 1,
+          "name": "Deadly Rollick"
+        },
+        {
+          "count": 1,
+          "name": "Flawless Maneuver"
+        },
+        {
+          "count": 1,
+          "name": "Alhammarret's Archive"
+        },
+        {
+          "count": 1,
+          "name": "Basalt Monolith"
+        },
+        {
+          "count": 1,
+          "name": "Sigil of Sleep"
+        },
+        {
+          "count": 1,
+          "name": "Generous Gift"
+        },
+        {
+          "count": 1,
+          "name": "Ghostly Prison"
+        },
+        {
+          "count": 1,
+          "name": "Yawgmoth's Will"
+        },
+        {
+          "count": 1,
+          "name": "Serra Ascendant"
+        },
+        {
+          "count": 1,
+          "name": "Sheoldred, the Apocalypse"
+        },
+        {
+          "count": 1,
+          "name": "Fellwar Stone"
+        },
+        {
+          "count": 1,
+          "name": "Wizard's Staff"
+        },
+        {
+          "count": 1,
+          "name": "Mystic Remora"
+        },
+        {
+          "count": 1,
+          "name": "Demonic Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Bloodchief Ascension"
+        },
+        {
+          "count": 1,
+          "name": "Anguished Unmaking"
+        },
+        {
+          "count": 1,
+          "name": "Rhystic Study"
+        },
+        {
+          "count": 1,
+          "name": "Smothering Tithe"
+        },
+        {
+          "count": 1,
+          "name": "Brainstorm"
+        },
+        {
+          "count": 1,
+          "name": "Mox Amber"
+        },
+        {
+          "count": 1,
+          "name": "Sink into Stupor"
+        },
+        {
+          "count": 1,
+          "name": "Submerge"
+        },
+        {
+          "count": 1,
+          "name": "Windfall"
+        },
+        {
+          "count": 1,
+          "name": "Force of Will"
+        },
+        {
+          "count": 1,
+          "name": "Fell the Profane"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Tomb"
+        },
+        {
+          "count": 1,
+          "name": "City of Brass"
+        },
+        {
+          "count": 1,
+          "name": "Mana Confluence"
+        },
+        {
+          "count": 1,
+          "name": "Lotho, Corrupt Shirriff"
+        },
+        {
+          "count": 1,
+          "name": "Chrome Mox"
+        },
+        {
+          "count": 1,
+          "name": "Vampiric Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Godless Shrine"
+        },
+        {
+          "count": 1,
+          "name": "Hallowed Fountain"
         },
         {
           "count": 1,
@@ -386,11 +330,95 @@
         },
         {
           "count": 1,
-          "name": "Y'shtola, Night's Blessed"
+          "name": "Plaza of Heroes"
         },
         {
           "count": 1,
-          "name": "Zur the Enchanter"
+          "name": "Reliquary Tower"
+        },
+        {
+          "count": 1,
+          "name": "Corrupted Conscience"
+        },
+        {
+          "count": 1,
+          "name": "Otawara, Soaring City"
+        },
+        {
+          "count": 1,
+          "name": "Arid Mesa"
+        },
+        {
+          "count": 1,
+          "name": "Bloodstained Mire"
+        },
+        {
+          "count": 1,
+          "name": "Flooded Strand"
+        },
+        {
+          "count": 1,
+          "name": "Marsh Flats"
+        },
+        {
+          "count": 1,
+          "name": "Misty Rainforest"
+        },
+        {
+          "count": 1,
+          "name": "Polluted Delta"
+        },
+        {
+          "count": 1,
+          "name": "Scalding Tarn"
+        },
+        {
+          "count": 1,
+          "name": "Verdant Catacombs"
+        },
+        {
+          "count": 1,
+          "name": "Windswept Heath"
+        },
+        {
+          "count": 1,
+          "name": "Cephalid Coliseum"
+        },
+        {
+          "count": 1,
+          "name": "Gemstone Caverns"
+        },
+        {
+          "count": 1,
+          "name": "Urborg, Tomb of Yawgmoth"
+        },
+        {
+          "count": 1,
+          "name": "Prismatic Vista"
+        },
+        {
+          "count": 1,
+          "name": "Sea of Clouds"
+        },
+        {
+          "count": 1,
+          "name": "Morphic Pool"
+        },
+        {
+          "count": 1,
+          "name": "Vault of Champions"
+        },
+        {
+          "count": 1,
+          "name": "Force of Despair"
+        },
+        {
+          "count": 1,
+          "name": "Imperial Seal"
+        },
+        {
+          "count": 1,
+          "name": "Shadowy Backstreet"
         }
       ],
       "sideboard": []
@@ -399,8 +427,8 @@
       "name": "Thorin, King of Durin's Folk",
       "author": "MTGGoldfish",
       "colors": [
-        "W",
-        "R"
+        "R",
+        "W"
       ],
       "tags": [
         "metagame"
@@ -408,71 +436,15 @@
       "main": [
         {
           "count": 1,
-          "name": "Bifur, Melodic Rider"
-        },
-        {
-          "count": 1,
-          "name": "An Unexpected Party"
-        },
-        {
-          "count": 1,
-          "name": "Bruenor Battlehammer"
-        },
-        {
-          "count": 1,
-          "name": "Dwarven Shortsword"
-        },
-        {
-          "count": 1,
-          "name": "Fili the Pathfinder"
-        },
-        {
-          "count": 1,
-          "name": "Gimli's Reckless Might"
-        },
-        {
-          "count": 1,
-          "name": "Bearded Axe"
-        },
-        {
-          "count": 1,
-          "name": "Dain Ironfoot"
-        },
-        {
-          "count": 1,
-          "name": "Dwalin, Weaponmaster"
-        },
-        {
-          "count": 1,
-          "name": "Dwarven Mattock"
-        },
-        {
-          "count": 1,
-          "name": "Iron Hills Blacksmith"
-        },
-        {
-          "count": 1,
-          "name": "Long-Lost Lances"
-        },
-        {
-          "count": 1,
-          "name": "Vow to Erebor"
-        },
-        {
-          "count": 1,
-          "name": "Bloodforged Battle-Axe"
-        },
-        {
-          "count": 1,
           "name": "Thorin, King of Durin's Folk"
         },
         {
           "count": 1,
-          "name": "Balin, Loremaster"
+          "name": "Dwarven Mauler"
         },
         {
           "count": 1,
-          "name": "The Arkenstone"
+          "name": "Bofur, Reliable Guardian"
         },
         {
           "count": 1,
@@ -480,7 +452,7 @@
         },
         {
           "count": 1,
-          "name": "Giott, King of the Dwarves"
+          "name": "Dwalin, Weaponmaster"
         },
         {
           "count": 1,
@@ -488,47 +460,23 @@
         },
         {
           "count": 1,
-          "name": "Open the Armory"
+          "name": "Thorin Oakenshield"
         },
         {
           "count": 1,
-          "name": "Sram, Senior Edificer"
+          "name": "Aerial Responder"
         },
         {
           "count": 1,
-          "name": "Gloin the Mighty"
-        },
-        {
-          "count": 1,
-          "name": "Fili and Kili, Joyous"
-        },
-        {
-          "count": 1,
-          "name": "Glittering Stockpile"
-        },
-        {
-          "count": 1,
-          "name": "Rubble Rouser"
-        },
-        {
-          "count": 1,
-          "name": "Sword of Feast and Famine"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Thorin, Company's Leader"
+          "name": "Dain Ironfoot"
         },
         {
           "count": 1,
           "name": "Dori, Bearer of Friends"
+        },
+        {
+          "count": 1,
+          "name": "Fili and Kili, Joyous"
         },
         {
           "count": 1,
@@ -540,47 +488,15 @@
         },
         {
           "count": 1,
-          "name": "Orcrist, Goblin-cleaver"
+          "name": "Bruenor Battlehammer"
         },
         {
           "count": 1,
-          "name": "Plundering Barbarian"
+          "name": "Fili the Pathfinder"
         },
         {
           "count": 1,
-          "name": "The Reaver Cleaver"
-        },
-        {
-          "count": 1,
-          "name": "Magda, Brazen Outlaw"
-        },
-        {
-          "count": 1,
-          "name": "Goldvein Pick"
-        },
-        {
-          "count": 1,
-          "name": "Beamtown Beatstick"
-        },
-        {
-          "count": 1,
-          "name": "Diamond Pick-Axe"
-        },
-        {
-          "count": 1,
-          "name": "Ori, Plate Stacker"
-        },
-        {
-          "count": 1,
-          "name": "Argentum Armor"
-        },
-        {
-          "count": 1,
-          "name": "Austere Command"
-        },
-        {
-          "count": 1,
-          "name": "Taunt from the Rampart"
+          "name": "Gloin the Mighty"
         },
         {
           "count": 1,
@@ -588,43 +504,7 @@
         },
         {
           "count": 1,
-          "name": "Duergar Hedge-Mage"
-        },
-        {
-          "count": 1,
-          "name": "Generous Gift"
-        },
-        {
-          "count": 1,
-          "name": "Lorehold Archivist"
-        },
-        {
-          "count": 1,
-          "name": "Practiced Scrollsmith"
-        },
-        {
-          "count": 1,
-          "name": "Unbreakable Formation"
-        },
-        {
-          "count": 1,
-          "name": "Boros Charm"
-        },
-        {
-          "count": 1,
-          "name": "Dawn's Truce"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves"
-        },
-        {
-          "count": 1,
-          "name": "Thorin Oakenshield"
-        },
-        {
-          "count": 1,
-          "name": "Bofur, Reliable Guardian"
+          "name": "Balin, Loremaster"
         },
         {
           "count": 1,
@@ -632,31 +512,175 @@
         },
         {
           "count": 1,
-          "name": "Dwarven Reinforcements"
+          "name": "Thorin, Company's Leader"
         },
         {
           "count": 1,
-          "name": "Aerial Responder"
+          "name": "Bifur, Melodic Rider"
         },
         {
           "count": 1,
-          "name": "Warchanter Skald"
+          "name": "Ori, Plate Stacker"
         },
         {
           "count": 1,
-          "name": "Dwarven Mauler"
+          "name": "Smaug the Magnificent"
         },
         {
           "count": 1,
-          "name": "Dwarven Pony"
+          "name": "Hammers of Moradin"
         },
         {
           "count": 1,
-          "name": "Toolcraft Exemplar"
+          "name": "Torbran, Thane of Red Fell"
         },
         {
           "count": 1,
-          "name": "Axgard Armory"
+          "name": "Cavern-Hoard Dragon"
+        },
+        {
+          "count": 1,
+          "name": "Fumigate"
+        },
+        {
+          "count": 1,
+          "name": "Taunt from the Rampart"
+        },
+        {
+          "count": 1,
+          "name": "Blasphemous Act"
+        },
+        {
+          "count": 1,
+          "name": "Galadriel's Dismissal"
+        },
+        {
+          "count": 1,
+          "name": "Swords to Plowshares"
+        },
+        {
+          "count": 1,
+          "name": "Path to Exile"
+        },
+        {
+          "count": 1,
+          "name": "Stone by Sunlight"
+        },
+        {
+          "count": 1,
+          "name": "Olorin's Searing Light"
+        },
+        {
+          "count": 1,
+          "name": "Everflowing Chalice"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Anduril, Narsil Reforged"
+        },
+        {
+          "count": 1,
+          "name": "Dwarven Mattock"
+        },
+        {
+          "count": 1,
+          "name": "Lightning Greaves"
+        },
+        {
+          "count": 1,
+          "name": "Long-Lost Lances"
+        },
+        {
+          "count": 1,
+          "name": "Sting, Bilbo's Sword"
+        },
+        {
+          "count": 1,
+          "name": "Sting, the Glinting Dagger"
+        },
+        {
+          "count": 1,
+          "name": "Talisman of Conviction"
+        },
+        {
+          "count": 1,
+          "name": "Anduril, Flame of the West"
+        },
+        {
+          "count": 1,
+          "name": "Crown of Gondor"
+        },
+        {
+          "count": 1,
+          "name": "Heirloom Blade"
+        },
+        {
+          "count": 1,
+          "name": "Mithril Coat"
+        },
+        {
+          "count": 1,
+          "name": "Orcrist, Goblin-cleaver"
+        },
+        {
+          "count": 1,
+          "name": "Palantir of Orthanc"
+        },
+        {
+          "count": 1,
+          "name": "Rammas Echor, Ancient Shield"
+        },
+        {
+          "count": 1,
+          "name": "The Arkenstone"
+        },
+        {
+          "count": 1,
+          "name": "Vanquisher's Banner"
+        },
+        {
+          "count": 1,
+          "name": "Diamond Pick-Axe"
+        },
+        {
+          "count": 1,
+          "name": "Mjolnir, Hammer of Thor"
+        },
+        {
+          "count": 1,
+          "name": "Dawn of a New Age"
+        },
+        {
+          "count": 1,
+          "name": "Flowering of the White Tree"
+        },
+        {
+          "count": 1,
+          "name": "Gleaming Splendor"
+        },
+        {
+          "count": 1,
+          "name": "Spiteful Banditry"
+        },
+        {
+          "count": 1,
+          "name": "Forge Anew"
+        },
+        {
+          "count": 1,
+          "name": "An Unexpected Party"
+        },
+        {
+          "count": 1,
+          "name": "Celebrate the Mountain-king"
+        },
+        {
+          "count": 1,
+          "name": "Gimli's Reckless Might"
         },
         {
           "count": 1,
@@ -676,7 +700,11 @@
         },
         {
           "count": 1,
-          "name": "Dwarven Mine"
+          "name": "Furycalm Snarl"
+        },
+        {
+          "count": 1,
+          "name": "Minas Tirith"
         },
         {
           "count": 1,
@@ -688,31 +716,378 @@
         },
         {
           "count": 1,
-          "name": "Radiant Summit"
-        },
-        {
-          "count": 1,
-          "name": "Sunbillow Verge"
-        },
-        {
-          "count": 1,
-          "name": "Sundown Pass"
-        },
-        {
-          "count": 1,
           "name": "The Lonely Mountain"
         },
         {
-          "count": 1,
-          "name": "Turbulent Steppe"
-        },
-        {
-          "count": 13,
-          "name": "Plains"
-        },
-        {
-          "count": 12,
+          "count": 14,
           "name": "Mountain"
+        },
+        {
+          "count": 15,
+          "name": "Plains"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "Thranduil, the Elvenking",
+      "author": "MTGGoldfish",
+      "colors": [
+        "G",
+        "B",
+        "U"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Hinterland Harbor"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
+          "name": "Icon of Ancestry"
+        },
+        {
+          "count": 1,
+          "name": "Necroblossom Snarl"
+        },
+        {
+          "count": 1,
+          "name": "Putrefy"
+        },
+        {
+          "count": 1,
+          "name": "Llanowar Wastes"
+        },
+        {
+          "count": 1,
+          "name": "Talisman of Resilience"
+        },
+        {
+          "count": 1,
+          "name": "Devoted Druid"
+        },
+        {
+          "count": 1,
+          "name": "Immaculate Magistrate"
+        },
+        {
+          "count": 1,
+          "name": "Deepwood Denizen"
+        },
+        {
+          "count": 1,
+          "name": "Marwyn, the Nurturer"
+        },
+        {
+          "count": 1,
+          "name": "Sultai Ascendancy"
+        },
+        {
+          "count": 1,
+          "name": "Sultai Charm"
+        },
+        {
+          "count": 1,
+          "name": "Unstoppable Plan"
+        },
+        {
+          "count": 1,
+          "name": "Nature's Lore"
+        },
+        {
+          "count": 1,
+          "name": "Lumbering Falls"
+        },
+        {
+          "count": 1,
+          "name": "Riddles in the Dark"
+        },
+        {
+          "count": 1,
+          "name": "Elven Passage"
+        },
+        {
+          "count": 1,
+          "name": "Buried Alive"
+        },
+        {
+          "count": 1,
+          "name": "Tyvar, Jubilant Brawler"
+        },
+        {
+          "count": 1,
+          "name": "Gifts Ungiven"
+        },
+        {
+          "count": 1,
+          "name": "Entomb"
+        },
+        {
+          "count": 1,
+          "name": "An Offer You Can't Refuse"
+        },
+        {
+          "count": 1,
+          "name": "Dark Ritual"
+        },
+        {
+          "count": 1,
+          "name": "Harmonized Crescendo"
+        },
+        {
+          "count": 1,
+          "name": "Crop Rotation"
+        },
+        {
+          "count": 1,
+          "name": "Mental Misstep"
+        },
+        {
+          "count": 1,
+          "name": "Reanimate"
+        },
+        {
+          "count": 1,
+          "name": "Hermit Druid"
+        },
+        {
+          "count": 1,
+          "name": "Dread Return"
+        },
+        {
+          "count": 1,
+          "name": "Crawling Infestation"
+        },
+        {
+          "count": 1,
+          "name": "Phyrexian Arena"
+        },
+        {
+          "count": 1,
+          "name": "Staff of Domination"
+        },
+        {
+          "count": 1,
+          "name": "Woodland Cemetery"
+        },
+        {
+          "count": 1,
+          "name": "Polluted Delta"
+        },
+        {
+          "count": 1,
+          "name": "Drowned Catacomb"
+        },
+        {
+          "count": 1,
+          "name": "Darkslick Shores"
+        },
+        {
+          "count": 1,
+          "name": "Unclaimed Territory"
+        },
+        {
+          "count": 1,
+          "name": "Mosswort Bridge"
+        },
+        {
+          "count": 1,
+          "name": "Secluded Courtyard"
+        },
+        {
+          "count": 1,
+          "name": "Herald's Horn"
+        },
+        {
+          "count": 1,
+          "name": "Bloodline Bidding"
+        },
+        {
+          "count": 1,
+          "name": "Fanatic of Rhonas"
+        },
+        {
+          "count": 1,
+          "name": "Greater Good"
+        },
+        {
+          "count": 1,
+          "name": "Growing Rites of Itlimoc"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Rain-Slicked Copse"
+        },
+        {
+          "count": 1,
+          "name": "Eclipsed Realms"
+        },
+        {
+          "count": 1,
+          "name": "Exotic Orchard"
+        },
+        {
+          "count": 1,
+          "name": "Sodden Verdure"
+        },
+        {
+          "count": 1,
+          "name": "Farseek"
+        },
+        {
+          "count": 1,
+          "name": "Underground River"
+        },
+        {
+          "count": 1,
+          "name": "Tainted Wood"
+        },
+        {
+          "count": 7,
+          "name": "Forest"
+        },
+        {
+          "count": 5,
+          "name": "Swamp"
+        },
+        {
+          "count": 4,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Trystan, Callous Cultivator"
+        },
+        {
+          "count": 1,
+          "name": "Fauna Shaman"
+        },
+        {
+          "count": 1,
+          "name": "Jarad, Golgari Lich Lord"
+        },
+        {
+          "count": 1,
+          "name": "Lathril, Blade of the Elves"
+        },
+        {
+          "count": 1,
+          "name": "Selvala, Heart of the Wilds"
+        },
+        {
+          "count": 1,
+          "name": "Champions of the Perfect"
+        },
+        {
+          "count": 1,
+          "name": "Elves of Deep Shadow"
+        },
+        {
+          "count": 1,
+          "name": "Elvish Archdruid"
+        },
+        {
+          "count": 1,
+          "name": "High Perfect Morcant"
+        },
+        {
+          "count": 1,
+          "name": "Maralen, Fae Ascendant"
+        },
+        {
+          "count": 1,
+          "name": "Seedborn Muse"
+        },
+        {
+          "count": 1,
+          "name": "Thranduil, Sindarin Liege"
+        },
+        {
+          "count": 1,
+          "name": "Lluwen, Imperfect Naturalist"
+        },
+        {
+          "count": 1,
+          "name": "Glowspore Shaman"
+        },
+        {
+          "count": 1,
+          "name": "Trystan's Command"
+        },
+        {
+          "count": 1,
+          "name": "Dawnhand Eulogist"
+        },
+        {
+          "count": 1,
+          "name": "Delay"
+        },
+        {
+          "count": 1,
+          "name": "Scarblade Scout"
+        },
+        {
+          "count": 1,
+          "name": "Thranduil, the Elvenking"
+        },
+        {
+          "count": 1,
+          "name": "Priest of Titania"
+        },
+        {
+          "count": 1,
+          "name": "Woodland Weavemaster"
+        },
+        {
+          "count": 1,
+          "name": "Tyvar, the Pummeler"
+        },
+        {
+          "count": 1,
+          "name": "Aftermath Analyst"
+        },
+        {
+          "count": 1,
+          "name": "Llanowar Elves"
+        },
+        {
+          "count": 1,
+          "name": "Formidable Speaker"
+        },
+        {
+          "count": 1,
+          "name": "Thranduil's Company"
+        },
+        {
+          "count": 1,
+          "name": "Deathbloom Ritualist"
+        },
+        {
+          "count": 1,
+          "name": "Selfless Safewright"
+        },
+        {
+          "count": 1,
+          "name": "Reclamation Sage"
+        },
+        {
+          "count": 1,
+          "name": "Silvan Reveler"
         }
       ],
       "sideboard": []
@@ -729,27 +1104,195 @@
       "main": [
         {
           "count": 1,
+          "name": "Studious First-Year"
+        },
+        {
+          "count": 1,
           "name": "Beorn the Fierce"
         },
         {
           "count": 1,
-          "name": "Arcane Signet"
+          "name": "Dancing from Dark to Dawn"
         },
         {
           "count": 1,
-          "name": "Emerald Medallion"
+          "name": "Beorn's Hospitality"
         },
         {
           "count": 1,
-          "name": "Necklace of Girion"
+          "name": "Radagast of Rhosgobel"
         },
         {
           "count": 1,
-          "name": "Rhonas's Monument"
+          "name": "Gigantic Big Bear"
         },
         {
           "count": 1,
-          "name": "Sol Ring"
+          "name": "Little Bear"
+        },
+        {
+          "count": 1,
+          "name": "Ayula, Queen Among Bears"
+        },
+        {
+          "count": 1,
+          "name": "Werebear"
+        },
+        {
+          "count": 1,
+          "name": "Goreclaw, Terror of Qal Sisma"
+        },
+        {
+          "count": 1,
+          "name": "Wilson, Refined Grizzly"
+        },
+        {
+          "count": 1,
+          "name": "The Earth King"
+        },
+        {
+          "count": 1,
+          "name": "Bosco, Just a Bear"
+        },
+        {
+          "count": 1,
+          "name": "Cultivate"
+        },
+        {
+          "count": 1,
+          "name": "Rampant Growth"
+        },
+        {
+          "count": 1,
+          "name": "Heroic Intervention"
+        },
+        {
+          "count": 1,
+          "name": "Rishkar's Expertise"
+        },
+        {
+          "count": 1,
+          "name": "Throne of Eldraine"
+        },
+        {
+          "count": 1,
+          "name": "Zendikar Resurgent"
+        },
+        {
+          "count": 1,
+          "name": "Vastlands Scavenger"
+        },
+        {
+          "count": 1,
+          "name": "Mother Bear"
+        },
+        {
+          "count": 1,
+          "name": "Seedborn Muse"
+        },
+        {
+          "count": 1,
+          "name": "The One Ring"
+        },
+        {
+          "count": 1,
+          "name": "Realmwalker"
+        },
+        {
+          "count": 1,
+          "name": "Ordinary Bear"
+        },
+        {
+          "count": 1,
+          "name": "Chomping Changeling"
+        },
+        {
+          "count": 1,
+          "name": "Toski, Bearer of Secrets"
+        },
+        {
+          "count": 1,
+          "name": "Fanatic of Rhonas"
+        },
+        {
+          "count": 1,
+          "name": "Grizzly Bears"
+        },
+        {
+          "count": 1,
+          "name": "River Bear"
+        },
+        {
+          "count": 1,
+          "name": "Mutavault"
+        },
+        {
+          "count": 1,
+          "name": "Mutable Explorer"
+        },
+        {
+          "count": 1,
+          "name": "Masked Vandal"
+        },
+        {
+          "count": 1,
+          "name": "Dragon-Scarred Bear"
+        },
+        {
+          "count": 1,
+          "name": "Regrowth"
+        },
+        {
+          "count": 1,
+          "name": "Vivien's Grizzly"
+        },
+        {
+          "count": 1,
+          "name": "Archdruid's Charm"
+        },
+        {
+          "count": 1,
+          "name": "Ram Through"
+        },
+        {
+          "count": 1,
+          "name": "Primal Might"
+        },
+        {
+          "count": 1,
+          "name": "Quarrel"
+        },
+        {
+          "count": 1,
+          "name": "Nature's Lore"
+        },
+        {
+          "count": 1,
+          "name": "Grizzly Fate"
+        },
+        {
+          "count": 1,
+          "name": "Fade from History"
+        },
+        {
+          "count": 1,
+          "name": "Last March of the Ents"
+        },
+        {
+          "count": 1,
+          "name": "Season of Gathering"
+        },
+        {
+          "count": 1,
+          "name": "Seasons Past"
+        },
+        {
+          "count": 1,
+          "name": "The Great Henge"
+        },
+        {
+          "count": 1,
+          "name": "Lightning Greaves"
         },
         {
           "count": 1,
@@ -757,15 +1300,43 @@
         },
         {
           "count": 1,
-          "name": "Argoth, Sanctum of Nature"
+          "name": "Herald's Horn"
         },
         {
           "count": 1,
-          "name": "Castle Garenbrig"
+          "name": "Chronicle of Victory"
         },
         {
-          "count": 28,
-          "name": "Forest"
+          "count": 1,
+          "name": "Akroma's Memorial"
+        },
+        {
+          "count": 1,
+          "name": "Orcrist, Goblin-cleaver"
+        },
+        {
+          "count": 1,
+          "name": "Bow of Nylea"
+        },
+        {
+          "count": 1,
+          "name": "Tribute to the World Tree"
+        },
+        {
+          "count": 1,
+          "name": "Beastmaster Ascension"
+        },
+        {
+          "count": 1,
+          "name": "Growing Rites of Itlimoc"
+        },
+        {
+          "count": 1,
+          "name": "Garruk's Uprising"
+        },
+        {
+          "count": 1,
+          "name": "Sylvan Library"
         },
         {
           "count": 1,
@@ -777,247 +1348,63 @@
         },
         {
           "count": 1,
-          "name": "Rogue's Passage"
-        },
-        {
-          "count": 1,
           "name": "Three Tree City"
         },
         {
           "count": 1,
-          "name": "Ashcoat Bear"
+          "name": "Yavimaya, Cradle of Growth"
         },
         {
           "count": 1,
-          "name": "Ayula, Queen Among Bears"
+          "name": "Argoth, Sanctum of Nature"
         },
         {
           "count": 1,
-          "name": "Bear Cub"
-        },
-        {
-          "count": 1,
-          "name": "Beast Whisperer"
-        },
-        {
-          "count": 1,
-          "name": "Beorn, Reluctant Host"
-        },
-        {
-          "count": 1,
-          "name": "Chomping Changeling"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Mystic"
-        },
-        {
-          "count": 1,
-          "name": "Evercoat Ursine"
-        },
-        {
-          "count": 1,
-          "name": "Gigantic Big Bear"
-        },
-        {
-          "count": 1,
-          "name": "Goreclaw, Terror of Qal Sisma"
-        },
-        {
-          "count": 1,
-          "name": "Grizzly Bears"
-        },
-        {
-          "count": 1,
-          "name": "Little Bear"
-        },
-        {
-          "count": 1,
-          "name": "Llanowar Elves"
-        },
-        {
-          "count": 1,
-          "name": "Lumra, Bellow of the Woods"
-        },
-        {
-          "count": 1,
-          "name": "Metallic Mimic"
-        },
-        {
-          "count": 1,
-          "name": "Mother Bear"
-        },
-        {
-          "count": 1,
-          "name": "Ohran Frostfang"
-        },
-        {
-          "count": 1,
-          "name": "Ordinary Bear"
-        },
-        {
-          "count": 1,
-          "name": "Owlbear"
-        },
-        {
-          "count": 1,
-          "name": "Owlbear Cub"
-        },
-        {
-          "count": 1,
-          "name": "Radagast of Rhosgobel"
-        },
-        {
-          "count": 1,
-          "name": "Rampaging Yao Guai"
-        },
-        {
-          "count": 1,
-          "name": "Realmwalker"
-        },
-        {
-          "count": 1,
-          "name": "Roaming Throne"
-        },
-        {
-          "count": 1,
-          "name": "Runeclaw Bear"
-        },
-        {
-          "count": 1,
-          "name": "Studious First-Year"
-        },
-        {
-          "count": 1,
-          "name": "Surrak and Goreclaw"
-        },
-        {
-          "count": 1,
-          "name": "The Earth King"
-        },
-        {
-          "count": 1,
-          "name": "Toski, Bearer of Secrets"
-        },
-        {
-          "count": 1,
-          "name": "Vastlands Scavenger"
-        },
-        {
-          "count": 1,
-          "name": "Werebear"
-        },
-        {
-          "count": 1,
-          "name": "Wilson, Refined Grizzly"
-        },
-        {
-          "count": 1,
-          "name": "Ayula's Influence"
-        },
-        {
-          "count": 1,
-          "name": "Bear Umbra"
-        },
-        {
-          "count": 1,
-          "name": "Bearscape"
-        },
-        {
-          "count": 1,
-          "name": "Beorn's Hospitality"
-        },
-        {
-          "count": 1,
-          "name": "Dancing from Dark to Dawn"
-        },
-        {
-          "count": 1,
-          "name": "Garruk's Uprising"
-        },
-        {
-          "count": 1,
-          "name": "Tribute to the World Tree"
-        },
-        {
-          "count": 1,
-          "name": "Unnatural Growth"
-        },
-        {
-          "count": 1,
-          "name": "Archdruid's Charm"
-        },
-        {
-          "count": 1,
-          "name": "Beast Within"
-        },
-        {
-          "count": 1,
-          "name": "Entish Restoration"
-        },
-        {
-          "count": 1,
-          "name": "Fog"
-        },
-        {
-          "count": 1,
-          "name": "Heroic Intervention"
-        },
-        {
-          "count": 1,
-          "name": "Nature's Claim"
-        },
-        {
-          "count": 1,
-          "name": "Ram Through"
-        },
-        {
-          "count": 1,
-          "name": "Return of the Wildspeaker"
-        },
-        {
-          "count": 1,
-          "name": "Cultivate"
-        },
-        {
-          "count": 1,
-          "name": "Grizzly Fate"
-        },
-        {
-          "count": 1,
-          "name": "Kodama's Reach"
-        },
-        {
-          "count": 1,
-          "name": "Nature's Lore"
-        },
-        {
-          "count": 1,
-          "name": "Overwhelming Stampede"
-        },
-        {
-          "count": 1,
-          "name": "Rampant Growth"
-        },
-        {
-          "count": 1,
-          "name": "Rishkar's Expertise"
-        },
-        {
-          "count": 1,
-          "name": "Shamanic Revelation"
-        },
-        {
-          "count": 1,
-          "name": "Three Visits"
-        },
-        {
-          "count": 1,
-          "name": "Chronicle of Victory"
+          "name": "Evendo, Waking Haven"
         },
         {
           "count": 1,
           "name": "War Room"
+        },
+        {
+          "count": 1,
+          "name": "Bonders' Enclave"
+        },
+        {
+          "count": 1,
+          "name": "Temple of the False God"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Necklace of Girion"
+        },
+        {
+          "count": 1,
+          "name": "Herd Heirloom"
+        },
+        {
+          "count": 1,
+          "name": "Path of Ancestry"
+        },
+        {
+          "count": 1,
+          "name": "Myriad Landscape"
+        },
+        {
+          "count": 25,
+          "name": "Forest"
+        },
+        {
+          "count": 1,
+          "name": "Overlord of the Hauntwoods"
+        },
+        {
+          "count": 1,
+          "name": "Part in Friendship"
         }
       ],
       "sideboard": []
@@ -1026,8 +1413,8 @@
       "name": "The Great Goblin",
       "author": "MTGGoldfish",
       "colors": [
-        "R",
-        "B"
+        "B",
+        "R"
       ],
       "tags": [
         "metagame"
@@ -1035,15 +1422,43 @@
       "main": [
         {
           "count": 1,
+          "name": "Agadeem's Awakening"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
           "name": "Azog, Moria's Ruin"
         },
         {
           "count": 1,
-          "name": "Blasphemous Act"
+          "name": "Battle Cry Goblin"
         },
         {
           "count": 1,
-          "name": "Boggart Cursecrafter"
+          "name": "Battle Hymn"
+        },
+        {
+          "count": 1,
+          "name": "Beetleback Chief"
+        },
+        {
+          "count": 1,
+          "name": "Blightstep Pathway"
+        },
+        {
+          "count": 1,
+          "name": "Blood Crypt"
+        },
+        {
+          "count": 1,
+          "name": "Blood Moon"
+        },
+        {
+          "count": 1,
+          "name": "Bloodstained Mire"
         },
         {
           "count": 1,
@@ -1055,39 +1470,39 @@
         },
         {
           "count": 1,
-          "name": "Bolg of the North"
+          "name": "Boggart Mob"
         },
         {
           "count": 1,
-          "name": "Bolg's Company"
+          "name": "Castle Embereth"
         },
         {
           "count": 1,
-          "name": "Bothersome Noisemaker"
+          "name": "Cavern of Souls"
         },
         {
           "count": 1,
-          "name": "Brightstone Ritual"
+          "name": "Conspicuous Snoop"
         },
         {
           "count": 1,
-          "name": "Champion of the Weird"
+          "name": "Corrupted Conviction"
         },
         {
           "count": 1,
-          "name": "Chaos Warp"
+          "name": "Deadly Dispute"
         },
         {
           "count": 1,
-          "name": "Chthonian Nightmare"
+          "name": "Deadly Rollick"
         },
         {
           "count": 1,
-          "name": "Command Tower"
+          "name": "Deflecting Swat"
         },
         {
           "count": 1,
-          "name": "Dark-Dweller Oracle"
+          "name": "Dictate of Erebos"
         },
         {
           "count": 1,
@@ -1095,35 +1510,27 @@
         },
         {
           "count": 1,
-          "name": "Dreadhorde Invasion"
+          "name": "Fabled Passage"
         },
         {
           "count": 1,
-          "name": "Eclipsed Boggart"
+          "name": "Frogtosser Banneret"
         },
         {
           "count": 1,
-          "name": "Eclipsed Realms"
+          "name": "General Kreat, the Boltbringer"
         },
         {
           "count": 1,
-          "name": "Fearsome Goblin Pair"
+          "name": "Go for the Throat"
         },
         {
           "count": 1,
-          "name": "Feed the Swarm"
+          "name": "Goblin Bombardment"
         },
         {
           "count": 1,
-          "name": "First Day of Class"
-        },
-        {
-          "count": 1,
-          "name": "Foreboding Ruins"
-        },
-        {
-          "count": 1,
-          "name": "Gathering of Darkness"
+          "name": "Goblin Chieftain"
         },
         {
           "count": 1,
@@ -1131,7 +1538,11 @@
         },
         {
           "count": 1,
-          "name": "Goblin Cratermaker"
+          "name": "Goblin King"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Lackey"
         },
         {
           "count": 1,
@@ -1139,15 +1550,31 @@
         },
         {
           "count": 1,
+          "name": "Goblin Recruiter"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Ringleader"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Trashmaster"
+        },
+        {
+          "count": 1,
+          "name": "Goblin War Strike"
+        },
+        {
+          "count": 1,
           "name": "Goblin Warchief"
         },
         {
           "count": 1,
-          "name": "Goblin-town Flunkies"
+          "name": "Grave Pact"
         },
         {
           "count": 1,
-          "name": "Gorbag of Minas Morgul"
+          "name": "Grenzo, Havoc Raiser"
         },
         {
           "count": 1,
@@ -1155,15 +1582,23 @@
         },
         {
           "count": 1,
-          "name": "Grub's Command"
+          "name": "Haunting Voyage"
         },
         {
           "count": 1,
-          "name": "Howlsquad Heavy"
+          "name": "Hobgoblin Bandit Lord"
         },
         {
           "count": 1,
-          "name": "Impulsive Pilferer"
+          "name": "Kiki-Jiki, Mirror Breaker"
+        },
+        {
+          "count": 1,
+          "name": "Kindred Charge"
+        },
+        {
+          "count": 1,
+          "name": "Kindred Dominance"
         },
         {
           "count": 1,
@@ -1175,23 +1610,15 @@
         },
         {
           "count": 1,
-          "name": "Lethal Scheme"
-        },
-        {
-          "count": 1,
           "name": "Mad Auntie"
         },
         {
           "count": 1,
-          "name": "Mana Geyser"
+          "name": "Malakir Rebirth"
         },
         {
           "count": 1,
-          "name": "March from the Black Gate"
-        },
-        {
-          "count": 1,
-          "name": "Mauhur, Uruk-hai Captain"
+          "name": "Massive Raid"
         },
         {
           "count": 1,
@@ -1203,18 +1630,10 @@
         },
         {
           "count": 1,
-          "name": "Mordor Muster"
-        },
-        {
-          "count": 1,
           "name": "Moria Marauder"
         },
         {
-          "count": 1,
-          "name": "Moria Scavenger"
-        },
-        {
-          "count": 18,
+          "count": 8,
           "name": "Mountain"
         },
         {
@@ -1223,19 +1642,47 @@
         },
         {
           "count": 1,
+          "name": "Murderous Redcap"
+        },
+        {
+          "count": 1,
+          "name": "Muxus, Goblin Grandee"
+        },
+        {
+          "count": 1,
+          "name": "Pashalik Mons"
+        },
+        {
+          "count": 1,
           "name": "Path of Ancestry"
         },
         {
           "count": 1,
-          "name": "Putrid Goblin"
+          "name": "Patriarch's Bidding"
         },
         {
           "count": 1,
-          "name": "Rage into the Valley"
+          "name": "Phyrexian Altar"
         },
         {
           "count": 1,
-          "name": "Rakdos Charm"
+          "name": "Plumb the Forbidden"
+        },
+        {
+          "count": 1,
+          "name": "Prismatic Vista"
+        },
+        {
+          "count": 1,
+          "name": "Rakdos Signet"
+        },
+        {
+          "count": 1,
+          "name": "Raucous Theater"
+        },
+        {
+          "count": 1,
+          "name": "Roaming Throne"
         },
         {
           "count": 1,
@@ -1243,19 +1690,7 @@
         },
         {
           "count": 1,
-          "name": "Scuzzback Scrounger"
-        },
-        {
-          "count": 1,
-          "name": "Shadow Urchin"
-        },
-        {
-          "count": 1,
-          "name": "Shadowblood Ridge"
-        },
-        {
-          "count": 1,
-          "name": "Siege-Gang Lieutenant"
+          "name": "Secluded Courtyard"
         },
         {
           "count": 1,
@@ -1263,15 +1698,11 @@
         },
         {
           "count": 1,
+          "name": "Skullclamp"
+        },
+        {
+          "count": 1,
           "name": "Sling-Gang Lieutenant"
-        },
-        {
-          "count": 1,
-          "name": "Smoldering Marsh"
-        },
-        {
-          "count": 1,
-          "name": "Snowslope Hunter"
         },
         {
           "count": 1,
@@ -1279,31 +1710,31 @@
         },
         {
           "count": 1,
-          "name": "Soul Immolation"
+          "name": "Strip Mine"
         },
         {
-          "count": 1,
-          "name": "Stadium Headliner"
-        },
-        {
-          "count": 13,
+          "count": 11,
           "name": "Swamp"
         },
         {
           "count": 1,
-          "name": "Taurean Mauler"
+          "name": "Terminate"
         },
         {
           "count": 1,
-          "name": "Tidings of War"
+          "name": "The One Ring"
         },
         {
           "count": 1,
-          "name": "Undying Malice"
+          "name": "Unclaimed Territory"
         },
         {
           "count": 1,
-          "name": "Unearth"
+          "name": "Wasteland"
+        },
+        {
+          "count": 1,
+          "name": "Vandalblast"
         },
         {
           "count": 1,
@@ -1311,7 +1742,11 @@
         },
         {
           "count": 1,
-          "name": "Widespread Brutality"
+          "name": "Village Rites"
+        },
+        {
+          "count": 1,
+          "name": "Warren Instigator"
         },
         {
           "count": 1,
@@ -1321,371 +1756,12 @@
       "sideboard": []
     },
     {
-      "name": "Thranduil, the Elvenking",
-      "author": "MTGGoldfish",
-      "colors": [
-        "G",
-        "U",
-        "B"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Abomination of Llanowar"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Assassin's Trophy"
-        },
-        {
-          "count": 1,
-          "name": "Beast Whisperer"
-        },
-        {
-          "count": 1,
-          "name": "Bojuka Bog"
-        },
-        {
-          "count": 1,
-          "name": "Brainsurge"
-        },
-        {
-          "count": 1,
-          "name": "Champions of the Perfect"
-        },
-        {
-          "count": 1,
-          "name": "Collective Resistance"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Crippling Fear"
-        },
-        {
-          "count": 1,
-          "name": "Cryptolith Rite"
-        },
-        {
-          "count": 1,
-          "name": "Dark Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Dawn-Blessed Pennant"
-        },
-        {
-          "count": 1,
-          "name": "Devoted Druid"
-        },
-        {
-          "count": 1,
-          "name": "Dionus, Elvish Archdruid"
-        },
-        {
-          "count": 1,
-          "name": "Dwynen, Gilt-Leaf Daen"
-        },
-        {
-          "count": 1,
-          "name": "Eclipsed Realms"
-        },
-        {
-          "count": 1,
-          "name": "Eladamri, Korvecdal"
-        },
-        {
-          "count": 1,
-          "name": "Elven Ambush"
-        },
-        {
-          "count": 1,
-          "name": "Elven Passage"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Archdruid"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Harbinger"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Mystic"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Warmaster"
-        },
-        {
-          "count": 1,
-          "name": "Exotic Orchard"
-        },
-        {
-          "count": 7,
-          "name": "Forest"
-        },
-        {
-          "count": 1,
-          "name": "Frantic Search"
-        },
-        {
-          "count": 1,
-          "name": "Freyalise, Llanowar's Fury"
-        },
-        {
-          "count": 1,
-          "name": "Glissa Sunslayer"
-        },
-        {
-          "count": 1,
-          "name": "Harald Unites the Elves"
-        },
-        {
-          "count": 1,
-          "name": "Harald, King of Skemfar"
-        },
-        {
-          "count": 1,
-          "name": "High Perfect Morcant"
-        },
-        {
-          "count": 1,
-          "name": "Hinterland Harbor"
-        },
-        {
-          "count": 1,
-          "name": "Imperious Perfect"
-        },
-        {
-          "count": 4,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Keep Safe"
-        },
-        {
-          "count": 1,
-          "name": "Kindred Dominance"
-        },
-        {
-          "count": 1,
-          "name": "Kindred Summons"
-        },
-        {
-          "count": 1,
-          "name": "Lathril, Blade of the Elves"
-        },
-        {
-          "count": 1,
-          "name": "Leaf-Crowned Visionary"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves"
-        },
-        {
-          "count": 1,
-          "name": "Llanowar Elves"
-        },
-        {
-          "count": 1,
-          "name": "Llanowar Wastes"
-        },
-        {
-          "count": 1,
-          "name": "Lluwen, Imperfect Naturalist"
-        },
-        {
-          "count": 1,
-          "name": "Lys Alana Huntmaster"
-        },
-        {
-          "count": 1,
-          "name": "Maralen, Fae Ascendant"
-        },
-        {
-          "count": 1,
-          "name": "Marwyn, the Nurturer"
-        },
-        {
-          "count": 1,
-          "name": "Metallic Mimic"
-        },
-        {
-          "count": 1,
-          "name": "Mind Stone"
-        },
-        {
-          "count": 1,
-          "name": "Morcant's Loyalist"
-        },
-        {
-          "count": 1,
-          "name": "Nature's Lore"
-        },
-        {
-          "count": 1,
-          "name": "Path of Ancestry"
-        },
-        {
-          "count": 1,
-          "name": "Poison-Tip Archer"
-        },
-        {
-          "count": 1,
-          "name": "Ponder"
-        },
-        {
-          "count": 1,
-          "name": "Priest of Titania"
-        },
-        {
-          "count": 1,
-          "name": "Quirion Ranger"
-        },
-        {
-          "count": 1,
-          "name": "Reclamation Sage"
-        },
-        {
-          "count": 1,
-          "name": "Return of the Wildspeaker"
-        },
-        {
-          "count": 1,
-          "name": "Revitalizing Repast"
-        },
-        {
-          "count": 1,
-          "name": "Rewind"
-        },
-        {
-          "count": 1,
-          "name": "Secluded Courtyard"
-        },
-        {
-          "count": 1,
-          "name": "Selfless Safewright"
-        },
-        {
-          "count": 1,
-          "name": "Shaman of the Pack"
-        },
-        {
-          "count": 1,
-          "name": "Shamanic Revelation"
-        },
-        {
-          "count": 1,
-          "name": "Skemfar Avenger"
-        },
-        {
-          "count": 1,
-          "name": "Skemfar Shadowsage"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 6,
-          "name": "Swamp"
-        },
-        {
-          "count": 1,
-          "name": "Temple of Deceit"
-        },
-        {
-          "count": 1,
-          "name": "Temple of Malady"
-        },
-        {
-          "count": 1,
-          "name": "Thranduil, Sindarin Liege"
-        },
-        {
-          "count": 1,
-          "name": "Tromell, Seymour's Butler"
-        },
-        {
-          "count": 1,
-          "name": "Turn Aside"
-        },
-        {
-          "count": 1,
-          "name": "Twilight Mire"
-        },
-        {
-          "count": 1,
-          "name": "Tyvar Kell"
-        },
-        {
-          "count": 1,
-          "name": "Tyvar, Jubilant Brawler"
-        },
-        {
-          "count": 1,
-          "name": "Unclaimed Territory"
-        },
-        {
-          "count": 1,
-          "name": "Unwind"
-        },
-        {
-          "count": 1,
-          "name": "Vanquisher's Banner"
-        },
-        {
-          "count": 1,
-          "name": "Vernal Fen"
-        },
-        {
-          "count": 1,
-          "name": "Wirewood Symbiote"
-        },
-        {
-          "count": 1,
-          "name": "Wood Elves"
-        },
-        {
-          "count": 1,
-          "name": "Woodland Cemetery"
-        },
-        {
-          "count": 1,
-          "name": "Woodland Weavemaster"
-        },
-        {
-          "count": 1,
-          "name": "Thranduil, the Elvenking"
-        },
-        {
-          "count": 1,
-          "name": "Brainstorm"
-        }
-      ],
-      "sideboard": []
-    },
-    {
       "name": "Toph, the First Metalbender",
       "author": "MTGGoldfish",
       "colors": [
         "G",
-        "R",
-        "W"
+        "W",
+        "R"
       ],
       "tags": [
         "metagame"
@@ -1693,139 +1769,23 @@
       "main": [
         {
           "count": 1,
-          "name": "All-Fates Scroll"
+          "name": "Earthbender Ascension"
         },
         {
           "count": 1,
-          "name": "Ancient Tomb"
+          "name": "Great Divide Guide"
         },
         {
           "count": 1,
-          "name": "Arid Mesa"
+          "name": "Lotus Cobra"
         },
         {
           "count": 1,
-          "name": "Ashaya, Soul of the Wild"
+          "name": "Tireless Provisioner"
         },
         {
           "count": 1,
-          "name": "Ashnod's Altar"
-        },
-        {
-          "count": 1,
-          "name": "Badgermole Cub"
-        },
-        {
-          "count": 1,
-          "name": "Bala Ged Recovery"
-        },
-        {
-          "count": 1,
-          "name": "Boros Garrison"
-        },
-        {
-          "count": 1,
-          "name": "Boseiju, Who Endures"
-        },
-        {
-          "count": 1,
-          "name": "Brightglass Gearhulk"
-        },
-        {
-          "count": 1,
-          "name": "Bristly Bill, Spine Sower"
-        },
-        {
-          "count": 1,
-          "name": "Bumi, Unleashed"
-        },
-        {
-          "count": 1,
-          "name": "Chromatic Lantern"
-        },
-        {
-          "count": 1,
-          "name": "Chrome Mox"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Crop Rotation"
-        },
-        {
-          "count": 1,
-          "name": "Cultivate"
-        },
-        {
-          "count": 1,
-          "name": "Doubling Season"
-        },
-        {
-          "count": 1,
-          "name": "Enlightened Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Erode"
-        },
-        {
-          "count": 1,
-          "name": "Esper Sentinel"
-        },
-        {
-          "count": 1,
-          "name": "Fabled Passage"
-        },
-        {
-          "count": 1,
-          "name": "Field of the Dead"
-        },
-        {
-          "count": 1,
-          "name": "Finale of Devastation"
-        },
-        {
-          "count": 6,
-          "name": "Forest"
-        },
-        {
-          "count": 1,
-          "name": "Foundry Inspector"
-        },
-        {
-          "count": 1,
-          "name": "Gaea's Cradle"
-        },
-        {
-          "count": 1,
-          "name": "Gamble"
-        },
-        {
-          "count": 1,
-          "name": "Gruul Turf"
-        },
-        {
-          "count": 1,
-          "name": "Haywire Mite"
-        },
-        {
-          "count": 1,
-          "name": "Heroic Intervention"
-        },
-        {
-          "count": 1,
-          "name": "Hour of Revelation"
-        },
-        {
-          "count": 1,
-          "name": "Ichor Wellspring"
-        },
-        {
-          "count": 1,
-          "name": "Jeska's Will"
+          "name": "Dryad of the Ilysian Grove"
         },
         {
           "count": 1,
@@ -1833,163 +1793,23 @@
         },
         {
           "count": 1,
-          "name": "Land Tax"
+          "name": "Badgermole Cub"
         },
         {
           "count": 1,
-          "name": "Lightning Bolt"
+          "name": "Cycle of Renewal"
         },
         {
           "count": 1,
-          "name": "Liquimetal Torque"
+          "name": "Shared Roots"
         },
         {
           "count": 1,
-          "name": "Lotus Field"
+          "name": "Sphere Grid"
         },
         {
           "count": 1,
-          "name": "Lotus Petal"
-        },
-        {
-          "count": 1,
-          "name": "Mana Vault"
-        },
-        {
-          "count": 1,
-          "name": "Mindslaver"
-        },
-        {
-          "count": 1,
-          "name": "Mishra's Bauble"
-        },
-        {
-          "count": 1,
-          "name": "Moraug, Fury of Akoum"
-        },
-        {
-          "count": 1,
-          "name": "Mossborn Hydra"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Mox Diamond"
-        },
-        {
-          "count": 1,
-          "name": "Mox Opal"
-        },
-        {
-          "count": 1,
-          "name": "Mycosynth Lattice"
-        },
-        {
-          "count": 1,
-          "name": "Mystic Forge"
-        },
-        {
-          "count": 1,
-          "name": "Path to Exile"
-        },
-        {
-          "count": 1,
-          "name": "Phyrexian Altar"
-        },
-        {
-          "count": 1,
-          "name": "Plains"
-        },
-        {
-          "count": 1,
-          "name": "Plateau"
-        },
-        {
-          "count": 1,
-          "name": "Rampaging Baloths"
-        },
-        {
-          "count": 1,
-          "name": "Rogue's Passage"
-        },
-        {
-          "count": 1,
-          "name": "Sabotender"
-        },
-        {
-          "count": 1,
-          "name": "Sacred Foundry"
-        },
-        {
-          "count": 1,
-          "name": "Savannah"
-        },
-        {
-          "count": 1,
-          "name": "Scrap Trawler"
-        },
-        {
-          "count": 1,
-          "name": "Scute Swarm"
-        },
-        {
-          "count": 1,
-          "name": "Scythecat Cub"
-        },
-        {
-          "count": 1,
-          "name": "Selesnya Sanctuary"
-        },
-        {
-          "count": 1,
-          "name": "Sensei's Divining Top"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Stomping Ground"
-        },
-        {
-          "count": 1,
-          "name": "Strip Mine"
-        },
-        {
-          "count": 1,
-          "name": "Survey Mechan"
-        },
-        {
-          "count": 1,
-          "name": "Sylvan Library"
-        },
-        {
-          "count": 1,
-          "name": "Sylvan Safekeeper"
-        },
-        {
-          "count": 1,
-          "name": "Taiga"
-        },
-        {
-          "count": 1,
-          "name": "Tannuk, Memorial Ensign"
-        },
-        {
-          "count": 1,
-          "name": "Teferi's Protection"
-        },
-        {
-          "count": 1,
-          "name": "Temple Garden"
-        },
-        {
-          "count": 1,
-          "name": "Terra Eternal"
+          "name": "Ichor Wellspring"
         },
         {
           "count": 1,
@@ -1997,23 +1817,51 @@
         },
         {
           "count": 1,
-          "name": "The Earth Crystal"
+          "name": "Inspiring Call"
         },
         {
           "count": 1,
-          "name": "The One Ring"
+          "name": "Seismic Sense"
         },
         {
           "count": 1,
-          "name": "The Ozolith"
+          "name": "The Legend of Kyoshi"
         },
         {
           "count": 1,
-          "name": "The Stasis Coffin"
+          "name": "Bitter Work"
         },
         {
           "count": 1,
-          "name": "Toph, the Blind Bandit"
+          "name": "Return to Nature"
+        },
+        {
+          "count": 1,
+          "name": "Haywire Mite"
+        },
+        {
+          "count": 1,
+          "name": "Harrow"
+        },
+        {
+          "count": 1,
+          "name": "Origin of Metalbending"
+        },
+        {
+          "count": 1,
+          "name": "Sandbenders' Storm"
+        },
+        {
+          "count": 1,
+          "name": "Earth Rumble"
+        },
+        {
+          "count": 1,
+          "name": "Blasphemous Act"
+        },
+        {
+          "count": 1,
+          "name": "Roiling Regrowth"
         },
         {
           "count": 1,
@@ -2021,55 +1869,239 @@
         },
         {
           "count": 1,
-          "name": "Traveling Chocobo"
+          "name": "Toph, Hardheaded Teacher"
         },
         {
           "count": 1,
-          "name": "Underworld Breach"
+          "name": "Bumi, Unleashed"
         },
         {
           "count": 1,
-          "name": "Urza's Saga"
+          "name": "Tannuk, Memorial Ensign"
         },
         {
           "count": 1,
-          "name": "Vandalblast"
+          "name": "Toph, Greatest Earthbender"
         },
         {
           "count": 1,
-          "name": "Vesuva"
+          "name": "Toph, Earthbending Master"
         },
         {
           "count": 1,
-          "name": "Wayfarer's Bauble"
+          "name": "Toph, the Blind Bandit"
         },
         {
           "count": 1,
-          "name": "Welding Jar"
+          "name": "Earthshape"
         },
         {
           "count": 1,
-          "name": "Windswept Heath"
+          "name": "Rockalanche"
         },
         {
           "count": 1,
-          "name": "Wooded Foothills"
+          "name": "Earthbending Lesson"
         },
         {
           "count": 1,
-          "name": "Worldly Tutor"
+          "name": "Cracked Earth Technique"
         },
         {
           "count": 1,
-          "name": "Wrenn and Realmbreaker"
-        },
-        {
-          "count": 1,
-          "name": "Yavimaya, Cradle of Growth"
+          "name": "Felidar Retreat"
         },
         {
           "count": 1,
           "name": "Zuran Orb"
+        },
+        {
+          "count": 1,
+          "name": "Entish Restoration"
+        },
+        {
+          "count": 1,
+          "name": "Annie Joins Up"
+        },
+        {
+          "count": 1,
+          "name": "Avatar Kyoshi, Earthbender"
+        },
+        {
+          "count": 1,
+          "name": "Bumi, Eclectic Earthbender"
+        },
+        {
+          "count": 1,
+          "name": "Moraug, Fury of Akoum"
+        },
+        {
+          "count": 1,
+          "name": "Haru, Hidden Talent"
+        },
+        {
+          "count": 1,
+          "name": "Solid Ground"
+        },
+        {
+          "count": 1,
+          "name": "Hardened Scales"
+        },
+        {
+          "count": 1,
+          "name": "Tale of Katara and Toph"
+        },
+        {
+          "count": 1,
+          "name": "The Cave of Two Lovers"
+        },
+        {
+          "count": 1,
+          "name": "Badgermole"
+        },
+        {
+          "count": 1,
+          "name": "Earthbending Student"
+        },
+        {
+          "count": 1,
+          "name": "The Earth King"
+        },
+        {
+          "count": 1,
+          "name": "The Boulder, Ready to Rumble"
+        },
+        {
+          "count": 1,
+          "name": "Earth Kingdom General"
+        },
+        {
+          "count": 1,
+          "name": "Obscuring Haze"
+        },
+        {
+          "count": 1,
+          "name": "Farseek"
+        },
+        {
+          "count": 1,
+          "name": "The Earth Crystal"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
+          "name": "Enlightened Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Temple of Plenty"
+        },
+        {
+          "count": 1,
+          "name": "Temple of Abandon"
+        },
+        {
+          "count": 1,
+          "name": "Cragcrown Pathway"
+        },
+        {
+          "count": 1,
+          "name": "Branchloft Pathway"
+        },
+        {
+          "count": 1,
+          "name": "Rustvale Bridge"
+        },
+        {
+          "count": 1,
+          "name": "Sunbaked Canyon"
+        },
+        {
+          "count": 1,
+          "name": "Ba Sing Se"
+        },
+        {
+          "count": 1,
+          "name": "Abandoned Air Temple"
+        },
+        {
+          "count": 1,
+          "name": "Fire Nation Palace"
+        },
+        {
+          "count": 1,
+          "name": "Jungle Shrine"
+        },
+        {
+          "count": 1,
+          "name": "Rumble Arena"
+        },
+        {
+          "count": 1,
+          "name": "Darksteel Citadel"
+        },
+        {
+          "count": 1,
+          "name": "Secret Tunnel"
+        },
+        {
+          "count": 1,
+          "name": "Slagwoods Bridge"
+        },
+        {
+          "count": 10,
+          "name": "Forest"
+        },
+        {
+          "count": 4,
+          "name": "Plains"
+        },
+        {
+          "count": 5,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "Terramorphic Expanse"
+        },
+        {
+          "count": 1,
+          "name": "Thornglint Bridge"
+        },
+        {
+          "count": 1,
+          "name": "Cascading Cataracts"
+        },
+        {
+          "count": 1,
+          "name": "Mishra's Bauble"
+        },
+        {
+          "count": 1,
+          "name": "Azusa, Lost but Seeking"
+        },
+        {
+          "count": 1,
+          "name": "Fabled Passage"
+        },
+        {
+          "count": 1,
+          "name": "Solemn Simulacrum"
+        },
+        {
+          "count": 1,
+          "name": "Gathering Place"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Swiftfoot Boots"
         }
       ],
       "sideboard": []
@@ -2355,7 +2387,7 @@
           "name": "Arch of Orazca <prerelease> [RIX] (F)"
         },
         {
-          "count": 29,
+          "count": 28,
           "name": "Forest <019d4a3e-ded6-723c-9398-0545ecf0d534> [SOS]"
         },
         {
@@ -2369,6 +2401,10 @@
         {
           "count": 1,
           "name": "Labyrinth of Skophos <extended> [THB] (F)"
+        },
+        {
+          "count": 1,
+          "name": "Ruins of Oran-Rief [OGW]"
         }
       ],
       "sideboard": []
@@ -2377,9 +2413,9 @@
       "name": "Kaalia of the Vast",
       "author": "MTGGoldfish",
       "colors": [
+        "W",
         "B",
-        "R",
-        "W"
+        "R"
       ],
       "tags": [
         "metagame"
@@ -2391,167 +2427,7 @@
         },
         {
           "count": 1,
-          "name": "Aegis Angel"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Despair"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Serenity"
-        },
-        {
-          "count": 1,
-          "name": "Anguished Unmaking"
-        },
-        {
-          "count": 1,
-          "name": "Archangel Avacyn"
-        },
-        {
-          "count": 1,
-          "name": "Archfiend of Depravity"
-        },
-        {
-          "count": 1,
-          "name": "Archfiend of Despair"
-        },
-        {
-          "count": 1,
-          "name": "Archfiend of Spite"
-        },
-        {
-          "count": 1,
-          "name": "Aurelia, Exemplar of Justice"
-        },
-        {
-          "count": 1,
-          "name": "Aurelia, the Warleader"
-        },
-        {
-          "count": 1,
-          "name": "Avacyn, Angel of Hope"
-        },
-        {
-          "count": 1,
-          "name": "Basandra, Battle Seraph"
-        },
-        {
-          "count": 1,
-          "name": "Battlefield Forge"
-        },
-        {
-          "count": 1,
-          "name": "Bedevil"
-        },
-        {
-          "count": 1,
-          "name": "Blood Crypt"
-        },
-        {
-          "count": 1,
-          "name": "Bolas's Citadel"
-        },
-        {
-          "count": 1,
-          "name": "Boros Signet"
-        },
-        {
-          "count": 1,
-          "name": "Brightclimb Pathway"
-        },
-        {
-          "count": 1,
-          "name": "Canyon Slough"
-        },
-        {
-          "count": 1,
-          "name": "Castle Locthwain"
-        },
-        {
-          "count": 1,
-          "name": "Caves of Koilos"
-        },
-        {
-          "count": 1,
-          "name": "Chancellor of the Annex"
-        },
-        {
-          "count": 1,
-          "name": "Clifftop Retreat"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Commander's Sphere"
-        },
-        {
-          "count": 1,
-          "name": "Crackling Doom"
-        },
-        {
-          "count": 1,
-          "name": "Curse of Opulence"
-        },
-        {
-          "count": 1,
-          "name": "Dragonskull Summit"
-        },
-        {
-          "count": 1,
-          "name": "Drakuseth, Maw of Flames"
-        },
-        {
-          "count": 1,
-          "name": "Eerie Interlude"
-        },
-        {
-          "count": 1,
-          "name": "Exotic Orchard"
-        },
-        {
-          "count": 1,
-          "name": "Exquisite Archangel"
-        },
-        {
-          "count": 1,
-          "name": "Fiery Emancipation"
-        },
-        {
-          "count": 1,
-          "name": "Gisela, Blade of Goldnight"
-        },
-        {
-          "count": 1,
-          "name": "Glorybringer"
-        },
-        {
-          "count": 1,
-          "name": "Godless Shrine"
-        },
-        {
-          "count": 1,
-          "name": "Grand Abolisher"
-        },
-        {
-          "count": 1,
-          "name": "Harvester of Souls"
-        },
-        {
-          "count": 1,
-          "name": "Indulgent Tormentor"
-        },
-        {
-          "count": 1,
-          "name": "Iroas, God of Victory"
-        },
-        {
-          "count": 1,
-          "name": "Isolated Chapel"
+          "name": "Mother of Runes"
         },
         {
           "count": 1,
@@ -2559,79 +2435,47 @@
         },
         {
           "count": 1,
-          "name": "Kazuul's Fury"
+          "name": "Professional Face-Breaker"
         },
         {
           "count": 1,
-          "name": "Lightning Greaves"
+          "name": "Kardur, Doomscourge"
         },
         {
           "count": 1,
-          "name": "Luxury Suite"
+          "name": "Smaug, Wicked Worm"
         },
         {
           "count": 1,
-          "name": "Lyra Dawnbringer"
+          "name": "Archfiend of Depravity"
         },
         {
           "count": 1,
-          "name": "Malakir Rebirth"
+          "name": "Liesa, Forgotten Archangel"
         },
         {
           "count": 1,
-          "name": "Mind Stone"
-        },
-        {
-          "count": 7,
-          "name": "Mountain"
+          "name": "Terror of the Peaks"
         },
         {
           "count": 1,
-          "name": "Mythos of Snapdax"
+          "name": "Aegis Angel"
         },
         {
           "count": 1,
-          "name": "Ob Nixilis, Unshackled"
+          "name": "Aurelia, the Warleader"
         },
         {
           "count": 1,
-          "name": "Orzhov Signet"
+          "name": "Rakdos, Patron of Chaos"
         },
         {
           "count": 1,
-          "name": "Overseer of the Damned"
+          "name": "Angel of Despair"
         },
         {
           "count": 1,
-          "name": "Path to Exile"
-        },
-        {
-          "count": 1,
-          "name": "Phyrexian Arena"
-        },
-        {
-          "count": 7,
-          "name": "Plains"
-        },
-        {
-          "count": 1,
-          "name": "Platinum Angel"
-        },
-        {
-          "count": 1,
-          "name": "Rakdos Signet"
-        },
-        {
-          "count": 1,
-          "name": "Razaketh, the Foulblooded"
-        },
-        {
-          "count": 1,
-          "name": "Reya Dawnbringer"
-        },
-        {
-          "count": 1,
-          "name": "Ruinous Ultimatum"
+          "name": "Gisela, Blade of Goldnight"
         },
         {
           "count": 1,
@@ -2639,39 +2483,47 @@
         },
         {
           "count": 1,
-          "name": "Savai Crystal"
-        },
-        {
-          "count": 1,
-          "name": "Savai Triome"
-        },
-        {
-          "count": 1,
-          "name": "Scheming Symmetry"
-        },
-        {
-          "count": 1,
-          "name": "Sejiri Shelter"
-        },
-        {
-          "count": 1,
           "name": "Sephara, Sky's Blade"
         },
         {
           "count": 1,
-          "name": "Seraph of the Scales"
+          "name": "Angel of Serenity"
         },
         {
           "count": 1,
-          "name": "Serra's Guardian"
+          "name": "Serra's Emissary"
         },
         {
           "count": 1,
-          "name": "Shadowblood Ridge"
+          "name": "Balefire Dragon"
         },
         {
           "count": 1,
-          "name": "Smothering Tithe"
+          "name": "Lord of the Void"
+        },
+        {
+          "count": 1,
+          "name": "Shadowgrange Archfiend"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Gold Dragon"
+        },
+        {
+          "count": 1,
+          "name": "Angel of the Ruins"
+        },
+        {
+          "count": 1,
+          "name": "Avacyn, Angel of Hope"
+        },
+        {
+          "count": 1,
+          "name": "Vilis, Broker of Blood"
+        },
+        {
+          "count": 1,
+          "name": "Valgavoth, Terror Eater"
         },
         {
           "count": 1,
@@ -2679,15 +2531,19 @@
         },
         {
           "count": 1,
-          "name": "Sower of Discord"
-        },
-        {
-          "count": 7,
-          "name": "Swamp"
+          "name": "Arcane Signet"
         },
         {
           "count": 1,
-          "name": "Swiftfoot Boots"
+          "name": "Boros Signet"
+        },
+        {
+          "count": 1,
+          "name": "Orzhov Signet"
+        },
+        {
+          "count": 1,
+          "name": "Rakdos Signet"
         },
         {
           "count": 1,
@@ -2703,41 +2559,11 @@
         },
         {
           "count": 1,
-          "name": "Terror of Mount Velus"
+          "name": "Fellwar Stone"
         },
         {
           "count": 1,
-          "name": "Utvara Hellkite"
-        },
-        {
-          "count": 1,
-          "name": "Vilis, Broker of Blood"
-        }
-      ],
-      "sideboard": []
-    },
-    {
-      "name": "Vivi Ornitier",
-      "author": "MTGGoldfish",
-      "colors": [
-        "R",
-        "U"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Vivi Ornitier"
-        },
-        {
-          "count": 1,
-          "name": "Lithoform Engine"
-        },
-        {
-          "count": 1,
-          "name": "Harmonic Prodigy"
+          "name": "Lightning Greaves"
         },
         {
           "count": 1,
@@ -2745,275 +2571,63 @@
         },
         {
           "count": 1,
-          "name": "Mechanized Warfare"
+          "name": "Dolmen Gate"
         },
         {
           "count": 1,
-          "name": "Artist's Talent"
+          "name": "Reconnaissance"
         },
         {
           "count": 1,
-          "name": "Hawkeye, Young Avenger"
+          "name": "Animate Dead"
         },
         {
           "count": 1,
-          "name": "Wizard's Staff"
+          "name": "Dragon Tempest"
         },
         {
           "count": 1,
-          "name": "Exalted Flamer of Tzeentch"
+          "name": "Rising of the Day"
         },
         {
           "count": 1,
-          "name": "Big Score"
+          "name": "Phyrexian Arena"
         },
         {
           "count": 1,
-          "name": "Unexpected Windfall"
+          "name": "Swords to Plowshares"
         },
         {
           "count": 1,
-          "name": "Stormcarved Coast"
+          "name": "Path to Exile"
         },
         {
           "count": 1,
-          "name": "Temple of Epiphany"
+          "name": "Terminate"
         },
         {
           "count": 1,
-          "name": "Sulfur Falls"
+          "name": "Rakdos Charm"
         },
         {
           "count": 1,
-          "name": "Frostboil Snarl"
+          "name": "Boros Charm"
         },
         {
           "count": 1,
-          "name": "Shivan Reef"
+          "name": "Surge of Salvation"
         },
         {
           "count": 1,
-          "name": "Cascade Bluffs"
+          "name": "Dawn's Truce"
         },
         {
           "count": 1,
-          "name": "Scorched Geyser"
+          "name": "Anguished Unmaking"
         },
         {
           "count": 1,
-          "name": "Reliquary Tower"
-        },
-        {
-          "count": 1,
-          "name": "Thought Vessel"
-        },
-        {
-          "count": 1,
-          "name": "Ferrous Lake"
-        },
-        {
-          "count": 1,
-          "name": "Izzet Boilerworks"
-        },
-        {
-          "count": 14,
-          "name": "Mountain"
-        },
-        {
-          "count": 14,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Charmbreaker Devils"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Izzet Signet"
-        },
-        {
-          "count": 1,
-          "name": "Coruscation Mage"
-        },
-        {
-          "count": 1,
-          "name": "Delayed Blast Fireball"
-        },
-        {
-          "count": 1,
-          "name": "Niv-Mizzet, Parun"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Bolt"
-        },
-        {
-          "count": 1,
-          "name": "Invert Polarity"
-        },
-        {
-          "count": 1,
-          "name": "Ral, Crackling Wit"
-        },
-        {
-          "count": 1,
-          "name": "Curiosity"
-        },
-        {
-          "count": 1,
-          "name": "Electrostatic Field"
-        },
-        {
-          "count": 1,
-          "name": "Firebrand Archer"
-        },
-        {
-          "count": 1,
-          "name": "Guttersnipe"
-        },
-        {
-          "count": 1,
-          "name": "Kessig Flamebreather"
-        },
-        {
-          "count": 1,
-          "name": "Pink Horror"
-        },
-        {
-          "count": 1,
-          "name": "Ovika, Enigma Goliath"
-        },
-        {
-          "count": 1,
-          "name": "Storm-Kiln Artist"
-        },
-        {
-          "count": 1,
-          "name": "Tellah, Great Sage"
-        },
-        {
-          "count": 1,
-          "name": "Thunderclap Drake"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Bombardment"
-        },
-        {
-          "count": 1,
-          "name": "Thunderdrum Soloist"
-        },
-        {
-          "count": 1,
-          "name": "Sapphire Medallion"
-        },
-        {
-          "count": 1,
-          "name": "Ruby Medallion"
-        },
-        {
-          "count": 1,
-          "name": "Thousand-Year Storm"
-        },
-        {
-          "count": 1,
-          "name": "Lava Dart"
-        },
-        {
-          "count": 1,
-          "name": "Ojer Axonil, Deepest Might"
-        },
-        {
-          "count": 1,
-          "name": "Magma Jet"
-        },
-        {
-          "count": 1,
-          "name": "Shock"
-        },
-        {
-          "count": 1,
-          "name": "Pyretic Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Desperate Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Blasphemous Act"
-        },
-        {
-          "count": 1,
-          "name": "Cyclonic Rift"
-        },
-        {
-          "count": 1,
-          "name": "Aetherize"
-        },
-        {
-          "count": 1,
-          "name": "Fiery Confluence"
-        },
-        {
-          "count": 1,
-          "name": "Mana Geyser"
-        },
-        {
-          "count": 1,
-          "name": "End the Festivities"
-        },
-        {
-          "count": 1,
-          "name": "Tectonic Hazard"
-        },
-        {
-          "count": 1,
-          "name": "Boltwave"
-        },
-        {
-          "count": 1,
-          "name": "Seize the Spoils"
-        },
-        {
-          "count": 1,
-          "name": "Grapeshot"
-        },
-        {
-          "count": 1,
-          "name": "Expropriate"
-        },
-        {
-          "count": 1,
-          "name": "Helm of the Host"
-        },
-        {
-          "count": 1,
-          "name": "Imprisoned in the Moon"
-        },
-        {
-          "count": 1,
-          "name": "Flame Rift"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Strike"
-        },
-        {
-          "count": 1,
-          "name": "Searing Blood"
-        },
-        {
-          "count": 1,
-          "name": "Chandra's Ignition"
+          "name": "Generous Gift"
         },
         {
           "count": 1,
@@ -3021,19 +2635,500 @@
         },
         {
           "count": 1,
-          "name": "Arcanis the Omnipotent"
+          "name": "Wear // Tear"
+        },
+        {
+          "count": 1,
+          "name": "Night's Whisper"
+        },
+        {
+          "count": 1,
+          "name": "Damn"
+        },
+        {
+          "count": 1,
+          "name": "Painful Truths"
+        },
+        {
+          "count": 1,
+          "name": "Read the Bones"
+        },
+        {
+          "count": 1,
+          "name": "Syphon Mind"
+        },
+        {
+          "count": 1,
+          "name": "Diabolic Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Austere Command"
+        },
+        {
+          "count": 1,
+          "name": "Blasphemous Act"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Exotic Orchard"
+        },
+        {
+          "count": 1,
+          "name": "Savai Triome"
+        },
+        {
+          "count": 1,
+          "name": "Path of Ancestry"
+        },
+        {
+          "count": 1,
+          "name": "Battlefield Forge"
+        },
+        {
+          "count": 1,
+          "name": "Caves of Koilos"
+        },
+        {
+          "count": 1,
+          "name": "Sulfurous Springs"
+        },
+        {
+          "count": 1,
+          "name": "Spectator Seating"
+        },
+        {
+          "count": 1,
+          "name": "Vault of Champions"
+        },
+        {
+          "count": 1,
+          "name": "Luxury Suite"
+        },
+        {
+          "count": 1,
+          "name": "Clifftop Retreat"
+        },
+        {
+          "count": 1,
+          "name": "Isolated Chapel"
+        },
+        {
+          "count": 1,
+          "name": "Dragonskull Summit"
+        },
+        {
+          "count": 1,
+          "name": "Shattered Sanctum"
+        },
+        {
+          "count": 1,
+          "name": "Sundown Pass"
+        },
+        {
+          "count": 1,
+          "name": "Haunted Ridge"
+        },
+        {
+          "count": 1,
+          "name": "Concealed Courtyard"
+        },
+        {
+          "count": 1,
+          "name": "Inspiring Vantage"
+        },
+        {
+          "count": 1,
+          "name": "Blackcleave Cliffs"
+        },
+        {
+          "count": 1,
+          "name": "Needleverge Pathway"
+        },
+        {
+          "count": 1,
+          "name": "Brightclimb Pathway"
+        },
+        {
+          "count": 1,
+          "name": "Blightstep Pathway"
+        },
+        {
+          "count": 1,
+          "name": "Bojuka Bog"
+        },
+        {
+          "count": 1,
+          "name": "Ash Barrens"
+        },
+        {
+          "count": 1,
+          "name": "Evolving Wilds"
+        },
+        {
+          "count": 1,
+          "name": "Terramorphic Expanse"
+        },
+        {
+          "count": 1,
+          "name": "Fabled Passage"
+        },
+        {
+          "count": 1,
+          "name": "Valakut Awakening"
+        },
+        {
+          "count": 4,
+          "name": "Plains"
+        },
+        {
+          "count": 3,
+          "name": "Swamp"
+        },
+        {
+          "count": 3,
+          "name": "Mountain"
         }
       ],
       "sideboard": []
     },
     {
-      "name": "The Ur-Dragon",
+      "name": "Sauron, the Dark Lord",
       "author": "MTGGoldfish",
       "colors": [
-        "G",
+        "U",
+        "B",
+        "R"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Sauron, the Dark Lord"
+        },
+        {
+          "count": 1,
+          "name": "Saruman, the White Hand"
+        },
+        {
+          "count": 1,
+          "name": "Lord of the Nazgul"
+        },
+        {
+          "count": 1,
+          "name": "Witch-king of Angmar"
+        },
+        {
+          "count": 8,
+          "name": "Nazgul"
+        },
+        {
+          "count": 1,
+          "name": "Subjugate the Hobbits"
+        },
+        {
+          "count": 1,
+          "name": "Grima, Saruman's Footman"
+        },
+        {
+          "count": 1,
+          "name": "The Mouth of Sauron"
+        },
+        {
+          "count": 1,
+          "name": "Shelob, Dread Weaver"
+        },
+        {
+          "count": 1,
+          "name": "Cavern-Hoard Dragon"
+        },
+        {
+          "count": 1,
+          "name": "In the Darkness Bind Them"
+        },
+        {
+          "count": 1,
+          "name": "Moria Scavenger"
+        },
+        {
+          "count": 1,
+          "name": "Summons of Saruman"
+        },
+        {
+          "count": 1,
+          "name": "Too Greedily, Too Deep"
+        },
+        {
+          "count": 1,
+          "name": "Wake the Dragon"
+        },
+        {
+          "count": 1,
+          "name": "Relic of Sauron"
+        },
+        {
+          "count": 1,
+          "name": "Decree of Pain"
+        },
+        {
+          "count": 1,
+          "name": "Languish"
+        },
+        {
+          "count": 1,
+          "name": "Living Death"
+        },
+        {
+          "count": 1,
+          "name": "Reanimate"
+        },
+        {
+          "count": 1,
+          "name": "Blasphemous Act"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Dark-Dwellers"
+        },
+        {
+          "count": 1,
+          "name": "Scourge of the Throne"
+        },
+        {
+          "count": 1,
+          "name": "Treasure Nabber"
+        },
+        {
+          "count": 1,
+          "name": "Treason of Isengard"
+        },
+        {
+          "count": 1,
+          "name": "Fiery Inscription"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Denial"
+        },
+        {
+          "count": 1,
+          "name": "Consider"
+        },
+        {
+          "count": 1,
+          "name": "Deep Analysis"
+        },
+        {
+          "count": 1,
+          "name": "Fact or Fiction"
+        },
+        {
+          "count": 1,
+          "name": "Feed the Swarm"
+        },
+        {
+          "count": 1,
+          "name": "Faithless Looting"
+        },
+        {
+          "count": 1,
+          "name": "Guttersnipe"
+        },
+        {
+          "count": 1,
+          "name": "Thrill of Possibility"
+        },
+        {
+          "count": 1,
+          "name": "Extract from Darkness"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
+          "name": "Commander's Sphere"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Worn Powerstone"
+        },
+        {
+          "count": 1,
+          "name": "Orcish Bowmasters"
+        },
+        {
+          "count": 1,
+          "name": "Ringsight"
+        },
+        {
+          "count": 1,
+          "name": "Night's Whisper"
+        },
+        {
+          "count": 1,
+          "name": "One Ring to Rule Them All"
+        },
+        {
+          "count": 1,
+          "name": "Shadow of the Enemy"
+        },
+        {
+          "count": 1,
+          "name": "Sauron's Ransom"
+        },
+        {
+          "count": 1,
+          "name": "Palantir of Orthanc"
+        },
+        {
+          "count": 1,
+          "name": "Mystic Confluence"
+        },
+        {
+          "count": 1,
+          "name": "The One Ring"
+        },
+        {
+          "count": 1,
+          "name": "Barad-dur"
+        },
+        {
+          "count": 1,
+          "name": "The Black Gate"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Crumbling Necropolis"
+        },
+        {
+          "count": 1,
+          "name": "Evolving Wilds"
+        },
+        {
+          "count": 1,
+          "name": "Terramorphic Expanse"
+        },
+        {
+          "count": 1,
+          "name": "Path of Ancestry"
+        },
+        {
+          "count": 1,
+          "name": "Rogue's Passage"
+        },
+        {
+          "count": 1,
+          "name": "Bojuka Bog"
+        },
+        {
+          "count": 1,
+          "name": "Choked Estuary"
+        },
+        {
+          "count": 1,
+          "name": "Desolate Lighthouse"
+        },
+        {
+          "count": 1,
+          "name": "Dragonskull Summit"
+        },
+        {
+          "count": 1,
+          "name": "Drowned Catacomb"
+        },
+        {
+          "count": 1,
+          "name": "Foreboding Ruins"
+        },
+        {
+          "count": 1,
+          "name": "Frostboil Snarl"
+        },
+        {
+          "count": 1,
+          "name": "Smoldering Marsh"
+        },
+        {
+          "count": 1,
+          "name": "Sulfur Falls"
+        },
+        {
+          "count": 1,
+          "name": "Sulfurous Springs"
+        },
+        {
+          "count": 1,
+          "name": "Sunken Hollow"
+        },
+        {
+          "count": 1,
+          "name": "Underground River"
+        },
+        {
+          "count": 5,
+          "name": "Island"
+        },
+        {
+          "count": 6,
+          "name": "Swamp"
+        },
+        {
+          "count": 7,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "Fall of Cair Andros"
+        },
+        {
+          "count": 1,
+          "name": "Oliphaunt"
+        },
+        {
+          "count": 1,
+          "name": "The Balrog, Durin's Bane"
+        },
+        {
+          "count": 1,
+          "name": "Mauhur, Uruk-hai Captain"
+        },
+        {
+          "count": 1,
+          "name": "Call of the Ring"
+        },
+        {
+          "count": 1,
+          "name": "Corsairs of Umbar"
+        },
+        {
+          "count": 1,
+          "name": "Ringwraiths"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "Gandalf, Party Guest",
+      "author": "MTGGoldfish",
+      "colors": [
         "U",
         "R",
-        "B",
         "W"
       ],
       "tags": [
@@ -3042,79 +3137,67 @@
       "main": [
         {
           "count": 1,
-          "name": "Path of Ancestry"
+          "name": "Adarkar Wastes"
         },
         {
           "count": 1,
-          "name": "Lotus Field"
+          "name": "Alisaie Leveilleur"
         },
         {
           "count": 1,
-          "name": "Cascading Cataracts"
-        },
-        {
-          "count": 2,
-          "name": "Forest"
-        },
-        {
-          "count": 2,
-          "name": "Island"
+          "name": "Alphinaud Leveilleur"
         },
         {
           "count": 1,
-          "name": "Mystic Monastery"
-        },
-        {
-          "count": 4,
-          "name": "Mountain"
+          "name": "Aminatou's Augury"
         },
         {
           "count": 1,
-          "name": "Secluded Courtyard"
-        },
-        {
-          "count": 2,
-          "name": "Swamp"
-        },
-        {
-          "count": 2,
-          "name": "Plains"
+          "name": "Ancestral Vision"
         },
         {
           "count": 1,
-          "name": "Exotic Orchard"
+          "name": "Approach of the Second Sun"
         },
         {
           "count": 1,
-          "name": "Forbidden Orchard"
+          "name": "Arcane Denial"
         },
         {
           "count": 1,
-          "name": "Nomad Outpost"
+          "name": "Azorius Chancery"
         },
         {
           "count": 1,
-          "name": "Spara's Headquarters"
+          "name": "Balmor, Battlemage Captain"
         },
         {
           "count": 1,
-          "name": "Haven of the Spirit Dragon"
+          "name": "Battlefield Forge"
         },
         {
           "count": 1,
-          "name": "Temple of the Dragon Queen"
+          "name": "Boon of the Wish-Giver"
         },
         {
           "count": 1,
-          "name": "Evolving Wilds"
+          "name": "Boros Garrison"
         },
         {
           "count": 1,
-          "name": "Unclaimed Territory"
+          "name": "Careful Consideration"
         },
         {
           "count": 1,
-          "name": "Spire of Industry"
+          "name": "Cascade Bluffs"
+        },
+        {
+          "count": 1,
+          "name": "Chaos Warp"
+        },
+        {
+          "count": 1,
+          "name": "Clifftop Retreat"
         },
         {
           "count": 1,
@@ -3122,295 +3205,315 @@
         },
         {
           "count": 1,
-          "name": "Indatha Triome"
+          "name": "Counterspell"
         },
         {
           "count": 1,
-          "name": "Ketria Triome"
+          "name": "Deekah, Fractal Theorist"
         },
         {
           "count": 1,
-          "name": "Zagoth Triome"
+          "name": "Deserted Beach"
         },
         {
           "count": 1,
-          "name": "Rockfall Vale"
+          "name": "Dovin's Veto"
         },
         {
           "count": 1,
-          "name": "Terramorphic Expanse"
+          "name": "Emeria's Call"
         },
         {
           "count": 1,
-          "name": "Birds of Paradise"
+          "name": "Exotic Orchard"
         },
         {
           "count": 1,
-          "name": "Path to Exile"
+          "name": "Fabled Passage"
         },
         {
           "count": 1,
-          "name": "Tamiyo's Safekeeping"
+          "name": "Fact or Fiction"
         },
         {
           "count": 1,
-          "name": "Dig Up"
+          "name": "Flame of Anor"
         },
         {
           "count": 1,
-          "name": "Swords to Plowshares"
+          "name": "Flashback"
         },
         {
           "count": 1,
-          "name": "Worldly Tutor"
+          "name": "Frantic Search"
         },
         {
           "count": 1,
-          "name": "Goblin Anarchomancer"
+          "name": "Gandalf the Grey"
         },
         {
           "count": 1,
-          "name": "Farseek"
+          "name": "Gandalf, Goblins' Bane"
         },
         {
           "count": 1,
-          "name": "Eladamri's Call"
+          "name": "Gandalf, Party Guest"
         },
         {
           "count": 1,
-          "name": "Lotus Cobra"
+          "name": "Generous Gift"
         },
         {
           "count": 1,
-          "name": "Rampant Growth"
+          "name": "Glacial Fortress"
         },
         {
           "count": 1,
-          "name": "Despark"
+          "name": "Hermes, Overseer of Elpis"
         },
         {
           "count": 1,
-          "name": "And They Shall Know No Fear"
+          "name": "Hidden Hideout"
         },
         {
           "count": 1,
-          "name": "Once Upon a Time"
+          "name": "Hour of Revelation"
         },
         {
           "count": 1,
-          "name": "Bloom Tender"
+          "name": "Hurkyl, Master Wizard"
         },
         {
           "count": 1,
-          "name": "Korlessa, Scale Singer"
+          "name": "Hydroelectric Specimen"
         },
         {
           "count": 1,
-          "name": "Darksteel Mutation"
+          "name": "Improvisation Capstone"
         },
         {
           "count": 1,
-          "name": "Orb of Dragonkind"
+          "name": "Inspired Ultimatum"
         },
         {
+          "count": 3,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Izzet Boilerworks"
+        },
+        {
+          "count": 1,
+          "name": "Jadzi, Steward of Fate"
+        },
+        {
           "count": 1,
-          "name": "Nature's Lore"
+          "name": "Jori En, Ruin Diver"
         },
         {
           "count": 1,
-          "name": "Dragon Tempest"
+          "name": "Joshua, Phoenix's Dominant"
         },
         {
           "count": 1,
-          "name": "Temur Ascendancy"
+          "name": "Kaza, Roil Chaser"
         },
         {
           "count": 1,
-          "name": "Herald's Horn"
+          "name": "Kwain, Itinerant Meddler"
         },
         {
           "count": 1,
-          "name": "Domri, Anarch of Bolas"
+          "name": "Kykar, Wind's Fury"
         },
         {
           "count": 1,
-          "name": "Urza's Incubator"
+          "name": "Kykar, Zephyr Awakener"
         },
         {
           "count": 1,
-          "name": "Chromatic Lantern"
+          "name": "Long River's Pull"
         },
         {
           "count": 1,
-          "name": "Garruk's Uprising"
+          "name": "Lorien Revealed"
         },
         {
           "count": 1,
-          "name": "Rhythm of the Wild"
+          "name": "Ludevic, Necro-Alchemist"
         },
         {
           "count": 1,
-          "name": "Rivaz of the Claw"
+          "name": "Memories Returning"
         },
         {
           "count": 1,
-          "name": "Sarkhan, Soul Aflame"
+          "name": "Minn, Wily Illusionist"
+        },
+        {
+          "count": 3,
+          "name": "Mountain"
         },
         {
           "count": 1,
-          "name": "Sylvia Brightspear"
+          "name": "Mystic Confluence"
         },
         {
           "count": 1,
-          "name": "Dragon's Hoard"
+          "name": "Mystic Gate"
         },
         {
           "count": 1,
-          "name": "Dragonspeaker Shaman"
+          "name": "Mystic Monastery"
         },
         {
           "count": 1,
-          "name": "Dragonborn Champion"
+          "name": "Negate"
         },
         {
           "count": 1,
-          "name": "Chandra, Torch of Defiance"
+          "name": "Olorin's Searing Light"
         },
         {
           "count": 1,
-          "name": "Sarkhan's Unsealing"
+          "name": "Ondu Inversion"
         },
         {
           "count": 1,
-          "name": "Leyline Tyrant"
+          "name": "Path of Ancestry"
         },
         {
           "count": 1,
-          "name": "Call the Spirit Dragons"
+          "name": "Perilous Landscape"
         },
         {
           "count": 1,
-          "name": "Crux of Fate"
+          "name": "Pinnacle Monk"
         },
         {
           "count": 1,
-          "name": "Patriarch's Bidding"
+          "name": "Plagon, Lord of the Beach"
+        },
+        {
+          "count": 2,
+          "name": "Plains"
         },
         {
           "count": 1,
-          "name": "Goldspan Dragon"
+          "name": "Plea for Power"
         },
         {
           "count": 1,
-          "name": "Scion of the Ur-Dragon"
+          "name": "Pore Over the Pages"
         },
         {
           "count": 1,
-          "name": "Iymrith, Desert Doom"
+          "name": "Raff, Weatherlight Stalwart"
         },
         {
           "count": 1,
-          "name": "Timeless Lotus"
+          "name": "Recurring Insight"
         },
         {
           "count": 1,
-          "name": "Dragonlord Ojutai"
+          "name": "Rite of the Dragoncaller"
         },
         {
           "count": 1,
-          "name": "Scalelord Reckoner"
+          "name": "Rugged Prairie"
         },
         {
           "count": 1,
-          "name": "Terror of the Peaks"
+          "name": "Sejiri Shelter"
         },
         {
           "count": 1,
-          "name": "Thrakkus the Butcher"
+          "name": "Shantotto, Tactician Magician"
         },
         {
           "count": 1,
-          "name": "Twinflame Tyrant"
+          "name": "Shark Typhoon"
         },
         {
           "count": 1,
-          "name": "Two-Headed Hellkite"
+          "name": "Shivan Reef"
         },
         {
           "count": 1,
-          "name": "Hellkite Courser"
+          "name": "Silundi Vision"
         },
         {
           "count": 1,
-          "name": "Ancient Copper Dragon"
+          "name": "Splatter Technique"
         },
         {
           "count": 1,
-          "name": "Dragonlord Dromoka"
+          "name": "Steam Augury"
         },
         {
           "count": 1,
-          "name": "Lathliss, Dragon Queen"
+          "name": "Stock Up"
         },
         {
           "count": 1,
-          "name": "Miirym, Sentinel Wyrm"
+          "name": "Stormcarved Coast"
         },
         {
           "count": 1,
-          "name": "Dragonlord Silumgar"
+          "name": "Sulfur Falls"
         },
         {
           "count": 1,
-          "name": "Stormscale Scion"
+          "name": "Sundering Eruption"
         },
         {
           "count": 1,
-          "name": "Hellkite Tyrant"
+          "name": "Sundown Pass"
         },
         {
           "count": 1,
-          "name": "Atarka, World Render"
+          "name": "Supreme Verdict"
         },
         {
           "count": 1,
-          "name": "Balefire Dragon"
+          "name": "Talrand, Sky Summoner"
         },
         {
           "count": 1,
-          "name": "Ancient Brass Dragon"
+          "name": "Tersa Lightshatter"
         },
         {
           "count": 1,
-          "name": "Ancient Gold Dragon"
+          "name": "The Emperor of Palamecia"
         },
         {
           "count": 1,
-          "name": "Old Gnawbone"
+          "name": "Traverse Eternity"
         },
         {
           "count": 1,
-          "name": "Last March of the Ents"
+          "name": "Ugin's Insight"
         },
         {
           "count": 1,
-          "name": "Dracogenesis"
+          "name": "Unexplained Absence"
         },
         {
           "count": 1,
-          "name": "Utvara Hellkite"
+          "name": "Urza's Ruinous Blast"
         },
         {
           "count": 1,
-          "name": "Ancient Silver Dragon"
+          "name": "Venat, Heart of Hydaelyn"
         },
         {
           "count": 1,
-          "name": "The Great Henge"
+          "name": "Witch Enchanter"
         },
         {
           "count": 1,
-          "name": "The Ur-Dragon"
+          "name": "Wizard's Retort"
         }
       ],
       "sideboard": []

--- a/client/public/feeds/mtggoldfish-modern.json
+++ b/client/public/feeds/mtggoldfish-modern.json
@@ -5,33 +5,25 @@
   "icon": "G",
   "format": "modern",
   "version": 1,
-  "updated": "2026-08-23T00:00:00Z",
+  "updated": "2026-08-24T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/modern",
   "decks": [
     {
       "name": "Goryo's Vengeance",
       "author": "MTGGoldfish",
       "colors": [
-        "U",
-        "G",
+        "B",
         "W",
-        "B"
+        "U",
+        "G"
       ],
       "tags": [
         "metagame"
       ],
       "main": [
         {
-          "count": 4,
-          "name": "Atraxa, Grand Unifier"
-        },
-        {
           "count": 1,
-          "name": "Breeding Pool"
-        },
-        {
-          "count": 4,
-          "name": "Ephemerate"
+          "name": "Swamp"
         },
         {
           "count": 4,
@@ -39,23 +31,23 @@
         },
         {
           "count": 4,
+          "name": "Goryo's Vengeance"
+        },
+        {
+          "count": 4,
           "name": "Flooded Strand"
         },
         {
           "count": 3,
-          "name": "Force of Negation"
-        },
-        {
-          "count": 1,
-          "name": "Godless Shrine"
-        },
-        {
-          "count": 4,
-          "name": "Goryo's Vengeance"
+          "name": "Thoughtseize"
         },
         {
           "count": 1,
           "name": "Griselbrand"
+        },
+        {
+          "count": 4,
+          "name": "Ephemerate"
         },
         {
           "count": 1,
@@ -63,27 +55,51 @@
         },
         {
           "count": 1,
-          "name": "Island"
+          "name": "Breeding Pool"
         },
         {
           "count": 2,
+          "name": "Force of Negation"
+        },
+        {
+          "count": 1,
+          "name": "Superior Spider-Man"
+        },
+        {
+          "count": 1,
+          "name": "Island"
+        },
+        {
+          "count": 1,
           "name": "March of Otherworldly Light"
         },
         {
-          "count": 3,
-          "name": "Marsh Flats"
+          "count": 4,
+          "name": "Atraxa, Grand Unifier"
+        },
+        {
+          "count": 1,
+          "name": "Undercity Sewers"
+        },
+        {
+          "count": 4,
+          "name": "Psychic Frog"
+        },
+        {
+          "count": 1,
+          "name": "Shadowy Backstreet"
         },
         {
           "count": 1,
           "name": "Meticulous Archive"
         },
         {
-          "count": 1,
-          "name": "Plains"
-        },
-        {
           "count": 4,
           "name": "Polluted Delta"
+        },
+        {
+          "count": 1,
+          "name": "Watery Grave"
         },
         {
           "count": 2,
@@ -91,69 +107,53 @@
         },
         {
           "count": 4,
-          "name": "Psychic Frog"
-        },
-        {
-          "count": 4,
-          "name": "Quantum Riddler"
-        },
-        {
-          "count": 1,
-          "name": "Shadowy Backstreet"
-        },
-        {
-          "count": 4,
           "name": "Solitude"
         },
         {
           "count": 1,
-          "name": "Swamp"
-        },
-        {
-          "count": 3,
-          "name": "Thoughtseize"
+          "name": "Plains"
         },
         {
           "count": 1,
-          "name": "Undercity Sewers"
+          "name": "Godless Shrine"
         },
         {
-          "count": 1,
-          "name": "Watery Grave"
+          "count": 4,
+          "name": "Marsh Flats"
+        },
+        {
+          "count": 4,
+          "name": "Quantum Riddler"
         }
       ],
       "sideboard": [
-        {
-          "count": 4,
-          "name": "Consign to Memory"
-        },
-        {
-          "count": 3,
-          "name": "Mystical Dispute"
-        },
         {
           "count": 1,
           "name": "Nihil Spellbomb"
         },
         {
-          "count": 1,
-          "name": "Spell Snare"
+          "count": 2,
+          "name": "Mystical Dispute"
         },
         {
-          "count": 1,
-          "name": "Surgical Extraction"
-        },
-        {
-          "count": 1,
+          "count": 2,
           "name": "Teferi, Time Raveler"
         },
         {
-          "count": 1,
-          "name": "Thoughtseize"
+          "count": 4,
+          "name": "Consign to Memory"
+        },
+        {
+          "count": 2,
+          "name": "Spell Snare"
         },
         {
           "count": 3,
           "name": "Wrath of the Skies"
+        },
+        {
+          "count": 1,
+          "name": "Thoughtseize"
         }
       ]
     },
@@ -329,11 +329,11 @@
           "name": "Ephemerate"
         },
         {
-          "count": 3,
+          "count": 4,
           "name": "Fatal Push"
         },
         {
-          "count": 2,
+          "count": 3,
           "name": "Flickerwisp"
         },
         {
@@ -349,20 +349,12 @@
           "name": "Hallowed Fountain"
         },
         {
-          "count": 1,
-          "name": "March of Otherworldly Light"
-        },
-        {
-          "count": 3,
+          "count": 4,
           "name": "Marsh Flats"
         },
         {
           "count": 1,
           "name": "Meticulous Archive"
-        },
-        {
-          "count": 1,
-          "name": "Orcish Bowmasters"
         },
         {
           "count": 4,
@@ -377,7 +369,7 @@
           "name": "Plains"
         },
         {
-          "count": 2,
+          "count": 1,
           "name": "Polluted Delta"
         },
         {
@@ -423,32 +415,24 @@
       ],
       "sideboard": [
         {
-          "count": 1,
-          "name": "Ashiok, Dream Render"
-        },
-        {
-          "count": 1,
+          "count": 2,
           "name": "Clarion Conqueror"
         },
         {
-          "count": 3,
+          "count": 4,
           "name": "Consign to Memory"
         },
         {
-          "count": 1,
-          "name": "Elesh Norn, Mother of Machines"
-        },
-        {
-          "count": 1,
-          "name": "End of the Hunt"
+          "count": 2,
+          "name": "Containment Priest"
         },
         {
           "count": 2,
           "name": "High Noon"
         },
         {
-          "count": 3,
-          "name": "White Orchid Phantom"
+          "count": 2,
+          "name": "Mystical Dispute"
         },
         {
           "count": 3,
@@ -468,56 +452,44 @@
       ],
       "main": [
         {
-          "count": 3,
-          "name": "Forest"
-        },
-        {
-          "count": 3,
-          "name": "Blade of the Bloodchief"
-        },
-        {
-          "count": 2,
-          "name": "Misty Rainforest"
-        },
-        {
-          "count": 1,
-          "name": "Stomping Ground"
+          "count": 4,
+          "name": "Ancient Stirrings"
         },
         {
           "count": 4,
           "name": "Basking Broodscale"
         },
         {
+          "count": 3,
+          "name": "Blade of the Bloodchief"
+        },
+        {
+          "count": 1,
+          "name": "Boseiju, Who Endures"
+        },
+        {
           "count": 2,
-          "name": "Delighted Halfling"
+          "name": "Cavern of Souls"
+        },
+        {
+          "count": 1,
+          "name": "Commercial District"
         },
         {
           "count": 4,
           "name": "Eldrazi Temple"
         },
         {
-          "count": 1,
-          "name": "Cavern of Souls"
+          "count": 3,
+          "name": "Emrakul, the Promised End"
+        },
+        {
+          "count": 2,
+          "name": "Forest"
         },
         {
           "count": 1,
-          "name": "Windswept Heath"
-        },
-        {
-          "count": 1,
-          "name": "Springleaf Drum"
-        },
-        {
-          "count": 4,
-          "name": "Kozilek's Command"
-        },
-        {
-          "count": 4,
-          "name": "Grove of the Burnwillows"
-        },
-        {
-          "count": 4,
-          "name": "Malevolent Rumble"
+          "name": "Gemstone Caverns"
         },
         {
           "count": 1,
@@ -525,73 +497,81 @@
         },
         {
           "count": 4,
-          "name": "Ancient Stirrings"
-        },
-        {
-          "count": 4,
-          "name": "Sowing Mycospawn"
-        },
-        {
-          "count": 3,
-          "name": "Unholy Heat"
-        },
-        {
-          "count": 3,
-          "name": "Vexing Bauble"
-        },
-        {
-          "count": 1,
-          "name": "Commercial District"
+          "name": "Grove of the Burnwillows"
         },
         {
           "count": 1,
           "name": "Haywire Mite"
         },
         {
-          "count": 3,
-          "name": "Emrakul, the Promised End"
+          "count": 4,
+          "name": "Kozilek's Command"
+        },
+        {
+          "count": 4,
+          "name": "Malevolent Rumble"
+        },
+        {
+          "count": 1,
+          "name": "Misty Rainforest"
         },
         {
           "count": 1,
           "name": "Soul-Guide Lantern"
         },
         {
+          "count": 4,
+          "name": "Sowing Mycospawn"
+        },
+        {
           "count": 1,
-          "name": "Boseiju, Who Endures"
+          "name": "Springleaf Drum"
+        },
+        {
+          "count": 1,
+          "name": "Stomping Ground"
+        },
+        {
+          "count": 2,
+          "name": "Unholy Heat"
         },
         {
           "count": 4,
           "name": "Urza's Saga"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 2,
-          "name": "Soulless Jailer"
         },
         {
           "count": 1,
-          "name": "Firespout"
+          "name": "Verdant Catacombs"
+        },
+        {
+          "count": 2,
+          "name": "Vexing Bauble"
+        },
+        {
+          "count": 1,
+          "name": "Wooded Foothills"
+        },
+        {
+          "count": 2,
+          "name": "Writhing Chrysalis"
         },
         {
           "count": 1,
           "name": "Pithing Needle"
-        },
+        }
+      ],
+      "sideboard": [
         {
-          "count": 2,
-          "name": "Thief of Existence"
+          "count": 1,
+          "name": "Ghost Quarter"
         },
         {
           "count": 1,
-          "name": "Dismember"
-        },
-        {
-          "count": 2,
-          "name": "Warping Wail"
+          "name": "Grafdigger's Cage"
         },
         {
           "count": 1,
-          "name": "Pyroclasm"
+          "name": "Kozilek's Return"
         },
         {
           "count": 2,
@@ -599,15 +579,31 @@
         },
         {
           "count": 1,
+          "name": "Pyroclasm"
+        },
+        {
+          "count": 1,
+          "name": "Soulless Jailer"
+        },
+        {
+          "count": 2,
+          "name": "Thief of Existence"
+        },
+        {
+          "count": 2,
           "name": "Unholy Heat"
         },
         {
-          "count": 1,
-          "name": "Haywire Mite"
+          "count": 2,
+          "name": "Warping Wail"
         },
         {
           "count": 1,
-          "name": "Disruptor Flute"
+          "name": "Wrenn and Six"
+        },
+        {
+          "count": 1,
+          "name": "Vexing Bauble"
         }
       ]
     },
@@ -615,8 +611,8 @@
       "name": "Izzet Prowess",
       "author": "MTGGoldfish",
       "colors": [
-        "U",
-        "R"
+        "R",
+        "U"
       ],
       "tags": [
         "metagame"
@@ -627,24 +623,8 @@
           "name": "Dragon's Rage Channeler"
         },
         {
-          "count": 4,
-          "name": "Monastery Swiftspear"
-        },
-        {
-          "count": 4,
-          "name": "Slickshot Show-Off"
-        },
-        {
-          "count": 4,
-          "name": "Cori-Steel Cutter"
-        },
-        {
-          "count": 4,
-          "name": "Preordain"
-        },
-        {
-          "count": 4,
-          "name": "Mishra's Bauble"
+          "count": 1,
+          "name": "Thundering Falls"
         },
         {
           "count": 4,
@@ -655,44 +635,64 @@
           "name": "Lightning Bolt"
         },
         {
-          "count": 4,
-          "name": "Lava Dart"
+          "count": 3,
+          "name": "Scalding Tarn"
         },
         {
           "count": 4,
+          "name": "Preordain"
+        },
+        {
+          "count": 3,
           "name": "Mutagenic Growth"
         },
         {
           "count": 2,
-          "name": "Violent Urge"
-        },
-        {
-          "count": 3,
-          "name": "Steam Vents"
+          "name": "Consider"
         },
         {
           "count": 3,
           "name": "Mountain"
         },
         {
-          "count": 1,
-          "name": "Fiery Islet"
-        },
-        {
-          "count": 1,
-          "name": "Thundering Falls"
+          "count": 4,
+          "name": "Wooded Foothills"
         },
         {
           "count": 4,
-          "name": "Arid Mesa"
+          "name": "Mishra's Bauble"
+        },
+        {
+          "count": 4,
+          "name": "Cori-Steel Cutter"
         },
         {
           "count": 3,
-          "name": "Scalding Tarn"
+          "name": "Steam Vents"
         },
         {
-          "count": 3,
+          "count": 1,
+          "name": "Violent Urge"
+        },
+        {
+          "count": 4,
+          "name": "Monastery Swiftspear"
+        },
+        {
+          "count": 2,
+          "name": "Fiery Islet"
+        },
+        {
+          "count": 4,
+          "name": "Slickshot Show-Off"
+        },
+        {
+          "count": 2,
           "name": "Bloodstained Mire"
+        },
+        {
+          "count": 4,
+          "name": "Lava Dart"
         }
       ],
       "sideboard": [
@@ -701,16 +701,16 @@
           "name": "Consign to Memory"
         },
         {
-          "count": 3,
-          "name": "Spell Snare"
-        },
-        {
-          "count": 1,
+          "count": 2,
           "name": "Spell Pierce"
         },
         {
-          "count": 1,
-          "name": "Into the Flood Maw"
+          "count": 2,
+          "name": "Meltdown"
+        },
+        {
+          "count": 3,
+          "name": "Tormod's Crypt"
         },
         {
           "count": 3,
@@ -718,11 +718,7 @@
         },
         {
           "count": 1,
-          "name": "Tormod's Crypt"
-        },
-        {
-          "count": 2,
-          "name": "Meltdown"
+          "name": "Spell Snare"
         }
       ]
     },
@@ -877,7 +873,7 @@
       ],
       "main": [
         {
-          "count": 1,
+          "count": 4,
           "name": "Bloodstained Mire"
         },
         {
@@ -885,7 +881,11 @@
           "name": "Cling to Dust"
         },
         {
-          "count": 4,
+          "count": 2,
+          "name": "Consign to Memory"
+        },
+        {
+          "count": 2,
           "name": "Counterspell"
         },
         {
@@ -893,16 +893,8 @@
           "name": "Fatal Push"
         },
         {
-          "count": 2,
-          "name": "Flooded Strand"
-        },
-        {
-          "count": 3,
+          "count": 4,
           "name": "Force of Negation"
-        },
-        {
-          "count": 1,
-          "name": "Gloomlake Verge"
         },
         {
           "count": 2,
@@ -913,11 +905,7 @@
           "name": "Kaito, Bane of Nightmares"
         },
         {
-          "count": 1,
-          "name": "Murktide Regent"
-        },
-        {
-          "count": 4,
+          "count": 3,
           "name": "Orcish Bowmasters"
         },
         {
@@ -933,7 +921,7 @@
           "name": "Psychic Frog"
         },
         {
-          "count": 3,
+          "count": 4,
           "name": "Quantum Riddler"
         },
         {
@@ -965,7 +953,7 @@
           "name": "Tamiyo, Inquisitive Student"
         },
         {
-          "count": 3,
+          "count": 4,
           "name": "Thoughtseize"
         },
         {
@@ -973,33 +961,25 @@
           "name": "Undercity Sewers"
         },
         {
-          "count": 4,
+          "count": 3,
           "name": "Watery Grave"
         }
       ],
       "sideboard": [
         {
-          "count": 4,
+          "count": 3,
+          "name": "Break the Ice"
+        },
+        {
+          "count": 2,
           "name": "Consign to Memory"
         },
         {
           "count": 2,
-          "name": "Dress Down"
-        },
-        {
-          "count": 1,
           "name": "Engineered Explosives"
         },
         {
-          "count": 1,
-          "name": "Force of Despair"
-        },
-        {
-          "count": 2,
-          "name": "Harbinger of the Seas"
-        },
-        {
-          "count": 2,
+          "count": 3,
           "name": "Mystical Dispute"
         },
         {
@@ -1008,178 +988,11 @@
         },
         {
           "count": 1,
+          "name": "Requiting Hex"
+        },
+        {
+          "count": 2,
           "name": "Toxic Deluge"
-        }
-      ]
-    },
-    {
-      "name": "Neobrand",
-      "author": "MTGGoldfish",
-      "colors": [
-        "G",
-        "U"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 2,
-          "name": "Forest"
-        },
-        {
-          "count": 1,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Breeding Pool"
-        },
-        {
-          "count": 4,
-          "name": "Allosaurus Rider"
-        },
-        {
-          "count": 3,
-          "name": "Pact of Negation"
-        },
-        {
-          "count": 4,
-          "name": "Summoner's Pact"
-        },
-        {
-          "count": 4,
-          "name": "Misty Rainforest"
-        },
-        {
-          "count": 1,
-          "name": "Scalding Tarn"
-        },
-        {
-          "count": 1,
-          "name": "Nature's Claim"
-        },
-        {
-          "count": 1,
-          "name": "Xenagos, God of Revels"
-        },
-        {
-          "count": 1,
-          "name": "Hooting Mandrills"
-        },
-        {
-          "count": 1,
-          "name": "Flooded Strand"
-        },
-        {
-          "count": 1,
-          "name": "Windswept Heath"
-        },
-        {
-          "count": 4,
-          "name": "Eldritch Evolution"
-        },
-        {
-          "count": 1,
-          "name": "Griselbrand"
-        },
-        {
-          "count": 4,
-          "name": "Neoform"
-        },
-        {
-          "count": 2,
-          "name": "Veil of Summer"
-        },
-        {
-          "count": 2,
-          "name": "Endurance"
-        },
-        {
-          "count": 1,
-          "name": "Boseiju, Who Endures"
-        },
-        {
-          "count": 1,
-          "name": "Atraxa, Grand Unifier"
-        },
-        {
-          "count": 2,
-          "name": "Generous Ent"
-        },
-        {
-          "count": 2,
-          "name": "Ghalta, Stampede Tyrant"
-        },
-        {
-          "count": 3,
-          "name": "Hedge Maze"
-        },
-        {
-          "count": 4,
-          "name": "Consign to Memory"
-        },
-        {
-          "count": 4,
-          "name": "Planar Genesis"
-        },
-        {
-          "count": 1,
-          "name": "Bridgeworks Battle"
-        },
-        {
-          "count": 2,
-          "name": "Disciple of Freyalise"
-        },
-        {
-          "count": 1,
-          "name": "Ureni, the Song Unending"
-        },
-        {
-          "count": 1,
-          "name": "Nourishing Shoal"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 1,
-          "name": "Elesh Norn, Grand Cenobite"
-        },
-        {
-          "count": 1,
-          "name": "Hooting Mandrills"
-        },
-        {
-          "count": 1,
-          "name": "Natural State"
-        },
-        {
-          "count": 2,
-          "name": "Veil of Summer"
-        },
-        {
-          "count": 4,
-          "name": "Mystical Dispute"
-        },
-        {
-          "count": 1,
-          "name": "Endurance"
-        },
-        {
-          "count": 1,
-          "name": "Into the Flood Maw"
-        },
-        {
-          "count": 2,
-          "name": "Thundertrap Trainer"
-        },
-        {
-          "count": 1,
-          "name": "Abhorrent Oculus"
-        },
-        {
-          "count": 1,
-          "name": "Nature's Claim"
         }
       ]
     },
@@ -1478,6 +1291,173 @@
         {
           "count": 2,
           "name": "Trinisphere"
+        }
+      ]
+    },
+    {
+      "name": "Neobrand",
+      "author": "MTGGoldfish",
+      "colors": [
+        "G",
+        "U"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 4,
+          "name": "Neoform"
+        },
+        {
+          "count": 4,
+          "name": "Planar Genesis"
+        },
+        {
+          "count": 4,
+          "name": "Eldritch Evolution"
+        },
+        {
+          "count": 2,
+          "name": "Generous Ent"
+        },
+        {
+          "count": 2,
+          "name": "Forest"
+        },
+        {
+          "count": 1,
+          "name": "Griselbrand"
+        },
+        {
+          "count": 1,
+          "name": "Preordain"
+        },
+        {
+          "count": 4,
+          "name": "Misty Rainforest"
+        },
+        {
+          "count": 3,
+          "name": "Hedge Maze"
+        },
+        {
+          "count": 4,
+          "name": "Allosaurus Rider"
+        },
+        {
+          "count": 2,
+          "name": "Scalding Tarn"
+        },
+        {
+          "count": 1,
+          "name": "Breeding Pool"
+        },
+        {
+          "count": 4,
+          "name": "Consign to Memory"
+        },
+        {
+          "count": 1,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Hooting Mandrills"
+        },
+        {
+          "count": 1,
+          "name": "Verdant Catacombs"
+        },
+        {
+          "count": 1,
+          "name": "Xenagos, God of Revels"
+        },
+        {
+          "count": 2,
+          "name": "Disciple of Freyalise"
+        },
+        {
+          "count": 2,
+          "name": "Veil of Summer"
+        },
+        {
+          "count": 2,
+          "name": "Ghalta, Stampede Tyrant"
+        },
+        {
+          "count": 2,
+          "name": "Nature's Claim"
+        },
+        {
+          "count": 1,
+          "name": "Ureni, the Song Unending"
+        },
+        {
+          "count": 1,
+          "name": "Boseiju, Who Endures"
+        },
+        {
+          "count": 4,
+          "name": "Summoner's Pact"
+        },
+        {
+          "count": 3,
+          "name": "Pact of Negation"
+        },
+        {
+          "count": 1,
+          "name": "Bridgeworks Battle"
+        },
+        {
+          "count": 1,
+          "name": "Endurance"
+        },
+        {
+          "count": 1,
+          "name": "Atraxa, Grand Unifier"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 1,
+          "name": "Elesh Norn, Grand Cenobite"
+        },
+        {
+          "count": 1,
+          "name": "Nature's Claim"
+        },
+        {
+          "count": 1,
+          "name": "Abhorrent Oculus"
+        },
+        {
+          "count": 4,
+          "name": "Mystical Dispute"
+        },
+        {
+          "count": 1,
+          "name": "Hooting Mandrills"
+        },
+        {
+          "count": 1,
+          "name": "Into the Flood Maw"
+        },
+        {
+          "count": 2,
+          "name": "Thundertrap Trainer"
+        },
+        {
+          "count": 2,
+          "name": "Veil of Summer"
+        },
+        {
+          "count": 1,
+          "name": "Pact of Negation"
+        },
+        {
+          "count": 1,
+          "name": "Natural State"
         }
       ]
     }

--- a/client/public/feeds/mtggoldfish-pioneer.json
+++ b/client/public/feeds/mtggoldfish-pioneer.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "pioneer",
   "version": 1,
-  "updated": "2026-08-23T00:00:00Z",
+  "updated": "2026-08-24T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/pioneer",
   "decks": [
     {
@@ -454,94 +454,30 @@
       "main": [
         {
           "count": 4,
-          "name": "Hired Claw"
-        },
-        {
-          "count": 4,
-          "name": "Monastery Swiftspear"
-        },
-        {
-          "count": 2,
-          "name": "Soul-Scar Mage"
-        },
-        {
-          "count": 2,
-          "name": "Mountain"
-        },
-        {
-          "count": 2,
-          "name": "Bonecrusher Giant"
-        },
-        {
-          "count": 4,
-          "name": "Screaming Nemesis"
-        },
-        {
-          "count": 4,
           "name": "Burst Lightning"
         },
         {
-          "count": 4,
-          "name": "Monstrous Rage"
-        },
-        {
-          "count": 4,
-          "name": "Reckless Rage"
-        },
-        {
-          "count": 4,
-          "name": "Kumano Faces Kakkazan"
-        },
-        {
-          "count": 2,
+          "count": 1,
           "name": "Den of the Bugbear"
-        },
-        {
-          "count": 2,
-          "name": "Mountain"
         },
         {
           "count": 4,
           "name": "Emberheart Challenger"
         },
         {
-          "count": 2,
-          "name": "Rockface Village"
+          "count": 4,
+          "name": "Kumano Faces Kakkazan"
         },
         {
-          "count": 1,
-          "name": "Sokenzan, Crucible of Defiance"
+          "count": 4,
+          "name": "Monastery Swiftspear"
         },
         {
-          "count": 2,
-          "name": "Mountain"
+          "count": 3,
+          "name": "Monstrous Rage"
         },
         {
-          "count": 2,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 2,
-          "name": "Mountain"
-        },
-        {
-          "count": 1,
+          "count": 15,
           "name": "Mountain"
         },
         {
@@ -549,42 +485,62 @@
           "name": "Ramunap Ruins"
         },
         {
+          "count": 4,
+          "name": "Reckless Rage"
+        },
+        {
           "count": 2,
+          "name": "Screaming Nemesis"
+        },
+        {
+          "count": 1,
+          "name": "Sokenzan, Crucible of Defiance"
+        },
+        {
+          "count": 4,
+          "name": "Soul-Scar Mage"
+        },
+        {
+          "count": 3,
           "name": "Sunspine Lynx"
+        },
+        {
+          "count": 2,
+          "name": "Screaming Nemesis"
+        },
+        {
+          "count": 4,
+          "name": "Mutavault"
+        },
+        {
+          "count": 3,
+          "name": "Flowstone Infusion"
         }
       ],
       "sideboard": [
         {
-          "count": 1,
-          "name": "Flowstone Infusion"
-        },
-        {
           "count": 2,
-          "name": "Raze the Effigy"
-        },
-        {
-          "count": 1,
-          "name": "Grafdigger's Cage"
-        },
-        {
-          "count": 2,
-          "name": "Pyroclasm"
+          "name": "Scorching Shot"
         },
         {
           "count": 4,
           "name": "Magebane Lizard"
         },
         {
-          "count": 2,
-          "name": "Soul-Guide Lantern"
+          "count": 3,
+          "name": "Pyroclasm"
+        },
+        {
+          "count": 3,
+          "name": "Weathered Runestone"
         },
         {
           "count": 1,
-          "name": "Chandra, Dressed to Kill"
+          "name": "Sunspine Lynx"
         },
         {
           "count": 2,
-          "name": "Sunspine Lynx"
+          "name": "The Legend of Roku"
         }
       ]
     },
@@ -740,23 +696,15 @@
         },
         {
           "count": 4,
-          "name": "Gloomlake Verge"
+          "name": "Narset, Parter of Veils"
         },
         {
-          "count": 1,
-          "name": "Otawara, Soaring City"
+          "count": 4,
+          "name": "Gloomlake Verge"
         },
         {
           "count": 4,
           "name": "Fear of Isolation"
-        },
-        {
-          "count": 3,
-          "name": "Stock Up"
-        },
-        {
-          "count": 4,
-          "name": "Hopeless Nightmare"
         },
         {
           "count": 4,
@@ -764,11 +712,19 @@
         },
         {
           "count": 4,
-          "name": "Narset, Parter of Veils"
+          "name": "Hopeless Nightmare"
         },
         {
           "count": 4,
           "name": "Nowhere to Run"
+        },
+        {
+          "count": 4,
+          "name": "Fatal Push"
+        },
+        {
+          "count": 1,
+          "name": "Otawara, Soaring City"
         },
         {
           "count": 4,
@@ -779,28 +735,12 @@
           "name": "Stormchaser's Talent"
         },
         {
-          "count": 1,
-          "name": "Takenuma, Abandoned Mire"
-        },
-        {
-          "count": 4,
-          "name": "This Town Ain't Big Enough"
-        },
-        {
           "count": 2,
           "name": "Island"
         },
         {
           "count": 2,
-          "name": "Urborg, Tomb of Yawgmoth"
-        },
-        {
-          "count": 3,
-          "name": "Petrified Hamlet"
-        },
-        {
-          "count": 2,
-          "name": "Swamp"
+          "name": "Stock Up"
         },
         {
           "count": 2,
@@ -811,26 +751,42 @@
           "name": "Darkslick Shores"
         },
         {
+          "count": 2,
+          "name": "Swamp"
+        },
+        {
+          "count": 2,
+          "name": "Urborg, Tomb of Yawgmoth"
+        },
+        {
+          "count": 4,
+          "name": "Petrified Hamlet"
+        },
+        {
           "count": 4,
           "name": "Thoughtseize"
         },
         {
-          "count": 4,
-          "name": "Fatal Push"
+          "count": 1,
+          "name": "Takenuma, Abandoned Mire"
         },
         {
           "count": 4,
           "name": "Watery Grave"
+        },
+        {
+          "count": 4,
+          "name": "This Town Ain't Big Enough"
         }
       ],
       "sideboard": [
         {
-          "count": 2,
-          "name": "Change the Equation"
+          "count": 1,
+          "name": "The Meathook Massacre"
         },
         {
-          "count": 3,
-          "name": "Invoke Despair"
+          "count": 2,
+          "name": "Change the Equation"
         },
         {
           "count": 1,
@@ -841,12 +797,16 @@
           "name": "Unlicensed Hearse"
         },
         {
-          "count": 4,
-          "name": "Grim Bauble"
+          "count": 3,
+          "name": "Invoke Despair"
         },
         {
           "count": 2,
           "name": "Go Blank"
+        },
+        {
+          "count": 3,
+          "name": "Grim Bauble"
         }
       ]
     },
@@ -966,6 +926,173 @@
         {
           "count": 2,
           "name": "Brazen Borrower"
+        }
+      ]
+    },
+    {
+      "name": "Temur Lessons",
+      "author": "MTGGoldfish",
+      "colors": [
+        "U",
+        "R"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Accumulate Wisdom"
+        },
+        {
+          "count": 3,
+          "name": "Gran-Gran"
+        },
+        {
+          "count": 4,
+          "name": "Riverpyre Verge"
+        },
+        {
+          "count": 3,
+          "name": "Firebending Lesson"
+        },
+        {
+          "count": 2,
+          "name": "Island"
+        },
+        {
+          "count": 4,
+          "name": "Divide by Zero"
+        },
+        {
+          "count": 2,
+          "name": "Thor, God of Thunder"
+        },
+        {
+          "count": 1,
+          "name": "Mountain"
+        },
+        {
+          "count": 2,
+          "name": "Steam Vents"
+        },
+        {
+          "count": 4,
+          "name": "Riverglide Pathway"
+        },
+        {
+          "count": 1,
+          "name": "Combustion Technique"
+        },
+        {
+          "count": 2,
+          "name": "Ral, Crackling Wit"
+        },
+        {
+          "count": 1,
+          "name": "Spirebluff Canal"
+        },
+        {
+          "count": 4,
+          "name": "It'll Quench Ya!"
+        },
+        {
+          "count": 2,
+          "name": "Accumulate Wisdom"
+        },
+        {
+          "count": 3,
+          "name": "Willowrush Verge"
+        },
+        {
+          "count": 1,
+          "name": "Willowrush Verge"
+        },
+        {
+          "count": 3,
+          "name": "Questing Druid"
+        },
+        {
+          "count": 1,
+          "name": "Abandon Attachments"
+        },
+        {
+          "count": 2,
+          "name": "Steam Vents"
+        },
+        {
+          "count": 2,
+          "name": "Spirebluff Canal"
+        },
+        {
+          "count": 3,
+          "name": "Abandon Attachments"
+        },
+        {
+          "count": 1,
+          "name": "Gran-Gran"
+        },
+        {
+          "count": 4,
+          "name": "Tablet of Discovery"
+        },
+        {
+          "count": 2,
+          "name": "Pop Quiz"
+        },
+        {
+          "count": 2,
+          "name": "Combustion Technique"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 1,
+          "name": "Price of Freedom"
+        },
+        {
+          "count": 1,
+          "name": "Sokka's Haiku"
+        },
+        {
+          "count": 3,
+          "name": "Avengers Disassembled"
+        },
+        {
+          "count": 1,
+          "name": "Iroh's Demonstration"
+        },
+        {
+          "count": 1,
+          "name": "Accumulate Wisdom"
+        },
+        {
+          "count": 1,
+          "name": "Mascot Exhibition"
+        },
+        {
+          "count": 1,
+          "name": "Improvisation Capstone"
+        },
+        {
+          "count": 1,
+          "name": "Origin of Metalbending"
+        },
+        {
+          "count": 1,
+          "name": "Ral, Crackling Wit"
+        },
+        {
+          "count": 1,
+          "name": "Combustion Technique"
+        },
+        {
+          "count": 2,
+          "name": "Ghost Vacuum"
+        },
+        {
+          "count": 1,
+          "name": "Price of Freedom"
         }
       ]
     },
@@ -1097,10 +1224,11 @@
       ]
     },
     {
-      "name": "Temur Lessons",
+      "name": "Jeskai Lessons",
       "author": "MTGGoldfish",
       "colors": [
         "U",
+        "W",
         "R"
       ],
       "tags": [
@@ -1108,258 +1236,106 @@
       ],
       "main": [
         {
-          "count": 4,
-          "name": "Abandon Attachments"
-        },
-        {
-          "count": 3,
-          "name": "Accumulate Wisdom"
-        },
-        {
-          "count": 3,
-          "name": "Combustion Technique"
-        },
-        {
-          "count": 4,
-          "name": "Divide by Zero"
-        },
-        {
-          "count": 4,
-          "name": "Firebending Lesson"
-        },
-        {
-          "count": 4,
-          "name": "Gran-Gran"
-        },
-        {
           "count": 1,
-          "name": "Iroh's Demonstration"
-        },
-        {
-          "count": 4,
-          "name": "Steam Vents"
-        },
-        {
-          "count": 4,
-          "name": "It'll Quench Ya!"
-        },
-        {
-          "count": 3,
-          "name": "Spirebluff Canal"
-        },
-        {
-          "count": 2,
-          "name": "Pop Quiz"
-        },
-        {
-          "count": 3,
-          "name": "Questing Druid"
-        },
-        {
-          "count": 4,
-          "name": "Riverglide Pathway"
-        },
-        {
-          "count": 4,
-          "name": "Riverpyre Verge"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
+          "name": "Deserted Beach"
         },
         {
           "count": 2,
           "name": "Island"
         },
         {
-          "count": 4,
-          "name": "Tablet of Discovery"
-        },
-        {
-          "count": 2,
-          "name": "Thor, God of Thunder"
-        },
-        {
-          "count": 4,
-          "name": "Willowrush Verge"
-        }
-      ],
-      "sideboard": [
-        {
           "count": 1,
-          "name": "Accumulate Wisdom"
-        },
-        {
-          "count": 1,
-          "name": "Boomerang Basics"
-        },
-        {
-          "count": 1,
-          "name": "Combustion Technique"
-        },
-        {
-          "count": 1,
-          "name": "Environmental Sciences"
-        },
-        {
-          "count": 2,
-          "name": "Ghost Vacuum"
-        },
-        {
-          "count": 2,
-          "name": "Improvisation Capstone"
-        },
-        {
-          "count": 1,
-          "name": "Iroh's Demonstration"
-        },
-        {
-          "count": 1,
-          "name": "Mascot Exhibition"
-        },
-        {
-          "count": 1,
-          "name": "Origin of Metalbending"
-        },
-        {
-          "count": 1,
-          "name": "Price of Freedom"
-        },
-        {
-          "count": 2,
-          "name": "Sokka's Haiku"
-        },
-        {
-          "count": 1,
-          "name": "True Ancestry"
-        }
-      ]
-    },
-    {
-      "name": "Jeskai Lessons",
-      "author": "MTGGoldfish",
-      "colors": [
-        "R",
-        "W",
-        "U"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 4,
-          "name": "Abandon Attachments"
-        },
-        {
-          "count": 3,
-          "name": "Accumulate Wisdom"
-        },
-        {
-          "count": 4,
-          "name": "Firebending Lesson"
-        },
-        {
-          "count": 4,
-          "name": "Gran-Gran"
-        },
-        {
-          "count": 3,
-          "name": "Sacred Foundry"
-        },
-        {
-          "count": 4,
-          "name": "Steam Vents"
-        },
-        {
-          "count": 4,
-          "name": "Tablet of Discovery"
-        },
-        {
-          "count": 4,
-          "name": "Spirebluff Canal"
-        },
-        {
-          "count": 4,
-          "name": "Riverpyre Verge"
-        },
-        {
-          "count": 1,
-          "name": "Mistrise Village"
-        },
-        {
-          "count": 3,
-          "name": "Jeskai Revelation"
-        },
-        {
-          "count": 2,
-          "name": "Island"
-        },
-        {
-          "count": 4,
-          "name": "Hallowed Fountain"
+          "name": "Teferi, Hero of Dominaria"
         },
         {
           "count": 4,
           "name": "Divide by Zero"
-        },
-        {
-          "count": 4,
-          "name": "It'll Quench Ya!"
-        },
-        {
-          "count": 2,
-          "name": "Thor, God of Thunder"
-        },
-        {
-          "count": 4,
-          "name": "Combustion Technique"
         },
         {
           "count": 1,
           "name": "Stormcarved Coast"
         },
         {
+          "count": 2,
+          "name": "No More Lies"
+        },
+        {
+          "count": 4,
+          "name": "Riverpyre Verge"
+        },
+        {
+          "count": 3,
+          "name": "Accumulate Wisdom"
+        },
+        {
+          "count": 4,
+          "name": "It'll Quench Ya!"
+        },
+        {
+          "count": 3,
+          "name": "Combustion Technique"
+        },
+        {
+          "count": 4,
+          "name": "Firebending Lesson"
+        },
+        {
+          "count": 2,
+          "name": "Abandon Attachments"
+        },
+        {
+          "count": 4,
+          "name": "Tablet of Discovery"
+        },
+        {
           "count": 1,
-          "name": "Sundown Pass"
+          "name": "Hallowed Fountain"
+        },
+        {
+          "count": 2,
+          "name": "Sacred Foundry"
+        },
+        {
+          "count": 4,
+          "name": "Spirebluff Canal"
+        },
+        {
+          "count": 2,
+          "name": "Spell Pierce"
+        },
+        {
+          "count": 1,
+          "name": "Prismari Command"
+        },
+        {
+          "count": 2,
+          "name": "Seachrome Coast"
+        },
+        {
+          "count": 3,
+          "name": "Jeskai Revelation"
+        },
+        {
+          "count": 3,
+          "name": "Hallowed Fountain"
+        },
+        {
+          "count": 2,
+          "name": "Steam Vents"
+        },
+        {
+          "count": 3,
+          "name": "Abrade"
+        },
+        {
+          "count": 2,
+          "name": "Steam Vents"
         }
       ],
       "sideboard": [
         {
           "count": 1,
-          "name": "Boomerang Basics"
-        },
-        {
-          "count": 1,
-          "name": "Emeritus of Ideation"
-        },
-        {
-          "count": 1,
-          "name": "Jeskai Revelation"
-        },
-        {
-          "count": 1,
-          "name": "Price of Freedom"
-        },
-        {
-          "count": 1,
-          "name": "Soulless Jailer"
-        },
-        {
-          "count": 1,
-          "name": "Sokka's Haiku"
-        },
-        {
-          "count": 2,
-          "name": "Improvisation Capstone"
-        },
-        {
-          "count": 1,
-          "name": "Iroh's Demonstration"
-        },
-        {
-          "count": 2,
-          "name": "Ral, Crackling Wit"
+          "name": "Combustion Technique"
         },
         {
           "count": 1,
@@ -1367,11 +1343,31 @@
         },
         {
           "count": 1,
-          "name": "Sphinx of the Final Word"
+          "name": "Dovin's Veto"
+        },
+        {
+          "count": 1,
+          "name": "Improvisation Capstone"
+        },
+        {
+          "count": 3,
+          "name": "Mystical Dispute"
+        },
+        {
+          "count": 1,
+          "name": "Redcap Melee"
         },
         {
           "count": 2,
           "name": "Ghost Vacuum"
+        },
+        {
+          "count": 2,
+          "name": "Kutzil's Flanker"
+        },
+        {
+          "count": 3,
+          "name": "Gran-Gran"
         }
       ]
     }

--- a/client/public/feeds/mtggoldfish-standard.json
+++ b/client/public/feeds/mtggoldfish-standard.json
@@ -5,9 +5,131 @@
   "icon": "G",
   "format": "standard",
   "version": 1,
-  "updated": "2026-08-23T00:00:00Z",
+  "updated": "2026-08-24T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/standard",
   "decks": [
+    {
+      "name": "Mono-Green Landfall",
+      "author": "MTGGoldfish",
+      "colors": [
+        "G"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 4,
+          "name": "Earthbender Ascension"
+        },
+        {
+          "count": 3,
+          "name": "Esper Origins"
+        },
+        {
+          "count": 3,
+          "name": "Ba Sing Se"
+        },
+        {
+          "count": 2,
+          "name": "Icetill Explorer"
+        },
+        {
+          "count": 14,
+          "name": "Forest"
+        },
+        {
+          "count": 2,
+          "name": "Icetill Explorer"
+        },
+        {
+          "count": 4,
+          "name": "Fabled Passage"
+        },
+        {
+          "count": 1,
+          "name": "Meltstrider's Resolve"
+        },
+        {
+          "count": 4,
+          "name": "Mightform Harmonizer"
+        },
+        {
+          "count": 4,
+          "name": "Sapling Nursery"
+        },
+        {
+          "count": 4,
+          "name": "Sazh's Chocobo"
+        },
+        {
+          "count": 1,
+          "name": "Demolition Field"
+        },
+        {
+          "count": 1,
+          "name": "Surrak, Elusive Hunter"
+        },
+        {
+          "count": 2,
+          "name": "Escape Tunnel"
+        },
+        {
+          "count": 4,
+          "name": "Llanowar Elves"
+        },
+        {
+          "count": 2,
+          "name": "Elven Passage"
+        },
+        {
+          "count": 3,
+          "name": "Glimpse the Core"
+        },
+        {
+          "count": 1,
+          "name": "Promising Vein"
+        },
+        {
+          "count": 1,
+          "name": "Lumbering Worldwagon"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 1,
+          "name": "Gigantic Big Bear"
+        },
+        {
+          "count": 1,
+          "name": "Keen-Eyed Curator"
+        },
+        {
+          "count": 3,
+          "name": "Meltstrider's Resolve"
+        },
+        {
+          "count": 4,
+          "name": "Mossborn Hydra"
+        },
+        {
+          "count": 1,
+          "name": "Surrak, Elusive Hunter"
+        },
+        {
+          "count": 2,
+          "name": "Torpor Orb"
+        },
+        {
+          "count": 2,
+          "name": "Warg Tactics"
+        },
+        {
+          "count": 1,
+          "name": "Leatherhead, Swamp Stalker"
+        }
+      ]
+    },
     {
       "name": "4c Control",
       "author": "MTGGoldfish",
@@ -460,124 +582,6 @@
       ]
     },
     {
-      "name": "Mono-Green Landfall",
-      "author": "MTGGoldfish",
-      "colors": [
-        "G"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 3,
-          "name": "Ba Sing Se"
-        },
-        {
-          "count": 4,
-          "name": "Earthbender Ascension"
-        },
-        {
-          "count": 4,
-          "name": "Escape Tunnel"
-        },
-        {
-          "count": 4,
-          "name": "Esper Origins"
-        },
-        {
-          "count": 1,
-          "name": "Demolition Field"
-        },
-        {
-          "count": 4,
-          "name": "Icetill Explorer"
-        },
-        {
-          "count": 1,
-          "name": "Keen-Eyed Curator"
-        },
-        {
-          "count": 4,
-          "name": "Fabled Passage"
-        },
-        {
-          "count": 1,
-          "name": "Lumbering Worldwagon"
-        },
-        {
-          "count": 2,
-          "name": "Meltstrider's Resolve"
-        },
-        {
-          "count": 4,
-          "name": "Mightform Harmonizer"
-        },
-        {
-          "count": 1,
-          "name": "Royal Treatment"
-        },
-        {
-          "count": 2,
-          "name": "Sapling Nursery"
-        },
-        {
-          "count": 4,
-          "name": "Sazh's Chocobo"
-        },
-        {
-          "count": 2,
-          "name": "Shared Roots"
-        },
-        {
-          "count": 1,
-          "name": "Surrak, Elusive Hunter"
-        },
-        {
-          "count": 4,
-          "name": "Llanowar Elves"
-        },
-        {
-          "count": 14,
-          "name": "Forest"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 1,
-          "name": "Keen-Eyed Curator"
-        },
-        {
-          "count": 2,
-          "name": "Meltstrider's Resolve"
-        },
-        {
-          "count": 4,
-          "name": "Mossborn Hydra"
-        },
-        {
-          "count": 1,
-          "name": "Royal Treatment"
-        },
-        {
-          "count": 2,
-          "name": "Sapling Nursery"
-        },
-        {
-          "count": 1,
-          "name": "Surrak, Elusive Hunter"
-        },
-        {
-          "count": 2,
-          "name": "Torpor Orb"
-        },
-        {
-          "count": 2,
-          "name": "Warg Tactics"
-        }
-      ]
-    },
-    {
       "name": "Dimir Midrange",
       "author": "MTGGoldfish",
       "colors": [
@@ -820,6 +824,134 @@
       ]
     },
     {
+      "name": "Mardu Discard",
+      "author": "MTGGoldfish",
+      "colors": [
+        "W",
+        "B",
+        "R"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 3,
+          "name": "Godless Shrine"
+        },
+        {
+          "count": 2,
+          "name": "Tersa Lightshatter"
+        },
+        {
+          "count": 3,
+          "name": "Carnage, Crimson Chaos"
+        },
+        {
+          "count": 3,
+          "name": "Concealed Courtyard"
+        },
+        {
+          "count": 4,
+          "name": "Cool but Rude"
+        },
+        {
+          "count": 2,
+          "name": "Erode"
+        },
+        {
+          "count": 1,
+          "name": "Mountain"
+        },
+        {
+          "count": 4,
+          "name": "Hardened Academic"
+        },
+        {
+          "count": 2,
+          "name": "Inspiring Vantage"
+        },
+        {
+          "count": 4,
+          "name": "Sacred Foundry"
+        },
+        {
+          "count": 4,
+          "name": "Iron-Shield Elf"
+        },
+        {
+          "count": 4,
+          "name": "Marauding Mako"
+        },
+        {
+          "count": 1,
+          "name": "Swamp"
+        },
+        {
+          "count": 3,
+          "name": "Practiced Offense"
+        },
+        {
+          "count": 2,
+          "name": "Requiting Hex"
+        },
+        {
+          "count": 4,
+          "name": "Moonshadow"
+        },
+        {
+          "count": 4,
+          "name": "Starting Town"
+        },
+        {
+          "count": 4,
+          "name": "Blood Crypt"
+        },
+        {
+          "count": 2,
+          "name": "Inti, Seneschal of the Sun"
+        },
+        {
+          "count": 4,
+          "name": "Bloodghast"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 2,
+          "name": "Avatar's Wrath"
+        },
+        {
+          "count": 2,
+          "name": "Monument to Endurance"
+        },
+        {
+          "count": 2,
+          "name": "Abrade"
+        },
+        {
+          "count": 1,
+          "name": "Pyroclasm"
+        },
+        {
+          "count": 2,
+          "name": "Duress"
+        },
+        {
+          "count": 1,
+          "name": "Shoot the Sheriff"
+        },
+        {
+          "count": 3,
+          "name": "Strategic Betrayal"
+        },
+        {
+          "count": 2,
+          "name": "Voice of Victory"
+        }
+      ]
+    },
+    {
       "name": "Azorius Tempo",
       "author": "MTGGoldfish",
       "colors": [
@@ -947,134 +1079,6 @@
         {
           "count": 1,
           "name": "Negate"
-        }
-      ]
-    },
-    {
-      "name": "Mardu Discard",
-      "author": "MTGGoldfish",
-      "colors": [
-        "W",
-        "B",
-        "R"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 3,
-          "name": "Godless Shrine"
-        },
-        {
-          "count": 2,
-          "name": "Tersa Lightshatter"
-        },
-        {
-          "count": 3,
-          "name": "Carnage, Crimson Chaos"
-        },
-        {
-          "count": 3,
-          "name": "Concealed Courtyard"
-        },
-        {
-          "count": 4,
-          "name": "Cool but Rude"
-        },
-        {
-          "count": 2,
-          "name": "Erode"
-        },
-        {
-          "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 4,
-          "name": "Hardened Academic"
-        },
-        {
-          "count": 2,
-          "name": "Inspiring Vantage"
-        },
-        {
-          "count": 4,
-          "name": "Sacred Foundry"
-        },
-        {
-          "count": 4,
-          "name": "Iron-Shield Elf"
-        },
-        {
-          "count": 4,
-          "name": "Marauding Mako"
-        },
-        {
-          "count": 1,
-          "name": "Swamp"
-        },
-        {
-          "count": 3,
-          "name": "Practiced Offense"
-        },
-        {
-          "count": 2,
-          "name": "Requiting Hex"
-        },
-        {
-          "count": 4,
-          "name": "Moonshadow"
-        },
-        {
-          "count": 4,
-          "name": "Starting Town"
-        },
-        {
-          "count": 4,
-          "name": "Blood Crypt"
-        },
-        {
-          "count": 2,
-          "name": "Inti, Seneschal of the Sun"
-        },
-        {
-          "count": 4,
-          "name": "Bloodghast"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 2,
-          "name": "Avatar's Wrath"
-        },
-        {
-          "count": 2,
-          "name": "Monument to Endurance"
-        },
-        {
-          "count": 2,
-          "name": "Abrade"
-        },
-        {
-          "count": 1,
-          "name": "Pyroclasm"
-        },
-        {
-          "count": 2,
-          "name": "Duress"
-        },
-        {
-          "count": 1,
-          "name": "Shoot the Sheriff"
-        },
-        {
-          "count": 3,
-          "name": "Strategic Betrayal"
-        },
-        {
-          "count": 2,
-          "name": "Voice of Victory"
         }
       ]
     },


### PR DESCRIPTION
Automated daily metagame feed refresh from MTGGoldfish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Content Updates**
  * Refreshed MTGGoldfish Modern, Pioneer, and Standard metagame feeds with the latest timestamp and decklists.
  * Added a Neobrand deck entry to Modern.
  * Added and updated deck archetypes across Modern, Pioneer, and Standard, including Mono-Green Landfall.
  * Updated card compositions, colors, sideboards, and deck ordering to reflect current metagame data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->