### PR TITLE
fix(engine): normalize the chain tracked-set residue out of loop equality

### DIFF
--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -16435,6 +16435,10 @@ declare_game_state! {
     /// top-level chain entry (depth == 0) in `resolve_ability_chain`, and — when
     /// the chain is modal — again at each CR 700.2 mode boundary, keyed on
     /// [`Self::resolving_modal_instruction`].
+    ///
+    /// Resolution-scoped, so `normalize_for_loop` clears it for the CR 104.4b
+    /// position comparison: between resolutions it is the previous resolution's
+    /// residue and must not split two identical positions.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub chain_tracked_set_id: Option<TrackedSetId>,
 
@@ -23068,10 +23072,19 @@ impl GameState {
         // then differ here alone and never confirm a repeated position. It is
         // eq-compared (AI-search dedup legitimately reads it), so it is
         // normalized away HERE rather than excluded from `PartialEq`.
-        // NOTE: its lockstep partner `chain_tracked_set_id` carries the same
-        // residue and is deliberately NOT cleared here — that is pre-existing
-        // behavior with its own follow-up, not something this line may widen.
         clone.resolving_modal_instruction = None;
+        // CR 608.2c + CR 104.4b: the chain tracked-set pointer is that latch's
+        // lockstep partner and is resolution-scoped for the same reason — a chain's
+        // "those cards" anaphor names only what THIS resolution's instructions
+        // produced. Nothing narrows it at chain EXIT (a `repeat_for` drain even
+        // re-enters at depth 1 to preserve it), so between resolutions it still names
+        // the last resolution's set while the arena it points into
+        // (`tracked_object_sets` / `next_tracked_set_id` — real accumulated content,
+        // deliberately left compared) is unchanged. The pointer alone then splits two
+        // identical positions, so neither the CR 104.4b draw confirmation nor the
+        // CR 732.2a recurrence certification that shares this seam can confirm a
+        // repeat.
+        clone.chain_tracked_set_id = None;
         // CR 104.4b + CR 400.7: the all-zone incarnation bump advances a source's
         // epoch on every zone change, so a mandatory loop that cycles its source's
         // zones would otherwise carry a growing `TriggerSourceContext` into loop
@@ -29989,6 +30002,101 @@ mod tests {
             loop_states_equal(&first.normalize_for_loop(), &second.normalize_for_loop()),
             "CR 104.4b: positions differing only in the resolution-scoped mode-boundary \
              latch must confirm as a repeat"
+        );
+    }
+
+    /// CR 608.2c + CR 104.4b: the chain-local tracked-set pointer is resolution-scoped
+    /// and is narrowed only at scope ENTRY, so between resolutions it still names the
+    /// last resolution's set as pure residue. Two identical positions — the SAME
+    /// published set at the SAME counter — must still confirm as a repeated position
+    /// when only the pointer differs.
+    ///
+    /// DISCRIMINATION: delete `clone.chain_tracked_set_id = None;` from
+    /// `normalize_for_loop` and this test FAILS on the equality assertion — the field
+    /// is eq-compared, so the residue alone defeats the repeat. The `!=` assertion is
+    /// the paired non-vacuity witness: it proves the two inputs really do differ
+    /// BEFORE normalization.
+    #[test]
+    fn normalize_for_loop_clears_the_chain_tracked_set_residue() {
+        let mut first = GameState::new_two_player(7);
+        // Content authority identical in both — the published set and the advanced
+        // counter are established BEFORE the clone, so the pointer is the only
+        // difference.
+        first
+            .tracked_object_sets
+            .insert(TrackedSetId(1), Vec::new());
+        first.next_tracked_set_id = 2;
+        let mut second = first.clone();
+        first.chain_tracked_set_id = Some(TrackedSetId(1));
+        second.chain_tracked_set_id = None;
+
+        assert!(
+            first != second,
+            "non-vacuity: the two states must differ before normalization, else the \
+             equality assertion below proves nothing"
+        );
+
+        assert!(
+            loop_states_equal(&first.normalize_for_loop(), &second.normalize_for_loop()),
+            "CR 104.4b: positions naming the same published set must confirm as a repeat \
+             whether or not the resolution-scoped pointer still holds it"
+        );
+    }
+
+    /// CR 104.4b: `tracked_object_sets` and `next_tracked_set_id` are the tracked-set
+    /// CONTENT authority — real accumulated progress, not resolution-scoped residue.
+    /// `normalize_for_loop` neutralizes the chain POINTER into that arena and must
+    /// leave the arena and its mint compared: normalizing them would collapse two
+    /// genuinely different positions into one and draw a game that is still
+    /// progressing.
+    ///
+    /// DISCRIMINATION: this row's failing arrangement is not the clear this change
+    /// adds but a widening of it — add `clone.tracked_object_sets.clear();` or
+    /// `clone.next_tracked_set_id = 0;` to `normalize_for_loop` and the matching
+    /// inequality FAILS. The first assertion is the paired reach-guard: it differs
+    /// only in a field normalization does neutralize, so a normalization that stopped
+    /// running reddens it instead of leaving the inequalities to pass by default.
+    #[test]
+    fn normalize_for_loop_leaves_the_tracked_set_content_authority_compared() {
+        let mut base = GameState::new_two_player(7);
+        base.tracked_object_sets
+            .insert(TrackedSetId(1), vec![ObjectId(90_001)]);
+        base.next_tracked_set_id = 2;
+        base.chain_tracked_set_id = Some(TrackedSetId(1));
+
+        let mut volatile_only = base.clone();
+        volatile_only.state_revision = 99;
+        assert!(
+            loop_states_equal(
+                &base.normalize_for_loop(),
+                &volatile_only.normalize_for_loop()
+            ),
+            "reach guard: holding the arena equal, this pair must still confirm — else the \
+             inequalities below say nothing about the arena"
+        );
+
+        let mut other_members = base.clone();
+        other_members
+            .tracked_object_sets
+            .insert(TrackedSetId(1), vec![ObjectId(90_002)]);
+        assert!(
+            !loop_states_equal(
+                &base.normalize_for_loop(),
+                &other_members.normalize_for_loop()
+            ),
+            "CR 104.4b: differing tracked-set membership is real accumulated content and \
+             must not be normalized into a repeat"
+        );
+
+        let mut other_counter = base.clone();
+        other_counter.next_tracked_set_id = 3;
+        assert!(
+            !loop_states_equal(
+                &base.normalize_for_loop(),
+                &other_counter.normalize_for_loop()
+            ),
+            "CR 104.4b: a further minted tracked set is real accumulated content and must \
+             not be normalized into a repeat"
         );
     }
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

`GameState::chain_tracked_set_id` is resolution-scoped state that is narrowed only at scope entry and never at chain exit, so between resolutions it still names the previous resolution's tracked set as pure residue — and because the field is compared by `PartialEq`, two genuinely identical positions reached by way of different last resolutions never confirmed as a repeat. This clears the pointer in `normalize_for_loop`, exactly as its lockstep partner `resolving_modal_instruction` already is one line above (#7484, `976eb923d`).

## Files changed

- `crates/engine/src/types/game_state.rs` — clear the chain tracked-set pointer in `normalize_for_loop`; rewrite the note the clear falsifies; add the pairing sentence to the field doc; add two unit test rows.

## Track

Developer

## LLM

Model: claude-opus-5 (via Claude Code; canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- `CR 104.4b` — a loop of mandatory actions with no way to stop is a draw. This is the confirmation that was silently never firing.
- `CR 608.2c` — instructions are followed in the order written, applying the rules of English. This is why a chain's "those cards" anaphor is scoped to one resolution's own instructions, and therefore why the pointer is resolution-scoped rather than positional state.
- `CR 732.2a` — a shortcut through a loop that repeats a specified number of times, ending where a player has priority. The recurrence certification shares this seam and was blocked by the same residue.

Not used, deliberately: `CR 603.7` (delayed triggered abilities) and `CR 700.2` (modal spells) appear on neighbouring code but neither rule's subject is the claim made at this site.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

All run in a clean detached worktree at the committed head `0f778cf0e90d97d95391bc2c18f06f1b2d297631`, with `CARGO_INCREMENTAL=0` and an isolated `CARGO_TARGET_DIR`. Each build leg asserted its own `Compiling phase-engine` line, so no leg re-ran a stale binary.

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy --workspace --all-targets -- -D warnings` — exit 0, 0 errors, 0 warnings
- `cargo test -p phase-engine --lib` — 19639 passed; 0 failed; 6 ignored
- `cargo test -p phase-engine --test integration` — 5384 passed; 0 failed; 2 ignored

Both new rows were observed running by exact path, not inferred from a suite total:
`types::game_state::tests::normalize_for_loop_clears_the_chain_tracked_set_residue ... ok`
`types::game_state::tests::normalize_for_loop_leaves_the_tracked_set_content_authority_compared ... ok`

Both rows are discriminating, measured independently by the implementer and re-derived from scratch by the reviewer. Deleting the production line reddens row 1 on its `loop_states_equal` assertion (not its non-vacuity guard). Adding `clone.tracked_object_sets.clear()` reddens row 2 on its membership inequality; adding `clone.next_tracked_set_id = 0` reddens row 2 on its mint inequality — each inequality falls to its own orthogonal half. Deleting the production line leaves row 2 green, which confirms row 1's failure is attributable to the clear rather than to a shared fixture effect.

## Gate A

Gate A PASS head=0f778cf0e90d97d95391bc2c18f06f1b2d297631 base=b9f06c184d6cdfb1a95d935611bd0b9851ded0c3

Non-vacuous: that range spans 108 commits and 512 files and contains this commit.

## Anchored on

- `crates/engine/src/types/game_state.rs:23075` — `clone.resolving_modal_instruction = None;` in `normalize_for_loop`: the lockstep partner cleared for the same reason by #7484, immediately above the new line.
- `crates/engine/src/types/game_state.rs:29988` — `normalize_for_loop_clears_the_modal_boundary_latch_residue`: the partner's test row, whose shape (single-field delta, `!=` non-vacuity witness, then `loop_states_equal` on both normalized products) the new rows follow.

## Final review-impl

Final review-impl PASS head=0f778cf0e90d97d95391bc2c18f06f1b2d297631

## Claimed parse impact

None.

## Scope Expansion

None.

Two siblings in the same residue class are deliberately untouched: `product_knowledge_state` (#7094) and `chosen_counter_kind_this_resolution`. The latter is not a copy of this diff — it is also hashed into `loop_fingerprint`, so clearing it alone would leave the pre-filter still splitting the positions.

The arena this pointer indexes — `tracked_object_sets` and its mint `next_tracked_set_id` — stays compared and un-normalized on purpose. That content is real accumulated progress, and neutralizing it would collapse two genuinely different positions and draw a game that is still progressing. The second test row is the tripwire for exactly that direction.

## Validation Failures

None.

## CI Failures

None.

---

Closes #7514

Pipeline-reviewed head: 0f778cf0e90d97d95391bc2c18f06f1b2d297631
Current branch head: 0f778cf0e90d97d95391bc2c18f06f1b2d297631
Pipeline status: current
Current-head review: clean at 0f778cf0e90d97d95391bc2c18f06f1b2d297631


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved game-state normalization by clearing temporary resolution data.
  * Ensured equivalent positions compare consistently while preserving meaningful tracked-set and allocation differences.
* **Tests**
  * Added coverage for normalized positions with differing temporary references and significant state contents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->