### PR TITLE
fix(parser): lower Grimdancer's two-different-counters entry choice as a pair pick

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -6380,6 +6380,18 @@ pub(crate) fn classify_and_parse_counter_choice_list(
     Some(classify_counter_choice_list(&lower)?.entries)
 }
 
+/// CR 122.1b: Parse a bare "from among" counter list ("menace, deathtouch, and
+/// lifelink") into typed entries. Shares the item authority
+/// (`parse_counter_choice_list_entries`) with `classify_counter_choice_list`'s
+/// FromAmong arm — the caller has already consumed the "from among" preamble.
+pub(crate) fn classify_and_parse_from_among_counter_list(
+    list_text: &str,
+) -> Option<Vec<(CounterType, QuantityExpr)>> {
+    let lower = list_text.to_lowercase();
+    let items = split_choice_list_items(&lower)?;
+    parse_counter_choice_list_entries(ChoiceListShape::FromAmong, &items)
+}
+
 /// CR 122.1 + CR 122.1a + CR 122.1b: Parse shared-target counter choices of the form
 /// "put your choice of A counter-pattern, B counter-pattern, or C
 /// counter-pattern on TARGET" (N-ary branches).

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -3986,77 +3986,110 @@ fn parse_enters_with_counters(
     // always the recipient). Runtime folds the chosen counter pre-entry via the
     // deferred-entry-events capture in `engine_replacement.rs` /
     // `engine_resolution_choices.rs`.
-    if let Some((choices, _on)) = strip_enters_with_choice_target(after_additional) {
-        if let Some(entries) =
-            crate::parser::oracle_effect::classify_and_parse_counter_choice_list(choices)
-        {
-            // `classify_and_parse_counter_choice_list` already requires len >= 2.
-            let branches: Vec<AbilityDefinition> = entries
-                .into_iter()
-                .map(|(counter_type, count)| {
-                    let mut def = AbilityDefinition::new(
-                        AbilityKind::Spell,
-                        Effect::PutCounter {
-                            counter_type: counter_type.clone(),
-                            count,
-                            // CR 614.12a: the entering permanent is the recipient.
-                            target: TargetFilter::SelfRef,
-                        },
-                    );
-                    def.description = Some(format!("a {} counter", counter_type.display_phrase()));
-                    def
-                })
-                .collect();
+    let choice_branches: Option<Vec<AbilityDefinition>> = if let Some((choices, _on)) =
+        strip_enters_with_choice_target(after_additional)
+    {
+        crate::parser::oracle_effect::classify_and_parse_counter_choice_list(choices).map(
+            |entries| {
+                // `classify_and_parse_counter_choice_list` already requires len >= 2.
+                entries
+                    .into_iter()
+                    .map(|(counter_type, count)| {
+                        let mut def = AbilityDefinition::new(
+                            AbilityKind::Spell,
+                            Effect::PutCounter {
+                                counter_type: counter_type.clone(),
+                                count,
+                                // CR 614.12a: the entering permanent is the recipient.
+                                target: TargetFilter::SelfRef,
+                            },
+                        );
+                        def.description =
+                            Some(format!("a {} counter", counter_type.display_phrase()));
+                        def
+                    })
+                    .collect()
+            },
+        )
+    } else if let Some(list_text) = strip_enters_with_two_different_from_among(after_additional) {
+        // CR 614.12a + CR 608.2d: Grimdancer's reordered multi-pick form —
+        // "your choice of two different counters on it from among <list>".
+        // Choosing two distinct kinds is the same decision as choosing one
+        // unordered pair, so build the C(n,2) pairs; each branch chains two
+        // self-targeted `PutCounter`s via `build_enters_counter_ability`, and
+        // `resolve_branch` runs the chosen branch's full sub-ability chain
+        // before the deferred entry replays, so both counters fold pre-entry.
+        crate::parser::oracle_effect::classify_and_parse_from_among_counter_list(list_text).map(
+            |entries| {
+                let mut branches = Vec::new();
+                for i in 0..entries.len() {
+                    for j in (i + 1)..entries.len() {
+                        let mut def = build_enters_counter_ability(vec![
+                            entries[i].clone(),
+                            entries[j].clone(),
+                        ]);
+                        def.description = Some(format!(
+                            "a {} counter and a {} counter",
+                            entries[i].0.display_phrase(),
+                            entries[j].0.display_phrase()
+                        ));
+                        branches.push(def);
+                    }
+                }
+                branches
+            },
+        )
+    } else {
+        None
+    };
 
-            let choice = AbilityDefinition::new(
+    if let Some(branches) = choice_branches {
+        let choice = AbilityDefinition::new(
+            AbilityKind::Spell,
+            // CR 608.2d: resolution choice — controller picks the branch.
+            Effect::ChooseOneOf {
+                chooser: PlayerFilter::Controller,
+                branches,
+            },
+        );
+        let mut choice = choice;
+        choice.description = Some("your choice of counter".to_string());
+
+        // Compose with "enters tapped" if present (mirrors the single-counter
+        // tail below).
+        let execute = if has_enters_tapped_phrase(work_text) {
+            AbilityDefinition::new(
                 AbilityKind::Spell,
-                // CR 608.2d: resolution choice — controller picks the branch.
-                Effect::ChooseOneOf {
-                    chooser: PlayerFilter::Controller,
-                    branches,
+                Effect::SetTapState {
+                    target: TargetFilter::SelfRef,
+                    scope: EffectScope::Single,
+                    state: TapStateChange::Tap,
                 },
-            );
-            let mut choice = choice;
-            choice.description = Some("your choice of counter".to_string());
+            )
+            .sub_ability(choice)
+        } else {
+            choice
+        };
 
-            // Compose with "enters tapped" if present (mirrors the single-counter
-            // tail below).
-            let execute = if has_enters_tapped_phrase(work_text) {
-                AbilityDefinition::new(
-                    AbilityKind::Spell,
-                    Effect::SetTapState {
-                        target: TargetFilter::SelfRef,
-                        scope: EffectScope::Single,
-                        state: TapStateChange::Tap,
-                    },
-                )
-                .sub_ability(choice)
-            } else {
-                choice
-            };
+        // CR 614.1c: "enters with" is a replacement effect on the Moved event,
+        // battlefield-entry-scoped (see destination-gate note above).
+        let mut def = ReplacementDefinition::new(ReplacementEvent::Moved)
+            .execute(execute)
+            .valid_card(TargetFilter::SelfRef)
+            .destination_zone(Zone::Battlefield)
+            .description(original_text.to_string());
 
-            // CR 614.1c: "enters with" is a replacement effect on the Moved event,
-            // battlefield-entry-scoped (see destination-gate note above).
-            let mut def = ReplacementDefinition::new(ReplacementEvent::Moved)
-                .execute(execute)
-                .valid_card(TargetFilter::SelfRef)
-                .destination_zone(Zone::Battlefield)
-                .description(original_text.to_string());
-
-            // CR 614.1c: Attach the single applicable gate. The " unless " gate
-            // and the trailing conditional-suffix gate are mutually exclusive —
-            // one condition slot — so their co-occurrence fails closed.
-            let other_suffix =
-                enters_with_condition_suffix(is_escape, &kicker_condition, work_text);
-            match resolve_enters_with_condition(&unless_outcome, &leading_if_outcome, other_suffix)
-            {
-                None => return None,
-                Some(Some(cond)) => def = def.condition(cond),
-                Some(None) => {}
-            }
-
-            return Some(def);
+        // CR 614.1c: Attach the single applicable gate. The " unless " gate
+        // and the trailing conditional-suffix gate are mutually exclusive —
+        // one condition slot — so their co-occurrence fails closed.
+        let other_suffix = enters_with_condition_suffix(is_escape, &kicker_condition, work_text);
+        match resolve_enters_with_condition(&unless_outcome, &leading_if_outcome, other_suffix) {
+            None => return None,
+            Some(Some(cond)) => def = def.condition(cond),
+            Some(None) => {}
         }
+
+        return Some(def);
     }
 
     let counter_entries = parse_enters_counter_entries(after_additional);
@@ -4818,6 +4851,26 @@ fn strip_enters_with_choice_target(after_choice: &str) -> Option<(&str, &str)> {
     } else {
         None
     }
+}
+
+/// CR 614.12a: Grimdancer's reordered multi-pick surface. Given the text AFTER
+/// "enters with " (e.g. "your choice of two different counters on it from
+/// among menace, deathtouch, and lifelink."), return the bare counter list
+/// ("menace, deathtouch, and lifelink") when the recipient is the entering
+/// permanent itself. The list TRAILS the self-reference here — the mirror of
+/// `strip_enters_with_choice_target`'s "<list> on it" order.
+fn strip_enters_with_two_different_from_among(after_choice: &str) -> Option<&str> {
+    let (rest, _) = tag::<_, _, OracleError<'_>>("your choice of two different counters on ")
+        .parse(after_choice)
+        .ok()?;
+    // CR 614.12a: the recipient must be the entering permanent itself.
+    let (rest, _) = alt((tag::<_, _, OracleError<'_>>("it"), tag("~")))
+        .parse(rest)
+        .ok()?;
+    let (list, _) = tag::<_, _, OracleError<'_>>(" from among ")
+        .parse(rest)
+        .ok()?;
+    Some(list.trim().trim_end_matches('.'))
 }
 
 fn build_enters_counter_ability(entries: Vec<(CounterType, QuantityExpr)>) -> AbilityDefinition {
@@ -16482,6 +16535,60 @@ mod tests {
                 CounterType::Keyword(KeywordKind::Lifelink),
             ],
         );
+    }
+
+    /// CR 614.12a + CR 608.2d: Grimdancer — "enters with your choice of two
+    /// different counters on it from among menace, deathtouch, and lifelink."
+    /// Choosing two distinct kinds is the same decision as choosing one
+    /// unordered pair, so the line lowers to a `ChooseOneOf` over the three
+    /// pairs, each branch chaining two self-targeted `PutCounter`s (both fold
+    /// pre-entry through the deferred-entry capture, like the single pick).
+    #[test]
+    fn enters_with_two_different_counters_from_among_builds_pair_choice() {
+        use crate::types::keywords::KeywordKind;
+
+        let def = parse_replacement_line(
+            "This creature enters with your choice of two different counters on it from among menace, deathtouch, and lifelink.",
+            "Grimdancer",
+        )
+        .unwrap();
+        let execute = def.execute.as_ref().unwrap();
+        let Effect::ChooseOneOf { chooser, branches } = &*execute.effect else {
+            panic!("expected ChooseOneOf, got {:?}", execute.effect);
+        };
+        assert_eq!(*chooser, PlayerFilter::Controller);
+        let expected = [
+            (KeywordKind::Menace, KeywordKind::Deathtouch),
+            (KeywordKind::Menace, KeywordKind::Lifelink),
+            (KeywordKind::Deathtouch, KeywordKind::Lifelink),
+        ];
+        assert_eq!(branches.len(), expected.len());
+        for (branch, (first, second)) in branches.iter().zip(expected) {
+            let Effect::PutCounter {
+                counter_type,
+                target,
+                ..
+            } = &*branch.effect
+            else {
+                panic!("expected PutCounter head, got {:?}", branch.effect);
+            };
+            assert_eq!(counter_type, &CounterType::Keyword(first));
+            assert_eq!(target, &TargetFilter::SelfRef);
+            let sub = branch
+                .sub_ability
+                .as_deref()
+                .expect("pair branch must chain its second counter");
+            let Effect::PutCounter {
+                counter_type,
+                target,
+                ..
+            } = &*sub.effect
+            else {
+                panic!("expected PutCounter sub, got {:?}", sub.effect);
+            };
+            assert_eq!(counter_type, &CounterType::Keyword(second));
+            assert_eq!(target, &TargetFilter::SelfRef);
+        }
     }
 
     #[test]

--- a/crates/engine/tests/integration/grimdancer_two_counter_entry_choice.rs
+++ b/crates/engine/tests/integration/grimdancer_two_counter_entry_choice.rs
@@ -1,0 +1,126 @@
+//! Grimdancer's "enters with your choice of two different counters on it from
+//! among menace, deathtouch, and lifelink" (issue #7794) — the real cast →
+//! resolve → `ChooseOneOfBranch` → `ChooseBranch` pipeline. Choosing two
+//! distinct kinds is lowered as one unordered PAIR pick (three branches), and
+//! the chosen branch chains two self-targeted `PutCounter`s that both fold
+//! onto the entering permanent.
+//!
+//! REVERT DISCRIMINATOR: without the reordered-list reader the line parses as
+//! ONE generic counter literally named "your choice of two different" and no
+//! choice is ever offered — the `ChooseOneOfBranch` assertion fails first.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::{Keyword, KeywordKind};
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const GRIMDANCER: &str = "This creature enters with your choice of two different counters on it from among menace, deathtouch, and lifelink.";
+
+fn counter_count(runner: &GameRunner, object: ObjectId, kind: KeywordKind) -> u32 {
+    runner
+        .state()
+        .objects
+        .get(&object)
+        .and_then(|card| card.counters.get(&CounterType::Keyword(kind)).copied())
+        .unwrap_or(0)
+}
+
+fn has_keyword(runner: &GameRunner, object: ObjectId, keyword: &Keyword) -> bool {
+    runner
+        .state()
+        .objects
+        .get(&object)
+        .is_some_and(|card| card.has_keyword(keyword))
+}
+
+/// Cast Grimdancer, expect the three-pair choice, pick `index`, and settle.
+fn cast_and_choose(index: usize) -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let grimdancer = scenario
+        .add_creature_to_hand_from_oracle(P0, "Grimdancer", 4, 1, GRIMDANCER)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 0,
+            shards: vec![ManaCostShard::Black, ManaCostShard::Black],
+        })
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Black, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Black, ObjectId(0), false, vec![]),
+        ],
+    );
+
+    let mut runner = scenario.build();
+    runner.cast(grimdancer).resolve();
+
+    match &runner.state().waiting_for {
+        WaitingFor::ChooseOneOfBranch { branches, .. } => assert_eq!(
+            branches.len(),
+            3,
+            "two different from among three kinds must offer the three pairs"
+        ),
+        other => panic!("expected the pair choice on entry, got {other:?}"),
+    }
+    runner
+        .act(GameAction::ChooseBranch { index })
+        .expect("choosing a counter pair must succeed");
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&grimdancer)
+            .expect("Grimdancer object exists")
+            .zone,
+        Zone::Battlefield,
+        "Grimdancer must finish entering after the choice"
+    );
+    (runner, grimdancer)
+}
+
+#[test]
+fn the_first_pair_folds_menace_and_deathtouch_but_not_lifelink() {
+    let (runner, grimdancer) = cast_and_choose(0);
+
+    assert_eq!(counter_count(&runner, grimdancer, KeywordKind::Menace), 1);
+    assert_eq!(
+        counter_count(&runner, grimdancer, KeywordKind::Deathtouch),
+        1
+    );
+    assert_eq!(
+        counter_count(&runner, grimdancer, KeywordKind::Lifelink),
+        0,
+        "the unchosen kind must not be folded"
+    );
+    assert!(has_keyword(&runner, grimdancer, &Keyword::Menace));
+    assert!(has_keyword(&runner, grimdancer, &Keyword::Deathtouch));
+    assert!(
+        !has_keyword(&runner, grimdancer, &Keyword::Lifelink),
+        "no innate lifelink and no lifelink counter chosen"
+    );
+}
+
+#[test]
+fn the_last_pair_folds_deathtouch_and_lifelink_but_not_menace() {
+    let (runner, grimdancer) = cast_and_choose(2);
+
+    assert_eq!(
+        counter_count(&runner, grimdancer, KeywordKind::Deathtouch),
+        1
+    );
+    assert_eq!(counter_count(&runner, grimdancer, KeywordKind::Lifelink), 1);
+    assert_eq!(counter_count(&runner, grimdancer, KeywordKind::Menace), 0);
+    assert!(has_keyword(&runner, grimdancer, &Keyword::Lifelink));
+    assert!(
+        !has_keyword(&runner, grimdancer, &Keyword::Menace),
+        "the unchosen kind must not grant its keyword"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -293,6 +293,7 @@ mod graveyard_to_hand_activation_zone;
 mod greater_good_activation;
 mod green_suns_zenith_regression;
 mod griffin_rider_conditional_self_buff;
+mod grimdancer_two_counter_entry_choice;
 mod grubs_command_tracked_set_filter;
 mod hag_noxious_nightmares_menace_grant;
 mod halana_alena_partners_where_x;


### PR DESCRIPTION
Fixes #7794.

Grimdancer's "enters with your choice of two different counters on it **from among** menace, deathtouch, and lifelink" puts the list BEHIND the self-reference — the enters-with choice reader only knew "<list> on it". The words before "counters" were swallowed as a generic counter literally named `your choice of two different`, and no choice was ever offered.

**Fix:** choosing two distinct kinds is the same decision as choosing one unordered pair (CR 614.12a + CR 608.2d). A new reordered-form reader (`strip_enters_with_two_different_from_among`) feeds the existing from-among item authority (`parse_counter_choice_list_entries`) and lowers the line to a `ChooseOneOf` over the three pairs; each branch chains two self-targeted `PutCounter`s via the existing `build_enters_counter_ability`. `resolve_branch` runs the chosen branch's full chain before the deferred entry replays, so both counters fold pre-entry — `is_enters_counter_choice` already matches on the branch head.

**Class (double bake over all 35,798 cards, full-entry diff):** exactly Grimdancer changes. Corpus scan: it is the only card with this surface form.

**Runtime proof:** two new integration tests drive the real cast → `ChooseOneOfBranch` (3 branches) → `ChooseBranch` pipeline; the chosen pair's counters and keywords are present, the unchosen kind is absent (counter 0, no keyword).

**Counter-proof:** with the reader neutralized, the parser test fails with `got PutCounter { counter_type: "your choice of two different" }` and both integration tests fail at the `ChooseOneOfBranch` assertion.

**Remaining gap:** only the printed "two different" count is read — no card uses another count with this word order. The sibling "from among" gaps stay open: Aragorn/Elspeth's put-choice trigger path (#7795) and Crystalline Giant's random kind (#7796).

Suites: clippy, `--lib`, `--test integration` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for choosing two different counters from an “among” list when an entering permanent’s ability resolves.
  * Presents each unique counter pair as an available choice.
  * Applies the selected counters and related effects while preserving existing tapped-entry and conditional behavior.

* **Tests**
  * Added coverage verifying counter-pair choices and confirming selected and unselected counters behave correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->