### PR TITLE
fix(client): move pnpm overrides to their pnpm 10.6+ home and pin the toolchain

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -755,7 +755,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 11.13.0
+          version: 11.13.1
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -755,7 +755,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11.13.0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -735,7 +735,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11.13.0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -735,7 +735,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 11.13.0
+          version: 11.13.1
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11.13.0
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,7 +103,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 11.13.0
+          version: 11.13.1
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/shell-release.yml
+++ b/.github/workflows/shell-release.yml
@@ -177,7 +177,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 11.13.0
+          version: 11.13.1
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/shell-release.yml
+++ b/.github/workflows/shell-release.yml
@@ -177,7 +177,7 @@ jobs:
 
       - uses: pnpm/action-setup@v4
         with:
-          version: 9
+          version: 11.13.0
 
       - uses: actions/setup-node@v4
         with:

--- a/client/package.json
+++ b/client/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "0.62.0",
   "type": "module",
-  "packageManager": "pnpm@11.13.0",
+  "packageManager": "pnpm@11.13.1",
   "scripts": {
     "dev": "vite",
     "build": "pnpm run protocol:check && tsc -b && vite build",

--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.62.0",
   "type": "module",
+  "packageManager": "pnpm@11.13.0",
   "scripts": {
     "dev": "vite",
     "build": "pnpm run protocol:check && tsc -b && vite build",
@@ -40,24 +41,6 @@
     "three": "^0.184.0",
     "vite-plugin-wasm": "^3.4.1",
     "zustand": "^5.0.11"
-  },
-  "pnpm": {
-    "overrides": {
-      "serialize-javascript@<7.0.5": "7.0.5",
-      "ws@<8.21.0": "8.21.0",
-      "@babel/core": "7.29.7",
-      "brace-expansion@1": "1.1.16",
-      "brace-expansion@2": "2.1.2",
-      "brace-expansion@>=3 <5.0.7": "5.0.7",
-      "fast-uri": "3.1.4",
-      "js-yaml": "4.3.0",
-      "picomatch": ">=4.0.4",
-      "lodash": ">=4.18.0",
-      "postcss": ">=8.5.10",
-      "sharp": "0.35.3",
-      "undici": "7.28.0",
-      "uuid": "11.1.1"
-    }
   },
   "devDependencies": {
     "@eslint/js": "^9.21.0",

--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -1,0 +1,34 @@
+# pnpm settings live here as of pnpm 10.6+. The "pnpm" field in package.json is
+# no longer read -- pnpm 11 ignores it outright, which silently drops every pin
+# below and makes "pnpm install --frozen-lockfile" fail against a lockfile that
+# still records them. See https://pnpm.io/settings.
+#
+# The pnpm version itself is pinned by "packageManager" in package.json; keep
+# the pnpm/action-setup versions in .github/workflows/ in sync with it.
+
+# Security pins -- transitive advisories resolved forward. Must stay in sync
+# with the "overrides:" block recorded in pnpm-lock.yaml; a mismatch fails
+# frozen installs.
+overrides:
+  serialize-javascript@<7.0.5: 7.0.5
+  ws@<8.21.0: 8.21.0
+  '@babel/core': 7.29.7
+  brace-expansion@1: 1.1.16
+  brace-expansion@2: 2.1.2
+  brace-expansion@>=3 <5.0.7: 5.0.7
+  fast-uri: 3.1.4
+  js-yaml: 4.3.0
+  picomatch: '>=4.0.4'
+  lodash: '>=4.18.0'
+  postcss: '>=8.5.10'
+  sharp: 0.35.3
+  undici: 7.28.0
+  uuid: 11.1.1
+
+# pnpm 9 ran every dependency's install scripts; pnpm 10+ blocks them unless
+# allowlisted. These two ship platform binaries that vite/vitest (esbuild) and
+# wrangler (workerd) need at build time, so allowing them preserves the previous
+# behaviour rather than silently shipping a broken toolchain.
+allowBuilds:
+  esbuild: true
+  workerd: true

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -101,8 +101,8 @@ fi
 pnpm_major="$(pnpm --version 2>/dev/null | cut -d. -f1)"
 if ! [ "${pnpm_major:-0}" -ge 10 ] 2>/dev/null; then
   echo "ERROR: pnpm >= 10 required (found ${pnpm_major:-unknown})" >&2
-  echo "  client/package.json pins pnpm@11.13.0; pnpm 10+ switches to it automatically." >&2
-  echo "  Upgrade: corepack enable && corepack use pnpm@11.13.0" >&2
+  echo "  client/package.json pins pnpm@11.13.1; pnpm 10+ switches to it automatically." >&2
+  echo "  Upgrade: corepack enable && corepack use pnpm@11.13.1" >&2
   echo "  Or see: https://pnpm.io/installation" >&2
   exit 1
 fi

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -91,6 +91,22 @@ if [ "${#missing[@]}" -ne 0 ]; then
   exit 1
 fi
 
+# --- Preflight: pnpm major version ---
+# pnpm settings (the security `overrides`) live in client/pnpm-workspace.yaml,
+# which only pnpm 10.6+ reads. pnpm 9 also ignores the `packageManager` pin in
+# client/package.json, so it can neither read the overrides nor hand off to the
+# pinned pnpm — it fails the frozen install with an opaque
+# ERR_PNPM_LOCKFILE_CONFIG_MISMATCH. pnpm 10+ self-switches to the pin, so gate
+# on the major and fail with an actionable message instead.
+pnpm_major="$(pnpm --version 2>/dev/null | cut -d. -f1)"
+if ! [ "${pnpm_major:-0}" -ge 10 ] 2>/dev/null; then
+  echo "ERROR: pnpm >= 10 required (found ${pnpm_major:-unknown})" >&2
+  echo "  client/package.json pins pnpm@11.13.0; pnpm 10+ switches to it automatically." >&2
+  echo "  Upgrade: corepack enable && corepack use pnpm@11.13.0" >&2
+  echo "  Or see: https://pnpm.io/installation" >&2
+  exit 1
+fi
+
 # --- Preflight: soft tool (tilt-dev/tilt, NOT other CLIs named "tilt") ---
 # Multiple unrelated binaries ship as `tilt` (e.g. Go template tools). The
 # tilt-dev/tilt binary is the only one whose help text references the


### PR DESCRIPTION
"pnpm install --frozen-lockfile" failed in any clean checkout with
ERR_PNPM_LOCKFILE_CONFIG_MISMATCH on "overrides". The lockfile was not
actually stale: its "overrides:" block matched client/package.json entry for
entry. The mismatch was a pnpm major-version split. pnpm 10.6+ no longer
reads the "pnpm" field in package.json (pnpm 11 warns and ignores it), so a
modern local pnpm saw zero overrides while the lockfile recorded fourteen. CI
pinned pnpm 9, which still reads the old location, so CI stayed green and hid
the split.

Regenerating the lockfile -- the obvious fix -- would have made this worse:
under pnpm 11 it strips all fourteen security pins from the lockfile,
silently un-resolving the advisories they forward-resolve, and then breaks CI
with the mirror-image mismatch.

Instead, move the settings to their documented new home and pin the pnpm
version so every consumer reads the same config:

- Add client/pnpm-workspace.yaml carrying the "overrides" block verbatim.
- Drop the now-ignored "pnpm.overrides" field from client/package.json so
  there is a single source of truth.
- Pin "packageManager": "pnpm@11.13.0" and bump the four client-installing
  workflows to match. The lobby-worker job keeps pnpm 9 -- it installs via
  "npm ci" and only uses pnpm as a script runner.
- Declare "allowBuilds" for esbuild and workerd. pnpm 9 ran every install
  script; pnpm 10+ blocks them unless allowlisted, and those two ship the
  platform binaries vite/vitest and wrangler need at build time.
- Gate scripts/setup.sh on pnpm >= 10 so a contributor on pnpm 9 gets an
  actionable message instead of the opaque lockfile mismatch.

client/pnpm-lock.yaml is deliberately unchanged -- it was correct all along.

Verified: frozen install succeeds twice from a wiped node_modules with no
lockfile drift; all fourteen overrides audited as satisfied against the
resolved tree with nothing downgraded (uuid is inert, not in the tree);
type-check clean; lint 0 errors; vitest 3131 passed across 320 files, exit 0.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated project tooling to use pnpm 11.13.1 consistently across development, build, deployment, and release workflows.
  * Added workspace configuration for dependency security settings and required build permissions.
  * Added setup validation to require pnpm 10 or later and provide upgrade guidance when an unsupported version is detected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->