### PR TITLE
fix(client): honor explicit split layout on mobile

### DIFF
--- a/client/src/components/chrome/GameMenu.tsx
+++ b/client/src/components/chrome/GameMenu.tsx
@@ -10,7 +10,7 @@ import { clearGame } from "../../stores/gameStore.ts";
 import { useDraftStore } from "../../stores/draftStore.ts";
 import { useCardDataMeta } from "../../hooks/useCardDataMeta.ts";
 import { useConcedeHandler } from "../../hooks/useConcedeHandler.ts";
-import type { MultiplayerBoardLayout } from "../../stores/preferencesStore.ts";
+import type { ResolvedMultiplayerBoardLayout } from "../../stores/preferencesStore.ts";
 
 /**
  * Who a rollback request is addressed to. A string union rather than a boolean
@@ -27,7 +27,8 @@ interface GameMenuProps {
   isOnlineMode: boolean;
   showAiHand: boolean;
   onToggleAiHand: () => void;
-  multiplayerBoardLayout?: MultiplayerBoardLayout;
+  /** The currently displayed layout, already resolved from the raw preference. */
+  multiplayerBoardLayout?: ResolvedMultiplayerBoardLayout;
   onToggleMultiplayerBoardLayout?: () => void;
   showMultiplayerSplitLayoutNudge?: boolean;
   onTryMultiplayerSplitLayout?: () => void;

--- a/client/src/components/settings/PreferencesModal.tsx
+++ b/client/src/components/settings/PreferencesModal.tsx
@@ -76,7 +76,7 @@ const CARD_PREVIEW_MODES: CardPreviewMode[] = ["follow", "side", "shift"];
 const SPELL_PAYMENT_MODES: SpellPaymentMode[] = ["auto", "autoExceptSacrificialMana", "manual"];
 const LOG_DEFAULTS: LogDefaultState[] = ["open", "closed"];
 const VFX_QUALITIES: VfxQuality[] = ["full", "reduced", "minimal"];
-const MULTIPLAYER_BOARD_LAYOUTS: MultiplayerBoardLayout[] = ["focused", "split"];
+const MULTIPLAYER_BOARD_LAYOUTS: MultiplayerBoardLayout[] = ["auto", "focused", "split"];
 
 /** Format a speed value as a user-facing label. The slider goes 0→max where
  *  max = instant (skip animations). `0` = slowest, `1` = normal. The endpoint

--- a/client/src/components/settings/__tests__/PreferencesModal.cardPreview.test.tsx
+++ b/client/src/components/settings/__tests__/PreferencesModal.cardPreview.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, within } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import { usePreferencesStore } from "../../../stores/preferencesStore";
@@ -27,5 +27,16 @@ describe("PreferencesModal card preview", () => {
     fireEvent.click(checkbox);
 
     expect(usePreferencesStore.getState().showCardPreviewFooter).toBe(false);
+  });
+
+  it("offers Auto as the viewport-adaptive multiplayer board layout", () => {
+    usePreferencesStore.setState({ multiplayerBoardLayout: "focused" });
+    render(<PreferencesModal onClose={vi.fn()} initialTab="visual" />);
+
+    const group = screen.getByText("Multiplayer Board Layout").parentElement;
+    expect(group).not.toBeNull();
+    fireEvent.click(within(group!).getByRole("button", { name: "Auto" }));
+
+    expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("auto");
   });
 });

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -70,6 +70,7 @@
     "showOpponentBoard": "Spielfeld des Gegners beim Hovern über das HUD anzeigen",
     "multiplayerBoardLayout": "Mehrspieler-Boardlayout",
     "multiplayerBoardLayoutOptions": {
+      "auto": "Automatisch",
       "focused": "Fokussierter Gegner",
       "split": "Geteilter Tisch"
     },

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -74,6 +74,7 @@
     "showOpponentBoard": "Show opponent's board on HUD hover",
     "multiplayerBoardLayout": "Multiplayer Board Layout",
     "multiplayerBoardLayoutOptions": {
+      "auto": "Auto",
       "focused": "Focused opponent",
       "split": "Split table"
     },

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -70,6 +70,7 @@
     "showOpponentBoard": "Mostrar el tablero del oponente al pasar el cursor sobre el HUD",
     "multiplayerBoardLayout": "Diseño de tablero multijugador",
     "multiplayerBoardLayoutOptions": {
+      "auto": "Automático",
       "focused": "Oponente enfocado",
       "split": "Mesa dividida"
     },

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -70,6 +70,7 @@
     "showOpponentBoard": "Afficher le plateau de l'adversaire au survol du HUD",
     "multiplayerBoardLayout": "Disposition du plateau multijoueur",
     "multiplayerBoardLayoutOptions": {
+      "auto": "Automatique",
       "focused": "Adversaire ciblé",
       "split": "Table divisée"
     },

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -70,6 +70,7 @@
     "showOpponentBoard": "Mostra il campo dell'avversario passando sull'HUD",
     "multiplayerBoardLayout": "Layout del campo multigiocatore",
     "multiplayerBoardLayoutOptions": {
+      "auto": "Automatico",
       "focused": "Avversario in focus",
       "split": "Tavolo diviso"
     },

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -70,6 +70,7 @@
     "showOpponentBoard": "Pokaż pole bitwy przeciwnika po najechaniu na HUD",
     "multiplayerBoardLayout": "Układ planszy wieloosobowej",
     "multiplayerBoardLayoutOptions": {
+      "auto": "Automatyczny",
       "focused": "Skupiony przeciwnik",
       "split": "Podzielony stół"
     },

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -70,6 +70,7 @@
     "showOpponentBoard": "Mostrar o tabuleiro do oponente ao passar o mouse sobre o HUD",
     "multiplayerBoardLayout": "Layout do campo multijogador",
     "multiplayerBoardLayoutOptions": {
+      "auto": "Automático",
       "focused": "Oponente em foco",
       "split": "Mesa dividida"
     },

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -1001,18 +1001,23 @@ function GamePageContent({
     seatCount,
     isMobile,
   );
-  const effectiveMultiplayerBoardLayout =
-    seatCount > 2 && canActForWaitingState && getBoardChoiceView(waitingFor, objects)?.intent === "untap"
-      ? "split"
-      : resolvedMultiplayerBoardLayout;
+  const untapForcedSplit =
+    seatCount > 2 &&
+    canActForWaitingState &&
+    getBoardChoiceView(waitingFor, objects)?.intent === "untap";
+  const effectiveMultiplayerBoardLayout = untapForcedSplit
+    ? "split"
+    : resolvedMultiplayerBoardLayout;
   const splitBoardActive = isSplitBoardActive(effectiveMultiplayerBoardLayout, seatCount);
   const renderFocusedOpponentTopRow = shouldRenderFocusedOpponentTopRow(
     effectiveMultiplayerBoardLayout,
     seatCount,
   );
   const handleToggleMultiplayerBoardLayout = useCallback(() => {
-    setMultiplayerBoardLayout(multiplayerBoardLayout === "split" ? "focused" : "split");
-  }, [multiplayerBoardLayout, setMultiplayerBoardLayout]);
+    setMultiplayerBoardLayout(
+      resolvedMultiplayerBoardLayout === "split" ? "focused" : "split",
+    );
+  }, [resolvedMultiplayerBoardLayout, setMultiplayerBoardLayout]);
   const handleTryMultiplayerSplitLayout = useCallback(() => {
     setMultiplayerBoardLayout("split");
   }, [setMultiplayerBoardLayout]);
@@ -1023,6 +1028,7 @@ function GamePageContent({
     seatCount > 2 &&
     !isMobile &&
     multiplayerBoardLayout === "focused" &&
+    !untapForcedSplit &&
     !multiplayerSplitLayoutNudgeDismissed;
   const gridTemplateRows = splitBoardActive ? splitGridTemplateRows : focusedGridTemplateRows;
   const handleKickPlayer = useCallback((pid: number) => {
@@ -1646,8 +1652,12 @@ function GamePageContent({
         isOnlineMode={isOnlineMode}
         showAiHand={showAiHand}
         onToggleAiHand={() => setShowAiHand((v) => !v)}
-        multiplayerBoardLayout={seatCount > 2 ? multiplayerBoardLayout : undefined}
-        onToggleMultiplayerBoardLayout={seatCount > 2 ? handleToggleMultiplayerBoardLayout : undefined}
+        multiplayerBoardLayout={
+          seatCount > 2 && !untapForcedSplit ? resolvedMultiplayerBoardLayout : undefined
+        }
+        onToggleMultiplayerBoardLayout={
+          seatCount > 2 && !untapForcedSplit ? handleToggleMultiplayerBoardLayout : undefined
+        }
         showMultiplayerSplitLayoutNudge={showMultiplayerSplitLayoutNudge}
         onTryMultiplayerSplitLayout={
           showMultiplayerSplitLayoutNudge ? handleTryMultiplayerSplitLayout : undefined

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -484,6 +484,8 @@ describe("GamePage — multiplayer board layout during board choices", () => {
     renderGamePage();
 
     expect(screen.getByTestId("game-board-layout")).toHaveAttribute("data-layout", "split");
+    expect(capturedGameMenuProps?.multiplayerBoardLayout).toBeUndefined();
+    expect(capturedGameMenuProps?.showMultiplayerSplitLayoutNudge).toBe(false);
   });
 
   it("retains the persisted focused layout for a non-untap waiting state", () => {
@@ -506,7 +508,7 @@ describe("GamePage — multiplayer board layout during board choices", () => {
     expect(screen.getByTestId("game-board-layout")).toHaveAttribute("data-layout", "focused");
   });
 
-  it("resolves a raw split preference to focused on mobile outside an untap choice", () => {
+  it("honors an explicit split preference on mobile outside an untap choice", () => {
     mockIsMobile.mockReturnValue(true);
     usePreferencesStore.setState({ multiplayerBoardLayout: "split" });
     const permanent = gameObjectFactory
@@ -525,8 +527,44 @@ describe("GamePage — multiplayer board layout during board choices", () => {
 
     renderGamePage();
 
-    expect(screen.getByTestId("game-board-layout")).toHaveAttribute("data-layout", "focused");
+    expect(screen.getByTestId("game-board-layout")).toHaveAttribute("data-layout", "split");
   });
+
+  it.each([
+    ["mobile", true, "focused"],
+    ["desktop", false, "split"],
+  ] as const)("resolves the auto layout for a %s viewport", (_viewport, isMobile, layout) => {
+    mockIsMobile.mockReturnValue(isMobile);
+    usePreferencesStore.setState({ multiplayerBoardLayout: "auto" });
+    const gameState = gameStateFactory.withPlayers(0, 1, 2).priority(0).build();
+    storeOverrides.gameState = gameState;
+    storeOverrides.waitingFor = gameState.waiting_for;
+
+    renderGamePage();
+
+    expect(screen.getByTestId("game-board-layout")).toHaveAttribute("data-layout", layout);
+    expect(capturedGameMenuProps?.multiplayerBoardLayout).toBe(layout);
+  });
+
+  it.each([
+    ["mobile", true, "focused", "split"],
+    ["desktop", false, "split", "focused"],
+  ] as const)(
+    "writes the opposite explicit choice when toggling auto on %s",
+    (_viewport, isMobile, displayedLayout, expectedPreference) => {
+      mockIsMobile.mockReturnValue(isMobile);
+      usePreferencesStore.setState({ multiplayerBoardLayout: "auto" });
+      const gameState = gameStateFactory.withPlayers(0, 1, 2).priority(0).build();
+      storeOverrides.gameState = gameState;
+      storeOverrides.waitingFor = gameState.waiting_for;
+
+      renderGamePage();
+
+      expect(capturedGameMenuProps?.multiplayerBoardLayout).toBe(displayedLayout);
+      act(() => (capturedGameMenuProps?.onToggleMultiplayerBoardLayout as () => void)());
+      expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe(expectedPreference);
+    },
+  );
 
   it("offers the wide focused-layout nudge without writing preferences on render", () => {
     const permanent = gameObjectFactory

--- a/client/src/pages/__tests__/ReplayPage.test.tsx
+++ b/client/src/pages/__tests__/ReplayPage.test.tsx
@@ -1,0 +1,74 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter } from "react-router";
+
+import { ReplayPage } from "../ReplayPage";
+import { usePreferencesStore } from "../../stores/preferencesStore";
+import { gameStateFactory } from "../../test/factories/gameStateFactory";
+
+const { mockIsMobile, replayState, gameState } = vi.hoisted(() => ({
+  mockIsMobile: vi.fn(() => false),
+  replayState: {
+    adapter: {} as object | null,
+    isLoading: false,
+    error: null as string | null,
+    loadReplay: vi.fn(),
+    unload: vi.fn(),
+  },
+  gameState: { current: null as unknown },
+}));
+
+vi.mock("../../audio/useAudioContext", () => ({
+  useAudioContext: () => undefined,
+}));
+
+vi.mock("../../hooks/useIsMobile", () => ({
+  useIsMobile: () => mockIsMobile(),
+}));
+
+vi.mock("../../stores/replayStore", () => ({
+  useReplayStore: (selector: (state: typeof replayState) => unknown) => selector(replayState),
+}));
+
+vi.mock("../../stores/gameStore", () => ({
+  useGameStore: (selector: (state: { gameState: unknown }) => unknown) =>
+    selector({ gameState: gameState.current }),
+}));
+
+vi.mock("../../components/board/GameBoard", () => ({
+  GameBoard: ({ effectiveMultiplayerBoardLayout }: { effectiveMultiplayerBoardLayout: string }) => (
+    <div data-layout={effectiveMultiplayerBoardLayout} data-testid="replay-board-layout" />
+  ),
+}));
+
+vi.mock("../../components/replay/ReplayControls", () => ({
+  ReplayControls: () => null,
+}));
+
+describe("ReplayPage multiplayer layout", () => {
+  beforeEach(() => {
+    mockIsMobile.mockReturnValue(false);
+    gameState.current = gameStateFactory.withPlayers(0, 1, 2).priority(0).build();
+    usePreferencesStore.setState({ multiplayerBoardLayout: "auto" });
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.clearAllMocks();
+  });
+
+  it.each([
+    ["mobile", true, "focused"],
+    ["desktop", false, "split"],
+  ] as const)("resolves auto for a %s replay viewport", (_viewport, isMobile, layout) => {
+    mockIsMobile.mockReturnValue(isMobile);
+
+    render(
+      <MemoryRouter>
+        <ReplayPage />
+      </MemoryRouter>,
+    );
+
+    expect(screen.getByTestId("replay-board-layout")).toHaveAttribute("data-layout", layout);
+  });
+});

--- a/client/src/stores/__tests__/preferencesStore.test.ts
+++ b/client/src/stores/__tests__/preferencesStore.test.ts
@@ -24,7 +24,7 @@ describe("preferencesStore", () => {
         sfxMuted: false,
         musicMuted: false,
         masterMuted: false,
-        multiplayerBoardLayout: "split",
+        multiplayerBoardLayout: "auto",
         multiplayerSplitLayoutNudgeDismissed: true,
         aiSeats: [{ difficulty: "Medium", deckId: "Random" }],
         aiBracketFilter: [],
@@ -44,7 +44,7 @@ describe("preferencesStore", () => {
     // Read the store's real initialization snapshot (the getInitialState idiom
     // used below): the shared beforeEach writes its own defaults snapshot, so a
     // getState() read here would assert that snapshot, not buildDefaultPreferences().
-    expect(usePreferencesStore.getInitialState().multiplayerBoardLayout).toBe("split");
+    expect(usePreferencesStore.getInitialState().multiplayerBoardLayout).toBe("auto");
     expect(usePreferencesStore.getInitialState().multiplayerSplitLayoutNudgeDismissed).toBe(true);
     expect(state.aiSeats).toEqual([{ difficulty: "Medium", deckId: "Random" }]);
     expect(state.priorityPassingMode).toBe("Standard");
@@ -101,13 +101,11 @@ describe("preferencesStore", () => {
   });
 
   it("setMultiplayerBoardLayout updates multiplayer board layout", () => {
-    // Set the NON-default value: "split" is the default, so asserting it here
-    // would pass with the setter deleted.
     act(() => {
-      usePreferencesStore.getState().setMultiplayerBoardLayout("focused");
+      usePreferencesStore.getState().setMultiplayerBoardLayout("split");
     });
 
-    expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("focused");
+    expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("split");
   });
 
   it("updates the multiplayer split-layout nudge dismissal independently", () => {
@@ -116,7 +114,7 @@ describe("preferencesStore", () => {
     });
 
     expect(usePreferencesStore.getState().multiplayerSplitLayoutNudgeDismissed).toBe(false);
-    expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("split");
+    expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("auto");
   });
 
   it("setFollowActiveOpponent updates the value", () => {
@@ -278,6 +276,7 @@ describe("preferencesStore", () => {
       usePreferencesStore.getState().setCardSize("small");
       usePreferencesStore.getState().setFollowActiveOpponent(true);
       usePreferencesStore.getState().setAiSeatDifficulty(0, "VeryHard");
+      usePreferencesStore.getState().setMultiplayerBoardLayout("auto");
     });
 
     // Zustand persist writes to localStorage
@@ -288,6 +287,7 @@ describe("preferencesStore", () => {
     expect(parsed.state.cardSize).toBe("small");
     expect(parsed.state.followActiveOpponent).toBe(true);
     expect(parsed.state.aiSeats[0].difficulty).toBe("VeryHard");
+    expect(parsed.state.multiplayerBoardLayout).toBe("auto");
   });
 
   it("migrates v1 enum animationSpeed='instant' to multiplier 0", () => {
@@ -623,6 +623,35 @@ describe("preferencesStore", () => {
 
     expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("focused");
   });
+
+  it("uses auto when a v30 persisted profile has no layout preference", () => {
+    localStorage.setItem(
+      "phase-preferences",
+      JSON.stringify({ state: { cardSize: "large" }, version: 30 }),
+    );
+
+    act(() => {
+      usePreferencesStore.persist.rehydrate();
+    });
+
+    expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe("auto");
+  });
+
+  it.each(["focused", "split"] as const)(
+    "preserves the explicit v30 %s layout",
+    (multiplayerBoardLayout) => {
+      localStorage.setItem(
+        "phase-preferences",
+        JSON.stringify({ state: { multiplayerBoardLayout }, version: 30 }),
+      );
+
+      act(() => {
+        usePreferencesStore.persist.rehydrate();
+      });
+
+      expect(usePreferencesStore.getState().multiplayerBoardLayout).toBe(multiplayerBoardLayout);
+    },
+  );
 
   it.each([
     ["focused", false],

--- a/client/src/stores/preferencesStore.ts
+++ b/client/src/stores/preferencesStore.ts
@@ -99,7 +99,11 @@ export type StackDockSide = "left" | "right";
  *  a single thin row (small avatar + name + life) that trades the breakdown for
  *  vertical real-estate. Player-toggleable from the rail. */
 export type OpponentHudDensity = "comfortable" | "compact";
-export type MultiplayerBoardLayout = "focused" | "split";
+/** The persisted board-layout preference. `auto` adapts at the view-model
+ * boundary; the explicit values always honor the player's selection. */
+export type MultiplayerBoardLayout = "auto" | "focused" | "split";
+/** A layout after viewport/table-size resolution, suitable for board chrome. */
+export type ResolvedMultiplayerBoardLayout = Exclude<MultiplayerBoardLayout, "auto">;
 /** "auto-wubrg" picks a random battlefield matching the dominant mana color.
  *  "random" picks a random battlefield each game regardless of color.
  *  "none" disables the background image.
@@ -302,7 +306,7 @@ function buildDefaultPreferences(): PreferencesState {
     showCardPreviewFooter: true,
     stackDockSide: "right",
     opponentHudDensity: "comfortable",
-    multiplayerBoardLayout: "split",
+    multiplayerBoardLayout: "auto",
     multiplayerSplitLayoutNudgeDismissed: true,
     aiSeats: [defaultAiSeat()],
     cedhMode: false,
@@ -833,7 +837,7 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       //          merge, so existing users see no behavior change.
       // v20 → v21: Add multiplayerBoardLayout; legacy stores are pinned to
       //          "focused", preserving the layout they were already playing on.
-      //          Load-bearing now that the fresh-store default is "split": this
+      //          Load-bearing now that the fresh-store default is "auto": this
       //          block is what keeps the new default a NEW-user default rather
       //          than a layout swap under existing players.
       // v21 → v22: Add telemetryEnabled; legacy stores default to `true` (opt-out,
@@ -1004,7 +1008,7 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
           };
         }
 
-        // Pin, not merge: the fresh-store default is "split", so letting a
+        // Pin, not merge: the fresh-store default is "auto", so letting a
         // pre-v21 store fall through to the shallow merge would move existing
         // players off the layout they have been using.
         if (version < 21) {

--- a/client/src/viewmodel/__tests__/gameStateView.test.ts
+++ b/client/src/viewmodel/__tests__/gameStateView.test.ts
@@ -154,11 +154,12 @@ describe("getVisibleBoardPlayerIds", () => {
 });
 
 describe("split board ownership helpers", () => {
-  it("resolves split only at desktop multiplayer widths", () => {
-    expect(resolveMultiplayerBoardLayout("split", 3, true)).toBe("focused");
-    expect(resolveMultiplayerBoardLayout("split", 3, false)).toBe("split");
+  it("resolves auto by viewport while honoring explicit multiplayer choices", () => {
+    expect(resolveMultiplayerBoardLayout("auto", 3, true)).toBe("focused");
+    expect(resolveMultiplayerBoardLayout("auto", 3, false)).toBe("split");
+    expect(resolveMultiplayerBoardLayout("split", 3, true)).toBe("split");
+    expect(resolveMultiplayerBoardLayout("focused", 3, false)).toBe("focused");
     expect(resolveMultiplayerBoardLayout("split", 2, false)).toBe("focused");
-    expect(resolveMultiplayerBoardLayout("focused", 4, false)).toBe("focused");
   });
 
   it("activates split layout only for 3+ player games", () => {

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -8,7 +8,10 @@ import type {
   TargetRef,
   WaitingFor,
 } from "../adapter/types";
-import type { MultiplayerBoardLayout } from "../stores/preferencesStore";
+import type {
+  MultiplayerBoardLayout,
+  ResolvedMultiplayerBoardLayout,
+} from "../stores/preferencesStore";
 import {
   groupByName,
   partitionByType,
@@ -63,15 +66,18 @@ export function isOneOnOne(gameState: GameState | null): boolean {
 
 /**
  * Resolves the display layout without mutating the persisted raw preference.
- * Split view needs at least three seats and a desktop-width viewport; a
- * focused preference is always honored.
+ * Two-player games always use the focused presentation. For multiplayer,
+ * `auto` selects focused on mobile and split elsewhere; explicit choices are
+ * honored on either viewport.
  */
 export function resolveMultiplayerBoardLayout(
   layout: MultiplayerBoardLayout,
   seatCount: number,
   isMobile: boolean,
-): MultiplayerBoardLayout {
-  return layout === "split" && seatCount > 2 && !isMobile ? "split" : "focused";
+): ResolvedMultiplayerBoardLayout {
+  if (seatCount <= 2) return "focused";
+  if (layout === "auto") return isMobile ? "focused" : "split";
+  return layout;
 }
 
 export function isSplitBoardActive(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added an **Auto** multiplayer board layout option.
  - Automatically selects focused layout on mobile and split layout on desktop.
  - New preferences default to Auto, with existing selections preserved during migration.

- **Bug Fixes**
  - Multiplayer boards now enforce split layout during certain three-player-or-more choices.
  - Layout controls are hidden while that enforced layout is active.
  - Added localized Auto labels across supported languages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->