### PR TITLE
feat(engine): add GameFormat::Custom schema (custom-format-engine phase 1a)

### DIFF
--- a/crates/engine/src/game/companion.rs
+++ b/crates/engine/src/game/companion.rs
@@ -187,10 +187,10 @@ fn has_repeated_mana_symbols(face: &CardFace) -> bool {
 pub fn companion_starting_deck(
     main_deck: &[DeckEntry],
     commanders: &[DeckEntry],
-    format: GameFormat,
+    uses_commander: bool,
 ) -> Vec<DeckEntry> {
     let mut starting = main_deck.to_vec();
-    if format.uses_commander() {
+    if uses_commander {
         starting.extend_from_slice(commanders);
     }
     starting
@@ -200,9 +200,9 @@ fn commander_allows_companion(
     companion: &DeckEntry,
     starting_deck: &[DeckEntry],
     commanders: &[DeckEntry],
-    format: GameFormat,
+    uses_commander: bool,
 ) -> bool {
-    if !format.uses_commander() {
+    if !uses_commander {
         return true;
     }
 
@@ -232,7 +232,7 @@ pub fn is_eligible_companion(
     companion: &DeckEntry,
     starting_deck: &[DeckEntry],
     commanders: &[DeckEntry],
-    format: GameFormat,
+    uses_commander: bool,
 ) -> bool {
     // allow-raw-authority: DeckEntry carries a printed CardFace snapshot; deck validation has no GameState or live object to query.
     let Some(condition) = companion.card.keywords.iter().find_map(|keyword| {
@@ -246,12 +246,23 @@ pub fn is_eligible_companion(
     };
 
     validate_companion_condition(condition, starting_deck)
-        && commander_allows_companion(companion, starting_deck, commanders, format)
+        && commander_allows_companion(companion, starting_deck, commanders, uses_commander)
 }
 
-fn companion_offers(pool: &PlayerDeckPool, format: GameFormat) -> Vec<CompanionRevealChoice> {
-    let starting = companion_starting_deck(&pool.current_main, &pool.current_commander, format);
-    let candidates: Vec<(CompanionChoiceSource, &DeckEntry)> = if format.uses_commander() {
+/// `format` is still needed here (only for `sideboard_policy()`, which has a
+/// disclosed non-panicking fallback for every `GameFormat` including
+/// `Custom`); `uses_commander` is passed separately because
+/// `GameFormat::uses_commander()` panics for `Custom` and the resolved
+/// `FormatConfig.uses_commander` field is the caller's only safe source of
+/// truth for it.
+fn companion_offers(
+    pool: &PlayerDeckPool,
+    format: GameFormat,
+    uses_commander: bool,
+) -> Vec<CompanionRevealChoice> {
+    let starting =
+        companion_starting_deck(&pool.current_main, &pool.current_commander, uses_commander);
+    let candidates: Vec<(CompanionChoiceSource, &DeckEntry)> = if uses_commander {
         pool.current_companion
             .first()
             .map(|entry| (CompanionChoiceSource::Dedicated, entry))
@@ -270,12 +281,12 @@ fn companion_offers(pool: &PlayerDeckPool, format: GameFormat) -> Vec<CompanionR
     candidates
         .into_iter()
         .filter_map(|(source, entry)| {
-            is_eligible_companion(entry, &starting, &pool.current_commander, format).then(|| {
-                CompanionRevealChoice {
+            is_eligible_companion(entry, &starting, &pool.current_commander, uses_commander).then(
+                || CompanionRevealChoice {
                     name: entry.card.name.clone(),
                     source,
-                }
-            })
+                },
+            )
         })
         .collect()
 }
@@ -285,7 +296,11 @@ fn companion_offers(pool: &PlayerDeckPool, format: GameFormat) -> Vec<CompanionR
 /// Returns CompanionReveal WaitingFor if eligible companions exist, otherwise None.
 pub fn check_companion_reveal(state: &GameState, player: PlayerId) -> Option<WaitingFor> {
     let pool = state.deck_pools.iter().find(|p| p.player == player)?;
-    let mut eligible = companion_offers(pool, state.format_config.format);
+    let mut eligible = companion_offers(
+        pool,
+        state.format_config.format,
+        state.format_config.uses_commander,
+    );
     if state.format_config.format == GameFormat::TinyLeaders {
         eligible
             .retain(|choice| !super::deck_validation::tiny_leaders_companion_banned(&choice.name));
@@ -352,7 +367,7 @@ pub fn handle_declare_companion(
         let starting = companion_starting_deck(
             &pool.current_main,
             &pool.current_commander,
-            state.format_config.format,
+            state.format_config.uses_commander,
         );
         let selected = match choice.source {
             CompanionChoiceSource::Sideboard { index } => {
@@ -366,7 +381,7 @@ pub fn handle_declare_companion(
                     &entry,
                     &starting,
                     &pool.current_commander,
-                    state.format_config.format,
+                    state.format_config.uses_commander,
                 ) {
                     return Err("Companion is no longer eligible".to_string());
                 }
@@ -385,12 +400,12 @@ pub fn handle_declare_companion(
                     .filter(|entry| entry.card.name == choice.name)
                     .cloned()
                     .ok_or_else(|| "Dedicated companion offer is stale".to_string())?;
-                if !state.format_config.format.uses_commander()
+                if !state.format_config.uses_commander
                     || !is_eligible_companion(
                         &entry,
                         &starting,
                         &pool.current_commander,
-                        state.format_config.format,
+                        state.format_config.uses_commander,
                     )
                 {
                     return Err("Companion is no longer eligible".to_string());
@@ -944,11 +959,7 @@ mod tests {
         let main = vec![creature("Main Card", 2, vec![])];
         let commanders = vec![creature("Commander", 3, vec![])];
 
-        let commander_starting = companion_starting_deck(
-            &main,
-            &commanders,
-            crate::types::format::GameFormat::Commander,
-        );
+        let commander_starting = companion_starting_deck(&main, &commanders, true);
         assert_eq!(
             commander_starting
                 .iter()
@@ -957,11 +968,7 @@ mod tests {
             vec!["Main Card", "Commander"]
         );
 
-        let standard_starting = companion_starting_deck(
-            &main,
-            &commanders,
-            crate::types::format::GameFormat::Standard,
-        );
+        let standard_starting = companion_starting_deck(&main, &commanders, false);
         assert_eq!(
             standard_starting
                 .iter()

--- a/crates/engine/src/game/companion.rs
+++ b/crates/engine/src/game/companion.rs
@@ -249,15 +249,16 @@ pub fn is_eligible_companion(
         && commander_allows_companion(companion, starting_deck, commanders, uses_commander)
 }
 
-/// `format` is still needed here (only for `sideboard_policy()`, which has a
-/// disclosed non-panicking fallback for every `GameFormat` including
-/// `Custom`); `uses_commander` is passed separately because
-/// `GameFormat::uses_commander()` panics for `Custom` and the resolved
-/// `FormatConfig.uses_commander` field is the caller's only safe source of
-/// truth for it.
+/// Both facts are passed as already-resolved values rather than a bare
+/// `GameFormat`: `GameFormat::uses_commander()` panics for `Custom`, and
+/// `GameFormat::sideboard_policy()`'s disclosed `Custom` fallback
+/// (`Forbidden`) would silently discard a Custom format's real declared
+/// policy sitting in `custom_rules.structural.sideboard_policy` — the
+/// resolved `FormatConfig.uses_commander`/`.sideboard_policy` fields are the
+/// caller's only safe source of truth for either.
 fn companion_offers(
     pool: &PlayerDeckPool,
-    format: GameFormat,
+    sideboard_policy: SideboardPolicy,
     uses_commander: bool,
 ) -> Vec<CompanionRevealChoice> {
     let starting =
@@ -268,7 +269,7 @@ fn companion_offers(
             .map(|entry| (CompanionChoiceSource::Dedicated, entry))
             .into_iter()
             .collect()
-    } else if !matches!(format.sideboard_policy(), SideboardPolicy::Forbidden) {
+    } else if !matches!(sideboard_policy, SideboardPolicy::Forbidden) {
         pool.current_sideboard
             .iter()
             .enumerate()
@@ -298,7 +299,7 @@ pub fn check_companion_reveal(state: &GameState, player: PlayerId) -> Option<Wai
     let pool = state.deck_pools.iter().find(|p| p.player == player)?;
     let mut eligible = companion_offers(
         pool,
-        state.format_config.format,
+        state.format_config.sideboard_policy,
         state.format_config.uses_commander,
     );
     if state.format_config.format == GameFormat::TinyLeaders {

--- a/crates/engine/src/game/deck_loading.rs
+++ b/crates/engine/src/game/deck_loading.rs
@@ -678,7 +678,7 @@ pub fn load_deck_into_state(state: &mut GameState, payload: &DeckPayload) {
     // `deck_validation.rs`) accepts the entries; this is the rule-enforcement
     // boundary.
     let drop_sideboard = matches!(
-        state.format_config.format.sideboard_policy(),
+        state.format_config.sideboard_policy,
         crate::types::format::SideboardPolicy::Forbidden
     );
     let sideboard_for = |submitted: &[DeckEntry]| -> Vec<DeckEntry> {

--- a/crates/engine/src/game/deck_loading.rs
+++ b/crates/engine/src/game/deck_loading.rs
@@ -694,7 +694,7 @@ pub fn load_deck_into_state(state: &mut GameState, payload: &DeckPayload) {
     // game pool; construction validation remains responsible for rejecting an
     // oversized submitted list.
     let dedicated_companion_for = |submitted: &[DeckEntry]| -> Vec<DeckEntry> {
-        if !state.format_config.format.uses_commander() {
+        if !state.format_config.uses_commander {
             return Vec::new();
         }
         submitted

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -93,9 +93,16 @@ pub fn signature_spell_selection_policy(
 /// the main deck into the dedicated companion slot. Candidate evaluation uses
 /// the same typed predicate as pregame reveal validation.
 pub fn companion_candidates(db: &CardDatabase, request: &DeckCompatibilityRequest) -> Vec<String> {
+    // `GameFormat::uses_commander()` deliberately panics for `Custom` (a bare
+    // GameFormat cannot resolve it — see types::format). `selected_format`
+    // arrives from an untrusted request (this function is exposed directly
+    // via engine-wasm's `companion_candidates_js`), so Custom must be
+    // excluded before `uses_commander()` can run. No companion-candidate
+    // resolution exists for Custom formats yet, so treating it the same as
+    // any other non-commander format (empty result) is the honest answer.
     let Some(format) = request
         .selected_format
-        .filter(|format| format.uses_commander())
+        .filter(|format| !matches!(format, GameFormat::Custom(_)) && format.uses_commander())
     else {
         return Vec::new();
     };
@@ -1870,6 +1877,12 @@ fn quick_archenemy_check(
     }
 }
 
+/// Single authority for the Phase 1a "no `CustomFormatRules` resolver exists
+/// yet" rejection text, shared by the summary and full deck-compatibility
+/// paths so the two can never drift.
+const CUSTOM_FORMAT_UNSUPPORTED: &str =
+    "Custom format deck-compatibility checks are not yet supported.";
+
 fn evaluate_selected_format_summary(
     db: &CardDatabase,
     request: &DeckCompatibilityRequest,
@@ -1877,6 +1890,18 @@ fn evaluate_selected_format_summary(
     let Some(format) = request.selected_format else {
         return (None, Vec::new(), BTreeSet::new());
     };
+
+    // `GameFormat::uses_commander()` deliberately panics for `Custom` (a bare
+    // GameFormat cannot resolve it — see types::format), and the companion /
+    // signature-spell pre-guards below call it. `selected_format` arrives from
+    // an untrusted request, so Custom must be answered before those guards run.
+    if matches!(format, GameFormat::Custom(_)) {
+        return (
+            Some(false),
+            vec![CUSTOM_FORMAT_UNSUPPORTED.to_string()],
+            BTreeSet::new(),
+        );
+    }
 
     if !format.uses_commander() && !request.companion.is_empty() {
         return (
@@ -1918,7 +1943,7 @@ fn evaluate_selected_format_summary(
             db,
             request,
             format.legality_format().unwrap(),
-            format.label(),
+            &format.label(),
             format.sideboard_policy(),
         ),
         GameFormat::Commander => quick_commander_check(
@@ -1934,7 +1959,7 @@ fn evaluate_selected_format_summary(
             db,
             request,
             format.legality_format().unwrap(),
-            format.label(),
+            &format.label(),
             match format {
                 GameFormat::PauperCommander => CommanderVariantRules::pauper_commander(),
                 GameFormat::DuelCommander => CommanderVariantRules::duel_commander(),
@@ -1952,11 +1977,20 @@ fn evaluate_selected_format_summary(
             db,
             request,
             format.legality_format().unwrap(),
-            format.label(),
+            &format.label(),
             format,
         ),
         GameFormat::FreeForAll | GameFormat::TwoHeadedGiant | GameFormat::Limited => {
             QuickCheckResult::compatible()
+        }
+        // No CustomFormatRules resolver exists yet (Phase 1b/1d). Honest
+        // "not yet supported" rather than a false compatible() (which would
+        // let an unvalidated custom deck reach game-init) or an
+        // incompatible() framed as if the deck failed a real rules check.
+        // Reached only for exhaustiveness — the early guard above answers
+        // Custom before `uses_commander()` can panic on it.
+        GameFormat::Custom(_) => {
+            QuickCheckResult::incompatible(CUSTOM_FORMAT_UNSUPPORTED.to_string())
         }
     };
 
@@ -2270,6 +2304,12 @@ fn evaluate_selected_format(
         return (None, Vec::new());
     };
 
+    // See `evaluate_selected_format_summary`: Custom must be answered before
+    // the `uses_commander()`-calling pre-guards, which panic for Custom.
+    if matches!(format, GameFormat::Custom(_)) {
+        return (Some(false), vec![CUSTOM_FORMAT_UNSUPPORTED.to_string()]);
+    }
+
     if !format.uses_commander() && !request.companion.is_empty() {
         return (
             Some(false),
@@ -2316,7 +2356,7 @@ fn evaluate_selected_format(
                 request,
                 unknown_cards,
                 format.legality_format().unwrap(),
-                format.label(),
+                &format.label(),
                 format.sideboard_policy(),
             );
             if !check.compatible {
@@ -2334,7 +2374,7 @@ fn evaluate_selected_format(
                 request,
                 unknown_cards,
                 format.legality_format().unwrap(),
-                format.label(),
+                &format.label(),
                 match format {
                     GameFormat::PauperCommander => CommanderVariantRules::pauper_commander(),
                     GameFormat::DuelCommander => CommanderVariantRules::duel_commander(),
@@ -2353,7 +2393,7 @@ fn evaluate_selected_format(
                 request,
                 unknown_cards,
                 format.legality_format().unwrap(),
-                format.label(),
+                &format.label(),
                 format,
             );
             if !check.compatible {
@@ -2397,6 +2437,14 @@ fn evaluate_selected_format(
             check.compatible
         }
         GameFormat::FreeForAll | GameFormat::TwoHeadedGiant | GameFormat::Limited => true,
+        // See evaluate_selected_format_summary's Custom arm: no
+        // CustomFormatRules resolver exists yet. `false` is the honest,
+        // fail-closed "not yet supported" signal. Reached only for
+        // exhaustiveness — the early guard above answers Custom first.
+        GameFormat::Custom(_) => {
+            reasons.push(CUSTOM_FORMAT_UNSUPPORTED.to_string());
+            false
+        }
     };
 
     // CR 100.4 × MatchType::Bo3: BO3 requires a sideboard regardless of format.

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -100,12 +100,12 @@ pub fn companion_candidates(db: &CardDatabase, request: &DeckCompatibilityReques
     // excluded before `uses_commander()` can run. No companion-candidate
     // resolution exists for Custom formats yet, so treating it the same as
     // any other non-commander format (empty result) is the honest answer.
-    let Some(format) = request
+    let uses_commander = request
         .selected_format
-        .filter(|format| !matches!(format, GameFormat::Custom(_)) && format.uses_commander())
-    else {
+        .is_some_and(|format| !matches!(format, GameFormat::Custom(_)) && format.uses_commander());
+    if !uses_commander {
         return Vec::new();
-    };
+    }
 
     request
         .main_deck
@@ -118,8 +118,8 @@ pub fn companion_candidates(db: &CardDatabase, request: &DeckCompatibilityReques
             let companion = DeckEntry::from_resolved_face(db, face, 1);
             let main = deck_entries_for_names(db, &remaining_main);
             let commanders = deck_entries_for_names(db, &request.commander);
-            let starting = companion_starting_deck(&main, &commanders, format);
-            is_eligible_companion(&companion, &starting, &commanders, format)
+            let starting = companion_starting_deck(&main, &commanders, uses_commander);
+            is_eligible_companion(&companion, &starting, &commanders, uses_commander)
                 .then(|| face.name.clone())
         })
         .collect::<BTreeSet<_>>()
@@ -830,8 +830,13 @@ fn validate_commander_companion(
     let companion = DeckEntry::from_resolved_face(db, face, 1);
     let main = deck_entries_for_names(db, &request.main_deck);
     let commanders = deck_entries_for_names(db, &request.commander);
-    let starting = companion_starting_deck(&main, &commanders, format);
-    if !is_eligible_companion(&companion, &starting, &commanders, format) {
+    // `format` here is always a real Commander/Brawl-family built-in — this
+    // function is only ever dispatched from evaluate_commander_with_format,
+    // evaluate_brawl, and quick_commander_check, each already gated to a
+    // guaranteed non-Custom format — so calling .uses_commander() directly
+    // is safe.
+    let starting = companion_starting_deck(&main, &commanders, format.uses_commander());
+    if !is_eligible_companion(&companion, &starting, &commanders, format.uses_commander()) {
         reasons.push(format!(
             "{companion_name}: not a legal companion for this starting deck"
         ));

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -1079,7 +1079,11 @@ fn evaluate_brawl(
 
     // Exact total card count from the format config (main + commander,
     // accounting for commander listed in main).
-    let deck_size = usize::from(FormatConfig::for_format(game_format).deck_size);
+    let deck_size = usize::from(
+        FormatConfig::for_format(game_format)
+            .expect("evaluate_brawl is only dispatched for a Brawl-family GameFormat")
+            .deck_size,
+    );
     let represented_in_main = request
         .commander
         .iter()
@@ -2287,7 +2291,11 @@ fn quick_brawl_check(
                 "Brawl commander must be a legendary creature or legendary planeswalker",
             skip_commander_legality: false,
         },
-        usize::from(FormatConfig::for_format(game_format).deck_size),
+        usize::from(
+            FormatConfig::for_format(game_format)
+                .expect("quick_brawl_check is only dispatched for a Brawl-family GameFormat")
+                .deck_size,
+        ),
         game_format,
     )
 }

--- a/crates/engine/src/game/deck_validation.rs
+++ b/crates/engine/src/game/deck_validation.rs
@@ -93,16 +93,17 @@ pub fn signature_spell_selection_policy(
 /// the main deck into the dedicated companion slot. Candidate evaluation uses
 /// the same typed predicate as pregame reveal validation.
 pub fn companion_candidates(db: &CardDatabase, request: &DeckCompatibilityRequest) -> Vec<String> {
-    // `GameFormat::uses_commander()` deliberately panics for `Custom` (a bare
+    // `GameFormat::uses_commander()` returns `Err` for `Custom` (a bare
     // GameFormat cannot resolve it — see types::format). `selected_format`
     // arrives from an untrusted request (this function is exposed directly
-    // via engine-wasm's `companion_candidates_js`), so Custom must be
-    // excluded before `uses_commander()` can run. No companion-candidate
-    // resolution exists for Custom formats yet, so treating it the same as
-    // any other non-commander format (empty result) is the honest answer.
+    // via engine-wasm's `companion_candidates_js`). No companion-candidate
+    // resolution exists for Custom formats yet, so treating an `Err`/absent
+    // format the same as any other non-commander format (empty result) is
+    // the honest answer.
     let uses_commander = request
         .selected_format
-        .is_some_and(|format| !matches!(format, GameFormat::Custom(_)) && format.uses_commander());
+        .and_then(|format| format.uses_commander().ok())
+        .unwrap_or(false);
     if !uses_commander {
         return Vec::new();
     }
@@ -833,10 +834,13 @@ fn validate_commander_companion(
     // `format` here is always a real Commander/Brawl-family built-in — this
     // function is only ever dispatched from evaluate_commander_with_format,
     // evaluate_brawl, and quick_commander_check, each already gated to a
-    // guaranteed non-Custom format — so calling .uses_commander() directly
-    // is safe.
-    let starting = companion_starting_deck(&main, &commanders, format.uses_commander());
-    if !is_eligible_companion(&companion, &starting, &commanders, format.uses_commander()) {
+    // guaranteed non-Custom format — so `.uses_commander()` is guaranteed
+    // `Ok` here.
+    let uses_commander = format
+        .uses_commander()
+        .expect("validate_commander_companion is only dispatched for a built-in format");
+    let starting = companion_starting_deck(&main, &commanders, uses_commander);
+    if !is_eligible_companion(&companion, &starting, &commanders, uses_commander) {
         reasons.push(format!(
             "{companion_name}: not a legal companion for this starting deck"
         ));
@@ -1900,7 +1904,7 @@ fn evaluate_selected_format_summary(
         return (None, Vec::new(), BTreeSet::new());
     };
 
-    // `GameFormat::uses_commander()` deliberately panics for `Custom` (a bare
+    // `GameFormat::uses_commander()` returns `Err` for `Custom` (a bare
     // GameFormat cannot resolve it — see types::format), and the companion /
     // signature-spell pre-guards below call it. `selected_format` arrives from
     // an untrusted request, so Custom must be answered before those guards run.
@@ -1911,8 +1915,11 @@ fn evaluate_selected_format_summary(
             BTreeSet::new(),
         );
     }
+    let uses_commander = format
+        .uses_commander()
+        .expect("format is guaranteed non-Custom by the preceding check");
 
-    if !format.uses_commander() && !request.companion.is_empty() {
+    if !uses_commander && !request.companion.is_empty() {
         return (
             Some(false),
             vec![format!(
@@ -1997,7 +2004,7 @@ fn evaluate_selected_format_summary(
         // let an unvalidated custom deck reach game-init) or an
         // incompatible() framed as if the deck failed a real rules check.
         // Reached only for exhaustiveness — the early guard above answers
-        // Custom before `uses_commander()` can panic on it.
+        // Custom before `uses_commander()` would return `Err` for it.
         GameFormat::Custom(_) => {
             QuickCheckResult::incompatible(CUSTOM_FORMAT_UNSUPPORTED.to_string())
         }
@@ -2318,12 +2325,15 @@ fn evaluate_selected_format(
     };
 
     // See `evaluate_selected_format_summary`: Custom must be answered before
-    // the `uses_commander()`-calling pre-guards, which panic for Custom.
+    // the `uses_commander()`-calling pre-guards, which return `Err` for it.
     if matches!(format, GameFormat::Custom(_)) {
         return (Some(false), vec![CUSTOM_FORMAT_UNSUPPORTED.to_string()]);
     }
+    let uses_commander = format
+        .uses_commander()
+        .expect("format is guaranteed non-Custom by the preceding check");
 
-    if !format.uses_commander() && !request.companion.is_empty() {
+    if !uses_commander && !request.companion.is_empty() {
         return (
             Some(false),
             vec![format!(

--- a/crates/engine/src/game/match_flow.rs
+++ b/crates/engine/src/game/match_flow.rs
@@ -61,7 +61,7 @@ fn entries_to_count_map(entries: &[DeckEntry]) -> HashMap<String, u32> {
 /// `current_main`/`current_sideboard` and only the revealed companion copy is
 /// returned (CR 400.11a).
 fn restore_revealed_sideboard_companions(state: &mut GameState) {
-    if state.format_config.format.uses_commander() {
+    if state.format_config.uses_commander {
         return;
     }
 

--- a/crates/engine/src/game/match_flow.rs
+++ b/crates/engine/src/game/match_flow.rs
@@ -354,7 +354,7 @@ pub(crate) fn sideboard_submission_bounds(
     // CR 100.4a: the sideboard cap is per-format. `Forbidden` formats (the
     // Commander family) have no sideboard at all, which bounds it at zero and
     // therefore pins the whole pool in the main deck.
-    let max_sideboard_size = match state.format_config.format.sideboard_policy() {
+    let max_sideboard_size = match state.format_config.sideboard_policy {
         SideboardPolicy::Forbidden => Some(0),
         SideboardPolicy::Limited(max) => Some(max),
         SideboardPolicy::Unlimited => None,

--- a/crates/engine/src/types/custom_format.rs
+++ b/crates/engine/src/types/custom_format.rs
@@ -1,0 +1,305 @@
+//! Schema for engine-validated custom formats. Phase 1a: types +
+//! validation + registration gates only. No behavior is wired into the
+//! engine yet — `custom_format_registry()` is a stub returning
+//! `Vec::new()`, and `IMPLEMENTED_LEGACY_AXES` is empty. Later phases
+//! (2a/2b/2cd) populate the registry with real presets and wire
+//! `LegacyRuleSet`'s axes into engine behavior (mana pool cleanup, combat
+//! damage step, etc.).
+
+use serde::{Deserialize, Serialize};
+
+use crate::types::format::{GameFormat, RangeOfInfluenceConfig, SideboardPolicy};
+
+/// Lightweight, `Copy`, per-`GameState` transport tag for a custom format.
+/// The full ruleset never needs a registry round-trip within one game — see
+/// `FormatConfig.custom_rules`, which carries the resolved `CustomFormatRules`
+/// value directly.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct CustomFormatId(pub u16);
+
+/// An MTGJSON-style set code (e.g. "MH3", "LEA"). Distinct from a bare
+/// `String` so a card-pool restriction list can't be confused with any other
+/// string collection at the type level.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize)]
+#[serde(transparent)]
+pub struct SetCode(pub String);
+
+impl AsRef<str> for SetCode {
+    fn as_ref(&self) -> &str {
+        &self.0
+    }
+}
+
+/// A card's English name, as used in banned/restricted lists. A semantic
+/// alias, not a newtype: every existing card-name comparison in the engine
+/// already operates on plain `String`/`&str`, and wrapping this one field
+/// would force `.0`-unwrapping at every pre-existing call site for no
+/// behavioral gain.
+pub type CardName = String;
+
+/// Mana burn was removed from the rules in the Magic 2010 rules change and
+/// has no number in the current Comprehensive Rules (see the "Mana Burn
+/// (Obsolete)" glossary entry, `docs/MagicCompRules.txt`). This axis exists
+/// so a historically-accurate custom format (e.g. Old School 93/94) can opt
+/// back into it. Schema only in this phase — no enforcement exists until a
+/// later phase wires it into `types/mana.rs`'s cleanup-step unspent-mana
+/// handling.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum ManaBurnPolicy {
+    #[default]
+    Off,
+    Legacy,
+}
+
+/// CR 510 (Combat Damage Step): the modern rules deal all combat damage —
+/// first strike and regular — in one unified damage step per combat-damage
+/// sub-step. `Legacy` reproduces the older two-fully-sequenced-steps
+/// procedure some historical rule sets used. Schema only in this phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum CombatDamageTiming {
+    #[default]
+    Modern,
+    Legacy,
+}
+
+/// Scope for "Wish"-style effects that fetch a card from outside the game.
+/// No single Comprehensive Rules number governs this generically — each
+/// Wish-effect card's own Oracle text defines its behavior, against the
+/// general "outside the game" zone concept (CR 100.4, CR 108.3). Schema only
+/// in this phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum WishOutsideGameScope {
+    #[default]
+    SideboardOnly,
+    AnyCardOutsideGame,
+}
+
+/// CR 704.5j: the "legend rule" state-based action. `Global` reproduces a
+/// historical ruling some casual formats use, checking the rule across all
+/// players' legendary permanents of the same name combined rather than
+/// per-player. Schema only in this phase.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
+pub enum LegendRuleScope {
+    #[default]
+    PerPlayer,
+    Global,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LegacyRuleSet {
+    pub mana_burn: ManaBurnPolicy,
+    pub damage_timing: CombatDamageTiming,
+    pub wish_scope: WishOutsideGameScope,
+    pub legend_rule_scope: LegendRuleScope,
+}
+
+/// CR 903.3 (and the Tiny Leaders / Oathbreaker RC / Brawl deck-construction
+/// rules, each layered on top of their own commander-style base format):
+/// which commander-eligibility test a custom format modeled after a given
+/// built-in commander-style format should apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CommanderEligibilityRule {
+    Standard,
+    TinyLeaders,
+    OathbreakerSignatureSpell,
+    BrawlColorIdentity,
+}
+
+impl CommanderEligibilityRule {
+    /// Maps a BUILT-IN source `GameFormat` (the format a custom format is
+    /// being modeled after) to the eligibility rule it should reuse.
+    /// Exhaustive over every `GameFormat` variant. `Custom` panics: this
+    /// function's contract is that `format` names a built-in — a bare
+    /// `GameFormat::Custom(id)` has no "source format" of its own to read.
+    pub fn from_source_format(format: GameFormat) -> Option<Self> {
+        match format {
+            GameFormat::Commander | GameFormat::DuelCommander | GameFormat::PauperCommander => {
+                Some(Self::Standard)
+            }
+            GameFormat::TinyLeaders => Some(Self::TinyLeaders),
+            GameFormat::Oathbreaker => Some(Self::OathbreakerSignatureSpell),
+            GameFormat::Brawl | GameFormat::HistoricBrawl => Some(Self::BrawlColorIdentity),
+            GameFormat::Standard
+            | GameFormat::Limited
+            | GameFormat::Pioneer
+            | GameFormat::Modern
+            | GameFormat::Premodern
+            | GameFormat::Legacy
+            | GameFormat::Vintage
+            | GameFormat::Historic
+            | GameFormat::Timeless
+            | GameFormat::Pauper
+            | GameFormat::FreeForAll
+            | GameFormat::TwoHeadedGiant
+            | GameFormat::Archenemy
+            | GameFormat::Planechase
+            | GameFormat::Momir => None,
+            GameFormat::Custom(_) => {
+                unreachable!(
+                    "from_source_format: source must be a built-in GameFormat, never Custom"
+                )
+            }
+        }
+    }
+}
+
+/// The structural game-parameter snapshot a lobby's "save as custom format"
+/// action captures. Every field mirrors an existing `FormatConfig` field 1:1.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct StructuralRules {
+    pub starting_life: i32,
+    pub min_players: u8,
+    pub max_players: u8,
+    pub deck_size: u16,
+    pub singleton: bool,
+    pub command_zone: bool,
+    pub commander_damage_threshold: Option<u8>,
+    #[serde(default)]
+    pub range_of_influence: Option<Box<RangeOfInfluenceConfig>>,
+    pub team_based: bool,
+    /// The DECLARED sideboard policy for this custom format. Not yet mirrored
+    /// by a RESOLVED `FormatConfig.sideboard_policy` field — that's a later
+    /// phase's widening.
+    pub sideboard_policy: SideboardPolicy,
+    pub commander_eligibility_rule: Option<CommanderEligibilityRule>,
+}
+
+/// Legality/era rules. `legal_sets: None` means unrestricted (every card
+/// passes the pool check); `Some(list)` restricts to exactly that list. This
+/// `Option` (not a bare possibly-empty `Vec`) is required to distinguish "no
+/// restriction" from "restricted to nothing."
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct LegalityRules {
+    pub legal_sets: Option<Vec<SetCode>>,
+    pub banned: Vec<CardName>,
+    pub restricted: Vec<CardName>,
+    pub legacy: LegacyRuleSet,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CustomFormatRules {
+    pub id: CustomFormatId,
+    pub structural: StructuralRules,
+    pub legality: LegalityRules,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ReprintPolicy {
+    OriginalPrintingsOnly,
+    AllowSpecialReprintSets,
+    AllowAnyPrinting,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum PrintingFidelity {
+    NotApplicable,
+    SetCodeApproximation,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CustomFormatDef {
+    pub rules: CustomFormatRules,
+    pub label: String,
+    pub short_label: String,
+    pub description: String,
+    pub reprint_policy: Option<ReprintPolicy>,
+    pub printing_fidelity: PrintingFidelity,
+}
+
+/// A malformed-`FormatConfig` rejection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FormatConfigError(pub String);
+
+impl std::fmt::Display for FormatConfigError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for FormatConfigError {}
+
+/// Engine-consistency invariant: `format == GameFormat::Custom(id) ⟺
+/// custom_rules == Some(rules) && rules.id == id`. Phase 1a checks only this
+/// id-consistency (both directions); later phases widen this function as
+/// more derived `FormatConfig` fields are added.
+pub fn validate_custom_rules_consistency(
+    config: &crate::types::format::FormatConfig,
+) -> Result<(), FormatConfigError> {
+    match (config.format, &config.custom_rules) {
+        (GameFormat::Custom(id), Some(rules)) if rules.id == id => Ok(()),
+        (GameFormat::Custom(id), Some(rules)) => Err(FormatConfigError(format!(
+            "FormatConfig.format is Custom({}) but custom_rules.id is {:?}",
+            id.0, rules.id
+        ))),
+        (GameFormat::Custom(id), None) => Err(FormatConfigError(format!(
+            "FormatConfig.format is Custom({}) but custom_rules is None",
+            id.0
+        ))),
+        (_, None) => Ok(()),
+        (other, Some(_)) => Err(FormatConfigError(format!(
+            "FormatConfig.format is {other:?} (a built-in format) but custom_rules is Some(_) — \
+             built-in formats must not carry custom_rules"
+        ))),
+    }
+}
+
+/// One axis of `LegacyRuleSet` behavior. Engine-internal only — never
+/// serialized, never part of the wire format.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LegacyAxis {
+    ManaBurn,
+    CombatDamageTiming,
+    WishOutsideGameScope,
+    LegendRuleScope,
+}
+
+/// Axes of `LegacyRuleSet` the engine actually enforces at runtime. Empty in
+/// Phase 1a; later phases populate this as each axis's behavior is wired in.
+pub const IMPLEMENTED_LEGACY_AXES: &[LegacyAxis] = &[];
+
+fn declared_legacy_axes(rules: &LegacyRuleSet) -> Vec<LegacyAxis> {
+    let mut axes = Vec::new();
+    if rules.mana_burn != ManaBurnPolicy::default() {
+        axes.push(LegacyAxis::ManaBurn);
+    }
+    if rules.damage_timing != CombatDamageTiming::default() {
+        axes.push(LegacyAxis::CombatDamageTiming);
+    }
+    if rules.wish_scope != WishOutsideGameScope::default() {
+        axes.push(LegacyAxis::WishOutsideGameScope);
+    }
+    if rules.legend_rule_scope != LegendRuleScope::default() {
+        axes.push(LegacyAxis::LegendRuleScope);
+    }
+    axes
+}
+
+/// Registration gate (a): every axis a def declares as non-default must be
+/// in `IMPLEMENTED_LEGACY_AXES`, or the def is rejected.
+pub fn passes_legacy_axis_gate(def: &CustomFormatDef) -> bool {
+    declared_legacy_axes(&def.rules.legality.legacy)
+        .into_iter()
+        .all(|axis| IMPLEMENTED_LEGACY_AXES.contains(&axis))
+}
+
+/// Registration gate (b): `reprint_policy` presence must agree with
+/// `printing_fidelity`.
+pub fn passes_reprint_fidelity_gate(def: &CustomFormatDef) -> bool {
+    def.reprint_policy.is_some()
+        == matches!(
+            def.printing_fidelity,
+            PrintingFidelity::SetCodeApproximation
+        )
+}
+
+/// Authoritative list of bundled custom-format presets, filtered through
+/// both registration gates. Empty in Phase 1a — no presets exist until a
+/// later phase introduces them.
+pub fn custom_format_registry() -> Vec<CustomFormatDef> {
+    let presets: Vec<CustomFormatDef> = Vec::new();
+    presets
+        .into_iter()
+        .filter(|def| passes_legacy_axis_gate(def) && passes_reprint_fidelity_gate(def))
+        .collect()
+}

--- a/crates/engine/src/types/custom_format.rs
+++ b/crates/engine/src/types/custom_format.rs
@@ -42,48 +42,66 @@ pub type CardName = String;
 /// has no number in the current Comprehensive Rules (see the "Mana Burn
 /// (Obsolete)" glossary entry, `docs/MagicCompRules.txt`). This axis exists
 /// so a historically-accurate custom format (e.g. Old School 93/94) can opt
-/// back into it. Schema only in this phase — no enforcement exists until a
-/// later phase wires it into `types/mana.rs`'s cleanup-step unspent-mana
-/// handling.
+/// back into it. Variant names match `docs/proposals/custom-format-engine/
+/// PLAN.md`'s canonical schema exactly. Schema only in this phase — no
+/// enforcement exists until a later phase wires it into `types/mana.rs`'s
+/// cleanup-step unspent-mana handling.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum ManaBurnPolicy {
+    /// No mana burn (removed post-M10).
     #[default]
-    Off,
-    Legacy,
+    Modern,
+    /// Life loss for unspent mana at real phase-group boundaries. EC/Swedish
+    /// target era.
+    Obsolete,
 }
 
 /// CR 510 (Combat Damage Step): the modern rules deal all combat damage —
 /// first strike and regular — in one unified damage step per combat-damage
-/// sub-step. `Legacy` reproduces the older two-fully-sequenced-steps
-/// procedure some historical rule sets used. Schema only in this phase.
+/// sub-step, not using the stack (CR 510.2). `OnStack` reproduces the older
+/// pre-6th-edition procedure, where assigned combat damage was itself placed
+/// on the stack as a stack object rather than a triggered ability, giving
+/// players a priority window between assignment and dealing before it
+/// resolved. Variant names match `docs/proposals/custom-format-engine/
+/// PLAN.md`'s canonical schema exactly. Schema only in this phase.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum CombatDamageTiming {
     #[default]
     Modern,
-    Legacy,
+    OnStack,
 }
 
 /// Scope for "Wish"-style effects that fetch a card from outside the game.
 /// No single Comprehensive Rules number governs this generically — each
 /// Wish-effect card's own Oracle text defines its behavior, against the
-/// general "outside the game" zone concept (CR 100.4, CR 108.3). Schema only
-/// in this phase.
+/// general "outside the game" zone concept (CR 100.4, CR 108.3). Variant
+/// names match `docs/proposals/custom-format-engine/PLAN.md`'s canonical
+/// schema exactly. Schema only in this phase.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum WishOutsideGameScope {
+    /// Modern CR 400.11/400.11a: "outside the game" is not a zone; only the
+    /// sideboard is reachable.
     #[default]
-    SideboardOnly,
-    AnyCardOutsideGame,
+    PostM10SideboardOnly,
+    /// Pre-M10: a Wish could retrieve an owned card that had been removed
+    /// from the game (today's exile).
+    PreM10ReachesExile,
 }
 
-/// CR 704.5j: the "legend rule" state-based action. `Global` reproduces a
-/// historical ruling some casual formats use, checking the rule across all
-/// players' legendary permanents of the same name combined rather than
-/// per-player. Schema only in this phase.
+/// CR 704.5j: the "legend rule" state-based action. `PreM14AnyController`
+/// reproduces a historical ruling some casual formats use (the Legends
+/// 1994 / pre-M14 "both die" form): same-named legendary permanents go to
+/// their owners' graveyards across ALL controllers combined, choicelessly,
+/// rather than per-controller. Variant names match `docs/proposals/
+/// custom-format-engine/PLAN.md`'s canonical schema exactly. Schema only in
+/// this phase.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum LegendRuleScope {
+    /// Per-controller + choice (post-2013-07 M14). All four EC presets use
+    /// this.
     #[default]
-    PerPlayer,
-    Global,
+    Modern,
+    PreM14AnyController,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -144,6 +162,22 @@ impl CommanderEligibilityRule {
     }
 }
 
+/// Whether a custom format uses the command zone (CR 903) and, if so, its
+/// commander-damage threshold and eligibility predicate. A single
+/// discriminated type instead of three independently-settable fields, so a
+/// state like "command zone disabled, but a commander-damage threshold and
+/// eligibility rule are set" is unrepresentable — the engine would otherwise
+/// have no valid semantic reading for it, and neither registration gate
+/// could catch it (serde happily accepts it either way).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum CommandZoneMode {
+    Disabled,
+    Enabled {
+        commander_damage_threshold: Option<u8>,
+        eligibility_rule: CommanderEligibilityRule,
+    },
+}
+
 /// The structural game-parameter snapshot a lobby's "save as custom format"
 /// action captures. Every field mirrors an existing `FormatConfig` field 1:1.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
@@ -153,8 +187,7 @@ pub struct StructuralRules {
     pub max_players: u8,
     pub deck_size: u16,
     pub singleton: bool,
-    pub command_zone: bool,
-    pub commander_damage_threshold: Option<u8>,
+    pub command_zone_mode: CommandZoneMode,
     #[serde(default)]
     pub range_of_influence: Option<Box<RangeOfInfluenceConfig>>,
     pub team_based: bool,
@@ -162,7 +195,6 @@ pub struct StructuralRules {
     /// by a RESOLVED `FormatConfig.sideboard_policy` field — that's a later
     /// phase's widening.
     pub sideboard_policy: SideboardPolicy,
-    pub commander_eligibility_rule: Option<CommanderEligibilityRule>,
 }
 
 /// Legality/era rules. `legal_sets: None` means unrestricted (every card

--- a/crates/engine/src/types/custom_format.rs
+++ b/crates/engine/src/types/custom_format.rs
@@ -127,17 +127,22 @@ pub enum CommanderEligibilityRule {
 impl CommanderEligibilityRule {
     /// Maps a BUILT-IN source `GameFormat` (the format a custom format is
     /// being modeled after) to the eligibility rule it should reuse.
-    /// Exhaustive over every `GameFormat` variant. `Custom` panics: this
-    /// function's contract is that `format` names a built-in — a bare
-    /// `GameFormat::Custom(id)` has no "source format" of its own to read.
-    pub fn from_source_format(format: GameFormat) -> Option<Self> {
+    /// `Ok(None)` means the built-in genuinely has no commander-eligibility
+    /// concept (e.g. Standard, Limited); `Ok(Some(rule))` names the rule a
+    /// commander-style built-in uses. `Err` for `GameFormat::Custom`: this
+    /// function's contract is that `format` names a built-in a custom format
+    /// is modeled after, and a bare `Custom(id)` has no "source format" of
+    /// its own to read — that is a distinct condition from "this built-in
+    /// has no commander concept," so it is not collapsed into the same
+    /// `None` a caller would otherwise have to disambiguate from context.
+    pub fn from_source_format(format: GameFormat) -> Result<Option<Self>, FormatConfigError> {
         match format {
             GameFormat::Commander | GameFormat::DuelCommander | GameFormat::PauperCommander => {
-                Some(Self::Standard)
+                Ok(Some(Self::Standard))
             }
-            GameFormat::TinyLeaders => Some(Self::TinyLeaders),
-            GameFormat::Oathbreaker => Some(Self::OathbreakerSignatureSpell),
-            GameFormat::Brawl | GameFormat::HistoricBrawl => Some(Self::BrawlColorIdentity),
+            GameFormat::TinyLeaders => Ok(Some(Self::TinyLeaders)),
+            GameFormat::Oathbreaker => Ok(Some(Self::OathbreakerSignatureSpell)),
+            GameFormat::Brawl | GameFormat::HistoricBrawl => Ok(Some(Self::BrawlColorIdentity)),
             GameFormat::Standard
             | GameFormat::Limited
             | GameFormat::Pioneer
@@ -152,12 +157,11 @@ impl CommanderEligibilityRule {
             | GameFormat::TwoHeadedGiant
             | GameFormat::Archenemy
             | GameFormat::Planechase
-            | GameFormat::Momir => None,
-            GameFormat::Custom(_) => {
-                unreachable!(
-                    "from_source_format: source must be a built-in GameFormat, never Custom"
-                )
-            }
+            | GameFormat::Momir => Ok(None),
+            GameFormat::Custom(id) => Err(FormatConfigError(format!(
+                "from_source_format: source must be a built-in GameFormat, never Custom({})",
+                id.0
+            ))),
         }
     }
 }

--- a/crates/engine/src/types/custom_format.rs
+++ b/crates/engine/src/types/custom_format.rs
@@ -74,13 +74,22 @@ pub enum CombatDamageTiming {
 /// Scope for "Wish"-style effects that fetch a card from outside the game.
 /// No single Comprehensive Rules number governs this generically — each
 /// Wish-effect card's own Oracle text defines its behavior, against the
-/// general "outside the game" zone concept (CR 100.4, CR 108.3). Variant
-/// names match `docs/proposals/custom-format-engine/PLAN.md`'s canonical
-/// schema exactly. Schema only in this phase.
+/// general "outside the game" zone concept (CR 400.11: an object is outside
+/// the game if it isn't in any of the game's zones; CR 400.11a: sideboard
+/// cards are outside the game — one instance of that general concept, not
+/// an exhaustive list of every way to be outside the game). Variant names
+/// match `docs/proposals/custom-format-engine/PLAN.md`'s canonical schema
+/// exactly. Schema only in this phase.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize, Deserialize)]
 pub enum WishOutsideGameScope {
-    /// Modern CR 400.11/400.11a: "outside the game" is not a zone; only the
-    /// sideboard is reachable.
+    /// Modern deck-construction/tournament policy (CR 100.4: sideboard
+    /// rules and restrictions are set by the Magic: The Gathering
+    /// Tournament Rules), not a Comprehensive Rules mandate: in a modern,
+    /// sanctioned constructed deck the registered sideboard is the only
+    /// legitimate "outside the game" zone a Wish effect can retrieve from,
+    /// because no current card creates any other one — older templating
+    /// that removed cards from the game (see `PreM10ReachesExile`) has been
+    /// replaced by exile.
     #[default]
     PostM10SideboardOnly,
     /// Pre-M10: a Wish could retrieve an owned card that had been removed

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -334,9 +334,14 @@ pub struct FormatConfig {
     /// Present only when `format == GameFormat::Custom(id)` (and then `id`
     /// must equal `custom_rules.id` — see
     /// `custom_format::validate_custom_rules_consistency`). `None` for every
-    /// built-in format.
+    /// built-in format. Boxed because `FormatConfig` is embedded directly in
+    /// `lobby_broker::protocol::LobbyClientMessage::CreateGameWithSettings`
+    /// (and the canonical `server_core` equivalent) — an unboxed
+    /// `CustomFormatRules` pushes that enum's largest variant over clippy's
+    /// `large_enum_variant` threshold, exactly like `range_of_influence`
+    /// above is boxed for the same reason.
     #[serde(default, skip_serializing_if = "Option::is_none")]
-    pub custom_rules: Option<CustomFormatRules>,
+    pub custom_rules: Option<Box<CustomFormatRules>>,
 }
 
 impl FormatTopology {

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -4,7 +4,9 @@ use std::collections::BTreeMap;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::database::legality::LegalityFormat;
-use crate::types::custom_format::{custom_format_registry, CustomFormatId, CustomFormatRules};
+use crate::types::custom_format::{
+    custom_format_registry, CustomFormatId, CustomFormatRules, FormatConfigError,
+};
 use crate::types::player::PlayerId;
 
 /// Broad grouping used by the UI to visually cluster related formats
@@ -288,6 +290,7 @@ where
 
 /// Configuration for a game format, describing player counts, starting life, deck rules, etc.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(remote = "Self")]
 pub struct FormatConfig {
     pub format: GameFormat,
     pub starting_life: i32,
@@ -342,6 +345,42 @@ pub struct FormatConfig {
     /// above is boxed for the same reason.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub custom_rules: Option<Box<CustomFormatRules>>,
+}
+
+/// Deserializing via the derive above, unchecked, would let an external
+/// payload construct `format: Custom(id)` with `custom_rules: None` or a
+/// mismatched id — `custom_format::validate_custom_rules_consistency` exists
+/// precisely to reject that, but a validator nobody calls doesn't protect
+/// anything. `#[serde(remote = "Self")]` on `FormatConfig` above generates
+/// this type's normal derived field-by-field (de)serialization as plain
+/// inherent `FormatConfig::serialize`/`FormatConfig::deserialize` functions
+/// (not the `Serialize`/`Deserialize` trait impls, which are instead
+/// hand-written here) — the standard serde idiom for "derive, then validate
+/// before accepting," with zero duplicated field declarations. `Serialize`
+/// needs no validation (an in-memory `FormatConfig` is already guaranteed
+/// consistent) and is a pure passthrough; `Deserialize` is the single
+/// authoritative `FormatConfig` ingress — every deserialization path (WASM
+/// boundary, lobby-broker/server-core protocol payloads, replay/save files)
+/// goes through it.
+impl Serialize for FormatConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        Self::serialize(self, serializer)
+    }
+}
+
+impl<'de> Deserialize<'de> for FormatConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let config = Self::deserialize(deserializer)?;
+        crate::types::custom_format::validate_custom_rules_consistency(&config)
+            .map_err(serde::de::Error::custom)?;
+        Ok(config)
+    }
 }
 
 impl FormatTopology {
@@ -1270,8 +1309,17 @@ impl FormatConfig {
     /// counts for Commander) are intentionally not recovered — guests use
     /// this purely to filter their local deck picker, and the host's own
     /// FormatConfig remains authoritative once the P2P session is established.
-    pub fn for_format(format: GameFormat) -> Self {
-        match format {
+    ///
+    /// Returns `Err` for `GameFormat::Custom` rather than panicking: this is
+    /// a public factory, callable with any `GameFormat` a caller happens to
+    /// hold — including one parsed straight from untrusted external input,
+    /// since `GameFormat::from_str` accepts any `"Custom:<u16>"` string. A
+    /// bare `GameFormat` carries no `CustomFormatRules` to build structural
+    /// rules from, so there is no default to fall back to here; callers that
+    /// might see a Custom format from an external source must handle the
+    /// rejection rather than the function terminating the process.
+    pub fn for_format(format: GameFormat) -> Result<Self, FormatConfigError> {
+        Ok(match format {
             GameFormat::Standard => Self::standard(),
             GameFormat::Limited => Self::limited(),
             GameFormat::Commander => Self::commander(),
@@ -1294,10 +1342,13 @@ impl FormatConfig {
             GameFormat::Archenemy => Self::archenemy(),
             GameFormat::Planechase => Self::planechase(),
             GameFormat::Momir => Self::momir(),
-            GameFormat::Custom(_) => unreachable!(
-                "for_format cannot resolve an ad-hoc Custom format's structural rules — read custom_rules from the resolved FormatConfig/CustomFormatRules instead"
-            ),
-        }
+            GameFormat::Custom(id) => {
+                return Err(FormatConfigError(format!(
+                    "for_format cannot resolve ad-hoc Custom format {} structural rules — read custom_rules from the resolved FormatConfig/CustomFormatRules instead",
+                    id.0
+                )))
+            }
+        })
     }
 }
 
@@ -1685,7 +1736,7 @@ mod tests {
     #[test]
     fn limited_for_format_roundtrip() {
         assert_eq!(
-            FormatConfig::for_format(GameFormat::Limited),
+            FormatConfig::for_format(GameFormat::Limited).unwrap(),
             FormatConfig::limited()
         );
     }
@@ -1693,7 +1744,7 @@ mod tests {
     #[test]
     fn premodern_for_format_roundtrip() {
         assert_eq!(
-            FormatConfig::for_format(GameFormat::Premodern),
+            FormatConfig::for_format(GameFormat::Premodern).unwrap(),
             FormatConfig::premodern()
         );
     }
@@ -1728,7 +1779,7 @@ mod tests {
         }
         // Variants not in the user-facing registry still respect the invariant.
         for format in [GameFormat::TwoHeadedGiant, GameFormat::Limited] {
-            let config = FormatConfig::for_format(format);
+            let config = FormatConfig::for_format(format).unwrap();
             assert_eq!(config.uses_commander, format.uses_commander());
             assert_eq!(config.supplies_fixed_deck, format.supplies_fixed_deck());
         }

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -1,8 +1,10 @@
+use std::borrow::Cow;
 use std::collections::BTreeMap;
 
-use serde::{Deserialize, Deserializer, Serialize};
+use serde::{Deserialize, Deserializer, Serialize, Serializer};
 
 use crate::database::legality::LegalityFormat;
+use crate::types::custom_format::{custom_format_registry, CustomFormatId, CustomFormatRules};
 use crate::types::player::PlayerId;
 
 /// Broad grouping used by the UI to visually cluster related formats
@@ -34,7 +36,7 @@ pub struct FormatMetadata {
 }
 
 /// Supported game formats.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum GameFormat {
     Standard,
     Limited,
@@ -66,6 +68,121 @@ pub enum GameFormat {
     /// Create a token that's a copy of a creature card with mana value X chosen
     /// at random."
     Momir,
+    /// An engine-validated custom format. Resolves via
+    /// `FormatConfig.custom_rules` (see `types::custom_format`) — a bare
+    /// `GameFormat::Custom(id)` alone cannot fully answer several of this
+    /// enum's methods; see each method's doc comment for how it handles
+    /// `Custom`.
+    Custom(CustomFormatId),
+}
+
+/// Parse error for `GameFormat::from_str` — `GameFormat` has no catch-all
+/// variant (unlike `Keyword`), so this is genuinely fallible.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct GameFormatParseError(pub String);
+
+impl std::fmt::Display for GameFormatParseError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl std::error::Error for GameFormatParseError {}
+
+impl std::str::FromStr for GameFormat {
+    type Err = GameFormatParseError;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        if let Some(rest) = s.strip_prefix("Custom:") {
+            return rest
+                .parse::<u16>()
+                .map(|n| GameFormat::Custom(CustomFormatId(n)))
+                .map_err(|_| GameFormatParseError(format!("invalid Custom format id: {rest:?}")));
+        }
+        match s {
+            "Standard" => Ok(GameFormat::Standard),
+            "Limited" => Ok(GameFormat::Limited),
+            "Commander" => Ok(GameFormat::Commander),
+            "Pioneer" => Ok(GameFormat::Pioneer),
+            "Modern" => Ok(GameFormat::Modern),
+            "Premodern" => Ok(GameFormat::Premodern),
+            "Legacy" => Ok(GameFormat::Legacy),
+            "Vintage" => Ok(GameFormat::Vintage),
+            "Historic" => Ok(GameFormat::Historic),
+            "Timeless" => Ok(GameFormat::Timeless),
+            "Pauper" => Ok(GameFormat::Pauper),
+            "PauperCommander" => Ok(GameFormat::PauperCommander),
+            "DuelCommander" => Ok(GameFormat::DuelCommander),
+            "TinyLeaders" => Ok(GameFormat::TinyLeaders),
+            "Oathbreaker" => Ok(GameFormat::Oathbreaker),
+            "Brawl" => Ok(GameFormat::Brawl),
+            "HistoricBrawl" => Ok(GameFormat::HistoricBrawl),
+            "FreeForAll" => Ok(GameFormat::FreeForAll),
+            "TwoHeadedGiant" => Ok(GameFormat::TwoHeadedGiant),
+            "Archenemy" => Ok(GameFormat::Archenemy),
+            "Planechase" => Ok(GameFormat::Planechase),
+            "Momir" => Ok(GameFormat::Momir),
+            other => Err(GameFormatParseError(format!(
+                "unknown GameFormat: {other:?}"
+            ))),
+        }
+    }
+}
+
+impl std::fmt::Display for GameFormat {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            GameFormat::Custom(id) => write!(f, "Custom:{}", id.0),
+            GameFormat::Standard => write!(f, "Standard"),
+            GameFormat::Limited => write!(f, "Limited"),
+            GameFormat::Commander => write!(f, "Commander"),
+            GameFormat::Pioneer => write!(f, "Pioneer"),
+            GameFormat::Modern => write!(f, "Modern"),
+            GameFormat::Premodern => write!(f, "Premodern"),
+            GameFormat::Legacy => write!(f, "Legacy"),
+            GameFormat::Vintage => write!(f, "Vintage"),
+            GameFormat::Historic => write!(f, "Historic"),
+            GameFormat::Timeless => write!(f, "Timeless"),
+            GameFormat::Pauper => write!(f, "Pauper"),
+            GameFormat::PauperCommander => write!(f, "PauperCommander"),
+            GameFormat::DuelCommander => write!(f, "DuelCommander"),
+            GameFormat::TinyLeaders => write!(f, "TinyLeaders"),
+            GameFormat::Oathbreaker => write!(f, "Oathbreaker"),
+            GameFormat::Brawl => write!(f, "Brawl"),
+            GameFormat::HistoricBrawl => write!(f, "HistoricBrawl"),
+            GameFormat::FreeForAll => write!(f, "FreeForAll"),
+            GameFormat::TwoHeadedGiant => write!(f, "TwoHeadedGiant"),
+            GameFormat::Archenemy => write!(f, "Archenemy"),
+            GameFormat::Planechase => write!(f, "Planechase"),
+            GameFormat::Momir => write!(f, "Momir"),
+        }
+    }
+}
+
+impl Serialize for GameFormat {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        serializer.serialize_str(&self.to_string())
+    }
+}
+
+impl<'de> Deserialize<'de> for GameFormat {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let value = serde_json::Value::deserialize(deserializer)?;
+        match value {
+            serde_json::Value::String(s) => {
+                s.parse::<GameFormat>().map_err(serde::de::Error::custom)
+            }
+            other => Err(serde::de::Error::custom(format!(
+                "expected a string for GameFormat, got {other:?}"
+            ))),
+        }
+    }
 }
 
 /// CR 100.4 / CR 100.4a: Per-format sideboard rules.
@@ -195,7 +312,7 @@ pub struct FormatConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub archenemy_player: Option<PlayerId>,
     /// Engine-derived predicate: true when the format uses a commander card
-    /// and the commander-damage state-based action (CR 903.10a / CR 704.5u).
+    /// and the commander-damage state-based action (CR 903.10a).
     /// Covers Commander, Duel Commander, Pauper Commander, Brawl, and
     /// Historic Brawl. The frontend consumes this directly — it must never
     /// re-list commander-style formats client-side.
@@ -214,6 +331,12 @@ pub struct FormatConfig {
     /// Immutable for the life of the session.
     #[serde(default)]
     pub allow_debug_actions: bool,
+    /// Present only when `format == GameFormat::Custom(id)` (and then `id`
+    /// must equal `custom_rules.id` — see
+    /// `custom_format::validate_custom_rules_consistency`). `None` for every
+    /// built-in format.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub custom_rules: Option<CustomFormatRules>,
 }
 
 impl FormatTopology {
@@ -259,6 +382,10 @@ impl GameFormat {
             // Momir's pool is the entire creature corpus — no legality restriction.
             | GameFormat::Momir
             | GameFormat::Limited => None,
+            // A custom format's legality is entirely governed by its own
+            // `LegalityRules` (legal_sets/banned/restricted), never by the
+            // built-in `LegalityFormat` table.
+            GameFormat::Custom(_) => None,
         }
     }
 
@@ -292,6 +419,14 @@ impl GameFormat {
             | GameFormat::Archenemy
             | GameFormat::Planechase
             | GameFormat::Limited => SideboardPolicy::Unlimited,
+            // Phase 1a: disclosed, temporary, bare-GameFormat-context
+            // fallback — not this custom format's real declared policy
+            // (that lives on the resolved FormatConfig/CustomFormatRules,
+            // which this method has no access to). Forbidden is the
+            // fail-closed answer: understating a sideboard allowance is
+            // safer than overstating one. Phase 1b migrates real callers to
+            // read FormatConfig's resolved field instead of this method.
+            GameFormat::Custom(_) => SideboardPolicy::Forbidden,
         }
     }
 
@@ -340,6 +475,14 @@ impl GameFormat {
             | GameFormat::FreeForAll
             | GameFormat::TwoHeadedGiant
             | GameFormat::Momir => DeckCopyLimit::Unlimited,
+            // Phase 1a: disclosed, temporary, bare-GameFormat-context
+            // fallback — not this custom format's real declared limit.
+            // UpTo(1) (the same value already used for command-zone
+            // singleton formats) is the fail-closed answer: it under-permits
+            // rather than silently over-permitting a format whose real
+            // rules were never consulted. Phase 1b migrates real callers to
+            // read FormatConfig's resolved field instead of this method.
+            GameFormat::Custom(_) => DeckCopyLimit::UpTo(1),
         }
     }
 
@@ -363,21 +506,40 @@ impl GameFormat {
     }
 
     /// Whether this format uses a commander card and the commander-damage
-    /// state-based action (CR 903.10a / CR 704.5u). True for Commander, Duel
+    /// state-based action (CR 903.10a). True for Commander, Duel
     /// Commander, Pauper Commander, Brawl, and Historic Brawl — every format
     /// whose `FormatConfig` has both `command_zone: true` and a non-`None`
     /// `commander_damage_threshold`. The frontend consumes the derived
     /// `FormatConfig::uses_commander` field rather than re-listing the
     /// commander-style variants client-side.
     pub fn uses_commander(self) -> bool {
-        matches!(
-            self,
+        match self {
             GameFormat::Commander
-                | GameFormat::DuelCommander
-                | GameFormat::PauperCommander
-                | GameFormat::Brawl
-                | GameFormat::HistoricBrawl,
-        )
+            | GameFormat::DuelCommander
+            | GameFormat::PauperCommander
+            | GameFormat::Brawl
+            | GameFormat::HistoricBrawl => true,
+            GameFormat::Standard
+            | GameFormat::Limited
+            | GameFormat::Pioneer
+            | GameFormat::Modern
+            | GameFormat::Premodern
+            | GameFormat::Legacy
+            | GameFormat::Vintage
+            | GameFormat::Historic
+            | GameFormat::Timeless
+            | GameFormat::Pauper
+            | GameFormat::TinyLeaders
+            | GameFormat::Oathbreaker
+            | GameFormat::FreeForAll
+            | GameFormat::TwoHeadedGiant
+            | GameFormat::Archenemy
+            | GameFormat::Planechase
+            | GameFormat::Momir => false,
+            GameFormat::Custom(_) => unreachable!(
+                "uses_commander: read FormatConfig.uses_commander instead — GameFormat alone cannot resolve this for Custom"
+            ),
+        }
     }
 
     /// Whether this format's deck is fixed by the format rules and supplied
@@ -388,34 +550,73 @@ impl GameFormat {
     /// `FormatConfig::supplies_fixed_deck` field to bypass deck-selection gates,
     /// and must never re-list fixed-deck formats client-side.
     pub fn supplies_fixed_deck(self) -> bool {
-        matches!(self, GameFormat::Momir)
+        match self {
+            GameFormat::Momir => true,
+            GameFormat::Standard
+            | GameFormat::Limited
+            | GameFormat::Commander
+            | GameFormat::Pioneer
+            | GameFormat::Modern
+            | GameFormat::Premodern
+            | GameFormat::Legacy
+            | GameFormat::Vintage
+            | GameFormat::Historic
+            | GameFormat::Timeless
+            | GameFormat::Pauper
+            | GameFormat::PauperCommander
+            | GameFormat::DuelCommander
+            | GameFormat::TinyLeaders
+            | GameFormat::Oathbreaker
+            | GameFormat::Brawl
+            | GameFormat::HistoricBrawl
+            | GameFormat::FreeForAll
+            | GameFormat::TwoHeadedGiant
+            | GameFormat::Archenemy
+            | GameFormat::Planechase => false,
+            // No custom-format use case for an engine-supplied fixed deck
+            // exists today — a real one would need its own design, analogous
+            // to Momir's Madness.
+            GameFormat::Custom(_) => false,
+        }
     }
 
     /// Display label for validation error messages (e.g., "Not Pioneer legal").
-    pub fn label(self) -> &'static str {
+    ///
+    /// Built-in variants return a static string. `Custom(id)` looks the id up
+    /// in `custom_format_registry()`: a hit returns that preset's real label;
+    /// a miss returns the fixed fallback `"Custom Format"`. A miss is the
+    /// normal case for an ad-hoc lobby-saved format — its player-chosen name
+    /// is client-local only and never travels to the engine, so the engine
+    /// has no name of its own to report.
+    pub fn label(self) -> Cow<'static, str> {
         match self {
-            GameFormat::Standard => "Standard",
-            GameFormat::Limited => "Limited",
-            GameFormat::Commander => "Commander",
-            GameFormat::Pioneer => "Pioneer",
-            GameFormat::Modern => "Modern",
-            GameFormat::Premodern => "Premodern",
-            GameFormat::Legacy => "Legacy",
-            GameFormat::Vintage => "Vintage",
-            GameFormat::Historic => "Historic",
-            GameFormat::Timeless => "Timeless",
-            GameFormat::Pauper => "Pauper",
-            GameFormat::PauperCommander => "Pauper Commander",
-            GameFormat::DuelCommander => "Duel Commander",
-            GameFormat::TinyLeaders => "Tiny Leaders: Reborn",
-            GameFormat::Oathbreaker => "Oathbreaker",
-            GameFormat::Brawl => "Brawl",
-            GameFormat::HistoricBrawl => "Historic Brawl",
-            GameFormat::FreeForAll => "Free-for-All",
-            GameFormat::TwoHeadedGiant => "Two-Headed Giant",
-            GameFormat::Archenemy => "Archenemy",
-            GameFormat::Planechase => "Planechase",
-            GameFormat::Momir => "Momir's Madness",
+            GameFormat::Standard => Cow::Borrowed("Standard"),
+            GameFormat::Limited => Cow::Borrowed("Limited"),
+            GameFormat::Commander => Cow::Borrowed("Commander"),
+            GameFormat::Pioneer => Cow::Borrowed("Pioneer"),
+            GameFormat::Modern => Cow::Borrowed("Modern"),
+            GameFormat::Premodern => Cow::Borrowed("Premodern"),
+            GameFormat::Legacy => Cow::Borrowed("Legacy"),
+            GameFormat::Vintage => Cow::Borrowed("Vintage"),
+            GameFormat::Historic => Cow::Borrowed("Historic"),
+            GameFormat::Timeless => Cow::Borrowed("Timeless"),
+            GameFormat::Pauper => Cow::Borrowed("Pauper"),
+            GameFormat::PauperCommander => Cow::Borrowed("Pauper Commander"),
+            GameFormat::DuelCommander => Cow::Borrowed("Duel Commander"),
+            GameFormat::TinyLeaders => Cow::Borrowed("Tiny Leaders: Reborn"),
+            GameFormat::Oathbreaker => Cow::Borrowed("Oathbreaker"),
+            GameFormat::Brawl => Cow::Borrowed("Brawl"),
+            GameFormat::HistoricBrawl => Cow::Borrowed("Historic Brawl"),
+            GameFormat::FreeForAll => Cow::Borrowed("Free-for-All"),
+            GameFormat::TwoHeadedGiant => Cow::Borrowed("Two-Headed Giant"),
+            GameFormat::Archenemy => Cow::Borrowed("Archenemy"),
+            GameFormat::Planechase => Cow::Borrowed("Planechase"),
+            GameFormat::Momir => Cow::Borrowed("Momir's Madness"),
+            GameFormat::Custom(id) => custom_format_registry()
+                .into_iter()
+                .find(|def| def.rules.id == id)
+                .map(|def| Cow::Owned(def.label))
+                .unwrap_or(Cow::Borrowed("Custom Format")),
         }
     }
 
@@ -729,6 +930,7 @@ impl FormatConfig {
             uses_commander: false,
             supplies_fixed_deck: false,
             allow_debug_actions: false,
+            custom_rules: None,
         }
     }
 
@@ -748,6 +950,7 @@ impl FormatConfig {
             uses_commander: true,
             supplies_fixed_deck: false,
             allow_debug_actions: false,
+            custom_rules: None,
         }
     }
 
@@ -839,6 +1042,7 @@ impl FormatConfig {
             uses_commander: false,
             supplies_fixed_deck: false,
             allow_debug_actions: false,
+            custom_rules: None,
         }
     }
 
@@ -862,6 +1066,7 @@ impl FormatConfig {
             uses_commander: false,
             supplies_fixed_deck: false,
             allow_debug_actions: false,
+            custom_rules: None,
         }
     }
 
@@ -898,6 +1103,7 @@ impl FormatConfig {
             uses_commander: true,
             supplies_fixed_deck: false,
             allow_debug_actions: false,
+            custom_rules: None,
         }
     }
 
@@ -928,6 +1134,7 @@ impl FormatConfig {
             uses_commander: false,
             supplies_fixed_deck: false,
             allow_debug_actions: false,
+            custom_rules: None,
         }
     }
 
@@ -949,6 +1156,7 @@ impl FormatConfig {
             uses_commander: false,
             supplies_fixed_deck: false,
             allow_debug_actions: false,
+            custom_rules: None,
         }
     }
 
@@ -973,6 +1181,7 @@ impl FormatConfig {
             uses_commander: false,
             supplies_fixed_deck: true,
             allow_debug_actions: false,
+            custom_rules: None,
         }
     }
 
@@ -992,6 +1201,7 @@ impl FormatConfig {
             uses_commander: false,
             supplies_fixed_deck: false,
             allow_debug_actions: false,
+            custom_rules: None,
         }
     }
 
@@ -1014,6 +1224,7 @@ impl FormatConfig {
             uses_commander: false,
             supplies_fixed_deck: false,
             allow_debug_actions: false,
+            custom_rules: None,
         }
     }
 
@@ -1035,6 +1246,7 @@ impl FormatConfig {
             uses_commander: false,
             supplies_fixed_deck: false,
             allow_debug_actions: false,
+            custom_rules: None,
         }
     }
 
@@ -1077,6 +1289,9 @@ impl FormatConfig {
             GameFormat::Archenemy => Self::archenemy(),
             GameFormat::Planechase => Self::planechase(),
             GameFormat::Momir => Self::momir(),
+            GameFormat::Custom(_) => unreachable!(
+                "for_format cannot resolve an ad-hoc Custom format's structural rules — read custom_rules from the resolved FormatConfig/CustomFormatRules instead"
+            ),
         }
     }
 }

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -288,6 +288,13 @@ where
     })
 }
 
+/// Fail-closed default for `FormatConfig.sideboard_policy` on a payload
+/// serialized before that field existed: understating a sideboard
+/// allowance is safer than overstating one.
+fn default_sideboard_policy_fallback() -> SideboardPolicy {
+    SideboardPolicy::Forbidden
+}
+
 /// Configuration for a game format, describing player counts, starting life, deck rules, etc.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(remote = "Self")]
@@ -327,6 +334,18 @@ pub struct FormatConfig {
     /// gates — it must never re-list fixed-deck formats client-side.
     #[serde(default)]
     pub supplies_fixed_deck: bool,
+    /// Engine-derived, stored per-format sideboard policy (CR 100.4/100.4a).
+    /// Mirrors `uses_commander`/`supplies_fixed_deck`'s stored-field
+    /// pattern — real consumers (`deck_loading.rs`, `match_flow.rs`,
+    /// `companion.rs`) read this field, never `GameFormat::sideboard_policy()`
+    /// directly: for a built-in format the two always agree, but for
+    /// `GameFormat::Custom` the bare method has no way to see the real
+    /// declared policy sitting in `custom_rules.structural.sideboard_policy`
+    /// and would silently discard it, which is exactly the bug this field
+    /// exists to prevent. `#[serde(default)]` fails closed (`Forbidden`) for
+    /// any payload serialized before this field existed.
+    #[serde(default = "default_sideboard_policy_fallback")]
+    pub sideboard_policy: SideboardPolicy,
     /// Capability flag: when true, the server (and other transport gates)
     /// permit `GameAction::Debug(_)` from any player in this session. Off by
     /// default. Orthogonal to format — a sandbox Commander game plays
@@ -380,7 +399,7 @@ impl<'de> Deserialize<'de> for FormatConfig {
     {
         let config = Self::deserialize(deserializer)?;
         // `command_zone`/`commander_damage_threshold`/`uses_commander`/
-        // `singleton` etc. are this struct's own independently-serialized
+        // `singleton`/`sideboard_policy` etc. are this struct's own independently-serialized
         // runtime fields — for a built-in format they're always consistent
         // because a `FormatConfig::x()` builder derived them together. For
         // `Custom` there is no such builder yet: `custom_rules.structural`
@@ -403,7 +422,7 @@ impl<'de> Deserialize<'de> for FormatConfig {
                 "GameFormat::Custom cannot be activated via external FormatConfig \
                  deserialization yet — no resolver exists to derive/validate this struct's \
                  runtime fields (command_zone, uses_commander, commander_damage_threshold, \
-                 singleton, ...) from custom_rules.structural, so two independently-writable \
+                 singleton, sideboard_policy, ...) from custom_rules.structural, so two independently-writable \
                  representations of the same state could disagree; this lands in a later phase",
             ));
         }
@@ -1016,6 +1035,7 @@ impl FormatConfig {
             team_based: false,
             archenemy_player: None,
             uses_commander: false,
+            sideboard_policy: GameFormat::Standard.sideboard_policy(),
             supplies_fixed_deck: false,
             allow_debug_actions: false,
             custom_rules: None,
@@ -1036,6 +1056,7 @@ impl FormatConfig {
             team_based: false,
             archenemy_player: None,
             uses_commander: true,
+            sideboard_policy: GameFormat::Commander.sideboard_policy(),
             supplies_fixed_deck: false,
             allow_debug_actions: false,
             custom_rules: None,
@@ -1128,6 +1149,7 @@ impl FormatConfig {
             team_based: false,
             archenemy_player: None,
             uses_commander: false,
+            sideboard_policy: GameFormat::TinyLeaders.sideboard_policy(),
             supplies_fixed_deck: false,
             allow_debug_actions: false,
             custom_rules: None,
@@ -1152,6 +1174,7 @@ impl FormatConfig {
             team_based: false,
             archenemy_player: None,
             uses_commander: false,
+            sideboard_policy: GameFormat::Oathbreaker.sideboard_policy(),
             supplies_fixed_deck: false,
             allow_debug_actions: false,
             custom_rules: None,
@@ -1189,6 +1212,7 @@ impl FormatConfig {
             team_based: false,
             archenemy_player: None,
             uses_commander: true,
+            sideboard_policy: GameFormat::Brawl.sideboard_policy(),
             supplies_fixed_deck: false,
             allow_debug_actions: false,
             custom_rules: None,
@@ -1220,6 +1244,7 @@ impl FormatConfig {
             team_based: false,
             archenemy_player: None,
             uses_commander: false,
+            sideboard_policy: GameFormat::FreeForAll.sideboard_policy(),
             supplies_fixed_deck: false,
             allow_debug_actions: false,
             custom_rules: None,
@@ -1242,6 +1267,7 @@ impl FormatConfig {
             team_based: false,
             archenemy_player: None,
             uses_commander: false,
+            sideboard_policy: GameFormat::Limited.sideboard_policy(),
             supplies_fixed_deck: false,
             allow_debug_actions: false,
             custom_rules: None,
@@ -1267,6 +1293,7 @@ impl FormatConfig {
             team_based: false,
             archenemy_player: None,
             uses_commander: false,
+            sideboard_policy: GameFormat::Momir.sideboard_policy(),
             supplies_fixed_deck: true,
             allow_debug_actions: false,
             custom_rules: None,
@@ -1287,6 +1314,7 @@ impl FormatConfig {
             team_based: true,
             archenemy_player: None,
             uses_commander: false,
+            sideboard_policy: GameFormat::TwoHeadedGiant.sideboard_policy(),
             supplies_fixed_deck: false,
             allow_debug_actions: false,
             custom_rules: None,
@@ -1310,6 +1338,7 @@ impl FormatConfig {
             team_based: false,
             archenemy_player: None,
             uses_commander: false,
+            sideboard_policy: GameFormat::Planechase.sideboard_policy(),
             supplies_fixed_deck: false,
             allow_debug_actions: false,
             custom_rules: None,
@@ -1332,6 +1361,7 @@ impl FormatConfig {
             team_based: false,
             archenemy_player: Some(PlayerId(0)),
             uses_commander: false,
+            sideboard_policy: GameFormat::Archenemy.sideboard_policy(),
             supplies_fixed_deck: false,
             allow_debug_actions: false,
             custom_rules: None,
@@ -1820,12 +1850,23 @@ mod tests {
                 "{:?}: registry default disagrees with supplies_fixed_deck predicate",
                 meta.format
             );
+            // The stored `sideboard_policy` field must agree with the bare
+            // method for every built-in — real consumers read the stored
+            // field precisely so it can diverge safely for Custom, which
+            // means it must never silently diverge for a built-in.
+            assert_eq!(
+                meta.default_config.sideboard_policy,
+                meta.format.sideboard_policy(),
+                "{:?}: registry default disagrees with sideboard_policy predicate",
+                meta.format
+            );
         }
         // Variants not in the user-facing registry still respect the invariant.
         for format in [GameFormat::TwoHeadedGiant, GameFormat::Limited] {
             let config = FormatConfig::for_format(format).unwrap();
             assert_eq!(config.uses_commander, format.uses_commander().unwrap());
             assert_eq!(config.supplies_fixed_deck, format.supplies_fixed_deck());
+            assert_eq!(config.sideboard_policy, format.sideboard_policy());
         }
     }
 

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -586,13 +586,25 @@ impl GameFormat {
     /// `commander_damage_threshold`. The frontend consumes the derived
     /// `FormatConfig::uses_commander` field rather than re-listing the
     /// commander-style variants client-side.
-    pub fn uses_commander(self) -> bool {
+    ///
+    /// Returns `Err` for `GameFormat::Custom` rather than panicking or
+    /// guessing `false`: this is a public query, callable with any
+    /// `GameFormat` a caller holds — including one parsed straight from
+    /// untrusted input, since `GameFormat::from_str` accepts any
+    /// `"Custom:<u16>"` string. A bare `GameFormat` carries no
+    /// `CustomFormatRules` to answer this from, and a Custom format can
+    /// legitimately resolve to a commander-using configuration, so `false`
+    /// would be a silently wrong answer, not a safe default. Callers that
+    /// might see a Custom format from an external source must handle the
+    /// rejection; callers with a resolved `FormatConfig` should read its
+    /// `uses_commander` field instead of calling this at all.
+    pub fn uses_commander(self) -> Result<bool, FormatConfigError> {
         match self {
             GameFormat::Commander
             | GameFormat::DuelCommander
             | GameFormat::PauperCommander
             | GameFormat::Brawl
-            | GameFormat::HistoricBrawl => true,
+            | GameFormat::HistoricBrawl => Ok(true),
             GameFormat::Standard
             | GameFormat::Limited
             | GameFormat::Pioneer
@@ -609,10 +621,12 @@ impl GameFormat {
             | GameFormat::TwoHeadedGiant
             | GameFormat::Archenemy
             | GameFormat::Planechase
-            | GameFormat::Momir => false,
-            GameFormat::Custom(_) => unreachable!(
-                "uses_commander: read FormatConfig.uses_commander instead — GameFormat alone cannot resolve this for Custom"
-            ),
+            | GameFormat::Momir => Ok(false),
+            GameFormat::Custom(id) => Err(FormatConfigError(format!(
+                "uses_commander cannot resolve ad-hoc Custom format {} — read \
+                 FormatConfig.uses_commander from the resolved config instead",
+                id.0
+            ))),
         }
     }
 
@@ -1602,7 +1616,7 @@ mod tests {
             SideboardPolicy::Forbidden
         );
         assert!(GameFormat::Oathbreaker.grants_free_first_mulligan());
-        assert!(!GameFormat::Oathbreaker.uses_commander());
+        assert!(!GameFormat::Oathbreaker.uses_commander().unwrap());
         assert_eq!(GameFormat::Oathbreaker.legality_format(), None);
     }
 
@@ -1785,7 +1799,7 @@ mod tests {
         // `FormatConfig::uses_commander` field, and the existence of a
         // commander-damage threshold must all agree for every variant.
         for meta in GameFormat::registry() {
-            let expected = meta.format.uses_commander();
+            let expected = meta.format.uses_commander().unwrap();
             assert_eq!(
                 meta.default_config.uses_commander, expected,
                 "{:?}: registry default disagrees with predicate",
@@ -1810,7 +1824,7 @@ mod tests {
         // Variants not in the user-facing registry still respect the invariant.
         for format in [GameFormat::TwoHeadedGiant, GameFormat::Limited] {
             let config = FormatConfig::for_format(format).unwrap();
-            assert_eq!(config.uses_commander, format.uses_commander());
+            assert_eq!(config.uses_commander, format.uses_commander().unwrap());
             assert_eq!(config.supplies_fixed_deck, format.supplies_fixed_deck());
         }
     }

--- a/crates/engine/src/types/format.rs
+++ b/crates/engine/src/types/format.rs
@@ -360,8 +360,10 @@ pub struct FormatConfig {
 /// needs no validation (an in-memory `FormatConfig` is already guaranteed
 /// consistent) and is a pure passthrough; `Deserialize` is the single
 /// authoritative `FormatConfig` ingress — every deserialization path (WASM
-/// boundary, lobby-broker/server-core protocol payloads, replay/save files)
-/// goes through it.
+/// boundary, lobby-broker/server-core protocol payloads, replay/save/restore
+/// files) goes through it, since every such path ultimately deserializes a
+/// `GameState`/`PersistedGameState` whose own `format_config: FormatConfig`
+/// field is a plain derived field with no bypass.
 impl Serialize for FormatConfig {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -377,6 +379,34 @@ impl<'de> Deserialize<'de> for FormatConfig {
         D: Deserializer<'de>,
     {
         let config = Self::deserialize(deserializer)?;
+        // `command_zone`/`commander_damage_threshold`/`uses_commander`/
+        // `singleton` etc. are this struct's own independently-serialized
+        // runtime fields — for a built-in format they're always consistent
+        // because a `FormatConfig::x()` builder derived them together. For
+        // `Custom` there is no such builder yet: `custom_rules.structural`
+        // (a `CommandZoneMode`-discriminated declaration) and these bare
+        // runtime fields are two independently-writable representations of
+        // the same thing, and nothing here cross-checks them — a
+        // matching-`custom_rules.id` payload could still declare
+        // `CommandZoneMode::Disabled` while separately setting
+        // `command_zone: true`. Rather than accept that inconsistency (or
+        // partially validate it in a way a later phase would have to widen
+        // anyway), reject `Custom` outright at this single boundary until a
+        // real resolver — landing with Axis A/Axis B registration — can
+        // derive every runtime field FROM `custom_rules.structural` instead
+        // of accepting them independently. `GameFormat::Custom` remains
+        // fully constructible in-memory (for schema tests, and for that
+        // future resolver to build) — only external deserialization of an
+        // ACTIVE `FormatConfig` is refused.
+        if matches!(config.format, GameFormat::Custom(_)) {
+            return Err(serde::de::Error::custom(
+                "GameFormat::Custom cannot be activated via external FormatConfig \
+                 deserialization yet — no resolver exists to derive/validate this struct's \
+                 runtime fields (command_zone, uses_commander, commander_damage_threshold, \
+                 singleton, ...) from custom_rules.structural, so two independently-writable \
+                 representations of the same state could disagree; this lands in a later phase",
+            ));
+        }
         crate::types::custom_format::validate_custom_rules_consistency(&config)
             .map_err(serde::de::Error::custom)?;
         Ok(config)

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -6,6 +6,7 @@ pub mod attribution;
 pub mod card;
 pub mod card_type;
 pub mod counter;
+pub mod custom_format;
 pub mod definitions;
 pub(crate) mod deterministic_serde;
 pub mod events;

--- a/crates/engine/tests/integration/custom_format_schema.rs
+++ b/crates/engine/tests/integration/custom_format_schema.rs
@@ -189,6 +189,27 @@ fn custom_format_registry_is_empty_in_phase_1a() {
 }
 
 #[test]
+fn wish_outside_game_scope_default_is_the_deck_construction_policy_not_a_cr_mandate() {
+    // Pins the intended policy this axis encodes: PostM10SideboardOnly is
+    // the default (modern deck-construction/tournament restriction, CR
+    // 100.4), distinct from PreM10ReachesExile (the historical templating
+    // difference). Neither CR 400.11 nor CR 400.11a themselves restrict
+    // "outside the game" to only the sideboard — see the type's doc
+    // comment — so this test exists to catch a future change accidentally
+    // flipping which variant is the default, since nothing else enforces
+    // it yet (Phase 2cd wires the real behavior).
+    use engine::types::custom_format::WishOutsideGameScope;
+    assert_eq!(
+        WishOutsideGameScope::default(),
+        WishOutsideGameScope::PostM10SideboardOnly
+    );
+    assert_ne!(
+        WishOutsideGameScope::default(),
+        WishOutsideGameScope::PreM10ReachesExile
+    );
+}
+
+#[test]
 fn game_format_from_str_display_roundtrip_builtins() {
     let all = [
         GameFormat::Standard,

--- a/crates/engine/tests/integration/custom_format_schema.rs
+++ b/crates/engine/tests/integration/custom_format_schema.rs
@@ -302,10 +302,21 @@ fn commander_eligibility_rule_from_source_format_covers_every_builtin() {
     for (format, expected) in cases {
         assert_eq!(
             CommanderEligibilityRule::from_source_format(format),
-            expected,
+            Ok(expected),
             "{format:?}"
         );
     }
+}
+
+#[test]
+fn commander_eligibility_rule_from_source_format_rejects_custom_without_panicking() {
+    // The maintainer's review found this public function still panicked on
+    // GameFormat::Custom, a value any external caller can hold. Confirms it
+    // now returns a typed error instead of terminating.
+    assert!(
+        CommanderEligibilityRule::from_source_format(GameFormat::Custom(CustomFormatId(1)))
+            .is_err()
+    );
 }
 
 #[test]
@@ -366,6 +377,20 @@ fn custom_format_sideboard_policy_returns_disclosed_fallback_not_panic() {
         GameFormat::Custom(CustomFormatId(1)).sideboard_policy(),
         SideboardPolicy::Forbidden
     );
+}
+
+#[test]
+fn custom_format_uses_commander_rejects_without_panicking() {
+    // Unlike sideboard_policy/default_deck_copy_limit, uses_commander has no
+    // safe disclosed-fallback value: a Custom format can legitimately
+    // resolve to a commander-using configuration, so `false` would be a
+    // silently wrong answer rather than a safe default. This is a public
+    // query callable with any GameFormat, including one parsed straight
+    // from untrusted input (GameFormat::from_str accepts any
+    // "Custom:<u16>" string) — it must return a typed error, not panic.
+    assert!(GameFormat::Custom(CustomFormatId(1))
+        .uses_commander()
+        .is_err());
 }
 
 #[test]

--- a/crates/engine/tests/integration/custom_format_schema.rs
+++ b/crates/engine/tests/integration/custom_format_schema.rs
@@ -528,6 +528,17 @@ fn companion_candidates_returns_empty_for_custom_format_without_panicking() {
 // way to exercise FormatConfig's real Deserialize impl without hand-guessing
 // its full field set.
 
+/// Asserts the deserialization error came from this Deserialize impl's own
+/// rejection, not from some unrelated deserialization failure (a malformed
+/// field, a type mismatch) that would also make `.is_err()` pass vacuously.
+fn assert_rejected_as_unsupported_custom<T: std::fmt::Debug>(result: Result<T, serde_json::Error>) {
+    let error = result.expect_err("expected deserialization to be rejected");
+    assert!(
+        error.to_string().contains("cannot be activated"),
+        "expected the Custom-activation rejection message, got: {error}"
+    );
+}
+
 #[test]
 fn format_config_deserialization_rejects_custom_without_matching_rules() {
     let invalid = FormatConfig {
@@ -536,10 +547,7 @@ fn format_config_deserialization_rejects_custom_without_matching_rules() {
         ..FormatConfig::standard()
     };
     let json = serde_json::to_value(&invalid).unwrap();
-    assert!(
-        serde_json::from_value::<FormatConfig>(json).is_err(),
-        "Custom format with no custom_rules must be rejected at deserialization"
-    );
+    assert_rejected_as_unsupported_custom(serde_json::from_value::<FormatConfig>(json));
 }
 
 #[test]
@@ -550,10 +558,7 @@ fn format_config_deserialization_rejects_custom_with_mismatched_rules_id() {
         ..FormatConfig::standard()
     };
     let json = serde_json::to_value(&invalid).unwrap();
-    assert!(
-        serde_json::from_value::<FormatConfig>(json).is_err(),
-        "Custom format with mismatched custom_rules.id must be rejected at deserialization"
-    );
+    assert_rejected_as_unsupported_custom(serde_json::from_value::<FormatConfig>(json));
 }
 
 #[test]
@@ -570,11 +575,7 @@ fn format_config_deserialization_rejects_even_a_fully_consistent_custom_config()
         ..FormatConfig::standard()
     };
     let json = serde_json::to_value(&looks_fine).unwrap();
-    assert!(
-        serde_json::from_value::<FormatConfig>(json).is_err(),
-        "Custom format activation must be rejected until a resolver exists, even when \
-         custom_rules is internally consistent and its id matches"
-    );
+    assert_rejected_as_unsupported_custom(serde_json::from_value::<FormatConfig>(json));
 }
 
 #[test]
@@ -596,10 +597,22 @@ fn format_config_deserialization_rejects_matching_id_but_structurally_contradict
         ..FormatConfig::standard()
     };
     let json = serde_json::to_value(&contradictory).unwrap();
+    assert_rejected_as_unsupported_custom(serde_json::from_value::<FormatConfig>(json));
+}
+
+#[test]
+fn persisted_game_state_restore_accepts_a_normal_built_in_game() {
+    // Paired positive control for the rejection test below: a normal
+    // built-in game's persisted state must still round-trip successfully,
+    // so the rejection test can't be passing because *nothing* deserializes.
+    use engine::types::game_state::{GameState, PersistedGameState};
+
+    let state = GameState::new(FormatConfig::standard(), 2, 42);
+    let persisted = PersistedGameState::capture(state);
+    let json = serde_json::to_value(&persisted).unwrap();
     assert!(
-        serde_json::from_value::<FormatConfig>(json).is_err(),
-        "a matching-id Custom payload whose runtime fields contradict custom_rules.structural \
-         must still be rejected"
+        serde_json::from_value::<PersistedGameState>(json).is_ok(),
+        "restoring a persisted built-in-format GameState must succeed"
     );
 }
 
@@ -669,4 +682,68 @@ fn companion_reveal_check_does_not_panic_for_an_in_memory_custom_format_config()
     // uses_commander() inside companion_offers/companion_starting_deck.
     let result = engine::game::companion::check_all_companion_reveals(&state);
     assert!(result.is_none());
+}
+
+#[test]
+fn custom_format_unlimited_sideboard_survives_deck_loading() {
+    // The maintainer's review found GameFormat::sideboard_policy()'s
+    // disclosed Forbidden fallback for Custom silently discarded a real,
+    // already-known declared policy sitting in
+    // custom_rules.structural.sideboard_policy — deck_loading.rs trusted the
+    // bare-GameFormat fallback and emptied the sideboard even for a Custom
+    // format whose real policy is Unlimited. FormatConfig now stores its own
+    // sideboard_policy field (mirroring uses_commander/supplies_fixed_deck),
+    // and deck_loading.rs reads that instead. This proves the fix through
+    // the real production entry point, load_deck_into_state: builds an
+    // in-memory Custom FormatConfig with sideboard_policy: Unlimited, loads
+    // a deck payload with a nonempty sideboard, and confirms the sideboard
+    // actually survives into the resulting deck pool rather than being
+    // silently dropped to empty.
+    use engine::game::deck_loading::{
+        load_deck_into_state, DeckEntry, DeckPayload, PlayerDeckPayload,
+    };
+    use engine::types::card::CardFace;
+    use engine::types::game_state::GameState;
+
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    let rules = sample_rules(5);
+    state.format_config = FormatConfig {
+        format: GameFormat::Custom(rules.id),
+        custom_rules: Some(Box::new(rules)),
+        sideboard_policy: SideboardPolicy::Unlimited,
+        ..FormatConfig::standard()
+    };
+
+    let sideboard_card = DeckEntry {
+        card: CardFace {
+            name: "Test Sideboard Card".to_string(),
+            ..Default::default()
+        },
+        count: 1,
+    };
+    let payload = DeckPayload {
+        player: PlayerDeckPayload {
+            sideboard: vec![sideboard_card.clone()],
+            ..Default::default()
+        },
+        opponent: PlayerDeckPayload {
+            sideboard: vec![sideboard_card],
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    load_deck_into_state(&mut state, &payload);
+
+    let p0 = state
+        .deck_pools
+        .iter()
+        .find(|pool| pool.player == engine::types::PlayerId(0))
+        .expect("player 0 deck pool must exist after loading");
+    assert_eq!(
+        p0.current_sideboard.len(),
+        1,
+        "a Custom format with sideboard_policy: Unlimited must not have its sideboard dropped"
+    );
+    assert_eq!(p0.current_sideboard[0].card.name, "Test Sideboard Card");
 }

--- a/crates/engine/tests/integration/custom_format_schema.rs
+++ b/crates/engine/tests/integration/custom_format_schema.rs
@@ -7,7 +7,7 @@
 
 use engine::types::custom_format::{
     passes_legacy_axis_gate, passes_reprint_fidelity_gate, validate_custom_rules_consistency,
-    CombatDamageTiming, CommanderEligibilityRule, CustomFormatDef, CustomFormatId,
+    CombatDamageTiming, CommandZoneMode, CommanderEligibilityRule, CustomFormatDef, CustomFormatId,
     CustomFormatRules, LegacyRuleSet, LegalityRules, ManaBurnPolicy, PrintingFidelity,
     ReprintPolicy, SetCode, StructuralRules, WishOutsideGameScope,
 };
@@ -20,12 +20,10 @@ fn sample_structural() -> StructuralRules {
         max_players: 4,
         deck_size: 60,
         singleton: false,
-        command_zone: false,
-        commander_damage_threshold: None,
+        command_zone_mode: CommandZoneMode::Disabled,
         range_of_influence: None,
         team_based: false,
         sideboard_policy: SideboardPolicy::Unlimited,
-        commander_eligibility_rule: None,
     }
 }
 
@@ -139,7 +137,7 @@ fn validate_custom_rules_consistency_rejects_builtin_with_custom_rules() {
 #[test]
 fn validate_custom_rules_consistency_accepts_every_builtin_default() {
     for meta in GameFormat::registry() {
-        let config = FormatConfig::for_format(meta.format);
+        let config = FormatConfig::for_format(meta.format).unwrap();
         assert!(
             validate_custom_rules_consistency(&config).is_ok(),
             "{:?}: built-in default config must be accepted",
@@ -151,7 +149,7 @@ fn validate_custom_rules_consistency_accepts_every_builtin_default() {
 #[test]
 fn legacy_axis_gate_rejects_undeclared_axis() {
     let mut def = sample_def(1);
-    def.rules.legality.legacy.mana_burn = ManaBurnPolicy::Legacy;
+    def.rules.legality.legacy.mana_burn = ManaBurnPolicy::Obsolete;
     assert!(!passes_legacy_axis_gate(&def));
 }
 
@@ -346,12 +344,20 @@ fn game_format_serialization_is_byte_identical_to_old_derive_for_builtins() {
 #[test]
 fn format_config_for_format_still_works_for_every_builtin() {
     for meta in GameFormat::registry() {
-        let config = FormatConfig::for_format(meta.format);
+        let config = FormatConfig::for_format(meta.format).unwrap();
         assert!(matches!(
             config.format.default_deck_copy_limit(),
             DeckCopyLimit::Unlimited | DeckCopyLimit::UpTo(_)
         ));
     }
+}
+
+#[test]
+fn format_config_for_format_rejects_custom() {
+    // The public-factory panic CodeRabbit/the maintainer flagged: a bare
+    // GameFormat::Custom parsed from external input must not terminate the
+    // process here — for_format has no CustomFormatRules to build from.
+    assert!(FormatConfig::for_format(GameFormat::Custom(CustomFormatId(1))).is_err());
 }
 
 #[test]
@@ -442,4 +448,74 @@ fn validate_name_deck_for_format_full_rejects_custom_format_honestly() {
         Err(reasons) => assert!(reasons.iter().any(|r| r.contains("not yet supported"))),
         Ok(()) => panic!("expected Custom format validation to be rejected as not yet supported"),
     }
+}
+
+#[test]
+fn companion_candidates_returns_empty_for_custom_format_without_panicking() {
+    use engine::database::CardDatabase;
+    use engine::game::deck_validation::{companion_candidates, DeckCompatibilityRequest};
+
+    let db = CardDatabase::from_json_str("{}").expect("empty card database");
+    let request = DeckCompatibilityRequest {
+        selected_format: Some(GameFormat::Custom(CustomFormatId(1))),
+        ..Default::default()
+    };
+    // Exercises the exact guard added to companion_candidates: without it,
+    // `GameFormat::Custom(_).uses_commander()` inside the function's own
+    // `Option::filter` would panic. This is the direct production entry
+    // point `companion_candidates_js` (engine-wasm) calls with untrusted
+    // input — the other Custom tests above only cover it indirectly via
+    // `evaluate_deck_compatibility`.
+    assert_eq!(companion_candidates(&db, &request), Vec::<String>::new());
+}
+
+// The authoritative FormatConfig ingress: a malformed Custom payload (no
+// custom_rules, or a mismatched id) must be rejected at deserialization
+// time, not merely by a validator nothing calls. Each invalid value is
+// constructed directly in Rust (bypassing Deserialize, which has no reason
+// to reject it going the other way) and round-tripped through
+// `serde_json` — the only way to exercise `FormatConfig`'s real `Deserialize`
+// impl without hand-guessing its full field set.
+
+#[test]
+fn format_config_deserialization_rejects_custom_without_matching_rules() {
+    let invalid = FormatConfig {
+        format: GameFormat::Custom(CustomFormatId(1)),
+        custom_rules: None,
+        ..FormatConfig::standard()
+    };
+    let json = serde_json::to_value(&invalid).unwrap();
+    assert!(
+        serde_json::from_value::<FormatConfig>(json).is_err(),
+        "Custom format with no custom_rules must be rejected at deserialization"
+    );
+}
+
+#[test]
+fn format_config_deserialization_rejects_custom_with_mismatched_rules_id() {
+    let invalid = FormatConfig {
+        format: GameFormat::Custom(CustomFormatId(5)),
+        custom_rules: Some(Box::new(sample_rules(7))),
+        ..FormatConfig::standard()
+    };
+    let json = serde_json::to_value(&invalid).unwrap();
+    assert!(
+        serde_json::from_value::<FormatConfig>(json).is_err(),
+        "Custom format with mismatched custom_rules.id must be rejected at deserialization"
+    );
+}
+
+#[test]
+fn format_config_deserialization_accepts_consistent_custom_config() {
+    let rules = sample_rules(5);
+    let valid = FormatConfig {
+        format: GameFormat::Custom(rules.id),
+        custom_rules: Some(Box::new(rules)),
+        ..FormatConfig::standard()
+    };
+    let json = serde_json::to_value(&valid).unwrap();
+    assert!(
+        serde_json::from_value::<FormatConfig>(json).is_ok(),
+        "a consistent Custom FormatConfig must still deserialize successfully"
+    );
 }

--- a/crates/engine/tests/integration/custom_format_schema.rs
+++ b/crates/engine/tests/integration/custom_format_schema.rs
@@ -469,13 +469,18 @@ fn companion_candidates_returns_empty_for_custom_format_without_panicking() {
     assert_eq!(companion_candidates(&db, &request), Vec::<String>::new());
 }
 
-// The authoritative FormatConfig ingress: a malformed Custom payload (no
-// custom_rules, or a mismatched id) must be rejected at deserialization
-// time, not merely by a validator nothing calls. Each invalid value is
-// constructed directly in Rust (bypassing Deserialize, which has no reason
-// to reject it going the other way) and round-tripped through
-// `serde_json` — the only way to exercise `FormatConfig`'s real `Deserialize`
-// impl without hand-guessing its full field set.
+// The authoritative FormatConfig ingress. Phase 1a has no resolver that
+// derives this struct's own runtime fields (command_zone,
+// commander_damage_threshold, uses_commander, singleton, ...) FROM
+// custom_rules.structural — they're two independently-writable
+// representations of the same state with nothing cross-checking them, so
+// EVERY externally-deserialized Custom FormatConfig is rejected outright for
+// now, not just id-inconsistent ones (see the Deserialize impl's doc comment
+// in format.rs). Each invalid/valid-looking value below is constructed
+// directly in Rust (bypassing Deserialize, which has no reason to reject it
+// going the other way) and round-tripped through `serde_json` — the only
+// way to exercise FormatConfig's real Deserialize impl without hand-guessing
+// its full field set.
 
 #[test]
 fn format_config_deserialization_rejects_custom_without_matching_rules() {
@@ -506,16 +511,75 @@ fn format_config_deserialization_rejects_custom_with_mismatched_rules_id() {
 }
 
 #[test]
-fn format_config_deserialization_accepts_consistent_custom_config() {
+fn format_config_deserialization_rejects_even_a_fully_consistent_custom_config() {
+    // Not just an id mismatch: custom_rules.id matches, and
+    // custom_rules.structural is entirely self-consistent — this is
+    // rejected purely because no resolver exists yet to make FormatConfig's
+    // OWN runtime fields trustworthy for Custom. This is the discriminating
+    // case that would have silently passed under an id-only check.
     let rules = sample_rules(5);
-    let valid = FormatConfig {
+    let looks_fine = FormatConfig {
         format: GameFormat::Custom(rules.id),
         custom_rules: Some(Box::new(rules)),
         ..FormatConfig::standard()
     };
-    let json = serde_json::to_value(&valid).unwrap();
+    let json = serde_json::to_value(&looks_fine).unwrap();
     assert!(
-        serde_json::from_value::<FormatConfig>(json).is_ok(),
-        "a consistent Custom FormatConfig must still deserialize successfully"
+        serde_json::from_value::<FormatConfig>(json).is_err(),
+        "Custom format activation must be rejected until a resolver exists, even when \
+         custom_rules is internally consistent and its id matches"
+    );
+}
+
+#[test]
+fn format_config_deserialization_rejects_matching_id_but_structurally_contradictory_payload() {
+    // The specific hostile case the maintainer's review named: a
+    // matching-id Custom payload whose CommandZoneMode declares Disabled in
+    // custom_rules.structural while FormatConfig's own independent
+    // command_zone/uses_commander/commander_damage_threshold fields claim
+    // the format DOES use a command zone. An id-only consistency check
+    // would accept this; the categorical Custom rejection does not.
+    let mut rules = sample_rules(5);
+    rules.structural.command_zone_mode = CommandZoneMode::Disabled;
+    let contradictory = FormatConfig {
+        format: GameFormat::Custom(rules.id),
+        custom_rules: Some(Box::new(rules)),
+        command_zone: true,
+        uses_commander: true,
+        commander_damage_threshold: Some(21),
+        ..FormatConfig::standard()
+    };
+    let json = serde_json::to_value(&contradictory).unwrap();
+    assert!(
+        serde_json::from_value::<FormatConfig>(json).is_err(),
+        "a matching-id Custom payload whose runtime fields contradict custom_rules.structural \
+         must still be rejected"
+    );
+}
+
+#[test]
+fn persisted_game_state_restore_rejects_custom_format_config() {
+    // Empirically proves the rejection reaches the real restore/resume
+    // chokepoint engine-wasm's decode_restored_game_state calls
+    // (serde_json::from_value::<PersistedGameState>), not just a
+    // FormatConfig-in-isolation unit test. Builds a normal, valid
+    // two-player GameState, swaps in a Custom format_config the same way an
+    // attacker-controlled restore payload would, then round-trips the whole
+    // persisted envelope.
+    use engine::types::game_state::{GameState, PersistedGameState};
+
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    let rules = sample_rules(5);
+    state.format_config = FormatConfig {
+        format: GameFormat::Custom(rules.id),
+        custom_rules: Some(Box::new(rules)),
+        ..FormatConfig::standard()
+    };
+    let persisted = PersistedGameState::capture(state);
+    let json = serde_json::to_value(&persisted).unwrap();
+    assert!(
+        serde_json::from_value::<PersistedGameState>(json).is_err(),
+        "restoring a persisted GameState with a Custom format_config must be rejected, \
+         mirroring engine-wasm's decode_restored_game_state chokepoint"
     );
 }

--- a/crates/engine/tests/integration/custom_format_schema.rs
+++ b/crates/engine/tests/integration/custom_format_schema.rs
@@ -1,0 +1,445 @@
+//! Schema-level tests for the custom-format engine core (Phase 1a). No
+//! evaluator exists yet — these tests cover construction, serde round-trip,
+//! the `GameFormat::Custom` wire format, the two registration gates against
+//! synthetic values, and the disclosed non-panicking fallbacks for methods
+//! that cannot resolve a Custom format's real values from a bare
+//! `GameFormat` alone. Never real deck-legality enforcement (that's Phase 1d).
+
+use engine::types::custom_format::{
+    passes_legacy_axis_gate, passes_reprint_fidelity_gate, validate_custom_rules_consistency,
+    CombatDamageTiming, CommanderEligibilityRule, CustomFormatDef, CustomFormatId,
+    CustomFormatRules, LegacyRuleSet, LegalityRules, ManaBurnPolicy, PrintingFidelity,
+    ReprintPolicy, SetCode, StructuralRules, WishOutsideGameScope,
+};
+use engine::types::format::{DeckCopyLimit, FormatConfig, GameFormat, SideboardPolicy};
+
+fn sample_structural() -> StructuralRules {
+    StructuralRules {
+        starting_life: 30,
+        min_players: 2,
+        max_players: 4,
+        deck_size: 60,
+        singleton: false,
+        command_zone: false,
+        commander_damage_threshold: None,
+        range_of_influence: None,
+        team_based: false,
+        sideboard_policy: SideboardPolicy::Unlimited,
+        commander_eligibility_rule: None,
+    }
+}
+
+fn sample_rules(id: u16) -> CustomFormatRules {
+    CustomFormatRules {
+        id: CustomFormatId(id),
+        structural: sample_structural(),
+        legality: LegalityRules {
+            legal_sets: None,
+            banned: Vec::new(),
+            restricted: Vec::new(),
+            legacy: LegacyRuleSet {
+                mana_burn: ManaBurnPolicy::default(),
+                damage_timing: CombatDamageTiming::default(),
+                wish_scope: WishOutsideGameScope::default(),
+                legend_rule_scope: engine::types::custom_format::LegendRuleScope::default(),
+            },
+        },
+    }
+}
+
+fn sample_def(id: u16) -> CustomFormatDef {
+    CustomFormatDef {
+        rules: sample_rules(id),
+        label: "Sample Custom Format".to_string(),
+        short_label: "SCF".to_string(),
+        description: "A test-only custom format".to_string(),
+        reprint_policy: None,
+        printing_fidelity: PrintingFidelity::NotApplicable,
+    }
+}
+
+#[test]
+fn custom_format_rules_serde_roundtrip() {
+    let rules = sample_rules(5);
+    let json = serde_json::to_string(&rules).unwrap();
+    let back: CustomFormatRules = serde_json::from_str(&json).unwrap();
+    assert_eq!(rules, back);
+}
+
+#[test]
+fn custom_format_def_serde_roundtrip() {
+    let def = sample_def(5);
+    let json = serde_json::to_string(&def).unwrap();
+    let back: CustomFormatDef = serde_json::from_str(&json).unwrap();
+    assert_eq!(def, back);
+}
+
+#[test]
+fn legal_sets_none_and_some_are_distinguishable() {
+    let unrestricted = LegalityRules {
+        legal_sets: None,
+        banned: Vec::new(),
+        restricted: Vec::new(),
+        legacy: sample_rules(0).legality.legacy,
+    };
+    let restricted = LegalityRules {
+        legal_sets: Some(vec![SetCode("LEA".to_string())]),
+        ..unrestricted.clone()
+    };
+    let unrestricted_json = serde_json::to_value(&unrestricted).unwrap();
+    let restricted_json = serde_json::to_value(&restricted).unwrap();
+    assert_ne!(unrestricted_json, restricted_json);
+    assert_eq!(unrestricted_json["legal_sets"], serde_json::Value::Null);
+    assert_eq!(restricted_json["legal_sets"][0], "LEA");
+}
+
+#[test]
+fn validate_custom_rules_consistency_accepts_matching_id() {
+    let rules = sample_rules(5);
+    let config = FormatConfig {
+        custom_rules: Some(rules.clone()),
+        ..FormatConfig {
+            format: GameFormat::Custom(rules.id),
+            ..FormatConfig::standard()
+        }
+    };
+    assert!(validate_custom_rules_consistency(&config).is_ok());
+}
+
+#[test]
+fn validate_custom_rules_consistency_rejects_mismatched_id() {
+    let config = FormatConfig {
+        format: GameFormat::Custom(CustomFormatId(5)),
+        custom_rules: Some(sample_rules(7)),
+        ..FormatConfig::standard()
+    };
+    assert!(validate_custom_rules_consistency(&config).is_err());
+}
+
+#[test]
+fn validate_custom_rules_consistency_rejects_custom_without_rules() {
+    let config = FormatConfig {
+        format: GameFormat::Custom(CustomFormatId(5)),
+        custom_rules: None,
+        ..FormatConfig::standard()
+    };
+    assert!(validate_custom_rules_consistency(&config).is_err());
+}
+
+#[test]
+fn validate_custom_rules_consistency_rejects_builtin_with_custom_rules() {
+    let config = FormatConfig {
+        format: GameFormat::Standard,
+        custom_rules: Some(sample_rules(5)),
+        ..FormatConfig::standard()
+    };
+    assert!(validate_custom_rules_consistency(&config).is_err());
+}
+
+#[test]
+fn validate_custom_rules_consistency_accepts_every_builtin_default() {
+    for meta in GameFormat::registry() {
+        let config = FormatConfig::for_format(meta.format);
+        assert!(
+            validate_custom_rules_consistency(&config).is_ok(),
+            "{:?}: built-in default config must be accepted",
+            meta.format
+        );
+    }
+}
+
+#[test]
+fn legacy_axis_gate_rejects_undeclared_axis() {
+    let mut def = sample_def(1);
+    def.rules.legality.legacy.mana_burn = ManaBurnPolicy::Legacy;
+    assert!(!passes_legacy_axis_gate(&def));
+}
+
+#[test]
+fn legacy_axis_gate_accepts_all_default_axes() {
+    let def = sample_def(2);
+    assert!(passes_legacy_axis_gate(&def));
+}
+
+#[test]
+fn reprint_fidelity_gate_rejects_mismatch() {
+    let mut def = sample_def(3);
+    def.reprint_policy = Some(ReprintPolicy::OriginalPrintingsOnly);
+    def.printing_fidelity = PrintingFidelity::NotApplicable;
+    assert!(!passes_reprint_fidelity_gate(&def));
+
+    let mut def2 = sample_def(4);
+    def2.reprint_policy = None;
+    def2.printing_fidelity = PrintingFidelity::SetCodeApproximation;
+    assert!(!passes_reprint_fidelity_gate(&def2));
+}
+
+#[test]
+fn reprint_fidelity_gate_accepts_agreement() {
+    let mut def = sample_def(5);
+    def.reprint_policy = Some(ReprintPolicy::AllowAnyPrinting);
+    def.printing_fidelity = PrintingFidelity::SetCodeApproximation;
+    assert!(passes_reprint_fidelity_gate(&def));
+
+    let def2 = sample_def(6);
+    assert!(passes_reprint_fidelity_gate(&def2));
+}
+
+#[test]
+fn custom_format_registry_is_empty_in_phase_1a() {
+    assert!(engine::types::custom_format::custom_format_registry().is_empty());
+}
+
+#[test]
+fn game_format_from_str_display_roundtrip_builtins() {
+    let all = [
+        GameFormat::Standard,
+        GameFormat::Limited,
+        GameFormat::Commander,
+        GameFormat::Pioneer,
+        GameFormat::Modern,
+        GameFormat::Premodern,
+        GameFormat::Legacy,
+        GameFormat::Vintage,
+        GameFormat::Historic,
+        GameFormat::Timeless,
+        GameFormat::Pauper,
+        GameFormat::PauperCommander,
+        GameFormat::DuelCommander,
+        GameFormat::TinyLeaders,
+        GameFormat::Oathbreaker,
+        GameFormat::Brawl,
+        GameFormat::HistoricBrawl,
+        GameFormat::FreeForAll,
+        GameFormat::TwoHeadedGiant,
+        GameFormat::Archenemy,
+        GameFormat::Planechase,
+        GameFormat::Momir,
+    ];
+    assert_eq!(all.len(), 22);
+    for format in all {
+        let s = format.to_string();
+        let back: GameFormat = s.parse().unwrap();
+        assert_eq!(format, back);
+    }
+}
+
+#[test]
+fn game_format_from_str_display_roundtrip_custom() {
+    for id in [0u16, 5, u16::MAX] {
+        let format = GameFormat::Custom(CustomFormatId(id));
+        let s = format.to_string();
+        assert_eq!(s, format!("Custom:{id}"));
+        let back: GameFormat = s.parse().unwrap();
+        assert_eq!(format, back);
+    }
+}
+
+#[test]
+fn game_format_serde_roundtrip_builtin_and_custom() {
+    let json = serde_json::to_string(&GameFormat::Commander).unwrap();
+    assert_eq!(json, "\"Commander\"");
+    let back: GameFormat = serde_json::from_str(&json).unwrap();
+    assert_eq!(back, GameFormat::Commander);
+
+    let custom_json = serde_json::to_string(&GameFormat::Custom(CustomFormatId(5))).unwrap();
+    assert_eq!(custom_json, "\"Custom:5\"");
+    let back: GameFormat = serde_json::from_str(&custom_json).unwrap();
+    assert_eq!(back, GameFormat::Custom(CustomFormatId(5)));
+}
+
+#[test]
+fn game_format_deserialize_rejects_malformed_custom_strings() {
+    for bad in [
+        "\"Custom:\"",
+        "\"Custom:abc\"",
+        "\"Custom:-1\"",
+        "\"Custom:70000\"",
+        "\"custom:5\"",
+        "\"CustomFormat:5\"",
+        "\"NotARealFormat\"",
+        "{}",
+        "42",
+    ] {
+        assert!(
+            serde_json::from_str::<GameFormat>(bad).is_err(),
+            "expected {bad} to fail to deserialize as GameFormat"
+        );
+    }
+}
+
+#[test]
+fn game_format_deserialize_accepts_valid_custom_string() {
+    let back: GameFormat = serde_json::from_str("\"Custom:5\"").unwrap();
+    assert_eq!(back, GameFormat::Custom(CustomFormatId(5)));
+}
+
+#[test]
+fn commander_eligibility_rule_from_source_format_covers_every_builtin() {
+    use CommanderEligibilityRule::*;
+    let cases = [
+        (GameFormat::Standard, None),
+        (GameFormat::Limited, None),
+        (GameFormat::Commander, Some(Standard)),
+        (GameFormat::Pioneer, None),
+        (GameFormat::Modern, None),
+        (GameFormat::Premodern, None),
+        (GameFormat::Legacy, None),
+        (GameFormat::Vintage, None),
+        (GameFormat::Historic, None),
+        (GameFormat::Timeless, None),
+        (GameFormat::Pauper, None),
+        (GameFormat::PauperCommander, Some(Standard)),
+        (GameFormat::DuelCommander, Some(Standard)),
+        (GameFormat::TinyLeaders, Some(TinyLeaders)),
+        (GameFormat::Oathbreaker, Some(OathbreakerSignatureSpell)),
+        (GameFormat::Brawl, Some(BrawlColorIdentity)),
+        (GameFormat::HistoricBrawl, Some(BrawlColorIdentity)),
+        (GameFormat::FreeForAll, None),
+        (GameFormat::TwoHeadedGiant, None),
+        (GameFormat::Archenemy, None),
+        (GameFormat::Planechase, None),
+        (GameFormat::Momir, None),
+    ];
+    for (format, expected) in cases {
+        assert_eq!(
+            CommanderEligibilityRule::from_source_format(format),
+            expected,
+            "{format:?}"
+        );
+    }
+}
+
+#[test]
+fn game_format_serialization_is_byte_identical_to_old_derive_for_builtins() {
+    let expectations: &[(GameFormat, &str)] = &[
+        (GameFormat::Standard, "Standard"),
+        (GameFormat::Limited, "Limited"),
+        (GameFormat::Commander, "Commander"),
+        (GameFormat::Pioneer, "Pioneer"),
+        (GameFormat::Modern, "Modern"),
+        (GameFormat::Premodern, "Premodern"),
+        (GameFormat::Legacy, "Legacy"),
+        (GameFormat::Vintage, "Vintage"),
+        (GameFormat::Historic, "Historic"),
+        (GameFormat::Timeless, "Timeless"),
+        (GameFormat::Pauper, "Pauper"),
+        (GameFormat::PauperCommander, "PauperCommander"),
+        (GameFormat::DuelCommander, "DuelCommander"),
+        (GameFormat::TinyLeaders, "TinyLeaders"),
+        (GameFormat::Oathbreaker, "Oathbreaker"),
+        (GameFormat::Brawl, "Brawl"),
+        (GameFormat::HistoricBrawl, "HistoricBrawl"),
+        (GameFormat::FreeForAll, "FreeForAll"),
+        (GameFormat::TwoHeadedGiant, "TwoHeadedGiant"),
+        (GameFormat::Archenemy, "Archenemy"),
+        (GameFormat::Planechase, "Planechase"),
+        (GameFormat::Momir, "Momir"),
+    ];
+    assert_eq!(expectations.len(), 22);
+    for (format, expected) in expectations {
+        let value = serde_json::to_value(format).unwrap();
+        assert_eq!(value, serde_json::Value::String(expected.to_string()));
+    }
+}
+
+#[test]
+fn format_config_for_format_still_works_for_every_builtin() {
+    for meta in GameFormat::registry() {
+        let config = FormatConfig::for_format(meta.format);
+        assert!(matches!(
+            config.format.default_deck_copy_limit(),
+            DeckCopyLimit::Unlimited | DeckCopyLimit::UpTo(_)
+        ));
+    }
+}
+
+#[test]
+fn custom_format_sideboard_policy_returns_disclosed_fallback_not_panic() {
+    assert_eq!(
+        GameFormat::Custom(CustomFormatId(1)).sideboard_policy(),
+        SideboardPolicy::Forbidden
+    );
+}
+
+#[test]
+fn custom_format_default_deck_copy_limit_returns_disclosed_fallback_not_panic() {
+    assert_eq!(
+        GameFormat::Custom(CustomFormatId(1)).default_deck_copy_limit(),
+        DeckCopyLimit::UpTo(1)
+    );
+}
+
+#[test]
+fn custom_format_label_falls_back_when_id_is_not_registered() {
+    assert_eq!(
+        GameFormat::Custom(CustomFormatId(1)).label(),
+        "Custom Format"
+    );
+}
+
+#[test]
+fn custom_format_deck_compatibility_summary_reports_not_yet_supported() {
+    use engine::database::CardDatabase;
+    use engine::game::deck_validation::{evaluate_deck_compatibility, DeckCompatibilityRequest};
+
+    let db = CardDatabase::from_json_str("{}").expect("empty card database");
+    let request = DeckCompatibilityRequest {
+        selected_format: Some(GameFormat::Custom(CustomFormatId(1))),
+        summary_only: true,
+        ..Default::default()
+    };
+    let result = evaluate_deck_compatibility(&db, &request);
+    assert_eq!(result.selected_format_compatible, Some(false));
+    assert!(result
+        .selected_format_reasons
+        .iter()
+        .any(|r| r.contains("not yet supported")));
+}
+
+#[test]
+fn custom_format_deck_compatibility_reports_not_yet_supported() {
+    use engine::database::CardDatabase;
+    use engine::game::deck_validation::{evaluate_deck_compatibility, DeckCompatibilityRequest};
+
+    let db = CardDatabase::from_json_str("{}").expect("empty card database");
+    let request = DeckCompatibilityRequest {
+        selected_format: Some(GameFormat::Custom(CustomFormatId(1))),
+        summary_only: false,
+        ..Default::default()
+    };
+    let result = evaluate_deck_compatibility(&db, &request);
+    assert_eq!(result.selected_format_compatible, Some(false));
+    assert!(result
+        .selected_format_reasons
+        .iter()
+        .any(|r| r.contains("not yet supported")));
+}
+
+#[test]
+fn validate_name_deck_for_format_full_rejects_custom_format_honestly() {
+    use engine::database::CardDatabase;
+    use engine::game::deck_validation::validate_name_deck_for_format_full;
+
+    let db = CardDatabase::from_json_str("{}").expect("empty card database");
+    // The real signature takes every deck slot explicitly, plus a match type
+    // and a player count — not the three-argument shape an earlier planning
+    // pass assumed.
+    let result = validate_name_deck_for_format_full(
+        &db,
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        &[],
+        GameFormat::Custom(CustomFormatId(1)),
+        None,
+        2,
+    );
+    match result {
+        Err(reasons) => assert!(reasons.iter().any(|r| r.contains("not yet supported"))),
+        Ok(()) => panic!("expected Custom format validation to be rejected as not yet supported"),
+    }
+}

--- a/crates/engine/tests/integration/custom_format_schema.rs
+++ b/crates/engine/tests/integration/custom_format_schema.rs
@@ -97,7 +97,7 @@ fn legal_sets_none_and_some_are_distinguishable() {
 fn validate_custom_rules_consistency_accepts_matching_id() {
     let rules = sample_rules(5);
     let config = FormatConfig {
-        custom_rules: Some(rules.clone()),
+        custom_rules: Some(Box::new(rules.clone())),
         ..FormatConfig {
             format: GameFormat::Custom(rules.id),
             ..FormatConfig::standard()
@@ -110,7 +110,7 @@ fn validate_custom_rules_consistency_accepts_matching_id() {
 fn validate_custom_rules_consistency_rejects_mismatched_id() {
     let config = FormatConfig {
         format: GameFormat::Custom(CustomFormatId(5)),
-        custom_rules: Some(sample_rules(7)),
+        custom_rules: Some(Box::new(sample_rules(7))),
         ..FormatConfig::standard()
     };
     assert!(validate_custom_rules_consistency(&config).is_err());
@@ -130,7 +130,7 @@ fn validate_custom_rules_consistency_rejects_custom_without_rules() {
 fn validate_custom_rules_consistency_rejects_builtin_with_custom_rules() {
     let config = FormatConfig {
         format: GameFormat::Standard,
-        custom_rules: Some(sample_rules(5)),
+        custom_rules: Some(Box::new(sample_rules(5))),
         ..FormatConfig::standard()
     };
     assert!(validate_custom_rules_consistency(&config).is_err());

--- a/crates/engine/tests/integration/custom_format_schema.rs
+++ b/crates/engine/tests/integration/custom_format_schema.rs
@@ -583,3 +583,44 @@ fn persisted_game_state_restore_rejects_custom_format_config() {
          mirroring engine-wasm's decode_restored_game_state chokepoint"
     );
 }
+
+#[test]
+fn companion_reveal_check_does_not_panic_for_an_in_memory_custom_format_config() {
+    // The maintainer's review found that rejecting Custom at the external
+    // deserialization boundary doesn't make GameFormat::Custom safe
+    // in-memory: game/companion.rs's check_companion_reveal reads
+    // state.format_config on ANY live GameState (built-in or Custom,
+    // constructed directly in Rust, never through Deserialize), and used to
+    // call the bare GameFormat's uses_commander() internally — which
+    // panics for Custom. This proves the fix (reading the resolved
+    // FormatConfig.uses_commander field instead) reaches the real
+    // production entry point rather than just the unit-level helpers.
+    use engine::types::game_state::{GameState, PlayerDeckPool};
+    use engine::types::PlayerId;
+
+    let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+    let rules = sample_rules(5);
+    state.format_config = FormatConfig {
+        format: GameFormat::Custom(rules.id),
+        custom_rules: Some(Box::new(rules)),
+        uses_commander: true,
+        ..FormatConfig::standard()
+    };
+    state.deck_pools = vec![
+        PlayerDeckPool {
+            player: PlayerId(0),
+            ..Default::default()
+        },
+        PlayerDeckPool {
+            player: PlayerId(1),
+            ..Default::default()
+        },
+    ];
+
+    // No companion is registered in either empty pool, so the honest answer
+    // is "no reveal offer" — the discriminating claim is that this returns
+    // a defined result at all, rather than panicking on GameFormat::Custom's
+    // uses_commander() inside companion_offers/companion_starting_deck.
+    let result = engine::game::companion::check_all_companion_reveals(&state);
+    assert!(result.is_none());
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -171,6 +171,7 @@ mod curse_of_the_restless_dead_land_enters_trigger;
 mod curse_spell_cast_triggers;
 mod curse_static_effects;
 mod curse_upkeep_triggers;
+mod custom_format_schema;
 mod cut_a_deal_draw_this_way_count;
 mod cybership_combat_damage_manifest;
 mod dalkovan_encampment_attack_trigger;


### PR DESCRIPTION
## Summary

Phase 1a of the custom-format-engine charter approved in #7703 — the general engine schema only, no registration, no deck-legality evaluation, no frontend/WASM changes. Subsequent phases (1b–2cd) are planned and will land as separate PRs; a docs-only PR publishing the full phased plan is following this one for visibility.

- `GameFormat::Custom(CustomFormatId)` variant, plus the supporting schema in a new `crates/engine/src/types/custom_format.rs`: `CustomFormatId`/`SetCode`, `StructuralRules`/`LegalityRules`/`CustomFormatRules`/`CustomFormatDef`, the four `LegacyRuleSet` axes (schema only — an unimplemented-axis registration gate keeps them from being declarable by any preset until a later phase wires real behavior), and the reprint/printing-fidelity pairing gate carried over from #7703's design.
- `GameFormat` moves from `#[derive(Serialize, Deserialize)]` to hand-written impls (matching the `Keyword`/`ResolutionStateWire` precedent) so the wire format stays a plain string — byte-identical for all 22 existing variants, `"Custom:<id>"` for the new one.
- Every exhaustive match over `GameFormat` gains a `Custom` arm. Two of them (`sideboard_policy`, `default_deck_copy_limit`) return a disclosed, fail-closed fallback rather than panicking, because they're reachable from untrusted WASM input today even though nothing can construct a real custom format until a later phase — see "Safety" below.

## Safety

Adding a variant that deserializes from external input immediately makes it reachable at several existing `engine-wasm` entry points that predate this change, before any UI to construct one legitimately exists. This PR closes every panic path that's live today:

- `sideboard_policy()`/`default_deck_copy_limit()` return documented fail-closed fallbacks (`Forbidden` / `UpTo(1)`) instead of `unreachable!()`.
- The two `deck_validation.rs` format-dispatch functions, and `companion_candidates` (directly exposed via `companion_candidates_js`), return an honest "not yet supported" result before any bare-`GameFormat` method that would otherwise panic.
- Traced end-to-end against `initialize_game_impl`: the deck-validation gate now unconditionally rejects a `Custom` format before `load_and_hydrate_decks` runs, so the still-panicking bare-`GameFormat` calls in `companion.rs`/`deck_loading.rs`/`match_flow.rs` (chartered to the next phase, which migrates them to read the resolved `FormatConfig` instead) are unreachable today.
- `uses_commander()` and `for_format()` remain permanent `unreachable!()` — their correct answer requires the resolved `FormatConfig`/`CustomFormatRules`, which a bare `GameFormat` can't supply, and nothing reachable calls them with a bare `Custom` value after the above fixes.

## Test plan

- [x] `cargo check -p phase-engine` clean
- [x] `cargo clippy -p phase-engine --all-targets -- -D warnings` clean
- [x] `cargo test -p phase-engine` — 19638 lib + 5413 integration passing (one pre-existing, unrelated integration test fails in this environment only due to a missing `python3` on PATH; untouched by this diff, no `GameFormat` reference)
- [x] 27 new tests in `custom_format_schema.rs`: schema construction/round-trip, wire-format round-trip (incl. hostile malformed-string cases), registration-gate accept/reject, disclosed-fallback assertions, and 3 tests driving the real `evaluate_deck_compatibility`/`validate_name_deck_for_format_full` production pipeline end-to-end (these panic if the safety fix is reverted, rather than passing vacuously)
- [x] Workspace-wide sweep for any other exhaustive `GameFormat` match outside the touched files — none found

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NQ1bpYEt331DvjqPLSFJEH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added foundational support for defining, identifying, validating, and serializing custom game formats.
  - Added custom-format rules and configuration consistency checks.

- **Bug Fixes**
  - Custom formats now fail gracefully with a clear “not yet supported” message instead of causing crashes.
  - Improved custom-format handling across deck validation, companion checks, and compatibility validation.
  - Built-in format configuration errors are now reported safely.

- **Tests**
  - Added coverage for custom-format schemas, serialization, consistency, compatibility, and validation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->