### PR TITLE
fix(parser,engine): scope bare-plural enters-with subjects and match entry filters against the face-down profile

### DIFF
--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -2449,6 +2449,20 @@ pub fn matches_target_filter_for_zone(
     }
 }
 
+/// The object a battlefield entry is about to deliver, as currently staged:
+/// the liminal projection when one exists, otherwise the live object. Shared
+/// by every entry-projection arm below so the resolution logic cannot drift.
+fn entering_object_projection(
+    state: &GameState,
+    object_id: &ObjectId,
+) -> Option<crate::game::game_object::GameObject> {
+    state
+        .liminal_entries
+        .get(object_id)
+        .map(|entry| entry.object.projected().clone())
+        .or_else(|| state.objects.get(object_id).cloned())
+}
+
 pub fn matches_target_filter_on_battlefield_entry(
     state: &GameState,
     event: &ProposedEvent,
@@ -2463,23 +2477,18 @@ pub fn matches_target_filter_on_battlefield_entry(
             face_down_profile,
             ..
         } if *to == Zone::Battlefield => {
-            if let Some(copy) = enter_as_copy {
-                let Some(mut obj) = state
-                    .liminal_entries
-                    .get(object_id)
-                    .map(|entry| entry.object.projected().clone())
-                    .or_else(|| state.objects.get(object_id).cloned())
-                else {
+            if let Some(profile) = face_down_profile {
+                // CR 708.2a + CR 708.3 + CR 614.12: an object entering face
+                // down IS the profile's body (a colorless 2/2 creature for
+                // manifest/morph/cloak) — checked BEFORE the copy arm, because
+                // a co-occurring enter-as-copy keeps the permanent face down
+                // and only its copiable underside changes; the observable
+                // entry characteristics stay the face-down profile.
+                let Some(mut obj) = entering_object_projection(state, object_id) else {
                     return false;
                 };
-                crate::game::effects::token::apply_copiable_values_to_liminal_object(
-                    &mut obj,
-                    &copy.values,
-                    copy.display_source,
-                    copy.printed_ref.clone(),
-                    copy.token_image_ref.clone(),
-                );
-                filter_inner_for_object(
+                crate::game::morph::apply_face_down_creature_characteristics(&mut obj, profile);
+                return filter_inner_for_object(
                     state,
                     &obj,
                     *object_id,
@@ -2491,25 +2500,19 @@ pub fn matches_target_filter_on_battlefield_entry(
                     ctx.recipient_id,
                     ctx.scoped_iteration_player,
                     ControllerLookup::LiveOrLki,
-                )
-            } else if let Some(profile) = face_down_profile {
-                // CR 708.2a + CR 614.12: the object would enter as the
-                // face-down profile's body (a colorless 2/2 creature for
-                // manifest/morph/cloak), so entry-scoped filters must be
-                // evaluated against that projection, not the card's face-up
-                // characteristics — Curator Beastie's "colorless creatures you
-                // control enter with two additional +1/+1 counters" must see
-                // the manifested 2/2 (issue #7821), and a face-up card's types
-                // must not leak into entry matching.
-                let Some(mut obj) = state
-                    .liminal_entries
-                    .get(object_id)
-                    .map(|entry| entry.object.projected().clone())
-                    .or_else(|| state.objects.get(object_id).cloned())
-                else {
+                );
+            }
+            if let Some(copy) = enter_as_copy {
+                let Some(mut obj) = entering_object_projection(state, object_id) else {
                     return false;
                 };
-                crate::game::morph::apply_face_down_creature_characteristics(&mut obj, profile);
+                crate::game::effects::token::apply_copiable_values_to_liminal_object(
+                    &mut obj,
+                    &copy.values,
+                    copy.display_source,
+                    copy.printed_ref.clone(),
+                    copy.token_image_ref.clone(),
+                );
                 filter_inner_for_object(
                     state,
                     &obj,

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -2460,6 +2460,7 @@ pub fn matches_target_filter_on_battlefield_entry(
             object_id,
             to,
             enter_as_copy,
+            face_down_profile,
             ..
         } if *to == Zone::Battlefield => {
             if let Some(copy) = enter_as_copy {
@@ -2478,6 +2479,37 @@ pub fn matches_target_filter_on_battlefield_entry(
                     copy.printed_ref.clone(),
                     copy.token_image_ref.clone(),
                 );
+                filter_inner_for_object(
+                    state,
+                    &obj,
+                    *object_id,
+                    filter,
+                    ctx.source_id,
+                    ctx.source_controller,
+                    ctx.ability,
+                    ctx.trigger_source,
+                    ctx.recipient_id,
+                    ctx.scoped_iteration_player,
+                    ControllerLookup::LiveOrLki,
+                )
+            } else if let Some(profile) = face_down_profile {
+                // CR 708.2a + CR 614.12: the object would enter as the
+                // face-down profile's body (a colorless 2/2 creature for
+                // manifest/morph/cloak), so entry-scoped filters must be
+                // evaluated against that projection, not the card's face-up
+                // characteristics — Curator Beastie's "colorless creatures you
+                // control enter with two additional +1/+1 counters" must see
+                // the manifested 2/2 (issue #7821), and a face-up card's types
+                // must not leak into entry matching.
+                let Some(mut obj) = state
+                    .liminal_entries
+                    .get(object_id)
+                    .map(|entry| entry.object.projected().clone())
+                    .or_else(|| state.objects.get(object_id).cloned())
+                else {
+                    return false;
+                };
+                crate::game::morph::apply_face_down_creature_characteristics(&mut obj, profile);
                 filter_inner_for_object(
                     state,
                     &obj,

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -2478,12 +2478,13 @@ pub fn matches_target_filter_on_battlefield_entry(
             ..
         } if *to == Zone::Battlefield => {
             if let Some(profile) = face_down_profile {
-                // CR 708.2a + CR 708.3 + CR 614.12: an object entering face
-                // down IS the profile's body (a colorless 2/2 creature for
-                // manifest/morph/cloak) — checked BEFORE the copy arm, because
-                // a co-occurring enter-as-copy keeps the permanent face down
-                // and only its copiable underside changes; the observable
-                // entry characteristics stay the face-down profile.
+                // CR 708.2a + CR 708.3 + CR 708.10 + CR 614.12: an object
+                // entering face down IS the profile's body (a colorless 2/2
+                // creature for manifest/morph/cloak) — checked BEFORE the copy
+                // arm, because a face-down permanent that becomes a copy keeps
+                // the face-down characteristics (CR 708.10): only its copiable
+                // underside changes, and the observable entry characteristics
+                // stay the face-down profile.
                 let Some(mut obj) = entering_object_projection(state, object_id) else {
                     return false;
                 };
@@ -14529,6 +14530,96 @@ mod tests {
                 FaceControllerScope::AssumeOwn
             ),
             "a definitely-matching alternative admits even beside an unknown"
+        );
+    }
+
+    /// CR 708.10 + CR 708.2a: a `ZoneChange` carrying BOTH `enter_as_copy` AND
+    /// `face_down_profile` matches entry filters as the face-down 2/2 — a
+    /// face-down permanent that becomes a copy keeps the face-down
+    /// characteristics; only its copiable underside changes. Discriminator for
+    /// the arm ordering in `matches_target_filter_on_battlefield_entry`:
+    /// reverse the arms and BOTH assertions flip (the green copied face would
+    /// match as face-up and the colorless face-down body would not).
+    #[test]
+    fn a_face_down_copy_entry_matches_as_the_face_down_body() {
+        use crate::types::ability::{FaceDownProfile, TypeFilter};
+        use crate::types::proposed_event::{CopyTokenSpec, ProposedEvent};
+
+        let mut state = GameState::new_two_player(42);
+        let entering = create_object(
+            &mut state,
+            CardId(900),
+            PlayerId(0),
+            "Copying Entrant".to_string(),
+            Zone::Library,
+        );
+        let green_source = create_object(
+            &mut state,
+            CardId(901),
+            PlayerId(0),
+            "Green Original".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&green_source).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.color = vec![ManaColor::Green];
+            obj.power = Some(3);
+            obj.toughness = Some(3);
+        }
+        let values =
+            crate::game::printed_cards::intrinsic_copiable_values(&state.objects[&green_source]);
+
+        let mut event =
+            ProposedEvent::zone_change(entering, Zone::Library, Zone::Battlefield, None);
+        if let ProposedEvent::ZoneChange {
+            enter_as_copy,
+            face_down_profile,
+            ..
+        } = &mut event
+        {
+            *enter_as_copy = Some(Box::new(CopyTokenSpec {
+                values: Box::new(values),
+                display_source: crate::game::game_object::DisplaySource::Token,
+                printed_ref: None,
+                token_image_ref: None,
+                extra_keywords: vec![],
+                additional_modifications: vec![],
+                tapped: false,
+                enters_attacking: false,
+                sacrifice_at: None,
+                source_id: ObjectId(0),
+                controller: PlayerId(0),
+            }));
+            *face_down_profile = Some(Box::new(FaceDownProfile::vanilla_2_2()));
+        } else {
+            unreachable!();
+        }
+
+        let ctx = FilterContext::from_source(&state, entering);
+        let colorless_creatures = TargetFilter::Typed(
+            TypedFilter::new(TypeFilter::Creature)
+                .controller(ControllerRef::You)
+                .properties(vec![FilterProp::ColorCount {
+                    comparator: Comparator::EQ,
+                    count: 0,
+                }]),
+        );
+        let green_creatures = TargetFilter::Typed(
+            TypedFilter::new(TypeFilter::Creature)
+                .controller(ControllerRef::You)
+                .properties(vec![FilterProp::HasColor {
+                    color: ManaColor::Green,
+                }]),
+        );
+
+        assert!(
+            matches_target_filter_on_battlefield_entry(&state, &event, &colorless_creatures, &ctx),
+            "the face-down body (colorless 2/2 creature) must match"
+        );
+        assert!(
+            !matches_target_filter_on_battlefield_entry(&state, &event, &green_creatures, &ctx),
+            "the copied green face must NOT leak into entry matching (CR 708.10)"
         );
     }
 }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_ir.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1333
 expression: "&ir"
 ---
 {
@@ -25,7 +24,7 @@ expression: "&ir"
       "node": {
         "Replacement": {
           "definition": {
-            "event": "Moved",
+            "event": "ChangeZone",
             "execute": {
               "kind": "Spell",
               "effect": {
@@ -53,7 +52,17 @@ expression: "&ir"
               "type": "Mandatory"
             },
             "valid_card": {
-              "type": "SelfRef"
+              "type": "Typed",
+              "type_filters": [
+                "Creature"
+              ],
+              "controller": "You",
+              "properties": [
+                {
+                  "type": "HasSupertype",
+                  "value": "Legendary"
+                }
+              ]
             },
             "description": "Legendary creatures you control enter with an additional +1/+1 counter on them.",
             "condition": null,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__bard_class_lowered.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
-assertion_line: 1334
 expression: "&lowered"
 ---
 {
@@ -214,7 +213,7 @@ expression: "&lowered"
   ],
   "replacements": [
     {
-      "event": "Moved",
+      "event": "ChangeZone",
       "execute": {
         "kind": "Spell",
         "effect": {
@@ -242,7 +241,17 @@ expression: "&lowered"
         "type": "Mandatory"
       },
       "valid_card": {
-        "type": "SelfRef"
+        "type": "Typed",
+        "type_filters": [
+          "Creature"
+        ],
+        "controller": "You",
+        "properties": [
+          {
+            "type": "HasSupertype",
+            "value": "Legendary"
+          }
+        ]
       },
       "description": "Legendary creatures you control enter with an additional +1/+1 counter on them.",
       "condition": null,

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4219,7 +4219,7 @@ fn parse_enters_with_counters(
             .then_some((work_text, SubjectScope::Distributive))
         })
         .and_then(|(subject_text, scope)| {
-            // CR 105.2a + CR 105.2b: peel a leading color-quality word ("colorless "/
+            // CR 105.2a-105.2c: peel a leading color-quality word ("colorless "/
             // "monocolored "/"multicolored ") so the type detector sees the
             // noun and the quality survives as a filter property.
             let (after_color, color_prop) =

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -4206,16 +4206,43 @@ fn parse_enters_with_counters(
     // parse yields a typed filter with a concrete type/subtype (not the `Any`
     // fallback). A non-type subject parses to the `[Any]` fallback and is
     // rejected, falling through to the `SelfRef` self-ETB branch.
-    let subject = parse_distributive_subject(work_text).and_then(|(subject_text, scope)| {
-        let (filter, _) = parse_type_phrase(subject_text);
-        let is_valid = matches!(
-            &filter,
-            TargetFilter::Typed(TypedFilter { type_filters, .. })
-                if !type_filters.is_empty()
-                    && type_filters.as_slice() != [TypeFilter::Any]
-        );
-        is_valid.then_some((filter, scope))
-    });
+    let subject = parse_distributive_subject(work_text)
+        .or_else(|| {
+            // CR 614.12 + issue #7821: bare-plural distributive subject —
+            // "Colorless creatures you control enter with two additional +1/+1
+            // counters on them" (Curator Beastie). Only the PLURAL verb marks a
+            // bare subject: singular lines are the self-ETB "~ enters with"
+            // shape or carry the explicit each/other prefix handled above; the
+            // type-validity gate below still rejects non-subject plurals.
+            (nom_primitives::scan_contains(work_text, "enter with")
+                || nom_primitives::scan_contains(work_text, "escape with"))
+            .then_some((work_text, SubjectScope::Distributive))
+        })
+        .and_then(|(subject_text, scope)| {
+            // CR 105.2a + CR 105.2b: peel a leading color-quality word ("colorless "/
+            // "monocolored "/"multicolored ") so the type detector sees the
+            // noun and the quality survives as a filter property.
+            let (after_color, color_prop) =
+                crate::parser::oracle_static::peel_color_quality_prefix(subject_text);
+            let (filter, _) = parse_type_phrase(after_color);
+            let is_valid = matches!(
+                &filter,
+                TargetFilter::Typed(TypedFilter { type_filters, .. })
+                    if !type_filters.is_empty()
+                        && type_filters.as_slice() != [TypeFilter::Any]
+            );
+            if !is_valid {
+                return None;
+            }
+            let filter = match (filter, color_prop) {
+                (TargetFilter::Typed(mut tf), Some(prop)) => {
+                    tf.properties.insert(0, prop);
+                    TargetFilter::Typed(tf)
+                }
+                (other, _) => other,
+            };
+            Some((filter, scope))
+        });
     let valid_card = if let Some((filter, scope)) = subject {
         // CR 614.12: only the "other" scope excludes the source from the subset.
         let filter = match (filter, scope) {
@@ -16537,6 +16564,72 @@ mod tests {
         );
     }
 
+    /// Issue #7821 (Curator Beastie): the bare-plural distributive subject —
+    /// "Colorless creatures you control enter with two additional +1/+1
+    /// counters on them." Without the bare-plural arm the subject is silently
+    /// swallowed and the replacement anchors to the source's own entry
+    /// (valid_card AND counter target become SelfRef). CR 614.12: this is the
+    /// general-subset scope — the filter includes the source iff it matches
+    /// (Beastie is GU, so it simply doesn't), and no `Another` is injected.
+    #[test]
+    fn bare_plural_colorless_subject_scopes_the_enters_with_replacement() {
+        use crate::types::ability::Comparator;
+
+        let def = parse_replacement_line(
+            "Colorless creatures you control enter with two additional +1/+1 counters on them.",
+            "Curator Beastie",
+        )
+        .unwrap();
+
+        match def.valid_card.as_ref() {
+            Some(TargetFilter::Typed(tf)) => {
+                assert!(
+                    tf.type_filters.contains(&TypeFilter::Creature),
+                    "creature type filter, got {:?}",
+                    tf.type_filters
+                );
+                assert_eq!(tf.controller, Some(ControllerRef::You));
+                assert!(
+                    tf.properties.iter().any(|p| matches!(
+                        p,
+                        FilterProp::ColorCount {
+                            comparator: Comparator::EQ,
+                            count: 0
+                        }
+                    )),
+                    "colorless must survive as a color property, got {:?}",
+                    tf.properties
+                );
+                assert!(
+                    !tf.properties.contains(&FilterProp::Another),
+                    "general subset includes the source (CR 614.12), got {:?}",
+                    tf.properties
+                );
+            }
+            other => panic!("expected the typed colorless filter, got {other:?}"),
+        }
+
+        let execute = def.execute.as_ref().unwrap();
+        match &*execute.effect {
+            Effect::PutCounter {
+                counter_type,
+                count,
+                ..
+            } => {
+                assert_eq!(counter_type, &CounterType::Plus1Plus1);
+                assert!(
+                    matches!(count, QuantityExpr::Fixed { value: 2 }),
+                    "two counters, got {count:?}"
+                );
+            }
+            other => panic!("expected PutCounter, got {other:?}"),
+        }
+
+        // CR 614.12: external ETB placements ride ChangeZone so tokens are
+        // covered too (mirrors the each/other forms).
+        assert_eq!(def.event, ReplacementEvent::ChangeZone);
+    }
+
     /// CR 614.12a + CR 608.2d: Grimdancer — "enters with your choice of two
     /// different counters on it from among menace, deathtouch, and lifelink."
     /// Choosing two distinct kinds is the same decision as choosing one
@@ -16967,12 +17060,24 @@ mod tests {
     fn plural_subject_escape_with_counter_keeps_escape_condition() {
         // CR 702.138c: plural-subject "escape with" is still escape-gated, not
         // an unconditional battlefield-entry counter replacement.
+        //
+        // Since the #7821 bare-plural subject arm, the plural subject anchors
+        // the replacement to "creatures you control" (ChangeZone scope) instead
+        // of the source's own entry — the escape gate is the invariant pinned
+        // here and must survive that re-anchoring.
         let def = parse_replacement_line(
             "Creatures you control escape with a +1/+1 counter on them.",
             "Escape Anthem",
         )
         .unwrap();
-        assert_eq!(def.event, ReplacementEvent::Moved);
+        assert_eq!(def.event, ReplacementEvent::ChangeZone);
+        match def.valid_card.as_ref() {
+            Some(TargetFilter::Typed(tf)) => {
+                assert!(tf.type_filters.contains(&TypeFilter::Creature));
+                assert_eq!(tf.controller, Some(ControllerRef::You));
+            }
+            other => panic!("expected the plural-subject filter, got {other:?}"),
+        }
         assert!(matches!(
             *def.execute.as_ref().unwrap().effect,
             Effect::PutCounter {

--- a/crates/engine/src/parser/oracle_static/mod.rs
+++ b/crates/engine/src/parser/oracle_static/mod.rs
@@ -93,6 +93,7 @@ mod static_helpers;
 mod type_change;
 
 pub(crate) use shared::parse_commander_subject_filter_prefix;
+pub(crate) use shared::peel_color_quality_prefix;
 
 pub(crate) use dispatch::is_speed_unlock_sentence;
 pub(crate) use dispatch::parse_may_look_at_face_down_filter;

--- a/crates/engine/tests/integration/issue_7821_bare_plural_enters_with_counters.rs
+++ b/crates/engine/tests/integration/issue_7821_bare_plural_enters_with_counters.rs
@@ -1,0 +1,149 @@
+//! Issue #7821 (Curator Beastie): "Colorless creatures you control enter with
+//! two additional +1/+1 counters on them." — the bare-plural distributive
+//! subject used to be swallowed, anchoring the replacement to Beastie's own
+//! entry. Runtime proof over the real pipeline: a manifested face-down 2/2
+//! (colorless, CR 708.2a) enters with the two counters; a colored creature
+//! does not; Beastie itself carries none.
+//!
+//! REVERT DISCRIMINATOR: without the bare-plural subject arm the replacement
+//! is SelfRef-anchored — the manifested creature enters bare and the
+//! `== 2` assertion fails.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const BEASTIE: &str = "Reach\nColorless creatures you control enter with two additional +1/+1 counters on them.\nWhenever this creature enters or attacks, manifest dread.";
+const MANIFEST_DREAD: &str = "Manifest dread.";
+
+fn plus_counters(runner: &GameRunner, object: ObjectId) -> u32 {
+    runner
+        .state()
+        .objects
+        .get(&object)
+        .and_then(|card| card.counters.get(&CounterType::Plus1Plus1).copied())
+        .unwrap_or(0)
+}
+
+#[test]
+fn a_manifested_colorless_creature_enters_with_two_counters() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let beastie = scenario
+        .add_creature_from_oracle(P0, "Curator Beastie", 4, 5, BEASTIE)
+        .id();
+    scenario.add_card_to_library_top(P0, "Library Top");
+    scenario.add_card_to_library_top(P0, "Second Top");
+    let spell = scenario
+        .add_spell_to_hand(P0, "Dread Test", false)
+        .from_oracle_text(MANIFEST_DREAD)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+    scenario.with_mana_pool(P0, vec![]);
+
+    let mut runner = scenario.build();
+    let top = runner.state().players[0].library[0];
+
+    runner.cast(spell).resolve();
+    let WaitingFor::ManifestDreadChoice { .. } = runner.state().waiting_for.clone() else {
+        panic!(
+            "manifest dread must pause for a card choice, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    runner
+        .act(GameAction::SelectCards { cards: vec![top] })
+        .expect("manifest choice must be accepted");
+    runner.advance_until_stack_empty();
+
+    let manifested = runner
+        .state()
+        .objects
+        .get(&top)
+        .expect("manifested object exists");
+    assert_eq!(manifested.zone, Zone::Battlefield);
+    assert!(manifested.face_down, "manifested object is face down");
+    assert_eq!(
+        plus_counters(&runner, top),
+        2,
+        "the colorless face-down 2/2 must enter with Beastie's two counters"
+    );
+    assert_eq!(
+        plus_counters(&runner, beastie),
+        0,
+        "Beastie (GU) must not receive its own counters"
+    );
+}
+
+/// Negative + reach-guard pair: a COLORED creature entering under the same
+/// Beastie gets nothing (the manifest test above proves the same static DOES
+/// reach a colorless entry, so this cannot pass vacuously).
+#[test]
+fn a_colored_creature_enters_without_beastie_counters() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Curator Beastie", 4, 5, BEASTIE);
+    let bear = scenario
+        .add_creature_to_hand(P0, "White Bear", 2, 2)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 0,
+            shards: vec![ManaCostShard::White],
+        })
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        vec![ManaUnit::new(ManaType::White, ObjectId(0), false, vec![])],
+    );
+
+    let mut runner = scenario.build();
+    runner.cast(bear).resolve();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects.get(&bear).expect("bear exists").zone,
+        Zone::Battlefield
+    );
+    assert_eq!(
+        plus_counters(&runner, bear),
+        0,
+        "a white creature must not match the colorless filter"
+    );
+}
+
+/// A normally cast colorless creature must also receive the two
+/// counters — bisects the runtime path from the manifest-specific one.
+#[test]
+fn a_cast_colorless_creature_enters_with_two_counters() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Curator Beastie", 4, 5, BEASTIE);
+    let golem = scenario
+        .add_creature_to_hand(P0, "Plain Golem", 3, 3)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+    scenario.with_mana_pool(P0, vec![]);
+
+    let mut runner = scenario.build();
+    runner.cast(golem).resolve();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&golem)
+            .expect("golem exists")
+            .zone,
+        Zone::Battlefield
+    );
+    assert_eq!(
+        plus_counters(&runner, golem),
+        2,
+        "a cast colorless creature must enter with the two counters"
+    );
+}

--- a/crates/engine/tests/integration/issue_7821_bare_plural_enters_with_counters.rs
+++ b/crates/engine/tests/integration/issue_7821_bare_plural_enters_with_counters.rs
@@ -147,3 +147,47 @@ fn a_cast_colorless_creature_enters_with_two_counters() {
         "a cast colorless creature must enter with the two counters"
     );
 }
+
+/// The direct guard against the reported self-anchoring symptom: a SECOND
+/// Curator Beastie cast through the real entry pipeline (GU — colored) gets
+/// nothing from the first one's static. The manifest test proves the same
+/// fixture DOES reach a colorless entry, so this cannot pass vacuously.
+#[test]
+fn a_second_cast_beastie_enters_bare() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(P0, "Curator Beastie", 4, 5, BEASTIE);
+    let second = scenario
+        .add_creature_to_hand_from_oracle(P0, "Curator Beastie", 4, 5, BEASTIE)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 0,
+            shards: vec![ManaCostShard::Green, ManaCostShard::Blue],
+        })
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Green, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Blue, ObjectId(0), false, vec![]),
+        ],
+    );
+
+    let mut runner = scenario.build();
+    runner.cast(second).resolve();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&second)
+            .expect("second Beastie exists")
+            .zone,
+        Zone::Battlefield
+    );
+    assert_eq!(
+        plus_counters(&runner, second),
+        0,
+        "a cast GU Beastie must not match the colorless filter nor self-anchor"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1237,6 +1237,7 @@ mod issue_5263_chaos_warp;
 mod issue_6367_thassas_oracle;
 mod issue_7467_manifest_dread_tracked_set;
 mod issue_7552_role_token_image_ref;
+mod issue_7821_bare_plural_enters_with_counters;
 mod kang_dynasty_until_next_turn_rider;
 mod karplusan_yeti_fight_back;
 mod kav_landseeker_delayed_sacrifice;


### PR DESCRIPTION
Fixes #7821.

Curator Beastie's "Colorless creatures you control enter with two additional +1/+1 counters on them." put both counters on BEASTIE'S own entry and none on manifested creatures. Two seams, both fixed:

**Parser:** `parse_distributive_subject` only knew "each "/"each other "/"other " prefixes — a bare-plural subject fell through and the line silently anchored to the source (`valid_card` AND counter target `SelfRef`). New bare-plural arm, gated on the PLURAL verb ("enter with"/"escape with", word-boundary scan) plus the existing concrete-type validity gate; a leading color quality ("colorless "/"monocolored "/"multicolored ") is peeled via the shared `peel_color_quality_prefix` authority and survives as a `ColorCount` property (CR 105.2a-c). Scope is Distributive — the general subset includes the source iff it matches (CR 614.12); Beastie is GU and simply doesn't.

**Engine:** `matches_target_filter_on_battlefield_entry` evaluated entry filters against the card's FACE-UP characteristics; a manifest entry therefore never matched "colorless creatures" (the library card isn't a 2/2 yet). The matcher now projects the event's `face_down_profile` onto a clone before filtering — mirroring the existing `enter_as_copy` projection arm (CR 708.2a + CR 614.12: the filter must see how the object WOULD enter).

**Adjusted pin:** `plural_subject_escape_with_counter_keeps_escape_condition` ("Escape Anthem", synthetic text) pinned the old SelfRef anchoring incidentally; its documented invariant — the escape gate survives — is unchanged and still asserted, now against the correct plural-subject filter.

**Class (double bake over all 35,798 cards, full-entry diff):** exactly 4 cards change — the whole bare-plural family, each inspected by hand:

| card | subject line | new `valid_card` |
|---|---|---|
| Curator Beastie | "Colorless creatures you control enter with two additional +1/+1 counters" | Creature + You + ColorCount==0 |
| Bard Class | "Legendary creatures you control enter with an additional +1/+1 counter" (its LEVEL 1 line — printed before "{R}{G}: Level 2", so ungated is correct) | Creature + You + HasSupertype(Legendary) |
| Gorma, the Gullet | "Nontoken creatures you control enter with an additional +1/+1 counter ... for each creature that died under your control this turn" | Creature + You + NonToken, count = your Battlefield→Graveyard creatures this turn |
| Veiled Ascension | "Face-down creatures you control enter with a flying counter on them" | Creature + You + FaceDown — this line WORKS only with both halves of this PR (the face-down projection makes the entering manifest match) |

All four previously anchored to the source's own entry.

**Snapshot pins refreshed:** the two Bard Class insta snapshots (`bard_class_ir`, `bard_class_lowered`) pinned the old SelfRef anchoring; their diffs are exactly this fix's change (SelfRef → typed legendary filter, Moved → ChangeZone).

**Runtime proof:** three integration tests — a manifested face-down 2/2 (colorless per CR 708.2a) enters with the two counters, a cast colorless creature does too, a white creature does not, and Beastie itself stays bare in every fixture.

**Counter-proofs:** with the bare-plural arm neutralized the parser pin fails with `got Some(SelfRef)`; with the face-down projection skipped the manifest test fails with `left: 0`.

Suites: clippy, `--lib`, `--test integration` all green locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved “enter with” and “escape with” effects involving groups of permanents.
  * Entry effects now correctly evaluate manifested, morphed, and cloaked creatures using their face-down characteristics, including when they also enter as copies.
  * Colorless creature replacement effects now apply correctly while excluding colored creatures and the entering source itself.

* **Tests**
  * Added coverage for counters being placed on eligible colorless creatures, including face-down creatures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->