### PR TITLE
fix(probe-pin): compile off Unix so the workspace checks on Windows

### DIFF
--- a/crates/probe-pin/src/isolate.rs
+++ b/crates/probe-pin/src/isolate.rs
@@ -47,11 +47,28 @@ pub struct Run {
 /// A signal-killed process has no exit CODE at all — `timeout` re-raises the child's signal
 /// rather than translating it. Every shell reports `128 + signal` for that, and so does
 /// probe-pin: a stack-overflow abort is the 134 that `HarnessIncomplete`'s message quotes.
+#[cfg(unix)]
 pub fn exit_rc(status: &std::process::ExitStatus) -> i32 {
     use std::os::unix::process::ExitStatusExt;
     status
         .code()
         .unwrap_or_else(|| 128 + status.signal().unwrap_or(0))
+}
+
+/// The non-Unix arm exists so the crate COMPILES off Unix — `cargo check --workspace` on a
+/// Windows checkout — not so it runs there: `child_command` shells out to `unshare` and the
+/// SCRIPT calls `mount --bind`, so a real isolated run stays Unix-only either way.
+///
+/// There is no signal to fold in. A terminated process on Windows reports an exit code like
+/// any other — the OS carries the termination reason IN the code (`STATUS_STACK_OVERFLOW`
+/// surfaces as `0xC00000FD`, not as a separate signal number) — so `128 + signal` has no
+/// analogue and `code()` alone IS the exit code. The `unwrap_or` is unreachable on Windows,
+/// where `ExitStatus::code()` is always `Some`; 128 is what the Unix arm yields for the
+/// matching "no code, no signal" status, so both arms agree on the one status neither
+/// platform can describe.
+#[cfg(not(unix))]
+pub fn exit_rc(status: &std::process::ExitStatus) -> i32 {
+    status.code().unwrap_or(128)
 }
 
 /// The flags probe-pin itself puts on the target's argv — the OWNERSHIP allowlist. Everything

--- a/crates/probe-pin/tests/common/mod.rs
+++ b/crates/probe-pin/tests/common/mod.rs
@@ -12,12 +12,13 @@ use std::path::Path;
 /// `cargo check --workspace --all-targets` on a Windows checkout — an error at every one of
 /// them, before any test could report anything at all.
 ///
-/// Compiling is not running. Windows creates symlinks only with Developer Mode on or from an
-/// elevated shell, so the Tier-1 callers carry `#[cfg_attr(windows, ignore = …)]` and report as
-/// IGNORED there — the same vocabulary this suite already uses for `spawns GNU timeout(1)`, and
-/// the reason it uses it: a test that vanishes from the report is indistinguishable from one
-/// that passed. (Every Tier-2 test is `#[ignore]`d unconditionally already, so those need
-/// nothing added.)
+/// Compiling is not running. No target off Unix creates a symlink the way these suites need —
+/// Windows wants Developer Mode or an elevated shell, and a third target has no such call at
+/// all — so the Tier-1 callers carry `#[cfg_attr(not(unix), ignore = …)]` and report as IGNORED
+/// there, the same vocabulary this suite already uses for `spawns GNU timeout(1)` and for the
+/// reason it uses it: a test that vanishes from the report is indistinguishable from one that
+/// passed. (Every Tier-2 test is `#[ignore]`d unconditionally already, so those need nothing
+/// added.)
 #[cfg(unix)]
 pub fn symlink(target: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
     std::os::unix::fs::symlink(target, link)
@@ -37,4 +38,26 @@ pub fn symlink(target: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<(
     } else {
         std::os::windows::fs::symlink_file(target, link)
     }
+}
+
+/// Every remaining target — `rust-toolchain.toml` installs `wasm32-unknown-unknown`, so
+/// "remaining" is not hypothetical — gets a binding that COMPILES and refuses at run time.
+/// The two halves of the problem have different answers: the binding must EXIST everywhere the
+/// test binaries do, because both suites call it unconditionally and an `#[ignore]`d test is
+/// still type-checked; but no third platform has a symlink call to bind it to.
+///
+/// So the refusal is a value, not a compile error. Callers are `#[cfg_attr(not(unix), ignore)]`,
+/// which makes this body unreachable unless someone runs the suite with `--ignored` on such a
+/// target — and there, an `Unsupported` error naming the platform is the honest answer. A
+/// compile error would have been the unhelpful one, and compiling out the helper would take the
+/// four tests off the report entirely, which is what the `#[ignore]`s exist to prevent.
+#[cfg(not(any(unix, windows)))]
+pub fn symlink(_target: impl AsRef<Path>, _link: impl AsRef<Path>) -> io::Result<()> {
+    Err(io::Error::new(
+        io::ErrorKind::Unsupported,
+        format!(
+            "{} has no symlink API; this test is #[ignore]d off Unix",
+            std::env::consts::OS
+        ),
+    ))
 }

--- a/crates/probe-pin/tests/common/mod.rs
+++ b/crates/probe-pin/tests/common/mod.rs
@@ -1,0 +1,40 @@
+//! Support shared by both test binaries. Not a suite: nothing here asserts anything, and
+//! `common/mod.rs` is a module both suites include, never a test binary of its own.
+
+use std::io;
+use std::path::Path;
+
+/// The portable `symlink` both suites need, signature-compatible with the `std` calls it
+/// replaces so no call site changes shape.
+///
+/// It exists so the suites COMPILE off Unix. `std::os::unix` is configured away on Windows, so
+/// the seven `std::os::unix::fs::symlink` call sites were the last thing failing a
+/// `cargo check --workspace --all-targets` on a Windows checkout — an error at every one of
+/// them, before any test could report anything at all.
+///
+/// Compiling is not running. Windows creates symlinks only with Developer Mode on or from an
+/// elevated shell, so the Tier-1 callers carry `#[cfg_attr(windows, ignore = …)]` and report as
+/// IGNORED there — the same vocabulary this suite already uses for `spawns GNU timeout(1)`, and
+/// the reason it uses it: a test that vanishes from the report is indistinguishable from one
+/// that passed. (Every Tier-2 test is `#[ignore]`d unconditionally already, so those need
+/// nothing added.)
+#[cfg(unix)]
+pub fn symlink(target: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
+    std::os::unix::fs::symlink(target, link)
+}
+
+/// Windows splits the one Unix call in two and fixes the flavour at CREATION time, so the
+/// flavour is chosen from what `target` IS rather than from how the link is later read.
+///
+/// A target that does not exist gets the file flavour. That is the DANGLING link
+/// `path_surface_is_realpath_containment` creates deliberately, and the arm only cares that it
+/// fails to resolve — which neither flavour does when nothing is there.
+#[cfg(windows)]
+pub fn symlink(target: impl AsRef<Path>, link: impl AsRef<Path>) -> io::Result<()> {
+    let target = target.as_ref();
+    if target.is_dir() {
+        std::os::windows::fs::symlink_dir(target, link)
+    } else {
+        std::os::windows::fs::symlink_file(target, link)
+    }
+}

--- a/crates/probe-pin/tests/isolation_e2e.rs
+++ b/crates/probe-pin/tests/isolation_e2e.rs
@@ -39,6 +39,8 @@ use probe_pin::mutate::Mount;
 use probe_pin::verdict::{self, Verdict};
 use probe_pin::{Abort, HarnessMarker};
 
+mod common;
+
 const PROD: &str = "crates/probe-pin/tests/fixtures/prod.txt";
 /// Row 21 arm 2 WRITES this path. It is gitignored (`.gitignore:113` = `tmp/`), so the arm
 /// cannot leak into the tree even when its assertion panics before a restore — and it is
@@ -713,7 +715,7 @@ fn wiring_validate_paths() {
     std::fs::create_dir_all(root().join(TMP)).unwrap();
     let link = root().join(TMP).join("escape_link");
     std::fs::remove_file(&link).ok();
-    std::os::unix::fs::symlink(outside.path(), &link).unwrap();
+    common::symlink(outside.path(), &link).unwrap();
 
     let text = std::fs::read_to_string(root().join("crates/probe-pin/tests/fixtures/dogfood.toml"))
         .unwrap()
@@ -867,7 +869,7 @@ fn script_failure_is_named_not_inferred() {
     std::fs::create_dir_all(&bin).unwrap();
     // enough to reach the script, and nothing the script needs after that
     for tool in ["unshare", "bash"] {
-        std::os::unix::fs::symlink(on_path(tool), bin.join(tool)).unwrap();
+        common::symlink(on_path(tool), bin.join(tool)).unwrap();
     }
     for missing in ["mount", "cmp", "timeout"] {
         assert!(

--- a/crates/probe-pin/tests/pure_logic.rs
+++ b/crates/probe-pin/tests/pure_logic.rs
@@ -1030,8 +1030,8 @@ fn every_write_of_the_pinned_file_routes_through_splice() {
 /// bound, and this one is "not reached today", not "cannot be reached".
 #[test]
 #[cfg_attr(
-    windows,
-    ignore = "creates a symlink; Windows needs Developer Mode or an elevated shell"
+    not(unix),
+    ignore = "creates a symlink; off Unix that needs Developer Mode (Windows) or has no API at all"
 )]
 fn workspace_root_is_canonical() {
     let root = target::workspace_root().expect("workspace root");
@@ -2230,8 +2230,8 @@ fn manifest_outside_the_workspace_is_refused() {
 /// this replaced.
 #[test]
 #[cfg_attr(
-    windows,
-    ignore = "creates a symlink; Windows needs Developer Mode or an elevated shell"
+    not(unix),
+    ignore = "creates a symlink; off Unix that needs Developer Mode (Windows) or has no API at all"
 )]
 fn manifest_rel_compares_realpaths() {
     let base = tempfile::tempdir().unwrap();
@@ -2684,8 +2684,8 @@ fn env_surface_refuses_probe_pin_owned_keys() {
 /// the scratch dir in `mutant_destination_cannot_escape_the_scratch_dir`.
 #[test]
 #[cfg_attr(
-    windows,
-    ignore = "creates symlinks; Windows needs Developer Mode or an elevated shell"
+    not(unix),
+    ignore = "creates symlinks; off Unix that needs Developer Mode (Windows) or has no API at all"
 )]
 fn path_surface_is_realpath_containment() {
     let base = tempfile::tempdir().unwrap();
@@ -2772,8 +2772,8 @@ fn path_surface_is_realpath_containment() {
 /// dir named as a plain probe id — writing a mutant straight into the measured workspace.
 #[test]
 #[cfg_attr(
-    windows,
-    ignore = "creates a symlink; Windows needs Developer Mode or an elevated shell"
+    not(unix),
+    ignore = "creates a symlink; off Unix that needs Developer Mode (Windows) or has no API at all"
 )]
 fn mutant_destination_cannot_escape_the_scratch_dir() {
     let base = tempfile::tempdir().unwrap();

--- a/crates/probe-pin/tests/pure_logic.rs
+++ b/crates/probe-pin/tests/pure_logic.rs
@@ -29,6 +29,8 @@ use probe_pin::{
     Abort, CheckOutcome, DriftCause, HarnessMarker, Instrument, InstrumentChange, NothingRan,
 };
 
+mod common;
+
 // ------------------------------------------------------------------ helpers
 
 fn fixtures() -> PathBuf {
@@ -1027,6 +1029,10 @@ fn every_write_of_the_pinned_file_routes_through_splice() {
 /// GUARD's shape measured on a synthetic pair, not a live escape — a found hole is a lower
 /// bound, and this one is "not reached today", not "cannot be reached".
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "creates a symlink; Windows needs Developer Mode or an elevated shell"
+)]
 fn workspace_root_is_canonical() {
     let root = target::workspace_root().expect("workspace root");
     assert_eq!(
@@ -1041,7 +1047,7 @@ fn workspace_root_is_canonical() {
     std::fs::create_dir_all(real.join("crates")).unwrap();
     std::fs::write(real.join("crates/m.toml"), "version = 1\n").unwrap();
     let link = base.path().join("link");
-    std::os::unix::fs::symlink(&real, &link).unwrap();
+    common::symlink(&real, &link).unwrap();
 
     let manifest_real = link.join("crates/m.toml").canonicalize().unwrap();
     assert!(
@@ -2223,13 +2229,17 @@ fn manifest_outside_the_workspace_is_refused() {
 /// where a test can drive it: arm 1 below is the escaping pair, and it is refused by the shape
 /// this replaced.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "creates a symlink; Windows needs Developer Mode or an elevated shell"
+)]
 fn manifest_rel_compares_realpaths() {
     let base = tempfile::tempdir().unwrap();
     let real = base.path().join("real");
     std::fs::create_dir_all(real.join("crates")).unwrap();
     std::fs::write(real.join("crates/m.toml"), "version = 1\n").unwrap();
     let link = base.path().join("link");
-    std::os::unix::fs::symlink(&real, &link).unwrap();
+    common::symlink(&real, &link).unwrap();
 
     // arm 1 — the phenomenon: a canonicalized manifest path shares no prefix with a root
     // reached through a symlink, so the lexical comparison rejects a manifest that is inside it
@@ -2673,6 +2683,10 @@ fn env_surface_refuses_probe_pin_owned_keys() {
 /// is the in-tree pattern this reuses, in both directions — into the workspace here, and into
 /// the scratch dir in `mutant_destination_cannot_escape_the_scratch_dir`.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "creates symlinks; Windows needs Developer Mode or an elevated shell"
+)]
 fn path_surface_is_realpath_containment() {
     let base = tempfile::tempdir().unwrap();
     let ws = base.path().join("ws");
@@ -2680,8 +2694,8 @@ fn path_surface_is_realpath_containment() {
     std::fs::create_dir_all(ws.join("crates")).unwrap();
     std::fs::create_dir_all(&outside).unwrap();
     std::fs::write(outside.join("victim.rs"), "OUTSIDE\n").unwrap();
-    std::os::unix::fs::symlink(&outside, ws.join("crates/link")).unwrap();
-    std::os::unix::fs::symlink(outside.join("does_not_exist"), ws.join("crates/dangling")).unwrap();
+    common::symlink(&outside, ws.join("crates/link")).unwrap();
+    common::symlink(outside.join("does_not_exist"), ws.join("crates/dangling")).unwrap();
 
     // arm 1 — the phenomenon: every escaping key below passes the LEXICAL check
     for key in [
@@ -2757,6 +2771,10 @@ fn path_surface_is_realpath_containment() {
 /// neither says what the join resolves to. Arm 1 exhibits the escape — a symlink in the scratch
 /// dir named as a plain probe id — writing a mutant straight into the measured workspace.
 #[test]
+#[cfg_attr(
+    windows,
+    ignore = "creates a symlink; Windows needs Developer Mode or an elevated shell"
+)]
 fn mutant_destination_cannot_escape_the_scratch_dir() {
     let base = tempfile::tempdir().unwrap();
     let ws = base.path().join("ws");
@@ -2771,7 +2789,7 @@ fn mutant_destination_cannot_escape_the_scratch_dir() {
     assert!(manifest::is_plain_name(&p.id) && manifest::is_workspace_relative("f.txt"));
 
     // arm 1 — the phenomenon, with the guard's own base symlinked into the workspace
-    std::os::unix::fs::symlink(&ws, scratch.join("P1_plain_name")).unwrap();
+    common::symlink(&ws, scratch.join("P1_plain_name")).unwrap();
     let e = mutate::apply(&p, &ws, &scratch).unwrap_err();
     assert!(
         e.to_string()


### PR DESCRIPTION
`exit_rc` reached for `std::os::unix::process::ExitStatusExt`, which is
configured away on Windows, so the crate could not build there at all —
E0433 on the import plus E0599 on `status.signal()`. That failed
`cargo check --workspace` for every Windows developer, on a crate whose
own tests are the only thing that runs it.

Split `exit_rc` into two cfg'd arms. The Unix body is byte-identical;
the non-Unix arm derives the code from `ExitStatus::code()` alone, since
Windows carries the termination reason IN the code
(`STATUS_STACK_OVERFLOW` surfaces as `0xC00000FD`, not as a separate
signal) and `128 + signal` has no analogue. Its `unwrap_or(128)` is
unreachable there — `code()` is always `Some` on Windows — and 128 is
what the Unix arm yields for the matching "no code, no signal" status,
so both arms agree on the one status neither platform can describe.

The seven `std::os::unix::fs::symlink` call sites in the two test
binaries were the rest of the failure. They route through a new
`tests/common/mod.rs` shim taking `impl AsRef<Path>` exactly like the
`std` call it replaces, so no call site changes shape. Windows fixes
file-vs-dir at CREATION time, so the flavour is chosen from what the
target IS; a target that does not exist gets the file flavour, which is
the dangling link `path_surface_is_realpath_containment` builds on
purpose — that arm only cares that it fails to resolve, and neither
flavour resolves when nothing is there.

Compiling is not running: Windows creates symlinks only with Developer
Mode on or from an elevated shell. So the four Tier-1 callers carry
`#[cfg_attr(windows, ignore = ...)]` and report as IGNORED there, the
same vocabulary this suite already uses for "spawns GNU timeout(1)" and
for the reason it uses it — a test that vanishes from the report is
indistinguishable from one that passed. Nothing is compiled out. Tier 2
needed no attribute: every test there is already unconditionally
ignored, and adding one would break
`tier2_suite_is_uniformly_ignored_with_the_measured_reason`, which pins
the exact attribute text on each test.

Verified on Windows: `cargo check -p probe-pin --all-targets`,
`cargo clippy -p probe-pin --all-targets` and
`cargo check --workspace --all-targets` are clean, the four newly-gated
tests report as ignored rather than missing, and the Tier-2 pinning test
still passes. The Unix arm could not be compiled here — only
wasm32-unknown-unknown and x86_64-pc-windows-msvc toolchains are
installed — so it wants one CI run on Linux to confirm.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows compatibility by handling process exit statuses correctly across platforms.
  * Added platform-appropriate behavior for symlink operations.

* **Tests**
  * Added portable symlink support for Unix and Windows test environments.
  * Added guidance and exclusions for Windows setups where symlink creation requires additional permissions.
  * Improved cross-platform isolation and logic test coverage.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->