### PR TITLE
fix(client): let pnpm 10+ find the security overrides again

### DIFF
--- a/client/pnpm-workspace.yaml
+++ b/client/pnpm-workspace.yaml
@@ -1,0 +1,46 @@
+# pnpm settings file. It exists so that pnpm 10.6+ can find the "overrides"
+# block below: those versions no longer read the "pnpm" field in package.json,
+# so without this file a current pnpm sees zero overrides while pnpm-lock.yaml
+# records fourteen, and "pnpm install --frozen-lockfile" fails on any clean
+# checkout with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH. See https://pnpm.io/settings.
+
+# "packages" is required, not decorative. pnpm 9 -- still what CI installs
+# with -- treats the mere presence of this file as a workspace root and aborts
+# with "packages field missing or empty" when it is absent. Listing "." keeps
+# the single-project layout identical across both majors: pnpm 9.15.9 and
+# pnpm 11 each install the same 778-package tree from the unchanged lockfile.
+packages:
+  - '.'
+
+# TEMPORARY DUPLICATION: these mirror "pnpm.overrides" in package.json, which
+# pnpm 9 reads and pnpm 10.6+ ignores. Both copies must stay in sync until the
+# package.json copy is removed and the pnpm version is pinned repo-wide, which
+# needs a maintainer-owned review because it touches protected surfaces.
+# They must also match the "overrides:" block recorded in pnpm-lock.yaml -- a
+# mismatch is what fails frozen installs in the first place.
+#
+# Security pins: transitive advisories resolved forward.
+overrides:
+  serialize-javascript@<7.0.5: 7.0.5
+  ws@<8.21.0: 8.21.0
+  '@babel/core': 7.29.7
+  brace-expansion@1: 1.1.16
+  brace-expansion@2: 2.1.2
+  brace-expansion@>=3 <5.0.7: 5.0.7
+  fast-uri: 3.1.4
+  js-yaml: 4.3.0
+  picomatch: '>=4.0.4'
+  lodash: '>=4.18.0'
+  postcss: '>=8.5.10'
+  sharp: 0.35.3
+  undici: 7.28.0
+  uuid: 11.1.1
+
+# pnpm 9 runs every dependency's install scripts; pnpm 10+ blocks them unless
+# allowlisted. esbuild and workerd ship the platform binaries that vite/vitest
+# and wrangler need at build time, so allowing exactly those two keeps local
+# behaviour on a current pnpm identical to what CI already does on pnpm 9.
+# Ignored by pnpm 9, which has no such gate.
+allowBuilds:
+  esbuild: true
+  workerd: true


### PR DESCRIPTION
"pnpm install --frozen-lockfile" fails on any clean checkout or worktree
with ERR_PNPM_LOCKFILE_CONFIG_MISMATCH on "overrides", so nobody running a
current pnpm can install the frontend dependencies.

This is not lockfile drift. The "overrides:" block in pnpm-lock.yaml
matches client/package.json entry for entry, all fourteen. pnpm 10.6+
stopped reading the "pnpm" field in package.json, so a current pnpm sees
zero overrides while the lockfile records fourteen and refuses the frozen
install. CI pins pnpm 9, which still reads the old location, so CI has
stayed green and masked the split.

Regenerating the lockfile is the trap, not the fix: under pnpm 11 it
strips all fourteen security pins and then breaks CI with the mirror-image
mismatch. pnpm-lock.yaml is deliberately untouched here.

Add client/pnpm-workspace.yaml carrying the same overrides in the location
pnpm 10.6+ actually reads. package.json keeps its copy so pnpm 9 -- and
therefore CI -- is entirely unaffected. The duplication is deliberate and
temporary; collapsing it to a single source of truth also requires pinning
the pnpm version across the workflows, which touches protected surfaces
and needs a maintainer-owned security and release review, so it is kept
out of this change.

The "packages" entry is required rather than decorative: pnpm 9 treats the
presence of this file as a workspace root and aborts with "packages field
missing or empty" without it. Omitting it would have broken every CI job.

Also allowlist the esbuild and workerd build scripts. pnpm 9 runs every
dependency's install scripts; pnpm 10+ blocks them unless allowlisted, and
those two ship the platform binaries vite/vitest and wrangler need at build
time. pnpm 9 has no such gate and ignores the key.

Verified on both majors against the unchanged lockfile: pnpm 9.15.9 and
pnpm 11.13.0 each complete "pnpm install --frozen-lockfile" and resolve the
same 778-package tree, with normal node_modules layout and zero lockfile
drift from either.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
