### PR TITLE
Replaced mapfile commands in fetch scripts

### DIFF
--- a/scripts/fetch-draft-sets.sh
+++ b/scripts/fetch-draft-sets.sh
@@ -52,7 +52,10 @@ else
     if command -v jq &>/dev/null; then
         # tr strips Windows jq's trailing \r, which otherwise malforms every
         # per-set download URL (see fetch-token-sets.sh).
-        mapfile -t CODES < <(jq -r '.data[]
+        CODES=()
+        while IFS= read -r code; do
+            CODES+=("$code")
+        done < <(jq -r '.data[]
             | select(.type | IN("core", "expansion", "draft_innovation", "masters", "masterpiece", "eternal", "funny"))
             | .code' "$SET_LIST" 2>/dev/null | tr -d '\r')
     else

--- a/scripts/fetch-token-sets.sh
+++ b/scripts/fetch-token-sets.sh
@@ -20,7 +20,10 @@ if ! command -v jq >/dev/null 2>&1; then
   exit 1
 fi
 
-mapfile -t CODES < <(
+CODES=()
+while IFS= read -r code; do
+  CODES+=("$code")
+done < <(
   # tokenSetCode can name a legacy token pseudo-set that MTGJSON no longer
   # publishes as its own file; the parent set file already carries data.tokens.
   # tr strips the \r that Windows jq appends to every line — a code with a


### PR DESCRIPTION
## Summary

Replaced mapfile commands in scripts/fetch-draft-sets.sh and scripts/fetch-token-sets.sh. Macos does not ship with a version of bash that has `mapfile`, and it was causing the scripts/gen-card-data.sh to fail.

## Files changed

- scripts/fetch-draft-sets.sh
- scripts/fetch-token-sets.sh

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved compatibility when collecting set and token codes during automated data fetching.
  - Preserved existing filtering and carriage-return handling while ensuring codes are processed reliably line by line.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->