### PR TITLE
Fix remains-exiled casting permissions

### DIFF
--- a/crates/engine/src/parser/clause_shell.rs
+++ b/crates/engine/src/parser/clause_shell.rs
@@ -77,6 +77,7 @@ use super::oracle_effect::conditions::{
     strip_leading_general_conditional, strip_unrecognized_conditional_head_when_body_optional,
 };
 use super::oracle_effect::strip_trailing_duration;
+use super::oracle_ir::ast::is_play_from_exile_lifetime_duration;
 use super::oracle_ir::context::ParseContext;
 use super::oracle_nom::bridge::nom_on_lower;
 use crate::types::ability::{
@@ -415,6 +416,14 @@ fn is_specialized_duration_carrier(text_lower: &str) -> bool {
     use nom::branch::alt;
     use nom::bytes::complete::tag;
     use nom::combinator::value;
+    let (body, duration) = strip_trailing_duration(text_lower);
+    let bare_tracked_exile_grant = duration
+        .as_ref()
+        .is_some_and(is_play_from_exile_lifetime_duration)
+        && tag::<_, _, OracleError<'_>>("cast spells from among ")
+            .parse(body)
+            .is_ok();
+
     let head: nom::IResult<&str, (), OracleError<'_>> = alt((
         // CR 400.7i — impulse-draw bare form (post strip_optional_effect_prefix
         // in the chunk loop). `try_parse_play_from_exile` requires the
@@ -455,7 +464,7 @@ fn is_specialized_duration_carrier(text_lower: &str) -> bool {
         parse_additional_land_head,
     ))
     .parse(text_lower);
-    head.is_ok()
+    bare_tracked_exile_grant || head.is_ok()
 }
 
 /// CR 305.2: Head matcher for the turn-scoped additional-land grant, used by

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13327,6 +13327,17 @@ fn try_parse_per_grantee_play_grant(tp: TextPair<'_>) -> Option<ParsedEffectClau
 /// `mana_spend_permission: Some(ManaSpendPermission::AnyTypeOrColor)`,
 /// matching the wire-up used by `try_parse_exile_play_grant_with_any_mana`.
 fn try_parse_cast_from_tracked_exile_grant(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
+    let (permission_text, explicit_duration) = strip_trailing_duration(tp.original);
+    let permission_lower = permission_text.to_lowercase();
+    let owns_exile_lifetime = explicit_duration
+        .as_ref()
+        .is_some_and(is_play_from_exile_lifetime_duration);
+    let permission_tp = if owns_exile_lifetime {
+        TextPair::new(permission_text, &permission_lower)
+    } else {
+        tp
+    };
+
     // CR 601.2a: Two grant shapes share the "...from among [those|the] exiled
     // cards" anaphor:
     //   * Plural unbounded — "you may cast spells from among those exiled cards"
@@ -13336,45 +13347,53 @@ fn try_parse_cast_from_tracked_exile_grant(tp: TextPair<'_>) -> Option<ParsedEff
     //     restricted to the typed filter.
     // The singular determiner ("a"/"an"/"one") encodes the single-use cap; the
     // optional type phrase encodes the card filter.
-    let ((card_filter, single_use), rest_orig) = nom_on_lower(tp.original, tp.lower, |i| {
-        let (i, _) = tag("you may cast ").parse(i)?;
-        // Singular bounded: a[n]/one [type-phrase] spell → single-use + filter.
-        let singular = |i| {
-            let (i, _) = alt((tag("an "), tag("a "), tag("one "))).parse(i)?;
-            // CR 601.2a: the printed type-phrase ("instant or sorcery", a bare
-            // "spell") restricts WHICH exiled cards this single-use grant
-            // authorizes. `parse_type_phrase` maps a bare "spell" → `Card`; a
-            // typed phrase ("instant or sorcery") → the `AnyOf` type filter.
-            let (i, filter) = super::oracle_nom::target::parse_type_phrase.parse(i)?;
-            // A typed phrase ("instant or sorcery") is followed by the " spell"
-            // noun; a bare "spell" already consumed it. The card filter is a
-            // printed quality (no stack pin) so the exile object matches it.
-            let is_bare_card = matches!(
-                &filter,
-                TargetFilter::Typed(TypedFilter { type_filters, .. })
-                    if type_filters.as_slice() == [TypeFilter::Card]
-            );
-            let (i, card_filter) = match tag::<_, _, OracleError<'_>>(" spell").parse(i) {
-                Ok((i, _)) => (i, Some(filter)),
-                Err(e) => {
-                    if is_bare_card {
-                        // "a spell" — single-use but no type restriction.
-                        (i, None)
-                    } else {
-                        return Err(e);
+    let ((card_filter, single_use, explicit_permission), rest_orig) =
+        nom_on_lower(permission_tp.original, permission_tp.lower, |i| {
+            let (i, explicit_permission) = alt((
+                value(true, tag("you may cast ")),
+                value(false, tag("cast ")),
+            ))
+            .parse(i)?;
+            // Singular bounded: a[n]/one [type-phrase] spell → single-use + filter.
+            let singular = |i| {
+                let (i, _) = alt((tag("an "), tag("a "), tag("one "))).parse(i)?;
+                // CR 601.2a: the printed type-phrase ("instant or sorcery", a bare
+                // "spell") restricts WHICH exiled cards this single-use grant
+                // authorizes. `parse_type_phrase` maps a bare "spell" → `Card`; a
+                // typed phrase ("instant or sorcery") → the `AnyOf` type filter.
+                let (i, filter) = super::oracle_nom::target::parse_type_phrase.parse(i)?;
+                // A typed phrase ("instant or sorcery") is followed by the " spell"
+                // noun; a bare "spell" already consumed it. The card filter is a
+                // printed quality (no stack pin) so the exile object matches it.
+                let is_bare_card = matches!(
+                    &filter,
+                    TargetFilter::Typed(TypedFilter { type_filters, .. })
+                        if type_filters.as_slice() == [TypeFilter::Card]
+                );
+                let (i, card_filter) = match tag::<_, _, OracleError<'_>>(" spell").parse(i) {
+                    Ok((i, _)) => (i, Some(filter)),
+                    Err(e) => {
+                        if is_bare_card {
+                            // "a spell" — single-use but no type restriction.
+                            (i, None)
+                        } else {
+                            return Err(e);
+                        }
                     }
-                }
+                };
+                Ok((i, (card_filter, true)))
             };
-            Ok((i, (card_filter, true)))
-        };
-        // Plural unbounded: "spells" → unlimited within the window, any type.
-        let plural = value((None, false), tag("spells"));
-        let (i, parsed) = alt((singular, plural)).parse(i)?;
-        let (i, _) = tag(" from among ").parse(i)?;
-        let (i, _) = alt((tag("those exiled cards"), tag("the exiled cards"))).parse(i)?;
-        Ok((i, parsed))
-    })?;
-    let rest_lower = &tp.lower[tp.lower.len() - rest_orig.len()..];
+            // Plural unbounded: "spells" → unlimited within the window, any type.
+            let plural = value((None, false), tag("spells"));
+            let (i, parsed) = alt((singular, plural)).parse(i)?;
+            let (i, _) = tag(" from among ").parse(i)?;
+            let (i, _) = alt((tag("those exiled cards"), tag("the exiled cards"))).parse(i)?;
+            Ok((i, (parsed.0, parsed.1, explicit_permission)))
+        })?;
+    if !explicit_permission && !owns_exile_lifetime {
+        return None;
+    }
+    let rest_lower = &permission_tp.lower[permission_tp.lower.len() - rest_orig.len()..];
 
     // Optional any-color mana conjunct: ", and you may spend mana as though
     // it were mana of any color to cast those spells" (or "...any type...").
@@ -13394,7 +13413,7 @@ fn try_parse_cast_from_tracked_exile_grant(tp: TextPair<'_>) -> Option<ParsedEff
         Some(ManaSpendPermission::AnyTypeOrColor)
     };
 
-    Some(parsed_clause(Effect::GrantCastingPermission {
+    let clause = parsed_clause(Effect::GrantCastingPermission {
         permission: CastingPermission::PlayFromExile {
             // Duration is a placeholder; `with_clause_duration` patches this
             // when a leading "Until end of turn, " or trailing "... this turn"
@@ -13424,7 +13443,13 @@ fn try_parse_cast_from_tracked_exile_grant(tp: TextPair<'_>) -> Option<ParsedEff
             id: TrackedSetId(0),
         },
         grantee: Default::default(),
-    }))
+    });
+
+    Some(if owns_exile_lifetime {
+        with_clause_duration(clause, explicit_duration.expect("checked above"))
+    } else {
+        clause
+    })
 }
 
 fn try_parse_exile_play_grant_with_any_mana(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
@@ -13545,6 +13570,25 @@ fn try_parse_play_from_exile(tp: TextPair, ctx: &ParseContext) -> Option<ParsedE
         return Some(clause);
     }
 
+    // Parse the duration as part of this permission clause before classifying
+    // the remaining grammar. Keeping the extracted typed duration lets
+    // `with_clause_duration` apply the exact exile-lifetime normalization in
+    // `oracle_ir::ast`, without a clause-wide phrase scan that could bind an
+    // unrelated "remain(s) exiled" instruction to this permission.
+    let invalidation = scan_until_next_same_source_exile_invalidation(tp.lower)
+        .then_some(PlayPermissionInvalidation::UntilNextGrantFromSameSource);
+    let original_tp = tp;
+    let (permission_text, explicit_duration) = strip_trailing_duration(tp.original);
+    let permission_lower = permission_text.to_lowercase();
+    let owns_exile_lifetime = explicit_duration
+        .as_ref()
+        .is_some_and(is_play_from_exile_lifetime_duration);
+    let tp = if owns_exile_lifetime {
+        TextPair::new(permission_text, &permission_lower)
+    } else {
+        original_tp
+    };
+
     // Try full forms first: "you may play/cast that card/it/those cards ..."
     // Then bare forms (after "you may" has been stripped): "play that card ..."
     // CR 406.6 + CR 400.7i: "you may look at and play those cards for as long as
@@ -13634,13 +13678,12 @@ fn try_parse_play_from_exile(tp: TextPair, ctx: &ParseContext) -> Option<ParsedE
         if look_at_play_anaphor_form || mass_anaphor_form {
             // fall through to the grant builder.
         } else {
-            // Only match when temporal context exists ("this turn", "until",
-            // or a remains-exiled lifetime), otherwise it's a CastFromZone,
-            // not impulse draw permission.
+            // Preserve the legacy turn/until disambiguation while admitting an
+            // exile lifetime only when this permission grammar consumed it.
             let has_temporal = scan_contains_phrase(tp.lower, "this turn")
                 || scan_contains_phrase(tp.lower, "until ")
-                || scan_contains_phrase(tp.lower, "remain exiled")
-                || scan_contains_phrase(tp.lower, "remains exiled");
+                || owns_exile_lifetime
+                || invalidation.is_some();
             if !has_temporal {
                 return None;
             }
@@ -13683,23 +13726,16 @@ fn try_parse_play_from_exile(tp: TextPair, ctx: &ParseContext) -> Option<ParsedE
         return None;
     }
 
-    // Duration: extract from trailing text, defaulting to UntilEndOfTurn for impulse draw.
-    // CR 400.7i + CR 611.2a: "for as long as ... remain[s] exiled" persists until
-    // zone-exit cleanup clears the exile-scoped permission, matching the existing
-    // any-mana remains-exiled grant path.
-    let invalidation = scan_until_next_same_source_exile_invalidation(tp.lower)
-        .then_some(PlayPermissionInvalidation::UntilNextGrantFromSameSource);
-    let (_, dur) = strip_trailing_duration(tp.original);
-    let duration = if invalidation.is_some()
-        || scan_contains_phrase(tp.lower, "remain exiled")
-        || scan_contains_phrase(tp.lower, "remains exiled")
-    {
+    let duration = if invalidation.is_some() {
         Duration::Permanent
     } else {
-        dur.unwrap_or(Duration::UntilEndOfTurn)
+        explicit_duration
+            .clone()
+            .unwrap_or(Duration::UntilEndOfTurn)
     };
+    let has_source_invalidation = invalidation.is_some();
 
-    Some(parsed_clause(Effect::GrantCastingPermission {
+    let clause = parsed_clause(Effect::GrantCastingPermission {
         permission: CastingPermission::PlayFromExile {
             duration,
             // Placeholder — `grant_permission::resolve` rewrites this to the
@@ -13723,7 +13759,18 @@ fn try_parse_play_from_exile(tp: TextPair, ctx: &ParseContext) -> Option<ParsedE
         // impulse-draw chains like Act on Impulse, Light Up the Stage, etc.
         target: tracked_set_filter(),
         grantee: Default::default(),
-    }))
+    });
+
+    Some(match explicit_duration {
+        // Source invalidation is represented separately on the permission. Keep
+        // its established permanent embedded duration so the source event, not
+        // a duplicate duration patch, owns revocation.
+        Some(duration) if owns_exile_lifetime && !has_source_invalidation => {
+            with_clause_duration(clause, duration)
+        }
+        None => clause,
+        Some(_) => clause,
+    })
 }
 
 fn try_parse_play_the_exiled_card_grant(tp: TextPair) -> Option<ParsedEffectClause> {

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13634,10 +13634,13 @@ fn try_parse_play_from_exile(tp: TextPair, ctx: &ParseContext) -> Option<ParsedE
         if look_at_play_anaphor_form || mass_anaphor_form {
             // fall through to the grant builder.
         } else {
-            // Only match when temporal context exists ("this turn", "until"),
-            // otherwise it's a CastFromZone, not impulse draw permission.
+            // Only match when temporal context exists ("this turn", "until",
+            // or a remains-exiled lifetime), otherwise it's a CastFromZone,
+            // not impulse draw permission.
             let has_temporal = scan_contains_phrase(tp.lower, "this turn")
-                || scan_contains_phrase(tp.lower, "until ");
+                || scan_contains_phrase(tp.lower, "until ")
+                || scan_contains_phrase(tp.lower, "remain exiled")
+                || scan_contains_phrase(tp.lower, "remains exiled");
             if !has_temporal {
                 return None;
             }

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -13207,7 +13207,9 @@ fn parse_per_owner_exiled_this_way(i: &str) -> OracleResult<'_, ()> {
 ///   → [`PermissionGrantee::ParentTargetController`] (Expedited Inheritance).
 ///   The pronoun "they" refers to the parent effect's player target.
 fn try_parse_per_grantee_play_grant(tp: TextPair<'_>) -> Option<ParsedEffectClause> {
-    let lower = tp.lower;
+    let (permission_text, explicit_duration) = strip_trailing_duration(tp.original);
+    let permission_lower = permission_text.to_lowercase();
+    let lower = permission_lower.as_str();
 
     let grantee = if alt((
         tag::<_, _, OracleError<'_>>("for each of those cards, its owner may play it"),
@@ -13265,18 +13267,15 @@ fn try_parse_per_grantee_play_grant(tp: TextPair<'_>) -> Option<ParsedEffectClau
         return None;
     };
 
-    // CR 400.7i + CR 611.2a: "for as long as it remains exiled" persists until
+    // CR 611.2a: "for as long as it remains exiled" persists until
     // the exile-scoped permission is cleared on zone exit
     // (`zones::apply_zone_exit_cleanup`) — the same Permanent encoding the
     // impulse `try_parse_play_from_exile` path uses (Lightstall Inquisitor).
     // Otherwise default to UntilEndOfTurn (matches impulse-draw default).
-    let duration = if scan_contains_phrase(tp.lower, "remain exiled")
-        || scan_contains_phrase(tp.lower, "remains exiled")
-    {
-        Duration::Permanent
-    } else {
-        let (_, dur) = strip_trailing_duration(tp.original);
-        dur.unwrap_or(Duration::UntilEndOfTurn)
+    let duration = match explicit_duration {
+        Some(duration) if is_play_from_exile_lifetime_duration(&duration) => Duration::Permanent,
+        Some(duration) => duration,
+        None => Duration::UntilEndOfTurn,
     };
 
     Some(parsed_clause(Effect::GrantCastingPermission {

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -45675,6 +45675,38 @@ fn play_that_card_until_next_same_source_exile_has_source_invalidation() {
     );
 }
 
+#[test]
+fn unrelated_remains_exiled_text_cannot_extend_permission_duration() {
+    let ctx = ParseContext::default();
+    let valid = "cast that card this turn";
+    let valid_clause = try_parse_play_from_exile(TextPair::new(valid, valid), &ctx)
+        .expect("the permission grammar should recognize its own turn duration");
+    assert!(matches!(
+        valid_clause.effect,
+        Effect::GrantCastingPermission {
+            permission: CastingPermission::PlayFromExile {
+                duration: Duration::UntilEndOfTurn,
+                ..
+            },
+            ..
+        }
+    ));
+
+    let unrelated = "cast that card this turn, then another card remains exiled";
+    let unrelated_clause = try_parse_play_from_exile(TextPair::new(unrelated, unrelated), &ctx)
+        .expect("the existing this-turn permission classification should remain unchanged");
+    assert!(matches!(
+        unrelated_clause.effect,
+        Effect::GrantCastingPermission {
+            permission: CastingPermission::PlayFromExile {
+                duration: Duration::UntilEndOfTurn,
+                ..
+            },
+            ..
+        }
+    ));
+}
+
 /// Discriminating: the "for as long as it remains exiled, and mana of any
 /// type..." form (Blightwing Bandit class) must keep dispatching to
 /// `try_parse_exile_play_grant_with_any_mana` (duration `Permanent`), NOT be

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -45707,6 +45707,67 @@ fn unrelated_remains_exiled_text_cannot_extend_permission_duration() {
     ));
 }
 
+#[test]
+fn exile_lifetime_duration_requires_the_complete_supported_condition() {
+    for text in [
+        "it remains exiled",
+        "that card remains exiled",
+        "those cards remain exiled",
+        "they remain exiled",
+    ] {
+        let duration = Duration::ForAsLongAs {
+            condition: StaticCondition::Unrecognized {
+                text: text.to_string(),
+            },
+        };
+        assert!(
+            is_play_from_exile_lifetime_duration(&duration),
+            "expected supported exile-lifetime subject: {text}"
+        );
+    }
+
+    let unrelated_tail = Duration::ForAsLongAs {
+        condition: StaticCondition::Unrecognized {
+            text: "it remains exiled and another card remains exiled".to_string(),
+        },
+    };
+    assert!(
+        !is_play_from_exile_lifetime_duration(&unrelated_tail),
+        "unrelated trailing text must not be absorbed into the permission duration"
+    );
+}
+
+#[test]
+fn per_grantee_permission_owns_only_its_trailing_exile_duration() {
+    let valid = "may play that card for as long as it remains exiled";
+    let valid_clause = try_parse_per_grantee_play_grant(TextPair::new(valid, valid))
+        .expect("expected per-owner casting permission");
+    assert!(matches!(
+        valid_clause.effect,
+        Effect::GrantCastingPermission {
+            permission: CastingPermission::PlayFromExile {
+                duration: Duration::Permanent,
+                ..
+            },
+            ..
+        }
+    ));
+
+    let unrelated = "may play that card this turn, then another card remains exiled";
+    let unrelated_clause = try_parse_per_grantee_play_grant(TextPair::new(unrelated, unrelated))
+        .expect("expected existing per-owner permission classification");
+    assert!(matches!(
+        unrelated_clause.effect,
+        Effect::GrantCastingPermission {
+            permission: CastingPermission::PlayFromExile {
+                duration: Duration::UntilEndOfTurn,
+                ..
+            },
+            ..
+        }
+    ));
+}
+
 /// Discriminating: the "for as long as it remains exiled, and mana of any
 /// type..." form (Blightwing Bandit class) must keep dispatching to
 /// `try_parse_exile_play_grant_with_any_mana` (duration `Permanent`), NOT be

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1981,8 +1981,9 @@ pub(crate) fn with_clause_duration(
     clause
 }
 
-fn normalize_play_from_exile_duration(duration: Duration) -> Duration {
-    match duration {
+pub(crate) fn is_play_from_exile_lifetime_duration(duration: &Duration) -> bool {
+    matches!(
+        duration,
         Duration::ForAsLongAs {
             condition: StaticCondition::Unrecognized { text },
         } if matches!(
@@ -1991,8 +1992,13 @@ fn normalize_play_from_exile_duration(duration: Duration) -> Duration {
                 | "that card remains exiled"
                 | "those cards remain exiled"
                 | "they remain exiled"
-        ) =>
-        {
+        )
+    )
+}
+
+fn normalize_play_from_exile_duration(duration: Duration) -> Duration {
+    match duration {
+        duration if is_play_from_exile_lifetime_duration(&duration) => {
             // CR 400.7i + CR 611.2a: exile-play permissions persist until the
             // referenced object leaves exile; zone-exit cleanup removes the
             // object-tagged permission.

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1,6 +1,11 @@
+use nom::branch::alt;
+use nom::bytes::complete::tag;
+use nom::combinator::{all_consuming, value};
+use nom::Parser;
 use serde::Serialize;
 
 use crate::parser::oracle_nom::enters_under::ControlClausePossessor;
+use crate::parser::oracle_nom::error::OracleError;
 use crate::types::ability::MultiTargetSpec;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, ActivationRestriction, BounceSelection,
@@ -1981,25 +1986,29 @@ pub(crate) fn with_clause_duration(
     clause
 }
 
+/// CR 611.2a: recognizes the complete duration conditions whose casting
+/// permission lasts exactly while the referenced object remains in exile.
 pub(crate) fn is_play_from_exile_lifetime_duration(duration: &Duration) -> bool {
-    matches!(
-        duration,
-        Duration::ForAsLongAs {
-            condition: StaticCondition::Unrecognized { text },
-        } if matches!(
-            text.as_str(),
-            "it remains exiled"
-                | "that card remains exiled"
-                | "those cards remain exiled"
-                | "they remain exiled"
-        )
-    )
+    let Duration::ForAsLongAs {
+        condition: StaticCondition::Unrecognized { text },
+    } = duration
+    else {
+        return false;
+    };
+    let parsed: nom::IResult<&str, (), OracleError<'_>> = all_consuming(alt((
+        value((), tag("it remains exiled")),
+        value((), tag("that card remains exiled")),
+        value((), tag("those cards remain exiled")),
+        value((), tag("they remain exiled")),
+    )))
+    .parse(text);
+    parsed.is_ok()
 }
 
 fn normalize_play_from_exile_duration(duration: Duration) -> Duration {
     match duration {
         duration if is_play_from_exile_lifetime_duration(&duration) => {
-            // CR 400.7i + CR 611.2a: exile-play permissions persist until the
+            // CR 611.2a: exile-play permissions persist until the
             // referenced object leaves exile; zone-exit cleanup removes the
             // object-tagged permission.
             Duration::Permanent

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__valakut_exploration_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__valakut_exploration_ir.snap
@@ -138,21 +138,18 @@ expression: "&ir"
                     },
                     "parsed": {
                       "effect": {
-                        "type": "CastFromZone",
-                        "target": {
-                          "type": "ParentTarget"
+                        "type": "GrantCastingPermission",
+                        "permission": {
+                          "type": "PlayFromExile",
+                          "duration": "Permanent",
+                          "granted_to": 0
                         },
-                        "without_paying_mana_cost": false,
-                        "mode": "Play"
-                      },
-                      "duration": {
-                        "ForAsLongAs": {
-                          "condition": {
-                            "type": "Unrecognized",
-                            "text": "it remains exiled"
-                          }
+                        "target": {
+                          "type": "TrackedSet",
+                          "id": 0
                         }
                       },
+                      "duration": null,
                       "sub_ability": null,
                       "distribute": null,
                       "multi_target": null,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__valakut_exploration_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__valakut_exploration_ir.snap
@@ -149,7 +149,14 @@ expression: "&ir"
                           "id": 0
                         }
                       },
-                      "duration": null,
+                      "duration": {
+                        "ForAsLongAs": {
+                          "condition": {
+                            "type": "Unrecognized",
+                            "text": "it remains exiled"
+                          }
+                        }
+                      },
                       "sub_ability": null,
                       "distribute": null,
                       "multi_target": null,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__valakut_exploration_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__valakut_exploration_lowered.snap
@@ -40,7 +40,14 @@ expression: "&lowered"
           },
           "cost": null,
           "sub_ability": null,
-          "duration": null,
+          "duration": {
+            "ForAsLongAs": {
+              "condition": {
+                "type": "Unrecognized",
+                "text": "it remains exiled"
+              }
+            }
+          },
           "description": null,
           "target_prompt": null,
           "condition": null,

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__valakut_exploration_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__valakut_exploration_lowered.snap
@@ -27,33 +27,25 @@ expression: "&lowered"
         "sub_ability": {
           "kind": "Spell",
           "effect": {
-            "type": "CastFromZone",
-            "target": {
-              "type": "TrackedSetFiltered",
-              "id": 0,
-              "filter": {
-                "type": "Any"
-              },
-              "caused_by": "Exiled"
+            "type": "GrantCastingPermission",
+            "permission": {
+              "type": "PlayFromExile",
+              "duration": "Permanent",
+              "granted_to": 0
             },
-            "without_paying_mana_cost": false,
-            "mode": "Play"
+            "target": {
+              "type": "TrackedSet",
+              "id": 0
+            }
           },
           "cost": null,
           "sub_ability": null,
-          "duration": {
-            "ForAsLongAs": {
-              "condition": {
-                "type": "Unrecognized",
-                "text": "it remains exiled"
-              }
-            }
-          },
+          "duration": null,
           "description": null,
           "target_prompt": null,
           "condition": null,
           "optional_targeting": false,
-          "optional": true,
+          "optional": false,
           "forward_result": false,
           "sub_link": "SequentialSibling"
         },

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -28537,6 +28537,36 @@ fn elder_brain_they_draw_binds_to_defending_player() {
         }
         other => panic!("expected Draw, got {other:?}"),
     }
+
+    use crate::types::identifiers::TrackedSetId;
+
+    let mut cursor = draw.sub_ability.as_deref();
+    let mut grant = None;
+    while let Some(link) = cursor {
+        if matches!(link.effect.as_ref(), Effect::GrantCastingPermission { .. }) {
+            grant = Some(link);
+            break;
+        }
+        cursor = link.sub_ability.as_deref();
+    }
+    let grant = grant.expect("the plural exile-play permission must remain in the effect chain");
+    assert!(
+        matches!(
+            grant.effect.as_ref(),
+            Effect::GrantCastingPermission {
+                permission: CastingPermission::PlayFromExile {
+                    duration: Duration::Permanent,
+                    ..
+                },
+                target: TargetFilter::TrackedSet {
+                    id: TrackedSetId(0),
+                },
+                ..
+            }
+        ),
+        "expected a permanent plural PlayFromExile grant on the tracked cards, got {:?}",
+        grant.effect
+    );
 }
 
 #[test]

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -3553,6 +3553,55 @@ fn trigger_combat_damage_look_then_exile_face_down_grants_impulse_play() {
     );
 }
 
+/// CR 406.3, CR 406.3a-b, CR 601.2a, and CR 611.2a: Rev's exact Oracle text
+/// grants its controller permission to look at and cast the face-down card for
+/// as long as it remains exiled. The intervening Treasure creation must not
+/// make "that card" bind to the token or lower the permission as an immediate
+/// during-resolution cast.
+#[test]
+fn rev_tithe_extractor_grants_lingering_cast_permission() {
+    use crate::types::identifiers::TrackedSetId;
+
+    let def = parse_trigger_line(
+        "Whenever one or more creatures you control deal combat damage to a player, create a Treasure token, then look at the top card of that player's library and exile it face down. You may cast that card for as long as it remains exiled.",
+        "Rev, Tithe Extractor",
+    );
+    let execute = def.execute.as_deref().expect("trigger should have execute");
+
+    let mut cursor = Some(execute);
+    let mut grant = None;
+    let mut immediate_cast = false;
+    while let Some(link) = cursor {
+        match link.effect.as_ref() {
+            effect @ Effect::GrantCastingPermission { .. } => grant = Some(effect),
+            Effect::CastFromZone { .. } => immediate_cast = true,
+            _ => {}
+        }
+        cursor = link.sub_ability.as_deref();
+    }
+
+    assert!(
+        !immediate_cast,
+        "Rev grants a later casting permission; it must not cast during resolution"
+    );
+    assert!(
+        matches!(
+            grant,
+            Some(Effect::GrantCastingPermission {
+                permission: CastingPermission::PlayFromExile {
+                    duration: Duration::Permanent,
+                    ..
+                },
+                target: TargetFilter::TrackedSet {
+                    id: TrackedSetId(0),
+                },
+                ..
+            })
+        ),
+        "expected a permanent PlayFromExile grant on Rev's tracked face-down card, got: {grant:?}"
+    );
+}
+
 #[test]
 fn trigger_upkeep() {
     let def = parse_trigger_line(

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -969,6 +969,7 @@ mod replacement_mill_double_application;
 mod repro_pilot_crew;
 mod resolve_all_consent;
 mod retarget_prompt_softlock;
+mod rev_tithe_extractor_facedown_cast;
 mod revealed_card_type_disjunction_518;
 mod rhys_evermore_remove_counters;
 mod riot_control_regression;

--- a/crates/engine/tests/integration/rev_tithe_extractor_facedown_cast.rs
+++ b/crates/engine/tests/integration/rev_tithe_extractor_facedown_cast.rs
@@ -30,6 +30,10 @@ fn rev_reveals_and_casts_the_opponents_facedown_exiled_card() {
         .add_spell_to_library_top(P1, "Opponent Zero-Cost Instant", true)
         .with_mana_cost(ManaCost::zero())
         .id();
+    let removal = scenario
+        .add_spell_to_hand_from_oracle(P0, "Rev Test Removal", true, "Destroy target creature.")
+        .with_mana_cost(ManaCost::zero())
+        .id();
     let expected_name = "Opponent Zero-Cost Instant";
 
     let mut runner = scenario.build();
@@ -96,7 +100,9 @@ fn rev_reveals_and_casts_the_opponents_facedown_exiled_card() {
         "Hidden Card"
     );
 
-    engine::game::zones::move_to_zone(runner.state_mut(), rev, Zone::Graveyard, &mut Vec::new());
+    runner.cast(removal).target_object(rev).resolve();
+    runner.advance_until_stack_empty();
+    assert_eq!(runner.state().objects[&rev].zone, Zone::Graveyard);
     assert_eq!(
         filter_state_for_viewer(runner.state(), P0).objects[&exiled].name,
         expected_name,

--- a/crates/engine/tests/integration/rev_tithe_extractor_facedown_cast.rs
+++ b/crates/engine/tests/integration/rev_tithe_extractor_facedown_cast.rs
@@ -1,0 +1,124 @@
+//! End-to-end regression for Rev, Tithe Extractor's face-down exile permission.
+//!
+//! CR 406.3a-b lets the permission holder inspect the face-down exiled card;
+//! CR 601.2a lets that player cast it; CR 611.2a keeps the permission after Rev
+//! leaves the battlefield, for as long as the card remains exiled.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::game::visibility::filter_state_for_viewer;
+use engine::types::ability::{CastingPermission, Duration};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use super::rules::run_combat;
+
+const REV_DAMAGE_TRIGGER: &str = "Whenever one or more creatures you control deal combat damage to a player, create a Treasure token, then look at the top card of that player's library and exile it face down. You may cast that card for as long as it remains exiled.";
+
+#[test]
+fn rev_reveals_and_casts_the_opponents_facedown_exiled_card() {
+    let mut scenario = GameScenario::new_n_player(2, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let rev = scenario
+        .add_creature_from_oracle(P0, "Rev, Tithe Extractor", 3, 3, REV_DAMAGE_TRIGGER)
+        .id();
+    let attacker = scenario.add_creature(P0, "Rev Test Attacker", 2, 2).id();
+    let deep = scenario.add_card_to_library_top(P1, "Opponent Deep Card");
+    let exiled = scenario
+        .add_spell_to_library_top(P1, "Opponent Zero-Cost Instant", true)
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    let expected_name = "Opponent Zero-Cost Instant";
+
+    let mut runner = scenario.build();
+    run_combat(&mut runner, vec![attacker], vec![]);
+
+    for _ in 0..64 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalEffectChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("Rev's optional permission should be accepted");
+            }
+            WaitingFor::OrderTriggers { triggers, .. } => {
+                runner
+                    .act(GameAction::OrderTriggers {
+                        order: (0..triggers.len()).collect(),
+                    })
+                    .expect("trigger ordering should succeed");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.state().objects[&exiled].zone == Zone::Exile
+                    && runner.state().stack.is_empty()
+                {
+                    break;
+                }
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("priority pass should advance Rev's trigger");
+            }
+            ref other => panic!("unexpected prompt while resolving Rev: {other:?}"),
+        }
+    }
+
+    assert_eq!(runner.state().objects[&exiled].zone, Zone::Exile);
+    assert!(runner.state().objects[&exiled].face_down);
+    assert_eq!(runner.state().objects[&deep].zone, Zone::Library);
+    assert!(runner.state().objects.values().any(|object| {
+        object.zone == Zone::Battlefield
+            && object.controller == P0
+            && object
+                .card_types
+                .subtypes
+                .iter()
+                .any(|kind| kind == "Treasure")
+    }));
+    assert!(runner.state().objects[&exiled]
+        .casting_permissions
+        .iter()
+        .any(|permission| matches!(
+            permission,
+            CastingPermission::PlayFromExile {
+                granted_to: P0,
+                duration: Duration::Permanent,
+                ..
+            }
+        )));
+
+    assert_eq!(
+        filter_state_for_viewer(runner.state(), P0).objects[&exiled].name,
+        expected_name
+    );
+    assert_eq!(
+        filter_state_for_viewer(runner.state(), P1).objects[&exiled].name,
+        "Hidden Card"
+    );
+
+    engine::game::zones::move_to_zone(runner.state_mut(), rev, Zone::Graveyard, &mut Vec::new());
+    assert_eq!(
+        filter_state_for_viewer(runner.state(), P0).objects[&exiled].name,
+        expected_name,
+        "Rev may leave play without ending the exile-scoped permission"
+    );
+
+    let cast = engine::ai_support::legal_actions(runner.state())
+        .into_iter()
+        .find(|action| {
+            matches!(
+                action,
+                GameAction::CastSpell { object_id, .. } if *object_id == exiled
+            )
+        })
+        .expect("Rev's controller must be offered the exiled card as a cast action");
+    runner
+        .act(cast)
+        .expect("casting Rev's exiled card should start");
+    runner.advance_until_stack_empty();
+    assert_eq!(
+        runner.state().objects[&exiled].zone,
+        Zone::Graveyard,
+        "the zero-cost instant should resolve after being cast from exile"
+    );
+}


### PR DESCRIPTION
## Summary
- recognize `remain exiled` / `remains exiled` as temporal context after the chunk loop peels `You may`
- lower Rev, Tithe Extractor and Valakut Exploration to a lasting `PlayFromExile` grant instead of an immediate `CastFromZone`
- add exact-Oracle parser coverage plus an end-to-end combat, visibility, persistence, legal-action, and cast regression

## Root cause
The chunk loop reduced `You may cast that card for as long as it remains exiled` to its bare form. The impulse parser only treated `this turn` and `until` as temporal markers, so the clause fell through to the immediate cast parser. Face-down visibility is derived from `PlayFromExile`, which explains both the hidden card and missing later cast action.

## Validation
- `cargo fmt --all`
- `cargo clippy -p phase-engine --all-targets -- -D warnings`
- `cargo test -p phase-engine` (19,680 unit + 5,417 integration passed; expected ignores only)
- `scripts/check-parser-combinators.sh`
- `scripts/check-skill-doc.sh`
- `cargo coverage` (35,798 faces; 88.8% overall, 92.3% Commander)
- `cargo semantic-audit` (32,779 cards audited)
- full MTGJSON generation and schema validation completed; the wrapper later stopped on Windows because `shasum` is unavailable, after card-data validation and promotion

Rules: CR 406.3a-b, 601.2a, 611.2a.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed handling of cards exiled face down by Rev, Tithe Extractor.
  * Exiled cards remain castable by the correct player, even if Rev leaves play.
  * Prevented these cards from being cast immediately when the triggering ability resolves.
  * Improved recognition of exile-related duration text, including permissions lasting as long as cards remain exiled.
  * Preserved permanent casting permissions for multiple cards exiled through relevant effects.

* **Tests**
  * Added coverage for face-down exile, inspection, casting, and cleanup.
  * Added regression tests for permanent permissions and unrelated trailing text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->