### PR TITLE
fix(client): restore drag for castable fan cards

### DIFF
--- a/client/src/components/hand/PlayerHand.tsx
+++ b/client/src/components/hand/PlayerHand.tsx
@@ -619,8 +619,10 @@ export function PlayerHand() {
       >
         <AnimatePresence>
           {/* Exile wing (left): absolute fan positions 0 .. E-1. Cast-only —
-              never reorder targets. zIndex stays negative so exile sits beneath
-              the hand cards (whose zIndex is their 0-based hand index). */}
+              never reorder targets. Keep their stacking level non-negative:
+              a negative z-index puts the cards behind the transformed fan
+              container's hit-test layer, so they render but cannot be grabbed
+              for their flick-up-to-cast gesture. */}
           {exileCards.map((obj, j) => {
             return (
               <ZoneFanCard
@@ -634,7 +636,7 @@ export function PlayerHand() {
                 restingY={verticalMetrics.restingY}
                 hoverY={verticalMetrics.hoverY}
                 marginLeft={j === 0 ? 0 : fan.overlap}
-                zIndex={j - exileCount}
+                zIndex={j}
                 theme={ZONE_THEME.exile}
                 hasPriority={hasPriority}
                 isSelected={selectedCardId === obj.id}
@@ -1114,6 +1116,7 @@ const ZoneFanCard = memo(function ZoneFanCard({
 
   return (
     <motion.div
+      data-zone-fan-card
       // Marks the card as inspectable, which is what usePreviewDismiss's 300ms
       // `[data-card-hover]:hover` poll (and uiStore's 50ms deferred clear) test
       // for. Without it the poll saw nothing hovered and tore the preview down
@@ -1160,7 +1163,7 @@ const ZoneFanCard = memo(function ZoneFanCard({
       }}
       onMouseEnter={() => onMouseEnter(objectId)}
       onMouseLeave={onMouseLeave}
-      className="relative cursor-pointer leading-[0] select-none"
+      className="relative cursor-grab active:cursor-grabbing leading-[0] select-none"
       style={{ marginLeft, zIndex }}
       {...longPressHandlers}
     >

--- a/client/src/components/hand/__tests__/ZoneFanCardHover.test.tsx
+++ b/client/src/components/hand/__tests__/ZoneFanCardHover.test.tsx
@@ -57,6 +57,21 @@ function graveyardWingState() {
   return { gyCard, handCard };
 }
 
+function exileWingState() {
+  const exileCard = gameObjectFactory.withId(401).inExile().named("Plot Card").build();
+  const handCard = gameObjectFactory.withId(402).inHand().named("Hand Card").build();
+  const gameState = gameStateFactory
+    .withPlayers({ id: 0, hand: [handCard.id] }, 1)
+    .withObjects(exileCard, handCard)
+    .build({ exile: [exileCard.id] });
+  useGameStore.setState({
+    gameState,
+    spellCosts: {},
+    legalActionsByObject: { [String(exileCard.id)]: [castSpell(exileCard.id)] },
+  });
+  return { exileCard };
+}
+
 /**
  * Stand in for the browser's `:hover` hit-test, which jsdom does not implement.
  *
@@ -108,7 +123,7 @@ describe("castable graveyard/exile wing hover", () => {
     // would make a revert fail at this lookup rather than at the dismissal
     // assertion below, which is the behaviour this test exists to pin.
     const art = within(container).getByAltText("Encore Card");
-    const wing = art.closest<HTMLElement>(".cursor-pointer");
+    const wing = art.closest<HTMLElement>(".cursor-grab");
     expect(wing).not.toBeNull();
     simulatePointerOver(wing!);
 
@@ -147,5 +162,24 @@ describe("castable graveyard/exile wing hover", () => {
     const reorderable = container.querySelectorAll(HAND_REORDER_SELECTOR);
     expect(reorderable.length).toBe(1);
     expect((reorderable[0] as HTMLElement).dataset.objectId).toBe(String(handCard.id));
+  });
+
+  it("keeps exile and graveyard wing cards in the fan's interactive stacking layer", () => {
+    graveyardWingState();
+    const { container: graveyardContainer } = render(<PlayerHand />);
+    const graveyardWing = within(graveyardContainer)
+      .getByAltText("Encore Card")
+      .closest<HTMLElement>(".cursor-grab");
+    expect(graveyardWing).not.toBeNull();
+    expect(graveyardWing).toHaveStyle({ zIndex: "1" });
+
+    cleanup();
+    exileWingState();
+    const { container: exileContainer } = render(<PlayerHand />);
+    const exileWing = within(exileContainer)
+      .getByAltText("Plot Card")
+      .closest<HTMLElement>(".cursor-grab");
+    expect(exileWing).not.toBeNull();
+    expect(exileWing).toHaveStyle({ zIndex: "0" });
   });
 });

--- a/client/src/components/hand/__tests__/useHandScrubPreview.test.tsx
+++ b/client/src/components/hand/__tests__/useHandScrubPreview.test.tsx
@@ -48,6 +48,7 @@ function ScrubHarness({
     >
       <div data-testid="card-11" data-hand-card data-object-id="11" />
       <div data-testid="card-12" data-hand-card data-object-id="12" />
+      <div data-testid="zone-wing" data-zone-fan-card />
     </div>
   );
 }
@@ -59,6 +60,25 @@ afterEach(() => {
 });
 
 describe("useHandScrubPreview", () => {
+  it("leaves a castable zone wing's pointer stream to its own drag gesture", () => {
+    vi.useFakeTimers();
+    const onOpen = vi.fn();
+    render(<ScrubHarness onOpen={onOpen} />);
+
+    fireEvent.pointerDown(screen.getByTestId("zone-wing"), {
+      button: 0,
+      clientX: 40,
+      clientY: 100,
+      isPrimary: true,
+      pointerId: 3,
+      pointerType: "touch",
+    });
+    act(() => vi.advanceTimersByTime(400));
+
+    expect(useUiStore.getState().inspectedObjectId).toBeNull();
+    expect(useUiStore.getState().mobileHandGesture).toBeNull();
+  });
+
   it("holds to preview, scrubs adjacent cards, and suppresses the release click", () => {
     vi.useFakeTimers();
     const onOpen = vi.fn();

--- a/client/src/components/hand/useHandScrubPreview.ts
+++ b/client/src/components/hand/useHandScrubPreview.ts
@@ -223,6 +223,16 @@ export function useHandScrubPreview(
         return;
       }
 
+      // Castable exile/graveyard wings own their Framer Motion drag gesture.
+      // Do not capture the pointer at the hand container: doing so prevents the
+      // wing from receiving the move/up events needed for flick-up-to-cast.
+      if (
+        event.target instanceof Element
+        && event.target.closest("[data-zone-fan-card]")
+      ) {
+        return;
+      }
+
       clearClickSuppression();
       clearHoldTimer();
       setMobileHandGesture(null);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved interaction with castable cards in exile and graveyard zones.
  - Cards now remain accessible above the hand fan and can be grabbed for flick-up casting.
  - Prevented long-touch gestures on zone cards from incorrectly triggering hand previews or mobile hand interactions.
  - Updated cursor feedback to clearly indicate draggable cards.

- **Tests**
  - Added coverage for card stacking, dragging, and touch interaction behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->