### PR TITLE
Add creature-death threshold conditions

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -6475,6 +6475,7 @@ fn parse_played_a_land_this_turn(input: &str) -> OracleResult<'_, StaticConditio
 
 fn parse_creature_died_this_turn_conditions(input: &str) -> OracleResult<'_, StaticCondition> {
     alt((
+        parse_creatures_died_this_turn_threshold,
         parse_died_under_your_control_this_turn,
         // "a creature died this turn" (Morbid) → zone-change count >= 1
         value(
@@ -6491,6 +6492,19 @@ fn parse_creature_died_this_turn_conditions(input: &str) -> OracleResult<'_, Sta
         parse_filtered_creature_died_this_turn,
     ))
     .parse(input)
+}
+
+/// CR 603.4 + CR 700.4: "N or more/fewer creatures died this turn" compares
+/// the requested threshold with the number of creature battlefield-to-graveyard
+/// moves recorded this turn. The shared threshold grammar also covers the
+/// equivalent "at least N" wording and keeps the comparator axis typed.
+fn parse_creatures_died_this_turn_threshold(input: &str) -> OracleResult<'_, StaticCondition> {
+    let (rest, (threshold, comparator)) = parse_amount_threshold(input)?;
+    let (rest, _) = tag(" creatures died this turn").parse(rest)?;
+    Ok((
+        rest,
+        make_quantity_comparison(creatures_died_this_turn_ref(), comparator, threshold),
+    ))
 }
 
 /// "a <type-phrase> died this turn" — the filtered Morbid gate without a
@@ -17258,6 +17272,29 @@ mod tests {
                 assert_eq!(rhs, QuantityExpr::Fixed { value: 1 });
             }
             _ => panic!("expected QuantityComparison, got {c:?}"),
+        }
+    }
+
+    #[test]
+    fn creature_death_threshold_uses_zone_change_count_and_typed_comparator() {
+        for (text, comparator, threshold) in [
+            ("three or more creatures died this turn", Comparator::GE, 3),
+            ("two or fewer creatures died this turn", Comparator::LE, 2),
+            ("at least five creatures died this turn", Comparator::GE, 5),
+        ] {
+            let (rest, condition) = parse_inner_condition(text).unwrap();
+            assert_eq!(rest, "", "{text}");
+            assert_eq!(
+                condition,
+                StaticCondition::QuantityComparison {
+                    lhs: QuantityExpr::Ref {
+                        qty: creatures_died_this_turn_ref(),
+                    },
+                    comparator,
+                    rhs: QuantityExpr::Fixed { value: threshold },
+                },
+                "{text}"
+            );
         }
     }
 

--- a/crates/engine/tests/integration/fra_bloodline_recollector.rs
+++ b/crates/engine/tests/integration/fra_bloodline_recollector.rs
@@ -1,0 +1,172 @@
+//! Reality Fracture coverage for Bloodline Recollector's creature-death threshold.
+
+use engine::game::game_object::BackFaceData;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    Comparator, QuantityExpr, QuantityRef, TargetFilter, TriggerCondition, TypeFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card::LayoutKind;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const BLOODLINE_ORACLE: &str = "At the beginning of each end step, if three or more creatures died this turn, this creature becomes prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)";
+
+fn setup(death_count: usize) -> (GameRunner, engine::types::identifiers::ObjectId) {
+    let parsed = parse_oracle_text(
+        BLOODLINE_ORACLE,
+        "Bloodline Recollector",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let trigger = parsed
+        .triggers
+        .first()
+        .expect("Bloodline must parse its end-step trigger");
+    assert!(
+        !serde_json::to_string(trigger)
+            .expect("serialize trigger")
+            .contains("\"Unimplemented\""),
+        "verbatim Bloodline Oracle must contain no Unimplemented node"
+    );
+    let Some(TriggerCondition::QuantityComparison {
+        lhs:
+            QuantityExpr::Ref {
+                qty:
+                    QuantityRef::ZoneChangeCountThisTurn {
+                        from,
+                        to,
+                        filter: TargetFilter::Typed(filter),
+                    },
+            },
+        comparator,
+        rhs,
+    }) = trigger.condition.as_ref()
+    else {
+        panic!("expected the typed creature-death threshold condition")
+    };
+    assert_eq!(*from, Some(Zone::Battlefield));
+    assert_eq!(*to, Some(Zone::Graveyard));
+    assert!(filter.type_filters.contains(&TypeFilter::Creature));
+    assert_eq!(*comparator, Comparator::GE);
+    assert_eq!(*rhs, QuantityExpr::Fixed { value: 3 });
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Bloodline Recollector", 2, 2)
+        .from_oracle_text(BLOODLINE_ORACLE)
+        .id();
+
+    let mut victims = Vec::new();
+    let mut removal = Vec::new();
+    for index in 0..death_count {
+        victims.push(
+            scenario
+                .add_creature(P1, &format!("Threshold Victim {index}"), 2, 2)
+                .id(),
+        );
+        removal.push(
+            scenario
+                .add_spell_to_hand_from_oracle(
+                    P0,
+                    &format!("Threshold Removal {index}"),
+                    true,
+                    "Destroy target creature.",
+                )
+                .id(),
+        );
+    }
+
+    let mut runner = scenario.build();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&source)
+        .unwrap()
+        .back_face = Some(BackFaceData {
+        layout_kind: Some(LayoutKind::Prepare),
+        ..BackFaceData::default()
+    });
+
+    for (spell, victim) in removal.into_iter().zip(victims) {
+        runner.cast(spell).target_object(victim).resolve();
+    }
+    (runner, source)
+}
+
+fn source_trigger_count(
+    runner: &GameRunner,
+    source: engine::types::identifiers::ObjectId,
+) -> usize {
+    runner
+        .state()
+        .stack
+        .iter()
+        .filter(|entry| entry.source_id == source)
+        .count()
+}
+
+fn advance_to_end_step_trigger(
+    runner: &mut GameRunner,
+    source: engine::types::identifiers::ObjectId,
+) {
+    for _ in 0..200 {
+        if source_trigger_count(runner, source) > 0
+            || (runner.state().phase == Phase::End
+                && runner.state().stack.is_empty()
+                && matches!(runner.state().waiting_for, WaitingFor::Priority { .. }))
+        {
+            return;
+        }
+        match runner.state().waiting_for.clone() {
+            WaitingFor::Priority { .. } => runner
+                .act(GameAction::PassPriority)
+                .expect("pass priority while advancing to the end step"),
+            WaitingFor::DeclareAttackers { .. } => runner
+                .act(GameAction::DeclareAttackers {
+                    attacks: vec![],
+                    bands: vec![],
+                })
+                .expect("declare no attackers"),
+            WaitingFor::DeclareBlockers { .. } => runner
+                .act(GameAction::DeclareBlockers {
+                    assignments: vec![],
+                })
+                .expect("declare no blockers"),
+            other => panic!("unexpected waiting state before end step: {other:?}"),
+        };
+    }
+    panic!("phase machine did not reach the end-step trigger");
+}
+
+#[test]
+fn bloodline_threshold_gates_at_two_and_fires_at_three() {
+    let (mut below, source) = setup(2);
+    advance_to_end_step_trigger(&mut below, source);
+    assert_eq!(source_trigger_count(&below, source), 0);
+    assert!(below.state().objects[&source].prepared.is_none());
+
+    let (mut exact, source) = setup(3);
+    advance_to_end_step_trigger(&mut exact, source);
+    assert_eq!(source_trigger_count(&exact, source), 1);
+    exact.advance_until_stack_empty();
+    assert!(exact.state().objects[&source].prepared.is_some());
+}
+
+#[test]
+fn bloodline_intervening_if_is_rechecked_on_resolution() {
+    let (mut runner, source) = setup(3);
+    advance_to_end_step_trigger(&mut runner, source);
+    assert_eq!(source_trigger_count(&runner, source), 1);
+
+    // CR 603.4 requires a live resolution-time recheck. Death history is
+    // monotonic during ordinary play, so clear the observed ledger after the
+    // trigger reaches the stack to make a skipped recheck observably wrong.
+    runner.state_mut().zone_changes_this_turn.clear();
+    runner.advance_until_stack_empty();
+    assert!(runner.state().objects[&source].prepared.is_none());
+}

--- a/crates/engine/tests/integration/fra_bloodline_recollector.rs
+++ b/crates/engine/tests/integration/fra_bloodline_recollector.rs
@@ -4,15 +4,26 @@ use engine::game::game_object::BackFaceData;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::{
-    Comparator, QuantityExpr, QuantityRef, TargetFilter, TriggerCondition, TypeFilter,
+    AbilityCondition, Comparator, Effect, QuantityExpr, QuantityRef, TargetFilter,
+    TriggerCondition, TypeFilter,
 };
 use engine::types::actions::GameAction;
 use engine::types::card::LayoutKind;
 use engine::types::game_state::WaitingFor;
 use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
 use engine::types::zones::Zone;
 
 const BLOODLINE_ORACLE: &str = "At the beginning of each end step, if three or more creatures died this turn, this creature becomes prepared. (While it's prepared, you may cast a copy of its spell. Doing so unprepares it.)";
+const TALLYMAN_ORACLE: &str = "Lifelink\nThe Seven-fold Chant — At the beginning of your end step, if a creature died this turn, you draw a card and you lose 1 life. If seven or more creatures died this turn, instead you draw seven cards and you lose 7 life.";
+
+fn hand_len(runner: &GameRunner, player: PlayerId) -> usize {
+    runner.state().players[player.0 as usize].hand.len()
+}
+
+fn life_total(runner: &GameRunner, player: PlayerId) -> i32 {
+    runner.state().players[player.0 as usize].life
+}
 
 fn setup(death_count: usize) -> (GameRunner, engine::types::identifiers::ObjectId) {
     let parsed = parse_oracle_text(
@@ -169,4 +180,138 @@ fn bloodline_intervening_if_is_rechecked_on_resolution() {
     runner.state_mut().zone_changes_this_turn.clear();
     runner.advance_until_stack_empty();
     assert!(runner.state().objects[&source].prepared.is_none());
+}
+
+fn setup_tallyman(death_count: usize) -> (GameRunner, engine::types::identifiers::ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Tallyman of Nurgle", 2, 3)
+        .from_oracle_text(TALLYMAN_ORACLE)
+        .id();
+
+    let mut victims = Vec::new();
+    let mut removal = Vec::new();
+    for index in 0..death_count {
+        victims.push(
+            scenario
+                .add_creature(P1, &format!("Sevenfold Victim {index}"), 1, 1)
+                .id(),
+        );
+        removal.push(
+            scenario
+                .add_spell_to_hand_from_oracle(
+                    P0,
+                    &format!("Sevenfold Removal {index}"),
+                    true,
+                    "Destroy target creature.",
+                )
+                .id(),
+        );
+    }
+    for index in 0..7 {
+        scenario.add_card_to_library_top(P0, &format!("Sevenfold Draw {index}"));
+    }
+
+    let mut runner = scenario.build();
+    for (spell, victim) in removal.into_iter().zip(victims) {
+        runner.cast(spell).target_object(victim).resolve();
+    }
+    (runner, source)
+}
+
+#[test]
+fn tallyman_instead_branch_preserves_draw_and_life_loss_chains() {
+    let parsed = parse_oracle_text(
+        TALLYMAN_ORACLE,
+        "Tallyman of Nurgle",
+        &[],
+        &["Creature".to_string()],
+        &["Astartes".to_string(), "Warrior".to_string()],
+    );
+    let base = parsed.triggers[0]
+        .execute
+        .as_ref()
+        .expect("Tallyman's end-step trigger must have an effect");
+    assert!(matches!(
+        base.effect.as_ref(),
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            ..
+        }
+    ));
+
+    let replacement = base
+        .sub_ability
+        .as_ref()
+        .expect("the seven-death replacement must be attached to the base draw");
+    assert!(matches!(
+        replacement.condition,
+        Some(AbilityCondition::ConditionInstead { .. })
+    ));
+    assert!(matches!(
+        replacement.effect.as_ref(),
+        Effect::Draw {
+            count: QuantityExpr::Fixed { value: 7 },
+            ..
+        }
+    ));
+    assert!(matches!(
+        replacement
+            .sub_ability
+            .as_ref()
+            .expect("the replacement must retain its lose-7 tail")
+            .effect
+            .as_ref(),
+        Effect::LoseLife {
+            amount: QuantityExpr::Fixed { value: 7 },
+            ..
+        }
+    ));
+    assert!(matches!(
+        replacement
+            .else_ability
+            .as_ref()
+            .expect("the false branch must retain the printed lose-1 tail")
+            .effect
+            .as_ref(),
+        Effect::LoseLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            ..
+        }
+    ));
+}
+
+/// CR 614.6 + CR 608.2c: every instruction in the seven-death `instead`
+/// branch replaces the printed one-card/one-life chain. This drives the real
+/// trigger and resolution pipeline and asserts both instructions in the branch.
+#[test]
+fn tallyman_seven_deaths_draws_seven_and_loses_seven_life() {
+    let (mut runner, source) = setup_tallyman(7);
+
+    let hand_before = hand_len(&runner, P0);
+    let life_before = life_total(&runner, P0);
+    advance_to_end_step_trigger(&mut runner, source);
+    assert_eq!(source_trigger_count(&runner, source), 1);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(hand_len(&runner, P0), hand_before + 7);
+    assert_eq!(life_total(&runner, P0), life_before - 7);
+}
+
+/// CR 614.6: below seven deaths, no instruction from the `instead` branch may
+/// run. This is the negative discriminator for the seven-death runtime witness:
+/// an `and` tail peeled into an unconditional sibling loses 7 life here.
+#[test]
+fn tallyman_one_death_keeps_the_one_card_one_life_base_branch() {
+    let (mut runner, source) = setup_tallyman(1);
+
+    let hand_before = hand_len(&runner, P0);
+    let life_before = life_total(&runner, P0);
+    advance_to_end_step_trigger(&mut runner, source);
+    assert_eq!(source_trigger_count(&runner, source), 1);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(hand_len(&runner, P0), hand_before + 1);
+    assert_eq!(life_total(&runner, P0), life_before - 1);
 }

--- a/crates/engine/tests/integration/fra_bloodline_recollector.rs
+++ b/crates/engine/tests/integration/fra_bloodline_recollector.rs
@@ -282,9 +282,9 @@ fn tallyman_instead_branch_preserves_draw_and_life_loss_chains() {
     ));
 }
 
-/// CR 614.6 + CR 608.2c: every instruction in the seven-death `instead`
-/// branch replaces the printed one-card/one-life chain. This drives the real
-/// trigger and resolution pipeline and asserts both instructions in the branch.
+/// CR 608.2c: the seven-death condition selects the printed `instead` branch
+/// while the ability resolves. This drives the real trigger and resolution
+/// pipeline and asserts both instructions in the selected branch.
 #[test]
 fn tallyman_seven_deaths_draws_seven_and_loses_seven_life() {
     let (mut runner, source) = setup_tallyman(7);
@@ -299,8 +299,8 @@ fn tallyman_seven_deaths_draws_seven_and_loses_seven_life() {
     assert_eq!(life_total(&runner, P0), life_before - 7);
 }
 
-/// CR 614.6: below seven deaths, no instruction from the `instead` branch may
-/// run. This is the negative discriminator for the seven-death runtime witness:
+/// CR 608.2c: below seven deaths, resolution follows the base instructions and
+/// does not select the printed `instead` branch. This is the negative witness:
 /// an `and` tail peeled into an unconditional sibling loses 7 life here.
 #[test]
 fn tallyman_one_death_keeps_the_one_card_one_life_base_branch() {

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -259,6 +259,7 @@ mod floodpits_drowner;
 mod flowstone_surge_mixed_anthem;
 mod forced_retarget_multi_role_mana_6056;
 mod foretell_pipeline;
+mod fra_bloodline_recollector;
 mod frenzy_attacker_unblocked_pump;
 mod frodo_ringbearer_must_be_blocked_gate;
 mod frostcliff_siege_anchor_word_modes;

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 30
-- **Distinct cards implicated:** 4718
-- **Total card appearances across root causes:** 4751 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4714
+- **Total card appearances across root causes:** 4747 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -13,7 +13,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | # | Root cause | # cards | Fix hint (where it likely lives) |
 |---|------------|--------:|----------------------------------|
 | 1 | Relative-clause / filter restriction on target dropped | 746 | oracle_target.rs / game/filter.rs — extend TargetFilter property extraction for trailing relative clauses |
-| 2 | Dropped intervening-if / gating condition (condition: null) | 589 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
+| 2 | Dropped intervening-if / gating condition (condition: null) | 585 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
 | 3 | Anaphor bound to wrong referent | 404 | oracle_quantity.rs context-ref resolution + game/ability_utils.rs forward_result wiring |
 | 4 | Conjoined / chained second effect clause dropped | 387 | oracle.rs effect-chain composition — split on 'and'/'then'/sentence boundaries and build sub_ability chain |
 | 5 | Dropped 'for each' / dynamic count collapsed to Fixed | 330 | oracle_quantity.rs parse_for_each_clause / parse_quantity_ref — thread ForEach/ObjectCount into the effect count field |
@@ -803,7 +803,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 2. Dropped intervening-if / gating condition (condition: null)  (589 cards)
+### 2. Dropped intervening-if / gating condition (condition: null)  (585 cards)
 
 **Signature.** Trigger/static/replacement/spell condition left null though Oracle has an 'if/while/as long as/unless' game-state gate; the effect resolves unconditionally (CR 603.4 / 608.2c).
 
@@ -956,7 +956,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Earwig Squad
 - Ego Drain
 - Elcohol
-- Emeritus of Woe
 - Endless Evil
 - Enshrouding Mist
 - Ephara, God of the Polis
@@ -1073,7 +1072,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Incisor Glider
 - Inferno Hellion
 - Infinite Guideline Station
-- Inga Rune-Eyes
 - Initiates of the Ebon Hand
 - Instrument of the Bards
 - Intermediate Chirography
@@ -1101,7 +1099,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Kyren Legate
 - Kytheon, Hero of Akros
 - Laboratory Drudge
-- Lagomos, Hand of Hatred
 - Lairwatch Giant
 - Lashwhip Predator
 - Latchkey Faerie

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -868,7 +868,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Blazing Bomb
 - Blitzwing, Cruel Tormentor
 - Bloodletter of Aclazotz
-- Bloodline Recollector
 - Boing!
 - Bonehoard Dracosaur
 - Boreal Outrider


### PR DESCRIPTION
## Summary

Adds general parser and runtime support for numeric creature-death thresholds such as Bloodline Recollector's "three or more creatures died this turn", including correct intervening-if rechecks.

Review follow-up: Tallyman of Nurgle's complete seven-death replacement was already present in the generated AST; the parse-impact receipt showed the changed conditional draw signature but omitted the unchanged nested lose-7 tail. Exact AST assertions plus seven-death and one-death runtime witnesses now prove both complete branches.

## Files changed

- `crates/engine/src/parser/oracle_nom/condition.rs`
- `crates/engine/tests/integration/fra_bloodline_recollector.rs`
- `crates/engine/tests/integration/main.rs`
- `docs/parser-misparse-backlog.md`

## Track

Developer

## LLM

Model: gpt-5.6-sol (via Codex; canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 603.4
- CR 608.2c
- CR 700.4

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — PASS
- `cargo clippy-strict` — PASS
- `cargo test -p phase-engine creature_death_threshold_uses_zone_change_count_and_typed_comparator --lib` — PASS (1/1)
- `cargo test -p phase-engine --test integration fra_bloodline_recollector` — PASS (5/5), including exact AST shape plus seven-death and one-death runtime witnesses for Tallyman of Nurgle
- `cargo test -p phase-engine` — PASS (19,697 unit tests run; integration 5,487 passed, 0 failed, 2 ignored; doc tests 0 failed)
- `./scripts/gen-card-data.sh` — PASS (35,009 cards; 32,172 fully implemented)
- `cargo coverage` — PASS (31,809/35,798 supported; Commander 30,131/32,629)
- `cargo semantic-audit` — PASS; Tallyman has no finding, while Underbridge Warlock remains unsupported and retains its audit finding
- current-head parse-impact receipt — 7 cards / 8 signatures; Underbridge Warlock is not claimed
- `git diff --check upstream/main...HEAD` — PASS

## Gate A

Gate A PASS head=66a6da28a0661a785137c3edf0b958271a9b27fd base=1549e7a57b2a679072214f6eeb31aca495b2d7ed00

## Anchored on

- `crates/engine/src/parser/oracle_nom/condition.rs:6476` — existing creature-died-this-turn condition family and authority
- `crates/engine/src/parser/oracle_nom/condition.rs:6573` — shared typed amount-threshold grammar reused by the new class

## Final review-impl

Final review-impl PASS head=66a6da28a0661a785137c3edf0b958271a9b27fd

## Claimed parse impact

- Bloodline Recollector
- Emeritus of Woe
- Feast of the Victorious Dead
- Inga Rune-Eyes
- Kuon, Ogre Ascendant
- Lagomos, Hand of Hatred
- Tallyman of Nurgle

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for parsing and evaluating numeric creature-death thresholds, including “three or more,” “two or fewer,” and “at least five.”
  * Threshold-based abilities now correctly recheck intervening conditions when resolving.

* **Bug Fixes**
  * Corrected threshold-triggered outcomes for Bloodline Recollector and Tallyman of Nurgle.

* **Tests**
  * Added coverage for below-threshold, exact-threshold, and multi-outcome scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

