### PR TITLE
Support compound printed short names

### DIFF
--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -14,7 +14,7 @@ use crate::parser::oracle::{
     is_draft_matters_sentence,
 };
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
-use crate::parser::oracle_util::SELF_REF_TYPE_PHRASES;
+use crate::parser::oracle_util::normalize_card_name_refs;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, ActivationRestriction,
     AdditionalCost, AggregateFunction, AttackScope, AttackSubject, CardTypeSetSource, ChoiceType,
@@ -9422,73 +9422,9 @@ impl<'a> ParsedElement<'a> {
 /// Normalize Oracle text for description matching: replace card-name self-references
 /// with `~` so they match parsed descriptions (which use `~` normalization).
 fn normalize_for_matching(lower: &str, card_name_lower: &str) -> String {
-    // Replace the full card name (or comma-truncated/word-prefix form) with ~
-    let mut result = lower.to_string();
-    if !card_name_lower.is_empty() {
-        // Try full name first
-        result = result.replace(card_name_lower, "~");
-        // Alchemy rebalance prefix: "a-armory veteran" → try "armory veteran"
-        if !result.contains('~') {
-            if let Some(stripped) = card_name_lower.strip_prefix("a-") {
-                result = result.replace(stripped, "~");
-            }
-        }
-        // Comma-truncated: "akiri, line-slinger" → "akiri"
-        if let Some(short) = card_name_lower.split(',').next() {
-            let short = short.trim();
-            if short.len() > 2 {
-                result = result.replace(short, "~");
-                // Also try with Alchemy prefix stripped: "a-alrund" → "alrund"
-                if !result.contains('~') {
-                    if let Some(stripped) = short.strip_prefix("a-") {
-                        if stripped.len() > 2 {
-                            result = result.replace(stripped, "~");
-                        }
-                    }
-                }
-            }
-        }
-        // "of"-based: "rosie cotton of south lane" → "rosie cotton"
-        if !result.contains('~') {
-            if let Some(of_pos) = card_name_lower.find(" of ") {
-                let short = &card_name_lower[..of_pos];
-                if short.len() >= 3 {
-                    result = result.replace(short, "~");
-                }
-            }
-        }
-        // First-word prefix: "bontu the glorified" → try "bontu the", "bontu"
-        // Mirrors the parser's normalize_card_name_refs short-name strategy.
-        // Always runs (even if `~` is already present from the parser) to ensure
-        // consistent normalization between oracle lines and parsed descriptions.
-        // Skips common MTG game terms that would cause false matches.
-        {
-            const GAME_TERM_BLOCKLIST: &[&str] = &[
-                "quest", "spirit", "heart", "edge", "wall", "lake", "dream", "herald", "champion",
-                "guardian", "master", "prophet", "bringer",
-            ];
-            let name_words: Vec<&str> = card_name_lower.split_whitespace().collect();
-            for len in (1..name_words.len()).rev() {
-                let candidate: String = name_words[..len].join(" ");
-                if candidate.len() >= 3 {
-                    // Skip single-word candidates that are common MTG game terms
-                    if len == 1 && GAME_TERM_BLOCKLIST.contains(&candidate.as_str()) {
-                        continue;
-                    }
-                    let replaced = result.replace(candidate.as_str(), "~");
-                    if replaced != result {
-                        result = replaced;
-                        break;
-                    }
-                }
-            }
-        }
-    }
-    // Normalize common self-reference phrases to ~
-    for phrase in SELF_REF_TYPE_PHRASES.iter().chain(["this spell"].iter()) {
-        result = result.replace(phrase, "~");
-    }
-    result
+    // Keep coverage matching byte-equivalent to the parser's self-reference
+    // authority. Coverage adds only its historical "this spell" alias.
+    normalize_card_name_refs(lower, card_name_lower).replace("this spell", "~")
 }
 
 fn split_trigger_variants(norm: &str) -> Option<Vec<String>> {
@@ -15190,6 +15126,31 @@ mod tests {
             normalize_for_matching("when this battle enters", ""),
             "when ~ enters"
         );
+    }
+
+    #[test]
+    fn test_normalize_for_matching_uses_parser_compound_short_name_authority() {
+        let cases = [
+            (
+                "whenever captain kirk enters or attacks, choose one.",
+                "captain james t. kirk",
+            ),
+            (
+                "whenever captain janeway or another creature you control enters, that creature explores.",
+                "captain kathryn janeway",
+            ),
+            (
+                "the minstrel's ballad — at the beginning of combat on your turn, create a token.",
+                "the wandering minstrel",
+            ),
+        ];
+        for (text, name) in cases {
+            assert_eq!(
+                normalize_for_matching(text, name),
+                normalize_card_name_refs(text, name),
+                "coverage and parser normalization must not drift for {name}"
+            );
+        }
     }
 
     #[test]

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -15154,6 +15154,17 @@ mod tests {
     }
 
     #[test]
+    fn test_normalize_for_matching_strips_lowercase_alchemy_prefix() {
+        assert_eq!(
+            normalize_for_matching(
+                "whenever sprouting goblin attacks, create a token.",
+                "a-sprouting goblin",
+            ),
+            "whenever ~ attacks, create a token."
+        );
+    }
+
+    #[test]
     fn test_audit_treats_firebending_as_keyword_line() {
         assert!(is_keyword_line(
             "firebending x, where x is this creature's power."

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -1284,7 +1284,7 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
             .as_ref()
             .or(state.current_trigger_event.as_ref());
         super::triggers::seed_batched_attack_parent_targets(ability, event_ref);
-        super::triggers::seed_event_context_parent_targets(ability, event_ref);
+        super::triggers::seed_event_context_parent_targets(state, ability, event_ref);
     }
 
     if ability

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -1285,7 +1285,6 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
             .or(state.current_trigger_event.as_ref());
         super::triggers::seed_batched_attack_parent_targets(ability, event_ref);
         super::triggers::seed_event_context_parent_targets(
-            state,
             ability,
             event_ref,
             super::triggers::EventContextSeedTiming::ResolutionFallback,

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -1284,7 +1284,12 @@ pub fn resolve_top(state: &mut GameState, events: &mut Vec<GameEvent>) {
             .as_ref()
             .or(state.current_trigger_event.as_ref());
         super::triggers::seed_batched_attack_parent_targets(ability, event_ref);
-        super::triggers::seed_event_context_parent_targets(state, ability, event_ref);
+        super::triggers::seed_event_context_parent_targets(
+            state,
+            ability,
+            event_ref,
+            super::triggers::EventContextSeedTiming::ResolutionFallback,
+        );
     }
 
     if ability

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -7422,10 +7422,17 @@ fn parent_target_seeding_blocked(ability: &ResolvedAbility) -> bool {
         .any(|t| !matches!(t, TargetRef::Object(id) if *id == ability.source_id))
 }
 
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum EventContextSeedTiming {
+    StackPush,
+    ResolutionFallback,
+}
+
 pub(crate) fn seed_event_context_parent_targets(
     state: &GameState,
     ability: &mut ResolvedAbility,
     trigger_event: Option<&GameEvent>,
+    timing: EventContextSeedTiming,
 ) {
     let Some(event) = trigger_event else {
         return;
@@ -7433,12 +7440,21 @@ pub(crate) fn seed_event_context_parent_targets(
     if !effect_uses_parent_target(&ability.effect) || parent_target_seeding_blocked(ability) {
         return;
     }
-    let (parent_id, pin_zone_change_referent) = match event {
-        GameEvent::ZoneChanged { object_id, .. } => (Some(*object_id), true),
-        GameEvent::Stationed { creature_id, .. } => (Some(*creature_id), false),
-        GameEvent::VehicleCrewed { vehicle_id, .. } => (Some(*vehicle_id), false),
-        GameEvent::Saddled { mount_id, .. } => (Some(*mount_id), false),
-        _ => (None, false),
+    let parent_id = match event {
+        GameEvent::ZoneChanged { object_id, .. } => {
+            // CR 400.7: the exact post-change incarnation can be captured only
+            // when the trigger is put on the stack. A resolution fallback may
+            // run after the card left and returned with the same storage id, so
+            // it must never create or replace a zone-change referent.
+            if timing == EventContextSeedTiming::ResolutionFallback {
+                return;
+            }
+            Some(*object_id)
+        }
+        GameEvent::Stationed { creature_id, .. } => Some(*creature_id),
+        GameEvent::VehicleCrewed { vehicle_id, .. } => Some(*vehicle_id),
+        GameEvent::Saddled { mount_id, .. } => Some(*mount_id),
+        _ => None,
     };
     if let Some(id) = parent_id {
         ability.targets = vec![TargetRef::Object(id)];
@@ -7446,7 +7462,7 @@ pub(crate) fn seed_event_context_parent_targets(
         // post-change object. Pin that incarnation so leaving the destination
         // zone and returning before resolution cannot retarget the ability to
         // the new object that reuses the same storage id.
-        if pin_zone_change_referent && ability.target_incarnations.is_empty() {
+        if matches!(event, GameEvent::ZoneChanged { .. }) {
             let pins = state
                 .objects
                 .get(&id)
@@ -7553,7 +7569,12 @@ fn push_pending_trigger_to_stack_with_firing_and_duration_events(
     let event_attacker = event_attacker_from_trigger_event(state, trigger_event.as_ref());
     ability.bind_force_block_attacker_recursive(event_attacker);
     seed_batched_attack_parent_targets(&mut ability, trigger_event.as_ref());
-    seed_event_context_parent_targets(state, &mut ability, trigger_event.as_ref());
+    seed_event_context_parent_targets(
+        state,
+        &mut ability,
+        trigger_event.as_ref(),
+        EventContextSeedTiming::StackPush,
+    );
 
     let entry_id = ObjectId(state.next_object_id);
     state.next_object_id += 1;
@@ -16366,7 +16387,12 @@ pub mod tests {
             counters_added: 1,
         };
         let state = GameState::new_two_player(1);
-        seed_event_context_parent_targets(&state, &mut ability, Some(&event));
+        seed_event_context_parent_targets(
+            &state,
+            &mut ability,
+            Some(&event),
+            EventContextSeedTiming::StackPush,
+        );
         assert_eq!(ability.targets, vec![TargetRef::Object(creature)]);
     }
 
@@ -16392,10 +16418,52 @@ pub mod tests {
             vec![],
         );
 
-        seed_event_context_parent_targets(&state, &mut ability, Some(&event));
+        seed_event_context_parent_targets(
+            &state,
+            &mut ability,
+            Some(&event),
+            EventContextSeedTiming::StackPush,
+        );
 
         assert_eq!(ability.targets, vec![TargetRef::Object(entered)]);
         assert_eq!(ability.target_incarnations, vec![entered_pin]);
+    }
+
+    #[test]
+    fn resolution_fallback_does_not_pin_reentered_zone_change_object() {
+        let source = ObjectId(999);
+        let mut state = GameState::new_two_player(1);
+        let entered = make_creature(&mut state, PlayerId(0), "Entered", 2, 2);
+        let event = zone_changed_event(
+            entered,
+            Zone::Hand,
+            Zone::Battlefield,
+            vec![CoreType::Creature],
+            vec![],
+        );
+        let observed_incarnation = state.objects[&entered].incarnation;
+        let mut move_events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, entered, Zone::Exile, &mut move_events);
+        crate::game::zones::move_to_zone(&mut state, entered, Zone::Battlefield, &mut move_events);
+        assert_ne!(state.objects[&entered].incarnation, observed_incarnation);
+
+        let mut ability = ResolvedAbility::new(
+            Effect::TargetOnly {
+                target: TargetFilter::ParentTarget,
+            },
+            vec![TargetRef::Object(source)],
+            source,
+            PlayerId(0),
+        );
+        seed_event_context_parent_targets(
+            &state,
+            &mut ability,
+            Some(&event),
+            EventContextSeedTiming::ResolutionFallback,
+        );
+
+        assert_eq!(ability.targets, vec![TargetRef::Object(source)]);
+        assert!(ability.target_incarnations.is_empty());
     }
 
     fn zone_changed_event(

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -7429,7 +7429,6 @@ pub(crate) enum EventContextSeedTiming {
 }
 
 pub(crate) fn seed_event_context_parent_targets(
-    state: &GameState,
     ability: &mut ResolvedAbility,
     trigger_event: Option<&GameEvent>,
     timing: EventContextSeedTiming,
@@ -7440,21 +7439,23 @@ pub(crate) fn seed_event_context_parent_targets(
     if !effect_uses_parent_target(&ability.effect) || parent_target_seeding_blocked(ability) {
         return;
     }
-    let parent_id = match event {
+    let (parent_id, zone_change_pin) = match event {
         GameEvent::ZoneChanged { object_id, .. } => {
-            // CR 400.7: the exact post-change incarnation can be captured only
-            // when the trigger is put on the stack. A resolution fallback may
-            // run after the card left and returned with the same storage id, so
-            // it must never create or replace a zone-change referent.
+            // CR 400.7: the exact post-change incarnation must come from the
+            // event authority when the trigger is put on the stack. A live-state
+            // lookup or resolution fallback may see a later same-id object.
             if timing == EventContextSeedTiming::ResolutionFallback {
                 return;
             }
-            Some(*object_id)
+            let Some(pin) = zone_change_parent_target_pin(event) else {
+                return;
+            };
+            (Some(*object_id), Some(pin))
         }
-        GameEvent::Stationed { creature_id, .. } => Some(*creature_id),
-        GameEvent::VehicleCrewed { vehicle_id, .. } => Some(*vehicle_id),
-        GameEvent::Saddled { mount_id, .. } => Some(*mount_id),
-        _ => None,
+        GameEvent::Stationed { creature_id, .. } => (Some(*creature_id), None),
+        GameEvent::VehicleCrewed { vehicle_id, .. } => (Some(*vehicle_id), None),
+        GameEvent::Saddled { mount_id, .. } => (Some(*mount_id), None),
+        _ => (None, None),
     };
     if let Some(id) = parent_id {
         ability.targets = vec![TargetRef::Object(id)];
@@ -7462,16 +7463,45 @@ pub(crate) fn seed_event_context_parent_targets(
         // post-change object. Pin that incarnation so leaving the destination
         // zone and returning before resolution cannot retarget the ability to
         // the new object that reuses the same storage id.
-        if matches!(event, GameEvent::ZoneChanged { .. }) {
-            let pins = state
-                .objects
-                .get(&id)
-                .map(ObjectIncarnationRef::from_object)
-                .into_iter()
-                .collect();
-            ability.set_target_incarnations_recursive(pins);
+        if let Some(pin) = zone_change_pin {
+            ability.set_target_incarnations_recursive(vec![pin]);
         }
     }
+}
+
+/// Returns the destination incarnation recorded by the zone-change authority.
+/// Never consult live state here: trigger placement can be deferred until after
+/// the same storage id has already left and returned as a different object.
+fn zone_change_parent_target_pin(event: &GameEvent) -> Option<ObjectIncarnationRef> {
+    let GameEvent::ZoneChanged {
+        object_id,
+        from,
+        to,
+        record,
+    } = event
+    else {
+        return None;
+    };
+    if record.object_id != *object_id || record.from_zone != *from || record.to_zone != *to {
+        return None;
+    }
+
+    let incarnation = if *to == Zone::Battlefield {
+        record.entered_incarnation?
+    } else {
+        let source = record.trigger_source_context()?;
+        if source.identity.reference.object_id != *object_id
+            || from.is_some_and(|zone| source.identity.expected_zone != zone)
+        {
+            return None;
+        }
+        if from.is_some_and(|zone| zone != *to) {
+            source.identity.reference.incarnation.checked_add(1)?
+        } else {
+            source.identity.reference.incarnation
+        }
+    };
+    Some(ObjectIncarnationRef::of(*object_id, incarnation))
 }
 
 fn effect_uses_parent_target(effect: &Effect) -> bool {
@@ -7570,7 +7600,6 @@ fn push_pending_trigger_to_stack_with_firing_and_duration_events(
     ability.bind_force_block_attacker_recursive(event_attacker);
     seed_batched_attack_parent_targets(&mut ability, trigger_event.as_ref());
     seed_event_context_parent_targets(
-        state,
         &mut ability,
         trigger_event.as_ref(),
         EventContextSeedTiming::StackPush,
@@ -16386,9 +16415,7 @@ pub mod tests {
             creature_id: creature,
             counters_added: 1,
         };
-        let state = GameState::new_two_player(1);
         seed_event_context_parent_targets(
-            &state,
             &mut ability,
             Some(&event),
             EventContextSeedTiming::StackPush,
@@ -16400,7 +16427,26 @@ pub mod tests {
     fn seed_event_context_parent_targets_binds_zone_changed_object() {
         let source = ObjectId(999);
         let mut state = GameState::new_two_player(1);
-        let entered = make_creature(&mut state, PlayerId(0), "Entered", 2, 2);
+        let entered = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Entered".to_string(),
+            Zone::Hand,
+        );
+        state
+            .objects
+            .get_mut(&entered)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        let mut entry_events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, entered, Zone::Battlefield, &mut entry_events);
+        let event = entry_events
+            .iter()
+            .find(|event| matches!(event, GameEvent::ZoneChanged { .. }))
+            .expect("production entry emits a zone-change event");
         let entered_pin = ObjectIncarnationRef::from_object(&state.objects[&entered]);
         let mut ability = ResolvedAbility::new(
             Effect::TargetOnly {
@@ -16410,18 +16456,9 @@ pub mod tests {
             source,
             PlayerId(0),
         );
-        let event = zone_changed_event(
-            entered,
-            Zone::Hand,
-            Zone::Battlefield,
-            vec![CoreType::Creature],
-            vec![],
-        );
-
         seed_event_context_parent_targets(
-            &state,
             &mut ability,
-            Some(&event),
+            Some(event),
             EventContextSeedTiming::StackPush,
         );
 
@@ -16456,7 +16493,6 @@ pub mod tests {
             PlayerId(0),
         );
         seed_event_context_parent_targets(
-            &state,
             &mut ability,
             Some(&event),
             EventContextSeedTiming::ResolutionFallback,
@@ -16464,6 +16500,71 @@ pub mod tests {
 
         assert_eq!(ability.targets, vec![TargetRef::Object(source)]);
         assert!(ability.target_incarnations.is_empty());
+    }
+
+    #[test]
+    fn stack_push_uses_event_incarnation_after_zone_change_reentry() {
+        let source = ObjectId(999);
+        let mut state = GameState::new_two_player(1);
+        let entered = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Entered".to_string(),
+            Zone::Hand,
+        );
+        state
+            .objects
+            .get_mut(&entered)
+            .unwrap()
+            .card_types
+            .core_types
+            .push(CoreType::Creature);
+        let mut entry_events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, entered, Zone::Battlefield, &mut entry_events);
+        let event = entry_events
+            .iter()
+            .find(|event| matches!(event, GameEvent::ZoneChanged { .. }))
+            .expect("production entry emits a zone-change event");
+        let GameEvent::ZoneChanged { record, .. } = event else {
+            unreachable!();
+        };
+        let event_pin = ObjectIncarnationRef::of(
+            entered,
+            record
+                .entered_incarnation
+                .expect("battlefield entry records its destination incarnation"),
+        );
+
+        let mut later_events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, entered, Zone::Exile, &mut later_events);
+        crate::game::zones::move_to_zone(&mut state, entered, Zone::Battlefield, &mut later_events);
+        assert_ne!(
+            ObjectIncarnationRef::from_object(&state.objects[&entered]),
+            event_pin
+        );
+
+        let mut ability = ResolvedAbility::new(
+            Effect::TargetOnly {
+                target: TargetFilter::ParentTarget,
+            },
+            vec![TargetRef::Object(source)],
+            source,
+            PlayerId(0),
+        );
+        seed_event_context_parent_targets(
+            &mut ability,
+            Some(event),
+            EventContextSeedTiming::StackPush,
+        );
+        assert_eq!(ability.target_incarnations, vec![event_pin]);
+
+        seed_event_context_parent_targets(
+            &mut ability,
+            Some(event),
+            EventContextSeedTiming::ResolutionFallback,
+        );
+        assert_eq!(ability.target_incarnations, vec![event_pin]);
     }
 
     fn zone_changed_event(

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -16567,6 +16567,101 @@ pub mod tests {
         assert_eq!(ability.target_incarnations, vec![event_pin]);
     }
 
+    #[test]
+    fn production_ltb_stack_push_pins_recorded_destination_incarnation() {
+        let mut state = GameState::new_two_player(1);
+        let angel = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Avenging Angel".to_string(),
+            Zone::Battlefield,
+        );
+        let mut trigger = TriggerDefinition::new(TriggerMode::ChangesZone);
+        trigger.origin = Some(Zone::Battlefield);
+        trigger.destination = Some(Zone::Graveyard);
+        trigger.valid_card = Some(TargetFilter::SelfRef);
+        trigger.trigger_zones = vec![Zone::Graveyard];
+        trigger.execute = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::TargetOnly {
+                target: TargetFilter::ParentTarget,
+            },
+        )));
+        state
+            .objects
+            .get_mut(&angel)
+            .unwrap()
+            .trigger_definitions
+            .push(trigger);
+
+        let mut death_events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, angel, Zone::Graveyard, &mut death_events);
+        let destination_pin = ObjectIncarnationRef::from_object(&state.objects[&angel]);
+        process_triggers(&mut state, &death_events);
+
+        let Some(StackEntryKind::TriggeredAbility { ability, .. }) =
+            state.stack.back().map(|entry| &entry.kind)
+        else {
+            panic!("production LTB trigger must reach the stack");
+        };
+        assert_eq!(ability.targets, vec![TargetRef::Object(angel)]);
+        assert_eq!(ability.target_incarnations, vec![destination_pin]);
+        assert!(destination_pin.is_current(&state));
+    }
+
+    #[test]
+    fn non_battlefield_zone_change_pin_rejects_later_same_id_incarnation() {
+        let source = ObjectId(999);
+        let mut state = GameState::new_two_player(1);
+        let object = make_creature(&mut state, PlayerId(0), "Departing", 2, 2);
+        let mut death_events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, object, Zone::Graveyard, &mut death_events);
+        let event = death_events
+            .iter()
+            .find(|event| matches!(event, GameEvent::ZoneChanged { .. }))
+            .expect("production departure emits a zone-change event");
+        let destination_pin = ObjectIncarnationRef::from_object(&state.objects[&object]);
+
+        let mut reentry_events = Vec::new();
+        crate::game::zones::move_to_zone(
+            &mut state,
+            object,
+            Zone::Battlefield,
+            &mut reentry_events,
+        );
+        assert_ne!(
+            ObjectIncarnationRef::from_object(&state.objects[&object]),
+            destination_pin
+        );
+
+        let mut ability = ResolvedAbility::new(
+            Effect::TargetOnly {
+                target: TargetFilter::ParentTarget,
+            },
+            vec![TargetRef::Object(source)],
+            source,
+            PlayerId(0),
+        );
+        seed_event_context_parent_targets(
+            &mut ability,
+            Some(event),
+            EventContextSeedTiming::StackPush,
+        );
+
+        assert_eq!(ability.targets, vec![TargetRef::Object(object)]);
+        assert_eq!(ability.target_incarnations, vec![destination_pin]);
+        assert!(
+            crate::game::targeting::resolved_targets(
+                &ability,
+                &TargetFilter::ParentTarget,
+                &state,
+            )
+            .is_empty(),
+            "the recorded graveyard object must not resolve to its later battlefield incarnation"
+        );
+    }
+
     fn zone_changed_event(
         object_id: ObjectId,
         from: Zone,

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -7402,12 +7402,14 @@ pub(crate) fn seed_batched_attack_parent_targets(
         .collect();
 }
 
-/// CR 608.2c + CR 702.184a/702.122/702.171: Stationed/VehicleCrewed/Saddled
+/// CR 603.6 + CR 608.2c + CR 702.184a/702.122/702.171: Zone-change and
+/// Stationed/VehicleCrewed/Saddled
 /// triggers whose effect anaphorically binds `ParentTarget` ("that creature",
 /// "that Vehicle", "that Mount") inherit the event referent as propagated
 /// targets at stack-push time — mirroring `seed_batched_attack_parent_targets`
 /// for attack batches — so resolution does not depend on a live
-/// `current_trigger_event`.
+/// `current_trigger_event`. CR 603.6 specifically authorizes zone-change
+/// abilities to find and affect the object after it changes zones.
 fn parent_target_seeding_blocked(ability: &ResolvedAbility) -> bool {
     if ability.targets.is_empty() {
         return false;
@@ -7421,6 +7423,7 @@ fn parent_target_seeding_blocked(ability: &ResolvedAbility) -> bool {
 }
 
 pub(crate) fn seed_event_context_parent_targets(
+    state: &GameState,
     ability: &mut ResolvedAbility,
     trigger_event: Option<&GameEvent>,
 ) {
@@ -7430,14 +7433,28 @@ pub(crate) fn seed_event_context_parent_targets(
     if !effect_uses_parent_target(&ability.effect) || parent_target_seeding_blocked(ability) {
         return;
     }
-    let parent_id = match event {
-        GameEvent::Stationed { creature_id, .. } => Some(*creature_id),
-        GameEvent::VehicleCrewed { vehicle_id, .. } => Some(*vehicle_id),
-        GameEvent::Saddled { mount_id, .. } => Some(*mount_id),
-        _ => None,
+    let (parent_id, pin_zone_change_referent) = match event {
+        GameEvent::ZoneChanged { object_id, .. } => (Some(*object_id), true),
+        GameEvent::Stationed { creature_id, .. } => (Some(*creature_id), false),
+        GameEvent::VehicleCrewed { vehicle_id, .. } => (Some(*vehicle_id), false),
+        GameEvent::Saddled { mount_id, .. } => (Some(*mount_id), false),
+        _ => (None, false),
     };
     if let Some(id) = parent_id {
         ability.targets = vec![TargetRef::Object(id)];
+        // CR 400.7 + CR 603.6: a zone-change trigger refers to the exact
+        // post-change object. Pin that incarnation so leaving the destination
+        // zone and returning before resolution cannot retarget the ability to
+        // the new object that reuses the same storage id.
+        if pin_zone_change_referent && ability.target_incarnations.is_empty() {
+            let pins = state
+                .objects
+                .get(&id)
+                .map(ObjectIncarnationRef::from_object)
+                .into_iter()
+                .collect();
+            ability.set_target_incarnations_recursive(pins);
+        }
     }
 }
 
@@ -7536,7 +7553,7 @@ fn push_pending_trigger_to_stack_with_firing_and_duration_events(
     let event_attacker = event_attacker_from_trigger_event(state, trigger_event.as_ref());
     ability.bind_force_block_attacker_recursive(event_attacker);
     seed_batched_attack_parent_targets(&mut ability, trigger_event.as_ref());
-    seed_event_context_parent_targets(&mut ability, trigger_event.as_ref());
+    seed_event_context_parent_targets(state, &mut ability, trigger_event.as_ref());
 
     let entry_id = ObjectId(state.next_object_id);
     state.next_object_id += 1;
@@ -16348,8 +16365,37 @@ pub mod tests {
             creature_id: creature,
             counters_added: 1,
         };
-        seed_event_context_parent_targets(&mut ability, Some(&event));
+        let state = GameState::new_two_player(1);
+        seed_event_context_parent_targets(&state, &mut ability, Some(&event));
         assert_eq!(ability.targets, vec![TargetRef::Object(creature)]);
+    }
+
+    #[test]
+    fn seed_event_context_parent_targets_binds_zone_changed_object() {
+        let source = ObjectId(999);
+        let mut state = GameState::new_two_player(1);
+        let entered = make_creature(&mut state, PlayerId(0), "Entered", 2, 2);
+        let entered_pin = ObjectIncarnationRef::from_object(&state.objects[&entered]);
+        let mut ability = ResolvedAbility::new(
+            Effect::TargetOnly {
+                target: TargetFilter::ParentTarget,
+            },
+            vec![TargetRef::Object(source)],
+            source,
+            PlayerId(0),
+        );
+        let event = zone_changed_event(
+            entered,
+            Zone::Hand,
+            Zone::Battlefield,
+            vec![CoreType::Creature],
+            vec![],
+        );
+
+        seed_event_context_parent_targets(&state, &mut ability, Some(&event));
+
+        assert_eq!(ability.targets, vec![TargetRef::Object(entered)]);
+        assert_eq!(ability.target_incarnations, vec![entered_pin]);
     }
 
     fn zone_changed_event(

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -16622,19 +16622,6 @@ pub mod tests {
             .find(|event| matches!(event, GameEvent::ZoneChanged { .. }))
             .expect("production departure emits a zone-change event");
         let destination_pin = ObjectIncarnationRef::from_object(&state.objects[&object]);
-
-        let mut reentry_events = Vec::new();
-        crate::game::zones::move_to_zone(
-            &mut state,
-            object,
-            Zone::Battlefield,
-            &mut reentry_events,
-        );
-        assert_ne!(
-            ObjectIncarnationRef::from_object(&state.objects[&object]),
-            destination_pin
-        );
-
         let mut ability = ResolvedAbility::new(
             Effect::TargetOnly {
                 target: TargetFilter::ParentTarget,
@@ -16651,6 +16638,23 @@ pub mod tests {
 
         assert_eq!(ability.targets, vec![TargetRef::Object(object)]);
         assert_eq!(ability.target_incarnations, vec![destination_pin]);
+        assert_eq!(
+            crate::game::targeting::resolved_targets(&ability, &TargetFilter::ParentTarget, &state,),
+            vec![TargetRef::Object(object)],
+            "the record-owned pre-change incarnation + 1 must name the graveyard object"
+        );
+
+        let mut reentry_events = Vec::new();
+        crate::game::zones::move_to_zone(
+            &mut state,
+            object,
+            Zone::Battlefield,
+            &mut reentry_events,
+        );
+        assert_ne!(
+            ObjectIncarnationRef::from_object(&state.objects[&object]),
+            destination_pin
+        );
         assert!(
             crate::game::targeting::resolved_targets(
                 &ability,

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -1428,6 +1428,44 @@ pub(crate) fn comma_short_self_name(card_name: &str) -> Option<&str> {
     }
 }
 
+/// CR 201.5c: derive the printed first-and-last-word short name used by some
+/// multi-word legendary names (for example, "Captain James T. Kirk" →
+/// "Captain Kirk").
+///
+/// The leading word must be a proper-name/title word, not an article, game
+/// term, keyword, verb, or subtype. This rejects ambiguous prose and flavor
+/// labels such as "The Minstrel's Ballad" for "The Wandering Minstrel"
+/// (CR 207.2c–d) while keeping the rule independent of any individual card.
+fn compound_short_self_name(card_name: &str) -> Option<String> {
+    let effective_name = if card_name.as_bytes().get(0..2) == Some(b"A-") {
+        &card_name[2..]
+    } else {
+        card_name
+    };
+    let words: Vec<&str> = effective_name.split_whitespace().collect();
+    if comma_short_self_name(card_name).is_some() || words.contains(&"//") || words.len() < 3 {
+        return None;
+    }
+    let first = words[0];
+    let last = *words.last()?;
+    let lower_first = first.to_lowercase();
+    if first.eq_ignore_ascii_case(last)
+        || matches!(
+            lower_first.as_str(),
+            "the" | "a" | "an" | "of" | "in" | "on" | "to" | "for" | "at" | "by"
+        )
+        || is_core_type_name(&lower_first)
+        || is_non_subtype_subject_name(&lower_first)
+        || is_supertype_word(&lower_first)
+        || super::oracle_nom::primitives::is_keyword_word(&lower_first)
+        || super::oracle_nom::primitives::is_verb_word(&lower_first)
+        || is_subtype_word(&lower_first)
+    {
+        return None;
+    }
+    Some(format!("{first} {last}"))
+}
+
 /// Replace all occurrences of `needle` in `haystack` with `replacement`,
 /// case-sensitively, only at word boundaries.
 fn replace_all_words_case_sensitive(haystack: &str, needle: &str, replacement: &str) -> String {
@@ -2129,10 +2167,10 @@ const GRANTER_SELF_REF_VERB_PREFIXES: &[&str] = &[
 /// everywhere else (outside quotes, or in-quote QuantityRef / condition /
 /// damage-source / exclusion / name-filter positions) the card name still
 /// normalizes to `~` (host self-ref), byte-identical to pre-fix. Only the
-/// deterministic proper-noun variants (full multi-word name and comma-separated
-/// short name) are masked, mirroring `normalize_card_name_refs` strategies 1–2;
-/// the risky single-word / of-short fallbacks are skipped to avoid matching
-/// English words.
+/// deterministic proper-noun variants (full multi-word name, comma-separated
+/// short name, and guarded compound first/last short name) are masked, mirroring
+/// `normalize_card_name_refs`; the risky single-word / of-short fallbacks are
+/// skipped to avoid matching English words.
 fn mask_granting_self_reference_in_quotes(text: &str, card_name: &str) -> String {
     // allow-noncombinator: structural masking of a card-name self-reference
     // before `~` normalization (mirrors `mask_card_name_keyword_action`), not
@@ -2144,19 +2182,24 @@ fn mask_granting_self_reference_in_quotes(text: &str, card_name: &str) -> String
     // hits the capitalized card-name occurrence — mirroring
     // `normalize_card_name_refs`' single-word discipline. Position-gating (the
     // verb-object allowlist) makes even single-word masking safe here.
-    let mut variants: Vec<(&str, bool)> = Vec::new();
+    let mut variants: Vec<(String, bool)> = Vec::new();
     if effective_name.contains(' ') {
-        variants.push((effective_name, false));
+        variants.push((effective_name.to_string(), false));
     } else if effective_name.len() >= 3 {
         // `>= 3`: skip 1-2 char names, matching normalize_card_name_refs guards.
-        variants.push((effective_name, true));
+        variants.push((effective_name.to_string(), true));
     }
     // allow-noncombinator: comma-short name extraction (structural, not parsing dispatch)
     if let Some(comma_pos) = effective_name.find(", ") {
         let short = &effective_name[..comma_pos];
         // `>= 2`: matches the comma-short guard in `normalize_card_name_refs`.
         if short.len() >= 2 && short.contains(' ') {
-            variants.push((short, false));
+            variants.push((short.to_string(), false));
+        }
+    }
+    if let Some(compound) = compound_short_self_name(card_name) {
+        if !variants.iter().any(|(name, _)| name == &compound) {
+            variants.push((compound, false));
         }
     }
     if variants.is_empty() {
@@ -2170,8 +2213,8 @@ fn mask_granting_self_reference_in_quotes(text: &str, card_name: &str) -> String
         }
         if seg_idx % 2 == 1 {
             let mut masked = segment.to_string();
-            for &(name, case_sensitive) in &variants {
-                masked = mask_name_occurrences_in_segment(&masked, name, case_sensitive);
+            for (name, case_sensitive) in &variants {
+                masked = mask_name_occurrences_in_segment(&masked, name, *case_sensitive);
             }
             result.push_str(&masked);
         } else {
@@ -2303,6 +2346,14 @@ pub fn normalize_card_name_refs(text: &str, card_name: &str) -> String {
     } else {
         replace_all_words_case_sensitive(&result, effective_name, "~")
     };
+
+    // CR 201.5c: some multi-word names use a first-and-last-word printed short
+    // name. Run this independently of full-name replacement because one Oracle
+    // paragraph may contain both forms. Word boundaries prevent partial-name
+    // collisions; candidate construction rejects ambiguous game/prose words.
+    if let Some(short_name) = compound_short_self_name(card_name) {
+        result = replace_all_words(&result, &short_name, "~");
+    }
 
     // Comma-based legendary short name: "Haliya, Guided by Light" → "Haliya"
     // CR 201.3a: A legendary creature's name is the full name printed on the card;
@@ -3041,6 +3092,83 @@ mod tests {
                 "Haliya, Guided by Light"
             ),
             "Whenever ~ or another creature enters"
+        );
+    }
+
+    #[test]
+    fn normalize_compound_printed_short_names() {
+        // CR 201.5c: printed shortened names are the same object reference.
+        assert_eq!(
+            normalize_card_name_refs(
+                "Whenever Captain Kirk enters or attacks, choose one.",
+                "Captain James T. Kirk",
+            ),
+            "Whenever ~ enters or attacks, choose one."
+        );
+        assert_eq!(
+            normalize_card_name_refs(
+                "Whenever Captain Janeway or another creature you control enters, that creature explores.",
+                "Captain Kathryn Janeway",
+            ),
+            "Whenever ~ or another creature you control enters, that creature explores."
+        );
+        assert_eq!(
+            normalize_card_name_refs(
+                "Whenever you gain life, put a +1/+1 counter on Dr. Crusher.",
+                "Dr. Beverly Crusher",
+            ),
+            "Whenever you gain life, put a +1/+1 counter on ~."
+        );
+    }
+
+    #[test]
+    fn normalize_compound_short_name_rejects_ambiguous_prose_and_labels() {
+        // CR 207.2c–d: an ability/flavor label has no rules meaning and is not
+        // a shortened self-reference merely because it shares the outer words.
+        assert_eq!(
+            normalize_card_name_refs(
+                "The Minstrel's Ballad — At the beginning of combat on your turn, create a token.",
+                "The Wandering Minstrel",
+            ),
+            "The Minstrel's Ballad — At the beginning of combat on your turn, create a token."
+        );
+        // The same candidate guard rejects an ordinary imperative/game-word
+        // collision rather than rewriting prose as a self-reference.
+        assert_eq!(
+            normalize_card_name_refs("Search Tomorrow for a card.", "Search for Tomorrow"),
+            "Search Tomorrow for a card."
+        );
+    }
+
+    #[test]
+    fn normalize_compound_short_name_preserves_named_literals() {
+        assert_eq!(
+            normalize_card_name_refs(
+                "A deck can have only one card named Captain Kirk.",
+                "Captain James T. Kirk",
+            ),
+            "A deck can have only one card named Captain Kirk."
+        );
+        assert_eq!(
+            normalize_card_name_refs(
+                "Create a legendary 1/1 Human creature token named Captain Kirk.",
+                "Captain James T. Kirk",
+            ),
+            "Create a legendary 1/1 Human creature token named Captain Kirk."
+        );
+    }
+
+    #[test]
+    fn normalize_compound_short_name_masks_quoted_granter_reference() {
+        let normalized = normalize_card_name_refs(
+            "Creatures you control have \"Sacrifice Captain Kirk: Draw a card.\" Whenever Captain Kirk attacks, draw a card.",
+            "Captain James T. Kirk",
+        );
+        assert_eq!(
+            normalized,
+            format!(
+                "Creatures you control have \"Sacrifice {GRANTING_SELF_PLACEHOLDER}: Draw a card.\" Whenever ~ attacks, draw a card."
+            )
         );
     }
 

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -1415,17 +1415,22 @@ pub fn has_unconsumed_conditional(text: &str) -> bool {
 /// For comma-form names, the short self-reference is the span before the comma
 /// after removing MTGJSON's structural Alchemy `A-` prefix.
 pub(crate) fn comma_short_self_name(card_name: &str) -> Option<&str> {
-    let effective_name = if card_name.as_bytes().get(0..2) == Some(b"A-") {
-        &card_name[2..]
-    } else {
-        card_name
-    };
+    let effective_name = alchemy_effective_name(card_name);
     let (_, (short_name, _)) = nom_primitives::split_once_on(effective_name, ", ").ok()?;
     if short_name.len() >= 2 {
         Some(short_name)
     } else {
         None
     }
+}
+
+/// Remove MTGJSON's structural Alchemy prefix while accepting either casing.
+fn alchemy_effective_name(card_name: &str) -> &str {
+    card_name
+        .get(..2)
+        .filter(|prefix| prefix.eq_ignore_ascii_case("A-"))
+        .and_then(|_| card_name.get(2..))
+        .unwrap_or(card_name)
 }
 
 /// CR 201.5c: derive the printed first-and-last-word short name used by some
@@ -1437,11 +1442,7 @@ pub(crate) fn comma_short_self_name(card_name: &str) -> Option<&str> {
 /// labels such as "The Minstrel's Ballad" for "The Wandering Minstrel"
 /// (CR 207.2c–d) while keeping the rule independent of any individual card.
 fn compound_short_self_name(card_name: &str) -> Option<String> {
-    let effective_name = if card_name.as_bytes().get(0..2) == Some(b"A-") {
-        &card_name[2..]
-    } else {
-        card_name
-    };
+    let effective_name = alchemy_effective_name(card_name);
     let words: Vec<&str> = effective_name.split_whitespace().collect();
     if comma_short_self_name(card_name).is_some() || words.contains(&"//") || words.len() < 3 {
         return None;
@@ -2176,7 +2177,7 @@ fn mask_granting_self_reference_in_quotes(text: &str, card_name: &str) -> String
     // before `~` normalization (mirrors `mask_card_name_keyword_action`), not
     // parsing dispatch.
     // allow-noncombinator: strip MTGJSON A- prefix (structural, mirrors normalize_card_name_refs)
-    let effective_name = card_name.strip_prefix("A-").unwrap_or(card_name);
+    let effective_name = alchemy_effective_name(card_name);
     // (name, case_sensitive). Multi-word / comma-short are case-insensitive
     // (proper nouns); a single-word name is matched case-sensitively so it only
     // hits the capitalized card-name occurrence — mirroring
@@ -2305,7 +2306,7 @@ pub fn normalize_card_name_refs(text: &str, card_name: &str) -> String {
     };
     let (text, card_named_originals) = mask_card_named_literal_spans(&text);
     // Strip A- prefix (Alchemy rebalanced cards in MTGJSON)
-    let effective_name = card_name.strip_prefix("A-").unwrap_or(card_name);
+    let effective_name = alchemy_effective_name(card_name);
 
     // Alchemy rebalanced cards (CR n/a — MTGJSON convention): the Oracle
     // text often references the prefixed name literally ("Return A-~ from

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1083,6 +1083,7 @@ mod total_war_attacking_player_scope;
 mod tracked_set_anaphor_quantity_binds;
 mod treasured_find_regression;
 mod trespassers_curse_enchanted_player_trigger;
+mod trk_compound_short_names;
 mod true_conviction_double_keyword_grant;
 mod turn_based_draw_step_miracle_offer;
 mod turn_control_priority_softlock;

--- a/crates/engine/tests/integration/trk_compound_short_names.rs
+++ b/crates/engine/tests/integration/trk_compound_short_names.rs
@@ -1,0 +1,230 @@
+//! TRK compound printed short names (CR 201.5c).
+//!
+//! Captain James T. Kirk and Captain Kathryn Janeway use first-and-last-word
+//! self-references in their printed Oracle text. These tests use the verbatim
+//! Oracle through `parse_oracle_text` and the live scenario pipeline so reverting
+//! the shared normalizer makes both parser shape and gameplay fail.
+
+use engine::game::combat::AttackTarget;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityDefinition, ControllerRef, Effect, FilterProp, ModalSelectionConstraint, TargetFilter,
+    TypeFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
+
+const KIRK_ORACLE: &str = "Whenever Captain Kirk enters or attacks, choose one. If you have no cards in hand, choose one or more instead.\n• Discard a card, then draw a card.\n• Create a 1/1 red Officer creature token.\n• Creatures you control get +1/+0 until end of turn.";
+
+const JANEWAY_ORACLE: &str = "You may play an additional land on each of your turns.\nWhenever Captain Janeway or another creature you control enters, that creature explores. (Reveal the top card of your library. Put that card into your hand if it's a land. Otherwise, put a +1/+1 counter on the creature, then put the card back or put it into your graveyard.)";
+
+fn ability_contains_explore(ability: &AbilityDefinition) -> bool {
+    matches!(*ability.effect, Effect::Explore)
+        || ability
+            .sub_ability
+            .as_deref()
+            .is_some_and(ability_contains_explore)
+        || ability
+            .else_ability
+            .as_deref()
+            .is_some_and(ability_contains_explore)
+        || ability.mode_abilities.iter().any(ability_contains_explore)
+}
+
+#[test]
+fn kirk_full_oracle_parses_modal_enters_or_attacks_trigger() {
+    let parsed = parse_oracle_text(
+        KIRK_ORACLE,
+        "Captain James T. Kirk",
+        &[],
+        &["Creature".to_string()],
+        &["Human".to_string(), "Soldier".to_string()],
+    );
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|trigger| trigger.mode == TriggerMode::EntersOrAttacks)
+        .expect("Captain Kirk must parse as one EntersOrAttacks trigger");
+    assert_eq!(trigger.valid_card, Some(TargetFilter::SelfRef));
+    let execute = trigger.execute.as_ref().expect("Kirk trigger execute");
+    let modal = execute.modal.as_ref().expect("Kirk trigger modal");
+    assert_eq!((modal.min_choices, modal.max_choices), (1, 1));
+    assert_eq!(modal.mode_count, 3);
+    assert_eq!(execute.mode_abilities.len(), 3);
+    assert!(modal.constraints.iter().any(|constraint| matches!(
+        constraint,
+        ModalSelectionConstraint::ConditionalMaxChoices {
+            max_choices: 3,
+            otherwise_max_choices: 1,
+            ..
+        }
+    )));
+    assert!(matches!(
+        *execute.mode_abilities[0].effect,
+        Effect::Discard { .. }
+    ));
+    assert!(matches!(
+        *execute.mode_abilities[1].effect,
+        Effect::Token { .. }
+    ));
+    assert!(matches!(
+        *execute.mode_abilities[2].effect,
+        Effect::PumpAll { .. }
+    ));
+    assert!(
+        !format!("{parsed:?}").contains("Unimplemented"),
+        "verbatim Kirk Oracle must contain no partial-support placeholder"
+    );
+}
+
+#[test]
+fn janeway_full_oracle_parses_compound_subject_explore() {
+    let parsed = parse_oracle_text(
+        JANEWAY_ORACLE,
+        "Captain Kathryn Janeway",
+        &[],
+        &["Creature".to_string()],
+        &["Human".to_string(), "Scientist".to_string()],
+    );
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|trigger| trigger.mode == TriggerMode::ChangesZone)
+        .expect("Captain Janeway must parse as an enters trigger");
+    let TargetFilter::Or { filters } = trigger
+        .valid_card
+        .as_ref()
+        .expect("Janeway trigger subject")
+    else {
+        panic!("Janeway trigger must retain its compound subject");
+    };
+    assert!(filters.contains(&TargetFilter::SelfRef));
+    assert!(filters.iter().any(|filter| matches!(
+        filter,
+        TargetFilter::Typed(typed)
+            if typed.type_filters.contains(&TypeFilter::Creature)
+                && typed.controller == Some(ControllerRef::You)
+                && typed.properties.contains(&FilterProp::Another)
+    )));
+    assert!(
+        trigger
+            .execute
+            .as_deref()
+            .is_some_and(ability_contains_explore),
+        "Janeway's compound-subject trigger must execute Explore"
+    );
+    assert!(
+        !format!("{parsed:?}").contains("Unimplemented"),
+        "verbatim Janeway Oracle must contain no partial-support placeholder"
+    );
+}
+
+fn drive_to_kirk_modal(runner: &mut GameRunner) -> (usize, usize, usize) {
+    for _ in 0..128 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::AbilityModeChoice { modal, .. } => {
+                return (modal.min_choices, modal.max_choices, modal.mode_count);
+            }
+            WaitingFor::OrderTriggers { .. } => {
+                engine::game::triggers::drain_order_triggers_with_identity(runner.state_mut());
+            }
+            WaitingFor::Priority { .. } => {
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("pass priority while driving Kirk trigger");
+            }
+            other => panic!("unexpected prompt while driving Kirk trigger: {other:?}"),
+        }
+    }
+    panic!("Kirk trigger did not reach AbilityModeChoice");
+}
+
+fn add_kirk_to_hand(scenario: &mut GameScenario) -> ObjectId {
+    scenario
+        .add_creature_to_hand_from_oracle(P0, "Captain James T. Kirk", 3, 3, KIRK_ORACLE)
+        .with_mana_cost(ManaCost::zero())
+        .id()
+}
+
+#[test]
+fn kirk_enters_branch_offers_the_live_modal_choice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_to_hand(P0, "Spare Card", 1, 1);
+    let kirk = add_kirk_to_hand(&mut scenario);
+    let mut runner = scenario.build();
+
+    let card_id = runner.state().objects[&kirk].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: kirk,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast Kirk");
+
+    assert_eq!(
+        drive_to_kirk_modal(&mut runner),
+        (1, 1, 3),
+        "Kirk entering with a card in hand must offer exactly one of three modes"
+    );
+}
+
+#[test]
+fn kirk_attacks_branch_offers_the_same_live_modal_choice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_to_hand(P0, "Spare Card", 1, 1);
+    let kirk = scenario
+        .add_creature_from_oracle(P0, "Captain James T. Kirk", 3, 3, KIRK_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(kirk, AttackTarget::Player(P1))])
+        .expect("declare Kirk as an attacker");
+
+    assert_eq!(
+        drive_to_kirk_modal(&mut runner),
+        (1, 1, 3),
+        "Kirk attacking must route through the same EntersOrAttacks modal"
+    );
+}
+
+#[test]
+fn janeway_other_creature_entry_explores_that_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Forest", "Library Bottom"]);
+    scenario.add_creature_from_oracle(P0, "Captain Kathryn Janeway", 2, 3, JANEWAY_ORACLE);
+    let explorer = scenario.add_creature_to_hand(P0, "Away Team", 2, 2).id();
+    let mut runner = scenario.build();
+    let forest = runner.state().players[P0.0 as usize].library[0];
+    {
+        let top = runner.state_mut().objects.get_mut(&forest).expect("Forest");
+        top.card_types.core_types.push(CoreType::Land);
+        top.base_card_types = top.card_types.clone();
+    }
+
+    runner.cast(explorer).resolve();
+
+    assert_eq!(runner.state().objects[&forest].zone, Zone::Hand);
+    assert_eq!(
+        runner.state().objects[&explorer]
+            .counters
+            .values()
+            .copied()
+            .sum::<u32>(),
+        0,
+        "a land reveal moves to hand without adding an explore counter"
+    );
+}

--- a/crates/engine/tests/integration/trk_compound_short_names.rs
+++ b/crates/engine/tests/integration/trk_compound_short_names.rs
@@ -13,7 +13,6 @@ use engine::types::ability::{
     TypeFilter,
 };
 use engine::types::actions::GameAction;
-use engine::types::card_type::CoreType;
 use engine::types::game_state::{CastPaymentMode, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::ManaCost;
@@ -204,27 +203,42 @@ fn kirk_attacks_branch_offers_the_same_live_modal_choice() {
 fn janeway_other_creature_entry_explores_that_creature() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
-    scenario.with_library_top(P0, &["Forest", "Library Bottom"]);
-    scenario.add_creature_from_oracle(P0, "Captain Kathryn Janeway", 2, 3, JANEWAY_ORACLE);
+    let nonland = scenario
+        .add_spell_to_library_top(P0, "Explore Probe", true)
+        .id();
+    let janeway = scenario
+        .add_creature_from_oracle(P0, "Captain Kathryn Janeway", 2, 3, JANEWAY_ORACLE)
+        .id();
     let explorer = scenario.add_creature_to_hand(P0, "Away Team", 2, 2).id();
     let mut runner = scenario.build();
-    let forest = runner.state().players[P0.0 as usize].library[0];
-    {
-        let top = runner.state_mut().objects.get_mut(&forest).expect("Forest");
-        top.card_types.core_types.push(CoreType::Land);
-        top.base_card_types = top.card_types.clone();
-    }
 
     runner.cast(explorer).resolve();
 
-    assert_eq!(runner.state().objects[&forest].zone, Zone::Hand);
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::DigChoice { ref cards, .. } if cards == &vec![nonland]
+    ));
+    runner
+        .act(GameAction::SelectCards { cards: vec![] })
+        .expect("put the explored nonland into the graveyard");
+
+    assert_eq!(runner.state().objects[&nonland].zone, Zone::Graveyard);
     assert_eq!(
         runner.state().objects[&explorer]
             .counters
             .values()
             .copied()
             .sum::<u32>(),
+        1,
+        "the entering Away Team must receive the explore counter"
+    );
+    assert_eq!(
+        runner.state().objects[&janeway]
+            .counters
+            .values()
+            .copied()
+            .sum::<u32>(),
         0,
-        "a land reveal moves to hand without adding an explore counter"
+        "Janeway must not receive Away Team's explore counter"
     );
 }


### PR DESCRIPTION
## Summary

Adds shared CR 201.5c normalization for compound printed short names so Captain James T. Kirk, Captain Kathryn Janeway, and Dr. Beverly Crusher parse through the common authority. The review-driven runtime fix also preserves the exact zone-change event incarnation for `ParentTarget` triggers, so delayed stack placement or resolution cannot retarget a later same-ID object.

## Files changed

- `crates/engine/src/parser/oracle_util.rs` — shared compound printed-short-name and case-insensitive `A-` normalization.
- `crates/engine/src/game/coverage.rs` — delegate coverage matching to the parser authority and regress lowercase Alchemy names.
- `crates/engine/src/game/triggers.rs` — seed zone-change parent targets from record-owned event provenance at stack push, with ETB/LTB and leave/reentry regressions.
- `crates/engine/src/game/stack.rs` — use typed resolution-fallback timing without repinning zone-change objects.
- `crates/engine/tests/integration/main.rs` — register the TRK runtime module.
- `crates/engine/tests/integration/trk_compound_short_names.rs` — Kirk and Janeway parser/runtime proof, including nonland `DigChoice` and counter placement only on Away Team.

## Track

Developer

## LLM

Model: gpt-5.6-sol (via Codex; canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 201.5c
- CR 207.2c-d
- CR 400.7
- CR 603.6
- CR 608.2c

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — PASS
- strict workspace clippy — PASS
- full engine suite — PASS: 19,690 library tests (6 ignored), 21 + 9 binary tests, and 5,475 integration tests (2 ignored), zero failures
- TRK production integration — PASS (5/5), including nonland Janeway `DigChoice` and +1/+1 counter on Away Team only
- exact event-provenance regressions — PASS: StackPush uses the event incarnation, ResolutionFallback does not repin, production battlefield entry pins correctly, production LTB pins the recorded destination, and later same-ID incarnations are rejected
- compound normalizer / coverage authority / lowercase `A-` regressions — PASS
- card-data generation and `cargo coverage` — PASS: 31,808/35,798 supported (88.9%); Kirk, Janeway, and Crusher have `supported=true`, `gap_count=0`
- `cargo semantic-audit` — PASS: 32,781 cards audited; no new findings (269 baseline findings)

## Gate A

Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=15e1bfff70d3a71e19f95791ffcc0f3ccacc537b base=7dc870aed0240d5a8c94dc192a642e2e8ac1db29

## Anchored on

- `crates/engine/src/parser/oracle_util.rs:2298` — existing shared self-reference normalization authority extended for compound names.
- `crates/engine/src/game/triggers.rs:7386` — existing batched-attack parent-target propagation pattern reused for event referents.
- `crates/engine/src/game/stack.rs:1287` — existing resolution fallback seam now explicitly separated from StackPush authority.

## Final review-impl

Final review-impl PASS head=15e1bfff70d3a71e19f95791ffcc0f3ccacc537b

## Claimed parse impact

- Captain James T. Kirk
- Captain Kathryn Janeway
- Dr. Beverly Crusher

## Scope Expansion

Review-driven shared event-provenance correction required to make Janeway's production target-threading proof discriminating. The implementation is general, typed by timing, and covered for ETB, LTB, delayed StackPush, resolution fallback, and same-ID leave/reentry.

## Validation Failures

None.

## CI Failures

None locally; fresh current-head CI is running after the push.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved recognition of self-references in card text, including compound card names.
  - Added support for aliases such as “this spell” and shortened multi-word card names where unambiguous.
  - Prevented ambiguous wording from being incorrectly interpreted as a card reference.
  - Corrected triggered abilities, modal choices, targeting, and resolution behavior for affected cards and zone changes.

- **Tests**
  - Added coverage for compound-name cards, including Captain James T. Kirk and Captain Kathryn Janeway, across parsing and gameplay scenarios.
  - Added tests for battlefield entry, re-entry, and leave-the-battlefield triggers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->