### PR TITLE
Support unqualified loyalty ability triggers

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -7352,6 +7352,45 @@ mod tests {
         ));
     }
 
+    /// CR 606.2 + CR 109.5: an unqualified loyalty-activation trigger accepts
+    /// any loyalty ability activated by its controller, while still rejecting
+    /// an ordinary activated ability from the same planeswalker.
+    #[test]
+    fn loyalty_ability_activation_without_card_filter_accepts_any_loyalty_kind() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Unqualified Loyalty Trigger".to_string(),
+            Zone::Battlefield,
+        );
+        let planeswalker =
+            create_pw_with_subtype(&mut state, PlayerId(0), "Jace, the Mind", "Jace");
+        let trigger = make_trigger(TriggerMode::LoyaltyAbilityActivated);
+
+        assert!(match_loyalty_ability_activated(
+            &GameEvent::AbilityActivated {
+                player_id: PlayerId(0),
+                source_id: planeswalker,
+                kind: crate::types::events::ActivatedAbilityKind::Loyalty,
+            },
+            &trigger,
+            &test_trigger_source_context(&state, source),
+            &state
+        ));
+        assert!(!match_loyalty_ability_activated(
+            &GameEvent::AbilityActivated {
+                player_id: PlayerId(0),
+                source_id: planeswalker,
+                kind: crate::types::events::ActivatedAbilityKind::Normal,
+            },
+            &trigger,
+            &test_trigger_source_context(&state, source),
+            &state
+        ));
+    }
+
     /// CR 606.2: a loyalty ability of a NON-Chandra planeswalker does not fire.
     #[test]
     fn loyalty_ability_activation_non_chandra_does_not_fire() {

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -7660,13 +7660,18 @@ fn try_parse_ability_activation_trigger(lower: &str) -> Option<(TriggerMode, Tri
         alt((parse_subtyped_planeswalker, parse_attached_to_subject)).parse(input)
     }
 
-    fn parse_loyalty_line(input: &str) -> OracleResult<'_, TargetFilter> {
+    fn parse_loyalty_scope(input: &str) -> OracleResult<'_, Option<TargetFilter>> {
+        alt((
+            map(preceded(tag(" of "), parse_loyalty_planeswalker), Some),
+            value(None, eof),
+        ))
+        .parse(input)
+    }
+
+    fn parse_loyalty_line(input: &str) -> OracleResult<'_, Option<TargetFilter>> {
         preceded(
             alt((tag("whenever "), tag("when "))),
-            preceded(
-                tag("you activate a loyalty ability of "),
-                parse_loyalty_planeswalker,
-            ),
+            preceded(tag("you activate a loyalty ability"), parse_loyalty_scope),
         )
         .parse(input)
     }
@@ -7674,7 +7679,7 @@ fn try_parse_ability_activation_trigger(lower: &str) -> Option<(TriggerMode, Tri
     if let Ok((_, pw_filter)) = all_consuming(parse_loyalty_line).parse(lower) {
         let mut def = make_base();
         def.mode = TriggerMode::LoyaltyAbilityActivated;
-        def.valid_card = Some(pw_filter);
+        def.valid_card = pw_filter;
         return Some((TriggerMode::LoyaltyAbilityActivated, def));
     }
 

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -18339,6 +18339,24 @@ fn harsh_mentor_ability_activation_trigger_accepts_oxford_type_list() {
 
 // --- CR 606.2: "Whenever you activate a loyalty ability of [pw]" ---
 
+/// CR 606.2: Ajani Unrelenting's unqualified form accepts every loyalty
+/// ability activated by the source controller, so it carries no card filter.
+#[test]
+fn loyalty_ability_trigger_without_planeswalker_qualifier() {
+    let def = parse_trigger_line(
+        "Whenever you activate a loyalty ability, create a 2/2 colorless Wizard Soldier creature token named Cadet.",
+        "Ajani Unrelenting",
+    );
+    assert_eq!(def.mode, TriggerMode::LoyaltyAbilityActivated);
+    assert_eq!(def.valid_card, None);
+    let execute = def.execute.as_ref().expect("execute ability present");
+    assert!(
+        !matches!(*execute.effect, Effect::Unimplemented { .. }),
+        "Ajani's Cadet effect should parse, got {:?}",
+        execute.effect
+    );
+}
+
 /// CR 606.2 + CR 205.3j: Chandra's Regulator — "a Chandra planeswalker"
 /// parses to a typed Planeswalker + Subtype("Chandra") filter on
 /// `valid_card`, mode `LoyaltyAbilityActivated`, and the effect is not

--- a/crates/engine/tests/integration/loyalty_ability_activated_trigger.rs
+++ b/crates/engine/tests/integration/loyalty_ability_activated_trigger.rs
@@ -46,6 +46,7 @@ const KERAL_ORACLE: &str =
     "Whenever you activate a loyalty ability of a Chandra planeswalker, this creature deals 1 damage to each opponent.";
 const ELSPETH_TALENT_ORACLE: &str =
     "Whenever you activate a loyalty ability of enchanted planeswalker, creatures you control get +2/+2 and gain vigilance until end of turn.";
+const AJANI_ORACLE: &str = "Whenever you activate a loyalty ability, create a 2/2 colorless Wizard Soldier creature token named Cadet.\n[+1]: Creatures you control get +1/+0 and gain haste until end of turn.\n[−2]: Discard your hand, then draw a card for each creature you control.\n[−3]: Ajani deals 4 damage to each creature except for tokens you control.";
 
 /// A targeted minus-loyalty ability: CR 606.1 loyalty cost (`[−2]`, an
 /// `AbilityCost::Loyalty`) + `Effect::DealDamage 2` to `target creature`. Two
@@ -128,6 +129,85 @@ fn scenario_with_trigger_source(
         .from_oracle_text(oracle)
         .id();
     (scenario.build(), c1, source)
+}
+
+fn scenario_with_ajani() -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature(P0, "Ajani Ally", 2, 2);
+    let ajani = scenario
+        .add_creature(P0, "Ajani Unrelenting", 0, 0)
+        .from_oracle_text(AJANI_ORACLE)
+        .id();
+    let mut runner = scenario.build();
+    let object = runner.state_mut().objects.get_mut(&ajani).unwrap();
+    object.card_types.core_types = vec![CoreType::Planeswalker];
+    object.base_card_types = object.card_types.clone();
+    object.loyalty = Some(5);
+    object.counters.insert(CounterType::Loyalty, 5);
+    (runner, ajani)
+}
+
+fn ajani_stack_entries(runner: &GameRunner, ajani: ObjectId) -> usize {
+    runner
+        .state()
+        .stack
+        .iter()
+        .filter(|entry| entry.source_id == ajani)
+        .count()
+}
+
+#[test]
+fn ajani_unqualified_loyalty_trigger_uses_production_activation_scope() {
+    let (mut positive, ajani) = scenario_with_ajani();
+    positive
+        .act(GameAction::ActivateAbility {
+            source_id: ajani,
+            ability_index: 0,
+        })
+        .expect("Ajani's parsed +1 loyalty ability must activate through apply");
+    assert_eq!(
+        ajani_stack_entries(&positive, ajani),
+        2,
+        "the loyalty ability and Ajani's unqualified trigger must both be stacked"
+    );
+
+    let (mut normal, ajani) = scenario_with_ajani();
+    let normal_source = place_planeswalker(
+        &mut normal,
+        P0,
+        "Normal Ability Source",
+        "Jace",
+        5,
+        targeted_normal_ability(),
+    );
+    activate_and_target(&mut normal, normal_source, ajani);
+    assert_eq!(
+        ajani_stack_entries(&normal, ajani),
+        0,
+        "a Normal-kind activation must not fire Ajani's loyalty trigger"
+    );
+
+    let (mut opponent, ajani) = scenario_with_ajani();
+    let opponent_walker = place_planeswalker(
+        &mut opponent,
+        PlayerId(1),
+        "Opponent Walker",
+        "Jace",
+        5,
+        targeted_minus_loyalty_ability(),
+    );
+    opponent.state_mut().active_player = PlayerId(1);
+    opponent.state_mut().priority_player = PlayerId(1);
+    opponent.state_mut().waiting_for = WaitingFor::Priority {
+        player: PlayerId(1),
+    };
+    activate_and_target(&mut opponent, opponent_walker, ajani);
+    assert_eq!(
+        ajani_stack_entries(&opponent, ajani),
+        0,
+        "an opponent's loyalty activation must not satisfy Ajani's 'you' scope"
+    );
 }
 
 /// Activate `pw`'s loyalty ability at index 0, announcing the `[−X]` counter


### PR DESCRIPTION
## Summary

Adds general support for unqualified "Whenever you activate a loyalty ability" triggers, allowing Ajani Unrelenting to fire for its controller's loyalty activations without accepting normal abilities or an opponent's activations.

## Files changed

- `crates/engine/src/game/trigger_matchers.rs`
- `crates/engine/src/parser/oracle_trigger.rs`
- `crates/engine/src/parser/oracle_trigger_tests.rs`
- `crates/engine/tests/integration/loyalty_ability_activated_trigger.rs`

## Track

Developer

## LLM

Model: gpt-5.6-sol (via Codex; canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 606.2
- CR 109.5

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — PASS
- unqualified loyalty parser unit test — PASS (1/1)
- loyalty matcher unit test — PASS (1/1)
- Ajani production `apply()` integration — PASS (1/1; own loyalty positive, normal ability and opponent loyalty negative)
- `git diff --check upstream/main...HEAD` — PASS
- full workspace matrix — GitHub Actions CI-owned

## Gate A

Gate A PASS head=3c2ee387416147ce3fa26a6cd403ecd553b37cdb base=0622b17a5a26d498b1fd86178374bc6c94dda8b8

## Anchored on

- `crates/engine/src/parser/oracle_trigger.rs:7681` — existing typed `LoyaltyAbilityActivated` parser authority
- `crates/engine/src/game/trigger_matchers.rs:4877` — existing production loyalty-activation matcher

## Final review-impl

Final review-impl PASS head=3c2ee387416147ce3fa26a6cd403ecd553b37cdb

## Claimed parse impact

- Ajani Unrelenting

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.