### PR TITLE
Fix P2P reconnect after manual pause

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -1399,7 +1399,7 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     // the seat disconnected and eligible for a later retry.
     reconnect.simulateClose();
     pendingSnapshot.resolve({
-      state: { players: [], objects: {}, waiting_for: { type: "Priority", data: { player: 1 } } } as GameState,
+      state: { players: [], objects: {}, waiting_for: { type: "Priority", data: { player: 1 } } } as unknown as GameState,
       actions: [{ type: "PassPriority" }],
       autoPassRecommended: false,
     });

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -202,6 +202,7 @@ vi.mock("../ws-adapter", () => ({
 }));
 const mockSubmitAction = mocks.submitAction;
 const mockCheckDeckCompatibility = mocks.checkDeckCompatibility;
+const mockGetSnapshot = mocks.getSnapshot as unknown as AsyncMockWithResolvedValueOnce;
 const mockGetViewerSnapshot = mocks.getViewerSnapshot;
 const mockInitializeHostGame = mocks.initializeMultiplayerHostGame;
 const mockSetMultiplayerMode = mocks.setMultiplayerMode;
@@ -1545,6 +1546,90 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
       revision: 2,
       state: { label: "native revision two" },
     });
+  });
+
+  it("serializes a WASM reconnect with a queued final state and terminal delivery", async () => {
+    const { adapter, emitConnection } = makeHost(2, 5_000);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    await adapter.initializeGame();
+    const setup = (await guest.getSentMessages()).find(
+      (message): message is { type: "game_setup"; playerToken: string } =>
+        typeof message === "object"
+        && message !== null
+        && (message as { type?: string }).type === "game_setup",
+    );
+    const oldState = remoteState("before final state");
+    const finalState = {
+      ...remoteState("final state"),
+      waiting_for: { type: "GameOver", data: { winner: 0 } },
+    } as unknown as GameState;
+    let viewerState = oldState;
+    (mockGetViewerSnapshot as unknown as {
+      mockImplementation: (implementation: () => Promise<unknown>) => void;
+    }).mockImplementation(async () => ({
+      state: viewerState,
+      actions: [],
+      autoPassRecommended: false,
+    }));
+    mockGetSnapshot.mockResolvedValueOnce({
+      state: finalState,
+      legalResult: { actions: [], autoPassRecommended: false },
+      seq: 99,
+    });
+
+    const host = adapter as unknown as {
+      enqueueDelivery: (operation: () => Promise<void>) => Promise<void>;
+      broadcastStateUpdate: (
+        events: GameEvent[],
+        logEntries?: GameLogEntry[],
+        terminalReason?: string,
+      ) => Promise<void>;
+    };
+    const releaseDelivery = deferred<void>();
+    const inFlightDelivery = host.enqueueDelivery(async () => {
+      await releaseDelivery.promise;
+    });
+
+    guest.simulateClose();
+    const reconnect = await joinGuest(emitConnection, {
+      type: "reconnect",
+      playerToken: setup!.playerToken,
+    });
+    viewerState = finalState;
+    const finalBroadcast = host.broadcastStateUpdate([], [], "Game complete");
+
+    releaseDelivery.resolve();
+    await inFlightDelivery;
+    await finalBroadcast;
+    await flushPromises();
+
+    const messages = await reconnect.getSentMessages();
+    const ack = messages.find(
+      (message): message is { type: "reconnect_ack"; revision: number; state: { label: string } } =>
+        typeof message === "object"
+        && message !== null
+        && (message as { type?: string }).type === "reconnect_ack",
+    );
+    const update = messages.find(
+      (message): message is { type: "state_update"; revision: number; state: { label: string } } =>
+        typeof message === "object"
+        && message !== null
+        && (message as { type?: string }).type === "state_update",
+    );
+    const terminalIndex = messages.findIndex(
+      (message) => typeof message === "object"
+        && message !== null
+        && (message as { type?: string }).type === "terminal_result",
+    );
+
+    expect(ack).toMatchObject({ state: { label: "final state" } });
+    expect(update).toMatchObject({ state: { label: "final state" } });
+    expect(update!.revision).toBeGreaterThan(ack!.revision);
+    expect(terminalIndex).toBeGreaterThan(messages.indexOf(update!));
   });
 
   it("resumes a manual pause only after the last disconnected seat is resolved", async () => {

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -1350,6 +1350,96 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(mockSubmitAction).not.toHaveBeenCalled();
   });
 
+  it("reserves a reconnect seat through its ACK and ignores duplicate or pending actions", async () => {
+    const { adapter, emitConnection } = makeHost(2, 5_000);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    await adapter.initializeGame();
+    const setup = (await guest.getSentMessages()).find(
+      (message): message is { type: "game_setup"; playerToken: string } =>
+        typeof message === "object"
+        && message !== null
+        && (message as { type?: string }).type === "game_setup",
+    );
+    const pendingSnapshot = deferred<{
+      state: GameState;
+      actions: GameAction[];
+      autoPassRecommended: boolean;
+    }>();
+    (mockGetViewerSnapshot as unknown as {
+      mockImplementationOnce: (implementation: () => Promise<unknown>) => void;
+    }).mockImplementationOnce(() => pendingSnapshot.promise);
+    guest.simulateClose();
+
+    const reconnect = await joinGuest(emitConnection, {
+      type: "reconnect",
+      playerToken: setup!.playerToken,
+    });
+    await reconnect.simulateData({
+      type: "action",
+      senderPlayerId: 1,
+      action: { type: "PassPriority" },
+    });
+    const duplicate = await joinGuest(emitConnection, {
+      type: "reconnect",
+      playerToken: setup!.playerToken,
+    });
+    await flushPromises();
+
+    expect(mockSubmitAction).not.toHaveBeenCalled();
+    expect((await duplicate.getSentMessages()).some(
+      (message) => (message as { type?: string }).type === "reconnect_rejected",
+    )).toBe(true);
+
+    // Closing the reserved channel must release only its reservation, leaving
+    // the seat disconnected and eligible for a later retry.
+    reconnect.simulateClose();
+    pendingSnapshot.resolve({
+      state: { players: [], objects: {}, waiting_for: { type: "Priority", data: { player: 1 } } } as GameState,
+      actions: [{ type: "PassPriority" }],
+      autoPassRecommended: false,
+    });
+    await flushPromises();
+
+    const retry = await joinGuest(emitConnection, {
+      type: "reconnect",
+      playerToken: setup!.playerToken,
+    });
+    await flushPromises();
+    const messages = await retry.getSentMessages();
+    expect(messages.map((message) => (message as { type?: string }).type)).toContain("reconnect_ack");
+    const action = retry.simulateData({
+      type: "action",
+      senderPlayerId: 1,
+      action: { type: "PassPriority" },
+    });
+    await action;
+    expect(mockSubmitAction).toHaveBeenCalledWith({ type: "PassPriority" }, 1);
+  });
+
+  it("resumes a manual pause only after the last disconnected seat is resolved", async () => {
+    const { adapter } = makeHost(2, 5_000);
+    await adapter.initialize();
+    const events: P2PAdapterEvent[] = [];
+    adapter.onEvent((event) => events.push(event));
+    adapter.requestPause();
+    adapter.requestResume();
+
+    expect(events.map((event) => event.type)).toEqual(["gamePaused", "gameResumed"]);
+
+    const host = adapter as unknown as {
+      disconnectedSeats: Map<number, { disconnectedAt: number; timer: null }>;
+    };
+    host.disconnectedSeats.set(1, { disconnectedAt: Date.now(), timer: null });
+    adapter.requestPause();
+    adapter.requestResume();
+
+    expect(events.filter((event) => event.type === "gameResumed")).toHaveLength(1);
+  });
+
   it("replays a native AI driver fault after reconnecting guest's snapshot", async () => {
     const { adapter, emitConnection } = makeHost(2, 5_000);
     await adapter.initialize();

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -1481,6 +1481,38 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     )).toBe(true);
   });
 
+  it("rejects a reconnect when its native handoff cannot be built", async () => {
+    const { adapter, emitConnection } = makeHost(2, 5_000);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    await adapter.initializeGame();
+    const setup = (await guest.getSentMessages()).find(
+      (message): message is { type: "game_setup"; playerToken: string } =>
+        typeof message === "object"
+        && message !== null
+        && (message as { type?: string }).type === "game_setup",
+    );
+    guest.simulateClose();
+
+    const host = adapter as unknown as { nativeBridge: object | null };
+    host.nativeBridge = {};
+    const reconnect = await joinGuest(emitConnection, {
+      type: "reconnect",
+      playerToken: setup!.playerToken,
+    });
+    await flushPromises();
+
+    expect((await reconnect.getSentMessages()).find(
+      (message) => (message as { type?: string }).type === "reconnect_rejected",
+    )).toMatchObject({
+      type: "reconnect_rejected",
+      reason: "Reconnect acknowledgement failed",
+    });
+  });
+
   it("serializes a native reconnect behind an in-flight native revision delivery", async () => {
     const { adapter, emitConnection } = makeHost(2, 5_000);
     await adapter.initialize();

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -1501,7 +1501,7 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
       nativeBridge: object | null;
       nativeDeliveredViews: Map<number, { revision: number; snapshot: EngineSnapshot }>;
       authoritativeRevision: number;
-      enqueueNativeDelivery: (operation: () => Promise<void>) => Promise<void>;
+      enqueueDelivery: (operation: () => Promise<void>) => Promise<void>;
     };
     const oldSnapshot: EngineSnapshot = {
       state: remoteState("native revision one"),
@@ -1517,7 +1517,7 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     host.nativeDeliveredViews.set(1, { revision: 1, snapshot: oldSnapshot });
     host.authoritativeRevision = 1;
     const revisionDelivery = deferred<void>();
-    const inFlightRevision = host.enqueueNativeDelivery(async () => {
+    const inFlightRevision = host.enqueueDelivery(async () => {
       host.authoritativeRevision = 2;
       await revisionDelivery.promise;
       host.nativeDeliveredViews.set(1, { revision: 2, snapshot: currentSnapshot });

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -1420,6 +1420,133 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(mockSubmitAction).toHaveBeenCalledWith({ type: "PassPriority" }, 1);
   });
 
+  it("keeps a seat disconnected when its reconnect ACK is dropped before the write", async () => {
+    const { adapter, emitConnection } = makeHost(2, 5_000);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    await adapter.initializeGame();
+    const setup = (await guest.getSentMessages()).find(
+      (message): message is { type: "game_setup"; playerToken: string } =>
+        typeof message === "object"
+        && message !== null
+        && (message as { type?: string }).type === "game_setup",
+    );
+    const pendingSnapshot = deferred<{
+      state: GameState;
+      actions: GameAction[];
+      autoPassRecommended: boolean;
+    }>();
+    (mockGetViewerSnapshot as unknown as {
+      mockImplementationOnce: (implementation: () => Promise<unknown>) => void;
+    }).mockImplementationOnce(() => pendingSnapshot.promise);
+    guest.simulateClose();
+
+    const reconnect = await joinGuest(emitConnection, {
+      type: "reconnect",
+      playerToken: setup!.playerToken,
+    });
+    // The handoff is still resolving, then the data channel drops before the
+    // queued reconnect_ack can reach `conn.send`.
+    reconnect.open = false;
+    pendingSnapshot.resolve({
+      state: remoteState("dropped reconnect acknowledgement"),
+      actions: [{ type: "PassPriority" }],
+      autoPassRecommended: false,
+    });
+    await flushPromises();
+
+    const host = adapter as unknown as {
+      guestSessions: Map<number, unknown>;
+      pendingReconnectSessions: Map<number, unknown>;
+      disconnectedSeats: Map<number, unknown>;
+      gameRunState: string;
+    };
+    expect(await reconnect.getSentMessages()).toEqual([]);
+    expect(host.guestSessions.has(1)).toBe(false);
+    expect(host.pendingReconnectSessions.has(1)).toBe(false);
+    expect(host.disconnectedSeats.has(1)).toBe(true);
+    expect(host.gameRunState).toBe("paused-disconnect");
+
+    const retry = await joinGuest(emitConnection, {
+      type: "reconnect",
+      playerToken: setup!.playerToken,
+    });
+    await flushPromises();
+    expect((await retry.getSentMessages()).some(
+      (message) => (message as { type?: string }).type === "reconnect_ack",
+    )).toBe(true);
+  });
+
+  it("serializes a native reconnect behind an in-flight native revision delivery", async () => {
+    const { adapter, emitConnection } = makeHost(2, 5_000);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    await adapter.initializeGame();
+    const setup = (await guest.getSentMessages()).find(
+      (message): message is { type: "game_setup"; playerToken: string } =>
+        typeof message === "object"
+        && message !== null
+        && (message as { type?: string }).type === "game_setup",
+    );
+    guest.simulateClose();
+
+    const host = adapter as unknown as {
+      nativeBridge: object | null;
+      nativeDeliveredViews: Map<number, { revision: number; snapshot: EngineSnapshot }>;
+      authoritativeRevision: number;
+      enqueueNativeDelivery: (operation: () => Promise<void>) => Promise<void>;
+    };
+    const oldSnapshot: EngineSnapshot = {
+      state: remoteState("native revision one"),
+      legalResult: { actions: [], autoPassRecommended: false },
+      seq: 1,
+    };
+    const currentSnapshot: EngineSnapshot = {
+      state: remoteState("native revision two"),
+      legalResult: { actions: [{ type: "PassPriority" }], autoPassRecommended: false },
+      seq: 2,
+    };
+    host.nativeBridge = {};
+    host.nativeDeliveredViews.set(1, { revision: 1, snapshot: oldSnapshot });
+    host.authoritativeRevision = 1;
+    const revisionDelivery = deferred<void>();
+    const inFlightRevision = host.enqueueNativeDelivery(async () => {
+      host.authoritativeRevision = 2;
+      await revisionDelivery.promise;
+      host.nativeDeliveredViews.set(1, { revision: 2, snapshot: currentSnapshot });
+    });
+
+    const reconnect = await joinGuest(emitConnection, {
+      type: "reconnect",
+      playerToken: setup!.playerToken,
+    });
+    await flushPromises();
+    expect((await reconnect.getSentMessages()).some(
+      (message) => (message as { type?: string }).type === "reconnect_ack",
+    )).toBe(false);
+
+    revisionDelivery.resolve();
+    await inFlightRevision;
+    await flushPromises();
+
+    const ack = (await reconnect.getSentMessages()).find(
+      (message): message is { type: "reconnect_ack"; revision: number; state: { label: string } } =>
+        typeof message === "object"
+        && message !== null
+        && (message as { type?: string }).type === "reconnect_ack",
+    );
+    expect(ack).toMatchObject({
+      revision: 2,
+      state: { label: "native revision two" },
+    });
+  });
+
   it("resumes a manual pause only after the last disconnected seat is resolved", async () => {
     const { adapter } = makeHost(2, 5_000);
     await adapter.initialize();

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -695,10 +695,10 @@ export class P2PHostAdapter implements EngineAdapter {
   /** Native snapshots become reconnectable only after their matching server
    * revision has completed the PeerJS fan-out. */
   private nativeDeliveredViews = new Map<PlayerId, { revision: number; snapshot: EngineSnapshot }>();
-  /** Serializes native state fan-out with reconnect promotion. A reconnect
-   * cannot acknowledge an older delivered view while a newer native revision
-   * is in flight and would otherwise miss its newly promoted session. */
-  private nativeDeliveryQueue: Promise<void> = Promise.resolve();
+  /** Serializes every state-bearing delivery with reconnect promotion. A
+   * reconnect cannot acknowledge an older view while a state fan-out is in
+   * flight and would otherwise miss that update after becoming active. */
+  private deliveryQueue: Promise<void> = Promise.resolve();
   private guestDecks = new Map<PlayerId, DeckListPayload["player"]>();
   private aiDecks = new Map<PlayerId, DeckListPayload["player"]>();
   private playerTokens = new Map<PlayerId, string>();
@@ -877,10 +877,10 @@ export class P2PHostAdapter implements EngineAdapter {
         formatConfig,
         matchConfig,
         native,
-        (revision, views) => this.enqueueNativeDelivery(
+        (revision, views) => this.enqueueDelivery(
           () => this.handleNativeRevision(revision, views),
         ),
-        (fault) => this.enqueueNativeDelivery(() => this.handleNativeAiDriverFault(fault)),
+        (fault) => this.enqueueDelivery(() => this.handleNativeAiDriverFault(fault)),
         nativeResume,
       );
     } else {
@@ -1130,13 +1130,14 @@ export class P2PHostAdapter implements EngineAdapter {
     return session.send({ ...message, authority: this.authority });
   }
 
-  /** Keep native server revisions and reconnect acknowledgement/promotion in
-   * one ordered critical section. The bridge already serializes revisions;
-   * this additionally keeps an independently arriving PeerJS reconnect from
-   * slipping between a revision's snapshot fan-out and its delivery record. */
-  private enqueueNativeDelivery<T>(operation: () => Promise<T>): Promise<T> {
-    const result = this.nativeDeliveryQueue.then(operation, operation);
-    this.nativeDeliveryQueue = result.then(
+  /** Keep state fan-out, terminal delivery, and reconnect acknowledgement /
+   * promotion in one ordered critical section. PeerJS reconnects arrive
+   * independently of both the native revision stream and browser WASM action
+   * fan-out; without this fence either path can skip a pending session while
+   * the reconnect acknowledges an older snapshot. */
+  private enqueueDelivery<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.deliveryQueue.then(operation, operation);
+    this.deliveryQueue = result.then(
       () => undefined,
       () => undefined,
     );
@@ -2181,6 +2182,14 @@ export class P2PHostAdapter implements EngineAdapter {
     logEntries?: GameLogEntry[],
     terminalReason?: string,
   ): Promise<void> {
+    return this.enqueueDelivery(() => this.broadcastStateUpdateInner(events, logEntries, terminalReason));
+  }
+
+  private async broadcastStateUpdateInner(
+    events: GameEvent[],
+    logEntries?: GameLogEntry[],
+    terminalReason?: string,
+  ): Promise<void> {
     if (!this.ownsAuthority()) return;
     if (this.nativeBridge) return;
     const revision = ++this.authoritativeRevision;
@@ -2740,11 +2749,7 @@ export class P2PHostAdapter implements EngineAdapter {
   }
 
   private async completeReconnect(pid: PlayerId, session: PeerSession): Promise<void> {
-    if (this.nativeBridge) {
-      await this.enqueueNativeDelivery(() => this.completeReconnectAfterHandoff(pid, session));
-      return;
-    }
-    await this.completeReconnectAfterHandoff(pid, session);
+    await this.enqueueDelivery(() => this.completeReconnectAfterHandoff(pid, session));
   }
 
   private async completeReconnectAfterHandoff(pid: PlayerId, session: PeerSession): Promise<void> {

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -695,6 +695,10 @@ export class P2PHostAdapter implements EngineAdapter {
   /** Native snapshots become reconnectable only after their matching server
    * revision has completed the PeerJS fan-out. */
   private nativeDeliveredViews = new Map<PlayerId, { revision: number; snapshot: EngineSnapshot }>();
+  /** Serializes native state fan-out with reconnect promotion. A reconnect
+   * cannot acknowledge an older delivered view while a newer native revision
+   * is in flight and would otherwise miss its newly promoted session. */
+  private nativeDeliveryQueue: Promise<void> = Promise.resolve();
   private guestDecks = new Map<PlayerId, DeckListPayload["player"]>();
   private aiDecks = new Map<PlayerId, DeckListPayload["player"]>();
   private playerTokens = new Map<PlayerId, string>();
@@ -873,8 +877,10 @@ export class P2PHostAdapter implements EngineAdapter {
         formatConfig,
         matchConfig,
         native,
-        (revision, views) => this.handleNativeRevision(revision, views),
-        (fault) => this.handleNativeAiDriverFault(fault),
+        (revision, views) => this.enqueueNativeDelivery(
+          () => this.handleNativeRevision(revision, views),
+        ),
+        (fault) => this.enqueueNativeDelivery(() => this.handleNativeAiDriverFault(fault)),
         nativeResume,
       );
     } else {
@@ -1119,9 +1125,22 @@ export class P2PHostAdapter implements EngineAdapter {
     throw new AdapterError("P2P_ERROR", `Host session disposed during ${during}`, true);
   }
 
-  private send(session: PeerSession, message: P2PMessage): Promise<void> {
-    if (!this.ownsAuthority()) return Promise.resolve();
+  private send(session: PeerSession, message: P2PMessage): Promise<boolean> {
+    if (!this.ownsAuthority()) return Promise.resolve(false);
     return session.send({ ...message, authority: this.authority });
+  }
+
+  /** Keep native server revisions and reconnect acknowledgement/promotion in
+   * one ordered critical section. The bridge already serializes revisions;
+   * this additionally keeps an independently arriving PeerJS reconnect from
+   * slipping between a revision's snapshot fan-out and its delivery record. */
+  private enqueueNativeDelivery<T>(operation: () => Promise<T>): Promise<T> {
+    const result = this.nativeDeliveryQueue.then(operation, operation);
+    this.nativeDeliveryQueue = result.then(
+      () => undefined,
+      () => undefined,
+    );
+    return result;
   }
 
   private rejectSuperseded(session: PeerSession): void {
@@ -1998,7 +2017,7 @@ export class P2PHostAdapter implements EngineAdapter {
     if (revision < this.authoritativeRevision) return;
     this.authoritativeRevision = revision;
     const allNames = this.playerNamesForSeats();
-    const sends: Array<Promise<void>> = [];
+    const sends: Array<Promise<boolean>> = [];
     for (const [pid, session] of this.guestSessions) {
       const update = views.get(pid);
       if (!update || this.disconnectedSeats.has(pid)) continue;
@@ -2165,7 +2184,7 @@ export class P2PHostAdapter implements EngineAdapter {
     if (!this.ownsAuthority()) return;
     if (this.nativeBridge) return;
     const revision = ++this.authoritativeRevision;
-    const sends: Array<Promise<void>> = [];
+    const sends: Array<Promise<boolean>> = [];
     for (const [pid, session] of this.guestSessions) {
       if (this.disconnectedSeats.has(pid)) continue;
       const snapshot = await this.wasm.getViewerSnapshot(pid);
@@ -2721,11 +2740,19 @@ export class P2PHostAdapter implements EngineAdapter {
   }
 
   private async completeReconnect(pid: PlayerId, session: PeerSession): Promise<void> {
+    if (this.nativeBridge) {
+      await this.enqueueNativeDelivery(() => this.completeReconnectAfterHandoff(pid, session));
+      return;
+    }
+    await this.completeReconnectAfterHandoff(pid, session);
+  }
+
+  private async completeReconnectAfterHandoff(pid: PlayerId, session: PeerSession): Promise<void> {
     try {
       const handoff = await this.reconnectHandoff(pid);
       if (this.pendingReconnectSessions.get(pid) !== session || !this.ownsAuthority()) return;
 
-      await this.send(session, {
+      const acknowledged = await this.send(session, {
         type: "reconnect_ack",
         wireProtocolVersion: WIRE_PROTOCOL_VERSION,
         assignedPlayerId: pid,
@@ -2734,16 +2761,32 @@ export class P2PHostAdapter implements EngineAdapter {
         playerNames: this.playerNamesForSeats(),
         ...legalActionsToWire(handoff.snapshot.legalResult),
       });
-      // Sending may race a transport close. Only the exact still-reserved
-      // channel can take the seat; a failed ACK leaves it retryable.
+      // A queued send can be dropped after the reconnect handoff was captured.
+      // Only a channel that actually accepted its ACK can take the seat; a
+      // failed ACK remains disconnected and is eligible for a later retry.
+      if (!acknowledged) {
+        this.failPendingReconnect(pid, session, "Reconnect acknowledgement could not be delivered");
+        return;
+      }
       if (this.pendingReconnectSessions.get(pid) !== session || !this.ownsAuthority()) return;
 
       if (this.deliveredNativeAiDriverFault !== null) {
-        await this.send(session, { type: "ai_driver_fault", ...this.deliveredNativeAiDriverFault });
+        const faultDelivered = await this.send(session, {
+          type: "ai_driver_fault",
+          ...this.deliveredNativeAiDriverFault,
+        });
+        if (!faultDelivered) {
+          this.failPendingReconnect(pid, session, "Reconnect fault could not be delivered");
+          return;
+        }
       }
       if (this.terminalResult !== null) {
         const result = await this.terminalResultForRecipient(pid, handoff.snapshot.state, handoff.revision);
-        await this.send(session, { type: "terminal_result", result });
+        const terminalDelivered = await this.send(session, { type: "terminal_result", result });
+        if (!terminalDelivered) {
+          this.failPendingReconnect(pid, session, "Reconnect terminal result could not be delivered");
+          return;
+        }
       }
       if (this.pendingReconnectSessions.get(pid) !== session || !this.ownsAuthority()) return;
 
@@ -2761,10 +2804,7 @@ export class P2PHostAdapter implements EngineAdapter {
       this.emit({ type: "playerReconnected", playerId: pid });
       this.resumeIfUnblocked();
     } catch (error) {
-      if (this.pendingReconnectSessions.get(pid) === session) {
-        this.pendingReconnectSessions.delete(pid);
-        session.close("Reconnect acknowledgement failed");
-      }
+      this.failPendingReconnect(pid, session, "Reconnect acknowledgement failed");
       traceAdapter("Host", "reconnect-ack-failed", {
         pid,
         error: error instanceof Error ? error.message : String(error),
@@ -2798,6 +2838,12 @@ export class P2PHostAdapter implements EngineAdapter {
         return;
       }
     }
+  }
+
+  private failPendingReconnect(pid: PlayerId, session: PeerSession, reason: string): void {
+    if (this.pendingReconnectSessions.get(pid) !== session) return;
+    this.pendingReconnectSessions.delete(pid);
+    session.close(reason);
   }
 
   private closePendingReconnect(pid: PlayerId, reason: string): void {

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -685,6 +685,16 @@ export class P2PHostAdapter implements EngineAdapter {
   private readonly engineClaim = Symbol("p2p-host-engine-claim");
 
   private guestSessions = new Map<PlayerId, PeerSession>();
+  /**
+   * A reconnecting transport has proved its token but is not a game session
+   * until its complete reconnect acknowledgement has been written. This is
+   * deliberately adapter-ephemeral: persisting an in-flight channel would
+   * make a reload retain a connection that cannot exist any more.
+   */
+  private pendingReconnectSessions = new Map<PlayerId, PeerSession>();
+  /** Native snapshots become reconnectable only after their matching server
+   * revision has completed the PeerJS fan-out. */
+  private nativeDeliveredViews = new Map<PlayerId, { revision: number; snapshot: EngineSnapshot }>();
   private guestDecks = new Map<PlayerId, DeckListPayload["player"]>();
   private aiDecks = new Map<PlayerId, DeckListPayload["player"]>();
   private playerTokens = new Map<PlayerId, string>();
@@ -1499,6 +1509,7 @@ export class P2PHostAdapter implements EngineAdapter {
             return;
           }
         }
+        this.clearPendingReconnectReservation(session);
       },
     });
 
@@ -1646,7 +1657,7 @@ export class P2PHostAdapter implements EngineAdapter {
       await this.refreshPregameSeatView();
       this.saveSession();
 
-      session.onMessage((msg) => this.handleGuestMessage(pid, msg));
+      session.onMessage((msg) => this.handleGuestMessage(pid, session, msg));
 
       this.broadcastSeatSnapshot();
       this.syncLobbyMetadata(reservationToken ? [reservationToken] : []);
@@ -2018,6 +2029,9 @@ export class P2PHostAdapter implements EngineAdapter {
     }
     await Promise.all(sends);
     this.nativeInitialSetupPending = false;
+    for (const [playerId, update] of views) {
+      this.nativeDeliveredViews.set(playerId, { revision, snapshot: update.snapshot });
+    }
     this.emit({
       type: "stateChanged",
       snapshot: hostUpdate.snapshot,
@@ -2077,6 +2091,7 @@ export class P2PHostAdapter implements EngineAdapter {
   ): Promise<void> {
     const { waiting_for: waitingFor } = snapshot.state;
     if (waitingFor.type !== "GameOver" || this.terminalResult) return;
+    this.authoritativeRevision = Math.max(this.authoritativeRevision, revision);
     const winner = waitingFor.data.winner;
     const display = { winner, reason };
     const createResult = async (
@@ -2116,14 +2131,18 @@ export class P2PHostAdapter implements EngineAdapter {
   private async terminalResultForRecipient(
     recipient: PlayerId,
     terminalState: GameState,
+    revision: number,
   ): Promise<P2PTerminalResult> {
     const terminal = this.terminalResult;
     if (terminal === null) throw new Error("No terminal result to deliver");
+    if (terminalState.waiting_for.type !== "GameOver" || terminal.revision !== revision) {
+      throw new Error("Reconnect acknowledgement is not the committed final state");
+    }
     return {
       key: this.sessionKey,
       lease: this.authority,
       recipient,
-      revision: this.authoritativeRevision,
+      revision,
       terminalId: crypto.randomUUID(),
       finalStateCommitment: await p2pFinalStateCommitment(terminalState),
       display: terminal.display,
@@ -2283,6 +2302,10 @@ export class P2PHostAdapter implements EngineAdapter {
       if (timer !== null) clearTimeout(timer);
     }
     this.disconnectedSeats.clear();
+    for (const session of this.pendingReconnectSessions.values()) {
+      session.close();
+    }
+    this.pendingReconnectSessions.clear();
     for (const session of this.guestSessions.values()) {
       session.close();
     }
@@ -2291,6 +2314,7 @@ export class P2PHostAdapter implements EngineAdapter {
     this.playerTokens.clear();
     this.guestDecks.clear();
     this.aiDecks.clear();
+    this.nativeDeliveredViews.clear();
     try {
       this.hostPeer.destroy();
     } catch {
@@ -2369,9 +2393,14 @@ export class P2PHostAdapter implements EngineAdapter {
 
   private async handleGuestMessage(
     pid: PlayerId,
+    sourceSession: PeerSession,
     msg: P2PMessage,
   ): Promise<void> {
     const session = this.guestSessions.get(pid);
+    // A reconnecting channel is intentionally not installed in
+    // `guestSessions` until its ACK has been delivered. Keep every control
+    // frame bound to the exact installed channel, not merely its player id.
+    if (session !== sourceSession) return;
     if (!this.ownsAuthority()) {
       if (session) this.rejectSuperseded(session);
       return;
@@ -2677,63 +2706,118 @@ export class P2PHostAdapter implements EngineAdapter {
       return;
     }
 
-    const grace = this.disconnectedSeats.get(pid)!;
-    if (grace.timer !== null) clearTimeout(grace.timer);
-    this.disconnectedSeats.delete(pid);
-    this.guestSessions.set(pid, session);
+    if (this.pendingReconnectSessions.has(pid)) {
+      void this.send(session, { type: "reconnect_rejected", reason: "Reconnect already in progress" });
+      session.close("Reconnect already in progress");
+      return;
+    }
 
-    // Wire subsequent messages from this guest.
-    session.onMessage((msg) => this.handleGuestMessage(pid as PlayerId, msg));
+    // Consume every pre-ACK frame. If a channel sends action/concede/control
+    // frames while the snapshot is in flight, those frames must never be
+    // replayed into the promoted session later.
+    session.onMessage(() => undefined);
+    this.pendingReconnectSessions.set(pid, session);
+    void this.completeReconnect(pid, session);
+  }
 
-    // Send fresh state to the reconnecting guest.
-    void (async () => {
-      let state: GameState;
-      let legalResult: LegalActionsResult;
-      if (this.nativeBridge) {
-        const snapshot = this.nativeBridge.viewerSnapshot(pid as PlayerId);
-        state = snapshot.state;
-        legalResult = snapshot.legalResult;
-      } else {
-        const snapshot = await this.wasm.getViewerSnapshot(pid as PlayerId);
-        state = snapshot.state;
-        legalResult = snapshot;
-      }
+  private async completeReconnect(pid: PlayerId, session: PeerSession): Promise<void> {
+    try {
+      const handoff = await this.reconnectHandoff(pid);
+      if (this.pendingReconnectSessions.get(pid) !== session || !this.ownsAuthority()) return;
+
       await this.send(session, {
         type: "reconnect_ack",
         wireProtocolVersion: WIRE_PROTOCOL_VERSION,
-        assignedPlayerId: pid as PlayerId,
-        revision: this.authoritativeRevision,
-        state,
+        assignedPlayerId: pid,
+        revision: handoff.revision,
+        state: handoff.snapshot.state,
         playerNames: this.playerNamesForSeats(),
-        ...legalActionsToWire(legalResult),
+        ...legalActionsToWire(handoff.snapshot.legalResult),
       });
+      // Sending may race a transport close. Only the exact still-reserved
+      // channel can take the seat; a failed ACK leaves it retryable.
+      if (this.pendingReconnectSessions.get(pid) !== session || !this.ownsAuthority()) return;
+
       if (this.deliveredNativeAiDriverFault !== null) {
-        await this.send(session, {
-          type: "ai_driver_fault",
-          ...this.deliveredNativeAiDriverFault,
-        });
+        await this.send(session, { type: "ai_driver_fault", ...this.deliveredNativeAiDriverFault });
       }
       if (this.terminalResult !== null) {
-        const result = await this.terminalResultForRecipient(pid as PlayerId, state);
+        const result = await this.terminalResultForRecipient(pid, handoff.snapshot.state, handoff.revision);
         await this.send(session, { type: "terminal_result", result });
       }
-    })();
+      if (this.pendingReconnectSessions.get(pid) !== session || !this.ownsAuthority()) return;
 
-    // Notify other guests.
-    for (const [otherPid, otherSession] of this.guestSessions) {
-      if (otherPid === pid) continue;
-      void this.send(otherSession, { type: "player_reconnected", playerId: pid });
-    }
-    this.emit({ type: "playerReconnected", playerId: pid });
+      const grace = this.disconnectedSeats.get(pid);
+      if (!grace) return;
+      if (grace.timer !== null) clearTimeout(grace.timer);
+      this.pendingReconnectSessions.delete(pid);
+      this.disconnectedSeats.delete(pid);
+      this.guestSessions.set(pid, session);
+      session.onMessage((msg) => this.handleGuestMessage(pid, session, msg));
 
-    // Resume if no other seats are paused.
-    if (this.disconnectedSeats.size === 0 && this.gameRunState === "paused-disconnect") {
-      this.gameRunState = "running";
-      for (const [, s] of this.guestSessions) {
-        void this.send(s, { type: "game_resumed" });
+      for (const [otherPid, otherSession] of this.guestSessions) {
+        if (otherPid !== pid) void this.send(otherSession, { type: "player_reconnected", playerId: pid });
       }
-      this.emit({ type: "gameResumed" });
+      this.emit({ type: "playerReconnected", playerId: pid });
+      this.resumeIfUnblocked();
+    } catch (error) {
+      if (this.pendingReconnectSessions.get(pid) === session) {
+        this.pendingReconnectSessions.delete(pid);
+        session.close("Reconnect acknowledgement failed");
+      }
+      traceAdapter("Host", "reconnect-ack-failed", {
+        pid,
+        error: error instanceof Error ? error.message : String(error),
+      });
     }
+  }
+
+  /** Capture state, legal actions, and their authority revision as one handoff.
+   * WASM has no server revision, so retry if an action fan-out advances the
+   * local revision while its viewer snapshot is resolving. */
+  private async reconnectHandoff(pid: PlayerId): Promise<{ revision: number; snapshot: EngineSnapshot }> {
+    if (this.nativeBridge) {
+      const delivered = this.nativeDeliveredViews.get(pid);
+      if (!delivered) throw new AdapterError("P2P_ERROR", `No delivered native snapshot for seat ${pid}`, true);
+      return delivered;
+    }
+    while (this.ownsAuthority()) {
+      const revision = this.authoritativeRevision;
+      const viewer = await this.wasm.getViewerSnapshot(pid);
+      if (revision === this.authoritativeRevision) {
+        return { revision, snapshot: { state: viewer.state, legalResult: viewer, seq: nextSnapshotSeq() } };
+      }
+    }
+    throw new AdapterError("P2P_ERROR", "Host session superseded", true);
+  }
+
+  private clearPendingReconnectReservation(session: PeerSession): void {
+    for (const [pid, pending] of this.pendingReconnectSessions) {
+      if (pending === session) {
+        this.pendingReconnectSessions.delete(pid);
+        return;
+      }
+    }
+  }
+
+  private closePendingReconnect(pid: PlayerId, reason: string): void {
+    const session = this.pendingReconnectSessions.get(pid);
+    if (!session) return;
+    this.pendingReconnectSessions.delete(pid);
+    session.close(reason);
+  }
+
+  private resumeIfUnblocked(): void {
+    if (
+      this.disconnectedSeats.size !== 0
+      || this.pendingReconnectSessions.size !== 0
+      || (this.gameRunState !== "paused-disconnect" && this.gameRunState !== "paused-manual")
+    ) return;
+    this.gameRunState = "running";
+    for (const session of this.guestSessions.values()) {
+      void this.send(session, { type: "game_resumed" });
+    }
+    this.emit({ type: "gameResumed" });
   }
 
   /**
@@ -2756,6 +2840,7 @@ export class P2PHostAdapter implements EngineAdapter {
       if (grace.timer !== null) clearTimeout(grace.timer);
       this.disconnectedSeats.delete(pid);
     }
+    this.closePendingReconnect(pid, "Player conceded");
     // Remove the session for self-concede / grace-expiry paths. (The kick
     // path removes its own session before calling concedePlayer so it can
     // send the `kick` wire message first; double-deletion is a no-op here.)
@@ -2796,17 +2881,8 @@ export class P2PHostAdapter implements EngineAdapter {
     } catch (err) {
       console.error("[P2PHost] concedePlayer failed:", err);
     }
-    // Resume game state if this concede unblocked the pause.
-    if (
-      this.disconnectedSeats.size === 0 &&
-      this.gameRunState === "paused-disconnect"
-    ) {
-      this.gameRunState = "running";
-      for (const [, s] of this.guestSessions) {
-        void this.send(s, { type: "game_resumed" });
-      }
-      this.emit({ type: "gameResumed" });
-    }
+    // A concession may clear the final outstanding reconnect reservation.
+    this.resumeIfUnblocked();
   }
 
   // ────────────────────────────────────────────────────────────────────────
@@ -2821,6 +2897,7 @@ export class P2PHostAdapter implements EngineAdapter {
     if (!this.ownsAuthority()) return;
     const token = this.playerTokens.get(pid);
     if (token) this.kickedTokens.add(token);
+    this.closePendingReconnect(pid, "Kicked");
     // Persist the kick before the session close — the kickedTokens set
     // survives host reload so a kicked guest can't sneak back in on
     // resume.
@@ -2890,12 +2967,13 @@ export class P2PHostAdapter implements EngineAdapter {
     }
   }
 
-  /** Manually resume (host UI). Only resumes if no seats are still disconnected. */
+  /** Manually resume only an explicit manual pause after every reconnect settles. */
   requestResume(): void {
     if (!this.ownsAuthority()) return;
     if (
       this.gameRunState === "paused-manual" &&
-      this.disconnectedSeats.size === 0
+      this.disconnectedSeats.size === 0 &&
+      this.pendingReconnectSessions.size === 0
     ) {
       this.gameRunState = "running";
       for (const [, s] of this.guestSessions) {

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -2848,6 +2848,11 @@ export class P2PHostAdapter implements EngineAdapter {
   private failPendingReconnect(pid: PlayerId, session: PeerSession, reason: string): void {
     if (this.pendingReconnectSessions.get(pid) !== session) return;
     this.pendingReconnectSessions.delete(pid);
+    // An otherwise open guest needs an explicit terminal response; a bare
+    // close is treated as a transient transport loss and starts its retry loop.
+    // `PeerSession.close` preserves already-queued sends, so this rejection is
+    // written before the farewell close frame when the transport remains open.
+    void this.send(session, { type: "reconnect_rejected", reason });
     session.close(reason);
   }
 

--- a/client/src/components/chrome/PausedBanner.tsx
+++ b/client/src/components/chrome/PausedBanner.tsx
@@ -4,6 +4,7 @@ import { useTranslation } from "react-i18next";
 interface PausedBannerProps {
   isVisible: boolean;
   reason: string;
+  onResume?: () => void;
 }
 
 /**
@@ -12,7 +13,7 @@ interface PausedBannerProps {
  * `DisconnectChoiceDialog` overlay simultaneously; guests see only this
  * banner.
  */
-export function PausedBanner({ isVisible, reason }: PausedBannerProps) {
+export function PausedBanner({ isVisible, reason, onResume }: PausedBannerProps) {
   const { t } = useTranslation();
   return (
     <AnimatePresence>
@@ -24,8 +25,17 @@ export function PausedBanner({ isVisible, reason }: PausedBannerProps) {
           exit={{ opacity: 0, y: -16 }}
           transition={{ duration: 0.18 }}
         >
-          <div className="rounded-full bg-amber-500/20 px-4 py-1.5 text-xs font-semibold text-amber-200 ring-1 ring-amber-300/40 backdrop-blur">
+          <div className="flex items-center gap-3 rounded-full bg-amber-500/20 px-4 py-1.5 text-xs font-semibold text-amber-200 ring-1 ring-amber-300/40 backdrop-blur">
             {t("pausedBanner.message", { reason })}
+            {onResume && (
+              <button
+                type="button"
+                className="pointer-events-auto rounded bg-amber-200/15 px-2 py-1 text-xs font-bold text-amber-100 hover:bg-amber-200/25 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-100"
+                onClick={onResume}
+              >
+                {t("pausedBanner.resume")}
+              </button>
+            )}
           </div>
         </motion.div>
       )}

--- a/client/src/components/chrome/PausedBanner.tsx
+++ b/client/src/components/chrome/PausedBanner.tsx
@@ -30,7 +30,7 @@ export function PausedBanner({ isVisible, reason, onResume }: PausedBannerProps)
             {onResume && (
               <button
                 type="button"
-                className="pointer-events-auto rounded bg-amber-200/15 px-2 py-1 text-xs font-bold text-amber-100 hover:bg-amber-200/25 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-100"
+                className="pointer-events-auto min-h-11 min-w-11 rounded bg-amber-200/15 px-2 py-1 text-xs font-bold text-amber-100 hover:bg-amber-200/25 active:bg-amber-200/25 focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-amber-100"
                 onClick={onResume}
               >
                 {t("pausedBanner.resume")}

--- a/client/src/components/chrome/__tests__/PausedBanner.test.tsx
+++ b/client/src/components/chrome/__tests__/PausedBanner.test.tsx
@@ -1,10 +1,12 @@
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
-import { describe, expect, it, vi } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { PausedBanner } from "../PausedBanner";
 
 describe("PausedBanner", () => {
+  afterEach(cleanup);
+
   it("shows an accessible Resume control only when the host supplies a handler", async () => {
     const onResume = vi.fn();
     const user = userEvent.setup();

--- a/client/src/components/chrome/__tests__/PausedBanner.test.tsx
+++ b/client/src/components/chrome/__tests__/PausedBanner.test.tsx
@@ -1,0 +1,23 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { describe, expect, it, vi } from "vitest";
+
+import { PausedBanner } from "../PausedBanner";
+
+describe("PausedBanner", () => {
+  it("shows an accessible Resume control only when the host supplies a handler", async () => {
+    const onResume = vi.fn();
+    const user = userEvent.setup();
+    render(<PausedBanner isVisible reason="Paused by host" onResume={onResume} />);
+
+    await user.click(screen.getByRole("button", { name: "Resume" }));
+
+    expect(onResume).toHaveBeenCalledOnce();
+  });
+
+  it("does not expose a resume control to guests", () => {
+    render(<PausedBanner isVisible reason="Paused by host" />);
+
+    expect(screen.queryByRole("button", { name: "Resume" })).toBeNull();
+  });
+});

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -19,7 +19,8 @@
     "defaultEyebrow": "Workspace-Werkzeug"
   },
   "pausedBanner": {
-    "message": "Spiel pausiert — {{reason}}"
+    "message": "Spiel pausiert — {{reason}}",
+    "resume": "Fortsetzen"
   },
   "fullscreen": {
     "enter": "Vollbild starten",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -19,7 +19,8 @@
     "defaultEyebrow": "Workspace Tool"
   },
   "pausedBanner": {
-    "message": "Game paused — {{reason}}"
+    "message": "Game paused — {{reason}}",
+    "resume": "Resume"
   },
   "fullscreen": {
     "enter": "Enter fullscreen",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -19,7 +19,8 @@
     "defaultEyebrow": "Herramienta del espacio de trabajo"
   },
   "pausedBanner": {
-    "message": "Partida en pausa — {{reason}}"
+    "message": "Partida en pausa — {{reason}}",
+    "resume": "Reanudar"
   },
   "fullscreen": {
     "enter": "Activar pantalla completa",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -19,7 +19,8 @@
     "defaultEyebrow": "Outil d'espace de travail"
   },
   "pausedBanner": {
-    "message": "Partie en pause — {{reason}}"
+    "message": "Partie en pause — {{reason}}",
+    "resume": "Reprendre"
   },
   "fullscreen": {
     "enter": "Passer en plein écran",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -19,7 +19,8 @@
     "defaultEyebrow": "Strumento dello spazio di lavoro"
   },
   "pausedBanner": {
-    "message": "Partita in pausa — {{reason}}"
+    "message": "Partita in pausa — {{reason}}",
+    "resume": "Riprendi"
   },
   "fullscreen": {
     "enter": "Attiva schermo intero",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -19,7 +19,8 @@
     "defaultEyebrow": "Narzędzie warsztatu"
   },
   "pausedBanner": {
-    "message": "Gra wstrzymana — {{reason}}"
+    "message": "Gra wstrzymana — {{reason}}",
+    "resume": "Wznów"
   },
   "fullscreen": {
     "enter": "Włącz pełny ekran",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -19,7 +19,8 @@
     "defaultEyebrow": "Ferramenta de Workspace"
   },
   "pausedBanner": {
-    "message": "Jogo pausado — {{reason}}"
+    "message": "Jogo pausado — {{reason}}",
+    "resume": "Retomar"
   },
   "fullscreen": {
     "enter": "Entrar em tela cheia",

--- a/client/src/network/__tests__/peer.test.ts
+++ b/client/src/network/__tests__/peer.test.ts
@@ -67,13 +67,21 @@ describe("P2P Protocol - validateMessage", () => {
 });
 
 describe("PeerSession", () => {
-  it("send resolves immediately and bypasses encoding when connection is not open", async () => {
+  it("reports a dropped send and bypasses encoding when connection is not open", async () => {
     const { conn, session } = createTestSession();
     conn.open = false;
-    // The closed-channel sentinel is now a same-microtask resolve with no
-    // bytes recorded — equivalent to the old `false` return.
-    await session.send({ type: "concede" });
+    await expect(session.send({ type: "concede" })).resolves.toBe(false);
     expect(conn.sentRaw.length).toBe(0);
+    session.close();
+  });
+
+  it("reports a dropped queued send when the channel closes before its write", async () => {
+    const { conn, session } = createTestSession();
+    const send = session.send({ type: "concede" });
+    conn.open = false;
+
+    await expect(send).resolves.toBe(false);
+    expect(conn.sentRaw).toEqual([]);
     session.close();
   });
 
@@ -230,7 +238,7 @@ describe("PeerSession", () => {
       throw new Error("channel torn down");
     };
 
-    await session.send({ type: "concede" });
+    await expect(session.send({ type: "concede" })).resolves.toBe(false);
 
     expect(onDisconnect).toHaveBeenCalledTimes(1);
     expect(onDisconnect).toHaveBeenCalledWith("Channel send failed");

--- a/client/src/network/peer.ts
+++ b/client/src/network/peer.ts
@@ -9,15 +9,15 @@ function tracePeerSession(event: string, data?: Record<string, unknown>): void {
 
 export interface PeerSession {
   /**
-   * Queue a message for the wire. Resolves after the encoded bytes have been
-   * written to the underlying RTCDataChannel (or after the queue entry is
-   * dropped due to channel closure). The encode is async (CompressionStream),
-   * so production callers awaiting this promise get a real "bytes are out"
-   * guarantee — useful for fan-out broadcast sites that need to settle all
-   * sends before returning, and for deterministic test assertions. Callers
-   * that don't care about timing can ignore the promise.
+   * Queue a message for the wire. Resolves `true` after the encoded bytes have
+   * been handed to the underlying RTCDataChannel, or `false` if the queue entry
+   * cannot be written because the channel closed, encoding failed, or the write
+   * threw. The encode is async (CompressionStream), so production callers
+   * awaiting this promise get a real "bytes are out" outcome — useful for
+   * reconnect handshakes that must not promote a dead channel. Callers that
+   * don't care about timing can ignore the promise.
    */
-  send(msg: P2PMessage): Promise<void>;
+  send(msg: P2PMessage): Promise<boolean>;
   onMessage(handler: (msg: P2PMessage) => void | Promise<void>): () => void;
   onDisconnect(handler: (reason: string) => void): () => void;
   close(reason?: string): void;
@@ -62,20 +62,19 @@ export function createPeerSession(
   // hit the DataChannel in submission order. Applied identically on receive.
   let sendQueue: Promise<void> = Promise.resolve();
 
-  // Returns the promise representing this entry's slot in the queue — resolves
-  // after the encoded bytes hit `conn.send` (or after the entry is dropped
-  // because the channel closed). Production callers that don't care about
-  // timing simply ignore the promise. Channel-level send failures still
-  // trigger `handleDisconnect` from inside the queue.
-  const trySend = (msg: P2PMessage): Promise<void> => {
-    if (closed || !conn.open) return Promise.resolve();
+  // Returns the promise representing this entry's slot in the queue. `true`
+  // means `conn.send` accepted the encoded bytes; `false` means this entry
+  // could not reach the channel. Channel-level send failures still trigger
+  // `handleDisconnect` from inside the queue.
+  const trySend = (msg: P2PMessage): Promise<boolean> => {
+    if (closed || !conn.open) return Promise.resolve(false);
     const entry = sendQueue.then(async () => {
       // Only gate on `conn.open` here, NOT `closed`. `close()` flips `closed`
       // to true synchronously so subsequent NEW `trySend` calls bail (the
       // outer guard above), but already-queued entries — including the
       // `disconnect` farewell `close()` itself enqueues — still need to
       // flush before the channel is disposed.
-      if (!conn.open) return;
+      if (!conn.open) return false;
       let bytes: Uint8Array;
       try {
         bytes = await encodeWireMessage(msg);
@@ -83,7 +82,7 @@ export function createPeerSession(
         // Encode failure is a programmer bug, not a channel failure. Log loud
         // but keep the channel alive for other (working) messages.
         console.error("[PeerSession] encode failed:", err, msg);
-        return;
+        return false;
       }
       if (msg.type !== "ping" && msg.type !== "pong") {
         const rawSize = JSON.stringify(msg).length;
@@ -95,12 +94,14 @@ export function createPeerSession(
       }
       try {
         conn.send(bytes);
+        return true;
       } catch (err) {
         console.warn("[PeerSession] send failed:", err);
         handleDisconnect("Channel send failed");
+        return false;
       }
     });
-    sendQueue = entry;
+    sendQueue = entry.then(() => undefined);
     return entry;
   };
 

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -147,7 +147,7 @@ import { DisconnectChoiceDialog } from "../components/hud/DisconnectChoiceDialog
 import { PlayerEnchantmentsDialog } from "../components/hud/PlayerEnchantmentsDialog.tsx";
 import { AttachmentFan } from "../components/board/AttachmentFan.tsx";
 import { PausedBanner } from "../components/chrome/PausedBanner.tsx";
-import type { P2PAdapterEvent } from "../adapter/p2p-adapter.ts";
+import { P2PHostAdapter, type P2PAdapterEvent } from "../adapter/p2p-adapter.ts";
 import { WebSocketAdapter } from "../adapter/ws-adapter.ts";
 import type { WsAdapterEvent } from "../adapter/ws-adapter.ts";
 import { MANA_PAYMENT_WAITING_FOR_TYPES } from "../game/waitingForRegistry.ts";
@@ -1037,6 +1037,9 @@ function GamePageContent({
       | null;
     void adapter?.kickPlayer?.(pid);
   }, []);
+  const handleResumeP2P = useCallback(() => {
+    if (adapter instanceof P2PHostAdapter) adapter.requestResume();
+  }, [adapter]);
 
   // Memoize the HUD elements passed to GameBoard. GameBoard is wrapped in
   // React.memo, which shallow-compares props; without stable element
@@ -1733,7 +1736,11 @@ function GamePageContent({
       )}
 
       {/* P2P pause banner — visible to everyone while paused. */}
-      <PausedBanner isVisible={pauseReason !== null} reason={pauseReason ?? ""} />
+      <PausedBanner
+        isVisible={pauseReason !== null}
+        reason={pauseReason ?? ""}
+        onResume={isP2PHost && adapter instanceof P2PHostAdapter ? handleResumeP2P : undefined}
+      />
 
       {/* P2P host-only disconnect decision modal. */}
       {isP2PHost && disconnectChoice !== null && (

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -19,6 +19,7 @@ import { GamePage } from "../GamePage";
 import type { FormatConfig } from "../../adapter/types";
 import type { WsAdapterEvent } from "../../adapter/ws-adapter";
 import type { P2PAdapterEvent } from "../../adapter/p2p-adapter";
+import { P2PHostAdapter } from "../../adapter/p2p-adapter";
 import { WebSocketAdapter } from "../../adapter/ws-adapter";
 import { usePreferencesStore } from "../../stores/preferencesStore";
 import { gameObjectFactory } from "../../test/factories/gameObjectFactory";
@@ -460,6 +461,28 @@ describe("GamePage — cEDH bracket-violation blocking modal", () => {
     });
 
     expect(screen.queryByTestId("bracket-violation-modal")).toBeNull();
+  });
+});
+
+describe("GamePage — P2P pause resume control", () => {
+  it("wires Resume to a P2P host adapter", async () => {
+    const requestResume = vi.fn();
+    const host = Object.create(P2PHostAdapter.prototype) as P2PHostAdapter;
+    host.requestResume = requestResume;
+    storeOverrides.adapter = host;
+
+    renderGamePage("/game/test-game-123?mode=p2p-host");
+    act(() => { capturedOnP2PEvent?.({ type: "gamePaused", reason: "Paused by host" }); });
+
+    await userEvent.setup().click(screen.getByRole("button", { name: "Resume" }));
+    expect(requestResume).toHaveBeenCalledOnce();
+  });
+
+  it("does not expose Resume to a P2P guest", () => {
+    renderGamePage("/game/test-game-123?mode=p2p-join");
+    act(() => { capturedOnP2PEvent?.({ type: "gamePaused", reason: "Paused by host" }); });
+
+    expect(screen.queryByRole("button", { name: "Resume" })).toBeNull();
   });
 });
 


### PR DESCRIPTION
Fixes P2P host navigation/reconnect leaving both players paused with no usable resume path.

- reserve reconnect sessions until a successfully written ACK
- serialize reconnect handoff with native and WASM state/terminal delivery
- resume manual/disconnect pauses only when reconnect holds clear
- add a host-only localized Resume control and focused race coverage

Validation: independent plan and implementation review cleared; `git diff --check` and pre-commit parser gates pass. Frontend tests were not run directly because Tilt is active and watches a different checkout; the shared frontend test resource is currently blocked by an unrelated DraftPodPage mock failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * P2P hosts can resume paused games directly from the pause banner.
  * Resume controls are localized across supported languages.
* **Bug Fixes**
  * Improved multiplayer reconnect handling to preserve message order and prevent stale updates.
  * Reconnecting players now receive reliable state and final-result acknowledgements.
  * Paused games resume only after disconnected seats and pending reconnects are resolved.
  * Network sends now clearly report whether delivery succeeded, including for closed connections.
* **Tests**
  * Added coverage for reconnects, pause/resume behavior, message delivery, and connection failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->