### PR TITLE
Parse Teamwork instead clauses by syntax order

### DIFF
--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -4031,6 +4031,20 @@ pub(super) enum InsteadLowering {
     NotOwned,
 }
 
+/// Printed word order for a self-replacement clause.
+///
+/// The axis matters only for Teamwork today: a forward clause whose body begins
+/// with "instead" is already owned by the additional-cost fold that preserves
+/// cast-time alternative targeting. A trailing "instead" (whether the condition
+/// is leading or trailing) has no such owner and lowers through the generic
+/// `ConditionInstead` branch.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum InsteadClauseOrder {
+    ForwardLeadingInstead,
+    ForwardTrailingInstead,
+    Inverted,
+}
+
 pub(super) fn try_parse_generic_instead_clause(
     text: &str,
     kind: AbilityKind,
@@ -4038,8 +4052,8 @@ pub(super) fn try_parse_generic_instead_clause(
 ) -> InsteadLowering {
     // Forward form: "If <cond>, [body] instead." — split on the leading "If, "
     // and strip a trailing/leading "instead" from the body.
-    if let Some((cond_text, effect_text)) = split_forward_instead_clause(text) {
-        return build_instead_def(cond_text, effect_text, kind, ctx);
+    if let Some((cond_text, effect_text, order)) = split_forward_instead_clause(text) {
+        return build_instead_def(cond_text, effect_text, kind, ctx, order);
     }
 
     // CR 614.1a + CR 608.2c: Inverted form — "[body] instead if <cond>." (e.g.
@@ -4048,7 +4062,13 @@ pub(super) fn try_parse_generic_instead_clause(
     // `" instead if "` boundary mirrors the line-level `strip_instead_clause`
     // in `oracle.rs` but operates on a single chunk inside the chain loop.
     if let Some((cond_text, effect_text)) = split_inverted_instead_clause(text) {
-        return build_instead_def(cond_text, effect_text, kind, ctx);
+        return build_instead_def(
+            cond_text,
+            effect_text,
+            kind,
+            ctx,
+            InsteadClauseOrder::Inverted,
+        );
     }
 
     InsteadLowering::NotOwned
@@ -4057,7 +4077,7 @@ pub(super) fn try_parse_generic_instead_clause(
 /// Forward instead form: "If <cond>, [body] instead." Returns the trimmed
 /// `(condition_text, effect_text)` if the leading-conditional + trailing-or-
 /// leading "instead" structure matches. Returns None otherwise.
-fn split_forward_instead_clause(text: &str) -> Option<(String, String)> {
+fn split_forward_instead_clause(text: &str) -> Option<(String, String, InsteadClauseOrder)> {
     let (condition_fragment, raw_body) = split_leading_conditional(text)?;
     let condition_lower = condition_fragment.to_lowercase();
     let cond_text = nom_on_lower(&condition_fragment, &condition_lower, |i| {
@@ -4070,17 +4090,30 @@ fn split_forward_instead_clause(text: &str) -> Option<(String, String)> {
 
     let trimmed_body = raw_body.trim_end_matches('.').trim();
     let trimmed_lower = trimmed_body.to_lowercase();
-    let effect_text = if let Some(stripped) = trimmed_body.strip_suffix(" instead") {
-        stripped.trim().to_string()
+    let trailing_instead = nom_on_lower(trimmed_body, &trimmed_lower, |i| {
+        map(
+            all_consuming(terminated(take_until(" instead"), tag(" instead"))),
+            str::len,
+        )
+        .parse(i)
+    });
+    let (effect_text, order) = if let Some((stripped_len, _)) = trailing_instead {
+        (
+            trimmed_body[..stripped_len].trim().to_string(),
+            InsteadClauseOrder::ForwardTrailingInstead,
+        )
     } else if let Some((_, rest)) = nom_on_lower(trimmed_body, &trimmed_lower, |i| {
         value((), tag("instead ")).parse(i)
     }) {
-        rest.trim().to_string()
+        (
+            rest.trim().to_string(),
+            InsteadClauseOrder::ForwardLeadingInstead,
+        )
     } else {
         return None;
     };
 
-    Some((cond_text, effect_text))
+    Some((cond_text, effect_text, order))
 }
 
 /// Inverted instead form: "[body] instead if <cond>." Returns the trimmed
@@ -4161,6 +4194,7 @@ fn build_instead_def(
     effect_text: String,
     kind: AbilityKind,
     ctx: &mut ParseContext,
+    order: InsteadClauseOrder,
 ) -> InsteadLowering {
     // CR 608.2c: An additional-cost-paid "instead" fold ("if it/this spell was
     // kicked, ... instead") is owned by `strip_additional_cost_conditional`,
@@ -4180,7 +4214,19 @@ fn build_instead_def(
     // replacement. Everything that lowers today still lowers; only the failure
     // path is split, by `condition_names_an_event`, into "defer" vs "fail
     // honestly".
-    let Some(condition) = lower_instead_condition(&cond_text, ctx) else {
+    let condition = lower_instead_condition(&cond_text, ctx).or_else(|| match order {
+        // CR 601.2b/c + CR 608.2c: "if teamwork, instead [body]" remains with
+        // the established additional-cost fold, which announces alternative
+        // target requirements before targets are chosen.
+        InsteadClauseOrder::ForwardLeadingInstead => None,
+        // CR 601.2f + CR 608.2c: "[body] instead if teamwork" and "if teamwork,
+        // [body] instead" are typed resolution-time replacements gated
+        // specifically on the Teamwork cost.
+        InsteadClauseOrder::ForwardTrailingInstead | InsteadClauseOrder::Inverted => {
+            parse_cast_using_teamwork_condition_text(&cond_text)
+        }
+    });
+    let Some(condition) = condition else {
         return if condition_names_an_event(&cond_text) {
             InsteadLowering::NotOwned
         } else {

--- a/crates/engine/tests/integration/teamwork_keyword.rs
+++ b/crates/engine/tests/integration/teamwork_keyword.rs
@@ -978,9 +978,9 @@ fn helicarrier_strike_runtime_replaces_two_damage_with_four() {
     );
 }
 
-/// Cast We Say Thee Nay! in response to a creature spell and return the generic
-/// mana in the controller's first unless-payment prompt.
-fn we_say_thee_nay_unless_generic(pay_teamwork: bool) -> u32 {
+/// Cast We Say Thee Nay! in response to a creature spell and collect every
+/// generic unless-payment cost shown to the targeted spell's controller.
+fn we_say_thee_nay_unless_generics(pay_teamwork: bool) -> Vec<u32> {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     let mut creature = scenario.add_creature_to_hand(P0, "Target Spell", 2, 2);
@@ -1028,7 +1028,12 @@ fn we_say_thee_nay_unless_generic(pay_teamwork: bool) -> u32 {
         })
         .expect("casting We Say Thee Nay! must succeed");
 
+    let mut unless_generics = Vec::new();
     for _ in 0..64 {
+        if runner.state().stack.is_empty() {
+            break;
+        }
+
         match runner.state().waiting_for.clone() {
             WaitingFor::OptionalCostChoice { .. } => runner
                 .act(GameAction::DecideOptionalCost { pay: pay_teamwork })
@@ -1054,29 +1059,37 @@ fn we_say_thee_nay_unless_generic(pay_teamwork: bool) -> u32 {
                     player, P0,
                     "the targeted spell's controller must be prompted"
                 );
-                return match cost {
+                let generic = match cost {
                     AbilityCost::Mana {
                         cost: ManaCost::Cost { generic, .. },
                     } => generic,
                     other => panic!("expected a fixed generic unless cost, got {other:?}"),
                 };
+                unless_generics.push(generic);
+                runner
+                    .act(GameAction::PayUnlessCost { pay: false })
+                    .expect("declining the unless payment must continue resolution");
             }
             other => panic!("unexpected We Say Thee Nay waiting state: {other:?}"),
         };
     }
-    panic!("We Say Thee Nay! never reached an unless-payment prompt")
+    assert!(
+        runner.state().stack.is_empty(),
+        "We Say Thee Nay! must finish resolving after every unless-payment prompt"
+    );
+    unless_generics
 }
 
 #[test]
 fn we_say_thee_nay_runtime_selects_exactly_one_unless_cost() {
     assert_eq!(
-        we_say_thee_nay_unless_generic(false),
-        2,
+        we_say_thee_nay_unless_generics(false),
+        vec![2],
         "declining Teamwork must retain the base {{2}} tax"
     );
     assert_eq!(
-        we_say_thee_nay_unless_generic(true),
-        4,
+        we_say_thee_nay_unless_generics(true),
+        vec![4],
         "paying Teamwork must replace the {{2}} tax with {{4}}"
     );
 }

--- a/crates/engine/tests/integration/teamwork_keyword.rs
+++ b/crates/engine/tests/integration/teamwork_keyword.rs
@@ -17,8 +17,8 @@ use engine::game::scenario::{GameRunner, GameScenario};
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AdditionalCost, AdditionalCostOrigin,
-    Comparator, Effect, SpellCastingOptionKind, TapCreaturesAggregateStat, TapCreaturesRequirement,
-    TargetRef,
+    Comparator, Effect, QuantityExpr, SpellCastingOptionKind, TapCreaturesAggregateStat,
+    TapCreaturesRequirement, TargetRef,
 };
 use engine::types::actions::GameAction;
 use engine::types::card_type::CoreType;
@@ -646,6 +646,14 @@ fn is_teamwork_gate(cond: &AbilityCondition) -> bool {
     )
 }
 
+/// `true` if an `instead` branch is gated specifically on paying Teamwork.
+fn is_teamwork_instead_gate(cond: &AbilityCondition) -> bool {
+    matches!(
+        cond,
+        AbilityCondition::ConditionInstead { inner } if is_teamwork_gate(inner)
+    )
+}
+
 /// Beast Mode's second clause ("Also put a +1/+1 counter on that creature if
 /// this spell was cast using teamwork") must parse to a real `PutCounter`
 /// effect gated on the Teamwork payment — NOT `Effect::Unimplemented{"also"}`
@@ -679,22 +687,45 @@ fn beast_mode_teamwork_counter_rider() {
     );
 }
 
-// KNOWN GAP — We Say Thee Nay! ("Counter that spell unless its controller pays
-// {4} instead if this spell was cast using teamwork") is NOT fixed by this change.
-// Tracing proves its inverted "... instead if teamwork" clause is consumed by the
-// instead-clause / counter-unless chain path (try_parse_generic_instead_clause →
-// split_inverted_instead_clause → build_instead_def, conditions.rs:2416/2473)
-// BEFORE it can reach `strip_suffix_conditional` — so the trailing-rider
-// recognizer never sees it (verified: strip_suffix_conditional is never called
-// with the teamwork text for this card). The {4} tax sub-ability keeps
-// `condition: null` and fires on every cast. The correct fix is inverted-form
-// specific (the shared build_instead_def chain also serves the FORWARD teamwork
-// "instead" cards — Cruel Alliance/Too Evil — which rely on it returning None so
-// the leading peel folds them to `AdditionalCostPaidInstead`; adding teamwork to
-// that shared chain would regress them). This is outside the reviewed plan's
-// stated root cause (the plan asserted strip_suffix_conditional would peel it) and
-// is returned to the orchestrator as a stop-and-return item. `shipped_teamwork_
-// cards_parse_without_unimplemented` still covers WSTN parsing cleanly.
+/// We Say Thee Nay!'s inverted replacement must bind the {4} unless-payment as
+/// the Teamwork-paid alternative to the base {2} payment (CR 601.2f, 608.2c,
+/// 614.6). It must not survive as an independent sequential {4} instruction.
+#[test]
+fn we_say_thee_nay_inverted_teamwork_instead_is_typed() {
+    let parsed = parse_spell("We Say Thee Nay!", WE_SAY_THEE_NAY, &["Instant"]);
+    assert_no_unimplemented(&parsed, "We Say Thee Nay!");
+
+    let four_tax = all_defs(&parsed)
+        .into_iter()
+        .find(|d| {
+            matches!(
+                d.unless_pay.as_ref().map(|modifier| &modifier.cost),
+                Some(AbilityCost::Mana {
+                    cost: ManaCost::Cost { generic: 4, .. }
+                })
+            )
+        })
+        .expect("We Say Thee Nay! must carry the {4} unless-payment alternative");
+    assert!(
+        four_tax
+            .condition
+            .as_ref()
+            .is_some_and(is_teamwork_instead_gate),
+        "the {{4}} alternative must be ConditionInstead{{AdditionalCostPaid{{Teamwork}}}}, got {:?}",
+        four_tax.condition
+    );
+    assert!(
+        !parsed.parse_warnings.iter().any(|warning| matches!(
+            warning,
+            engine::parser::oracle_ir::diagnostic::OracleDiagnostic::SwallowedClause {
+                detector,
+                ..
+            } if detector == "Replacement_Instead"
+        )),
+        "the typed replacement must satisfy the Replacement_Instead audit: {:?}",
+        parsed.parse_warnings
+    );
+}
 
 /// EMH lowers to a teamwork-gated `DigInsteadAlt`: the top-level Dig keeps any
 /// number (`keep_count == u32::MAX`, `up_to`), gated on Teamwork, with the base
@@ -802,39 +833,251 @@ fn quantum_reduction_flash_not_unconditional() {
 // where one should not appear, and the presence of the pre-existing gate).
 // ---------------------------------------------------------------------------
 
-/// Cruel Alliance's leading "instead" form stays an `AdditionalCostPaidInstead`
-/// sub-ability — the trailing/Dig fix must not re-route it.
+/// Forward Teamwork replacement forms stay on the established
+/// `AdditionalCostPaidInstead` fold. That exact shape is consumed during
+/// CR 601.2c target announcement to expose the broad paid-mode target filter.
 #[test]
-fn cruel_alliance_unchanged() {
-    let parsed = parse_spell("Cruel Alliance", CRUEL_ALLIANCE, &["Sorcery"]);
-    assert_no_unimplemented(&parsed, "Cruel Alliance");
-    let has_instead = all_defs(&parsed).into_iter().any(|d| {
-        matches!(
-            d.condition,
-            Some(AbilityCondition::AdditionalCostPaidInstead)
-        )
-    });
+fn forward_teamwork_instead_forms_keep_additional_cost_fold() {
+    for (name, oracle) in [
+        ("Cruel Alliance", CRUEL_ALLIANCE),
+        ("Too Evil to Stay Dead", TOO_EVIL_TO_STAY_DEAD),
+    ] {
+        let parsed = parse_spell(name, oracle, &["Sorcery"]);
+        assert_no_unimplemented(&parsed, name);
+        let has_instead = all_defs(&parsed).into_iter().any(|d| {
+            matches!(
+                d.condition,
+                Some(AbilityCondition::AdditionalCostPaidInstead)
+            )
+        });
+        assert!(
+            has_instead,
+            "{name} must keep its AdditionalCostPaidInstead sub-ability"
+        );
+    }
+}
+
+/// Helicarrier Strike's forward-condition/trailing-`instead` replacement must
+/// be one Teamwork-gated `ConditionInstead` branch. A sequential gated
+/// 4-damage instruction would deal six damage when Teamwork was paid instead
+/// of replacing two with four.
+#[test]
+fn helicarrier_strike_forward_trailing_teamwork_instead_is_typed() {
+    let parsed = parse_spell("Helicarrier Strike", HELICARRIER_STRIKE, &["Instant"]);
+    assert_no_unimplemented(&parsed, "Helicarrier Strike");
+    let four_damage = all_defs(&parsed)
+        .into_iter()
+        .find(|d| {
+            matches!(
+                &*d.effect,
+                Effect::DealDamage {
+                    amount: QuantityExpr::Fixed { value: 4 },
+                    ..
+                }
+            )
+        })
+        .expect("Helicarrier Strike must carry the four-damage alternative");
     assert!(
-        has_instead,
-        "Cruel Alliance must keep its AdditionalCostPaidInstead sub-ability"
+        four_damage
+            .condition
+            .as_ref()
+            .is_some_and(is_teamwork_instead_gate),
+        "four damage must be ConditionInstead{{AdditionalCostPaid{{Teamwork}}}}, got {:?}",
+        four_damage.condition
+    );
+    assert!(
+        !parsed.parse_warnings.iter().any(|warning| matches!(
+            warning,
+            engine::parser::oracle_ir::diagnostic::OracleDiagnostic::SwallowedClause {
+                detector,
+                ..
+            } if detector == "Replacement_Instead"
+        )),
+        "the typed replacement must satisfy the Replacement_Instead audit: {:?}",
+        parsed.parse_warnings
     );
 }
 
-/// Helicarrier Strike's leading "If teamwork, ... instead" peels at the leading
-/// site (which already recognized teamwork) — its `AdditionalCostPaid{Teamwork}`
-/// sub-ability is intact and the trailing rider must not double-handle it.
+/// Cast Helicarrier Strike at a real attacking creature and return the damage
+/// marked after resolution. This crosses casting, optional aggregate-cost
+/// payment, target selection, `ConditionInstead` evaluation, and resolution.
+fn helicarrier_damage_after_cast(pay_teamwork: bool) -> u32 {
+    use engine::game::combat::AttackTarget;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let attacker = scenario.add_creature(P0, "Attacker", 2, 9).id();
+    let tapper = scenario.add_creature(P0, "Teamwork Tapper", 2, 2).id();
+    let mut strike =
+        scenario.add_spell_to_hand_from_oracle(P0, "Helicarrier Strike", true, HELICARRIER_STRIKE);
+    strike.with_mana_cost(ManaCost::Cost {
+        shards: vec![],
+        generic: 0,
+    });
+    let strike = strike.id();
+    let mut runner = scenario.build();
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(attacker, AttackTarget::Player(PlayerId(1)))])
+        .expect("declaring the Helicarrier target as an attacker must succeed");
+
+    let card_id = runner.state().objects[&strike].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: strike,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting Helicarrier Strike must succeed");
+
+    for _ in 0..48 {
+        if runner.state().stack.is_empty() {
+            break;
+        }
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalCostChoice { .. } => runner
+                .act(GameAction::DecideOptionalCost { pay: pay_teamwork })
+                .expect("choosing whether to pay Teamwork must succeed"),
+            WaitingFor::PayCost {
+                kind: PayCostKind::TapCreatures { .. },
+                ..
+            } => runner
+                .act(GameAction::SelectCards {
+                    cards: vec![tapper],
+                })
+                .expect("tapping the 2-power creature must pay Teamwork 2"),
+            WaitingFor::TargetSelection { .. } => runner
+                .act(GameAction::ChooseTarget {
+                    target: Some(TargetRef::Object(attacker)),
+                })
+                .expect("the attacking creature must be a legal target"),
+            WaitingFor::ManaPayment { .. } | WaitingFor::Priority { .. } => runner
+                .act(GameAction::PassPriority)
+                .expect("advancing the zero-cost cast or priority must succeed"),
+            other => panic!("unexpected Helicarrier waiting state: {other:?}"),
+        };
+    }
+
+    assert!(runner.state().stack.is_empty(), "Helicarrier must resolve");
+    runner.state().objects[&attacker].damage_marked
+}
+
 #[test]
-fn helicarrier_strike_unchanged() {
-    let parsed = parse_spell("Helicarrier Strike", HELICARRIER_STRIKE, &["Instant"]);
-    assert_no_unimplemented(&parsed, "Helicarrier Strike");
-    let gated = all_defs(&parsed)
-        .into_iter()
-        .filter(|d| matches!(&*d.effect, Effect::DealDamage { .. }))
-        .filter(|d| d.condition.as_ref().is_some_and(is_teamwork_gate))
-        .count();
+fn helicarrier_strike_runtime_replaces_two_damage_with_four() {
     assert_eq!(
-        gated, 1,
-        "Helicarrier keeps exactly one Teamwork-gated DealDamage sub-ability"
+        helicarrier_damage_after_cast(false),
+        2,
+        "declining Teamwork must retain the base two damage"
+    );
+    assert_eq!(
+        helicarrier_damage_after_cast(true),
+        4,
+        "paying Teamwork must replace two damage with four, not add four"
+    );
+}
+
+/// Cast We Say Thee Nay! in response to a creature spell and return the generic
+/// mana in the controller's first unless-payment prompt.
+fn we_say_thee_nay_unless_generic(pay_teamwork: bool) -> u32 {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mut creature = scenario.add_creature_to_hand(P0, "Target Spell", 2, 2);
+    creature.with_mana_cost(ManaCost::Cost {
+        shards: vec![],
+        generic: 0,
+    });
+    let creature = creature.id();
+    let tapper = scenario
+        .add_creature(PlayerId(1), "Teamwork Tapper", 2, 2)
+        .id();
+    let mut nay = scenario.add_spell_to_hand_from_oracle(
+        PlayerId(1),
+        "We Say Thee Nay!",
+        true,
+        WE_SAY_THEE_NAY,
+    );
+    nay.with_mana_cost(ManaCost::Cost {
+        shards: vec![],
+        generic: 0,
+    });
+    let nay = nay.id();
+    let mut runner = scenario.build();
+
+    let creature_card = runner.state().objects[&creature].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: creature,
+            card_id: creature_card,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting the target creature spell must succeed");
+    runner
+        .act(GameAction::PassPriority)
+        .expect("passing priority to the responder must succeed");
+
+    let nay_card = runner.state().objects[&nay].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: nay,
+            card_id: nay_card,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("casting We Say Thee Nay! must succeed");
+
+    for _ in 0..64 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OptionalCostChoice { .. } => runner
+                .act(GameAction::DecideOptionalCost { pay: pay_teamwork })
+                .expect("choosing whether to pay Teamwork must succeed"),
+            WaitingFor::PayCost {
+                kind: PayCostKind::TapCreatures { .. },
+                ..
+            } => runner
+                .act(GameAction::SelectCards {
+                    cards: vec![tapper],
+                })
+                .expect("tapping the 2-power creature must pay Teamwork 2"),
+            WaitingFor::TargetSelection { .. } => runner
+                .act(GameAction::ChooseTarget {
+                    target: Some(TargetRef::Object(creature)),
+                })
+                .expect("the creature spell must be a legal target"),
+            WaitingFor::ManaPayment { .. } | WaitingFor::Priority { .. } => runner
+                .act(GameAction::PassPriority)
+                .expect("advancing the zero-cost cast or priority must succeed"),
+            WaitingFor::UnlessPayment { player, cost, .. } => {
+                assert_eq!(
+                    player, P0,
+                    "the targeted spell's controller must be prompted"
+                );
+                return match cost {
+                    AbilityCost::Mana {
+                        cost: ManaCost::Cost { generic, .. },
+                    } => generic,
+                    other => panic!("expected a fixed generic unless cost, got {other:?}"),
+                };
+            }
+            other => panic!("unexpected We Say Thee Nay waiting state: {other:?}"),
+        };
+    }
+    panic!("We Say Thee Nay! never reached an unless-payment prompt")
+}
+
+#[test]
+fn we_say_thee_nay_runtime_selects_exactly_one_unless_cost() {
+    assert_eq!(
+        we_say_thee_nay_unless_generic(false),
+        2,
+        "declining Teamwork must retain the base {{2}} tax"
+    );
+    assert_eq!(
+        we_say_thee_nay_unless_generic(true),
+        4,
+        "paying Teamwork must replace the {{2}} tax with {{4}}"
     );
 }
 

--- a/crates/engine/tests/integration/teamwork_keyword.rs
+++ b/crates/engine/tests/integration/teamwork_keyword.rs
@@ -26,7 +26,7 @@ use engine::types::counter::CounterType;
 use engine::types::game_state::{CastPaymentMode, PayCostKind, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::keywords::Keyword;
-use engine::types::mana::ManaCost;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
 
@@ -978,11 +978,19 @@ fn helicarrier_strike_runtime_replaces_two_damage_with_four() {
     );
 }
 
-/// Cast We Say Thee Nay! in response to a creature spell and collect every
-/// generic unless-payment cost shown to the targeted spell's controller.
-fn we_say_thee_nay_unless_generics(pay_teamwork: bool) -> Vec<u32> {
+/// Cast We Say Thee Nay! in response to a creature spell, pay every surfaced
+/// unless cost, and return the complete prompt sequence. Paying (rather than
+/// declining) keeps the target spell live, so either possible duplicate order
+/// (`{2}` then `{4}` or `{4}` then `{2}`) remains observable.
+fn we_say_thee_nay_unless_costs(pay_teamwork: bool) -> Vec<u32> {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_mana_pool(
+        P0,
+        (0..8)
+            .map(|_| ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]))
+            .collect(),
+    );
     let mut creature = scenario.add_creature_to_hand(P0, "Target Spell", 2, 2);
     creature.with_mana_cost(ManaCost::Cost {
         shards: vec![],
@@ -1004,6 +1012,7 @@ fn we_say_thee_nay_unless_generics(pay_teamwork: bool) -> Vec<u32> {
     });
     let nay = nay.id();
     let mut runner = scenario.build();
+    let mut prompts = Vec::new();
 
     let creature_card = runner.state().objects[&creature].card_id;
     runner
@@ -1028,12 +1037,10 @@ fn we_say_thee_nay_unless_generics(pay_teamwork: bool) -> Vec<u32> {
         })
         .expect("casting We Say Thee Nay! must succeed");
 
-    let mut unless_generics = Vec::new();
     for _ in 0..64 {
         if runner.state().stack.is_empty() {
             break;
         }
-
         match runner.state().waiting_for.clone() {
             WaitingFor::OptionalCostChoice { .. } => runner
                 .act(GameAction::DecideOptionalCost { pay: pay_teamwork })
@@ -1059,38 +1066,38 @@ fn we_say_thee_nay_unless_generics(pay_teamwork: bool) -> Vec<u32> {
                     player, P0,
                     "the targeted spell's controller must be prompted"
                 );
-                let generic = match cost {
+                prompts.push(match cost {
                     AbilityCost::Mana {
                         cost: ManaCost::Cost { generic, .. },
                     } => generic,
                     other => panic!("expected a fixed generic unless cost, got {other:?}"),
-                };
-                unless_generics.push(generic);
+                });
                 runner
-                    .act(GameAction::PayUnlessCost { pay: false })
-                    .expect("declining the unless payment must continue resolution");
+                    .act(GameAction::PayUnlessCost { pay: true })
+                    .expect("paying the surfaced unless cost must succeed")
             }
             other => panic!("unexpected We Say Thee Nay waiting state: {other:?}"),
         };
     }
+    assert!(runner.state().stack.is_empty(), "both spells must resolve");
     assert!(
-        runner.state().stack.is_empty(),
-        "We Say Thee Nay! must finish resolving after every unless-payment prompt"
+        runner.state().battlefield.contains(&creature),
+        "paying every surfaced tax must let the target creature spell resolve"
     );
-    unless_generics
+    prompts
 }
 
 #[test]
 fn we_say_thee_nay_runtime_selects_exactly_one_unless_cost() {
     assert_eq!(
-        we_say_thee_nay_unless_generics(false),
+        we_say_thee_nay_unless_costs(false),
         vec![2],
-        "declining Teamwork must retain the base {{2}} tax"
+        "declining Teamwork must surface exactly the base {{2}} tax"
     );
     assert_eq!(
-        we_say_thee_nay_unless_generics(true),
+        we_say_thee_nay_unless_costs(true),
         vec![4],
-        "paying Teamwork must replace the {{2}} tax with {{4}}"
+        "paying Teamwork must replace the {{2}} tax with exactly one {{4}} tax"
     );
 }
 


### PR DESCRIPTION
## Summary

Lower generic `instead` clauses through a typed syntax-order axis so Teamwork alternatives are represented correctly without changing the established cast-time additional-cost fold. This unlocks We Say Thee Nay! and Helicarrier Strike while preserving Cruel Alliance and Too Evil target legality.

## Files changed

- `crates/engine/src/parser/oracle_effect/conditions.rs` — add typed `InsteadClauseOrder`, nom-composed trailing-`instead` parsing, and route only inverted/forward-trailing Teamwork clauses to `ConditionInstead`.
- `crates/engine/tests/integration/teamwork_keyword.rs` — parser, hostile shape, cast/runtime, target-legality, swallow-honesty, and blast-radius regressions.

## Track

Developer

## LLM

Model: gpt-5.6-sol (via Codex; canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 601.2b-c
- CR 601.2f
- CR 608.2c
- CR 614.1a
- CR 614.6

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- exact-head robust We Say Thee Nay! discriminator — PASS (1/1): pays and records every prompt, exact `[2]` / `[4]`, both spells resolve, target creature reaches battlefield
- exact-head Teamwork integration suite — PASS (21/21)
- exact-head `cargo fmt --all -- --check` and `git diff --check` — PASS
- exact-head `cargo clippy -p phase-engine --all-targets -- -D warnings` — PASS
- byte-identical pre-rebase full `cargo test -p phase-engine` — PASS: 19,706 library tests; 5,495 integration tests passed, 0 failed, 2 ignored; doc tests 0 failed
- generated card data and `cargo coverage` — PASS: global 31,815 -> 31,817; MSH 282/286 -> 284/286; zero engine/honesty regressions
- `cargo semantic-audit` — PASS; no findings for We Say Thee Nay! or Helicarrier Strike
- CI owns the fresh all-shard full-suite receipt after the clean rebase onto `af373adbac87a0aa3f22045b5646734edd3571c5`; the exact-head targeted/clippy gates above were rerun after that rebase

Runtime discriminators:

- Helicarrier Strike deals 2 damage normally and 4 with Teamwork, never sequential 6.
- We Say Thee Nay! produces one unless-payment prompt for {2} normally or {4} with Teamwork.
- Cruel Alliance and Too Evil remain `AdditionalCostPaidInstead`; Cruel Alliance retains broad cast-time target legality.

## Gate A

Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=27c91e00c516a1200bb54caffbdad75596bc4358 base=af373adbac87a0aa3f22045b5646734edd3571c5

## Anchored on

- `crates/engine/src/parser/oracle_effect/conditions.rs:3418` — existing typed Teamwork additional-cost condition parser.
- `crates/engine/src/parser/oracle_effect/conditions.rs:4178` — shared `instead` condition-lowering authority.
- `crates/engine/tests/integration/teamwork_keyword.rs:840` — established forward Teamwork fold regression retained as blast-radius protection.

## Final review-impl

Final review-impl PASS head=27c91e00c516a1200bb54caffbdad75596bc4358

## Claimed parse impact

- We Say Thee Nay!
- Helicarrier Strike

## Scope Expansion

None. The change stays in the existing generic `instead` parser authority and its integration tests; casting/runtime types are unchanged.

## Validation Failures

None.

## CI Failures

The maintainer test-only head `e6717d9d092f272a8057525d244e3562c831d511` had one E0308 match-arm return-type compile failure. Fast-forward child `27c91e00c516a1200bb54caffbdad75596bc4358` corrects it while strengthening the duplicate-prompt discriminator; exact-head local test, Teamwork suite, fmt, diff-check, and clippy pass. Fresh upstream CI is required.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of Teamwork “instead” clauses across forward-leading, trailing, and inverted wording.
  * Corrected replacement behavior for Teamwork alternatives, including damage, payment, and Dig outcomes.
  * Preserved existing handling for additional-cost cases.

* **Tests**
  * Expanded coverage for Teamwork replacement conditions, including We Say Thee Nay!, Helicarrier Strike, and Dig-based alternatives.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->