### PR TITLE
Register Power-up activation triggers

### DIFF
--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -564,8 +564,14 @@ pub fn build_trigger_registry() -> HashMap<TriggerMode, TriggerMatcher> {
 
     // CR 702.49a: Ninjutsu activation trigger
     r.insert(TriggerMode::NinjutsuActivated, match_ninjutsu_activated);
-    // CR 702.107a + CR 702.142b + CR 702.177a: keyword ability activation triggers
-    for tag in [AbilityTag::Boast, AbilityTag::Exhaust, AbilityTag::Outlast] {
+    // CR 702.107a + CR 702.142b + CR 702.177a + CR 702.193a:
+    // keyword ability activation triggers
+    for tag in [
+        AbilityTag::Boast,
+        AbilityTag::Exhaust,
+        AbilityTag::Outlast,
+        AbilityTag::PowerUp,
+    ] {
         r.insert(
             TriggerMode::KeywordAbilityActivated(tag),
             match_keyword_ability_activated,

--- a/crates/engine/tests/integration/power_up_keyword.rs
+++ b/crates/engine/tests/integration/power_up_keyword.rs
@@ -12,7 +12,7 @@
 //! this turn.
 //! CR 106.6: tag-scoped mana spend restriction (Quinjet).
 //! CR 500.7 + CR 514.2: Kang's extra-turn power-up prohibition.
-//! CR 603.1b: Marvel Boy's dual-condition trigger.
+//! CR 603.2c: Marvel Boy's dual-condition trigger fires once for each event.
 
 use engine::types::ability::AbilityTag;
 use engine::types::actions::GameAction;
@@ -593,11 +593,12 @@ fn set_tagged_mana(runner: &mut GameRunner, player: PlayerId, n: usize) {
 // 6. Marvel Boy trigger — fires on power-up activation only.
 // ---------------------------------------------------------------------------
 
-/// CR 602.1 + CR 603.1b: "whenever you activate a power-up ability" triggers.
+/// CR 602.1 + CR 603.2c: "whenever you activate a power-up ability" triggers
+/// once for each qualifying activation event.
 ///
 /// Revert-failing assertion: activating a power-up ability puts a +1/+1 counter
-/// on Marvel Boy; activating a NON-power-up ability does not. If the trigger arm
-/// is reverted, the parser drops the condition and no counter ever lands.
+/// on Marvel Boy; activating a NON-power-up ability does not. If the trigger
+/// registry entry is reverted, Marvel Boy is marked unsupported before play.
 #[test]
 fn marvel_boy_triggers_only_on_power_up_activation() {
     let mut scenario = GameScenario::new();
@@ -609,7 +610,7 @@ fn marvel_boy_triggers_only_on_power_up_activation() {
             "Marvel Boy",
             2,
             2,
-            "Whenever you activate a power-up ability, put a +1/+1 counter on Marvel Boy.",
+            "Whenever another creature you control enters and whenever you activate a power-up ability, put a +1/+1 counter on Marvel Boy.",
         )
         .id();
     let hero = scenario
@@ -633,6 +634,10 @@ fn marvel_boy_triggers_only_on_power_up_activation() {
 
     let mut runner = scenario.build();
 
+    assert!(
+        !runner.state().objects[&marvel].has_unimplemented_mechanics(),
+        "the production Marvel Boy Oracle must be fully supported"
+    );
     let before = p1p1_on(&runner, marvel);
 
     // Activate the NON-power-up ability first: must NOT trigger Marvel Boy.
@@ -655,9 +660,10 @@ fn marvel_boy_triggers_only_on_power_up_activation() {
     refill_colorless(&mut runner, P0, 1);
     runner.activate(hero, power_idx).resolve();
     runner.advance_until_stack_empty();
-    assert!(
-        p1p1_on(&runner, marvel) > before,
-        "a power-up activation must trigger Marvel Boy (+1/+1 counter)"
+    assert_eq!(
+        p1p1_on(&runner, marvel),
+        before + 1,
+        "CR 603.2c: one power-up activation event must trigger Marvel Boy exactly once"
     );
 }
 


### PR DESCRIPTION
## Summary

Register `PowerUp` in the existing generic `KeywordAbilityActivated` trigger-support authority. The runtime matcher and event emission already handle parameterized ability tags; this closes the missing support-reach path for Marvel Boy, Noh-Varr without card-specific logic.

## Files changed

- `crates/engine/src/game/trigger_matchers.rs` — include `AbilityTag::PowerUp` in the shared keyword-activation trigger registry.
- `crates/engine/tests/integration/power_up_keyword.rs` — full-Oracle parser/support/runtime regression proving only Power-up activations trigger Marvel Boy and add exactly one +1/+1 counter.

## Track

Developer

## LLM

Model: gpt-5.6-sol (via Codex; canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 602.1
- CR 603.2c
- CR 702.193a

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- exact-head Marvel Boy production regression — PASS (1/1)
- exact-head sibling `KeywordAbilityActivated` matcher regressions — PASS (2/2: Exhaust/Boast/Outlast positive and negative scoping)
- exact-head `cargo fmt --all -- --check` and `git diff --check` — PASS
- isolated byte-identical candidate `cargo clippy-strict` — PASS
- isolated byte-identical candidate full engine suite — PASS: 19,700 library tests; 21 + 9 binary tests; 5,492 integration tests; zero failures
- candidate-exclusive card-data generation and `cargo coverage` — PASS: MSC 605/616 -> 606/616; Marvel Boy `supported=true`, `gap_count=0`; global 31,816/35,798
- `cargo semantic-audit` — PASS; no Marvel Boy findings
- explicit revert projection — FAILS at the positive full-Oracle support-reach assertion when only the `PowerUp` registry entry is removed, proving the regression is non-vacuous
- exact-head patch-id after changelog-only rebase is identical to the independently reviewed candidate

## Gate A

Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=cfacc08d41198ea3f7a16e1fcfa40bf3af02ac78 base=fe27a9292bc472f4f157d20ae740150b0620a1ca

## Anchored on

- `crates/engine/src/game/trigger_matchers.rs:570` — existing Boast/Exhaust/Outlast registrations in the same parameterized keyword-activation authority.
- `crates/engine/src/game/trigger_matchers.rs:7101` — existing Exhaust/Boast tag and controller matcher regression.
- `crates/engine/src/game/trigger_matchers.rs:7158` — existing Outlast `SelfRef` source-scoping regression.

## Final review-impl

Final review-impl PASS head=cfacc08d41198ea3f7a16e1fcfa40bf3af02ac78

## Claimed parse impact

No card-parse structural changes. Coverage/support impact: Marvel Boy, Noh-Varr.

## Scope Expansion

None. The change extends the existing generic registry list; runtime event/matcher types are unchanged.

## Validation Failures

None. A deliberately reverted projection failed exactly at the new support-reach assertion, as expected.

## CI Failures

None locally. Fresh upstream CI owns the final all-shard receipt.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Power Up abilities now correctly trigger when activated.
  * Power Up effects correctly respond to qualifying creature entries.
  * Counter gains are now limited to one per Power Up activation event.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->