### PR TITLE
fix(engine): let Resolve All supersede auto-pass

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -7602,6 +7602,10 @@ fn begin_resolve_all_consent(
     max_resolutions: u32,
 ) -> Result<WaitingFor, EngineError> {
     super::priority::pass_priority_legality(state, priority_player)?;
+    // Resolve All consent supersedes this representative's standing yield. A
+    // Ready run must be free of auto-pass state so its one-resolution proof
+    // cannot advance beyond the consented boundary.
+    state.auto_pass.remove(&priority_player);
     let current_representative =
         super::topology::priority_pass_representative(state, priority_player);
     let mut representatives = super::topology::priority_pass_participants(state);
@@ -7811,6 +7815,9 @@ fn respond_resolve_all_consent(
                 .find(|participant| participant.representative == representative)
                 .expect("pending Resolve All representative must be a participant");
             participant.granted = true;
+            // A grant replaces this representative's standing auto-pass with
+            // the consented, bounded Resolve All sequence.
+            state.auto_pass.remove(&representative);
         }
     }
     if matches!(decision, ResolveAllConsentDecision::Decline) {

--- a/crates/engine/src/game/engine_resolve_batch.rs
+++ b/crates/engine/src/game/engine_resolve_batch.rs
@@ -681,7 +681,9 @@ mod tests {
     use crate::types::actions::ResolveAllConsentDecision;
     use crate::types::card_type::{CardType, CoreType};
     use crate::types::format::FormatConfig;
-    use crate::types::game_state::{AutoPassMode, PublicStateDirty, StackEntry, StackEntryKind};
+    use crate::types::game_state::{
+        AutoPassMode, PublicStateDirty, StackEntry, StackEntryKind, TurnBoundary,
+    };
     use crate::types::identifiers::{CardId, ObjectId};
     use crate::types::mana::ManaColor;
     use crate::types::phase::{Phase, PhaseStop, PhaseStopScope};
@@ -1081,6 +1083,55 @@ mod tests {
 
         let result = resolve_all_ready_prefix(&mut state, PlayerId(0));
 
+        assert_eq!(result.items_resolved, 1);
+        assert!(state.stack.is_empty());
+    }
+
+    #[test]
+    fn resolve_all_consent_supersedes_until_end_of_turn_auto_passes() {
+        let mut state = priority_state(PlayerId(0), vec![no_op_entry(1, PlayerId(0))]);
+        state.auto_pass.insert(
+            PlayerId(0),
+            AutoPassMode::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            },
+        );
+
+        super::super::engine::apply(
+            &mut state,
+            PlayerId(0),
+            GameAction::BeginResolveAll { max_resolutions: 0 },
+        )
+        .expect("priority holder begins the consent run");
+        assert!(!state.auto_pass.contains_key(&PlayerId(0)));
+
+        let epoch = match &state.waiting_for {
+            WaitingFor::ResolveAllConsent { epoch, .. } => *epoch,
+            _ => panic!("second representative should be queued"),
+        };
+        state.auto_pass.insert(
+            PlayerId(1),
+            AutoPassMode::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            },
+        );
+        super::super::engine::apply(
+            &mut state,
+            PlayerId(1),
+            GameAction::RespondResolveAllConsent {
+                epoch,
+                decision: ResolveAllConsentDecision::Grant,
+            },
+        )
+        .expect("second representative grants");
+
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::ResolveAllReady { .. }
+        ));
+        assert!(state.auto_pass.is_empty());
+
+        let result = resolve_all_ready_prefix(&mut state, PlayerId(0));
         assert_eq!(result.items_resolved, 1);
         assert!(state.stack.is_empty());
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Starting a Ready run now correctly clears the priority player’s automatic pass.
  * Beginning Resolve All clears relevant automatic-pass states, ensuring the action proceeds correctly after consent.
* **Tests**
  * Added coverage for automatic-pass handling during Ready and Resolve All flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->