### PR TITLE
feat(parser,engine): trigger on choosing a Ring-bearer (Call of the Ring)

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -1945,6 +1945,7 @@ fn legacy_trigger_condition(x: &TriggerCondition) -> bool {
         | TriggerCondition::WasType { .. }
         | TriggerCondition::AttackedThisTurn
         | TriggerCondition::ChoseOtherRingBearer
+        | TriggerCondition::ChoseRingBearer
         | TriggerCondition::FirstCombatPhaseOfTurn
         | TriggerCondition::HasMaxSpeed
         // CR 725.1: no `legacy_player_scope` classifier exists, and both scopes
@@ -6690,6 +6691,7 @@ fn rw_trigger_condition(x: &TriggerCondition) -> RwProfile {
         // bearer — an event-live read, so the profile mirrors the other
         // event-consuming intervening-ifs.
         TriggerCondition::ChoseOtherRingBearer => reads_event_live(),
+        TriggerCondition::ChoseRingBearer => reads_event_live(),
     }
 }
 
@@ -9101,6 +9103,17 @@ mod tests {
 
         assert_eq!(
             rw_trigger_condition(&TriggerCondition::ChoseOtherRingBearer),
+            reads_event_live()
+        );
+    }
+
+    /// #7816: the sibling choice gate consumes the same live event.
+    #[test]
+    fn chose_ring_bearer_reads_the_event_live() {
+        use crate::types::ability::TriggerCondition;
+
+        assert_eq!(
+            rw_trigger_condition(&TriggerCondition::ChoseRingBearer),
             reads_event_live()
         );
     }

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -3373,6 +3373,13 @@ fn scan_trigger_condition(x: &TriggerCondition, mode: ScanMode) -> Axes {
             sibling: false,
             projected: false,
         },
+        // Same event-bound read as `ChoseOtherRingBearer`: the chooser and
+        // the chosen bearer live on the triggering temptation event.
+        TriggerCondition::ChoseRingBearer => Axes {
+            event: true,
+            sibling: false,
+            projected: false,
+        },
         TriggerCondition::FirstCombatPhaseOfTurn => Axes {
             event: false,
             sibling: false,
@@ -8173,6 +8180,19 @@ mod tests {
             &TriggerCondition::ChoseOtherRingBearer,
             ScanMode::Conservative,
         );
+        assert!(axes.event, "must be event-bound");
+        assert!(!axes.sibling);
+        assert!(!axes.projected);
+    }
+
+    /// #7816: same event-bound classification as its `ChoseOtherRingBearer`
+    /// sibling — chooser and bearer live on the triggering temptation.
+    #[test]
+    fn chose_ring_bearer_is_event_bound() {
+        use crate::types::ability::TriggerCondition;
+
+        let axes =
+            scan_trigger_condition(&TriggerCondition::ChoseRingBearer, ScanMode::Conservative);
         assert!(axes.event, "must be event-bound");
         assert!(!axes.sibling);
         assert!(!axes.projected);

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -4347,6 +4347,7 @@ fn fmt_trigger_condition(cond: &crate::types::ability::TriggerCondition) -> Stri
         TC::LostLife => "lost life this turn".into(),
         TC::Descended => "descended this turn".into(),
         TC::ChoseOtherRingBearer => "chose a creature other than this as your Ring-bearer".into(),
+        TC::ChoseRingBearer => "you chose a creature as your Ring-bearer".into(),
         TC::ControlsType { filter } => format!("you control {}", fmt_target(filter)),
         TC::NoSpellsCastLastTurn => "no spells cast last turn".into(),
         TC::TwoOrMoreSpellsCastLastTurn => "two or more spells cast last turn".into(),

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -12994,6 +12994,16 @@ fn evaluate_trigger_condition_with_source(
             }) => source_id.is_some_and(|source| source != *bearer),
             _ => false,
         },
+        TriggerCondition::ChoseRingBearer => match trigger_event {
+            // CR 701.54a: a temptation with no legal candidates chooses
+            // nothing — `chosen_bearer: None` must not fire "you choose a
+            // creature as your Ring-bearer".
+            Some(GameEvent::RingTemptsYou {
+                player_id,
+                chosen_bearer: Some(_),
+            }) => *player_id == controller,
+            _ => false,
+        },
         TriggerCondition::SourceEnteredThisTurn => source_context.is_some_and(|source| {
             source.source_read(state).entered_battlefield_turn() == Some(state.turn_number)
         }),
@@ -45740,6 +45750,54 @@ pub mod tests {
             PlayerId(0),
             None,
             Some(&event),
+        ));
+    }
+
+    /// CR 701.54a: "you choose a creature as your Ring-bearer" — fires only
+    /// for the controller's own choice, and only when a bearer was actually
+    /// chosen (#7816).
+    #[test]
+    fn chose_ring_bearer_requires_the_controllers_own_choice() {
+        let mut state = setup();
+        let bearer = create_object(
+            &mut state,
+            CardId(43),
+            PlayerId(0),
+            "Bearer".to_string(),
+            Zone::Battlefield,
+        );
+        let condition = TriggerCondition::ChoseRingBearer;
+        let chosen = GameEvent::RingTemptsYou {
+            player_id: PlayerId(0),
+            chosen_bearer: Some(bearer),
+        };
+        // The controller's own choice fires — no source identity required.
+        assert!(check_trigger_condition_with_source(
+            &state,
+            &condition,
+            PlayerId(0),
+            None,
+            Some(&chosen),
+        ));
+        // Another player's choice must not fire this controller's trigger.
+        assert!(!check_trigger_condition_with_source(
+            &state,
+            &condition,
+            PlayerId(1),
+            None,
+            Some(&chosen),
+        ));
+        // A temptation that chose nothing (no legal candidates) must not fire.
+        let unchosen = GameEvent::RingTemptsYou {
+            player_id: PlayerId(0),
+            chosen_bearer: None,
+        };
+        assert!(!check_trigger_condition_with_source(
+            &state,
+            &condition,
+            PlayerId(0),
+            None,
+            Some(&unchosen),
         ));
     }
 }

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -13017,6 +13017,22 @@ fn try_parse_named_trigger_mode(lower: &str) -> Option<(TriggerMode, TriggerDefi
         def.mode = TriggerMode::RingTemptsYou;
         return Some((TriggerMode::RingTemptsYou, def));
     }
+
+    // CR 701.54a: "Whenever you choose a creature as your Ring-bearer" — the
+    // same temptation event, gated on a choice actually having been made
+    // (Call of the Ring). The gate rides in `def.condition`, which the
+    // caller ANDs with any additional intervening-if.
+    if all_consuming(pair(
+        alt((tag::<_, _, OracleError<'_>>("whenever "), tag("when "))),
+        tag("you choose a creature as your ring-bearer"),
+    ))
+    .parse(lower)
+    .is_ok()
+    {
+        def.mode = TriggerMode::RingTemptsYou;
+        def.condition = Some(TriggerCondition::ChoseRingBearer);
+        return Some((TriggerMode::RingTemptsYou, def));
+    }
     None
 }
 

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -14622,6 +14622,37 @@ fn trigger_coin_flip_rejects_partial_suffix() {
 }
 
 #[test]
+fn trigger_choose_ring_bearer_lowers_the_gated_temptation_mode() {
+    // Call of the Ring, second line (#7816): the same temptation event as
+    // "whenever the Ring tempts you", gated on a choice having been made.
+    let def = parse_trigger_line(
+        "Whenever you choose a creature as your Ring-bearer, you may pay 2 life. If you do, draw a card.",
+        "Call of the Ring",
+    );
+    assert_eq!(def.mode, TriggerMode::RingTemptsYou);
+    assert_eq!(
+        def.condition,
+        Some(crate::types::ability::TriggerCondition::ChoseRingBearer),
+        "the choice gate must ride in the trigger condition"
+    );
+    assert!(
+        def.execute.is_some(),
+        "the pay-life body must lower onto the trigger execute slot"
+    );
+}
+
+#[test]
+fn trigger_choose_ring_bearer_rejects_a_longer_suffix() {
+    // Regel 12: the head is all_consuming — trailing prose must fall through
+    // to Unknown, not silently truncate.
+    let def = parse_trigger_line(
+        "Whenever you choose a creature as your Ring-bearer or a food, draw a card.",
+        "Test Card",
+    );
+    assert!(matches!(def.mode, TriggerMode::Unknown(_)));
+}
+
+#[test]
 fn trigger_ring_tempts_you_whenever() {
     let def = parse_trigger_line(
         "Whenever the Ring tempts you, you may discard your hand.",

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -22691,6 +22691,12 @@ pub enum TriggerCondition {
     /// controller's mutable `state.ring_bearer`. This retains the trigger-time
     /// choice if a later Ring temptation changes the current Ring-bearer.
     ChoseOtherRingBearer,
+    /// CR 701.54a/d: "Whenever you choose a creature as your Ring-bearer"
+    /// (Call of the Ring). True when the triggering
+    /// `GameEvent::RingTemptsYou` carries a `chosen_bearer` — a temptation
+    /// with no legal candidates chooses nothing and must not fire this —
+    /// and the chooser is the trigger's controller.
+    ChoseRingBearer,
     /// CR 702.30a: Echo intervening-if for a permanent that has not yet had
     /// its next-controller-upkeep echo payment handled.
     EchoDue,
@@ -23151,6 +23157,7 @@ impl TriggerCondition {
             | TriggerCondition::LostLife
             | TriggerCondition::Descended
             | TriggerCondition::ChoseOtherRingBearer
+            | TriggerCondition::ChoseRingBearer
             | TriggerCondition::ControlsType { .. }
             | TriggerCondition::NoSpellsCastLastTurn
             | TriggerCondition::TwoOrMoreSpellsCastLastTurn

--- a/crates/engine/tests/integration/issue_7816_call_of_the_ring.rs
+++ b/crates/engine/tests/integration/issue_7816_call_of_the_ring.rs
@@ -1,0 +1,210 @@
+//! Issue #7816 (Call of the Ring) — "Whenever you choose a creature as your
+//! Ring-bearer" over the REAL temptation pipeline: `Effect::RingTemptsYou` →
+//! bearer choice (interactive AND sole-candidate auto-select) →
+//! `GameEvent::RingTemptsYou { chosen_bearer }` → `TriggerMode::RingTemptsYou`
+//! gated by `TriggerCondition::ChoseRingBearer` → optional PayCost(2 life) →
+//! conditional Draw.
+//!
+//! Driver note: the boards drive from `commit()` — `resolve()` auto-answers
+//! may-triggers (declining this one), which would hide the prompt under test.
+//!
+//! REVERT DISCRIMINATORS:
+//! - without the parser head the mode is `Unknown` — no trigger ever stacks
+//!   and `paying_two_life_draws_a_card` never sees its pay prompt;
+//! - without the `chosen_bearer: Some(_)` gate in the evaluator,
+//!   `a_temptation_with_no_creatures_stacks_no_trigger` sees a pay prompt
+//!   from a temptation that chose nothing (CR 701.54a);
+//! - without the `player_id == controller` gate,
+//!   `an_opponents_choice_does_not_fire_your_call` sees P0's pay prompt off
+//!   P1's temptation.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const CALL_LINE_2: &str =
+    "Whenever you choose a creature as your Ring-bearer, you may pay 2 life. If you do, draw a card.";
+const TEMPT: &str = "The Ring tempts you.";
+
+fn hand_size(runner: &GameRunner, player: PlayerId) -> usize {
+    runner.state().players[player.0 as usize].hand.len()
+}
+
+fn life(runner: &GameRunner, player: PlayerId) -> i32 {
+    runner.state().players[player.0 as usize].life
+}
+
+/// Drive the committed temptation to a settled empty stack. `pay` answers the
+/// Call's optional pay-life prompt when it appears; returns whether that
+/// prompt was seen. Unexpected prompts panic, and the loop must REACH the
+/// empty-stack terminal.
+fn drive_temptation(runner: &mut GameRunner, bearer: Option<ObjectId>, pay: bool) -> bool {
+    let mut pay_prompt_seen = false;
+    for _ in 0..64 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::ChooseRingBearer { candidates, .. } => {
+                let target = bearer.expect("a bearer prompt appeared but none was intended");
+                assert!(
+                    candidates.contains(&target),
+                    "intended bearer must be a legal candidate, got {candidates:?}"
+                );
+                runner
+                    .act(GameAction::ChooseRingBearer { target })
+                    .expect("the Ring-bearer choice must be accepted");
+            }
+            WaitingFor::OptionalEffectChoice { .. } => {
+                pay_prompt_seen = true;
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: pay })
+                    .expect("answering the pay-life prompt must succeed");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty() {
+                    return pay_prompt_seen;
+                }
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("PassPriority must be accepted mid-drive");
+            }
+            other => panic!("unexpected prompt during the temptation: {other:?}"),
+        }
+    }
+    panic!("temptation never settled to an empty stack within 64 steps");
+}
+
+/// `creatures`: 0 = choiceless temptation, 1 = sole-candidate auto-select,
+/// 2 = interactive `ChooseRingBearer` prompt.
+fn call_board(creatures: usize) -> (GameRunner, Option<ObjectId>) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_enchantment_from_oracle(P0, "Call of the Ring", CALL_LINE_2)
+        .id();
+    let bearer = (creatures >= 1).then(|| scenario.add_creature(P0, "Companion Hobbit", 1, 1).id());
+    if creatures >= 2 {
+        scenario.add_creature(P0, "Second Hobbit", 1, 1);
+    }
+    let tempt = scenario
+        .add_spell_to_hand(P0, "Temptation Test", false)
+        .from_oracle_text(TEMPT)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+    scenario.add_card_to_library_top(P0, "Library Filler");
+    scenario.with_mana_pool(P0, vec![]);
+    let mut runner = scenario.build();
+    runner.cast(tempt).commit();
+    (runner, bearer)
+}
+
+#[test]
+fn paying_two_life_draws_a_card() {
+    let (mut runner, bearer) = call_board(2);
+    let life_before = life(&runner, P0);
+    let hand_before = hand_size(&runner, P0);
+
+    let prompted = drive_temptation(&mut runner, bearer, true);
+
+    assert!(prompted, "the pay-life prompt must be offered");
+    assert_eq!(life(&runner, P0), life_before - 2, "CR 119.4: 2 life paid");
+    assert_eq!(
+        hand_size(&runner, P0),
+        hand_before + 1,
+        "the paid-for draw must resolve"
+    );
+    assert_eq!(
+        runner.state().ring_bearer.get(&P0).copied().flatten(),
+        bearer,
+        "the chosen creature must be the Ring-bearer"
+    );
+}
+
+#[test]
+fn declining_the_payment_keeps_life_and_hand() {
+    let (mut runner, bearer) = call_board(2);
+    let life_before = life(&runner, P0);
+    let hand_before = hand_size(&runner, P0);
+
+    let prompted = drive_temptation(&mut runner, bearer, false);
+
+    assert!(prompted, "the pay-life prompt must be offered");
+    assert_eq!(life(&runner, P0), life_before, "declined: no life paid");
+    assert_eq!(hand_size(&runner, P0), hand_before, "declined: no draw");
+}
+
+#[test]
+fn a_sole_candidate_auto_selection_also_fires_the_call() {
+    // CR 701.54a: with exactly one legal candidate the choice is made without
+    // a prompt — it is still "you choose a creature as your Ring-bearer".
+    let (mut runner, bearer) = call_board(1);
+    let life_before = life(&runner, P0);
+    let hand_before = hand_size(&runner, P0);
+
+    let prompted = drive_temptation(&mut runner, bearer, true);
+
+    assert!(
+        prompted,
+        "the auto-selected choice must still fire the Call"
+    );
+    assert_eq!(life(&runner, P0), life_before - 2);
+    assert_eq!(hand_size(&runner, P0), hand_before + 1);
+    assert_eq!(
+        runner.state().ring_bearer.get(&P0).copied().flatten(),
+        bearer
+    );
+}
+
+#[test]
+fn a_temptation_with_no_creatures_stacks_no_trigger() {
+    // CR 701.54a: with no legal candidates nothing is chosen — "you choose a
+    // creature as your Ring-bearer" never happened, so the Call stays silent.
+    let (mut runner, bearer) = call_board(0);
+    let life_before = life(&runner, P0);
+    let hand_before = hand_size(&runner, P0);
+
+    let prompted = drive_temptation(&mut runner, bearer, true);
+
+    assert!(!prompted, "a choiceless temptation must not fire the Call");
+    assert_eq!(life(&runner, P0), life_before);
+    assert_eq!(hand_size(&runner, P0), hand_before);
+}
+
+#[test]
+fn an_opponents_choice_does_not_fire_your_call() {
+    // "you choose" — P1's own temptation and bearer choice must not fire
+    // P0's enchantment.
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_enchantment_from_oracle(P0, "Call of the Ring", CALL_LINE_2)
+        .id();
+    let their_bearer = scenario.add_creature(P1, "Orc Bearer", 1, 1).id();
+    // Instant: P1 casts during P0's turn (a sorcery would be refused).
+    let tempt = scenario
+        .add_spell_to_hand(P1, "Temptation Test", true)
+        .from_oracle_text(TEMPT)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+    scenario.with_mana_pool(P1, vec![]);
+    let mut runner = scenario.build();
+    let p0_life = life(&runner, P0);
+    let p0_hand = hand_size(&runner, P0);
+    // Hand P1 priority on the empty stack, then let P1 cast the instant.
+    runner
+        .act(GameAction::PassPriority)
+        .expect("P0 passes so P1 holds priority");
+    runner.cast(tempt).commit();
+
+    let prompted = drive_temptation(&mut runner, Some(their_bearer), true);
+
+    assert!(!prompted, "P1's choice must not fire P0's Call of the Ring");
+    assert_eq!(
+        runner.state().ring_bearer.get(&P1).copied().flatten(),
+        Some(their_bearer)
+    );
+    assert_eq!(life(&runner, P0), p0_life);
+    assert_eq!(hand_size(&runner, P0), p0_hand);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1249,6 +1249,7 @@ mod issue_6367_thassas_oracle;
 mod issue_7467_manifest_dread_tracked_set;
 mod issue_7552_role_token_image_ref;
 mod issue_7795_put_choice_from_among_trigger;
+mod issue_7816_call_of_the_ring;
 mod issue_7821_bare_plural_enters_with_counters;
 mod issue_7822_manifested_planeswalker_loyalty;
 mod kang_dynasty_until_next_turn_rider;


### PR DESCRIPTION
Fixes #7816.

**What**: Call of the Ring's second ability ("Whenever you choose a creature as your Ring-bearer, you may pay 2 life. If you do, draw a card.") never fired: the head fell through to plain temptation parsing and the trigger was lost. It now lowers to `TriggerMode::RingTemptsYou` gated by a new `TriggerCondition::ChoseRingBearer`, which matches only the event where the trigger's controller actually chose a bearer (`GameEvent::RingTemptsYou { chosen_bearer: Some(_) }`, CR 701.54a/d).

**How**
- New parser head in `oracle_trigger.rs` directly after the ring-tempts head: `when(ever) you choose a creature as your ring-bearer` → mode + condition. The existing `def.condition.take()` merge preserves head-set conditions (verified).
- Evaluator arm in `triggers.rs`: fires only for the controller's own choice; `None` (declined/no creature) and other players' choices do not match — each pinned by a unit test.
- `ability_scan` / `ability_rw`: condition registered as event-bound and reads-event-live, both pinned.

**Evidence**
- 5 integration tests: pay + decline (interactive, 2 creatures), sole-candidate auto-selection (covers the previously untested auto-select path in ring.rs), no-creatures negative, opponent-tempted negative.
- Counter-probe: removing the parser head fails exactly the 3 positive tests.
- Census over all 35798 cards: exactly 1 card changes — Call of the Ring.
- On current main (06d9d9705): integration 5506/5506 pass, full engine lib + clippy + swallow/coverage gates green (pre-push chain); coverage delta net ±0, gained card is exactly Call of the Ring.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for triggers that respond when you choose a creature as your Ring-bearer.
  * Added parsing for Ring-bearer choice triggers in supported card text.
  * Triggers now correctly distinguish your Ring-bearer choice from an opponent’s choice and cases where no valid choice exists.

* **Bug Fixes**
  * Improved Ring-bearer trigger handling, including optional costs and automatic selections.

* **Tests**
  * Added comprehensive coverage for parsing and Call of the Ring gameplay scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->