### PR TITLE
Add Mount Doom

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -3275,14 +3275,14 @@ describe("P2P wire-protocol version gate", () => {
   // Both halves stamp LITERALS. A frame built from WIRE_PROTOCOL_VERSION
   // cannot tell a bumped client from an unbumped one, which is why every
   // other handshake fixture in the suite is useless as an instrument for a
-  // bump. Revert 27 → 26 and BOTH halves red: the v26 frame stops being
-  // refused, and the v27 frame stops being admitted. The admitting half is
-  // the reach-guard — without it "refuses v26" is also satisfied by a client
+  // bump. Revert 28 → 27 and BOTH halves red: the v27 frame stops being
+  // refused, and the v28 frame stops being admitted. The admitting half is
+  // the reach-guard — without it "refuses v27" is also satisfied by a client
   // that refuses everything.
-  it("refuses the previous wire protocol (v26) and admits its own (v27)", async () => {
+  it("refuses the previous wire protocol (v27) and admits its own (v28)", async () => {
     const refusing = makeGuest();
     await refusing.adapter.initialize();
-    await refusing.conn.simulateData(setupFrameAt(26));
+    await refusing.conn.simulateData(setupFrameAt(27));
 
     await expect(refusing.adapter.initializeGame()).rejects.toMatchObject({
       code: "P2P_REJECTED",
@@ -3294,7 +3294,7 @@ describe("P2P wire-protocol version gate", () => {
 
     const admitting = makeGuest();
     await admitting.adapter.initialize();
-    await admitting.conn.simulateData(setupFrameAt(27));
+    await admitting.conn.simulateData(setupFrameAt(28));
 
     await expect(admitting.adapter.initializeGame()).resolves.toBeDefined();
     expect(admitting.emitted).not.toHaveBeenCalledWith(

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -3275,14 +3275,14 @@ describe("P2P wire-protocol version gate", () => {
   // Both halves stamp LITERALS. A frame built from WIRE_PROTOCOL_VERSION
   // cannot tell a bumped client from an unbumped one, which is why every
   // other handshake fixture in the suite is useless as an instrument for a
-  // bump. Revert 28 → 27 and BOTH halves red: the v27 frame stops being
-  // refused, and the v28 frame stops being admitted. The admitting half is
-  // the reach-guard — without it "refuses v27" is also satisfied by a client
+  // bump. Revert 29 → 28 and BOTH halves red: the v28 frame stops being
+  // refused, and the v29 frame stops being admitted. The admitting half is
+  // the reach-guard — without it "refuses v28" is also satisfied by a client
   // that refuses everything.
-  it("refuses the previous wire protocol (v27) and admits its own (v28)", async () => {
+  it("refuses the previous wire protocol (v28) and admits its own (v29)", async () => {
     const refusing = makeGuest();
     await refusing.adapter.initialize();
-    await refusing.conn.simulateData(setupFrameAt(27));
+    await refusing.conn.simulateData(setupFrameAt(28));
 
     await expect(refusing.adapter.initializeGame()).rejects.toMatchObject({
       code: "P2P_REJECTED",
@@ -3294,7 +3294,7 @@ describe("P2P wire-protocol version gate", () => {
 
     const admitting = makeGuest();
     await admitting.adapter.initialize();
-    await admitting.conn.simulateData(setupFrameAt(28));
+    await admitting.conn.simulateData(setupFrameAt(29));
 
     await expect(admitting.adapter.initializeGame()).resolves.toBeDefined();
     expect(admitting.emitted).not.toHaveBeenCalledWith(

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1957,7 +1957,7 @@ export type WaitingFor =
   | { type: "TimeTravelChoice"; data: { player: PlayerId; eligible: TargetRef[]; phase: "Remove" | "Add" } }
   | { type: "AssistChoosePlayer"; data: { player: PlayerId; candidates: PlayerId[]; max_generic: number; convoke_mode?: ConvokeMode } }
   | { type: "AssistPayment"; data: { caster: PlayerId; chosen: PlayerId; max_generic: number; convoke_mode?: ConvokeMode } }
-  | { type: "ChooseObjectsSelection"; data: { player: PlayerId; eligible: TargetRef[]; trigger_event?: GameEvent } }
+  | { type: "ChooseObjectsSelection"; data: { player: PlayerId; eligible: TargetRef[]; min: number; max?: number; trigger_event?: GameEvent } }
   | { type: "ConniveDiscard"; data: { player: PlayerId; conniver_id: ObjectId; source_id: ObjectId; cards: ObjectId[]; count: number } }
   | { type: "DiscardChoice"; data: { player: PlayerId; count: number; cards: ObjectId[]; source_id: ObjectId; effect_kind: string; up_to?: boolean; unless_filter?: TargetFilter } }
   | { type: "ManifestDreadChoice"; data: { player: PlayerId; cards: ObjectId[]; source_id: ObjectId } }

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -203,6 +203,10 @@ export class NativeEngineVersionMismatchError extends Error {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 37 — WaitingFor.ChooseObjectsSelection publishes the resolving effect's
+ *      min and optional max bounds. Older clients silently ignore these
+ *      additive fields and offer selections outside the engine-authoritative
+ *      range, so the full-game handshake refuses that capability mismatch.
  * 36 — WaitingFor.ChooseDungeon.options changed from DungeonId[] to
  *      DungeonPreview[], and ChooseDungeonRoom dropped option_names, gained a
  *      required dungeon_name, and changed options from number[] to
@@ -280,7 +284,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 36;
+export const PROTOCOL_VERSION = 37;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/components/modal/ProliferateModal.tsx
+++ b/client/src/components/modal/ProliferateModal.tsx
@@ -105,12 +105,12 @@ export function ProliferateModal({
       setSelected((prev) => {
         const selectedAlready = prev.some((t) => targetKey(t) === key);
         if (selectedAlready) {
-          return prev.length > min ? prev.filter((t) => targetKey(t) !== key) : prev;
+          return prev.filter((t) => targetKey(t) !== key);
         }
         return prev.length < max ? [...prev, target] : prev;
       });
     },
-    [max, min],
+    [max],
   );
 
   const handleConfirm = useCallback(() => {
@@ -166,7 +166,7 @@ export function ProliferateModal({
         {data.eligible.map((target) => {
           const key = targetKey(target);
           const isSelected = selected.some((t) => targetKey(t) === key);
-          const disabled = isSelected ? selected.length <= min : selected.length >= max;
+          const disabled = !isSelected && selected.length >= max;
           return (
             <button
               key={key}

--- a/client/src/components/modal/ProliferateModal.tsx
+++ b/client/src/components/modal/ProliferateModal.tsx
@@ -23,13 +23,11 @@ type ChooseObjectsSelection = Extract<
 // CR 701.56a: Time travel — choose any number of eligible objects for the
 // current remove/add phase; each selected object gets exactly that phase's
 // counter operation.
-// CR 603.7e: ChooseObjectsSelection — choose any number of battlefield
-// permanents (Magnetic Mountain class). These prompts share the same
+// CR 608.2c: ChooseObjectsSelection — choose within the engine-published
+// min/max range of battlefield permanents. These prompts share the same
 // `SelectTargets` dispatch over an engine-provided `eligible` list, so a single
-// modal serves them; `variant` adapts copy and default selection.
-// Engine pre-filters `eligible`; the modal is purely a chooser. Default-select-
-// all is a UX choice (one-click confirm for the common case), not a rules
-// requirement.
+// modal serves them; `variant` adapts copy, bounds, and default selection.
+// Engine pre-filters `eligible`; the modal is purely a chooser.
 type ProliferateModalData =
   | ProliferateChoice["data"]
   | TimeTravelChoice["data"]
@@ -55,10 +53,43 @@ export function ProliferateModal({
   const objects = useGameStore((s) => s.gameState?.objects);
   const playerId = usePlayerId();
   const hoverProps = useInspectHoverProps();
+  const chooseObjectsData =
+    variant === "chooseObjects" ? (data as ChooseObjectsSelection["data"]) : undefined;
+
+  const max = Math.max(
+    0,
+    Math.min(
+      data.eligible.length,
+      chooseObjectsData?.max ?? data.eligible.length,
+    ),
+  );
+  const min = Math.min(max, chooseObjectsData?.min ?? 0);
+
+  const boundedSelection = useCallback(
+    (targets: TargetRef[]) => {
+      const selectedKeys = new Set<string>();
+      const bounded = targets.filter((target) => {
+        const key = targetKey(target);
+        if (selectedKeys.has(key)) return false;
+        selectedKeys.add(key);
+        return true;
+      }).slice(0, max);
+      for (const target of data.eligible) {
+        if (bounded.length >= min) break;
+        const key = targetKey(target);
+        if (!selectedKeys.has(key)) {
+          selectedKeys.add(key);
+          bounded.push(target);
+        }
+      }
+      return bounded;
+    },
+    [data.eligible, max, min],
+  );
 
   const defaultSelection = useCallback(
-    () => (variant === "timeTravelAdd" ? [] : data.eligible),
-    [data.eligible, variant],
+    () => boundedSelection(variant === "timeTravelAdd" ? [] : data.eligible),
+    [boundedSelection, data.eligible, variant],
   );
   const [selected, setSelected] = useState<TargetRef[]>(() => defaultSelection());
 
@@ -68,44 +99,63 @@ export function ProliferateModal({
     setSelected(defaultSelection());
   }, [defaultSelection]);
 
-  const handleToggle = useCallback((target: TargetRef) => {
-    const key = targetKey(target);
-    setSelected((prev) =>
-      prev.some((t) => targetKey(t) === key)
-        ? prev.filter((t) => targetKey(t) !== key)
-        : [...prev, target],
-    );
-  }, []);
+  const handleToggle = useCallback(
+    (target: TargetRef) => {
+      const key = targetKey(target);
+      setSelected((prev) => {
+        const selectedAlready = prev.some((t) => targetKey(t) === key);
+        if (selectedAlready) {
+          return prev.length > min ? prev.filter((t) => targetKey(t) !== key) : prev;
+        }
+        return prev.length < max ? [...prev, target] : prev;
+      });
+    },
+    [max, min],
+  );
 
   const handleConfirm = useCallback(() => {
     dispatch({ type: "SelectTargets", data: { targets: selected } });
   }, [dispatch, selected]);
 
+  const selectionValid = selected.length >= min && selected.length <= max;
+
   return (
     <ChoiceOverlay
       title={t(`proliferate.${VARIANT_KEYS[variant].title}`)}
       subtitle={t(`proliferate.${VARIANT_KEYS[variant].subtitle}`)}
-      footer={<ConfirmButton onClick={handleConfirm} label={t("proliferate.confirm")} />}
+      footer={
+        <ConfirmButton
+          onClick={handleConfirm}
+          disabled={!selectionValid}
+          label={t("proliferate.confirm")}
+        />
+      }
     >
       {data.eligible.length > 1 && (
         <div className="mb-3 flex flex-wrap gap-2">
           <button
             type="button"
-            onClick={() => setSelected(data.eligible)}
+            onClick={() => setSelected(boundedSelection(data.eligible))}
             className={gameButtonClass({ tone: "neutral", size: "xs" })}
           >
             {t("proliferate.selectAll")}
           </button>
+          {min === 0 && (
+            <button
+              type="button"
+              onClick={() => setSelected([])}
+              className={gameButtonClass({ tone: "neutral", size: "xs" })}
+            >
+              {t("proliferate.selectNone")}
+            </button>
+          )}
           <button
             type="button"
-            onClick={() => setSelected([])}
-            className={gameButtonClass({ tone: "neutral", size: "xs" })}
-          >
-            {t("proliferate.selectNone")}
-          </button>
-          <button
-            type="button"
-            onClick={() => setSelected(filterTargetsByController(data.eligible, objects, playerId))}
+            onClick={() =>
+              setSelected(
+                boundedSelection(filterTargetsByController(data.eligible, objects, playerId)),
+              )
+            }
             className={gameButtonClass({ tone: "neutral", size: "xs" })}
           >
             {t("proliferate.selectMine")}
@@ -116,11 +166,13 @@ export function ProliferateModal({
         {data.eligible.map((target) => {
           const key = targetKey(target);
           const isSelected = selected.some((t) => targetKey(t) === key);
+          const disabled = isSelected ? selected.length <= min : selected.length >= max;
           return (
             <button
               key={key}
               type="button"
               aria-pressed={isSelected}
+              disabled={disabled}
               {...("Object" in target ? hoverProps(target.Object) : undefined)}
               onClick={() => handleToggle(target)}
               className={

--- a/client/src/components/modal/__tests__/ProliferateModal.test.tsx
+++ b/client/src/components/modal/__tests__/ProliferateModal.test.tsx
@@ -1,7 +1,7 @@
 import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { GameState, TargetRef } from "../../../adapter/types.ts";
+import type { GameState, TargetRef, WaitingFor } from "../../../adapter/types.ts";
 import { CardChoiceModal } from "../CardChoiceModal.tsx";
 import { useGameStore } from "../../../stores/gameStore.ts";
 import { useMultiplayerStore } from "../../../stores/multiplayerStore.ts";
@@ -11,6 +11,8 @@ import {
   buildGameState,
   buildPlayer,
 } from "../../../test/factories/gameStateFactory.ts";
+
+type ChooseObjectsWaitingFor = Extract<WaitingFor, { type: "ChooseObjectsSelection" }>;
 
 const dispatchMock = vi.fn();
 
@@ -41,14 +43,25 @@ function makeState(eligible: TargetRef[]): GameState {
     objects: buildObjectMap(
       makeObject(42, "Walking Ballista"),
       makeObject(43, "Hangarback Walker"),
+      makeObject(44, "Triskelion"),
     ),
     next_object_id: 100,
-    battlefield: [42, 43],
+    battlefield: [42, 43, 44],
     waiting_for: {
       type: "ProliferateChoice",
       data: { player: 0, eligible },
     },
     next_timestamp: 2,
+  });
+}
+
+function setUpWaitingFor(waitingFor: ChooseObjectsWaitingFor) {
+  const state = makeState(waitingFor.data.eligible);
+  state.waiting_for = waitingFor;
+  useGameStore.setState({
+    gameMode: "online",
+    gameState: state,
+    waitingFor,
   });
 }
 
@@ -125,5 +138,43 @@ describe("ProliferateModal (via CardChoiceModal)", () => {
     setUp([{ Object: 42 }]);
     const { container } = render(<CardChoiceModal />);
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("caps ChooseObjects default, toggles, and Select All at max", () => {
+    const eligible: TargetRef[] = [{ Object: 42 }, { Object: 43 }, { Object: 44 }];
+    setUpWaitingFor({
+      type: "ChooseObjectsSelection",
+      data: { player: 0, eligible, min: 0, max: 2 },
+    });
+    render(<CardChoiceModal />);
+
+    fireEvent.click(screen.getByRole("button", { name: "Triskelion" }));
+    fireEvent.click(screen.getByRole("button", { name: "All" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: "SelectTargets",
+      data: { targets: eligible.slice(0, 2) },
+    });
+  });
+
+  it("keeps a ChooseObjects selection at or above a required minimum", () => {
+    const eligible: TargetRef[] = [{ Object: 42 }, { Object: 43 }, { Object: 44 }];
+    setUpWaitingFor({
+      type: "ChooseObjectsSelection",
+      data: { player: 0, eligible, min: 2, max: 3 },
+    });
+    render(<CardChoiceModal />);
+
+    expect(screen.queryByRole("button", { name: "None" })).not.toBeInTheDocument();
+    fireEvent.click(screen.getByRole("button", { name: "Triskelion" }));
+    expect(screen.getByRole("button", { name: "Walking Ballista" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Walking Ballista" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: "SelectTargets",
+      data: { targets: eligible.slice(0, 2) },
+    });
   });
 });

--- a/client/src/components/modal/__tests__/ProliferateModal.test.tsx
+++ b/client/src/components/modal/__tests__/ProliferateModal.test.tsx
@@ -158,7 +158,7 @@ describe("ProliferateModal (via CardChoiceModal)", () => {
     });
   });
 
-  it("keeps a ChooseObjects selection at or above a required minimum", () => {
+  it("disables confirmation below a required minimum without locking reselection", () => {
     const eligible: TargetRef[] = [{ Object: 42 }, { Object: 43 }, { Object: 44 }];
     setUpWaitingFor({
       type: "ChooseObjectsSelection",
@@ -168,13 +168,37 @@ describe("ProliferateModal (via CardChoiceModal)", () => {
 
     expect(screen.queryByRole("button", { name: "None" })).not.toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Triskelion" }));
-    expect(screen.getByRole("button", { name: "Walking Ballista" })).toBeDisabled();
     fireEvent.click(screen.getByRole("button", { name: "Walking Ballista" }));
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+    expect(dispatchMock).not.toHaveBeenCalled();
+    fireEvent.click(screen.getByRole("button", { name: "Triskelion" }));
     fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
 
     expect(dispatchMock).toHaveBeenCalledWith({
       type: "SelectTargets",
-      data: { targets: eligible.slice(0, 2) },
+      data: { targets: eligible.slice(1) },
+    });
+  });
+
+  it("can replace a default target when the exact minimum equals the maximum", () => {
+    const eligible: TargetRef[] = [{ Object: 42 }, { Object: 43 }, { Object: 44 }];
+    setUpWaitingFor({
+      type: "ChooseObjectsSelection",
+      data: { player: 0, eligible, min: 2, max: 2 },
+    });
+    render(<CardChoiceModal />);
+
+    expect(screen.getByRole("button", { name: "Triskelion" })).toBeDisabled();
+    fireEvent.click(screen.getByRole("button", { name: "Walking Ballista" }));
+    expect(screen.getByRole("button", { name: "Confirm" })).toBeDisabled();
+    expect(screen.getByRole("button", { name: "Triskelion" })).toBeEnabled();
+    fireEvent.click(screen.getByRole("button", { name: "Triskelion" }));
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(dispatchMock).toHaveBeenCalledWith({
+      type: "SelectTargets",
+      data: { targets: eligible.slice(1) },
     });
   });
 });

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -36,8 +36,8 @@ const viewerInteractionWithProducedMana = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v27", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(27);
+  it("pins the P2P wire protocol to v28", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(28);
   });
 
   it("defaults shortcut actions for a legacy payload created before the additive field", () => {

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -36,8 +36,8 @@ const viewerInteractionWithProducedMana = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v28", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(28);
+  it("pins the P2P wire protocol to v29", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(29);
   });
 
   it("defaults shortcut actions for a legacy payload created before the additive field", () => {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -94,6 +94,10 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  * admitted; see the gate for why.
  *
  * Bumps to date:
+ *  28 — WaitingFor.ChooseObjectsSelection publishes min and optional max
+ *       bounds. A v27 peer silently ignores the additive fields and offers
+ *       out-of-range selections, so refuse the capability mismatch during
+ *       host/guest first contact.
  *  27 — WaitingFor.ChooseDungeon.options changed from DungeonId[] to
  *       DungeonPreview[], and ChooseDungeonRoom dropped option_names, gained a
  *       required dungeon_name, and changed options from number[] to
@@ -157,7 +161,7 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *       sub-phase on WaitingFor::MulliganDecision; the MulliganBottomCards
  *       variant was removed
  */
-export const WIRE_PROTOCOL_VERSION = 27 as const;
+export const WIRE_PROTOCOL_VERSION = 28 as const;
 
 export type P2PMessage = P2PAuthorityWire & (
   // `wireProtocolVersion` is optional on both first-contact guest messages:

--- a/client/src/viewmodel/__tests__/gameStateView.test.ts
+++ b/client/src/viewmodel/__tests__/gameStateView.test.ts
@@ -897,7 +897,10 @@ const PARTITION_FIXTURES: Record<
   },
   // Shares ProliferateModal; `SelectTargets` subset.
   ChooseObjectsSelection: {
-    waitingFor: { type: "ChooseObjectsSelection", data: { player: 0, eligible: MIXED_LEGAL } },
+    waitingFor: {
+      type: "ChooseObjectsSelection",
+      data: { player: 0, eligible: MIXED_LEGAL, min: 0 },
+    },
     legal: MIXED_LEGAL,
   },
   // Answered by an ORDERED `SelectTargets` (first pick is copied, second

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -2887,33 +2887,63 @@ pub fn candidate_actions_broad_with_probe(
             }
             actions
         }
-        // CR 608.2c: ChooseObjectsIntoTrackedSet — choose any subset of the
-        // eligible battlefield permanents (or decline with an empty selection).
+        // CR 608.2c: ChooseObjectsIntoTrackedSet — emit only distinct subsets
+        // within the resolution choice's printed cardinality.
         WaitingFor::ChooseObjectsSelection {
-            player, eligible, ..
+            player,
+            eligible,
+            min,
+            max,
+            ..
         } => {
-            let mut actions = vec![
-                // Pay for all affordable: select every eligible permanent.
-                candidate(
+            let mut unique = Vec::with_capacity(eligible.len());
+            for target in eligible {
+                if !unique.contains(target) {
+                    unique.push(target.clone());
+                }
+            }
+            let floor = *min as usize;
+            let ceiling = max
+                .map(|maximum| maximum as usize)
+                .unwrap_or(unique.len())
+                .min(unique.len());
+            if floor > ceiling {
+                return Vec::new();
+            }
+
+            let mut actions = Vec::new();
+            if ceiling > 1 || floor > 1 {
+                actions.push(candidate(
                     GameAction::SelectTargets {
-                        targets: eligible.clone(),
+                        targets: unique[..ceiling].to_vec(),
                     },
                     TacticalClass::Selection,
                     Some(*player),
-                ),
-                // Decline: empty selection.
-                candidate(
+                ));
+            }
+            if floor == 0 {
+                actions.push(candidate(
                     GameAction::SelectTargets {
                         targets: Vec::new(),
                     },
                     TacticalClass::Selection,
                     Some(*player),
-                ),
-            ];
-            for target in eligible {
+                ));
+            }
+            if floor <= 1 && ceiling >= 1 {
+                for target in &unique {
+                    actions.push(candidate(
+                        GameAction::SelectTargets {
+                            targets: vec![target.clone()],
+                        },
+                        TacticalClass::Selection,
+                        Some(*player),
+                    ));
+                }
+            } else if floor < ceiling {
                 actions.push(candidate(
                     GameAction::SelectTargets {
-                        targets: vec![target.clone()],
+                        targets: unique[..floor].to_vec(),
                     },
                     TacticalClass::Selection,
                     Some(*player),
@@ -5765,6 +5795,58 @@ mod tests {
     use crate::types::keywords::{Keyword, KeywordKind};
     use crate::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
     use crate::types::zones::Zone;
+
+    #[test]
+    fn choose_objects_candidates_respect_bounds_and_distinctness() {
+        let mut state = GameState::new_two_player(42);
+        let eligible = vec![
+            TargetRef::Object(ObjectId(1)),
+            TargetRef::Object(ObjectId(2)),
+            TargetRef::Object(ObjectId(3)),
+        ];
+        state.waiting_for = WaitingFor::ChooseObjectsSelection {
+            player: PlayerId(0),
+            eligible,
+            min: 0,
+            max: Some(2),
+            trigger_event: None,
+        };
+
+        let actions = candidate_actions(&state);
+        let selections: Vec<&Vec<TargetRef>> = actions
+            .iter()
+            .filter_map(|candidate| match &candidate.action {
+                GameAction::SelectTargets { targets } => Some(targets),
+                _ => None,
+            })
+            .collect();
+        assert!(selections.iter().any(|targets| targets.is_empty()));
+        assert!(selections.iter().any(|targets| targets.len() == 2));
+        assert!(selections.iter().all(|targets| {
+            targets.len() <= 2
+                && targets
+                    .iter()
+                    .enumerate()
+                    .all(|(index, target)| !targets[..index].contains(target))
+        }));
+
+        state.waiting_for = WaitingFor::ChooseObjectsSelection {
+            player: PlayerId(0),
+            eligible: vec![
+                TargetRef::Object(ObjectId(1)),
+                TargetRef::Object(ObjectId(2)),
+                TargetRef::Object(ObjectId(3)),
+            ],
+            min: 2,
+            max: Some(2),
+            trigger_event: None,
+        };
+        let required_actions = candidate_actions(&state);
+        assert!(required_actions.iter().all(|candidate| matches!(
+            &candidate.action,
+            GameAction::SelectTargets { targets } if targets.len() == 2
+        )));
+    }
 
     /// CR 732.2a: an AI-controlled priority holder receives both legal shortcut choices.
     /// The `legal_actions` assertion reaches the simulation-filtered surface used by AI search;

--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -2911,45 +2911,21 @@ pub fn candidate_actions_broad_with_probe(
                 return Vec::new();
             }
 
-            let mut actions = Vec::new();
-            if ceiling > 1 || floor > 1 {
-                actions.push(candidate(
-                    GameAction::SelectTargets {
-                        targets: unique[..ceiling].to_vec(),
-                    },
+            bounded_combinations_generic(
+                &unique,
+                floor..=ceiling,
+                SELECTION_POOL_CAP,
+                SELECTION_CANDIDATE_CAP,
+            )
+            .into_iter()
+            .map(|targets| {
+                candidate(
+                    GameAction::SelectTargets { targets },
                     TacticalClass::Selection,
                     Some(*player),
-                ));
-            }
-            if floor == 0 {
-                actions.push(candidate(
-                    GameAction::SelectTargets {
-                        targets: Vec::new(),
-                    },
-                    TacticalClass::Selection,
-                    Some(*player),
-                ));
-            }
-            if floor <= 1 && ceiling >= 1 {
-                for target in &unique {
-                    actions.push(candidate(
-                        GameAction::SelectTargets {
-                            targets: vec![target.clone()],
-                        },
-                        TacticalClass::Selection,
-                        Some(*player),
-                    ));
-                }
-            } else if floor < ceiling {
-                actions.push(candidate(
-                    GameAction::SelectTargets {
-                        targets: unique[..floor].to_vec(),
-                    },
-                    TacticalClass::Selection,
-                    Some(*player),
-                ));
-            }
-            actions
+                )
+            })
+            .collect()
         }
         // CR 701.36a: Populate — choose a creature token to copy.
         WaitingFor::PopulateChoice {
@@ -5822,6 +5798,13 @@ mod tests {
             .collect();
         assert!(selections.iter().any(|targets| targets.is_empty()));
         assert!(selections.iter().any(|targets| targets.len() == 2));
+        assert!(selections.iter().any(|targets| {
+            targets.as_slice()
+                == [
+                    TargetRef::Object(ObjectId(2)),
+                    TargetRef::Object(ObjectId(3)),
+                ]
+        }));
         assert!(selections.iter().all(|targets| {
             targets.len() <= 2
                 && targets

--- a/crates/engine/src/game/contraptions.rs
+++ b/crates/engine/src/game/contraptions.rs
@@ -170,6 +170,8 @@ pub fn perform_contraption_upkeep_turn_based_action(
     state.waiting_for = WaitingFor::ChooseObjectsSelection {
         player,
         eligible,
+        min: 0,
+        max: None,
         trigger_event: None,
     };
     let _ = events;

--- a/crates/engine/src/game/effects/choose_objects_into_tracked_set.rs
+++ b/crates/engine/src/game/effects/choose_objects_into_tracked_set.rs
@@ -60,6 +60,14 @@ pub fn resolve(
         .map(|&obj_id| TargetRef::Object(obj_id))
         .collect();
 
+    // CR 609.3: If a resolving effect asks for more objects than are
+    // available, the player chooses all that are available. Publish an
+    // achievable runtime range at this trust seam so every consumer (engine,
+    // AI, and client) sees the same liveness-preserving cardinality.
+    let available = u32::try_from(eligible.len()).unwrap_or(u32::MAX);
+    let max = max.map(|maximum| maximum.min(available));
+    let min = min.min(max.unwrap_or(available));
+
     // CR 608.2c: Surface the interactive selection. Even with an empty
     // `eligible` set the prompt is raised — the player's act of submitting an
     // empty selection IS a legal resolution-time choice (CR 608.2d: choosing
@@ -85,7 +93,9 @@ pub fn resolve(
 mod tests {
     use crate::game::scenario::GameScenario;
     use crate::parser::oracle_effect::parse_effect_chain;
-    use crate::types::ability::AbilityKind;
+    use crate::types::ability::{
+        AbilityDefinition, AbilityKind, Effect, TargetFilter, TypedFilter,
+    };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
     use crate::types::game_state::WaitingFor;
@@ -96,6 +106,51 @@ mod tests {
 
     const P0: PlayerId = PlayerId(0);
     const P1: PlayerId = PlayerId(1);
+
+    #[test]
+    fn required_choice_clamps_to_the_objects_that_exist() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let required_choice = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::ChooseObjectsIntoTrackedSet {
+                chooser: TargetFilter::Controller,
+                filter: TargetFilter::Typed(TypedFilter::creature()),
+                min: 2,
+                max: Some(2),
+            },
+        );
+        let host = {
+            let mut builder = scenario.add_artifact_from_oracle(P0, "Required Choice Host", "");
+            builder.with_ability_definition(required_choice);
+            builder.id()
+        };
+        let only_eligible = scenario
+            .add_creature(P0, "Only Eligible Creature", 1, 1)
+            .id();
+
+        let mut runner = scenario.build();
+        runner
+            .act(GameAction::ActivateAbility {
+                source_id: host,
+                ability_index: 0,
+            })
+            .expect("activate required-choice ability");
+        runner.advance_until_stack_empty();
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::ChooseObjectsSelection {
+                min: 1,
+                max: Some(1),
+                ..
+            }
+        ));
+        runner
+            .act(GameAction::SelectTargets {
+                targets: vec![crate::types::ability::TargetRef::Object(only_eligible)],
+            })
+            .expect("CR 609.3 permits choosing the sole available object");
+    }
 
     /// CR 608.2c + CR 608.2d + official ruling: The Day of the Doctor IV — "Choose
     /// up to three Doctors. You may exile all other creatures." — when the

--- a/crates/engine/src/game/effects/choose_objects_into_tracked_set.rs
+++ b/crates/engine/src/game/effects/choose_objects_into_tracked_set.rs
@@ -21,10 +21,13 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (chooser_filter, filter) = match &ability.effect {
+    let (chooser_filter, filter, min, max) = match &ability.effect {
         Effect::ChooseObjectsIntoTrackedSet {
-            chooser, filter, ..
-        } => (chooser.clone(), filter.clone()),
+            chooser,
+            filter,
+            min,
+            max,
+        } => (chooser.clone(), filter.clone(), *min, *max),
         _ => {
             return Err(EffectError::MissingParam(
                 "ChooseObjectsIntoTrackedSet".to_string(),
@@ -70,6 +73,8 @@ pub fn resolve(
     state.waiting_for = WaitingFor::ChooseObjectsSelection {
         player: chooser,
         eligible,
+        min,
+        max,
         trigger_event: state.current_trigger_event.clone(),
     };
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -12093,6 +12093,8 @@ fn apply_action(
             WaitingFor::ChooseObjectsSelection {
                 player,
                 eligible,
+                min,
+                max,
                 trigger_event,
             },
             GameAction::SelectTargets { targets },
@@ -12100,21 +12102,39 @@ fn apply_action(
             let p = *player;
             let eligible_set = eligible.clone();
             let pending_event = trigger_event.clone();
-            // Validate all selected targets are in the eligible set.
+            let selected_count = targets.len();
+            if selected_count < *min as usize
+                || max.is_some_and(|maximum| selected_count > maximum as usize)
+            {
+                return Err(EngineError::InvalidAction(format!(
+                    "Object selection must choose at least {min}{} distinct objects, got {selected_count}",
+                    max.map_or(String::new(), |maximum| format!(" and at most {maximum}"))
+                )));
+            }
+            // Validate all selected targets are distinct objects in the eligible set.
+            let mut selected_objects = HashSet::with_capacity(selected_count);
             for t in &targets {
                 if !eligible_set.contains(t) {
                     return Err(EngineError::InvalidAction(
                         "Selected target not eligible for object selection".to_string(),
                     ));
                 }
+                let TargetRef::Object(id) = t else {
+                    return Err(EngineError::InvalidAction(
+                        "Object selection accepts battlefield objects only".to_string(),
+                    ));
+                };
+                if !selected_objects.insert(*id) {
+                    return Err(EngineError::InvalidAction(
+                        "Duplicate object in object selection".to_string(),
+                    ));
+                }
             }
-            // Map TargetRef → ObjectId. The eligible set is all battlefield
-            // permanents, so every selected target is an Object.
             let ids: Vec<ObjectId> = targets
                 .iter()
-                .filter_map(|t| match t {
-                    TargetRef::Object(id) => Some(*id),
-                    TargetRef::Player(_) => None,
+                .map(|target| match target {
+                    TargetRef::Object(id) => *id,
+                    TargetRef::Player(_) => unreachable!("validated as objects above"),
                 })
                 .collect();
             // CR 603.7: Always allocate a fresh tracked set — a player-chosen

--- a/crates/engine/src/game/interaction.rs
+++ b/crates/engine/src/game/interaction.rs
@@ -9930,13 +9930,13 @@ mod tests {
                 TargetRef::Object(ObjectId(3)),
             ],
             min: 1,
-            max: Some(2),
+            max: Some(4),
             trigger_event: None,
         };
         let projection = target_sequence_projection(&waiting)
             .expect("projection must succeed")
             .expect("choose-objects is a target sequence");
-        assert_eq!((projection.min, projection.max), (1, 2));
+        assert_eq!((projection.min, projection.max), (1, 3));
         assert!(projection.unique);
     }
 

--- a/crates/engine/src/game/interaction.rs
+++ b/crates/engine/src/game/interaction.rs
@@ -1271,10 +1271,15 @@ fn target_sequence_projection(
             action: TargetSequenceAction::SelectObjects,
             intent: InteractionIntentCode::Choose,
         },
-        WaitingFor::ChooseObjectsSelection { eligible, .. } => TargetSequenceProjection {
+        WaitingFor::ChooseObjectsSelection {
+            eligible, min, max, ..
+        } => TargetSequenceProjection {
             candidates: eligible.clone(),
-            min: 0,
-            max: eligible.len(),
+            min: *min as usize,
+            max: max
+                .map(|maximum| maximum as usize)
+                .unwrap_or(eligible.len())
+                .min(eligible.len()),
             unique: true,
             action: TargetSequenceAction::SelectTargets,
             intent: InteractionIntentCode::Choose,
@@ -9909,6 +9914,26 @@ pub fn submit_interaction(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn choose_objects_projection_preserves_runtime_cardinality() {
+        let waiting = WaitingFor::ChooseObjectsSelection {
+            player: PlayerId(0),
+            eligible: vec![
+                TargetRef::Object(ObjectId(1)),
+                TargetRef::Object(ObjectId(2)),
+                TargetRef::Object(ObjectId(3)),
+            ],
+            min: 1,
+            max: Some(2),
+            trigger_event: None,
+        };
+        let projection = target_sequence_projection(&waiting)
+            .expect("projection must succeed")
+            .expect("choose-objects is a target sequence");
+        assert_eq!((projection.min, projection.max), (1, 2));
+        assert!(projection.unique);
+    }
 
     /// F4 — the preview's entry list is budgeted like every other outbound list on the
     /// shortcut spec.

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -14702,6 +14702,121 @@ fn parse_balance_arm_c(input: &str) -> OracleResult<'_, Vec<(EqualizeVerb, Targe
     Ok((input, pairs))
 }
 
+/// CR 608.2c/d + CR 701.8a: Whole-body recognizer for the battlefield
+/// "Choose up to N <permanents>, [then] destroy the rest" class (Duneblast,
+/// Mount Doom). The choice is made during resolution, so it publishes the
+/// spared objects into the chain's tracked set; the following mass destruction
+/// applies to the same typed battlefield filter minus that set.
+fn parse_choose_survivors_destroy_rest_ir(
+    text: &str,
+    kind: AbilityKind,
+    ctx: &ParseContext,
+) -> Option<EffectChainIr> {
+    let lower = text.to_ascii_lowercase();
+    let (max, after_count) = nom_on_lower(text, &lower, |input| {
+        let (input, _) = tag("choose up to ").parse(input)?;
+        let (input, max) = nom_primitives::parse_number.parse(input)?;
+        let (input, _) = space1.parse(input)?;
+        Ok((input, max))
+    })?;
+    let after_count_lower = &lower[lower.len() - after_count.len()..];
+
+    #[derive(Clone, Copy)]
+    enum DestroyRestConnector {
+        Then,
+        Sentence,
+    }
+
+    let ((filter_len, connector), _) = nom_on_lower(after_count, after_count_lower, |input| {
+        let (input, (filter, connector)) = alt((
+            map(
+                terminated(
+                    take_until(", then destroy the rest"),
+                    tag(", then destroy the rest"),
+                ),
+                |filter: &str| (filter, DestroyRestConnector::Then),
+            ),
+            map(
+                terminated(take_until(". destroy the rest"), tag(". destroy the rest")),
+                |filter: &str| (filter, DestroyRestConnector::Sentence),
+            ),
+        ))
+        .parse(input)?;
+        let (input, _) = opt(tag(".")).parse(input)?;
+        let (input, _) = eof.parse(input)?;
+        Ok((input, (filter.len(), connector)))
+    })?;
+
+    let filter_text = after_count.get(..filter_len)?.trim();
+    let mut filter_ctx = ctx.clone();
+    let filter = parse_choose_object_selection_filter(filter_text, &mut filter_ctx)?;
+    let TargetFilter::Typed(mut destroy_filter) = filter.clone() else {
+        return None;
+    };
+    destroy_filter.properties.push(FilterProp::Not {
+        prop: Box::new(FilterProp::InTrackedSet {
+            id: TrackedSetId(0),
+        }),
+    });
+
+    let prefix_len = text.len().checked_sub(after_count.len())?;
+    let choose_end = prefix_len.checked_add(filter_len)?;
+    let connector_prefix = match connector {
+        DestroyRestConnector::Then => ", then ",
+        DestroyRestConnector::Sentence => ". ",
+    };
+    let destroy_start = choose_end.checked_add(connector_prefix.len())?;
+    let destroy_end = destroy_start.checked_add("destroy the rest".len())?;
+    let choose_source = text.get(..choose_end)?;
+    let destroy_source = text.get(destroy_start..destroy_end)?;
+
+    let mut builder = ClauseIrBuilder::new(text);
+    builder
+        .clause(
+            choose_source,
+            parsed_clause(Effect::ChooseObjectsIntoTrackedSet {
+                chooser: TargetFilter::Controller,
+                filter,
+                min: 0,
+                max: Some(max),
+            }),
+            Some(match connector {
+                DestroyRestConnector::Then => ClauseBoundary::Then,
+                DestroyRestConnector::Sentence => ClauseBoundary::Sentence,
+            }),
+            ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        )
+        .push();
+    builder
+        .clause(
+            destroy_source,
+            parsed_clause(Effect::DestroyAll {
+                target: TargetFilter::Typed(destroy_filter),
+                cant_regenerate: false,
+            }),
+            None,
+            ClauseDisposition::Emit {
+                followup: None,
+                intrinsic: None,
+            },
+        )
+        .push();
+
+    Some(EffectChainIr {
+        clauses: builder.finish(),
+        kind,
+        continuation_kind: Some(kind),
+        player_scope_rewrite: PlayerScopeRewrite::Apply,
+        chain_rounding: None,
+        actor: ctx.actor.clone(),
+        in_trigger: ctx.in_trigger,
+        repeat_until: None,
+    })
+}
+
 /// CR 107.1 + CR 608.2e: Whole-chain recognizer for the Balance equalization
 /// class (Balance, Restore Balance, Balancing Act).
 ///
@@ -31192,6 +31307,9 @@ pub(crate) fn parse_effect_chain_ir(
     kind: AbilityKind,
     ctx: &mut ParseContext,
 ) -> EffectChainIr {
+    if let Some(ir) = parse_choose_survivors_destroy_rest_ir(text, kind, ctx) {
+        return ir;
+    }
     if let Some(ir) = parse_grant_graveyard_keyword_to_target_ir(text, kind, ctx) {
         return ir;
     }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -52835,27 +52835,34 @@ fn mount_doom_lowers_choose_two_then_destroy_rest() {
         &mut ParseContext::default(),
     );
 
-    assert!(matches!(
-        def.effect.as_ref(),
-        Effect::ChooseObjectsIntoTrackedSet {
-            chooser: TargetFilter::Controller,
-            min: 0,
-            max: Some(2),
-            ..
-        }
-    ));
-    assert!(matches!(
-        def.sub_ability.as_deref().map(|sub| sub.effect.as_ref()),
-        Some(Effect::DestroyAll {
-            target: TargetFilter::Typed(tf),
-            ..
-        }) if tf.type_filters.contains(&TypeFilter::Creature)
-            && tf.properties.iter().any(|prop| matches!(
-                prop,
-                FilterProp::Not { prop }
-                    if matches!(**prop, FilterProp::InTrackedSet { .. })
-            ))
-    ));
+    let Effect::ChooseObjectsIntoTrackedSet {
+        chooser,
+        filter,
+        min,
+        max,
+    } = def.effect.as_ref()
+    else {
+        panic!("expected tracked-set survivor choice, got {:?}", def.effect);
+    };
+    assert_eq!(*chooser, TargetFilter::Controller);
+    assert_eq!((*min, *max), (0, Some(2)));
+    assert_eq!(*filter, TargetFilter::Typed(TypedFilter::creature()));
+
+    let destroy = def
+        .sub_ability
+        .as_deref()
+        .expect("survivor choice must be followed by destroy-rest");
+    let Effect::DestroyAll { target, .. } = destroy.effect.as_ref() else {
+        panic!("expected DestroyAll continuation, got {:?}", destroy.effect);
+    };
+    assert_eq!(
+        *target,
+        TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::Not {
+            prop: Box::new(FilterProp::InTrackedSet {
+                id: TrackedSetId(0),
+            }),
+        }]))
+    );
     assert!(!ability_chain_has_unimplemented(&def));
 }
 

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -52784,6 +52784,81 @@ fn expose_the_culprit_mode2_lowers_to_choose_shuffle_cloak_chain() {
     );
 }
 
+/// CR 608.2c/d + CR 701.8a: Duneblast's untargeted resolution choice publishes
+/// the creature(s) spared by the controller, then destroys every other creature.
+#[test]
+fn duneblast_lowers_choose_survivor_then_destroy_rest() {
+    let def = parse_effect_chain_with_context(
+        "Choose up to one creature. Destroy the rest.",
+        AbilityKind::Spell,
+        &mut ParseContext::default(),
+    );
+
+    let Effect::ChooseObjectsIntoTrackedSet {
+        chooser,
+        filter,
+        min,
+        max,
+    } = def.effect.as_ref()
+    else {
+        panic!("expected tracked-set survivor choice, got {:?}", def.effect);
+    };
+    assert_eq!(*chooser, TargetFilter::Controller);
+    assert_eq!((*min, *max), (0, Some(1)));
+    assert_eq!(*filter, TargetFilter::Typed(TypedFilter::creature()));
+
+    let destroy = def
+        .sub_ability
+        .as_deref()
+        .expect("survivor choice must be followed by destroy-rest");
+    let Effect::DestroyAll { target, .. } = destroy.effect.as_ref() else {
+        panic!("expected DestroyAll continuation, got {:?}", destroy.effect);
+    };
+    assert_eq!(
+        *target,
+        TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::Not {
+            prop: Box::new(FilterProp::InTrackedSet {
+                id: TrackedSetId(0),
+            }),
+        }]))
+    );
+    assert!(!ability_chain_has_unimplemented(&def));
+}
+
+/// Same grammar class as Duneblast, with a comma/"then" connector and a
+/// different upper bound. This is the exact Mount Doom ability body.
+#[test]
+fn mount_doom_lowers_choose_two_then_destroy_rest() {
+    let def = parse_effect_chain_with_context(
+        "Choose up to two creatures, then destroy the rest.",
+        AbilityKind::Activated,
+        &mut ParseContext::default(),
+    );
+
+    assert!(matches!(
+        def.effect.as_ref(),
+        Effect::ChooseObjectsIntoTrackedSet {
+            chooser: TargetFilter::Controller,
+            min: 0,
+            max: Some(2),
+            ..
+        }
+    ));
+    assert!(matches!(
+        def.sub_ability.as_deref().map(|sub| sub.effect.as_ref()),
+        Some(Effect::DestroyAll {
+            target: TargetFilter::Typed(tf),
+            ..
+        }) if tf.type_filters.contains(&TypeFilter::Creature)
+            && tf.properties.iter().any(|prop| matches!(
+                prop,
+                FilterProp::Not { prop }
+                    if matches!(**prop, FilterProp::InTrackedSet { .. })
+            ))
+    ));
+    assert!(!ability_chain_has_unimplemented(&def));
+}
+
 /// The legacy bypass exposed the pile/shuffle/cloak recognizer only to the
 /// WithContext entry point. U3c routes it through `AbilityIr`, but retains that
 /// entry-point gate rather than making die-result (`Standalone`) callers newly

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -13081,14 +13081,20 @@ pub enum WaitingFor {
         phase: TimeTravelPhase,
     },
     /// CR 603.7e: The affected player of a `ChooseObjectsIntoTrackedSet` effect
-    /// selects any number of battlefield permanents from `eligible`. The
+    /// selects `min..=max` battlefield permanents from `eligible`. The
     /// chosen objects are written into a fresh tracked set so a downstream
     /// `PayCost { ScaledMana }` and `IfYouDo`/`Untap` reference the exact
-    /// selection. An empty selection is legal — the player declines.
+    /// selection. An empty selection is legal when `min == 0`.
     ChooseObjectsSelection {
         player: PlayerId,
         /// Eligible battlefield permanents matching the effect's filter.
         eligible: Vec<TargetRef>,
+        /// Minimum number of distinct eligible objects that must be selected.
+        #[serde(default)]
+        min: u32,
+        /// Maximum number selectable (`None` = all eligible objects).
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        max: Option<u32>,
         /// CR 608.2: triggering event of the ability whose `ChooseObjectsIntoTrackedSet`
         /// raised this prompt. Restored around the continuation drain so the stashed
         /// `PayCost { payer: TriggeringPlayer }` resolves to the correct player.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -31522,6 +31522,39 @@ mod tests {
     }
 
     #[test]
+    fn choose_objects_selection_serializes_bounds_and_defaults_legacy_shape() {
+        use crate::types::ability::TargetRef;
+
+        let waiting = WaitingFor::ChooseObjectsSelection {
+            player: PlayerId(0),
+            eligible: vec![TargetRef::Object(ObjectId(1))],
+            min: 1,
+            max: Some(2),
+            trigger_event: None,
+        };
+        let json = serde_json::to_value(&waiting).expect("serialize bounded prompt");
+        assert_eq!(json["data"]["min"], 1);
+        assert_eq!(json["data"]["max"], 2);
+        assert_eq!(
+            serde_json::from_value::<WaitingFor>(json).expect("roundtrip bounded prompt"),
+            waiting
+        );
+
+        let legacy = r#"{
+            "type":"ChooseObjectsSelection",
+            "data":{"player":0,"eligible":[]}
+        }"#;
+        assert!(matches!(
+            serde_json::from_str::<WaitingFor>(legacy).expect("legacy prompt remains parseable"),
+            WaitingFor::ChooseObjectsSelection {
+                min: 0,
+                max: None,
+                ..
+            }
+        ));
+    }
+
+    #[test]
     fn crew_vehicle_legacy_missing_contributions_deserializes() {
         let json = r#"{
             "type":"CrewVehicle",

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -13085,7 +13085,7 @@ pub enum WaitingFor {
         eligible: Vec<TargetRef>,
         phase: TimeTravelPhase,
     },
-    /// CR 603.7e: The affected player of a `ChooseObjectsIntoTrackedSet` effect
+    /// CR 608.2d: While applying `ChooseObjectsIntoTrackedSet`, the affected player
     /// selects `min..=max` battlefield permanents from `eligible`. The
     /// chosen objects are written into a fresh tracked set so a downstream
     /// `PayCost { ScaledMana }` and `IfYouDo`/`Untap` reference the exact

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -887,6 +887,7 @@ mod mole_man_moloid_optional_mill;
 mod morbid_curiosity_cost_paid_mana_value_draw;
 mod morkrut_ashaya_self_sacrifice;
 mod morophon_chosen_type_1653;
+mod mount_doom_destroy_rest;
 mod mr_foxglove_defending_hand_minus_yours_draw;
 mod ms_marvel_power_exceeds_base;
 mod msh_wave5a_group1_classifier;

--- a/crates/engine/tests/integration/mount_doom_destroy_rest.rs
+++ b/crates/engine/tests/integration/mount_doom_destroy_rest.rs
@@ -1,0 +1,210 @@
+//! Mount Doom's final ability — resolution-time survivor choice followed by a
+//! battlefield wipe of the remaining creatures.
+//!
+//! CR 608.2c/d: the controller chooses the spared creatures while resolving.
+//! CR 701.8a: every other creature is destroyed and moves to its graveyard.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::ability::{
+    AbilityDefinition, AbilityKind, Effect, TargetFilter, TargetRef, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const DESTROY_REST_ORACLE: &str = "Choose up to two creatures, then destroy the rest.";
+
+struct MountDoomPrompt {
+    runner: GameRunner,
+    creatures: [ObjectId; 4],
+    noncreature: ObjectId,
+}
+
+fn mount_doom_prompt() -> MountDoomPrompt {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let spared_own = scenario.add_creature(P0, "Spared Own", 2, 2).id();
+    let destroyed_own = scenario.add_creature(P0, "Destroyed Own", 2, 2).id();
+    let spared_opponent = scenario.add_creature(P1, "Spared Opponent", 2, 2).id();
+    let destroyed_opponent = scenario.add_creature(P1, "Destroyed Opponent", 2, 2).id();
+    let noncreature = scenario
+        .add_artifact_from_oracle(P0, "Unaffected Artifact", "")
+        .id();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Mount Doom Test", false, DESTROY_REST_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&spell].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: spell,
+            card_id,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("cast the destroy-rest spell");
+    runner.advance_until_stack_empty();
+
+    let WaitingFor::ChooseObjectsSelection {
+        min, max, eligible, ..
+    } = &runner.state().waiting_for
+    else {
+        panic!("resolution must pause for the untargeted survivor choice");
+    };
+    assert_eq!((*min, *max), (0, Some(2)));
+    assert_eq!(eligible.len(), 4);
+
+    MountDoomPrompt {
+        runner,
+        creatures: [
+            spared_own,
+            destroyed_own,
+            spared_opponent,
+            destroyed_opponent,
+        ],
+        noncreature,
+    }
+}
+
+#[test]
+fn mount_doom_rejects_three_then_accepts_two_distinct_survivors() {
+    let MountDoomPrompt {
+        mut runner,
+        creatures: [spared_own, destroyed_own, spared_opponent, destroyed_opponent],
+        noncreature,
+    } = mount_doom_prompt();
+
+    let over_max = runner.act(GameAction::SelectTargets {
+        targets: vec![
+            TargetRef::Object(spared_own),
+            TargetRef::Object(spared_opponent),
+            TargetRef::Object(destroyed_own),
+        ],
+    });
+    assert!(
+        over_max.is_err(),
+        "three choices must be rejected when max is two"
+    );
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ChooseObjectsSelection { .. }
+    ));
+
+    runner
+        .act(GameAction::SelectTargets {
+            targets: vec![
+                TargetRef::Object(spared_own),
+                TargetRef::Object(spared_opponent),
+            ],
+        })
+        .expect("choose the two creatures to spare");
+    runner.advance_until_stack_empty();
+
+    for id in [spared_own, spared_opponent, noncreature] {
+        assert_eq!(
+            runner.state().objects.get(&id).map(|object| object.zone),
+            Some(Zone::Battlefield),
+            "chosen creatures and noncreature permanents must survive"
+        );
+    }
+    for id in [destroyed_own, destroyed_opponent] {
+        assert_eq!(
+            runner.state().objects.get(&id).map(|object| object.zone),
+            Some(Zone::Graveyard),
+            "each unchosen creature must be destroyed"
+        );
+    }
+}
+
+#[test]
+fn mount_doom_rejects_duplicate_then_accepts_zero_survivors() {
+    let MountDoomPrompt {
+        mut runner,
+        creatures,
+        noncreature,
+    } = mount_doom_prompt();
+
+    let duplicate = runner.act(GameAction::SelectTargets {
+        targets: vec![
+            TargetRef::Object(creatures[0]),
+            TargetRef::Object(creatures[0]),
+        ],
+    });
+    assert!(
+        duplicate.is_err(),
+        "the same object cannot fill two choice slots"
+    );
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ChooseObjectsSelection { .. }
+    ));
+
+    runner
+        .act(GameAction::SelectTargets { targets: vec![] })
+        .expect("zero survivors is legal for an up-to-two choice");
+    runner.advance_until_stack_empty();
+
+    for id in creatures {
+        assert_eq!(
+            runner.state().objects.get(&id).map(|object| object.zone),
+            Some(Zone::Graveyard),
+            "choosing zero must destroy every creature"
+        );
+    }
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&noncreature)
+            .map(|object| object.zone),
+        Some(Zone::Battlefield)
+    );
+}
+
+#[test]
+fn choose_objects_runtime_rejects_fewer_than_required_minimum() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let required_choice = AbilityDefinition::new(
+        AbilityKind::Activated,
+        Effect::ChooseObjectsIntoTrackedSet {
+            chooser: TargetFilter::Controller,
+            filter: TargetFilter::Typed(TypedFilter::creature()),
+            min: 1,
+            max: Some(2),
+        },
+    );
+    let host = {
+        let mut builder = scenario.add_creature(P0, "Required Choice Host", 1, 1);
+        builder.with_ability_definition(required_choice);
+        builder.id()
+    };
+    scenario.add_creature(P0, "Eligible Creature", 1, 1);
+
+    let mut runner = scenario.build();
+    runner
+        .act(GameAction::ActivateAbility {
+            source_id: host,
+            ability_index: 0,
+        })
+        .expect("activate required-choice ability");
+    runner.advance_until_stack_empty();
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ChooseObjectsSelection {
+            min: 1,
+            max: Some(2),
+            ..
+        }
+    ));
+    assert!(
+        runner
+            .act(GameAction::SelectTargets { targets: vec![] })
+            .is_err(),
+        "an empty selection must be rejected when min is one"
+    );
+}

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -43,6 +43,11 @@ pub enum ServerErrorCode {
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
 ///
+/// 37 — `WaitingFor::ChooseObjectsSelection` publishes the resolving effect's
+///      `min` and optional `max` bounds. Older clients parse and silently
+///      ignore these additive fields, then offer selections outside the
+///      engine-authoritative range; refuse that capability mismatch at the
+///      full-game handshake. Lobby messages are unchanged.
 /// 36 — `WaitingFor::ChooseDungeon::options` changed from `Vec<DungeonId>` to
 ///      `Vec<DungeonPreview>`, and `WaitingFor::ChooseDungeonRoom` dropped
 ///      `option_names`, gained a required `dungeon_name`, and changed `options`
@@ -119,7 +124,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 36;
+pub const PROTOCOL_VERSION: u32 = 37;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake **from clients that predate [`LOBBY_PROTOCOL_VERSION`]** — the
@@ -527,12 +532,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 36);
+        assert_eq!(PROTOCOL_VERSION, 37);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot
         // understand a success acknowledgment the submitting client awaits.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 35);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 36);
     }
 
     #[test]

--- a/crates/phase-ai/src/search.rs
+++ b/crates/phase-ai/src/search.rs
@@ -1961,10 +1961,12 @@ pub fn fallback_action(
         }
         WaitingFor::AssistPayment { .. } => Some(GameAction::CommitAssistPayment { generic: 0 }),
 
-        // ChooseObjectsIntoTrackedSet: default to declining (empty selection).
-        WaitingFor::ChooseObjectsSelection { .. } => Some(GameAction::SelectTargets {
-            targets: Vec::new(),
-        }),
+        // ChooseObjectsIntoTrackedSet: take an engine-issued selection. This
+        // preserves the empty conservative choice when min is zero and remains
+        // live for required choices where an empty selection is illegal.
+        WaitingFor::ChooseObjectsSelection { .. } => {
+            issued(|action| matches!(action, GameAction::SelectTargets { .. }))
+        }
 
         // CR 101.4 + CR 707.2: EachPlayerCopyChosen selection — an empty pick is
         // illegal (min >= 1), so pick the first `min` eligible objects.
@@ -12856,6 +12858,45 @@ mod tests {
             Some(GameAction::SelectCards { cards: Vec::new() }),
             "an `up_to` prompt legally admits nothing, and the conservative pick \
              is still nothing"
+        );
+    }
+
+    #[test]
+    fn choose_objects_fallback_uses_an_issued_required_selection() {
+        let mut state = make_state();
+        let ai = P0;
+        let first = create_object(
+            &mut state,
+            CardId(90_001),
+            ai,
+            "First required choice".to_string(),
+            Zone::Battlefield,
+        );
+        let second = create_object(
+            &mut state,
+            CardId(90_002),
+            ai,
+            "Second required choice".to_string(),
+            Zone::Battlefield,
+        );
+        state.waiting_for = WaitingFor::ChooseObjectsSelection {
+            player: ai,
+            eligible: vec![TargetRef::Object(first), TargetRef::Object(second)],
+            min: 1,
+            max: Some(2),
+            trigger_event: None,
+        };
+
+        let contract = AiDecisionContract::issue(&state, ai);
+        let action = fallback_action_default(&state)
+            .expect("a required object choice must have a live fallback");
+        assert!(matches!(
+            &action,
+            GameAction::SelectTargets { targets } if !targets.is_empty()
+        ));
+        assert!(
+            contract.contains_action(&state, &action),
+            "fallback must return an engine-issued legal action"
         );
     }
 

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -2398,8 +2398,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_36() {
-        assert_eq!(PROTOCOL_VERSION, 36);
+    fn protocol_version_is_37() {
+        assert_eq!(PROTOCOL_VERSION, 37);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -2409,7 +2409,7 @@ mod tests {
     /// understand.
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
-    /// this guards — and this test reds while `protocol_version_is_36` stays
+    /// this guards — and this test reds while `protocol_version_is_37` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 36;
+const EXPECTED_PROTOCOL_VERSION = 37;
 // The LOBBY message-set version. Deliberately separate from the full-game
 // number above and deliberately NOT derived from it: a GameState-only bump must
 // not move the lobby's compatibility window. See the assertions at the bottom.
@@ -14,7 +14,7 @@ const EXPECTED_LOBBY_PROTOCOL_VERSION = 1;
 // here, so a full-game bump could ship with an unbumped P2P version and CI
 // stayed green — a v(n-1) host and a v(n) guest would then complete a
 // handshake and only fail when the incompatible payload arrived.
-const EXPECTED_WIRE_PROTOCOL_VERSION = 27;
+const EXPECTED_WIRE_PROTOCOL_VERSION = 28;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);


### PR DESCRIPTION
## Summary

Closes #7432 by adding a general typed mid-resolution choice for “choose up to N [objects], then [act on] the rest”, and uses it to parse and resolve Mount Doom (and the same Duneblast class) correctly. The selected-object bounds are enforced by the engine and carried through AI, transport, and client selection UX.

## Files changed

- `client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts` — verifies bounded choice data crosses the P2P adapter.
- `client/src/adapter/types.ts` — exposes typed minimum/maximum choice bounds.
- `client/src/adapter/ws-adapter.ts` — maps bounded choice data from the wire.
- `client/src/components/modal/ProliferateModal.tsx` — supports legal bounded selection, including exact-count reselection.
- `client/src/components/modal/__tests__/ProliferateModal.test.tsx` — covers minimum, maximum, and exact-count alternative subsets.
- `client/src/network/__tests__/protocol.test.ts` — updates protocol-version expectations.
- `client/src/network/protocol.ts` — bumps the full and P2P protocol versions for the wire change.
- `client/src/viewmodel/__tests__/gameStateView.test.ts` — updates the bounded waiting-state fixture.
- `crates/engine/src/ai_support/candidates.rs` — enumerates legal bounded unique choice subsets.
- `crates/engine/src/game/contraptions.rs` — preserves the existing unbounded contraption choice semantics.
- `crates/engine/src/game/effects/choose_objects_into_tracked_set.rs` — resolves and publishes the bounded object choice.
- `crates/engine/src/game/engine.rs` — validates cardinality, uniqueness, and eligibility at the action authority.
- `crates/engine/src/game/interaction.rs` — carries typed bounds in the pending interaction.
- `crates/engine/src/parser/oracle_effect/mod.rs` — parses the choose-survivors/destroy-rest class with nom combinators.
- `crates/engine/src/parser/oracle_effect/tests.rs` — snapshots Mount Doom and Duneblast AST shape.
- `crates/engine/src/types/game_state.rs` — serializes bounded waiting-state fields.
- `crates/engine/tests/integration/main.rs` — registers the Mount Doom runtime suite.
- `crates/engine/tests/integration/mount_doom_destroy_rest.rs` — tests legal 0/2 picks and hostile over-max/duplicate submissions.
- `crates/lobby-broker/src/protocol.rs` — updates lobby protocol fixtures for the wire revision.
- `crates/phase-ai/src/search.rs` — chooses an engine-issued legal fallback when the minimum is nonzero.
- `crates/server-core/src/protocol.rs` — bumps the server full-protocol version.
- `scripts/check-protocol-version.mjs` — updates the synchronized protocol-version assertion.

## Track

Developer

## LLM

Model: OpenAI Codex (GPT-5 family; exact deployment model not exposed)
Tier: Frontier
Thinking: not exposed by runtime

## Implementation method (required)

Method: /engine-implementer

## CR references

CR 608.2c, CR 608.2d, CR 609.3, CR 701.8a.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- Targeted parser, resolver, authority, AI, and protocol Rust tests — PASS.
- Frontend targeted Vitest matrix — 203/203 PASS; TypeScript typecheck, protocol check, and changed-file ESLint PASS.
- `cargo fmt --all -- --check` — PASS.
- strict workspace clippy, single build job — PASS.
- workspace tests — 22,195 unit-lib PASS (14 ignored), 212 unit-bin PASS, and 5,630 integration PASS (42 ignored) before two unrelated Windows-only `probe-pin` failures. Both exact failures reproduce unchanged on a detached clean `06d9d970` base; this PR changes no `crates/probe-pin` path. See Validation Failures.
- `cargo test --doc` — PASS across all 8 targets (7 engine examples intentionally ignored).
- card-data generator — PASS: 35,009 cards / 35,798 faces; 32,175 fully implemented (91.9%); no generated-data diff.
- official coverage gate — PASS: 31,822/35,798 overall (88.9%); commander 30,142/32,629 (92.4%).
- semantic audit — PASS: 32,785 audited; 269 pre-existing findings; no Mount Doom or Duneblast finding.
- HOC coverage after regeneration — 114/117 (97.435897%); Mount Doom has zero parse gaps.

## Gate A

Gate A PASS head=2133e65ead1784ab4ce2b00df247939d84eb53df base=06d9d970508b265d50bb5732706680456be2fded

## Gate G

Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)

## Anchored on

- `crates/engine/src/parser/oracle_effect/mod.rs:14829` — existing whole-chain nom recognizer using `nom_on_lower`, `eof`, and typed clause construction.
- `crates/engine/src/game/effects/choose_and_sacrifice_rest.rs:434` — existing CR 609.3 trust-seam clamp when fewer eligible objects exist than the required choice.
- `crates/engine/src/ai_support/candidates.rs:1452` — existing capped bounded-combination generation for legal selection subsets.
- `crates/engine/src/game/effects/choose_from_zone.rs:830` — existing fresh tracked-set publication for a resolution-time player choice.

## Final review-impl

Final review-impl PASS head=2133e65ead1784ab4ce2b00df247939d84eb53df

## Claimed parse impact

- Mount Doom
- Duneblast

## Scope Expansion

The confirmed issue identifies a missing mid-resolution choice primitive. Implementing that class safely required carrying its cardinality through the shared waiting state, engine authority, AI candidates/fallback, serialized transport, and client selector. Full protocol 36→37 and P2P protocol 27→28 are intentional wire-compatibility bumps. No card-name special case is used.

## Validation Failures

On Windows, the workspace run reaches two unrelated `crates/probe-pin` failures: `path_keys_cannot_escape_the_scratch_dir` (`StripPrefixError`) and `proj_missing` (attempts to execute a `.sh` file as Win32, OS error 193). The exact two tests fail identically on a clean detached `06d9d970` worktree under the same environment, and this PR has no `crates/probe-pin` diff. All HOC/parser/runtime/AI/frontend/protocol tests and doc tests pass.

## CI Failures

None; upstream CI has not run yet.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for bounded object selections with minimum and maximum choices.
  * Improved “choose up to” effects, preserving selected permanents while destroying the rest.
  * Added aggregate, fixed-count, and variable-count creature-tapping costs.

* **Bug Fixes**
  * Prevented invalid selections, duplicates, and player targets.
  * Improved fallback choices when selections are required.
  * Updated selection controls to enforce valid limits and confirmation rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->