### PR TITLE
Add Cloak and Dagger, Entwined

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -3162,6 +3162,9 @@ fn legacy_effect(x: &Effect) -> bool {
                         legacy_target_filter(f)
                     }
                     crate::types::ability::EachDamageRecipient::EachController => false,
+                    crate::types::ability::EachDamageRecipient::OtherBatchSource {
+                        source_filters,
+                    } => source_filters.iter().any(|filter| legacy_target_filter(filter)),
                 }
         }
         Effect::ChooseCounterKind { target } => legacy_target_filter(target),
@@ -4466,10 +4469,11 @@ fn rw_effect(
             p.merge(damage_writes(subject));
             (p, None)
         }
-        // CR 120.1 + CR 608.2c: each object matching `sources` (enumerated on the
-        // battlefield at resolution ⇒ a board membership read) deals `amount` damage.
-        // `Shared` ⇒ target damage_writes; `EachController` ⇒ each source's controller
-        // takes life loss (CR 120.3a).
+        // CR 120.1 + CR 608.2c: each object matching `sources` (or each legal
+        // member of a typed announced pair) deals `amount` damage. `Shared` ⇒
+        // target damage_writes; `EachController` ⇒ each source's controller
+        // takes life loss; `OtherBatchSource` ⇒ both slot filters are board
+        // reads and the reciprocal objects are damage writes.
         Effect::EachSourceDealsDamage {
             sources,
             amount,
@@ -4479,6 +4483,15 @@ fn rw_effect(
             p.merge(match recipient {
                 crate::types::ability::EachDamageRecipient::Shared(filter) => damage_writes(filter),
                 crate::types::ability::EachDamageRecipient::EachController => life_writes(),
+                crate::types::ability::EachDamageRecipient::OtherBatchSource {
+                    source_filters,
+                } => {
+                    let mut pair = damage_writes(&TargetFilter::ParentTarget);
+                    for filter in source_filters {
+                        pair.merge(board_membership_read(filter));
+                    }
+                    pair
+                }
             });
             p.merge(rw_quantity_expr(amount));
             (p, None)

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -496,8 +496,16 @@ fn scan_effect(x: &Effect, mode: ScanMode) -> Axes {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(sources, target_ctx, mode));
             acc = acc.or(scan_quantity_expr(amount, mode));
-            if let EachDamageRecipient::Shared(filter) = recipient {
-                acc = acc.or(scan_target_filter(filter, target_ctx, mode));
+            match recipient {
+                EachDamageRecipient::Shared(filter) => {
+                    acc = acc.or(scan_target_filter(filter, target_ctx, mode));
+                }
+                EachDamageRecipient::OtherBatchSource { source_filters } => {
+                    for filter in source_filters {
+                        acc = acc.or(scan_target_filter(filter, target_ctx, mode));
+                    }
+                }
+                EachDamageRecipient::EachController => {}
             }
             acc
         }

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -3,8 +3,8 @@ use crate::types::ability::TapStateChange;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AdditionalCost,
     CardTypeSetSource, CastManaSpentMetric, CombatRelationSubject, ControllerRef,
-    CounterMoveSelection, DamageSource, Effect, EffectKind, EffectScope, FilterProp,
-    GameRestriction, ModalChoice, ModalSelectionCondition, ModalSelectionConstraint,
+    CounterMoveSelection, DamageSource, EachDamageRecipient, Effect, EffectKind, EffectScope,
+    FilterProp, GameRestriction, ModalChoice, ModalSelectionCondition, ModalSelectionConstraint,
     MultiTargetSpec, ObjectScope, PlayerFilter, PlayerScope, PtValue, QuantityExpr, QuantityRef,
     ResolvedAbility, RestrictionPlayerScope, SpellContext, SubAbilityLink, TargetChoiceTiming,
     TargetFilter, TargetRef, TriggerDefinition, TypeFilter, TypedFilter,
@@ -1839,6 +1839,7 @@ pub fn assign_targets_in_chain(
             "Unused selected targets".to_string(),
         ));
     }
+    stamp_other_batch_source_targets(ability);
     ability.capture_target_incarnations_recursive(state);
     Ok(())
 }
@@ -1865,8 +1866,51 @@ pub fn assign_selected_slots_in_chain(
             "Unused selected target slots".to_string(),
         ));
     }
+    stamp_other_batch_source_targets(ability);
     ability.capture_target_incarnations_recursive(state);
     Ok(())
+}
+
+/// CR 608.2c + CR 120.1: a pairwise "each of those ... to the other" damage
+/// node has no target slot of its own, but it must retain the exact announced
+/// object pair rather than inherit only the immediately preceding slot.
+/// Uses the two nearest `TargetOnly` producers in this branch. Empty optional
+/// slots remain in the window so older unrelated targets cannot backfill them.
+fn stamp_other_batch_source_targets(ability: &mut ResolvedAbility) {
+    fn visit(ability: &mut ResolvedAbility, recent_slots: &mut Vec<Vec<TargetRef>>) {
+        if matches!(ability.effect, Effect::TargetOnly { .. }) {
+            recent_slots.push(object_targets_only(&ability.targets));
+            if recent_slots.len() > 2 {
+                recent_slots.remove(0);
+            }
+        }
+
+        if matches!(
+            ability.effect,
+            Effect::EachSourceDealsDamage {
+                sources: TargetFilter::ParentTarget,
+                recipient: EachDamageRecipient::OtherBatchSource { .. },
+                ..
+            }
+        ) {
+            ability.targets = if recent_slots.len() == 2 {
+                recent_slots.iter().flatten().cloned().collect()
+            } else {
+                Vec::new()
+            };
+        }
+
+        let branch_slots = recent_slots.clone();
+        if let Some(sub) = ability.sub_ability.as_deref_mut() {
+            visit(sub, recent_slots);
+        }
+        if let Some(other) = ability.else_ability.as_deref_mut() {
+            let mut other_slots = branch_slots;
+            visit(other, &mut other_slots);
+        }
+    }
+
+    visit(ability, &mut Vec::new());
 }
 
 pub fn flatten_targets_in_chain(ability: &ResolvedAbility) -> Vec<TargetRef> {
@@ -11860,73 +11904,288 @@ mod tests {
     }
 
     #[test]
-    fn great_aerie_allows_skipping_both_optional_targets_without_mutation() {
+    fn great_aerie_resolves_every_optional_target_combination() {
+        for (choose_yours, choose_opponents, expected_damage) in [
+            (false, false, [0, 0]),
+            (true, false, [0, 0]),
+            (false, true, [0, 0]),
+            (true, true, [3, 2]),
+        ] {
+            let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+            let source = create_object(
+                &mut state,
+                CardId(1),
+                PlayerId(0),
+                "The Great Aerie".to_string(),
+                Zone::Battlefield,
+            );
+            let yours = create_creature(&mut state, PlayerId(0), CardId(2), "Your Creature");
+            let opponents =
+                create_creature(&mut state, PlayerId(1), CardId(3), "Opponent Creature");
+            for (id, toughness) in [(yours, 2), (opponents, 3)] {
+                let creature = state.objects.get_mut(&id).expect("test creature");
+                creature.power = Some(1);
+                creature.toughness = Some(toughness);
+                creature.base_power = Some(1);
+                creature.base_toughness = Some(toughness);
+            }
+            let parsed = crate::parser::oracle::parse_oracle_text(
+                "Whenever chaos ensues, choose up to one target creature you control and up to one target creature an opponent controls. Each of those creatures deals damage equal to its toughness to the other.",
+                "The Great Aerie",
+                &[],
+                &["Plane".to_string()],
+                &["Tarkir".to_string()],
+            );
+            let definition = parsed
+                .triggers
+                .iter()
+                .find(|trigger| {
+                    matches!(
+                        trigger.mode,
+                        crate::types::triggers::TriggerMode::ChaosEnsues
+                    )
+                })
+                .and_then(|trigger| trigger.execute.as_deref())
+                .expect("Great Aerie chaos trigger");
+            let mut ability = build_resolved_from_def(definition, source, PlayerId(0));
+            let slots = build_target_slots(&state, &ability).expect("two optional target slots");
+
+            assert_eq!(slots.len(), 2);
+            assert!(slots.iter().all(|slot| slot.optional));
+            let progress = begin_target_selection_for_ability(&state, &ability, &slots, &[])
+                .expect("selection starts");
+            let first = choose_yours.then_some(TargetRef::Object(yours));
+            let TargetSelectionAdvance::InProgress(progress) =
+                choose_target_for_ability(&state, &ability, &slots, &[], &progress, first)
+                    .expect("first optional slot resolves")
+            else {
+                panic!("second optional slot remains");
+            };
+            let second = choose_opponents.then_some(TargetRef::Object(opponents));
+            let TargetSelectionAdvance::Complete(selected) =
+                choose_target_for_ability(&state, &ability, &slots, &[], &progress, second)
+                    .expect("second optional slot resolves")
+            else {
+                panic!("two optional slots complete selection");
+            };
+
+            assign_selected_slots_in_chain(&state, &mut ability, &selected)
+                .expect("optional pair assigns without inventing targets");
+            let mut events = Vec::new();
+            crate::game::effects::resolve_ability_chain(&mut state, &ability, &mut events, 0)
+                .expect("Great Aerie target combination must resolve");
+            assert_eq!(
+                [
+                    state.objects[&yours].damage_marked,
+                    state.objects[&opponents].damage_marked,
+                ],
+                expected_damage,
+                "pairwise damage mismatch for choices ({choose_yours}, {choose_opponents})"
+            );
+        }
+    }
+
+    #[test]
+    fn grim_contest_resolves_mandatory_pairwise_damage() {
         let mut state = GameState::new(FormatConfig::standard(), 2, 42);
         let source = create_object(
             &mut state,
             CardId(1),
             PlayerId(0),
-            "The Great Aerie".to_string(),
-            Zone::Battlefield,
+            "Grim Contest".to_string(),
+            Zone::Stack,
         );
         let yours = create_creature(&mut state, PlayerId(0), CardId(2), "Your Creature");
         let opponents = create_creature(&mut state, PlayerId(1), CardId(3), "Opponent Creature");
+        for (id, toughness) in [(yours, 2), (opponents, 4)] {
+            let creature = state.objects.get_mut(&id).expect("test creature");
+            creature.power = Some(1);
+            creature.toughness = Some(toughness);
+            creature.base_power = Some(1);
+            creature.base_toughness = Some(toughness);
+        }
         let parsed = crate::parser::oracle::parse_oracle_text(
-            "Whenever chaos ensues, choose up to one target creature you control and up to one target creature an opponent controls. Each of those creatures deals damage equal to its toughness to the other.",
-            "The Great Aerie",
+            "Choose target creature you control and target creature an opponent controls. Each of those creatures deals damage equal to its toughness to the other.",
+            "Grim Contest",
             &[],
-            &["Plane".to_string()],
-            &["Tarkir".to_string()],
+            &["Sorcery".to_string()],
+            &[],
         );
         let definition = parsed
-            .triggers
-            .iter()
-            .find(|trigger| {
-                matches!(
-                    trigger.mode,
-                    crate::types::triggers::TriggerMode::ChaosEnsues
-                )
-            })
-            .and_then(|trigger| trigger.execute.as_deref())
-            .expect("Great Aerie chaos trigger");
+            .abilities
+            .first()
+            .expect("Grim Contest spell ability");
         let mut ability = build_resolved_from_def(definition, source, PlayerId(0));
-        let slots = build_target_slots(&state, &ability).expect("two optional target slots");
-
+        let slots = build_target_slots(&state, &ability).expect("two mandatory target slots");
         assert_eq!(slots.len(), 2);
-        assert!(slots.iter().all(|slot| slot.optional));
-        let damage_before = [
-            state.objects[&yours].damage_marked,
-            state.objects[&opponents].damage_marked,
-        ];
+        assert!(slots.iter().all(|slot| !slot.optional));
+
         let progress = begin_target_selection_for_ability(&state, &ability, &slots, &[])
             .expect("selection starts");
-        let TargetSelectionAdvance::InProgress(progress) =
-            choose_target_for_ability(&state, &ability, &slots, &[], &progress, None)
-                .expect("skip first optional target")
-        else {
-            panic!("second optional slot remains");
+        let TargetSelectionAdvance::InProgress(progress) = choose_target_for_ability(
+            &state,
+            &ability,
+            &slots,
+            &[],
+            &progress,
+            Some(TargetRef::Object(yours)),
+        )
+        .expect("first mandatory target resolves") else {
+            panic!("second mandatory slot remains");
         };
-        let TargetSelectionAdvance::Complete(selected) =
-            choose_target_for_ability(&state, &ability, &slots, &[], &progress, None)
-                .expect("skip second optional target")
-        else {
-            panic!("both skipped targets complete selection");
+        let TargetSelectionAdvance::Complete(selected) = choose_target_for_ability(
+            &state,
+            &ability,
+            &slots,
+            &[],
+            &progress,
+            Some(TargetRef::Object(opponents)),
+        )
+        .expect("second mandatory target resolves") else {
+            panic!("mandatory pair completes selection");
         };
 
-        assert_eq!(selected, vec![None, None]);
         assign_selected_slots_in_chain(&state, &mut ability, &selected)
-            .expect("both omitted slots must assign without inventing targets");
+            .expect("mandatory pair assigns");
         let mut events = Vec::new();
         crate::game::effects::resolve_ability_chain(&mut state, &ability, &mut events, 0)
-            .expect("Great Aerie must resolve after both optional targets are skipped");
-        assert_eq!(
-            [
-                state.objects[&yours].damage_marked,
-                state.objects[&opponents].damage_marked,
-            ],
-            damage_before,
-            "zero-target resolution must not mutate either creature"
+            .expect("Grim Contest resolves");
+        assert_eq!(state.objects[&yours].damage_marked, 4);
+        assert_eq!(state.objects[&opponents].damage_marked, 2);
+    }
+
+    #[test]
+    fn pairwise_damage_uses_nearest_two_target_producers() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Pairwise Source".to_string(),
+            Zone::Battlefield,
         );
+        let unrelated = create_creature(&mut state, PlayerId(0), CardId(2), "Unrelated");
+        let first = create_creature(&mut state, PlayerId(0), CardId(3), "First");
+        let second = create_creature(&mut state, PlayerId(1), CardId(4), "Second");
+
+        let damage = ResolvedAbility::new(
+            Effect::EachSourceDealsDamage {
+                sources: TargetFilter::ParentTarget,
+                amount: QuantityExpr::Fixed { value: 1 },
+                recipient: EachDamageRecipient::OtherBatchSource {
+                    source_filters: [
+                        Box::new(TargetFilter::Typed(
+                            TypedFilter::creature().controller(ControllerRef::You),
+                        )),
+                        Box::new(TargetFilter::Typed(
+                            TypedFilter::creature().controller(ControllerRef::Opponent),
+                        )),
+                    ],
+                },
+            },
+            Vec::new(),
+            source,
+            PlayerId(0),
+        );
+        let mut second_target = ResolvedAbility::new(
+            Effect::TargetOnly {
+                target: TargetFilter::Typed(
+                    TypedFilter::creature().controller(ControllerRef::Opponent),
+                ),
+            },
+            Vec::new(),
+            source,
+            PlayerId(0),
+        );
+        second_target.sub_ability = Some(Box::new(damage));
+        let mut first_target = ResolvedAbility::new(
+            Effect::TargetOnly {
+                target: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
+            },
+            Vec::new(),
+            source,
+            PlayerId(0),
+        );
+        first_target.sub_ability = Some(Box::new(second_target));
+        let mut ability = ResolvedAbility::new(
+            Effect::TargetOnly {
+                target: TargetFilter::Typed(TypedFilter::creature()),
+            },
+            Vec::new(),
+            source,
+            PlayerId(0),
+        );
+        ability.sub_ability = Some(Box::new(first_target));
+
+        let mut omitted_first = ability.clone();
+        omitted_first.targets = vec![TargetRef::Object(unrelated)];
+        omitted_first
+            .sub_ability
+            .as_deref_mut()
+            .expect("first pair slot")
+            .sub_ability
+            .as_deref_mut()
+            .expect("second pair slot")
+            .targets = vec![TargetRef::Object(second)];
+        stamp_other_batch_source_targets(&mut omitted_first);
+        let omitted_pairwise = omitted_first
+            .sub_ability
+            .as_deref()
+            .and_then(|a| a.sub_ability.as_deref())
+            .and_then(|a| a.sub_ability.as_deref())
+            .expect("pairwise damage node");
+        assert_eq!(
+            omitted_pairwise.targets,
+            vec![TargetRef::Object(second)],
+            "an omitted immediate slot must not be filled by an older target"
+        );
+
+        assign_targets_in_chain(
+            &state,
+            &mut ability,
+            &[
+                TargetRef::Object(unrelated),
+                TargetRef::Object(first),
+                TargetRef::Object(second),
+            ],
+        )
+        .expect("three declared targets assign");
+        let pairwise = ability
+            .sub_ability
+            .as_deref()
+            .and_then(|a| a.sub_ability.as_deref())
+            .and_then(|a| a.sub_ability.as_deref())
+            .expect("pairwise damage node");
+        assert_eq!(
+            pairwise.targets,
+            vec![TargetRef::Object(first), TargetRef::Object(second)],
+            "an unrelated older target must not enter the immediate pair"
+        );
+
+        let mut invalidated = state.clone();
+        let mut invalid_events = Vec::new();
+        crate::game::zones::move_to_zone(
+            &mut invalidated,
+            first,
+            Zone::Graveyard,
+            &mut invalid_events,
+        );
+        crate::game::effects::resolve_ability_chain(
+            &mut invalidated,
+            &ability,
+            &mut invalid_events,
+            0,
+        )
+        .expect("invalidated pair resolves as a no-op");
+        assert_eq!(invalidated.objects[&first].damage_marked, 0);
+        assert_eq!(invalidated.objects[&second].damage_marked, 0);
+
+        let mut events = Vec::new();
+        crate::game::effects::resolve_ability_chain(&mut state, &ability, &mut events, 0)
+            .expect("pairwise chain resolves");
+        assert_eq!(state.objects[&unrelated].damage_marked, 0);
+        assert_eq!(state.objects[&first].damage_marked, 1);
+        assert_eq!(state.objects[&second].damage_marked, 1);
     }
 
     #[test]

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -11889,7 +11889,7 @@ mod tests {
             })
             .and_then(|trigger| trigger.execute.as_deref())
             .expect("Great Aerie chaos trigger");
-        let ability = build_resolved_from_def(definition, source, PlayerId(0));
+        let mut ability = build_resolved_from_def(definition, source, PlayerId(0));
         let slots = build_target_slots(&state, &ability).expect("two optional target slots");
 
         assert_eq!(slots.len(), 2);
@@ -11914,13 +11914,18 @@ mod tests {
         };
 
         assert_eq!(selected, vec![None, None]);
+        assign_selected_slots_in_chain(&state, &mut ability, &selected)
+            .expect("both omitted slots must assign without inventing targets");
+        let mut events = Vec::new();
+        crate::game::effects::resolve_ability_chain(&mut state, &ability, &mut events, 0)
+            .expect("Great Aerie must resolve after both optional targets are skipped");
         assert_eq!(
             [
                 state.objects[&yours].damage_marked,
                 state.objects[&opponents].damage_marked,
             ],
             damage_before,
-            "target announcement must not mutate either creature"
+            "zero-target resolution must not mutate either creature"
         );
     }
 

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -4077,6 +4077,19 @@ pub(crate) fn collect_player_targets(
     ability: &ResolvedAbility,
     target: &TargetFilter,
 ) -> Vec<PlayerId> {
+    // CR 608.2c: a definite player anaphor may name one exact slot in the
+    // flattened resolving chain after an intervening object target. Resolve
+    // that slot before inspecting this node's propagated local targets, which
+    // may contain only the most-recent object slot.
+    if let TargetFilter::ParentTargetSlot { index } = target {
+        return crate::game::targeting::resolve_parent_slot_from_root(state, ability, *index)
+            .and_then(|target| match target {
+                TargetRef::Player(player) => Some(player),
+                TargetRef::Object(_) => None,
+            })
+            .into_iter()
+            .collect();
+    }
     let from_targets: Vec<PlayerId> = ability
         .targets
         .iter()

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -11860,6 +11860,71 @@ mod tests {
     }
 
     #[test]
+    fn great_aerie_allows_skipping_both_optional_targets_without_mutation() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "The Great Aerie".to_string(),
+            Zone::Battlefield,
+        );
+        let yours = create_creature(&mut state, PlayerId(0), CardId(2), "Your Creature");
+        let opponents = create_creature(&mut state, PlayerId(1), CardId(3), "Opponent Creature");
+        let parsed = crate::parser::oracle::parse_oracle_text(
+            "Whenever chaos ensues, choose up to one target creature you control and up to one target creature an opponent controls. Each of those creatures deals damage equal to its toughness to the other.",
+            "The Great Aerie",
+            &[],
+            &["Plane".to_string()],
+            &["Tarkir".to_string()],
+        );
+        let definition = parsed
+            .triggers
+            .iter()
+            .find(|trigger| {
+                matches!(
+                    trigger.mode,
+                    crate::types::triggers::TriggerMode::ChaosEnsues
+                )
+            })
+            .and_then(|trigger| trigger.execute.as_deref())
+            .expect("Great Aerie chaos trigger");
+        let ability = build_resolved_from_def(definition, source, PlayerId(0));
+        let slots = build_target_slots(&state, &ability).expect("two optional target slots");
+
+        assert_eq!(slots.len(), 2);
+        assert!(slots.iter().all(|slot| slot.optional));
+        let damage_before = [
+            state.objects[&yours].damage_marked,
+            state.objects[&opponents].damage_marked,
+        ];
+        let progress = begin_target_selection_for_ability(&state, &ability, &slots, &[])
+            .expect("selection starts");
+        let TargetSelectionAdvance::InProgress(progress) =
+            choose_target_for_ability(&state, &ability, &slots, &[], &progress, None)
+                .expect("skip first optional target")
+        else {
+            panic!("second optional slot remains");
+        };
+        let TargetSelectionAdvance::Complete(selected) =
+            choose_target_for_ability(&state, &ability, &slots, &[], &progress, None)
+                .expect("skip second optional target")
+        else {
+            panic!("both skipped targets complete selection");
+        };
+
+        assert_eq!(selected, vec![None, None]);
+        assert_eq!(
+            [
+                state.objects[&yours].damage_marked,
+                state.objects[&opponents].damage_marked,
+            ],
+            damage_before,
+            "target announcement must not mutate either creature"
+        );
+    }
+
+    #[test]
     fn choose_target_for_ability_skip_completes_optional_multi_target_tail() {
         let mut state = GameState::new(FormatConfig::standard(), 2, 42);
         let source = create_creature(&mut state, PlayerId(0), CardId(1), "Source");

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -2492,6 +2492,11 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
                 match recipient {
                     EachDamageRecipient::Shared(filter) => fmt_target(filter),
                     EachDamageRecipient::EachController => "its controller".into(),
+                    EachDamageRecipient::OtherBatchSource { source_filters } => format!(
+                        "the other batch source of ({}, {})",
+                        fmt_target(&source_filters[0]),
+                        fmt_target(&source_filters[1]),
+                    ),
                 },
             ));
         }

--- a/crates/engine/src/game/effects/deal_damage.rs
+++ b/crates/engine/src/game/effects/deal_damage.rs
@@ -2502,17 +2502,45 @@ pub fn resolve_each_source_deals_damage(
         resolve_quantity_with_targets(state, amount, ability).max(0) as u32
     };
 
-    // CR 608.2 + CR 120.1: evaluate the source class against the battlefield at
-    // resolution (mirrors `resolve_all`). Each matching object is an independent
-    // source of its own damage.
-    let resolved_sources = crate::game::effects::resolved_object_filter(ability, sources);
-    let filter_ctx = filter::FilterContext::from_ability(ability);
-    let source_ids: Vec<ObjectId> = state
-        .battlefield
-        .iter()
-        .filter(|id| filter::matches_target_filter(state, **id, &resolved_sources, &filter_ctx))
-        .copied()
-        .collect();
+    // CR 608.2 + CR 120.1: ordinary source classes are evaluated against the
+    // battlefield. A pairwise targeted batch instead uses the exact announced
+    // objects stamped on this damage node; a missing target is absent, and an
+    // object whose incarnation is no longer current or which is no longer on
+    // the battlefield cannot deal damage.
+    let source_ids: Vec<ObjectId> = match recipient {
+        EachDamageRecipient::OtherBatchSource { source_filters } => ability
+            .targets
+            .iter()
+            .zip(source_filters)
+            .filter_map(|(target, source_filter)| {
+                let TargetRef::Object(id) = target else {
+                    return None;
+                };
+                (ability.target_pin_is_current(*id, state)
+                    && ability.selected_target_pin_is_current(*id, state)
+                    && !crate::game::targeting::validate_targets_for_ability(
+                        state,
+                        std::slice::from_ref(target),
+                        source_filter,
+                        ability,
+                    )
+                    .is_empty())
+                .then_some(*id)
+            })
+            .collect(),
+        EachDamageRecipient::Shared(_) | EachDamageRecipient::EachController => {
+            let resolved_sources = crate::game::effects::resolved_object_filter(ability, sources);
+            let filter_ctx = filter::FilterContext::from_ability(ability);
+            state
+                .battlefield
+                .iter()
+                .filter(|id| {
+                    filter::matches_target_filter(state, **id, &resolved_sources, &filter_ctx)
+                })
+                .copied()
+                .collect()
+        }
+    };
 
     // CR 115.1 / CR 608.2c: resolve the shared recipient ONCE (an announced target
     // or a hydrated context anaphor). An empty result (e.g. an "up to one" / fizzled
@@ -2521,7 +2549,9 @@ pub fn resolve_each_source_deals_damage(
         EachDamageRecipient::Shared(filter) => {
             resolve_effect_recipients(state, ability, filter, false)
         }
-        EachDamageRecipient::EachController => Vec::new(),
+        EachDamageRecipient::EachController | EachDamageRecipient::OtherBatchSource { .. } => {
+            Vec::new()
+        }
     };
 
     // Build every (source, context, recipient, amount) entry up front, before any
@@ -2565,6 +2595,19 @@ pub fn resolve_each_source_deals_damage(
                     .unwrap_or(ctx.controller);
                 entries.push((source_id, ctx, TargetRef::Player(controller), amt));
             }
+            // CR 120.1 + CR 608.2c: the relation exists only for an exact
+            // two-object batch. With zero/one surviving choices there is no
+            // "other" object, so this source produces no damage entry.
+            EachDamageRecipient::OtherBatchSource { .. } if source_ids.len() == 2 => {
+                if let Some(other) = source_ids
+                    .iter()
+                    .copied()
+                    .find(|candidate| *candidate != source_id)
+                {
+                    entries.push((source_id, ctx, TargetRef::Object(other), amt));
+                }
+            }
+            EachDamageRecipient::OtherBatchSource { .. } => {}
         }
     }
 

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -2016,15 +2016,10 @@ fn stack_entry_controller_matches(
             ctx.scoped_iteration_player,
         )
         .is_some_and(|pid| pid == entry_controller),
-        Some(ControllerRef::TargetPlayer | ControllerRef::TargetOpponent) => ctx
-            .ability
-            .and_then(|ability| {
-                ability.targets.iter().find_map(|target| match target {
-                    TargetRef::Player(pid) => Some(*pid),
-                    TargetRef::Object(_) => None,
-                })
-            })
-            .is_some_and(|pid| pid == entry_controller),
+        Some(ControllerRef::TargetPlayer | ControllerRef::TargetOpponent) => {
+            target_player_from_ability_or_root(state, ctx.ability)
+                .is_some_and(|pid| pid == entry_controller)
+        }
         Some(ControllerRef::ParentTargetController) => {
             parent_target_controller_player(state, ctx.ability)
                 .is_some_and(|pid| pid == entry_controller)
@@ -3827,12 +3822,7 @@ fn zone_change_filter_inner(
                     // record's controller against the chosen player target.
                     // TargetOpponent reads identically (opponent constraint in slot).
                     ControllerRef::TargetPlayer | ControllerRef::TargetOpponent => {
-                        let target_player = ability.and_then(|a| {
-                            a.targets.iter().find_map(|t| match t {
-                                TargetRef::Player(pid) => Some(*pid),
-                                TargetRef::Object(_) => None,
-                            })
-                        });
+                        let target_player = target_player_from_ability_or_root(state, ability);
                         match target_player {
                             Some(pid) if pid == record.controller => {}
                             _ => return false,
@@ -5794,17 +5784,13 @@ fn matches_filter_prop(
                     .is_some_and(|pid| pid == obj.owner)
             }
             // CR 109.5: Ownership relative to a chosen target player.
-            // Resolves against the first TargetRef::Player in ability.targets.
-            // TargetOpponent reads identically (opponent constraint lives in the slot).
-            ControllerRef::TargetPlayer | ControllerRef::TargetOpponent => source
-                .ability
-                .and_then(|a| {
-                    a.targets.iter().find_map(|t| match t {
-                        TargetRef::Player(pid) => Some(*pid),
-                        TargetRef::Object(_) => None,
-                    })
-                })
-                .is_some_and(|pid| pid == obj.owner),
+            // Resolves against the first player target on the current node or
+            // its resolving root. TargetOpponent reads identically (the
+            // opponent constraint lives in the declared slot).
+            ControllerRef::TargetPlayer | ControllerRef::TargetOpponent => {
+                target_player_from_ability_or_root(state, source.ability)
+                    .is_some_and(|pid| pid == obj.owner)
+            }
             ControllerRef::ParentTargetController => {
                 parent_target_controller_player(state, source.ability)
                     .is_some_and(|pid| pid == obj.owner)
@@ -6558,14 +6544,8 @@ fn zone_change_record_matches_property(
             }
             // CR 109.5: Ownership relative to a chosen target player.
             // TargetOpponent reads identically (opponent constraint lives in the slot).
-            ControllerRef::TargetPlayer | ControllerRef::TargetOpponent => source
-                .ability
-                .and_then(|a| {
-                    a.targets.iter().find_map(|t| match t {
-                        TargetRef::Player(pid) => Some(*pid),
-                        TargetRef::Object(_) => None,
-                    })
-                })
+            ControllerRef::TargetPlayer | ControllerRef::TargetOpponent =>
+                target_player_from_ability_or_root(state, source.ability)
                 .is_some_and(|pid| pid == record.owner),
             ControllerRef::ParentTargetController => {
                 parent_target_controller_player(state, source.ability)
@@ -6926,15 +6906,10 @@ fn attachment_controller_matches(
             scoped_player_or_controller(state, source.ability, source.controller, None)
                 .is_some_and(|pid| pid == attachment_controller)
         }
-        Some(ControllerRef::TargetPlayer | ControllerRef::TargetOpponent) => source
-            .ability
-            .and_then(|a| {
-                a.targets.iter().find_map(|t| match t {
-                    TargetRef::Player(pid) => Some(*pid),
-                    TargetRef::Object(_) => None,
-                })
-            })
-            .is_some_and(|pid| pid == attachment_controller),
+        Some(ControllerRef::TargetPlayer | ControllerRef::TargetOpponent) => {
+            target_player_from_ability_or_root(state, source.ability)
+                .is_some_and(|pid| pid == attachment_controller)
+        }
         Some(ControllerRef::ParentTargetController) => {
             parent_target_controller_player(state, source.ability)
                 .is_some_and(|pid| pid == attachment_controller)
@@ -7787,6 +7762,118 @@ mod tests {
             .core_types
             .push(CoreType::Creature);
         id
+    }
+
+    /// CR 608.2c: every target-relative player seam must recover the root's
+    /// earlier player slot when the current chained node carries only an object.
+    #[test]
+    fn sibling_target_player_lookups_recover_player_from_resolving_root() {
+        use crate::types::game_state::{StackEntry, StackEntryKind};
+
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        let opponent_object = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(1),
+            "Opponent Object".to_string(),
+            Zone::Battlefield,
+        );
+        let child = ResolvedAbility::new(
+            Effect::TargetOnly {
+                target: TargetFilter::Any,
+            },
+            vec![TargetRef::Object(opponent_object)],
+            source,
+            PlayerId(0),
+        );
+        let mut root = ResolvedAbility::new(
+            Effect::TargetOnly {
+                target: TargetFilter::Opponent,
+            },
+            vec![TargetRef::Player(PlayerId(1))],
+            source,
+            PlayerId(0),
+        );
+        root.sub_ability = Some(Box::new(child.clone()));
+        state.stack.push_back(StackEntry {
+            id: ObjectId(900),
+            source_id: source,
+            controller: PlayerId(0),
+            kind: StackEntryKind::TriggeredAbility {
+                source_id: source,
+                ability: Box::new(root),
+                condition: None,
+                trigger_event: None,
+                description: None,
+                source_name: String::new(),
+                subject_match_count: None,
+                die_result: None,
+                provenance: None,
+            },
+        });
+
+        let ctx = FilterContext::from_ability(&child);
+        assert!(stack_entry_controller_matches(
+            &state,
+            Some(&ControllerRef::TargetOpponent),
+            PlayerId(1),
+            &ctx,
+        ));
+
+        let owned =
+            TargetFilter::Typed(TypedFilter::default().properties(vec![FilterProp::Owned {
+                controller: ControllerRef::TargetOpponent,
+            }]));
+        assert!(super::matches_target_filter(
+            &state,
+            opponent_object,
+            &owned,
+            &ctx,
+        ));
+
+        let record = ZoneChangeRecord {
+            controller: PlayerId(1),
+            owner: PlayerId(1),
+            ..ZoneChangeRecord::test_minimal(
+                opponent_object,
+                Some(Zone::Battlefield),
+                Zone::Graveyard,
+            )
+        };
+        assert!(zone_change_filter_inner(
+            &state,
+            &record,
+            &TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::TargetOpponent)),
+            source,
+            Some(PlayerId(0)),
+            Some(&child),
+            None,
+        ));
+        assert!(zone_change_filter_inner(
+            &state,
+            &record,
+            &owned,
+            source,
+            Some(PlayerId(0)),
+            Some(&child),
+            None,
+        ));
+
+        let source_ctx =
+            source_context_from_filter(&state, source, Some(PlayerId(0)), Some(&child), None, None);
+        assert!(attachment_controller_matches(
+            Some(&ControllerRef::TargetOpponent),
+            PlayerId(1),
+            &state,
+            &source_ctx,
+        ));
     }
 
     #[test]

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -1465,13 +1465,12 @@ pub(crate) fn controller_ref_player(
         ControllerRef::ScopedPlayer => {
             scoped_player_or_controller(state, ability, source_controller, None)
         }
-        // CR 109.4: TargetOpponent reads identically to TargetPlayer (first player target).
-        ControllerRef::TargetPlayer | ControllerRef::TargetOpponent => ability.and_then(|a| {
-            a.targets.iter().find_map(|t| match t {
-                TargetRef::Player(pid) => Some(*pid),
-                TargetRef::Object(_) => None,
-            })
-        }),
+        // CR 109.4: TargetOpponent reads identically to TargetPlayer (first
+        // declared player target), including an earlier slot in the resolving
+        // root after an intervening object-target node.
+        ControllerRef::TargetPlayer | ControllerRef::TargetOpponent => {
+            target_player_from_ability_or_root(state, ability)
+        }
         ControllerRef::ParentTargetController => parent_target_controller_player(state, ability),
         ControllerRef::ParentTargetOwner => parent_target_owner_player(state, ability),
         ControllerRef::DefendingPlayer => {
@@ -1503,6 +1502,36 @@ pub(crate) fn controller_ref_player(
         // resolving ability (Gideon Jura's "+2").
         ControllerRef::SpecificPlayer { id } => Some(*id),
     }
+}
+
+/// CR 608.2c: resolve the first declared player target without letting a
+/// chained node's most-recent object-target propagation hide an earlier player
+/// slot. Local targets remain the fast path; the flattened resolving root is
+/// the exact fallback used by `ParentTargetSlot` anaphors elsewhere.
+fn target_player_from_ability_or_root(
+    state: &GameState,
+    ability: Option<&ResolvedAbility>,
+) -> Option<PlayerId> {
+    let ability = ability?;
+    ability
+        .targets
+        .iter()
+        .find_map(|target| match target {
+            TargetRef::Player(player) => Some(*player),
+            TargetRef::Object(_) => None,
+        })
+        .or_else(|| {
+            let root = crate::game::targeting::resolving_root_ability(state, ability);
+            if std::ptr::eq(root, ability) {
+                return None;
+            }
+            crate::game::ability_utils::flatten_targets_in_chain(root)
+                .into_iter()
+                .find_map(|target| match target {
+                    TargetRef::Player(player) => Some(player),
+                    TargetRef::Object(_) => None,
+                })
+        })
 }
 /// Whether `filter`, or any filter nested anywhere inside it, satisfies `leaf`.
 ///
@@ -3167,13 +3196,7 @@ fn filter_inner_for_object(
                     // whenever this variant appears). CR 109.4: TargetOpponent reads
                     // identically (the opponent constraint lives in the slot).
                     ControllerRef::TargetPlayer | ControllerRef::TargetOpponent => {
-                        let target_player = ability
-                            .and_then(|a| {
-                                a.targets.iter().find_map(|t| match t {
-                                    TargetRef::Player(pid) => Some(*pid),
-                                    TargetRef::Object(_) => None,
-                                })
-                            })
+                        let target_player = target_player_from_ability_or_root(state, ability)
                             // CR 603.2: When no player target was chosen, "that
                             // player" is the triggering event's player. Non-Phase
                             // triggers resolve their player anaphor from event

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -4952,7 +4952,9 @@ fn try_parse_two_targets(rest: &str, ctx: &mut ParseContext) -> Option<ChooseImp
 
     // CR 115.1c slot A: the prefix must be a targeting phrase. `parse_target`
     // returning `Any` means "no recognized target" — we refuse to split.
-    let (target_a, rem_a) = parse_target_with_ctx(prefix_orig.trim_end(), ctx);
+    let (target_a_text, explicit_target_a_multi_target) =
+        super::strip_optional_target_prefix(prefix_orig.trim_end());
+    let (target_a, rem_a) = parse_target_with_ctx(target_a_text, ctx);
     if matches!(target_a, TargetFilter::Any) {
         return None;
     }
@@ -5003,9 +5005,11 @@ fn try_parse_two_targets(rest: &str, ctx: &mut ParseContext) -> Option<ChooseImp
     // heads in one chain; the single-declaration form is the whole class.)
     ctx.declared_target_slots = vec![target_a.clone(), target_b.clone()];
 
-    let target_a_multi_target = target_b_multi_target
-        .as_ref()
-        .map(|_| MultiTargetSpec::exact(QuantityExpr::Fixed { value: 1 }));
+    let target_a_multi_target = explicit_target_a_multi_target.or_else(|| {
+        target_b_multi_target
+            .as_ref()
+            .map(|_| MultiTargetSpec::exact(QuantityExpr::Fixed { value: 1 }))
+    });
     Some(ChooseImperativeAst::TwoTargets {
         target_a,
         target_a_multi_target,
@@ -19445,9 +19449,9 @@ mod tests {
         let lower = text.to_lowercase();
         let Some(ChooseImperativeAst::TwoTargets {
             target_a,
+            target_a_multi_target,
             target_b,
             target_b_multi_target,
-            ..
         }) = parse_choose_ast(text, &lower, &mut ParseContext::default())
         else {
             panic!("expected the two-target Great Aerie head");
@@ -19464,6 +19468,10 @@ mod tests {
                 if tf.type_filters.contains(&TypeFilter::Creature)
                     && tf.controller == Some(ControllerRef::Opponent)
         ));
+        assert_eq!(
+            target_a_multi_target,
+            Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 1 }))
+        );
         assert_eq!(
             target_b_multi_target,
             Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 1 }))

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -4948,19 +4948,24 @@ fn try_parse_two_targets(rest: &str, ctx: &mut ParseContext) -> Option<ChooseImp
     // is part of the prefix.
     let prefix_orig = &rest[..lower_prefix.len()];
     let match_start_orig = &rest[rest.len() - lower_match_start.len()..];
+    let (_, target_b_multi_target) = parse_connector(match_start_orig).ok()?;
 
     // CR 115.1c slot A: the prefix must be a targeting phrase. `parse_target`
     // returning `Any` means "no recognized target" — we refuse to split.
-    let (target_a, _rem_a) = parse_target_with_ctx(prefix_orig.trim_end(), ctx);
+    let (target_a, rem_a) = parse_target_with_ctx(prefix_orig.trim_end(), ctx);
     if matches!(target_a, TargetFilter::Any) {
         return None;
+    }
+    if target_b_multi_target.is_some() {
+        all_consuming((space0::<_, E>, opt(alt((tag(","), tag(".")))), space0, eof))
+            .parse(rem_a)
+            .ok()?;
     }
 
     // CR 115.1c slot B: skip the leading "and " on the matched connector
     // and parse the second target. `tag("and ").parse(input)` returns
     // `(remainder, matched)` so we bind the first element.
     let (after_and_orig, _) = tag::<_, _, E>("and ").parse(match_start_orig).ok()?;
-    let (_, target_b_multi_target) = parse_connector(match_start_orig).ok()?;
     let target_b_text = if target_b_multi_target.is_some() {
         tag::<_, _, E>("up to one ").parse(after_and_orig).ok()?.0
     } else {
@@ -19420,6 +19425,65 @@ mod tests {
         assert!(!matches!(
             parse_choose_ast(text, &lower, &mut ParseContext::default()),
             Some(ChooseImperativeAst::TwoTargets { .. })
+        ));
+    }
+
+    #[test]
+    fn teferi_optional_second_slot_does_not_steal_a_three_target_list() {
+        let text =
+            "choose up to one target artifact, up to one target creature, and up to one target land";
+        let lower = text.to_lowercase();
+        assert!(!matches!(
+            parse_choose_ast(text, &lower, &mut ParseContext::default()),
+            Some(ChooseImperativeAst::TwoTargets { .. })
+        ));
+    }
+
+    #[test]
+    fn great_aerie_keeps_both_optional_creature_targets() {
+        let text = "choose up to one target creature you control and up to one target creature an opponent controls";
+        let lower = text.to_lowercase();
+        let Some(ChooseImperativeAst::TwoTargets {
+            target_a,
+            target_b,
+            target_b_multi_target,
+            ..
+        }) = parse_choose_ast(text, &lower, &mut ParseContext::default())
+        else {
+            panic!("expected the two-target Great Aerie head");
+        };
+        assert!(matches!(
+            target_a,
+            TargetFilter::Typed(ref tf)
+                if tf.type_filters.contains(&TypeFilter::Creature)
+                    && tf.controller == Some(ControllerRef::You)
+        ));
+        assert!(matches!(
+            target_b.as_ref(),
+            TargetFilter::Typed(tf)
+                if tf.type_filters.contains(&TypeFilter::Creature)
+                    && tf.controller == Some(ControllerRef::Opponent)
+        ));
+        assert_eq!(
+            target_b_multi_target,
+            Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 1 }))
+        );
+    }
+
+    #[test]
+    fn mouth_to_mouth_binds_creature_to_target_opponent() {
+        let text = "choose target opponent and target creature they control";
+        let lower = text.to_lowercase();
+        let Some(ChooseImperativeAst::TwoTargets { target_b, .. }) =
+            parse_choose_ast(text, &lower, &mut ParseContext::default())
+        else {
+            panic!("expected the two-target Mouth to Mouth head");
+        };
+        assert!(matches!(
+            target_b.as_ref(),
+            TargetFilter::Typed(tf)
+                if tf.type_filters.contains(&TypeFilter::Creature)
+                    && tf.controller == Some(ControllerRef::TargetOpponent)
         ));
     }
 

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -52,11 +52,11 @@ use crate::types::statics::{ActivationExemption, CostModifyMode, StaticMode};
 use crate::types::zones::Zone;
 
 use super::super::oracle_target::{
-    match_mass_union_separator, parse_anaphoric_target_ref, parse_event_context_ref,
-    parse_fight_target, parse_mass_type_union, parse_target, parse_target_with_ctx,
-    parse_target_with_syntax, parse_type_phrase, parse_type_phrase_with_ctx, parse_word_bounded,
-    resolve_pronoun_target, resolve_singular_exiled_card_target, starts_with_type_word,
-    TargetSyntax,
+    match_mass_union_separator, parse_anaphoric_target_ref, parse_definite_parent_reference,
+    parse_event_context_ref, parse_fight_target, parse_mass_type_union, parse_target,
+    parse_target_with_ctx, parse_target_with_syntax, parse_type_phrase, parse_type_phrase_with_ctx,
+    parse_word_bounded, resolve_pronoun_target, resolve_singular_exiled_card_target,
+    starts_with_type_word, TargetSyntax,
 };
 use super::super::oracle_util::{
     contains_possessive, contains_self_or_object_pronoun, merge_or_filters, parse_count_expr,
@@ -2914,6 +2914,61 @@ fn is_bare_battlefield_permanent_leg(filter: &TargetFilter) -> bool {
     }
 }
 
+/// CR 608.2c + CR 701.13a: a bounded exile choice whose alternatives live in
+/// different zones: "a <card filter> from their hand or the chosen <type>".
+/// The possessive hand leg is relative to an earlier targeted opponent, while
+/// the definite object leg names one unique declared target slot. Both operands
+/// are carried by one `Or` filter so the existing zone-choice resolver offers a
+/// single choice across Hand and Battlefield.
+fn try_parse_heterogeneous_chosen_exile(input: &str, ctx: &ParseContext) -> Option<TargetFilter> {
+    type E<'a> = OracleError<'a>;
+
+    let opponent_slots = ctx
+        .declared_target_slots
+        .iter()
+        .filter(|slot| {
+            matches!(
+                slot,
+                TargetFilter::Typed(tf)
+                    if tf.type_filters.is_empty()
+                        && tf.properties.is_empty()
+                        && tf.controller == Some(ControllerRef::Opponent)
+            )
+        })
+        .count();
+    if opponent_slots != 1 {
+        return None;
+    }
+
+    let (input, _) = opt(nom_primitives::parse_article).parse(input).ok()?;
+    let (chosen_text, hand_head) = terminated(
+        take_until::<_, _, E>(" from their hand or "),
+        tag(" from their hand or "),
+    )
+    .parse(input)
+    .ok()?;
+    let (mut hand_filter, hand_rem) = parse_type_phrase(hand_head.trim());
+    if !hand_rem.trim().is_empty() || !matches!(hand_filter, TargetFilter::Typed(_)) {
+        return None;
+    }
+    let (chosen_filter, chosen_rem) =
+        parse_definite_parent_reference(chosen_text, &ctx.declared_target_slots)?;
+    all_consuming((opt(tag::<_, _, E>(".")), eof))
+        .parse(chosen_rem.trim())
+        .ok()?;
+
+    attach_controller_if_absent(&mut hand_filter, ControllerRef::TargetOpponent);
+    let hand_filter =
+        super::add_filter_props(hand_filter, &[FilterProp::InZone { zone: Zone::Hand }]);
+    let chosen_filter = super::add_filter_props(
+        chosen_filter,
+        &[FilterProp::InZone {
+            zone: Zone::Battlefield,
+        }],
+    );
+    Some(merge_or_filters(hand_filter, chosen_filter))
+}
+
 /// CR 404.1 + CR 108.2: parse a trailing whole-zone union tail after the
 /// permanent legs of a mass exile — a leading union separator, then one or more
 /// bare zone words ("graveyards", "hands", "libraries"), each optionally
@@ -4865,14 +4920,22 @@ fn parse_choose_zone_list(input: &str) -> nom::IResult<&str, Vec<Zone>, OracleEr
 fn try_parse_two_targets(rest: &str, ctx: &mut ParseContext) -> Option<ChooseImperativeAst> {
     type E<'a> = OracleError<'a>;
 
-    // CR 601.2c connector parser: "and target " or "and another target ".
+    // CR 601.2c connector parser. Cardinality belongs to the target slot whose
+    // target phrase carries it; it is not an ability-wide optionality flag.
     // `scan_split_at_phrase` advances at word boundaries (jumping past each
     // space), so the connector body itself is matched without a leading
     // space — the word boundary is enforced by the scan loop. Trailing
     // space is required so the next character is the start of the second
     // target's type/quantity phrase.
-    fn parse_connector(input: &str) -> nom::IResult<&str, (), E<'_>> {
-        value((), alt((tag("and target "), tag("and another target ")))).parse(input)
+    fn parse_connector(input: &str) -> nom::IResult<&str, Option<MultiTargetSpec>, E<'_>> {
+        alt((
+            value(
+                Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 1 })),
+                tag("and up to one target "),
+            ),
+            value(None, alt((tag("and target "), tag("and another target ")))),
+        ))
+        .parse(input)
     }
 
     let lower = rest.to_ascii_lowercase();
@@ -4888,7 +4951,7 @@ fn try_parse_two_targets(rest: &str, ctx: &mut ParseContext) -> Option<ChooseImp
 
     // CR 115.1c slot A: the prefix must be a targeting phrase. `parse_target`
     // returning `Any` means "no recognized target" — we refuse to split.
-    let (target_a, _rem_a) = parse_target(prefix_orig.trim_end());
+    let (target_a, _rem_a) = parse_target_with_ctx(prefix_orig.trim_end(), ctx);
     if matches!(target_a, TargetFilter::Any) {
         return None;
     }
@@ -4897,9 +4960,30 @@ fn try_parse_two_targets(rest: &str, ctx: &mut ParseContext) -> Option<ChooseImp
     // and parse the second target. `tag("and ").parse(input)` returns
     // `(remainder, matched)` so we bind the first element.
     let (after_and_orig, _) = tag::<_, _, E>("and ").parse(match_start_orig).ok()?;
-    let (target_b, _rem_b) = parse_target(after_and_orig);
+    let (_, target_b_multi_target) = parse_connector(match_start_orig).ok()?;
+    let target_b_text = if target_b_multi_target.is_some() {
+        tag::<_, _, E>("up to one ").parse(after_and_orig).ok()?.0
+    } else {
+        after_and_orig
+    };
+    let target_a_is_opponent = matches!(
+        &target_a,
+        TargetFilter::Typed(tf) if tf.controller == Some(ControllerRef::Opponent)
+    );
+    let (target_b, rem_b) = if target_a_is_opponent {
+        ctx.with_player_scope(ControllerRef::TargetOpponent, |ctx| {
+            parse_target_with_ctx(target_b_text, ctx)
+        })
+    } else {
+        parse_target_with_ctx(target_b_text, ctx)
+    };
     if matches!(target_b, TargetFilter::Any) {
         return None;
+    }
+    if target_b_multi_target.is_some() {
+        all_consuming((space0::<_, E>, opt(tag(".")), space0, eof))
+            .parse(rem_b)
+            .ok()?;
     }
 
     // CR 601.2c + CR 608.2c: Register the two announced slot filters (A then B)
@@ -4914,7 +4998,15 @@ fn try_parse_two_targets(rest: &str, ctx: &mut ParseContext) -> Option<ChooseImp
     // heads in one chain; the single-declaration form is the whole class.)
     ctx.declared_target_slots = vec![target_a.clone(), target_b.clone()];
 
-    Some(ChooseImperativeAst::TwoTargets { target_a, target_b })
+    let target_a_multi_target = target_b_multi_target
+        .as_ref()
+        .map(|_| MultiTargetSpec::exact(QuantityExpr::Fixed { value: 1 }));
+    Some(ChooseImperativeAst::TwoTargets {
+        target_a,
+        target_a_multi_target,
+        target_b: Box::new(target_b),
+        target_b_multi_target,
+    })
 }
 
 /// Parse anaphoric "choose N of them/those [cards]" patterns using nom combinators.
@@ -8835,20 +8927,14 @@ pub(super) fn parse_exile_ast(
     let (_, rest_text) = nom_on_lower(text, lower, |input| value((), tag("exile ")).parse(input))?;
     let rest_lower = &lower[lower.len() - rest_text.len()..];
 
-    // CR 608.2c + CR 115.10a: an anaphoric ALTERNATIVE referent — "… or the
-    // chosen creature/permanent" — composes this exile with an object chosen
-    // by an EARLIER instruction in the same ability ("choose target opponent
-    // and up to one target creature they control. … You may exile a nonland
-    // card from their hand or the chosen creature …", Cloak and Dagger,
-    // Entwined — issue #4235 review). No object-anaphor filter exists to
-    // represent that alternative yet, and every arm below would silently
-    // narrow the choice to its own operand (the hand-card leg), making the
-    // card look supported while dropping the printed alternative entirely.
-    // Decline the whole imperative so the clause stays an honest
-    // `Effect::Unimplemented` strict failure until the chosen-object anaphor
-    // is representable.
-    if nom_primitives::scan_contains(rest_lower, "or the chosen ") {
-        return None;
+    if let Some(target) = try_parse_heterogeneous_chosen_exile(rest_lower, ctx) {
+        return Some(ZoneCounterImperativeAst::Exile {
+            origin: None,
+            target,
+            all: false,
+            enter_with_counters: vec![],
+            multi_target: None,
+        });
     }
 
     // CR 701.13a: "exile a card from the top of your library" — synonymous with
@@ -12512,13 +12598,21 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
         // instructions are followed in order; later text may modify earlier
         // text).
         ImperativeFamilyAst::Structured(ImperativeAst::Choose(
-            ChooseImperativeAst::TwoTargets { target_a, target_b },
+            ChooseImperativeAst::TwoTargets {
+                target_a,
+                target_a_multi_target,
+                target_b,
+                target_b_multi_target,
+            },
         )) => {
             let mut clause = parsed_clause(Effect::TargetOnly { target: target_a });
-            clause.sub_ability = Some(Box::new(AbilityDefinition::new(
+            clause.multi_target = target_a_multi_target;
+            let mut target_b_clause = AbilityDefinition::new(
                 AbilityKind::Spell,
-                Effect::TargetOnly { target: target_b },
-            )));
+                Effect::TargetOnly { target: *target_b },
+            );
+            target_b_clause.multi_target = target_b_multi_target;
+            clause.sub_ability = Some(Box::new(target_b_clause));
             clause
         }
         // CR 701.23a + CR 107.1: Dual/N-way search ("a X card and a Y card") lowers
@@ -19223,7 +19317,9 @@ mod tests {
         let lower = text.to_lowercase();
         let result = parse_choose_ast(text, &lower, &mut ParseContext::default());
         match result {
-            Some(ChooseImperativeAst::TwoTargets { target_a, target_b }) => {
+            Some(ChooseImperativeAst::TwoTargets {
+                target_a, target_b, ..
+            }) => {
                 let tf_a = match &target_a {
                     TargetFilter::Typed(tf) => tf,
                     other => panic!("target_a should be Typed, got {other:?}"),
@@ -19233,7 +19329,7 @@ mod tests {
                     vec![TypeFilter::Artifact],
                     "target_a should be Artifact"
                 );
-                let tf_b = match &target_b {
+                let tf_b = match target_b.as_ref() {
                     TargetFilter::Typed(tf) => tf,
                     other => panic!("target_b should be Typed, got {other:?}"),
                 };
@@ -19264,6 +19360,153 @@ mod tests {
         }
     }
 
+    /// CR 115.1d + CR 601.2c: cardinality is per printed instance of
+    /// "target". The opponent remains mandatory while the creature they
+    /// control is independently optional.
+    #[test]
+    fn parse_choose_two_targets_with_optional_dependent_second_slot() {
+        let text = "choose target opponent and up to one target creature they control";
+        let lower = text.to_lowercase();
+        let result = parse_choose_ast(text, &lower, &mut ParseContext::default());
+        let Some(ChooseImperativeAst::TwoTargets {
+            target_a,
+            target_a_multi_target,
+            target_b,
+            target_b_multi_target,
+        }) = result
+        else {
+            panic!("expected TwoTargets, got {result:?}");
+        };
+
+        assert!(matches!(
+            target_a,
+            TargetFilter::Typed(ref tf)
+                if tf.controller == Some(ControllerRef::Opponent)
+        ));
+        assert_eq!(
+            target_a_multi_target,
+            Some(MultiTargetSpec::exact(QuantityExpr::Fixed { value: 1 }))
+        );
+        assert!(matches!(
+            *target_b,
+            TargetFilter::Typed(ref tf)
+                if tf.type_filters.contains(&TypeFilter::Creature)
+                    && tf.controller == Some(ControllerRef::TargetOpponent)
+        ));
+        assert_eq!(
+            target_b_multi_target,
+            Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 1 }))
+        );
+    }
+
+    #[test]
+    fn optional_dependent_second_slot_does_not_accept_two_targets() {
+        let text = "choose target opponent and up to two target creatures they control";
+        let lower = text.to_lowercase();
+        assert!(
+            !matches!(
+                parse_choose_ast(text, &lower, &mut ParseContext::default()),
+                Some(ChooseImperativeAst::TwoTargets { .. })
+            ),
+            "the up-to-one connector must not consume a different cardinality"
+        );
+    }
+
+    #[test]
+    fn optional_dependent_second_slot_rejects_trailing_garbage() {
+        let text =
+            "choose target opponent and up to one target creature they control trailing garbage";
+        let lower = text.to_lowercase();
+        assert!(!matches!(
+            parse_choose_ast(text, &lower, &mut ParseContext::default()),
+            Some(ChooseImperativeAst::TwoTargets { .. })
+        ));
+    }
+
+    #[test]
+    fn heterogeneous_chosen_exile_binds_hand_and_declared_creature_slots() {
+        let ctx = ParseContext {
+            declared_target_slots: vec![
+                TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
+                TargetFilter::Typed(
+                    TypedFilter::creature().controller(ControllerRef::TargetOpponent),
+                ),
+            ],
+            ..Default::default()
+        };
+        let target = try_parse_heterogeneous_chosen_exile(
+            "a nonland card from their hand or the chosen creature",
+            &ctx,
+        )
+        .expect("heterogeneous exile choice");
+        let TargetFilter::Or { filters } = target else {
+            panic!("expected Or filter, got {target:?}");
+        };
+        assert_eq!(filters.len(), 2);
+        assert!(matches!(
+            &filters[0],
+            TargetFilter::Typed(tf)
+                if tf.controller == Some(ControllerRef::TargetOpponent)
+                    && tf.type_filters.contains(&TypeFilter::Card)
+                    && tf.type_filters.iter().any(|ty| matches!(
+                        ty,
+                        TypeFilter::Non(inner) if **inner == TypeFilter::Land
+                    ))
+                    && tf.properties.contains(&FilterProp::InZone { zone: Zone::Hand })
+        ));
+        assert!(matches!(
+            &filters[1],
+            TargetFilter::And { filters }
+                if filters.contains(&TargetFilter::ParentTargetSlot { index: 1 })
+        ));
+        assert!(filters[1].extract_zones().contains(&Zone::Battlefield));
+    }
+
+    #[test]
+    fn heterogeneous_chosen_exile_requires_unique_slot_and_full_consumption() {
+        let empty = ParseContext::default();
+        assert!(try_parse_heterogeneous_chosen_exile(
+            "a nonland card from their hand or the chosen creature",
+            &empty,
+        )
+        .is_none());
+
+        let no_opponent = ParseContext {
+            declared_target_slots: vec![TargetFilter::Typed(TypedFilter::creature())],
+            ..Default::default()
+        };
+        assert!(try_parse_heterogeneous_chosen_exile(
+            "a nonland card from their hand or the chosen creature",
+            &no_opponent,
+        )
+        .is_none());
+
+        let mut ctx = ParseContext {
+            declared_target_slots: vec![
+                TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
+                TargetFilter::Typed(
+                    TypedFilter::creature().controller(ControllerRef::TargetOpponent),
+                ),
+            ],
+            ..Default::default()
+        };
+        assert!(try_parse_heterogeneous_chosen_exile(
+            "a nonland card from their hand or the chosen creature and draw a card",
+            &ctx,
+        )
+        .is_none());
+
+        ctx.declared_target_slots.insert(
+            1,
+            TargetFilter::Typed(TypedFilter::default().controller(ControllerRef::Opponent)),
+        );
+        assert!(try_parse_heterogeneous_chosen_exile(
+            "a nonland card from their hand or the chosen creature",
+            &ctx,
+        )
+        .is_none());
+    }
+
     /// CR 115.1c + CR 601.2c: TwoTargets lowering must emit a primary
     /// `TargetOnly` for slot A with a chained `TargetOnly` sub_ability for
     /// slot B so both targets are announced at activation.
@@ -19276,10 +19519,12 @@ mod tests {
                     type_filters: vec![TypeFilter::Artifact],
                     ..Default::default()
                 }),
-                target_b: TargetFilter::Typed(TypedFilter {
+                target_a_multi_target: None,
+                target_b: Box::new(TargetFilter::Typed(TypedFilter {
                     type_filters: vec![TypeFilter::Card],
                     ..Default::default()
-                }),
+                })),
+                target_b_multi_target: None,
             },
         ));
         let clause = lower_imperative_family_ast(ast);

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -3719,6 +3719,33 @@ fn resolve_they_pronoun(ctx: &mut ParseContext) -> TargetFilter {
     if let Some(filter) = chosen_player_anaphor_filter(ctx.relative_player_scope.as_ref()) {
         return filter;
     }
+    // CR 608.2c: after a multi-target declaration, a bare "They" can name the
+    // unique earlier player slot even when a later object slot intervenes.
+    // Bind by the declared slot's typed player shape, never by card text or
+    // position alone; zero or multiple player slots remain ambiguous and fall
+    // through to the established pronoun rules below.
+    let mut declared_player_slot = None;
+    for (index, slot) in ctx.declared_target_slots.iter().enumerate() {
+        let is_player = match slot {
+            TargetFilter::Player | TargetFilter::Opponent => true,
+            TargetFilter::Typed(TypedFilter {
+                type_filters,
+                properties,
+                ..
+            }) => type_filters.is_empty() && properties.is_empty(),
+            _ => false,
+        };
+        if is_player {
+            if declared_player_slot.is_some() {
+                declared_player_slot = None;
+                break;
+            }
+            declared_player_slot = Some(index);
+        }
+    }
+    if let Some(index) = declared_player_slot {
+        return TargetFilter::ParentTargetSlot { index };
+    }
     match &ctx.subject {
         // Player-type trigger subject: no type_filters, has controller ref
         Some(TargetFilter::Typed(tf)) if tf.type_filters.is_empty() && tf.controller.is_some() => {

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -6498,11 +6498,25 @@ pub(super) fn try_parse_each_source_deals_damage(
         )));
     }
 
-    // Require a usable non-player object-class source. Player-shaped subjects
-    // ("each player", "each opponent") and anaphoric "each of those …"
-    // (`ParentTarget`) fall through to their own handling.
+    // Require a usable non-player object-class source. The one context-set
+    // exception is an exact pairwise relation: "each of those ... to the
+    // other" reads the previously announced object pair through ParentTarget.
+    // Only `TwoTargets` publishes this two-slot registry; a single multi-target
+    // producer therefore fails closed without typed per-member provenance.
     let sources = parse_subject_application(subject, ctx)?.affected;
-    if !is_object_class_source(&sources) {
+    let pairwise_filters = match (&sources, ctx.declared_target_slots.as_slice()) {
+        (TargetFilter::ParentTarget, [first, second])
+            if has_pairwise_other_recipient(&predicate_lower)
+                && matches!(first, TargetFilter::Typed(typed)
+                    if !typed.type_filters.is_empty() || !typed.properties.is_empty())
+                && matches!(second, TargetFilter::Typed(typed)
+                    if !typed.type_filters.is_empty() || !typed.properties.is_empty()) =>
+        {
+            Some([Box::new(first.clone()), Box::new(second.clone())])
+        }
+        _ => None,
+    };
+    if !is_object_class_source(&sources) && pairwise_filters.is_none() {
         return None;
     }
 
@@ -6541,7 +6555,9 @@ pub(super) fn try_parse_each_source_deals_damage(
 
     // CR 109.4 + CR 120.3a: "its controller" is a per-source recipient. Every other
     // recipient is the shared announced/context target produced above.
-    let recipient = if recipient_phrase.is_some_and(is_its_controller_recipient) {
+    let recipient = if let Some(source_filters) = pairwise_filters {
+        EachDamageRecipient::OtherBatchSource { source_filters }
+    } else if recipient_phrase.is_some_and(is_its_controller_recipient) {
         EachDamageRecipient::EachController
     } else {
         EachDamageRecipient::Shared(target)
@@ -6584,6 +6600,29 @@ fn subject_sources_tapped_this_way(subject_lower: &str) -> bool {
 fn is_its_controller_recipient(recipient_phrase: &str) -> bool {
     all_consuming(tag::<_, _, OracleError<'_>>("its controller"))
         .parse(recipient_phrase)
+        .is_ok()
+}
+
+/// CR 120.3: exact pairwise recipient phrase used after a two-object anaphoric
+/// source set. Full consumption keeps "the other player/permanent" out.
+fn is_the_other_recipient(recipient_phrase: &str) -> bool {
+    all_consuming(tag::<_, _, OracleError<'_>>("the other"))
+        .parse(recipient_phrase)
+        .is_ok()
+}
+
+/// CR 120.3: recognize the pairwise recipient in both fixed damage
+/// ("deals N damage to the other") and characteristic damage ("deals damage
+/// equal to its toughness to the other"). The latter has no `" damage to "`
+/// delimiter, so Pattern 2 consumes the suffix last and requires EOF.
+fn has_pairwise_other_recipient(predicate_lower: &str) -> bool {
+    damage_recipient_phrase(predicate_lower).is_some_and(is_the_other_recipient)
+        || all_consuming((
+            take_until::<_, _, OracleError<'_>>(" to the other"),
+            tag(" to the other"),
+            opt(tag(".")),
+        ))
+        .parse(predicate_lower)
         .is_ok()
 }
 
@@ -7389,6 +7428,48 @@ mod tests {
         assert!(matches!(sources, TargetFilter::Typed(_)), "got {sources:?}");
         assert_eq!(amount, QuantityExpr::Fixed { value: 1 });
         assert_eq!(recipient, EachDamageRecipient::EachController);
+    }
+
+    #[test]
+    fn each_of_those_deals_to_the_other_is_pairwise_damage() {
+        let text = "each of those creatures deals damage equal to its toughness to the other";
+        let mut ctx = ParseContext {
+            declared_target_slots: vec![
+                TargetFilter::Typed(TypedFilter::creature()),
+                TargetFilter::Typed(TypedFilter::creature()),
+            ],
+            ..Default::default()
+        };
+        let effect = try_parse_each_source_deals_damage(text, &mut ctx)
+            .expect("declared object pair parses")
+            .effect;
+        let Effect::EachSourceDealsDamage {
+            sources,
+            amount,
+            recipient,
+        } = effect
+        else {
+            panic!("expected pairwise EachSourceDealsDamage, got {effect:?}");
+        };
+        assert_eq!(sources, TargetFilter::ParentTarget);
+        assert!(crate::game::quantity::quantity_expr_contains_scope(
+            &amount,
+            ObjectScope::BatchSource,
+        ));
+        assert!(matches!(
+            recipient,
+            EachDamageRecipient::OtherBatchSource { source_filters }
+                if source_filters.iter().all(|filter| matches!(
+                    filter.as_ref(),
+                    TargetFilter::Typed(typed)
+                        if typed.type_filters.contains(&TypeFilter::Creature)
+                ))
+        ));
+        assert!(!is_the_other_recipient("the other player"));
+        assert!(!has_pairwise_other_recipient(
+            "deals damage equal to its toughness to the other player"
+        ));
+        assert!(try_parse_each_source_deals_damage(text, &mut ParseContext::default()).is_none());
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/subject.rs
+++ b/crates/engine/src/parser/oracle_effect/subject.rs
@@ -3728,12 +3728,7 @@ fn resolve_they_pronoun(ctx: &mut ParseContext) -> TargetFilter {
     for (index, slot) in ctx.declared_target_slots.iter().enumerate() {
         let is_player = match slot {
             TargetFilter::Player | TargetFilter::Opponent => true,
-            TargetFilter::Typed(TypedFilter {
-                type_filters,
-                properties,
-                ..
-            }) => type_filters.is_empty() && properties.is_empty(),
-            _ => false,
+            filter => filter.is_player_scope(),
         };
         if is_player {
             if declared_player_slot.is_some() {
@@ -7006,6 +7001,32 @@ mod tests {
     };
     use crate::types::card_type::{CoreType, Supertype};
     use crate::types::statics::BlockExceptionKind;
+
+    #[test]
+    fn they_ignores_controllerless_empty_typed_target_slot() {
+        let mut only_empty = ParseContext {
+            declared_target_slots: vec![TargetFilter::Typed(TypedFilter::default())],
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_they_pronoun(&mut only_empty),
+            TargetFilter::ParentTarget,
+            "an empty object filter must not masquerade as a player slot"
+        );
+
+        let mut with_opponent = ParseContext {
+            declared_target_slots: vec![
+                TargetFilter::Typed(TypedFilter::default()),
+                TargetFilter::Opponent,
+            ],
+            ..Default::default()
+        };
+        assert_eq!(
+            resolve_they_pronoun(&mut with_opponent),
+            TargetFilter::ParentTargetSlot { index: 1 },
+            "the sole genuine player slot must remain unambiguous"
+        );
+    }
 
     /// CR 105.3 + CR 106.1a: "becomes that color" (Foraging Wickermaw) maps to the
     /// same `AddChosenColor` reader as "the chosen color" (Puca's Eye) — only the

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1509,7 +1509,9 @@ pub(crate) enum ChooseImperativeAst {
     /// sub_ability lattice.
     TwoTargets {
         target_a: TargetFilter,
-        target_b: TargetFilter,
+        target_a_multi_target: Option<MultiTargetSpec>,
+        target_b: Box<TargetFilter>,
+        target_b_multi_target: Option<MultiTargetSpec>,
     },
     /// CR 608.2d + CR 122.1: "choose a counter on it / that permanent" — pick one
     /// of the distinct counter kinds present on the anaphoric object (The Caves

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -11653,6 +11653,16 @@ pub enum EachDamageRecipient {
     /// ("each creature deals 1 damage to its controller"). A per-source recipient
     /// computed at resolution — surfaces no player-selectable target slot.
     EachController,
+    /// CR 120.1 + CR 608.2c: in an exactly two-object targeted batch, each
+    /// source deals to the other source ("each of those creatures ... to the
+    /// other"). Zero or one surviving/chosen object has no "other" and deals
+    /// no damage; any non-pair cardinality fails closed.
+    OtherBatchSource {
+        /// The two declared target-slot filters, in announcement order. These
+        /// remain the CR 608.2b legality authority at resolution; the compact
+        /// selected object list alone cannot prove type/controller legality.
+        source_filters: [Box<TargetFilter>; 2],
+    },
     // DEFERRED (§9, set-audit backlog): AttachedPermanent — each Aura source deals
     // to the permanent it's attached to (CR 303.4). Needs a new attachment
     // `FilterProp` (`AttachedToObjectOfType`) for the source filter; until then
@@ -12329,7 +12339,7 @@ pub enum Effect {
     },
     /// CR 120.1 + CR 120.3 + CR 608.2: Each object matching `sources` (evaluated
     /// at resolution time, CR 608.2) deals `amount` damage as its OWN source
-    /// (CR 120.1) to `recipient`. The filter-evaluated-source counterpart of
+    /// (CR 120.1) to `recipient`. Primarily the filter-evaluated-source counterpart of
     /// [`Effect::EachDealsDamageEqualToPower`] (whose sources are announced
     /// targets with a `multi_target` count and whose amount is each source's own
     /// power). Split as a sibling — not unified — because the source-selection
@@ -12338,17 +12348,21 @@ pub enum Effect {
     /// `QuantityExpr` so a future variable-amount filter-source card extends
     /// `amount` rather than adding a third sibling.
     ///
-    /// Covers "each <object class> [you control] deals N damage to <recipient>":
+    /// Covers "each <object class> [you control] deals N damage to <recipient>"
+    /// and the targeted pairwise "each of those ... to the other" shape:
     /// tribal pingers (Sarkhan the Masterless, Princess Snowfall), villainous-
     /// choice / modal pingers (Missy, Rakdos Charm), and Pestilence-adjacent "each
     /// creature deals" (Aura Barbs clause 1). `recipient` is an
-    /// [`EachDamageRecipient`] so "its controller" (per-source) and a shared
-    /// announced/context target are both expressed without a boolean.
+    /// [`EachDamageRecipient`] so "its controller" (per-source), a shared
+    /// announced/context target, and an exact reciprocal pair are expressed
+    /// without booleans.
     EachSourceDealsDamage {
         /// CR 608.2: The source class, evaluated against the battlefield at
         /// resolution. Each matching object is an independent damage source
-        /// (CR 120.1). Always a non-player object-class filter — player-shaped
-        /// subjects route to `DamageEachPlayer`.
+        /// (CR 120.1). Ordinarily a non-player object-class filter — player-shaped
+        /// subjects route to `DamageEachPlayer`. `ParentTarget` is reserved for
+        /// the typed `OtherBatchSource` pairwise relation, whose exact announced
+        /// objects are retained on the damage node.
         sources: TargetFilter,
         /// CR 120.1: Damage dealt by every source. Uniform across the batch
         /// (resolved once, CR 608.2) UNLESS the amount reads the per-source
@@ -12356,8 +12370,8 @@ pub enum Effect {
         /// in which case it is resolved per batch member (each source is the
         /// source of its own damage, CR 120.1).
         amount: QuantityExpr,
-        /// CR 120.3: The recipient resolution strategy (shared target vs
-        /// per-source controller).
+        /// CR 120.3: The recipient resolution strategy (shared target,
+        /// per-source controller, or the other member of an exact target pair).
         recipient: EachDamageRecipient,
     },
     /// CR 121.1: Draw a card.
@@ -17188,8 +17202,8 @@ impl Effect {
             // CR 115.1 / CR 608.2c: a `Shared` recipient is resolved exactly like
             // `DealDamage::target` — surface it so the same target-slot collection
             // and event-context hydration build / bind the recipient. The
-            // `EachController` and deferred per-source recipients carry no slot and
-            // fall through to the `None` group below.
+            // `EachController` carries no slot; `OtherBatchSource` reuses the
+            // two preceding `TargetOnly` slots. Both fall through to `None`.
             Effect::EachSourceDealsDamage {
                 recipient: EachDamageRecipient::Shared(filter),
                 ..
@@ -17491,11 +17505,13 @@ impl Effect {
             // spec, the recipient is one mandatory slot), not by `target_filter()`.
             | Effect::EachDealsDamageEqualToPower { .. }
             // CR 109.4 + CR 120.3a: `EachController` resolves per-source at the
-            // resolver — no player-selectable target slot. Exhaustive match
-            // ensures any future `EachDamageRecipient` variant must be
-            // explicitly decided here rather than silently falling through.
+            // resolver; `OtherBatchSource` reuses the preceding declared object
+            // slots. Neither surfaces another selectable slot. Exhaustive match
+            // ensures future recipient variants are explicitly decided here.
             | Effect::EachSourceDealsDamage {
-                recipient: EachDamageRecipient::EachController,
+                recipient:
+                    EachDamageRecipient::EachController
+                        | EachDamageRecipient::OtherBatchSource { .. },
                 ..
             }
             // CR 701.12a: player targets (player_a/player_b) are surfaced as

--- a/crates/engine/tests/integration/issue_4235_cloak_and_dagger_entwined.rs
+++ b/crates/engine/tests/integration/issue_4235_cloak_and_dagger_entwined.rs
@@ -217,6 +217,10 @@ fn full_card_can_decline_without_exiling_either_alternative() {
     assert_eq!(zone_of(&runner, cloak), Zone::Battlefield);
     assert_eq!(zone_of(&runner, prey), Zone::Battlefield);
     assert_eq!(zone_of(&runner, hand_card), Zone::Hand);
+    assert!(
+        runner.state().public_revealed_cards.contains(&hand_card),
+        "the chosen opponent's hand must be revealed through ParentTargetSlot 0"
+    );
     assert!(runner.state().exile_links.is_empty());
 }
 

--- a/crates/engine/tests/integration/issue_4235_cloak_and_dagger_entwined.rs
+++ b/crates/engine/tests/integration/issue_4235_cloak_and_dagger_entwined.rs
@@ -1,6 +1,5 @@
 //! Issue #4235: Cloak and Dagger, Entwined — plural "leave the battlefield"
-//! duration parsing, interactive-choice duration carry-through, and coverage
-//! honesty for the card's unsupported "or the chosen creature" alternative.
+//! duration parsing, per-slot targeting, and heterogeneous exile choice.
 //!
 //! Oracle text (Marvel Spider-Man set MSH, read from `client/public/card-data.json`):
 //!   "Deathtouch, lifelink
@@ -29,20 +28,17 @@
 //!    proves the chosen card's exile link survives an interactive selection
 //!    and the card returns when the source leaves.
 //!
-//! 3. COVERAGE HONESTY (review blocker 2): the full printed sentence carries
-//!    an "or the chosen creature" alternative that depends on the secondary
-//!    "up to one target creature they control" declaration — neither of
-//!    which is representable yet (no object-anaphor "the chosen creature"
-//!    filter exists, and the hand filter is not bound to the chosen
-//!    opponent). Rather than accept the card while silently dropping the
-//!    alternative, the full clause now stays an explicit strict failure
-//!    (`Effect::Unimplemented`) until that binding is implemented; the
-//!    duration and carry-through fixes are exercised through the supported
-//!    single-referent form of the same idiom.
+//! 3. The full printed sentence now uses two independent target slots: an
+//!    exact-one opponent and an up-to-one creature that opponent controls.
+//!    The reveal binds slot 0, and one optional zone choice unions a nonland
+//!    card in that opponent's hand with the chosen creature in slot 1.
 
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::parser::oracle::parse_oracle_text;
-use engine::types::ability::{Duration, Effect};
+use engine::types::ability::{
+    ControllerRef, Duration, Effect, FilterProp, MultiTargetSpec, QuantityExpr, TargetFilter,
+    TypeFilter,
+};
 use engine::types::actions::GameAction;
 use engine::types::game_state::{ExileLinkKind, WaitingFor};
 use engine::types::identifiers::ObjectId;
@@ -50,8 +46,7 @@ use engine::types::phase::Phase;
 use engine::types::triggers::TriggerMode;
 use engine::types::zones::Zone;
 
-/// Cloak and Dagger's full, real printed text — carries the unsupported
-/// "or the chosen creature" alternative.
+/// Cloak and Dagger's full, real printed text.
 const CLOAK_AND_DAGGER_FULL: &str = "Deathtouch, lifelink\n\
 When Cloak and Dagger enter, choose target opponent and up to one target creature they control. \
 They reveal their hand. You may exile a nonland card from their hand or the chosen creature \
@@ -106,13 +101,11 @@ fn plural_leave_duration_parses_on_supported_subset() {
     );
 }
 
-/// Coverage honesty (review blocker 2): the FULL printed text's exile clause
-/// carries the "or the chosen creature" alternative, which has no
-/// representable lowering yet. The clause must surface as an explicit strict
-/// failure — an `Effect::Unimplemented` node somewhere in the trigger chain —
-/// not as a supported-looking exile that silently dropped the alternative.
+/// CR 115.1d + CR 608.2c: the full Oracle text preserves both independently
+/// announced target slots and both exile alternatives without an unsupported
+/// node or a broad immediate-parent anaphor.
 #[test]
-fn full_card_with_chosen_creature_alternative_stays_strict_failure() {
+fn full_card_has_exact_target_slots_reveal_binding_and_exile_union() {
     let parsed = parse_oracle_text(
         CLOAK_AND_DAGGER_FULL,
         "Cloak and Dagger, Entwined",
@@ -121,38 +114,249 @@ fn full_card_with_chosen_creature_alternative_stays_strict_failure() {
         &[],
     );
 
-    fn chain_has_unimplemented(def: &engine::types::ability::AbilityDefinition) -> bool {
-        fn effect_unimplemented(effect: &Effect) -> bool {
-            matches!(effect, Effect::Unimplemented { .. })
-        }
-        effect_unimplemented(&def.effect)
-            || def
-                .sub_ability
-                .as_deref()
-                .is_some_and(chain_has_unimplemented)
-            || def
-                .else_ability
-                .as_deref()
-                .is_some_and(chain_has_unimplemented)
-    }
-
-    let etb_has_strict_failure = parsed
+    let execute = parsed
         .triggers
         .iter()
-        .filter(|t| t.mode == TriggerMode::ChangesZone)
-        .filter_map(|t| t.execute.as_deref())
-        .any(chain_has_unimplemented);
-    assert!(
-        etb_has_strict_failure,
-        "the unsupported 'or the chosen creature' alternative must keep the \
-         clause an explicit Unimplemented strict failure, not a silently \
-         narrowed exile; got triggers: {:#?}",
-        parsed.triggers
+        .find(|t| t.mode == TriggerMode::ChangesZone)
+        .and_then(|t| t.execute.as_deref())
+        .expect("ETB execute");
+    assert!(matches!(
+        execute.effect.as_ref(),
+        Effect::TargetOnly {
+            target: TargetFilter::Typed(tf)
+        } if tf.controller == Some(ControllerRef::Opponent)
+    ));
+    assert_eq!(
+        execute.multi_target,
+        Some(MultiTargetSpec::exact(QuantityExpr::Fixed { value: 1 }))
     );
+    let creature = execute.sub_ability.as_deref().expect("creature slot");
+    assert!(matches!(
+        creature.effect.as_ref(),
+        Effect::TargetOnly {
+            target: TargetFilter::Typed(tf)
+        } if tf.type_filters.contains(&TypeFilter::Creature)
+            && tf.controller == Some(ControllerRef::TargetOpponent)
+    ));
+    assert_eq!(
+        creature.multi_target,
+        Some(MultiTargetSpec::up_to(QuantityExpr::Fixed { value: 1 }))
+    );
+    let reveal = creature.sub_ability.as_deref().expect("reveal");
+    assert!(matches!(
+        reveal.effect.as_ref(),
+        Effect::RevealHand {
+            target: TargetFilter::ParentTargetSlot { index: 0 },
+            ..
+        }
+    ));
+    let exile = reveal.sub_ability.as_deref().expect("exile");
+    let Effect::ChangeZone {
+        origin: None,
+        destination: Zone::Exile,
+        target: TargetFilter::Or { filters },
+        ..
+    } = exile.effect.as_ref()
+    else {
+        panic!("expected heterogeneous exile union, got {:?}", exile.effect);
+    };
+    assert_eq!(exile.duration, Some(Duration::UntilHostLeavesPlay));
+    assert!(exile.optional);
+    assert!(filters.iter().any(|filter| matches!(
+        filter,
+        TargetFilter::Typed(tf)
+            if tf.controller == Some(ControllerRef::TargetOpponent)
+                && tf.properties.contains(&FilterProp::InZone { zone: Zone::Hand })
+    )));
+    assert!(filters.iter().any(|filter| matches!(
+        filter,
+        TargetFilter::And { filters }
+            if filters.contains(&TargetFilter::ParentTargetSlot { index: 1 })
+    )));
+
+    fn assert_no_unimplemented(def: &engine::types::ability::AbilityDefinition) {
+        assert!(!matches!(def.effect.as_ref(), Effect::Unimplemented { .. }));
+        if let Some(sub) = def.sub_ability.as_deref() {
+            assert_no_unimplemented(sub);
+        }
+        if let Some(other) = def.else_ability.as_deref() {
+            assert_no_unimplemented(other);
+        }
+    }
+    assert_no_unimplemented(execute);
 }
 
 fn zone_of(runner: &GameRunner, id: ObjectId) -> Zone {
     runner.state().objects[&id].zone
+}
+
+#[test]
+fn full_card_can_decline_without_exiling_either_alternative() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let cloak = scenario
+        .add_creature_to_hand_from_oracle(
+            P0,
+            "Cloak and Dagger, Entwined",
+            2,
+            2,
+            CLOAK_AND_DAGGER_FULL,
+        )
+        .id();
+    let prey = scenario.add_creature(P1, "Opponent Creature", 2, 2).id();
+    let hand_card = scenario.add_card_to_hand(P1, "Opponent Spell");
+    let mut runner = scenario.build();
+
+    runner
+        .cast(cloak)
+        .target_player(P1)
+        .target_object(prey)
+        .decline_optional()
+        .resolve();
+
+    assert_eq!(zone_of(&runner, cloak), Zone::Battlefield);
+    assert_eq!(zone_of(&runner, prey), Zone::Battlefield);
+    assert_eq!(zone_of(&runner, hand_card), Zone::Hand);
+    assert!(runner.state().exile_links.is_empty());
+}
+
+#[test]
+fn full_card_may_omit_creature_target_and_exile_only_opponents_nonland_hand_card() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let cloak = scenario
+        .add_creature_to_hand_from_oracle(
+            P0,
+            "Cloak and Dagger, Entwined",
+            2,
+            2,
+            CLOAK_AND_DAGGER_FULL,
+        )
+        .id();
+    let pick = scenario.add_card_to_hand(P1, "Opponent Spell A");
+    let keep = scenario.add_card_to_hand(P1, "Opponent Spell B");
+    let land = scenario.add_land_to_hand(P1, "Opponent Land").id();
+    let mut runner = scenario.build();
+
+    runner
+        .cast(cloak)
+        .target_player(P1)
+        .accept_optional()
+        .effect_zone(&[pick])
+        .resolve();
+
+    assert_eq!(zone_of(&runner, pick), Zone::Exile);
+    assert_eq!(zone_of(&runner, keep), Zone::Hand);
+    assert_eq!(zone_of(&runner, land), Zone::Hand);
+    assert!(runner.state().exile_links.iter().any(|link| {
+        link.exiled_id == pick
+            && link.source_id == cloak
+            && link.kind
+                == ExileLinkKind::UntilSourceLeaves {
+                    return_zone: Zone::Hand,
+                }
+    }));
+}
+
+#[test]
+fn full_card_can_choose_creature_and_returns_it_when_source_leaves() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let cloak = scenario
+        .add_creature_to_hand_from_oracle(
+            P0,
+            "Cloak and Dagger, Entwined",
+            2,
+            2,
+            CLOAK_AND_DAGGER_FULL,
+        )
+        .id();
+    let prey = scenario.add_creature(P1, "Opponent Creature", 2, 2).id();
+    let hand_card = scenario.add_card_to_hand(P1, "Opponent Spell");
+    let destroy = scenario
+        .add_spell_to_hand_from_oracle(P0, "Murder", true, "Destroy target creature.")
+        .id();
+    let mut runner = scenario.build();
+
+    runner
+        .cast(cloak)
+        .target_player(P1)
+        .target_object(prey)
+        .accept_optional()
+        .effect_zone(&[prey])
+        .resolve();
+    assert_eq!(zone_of(&runner, prey), Zone::Exile);
+    assert_eq!(zone_of(&runner, hand_card), Zone::Hand);
+    assert!(runner.state().exile_links.iter().any(|link| {
+        link.exiled_id == prey
+            && link.source_id == cloak
+            && link.kind
+                == ExileLinkKind::UntilSourceLeaves {
+                    return_zone: Zone::Battlefield,
+                }
+    }));
+
+    runner.cast(destroy).target_object(cloak).resolve();
+    assert_eq!(zone_of(&runner, cloak), Zone::Graveyard);
+    assert_eq!(zone_of(&runner, prey), Zone::Battlefield);
+    assert!(!runner
+        .state()
+        .exile_links
+        .iter()
+        .any(|link| link.exiled_id == prey));
+}
+
+#[test]
+fn until_source_leaves_does_not_begin_after_source_left_event() {
+    use engine::game::effects::resolve_ability_chain;
+    use engine::types::ability::{DurationEvent, ResolvedAbility, TargetFilter, TypedFilter};
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Departed Exiler", 2, 2).id();
+    let candidate = scenario.add_card_to_hand(P1, "Opponent Spell");
+    let mut runner = scenario.build();
+    runner.state_mut().objects.get_mut(&source).unwrap().zone = Zone::Graveyard;
+
+    let mut ability = ResolvedAbility::new(
+        Effect::ChangeZone {
+            origin: Some(Zone::Hand),
+            destination: Zone::Exile,
+            target: TargetFilter::Typed(
+                TypedFilter::card()
+                    .controller(ControllerRef::Opponent)
+                    .properties(vec![FilterProp::InZone { zone: Zone::Hand }]),
+            ),
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: engine::types::zones::EtbTapState::Unspecified,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            conditional_enter_with_counters: vec![],
+            face_down_profile: None,
+            enters_modified_if: None,
+        },
+        vec![],
+        source,
+        P0,
+    );
+    ability.duration = Some(Duration::UntilHostLeavesPlay);
+    ability
+        .context
+        .duration_events
+        .push(DurationEvent::SourceLeftBattlefield);
+
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &ability, &mut events, 0)
+        .expect("expired duration must resolve as a no-op");
+    assert_eq!(zone_of(&runner, candidate), Zone::Hand);
+    assert!(!matches!(
+        runner.state().waiting_for,
+        WaitingFor::EffectZoneChoice { .. }
+    ));
+    assert!(runner.state().exile_links.is_empty());
 }
 
 /// Runtime regression for review blocker 1: TWO eligible nonland candidates
@@ -162,13 +366,11 @@ fn zone_of(runner: &GameRunner, id: ObjectId) -> Zone {
 /// round-trip, and the card must return to its owner's hand when the source
 /// leaves the battlefield.
 ///
-/// The bounded exile is driven as a hand-built `ResolvedAbility` through the
+/// The bounded exile is also driven as a hand-built `ResolvedAbility` through the
 /// production `resolve_ability_chain` -> `change_zone::resolve` ->
 /// `WaitingFor::EffectZoneChoice` -> `engine_resolution_choices` resume
-/// pipeline — the exact authority the review named — rather than through
-/// Cloak and Dagger's printed text: the full card is now an honest strict
-/// failure (see the coverage-honesty test above), so no parsed card text can
-/// exercise this seam for the two-candidate case yet.
+/// pipeline — the exact low-level authority the original review named — so the
+/// duration carrier remains covered independently of the full-card E2E paths.
 #[test]
 fn interactive_two_candidate_exile_choice_preserves_until_leaves_link() {
     use engine::game::effects::resolve_ability_chain;


### PR DESCRIPTION
## Summary

Add full engine support for Cloak and Dagger, Entwined through generic typed target-slot, root-aware target-player, pairwise target-batch damage, and until-source-leaves machinery. The implementation preserves independent target cardinality, binds the optional creature to the mandatory opponent, reveals the selected opponent's hand, and supports choosing either a nonland hand card or the creature.

The review follow-up also makes The Great Aerie and Grim Contest's reciprocal damage use the exact immediate two-target batch, with target-incarnation and legality revalidation at resolution.

## Track

Developer

## LLM

Model: gpt-5.6-sol (via Codex; canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 115.1c-d, 115.10a
- CR 601.2c
- CR 608.2b-d, 608.2h
- CR 120.1, 120.6, 120.10
- CR 701.13a
- CR 404.1

## Verification

- [x] Exact head `8eec1b7b7025a709903424b96ad48afe4594e164` reviewed and validated.
- [x] Gate A/G receipts below are bound to the exact head and base.
- [x] Gate B anchors are existing analogous code at the same seams.

Exact-head focused validation (all PASS, 0 failed):

- root-aware sibling target-player consumers, ambiguous empty `TypedFilter`, Great Aerie zero/zero resolution, Great Aerie/Mouth to Mouth/Teferi parser blast radius, and Cloak integration 7/7;
- full-consuming pairwise parser discriminator;
- The Great Aerie production pipeline for all four optional target combinations (0/0, 1/0, 0/1, 1/1);
- Grim Contest mandatory reciprocal-damage pipeline;
- hostile immediate-provenance test covering an unrelated older target, an omitted immediate slot, and a target leaving before resolution.

Broader validation:

- `cargo fmt --all -- --check` and `git diff --check` — PASS.
- `CARGO_BUILD_JOBS=1 cargo clippy-strict` — PASS on the reviewed implementation; exact-head CI owns the final rerun.
- Warm full workspace validation passed all project tests except the two documented Windows-only `probe-pin` shell-fixture failures, reproduced unchanged on clean base; doc tests PASS. Exact-head CI owns the final platform matrix after the review follow-up.
- Exact-head frozen-data parse projection: exactly 4 cards / 8 signatures; no unclaimed parser blast radius.
- Exact-head targeted coverage audit: 0 engine gaps / 0 coverage-honesty findings for the affected cards.
- Semantic audit: 0 findings on the affected cards.
- Generated artifacts: no unintended tracked diff.

Runtime discriminators:

- The opponent target is mandatory while its dependent creature target is independently optional.
- The selected opponent's hand becomes visible to the caster through the production reveal authority.
- Declining exile leaves both alternatives unchanged; omitting the creature still permits the opponent's nonland hand card.
- Exiled creatures return when the source leaves; if the source is already gone, no impossible-duration exile begins.
- Pairwise damage uses only the nearest two declared object slots, revalidates live incarnations, no-ops for 0/1 valid sources, and resolves reciprocally for two valid sources.

## Gate B anchors

- `crates/engine/src/parser/oracle_effect/imperative.rs:2168` — existing `strip_optional_target_prefix` cardinality authority.
- `crates/engine/src/parser/oracle_effect/subject.rs:2503` — existing typed target metadata path.
- `crates/engine/src/parser/oracle_effect/subject.rs:3747` — existing `ParentTargetSlot` definite-anaphor binding.

## Gate A / Gate G

Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)

Gate A PASS head=8eec1b7b7025a709903424b96ad48afe4594e164 base=9c4871154a29a6f8aceefc18856225afb362dc4b

## Final review-impl

Final review-impl PASS head=8eec1b7b7025a709903424b96ad48afe4594e164 base=9c4871154a29a6f8aceefc18856225afb362dc4b

Reviewed seams: typed target cardinality, root-aware player authority, immediate target-batch provenance, branch isolation, target legality/incarnation validation, reciprocal damage, parser full consumption, scan/RW/coverage threading, and production runtime tests.

## Claimed parse impact

- Cloak and Dagger, Entwined
- The Great Aerie
- Grim Contest
- Mouth to Mouth

Parse projection: 4 cards / 8 signatures against `9c4871154a29a6f8aceefc18856225afb362dc4b`.

## Scope Expansion

None. The change stays inside generic typed target slots, target-relative player resolution, pairwise target-batch damage, and until-source-leaves seams. No card-name dispatch was added.

## Validation Failures

None in the exact-head focused matrix. The two Windows-only `probe-pin` shell-fixture failures in the broader local workspace run reproduce on clean base and are unrelated to this diff.

## CI Failures

None known. Fresh upstream CI is running for exact head `8eec1b7b7025a709903424b96ad48afe4594e164`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for pairwise damage effects where two selected objects deal damage to each other.
  * Added support for choosing up to one target alongside an opponent’s hand cards for exile effects.
  * Improved handling of chained and optional targets during effect resolution.

* **Bug Fixes**
  * Corrected target selection, ownership, controller, and attachment resolution in chained abilities.
  * Prevented invalid, expired, or omitted targets from producing unintended effects.
  * Improved parsing and execution for Cloak and Dagger and related card interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->