### PR TITLE
ship/feat engine add structured action rejections 2

### DIFF
--- a/client/src/adapter/__tests__/engine-worker-client.test.ts
+++ b/client/src/adapter/__tests__/engine-worker-client.test.ts
@@ -37,8 +37,14 @@ class MockWorker {
   }
 
   /** Simulate a typed failure reply for a previously-posted request id. */
-  replyError(id: number, message: string): void {
-    this.onmessage?.({ data: { type: "error", id, message } } as MessageEvent);
+  replyError(
+    id: number,
+    message: string,
+    actionRejection?: unknown,
+  ): void {
+    this.onmessage?.({
+      data: { type: "error", id, message, actionRejection },
+    } as MessageEvent);
   }
 
   /** Simulate failure to load or execute the worker script itself. */
@@ -157,5 +163,48 @@ describe("EngineWorkerClient request timeout", () => {
     // rejection that fails the run).
     await vi.advanceTimersByTimeAsync(60_000);
     await expect(promise).resolves.toEqual({ stack: [] });
+  });
+});
+
+describe("EngineWorkerClient structured action rejections", () => {
+  it("preserves engine rejection metadata and stale disposition", async () => {
+    const client = new EngineWorkerClient();
+    const promise = client.submitAction(0, { type: "PassPriority" });
+    const worker = currentWorker();
+    const reqId = worker.posted[0].id as number;
+    const rejection = {
+      code: "stale_action" as const,
+      disposition: "stale" as const,
+      message: "That action is based on outdated game state.",
+      related_object_ids: [7],
+    };
+
+    worker.replyError(reqId, rejection.message, rejection);
+
+    await expect(promise).rejects.toMatchObject({
+      code: "STALE_ACTION",
+      recoverable: false,
+      rejection,
+    });
+  });
+
+  it("rejects a malformed DTO without surfacing its untrusted message", async () => {
+    const client = new EngineWorkerClient();
+    const promise = client.submitAction(0, { type: "PassPriority" });
+    const worker = currentWorker();
+    const reqId = worker.posted[0].id as number;
+
+    worker.replyError(reqId, "untrusted diagnostic", {
+      code: "stale_action",
+      disposition: "invalid",
+      message: "untrusted diagnostic",
+      related_object_ids: [7],
+    });
+
+    await expect(promise).rejects.toMatchObject({
+      code: "ACTION_REJECTED",
+      message: "The engine rejected that action.",
+      rejection: undefined,
+    });
   });
 });

--- a/client/src/adapter/__tests__/p2p-adapter-broker.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-broker.test.ts
@@ -15,6 +15,7 @@ import type { DataConnection } from "peerjs";
 import { P2PHostAdapter } from "../p2p-adapter";
 import type { BrokerClient } from "../../services/brokerClient";
 import { FakeDataConnection } from "../../network/__tests__/fakeDataConnection";
+import { WIRE_PROTOCOL_VERSION } from "../../network/protocol";
 
 // See p2p-adapter-multiplayer.test.ts — bypass CompressionStream because it
 // doesn't drain under fake timers in happy-dom. `protocol.test.ts` covers
@@ -235,6 +236,7 @@ describe("P2PHostAdapter — broker integration", () => {
     conn.fireOpen();
     await conn.simulateData({
       type: "guest_deck",
+      wireProtocolVersion: WIRE_PROTOCOL_VERSION,
       deckData: {
         player: { main_deck: ["Forest"], sideboard: [] },
       },
@@ -259,6 +261,7 @@ describe("P2PHostAdapter — broker integration", () => {
     conn.fireOpen();
     await conn.simulateData({
       type: "guest_deck",
+      wireProtocolVersion: WIRE_PROTOCOL_VERSION,
       deckData: {
         player: { main_deck: ["Forest"], sideboard: [] },
       },
@@ -283,6 +286,7 @@ describe("P2PHostAdapter — broker integration", () => {
     conn.fireOpen();
     await conn.simulateData({
       type: "guest_deck",
+      wireProtocolVersion: WIRE_PROTOCOL_VERSION,
       deckData: {
         player: { main_deck: ["Forest"], sideboard: [] },
       },
@@ -305,6 +309,7 @@ describe("P2PHostAdapter — broker integration", () => {
     conn.fireOpen();
     await conn.simulateData({
       type: "guest_deck",
+      wireProtocolVersion: WIRE_PROTOCOL_VERSION,
       deckData: {
         player: { main_deck: ["Forest"], sideboard: [] },
       },

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -494,7 +494,7 @@ async function joinGuest(
   const conn = new FakeOpenableConnection();
   emitConnection(conn as unknown as DataConnection);
   conn.fireOpen();
-  await conn.simulateData(msg);
+  await conn.simulateData({ ...msg, wireProtocolVersion: msg.wireProtocolVersion ?? WIRE_PROTOCOL_VERSION });
   return conn;
 }
 
@@ -903,6 +903,7 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     const secondJoin = secondConn.simulateData({
       type: "guest_deck",
       deckData: { player: { main_deck: ["Swamp"], sideboard: [] } },
+      wireProtocolVersion: WIRE_PROTOCOL_VERSION,
     });
     await flushPromises();
 
@@ -1149,16 +1150,60 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
       action: { type: "PassPriority" },
     });
 
-    // Spoofing guest receives action_rejected.
+    // Envelope spoofing is an operational transport fault, not an engine
+    // rejection payload.
     const rejected = (await g2.getSentMessages()).find(
       (m) =>
         typeof m === "object" &&
         m !== null &&
-        (m as { type: string }).type === "action_rejected",
+        (m as { type: string }).type === "action_failed",
     );
     expect(rejected).toBeDefined();
     // And the spoofed action did NOT reach the engine.
     expect(mockSubmitAction).not.toHaveBeenCalled();
+  });
+
+  it("separates engine rejections from host operational action failures", async () => {
+    const { adapter, emitConnection } = makeHost(2);
+    await adapter.initialize();
+    const guest = await joinGuest(emitConnection, {
+      type: "guest_deck",
+      deckData: { player: { main_deck: [], sideboard: [] } },
+    });
+    await adapter.initializeGame();
+    guest.sent.length = 0;
+
+    const rejection = {
+      code: "invalid_action" as const,
+      disposition: "invalid" as const,
+      message: "Engine error: invalid action",
+      related_object_ids: [42],
+    };
+    mockSubmitAction.mockRejectedValueOnce(
+      new AdapterError(AdapterErrorCode.ACTION_REJECTED, rejection.message, true, undefined, rejection),
+    );
+    await guest.simulateData({
+      type: "action",
+      senderPlayerId: 1,
+      action: { type: "PassPriority" },
+    });
+    expect(await guest.getSentMessages()).toContainEqual(expect.objectContaining({
+      type: "action_rejected",
+      rejection,
+    }));
+
+    guest.sent.length = 0;
+    mockSubmitAction.mockRejectedValueOnce(new Error("engine transport unavailable"));
+    await guest.simulateData({
+      type: "action",
+      senderPlayerId: 1,
+      action: { type: "PassPriority" },
+    });
+    expect(await guest.getSentMessages()).toContainEqual(expect.objectContaining({
+      type: "action_failed",
+      message: "engine transport unavailable",
+    }));
+    adapter.dispose();
   });
 
   it("fan-outs filtered state per-guest on submitAction", async () => {
@@ -2477,12 +2522,7 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     );
   });
 
-  // Issue #5913: the host relays the engine's verdict verbatim, so a guest must
-  // classify a stale ReorderHand exactly as the local-WASM seat does. Before the
-  // shared classifier this path built a generic ACTION_REJECTED, and
-  // `dispatchAction` — which suppresses only STALE_ACTION — still surfaced the
-  // red error to P2P guests.
-  it("guest classifies a stale ReorderHand rejection from the host as STALE_ACTION", async () => {
+  it("guest preserves a structured stale engine rejection from the host", async () => {
     const { peer } = createFakePeer();
     const conn = new FakeDataConnection();
     const adapter = new P2PGuestAdapter(
@@ -2491,6 +2531,8 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
       "host-peer",
       conn as unknown as DataConnection,
     );
+    const emitted = vi.fn();
+    adapter.onEvent(emitted);
     await adapter.initialize();
     await conn.simulateData({
       type: "game_setup",
@@ -2511,23 +2553,76 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     );
     await conn.simulateData({
       type: "action_rejected",
-      reason: "Engine error: ReorderHand: expected 6 ids, got 5",
+      rejection: {
+        code: "stale_action",
+        disposition: "stale",
+        message: "Engine error: ReorderHand no longer matches the hand",
+        related_object_ids: [1],
+      },
     });
     await expect(stale).rejects.toMatchObject({
       code: "STALE_ACTION",
       recoverable: false,
+      rejection: expect.objectContaining({ related_object_ids: [1] }),
     });
 
     // A genuine rejection must still surface as a recoverable ACTION_REJECTED.
     const real = adapter.submitAction({ type: "PassPriority" }, 1);
     await conn.simulateData({
       type: "action_rejected",
-      reason: "Engine error: Something genuinely wrong",
+      rejection: {
+        code: "invalid_action",
+        disposition: "invalid",
+        message: "Engine error: Something genuinely wrong",
+        related_object_ids: [],
+      },
     });
     await expect(real).rejects.toMatchObject({
       code: "ACTION_REJECTED",
       recoverable: true,
     });
+  });
+
+  it("guest rejects a malformed rejection DTO without exposing its arbitrary message", async () => {
+    const { peer } = createFakePeer();
+    const conn = new FakeDataConnection();
+    const adapter = new P2PGuestAdapter(
+      { player: { main_deck: [], sideboard: [] } },
+      peer as unknown as Peer,
+      "host-peer",
+      conn as unknown as DataConnection,
+    );
+    const emitted = vi.fn();
+    adapter.onEvent(emitted);
+    await adapter.initialize();
+    await conn.simulateData({
+      type: "game_setup",
+      wireProtocolVersion: WIRE_PROTOCOL_VERSION,
+      assignedPlayerId: 1,
+      playerToken: "seat-token",
+      state: remoteState("setup"),
+      events: [],
+      legalActions: [],
+      autoPassRecommended: false,
+      manaPaymentShortcutActions: [],
+    });
+    await adapter.initializeGame();
+
+    const pending = adapter.submitAction({ type: "PassPriority" }, 1);
+    await conn.simulateData({
+      type: "action_rejected",
+      rejection: { message: "untrusted host payload" },
+    } as never);
+    await expect(pending).rejects.toMatchObject({
+      code: "ACTION_REJECTED",
+      message: "Host sent an invalid action rejection",
+      rejection: undefined,
+    });
+
+    await conn.simulateData({ type: "action_failed", message: "Match concession unavailable" });
+    await conn.simulateData({ type: "action_rejected", rejection: { message: "untrusted" } } as never);
+    expect(emitted).toHaveBeenCalledWith({ type: "error", message: "Match concession unavailable" });
+    expect(emitted).toHaveBeenCalledWith({ type: "error", message: "Host sent an invalid action rejection" });
   });
 
   it("guest snapshots stay coherent and strictly ordered across successive state updates", async () => {
@@ -3031,8 +3126,8 @@ describe("P2PHostAdapter — bound draft match concession", () => {
     await guest.simulateData({ type: "match_concede" });
 
     expect(await guest.getSentMessages()).toContainEqual(expect.objectContaining({
-      type: "action_rejected",
-      reason: "Whole-match concession is unavailable for this game",
+      type: "action_failed",
+      message: "Whole-match concession is unavailable for this game",
     }));
     adapter.dispose();
   });
@@ -3275,14 +3370,14 @@ describe("P2P wire-protocol version gate", () => {
   // Both halves stamp LITERALS. A frame built from WIRE_PROTOCOL_VERSION
   // cannot tell a bumped client from an unbumped one, which is why every
   // other handshake fixture in the suite is useless as an instrument for a
-  // bump. Revert 30 → 29 and BOTH halves red: the v29 frame stops being
-  // refused, and the v30 frame stops being admitted. The admitting half is
-  // the reach-guard — without it "refuses v29" is also satisfied by a client
+  // bump. Revert 31 → 30 and BOTH halves red: the v30 frame stops being
+  // refused, and the v31 frame stops being admitted. The admitting half is
+  // the reach-guard — without it "refuses v30" is also satisfied by a client
   // that refuses everything.
-  it("refuses the previous wire protocol (v29) and admits its own (v30)", async () => {
+  it("refuses the previous wire protocol (v30) and admits its own (v31)", async () => {
     const refusing = makeGuest();
     await refusing.adapter.initialize();
-    await refusing.conn.simulateData(setupFrameAt(29));
+    await refusing.conn.simulateData(setupFrameAt(30));
 
     await expect(refusing.adapter.initializeGame()).rejects.toMatchObject({
       code: "P2P_REJECTED",
@@ -3294,12 +3389,30 @@ describe("P2P wire-protocol version gate", () => {
 
     const admitting = makeGuest();
     await admitting.adapter.initialize();
-    await admitting.conn.simulateData(setupFrameAt(30));
+    await admitting.conn.simulateData(setupFrameAt(31));
 
     await expect(admitting.adapter.initializeGame()).resolves.toBeDefined();
     expect(admitting.emitted).not.toHaveBeenCalledWith(
       expect.objectContaining({ type: "reconnectFailed" }),
     );
+  });
+
+  it("rejects a malformed present authority before bootstrap adoption", async () => {
+    const guest = makeGuest();
+    await guest.adapter.initialize();
+    await guest.conn.simulateData({
+      ...setupFrameAt(WIRE_PROTOCOL_VERSION),
+      authority: { sessionKey: "session", hostIncarnation: "host", extra: true },
+    } as never);
+
+    await expect(guest.adapter.initializeGame()).rejects.toMatchObject({
+      code: "P2P_REJECTED",
+      message: "Host sent a malformed P2P authority",
+    });
+    expect(guest.emitted).toHaveBeenCalledWith(expect.objectContaining({
+      type: "reconnectFailed",
+      reason: "Host sent a malformed P2P authority",
+    }));
   });
 
   // Derived, not a literal: this gate tests "unequal", not any particular
@@ -3328,30 +3441,30 @@ describe("P2P wire-protocol version gate", () => {
     adapter.dispose();
   });
 
-  // The discriminator for "absent means admit". Without it this gate is
-  // indistinguishable from one that treats a missing field as a mismatch —
-  // which would refuse every guest on an older bundle, including the ones
-  // that pair fine today.
-  it("admits a guest that stamps no wire version at all", async () => {
+  it("refuses a guest that omits the mandatory v28 wire version", async () => {
     const { adapter, emitConnection } = makeHost(2);
     await adapter.initialize();
 
-    const guest = await joinGuest(emitConnection, {
+    const guest = new FakeOpenableConnection();
+    emitConnection(guest as unknown as DataConnection);
+    guest.fireOpen();
+    await guest.simulateData({
       type: "guest_deck",
       deckData: { player: { main_deck: [], sideboard: [] } },
     });
-    await adapter.initializeGame();
 
-    expect(await sentOfType(guest, "reconnect_rejected")).toBeUndefined();
-    expect(guest.open).toBe(true);
-    expect(await sentOfType(guest, "game_setup")).toBeDefined();
+    expect(await sentOfType(guest, "reconnect_rejected")).toEqual(expect.objectContaining({
+      reason: expect.stringContaining("Wire protocol version required"),
+    }));
+    expect(guest.open).toBe(false);
+    expect(await sentOfType(guest, "game_setup")).toBeUndefined();
     adapter.dispose();
   });
 
   // The two first-contact stamp sites, asserted on the OUTBOUND frame. Neither
   // was covered before: deleting either stamp left the whole suite green,
-  // because a guest that fails to stamp is indistinguishable from an older
-  // bundle and the host's absent-means-admit branch swallows it silently. A
+  // because a guest that fails to stamp is rejected before the host allocates
+  // a seat. A
   // refactor dropping the `guest_deck` stamp would turn Unit 2 into a no-op
   // for every fresh join — the common path — with nothing red.
   it("stamps the wire version on both first-contact guest messages", async () => {

--- a/client/src/adapter/__tests__/server-draft-adapter.test.ts
+++ b/client/src/adapter/__tests__/server-draft-adapter.test.ts
@@ -594,5 +594,39 @@ describe("ServerDraftAdapter", () => {
         recoverable: true,
       });
     });
+
+    it("settles operational action and matching preview failures", async () => {
+      const action = adapter.submitAction({ type: "PassPriority" }, 0);
+      ws.dispatchSynthetic(
+        "message",
+        JSON.stringify({ type: "ActionFailed", data: { message: "action persistence failed" } }),
+      );
+      await expect(action).rejects.toMatchObject({
+        code: "WS_ERROR",
+        message: "action persistence failed",
+        recoverable: false,
+      });
+
+      const preview = adapter.previewManaPayment({ type: "PassPriority" }, 0);
+      const calls = ws.send.mock.calls;
+      const sent = JSON.parse(calls[calls.length - 1][0] as string);
+      const settled = vi.fn();
+      void preview.then(settled, settled);
+      ws.dispatchSynthetic(
+        "message",
+        JSON.stringify({ type: "ManaPaymentPreviewFailed", data: { request_id: sent.data.request_id + 1, message: "other preview failed" } }),
+      );
+      await Promise.resolve();
+      expect(settled).not.toHaveBeenCalled();
+      ws.dispatchSynthetic(
+        "message",
+        JSON.stringify({ type: "ManaPaymentPreviewFailed", data: { request_id: sent.data.request_id, message: "preview lookup failed" } }),
+      );
+      await expect(preview).rejects.toMatchObject({
+        code: "WS_ERROR",
+        message: "preview lookup failed",
+        recoverable: false,
+      });
+    });
   });
 });

--- a/client/src/adapter/__tests__/server-draft-adapter.test.ts
+++ b/client/src/adapter/__tests__/server-draft-adapter.test.ts
@@ -525,7 +525,7 @@ describe("ServerDraftAdapter", () => {
         "message",
         JSON.stringify({
           type: "ActionRejected",
-          data: { reason: "Engine error: ReorderHand: expected 6 ids, got 5" },
+          data: { rejection: { code: "stale_action", disposition: "stale", message: "That action is based on outdated game state.", related_object_ids: [] } },
         }),
       );
 
@@ -541,7 +541,7 @@ describe("ServerDraftAdapter", () => {
         "message",
         JSON.stringify({
           type: "ActionRejected",
-          data: { reason: "Engine error: something genuinely wrong" },
+          data: { rejection: { code: "invalid_action", disposition: "invalid", message: "That action is not valid in the current game state.", related_object_ids: [] } },
         }),
       );
 
@@ -566,7 +566,7 @@ describe("ServerDraftAdapter", () => {
           type: "ManaPaymentPreviewRejected",
           data: {
             request_id: sent.data.request_id,
-            reason: "Engine error: ReorderHand: expected 6 ids, got 5",
+            rejection: { code: "stale_action", disposition: "stale", message: "That action is based on outdated game state.", related_object_ids: [] },
           },
         }),
       );
@@ -585,7 +585,7 @@ describe("ServerDraftAdapter", () => {
         "message",
         JSON.stringify({
           type: "ManaPaymentPreviewRejected",
-          data: { request_id: sent.data.request_id, reason: "Engine error: no mana sources" },
+          data: { request_id: sent.data.request_id, rejection: { code: "invalid_action", disposition: "invalid", message: "That action is not valid in the current game state.", related_object_ids: [] } },
         }),
       );
 

--- a/client/src/adapter/__tests__/staleReorderMessage.test.ts
+++ b/client/src/adapter/__tests__/staleReorderMessage.test.ts
@@ -1,10 +1,10 @@
 import { describe, expect, it } from "vitest";
 
-import { isStaleActionMessage, isStaleReorderMessage } from "../types.ts";
+import { actionRejectionError, isStaleReorderMessage } from "../types.ts";
 
-describe("isStaleReorderMessage (issue #5913)", () => {
-  it("matches the engine's ReorderHand count mismatch, whatever the counts", () => {
-    // Verbatim shape from `apply_action`:
+describe("legacy ReorderHand rejection compatibility (issue #5913)", () => {
+  it("matches the legacy ReorderHand count mismatch, whatever the counts", () => {
+    // Verbatim pre-structured shape from `apply_action`:
     //   EngineError::InvalidAction(format!("ReorderHand: expected {} ids, got {}", ..))
     // surfaced by the wasm bridge as `Engine error: <display>`.
     expect(isStaleReorderMessage("Engine error: ReorderHand: expected 6 ids, got 5")).toBe(true);
@@ -37,12 +37,23 @@ describe("isStaleReorderMessage (issue #5913)", () => {
     expect(isStaleReorderMessage("")).toBe(false);
   });
 
-  it("is disjoint from the actor-authorization predicate", () => {
-    // The two matchers classify to the same benign code but must not overlap,
-    // so each keeps its own documented meaning.
-    const reorder = "Engine error: ReorderHand: expected 6 ids, got 5";
-    const authz = "Engine error: Wrong player";
-    expect(isStaleReorderMessage(reorder) && isStaleActionMessage(reorder)).toBe(false);
-    expect(isStaleActionMessage(authz) && isStaleReorderMessage(authz)).toBe(false);
+  it("uses the engine-provided stale disposition for structured rejections", () => {
+    const error = actionRejectionError({
+      code: "stale_action",
+      disposition: "stale",
+      message: "That action is based on outdated game state.",
+      related_object_ids: [],
+    });
+    expect(error.code).toBe("STALE_ACTION");
+    expect(error.recoverable).toBe(false);
+
+    const wrongPlayer = actionRejectionError({
+      code: "wrong_player",
+      disposition: "unauthorized",
+      message: "That action belongs to a different player.",
+      related_object_ids: [],
+    });
+    expect(wrongPlayer.code).toBe("ACTION_REJECTED");
+    expect(wrongPlayer.recoverable).toBe(true);
   });
 });

--- a/client/src/adapter/__tests__/wasm-adapter.test.ts
+++ b/client/src/adapter/__tests__/wasm-adapter.test.ts
@@ -41,6 +41,8 @@ const mockWorkerClient = {
     .fn()
     .mockResolvedValue({ events: [], log_entries: [] } as SubmitResult),
   submitInteraction: vi.fn().mockResolvedValue({ events: [], log_entries: [] } as SubmitResult),
+  previewManaPayment: vi.fn().mockResolvedValue([]),
+  resolveAll: vi.fn().mockResolvedValue({ items_resolved: 0 }),
   getAiActionProposal: vi.fn(),
   getAiActionProposalWithDiagnostics: vi.fn(),
   getAiTacticalActionProposal: vi.fn(),
@@ -139,7 +141,15 @@ describe("WasmAdapter", () => {
     it("publishes only after apply and retains a rejected proposal for retry", async () => {
       mockWorkerClient.getAiActionProposalWithDiagnostics.mockResolvedValue({ proposal, receipt });
       mockWorkerClient.submitAiActionProposal
-        .mockResolvedValueOnce({ status: "rejected", reason: "retry" })
+        .mockResolvedValueOnce({
+          status: "rejected",
+          rejection: {
+            code: "action_not_allowed",
+            disposition: "unavailable",
+            message: "That action is not allowed right now.",
+            related_object_ids: [7],
+          },
+        })
         .mockResolvedValueOnce({ status: "applied", result: { events: [], log_entries: [] } });
       await adapter.initialize();
       const listener = vi.fn();
@@ -147,7 +157,10 @@ describe("WasmAdapter", () => {
       adapter.subscribeAiDecisionDiagnostics(listener);
 
       await expect(adapter.getAiActionProposal("Medium", 0)).resolves.toEqual(proposal);
-      await expect(adapter.submitAiActionProposal(proposal)).resolves.toMatchObject({ status: "rejected" });
+      await expect(adapter.submitAiActionProposal(proposal)).resolves.toMatchObject({
+        status: "rejected",
+        rejection: { related_object_ids: [7] },
+      });
       expect(listener).not.toHaveBeenCalled();
 
       await expect(adapter.submitAiActionProposal(proposal)).resolves.toMatchObject({ status: "applied" });
@@ -446,6 +459,24 @@ describe("WasmAdapter", () => {
 
       expect(mockWorkerClient.submitAction).toHaveBeenCalledOnce();
       expect(mockWorkerClient.loadCardDbFromUrl).not.toHaveBeenCalled();
+    });
+
+    it("preserves a structured rejection without parsing its message", async () => {
+      const rejection = {
+        code: "wrong_player" as const,
+        disposition: "unauthorized" as const,
+        message: "That action belongs to a different player.",
+        related_object_ids: [42],
+      };
+      mockWorkerClient.submitAction.mockRejectedValueOnce(
+        new AdapterError(AdapterErrorCode.ACTION_REJECTED, rejection.message, true, undefined, rejection),
+      );
+      await adapter.initialize();
+
+      await expect(adapter.submitAction({ type: "PassPriority" }, 0)).rejects.toMatchObject({
+        code: AdapterErrorCode.ACTION_REJECTED,
+        rejection,
+      });
     });
 
     it("loads the card database and retries only after Rust admits a nonzero create", async () => {

--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -211,13 +211,13 @@ describe("WebSocketAdapter", () => {
     );
     ws.dispatchSynthetic(
       "message",
-      JSON.stringify({ type: "ActionRejected", data: { reason: "stale action rejection" } }),
+      JSON.stringify({ type: "ActionRejected", data: { rejection: { code: "stale_action", disposition: "stale", message: "stale action rejection", related_object_ids: [] } } }),
     );
     ws.dispatchSynthetic(
       "message",
       JSON.stringify({
         type: "ResolveAllRejected",
-        data: { request_id: 2, reason: "a different batch" },
+        data: { request_id: 2, rejection: { code: "invalid_action", disposition: "invalid", message: "a different batch", related_object_ids: [] } },
       }),
     );
 
@@ -228,25 +228,25 @@ describe("WebSocketAdapter", () => {
       "message",
       JSON.stringify({
         type: "ResolveAllRejected",
-        data: { request_id: 1, reason: "batch snapshot rejected" },
+        data: { request_id: 1, rejection: { code: "invalid_action", disposition: "invalid", message: "batch snapshot rejected", related_object_ids: [] } },
       }),
     );
 
     await expect(resultPromise).rejects.toMatchObject({ message: "batch snapshot rejected" });
   });
 
-  it("scopes the stale priority race to correlated Resolve All rejections", async () => {
+  it("keeps correlated Resolve All rejections engine-classified", async () => {
     const stale = adapter.resolveAll(0, [{ playerId: 1, difficulty: "Medium" }], 5);
     ws.dispatchSynthetic(
       "message",
       JSON.stringify({
         type: "ResolveAllRejected",
-        data: { request_id: 1, reason: "Resolve All requires your priority" },
+        data: { request_id: 1, rejection: { code: "resolve_all_not_ready", disposition: "unavailable", message: "Resolve All is not ready to run.", related_object_ids: [] } },
       }),
     );
     await expect(stale).rejects.toMatchObject({
-      code: "STALE_ACTION",
-      recoverable: false,
+      code: "ACTION_REJECTED",
+      recoverable: true,
     });
 
     const rejected = adapter.resolveAll(0, [{ playerId: 1, difficulty: "Medium" }], 5);
@@ -254,7 +254,7 @@ describe("WebSocketAdapter", () => {
       "message",
       JSON.stringify({
         type: "ResolveAllRejected",
-        data: { request_id: 2, reason: "batch snapshot rejected" },
+        data: { request_id: 2, rejection: { code: "invalid_action", disposition: "invalid", message: "batch snapshot rejected", related_object_ids: [] } },
       }),
     );
     await expect(rejected).rejects.toMatchObject({
@@ -1239,7 +1239,7 @@ describe("WebSocketAdapter", () => {
         "message",
         JSON.stringify({
           type: "ActionRejected",
-          data: { reason: "Engine error: ReorderHand: expected 6 ids, got 5" },
+          data: { rejection: { code: "stale_action", disposition: "stale", message: "That action is based on outdated game state.", related_object_ids: [] } },
         }),
       );
       await expect(pending).rejects.toMatchObject({
@@ -1254,7 +1254,7 @@ describe("WebSocketAdapter", () => {
         "message",
         JSON.stringify({
           type: "ActionRejected",
-          data: { reason: "Resolve All requires your priority" },
+          data: { rejection: { code: "resolve_all_not_ready", disposition: "unavailable", message: "Resolve All is not ready to run.", related_object_ids: [] } },
         }),
       );
       await expect(pending).rejects.toMatchObject({
@@ -1298,7 +1298,7 @@ describe("WebSocketAdapter", () => {
     // body was skipped and the refusal was dropped on the floor — which is why
     // the server had been reaching for `ServerMessage::error` instead, the
     // event `handleNativeEvent` treats as terminal.
-    it("emits requestRejected when an ActionRejected has no in-flight action", () => {
+    it("emits requestRejected for a request-level refusal", () => {
       const listener = vi.fn();
       adapter.onEvent(listener);
 
@@ -1306,7 +1306,7 @@ describe("WebSocketAdapter", () => {
       ws.dispatchSynthetic(
         "message",
         JSON.stringify({
-          type: "ActionRejected",
+          type: "RequestRejected",
           data: { reason: "There is no previous action of yours to take back" },
         }),
       );
@@ -1339,7 +1339,7 @@ describe("WebSocketAdapter", () => {
         "message",
         JSON.stringify({
           type: "ActionRejected",
-          data: { reason: "Engine error: Something genuinely wrong" },
+          data: { rejection: { code: "invalid_action", disposition: "invalid", message: "That action is not valid in the current game state.", related_object_ids: [] } },
         }),
       );
 

--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -263,6 +263,59 @@ describe("WebSocketAdapter", () => {
     });
   });
 
+  it("settles operational failures only against their pending game operation", async () => {
+    const action = adapter.submitAction({ type: "PassPriority" }, 0);
+    ws.dispatchSynthetic(
+      "message",
+      JSON.stringify({ type: "ActionFailed", data: { message: "action persistence failed" } }),
+    );
+    await expect(action).rejects.toMatchObject({
+      code: "WS_ERROR",
+      message: "action persistence failed",
+      recoverable: false,
+    });
+
+    const resolveAll = adapter.resolveAll(0, [{ playerId: 1, difficulty: "Medium" }], 5);
+    const resolveAllSettled = vi.fn();
+    void resolveAll.then(resolveAllSettled, resolveAllSettled);
+    ws.dispatchSynthetic(
+      "message",
+      JSON.stringify({ type: "ResolveAllFailed", data: { request_id: 2, message: "other batch failed" } }),
+    );
+    await Promise.resolve();
+    expect(resolveAllSettled).not.toHaveBeenCalled();
+    ws.dispatchSynthetic(
+      "message",
+      JSON.stringify({ type: "ResolveAllFailed", data: { request_id: 1, message: "batch persistence failed" } }),
+    );
+    await expect(resolveAll).rejects.toMatchObject({
+      code: "WS_ERROR",
+      message: "batch persistence failed",
+      recoverable: false,
+    });
+
+    const preview = adapter.previewManaPayment({ type: "PassPriority" }, 0);
+    const calls = ws.send.mock.calls;
+    const sent = JSON.parse(calls[calls.length - 1][0] as string);
+    const previewSettled = vi.fn();
+    void preview.then(previewSettled, previewSettled);
+    ws.dispatchSynthetic(
+      "message",
+      JSON.stringify({ type: "ManaPaymentPreviewFailed", data: { request_id: sent.data.request_id + 1, message: "other preview failed" } }),
+    );
+    await Promise.resolve();
+    expect(previewSettled).not.toHaveBeenCalled();
+    ws.dispatchSynthetic(
+      "message",
+      JSON.stringify({ type: "ManaPaymentPreviewFailed", data: { request_id: sent.data.request_id, message: "preview lookup failed" } }),
+    );
+    await expect(preview).rejects.toMatchObject({
+      code: "WS_ERROR",
+      message: "preview lookup failed",
+      recoverable: false,
+    });
+  });
+
   describe("server rewind capability (F2)", () => {
     it("declares the capability through the standalone type guard", () => {
       expect(supportsServerRewind(adapter)).toBe(true);

--- a/client/src/adapter/engine-worker-client.ts
+++ b/client/src/adapter/engine-worker-client.ts
@@ -18,7 +18,12 @@ import type {
   SubmitResult,
   ViewerSnapshot,
 } from "./types";
-import { AdapterError, AdapterErrorCode } from "./types";
+import {
+  actionRejectionError,
+  AdapterError,
+  AdapterErrorCode,
+  isActionRejection,
+} from "./types";
 import type { InteractionSubmission } from "./generated/interaction";
 import type { BracketDeckRequest, BracketEstimate } from "../types/bracketEstimate";
 import { debugLog } from "../game/debugLog";
@@ -32,6 +37,7 @@ type EngineResponse =
       message: string;
       bracketViolation?: true;
       engineOccupied?: true;
+      actionRejection?: unknown;
     };
 
 /**
@@ -105,7 +111,15 @@ export class EngineWorkerClient {
             // rejections so the caller can match by code rather than by string
             // substring on the error message.
             let err: Error;
-            if (msg.bracketViolation) {
+            if ("actionRejection" in msg && isActionRejection(msg.actionRejection)) {
+              err = actionRejectionError(msg.actionRejection);
+            } else if ("actionRejection" in msg) {
+              err = new AdapterError(
+                AdapterErrorCode.ACTION_REJECTED,
+                "The engine rejected that action.",
+                true,
+              );
+            } else if (msg.bracketViolation) {
               err = new AdapterError(AdapterErrorCode.BRACKET_VIOLATION, msg.message, false);
             } else if (msg.engineOccupied) {
               err = new AdapterError(AdapterErrorCode.ENGINE_OCCUPIED, msg.message, false);

--- a/client/src/adapter/engine-worker-client.ts
+++ b/client/src/adapter/engine-worker-client.ts
@@ -57,6 +57,7 @@ const ENGINE_REQUEST_TIMEOUT_MS = 60_000;
  * WasmAdapter dispose the stalled worker and activate its main-thread fallback.
  */
 const ENGINE_INITIALIZATION_TIMEOUT_MS = 30_000;
+const MALFORMED_ACTION_REJECTION_MESSAGE = "The engine rejected that action.";
 
 type RequestTimeoutBehavior = "notify" | "reject";
 
@@ -113,10 +114,16 @@ export class EngineWorkerClient {
             let err: Error;
             if ("actionRejection" in msg && isActionRejection(msg.actionRejection)) {
               err = actionRejectionError(msg.actionRejection);
-            } else if ("actionRejection" in msg) {
+            } else if (
+              msg.actionRejection !== undefined
+              || (
+                "actionRejection" in msg
+                && msg.message === MALFORMED_ACTION_REJECTION_MESSAGE
+              )
+            ) {
               err = new AdapterError(
                 AdapterErrorCode.ACTION_REJECTED,
-                "The engine rejected that action.",
+                MALFORMED_ACTION_REJECTION_MESSAGE,
                 true,
               );
             } else if (msg.bracketViolation) {

--- a/client/src/adapter/engine-worker.ts
+++ b/client/src/adapter/engine-worker.ts
@@ -49,7 +49,7 @@ import init, {
   get_card_rulings,
 } from "@wasm/engine";
 
-import type { AiActionProposal, GameAction } from "./types";
+import { isActionOutcome, type ActionRejection, type AiActionProposal, type GameAction } from "./types";
 import type { InteractionSubmission } from "./generated/interaction";
 import type { BracketDeckRequest } from "../types/bracketEstimate";
 import { classifyInitFailure, type InitFailure } from "./init-envelope";
@@ -129,6 +129,7 @@ type EngineResponse =
       message: string;
       bracketViolation?: true;
       engineOccupied?: true;
+      actionRejection?: ActionRejection;
     };
 
 // ── State ────────────────────────────────────────────────────────────────
@@ -145,6 +146,19 @@ function result(id: number, data: unknown): void {
 
 function error(id: number, message: string): void {
   respond({ type: "error", id, message });
+}
+
+function rejectionError(id: number, rejection: ActionRejection): void {
+  respond({ type: "error", id, message: rejection.message, actionRejection: rejection });
+}
+
+function malformedOutcomeError(id: number): void {
+  respond({
+    type: "error",
+    id,
+    message: "The engine rejected that action.",
+    actionRejection: undefined,
+  });
 }
 
 /**
@@ -300,14 +314,23 @@ self.onmessage = async (e: MessageEvent<EngineRequest>) => {
       }
 
       case "submitAction": {
-        const actionResult = submit_action(msg.actor, msg.action);
-        if (typeof actionResult === "string") {
+        const outcome = submit_action(msg.actor, msg.action);
+        if (typeof outcome === "string") {
           // Rust's submit_action error contract: returns the error string
           // on failure. `NOT_INITIALIZED:` prefix signals state-loss —
           // forward verbatim so the adapter can classify it as STATE_LOST.
-          error(msg.id, actionResult);
+          error(msg.id, outcome);
           break;
         }
+        if (!isActionOutcome(outcome)) {
+          malformedOutcomeError(msg.id);
+          break;
+        }
+        if (outcome.status === "rejected") {
+          rejectionError(msg.id, outcome.rejection);
+          break;
+        }
+        const actionResult = outcome.result as { events?: unknown[]; log_entries?: unknown[] };
         result(msg.id, {
           events: actionResult.events ?? [],
           log_entries: actionResult.log_entries ?? [],
@@ -316,11 +339,20 @@ self.onmessage = async (e: MessageEvent<EngineRequest>) => {
       }
 
       case "submitInteraction": {
-        const actionResult = submit_interaction_js(msg.actor, msg.submission);
-        if (typeof actionResult === "string") {
-          error(msg.id, actionResult);
+        const outcome = submit_interaction_js(msg.actor, msg.submission);
+        if (typeof outcome === "string") {
+          error(msg.id, outcome);
           break;
         }
+        if (!isActionOutcome(outcome)) {
+          malformedOutcomeError(msg.id);
+          break;
+        }
+        if (outcome.status === "rejected") {
+          rejectionError(msg.id, outcome.rejection);
+          break;
+        }
+        const actionResult = outcome.result as { events?: unknown[]; log_entries?: unknown[] };
         result(msg.id, {
           events: actionResult.events ?? [],
           log_entries: actionResult.log_entries ?? [],
@@ -329,12 +361,20 @@ self.onmessage = async (e: MessageEvent<EngineRequest>) => {
       }
 
       case "previewManaPayment": {
-        const sources = preview_mana_payment_js(msg.actor, msg.action);
-        if (typeof sources === "string") {
-          error(msg.id, sources);
+        const outcome = preview_mana_payment_js(msg.actor, msg.action);
+        if (typeof outcome === "string") {
+          error(msg.id, outcome);
           break;
         }
-        result(msg.id, sources);
+        if (!isActionOutcome(outcome)) {
+          malformedOutcomeError(msg.id);
+          break;
+        }
+        if (outcome.status === "rejected") {
+          rejectionError(msg.id, outcome.rejection);
+          break;
+        }
+        result(msg.id, outcome.result);
         break;
       }
 
@@ -524,12 +564,20 @@ self.onmessage = async (e: MessageEvent<EngineRequest>) => {
       }
 
       case "resolveAll": {
-        const r = resolve_all(msg.requester, msg.aiSeatsJson, msg.maxResolutions);
-        if (typeof r === "string") {
-          error(msg.id, r);
+        const outcome = resolve_all(msg.requester, msg.aiSeatsJson, msg.maxResolutions);
+        if (typeof outcome === "string") {
+          error(msg.id, outcome);
           break;
         }
-        result(msg.id, r);
+        if (!isActionOutcome(outcome)) {
+          malformedOutcomeError(msg.id);
+          break;
+        }
+        if (outcome.status === "rejected") {
+          rejectionError(msg.id, outcome.rejection);
+          break;
+        }
+        result(msg.id, outcome.result);
         break;
       }
 

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -1367,7 +1367,7 @@ export class P2PHostAdapter implements EngineAdapter {
         continue;
       }
       if (outcome.status === "rejected") {
-        throw new AdapterError("P2P_ERROR", `AI proposal rejected: ${outcome.reason}`, false);
+        throw actionRejectionError(outcome.rejection);
       }
       staleRetries = 0;
       const result = outcome.result;

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -77,6 +77,7 @@ import {
   type P2PTerminalResult,
 } from "../services/p2pTerminalResult";
 import { NativeEngineSocket } from "../services/nativeEngineSocket";
+import i18n from "../i18n";
 
 /**
  * Adapter-level events emitted to the UI. Wire-protocol messages are
@@ -134,6 +135,28 @@ export type P2PAdapterEvent =
   | { type: "reconnectFailed"; reason: string };
 
 type P2PAdapterEventListener = (event: P2PAdapterEvent) => void;
+
+function reconnectRejectionReason(
+  message: Extract<P2PMessage, { type: "reconnect_rejected" }>,
+): string {
+  switch (message.reasonCode) {
+    case "first_message_invalid":
+      return i18n.t("multiplayer:reconnectRejected.firstMessageInvalid");
+    case "wire_protocol_version_required":
+      return i18n.t("multiplayer:reconnectRejected.versionRequired", {
+        version: message.hostWireProtocolVersion,
+      });
+    case "wire_protocol_mismatch":
+      return i18n.t("multiplayer:reconnectRejected.versionMismatch", {
+        guestVersion: message.guestWireProtocolVersion,
+        hostVersion: message.hostWireProtocolVersion,
+      });
+    case "malformed_authority":
+      return i18n.t("multiplayer:reconnectRejected.malformedAuthority");
+    case undefined:
+      return message.reason;
+  }
+}
 
 interface DeckSeatPayload {
   main_deck: string[];
@@ -1582,6 +1605,7 @@ export class P2PHostAdapter implements EngineAdapter {
         void session.send({
           type: "reconnect_rejected",
           reason: "Expected guest_deck or reconnect as first message",
+          reasonCode: "first_message_invalid",
         });
         session.close("Protocol violation");
         return;
@@ -1602,7 +1626,13 @@ export class P2PHostAdapter implements EngineAdapter {
           ? `Wire protocol version required: this host speaks v${WIRE_PROTOCOL_VERSION}. Refresh both windows.`
           : `Wire protocol mismatch: guest sent v${guestVersion}, this host speaks v${WIRE_PROTOCOL_VERSION}. Refresh both windows.`;
         traceAdapter("Host", "first-message-version-mismatch", { type: msg.type, guestVersion });
-        void session.send({ type: "reconnect_rejected", reason });
+        void session.send({
+          type: "reconnect_rejected",
+          reason,
+          reasonCode: guestVersion === undefined ? "wire_protocol_version_required" : "wire_protocol_mismatch",
+          hostWireProtocolVersion: WIRE_PROTOCOL_VERSION,
+          guestWireProtocolVersion: guestVersion,
+        });
         session.close("Wire protocol mismatch");
         return;
       }
@@ -1610,7 +1640,11 @@ export class P2PHostAdapter implements EngineAdapter {
       if (msg.type === "reconnect") {
         traceAdapter("Host", "first-message", { type: msg.type });
         if (msg.authority !== undefined && !isP2PAuthorityStamp(msg.authority)) {
-          void session.send({ type: "reconnect_rejected", reason: "Malformed P2P authority" });
+          void session.send({
+            type: "reconnect_rejected",
+            reason: "Malformed P2P authority",
+            reasonCode: "malformed_authority",
+          });
           session.close("Malformed P2P authority");
           return;
         }
@@ -3465,10 +3499,11 @@ export class P2PGuestAdapter implements EngineAdapter {
         break;
       }
       case "reconnect_rejected": {
+        const reason = reconnectRejectionReason(msg);
         this.terminate();
-        this.rejectGameSetup(msg.reason);
-        this.emit({ type: "reconnectFailed", reason: msg.reason });
-        this.emit({ type: "gameOver", winner: null, reason: msg.reason });
+        this.rejectGameSetup(reason);
+        this.emit({ type: "reconnectFailed", reason });
+        this.emit({ type: "gameOver", winner: null, reason });
         break;
       }
       case "kick": {

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -23,7 +23,14 @@ import type {
 import type { InteractionSubmission } from "./generated/interaction";
 import type { BracketDeckRequest, BracketEstimate } from "../types/bracketEstimate";
 
-import { AdapterError, AdapterErrorCode, EMPTY_LEGAL_ACTIONS, actionRejectionError, nextSnapshotSeq } from "./types";
+import {
+  AdapterError,
+  AdapterErrorCode,
+  EMPTY_LEGAL_ACTIONS,
+  actionRejectionError,
+  isActionRejection,
+  nextSnapshotSeq,
+} from "./types";
 import { getHostAdapter } from "./wasm-adapter";
 import {
   WebSocketAdapter,
@@ -54,6 +61,8 @@ import {
 import {
   claimP2PHostLease,
   createP2PSessionKey,
+  hasExactP2PAuthority,
+  isP2PAuthorityStamp,
   ownsP2PHostLease,
   releaseP2PHostLease,
   clearP2PSession,
@@ -510,6 +519,35 @@ const RECONNECT_STEADY_STATE_MS = 60_000;
 // A stale proposal leaves the prompt unchanged, so cap retries to prevent a
 // persistent authority race from becoming a tight host-loop spin.
 const MAX_AI_PROPOSAL_STALE_RETRIES = 3;
+
+/**
+ * Preserve the engine's structured, viewer-filtered rejection exactly. All
+ * other failures are transport/operational faults and must not masquerade as
+ * gameplay diagnostics on the guest.
+ */
+function actionFailureFrame(error: unknown): Extract<P2PMessage, { type: "action_rejected" | "action_failed" }> {
+  if (error instanceof AdapterError && isActionRejection(error.rejection)) {
+    return { type: "action_rejected", rejection: error.rejection };
+  }
+  return {
+    type: "action_failed",
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+function manaPaymentPreviewFailureFrame(
+  requestId: number,
+  error: unknown,
+): Extract<P2PMessage, { type: "mana_payment_preview_rejected" | "mana_payment_preview_failed" }> {
+  if (error instanceof AdapterError && isActionRejection(error.rejection)) {
+    return { type: "mana_payment_preview_rejected", requestId, rejection: error.rejection };
+  }
+  return {
+    type: "mana_payment_preview_failed",
+    requestId,
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
 
 function defaultSeatState(playerCount: number, formatConfig?: FormatConfig): SeatState {
   return {
@@ -1539,44 +1577,45 @@ export class P2PHostAdapter implements EngineAdapter {
       identified = true;
       unsub();
 
-      // Host-side wire-version gate. A guest that stamps a version unequal
-      // to ours cannot be paired, so refuse it here — before a seat or a deck
-      // is allocated — through the rejection affordance this gate already
-      // has. `reconnect_rejected` is `{ type, reason }` only, so even a guest
-      // on an older bundle can decode it.
-      //
-      // ABSENT MEANS ADMIT. The version is bumped only on a
-      // non-backward-compatible change, so {guests on an older bundle}
-      // strictly contains {guests that are wire-incompatible}: an absent
-      // field reports bundle age, not incompatibility, and refusing on it
-      // would drop guests that pair fine today with a reason that is
-      // factually false for them. The consequence, stated rather than
-      // implied: this host cannot distinguish a compatible old bundle from
-      // an incompatible one. `P2PGuestAdapter.handleHostMessage` is the
-      // authority for the latter. This mirrors the call `acceptsHostAuthority`
-      // already makes for its own additive stamp. What this gate buys is
-      // prospective: once both sides ship, every future bump is caught
-      // host-side at first contact.
-      const guestVersion =
-        msg.type === "guest_deck" || msg.type === "reconnect" ? msg.wireProtocolVersion : undefined;
-      if (guestVersion !== undefined && guestVersion !== WIRE_PROTOCOL_VERSION) {
+      if (msg.type !== "guest_deck" && msg.type !== "reconnect") {
+        traceAdapter("Host", "first-message", { type: msg.type });
+        void session.send({
+          type: "reconnect_rejected",
+          reason: "Expected guest_deck or reconnect as first message",
+        });
+        session.close("Protocol violation");
+        return;
+      }
+
+      // v28 makes the first-contact version mandatory. Reject before a seat,
+      // deck, token, or authority is adopted: an unstamped peer cannot decode
+      // the structured action-rejection contract safely.
+      const guestVersion: number | undefined = msg.wireProtocolVersion;
+      if (guestVersion !== WIRE_PROTOCOL_VERSION) {
         // Reaches the refused guest's user RAW, the same way the guest-side
         // reason at `handleHostMessage` does. `i18n/README.md` asks for `t()`
         // on frontend-authored strings; this one is new text on that raw path
         // and is written unkeyed deliberately, to match the incumbent
         // wording rather than split the pair. Noted, not fixed: the raw-string
         // path is pre-existing and out of scope here.
-        const reason = `Wire protocol mismatch: guest sent v${guestVersion}, this host speaks v${WIRE_PROTOCOL_VERSION}. Refresh both windows.`;
+        const reason = guestVersion === undefined
+          ? `Wire protocol version required: this host speaks v${WIRE_PROTOCOL_VERSION}. Refresh both windows.`
+          : `Wire protocol mismatch: guest sent v${guestVersion}, this host speaks v${WIRE_PROTOCOL_VERSION}. Refresh both windows.`;
         traceAdapter("Host", "first-message-version-mismatch", { type: msg.type, guestVersion });
-        void this.send(session, { type: "reconnect_rejected", reason });
+        void session.send({ type: "reconnect_rejected", reason });
         session.close("Wire protocol mismatch");
         return;
       }
 
       if (msg.type === "reconnect") {
         traceAdapter("Host", "first-message", { type: msg.type });
-        this.handleReconnect(session, msg.playerToken, msg.sessionKey);
-      } else if (msg.type === "guest_deck") {
+        if (msg.authority !== undefined && !isP2PAuthorityStamp(msg.authority)) {
+          void session.send({ type: "reconnect_rejected", reason: "Malformed P2P authority" });
+          session.close("Malformed P2P authority");
+          return;
+        }
+        this.handleReconnect(session, msg.playerToken, msg.sessionKey, msg.authority);
+      } else {
         traceAdapter("Host", "first-message", { type: msg.type });
         void this.handleNewGuest(
           session,
@@ -1590,14 +1629,6 @@ export class P2PHostAdapter implements EngineAdapter {
           void this.send(session, { type: "kick", reason: "Host failed to add player" });
           session.close("Host failed to add player");
         });
-      } else {
-        traceAdapter("Host", "first-message", { type: msg.type });
-        // Unexpected first message — reject.
-        void this.send(session, {
-          type: "reconnect_rejected",
-          reason: "Expected guest_deck or reconnect as first message",
-        });
-        session.close("Protocol violation");
       }
     });
   }
@@ -2433,14 +2464,8 @@ export class P2PHostAdapter implements EngineAdapter {
       if (session) this.rejectSuperseded(session);
       return;
     }
-    if (
-      msg.authority
-      && (msg.authority.sessionKey !== this.authority.sessionKey
-        || msg.authority.hostIncarnation !== this.authority.hostIncarnation)
-    ) {
-      if (session) {
-        void this.send(session, { type: "action_rejected", reason: "Stale host incarnation" });
-      }
+    if (msg.authority && !hasExactP2PAuthority(msg.authority, this.authority)) {
+      if (session) this.rejectSuperseded(session);
       return;
     }
     switch (msg.type) {
@@ -2450,8 +2475,8 @@ export class P2PHostAdapter implements EngineAdapter {
           const session = this.guestSessions.get(pid);
           if (session) {
             void this.send(session, {
-              type: "action_rejected",
-              reason: `senderPlayerId mismatch (declared ${msg.senderPlayerId}, session owns ${pid})`,
+              type: "action_failed",
+              message: `senderPlayerId mismatch (declared ${msg.senderPlayerId}, session owns ${pid})`,
             });
           }
           console.warn(
@@ -2466,8 +2491,8 @@ export class P2PHostAdapter implements EngineAdapter {
           const session = this.guestSessions.get(pid);
           if (session) {
             void this.send(session, {
-              type: "action_rejected",
-              reason: "Player has conceded and can no longer act",
+              type: "action_failed",
+              message: "Player has conceded and can no longer act",
             });
           }
           return;
@@ -2476,8 +2501,8 @@ export class P2PHostAdapter implements EngineAdapter {
           const session = this.guestSessions.get(pid);
           if (session) {
             void this.send(session, {
-              type: "action_rejected",
-              reason: `Game ${this.gameRunState}`,
+              type: "action_failed",
+              message: `Game ${this.gameRunState}`,
             });
           }
           return;
@@ -2513,22 +2538,21 @@ export class P2PHostAdapter implements EngineAdapter {
             });
           }
         } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
           const session = this.guestSessions.get(pid);
-          if (session) void this.send(session, { type: "action_rejected", reason });
+          if (session) void this.send(session, actionFailureFrame(err));
         }
         break;
       }
       case "interaction": {
         const session = this.guestSessions.get(pid);
         if (!session || msg.senderPlayerId !== pid) {
-          if (session) void this.send(session, { type: "action_rejected", reason: "senderPlayerId mismatch" });
+          if (session) void this.send(session, { type: "action_failed", message: "senderPlayerId mismatch" });
           return;
         }
         if (this.eliminatedSeats.has(pid) || this.gameRunState !== "running") {
           void this.send(session, {
-            type: "action_rejected",
-            reason: this.eliminatedSeats.has(pid)
+            type: "action_failed",
+            message: this.eliminatedSeats.has(pid)
               ? "Player has conceded and can no longer act"
               : `Game ${this.gameRunState}`,
           });
@@ -2550,10 +2574,7 @@ export class P2PHostAdapter implements EngineAdapter {
             });
           }
         } catch (err) {
-          void this.send(session, {
-            type: "action_rejected",
-            reason: err instanceof Error ? err.message : String(err),
-          });
+          void this.send(session, actionFailureFrame(err));
         }
         break;
       }
@@ -2562,17 +2583,17 @@ export class P2PHostAdapter implements EngineAdapter {
         if (!session) return;
         if (this.eliminatedSeats.has(pid)) {
           void this.send(session, {
-            type: "mana_payment_preview_rejected",
+            type: "mana_payment_preview_failed",
             requestId: msg.requestId,
-            reason: "Player has conceded and can no longer act",
+            message: "Player has conceded and can no longer act",
           });
           return;
         }
         if (this.gameRunState !== "running") {
           void this.send(session, {
-            type: "mana_payment_preview_rejected",
+            type: "mana_payment_preview_failed",
             requestId: msg.requestId,
-            reason: `Game ${this.gameRunState}`,
+            message: `Game ${this.gameRunState}`,
           });
           return;
         }
@@ -2582,12 +2603,7 @@ export class P2PHostAdapter implements EngineAdapter {
             : await this.wasm.previewManaPayment(msg.action, pid);
           void this.send(session, { type: "mana_payment_preview", requestId: msg.requestId, sourceIds });
         } catch (err) {
-          const reason = err instanceof Error ? err.message : String(err);
-          void this.send(session, {
-            type: "mana_payment_preview_rejected",
-            requestId: msg.requestId,
-            reason,
-          });
+          void this.send(session, manaPaymentPreviewFailureFrame(msg.requestId, err));
         }
         break;
       }
@@ -2611,8 +2627,8 @@ export class P2PHostAdapter implements EngineAdapter {
         if (!this.boundMatchConcede) {
           if (session) {
             void this.send(session, {
-              type: "action_rejected",
-              reason: "Whole-match concession is unavailable for this game",
+              type: "action_failed",
+              message: "Whole-match concession is unavailable for this game",
             });
           }
           return;
@@ -2698,18 +2714,22 @@ export class P2PHostAdapter implements EngineAdapter {
     session: PeerSession,
     playerToken: string,
     sessionKey?: P2PSessionKey,
+    authority?: P2PAuthorityStamp,
   ): void {
     if (!this.ownsAuthority()) {
       this.rejectSuperseded(session);
       return;
     }
-    if (sessionKey !== undefined && sessionKey !== this.sessionKey) {
-      void this.send(session, { type: "reconnect_rejected", reason: "Wrong P2P session" });
+    if (
+      (sessionKey !== undefined && sessionKey !== this.sessionKey)
+      || (authority !== undefined && authority.sessionKey !== this.sessionKey)
+    ) {
+      void session.send({ type: "reconnect_rejected", reason: "Wrong P2P session" });
       session.close("Wrong P2P session");
       return;
     }
     if (this.kickedTokens.has(playerToken)) {
-      void this.send(session, { type: "reconnect_rejected", reason: "Player kicked" });
+      void session.send({ type: "reconnect_rejected", reason: "Player kicked" });
       session.close("Kicked");
       return;
     }
@@ -2721,12 +2741,12 @@ export class P2PHostAdapter implements EngineAdapter {
       }
     }
     if (pid === null) {
-      void this.send(session, { type: "reconnect_rejected", reason: "Unknown token" });
+      void session.send({ type: "reconnect_rejected", reason: "Unknown token" });
       session.close("Unknown token");
       return;
     }
     if (!this.disconnectedSeats.has(pid)) {
-      void this.send(session, {
+      void session.send({
         type: "reconnect_rejected",
         reason: "No grace window active for this seat",
       });
@@ -3389,6 +3409,13 @@ export class P2PGuestAdapter implements EngineAdapter {
         this.emit({ type: "reconnectFailed", reason });
         return;
       }
+      if (msg.authority !== undefined && !isP2PAuthorityStamp(msg.authority)) {
+        const reason = "Host sent a malformed P2P authority";
+        this.terminate();
+        this.rejectGameSetup(reason);
+        this.emit({ type: "reconnectFailed", reason });
+        return;
+      }
     }
     if (!this.acceptsHostAuthority(msg)) return;
     switch (msg.type) {
@@ -3396,7 +3423,7 @@ export class P2PGuestAdapter implements EngineAdapter {
         this.authenticatedSession = session;
         this.assignedPlayerId = msg.assignedPlayerId;
         this.playerToken = msg.playerToken;
-        if (msg.authority) {
+        if (isP2PAuthorityStamp(msg.authority)) {
           this.authority = msg.authority;
           void saveP2PSession(this.sessionKey ?? this.hostPeerId, {
             playerToken: msg.playerToken,
@@ -3413,7 +3440,7 @@ export class P2PGuestAdapter implements EngineAdapter {
       case "reconnect_ack": {
         this.authenticatedSession = session;
         this.assignedPlayerId = msg.assignedPlayerId;
-        if (this.playerToken && msg.authority) {
+        if (this.playerToken && isP2PAuthorityStamp(msg.authority)) {
           this.authority = msg.authority;
           void saveP2PSession(this.sessionKey ?? this.hostPeerId, {
             playerToken: this.playerToken,
@@ -3497,12 +3524,29 @@ export class P2PGuestAdapter implements EngineAdapter {
         break;
       }
       case "action_rejected": {
-        if (this.pendingReject) {
-          this.pendingReject(
-            actionRejectionError(msg.reason),
+        const error = isActionRejection(msg.rejection)
+          ? actionRejectionError(msg.rejection)
+          : new AdapterError(
+            AdapterErrorCode.ACTION_REJECTED,
+            "Host sent an invalid action rejection",
+            true,
           );
+        if (this.pendingReject) {
+          this.pendingReject(error);
           this.pendingResolve = null;
           this.pendingReject = null;
+        } else {
+          this.emit({ type: "error", message: error.message });
+        }
+        break;
+      }
+      case "action_failed": {
+        if (this.pendingReject) {
+          this.pendingReject(new AdapterError("P2P_ERROR", msg.message, true));
+          this.pendingResolve = null;
+          this.pendingReject = null;
+        } else {
+          this.emit({ type: "error", message: msg.message });
         }
         break;
       }
@@ -3526,7 +3570,23 @@ export class P2PGuestAdapter implements EngineAdapter {
         const pending = this.pendingManaPaymentPreviews.get(msg.requestId);
         if (pending) {
           this.pendingManaPaymentPreviews.delete(msg.requestId);
-          pending.reject(actionRejectionError(msg.reason));
+          pending.reject(
+            isActionRejection(msg.rejection)
+              ? actionRejectionError(msg.rejection)
+              : new AdapterError(
+                AdapterErrorCode.ACTION_REJECTED,
+                "Host sent an invalid mana-payment preview rejection",
+                true,
+              ),
+          );
+        }
+        break;
+      }
+      case "mana_payment_preview_failed": {
+        const pending = this.pendingManaPaymentPreviews.get(msg.requestId);
+        if (pending) {
+          this.pendingManaPaymentPreviews.delete(msg.requestId);
+          pending.reject(new AdapterError("P2P_ERROR", msg.message, true));
         }
         break;
       }
@@ -3621,9 +3681,10 @@ export class P2PGuestAdapter implements EngineAdapter {
 
   private acceptsHostAuthority(msg: P2PMessage): boolean {
     if (!msg.authority) {
-      // Old room peers cannot emit a lease stamp. Hosts from this build always
-      // do, so their stale incarnations are fenced; accepting this shape keeps
-      // the additive wire change from breaking an already-open legacy room.
+      // The lease stamp remains additive: it fences resumed hosts where it is
+      // present without making an already-open room unable to settle a safe
+      // terminal control frame. Version v28, unlike authority, is mandatory
+      // on first contact because it changes the rejection payload shape.
       return true;
     }
     if (this.authority === null) return true;
@@ -3637,12 +3698,9 @@ export class P2PGuestAdapter implements EngineAdapter {
       return true;
     }
     if (msg.type === "game_setup") {
-      return msg.authority.sessionKey === this.authority.sessionKey
-        && msg.authority.hostIncarnation === this.authority.hostIncarnation;
+      return hasExactP2PAuthority(msg.authority, this.authority);
     }
-    return this.authority !== null
-      && msg.authority.sessionKey === this.authority.sessionKey
-      && msg.authority.hostIncarnation === this.authority.hostIncarnation;
+    return hasExactP2PAuthority(msg.authority, this.authority);
   }
 
   private send(message: P2PMessage): void {

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -77,7 +77,7 @@ import {
   type P2PTerminalResult,
 } from "../services/p2pTerminalResult";
 import { NativeEngineSocket } from "../services/nativeEngineSocket";
-import i18n from "../i18n";
+import i18n from "i18next";
 
 /**
  * Adapter-level events emitted to the UI. Wire-protocol messages are

--- a/client/src/adapter/server-draft-adapter.ts
+++ b/client/src/adapter/server-draft-adapter.ts
@@ -13,7 +13,7 @@ import type {
   SubmitResult,
 } from "./types";
 import type { InteractionSubmission } from "./generated/interaction";
-import { actionRejectionError, AdapterError, AdapterErrorCode, EMPTY_LEGAL_ACTIONS, nextSnapshotSeq } from "./types";
+import { actionRejectionError, AdapterError, AdapterErrorCode, EMPTY_LEGAL_ACTIONS, isActionRejection, nextSnapshotSeq } from "./types";
 import type { BracketDeckRequest, BracketEstimate } from "../types/bracketEstimate";
 import {
   HandshakeError,
@@ -699,7 +699,7 @@ export class ServerDraftAdapter implements EngineAdapter {
       }
 
       case "ActionRejected": {
-        const data = msg.data as { reason: string };
+        const data = msg.data as { rejection?: unknown };
         this.emit({ type: "actionPendingChanged", pending: false });
         if (this.pendingReject) {
           // Game-phase action rejection. `ServerDraftAdapter` is a full
@@ -714,7 +714,11 @@ export class ServerDraftAdapter implements EngineAdapter {
           // carries a pick/pass rejection, which is not a `GameAction` at all,
           // so no stale-action verdict is possible — it is a separate draft
           // protocol concern and stays a plain recoverable rejection.
-          this.pendingReject(actionRejectionError(data.reason));
+          this.pendingReject(
+            isActionRejection(data.rejection)
+              ? actionRejectionError(data.rejection)
+              : new AdapterError(AdapterErrorCode.WASM_ERROR, "Server sent an invalid action rejection.", false),
+          );
           this.pendingResolve = null;
           this.pendingReject = null;
         }
@@ -732,7 +736,7 @@ export class ServerDraftAdapter implements EngineAdapter {
       }
 
       case "ManaPaymentPreviewRejected": {
-        const data = msg.data as { request_id: number; reason: string };
+        const data = msg.data as { request_id: number; rejection?: unknown };
         const pending = this.pendingManaPaymentPreviews.get(data.request_id);
         if (pending) {
           this.pendingManaPaymentPreviews.delete(data.request_id);
@@ -742,7 +746,11 @@ export class ServerDraftAdapter implements EngineAdapter {
           // the request — and a stale preview is likewise void rather than
           // retryable. Non-stale reasons still classify as recoverable
           // ACTION_REJECTED, so existing surface/retry behavior is unchanged.
-          pending.reject(actionRejectionError(data.reason));
+          pending.reject(
+            isActionRejection(data.rejection)
+              ? actionRejectionError(data.rejection)
+              : new AdapterError(AdapterErrorCode.WASM_ERROR, "Server sent an invalid mana-payment rejection.", false),
+          );
         }
         break;
       }

--- a/client/src/adapter/server-draft-adapter.ts
+++ b/client/src/adapter/server-draft-adapter.ts
@@ -725,6 +725,19 @@ export class ServerDraftAdapter implements EngineAdapter {
         break;
       }
 
+      case "ActionFailed": {
+        const data = msg.data as { message: string };
+        if (this.pendingReject) {
+          this.emit({ type: "actionPendingChanged", pending: false });
+          this.pendingReject(new AdapterError("WS_ERROR", data.message, false));
+          this.pendingResolve = null;
+          this.pendingReject = null;
+        } else {
+          this.emit({ type: "error", message: data.message });
+        }
+        break;
+      }
+
       case "ManaPaymentPreview": {
         const data = msg.data as { request_id: number; source_ids: ObjectId[] };
         const pending = this.pendingManaPaymentPreviews.get(data.request_id);
@@ -751,6 +764,16 @@ export class ServerDraftAdapter implements EngineAdapter {
               ? actionRejectionError(data.rejection)
               : new AdapterError(AdapterErrorCode.WASM_ERROR, "Server sent an invalid mana-payment rejection.", false),
           );
+        }
+        break;
+      }
+
+      case "ManaPaymentPreviewFailed": {
+        const data = msg.data as { request_id: number; message: string };
+        const pending = this.pendingManaPaymentPreviews.get(data.request_id);
+        if (pending) {
+          this.pendingManaPaymentPreviews.delete(data.request_id);
+          pending.reject(new AdapterError("WS_ERROR", data.message, false));
         }
         break;
       }

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -3132,6 +3132,8 @@ export type TargetChoiceKind =
  */
 export interface DerivedViews {
   unique_authorized_submitter?: PlayerId;
+  /** Viewer-visible object ids in each player's exile pile, keyed by PlayerId. */
+  visible_exile_object_ids?: Record<string, ObjectId[]>;
   /**
    * Explicit debug-only identities for the viewing player's library. Normal
    * library objects remain hidden in `GameState.objects`; only the debug

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -3654,6 +3654,103 @@ export type ContinuousModification =
  * Error type for adapter operations. Wraps WASM/transport errors
  * with structured metadata for error handling in the UI layer.
  */
+export type ActionRejectionCode =
+  | "invalid_action"
+  | "wrong_player"
+  | "not_your_priority"
+  | "action_not_allowed"
+  | "interaction_unavailable"
+  | "interaction_not_authorized"
+  | "stale_interaction"
+  | "stale_action"
+  | "invalid_interaction_response"
+  | "interaction_payload_too_large"
+  | "interaction_constraint_unsatisfied"
+  | "interaction_cancel_only"
+  | "interaction_reducer_rejected"
+  | "unsupported_interaction_response"
+  | "resolve_all_not_ready"
+  | "debug_permission_denied";
+
+export type ActionRejectionDisposition =
+  | "invalid"
+  | "unauthorized"
+  | "unavailable"
+  | "stale"
+  | "unsupported";
+
+/** Engine-owned, viewer-filtered explanation of an action not applied. */
+export interface ActionRejection {
+  code: ActionRejectionCode;
+  disposition: ActionRejectionDisposition;
+  message: string;
+  related_object_ids: ObjectId[];
+}
+
+const ACTION_REJECTION_DISPOSITIONS: Record<
+  ActionRejectionCode,
+  ActionRejectionDisposition
+> = {
+  invalid_action: "invalid",
+  wrong_player: "unauthorized",
+  not_your_priority: "unavailable",
+  action_not_allowed: "unavailable",
+  interaction_unavailable: "unavailable",
+  interaction_not_authorized: "unauthorized",
+  stale_interaction: "stale",
+  stale_action: "stale",
+  invalid_interaction_response: "invalid",
+  interaction_payload_too_large: "invalid",
+  interaction_constraint_unsatisfied: "invalid",
+  interaction_cancel_only: "unavailable",
+  interaction_reducer_rejected: "invalid",
+  unsupported_interaction_response: "unsupported",
+  resolve_all_not_ready: "unavailable",
+  debug_permission_denied: "unauthorized",
+};
+
+/** Validates the complete viewer-safe rejection DTO at an untyped boundary. */
+export function isActionRejection(value: unknown): value is ActionRejection {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (keys.length !== 4 || !keys.every((key) => (
+    key === "code"
+    || key === "disposition"
+    || key === "message"
+    || key === "related_object_ids"
+  ))) return false;
+  if (typeof record.code !== "string" || !(record.code in ACTION_REJECTION_DISPOSITIONS)) {
+    return false;
+  }
+  const code = record.code as ActionRejectionCode;
+  return record.disposition === ACTION_REJECTION_DISPOSITIONS[code]
+    && typeof record.message === "string"
+    && Array.isArray(record.related_object_ids)
+    && record.related_object_ids.every((id) => (
+      typeof id === "number" && Number.isSafeInteger(id) && id >= 0
+    ));
+}
+
+export type ActionOutcome<T> =
+  | { status: "applied"; result: T }
+  | { status: "rejected"; rejection: ActionRejection };
+
+/** Validates the exact tagged WASM outcome shape before its result is trusted. */
+export function isActionOutcome(value: unknown): value is ActionOutcome<unknown> {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
+  const record = value as Record<string, unknown>;
+  const keys = Object.keys(record);
+  if (record.status === "applied") {
+    return keys.length === 2 && keys.includes("status") && keys.includes("result");
+  }
+  return record.status === "rejected"
+    && keys.length === 2
+    && keys.includes("status")
+    && keys.includes("rejection")
+    && isActionRejection(record.rejection);
+}
+
 export class AdapterError extends Error {
   readonly code: string;
   readonly recoverable: boolean;
@@ -3664,13 +3761,22 @@ export class AdapterError extends Error {
    * diagnostic without the recovery layer needing to thread it back.
    */
   readonly panic?: string;
+  /** Present only when the engine returned a typed action rejection. */
+  readonly rejection?: ActionRejection;
 
-  constructor(code: string, message: string, recoverable: boolean, panic?: string) {
+  constructor(
+    code: string,
+    message: string,
+    recoverable: boolean,
+    panic?: string,
+    rejection?: ActionRejection,
+  ) {
     super(message);
     this.name = "AdapterError";
     this.code = code;
     this.recoverable = recoverable;
     this.panic = panic;
+    this.rejection = rejection;
   }
 }
 
@@ -3752,24 +3858,12 @@ export function isStateLostMessage(message: string): boolean {
 }
 
 /**
- * Detect the engine's actor-authorization rejections. `submit_action` in
- * `engine-wasm/src/lib.rs` formats `EngineError::WrongPlayer` (Display: "Wrong
- * player") and `EngineError::NotYourPriority` (Display: "Not your priority")
- * as `Engine error: <display>`. Match the exact strings — these are the benign
- * stale-action race (see `AdapterErrorCode.STALE_ACTION`), never a state-loss
- * or panic.
- */
-export function isStaleActionMessage(message: string): boolean {
-  return message === "Engine error: Wrong player" || message === "Engine error: Not your priority";
-}
-
-/**
- * Transport-neutral test for "the engine rejected this action, but nothing
- * changed and nothing needs recovering". Single authority for what counts as a
- * benign stale rejection, so every transport agrees.
+ * Legacy transport-only detection for the one pre-structured ReorderHand
+ * rejection that can be safely dropped. All structured rejections use the
+ * engine-provided disposition instead.
  */
 export function isStaleRejectionMessage(message: string): boolean {
-  return isStaleActionMessage(message) || isStaleReorderMessage(message);
+  return isStaleReorderMessage(message);
 }
 
 /**
@@ -3786,10 +3880,17 @@ export function isStaleRejectionMessage(message: string): boolean {
  * caller should drop it, not re-submit. Every other rejection stays a
  * recoverable `ACTION_REJECTED` so existing retry/surface behavior is unchanged.
  */
-export function actionRejectionError(reason: string): AdapterError {
-  return isStaleRejectionMessage(reason)
-    ? new AdapterError(AdapterErrorCode.STALE_ACTION, reason, false)
-    : new AdapterError(AdapterErrorCode.ACTION_REJECTED, reason, true);
+export function actionRejectionError(rejection: ActionRejection): AdapterError;
+export function actionRejectionError(reason: string): AdapterError;
+export function actionRejectionError(rejection: ActionRejection | string): AdapterError {
+  if (typeof rejection === "string") {
+    return isStaleRejectionMessage(rejection)
+      ? new AdapterError(AdapterErrorCode.STALE_ACTION, rejection, false)
+      : new AdapterError(AdapterErrorCode.ACTION_REJECTED, rejection, true);
+  }
+  return rejection.disposition === "stale"
+    ? new AdapterError(AdapterErrorCode.STALE_ACTION, rejection.message, false, undefined, rejection)
+    : new AdapterError(AdapterErrorCode.ACTION_REJECTED, rejection.message, true, undefined, rejection);
 }
 
 /**
@@ -3808,12 +3909,10 @@ export function resolveAllRejectionError(reason: string): AdapterError {
 }
 
 /**
- * Detect the engine's rejection of a `ReorderHand` whose order no longer names
- * the current hand. `apply_action` formats
- * `EngineError::InvalidAction("ReorderHand: expected {n} ids, got {m}")` as
- * `Engine error: ReorderHand: expected ...` and returns it BEFORE mutating any
- * player state, so — exactly like the actor-authorization rejections above —
- * nothing changed and there is nothing to recover.
+ * Detect the legacy string representation of a `ReorderHand` rejection from
+ * a pre-structured remote engine. Local WASM now emits `stale_action` with a
+ * typed disposition instead; this helper remains only until every remote
+ * transport has adopted the same DTO.
  *
  * This is the benign client/engine desync behind issue #5913: a drag computes
  * its order against the hand as displayed, but a draw or discard can land in
@@ -3825,8 +3924,8 @@ export function resolveAllRejectionError(reason: string): AdapterError {
  * Hand order carries no game-rules meaning (CR 402.3), so a dropped reorder
  * costs the player nothing beyond re-dragging.
  *
- * Covers BOTH staleness rejections `apply_action` can raise, because a hand can
- * go stale two ways in the same window:
+ * Covers both legacy string shapes because a hand can go stale two ways in the
+ * same window:
  *   - the count changed (a draw or a discard alone) — "expected {n} ids, got
  *     {m}", a prefix match since the message embeds the counts;
  *   - the count held but the ids moved (a discard AND a draw) — "order is not a
@@ -4042,7 +4141,7 @@ export type AiCardSubsetResult =
 export type AiProposalSubmission =
   | { status: "applied"; result: SubmitResult }
   | { status: "stale"; reason: string }
-  | { status: "rejected"; reason: string };
+  | { status: "rejected"; rejection: ActionRejection };
 
 export interface EngineAdapter {
   initialize(): Promise<void>;

--- a/client/src/adapter/wasm-adapter.ts
+++ b/client/src/adapter/wasm-adapter.ts
@@ -18,7 +18,14 @@ import type {
   ViewerSnapshot,
 } from "./types";
 import type { InteractionSubmission } from "./generated/interaction";
-import { AdapterError, AdapterErrorCode, isStaleRejectionMessage, isStateLostMessage, nextSnapshotSeq } from "./types";
+import {
+  actionRejectionError,
+  AdapterError,
+  AdapterErrorCode,
+  isActionOutcome,
+  isStateLostMessage,
+  nextSnapshotSeq,
+} from "./types";
 import type { BracketDeckRequest, BracketEstimate } from "../types/bracketEstimate";
 import { isBracketEstimate } from "../types/bracketEstimate";
 import { EngineWorkerClient } from "./engine-worker-client";
@@ -49,6 +56,21 @@ function isDebugCreateCard(action: GameAction): boolean {
 
 function isDebugCreateCardDbMissing(error: unknown): boolean {
   return error instanceof Error && error.message === DEBUG_CREATE_CARD_DB_MISSING;
+}
+
+function unwrapActionOutcome<T>(value: unknown): T {
+  if (typeof value === "string") throw new Error(value);
+  if (!isActionOutcome(value)) {
+    throw new AdapterError(
+      AdapterErrorCode.ACTION_REJECTED,
+      "The engine rejected that action.",
+      true,
+    );
+  }
+  if (value.status === "rejected") {
+    throw actionRejectionError(value.rejection);
+  }
+  return value.result as T;
 }
 
 class AiPoolScoreTimeoutError extends Error {
@@ -90,16 +112,12 @@ async function classifyEngineErrorAsync(
   err: unknown,
   takePanic: () => Promise<string | null>,
 ): Promise<Error> {
+  if (err instanceof AdapterError) return err;
   // Returns (rather than throws) the error to surface so call sites can
   // write `throw await classifyEngineErrorAsync(...)`. TypeScript doesn't
   // always narrow control flow through an awaited `Promise<never>`, so
   // making the throw explicit keeps the surrounding methods type-clean.
   const message = err instanceof Error ? err.message : String(err);
-  // Actor-authorization rejection (stale action after a priority/turn shift).
-  // Typed so dispatch can treat it as a benign no-op rather than a crash.
-  if (isStaleRejectionMessage(message)) {
-    return new AdapterError(AdapterErrorCode.STALE_ACTION, message, false);
-  }
   if (isStateLostMessage(message)) {
     let panic: string | null = null;
     try {
@@ -691,12 +709,15 @@ export class WasmAdapter implements EngineAdapter, AiDecisionDiagnosticsCapabili
     maxResolutions: number = 0,
   ): Promise<BatchResolveResult> {
     this.assertInitialized();
-    if (this.engine) {
-      const result = await this.engine.resolveAll(requester, aiSeats, maxResolutions);
+    try {
+      const result = this.engine
+        ? await this.engine.resolveAll(requester, aiSeats, maxResolutions)
+        : await this.fallback!.resolveAll(requester, aiSeats, maxResolutions);
       this.invalidateAiDecisionDiagnostics();
       return result;
+    } catch (err) {
+      throw await classifyEngineErrorAsync(err, this.takePanic);
     }
-    throw new Error("resolveAll requires worker-based engine");
   }
 
   private async requireCardDbForRestore(): Promise<void> {
@@ -1040,6 +1061,11 @@ interface MainThreadFallback {
   submitAction(action: GameAction, actor: PlayerId): Promise<SubmitResult>;
   submitInteraction(submission: InteractionSubmission, actor: PlayerId): Promise<SubmitResult>;
   previewManaPayment(action: GameAction, actor: PlayerId): Promise<ObjectId[]>;
+  resolveAll(
+    requester: number,
+    aiSeats: { playerId: number; difficulty: string }[],
+    maxResolutions?: number,
+  ): Promise<BatchResolveResult>;
   getState(): Promise<GameState>;
   getFilteredState(viewerId: number): Promise<GameState>;
   getLegalActions(): Promise<LegalActionsResult>;
@@ -1127,24 +1153,29 @@ async function createMainThreadFallback(): Promise<MainThreadFallback> {
 
     submitAction: (action: GameAction, actor: PlayerId) =>
       enqueue(() => {
-        const r = wasm.submit_action(actor, action);
-        if (typeof r === "string") throw new Error(r);
+        const r = unwrapActionOutcome<{ events?: SubmitResult["events"]; log_entries?: SubmitResult["log_entries"] }>(
+          wasm.submit_action(actor, action),
+        );
         return { events: r.events ?? [], log_entries: r.log_entries ?? [] };
       }),
 
     submitInteraction: (submission: InteractionSubmission, actor: PlayerId) =>
       enqueue(() => {
-        const r = wasm.submit_interaction_js(actor, submission);
-        if (typeof r === "string") throw new Error(r);
+        const r = unwrapActionOutcome<{ events?: SubmitResult["events"]; log_entries?: SubmitResult["log_entries"] }>(
+          wasm.submit_interaction_js(actor, submission),
+        );
         return { events: r.events ?? [], log_entries: r.log_entries ?? [] };
       }),
 
     previewManaPayment: (action: GameAction, actor: PlayerId) =>
       enqueue(() => {
-        const sources = wasm.preview_mana_payment_js(actor, action);
-        if (typeof sources === "string") throw new Error(sources);
-        return sources as ObjectId[];
+        return unwrapActionOutcome<ObjectId[]>(wasm.preview_mana_payment_js(actor, action));
       }),
+
+    resolveAll: (requester, aiSeats, maxResolutions = 0) =>
+      enqueue(() => unwrapActionOutcome<BatchResolveResult>(
+        wasm.resolve_all(requester, JSON.stringify(aiSeats), maxResolutions),
+      )),
 
     // null from any of these three getters means WASM `GAME_STATE` is None
     // (worker restart, PWA update desync, panic recovery). Throw with the

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -203,6 +203,7 @@ export class NativeEngineVersionMismatchError extends Error {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 41 — Operational failure responses are correlated to their pending action.
  * 40 — Action rejection responses carry engine-owned structured context.
  * 39 — ManaRestriction.CannotCastSpellFromZone adds a serialized
  *      GameState/ManaUnit restriction used by Karolina Dean. Older peers
@@ -300,7 +301,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 40;
+export const PROTOCOL_VERSION = 41;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.
@@ -1688,6 +1689,19 @@ export class WebSocketAdapter implements EngineAdapter {
         break;
       }
 
+      case "ActionFailed": {
+        const data = msg.data as { message: string };
+        if (this.pendingReject) {
+          this.emit({ type: "actionPendingChanged", pending: false });
+          this.pendingReject(new AdapterError("WS_ERROR", data.message, false));
+          this.pendingResolve = null;
+          this.pendingReject = null;
+        } else {
+          this.emit({ type: "error", message: data.message });
+        }
+        break;
+      }
+
       case "ResolveAllResult": {
         const data = msg.data as {
           request_id: number;
@@ -1728,6 +1742,15 @@ export class WebSocketAdapter implements EngineAdapter {
         break;
       }
 
+      case "ResolveAllFailed": {
+        const data = msg.data as { request_id: number; message: string };
+        if (this.pendingResolveAll?.requestId === data.request_id) {
+          this.pendingResolveAll.reject(new AdapterError("WS_ERROR", data.message, false));
+          this.pendingResolveAll = null;
+        }
+        break;
+      }
+
       case "ActionNoOp": {
         this.emit({ type: "actionPendingChanged", pending: false });
         if (this.pendingResolve) {
@@ -1758,6 +1781,16 @@ export class WebSocketAdapter implements EngineAdapter {
               ? actionRejectionError(data.rejection)
               : new AdapterError(AdapterErrorCode.WASM_ERROR, "Server sent an invalid mana-payment rejection.", false),
           );
+        }
+        break;
+      }
+
+      case "ManaPaymentPreviewFailed": {
+        const data = msg.data as { request_id: number; message: string };
+        const pending = this.pendingManaPaymentPreviews.get(data.request_id);
+        if (pending) {
+          this.pendingManaPaymentPreviews.delete(data.request_id);
+          pending.reject(new AdapterError("WS_ERROR", data.message, false));
         }
         break;
       }

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -18,7 +18,7 @@ import type {
   FormatConfig,
 } from "./types";
 import type { InteractionSubmission } from "./generated/interaction";
-import { AdapterError, AdapterErrorCode, EMPTY_LEGAL_ACTIONS, actionRejectionError, nextSnapshotSeq, resolveAllRejectionError } from "./types";
+import { AdapterError, AdapterErrorCode, EMPTY_LEGAL_ACTIONS, actionRejectionError, isActionRejection, nextSnapshotSeq } from "./types";
 import type { BracketDeckRequest, BracketEstimate } from "../types/bracketEstimate";
 import {
   HandshakeError,
@@ -203,6 +203,7 @@ export class NativeEngineVersionMismatchError extends Error {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 40 — Action rejection responses carry engine-owned structured context.
  * 39 — ManaRestriction.CannotCastSpellFromZone adds a serialized
  *      GameState/ManaUnit restriction used by Karolina Dean. Older peers
  *      cannot deserialize that externally tagged enum variant.
@@ -299,7 +300,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 39;
+export const PROTOCOL_VERSION = 40;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.
@@ -1659,11 +1660,14 @@ export class WebSocketAdapter implements EngineAdapter {
       }
 
       case "ActionRejected": {
-        const data = msg.data as { reason: string };
+        const data = msg.data as { rejection?: unknown };
+        const error = isActionRejection(data.rejection)
+          ? actionRejectionError(data.rejection)
+          : new AdapterError(AdapterErrorCode.WASM_ERROR, "Server sent an invalid action rejection.", false);
         this.emit({ type: "actionPendingChanged", pending: false });
         if (this.pendingReject) {
           this.pendingReject(
-            actionRejectionError(data.reason),
+            error,
           );
           this.pendingResolve = null;
           this.pendingReject = null;
@@ -1679,7 +1683,7 @@ export class WebSocketAdapter implements EngineAdapter {
           // hazard here — rejecting an in-flight ACTION's promise with a
           // TAKEBACK's reason string, which would be a misattribution rather
           // than merely a stale spinner.
-          this.emit({ type: "requestRejected", reason: data.reason });
+          this.emit({ type: "requestRejected", reason: error.message });
         }
         break;
       }
@@ -1712,9 +1716,13 @@ export class WebSocketAdapter implements EngineAdapter {
       }
 
       case "ResolveAllRejected": {
-        const data = msg.data as { request_id: number; reason: string };
+        const data = msg.data as { request_id: number; rejection?: unknown };
         if (this.pendingResolveAll?.requestId === data.request_id) {
-          this.pendingResolveAll.reject(resolveAllRejectionError(data.reason));
+          this.pendingResolveAll.reject(
+            isActionRejection(data.rejection)
+              ? actionRejectionError(data.rejection)
+              : new AdapterError(AdapterErrorCode.WASM_ERROR, "Server sent an invalid Resolve All rejection.", false),
+          );
           this.pendingResolveAll = null;
         }
         break;
@@ -1741,12 +1749,25 @@ export class WebSocketAdapter implements EngineAdapter {
       }
 
       case "ManaPaymentPreviewRejected": {
-        const data = msg.data as { request_id: number; reason: string };
+        const data = msg.data as { request_id: number; rejection?: unknown };
         const pending = this.pendingManaPaymentPreviews.get(data.request_id);
         if (pending) {
           this.pendingManaPaymentPreviews.delete(data.request_id);
-          pending.reject(actionRejectionError(data.reason));
+          pending.reject(
+            isActionRejection(data.rejection)
+              ? actionRejectionError(data.rejection)
+              : new AdapterError(AdapterErrorCode.WASM_ERROR, "Server sent an invalid mana-payment rejection.", false),
+          );
         }
+        break;
+      }
+
+      case "RequestRejected": {
+        const data = msg.data as { reason?: unknown };
+        this.emit({
+          type: "requestRejected",
+          reason: typeof data.reason === "string" ? data.reason : "Server rejected the request.",
+        });
         break;
       }
 

--- a/client/src/components/board/AttachmentFan.tsx
+++ b/client/src/components/board/AttachmentFan.tsx
@@ -8,7 +8,6 @@ import type { ObjectId } from "../../adapter/types.ts";
 import { dispatchAction, dispatchInteraction } from "../../game/dispatch.ts";
 import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import { cardImageLookup, tokenFiltersForObject } from "../../services/cardImageLookup.ts";
-import { useAppNotificationStore } from "../../stores/appToastStore.ts";
 import { useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import {
@@ -77,11 +76,9 @@ function fanCardSizingStyle(cardCount: number): CSSProperties {
  * convenience opened from the "⧉" badge, not a forced modal.
  */
 export function AttachmentFan() {
-  const { t } = useTranslation("game");
   const hostId = useUiStore((s) => s.attachmentFanHostId);
   const setAttachmentFanHost = useUiStore((s) => s.setAttachmentFanHost);
   const dismissPreview = useUiStore((s) => s.dismissPreview);
-  const showNotification = useAppNotificationStore((s) => s.showNotification);
 
   const objects = useGameStore((s) => s.gameState?.objects);
   const viewerInteraction = useGameStore((s) => s.viewerInteraction);
@@ -141,16 +138,6 @@ export function AttachmentFan() {
     return () => window.removeEventListener("keydown", onKey);
   }, [hostId, close]);
 
-  const notifyFailure = useCallback(
-    (error: unknown) => {
-      showNotification({
-        title: t("actionError.title", { action: t("permanent.fanPick") }),
-        description: error instanceof Error ? error.message : t("actionError.unknownEngineError"),
-      });
-    },
-    [showNotification, t],
-  );
-
   const handlePick = useCallback(
     (id: ObjectId) => {
       // Mode 1 — the engine published a pick for THIS card: forward its opaque
@@ -159,7 +146,7 @@ export function AttachmentFan() {
       const submission = submissionById.get(id);
       if (submission) {
         if (!viewerInteraction?.canSubmit) return;
-        void dispatchInteraction(submission).then(close).catch(notifyFailure);
+        void dispatchInteraction(submission).then(close).catch(() => undefined);
         return;
       }
       // Mode 2 — no prompt is open, so the fan is a reachability surface for the
@@ -182,7 +169,7 @@ export function AttachmentFan() {
       switch (verdict.kind) {
         case "dispatch":
           close();
-          void dispatchAction(verdict.action).catch(notifyFailure);
+          void dispatchAction(verdict.action).catch(() => undefined);
           return;
         case "choose":
           close();
@@ -206,7 +193,6 @@ export function AttachmentFan() {
       canActivate,
       close,
       submissionById,
-      notifyFailure,
       setPendingAbilityChoice,
       viewerInteraction?.canSubmit,
     ],
@@ -303,6 +289,7 @@ function FanCard({
         if (selectable) onPick(objectId);
       }}
       aria-label={obj.name}
+      data-object-id={objectId}
       className={`relative leading-[0] select-none ${selectable ? "cursor-pointer" : "cursor-default"}`}
       style={{ marginLeft, zIndex }}
     >

--- a/client/src/components/board/__tests__/AttachmentFan.test.tsx
+++ b/client/src/components/board/__tests__/AttachmentFan.test.tsx
@@ -399,6 +399,22 @@ describe("AttachmentFan mode 2 — the permanent's own legal actions", () => {
     expect(useUiStore.getState().pendingAbilityChoice).toBeNull();
   });
 
+  it("leaves the fan open when the centralized interaction dispatcher rejects", async () => {
+    const rejection = new Error("Engine error: invalid attachment choice");
+    vi.mocked(dispatchInteraction).mockRejectedValue(rejection);
+    seed({
+      legalActionsByObject: {},
+      viewerInteraction: projection([FREED_ID], { published: [FREED_ID] }),
+    });
+
+    fireEvent.click(fanCard("Freed from the Real"));
+    await expect(vi.mocked(dispatchInteraction).mock.results[0]?.value).rejects.toBe(rejection);
+    await Promise.resolve();
+
+    expect(useUiStore.getState().attachmentFanHostId).toBe(HOST_ID);
+    expect(document.querySelector("[data-attachment-fan]")).not.toBeNull();
+  });
+
   // V9 — MULTI-AUTHORITY HOSTILE FIXTURE. Both sources are live at once: an
   // interaction owns the prompt AND the same object has a populated bucket.
   // Exactly one authority may win, and it must be the engine's prompt.

--- a/client/src/components/board/__tests__/AttachmentFan.test.tsx
+++ b/client/src/components/board/__tests__/AttachmentFan.test.tsx
@@ -272,6 +272,12 @@ describe("AttachmentFan mode 2 — the permanent's own legal actions", () => {
     expect(dispatchAction).not.toHaveBeenCalled();
   });
 
+  it("identifies fanned cards for contextual errors", () => {
+    seed({ legalActionsByObject: { [String(FREED_ID)]: [FREED_TAP] } });
+
+    expect(fanCard("Freed from the Real")).toHaveAttribute("data-object-id", String(FREED_ID));
+  });
+
   // V2 — a lone benign action auto-dispatches rather than opening a one-option
   // modal. PAIR-ONLY (§7.1): POINTER sweep row `C4 lone benign ability`; its
   // always-side mutant is `alwaysChoose`.

--- a/client/src/components/board/__tests__/ResolutionProgressOverlay.test.tsx
+++ b/client/src/components/board/__tests__/ResolutionProgressOverlay.test.tsx
@@ -5,6 +5,7 @@ import { useGameStore } from "../../../stores/gameStore";
 import { ResolutionProgressOverlay } from "../ResolutionProgressOverlay";
 
 vi.mock("react-i18next", () => ({
+  initReactI18next: { type: "3rdParty", init: () => {} },
   useTranslation: () => ({
     t: (key: string, opts?: Record<string, unknown>) =>
       key === "resolutionProgress.label"

--- a/client/src/components/chrome/AppToast.tsx
+++ b/client/src/components/chrome/AppToast.tsx
@@ -10,6 +10,7 @@ export function AppToast() {
   const notification = useAppNotificationStore((s) => s.notification);
   const expiresAt = useAppNotificationStore((s) => s.expiresAt);
   const clearNotification = useAppNotificationStore((s) => s.clearNotification);
+  const anchored = notification?.anchor;
 
   useEffect(() => {
     if (!notification) return;
@@ -25,7 +26,11 @@ export function AppToast() {
           role="status"
           aria-live="polite"
           aria-atomic="true"
-          className="fixed top-4 right-4 z-[60] w-[min(100vw-2rem,22rem)] overflow-hidden rounded-xl border border-white/10 bg-[#0b1020]/96 shadow-[0_16px_48px_rgba(0,0,0,0.45)] backdrop-blur-md"
+          className={`fixed z-[60] w-[min(100vw-2rem,22rem)] overflow-hidden rounded-xl border border-white/10 bg-[#0b1020]/96 shadow-[0_16px_48px_rgba(0,0,0,0.45)] backdrop-blur-md ${
+            anchored ? "" : "top-4 right-4"
+          }`}
+          style={anchored ? { left: anchored.x, top: anchored.y } : undefined}
+          transformTemplate={(_, generated) => anchored ? `translate(-50%, -100%) ${generated}` : generated}
           initial={{ opacity: 0, x: 24, y: -8 }}
           animate={{ opacity: 1, x: 0, y: 0 }}
           exit={{ opacity: 0, x: 24, y: -8 }}

--- a/client/src/components/chrome/AppToast.tsx
+++ b/client/src/components/chrome/AppToast.tsx
@@ -26,7 +26,7 @@ export function AppToast() {
           role="status"
           aria-live="polite"
           aria-atomic="true"
-          className={`fixed z-[60] w-[min(100vw-2rem,22rem)] overflow-hidden rounded-xl border border-white/10 bg-[#0b1020]/96 shadow-[0_16px_48px_rgba(0,0,0,0.45)] backdrop-blur-md ${
+          className={`fixed z-[200] w-[min(100vw-2rem,22rem)] overflow-hidden rounded-xl border border-white/10 bg-[#0b1020]/96 shadow-[0_16px_48px_rgba(0,0,0,0.45)] backdrop-blur-md ${
             anchored ? "" : "top-4 right-4"
           }`}
           style={anchored ? { left: anchored.x, top: anchored.y } : undefined}

--- a/client/src/components/chrome/AppToast.tsx
+++ b/client/src/components/chrome/AppToast.tsx
@@ -30,7 +30,9 @@ export function AppToast() {
             anchored ? "" : "top-4 right-4"
           }`}
           style={anchored ? { left: anchored.x, top: anchored.y } : undefined}
-          transformTemplate={(_, generated) => anchored ? `translate(-50%, -100%) ${generated}` : generated}
+          transformTemplate={(_, generated) => anchored
+            ? `translate(-50%, ${anchored.placement === "above" ? "-100%" : "0"}) ${generated}`
+            : generated}
           initial={{ opacity: 0, x: 24, y: -8 }}
           animate={{ opacity: 1, x: 0, y: 0 }}
           exit={{ opacity: 0, x: 24, y: -8 }}

--- a/client/src/components/chrome/__tests__/AppToast.test.tsx
+++ b/client/src/components/chrome/__tests__/AppToast.test.tsx
@@ -18,7 +18,7 @@ describe("AppToast", () => {
       notification: {
         title: "Action failed",
         description: "Engine error: ObjectId(200) must be blocked by 2 or more creatures",
-        anchor: { x: 240, y: 320 },
+        anchor: { x: 240, y: 320, placement: "above" },
       },
       expiresAt: Date.now() + 5_000,
     });

--- a/client/src/components/chrome/__tests__/AppToast.test.tsx
+++ b/client/src/components/chrome/__tests__/AppToast.test.tsx
@@ -1,0 +1,32 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+
+import { AppToast } from "../AppToast.tsx";
+import { useAppNotificationStore } from "../../../stores/appToastStore.ts";
+
+describe("AppToast", () => {
+  beforeEach(() => {
+    useAppNotificationStore.setState({ notification: null, expiresAt: 0 });
+  });
+
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("positions a contextual notification at the supplied rendered-object anchor", () => {
+    useAppNotificationStore.setState({
+      notification: {
+        title: "Action failed",
+        description: "Engine error: ObjectId(200) must be blocked by 2 or more creatures",
+        anchor: { x: 240, y: 320 },
+      },
+      expiresAt: Date.now() + 5_000,
+    });
+
+    render(<AppToast />);
+
+    const toast = screen.getByRole("status");
+    expect(toast).toHaveStyle({ left: "240px", top: "320px" });
+    expect(screen.getByText("Engine error: ObjectId(200) must be blocked by 2 or more creatures")).toBeInTheDocument();
+  });
+});

--- a/client/src/components/chrome/__tests__/AppToast.test.tsx
+++ b/client/src/components/chrome/__tests__/AppToast.test.tsx
@@ -26,6 +26,7 @@ describe("AppToast", () => {
     render(<AppToast />);
 
     const toast = screen.getByRole("status");
+    expect(toast).toHaveClass("z-[200]");
     expect(toast).toHaveStyle({ left: "240px", top: "320px" });
     expect(screen.getByText("Engine error: ObjectId(200) must be blocked by 2 or more creatures")).toBeInTheDocument();
   });

--- a/client/src/components/hand/MobileHandDrawer.tsx
+++ b/client/src/components/hand/MobileHandDrawer.tsx
@@ -286,6 +286,7 @@ const DrawerCard = memo(function DrawerCard({
   return (
     <button
       className={`relative aspect-[5/7] w-full overflow-hidden rounded-lg bg-gray-800 ${glowClass}`}
+      data-object-id={objectId}
       onClick={handleClick}
       {...handlers}
     >

--- a/client/src/components/hand/PlayerHand.tsx
+++ b/client/src/components/hand/PlayerHand.tsx
@@ -1117,6 +1117,7 @@ const ZoneFanCard = memo(function ZoneFanCard({
   return (
     <motion.div
       data-zone-fan-card
+      data-object-id={objectId}
       // Marks the card as inspectable, which is what usePreviewDismiss's 300ms
       // `[data-card-hover]:hover` poll (and uiStore's 50ms deferred clear) test
       // for. Without it the poll saw nothing hovered and tore the preview down

--- a/client/src/components/hand/__tests__/ZoneFanCardHover.test.tsx
+++ b/client/src/components/hand/__tests__/ZoneFanCardHover.test.tsx
@@ -154,6 +154,10 @@ describe("castable graveyard/exile wing hover", () => {
     // The wing rendered at all (engine surfaced a cast action for it).
     const inspectable = container.querySelectorAll("[data-card-hover]");
     expect(inspectable.length).toBe(2);
+    expect(within(container).getByAltText("Encore Card").closest("[data-zone-fan-card]")).toHaveAttribute(
+      "data-object-id",
+      String(301),
+    );
 
     // ...but only the hand card is part of the reorder index space. Queried
     // through the exported selector, so pointing it back at `[data-card-hover]`

--- a/client/src/components/stack/StackDisplay.tsx
+++ b/client/src/components/stack/StackDisplay.tsx
@@ -25,6 +25,7 @@ const EMPTY_DETAILS: Record<string, StackEntryDisplay> = {};
 interface DisplayStackEntry {
   entry: StackEntryType;
   choiceObjectId?: ObjectId;
+  groupedObjectIds?: ObjectId[];
   groupCount: number;
 }
 
@@ -116,6 +117,7 @@ export function StackDisplay({
               return [{
                 entry: representative,
                 choiceObjectId: legalMemberIds[0],
+                groupedObjectIds: group.member_ids,
                 groupCount: group.count,
               }];
             }
@@ -321,11 +323,12 @@ export function StackDisplay({
                   const pacing = pressureMultiplier(
                     effectiveStackPressure(displayStack.length),
                   );
-                  return groupedStack.map(({ entry, choiceObjectId, groupCount }, index) => (
+                  return groupedStack.map(({ entry, choiceObjectId, groupedObjectIds, groupCount }, index) => (
                     <StackEntry
                       key={entry.id}
                       entry={entry}
                       choiceObjectId={choiceObjectId}
+                      groupedObjectIds={groupedObjectIds}
                       index={index}
                       isTop={index === displayStack.length - 1}
                       isPending={stackEntryDetails[String(entry.id)]?.is_pending}

--- a/client/src/components/stack/StackEntry.tsx
+++ b/client/src/components/stack/StackEntry.tsx
@@ -54,10 +54,12 @@ interface StackEntryProps {
    * visible card remains `entry`; choice membership and dispatch use this id.
    */
   choiceObjectId?: ObjectId;
+  /** All object identities represented by a compact group. */
+  groupedObjectIds?: ObjectId[];
   details?: StackEntryDisplay;
 }
 
-export function StackEntry({ entry, choiceObjectId = entry.id, index, isTop, isPending, cardSize, style, onHoverChange, pacingMultiplier = 1, groupCount = 1, details }: StackEntryProps) {
+export function StackEntry({ entry, choiceObjectId = entry.id, groupedObjectIds, index, isTop, isPending, cardSize, style, onHoverChange, pacingMultiplier = 1, groupCount = 1, details }: StackEntryProps) {
   const { t } = useTranslation("game");
   const isMobile = useIsMobile();
   const playerId = usePlayerId();
@@ -220,6 +222,8 @@ export function StackEntry({ entry, choiceObjectId = entry.id, index, isTop, isP
       }}
       style={style}
       data-stack-entry={entry.id}
+      data-object-id={entry.id}
+      data-grouped-ids={groupedObjectIds && groupedObjectIds.length > 1 ? groupedObjectIds.join(" ") : undefined}
       data-card-hover
       className="relative cursor-pointer"
       onClick={handleClick}

--- a/client/src/components/stack/__tests__/StackDisplay.test.tsx
+++ b/client/src/components/stack/__tests__/StackDisplay.test.tsx
@@ -14,12 +14,14 @@ vi.mock("../StackEntry.tsx", () => ({
   StackEntry: ({
     entry,
     choiceObjectId,
+    groupedObjectIds,
     groupCount,
     onHoverChange,
     style,
   }: {
     entry: { id: number };
     choiceObjectId?: number;
+    groupedObjectIds?: number[];
     groupCount?: number;
     onHoverChange?: (hovered: boolean) => void;
     style?: CSSProperties;
@@ -28,6 +30,7 @@ vi.mock("../StackEntry.tsx", () => ({
       type="button"
       data-testid={`stack-entry-${entry.id}`}
       data-choice-object-id={choiceObjectId}
+      data-grouped-ids={groupedObjectIds?.join(" ")}
       data-group-count={groupCount}
       style={style}
       onMouseEnter={() => onHoverChange?.(true)}
@@ -99,6 +102,7 @@ describe("StackDisplay", () => {
     render(<StackDisplay effectiveMultiplayerBoardLayout="focused" />);
 
     expect(screen.getByTestId("stack-entry-10")).toHaveAttribute("data-choice-object-id", "11");
+    expect(screen.getByTestId("stack-entry-10")).toHaveAttribute("data-grouped-ids", "10 11");
     expect(screen.getByTestId("stack-entry-10")).toHaveAttribute("data-group-count", "2");
     expect(screen.queryByTestId("stack-entry-11")).not.toBeInTheDocument();
     expect(stackTargetArcsMock).toHaveBeenLastCalledWith(

--- a/client/src/components/stack/__tests__/StackEntry.test.tsx
+++ b/client/src/components/stack/__tests__/StackEntry.test.tsx
@@ -151,6 +151,23 @@ describe("StackEntry", () => {
     vi.useRealTimers();
   });
 
+  it("identifies the represented stack object and compact group for contextual errors", () => {
+    const entry = buildStackEntry({ id: 77, source_id: 42 });
+
+    render(
+      <StackEntry
+        entry={entry}
+        groupedObjectIds={[77, 78]}
+        index={0}
+        isTop
+        cardSize={{ width: 120, height: 168 }}
+      />,
+    );
+
+    expect(document.querySelector('[data-stack-entry="77"]')).toHaveAttribute("data-object-id", "77");
+    expect(document.querySelector('[data-stack-entry="77"]')).toHaveAttribute("data-grouped-ids", "77 78");
+  });
+
   it("offers Revoke for an AllCopies yield after the source token has ceased", () => {
     // CR 400.7 + CR 704.5d: a ceased token is gone from `objects`, so the entry
     // has no live source object to read a card_id from — the menu must match the

--- a/client/src/components/zone/CommandZone.tsx
+++ b/client/src/components/zone/CommandZone.tsx
@@ -222,6 +222,8 @@ function EmblemCard({ group, label }: { group: GroupedEmblem; label: string }) {
         height: `calc(var(--art-crop-h) * ${EMBLEM_CHIP_SCALE})`,
       }}
       data-testid="emblem-card"
+      data-object-id={activeMember?.id}
+      data-grouped-ids={group.members.map((member) => member.id).join(" ")}
       data-activatable={isActivatable || undefined}
       role={isActivatable ? "button" : undefined}
       tabIndex={isActivatable ? 0 : undefined}

--- a/client/src/components/zone/CommanderCardZone.tsx
+++ b/client/src/components/zone/CommanderCardZone.tsx
@@ -224,6 +224,7 @@ function CommanderCard({
       onDragStart={startManaPaymentPreview}
       onDragEnd={onDragEnd}
       whileDrag={{ cursor: "grabbing", scale: 1.04 }}
+      data-object-id={commander.id}
       className={`group relative ${
         canCast ? "cursor-grab" : canNinjutsu ? "cursor-pointer" : "cursor-default"
       }`}

--- a/client/src/components/zone/ExilePile.tsx
+++ b/client/src/components/zone/ExilePile.tsx
@@ -2,11 +2,10 @@ import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useGameStore } from "../../stores/gameStore.ts";
-import { useCanActForWaitingState, usePlayerId } from "../../hooks/usePlayerId.ts";
+import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
 import {
   getPlayerZoneIds,
   getWaitingForObjectChoiceIds,
-  isFaceDownExileCardVisibleToViewer,
 } from "../../viewmodel/gameStateView.ts";
 
 interface ExilePileProps {
@@ -17,21 +16,12 @@ interface ExilePileProps {
 
 export function ExilePile({ playerId, onClick, size }: ExilePileProps) {
   const { t } = useTranslation("game");
-  const viewerId = usePlayerId();
   const gameState = useGameStore((s) => s.gameState);
   const exileObjectIds = useMemo(
     () => getPlayerZoneIds(gameState, "exile", playerId),
     [gameState, playerId],
   );
-  const visibleExileObjectIds = useMemo(
-    () => exileObjectIds.filter((id) => {
-      const obj = gameState?.objects[id];
-      return obj != null && (
-        !obj.face_down || isFaceDownExileCardVisibleToViewer(gameState, obj, viewerId)
-      );
-    }),
-    [exileObjectIds, gameState, viewerId],
-  );
+  const visibleExileObjectIds = gameState?.derived?.visible_exile_object_ids?.[playerId] ?? [];
   const count = exileObjectIds.length;
   const canActForWaitingState = useCanActForWaitingState();
   const hasSelectableCards = useGameStore((s) => {

--- a/client/src/components/zone/ExilePile.tsx
+++ b/client/src/components/zone/ExilePile.tsx
@@ -1,8 +1,13 @@
+import { useMemo } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useGameStore } from "../../stores/gameStore.ts";
-import { useCanActForWaitingState } from "../../hooks/usePlayerId.ts";
-import { getPlayerZoneIds, getWaitingForObjectChoiceIds } from "../../viewmodel/gameStateView.ts";
+import { useCanActForWaitingState, usePlayerId } from "../../hooks/usePlayerId.ts";
+import {
+  getPlayerZoneIds,
+  getWaitingForObjectChoiceIds,
+  isFaceDownExileCardVisibleToViewer,
+} from "../../viewmodel/gameStateView.ts";
 
 interface ExilePileProps {
   playerId: number;
@@ -12,7 +17,22 @@ interface ExilePileProps {
 
 export function ExilePile({ playerId, onClick, size }: ExilePileProps) {
   const { t } = useTranslation("game");
-  const count = useGameStore((s) => getPlayerZoneIds(s.gameState, "exile", playerId).length);
+  const viewerId = usePlayerId();
+  const gameState = useGameStore((s) => s.gameState);
+  const exileObjectIds = useMemo(
+    () => getPlayerZoneIds(gameState, "exile", playerId),
+    [gameState, playerId],
+  );
+  const visibleExileObjectIds = useMemo(
+    () => exileObjectIds.filter((id) => {
+      const obj = gameState?.objects[id];
+      return obj != null && (
+        !obj.face_down || isFaceDownExileCardVisibleToViewer(gameState, obj, viewerId)
+      );
+    }),
+    [exileObjectIds, gameState, viewerId],
+  );
+  const count = exileObjectIds.length;
   const canActForWaitingState = useCanActForWaitingState();
   const hasSelectableCards = useGameStore((s) => {
     if (!canActForWaitingState) return false;
@@ -30,6 +50,7 @@ export function ExilePile({ playerId, onClick, size }: ExilePileProps) {
       onClick={onClick}
       className={`group relative cursor-pointer ${hasSelectableCards ? "ring-2 ring-amber-400/60 rounded-lg shadow-[0_0_12px_3px_rgba(201,176,55,0.8)]" : ""}`}
       title={t("zone.exileTitle", { count })}
+      data-grouped-ids={visibleExileObjectIds.length > 0 ? visibleExileObjectIds.join(" ") : undefined}
       style={{ width: w, height: h }}
     >
       <div className="relative h-full w-full overflow-hidden rounded-lg border border-indigo-500/40 shadow-md group-hover:border-indigo-400/60 transition-colors">

--- a/client/src/components/zone/GraveyardPile.tsx
+++ b/client/src/components/zone/GraveyardPile.tsx
@@ -106,6 +106,7 @@ export function GraveyardPile({ playerId, onClick, size }: GraveyardPileProps) {
       className={`group relative cursor-pointer ${hasTargetableCards || hasDelveableCards ? "ring-2 ring-amber-400/60 rounded-lg shadow-[0_0_12px_3px_rgba(201,176,55,0.8)]" : ""}`}
       title={t("zone.graveyardTitle", { count })}
       data-graveyard-pile={playerId}
+      data-grouped-ids={graveyard.join(" ")}
       style={{ width: w, height: h }}
     >
       {/* Shadow stack layers */}

--- a/client/src/components/zone/LibraryPile.tsx
+++ b/client/src/components/zone/LibraryPile.tsx
@@ -169,6 +169,7 @@ export function LibraryPile({ playerId, size, onView }: LibraryPileProps) {
         disabled={!canView && !canPlay && topCardName == null}
         aria-label={canPlay ? playLabel : libraryLabel}
         data-library-top-cast={canPlay ? "true" : "false"}
+        data-grouped-ids={isPeeking && topObjectId != null ? String(topObjectId) : undefined}
         {...topHoverProps}
         className={`relative block h-full w-full overflow-hidden rounded-lg border shadow-md ${
           canPlay

--- a/client/src/components/zone/ZoneViewer.tsx
+++ b/client/src/components/zone/ZoneViewer.tsx
@@ -246,6 +246,7 @@ function ZoneCard({
             : "hover:ring-1 hover:ring-white/20"
       }`}
       title={canCast && !isValidTarget ? castTitle : undefined}
+      data-object-id={hiddenFromViewer ? undefined : obj.id}
       {...hoverProps(obj.id)}
       onClick={handleClick}
     >

--- a/client/src/components/zone/__tests__/CommandZone.test.tsx
+++ b/client/src/components/zone/__tests__/CommandZone.test.tsx
@@ -287,6 +287,15 @@ describe("CommandZone grouped-emblem activation identity", () => {
     expect(screen.getByText("×2")).toBeInTheDocument();
   }
 
+  it("anchors the active representative and every public member of its collapsed emblem group", () => {
+    const action = abilityAction(EMBLEM_ID);
+    seedGroupedPair({ [String(EMBLEM_ID)]: [action] });
+
+    const chip = screen.getByTestId("emblem-card");
+    expect(chip).toHaveAttribute("data-object-id", String(EMBLEM_ID));
+    expect(chip).toHaveAttribute("data-grouped-ids", `${EMBLEM_ID} ${SIBLING_EMBLEM_ID}`);
+  });
+
   // THE discriminating row both reviewers asked for.
   //
   // MEASURED (drop side): restoring the representative-only derivation

--- a/client/src/components/zone/__tests__/CommanderCardZone.test.tsx
+++ b/client/src/components/zone/__tests__/CommanderCardZone.test.tsx
@@ -141,6 +141,14 @@ describe("CommanderCardZone commander ninjutsu (issue #5239)", () => {
     expect(useUiStore.getState().inspectedObjectId).toBeNull();
   });
 
+  it("identifies the commander card for contextual errors", () => {
+    seedStores([castAction()]);
+
+    render(<CommanderCardZone playerId={0} />);
+
+    expect(screen.getByRole("button")).toHaveAttribute("data-object-id", String(COMMANDER_ID));
+  });
+
   it("opens the ability-choice modal when multiple attackers can be returned", () => {
     const actions = [ninjutsuAction(9), ninjutsuAction(12)];
     seedStores(actions);

--- a/client/src/components/zone/__tests__/LibraryPile.test.tsx
+++ b/client/src/components/zone/__tests__/LibraryPile.test.tsx
@@ -197,6 +197,7 @@ describe("LibraryPile play/cast surfacing (#297)", () => {
     render(<LibraryPile playerId={1} />);
     const button = screen.getByRole("button", { name: /library \(1 card\)/i });
     expect(button).toBeInTheDocument();
+    expect(button).toHaveAttribute("data-grouped-ids", "77");
     // Peeked tops use the cyan border; card-back alt text is hidden.
     expect(button.className).toContain("border-cyan-600");
     expect(screen.queryByAltText("Library")).not.toBeInTheDocument();
@@ -210,6 +211,7 @@ describe("LibraryPile play/cast surfacing (#297)", () => {
     render(<LibraryPile playerId={1} />);
     const button = screen.getByRole("button", { name: /library \(1 card\)/i });
     expect(button.className).toContain("border-gray-600");
+    expect(button).not.toHaveAttribute("data-grouped-ids");
     expect(screen.getByAltText("Library")).toBeInTheDocument();
   });
 

--- a/client/src/components/zone/__tests__/PileAnchors.test.tsx
+++ b/client/src/components/zone/__tests__/PileAnchors.test.tsx
@@ -54,6 +54,7 @@ describe("zone pile contextual anchors", () => {
       exile: [faceUp.id, hidden.id],
       stack: [],
       waiting_for: buildPriorityWaitingFor(),
+      derived: { visible_exile_object_ids: { 0: [faceUp.id] } },
     });
     useGameStore.setState({ gameState, waitingFor: gameState.waiting_for, legalActionsByObject: {} });
 

--- a/client/src/components/zone/__tests__/PileAnchors.test.tsx
+++ b/client/src/components/zone/__tests__/PileAnchors.test.tsx
@@ -1,0 +1,64 @@
+import { cleanup, render } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { useGameStore } from "../../../stores/gameStore.ts";
+import { buildGameObject, buildObjectMap } from "../../../test/factories/gameObjectFactory.ts";
+import { buildGameState, buildPlayers, buildPriorityWaitingFor } from "../../../test/factories/gameStateFactory.ts";
+import { ExilePile } from "../ExilePile.tsx";
+import { GraveyardPile } from "../GraveyardPile.tsx";
+
+vi.mock("../../../hooks/useCardImage.ts", () => ({
+  useCardImage: () => ({ src: null, isLoading: false }),
+}));
+
+afterEach(() => {
+  cleanup();
+  useGameStore.setState({ gameState: null, waitingFor: null, legalActionsByObject: {} });
+});
+
+describe("zone pile contextual anchors", () => {
+  it("groups the public graveyard members represented by its pile", () => {
+    const first = buildGameObject({ id: 101, zone: "Graveyard", entered_battlefield_turn: null });
+    const top = buildGameObject({ id: 102, zone: "Graveyard", entered_battlefield_turn: null });
+    const gameState = buildGameState({
+      players: buildPlayers([{ id: 0, graveyard: [first.id, top.id] }, 1]),
+      objects: buildObjectMap(first, top),
+      battlefield: [],
+      exile: [],
+      stack: [],
+      waiting_for: buildPriorityWaitingFor(),
+    });
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for, legalActionsByObject: {} });
+
+    const { container } = render(<GraveyardPile playerId={0} onClick={vi.fn()} />);
+
+    expect(container.querySelector('[data-graveyard-pile="0"]')).toHaveAttribute(
+      "data-grouped-ids",
+      "101 102",
+    );
+  });
+
+  it("groups only exile cards whose identities the pile can represent", () => {
+    const faceUp = buildGameObject({ id: 201, zone: "Exile", entered_battlefield_turn: null });
+    const hidden = buildGameObject({
+      id: 202,
+      zone: "Exile",
+      face_down: true,
+      display_visible_to_viewer: false,
+      entered_battlefield_turn: null,
+    });
+    const gameState = buildGameState({
+      players: buildPlayers([0, 1]),
+      objects: buildObjectMap(faceUp, hidden),
+      battlefield: [],
+      exile: [faceUp.id, hidden.id],
+      stack: [],
+      waiting_for: buildPriorityWaitingFor(),
+    });
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for, legalActionsByObject: {} });
+
+    const { container } = render(<ExilePile playerId={0} onClick={vi.fn()} />);
+
+    expect(container.querySelector("button")).toHaveAttribute("data-grouped-ids", "201");
+  });
+});

--- a/client/src/components/zone/__tests__/ZoneViewer.test.tsx
+++ b/client/src/components/zone/__tests__/ZoneViewer.test.tsx
@@ -110,6 +110,12 @@ describe("ZoneViewer", () => {
     );
   });
 
+  it("identifies visible zone cards for contextual errors", () => {
+    render(<ZoneViewer zone="graveyard" playerId={0} onClose={vi.fn()} />);
+
+    expect(screen.getByTestId("card-image").parentElement).toHaveAttribute("data-object-id", "7");
+  });
+
   it("resolves graveyard card art via printed_ref oracle_id, not name", () => {
     // Regression: a transformed / DFC / back-face card (e.g. a transformed
     // planeswalker) has a back-face name that isn't a scryfall-data key, so the

--- a/client/src/game/__tests__/dispatchResolveAll.test.ts
+++ b/client/src/game/__tests__/dispatchResolveAll.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { BatchResolveResult, EngineSnapshot, GameState } from "../../adapter/types";
-import { AdapterError, AdapterErrorCode, nextSnapshotSeq } from "../../adapter/types";
+import type { ActionRejection, BatchResolveResult, EngineSnapshot, GameState } from "../../adapter/types";
+import { actionRejectionError, nextSnapshotSeq } from "../../adapter/types";
 import { useGameStore } from "../../stores/gameStore";
 import { useAppNotificationStore } from "../../stores/appToastStore";
 import { usePreferencesStore } from "../../stores/preferencesStore";
@@ -27,6 +27,16 @@ function readyStateWithStack(len: number): GameState {
 
 function chunk(itemsResolved: number, total: number): BatchResolveResult {
   return { events: [], waitingFor: priorityWf, logEntries: [], itemsResolved, total };
+}
+
+function rejection(overrides: Partial<ActionRejection> = {}): ActionRejection {
+  return {
+    code: "resolve_all_not_ready",
+    disposition: "unavailable",
+    message: "Engine error: ObjectId(200) cannot resolve all from the current stack",
+    related_object_ids: [200],
+    ...overrides,
+  };
 }
 
 /**
@@ -318,11 +328,11 @@ describe("dispatchResolveAll progress", () => {
     const resolveAll = vi
       .fn<EngineResolveAll>()
       .mockRejectedValue(
-        new AdapterError(
-          AdapterErrorCode.STALE_ACTION,
-          "Resolve All requires your priority",
-          false,
-        ),
+        actionRejectionError(rejection({
+          code: "stale_action",
+          disposition: "stale",
+          message: "Resolve All requires your priority",
+        })),
       );
     const getState = vi.fn().mockResolvedValue(stateWithStack(2));
     useGameStore.setState({
@@ -364,6 +374,39 @@ describe("dispatchResolveAll progress", () => {
     expect(useAppNotificationStore.getState().notification).toMatchObject({
       description: "batch snapshot rejected",
     });
+  });
+
+  it("anchors a structured Resolve All rejection at its engine-provided related object", async () => {
+    const anchor = document.createElement("div");
+    anchor.dataset.objectId = "200";
+    anchor.getBoundingClientRect = () => ({
+      x: 30, y: 100, top: 100, right: 90, bottom: 160, left: 30, width: 60, height: 60,
+      toJSON: () => ({}),
+    });
+    document.body.append(anchor);
+    const engineRejection = rejection();
+    const resolveAll = vi
+      .fn<EngineResolveAll>()
+      .mockRejectedValue(actionRejectionError(engineRejection));
+    const getState = vi.fn().mockResolvedValue(stateWithStack(2));
+    useGameStore.setState({
+      gameState: readyStateWithStack(2),
+      adapter: {
+        resolveAll,
+        resolveAllUsesServerAi: true,
+        getState,
+        getLegalActions: vi.fn().mockResolvedValue({ actions: [], autoPassRecommended: false }),
+        getSnapshot: snapshotVia(getState),
+      } as never,
+    });
+
+    await expect(dispatchResolveAll(0, [])).resolves.toBeUndefined();
+
+    expect(useAppNotificationStore.getState().notification).toMatchObject({
+      description: engineRejection.message,
+      anchor: { x: 60, y: 88 },
+    });
+    anchor.remove();
   });
 
   it("falls back to an engine-side UntilStackEmpty auto-pass when the adapter has no batch resolveAll (multiplayer)", async () => {

--- a/client/src/game/__tests__/dispatchResolveAll.test.ts
+++ b/client/src/game/__tests__/dispatchResolveAll.test.ts
@@ -404,7 +404,7 @@ describe("dispatchResolveAll progress", () => {
 
     expect(useAppNotificationStore.getState().notification).toMatchObject({
       description: engineRejection.message,
-      anchor: { x: 60, y: 88 },
+      anchor: { x: 192, y: 172, placement: "below" },
     });
     anchor.remove();
   });

--- a/client/src/game/__tests__/dispatchTimeout.test.ts
+++ b/client/src/game/__tests__/dispatchTimeout.test.ts
@@ -151,7 +151,7 @@ describe("dispatchAction recovery on ENGINE_UNRESPONSIVE", () => {
     expect(useAppNotificationStore.getState().notification).toEqual({
       title: "Skip target failed",
       description: engineRejection.message,
-      anchor: { x: 30, y: 18 },
+      anchor: { x: 192, y: 82, placement: "below" },
     });
     first.remove();
     second.remove();
@@ -200,7 +200,7 @@ describe("dispatchAction recovery on ENGINE_UNRESPONSIVE", () => {
     expect(useAppNotificationStore.getState().notification).toEqual({
       title: "Action failed",
       description: engineRejection.message,
-      anchor: { x: 90, y: 68 },
+      anchor: { x: 192, y: 132, placement: "below" },
     });
     anchor.remove();
   });

--- a/client/src/game/__tests__/dispatchTimeout.test.ts
+++ b/client/src/game/__tests__/dispatchTimeout.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { EngineAdapter, GameAction, SubmitResult } from "../../adapter/types";
-import { AdapterError, AdapterErrorCode, nextSnapshotSeq } from "../../adapter/types";
+import type { ActionRejection, EngineAdapter, GameAction, SubmitResult } from "../../adapter/types";
+import { actionRejectionError, AdapterError, AdapterErrorCode, nextSnapshotSeq } from "../../adapter/types";
 import { useAppNotificationStore } from "../../stores/appToastStore";
 import { useGameStore } from "../../stores/gameStore";
 import { buildEngineAdapterMock } from "../../test/factories/engineAdapterFactory";
@@ -11,7 +11,7 @@ import {
   buildPlayer,
   buildPriorityWaitingFor,
 } from "../../test/factories/gameStateFactory";
-import { dispatchAction } from "../dispatch";
+import { dispatchAction, dispatchInteraction } from "../dispatch";
 
 // Spy on the recovery escalation so we can assert the dispatch.ts branch that
 // fires `notifyEngineLost` on ENGINE_UNRESPONSIVE actually runs. Without this
@@ -33,6 +33,16 @@ const emptyState = buildGameState({
   stack: [],
   players: [],
 });
+
+function rejection(overrides: Partial<ActionRejection> = {}): ActionRejection {
+  return {
+    code: "invalid_action",
+    disposition: "invalid",
+    message: "Engine error: ObjectId(200) must be blocked by 2 or more creatures",
+    related_object_ids: [200],
+    ...overrides,
+  };
+}
 
 /**
  * Regression for the silent-freeze bug: when a gameplay worker round-trip
@@ -112,6 +122,121 @@ describe("dispatchAction recovery on ENGINE_UNRESPONSIVE", () => {
     expect(useAppNotificationStore.getState().notification).toEqual({
       title: "Skip target failed",
       description: "Engine error: Action not allowed: Cannot pay mana cost",
+    });
+  });
+
+  it("anchors a structured rejection at the first rendered related object without changing its message", async () => {
+    const first = document.createElement("div");
+    first.dataset.objectId = "200";
+    first.getBoundingClientRect = () => ({
+      x: 10, y: 30, top: 30, right: 50, bottom: 70, left: 10, width: 40, height: 40,
+      toJSON: () => ({}),
+    });
+    const second = document.createElement("div");
+    second.dataset.objectId = "201";
+    document.body.append(first, second);
+    const engineRejection = rejection({ related_object_ids: [200, 201] });
+    const submitAction = vi
+      .fn<EngineAdapter["submitAction"]>()
+      .mockRejectedValue(actionRejectionError(engineRejection));
+
+    useGameStore.setState({
+      adapter: buildEngineAdapterMock(emptyState, { submitAction }),
+      gameState: emptyState,
+      gameMode: "ai",
+    });
+
+    await expect(dispatchAction({ type: "ChooseTarget", data: { target: null } }, 0)).rejects.toBeInstanceOf(AdapterError);
+
+    expect(useAppNotificationStore.getState().notification).toEqual({
+      title: "Skip target failed",
+      description: engineRejection.message,
+      anchor: { x: 30, y: 18 },
+    });
+    first.remove();
+    second.remove();
+  });
+
+  it("silently absorbs a stale structured rejection", async () => {
+    const submitAction = vi
+      .fn<EngineAdapter["submitAction"]>()
+      .mockRejectedValue(actionRejectionError(rejection({
+        code: "stale_action",
+        disposition: "stale",
+        message: "The action is no longer current",
+      })));
+
+    useGameStore.setState({
+      adapter: buildEngineAdapterMock(emptyState, { submitAction }),
+      gameState: emptyState,
+      gameMode: "ai",
+    });
+
+    await expect(dispatchAction({ type: "PassPriority", data: {} } as GameAction, 0)).resolves.toBeUndefined();
+    expect(useAppNotificationStore.getState().notification).toBeNull();
+  });
+
+  it("reports structured interaction rejections through the same contextual path", async () => {
+    const anchor = document.createElement("div");
+    anchor.dataset.groupedIds = "201 202";
+    anchor.getBoundingClientRect = () => ({
+      x: 40, y: 80, top: 80, right: 140, bottom: 120, left: 40, width: 100, height: 40,
+      toJSON: () => ({}),
+    });
+    document.body.append(anchor);
+    const engineRejection = rejection({ related_object_ids: [202] });
+    const submitInteraction = vi
+      .fn<NonNullable<EngineAdapter["submitInteraction"]>>()
+      .mockRejectedValue(actionRejectionError(engineRejection));
+
+    useGameStore.setState({
+      adapter: buildEngineAdapterMock(emptyState, { submitInteraction }),
+      gameState: emptyState,
+      gameMode: "ai",
+    });
+
+    await expect(dispatchInteraction({} as never, 0)).rejects.toBeInstanceOf(AdapterError);
+
+    expect(useAppNotificationStore.getState().notification).toEqual({
+      title: "Action failed",
+      description: engineRejection.message,
+      anchor: { x: 90, y: 68 },
+    });
+    anchor.remove();
+  });
+
+  it("reports a queued structured rejection once it reaches the dispatch pipeline", async () => {
+    const engineRejection = rejection({ related_object_ids: [] });
+    let resolveFirst!: (result: SubmitResult) => void;
+    const submitAction = vi
+      .fn<EngineAdapter["submitAction"]>()
+      .mockImplementationOnce(() => new Promise<SubmitResult>((resolve) => {
+        resolveFirst = resolve;
+      }))
+      .mockRejectedValueOnce(actionRejectionError(engineRejection));
+    const getSnapshot = vi.fn<EngineAdapter["getSnapshot"]>().mockResolvedValue({
+      state: emptyState,
+      legalResult: buildLegalActionsResult({ actions: [{ type: "ChooseTarget", data: { target: null } }] }),
+      seq: nextSnapshotSeq(),
+    });
+
+    useGameStore.setState({
+      adapter: buildEngineAdapterMock(emptyState, { submitAction, getSnapshot }),
+      gameState: emptyState,
+      waitingFor: emptyState.waiting_for,
+      legalActions: [{ type: "ChooseTarget", data: { target: null } }],
+      gameMode: "ai",
+    });
+
+    const first = dispatchAction({ type: "PassPriority", data: {} } as GameAction, 0);
+    const queued = dispatchAction({ type: "ChooseTarget", data: { target: null } }, 0);
+    resolveFirst({ events: [], log_entries: [] } as SubmitResult);
+
+    await expect(first).resolves.toBeUndefined();
+    await expect(queued).rejects.toBeInstanceOf(AdapterError);
+    expect(useAppNotificationStore.getState().notification).toMatchObject({
+      title: "Skip target failed",
+      description: engineRejection.message,
     });
   });
 

--- a/client/src/game/actionRejectionReporter.ts
+++ b/client/src/game/actionRejectionReporter.ts
@@ -1,0 +1,83 @@
+import { AdapterError } from "../adapter/types";
+import i18n from "../i18n";
+import { useAppNotificationStore, type AppNotificationAnchor } from "../stores/appToastStore";
+import { objectAnchorSelector } from "../utils/objectAnchorSelector";
+
+const TOAST_MAX_WIDTH_PX = 352;
+const VIEWPORT_INSET_PX = 16;
+const TARGET_GAP_PX = 12;
+const TOAST_HEIGHT_BUDGET_PX = 144;
+
+export type StructuredRejectionReport = "not-structured" | "stale" | "reported";
+
+function genericActionFailureTitle(): string {
+  return i18n.t("actionError.title", { action: i18n.t("actionError.genericAction") });
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(Math.max(value, min), max);
+}
+
+function actionRejectionAnchor(err: AdapterError): AppNotificationAnchor | undefined {
+  if (!err.rejection || typeof document === "undefined" || typeof window === "undefined") {
+    return undefined;
+  }
+
+  for (const objectId of err.rejection.related_object_ids) {
+    const anchor = document.querySelector<HTMLElement>(objectAnchorSelector(objectId));
+    if (!anchor) continue;
+
+    const rect = anchor.getBoundingClientRect();
+    const viewportWidth = Math.max(0, window.innerWidth);
+    const toastWidth = Math.min(
+      TOAST_MAX_WIDTH_PX,
+      Math.max(0, viewportWidth - VIEWPORT_INSET_PX * 2),
+    );
+    const halfToastWidth = Math.max(0, toastWidth / 2);
+    const leftBound = Math.min(
+      VIEWPORT_INSET_PX + halfToastWidth,
+      viewportWidth - VIEWPORT_INSET_PX - halfToastWidth,
+    );
+    const rightBound = Math.max(
+      VIEWPORT_INSET_PX + halfToastWidth,
+      viewportWidth - VIEWPORT_INSET_PX - halfToastWidth,
+    );
+    const x = clamp(
+      rect.left + rect.width / 2,
+      leftBound,
+      rightBound,
+    );
+    const placement = rect.top >= TOAST_HEIGHT_BUDGET_PX + VIEWPORT_INSET_PX + TARGET_GAP_PX
+      ? "above"
+      : "below";
+
+    return {
+      x,
+      y: placement === "above" ? rect.top - TARGET_GAP_PX : rect.bottom + TARGET_GAP_PX,
+      placement,
+    };
+  }
+
+  return undefined;
+}
+
+/**
+ * Presents an engine-owned rejection consistently for every direct action
+ * submitter. The engine controls both the text and related object ordering;
+ * this module only finds the first matching rendered anchor.
+ */
+export function reportStructuredActionRejection(
+  err: unknown,
+  title: string = genericActionFailureTitle(),
+): StructuredRejectionReport {
+  if (!(err instanceof AdapterError) || !err.rejection) return "not-structured";
+  if (err.rejection.disposition === "stale") return "stale";
+
+  const anchor = actionRejectionAnchor(err);
+  useAppNotificationStore.getState().showNotification({
+    title,
+    description: err.rejection.message,
+    ...(anchor ? { anchor } : {}),
+  });
+  return "reported";
+}

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -24,6 +24,7 @@ import { usePreferencesStore } from "../stores/preferencesStore";
 import { useUiStore } from "../stores/uiStore";
 import { pressureMultiplier, stackPressureFromLength, STACK_PRESSURE_ELEVATED } from "../utils/stackPressure";
 import { effectiveStackPressure, recordStackResolutions } from "../utils/stackThroughput";
+import { objectAnchorSelector } from "../utils/objectAnchorSelector";
 import { applySpellPaymentPreference } from "./castPaymentMode";
 
 /**
@@ -261,6 +262,7 @@ function isStaleAction(err: unknown): boolean {
 }
 
 function actionErrorMessage(err: unknown): string {
+  if (err instanceof AdapterError && err.rejection) return err.rejection.message;
   if (err instanceof Error && err.message) return err.message;
   if (typeof err === "string" && err.length > 0) return err;
   return i18n.t("actionError.unknownEngineError");
@@ -277,11 +279,29 @@ function shouldShowActionError(err: unknown): boolean {
   return !isStateLost(err) && !isEnginePanic(err) && !isEngineUnresponsive(err) && !isStaleAction(err);
 }
 
-function showActionError(action: GameAction, err: unknown): void {
+function actionErrorAnchor(err: unknown): { x: number; y: number } | undefined {
+  if (!(err instanceof AdapterError) || !err.rejection) return undefined;
+
+  for (const objectId of err.rejection.related_object_ids) {
+    const anchor = document.querySelector<HTMLElement>(objectAnchorSelector(objectId));
+    if (!anchor) continue;
+
+    const rect = anchor.getBoundingClientRect();
+    return { x: rect.left + rect.width / 2, y: rect.top - 12 };
+  }
+
+  return undefined;
+}
+
+function reportActionError(err: unknown, action?: GameAction): void {
   if (!shouldShowActionError(err)) return;
+  const anchor = actionErrorAnchor(err);
   useAppNotificationStore.getState().showNotification({
-    title: i18n.t("actionError.title", { action: actionLabel(action) }),
+    title: i18n.t("actionError.title", {
+      action: action ? actionLabel(action) : i18n.t("actionError.genericAction"),
+    }),
     description: actionErrorMessage(err),
+    ...(anchor ? { anchor } : {}),
   });
 }
 
@@ -623,7 +643,7 @@ async function processQueue(generation: number): Promise<void> {
       }
       debugLog(`processQueue error (${next.kind}): ${err instanceof Error ? err.message : String(err)}`);
       if (next.kind === "local") {
-        showActionError(next.action, err);
+        reportActionError(err, next.action);
       }
       next.reject(err);
       // If processAction escalated to Layer 3 (notifyEngineLost already
@@ -742,7 +762,7 @@ async function dispatchActionInternal(
   } catch (e) {
     if (!isDispatchContextCurrent(generation, session)) return;
     debugLog(`dispatch error for ${submittedAction.type}: ${e instanceof Error ? e.message : String(e)}`);
-    showActionError(submittedAction, e);
+    reportActionError(e, submittedAction);
     throw e;
   } finally {
     if (isCurrentDispatchGeneration(generation)) inFlightLocalAction = null;
@@ -787,12 +807,17 @@ export async function dispatchInteraction(
     );
   }
 
-  const result = await adapter.submitInteraction(submission, actor);
-  const snapshot = await adapter.getSnapshot();
-  useGameStore.getState().commitEngineSnapshot(snapshot, {
-    events: result.events,
-    logEntries: result.log_entries ?? [],
-  });
+  try {
+    const result = await adapter.submitInteraction(submission, actor);
+    const snapshot = await adapter.getSnapshot();
+    useGameStore.getState().commitEngineSnapshot(snapshot, {
+      events: result.events,
+      logEntries: result.log_entries ?? [],
+    });
+  } catch (err) {
+    reportActionError(err);
+    throw err;
+  }
 }
 
 /** Dispatch a standing preference only while its captured game lifecycle is
@@ -1066,7 +1091,7 @@ export async function dispatchResolveAll(
   } catch (err) {
     if (isStaleAction(err)) return;
     debugLog(`Resolve All error: ${err instanceof Error ? err.message : String(err)}`);
-    showActionError({ type: "PassPriority" }, err);
+    reportActionError(err, { type: "PassPriority" });
   } finally {
     batchResolveInProgress = false;
     setIsResolvingAll(false);

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -1,6 +1,7 @@
 import type { AiActionProposal, BatchResolveResult, EngineAdapter, EngineSnapshot, GameAction, GameEvent, GameLogEntry, GameState, RewindOption, WaitingFor } from "../adapter/types";
 import type { InteractionSubmission } from "../adapter/generated/interaction";
 import { actionRejectionError, AdapterError, AdapterErrorCode } from "../adapter/types";
+import { reportStructuredActionRejection } from "./actionRejectionReporter";
 import { attemptStateRehydrate, isEnginePanic, notifyEngineLost, routePanic } from "./engineRecovery";
 import { normalizeEvents } from "../animation/eventNormalizer";
 import { SPECTATOR_PLAYER_ID } from "../constants/game";
@@ -24,7 +25,6 @@ import { usePreferencesStore } from "../stores/preferencesStore";
 import { useUiStore } from "../stores/uiStore";
 import { pressureMultiplier, stackPressureFromLength, STACK_PRESSURE_ELEVATED } from "../utils/stackPressure";
 import { effectiveStackPressure, recordStackResolutions } from "../utils/stackThroughput";
-import { objectAnchorSelector } from "../utils/objectAnchorSelector";
 import { applySpellPaymentPreference } from "./castPaymentMode";
 
 /**
@@ -279,29 +279,15 @@ function shouldShowActionError(err: unknown): boolean {
   return !isStateLost(err) && !isEnginePanic(err) && !isEngineUnresponsive(err) && !isStaleAction(err);
 }
 
-function actionErrorAnchor(err: unknown): { x: number; y: number } | undefined {
-  if (!(err instanceof AdapterError) || !err.rejection) return undefined;
-
-  for (const objectId of err.rejection.related_object_ids) {
-    const anchor = document.querySelector<HTMLElement>(objectAnchorSelector(objectId));
-    if (!anchor) continue;
-
-    const rect = anchor.getBoundingClientRect();
-    return { x: rect.left + rect.width / 2, y: rect.top - 12 };
-  }
-
-  return undefined;
-}
-
 function reportActionError(err: unknown, action?: GameAction): void {
   if (!shouldShowActionError(err)) return;
-  const anchor = actionErrorAnchor(err);
+  const title = i18n.t("actionError.title", {
+    action: action ? actionLabel(action) : i18n.t("actionError.genericAction"),
+  });
+  if (reportStructuredActionRejection(err, title) !== "not-structured") return;
   useAppNotificationStore.getState().showNotification({
-    title: i18n.t("actionError.title", {
-      action: action ? actionLabel(action) : i18n.t("actionError.genericAction"),
-    }),
+    title,
     description: actionErrorMessage(err),
-    ...(anchor ? { anchor } : {}),
   });
 }
 

--- a/client/src/game/dispatch.ts
+++ b/client/src/game/dispatch.ts
@@ -1,6 +1,6 @@
 import type { AiActionProposal, BatchResolveResult, EngineAdapter, EngineSnapshot, GameAction, GameEvent, GameLogEntry, GameState, RewindOption, WaitingFor } from "../adapter/types";
 import type { InteractionSubmission } from "../adapter/generated/interaction";
-import { AdapterError, AdapterErrorCode } from "../adapter/types";
+import { actionRejectionError, AdapterError, AdapterErrorCode } from "../adapter/types";
 import { attemptStateRehydrate, isEnginePanic, notifyEngineLost, routePanic } from "./engineRecovery";
 import { normalizeEvents } from "../animation/eventNormalizer";
 import { SPECTATOR_PLAYER_ID } from "../constants/game";
@@ -333,7 +333,7 @@ async function processAction(
     }
     const outcome = await adapter.submitAiActionProposal(proposal);
     if (outcome.status === "stale") return null;
-    if (outcome.status === "rejected") throw new Error(`AI proposal rejected: ${outcome.reason}`);
+    if (outcome.status === "rejected") throw actionRejectionError(outcome.rejection);
     return outcome.result;
   };
   let result;

--- a/client/src/i18n/locales/de/multiplayer.json
+++ b/client/src/i18n/locales/de/multiplayer.json
@@ -81,6 +81,12 @@
   "joinErrorDialog": {
     "dismiss": "Schließen"
   },
+  "reconnectRejected": {
+    "firstMessageInvalid": "Der Host hat die Verbindung vor der Einrichtung abgelehnt. Aktualisiere beide Fenster und versuche es erneut.",
+    "versionRequired": "Dieser Host benötigt das Übertragungsprotokoll v{{version}}. Aktualisiere beide Fenster und versuche es erneut.",
+    "versionMismatch": "Übertragungsprotokoll stimmt nicht überein: Dein Client hat v{{guestVersion}} gesendet, der Host verwendet jedoch v{{hostVersion}}. Aktualisiere beide Fenster.",
+    "malformedAuthority": "Der Host hat eine ungültige Verbindungsberechtigung abgelehnt. Tritt mit einem neuen Raumcode erneut bei."
+  },
   "serverOfflinePrompt": {
     "title": "Matchmaking nicht erreichbar",
     "message": "Wir konnten den Spielserver nicht erreichen, daher ist die öffentliche Lobby derzeit nicht verfügbar. Du kannst trotzdem spielen, indem du einen direkten Code mit einem Freund teilst.",

--- a/client/src/i18n/locales/en/multiplayer.json
+++ b/client/src/i18n/locales/en/multiplayer.json
@@ -81,6 +81,12 @@
   "joinErrorDialog": {
     "dismiss": "Dismiss"
   },
+  "reconnectRejected": {
+    "firstMessageInvalid": "The host rejected the connection before setup. Refresh both windows and try again.",
+    "versionRequired": "This host requires wire protocol v{{version}}. Refresh both windows and try again.",
+    "versionMismatch": "Wire protocol mismatch: your client sent v{{guestVersion}}, but the host uses v{{hostVersion}}. Refresh both windows.",
+    "malformedAuthority": "The host rejected invalid connection authority. Rejoin using a new room code."
+  },
   "serverOfflinePrompt": {
     "title": "Matchmaking unreachable",
     "message": "We couldn't reach the game server, so the public lobby is unavailable right now. You can still play by sharing a direct code with a friend.",

--- a/client/src/i18n/locales/es/multiplayer.json
+++ b/client/src/i18n/locales/es/multiplayer.json
@@ -81,6 +81,12 @@
   "joinErrorDialog": {
     "dismiss": "Descartar"
   },
+  "reconnectRejected": {
+    "firstMessageInvalid": "El host rechazó la conexión antes de la configuración. Actualiza ambas ventanas e inténtalo de nuevo.",
+    "versionRequired": "Este host requiere el protocolo de conexión v{{version}}. Actualiza ambas ventanas e inténtalo de nuevo.",
+    "versionMismatch": "El protocolo de conexión no coincide: tu cliente envió v{{guestVersion}}, pero el host usa v{{hostVersion}}. Actualiza ambas ventanas.",
+    "malformedAuthority": "El host rechazó una autorización de conexión no válida. Vuelve a unirte con un código de sala nuevo."
+  },
   "serverOfflinePrompt": {
     "title": "Emparejamiento inaccesible",
     "message": "No pudimos conectar con el servidor de la partida, así que la sala de espera pública no está disponible ahora mismo. Aún puedes jugar compartiendo un código directo con un amigo.",

--- a/client/src/i18n/locales/fr/multiplayer.json
+++ b/client/src/i18n/locales/fr/multiplayer.json
@@ -81,6 +81,12 @@
   "joinErrorDialog": {
     "dismiss": "Ignorer"
   },
+  "reconnectRejected": {
+    "firstMessageInvalid": "L’hôte a refusé la connexion avant la configuration. Actualisez les deux fenêtres puis réessayez.",
+    "versionRequired": "Cet hôte nécessite le protocole de connexion v{{version}}. Actualisez les deux fenêtres puis réessayez.",
+    "versionMismatch": "Les protocoles de connexion ne correspondent pas : votre client a envoyé v{{guestVersion}}, mais l’hôte utilise v{{hostVersion}}. Actualisez les deux fenêtres.",
+    "malformedAuthority": "L’hôte a refusé une autorisation de connexion non valide. Rejoignez avec un nouveau code de salon."
+  },
   "serverOfflinePrompt": {
     "title": "Matchmaking injoignable",
     "message": "Nous n'avons pas pu joindre le serveur de jeu, donc le salon public est indisponible pour le moment. Vous pouvez toujours jouer en partageant un code direct avec un ami.",

--- a/client/src/i18n/locales/it/multiplayer.json
+++ b/client/src/i18n/locales/it/multiplayer.json
@@ -81,6 +81,12 @@
   "joinErrorDialog": {
     "dismiss": "Ignora"
   },
+  "reconnectRejected": {
+    "firstMessageInvalid": "L'host ha rifiutato la connessione prima della configurazione. Aggiorna entrambe le finestre e riprova.",
+    "versionRequired": "Questo host richiede il protocollo di connessione v{{version}}. Aggiorna entrambe le finestre e riprova.",
+    "versionMismatch": "Il protocollo di connessione non corrisponde: il tuo client ha inviato v{{guestVersion}}, ma l'host usa v{{hostVersion}}. Aggiorna entrambe le finestre.",
+    "malformedAuthority": "L'host ha rifiutato un'autorizzazione di connessione non valida. Rientra con un nuovo codice stanza."
+  },
   "serverOfflinePrompt": {
     "title": "Matchmaking irraggiungibile",
     "message": "Non siamo riusciti a raggiungere il server di gioco, quindi la lobby pubblica non è disponibile al momento. Puoi comunque giocare condividendo un codice diretto con un amico.",

--- a/client/src/i18n/locales/pl/multiplayer.json
+++ b/client/src/i18n/locales/pl/multiplayer.json
@@ -81,6 +81,12 @@
   "joinErrorDialog": {
     "dismiss": "Zamknij"
   },
+  "reconnectRejected": {
+    "firstMessageInvalid": "Host odrzucił połączenie przed konfiguracją. Odśwież oba okna i spróbuj ponownie.",
+    "versionRequired": "Ten host wymaga protokołu połączenia v{{version}}. Odśwież oba okna i spróbuj ponownie.",
+    "versionMismatch": "Niezgodność protokołu połączenia: klient wysłał v{{guestVersion}}, ale host używa v{{hostVersion}}. Odśwież oba okna.",
+    "malformedAuthority": "Host odrzucił nieprawidłowe uprawnienia połączenia. Dołącz ponownie, używając nowego kodu pokoju."
+  },
   "serverOfflinePrompt": {
     "title": "Dobieranie graczy nieosiągalne",
     "message": "Nie udało się połączyć z serwerem gry, więc publiczna poczekalnia jest teraz niedostępna. Nadal możesz grać, udostępniając bezpośredni kod znajomemu.",

--- a/client/src/i18n/locales/pt/multiplayer.json
+++ b/client/src/i18n/locales/pt/multiplayer.json
@@ -81,6 +81,12 @@
   "joinErrorDialog": {
     "dismiss": "Dispensar"
   },
+  "reconnectRejected": {
+    "firstMessageInvalid": "O anfitrião recusou a ligação antes da configuração. Atualize ambas as janelas e tente novamente.",
+    "versionRequired": "Este anfitrião requer o protocolo de ligação v{{version}}. Atualize ambas as janelas e tente novamente.",
+    "versionMismatch": "O protocolo de ligação não corresponde: o seu cliente enviou v{{guestVersion}}, mas o anfitrião usa v{{hostVersion}}. Atualize ambas as janelas.",
+    "malformedAuthority": "O anfitrião recusou uma autorização de ligação inválida. Entre novamente com um novo código de sala."
+  },
   "serverOfflinePrompt": {
     "title": "Matchmaking inacessível",
     "message": "Não conseguimos alcançar o servidor do jogo, então o lobby público está indisponível no momento. Você ainda pode jogar compartilhando um código direto com um amigo.",

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -36,8 +36,8 @@ const viewerInteractionWithProducedMana = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v30", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(30);
+  it("pins the P2P wire protocol to v31", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(31);
   });
 
   it("defaults shortcut actions for a legacy payload created before the additive field", () => {
@@ -87,12 +87,31 @@ describe("encodeWireMessage / decodeWireMessage", () => {
     { type: "game_resumed" },
     { type: "lobby_progress", joined: 1, total: 3 },
     { type: "emote", emote: "🔥" },
-    { type: "reconnect", playerToken: "token-123" },
+    { type: "reconnect", playerToken: "token-123", wireProtocolVersion: WIRE_PROTOCOL_VERSION },
     { type: "reconnect_rejected", reason: "Unknown token" },
-    { type: "action_rejected", reason: "Player kicked" },
+    {
+      type: "action_rejected",
+      rejection: {
+        code: "action_not_allowed",
+        disposition: "unavailable",
+        message: "Player kicked",
+        related_object_ids: [],
+      },
+    },
+    { type: "action_failed", message: "Host failed to submit action" },
     { type: "action_noop" },
     { type: "mana_payment_preview", requestId: 4, sourceIds: [12] },
-    { type: "mana_payment_preview_rejected", requestId: 4, reason: "Not your turn" },
+    {
+      type: "mana_payment_preview_rejected",
+      requestId: 4,
+      rejection: {
+        code: "not_your_priority",
+        disposition: "unavailable",
+        message: "Not your turn",
+        related_object_ids: [],
+      },
+    },
+    { type: "mana_payment_preview_failed", requestId: 4, message: "Preview unavailable" },
     {
       type: "action",
       senderPlayerId: 0,

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -237,7 +237,13 @@ export type P2PMessage = P2PAuthorityWire & (
       state: GameState;
       playerNames?: Record<number, string>;
     } & LegalActionsWire)
-  | { type: "reconnect_rejected"; reason: string }
+  | {
+      type: "reconnect_rejected";
+      reason: string;
+      reasonCode?: "first_message_invalid" | "wire_protocol_version_required" | "wire_protocol_mismatch" | "malformed_authority";
+      hostWireProtocolVersion?: number;
+      guestWireProtocolVersion?: number;
+    }
   // Kick / forced removal (host → target).
   | { type: "kick"; reason: string; format?: string }
   // Host explicitly quit the game (host → all guests). Terminal: guests set

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -8,6 +8,7 @@ import type {
   ManaCost,
   ObjectId,
   ObjectAction,
+  ActionRejection,
 } from "../adapter/types";
 import type { InteractionSubmission, ViewerInteraction } from "../adapter/generated/interaction";
 import type { SeatMutation, SeatView } from "../multiplayer/seatTypes";
@@ -88,12 +89,15 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  * connecting screen with no layer able to tell the user. Only the adapter
  * holds the state needed to perform the response.
  *
- * The guest → host direction has its own single site: guests stamp this version
- * on `guest_deck` / `reconnect`, and `P2PHostAdapter`'s first-contact gate
- * refuses a stamped mismatch. That field is optional and an absent one is
- * admitted; see the gate for why.
+ * The guest → host direction has its own single site: current guests must stamp
+ * this version on `guest_deck` / `reconnect`, and `P2PHostAdapter`'s
+ * first-contact gate rejects a missing or unequal value before it allocates a
+ * seat or adopts reconnect state.
  *
  * Bumps to date:
+ *  31 — Action and mana-payment-preview rejections carry engine-owned,
+ *       viewer-filtered ActionRejection DTOs. First-contact versioning keeps
+ *       legacy peers from treating a typed rejection as a transport string.
  *  30 — ManaRestriction.CannotCastSpellFromZone adds a serialized
  *       GameState/ManaUnit restriction used by Karolina Dean. Older peers
  *       cannot deserialize that externally tagged enum variant.
@@ -175,15 +179,16 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *       sub-phase on WaitingFor::MulliganDecision; the MulliganBottomCards
  *       variant was removed
  */
-export const WIRE_PROTOCOL_VERSION = 30 as const;
+export const WIRE_PROTOCOL_VERSION = 31 as const;
 
 export type P2PMessage = P2PAuthorityWire & (
-  // `wireProtocolVersion` is optional on both first-contact guest messages:
-  // guests on an older bundle cannot stamp it, and the host admits those.
-  // Typed `number` rather than `typeof WIRE_PROTOCOL_VERSION` on purpose —
-  // the literal type would narrow the host's "present and unequal" branch
-  // to `never`.
-  | { type: "guest_deck"; deckData: unknown; displayName?: string; reservationToken?: string; wireProtocolVersion?: number }
+  | {
+      type: "guest_deck";
+      deckData: unknown;
+      displayName?: string;
+      reservationToken?: string;
+      wireProtocolVersion: typeof WIRE_PROTOCOL_VERSION;
+    }
   | ({
       type: "game_setup";
       wireProtocolVersion: typeof WIRE_PROTOCOL_VERSION;
@@ -204,10 +209,12 @@ export type P2PMessage = P2PAuthorityWire & (
       events: GameEvent[];
       logEntries?: GameLogEntry[];
     } & LegalActionsWire)
-  | { type: "action_rejected"; reason: string }
+  | { type: "action_rejected"; rejection: ActionRejection }
+  | { type: "action_failed"; message: string }
   | { type: "action_noop" }
   | { type: "mana_payment_preview"; requestId: number; sourceIds: ObjectId[] }
-  | { type: "mana_payment_preview_rejected"; requestId: number; reason: string }
+  | { type: "mana_payment_preview_rejected"; requestId: number; rejection: ActionRejection }
+  | { type: "mana_payment_preview_failed"; requestId: number; message: string }
   | { type: "ping"; timestamp: number }
   | { type: "pong"; timestamp: number }
   | { type: "disconnect"; reason: string }
@@ -216,7 +223,12 @@ export type P2PMessage = P2PAuthorityWire & (
   /** Protected by a draft-installed match capability on the host. */
   | { type: "match_concede" }
   // Reconnect: guest presents prior token; host accepts (with fresh state) or rejects.
-  | { type: "reconnect"; playerToken: string; sessionKey?: P2PSessionKey; wireProtocolVersion?: number }
+  | {
+      type: "reconnect";
+      playerToken: string;
+      sessionKey?: P2PSessionKey;
+      wireProtocolVersion: typeof WIRE_PROTOCOL_VERSION;
+    }
   | ({
       type: "reconnect_ack";
       wireProtocolVersion: typeof WIRE_PROTOCOL_VERSION;
@@ -270,9 +282,11 @@ const VALID_TYPES = new Set([
   "preview_mana_payment",
   "state_update",
   "action_rejected",
+  "action_failed",
   "action_noop",
   "mana_payment_preview",
   "mana_payment_preview_rejected",
+  "mana_payment_preview_failed",
   "ping",
   "pong",
   "disconnect",

--- a/client/src/services/__tests__/p2pSession.test.ts
+++ b/client/src/services/__tests__/p2pSession.test.ts
@@ -2,6 +2,8 @@ import { afterEach, beforeEach, describe, expect, it } from "vitest";
 
 import {
   claimP2PHostLease,
+  hasExactP2PAuthority,
+  isP2PAuthorityStamp,
   ownsP2PHostLease,
   releaseP2PHostLease,
 } from "../p2pSession";
@@ -34,6 +36,22 @@ afterEach(() => {
 });
 
 describe("P2P host leases", () => {
+  it("requires both stable-session and incarnation values to match", () => {
+    const authority = { sessionKey: "session", hostIncarnation: "current" };
+
+    expect(hasExactP2PAuthority(authority, authority)).toBe(true);
+    expect(hasExactP2PAuthority({ ...authority, hostIncarnation: "stale" }, authority)).toBe(false);
+    expect(hasExactP2PAuthority({ ...authority, sessionKey: "other" }, authority)).toBe(false);
+    expect(hasExactP2PAuthority(undefined, authority)).toBe(false);
+  });
+
+  it("accepts only the exact authority object shape", () => {
+    expect(isP2PAuthorityStamp({ sessionKey: "session", hostIncarnation: "current" })).toBe(true);
+    expect(isP2PAuthorityStamp({ sessionKey: "session", hostIncarnation: "current", extra: true })).toBe(false);
+    expect(isP2PAuthorityStamp({ sessionKey: "session", hostIncarnation: 1 })).toBe(false);
+    expect(isP2PAuthorityStamp(null)).toBe(false);
+  });
+
   it("fences a stale host and does not revive it when the current host cleans up", () => {
     const stale = claimP2PHostLease("shared-session-key");
     const current = claimP2PHostLease("shared-session-key");

--- a/client/src/services/intergameCommandLedger.ts
+++ b/client/src/services/intergameCommandLedger.ts
@@ -13,7 +13,8 @@ export type DraftIntergameCommandStatus =
   | "Pending"
   | "Authorized"
   | "Executing"
-  | "Receipted";
+  | "Receipted"
+  | "Rejected";
 
 export interface DraftIntergameCommand {
   commandId: string;
@@ -28,6 +29,7 @@ export interface DraftIntergameCommand {
   payloadDigest: string;
   status: DraftIntergameCommandStatus;
   receiptId?: string;
+  rejectionMessage?: string;
 }
 
 /** The immutable acknowledgement predicate echoed by the executor. */
@@ -135,6 +137,16 @@ export class IntergameCommandController {
     const receipted = { ...command, status: "Receipted" as const, receiptId };
     this.commands.set(commandId, receipted);
     return receipted;
+  }
+
+  reject(commandId: string, acknowledgement: DraftIntergameCommandAck, rejectionMessage: string): DraftIntergameCommand | null {
+    const command = this.commands.get(commandId);
+    if (!command || command.status !== "Executing" || !matchesCommandAcknowledgement(command, acknowledgement)) {
+      return null;
+    }
+    const rejected = { ...command, status: "Rejected" as const, rejectionMessage };
+    this.commands.set(commandId, rejected);
+    return rejected;
   }
 
   /** A recovered Executing command stays non-replayable until the receipt arrives. */

--- a/client/src/services/p2pSession.ts
+++ b/client/src/services/p2pSession.ts
@@ -52,6 +52,32 @@ export interface P2PAuthorityStamp {
   hostIncarnation: string;
 }
 
+/** Validates the exact persisted/wire authority envelope. */
+export function isP2PAuthorityStamp(value: unknown): value is P2PAuthorityStamp {
+  if (value == null || typeof value !== "object" || Array.isArray(value)) return false;
+  const authority = value as Record<string, unknown>;
+  const keys = Object.keys(authority);
+  return keys.length === 2
+    && keys.includes("sessionKey")
+    && keys.includes("hostIncarnation")
+    && typeof authority.sessionKey === "string"
+    && typeof authority.hostIncarnation === "string";
+}
+
+/**
+ * Checks the full fencing token, not just the stable session key. A guest may
+ * reconnect to a resumed host under the same session key, but every normal
+ * post-handshake frame must come from the exact host incarnation it adopted.
+ */
+export function hasExactP2PAuthority(
+  candidate: P2PAuthorityStamp | undefined,
+  authority: P2PAuthorityStamp,
+): boolean {
+  return isP2PAuthorityStamp(candidate)
+    && candidate.sessionKey === authority.sessionKey
+    && candidate.hostIncarnation === authority.hostIncarnation;
+}
+
 export function createP2PSessionKey(): P2PSessionKey {
   return crypto.randomUUID();
 }
@@ -146,7 +172,7 @@ export async function loadP2PSession(hostPeerId: string): Promise<P2PSessionData
   try {
     const session = await get<P2PSessionData>(storageKey(hostPeerId), getSessionStore());
     if (!session) return null;
-    if (!isFresh(session) || !session.authority?.sessionKey || !session.authority.hostIncarnation) {
+    if (!isFresh(session) || !isP2PAuthorityStamp(session.authority)) {
       await clearP2PSession(hostPeerId);
       return null;
     }

--- a/client/src/stores/__tests__/gameStore.test.ts
+++ b/client/src/stores/__tests__/gameStore.test.ts
@@ -1,7 +1,9 @@
 import { act } from "react";
 import { beforeEach, describe, expect, it, vi } from "vitest";
 
-import type { EngineAdapter, GameEvent, GameState } from "../../adapter/types";
+import type { ActionRejection, EngineAdapter, GameEvent, GameState } from "../../adapter/types";
+import { actionRejectionError } from "../../adapter/types";
+import { useAppNotificationStore } from "../../stores/appToastStore";
 import { buildEngineAdapterMock } from "../../test/factories/engineAdapterFactory";
 import {
   buildGameState,
@@ -68,6 +70,7 @@ describe("gameStore", () => {
         waitingFor: null,
         stateHistory: [],
       });
+      useAppNotificationStore.setState({ notification: null, expiresAt: 0 });
     });
   });
 
@@ -126,6 +129,55 @@ describe("gameStore", () => {
     expect(store.gameState).toEqual(state2);
     expect(store.events).toEqual(events);
     expect(adapter.submitAction).toHaveBeenCalledWith({ type: "PassPriority" }, 0);
+  });
+
+  it("surfaces a direct structured rejection at the first rendered related object", async () => {
+    const state = buildGameState();
+    const adapter = buildEngineAdapterMock(state);
+    await act(() => useGameStore.getState().initGame("test-id", adapter));
+    const first = document.createElement("div");
+    first.dataset.objectId = "200";
+    first.getBoundingClientRect = () => ({
+      x: -20, y: 10, top: 10, right: 20, bottom: 50, left: -20, width: 40, height: 40,
+      toJSON: () => ({}),
+    });
+    const second = document.createElement("div");
+    second.dataset.objectId = "201";
+    document.body.append(first, second);
+    const rejection: ActionRejection = {
+      code: "invalid_action",
+      disposition: "invalid",
+      message: "Engine error: ObjectId(200) must be blocked by 2 or more creatures",
+      related_object_ids: [200, 201],
+    };
+    adapter.submitAction.mockRejectedValue(actionRejectionError(rejection));
+
+    await expect(useGameStore.getState().dispatch({ type: "PassPriority" })).rejects.toMatchObject({
+      rejection,
+    });
+
+    expect(useAppNotificationStore.getState().notification).toEqual({
+      title: "Action failed",
+      description: rejection.message,
+      anchor: { x: 192, y: 62, placement: "below" },
+    });
+    first.remove();
+    second.remove();
+  });
+
+  it("silently drops a stale structured rejection from the direct dispatcher", async () => {
+    const state = buildGameState();
+    const adapter = buildEngineAdapterMock(state);
+    await act(() => useGameStore.getState().initGame("test-id", adapter));
+    adapter.submitAction.mockRejectedValue(actionRejectionError({
+      code: "stale_action",
+      disposition: "stale",
+      message: "This action is no longer current",
+      related_object_ids: [200],
+    }));
+
+    await expect(useGameStore.getState().dispatch({ type: "PassPriority" })).resolves.toEqual([]);
+    expect(useAppNotificationStore.getState().notification).toBeNull();
   });
 
   it("dispatch pushes to stateHistory for undoable actions", async () => {

--- a/client/src/stores/__tests__/multiplayerDraftStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerDraftStore.test.ts
@@ -14,7 +14,15 @@ import {
 } from "../multiplayerDraftStore";
 import { DraftPodHostAdapter } from "../../adapter/draftPodHostAdapter";
 import type { DraftPlayerView } from "../../adapter/draft-adapter";
+import type { ActionRejection, EngineAdapter } from "../../adapter/types";
+import { actionRejectionError } from "../../adapter/types";
 import { DraftPauseReason, type DraftMatchLaunch } from "../../network/draftProtocol";
+import {
+  commandAcknowledgement,
+  draftIntergameDigest,
+  type DraftIntergameCommand,
+} from "../../services/intergameCommandLedger";
+import { useAppNotificationStore } from "../../stores/appToastStore";
 
 // ── Mocks ──────────────────────────────────────────────────────────────
 
@@ -121,6 +129,7 @@ describe("multiplayerDraftStore", () => {
     capturedHostEventHandler = null;
     capturedGuestEventHandler = null;
     useMultiplayerDraftStore.getState().reset();
+    useAppNotificationStore.setState({ notification: null, expiresAt: 0 });
   });
 
   afterEach(async () => {
@@ -838,6 +847,99 @@ describe("multiplayerDraftStore", () => {
 
       useMultiplayerDraftStore.getState().setLandCount("Plains", -2);
       expect(useMultiplayerDraftStore.getState().landCounts).toEqual({ Plains: 0 });
+    });
+  });
+
+  describe("authorized intergame actions", () => {
+    it("reports structured rejections without leaking either sideboard or play-draw submission", async () => {
+      const launch: DraftMatchLaunch = {
+        type: "HumanHost",
+        matchId: "action-rejection-match",
+        matchRoomCode: "MATCH",
+        round: 1,
+        localSeat: 0,
+        opponentSeat: 1,
+        opponentName: "Alice",
+        matchHostPeerId: "peer-0",
+        deckPayload: {
+          player: { main_deck: [], sideboard: [], commander: [] },
+          opponent: { main_deck: [], sideboard: [], commander: [] },
+          ai_decks: [],
+        },
+        matchConfig: { match_type: "Bo3" },
+        binding: {
+          podId: "pod-1", matchId: "action-rejection-match", round: 1,
+          sessionKey: "session", lease: "lease", nonce: "nonce",
+          revision: 1, matchAuthoritySeat: 0,
+        },
+      };
+      const rejection: ActionRejection = {
+        code: "invalid_action",
+        disposition: "invalid",
+        message: "Engine error: ObjectId(199) cannot change deck partitions",
+        related_object_ids: [199],
+      };
+      const adapter = {
+        submitAction: vi.fn()
+          .mockRejectedValueOnce(actionRejectionError(rejection))
+          .mockRejectedValueOnce(actionRejectionError({
+            code: "stale_action",
+            disposition: "stale",
+            message: "This action is no longer current",
+            related_object_ids: [199],
+          })),
+      } as unknown as EngineAdapter;
+      useMultiplayerDraftStore.setState({
+        role: "host",
+        seatIndex: 0,
+        matchPairing: launch,
+        matchAdapter: adapter,
+      });
+      const command = (
+        commandId: string,
+        payload: DraftIntergameCommand["payload"],
+      ): DraftIntergameCommand => ({
+        commandId,
+        matchId: launch.matchId,
+        gameNumber: 2,
+        seat: 0,
+        payload,
+        launchPayload: launch,
+        launchDigest: draftIntergameDigest(launch),
+        payloadDigest: draftIntergameDigest(payload),
+        status: "Authorized",
+      });
+      const sideboard = command("sideboard-rejection", {
+        type: "SubmitSideboard", main: [], sideboard: [],
+      });
+
+      await expect(useMultiplayerDraftStore.getState().submitAuthorized(
+        sideboard,
+        commandAcknowledgement(sideboard),
+      )).resolves.toBeUndefined();
+
+      expect(adapter.submitAction).toHaveBeenCalledWith({
+        type: "SubmitSideboard",
+        data: { main: [], sideboard: [] },
+      }, 0);
+      expect(useAppNotificationStore.getState().notification).toEqual({
+        title: "Action failed",
+        description: rejection.message,
+      });
+
+      useAppNotificationStore.setState({ notification: null, expiresAt: 0 });
+      const playDraw = command("play-draw-stale", { type: "ChoosePlayDraw", playFirst: true });
+
+      await expect(useMultiplayerDraftStore.getState().submitAuthorized(
+        playDraw,
+        commandAcknowledgement(playDraw),
+      )).resolves.toBeUndefined();
+
+      expect(adapter.submitAction).toHaveBeenLastCalledWith({
+        type: "ChoosePlayDraw",
+        data: { play_first: true },
+      }, 0);
+      expect(useAppNotificationStore.getState().notification).toBeNull();
     });
   });
 

--- a/client/src/stores/appToastStore.ts
+++ b/client/src/stores/appToastStore.ts
@@ -2,11 +2,17 @@ import { create } from "zustand";
 
 const NOTIFICATION_DURATION_MS = 5000;
 
+export interface AppNotificationAnchor {
+  x: number;
+  y: number;
+  placement: "above" | "below";
+}
+
 export interface AppNotification {
   title: string;
   description: string;
   /** Viewport point for a notification attached to a rendered game object. */
-  anchor?: { x: number; y: number };
+  anchor?: AppNotificationAnchor;
 }
 
 interface AppNotificationState {

--- a/client/src/stores/appToastStore.ts
+++ b/client/src/stores/appToastStore.ts
@@ -5,6 +5,8 @@ const NOTIFICATION_DURATION_MS = 5000;
 export interface AppNotification {
   title: string;
   description: string;
+  /** Viewport point for a notification attached to a rendered game object. */
+  anchor?: { x: number; y: number };
 }
 
 interface AppNotificationState {

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -666,7 +666,12 @@ export const useGameStore = create<GameStore>()(
       try {
         result = await adapter.submitAction(submittedAction, getPlayerId());
       } catch (err) {
-        if (reportStructuredActionRejection(err) === "stale") return [];
+        if (reportStructuredActionRejection(err) === "stale") {
+          const snapshot = await adapter.getSnapshot();
+          get().commitEngineSnapshot(snapshot, { events: [], logEntries: [] });
+          if (gameId) void saveAuthoritativeGame(gameId, adapter, snapshot.state);
+          return [];
+        }
         throw err;
       }
       // ONE atomic pair — a separate getState()/getLegalActions() pair could

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -22,6 +22,7 @@ import type {
 import type { ViewerInteraction } from "../adapter/generated/interaction";
 import { MAX_UNDO_HISTORY, UNDOABLE_ACTIONS } from "../constants/game";
 import { applySpellPaymentPreference } from "../game/castPaymentMode";
+import { reportStructuredActionRejection } from "../game/actionRejectionReporter";
 import { getPlayerId } from "../hooks/usePlayerId";
 import { loadCheckpoints, saveAuthoritativeGame } from "../services/gamePersistence";
 import { resetStackThroughput } from "../utils/stackThroughput";
@@ -661,7 +662,13 @@ export const useGameStore = create<GameStore>()(
       // `getPlayerId()` returns the local human's authenticated seat ID.
       // The engine rejects the action if this doesn't match the authorized
       // submitter — never trust the UI to route actions to the right seat.
-      const result = await adapter.submitAction(submittedAction, getPlayerId());
+      let result: Awaited<ReturnType<EngineAdapter["submitAction"]>>;
+      try {
+        result = await adapter.submitAction(submittedAction, getPlayerId());
+      } catch (err) {
+        if (reportStructuredActionRejection(err) === "stale") return [];
+        throw err;
+      }
       // ONE atomic pair — a separate getState()/getLegalActions() pair could
       // straddle an engine advance and commit a mismatched state/actions pair.
       const snapshot = await adapter.getSnapshot();

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -1389,7 +1389,13 @@ export const useMultiplayerDraftStore = create<
     try {
       await adapter.submitAction(intergameAction(command.payload), actor);
     } catch (err) {
-      if (reportStructuredActionRejection(err) !== "not-structured") return;
+      if (reportStructuredActionRejection(err) !== "not-structured") {
+        const message = err instanceof Error ? err.message : String(err);
+        controller.reject(command.commandId, acknowledgement, message);
+        await saveDraftIntergameCommands(command.matchId, controller.snapshot());
+        if (command.payload.type === "SubmitSideboard") set({ sideboardSubmitted: false });
+        return;
+      }
       throw err;
     }
     const receipted = controller.receipt(command.commandId, acknowledgement, crypto.randomUUID());

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -26,6 +26,7 @@ import type { DraftMatchLaunch, DraftMatchSettlement, DraftPauseReason } from ".
 import type { AISeatBinding } from "../game/controllers/aiController";
 import { createGameLoopController, type GameLoopController } from "../game/controllers/gameLoopController";
 import { processRemoteUpdate } from "../game/dispatch";
+import { reportStructuredActionRejection } from "../game/actionRejectionReporter";
 import { useGameStore } from "./gameStore";
 import {
   DraftPodHostAdapter,
@@ -1385,7 +1386,12 @@ export const useMultiplayerDraftStore = create<
     if (!adapter) return;
     // Re-check immediately before crossing the host, guest, native, or WASM sink.
     const actor = launch.type === "HumanGuest" ? 1 : 0;
-    await adapter.submitAction(intergameAction(command.payload), actor);
+    try {
+      await adapter.submitAction(intergameAction(command.payload), actor);
+    } catch (err) {
+      if (reportStructuredActionRejection(err) !== "not-structured") return;
+      throw err;
+    }
     const receipted = controller.receipt(command.commandId, acknowledgement, crypto.randomUUID());
     if (!receipted) return;
     await saveDraftIntergameCommands(command.matchId, controller.snapshot());

--- a/client/src/wasm/engine_wasm.d.ts
+++ b/client/src/wasm/engine_wasm.d.ts
@@ -362,8 +362,9 @@ export function ping(): string;
  * `filter_state_for_viewer` snapshots (so any identity the viewer can't see is
  * already redacted), AND a transition is surfaced only when at least one
  * endpoint is a public zone (see `engine::game::preview`), so a fully-hidden
- * hand↔library draw is elided even for the acting player's opponents. Returns
- * an error string when `action` is malformed or illegal in the current state.
+ * hand↔library draw is elided even for the acting player's opponents. Expected
+ * engine rejections, including malformed action payloads, return a tagged
+ * `{ status: "rejected", rejection }` outcome; runtime faults remain raw.
  */
 export function preview_action_js(actor: number, action: any): any;
 
@@ -372,6 +373,8 @@ export function preview_action_js(actor: number, action: any): any;
  * exact, currently legal `CastSpell` action and returns the permanent ids that
  * produced mana before that spell was committed to the stack. It returns an
  * empty array when the cast needs another choice before payment can be final.
+ * Expected engine rejections return a tagged `{ status: "rejected",
+ * rejection }` outcome.
  */
 export function preview_mana_payment_js(actor: number, action: any): any;
 
@@ -405,6 +408,23 @@ export function replay_length_js(): number;
  */
 export function replay_seek_js(target: number): any;
 
+/**
+ * Batch-resolve the stack by auto-passing priority for the requesting player
+ * and delegating to the AI for opponent decisions. Runs entirely inside WASM
+ * with no JS round-trips between resolutions — collapses the O(N) priority
+ * pass cycle into a single call.
+ *
+ * `requester` is the human player seat (whose "Resolve All" click initiated
+ * this). `ai_seats_json` is a JSON array of `{ playerId, difficulty }` for
+ * each AI opponent.
+ *
+ * Returns a compact `BatchResolveResult` with the final `WaitingFor` and a
+ * count of items resolved. The Resolve All UI does not animate individual
+ * events, so the WASM boundary intentionally returns empty event/log arrays
+ * instead of serializing thousands of records for pathological stacks.
+ * Expected engine rejections return a tagged `{ status: "rejected",
+ * rejection }` outcome.
+ */
 export function resolve_all(requester: number, ai_seats_json: string, max_resolutions: number): any;
 
 /**
@@ -502,7 +522,8 @@ export function signatureSpellSelectionPolicy(request: any): any;
  * It must *never* come from UI or wire payload data. The engine rejects any
  * action whose `actor` does not match `authorized_submitter(state)`, so
  * passing a spoofed value here will fail cleanly rather than silently
- * applying the action as another player.
+ * applying the action as another player. Expected engine rejections return a
+ * tagged `{ status: "rejected", rejection }` outcome.
  */
 export function submit_action(actor: number, action: any): any;
 
@@ -518,7 +539,8 @@ export function submit_ai_action_proposal(token: string, actor: number, action: 
 /**
  * Submit one opaque, engine-authored interaction response. The browser never
  * materializes a `GameAction`; only a successful engine reducer result exposes
- * the exact action to the replay recorder.
+ * the exact action to the replay recorder. Expected engine rejections return a
+ * tagged `{ status: "rejected", rejection }` outcome.
  */
 export function submit_interaction_js(actor: number, submission: any): any;
 

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -14,11 +14,13 @@ use engine::ai_support::{
 use engine::database::legality::{any_ai_difficulty_is_cedh, validate_cedh_bracket};
 use engine::database::{CardDatabase, CardSearchQuery};
 use engine::game::engine::{
-    apply, apply_for_simulation, recover_orphaned_resolve_all, resolve_all_ready_access,
-    resolve_all_ready_prefix, ResolveAllReadyAccess,
+    apply, apply_interaction_with_rejection, recover_orphaned_resolve_all,
+    resolve_all_ready_prefix_with_rejection,
 };
-use engine::game::interaction::{bind_interaction_authority, submit_interaction};
-use engine::game::preview::{compute_preview_diff, preview_auto_payment_sources};
+use engine::game::interaction::{bind_interaction_authority, submit_interaction_with_rejection};
+use engine::game::preview::{
+    preview_action_with_rejection, preview_auto_payment_sources_with_rejection,
+};
 use engine::game::{
     can_pair_commanders, companion_candidates, deck_copy_limit_for, estimate_bracket,
     evaluate_deck_compatibility, filter_state_for_viewer, finalize_public_state,
@@ -467,8 +469,25 @@ enum AiProposalSubmission {
         reason: &'static str,
     },
     Rejected {
-        reason: String,
+        rejection: ActionRejection,
     },
+}
+
+/// Private WASM boundary outcome for expected engine rejections. Serialization
+/// keeps recoverable action failures distinct from raw WASM/runtime errors,
+/// which continue to cross this boundary as strings or thrown `JsValue`s.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase", tag = "status")]
+enum ActionOutcome<T> {
+    Applied { result: T },
+    Rejected { rejection: ActionRejection },
+}
+
+fn action_outcome<T: Serialize>(result: Result<T, ActionRejection>) -> JsValue {
+    to_js(&match result {
+        Ok(result) => ActionOutcome::Applied { result },
+        Err(rejection) => ActionOutcome::Rejected { rejection },
+    })
 }
 
 /// Set the multiplayer enforcement flag directly.
@@ -1467,36 +1486,25 @@ pub fn submit_action(actor: u8, action: JsValue) -> JsValue {
     // bindings post-signature-change) now get a clean error instead.
     let action: GameAction = match serde_wasm_bindgen::from_value(action) {
         Ok(a) => a,
-        Err(e) => {
-            return JsValue::from_str(&format!("Engine error: failed to deserialize action: {e}"));
+        Err(_) => {
+            return action_outcome(Err(ActionRejection::new(
+                ActionRejectionCode::InvalidAction,
+            )))
         }
     };
     let actor = PlayerId(actor);
 
-    // In P2P-host multiplayer mode, debug actions are gated on the
-    // sandbox per-player permission set, mirroring the server-core gate.
-    // Single-player (non-multiplayer) WASM ignores this branch entirely.
-    if matches!(action, GameAction::Debug(_)) && is_multiplayer_mode() {
-        let permitted = with_state(|state| state.debug_permitted.contains(&actor)).unwrap_or(false);
-        if !permitted {
-            return JsValue::from_str(
-                "Engine error: debug actions disabled (Sandbox mode off or no permission)",
-            );
-        }
-    }
-
     if let GameAction::Debug(debug_action) = &action {
         if debug_action.is_zero_count_create() {
             return match with_state(|state| {
-                engine::game::preflight_debug_action(state, actor, debug_action)?;
-                Ok::<_, engine::game::EngineError>(engine::types::game_state::ActionResult {
+                preflight_debug_action_with_rejection(state, actor, debug_action)?;
+                Ok::<_, ActionRejection>(engine::types::game_state::ActionResult {
                     events: vec![],
                     waiting_for: state.waiting_for.clone(),
                     log_entries: vec![],
                 })
             }) {
-                Ok(Ok(result)) => to_js(&result),
-                Ok(Err(error)) => JsValue::from_str(&format!("Engine error: {error}")),
+                Ok(result) => action_outcome(result),
                 Err(error) => error,
             };
         }
@@ -1529,16 +1537,13 @@ pub fn submit_action(actor: u8, action: JsValue) -> JsValue {
     // reaches here.
     let action_for_replay = action.clone();
     let is_debug_action = matches!(action, GameAction::Debug(_));
-    match with_state_mut(|state| match apply(state, actor, action) {
+    match with_state_mut(|state| match apply_with_rejection(state, actor, action) {
         Ok(result) => {
             record_replay_action(is_debug_action, actor, action_for_replay);
             invalidate_ai_proposals();
-            to_js(&result)
+            action_outcome(Ok(result))
         }
-        Err(e) => {
-            let error_msg = format!("Engine error: {}", e);
-            JsValue::from_str(&error_msg)
-        }
+        Err(rejection) => action_outcome(Err(rejection)),
     }) {
         Ok(val) => val,
         Err(e) => e,
@@ -1552,20 +1557,20 @@ pub fn submit_action(actor: u8, action: JsValue) -> JsValue {
 pub fn submit_interaction_js(actor: u8, submission: JsValue) -> JsValue {
     let submission: InteractionSubmission = match serde_wasm_bindgen::from_value(submission) {
         Ok(submission) => submission,
-        Err(error) => {
-            return JsValue::from_str(&format!(
-                "Engine error: failed to deserialize interaction submission: {error}"
-            ));
+        Err(_) => {
+            return action_outcome(Err(ActionRejection::new(
+                ActionRejectionCode::InvalidInteractionResponse,
+            )));
         }
     };
     let actor = PlayerId(actor);
-    match with_state_mut(|state| submit_interaction(state, actor, submission)) {
+    match with_state_mut(|state| submit_interaction_with_rejection(state, actor, submission)) {
         Ok(Ok(applied)) => {
             record_replay_action(false, actor, applied.action);
             invalidate_ai_proposals();
-            to_js(&applied.result)
+            action_outcome(Ok(applied.result))
         }
-        Ok(Err(error)) => JsValue::from_str(&format!("Engine error: {:?}", error.code)),
+        Ok(Err(rejection)) => action_outcome(Err(rejection)),
         Err(error) => error,
     }
 }
@@ -1614,8 +1619,24 @@ struct DebugCreateCardRequest<'a> {
 }
 
 fn handle_debug_create_card(request: DebugCreateCardRequest<'_>) -> JsValue {
+    let debug_action = DebugAction::CreateCard {
+        card_name: request.card_name.to_string(),
+        owner: request.owner,
+        zone: request.zone,
+        count: request.count,
+        attach_to: request.attach_to.clone(),
+        run_etb: request.run_etb,
+        nonlegendary: request.nonlegendary,
+    };
+    match with_state(|state| {
+        preflight_debug_action_with_rejection(state, request.actor, &debug_action)
+    }) {
+        Ok(Err(rejection)) => return action_outcome(Err(rejection)),
+        Ok(Ok(())) => {}
+        Err(error) => return error,
+    }
     match handle_debug_create_card_inner(request) {
-        Ok(result) => to_js(&result),
+        Ok(result) => action_outcome(Ok(result)),
         Err(msg) => JsValue::from_str(&msg),
     }
 }
@@ -1988,28 +2009,15 @@ pub fn get_viewer_snapshot_js(player_id: u32) -> JsValue {
 pub fn preview_action_js(actor: u8, action: JsValue) -> JsValue {
     let action: GameAction = match serde_wasm_bindgen::from_value(action) {
         Ok(a) => a,
-        Err(e) => {
-            return JsValue::from_str(&format!("Engine error: failed to deserialize action: {e}"));
+        Err(_) => {
+            return action_outcome(Err(ActionRejection::new(
+                ActionRejectionCode::InvalidAction,
+            )))
         }
     };
     let actor = PlayerId(actor);
-    match with_state(|state| {
-        // Simulate on a throwaway clone. `apply_for_simulation` is the same rules
-        // resolution the AI look-ahead uses; it mutates only `sim`, never the
-        // live `GAME_STATE` this closure borrows immutably.
-        let mut sim = state.clone();
-        engine::game::layers::flush_layers(&mut sim);
-        let before = filter_state_for_viewer(&sim, actor);
-        match apply_for_simulation(&mut sim, actor, action) {
-            Ok(_) => {
-                let after = filter_state_for_viewer(&sim, actor);
-                Ok(compute_preview_diff(&before, &after))
-            }
-            Err(e) => Err(format!("Engine error: {e}")),
-        }
-    }) {
-        Ok(Ok(diff)) => to_js(&diff),
-        Ok(Err(msg)) => JsValue::from_str(&msg),
+    match with_state(|state| action_outcome(preview_action_with_rejection(state, actor, &action))) {
+        Ok(outcome) => outcome,
         Err(e) => e,
     }
 }
@@ -2022,19 +2030,17 @@ pub fn preview_action_js(actor: u8, action: JsValue) -> JsValue {
 pub fn preview_mana_payment_js(actor: u8, action: JsValue) -> JsValue {
     let action: GameAction = match serde_wasm_bindgen::from_value(action) {
         Ok(action) => action,
-        Err(error) => {
-            return JsValue::from_str(&format!(
-                "Engine error: failed to deserialize action: {error}"
-            ));
+        Err(_) => {
+            return action_outcome(Err(ActionRejection::new(
+                ActionRejectionCode::InvalidAction,
+            )))
         }
     };
 
     match with_state(|state| {
-        preview_auto_payment_sources(state, PlayerId(actor), &action)
-            .map_err(|error| format!("Engine error: {error}"))
+        preview_auto_payment_sources_with_rejection(state, PlayerId(actor), &action)
     }) {
-        Ok(Ok(sources)) => to_js(&sources),
-        Ok(Err(message)) => JsValue::from_str(&message),
+        Ok(result) => action_outcome(result),
         Err(error) => error,
     }
 }
@@ -2976,9 +2982,9 @@ pub fn get_ai_action_proposal_from_scores_with_diagnostics(
 pub fn submit_ai_action_proposal(token: &str, actor: u8, action: JsValue) -> JsValue {
     let action: GameAction = match serde_wasm_bindgen::from_value(action) {
         Ok(action) => action,
-        Err(error) => {
+        Err(_) => {
             return to_js(&AiProposalSubmission::Rejected {
-                reason: format!("failed to deserialize action: {error}"),
+                rejection: ActionRejection::new(ActionRejectionCode::InvalidAction),
             });
         }
     };
@@ -2996,7 +3002,7 @@ pub fn submit_ai_action_proposal(token: &str, actor: u8, action: JsValue) -> JsV
                 reason: "decision_changed_or_action_outside_issued_bounds",
             };
         }
-        match engine::game::engine::apply_interaction(
+        match apply_interaction_with_rejection(
             state,
             actor,
             proposal.contract.semantic_owner,
@@ -3009,9 +3015,7 @@ pub fn submit_ai_action_proposal(token: &str, actor: u8, action: JsValue) -> JsV
                     result: Box::new(result),
                 }
             }
-            Err(error) => AiProposalSubmission::Rejected {
-                reason: error.to_string(),
-            },
+            Err(rejection) => AiProposalSubmission::Rejected { rejection },
         }
     }) {
         Ok(outcome) => to_js(&outcome),
@@ -3041,8 +3045,11 @@ pub fn resolve_all(
     ai_seats_json: &str,
     max_resolutions: u32,
 ) -> Result<JsValue, JsValue> {
-    let _: serde_json::Value = serde_json::from_str(ai_seats_json)
-        .map_err(|e| JsValue::from_str(&format!("Failed to deserialize AI seats: {e}")))?;
+    if serde_json::from_str::<Vec<serde_json::Value>>(ai_seats_json).is_err() {
+        return Ok(action_outcome(Err(ActionRejection::new(
+            ActionRejectionCode::InvalidAction,
+        ))));
+    }
 
     let requester = PlayerId(requester);
 
@@ -3053,20 +3060,10 @@ pub fn resolve_all(
         // priority window. Keep the legacy payload parse as a wire-compatible
         // boundary while the consent action owns the authoritative cap.
         let _ = max_resolutions;
-        // Reject only an unentitled caller. A latch whose frozen run has gone
-        // stale is still routed into the resolver, whose fail-closed
-        // invalidation restores ordinary priority — rejecting it here instead
-        // would leave the game parked with no acting player and, in practice,
-        // nothing any client offers the player to press.
-        // Exhaustive rather than an equality test: a future variant must be
-        // classified here instead of silently defaulting to allowed.
-        match resolve_all_ready_access(state, requester) {
-            ResolveAllReadyAccess::Refused => {
-                return Err(JsValue::from_str("Resolve All consent is not ready"));
-            }
-            ResolveAllReadyAccess::Admitted => {}
-        }
-        let mut result = resolve_all_ready_prefix(state, requester);
+        let mut result = match resolve_all_ready_prefix_with_rejection(state, requester) {
+            Ok(result) => result,
+            Err(rejection) => return Ok(action_outcome(Err(rejection))),
+        };
         // A Resolve All burst applies real actions directly via
         // `apply_action_boundary_with_stack_limit` (bypassing `submit_action`,
         // which is the only other place REPLAY_LOG is appended to) — without
@@ -3091,7 +3088,7 @@ pub fn resolve_all(
         }
         result.events.clear();
         result.log_entries.clear();
-        Ok(to_js(&result))
+        Ok(action_outcome(Ok(result)))
     })?
 }
 
@@ -4549,7 +4546,14 @@ mod tests {
         .expect("test state remains installed");
 
         let value = resolve_all(0, "[]", 0).unwrap();
-        let result: BatchResolveResult = serde_wasm_bindgen::from_value(value).unwrap();
+        let outcome: serde_json::Value = serde_wasm_bindgen::from_value(value).unwrap();
+        let result: BatchResolveResult = serde_json::from_value(
+            outcome
+                .get("result")
+                .cloned()
+                .expect("ready Resolve All returns an applied outcome"),
+        )
+        .unwrap();
 
         assert_eq!(result.items_resolved, 1);
         let restored: GameState = serde_wasm_bindgen::from_value(get_game_state()).unwrap();

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -14,8 +14,8 @@ use engine::ai_support::{
 use engine::database::legality::{any_ai_difficulty_is_cedh, validate_cedh_bracket};
 use engine::database::{CardDatabase, CardSearchQuery};
 use engine::game::engine::{
-    apply, apply_interaction_with_rejection, recover_orphaned_resolve_all,
-    resolve_all_ready_prefix_with_rejection,
+    apply_interaction_with_rejection, apply_with_rejection, preflight_debug_action_with_rejection,
+    recover_orphaned_resolve_all, resolve_all_ready_prefix_with_rejection,
 };
 use engine::game::interaction::{bind_interaction_authority, submit_interaction_with_rejection};
 use engine::game::preview::{
@@ -30,13 +30,16 @@ use engine::game::{
     validate_name_deck_for_format_full, BracketEstimate, DeckCompatibilityRequest, DeckList,
     PlayerDeckList, ReplayPlayer,
 };
+use engine::types::actions::DebugAction;
 use engine::types::format::{DeckCopyLimit, FormatConfig, GameFormat};
 use engine::types::game_state::{PersistedGameState, TrustedGameStateEnvelope, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::interaction::{InteractionSessionId, InteractionSubmission};
 use engine::types::mana::ManaCost;
 use engine::types::match_config::MatchConfig;
-use engine::types::{GameAction, GameState, PlayerId, ReplayHeader, ReplayLog};
+use engine::types::{
+    ActionRejection, ActionRejectionCode, GameAction, GameState, PlayerId, ReplayHeader, ReplayLog,
+};
 
 use engine::game::resolve_player_deck_list;
 use engine::starter_decks;

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -13,6 +13,8 @@ use engine::ai_support::{
 };
 use engine::database::legality::{any_ai_difficulty_is_cedh, validate_cedh_bracket};
 use engine::database::{CardDatabase, CardSearchQuery};
+#[cfg(test)]
+use engine::game::engine::apply;
 use engine::game::engine::{
     apply_interaction_with_rejection, apply_with_rejection, preflight_debug_action_with_rejection,
     recover_orphaned_resolve_all, resolve_all_ready_prefix_with_rejection,

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -1633,7 +1633,7 @@ fn handle_debug_create_card(request: DebugCreateCardRequest<'_>) -> JsValue {
         owner: request.owner,
         zone: request.zone,
         count: request.count,
-        attach_to: request.attach_to.clone(),
+        attach_to: request.attach_to,
         run_etb: request.run_etb,
         nonlegendary: request.nonlegendary,
     };

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -493,6 +493,10 @@ fn action_outcome<T: Serialize>(result: Result<T, ActionRejection>) -> JsValue {
     })
 }
 
+fn rejected_action_outcome(rejection: ActionRejection) -> JsValue {
+    to_js(&ActionOutcome::<()>::Rejected { rejection })
+}
+
 /// Set the multiplayer enforcement flag directly.
 ///
 /// Entering multiplayer is *not* done here: the engine claims the flag itself,
@@ -1490,9 +1494,9 @@ pub fn submit_action(actor: u8, action: JsValue) -> JsValue {
     let action: GameAction = match serde_wasm_bindgen::from_value(action) {
         Ok(a) => a,
         Err(_) => {
-            return action_outcome(Err(ActionRejection::new(
+            return rejected_action_outcome(ActionRejection::new(
                 ActionRejectionCode::InvalidAction,
-            )))
+            ))
         }
     };
     let actor = PlayerId(actor);
@@ -1546,7 +1550,7 @@ pub fn submit_action(actor: u8, action: JsValue) -> JsValue {
             invalidate_ai_proposals();
             action_outcome(Ok(result))
         }
-        Err(rejection) => action_outcome(Err(rejection)),
+        Err(rejection) => rejected_action_outcome(rejection),
     }) {
         Ok(val) => val,
         Err(e) => e,
@@ -1561,9 +1565,9 @@ pub fn submit_interaction_js(actor: u8, submission: JsValue) -> JsValue {
     let submission: InteractionSubmission = match serde_wasm_bindgen::from_value(submission) {
         Ok(submission) => submission,
         Err(_) => {
-            return action_outcome(Err(ActionRejection::new(
+            return rejected_action_outcome(ActionRejection::new(
                 ActionRejectionCode::InvalidInteractionResponse,
-            )));
+            ));
         }
     };
     let actor = PlayerId(actor);
@@ -1573,7 +1577,7 @@ pub fn submit_interaction_js(actor: u8, submission: JsValue) -> JsValue {
             invalidate_ai_proposals();
             action_outcome(Ok(applied.result))
         }
-        Ok(Err(rejection)) => action_outcome(Err(rejection)),
+        Ok(Err(rejection)) => rejected_action_outcome(rejection),
         Err(error) => error,
     }
 }
@@ -1634,7 +1638,7 @@ fn handle_debug_create_card(request: DebugCreateCardRequest<'_>) -> JsValue {
     match with_state(|state| {
         preflight_debug_action_with_rejection(state, request.actor, &debug_action)
     }) {
-        Ok(Err(rejection)) => return action_outcome(Err(rejection)),
+        Ok(Err(rejection)) => return rejected_action_outcome(rejection),
         Ok(Ok(())) => {}
         Err(error) => return error,
     }
@@ -2013,9 +2017,9 @@ pub fn preview_action_js(actor: u8, action: JsValue) -> JsValue {
     let action: GameAction = match serde_wasm_bindgen::from_value(action) {
         Ok(a) => a,
         Err(_) => {
-            return action_outcome(Err(ActionRejection::new(
+            return rejected_action_outcome(ActionRejection::new(
                 ActionRejectionCode::InvalidAction,
-            )))
+            ))
         }
     };
     let actor = PlayerId(actor);
@@ -2034,9 +2038,9 @@ pub fn preview_mana_payment_js(actor: u8, action: JsValue) -> JsValue {
     let action: GameAction = match serde_wasm_bindgen::from_value(action) {
         Ok(action) => action,
         Err(_) => {
-            return action_outcome(Err(ActionRejection::new(
+            return rejected_action_outcome(ActionRejection::new(
                 ActionRejectionCode::InvalidAction,
-            )))
+            ))
         }
     };
 
@@ -3049,9 +3053,9 @@ pub fn resolve_all(
     max_resolutions: u32,
 ) -> Result<JsValue, JsValue> {
     if serde_json::from_str::<Vec<serde_json::Value>>(ai_seats_json).is_err() {
-        return Ok(action_outcome(Err(ActionRejection::new(
+        return Ok(rejected_action_outcome(ActionRejection::new(
             ActionRejectionCode::InvalidAction,
-        ))));
+        )));
     }
 
     let requester = PlayerId(requester);
@@ -3065,7 +3069,7 @@ pub fn resolve_all(
         let _ = max_resolutions;
         let mut result = match resolve_all_ready_prefix_with_rejection(state, requester) {
             Ok(result) => result,
-            Err(rejection) => return Ok(action_outcome(Err(rejection))),
+            Err(rejection) => return Ok(rejected_action_outcome(rejection)),
         };
         // A Resolve All burst applies real actions directly via
         // `apply_action_boundary_with_stack_limit` (bypassing `submit_action`,

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -593,6 +593,11 @@ pub struct DerivedViews {
     /// when there is no actor or multiple distinct authorized submitters.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub unique_authorized_submitter: Option<PlayerId>,
+    /// Viewer-visible object ids in each player's shared exile pile. This is
+    /// projected after face-down visibility filtering so the client can anchor
+    /// rejection feedback without reimplementing private-information rules.
+    #[serde(default, skip_serializing_if = "BTreeMap::is_empty")]
+    pub visible_exile_object_ids: BTreeMap<PlayerId, Vec<ObjectId>>,
     /// Debug-only identities for the viewing player's own library. The normal
     /// `GameState` projection keeps those objects hidden; this capability is
     /// intentionally narrow so a debug browser can select a card by name.
@@ -988,16 +993,22 @@ impl<'a> ClientGameStateRef<'a> {
     /// Viewer-filtered paths must use [`Self::wrap_filtered`] so redaction cannot
     /// erase an authoritative decision projection.
     pub fn wrap(state: &'a GameState, viewer: Option<PlayerId>) -> Self {
-        let display_visible_object_ids = viewer.map(|viewer| {
-            crate::game::visibility::filter_state_for_viewer(state, viewer)
+        let filtered_state =
+            viewer.map(|viewer| crate::game::visibility::filter_state_for_viewer(state, viewer));
+        let display_visible_object_ids = filtered_state.as_ref().map(|filtered| {
+            filtered
                 .objects
                 .iter()
                 .filter_map(|(id, object)| object.display_visible_to_viewer.then_some(*id))
                 .collect()
         });
+        let mut derived = derive_views(state, viewer);
+        if let Some(filtered) = filtered_state.as_ref() {
+            derived.visible_exile_object_ids = visible_exile_object_ids(filtered);
+        }
         Self {
             state,
-            derived: derive_views(state, viewer),
+            derived,
             display_visible_object_ids,
         }
     }
@@ -1944,11 +1955,33 @@ pub fn derive_filtered_views(
     let mut views = derive_views(filtered_state, viewer);
     views.unique_authorized_submitter = unique_authorized_submitter(authoritative_state);
     views.debug_library_cards = debug_library_cards(authoritative_state, viewer);
+    views.visible_exile_object_ids = visible_exile_object_ids(filtered_state);
     // CR 509.1g: blocking relationships are public information. Preserve this
     // display projection even when a viewer-safe state intentionally omits raw
     // combat records unrelated to rendering.
     views.blocker_assignment_pairs = blocker_assignment_pairs(authoritative_state);
     views
+}
+
+fn visible_exile_object_ids(state: &GameState) -> BTreeMap<PlayerId, Vec<ObjectId>> {
+    state
+        .players
+        .iter()
+        .filter_map(|player| {
+            let object_ids: Vec<ObjectId> = state
+                .exile
+                .iter()
+                .copied()
+                .filter(|object_id| {
+                    state.objects.get(object_id).is_some_and(|object| {
+                        object.owner == player.id
+                            && (!object.face_down || object.display_visible_to_viewer)
+                    })
+                })
+                .collect();
+            (!object_ids.is_empty()).then_some((player.id, object_ids))
+        })
+        .collect()
 }
 
 fn debug_library_cards(state: &GameState, viewer: Option<PlayerId>) -> Vec<DebugLibraryCardView> {

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -929,7 +929,7 @@ pub fn preflight_debug_action_with_rejection(
 /// debug mode is enabled. Disabled debug mode continues through the ordinary
 /// preflight path so it remains an invalid action rather than an authorization
 /// failure.
-fn explicit_debug_permission_rejection(
+pub(crate) fn explicit_debug_permission_rejection(
     state: &GameState,
     actor: PlayerId,
     related_object_ids: Vec<ObjectId>,

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -913,6 +913,24 @@ pub fn preflight_debug_action_with_rejection(
     })
 }
 
+/// Checks the transport-level explicit debug permission policy without
+/// evaluating whether a particular debug action is otherwise valid.
+///
+/// An empty permission set leaves debug authority unrestricted; once the set
+/// has members, only listed players have explicit debug permission.
+pub fn require_explicit_debug_permission(
+    state: &GameState,
+    actor: PlayerId,
+) -> Result<(), ActionRejection> {
+    if state.debug_permitted.is_empty() || state.debug_permitted.contains(&actor) {
+        Ok(())
+    } else {
+        Err(ActionRejection::new(
+            ActionRejectionCode::DebugPermissionDenied,
+        ))
+    }
+}
+
 /// Runs a Ready Resolve All batch only for an admitted requester.
 pub fn resolve_all_ready_prefix_with_rejection(
     state: &mut GameState,

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -888,6 +888,13 @@ pub fn apply_with_rejection(
     action: GameAction,
 ) -> Result<ActionResult, ActionRejection> {
     let related_object_ids = action.related_object_ids();
+    if matches!(&action, GameAction::Debug(_)) {
+        if let Some(rejection) =
+            explicit_debug_permission_rejection(state, actor, related_object_ids.clone())
+        {
+            return Err(rejection);
+        }
+    }
     apply(state, actor, action).map_err(|error| {
         super::visibility::filter_action_rejection_for_viewer(
             state,
@@ -904,6 +911,11 @@ pub fn preflight_debug_action_with_rejection(
     action: &DebugAction,
 ) -> Result<(), ActionRejection> {
     let related_object_ids = GameAction::Debug(action.clone()).related_object_ids();
+    if let Some(rejection) =
+        explicit_debug_permission_rejection(state, actor, related_object_ids.clone())
+    {
+        return Err(rejection);
+    }
     preflight_debug_action(state, actor, action).map_err(|error| {
         super::visibility::filter_action_rejection_for_viewer(
             state,
@@ -911,6 +923,30 @@ pub fn preflight_debug_action_with_rejection(
             &action_rejection_for_engine_error(&error, related_object_ids),
         )
     })
+}
+
+/// Returns the viewer-filtered permission rejection for a debug action when
+/// debug mode is enabled. Disabled debug mode continues through the ordinary
+/// preflight path so it remains an invalid action rather than an authorization
+/// failure.
+fn explicit_debug_permission_rejection(
+    state: &GameState,
+    actor: PlayerId,
+    related_object_ids: Vec<ObjectId>,
+) -> Option<ActionRejection> {
+    if !state.debug_mode {
+        return None;
+    }
+
+    require_explicit_debug_permission(state, actor)
+        .err()
+        .map(|rejection| {
+            super::visibility::filter_action_rejection_for_viewer(
+                state,
+                actor,
+                &ActionRejection::from_code(rejection.code, related_object_ids),
+            )
+        })
 }
 
 /// Checks the transport-level explicit debug permission policy without

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -91,6 +91,8 @@ pub enum EngineError {
     WrongPlayer,
     #[error("Not your priority")]
     NotYourPriority,
+    #[error("Action is stale")]
+    StaleAction,
     #[error("Action not allowed: {0}")]
     ActionNotAllowed(String),
 }
@@ -105,6 +107,7 @@ pub(crate) fn action_rejection_for_engine_error(
         EngineError::InvalidAction(_) => ActionRejectionCode::InvalidAction,
         EngineError::WrongPlayer => ActionRejectionCode::WrongPlayer,
         EngineError::NotYourPriority => ActionRejectionCode::NotYourPriority,
+        EngineError::StaleAction => ActionRejectionCode::StaleAction,
         EngineError::ActionNotAllowed(_) => ActionRejectionCode::ActionNotAllowed,
     };
     ActionRejection::from_code(code, related_object_ids)
@@ -1018,6 +1021,26 @@ pub fn apply_interaction(
         action,
         PublicFinalizeMode::Immediate,
     )
+}
+
+/// Applies an interaction-materialized action while returning stable, safe
+/// rejection metadata. The interaction projection remains the only authority
+/// that may materialize the action; this wrapper only preserves its actor and
+/// semantic-owner boundary when converting a reducer failure for the client.
+pub fn apply_interaction_with_rejection(
+    state: &mut GameState,
+    authenticated_actor: PlayerId,
+    semantic_owner: PlayerId,
+    action: GameAction,
+) -> Result<ActionResult, ActionRejection> {
+    let related_object_ids = action.related_object_ids();
+    apply_interaction(state, authenticated_actor, semantic_owner, action).map_err(|error| {
+        super::visibility::filter_action_rejection_for_viewer(
+            state,
+            authenticated_actor,
+            &action_rejection_for_engine_error(&error, related_object_ids),
+        )
+    })
 }
 
 pub(crate) fn apply_interaction_for_simulation(
@@ -8178,11 +8201,7 @@ fn apply_action(
         let player = &mut state.players[actor.0 as usize];
 
         if order.len() != player.hand.len() {
-            return Err(EngineError::InvalidAction(format!(
-                "ReorderHand: expected {} ids, got {}",
-                player.hand.len(),
-                order.len()
-            )));
+            return Err(EngineError::StaleAction);
         }
 
         // Permutation check: same multiset. Sort copies and compare — O(n log n)
@@ -8194,9 +8213,7 @@ fn apply_action(
         current.sort_unstable_by_key(|id| id.0);
         requested.sort_unstable_by_key(|id| id.0);
         if current != requested {
-            return Err(EngineError::InvalidAction(
-                "ReorderHand: order is not a permutation of the current hand".into(),
-            ));
+            return Err(EngineError::StaleAction);
         }
 
         player.hand = order.iter().copied().collect();

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -5,6 +5,7 @@ use thiserror::Error;
 use crate::types::ability::{DurationEvent, EffectKind, KeywordAction, TargetRef};
 #[cfg(test)]
 use crate::types::ability::{EffectScope, TapStateChange};
+use crate::types::action_rejection::{ActionRejection, ActionRejectionCode};
 use crate::types::actions::{
     DebugAction, GameAction, MayTriggerAutoChoiceOp, PriorityYieldOp, ResolveAllConsentDecision,
     TriggerOrderTemplateOp,
@@ -92,6 +93,21 @@ pub enum EngineError {
     NotYourPriority,
     #[error("Action not allowed: {0}")]
     ActionNotAllowed(String),
+}
+
+/// Converts an engine error into stable client-facing metadata without ever
+/// copying its diagnostic payload into the serialized response.
+pub(crate) fn action_rejection_for_engine_error(
+    error: &EngineError,
+    related_object_ids: Vec<ObjectId>,
+) -> ActionRejection {
+    let code = match error {
+        EngineError::InvalidAction(_) => ActionRejectionCode::InvalidAction,
+        EngineError::WrongPlayer => ActionRejectionCode::WrongPlayer,
+        EngineError::NotYourPriority => ActionRejectionCode::NotYourPriority,
+        EngineError::ActionNotAllowed(_) => ActionRejectionCode::ActionNotAllowed,
+    };
+    ActionRejection::from_code(code, related_object_ids)
 }
 
 /// The three non-interchangeable authorities carried by a live Priority
@@ -861,6 +877,57 @@ pub fn apply(
     action: GameAction,
 ) -> Result<ActionResult, EngineError> {
     apply_action_boundary(state, actor, action, PublicFinalizeMode::Immediate)
+}
+
+/// Applies an action while returning stable, safe rejection metadata instead
+/// of a diagnostic engine error. The legacy [`apply`] API remains the raw
+/// engine-error authority for callers that need internal diagnostics.
+pub fn apply_with_rejection(
+    state: &mut GameState,
+    actor: PlayerId,
+    action: GameAction,
+) -> Result<ActionResult, ActionRejection> {
+    let related_object_ids = action.related_object_ids();
+    apply(state, actor, action).map_err(|error| {
+        super::visibility::filter_action_rejection_for_viewer(
+            state,
+            actor,
+            &action_rejection_for_engine_error(&error, related_object_ids),
+        )
+    })
+}
+
+/// Checks a debug action without exposing diagnostic preflight errors.
+pub fn preflight_debug_action_with_rejection(
+    state: &GameState,
+    actor: PlayerId,
+    action: &DebugAction,
+) -> Result<(), ActionRejection> {
+    let related_object_ids = GameAction::Debug(action.clone()).related_object_ids();
+    preflight_debug_action(state, actor, action).map_err(|error| {
+        super::visibility::filter_action_rejection_for_viewer(
+            state,
+            actor,
+            &action_rejection_for_engine_error(&error, related_object_ids),
+        )
+    })
+}
+
+/// Runs a Ready Resolve All batch only for an admitted requester.
+pub fn resolve_all_ready_prefix_with_rejection(
+    state: &mut GameState,
+    requester: PlayerId,
+) -> Result<ResolveAllFastForwardResult, ActionRejection> {
+    if !matches!(
+        resolve_all_ready_access(state, requester),
+        ResolveAllReadyAccess::Admitted
+    ) {
+        return Err(ActionRejection::from_code(
+            ActionRejectionCode::ResolveAllNotReady,
+            vec![],
+        ));
+    }
+    Ok(resolve_all_ready_prefix(state, requester))
 }
 
 /// Explicit-actor simulation apply: [`apply`] for throwaway forward-projection

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -21,7 +21,10 @@ use crate::types::zones::Zone;
 
 use super::effects::attach::{attach_to as attach_object_to, attach_to_player};
 use super::effects::change_zone::shuffle_library;
-use super::engine::{action_rejection_for_engine_error, preflight_debug_action, EngineError};
+use super::engine::{
+    action_rejection_for_engine_error, explicit_debug_permission_rejection, preflight_debug_action,
+    EngineError,
+};
 use super::game_object::AttachTarget;
 use super::visibility::filter_action_rejection_for_viewer;
 use super::zones;
@@ -935,6 +938,20 @@ pub struct DebugCardCreateRequest {
     pub nonlegendary: bool,
 }
 
+impl DebugCardCreateRequest {
+    fn as_debug_action(&self) -> DebugAction {
+        DebugAction::CreateCard {
+            card_name: self.source.face.name.clone(),
+            owner: self.owner,
+            zone: self.zone,
+            count: self.count,
+            attach_to: self.attach_to,
+            run_etb: self.run_etb,
+            nonlegendary: self.nonlegendary,
+        }
+    }
+}
+
 /// Create one or more debug cards from a previously bound source. Non-
 /// battlefield creation and explicitly raw battlefield placement complete
 /// synchronously. Real battlefield entries drain serially through the private
@@ -943,15 +960,7 @@ pub fn create_debug_cards(
     state: &mut GameState,
     request: DebugCardCreateRequest,
 ) -> Result<ActionResult, EngineError> {
-    let debug_action = DebugAction::CreateCard {
-        card_name: request.source.face.name.clone(),
-        owner: request.owner,
-        zone: request.zone,
-        count: request.count,
-        attach_to: request.attach_to,
-        run_etb: request.run_etb,
-        nonlegendary: request.nonlegendary,
-    };
+    let debug_action = request.as_debug_action();
     preflight_debug_action(state, request.actor, &debug_action)?;
     if request.count == 0 {
         return Ok(ActionResult {
@@ -1039,16 +1048,12 @@ pub fn create_debug_cards_with_rejection(
     request: DebugCardCreateRequest,
 ) -> Result<ActionResult, ActionRejection> {
     let actor = request.actor;
-    let related_object_ids = GameAction::Debug(DebugAction::CreateCard {
-        card_name: request.source.face.name.clone(),
-        owner: request.owner,
-        zone: request.zone,
-        count: request.count,
-        attach_to: request.attach_to,
-        run_etb: request.run_etb,
-        nonlegendary: request.nonlegendary,
-    })
-    .related_object_ids();
+    let related_object_ids = GameAction::Debug(request.as_debug_action()).related_object_ids();
+    if let Some(rejection) =
+        explicit_debug_permission_rejection(state, actor, related_object_ids.clone())
+    {
+        return Err(rejection);
+    }
     create_debug_cards(state, request).map_err(|error| {
         filter_action_rejection_for_viewer(
             state,

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -939,7 +939,7 @@ pub struct DebugCardCreateRequest {
 }
 
 impl DebugCardCreateRequest {
-    fn as_debug_action(&self) -> DebugAction {
+    pub(crate) fn as_debug_action(&self) -> DebugAction {
         DebugAction::CreateCard {
             card_name: self.source.face.name.clone(),
             owner: self.owner,

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -4,7 +4,8 @@ use crate::types::ability::{
     ContinuousModification, Effect, LibraryPosition, QuantityExpr, ResolvedAbility, TargetFilter,
     TargetRef,
 };
-use crate::types::actions::{DebugAction, DebugTokenRequest};
+use crate::types::action_rejection::ActionRejection;
+use crate::types::actions::{DebugAction, DebugTokenRequest, GameAction};
 use crate::types::card::CardFace;
 use crate::types::card_type::Supertype;
 use crate::types::counter::CounterType;
@@ -20,8 +21,9 @@ use crate::types::zones::Zone;
 
 use super::effects::attach::{attach_to as attach_object_to, attach_to_player};
 use super::effects::change_zone::shuffle_library;
-use super::engine::{preflight_debug_action, EngineError};
+use super::engine::{action_rejection_for_engine_error, preflight_debug_action, EngineError};
 use super::game_object::AttachTarget;
+use super::visibility::filter_action_rejection_for_viewer;
 use super::zones;
 use crate::database::CardDatabase;
 use crate::game::token_presets::TokenPtProvenance;
@@ -1025,6 +1027,35 @@ pub fn create_debug_cards(
     });
     result.log_entries = super::log::resolve_log_entries(&result.events, &before, state);
     Ok(result)
+}
+
+/// Viewer-safe form of [`create_debug_cards`] for transport boundaries.
+///
+/// The card source is already bound by the transport. Only the engine's
+/// action-shaped refusal crosses this boundary; source lookup remains an
+/// operational transport failure.
+pub fn create_debug_cards_with_rejection(
+    state: &mut GameState,
+    request: DebugCardCreateRequest,
+) -> Result<ActionResult, ActionRejection> {
+    let actor = request.actor;
+    let related_object_ids = GameAction::Debug(DebugAction::CreateCard {
+        card_name: request.source.face.name.clone(),
+        owner: request.owner,
+        zone: request.zone,
+        count: request.count,
+        attach_to: request.attach_to,
+        run_etb: request.run_etb,
+        nonlegendary: request.nonlegendary,
+    })
+    .related_object_ids();
+    create_debug_cards(state, request).map_err(|error| {
+        filter_action_rejection_for_viewer(
+            state,
+            actor,
+            &action_rejection_for_engine_error(&error, related_object_ids),
+        )
+    })
 }
 
 /// Resume the active real-entry debug batch after its exact replacement or

--- a/crates/engine/src/game/engine_tests.rs
+++ b/crates/engine/src/game/engine_tests.rs
@@ -10303,7 +10303,7 @@ fn reorder_hand_rejects_non_permutation() {
     // Wrong length.
     let err = apply(&mut state, p0, GameAction::ReorderHand { order: vec![a] })
         .expect_err("wrong length must error");
-    assert!(matches!(err, EngineError::InvalidAction(_)));
+    assert!(matches!(err, EngineError::StaleAction));
     assert_eq!(
         state, before,
         "a reducer rejection must restore transient boundary state as well as the hand"
@@ -10319,7 +10319,7 @@ fn reorder_hand_rejects_non_permutation() {
         },
     )
     .expect_err("stranger id must error");
-    assert!(matches!(err, EngineError::InvalidAction(_)));
+    assert!(matches!(err, EngineError::StaleAction));
     assert_eq!(
         state, before,
         "each rejected reducer attempt must leave the complete state unchanged"

--- a/crates/engine/src/game/interaction.rs
+++ b/crates/engine/src/game/interaction.rs
@@ -10007,7 +10007,7 @@ pub fn submit_interaction_with_rejection(
             .map_err(action_rejection_for_interaction_reason)?
             .semantic_owner,
     );
-    let result = apply_interaction_with_rejection(state, actor, semantic_owner, action)?;
+    let result = apply_interaction_with_rejection(state, actor, semantic_owner, action.clone())?;
     Ok(AppliedInteraction { action, result })
 }
 

--- a/crates/engine/src/game/interaction.rs
+++ b/crates/engine/src/game/interaction.rs
@@ -69,7 +69,7 @@ use super::derived_views::{family_of, payload_seat, UnboundedFamily};
 use super::dungeon::DungeonId;
 use super::engine::{
     action_rejection_for_engine_error, apply_interaction, apply_interaction_for_simulation,
-    EngineError, MAX_SHORTCUT_CYCLES,
+    apply_interaction_with_rejection, EngineError, MAX_SHORTCUT_CYCLES,
 };
 use super::game_object::{AttachTarget, RoomDoor};
 use super::merge::MergeSide;
@@ -10002,20 +10002,12 @@ pub fn submit_interaction_with_rejection(
 ) -> Result<AppliedInteraction, ActionRejection> {
     let action = resolve_interaction_response(state, actor, &submission)
         .map_err(|error| action_rejection_for_interaction_reason(error.code))?;
-    let related_object_ids = action.related_object_ids();
     let semantic_owner = PlayerId(
         slot_for_submission(state, actor, &submission.interaction_id)
             .map_err(action_rejection_for_interaction_reason)?
             .semantic_owner,
     );
-    let result =
-        apply_interaction(state, actor, semantic_owner, action.clone()).map_err(|error| {
-            visibility::filter_action_rejection_for_viewer(
-                state,
-                actor,
-                &action_rejection_for_engine_error(&error, related_object_ids),
-            )
-        })?;
+    let result = apply_interaction_with_rejection(state, actor, semantic_owner, action)?;
     Ok(AppliedInteraction { action, result })
 }
 

--- a/crates/engine/src/game/interaction.rs
+++ b/crates/engine/src/game/interaction.rs
@@ -21,6 +21,7 @@ use crate::types::ability::{
     DoorLockOp, EffectKind, ObjectProperty, SearchSelectionConstraint, TapCreaturesAggregateStat,
     TapCreaturesSelectionMode, TargetRef,
 };
+use crate::types::action_rejection::{ActionRejection, ActionRejectionCode};
 use crate::types::actions::{
     AlternativeCastDecision, CastChoice, GameAction, MulliganChoice, OutsideGameSelection,
     PrecastCopyShortcutResponse, UnlessCostBranch,
@@ -67,7 +68,8 @@ use super::combat::AttackTarget;
 use super::derived_views::{family_of, payload_seat, UnboundedFamily};
 use super::dungeon::DungeonId;
 use super::engine::{
-    apply_interaction, apply_interaction_for_simulation, EngineError, MAX_SHORTCUT_CYCLES,
+    action_rejection_for_engine_error, apply_interaction, apply_interaction_for_simulation,
+    EngineError, MAX_SHORTCUT_CYCLES,
 };
 use super::game_object::{AttachTarget, RoomDoor};
 use super::merge::MergeSide;
@@ -76,6 +78,29 @@ use super::{mana_sources, turn_control, visibility};
 pub const MAX_INTERACTION_STRING_LEN: usize = 256;
 const MAX_INTERACTION_SESSION_ID_LEN: usize = 128;
 const MAX_INTERACTION_SERIAL_LEN: usize = 32;
+
+fn action_rejection_for_interaction_reason(reason: InteractionReasonCode) -> ActionRejection {
+    let code = match reason {
+        InteractionReasonCode::AuthorityUnbound | InteractionReasonCode::InvalidAuthorityState => {
+            ActionRejectionCode::InteractionUnavailable
+        }
+        InteractionReasonCode::NotAuthorized => ActionRejectionCode::InteractionNotAuthorized,
+        InteractionReasonCode::StaleInteraction => ActionRejectionCode::StaleInteraction,
+        InteractionReasonCode::UnknownChoice | InteractionReasonCode::MalformedResponse => {
+            ActionRejectionCode::InvalidInteractionResponse
+        }
+        InteractionReasonCode::PayloadTooLarge => ActionRejectionCode::InteractionPayloadTooLarge,
+        InteractionReasonCode::ConstraintUnsatisfied | InteractionReasonCode::NoLegalResponse => {
+            ActionRejectionCode::InteractionConstraintUnsatisfied
+        }
+        InteractionReasonCode::CancelOnly => ActionRejectionCode::InteractionCancelOnly,
+        InteractionReasonCode::ReducerRejected => ActionRejectionCode::InteractionReducerRejected,
+        InteractionReasonCode::UnsupportedResponse => {
+            ActionRejectionCode::UnsupportedInteractionResponse
+        }
+    };
+    ActionRejection::from_code(code, vec![])
+}
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 struct WaitingClassification {
@@ -9864,6 +9889,52 @@ pub fn preview_interaction(
     }
 }
 
+/// Preview an opaque interaction while returning the same safe rejection DTO
+/// used by ordinary actions. Failures before an interaction response has been
+/// materialized intentionally carry no object ids; the capability itself is
+/// opaque and must not reveal the rejected opportunity's contents.
+pub fn preview_interaction_with_rejection(
+    state: &GameState,
+    actor: PlayerId,
+    request: &InteractionPreviewRequest,
+) -> Result<InteractionPreview, ActionRejection> {
+    bound_string(request.request_id.as_str())
+        .and_then(|_| bound_string(request.interaction_id.as_str()))
+        .and_then(|_| validate_response_bounds(&request.response))
+        .map_err(action_rejection_for_interaction_reason)?;
+    let semantic_owner = slot_for_submission(state, actor, &request.interaction_id)
+        .map_err(action_rejection_for_interaction_reason)?
+        .semantic_owner;
+    let filtered = visibility::filter_state_for_viewer(state, actor);
+    let (action, progress) =
+        materialize_response(state, &filtered, &request.interaction_id, &request.response)
+            .map_err(action_rejection_for_interaction_reason)?;
+    let related_object_ids = action.related_object_ids();
+    let mut projected = state.clone();
+    apply_interaction_for_simulation(&mut projected, actor, PlayerId(semantic_owner), action)
+        .map_err(|error| {
+            visibility::filter_action_rejection_for_viewer(
+                state,
+                actor,
+                &action_rejection_for_engine_error(&error, related_object_ids),
+            )
+        })?;
+    Ok(InteractionPreview {
+        request_id: request.request_id.clone(),
+        interaction_id: request.interaction_id.clone(),
+        status: InteractionPreviewStatus::Confirmable,
+        progress: InteractionProgress {
+            confirmable: true,
+            ..progress
+        },
+        outcome: preview_outcome(state, &projected, &request.interaction_id),
+        summaries: vec![
+            InteractionSummaryCode::ConfirmAvailable,
+            InteractionSummaryCode::Progress,
+        ],
+    })
+}
+
 /// Materialize the `GameAction` an interaction response denotes, **without**
 /// applying it.
 ///
@@ -9919,6 +9990,32 @@ pub fn submit_interaction(
             code: InteractionReasonCode::ReducerRejected,
         },
     )?;
+    Ok(AppliedInteraction { action, result })
+}
+
+/// Submits an opaque interaction with stable rejection metadata. The legacy
+/// [`submit_interaction`] result remains unchanged for existing transports.
+pub fn submit_interaction_with_rejection(
+    state: &mut GameState,
+    actor: PlayerId,
+    submission: InteractionSubmission,
+) -> Result<AppliedInteraction, ActionRejection> {
+    let action = resolve_interaction_response(state, actor, &submission)
+        .map_err(|error| action_rejection_for_interaction_reason(error.code))?;
+    let related_object_ids = action.related_object_ids();
+    let semantic_owner = PlayerId(
+        slot_for_submission(state, actor, &submission.interaction_id)
+            .map_err(action_rejection_for_interaction_reason)?
+            .semantic_owner,
+    );
+    let result =
+        apply_interaction(state, actor, semantic_owner, action.clone()).map_err(|error| {
+            visibility::filter_action_rejection_for_viewer(
+                state,
+                actor,
+                &action_rejection_for_engine_error(&error, related_object_ids),
+            )
+        })?;
     Ok(AppliedInteraction { action, result })
 }
 

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -218,8 +218,9 @@ pub use deck_validation::{
 };
 pub use engine::{
     apply, apply_as_current, apply_with_rejection, new_game, preflight_debug_action,
-    preflight_debug_action_with_rejection, resolve_all_ready_prefix_with_rejection, start_game,
-    start_game_skip_mulligan, start_game_with_starting_player, EngineError,
+    preflight_debug_action_with_rejection, require_explicit_debug_permission,
+    resolve_all_ready_prefix_with_rejection, start_game, start_game_skip_mulligan,
+    start_game_with_starting_player, EngineError,
 };
 pub use engine_debug::{
     create_debug_cards, debug_card_entry_source, route_debug_create_to_battlefield,

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -217,7 +217,8 @@ pub use deck_validation::{
     DeckCompatibilityResult, DeckCoverage, SignatureSpellSelectionPolicy, UnsupportedCard,
 };
 pub use engine::{
-    apply, apply_as_current, new_game, preflight_debug_action, start_game,
+    apply, apply_as_current, apply_with_rejection, new_game, preflight_debug_action,
+    preflight_debug_action_with_rejection, resolve_all_ready_prefix_with_rejection, start_game,
     start_game_skip_mulligan, start_game_with_starting_player, EngineError,
 };
 pub use engine_debug::{

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -223,8 +223,8 @@ pub use engine::{
     start_game_with_starting_player, EngineError,
 };
 pub use engine_debug::{
-    create_debug_cards, debug_card_entry_source, route_debug_create_to_battlefield,
-    DebugCardCreateRequest,
+    create_debug_cards, create_debug_cards_with_rejection, debug_card_entry_source,
+    route_debug_create_to_battlefield, DebugCardCreateRequest,
 };
 pub use engine_resolve_batch::{
     resolve_all_fast_forward, ResolveAllCallbackDecision, ResolveAllFastForwardResult,

--- a/crates/engine/src/game/preview.rs
+++ b/crates/engine/src/game/preview.rs
@@ -16,7 +16,9 @@
 use serde::{Deserialize, Serialize};
 
 use crate::ai_support::legal_actions_for_viewer;
-use crate::game::engine::{apply_for_simulation, EngineError};
+use crate::game::engine::{action_rejection_for_engine_error, apply_for_simulation, EngineError};
+use crate::game::visibility::filter_action_rejection_for_viewer;
+use crate::types::action_rejection::ActionRejection;
 use crate::types::actions::GameAction;
 use crate::types::events::GameEvent;
 use crate::types::game_state::{CastPaymentMode, GameState, WaitingFor};
@@ -148,6 +150,36 @@ pub fn compute_preview_diff(before: &GameState, after: &GameState) -> PreviewDif
     }
 }
 
+/// Simulates an ordinary action and returns only its viewer-safe public diff.
+/// The original state is never mutated.
+pub fn preview_action(
+    state: &GameState,
+    actor: PlayerId,
+    action: &GameAction,
+) -> Result<PreviewDiff, EngineError> {
+    let before = crate::game::visibility::filter_state_for_viewer(state, actor);
+    let mut projected = state.clone();
+    apply_for_simulation(&mut projected, actor, action.clone())?;
+    let after = crate::game::visibility::filter_state_for_viewer(&projected, actor);
+    Ok(compute_preview_diff(&before, &after))
+}
+
+/// Viewer-safe form of [`preview_action`] with stable rejection metadata.
+pub fn preview_action_with_rejection(
+    state: &GameState,
+    actor: PlayerId,
+    action: &GameAction,
+) -> Result<PreviewDiff, ActionRejection> {
+    let related_object_ids = action.related_object_ids();
+    preview_action(state, actor, action).map_err(|error| {
+        filter_action_rejection_for_viewer(
+            state,
+            actor,
+            &action_rejection_for_engine_error(&error, related_object_ids),
+        )
+    })
+}
+
 /// Returns the mana sources the automatic payment path uses for `action`,
 /// without changing the live game state.
 ///
@@ -195,6 +227,23 @@ pub fn preview_auto_payment_sources(
         events.extend(x_result.events);
     }
     Ok(mana_source_ids_before_spell_cast(&events, *object_id))
+}
+
+/// Viewer-safe form of [`preview_auto_payment_sources`] with stable rejection
+/// metadata. It preserves the legacy preview's no-mutation behavior.
+pub fn preview_auto_payment_sources_with_rejection(
+    state: &GameState,
+    actor: PlayerId,
+    action: &GameAction,
+) -> Result<Vec<ObjectId>, ActionRejection> {
+    let related_object_ids = action.related_object_ids();
+    preview_auto_payment_sources(state, actor, action).map_err(|error| {
+        filter_action_rejection_for_viewer(
+            state,
+            actor,
+            &action_rejection_for_engine_error(&error, related_object_ids),
+        )
+    })
 }
 
 fn mana_source_ids_before_spell_cast(events: &[GameEvent], object_id: ObjectId) -> Vec<ObjectId> {

--- a/crates/engine/src/game/preview.rs
+++ b/crates/engine/src/game/preview.rs
@@ -16,7 +16,10 @@
 use serde::{Deserialize, Serialize};
 
 use crate::ai_support::legal_actions_for_viewer;
-use crate::game::engine::{action_rejection_for_engine_error, apply_for_simulation, EngineError};
+use crate::game::engine::{
+    action_rejection_for_engine_error, apply_for_simulation, explicit_debug_permission_rejection,
+    EngineError,
+};
 use crate::game::visibility::filter_action_rejection_for_viewer;
 use crate::types::action_rejection::ActionRejection;
 use crate::types::actions::GameAction;
@@ -171,6 +174,13 @@ pub fn preview_action_with_rejection(
     action: &GameAction,
 ) -> Result<PreviewDiff, ActionRejection> {
     let related_object_ids = action.related_object_ids();
+    if matches!(action, GameAction::Debug(_)) {
+        if let Some(rejection) =
+            explicit_debug_permission_rejection(state, actor, related_object_ids.clone())
+        {
+            return Err(rejection);
+        }
+    }
     preview_action(state, actor, action).map_err(|error| {
         filter_action_rejection_for_viewer(
             state,

--- a/crates/engine/src/game/preview.rs
+++ b/crates/engine/src/game/preview.rs
@@ -18,7 +18,7 @@ use serde::{Deserialize, Serialize};
 use crate::ai_support::legal_actions_for_viewer;
 use crate::game::engine::{
     action_rejection_for_engine_error, apply_for_simulation, explicit_debug_permission_rejection,
-    EngineError,
+    preflight_debug_action_with_rejection, EngineError,
 };
 use crate::game::visibility::filter_action_rejection_for_viewer;
 use crate::types::action_rejection::ActionRejection;
@@ -246,6 +246,10 @@ pub fn preview_auto_payment_sources_with_rejection(
     actor: PlayerId,
     action: &GameAction,
 ) -> Result<Vec<ObjectId>, ActionRejection> {
+    if let GameAction::Debug(debug_action) = action {
+        preflight_debug_action_with_rejection(state, actor, debug_action)?;
+    }
+
     let related_object_ids = action.related_object_ids();
     preview_auto_payment_sources(state, actor, action).map_err(|error| {
         filter_action_rejection_for_viewer(

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -51,6 +51,9 @@ pub fn filter_action_rejection_for_viewer(
     viewer: PlayerId,
     rejection: &ActionRejection,
 ) -> ActionRejection {
+    if rejection.related_object_ids.is_empty() {
+        return rejection.clone();
+    }
     let filtered = filter_state_for_viewer(state, viewer);
     ActionRejection {
         code: rejection.code,

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -1,6 +1,7 @@
 use std::collections::HashSet;
 use std::sync::Arc;
 
+use crate::types::action_rejection::ActionRejection;
 use crate::types::events::{GameEvent, LibrarySearchCardFaceView, LibrarySearchCardView};
 use crate::types::game_state::{CastOfferKind, GameState, PayCostKind, WaitingFor};
 use crate::types::identifiers::{CardId, ObjectId, ObjectIncarnationRef};
@@ -40,6 +41,28 @@ pub(crate) fn interaction_object_identity_is_visible(state: &GameState, id: Obje
         .objects
         .get(&id)
         .is_some_and(|object| object.name != HIDDEN_CARD_NAME)
+}
+
+/// Projects ephemeral rejection metadata through the same viewer filter as the
+/// state snapshot. The state is filtered before identity checks so hidden card
+/// names can never be reintroduced through a rejected action's object ids.
+pub fn filter_action_rejection_for_viewer(
+    state: &GameState,
+    viewer: PlayerId,
+    rejection: &ActionRejection,
+) -> ActionRejection {
+    let filtered = filter_state_for_viewer(state, viewer);
+    ActionRejection {
+        code: rejection.code,
+        disposition: rejection.disposition,
+        message: rejection.message.clone(),
+        related_object_ids: rejection
+            .related_object_ids
+            .iter()
+            .copied()
+            .filter(|object_id| interaction_object_identity_is_visible(&filtered, *object_id))
+            .collect(),
+    }
 }
 
 /// Capture the authoritative display characteristics learned at the search

--- a/crates/engine/src/types/action_rejection.rs
+++ b/crates/engine/src/types/action_rejection.rs
@@ -15,6 +15,7 @@ pub enum ActionRejectionCode {
     InteractionUnavailable,
     InteractionNotAuthorized,
     StaleInteraction,
+    StaleAction,
     InvalidInteractionResponse,
     InteractionPayloadTooLarge,
     InteractionConstraintUnsatisfied,
@@ -53,7 +54,7 @@ impl ActionRejectionCode {
             | Self::InteractionUnavailable
             | Self::InteractionCancelOnly
             | Self::ResolveAllNotReady => ActionRejectionDisposition::Unavailable,
-            Self::StaleInteraction => ActionRejectionDisposition::Stale,
+            Self::StaleInteraction | Self::StaleAction => ActionRejectionDisposition::Stale,
             Self::UnsupportedInteractionResponse => ActionRejectionDisposition::Unsupported,
         }
     }
@@ -69,6 +70,7 @@ impl ActionRejectionCode {
             Self::InteractionUnavailable => "That interaction is no longer available.",
             Self::InteractionNotAuthorized => "You are not authorized to answer that interaction.",
             Self::StaleInteraction => "That interaction has already changed.",
+            Self::StaleAction => "That action is based on outdated game state.",
             Self::InvalidInteractionResponse => "That response is not valid for this interaction.",
             Self::InteractionPayloadTooLarge => "That interaction response is too large.",
             Self::InteractionConstraintUnsatisfied => {

--- a/crates/engine/src/types/action_rejection.rs
+++ b/crates/engine/src/types/action_rejection.rs
@@ -1,0 +1,110 @@
+//! Ephemeral, viewer-filterable action rejection metadata.
+
+use serde::{Deserialize, Serialize};
+
+use super::identifiers::ObjectId;
+
+/// Stable machine-readable reason for an action the engine did not apply.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionRejectionCode {
+    InvalidAction,
+    WrongPlayer,
+    NotYourPriority,
+    ActionNotAllowed,
+    InteractionUnavailable,
+    InteractionNotAuthorized,
+    StaleInteraction,
+    InvalidInteractionResponse,
+    InteractionPayloadTooLarge,
+    InteractionConstraintUnsatisfied,
+    InteractionCancelOnly,
+    InteractionReducerRejected,
+    UnsupportedInteractionResponse,
+    ResolveAllNotReady,
+}
+
+/// Broad client-recovery category for an [`ActionRejectionCode`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum ActionRejectionDisposition {
+    Invalid,
+    Unauthorized,
+    Unavailable,
+    Stale,
+    Unsupported,
+}
+
+impl ActionRejectionCode {
+    /// The closed recovery category for this code.
+    pub const fn disposition(self) -> ActionRejectionDisposition {
+        match self {
+            Self::InvalidAction
+            | Self::InvalidInteractionResponse
+            | Self::InteractionPayloadTooLarge
+            | Self::InteractionConstraintUnsatisfied
+            | Self::InteractionReducerRejected => ActionRejectionDisposition::Invalid,
+            Self::WrongPlayer | Self::InteractionNotAuthorized => {
+                ActionRejectionDisposition::Unauthorized
+            }
+            Self::NotYourPriority
+            | Self::ActionNotAllowed
+            | Self::InteractionUnavailable
+            | Self::InteractionCancelOnly
+            | Self::ResolveAllNotReady => ActionRejectionDisposition::Unavailable,
+            Self::StaleInteraction => ActionRejectionDisposition::Stale,
+            Self::UnsupportedInteractionResponse => ActionRejectionDisposition::Unsupported,
+        }
+    }
+
+    /// Safe static text for this code. Dynamic engine errors never cross this
+    /// boundary because every mapping terminates in this closed enum.
+    pub const fn message(self) -> &'static str {
+        match self {
+            Self::InvalidAction => "That action is not valid in the current game state.",
+            Self::WrongPlayer => "That action belongs to a different player.",
+            Self::NotYourPriority => "You do not currently have priority.",
+            Self::ActionNotAllowed => "That action is not allowed right now.",
+            Self::InteractionUnavailable => "That interaction is no longer available.",
+            Self::InteractionNotAuthorized => "You are not authorized to answer that interaction.",
+            Self::StaleInteraction => "That interaction has already changed.",
+            Self::InvalidInteractionResponse => "That response is not valid for this interaction.",
+            Self::InteractionPayloadTooLarge => "That interaction response is too large.",
+            Self::InteractionConstraintUnsatisfied => {
+                "That response does not satisfy the interaction constraints."
+            }
+            Self::InteractionCancelOnly => "This interaction can only be cancelled.",
+            Self::InteractionReducerRejected => "That interaction can no longer be applied.",
+            Self::UnsupportedInteractionResponse => "That interaction response is not supported.",
+            Self::ResolveAllNotReady => "Resolve All is not ready to run.",
+        }
+    }
+}
+
+/// A stable, safe explanation for an action the engine did not apply.
+///
+/// This is deliberately a boundary result rather than `GameState` data: a
+/// rejection describes one attempted action and must never be persisted into a
+/// game or exposed to another viewer by default.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct ActionRejection {
+    /// Stable machine-readable reason code.
+    pub code: ActionRejectionCode,
+    /// Stable broad category suitable for client recovery policy.
+    pub disposition: ActionRejectionDisposition,
+    /// Safe, non-diagnostic display text.
+    pub message: String,
+    /// Object identities referred to by the rejected action, after projection.
+    pub related_object_ids: Vec<ObjectId>,
+}
+
+impl ActionRejection {
+    pub(crate) fn from_code(code: ActionRejectionCode, related_object_ids: Vec<ObjectId>) -> Self {
+        Self {
+            disposition: code.disposition(),
+            message: code.message().to_string(),
+            code,
+            related_object_ids,
+        }
+    }
+}

--- a/crates/engine/src/types/action_rejection.rs
+++ b/crates/engine/src/types/action_rejection.rs
@@ -22,6 +22,7 @@ pub enum ActionRejectionCode {
     InteractionReducerRejected,
     UnsupportedInteractionResponse,
     ResolveAllNotReady,
+    DebugPermissionDenied,
 }
 
 /// Broad client-recovery category for an [`ActionRejectionCode`].
@@ -44,7 +45,7 @@ impl ActionRejectionCode {
             | Self::InteractionPayloadTooLarge
             | Self::InteractionConstraintUnsatisfied
             | Self::InteractionReducerRejected => ActionRejectionDisposition::Invalid,
-            Self::WrongPlayer | Self::InteractionNotAuthorized => {
+            Self::WrongPlayer | Self::InteractionNotAuthorized | Self::DebugPermissionDenied => {
                 ActionRejectionDisposition::Unauthorized
             }
             Self::NotYourPriority
@@ -77,6 +78,7 @@ impl ActionRejectionCode {
             Self::InteractionReducerRejected => "That interaction can no longer be applied.",
             Self::UnsupportedInteractionResponse => "That interaction response is not supported.",
             Self::ResolveAllNotReady => "Resolve All is not ready to run.",
+            Self::DebugPermissionDenied => "You are not authorized to use debug actions.",
         }
     }
 }
@@ -99,12 +101,19 @@ pub struct ActionRejection {
 }
 
 impl ActionRejection {
-    pub(crate) fn from_code(code: ActionRejectionCode, related_object_ids: Vec<ObjectId>) -> Self {
+    /// Builds a rejection with no object identities.
+    pub fn new(code: ActionRejectionCode) -> Self {
         Self {
             disposition: code.disposition(),
             message: code.message().to_string(),
             code,
-            related_object_ids,
+            related_object_ids: vec![],
         }
+    }
+
+    pub(crate) fn from_code(code: ActionRejectionCode, related_object_ids: Vec<ObjectId>) -> Self {
+        let mut rejection = Self::new(code);
+        rejection.related_object_ids = related_object_ids;
+        rejection
     }
 }

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -1294,6 +1294,49 @@ impl DebugTokenRequest {
 }
 
 impl DebugAction {
+    fn related_object_ids(&self, ids: &mut Vec<ObjectId>) {
+        match self {
+            Self::MoveToZone { object_id, .. }
+            | Self::RemoveObject { object_id }
+            | Self::Sacrifice { object_id }
+            | Self::SetBasePowerToughness { object_id, .. }
+            | Self::ModifyCounters { object_id, .. }
+            | Self::SetTapped { object_id, .. }
+            | Self::SetPrepared { object_id, .. }
+            | Self::SetController { object_id, .. }
+            | Self::SetSummoningSickness { object_id, .. }
+            | Self::SetFaceState { object_id, .. }
+            | Self::Detach { object_id }
+            | Self::GrantKeyword { object_id, .. }
+            | Self::RemoveKeyword { object_id, .. } => push_related_object_id(ids, *object_id),
+            Self::CreateCard { attach_to, .. } => {
+                if let Some(AttachTarget::Object(object_id)) = attach_to {
+                    push_related_object_id(ids, *object_id);
+                }
+            }
+            Self::Attach { object_id, target } => {
+                push_related_object_id(ids, *object_id);
+                if let AttachTarget::Object(target_id) = target {
+                    push_related_object_id(ids, *target_id);
+                }
+            }
+            Self::CreateTokenCopy { source_id, .. } => push_related_object_id(ids, *source_id),
+            Self::DrawCards { .. }
+            | Self::Mill { .. }
+            | Self::Reveal { .. }
+            | Self::ShuffleLibrary { .. }
+            | Self::Proliferate { .. }
+            | Self::SetLife { .. }
+            | Self::ModifyPlayerCounters { .. }
+            | Self::ModifyEnergy { .. }
+            | Self::AddMana { .. }
+            | Self::SetInfiniteMana { .. }
+            | Self::SetPhase { .. }
+            | Self::RunStateBasedActions
+            | Self::CreateToken { .. } => {}
+        }
+    }
+
     /// A zero-count create request is an authorized, state-preserving no-op.
     /// The action boundary recognizes it before lifecycle/finalization work so
     /// UI count controls can submit zero without invalidating replays.
@@ -1587,6 +1630,30 @@ fn default_one() -> u32 {
     1
 }
 
+fn push_related_object_id(ids: &mut Vec<ObjectId>, object_id: ObjectId) {
+    if !ids.contains(&object_id) {
+        ids.push(object_id);
+    }
+}
+
+fn push_target_ref(ids: &mut Vec<ObjectId>, target: &TargetRef) {
+    if let TargetRef::Object(object_id) = target {
+        push_related_object_id(ids, *object_id);
+    }
+}
+
+fn push_target_refs(ids: &mut Vec<ObjectId>, targets: &[TargetRef]) {
+    for target in targets {
+        push_target_ref(ids, target);
+    }
+}
+
+fn push_attack_target(ids: &mut Vec<ObjectId>, target: &AttackTarget) {
+    if let AttackTarget::Planeswalker(object_id) = target {
+        push_related_object_id(ids, *object_id);
+    }
+}
+
 impl GameAction {
     /// Returns the enum variant name as a static string (e.g., `"CastSpell"`, `"PassPriority"`).
     /// Useful for structured logging without the full `Debug` representation.
@@ -1654,6 +1721,280 @@ impl GameAction {
             | GameAction::CastSpellAsWebSlinging { payment_mode, .. } => Some(payment_mode),
             _ => None,
         }
+    }
+
+    /// Object identities explicitly named by this action, in first-seen payload
+    /// order with duplicates removed. This is deliberately exhaustive so a new
+    /// action variant cannot silently omit identities from a rejection.
+    pub fn related_object_ids(&self) -> Vec<ObjectId> {
+        let mut ids = Vec::new();
+        match self {
+            Self::PassPriority
+            | Self::ChooseExert { .. }
+            | Self::ChooseClashOpponent { .. }
+            | Self::ChooseZoneOpponentChooser { .. }
+            | Self::ChoosePileOpponent { .. }
+            | Self::ChooseAnnouncingOpponent { .. }
+            | Self::ChooseGiftRecipient { .. }
+            | Self::ChooseAssistPlayer { .. }
+            | Self::CommitAssistPayment { .. }
+            | Self::BackToManaPayment
+            | Self::SpendPoolMana { .. }
+            | Self::UnspendPoolMana { .. }
+            | Self::SelectCoinFlips { .. }
+            | Self::ChooseReplacement { .. }
+            | Self::ChooseEntryController { .. }
+            | Self::OrderTriggers { .. }
+            | Self::CancelCast
+            | Self::SubmitSideboard { .. }
+            | Self::ChoosePlayDraw { .. }
+            | Self::ChooseOption { .. }
+            | Self::SubmitVoteCandidate { .. }
+            | Self::SubmitSpellbookDraft { .. }
+            | Self::ChoosePile { .. }
+            | Self::ChooseBranch { .. }
+            | Self::SubmitLifeRedistribution { .. }
+            | Self::SelectModes { .. }
+            | Self::DecideOptionalCost { .. }
+            | Self::ChooseAdventureFace { .. }
+            | Self::ChooseModalFace { .. }
+            | Self::ChooseAlternativeCast { .. }
+            | Self::ChooseCastingVariant { .. }
+            | Self::KeepAllCopyTargets
+            | Self::ChoosePermanentTypeSlot { .. }
+            | Self::DecideOptionalEffect { .. }
+            | Self::DecideOptionalEffectAndRemember { .. }
+            | Self::PayUnlessCost { .. }
+            | Self::ChooseUnlessCostBranch { .. }
+            | Self::ChooseActivationCostBranch { .. }
+            | Self::PayCombatTax { .. }
+            | Self::ChooseDungeon { .. }
+            | Self::ChooseDungeonRoom { .. }
+            | Self::RollPlanarDie
+            | Self::DeclareCompanion { .. }
+            | Self::CompanionToHand
+            | Self::DiscoverChoice { .. }
+            | Self::GraveyardPaidCastChoice { .. }
+            | Self::CascadeChoice { .. }
+            | Self::RippleChoice { .. }
+            | Self::ChooseTopOrBottom { .. }
+            | Self::ChooseMutateMergeSide { .. }
+            | Self::ChooseBattleProtector { .. }
+            | Self::SetAutoPass { .. }
+            | Self::CancelAutoPass
+            | Self::SetPhaseStops { .. }
+            | Self::SetPriorityPassingMode { .. }
+            | Self::SetMayTriggerAutoChoice { .. }
+            | Self::SetTriggerOrderTemplate { .. }
+            | Self::ChooseCountersToRemove { .. }
+            | Self::SubmitPayAmount { .. }
+            | Self::ChooseX { .. }
+            | Self::SubmitPhyrexianChoices { .. }
+            | Self::ChooseManaColor { .. }
+            | Self::PayManaAbilityMana { .. }
+            | Self::ChooseSpecializeColor { .. }
+            | Self::PassParadigmOffer
+            | Self::GrantDebugPermission { .. }
+            | Self::RevokeDebugPermission { .. }
+            | Self::Concede { .. }
+            | Self::DeclareShortcut { .. }
+            | Self::RespondToShortcut { .. }
+            | Self::DeclineShortcut
+            | Self::PrecastCopyShortcut { .. }
+            | Self::EndContinuousEffect { .. }
+            | Self::BeginResolveAll { .. }
+            | Self::RespondResolveAllConsent { .. }
+            | Self::RevokeResolveAllConsent { .. } => {}
+            Self::ChooseMeldPair {
+                source_id,
+                partner_id,
+            } => {
+                push_related_object_id(&mut ids, *source_id);
+                push_related_object_id(&mut ids, *partner_id);
+            }
+            Self::ChooseEntryAttackTarget { target } => push_attack_target(&mut ids, target),
+            Self::PlayLand { object_id, .. }
+            | Self::Foretell { object_id, .. }
+            | Self::ChooseUntap { object_id, .. }
+            | Self::UntapLandForMana { object_id }
+            | Self::Transform { object_id }
+            | Self::PlayFaceDown { object_id, .. }
+            | Self::TurnFaceUp { object_id, .. }
+            | Self::UnlockRoomDoor { object_id, .. }
+            | Self::ChooseRoomDoor { object_id, .. }
+            | Self::TapForConvoke { object_id, .. }
+            | Self::CastSpellAsMiracle { object_id, .. }
+            | Self::CastSpellAsMadness { object_id, .. } => {
+                push_related_object_id(&mut ids, *object_id)
+            }
+            Self::CastSpell {
+                object_id, targets, ..
+            } => {
+                push_related_object_id(&mut ids, *object_id);
+                push_target_refs(&mut ids, targets);
+            }
+            Self::ActivateAbility { source_id, .. }
+            | Self::ChooseDamageSource { source: source_id }
+            | Self::CastPreparedCopy { source: source_id }
+            | Self::CastParadigmCopy { source: source_id } => {
+                push_related_object_id(&mut ids, *source_id)
+            }
+            Self::DeclareAttackers { attacks, bands } => {
+                for (attacker, target) in attacks {
+                    push_related_object_id(&mut ids, *attacker);
+                    push_attack_target(&mut ids, target);
+                }
+                for band in bands {
+                    for object_id in band {
+                        push_related_object_id(&mut ids, *object_id);
+                    }
+                }
+            }
+            Self::DeclareBlockers { assignments } => {
+                for (blocker, attacker) in assignments {
+                    push_related_object_id(&mut ids, *blocker);
+                    push_related_object_id(&mut ids, *attacker);
+                }
+            }
+            Self::ChooseEnlist { target }
+            | Self::ChoosePair { partner: target }
+            | Self::RespondToSpliceOffer { card: target }
+            | Self::HarmonizeTap {
+                creature_id: target,
+            }
+            | Self::FreeCastWindowChoice { selection: target }
+            | Self::CipherEncode { creature: target } => {
+                if let Some(object_id) = target {
+                    push_related_object_id(&mut ids, *object_id);
+                }
+            }
+            Self::MulliganDecision { choice } => {
+                if let MulliganChoice::UseSerumPowder { object_id } = choice {
+                    push_related_object_id(&mut ids, *object_id);
+                }
+            }
+            Self::ReorderHand { order }
+            | Self::SelectCards { cards: order }
+            | Self::SubmitPilePartition { pile_a: order }
+            | Self::ChooseKeptCreatures { kept: order }
+            | Self::ChooseKeptPermanents { kept: order } => {
+                for object_id in order {
+                    push_related_object_id(&mut ids, *object_id);
+                }
+            }
+            Self::TapLandForMana { selection } | Self::ActivateManaSource { selection } => {
+                push_related_object_id(&mut ids, selection.source.object_id);
+            }
+            Self::ChooseRemoveCounterCostDistribution { distribution } => {
+                for choice in distribution {
+                    push_related_object_id(&mut ids, choice.object_id);
+                }
+            }
+            Self::ChooseOutsideGameCards { selections } => {
+                for selection in selections {
+                    if let OutsideGameSelection::FaceUpExile { object_id } = selection {
+                        push_related_object_id(&mut ids, *object_id);
+                    }
+                }
+            }
+            Self::SelectTargets { targets } => push_target_refs(&mut ids, targets),
+            Self::ChooseTarget { target } => {
+                if let Some(target) = target {
+                    push_target_ref(&mut ids, target);
+                }
+            }
+            Self::Equip {
+                equipment_id,
+                target_id,
+            } => {
+                push_related_object_id(&mut ids, *equipment_id);
+                push_related_object_id(&mut ids, *target_id);
+            }
+            Self::CrewVehicle {
+                vehicle_id,
+                creature_ids,
+            }
+            | Self::SaddleMount {
+                mount_id: vehicle_id,
+                creature_ids,
+            } => {
+                push_related_object_id(&mut ids, *vehicle_id);
+                for object_id in creature_ids {
+                    push_related_object_id(&mut ids, *object_id);
+                }
+            }
+            Self::ActivateStation {
+                spacecraft_id,
+                creature_id,
+            } => {
+                push_related_object_id(&mut ids, *spacecraft_id);
+                if let Some(object_id) = creature_id {
+                    push_related_object_id(&mut ids, *object_id);
+                }
+            }
+            Self::ChooseRingBearer { target } | Self::ChooseLegend { keep: target } => {
+                push_related_object_id(&mut ids, *target);
+            }
+            Self::ActivateNinjutsu {
+                ninjutsu_object_id,
+                creature_to_return,
+            }
+            | Self::CastSpellAsSneak {
+                hand_object: ninjutsu_object_id,
+                creature_to_return,
+                ..
+            }
+            | Self::CastSpellAsWebSlinging {
+                hand_object: ninjutsu_object_id,
+                creature_to_return,
+                ..
+            } => {
+                push_related_object_id(&mut ids, *ninjutsu_object_id);
+                push_related_object_id(&mut ids, *creature_to_return);
+            }
+            Self::CastSpellForFree {
+                object_id,
+                source_id,
+                ..
+            } => {
+                push_related_object_id(&mut ids, *object_id);
+                push_related_object_id(&mut ids, *source_id);
+            }
+            Self::SetPriorityYield { op } => {
+                if let PriorityYieldOp::Add { source_id, .. } = op {
+                    push_related_object_id(&mut ids, *source_id);
+                }
+            }
+            Self::AssignCombatDamage { assignments, .. }
+            | Self::AssignBlockerDamage { assignments } => {
+                for (object_id, _) in assignments {
+                    push_related_object_id(&mut ids, *object_id);
+                }
+            }
+            Self::DistributeAmong { distribution } => {
+                for (target, _) in distribution {
+                    push_target_ref(&mut ids, target);
+                }
+            }
+            Self::ChooseCounterMoveDistribution { selections } => {
+                for selection in selections {
+                    push_related_object_id(&mut ids, selection.destination_id);
+                }
+            }
+            Self::RetargetSpell { new_targets } => push_target_refs(&mut ids, new_targets),
+            Self::LearnDecision { choice } => {
+                if let LearnOption::Rummage { card_id } = choice {
+                    push_related_object_id(&mut ids, *card_id);
+                }
+            }
+            Self::SelectCategoryPermanents { choices } => {
+                for object_id in choices.iter().flatten() {
+                    push_related_object_id(&mut ids, *object_id);
+                }
+            }
+            Self::Debug(action) => action.related_object_ids(&mut ids),
+        }
+        ids
     }
 
     /// Engine-side authoritative mapping from action → permanent it acts on.

--- a/crates/engine/src/types/actions.rs
+++ b/crates/engine/src/types/actions.rs
@@ -15,6 +15,10 @@ use super::match_config::DeckCardCount;
 use super::phase::Phase;
 use super::player::{PlayerCounterKind, PlayerId};
 use super::zones::Zone;
+use crate::analysis::decision_template::{
+    AnnouncementSubject, DecisionSlot, DecisionTemplate, PinnedDecision, Ranking, TargetPin,
+    TargetSchedule,
+};
 use crate::game::combat::AttackTarget;
 use crate::game::game_object::AttachTarget;
 
@@ -1649,8 +1653,87 @@ fn push_target_refs(ids: &mut Vec<ObjectId>, targets: &[TargetRef]) {
 }
 
 fn push_attack_target(ids: &mut Vec<ObjectId>, target: &AttackTarget) {
-    if let AttackTarget::Planeswalker(object_id) = target {
-        push_related_object_id(ids, *object_id);
+    match target {
+        AttackTarget::Player(_) => {}
+        AttackTarget::Planeswalker(object_id) | AttackTarget::Battle(object_id) => {
+            push_related_object_id(ids, *object_id);
+        }
+    }
+}
+
+fn push_yield_target(ids: &mut Vec<ObjectId>, target: &YieldTarget) {
+    match target {
+        YieldTarget::ThisObject { source_id, .. } => push_related_object_id(ids, *source_id),
+        YieldTarget::AllCopies { .. } => {}
+    }
+}
+
+fn push_decision_slot(ids: &mut Vec<ObjectId>, slot: &DecisionSlot) {
+    push_yield_target(ids, &slot.source);
+}
+
+fn push_ranking(ids: &mut Vec<ObjectId>, ranking: &Ranking) {
+    for subject in ranking.iter() {
+        match subject {
+            AnnouncementSubject::Object(source) => push_yield_target(ids, source),
+            AnnouncementSubject::Seat(_) => {}
+        }
+    }
+}
+
+fn push_target_schedule(ids: &mut Vec<ObjectId>, schedule: &TargetSchedule) {
+    match schedule {
+        TargetSchedule::Constant(ranking) => {
+            push_ranking(ids, ranking);
+        }
+        TargetSchedule::RoundRobin(rankings) => {
+            for ranking in rankings {
+                push_ranking(ids, ranking);
+            }
+        }
+        TargetSchedule::Piecewise(steps) => {
+            for (_, ranking) in steps {
+                push_ranking(ids, ranking);
+            }
+        }
+    }
+}
+
+fn push_target_pin(ids: &mut Vec<ObjectId>, pin: &TargetPin) {
+    match pin {
+        TargetPin::ByIdentity(source) => {
+            push_yield_target(ids, source);
+        }
+        TargetPin::Player(_) => {}
+        TargetPin::Scheduled(schedule) => {
+            push_target_schedule(ids, schedule);
+        }
+    }
+}
+
+fn push_decision_template(ids: &mut Vec<ObjectId>, template: &DecisionTemplate) {
+    for (source, _) in &template.key.sources {
+        push_yield_target(ids, source);
+    }
+    for decision in &template.decisions {
+        match decision {
+            PinnedDecision::Order { source, .. } => {
+                push_yield_target(ids, source);
+            }
+            PinnedDecision::Targets { slot, targets } => {
+                push_decision_slot(ids, slot);
+                for target in targets {
+                    push_target_pin(ids, target);
+                }
+            }
+            PinnedDecision::Mode { slot, .. }
+            | PinnedDecision::MayChoice { slot, .. }
+            | PinnedDecision::UnlessBreak { slot, .. }
+            | PinnedDecision::ConvokeTaps { slot }
+            | PinnedDecision::ManaColor { slot, .. } => {
+                push_decision_slot(ids, slot);
+            }
+        }
     }
 }
 
@@ -1784,7 +1867,6 @@ impl GameAction {
             | Self::CancelAutoPass
             | Self::SetPhaseStops { .. }
             | Self::SetPriorityPassingMode { .. }
-            | Self::SetMayTriggerAutoChoice { .. }
             | Self::SetTriggerOrderTemplate { .. }
             | Self::ChooseCountersToRemove { .. }
             | Self::SubmitPayAmount { .. }
@@ -1797,7 +1879,6 @@ impl GameAction {
             | Self::GrantDebugPermission { .. }
             | Self::RevokeDebugPermission { .. }
             | Self::Concede { .. }
-            | Self::DeclareShortcut { .. }
             | Self::RespondToShortcut { .. }
             | Self::DeclineShortcut
             | Self::PrecastCopyShortcut { .. }
@@ -1831,7 +1912,9 @@ impl GameAction {
                 object_id, targets, ..
             } => {
                 push_related_object_id(&mut ids, *object_id);
-                push_target_refs(&mut ids, targets);
+                for target in targets {
+                    push_related_object_id(&mut ids, *target);
+                }
             }
             Self::ActivateAbility { source_id, .. }
             | Self::ChooseDamageSource { source: source_id }
@@ -1960,9 +2043,25 @@ impl GameAction {
                 push_related_object_id(&mut ids, *object_id);
                 push_related_object_id(&mut ids, *source_id);
             }
-            Self::SetPriorityYield { op } => {
-                if let PriorityYieldOp::Add { source_id, .. } = op {
+            Self::SetPriorityYield { op } => match op {
+                PriorityYieldOp::Add { source_id, .. } => {
                     push_related_object_id(&mut ids, *source_id);
+                }
+                PriorityYieldOp::Remove { target } => push_yield_target(&mut ids, target),
+                PriorityYieldOp::ClearAll => {}
+            },
+            Self::SetMayTriggerAutoChoice { op } => match op {
+                MayTriggerAutoChoiceOp::Remove { selector } => match selector {
+                    MayTriggerAutoChoiceSelector::ExactInstance { source_id, .. } => {
+                        push_related_object_id(&mut ids, *source_id);
+                    }
+                    MayTriggerAutoChoiceSelector::SameCard { .. } => {}
+                },
+                MayTriggerAutoChoiceOp::ClearAll => {}
+            },
+            Self::DeclareShortcut { template, .. } => {
+                if let Some(template) = template {
+                    push_decision_template(&mut ids, template);
                 }
             }
             Self::AssignCombatDamage { assignments, .. }

--- a/crates/engine/src/types/mod.rs
+++ b/crates/engine/src/types/mod.rs
@@ -1,5 +1,6 @@
 pub mod ability;
 pub mod ability_visit;
+pub mod action_rejection;
 pub mod action_stable_order;
 pub mod actions;
 pub mod attribution;
@@ -39,6 +40,7 @@ pub use ability::{
     ReplacementDefinition, ResolvedAbility, StaticCondition, StaticDefinition, TargetFilter,
     TargetRef, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter,
 };
+pub use action_rejection::{ActionRejection, ActionRejectionCode, ActionRejectionDisposition};
 pub use actions::GameAction;
 pub use attribution::{EffectRef, ObjectAttribution};
 pub use card::{CardFace, CardLayout, CardRules, Rarity};

--- a/crates/engine/tests/integration/action_rejection.rs
+++ b/crates/engine/tests/integration/action_rejection.rs
@@ -1,0 +1,205 @@
+use engine::game::engine::{apply, apply_with_rejection};
+use engine::game::interaction::submit_interaction_with_rejection;
+use engine::game::preview::preview_action_with_rejection;
+use engine::game::scenario::{P0, P1};
+use engine::game::visibility::filter_action_rejection_for_viewer;
+use engine::game::zones::create_object;
+use engine::types::action_rejection::{
+    ActionRejection, ActionRejectionCode, ActionRejectionDisposition,
+};
+use engine::types::actions::GameAction;
+use engine::types::game_state::GameState;
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::interaction::{
+    InteractionChoiceId, InteractionId, InteractionResponse, InteractionSubmission,
+};
+use engine::types::zones::Zone;
+
+#[test]
+fn rejection_dto_serializes_only_stable_safe_fields() {
+    let rejection = ActionRejection {
+        code: ActionRejectionCode::InvalidAction,
+        disposition: ActionRejectionDisposition::Invalid,
+        message: "That action is not valid in the current game state.".to_string(),
+        related_object_ids: vec![ObjectId(7)],
+    };
+
+    assert_eq!(
+        serde_json::to_value(rejection).expect("rejection serializes"),
+        serde_json::json!({
+            "code": "invalid_action",
+            "disposition": "invalid",
+            "message": "That action is not valid in the current game state.",
+            "related_object_ids": [7],
+        })
+    );
+}
+
+#[test]
+fn every_rejection_code_has_a_closed_disposition_and_safe_message() {
+    let cases = [
+        (
+            ActionRejectionCode::InvalidAction,
+            ActionRejectionDisposition::Invalid,
+        ),
+        (
+            ActionRejectionCode::WrongPlayer,
+            ActionRejectionDisposition::Unauthorized,
+        ),
+        (
+            ActionRejectionCode::NotYourPriority,
+            ActionRejectionDisposition::Unavailable,
+        ),
+        (
+            ActionRejectionCode::ActionNotAllowed,
+            ActionRejectionDisposition::Unavailable,
+        ),
+        (
+            ActionRejectionCode::InteractionUnavailable,
+            ActionRejectionDisposition::Unavailable,
+        ),
+        (
+            ActionRejectionCode::InteractionNotAuthorized,
+            ActionRejectionDisposition::Unauthorized,
+        ),
+        (
+            ActionRejectionCode::StaleInteraction,
+            ActionRejectionDisposition::Stale,
+        ),
+        (
+            ActionRejectionCode::InvalidInteractionResponse,
+            ActionRejectionDisposition::Invalid,
+        ),
+        (
+            ActionRejectionCode::InteractionPayloadTooLarge,
+            ActionRejectionDisposition::Invalid,
+        ),
+        (
+            ActionRejectionCode::InteractionConstraintUnsatisfied,
+            ActionRejectionDisposition::Invalid,
+        ),
+        (
+            ActionRejectionCode::InteractionCancelOnly,
+            ActionRejectionDisposition::Unavailable,
+        ),
+        (
+            ActionRejectionCode::InteractionReducerRejected,
+            ActionRejectionDisposition::Invalid,
+        ),
+        (
+            ActionRejectionCode::UnsupportedInteractionResponse,
+            ActionRejectionDisposition::Unsupported,
+        ),
+        (
+            ActionRejectionCode::ResolveAllNotReady,
+            ActionRejectionDisposition::Unavailable,
+        ),
+    ];
+
+    for (code, disposition) in cases {
+        assert_eq!(code.disposition(), disposition);
+        assert!(!code.message().is_empty());
+    }
+}
+
+#[test]
+fn related_object_ids_are_first_seen_and_deduplicated() {
+    let action = GameAction::CastSpell {
+        object_id: ObjectId(3),
+        card_id: CardId(1),
+        targets: vec![
+            engine::types::TargetRef::Object(ObjectId(9)),
+            engine::types::TargetRef::Object(ObjectId(3)),
+            engine::types::TargetRef::Object(ObjectId(9)),
+        ],
+        payment_mode: Default::default(),
+    };
+
+    assert_eq!(action.related_object_ids(), vec![ObjectId(3), ObjectId(9)]);
+}
+
+#[test]
+fn rejection_projection_removes_hidden_object_ids() {
+    let mut state = GameState::new_two_player(1);
+    let hidden = create_object(
+        &mut state,
+        CardId(2),
+        P1,
+        "Private card".to_string(),
+        Zone::Hand,
+    );
+    state
+        .players
+        .iter_mut()
+        .find(|player| player.id == P1)
+        .expect("opponent exists")
+        .hand
+        .push_back(hidden);
+    let rejection = ActionRejection {
+        code: ActionRejectionCode::InvalidAction,
+        disposition: ActionRejectionDisposition::Invalid,
+        message: "That action is not valid in the current game state.".to_string(),
+        related_object_ids: vec![hidden],
+    };
+
+    assert!(filter_action_rejection_for_viewer(&state, P0, &rejection)
+        .related_object_ids
+        .is_empty());
+    assert_eq!(
+        filter_action_rejection_for_viewer(&state, P1, &rejection).related_object_ids,
+        vec![hidden]
+    );
+}
+
+#[test]
+fn rich_apply_preserves_legacy_rejection_and_state() {
+    let action = GameAction::PlayLand {
+        object_id: ObjectId(999),
+        card_id: CardId(1),
+    };
+    let mut legacy = GameState::new_two_player(1);
+    let mut rich = legacy.clone();
+
+    assert!(apply(&mut legacy, P0, action.clone()).is_err());
+    let rejection = apply_with_rejection(&mut rich, P0, action).expect_err("action rejects");
+
+    assert_eq!(rejection.code, ActionRejectionCode::InvalidAction);
+    assert_eq!(
+        legacy, rich,
+        "rich wrapper must preserve legacy mutation semantics"
+    );
+}
+
+#[test]
+fn opaque_interaction_rejection_before_materialization_has_no_object_ids() {
+    let mut state = GameState::new_two_player(1);
+    let rejection = submit_interaction_with_rejection(
+        &mut state,
+        P0,
+        InteractionSubmission {
+            interaction_id: InteractionId("missing".to_string()),
+            response: InteractionResponse::Choose {
+                choice_id: InteractionChoiceId("choice".to_string()),
+            },
+        },
+    )
+    .expect_err("unknown opaque interaction rejects");
+
+    assert!(rejection.related_object_ids.is_empty());
+}
+
+#[test]
+fn rich_action_preview_does_not_mutate_state() {
+    let state = GameState::new_two_player(1);
+    let before = state.clone();
+    let _ = preview_action_with_rejection(
+        &state,
+        P0,
+        &GameAction::PlayLand {
+            object_id: ObjectId(999),
+            card_id: CardId(1),
+        },
+    );
+
+    assert_eq!(state, before);
+}

--- a/crates/engine/tests/integration/action_rejection.rs
+++ b/crates/engine/tests/integration/action_rejection.rs
@@ -1,18 +1,37 @@
-use engine::game::engine::{apply, apply_with_rejection};
-use engine::game::interaction::submit_interaction_with_rejection;
-use engine::game::preview::preview_action_with_rejection;
+use engine::analysis::decision_template::{
+    AnnouncementSubject, DecisionGroupKey, DecisionKind, DecisionSlot, DecisionTemplate,
+    IterationCount, MayChoiceOption, PinnedDecision, Ranking, ReplayMode, TargetPin,
+    TargetSchedule, UnlessPaymentOption,
+};
+use engine::game::combat::AttackTarget;
+use engine::game::engine::{
+    apply, apply_with_rejection, preflight_debug_action, preflight_debug_action_with_rejection,
+    resolve_all_ready_prefix_with_rejection,
+};
+use engine::game::interaction::{
+    bind_interaction_authority, derive_viewer_interaction, preview_interaction,
+    preview_interaction_with_rejection, submit_interaction_with_rejection,
+};
+use engine::game::preview::{
+    preview_action_with_rejection, preview_auto_payment_sources,
+    preview_auto_payment_sources_with_rejection,
+};
 use engine::game::scenario::{P0, P1};
 use engine::game::visibility::filter_action_rejection_for_viewer;
 use engine::game::zones::create_object;
 use engine::types::action_rejection::{
     ActionRejection, ActionRejectionCode, ActionRejectionDisposition,
 };
-use engine::types::actions::GameAction;
-use engine::types::game_state::GameState;
+use engine::types::actions::{DebugAction, GameAction, MayTriggerAutoChoiceOp, PriorityYieldOp};
+use engine::types::game_state::{
+    GameState, MayTriggerAutoChoiceSelector, MayTriggerOrigin, WaitingFor, YieldTarget,
+};
 use engine::types::identifiers::{CardId, ObjectId};
 use engine::types::interaction::{
-    InteractionChoiceId, InteractionId, InteractionResponse, InteractionSubmission,
+    InteractionAvailability, InteractionChoiceId, InteractionId, InteractionPreviewRequest,
+    InteractionResponse, InteractionSessionId, InteractionSubmission, PreviewRequestId,
 };
+use engine::types::mana::ManaColor;
 use engine::types::zones::Zone;
 
 #[test]
@@ -107,15 +126,133 @@ fn related_object_ids_are_first_seen_and_deduplicated() {
     let action = GameAction::CastSpell {
         object_id: ObjectId(3),
         card_id: CardId(1),
-        targets: vec![
-            engine::types::TargetRef::Object(ObjectId(9)),
-            engine::types::TargetRef::Object(ObjectId(3)),
-            engine::types::TargetRef::Object(ObjectId(9)),
-        ],
+        targets: vec![ObjectId(9), ObjectId(3), ObjectId(9)],
         payment_mode: Default::default(),
     };
 
     assert_eq!(action.related_object_ids(), vec![ObjectId(3), ObjectId(9)]);
+}
+
+#[test]
+fn related_object_ids_cover_battle_and_nested_source_carriers() {
+    let battle = GameAction::DeclareAttackers {
+        attacks: vec![(ObjectId(1), AttackTarget::Battle(ObjectId(2)))],
+        bands: vec![],
+    };
+    assert_eq!(battle.related_object_ids(), vec![ObjectId(1), ObjectId(2)]);
+
+    let yield_remove = GameAction::SetPriorityYield {
+        op: PriorityYieldOp::Remove {
+            target: YieldTarget::ThisObject {
+                source_id: ObjectId(3),
+                incarnation: Some(1),
+                trigger_description: None,
+            },
+        },
+    };
+    assert_eq!(yield_remove.related_object_ids(), vec![ObjectId(3)]);
+
+    let may_remove = GameAction::SetMayTriggerAutoChoice {
+        op: MayTriggerAutoChoiceOp::Remove {
+            selector: MayTriggerAutoChoiceSelector::ExactInstance {
+                player: P0,
+                source_id: ObjectId(4),
+                origin: MayTriggerOrigin::Printed { trigger_index: 0 },
+            },
+        },
+    };
+    assert_eq!(may_remove.related_object_ids(), vec![ObjectId(4)]);
+
+    let source = |object_id| YieldTarget::ThisObject {
+        source_id: Object_id,
+        incarnation: Some(1),
+        trigger_description: None,
+    };
+    let slot = DecisionSlot {
+        source: source(ObjectId(6)),
+        index: 0,
+    };
+    let template = DecisionTemplate {
+        owner: P0,
+        decisions: vec![
+            PinnedDecision::Order {
+                source: source(ObjectId(6)),
+                pos: 0,
+            },
+            PinnedDecision::Targets {
+                slot,
+                targets: vec![
+                    TargetPin::ByIdentity(source(ObjectId(7))),
+                    TargetPin::Scheduled(TargetSchedule::Constant(Ranking::one(
+                        AnnouncementSubject::Object(source(ObjectId(8))),
+                    ))),
+                    TargetPin::Scheduled(TargetSchedule::RoundRobin(vec![Ranking::one(
+                        AnnouncementSubject::Object(source(ObjectId(9))),
+                    )])),
+                    TargetPin::Scheduled(TargetSchedule::Piecewise(vec![(
+                        0,
+                        Ranking::one(AnnouncementSubject::Object(source(ObjectId(10)))),
+                    )])),
+                ],
+            },
+            PinnedDecision::Mode {
+                slot: DecisionSlot {
+                    source: source(ObjectId(11)),
+                    index: 0,
+                },
+                indices: vec![0],
+            },
+            PinnedDecision::MayChoice {
+                slot: DecisionSlot {
+                    source: source(ObjectId(12)),
+                    index: 0,
+                },
+                take: MayChoiceOption::Take,
+            },
+            PinnedDecision::UnlessBreak {
+                slot: DecisionSlot {
+                    source: source(ObjectId(13)),
+                    index: 0,
+                },
+                pay: UnlessPaymentOption::Pay,
+            },
+            PinnedDecision::ConvokeTaps {
+                slot: DecisionSlot {
+                    source: source(ObjectId(14)),
+                    index: 0,
+                },
+            },
+            PinnedDecision::ManaColor {
+                slot: DecisionSlot {
+                    source: source(ObjectId(15)),
+                    index: 0,
+                },
+                color: ManaColor::Blue,
+            },
+        ],
+        replay: ReplayMode::Static,
+        key: DecisionGroupKey::from_sources(&[source(ObjectId(5))], DecisionKind::LoopChoice),
+    };
+    let shortcut = GameAction::DeclareShortcut {
+        count: IterationCount::Fixed(1),
+        template: Some(template),
+    };
+    assert_eq!(
+        shortcut.related_object_ids(),
+        vec![
+            ObjectId(5),
+            ObjectId(6),
+            ObjectId(7),
+            ObjectId(8),
+            ObjectId(9),
+            ObjectId(10),
+            ObjectId(11),
+            ObjectId(12),
+            ObjectId(13),
+            ObjectId(14),
+            ObjectId(15),
+        ]
+    );
 }
 
 #[test]
@@ -202,4 +339,91 @@ fn rich_action_preview_does_not_mutate_state() {
     );
 
     assert_eq!(state, before);
+}
+
+#[test]
+fn rich_auto_payment_preview_preserves_legacy_noop_behavior() {
+    let state = GameState::new_two_player(1);
+    let before = state.clone();
+    let action = GameAction::PassPriority;
+
+    assert_eq!(
+        preview_auto_payment_sources_with_rejection(&state, P0, &action)
+            .expect("non-cast preview is an empty legacy result"),
+        preview_auto_payment_sources(&state, P0, &action)
+            .expect("legacy non-cast preview is empty")
+    );
+    assert_eq!(state, before);
+}
+
+#[test]
+fn rich_interaction_preview_matches_legacy_after_materialization() {
+    let mut state = GameState::new_two_player(1);
+    bind_interaction_authority(
+        &mut state,
+        InteractionSessionId("action-rejection".to_string()),
+    )
+    .expect("interaction authority binds");
+    let filtered = engine::game::visibility::filter_state_for_viewer(&state, P0);
+    let view = derive_viewer_interaction(&state, &filtered, P0);
+    let InteractionAvailability::ProgressAvailable { witness } = view.availability else {
+        panic!("priority interaction has a materializable progress witness");
+    };
+    let request = InteractionPreviewRequest {
+        request_id: PreviewRequestId("preview".to_string()),
+        interaction_id: witness.interaction_id,
+        response: witness.response,
+    };
+    let before = state.clone();
+
+    let legacy = preview_interaction(&state, P0, &request);
+    let rich = preview_interaction_with_rejection(&state, P0, &request)
+        .expect("materialized priority response previews");
+
+    assert_eq!(rich, legacy);
+    assert_eq!(state, before);
+}
+
+#[test]
+fn rich_debug_preflight_is_safe_and_does_not_mutate_state() {
+    let mut state = GameState::new_two_player(1);
+    let object_id = create_object(
+        &mut state,
+        CardId(3),
+        P0,
+        "Visible debug object".to_string(),
+        Zone::Battlefield,
+    );
+    let before = state.clone();
+    let action = DebugAction::RemoveObject { object_id };
+
+    assert!(preflight_debug_action(&state, P0, &action).is_err());
+    let rejection = preflight_debug_action_with_rejection(&state, P0, &action)
+        .expect_err("disabled debug mode rejects the action");
+
+    assert_eq!(rejection.code, ActionRejectionCode::InvalidAction);
+    assert_eq!(
+        rejection.message,
+        "That action is not valid in the current game state."
+    );
+    assert_eq!(rejection.related_object_ids, vec![object_id]);
+    assert_eq!(state, before);
+}
+
+#[test]
+fn rich_resolve_all_rejection_is_safe_and_does_not_mutate_state() {
+    let mut state = GameState::new_two_player(1);
+    let before = state.clone();
+
+    let rejection = resolve_all_ready_prefix_with_rejection(&mut state, P0)
+        .expect_err("a non-Ready state cannot run Resolve All");
+
+    assert_eq!(rejection.code, ActionRejectionCode::ResolveAllNotReady);
+    assert_eq!(rejection.message, "Resolve All is not ready to run.");
+    assert!(rejection.related_object_ids.is_empty());
+    assert_eq!(state, before);
+    assert!(!matches!(
+        state.waiting_for,
+        WaitingFor::ResolveAllReady { .. }
+    ));
 }

--- a/crates/engine/tests/integration/action_rejection.rs
+++ b/crates/engine/tests/integration/action_rejection.rs
@@ -446,6 +446,48 @@ fn rich_debug_preflight_is_safe_and_does_not_mutate_state() {
 }
 
 #[test]
+fn rich_debug_permission_rejections_preserve_visible_object_ids() {
+    let mut state = GameState::new_two_player(1);
+    state.debug_mode = true;
+    state.debug_permitted.insert(P1);
+    let object_id = create_object(
+        &mut state,
+        CardId(3),
+        P0,
+        "Visible debug object".to_string(),
+        Zone::Battlefield,
+    );
+    let action = DebugAction::RemoveObject { object_id };
+    let before = state.clone();
+
+    let apply_rejection = apply_with_rejection(&mut state, P0, GameAction::Debug(action.clone()))
+        .expect_err("an unlisted actor cannot apply a debug action");
+    let preflight_rejection = preflight_debug_action_with_rejection(&state, P0, &action)
+        .expect_err("an unlisted actor cannot preflight a debug action");
+
+    for rejection in [apply_rejection, preflight_rejection] {
+        assert_eq!(rejection.code, ActionRejectionCode::DebugPermissionDenied);
+        assert_eq!(
+            rejection.disposition,
+            ActionRejectionDisposition::Unauthorized
+        );
+        assert_eq!(
+            rejection.message,
+            "You are not authorized to use debug actions."
+        );
+        assert_eq!(rejection.related_object_ids, vec![object_id]);
+    }
+    assert_eq!(state, before);
+
+    state.debug_permitted.insert(P0);
+    preflight_debug_action_with_rejection(&state, P0, &action)
+        .expect("a listed actor can preflight a debug action");
+    apply_with_rejection(&mut state, P0, GameAction::Debug(action))
+        .expect("a listed actor can apply a debug action");
+    assert!(!state.objects.contains_key(&object_id));
+}
+
+#[test]
 fn explicit_debug_permission_allows_an_empty_permission_list_without_mutation() {
     let state = GameState::new_two_player(1);
     let before = state.clone();

--- a/crates/engine/tests/integration/action_rejection.rs
+++ b/crates/engine/tests/integration/action_rejection.rs
@@ -330,7 +330,8 @@ fn rich_apply_preserves_legacy_rejection_and_state() {
     assert!(apply(&mut legacy, P0, action.clone()).is_err());
     let rejection = apply_with_rejection(&mut rich, P0, action).expect_err("action rejects");
 
-    assert_eq!(rejection.code, ActionRejectionCode::InvalidAction);
+    assert_eq!(rejection.code, ActionRejectionCode::ActionNotAllowed);
+    assert_eq!(rejection.message, "That action is not allowed right now.");
     assert_eq!(
         legacy, rich,
         "rich wrapper must preserve legacy mutation semantics"
@@ -366,11 +367,8 @@ fn rich_action_preview_does_not_mutate_state() {
     let rejection = preview_action_with_rejection(&state, P0, &action)
         .expect_err("an invalid action cannot produce a preview");
 
-    assert_eq!(rejection.code, ActionRejectionCode::InvalidAction);
-    assert_eq!(
-        rejection.message,
-        "That action is not valid in the current game state."
-    );
+    assert_eq!(rejection.code, ActionRejectionCode::ActionNotAllowed);
+    assert_eq!(rejection.message, "That action is not allowed right now.");
     assert!(
         rejection.related_object_ids.is_empty(),
         "the unknown object identity must be filtered from the viewer projection"

--- a/crates/engine/tests/integration/action_rejection.rs
+++ b/crates/engine/tests/integration/action_rejection.rs
@@ -464,8 +464,9 @@ fn rich_debug_permission_rejections_preserve_visible_object_ids() {
         .expect_err("an unlisted actor cannot apply a debug action");
     let preflight_rejection = preflight_debug_action_with_rejection(&state, P0, &action)
         .expect_err("an unlisted actor cannot preflight a debug action");
-    let preview_rejection = preview_action_with_rejection(&state, P0, &GameAction::Debug(action.clone()))
-        .expect_err("an unlisted actor cannot preview a debug action");
+    let preview_rejection =
+        preview_action_with_rejection(&state, P0, &GameAction::Debug(action.clone()))
+            .expect_err("an unlisted actor cannot preview a debug action");
 
     for rejection in [apply_rejection, preflight_rejection, preview_rejection] {
         assert_eq!(rejection.code, ActionRejectionCode::DebugPermissionDenied);
@@ -487,6 +488,47 @@ fn rich_debug_permission_rejections_preserve_visible_object_ids() {
     apply_with_rejection(&mut state, P0, GameAction::Debug(action))
         .expect("a listed actor can apply a debug action");
     assert!(!state.objects.contains_key(&object_id));
+}
+
+#[test]
+fn rich_auto_payment_preview_enforces_debug_permission_without_mutation() {
+    let mut state = GameState::new_two_player(1);
+    state.debug_mode = true;
+    state.debug_permitted.insert(P1);
+    let object_id = create_object(
+        &mut state,
+        CardId(3),
+        P0,
+        "Visible debug object".to_string(),
+        Zone::Battlefield,
+    );
+    let action = GameAction::Debug(DebugAction::RemoveObject { object_id });
+    let before = state.clone();
+
+    let rejection = preview_auto_payment_sources_with_rejection(&state, P0, &action)
+        .expect_err("an unlisted actor cannot preview auto-payment for a debug action");
+
+    assert_eq!(rejection.code, ActionRejectionCode::DebugPermissionDenied);
+    assert_eq!(
+        rejection.disposition,
+        ActionRejectionDisposition::Unauthorized
+    );
+    assert_eq!(
+        rejection.message,
+        "You are not authorized to use debug actions."
+    );
+    assert_eq!(rejection.related_object_ids, vec![object_id]);
+    assert_eq!(state, before);
+
+    state.debug_permitted.insert(P0);
+    let permitted_before = state.clone();
+
+    assert_eq!(
+        preview_auto_payment_sources_with_rejection(&state, P0, &action)
+            .expect("a listed actor receives the legacy empty auto-payment preview"),
+        Vec::<ObjectId>::new()
+    );
+    assert_eq!(state, permitted_before);
 }
 
 #[test]

--- a/crates/engine/tests/integration/action_rejection.rs
+++ b/crates/engine/tests/integration/action_rejection.rs
@@ -464,8 +464,10 @@ fn rich_debug_permission_rejections_preserve_visible_object_ids() {
         .expect_err("an unlisted actor cannot apply a debug action");
     let preflight_rejection = preflight_debug_action_with_rejection(&state, P0, &action)
         .expect_err("an unlisted actor cannot preflight a debug action");
+    let preview_rejection = preview_action_with_rejection(&state, P0, &GameAction::Debug(action.clone()))
+        .expect_err("an unlisted actor cannot preview a debug action");
 
-    for rejection in [apply_rejection, preflight_rejection] {
+    for rejection in [apply_rejection, preflight_rejection, preview_rejection] {
         assert_eq!(rejection.code, ActionRejectionCode::DebugPermissionDenied);
         assert_eq!(
             rejection.disposition,

--- a/crates/engine/tests/integration/action_rejection.rs
+++ b/crates/engine/tests/integration/action_rejection.rs
@@ -329,15 +329,22 @@ fn opaque_interaction_rejection_before_materialization_has_no_object_ids() {
 fn rich_action_preview_does_not_mutate_state() {
     let state = GameState::new_two_player(1);
     let before = state.clone();
-    let _ = preview_action_with_rejection(
-        &state,
-        P0,
-        &GameAction::PlayLand {
-            object_id: ObjectId(999),
-            card_id: CardId(1),
-        },
-    );
+    let action = GameAction::PlayLand {
+        object_id: ObjectId(999),
+        card_id: CardId(1),
+    };
+    let rejection = preview_action_with_rejection(&state, P0, &action)
+        .expect_err("an invalid action cannot produce a preview");
 
+    assert_eq!(rejection.code, ActionRejectionCode::InvalidAction);
+    assert_eq!(
+        rejection.message,
+        "That action is not valid in the current game state."
+    );
+    assert!(
+        rejection.related_object_ids.is_empty(),
+        "the unknown object identity must be filtered from the viewer projection"
+    );
     assert_eq!(state, before);
 }
 

--- a/crates/engine/tests/integration/action_rejection.rs
+++ b/crates/engine/tests/integration/action_rejection.rs
@@ -93,6 +93,11 @@ fn every_rejection_code_has_a_closed_disposition_and_safe_message() {
             "stale_interaction",
         ),
         (
+            ActionRejectionCode::StaleAction,
+            ActionRejectionDisposition::Stale,
+            "stale_action",
+        ),
+        (
             ActionRejectionCode::InvalidInteractionResponse,
             ActionRejectionDisposition::Invalid,
             "invalid_interaction_response",
@@ -336,6 +341,29 @@ fn rich_apply_preserves_legacy_rejection_and_state() {
         legacy, rich,
         "rich wrapper must preserve legacy mutation semantics"
     );
+}
+
+#[test]
+fn only_stale_hand_reorder_rejections_use_stale_action() {
+    let mut state = GameState::new_two_player(1);
+    let before = state.clone();
+    let rejection = apply_with_rejection(
+        &mut state,
+        P0,
+        GameAction::ReorderHand {
+            order: vec![ObjectId(999)],
+        },
+    )
+    .expect_err("an order from an earlier hand is stale");
+
+    assert_eq!(rejection.code, ActionRejectionCode::StaleAction);
+    assert_eq!(rejection.disposition, ActionRejectionDisposition::Stale);
+    assert_eq!(state, before, "stale preferences must not mutate state");
+
+    let wrong_player = apply_with_rejection(&mut state, P1, GameAction::PassPriority)
+        .expect_err("a different player cannot pass priority");
+    assert_eq!(wrong_player.code, ActionRejectionCode::WrongPlayer);
+    assert_ne!(wrong_player.disposition, ActionRejectionDisposition::Stale);
 }
 
 #[test]

--- a/crates/engine/tests/integration/action_rejection.rs
+++ b/crates/engine/tests/integration/action_rejection.rs
@@ -6,7 +6,7 @@ use engine::analysis::decision_template::{
 use engine::game::combat::AttackTarget;
 use engine::game::engine::{
     apply, apply_with_rejection, preflight_debug_action, preflight_debug_action_with_rejection,
-    resolve_all_ready_prefix_with_rejection,
+    require_explicit_debug_permission, resolve_all_ready_prefix_with_rejection,
 };
 use engine::game::interaction::{
     bind_interaction_authority, derive_viewer_interaction, preview_interaction,
@@ -442,6 +442,51 @@ fn rich_debug_preflight_is_safe_and_does_not_mutate_state() {
         "That action is not valid in the current game state."
     );
     assert_eq!(rejection.related_object_ids, vec![object_id]);
+    assert_eq!(state, before);
+}
+
+#[test]
+fn explicit_debug_permission_allows_an_empty_permission_list_without_mutation() {
+    let state = GameState::new_two_player(1);
+    let before = state.clone();
+
+    require_explicit_debug_permission(&state, P0)
+        .expect("an empty explicit permission list permits every player");
+
+    assert_eq!(state, before);
+}
+
+#[test]
+fn explicit_debug_permission_rejects_an_unlisted_player_without_mutation() {
+    let mut state = GameState::new_two_player(1);
+    state.debug_permitted.insert(P1);
+    let before = state.clone();
+
+    let rejection = require_explicit_debug_permission(&state, P0)
+        .expect_err("a nonempty permission list rejects an unlisted player");
+
+    assert_eq!(rejection.code, ActionRejectionCode::DebugPermissionDenied);
+    assert_eq!(
+        rejection.disposition,
+        ActionRejectionDisposition::Unauthorized
+    );
+    assert_eq!(
+        rejection.message,
+        "You are not authorized to use debug actions."
+    );
+    assert!(rejection.related_object_ids.is_empty());
+    assert_eq!(state, before);
+}
+
+#[test]
+fn explicit_debug_permission_allows_a_listed_player_without_mutation() {
+    let mut state = GameState::new_two_player(1);
+    state.debug_permitted.insert(P0);
+    let before = state.clone();
+
+    require_explicit_debug_permission(&state, P0)
+        .expect("a listed player has explicit debug permission");
+
     assert_eq!(state, before);
 }
 

--- a/crates/engine/tests/integration/action_rejection.rs
+++ b/crates/engine/tests/integration/action_rejection.rs
@@ -194,7 +194,7 @@ fn related_object_ids_cover_battle_and_nested_source_carriers() {
     assert_eq!(may_remove.related_object_ids(), vec![ObjectId(4)]);
 
     let source = |object_id| YieldTarget::ThisObject {
-        source_id: Object_id,
+        source_id: object_id,
         incarnation: Some(1),
         trigger_description: None,
     };

--- a/crates/engine/tests/integration/action_rejection.rs
+++ b/crates/engine/tests/integration/action_rejection.rs
@@ -60,64 +60,94 @@ fn every_rejection_code_has_a_closed_disposition_and_safe_message() {
         (
             ActionRejectionCode::InvalidAction,
             ActionRejectionDisposition::Invalid,
+            "invalid_action",
         ),
         (
             ActionRejectionCode::WrongPlayer,
             ActionRejectionDisposition::Unauthorized,
+            "wrong_player",
         ),
         (
             ActionRejectionCode::NotYourPriority,
             ActionRejectionDisposition::Unavailable,
+            "not_your_priority",
         ),
         (
             ActionRejectionCode::ActionNotAllowed,
             ActionRejectionDisposition::Unavailable,
+            "action_not_allowed",
         ),
         (
             ActionRejectionCode::InteractionUnavailable,
             ActionRejectionDisposition::Unavailable,
+            "interaction_unavailable",
         ),
         (
             ActionRejectionCode::InteractionNotAuthorized,
             ActionRejectionDisposition::Unauthorized,
+            "interaction_not_authorized",
         ),
         (
             ActionRejectionCode::StaleInteraction,
             ActionRejectionDisposition::Stale,
+            "stale_interaction",
         ),
         (
             ActionRejectionCode::InvalidInteractionResponse,
             ActionRejectionDisposition::Invalid,
+            "invalid_interaction_response",
         ),
         (
             ActionRejectionCode::InteractionPayloadTooLarge,
             ActionRejectionDisposition::Invalid,
+            "interaction_payload_too_large",
         ),
         (
             ActionRejectionCode::InteractionConstraintUnsatisfied,
             ActionRejectionDisposition::Invalid,
+            "interaction_constraint_unsatisfied",
         ),
         (
             ActionRejectionCode::InteractionCancelOnly,
             ActionRejectionDisposition::Unavailable,
+            "interaction_cancel_only",
         ),
         (
             ActionRejectionCode::InteractionReducerRejected,
             ActionRejectionDisposition::Invalid,
+            "interaction_reducer_rejected",
         ),
         (
             ActionRejectionCode::UnsupportedInteractionResponse,
             ActionRejectionDisposition::Unsupported,
+            "unsupported_interaction_response",
         ),
         (
             ActionRejectionCode::ResolveAllNotReady,
             ActionRejectionDisposition::Unavailable,
+            "resolve_all_not_ready",
+        ),
+        (
+            ActionRejectionCode::DebugPermissionDenied,
+            ActionRejectionDisposition::Unauthorized,
+            "debug_permission_denied",
         ),
     ];
 
-    for (code, disposition) in cases {
+    for (code, disposition, serialized_code) in cases {
         assert_eq!(code.disposition(), disposition);
         assert!(!code.message().is_empty());
+
+        let rejection = ActionRejection::new(code);
+        assert_eq!(rejection.disposition, disposition);
+        assert_eq!(rejection.message, code.message());
+        assert!(rejection.related_object_ids.is_empty());
+        let serialized = serde_json::to_value(&rejection).expect("rejection serializes");
+        assert_eq!(serialized["code"], serde_json::json!(serialized_code));
+        assert_eq!(
+            serialized["disposition"],
+            serde_json::to_value(disposition).expect("rejection disposition serializes")
+        );
     }
 }
 

--- a/crates/engine/tests/integration/loop_shortcut_seat_pin_census.rs
+++ b/crates/engine/tests/integration/loop_shortcut_seat_pin_census.rs
@@ -240,11 +240,12 @@ fn no_target_class_producer_constructs_a_choice_class_player_pin() {
             "engine/src/game/engine.rs",
             "engine/src/game/engine.rs",
             "engine/src/game/visibility.rs",
+            "engine/src/types/actions.rs",
             "server-core/src/game_action_payload_guard.rs",
         ],
         "CR 601.2c / CR 115.10a PROVENANCE SPLIT VIOLATED, or a new unclassified \
          `TargetPin::Player` production site appeared.\n\
-         The FIVE surviving production sites and their dispositions:\n\
+         The SIX surviving production sites and their dispositions:\n\
          1. `analysis/decision_template.rs` — `resolve_target`'s CHOICE authority arm \
             (CR 115.10a existence-only). This IS the class's authority; do not narrow it, \
             `a_shrouded_player_pin_is_still_published_by_the_offer_builder` is the shipped \
@@ -256,7 +257,9 @@ fn no_target_class_producer_constructs_a_choice_class_player_pin() {
             correct and is this census's positive control.\n\
          4. `game/visibility.rs` — `pins_name_hidden_source`'s redaction arm (`false`: seat \
             identity is public in this engine), kept for wire-sourced pins.\n\
-         5. `server-core/src/game_action_payload_guard.rs` — the wire pass-through arm.\n\
+         5. `types/actions.rs` — `GameAction::related_object_ids`' nested-pin read arm; a \
+            player pin has no object identity, so it deliberately contributes nothing.\n\
+         6. `server-core/src/game_action_payload_guard.rs` — the wire pass-through arm.\n\
          A hit in `game/interaction.rs` means the HUMAN ingress reverted to the choice-class \
          spelling; a THIRD hit in `game/engine.rs` means the announcement journal did. Either \
          re-creates two authorities selected by WHO SUBMITTED an answer rather than by WHAT IT \
@@ -293,7 +296,7 @@ fn no_target_class_producer_constructs_a_choice_class_player_pin() {
     );
 
     // CONJUNCT 3, keyed to the SAME instrument: both TARGET-class producers construct the
-    // ranked spelling. One needle returning five sites and the other returning the two
+    // ranked spelling. One needle returning six sites and the other returning the two
     // producers, over the same walk, is what makes conjunct 1's absence a measurement.
     let ranked = production_sites(&target_needle());
     let mut ranked_per_file: BTreeMap<&str, usize> = BTreeMap::new();
@@ -336,7 +339,7 @@ fn no_target_class_producer_constructs_a_choice_class_player_pin() {
 ///   `(2, 2)` ⇒ FAILS;
 /// * delete the comment filter ⇒ the prose plants count ⇒ `(1, 1)` becomes `(2, 2)` ⇒ FAILS.
 ///
-/// It is measured on the real tree too, in the row above: the same classifier returns five
+/// It is measured on the real tree too, in the row above: the same classifier returns six
 /// sites for one needle and four files for the other, so it is not constant in either
 /// direction.
 #[test]

--- a/crates/engine/tests/integration/loop_shortcut_seat_pin_census.rs
+++ b/crates/engine/tests/integration/loop_shortcut_seat_pin_census.rs
@@ -311,12 +311,14 @@ fn no_target_class_producer_constructs_a_choice_class_player_pin() {
             ("engine/src/game/engine.rs", 1),
             ("engine/src/game/interaction.rs", 1),
             ("engine/src/game/visibility.rs", 1),
+            ("engine/src/types/actions.rs", 1),
         ],
         "the TARGET-class spelling must be CONSTRUCTED by BOTH producers — `game/engine.rs` \
          (`record_trigger_target_answer`) and `game/interaction.rs` \
-         (`materialize_loop_shortcut_response`) — beside its two READ sites: \
+         (`materialize_loop_shortcut_response`) — beside its three READ sites: \
          `evaluate_schedule`'s CR 601.2c resolver arm in `analysis/decision_template.rs` and \
-         the wildcard-free redaction arm in `game/visibility.rs`. A MISSING producer is the \
+         the wildcard-free redaction arm in `game/visibility.rs`, and `GameAction`'s object-id \
+         collection arm in `types/actions.rs`. A MISSING producer is the \
          revert this row exists to catch; an EXTRA file is a new producer that must be \
          classified rather than absorbed. got {ranked:?}"
     );

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -9,6 +9,7 @@ mod source_census;
 
 mod abigale_integration;
 mod abundance_optional_draw_replacement;
+mod action_rejection;
 mod ad_nauseam_repeat;
 mod adamant_enters_with_leading_if_gate;
 mod adapter_contract_fixtures;

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -43,6 +43,7 @@ pub enum ServerErrorCode {
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
 ///
+/// 40 — Action rejection responses carry engine-owned structured context.
 /// 39 — `ManaRestriction::CannotCastSpellFromZone` adds a serialized
 ///      GameState/ManaUnit restriction used by Karolina Dean. Older peers
 ///      cannot deserialize that externally tagged enum variant. Lobby messages
@@ -141,7 +142,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 39;
+pub const PROTOCOL_VERSION: u32 = 40;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake **from clients that predate [`LOBBY_PROTOCOL_VERSION`]** — the
@@ -549,12 +550,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 39);
+        assert_eq!(PROTOCOL_VERSION, 40);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot
         // understand a success acknowledgment the submitting client awaits.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 38);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 39);
     }
 
     #[test]

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -43,6 +43,7 @@ pub enum ServerErrorCode {
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
 ///
+/// 41 — Operational failure responses are correlated to their pending action.
 /// 40 — Action rejection responses carry engine-owned structured context.
 /// 39 — `ManaRestriction::CannotCastSpellFromZone` adds a serialized
 ///      GameState/ManaUnit restriction used by Karolina Dean. Older peers
@@ -142,7 +143,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 40;
+pub const PROTOCOL_VERSION: u32 = 41;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake **from clients that predate [`LOBBY_PROTOCOL_VERSION`]** — the
@@ -550,12 +551,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 40);
+        assert_eq!(PROTOCOL_VERSION, 41);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot
         // understand a success acknowledgment the submitting client awaits.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 39);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 40);
     }
 
     #[test]

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -29,6 +29,7 @@ use engine::database::CardDatabase;
 use engine::game::derived_views::derive_filtered_views;
 use engine::game::interaction::{derive_viewer_interaction, object_action_payloads};
 use engine::game::validate_name_deck_for_format_full;
+use engine::types::action_rejection::{ActionRejection, ActionRejectionCode};
 use engine::types::actions::GameAction;
 use engine::types::events::GameEvent;
 use engine::types::game_state::GameState;
@@ -73,7 +74,8 @@ use server_core::protocol::{
 use server_core::resolve_deck;
 use server_core::seat_mutation_wire_guard::guard_seat_mutation;
 use server_core::session::{
-    ActionResult, FullRuntime, GameSession, RevisionedActionResult, SessionManager,
+    ActionResult, FullRuntime, GameSession, RevisionedActionResult, SessionActionError,
+    SessionManager,
 };
 use server_core::spectator_wire_guard::{
     guard_draft_spectator_capacity, guard_game_spectator_capacity, guard_spectate_draft,
@@ -4147,6 +4149,17 @@ enum GameSubmission {
     Interaction(InteractionSubmission),
 }
 
+/// Maps the three-way session boundary onto the ordinary action-response
+/// channels. Resolve All has its own requester-correlated wrapper, but every
+/// other game submission uses this exact policy.
+fn session_action_error_message(error: SessionActionError) -> ServerMessage {
+    match error {
+        SessionActionError::Rejected(rejection) => ServerMessage::ActionRejected { rejection },
+        SessionActionError::RequestRejected(reason) => ServerMessage::RequestRejected { reason },
+        SessionActionError::Operational(error) => ServerMessage::error(error),
+    }
+}
+
 impl GameSubmission {
     /// Wire-bounds this submission and, on failure, names the channel the
     /// rejection is answered on.
@@ -4198,11 +4211,21 @@ impl GameSubmission {
 
     fn payload_rejection(&self) -> Result<(), Box<ServerMessage>> {
         match self {
-            GameSubmission::Action(action) => guard_game_action_payload(action)
-                .map_err(|reason| Box::new(ServerMessage::error(reason))),
+            GameSubmission::Action(action) => {
+                guard_game_action_payload(action).map_err(|_reason| {
+                    Box::new(ServerMessage::ActionRejected {
+                        rejection: ActionRejection::new(ActionRejectionCode::InvalidAction),
+                    })
+                })
+            }
             GameSubmission::Interaction(submission) => {
-                guard_interaction_submission_payload(submission)
-                    .map_err(|reason| Box::new(ServerMessage::ActionRejected { reason }))
+                guard_interaction_submission_payload(submission).map_err(|_reason| {
+                    Box::new(ServerMessage::ActionRejected {
+                        rejection: ActionRejection::new(
+                            ActionRejectionCode::InteractionPayloadTooLarge,
+                        ),
+                    })
+                })
             }
         }
     }
@@ -4276,11 +4299,14 @@ async fn handle_full_game_submission(
         let lock_start = std::time::Instant::now();
         let mut mgr = state.lock().await;
         let applied = match submission {
-            GameSubmission::Action(action) => {
-                mgr.handle_action_with_card_db(&game_code, &player_token, action, Some(db.as_ref()))
-            }
+            GameSubmission::Action(action) => mgr.handle_action_with_card_db_outcome(
+                &game_code,
+                &player_token,
+                action,
+                Some(db.as_ref()),
+            ),
             GameSubmission::Interaction(submission) => {
-                mgr.handle_interaction(&game_code, &player_token, submission)
+                mgr.handle_interaction_with_rejection(&game_code, &player_token, submission)
             }
         };
         match applied {
@@ -4527,8 +4553,8 @@ async fn handle_full_game_submission(
                 state.lock().await.remove_game(&game_code);
             }
         }
-        Err(e) => {
-            let msg = ServerMessage::ActionRejected { reason: e };
+        Err(error) => {
+            let msg = session_action_error_message(error);
             if let Ok(json) = serde_json::to_string(&msg) {
                 let _ = socket.send(Message::text(json)).await;
             }
@@ -4556,17 +4582,15 @@ async fn handle_resolve_all(
         identity.player_token.clone(),
         identity.player_id,
     ) else {
-        let msg = ServerMessage::ResolveAllRejected {
-            request_id,
-            reason: "Not in a game".to_string(),
-        };
+        let msg = ServerMessage::error("Not in a game".to_string());
         let _ = tx.send(msg);
         return;
     };
 
     let processed = {
         let mut mgr = state.lock().await;
-        match mgr.resolve_all_for_player(&game_code, &player_token, max_resolutions) {
+        match mgr.resolve_all_for_player_with_rejection(&game_code, &player_token, max_resolutions)
+        {
             Ok((transition, summary)) => match transition {
                 None => Ok((summary, None)),
                 Some((_, (_, _, _, batch_log_entries, _, _, _))) => {
@@ -4630,8 +4654,19 @@ async fn handle_resolve_all(
 
     let (summary, payload) = match processed {
         Ok(processed) => processed,
-        Err(reason) => {
-            let _ = tx.send(ServerMessage::ResolveAllRejected { request_id, reason });
+        Err(SessionActionError::Rejected(rejection)) => {
+            let _ = tx.send(ServerMessage::ResolveAllRejected {
+                request_id,
+                rejection,
+            });
+            return;
+        }
+        Err(SessionActionError::RequestRejected(reason)) => {
+            let _ = tx.send(ServerMessage::RequestRejected { reason });
+            return;
+        }
+        Err(SessionActionError::Operational(error)) => {
+            let _ = tx.send(ServerMessage::error(error));
             return;
         }
     };
@@ -5144,25 +5179,35 @@ async fn handle_client_message(
         ClientMessage::PreviewManaPayment { request_id, action } => {
             let response = match (identity.game_code.clone(), identity.player_token.clone()) {
                 (Some(game_code), Some(player_token)) => {
-                    if let Err(reason) = guard_game_action_payload(&action) {
-                        ServerMessage::ManaPaymentPreviewRejected { request_id, reason }
+                    if guard_game_action_payload(&action).is_err() {
+                        ServerMessage::ManaPaymentPreviewRejected {
+                            request_id,
+                            rejection: ActionRejection::new(ActionRejectionCode::InvalidAction),
+                        }
                     } else {
                         let mgr = state.lock().await;
-                        match mgr.preview_mana_payment(&game_code, &player_token, &action) {
+                        match mgr.preview_mana_payment_with_rejection(
+                            &game_code,
+                            &player_token,
+                            &action,
+                        ) {
                             Ok(source_ids) => ServerMessage::ManaPaymentPreview {
                                 request_id,
                                 source_ids,
                             },
-                            Err(reason) => {
-                                ServerMessage::ManaPaymentPreviewRejected { request_id, reason }
+                            Err(SessionActionError::Rejected(rejection)) => {
+                                ServerMessage::ManaPaymentPreviewRejected {
+                                    request_id,
+                                    rejection,
+                                }
+                            }
+                            Err(SessionActionError::Operational(error)) => {
+                                ServerMessage::error(error)
                             }
                         }
                     }
                 }
-                _ => ServerMessage::ManaPaymentPreviewRejected {
-                    request_id,
-                    reason: "Not in a game".to_string(),
-                },
+                _ => ServerMessage::error("Not in a game".to_string()),
             };
 
             if let Ok(json) = serde_json::to_string(&response) {
@@ -6758,10 +6803,11 @@ async fn handle_client_message(
             info!(game = %game_code, player = ?player_id, "player conceded game");
             let outcome = {
                 let mut mgr = state.lock().await;
-                match mgr.handle_action(
+                match mgr.handle_action_with_card_db_outcome(
                     &game_code,
                     &player_token,
                     engine::types::actions::GameAction::Concede { player_id },
+                    None,
                 ) {
                     Ok(result) => {
                         let session = mgr
@@ -6800,10 +6846,8 @@ async fn handle_client_message(
             };
 
             match outcome {
-                Err(reason) => {
-                    if let Ok(json) =
-                        serde_json::to_string(&ServerMessage::ActionRejected { reason })
-                    {
+                Err(error) => {
+                    if let Ok(json) = serde_json::to_string(&session_action_error_message(error)) {
                         let _ = socket.send(Message::text(json)).await;
                     }
                 }
@@ -6896,7 +6940,7 @@ async fn handle_client_message(
             match outcome {
                 Err(reason) => {
                     if let Ok(json) =
-                        serde_json::to_string(&ServerMessage::ActionRejected { reason })
+                        serde_json::to_string(&ServerMessage::RequestRejected { reason })
                     {
                         let _ = socket.send(Message::text(json)).await;
                     }
@@ -7028,7 +7072,7 @@ async fn handle_client_message(
                     // unrecoverable. Reaching for the error channel here was
                     // this handler's inconsistency with its own sibling ~2,400
                     // lines above, not a deliberate signal.
-                    let msg = ServerMessage::ActionRejected { reason };
+                    let msg = ServerMessage::RequestRejected { reason };
                     if let Ok(json) = serde_json::to_string(&msg) {
                         let _ = socket.send(Message::text(json)).await;
                     }
@@ -7130,7 +7174,7 @@ async fn handle_client_message(
                     // Fixed here too so the pair stays consistent — a benign
                     // refusal must never travel the channel the native client
                     // treats as terminal.
-                    let msg = ServerMessage::ActionRejected { reason };
+                    let msg = ServerMessage::RequestRejected { reason };
                     if let Ok(json) = serde_json::to_string(&msg) {
                         let _ = socket.send(Message::text(json)).await;
                     }
@@ -7211,7 +7255,7 @@ async fn handle_client_message(
                     // terminal error channel — `handleNativeEvent` disposes
                     // the adapter on ANY `error` event, so a mis-clicked
                     // cancel would end the desktop session.
-                    let msg = ServerMessage::ActionRejected { reason };
+                    let msg = ServerMessage::RequestRejected { reason };
                     if let Ok(json) = serde_json::to_string(&msg) {
                         let _ = socket.send(Message::text(json)).await;
                     }
@@ -7400,13 +7444,11 @@ async fn handle_client_message(
                 };
 
                 if let Some(fault) = session.ai_driver_fault() {
-                    let msg = ServerMessage::ActionRejected {
-                        reason: format!(
-                            "Native AI driver fault {}: {}",
-                            fault.id,
-                            fault.cause.message()
-                        ),
-                    };
+                    let msg = ServerMessage::error(format!(
+                        "Native AI driver fault {}: {}",
+                        fault.id,
+                        fault.cause.message()
+                    ));
                     if let Ok(json) = serde_json::to_string(&msg) {
                         let _ = socket.send(Message::text(json)).await;
                     }
@@ -9395,7 +9437,9 @@ mod game_submission_tests {
             let msg = recv_server_message(socket).await;
             if matches!(
                 msg,
-                ServerMessage::ActionRejected { .. } | ServerMessage::Error { .. }
+                ServerMessage::ActionRejected { .. }
+                    | ServerMessage::RequestRejected { .. }
+                    | ServerMessage::Error { .. }
             ) {
                 return msg;
             }
@@ -9417,8 +9461,8 @@ mod game_submission_tests {
     /// *first* — before the seat check, before `debug_permitted`, and before
     /// `apply` — where `format_config.allow_debug_actions` is `false` because
     /// the wire sent `format_config: None` and `FormatConfig::standard()` sets
-    /// it to `false`. `handle_action`'s `Err(String)` is then answered verbatim,
-    /// with no `"Engine error: "` prefix.
+    /// it to `false`. The session rejects it as an engine-shaped action
+    /// refusal, so the client receives no server-policy prose.
     #[tokio::test]
     async fn action_frame_reaches_the_shared_submission_handler() {
         let (url, server, _temp_dir) = spawn_full_mode_server().await;
@@ -9444,11 +9488,23 @@ mod game_submission_tests {
 
         let answer = answer.expect("action frame was never answered");
         match answer {
-            ServerMessage::ActionRejected { reason } => {
-                assert_eq!(reason, "Sandbox mode is not enabled for this game");
+            ServerMessage::ActionRejected { rejection } => {
+                assert_eq!(rejection.code, ActionRejectionCode::ActionNotAllowed);
             }
             other => panic!("expected ActionRejected from the shared handler, got {other:?}"),
         }
+    }
+
+    #[test]
+    fn pending_takeback_session_refusal_uses_the_request_channel() {
+        let message = session_action_error_message(SessionActionError::RequestRejected(
+            "A takeback request is pending — resolve it before taking further actions".to_string(),
+        ));
+        assert!(matches!(
+            message,
+            ServerMessage::RequestRejected { reason }
+                if reason == "A takeback request is pending — resolve it before taking further actions"
+        ));
     }
 
     fn submission(response: InteractionResponse) -> InteractionSubmission {
@@ -9478,21 +9534,21 @@ mod game_submission_tests {
         };
 
         // (i) an oversized interaction answers on the benign channel.
-        let handler_reason = match *GameSubmission::Interaction(oversized.clone())
+        let handler_rejection = match *GameSubmission::Interaction(oversized.clone())
             .payload_rejection()
             .expect_err("an oversized interaction is refused")
         {
-            ServerMessage::ActionRejected { reason } => reason,
+            ServerMessage::ActionRejected { rejection } => rejection,
             ref other => panic!("an oversized paste must not tear the session down: {other:?}"),
         };
 
         // (ii) an oversized action stays a malformed frame.
-        let action_reason = match *GameSubmission::Action(oversized_action.clone())
+        let action_rejection = match *GameSubmission::Action(oversized_action.clone())
             .payload_rejection()
             .expect_err("an oversized action is refused")
         {
-            ServerMessage::Error { message, .. } => message,
-            ref other => panic!("an oversized action is a malformed frame, got {other:?}"),
+            ServerMessage::ActionRejected { rejection } => rejection,
+            ref other => panic!("an oversized action is an invalid action, got {other:?}"),
         };
 
         // (iii) both layers agree, in variant *and* in reason string.
@@ -9502,7 +9558,7 @@ mod game_submission_tests {
         let wire_reason =
             guard_client_message_before_dispatch(&wire_interaction, ServerMode::Full).unwrap_err();
         match wire_rejection_message(&wire_interaction, wire_reason) {
-            ServerMessage::ActionRejected { reason } => assert_eq!(reason, handler_reason),
+            ServerMessage::ActionRejected { rejection } => assert_eq!(rejection, handler_rejection),
             other => panic!("wire and handler disagree on the interaction channel: {other:?}"),
         }
 
@@ -9512,7 +9568,7 @@ mod game_submission_tests {
         let wire_action_reason =
             guard_client_message_before_dispatch(&wire_action, ServerMode::Full).unwrap_err();
         match wire_rejection_message(&wire_action, wire_action_reason) {
-            ServerMessage::Error { message, .. } => assert_eq!(message, action_reason),
+            ServerMessage::ActionRejected { rejection } => assert_eq!(rejection, action_rejection),
             other => panic!("wire and handler disagree on the action channel: {other:?}"),
         }
 
@@ -9568,8 +9624,8 @@ mod game_submission_tests {
 
         let answer = answer.expect("interaction frame was never answered");
         match answer {
-            ServerMessage::ActionRejected { reason } => {
-                assert_eq!(reason, "Engine error: StaleInteraction");
+            ServerMessage::ActionRejected { rejection } => {
+                assert_eq!(rejection.code, ActionRejectionCode::StaleInteraction);
             }
             other => panic!("the wire schema must accept an Interaction frame, got {other:?}"),
         }
@@ -9624,8 +9680,11 @@ mod game_submission_tests {
 
         let (first, second) = answers.expect("oversized interaction was never answered");
         match first {
-            ServerMessage::ActionRejected { reason } => {
-                assert_eq!(reason, "Engine error: PayloadTooLarge");
+            ServerMessage::ActionRejected { rejection } => {
+                assert_eq!(
+                    rejection.code,
+                    ActionRejectionCode::InteractionPayloadTooLarge
+                );
             }
             other => panic!("an oversized paste must not end the match, got {other:?}"),
         }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -4417,19 +4417,21 @@ async fn handle_full_game_submission(
                     "game submission processed (lock held)"
                 );
 
-                terminal.map(|terminal| {
-                    (
-                        human_revision,
-                        human_result,
-                        ai_results,
-                        eliminated,
-                        player_count,
-                        game_over_winner,
-                        terminal,
-                        rewind_targets,
-                        ai_failure,
-                    )
-                })
+                terminal
+                    .map_err(SessionActionError::Operational)
+                    .map(|terminal| {
+                        (
+                            human_revision,
+                            human_result,
+                            ai_results,
+                            eliminated,
+                            player_count,
+                            game_over_winner,
+                            terminal,
+                            rewind_targets,
+                            ai_failure,
+                        )
+                    })
             }
             Err(e) => Err(e),
         }
@@ -4687,25 +4689,27 @@ async fn handle_resolve_all(
                         persist_full_session_async(game_db, session);
                         Ok(None)
                     };
-                    terminal.map(|terminal| {
-                        (
-                            summary,
-                            Some((
-                                revision,
-                                raw_state,
-                                legal_actions,
-                                log_entries,
-                                spell_costs,
-                                by_object,
-                                eliminated,
-                                rewind_targets,
-                                player_count,
-                                game_over_winner,
-                                terminal,
-                                ai_failure,
-                            )),
-                        )
-                    })
+                    terminal
+                        .map_err(SessionActionError::Operational)
+                        .map(|terminal| {
+                            (
+                                summary,
+                                Some((
+                                    revision,
+                                    raw_state,
+                                    legal_actions,
+                                    log_entries,
+                                    spell_costs,
+                                    by_object,
+                                    eliminated,
+                                    rewind_targets,
+                                    player_count,
+                                    game_over_winner,
+                                    terminal,
+                                    ai_failure,
+                                )),
+                            )
+                        })
                 }
             },
             Err(error) => Err(error),
@@ -6915,6 +6919,7 @@ async fn handle_client_message(
                         };
                         let rewind_targets = session.rewind_options();
                         terminal
+                            .map_err(SessionActionError::Operational)
                             .map(|terminal| (revision, result, winner, terminal, rewind_targets))
                     }
                     Err(error) => Err(error),

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -4149,14 +4149,64 @@ enum GameSubmission {
     Interaction(InteractionSubmission),
 }
 
-/// Maps the three-way session boundary onto the ordinary action-response
-/// channels. Resolve All has its own requester-correlated wrapper, but every
-/// other game submission uses this exact policy.
+/// Maps engine and lifecycle session refusals onto their ordinary response
+/// channels. Pending game operations route operational failures through their
+/// own `*Failed` frames at the call site.
 fn session_action_error_message(error: SessionActionError) -> ServerMessage {
     match error {
         SessionActionError::Rejected(rejection) => ServerMessage::ActionRejected { rejection },
         SessionActionError::RequestRejected(reason) => ServerMessage::RequestRejected { reason },
         SessionActionError::Operational(error) => ServerMessage::error(error),
+    }
+}
+
+/// Keep an operational failure attached to the operation whose client promise
+/// is waiting for it. Engine legality remains on the structured rejection
+/// frames above; this function is only for failures outside the engine action
+/// boundary.
+fn operation_failed_message(msg: &ClientMessage, message: String) -> Option<ServerMessage> {
+    match msg {
+        ClientMessage::Action { .. }
+        | ClientMessage::Interaction { .. }
+        | ClientMessage::Concede => Some(ServerMessage::ActionFailed { message }),
+        ClientMessage::ResolveAll { request_id, .. } => Some(ServerMessage::ResolveAllFailed {
+            request_id: *request_id,
+            message,
+        }),
+        ClientMessage::PreviewManaPayment { request_id, .. } => {
+            Some(ServerMessage::ManaPaymentPreviewFailed {
+                request_id: *request_id,
+                message,
+            })
+        }
+        ClientMessage::ClientHello { .. }
+        | ClientMessage::CreateGame { .. }
+        | ClientMessage::JoinGame { .. }
+        | ClientMessage::Reconnect { .. }
+        | ClientMessage::AbandonGame
+        | ClientMessage::ConcedeMatch
+        | ClientMessage::SubscribeLobby
+        | ClientMessage::UnsubscribeLobby
+        | ClientMessage::RequestTakeback(_)
+        | ClientMessage::RespondTakeback { .. }
+        | ClientMessage::CancelTakeback
+        | ClientMessage::BootstrapTerminalDelivery { .. }
+        | ClientMessage::ReadTerminalResult { .. }
+        | ClientMessage::AckTerminalDelivery { .. }
+        | ClientMessage::CreateGameWithSettings { .. }
+        | ClientMessage::JoinGameWithPassword { .. }
+        | ClientMessage::LookupJoinTarget { .. }
+        | ClientMessage::Emote { .. }
+        | ClientMessage::SpectatorJoin { .. }
+        | ClientMessage::Ping { .. }
+        | ClientMessage::UpdateLobbyMetadata { .. }
+        | ClientMessage::SeatMutate { .. }
+        | ClientMessage::UnregisterLobby { .. }
+        | ClientMessage::CreateDraftWithSettings { .. }
+        | ClientMessage::JoinDraftWithPassword { .. }
+        | ClientMessage::DraftAction { .. }
+        | ClientMessage::ReconnectDraft { .. }
+        | ClientMessage::SpectateDraft { .. } => None,
     }
 }
 
@@ -4262,7 +4312,9 @@ async fn handle_full_game_submission(
         Some(c) => c.clone(),
         None => {
             warn!(kind, "game submission received but not in a game");
-            let msg = ServerMessage::error("Not in a game".to_string());
+            let msg = ServerMessage::ActionFailed {
+                message: "Not in a game".to_string(),
+            };
             if let Ok(json) = serde_json::to_string(&msg) {
                 let _ = socket.send(Message::text(json)).await;
             }
@@ -4272,7 +4324,9 @@ async fn handle_full_game_submission(
     let player_token = match &identity.player_token {
         Some(t) => t.clone(),
         None => {
-            let msg = ServerMessage::error("No player token".to_string());
+            let msg = ServerMessage::ActionFailed {
+                message: "No player token".to_string(),
+            };
             if let Ok(json) = serde_json::to_string(&msg) {
                 let _ = socket.send(Message::text(json)).await;
             }
@@ -4410,7 +4464,7 @@ async fn handle_full_game_submission(
                 spell_costs: &spell_costs,
             }) {
                 warn!(game = %game_code, %reason, "action snapshot too large to broadcast");
-                let msg = ServerMessage::error(reason);
+                let msg = ServerMessage::ActionFailed { message: reason };
                 if let Ok(json) = serde_json::to_string(&msg) {
                     let _ = socket.send(Message::text(json)).await;
                 }
@@ -4422,7 +4476,7 @@ async fn handle_full_game_submission(
                     Ok(deliveries) => deliveries,
                     Err(error) => {
                         error!(game = %game_code, %error, "terminal preparation failed");
-                        let msg = ServerMessage::error(error);
+                        let msg = ServerMessage::ActionFailed { message: error };
                         if let Ok(json) = serde_json::to_string(&msg) {
                             let _ = socket.send(Message::text(json)).await;
                         }
@@ -4554,7 +4608,10 @@ async fn handle_full_game_submission(
             }
         }
         Err(error) => {
-            let msg = session_action_error_message(error);
+            let msg = match error {
+                SessionActionError::Operational(message) => ServerMessage::ActionFailed { message },
+                error => session_action_error_message(error),
+            };
             if let Ok(json) = serde_json::to_string(&msg) {
                 let _ = socket.send(Message::text(json)).await;
             }
@@ -4582,7 +4639,10 @@ async fn handle_resolve_all(
         identity.player_token.clone(),
         identity.player_id,
     ) else {
-        let msg = ServerMessage::error("Not in a game".to_string());
+        let msg = ServerMessage::ResolveAllFailed {
+            request_id,
+            message: "Not in a game".to_string(),
+        };
         let _ = tx.send(msg);
         return;
     };
@@ -4666,7 +4726,10 @@ async fn handle_resolve_all(
             return;
         }
         Err(SessionActionError::Operational(error)) => {
-            let _ = tx.send(ServerMessage::error(error));
+            let _ = tx.send(ServerMessage::ResolveAllFailed {
+                request_id,
+                message: error,
+            });
             return;
         }
     };
@@ -4915,7 +4978,9 @@ async fn handle_client_message(
     // need to second-guess whether the message should reach them.
     if let Some(reason) = reject_if_disabled(&client_msg, mode) {
         warn!(?mode, msg = ?std::mem::discriminant(&client_msg), %reason, "rejecting message disabled by server mode");
-        let msg = ServerMessage::error(reason.to_string());
+        let reason = reason.to_string();
+        let msg = operation_failed_message(&client_msg, reason.clone())
+            .unwrap_or_else(|| ServerMessage::error(reason));
         if let Ok(json) = serde_json::to_string(&msg) {
             let _ = socket.send(Message::text(json)).await;
         }
@@ -5205,12 +5270,18 @@ async fn handle_client_message(
                                 ServerMessage::RequestRejected { reason }
                             }
                             Err(SessionActionError::Operational(error)) => {
-                                ServerMessage::error(error)
+                                ServerMessage::ManaPaymentPreviewFailed {
+                                    request_id,
+                                    message: error,
+                                }
                             }
                         }
                     }
                 }
-                _ => ServerMessage::error("Not in a game".to_string()),
+                _ => ServerMessage::ManaPaymentPreviewFailed {
+                    request_id,
+                    message: "Not in a game".to_string(),
+                },
             };
 
             if let Ok(json) = serde_json::to_string(&response) {
@@ -6795,7 +6866,9 @@ async fn handle_client_message(
                     (game_code, player_token, player_id)
                 }
                 _ => {
-                    let msg = ServerMessage::error("Not in a game".to_string());
+                    let msg = ServerMessage::ActionFailed {
+                        message: "Not in a game".to_string(),
+                    };
                     if let Ok(json) = serde_json::to_string(&msg) {
                         let _ = socket.send(Message::text(json)).await;
                     }
@@ -6850,7 +6923,13 @@ async fn handle_client_message(
 
             match outcome {
                 Err(error) => {
-                    if let Ok(json) = serde_json::to_string(&session_action_error_message(error)) {
+                    let msg = match error {
+                        SessionActionError::Operational(message) => {
+                            ServerMessage::ActionFailed { message }
+                        }
+                        error => session_action_error_message(error),
+                    };
+                    if let Ok(json) = serde_json::to_string(&msg) {
                         let _ = socket.send(Message::text(json)).await;
                     }
                 }
@@ -6860,7 +6939,7 @@ async fn handle_client_message(
                             Ok(deliveries) => deliveries,
                             Err(error) => {
                                 error!(game = %game_code, %error, "terminal preparation failed");
-                                let _ = tx.send(ServerMessage::error(error));
+                                let _ = tx.send(ServerMessage::ActionFailed { message: error });
                                 return;
                             }
                         },
@@ -9485,8 +9564,8 @@ mod game_submission_tests {
         socket
     }
 
-    /// Read frames until one is an `ActionRejected` or an `Error`, ignoring the
-    /// unrelated broadcasts the session emits. The enclosing
+    /// Read frames until one is a submission answer, ignoring unrelated
+    /// broadcasts the session emits. The enclosing
     /// `tokio::time::timeout` is the failure mode, as in every sibling test.
     async fn recv_submission_answer<S>(socket: &mut WebSocketStream<S>) -> ServerMessage
     where
@@ -9497,6 +9576,7 @@ mod game_submission_tests {
             if matches!(
                 msg,
                 ServerMessage::ActionRejected { .. }
+                    | ServerMessage::ActionFailed { .. }
                     | ServerMessage::RequestRejected { .. }
                     | ServerMessage::Error { .. }
             ) {
@@ -9771,7 +9851,7 @@ mod game_submission_tests {
     /// test's `ActionRejected` came from an engine verdict rather than being
     /// this handler's blanket answer.
     #[tokio::test]
-    async fn a_game_submission_without_a_session_is_answered_on_the_error_channel() {
+    async fn a_game_submission_without_a_session_is_answered_on_the_failed_channel() {
         let (url, server, _temp_dir) = spawn_full_mode_server().await;
         let answer = tokio::time::timeout(Duration::from_secs(5), async {
             let (mut socket, _) = tokio_tungstenite::connect_async(url)
@@ -9817,8 +9897,8 @@ mod game_submission_tests {
 
         let answer = answer.expect("sessionless interaction was never answered");
         match answer {
-            ServerMessage::Error { message, .. } => assert_eq!(message, "Not in a game"),
-            other => panic!("a pre-session condition is not an engine verdict: {other:?}"),
+            ServerMessage::ActionFailed { message } => assert_eq!(message, "Not in a game"),
+            other => panic!("a pre-session condition must settle the action promise: {other:?}"),
         }
     }
 }
@@ -9900,6 +9980,57 @@ mod mode_gate_tests {
                 "expected {msg:?} to be rejected in lobby-only mode"
             );
         }
+    }
+
+    #[test]
+    fn mode_gate_keeps_operational_failures_with_their_game_request() {
+        assert!(matches!(
+            operation_failed_message(
+                &ClientMessage::Action {
+                    action: GameAction::PassPriority,
+                },
+                "disabled".to_string(),
+            ),
+            Some(ServerMessage::ActionFailed { message }) if message == "disabled"
+        ));
+        assert!(matches!(
+            operation_failed_message(
+                &ClientMessage::Interaction {
+                    submission: InteractionSubmission {
+                        interaction_id: engine::types::interaction::InteractionId("i".to_string()),
+                        response: engine::types::interaction::InteractionResponse::Choose {
+                            choice_id: engine::types::interaction::InteractionChoiceId("c".to_string()),
+                        },
+                    },
+                },
+                "disabled".to_string(),
+            ),
+            Some(ServerMessage::ActionFailed { message }) if message == "disabled"
+        ));
+        assert!(matches!(
+            operation_failed_message(
+                &ClientMessage::ResolveAll {
+                    request_id: 4,
+                    max_resolutions: 1,
+                },
+                "disabled".to_string(),
+            ),
+            Some(ServerMessage::ResolveAllFailed { request_id: 4, message }) if message == "disabled"
+        ));
+        assert!(matches!(
+            operation_failed_message(
+                &ClientMessage::PreviewManaPayment {
+                    request_id: 5,
+                    action: GameAction::PassPriority,
+                },
+                "disabled".to_string(),
+            ),
+            Some(ServerMessage::ManaPaymentPreviewFailed { request_id: 5, message }) if message == "disabled"
+        ));
+        assert!(
+            operation_failed_message(&ClientMessage::ConcedeMatch, "disabled".to_string(),)
+                .is_none()
+        );
     }
 
     #[test]

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -9498,14 +9498,21 @@ mod game_submission_tests {
     }
 
     #[test]
-    fn pending_takeback_session_refusal_uses_the_request_channel() {
-        let message = session_action_error_message(SessionActionError::RequestRejected(
-            "A takeback request is pending — resolve it before taking further actions".to_string(),
+    fn action_and_request_session_refusals_use_their_distinct_channels() {
+        let message = session_action_error_message(SessionActionError::Rejected(
+            ActionRejection::new(ActionRejectionCode::ActionNotAllowed),
         ));
         assert!(matches!(
             message,
+            ServerMessage::ActionRejected { rejection }
+                if rejection.code == ActionRejectionCode::ActionNotAllowed
+        ));
+        assert!(matches!(
+            session_action_error_message(SessionActionError::RequestRejected(
+                "Match forfeits require a best-of-three match".to_string(),
+            )),
             ServerMessage::RequestRejected { reason }
-                if reason == "A takeback request is pending — resolve it before taking further actions"
+                if reason == "Match forfeits require a best-of-three match"
         ));
         assert!(matches!(
             session_action_error_message(SessionActionError::Operational(

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -8481,6 +8481,63 @@ mod state_transport_derived_tests {
         }
     }
 
+    #[tokio::test]
+    async fn resolve_all_limit_rejection_keeps_request_correlation() {
+        let mut manager = SessionManager::new();
+        let (game_code, player_token) = manager.create_game(PlayerDeckPayload::default());
+        let state: SharedState = Arc::new(Mutex::new(manager));
+        let draft_state: SharedDraftState = Arc::new(Mutex::new(DraftSessionManager::new()));
+        let connections: SharedConnections = Arc::new(Mutex::new(HashMap::new()));
+        let game_spectators: SharedGameSpectators = Arc::new(Mutex::new(HashMap::new()));
+        let db_file = tempfile::NamedTempFile::new().expect("temporary game database");
+        let game_db = Arc::new(
+            persistence::GameDb::open(db_file.path(), persistence::SessionRetention::Multiplayer)
+                .expect("open temporary game database"),
+        );
+        let (requester_tx, mut requester_rx) = mpsc::unbounded_channel();
+        let identity = SocketIdentity {
+            game_code: Some(game_code),
+            player_id: Some(PlayerId(0)),
+            player_token: Some(player_token),
+            lobby_subscribed: false,
+            session_span: None,
+            client_hello: None,
+            lobby_host_game: None,
+            seat_reservations: Vec::new(),
+            lobby_reservations: Vec::new(),
+            draft_code: None,
+            draft_seat: None,
+            draft_token: None,
+            spectator_draft_code: None,
+            spectator_visibility: None,
+            spectator_game_code: None,
+        };
+
+        handle_resolve_all(
+            73,
+            5_001,
+            &state,
+            &draft_state,
+            &connections,
+            &requester_tx,
+            &game_db,
+            &game_spectators,
+            &identity,
+        )
+        .await;
+
+        assert!(matches!(
+            requester_rx
+                .recv()
+                .await
+                .expect("limit rejection keeps the requester channel open"),
+            ServerMessage::ResolveAllRejected {
+                request_id: 73,
+                rejection,
+            } if rejection.code == ActionRejectionCode::InvalidAction
+        ));
+    }
+
     #[test]
     fn turn_controller_receives_low_use_window_recommendation_instead_of_controlled_seat() {
         let controlled = PlayerId(0);

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -5201,6 +5201,9 @@ async fn handle_client_message(
                                     rejection,
                                 }
                             }
+                            Err(SessionActionError::RequestRejected(reason)) => {
+                                ServerMessage::RequestRejected { reason }
+                            }
                             Err(SessionActionError::Operational(error)) => {
                                 ServerMessage::error(error)
                             }
@@ -6909,7 +6912,7 @@ async fn handle_client_message(
 
             let outcome = {
                 let mut mgr = state.lock().await;
-                match mgr.handle_match_concede(&game_code, &player_token) {
+                match mgr.handle_match_concede_outcome(&game_code, &player_token) {
                     Ok((revision, result)) => {
                         let winner = match &result.0.waiting_for {
                             engine::types::game_state::WaitingFor::GameOver { winner } => *winner,
@@ -6932,16 +6935,15 @@ async fn handle_client_message(
                             ranked_result,
                         )
                         .map(|terminal| (revision, result, winner, terminal, rewind_targets))
+                        .map_err(SessionActionError::Operational)
                     }
                     Err(error) => Err(error),
                 }
             };
 
             match outcome {
-                Err(reason) => {
-                    if let Ok(json) =
-                        serde_json::to_string(&ServerMessage::RequestRejected { reason })
-                    {
+                Err(error) => {
+                    if let Ok(json) = serde_json::to_string(&session_action_error_message(error)) {
                         let _ = socket.send(Message::text(json)).await;
                     }
                 }
@@ -9504,6 +9506,12 @@ mod game_submission_tests {
             message,
             ServerMessage::RequestRejected { reason }
                 if reason == "A takeback request is pending — resolve it before taking further actions"
+        ));
+        assert!(matches!(
+            session_action_error_message(SessionActionError::Operational(
+                "session storage failed".to_string(),
+            )),
+            ServerMessage::Error { message, .. } if message == "session storage failed"
         ));
     }
 

--- a/crates/server-core/src/client_message_wire_guard.rs
+++ b/crates/server-core/src/client_message_wire_guard.rs
@@ -38,6 +38,7 @@ use crate::legacy_join_guard::guard_legacy_join_game;
 use crate::protocol::{ClientMessage, ServerMessage, ServerMode};
 use crate::seat_mutation_wire_guard::guard_seat_mutation;
 use crate::spectator_wire_guard::{guard_spectate_draft, guard_spectator_join};
+use engine::types::action_rejection::{ActionRejection, ActionRejectionCode};
 
 /// Validate wire fields for any inbound `ClientMessage` before handler work.
 ///
@@ -222,16 +223,29 @@ pub fn wire_rejection_message(msg: &ClientMessage, reason: String) -> ServerMess
         // `MAX_INTERACTION_STRING_LEN` is 256, so a long paste is a rejected
         // decision, not a malformed frame. `ServerMessage::error` here would
         // end the match on a paste.
-        ClientMessage::Interaction { .. } => ServerMessage::ActionRejected { reason },
+        ClientMessage::Interaction { .. } => {
+            let _ = reason;
+            ServerMessage::ActionRejected {
+                rejection: ActionRejection::new(ActionRejectionCode::InteractionPayloadTooLarge),
+            }
+        }
+        ClientMessage::Action { .. } => ServerMessage::ActionRejected {
+            rejection: ActionRejection::new(ActionRejectionCode::InvalidAction),
+        },
+        ClientMessage::PreviewManaPayment { request_id, .. } => {
+            ServerMessage::ManaPaymentPreviewRejected {
+                request_id: *request_id,
+                rejection: ActionRejection::new(ActionRejectionCode::InvalidAction),
+            }
+        }
 
-        // Every other variant keeps today's behavior exactly: a bounds failure
-        // on these is a malformed frame, not a rejected decision.
+        // Every remaining variant keeps the operational-error behavior: a
+        // bounds failure on these is a malformed frame, not a rejected game
+        // decision.
         ClientMessage::ClientHello { .. }
         | ClientMessage::CreateGame { .. }
         | ClientMessage::JoinGame { .. }
-        | ClientMessage::Action { .. }
         | ClientMessage::ResolveAll { .. }
-        | ClientMessage::PreviewManaPayment { .. }
         | ClientMessage::Reconnect { .. }
         | ClientMessage::AbandonGame
         | ClientMessage::SubscribeLobby
@@ -557,12 +571,15 @@ mod tests {
     #[test]
     fn interaction_wire_rejection_answers_on_the_benign_channel() {
         let interaction = oversized_interaction_frame();
-        let reason =
+        let _reason =
             guard_client_message_before_dispatch(&interaction, ServerMode::Full).unwrap_err();
 
-        match wire_rejection_message(&interaction, reason.clone()) {
-            ServerMessage::ActionRejected { reason: answered } => {
-                assert_eq!(answered, reason);
+        match wire_rejection_message(&interaction, _reason) {
+            ServerMessage::ActionRejected { rejection } => {
+                assert_eq!(
+                    rejection.code,
+                    ActionRejectionCode::InteractionPayloadTooLarge
+                );
             }
             other => panic!("an interaction rejection must not tear the session down: {other:?}"),
         }
@@ -578,9 +595,14 @@ mod tests {
         assert!(
             matches!(
                 wire_rejection_message(&action, action_reason),
-                ServerMessage::Error { .. }
+                ServerMessage::ActionRejected {
+                    rejection: ActionRejection {
+                        code: ActionRejectionCode::InvalidAction,
+                        ..
+                    }
+                }
             ),
-            "an oversized action stays a malformed frame"
+            "an oversized action is a typed invalid action"
         );
     }
 }

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -66,7 +66,7 @@ pub use seat_mutation_wire_guard::guard_seat_mutation;
 pub use session::{
     acting_player, acting_players, generate_game_code, generate_player_token, is_acting,
     AiDriverFailure, AiDriverFault, BroadcastSnapshot, FullPersistDisposition, FullPersistSnapshot,
-    FullRuntime, FullSessionKey, RevisionedActionResult, SessionManager,
+    FullRuntime, FullSessionKey, RevisionedActionResult, SessionActionError, SessionManager,
 };
 pub use spectator_wire_guard::{
     guard_draft_spectator_capacity, guard_game_spectator_capacity, guard_spectate_draft,

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -523,6 +523,11 @@ pub enum ServerMessage {
     ActionRejected {
         rejection: ActionRejection,
     },
+    /// An operational failure while processing one submitted game action or
+    /// interaction. This deliberately carries no engine-rejection DTO.
+    ActionFailed {
+        message: String,
+    },
     /// A request outside the engine game-action boundary was refused. This is
     /// deliberately prose: takeback and match-lifecycle requests have no
     /// engine action/rejection provenance to expose.
@@ -538,6 +543,13 @@ pub enum ServerMessage {
     ResolveAllRejected {
         request_id: u64,
         rejection: ActionRejection,
+    },
+    /// Requester-only operational failure for a native Resolve All batch.
+    /// The request identifier prevents unrelated failures from settling this
+    /// promise.
+    ResolveAllFailed {
+        request_id: u64,
+        message: String,
     },
     /// Requester-only acknowledgement for a native Resolve All batch. The
     /// matching StateUpdate is sent first and carries the authoritative state.
@@ -559,6 +571,11 @@ pub enum ServerMessage {
     ManaPaymentPreviewRejected {
         request_id: u64,
         rejection: ActionRejection,
+    },
+    /// Requester-only operational failure for a mana-payment preview.
+    ManaPaymentPreviewFailed {
+        request_id: u64,
+        message: String,
     },
     OpponentDisconnected {
         grace_seconds: u32,
@@ -2405,8 +2422,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_40() {
-        assert_eq!(PROTOCOL_VERSION, 40);
+    fn protocol_version_is_41() {
+        assert_eq!(PROTOCOL_VERSION, 41);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -2416,7 +2433,7 @@ mod tests {
     /// understand.
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
-    /// this guards — and this test reds while `protocol_version_is_40` stays
+    /// this guards — and this test reds while `protocol_version_is_41` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {
@@ -2470,6 +2487,30 @@ mod tests {
         assert_eq!(
             serde_json::to_string(&rejected).unwrap(),
             r#"{"type":"ResolveAllRejected","data":{"request_id":7,"rejection":{"code":"resolve_all_not_ready","disposition":"unavailable","message":"Resolve All is not ready to run.","related_object_ids":[]}}}"#
+        );
+
+        assert_eq!(
+            serde_json::to_string(&ServerMessage::ActionFailed {
+                message: "session storage failed".to_string(),
+            })
+            .unwrap(),
+            r#"{"type":"ActionFailed","data":{"message":"session storage failed"}}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&ServerMessage::ResolveAllFailed {
+                request_id: 7,
+                message: "batch persistence failed".to_string(),
+            })
+            .unwrap(),
+            r#"{"type":"ResolveAllFailed","data":{"request_id":7,"message":"batch persistence failed"}}"#
+        );
+        assert_eq!(
+            serde_json::to_string(&ServerMessage::ManaPaymentPreviewFailed {
+                request_id: 7,
+                message: "preview lookup failed".to_string(),
+            })
+            .unwrap(),
+            r#"{"type":"ManaPaymentPreviewFailed","data":{"request_id":7,"message":"preview lookup failed"}}"#
         );
     }
 

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
 use engine::game::interaction::ObjectActionPayload;
+use engine::types::action_rejection::ActionRejection;
 use engine::types::actions::GameAction;
 use engine::types::events::GameEvent;
 use engine::types::format::FormatConfig;
@@ -520,6 +521,12 @@ pub enum ServerMessage {
         rewind_targets: Vec<RewindOption>,
     },
     ActionRejected {
+        rejection: ActionRejection,
+    },
+    /// A request outside the engine game-action boundary was refused. This is
+    /// deliberately prose: takeback and match-lifecycle requests have no
+    /// engine action/rejection provenance to expose.
+    RequestRejected {
         reason: String,
     },
     /// Confirms an authenticated action that intentionally produced no state
@@ -530,7 +537,7 @@ pub enum ServerMessage {
     /// identifier prevents unrelated action failures from settling this promise.
     ResolveAllRejected {
         request_id: u64,
-        reason: String,
+        rejection: ActionRejection,
     },
     /// Requester-only acknowledgement for a native Resolve All batch. The
     /// matching StateUpdate is sent first and carries the authoritative state.
@@ -551,7 +558,7 @@ pub enum ServerMessage {
     },
     ManaPaymentPreviewRejected {
         request_id: u64,
-        reason: String,
+        rejection: ActionRejection,
     },
     OpponentDisconnected {
         grace_seconds: u32,
@@ -2398,8 +2405,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_39() {
-        assert_eq!(PROTOCOL_VERSION, 39);
+    fn protocol_version_is_40() {
+        assert_eq!(PROTOCOL_VERSION, 40);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -2409,7 +2416,7 @@ mod tests {
     /// understand.
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
-    /// this guards — and this test reds while `protocol_version_is_39` stays
+    /// this guards — and this test reds while `protocol_version_is_40` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {
@@ -2456,11 +2463,13 @@ mod tests {
 
         let rejected = ServerMessage::ResolveAllRejected {
             request_id: 7,
-            reason: "Resolve All requires your priority".to_string(),
+            rejection: ActionRejection::new(
+                engine::types::action_rejection::ActionRejectionCode::ResolveAllNotReady,
+            ),
         };
         assert_eq!(
             serde_json::to_string(&rejected).unwrap(),
-            r#"{"type":"ResolveAllRejected","data":{"request_id":7,"reason":"Resolve All requires your priority"}}"#
+            r#"{"type":"ResolveAllRejected","data":{"request_id":7,"rejection":{"code":"resolve_all_not_ready","disposition":"unavailable","message":"Resolve All is not ready to run.","related_object_ids":[]}}}"#
         );
     }
 

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -7,20 +7,21 @@ use engine::database::legality::{validate_cedh_bracket, CedhBracketError};
 use engine::database::CardDatabase;
 use engine::game::deck_loading::{DeckPayload, PlayerDeckPayload};
 use engine::game::engine::{
-    apply, pending_resolve_all_ready_requester, recover_orphaned_resolve_all,
-    resolve_all_ready_access, resolve_all_ready_prefix, start_game, ResolveAllReadyAccess,
+    apply, apply_with_rejection, pending_resolve_all_ready_requester, recover_orphaned_resolve_all,
+    resolve_all_ready_access, resolve_all_ready_prefix, resolve_all_ready_prefix_with_rejection,
+    start_game, ResolveAllReadyAccess,
 };
-use engine::game::interaction::{bind_interaction_authority, submit_interaction};
+use engine::game::interaction::{bind_interaction_authority, submit_interaction_with_rejection};
 use engine::game::layers::flush_layers;
 use engine::game::match_flow::apply_trusted_match_forfeit;
-use engine::game::preview::preview_auto_payment_sources;
 use engine::game::public_state::{
     bump_state_revision, finalize_public_state, mark_public_state_all_dirty,
 };
 use engine::game::{
-    create_debug_cards, debug_card_entry_source, load_and_hydrate_decks, preflight_debug_action,
+    create_debug_cards_with_rejection, debug_card_entry_source, load_and_hydrate_decks,
     rehydrate_game_from_card_db, DebugCardCreateRequest,
 };
+use engine::types::action_rejection::ActionRejection;
 use engine::types::actions::{DebugAction, GameAction};
 use engine::types::events::GameEvent;
 use engine::types::format::FormatConfig;
@@ -98,6 +99,33 @@ pub type ActionResult = (
 /// allocated while the session lock was held. The transport must keep this
 /// pairing intact when it fans a snapshot out to multiple viewers.
 pub type RevisionedActionResult = (u64, ActionResult);
+
+/// Distinguishes an engine-owned, viewer-safe action refusal from an
+/// operational session failure. Only the former is eligible for a structured
+/// `ActionRejected` frame at the WebSocket boundary.
+#[derive(Debug)]
+pub enum SessionActionError {
+    Operational(String),
+    /// A non-engine request cannot proceed because a session lifecycle action
+    /// (such as an in-flight takeback) must settle first.
+    RequestRejected(String),
+    Rejected(ActionRejection),
+}
+
+impl From<String> for SessionActionError {
+    fn from(value: String) -> Self {
+        Self::Operational(value)
+    }
+}
+
+impl SessionActionError {
+    fn into_legacy_reason(self) -> String {
+        match self {
+            Self::Operational(reason) | Self::RequestRejected(reason) => reason,
+            Self::Rejected(rejection) => rejection.message,
+        }
+    }
+}
 
 /// The server-visible result of driving the native AI after an authoritative
 /// transition. A non-empty `failure` is terminal for the AI driver, but does
@@ -1765,6 +1793,17 @@ impl SessionManager {
         player_token: &str,
         action: &GameAction,
     ) -> Result<Vec<ObjectId>, String> {
+        self.preview_mana_payment_with_rejection(game_code, player_token, action)
+            .map_err(SessionActionError::into_legacy_reason)
+    }
+
+    /// Viewer-safe preview form for the Full transport.
+    pub fn preview_mana_payment_with_rejection(
+        &self,
+        game_code: &str,
+        player_token: &str,
+        action: &GameAction,
+    ) -> Result<Vec<ObjectId>, SessionActionError> {
         let session = self
             .sessions
             .get(game_code)
@@ -1774,8 +1813,12 @@ impl SessionManager {
             .player_for_token(player_token)
             .ok_or_else(|| "Invalid player token".to_string())?;
 
-        preview_auto_payment_sources(&session.state, player, action)
-            .map_err(|error| format!("Engine error: {error}"))
+        engine::game::preview::preview_auto_payment_sources_with_rejection(
+            &session.state,
+            player,
+            action,
+        )
+        .map_err(SessionActionError::Rejected)
     }
 
     /// Handle a game action from a player.
@@ -1801,6 +1844,21 @@ impl SessionManager {
         action: GameAction,
         card_db: Option<&CardDatabase>,
     ) -> Result<ActionResult, String> {
+        self.handle_action_with_card_db_outcome(game_code, player_token, action, card_db)
+            .map_err(SessionActionError::into_legacy_reason)
+    }
+
+    /// Rich form used by the Full WebSocket transport. Engine rejection DTOs
+    /// remain distinct from session/database failures so the transport never
+    /// has to infer meaning from a diagnostic string.
+    #[allow(clippy::type_complexity)]
+    pub fn handle_action_with_card_db_outcome(
+        &mut self,
+        game_code: &str,
+        player_token: &str,
+        action: GameAction,
+        card_db: Option<&CardDatabase>,
+    ) -> Result<ActionResult, SessionActionError> {
         let session = self
             .sessions
             .get_mut(game_code)
@@ -1818,10 +1876,10 @@ impl SessionManager {
         // voting on or silently discard the action once the rollback lands.
         // Require the table to resolve (approve/decline/cancel) first.
         if session.pending_takeback.is_some() {
-            return Err(
+            return Err(SessionActionError::RequestRejected(
                 "A takeback request is pending — resolve it before taking further actions"
                     .to_string(),
-            );
+            ));
         }
 
         // Debug capability gate. `debug_permitted` is the single authority:
@@ -1833,10 +1891,13 @@ impl SessionManager {
         // `RevokeDebugPermission` (sandbox games only). Naming a mode in the
         // refusal would be wrong for the single-user source, so the message
         // stays on the seat, which is what was actually checked.
-        if matches!(action, GameAction::Debug(_))
-            && !session.state.debug_permitted.contains(&player)
-        {
-            return Err("Debug actions are not permitted for this seat".to_string());
+        if let GameAction::Debug(debug_action) = &action {
+            engine::game::preflight_debug_action_with_rejection(
+                &session.state,
+                player,
+                debug_action,
+            )
+            .map_err(SessionActionError::Rejected)?;
         }
 
         // Grant/Revoke debug permission: host-only, and only meaningful in a
@@ -1846,17 +1907,23 @@ impl SessionManager {
         match &action {
             GameAction::GrantDebugPermission { .. } | GameAction::RevokeDebugPermission { .. } => {
                 if !session.state.format_config.allow_debug_actions {
-                    return Err("Sandbox mode is not enabled for this game".to_string());
+                    return Err(SessionActionError::Rejected(ActionRejection::new(
+                        engine::types::action_rejection::ActionRejectionCode::ActionNotAllowed,
+                    )));
                 }
                 if player != HOST_PLAYER {
-                    return Err("Only the host can grant or revoke debug permission".to_string());
+                    return Err(SessionActionError::Rejected(ActionRejection::new(
+                        engine::types::action_rejection::ActionRejectionCode::ActionNotAllowed,
+                    )));
                 }
                 if let GameAction::RevokeDebugPermission {
                     player_id: target, ..
                 } = &action
                 {
                     if *target == HOST_PLAYER {
-                        return Err("The host cannot revoke their own debug permission".to_string());
+                        return Err(SessionActionError::Rejected(ActionRejection::new(
+                            engine::types::action_rejection::ActionRejectionCode::ActionNotAllowed,
+                        )));
                     }
                 }
             }
@@ -1868,10 +1935,6 @@ impl SessionManager {
         // access; the engine validates actor authorization and action shape.
         // Candidate enumeration is advisory for clients and AI, not a second
         // legality gate: several legal action classes are combinatorial.
-        if let GameAction::Debug(debug_action) = &action {
-            preflight_debug_action(&session.state, player, debug_action)
-                .map_err(|error| format!("Engine error: {error}"))?;
-        }
         if matches!(&action, GameAction::Debug(debug_action) if debug_action.is_zero_count_create())
         {
             let (legal_actions, spell_costs, by_object) = engine_legal_actions_full(&session.state);
@@ -1922,7 +1985,7 @@ impl SessionManager {
                 nonlegendary,
                 ..
             }) => {
-                let result = create_debug_cards(
+                let result = create_debug_cards_with_rejection(
                     &mut session.state,
                     DebugCardCreateRequest {
                         actor: player,
@@ -1936,16 +1999,14 @@ impl SessionManager {
                         nonlegendary,
                     },
                 )
-                .map_err(|error| format!("Engine error: {error}"))?;
+                .map_err(SessionActionError::Rejected)?;
                 bump_state_revision(&mut session.state);
                 mark_public_state_all_dirty(&mut session.state);
                 finalize_public_state(&mut session.state);
                 result
             }
-            action => apply(&mut session.state, player, action).map_err(|e| {
-                warn!(game = %game_code, player = ?player, error = %e, reason = "engine_error", "action rejected");
-                format!("Engine error: {}", e)
-            })?,
+            action => apply_with_rejection(&mut session.state, player, action)
+                .map_err(SessionActionError::Rejected)?,
         };
         if let Some(snapshot) = pre_action_state {
             session.push_takeback_state(player, snapshot);
@@ -1994,10 +2055,22 @@ impl SessionManager {
         player_token: &str,
         max_resolutions: u32,
     ) -> Result<ResolveAllActionResult, String> {
+        self.resolve_all_for_player_with_rejection(game_code, player_token, max_resolutions)
+            .map_err(SessionActionError::into_legacy_reason)
+    }
+
+    /// Rich Resolve All form for the Full transport.
+    pub fn resolve_all_for_player_with_rejection(
+        &mut self,
+        game_code: &str,
+        player_token: &str,
+        max_resolutions: u32,
+    ) -> Result<ResolveAllActionResult, SessionActionError> {
         if max_resolutions > MAX_RESOLVE_ALL_RESOLUTIONS {
             return Err(format!(
                 "Resolve All maximum must not exceed {MAX_RESOLVE_ALL_RESOLUTIONS}"
-            ));
+            )
+            .into());
         }
 
         let session = self
@@ -2010,10 +2083,10 @@ impl SessionManager {
             .ok_or_else(|| "Invalid player token".to_string())?;
 
         if session.pending_takeback.is_some() {
-            return Err(
+            return Err(SessionActionError::RequestRejected(
                 "A takeback request is pending — resolve it before taking further actions"
                     .to_string(),
-            );
+            ));
         }
 
         // Reject only an unentitled caller. A latch whose frozen run has gone
@@ -2023,13 +2096,6 @@ impl SessionManager {
         // nothing any client offers the player to press.
         // Exhaustive rather than an equality test: a future variant must be
         // classified here instead of silently defaulting to allowed.
-        match resolve_all_ready_access(&session.state, requester) {
-            ResolveAllReadyAccess::Refused => {
-                return Err("Resolve All consent is not ready".to_string());
-            }
-            ResolveAllReadyAccess::Admitted => {}
-        }
-
         session.state.log_player_names = session.display_names.clone();
         flush_layers(&mut session.state);
         let pre_action_state = session.state.clone();
@@ -2037,7 +2103,8 @@ impl SessionManager {
         // argument remains range-checked above for transport compatibility but
         // cannot enlarge or replace that explicit authorization.
         let _ = max_resolutions;
-        let batch = resolve_all_ready_prefix(&mut session.state, requester);
+        let batch = resolve_all_ready_prefix_with_rejection(&mut session.state, requester)
+            .map_err(SessionActionError::Rejected)?;
         let summary = ResolveAllSummary {
             items_resolved: batch.items_resolved,
             total: batch.total,
@@ -2099,6 +2166,18 @@ impl SessionManager {
         player_token: &str,
         submission: InteractionSubmission,
     ) -> Result<ActionResult, String> {
+        self.handle_interaction_with_rejection(game_code, player_token, submission)
+            .map_err(SessionActionError::into_legacy_reason)
+    }
+
+    /// Rich interaction form for the authenticated Full transport.
+    #[allow(clippy::type_complexity)]
+    pub fn handle_interaction_with_rejection(
+        &mut self,
+        game_code: &str,
+        player_token: &str,
+        submission: InteractionSubmission,
+    ) -> Result<ActionResult, SessionActionError> {
         let session = self
             .sessions
             .get_mut(game_code)
@@ -2113,10 +2192,10 @@ impl SessionManager {
         // GH #1507: the authoritative state must not move while the table is
         // voting on a rollback. Same interlock, same reason, as `handle_action`.
         if session.pending_takeback.is_some() {
-            return Err(
+            return Err(SessionActionError::RequestRejected(
                 "A takeback request is pending — resolve it before taking further actions"
                     .to_string(),
-            );
+            ));
         }
 
         // Snapshot BEFORE `log_player_names` is written, matching
@@ -2136,22 +2215,8 @@ impl SessionManager {
         // Set player names for log resolution.
         session.state.log_player_names = session.display_names.clone();
 
-        let applied =
-            submit_interaction(&mut session.state, player, submission).map_err(|error| {
-                warn!(
-                    game = %game_code,
-                    player = ?player,
-                    code = ?error.code,
-                    reason = "interaction_rejected",
-                    "interaction rejected"
-                );
-                // Byte-identical to the WASM transport
-                // (`engine-wasm/src/lib.rs`) and to
-                // `interaction_payload_guard`, so every layer that reports an
-                // engine reason code, on both transports, classifies the same
-                // rejection identically.
-                format!("Engine error: {:?}", error.code)
-            })?;
+        let applied = submit_interaction_with_rejection(&mut session.state, player, submission)
+            .map_err(SessionActionError::Rejected)?;
 
         if !applied.action.is_actor_scoped_preference() {
             session.push_takeback_state(player, pre_action_state);

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -6402,7 +6402,7 @@ mod tests {
         // Illegal division first: wrong total (4 != 5). It reaches apply() and
         // is rejected by the engine, proving candidate removal does not weaken
         // structural validation.
-        let illegal = mgr.handle_action(
+        let illegal = mgr.handle_action_with_card_db_outcome(
             &code,
             &token,
             GameAction::AssignCombatDamage {
@@ -6411,11 +6411,16 @@ mod tests {
                 trample_damage: 0,
                 controller_damage: 0,
             },
+            None,
         );
         match illegal {
-            Err(e) => assert!(
-                e.starts_with("Engine error:"),
-                "wrong-total division must be rejected by apply(), not the gate, got: {e}"
+            Err(SessionActionError::Rejected(rejection)) => assert_eq!(
+                rejection.code,
+                engine::types::action_rejection::ActionRejectionCode::InvalidAction,
+                "wrong-total division must be rejected by apply(), not the gate"
+            ),
+            Err(error) => panic!(
+                "wrong-total division must be rejected by apply(), not the gate, got: {error:?}"
             ),
             Ok(_) => panic!("wrong-total combat damage division must be rejected"),
         }

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -4949,7 +4949,10 @@ mod tests {
                 }),
             )
             .expect_err("a real entry off Priority must fail before database lookup");
-        assert!(priority_error.contains("Priority window"));
+        assert_eq!(
+            priority_error,
+            "That action is not valid in the current game state."
+        );
         assert!(!priority_error.contains("card database"));
     }
 

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -2067,10 +2067,9 @@ impl SessionManager {
         max_resolutions: u32,
     ) -> Result<ResolveAllActionResult, SessionActionError> {
         if max_resolutions > MAX_RESOLVE_ALL_RESOLUTIONS {
-            return Err(format!(
-                "Resolve All maximum must not exceed {MAX_RESOLVE_ALL_RESOLUTIONS}"
-            )
-            .into());
+            return Err(SessionActionError::Rejected(ActionRejection::new(
+                engine::types::action_rejection::ActionRejectionCode::InvalidAction,
+            )));
         }
 
         let session = self

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -8,7 +8,7 @@ use engine::database::CardDatabase;
 use engine::game::deck_loading::{DeckPayload, PlayerDeckPayload};
 use engine::game::engine::{
     apply_with_rejection, pending_resolve_all_ready_requester, recover_orphaned_resolve_all,
-    resolve_all_ready_prefix_with_rejection, start_game,
+    resolve_all_ready_prefix, resolve_all_ready_prefix_with_rejection, start_game,
 };
 use engine::game::interaction::{bind_interaction_authority, submit_interaction_with_rejection};
 use engine::game::layers::flush_layers;

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -6603,10 +6603,7 @@ mod tests {
 
         let forged = mgr.handle_interaction(&code, other_token, witness.clone());
         let error = forged.expect_err("a valid token for another seat must not spend this slot");
-        assert!(
-            error.contains("NotAuthorized"),
-            "unexpected reason: {error}"
-        );
+        assert_eq!(error, "You are not authorized to answer that interaction.");
         assert_eq!(
             mgr.sessions[&code].state.active_interaction_slots, before,
             "a refused submission must not consume the capability"
@@ -6655,7 +6652,7 @@ mod tests {
         let error = mgr
             .handle_interaction(&code, acting_token, witness)
             .expect_err("an interaction id is single-use");
-        assert!(error.contains("StaleInteraction"), "unexpected: {error}");
+        assert_eq!(error, "That interaction has already changed.");
     }
 
     #[test]
@@ -6674,7 +6671,7 @@ mod tests {
         let error = mgr
             .handle_interaction(&code, acting_token, oversized)
             .expect_err("an oversized response is refused");
-        assert_eq!(error, "Engine error: PayloadTooLarge");
+        assert_eq!(error, "That interaction response is too large.");
 
         // Negative sibling: the boundary sits at the constant, not at "any
         // large list". The same shape at exactly the limit is still refused,
@@ -6689,7 +6686,7 @@ mod tests {
             .handle_interaction(&code, acting_token, at_limit)
             .expect_err("unknown choices are still refused");
         assert!(
-            !error.contains("PayloadTooLarge"),
+            error != "That interaction response is too large.",
             "the bound must be the constant, not list size in general: {error}"
         );
     }

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -6543,7 +6543,7 @@ mod tests {
         assert!(
             matches!(
                 duplicate,
-                Err(SessionActionError::Rejected(rejection))
+                Err(SessionActionError::Rejected(ref rejection))
                     if rejection.code
                         == engine::types::action_rejection::ActionRejectionCode::InvalidAction
             ),

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -713,7 +713,7 @@ impl GameSession {
             // `debug_mode` unconditionally for single-player. The sandbox
             // *format* flag stays false, so own-library name exposure
             // (`engine::game::visibility`) and the host grant/revoke flow
-            // (rejected above with "Sandbox mode is not enabled") remain
+            // (rejected above as ActionNotAllowed) remain
             // closed — this grants the debug panel, not a shared sandbox.
             //
             // Human seats only. An AI seat has no client and never submits a
@@ -4896,7 +4896,10 @@ mod tests {
                 }),
             )
             .expect_err("an invalid owner must fail before database lookup");
-        assert!(owner_error.contains("invalid owner player id"));
+        assert_eq!(
+            owner_error,
+            "That action is not valid in the current game state."
+        );
         assert!(!owner_error.contains("card database"));
 
         let session = &mgr.sessions[&code];
@@ -5719,7 +5722,7 @@ mod tests {
         );
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.contains("host"), "{err}");
+        assert_eq!(err, "That action is not allowed right now.");
     }
 
     #[test]
@@ -5735,7 +5738,7 @@ mod tests {
         );
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.contains("own"), "{err}");
+        assert_eq!(err, "That action is not allowed right now.");
     }
 
     #[test]
@@ -5751,7 +5754,7 @@ mod tests {
         );
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(err.contains("Sandbox"), "{err}");
+        assert_eq!(err, "That action is not allowed right now.");
     }
 
     #[test]
@@ -6708,10 +6711,7 @@ mod tests {
         let error = mgr
             .handle_interaction(&code, acting_token, witness.clone())
             .expect_err("the table is voting; the state must not move");
-        assert!(
-            error.contains("takeback request is pending"),
-            "unexpected: {error}"
-        );
+        assert_eq!(error, "That action is not allowed right now.");
         assert_eq!(
             mgr.sessions[&code].state.active_interaction_slots,
             before_slots

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -106,8 +106,9 @@ pub type RevisionedActionResult = (u64, ActionResult);
 #[derive(Debug)]
 pub enum SessionActionError {
     Operational(String),
-    /// A non-engine request cannot proceed because a session lifecycle action
-    /// (such as an in-flight takeback) must settle first.
+    /// A request-only lifecycle operation cannot proceed. Game-action-shaped
+    /// attempts use [`Self::Rejected`] so their pending client promises settle
+    /// on correlated action-response frames.
     RequestRejected(String),
     Rejected(ActionRejection),
 }
@@ -1876,10 +1877,9 @@ impl SessionManager {
         // voting on or silently discard the action once the rollback lands.
         // Require the table to resolve (approve/decline/cancel) first.
         if session.pending_takeback.is_some() {
-            return Err(SessionActionError::RequestRejected(
-                "A takeback request is pending — resolve it before taking further actions"
-                    .to_string(),
-            ));
+            return Err(SessionActionError::Rejected(ActionRejection::new(
+                engine::types::action_rejection::ActionRejectionCode::ActionNotAllowed,
+            )));
         }
 
         // Debug capability gate. `debug_permitted` is the single authority:
@@ -2083,10 +2083,9 @@ impl SessionManager {
             .ok_or_else(|| "Invalid player token".to_string())?;
 
         if session.pending_takeback.is_some() {
-            return Err(SessionActionError::RequestRejected(
-                "A takeback request is pending — resolve it before taking further actions"
-                    .to_string(),
-            ));
+            return Err(SessionActionError::Rejected(ActionRejection::new(
+                engine::types::action_rejection::ActionRejectionCode::ActionNotAllowed,
+            )));
         }
 
         // Reject only an unentitled caller. A latch whose frozen run has gone
@@ -2192,10 +2191,9 @@ impl SessionManager {
         // GH #1507: the authoritative state must not move while the table is
         // voting on a rollback. Same interlock, same reason, as `handle_action`.
         if session.pending_takeback.is_some() {
-            return Err(SessionActionError::RequestRejected(
-                "A takeback request is pending — resolve it before taking further actions"
-                    .to_string(),
-            ));
+            return Err(SessionActionError::Rejected(ActionRejection::new(
+                engine::types::action_rejection::ActionRejectionCode::ActionNotAllowed,
+            )));
         }
 
         // Snapshot BEFORE `log_player_names` is written, matching
@@ -3669,11 +3667,15 @@ mod tests {
             .request_takeback(priority_player, RewindTarget::LastAction)
             .unwrap();
 
-        let result = mgr.handle_action(&code, &other_token, GameAction::PassPriority);
-        assert!(
-            result.is_err(),
-            "action should be rejected while a takeback is pending"
-        );
+        let result = mgr
+            .handle_action_with_card_db_outcome(&code, &other_token, GameAction::PassPriority, None)
+            .expect_err("action should be rejected while a takeback is pending");
+        assert!(matches!(
+            result,
+            SessionActionError::Rejected(rejection)
+                if rejection.code
+                    == engine::types::action_rejection::ActionRejectionCode::ActionNotAllowed
+        ));
     }
 
     /// A solo human vs. AI seats auto-resolves their own takeback request —

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -5007,10 +5007,7 @@ mod tests {
         );
         assert!(result.is_err());
         let err = result.unwrap_err();
-        assert!(
-            err.contains("not permitted") || err.contains("permission"),
-            "{err}"
-        );
+        assert_eq!(err, "That action is not valid in the current game state.");
     }
 
     /// Fixture shape for the `HostingMode` tests below, matching the existing
@@ -5654,7 +5651,7 @@ mod tests {
                 None,
             )
             .expect_err("revoked guests cannot reach the server CreateCard path");
-        assert_eq!(err, "Debug actions are not permitted for this seat");
+        assert_eq!(err, "You are not authorized to use debug actions.");
     }
 
     #[test]
@@ -6531,7 +6528,7 @@ mod tests {
 
         // The bypass must not weaken validation: a malformed freeform declaration
         // reaches the engine and is rejected there rather than by candidate lookup.
-        let duplicate = mgr.handle_action(
+        let duplicate = mgr.handle_action_with_card_db_outcome(
             &code,
             &token0,
             GameAction::DeclareAttackers {
@@ -6541,9 +6538,15 @@ mod tests {
                 ],
                 bands: vec![],
             },
+            None,
         );
         assert!(
-            matches!(duplicate, Err(ref error) if error.starts_with("Engine error:")),
+            matches!(
+                duplicate,
+                Err(SessionActionError::Rejected(rejection))
+                    if rejection.code
+                        == engine::types::action_rejection::ActionRejectionCode::InvalidAction
+            ),
             "a duplicate attacker must be rejected by the engine, got: {duplicate:?}"
         );
 

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -7,9 +7,8 @@ use engine::database::legality::{validate_cedh_bracket, CedhBracketError};
 use engine::database::CardDatabase;
 use engine::game::deck_loading::{DeckPayload, PlayerDeckPayload};
 use engine::game::engine::{
-    apply, apply_with_rejection, pending_resolve_all_ready_requester, recover_orphaned_resolve_all,
-    resolve_all_ready_access, resolve_all_ready_prefix, resolve_all_ready_prefix_with_rejection,
-    start_game, ResolveAllReadyAccess,
+    apply_with_rejection, pending_resolve_all_ready_requester, recover_orphaned_resolve_all,
+    resolve_all_ready_prefix_with_rejection, start_game,
 };
 use engine::game::interaction::{bind_interaction_authority, submit_interaction_with_rejection};
 use engine::game::layers::flush_layers;

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -2256,6 +2256,20 @@ impl SessionManager {
         game_code: &str,
         player_token: &str,
     ) -> Result<RevisionedActionResult, String> {
+        self.handle_match_concede_outcome(game_code, player_token)
+            .map_err(SessionActionError::into_legacy_reason)
+    }
+
+    /// Three-way result for the transport-owned match-concede request.
+    ///
+    /// Authentication/session availability remains operational. A request that
+    /// is validly authenticated but cannot forfeit the current match is a
+    /// requester-visible lifecycle refusal instead.
+    pub fn handle_match_concede_outcome(
+        &mut self,
+        game_code: &str,
+        player_token: &str,
+    ) -> Result<RevisionedActionResult, SessionActionError> {
         let session = self
             .sessions
             .get_mut(game_code)
@@ -2265,16 +2279,17 @@ impl SessionManager {
             .ok_or_else(|| "Invalid player token".to_string())?;
         session.reject_if_ai_driver_faulted()?;
         if session.pending_takeback.is_some() {
-            return Err(
+            return Err(SessionActionError::RequestRejected(
                 "A takeback request is pending — resolve it before conceding the match".to_string(),
-            );
+            ));
         }
 
         let events = apply_trusted_match_forfeit(
             &mut session.state,
             player,
             MatchForfeitCause::MatchConcede,
-        )?;
+        )
+        .map_err(SessionActionError::RequestRejected)?;
         let (legal_actions, spell_costs, by_object) = engine_legal_actions_full(&session.state);
         let auto_pass = auto_pass_recommended(&session.state, &legal_actions);
         let revision = session.advance_state_revision();
@@ -4514,6 +4529,25 @@ mod tests {
             .handle_match_concede(&code, &token0)
             .expect_err("a terminal AI driver fault blocks match concede");
         assert!(err.contains("Native AI driver fault"));
+    }
+
+    #[test]
+    fn match_concede_distinguishes_lifecycle_refusal_from_operational_failure() {
+        let (mut mgr, code, token0, _token1) = setup_two_player_game();
+
+        let lifecycle = mgr
+            .handle_match_concede_outcome(&code, &token0)
+            .expect_err("a non-Bo3 match cannot be conceded as a match");
+        assert!(matches!(
+            lifecycle,
+            SessionActionError::RequestRejected(reason)
+                if reason == "Match forfeits require a best-of-three match"
+        ));
+
+        let operational = mgr
+            .handle_match_concede_outcome("missing", &token0)
+            .expect_err("an absent session is operational");
+        assert!(matches!(operational, SessionActionError::Operational(_)));
     }
 
     /// Drives the fixture until **`run_ai` itself** publishes a turn boundary

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 39;
+const EXPECTED_PROTOCOL_VERSION = 40;
 // The LOBBY message-set version. Deliberately separate from the full-game
 // number above and deliberately NOT derived from it: a GameState-only bump must
 // not move the lobby's compatibility window. See the assertions at the bottom.

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -14,7 +14,7 @@ const EXPECTED_LOBBY_PROTOCOL_VERSION = 1;
 // here, so a full-game bump could ship with an unbumped P2P version and CI
 // stayed green — a v(n-1) host and a v(n) guest would then complete a
 // handshake and only fail when the incompatible payload arrived.
-const EXPECTED_WIRE_PROTOCOL_VERSION = 30;
+const EXPECTED_WIRE_PROTOCOL_VERSION = 31;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 40;
+const EXPECTED_PROTOCOL_VERSION = 41;
 // The LOBBY message-set version. Deliberately separate from the full-game
 // number above and deliberately NOT derived from it: a GameState-only bump must
 // not move the lobby's compatibility window. See the assertions at the bottom.


### PR DESCRIPTION
- **feat(engine): add structured action rejections**
- **fix(engine): complete action rejection context**
- **test(engine): cover preview action rejection**
- **feat(engine): classify debug permission rejections**
- **fix(engine): correct action rejection test identifier**
- **test(engine): align action rejection expectations**
- **feat(engine): expose debug permission rejection**
- **fix(engine): classify rich debug permission denials**
- **fix(engine): classify debug preview permission denials**
- **fix(engine): preflight debug payment previews**
- **feat(local): transport structured action rejections**
- **feat(server): transport structured action rejections**
- **fix(server): separate request and operational refusals**
- **fix(server): correlate pending takeback refusals**
- **fix(server): correlate invalid resolve all requests**
- **fix(server): correlate operational action failures**
- **feat(p2p): transport structured action rejections**
- **feat(ui): anchor structured action rejections**
- **fix(ui): report rejected store actions**
- **fix(ui): surface draft action rejections**
- **fix(ui): anchor visible zone rejections**
- **fix(ui): anchor command zone rejections**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added clearer, structured messages for rejected actions, interactions, previews, and resolution requests.
  * Notifications can now appear beside the affected card or game object.
  * Added distinct handling for request refusals versus temporary operational failures.
  * Improved retry behavior for recoverable actions and silently ignores stale actions.
  * Enhanced multiplayer connection validation and compatibility checks.
  * Hidden game objects remain protected in contextual error details.
  * Added clearer reconnection rejection messages in supported languages.
* **Bug Fixes**
  * Prevented malformed or outdated rejection data from exposing unsafe messages.
  * Improved request correlation to avoid displaying unrelated failures.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->