### PR TITLE
ship/fix engine clear command roles from spell copies

### DIFF
--- a/crates/engine/src/game/commander.rs
+++ b/crates/engine/src/game/commander.rs
@@ -582,9 +582,10 @@ mod tests {
             "Malformed Commander Copy",
             vec![],
         );
+        let signature_card_id = CardId(state.next_object_id);
         let signature_spell = create_object(
             &mut state,
-            CardId(state.next_object_id),
+            signature_card_id,
             PlayerId(1),
             "Malformed Signature Copy".to_string(),
             Zone::Exile,
@@ -614,9 +615,10 @@ mod tests {
             "Malformed Commander Copy",
             vec![],
         );
+        let signature_card_id = CardId(state.next_object_id);
         let signature_spell = create_object(
             &mut state,
-            CardId(state.next_object_id),
+            signature_card_id,
             PlayerId(1),
             "Malformed Signature Copy".to_string(),
             Zone::Exile,
@@ -671,9 +673,10 @@ mod tests {
         ));
 
         let mut signature_state = setup_commander_game();
+        let signature_card_id = CardId(signature_state.next_object_id);
         let signature_spell = create_object(
             &mut signature_state,
-            CardId(signature_state.next_object_id),
+            signature_card_id,
             PlayerId(1),
             "Signature Spell".to_string(),
             Zone::Exile,

--- a/crates/engine/src/game/commander.rs
+++ b/crates/engine/src/game/commander.rs
@@ -131,6 +131,12 @@ pub fn commander_lethal_headroom(
 /// commander. Hand/library components are not eligible for this SBA helper.
 pub fn commander_eligible_for_zone_return(state: &GameState) -> Option<(ObjectId, PlayerId, Zone)> {
     state.objects.values().find_map(|obj| {
+        // CR 903.3 + CR 111.6: command-zone roles designate cards, not tokens.
+        // This defensive gate also lets CR 704.5d remove malformed legacy
+        // token copies instead of pausing SBA processing for an impossible choice.
+        if obj.is_token {
+            return None;
+        }
         // Oathbreaker RC: signature spells return to the command zone just like
         // commanders.
         if !obj.uses_command_zone_rules() {
@@ -565,6 +571,128 @@ mod tests {
 
         assert!(commander_eligible_for_zone_return(&state).is_none());
         let _ = obj_id; // suppress unused warning
+    }
+
+    #[test]
+    fn token_command_zone_roles_are_not_sba_eligible() {
+        let mut state = setup_commander_game();
+        let commander = create_commander_in_command_zone(
+            &mut state,
+            PlayerId(0),
+            "Malformed Commander Copy",
+            vec![],
+        );
+        let signature_spell = create_object(
+            &mut state,
+            CardId(state.next_object_id),
+            PlayerId(1),
+            "Malformed Signature Copy".to_string(),
+            Zone::Exile,
+        );
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, commander, Zone::Graveyard, &mut events);
+        state.objects.get_mut(&commander).unwrap().is_token = true;
+        let signature = state.objects.get_mut(&signature_spell).unwrap();
+        signature.is_token = true;
+        signature.mark_signature_spell();
+
+        assert!(
+            commander_eligible_for_zone_return(&state).is_none(),
+            "CR 903.3: tokens with copied command-zone roles are not eligible"
+        );
+    }
+
+    #[test]
+    fn token_command_zone_roles_cease_without_blocking_sba_progress() {
+        use crate::game::sba::check_state_based_actions;
+        use crate::types::game_state::WaitingFor;
+
+        let mut state = setup_commander_game();
+        let commander = create_commander_in_command_zone(
+            &mut state,
+            PlayerId(0),
+            "Malformed Commander Copy",
+            vec![],
+        );
+        let signature_spell = create_object(
+            &mut state,
+            CardId(state.next_object_id),
+            PlayerId(1),
+            "Malformed Signature Copy".to_string(),
+            Zone::Exile,
+        );
+        let mut events = Vec::new();
+        crate::game::zones::move_to_zone(&mut state, commander, Zone::Graveyard, &mut events);
+        state.objects.get_mut(&commander).unwrap().is_token = true;
+        let signature = state.objects.get_mut(&signature_spell).unwrap();
+        signature.is_token = true;
+        signature.mark_signature_spell();
+
+        check_state_based_actions(&mut state, &mut events);
+
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::CommanderZoneChoice { .. }),
+            "malformed token roles must not create an unreachable commander choice"
+        );
+        assert!(
+            !state.objects.contains_key(&commander)
+                && !state.objects.contains_key(&signature_spell),
+            "CR 704.5d: token copies outside the battlefield must cease to exist"
+        );
+    }
+
+    #[test]
+    fn non_token_commander_and_signature_spell_remain_sba_eligible() {
+        use crate::game::sba::check_state_based_actions;
+        use crate::types::game_state::WaitingFor;
+
+        let mut commander_state = setup_commander_game();
+        let commander = create_commander_in_command_zone(
+            &mut commander_state,
+            PlayerId(0),
+            "Commander",
+            vec![],
+        );
+        let mut commander_events = Vec::new();
+        crate::game::zones::move_to_zone(
+            &mut commander_state,
+            commander,
+            Zone::Graveyard,
+            &mut commander_events,
+        );
+        check_state_based_actions(&mut commander_state, &mut commander_events);
+        assert!(matches!(
+            commander_state.waiting_for,
+            WaitingFor::CommanderZoneChoice {
+                commander_id,
+                current_zone: Zone::Graveyard,
+                ..
+            } if commander_id == commander
+        ));
+
+        let mut signature_state = setup_commander_game();
+        let signature_spell = create_object(
+            &mut signature_state,
+            CardId(signature_state.next_object_id),
+            PlayerId(1),
+            "Signature Spell".to_string(),
+            Zone::Exile,
+        );
+        signature_state
+            .objects
+            .get_mut(&signature_spell)
+            .unwrap()
+            .mark_signature_spell();
+        let mut signature_events = Vec::new();
+        check_state_based_actions(&mut signature_state, &mut signature_events);
+        assert!(matches!(
+            signature_state.waiting_for,
+            WaitingFor::CommanderZoneChoice {
+                commander_id,
+                current_zone: Zone::Exile,
+                ..
+            } if commander_id == signature_spell
+        ));
     }
 
     // --- Control-Condition Phasing Tests (CR 702.26b) ---

--- a/crates/engine/src/game/effects/copy_spell.rs
+++ b/crates/engine/src/game/effects/copy_spell.rs
@@ -100,6 +100,11 @@ pub fn resolve(
         // allow-raw-zone: spell-copy birth directly on stack has no from-zone event (CR 707.10).
         copy_obj.zone = Zone::Stack;
         copy_obj.is_token = true;
+        // CR 903.3 + CR 707.10: commander is a card designation, so a spell
+        // copy is never a commander. Command-zone roles likewise belong only
+        // to the designated card, not its copy.
+        copy_obj.is_commander = false;
+        copy_obj.signature_spell = None;
         copy_obj.additional_cost_payment_count = 0;
         copy_obj.kickers_paid.clear();
         // CR 707.10: A copy of a spell is put on the stack; it is not cast.
@@ -1004,6 +1009,14 @@ mod tests {
             original_ability.clone(),
             CastingVariant::Normal,
         );
+        {
+            let original = state
+                .objects
+                .get_mut(&ObjectId(10))
+                .expect("original spell object exists");
+            original.is_commander = true;
+            original.mark_signature_spell();
+        }
 
         let copy_ability = ResolvedAbility::new(
             Effect::CopySpell {
@@ -1031,6 +1044,18 @@ mod tests {
         let copy_obj = state.objects.get(&copy_id).expect("copy object exists");
         assert!(copy_obj.is_token);
         assert_eq!(copy_obj.zone, Zone::Stack);
+        assert!(
+            !copy_obj.is_commander && !copy_obj.is_signature_spell(),
+            "CR 903.3: a spell copy must not inherit command-zone card roles"
+        );
+        let original = state
+            .objects
+            .get(&ObjectId(10))
+            .expect("original spell object remains");
+        assert!(
+            original.is_commander && original.is_signature_spell(),
+            "clearing copied roles must not mutate the original card"
+        );
 
         // Same spell kind
         match (&state.stack[0].kind, &state.stack[1].kind) {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -11110,9 +11110,11 @@ impl GameState {
             return;
         }
 
-        self.waiting_for = WaitingFor::Priority {
+        crate::game::priority::reset_priority(self);
+        let waiting_for = WaitingFor::Priority {
             player: self.active_player,
         };
+        crate::game::public_state::sync_waiting_for(self, &waiting_for);
         crate::game::sba::check_state_based_actions(self, &mut Vec::new());
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -11090,6 +11090,32 @@ impl GameState {
         });
     }
 
+    /// CR 903.3 + CR 111.6 + CR 704.3 + CR 704.5d: a token cannot be the
+    /// commander card named by a command-zone return choice. Older snapshots
+    /// can retain such an impossible choice after a copied commander spell left
+    /// the battlefield, so resume at the normal SBA boundary and let the token
+    /// cease-to-exist sweep remove it.
+    ///
+    /// This is intentionally limited to token-backed choices. A real commander
+    /// card in a graveyard or exile retains its owner-facing CR 903.9a choice.
+    pub fn resume_stale_token_commander_zone_choice(&mut self) {
+        let WaitingFor::CommanderZoneChoice { commander_id, .. } = &self.waiting_for else {
+            return;
+        };
+        if !self
+            .objects
+            .get(commander_id)
+            .is_some_and(|object| object.is_token)
+        {
+            return;
+        }
+
+        self.waiting_for = WaitingFor::Priority {
+            player: self.active_player,
+        };
+        crate::game::sba::check_state_based_actions(self, &mut Vec::new());
+    }
+
     /// CR 732.2a: the seat whose driving period `last_loop_action_sequence` currently records.
     ///
     /// CR 732.2a lets "the player with priority … suggest a shortcut by describing a sequence of
@@ -11250,6 +11276,7 @@ impl PersistedGameState {
         //     <saved>, so the next `capture_rng_word_pos` `.expect`-panicked `HighWaterRegression`.
         // Offline tooling (`phase-ai`'s `load_saved_game_state`) simply inherits the repair.
         state.rehydrate_rng();
+        state.resume_stale_token_commander_zone_choice();
         state
     }
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -990,6 +990,7 @@ mod runadi_behemoth_caller_etb_counters;
 mod saddle_become_effect;
 mod saddle_state_model;
 mod saruman_white_hand_amass;
+mod satya_localized_destruction_commander_copy;
 mod sba_lethal_damage_redirect_single_application;
 mod scarab_god_regression;
 mod scholarship_sponsor;

--- a/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
+++ b/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
@@ -8,12 +8,11 @@ use engine::types::game_state::WaitingFor;
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
 
-const LOCALIZED_DESTRUCTION: &str = "You get {E} (an energy counter), then you may pay one or more {E}. If you do, each creature you control with power equal to the amount of {E} paid this way gains indestructible until end of turn.\nDestroy all creatures.";
-
 /// CR 903.3 + CR 707.10 + CR 704.5d: The Sixth Doctor grants Demonstrate to
-/// commander Sarah Jane Smith. Its spell copies become tokens only after they
-/// resolve, so Localized Destruction must offer the real card's command-zone
-/// return and then remove the copied token without a second unreachable choice.
+/// commander Sarah Jane Smith. Its spell copies are tokens, so Localized
+/// Destruction's "Destroy all creatures" instruction must offer the real
+/// card's command-zone return and then remove the copied token without a
+/// second unreachable choice.
 #[test]
 fn localized_destruction_does_not_deadlock_on_a_copied_commander_spell() {
     let mut scenario = GameScenario::new();
@@ -30,7 +29,7 @@ fn localized_destruction_does_not_deadlock_on_a_copied_commander_spell() {
         .commander()
         .id();
     let localized_destruction = scenario
-        .add_spell_to_hand_from_oracle(P0, "Localized Destruction", false, LOCALIZED_DESTRUCTION)
+        .add_spell_to_hand_from_oracle(P0, "Localized Destruction", false, "Destroy all creatures.")
         .id();
 
     let mut runner = scenario.build();
@@ -65,48 +64,7 @@ fn localized_destruction_does_not_deadlock_on_a_copied_commander_spell() {
         "the original Sarah Jane Smith card remains the commander"
     );
 
-    // Resolve the actual first line of Localized Destruction explicitly. Its
-    // energy-payment choice must settle before the following board wipe runs.
-    let mut destruction = runner.cast(localized_destruction).commit();
-    destruction
-        .act(GameAction::PassPriority)
-        .expect("first priority pass accepts the cast");
-    let energy_optional = destruction
-        .act(GameAction::PassPriority)
-        .expect("second priority pass begins Localized Destruction resolution");
-    assert!(matches!(
-        energy_optional.waiting_for,
-        WaitingFor::OptionalEffectChoice { .. }
-    ));
-    destruction
-        .act(GameAction::DecideOptionalEffect { accept: false })
-        .expect("declining Localized Destruction's energy payment is valid");
-    drop(destruction);
-
-    assert_eq!(
-        runner.state().players[P0.0 as usize].energy,
-        1,
-        "declining the optional payment leaves the energy granted by the spell unspent"
-    );
-
-    // The decline completes the spell at a priority boundary. Finish that
-    // priority round so the engine performs the next SBA check, whose
-    // commander-return choice is the behavior under regression.
-    for _ in 0..runner.state().players.len() {
-        if matches!(
-            runner.state().waiting_for,
-            WaitingFor::CommanderZoneChoice { .. }
-        ) {
-            break;
-        }
-        assert!(matches!(
-            runner.state().waiting_for,
-            WaitingFor::Priority { .. }
-        ));
-        runner
-            .act(GameAction::PassPriority)
-            .expect("priority pass must advance the post-resolution SBA pipeline");
-    }
+    runner.cast(localized_destruction).resolve();
 
     assert!(matches!(
         runner.state().waiting_for,

--- a/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
+++ b/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
@@ -89,15 +89,29 @@ fn localized_destruction_does_not_deadlock_on_a_copied_commander_spell() {
         "the accepted one-or-more energy payment spends the one energy the spell granted"
     );
 
-    // The optional-payment continuation has finished the spell; the next
-    // priority action enters the normal SBA check that offers the command-zone
-    // return for Sarah Jane Smith.
-    let result = runner
-        .act(GameAction::PassPriority)
-        .expect("priority resumes after Localized Destruction resolves");
+    // The optional-payment continuation has finished the spell. Drive the
+    // current priority round until its normal SBA check offers the command-zone
+    // return; the number of passes is determined by the player count, not this
+    // two-player fixture's seat order.
+    for _ in 0..runner.state().players.len() {
+        if matches!(
+            runner.state().waiting_for,
+            WaitingFor::CommanderZoneChoice { .. }
+        ) {
+            break;
+        }
+        assert!(
+            matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
+            "Localized Destruction must resume at priority before the next SBA check; got {:?}",
+            runner.state().waiting_for
+        );
+        runner
+            .act(GameAction::PassPriority)
+            .expect("priority pass must advance the post-resolution SBA pipeline");
+    }
 
     assert!(matches!(
-        result.waiting_for,
+        runner.state().waiting_for,
         WaitingFor::CommanderZoneChoice {
             commander_id,
             current_zone: Zone::Graveyard,

--- a/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
+++ b/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
@@ -1,0 +1,127 @@
+//! Regression: The Sixth Doctor's Demonstrate spell copy must not retain the
+//! source card's commander designation and block state-based actions after a
+//! Localized Destruction board wipe.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const LOCALIZED_DESTRUCTION: &str = "You get {E} (an energy counter), then you may pay one or more {E}. If you do, each creature you control with power equal to the amount of {E} paid this way gains indestructible until end of turn.\nDestroy all creatures.";
+
+/// CR 903.3 + CR 707.10 + CR 704.5d: The Sixth Doctor grants Demonstrate to
+/// commander Sarah Jane Smith. Its spell copies become tokens only after they
+/// resolve, so Localized Destruction must offer the real card's command-zone
+/// return and then remove the copied token without a second unreachable choice.
+#[test]
+fn localized_destruction_does_not_deadlock_on_a_copied_commander_spell() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_creature_from_oracle(
+        P0,
+        "The Sixth Doctor",
+        2,
+        4,
+        "The first nonartifact spell you cast each turn has demonstrate.",
+    );
+    let sarah = scenario
+        .add_creature_to_hand_from_oracle(P0, "Sarah Jane Smith", 3, 4, "")
+        .commander()
+        .id();
+    let localized_destruction = scenario
+        .add_spell_to_hand_from_oracle(P0, "Localized Destruction", false, LOCALIZED_DESTRUCTION)
+        .id();
+
+    let mut runner = scenario.build();
+    runner.state_mut().format_config.command_zone = true;
+
+    // CR 702.144a: accept Demonstrate's self-copy. The opponent copy is also
+    // produced by the keyword, but all copies must shed the source's commander
+    // designation before resolving.
+    runner.cast(sarah).accept_optional().resolve();
+
+    let copied_sarah_ids: Vec<_> = runner
+        .state()
+        .battlefield
+        .iter()
+        .filter_map(|id| runner.state().objects.get(id))
+        .filter(|obj| obj.name == "Sarah Jane Smith" && obj.is_token)
+        .map(|obj| obj.id)
+        .collect();
+    assert!(
+        !copied_sarah_ids.is_empty(),
+        "CR 702.144a: Demonstrate must create at least its self-copy"
+    );
+    assert!(
+        copied_sarah_ids.iter().all(|id| {
+            let copy = &runner.state().objects[id];
+            !copy.is_commander && !copy.is_signature_spell()
+        }),
+        "CR 903.3: copied spells are tokens, not command-zone cards"
+    );
+    assert!(
+        runner.state().objects[&sarah].is_commander,
+        "the original Sarah Jane Smith card remains the commander"
+    );
+
+    // Resolve the actual first line of Localized Destruction explicitly. Its
+    // energy-payment choice must settle before the following board wipe runs.
+    let mut destruction = runner.cast(localized_destruction).commit();
+    destruction
+        .act(GameAction::PassPriority)
+        .expect("first priority pass accepts the cast");
+    let energy_optional = destruction
+        .act(GameAction::PassPriority)
+        .expect("second priority pass begins Localized Destruction resolution");
+    assert!(matches!(
+        energy_optional.waiting_for,
+        WaitingFor::OptionalEffectChoice { .. }
+    ));
+    let energy_payment = destruction
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accepting Localized Destruction's energy payment is valid");
+    assert!(matches!(
+        energy_payment.waiting_for,
+        WaitingFor::PayAmountChoice {
+            player: P0,
+            max: 1,
+            ..
+        }
+    ));
+    let result = destruction
+        .act(GameAction::SubmitPayAmount { amount: 1 })
+        .expect("paying the one energy granted by Localized Destruction is valid");
+    drop(destruction);
+
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::CommanderZoneChoice {
+            commander_id,
+            current_zone: Zone::Graveyard,
+            ..
+        } if commander_id == sarah
+    ));
+
+    let result = runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("the genuine commander return choice must be actionable");
+    assert!(
+        matches!(result.waiting_for, WaitingFor::Priority { .. }),
+        "after the genuine choice, priority must progress instead of surfacing a token choice"
+    );
+    assert_eq!(runner.state().objects[&sarah].zone, Zone::Command);
+    assert!(
+        copied_sarah_ids
+            .iter()
+            .all(|id| !runner.state().objects.contains_key(id)),
+        "CR 704.5d: copied Sarah Jane tokens must cease to exist after the wipe"
+    );
+    assert!(
+        !matches!(
+            runner.state().waiting_for,
+            WaitingFor::CommanderZoneChoice { .. }
+        ),
+        "no second CommanderZoneChoice may strand the player"
+    );
+}

--- a/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
+++ b/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
@@ -78,40 +78,19 @@ fn localized_destruction_does_not_deadlock_on_a_copied_commander_spell() {
         energy_optional.waiting_for,
         WaitingFor::OptionalEffectChoice { .. }
     ));
-    destruction
-        .act(GameAction::DecideOptionalEffect { accept: true })
-        .expect("accepting Localized Destruction's energy payment is valid");
+    let result = destruction
+        .act(GameAction::DecideOptionalEffect { accept: false })
+        .expect("declining Localized Destruction's energy payment is valid");
     drop(destruction);
 
     assert_eq!(
         runner.state().players[P0.0 as usize].energy,
-        0,
-        "the accepted one-or-more energy payment spends the one energy the spell granted"
+        1,
+        "declining the optional payment leaves the energy granted by the spell unspent"
     );
 
-    // The optional-payment continuation has finished the spell. Drive the
-    // current priority round until its normal SBA check offers the command-zone
-    // return; the number of passes is determined by the player count, not this
-    // two-player fixture's seat order.
-    for _ in 0..runner.state().players.len() {
-        if matches!(
-            runner.state().waiting_for,
-            WaitingFor::CommanderZoneChoice { .. }
-        ) {
-            break;
-        }
-        assert!(
-            matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
-            "Localized Destruction must resume at priority before the next SBA check; got {:?}",
-            runner.state().waiting_for
-        );
-        runner
-            .act(GameAction::PassPriority)
-            .expect("priority pass must advance the post-resolution SBA pipeline");
-    }
-
     assert!(matches!(
-        runner.state().waiting_for,
+        result.waiting_for,
         WaitingFor::CommanderZoneChoice {
             commander_id,
             current_zone: Zone::Graveyard,

--- a/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
+++ b/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
@@ -78,7 +78,7 @@ fn localized_destruction_does_not_deadlock_on_a_copied_commander_spell() {
         energy_optional.waiting_for,
         WaitingFor::OptionalEffectChoice { .. }
     ));
-    let result = destruction
+    destruction
         .act(GameAction::DecideOptionalEffect { accept: true })
         .expect("accepting Localized Destruction's energy payment is valid");
     drop(destruction);
@@ -88,6 +88,13 @@ fn localized_destruction_does_not_deadlock_on_a_copied_commander_spell() {
         0,
         "the accepted one-or-more energy payment spends the one energy the spell granted"
     );
+
+    // The optional-payment continuation has finished the spell; the next
+    // priority action enters the normal SBA check that offers the command-zone
+    // return for Sarah Jane Smith.
+    let result = runner
+        .act(GameAction::PassPriority)
+        .expect("priority resumes after Localized Destruction resolves");
 
     assert!(matches!(
         result.waiting_for,

--- a/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
+++ b/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
@@ -78,21 +78,16 @@ fn localized_destruction_does_not_deadlock_on_a_copied_commander_spell() {
         energy_optional.waiting_for,
         WaitingFor::OptionalEffectChoice { .. }
     ));
-    let energy_payment = destruction
+    let result = destruction
         .act(GameAction::DecideOptionalEffect { accept: true })
         .expect("accepting Localized Destruction's energy payment is valid");
-    assert!(matches!(
-        energy_payment.waiting_for,
-        WaitingFor::PayAmountChoice {
-            player: P0,
-            max: 1,
-            ..
-        }
-    ));
-    let result = destruction
-        .act(GameAction::SubmitPayAmount { amount: 1 })
-        .expect("paying the one energy granted by Localized Destruction is valid");
     drop(destruction);
+
+    assert_eq!(
+        runner.state().players[P0.0 as usize].energy,
+        0,
+        "the accepted one-or-more energy payment spends the one energy the spell granted"
+    );
 
     assert!(matches!(
         result.waiting_for,

--- a/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
+++ b/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
@@ -2,7 +2,7 @@
 //! source card's commander designation and block state-based actions after a
 //! Localized Destruction board wipe.
 
-use engine::game::scenario::{GameScenario, P0};
+use engine::game::scenario::{GameScenario, P0, P1};
 use engine::game::zones::move_to_zone;
 use engine::types::actions::GameAction;
 use engine::types::game_state::{PersistedGameState, WaitingFor};
@@ -128,23 +128,99 @@ fn restored_token_commander_choice_resumes_sba_cleanup() {
         .get_mut(&copied_commander)
         .unwrap()
         .is_token = true;
-    runner.state_mut().waiting_for = WaitingFor::CommanderZoneChoice {
-        player,
-        commander_id: copied_commander,
-        current_zone: Zone::Graveyard,
-    };
+    {
+        let state = runner.state_mut();
+        state.priority_player = P1;
+        state.priority_pass_count = 1;
+        state.priority_passes.insert(P1);
+        state.waiting_for = WaitingFor::CommanderZoneChoice {
+            player,
+            commander_id: copied_commander,
+            current_zone: Zone::Graveyard,
+        };
+    }
 
     let serialized = serde_json::to_string(&PersistedGameState::capture(runner.state().clone()))
         .expect("the captured command-zone choice serializes");
-    let restored = serde_json::from_str::<PersistedGameState>(&serialized)
+    let mut restored = serde_json::from_str::<PersistedGameState>(&serialized)
         .expect("the captured command-zone choice restores")
         .into_game_state();
 
-    assert!(matches!(restored.waiting_for, WaitingFor::Priority { .. }));
+    assert!(matches!(
+        &restored.waiting_for,
+        WaitingFor::Priority { player } if *player == P0
+    ));
+    assert_eq!(restored.priority_player, P0);
+    assert_eq!(restored.priority_pass_count, 0);
+    assert!(restored.priority_passes.is_empty());
     assert!(
         !restored.objects.contains_key(&copied_commander),
         "CR 704.5d: the malformed token must cease to exist during restore cleanup"
     );
+    engine::game::engine::apply(&mut restored, P0, GameAction::PassPriority)
+        .expect("the active player must be able to act after stale choice recovery");
+}
+
+/// CR 723.3 + CR 723.5: restoring an impossible command-zone prompt during a
+/// controlled turn preserves the controlled seat as the semantic priority
+/// holder while assigning action authority to the turn controller.
+#[test]
+fn restored_token_commander_choice_respects_turn_control_priority_authority() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let copied_commander = scenario
+        .add_creature(P0, "Controlled Copied Commander", 3, 4)
+        .commander()
+        .id();
+    let mut runner = scenario.build();
+    runner.state_mut().format_config.command_zone = true;
+
+    let mut events = Vec::new();
+    move_to_zone(
+        runner.state_mut(),
+        copied_commander,
+        Zone::Graveyard,
+        &mut events,
+    );
+    let player = runner.state().objects[&copied_commander].owner;
+    {
+        let state = runner.state_mut();
+        state.objects.get_mut(&copied_commander).unwrap().is_token = true;
+        state.active_player = P0;
+        state.turn_decision_controller = Some(P1);
+        state.priority_player = P0;
+        state.priority_pass_count = 1;
+        state.priority_passes.insert(P0);
+        state.waiting_for = WaitingFor::CommanderZoneChoice {
+            player,
+            commander_id: copied_commander,
+            current_zone: Zone::Graveyard,
+        };
+    }
+
+    let serialized = serde_json::to_string(&PersistedGameState::capture(runner.state().clone()))
+        .expect("the controlled stale command-zone choice serializes");
+    let mut restored = serde_json::from_str::<PersistedGameState>(&serialized)
+        .expect("the controlled stale command-zone choice restores")
+        .into_game_state();
+
+    assert!(matches!(
+        &restored.waiting_for,
+        WaitingFor::Priority { player } if *player == P0
+    ));
+    assert_eq!(restored.priority_player, P1);
+    assert_eq!(restored.priority_pass_count, 0);
+    assert!(restored.priority_passes.is_empty());
+    assert!(
+        !restored.objects.contains_key(&copied_commander),
+        "CR 704.5d: the malformed token must cease to exist during restore cleanup"
+    );
+    assert!(
+        engine::game::engine::apply(&mut restored, P0, GameAction::PassPriority).is_err(),
+        "CR 723.5: the controlled seat cannot submit its own priority action"
+    );
+    engine::game::engine::apply(&mut restored, P1, GameAction::PassPriority)
+        .expect("CR 723.5: the turn controller must be able to submit priority actions");
 }
 
 /// CR 903.3 + CR 903.9a: restore must preserve a legitimate card-backed

--- a/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
+++ b/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
@@ -3,8 +3,9 @@
 //! Localized Destruction board wipe.
 
 use engine::game::scenario::{GameScenario, P0};
+use engine::game::zones::move_to_zone;
 use engine::types::actions::GameAction;
-use engine::types::game_state::WaitingFor;
+use engine::types::game_state::{PersistedGameState, WaitingFor};
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
 
@@ -96,4 +97,91 @@ fn localized_destruction_does_not_deadlock_on_a_copied_commander_spell() {
         ),
         "no second CommanderZoneChoice may strand the player"
     );
+}
+
+/// CR 903.3 + CR 111.6 + CR 704.3 + CR 704.5d: a saved copy of a commander
+/// spell must not preserve an unreachable command-zone prompt after it leaves
+/// the battlefield. This models the reported capture's `CommanderZoneChoice`
+/// shape, then restores it through the production persistence chokepoint.
+#[test]
+fn restored_token_commander_choice_resumes_sba_cleanup() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let copied_commander = scenario
+        .add_creature(P0, "Copied Commander", 3, 4)
+        .commander()
+        .id();
+    let mut runner = scenario.build();
+    runner.state_mut().format_config.command_zone = true;
+
+    let mut events = Vec::new();
+    move_to_zone(
+        runner.state_mut(),
+        copied_commander,
+        Zone::Graveyard,
+        &mut events,
+    );
+    let player = runner.state().objects[&copied_commander].owner;
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&copied_commander)
+        .unwrap()
+        .is_token = true;
+    runner.state_mut().waiting_for = WaitingFor::CommanderZoneChoice {
+        player,
+        commander_id: copied_commander,
+        current_zone: Zone::Graveyard,
+    };
+
+    let serialized = serde_json::to_string(&PersistedGameState::capture(runner.state().clone()))
+        .expect("the captured command-zone choice serializes");
+    let restored = serde_json::from_str::<PersistedGameState>(&serialized)
+        .expect("the captured command-zone choice restores")
+        .into_game_state();
+
+    assert!(matches!(restored.waiting_for, WaitingFor::Priority { .. }));
+    assert!(
+        !restored.objects.contains_key(&copied_commander),
+        "CR 704.5d: the malformed token must cease to exist during restore cleanup"
+    );
+}
+
+/// CR 903.3 + CR 903.9a: restore must preserve a legitimate card-backed
+/// command-zone choice; only the impossible token-backed shape is normalized.
+#[test]
+fn restored_genuine_commander_choice_remains_actionable() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let commander = scenario
+        .add_creature(P0, "Genuine Commander", 3, 4)
+        .commander()
+        .id();
+    let mut runner = scenario.build();
+    runner.state_mut().format_config.command_zone = true;
+
+    let mut events = Vec::new();
+    move_to_zone(runner.state_mut(), commander, Zone::Graveyard, &mut events);
+    let player = runner.state().objects[&commander].owner;
+    runner.state_mut().waiting_for = WaitingFor::CommanderZoneChoice {
+        player,
+        commander_id: commander,
+        current_zone: Zone::Graveyard,
+    };
+
+    let serialized = serde_json::to_string(&PersistedGameState::capture(runner.state().clone()))
+        .expect("the genuine command-zone choice serializes");
+    let restored = serde_json::from_str::<PersistedGameState>(&serialized)
+        .expect("the genuine command-zone choice restores")
+        .into_game_state();
+
+    assert!(matches!(
+        restored.waiting_for,
+        WaitingFor::CommanderZoneChoice {
+            commander_id,
+            current_zone: Zone::Graveyard,
+            ..
+        } if commander_id == commander
+    ));
+    assert_eq!(restored.objects[&commander].zone, Zone::Graveyard);
 }

--- a/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
+++ b/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
@@ -78,7 +78,7 @@ fn localized_destruction_does_not_deadlock_on_a_copied_commander_spell() {
         energy_optional.waiting_for,
         WaitingFor::OptionalEffectChoice { .. }
     ));
-    let result = destruction
+    destruction
         .act(GameAction::DecideOptionalEffect { accept: false })
         .expect("declining Localized Destruction's energy payment is valid");
     drop(destruction);
@@ -89,8 +89,27 @@ fn localized_destruction_does_not_deadlock_on_a_copied_commander_spell() {
         "declining the optional payment leaves the energy granted by the spell unspent"
     );
 
+    // The decline completes the spell at a priority boundary. Finish that
+    // priority round so the engine performs the next SBA check, whose
+    // commander-return choice is the behavior under regression.
+    for _ in 0..runner.state().players.len() {
+        if matches!(
+            runner.state().waiting_for,
+            WaitingFor::CommanderZoneChoice { .. }
+        ) {
+            break;
+        }
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::Priority { .. }
+        ));
+        runner
+            .act(GameAction::PassPriority)
+            .expect("priority pass must advance the post-resolution SBA pipeline");
+    }
+
     assert!(matches!(
-        result.waiting_for,
+        runner.state().waiting_for,
         WaitingFor::CommanderZoneChoice {
             commander_id,
             current_zone: Zone::Graveyard,


### PR DESCRIPTION
- **fix(engine): clear command roles from spell copies**
- **test(engine): follow localized destruction payment flow**
- **test(engine): drive post-wipe commander SBA**
- **test(engine): complete localized destruction priority round**
- **test(engine): cover localized destruction decline branch**
- **test(engine): advance declined wipe through SBAs**
- **test(engine): cover copied commander board wipe**
- **test(engine): order commander fixture borrows**
- **fix(engine): recover stale token commander choices**
