### PR TITLE
fix(engine): model optional fixed tap payments

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -7056,7 +7056,11 @@ fn optional_effect_is_infeasible(state: &GameState, ability: &ResolvedAbility) -
         // CR 701.61a + CR 608.2d: A player cannot choose to forage unless at
         // least one complete forage mode is currently available.
         Effect::Forage => !forage::can_forage(state, ability),
-        Effect::PayCost { cost, payer, .. } => {
+        Effect::PayCost {
+            cost: AbilityCost::TapCreatures { .. },
+            payer,
+            ..
+        } => {
             let Some(payer) =
                 crate::game::targeting::resolve_effect_player_ref(state, ability, payer)
             else {

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -7056,6 +7056,25 @@ fn optional_effect_is_infeasible(state: &GameState, ability: &ResolvedAbility) -
         // CR 701.61a + CR 608.2d: A player cannot choose to forage unless at
         // least one complete forage mode is currently available.
         Effect::Forage => !forage::can_forage(state, ability),
+        Effect::PayCost { cost, payer, .. } => {
+            let Some(payer) =
+                crate::game::targeting::resolve_effect_player_ref(state, ability, payer)
+            else {
+                return true;
+            };
+            let mut payment_ability = ability.clone();
+            payment_ability.controller = payer;
+            !crate::game::costs::can_pay(
+                state,
+                payer,
+                ability.source_id,
+                cost,
+                &crate::game::costs::PaymentScope::Resolution {
+                    ability: &payment_ability,
+                    cost_move_root: crate::game::costs::ResolutionCostMoveRoot::EffectPayCost,
+                },
+            )
+        }
         Effect::CastFromZone {
             mode,
             target,

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -7057,7 +7057,7 @@ fn optional_effect_is_infeasible(state: &GameState, ability: &ResolvedAbility) -
         // least one complete forage mode is currently available.
         Effect::Forage => !forage::can_forage(state, ability),
         Effect::PayCost {
-            cost: AbilityCost::TapCreatures { .. },
+            cost: cost @ AbilityCost::TapCreatures { .. },
             payer,
             ..
         } => {

--- a/crates/engine/src/parser/oracle_ir/trigger.rs
+++ b/crates/engine/src/parser/oracle_ir/trigger.rs
@@ -10,9 +10,9 @@ use super::ast::parsed_clause;
 use super::context::ParseContext;
 use super::effect_chain::{DieResultBranchIr, EffectChainIr, ModalModeIr};
 use crate::types::ability::{
-    AbilityCost, AbilityDefinition, AbilityKind, ChoiceType, ControllerRef, Effect, ModalChoice,
-    TargetFilter, TargetSelectionMode, TriggerCondition, TriggerConstraint, TriggerDefinition,
-    UnlessPayModifier,
+    AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, ChoiceType, ControllerRef,
+    Effect, ModalChoice, TargetFilter, TargetSelectionMode, TriggerCondition, TriggerConstraint,
+    TriggerDefinition, UnlessPayModifier,
 };
 use crate::types::triggers::TriggerMode;
 
@@ -167,7 +167,9 @@ pub(crate) enum TriggerBody {
 pub(crate) struct ReflexiveParentIr {
     /// How the parent instruction is printed and offered.
     pub(crate) parent: ReflexiveParent,
-    /// The reflexive body — what `"When you do, …"` introduces.
+    /// The connector between the parent instruction and its dependent body.
+    pub(crate) connector: AbilityCondition,
+    /// The reflexive body that follows the connector.
     pub(crate) effect_chain: EffectChainIr,
     /// CR 700.2b: modal metadata when the reflexive body is a mode choice.
     pub(crate) modal: Option<ModalIr>,

--- a/crates/engine/src/parser/oracle_modal.rs
+++ b/crates/engine/src/parser/oracle_modal.rs
@@ -8,10 +8,11 @@ use nom::sequence::{delimited, preceded, terminated};
 use nom::Parser;
 
 use crate::types::ability::{
-    AbilityDefinition, AbilityKind, AdditionalCostOrigin, AdditionalCostPaymentSource, ChoiceType,
-    ControllerRef, Effect, ModalChoice, ModalSelectionCondition, ModalSelectionConstraint,
-    PlayerFilter, QuantityExpr, QuantityRef, ReplacementDefinition, StaticCondition, TargetFilter,
-    TargetSelectionMode, TriggerCondition, TypedFilter,
+    AbilityCondition, AbilityDefinition, AbilityKind, AdditionalCostOrigin,
+    AdditionalCostPaymentSource, ChoiceType, ControllerRef, Effect, ModalChoice,
+    ModalSelectionCondition, ModalSelectionConstraint, PlayerFilter, QuantityExpr, QuantityRef,
+    ReplacementDefinition, StaticCondition, TargetFilter, TargetSelectionMode, TriggerCondition,
+    TypedFilter,
 };
 use crate::types::replacements::ReplacementEvent;
 use crate::types::triggers::TriggerMode;
@@ -46,8 +47,6 @@ use super::oracle_util::{parse_mana_symbols, strip_reminder_text, TextPair};
 use crate::parser::oracle_ir::ast::{
     parsed_clause, ModalHeaderAst, ModalOptionality, ModeAst, OracleBlockAst, ReflexiveModalParent,
 };
-#[cfg(test)]
-use crate::types::ability::AbilityCondition;
 use crate::types::mana::ManaCost;
 
 pub(crate) fn parse_oracle_block(lines: &[&str], start: usize) -> Option<(OracleBlockAst, usize)> {
@@ -1226,6 +1225,7 @@ pub(crate) fn lower_oracle_block_ir(
                                     .body,
                                 ),
                             },
+                            connector: AbilityCondition::WhenYouDo,
                             effect_chain: EffectChainIr::single_clause(
                                 cost_text,
                                 AbilityKind::Spell,
@@ -1251,6 +1251,7 @@ pub(crate) fn lower_oracle_block_ir(
                         Some(TriggerBody::EffectChain(instruction)) => {
                             TriggerBody::Reflexive(Box::new(ReflexiveParentIr {
                                 parent: ReflexiveParent::Mandatory { instruction },
+                                connector: AbilityCondition::WhenYouDo,
                                 effect_chain: payload.marker.clone(),
                                 modal: Some(payload.clone()),
                             }))
@@ -4574,6 +4575,11 @@ When The Ruinous Wrecking Crew enters, choose up to X —\n\
         let Some(TriggerBody::Reflexive(reflexive)) = trigger.body.as_ref() else {
             panic!("Caesar must retain its native reflexive-payment trigger body");
         };
+        assert_eq!(
+            reflexive.connector,
+            AbilityCondition::WhenYouDo,
+            "Caesar's native IR must retain its printed reflexive connector"
+        );
         let modal = reflexive
             .modal
             .as_ref()

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -22,7 +22,9 @@ use super::oracle_ir::trigger::{
     TriggerBody, TriggerIr, TriggerModifiers, TriggerNodeIr,
 };
 use super::oracle_modal::try_parse_inline_modal_ir;
-use super::oracle_nom::condition::parse_elided_subject_state_condition;
+use super::oracle_nom::condition::{
+    parse_affirmative_reflexive_connector, parse_elided_subject_state_condition,
+};
 use super::oracle_nom::condition::{
     parse_inner_condition, parse_spell_history_filter, parse_there_are_battlefield_count_clause,
 };
@@ -1546,7 +1548,7 @@ pub(crate) fn parse_trigger_line_with_index_ir(
     let has_up_to = scan_contains(&effect_for_parse_lower, "up to one")
         || scan_contains(&effect_for_parse_lower, "any number of target");
     let body = if !effect_for_parse.is_empty() {
-        if let Some((cost, reflexive_effect_text)) =
+        if let Some((cost, connector, reflexive_effect_text)) =
             split_reflexive_optional_payment(&effect_for_parse)
         {
             optional = false;
@@ -1557,6 +1559,7 @@ pub(crate) fn parse_trigger_line_with_index_ir(
                     cost,
                     payment_chain: None,
                 },
+                connector,
                 effect_chain,
                 modal: None,
             })))
@@ -1826,7 +1829,7 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
                 modifiers,
                 reflexive_die_results,
             );
-            reflexive_ability.condition = Some(AbilityCondition::WhenYouDo);
+            reflexive_ability.condition = Some(reflexive.connector.clone());
 
             if let Some(modal) = &reflexive.modal {
                 reflexive_ability = reflexive_ability.with_modal(
@@ -1841,7 +1844,8 @@ pub(crate) fn lower_trigger_ir(ir: &TriggerIr) -> TriggerDefinition {
 
             // CR 603.12: the parent is either an optional instruction the
             // controller may decline or a mandatory instruction. Both build the
-            // same parent → `WhenYouDo` sub shape.
+            // same parent → dependent-subability shape; the typed connector
+            // preserves whether the printed rider is reflexive or outcome-gated.
             let mut parent_ability = match &reflexive.parent {
                 ReflexiveParent::MayPay {
                     cost,
@@ -3330,7 +3334,9 @@ fn infer_pronoun_unless_payer(
 /// fully recognized and payable during resolution; unsupported or branch-choice
 /// costs should remain honest parser gaps rather than becoming a broad no-op
 /// `PayCost`.
-fn split_reflexive_optional_payment(effect_text: &str) -> Option<(AbilityCost, String)> {
+fn split_reflexive_optional_payment(
+    effect_text: &str,
+) -> Option<(AbilityCost, AbilityCondition, String)> {
     let lower = effect_text.to_lowercase();
     let (after_prefix, _) = tag::<_, _, OracleError<'_>>("you may ")
         .parse(lower.as_str())
@@ -3338,9 +3344,7 @@ fn split_reflexive_optional_payment(effect_text: &str) -> Option<(AbilityCost, S
     let (connector, cost_lower) = terminated(take_until::<_, _, OracleError<'_>>(". "), tag(". "))
         .parse(after_prefix)
         .ok()?;
-    let (body_lower, _) = tag::<_, _, OracleError<'_>>("when you do, ")
-        .parse(connector)
-        .ok()?;
+    let (body_lower, connector) = parse_affirmative_reflexive_connector(connector).ok()?;
 
     let cost_start = effect_text.len() - after_prefix.len();
     let cost_len = cost_lower.len();
@@ -3359,7 +3363,62 @@ fn split_reflexive_optional_payment(effect_text: &str) -> Option<(AbilityCost, S
     {
         return None;
     }
-    Some((cost, body_text.to_string()))
+    Some((cost, connector, body_text.to_string()))
+}
+
+#[cfg(test)]
+#[test]
+fn reflexive_optional_payment_preserves_the_printed_affirmative_connector() {
+    const THOUSAND_MOONS_SMITHY: &str = "At the beginning of your first main phase, you may tap five untapped artifacts and/or creatures you control. If you do, transform Thousand Moons Smithy.";
+
+    let trigger = parse_trigger_line(THOUSAND_MOONS_SMITHY, "Thousand Moons Smithy");
+    let parent = trigger
+        .execute
+        .as_deref()
+        .expect("Smithy's first-main-phase trigger must have a parent instruction");
+    let Effect::PayCost { cost, .. } = parent.effect.as_ref() else {
+        panic!(
+            "Smithy's parent must lower to PayCost, got {:?}",
+            parent.effect
+        );
+    };
+    assert!(matches!(
+        cost,
+        AbilityCost::TapCreatures {
+            requirement: TapCreaturesRequirement::Count { count: 5 },
+            ..
+        }
+    ));
+    assert!(
+        parent.target_prompt.is_none()
+            && parent.multi_target.is_none()
+            && parent.target_constraints.is_empty(),
+        "the fixed-five payment must not introduce a spell-target selection"
+    );
+    assert_eq!(
+        parent
+            .sub_ability
+            .as_deref()
+            .and_then(|child| child.condition.clone()),
+        Some(AbilityCondition::EffectOutcome {
+            signal: crate::types::ability::EffectOutcomeSignal::OptionalEffectPerformed,
+        }),
+        "Smithy's printed If-you-do rider must remain an EffectOutcome gate"
+    );
+
+    let when_you_do = parse_trigger_line(
+        "Whenever ~ attacks, you may tap five untapped creatures you control. When you do, transform ~.",
+        "When Probe",
+    );
+    assert_eq!(
+        when_you_do
+            .execute
+            .as_deref()
+            .and_then(|parent| parent.sub_ability.as_deref())
+            .and_then(|child| child.condition.clone()),
+        Some(AbilityCondition::WhenYouDo),
+        "a printed When-you-do connector must remain a reflexive trigger"
+    );
 }
 
 fn is_unsupported_disjunctive_reflexive_optional_payment(effect_text: &str) -> bool {
@@ -3379,8 +3438,7 @@ fn is_unsupported_disjunctive_reflexive_optional_payment(effect_text: &str) -> b
     {
         return false;
     }
-    let parsed_reflexive_connector = tag::<_, _, OracleError<'_>>("when you do, ").parse(connector);
-    if parsed_reflexive_connector.is_err() {
+    if parse_affirmative_reflexive_connector(connector).is_err() {
         return false;
     }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1078,6 +1078,7 @@ mod thor_god_of_thunder;
 mod thorna_and_twigtooth_shared_x_relay_6956;
 mod thought_distortion;
 mod thoughtweft_trample_regression;
+mod thousand_moons_smithy;
 mod throne_of_eldraine_mana_riders;
 mod throw_instead_tail_class;
 mod timely_ward_regression;

--- a/crates/engine/tests/integration/thousand_moons_smithy.rs
+++ b/crates/engine/tests/integration/thousand_moons_smithy.rs
@@ -1,0 +1,295 @@
+//! End-to-end coverage for Thousand Moons Smithy's reflexive optional payment.
+
+use std::sync::Arc;
+
+use engine::game::game_object::BackFaceData;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::trigger_index::reindex_object_triggers;
+use engine::types::ability::{Effect, TargetFilter, TriggerDefinition};
+use engine::types::actions::GameAction;
+use engine::types::card::LayoutKind;
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::game_state::{PayCostKind, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaColor, ManaCost};
+use engine::types::phase::Phase;
+use engine::types::triggers::TriggerMode;
+use engine::types::PlayerId;
+
+const THOUSAND_MOONS_SMITHY: &str = "When Thousand Moons Smithy enters, create a white Gnome Soldier artifact creature token with \"This token's power and toughness are each equal to the number of artifacts and/or creatures you control.\"\nAt the beginning of your first main phase, you may tap five untapped artifacts and/or creatures you control. If you do, transform Thousand Moons Smithy.";
+
+fn attach_back_face(runner: &mut GameRunner, smithy: ObjectId) {
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&smithy)
+        .unwrap()
+        .back_face = Some(BackFaceData {
+        name: "Barracks of the Thousand".to_string(),
+        power: None,
+        toughness: None,
+        loyalty: None,
+        printed_loyalty: None,
+        defense: None,
+        card_types: CardType {
+            supertypes: vec![],
+            core_types: vec![CoreType::Land],
+            subtypes: vec![],
+        },
+        mana_cost: ManaCost::default(),
+        keywords: vec![],
+        abilities: vec![],
+        trigger_definitions: Default::default(),
+        replacement_definitions: Default::default(),
+        static_definitions: Default::default(),
+        color: vec![],
+        printed_ref: None,
+        modal: None,
+        additional_cost: None,
+        strive_cost: None,
+        casting_restrictions: vec![],
+        casting_options: vec![],
+        layout_kind: Some(LayoutKind::Transform),
+        parse_warnings: vec![],
+    });
+}
+
+fn resolve_first_main_trigger(runner: &mut GameRunner) {
+    runner.state_mut().turn_number = 2;
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+    runner.auto_advance_to_main_phase();
+    assert_eq!(runner.state().phase, Phase::PreCombatMain);
+    assert_eq!(
+        runner.state().stack.len(),
+        1,
+        "Smithy's first-main trigger must reach the stack"
+    );
+    runner.act(GameAction::PassPriority).unwrap();
+    runner.act(GameAction::PassPriority).unwrap();
+}
+
+fn assert_tap_five_prompt(runner: &GameRunner, player: PlayerId) {
+    match &runner.state().waiting_for {
+        WaitingFor::PayCost {
+            player: prompt_player,
+            kind: PayCostKind::TapCreatures { .. },
+            count,
+            min_count,
+            choices,
+            ..
+        } => {
+            assert_eq!(*prompt_player, player);
+            assert_eq!(*count, 5);
+            assert_eq!(*min_count, 5);
+            assert!(choices.len() >= 5);
+        }
+        other => panic!("expected Smithy's fixed five-permanent payment prompt, got {other:?}"),
+    }
+}
+
+#[test]
+fn thousand_moons_smithy_taps_exactly_five_and_transforms() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Upkeep);
+    scenario.with_library_top(P0, &["P0 Library Card"; 40]);
+    let smithy = scenario
+        .add_creature_from_oracle(P0, "Thousand Moons Smithy", 1, 1, THOUSAND_MOONS_SMITHY)
+        .as_artifact()
+        .id();
+    let payments: Vec<_> = (0..5)
+        .map(|_| scenario.add_creature(P0, "Payment", 1, 1).id())
+        .collect();
+    let mut runner = scenario.build();
+    attach_back_face(&mut runner, smithy);
+
+    resolve_first_main_trigger(&mut runner);
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::OptionalEffectChoice { player: P0, .. }
+    ));
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .unwrap();
+    assert_tap_five_prompt(&runner, P0);
+    runner
+        .act(GameAction::SelectCards {
+            cards: payments.clone(),
+        })
+        .unwrap();
+
+    assert!(runner.state().objects[&smithy].transformed);
+    assert!(payments.iter().all(|id| runner.state().objects[id].tapped));
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+}
+
+#[test]
+fn thousand_moons_smithy_decline_and_under_five_skip_the_payment_prompt() {
+    let mut decline = GameScenario::new();
+    decline.at_phase(Phase::Upkeep);
+    decline.with_library_top(P0, &["P0 Library Card"; 40]);
+    let decline_smithy = decline
+        .add_creature_from_oracle(P0, "Thousand Moons Smithy", 1, 1, THOUSAND_MOONS_SMITHY)
+        .as_artifact()
+        .id();
+    let decline_payments: Vec<_> = (0..5)
+        .map(|_| decline.add_creature(P0, "Decline Payment", 1, 1).id())
+        .collect();
+    let mut decline_runner = decline.build();
+    attach_back_face(&mut decline_runner, decline_smithy);
+    resolve_first_main_trigger(&mut decline_runner);
+    decline_runner
+        .act(GameAction::DecideOptionalEffect { accept: false })
+        .unwrap();
+    assert!(!decline_runner.state().objects[&decline_smithy].transformed);
+    assert!(decline_payments
+        .iter()
+        .all(|id| !decline_runner.state().objects[id].tapped));
+
+    let mut under_five = GameScenario::new();
+    under_five.at_phase(Phase::Upkeep);
+    under_five.with_library_top(P0, &["P0 Library Card"; 40]);
+    let under_five_smithy = under_five
+        .add_creature_from_oracle(P0, "Thousand Moons Smithy", 1, 1, THOUSAND_MOONS_SMITHY)
+        .as_artifact()
+        .id();
+    for _ in 0..3 {
+        under_five.add_creature(P0, "Insufficient Payment", 1, 1);
+    }
+    let mut under_five_runner = under_five.build();
+    attach_back_face(&mut under_five_runner, under_five_smithy);
+    resolve_first_main_trigger(&mut under_five_runner);
+    assert!(matches!(
+        under_five_runner.state().waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert!(under_five_runner.state().stack.is_empty());
+    assert!(!under_five_runner.state().objects[&under_five_smithy].transformed);
+}
+
+#[test]
+fn thousand_moons_smithy_rejects_invalid_fixed_selection_without_losing_the_prompt() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Upkeep);
+    scenario.with_library_top(P0, &["P0 Library Card"; 40]);
+    let smithy = scenario
+        .add_creature_from_oracle(P0, "Thousand Moons Smithy", 1, 1, THOUSAND_MOONS_SMITHY)
+        .as_artifact()
+        .id();
+    let payments: Vec<_> = (0..6)
+        .map(|_| scenario.add_creature(P0, "Payment", 1, 1).id())
+        .collect();
+    let opponent = scenario.add_creature(P1, "Opponent Payment", 1, 1).id();
+    let nonmatching = scenario.add_basic_land(P0, ManaColor::White);
+    let mut runner = scenario.build();
+    attach_back_face(&mut runner, smithy);
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&payments[5])
+        .unwrap()
+        .tapped = true;
+    resolve_first_main_trigger(&mut runner);
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .unwrap();
+    assert_tap_five_prompt(&runner, P0);
+    let invalid_selections = vec![
+        payments[..4].to_vec(),
+        vec![
+            payments[0],
+            payments[1],
+            payments[2],
+            payments[3],
+            payments[0],
+        ],
+        vec![
+            payments[0],
+            payments[1],
+            payments[2],
+            payments[3],
+            payments[5],
+        ],
+        vec![payments[0], payments[1], payments[2], payments[3], opponent],
+        vec![
+            payments[0],
+            payments[1],
+            payments[2],
+            payments[3],
+            nonmatching,
+        ],
+    ];
+    for cards in invalid_selections {
+        assert!(runner.act(GameAction::SelectCards { cards }).is_err());
+        assert_tap_five_prompt(&runner, P0);
+        assert!(!runner.state().objects[&smithy].transformed);
+    }
+
+    runner
+        .act(GameAction::SelectCards {
+            cards: payments[..5].to_vec(),
+        })
+        .unwrap();
+    assert!(runner.state().objects[&smithy].transformed);
+}
+
+#[test]
+fn thousand_moons_smithy_payment_uses_triggering_player_not_source_controller() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P1, &["P1 Library Card"; 40]);
+    let smithy = scenario
+        .add_creature_from_oracle(P0, "Thousand Moons Smithy", 1, 1, THOUSAND_MOONS_SMITHY)
+        .as_artifact()
+        .id();
+    let p1_payments: Vec<_> = (0..5)
+        .map(|_| scenario.add_creature(P1, "P1 Payment", 1, 1).id())
+        .collect();
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P1, "Triggering Player Probe", true, "Draw a card.")
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    let mut runner = scenario.build();
+
+    let mut payment = runner.state().objects[&smithy]
+        .base_trigger_definitions
+        .iter()
+        .find_map(|trigger| {
+            let ability = trigger.execute.as_deref()?;
+            matches!(ability.effect.as_ref(), Effect::PayCost { .. }).then(|| ability.clone())
+        })
+        .expect("Smithy's exact Oracle must provide its first-main PayCost trigger");
+    let Effect::PayCost { payer, .. } = payment.effect.as_mut() else {
+        panic!("Smithy's parsed first-main trigger must begin with PayCost");
+    };
+    *payer = TargetFilter::TriggeringPlayer;
+    let trigger = TriggerDefinition::new(TriggerMode::SpellCast).execute(payment);
+    let smithy_object = runner.state_mut().objects.get_mut(&smithy).unwrap();
+    smithy_object.base_trigger_definitions = Arc::new(vec![trigger]);
+    smithy_object.materialize_base_trigger_definitions();
+    reindex_object_triggers(runner.state_mut(), smithy);
+    runner.state_mut().active_player = P1;
+    runner.state_mut().priority_player = P1;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P1 };
+
+    runner.cast(spell).commit();
+    runner.act(GameAction::PassPriority).unwrap();
+    runner.act(GameAction::PassPriority).unwrap();
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::OptionalEffectChoice { player: P1, .. }
+    ));
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .unwrap();
+    assert_tap_five_prompt(&runner, P1);
+    let WaitingFor::PayCost { choices, .. } = &runner.state().waiting_for else {
+        unreachable!();
+    };
+    assert!(p1_payments.iter().all(|id| choices.contains(id)));
+    assert!(!choices.contains(&smithy));
+}


### PR DESCRIPTION
Fix Thousand Moons Smithy and the general optional tap-creature payment path. Preserves `If you do` semantics, uses the canonical payment selector, and adds end-to-end coverage.