### PR TITLE
fix wasm custom format commander eligibility

### DIFF
--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -880,7 +880,10 @@ pub fn is_card_commander_eligible_for_format(name: &str, format: JsValue) -> boo
             | GameFormat::Archenemy
             | GameFormat::FreeForAll
             | GameFormat::TwoHeadedGiant
-            | GameFormat::Limited => false,
+            | GameFormat::Limited
+            // A Custom id alone does not carry its `FormatConfig.custom_rules`,
+            // which is the authority for custom commander eligibility.
+            | GameFormat::Custom(_) => false,
             // Matches `evaluate_selected_format_summary`'s Custom arm: no
             // CustomFormatRules resolver exists yet, so eligibility cannot be
             // answered here. `false` is the fail-closed reading — a permissive


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified commander eligibility behavior for Limited and Custom formats.
  * Documented that Custom eligibility cannot be determined from a format ID alone.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->