### PR TITLE
ship/resume auto pass after resolve all

### DIFF
--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -3155,28 +3155,22 @@ pub fn resolve_all(
             Ok(result) => result,
             Err(rejection) => return Ok(rejected_action_outcome(rejection)),
         };
-        // A Resolve All burst applies real actions directly via
-        // `apply_action_boundary_with_stack_limit` (bypassing `submit_action`,
-        // which is the only other place REPLAY_LOG is appended to) — without
-        // this, an exported replay would silently omit every action a player
-        // fast-forwarded through, and playback would desync from the game
-        // they actually played. `recorded_actions` is `#[serde(skip)]`, so
-        // draining it here has no effect on the JS-visible result shape.
-        if !result.recorded_actions.is_empty() {
-            REPLAY_LOG.with(|cell| {
-                let mut log = cell.take();
-                if let Some(log) = log.as_mut() {
-                    for (actor, action) in result.recorded_actions.drain(..) {
-                        log.push_action(actor, action);
-                    }
-                }
-                cell.set(log);
-            });
-            // Resolve All advances the live state without travelling through
-            // `submit_action`, so it must invalidate proposal capabilities at
-            // the same authority boundary.
-            invalidate_ai_proposals();
-        }
+        // Resolve All consumes a transport-owned Ready latch, rather than one
+        // `GameAction` per internal priority pass. Record the entire consumer
+        // atomically after the last submitted consent action; playback invokes
+        // the same engine consumer at that exact boundary, so auto-pass cannot
+        // re-run between synthetic recorded passes.
+        REPLAY_LOG.with(|cell| {
+            let mut log = cell.take();
+            if let Some(log) = log.as_mut() {
+                log.push_resolve_all_boundary(requester);
+            }
+            cell.set(log);
+        });
+        // Resolve All advances the live state without travelling through
+        // `submit_action`, so it must invalidate proposal capabilities at the
+        // same authority boundary.
+        invalidate_ai_proposals();
         result.events.clear();
         result.log_entries.clear();
         Ok(action_outcome(Ok(result)))

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -4671,7 +4671,10 @@ mod tests {
             .expect("P0 begins the Resolve All consent run");
         record_replay_action(false, PlayerId(0), begin);
         let WaitingFor::ResolveAllConsent { epoch, .. } = state.waiting_for else {
-            panic!("P1 should be asked for consent, got {:?}", state.waiting_for);
+            panic!(
+                "P1 should be asked for consent, got {:?}",
+                state.waiting_for
+            );
         };
         let grant = GameAction::RespondResolveAllConsent {
             epoch,
@@ -4679,7 +4682,10 @@ mod tests {
         };
         apply(&mut state, PlayerId(1), grant.clone()).expect("P1 grants Resolve All consent");
         record_replay_action(false, PlayerId(1), grant);
-        assert!(matches!(state.waiting_for, WaitingFor::ResolveAllReady { .. }));
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::ResolveAllReady { .. }
+        ));
         GAME_STATE.with(|cell| cell.set(Some(state)));
 
         resolve_all(0, "[]", 0).expect("the Ready consumer resolves through the WASM bridge");

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -4647,6 +4647,56 @@ mod tests {
     }
 
     #[test]
+    fn resolve_all_exported_path_records_one_atomic_replay_boundary() {
+        clear_game_state();
+
+        let mut state = GameState::new_two_player(8);
+        state.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+        state.priority_player = PlayerId(0);
+        state.stack.push_back(no_op_stack_entry(1, PlayerId(0)));
+        let header = ReplayHeader {
+            format_config: state.format_config.clone(),
+            match_config: state.match_config,
+            player_count: state.players.len() as u8,
+            first_player: Some(0),
+            seed: state.rng_seed,
+            deck_data: None,
+        };
+        REPLAY_LOG.with(|cell| cell.set(Some(ReplayLog::new(header))));
+
+        let begin = GameAction::BeginResolveAll { max_resolutions: 0 };
+        apply(&mut state, PlayerId(0), begin.clone())
+            .expect("P0 begins the Resolve All consent run");
+        record_replay_action(false, PlayerId(0), begin);
+        let WaitingFor::ResolveAllConsent { epoch, .. } = state.waiting_for else {
+            panic!("P1 should be asked for consent, got {:?}", state.waiting_for);
+        };
+        let grant = GameAction::RespondResolveAllConsent {
+            epoch,
+            decision: ResolveAllConsentDecision::Grant,
+        };
+        apply(&mut state, PlayerId(1), grant.clone()).expect("P1 grants Resolve All consent");
+        record_replay_action(false, PlayerId(1), grant);
+        assert!(matches!(state.waiting_for, WaitingFor::ResolveAllReady { .. }));
+        GAME_STATE.with(|cell| cell.set(Some(state)));
+
+        resolve_all(0, "[]", 0).expect("the Ready consumer resolves through the WASM bridge");
+
+        REPLAY_LOG.with(|cell| {
+            let log = cell.take().expect("the replay log remains installed");
+            assert_eq!(log.actions.len(), 2);
+            assert_eq!(log.resolve_all_boundaries.len(), 1);
+            let boundary = &log.resolve_all_boundaries[0];
+            assert_eq!(boundary.after_action_count, 2);
+            assert_eq!(boundary.requester, PlayerId(0));
+            cell.set(Some(log));
+        });
+        clear_game_state();
+    }
+
+    #[test]
     fn restore_rehydrates_saved_state_when_db_loaded() {
         load_db_with_updated_face();
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -7596,7 +7596,9 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) -> bool 
                 }
             }
 
-            // Auto-submit empty blockers only when there's nothing to choose.
+            // Auto-submit empty blockers when nothing can be chosen, and submit
+            // an empty declaration for a live turn-boundary preference just as
+            // Declare Attackers does above.
             // CR 509.1 says the turn-based action still runs when no legal blocks
             // are available, and CR 117.1c requires the active player to receive
             // priority during the step (instants and Ninjutsu-family activations
@@ -7610,7 +7612,8 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) -> bool 
                 ..
             } if !state.phase_stop_hit(*player)
                 && (valid_blocker_ids.is_empty()
-                    || !super::combat::has_attackers_in_play(state)) =>
+                    || !super::combat::has_attackers_in_play(state)
+                    || end_of_turn_active(state, *player)) =>
             {
                 let mut events = Vec::new();
                 match engine_combat::handle_empty_blockers(state, *player, &mut events) {
@@ -7629,6 +7632,35 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) -> bool 
         }
     }
     advanced
+}
+
+/// CR 117.3d + CR 117.4: continues a live auto-pass preference after Resolve
+/// All has discharged its one-run consent. Resolve All is not an ordinary
+/// action boundary, so it owns the aggregation while this seam owns the normal
+/// priority progression.
+pub(crate) fn resume_auto_pass_after_resolve_all(
+    state: &mut GameState,
+    batch: &mut super::engine_resolve_batch::ResolveAllFastForwardResult,
+) {
+    let before = state.clone();
+    let mut result = ActionResult {
+        events: Vec::new(),
+        waiting_for: state.waiting_for.clone(),
+        log_entries: Vec::new(),
+    };
+    run_auto_pass_loop(state, &mut result);
+
+    let log_entries = super::log::resolve_log_entries(&result.events, &before, state);
+    batch.items_resolved = batch.items_resolved.saturating_add(
+        result
+            .events
+            .iter()
+            .filter(|event| matches!(event, GameEvent::StackResolved { .. }))
+            .count() as u32,
+    );
+    batch.events.extend(result.events);
+    batch.log_entries.extend(log_entries);
+    batch.waiting_for = state.waiting_for.clone();
 }
 
 /// CR 732.2: settle a runaway mandatory cascade gracefully. Pauses resolution,
@@ -7746,10 +7778,6 @@ fn begin_resolve_all_consent(
     max_resolutions: u32,
 ) -> Result<WaitingFor, EngineError> {
     super::priority::pass_priority_legality(state, priority_player)?;
-    // Resolve All consent supersedes this representative's standing yield. A
-    // Ready run must be free of auto-pass state so its one-resolution proof
-    // cannot advance beyond the consented boundary.
-    state.auto_pass.remove(&priority_player);
     let current_representative =
         super::topology::priority_pass_representative(state, priority_player);
     let mut representatives = super::topology::priority_pass_participants(state);
@@ -7959,9 +7987,6 @@ fn respond_resolve_all_consent(
                 .find(|participant| participant.representative == representative)
                 .expect("pending Resolve All representative must be a participant");
             participant.granted = true;
-            // A grant replaces this representative's standing auto-pass with
-            // the consented, bounded Resolve All sequence.
-            state.auto_pass.remove(&representative);
         }
     }
     if matches!(decision, ResolveAllConsentDecision::Decline) {
@@ -11003,11 +11028,47 @@ fn apply_action(
             engine_combat::handle_declare_attackers(state, *player, &attacks, &bands, &mut events)?
         }
         (
+            WaitingFor::DeclareAttackers { player, .. },
+            GameAction::SetAutoPass {
+                mode: AutoPassRequest::UntilTurnBoundary { until },
+            },
+        ) => {
+            store_auto_pass_request(
+                state,
+                *player,
+                AutoPassRequest::UntilTurnBoundary { until },
+            );
+            state.waiting_for.clone()
+        }
+        (WaitingFor::DeclareAttackers { .. }, GameAction::SetAutoPass { .. }) => {
+            return Err(EngineError::ActionNotAllowed(
+                "UntilStackEmpty auto-pass is unavailable while declaring attackers".to_string(),
+            ));
+        }
+        (
             WaitingFor::DeclareBlockers { player, .. },
             GameAction::DeclareBlockers { assignments },
         ) => {
             triggers_processed_inline = true;
             engine_combat::handle_declare_blockers(state, *player, &assignments, &mut events)?
+        }
+        (
+            WaitingFor::DeclareBlockers { player, .. },
+            GameAction::SetAutoPass {
+                mode: AutoPassRequest::UntilTurnBoundary { until },
+            },
+        ) => {
+            store_auto_pass_request(
+                state,
+                *player,
+                AutoPassRequest::UntilTurnBoundary { until },
+            );
+            state.waiting_for.clone()
+        }
+        (WaitingFor::DeclareBlockers { .. }, GameAction::SetAutoPass { .. }) => {
+            return Err(EngineError::ActionNotAllowed(
+                "UntilStackEmpty auto-pass is unavailable while declaring blockers".to_string(),
+            ));
         }
         (
             WaitingFor::UntapChoice {

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -7648,7 +7648,13 @@ pub(crate) fn resume_auto_pass_after_resolve_all(
         waiting_for: state.waiting_for.clone(),
         log_entries: Vec::new(),
     };
+    // CR 704.3: mirror the ordinary action-boundary reconciliation on both
+    // sides of the internal auto-pass drive. The resume seam bypasses
+    // `finish_action_boundary`, so without this a loss created by its final
+    // resolution could remain at Priority instead of becoming GameOver.
+    reconcile_terminal_result(state, &mut result);
     run_auto_pass_loop(state, &mut result);
+    reconcile_terminal_result(state, &mut result);
 
     let log_entries = super::log::resolve_log_entries(&result.events, &before, state);
     batch.items_resolved = batch.items_resolved.saturating_add(

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -7404,6 +7404,16 @@ mod auto_pass_decision_tests;
 /// Auto-pass loop: when a player has an auto-pass flag and receives priority,
 /// automatically pass for them until the goal condition is met or interrupted.
 fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) -> bool {
+    run_auto_pass_loop_with_recording(state, result, None)
+}
+
+/// Runs the ordinary auto-pass progression and optionally records the semantic
+/// actions it materializes for an enclosing action batch.
+fn run_auto_pass_loop_with_recording(
+    state: &mut GameState,
+    result: &mut ActionResult,
+    mut recorded_actions: Option<&mut Vec<(PlayerId, GameAction)>>,
+) -> bool {
     // CR 732.2: per-dispatch resource ceilings for a runaway mandatory cascade.
     // Sized above the largest legitimate single-dispatch burst (a Scute Swarm
     // landfall copies every Scute in one resolution — tested boards reach ~2,936
@@ -7476,9 +7486,13 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) -> bool 
                 }
 
                 let mut events = Vec::new();
+                let actor = turn_control::authorized_submitter_for_player(state, player);
                 match pass_priority_once_with_pipeline(state, &mut events, None) {
                     Ok(wf) => {
                         advanced = true;
+                        if let Some(recorded_actions) = recorded_actions.as_deref_mut() {
+                            recorded_actions.push((actor, GameAction::PassPriority));
+                        }
                         let stack_empty_or_grew =
                             finish_completed_or_interrupted_until_stack_empty_sessions(state);
                         result.events.extend(events);
@@ -7585,9 +7599,19 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) -> bool 
                 && (valid_attacker_ids.is_empty() || end_of_turn_active(state, *player)) =>
             {
                 let mut events = Vec::new();
+                let actor = turn_control::authorized_submitter_for_player(state, *player);
                 match engine_combat::handle_empty_attackers(state, &mut events) {
                     Ok(wf) => {
                         advanced = true;
+                        if let Some(recorded_actions) = recorded_actions.as_deref_mut() {
+                            recorded_actions.push((
+                                actor,
+                                GameAction::DeclareAttackers {
+                                    attacks: Vec::new(),
+                                    bands: Vec::new(),
+                                },
+                            ));
+                        }
                         sync_waiting_for(state, &wf);
                         result.events.extend(events);
                         result.waiting_for = wf;
@@ -7616,9 +7640,18 @@ fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) -> bool 
                     || end_of_turn_active(state, *player)) =>
             {
                 let mut events = Vec::new();
+                let actor = turn_control::authorized_submitter_for_player(state, *player);
                 match engine_combat::handle_empty_blockers(state, *player, &mut events) {
                     Ok(wf) => {
                         advanced = true;
+                        if let Some(recorded_actions) = recorded_actions.as_deref_mut() {
+                            recorded_actions.push((
+                                actor,
+                                GameAction::DeclareBlockers {
+                                    assignments: Vec::new(),
+                                },
+                            ));
+                        }
                         sync_waiting_for(state, &wf);
                         result.events.extend(events);
                         result.waiting_for = wf;
@@ -7653,7 +7686,7 @@ pub(crate) fn resume_auto_pass_after_resolve_all(
     // `finish_action_boundary`, so without this a loss created by its final
     // resolution could remain at Priority instead of becoming GameOver.
     reconcile_terminal_result(state, &mut result);
-    run_auto_pass_loop(state, &mut result);
+    run_auto_pass_loop_with_recording(state, &mut result, Some(&mut batch.recorded_actions));
     reconcile_terminal_result(state, &mut result);
 
     let log_entries = super::log::resolve_log_entries(&result.events, &before, state);
@@ -7962,6 +7995,16 @@ fn decline_resolve_all_consent_with_auto_pass(
     // from this state. Install the captured Priority window before reusing the
     // normal SetAutoPass path, rather than passing from the consent prompt.
     state.waiting_for = WaitingFor::Priority { player };
+    // The outer action boundary drives an existing preference immediately.
+    // Replacing it here would turn a retained time-boundary request into a
+    // stack-bound fallback before that normal progression can observe it.
+    if state.auto_pass.contains_key(&player) {
+        return Ok(ActionResult {
+            events: std::mem::take(events),
+            waiting_for: state.waiting_for.clone(),
+            log_entries: vec![],
+        });
+    }
     install_until_stack_empty_auto_pass_and_pass_priority(state, player, events)
 }
 

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -7404,16 +7404,6 @@ mod auto_pass_decision_tests;
 /// Auto-pass loop: when a player has an auto-pass flag and receives priority,
 /// automatically pass for them until the goal condition is met or interrupted.
 fn run_auto_pass_loop(state: &mut GameState, result: &mut ActionResult) -> bool {
-    run_auto_pass_loop_with_recording(state, result, None)
-}
-
-/// Runs the ordinary auto-pass progression and optionally records the semantic
-/// actions it materializes for an enclosing action batch.
-fn run_auto_pass_loop_with_recording(
-    state: &mut GameState,
-    result: &mut ActionResult,
-    mut recorded_actions: Option<&mut Vec<(PlayerId, GameAction)>>,
-) -> bool {
     // CR 732.2: per-dispatch resource ceilings for a runaway mandatory cascade.
     // Sized above the largest legitimate single-dispatch burst (a Scute Swarm
     // landfall copies every Scute in one resolution — tested boards reach ~2,936
@@ -7486,13 +7476,9 @@ fn run_auto_pass_loop_with_recording(
                 }
 
                 let mut events = Vec::new();
-                let actor = turn_control::authorized_submitter_for_player(state, player);
                 match pass_priority_once_with_pipeline(state, &mut events, None) {
                     Ok(wf) => {
                         advanced = true;
-                        if let Some(recorded_actions) = recorded_actions.as_deref_mut() {
-                            recorded_actions.push((actor, GameAction::PassPriority));
-                        }
                         let stack_empty_or_grew =
                             finish_completed_or_interrupted_until_stack_empty_sessions(state);
                         result.events.extend(events);
@@ -7599,19 +7585,9 @@ fn run_auto_pass_loop_with_recording(
                 && (valid_attacker_ids.is_empty() || end_of_turn_active(state, *player)) =>
             {
                 let mut events = Vec::new();
-                let actor = turn_control::authorized_submitter_for_player(state, *player);
                 match engine_combat::handle_empty_attackers(state, &mut events) {
                     Ok(wf) => {
                         advanced = true;
-                        if let Some(recorded_actions) = recorded_actions.as_deref_mut() {
-                            recorded_actions.push((
-                                actor,
-                                GameAction::DeclareAttackers {
-                                    attacks: Vec::new(),
-                                    bands: Vec::new(),
-                                },
-                            ));
-                        }
                         sync_waiting_for(state, &wf);
                         result.events.extend(events);
                         result.waiting_for = wf;
@@ -7640,18 +7616,9 @@ fn run_auto_pass_loop_with_recording(
                     || end_of_turn_active(state, *player)) =>
             {
                 let mut events = Vec::new();
-                let actor = turn_control::authorized_submitter_for_player(state, *player);
                 match engine_combat::handle_empty_blockers(state, *player, &mut events) {
                     Ok(wf) => {
                         advanced = true;
-                        if let Some(recorded_actions) = recorded_actions.as_deref_mut() {
-                            recorded_actions.push((
-                                actor,
-                                GameAction::DeclareBlockers {
-                                    assignments: Vec::new(),
-                                },
-                            ));
-                        }
                         sync_waiting_for(state, &wf);
                         result.events.extend(events);
                         result.waiting_for = wf;
@@ -7686,7 +7653,7 @@ pub(crate) fn resume_auto_pass_after_resolve_all(
     // `finish_action_boundary`, so without this a loss created by its final
     // resolution could remain at Priority instead of becoming GameOver.
     reconcile_terminal_result(state, &mut result);
-    run_auto_pass_loop_with_recording(state, &mut result, Some(&mut batch.recorded_actions));
+    run_auto_pass_loop(state, &mut result);
     reconcile_terminal_result(state, &mut result);
 
     let log_entries = super::log::resolve_log_entries(&result.events, &before, state);

--- a/crates/engine/src/game/engine_auto_pass_decision_tests.rs
+++ b/crates/engine/src/game/engine_auto_pass_decision_tests.rs
@@ -156,7 +156,7 @@ fn declare_attackers_accepts_turn_boundary_auto_pass_but_rejects_stack_empty() {
         vec![stop(Phase::DeclareAttackers, PhaseStopScope::AllTurns)],
     );
 
-    apply(
+    let result = apply(
         &mut state,
         PlayerId(0),
         GameAction::SetAutoPass {
@@ -166,7 +166,26 @@ fn declare_attackers_accepts_turn_boundary_auto_pass_but_rejects_stack_empty() {
         },
     )
     .expect("turn-boundary auto-pass is valid at Declare Attackers");
-    assert!(state.auto_pass.contains_key(&PlayerId(0)));
+    assert_eq!(
+        state.auto_pass.get(&PlayerId(0)),
+        Some(&AutoPassMode::UntilTurnBoundary {
+            until: TurnBoundary::EndOfCurrentTurn,
+        })
+    );
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::DeclareAttackers {
+            player: PlayerId(0),
+            ..
+        }
+    ));
+    assert!(
+        !result
+            .events
+            .iter()
+            .any(|event| matches!(event, GameEvent::AttackersDeclared { .. })),
+        "the phase stop must leave the attacker prompt unsubmitted"
+    );
 
     let error = apply(
         &mut state,
@@ -197,7 +216,7 @@ fn declare_blockers_accepts_turn_boundary_auto_pass_but_rejects_stack_empty() {
         vec![stop(Phase::DeclareBlockers, PhaseStopScope::AllTurns)],
     );
 
-    apply(
+    let result = apply(
         &mut state,
         PlayerId(0),
         GameAction::SetAutoPass {
@@ -207,7 +226,26 @@ fn declare_blockers_accepts_turn_boundary_auto_pass_but_rejects_stack_empty() {
         },
     )
     .expect("turn-boundary auto-pass is valid at Declare Blockers");
-    assert!(state.auto_pass.contains_key(&PlayerId(0)));
+    assert_eq!(
+        state.auto_pass.get(&PlayerId(0)),
+        Some(&AutoPassMode::UntilTurnBoundary {
+            until: TurnBoundary::EndOfCurrentTurn,
+        })
+    );
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::DeclareBlockers {
+            player: PlayerId(0),
+            ..
+        }
+    ));
+    assert!(
+        !result
+            .events
+            .iter()
+            .any(|event| matches!(event, GameEvent::BlockersDeclared { .. })),
+        "the phase stop must leave the blocker prompt unsubmitted"
+    );
 
     let error = apply(
         &mut state,
@@ -286,6 +324,13 @@ fn turn_boundary_auto_pass_does_not_bypass_must_attack() {
         result.waiting_for,
         WaitingFor::DeclareAttackers { .. }
     ));
+    assert_eq!(
+        state.auto_pass.get(&PlayerId(0)),
+        Some(&AutoPassMode::UntilTurnBoundary {
+            until: TurnBoundary::EndOfCurrentTurn,
+        }),
+        "an unsatisfied must-attack requirement leaves the requested session armed"
+    );
 }
 
 fn blockers_declaration_state(must_block: bool) -> GameState {
@@ -359,6 +404,13 @@ fn turn_boundary_auto_pass_does_not_bypass_must_block() {
         result.waiting_for,
         WaitingFor::DeclareBlockers { .. }
     ));
+    assert_eq!(
+        state.auto_pass.get(&PlayerId(0)),
+        Some(&AutoPassMode::UntilTurnBoundary {
+            until: TurnBoundary::EndOfCurrentTurn,
+        }),
+        "an unsatisfied must-block requirement leaves the requested session armed"
+    );
 }
 
 fn push_simple_stack_entry(state: &mut GameState, id: u64, controller: PlayerId) {
@@ -800,6 +852,12 @@ fn declare_blockers_opponents_turns_stop_pauses_empty_blocker_submit() {
         PlayerId(0),
         vec![stop(Phase::DeclareBlockers, PhaseStopScope::OpponentsTurns)],
     );
+    state.auto_pass.insert(
+        PlayerId(0),
+        AutoPassMode::UntilTurnBoundary {
+            until: TurnBoundary::EndOfCurrentTurn,
+        },
+    );
 
     let mut result = ActionResult {
         events: Vec::new(),
@@ -818,6 +876,13 @@ fn declare_blockers_opponents_turns_stop_pauses_empty_blocker_submit() {
         ),
         "OpponentsTurns stop fires on the attacker's turn → the empty-blocker \
          auto-submit is paused"
+    );
+    assert!(
+        !result
+            .events
+            .iter()
+            .any(|event| matches!(event, GameEvent::BlockersDeclared { .. })),
+        "the phase stop must not submit an empty blocker declaration"
     );
 }
 
@@ -934,6 +999,13 @@ fn declare_attackers_own_turn_stop_pauses_empty_attacker_submit() {
         ),
         "OwnTurn stop fires on the owner's own turn → the empty-attacker \
          auto-submit is paused"
+    );
+    assert!(
+        !result
+            .events
+            .iter()
+            .any(|event| matches!(event, GameEvent::AttackersDeclared { .. })),
+        "the phase stop must not submit an empty attacker declaration"
     );
 }
 

--- a/crates/engine/src/game/engine_auto_pass_decision_tests.rs
+++ b/crates/engine/src/game/engine_auto_pass_decision_tests.rs
@@ -778,45 +778,6 @@ fn phase_stop_hit_is_independent_of_auto_pass_mode() {
 }
 
 #[test]
-fn until_end_of_turn_auto_submits_the_empty_blocker_declaration() {
-    let waiting_for = WaitingFor::DeclareBlockers {
-        player: PlayerId(0),
-        valid_blocker_ids: vec![ObjectId(10)],
-        valid_block_targets: [(ObjectId(10), vec![ObjectId(20)])].into_iter().collect(),
-        block_requirements: Default::default(),
-        blocker_constraints: Default::default(),
-    };
-    let mut state = GameState {
-        phase: Phase::DeclareBlockers,
-        active_player: PlayerId(1),
-        waiting_for: waiting_for.clone(),
-        ..GameState::default()
-    };
-    state.auto_pass.insert(
-        PlayerId(0),
-        AutoPassMode::UntilTurnBoundary {
-            until: TurnBoundary::EndOfCurrentTurn,
-        },
-    );
-
-    let mut result = ActionResult {
-        events: Vec::new(),
-        waiting_for,
-        log_entries: Vec::new(),
-    };
-    run_auto_pass_loop(&mut state, &mut result);
-
-    assert!(!matches!(
-        result.waiting_for,
-        WaitingFor::DeclareBlockers { .. }
-    ));
-    assert!(
-        state.auto_pass.contains_key(&PlayerId(0)),
-        "the defender's turn-boundary session remains armed after the empty declaration"
-    );
-}
-
-#[test]
 fn declare_blockers_opponents_turns_stop_pauses_empty_blocker_submit() {
     // Matrix row 6: owner = defender P0; the attacker P1 is the active player.
     // An OpponentsTurns stop on Declare Blockers fires (owner != active_player),

--- a/crates/engine/src/game/engine_auto_pass_decision_tests.rs
+++ b/crates/engine/src/game/engine_auto_pass_decision_tests.rs
@@ -1,10 +1,11 @@
 use super::*;
 use std::sync::Arc;
 
+use crate::game::combat::AttackTarget;
 use crate::game::zones::create_object;
 use crate::types::ability::{
     AbilityDefinition, AbilityKind, CopyRetargetPermission, Effect, QuantityExpr, ResolvedAbility,
-    TargetFilter,
+    StaticDefinition, TargetFilter,
 };
 use crate::types::actions::GameAction;
 use crate::types::card_type::CoreType;
@@ -12,6 +13,7 @@ use crate::types::events::GameEvent;
 use crate::types::game_state::{CastingVariant, TurnBoundary};
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::phase::{PhaseStop, PhaseStopScope};
+use crate::types::statics::StaticMode;
 use crate::types::zones::Zone;
 
 fn stack_entry(controller: PlayerId) -> StackEntry {
@@ -56,6 +58,20 @@ fn priority_state() -> GameState {
     state.priority_passes.clear();
     state.priority_pass_count = 0;
     state
+}
+
+fn add_untapped_creature(state: &mut GameState, controller: PlayerId, card_id: u64) -> ObjectId {
+    let object_id = create_object(
+        state,
+        CardId(card_id),
+        controller,
+        "Combat creature".to_string(),
+        Zone::Battlefield,
+    );
+    let object = state.objects.get_mut(&object_id).unwrap();
+    object.card_types.core_types.push(CoreType::Creature);
+    object.summoning_sick = false;
+    object_id
 }
 
 #[test]
@@ -121,6 +137,228 @@ fn set_auto_pass_carries_requested_boundary_via_dispatch() {
             "SetAutoPass must store the requested boundary {until:?}"
         );
     }
+}
+
+#[test]
+fn declare_attackers_accepts_turn_boundary_auto_pass_but_rejects_stack_empty() {
+    let waiting_for = WaitingFor::DeclareAttackers {
+        player: PlayerId(0),
+        valid_attacker_ids: Vec::new(),
+        valid_attack_targets: Vec::new(),
+        valid_attack_targets_by_attacker: None,
+        attacker_constraints: Default::default(),
+    };
+    let mut state = priority_state();
+    state.phase = Phase::DeclareAttackers;
+    state.waiting_for = waiting_for;
+    state.phase_stops.insert(
+        PlayerId(0),
+        vec![stop(Phase::DeclareAttackers, PhaseStopScope::AllTurns)],
+    );
+
+    apply(
+        &mut state,
+        PlayerId(0),
+        GameAction::SetAutoPass {
+            mode: AutoPassRequest::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            },
+        },
+    )
+    .expect("turn-boundary auto-pass is valid at Declare Attackers");
+    assert!(state.auto_pass.contains_key(&PlayerId(0)));
+
+    let error = apply(
+        &mut state,
+        PlayerId(0),
+        GameAction::SetAutoPass {
+            mode: AutoPassRequest::UntilStackEmpty,
+        },
+    )
+    .expect_err("UntilStackEmpty must not bypass attacker declaration");
+    assert!(matches!(error, EngineError::ActionNotAllowed(_)));
+}
+
+#[test]
+fn declare_blockers_accepts_turn_boundary_auto_pass_but_rejects_stack_empty() {
+    let waiting_for = WaitingFor::DeclareBlockers {
+        player: PlayerId(0),
+        valid_blocker_ids: Vec::new(),
+        valid_block_targets: Default::default(),
+        block_requirements: Default::default(),
+        blocker_constraints: Default::default(),
+    };
+    let mut state = priority_state();
+    state.phase = Phase::DeclareBlockers;
+    state.active_player = PlayerId(1);
+    state.waiting_for = waiting_for;
+    state.phase_stops.insert(
+        PlayerId(0),
+        vec![stop(Phase::DeclareBlockers, PhaseStopScope::AllTurns)],
+    );
+
+    apply(
+        &mut state,
+        PlayerId(0),
+        GameAction::SetAutoPass {
+            mode: AutoPassRequest::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            },
+        },
+    )
+    .expect("turn-boundary auto-pass is valid at Declare Blockers");
+    assert!(state.auto_pass.contains_key(&PlayerId(0)));
+
+    let error = apply(
+        &mut state,
+        PlayerId(0),
+        GameAction::SetAutoPass {
+            mode: AutoPassRequest::UntilStackEmpty,
+        },
+    )
+    .expect_err("UntilStackEmpty must not bypass blocker declaration");
+    assert!(matches!(error, EngineError::ActionNotAllowed(_)));
+}
+
+#[test]
+fn turn_boundary_auto_pass_submits_a_legal_empty_attacker_declaration() {
+    let mut state = priority_state();
+    let attacker = add_untapped_creature(&mut state, PlayerId(0), 910);
+    state.phase = Phase::DeclareAttackers;
+    state.combat = Some(crate::game::combat::CombatState::default());
+    state.waiting_for = WaitingFor::DeclareAttackers {
+        player: PlayerId(0),
+        valid_attacker_ids: vec![attacker],
+        valid_attack_targets: vec![AttackTarget::Player(PlayerId(1))],
+        valid_attack_targets_by_attacker: None,
+        attacker_constraints: Default::default(),
+    };
+
+    let result = apply(
+        &mut state,
+        PlayerId(0),
+        GameAction::SetAutoPass {
+            mode: AutoPassRequest::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            },
+        },
+    )
+    .expect("a legal empty attack declaration may be auto-submitted");
+
+    assert!(!matches!(
+        result.waiting_for,
+        WaitingFor::DeclareAttackers { .. }
+    ));
+}
+
+#[test]
+fn turn_boundary_auto_pass_does_not_bypass_must_attack() {
+    let mut state = priority_state();
+    let attacker = add_untapped_creature(&mut state, PlayerId(0), 911);
+    state
+        .objects
+        .get_mut(&attacker)
+        .unwrap()
+        .static_definitions
+        .push(StaticDefinition::new(StaticMode::MustAttack).affected(TargetFilter::SelfRef));
+    state.phase = Phase::DeclareAttackers;
+    state.combat = Some(crate::game::combat::CombatState::default());
+    state.waiting_for = WaitingFor::DeclareAttackers {
+        player: PlayerId(0),
+        valid_attacker_ids: vec![attacker],
+        valid_attack_targets: vec![AttackTarget::Player(PlayerId(1))],
+        valid_attack_targets_by_attacker: None,
+        attacker_constraints: Default::default(),
+    };
+
+    let result = apply(
+        &mut state,
+        PlayerId(0),
+        GameAction::SetAutoPass {
+            mode: AutoPassRequest::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            },
+        },
+    )
+    .expect("the preference itself is valid at Declare Attackers");
+
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::DeclareAttackers { .. }
+    ));
+}
+
+fn blockers_declaration_state(must_block: bool) -> GameState {
+    let mut state = priority_state();
+    let attacker = add_untapped_creature(&mut state, PlayerId(1), 912);
+    let blocker = add_untapped_creature(&mut state, PlayerId(0), 913);
+    if must_block {
+        state
+            .objects
+            .get_mut(&blocker)
+            .unwrap()
+            .static_definitions
+            .push(StaticDefinition::new(StaticMode::MustBlock).affected(TargetFilter::SelfRef));
+    }
+    state.phase = Phase::DeclareBlockers;
+    state.active_player = PlayerId(1);
+    state.combat = Some(crate::game::combat::CombatState {
+        attackers: vec![crate::game::combat::AttackerInfo::attacking_player(
+            attacker,
+            PlayerId(0),
+        )],
+        ..Default::default()
+    });
+    state.waiting_for = WaitingFor::DeclareBlockers {
+        player: PlayerId(0),
+        valid_blocker_ids: vec![blocker],
+        valid_block_targets: [(blocker, vec![attacker])].into_iter().collect(),
+        block_requirements: Default::default(),
+        blocker_constraints: Default::default(),
+    };
+    state
+}
+
+#[test]
+fn turn_boundary_auto_pass_submits_a_legal_empty_blocker_declaration() {
+    let mut state = blockers_declaration_state(false);
+
+    let result = apply(
+        &mut state,
+        PlayerId(0),
+        GameAction::SetAutoPass {
+            mode: AutoPassRequest::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            },
+        },
+    )
+    .expect("a legal empty block declaration may be auto-submitted");
+
+    assert!(!matches!(
+        result.waiting_for,
+        WaitingFor::DeclareBlockers { .. }
+    ));
+}
+
+#[test]
+fn turn_boundary_auto_pass_does_not_bypass_must_block() {
+    let mut state = blockers_declaration_state(true);
+
+    let result = apply(
+        &mut state,
+        PlayerId(0),
+        GameAction::SetAutoPass {
+            mode: AutoPassRequest::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            },
+        },
+    )
+    .expect("the preference itself is valid at Declare Blockers");
+
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::DeclareBlockers { .. }
+    ));
 }
 
 fn push_simple_stack_entry(state: &mut GameState, id: u64, controller: PlayerId) {
@@ -540,7 +778,7 @@ fn phase_stop_hit_is_independent_of_auto_pass_mode() {
 }
 
 #[test]
-fn until_end_of_turn_does_not_auto_submit_available_blockers() {
+fn until_end_of_turn_auto_submits_the_empty_blocker_declaration() {
     let waiting_for = WaitingFor::DeclareBlockers {
         player: PlayerId(0),
         valid_blocker_ids: vec![ObjectId(10)],
@@ -568,16 +806,13 @@ fn until_end_of_turn_does_not_auto_submit_available_blockers() {
     };
     run_auto_pass_loop(&mut state, &mut result);
 
-    assert!(matches!(
+    assert!(!matches!(
         result.waiting_for,
-        WaitingFor::DeclareBlockers {
-            player: PlayerId(0),
-            ..
-        }
+        WaitingFor::DeclareBlockers { .. }
     ));
     assert!(
         state.auto_pass.contains_key(&PlayerId(0)),
-        "the defender's auto-pass session should stay armed after pausing for legal blockers"
+        "the defender's turn-boundary session remains armed after the empty declaration"
     );
 }
 

--- a/crates/engine/src/game/engine_resolve_batch.rs
+++ b/crates/engine/src/game/engine_resolve_batch.rs
@@ -22,13 +22,13 @@ pub struct ResolveAllFastForwardResult {
     /// Stack depth at this chunk's entry. The frontend latches the first
     /// chunk's `total` as the storm-origin denominator for progress display.
     pub total: u32,
-    /// Every action applied during this batch (including priority passes
-    /// fast-forwarded by `seed_remaining_priority_cycle_passes`, which are
-    /// semantically equivalent to — but bypass — an explicit `PassPriority`
-    /// through `apply`), in submission order. `#[serde(skip)]`: this is
-    /// consumed in-process by the WASM bridge to extend the Replay system's
-    /// recording (see `crates/engine-wasm/src/lib.rs::resolve_all`) and must
-    /// never reach the JS-visible result shape.
+    /// Every action applied during the legacy callback batch (including priority
+    /// passes fast-forwarded by `seed_remaining_priority_cycle_passes`, which
+    /// are semantically equivalent to — but bypass — an explicit
+    /// `PassPriority` through `apply`), in submission order. `#[serde(skip)]`:
+    /// this never reaches the JS-visible result shape. Ready-consumer Resolve
+    /// All is replayed atomically by the transport-owned replay boundary rather
+    /// than by appending these internal actions individually.
     #[serde(skip)]
     pub recorded_actions: Vec<(PlayerId, GameAction)>,
 }
@@ -1192,45 +1192,6 @@ mod tests {
             WaitingFor::ResolveAllReady { .. }
         ));
         assert!(state.resolve_all_consent_run.is_none());
-    }
-
-    #[test]
-    fn retained_auto_pass_remainder_records_actions_replay_can_apply() {
-        let mut state = ready_state(vec![no_op_entry(1, PlayerId(0))]);
-        state.auto_pass.insert(
-            PlayerId(0),
-            AutoPassMode::UntilTurnBoundary {
-                until: TurnBoundary::EndOfCurrentTurn,
-            },
-        );
-        // A nonempty pending-event batch makes the clone proof stop before it
-        // commits, leaving the live turn-boundary preference to resume.
-        state.pending_trigger_event_batch = vec![GameEvent::StackResolved {
-            object_id: ObjectId(99),
-        }];
-
-        let mut replay = state.clone();
-        replay.waiting_for = WaitingFor::Priority {
-            player: PlayerId(0),
-        };
-        replay.resolve_all_consent_run = None;
-
-        let result = resolve_all_ready_prefix(&mut state, PlayerId(0));
-
-        assert_eq!(
-            result.recorded_actions,
-            vec![(PlayerId(0), GameAction::PassPriority)],
-            "the resumed turn-boundary pass is an action replay can submit"
-        );
-        for (actor, action) in result.recorded_actions {
-            super::super::engine::apply(&mut replay, actor, action)
-                .expect("recorded auto-pass action reconstructs through apply");
-        }
-        assert_eq!(replay.stack, state.stack);
-        assert_eq!(replay.waiting_for, state.waiting_for);
-        assert_eq!(replay.auto_pass, state.auto_pass);
-        assert_eq!(replay.priority_player, state.priority_player);
-        assert_eq!(replay.priority_passes, state.priority_passes);
     }
 
     #[test]

--- a/crates/engine/src/game/engine_resolve_batch.rs
+++ b/crates/engine/src/game/engine_resolve_batch.rs
@@ -139,23 +139,13 @@ pub fn resolve_all_ready_prefix_with(
     while items_resolved < resolution_cap && !state.stack.is_empty() {
         let mut proof = state.clone();
         let stack_before = proof.stack.len();
-        // A turn-boundary preference remains live while Resolve All is asking
-        // for consent, but this proof is allowed to materialize exactly one
-        // consented resolution. Suppress only those entries on the clone, then
-        // restore the exact map entries before a successful clone is committed.
-        let suspended_turn_boundary_auto_passes: Vec<_> = proof
-            .auto_pass
-            .iter()
-            .filter_map(|(player, mode)| {
-                matches!(mode, AutoPassMode::UntilTurnBoundary { .. })
-                    .then_some((*player, mode.clone()))
-            })
-            .collect();
-        proof
-            .auto_pass
-            .retain(|_, mode| !matches!(mode, AutoPassMode::UntilTurnBoundary { .. }));
+        // Durable auto-pass intent remains live while Resolve All is asking
+        // for consent, but the clone may materialize exactly one consented
+        // resolution. Suspend the whole clone-local map: an UntilStackEmpty
+        // entry could otherwise run beyond this proof's one-entry limit.
+        let suspended_auto_passes = std::mem::take(&mut proof.auto_pass);
         let materialized = materialize_one_consented_resolution(&mut proof, &run);
-        proof.auto_pass.extend(suspended_turn_boundary_auto_passes);
+        proof.auto_pass = suspended_auto_passes;
         let Some((boundary, mut actions)) = materialized else {
             proof_stopped = true;
             break;
@@ -1306,6 +1296,45 @@ mod tests {
             state.auto_pass.get(&PlayerId(0)),
             Some(&AutoPassMode::UntilTurnBoundary {
                 until: TurnBoundary::EndOfCurrentTurn,
+            })
+        );
+    }
+
+    #[test]
+    fn ready_consent_proof_isolates_until_stack_empty_from_the_second_entry() {
+        let mut state = ready_state(vec![
+            no_op_entry(1, PlayerId(0)),
+            no_op_entry(2, PlayerId(0)),
+        ]);
+        state
+            .resolve_all_consent_run
+            .as_mut()
+            .expect("Ready retains its frozen run")
+            .max_resolutions = 1;
+        let initial_stack_len = state.stack.len();
+        state.auto_pass.insert(
+            PlayerId(0),
+            AutoPassMode::UntilStackEmpty { initial_stack_len },
+        );
+
+        let result = resolve_all_ready_prefix_with(
+            &mut state,
+            PlayerId(0),
+            ResolveAllContinuation::StopAtPriority,
+        );
+
+        assert_eq!(result.items_resolved, 1);
+        assert_eq!(
+            stack_resolved_count(&result.events),
+            1,
+            "one consented materialization may resolve only one stack entry"
+        );
+        assert_eq!(state.stack.len(), 1);
+        assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
+        assert_eq!(
+            state.auto_pass.get(&PlayerId(0)),
+            Some(&AutoPassMode::UntilStackEmpty {
+                initial_stack_len: 2,
             })
         );
     }

--- a/crates/engine/src/game/engine_resolve_batch.rs
+++ b/crates/engine/src/game/engine_resolve_batch.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::ai_support::AiDecisionContract;
 use crate::types::actions::GameAction;
 use crate::types::events::GameEvent;
-use crate::types::game_state::{GameState, ResolveAllConsentRun, WaitingFor};
+use crate::types::game_state::{AutoPassMode, GameState, ResolveAllConsentRun, WaitingFor};
 use crate::types::log::GameLogEntry;
 use crate::types::player::PlayerId;
 
@@ -76,9 +76,10 @@ pub fn resolve_all_ready_prefix(
 /// actionable state back and stops.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ResolveAllContinuation {
-    /// Install the ordinary `UntilStackEmpty` auto-pass and pass priority, so
-    /// the requester's standing intent to avoid manual passes survives a proof
-    /// that could not collapse the whole batch. The live-session answer.
+    /// Resume the requester's retained auto-pass, or install the ordinary
+    /// `UntilStackEmpty` fallback when they have no retained preference, so
+    /// a proof that could not collapse the whole batch does not require manual
+    /// priority passes. The live-session answer.
     AutoPassRemainder,
     /// Stop at ordinary priority and install nothing.
     ///
@@ -138,8 +139,24 @@ pub fn resolve_all_ready_prefix_with(
     while items_resolved < resolution_cap && !state.stack.is_empty() {
         let mut proof = state.clone();
         let stack_before = proof.stack.len();
-        let Some((boundary, mut actions)) = materialize_one_consented_resolution(&mut proof, &run)
-        else {
+        // A turn-boundary preference remains live while Resolve All is asking
+        // for consent, but this proof is allowed to materialize exactly one
+        // consented resolution. Suppress only those entries on the clone, then
+        // restore the exact map entries before a successful clone is committed.
+        let suspended_turn_boundary_auto_passes: Vec<_> = proof
+            .auto_pass
+            .iter()
+            .filter_map(|(player, mode)| {
+                matches!(mode, AutoPassMode::UntilTurnBoundary { .. })
+                    .then_some((*player, mode.clone()))
+            })
+            .collect();
+        proof
+            .auto_pass
+            .retain(|_, mode| !matches!(mode, AutoPassMode::UntilTurnBoundary { .. }));
+        let materialized = materialize_one_consented_resolution(&mut proof, &run);
+        proof.auto_pass.extend(suspended_turn_boundary_auto_passes);
+        let Some((boundary, mut actions)) = materialized else {
             proof_stopped = true;
             break;
         };
@@ -168,31 +185,36 @@ pub fn resolve_all_ready_prefix_with(
     // Authorization is one run only. Once the proved prefix ends, no later
     // stack entry inherits this consent. A proof failure is different from a
     // requested cap: it only rejects collapsing this sequence, not the
-    // requester's durable intent to avoid manual priority passes. Continue
-    // through the ordinary `UntilStackEmpty` engine path in that case.
+    // requester's durable intent to avoid manual priority passes.
     turn_control::invalidate_resolve_all_consent(state);
-    if proof_stopped && continuation == ResolveAllContinuation::AutoPassRemainder {
-        let mut fallback_events = Vec::new();
-        match super::engine::install_until_stack_empty_auto_pass_and_pass_priority(
-            state,
-            run.priority_snapshot.waiting_player,
-            &mut fallback_events,
-        ) {
-            Ok(fallback) => {
-                items_resolved += stack_resolved_count(&fallback.events);
-                events.extend(fallback.events);
-                log_entries.extend(fallback.log_entries);
-            }
-            Err(_) => {
-                // A pre-cast shortcut may require a meaningful action before the
-                // current Priority window can pass. Keep the requester's durable
-                // preference so the ordinary loop resumes after that action.
-                super::engine::install_until_stack_empty_auto_pass(
-                    state,
-                    run.priority_snapshot.waiting_player,
-                );
-            }
+    if continuation == ResolveAllContinuation::AutoPassRemainder {
+        if proof_stopped
+            && !state
+                .auto_pass
+                .contains_key(&run.priority_snapshot.waiting_player)
+        {
+            // Keep the previous fallback for a requester without a retained
+            // turn-boundary preference. The ordinary loop below also preserves
+            // its pre-cast guard: it leaves this request armed until an allowed
+            // action can resume it.
+            super::engine::install_until_stack_empty_auto_pass(
+                state,
+                run.priority_snapshot.waiting_player,
+            );
         }
+        let mut resumed = ResolveAllFastForwardResult {
+            events,
+            waiting_for: state.waiting_for.clone(),
+            log_entries,
+            items_resolved,
+            total,
+            recorded_actions,
+        };
+        super::engine::resume_auto_pass_after_resolve_all(state, &mut resumed);
+        events = resumed.events;
+        log_entries = resumed.log_entries;
+        items_resolved = resumed.items_resolved;
+        recorded_actions = resumed.recorded_actions;
     }
     finalize_display_state(state);
     interaction::ensure_interaction_authority(state);
@@ -356,11 +378,10 @@ fn ready_consent_run(state: &GameState, requester: PlayerId) -> Option<&ResolveA
     let WaitingFor::ResolveAllReady { epoch } = &state.waiting_for else {
         return None;
     };
-    let run = state.resolve_all_consent_run.as_ref().filter(|run| {
-        state.auto_pass.is_empty()
-            && run.epoch == *epoch
-            && run.participants.iter().all(|p| p.granted)
-    })?;
+    let run = state
+        .resolve_all_consent_run
+        .as_ref()
+        .filter(|run| run.epoch == *epoch && run.participants.iter().all(|p| p.granted))?;
     (run.participants
         .iter()
         .any(|participant| participant.authorized_submitter == requester)
@@ -1088,7 +1109,7 @@ mod tests {
     }
 
     #[test]
-    fn resolve_all_consent_supersedes_until_end_of_turn_auto_passes() {
+    fn resolve_all_consent_retains_until_end_of_turn_auto_passes() {
         let mut state = priority_state(PlayerId(0), vec![no_op_entry(1, PlayerId(0))]);
         state.auto_pass.insert(
             PlayerId(0),
@@ -1103,7 +1124,7 @@ mod tests {
             GameAction::BeginResolveAll { max_resolutions: 0 },
         )
         .expect("priority holder begins the consent run");
-        assert!(!state.auto_pass.contains_key(&PlayerId(0)));
+        assert!(state.auto_pass.contains_key(&PlayerId(0)));
 
         let epoch = match &state.waiting_for {
             WaitingFor::ResolveAllConsent { epoch, .. } => *epoch,
@@ -1129,11 +1150,24 @@ mod tests {
             state.waiting_for,
             WaitingFor::ResolveAllReady { .. }
         ));
-        assert!(state.auto_pass.is_empty());
+        assert_eq!(
+            state.auto_pass.get(&PlayerId(0)),
+            Some(&AutoPassMode::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            })
+        );
+        assert_eq!(
+            state.auto_pass.get(&PlayerId(1)),
+            Some(&AutoPassMode::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            })
+        );
 
         let result = resolve_all_ready_prefix(&mut state, PlayerId(0));
         assert_eq!(result.items_resolved, 1);
         assert!(state.stack.is_empty());
+        assert!(state.auto_pass.contains_key(&PlayerId(0)));
+        assert!(state.auto_pass.contains_key(&PlayerId(1)));
     }
 
     #[test]
@@ -1217,20 +1251,61 @@ mod tests {
     }
 
     #[test]
-    fn ready_consent_refuses_to_collapse_while_an_auto_pass_preference_is_active() {
-        let mut state = ready_state(vec![no_op_entry(1, PlayerId(0))]);
+    fn ready_consent_proof_isolates_turn_boundary_auto_pass_from_the_second_entry() {
+        let mut state = ready_state(vec![
+            no_op_entry(1, PlayerId(0)),
+            no_op_entry(2, PlayerId(0)),
+        ]);
+        state
+            .resolve_all_consent_run
+            .as_mut()
+            .expect("Ready retains its frozen run")
+            .max_resolutions = 1;
         state.auto_pass.insert(
             PlayerId(0),
-            AutoPassMode::UntilStackEmpty {
-                initial_stack_len: state.stack.len(),
+            AutoPassMode::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
             },
         );
 
         let result = resolve_all_ready_prefix(&mut state, PlayerId(0));
 
-        assert_eq!(result.items_resolved, 0);
+        assert_eq!(result.items_resolved, 1);
         assert_eq!(state.stack.len(), 1);
         assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
         assert!(state.resolve_all_consent_run.is_none());
+        assert_eq!(
+            state.auto_pass.get(&PlayerId(0)),
+            Some(&AutoPassMode::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            })
+        );
+    }
+
+    #[test]
+    fn ready_consumer_resumes_retained_turn_boundary_auto_pass_after_clearing_stack() {
+        let mut state = ready_state(vec![no_op_entry(1, PlayerId(0))]);
+        state.phase = Phase::PreCombatMain;
+        state.auto_pass.insert(
+            PlayerId(0),
+            AutoPassMode::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            },
+        );
+        let result = resolve_all_ready_prefix(&mut state, PlayerId(0));
+
+        assert_eq!(result.items_resolved, 1);
+        assert!(state.stack.is_empty());
+        assert_eq!(result.waiting_for, state.waiting_for);
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::Priority {
+                player: PlayerId(1)
+            }
+        ));
+        assert!(result
+            .events
+            .iter()
+            .any(|event| matches!(event, GameEvent::StackResolved { .. })));
     }
 }

--- a/crates/engine/src/game/engine_resolve_batch.rs
+++ b/crates/engine/src/game/engine_resolve_batch.rs
@@ -697,7 +697,7 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::types::ability::{
         AbilityCost, AbilityDefinition, AbilityKind, CopyRetargetPermission, Effect,
-        ManaContribution, ManaProduction, ResolvedAbility, TargetFilter,
+        ManaContribution, ManaProduction, QuantityExpr, ResolvedAbility, TargetFilter,
     };
     use crate::types::actions::ResolveAllConsentDecision;
     use crate::types::card_type::{CardType, CoreType};
@@ -723,6 +723,27 @@ mod tests {
                 source_id: object_id,
                 ability: Box::new(ResolvedAbility::new(
                     Effect::NoOp,
+                    vec![],
+                    object_id,
+                    controller,
+                )),
+            },
+        }
+    }
+
+    fn draw_entry(id: u64, controller: PlayerId) -> StackEntry {
+        let object_id = ObjectId(id);
+        StackEntry {
+            id: object_id,
+            source_id: object_id,
+            controller,
+            kind: StackEntryKind::ActivatedAbility {
+                source_id: object_id,
+                ability: Box::new(ResolvedAbility::new(
+                    Effect::Draw {
+                        count: QuantityExpr::Fixed { value: 1 },
+                        target: TargetFilter::Controller,
+                    },
                     vec![],
                     object_id,
                     controller,
@@ -1314,5 +1335,39 @@ mod tests {
             .events
             .iter()
             .any(|event| matches!(event, GameEvent::StackResolved { .. })));
+    }
+
+    #[test]
+    fn resumed_remainder_reconciles_empty_library_loss_to_game_over() {
+        // The no-op is consented and committed. The empty-library draw then
+        // fails the next proof on its terminal checkpoint and is resolved by
+        // the ordinary retained auto-pass remainder.
+        let mut state = ready_state(vec![
+            draw_entry(1, PlayerId(0)),
+            no_op_entry(2, PlayerId(0)),
+        ]);
+        for player in [PlayerId(0), PlayerId(1)] {
+            state.auto_pass.insert(
+                player,
+                AutoPassMode::UntilTurnBoundary {
+                    until: TurnBoundary::EndOfCurrentTurn,
+                },
+            );
+        }
+
+        let result = resolve_all_ready_prefix(&mut state, PlayerId(0));
+
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::GameOver {
+                winner: Some(PlayerId(1))
+            }
+        ));
+        assert!(result.events.iter().any(|event| matches!(
+            event,
+            GameEvent::GameOver {
+                winner: Some(PlayerId(1))
+            }
+        )));
     }
 }

--- a/crates/engine/src/game/engine_resolve_batch.rs
+++ b/crates/engine/src/game/engine_resolve_batch.rs
@@ -3,7 +3,7 @@ use serde::{Deserialize, Serialize};
 use crate::ai_support::AiDecisionContract;
 use crate::types::actions::GameAction;
 use crate::types::events::GameEvent;
-use crate::types::game_state::{AutoPassMode, GameState, ResolveAllConsentRun, WaitingFor};
+use crate::types::game_state::{GameState, ResolveAllConsentRun, WaitingFor};
 use crate::types::log::GameLogEntry;
 use crate::types::player::PlayerId;
 

--- a/crates/engine/src/game/engine_resolve_batch.rs
+++ b/crates/engine/src/game/engine_resolve_batch.rs
@@ -1166,8 +1166,11 @@ mod tests {
         let result = resolve_all_ready_prefix(&mut state, PlayerId(0));
         assert_eq!(result.items_resolved, 1);
         assert!(state.stack.is_empty());
-        assert!(state.auto_pass.contains_key(&PlayerId(0)));
-        assert!(state.auto_pass.contains_key(&PlayerId(1)));
+        assert!(!matches!(
+            state.waiting_for,
+            WaitingFor::ResolveAllReady { .. }
+        ));
+        assert!(state.resolve_all_consent_run.is_none());
     }
 
     #[test]
@@ -1194,7 +1197,11 @@ mod tests {
         assert!(stack::priority_checkpoint_is_settled(&proof));
         assert!(consent_authorization_matches(&proof, &run));
 
-        let result = resolve_all_ready_prefix(&mut state, PlayerId(0));
+        let result = resolve_all_ready_prefix_with(
+            &mut state,
+            PlayerId(0),
+            ResolveAllContinuation::StopAtPriority,
+        );
 
         assert_eq!(
             result.items_resolved,

--- a/crates/engine/src/game/engine_resolve_batch.rs
+++ b/crates/engine/src/game/engine_resolve_batch.rs
@@ -1195,6 +1195,45 @@ mod tests {
     }
 
     #[test]
+    fn retained_auto_pass_remainder_records_actions_replay_can_apply() {
+        let mut state = ready_state(vec![no_op_entry(1, PlayerId(0))]);
+        state.auto_pass.insert(
+            PlayerId(0),
+            AutoPassMode::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            },
+        );
+        // A nonempty pending-event batch makes the clone proof stop before it
+        // commits, leaving the live turn-boundary preference to resume.
+        state.pending_trigger_event_batch = vec![GameEvent::StackResolved {
+            object_id: ObjectId(99),
+        }];
+
+        let mut replay = state.clone();
+        replay.waiting_for = WaitingFor::Priority {
+            player: PlayerId(0),
+        };
+        replay.resolve_all_consent_run = None;
+
+        let result = resolve_all_ready_prefix(&mut state, PlayerId(0));
+
+        assert_eq!(
+            result.recorded_actions,
+            vec![(PlayerId(0), GameAction::PassPriority)],
+            "the resumed turn-boundary pass is an action replay can submit"
+        );
+        for (actor, action) in result.recorded_actions {
+            super::super::engine::apply(&mut replay, actor, action)
+                .expect("recorded auto-pass action reconstructs through apply");
+        }
+        assert_eq!(replay.stack, state.stack);
+        assert_eq!(replay.waiting_for, state.waiting_for);
+        assert_eq!(replay.auto_pass, state.auto_pass);
+        assert_eq!(replay.priority_player, state.priority_player);
+        assert_eq!(replay.priority_passes, state.priority_passes);
+    }
+
+    #[test]
     fn ready_consent_commits_the_greatest_settled_prefix_and_records_passes() {
         // The lower self-copy creates a new stack object. It is deliberately
         // left for ordinary priority, while both safe entries above it commit.

--- a/crates/engine/src/game/engine_resolve_batch.rs
+++ b/crates/engine/src/game/engine_resolve_batch.rs
@@ -1385,23 +1385,33 @@ mod tests {
             draw_entry(1, PlayerId(0)),
             no_op_entry(2, PlayerId(0)),
         ]);
-        for player in [PlayerId(0), PlayerId(1)] {
-            state.auto_pass.insert(
-                player,
-                AutoPassMode::UntilTurnBoundary {
-                    until: TurnBoundary::EndOfCurrentTurn,
-                },
-            );
-        }
+        // After the settled no-op, P0's retained turn-boundary preference
+        // passes its own draw and P1's stack-empty session completes the
+        // priority cycle that reaches the CR 704.5b SBA.
+        state.auto_pass.insert(
+            PlayerId(0),
+            AutoPassMode::UntilTurnBoundary {
+                until: TurnBoundary::EndOfCurrentTurn,
+            },
+        );
+        state.auto_pass.insert(
+            PlayerId(1),
+            AutoPassMode::UntilStackEmpty {
+                initial_stack_len: 1,
+            },
+        );
 
         let result = resolve_all_ready_prefix(&mut state, PlayerId(0));
 
+        assert_eq!(result.items_resolved, 2);
         assert!(matches!(
             state.waiting_for,
             WaitingFor::GameOver {
                 winner: Some(PlayerId(1))
             }
         ));
+        assert!(state.players[0].drew_from_empty_library);
+        assert!(state.players[0].is_eliminated);
         assert!(result.events.iter().any(|event| matches!(
             event,
             GameEvent::GameOver {

--- a/crates/engine/src/game/replay.rs
+++ b/crates/engine/src/game/replay.rs
@@ -19,7 +19,7 @@ use crate::types::player::PlayerId;
 use crate::types::replay::{RecordedAction, ReplayHeader, ReplayLog, REPLAY_FORMAT_VERSION};
 
 use super::deck_loading::{load_and_hydrate_decks, resolve_deck_list};
-use super::engine::{apply, start_game, start_game_with_starting_player};
+use super::engine::{apply, resolve_all_ready_prefix, start_game, start_game_with_starting_player};
 
 /// Checkpoints are cached every `CHECKPOINT_INTERVAL` actions, bounding cache
 /// size to roughly `len / CHECKPOINT_INTERVAL` snapshots while keeping any
@@ -33,7 +33,7 @@ const CHECKPOINT_INTERVAL: u32 = 20;
 pub enum ReplayError {
     #[error("replay is missing its format version")]
     MissingFormatVersion,
-    #[error("unsupported replay format version {version}; this engine supports version 2")]
+    #[error("unsupported replay format version {version}; this engine supports versions 2 and 3")]
     UnsupportedFormatVersion { version: u32 },
     /// An action that was recorded as having succeeded failed to re-apply
     /// during reconstruction. This means the recording and the engine version
@@ -133,7 +133,7 @@ impl ReplayPlayer {
     /// is `Some` and `db` is `None` — see that function's doc comment.
     pub fn load(log: ReplayLog, db: Option<&CardDatabase>) -> Result<Self, ReplayError> {
         match log.format_version {
-            Some(REPLAY_FORMAT_VERSION) => {}
+            Some(2 | REPLAY_FORMAT_VERSION) => {}
             Some(version) => return Err(ReplayError::UnsupportedFormatVersion { version }),
             None => return Err(ReplayError::MissingFormatVersion),
         }
@@ -198,6 +198,15 @@ impl ReplayPlayer {
                     message: e.to_string(),
                 }
             })?;
+            let after_action_count = recorded.seq + 1;
+            for boundary in self
+                .log
+                .resolve_all_boundaries
+                .iter()
+                .filter(|boundary| boundary.after_action_count == after_action_count)
+            {
+                resolve_all_ready_prefix(&mut state, boundary.requester);
+            }
         }
         Ok(state)
     }
@@ -206,10 +215,14 @@ impl ReplayPlayer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::types::ability::{TriggerBaseSetInstanceRef, TriggerDefinitionOccurrenceRef};
-    use crate::types::actions::GameAction;
+    use crate::types::ability::{
+        Effect, ResolvedAbility, TriggerBaseSetInstanceRef, TriggerDefinitionOccurrenceRef,
+    };
+    use crate::types::actions::{GameAction, ResolveAllConsentDecision};
     use crate::types::format::FormatConfig;
-    use crate::types::game_state::{ProductionOverride, WaitingFor};
+    use crate::types::game_state::{
+        AutoPassMode, ProductionOverride, StackEntry, StackEntryKind, TurnBoundary, WaitingFor,
+    };
     use crate::types::identifiers::{ObjectId, ObjectIncarnationRef};
     use crate::types::mana::{
         ManaSourceOutput, ManaSourcePenalty, ManaSourceSelection, ManaType, TapsForManaSelection,
@@ -238,6 +251,24 @@ mod tests {
         }
     }
 
+    fn no_op_entry(id: u64, controller: PlayerId) -> StackEntry {
+        let object_id = ObjectId(id);
+        StackEntry {
+            id: object_id,
+            source_id: object_id,
+            controller,
+            kind: StackEntryKind::ActivatedAbility {
+                source_id: object_id,
+                ability: Box::new(ResolvedAbility::new(
+                    Effect::NoOp,
+                    Vec::new(),
+                    object_id,
+                    controller,
+                )),
+            },
+        }
+    }
+
     #[test]
     fn load_rejects_missing_format_version_before_reconstruction() {
         let mut log = ReplayLog::new(two_player_header(1));
@@ -259,7 +290,7 @@ mod tests {
     }
 
     #[test]
-    fn version_two_roundtrips_semantic_mana_source_selections() {
+    fn version_three_roundtrips_semantic_mana_source_selections() {
         let source = ObjectIncarnationRef::of(ObjectId(7), 3);
         let aura = ObjectIncarnationRef::of(ObjectId(9), 2);
         let action = GameAction::TapLandForMana {
@@ -370,6 +401,53 @@ mod tests {
                 "waiting_for at {index}"
             );
         }
+    }
+
+    #[test]
+    fn replay_player_reconstructs_atomic_resolve_all_with_two_retained_auto_passes() {
+        let header = two_player_header(101);
+        let mut initial = GameState::new_two_player(header.seed);
+        initial.stack.push_back(no_op_entry(1, PlayerId(0)));
+        for player in [PlayerId(0), PlayerId(1)] {
+            initial.auto_pass.insert(
+                player,
+                AutoPassMode::UntilTurnBoundary {
+                    until: TurnBoundary::EndOfCurrentTurn,
+                },
+            );
+        }
+
+        let mut live = initial.clone();
+        let mut log = ReplayLog::new(header);
+        let begin = GameAction::BeginResolveAll { max_resolutions: 0 };
+        apply(&mut live, PlayerId(0), begin.clone()).expect("P0 begins Resolve All consent");
+        log.push_action(PlayerId(0), begin);
+        let WaitingFor::ResolveAllConsent { epoch, .. } = live.waiting_for else {
+            panic!("P1 should be asked for consent, got {:?}", live.waiting_for);
+        };
+        let grant = GameAction::RespondResolveAllConsent {
+            epoch,
+            decision: ResolveAllConsentDecision::Grant,
+        };
+        apply(&mut live, PlayerId(1), grant.clone()).expect("P1 grants Resolve All consent");
+        log.push_action(PlayerId(1), grant);
+        assert!(matches!(
+            live.waiting_for,
+            WaitingFor::ResolveAllReady { .. }
+        ));
+
+        resolve_all_ready_prefix(&mut live, PlayerId(0));
+        log.push_resolve_all_boundary(PlayerId(0));
+
+        let mut replay = ReplayPlayer::load(log, None).expect("the atomic boundary is replayable");
+        replay.checkpoints.insert(0, initial);
+        let replay_len = replay.len();
+        let reconstructed = replay
+            .seek(replay_len)
+            .expect("ReplayPlayer applies the Resolve All boundary")
+            .clone();
+
+        assert_eq!(reconstructed, live);
     }
 
     #[test]

--- a/crates/engine/src/game/replay.rs
+++ b/crates/engine/src/game/replay.rs
@@ -14,12 +14,15 @@ use std::collections::BTreeMap;
 use thiserror::Error;
 
 use crate::database::CardDatabase;
-use crate::types::game_state::GameState;
+use crate::types::game_state::{GameState, WaitingFor};
 use crate::types::player::PlayerId;
 use crate::types::replay::{RecordedAction, ReplayHeader, ReplayLog, REPLAY_FORMAT_VERSION};
 
 use super::deck_loading::{load_and_hydrate_decks, resolve_deck_list};
-use super::engine::{apply, resolve_all_ready_prefix, start_game, start_game_with_starting_player};
+use super::engine::{
+    apply, resolve_all_ready_access, resolve_all_ready_prefix, start_game,
+    start_game_with_starting_player, ResolveAllReadyAccess,
+};
 
 /// Checkpoints are cached every `CHECKPOINT_INTERVAL` actions, bounding cache
 /// size to roughly `len / CHECKPOINT_INTERVAL` snapshots while keeping any
@@ -137,6 +140,7 @@ impl ReplayPlayer {
             Some(version) => return Err(ReplayError::UnsupportedFormatVersion { version }),
             None => return Err(ReplayError::MissingFormatVersion),
         }
+        validate_resolve_all_boundaries(&log)?;
         let initial = reconstruct_initial_state(&log.header, db)?;
         let mut checkpoints = BTreeMap::new();
         checkpoints.insert(0, initial);
@@ -191,25 +195,77 @@ impl ReplayPlayer {
             .next_back()
             .expect("index 0 checkpoint is always present");
         let mut state = base.clone();
-        for recorded in &self.log.actions[start_idx as usize..target as usize] {
+        for (offset, recorded) in self.log.actions[start_idx as usize..target as usize]
+            .iter()
+            .enumerate()
+        {
             apply(&mut state, recorded.actor, recorded.action.clone()).map_err(|e| {
                 ReplayError::Desync {
                     index: recorded.seq,
                     message: e.to_string(),
                 }
             })?;
-            let after_action_count = recorded.seq + 1;
+            let after_action_count = start_idx + offset as u32 + 1;
             for boundary in self
                 .log
                 .resolve_all_boundaries
                 .iter()
                 .filter(|boundary| boundary.after_action_count == after_action_count)
             {
+                if !matches!(state.waiting_for, WaitingFor::ResolveAllReady { .. }) {
+                    return Err(ReplayError::Desync {
+                        index: recorded.seq,
+                        message: "Resolve All boundary was due without a Ready latch".to_string(),
+                    });
+                }
+                if resolve_all_ready_access(&state, boundary.requester)
+                    != ResolveAllReadyAccess::Admitted
+                {
+                    return Err(ReplayError::Desync {
+                        index: recorded.seq,
+                        message:
+                            "Resolve All boundary requester is not entitled to the Ready latch"
+                                .to_string(),
+                    });
+                }
                 resolve_all_ready_prefix(&mut state, boundary.requester);
             }
         }
         Ok(state)
     }
+}
+
+fn validate_resolve_all_boundaries(log: &ReplayLog) -> Result<(), ReplayError> {
+    let boundary_error = |after_action_count: u32, message: &str| ReplayError::Desync {
+        index: after_action_count.saturating_sub(1),
+        message: message.to_string(),
+    };
+
+    if log.format_version == Some(2) && !log.resolve_all_boundaries.is_empty() {
+        return Err(boundary_error(
+            log.resolve_all_boundaries[0].after_action_count,
+            "version 2 replay cannot contain Resolve All boundaries",
+        ));
+    }
+
+    let action_count = log.actions.len() as u32;
+    let mut previous = 0;
+    for boundary in &log.resolve_all_boundaries {
+        if boundary.after_action_count == 0 || boundary.after_action_count > action_count {
+            return Err(boundary_error(
+                boundary.after_action_count,
+                "Resolve All boundary anchor is outside the action sequence",
+            ));
+        }
+        if boundary.after_action_count <= previous {
+            return Err(boundary_error(
+                boundary.after_action_count,
+                "Resolve All boundaries must be unique and strictly ordered",
+            ));
+        }
+        previous = boundary.after_action_count;
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -221,13 +277,14 @@ mod tests {
     use crate::types::actions::{GameAction, ResolveAllConsentDecision};
     use crate::types::format::FormatConfig;
     use crate::types::game_state::{
-        AutoPassMode, ProductionOverride, StackEntry, StackEntryKind, TurnBoundary, WaitingFor,
+        AutoPassMode, ProductionOverride, StackEntry, StackEntryKind, TurnBoundary,
     };
     use crate::types::identifiers::{ObjectId, ObjectIncarnationRef};
     use crate::types::mana::{
         ManaSourceOutput, ManaSourcePenalty, ManaSourceSelection, ManaType, TapsForManaSelection,
     };
     use crate::types::match_config::MatchConfig;
+    use crate::types::replay::RecordedResolveAll;
 
     fn two_player_header(seed: u64) -> ReplayHeader {
         ReplayHeader {
@@ -286,6 +343,126 @@ mod tests {
             error,
             ReplayError::UnsupportedFormatVersion { version }
                 if version == REPLAY_FORMAT_VERSION + 1
+        ));
+    }
+
+    #[test]
+    fn version_two_rejects_resolve_all_boundaries() {
+        let mut legacy = ReplayLog::new(two_player_header(2));
+        legacy.format_version = Some(2);
+        ReplayPlayer::load(legacy.clone(), None)
+            .expect("v2 replay without Resolve All boundaries remains readable");
+
+        legacy.resolve_all_boundaries.push(RecordedResolveAll {
+            after_action_count: 1,
+            requester: PlayerId(0),
+        });
+        let error = ReplayPlayer::load(legacy, None)
+            .expect_err("v2 cannot represent an atomic Resolve All boundary");
+        assert!(matches!(
+            error,
+            ReplayError::Desync { message, .. }
+                if message == "version 2 replay cannot contain Resolve All boundaries"
+        ));
+    }
+
+    #[test]
+    fn version_three_rejects_invalid_resolve_all_boundary_anchors() {
+        let mut base = ReplayLog::new(two_player_header(3));
+        base.push_action(PlayerId(0), GameAction::PassPriority);
+        base.push_action(PlayerId(1), GameAction::PassPriority);
+
+        let mut zero = base.clone();
+        zero.resolve_all_boundaries.push(RecordedResolveAll {
+            after_action_count: 0,
+            requester: PlayerId(0),
+        });
+        let mut past_end = base.clone();
+        past_end.resolve_all_boundaries.push(RecordedResolveAll {
+            after_action_count: 3,
+            requester: PlayerId(0),
+        });
+        let mut unordered = base.clone();
+        unordered.resolve_all_boundaries = vec![
+            RecordedResolveAll {
+                after_action_count: 2,
+                requester: PlayerId(0),
+            },
+            RecordedResolveAll {
+                after_action_count: 1,
+                requester: PlayerId(1),
+            },
+        ];
+        let mut duplicate = base;
+        duplicate.resolve_all_boundaries = vec![
+            RecordedResolveAll {
+                after_action_count: 1,
+                requester: PlayerId(0),
+            },
+            RecordedResolveAll {
+                after_action_count: 1,
+                requester: PlayerId(1),
+            },
+        ];
+
+        for malformed in [zero, past_end, unordered, duplicate] {
+            let error = ReplayPlayer::load(malformed, None)
+                .expect_err("v3 boundary anchors must be in-range, unique, and ordered");
+            assert!(matches!(error, ReplayError::Desync { .. }));
+        }
+    }
+
+    #[test]
+    fn due_resolve_all_boundary_requires_a_ready_latch() {
+        let mut log = ReplayLog::new(two_player_header(4));
+        log.push_action(PlayerId(0), GameAction::PassPriority);
+        log.push_resolve_all_boundary(PlayerId(0));
+
+        let mut replay = ReplayPlayer::load(log, None).expect("boundary shape is valid");
+        let error = replay
+            .seek(1)
+            .expect_err("a due Resolve All boundary must not be silently ignored");
+        assert!(matches!(
+            error,
+            ReplayError::Desync { message, .. }
+                if message == "Resolve All boundary was due without a Ready latch"
+        ));
+    }
+
+    #[test]
+    fn due_resolve_all_boundary_rejects_an_unentitled_requester() {
+        let header = two_player_header(5);
+        let mut initial = GameState::new_two_player(header.seed);
+        initial.stack.push_back(no_op_entry(1, PlayerId(0)));
+        let mut log = ReplayLog::new(header);
+
+        let begin = GameAction::BeginResolveAll { max_resolutions: 0 };
+        let mut consent = initial.clone();
+        apply(&mut consent, PlayerId(0), begin.clone())
+            .expect("P0 can begin Resolve All from priority");
+        log.push_action(PlayerId(0), begin);
+        let WaitingFor::ResolveAllConsent { epoch, .. } = consent.waiting_for else {
+            panic!(
+                "P1 should be asked for consent, got {:?}",
+                consent.waiting_for
+            );
+        };
+        let grant = GameAction::RespondResolveAllConsent {
+            epoch,
+            decision: ResolveAllConsentDecision::Grant,
+        };
+        log.push_action(PlayerId(1), grant);
+        log.push_resolve_all_boundary(PlayerId(2));
+
+        let mut replay = ReplayPlayer::load(log, None).expect("boundary shape is valid");
+        replay.checkpoints.insert(0, initial);
+        let error = replay
+            .seek(2)
+            .expect_err("a non-participant cannot consume Resolve All Ready");
+        assert!(matches!(
+            error,
+            ReplayError::Desync { message, .. }
+                if message == "Resolve All boundary requester is not entitled to the Ready latch"
         ));
     }
 

--- a/crates/engine/src/types/replay.rs
+++ b/crates/engine/src/types/replay.rs
@@ -6,7 +6,9 @@ use super::match_config::MatchConfig;
 use super::player::PlayerId;
 use crate::game::deck_loading::DeckList;
 
-pub const REPLAY_FORMAT_VERSION: u32 = 2;
+/// Version 3 adds atomic Resolve All replay boundaries. Version 2 recordings
+/// remain readable because they cannot contain those boundaries.
+pub const REPLAY_FORMAT_VERSION: u32 = 3;
 
 /// Everything needed to reconstruct a game's starting state, deterministically,
 /// from scratch. Mirrors the inputs `initialize_game` already accepts at the
@@ -38,6 +40,17 @@ pub struct RecordedAction {
     pub action: GameAction,
 }
 
+/// One engine-owned Resolve All burst, anchored after the preceding submitted
+/// action. Resolve All has no `GameAction` because its Ready latch is consumed
+/// by the transport; replay therefore carries the whole burst as one atomic
+/// boundary rather than manufacturing individual priority passes.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct RecordedResolveAll {
+    /// Number of ordinary actions already applied when this burst began.
+    pub after_action_count: u32,
+    pub requester: PlayerId,
+}
+
 /// A complete, deterministic recording of a game: the inputs needed to
 /// reconstruct its starting state, plus every action that was submitted and
 /// accepted afterward. Replaying `actions` against the state produced by
@@ -51,6 +64,8 @@ pub struct ReplayLog {
     pub format_version: Option<u32>,
     pub header: ReplayHeader,
     pub actions: Vec<RecordedAction>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub resolve_all_boundaries: Vec<RecordedResolveAll>,
 }
 
 impl ReplayLog {
@@ -59,6 +74,7 @@ impl ReplayLog {
             format_version: Some(REPLAY_FORMAT_VERSION),
             header,
             actions: Vec::new(),
+            resolve_all_boundaries: Vec::new(),
         }
     }
 
@@ -68,5 +84,16 @@ impl ReplayLog {
     pub fn push_action(&mut self, actor: PlayerId, action: GameAction) {
         let seq = self.actions.len() as u32;
         self.actions.push(RecordedAction { seq, actor, action });
+    }
+
+    /// Records the transport-owned consumption of an already-ready Resolve All
+    /// latch. Playback runs the same engine consumer after this many ordinary
+    /// actions, preserving automatic follow-up without replaying its internal
+    /// passes as independent user actions.
+    pub fn push_resolve_all_boundary(&mut self, requester: PlayerId) {
+        self.resolve_all_boundaries.push(RecordedResolveAll {
+            after_action_count: self.actions.len() as u32,
+            requester,
+        });
     }
 }

--- a/crates/engine/tests/integration/resolve_all_consent.rs
+++ b/crates/engine/tests/integration/resolve_all_consent.rs
@@ -22,7 +22,8 @@ use engine::types::card_type::CoreType;
 use engine::types::events::GameEvent;
 use engine::types::format::FormatConfig;
 use engine::types::game_state::{
-    AutoPassMode, GameState, PersistedGameState, StackEntry, StackEntryKind, WaitingFor,
+    AutoPassMode, GameState, PersistedGameState, StackEntry, StackEntryKind, TurnBoundary,
+    WaitingFor,
 };
 use engine::types::identifiers::{CardId, ObjectId};
 use engine::types::interaction::{
@@ -366,6 +367,46 @@ fn stale_epoch_and_decline_continue_through_the_requesters_engine_auto_pass() {
         },
     )
     .is_err());
+}
+
+#[test]
+fn decline_preserves_the_requesters_retained_end_of_turn_auto_pass() {
+    let mut state = GameState::new_two_player(44);
+    state.stack.push_back(no_op_entry(1, P1));
+    state.auto_pass.insert(
+        P0,
+        AutoPassMode::UntilTurnBoundary {
+            until: TurnBoundary::EndOfCurrentTurn,
+        },
+    );
+    let epoch = begin(&mut state);
+
+    apply(
+        &mut state,
+        P1,
+        GameAction::RespondResolveAllConsent {
+            epoch,
+            decision: ResolveAllConsentDecision::Decline,
+        },
+    )
+    .expect("a decline restores the retained end-of-turn preference");
+
+    assert_eq!(
+        state.auto_pass.get(&P0),
+        Some(&AutoPassMode::UntilTurnBoundary {
+            until: TurnBoundary::EndOfCurrentTurn,
+        }),
+        "declining Resolve All must not overwrite a live end-of-turn preference"
+    );
+    assert_eq!(
+        state.stack.len(),
+        1,
+        "the opponent's stack object still pauses it"
+    );
+    assert!(matches!(
+        state.waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
 }
 
 #[test]

--- a/crates/engine/tests/integration/resolve_all_consent.rs
+++ b/crates/engine/tests/integration/resolve_all_consent.rs
@@ -254,25 +254,12 @@ fn browser_partial_priority_equip_keeps_the_requesters_no_manual_resolution_inte
     let result = resolve_all_ready_prefix(&mut state, P2);
 
     assert_eq!(
-        result.items_resolved, 0,
-        "the conservative batch proof must not consume an unsettled checkpoint"
+        result.items_resolved, 1,
+        "the proof resolves nothing, but the live continuation resolves Equip through ordinary auto-pass"
     );
-    assert!(matches!(
-        state.waiting_for,
-        WaitingFor::Priority { player: P1 },
-    ));
-    assert_eq!(
-        state.auto_pass.get(&P0),
-        Some(&AutoPassMode::UntilStackEmpty {
-            initial_stack_len: 1,
-        }),
-        "the failed proof becomes the requester's ordinary standing auto-pass"
-    );
-    apply(&mut state, P1, GameAction::PassPriority)
-        .expect("the next AI's ordinary pass continues the requester's auto-pass");
     assert!(
         state.stack.is_empty(),
-        "the Equip resolves without another manual P0 action"
+        "the failed proof resumes the requester's no-manual-resolution intent"
     );
     assert_eq!(
         state.objects[&equipment].attached_to,
@@ -803,7 +790,8 @@ fn ready_consent_collapses_the_safe_prefix_before_a_stack_growing_resolution() {
     )
     .expect("second representative grants");
 
-    let result = resolve_all_ready_prefix(&mut state, P0);
+    let result =
+        resolve_all_ready_prefix_with(&mut state, P0, ResolveAllContinuation::StopAtPriority);
 
     assert_eq!(
         result.items_resolved,
@@ -814,26 +802,9 @@ fn ready_consent_collapses_the_safe_prefix_before_a_stack_growing_resolution() {
     );
     assert_eq!(state.stack.len(), 1, "the stack-growing item remains live");
     assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
-    assert_eq!(
-        state.auto_pass.get(&P0),
-        Some(&AutoPassMode::UntilStackEmpty {
-            initial_stack_len: 1,
-        }),
-        "a partial proof keeps the original requester as the durable auto-pass owner"
-    );
-
-    let WaitingFor::Priority { player } = state.waiting_for else {
-        panic!("the unproved entry must return to the ordinary priority pipeline");
-    };
-    assert_ne!(
-        player, P0,
-        "the requester has already passed; another seat now owns the live priority window"
-    );
-    apply(&mut state, player, GameAction::PassPriority)
-        .expect("the ordinary priority action resumes the requester's stored auto-pass");
     assert!(
         state.auto_pass.is_empty(),
-        "a stack-growing resolution interrupts UntilStackEmpty instead of inheriting stale consent"
+        "the bounded proof continuation must not install an ordinary auto-pass session"
     );
 }
 /// Drives a two-seat run to unanimous consent and returns the latched state.
@@ -892,9 +863,8 @@ fn ready_access_refuses_an_unentitled_seat_and_admits_an_incoherent_run() {
         ResolveAllReadyAccess::Refused
     );
 
-    // An installed auto-pass makes the frozen priority snapshot no longer
-    // describe the live game. Entitlement is untouched by that — P0 is still a
-    // frozen submitter — so the gate must not move.
+    // A retained auto-pass is coherent: proof clones suppress only their
+    // turn-boundary entries. Entitlement and the frozen requester stay intact.
     state.auto_pass.insert(
         P1,
         AutoPassMode::UntilStackEmpty {
@@ -908,8 +878,8 @@ fn ready_access_refuses_an_unentitled_seat_and_admits_an_incoherent_run() {
     );
     assert_eq!(
         pending_resolve_all_ready_requester(&state),
-        None,
-        "an incoherent run authorizes no unattended consumption"
+        Some(P0),
+        "retained auto-pass does not make a Ready run incoherent"
     );
 
     // With no run at all there is no frozen submitter list, so there is nobody
@@ -1006,13 +976,9 @@ fn recovery_of_an_incoherent_latch_re_derives_the_ready_era_slots() {
     let mut state = ready_two_seat_state();
     // The run is present and epoch-matching — so the slots below really are the
     // Ready set — but the frozen priority snapshot no longer describes the live
-    // game, which is what makes the latch unconsumable.
-    state.auto_pass.insert(
-        P1,
-        AutoPassMode::UntilStackEmpty {
-            initial_stack_len: 1,
-        },
-    );
+    // game, which is what makes the latch unconsumable. Retained auto-pass is
+    // deliberately not used here because it is now coherent.
+    state.priority_pass_count += 1;
     bind_interaction_authority(
         &mut state,
         InteractionSessionId("resolve-all-restore".to_string()),
@@ -1089,20 +1055,20 @@ fn proof_stopping_ready_state() -> GameState {
 
 /// The two continuations must actually differ, and only on the remainder.
 ///
-/// A live session installs `UntilStackEmpty` so the requester's standing intent
-/// survives a proof that stopped short. A restore must not: that auto-pass
-/// resolves the rest of the stack through the ordinary pipeline, which can end
-/// the game — and a restore has no socket attached and no caller positioned to
-/// emit a ranked result or a terminal artifact, so the game would be registered
-/// live while parked in `GameOver`.
+/// A live session installs and immediately executes `UntilStackEmpty` so the
+/// requester's standing intent survives a proof that stopped short. A restore
+/// must not: that auto-pass resolves the rest of the stack through the ordinary
+/// pipeline, which can end the game — and a restore has no socket attached and
+/// no caller positioned to emit a ranked result or a terminal artifact, so the
+/// game would be registered live while parked in `GameOver`.
 #[test]
 fn the_restore_continuation_installs_no_auto_pass_where_the_live_one_does() {
     let mut live = proof_stopping_ready_state();
     let live_batch =
         resolve_all_ready_prefix_with(&mut live, P0, ResolveAllContinuation::AutoPassRemainder);
     assert!(
-        !live.auto_pass.is_empty(),
-        "non-vacuity: this fixture must reach the proof-stopped fallback at all"
+        live.auto_pass.is_empty(),
+        "the live continuation consumes its temporary fallback when CopySpell grows the stack"
     );
 
     let mut restored = proof_stopping_ready_state();
@@ -1123,8 +1089,8 @@ fn the_restore_continuation_installs_no_auto_pass_where_the_live_one_does() {
         "the consented prefix is collapsed either way; only the remainder differs"
     );
     assert!(
-        live_batch.items_resolved >= restored_batch.items_resolved,
-        "the live continuation may resolve more, never less"
+        live_batch.items_resolved > restored_batch.items_resolved,
+        "the live continuation runs past the bounded proof prefix"
     );
     assert!(
         restored.resolve_all_consent_run.is_none(),

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -6775,18 +6775,11 @@ mod tests {
         (mgr, game_code, ai_player)
     }
 
-    /// An AI-granted latch whose run is INCOHERENT is the one with no exit at
-    /// all, so it is the one the hand-off must not decline.
-    ///
-    /// `ready_consent_run` requires `auto_pass.is_empty()`, so a single seat
-    /// holding an End Turn auto-pass makes every latch minted that turn
-    /// incoherent. The hand-off previously read its requester through
-    /// `pending_resolve_all_ready_requester`, whose `?` propagates exactly that
-    /// coherence test — so it returned `None` here and left the latch standing:
-    /// no acting player, and no client that renders `ResolveAllReady`. This is
-    /// the reported hang, reachable from the ordinary End Turn button.
+    /// A retained End Turn auto-pass remains coherent with an AI-granted Ready
+    /// latch. The Resolve All proof temporarily suppresses it only on its
+    /// private one-entry clone, then restores it before committing the proof.
     #[test]
-    fn run_ai_repairs_its_own_grant_when_the_frozen_run_is_incoherent() {
+    fn run_ai_consumes_its_own_grant_with_a_retained_end_turn_auto_pass() {
         let (mut mgr, game_code, _ai_player) = ai_table_awaiting_one_consent();
         let session = mgr
             .sessions
@@ -6799,10 +6792,7 @@ mod tests {
             GameAction::BeginResolveAll { max_resolutions: 1 },
         )
         .expect("the priority holder may start Resolve All consent");
-        // Freeze the run first, THEN make the live game disagree with the
-        // snapshot it froze. `BeginResolveAll` has no auto-pass precondition,
-        // and `apply` exempts consent actions from clearing the actor's entry,
-        // so this is the ordinary End Turn shape and not a contrived state.
+        // A live End Turn preference must stay coherent through the AI's grant.
         session.state.auto_pass.insert(
             PlayerId(0),
             AutoPassMode::UntilTurnBoundary {
@@ -6839,12 +6829,12 @@ mod tests {
                 session.state.waiting_for,
                 WaitingFor::ResolveAllReady { .. }
             ),
-            "an incoherent AI-granted latch must not survive its own hand-off, got {:?}",
+            "an AI-granted latch must not survive its own hand-off, got {:?}",
             session.state.waiting_for
         );
         assert!(
             session.state.resolve_all_consent_run.is_none(),
-            "the repair discards the run it could not honor"
+            "consuming the ready run clears its one-shot consent record"
         );
     }
 


### PR DESCRIPTION
- **fix(engine): resume auto-pass after Resolve All**
- **test(engine): distinguish Resolve All from resumed passes**
- **fix(engine): finalize resumed Resolve All passes**
- **test(engine): cover retained Resolve All auto-pass**
- **fix(engine): preserve Resolve All auto-pass intent**
- **test(engine): exercise resumed terminal reconciliation**
- **fix(replay): record Resolve All as an atomic boundary**
- **fix(replay): validate Resolve All boundaries**
- **fix resolve all proof auto-pass isolation**
- **fix resolve batch unused import**
- **test wasm resolve all replay boundary**
- **style format wasm resolve all replay test**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Resolve All now records and replays as a single atomic operation.
  - Auto-pass preferences are preserved through Resolve All and resume correctly afterward.
  - Turn-boundary auto-pass now supports automatic attacker and blocker declarations when legal.
- **Bug Fixes**
  - Improved handling of terminal states, pending events, and interrupted resolutions.
  - Prevented invalid automatic declarations when required attacks or blocks remain.
- **Replay**
  - Added replay format version 3 with validation for Resolve All boundaries.
  - Existing version 2 replays remain supported when they do not contain Resolve All boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->