### PR TITLE
Add Cavern-Hoard Dragon

### DIFF
--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -2112,6 +2112,7 @@ fn scan_quantity_ref(x: &QuantityRef, mode: ScanMode) -> Axes {
         QuantityRef::ControlledByEachPlayer {
             filter,
             aggregate: _,
+            relation: _,
         } => {
             let mut acc = Axes {
                 event: false,

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -22,12 +22,12 @@ use crate::types::ability::{
     CountScope, CounterSourceRider, DelayedTriggerCondition, DieRollModifier, DoublePTMode,
     Duration, EachDamageRecipient, Effect, EffectOutcomeSignal, EffectScope, FilterProp,
     ForEachCategoryAction, GameRestriction, LibraryPosition, ManaProduction, ObjectProperty,
-    ObjectScope, ParsedCondition, PerpetualModification, PlayerFilter, PlayerScope, PtStat,
-    PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition,
-    ReplacementMode, SeatDirection, SharedQuality, SharedQualityRelation, SpeedDelta,
-    SpellCastingOption, SpellCastingOptionKind, SpellStackToGraveyardReplacement, StackAbilityKind,
-    StaticCondition, StaticDefinition, TapStateChange, TargetFilter, TriggerDefinition, TypeFilter,
-    TypedFilter, VoteSubject, ZoneRef,
+    ObjectScope, ParsedCondition, PerpetualModification, PlayerFilter, PlayerRelation, PlayerScope,
+    PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition,
+    ReplacementDefinition, ReplacementMode, SeatDirection, SharedQuality, SharedQualityRelation,
+    SpeedDelta, SpellCastingOption, SpellCastingOptionKind, SpellStackToGraveyardReplacement,
+    StackAbilityKind, StaticCondition, StaticDefinition, TapStateChange, TargetFilter,
+    TriggerDefinition, TypeFilter, TypedFilter, VoteSubject, ZoneRef,
 };
 use crate::types::card::CardFace;
 use crate::types::card_type::CoreType;
@@ -1873,14 +1873,23 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
         QuantityRef::PartySize { player } => {
             format!("party size ({})", fmt_player_scope(player))
         }
-        QuantityRef::ControlledByEachPlayer { filter, aggregate } => {
+        QuantityRef::ControlledByEachPlayer {
+            filter,
+            aggregate,
+            relation,
+        } => {
             let func = match aggregate {
                 AggregateFunction::Max => "most",
                 AggregateFunction::Min => "fewest",
                 AggregateFunction::Sum => "total",
             };
+            let population = match relation {
+                PlayerRelation::Controller => "you",
+                PlayerRelation::Opponent => "opponent",
+                PlayerRelation::All => "player",
+            };
             format!(
-                "# of {} controlled by player with {func}",
+                "# of {} controlled by {population} with {func}",
                 fmt_target(filter)
             )
         }

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -3732,7 +3732,11 @@ fn resolve_ref(
         }
         // CR 107.1 + CR 700.1: min/max across players of the count of
         // battlefield objects matching `filter` each player controls.
-        QuantityRef::ControlledByEachPlayer { filter, aggregate } => {
+        QuantityRef::ControlledByEachPlayer {
+            filter,
+            aggregate,
+            relation,
+        } => {
             // CR 608.2e (§8): prefer the clause-local snapshot if this clause
             // captured one — that freezes the extremum against the board as it
             // stood when the clause began, so an earlier APNAP player's
@@ -3749,31 +3753,37 @@ fn resolve_ref(
                 state,
                 crate::types::zones::Zone::Battlefield,
             );
-            aggregate_over_players(state.players.iter(), *aggregate, |p| {
-                // CR 109.5: evaluate `filter` as if `p` were "you" — count
-                // battlefield objects `p` controls matching the filter. The
-                // explicit `obj.controller == p.id` gate enforces the "they
-                // control" semantics even when `filter` itself carries no
-                // controller clause (Balance's Arm A parses a bare "lands"
-                // type phrase); the rebound `FilterContext` additionally makes
-                // any `controller: You` clause inside `filter` read `p`.
-                let pctx = match ability {
-                    Some(a) => FilterContext::from_ability_with_controller(a, p.id),
-                    None => FilterContext::from_source_with_controller(source_id, p.id),
-                };
-                usize_to_i32_saturating(
-                    zone_ids
-                        .iter()
-                        .filter(|&&id| {
-                            state
-                                .objects
-                                .get(&id)
-                                .is_some_and(|obj| obj.controller == p.id)
-                                && matches_target_filter(state, id, filter, &pctx)
-                        })
-                        .count(),
-                )
-            })
+            aggregate_over_players(
+                state.players.iter().filter(|p| {
+                    crate::game::players::matches_relation(state, p.id, controller, *relation)
+                }),
+                *aggregate,
+                |p| {
+                    // CR 109.5: evaluate `filter` as if `p` were "you" — count
+                    // battlefield objects `p` controls matching the filter. The
+                    // explicit `obj.controller == p.id` gate enforces the "they
+                    // control" semantics even when `filter` itself carries no
+                    // controller clause (Balance's Arm A parses a bare "lands"
+                    // type phrase); the rebound `FilterContext` additionally makes
+                    // any `controller: You` clause inside `filter` read `p`.
+                    let pctx = match ability {
+                        Some(a) => FilterContext::from_ability_with_controller(a, p.id),
+                        None => FilterContext::from_source_with_controller(source_id, p.id),
+                    };
+                    usize_to_i32_saturating(
+                        zone_ids
+                            .iter()
+                            .filter(|&&id| {
+                                state
+                                    .objects
+                                    .get(&id)
+                                    .is_some_and(|obj| obj.controller == p.id)
+                                    && matches_target_filter(state, id, filter, &pctx)
+                            })
+                            .count(),
+                    )
+                },
+            )
         }
         QuantityRef::CountersOnObjects {
             counter_type,
@@ -7665,8 +7675,8 @@ mod tests {
     use crate::game::zones::create_object;
     use crate::types::ability::{
         AggregateFunction, ChoiceValue, ControllerRef, DamageKindFilter, DevotionColors, Effect,
-        FilterProp, KickerVariant, ObjectProperty, SharedQuality, TargetFilter, TargetRef,
-        ThisWayCause, TypeFilter, TypedFilter,
+        FilterProp, KickerVariant, ObjectProperty, PlayerRelation, SharedQuality, TargetFilter,
+        TargetRef, ThisWayCause, TypeFilter, TypedFilter,
     };
     use crate::types::card_type::{CoreType, Supertype};
     use crate::types::counter::{CounterMatch, CounterType};
@@ -17502,6 +17512,7 @@ mod tests {
             qty: QuantityRef::ControlledByEachPlayer {
                 filter: lands_filter(),
                 aggregate: AggregateFunction::Min,
+                relation: PlayerRelation::All,
             },
         };
         assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), ObjectId(0)), 1);
@@ -17517,6 +17528,24 @@ mod tests {
             qty: QuantityRef::ControlledByEachPlayer {
                 filter: lands_filter(),
                 aggregate: AggregateFunction::Max,
+                relation: PlayerRelation::All,
+            },
+        };
+        assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), ObjectId(0)), 3);
+    }
+
+    #[test]
+    fn controlled_by_each_player_opponent_max_excludes_controller() {
+        // CR 102.2: P0 is not their own opponent. P0=5, P1=3 must therefore
+        // resolve to 3, not the all-player maximum of 5.
+        let mut state = GameState::new_two_player(42);
+        add_lands(&mut state, PlayerId(0), 5);
+        add_lands(&mut state, PlayerId(1), 3);
+        let qty = QuantityExpr::Ref {
+            qty: QuantityRef::ControlledByEachPlayer {
+                filter: lands_filter(),
+                aggregate: AggregateFunction::Max,
+                relation: PlayerRelation::Opponent,
             },
         };
         assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), ObjectId(0)), 3);
@@ -17548,6 +17577,7 @@ mod tests {
             qty: QuantityRef::ControlledByEachPlayer {
                 filter: lands_filter(),
                 aggregate: AggregateFunction::Min,
+                relation: PlayerRelation::All,
             },
         };
         assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), ObjectId(0)), 0);
@@ -17564,6 +17594,7 @@ mod tests {
             qty: QuantityRef::ControlledByEachPlayer {
                 filter: lands_filter(),
                 aggregate: AggregateFunction::Min,
+                relation: PlayerRelation::All,
             },
         };
         assert_eq!(resolve_quantity(&state, &qty, PlayerId(0), ObjectId(0)), 2);
@@ -17580,6 +17611,7 @@ mod tests {
         let qref = QuantityRef::ControlledByEachPlayer {
             filter: lands_filter(),
             aggregate: AggregateFunction::Min,
+            relation: PlayerRelation::All,
         };
         // Live board would yield 1; freeze a different value into the snapshot.
         let mut snap = crate::types::game_state::ClauseMinimumSnapshot::default();

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -5199,6 +5199,7 @@ pub(crate) fn parse_controls_permanent_object<'a>(
             qty: QuantityRef::ControlledByEachPlayer {
                 filter: filter.clone(),
                 aggregate: AggregateFunction::Max,
+                relation: crate::types::ability::PlayerRelation::All,
             },
         };
         return Some((Comparator::GE, count, filter, remainder));

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -14565,6 +14565,7 @@ fn balance_clause_effect(verb: EqualizeVerb, filter: TargetFilter) -> Effect {
                 qty: QuantityRef::ControlledByEachPlayer {
                     filter: filter.clone(),
                     aggregate: AggregateFunction::Min,
+                    relation: PlayerRelation::All,
                 },
             };
             Effect::Sacrifice {
@@ -15201,6 +15202,7 @@ fn parse_uneven_land_search_ir(
         qty: QuantityRef::ControlledByEachPlayer {
             filter: lands.clone(),
             aggregate: extremum,
+            relation: PlayerRelation::All,
         },
     };
     let difference = QuantityExpr::Difference {

--- a/crates/engine/src/parser/oracle_effect/snapshot_tests.rs
+++ b/crates/engine/src/parser/oracle_effect/snapshot_tests.rs
@@ -1229,6 +1229,7 @@ fn assert_land_sacrifice_clause(def: &AbilityDefinition) {
                 qty: QuantityRef::ControlledByEachPlayer {
                     aggregate: AggregateFunction::Min,
                     filter: TargetFilter::Typed(tf),
+                    relation: PlayerRelation::All,
                 }
             } if tf.controller == Some(ControllerRef::You)
         ),

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -54594,6 +54594,7 @@ fn assert_uneven_land_search_shape(
             qty: QuantityRef::ControlledByEachPlayer {
                 filter: TargetFilter::Typed(lands),
                 aggregate: AggregateFunction::Max,
+                relation: PlayerRelation::All,
             },
         } if lands == &TypedFilter::land()
     ));

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -4701,6 +4701,7 @@ fn parse_a_player_controls_no(input: &str) -> OracleResult<'_, StaticCondition> 
             QuantityRef::ControlledByEachPlayer {
                 filter,
                 aggregate: AggregateFunction::Min,
+                relation: PlayerRelation::All,
             },
             Comparator::EQ,
             0,
@@ -12691,6 +12692,7 @@ mod tests {
                             QuantityRef::ControlledByEachPlayer {
                                 filter,
                                 aggregate: AggregateFunction::Min,
+                                relation: PlayerRelation::All,
                             },
                     },
                 comparator: Comparator::EQ,

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -28,9 +28,9 @@ use crate::parser::oracle_util::parse_subtype;
 use crate::types::ability::{
     AggregateFunction, CardTypeSetSource, CastManaObjectScope, CastManaSpentMetric, ControllerRef,
     CountScope, DamageChannel, DamageKindFilter, DevotionColors, FilterProp, ObjectProperty,
-    ObjectScope, PlayerFilter, PlayerScope, PtStat, QuantityExpr, QuantityRef, RoundingMode,
-    SharedQuality, SubtypeExclusion, TargetFilter, ThisWayCause, TurnJournalKind, TypeFilter,
-    TypedFilter, ZoneRef,
+    ObjectScope, PlayerFilter, PlayerRelation, PlayerScope, PtStat, QuantityExpr, QuantityRef,
+    RoundingMode, SharedQuality, SubtypeExclusion, TargetFilter, ThisWayCause, TurnJournalKind,
+    TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::keywords::Keyword;
@@ -960,6 +960,7 @@ pub fn parse_quantity_ref(input: &str) -> OracleResult<'_, QuantityRef> {
         // scry-context "number of cards looked at …" reading wins over a
         // plain object-count reading.
         parse_scry_look_count_ref,
+        parse_controlled_object_count_extremum,
         parse_the_number_of,
         parse_object_property_aggregate_ref,
         // Group mana-value aggregate parsers to reduce alt arity
@@ -1992,7 +1993,7 @@ fn parse_distinct_named_objects(input: &str) -> OracleResult<'_, QuantityRef> {
 
 /// CR 107.1 + CR 700.1: Parse "[type-phrase] controlled by the player who
 /// controls the fewest" (and "… the most") after "the number of" →
-/// `QuantityRef::ControlledByEachPlayer { filter, aggregate }`.
+/// `QuantityRef::ControlledByEachPlayer { filter, aggregate, relation: All }`.
 ///
 /// Used by Balance / Restore Balance / Balancing Act for the equalization
 /// minimum ("a number of lands they control equal to the number of lands
@@ -2017,7 +2018,52 @@ fn parse_controlled_by_extremum_player(input: &str) -> OracleResult<'_, Quantity
     .parse(rest)?;
     Ok((
         rest,
-        QuantityRef::ControlledByEachPlayer { filter, aggregate },
+        QuantityRef::ControlledByEachPlayer {
+            filter,
+            aggregate,
+            relation: PlayerRelation::All,
+        },
+    ))
+}
+
+/// CR 107.1 + CR 102.1/102.2/102.3 + CR 109.5: Parse the greatest per-player
+/// controlled-object count: "the greatest number of artifacts an opponent
+/// controls" and "the greatest number of creatures a player controls".
+///
+/// This is the subject-after-extremum sibling of
+/// [`parse_controlled_by_extremum_player`]. Both lower to the same typed
+/// `ControlledByEachPlayer` authority; `relation` selects the player population
+/// before the per-player counts are reduced. The type phrase is kept bare
+/// because the resolver itself supplies each candidate player's controller gate.
+fn parse_controlled_object_count_extremum(input: &str) -> OracleResult<'_, QuantityRef> {
+    let (input, _) = tag("the ").parse(input)?;
+    let (input, _) = parse_max_extremum_adjective(input)?;
+    let (input, _) = tag(" number of ").parse(input)?;
+    let (rest, (type_text, relation)) = alt((
+        map(
+            terminated(
+                take_until(" an opponent controls"),
+                tag(" an opponent controls"),
+            ),
+            |type_text| (type_text, PlayerRelation::Opponent),
+        ),
+        map(
+            terminated(take_until(" a player controls"), tag(" a player controls")),
+            |type_text| (type_text, PlayerRelation::All),
+        ),
+    ))
+    .parse(input)?;
+    let (filter, filter_remainder) = parse_type_phrase(type_text);
+    if !filter_remainder.trim().is_empty() || !quantity_filter_has_meaningful_content(&filter) {
+        return Err(oracle_err(input));
+    }
+    Ok((
+        rest,
+        QuantityRef::ControlledByEachPlayer {
+            filter,
+            aggregate: AggregateFunction::Max,
+            relation,
+        },
     ))
 }
 
@@ -9076,6 +9122,7 @@ mod tests {
             QuantityRef::ControlledByEachPlayer {
                 filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Land)),
                 aggregate: AggregateFunction::Min,
+                relation: PlayerRelation::All,
             }
         );
         assert_eq!(rest, "");
@@ -9093,6 +9140,7 @@ mod tests {
             QuantityRef::ControlledByEachPlayer {
                 filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)),
                 aggregate: AggregateFunction::Max,
+                relation: PlayerRelation::All,
             }
         );
         assert_eq!(rest, "");
@@ -9110,9 +9158,51 @@ mod tests {
             QuantityRef::ControlledByEachPlayer {
                 filter: TargetFilter::Typed(TypedFilter::new(TypeFilter::Permanent)),
                 aggregate: AggregateFunction::Min,
+                relation: PlayerRelation::All,
             }
         );
         assert_eq!(rest, "");
+    }
+
+    #[test]
+    fn parse_controlled_count_extremum_preserves_player_population() {
+        for (text, expected_type, expected_relation) in [
+            (
+                "the greatest number of artifacts an opponent controls",
+                TypeFilter::Artifact,
+                PlayerRelation::Opponent,
+            ),
+            (
+                "the greatest number of creatures a player controls",
+                TypeFilter::Creature,
+                PlayerRelation::All,
+            ),
+        ] {
+            let (rest, qty) = parse_quantity_ref_complete(text).expect("extremum must parse");
+            assert_eq!(rest, "");
+            let QuantityRef::ControlledByEachPlayer {
+                filter: TargetFilter::Typed(filter),
+                aggregate: AggregateFunction::Max,
+                relation,
+            } = qty
+            else {
+                panic!("expected per-player controlled count for {text:?}, got {qty:?}");
+            };
+            assert_eq!(filter.type_filters, vec![expected_type]);
+            assert_eq!(filter.controller, None, "resolver owns controller binding");
+            assert_eq!(relation, expected_relation);
+        }
+    }
+
+    #[test]
+    fn parse_controlled_count_extremum_is_full_consuming() {
+        assert!(parse_quantity_ref_complete(
+            "the greatest number of artifacts an opponent controls and draws"
+        )
+        .is_err());
+        assert!(
+            parse_quantity_ref_complete("the greatest number of artifacts you control").is_err()
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -5852,6 +5852,40 @@ fn ghalta_self_cost_reduction_is_active_from_command_zone() {
 }
 
 #[test]
+fn cavern_hoard_dragon_reduction_uses_greatest_opponent_artifact_count() {
+    let def = parse_static_line(
+        "This spell costs {X} less to cast, where X is the greatest number of artifacts an opponent controls.",
+    )
+    .expect("Cavern-Hoard Dragon cost reduction must parse");
+
+    let StaticMode::ModifyCost {
+        mode: CostModifyMode::Reduce,
+        amount,
+        dynamic_count:
+            Some(QuantityRef::ControlledByEachPlayer {
+                filter: TargetFilter::Typed(filter),
+                aggregate: AggregateFunction::Max,
+                relation: PlayerRelation::Opponent,
+            }),
+        ..
+    } = def.mode
+    else {
+        panic!(
+            "expected opponent-scoped dynamic self-cost reduction, got {:?}",
+            def.mode
+        );
+    };
+    assert_eq!(amount, ManaCost::generic(1));
+    assert_eq!(filter.type_filters, vec![TypeFilter::Artifact]);
+    assert_eq!(filter.controller, None);
+    assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
+    assert_eq!(
+        def.active_zones,
+        crate::types::zones::self_spell_cost_mod_active_zones()
+    );
+}
+
+#[test]
 fn self_cost_reduction_where_x_distinct_named_lands_uses_static_cost_seam() {
     let def = parse_static_line(
         "This spell costs {X} less to cast, where X is the number of differently named lands you control.",

--- a/crates/engine/src/parser/swallow_check.rs
+++ b/crates/engine/src/parser/swallow_check.rs
@@ -5156,11 +5156,10 @@ mod tests {
     /// registration line in `check_swallowed_clauses` → no diagnostic → fails.
     #[test]
     fn modal_dynamic_max_dropped_registered_via_real_parse() {
-        // A cross-player "greatest number of creatures" count that no
-        // `parse_cda_quantity` arm recognizes ⇒ the dynamic cap is genuinely
-        // dropped. Shared const feeds both the guard and the fixture so they
-        // cannot drift.
-        const DROPPED_EXPR: &str = "the greatest number of creatures a player controls";
+        // A stored-die-result extremum that no `parse_cda_quantity` arm
+        // recognizes ⇒ the dynamic cap is genuinely dropped. Shared const
+        // feeds both the guard and the fixture so they cannot drift.
+        const DROPPED_EXPR: &str = "the greatest number of stored results on it of the same value";
         assert!(
             crate::parser::oracle_quantity::parse_cda_quantity(DROPPED_EXPR).is_none(),
             "fixture expr must stay unsupported so the modal cap is genuinely \

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -7121,7 +7121,8 @@ pub enum QuantityRef {
         property: ObjectProperty,
         filter: TargetFilter,
     },
-    /// CR 107.1: The [min/max], across every player in the game, of the number
+    /// CR 107.1 + CR 102.1/102.2/102.3: The [min/max], across players in
+    /// `relation`, of the number
     /// of **battlefield** objects matching `filter` that the player controls
     /// (the game counts only in integers). Each player's per-player count is
     /// computed as if `filter`'s
@@ -7136,6 +7137,15 @@ pub enum QuantityRef {
     ControlledByEachPlayer {
         filter: TargetFilter,
         aggregate: AggregateFunction,
+        /// Which players contribute one controlled-object count. `All` preserves
+        /// the original Balance-family reading; `Opponent` covers "the greatest
+        /// number of artifacts an opponent controls" without collapsing all
+        /// opponents into one object count.
+        #[serde(
+            default = "player_relation_all",
+            skip_serializing_if = "is_player_relation_all"
+        )]
+        relation: PlayerRelation,
     },
     /// Card count in a specific zone of the first targeted player.
     /// Generalized for library, graveyard, exile, etc.
@@ -8085,6 +8095,14 @@ pub enum PlayerRelation {
     Opponent,
     /// All players in the game.
     All,
+}
+
+fn player_relation_all() -> PlayerRelation {
+    PlayerRelation::All
+}
+
+fn is_player_relation_all(relation: &PlayerRelation) -> bool {
+    matches!(relation, PlayerRelation::All)
 }
 
 /// CR 108.3 + CR 109.4: Which possession relation binds a player to an object.

--- a/crates/engine/tests/integration/cavern_hoard_dragon_cost_reduction.rs
+++ b/crates/engine/tests/integration/cavern_hoard_dragon_cost_reduction.rs
@@ -1,0 +1,140 @@
+//! Cavern-Hoard Dragon's spell-cost reduction uses the greatest artifact count
+//! among opponents, not the caster's artifact count or the total artifact count.
+
+use engine::game::casting::display_spell_cost;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::counter::CounterType;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+use engine::types::PlayerId;
+
+const P2: PlayerId = PlayerId(2);
+
+const ORACLE: &str = "This spell costs {X} less to cast, where X is the greatest number of artifacts an opponent controls.\n\
+Flying, trample, haste\n\
+Whenever this creature deals combat damage to a player, you create a Treasure token for each artifact that player controls.";
+
+const INVESTIGATOR_ORACLE: &str = "This artifact enters with a number of suspect counters on it equal to the greatest number of creatures a player controls.\n\
+{2}, {T}, Remove a suspect counter from this artifact: Draw a card.\n\
+{2}, Sacrifice this artifact: Draw a card.";
+
+fn printed_cost() -> ManaCost {
+    ManaCost::Cost {
+        shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+        generic: 7,
+    }
+}
+
+fn reduced_cost() -> ManaCost {
+    ManaCost::Cost {
+        shards: vec![ManaCostShard::Red, ManaCostShard::Red],
+        generic: 4,
+    }
+}
+
+fn exact_payment() -> Vec<ManaUnit> {
+    [
+        ManaType::Colorless,
+        ManaType::Colorless,
+        ManaType::Colorless,
+        ManaType::Colorless,
+        ManaType::Red,
+        ManaType::Red,
+    ]
+    .into_iter()
+    .map(|kind| ManaUnit::new(kind, ObjectId(0), false, vec![]))
+    .collect()
+}
+
+fn add_artifacts(scenario: &mut GameScenario, player: PlayerId, count: usize) {
+    for index in 0..count {
+        scenario
+            .add_creature(player, &format!("Test Artifact {index}"), 1, 1)
+            .as_artifact();
+    }
+}
+
+#[test]
+fn cavern_hoard_dragon_uses_greatest_opponent_artifact_count_when_cast() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P0=5, P1=1, P2=3. The correct per-opponent maximum is 3. Summing the
+    // opponents would yield 4; including the caster would yield 5.
+    add_artifacts(&mut scenario, P0, 5);
+    add_artifacts(&mut scenario, P1, 1);
+    add_artifacts(&mut scenario, P2, 3);
+    let dragon = scenario
+        .add_creature_to_hand_from_oracle(P0, "Cavern-Hoard Dragon", 6, 6, ORACLE)
+        .with_mana_cost(printed_cost())
+        .id();
+    scenario.with_mana_pool(P0, exact_payment());
+
+    let mut runner = scenario.build();
+    assert_eq!(
+        display_spell_cost(runner.state(), P0, dragon),
+        Some(reduced_cost()),
+        "the cost must be {{4}}{{R}}{{R}}: reduce {{7}}{{R}}{{R}} by the opponent's three artifacts"
+    );
+
+    let outcome = runner.cast(dragon).resolve();
+    assert_eq!(
+        outcome.zone_of(dragon),
+        Zone::Battlefield,
+        "the full Oracle card must be castable with exactly the reduced cost"
+    );
+}
+
+#[test]
+fn cavern_hoard_dragon_has_no_reduction_when_opponents_control_no_artifacts() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    add_artifacts(&mut scenario, P0, 5);
+    let dragon = scenario
+        .add_creature_to_hand_from_oracle(P0, "Cavern-Hoard Dragon", 6, 6, ORACLE)
+        .with_mana_cost(printed_cost())
+        .id();
+
+    let runner = scenario.build();
+    assert_eq!(
+        display_spell_cost(runner.state(), P0, dragon),
+        Some(printed_cost()),
+        "the caster's five artifacts must not reduce the cost when both opponents control none"
+    );
+}
+
+#[test]
+fn investigators_journal_enters_with_greatest_per_player_creature_count() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    for (player, count) in [(P0, 2), (P1, 1), (P2, 3)] {
+        for index in 0..count {
+            scenario.add_creature(player, &format!("Test Creature {player:?} {index}"), 1, 1);
+        }
+    }
+    let journal = scenario
+        .add_artifact_to_hand_from_oracle(P0, "Investigator's Journal", INVESTIGATOR_ORACLE)
+        .with_mana_cost(ManaCost::generic(2))
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+        ],
+    );
+
+    let mut runner = scenario.build();
+    let outcome = runner.cast(journal).resolve();
+    assert_eq!(outcome.zone_of(journal), Zone::Battlefield);
+    assert_eq!(
+        outcome.state().objects[&journal]
+            .counters
+            .get(&CounterType::Generic("suspect".to_string()))
+            .copied(),
+        Some(3),
+        "the 2/1/3 creature distribution must yield max 3, not sum 6 or fixed 1"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -91,6 +91,7 @@ mod captain_marvel_apex_avenger;
 mod cascade_intervening_if_pipeline;
 mod case_solve_condition;
 mod cast_during_resolution_pipeline;
+mod cavern_hoard_dragon_cost_reduction;
 mod cda_counted_quantities_pt;
 mod chain_of_smog_copy;
 mod chains_of_mephistopheles_discard_draw_or_mill;

--- a/crates/engine/tests/integration/no_witnesses_most_creatures_investigate.rs
+++ b/crates/engine/tests/integration/no_witnesses_most_creatures_investigate.rs
@@ -115,6 +115,7 @@ fn assert_controls_the_most(scope: Option<&PlayerFilter>, ty: TypeFilter) {
             QuantityRef::ControlledByEachPlayer {
                 filter: count_filter,
                 aggregate,
+                relation: PlayerRelation::All,
             },
     } = count.as_ref()
     else {

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 30
-- **Distinct cards implicated:** 4714
-- **Total card appearances across root causes:** 4747 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4712
+- **Total card appearances across root causes:** 4745 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -16,7 +16,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 2 | Dropped intervening-if / gating condition (condition: null) | 585 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
 | 3 | Anaphor bound to wrong referent | 404 | oracle_quantity.rs context-ref resolution + game/ability_utils.rs forward_result wiring |
 | 4 | Conjoined / chained second effect clause dropped | 387 | oracle.rs effect-chain composition — split on 'and'/'then'/sentence boundaries and build sub_ability chain |
-| 5 | Dropped 'for each' / dynamic count collapsed to Fixed | 330 | oracle_quantity.rs parse_for_each_clause / parse_quantity_ref — thread ForEach/ObjectCount into the effect count field |
+| 5 | Dropped 'for each' / dynamic count collapsed to Fixed | 329 | oracle_quantity.rs parse_for_each_clause / parse_quantity_ref — thread ForEach/ObjectCount into the effect count field |
 | 6 | Disjunctive (or-list) collapsed to first branch | 238 | oracle_nom/filter.rs + oracle_target.rs — build TargetFilter::Or across all alt() branches |
 | 7 | Wrong / dropped zone parameters on zone-change effect | 211 | game/zones.rs + oracle parser zone routing — derive correct origin/destination/owner from Oracle |
 | 8 | Additional / alternative casting cost dropped | 210 | oracle_cost.rs — parse additional/alternative cost clauses into Spell.cost / AdditionalCost |
@@ -34,7 +34,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 20 | Damage subject/recipient set incomplete | 70 | Effect::DealDamage handling — capture all damage subjects/recipients per CR 120 |
 | 21 | Token entry flags / keyword / attachment clause dropped | 52 | oracle parser token-description handling — preserve attacking/tapped flags, keyword grants, attach target |
 | 22 | Attacks-alone / while-saddled combat constraint dropped | 43 | oracle_trigger.rs scan_for_phase / attacks-trigger constraint parsing; add SourceAttackingAlone/MinCoAttackers (attacks-alone remainder); "while saddled" folds into the attack trigger's valid_card at declaration (And { filters: [subject, Typed([IsSaddled])] }, CR 508.1m) — no stored TriggerCondition, no LKI (done) |
-| 23 | Effect modeled with structurally wrong variant / ability class | 51 | add-engine-effect: select the correct Effect/ability variant for the clause class |
+| 23 | Effect modeled with structurally wrong variant / ability class | 50 | add-engine-effect: select the correct Effect/ability variant for the clause class |
 | 24 | Variable X / where-X count unbound (sentinel or unresolved Variable) | 37 | oracle_cost.rs / oracle_quantity.rs — allow QuantityExpr in count fields and bind trailing 'where X is' clauses |
 | 25 | Wrong / dropped effect duration | 28 | oracle_nom/duration.rs — add until-event / two-turn / permanent duration variants |
 | 26 | Delayed / future-phase trigger flattened to immediate effect | 20 | add-trigger: wrap future-phase effects in CreateDelayedTrigger |
@@ -2215,7 +2215,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 5. Dropped 'for each' / dynamic count collapsed to Fixed  (330 cards)
+### 5. Dropped 'for each' / dynamic count collapsed to Fixed  (329 cards)
 
 **Signature.** Effect quantity (count/amount/P-T) parses as Fixed(1)/constant instead of a dynamic QuantityExpr::Ref over a 'for each X' / 'that many' / 'equal to' clause; the multiplier is dropped.
 
@@ -2366,7 +2366,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Immortal Coil
 - Impose Hierarchy
 - Infantry Shield
-- Investigator's Journal
 - Invoke the Ancients
 - Jester's Mask
 - Jinxed Choker
@@ -4832,7 +4831,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 23. Effect modeled with structurally wrong variant / ability class  (51 cards)
+### 23. Effect modeled with structurally wrong variant / ability class  (50 cards)
 
 **Signature.** A clause is lowered to the wrong AST shape: continuous static as one-shot Spell, replacement as static, single-target vs PumpAll, RevealHand vs library look, Bounce vs ChangeZone, or other categorical mismatch.
 
@@ -4845,7 +4844,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Baron Strucker, HYDRA Overlord
 - Blended Twistling
 - Blinding Flare
-- Cavern-Hoard Dragon
 - Chicken Egg
 - Circadian Struggle
 - Commune with Spirits


### PR DESCRIPTION
## Summary

Add full engine support for Cavern-Hoard Dragon's opponent-scoped greatest controlled-artifact count through the existing per-player extremum quantity. The generic parser and resolver change also corrects Investigator's Journal's greatest per-player creature count.

## Files changed

- `crates/engine/src/game/ability_scan.rs` — thread the player relation through ability scanning.
- `crates/engine/src/game/coverage.rs` — format the scoped per-player extremum quantity.
- `crates/engine/src/game/quantity.rs` — resolve extrema over the requested player relation and test opponent exclusion.
- `crates/engine/src/parser/oracle_effect/lower.rs` — preserve the existing all-player relation while lowering.
- `crates/engine/src/parser/oracle_effect/mod.rs` — preserve the relation in effect rewriting.
- `crates/engine/src/parser/oracle_effect/snapshot_tests.rs` — update the explicit quantity constructor.
- `crates/engine/src/parser/oracle_effect/tests.rs` — update the explicit quantity constructor.
- `crates/engine/src/parser/oracle_nom/condition.rs` — preserve the existing all-player relation.
- `crates/engine/src/parser/oracle_nom/quantity.rs` — parse greatest controlled-object counts with typed player population and full consumption.
- `crates/engine/src/parser/oracle_static/tests.rs` — assert Cavern-Hoard Dragon's exact static ability AST.
- `crates/engine/src/parser/swallow_check.rs` — replace Investigator's Journal as the obsolete unsupported DynamicQty fixture.
- `crates/engine/src/types/ability.rs` — add a backward-compatible player relation to the existing per-player quantity.
- `crates/engine/tests/integration/cavern_hoard_dragon_cost_reduction.rs` — production runtime tests for both cards.
- `crates/engine/tests/integration/main.rs` — register the integration module.
- `crates/engine/tests/integration/no_witnesses_most_creatures_investigate.rs` — preserve the existing all-player relation.
- `docs/parser-misparse-backlog.md` — remove the two corrected parser gaps and update counts.

## Track

Developer

## LLM

Model: gpt-5.6-sol (via Codex; canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 102.1, 102.2, 102.3 — players, opponents, and multiplayer scope.
- CR 107.1 — objects controlled by players.
- CR 109.5 — object controller.
- CR 601.2f — total spell cost and cost reductions.

## Verification

- [x] Required checks ran clean.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

Exact-head validation on `ad3d0f56e16aee70cca2c4e79dd6dbeb07b42226`:

- `cargo fmt --all -- --check` and `git diff --check` — PASS.
- Cavern/Journal production integration matrix — 3 passed, 0 failed.
- Controlled-count extremum parser matrix — 2 passed, 0 failed.
- Exact Cavern static Oracle AST — 1 passed, 0 failed.
- Opponent-population resolver test — 1 passed, 0 failed.
- `CARGO_BUILD_JOBS=1 cargo clippy-strict` — PASS.
- Full phase-engine suite — 19,829 library + 21 + 9 binary + 5,587 integration tests passed; 0 failed; 15 ignored.
- Official frozen-data generator — PASS, no unintended tracked generated diff.
- `cargo coverage` — 31,826 / 35,798 supported, +2 versus base; Cavern-Hoard Dragon and Investigator's Journal both `supported: true`, `gap_count: 0`.
- `cargo semantic-audit` — zero findings for both affected cards.
- Exact parse projection against `c36ae774439761239e815ac141b4a38535d0ad7e` — exactly 2 cards / 3 signatures, with every duplicate-name row compared.

The final upstream freshness rebase was over one client-only visual-pack commit. It had zero paths under `crates/engine` or the parser backlog; `git range-diff` reports exact patch equivalence, and the exact-head focused checks, clippy, comparator, review, and gates were rerun.

Runtime discriminators:

- Three players: caster controls 5 artifacts, opponents control 1 and 3; Cavern costs exactly `{4}{R}{R}`, proving opponent-only maximum 3 rather than sum 4 or caster count 5.
- Three players with zero opponent artifacts: Cavern remains `{7}{R}{R}`.
- Investigator's Journal with per-player creature counts 2, 1, and 3 enters with exactly 3 suspect counters, proving per-player maximum rather than total.

## Gate A

Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)

Gate A PASS head=ad3d0f56e16aee70cca2c4e79dd6dbeb07b42226 base=c36ae774439761239e815ac141b4a38535d0ad7e

## Anchored on

- `crates/engine/src/parser/oracle_nom/quantity.rs:2003` — existing controlled-object count extremum lowered to `ControlledByEachPlayer`.
- `crates/engine/src/parser/oracle_nom/quantity.rs:2076` — existing player-population plus aggregate quantity construction.
- `crates/engine/src/game/players.rs:229` — canonical `matches_relation` authority used to scope candidate players.

## Final review-impl

Final review-impl PASS head=ad3d0f56e16aee70cca2c4e79dd6dbeb07b42226 base=c36ae774439761239e815ac141b4a38535d0ad7e

The independent verify-only review found no remaining blockers after the multiplayer max-vs-sum, zero-opponent, and Investigator's Journal runtime cases were added.

## Claimed parse impact

- Cavern-Hoard Dragon
- Investigator's Journal

Parse projection: 2 cards / 3 signatures. Cavern replaces `ability/static_structure` with `static/ReduceCost`; Investigator's Journal changes the PutCounter quantity from fixed 1 to the greatest per-player controlled-creature count.

## Scope Expansion

Investigator's Journal is unavoidable same-mechanic collateral: its exact Oracle text uses the same generic “greatest number of [objects] a player controls” quantity. The prior parser swallowed that dynamic quantity as 1; the shared root-cause fix corrects both cards without card-name dispatch.

## Validation Failures

None.

## CI Failures

None known. Fresh upstream CI will validate exact head `ad3d0f56e16aee70cca2c4e79dd6dbeb07b42226`.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved support for quantities based on the greatest or fewest number of objects controlled by players.
  * Added correct handling for opponent-controlled populations in dynamic counts.
  * Updated Cavern-Hoard Dragon cost reduction to use the greatest artifact count among opponents.

* **Bug Fixes**
  * Corrected player-relation handling for dynamic counts and Balance-style effects.
  * Improved quantity formatting to distinguish controllers, opponents, and all players.

* **Tests**
  * Added coverage for opponent-based counts and Cavern-Hoard Dragon interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->