### PR TITLE
Fix Kotis, the Fangkeeper

### DIFF
--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -3941,7 +3941,7 @@ mod tests {
         ));
     }
 
-    /// CR 120.2a + CR 608.2h: the bare "the amount of damage dealt" dynamic-X
+    /// CR 608.2h: the bare "the amount of damage dealt" dynamic-X
     /// phrase (no qualifier) binds to `QuantityRef::EventContextAmount`
     /// through the static dynamic-X path (`parse_dynamic_x_clause`), the same
     /// as it does through the where-X effect-quantity path used by Kotis, the

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -3941,7 +3941,7 @@ mod tests {
         ));
     }
 
-    /// CR 120.1 + CR 608.2h: the bare "the amount of damage dealt" dynamic-X
+    /// CR 120.2a + CR 608.2h: the bare "the amount of damage dealt" dynamic-X
     /// phrase (no qualifier) binds to `QuantityRef::EventContextAmount`
     /// through the static dynamic-X path (`parse_dynamic_x_clause`), the same
     /// as it does through the where-X effect-quantity path used by Kotis, the

--- a/crates/engine/src/parser/oracle_cost.rs
+++ b/crates/engine/src/parser/oracle_cost.rs
@@ -3940,4 +3940,74 @@ mod tests {
             }
         ));
     }
+
+    /// CR 120.1 + CR 608.2h: the bare "the amount of damage dealt" dynamic-X
+    /// phrase (no qualifier) binds to `QuantityRef::EventContextAmount`
+    /// through the static dynamic-X path (`parse_dynamic_x_clause`), the same
+    /// as it does through the where-X effect-quantity path used by Kotis, the
+    /// Fangkeeper. Positive control for the rejection tests below: proves the
+    /// unqualified phrase still parses once the entry point requires full
+    /// consumption.
+    #[test]
+    fn cost_reduction_dynamic_x_damage_dealt_bare_binds_event_context_amount() {
+        let reduction = try_parse_cost_reduction(
+            "this ability costs {x} less to activate, where x is the amount of damage dealt",
+        )
+        .expect("bare damage-dealt dynamic-X cost reduction should parse");
+        assert_eq!(reduction.amount_per, 1);
+        assert!(matches!(
+            reduction.count,
+            QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount
+            }
+        ));
+    }
+
+    /// Regression for the false-green the maintainer flagged on PR #7969:
+    /// `parse_dynamic_x_clause` used to call the non-complete
+    /// `parse_quantity_ref` and unconditionally discard its remainder, so a
+    /// qualified phrase like "the amount of damage dealt this way" would
+    /// match only the bare "damage dealt" prefix and silently lose the
+    /// "this way" qualifier, misreading it as `EventContextAmount` instead of
+    /// the distinct `PreviousEffectAmount` meaning "this way" carries (or
+    /// staying an honest unsupported gap, since no arm spans the full
+    /// qualified phrase here). The entry point now requires full consumption
+    /// via `parse_quantity_ref_complete`, so this must be an honest `None`
+    /// gap, never a misparse.
+    #[test]
+    fn cost_reduction_dynamic_x_damage_dealt_this_way_stays_unsupported() {
+        assert!(
+            try_parse_cost_reduction(
+                "this ability costs {x} less to activate, where x is the amount of damage dealt this way",
+            )
+            .is_none(),
+            "qualified \"this way\" continuation must not truncate to EventContextAmount"
+        );
+    }
+
+    /// Sibling of the "this way" regression above: a "to <object>" qualifier
+    /// after "damage dealt" must not be dropped either.
+    #[test]
+    fn cost_reduction_dynamic_x_damage_dealt_to_continuation_stays_unsupported() {
+        assert!(
+            try_parse_cost_reduction(
+                "this ability costs {x} less to activate, where x is the amount of damage dealt to that player",
+            )
+            .is_none(),
+            "qualified \"to\" continuation must not truncate to EventContextAmount"
+        );
+    }
+
+    /// Sibling of the "this way" regression above: a "by <object>" qualifier
+    /// after "damage dealt" must not be dropped either.
+    #[test]
+    fn cost_reduction_dynamic_x_damage_dealt_by_continuation_stays_unsupported() {
+        assert!(
+            try_parse_cost_reduction(
+                "this ability costs {x} less to activate, where x is the amount of damage dealt by that creature",
+            )
+            .is_none(),
+            "qualified \"by\" continuation must not truncate to EventContextAmount"
+        );
+    }
 }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -429,6 +429,108 @@ fn beseech_suffix_constraint_unchanged_after_refactor() {
     );
 }
 
+/// CR 608.2h + CR 120.1 (issue #5923): Kotis, the Fangkeeper's combat-damage
+/// trigger — "exile the top X cards of their library, where X is the amount
+/// of damage dealt. You may cast any number of spells with mana value X or
+/// less from among them without paying their mana costs." Before the
+/// `parse_event_context_refs` fix, the "the amount of damage dealt"
+/// paraphrase was not recognized by the "the damage dealt" bare-phrase arm
+/// (`oracle_nom/quantity.rs`), so the where-X binding was left unresolved and
+/// the totality guard in `lower.rs` collapsed BOTH the `ExileTop` step and its
+/// `CastFromZone` sub-ability to `Effect::unimplemented("where_x_binding",
+/// ..)`. Revert-fail: with the bug present this test's positive-shape
+/// assertions fail (both effects were `Unimplemented`, not `ExileTop` /
+/// `CastFromZone`) and the no-Unimplemented sweep below also fails.
+#[test]
+fn kotis_the_fangkeeper_full_trigger_binds_damage_dealt_where_x() {
+    let parsed = parse_oracle_text(
+        "Indestructible\nWhenever Kotis deals combat damage to a player, exile the top X cards of their library, where X is the amount of damage dealt. You may cast any number of spells with mana value X or less from among them without paying their mana costs.",
+        "Kotis, the Fangkeeper",
+        &["Indestructible".to_string()],
+        &["Legendary".to_string(), "Creature".to_string()],
+        &["Zombie".to_string(), "Warrior".to_string()],
+    );
+
+    let execute = parsed
+        .triggers
+        .iter()
+        .find_map(|t| t.execute.as_deref())
+        .expect("Kotis's combat-damage trigger must produce an executable ability");
+
+    // Outer effect: exile the top X cards of the damaged player's library,
+    // where X is bound to the triggering event's damage amount.
+    let Effect::ExileTop {
+        ref player,
+        ref count,
+        ..
+    } = *execute.effect
+    else {
+        panic!("expected ExileTop, got {:?}", execute.effect);
+    };
+    assert_eq!(
+        *player,
+        TargetFilter::TriggeringPlayer,
+        "CR 608.2c: \"their library\" in a DamageDone trigger refers to the damaged player"
+    );
+    assert_eq!(
+        *count,
+        QuantityExpr::Ref {
+            qty: QuantityRef::EventContextAmount
+        },
+        "CR 608.2h: \"where X is the amount of damage dealt\" must bind X to the \
+         triggering event's damage amount, not fall back to an unbound sentinel"
+    );
+
+    // Sub-ability: cast any number of the exiled spells with mana value X or
+    // less, without paying their mana costs.
+    let sub_ability = execute
+        .sub_ability
+        .as_deref()
+        .expect("the \"you may cast\" sentence must attach as a sub-ability");
+    let Effect::CastFromZone {
+        ref target,
+        without_paying_mana_cost,
+        ref constraint,
+        ..
+    } = *sub_ability.effect
+    else {
+        panic!("expected CastFromZone, got {:?}", sub_ability.effect);
+    };
+    assert_eq!(*target, TargetFilter::ExiledBySource);
+    assert!(without_paying_mana_cost);
+    assert_eq!(
+        *constraint,
+        Some(CastPermissionConstraint::ManaValue {
+            comparator: Comparator::LE,
+            value: QuantityExpr::Ref {
+                qty: QuantityRef::EventContextAmount
+            },
+        }),
+        "the free-cast offer must be capped at mana value X (the same dynamic \
+         damage-dealt amount), not left unconstrained or Fixed"
+    );
+
+    // No clause of the trigger may have fallen back to Unimplemented.
+    fn effect_has_unimplemented(effect: &Effect) -> bool {
+        matches!(effect, Effect::Unimplemented { .. })
+    }
+    fn ability_has_unimplemented(ability: &AbilityDefinition) -> bool {
+        effect_has_unimplemented(&ability.effect)
+            || ability
+                .sub_ability
+                .as_deref()
+                .is_some_and(ability_has_unimplemented)
+            || ability
+                .else_ability
+                .as_deref()
+                .is_some_and(ability_has_unimplemented)
+    }
+    assert!(
+        !ability_has_unimplemented(execute),
+        "Kotis's trigger must have zero Unimplemented nodes: {execute:#?}"
+    );
+}
+
 /// A1 (full line): Cosmic Cube's whole attack trigger lowers to a
 /// `CastFromZone` whose `constraint` carries the dynamic ceiling. Revert-fail:
 /// today the constraint serializes as `null` (verified in card-data.json).

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -470,7 +470,10 @@ fn kotis_the_fangkeeper_full_trigger_binds_damage_dealt_where_x() {
     assert_eq!(
         *player,
         TargetFilter::TriggeringPlayer,
-        "CR 608.2c: \"their library\" in a DamageDone trigger refers to the damaged player"
+        "Oracle-text grammar: \"their library\" in a DamageDone trigger binds to the \
+         damaged player (\"deals combat damage to a player\"), not to Kotis's controller \
+         — a pronoun-antecedent reading, not a specific CR citation (CR 608.2c governs \
+         the ORDER effects apply their instructions, not pronoun antecedents)"
     );
     assert_eq!(
         *count,

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -429,7 +429,7 @@ fn beseech_suffix_constraint_unchanged_after_refactor() {
     );
 }
 
-/// CR 608.2h + CR 120.1 (issue #5923): Kotis, the Fangkeeper's combat-damage
+/// CR 120.2a + CR 608.2h (issue #5923): Kotis, the Fangkeeper's combat-damage
 /// trigger — "exile the top X cards of their library, where X is the amount
 /// of damage dealt. You may cast any number of spells with mana value X or
 /// less from among them without paying their mana costs." Before the

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -4013,11 +4013,36 @@ fn parse_event_context_refs(input: &str) -> OracleResult<'_, QuantityRef> {
         // counter-removal, and mana-production count-prefix slots).
         parse_that_much_or_many,
         value(QuantityRef::EventContextAmount, tag("that damage")),
-        // CR 120.1 + CR 603.7c: "the damage dealt" bare form in a triggered
-        // ability body — refers to the total from the triggering combat-damage
-        // event. Distinct from "that damage" (different article+verb) and
-        // "damage dealt this way" (PreviousEffectAmount).
-        value(QuantityRef::EventContextAmount, tag("the damage dealt")),
+        // CR 120.1 + CR 608.2h: "the damage dealt" bare form in a triggered
+        // ability body — refers to the total from the triggering
+        // combat-damage event, an amount determined once when the effect is
+        // applied. Accepts an optional "the amount of " / "amount of " / bare
+        // "the " determiner prefix ahead of the "damage dealt" phrase, so
+        // both the original bare form ("the damage dealt" — Primo, the
+        // Unbounded) and the paraphrase "the amount of damage dealt" (Kotis,
+        // the Fangkeeper: "exile the top X cards of their library, where X
+        // is the amount of damage dealt") parse uniformly — the prefix is
+        // factored once ahead of the phrase via `preceded` + `opt(alt(...))`,
+        // mirroring `parse_life_lost_ref` / `parse_life_gained_ref`'s
+        // "(the) amount of " prefix handling for the analogous life-change
+        // quantities (the bare "the " arm has no counterpart there because
+        // those functions spell "the " into each downstream full-phrase tag
+        // instead of a single bare-phrase tag). Distinct from "that damage"
+        // (different article+verb) and "damage dealt this way"
+        // (PreviousEffectAmount). The longer qualified forms ("the amount of
+        // damage dealt to/by <object> this turn [by <source>]" — Blazing
+        // Effigy, Grothama, All-Devouring, Impact Resonance, Tangled Colony)
+        // are not swallowed here: `parse_quantity_ref_complete`
+        // (`oracle_effect/lower.rs`) requires the where-X expression to be
+        // fully consumed, and this arm only matches when nothing follows
+        // "damage dealt".
+        value(
+            QuantityRef::EventContextAmount,
+            preceded(
+                opt(alt((tag("the amount of "), tag("amount of "), tag("the ")))),
+                tag("damage dealt"),
+            ),
+        ),
         // CR 701.47c: amass-specific definite phrases name the Army chosen by
         // the current amass instruction, not the generic demonstrative referent.
         parse_amassed_army_property_ref,

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -4049,8 +4049,8 @@ pub fn parse_that_much_or_many(input: &str) -> OracleResult<'_, QuantityRef> {
 
 /// Parse event-context quantity references.
 ///
-/// CR 603.7c: "that {noun}" in a triggered ability refers to the object or
-/// value from the triggering event. The source-object variants resolve via
+/// "That {noun}" in a triggered ability refers to the object or value from
+/// the triggering event. The source-object variants resolve via
 /// `extract_source_from_event` → live object or LKI cache.
 fn parse_event_context_refs(input: &str) -> OracleResult<'_, QuantityRef> {
     alt((
@@ -4059,9 +4059,9 @@ fn parse_event_context_refs(input: &str) -> OracleResult<'_, QuantityRef> {
         // counter-removal, and mana-production count-prefix slots).
         parse_that_much_or_many,
         value(QuantityRef::EventContextAmount, tag("that damage")),
-        // CR 120.2a + CR 608.2h: "the damage dealt" bare form in a triggered
-        // ability body — refers to the total from the triggering
-        // combat-damage event, an amount determined once when the effect is
+        // CR 608.2h: "the damage dealt" bare form in a triggered ability
+        // body — refers to the total from the triggering damage event, an
+        // amount determined once when the effect is
         // applied. Accepts an optional "the amount of " / "amount of " / bare
         // "the " determiner prefix ahead of the "damage dealt" phrase, so
         // both the original bare form ("the damage dealt" — Primo, the

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -4059,7 +4059,7 @@ fn parse_event_context_refs(input: &str) -> OracleResult<'_, QuantityRef> {
         // counter-removal, and mana-production count-prefix slots).
         parse_that_much_or_many,
         value(QuantityRef::EventContextAmount, tag("that damage")),
-        // CR 120.1 + CR 608.2h: "the damage dealt" bare form in a triggered
+        // CR 120.2a + CR 608.2h: "the damage dealt" bare form in a triggered
         // ability body — refers to the total from the triggering
         // combat-damage event, an amount determined once when the effect is
         // applied. Accepts an optional "the amount of " / "amount of " / bare

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -3666,10 +3666,12 @@ pub(crate) fn parse_dynamic_x_clause(input: &str) -> OracleResult<'_, QuantityRe
     use crate::parser::oracle_nom::error::OracleError;
 
     let (input, _) = tag_no_case::<_, _, OracleError<'_>>(", where x is ").parse(input)?;
+    let input = input.trim_end_matches('.');
 
     // CR 122.1: Untyped counter anaphor — only matches when it consumes the
-    // ENTIRE clause. A bare `Ok((_, _))` check here would discard whatever
-    // followed the anaphor instead of rejecting it, the same class of bug
+    // ENTIRE clause after terminal sentence punctuation is removed. A bare
+    // `Ok((_, _))` check here would discard whatever followed the anaphor
+    // instead of rejecting it, the same class of bug
     // fixed below for the general delegate — see that comment for the
     // concrete misparse this guards against.
     if let Ok(("", _)) = alt((

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -3667,10 +3667,12 @@ pub(crate) fn parse_dynamic_x_clause(input: &str) -> OracleResult<'_, QuantityRe
 
     let (input, _) = tag_no_case::<_, _, OracleError<'_>>(", where x is ").parse(input)?;
 
-    // CR 122.1: Untyped counter anaphor — consume the rest of the clause and
-    // emit `AnyCountersOnTarget`. Accepted variants mirror the counter-on-target
-    // anaphor family (no type prefix).
-    if let Ok((_, _)) = alt((
+    // CR 122.1: Untyped counter anaphor — only matches when it consumes the
+    // ENTIRE clause. A bare `Ok((_, _))` check here would discard whatever
+    // followed the anaphor instead of rejecting it, the same class of bug
+    // fixed below for the general delegate — see that comment for the
+    // concrete misparse this guards against.
+    if let Ok(("", _)) = alt((
         tag_no_case::<_, _, OracleError<'_>>("the number of counters on that creature"),
         tag_no_case::<_, _, OracleError<'_>>("the number of counters on that permanent"),
     ))
@@ -3688,16 +3690,36 @@ pub(crate) fn parse_dynamic_x_clause(input: &str) -> OracleResult<'_, QuantityRe
     // Delegate to the shared quantity-ref combinator which is case-sensitive on
     // lowercase patterns ("the number of"). Normalize to lowercase for the
     // remaining phrase so the upstream combinators match.
+    //
+    // Both callers of this function (`try_parse_dynamic_x_cost_reduction`'s
+    // "where X is <count>" cost-reduction tail, and the combat-tax
+    // `dynamic_qty` slot in `evasion.rs`) treat this function's returned
+    // remainder as authoritative: they resume parsing (or check
+    // full-consumption) from whatever `&str` comes back here, not from
+    // `input`. `parse_quantity_ref` (non-complete) matches a recognized
+    // phrase as a PREFIX and happily returns leftover text as its remainder
+    // — but unconditionally collapsing that remainder to `""` below would
+    // silently swallow a qualifier the phrase never actually matched. E.g.
+    // "the amount of damage dealt this way" only matches the bare
+    // "damage dealt" arm up to that point; the leftover " this way" would be
+    // discarded and the clause misread as `EventContextAmount` instead of
+    // the distinct `PreviousEffectAmount` meaning "this way" carries (CR
+    // 608.2h vs the "this way" family below it in quantity.rs), or instead
+    // of staying an honest unsupported gap when no arm actually spans the
+    // full qualified phrase. `parse_quantity_ref_complete` requires the
+    // entire (trimmed) phrase to be consumed and errors instead of
+    // truncating, so an unrecognized qualified phrase stays an honest gap.
     let lowered = input.to_lowercase();
-    let (_, quantity) =
-        super::oracle_nom::quantity::parse_quantity_ref(&lowered).map_err(|e| match e {
+    let (_, quantity) = super::oracle_nom::quantity::parse_quantity_ref_complete(&lowered)
+        .map_err(|e| match e {
             nom::Err::Error(_) | nom::Err::Failure(_) => {
                 nom::Err::Error(nom::error::Error::new(input, nom::error::ErrorKind::Fail))
             }
             nom::Err::Incomplete(n) => nom::Err::Incomplete(n),
         })?;
-    // Don't try to keep a &str reference into the lowered string — accept that the
-    // dynamic-X clause consumes the rest of the phrase and return empty remainder.
+    // `parse_quantity_ref_complete` already required full consumption of
+    // `lowered`, so returning an empty remainder here is honest, not
+    // discarding — unlike the direct `parse_quantity_ref` call this replaced.
     Ok(("", quantity))
 }
 

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -26445,7 +26445,7 @@ fn combat_tax_nils_per_affected_with_ref() {
     }
 }
 
-/// CR 120.1 + CR 608.2h: bare "the amount of damage dealt" (no qualifier)
+/// CR 608.2h: bare "the amount of damage dealt" (no qualifier)
 /// through `parse_dynamic_x_clause` — the exact combat-tax dynamic-X entry
 /// point the maintainer cited on PR #7969 (`shared.rs`, reached via the
 /// `dynamic_qty` slot in `evasion.rs`'s combat-tax parser) — binds to

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -26411,6 +26411,106 @@ fn combat_tax_nils_per_affected_with_ref() {
     }
 }
 
+/// CR 120.1 + CR 608.2h: bare "the amount of damage dealt" (no qualifier)
+/// through `parse_dynamic_x_clause` — the exact combat-tax dynamic-X entry
+/// point the maintainer cited on PR #7969 (`shared.rs`, reached via the
+/// `dynamic_qty` slot in `evasion.rs`'s combat-tax parser) — binds to
+/// `QuantityRef::EventContextAmount`. Positive control for the rejection
+/// tests below: proves the unqualified phrase still parses once that entry
+/// point requires full consumption.
+///
+/// Exercises `parse_dynamic_x_clause` directly rather than through
+/// `parse_static_line`: the full combat-tax dispatch chain has a deliberate,
+/// unrelated fallback (`parse_subject_combat_rule_static` →
+/// `parse_unless_static_condition`) that always succeeds with an honest
+/// `StaticCondition::Unrecognized` rider when the dedicated combat-tax
+/// combinator fails, so asserting `parse_static_line(..).is_none()` would
+/// not actually discriminate this fix from that pre-existing, correct
+/// fallback.
+#[test]
+fn dynamic_x_clause_damage_dealt_bare_binds_event_context_amount() {
+    let (rest, quantity) = parse_dynamic_x_clause(", where x is the amount of damage dealt")
+        .expect("bare damage-dealt dynamic-X clause should parse");
+    assert_eq!(rest, "");
+    assert!(matches!(quantity, QuantityRef::EventContextAmount));
+}
+
+/// Regression for the false-green the maintainer flagged on PR #7969, through
+/// the exact code path they cited (`shared.rs`'s `parse_dynamic_x_clause`):
+/// that function used to call the non-complete `parse_quantity_ref` and
+/// unconditionally discard its remainder, so "the amount of damage dealt
+/// this way" would match only the bare "damage dealt" prefix and silently
+/// lose the "this way" qualifier — misread as `EventContextAmount` instead
+/// of staying an honest unsupported gap (no arm spans the full qualified
+/// phrase). `parse_dynamic_x_clause` now requires full consumption via
+/// `parse_quantity_ref_complete`, so this must error rather than truncate.
+#[test]
+fn dynamic_x_clause_damage_dealt_this_way_stays_unsupported() {
+    assert!(
+        parse_dynamic_x_clause(", where x is the amount of damage dealt this way").is_err(),
+        "qualified \"this way\" continuation must not truncate to EventContextAmount"
+    );
+}
+
+/// Sibling of the "this way" regression above: a "to <object>" qualifier
+/// after "damage dealt" must not be dropped either.
+#[test]
+fn dynamic_x_clause_damage_dealt_to_continuation_stays_unsupported() {
+    assert!(
+        parse_dynamic_x_clause(", where x is the amount of damage dealt to that player").is_err(),
+        "qualified \"to\" continuation must not truncate to EventContextAmount"
+    );
+}
+
+/// Sibling of the "this way" regression above: a "by <object>" qualifier
+/// after "damage dealt" must not be dropped either.
+#[test]
+fn dynamic_x_clause_damage_dealt_by_continuation_stays_unsupported() {
+    assert!(
+        parse_dynamic_x_clause(", where x is the amount of damage dealt by that creature").is_err(),
+        "qualified \"by\" continuation must not truncate to EventContextAmount"
+    );
+}
+
+/// End-to-end companion to the direct `parse_dynamic_x_clause` tests above:
+/// through the full combat-tax dispatch (`parse_static_line`), a qualified
+/// "damage dealt this way" dynamic-X clause must not come back bound as
+/// `PerQuantityRef(EventContextAmount)` — the misparse the maintainer
+/// flagged. The dedicated combat-tax combinator honestly fails (proven
+/// directly above), so the unrelated `Unrecognized`-condition fallback in
+/// `parse_subject_combat_rule_static` takes over and preserves the raw
+/// unless-clause text instead of a wrong dynamic quantity binding.
+#[test]
+fn combat_tax_damage_dealt_this_way_does_not_bind_event_context_amount() {
+    let def = parse_static_line(
+        "Creatures can't attack you unless their controller pays {X}, where X is the amount of damage dealt this way.",
+    )
+    .expect("combat-tax line falls back to an Unrecognized unless-condition, not None");
+    assert_eq!(def.mode, StaticMode::CantAttack);
+    match def.condition {
+        // The dedicated combat-tax combinator honestly failed to bind {X}, so
+        // dispatch fell through to the generic unless-condition fallback,
+        // which preserves the raw clause text instead of a dynamic quantity.
+        Some(StaticCondition::Not { .. }) | None => {}
+        // If some other path DID produce a typed `UnlessPay`, it must not be
+        // the misparsed bare-`EventContextAmount` scaling — this is the
+        // concrete failure mode this regression guards against.
+        Some(ref cond) => {
+            if let Some((_, scaling)) = find_unless_pay(cond) {
+                assert!(
+                    !matches!(
+                        scaling,
+                        UnlessPayScaling::PerQuantityRef {
+                            quantity: QuantityRef::EventContextAmount
+                        }
+                    ),
+                    "qualified \"this way\" continuation must not truncate to EventContextAmount, got {scaling:?}"
+                );
+            }
+        }
+    }
+}
+
 /// CR 508.1d: Brainwash-class aura form — "Enchanted creature can't attack
 /// unless its controller pays {3}." Verifies the aura subject branch emits
 /// `FilterProp::EnchantedBy` and flat scaling.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -26435,6 +26435,23 @@ fn dynamic_x_clause_damage_dealt_bare_binds_event_context_amount() {
     assert!(matches!(quantity, QuantityRef::EventContextAmount));
 }
 
+/// CR 122.1: the untyped-counter dynamic-X anaphor still accepts the ordinary
+/// terminal sentence period after the complete-consumption hardening.
+#[test]
+fn dynamic_x_clause_untyped_counter_anaphor_accepts_terminal_period() {
+    let (rest, quantity) =
+        parse_dynamic_x_clause(", where x is the number of counters on that creature.")
+            .expect("terminal punctuation must not reject the untyped-counter anaphor");
+    assert_eq!(rest, "");
+    assert!(matches!(
+        quantity,
+        QuantityRef::CountersOn {
+            scope: ObjectScope::Target,
+            counter_type: None,
+        }
+    ));
+}
+
 /// Regression for the false-green the maintainer flagged on PR #7969, through
 /// the exact code path they cited (`shared.rs`'s `parse_dynamic_x_clause`):
 /// that function used to call the non-complete `parse_quantity_ref` and

--- a/crates/engine/tests/integration/kotis_the_fangkeeper_where_x_damage_dealt.rs
+++ b/crates/engine/tests/integration/kotis_the_fangkeeper_where_x_damage_dealt.rs
@@ -1,0 +1,168 @@
+//! Regression for issue #5923: Kotis, the Fangkeeper's combat-damage trigger
+//! must exile the top X cards of the damaged player's library (X = damage
+//! dealt) and grant Kotis's controller permission to cast, from among just
+//! that exiled batch, only the cards with mana value X or less.
+//!
+//! Before the `oracle_nom/quantity.rs` fix, the "where X is the amount of
+//! damage dealt" binding was left unresolved (the bare-phrase arm only
+//! matched "the damage dealt", not the "amount of" paraphrase), so the
+//! totality guard in `oracle_effect/lower.rs` collapsed both the `ExileTop`
+//! step and the `CastFromZone` sub-ability to `Effect::Unimplemented` and
+//! neither the exile nor the free-cast offer ever happened.
+//!
+//! https://github.com/phase-rs/phase/issues/5923
+
+use engine::game::casting::spell_objects_available_to_cast;
+use engine::game::combat::AttackTarget;
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const KOTIS_ORACLE: &str = "Indestructible\nWhenever Kotis deals combat damage to a player, exile the top X cards of their library, where X is the amount of damage dealt. You may cast any number of spells with mana value X or less from among them without paying their mana costs.";
+
+/// Drive combat until Kotis's trigger has fully resolved: declare no
+/// blockers, order the single trigger, then pass priority until the stack is
+/// empty and the expected top-of-library cards have left the library.
+fn drain_until_kotis_trigger_resolves(
+    runner: &mut engine::game::scenario::GameRunner,
+    cheap: ObjectId,
+    expensive: ObjectId,
+) {
+    for _ in 0..64 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OrderTriggers { .. } => {
+                runner
+                    .act(GameAction::OrderTriggers { order: vec![0] })
+                    .expect("order Kotis's trigger");
+            }
+            WaitingFor::DeclareBlockers { .. } => {
+                runner
+                    .act(GameAction::DeclareBlockers {
+                        assignments: vec![],
+                    })
+                    .expect("declare no blockers");
+            }
+            // CR 603.5 + CR 608.2d: the "you may cast ... from among them"
+            // sub-ability is a "may" effect — accept it so the CastFromZone
+            // permission is actually granted onto the exiled batch.
+            WaitingFor::OptionalEffectChoice { .. } => {
+                runner
+                    .act(GameAction::DecideOptionalEffect { accept: true })
+                    .expect("accept the optional cast-from-exile grant");
+            }
+            WaitingFor::Priority { .. } => {
+                if runner.state().stack.is_empty()
+                    && runner.state().objects[&cheap].zone == Zone::Exile
+                    && runner.state().objects[&expensive].zone == Zone::Exile
+                {
+                    return;
+                }
+                runner
+                    .act(GameAction::PassPriority)
+                    .expect("pass priority while draining Kotis's trigger");
+            }
+            other => panic!(
+                "unexpected waiting state while draining Kotis's trigger: {other:?} \
+                 (phase={:?})",
+                runner.state().phase
+            ),
+        }
+    }
+    panic!("Kotis's trigger did not resolve");
+}
+
+/// CR 120.1 + CR 608.2h: Kotis deals 2 combat damage (its printed power), so
+/// X = 2. The top two library cards are exiled (one within budget, MV 1; one
+/// over budget, MV 5) and a third card stays in the library, proving the
+/// exile is bounded to exactly X cards from the DAMAGED player's library, not
+/// Kotis's controller's.
+#[test]
+fn kotis_exiles_top_x_cards_and_offers_only_mana_value_x_or_less() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // P0 (Kotis's controller) has its own library card that must NOT be
+    // touched by Kotis's trigger.
+    let controller_top = scenario.add_card_to_library_top(P0, "Controller Top");
+
+    // P1 (the damaged player) library, top-to-bottom after seeding:
+    // Cheap Card (MV 1, within budget) -> Expensive Card (MV 5, over budget)
+    // -> Filler Card (must remain in library; outside the top-X window).
+    let filler = scenario.add_card_to_library_top(P1, "Filler Card");
+    let expensive = scenario.add_card_to_library_top(P1, "Expensive Card");
+    let cheap = scenario.add_card_to_library_top(P1, "Cheap Card");
+
+    let kotis = scenario
+        .add_creature(P0, "Kotis, the Fangkeeper", 2, 1)
+        .from_oracle_text_with_keywords(&["Indestructible"], KOTIS_ORACLE)
+        .id();
+
+    let mut runner = scenario.build();
+    {
+        let card = runner.state_mut().objects.get_mut(&cheap).unwrap();
+        card.card_types.core_types.push(CoreType::Instant);
+        card.mana_cost = ManaCost::Cost {
+            shards: Vec::new(),
+            generic: 1,
+        };
+    }
+    {
+        let card = runner.state_mut().objects.get_mut(&expensive).unwrap();
+        card.card_types.core_types.push(CoreType::Instant);
+        card.mana_cost = ManaCost::Cost {
+            shards: Vec::new(),
+            generic: 5,
+        };
+    }
+
+    runner.pass_both_players();
+    runner
+        .act(GameAction::DeclareAttackers {
+            attacks: vec![(kotis, AttackTarget::Player(P1))],
+            bands: vec![],
+        })
+        .expect("declare Kotis attacking P1");
+
+    drain_until_kotis_trigger_resolves(&mut runner, cheap, expensive);
+
+    let state = runner.state();
+
+    // Exactly the top two P1 library cards were exiled; the third stays put,
+    // and P0's own library is untouched (CR 608.2c: "their library" binds to
+    // the damaged player, not the source's controller).
+    assert_eq!(state.objects[&cheap].zone, Zone::Exile);
+    assert_eq!(state.objects[&expensive].zone, Zone::Exile);
+    assert_eq!(
+        state.objects[&filler].zone,
+        Zone::Library,
+        "only the top X (2) cards may be exiled, not the whole library"
+    );
+    assert_eq!(
+        state.objects[&controller_top].zone,
+        Zone::Library,
+        "Kotis must exile from the DAMAGED player's library, not its controller's"
+    );
+
+    // The free-cast offer is scoped to the exiled batch AND bounded by X (2):
+    // the within-budget card is offered, the over-budget card in the SAME
+    // batch is not, even though both were exiled.
+    let available = spell_objects_available_to_cast(state, P0);
+    assert!(
+        available.contains(&cheap),
+        "a mana value 1 card (<= X=2) exiled by Kotis must be offered for free casting"
+    );
+    assert!(
+        !available.contains(&expensive),
+        "a mana value 5 card (> X=2) must NOT be offered even though it was exiled in the same batch"
+    );
+
+    // Behavioral confirmation: the within-budget card can actually be cast
+    // for free through the granted permission.
+    let cast_outcome = runner.cast(cheap).resolve();
+    cast_outcome.assert_zone(&[cheap], Zone::Graveyard);
+}

--- a/crates/engine/tests/integration/kotis_the_fangkeeper_where_x_damage_dealt.rs
+++ b/crates/engine/tests/integration/kotis_the_fangkeeper_where_x_damage_dealt.rs
@@ -77,7 +77,7 @@ fn drain_until_kotis_trigger_resolves(
 }
 
 /// CR 120.2a + CR 608.2h: Kotis deals 2 combat damage (each attacking
-/// creature deals combat damage equal to its printed power), so X = 2. The
+/// creature deals combat damage equal to its power), so X = 2. The
 /// top two library cards are exiled (one within budget, MV 1; one over
 /// budget, MV 5) and a third card stays in the library, proving the exile is
 /// bounded to exactly X cards from the DAMAGED player's library, not Kotis's

--- a/crates/engine/tests/integration/kotis_the_fangkeeper_where_x_damage_dealt.rs
+++ b/crates/engine/tests/integration/kotis_the_fangkeeper_where_x_damage_dealt.rs
@@ -76,11 +76,12 @@ fn drain_until_kotis_trigger_resolves(
     panic!("Kotis's trigger did not resolve");
 }
 
-/// CR 120.1 + CR 608.2h: Kotis deals 2 combat damage (its printed power), so
-/// X = 2. The top two library cards are exiled (one within budget, MV 1; one
-/// over budget, MV 5) and a third card stays in the library, proving the
-/// exile is bounded to exactly X cards from the DAMAGED player's library, not
-/// Kotis's controller's.
+/// CR 120.2a + CR 608.2h: Kotis deals 2 combat damage (each attacking
+/// creature deals combat damage equal to its printed power), so X = 2. The
+/// top two library cards are exiled (one within budget, MV 1; one over
+/// budget, MV 5) and a third card stays in the library, proving the exile is
+/// bounded to exactly X cards from the DAMAGED player's library, not Kotis's
+/// controller's.
 #[test]
 fn kotis_exiles_top_x_cards_and_offers_only_mana_value_x_or_less() {
     let mut scenario = GameScenario::new();
@@ -133,8 +134,12 @@ fn kotis_exiles_top_x_cards_and_offers_only_mana_value_x_or_less() {
     let state = runner.state();
 
     // Exactly the top two P1 library cards were exiled; the third stays put,
-    // and P0's own library is untouched (CR 608.2c: "their library" binds to
-    // the damaged player, not the source's controller).
+    // and P0's own library is untouched. "Their library" is an Oracle-text
+    // grammar interpretation — the pronoun binds to the nearest preceding
+    // player noun, the damaged player from "deals combat damage to a
+    // player," not Kotis's controller — not a claim covered by a specific CR
+    // number (CR 608.2c governs the ORDER effects apply their instructions,
+    // not pronoun antecedents).
     assert_eq!(state.objects[&cheap].zone, Zone::Exile);
     assert_eq!(state.objects[&expensive].zone, Zone::Exile);
     assert_eq!(

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -811,6 +811,7 @@ mod kiora_self_library_peek_cast;
 mod knighthood_first_strike_grant;
 mod knollspine_dragon_target_damage_draw;
 mod kodama_anti_recursion_intervening_if;
+mod kotis_the_fangkeeper_where_x_damage_dealt;
 mod kozilek_broken_reality_manifest_from_hands;
 mod krark_clan_ironworks_castability;
 mod krark_thumb_coin_flip;

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -421,7 +421,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Knowledge Pool
 - Korlash, Heir to Blackblade
 - Korvold, Fae-Cursed King
-- Kotis, the Fangkeeper
 - Kotose, the Silent Spider
 - Krang, the All-Powerful
 - Krasis Incubation


### PR DESCRIPTION
## Summary

Fixes the `where X is the amount of damage dealt` misparse for **Kotis, the Fangkeeper**. `parse_event_context_refs` only recognized the bare phrase "the damage dealt", not this card's "amount of" paraphrase, so X was left unbound and both the trigger's `ExileTop` step and its `CastFromZone` sub-ability collapsed to `Effect::unimplemented("where_x_binding", ...)`.

Closes #5923.

## Files changed

- crates/engine/src/parser/oracle_nom/quantity.rs
- crates/engine/src/parser/oracle_effect/tests.rs
- crates/engine/tests/integration/kotis_the_fangkeeper_where_x_damage_dealt.rs (new)
- crates/engine/tests/integration/main.rs
- docs/parser-misparse-backlog.md

## Track

Developer

## LLM

Model: claude-sonnet-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 120.1
- CR 608.2h

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — PASS (clean)
- `cargo test -p phase-engine --lib` — 19826 passed, 0 failed, 6 ignored
- `cargo test -p phase-engine` (full, incl. integration) — 5584 passed, 1 failed: `cr733_authority_matrix_covers_the_fresh_write_census` fails only because `python` resolves to a Windows Store execution-alias stub on this machine's PATH — pre-existing environment limitation in a file untouched by this diff, not a regression (reproduces identically on a clean `upstream/main` checkout in this environment)
- `./scripts/check-parser-combinators.sh upstream/main` — Gate G PASS, Gate A PASS
- `cargo coverage` — Kotis, the Fangkeeper flips `supported: false → true`, `gap_count: 1 → 0`; the four other "amount of damage dealt" cards (Blazing Effigy, Grothama, All-Devouring, Impact Resonance, Tangled Colony) confirmed to remain honestly `supported: false` — their longer qualified phrases are not swallowed by the new prefix (full-consumption gate verified)

## Gate A

Gate A PASS head=96252edc4a8cc04b3cb47e2364443b63ac4d915e base=c36ae774439761239e815ac141b4a38535d0ad7e

## Anchored on

- crates/engine/src/parser/oracle_nom/quantity.rs:3408 — existing `parse_life_lost_ref` optional `"the amount of "` / `"amount of "` prefix idiom, the precedent this fix extends to the "damage dealt" bare phrase
- crates/engine/src/parser/oracle_effect/tests.rs:436 — existing `cosmic_cube_full_trigger_carries_dynamic_constraint` test style, the precedent for asserting a full lowered trigger→sub-ability AST shape with a dynamic `CastPermissionConstraint`

## Final review-impl

Final review-impl PASS head=96252edc4a8cc04b3cb47e2364443b63ac4d915e

## Claimed parse impact

Kotis, the Fangkeeper (`supported: false → true`, `gap_count: 1 → 0`).

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None. (See the Verification section's note on one pre-existing, unrelated `python`-path failure in this sandbox, reproducible on a clean base and untouched by this diff.)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed Kotis, the Fangkeeper’s combat-damage ability so X correctly equals damage dealt.
  - Cards are exiled from the damaged player’s library, with free casting limited to those cards and the damage-based mana value limit.
  - Improved parsing of damage-based values while rejecting ambiguous or incomplete phrases.

- **Tests**
  - Added parser and gameplay coverage to prevent regressions.

- **Documentation**
  - Updated the parser misparse backlog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->