### PR TITLE
Fix Security Bypass

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -1462,7 +1462,8 @@ pub(crate) fn parse_attached_subject_target_filter(input: &str) -> OracleResult<
 }
 
 /// CR 508.1a + CR 509.1a + CR 611.3a: Parse "enchanted/equipped creature is
-/// attacking|blocking" into the attached-subject's `TargetFilter` plus the
+/// attacking alone|attacking|blocking" into the attached-subject's
+/// `TargetFilter` plus the
 /// combat-state `FilterProp`. Unlike `parse_attached_subject_is_filter` (which
 /// folds a STATIC characteristic — color/type/supertype — into the subject
 /// filter), combat state is re-evaluated each layer cycle (CR 611.3a), so the
@@ -1479,6 +1480,7 @@ pub(crate) fn parse_attached_subject_combat_state(
     let (rest, subject) = parse_attached_condition_subject(input)?;
     let (rest, _) = tag("is ").parse(rest)?;
     let (rest, prop) = alt((
+        value(FilterProp::AttackingAlone, tag("attacking alone")),
         value(FilterProp::Attacking { defender: None }, tag("attacking")),
         value(FilterProp::Blocking, tag("blocking")),
     ))
@@ -14463,6 +14465,48 @@ mod tests {
         assert!(angel
             .type_filters
             .contains(&TypeFilter::Subtype("Angel".to_string())));
+    }
+
+    #[test]
+    fn attached_subject_combat_state_parses_attacking_alone_before_attacking() {
+        let (rest, (filter, prop)) =
+            parse_attached_subject_combat_state("enchanted creature is attacking alone")
+                .expect("attached attacking-alone condition must parse");
+        assert_eq!(rest, "");
+        assert_eq!(prop, FilterProp::AttackingAlone);
+        assert_eq!(
+            filter,
+            TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::EnchantedBy]))
+        );
+    }
+
+    #[test]
+    fn attached_subject_combat_state_preserves_equipped_and_broad_attacking_forms() {
+        let (rest, (filter, prop)) =
+            parse_attached_subject_combat_state("equipped creature is attacking alone")
+                .expect("equipped attacking-alone condition must parse");
+        assert_eq!(rest, "");
+        assert_eq!(prop, FilterProp::AttackingAlone);
+        assert_eq!(
+            filter,
+            TargetFilter::Typed(TypedFilter::creature().properties(vec![FilterProp::EquippedBy]))
+        );
+
+        let (rest, (_, prop)) =
+            parse_attached_subject_combat_state("enchanted creature is attacking")
+                .expect("existing broad attacking condition must still parse");
+        assert_eq!(rest, "");
+        assert_eq!(prop, FilterProp::Attacking { defender: None });
+    }
+
+    #[test]
+    fn attached_subject_combat_state_leaves_hostile_trailing_text_for_caller() {
+        let (rest, (_, prop)) = parse_attached_subject_combat_state(
+            "enchanted creature is attacking alone during your turn",
+        )
+        .expect("the building block should parse its exact predicate");
+        assert_eq!(prop, FilterProp::AttackingAlone);
+        assert_eq!(rest, " during your turn");
     }
 
     // -- Anaphoric "it" recipient conditions (CR 611.3a) --

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -578,6 +578,45 @@ pub(crate) fn try_parse_inverted_attached_combat_grant(
     defs
 }
 
+/// CR 506.5 + CR 509.1b + CR 611.3a: Inverted attached-subject evasion gated
+/// on the host creature's live combat state — "As long as enchanted/equipped
+/// creature is attacking alone, it can't be blocked." The restriction belongs
+/// to the attached host, not the Aura/Equipment source. Reuses the canonical
+/// evasion classifier and the same recipient gate as attached combat grants.
+pub(crate) fn try_parse_inverted_attached_combat_evasion(
+    split: &InvertedSplit,
+    description: &str,
+) -> Option<StaticDefinition> {
+    let condition_lower = split.condition_text.to_lowercase();
+    let (rest, (affected, combat_prop)) =
+        nom_condition::parse_attached_subject_combat_state(&condition_lower).ok()?;
+    if !rest.trim().is_empty() {
+        return None;
+    }
+
+    let effect_lower = split.effect_text.to_lowercase();
+    let effect_tp = TextPair::new(&split.effect_text, &effect_lower);
+    let predicate = nom_tag_tp(&effect_tp, "it ").or_else(|| nom_tag_tp(&effect_tp, "they "))?;
+    let (mode, evasion_condition) = super::evasion::cant_be_blocked_mode(predicate.lower.trim())?;
+
+    let recipient_gate = StaticCondition::RecipientMatchesFilter {
+        filter: TargetFilter::Typed(TypedFilter::creature().properties(vec![combat_prop])),
+    };
+    let condition = match evasion_condition {
+        Some(evasion_condition) => StaticCondition::And {
+            conditions: vec![recipient_gate, evasion_condition],
+        },
+        None => recipient_gate,
+    };
+
+    Some(
+        StaticDefinition::new(mode)
+            .affected(affected)
+            .condition(condition)
+            .description(description.to_string()),
+    )
+}
+
 fn parse_grant_conjunct_verb(input: &str) -> OracleResult<'_, ()> {
     value(
         (),
@@ -2362,18 +2401,22 @@ fn parse_static_line_multi_dispatch(text: &str) -> Vec<StaticDefinition> {
         return Vec::new();
     }
 
-    // CR 508.1a + CR 611.3a + CR 613.1f: Inverted attached-subject grant gated on
-    // the host creature's COMBAT STATE — "As long as equipped/enchanted creature
-    // is attacking|blocking, it has/gets <X> [and <unmodeled conjunct>]" (Ace's
-    // Baseball Bat). This must run on the multi-static path (and before the
-    // single-return fallback) for two reasons: (1) the generic inverted rewrite
-    // would gate the grant on `SourceIsAttacking` (the Equipment, never an
-    // attacker) with `affected = SelfRef` — both wrong; (2) the compound effect
-    // may carry an unmodeled conjunct (the "must be blocked by a Dalek if able"
-    // lure) that must surface as a sibling `Effect::Unimplemented` residual
-    // rather than being silently dropped. The single-return path can carry only
-    // one def, so the residual would have nowhere to live there.
+    // CR 508.1a + CR 509.1b + CR 611.3a + CR 613.1f: Inverted attached-subject
+    // grant/evasion gated on the host creature's COMBAT STATE — "As long as
+    // equipped/enchanted creature is attacking[ alone]|blocking, it has/gets
+    // <X>" or "it can't be blocked" (Ace's Baseball Bat, Security Bypass).
+    // This must run on the multi-static path (and before the single-return
+    // fallback) for two reasons: (1) the generic inverted rewrite would gate on
+    // the Aura/Equipment source and set `affected = SelfRef` — both wrong; (2)
+    // a compound grant may carry an unmodeled conjunct (the "must be blocked by
+    // a Dalek if able" lure) that must surface as a sibling
+    // `Effect::Unimplemented` residual rather than being silently dropped. The
+    // single-return path can carry only one def, so that residual would have
+    // nowhere to live there.
     if let Some(split) = try_split_inverted_as_long_as(&tp) {
+        if let Some(def) = try_parse_inverted_attached_combat_evasion(&split, &stripped) {
+            return vec![def];
+        }
         let defs = try_parse_inverted_attached_combat_grant(&split, &stripped);
         if !defs.is_empty() {
             return defs;

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -10354,6 +10354,136 @@ fn static_as_long_as_enchanted_creature_is_attacking_gate_binds_to_host() {
     );
 }
 
+/// CR 506.5 + CR 509.1b + CR 611.3a: Security Bypass's evasion applies to the
+/// enchanted host only while that recipient is the sole attacker. The Aura is
+/// not the affected object and its combat state is irrelevant.
+#[test]
+fn security_bypass_attacking_alone_evasion_binds_to_enchanted_host() {
+    let line = "As long as enchanted creature is attacking alone, it can't be blocked.";
+    let defs = parse_static_line_multi(line);
+    assert_eq!(defs.len(), 1, "expected one typed restriction: {defs:?}");
+    assert_eq!(defs[0].mode, StaticMode::CantBeBlocked);
+    assert_eq!(
+        defs[0].affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::creature().properties(vec![FilterProp::EnchantedBy])
+        ))
+    );
+    assert_eq!(
+        defs[0].condition,
+        Some(StaticCondition::RecipientMatchesFilter {
+            filter: TargetFilter::Typed(
+                TypedFilter::creature().properties(vec![FilterProp::AttackingAlone])
+            ),
+        })
+    );
+}
+
+/// The generic route also covers Equipment and the curly apostrophe used by
+/// some Oracle sources; neither variation may fall back to source/self binding.
+#[test]
+fn equipped_attacking_alone_evasion_accepts_curly_apostrophe() {
+    let defs = parse_static_line_multi(
+        "As long as equipped creature is attacking alone, it can’t be blocked.",
+    );
+    assert_eq!(defs.len(), 1, "expected one typed restriction: {defs:?}");
+    assert_eq!(defs[0].mode, StaticMode::CantBeBlocked);
+    assert_eq!(
+        defs[0].affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::creature().properties(vec![FilterProp::EquippedBy])
+        ))
+    );
+    assert_eq!(
+        defs[0].condition,
+        Some(StaticCondition::RecipientMatchesFilter {
+            filter: TargetFilter::Typed(
+                TypedFilter::creature().properties(vec![FilterProp::AttackingAlone])
+            ),
+        })
+    );
+}
+
+/// The attached-combat consumer is all-consuming. A longer, unsupported
+/// condition must not be silently truncated into the supported Security
+/// Bypass shape.
+#[test]
+fn attached_attacking_alone_rejects_hostile_trailing_condition() {
+    let defs = parse_static_line_multi(
+        "As long as enchanted creature is attacking alone during your turn, it can't be blocked.",
+    );
+    assert!(
+        !defs.iter().any(|def| {
+            def.mode == StaticMode::CantBeBlocked
+                && def.affected
+                    == Some(TargetFilter::Typed(
+                        TypedFilter::creature().properties(vec![FilterProp::EnchantedBy]),
+                    ))
+                && def.condition
+                    == Some(StaticCondition::RecipientMatchesFilter {
+                        filter: TargetFilter::Typed(
+                            TypedFilter::creature().properties(vec![FilterProp::AttackingAlone]),
+                        ),
+                    })
+        }),
+        "hostile trailing text must not be swallowed into the exact typed shape: {defs:?}"
+    );
+}
+
+/// Full production Oracle for Security Bypass: the evasion condition, attached
+/// host binding, granted combat-damage trigger, and Connive effect must all be
+/// typed with no permissive fallback or unsupported residual.
+#[test]
+fn security_bypass_full_oracle_is_fully_typed() {
+    const ORACLE: &str = "Enchant creature\nAs long as enchanted creature is attacking alone, it can't be blocked.\nEnchanted creature has \"Whenever this creature deals combat damage to a player, it connives.\" (Its controller draws a card, then discards a card. If they discarded a nonland card, they put a +1/+1 counter on this creature.)";
+
+    let parsed = crate::parser::oracle::parse_oracle_text(
+        ORACLE,
+        "Security Bypass",
+        &["Enchant".to_string()],
+        &["Enchantment".to_string()],
+        &["Aura".to_string()],
+    );
+    let evasion = parsed
+        .statics
+        .iter()
+        .find(|def| def.mode == StaticMode::CantBeBlocked)
+        .expect("full Oracle must contain the typed evasion static");
+    assert_eq!(
+        evasion.affected,
+        Some(TargetFilter::Typed(
+            TypedFilter::creature().properties(vec![FilterProp::EnchantedBy])
+        ))
+    );
+    assert_eq!(
+        evasion.condition,
+        Some(StaticCondition::RecipientMatchesFilter {
+            filter: TargetFilter::Typed(
+                TypedFilter::creature().properties(vec![FilterProp::AttackingAlone])
+            ),
+        })
+    );
+
+    let serialized = serde_json::to_string(&parsed).expect("parsed card must serialize");
+    for expected in ["DamageDone", "Connive"] {
+        assert!(
+            serialized.contains(expected),
+            "full Oracle must retain typed {expected}: {parsed:?}"
+        );
+    }
+    for forbidden in ["Unrecognized", "Unimplemented"] {
+        assert!(
+            !serialized.contains(forbidden),
+            "full Oracle must not contain {forbidden}: {parsed:?}"
+        );
+    }
+    assert!(
+        parsed.parse_warnings.is_empty(),
+        "full Oracle must not emit parser warnings: {:?}",
+        parsed.parse_warnings
+    );
+}
+
 /// CR 509.1a + CR 611.3a: the blocking branch of the combat-state gate.
 #[test]
 fn static_as_long_as_equipped_creature_is_blocking_grants_to_host() {

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1373,6 +1373,7 @@ mod scarblade_malice_delayed_dies_762;
 mod scry_choice_not_clobbered_by_triggers;
 mod scry_substituted_draw_per_card_replacement;
 mod secret_of_bloodbending_control_window;
+mod security_bypass_attacking_alone;
 mod she_hulk_wallbreaker_becomes_blocked_4599;
 mod shelob_repro_token;
 mod sheoldred_edict_multi_opponent_sac;

--- a/crates/engine/tests/integration/security_bypass_attacking_alone.rs
+++ b/crates/engine/tests/integration/security_bypass_attacking_alone.rs
@@ -1,0 +1,180 @@
+//! Security Bypass — recipient-scoped attacking-alone evasion and granted
+//! combat-damage Connive trigger.
+//!
+//! Oracle verified from the generated MTGJSON data. CR 506.5 defines
+//! "attacking alone" across the whole combat, CR 509.1b applies block
+//! restrictions, CR 611.3a continuously re-evaluates the static ability, and
+//! CR 113.8 makes the enchanted creature's controller control the granted
+//! triggered ability.
+
+use engine::game::combat::{can_block_pair, AttackTarget};
+use engine::game::effects::attach::attach_to;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P2: PlayerId = PlayerId(2);
+
+const SECURITY_BYPASS_ORACLE: &str = "Enchant creature\n\
+As long as enchanted creature is attacking alone, it can't be blocked.\n\
+Enchanted creature has \"Whenever this creature deals combat damage to a player, it connives.\" \
+(Its controller draws a card, then discards a card. If they discarded a nonland card, they put a \
++1/+1 counter on this creature.)";
+
+fn add_security_bypass(scenario: &mut GameScenario, aura_controller: PlayerId) -> ObjectId {
+    scenario
+        .add_enchantment_from_oracle(aura_controller, "Security Bypass", SECURITY_BYPASS_ORACLE)
+        .with_subtypes(vec!["Aura"])
+        .id()
+}
+
+fn attach_and_assert(runner: &mut GameRunner, aura: ObjectId, host: ObjectId) {
+    attach_to(runner.state_mut(), aura, host);
+    assert_eq!(
+        runner.state().objects[&aura]
+            .attached_to
+            .and_then(|target| target.as_object()),
+        Some(host),
+        "Security Bypass must be legally attached to the creature host"
+    );
+}
+
+fn drive_to_declare_attackers(runner: &mut GameRunner) {
+    for _ in 0..32 {
+        match runner.state().waiting_for {
+            WaitingFor::DeclareAttackers { .. } => return,
+            WaitingFor::Priority { .. } => runner
+                .act(GameAction::PassPriority)
+                .expect("passing priority should reach declare attackers"),
+            ref other => panic!("expected priority or declare attackers, got {other:?}"),
+        };
+    }
+    panic!("did not reach declare attackers");
+}
+
+fn drive_until_trigger_stacked(runner: &mut GameRunner) {
+    for _ in 0..64 {
+        if !runner.state().stack.is_empty() {
+            return;
+        }
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => runner
+                .act(GameAction::PassPriority)
+                .expect("passing priority should advance combat"),
+            WaitingFor::DeclareBlockers { .. } => runner
+                .act(GameAction::DeclareBlockers {
+                    assignments: vec![],
+                })
+                .expect("defender should be able to declare no blockers"),
+            WaitingFor::OrderTriggers { triggers, .. } => runner
+                .act(GameAction::OrderTriggers {
+                    order: (0..triggers.len()).collect(),
+                })
+                .expect("default trigger order should be accepted"),
+            ref other => panic!("unexpected wait state while advancing combat: {other:?}"),
+        };
+    }
+    panic!("Security Bypass trigger never reached the stack");
+}
+
+#[test]
+fn solo_enchanted_attacker_is_unblockable_and_aura_departure_removes_grant() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let host = scenario.add_creature(P0, "Bypassed Operative", 3, 3).id();
+    let blocker = scenario.add_creature(P1, "Guard", 2, 2).id();
+    let aura = add_security_bypass(&mut scenario, P2);
+    let mut runner = scenario.build();
+    attach_and_assert(&mut runner, aura, host);
+
+    assert_eq!(runner.state().objects[&aura].controller, P2);
+    assert_eq!(runner.state().objects[&host].controller, P0);
+    drive_to_declare_attackers(&mut runner);
+    runner
+        .declare_attackers(&[(host, AttackTarget::Player(P1))])
+        .expect("solo attack must be legal");
+    assert!(
+        !can_block_pair(runner.state(), blocker, host),
+        "the enchanted creature must be unblockable while attacking alone"
+    );
+
+    let mut events = Vec::new();
+    engine::game::zones::move_to_zone(runner.state_mut(), aura, Zone::Graveyard, &mut events);
+    assert_eq!(runner.state().objects[&aura].zone, Zone::Graveyard);
+    assert!(
+        can_block_pair(runner.state(), blocker, host),
+        "the evasion grant must disappear when Security Bypass leaves the battlefield"
+    );
+}
+
+#[test]
+fn a_global_coattacker_makes_the_enchanted_creature_blockable() {
+    let mut scenario = GameScenario::new_n_player(3, 43);
+    scenario.at_phase(Phase::PreCombatMain);
+    let host = scenario.add_creature(P0, "Bypassed Operative", 3, 3).id();
+    let coattacker = scenario.add_creature(P0, "Other Operative", 2, 2).id();
+    let blocker = scenario.add_creature(P1, "Guard", 2, 2).id();
+    let aura = add_security_bypass(&mut scenario, P2);
+    let mut runner = scenario.build();
+    attach_and_assert(&mut runner, aura, host);
+
+    drive_to_declare_attackers(&mut runner);
+    runner
+        .declare_attackers(&[
+            (host, AttackTarget::Player(P1)),
+            (coattacker, AttackTarget::Player(P2)),
+        ])
+        .expect("both attacks must be legal");
+    assert!(
+        can_block_pair(runner.state(), blocker, host),
+        "CR 506.5 counts all attackers, even those attacking another defender"
+    );
+}
+
+#[test]
+fn enchanted_host_controls_and_resolves_the_granted_connive_trigger() {
+    let mut scenario = GameScenario::new_n_player(3, 44);
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Nonland Top"]);
+    let host = scenario.add_creature(P0, "Bypassed Operative", 3, 3).id();
+    let aura = add_security_bypass(&mut scenario, P2);
+    let mut runner = scenario.build();
+    attach_and_assert(&mut runner, aura, host);
+
+    drive_to_declare_attackers(&mut runner);
+    runner
+        .declare_attackers(&[(host, AttackTarget::Player(P1))])
+        .expect("solo attack must be legal");
+    drive_until_trigger_stacked(&mut runner);
+
+    let trigger = runner
+        .state()
+        .stack
+        .iter()
+        .find(|entry| entry.source_id == host)
+        .expect("the enchanted host's granted damage trigger must reach the stack");
+    assert_eq!(
+        trigger.controller, P0,
+        "the host's controller, not the Aura's controller, controls the granted trigger"
+    );
+
+    runner.advance_until_stack_empty();
+    assert!(
+        runner.state().players[0].hand.is_empty(),
+        "Connive must draw and then discard the only nonland card"
+    );
+    assert_eq!(
+        runner.state().objects[&host]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied()
+            .unwrap_or(0),
+        1,
+        "discarding a nonland card while conniving must put a +1/+1 counter on the host"
+    );
+}

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 30
-- **Distinct cards implicated:** 4712
-- **Total card appearances across root causes:** 4745 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4711
+- **Total card appearances across root causes:** 4744 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -24,7 +24,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 10 | Trigger event/mode unrecognized → Unknown | 168 | oracle_trigger.rs — add typed TriggerMode variants for the unrecognized event classes |
 | 11 | Replacement / prevention / 'instead' effect mis-modeled | 157 | add-replacement-effect: route 'would … instead' into replacements[]; preserve damage_source/target filters |
 | 12 | Modal 'choose one/N' parsed as independent abilities | 138 | oracle.rs modal dispatch — detect 'Choose one —' header, wrap modes in Effect::ChooseOneOf |
-| 13 | State/game-state condition → StaticCondition::Unrecognized | 133 | oracle_nom/condition.rs parse_inner_condition — add typed variant for the predicate class |
+| 13 | State/game-state condition → StaticCondition::Unrecognized | 132 | oracle_nom/condition.rs parse_inner_condition — add typed variant for the predicate class |
 | 14 | Granted/quoted ability or continuous modification dropped | 95 | oracle_static.rs continuous-modification extraction — emit all conjuncts incl. GrantAbility/GrantKeyword |
 | 15 | Multi-target / 'up to N' optionality or count dropped | 83 | oracle_target.rs strip_optional_target_prefix — preserve MultiTargetSpec and optional_targeting |
 | 16 | Keyword payload / multiplicity / mis-tokenization | 83 | game/keywords.rs + oracle keyword parsing — use typed discriminants and guard ability-word labels |
@@ -3939,7 +3939,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 13. State/game-state condition → StaticCondition::Unrecognized  (133 cards)
+### 13. State/game-state condition → StaticCondition::Unrecognized  (132 cards)
 
 **Signature.** A parseable game-state predicate falls to StaticCondition::Unrecognized (evaluates permissively true) instead of a typed presence/combat/counter/comparison condition.
 
@@ -4051,7 +4051,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Sab-Sunen, Luxa Embodied
 - Sanwell, Avenger Ace
 - Secretkeeper
-- Security Bypass
 - Siege Behemoth
 - Skill Borrower
 - Skittish Kavu


### PR DESCRIPTION
## Summary

Fixes the **State/game-state condition → StaticCondition::Unrecognized** misparse for **Security Bypass**. The attached host now receives the existing typed attacking-alone combat gate, so its evasion applies only while that creature is the sole attacker; the resolved backlog entry and counts are updated in the same PR.

## Files changed

- `crates/engine/src/parser/oracle_nom/condition.rs`
- `crates/engine/src/parser/oracle_static/shared.rs`
- `crates/engine/src/parser/oracle_static/tests.rs`
- `crates/engine/tests/integration/main.rs`
- `crates/engine/tests/integration/security_bypass_attacking_alone.rs`
- `docs/parser-misparse-backlog.md`

## Track

Developer

## LLM

Model: GPT-5 (Codex; canonical model identifier not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 113.8 — an Aura's controller is independent of the enchanted permanent's controller
- CR 506.5 — a creature attacks alone only when it is the sole declared attacker
- CR 509.1b — blocking legality observes restrictions such as “can't be blocked”
- CR 611.3a — continuous effects from static abilities apply while the permanent remains on the battlefield
- CR 701.50a — Connive draws, discards, and adds a +1/+1 counter after a nonland discard

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — PASS
- `git diff --check` — PASS
- `cargo clippy-strict` — PASS, zero warnings on the content-identical production patch before the conflict-free latest-main rebase; current-head lint is delegated to required CI
- `cargo test -p phase-engine` — PASS before the conflict-free latest-main rebase: 19,837 library tests and 5,587 integration tests, zero failures
- exact-current-head targeted parser/full-Oracle/runtime matrix — PASS: attached enchanted/equipped attacking-alone phrases, broad-attacking preservation, hostile-tail rejection, curly apostrophe, and full Security Bypass Oracle
- exact-current-head 3-player runtime matrix — PASS, 3/3: solo host cannot be blocked; a global coattacker attacking another defender restores blockability; Aura departure removes evasion; host-sourced/host-controlled combat-damage trigger resolves Connive and a nonland discard adds +1/+1
- exact revert discriminator — PASS: parser/runtime tests fail when the production routing is removed and pass when restored
- `./scripts/gen-card-data.sh` — PASS on current base; 35,798 faces validated and 32,176/35,009 cards fully implemented
- `cargo coverage` / generated coverage — PASS; 31,827/35,798 supported overall, SNC 271/310 (87.42%), Security Bypass `supported=true`, `gap_count=0`
- SHA-bound parse evidence — PASS; exactly Security Bypass changes, with `CantBeBlocked.affects` from `self` to `enchanted by self creature` and condition from `unrecognized` to `recipient is attacking alone creature`
- `cargo semantic-audit` — PASS; 32,789 cards audited and zero findings for Security Bypass
- `./scripts/check-skill-doc.sh` — PASS
- Gate G — PASS head=66161699b492eb7819de903e888ef569b1376791 (strict router vs permissive grant boundary intact)

## Gate A

Gate A PASS head=66161699b492eb7819de903e888ef569b1376791 base=fba25131564a346d502d24ada326ea58eb6a0689

## Anchored on

- `crates/engine/src/parser/oracle_static/shared.rs:457` — existing inverted attached-combat grant binds the enchanted/equipped host through `RecipientMatchesFilter`
- `crates/engine/src/parser/oracle_static/evasion.rs:1669` — canonical typed “can't be blocked” classifier reused by the new route
- `crates/engine/src/game/combat.rs:5485` — existing multiplayer-aware `attacking_alone` runtime authority

## Final review-impl

Final review-impl PASS head=66161699b492eb7819de903e888ef569b1376791

## Claimed parse impact

- Security Bypass

## Scope Expansion

None. The parser route is generic for enchanted/equipped creatures, but measured generated parse impact is exactly Security Bypass. No new engine or serialized protocol variant is introduced.

## Validation Failures

None.

## CI Failures

None.