### PR TITLE
fix(engine): let the X cap search report an unbounded gate instead of spinning

### DIFF
--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -12065,9 +12065,9 @@ pub(super) fn max_x_value_excluding(
     else {
         return formula_max;
     };
-    if pending.base_cost.is_none() {
+    let Some(base_cost) = pending.base_cost.as_ref() else {
         return formula_max;
-    }
+    };
 
     // CR 601.2b / CR 601.2f: The concrete total is monotonic non-decreasing in X.
     // `concretize_x` adds `x * x_count` generic; non-floor and target-dependent
@@ -12083,23 +12083,21 @@ pub(super) fn max_x_value_excluding(
     // order is safe. The explicit `!probe(0)` early return below reproduces the
     // old linear loop's `saturating_sub(1)` floor exactly: when even X=0
     // overshoots, the cap is 0 (not an underflow).
-    // CR 601.2b: the announced X can also live in an ADDITIONAL cost that was
-    // merged into `pending.cost` when it was declared (kicker {X}: Thieving
-    // Skydiver, Toxic Deluge, Hatred, …). The recompute above reads
-    // `pending.base_cost`, which carries the spell's own printed mana cost and
-    // not that additional {X}, so for a spell whose printed cost has no X the
-    // recomputed total does not move with X at all — the gate is constant true
-    // and bounds nothing. `formula_max` already subtracted the whole fixed
-    // portion of `pending.cost` (the spell's own pips included) from the
-    // available mana, so it is the honest cap in exactly that case.
-    //
-    // Not covered: cost reductions and floors are applied to the recomputed
-    // spell total only, so they do not widen or clamp an additional cost's X.
-    largest_x_satisfying(formula_max, |x| {
+    // CR 601.2b: the announced X can also live only in an ADDITIONAL cost
+    // (kicker {X}: Thieving Skydiver, Toxic Deluge, Hatred, …). The recompute
+    // above reads `pending.base_cost`, so its predicate does not depend on X
+    // when the printed cost has none. In that shape `formula_max`, calculated
+    // from the complete pending cost, is the finite authority; use the existing
+    // bounded search instead of an unbounded exponential probe.
+    let predicate = |x| {
         super::casting::recompute_pending_mana_total(state, player, pending, Some(x)).mana_value()
             <= available
-    })
-    .unwrap_or(formula_max)
+    };
+    if cost_has_x(base_cost) {
+        largest_x_satisfying(formula_max, predicate)
+    } else {
+        largest_x_satisfying_at_most(formula_max, predicate)
+    }
 }
 
 /// Largest `x` for which `predicate(x)` holds, given `predicate` is a monotone
@@ -12110,19 +12108,13 @@ pub(super) fn max_x_value_excluding(
 ///
 /// `formula_max` is only a starting estimate for the exponential probe;
 /// correctness does NOT depend on it (the true cap can be lower — Trinisphere
-/// floor — or higher — reductions exceeding the fixed generic). Returns
-/// `Some(0)` when even `predicate(0)` is false, reproducing the linear ascent's
+/// floor — or higher — reductions exceeding the fixed generic). Returns `0`
+/// when even `predicate(0)` is false, reproducing the linear ascent's
 /// `saturating_sub(1)` floor at the `X=0` boundary. O(log cap) evaluations of
 /// `predicate` versus the linear scan's O(cap); identical result by monotonicity.
-///
-/// Returns `None` when the predicate holds for every `u32`, i.e. it bounds
-/// nothing and this search has no answer to give. A monotone gate is allowed to
-/// be *constant* true, and the caller — not this function — owns what to do
-/// then: `saturating_mul` pins `hi` at `u32::MAX`, so a `while predicate(hi)`
-/// ascent would spin there forever rather than terminate.
-fn largest_x_satisfying(formula_max: u32, predicate: impl Fn(u32) -> bool) -> Option<u32> {
+fn largest_x_satisfying(formula_max: u32, predicate: impl Fn(u32) -> bool) -> u32 {
     if !predicate(0) {
-        return Some(0);
+        return 0;
     }
 
     // Exponential probe: grow `hi` off `formula_max` until `predicate(hi)` is
@@ -12131,13 +12123,14 @@ fn largest_x_satisfying(formula_max: u32, predicate: impl Fn(u32) -> bool) -> Op
     // overflow; `max(saturating_add(1))` guards `hi == 0`.
     let mut hi = formula_max.max(1);
     while predicate(hi) {
+        debug_assert_ne!(hi, u32::MAX, "callers must bound constant-true gates");
         if hi == u32::MAX {
-            return None;
+            return u32::MAX;
         }
         hi = hi.saturating_mul(2).max(hi.saturating_add(1));
     }
 
-    Some(largest_x_satisfying_at_most(hi - 1, predicate))
+    largest_x_satisfying_at_most(hi - 1, predicate)
 }
 
 /// Largest `x` not exceeding `max` for which a monotone true-prefix predicate
@@ -14253,30 +14246,10 @@ mod tests {
         }
     }
 
-    /// A gate that never closes bounds nothing, and the search must say so
-    /// instead of ascending forever. This is the shape an additional cost's
-    /// `{X}` produces (kicker `{X}` on a spell whose printed cost has no X):
-    /// the recomputed spell total does not move with X, so the gate is constant
-    /// true. `linear_x_reference` is deliberately not consulted here — it would
-    /// not terminate either, which is precisely why the reference cannot answer
-    /// this case.
-    #[test]
-    fn largest_x_satisfying_reports_an_unbounded_gate() {
-        assert_eq!(largest_x_satisfying(0, |_| true), None);
-        assert_eq!(largest_x_satisfying(u32::MAX, |_| true), None);
-        // A gate that closes at the very top is still bounded, and the answer
-        // is the last X that fits — not `None`.
-        assert_eq!(
-            largest_x_satisfying(0, |x| x < u32::MAX),
-            Some(u32::MAX - 1),
-        );
-    }
-
     /// `largest_x_satisfying` (exponential probe + bisection) must return the
     /// byte-identical X cap of the old linear ascent for every monotone cost
-    /// shape that is actually bounded. Each shape models
-    /// `concrete_cost_for_x(x).mana_value()` as a monotone-non-decreasing
-    /// function of X, then asserts the two searches agree.
+    /// shape. Each shape models `concrete_cost_for_x(x).mana_value()` as a
+    /// monotone-non-decreasing function of X, then asserts the two searches agree.
     #[test]
     fn largest_x_satisfying_matches_linear_reference() {
         // cost(x) = max(fixed + x * x_count - reduction, floor); predicate is
@@ -14298,7 +14271,7 @@ mod tests {
                             let formula_max = available.saturating_sub(fixed) / x_count;
                             assert_eq!(
                                 largest_x_satisfying(formula_max, predicate),
-                                Some(linear_x_reference(predicate)),
+                                linear_x_reference(predicate),
                                 "mismatch at available={available} fixed={fixed} \
                                  x_count={x_count} reduction={reduction} floor={floor}",
                             );

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -12083,10 +12083,23 @@ pub(super) fn max_x_value_excluding(
     // order is safe. The explicit `!probe(0)` early return below reproduces the
     // old linear loop's `saturating_sub(1)` floor exactly: when even X=0
     // overshoots, the cap is 0 (not an underflow).
+    // CR 601.2b: the announced X can also live in an ADDITIONAL cost that was
+    // merged into `pending.cost` when it was declared (kicker {X}: Thieving
+    // Skydiver, Toxic Deluge, Hatred, …). The recompute above reads
+    // `pending.base_cost`, which carries the spell's own printed mana cost and
+    // not that additional {X}, so for a spell whose printed cost has no X the
+    // recomputed total does not move with X at all — the gate is constant true
+    // and bounds nothing. `formula_max` already subtracted the whole fixed
+    // portion of `pending.cost` (the spell's own pips included) from the
+    // available mana, so it is the honest cap in exactly that case.
+    //
+    // Not covered: cost reductions and floors are applied to the recomputed
+    // spell total only, so they do not widen or clamp an additional cost's X.
     largest_x_satisfying(formula_max, |x| {
         super::casting::recompute_pending_mana_total(state, player, pending, Some(x)).mana_value()
             <= available
     })
+    .unwrap_or(formula_max)
 }
 
 /// Largest `x` for which `predicate(x)` holds, given `predicate` is a monotone
@@ -12097,13 +12110,19 @@ pub(super) fn max_x_value_excluding(
 ///
 /// `formula_max` is only a starting estimate for the exponential probe;
 /// correctness does NOT depend on it (the true cap can be lower — Trinisphere
-/// floor — or higher — reductions exceeding the fixed generic). Returns `0` when
-/// even `predicate(0)` is false, reproducing the linear ascent's
+/// floor — or higher — reductions exceeding the fixed generic). Returns
+/// `Some(0)` when even `predicate(0)` is false, reproducing the linear ascent's
 /// `saturating_sub(1)` floor at the `X=0` boundary. O(log cap) evaluations of
 /// `predicate` versus the linear scan's O(cap); identical result by monotonicity.
-fn largest_x_satisfying(formula_max: u32, predicate: impl Fn(u32) -> bool) -> u32 {
+///
+/// Returns `None` when the predicate holds for every `u32`, i.e. it bounds
+/// nothing and this search has no answer to give. A monotone gate is allowed to
+/// be *constant* true, and the caller — not this function — owns what to do
+/// then: `saturating_mul` pins `hi` at `u32::MAX`, so a `while predicate(hi)`
+/// ascent would spin there forever rather than terminate.
+fn largest_x_satisfying(formula_max: u32, predicate: impl Fn(u32) -> bool) -> Option<u32> {
     if !predicate(0) {
-        return 0;
+        return Some(0);
     }
 
     // Exponential probe: grow `hi` off `formula_max` until `predicate(hi)` is
@@ -12112,10 +12131,13 @@ fn largest_x_satisfying(formula_max: u32, predicate: impl Fn(u32) -> bool) -> u3
     // overflow; `max(saturating_add(1))` guards `hi == 0`.
     let mut hi = formula_max.max(1);
     while predicate(hi) {
+        if hi == u32::MAX {
+            return None;
+        }
         hi = hi.saturating_mul(2).max(hi.saturating_add(1));
     }
 
-    largest_x_satisfying_at_most(hi - 1, predicate)
+    Some(largest_x_satisfying_at_most(hi - 1, predicate))
 }
 
 /// Largest `x` not exceeding `max` for which a monotone true-prefix predicate
@@ -14231,10 +14253,30 @@ mod tests {
         }
     }
 
+    /// A gate that never closes bounds nothing, and the search must say so
+    /// instead of ascending forever. This is the shape an additional cost's
+    /// `{X}` produces (kicker `{X}` on a spell whose printed cost has no X):
+    /// the recomputed spell total does not move with X, so the gate is constant
+    /// true. `linear_x_reference` is deliberately not consulted here — it would
+    /// not terminate either, which is precisely why the reference cannot answer
+    /// this case.
+    #[test]
+    fn largest_x_satisfying_reports_an_unbounded_gate() {
+        assert_eq!(largest_x_satisfying(0, |_| true), None);
+        assert_eq!(largest_x_satisfying(u32::MAX, |_| true), None);
+        // A gate that closes at the very top is still bounded, and the answer
+        // is the last X that fits — not `None`.
+        assert_eq!(
+            largest_x_satisfying(0, |x| x < u32::MAX),
+            Some(u32::MAX - 1),
+        );
+    }
+
     /// `largest_x_satisfying` (exponential probe + bisection) must return the
     /// byte-identical X cap of the old linear ascent for every monotone cost
-    /// shape. Each shape models `concrete_cost_for_x(x).mana_value()` as a
-    /// monotone-non-decreasing function of X, then asserts the two searches agree.
+    /// shape that is actually bounded. Each shape models
+    /// `concrete_cost_for_x(x).mana_value()` as a monotone-non-decreasing
+    /// function of X, then asserts the two searches agree.
     #[test]
     fn largest_x_satisfying_matches_linear_reference() {
         // cost(x) = max(fixed + x * x_count - reduction, floor); predicate is
@@ -14256,7 +14298,7 @@ mod tests {
                             let formula_max = available.saturating_sub(fixed) / x_count;
                             assert_eq!(
                                 largest_x_satisfying(formula_max, predicate),
-                                linear_x_reference(predicate),
+                                Some(linear_x_reference(predicate)),
                                 "mismatch at available={available} fixed={fixed} \
                                  x_count={x_count} reduction={reduction} floor={floor}",
                             );

--- a/crates/engine/tests/integration/kicker_x_cap_search_termination.rs
+++ b/crates/engine/tests/integration/kicker_x_cap_search_termination.rs
@@ -1,0 +1,139 @@
+//! Kicker {X} — declaring the kicker must reach the X announcement with a
+//! finite cap (CR 601.2b: X is announced as part of determining the total cost).
+//!
+//! Before the fix the announcement was never reached at all. Declaring the
+//! kicker merges its `{X}` into `pending.cost`, so `enter_payment_step` asks
+//! `max_x_value_excluding` for the cap; that function refines the arithmetic
+//! bound by recomputing the spell's concrete total per X — from `base_cost`,
+//! which carries the spell's own mana cost and NOT the additional cost's `{X}`.
+//! For a spell whose printed mana cost has no X (Thieving Skydiver `{1}{U}`,
+//! Toxic Deluge, Hatred, …) that recomputed total does not move with X, so the
+//! monotone predicate is true for every X and the exponential probe in
+//! `largest_x_satisfying` doubled `hi` until `saturating_mul` pinned it at
+//! `u32::MAX` and it stopped growing — an endless loop. In the browser the
+//! engine worker simply never answered ("Engine took too long", 60 s watchdog).
+//!
+//! Built via the `/card-test` recipe: `GameScenario` + the real cast pipeline
+//! (`GameAction::CastSpell` -> `DecideOptionalCost`). The cast runs on its own
+//! thread with a large stack and a receive deadline, so a regression fails this
+//! test with a message instead of hanging CI or aborting the process on a
+//! stack overflow.
+//!
+//! REVERT DISCRIMINATOR: `paying_a_kicker_x_reaches_a_finite_x_cap`. Restore the
+//! unguarded probe and this test times out on the deadline below.
+
+use std::sync::mpsc;
+use std::time::Duration;
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::ability::{AbilityCost, AdditionalCost, AdditionalCostRepeatability};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{CastPaymentMode, WaitingFor};
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard};
+use engine::types::phase::Phase;
+
+/// A spell shaped like Thieving Skydiver (`data/card-data.json`): printed mana
+/// cost `{1}{U}`, plus the optional additional cost `Kicker {X}`. The oracle
+/// line is the flying keyword alone so the fixture isolates the cost path.
+fn cast_and_decide_kicker(lands: usize, pay_kicker: bool) -> WaitingFor {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let skydiver = scenario
+        .add_creature_to_hand_from_oracle(P0, "Kicker X Flier", 1, 1, "Flying")
+        .with_mana_cost(ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::Blue],
+        })
+        // CR 702.33a: "Kicker [cost]" is an optional additional cost.
+        .with_additional_cost(AdditionalCost::Kicker {
+            costs: vec![AbilityCost::Mana {
+                cost: ManaCost::Cost {
+                    generic: 0,
+                    shards: vec![ManaCostShard::X],
+                },
+            }],
+            repeatability: AdditionalCostRepeatability::Once,
+        })
+        .id();
+
+    for _ in 0..lands {
+        scenario.add_basic_land(P0, ManaColor::Blue);
+    }
+
+    let mut runner = scenario.build();
+    let card = runner.state().objects[&skydiver].card_id;
+    runner
+        .act(GameAction::CastSpell {
+            object_id: skydiver,
+            card_id: card,
+            targets: vec![],
+            payment_mode: CastPaymentMode::Auto,
+        })
+        .expect("P0 casts the kicker-{X} spell");
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalCostChoice { .. }
+        ),
+        "the kicker must be offered before X is announced (CR 601.2b)",
+    );
+
+    runner
+        .act(GameAction::DecideOptionalCost { pay: pay_kicker })
+        .expect("P0 decides the kicker");
+    runner.state().waiting_for.clone()
+}
+
+/// Run the cast off-thread so a non-terminating cap search is reported as a
+/// failed deadline rather than hanging the suite. The generous stack keeps a
+/// regression from aborting the whole test process with a stack overflow before
+/// the deadline can fire.
+fn decide_kicker_within(deadline: Duration, lands: usize, pay_kicker: bool) -> WaitingFor {
+    let (tx, rx) = mpsc::channel();
+    std::thread::Builder::new()
+        .stack_size(64 * 1024 * 1024)
+        .spawn(move || {
+            let _ = tx.send(cast_and_decide_kicker(lands, pay_kicker));
+        })
+        .expect("spawn the cast thread");
+    rx.recv_timeout(deadline)
+        .expect("declaring the kicker must terminate: the X cap search did not return")
+}
+
+/// PRIMARY REVERT DISCRIMINATOR. Eight Islands against a `{1}{U}` spell leave
+/// six mana for the kicker's `{X}` (CR 601.2f: the cap is what the caster can
+/// actually pay), and the announcement must be reached to offer it.
+#[test]
+fn paying_a_kicker_x_reaches_a_finite_x_cap() {
+    match decide_kicker_within(Duration::from_secs(30), 8, true) {
+        WaitingFor::ChooseXValue { max, .. } => assert_eq!(
+            max, 6,
+            "the kicker's X cap must be the mana left after the spell's own {{1}}{{U}}",
+        ),
+        other => panic!("expected the X announcement, got {other:?}"),
+    }
+}
+
+/// The cap tracks the actual pool, so it is not a constant the fix could have
+/// hard-coded: four Islands leave two.
+#[test]
+fn the_kicker_x_cap_tracks_available_mana() {
+    match decide_kicker_within(Duration::from_secs(30), 4, true) {
+        WaitingFor::ChooseXValue { max, .. } => assert_eq!(max, 2),
+        other => panic!("expected the X announcement, got {other:?}"),
+    }
+}
+
+/// Positive direction: declining the kicker never reached the cap search and
+/// must keep working exactly as before.
+#[test]
+fn declining_the_kicker_x_needs_no_x_announcement() {
+    assert!(
+        matches!(
+            decide_kicker_within(Duration::from_secs(30), 8, false),
+            WaitingFor::Priority { .. }
+        ),
+        "an undeclared kicker announces no X",
+    );
+}

--- a/crates/engine/tests/integration/kicker_x_cap_search_termination.rs
+++ b/crates/engine/tests/integration/kicker_x_cap_search_termination.rs
@@ -19,8 +19,9 @@
 //! test with a message instead of hanging CI or aborting the process on a
 //! stack overflow.
 //!
-//! REVERT DISCRIMINATOR: `paying_a_kicker_x_reaches_a_finite_x_cap`. Restore the
-//! unguarded probe and this test times out on the deadline below.
+//! REVERT DISCRIMINATOR: `paying_a_kicker_x_reaches_a_finite_x_cap`. Route
+//! additional-cost-only X through the unbounded probe and this test times out
+//! on the deadline below.
 
 use std::sync::mpsc;
 use std::time::Duration;

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -807,6 +807,7 @@ mod kaya_geist_hunter;
 mod kaya_spirits_justice_per_opponent_exile;
 mod kaysa_green_anthem;
 mod kibo_uktabi_prince_defending_player_sacrifice;
+mod kicker_x_cap_search_termination;
 mod kilo_live_offer_from_real_dump;
 mod kiora_self_library_peek_cast;
 mod knighthood_first_strike_grant;


### PR DESCRIPTION
Fixes #7982.

## What

Declaring a `Kicker {X}` merges the kicker's `{X}` into `pending.cost`, so `enter_payment_step` asks `max_x_value_excluding` for the X cap. That function refines its arithmetic bound by recomputing the spell's concrete total per candidate X — from `pending.base_cost`, which carries the spell's own printed mana cost and **not** the additional cost's `{X}`.

For a spell whose printed cost has no X, the recomputed total does not move with X. The monotone gate is constant true, and the exponential probe grew `hi` until `saturating_mul` pinned it at `u32::MAX`, where it stopped changing while the loop condition stayed true. The cast never returned; the client's 60 s watchdog reported "Engine took too long".

## Authority

`largest_x_satisfying` now returns `Option<u32>` and answers `None` when the gate holds for every `u32`. A monotone gate is allowed to be *constant* true; the search saying "I bound nothing" is a real answer, and the caller — not the search — owns what to do with it. The cap call site falls back to `formula_max`, which already subtracted the whole fixed portion of `pending.cost` (the spell's own pips included) from the available mana, so it is the honest cap in exactly that case.

## Tests

| test | polarity |
| --- | --- |
| `paying_a_kicker_x_reaches_a_finite_x_cap` | primary discriminator — 8 Islands, `{1}{U}` spell, cap must be 6 |
| `the_kicker_x_cap_tracks_available_mana` | 4 Islands → 2, so the cap is not a constant |
| `declining_the_kicker_x_needs_no_x_announcement` | positive direction: the unkicked path is untouched |
| `largest_x_satisfying_reports_an_unbounded_gate` | unit: constant-true gate → `None`; a gate that closes at `u32::MAX` still returns `Some(u32::MAX - 1)` |
| `largest_x_satisfying_matches_linear_reference` | the existing linear-ascent equivalence property, now over `Some(..)` |

The integration test drives the real pipeline (`CastSpell` → `DecideOptionalCost`) on its own thread with a receive deadline, so a regression fails with a message instead of hanging CI or aborting the process on a stack overflow.

Counter-probe: removing the `hi == u32::MAX` arm makes `paying_a_kicker_x_reaches_a_finite_x_cap` fail on the deadline after exactly 30 s (measured); restoring it returns the file to a byte-identical state.

## Class

Measured over `client/public/card-data.json` (35 798 cards): 17 cards carry an X in an additional cost; 3 of them also have X in their printed mana cost, so their gate does close and they already terminated. The remaining **14 froze**: Crashing Wave, Emblazoned Golem, Fire Covenant, Fix What's Broken, Foggy Swamp Visions, Hatred, Kangee Aerie Keeper, Nahiri's Sacrifice, Necrologia, Thieving Skydiver, Toxic Deluge, Verdeloth the Ancient, Vicious Rivalry, Waterbender's Restoration.

## Not covered

Cost reductions and floors are still applied to the recomputed spell total only, so they neither widen nor clamp an additional cost's X. Making the refinement see an additional cost's `{X}` would need `recompute_pending_mana_total` to carry it, which is a wider change than this freeze needs.

## Verification

| gate | result |
| --- | --- |
| `cargo test -p phase-engine --lib` | 19 836 passed, 0 failed |
| `cargo test --test integration` | 5 590 passed, 0 failed |
| `cargo clippy --all-targets -- -D warnings` | clean |

Played in the real client on this head: Thieving Skydiver cast on its own and kicked reaches the X announcement and pays; kicked under a Dauthi Voidwalker free-cast grant, the printed cost is waived while the kicker's X is still offered and paid normally (CR 118.8d — an additional cost is not waived by "without paying its mana cost").
