### PR TITLE
fix(client): show granted keyword badges on face-down permanents

### DIFF
--- a/client/src/components/board/PermanentCard.tsx
+++ b/client/src/components/board/PermanentCard.tsx
@@ -603,7 +603,10 @@ export const PermanentCard = memo(function PermanentCard({
   // read as tokens via their distinct generic-token art and are excluded.
   // CR 708.2: a face-down permanent has no characteristics other than those
   // its face-down rule grants, so never surface "Copy" on it — that would leak
-  // that it's a token-copy (matches the `!face_down` guard on the keyword strip).
+  // that it's a token-copy. Deliberately NOT symmetric with the keyword strip
+  // below, which does render for face-down permanents: the keywords it shows
+  // are public (the face-down rules' own ward, or an external grant), whereas
+  // being a copy is exactly the hidden fact.
   // Two independent ways a permanent is a copy, unioned so the badge covers the
   // whole class rather than only the token half (issue #5932):
   //   - a token minted as a copy (`is_token` + card art), and
@@ -1036,8 +1039,30 @@ export const PermanentCard = memo(function PermanentCard({
           (after the art-crop/full-card ternary) so it appears in BOTH display
           modes, and — being at the overflow-visible level, outside the rounded
           overflow-hidden art wrapper — the half-off-card portion isn't clipped.
-          Badge size scales off the active card width var. */}
-      {showKeywordStrip && battlefieldKeywordBadges.length > 0 && !obj.face_down && (
+          Badge size scales off the active card width var.
+
+          Face-down permanents render the strip too. CR 708.2 + CR 708.2a: a
+          face-down permanent has "no characteristics other than those listed by
+          the ability or rules that allowed" it to be face down, and the plain
+          default carries "no text" — so none of the hidden card's own abilities.
+          The engine strips them into `back_face` and reseeds the face-down
+          profile every layer pass, so what is left in this list is public
+          either way: the face-down rules' OWN grant (cloak enters with ward {2},
+          CR 701.58a; disguise likewise, CR 702.168a) or an external effect (an Aura's menace, a
+          lord's flying). A cloaked or disguised permanent therefore shows a
+          ward badge — that is the mechanic, not the hidden card. Suppressing
+          the strip here hid a keyword the blocker prompt already announced
+          ("needs 2") and that the rules make public. The engine owns and
+          documents the contract on `battlefield_keyword_badges` itself and pins
+          both halves (`face_down_keyword_badges_carry_only_granted_keywords`,
+          `a_face_down_profile_ward_is_badged_like_any_public_keyword`).
+
+          Known gap: `KeywordStrip` styles printed vs granted off
+          `base_keywords`, which `visibility.rs` clears for observers of a
+          face-down permanent — so the same ward reads as printed to its
+          controller and as granted to everyone else. Cosmetic only, and in the
+          safe direction; not addressed here. */}
+      {showKeywordStrip && battlefieldKeywordBadges.length > 0 && (
         <KeywordStrip
           keywords={battlefieldKeywordBadges}
           baseKeywords={obj.base_keywords}

--- a/client/src/components/board/__tests__/PermanentCard.test.tsx
+++ b/client/src/components/board/__tests__/PermanentCard.test.tsx
@@ -413,6 +413,25 @@ describe("PermanentCard", () => {
     expect(screen.getByTestId("keyword-strip")).not.toHaveTextContent("Evoke");
   });
 
+  // CR 708.2 + CR 708.2a: a face-down permanent carries none of the hidden
+  // card's own abilities, so a keyword the engine still reports for it was granted from
+  // outside (Killer's Mask equipped to the creature it manifested) and is public —
+  // the blocker prompt already announces it. The strip must render.
+  it("renders granted keyword badges on a face-down permanent", () => {
+    const gameState = makeState();
+    gameState.objects[1].face_down = true;
+    gameState.objects[1].keywords = [];
+    gameState.derived = {
+      battlefield_keyword_badges: { 1: ["Menace"] },
+    };
+    useGameStore.setState({ gameState, waitingFor: gameState.waiting_for });
+    usePreferencesStore.setState({ showKeywordStrip: true });
+
+    renderPermanent();
+
+    expect(screen.getByTestId("keyword-strip")).toHaveTextContent("Menace");
+  });
+
   // CR 732.2a / CR 701.34a: an accepted counter-growth ∞ loop (Kilo proliferate → Pentad
   // charge) annotates the pumped row in `derived.counter_display`; the pill renders ∞
   // instead of the (still-finite) real count. Matched pair — the ONLY difference between the

--- a/crates/engine/src/game/derived_views.rs
+++ b/crates/engine/src/game/derived_views.rs
@@ -608,6 +608,25 @@ pub struct DerivedViews {
     /// can render the compact strip without reinterpreting keyword timing.
     /// Keyed by object ID; absent when a permanent has no display-relevant
     /// keyword.
+    ///
+    /// CR 708.2 + CR 708.2a: face-down permanents are INCLUDED, unlike
+    /// `copied_permanents` below. A face-down permanent has "no characteristics
+    /// other than those listed by the ability or rules that allowed" it to be
+    /// face down, so every keyword it carries is public: the face-down rules'
+    /// own grant (cloak's ward {2}, CR 701.58a; disguise's, CR 702.168a) or an
+    /// external effect. The hidden card's own text is not here — the authority
+    /// for that is `morph::apply_face_down_creature_characteristics`, which
+    /// blanks `keywords`/`base_keywords` to the profile, plus layer 1's reseed
+    /// on every pass (pinned by `morph::tests::manifest_puts_top_card_face_down_as_2_2`).
+    ///
+    /// That invariant is deliberately NOT asserted in this loop: an externally
+    /// granted keyword legitimately lands in `base_keywords` too
+    /// (`PerpetualModification::GrantKeywords` puts it there on purpose so it
+    /// survives the layer reset, CR 613.1), so no local predicate here can tell
+    /// a leaked printed keyword from a granted one. Issue #7822 is what a real
+    /// leak looks like — a manifested planeswalker kept its loyalty and badged
+    /// it — and it was fixed at the stripping authority, which is where the
+    /// next one belongs too.
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub battlefield_keyword_badges: HashMap<ObjectId, Vec<Keyword>>,
 
@@ -3846,6 +3865,120 @@ mod tests {
             Zone::Battlefield,
         );
         assert!(derive_views(&state, None).copied_permanents.is_empty());
+    }
+
+    /// CR 708.2 + CR 708.2a: a face-down permanent has "no characteristics
+    /// other than those listed by the ability or rules that allowed" it to be
+    /// face down, and the plain default carries "no text" — none of the hidden
+    /// card's own
+    /// abilities — `manifest` strips them into `back_face` and layer 1 reseeds
+    /// the face-down profile on every pass. What such a permanent still carries
+    /// is public either way: the face-down rules' OWN grant (cloak enters with ward {2}, CR 701.58a;
+    /// disguise likewise, CR 702.168a — both via
+    /// `apply_face_down_creature_characteristics`)
+    /// or an external effect (an Aura's menace, a lord's flying). Neither is the
+    /// hidden card's text, which is why the badge strip can be rendered.
+    /// `PermanentCard` relies on exactly this contract; pin it here so the
+    /// client never has to re-derive it.
+    ///
+    /// What this test does NOT prove: it stays green with and without the
+    /// client change it backs (the diff touches no engine runtime), and it
+    /// writes the granted keyword straight onto the object instead of resolving
+    /// an Aura — the layer pass that would grant it is not exercised. The
+    /// stripping half is covered by `morph::tests::manifest_puts_top_card_face_down_as_2_2`,
+    /// CR 701.58a (cloak) + CR 702.168a (disguise): the OTHER half of the same
+    /// contract — such a permanent's ward {2} is part of being face down, not
+    /// the hidden card's text, so it belongs on the strip. Measured because the
+    /// sibling test's vanilla manifest profile carries no keyword at all and
+    /// would let a "face-down permanents never badge anything" reading pass.
+    ///
+    /// The profile is built by the authority that writes it
+    /// (`apply_face_down_creature_characteristics` + `FaceDownProfile::cloaked_2_2`)
+    /// and the expectation is read back out of that same profile, so a change
+    /// to the face-down ward moves the test with it instead of silently
+    /// leaving it green.
+    #[test]
+    fn a_face_down_profile_ward_is_badged_like_any_public_keyword() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        let cloaked = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Cloaked Card".into(),
+            Zone::Battlefield,
+        );
+        let profile = crate::types::ability::FaceDownProfile::cloaked_2_2();
+        crate::game::morph::apply_face_down_creature_characteristics(
+            state.objects.get_mut(&cloaked).unwrap(),
+            &profile,
+        );
+
+        let expected = Keyword::Ward(
+            profile
+                .ward
+                .clone()
+                .expect("the cloaked profile is the warded one"),
+        );
+        let views = derive_views(&state, None);
+        assert_eq!(
+            views.battlefield_keyword_badges.get(&cloaked),
+            Some(&vec![expected]),
+            "the face-down profile's own ward is public and belongs on the strip",
+        );
+    }
+
+    /// Like its ward sibling, this test stays green with and without the
+    /// client change it backs — it pins the engine-side contract, not the diff.
+    #[test]
+    fn face_down_keyword_badges_carry_only_granted_keywords() {
+        let mut state = GameState::new(FormatConfig::standard(), 2, 42);
+        let player = PlayerId(0);
+        let hidden = create_object(
+            &mut state,
+            CardId(1),
+            player,
+            "Hidden Flyer".into(),
+            Zone::Library,
+        );
+        {
+            let obj = state.objects.get_mut(&hidden).unwrap();
+            obj.power = Some(3);
+            obj.toughness = Some(3);
+            obj.card_types = crate::types::card_type::CardType {
+                supertypes: vec![],
+                core_types: vec![CoreType::Creature],
+                subtypes: vec![],
+            };
+            obj.keywords = vec![Keyword::Flying];
+            obj.base_keywords = obj.keywords.clone();
+        }
+
+        let mut events = Vec::new();
+        crate::game::morph::manifest(&mut state, player, &mut events)
+            .expect("manifest the top card face down");
+        assert!(
+            state.objects[&hidden].face_down,
+            "the fixture must actually be face down",
+        );
+
+        // What layer 6 writes onto the permanent while an Aura grants menace.
+        state.objects.get_mut(&hidden).unwrap().keywords = vec![Keyword::Menace];
+
+        let views = derive_views(&state, None);
+        assert_eq!(
+            views.battlefield_keyword_badges.get(&hidden),
+            Some(&vec![Keyword::Menace]),
+            "the granted keyword is public and belongs on the strip",
+        );
+        assert_eq!(
+            state.objects[&hidden]
+                .back_face
+                .as_ref()
+                .expect("the hidden card is kept for the turn-up")
+                .keywords,
+            vec![Keyword::Flying],
+            "the hidden card's own keyword still exists — and stayed off the strip",
+        );
     }
 
     #[test]


### PR DESCRIPTION
Fixes #8000.

## What

`PermanentCard` suppressed the whole keyword strip on `obj.face_down`, so a manifested creature equipped with Killer's Mask showed no menace badge even though declaring blockers already announced it ("needs 2").

The gate is wider than the information it protects. CR 708.2: a face-down permanent has "no characteristics other than those listed by the ability or rules that allowed" it to be face down; CR 708.2a's plain default carries "no text". The engine enforces that at the stripping authority — `apply_face_down_creature_characteristics` blanks the keyword lists to the profile, layer 1 reseeds them every pass, and `manifest_puts_top_card_face_down_as_2_2` pins `keywords.is_empty()`. What such a permanent still carries is public either way: the face-down rules' own grant (cloak's ward {2}, CR 701.58a; disguise's, CR 702.168a) or an external effect. Neither is the hidden card's text.

A cloaked or disguised permanent therefore now shows a ward badge. That is the mechanic, not a leak.

## Where the decision lives

In the engine, per the display rule. The contract is documented on `battlefield_keyword_badges` itself, beside `copied_permanents`, which excludes face-down permanents for the opposite and equally deliberate reason: being a token-copy IS the hidden fact.

**Deliberately no assertion in the projection loop.** An externally granted keyword legitimately lands in `base_keywords` too — `PerpetualModification::GrantKeywords` puts it there on purpose so it survives the layer reset (CR 613.1) — so no local predicate can tell a leaked printed keyword from a granted one, and an allowlist by keyword shape would both false-fire and miss a printed ward. #7822 is what a real leak looks like (a manifested planeswalker kept its loyalty and badged it); it was fixed at the stripping authority, which is where the next one belongs.

## Tests

| test | what it pins |
| --- | --- |
| `face_down_keyword_badges_carry_only_granted_keywords` | manifest profile: the granted menace is badged, the hidden Flying is not |
| `a_face_down_profile_ward_is_badged_like_any_public_keyword` | cloaked profile, built by `FaceDownProfile::cloaked_2_2` + the real applier, expectation read back out of that profile |
| `renders granted keyword badges on a face-down permanent` | the discriminating one |

Both engine tests stay green with and without the client change — they pin the engine-side contract, not the diff; that is stated at each test. Counter-probe on the discriminating test: restoring the `!obj.face_down` gate makes the strip disappear and the test fails on a missing `keyword-strip` element.

## Not covered

Battlefield strip only; the hover preview is a separate surface and unchanged. `KeywordStrip` styles printed vs granted off `base_keywords`, which `visibility.rs` clears for observers of a face-down permanent, so the same ward reads as printed to its controller and as granted to everyone else — cosmetic, in the safe direction, left alone here.

## Verification

| gate | result |
| --- | --- |
| `cargo test -p phase-engine --lib` | 19 855 passed, 0 failed |
| `cargo test --test integration` | 5 597 passed, 0 failed |
| `cargo clippy --all-targets -- -D warnings` | clean |
| `vitest run` (full suite) | 3 681 passed, 0 failed |

Played in the real client on this head: Killer's Mask manifests, equips, and the menace badge appears on the face-down 2/2.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Face-down permanents now display publicly available granted keyword badges, such as Menace or Ward.
  * Printed keywords and copy status remain hidden when a permanent is face down.

* **Bug Fixes**
  * Corrected keyword badge display for manifested and cloaked permanents, including cases where their visible keyword list is empty.

* **Tests**
  * Added coverage confirming that only publicly granted keywords appear on face-down permanents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->