### PR TITLE
Unify property aggregate sources

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -3626,14 +3626,14 @@ describe("P2P wire-protocol version gate", () => {
   // Both halves stamp LITERALS. A frame built from WIRE_PROTOCOL_VERSION
   // cannot tell a bumped client from an unbumped one, which is why every
   // other handshake fixture in the suite is useless as an instrument for a
-  // bump. Revert 34 → 33 and BOTH halves red: the v33 frame stops being
-  // refused, and the v34 frame stops being admitted. The admitting half is
-  // the reach-guard — without it "refuses v33" is also satisfied by a client
+  // bump. Revert 35 → 34 and BOTH halves red: the v34 frame stops being
+  // refused, and the v35 frame stops being admitted. The admitting half is
+  // the reach-guard — without it "refuses v34" is also satisfied by a client
   // that refuses everything.
-  it("refuses the previous wire protocol (v33) and admits its own (v34)", async () => {
+  it("refuses the previous wire protocol (v34) and admits its own (v35)", async () => {
     const refusing = makeGuest();
     await refusing.adapter.initialize();
-    await refusing.conn.simulateData(setupFrameAt(33));
+    await refusing.conn.simulateData(setupFrameAt(34));
 
     await expect(refusing.adapter.initializeGame()).rejects.toMatchObject({
       code: "P2P_REJECTED",
@@ -3645,7 +3645,7 @@ describe("P2P wire-protocol version gate", () => {
 
     const admitting = makeGuest();
     await admitting.adapter.initialize();
-    await admitting.conn.simulateData(setupFrameAt(34));
+    await admitting.conn.simulateData(setupFrameAt(35));
 
     await expect(admitting.adapter.initializeGame()).resolves.toBeDefined();
     expect(admitting.emitted).not.toHaveBeenCalledWith(

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -202,6 +202,12 @@ export class NativeEngineVersionMismatchError extends Error {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 46 — QuantityRef.Aggregate and QuantityRef.TrackedSetAggregate were
+ *      replaced in serialized GameState payloads by the canonical
+ *      QuantityRef.PropertyAggregate tag with a validated source object. New
+ *      peers migrate both old input tags, but a v45 peer cannot deserialize
+ *      the canonical tag emitted by v46, so the full-game handshake refuses
+ *      that one-way parse mismatch. Lobby messages are unchanged.
  * 45 — GameState gained serialized cast-occurrence provenance and prepared-copy links.
  * 44 — Resolution-time optional PayCost(OneOf) branch choice added a
  *      serialized WaitingFor/GameAction pair.
@@ -326,7 +332,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 45;
+export const PROTOCOL_VERSION = 46;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -36,8 +36,8 @@ const viewerInteractionWithProducedMana = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v34", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(34);
+  it("pins the P2P wire protocol to v35", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(35);
   });
 
   it("defaults shortcut actions for a legacy payload created before the additive field", () => {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -95,6 +95,11 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  * seat or adopts reconnect state.
  *
  * Bumps to date:
+ *  35 — QuantityRef.Aggregate and QuantityRef.TrackedSetAggregate were
+ *       replaced in GameState snapshots by the canonical
+ *       QuantityRef.PropertyAggregate tag with a validated source object. New
+ *       peers migrate both legacy input tags, but a v34 peer cannot parse the
+ *       canonical tag emitted by v35, so P2P first contact rejects the skew.
  *  34 — GameState gained serialized cast-occurrence provenance and prepared-copy links.
  *  33 — Resolution-time optional PayCost(OneOf) branch choice added a
  *       serialized WaitingFor/GameAction pair.
@@ -198,7 +203,7 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *       sub-phase on WaitingFor::MulliganDecision; the MulliganBottomCards
  *       variant was removed
  */
-export const WIRE_PROTOCOL_VERSION = 34 as const;
+export const WIRE_PROTOCOL_VERSION = 35 as const;
 
 export type P2PMessage = P2PAuthorityWire & (
   | {

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -2177,7 +2177,7 @@ fn legacy_quantity_ref(x: &QuantityRef) -> bool {
         | QuantityRef::DistinctColorsAmong { .. }
         | QuantityRef::CountersOnObjects { .. }
         | QuantityRef::DistinctCounterKindsAmong { .. }
-        | QuantityRef::Aggregate { .. }
+        | QuantityRef::PropertyAggregate(_)
         | QuantityRef::PlayerCount { .. }
         | QuantityRef::EventContextPlayerCount { .. }
         | QuantityRef::TargetObjectManaValue { .. }
@@ -2195,7 +2195,6 @@ fn legacy_quantity_ref(x: &QuantityRef) -> bool {
         | QuantityRef::ExiledCardPower { .. }
         | QuantityRef::TrackedSetSize
         | QuantityRef::FilteredTrackedSetSize { .. }
-        | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
         | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::PreviousEffectCount
@@ -6203,11 +6202,32 @@ fn rw_quantity_ref(x: &QuantityRef) -> RwProfile {
         | QuantityRef::DistinctCounterKindsAmong { filter } => {
             board_value_aggregate_read(filter, StateKind::ObjectCounters)
         }
-        QuantityRef::Aggregate {
-            filter,
-            function: _,
-            property: _,
-        } => board_value_aggregate_read(filter, StateKind::ObjectPt),
+        QuantityRef::PropertyAggregate(aggregate) => {
+            let mut profile = characteristic_source_read_bounded(aggregate.source());
+            let mut reads_live_object = false;
+            let mut reads_tracked = false;
+            aggregate.source().try_for_each_member(
+                crate::types::ability::UNION_DEPTH_BUDGET,
+                &mut |leaf| match leaf {
+                    CardTypeSetSource::TurnJournal { .. } => {}
+                    CardTypeSetSource::TrackedSet { .. } => {
+                        reads_live_object = true;
+                        reads_tracked = true;
+                    }
+                    CardTypeSetSource::Zone { .. }
+                    | CardTypeSetSource::ExiledBySource
+                    | CardTypeSetSource::Objects { .. } => reads_live_object = true,
+                    CardTypeSetSource::AnyOf { .. } => {}
+                },
+            );
+            if reads_live_object {
+                profile.merge(reads_board_of(StateKind::ObjectPt));
+            }
+            if reads_tracked {
+                profile.reads_member_bound = true;
+            }
+            profile
+        }
         QuantityRef::PlayerCount { filter: _ } => RwProfile::empty(),
         QuantityRef::EventContextPlayerCount { filter: _ } => reads_event_live(),
         QuantityRef::CountersOn { scope, .. } | QuantityRef::Intensity { scope, .. } => {
@@ -6265,15 +6285,6 @@ fn rw_quantity_ref(x: &QuantityRef) -> RwProfile {
         //     for any non-legacy-12 ref (ability_rw.rs `ability_rw_profile`),
         //     collapsing that mirror to a fail-open read-live path. So fail-closed
         //     member-bound is the correct, not merely safe, verdict.
-        QuantityRef::TrackedSetAggregate {
-            function: _,
-            property: _,
-            source: _,
-        } => {
-            let mut p = RwProfile::empty();
-            p.reads_member_bound = true;
-            p
-        }
         // CR 603.10a (PR-6.75 c5): per-source tracked/exiled/chosen storage and
         // per-instance cast-context memory (X paid, kicker/convoke/vote/additional-
         // cost counts) are bound per member instance — each trigger stack object
@@ -7084,10 +7095,83 @@ fn rw_controller_ref(x: &ControllerRef) -> RwProfile {
 mod tests {
     use super::*;
     use crate::types::ability::{
-        AbilityKind, ChoiceType, Comparator, CountScope, PtValue, TargetSelectionMode,
+        AbilityKind, AggregateFunction, ChoiceType, Comparator, CountScope, PtValue,
+        TargetSelectionMode,
     };
 
     use crate::game::test_fixtures::mana_fixture_roles;
+
+    #[test]
+    fn property_aggregate_source_rw_profiles_are_exhaustive() {
+        use crate::types::ability::{
+            CardTypeSetSource, ObjectProperty, PropertyAggregate, TrackedAnaphorSource,
+            TurnJournalKind, ZoneRef,
+        };
+
+        fn expected(source: &CardTypeSetSource) -> RwProfile {
+            let mut profile = characteristic_source_read_bounded(source);
+            let mut live = false;
+            let mut tracked = false;
+            source.try_for_each_member(crate::types::ability::UNION_DEPTH_BUDGET, &mut |leaf| {
+                match leaf {
+                    CardTypeSetSource::TurnJournal { .. } => {}
+                    CardTypeSetSource::TrackedSet { .. } => {
+                        live = true;
+                        tracked = true;
+                    }
+                    CardTypeSetSource::Zone { .. }
+                    | CardTypeSetSource::ExiledBySource
+                    | CardTypeSetSource::Objects { .. } => live = true,
+                    CardTypeSetSource::AnyOf { .. } => unreachable!("walker flattens unions"),
+                }
+            });
+            if live {
+                profile.merge(reads_board_of(StateKind::ObjectPt));
+            }
+            if tracked {
+                profile.reads_member_bound = true;
+            }
+            profile
+        }
+
+        let objects = CardTypeSetSource::Objects {
+            filter: TargetFilter::Any,
+        };
+        let journal = CardTypeSetSource::TurnJournal {
+            journal: TurnJournalKind::SpellsCast,
+            scope: CountScope::Controller,
+            filter: None,
+        };
+        let sources = vec![
+            CardTypeSetSource::Zone {
+                zone: ZoneRef::Graveyard,
+                scope: CountScope::Controller,
+            },
+            CardTypeSetSource::ExiledBySource,
+            objects.clone(),
+            CardTypeSetSource::TrackedSet {
+                set: TrackedAnaphorSource::ChainSet,
+                caused_by: None,
+            },
+            CardTypeSetSource::TrackedSet {
+                set: TrackedAnaphorSource::TriggeringBatch,
+                caused_by: None,
+            },
+            journal.clone(),
+            CardTypeSetSource::any_of(vec![objects, journal]).unwrap(),
+        ];
+        for source in sources {
+            let qty = QuantityRef::PropertyAggregate(
+                PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::ManaValue,
+                    source.clone(),
+                )
+                .unwrap(),
+            );
+            assert_eq!(rw_quantity_ref(&qty), expected(&source), "{source:?}");
+        }
+    }
 
     /// Row 14. CR 603.3b: the same-event ordering gate reads this profile, and
     /// an OMITTED read is FAIL-OPEN. Every `CardTypeSetSource` must therefore map

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -103,10 +103,10 @@
 use crate::types::ability::FilterProp;
 use crate::types::ability::{
     AbilityCondition, AbilityDefinition, CardTypeSetSource, ContinuousModification, ControllerRef,
-    Duration, Effect, GuessSubject, ModalChoice, MultiTargetSpec, ObjectScope, PlayerFilter,
-    PlayerScope, QuantityExpr, QuantityRef, RepeatContinuation, ReplacementDefinition,
-    ResolvedAbility, StaticCondition, StaticDefinition, TargetFilter, TriggerCondition,
-    TriggerDefinition, TurnJournalKind, TypeFilter, TypedFilter, ZoneRef,
+    Duration, Effect, GuessSubject, ModalChoice, MultiTargetSpec, ObjectProperty, ObjectScope,
+    PlayerFilter, PlayerScope, QuantityExpr, QuantityRef, RepeatContinuation,
+    ReplacementDefinition, ResolvedAbility, StaticCondition, StaticDefinition, TargetFilter,
+    TriggerCondition, TriggerDefinition, TurnJournalKind, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::game_state::TargetSelectionConstraint;
 use crate::types::zones::Zone;
@@ -6222,9 +6222,14 @@ fn rw_quantity_ref(x: &QuantityRef) -> RwProfile {
             );
             if reads_live_object {
                 profile.merge(reads_board_of(StateKind::ObjectPt));
-                // CR 613.4: live-object property aggregates read current P/T,
-                // so +1/+1-counter writes can feed the aggregate read.
-                profile.current_pt_reads.add(PtReadScope::Board);
+                // CR 613.4: +1/+1-counter writes feed live current-P/T
+                // aggregates, but not intrinsic mana-value/symbol reads.
+                if matches!(
+                    aggregate.property(),
+                    ObjectProperty::Power | ObjectProperty::Toughness
+                ) {
+                    profile.current_pt_reads.add(PtReadScope::Board);
+                }
             }
             if reads_tracked {
                 profile.reads_member_bound = true;
@@ -7098,8 +7103,8 @@ fn rw_controller_ref(x: &ControllerRef) -> RwProfile {
 mod tests {
     use super::*;
     use crate::types::ability::{
-        AbilityKind, AggregateFunction, ChoiceType, Comparator, CountScope, ObjectProperty,
-        PropertyAggregate, PtValue, TargetSelectionMode,
+        AbilityKind, AggregateFunction, ChoiceType, Comparator, CountScope, PropertyAggregate,
+        PtValue, TargetSelectionMode,
     };
 
     use crate::game::test_fixtures::mana_fixture_roles;
@@ -7130,7 +7135,6 @@ mod tests {
             });
             if live {
                 profile.merge(reads_board_of(StateKind::ObjectPt));
-                profile.current_pt_reads.add(PtReadScope::Board);
             }
             if tracked {
                 profile.reads_member_bound = true;
@@ -7911,6 +7915,18 @@ mod tests {
             qcheck(QuantityRef::PropertyAggregate(aggregate), 6),
         );
         assert!(conflicts(&a, &batch()));
+
+        let mana_value = PropertyAggregate::new(
+            AggregateFunction::Max,
+            ObjectProperty::ManaValue,
+            CardTypeSetSource::Objects { filter: creature() },
+        )
+        .expect("live-object mana-value aggregate");
+        let control = cond(
+            ra(put_counter_all(qfix(1), creature())),
+            qcheck(QuantityRef::PropertyAggregate(mana_value), 6),
+        );
+        assert!(!conflicts(&control, &batch()));
     }
 
     #[test]

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -6222,6 +6222,9 @@ fn rw_quantity_ref(x: &QuantityRef) -> RwProfile {
             );
             if reads_live_object {
                 profile.merge(reads_board_of(StateKind::ObjectPt));
+                // CR 613.4: live-object property aggregates read current P/T,
+                // so +1/+1-counter writes can feed the aggregate read.
+                profile.current_pt_reads.add(PtReadScope::Board);
             }
             if reads_tracked {
                 profile.reads_member_bound = true;
@@ -7095,8 +7098,8 @@ fn rw_controller_ref(x: &ControllerRef) -> RwProfile {
 mod tests {
     use super::*;
     use crate::types::ability::{
-        AbilityKind, AggregateFunction, ChoiceType, Comparator, CountScope, PtValue,
-        TargetSelectionMode,
+        AbilityKind, AggregateFunction, ChoiceType, Comparator, CountScope, ObjectProperty,
+        PropertyAggregate, PtValue, TargetSelectionMode,
     };
 
     use crate::game::test_fixtures::mana_fixture_roles;
@@ -7127,6 +7130,7 @@ mod tests {
             });
             if live {
                 profile.merge(reads_board_of(StateKind::ObjectPt));
+                profile.current_pt_reads.add(PtReadScope::Board);
             }
             if tracked {
                 profile.reads_member_bound = true;
@@ -7892,6 +7896,21 @@ mod tests {
             qcheck(power_src(), 6),
         );
         assert!(conflicts(&a, &se()));
+    }
+
+    #[test]
+    fn property_aggregate_live_power_read_vs_board_counter_write_conflict() {
+        let aggregate = PropertyAggregate::new(
+            AggregateFunction::Max,
+            ObjectProperty::Power,
+            CardTypeSetSource::Objects { filter: creature() },
+        )
+        .expect("live-object power aggregate");
+        let a = cond(
+            ra(put_counter_all(qfix(1), creature())),
+            qcheck(QuantityRef::PropertyAggregate(aggregate), 6),
+        );
+        assert!(conflicts(&a, &batch()));
     }
 
     #[test]

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1895,11 +1895,17 @@ fn scan_property_aggregate_source(source: &CardTypeSetSource, mode: ScanMode) ->
                     set: TrackedAnaphorSource::ChainSet,
                     ..
                 } => Axes::NONE,
-                CardTypeSetSource::TurnJournal { .. } => Axes {
+                // CR 603.3b: the journal population is projected turn state,
+                // while an optional event-relative filter still reads the
+                // triggering event and must participate in trigger ordering.
+                CardTypeSetSource::TurnJournal { filter, .. } => Axes {
                     event: false,
                     sibling: false,
                     projected: true,
-                },
+                }
+                .or(filter.as_ref().map_or(Axes::NONE, |filter| {
+                    scan_target_filter(filter, FilterReadContext::SnapshotOrEvent, mode)
+                })),
                 CardTypeSetSource::Zone { .. } | CardTypeSetSource::ExiledBySource => {
                     Axes::CONSERVATIVE
                 }
@@ -6468,6 +6474,11 @@ mod tests {
             scope: CountScope::Controller,
             filter: None,
         };
+        let event_filtered_journal = CardTypeSetSource::TurnJournal {
+            journal: TurnJournalKind::SpellsCast,
+            scope: CountScope::Controller,
+            filter: Some(TargetFilter::TriggeringSource),
+        };
         let rows = vec![
             (
                 CardTypeSetSource::Objects {
@@ -6495,6 +6506,14 @@ mod tests {
                 journal.clone(),
                 Axes {
                     event: false,
+                    sibling: false,
+                    projected: true,
+                },
+            ),
+            (
+                event_filtered_journal,
+                Axes {
+                    event: true,
                     sibling: false,
                     projected: true,
                 },

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -92,8 +92,8 @@
 //! for the conflict model and its CR 603.3b commutation argument.
 
 use crate::types::ability::{
-    AbilityCondition, AbilityCost, AbilityDefinition, ContinuousModification, ControllerRef,
-    CountScope, Duration, EachDamageRecipient, Effect, EffectScope, FilterProp,
+    AbilityCondition, AbilityCost, AbilityDefinition, CardTypeSetSource, ContinuousModification,
+    ControllerRef, CountScope, Duration, EachDamageRecipient, Effect, EffectScope, FilterProp,
     ForEachCategoryAction, GuessSubject, KeeperConstraint, ManaProduction, ModalChoice,
     MultiTargetSpec, ObjectScope, PlayerFilter, PlayerScope, PtValue, QuantityExpr, QuantityRef,
     RepeatContinuation, ReplacementCondition, ResolvedAbility, StaticCondition, TargetFilter,
@@ -1868,6 +1868,51 @@ fn scan_effect(x: &Effect, mode: ScanMode) -> Axes {
     }
 }
 
+fn scan_property_aggregate_source(source: &CardTypeSetSource, mode: ScanMode) -> Axes {
+    let mut axes = Axes::NONE;
+    let complete =
+        source.try_for_each_member(crate::types::ability::UNION_DEPTH_BUDGET, &mut |leaf| {
+            axes = axes.or(match leaf {
+                CardTypeSetSource::Objects { filter } => Axes {
+                    event: false,
+                    sibling: true,
+                    projected: false,
+                }
+                .or(scan_target_filter(
+                    filter,
+                    FilterReadContext::LiveBoardCensus,
+                    mode,
+                )),
+                CardTypeSetSource::TrackedSet {
+                    set: TrackedAnaphorSource::TriggeringBatch,
+                    ..
+                } => Axes {
+                    event: true,
+                    sibling: false,
+                    projected: false,
+                },
+                CardTypeSetSource::TrackedSet {
+                    set: TrackedAnaphorSource::ChainSet,
+                    ..
+                } => Axes::NONE,
+                CardTypeSetSource::TurnJournal { .. } => Axes {
+                    event: false,
+                    sibling: false,
+                    projected: true,
+                },
+                CardTypeSetSource::Zone { .. } | CardTypeSetSource::ExiledBySource => {
+                    Axes::CONSERVATIVE
+                }
+                CardTypeSetSource::AnyOf { .. } => Axes::NONE,
+            });
+        });
+    if complete {
+        axes
+    } else {
+        Axes::CONSERVATIVE
+    }
+}
+
 fn scan_quantity_ref(x: &QuantityRef, mode: ScanMode) -> Axes {
     match x {
         QuantityRef::HandSize { player, .. } => {
@@ -2093,22 +2138,8 @@ fn scan_quantity_ref(x: &QuantityRef, mode: ScanMode) -> Axes {
             acc
         }
         QuantityRef::SelfManaValue => Axes::NONE,
-        QuantityRef::Aggregate {
-            filter,
-            function: _,
-            property: _,
-        } => {
-            let mut acc = Axes {
-                event: false,
-                sibling: true,
-                projected: false,
-            };
-            acc = acc.or(scan_target_filter(
-                filter,
-                FilterReadContext::LiveBoardCensus,
-                mode,
-            ));
-            acc
+        QuantityRef::PropertyAggregate(aggregate) => {
+            scan_property_aggregate_source(aggregate.source(), mode)
         }
         QuantityRef::ControlledByEachPlayer {
             filter,
@@ -2176,21 +2207,6 @@ fn scan_quantity_ref(x: &QuantityRef, mode: ScanMode) -> Axes {
             ));
             acc
         }
-        QuantityRef::TrackedSetAggregate {
-            function: _,
-            property: _,
-            source,
-        } => match source {
-            // Chain-published set: reads no trigger/sibling context (unchanged).
-            TrackedAnaphorSource::ChainSet => Axes::NONE,
-            // Reads `state.current_trigger_events` (the triggering event) →
-            // event axis true, mirroring `QuantityRef::EventContextAmount` below.
-            TrackedAnaphorSource::TriggeringBatch => Axes {
-                event: true,
-                sibling: false,
-                projected: false,
-            },
-        },
         QuantityRef::ExiledFromHandThisResolution => Axes::NONE,
         // CR 608.2c + CR 608.2i: every channel and every aggregate reads
         // resolution-local state — `last_effect_amount` /
@@ -6435,6 +6451,88 @@ mod tests {
     use crate::types::identifiers::ObjectId;
     use crate::types::mana::ManaColor;
     use crate::types::player::{PlayerCounterKind, PlayerId};
+
+    #[test]
+    fn property_aggregate_source_scan_axes_are_exhaustive() {
+        use crate::types::ability::{
+            CardTypeSetSource, CountScope, ObjectProperty, PropertyAggregate, TrackedAnaphorSource,
+            TurnJournalKind, ZoneRef,
+        };
+
+        let chain = CardTypeSetSource::TrackedSet {
+            set: TrackedAnaphorSource::ChainSet,
+            caused_by: None,
+        };
+        let journal = CardTypeSetSource::TurnJournal {
+            journal: TurnJournalKind::SpellsCast,
+            scope: CountScope::Controller,
+            filter: None,
+        };
+        let rows = vec![
+            (
+                CardTypeSetSource::Objects {
+                    filter: TargetFilter::Any,
+                },
+                Axes {
+                    event: false,
+                    sibling: true,
+                    projected: false,
+                },
+            ),
+            (
+                CardTypeSetSource::TrackedSet {
+                    set: TrackedAnaphorSource::TriggeringBatch,
+                    caused_by: None,
+                },
+                Axes {
+                    event: true,
+                    sibling: false,
+                    projected: false,
+                },
+            ),
+            (chain.clone(), Axes::NONE),
+            (
+                journal.clone(),
+                Axes {
+                    event: false,
+                    sibling: false,
+                    projected: true,
+                },
+            ),
+            (
+                CardTypeSetSource::Zone {
+                    zone: ZoneRef::Graveyard,
+                    scope: CountScope::Controller,
+                },
+                Axes::CONSERVATIVE,
+            ),
+            (CardTypeSetSource::ExiledBySource, Axes::CONSERVATIVE),
+            (
+                CardTypeSetSource::any_of(vec![chain, journal]).unwrap(),
+                Axes {
+                    event: false,
+                    sibling: false,
+                    projected: true,
+                },
+            ),
+        ];
+        for (source, expected) in rows {
+            let qty = QuantityRef::PropertyAggregate(
+                PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::ManaValue,
+                    source.clone(),
+                )
+                .unwrap(),
+            );
+            let actual = scan_quantity_ref(&qty, ScanMode::Conservative);
+            assert_eq!(
+                (actual.event, actual.sibling, actual.projected),
+                (expected.event, expected.sibling, expected.projected),
+                "{source:?}"
+            );
+        }
+    }
 
     fn ability_with_amount(qty: QuantityRef) -> ResolvedAbility {
         ResolvedAbility::new(

--- a/crates/engine/src/game/ability_utils.rs
+++ b/crates/engine/src/game/ability_utils.rs
@@ -4662,7 +4662,6 @@ fn quantity_ref_target_slot_spec(qty: &QuantityRef) -> Option<TargetFilter> {
         | QuantityRef::ObjectCountDistinct { filter, .. }
         | QuantityRef::ObjectCountBySharedQuality { filter, .. }
         | QuantityRef::CountersOnObjects { filter, .. }
-        | QuantityRef::Aggregate { filter, .. }
         | QuantityRef::EnteredThisTurn { filter }
         // CR 608.2i: the look-back sibling of `EnteredThisTurn` carries the same
         // kind of population filter, so it must reach the same recursion instead
@@ -4685,6 +4684,9 @@ fn quantity_ref_target_slot_spec(qty: &QuantityRef) -> Option<TargetFilter> {
         | QuantityRef::DistinctSubtypes { source, .. }
         | QuantityRef::DistinctColorsAmong { source } => {
             characteristic_source_target_slot_filter(source)
+        }
+        QuantityRef::PropertyAggregate(aggregate) => {
+            characteristic_source_target_slot_filter(aggregate.source())
         }
         QuantityRef::ManaSpentToCast { metric, .. } => match metric {
             CastManaSpentMetric::FromSource { source_filter } => {
@@ -14455,11 +14457,16 @@ mod tests {
         assert!(filter_references_target_creature_quantity(&shares_quality));
 
         let aggregate = QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: AggregateFunction::Max,
-                property: ObjectProperty::ManaValue,
-                filter: target_power_filter(),
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Max,
+                    ObjectProperty::ManaValue,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: target_power_filter(),
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         };
         assert!(quantity_expr_references_target_creature(&aggregate));
 

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -1,13 +1,13 @@
 use crate::types::ability::{
     is_variable_remove_counter_cost_count, AbilityBlockKind, AbilityBlockReason, AbilityCondition,
     AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, ActivationManaPaymentRestriction,
-    AdditionalCost, BoardWideCostModifier, CardPlayMode, CardSelectionMode, CastTimingPermission,
-    CastingPermission, ChoiceType, ContinuousModification, CostObjectCount, CostPaidObjectSnapshot,
-    CounterCostSelection, Duration, Effect, EffectKind, FilterProp, GameRestriction,
-    ModalSelectionCondition, ObjectScope, PlayerFilter, PlayerScope, ProhibitedActivity,
-    QuantityExpr, QuantityRef, ResolvedAbility, RestrictionExpiry, RestrictionPlayerScope,
-    StaticCondition, StaticDefinition, SubAbilityLink, TapCreaturesRequirement, TargetFilter,
-    TargetRef, TypeFilter,
+    AdditionalCost, BoardWideCostModifier, CardPlayMode, CardSelectionMode, CardTypeSetSource,
+    CastTimingPermission, CastingPermission, ChoiceType, ContinuousModification, CostObjectCount,
+    CostPaidObjectSnapshot, CounterCostSelection, Duration, Effect, EffectKind, FilterProp,
+    GameRestriction, ModalSelectionCondition, ObjectScope, PlayerFilter, PlayerScope,
+    ProhibitedActivity, QuantityExpr, QuantityRef, ResolvedAbility, RestrictionExpiry,
+    RestrictionPlayerScope, StaticCondition, StaticDefinition, SubAbilityLink,
+    TapCreaturesRequirement, TargetFilter, TargetRef, TypeFilter,
 };
 use crate::types::actions::{AlternativeCastDecision, GameAction};
 use crate::types::card::LayoutKind;
@@ -19241,8 +19241,24 @@ fn quantity_ref_is_board_state_relative(qty: &QuantityRef) -> bool {
         QuantityRef::LifeAboveStarting | QuantityRef::StartingLifeTotal => true,
         QuantityRef::ObjectCount { filter }
         | QuantityRef::ObjectCountDistinct { filter, .. }
-        | QuantityRef::CountersOnObjects { filter, .. }
-        | QuantityRef::Aggregate { filter, .. } => !filter_references_target_player(filter),
+        | QuantityRef::CountersOnObjects { filter, .. } => !filter_references_target_player(filter),
+        QuantityRef::PropertyAggregate(aggregate) => {
+            let mut relative = true;
+            let complete = aggregate.source().try_for_each_member(
+                crate::types::ability::UNION_DEPTH_BUDGET,
+                &mut |leaf| match leaf {
+                    CardTypeSetSource::Objects { filter } => {
+                        relative &= !filter_references_target_player(filter);
+                    }
+                    CardTypeSetSource::Zone { .. } => {}
+                    CardTypeSetSource::ExiledBySource
+                    | CardTypeSetSource::TrackedSet { .. }
+                    | CardTypeSetSource::TurnJournal { .. }
+                    | CardTypeSetSource::AnyOf { .. } => relative = false,
+                },
+            );
+            complete && relative
+        }
         QuantityRef::CountersOn { scope, .. }
         | QuantityRef::Power { scope }
         | QuantityRef::BasePower { scope }

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -1738,15 +1738,20 @@ fn ability_condition_currently_met_gates_on_board_relative_quantity() {
     );
     let your_power_ge_10 = AbilityCondition::QuantityCheck {
         lhs: QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: crate::types::ability::AggregateFunction::Sum,
-                property: crate::types::ability::ObjectProperty::Power,
-                filter: TargetFilter::Typed(
-                    crate::types::ability::TypedFilter::default()
-                        .with_type(crate::types::ability::TypeFilter::Creature)
-                        .controller(crate::types::ability::ControllerRef::You),
-                ),
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    crate::types::ability::AggregateFunction::Sum,
+                    crate::types::ability::ObjectProperty::Power,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::Typed(
+                            crate::types::ability::TypedFilter::default()
+                                .with_type(crate::types::ability::TypeFilter::Creature)
+                                .controller(crate::types::ability::ControllerRef::You),
+                        ),
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         },
         comparator: crate::types::ability::Comparator::GE,
         rhs: QuantityExpr::Fixed { value: 10 },
@@ -3383,23 +3388,28 @@ fn visions_of_ruin_flashback_commander_mv_reduces_flashback_cost() {
             mode: CostModifyMode::Reduce,
             amount: ManaCost::generic(1),
             spell_filter: None,
-            dynamic_count: Some(QuantityRef::Aggregate {
-                function: AggregateFunction::Max,
-                property: ObjectProperty::ManaValue,
-                filter: TargetFilter::Typed(
-                    TypedFilter::default()
-                        .with_type(TypeFilter::Creature)
-                        .properties(vec![
-                            FilterProp::IsCommander,
-                            FilterProp::Owned {
-                                controller: ControllerRef::You,
-                            },
-                            FilterProp::InAnyZone {
-                                zones: vec![Zone::Battlefield, Zone::Command],
-                            },
-                        ]),
-                ),
-            }),
+            dynamic_count: Some(QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Max,
+                    ObjectProperty::ManaValue,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::Typed(
+                            TypedFilter::default()
+                                .with_type(TypeFilter::Creature)
+                                .properties(vec![
+                                    FilterProp::IsCommander,
+                                    FilterProp::Owned {
+                                        controller: ControllerRef::You,
+                                    },
+                                    FilterProp::InAnyZone {
+                                        zones: vec![Zone::Battlefield, Zone::Command],
+                                    },
+                                ]),
+                        ),
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            )),
         })
         .affected(TargetFilter::SelfRef)
         .condition(StaticCondition::CastingAsVariant {
@@ -12027,11 +12037,18 @@ fn self_cost_reduction_applies_from_command_zone() {
             mode: CostModifyMode::Reduce,
             amount: ManaCost::generic(1),
             spell_filter: None,
-            dynamic_count: Some(QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::Power,
-                filter: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
-            }),
+            dynamic_count: Some(QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::Power,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::Typed(
+                            TypedFilter::creature().controller(ControllerRef::You),
+                        ),
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            )),
         })
         .affected(TargetFilter::SelfRef);
         def.active_zones = crate::types::zones::self_spell_cost_mod_active_zones();
@@ -50673,15 +50690,20 @@ fn cosmic_cube_dynamic_mv_ceiling_enforced_at_finalize() {
     let constraint = Some(CastPermissionConstraint::ManaValue {
         comparator: Comparator::LE,
         value: QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: AggregateFunction::Max,
-                property: ObjectProperty::Power,
-                filter: TargetFilter::Typed(TypedFilter {
-                    type_filters: vec![TypeFilter::Creature],
-                    controller: Some(ControllerRef::You),
-                    properties: vec![FilterProp::Attacking { defender: None }],
-                }),
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Max,
+                    ObjectProperty::Power,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::Typed(TypedFilter {
+                            type_filters: vec![TypeFilter::Creature],
+                            controller: Some(ControllerRef::You),
+                            properties: vec![FilterProp::Attacking { defender: None }],
+                        }),
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         },
     });
 

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -1515,23 +1515,24 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
             }
         }
         QuantityRef::SelfManaValue => "self mana value".into(),
-        QuantityRef::Aggregate {
-            function,
-            property,
-            filter,
-        } => {
-            let func = match function {
+        QuantityRef::PropertyAggregate(aggregate) => {
+            let func = match aggregate.function() {
                 AggregateFunction::Max => "max",
                 AggregateFunction::Min => "min",
                 AggregateFunction::Sum => "total",
             };
-            let prop = match property {
+            let prop = match aggregate.property() {
                 ObjectProperty::Power => "power",
                 ObjectProperty::Toughness => "toughness",
                 ObjectProperty::ManaValue => "mana value",
                 ObjectProperty::ManaSymbolCount(_) => "mana symbols",
             };
-            format!("{func} {prop} of {}", fmt_target(filter))
+            let population = if matches!(aggregate.source(), CardTypeSetSource::TrackedSet { .. }) {
+                "those cards".into()
+            } else {
+                fmt_characteristic_population_bounded(aggregate.source())
+            };
+            format!("{func} {prop} of {population}")
         }
         QuantityRef::Devotion { colors } => match colors {
             crate::types::ability::DevotionColors::Fixed(colors) => {
@@ -1641,24 +1642,6 @@ fn fmt_quantity_ref(qty: &QuantityRef) -> String {
         QuantityRef::TrackedSetSize => "cards moved".into(),
         QuantityRef::FilteredTrackedSetSize { filter, .. } => {
             format!("filtered tracked set ({})", fmt_target(filter))
-        }
-        QuantityRef::TrackedSetAggregate {
-            function,
-            property,
-            source: _,
-        } => {
-            let func = match function {
-                AggregateFunction::Max => "max",
-                AggregateFunction::Min => "min",
-                AggregateFunction::Sum => "total",
-            };
-            let prop = match property {
-                ObjectProperty::Power => "power",
-                ObjectProperty::Toughness => "toughness",
-                ObjectProperty::ManaValue => "mana value",
-                ObjectProperty::ManaSymbolCount(_) => "mana symbols",
-            };
-            format!("{func} {prop} of those cards")
         }
         QuantityRef::ExiledFromHandThisResolution => "cards exiled from hand this way".into(),
         QuantityRef::LifeLostThisTurn { player } => {
@@ -2383,7 +2366,7 @@ fn fmt_characteristic_population(source: &CardTypeSetSource) -> String {
         }
         CardTypeSetSource::ExiledBySource => "cards exiled with source".into(),
         CardTypeSetSource::Objects { filter } => fmt_target(filter),
-        CardTypeSetSource::TrackedSet { caused_by } => match caused_by {
+        CardTypeSetSource::TrackedSet { caused_by, .. } => match caused_by {
             Some(cause) => {
                 use crate::types::ability::ThisWayCause;
                 let verb = match cause {
@@ -8441,7 +8424,7 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
             ObjectScope::BatchSource => ("BatchSourceManaSymbolsInManaCost", Handled),
         },
         QuantityRef::SelfManaValue => ("SelfManaValue", Handled),
-        QuantityRef::Aggregate { .. } => ("Aggregate", Handled),
+        QuantityRef::PropertyAggregate(_) => ("PropertyAggregate", Handled),
         QuantityRef::Devotion { .. } => ("Devotion", Handled),
         QuantityRef::DistinctCardTypes { .. } => ("DistinctCardTypes", Handled),
         QuantityRef::DistinctSubtypes { .. } => ("DistinctSubtypes", Handled),
@@ -8456,7 +8439,6 @@ fn quantity_ref_feature(qref: &QuantityRef) -> (&'static str, FeatureSupport) {
         QuantityRef::PreviousEffectCount => ("PreviousEffectCount", Handled),
         QuantityRef::TrackedSetSize => ("TrackedSetSize", Handled),
         QuantityRef::FilteredTrackedSetSize { .. } => ("FilteredTrackedSetSize", Handled),
-        QuantityRef::TrackedSetAggregate { .. } => ("TrackedSetAggregate", Handled),
         QuantityRef::ExiledFromHandThisResolution => ("ExiledFromHandThisResolution", Handled),
         QuantityRef::LifeLostThisTurn { .. } => ("LifeLostThisTurn", Handled),
         QuantityRef::EventContextAmount => ("EventContextAmount", Handled),

--- a/crates/engine/src/game/effects/exile_top.rs
+++ b/crates/engine/src/game/effects/exile_top.rs
@@ -762,11 +762,17 @@ mod tests {
         let damage = ResolvedAbility::new(
             Effect::DealDamage {
                 amount: QuantityExpr::Ref {
-                    qty: QuantityRef::TrackedSetAggregate {
-                        function: AggregateFunction::Sum,
-                        property: ObjectProperty::ManaValue,
-                        source: crate::types::ability::TrackedAnaphorSource::ChainSet,
-                    },
+                    qty: QuantityRef::PropertyAggregate(
+                        crate::types::ability::PropertyAggregate::new(
+                            AggregateFunction::Sum,
+                            ObjectProperty::ManaValue,
+                            crate::types::ability::CardTypeSetSource::TrackedSet {
+                                set: crate::types::ability::TrackedAnaphorSource::ChainSet,
+                                caused_by: None,
+                            },
+                        )
+                        .expect("statically valid property aggregate"),
+                    ),
                 },
                 target: TargetFilter::Controller,
                 damage_source: None,

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -3363,7 +3363,6 @@ fn quantity_ref_counts_population_matching(
         | QuantityRef::ObjectCountDistinct { filter, .. }
         | QuantityRef::ObjectCountBySharedQuality { filter, .. }
         | QuantityRef::CountersOnObjects { filter, .. }
-        | QuantityRef::Aggregate { filter, .. }
         | QuantityRef::ControlledByEachPlayer { filter, .. }
         | QuantityRef::DistinctCounterKindsAmong { filter }
         | QuantityRef::EnteredThisTurn { filter }
@@ -3394,6 +3393,9 @@ fn quantity_ref_counts_population_matching(
         | QuantityRef::DistinctSubtypes { source, .. }
         | QuantityRef::DistinctColorsAmong { source } => {
             card_type_set_source_counts_population_matching(source, filter_pred)
+        }
+        QuantityRef::PropertyAggregate(aggregate) => {
+            card_type_set_source_counts_population_matching(aggregate.source(), filter_pred)
         }
         // No `TargetFilter` anywhere: player-scoped totals, per-object scopes,
         // resolution/turn counters, and cost bookkeeping.
@@ -3430,7 +3432,6 @@ fn quantity_ref_counts_population_matching(
         | QuantityRef::ExiledCardPower { .. }
         | QuantityRef::BasicLandTypeCount { .. }
         | QuantityRef::TrackedSetSize
-        | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
         | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::PreviousEffectCount
@@ -5765,7 +5766,6 @@ fn quantity_expr_references_tracked_set(qty: &QuantityExpr) -> bool {
         QuantityExpr::Ref { qty } => match qty {
             QuantityRef::TrackedSetSize
             | QuantityRef::FilteredTrackedSetSize { .. }
-            | QuantityRef::TrackedSetAggregate { .. }
             | QuantityRef::DistinctCardTypes {
                 source: CardTypeSetSource::TrackedSet { .. },
             }
@@ -5773,6 +5773,15 @@ fn quantity_expr_references_tracked_set(qty: &QuantityExpr) -> bool {
                 source: CardTypeSetSource::TrackedSet { .. },
                 ..
             } => true,
+            QuantityRef::PropertyAggregate(aggregate) => {
+                let mut found = false;
+                let complete = aggregate
+                    .source()
+                    .try_for_each_member(crate::types::ability::UNION_DEPTH_BUDGET, &mut |leaf| {
+                        found |= matches!(leaf, CardTypeSetSource::TrackedSet { .. })
+                    });
+                found || !complete
+            }
             // CR 608.2c: a player-count whose filter is keyed on the chain's
             // tracked object set is a CONSUMER of that set — the preceding
             // producer must publish it, or the count resolves to 0. This is the
@@ -16356,11 +16365,17 @@ mod tests {
     #[test]
     fn token_power_toughness_tracked_set_marks_ability_as_referencing_tracked_set() {
         let tracked_pt = PtValue::Quantity(QuantityExpr::Ref {
-            qty: QuantityRef::TrackedSetAggregate {
-                function: crate::types::ability::AggregateFunction::Sum,
-                property: crate::types::ability::ObjectProperty::Power,
-                source: crate::types::ability::TrackedAnaphorSource::ChainSet,
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    crate::types::ability::AggregateFunction::Sum,
+                    crate::types::ability::ObjectProperty::Power,
+                    crate::types::ability::CardTypeSetSource::TrackedSet {
+                        set: crate::types::ability::TrackedAnaphorSource::ChainSet,
+                        caused_by: None,
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         });
         let ability = ResolvedAbility::new(
             Effect::Token {
@@ -26089,13 +26104,18 @@ mod tests {
 
         let condition = AbilityCondition::QuantityCheck {
             lhs: QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Sum,
-                    property: ObjectProperty::Toughness,
-                    filter: TargetFilter::Typed(
-                        TypedFilter::creature().controller(ControllerRef::You),
-                    ),
-                },
+                qty: QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        AggregateFunction::Sum,
+                        ObjectProperty::Toughness,
+                        crate::types::ability::CardTypeSetSource::Objects {
+                            filter: TargetFilter::Typed(
+                                TypedFilter::creature().controller(ControllerRef::You),
+                            ),
+                        },
+                    )
+                    .expect("statically valid property aggregate"),
+                ),
             },
             comparator: Comparator::GE,
             rhs: QuantityExpr::Fixed { value: 40 },
@@ -26720,36 +26740,46 @@ mod tests {
             Effect::Token {
                 name: "Illusion".to_string(),
                 power: PtValue::Quantity(QuantityExpr::Ref {
-                    qty: QuantityRef::Aggregate {
-                        function: crate::types::ability::AggregateFunction::Sum,
-                        property: crate::types::ability::ObjectProperty::ManaValue,
-                        filter: TargetFilter::And {
-                            filters: vec![
-                                TargetFilter::ExiledBySource,
-                                TargetFilter::Typed(TypedFilter::default().properties(vec![
-                                    FilterProp::Owned {
-                                        controller: ControllerRef::You,
-                                    },
-                                ])),
-                            ],
-                        },
-                    },
+                    qty: QuantityRef::PropertyAggregate(
+                        crate::types::ability::PropertyAggregate::new(
+                            crate::types::ability::AggregateFunction::Sum,
+                            crate::types::ability::ObjectProperty::ManaValue,
+                            crate::types::ability::CardTypeSetSource::Objects {
+                                filter: TargetFilter::And {
+                                    filters: vec![
+                                        TargetFilter::ExiledBySource,
+                                        TargetFilter::Typed(TypedFilter::default().properties(
+                                            vec![FilterProp::Owned {
+                                                controller: ControllerRef::You,
+                                            }],
+                                        )),
+                                    ],
+                                },
+                            },
+                        )
+                        .expect("statically valid property aggregate"),
+                    ),
                 }),
                 toughness: PtValue::Quantity(QuantityExpr::Ref {
-                    qty: QuantityRef::Aggregate {
-                        function: crate::types::ability::AggregateFunction::Sum,
-                        property: crate::types::ability::ObjectProperty::ManaValue,
-                        filter: TargetFilter::And {
-                            filters: vec![
-                                TargetFilter::ExiledBySource,
-                                TargetFilter::Typed(TypedFilter::default().properties(vec![
-                                    FilterProp::Owned {
-                                        controller: ControllerRef::You,
-                                    },
-                                ])),
-                            ],
-                        },
-                    },
+                    qty: QuantityRef::PropertyAggregate(
+                        crate::types::ability::PropertyAggregate::new(
+                            crate::types::ability::AggregateFunction::Sum,
+                            crate::types::ability::ObjectProperty::ManaValue,
+                            crate::types::ability::CardTypeSetSource::Objects {
+                                filter: TargetFilter::And {
+                                    filters: vec![
+                                        TargetFilter::ExiledBySource,
+                                        TargetFilter::Typed(TypedFilter::default().properties(
+                                            vec![FilterProp::Owned {
+                                                controller: ControllerRef::You,
+                                            }],
+                                        )),
+                                    ],
+                                },
+                            },
+                        )
+                        .expect("statically valid property aggregate"),
+                    ),
                 }),
                 types: vec!["Creature".to_string(), "Illusion".to_string()],
                 colors: vec![ManaColor::Blue],
@@ -26865,36 +26895,46 @@ mod tests {
             Effect::Token {
                 name: "Illusion".to_string(),
                 power: PtValue::Quantity(QuantityExpr::Ref {
-                    qty: QuantityRef::Aggregate {
-                        function: crate::types::ability::AggregateFunction::Sum,
-                        property: crate::types::ability::ObjectProperty::ManaValue,
-                        filter: TargetFilter::And {
-                            filters: vec![
-                                TargetFilter::ExiledBySource,
-                                TargetFilter::Typed(TypedFilter::default().properties(vec![
-                                    FilterProp::Owned {
-                                        controller: ControllerRef::You,
-                                    },
-                                ])),
-                            ],
-                        },
-                    },
+                    qty: QuantityRef::PropertyAggregate(
+                        crate::types::ability::PropertyAggregate::new(
+                            crate::types::ability::AggregateFunction::Sum,
+                            crate::types::ability::ObjectProperty::ManaValue,
+                            crate::types::ability::CardTypeSetSource::Objects {
+                                filter: TargetFilter::And {
+                                    filters: vec![
+                                        TargetFilter::ExiledBySource,
+                                        TargetFilter::Typed(TypedFilter::default().properties(
+                                            vec![FilterProp::Owned {
+                                                controller: ControllerRef::You,
+                                            }],
+                                        )),
+                                    ],
+                                },
+                            },
+                        )
+                        .expect("statically valid property aggregate"),
+                    ),
                 }),
                 toughness: PtValue::Quantity(QuantityExpr::Ref {
-                    qty: QuantityRef::Aggregate {
-                        function: crate::types::ability::AggregateFunction::Sum,
-                        property: crate::types::ability::ObjectProperty::ManaValue,
-                        filter: TargetFilter::And {
-                            filters: vec![
-                                TargetFilter::ExiledBySource,
-                                TargetFilter::Typed(TypedFilter::default().properties(vec![
-                                    FilterProp::Owned {
-                                        controller: ControllerRef::You,
-                                    },
-                                ])),
-                            ],
-                        },
-                    },
+                    qty: QuantityRef::PropertyAggregate(
+                        crate::types::ability::PropertyAggregate::new(
+                            crate::types::ability::AggregateFunction::Sum,
+                            crate::types::ability::ObjectProperty::ManaValue,
+                            crate::types::ability::CardTypeSetSource::Objects {
+                                filter: TargetFilter::And {
+                                    filters: vec![
+                                        TargetFilter::ExiledBySource,
+                                        TargetFilter::Typed(TypedFilter::default().properties(
+                                            vec![FilterProp::Owned {
+                                                controller: ControllerRef::You,
+                                            }],
+                                        )),
+                                    ],
+                                },
+                            },
+                        )
+                        .expect("statically valid property aggregate"),
+                    ),
                 }),
                 types: vec!["Creature".to_string(), "Illusion".to_string()],
                 colors: vec![ManaColor::Blue],

--- a/crates/engine/src/game/effects/sacrifice.rs
+++ b/crates/engine/src/game/effects/sacrifice.rs
@@ -1631,11 +1631,16 @@ mod tests {
         let superlative = FilterProp::Cmc {
             comparator: Comparator::EQ,
             value: QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Max,
-                    property: ObjectProperty::ManaValue,
-                    filter: eligible_set,
-                },
+                qty: QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        AggregateFunction::Max,
+                        ObjectProperty::ManaValue,
+                        crate::types::ability::CardTypeSetSource::Objects {
+                            filter: eligible_set,
+                        },
+                    )
+                    .expect("statically valid property aggregate"),
+                ),
             },
         };
         let soul_shatter_target = TargetFilter::Or {
@@ -1755,11 +1760,16 @@ mod tests {
             scope: PtValueScope::Current,
             comparator: Comparator::EQ,
             value: QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Max,
-                    property: ObjectProperty::Power,
-                    filter: eligible_set,
-                },
+                qty: QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        AggregateFunction::Max,
+                        ObjectProperty::Power,
+                        crate::types::ability::CardTypeSetSource::Objects {
+                            filter: eligible_set,
+                        },
+                    )
+                    .expect("statically valid property aggregate"),
+                ),
             },
         };
         let target = TargetFilter::Typed(

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -2862,8 +2862,9 @@ fn quantity_ref_reads_zone(qty: &QuantityRef, zone: Zone) -> bool {
         // (an `ObjectCount` filter can carry `FilterProp::InZone { zone }`).
         QuantityRef::ObjectCount { filter }
         | QuantityRef::ObjectCountDistinct { filter, .. }
-        | QuantityRef::ObjectCountBySharedQuality { filter, .. }
-        | QuantityRef::Aggregate { filter, .. } => target_filter_reads_zone(filter, zone),
+        | QuantityRef::ObjectCountBySharedQuality { filter, .. } => {
+            target_filter_reads_zone(filter, zone)
+        }
         // CR 613.4a: A distinct-characteristic count reads `zone` only when its
         // population is sourced from that zone's cards (Tarmogoyf: card types
         // among cards in all graveyards; Subgoyf: different subtypes among the
@@ -2874,6 +2875,9 @@ fn quantity_ref_reads_zone(qty: &QuantityRef, zone: Zone) -> bool {
         | QuantityRef::DistinctSubtypes { source, .. }
         | QuantityRef::DistinctColorsAmong { source } => {
             characteristic_source_reads_zone(source, zone)
+        }
+        QuantityRef::PropertyAggregate(aggregate) => {
+            characteristic_source_reads_zone(aggregate.source(), zone)
         }
         // Everything else reads player-level state, single-object state, battle-
         // field-only population, history records, choices, or tracked sets — none
@@ -2916,7 +2920,6 @@ fn quantity_ref_reads_zone(qty: &QuantityRef, zone: Zone) -> bool {
         | QuantityRef::ExiledCardPower { .. }
         | QuantityRef::TrackedSetSize
         | QuantityRef::FilteredTrackedSetSize { .. }
-        | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
         | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::PreviousEffectCount
@@ -3147,7 +3150,6 @@ fn quantity_ref_reads_life(qty: &QuantityRef) -> bool {
         | QuantityRef::ObjectCountDistinct { filter, .. }
         | QuantityRef::ObjectCountBySharedQuality { filter, .. }
         | QuantityRef::CountersOnObjects { filter, .. }
-        | QuantityRef::Aggregate { filter, .. }
         | QuantityRef::ControlledByEachPlayer { filter, .. }
         | QuantityRef::DistinctCounterKindsAmong { filter }
         | QuantityRef::EnteredThisTurn { filter }
@@ -3192,6 +3194,9 @@ fn quantity_ref_reads_life(qty: &QuantityRef) -> bool {
         | QuantityRef::DistinctSubtypes { source, .. }
         | QuantityRef::DistinctColorsAmong { source } => {
             characteristic_source_reads_life_total(source)
+        }
+        QuantityRef::PropertyAggregate(aggregate) => {
+            characteristic_source_reads_life_total(aggregate.source())
         }
 
         // CR 601.2h: `ManaSpentToCast` carries no direct `TargetFilter`, but its
@@ -3246,7 +3251,6 @@ fn quantity_ref_reads_life(qty: &QuantityRef) -> bool {
         | QuantityRef::ExiledCardPower { .. }
         | QuantityRef::BasicLandTypeCount { .. }
         | QuantityRef::TrackedSetSize
-        | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
         | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::PreviousEffectCount

--- a/crates/engine/src/game/quantity.rs
+++ b/crates/engine/src/game/quantity.rs
@@ -27,8 +27,8 @@ use crate::types::card_type::CoreType;
 use crate::types::counter::{positive_counter_types, CounterType};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    BattlefieldDepartureSourceContext, DamageRecord, GameState, LinkedExileSnapshot,
-    TriggerSourceContext,
+    BattlefieldDepartureSourceContext, CastOccurrence, DamageRecord, GameState,
+    LinkedExileSnapshot, TriggerSourceContext,
 };
 use crate::types::identifiers::ObjectId;
 use crate::types::mana::{ManaColor, ManaCost};
@@ -152,7 +152,14 @@ fn cards_exiled_this_turn_for_context(state: &GameState, ctx: &QuantityContext) 
 /// targeting legality, the layer system, and combat).
 enum CharacteristicView<'a> {
     Object(&'a crate::game::game_object::GameObject),
+    Lki(&'a crate::types::game_state::LKISnapshot),
     SpellRecord(&'a crate::types::game_state::SpellCastRecord),
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+enum CharacteristicMember {
+    Object(ObjectId),
+    Cast(CastOccurrence),
 }
 
 impl<'a> CharacteristicView<'a> {
@@ -160,6 +167,7 @@ impl<'a> CharacteristicView<'a> {
     fn core_types(&self) -> &'a [CoreType] {
         match self {
             CharacteristicView::Object(obj) => &obj.card_types.core_types,
+            CharacteristicView::Lki(lki) => &lki.card_types,
             CharacteristicView::SpellRecord(record) => &record.core_types,
         }
     }
@@ -168,6 +176,7 @@ impl<'a> CharacteristicView<'a> {
     fn subtypes(&self) -> &'a [String] {
         match self {
             CharacteristicView::Object(obj) => &obj.card_types.subtypes,
+            CharacteristicView::Lki(lki) => &lki.subtypes,
             CharacteristicView::SpellRecord(record) => &record.subtypes,
         }
     }
@@ -176,7 +185,18 @@ impl<'a> CharacteristicView<'a> {
     fn colors(&self) -> &'a [ManaColor] {
         match self {
             CharacteristicView::Object(obj) => &obj.color,
+            CharacteristicView::Lki(lki) => &lki.colors,
             CharacteristicView::SpellRecord(record) => &record.colors,
+        }
+    }
+
+    /// CR 202.3: the member's mana value. Cast records carry the exact
+    /// cast-time snapshot; live objects include the stack-only X contribution.
+    fn mana_value(&self) -> i32 {
+        match self {
+            CharacteristicView::Object(obj) => u32_to_i32_saturating(obj.effective_mana_value()),
+            CharacteristicView::Lki(lki) => u32_to_i32_saturating(lki.mana_value),
+            CharacteristicView::SpellRecord(record) => u32_to_i32_saturating(record.mana_value),
         }
     }
 }
@@ -190,13 +210,50 @@ impl<'a> CharacteristicView<'a> {
 /// only its own characteristic extractor. Callers tally into a `HashSet`, so
 /// `AnyOf`'s recursion yields a genuine set UNION: a member present in two
 /// sources contributes its characteristics once.
+fn filter_without_current_cast_exclusion_marker(filter: &TargetFilter) -> TargetFilter {
+    match filter {
+        TargetFilter::Typed(typed) => {
+            let mut typed = typed.clone();
+            typed
+                .properties
+                .retain(|prop| prop != &FilterProp::OtherThanTriggerObject);
+            TargetFilter::Typed(typed)
+        }
+        TargetFilter::And { filters } => TargetFilter::And {
+            filters: filters
+                .iter()
+                .map(filter_without_current_cast_exclusion_marker)
+                .collect(),
+        },
+        TargetFilter::Or { filters } => TargetFilter::Or {
+            filters: filters
+                .iter()
+                .map(filter_without_current_cast_exclusion_marker)
+                .collect(),
+        },
+        TargetFilter::Not { filter } => TargetFilter::Not {
+            filter: Box::new(filter_without_current_cast_exclusion_marker(filter)),
+        },
+        TargetFilter::TrackedSetFiltered {
+            id,
+            filter,
+            caused_by,
+        } => TargetFilter::TrackedSetFiltered {
+            id: *id,
+            filter: Box::new(filter_without_current_cast_exclusion_marker(filter)),
+            caused_by: *caused_by,
+        },
+        other => other.clone(),
+    }
+}
+
 fn visit_characteristic_leaf<'s>(
     state: &'s GameState,
     source: &CardTypeSetSource,
     ctx: QuantityContext,
     filter_ctx: &FilterContext<'_>,
     controller: PlayerId,
-    visit: &mut impl FnMut(CharacteristicView<'s>),
+    visit: &mut impl FnMut(CharacteristicMember, CharacteristicView<'s>, bool),
 ) {
     match source {
         CardTypeSetSource::Zone { zone, scope } => match zone {
@@ -211,7 +268,11 @@ fn visit_characteristic_leaf<'s>(
                             obj.owner,
                         );
                         if owner_matches {
-                            visit(CharacteristicView::Object(obj));
+                            visit(
+                                CharacteristicMember::Object(obj_id),
+                                CharacteristicView::Object(obj),
+                                false,
+                            );
                         }
                     }
                 }
@@ -226,7 +287,11 @@ fn visit_characteristic_leaf<'s>(
                     };
                     for &obj_id in zone_ids {
                         if let Some(obj) = state.objects.get(&obj_id) {
-                            visit(CharacteristicView::Object(obj));
+                            visit(
+                                CharacteristicMember::Object(obj_id),
+                                CharacteristicView::Object(obj),
+                                false,
+                            );
                         }
                     }
                 }
@@ -235,38 +300,27 @@ fn visit_characteristic_leaf<'s>(
         CardTypeSetSource::ExiledBySource => {
             for linked in linked_exile_for_context(state, &ctx) {
                 if let Some(obj) = state.objects.get(&linked.exiled_id) {
-                    visit(CharacteristicView::Object(obj));
+                    visit(
+                        CharacteristicMember::Object(linked.exiled_id),
+                        CharacteristicView::Object(obj),
+                        false,
+                    );
                 }
             }
         }
-        // CR 400.1: EVERY zone the filter names, not just the first. The zone
-        // list comes from `CardTypeSetSource::population_zones` — the same
-        // authority `game::layers::characteristic_source_reads_zone` asks — so
-        // the set this walk enumerates and the set a zone transition dirties
-        // cannot drift apart.
-        //
-        // The previous `extract_in_zone().unwrap_or(Battlefield)` collapsed a
-        // multi-zone `FilterProp::InAnyZone` population to whichever zone the
-        // filter tree happened to yield first, silently undercounting every
-        // other zone in the union.
-        //
-        // CR 110.1: an empty list means the filter writes no zone constraint, so
-        // it denotes permanents. The default is substituted HERE and not inside
-        // `population_zones` — see that function on why the dependency half must
-        // not claim a defaulted battlefield read.
+        // The shared object-population authority preserves explicit zones,
+        // boolean branch defaults, LastZoneChanged/TrackedSet populations, and
+        // the triggering-object exclusion. Property aggregates must enumerate
+        // the exact same members as object-count quantities.
         CardTypeSetSource::Objects { filter } => {
-            let mut zones = source.population_zones();
-            if zones.is_empty() {
-                zones.push(crate::types::zones::Zone::Battlefield);
-            }
-            for zone in zones {
-                for obj_id in crate::game::targeting::zone_object_ids(state, zone) {
-                    if !matches_target_filter(state, obj_id, filter, filter_ctx) {
-                        continue;
-                    }
-                    if let Some(obj) = state.objects.get(&obj_id) {
-                        visit(CharacteristicView::Object(obj));
-                    }
+            for obj_id in object_count_matching_ids(state, filter, filter_ctx, ctx.source) {
+                let view = state
+                    .objects
+                    .get(&obj_id)
+                    .map(CharacteristicView::Object)
+                    .or_else(|| state.lki_cache.get(&obj_id).map(CharacteristicView::Lki));
+                if let Some(view) = view {
+                    visit(CharacteristicMember::Object(obj_id), view, false);
                 }
             }
         }
@@ -281,22 +335,41 @@ fn visit_characteristic_leaf<'s>(
         // `effects::publish_tracked_set`. Deliberately not routed through
         // `targeting::resolve_tracked_set_id`: that authority SKIPS empty sets, and
         // under mode scoping not skipping is the correct semantics here.
-        CardTypeSetSource::TrackedSet { caused_by } => {
-            if let Some((set_id, ids)) = state.tracked_object_sets.iter().max_by_key(|(id, _)| id.0)
-            {
-                for &oid in ids {
-                    let cause_ok = match caused_by {
-                        None => true,
-                        Some(cause) => state
+        CardTypeSetSource::TrackedSet { set, caused_by } => {
+            let tracked: Vec<(Option<crate::types::identifiers::TrackedSetId>, ObjectId)> =
+                match set {
+                    TrackedAnaphorSource::ChainSet => state
+                        .tracked_object_sets
+                        .iter()
+                        .max_by_key(|(id, _)| id.0)
+                        .map(|(set_id, ids)| ids.iter().map(|&id| (Some(*set_id), id)).collect())
+                        .unwrap_or_default(),
+                    TrackedAnaphorSource::TriggeringBatch => state
+                        .current_trigger_events
+                        .iter()
+                        .flat_map(crate::game::targeting::extract_sources_from_event)
+                        .map(|id| (None, id))
+                        .collect(),
+                };
+            for (set_id, oid) in tracked {
+                let cause_ok = match caused_by {
+                    None => true,
+                    Some(cause) => set_id.is_some_and(|set_id| {
+                        state
                             .tracked_set_member_causes
-                            .get(set_id)
+                            .get(&set_id)
                             .and_then(|causes| causes.get(&oid))
-                            .is_some_and(|member_cause| member_cause == cause),
-                    };
-                    if cause_ok {
-                        if let Some(obj) = state.objects.get(&oid) {
-                            visit(CharacteristicView::Object(obj));
-                        }
+                            .is_some_and(|member_cause| member_cause == cause)
+                    }),
+                };
+                if cause_ok {
+                    let view = state
+                        .objects
+                        .get(&oid)
+                        .map(CharacteristicView::Object)
+                        .or_else(|| state.lki_cache.get(&oid).map(CharacteristicView::Lki));
+                    if let Some(view) = view {
+                        visit(CharacteristicMember::Object(oid), view, false);
                     }
                 }
             }
@@ -316,13 +389,19 @@ fn visit_characteristic_leaf<'s>(
             filter,
         } => match journal {
             TurnJournalKind::SpellsCast => {
+                let excludes_current = filter
+                    .as_ref()
+                    .is_some_and(TargetFilter::contains_other_than_trigger_object);
+                let record_filter = filter
+                    .as_ref()
+                    .map(filter_without_current_cast_exclusion_marker);
                 for player in scoped_players(state, scope, ctx, controller) {
                     let Some(records) = state.spells_cast_this_turn_by_player.get(&player.id)
                     else {
                         continue;
                     };
-                    for record in records.iter() {
-                        let matches = match filter {
+                    for (index, record) in records.iter().enumerate() {
+                        let matches = match &record_filter {
                             None => true,
                             Some(filter) => spell_record_matches_filter(
                                 record,
@@ -332,7 +411,17 @@ fn visit_characteristic_leaf<'s>(
                             ),
                         };
                         if matches {
-                            visit(CharacteristicView::SpellRecord(record));
+                            let Ok(turn_journal_index) = u32::try_from(index) else {
+                                continue;
+                            };
+                            visit(
+                                CharacteristicMember::Cast(CastOccurrence {
+                                    caster: player.id,
+                                    turn_journal_index,
+                                }),
+                                CharacteristicView::SpellRecord(record),
+                                excludes_current,
+                            );
                         }
                     }
                 }
@@ -354,17 +443,65 @@ fn visit_characteristic_leaf<'s>(
 /// UNDERCOUNTS rather than over-counts, which is why the budget is set far above
 /// any printed union — the honest alternative would be refusing to resolve the
 /// quantity at all, and no card can reach the bound.
+#[derive(Clone, Copy)]
+struct CharacteristicFilterContexts<'a> {
+    base: &'a FilterContext<'a>,
+    scoped_owned_exile: Option<&'a FilterContext<'a>>,
+}
+
 fn visit_characteristic_source<'s>(
     state: &'s GameState,
     source: &CardTypeSetSource,
     ctx: QuantityContext,
-    filter_ctx: &FilterContext<'_>,
+    filter_contexts: CharacteristicFilterContexts<'_>,
     controller: PlayerId,
-    visit: &mut impl FnMut(CharacteristicView<'s>),
+    journal_controller: PlayerId,
+    visit: &mut impl FnMut(CharacteristicMember, CharacteristicView<'s>, bool),
 ) {
     source.try_for_each_member(crate::types::ability::UNION_DEPTH_BUDGET, &mut |leaf| {
-        visit_characteristic_leaf(state, leaf, ctx.clone(), filter_ctx, controller, visit);
+        let leaf_controller = if matches!(leaf, CardTypeSetSource::TurnJournal { .. }) {
+            journal_controller
+        } else {
+            controller
+        };
+        let leaf_filter_ctx = match leaf {
+            CardTypeSetSource::Objects { filter }
+                if filter.references_exiled_by_source() && filter_binds_owned_you(filter) =>
+            {
+                filter_contexts
+                    .scoped_owned_exile
+                    .unwrap_or(filter_contexts.base)
+            }
+            _ => filter_contexts.base,
+        };
+        visit_characteristic_leaf(
+            state,
+            leaf,
+            ctx.clone(),
+            leaf_filter_ctx,
+            leaf_controller,
+            visit,
+        );
     });
+}
+
+fn filter_binds_owned_you(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::Typed(TypedFilter { properties, .. }) => properties.iter().any(|prop| {
+            matches!(
+                prop,
+                FilterProp::Owned {
+                    controller: ControllerRef::You,
+                }
+            )
+        }),
+        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
+            filters.iter().any(filter_binds_owned_you)
+        }
+        TargetFilter::Not { filter } => filter_binds_owned_you(filter),
+        TargetFilter::TrackedSetFiltered { filter, .. } => filter_binds_owned_you(filter),
+        _ => false,
+    }
 }
 
 fn source_chosen_player_for_context(state: &GameState, ctx: &QuantityContext) -> Option<PlayerId> {
@@ -972,7 +1109,7 @@ fn quantity_ref_uses_unspent_mana(qty: &QuantityRef) -> bool {
         | QuantityRef::ObjectTypelineComponentCount { .. }
         | QuantityRef::ManaSymbolsInManaCost { .. }
         | QuantityRef::SelfManaValue
-        | QuantityRef::Aggregate { .. }
+        | QuantityRef::PropertyAggregate(_)
         | QuantityRef::ControlledByEachPlayer { .. }
         | QuantityRef::TargetZoneCardCount { .. }
         | QuantityRef::Devotion { .. }
@@ -984,7 +1121,6 @@ fn quantity_ref_uses_unspent_mana(qty: &QuantityRef) -> bool {
         | QuantityRef::BasicLandTypeCount { .. }
         | QuantityRef::TrackedSetSize
         | QuantityRef::FilteredTrackedSetSize { .. }
-        | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
         | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::PreviousEffectCount
@@ -1250,7 +1386,6 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         | QuantityRef::ObjectCountDistinct { .. }
         | QuantityRef::ObjectCountBySharedQuality { .. }
         | QuantityRef::CountersOnObjects { .. }
-        | QuantityRef::Aggregate { .. }
         | QuantityRef::ControlledByEachPlayer { .. }
         | QuantityRef::Devotion { .. }
         | QuantityRef::BasicLandTypeCount { .. }
@@ -1280,6 +1415,9 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         | QuantityRef::DistinctSubtypes { source, .. }
         | QuantityRef::DistinctColorsAmong { source } => {
             characteristic_source_reads_object_count(source)
+        }
+        QuantityRef::PropertyAggregate(aggregate) => {
+            characteristic_source_reads_object_count(aggregate.source())
         }
         // Player-level, single-object, history-record, payment, and choice
         // references: unaffected by another object's battlefield entry/exit.
@@ -1315,7 +1453,6 @@ fn quantity_ref_uses_object_count(qty: &QuantityRef) -> bool {
         | QuantityRef::ZoneCardCount { .. }
         | QuantityRef::TrackedSetSize
         | QuantityRef::FilteredTrackedSetSize { .. }
-        | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
         | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::PreviousEffectCount
@@ -1509,10 +1646,10 @@ fn quantity_ref_characteristic_reads(qty: &QuantityRef, depth: u32) -> Character
         } => target_filter_characteristic_reads_at(filter, depth)
             .union(shared_quality_characteristic_reads(quality)),
         // CR 202.3: aggregated object property plus the scanned filter.
-        QuantityRef::Aggregate {
-            property, filter, ..
-        } => object_property_characteristic_reads(property)
-            .union(target_filter_characteristic_reads_at(filter, depth)),
+        QuantityRef::PropertyAggregate(aggregate) => {
+            object_property_characteristic_reads(&aggregate.property())
+                .union(characteristic_source_reads_at(aggregate.source(), depth))
+        }
         // CR 109.5 + CR 613.1b: per-player partition of a live census.
         QuantityRef::ControlledByEachPlayer { filter, .. } => CharacteristicKinds::CONTROLLER
             .union(target_filter_characteristic_reads_at(filter, depth)),
@@ -1585,10 +1722,6 @@ fn quantity_ref_characteristic_reads(qty: &QuantityRef, depth: u32) -> Character
         QuantityRef::ObjectNameWordCount { .. } => CharacteristicKinds::NAME_TEXT,
         // CR 205.4a + CR 205.2a + CR 205.3: supertypes + card types + subtypes.
         QuantityRef::ObjectTypelineComponentCount { .. } => CharacteristicKinds::CARD_TYPES,
-        // CR 608.2c: aggregates an object property over an identity-addressed set.
-        QuantityRef::TrackedSetAggregate { property, .. } => {
-            object_property_characteristic_reads(property)
-        }
         // CR 122.1f + CR 109.4: reads the controller of the parent target.
         QuantityRef::TargetControllerCounter { .. } => CharacteristicKinds::CONTROLLER,
         // CR 400.7 + CR 613.1b: look-back attachment snapshot, optionally scoped
@@ -1791,7 +1924,6 @@ fn entered_object_perturbs_quantity_ref(
         | QuantityRef::ObjectCountDistinct { filter, .. }
         | QuantityRef::ObjectCountBySharedQuality { filter, .. }
         | QuantityRef::CountersOnObjects { filter, .. }
-        | QuantityRef::Aggregate { filter, .. }
         | QuantityRef::ControlledByEachPlayer { filter, .. }
         | QuantityRef::DistinctCounterKindsAmong { filter }
         | QuantityRef::EnteredThisTurn { filter }
@@ -1820,6 +1952,9 @@ fn entered_object_perturbs_quantity_ref(
         | QuantityRef::DistinctSubtypes { source, .. }
         | QuantityRef::DistinctColorsAmong { source } => {
             characteristic_source_perturbed_by_entry(state, entered, ctx, source)
+        }
+        QuantityRef::PropertyAggregate(aggregate) => {
+            characteristic_source_perturbed_by_entry(state, entered, ctx, aggregate.source())
         }
         // CR 700.5: devotion is perturbed iff the entered object's mana cost
         // contributes a symbol for one of the fixed colors. `ChosenColor`'s
@@ -1883,7 +2018,6 @@ fn entered_object_perturbs_quantity_ref(
         | QuantityRef::ZoneCardCount { .. }
         | QuantityRef::TrackedSetSize
         | QuantityRef::FilteredTrackedSetSize { .. }
-        | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
         | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::PreviousEffectCount
@@ -2770,28 +2904,35 @@ pub(crate) fn aggregate_property_over(
     function: AggregateFunction,
     property: ObjectProperty,
 ) -> i32 {
-    let extract = |id: ObjectId| -> Option<i32> {
-        let live = state.objects.get(&id).and_then(|obj| match property {
-            ObjectProperty::Power => obj.power,
-            ObjectProperty::Toughness => obj.toughness,
-            // CR 202.3e: include X when on the stack (cost_x_paid).
-            ObjectProperty::ManaValue => Some(u32_to_i32_saturating(obj.effective_mana_value())),
-            // CR 107.4a + CR 107.4e + CR 202.1: colored mana symbols of `color`;
-            // hybrid symbols contribute to each of their colors.
-            ObjectProperty::ManaSymbolCount(color) => Some(u32_to_i32_saturating(
-                crate::game::devotion::count_cost_color_symbols(&obj.mana_cost, color),
-            )),
-        });
-        live.or_else(|| {
-            state.lki_cache.get(&id).and_then(|lki| match property {
-                ObjectProperty::Power => lki.power,
-                ObjectProperty::Toughness => lki.toughness,
-                ObjectProperty::ManaValue => Some(u32_to_i32_saturating(lki.mana_value)),
-                ObjectProperty::ManaSymbolCount(_) => None,
-            })
+    let values = ids
+        .iter()
+        .filter_map(|&id| object_property_value(state, id, property));
+    reduce_property_values(values, function)
+}
+
+fn object_property_value(state: &GameState, id: ObjectId, property: ObjectProperty) -> Option<i32> {
+    let live = state.objects.get(&id).and_then(|obj| match property {
+        ObjectProperty::Power => obj.power,
+        ObjectProperty::Toughness => obj.toughness,
+        // CR 202.3e: include X when on the stack (cost_x_paid).
+        ObjectProperty::ManaValue => Some(u32_to_i32_saturating(obj.effective_mana_value())),
+        // CR 107.4a + CR 107.4e + CR 202.1: colored mana symbols of `color`;
+        // hybrid symbols contribute to each of their colors.
+        ObjectProperty::ManaSymbolCount(color) => Some(u32_to_i32_saturating(
+            crate::game::devotion::count_cost_color_symbols(&obj.mana_cost, color),
+        )),
+    });
+    live.or_else(|| {
+        state.lki_cache.get(&id).and_then(|lki| match property {
+            ObjectProperty::Power => lki.power,
+            ObjectProperty::Toughness => lki.toughness,
+            ObjectProperty::ManaValue => Some(u32_to_i32_saturating(lki.mana_value)),
+            ObjectProperty::ManaSymbolCount(_) => None,
         })
-    };
-    let values = ids.iter().filter_map(|&id| extract(id));
+    })
+}
+
+fn reduce_property_values(values: impl Iterator<Item = i32>, function: AggregateFunction) -> i32 {
     match function {
         AggregateFunction::Max => values.max().unwrap_or(0),
         AggregateFunction::Min => values.min().unwrap_or(0),
@@ -3193,23 +3334,30 @@ pub(crate) fn object_count_matching_candidate_ids(
     ids
 }
 
-fn filter_binds_owned_you(filter: &TargetFilter) -> bool {
-    match filter {
-        TargetFilter::Typed(TypedFilter { properties, .. }) => properties.iter().any(|prop| {
-            matches!(
-                prop,
-                FilterProp::Owned {
-                    controller: ControllerRef::You,
-                }
-            )
-        }),
-        TargetFilter::And { filters } | TargetFilter::Or { filters } => {
-            filters.iter().any(filter_binds_owned_you)
-        }
-        TargetFilter::Not { filter } => filter_binds_owned_you(filter),
-        TargetFilter::TrackedSetFiltered { filter, .. } => filter_binds_owned_you(filter),
-        _ => false,
+fn current_cast_occurrence_matches(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    member: CharacteristicMember,
+) -> bool {
+    let Some(occurrence) = ability.cast_occurrence else {
+        return false;
+    };
+    if member != CharacteristicMember::Cast(occurrence)
+        || !state
+            .objects
+            .get(&ability.source_id)
+            .is_some_and(|object| object.zone == Zone::Stack)
+    {
+        return false;
     }
+    let Ok(index) = usize::try_from(occurrence.turn_journal_index) else {
+        return false;
+    };
+    state
+        .spells_cast_this_turn_by_player
+        .get(&occurrence.caster)
+        .and_then(|records| records.get(index))
+        .is_some_and(|record| record.spell_object_id == Some(ability.source_id))
 }
 
 fn resolve_ref(
@@ -3697,38 +3845,62 @@ fn resolve_ref(
         // exactly what the "as they last existed on the battlefield" ruling
         // requires. `ManaValue` doesn't need LKI: the printed mana cost is
         // stable across zones.
-        QuantityRef::Aggregate {
-            function,
-            property,
-            filter,
-        } => {
-            // CR 608.2h + CR 400.7: id population delegated to
-            // `object_count_matching_ids` (single source of truth for zone
-            // selection + the `OtherThanTriggerObject` exclusion); per-object
-            // aggregation delegated to `aggregate_property_over` (single
-            // summation authority, live-then-LKI per property).
-            let mut scoped_exile_filter_ctx;
-            let aggregate_filter_ctx = if filter.references_exiled_by_source()
-                && filter_binds_owned_you(filter)
-                && ability.is_some_and(|a| {
-                    a.scoped_player.is_some()
-                        || a.original_controller
-                            .is_some_and(|orig| orig != a.controller)
-                }) {
-                let scoped = ability
-                    .and_then(|a| a.scoped_player.or(Some(a.controller)))
-                    .unwrap_or(controller);
-                scoped_exile_filter_ctx = match ability {
-                    Some(a) => FilterContext::from_ability_with_controller(a, scoped),
-                    None => FilterContext::from_source_with_controller(source_id, scoped),
-                };
-                scoped_exile_filter_ctx.recipient_id = ctx.recipient;
-                &scoped_exile_filter_ctx
-            } else {
-                &filter_ctx
-            };
-            let ids = object_count_matching_ids(state, filter, aggregate_filter_ctx, source_id);
-            aggregate_property_over(state, &ids, *function, *property)
+        QuantityRef::PropertyAggregate(aggregate) => {
+            let journal_controller = ability
+                .and_then(|ability| ability.original_controller)
+                .unwrap_or(controller);
+            // Preserve the legacy Aggregate rule used by Skyclave Apparition:
+            // during a per-owner fanout, "cards you own exiled by this source"
+            // binds "you" to that owner. Other object filters and journal
+            // scopes keep their normal controller authority.
+            let scoped_owned_exile_filter_ctx = ability.and_then(|ability| {
+                (ability.scoped_player.is_some()
+                    || ability
+                        .original_controller
+                        .is_some_and(|original| original != ability.controller))
+                .then(|| {
+                    let scoped = ability.scoped_player.unwrap_or(ability.controller);
+                    let mut scoped_ctx =
+                        FilterContext::from_ability_with_controller(ability, scoped);
+                    scoped_ctx.recipient_id = ctx.recipient;
+                    scoped_ctx
+                })
+            });
+            let mut seen = HashSet::new();
+            let mut values = Vec::new();
+            visit_characteristic_source(
+                state,
+                aggregate.source(),
+                ctx.clone(),
+                CharacteristicFilterContexts {
+                    base: &filter_ctx,
+                    scoped_owned_exile: scoped_owned_exile_filter_ctx.as_ref(),
+                },
+                controller,
+                journal_controller,
+                &mut |member, view, excludes_current| {
+                    if excludes_current
+                        && ability.is_some_and(|ability| {
+                            current_cast_occurrence_matches(state, ability, member)
+                        })
+                    {
+                        return;
+                    }
+                    if !seen.insert(member) {
+                        return;
+                    }
+                    let value = match member {
+                        CharacteristicMember::Object(id) => {
+                            object_property_value(state, id, aggregate.property())
+                        }
+                        CharacteristicMember::Cast(_) => Some(view.mana_value()),
+                    };
+                    if let Some(value) = value {
+                        values.push(value);
+                    }
+                },
+            );
+            reduce_property_values(values.into_iter(), aggregate.function())
         }
         // CR 107.1 + CR 700.1: min/max across players of the count of
         // battlefield objects matching `filter` each player controls.
@@ -3886,9 +4058,13 @@ fn resolve_ref(
                 state,
                 source,
                 ctx.clone(),
-                &filter_ctx,
+                CharacteristicFilterContexts {
+                    base: &filter_ctx,
+                    scoped_owned_exile: None,
+                },
                 controller,
-                &mut |view| {
+                controller,
+                &mut |_, view, _| {
                     for ct in view.core_types() {
                         seen.insert(*ct);
                     }
@@ -3931,9 +4107,13 @@ fn resolve_ref(
                 state,
                 source,
                 ctx.clone(),
-                &filter_ctx,
+                CharacteristicFilterContexts {
+                    base: &filter_ctx,
+                    scoped_owned_exile: None,
+                },
                 controller,
-                &mut |view| {
+                controller,
+                &mut |_, view, _| {
                     for sub in view.subtypes() {
                         if exclude_creature && creature_types.contains(sub.as_str()) {
                             continue;
@@ -4167,58 +4347,6 @@ fn resolve_ref(
                 .count();
             usize_to_i32_saturating(count)
         }
-        // CR 608.2c + CR 107.3e + CR 202.3: Reduce a numeric property
-        // over the most recent chain tracked set. Mirrors `FilteredTrackedSetSize`'s set
-        // selection (highest id = the set the preceding chain effect published)
-        // but aggregates a per-member value instead of counting. The members are
-        // addressed by identity, so cards the producer moved to exile are read in
-        // place (mirrors the `Aggregate` extract: live object first, LKI cache
-        // fallback). Drives "deals damage equal to the total mana value of those
-        // exiled cards" (Ensnared by the Mara).
-        QuantityRef::TrackedSetAggregate {
-            function,
-            property,
-            source,
-        } => {
-            // The id-set to reduce depends on which anaphor the parser matched.
-            let ids: Vec<ObjectId> = match source {
-                // Chain-published tracked set ("those exiled cards"): the set the
-                // immediately-preceding chain effect published (highest id).
-                // CR 700.2 + CR 608.2c: "highest id" == "the set the currently-resolving
-                // instruction published" — the ordering argument is written once, on
-                // `effects::publish_tracked_set`. Deliberately not routed through
-                // `targeting::resolve_tracked_set_id`: that authority SKIPS empty sets, and
-                // under mode scoping not skipping is the correct semantics here.
-                TrackedAnaphorSource::ChainSet => state
-                    .tracked_object_sets
-                    .iter()
-                    .max_by_key(|(id, _)| id.0)
-                    .map(|(_, ids)| ids.clone())
-                    .unwrap_or_default(),
-                // CR 603.2c + CR 603.10a: the current triggering event batch
-                // ("those creatures" on a batched dies trigger; "them" / "their
-                // total power" on a batched attack trigger). The subjects are
-                // read from `state.current_trigger_events`; each died creature's
-                // power comes from its last-known info (LKI), i.e. death-time
-                // power, via `aggregate_property_over`'s live-then-LKI extract.
-                //
-                // CR 508.1: `extract_sources_from_event` is the SET-valued
-                // extractor. The singleton `extract_source_from_event` collapses
-                // a multi-attacker `AttackersDeclared` to `None`, which reduced
-                // this aggregate over an EMPTY set — 0 attackers' worth of power
-                // on every board with 2+ attackers (Aloy, Shriekwood Devourer,
-                // Witch-king, Sky Scourge). Dies batches are unchanged: they
-                // arrive as one event per creature and are still collected here.
-                TrackedAnaphorSource::TriggeringBatch => state
-                    .current_trigger_events
-                    .iter()
-                    .flat_map(crate::game::targeting::extract_sources_from_event)
-                    .collect(),
-            };
-            // Per-object aggregation delegated to the shared
-            // `aggregate_property_over` summation authority (live-then-LKI).
-            aggregate_property_over(state, &ids, *function, *property)
-        }
         // CR 400.7 + CR 608.2c: Read the per-resolution counter populated by
         // ChangeZoneAll when it exiles cards from a hand. Used by "draws a card
         // for each card exiled from their hand this way" (Deadly Cover-Up).
@@ -4427,9 +4555,13 @@ fn resolve_ref(
                 state,
                 source,
                 ctx.clone(),
-                &filter_ctx,
+                CharacteristicFilterContexts {
+                    base: &filter_ctx,
+                    scoped_owned_exile: None,
+                },
                 controller,
-                &mut |view| {
+                controller,
+                &mut |_, view, _| {
                     for color in view.colors() {
                         seen.insert(*color);
                     }
@@ -7716,7 +7848,7 @@ mod tests {
     /// the refusal: the wrong shape silently under-counts; the right shape is
     /// available.
     #[test]
-    fn a_cross_zone_or_drops_a_leg_while_any_of_reads_both_zones() {
+    fn a_cross_zone_or_preserves_branch_local_zones_while_any_of_reads_both_zones() {
         let mut state = GameState::new_two_player(7);
         let controller = PlayerId(0);
 
@@ -7794,18 +7926,9 @@ mod tests {
              + blue (graveyard). A walk that kept only the first zone reads 1"
         );
 
-        // UNSUPPORTED SHAPE, and the boundary is asserted rather than assumed: a
-        // PARTIALLY zone-constrained `Or`. The first disjunct names no zone (so
-        // it means the battlefield, CR 110.1) while the second names the
-        // graveyard, and `population_zones` returns ONE FLAT LIST that cannot say
-        // "battlefield for that branch only". The list is `[Graveyard]`, which is
-        // non-empty, so the battlefield default never applies and the first
-        // disjunct's permanents are never scanned.
-        //
-        // The count is 1 — blue, from the graveyard — NOT the green the old
-        // comment here predicted. Both readings happen to be 1, which is exactly
-        // why the stale explanation survived: the number could not distinguish
-        // them. Asserting the identity below can.
+        // The shared object-population authority preserves each `Or` branch's
+        // own zone universe: an unconstrained permanent branch defaults to the
+        // battlefield while the explicitly constrained branch reads graveyard.
         let folded = QuantityExpr::Ref {
             qty: QuantityRef::DistinctColorsAmong {
                 source: CardTypeSetSource::Objects {
@@ -7817,13 +7940,11 @@ mod tests {
         };
         assert_eq!(
             resolve_quantity(&state, &folded, controller, bear),
-            1,
-            "a partially zone-constrained Or scans only the zone it names"
+            2,
+            "branch-local zone universes retain both the battlefield and graveyard legs"
         );
-        // The parser refuses to emit this shape, which is what keeps the
-        // undercount above unreachable from real Oracle text. If this guard ever
-        // goes green, the shape becomes expressible and the undercount becomes a
-        // live defect.
+        // The parser remains conservative about emitting this shape. Runtime
+        // support does not broaden the grammar accepted in Phase 2.
         assert!(
             !crate::parser::oracle_nom::quantity::objects_filter_zone_is_unambiguous(
                 &TargetFilter::Or {
@@ -8331,18 +8452,23 @@ mod tests {
         };
 
         let qty = QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::ManaSymbolCount(ManaColor::Black),
-                filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
-                    FilterProp::Owned {
-                        controller: ControllerRef::You,
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::ManaSymbolCount(ManaColor::Black),
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
+                            FilterProp::Owned {
+                                controller: ControllerRef::You,
+                            },
+                            FilterProp::InZone {
+                                zone: Zone::Graveyard,
+                            },
+                        ])),
                     },
-                    FilterProp::InZone {
-                        zone: Zone::Graveyard,
-                    },
-                ])),
-            },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         };
 
         // P0 sees 3 black symbols in their own graveyard (battlefield + P1's
@@ -8537,18 +8663,23 @@ mod tests {
         );
 
         let qty = QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::ManaSymbolCount(ManaColor::Black),
-                filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
-                    FilterProp::Owned {
-                        controller: ControllerRef::You,
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::ManaSymbolCount(ManaColor::Black),
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
+                            FilterProp::Owned {
+                                controller: ControllerRef::You,
+                            },
+                            FilterProp::InZone {
+                                zone: Zone::Graveyard,
+                            },
+                        ])),
                     },
-                    FilterProp::InZone {
-                        zone: Zone::Graveyard,
-                    },
-                ])),
-            },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         };
 
         // The card is counted for its OWNER (P0), not for the player who last
@@ -9815,20 +9946,25 @@ mod tests {
 
         let mut state = GameState::new(FormatConfig::commander(), 4, 42);
         let expr = QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: AggregateFunction::Max,
-                property: ObjectProperty::ManaValue,
-                filter: TargetFilter::Typed(
-                    TypedFilter::default()
-                        .controller(ControllerRef::You)
-                        .properties(vec![
-                            FilterProp::IsCommander,
-                            FilterProp::InAnyZone {
-                                zones: vec![Zone::Battlefield, Zone::Command],
-                            },
-                        ]),
-                ),
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Max,
+                    ObjectProperty::ManaValue,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::Typed(
+                            TypedFilter::default()
+                                .controller(ControllerRef::You)
+                                .properties(vec![
+                                    FilterProp::IsCommander,
+                                    FilterProp::InAnyZone {
+                                        zones: vec![Zone::Battlefield, Zone::Command],
+                                    },
+                                ]),
+                        ),
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         };
 
         // Add two partners in command zone: 3-mana and 5-mana
@@ -11242,7 +11378,7 @@ mod tests {
     /// adds matching records; Max picks the largest; a non-matching destination
     /// is excluded (returns 0 when none match).
     #[test]
-    fn resolve_zone_change_aggregate_this_turn_sums_dies_power() {
+    fn zone_change_aggregate_this_turn_remains_occurrence_stream_lki() {
         let mut state = GameState::new_two_player(42);
         let source = create_object(
             &mut state,
@@ -15417,11 +15553,18 @@ mod tests {
             Zone::Battlefield,
         );
         let expr = QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: AggregateFunction::Max,
-                property: ObjectProperty::Power,
-                filter: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Max,
+                    ObjectProperty::Power,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::Typed(
+                            TypedFilter::creature().controller(ControllerRef::You),
+                        ),
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         };
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), source), 5);
     }
@@ -15453,11 +15596,18 @@ mod tests {
             Zone::Battlefield,
         );
         let expr = QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::Power,
-                filter: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::Power,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::Typed(
+                            TypedFilter::creature().controller(ControllerRef::You),
+                        ),
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         };
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), source), 10);
     }
@@ -15494,13 +15644,520 @@ mod tests {
             properties: vec![crate::types::ability::FilterProp::InZone { zone: Zone::Exile }],
         });
         let expr = QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: AggregateFunction::Max,
-                property: ObjectProperty::ManaValue,
-                filter,
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Max,
+                    ObjectProperty::ManaValue,
+                    CardTypeSetSource::Objects { filter },
+                )
+                .expect("valid object aggregate"),
+            ),
         };
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), source), 7);
+    }
+
+    #[test]
+    fn property_aggregate_valid_empty_sources_return_zero_for_sum_max_and_min() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(500),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        for function in [
+            AggregateFunction::Sum,
+            AggregateFunction::Max,
+            AggregateFunction::Min,
+        ] {
+            let expr = QuantityExpr::Ref {
+                qty: QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        function,
+                        ObjectProperty::ManaValue,
+                        CardTypeSetSource::Zone {
+                            zone: ZoneRef::Library,
+                            scope: CountScope::Controller,
+                        },
+                    )
+                    .unwrap(),
+                ),
+            };
+            assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), source), 0);
+        }
+    }
+
+    #[test]
+    fn property_aggregate_objects_preserves_sum_max_min_and_filters() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(510),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        for (card, power) in [(511, 2), (512, 5)] {
+            let id = create_object(
+                &mut state,
+                CardId(card),
+                PlayerId(0),
+                format!("Creature {card}"),
+                Zone::Battlefield,
+            );
+            let object = state.objects.get_mut(&id).unwrap();
+            object.card_types.core_types = vec![CoreType::Creature];
+            object.power = Some(power);
+        }
+        let artifact = create_object(
+            &mut state,
+            CardId(513),
+            PlayerId(0),
+            "Artifact".to_string(),
+            Zone::Battlefield,
+        );
+        let object = state.objects.get_mut(&artifact).unwrap();
+        object.card_types.core_types = vec![CoreType::Artifact];
+        object.power = Some(100);
+
+        for (function, expected) in [
+            (AggregateFunction::Sum, 7),
+            (AggregateFunction::Max, 5),
+            (AggregateFunction::Min, 2),
+        ] {
+            let expr = QuantityExpr::Ref {
+                qty: QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        function,
+                        ObjectProperty::Power,
+                        CardTypeSetSource::Objects {
+                            filter: TargetFilter::Typed(TypedFilter::creature()),
+                        },
+                    )
+                    .unwrap(),
+                ),
+            };
+            assert_eq!(
+                resolve_quantity(&state, &expr, PlayerId(0), source),
+                expected
+            );
+        }
+    }
+
+    #[test]
+    fn property_aggregate_objects_preserves_last_zone_changed_population() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(514),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        let departed = create_object(
+            &mut state,
+            CardId(515),
+            PlayerId(0),
+            "Departed creature".to_string(),
+            Zone::Graveyard,
+        );
+        let object = state.objects.get_mut(&departed).unwrap();
+        object.card_types.core_types = vec![CoreType::Creature];
+        object.power = Some(6);
+        state.last_zone_changed_ids = vec![departed];
+
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::Power,
+                    CardTypeSetSource::Objects {
+                        filter: TargetFilter::And {
+                            filters: vec![
+                                TargetFilter::LastZoneChanged,
+                                TargetFilter::Typed(TypedFilter::creature()),
+                            ],
+                        },
+                    },
+                )
+                .unwrap(),
+            ),
+        };
+
+        assert_eq!(
+            resolve_quantity(&state, &expr, PlayerId(0), source),
+            6,
+            "LastZoneChanged is a population anchor; it must not collapse to the typed branch's battlefield default",
+        );
+    }
+
+    #[test]
+    fn property_aggregate_tracked_sources_keep_chain_set_and_triggering_batch_distinct() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(520),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        let chain_member = create_object(
+            &mut state,
+            CardId(521),
+            PlayerId(0),
+            "Chain member".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&chain_member).unwrap().power = Some(2);
+        let batch_member = create_object(
+            &mut state,
+            CardId(522),
+            PlayerId(0),
+            "Batch member".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&batch_member).unwrap().power = Some(5);
+
+        let set_id = crate::types::identifiers::TrackedSetId(state.next_tracked_set_id);
+        state.next_tracked_set_id += 1;
+        state.tracked_object_sets.insert(set_id, vec![chain_member]);
+        state.current_trigger_events = vec![crate::types::events::GameEvent::AttackersDeclared {
+            attacker_ids: vec![batch_member],
+            defending_player: PlayerId(1),
+            attacks: vec![],
+        }];
+
+        let aggregate = |set| QuantityExpr::Ref {
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::Power,
+                    CardTypeSetSource::TrackedSet {
+                        set,
+                        caused_by: None,
+                    },
+                )
+                .unwrap(),
+            ),
+        };
+        assert_eq!(
+            resolve_quantity(
+                &state,
+                &aggregate(TrackedAnaphorSource::ChainSet),
+                PlayerId(0),
+                source,
+            ),
+            2,
+        );
+        assert_eq!(
+            resolve_quantity(
+                &state,
+                &aggregate(TrackedAnaphorSource::TriggeringBatch),
+                PlayerId(0),
+                source,
+            ),
+            5,
+        );
+    }
+
+    #[test]
+    fn property_aggregate_tracked_sources_preserve_departed_and_ceased_lki() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(523),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        let departed = create_object(
+            &mut state,
+            CardId(524),
+            PlayerId(0),
+            "Departed".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&departed).unwrap().power = Some(4);
+        let departed_lki = state.objects[&departed].snapshot_public_characteristics();
+        state.lki_cache.insert(departed, departed_lki);
+        let departed_object = state.objects.get_mut(&departed).unwrap();
+        departed_object.zone = Zone::Graveyard;
+        departed_object.power = None;
+        state.battlefield.retain(|&id| id != departed);
+
+        let ceased = create_object(
+            &mut state,
+            CardId(525),
+            PlayerId(0),
+            "Ceased".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&ceased).unwrap().power = Some(7);
+        let ceased_lki = state.objects[&ceased].snapshot_public_characteristics();
+        state.lki_cache.insert(ceased, ceased_lki);
+        state.objects.remove(&ceased);
+        state.battlefield.retain(|&id| id != ceased);
+
+        let set_id = crate::types::identifiers::TrackedSetId(state.next_tracked_set_id);
+        state.next_tracked_set_id += 1;
+        state
+            .tracked_object_sets
+            .insert(set_id, vec![departed, ceased]);
+        let expr = QuantityExpr::Ref {
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::Power,
+                    CardTypeSetSource::TrackedSet {
+                        set: TrackedAnaphorSource::ChainSet,
+                        caused_by: None,
+                    },
+                )
+                .unwrap(),
+            ),
+        };
+
+        assert_eq!(
+            resolve_quantity(&state, &expr, PlayerId(0), source),
+            11,
+            "tracked populations retain both a departed live id's LKI and a ceased object's LKI",
+        );
+    }
+
+    #[test]
+    fn property_aggregate_any_of_deduplicates_objects_and_cast_occurrences() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(501),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        let exiled = create_object(
+            &mut state,
+            CardId(502),
+            PlayerId(0),
+            "Exiled".to_string(),
+            Zone::Exile,
+        );
+        state.objects.get_mut(&exiled).unwrap().mana_cost = ManaCost::generic(5);
+        let object_union = CardTypeSetSource::any_of(vec![
+            CardTypeSetSource::Zone {
+                zone: ZoneRef::Exile,
+                scope: CountScope::Controller,
+            },
+            CardTypeSetSource::Objects {
+                filter: TargetFilter::Typed(
+                    TypedFilter::card().properties(vec![FilterProp::InZone { zone: Zone::Exile }]),
+                ),
+            },
+        ])
+        .unwrap();
+        let object_expr = QuantityExpr::Ref {
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::ManaValue,
+                    object_union,
+                )
+                .unwrap(),
+            ),
+        };
+        assert_eq!(
+            resolve_quantity(&state, &object_expr, PlayerId(0), source),
+            5
+        );
+
+        state.spells_cast_this_turn_by_player.insert(
+            PlayerId(0),
+            crate::im::Vector::unit(SpellCastRecord {
+                mana_value: 3,
+                spell_object_id: Some(ObjectId(700)),
+                ..SpellCastRecord::default()
+            }),
+        );
+        let journal = CardTypeSetSource::TurnJournal {
+            journal: TurnJournalKind::SpellsCast,
+            scope: CountScope::Controller,
+            filter: None,
+        };
+        let cast_expr = QuantityExpr::Ref {
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::ManaValue,
+                    CardTypeSetSource::any_of(vec![journal.clone(), journal]).unwrap(),
+                )
+                .unwrap(),
+            ),
+        };
+        assert_eq!(resolve_quantity(&state, &cast_expr, PlayerId(0), source), 3);
+    }
+
+    #[test]
+    fn property_aggregate_turn_journal_excludes_only_the_resolving_occurrence() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(503),
+            PlayerId(0),
+            "Resolving".to_string(),
+            Zone::Stack,
+        );
+        state.spells_cast_this_turn_by_player.insert(
+            PlayerId(0),
+            crate::im::Vector::from(vec![
+                SpellCastRecord {
+                    core_types: vec![CoreType::Instant],
+                    mana_value: 2,
+                    spell_object_id: Some(ObjectId(701)),
+                    ..SpellCastRecord::default()
+                },
+                SpellCastRecord {
+                    core_types: vec![CoreType::Instant],
+                    mana_value: 5,
+                    spell_object_id: Some(source),
+                    ..SpellCastRecord::default()
+                },
+            ]),
+        );
+        let aggregate = crate::types::ability::PropertyAggregate::new(
+            AggregateFunction::Sum,
+            ObjectProperty::ManaValue,
+            CardTypeSetSource::TurnJournal {
+                journal: TurnJournalKind::SpellsCast,
+                scope: CountScope::Controller,
+                filter: Some(TargetFilter::Typed(
+                    TypedFilter::card().properties(vec![FilterProp::OtherThanTriggerObject]),
+                )),
+            },
+        )
+        .unwrap();
+        let qty = QuantityRef::PropertyAggregate(aggregate);
+        let mut ability = ResolvedAbility::new(Effect::NoOp, vec![], source, PlayerId(0));
+        ability.cast_occurrence = Some(crate::types::game_state::CastOccurrence {
+            caster: PlayerId(0),
+            turn_journal_index: 1,
+        });
+        let ctx = QuantityContext {
+            entering: None,
+            source,
+            trigger_source: None,
+            recipient: None,
+            scoped_player: None,
+            damage_source: None,
+        };
+        assert_eq!(
+            resolve_ref(
+                &state,
+                &qty,
+                PlayerId(0),
+                ctx.clone(),
+                &[],
+                None,
+                Some(&ability)
+            ),
+            2
+        );
+        let excluding = CardTypeSetSource::TurnJournal {
+            journal: TurnJournalKind::SpellsCast,
+            scope: CountScope::Controller,
+            filter: Some(TargetFilter::Typed(
+                TypedFilter::card().properties(vec![FilterProp::OtherThanTriggerObject]),
+            )),
+        };
+        let inclusive = CardTypeSetSource::TurnJournal {
+            journal: TurnJournalKind::SpellsCast,
+            scope: CountScope::Controller,
+            filter: None,
+        };
+        for members in [
+            vec![excluding.clone(), inclusive.clone()],
+            vec![inclusive.clone(), excluding.clone()],
+        ] {
+            let union = QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::ManaValue,
+                    CardTypeSetSource::any_of(members).unwrap(),
+                )
+                .unwrap(),
+            );
+            assert_eq!(
+                resolve_ref(
+                    &state,
+                    &union,
+                    PlayerId(0),
+                    ctx.clone(),
+                    &[],
+                    None,
+                    Some(&ability),
+                ),
+                7,
+                "a union's inclusive leg keeps the current cast regardless of member order",
+            );
+        }
+        ability.cast_occurrence.as_mut().unwrap().turn_journal_index = 0;
+        assert_eq!(
+            resolve_ref(&state, &qty, PlayerId(0), ctx, &[], None, Some(&ability)),
+            7,
+            "a divergent occurrence must not exclude either record"
+        );
+    }
+
+    #[test]
+    fn property_aggregate_turn_journal_uses_original_controller_during_player_fanout() {
+        let mut state = GameState::new_two_player(42);
+        state.spells_cast_this_turn_by_player.insert(
+            PlayerId(0),
+            crate::im::Vector::unit(SpellCastRecord {
+                mana_value: 6,
+                ..SpellCastRecord::default()
+            }),
+        );
+        state.spells_cast_this_turn_by_player.insert(
+            PlayerId(1),
+            crate::im::Vector::unit(SpellCastRecord {
+                mana_value: 1,
+                ..SpellCastRecord::default()
+            }),
+        );
+        let qty = QuantityRef::PropertyAggregate(
+            crate::types::ability::PropertyAggregate::new(
+                AggregateFunction::Sum,
+                ObjectProperty::ManaValue,
+                CardTypeSetSource::TurnJournal {
+                    journal: TurnJournalKind::SpellsCast,
+                    scope: CountScope::Controller,
+                    filter: None,
+                },
+            )
+            .unwrap(),
+        );
+        let source = ObjectId(900);
+        let mut ability = ResolvedAbility::new(Effect::NoOp, vec![], source, PlayerId(1));
+        ability.original_controller = Some(PlayerId(0));
+        assert_eq!(
+            resolve_ref(
+                &state,
+                &qty,
+                PlayerId(1),
+                QuantityContext {
+                    entering: None,
+                    source,
+                    trigger_source: None,
+                    recipient: None,
+                    scoped_player: None,
+                    damage_source: None,
+                },
+                &[],
+                None,
+                Some(&ability),
+            ),
+            6
+        );
     }
 
     #[test]
@@ -15536,20 +16193,25 @@ mod tests {
         }
 
         let expr = QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::ManaValue,
-                filter: TargetFilter::And {
-                    filters: vec![
-                        TargetFilter::ExiledBySource,
-                        TargetFilter::Typed(TypedFilter::default().properties(vec![
-                            FilterProp::Owned {
-                                controller: ControllerRef::You,
-                            },
-                        ])),
-                    ],
-                },
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::ManaValue,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::And {
+                            filters: vec![
+                                TargetFilter::ExiledBySource,
+                                TargetFilter::Typed(TypedFilter::default().properties(vec![
+                                    FilterProp::Owned {
+                                        controller: ControllerRef::You,
+                                    },
+                                ])),
+                            ],
+                        },
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         };
 
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), source), 5);
@@ -15620,20 +16282,25 @@ mod tests {
         });
 
         let expr = QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::ManaValue,
-                filter: TargetFilter::And {
-                    filters: vec![
-                        TargetFilter::ExiledBySource,
-                        TargetFilter::Typed(TypedFilter::default().properties(vec![
-                            FilterProp::Owned {
-                                controller: ControllerRef::You,
-                            },
-                        ])),
-                    ],
-                },
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::ManaValue,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::And {
+                            filters: vec![
+                                TargetFilter::ExiledBySource,
+                                TargetFilter::Typed(TypedFilter::default().properties(vec![
+                                    FilterProp::Owned {
+                                        controller: ControllerRef::You,
+                                    },
+                                ])),
+                            ],
+                        },
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         };
 
         assert_eq!(resolve_quantity(&state, &expr, PlayerId(0), source), 5);
@@ -17307,11 +17974,16 @@ mod tests {
         };
         // Max: triggering creature (power 6) must be excluded; max of remaining is 4.
         let max_expr = QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: AggregateFunction::Max,
-                property: ObjectProperty::Power,
-                filter: other_creatures(),
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Max,
+                    ObjectProperty::Power,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: other_creatures(),
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         };
         assert_eq!(resolve_quantity(&state, &max_expr, PlayerId(0), source), 4);
 
@@ -17319,11 +17991,16 @@ mod tests {
         // `OtherThanTriggerObject` exclusion — sum is 2 + 4 = 6 (NOT 12 with the
         // triggering 6/6 included).
         let sum_expr = QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::Power,
-                filter: other_creatures(),
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::Power,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: other_creatures(),
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         };
         assert_eq!(resolve_quantity(&state, &sum_expr, PlayerId(0), source), 6);
     }
@@ -17834,16 +18511,21 @@ mod tests {
         }
 
         let expr = QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::Power,
-                filter: TargetFilter::And {
-                    filters: vec![
-                        TargetFilter::Typed(TypedFilter::creature()),
-                        TargetFilter::ExiledBySource,
-                    ],
-                },
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::Power,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::And {
+                            filters: vec![
+                                TargetFilter::Typed(TypedFilter::creature()),
+                                TargetFilter::ExiledBySource,
+                            ],
+                        },
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         };
 
         // 3 + 5 = 8 from LKI; pre-fix this returned 0 because obj.power was None.
@@ -18395,7 +19077,10 @@ mod tests {
         let count_for = |caused_by| {
             let expr = QuantityExpr::Ref {
                 qty: QuantityRef::DistinctCardTypes {
-                    source: CardTypeSetSource::TrackedSet { caused_by },
+                    source: CardTypeSetSource::TrackedSet {
+                        set: TrackedAnaphorSource::ChainSet,
+                        caused_by,
+                    },
                 },
             };
             resolve_quantity(&state, &expr, PlayerId(0), ObjectId(999))
@@ -18467,6 +19152,7 @@ mod tests {
         let expr = QuantityExpr::Ref {
             qty: QuantityRef::DistinctCardTypes {
                 source: CardTypeSetSource::TrackedSet {
+                    set: TrackedAnaphorSource::ChainSet,
                     caused_by: Some(ThisWayCause::Discarded),
                 },
             },

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -10721,7 +10721,6 @@ fn quantity_ref_binding_diverges(qty: &QuantityRef) -> bool {
         | QuantityRef::ObjectCountDistinct { filter, .. }
         | QuantityRef::ObjectCountBySharedQuality { filter, .. }
         | QuantityRef::CountersOnObjects { filter, .. }
-        | QuantityRef::Aggregate { filter, .. }
         | QuantityRef::EnteredThisTurn { filter }
         | QuantityRef::DistinctCounterKindsAmong { filter }
         | QuantityRef::ControlledByEachPlayer { filter, .. }
@@ -10752,6 +10751,9 @@ fn quantity_ref_binding_diverges(qty: &QuantityRef) -> bool {
         | QuantityRef::DistinctSubtypes { source, .. }
         | QuantityRef::DistinctColorsAmong { source } => {
             card_type_set_source_binding_diverges(source)
+        }
+        QuantityRef::PropertyAggregate(aggregate) => {
+            card_type_set_source_binding_diverges(aggregate.source())
         }
         // CR 601.2h: `AbilityTarget` is a target-slot read that
         // `quantity::resolve_event_scoped_ref` explicitly answers `None` for at
@@ -10785,7 +10787,6 @@ fn quantity_ref_binding_diverges(qty: &QuantityRef) -> bool {
         // unrelated earlier resolution left in the ledger (or nothing at all).
         | QuantityRef::TrackedSetSize
         | QuantityRef::FilteredTrackedSetSize { .. }
-        | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
         | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::PreviousEffectCount
@@ -14824,7 +14825,6 @@ fn quantity_ref_refs_cost_paid_object(qty: &QuantityRef) -> bool {
         | QuantityRef::ObjectCountDistinct { filter, .. }
         | QuantityRef::ObjectCountBySharedQuality { filter, .. }
         | QuantityRef::CountersOnObjects { filter, .. }
-        | QuantityRef::Aggregate { filter, .. }
         | QuantityRef::ControlledByEachPlayer { filter, .. }
         | QuantityRef::EnteredThisTurn { filter }
         | QuantityRef::SacrificedThisTurn { filter, .. }
@@ -14862,6 +14862,9 @@ fn quantity_ref_refs_cost_paid_object(qty: &QuantityRef) -> bool {
         | QuantityRef::DistinctColorsAmong { source } => {
             characteristic_source_references_cost_paid_object(source)
         }
+        QuantityRef::PropertyAggregate(aggregate) => {
+            characteristic_source_references_cost_paid_object(aggregate.source())
+        }
 
         // Mana-spent metering embeds a `TargetFilter` through its metric enum.
         QuantityRef::ManaSpentToCast { metric, .. } => match metric {
@@ -14898,7 +14901,6 @@ fn quantity_ref_refs_cost_paid_object(qty: &QuantityRef) -> bool {
         | QuantityRef::ExiledCardPower { .. }
         | QuantityRef::BasicLandTypeCount { .. }
         | QuantityRef::TrackedSetSize
-        | QuantityRef::TrackedSetAggregate { .. }
         | QuantityRef::ExiledFromHandThisResolution
         | QuantityRef::PreviousEffectAmount { .. }
         | QuantityRef::PreviousEffectCount
@@ -21135,7 +21137,10 @@ pub mod tests {
         for source in [
             clean,
             CardTypeSetSource::ExiledBySource,
-            CardTypeSetSource::TrackedSet { caused_by: None },
+            CardTypeSetSource::TrackedSet {
+                set: crate::types::ability::TrackedAnaphorSource::ChainSet,
+                caused_by: None,
+            },
         ] {
             assert!(
                 !characteristic_source_references_cost_paid_object(&source),
@@ -26436,44 +26441,54 @@ pub mod tests {
                                 name: "Illusion".to_string(),
                                 power: crate::types::ability::PtValue::Quantity(
                                     QuantityExpr::Ref {
-                                        qty: QuantityRef::Aggregate {
-                                            function: crate::types::ability::AggregateFunction::Sum,
-                                            property:
+                                        qty: QuantityRef::PropertyAggregate(
+                                            crate::types::ability::PropertyAggregate::new(
+                                                crate::types::ability::AggregateFunction::Sum,
                                                 crate::types::ability::ObjectProperty::ManaValue,
-                                            filter: TargetFilter::And {
-                                                filters: vec![
-                                                    TargetFilter::ExiledBySource,
-                                                    TargetFilter::Typed(
-                                                        TypedFilter::default().properties(vec![
-                                                            FilterProp::Owned {
-                                                                controller: ControllerRef::You,
-                                                            },
-                                                        ]),
-                                                    ),
-                                                ],
-                                            },
-                                        },
+                                                crate::types::ability::CardTypeSetSource::Objects {
+                                                    filter: TargetFilter::And {
+                                                        filters: vec![
+                                                            TargetFilter::ExiledBySource,
+                                                            TargetFilter::Typed(
+                                                                TypedFilter::default().properties(
+                                                                    vec![FilterProp::Owned {
+                                                                        controller:
+                                                                            ControllerRef::You,
+                                                                    }],
+                                                                ),
+                                                            ),
+                                                        ],
+                                                    },
+                                                },
+                                            )
+                                            .expect("statically valid property aggregate"),
+                                        ),
                                     },
                                 ),
                                 toughness: crate::types::ability::PtValue::Quantity(
                                     QuantityExpr::Ref {
-                                        qty: QuantityRef::Aggregate {
-                                            function: crate::types::ability::AggregateFunction::Sum,
-                                            property:
+                                        qty: QuantityRef::PropertyAggregate(
+                                            crate::types::ability::PropertyAggregate::new(
+                                                crate::types::ability::AggregateFunction::Sum,
                                                 crate::types::ability::ObjectProperty::ManaValue,
-                                            filter: TargetFilter::And {
-                                                filters: vec![
-                                                    TargetFilter::ExiledBySource,
-                                                    TargetFilter::Typed(
-                                                        TypedFilter::default().properties(vec![
-                                                            FilterProp::Owned {
-                                                                controller: ControllerRef::You,
-                                                            },
-                                                        ]),
-                                                    ),
-                                                ],
-                                            },
-                                        },
+                                                crate::types::ability::CardTypeSetSource::Objects {
+                                                    filter: TargetFilter::And {
+                                                        filters: vec![
+                                                            TargetFilter::ExiledBySource,
+                                                            TargetFilter::Typed(
+                                                                TypedFilter::default().properties(
+                                                                    vec![FilterProp::Owned {
+                                                                        controller:
+                                                                            ControllerRef::You,
+                                                                    }],
+                                                                ),
+                                                            ),
+                                                        ],
+                                                    },
+                                                },
+                                            )
+                                            .expect("statically valid property aggregate"),
+                                        ),
                                     },
                                 ),
                                 types: vec!["Creature".to_string(), "Illusion".to_string()],

--- a/crates/engine/src/parser/oracle.rs
+++ b/crates/engine/src/parser/oracle.rs
@@ -1546,7 +1546,6 @@ fn quantity_ref_uses_filter_prop(qty: &QuantityRef, pred: &impl Fn(&FilterProp) 
         | QuantityRef::ObjectCountDistinct { filter, .. }
         | QuantityRef::ObjectCountBySharedQuality { filter, .. }
         | QuantityRef::CountersOnObjects { filter, .. }
-        | QuantityRef::Aggregate { filter, .. }
         | QuantityRef::ControlledByEachPlayer { filter, .. }
         | QuantityRef::DistinctCounterKindsAmong { filter }
         | QuantityRef::EnteredThisTurn { filter }
@@ -1564,6 +1563,9 @@ fn quantity_ref_uses_filter_prop(qty: &QuantityRef, pred: &impl Fn(&FilterProp) 
         | QuantityRef::DistinctSubtypes { source, .. }
         | QuantityRef::DistinctColorsAmong { source } => {
             characteristic_source_uses_filter_prop(source, pred)
+        }
+        QuantityRef::PropertyAggregate(aggregate) => {
+            characteristic_source_uses_filter_prop(aggregate.source(), pred)
         }
         _ => false,
     }

--- a/crates/engine/src/parser/oracle_effect/conditions.rs
+++ b/crates/engine/src/parser/oracle_effect/conditions.rs
@@ -7550,7 +7550,7 @@ mod tests {
     use crate::parser::oracle_nom::condition::parse_inner_condition;
     use crate::parser::parse_oracle_text;
     use crate::types::ability::{
-        AggregateFunction, CommanderOwnership, PlayerFilter, SharedQuality,
+        AggregateFunction, CardTypeSetSource, CommanderOwnership, PlayerFilter, SharedQuality,
     };
     use crate::types::counter::{CounterMatch, CounterType};
 
@@ -9206,11 +9206,16 @@ mod tests {
         assert_eq!(
             rhs,
             QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Min,
-                    property: ObjectProperty::Power,
-                    filter: TargetFilter::Typed(TypedFilter::creature()),
-                }
+                qty: QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        AggregateFunction::Min,
+                        ObjectProperty::Power,
+                        crate::types::ability::CardTypeSetSource::Objects {
+                            filter: TargetFilter::Typed(TypedFilter::creature())
+                        }
+                    )
+                    .expect("statically valid property aggregate")
+                )
             }
         );
     }
@@ -9248,21 +9253,22 @@ mod tests {
             }
         );
         let QuantityExpr::Ref {
-            qty:
-                QuantityRef::Aggregate {
-                    function,
-                    property,
-                    filter,
-                },
+            qty: QuantityRef::PropertyAggregate(aggregate),
         } = rhs
         else {
             panic!("expected Aggregate rhs, got {rhs:?}");
         };
-        assert_eq!(function, AggregateFunction::Min);
-        assert_eq!(property, ObjectProperty::Power);
+        assert_eq!(aggregate.function(), AggregateFunction::Min);
+        assert_eq!(aggregate.property(), ObjectProperty::Power);
+        let CardTypeSetSource::Objects { filter } = aggregate.source() else {
+            panic!(
+                "expected object aggregate source, got {:?}",
+                aggregate.source()
+            );
+        };
         // The "on the battlefield" qualifier rides the aggregate population.
         assert!(
-            matches!(&filter, TargetFilter::Typed(tf)
+            matches!(filter, TargetFilter::Typed(tf)
             if tf.properties.iter().any(|p| matches!(
                 p,
                 FilterProp::InZone { zone: Zone::Battlefield }
@@ -9289,11 +9295,16 @@ mod tests {
         assert_eq!(
             rhs,
             QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Max,
-                    property: ObjectProperty::Toughness,
-                    filter: TargetFilter::Typed(TypedFilter::creature()),
-                }
+                qty: QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        AggregateFunction::Max,
+                        ObjectProperty::Toughness,
+                        crate::types::ability::CardTypeSetSource::Objects {
+                            filter: TargetFilter::Typed(TypedFilter::creature())
+                        }
+                    )
+                    .expect("statically valid property aggregate")
+                )
             }
         );
     }

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -12149,12 +12149,10 @@ mod tests {
         assert!(matches!(
             count,
             QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Max,
-                    property: ObjectProperty::ManaValue,
-                    ..
-                }
+                qty: QuantityRef::PropertyAggregate(aggregate)
             }
+            if aggregate.function() == AggregateFunction::Max
+                && aggregate.property() == ObjectProperty::ManaValue
         ));
     }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -102,23 +102,24 @@ use crate::parser::oracle_effect::subject::parse_subject_application;
 use crate::parser::oracle_ir::diagnostic::OracleDiagnostic;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AbilityTag, AggregateFunction,
-    BounceSelection, CardPlayMode, CastFromZoneDriver, CastPermissionConstraint, CastingPermission,
-    ChoiceType, ChooseFromZoneConstraint, Chooser, CombatDamageScope, Comparator, ConjureCard,
-    ConjureSource, ContinuousModification, ControlWindow, ControllerRef, CopyChooseScope,
-    CopyRetargetPermission, CopyScale, DamageModification, DamageSource, DelayedTriggerCondition,
-    DelayedTriggerLifetime, DieResultBranch, DoubleTarget, Duration, Effect, EffectOutcomeSignal,
-    EffectScope, FilterProp, GameRestriction, GuessSubject, IntensityScope, IterationKindBinding,
-    KeeperConstraint, LibraryPosition, ManaProduction, ManaSpendPermission, ManaTargetRole,
-    MultiTargetSpec, NumberDistinctness, ObjectProperty, ObjectScope, OriginConstraint,
-    PerPlayerScope, PerpetualModification, PlayPermissionInvalidation, PlayerChoiceDistinctness,
-    PlayerFilter, PlayerRelation, PlayerScope, PreventionAmount, PreventionScope,
-    ProhibitedActivity, PtValue, QuantityExpr, QuantityRef, ReplacementCondition,
-    ReplacementDefinition, RestrictionExpiry, RestrictionPlayerScope, RevealUntilDisposition,
-    RoundingMode, SharedQuality, SharedQualityRelation, SiblingCondition, SkipScope,
-    SpellStackToGraveyardReplacement, StaticCondition, StaticDefinition, StepSkipTarget,
-    SubAbilityLink, TapStateChange, TargetFilter, TargetSelectionMode, ThisWayCause,
-    TrackedAnaphorSource, TriggerCondition, TriggerDefinition, TurnGate, TypeFilter, TypedFilter,
-    UnlessPayModifier, UntilCondition, WheneverEventExpiry, ZoneOwner,
+    BounceSelection, CardPlayMode, CardTypeSetSource, CastFromZoneDriver, CastPermissionConstraint,
+    CastingPermission, ChoiceType, ChooseFromZoneConstraint, Chooser, CombatDamageScope,
+    Comparator, ConjureCard, ConjureSource, ContinuousModification, ControlWindow, ControllerRef,
+    CopyChooseScope, CopyRetargetPermission, CopyScale, DamageModification, DamageSource,
+    DelayedTriggerCondition, DelayedTriggerLifetime, DieResultBranch, DoubleTarget, Duration,
+    Effect, EffectOutcomeSignal, EffectScope, FilterProp, GameRestriction, GuessSubject,
+    IntensityScope, IterationKindBinding, KeeperConstraint, LibraryPosition, ManaProduction,
+    ManaSpendPermission, ManaTargetRole, MultiTargetSpec, NumberDistinctness, ObjectProperty,
+    ObjectScope, OriginConstraint, PerPlayerScope, PerpetualModification,
+    PlayPermissionInvalidation, PlayerChoiceDistinctness, PlayerFilter, PlayerRelation,
+    PlayerScope, PreventionAmount, PreventionScope, ProhibitedActivity, PropertyAggregate, PtValue,
+    QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition, RestrictionExpiry,
+    RestrictionPlayerScope, RevealUntilDisposition, RoundingMode, SharedQuality,
+    SharedQualityRelation, SiblingCondition, SkipScope, SpellStackToGraveyardReplacement,
+    StaticCondition, StaticDefinition, StepSkipTarget, SubAbilityLink, TapStateChange,
+    TargetFilter, TargetSelectionMode, ThisWayCause, TrackedAnaphorSource, TriggerCondition,
+    TriggerDefinition, TurnGate, TypeFilter, TypedFilter, UnlessPayModifier, UntilCondition,
+    WheneverEventExpiry, ZoneOwner,
 };
 #[cfg(test)]
 use crate::types::ability::{AttackScope, AttackSubject};
@@ -27798,12 +27799,23 @@ fn def_slots_reference_triggering_batch(def: &AbilityDefinition) -> bool {
     fn expr_references_batch(expr: &QuantityExpr) -> bool {
         match expr {
             QuantityExpr::Ref {
-                qty:
-                    QuantityRef::TrackedSetAggregate {
-                        source: TrackedAnaphorSource::TriggeringBatch,
-                        ..
+                qty: QuantityRef::PropertyAggregate(aggregate),
+            } => {
+                let mut found = false;
+                let complete = aggregate.source().try_for_each_member(
+                    crate::types::ability::UNION_DEPTH_BUDGET,
+                    &mut |leaf| {
+                        found |= matches!(
+                            leaf,
+                            CardTypeSetSource::TrackedSet {
+                                set: TrackedAnaphorSource::TriggeringBatch,
+                                ..
+                            }
+                        );
                     },
-            } => true,
+                );
+                found || !complete
+            }
             QuantityExpr::Ref { .. } | QuantityExpr::Fixed { .. } => false,
             QuantityExpr::DivideRounded { inner, .. }
             | QuantityExpr::Multiply { inner, .. }
@@ -27843,12 +27855,23 @@ fn def_slots_reference_triggering_batch(def: &AbilityDefinition) -> bool {
 fn rebind_tracked_aggregate_expr(expr: &mut QuantityExpr) {
     match expr {
         QuantityExpr::Ref {
-            qty:
-                QuantityRef::TrackedSetAggregate {
-                    source: source @ TrackedAnaphorSource::TriggeringBatch,
-                    ..
+            qty: QuantityRef::PropertyAggregate(aggregate),
+        } => {
+            let mut source = aggregate.source().clone();
+            let complete = source.try_for_each_member_mut(
+                crate::types::ability::UNION_DEPTH_BUDGET,
+                &mut |leaf| {
+                    if let CardTypeSetSource::TrackedSet { set, .. } = leaf {
+                        if *set == TrackedAnaphorSource::TriggeringBatch {
+                            *set = TrackedAnaphorSource::ChainSet;
+                        }
+                    }
                 },
-        } => *source = TrackedAnaphorSource::ChainSet,
+            );
+            assert!(complete, "validated property aggregate source depth");
+            *aggregate = PropertyAggregate::new(aggregate.function(), aggregate.property(), source)
+                .expect("retargeting a tracked population preserves aggregate validity");
+        }
         QuantityExpr::Ref { .. } | QuantityExpr::Fixed { .. } => {}
         QuantityExpr::DivideRounded { inner, .. }
         | QuantityExpr::Multiply { inner, .. }

--- a/crates/engine/src/parser/oracle_effect/search.rs
+++ b/crates/engine/src/parser/oracle_effect/search.rs
@@ -2076,11 +2076,16 @@ fn parse_highest_mana_value_library_suffix(
             FilterProp::Cmc {
                 comparator: Comparator::EQ,
                 value: QuantityExpr::Ref {
-                    qty: QuantityRef::Aggregate {
-                        function: AggregateFunction::Max,
-                        property: ObjectProperty::ManaValue,
-                        filter: eligible_filter,
-                    },
+                    qty: QuantityRef::PropertyAggregate(
+                        crate::types::ability::PropertyAggregate::new(
+                            AggregateFunction::Max,
+                            ObjectProperty::ManaValue,
+                            crate::types::ability::CardTypeSetSource::Objects {
+                                filter: eligible_filter,
+                            },
+                        )
+                        .expect("statically valid property aggregate"),
+                    ),
                 },
             },
         ],
@@ -5035,13 +5040,10 @@ mod tests {
             FilterProp::Cmc {
                 comparator: Comparator::EQ,
                 value: QuantityExpr::Ref {
-                    qty: QuantityRef::Aggregate {
-                        function: AggregateFunction::Max,
-                        property: ObjectProperty::ManaValue,
-                        ..
-                    },
+                    qty: QuantityRef::PropertyAggregate(aggregate),
                 },
-            }
+            } if aggregate.function() == AggregateFunction::Max
+                && aggregate.property() == ObjectProperty::ManaValue
         )));
         assert!(ctx.diagnostics.iter().all(|diagnostic| !matches!(
             diagnostic,
@@ -5077,13 +5079,10 @@ mod tests {
             FilterProp::Cmc {
                 comparator: Comparator::EQ,
                 value: QuantityExpr::Ref {
-                    qty: QuantityRef::Aggregate {
-                        function: AggregateFunction::Max,
-                        property: ObjectProperty::ManaValue,
-                        ..
-                    },
+                    qty: QuantityRef::PropertyAggregate(aggregate),
                 },
-            }
+            } if aggregate.function() == AggregateFunction::Max
+                && aggregate.property() == ObjectProperty::ManaValue
         )));
         assert!(ctx.diagnostics.iter().all(|diagnostic| !matches!(
             diagnostic,

--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -12613,18 +12613,23 @@ mod tests {
         };
         assert_eq!(counter_type, CounterType::Plus1Plus1);
         let expected_qty = QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::Power,
-                filter: TargetFilter::And {
-                    filters: vec![
-                        TargetFilter::Typed(
-                            TypedFilter::creature().controller(ControllerRef::ScopedPlayer),
-                        ),
-                        TargetFilter::ExiledBySource,
-                    ],
-                },
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::Power,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::And {
+                            filters: vec![
+                                TargetFilter::Typed(
+                                    TypedFilter::creature().controller(ControllerRef::ScopedPlayer),
+                                ),
+                                TargetFilter::ExiledBySource,
+                            ],
+                        },
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         };
         assert_eq!(count, expected_qty);
     }

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -86,18 +86,30 @@ fn nested_triggering_batch_aggregate_is_rebound_through_the_source_visitor() {
     };
     let mut batch = 0;
     let mut chain = 0;
+    let mut objects = 0;
+    let mut graveyard = 0;
+    let mut leaves = 0;
     assert!(aggregate.source().try_for_each_member(
         crate::types::ability::UNION_DEPTH_BUDGET,
         &mut |leaf| {
-            if let CardTypeSetSource::TrackedSet { set, .. } = leaf {
-                match set {
+            leaves += 1;
+            match leaf {
+                CardTypeSetSource::TrackedSet { set, .. } => match set {
                     TrackedAnaphorSource::TriggeringBatch => batch += 1,
                     TrackedAnaphorSource::ChainSet => chain += 1,
-                }
+                },
+                CardTypeSetSource::Objects {
+                    filter: TargetFilter::Any,
+                } => objects += 1,
+                CardTypeSetSource::Zone {
+                    zone: ZoneRef::Graveyard,
+                    scope: CountScope::Controller,
+                } => graveyard += 1,
+                _ => {}
             }
         },
     ));
-    assert_eq!((batch, chain), (0, 1));
+    assert_eq!((batch, chain, objects, graveyard, leaves), (0, 1, 1, 1, 3));
 }
 
 #[test]
@@ -115,6 +127,34 @@ fn nested_triggering_batch_in_non_trigger_chain_is_demoted_honestly() {
     demote_unbindable_batch_aggregate(&mut def, "their total mana value");
 
     assert!(matches!(def.effect.as_ref(), Effect::Unimplemented { .. }));
+
+    let source = CardTypeSetSource::any_of(vec![
+        CardTypeSetSource::Objects {
+            filter: TargetFilter::Any,
+        },
+        CardTypeSetSource::Zone {
+            zone: ZoneRef::Graveyard,
+            scope: CountScope::Controller,
+        },
+    ])
+    .expect("non-batch source union");
+    let aggregate =
+        PropertyAggregate::new(AggregateFunction::Sum, ObjectProperty::ManaValue, source)
+            .expect("valid non-batch aggregate");
+    let mut control = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::LoseLife {
+            amount: QuantityExpr::Ref {
+                qty: QuantityRef::PropertyAggregate(aggregate),
+            },
+            target: None,
+        },
+    );
+    demote_unbindable_batch_aggregate(&mut control, "their total mana value");
+    assert!(!matches!(
+        control.effect.as_ref(),
+        Effect::Unimplemented { .. }
+    ));
 }
 
 #[test]

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -22,16 +22,99 @@ fn assert_tracked_mana_value_source(def: &AbilityDefinition, expected: TrackedAn
     let Effect::LoseLife { amount, .. } = def.effect.as_ref() else {
         panic!("expected LoseLife, got {:?}", def.effect);
     };
+    let QuantityExpr::Ref {
+        qty: QuantityRef::PropertyAggregate(aggregate),
+    } = amount
+    else {
+        panic!("expected property aggregate, got {amount:?}");
+    };
+    assert_eq!(aggregate.function(), AggregateFunction::Sum);
+    assert_eq!(aggregate.property(), ObjectProperty::ManaValue);
     assert!(matches!(
-        amount,
-        QuantityExpr::Ref {
-            qty: QuantityRef::TrackedSetAggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::ManaValue,
-                source,
-            }
-        } if *source == expected
+        aggregate.source(),
+        CardTypeSetSource::TrackedSet { set, .. } if *set == expected
     ));
+}
+
+fn nested_batch_aggregate() -> PropertyAggregate {
+    PropertyAggregate::new(
+        AggregateFunction::Sum,
+        ObjectProperty::ManaValue,
+        CardTypeSetSource::any_of(vec![
+            CardTypeSetSource::Objects {
+                filter: TargetFilter::Any,
+            },
+            CardTypeSetSource::any_of(vec![
+                CardTypeSetSource::TrackedSet {
+                    set: TrackedAnaphorSource::TriggeringBatch,
+                    caused_by: None,
+                },
+                CardTypeSetSource::Zone {
+                    zone: ZoneRef::Graveyard,
+                    scope: CountScope::Controller,
+                },
+            ])
+            .expect("nested union"),
+        ])
+        .expect("outer union"),
+    )
+    .expect("valid mana-value aggregate")
+}
+
+#[test]
+fn nested_triggering_batch_aggregate_is_rebound_through_the_source_visitor() {
+    let mut def = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::LoseLife {
+            amount: QuantityExpr::Ref {
+                qty: QuantityRef::PropertyAggregate(nested_batch_aggregate()),
+            },
+            target: None,
+        },
+    );
+
+    rebind_tracked_aggregate_to_chain_set(&mut def);
+
+    let Effect::LoseLife { amount, .. } = def.effect.as_ref() else {
+        panic!("expected life loss");
+    };
+    let QuantityExpr::Ref {
+        qty: QuantityRef::PropertyAggregate(aggregate),
+    } = amount
+    else {
+        panic!("expected property aggregate");
+    };
+    let mut batch = 0;
+    let mut chain = 0;
+    assert!(aggregate.source().try_for_each_member(
+        crate::types::ability::UNION_DEPTH_BUDGET,
+        &mut |leaf| {
+            if let CardTypeSetSource::TrackedSet { set, .. } = leaf {
+                match set {
+                    TrackedAnaphorSource::TriggeringBatch => batch += 1,
+                    TrackedAnaphorSource::ChainSet => chain += 1,
+                }
+            }
+        },
+    ));
+    assert_eq!((batch, chain), (0, 1));
+}
+
+#[test]
+fn nested_triggering_batch_in_non_trigger_chain_is_demoted_honestly() {
+    let mut def = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::LoseLife {
+            amount: QuantityExpr::Ref {
+                qty: QuantityRef::PropertyAggregate(nested_batch_aggregate()),
+            },
+            target: None,
+        },
+    );
+
+    demote_unbindable_batch_aggregate(&mut def, "their total mana value");
+
+    assert!(matches!(def.effect.as_ref(), Effect::Unimplemented { .. }));
 }
 
 #[test]
@@ -350,11 +433,9 @@ fn cosmic_cube_aggregate_quantity_returns_trailing_suffix() {
     assert!(
         matches!(
             qty,
-            QuantityRef::Aggregate {
-                function: AggregateFunction::Max,
-                property: ObjectProperty::Power,
-                ..
-            }
+            QuantityRef::PropertyAggregate(ref aggregate)
+                if aggregate.function() == AggregateFunction::Max
+                    && aggregate.property() == ObjectProperty::Power
         ),
         "expected Max-power aggregate, got {qty:?}"
     );
@@ -375,14 +456,10 @@ fn cosmic_cube_constraint_parses_dynamic_mana_value_ceiling() {
             comparator: Comparator::LE,
             value:
                 QuantityExpr::Ref {
-                    qty:
-                        QuantityRef::Aggregate {
-                            function: AggregateFunction::Max,
-                            property: ObjectProperty::Power,
-                            ..
-                        },
+                    qty: QuantityRef::PropertyAggregate(aggregate),
                 },
-        }) => {}
+        }) if aggregate.function() == AggregateFunction::Max
+            && aggregate.property() == ObjectProperty::Power => {}
         other => panic!("expected dynamic ManaValue{{LE, Max-power aggregate}}, got {other:?}"),
     }
 }
@@ -563,13 +640,9 @@ fn cosmic_cube_full_trigger_carries_dynamic_constraint() {
             comparator: Comparator::LE,
             value:
                 QuantityExpr::Ref {
-                    qty:
-                        QuantityRef::Aggregate {
-                            property: ObjectProperty::Power,
-                            ..
-                        },
+                    qty: QuantityRef::PropertyAggregate(aggregate),
                 },
-        }) => {}
+        }) if aggregate.property() == ObjectProperty::Power => {}
         other => panic!(
             "Cosmic Cube CastFromZone constraint must be the dynamic MV ceiling, got {other:?}"
         ),
@@ -4520,7 +4593,7 @@ fn where_x_binds_siblings_in_same_sentence() {
     match &*def.effect {
             Effect::LoseLife { amount, .. } => match amount {
                 QuantityExpr::Ref {
-                    qty: QuantityRef::Aggregate { .. },
+                    qty: QuantityRef::PropertyAggregate(_),
                 } => {}
                 other => panic!(
                     "expected LoseLife amount to be Aggregate (propagated from sibling where-X), got {other:?}"
@@ -4533,7 +4606,7 @@ fn where_x_binds_siblings_in_same_sentence() {
     match &*sub.effect {
         Effect::GainLife { amount, .. } => match amount {
             QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate { .. },
+                qty: QuantityRef::PropertyAggregate(_),
             } => {}
             other => panic!("expected GainLife Aggregate, got {other:?}"),
         },
@@ -31247,18 +31320,16 @@ fn crackling_doom_sacrifice_preserves_greatest_power_filter() {
     assert_eq!(*superlative.1, PtValueScope::Current);
     assert_eq!(*superlative.2, Comparator::EQ);
     let QuantityExpr::Ref {
-        qty:
-            QuantityRef::Aggregate {
-                function,
-                property,
-                filter,
-            },
+        qty: QuantityRef::PropertyAggregate(aggregate),
     } = superlative.3
     else {
         panic!("expected aggregate quantity, got {:?}", superlative.3);
     };
-    assert_eq!(*function, AggregateFunction::Max);
-    assert_eq!(*property, ObjectProperty::Power);
+    assert_eq!(aggregate.function(), AggregateFunction::Max);
+    assert_eq!(aggregate.property(), ObjectProperty::Power);
+    let CardTypeSetSource::Objects { filter } = aggregate.source() else {
+        panic!("expected object population, got {:?}", aggregate.source());
+    };
     let TargetFilter::Typed(TypedFilter {
         type_filters,
         controller,
@@ -41120,11 +41191,16 @@ fn wretched_banquet_least_power_condition() {
             assert_eq!(
                 rhs,
                 QuantityExpr::Ref {
-                    qty: QuantityRef::Aggregate {
-                        function: AggregateFunction::Min,
-                        property: ObjectProperty::Power,
-                        filter: TargetFilter::Typed(TypedFilter::creature()),
-                    }
+                    qty: QuantityRef::PropertyAggregate(
+                        crate::types::ability::PropertyAggregate::new(
+                            AggregateFunction::Min,
+                            ObjectProperty::Power,
+                            crate::types::ability::CardTypeSetSource::Objects {
+                                filter: TargetFilter::Typed(TypedFilter::creature())
+                            }
+                        )
+                        .expect("statically valid property aggregate")
+                    )
                 }
             );
         }
@@ -50340,19 +50416,21 @@ fn ensnared_by_the_mara_damage_amount_is_tracked_set_aggregate() {
             damage.effect
         );
     };
-    assert!(
-        matches!(
-            amount,
-            QuantityExpr::Ref {
-                qty: QuantityRef::TrackedSetAggregate {
-                    function: AggregateFunction::Sum,
-                    property: ObjectProperty::ManaValue,
-                    source: crate::types::ability::TrackedAnaphorSource::ChainSet,
-                }
-            }
-        ),
-        "branch 1 damage amount must be TrackedSetAggregate(Sum, ManaValue, ChainSet), got {amount:?}"
-    );
+    let QuantityExpr::Ref {
+        qty: QuantityRef::PropertyAggregate(aggregate),
+    } = amount
+    else {
+        panic!("branch 1 damage amount must be a property aggregate, got {amount:?}");
+    };
+    assert_eq!(aggregate.function(), AggregateFunction::Sum);
+    assert_eq!(aggregate.property(), ObjectProperty::ManaValue);
+    assert!(matches!(
+        aggregate.source(),
+        crate::types::ability::CardTypeSetSource::TrackedSet {
+            set: crate::types::ability::TrackedAnaphorSource::ChainSet,
+            caused_by: None
+        }
+    ));
 
     // The verbatim Oracle aggregate phrase must never be stored as a
     // resolvable `QuantityRef::Variable` name (the prohibited

--- a/crates/engine/src/parser/oracle_effect/token.rs
+++ b/crates/engine/src/parser/oracle_effect/token.rs
@@ -1682,7 +1682,7 @@ mod tests {
         // Gap A + Gap B composed. The Skullspore Nexus create clause (verbatim)
         // must lower to a dynamic-P/T token whose base P/T reads the triggering
         // batch's total power. Baseline: `Effect::Unimplemented` (measured).
-        use crate::types::ability::{AggregateFunction, ObjectProperty, TrackedAnaphorSource};
+        use crate::types::ability::{AggregateFunction, ObjectProperty};
         let txt = "Create a green Fungus Dinosaur creature token with base power and toughness each equal to the total power of those creatures.";
         let effect = try_parse_token(&txt.to_lowercase(), txt, &mut ParseContext::default())
             .expect("Skullspore token must parse (was Unimplemented)");
@@ -1698,11 +1698,17 @@ mod tests {
             panic!("expected Effect::Token, got {effect:?}");
         };
         let expected_pt = PtValue::Quantity(QuantityExpr::Ref {
-            qty: QuantityRef::TrackedSetAggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::Power,
-                source: TrackedAnaphorSource::TriggeringBatch,
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::Power,
+                    crate::types::ability::CardTypeSetSource::TrackedSet {
+                        set: crate::types::ability::TrackedAnaphorSource::TriggeringBatch,
+                        caused_by: None,
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         });
         assert_eq!(power, expected_pt.clone(), "base power must be batch sum");
         assert_eq!(toughness, expected_pt, "base toughness must be batch sum");
@@ -1879,7 +1885,7 @@ mod tests {
 
     #[test]
     fn where_x_token_pt_covers_cards_exiled_this_way_aggregate() {
-        use crate::types::ability::{AggregateFunction, ObjectProperty, TrackedAnaphorSource};
+        use crate::types::ability::{AggregateFunction, ObjectProperty};
 
         let txt = "Create an X/X blue Zombie creature token, where X is the total power of the cards exiled this way.";
         let effect = try_parse_token(&txt.to_lowercase(), txt, &mut ParseContext::default())
@@ -1896,11 +1902,17 @@ mod tests {
             panic!("expected Effect::Token, got {effect:?}");
         };
         let expected_pt = PtValue::Quantity(QuantityExpr::Ref {
-            qty: QuantityRef::TrackedSetAggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::Power,
-                source: TrackedAnaphorSource::ChainSet,
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::Power,
+                    crate::types::ability::CardTypeSetSource::TrackedSet {
+                        set: crate::types::ability::TrackedAnaphorSource::ChainSet,
+                        caused_by: None,
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ),
         });
         assert_eq!(name, "Zombie");
         assert!(
@@ -1927,6 +1939,7 @@ mod tests {
             QuantityExpr::Ref {
                 qty: QuantityRef::DistinctCardTypes {
                     source: crate::types::ability::CardTypeSetSource::TrackedSet {
+                        set: crate::types::ability::TrackedAnaphorSource::ChainSet,
                         caused_by: Some(crate::types::ability::ThisWayCause::Discarded),
                     },
                 },

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__karn_legacy_reforged_ir.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__karn_legacy_reforged_ir.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/engine/src/parser/oracle_ir/snapshot_tests.rs
+assertion_line: 1714
 expression: "&ir"
 ---
 {
@@ -34,16 +35,19 @@ expression: "&ir"
                 "value": {
                   "type": "Ref",
                   "qty": {
-                    "type": "Aggregate",
+                    "type": "PropertyAggregate",
                     "function": "Max",
                     "property": "ManaValue",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Artifact"
-                      ],
-                      "controller": "You",
-                      "properties": []
+                    "source": {
+                      "type": "Objects",
+                      "filter": {
+                        "type": "Typed",
+                        "type_filters": [
+                          "Artifact"
+                        ],
+                        "controller": "You",
+                        "properties": []
+                      }
                     }
                   }
                 }
@@ -53,16 +57,19 @@ expression: "&ir"
                 "value": {
                   "type": "Ref",
                   "qty": {
-                    "type": "Aggregate",
+                    "type": "PropertyAggregate",
                     "function": "Max",
                     "property": "ManaValue",
-                    "filter": {
-                      "type": "Typed",
-                      "type_filters": [
-                        "Artifact"
-                      ],
-                      "controller": "You",
-                      "properties": []
+                    "source": {
+                      "type": "Objects",
+                      "filter": {
+                        "type": "Typed",
+                        "type_filters": [
+                          "Artifact"
+                        ],
+                        "controller": "You",
+                        "properties": []
+                      }
                     }
                   }
                 }

--- a/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__karn_legacy_reforged_lowered.snap
+++ b/crates/engine/src/parser/oracle_ir/snapshots/engine__parser__oracle_ir__snapshot_tests__karn_legacy_reforged_lowered.snap
@@ -81,16 +81,19 @@ expression: "&lowered"
           "value": {
             "type": "Ref",
             "qty": {
-              "type": "Aggregate",
+              "type": "PropertyAggregate",
               "function": "Max",
               "property": "ManaValue",
-              "filter": {
-                "type": "Typed",
-                "type_filters": [
-                  "Artifact"
-                ],
-                "controller": "You",
-                "properties": []
+              "source": {
+                "type": "Objects",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Artifact"
+                  ],
+                  "controller": "You",
+                  "properties": []
+                }
               }
             }
           }
@@ -100,16 +103,19 @@ expression: "&lowered"
           "value": {
             "type": "Ref",
             "qty": {
-              "type": "Aggregate",
+              "type": "PropertyAggregate",
               "function": "Max",
               "property": "ManaValue",
-              "filter": {
-                "type": "Typed",
-                "type_filters": [
-                  "Artifact"
-                ],
-                "controller": "You",
-                "properties": []
+              "source": {
+                "type": "Objects",
+                "filter": {
+                  "type": "Typed",
+                  "type_filters": [
+                    "Artifact"
+                  ],
+                  "controller": "You",
+                  "properties": []
+                }
               }
             }
           }

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -25,11 +25,11 @@ use crate::parser::oracle_target::{
 };
 use crate::parser::oracle_util::parse_subtype;
 use crate::types::ability::{
-    AbilityCondition, AggregateFunction, CastManaObjectScope, CastManaSpentMetric,
-    CommanderOwnership, Comparator, ControllerRef, CountScope, DamageChannel, DamageGroupKey,
-    DamageKindFilter, FilterProp, ObjectProperty, ObjectScope, PlayerFilter, PlayerRelation,
-    PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef, SharedQuality, StaticCondition,
-    TargetFilter, TypeFilter, TypedFilter, ZoneRef,
+    AbilityCondition, AggregateFunction, CardTypeSetSource, CastManaObjectScope,
+    CastManaSpentMetric, CommanderOwnership, Comparator, ControllerRef, CountScope, DamageChannel,
+    DamageGroupKey, DamageKindFilter, FilterProp, ObjectProperty, ObjectScope, PlayerFilter,
+    PlayerRelation, PlayerScope, PropertyAggregate, PtStat, PtValueScope, QuantityExpr,
+    QuantityRef, SharedQuality, StaticCondition, TargetFilter, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::events::PlayerActionKind;
@@ -3140,11 +3140,16 @@ fn parse_you_control_superlative_object_condition(
             scope: PtValueScope::Current,
             comparator,
             value: QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: aggregate,
-                    property,
-                    filter: population_filter,
-                },
+                qty: QuantityRef::PropertyAggregate(
+                    PropertyAggregate::new(
+                        aggregate,
+                        property,
+                        CardTypeSetSource::Objects {
+                            filter: population_filter,
+                        },
+                    )
+                    .expect("object property aggregate is valid"),
+                ),
             },
         },
     );
@@ -3192,11 +3197,16 @@ fn build_superlative_comparison(
         lhs: QuantityExpr::Ref { qty: lhs_qty },
         comparator,
         rhs: QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: aggregate,
-                property,
-                filter: aggregate_filter,
-            },
+            qty: QuantityRef::PropertyAggregate(
+                PropertyAggregate::new(
+                    aggregate,
+                    property,
+                    CardTypeSetSource::Objects {
+                        filter: aggregate_filter,
+                    },
+                )
+                .expect("object property aggregate is valid"),
+            ),
         },
     }
 }
@@ -3253,11 +3263,14 @@ pub(crate) fn parse_spell_target_has_superlative(
             lhs: QuantityExpr::Ref { qty: lhs_qty },
             comparator,
             rhs: QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: aggregate,
-                    property,
-                    filter,
-                },
+                qty: QuantityRef::PropertyAggregate(
+                    PropertyAggregate::new(
+                        aggregate,
+                        property,
+                        CardTypeSetSource::Objects { filter },
+                    )
+                    .expect("object property aggregate is valid"),
+                ),
             },
         },
     ))
@@ -4843,11 +4856,14 @@ fn parse_filter_have_total_property(input: &str) -> OracleResult<'_, StaticCondi
         rest,
         StaticCondition::QuantityComparison {
             lhs: QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Sum,
-                    property,
-                    filter,
-                },
+                qty: QuantityRef::PropertyAggregate(
+                    PropertyAggregate::new(
+                        AggregateFunction::Sum,
+                        property,
+                        CardTypeSetSource::Objects { filter },
+                    )
+                    .expect("object property aggregate is valid"),
+                ),
             },
             comparator,
             rhs: QuantityExpr::Fixed { value: n as i32 },
@@ -19610,15 +19626,13 @@ mod tests {
                 );
                 match lhs {
                     QuantityExpr::Ref {
-                        qty:
-                            QuantityRef::Aggregate {
-                                function,
-                                property,
-                                filter,
-                            },
+                        qty: QuantityRef::PropertyAggregate(aggregate),
                     } => {
-                        assert_eq!(function, AggregateFunction::Sum);
-                        assert_eq!(property, expected_property.0);
+                        assert_eq!(aggregate.function(), AggregateFunction::Sum);
+                        assert_eq!(aggregate.property(), expected_property.0);
+                        let CardTypeSetSource::Objects { filter } = aggregate.source() else {
+                            panic!("expected object source, got {:?}", aggregate.source());
+                        };
                         match filter {
                             TargetFilter::Typed(t) => {
                                 assert_eq!(t.controller, Some(ControllerRef::You));
@@ -19784,15 +19798,13 @@ mod tests {
                 );
                 match rhs {
                     QuantityExpr::Ref {
-                        qty:
-                            QuantityRef::Aggregate {
-                                function,
-                                property,
-                                filter,
-                            },
+                        qty: QuantityRef::PropertyAggregate(aggregate),
                     } => {
-                        assert_eq!(function, AggregateFunction::Max);
-                        assert_eq!(property, ObjectProperty::Power);
+                        assert_eq!(aggregate.function(), AggregateFunction::Max);
+                        assert_eq!(aggregate.property(), ObjectProperty::Power);
+                        let CardTypeSetSource::Objects { filter } = aggregate.source() else {
+                            panic!("expected object source, got {:?}", aggregate.source());
+                        };
                         match filter {
                             TargetFilter::Typed(tf) => {
                                 assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
@@ -19822,12 +19834,12 @@ mod tests {
                 comparator,
                 rhs:
                     QuantityExpr::Ref {
-                        qty: QuantityRef::Aggregate { function, .. },
+                        qty: QuantityRef::PropertyAggregate(aggregate),
                     },
                 ..
             } => {
                 assert_eq!(comparator, Comparator::LT);
-                assert_eq!(function, AggregateFunction::Min);
+                assert_eq!(aggregate.function(), AggregateFunction::Min);
             }
             other => panic!("expected QuantityComparison with Aggregate, got {other:?}"),
         }
@@ -19852,15 +19864,12 @@ mod tests {
                     },
                 rhs:
                     QuantityExpr::Ref {
-                        qty:
-                            QuantityRef::Aggregate {
-                                function, property, ..
-                            },
+                        qty: QuantityRef::PropertyAggregate(aggregate),
                     },
             } => {
                 assert_eq!(comparator, Comparator::GE);
-                assert_eq!(function, AggregateFunction::Max);
-                assert_eq!(property, ObjectProperty::Toughness);
+                assert_eq!(aggregate.function(), AggregateFunction::Max);
+                assert_eq!(aggregate.property(), ObjectProperty::Toughness);
             }
             other => panic!("expected QuantityComparison, got {other:?}"),
         }
@@ -19878,12 +19887,12 @@ mod tests {
                 comparator,
                 rhs:
                     QuantityExpr::Ref {
-                        qty: QuantityRef::Aggregate { function, .. },
+                        qty: QuantityRef::PropertyAggregate(aggregate),
                     },
                 ..
             } => {
                 assert_eq!(comparator, Comparator::GT);
-                assert_eq!(function, AggregateFunction::Max);
+                assert_eq!(aggregate.function(), AggregateFunction::Max);
             }
             other => panic!("expected QuantityComparison, got {other:?}"),
         }
@@ -20052,17 +20061,23 @@ mod tests {
                         comparator: Comparator::GE,
                         value:
                             QuantityExpr::Ref {
-                                qty:
-                                    QuantityRef::Aggregate {
-                                        function: AggregateFunction::Max,
-                                        property: ObjectProperty::Toughness,
-                                        filter: TargetFilter::Typed(population),
-                                    },
+                                qty: QuantityRef::PropertyAggregate(aggregate),
                             },
                     } = prop
                     else {
                         return false;
                     };
+                    let CardTypeSetSource::Objects {
+                        filter: TargetFilter::Typed(population),
+                    } = aggregate.source()
+                    else {
+                        return false;
+                    };
+                    if aggregate.function() != AggregateFunction::Max
+                        || aggregate.property() != ObjectProperty::Toughness
+                    {
+                        return false;
+                    }
                     population.type_filters == vec![TypeFilter::Creature]
                         && population.controller.is_none()
                 });
@@ -20108,17 +20123,23 @@ mod tests {
                         comparator: Comparator::GE,
                         value:
                             QuantityExpr::Ref {
-                                qty:
-                                    QuantityRef::Aggregate {
-                                        function: AggregateFunction::Max,
-                                        property: ObjectProperty::Power,
-                                        filter: TargetFilter::Typed(population),
-                                    },
+                                qty: QuantityRef::PropertyAggregate(aggregate),
                             },
                     } = prop
                     else {
                         return false;
                     };
+                    let CardTypeSetSource::Objects {
+                        filter: TargetFilter::Typed(population),
+                    } = aggregate.source()
+                    else {
+                        return false;
+                    };
+                    if aggregate.function() != AggregateFunction::Max
+                        || aggregate.property() != ObjectProperty::Power
+                    {
+                        return false;
+                    }
                     population.type_filters == vec![TypeFilter::Creature]
                         && population.properties.iter().any(|prop| {
                             matches!(

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -28,9 +28,9 @@ use crate::parser::oracle_util::parse_subtype;
 use crate::types::ability::{
     AggregateFunction, CardTypeSetSource, CastManaObjectScope, CastManaSpentMetric, ControllerRef,
     CountScope, DamageChannel, DamageKindFilter, DevotionColors, FilterProp, ObjectProperty,
-    ObjectScope, PlayerFilter, PlayerRelation, PlayerScope, PtStat, QuantityExpr, QuantityRef,
-    RoundingMode, SharedQuality, SubtypeExclusion, TargetFilter, ThisWayCause, TurnJournalKind,
-    TypeFilter, TypedFilter, ZoneRef,
+    ObjectScope, PlayerFilter, PlayerRelation, PlayerScope, PropertyAggregate, PtStat,
+    QuantityExpr, QuantityRef, RoundingMode, SharedQuality, SubtypeExclusion, TargetFilter,
+    ThisWayCause, TrackedAnaphorSource, TurnJournalKind, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::keywords::Keyword;
@@ -1195,11 +1195,16 @@ fn parse_linked_exile_mana_value_ref(input: &str) -> OracleResult<'_, QuantityRe
     let (rest, _) = opt(parse_craft_materials_suffix).parse(rest)?;
     Ok((
         rest,
-        QuantityRef::Aggregate {
-            function: AggregateFunction::Sum,
-            property: ObjectProperty::ManaValue,
-            filter: linked_exile_owned_filter(),
-        },
+        QuantityRef::PropertyAggregate(
+            crate::types::ability::PropertyAggregate::new(
+                AggregateFunction::Sum,
+                ObjectProperty::ManaValue,
+                crate::types::ability::CardTypeSetSource::Objects {
+                    filter: linked_exile_owned_filter(),
+                },
+            )
+            .expect("statically valid property aggregate"),
+        ),
     ))
 }
 
@@ -1325,11 +1330,16 @@ fn parse_greatest_commander_mana_value_ref(input: &str) -> OracleResult<'_, Quan
 
     Ok((
         rest,
-        QuantityRef::Aggregate {
-            function: AggregateFunction::Max,
-            property,
-            filter: zone_filter,
-        },
+        QuantityRef::PropertyAggregate(
+            PropertyAggregate::new(
+                AggregateFunction::Max,
+                property,
+                CardTypeSetSource::Objects {
+                    filter: zone_filter,
+                },
+            )
+            .expect("object populations support every aggregate property"),
+        ),
     ))
 }
 
@@ -1647,11 +1657,17 @@ pub(crate) fn parse_contextual_bare_card_aggregate_ref(
     let (rest, _) = parse_bare_card_set_anaphor(rest)?;
     Ok((
         rest,
-        QuantityRef::TrackedSetAggregate {
-            function,
-            property,
-            source,
-        },
+        QuantityRef::PropertyAggregate(
+            PropertyAggregate::new(
+                function,
+                property,
+                CardTypeSetSource::TrackedSet {
+                    set: source,
+                    caused_by: None,
+                },
+            )
+            .expect("tracked populations support every aggregate property"),
+        ),
     ))
 }
 
@@ -1686,11 +1702,17 @@ fn parse_object_property_aggregate_ref(input: &str) -> OracleResult<'_, Quantity
         if let Ok((anaphor_rest, _)) = parse_this_way_anaphor(rest) {
             return Ok((
                 anaphor_rest,
-                QuantityRef::TrackedSetAggregate {
-                    function: AggregateFunction::Sum,
-                    property,
-                    source: crate::types::ability::TrackedAnaphorSource::ChainSet,
-                },
+                QuantityRef::PropertyAggregate(
+                    PropertyAggregate::new(
+                        AggregateFunction::Sum,
+                        property,
+                        CardTypeSetSource::TrackedSet {
+                            set: TrackedAnaphorSource::ChainSet,
+                            caused_by: None,
+                        },
+                    )
+                    .expect("tracked populations support every aggregate property"),
+                ),
             ));
         }
     }
@@ -1704,21 +1726,26 @@ fn parse_object_property_aggregate_ref(input: &str) -> OracleResult<'_, Quantity
     if let Ok((craft_rest, filter)) = parse_craft_materials_filter(rest) {
         return Ok((
             craft_rest,
-            QuantityRef::Aggregate {
-                function,
-                property,
-                filter,
-            },
+            QuantityRef::PropertyAggregate(
+                PropertyAggregate::new(function, property, CardTypeSetSource::Objects { filter })
+                    .expect("object populations support every aggregate property"),
+            ),
         ));
     }
     if let Ok((anaphor_rest, _)) = parse_tracked_set_anaphor(rest) {
         return Ok((
             anaphor_rest,
-            QuantityRef::TrackedSetAggregate {
-                function,
-                property,
-                source: crate::types::ability::TrackedAnaphorSource::ChainSet,
-            },
+            QuantityRef::PropertyAggregate(
+                PropertyAggregate::new(
+                    function,
+                    property,
+                    CardTypeSetSource::TrackedSet {
+                        set: TrackedAnaphorSource::ChainSet,
+                        caused_by: None,
+                    },
+                )
+                .expect("tracked populations support every aggregate property"),
+            ),
         ));
     }
     let (filter, remainder) = parse_type_phrase(rest);
@@ -1734,11 +1761,10 @@ fn parse_object_property_aggregate_ref(input: &str) -> OracleResult<'_, Quantity
     }
     Ok((
         final_remainder,
-        QuantityRef::Aggregate {
-            function,
-            property,
-            filter,
-        },
+        QuantityRef::PropertyAggregate(
+            PropertyAggregate::new(function, property, CardTypeSetSource::Objects { filter })
+                .expect("object populations support every aggregate property"),
+        ),
     ))
 }
 
@@ -2802,6 +2828,7 @@ fn parse_tracked_set_this_way_source(input: &str) -> OracleResult<'_, CardTypeSe
     Ok((
         rest,
         CardTypeSetSource::TrackedSet {
+            set: TrackedAnaphorSource::ChainSet,
             caused_by: Some(cause),
         },
     ))
@@ -4353,18 +4380,23 @@ fn parse_graveyard_chroma_ref(input: &str) -> OracleResult<'_, QuantityRef> {
     // LKI-independent axis here.
     Ok((
         rest,
-        QuantityRef::Aggregate {
-            function: AggregateFunction::Sum,
-            property: ObjectProperty::ManaSymbolCount(color),
-            filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
-                FilterProp::Owned {
-                    controller: ControllerRef::You,
+        QuantityRef::PropertyAggregate(
+            crate::types::ability::PropertyAggregate::new(
+                AggregateFunction::Sum,
+                ObjectProperty::ManaSymbolCount(color),
+                crate::types::ability::CardTypeSetSource::Objects {
+                    filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
+                        FilterProp::Owned {
+                            controller: ControllerRef::You,
+                        },
+                        FilterProp::InZone {
+                            zone: Zone::Graveyard,
+                        },
+                    ])),
                 },
-                FilterProp::InZone {
-                    zone: Zone::Graveyard,
-                },
-            ])),
-        },
+            )
+            .expect("statically valid property aggregate"),
+        ),
     ))
 }
 
@@ -7131,11 +7163,9 @@ mod tests {
         assert_eq!(rest, "");
         assert!(matches!(
             q,
-            QuantityRef::Aggregate {
-                function: AggregateFunction::Max,
-                property: ObjectProperty::Power,
-                ..
-            }
+            QuantityRef::PropertyAggregate(ref aggregate)
+                if aggregate.function() == AggregateFunction::Max
+                    && aggregate.property() == ObjectProperty::Power
         ));
     }
 
@@ -7171,11 +7201,17 @@ mod tests {
             parse_quantity_ref("the total power of the exiled cards used to craft it").unwrap();
         assert_eq!(rest, "");
         match q {
-            QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::Power,
-                filter,
-            } => assert_eq!(filter, linked_exile_owned_filter()),
+            QuantityRef::PropertyAggregate(aggregate)
+                if aggregate.function() == AggregateFunction::Sum
+                    && aggregate.property() == ObjectProperty::Power =>
+            {
+                assert_eq!(
+                    aggregate.source(),
+                    &CardTypeSetSource::Objects {
+                        filter: linked_exile_owned_filter()
+                    }
+                )
+            }
             other => panic!("expected craft-material power aggregate, got {other:?}"),
         }
     }
@@ -7199,11 +7235,17 @@ mod tests {
             assert_eq!(rest, "", "tracked-set phrase {phrase:?} must fully consume");
             assert_eq!(
                 q,
-                QuantityRef::TrackedSetAggregate {
-                    function: AggregateFunction::Sum,
-                    property: ObjectProperty::Power,
-                    source: TrackedAnaphorSource::ChainSet,
-                },
+                QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        AggregateFunction::Sum,
+                        ObjectProperty::Power,
+                        crate::types::ability::CardTypeSetSource::TrackedSet {
+                            set: TrackedAnaphorSource::ChainSet,
+                            caused_by: None
+                        }
+                    )
+                    .expect("statically valid property aggregate")
+                ),
                 "phrase {phrase:?}"
             );
         }
@@ -7238,11 +7280,9 @@ mod tests {
         assert_eq!(rest, "");
         assert!(matches!(
             q,
-            QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::ManaValue,
-                ..
-            }
+            QuantityRef::PropertyAggregate(ref aggregate)
+                if aggregate.function() == AggregateFunction::Sum
+                    && aggregate.property() == ObjectProperty::ManaValue
         ));
     }
 
@@ -7259,14 +7299,11 @@ mod tests {
         assert_eq!(exprs.len(), 2);
         assert!(matches!(exprs[0], QuantityExpr::Fixed { value: 2 }));
         assert!(matches!(
-            exprs[1],
+            &exprs[1],
             QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Max,
-                    property: ObjectProperty::Power,
-                    ..
-                }
-            }
+                qty: QuantityRef::PropertyAggregate(aggregate),
+            } if aggregate.function() == AggregateFunction::Max
+                && aggregate.property() == ObjectProperty::Power
         ));
     }
 
@@ -9789,6 +9826,7 @@ mod tests {
             q,
             QuantityRef::DistinctCardTypes {
                 source: CardTypeSetSource::TrackedSet {
+                    set: TrackedAnaphorSource::ChainSet,
                     caused_by: Some(ThisWayCause::Discarded),
                 },
             }
@@ -9806,6 +9844,7 @@ mod tests {
             q,
             QuantityRef::DistinctCardTypes {
                 source: CardTypeSetSource::TrackedSet {
+                    set: TrackedAnaphorSource::ChainSet,
                     caused_by: Some(ThisWayCause::Exiled),
                 },
             }
@@ -9822,6 +9861,7 @@ mod tests {
             q,
             QuantityRef::DistinctCardTypes {
                 source: CardTypeSetSource::TrackedSet {
+                    set: TrackedAnaphorSource::ChainSet,
                     caused_by: Some(ThisWayCause::Discarded),
                 },
             }
@@ -11135,18 +11175,23 @@ mod tests {
         .unwrap();
         assert_eq!(
             q,
-            QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::ManaSymbolCount(ManaColor::Black),
-                filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
-                    FilterProp::Owned {
-                        controller: ControllerRef::You,
-                    },
-                    FilterProp::InZone {
-                        zone: Zone::Graveyard,
-                    },
-                ])),
-            }
+            QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::ManaSymbolCount(ManaColor::Black),
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
+                            FilterProp::Owned {
+                                controller: ControllerRef::You,
+                            },
+                            FilterProp::InZone {
+                                zone: Zone::Graveyard,
+                            },
+                        ]))
+                    }
+                )
+                .expect("statically valid property aggregate")
+            )
         );
         assert_eq!(rest, "");
     }
@@ -11691,20 +11736,25 @@ mod tests {
             assert_eq!(rest, "");
             assert_eq!(
                 q,
-                QuantityRef::Aggregate {
-                    function: AggregateFunction::Sum,
-                    property: ObjectProperty::ManaValue,
-                    filter: TargetFilter::And {
-                        filters: vec![
-                            TargetFilter::ExiledBySource,
-                            TargetFilter::Typed(TypedFilter::default().properties(vec![
-                                FilterProp::Owned {
-                                    controller: ControllerRef::You,
-                                },
-                            ])),
-                        ],
-                    },
-                }
+                QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        AggregateFunction::Sum,
+                        ObjectProperty::ManaValue,
+                        crate::types::ability::CardTypeSetSource::Objects {
+                            filter: TargetFilter::And {
+                                filters: vec![
+                                    TargetFilter::ExiledBySource,
+                                    TargetFilter::Typed(TypedFilter::default().properties(vec![
+                                        FilterProp::Owned {
+                                            controller: ControllerRef::You,
+                                        },
+                                    ])),
+                                ],
+                            }
+                        }
+                    )
+                    .expect("statically valid property aggregate")
+                )
             );
         }
     }
@@ -11717,17 +11767,15 @@ mod tests {
         assert_eq!(rest, "", "phrase should be fully consumed");
 
         // Verify it produces Aggregate with Max function
-        let QuantityRef::Aggregate {
-            function,
-            property,
-            filter,
-        } = q
-        else {
+        let QuantityRef::PropertyAggregate(aggregate) = q else {
             panic!("Expected Aggregate, got {q:?}");
         };
 
-        assert_eq!(function, AggregateFunction::Max);
-        assert_eq!(property, ObjectProperty::ManaValue);
+        assert_eq!(aggregate.function(), AggregateFunction::Max);
+        assert_eq!(aggregate.property(), ObjectProperty::ManaValue);
+        let CardTypeSetSource::Objects { filter } = aggregate.source() else {
+            panic!("Expected object source, got {:?}", aggregate.source());
+        };
 
         // Verify the filter uses InAnyZone for multi-zone disjunction
         let TargetFilter::Typed(tf) = filter else {
@@ -11879,12 +11927,16 @@ mod tests {
                 .unwrap();
         assert_eq!(rest, "");
         match q {
-            QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::ManaValue,
-                filter,
-            } => {
-                assert!(matches!(filter, TargetFilter::Typed(_)));
+            QuantityRef::PropertyAggregate(aggregate)
+                if aggregate.function() == AggregateFunction::Sum
+                    && aggregate.property() == ObjectProperty::ManaValue =>
+            {
+                assert!(matches!(
+                    aggregate.source(),
+                    CardTypeSetSource::Objects {
+                        filter: TargetFilter::Typed(_)
+                    }
+                ));
             }
             _ => panic!("expected Aggregate with Sum and ManaValue"),
         }
@@ -12342,11 +12394,9 @@ mod tests {
             assert!(
                 matches!(
                     q,
-                    QuantityRef::Aggregate {
-                        function: AggregateFunction::Max,
-                        property: ObjectProperty::ManaValue,
-                        ..
-                    }
+                    QuantityRef::PropertyAggregate(ref aggregate)
+                        if aggregate.function() == AggregateFunction::Max
+                            && aggregate.property() == ObjectProperty::ManaValue
                 ),
                 "{phrase:?} -> {q:?}"
             );
@@ -12387,13 +12437,21 @@ mod tests {
                 .unwrap_or_else(|e| panic!("{phrase:?} must bind: {e:?}"));
             assert_eq!(rest, "", "{phrase:?} must fully consume");
             match q {
-                QuantityRef::TrackedSetAggregate {
-                    function: f,
-                    property: p,
-                    source: crate::types::ability::TrackedAnaphorSource::ChainSet,
-                } => {
-                    assert_eq!(f, function, "{phrase:?} aggregate function");
-                    assert_eq!(p, property, "{phrase:?} property");
+                QuantityRef::PropertyAggregate(aggregate)
+                    if matches!(
+                        aggregate.source(),
+                        CardTypeSetSource::TrackedSet {
+                            set: crate::types::ability::TrackedAnaphorSource::ChainSet,
+                            ..
+                        }
+                    ) =>
+                {
+                    assert_eq!(
+                        aggregate.function(),
+                        function,
+                        "{phrase:?} aggregate function"
+                    );
+                    assert_eq!(aggregate.property(), property, "{phrase:?} property");
                 }
                 other => panic!("{phrase:?} must be a ChainSet TrackedSetAggregate, got {other:?}"),
             }
@@ -12422,11 +12480,18 @@ mod tests {
                 .unwrap_or_else(|e| panic!("{phrase:?} must bind: {e:?}"));
             assert_eq!(rest, "", "{phrase:?} must fully consume");
             match q {
-                QuantityRef::TrackedSetAggregate {
-                    function: AggregateFunction::Sum,
-                    property: p,
-                    source: crate::types::ability::TrackedAnaphorSource::ChainSet,
-                } => assert_eq!(p, property, "{phrase:?} property"),
+                QuantityRef::PropertyAggregate(aggregate)
+                    if aggregate.function() == AggregateFunction::Sum
+                        && matches!(
+                            aggregate.source(),
+                            CardTypeSetSource::TrackedSet {
+                                set: crate::types::ability::TrackedAnaphorSource::ChainSet,
+                                ..
+                            }
+                        ) =>
+                {
+                    assert_eq!(aggregate.property(), property, "{phrase:?} property")
+                }
                 other => panic!("{phrase:?} must be a ChainSet TrackedSetAggregate, got {other:?}"),
             }
         }

--- a/crates/engine/src/parser/oracle_quantity.rs
+++ b/crates/engine/src/parser/oracle_quantity.rs
@@ -39,11 +39,11 @@ use crate::parser::oracle_effect::parse_controls_permanent_object;
 use crate::parser::oracle_target::{parse_target, parse_type_phrase, parse_type_phrase_with_ctx};
 use crate::parser::oracle_util::{merge_or_filters, parse_count_multiplier};
 use crate::types::ability::{
-    AggregateFunction, AttackScope, AttackSubject, Comparator, ControllerRef, CountScope,
-    DamageChannel, DamageKindFilter, DevotionColors, FilterProp, ObjectProperty, ObjectScope,
-    PlayerFilter, PlayerRelation, PlayerScope, PossessionAxis, QuantityExpr, QuantityRef,
-    RoundingMode, TargetFilter, ThisWayCause, TrackedAnaphorSource, TypeFilter, TypedFilter,
-    ZoneRef,
+    AggregateFunction, AttackScope, AttackSubject, CardTypeSetSource, Comparator, ControllerRef,
+    CountScope, DamageChannel, DamageKindFilter, DevotionColors, FilterProp, ObjectProperty,
+    ObjectScope, PlayerFilter, PlayerRelation, PlayerScope, PossessionAxis, PropertyAggregate,
+    QuantityExpr, QuantityRef, RoundingMode, TargetFilter, ThisWayCause, TrackedAnaphorSource,
+    TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::counter::CounterType;
 use crate::types::events::PlayerActionKind;
@@ -301,11 +301,17 @@ pub(crate) fn parse_quantity_ref_with_context(
     //     CHAIN SET ("their" = the creatures the PRECEDING clause sacrificed).
     if let Ok((rest, (func, prop))) = parse_possessive_batch_aggregate(trimmed) {
         if rest.trim().is_empty() {
-            return Some(QuantityRef::TrackedSetAggregate {
-                function: func,
-                property: prop,
-                source: TrackedAnaphorSource::TriggeringBatch,
-            });
+            return Some(QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    func,
+                    prop,
+                    crate::types::ability::CardTypeSetSource::TrackedSet {
+                        set: TrackedAnaphorSource::TriggeringBatch,
+                        caused_by: None,
+                    },
+                )
+                .expect("statically valid property aggregate"),
+            ));
         }
     }
 
@@ -358,11 +364,17 @@ pub(crate) fn parse_quantity_ref_with_context(
         .parse(rest)
         {
             if anaphor_rest.trim().is_empty() {
-                return Some(QuantityRef::TrackedSetAggregate {
-                    function: func,
-                    property: prop,
-                    source: TrackedAnaphorSource::ChainSet,
-                });
+                return Some(QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        func,
+                        prop,
+                        crate::types::ability::CardTypeSetSource::TrackedSet {
+                            set: TrackedAnaphorSource::ChainSet,
+                            caused_by: None,
+                        },
+                    )
+                    .expect("statically valid property aggregate"),
+                ));
             }
         }
         // CR 608.2c + CR 603.2c + CR 603.10a: batched-dies-trigger anaphor. In a
@@ -403,11 +415,17 @@ pub(crate) fn parse_quantity_ref_with_context(
             alt((tag::<_, _, OracleError<'_>>("those creatures"), tag("them"))).parse(rest)
         {
             if anaphor_rest.trim().is_empty() {
-                return Some(QuantityRef::TrackedSetAggregate {
-                    function: func,
-                    property: prop,
-                    source: TrackedAnaphorSource::TriggeringBatch,
-                });
+                return Some(QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        func,
+                        prop,
+                        crate::types::ability::CardTypeSetSource::TrackedSet {
+                            set: TrackedAnaphorSource::TriggeringBatch,
+                            caused_by: None,
+                        },
+                    )
+                    .expect("statically valid property aggregate"),
+                ));
             }
         }
         let (filter, remainder) = parse_type_phrase_with_ctx(rest, ctx);
@@ -421,11 +439,10 @@ pub(crate) fn parse_quantity_ref_with_context(
                 .map(|(r, _)| r.trim().is_empty())
                 .unwrap_or(false);
         if snapshot_ok && !matches!(filter, TargetFilter::Any) && !is_empty_typed_filter(&filter) {
-            return Some(QuantityRef::Aggregate {
-                function: func,
-                property: prop,
-                filter,
-            });
+            return Some(QuantityRef::PropertyAggregate(
+                PropertyAggregate::new(func, prop, CardTypeSetSource::Objects { filter })
+                    .expect("object populations support every aggregate property"),
+            ));
         }
 
         // CR 400.7 + CR 700.4: "the total power of <filter> that died [under your
@@ -480,11 +497,16 @@ pub(crate) fn parse_quantity_ref_with_context(
                 {
                     if let Ok((rest2, _)) = parse_cast_snapshot_suffix(after_ctrl) {
                         if rest2.trim().is_empty() {
-                            return Some(QuantityRef::Aggregate {
-                                function: func,
-                                property: prop,
-                                filter: inject_controller_you(head_filter),
-                            });
+                            return Some(QuantityRef::PropertyAggregate(
+                                crate::types::ability::PropertyAggregate::new(
+                                    func,
+                                    prop,
+                                    crate::types::ability::CardTypeSetSource::Objects {
+                                        filter: inject_controller_you(head_filter),
+                                    },
+                                )
+                                .expect("statically valid property aggregate"),
+                            ));
                         }
                     }
                 }
@@ -1132,18 +1154,24 @@ fn parse_greatest_among_conjunction(text: &str, ctx: &mut ParseContext) -> Optio
     Some(QuantityExpr::Max {
         exprs: vec![
             QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: func,
-                    property: prop,
-                    filter: filter_a,
-                },
+                qty: QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        func,
+                        prop,
+                        crate::types::ability::CardTypeSetSource::Objects { filter: filter_a },
+                    )
+                    .expect("statically valid property aggregate"),
+                ),
             },
             QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: func,
-                    property: prop,
-                    filter: filter_b,
-                },
+                qty: QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        func,
+                        prop,
+                        crate::types::ability::CardTypeSetSource::Objects { filter: filter_b },
+                    )
+                    .expect("statically valid property aggregate"),
+                ),
             },
         ],
     })
@@ -3965,11 +3993,18 @@ mod tests {
     fn total_power_you_control_stays_live_aggregate() {
         assert_eq!(
             parse_quantity_ref("the total power of creatures you control"),
-            Some(QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::Power,
-                filter: TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
-            })
+            Some(QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    ObjectProperty::Power,
+                    crate::types::ability::CardTypeSetSource::Objects {
+                        filter: TargetFilter::Typed(
+                            TypedFilter::creature().controller(ControllerRef::You)
+                        )
+                    }
+                )
+                .expect("statically valid property aggregate")
+            ))
         );
     }
 
@@ -4892,18 +4927,23 @@ mod tests {
         assert_eq!(
             expr,
             QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Sum,
-                    property: ObjectProperty::ManaSymbolCount(ManaColor::Black),
-                    filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
-                        FilterProp::Owned {
-                            controller: ControllerRef::You,
-                        },
-                        FilterProp::InZone {
-                            zone: Zone::Graveyard,
-                        },
-                    ])),
-                },
+                qty: QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        AggregateFunction::Sum,
+                        ObjectProperty::ManaSymbolCount(ManaColor::Black),
+                        crate::types::ability::CardTypeSetSource::Objects {
+                            filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
+                                FilterProp::Owned {
+                                    controller: ControllerRef::You,
+                                },
+                                FilterProp::InZone {
+                                    zone: Zone::Graveyard,
+                                },
+                            ]))
+                        }
+                    )
+                    .expect("statically valid property aggregate")
+                ),
             }
         );
     }
@@ -5633,30 +5673,20 @@ mod tests {
     #[test]
     fn cda_quantity_greatest_power() {
         let qty = parse_cda_quantity("the greatest power among creatures you control").unwrap();
-        assert!(matches!(
-            qty,
-            QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Max,
-                    property: ObjectProperty::Power,
-                    ..
-                }
-            }
+        assert!(is_property_aggregate(
+            &qty,
+            AggregateFunction::Max,
+            ObjectProperty::Power
         ));
     }
 
     #[test]
     fn cda_quantity_greatest_toughness() {
         let qty = parse_cda_quantity("the greatest toughness among creatures you control").unwrap();
-        assert!(matches!(
-            qty,
-            QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Max,
-                    property: ObjectProperty::Toughness,
-                    ..
-                }
-            }
+        assert!(is_property_aggregate(
+            &qty,
+            AggregateFunction::Max,
+            ObjectProperty::Toughness
         ));
     }
 
@@ -5664,15 +5694,10 @@ mod tests {
     fn cda_quantity_greatest_mana_value() {
         let qty =
             parse_cda_quantity("the greatest mana value among creatures you control").unwrap();
-        assert!(matches!(
-            qty,
-            QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Max,
-                    property: ObjectProperty::ManaValue,
-                    ..
-                }
-            }
+        assert!(is_property_aggregate(
+            &qty,
+            AggregateFunction::Max,
+            ObjectProperty::ManaValue
         ));
     }
 
@@ -5681,13 +5706,13 @@ mod tests {
         let qty = parse_cda_quantity("the greatest mana value among cards in exile").unwrap();
         match &qty {
             QuantityExpr::Ref {
-                qty:
-                    QuantityRef::Aggregate {
-                        function: AggregateFunction::Max,
-                        property: ObjectProperty::ManaValue,
-                        filter,
-                    },
-            } => {
+                qty: QuantityRef::PropertyAggregate(aggregate),
+            } if aggregate.function() == AggregateFunction::Max
+                && aggregate.property() == ObjectProperty::ManaValue =>
+            {
+                let CardTypeSetSource::Objects { filter } = aggregate.source() else {
+                    panic!("expected object population, got {:?}", aggregate.source());
+                };
                 // Filter should contain InZone(Exile), not be Any
                 assert!(
                     !matches!(filter, TargetFilter::Any),
@@ -5701,15 +5726,10 @@ mod tests {
     #[test]
     fn cda_quantity_total_power() {
         let qty = parse_cda_quantity("the total power of creatures you control").unwrap();
-        assert!(matches!(
-            qty,
-            QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Sum,
-                    property: ObjectProperty::Power,
-                    ..
-                }
-            }
+        assert!(is_property_aggregate(
+            &qty,
+            AggregateFunction::Sum,
+            ObjectProperty::Power
         ));
     }
 
@@ -5721,35 +5741,28 @@ mod tests {
         // Drives Ensnared by the Mara's "deals damage equal to the total mana
         // value of those exiled cards".
         let qty = parse_cda_quantity("the total mana value of those exiled cards").unwrap();
-        assert!(
-            matches!(
-                qty,
-                QuantityExpr::Ref {
-                    qty: QuantityRef::TrackedSetAggregate {
-                        function: AggregateFunction::Sum,
-                        property: ObjectProperty::ManaValue,
-                        source: TrackedAnaphorSource::ChainSet,
+        let is_chain_mana_sum = |expr: &QuantityExpr| {
+            let QuantityExpr::Ref {
+                qty: QuantityRef::PropertyAggregate(aggregate),
+            } = expr
+            else {
+                return false;
+            };
+            aggregate.function() == AggregateFunction::Sum
+                && aggregate.property() == ObjectProperty::ManaValue
+                && matches!(
+                    aggregate.source(),
+                    CardTypeSetSource::TrackedSet {
+                        set: TrackedAnaphorSource::ChainSet,
+                        caused_by: None
                     }
-                }
-            ),
-            "expected TrackedSetAggregate(Sum, ManaValue, ChainSet), got {qty:?}"
-        );
+                )
+        };
+        assert!(is_chain_mana_sum(&qty), "unexpected quantity: {qty:?}");
 
         // The "the exiled cards" anaphor variant maps to the same set.
         let qty2 = parse_cda_quantity("the total mana value of the exiled cards").unwrap();
-        assert!(
-            matches!(
-                qty2,
-                QuantityExpr::Ref {
-                    qty: QuantityRef::TrackedSetAggregate {
-                        function: AggregateFunction::Sum,
-                        property: ObjectProperty::ManaValue,
-                        source: TrackedAnaphorSource::ChainSet,
-                    }
-                }
-            ),
-            "expected TrackedSetAggregate(Sum, ManaValue, ChainSet) for 'the exiled cards', got {qty2:?}"
-        );
+        assert!(is_chain_mana_sum(&qty2), "unexpected quantity: {qty2:?}");
     }
 
     #[test]
@@ -5761,19 +5774,21 @@ mod tests {
         // before this change); this drives The Skullspore Nexus's dies trigger.
         let qty = parse_cda_quantity("the total power of those creatures")
             .expect("'the total power of those creatures' must now parse (was None)");
-        assert!(
-            matches!(
-                qty,
-                QuantityExpr::Ref {
-                    qty: QuantityRef::TrackedSetAggregate {
-                        function: AggregateFunction::Sum,
-                        property: ObjectProperty::Power,
-                        source: TrackedAnaphorSource::TriggeringBatch,
-                    }
-                }
-            ),
-            "expected TrackedSetAggregate(Sum, Power, TriggeringBatch), got {qty:?}"
-        );
+        let QuantityExpr::Ref {
+            qty: QuantityRef::PropertyAggregate(aggregate),
+        } = &qty
+        else {
+            panic!("expected property aggregate, got {qty:?}");
+        };
+        assert_eq!(aggregate.function(), AggregateFunction::Sum);
+        assert_eq!(aggregate.property(), ObjectProperty::Power);
+        assert!(matches!(
+            aggregate.source(),
+            CardTypeSetSource::TrackedSet {
+                set: TrackedAnaphorSource::TriggeringBatch,
+                caused_by: None
+            }
+        ));
 
         // Scoping guard: the overloaded "those cards" form must NOT map to the
         // triggering batch. It also names mill sets ("you mill three cards, then
@@ -5786,11 +5801,14 @@ mod tests {
             !matches!(
                 cards,
                 Some(QuantityExpr::Ref {
-                    qty: QuantityRef::TrackedSetAggregate {
-                        source: TrackedAnaphorSource::TriggeringBatch,
+                    qty: QuantityRef::PropertyAggregate(ref aggregate),
+                }) if matches!(
+                    aggregate.source(),
+                    CardTypeSetSource::TrackedSet {
+                        set: TrackedAnaphorSource::TriggeringBatch,
                         ..
                     }
-                })
+                )
             ),
             "'those cards' must NOT map to a TriggeringBatch aggregate (overloaded \
              mill/chosen anaphor), got {cards:?}"
@@ -5802,13 +5820,16 @@ mod tests {
         let qty = parse_cda_quantity("the mana value of the exiled card").unwrap();
         match qty {
             QuantityExpr::Ref {
-                qty:
-                    QuantityRef::Aggregate {
-                        function: AggregateFunction::Sum,
-                        property: ObjectProperty::ManaValue,
-                        filter: TargetFilter::And { filters },
-                    },
+                qty: QuantityRef::PropertyAggregate(aggregate),
             } => {
+                assert_eq!(aggregate.function(), AggregateFunction::Sum);
+                assert_eq!(aggregate.property(), ObjectProperty::ManaValue);
+                let CardTypeSetSource::Objects {
+                    filter: TargetFilter::And { filters },
+                } = aggregate.source()
+                else {
+                    panic!("expected object-filter property aggregate source");
+                };
                 assert!(
                     filters
                         .iter()
@@ -7638,14 +7659,28 @@ mod tests {
     fn aggregate_filter_controller(qty: &QuantityExpr) -> Option<ControllerRef> {
         match qty {
             QuantityExpr::Ref {
-                qty:
-                    QuantityRef::Aggregate {
-                        filter: TargetFilter::Typed(tf),
-                        ..
-                    },
-            } => tf.controller.clone(),
+                qty: QuantityRef::PropertyAggregate(aggregate),
+            } => match aggregate.source() {
+                CardTypeSetSource::Objects {
+                    filter: TargetFilter::Typed(tf),
+                } => tf.controller.clone(),
+                _ => None,
+            },
             _ => None,
         }
+    }
+
+    fn is_property_aggregate(
+        qty: &QuantityExpr,
+        function: AggregateFunction,
+        property: ObjectProperty,
+    ) -> bool {
+        matches!(
+            qty,
+            QuantityExpr::Ref {
+                qty: QuantityRef::PropertyAggregate(aggregate),
+            } if aggregate.function() == function && aggregate.property() == property
+        )
     }
 
     /// CR 608.2h: present-tense snapshot — "the greatest power among creatures
@@ -7658,15 +7693,10 @@ mod tests {
             "the greatest power among creatures you control as you cast this spell",
         )
         .unwrap();
-        assert!(matches!(
-            qty,
-            QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Max,
-                    property: ObjectProperty::Power,
-                    ..
-                }
-            }
+        assert!(is_property_aggregate(
+            &qty,
+            AggregateFunction::Max,
+            ObjectProperty::Power
         ));
         assert_eq!(
             aggregate_filter_controller(&qty),
@@ -7683,15 +7713,10 @@ mod tests {
             "the greatest power among creatures you control as you activate this ability",
         )
         .unwrap();
-        assert!(matches!(
-            qty,
-            QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Max,
-                    property: ObjectProperty::Power,
-                    ..
-                }
-            }
+        assert!(is_property_aggregate(
+            &qty,
+            AggregateFunction::Max,
+            ObjectProperty::Power
         ));
         assert_eq!(aggregate_filter_controller(&qty), Some(ControllerRef::You));
     }
@@ -7708,15 +7733,10 @@ mod tests {
             "the greatest power among creatures you controlled as you cast this spell",
         )
         .unwrap();
-        assert!(matches!(
-            qty,
-            QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Max,
-                    property: ObjectProperty::Power,
-                    ..
-                }
-            }
+        assert!(is_property_aggregate(
+            &qty,
+            AggregateFunction::Max,
+            ObjectProperty::Power
         ));
         assert_eq!(
             aggregate_filter_controller(&qty),
@@ -7730,15 +7750,10 @@ mod tests {
     #[test]
     fn cda_quantity_greatest_power_no_snapshot_regression() {
         let qty = parse_cda_quantity("the greatest power among creatures you control").unwrap();
-        assert!(matches!(
-            qty,
-            QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Max,
-                    property: ObjectProperty::Power,
-                    ..
-                }
-            }
+        assert!(is_property_aggregate(
+            &qty,
+            AggregateFunction::Max,
+            ObjectProperty::Power
         ));
         assert_eq!(aggregate_filter_controller(&qty), Some(ControllerRef::You));
     }
@@ -7841,18 +7856,23 @@ mod tests {
             "the total power of creatures they controlled that were exiled this way",
         )
         .expect("composite quantity must parse");
-        let expected = QuantityRef::Aggregate {
-            function: AggregateFunction::Sum,
-            property: ObjectProperty::Power,
-            filter: TargetFilter::And {
-                filters: vec![
-                    TargetFilter::Typed(
-                        TypedFilter::creature().controller(ControllerRef::ScopedPlayer),
-                    ),
-                    TargetFilter::ExiledBySource,
-                ],
-            },
-        };
+        let expected = QuantityRef::PropertyAggregate(
+            crate::types::ability::PropertyAggregate::new(
+                AggregateFunction::Sum,
+                ObjectProperty::Power,
+                crate::types::ability::CardTypeSetSource::Objects {
+                    filter: TargetFilter::And {
+                        filters: vec![
+                            TargetFilter::Typed(
+                                TypedFilter::creature().controller(ControllerRef::ScopedPlayer),
+                            ),
+                            TargetFilter::ExiledBySource,
+                        ],
+                    },
+                },
+            )
+            .expect("statically valid property aggregate"),
+        );
         assert_eq!(qty, expected);
     }
 
@@ -8267,16 +8287,23 @@ mod tests {
             "the total toughness of creatures you controlled that were exiled this way",
         )
         .expect("composite quantity must parse");
-        let expected = QuantityRef::Aggregate {
-            function: AggregateFunction::Sum,
-            property: ObjectProperty::Toughness,
-            filter: TargetFilter::And {
-                filters: vec![
-                    TargetFilter::Typed(TypedFilter::creature().controller(ControllerRef::You)),
-                    TargetFilter::ExiledBySource,
-                ],
-            },
-        };
+        let expected = QuantityRef::PropertyAggregate(
+            crate::types::ability::PropertyAggregate::new(
+                AggregateFunction::Sum,
+                ObjectProperty::Toughness,
+                crate::types::ability::CardTypeSetSource::Objects {
+                    filter: TargetFilter::And {
+                        filters: vec![
+                            TargetFilter::Typed(
+                                TypedFilter::creature().controller(ControllerRef::You),
+                            ),
+                            TargetFilter::ExiledBySource,
+                        ],
+                    },
+                },
+            )
+            .expect("statically valid property aggregate"),
+        );
         assert_eq!(qty, expected);
     }
 

--- a/crates/engine/src/parser/oracle_replacement.rs
+++ b/crates/engine/src/parser/oracle_replacement.rs
@@ -17970,7 +17970,7 @@ mod tests {
                     matches!(
                         count,
                         QuantityExpr::Ref {
-                            qty: QuantityRef::Aggregate { .. }
+                            qty: QuantityRef::PropertyAggregate(_)
                         }
                     ),
                     "count should be Aggregate quantity, got {count:?}"

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -3886,12 +3886,9 @@ fn dragon_man_cda_power_is_greatest_mana_value_across_zones() {
             matches!(
                 arm,
                 QuantityExpr::Ref {
-                    qty: QuantityRef::Aggregate {
-                        function: AggregateFunction::Max,
-                        property: ObjectProperty::ManaValue,
-                        ..
-                    }
-                }
+                    qty: QuantityRef::PropertyAggregate(aggregate),
+                } if aggregate.function() == AggregateFunction::Max
+                    && aggregate.property() == ObjectProperty::ManaValue
             ),
             "each arm must be a Max/ManaValue Aggregate, got {arm:?}"
         );
@@ -5640,12 +5637,7 @@ fn visions_of_ruin_cast_this_way_cost_reduction_binds_commander_mv() {
 
     let StaticMode::ModifyCost {
         mode: CostModifyMode::Reduce,
-        dynamic_count:
-            Some(QuantityRef::Aggregate {
-                function: AggregateFunction::Max,
-                property: ObjectProperty::ManaValue,
-                ..
-            }),
+        dynamic_count: Some(QuantityRef::PropertyAggregate(aggregate)),
         ..
     } = def.mode
     else {
@@ -5654,6 +5646,8 @@ fn visions_of_ruin_cast_this_way_cost_reduction_binds_commander_mv() {
             def.mode
         );
     };
+    assert_eq!(aggregate.function(), AggregateFunction::Max);
+    assert_eq!(aggregate.property(), ObjectProperty::ManaValue);
     assert!(matches!(
         def.condition,
         Some(StaticCondition::CastingAsVariant {
@@ -5833,17 +5827,14 @@ fn ghalta_self_cost_reduction_is_active_from_command_zone() {
 
     let StaticMode::ModifyCost {
         mode: CostModifyMode::Reduce,
-        dynamic_count:
-            Some(QuantityRef::Aggregate {
-                function: AggregateFunction::Sum,
-                property: ObjectProperty::Power,
-                ..
-            }),
+        dynamic_count: Some(QuantityRef::PropertyAggregate(aggregate)),
         ..
     } = def.mode
     else {
         panic!("expected dynamic self-spell ReduceCost, got {:?}", def.mode);
     };
+    assert_eq!(aggregate.function(), AggregateFunction::Sum);
+    assert_eq!(aggregate.property(), ObjectProperty::Power);
     assert!(matches!(def.affected, Some(TargetFilter::SelfRef)));
     assert_eq!(
         def.active_zones,
@@ -9439,18 +9430,23 @@ fn static_umbra_stalker_graveyard_chroma_cda() {
     );
 
     let expected_qty = QuantityExpr::Ref {
-        qty: QuantityRef::Aggregate {
-            function: AggregateFunction::Sum,
-            property: ObjectProperty::ManaSymbolCount(ManaColor::Black),
-            filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
-                FilterProp::Owned {
-                    controller: ControllerRef::You,
+        qty: QuantityRef::PropertyAggregate(
+            crate::types::ability::PropertyAggregate::new(
+                AggregateFunction::Sum,
+                ObjectProperty::ManaSymbolCount(ManaColor::Black),
+                crate::types::ability::CardTypeSetSource::Objects {
+                    filter: TargetFilter::Typed(TypedFilter::card().properties(vec![
+                        FilterProp::Owned {
+                            controller: ControllerRef::You,
+                        },
+                        FilterProp::InZone {
+                            zone: Zone::Graveyard,
+                        },
+                    ])),
                 },
-                FilterProp::InZone {
-                    zone: Zone::Graveyard,
-                },
-            ])),
-        },
+            )
+            .expect("statically valid property aggregate"),
+        ),
     };
 
     for m in &def.modifications {

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -9,11 +9,11 @@ use nom::sequence::{preceded, terminated};
 use nom::Parser;
 
 use crate::types::ability::{
-    AggregateFunction, AttachmentKind, ChoiceType, CombatRelation, CombatRelationSubject,
-    Comparator, ControllerRef, CountScope, DamageKindFilter, FilterProp, ObjectProperty,
-    ObjectScope, ParitySource, PlayerFilter, PtStat, PtValueScope, QuantityExpr, QuantityRef,
-    SeatDirection, SharedQuality, SharedQualityRelation, TargetFilter, TargetSelectionMode,
-    ThisWayCause, TypeFilter, TypedFilter,
+    AggregateFunction, AttachmentKind, CardTypeSetSource, ChoiceType, CombatRelation,
+    CombatRelationSubject, Comparator, ControllerRef, CountScope, DamageKindFilter, FilterProp,
+    ObjectProperty, ObjectScope, ParitySource, PlayerFilter, PropertyAggregate, PtStat,
+    PtValueScope, QuantityExpr, QuantityRef, SeatDirection, SharedQuality, SharedQualityRelation,
+    TargetFilter, TargetSelectionMode, ThisWayCause, TypeFilter, TypedFilter,
 };
 use crate::types::card_type::{noncreature_subtype_set, SubtypeSet, Supertype};
 use crate::types::counter::{CounterMatch, CounterType};
@@ -5882,11 +5882,10 @@ fn superlative_property_filter_prop(
     filter: TargetFilter,
 ) -> FilterProp {
     let value = QuantityExpr::Ref {
-        qty: QuantityRef::Aggregate {
-            function,
-            property,
-            filter,
-        },
+        qty: QuantityRef::PropertyAggregate(
+            PropertyAggregate::new(function, property, CardTypeSetSource::Objects { filter })
+                .expect("object populations support every aggregate property"),
+        ),
     };
     match property {
         ObjectProperty::ManaValue => FilterProp::Cmc {
@@ -9162,8 +9161,8 @@ mod tests {
         };
         match value {
             QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate { function, .. },
-            } => function,
+                qty: QuantityRef::PropertyAggregate(aggregate),
+            } => aggregate.function(),
             other => panic!("expected Aggregate quantity, got {other:?}"),
         }
     }
@@ -9214,20 +9213,18 @@ mod tests {
         assert_eq!(stat, PtStat::Toughness);
         assert_eq!(comparator, Comparator::EQ);
         let QuantityExpr::Ref {
-            qty:
-                QuantityRef::Aggregate {
-                    function,
-                    property,
-                    filter,
-                },
+            qty: QuantityRef::PropertyAggregate(aggregate),
         } = value
         else {
             panic!("expected Aggregate quantity, got {value:?}");
         };
-        assert_eq!(function, AggregateFunction::Min);
-        assert_eq!(property, ObjectProperty::Toughness);
+        assert_eq!(aggregate.function(), AggregateFunction::Min);
+        assert_eq!(aggregate.property(), ObjectProperty::Toughness);
+        let CardTypeSetSource::Objects { filter } = aggregate.source() else {
+            panic!("expected object source, got {:?}", aggregate.source());
+        };
         // The eligible set is "creatures you control".
-        let tf = typed_leg(&filter).expect("aggregate filter should be a typed creature filter");
+        let tf = typed_leg(filter).expect("aggregate filter should be a typed creature filter");
         assert_eq!(tf.controller, Some(ControllerRef::You));
         assert!(tf.type_filters.contains(&TypeFilter::Creature));
     }
@@ -18662,23 +18659,21 @@ mod tests {
         };
         assert_eq!(comparator, Comparator::EQ);
         let QuantityExpr::Ref {
-            qty:
-                QuantityRef::Aggregate {
-                    function,
-                    property,
-                    filter,
-                },
+            qty: QuantityRef::PropertyAggregate(aggregate),
         } = value
         else {
             panic!("expected QuantityRef::Aggregate, got {value:?}");
         };
-        assert_eq!(function, AggregateFunction::Max);
-        assert_eq!(property, ObjectProperty::ManaValue);
+        assert_eq!(aggregate.function(), AggregateFunction::Max);
+        assert_eq!(aggregate.property(), ObjectProperty::ManaValue);
+        let CardTypeSetSource::Objects { filter } = aggregate.source() else {
+            panic!("expected object source, got {:?}", aggregate.source());
+        };
         // The eligible set is an Or of Creature/Planeswalker, controller You.
         match filter {
             TargetFilter::Or { filters } => {
                 assert_eq!(filters.len(), 2);
-                for leg in &filters {
+                for leg in filters {
                     let tf = typed_leg(leg).expect("each leg is Typed");
                     assert_eq!(tf.controller, Some(ControllerRef::You));
                 }
@@ -18793,19 +18788,17 @@ mod tests {
         assert_eq!(scope, PtValueScope::Current);
         assert_eq!(comparator, Comparator::EQ);
         let QuantityExpr::Ref {
-            qty:
-                QuantityRef::Aggregate {
-                    function,
-                    property,
-                    filter,
-                },
+            qty: QuantityRef::PropertyAggregate(aggregate),
         } = value
         else {
             panic!("expected QuantityRef::Aggregate, got {value:?}");
         };
-        assert_eq!(function, AggregateFunction::Max);
-        assert_eq!(property, ObjectProperty::Power);
-        let tf = typed_leg(&filter).expect("eligible set should be Typed");
+        assert_eq!(aggregate.function(), AggregateFunction::Max);
+        assert_eq!(aggregate.property(), ObjectProperty::Power);
+        let CardTypeSetSource::Objects { filter } = aggregate.source() else {
+            panic!("expected object source, got {:?}", aggregate.source());
+        };
+        let tf = typed_leg(filter).expect("eligible set should be Typed");
         assert_eq!(tf.controller, Some(ControllerRef::You));
         assert!(has_type(tf, TypeFilter::Creature));
     }
@@ -18832,13 +18825,10 @@ mod tests {
                     FilterProp::Cmc {
                         comparator: Comparator::EQ,
                         value: QuantityExpr::Ref {
-                            qty: QuantityRef::Aggregate {
-                                function: AggregateFunction::Max,
-                                property: ObjectProperty::ManaValue,
-                                ..
-                            },
+                            qty: QuantityRef::PropertyAggregate(aggregate),
                         },
-                    }
+                    } if aggregate.function() == AggregateFunction::Max
+                        && aggregate.property() == ObjectProperty::ManaValue
                 )
             });
             assert!(
@@ -19152,34 +19142,37 @@ mod tests {
                     p,
                     FilterProp::Cmc {
                         value: QuantityExpr::Ref {
-                            qty: QuantityRef::Aggregate { .. }
+                            qty: QuantityRef::PropertyAggregate(_)
                         },
                         ..
                     } | FilterProp::PtComparison {
                         value: QuantityExpr::Ref {
-                            qty: QuantityRef::Aggregate { .. }
+                            qty: QuantityRef::PropertyAggregate(_)
                         },
                         ..
                     }
                 )
             })
             .expect("expected a superlative FilterProp carrying an Aggregate");
-        let population = match prop {
+        let aggregate = match prop {
             FilterProp::Cmc {
                 value:
                     QuantityExpr::Ref {
-                        qty: QuantityRef::Aggregate { filter, .. },
+                        qty: QuantityRef::PropertyAggregate(aggregate),
                     },
                 ..
             }
             | FilterProp::PtComparison {
                 value:
                     QuantityExpr::Ref {
-                        qty: QuantityRef::Aggregate { filter, .. },
+                        qty: QuantityRef::PropertyAggregate(aggregate),
                     },
                 ..
-            } => filter,
+            } => aggregate,
             _ => unreachable!("matched above"),
+        };
+        let CardTypeSetSource::Objects { filter: population } = aggregate.source() else {
+            unreachable!("bare superlatives always rank an object population")
         };
         (prop, population)
     }
@@ -19208,15 +19201,13 @@ mod tests {
         };
         assert_eq!(*comparator, Comparator::EQ, "ties are all legal targets");
         let QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function, property, ..
-            },
+            qty: QuantityRef::PropertyAggregate(aggregate),
         } = value
         else {
             unreachable!()
         };
-        assert_eq!(*function, AggregateFunction::Min, "lowest → Min");
-        assert_eq!(*property, ObjectProperty::ManaValue);
+        assert_eq!(aggregate.function(), AggregateFunction::Min, "lowest → Min");
+        assert_eq!(aggregate.property(), ObjectProperty::ManaValue);
 
         let pop = typed_leg(population).expect("population should be a Typed filter");
         assert!(pop.type_filters.contains(&TypeFilter::Permanent));
@@ -19246,12 +19237,16 @@ mod tests {
         };
         assert_eq!(*stat, PtStat::Power);
         let QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate { function, .. },
+            qty: QuantityRef::PropertyAggregate(aggregate),
         } = value
         else {
             unreachable!()
         };
-        assert_eq!(*function, AggregateFunction::Max, "greatest → Max");
+        assert_eq!(
+            aggregate.function(),
+            AggregateFunction::Max,
+            "greatest → Max"
+        );
         let pop = typed_leg(population).expect("typed population");
         assert_eq!(
             pop.controller,
@@ -19353,12 +19348,12 @@ mod tests {
                 p,
                 FilterProp::Cmc {
                     value: QuantityExpr::Ref {
-                        qty: QuantityRef::Aggregate { .. }
+                        qty: QuantityRef::PropertyAggregate(_)
                     },
                     ..
                 } | FilterProp::PtComparison {
                     value: QuantityExpr::Ref {
-                        qty: QuantityRef::Aggregate { .. }
+                        qty: QuantityRef::PropertyAggregate(_)
                     },
                     ..
                 }

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -20089,17 +20089,23 @@ fn assert_abzan_greatest_toughness_gate(condition: &AbilityCondition) {
             comparator: Comparator::GE,
             value:
                 QuantityExpr::Ref {
-                    qty:
-                        QuantityRef::Aggregate {
-                            function: AggregateFunction::Max,
-                            property: ObjectProperty::Toughness,
-                            filter: TargetFilter::Typed(population),
-                        },
+                    qty: QuantityRef::PropertyAggregate(aggregate),
                 },
         } = prop
         else {
             return false;
         };
+        let crate::types::ability::CardTypeSetSource::Objects {
+            filter: TargetFilter::Typed(population),
+        } = aggregate.source()
+        else {
+            return false;
+        };
+        if aggregate.function() != AggregateFunction::Max
+            || aggregate.property() != ObjectProperty::Toughness
+        {
+            return false;
+        }
         population.type_filters == vec![TypeFilter::Creature] && population.controller.is_none()
     });
     assert!(
@@ -20664,17 +20670,23 @@ fn assert_controlled_creature_greatest_power_filter(filter: &TargetFilter) {
             comparator: Comparator::GE,
             value:
                 QuantityExpr::Ref {
-                    qty:
-                        QuantityRef::Aggregate {
-                            function: AggregateFunction::Max,
-                            property: ObjectProperty::Power,
-                            filter: TargetFilter::Typed(population),
-                        },
+                    qty: QuantityRef::PropertyAggregate(aggregate),
                 },
         } = prop
         else {
             return false;
         };
+        let crate::types::ability::CardTypeSetSource::Objects {
+            filter: TargetFilter::Typed(population),
+        } = aggregate.source()
+        else {
+            return false;
+        };
+        if aggregate.function() != AggregateFunction::Max
+            || aggregate.property() != ObjectProperty::Power
+        {
+            return false;
+        }
         population.type_filters == vec![TypeFilter::Creature]
             && population.properties.iter().any(|prop| {
                 matches!(

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -52,16 +52,16 @@ use crate::types::ability::ManaProduction;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AbilityTag,
     AdditionalCostOrigin, AdditionalCostPaymentSource, AggregateFunction, AttachmentKind,
-    AttackersDeclaredCountSubject, CardSelectionMode, CastManaObjectScope, CastManaSpentMetric,
-    CastVariantPaid, CoinFlipResult, Comparator, ControllerRef, CountScope, CounterTriggerFilter,
-    DamageAmountScope, DamageAmountThreshold, DamageChannel, DamageKindFilter,
-    DestinationConstraint, DieResultFilter, Effect, EffectScope, FilterProp,
+    AttackersDeclaredCountSubject, CardSelectionMode, CardTypeSetSource, CastManaObjectScope,
+    CastManaSpentMetric, CastVariantPaid, CoinFlipResult, Comparator, ControllerRef, CountScope,
+    CounterTriggerFilter, DamageAmountScope, DamageAmountThreshold, DamageChannel,
+    DamageKindFilter, DestinationConstraint, DieResultFilter, Effect, EffectScope, FilterProp,
     ManaAbilityProducedFilter, ObjectScope, OriginConstraint, ParsedCondition, PlayerFilter,
-    PlayerRelation, PlayerScope, PtStat, PtValueScope, QuantityExpr, QuantityRef, RenownSubject,
-    SacrificeAggregateStat, SacrificeCost, SacrificeRequirement, SharedQuality, StaticCondition,
-    SubAbilityLink, TapCreaturesRequirement, TapStateChange, TargetFilter, TriggerCondition,
-    TriggerConstraint, TriggerDefinition, TypeFilter, TypedFilter, UnlessPayModifier,
-    ZoneChangeClause,
+    PlayerRelation, PlayerScope, PropertyAggregate, PtStat, PtValueScope, QuantityExpr,
+    QuantityRef, RenownSubject, SacrificeAggregateStat, SacrificeCost, SacrificeRequirement,
+    SharedQuality, StaticCondition, SubAbilityLink, TapCreaturesRequirement, TapStateChange,
+    TargetFilter, TriggerCondition, TriggerConstraint, TriggerDefinition, TypeFilter, TypedFilter,
+    UnlessPayModifier, ZoneChangeClause,
 };
 use crate::types::card_type::{is_land_subtype, CoreType};
 use crate::types::counter::CounterType;
@@ -4367,6 +4367,31 @@ fn substitute_another_in_filter(filter: &TargetFilter) -> TargetFilter {
     }
 }
 
+fn substitute_another_in_aggregate_source(source: &CardTypeSetSource) -> CardTypeSetSource {
+    match source {
+        CardTypeSetSource::Objects { filter } => CardTypeSetSource::Objects {
+            filter: substitute_another_in_filter(filter),
+        },
+        CardTypeSetSource::TurnJournal {
+            journal,
+            scope,
+            filter,
+        } => CardTypeSetSource::TurnJournal {
+            journal: *journal,
+            scope: scope.clone(),
+            filter: filter.as_ref().map(substitute_another_in_filter),
+        },
+        CardTypeSetSource::AnyOf { sources } => CardTypeSetSource::any_of(
+            sources
+                .iter()
+                .map(substitute_another_in_aggregate_source)
+                .collect(),
+        )
+        .expect("rewriting preserves union arity"),
+        other => other.clone(),
+    }
+}
+
 /// CR 603.4: Rewrite `Another` inside any `ObjectCount` / `ObjectCountDistinct`
 /// or `Aggregate` filter carried by a `QuantityExpr`. Leaves non-population
 /// refs untouched.
@@ -4406,18 +4431,16 @@ fn substitute_another_in_expr(expr: &QuantityExpr) -> QuantityExpr {
         // intervening-if references an aggregate over "each other <type>",
         // the exclusion must be trigger-relative, not source-relative.
         QuantityExpr::Ref {
-            qty:
-                QuantityRef::Aggregate {
-                    function,
-                    property,
-                    filter,
-                },
+            qty: QuantityRef::PropertyAggregate(aggregate),
         } => QuantityExpr::Ref {
-            qty: QuantityRef::Aggregate {
-                function: *function,
-                property: *property,
-                filter: substitute_another_in_filter(filter),
-            },
+            qty: QuantityRef::PropertyAggregate(
+                PropertyAggregate::new(
+                    aggregate.function(),
+                    aggregate.property(),
+                    substitute_another_in_aggregate_source(aggregate.source()),
+                )
+                .expect("rewriting filters preserves aggregate validity"),
+            ),
         },
         QuantityExpr::Offset { inner, offset } => QuantityExpr::Offset {
             inner: Box::new(substitute_another_in_expr(inner)),

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -4388,7 +4388,9 @@ fn substitute_another_in_aggregate_source(source: &CardTypeSetSource) -> CardTyp
                 .collect(),
         )
         .expect("rewriting preserves union arity"),
-        other => other.clone(),
+        CardTypeSetSource::TrackedSet { .. }
+        | CardTypeSetSource::Zone { .. }
+        | CardTypeSetSource::ExiledBySource => source.clone(),
     }
 }
 

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -7,14 +7,15 @@ use crate::parser::oracle_ir::doc::PrintedTriggerIndex;
 use crate::parser::oracle_ir::effect_chain::PlayerScopeRewrite;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction, AttackScope,
-    AttackSubject, BounceSelection, CardSelectionMode, CastingPermission, ChosenAttribute,
-    Comparator, ContinuousModification, ControllerRef, CopyChooseScope, CopyRetargetPermission,
-    CountScope, DamageAmountScope, DamageAmountThreshold, DamageChannel, DamageModification,
-    DamageSource, DelayedTriggerCondition, DiscardSelfScope, Duration, Effect, EffectScope,
-    FilterProp, ManaContribution, ManaProduction, ManaSpendPermission, ModalChoice, ObjectScope,
-    PerpetualModification, PlayerFilter, PlayerScope, PtStat, PtValue, PtValueScope, QuantityExpr,
-    QuantityRef, SeatDirection, SharedQuality, SiblingCondition, SubAbilityLink, TapStateChange,
-    TargetFilter, TriggerCondition, TriggerDefinition, TypeFilter, TypedFilter, ZoneRef,
+    AttackSubject, BounceSelection, CardSelectionMode, CardTypeSetSource, CastingPermission,
+    ChosenAttribute, Comparator, ContinuousModification, ControllerRef, CopyChooseScope,
+    CopyRetargetPermission, CountScope, DamageAmountScope, DamageAmountThreshold, DamageChannel,
+    DamageModification, DamageSource, DelayedTriggerCondition, DiscardSelfScope, Duration, Effect,
+    EffectScope, FilterProp, ManaContribution, ManaProduction, ManaSpendPermission, ModalChoice,
+    ObjectScope, PerpetualModification, PlayerFilter, PlayerScope, PropertyAggregate, PtStat,
+    PtValue, PtValueScope, QuantityExpr, QuantityRef, SeatDirection, SharedQuality,
+    SiblingCondition, SubAbilityLink, TapStateChange, TargetFilter, TriggerCondition,
+    TriggerDefinition, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::card_type::Supertype;
 use crate::types::counter::{CounterMatch, CounterType};
@@ -67,11 +68,17 @@ fn palantir_life_loss_uses_milled_chain_set_and_targeted_opponent() {
     assert_eq!(
         *amount,
         QuantityExpr::Ref {
-            qty: QuantityRef::TrackedSetAggregate {
-                function: AggregateFunction::Sum,
-                property: crate::types::ability::ObjectProperty::ManaValue,
-                source: crate::types::ability::TrackedAnaphorSource::ChainSet,
-            },
+            qty: QuantityRef::PropertyAggregate(
+                crate::types::ability::PropertyAggregate::new(
+                    AggregateFunction::Sum,
+                    crate::types::ability::ObjectProperty::ManaValue,
+                    crate::types::ability::CardTypeSetSource::TrackedSet {
+                        set: crate::types::ability::TrackedAnaphorSource::ChainSet,
+                        caused_by: None
+                    }
+                )
+                .expect("statically valid property aggregate")
+            ),
         }
     );
     assert!(
@@ -100,14 +107,22 @@ fn combustible_gearhulk_damage_uses_milled_chain_set() {
     let Effect::DealDamage { amount, target, .. } = damage.effect.as_ref() else {
         panic!("expected DealDamage, got {:?}", damage.effect);
     };
+    let QuantityExpr::Ref {
+        qty: QuantityRef::PropertyAggregate(aggregate),
+    } = amount
+    else {
+        panic!("expected property aggregate, got {amount:?}");
+    };
+    assert_eq!(aggregate.function(), AggregateFunction::Sum);
+    assert_eq!(
+        aggregate.property(),
+        crate::types::ability::ObjectProperty::ManaValue
+    );
     assert!(matches!(
-        amount,
-        QuantityExpr::Ref {
-            qty: QuantityRef::TrackedSetAggregate {
-                function: AggregateFunction::Sum,
-                property: crate::types::ability::ObjectProperty::ManaValue,
-                source: crate::types::ability::TrackedAnaphorSource::ChainSet,
-            }
+        aggregate.source(),
+        crate::types::ability::CardTypeSetSource::TrackedSet {
+            set: crate::types::ability::TrackedAnaphorSource::ChainSet,
+            caused_by: None
         }
     ));
     assert!(matches!(target, TargetFilter::ScopedPlayer));
@@ -6655,15 +6670,13 @@ fn parse_betor_kin_to_all_trigger_structure() {
             assert_eq!(*rhs, QuantityExpr::Fixed { value: 10 });
             match lhs {
                 QuantityExpr::Ref {
-                    qty:
-                        QuantityRef::Aggregate {
-                            function,
-                            property,
-                            filter,
-                        },
+                    qty: QuantityRef::PropertyAggregate(aggregate),
                 } => {
-                    assert_eq!(*function, AggregateFunction::Sum);
-                    assert_eq!(*property, ObjectProperty::Toughness);
+                    assert_eq!(aggregate.function(), AggregateFunction::Sum);
+                    assert_eq!(aggregate.property(), ObjectProperty::Toughness);
+                    let CardTypeSetSource::Objects { filter } = aggregate.source() else {
+                        panic!("expected object source, got {:?}", aggregate.source());
+                    };
                     match filter {
                         TargetFilter::Typed(t) => {
                             assert_eq!(t.controller, Some(ControllerRef::You));
@@ -6703,12 +6716,9 @@ fn parse_betor_kin_to_all_trigger_structure() {
                     matches!(
                         lhs,
                         QuantityExpr::Ref {
-                            qty: QuantityRef::Aggregate {
-                                function: AggregateFunction::Sum,
-                                property: ObjectProperty::Toughness,
-                                ..
-                            },
-                        }
+                            qty: QuantityRef::PropertyAggregate(aggregate),
+                        } if aggregate.function() == AggregateFunction::Sum
+                            && aggregate.property() == ObjectProperty::Toughness
                     ),
                     "untap sub_ability lhs must be Aggregate Sum/Toughness, got {lhs:?}",
                 );
@@ -6744,12 +6754,9 @@ fn parse_betor_kin_to_all_trigger_structure() {
                     matches!(
                         lhs,
                         QuantityExpr::Ref {
-                            qty: QuantityRef::Aggregate {
-                                function: AggregateFunction::Sum,
-                                property: ObjectProperty::Toughness,
-                                ..
-                            },
-                        }
+                            qty: QuantityRef::PropertyAggregate(aggregate),
+                        } if aggregate.function() == AggregateFunction::Sum
+                            && aggregate.property() == ObjectProperty::Toughness
                     ),
                     "lose-life sub_ability lhs must be Aggregate Sum/Toughness, got {lhs:?}",
                 );
@@ -8174,20 +8181,25 @@ fn trigger_skyclave_apparition_leaves_battlefield_uses_linked_exile_owner_scope(
         } => {
             assert_eq!(name, "Illusion");
             let expected = QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: crate::types::ability::AggregateFunction::Sum,
-                    property: crate::types::ability::ObjectProperty::ManaValue,
-                    filter: TargetFilter::And {
-                        filters: vec![
-                            TargetFilter::ExiledBySource,
-                            TargetFilter::Typed(TypedFilter::default().properties(vec![
-                                FilterProp::Owned {
-                                    controller: ControllerRef::You,
-                                },
-                            ])),
-                        ],
-                    },
-                },
+                qty: QuantityRef::PropertyAggregate(
+                    crate::types::ability::PropertyAggregate::new(
+                        crate::types::ability::AggregateFunction::Sum,
+                        crate::types::ability::ObjectProperty::ManaValue,
+                        crate::types::ability::CardTypeSetSource::Objects {
+                            filter: TargetFilter::And {
+                                filters: vec![
+                                    TargetFilter::ExiledBySource,
+                                    TargetFilter::Typed(TypedFilter::default().properties(vec![
+                                        FilterProp::Owned {
+                                            controller: ControllerRef::You,
+                                        },
+                                    ])),
+                                ],
+                            },
+                        },
+                    )
+                    .expect("statically valid property aggregate"),
+                ),
             };
             assert_eq!(power, &PtValue::Quantity(expected.clone()));
             assert_eq!(toughness, &PtValue::Quantity(expected));
@@ -26440,18 +26452,19 @@ fn trigger_intervening_if_selvala_power_greater_than_each_other() {
     );
     // RHS: Max(power) across creatures excluding the triggering object.
     let QuantityExpr::Ref {
-        qty:
-            QuantityRef::Aggregate {
-                function,
-                property,
-                filter,
-            },
+        qty: QuantityRef::PropertyAggregate(aggregate),
     } = rhs
     else {
         panic!("expected Aggregate Max Power rhs, got {rhs:?}");
     };
-    assert_eq!(*function, AggregateFunction::Max);
-    assert_eq!(*property, crate::types::ability::ObjectProperty::Power);
+    assert_eq!(aggregate.function(), AggregateFunction::Max);
+    assert_eq!(
+        aggregate.property(),
+        crate::types::ability::ObjectProperty::Power
+    );
+    let CardTypeSetSource::Objects { filter } = aggregate.source() else {
+        panic!("expected object source, got {:?}", aggregate.source());
+    };
     let TargetFilter::Typed(tf) = filter else {
         panic!("expected Typed creature filter, got {filter:?}");
     };
@@ -26499,6 +26512,65 @@ fn substitute_another_rewrites_shared_quality_count_filter() {
     };
     assert!(tf.properties.contains(&FilterProp::OtherThanTriggerObject));
     assert!(!tf.properties.contains(&FilterProp::Another));
+}
+
+#[test]
+fn substitute_another_rewrites_turn_journal_filters_directly_and_in_unions() {
+    let journal = || CardTypeSetSource::TurnJournal {
+        journal: crate::types::ability::TurnJournalKind::SpellsCast,
+        scope: CountScope::Controller,
+        filter: Some(TargetFilter::Typed(
+            TypedFilter::creature().properties(vec![FilterProp::Another]),
+        )),
+    };
+    let direct = PropertyAggregate::new(
+        AggregateFunction::Sum,
+        crate::types::ability::ObjectProperty::ManaValue,
+        journal(),
+    )
+    .unwrap();
+    let nested = PropertyAggregate::new(
+        AggregateFunction::Sum,
+        crate::types::ability::ObjectProperty::ManaValue,
+        CardTypeSetSource::any_of(vec![
+            CardTypeSetSource::Objects {
+                filter: TargetFilter::Any,
+            },
+            CardTypeSetSource::any_of(vec![journal(), CardTypeSetSource::ExiledBySource]).unwrap(),
+        ])
+        .unwrap(),
+    )
+    .unwrap();
+
+    for aggregate in [direct, nested] {
+        let rewritten = substitute_another_in_expr(&QuantityExpr::Ref {
+            qty: QuantityRef::PropertyAggregate(aggregate),
+        });
+        let QuantityExpr::Ref {
+            qty: QuantityRef::PropertyAggregate(aggregate),
+        } = rewritten
+        else {
+            panic!("expected property aggregate");
+        };
+        let mut journal_count = 0;
+        assert!(aggregate.source().try_for_each_member(
+            crate::types::ability::UNION_DEPTH_BUDGET,
+            &mut |leaf| {
+                if let CardTypeSetSource::TurnJournal {
+                    filter: Some(TargetFilter::Typed(filter)),
+                    ..
+                } = leaf
+                {
+                    journal_count += 1;
+                    assert!(filter
+                        .properties
+                        .contains(&FilterProp::OtherThanTriggerObject));
+                    assert!(!filter.properties.contains(&FilterProp::Another));
+                }
+            },
+        ));
+        assert_eq!(journal_count, 1);
+    }
 }
 
 /// Issue #444 — Odric, Lunarch Marshal. The full trigger parses to a

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -4039,12 +4039,9 @@ mod tests {
         assert!(matches!(
             qty,
             QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Max,
-                    property: ObjectProperty::ManaValue,
-                    ..
-                }
-            }
+                qty: QuantityRef::PropertyAggregate(aggregate),
+            } if aggregate.function() == AggregateFunction::Max
+                && aggregate.property() == ObjectProperty::ManaValue
         ));
         assert!(rest.is_empty());
     }

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -6594,6 +6594,8 @@ pub enum CardTypeSetSource {
     /// Draw->Discard set is disambiguated by CAUSE (drawn members are unstamped),
     /// so Some(Discarded) counts only discarded members. None counts all.
     TrackedSet {
+        #[serde(default, skip_serializing_if = "TrackedAnaphorSource::is_chain_set")]
+        set: TrackedAnaphorSource,
         #[serde(default, skip_serializing_if = "Option::is_none")]
         caused_by: Option<ThisWayCause>,
     },
@@ -6835,6 +6837,34 @@ impl CardTypeSetSource {
             }
         }
     }
+
+    /// Mutable counterpart of [`try_for_each_member`](Self::try_for_each_member).
+    ///
+    /// Transformations over the population axis use the same bounded recursion
+    /// authority as readers, so a nested `AnyOf` cannot evade a rewrite that is
+    /// exhaustive over leaf sources.
+    pub fn try_for_each_member_mut(
+        &mut self,
+        depth: u32,
+        visit: &mut impl FnMut(&mut CardTypeSetSource),
+    ) -> bool {
+        let Some(depth) = depth.checked_sub(1) else {
+            return false;
+        };
+        match self {
+            CardTypeSetSource::AnyOf { sources } => {
+                let mut complete = true;
+                for member in &mut sources.0 {
+                    complete &= member.try_for_each_member_mut(depth, visit);
+                }
+                complete
+            }
+            leaf => {
+                visit(leaf);
+                true
+            }
+        }
+    }
 }
 
 /// CR 109.2: Depth budget for [`CardTypeSetSource::try_for_each_member`].
@@ -6889,6 +6919,167 @@ pub enum CastManaSpentMetric {
     OfColor { color: ManaColor },
     /// Amount of mana whose source matched the filter at payment time.
     FromSource { source_filter: TargetFilter },
+}
+
+/// A validated numeric reduction over one characteristic-bearing population.
+///
+/// CR 202.3 + CR 208.1 + CR 209.1: the source must carry enough snapshot data
+/// to answer the selected property. In particular, spell-cast journal records
+/// retain mana value but not the other object characteristics.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+pub struct PropertyAggregate {
+    function: AggregateFunction,
+    property: ObjectProperty,
+    source: CardTypeSetSource,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Error)]
+pub enum PropertyAggregateError {
+    #[error("turn-journal property aggregates support only ManaValue, not {0:?}")]
+    UnsupportedTurnJournalProperty(ObjectProperty),
+    #[error("property aggregate source exceeds the supported union depth")]
+    SourceDepthExceeded,
+}
+
+impl PropertyAggregate {
+    pub fn new(
+        function: AggregateFunction,
+        property: ObjectProperty,
+        source: CardTypeSetSource,
+    ) -> Result<Self, PropertyAggregateError> {
+        let mut invalid_journal = false;
+        let complete = source.try_for_each_member(UNION_DEPTH_BUDGET, &mut |leaf| {
+            if matches!(leaf, CardTypeSetSource::TurnJournal { .. })
+                && property != ObjectProperty::ManaValue
+            {
+                invalid_journal = true;
+            }
+        });
+        if !complete {
+            return Err(PropertyAggregateError::SourceDepthExceeded);
+        }
+        if invalid_journal {
+            return Err(PropertyAggregateError::UnsupportedTurnJournalProperty(
+                property,
+            ));
+        }
+        Ok(Self {
+            function,
+            property,
+            source,
+        })
+    }
+
+    pub fn function(&self) -> AggregateFunction {
+        self.function
+    }
+
+    pub fn property(&self) -> ObjectProperty {
+        self.property
+    }
+
+    pub fn source(&self) -> &CardTypeSetSource {
+        &self.source
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(deny_unknown_fields)]
+struct PropertyAggregateRepr {
+    function: AggregateFunction,
+    property: ObjectProperty,
+    source: CardTypeSetSource,
+}
+
+impl<'de> Deserialize<'de> for PropertyAggregate {
+    fn deserialize<D: serde::Deserializer<'de>>(deserializer: D) -> Result<Self, D::Error> {
+        let repr = PropertyAggregateRepr::deserialize(deserializer)?;
+        Self::new(repr.function, repr.property, repr.source).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Deserialize)]
+#[serde(tag = "type", deny_unknown_fields)]
+enum LegacyPropertyAggregateWire {
+    Aggregate {
+        function: AggregateFunction,
+        property: ObjectProperty,
+        filter: TargetFilter,
+    },
+    TrackedSetAggregate {
+        function: AggregateFunction,
+        property: ObjectProperty,
+        #[serde(default)]
+        source: TrackedAnaphorSource,
+    },
+}
+
+pub(crate) fn deserialize_quantity_ref_compat<'de, D>(
+    deserializer: D,
+) -> Result<QuantityRef, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = serde_json::Value::deserialize(deserializer)?;
+    quantity_ref_from_value(value)
+}
+
+pub(crate) fn deserialize_boxed_quantity_ref_compat<'de, D>(
+    deserializer: D,
+) -> Result<Box<QuantityRef>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    deserialize_quantity_ref_compat(deserializer).map(Box::new)
+}
+
+pub(crate) fn deserialize_optional_quantity_ref_compat<'de, D>(
+    deserializer: D,
+) -> Result<Option<QuantityRef>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    Option::<serde_json::Value>::deserialize(deserializer)?
+        .map(quantity_ref_from_value)
+        .transpose()
+}
+
+fn quantity_ref_from_value<E: serde::de::Error>(
+    value: serde_json::Value,
+) -> Result<QuantityRef, E> {
+    let tag = value
+        .get("type")
+        .and_then(serde_json::Value::as_str)
+        .ok_or_else(|| E::custom("quantity reference requires a string type tag"))?;
+    match tag {
+        "Aggregate" | "TrackedSetAggregate" => {
+            let legacy: LegacyPropertyAggregateWire =
+                serde_json::from_value(value).map_err(E::custom)?;
+            let (function, property, source) = match legacy {
+                LegacyPropertyAggregateWire::Aggregate {
+                    function,
+                    property,
+                    filter,
+                } => (function, property, CardTypeSetSource::Objects { filter }),
+                LegacyPropertyAggregateWire::TrackedSetAggregate {
+                    function,
+                    property,
+                    source,
+                } => (
+                    function,
+                    property,
+                    CardTypeSetSource::TrackedSet {
+                        set: source,
+                        caused_by: None,
+                    },
+                ),
+            };
+            PropertyAggregate::new(function, property, source)
+                .map(QuantityRef::PropertyAggregate)
+                .map_err(E::custom)
+        }
+        _ => serde_json::from_value(value).map_err(E::custom),
+    }
 }
 
 /// A dynamic game quantity — a runtime lookup into the game state.
@@ -7118,11 +7309,7 @@ pub enum QuantityRef {
     /// `filter.extract_zones()`, so the query is zone-general.
     // TODO: no dedicated CR governs the extremum/aggregation itself; CR 202.3 is
     // cited for the mana-value property — the most common aggregated property.
-    Aggregate {
-        function: AggregateFunction,
-        property: ObjectProperty,
-        filter: TargetFilter,
-    },
+    PropertyAggregate(PropertyAggregate),
     /// CR 107.1 + CR 102.1/102.2/102.3: The [min/max], across players in
     /// `relation`, of the number
     /// of **battlefield** objects matching `filter` that the player controls
@@ -7234,15 +7421,6 @@ pub enum QuantityRef {
     /// are read in place. Used by "deals damage equal to the total mana value of
     /// those exiled cards" (Ensnared by the Mara — `Sum` over `ManaValue` of the
     /// set the preceding `ExileTop` published).
-    TrackedSetAggregate {
-        function: AggregateFunction,
-        property: ObjectProperty,
-        /// CR 608.2c: which object-id set to reduce. Defaults to `ChainSet`
-        /// (the chain-published tracked set) so existing serialized card-data
-        /// stays byte-identical — no `source` key is emitted for the default.
-        #[serde(default, skip_serializing_if = "TrackedAnaphorSource::is_chain_set")]
-        source: TrackedAnaphorSource,
-    },
     /// CR 400.7 + CR 608.2c: Number of cards exiled from a hand by the immediately
     /// preceding `Effect::ChangeZoneAll` resolution. Read by Deadly Cover-Up's
     /// "draws a card for each card exiled from their hand this way." The counter
@@ -7838,7 +8016,7 @@ impl QuantityRef {
             | QuantityRef::ObjectTypelineComponentCount { .. }
             | QuantityRef::ManaSymbolsInManaCost { .. }
             | QuantityRef::SelfManaValue
-            | QuantityRef::Aggregate { .. }
+            | QuantityRef::PropertyAggregate(_)
             | QuantityRef::ControlledByEachPlayer { .. }
             | QuantityRef::TargetZoneCardCount { .. }
             | QuantityRef::Devotion { .. }
@@ -7850,7 +8028,6 @@ impl QuantityRef {
             | QuantityRef::BasicLandTypeCount { .. }
             | QuantityRef::TrackedSetSize
             | QuantityRef::FilteredTrackedSetSize { .. }
-            | QuantityRef::TrackedSetAggregate { .. }
             | QuantityRef::ExiledFromHandThisResolution
             | QuantityRef::PreviousEffectAmount { .. }
             | QuantityRef::PreviousEffectCount
@@ -7936,7 +8113,7 @@ pub enum TrackedAnaphorSource {
 impl TrackedAnaphorSource {
     /// The default source. Used by `skip_serializing_if` so existing
     /// `TrackedSetAggregate` card-data stays byte-identical (no `source` key).
-    fn is_chain_set(&self) -> bool {
+    pub(crate) fn is_chain_set(&self) -> bool {
         matches!(self, Self::ChainSet)
     }
 }
@@ -8369,6 +8546,7 @@ pub enum PlayerFilter {
     /// the enum infinite size.
     PlayerAttribute {
         relation: PlayerRelation,
+        #[serde(deserialize_with = "deserialize_boxed_quantity_ref_compat")]
         attr: Box<QuantityRef>,
         comparator: Comparator,
         value: Box<QuantityExpr>,
@@ -8585,6 +8763,7 @@ impl<'de> serde::Deserialize<'de> for QuantityExpr {
                 #[serde(tag = "type")]
                 enum Tagged {
                     Ref {
+                        #[serde(deserialize_with = "deserialize_quantity_ref_compat")]
                         qty: QuantityRef,
                     },
                     Fixed {
@@ -8970,9 +9149,11 @@ pub enum UnlessPayScaling {
     Flat,
     PerAffectedCreature,
     PerQuantityRef {
+        #[serde(deserialize_with = "deserialize_quantity_ref_compat")]
         quantity: QuantityRef,
     },
     PerAffectedAndQuantityRef {
+        #[serde(deserialize_with = "deserialize_quantity_ref_compat")]
         quantity: QuantityRef,
     },
     /// CR 118.12a + CR 202.3e: Per-affected-creature cost where the scaling quantity
@@ -8985,6 +9166,7 @@ pub enum UnlessPayScaling {
     /// quantity is resolved per-creature using that creature as the `TargetRef::Object`
     /// during resolution.
     PerAffectedWithRef {
+        #[serde(deserialize_with = "deserialize_quantity_ref_compat")]
         quantity: QuantityRef,
     },
 }
@@ -9582,8 +9764,10 @@ pub enum ParsedCondition {
     /// Compares a player-relative quantity against each opponent's quantity.
     /// The comparison must hold for ALL opponents.
     QuantityVsEachOpponent {
+        #[serde(deserialize_with = "deserialize_quantity_ref_compat")]
         lhs: QuantityRef,
         comparator: Comparator,
+        #[serde(deserialize_with = "deserialize_quantity_ref_compat")]
         rhs: QuantityRef,
     },
     /// CR 601.3 / CR 602.5: Generic measurable restriction predicate.
@@ -16774,6 +16958,23 @@ impl TargetFilter {
                 .any(TargetFilter::references_cost_paid_object),
             TargetFilter::Not { filter } => filter.references_cost_paid_object(),
             TargetFilter::TrackedSetFiltered { filter, .. } => filter.references_cost_paid_object(),
+            _ => false,
+        }
+    }
+
+    /// True when this filter carries the typed "other than the currently
+    /// resolving object" marker at any structural position.
+    pub fn contains_other_than_trigger_object(&self) -> bool {
+        match self {
+            TargetFilter::Typed(TypedFilter { properties, .. }) => properties
+                .iter()
+                .any(|prop| matches!(prop, FilterProp::OtherThanTriggerObject)),
+            TargetFilter::And { filters } | TargetFilter::Or { filters } => filters
+                .iter()
+                .any(TargetFilter::contains_other_than_trigger_object),
+            TargetFilter::Not { filter } | TargetFilter::TrackedSetFiltered { filter, .. } => {
+                filter.contains_other_than_trigger_object()
+            }
             _ => false,
         }
     }
@@ -28701,6 +28902,7 @@ mod tests {
     #[test]
     fn try_for_each_member_unrolls_unions_and_bounds_depth() {
         let leaf = |n: u32| CardTypeSetSource::TrackedSet {
+            set: TrackedAnaphorSource::ChainSet,
             caused_by: (n > 0).then_some(ThisWayCause::Discarded),
         };
         let union = CardTypeSetSource::any_of(vec![
@@ -28788,7 +28990,10 @@ mod tests {
         // A snapshot population is NOT a zone read (CR 400.7 / CR 608.2c), and
         // that is asserted rather than left implicit.
         for snapshot in [
-            CardTypeSetSource::TrackedSet { caused_by: None },
+            CardTypeSetSource::TrackedSet {
+                set: TrackedAnaphorSource::ChainSet,
+                caused_by: None,
+            },
             CardTypeSetSource::TurnJournal {
                 journal: TurnJournalKind::SpellsCast,
                 scope: CountScope::Controller,
@@ -28992,7 +29197,10 @@ mod tests {
         };
         for source in [
             CardTypeSetSource::ExiledBySource,
-            CardTypeSetSource::TrackedSet { caused_by: None },
+            CardTypeSetSource::TrackedSet {
+                set: TrackedAnaphorSource::ChainSet,
+                caused_by: None,
+            },
             objects.clone(),
             CardTypeSetSource::any_of(vec![
                 objects,
@@ -29014,6 +29222,221 @@ mod tests {
                 "the current reading must win for {json}",
             );
         }
+    }
+
+    #[test]
+    fn legacy_property_aggregate_variants_deserialize_and_reserialize_canonically() {
+        let legacy_objects = r#"{"type":"Aggregate","function":"Sum","property":"Power","filter":{"type":"Typed","type_filters":["Creature"],"properties":[]}}"#;
+        let legacy_tracked = r#"{"type":"TrackedSetAggregate","function":"Max","property":"ManaValue","source":"TriggeringBatch"}"#;
+        let legacy_tracked_default =
+            r#"{"type":"TrackedSetAggregate","function":"Min","property":"Power"}"#;
+
+        for (payload, expected_source) in [
+            (
+                legacy_objects,
+                CardTypeSetSource::Objects {
+                    filter: TargetFilter::Typed(TypedFilter::creature()),
+                },
+            ),
+            (
+                legacy_tracked,
+                CardTypeSetSource::TrackedSet {
+                    set: TrackedAnaphorSource::TriggeringBatch,
+                    caused_by: None,
+                },
+            ),
+            (
+                legacy_tracked_default,
+                CardTypeSetSource::TrackedSet {
+                    set: TrackedAnaphorSource::ChainSet,
+                    caused_by: None,
+                },
+            ),
+        ] {
+            let wrapped = format!(r#"{{"type":"Ref","qty":{payload}}}"#);
+            let expr: QuantityExpr =
+                serde_json::from_str(&wrapped).expect("legacy aggregate loads at its wire field");
+            let QuantityExpr::Ref {
+                qty: node @ QuantityRef::PropertyAggregate(aggregate),
+            } = &expr
+            else {
+                panic!("legacy aggregate must lift to PropertyAggregate: {expr:?}");
+            };
+            assert_eq!(aggregate.source(), &expected_source);
+            let canonical = serde_json::to_string(&expr).expect("canonical aggregate serializes");
+            assert!(canonical.contains(r#""type":"PropertyAggregate""#));
+            assert!(canonical.contains(r#""source""#));
+            let canonical_value: serde_json::Value = serde_json::from_str(&canonical).unwrap();
+            let canonical_qty = &canonical_value["qty"];
+            assert!(!canonical_qty.as_object().unwrap().contains_key("filter"));
+            assert!(!canonical.contains("TrackedSetAggregate"));
+            assert_eq!(
+                serde_json::from_str::<QuantityExpr>(&canonical).unwrap(),
+                expr
+            );
+            assert!(matches!(node, QuantityRef::PropertyAggregate(_)));
+        }
+    }
+
+    /// Every direct `QuantityRef` carrier must use the compatibility deserializer,
+    /// not only `QuantityExpr::Ref`. This is the bounded direct-field census:
+    /// `PlayerFilter::PlayerAttribute`, all three quantity-bearing
+    /// `UnlessPayScaling` variants, and both sides of
+    /// `ParsedCondition::QuantityVsEachOpponent`. The three `StaticMode`
+    /// carriers are pinned separately in `types::statics`.
+    #[test]
+    fn legacy_property_aggregate_loads_through_every_direct_quantity_ref_carrier() {
+        let legacy_objects = serde_json::json!({
+            "type": "Aggregate",
+            "function": "Sum",
+            "property": "Power",
+            "filter": { "type": "Any" }
+        });
+        let legacy_tracked = serde_json::json!({
+            "type": "TrackedSetAggregate",
+            "function": "Max",
+            "property": "ManaValue",
+            "source": "TriggeringBatch"
+        });
+        let assert_canonical = |value: &serde_json::Value| {
+            let json = serde_json::to_string(value).unwrap();
+            assert!(json.contains(r#""type":"PropertyAggregate""#), "{json}");
+            assert!(!json.contains(r#""type":"Aggregate""#), "{json}");
+            assert!(!json.contains("TrackedSetAggregate"), "{json}");
+        };
+
+        let player_filter = PlayerFilter::PlayerAttribute {
+            relation: PlayerRelation::All,
+            attr: Box::new(QuantityRef::LifeTotal {
+                player: PlayerScope::ScopedPlayer,
+            }),
+            comparator: Comparator::GE,
+            value: Box::new(QuantityExpr::Fixed { value: 1 }),
+        };
+        let mut wire = serde_json::to_value(player_filter).unwrap();
+        wire["attr"] = legacy_objects.clone();
+        let loaded: PlayerFilter = serde_json::from_value(wire).unwrap();
+        assert_canonical(&serde_json::to_value(loaded).unwrap());
+
+        for scaling in [
+            UnlessPayScaling::PerQuantityRef {
+                quantity: QuantityRef::LifeAboveStarting,
+            },
+            UnlessPayScaling::PerAffectedAndQuantityRef {
+                quantity: QuantityRef::LifeAboveStarting,
+            },
+            UnlessPayScaling::PerAffectedWithRef {
+                quantity: QuantityRef::LifeAboveStarting,
+            },
+        ] {
+            let mut wire = serde_json::to_value(scaling).unwrap();
+            wire["data"]["quantity"] = legacy_tracked.clone();
+            let loaded: UnlessPayScaling = serde_json::from_value(wire).unwrap();
+            assert_canonical(&serde_json::to_value(loaded).unwrap());
+        }
+
+        for field in ["lhs", "rhs"] {
+            let restriction = ParsedCondition::QuantityVsEachOpponent {
+                lhs: QuantityRef::LifeTotal {
+                    player: PlayerScope::Controller,
+                },
+                comparator: Comparator::GE,
+                rhs: QuantityRef::LifeTotal {
+                    player: PlayerScope::Opponent {
+                        aggregate: AggregateFunction::Max,
+                    },
+                },
+            };
+            let mut wire = serde_json::to_value(restriction).unwrap();
+            wire[field] = if field == "lhs" {
+                legacy_objects.clone()
+            } else {
+                legacy_tracked.clone()
+            };
+            let loaded: ParsedCondition = serde_json::from_value(wire).unwrap();
+            assert_canonical(&serde_json::to_value(loaded).unwrap());
+        }
+    }
+
+    #[test]
+    fn property_aggregate_wire_tags_require_their_exact_population_shape() {
+        let canonical_source = r#"{"type":"Objects","filter":{"type":"Any"}}"#;
+        let typed_filter = r#"{"type":"Typed","type_filters":["Creature"],"properties":[]}"#;
+        let wrap = |qty: &str| format!(r#"{{"type":"Ref","qty":{qty}}}"#);
+
+        let canonical = format!(
+            r#"{{"type":"PropertyAggregate","function":"Sum","property":"Power","source":{canonical_source}}}"#
+        );
+        assert!(serde_json::from_str::<QuantityExpr>(&wrap(&canonical)).is_ok());
+
+        for rejected in [
+            r#"{"type":"PropertyAggregate","function":"Sum","property":"Power"}"#.to_string(),
+            format!(
+                r#"{{"type":"PropertyAggregate","function":"Sum","property":"Power","filter":{typed_filter}}}"#
+            ),
+            format!(
+                r#"{{"type":"Aggregate","function":"Sum","property":"Power","source":{canonical_source}}}"#
+            ),
+            r#"{"type":"Aggregate","function":"Sum","property":"Power"}"#.to_string(),
+            format!(
+                r#"{{"type":"TrackedSetAggregate","function":"Sum","property":"Power","filter":{typed_filter}}}"#
+            ),
+            format!(
+                r#"{{"type":"TrackedSetAggregate","function":"Sum","property":"Power","source":{canonical_source}}}"#
+            ),
+        ] {
+            assert!(
+                serde_json::from_str::<QuantityExpr>(&wrap(&rejected)).is_err(),
+                "crossed or incomplete aggregate shape must be rejected: {rejected}",
+            );
+        }
+
+        let legacy = format!(
+            r#"{{"type":"Aggregate","function":"Sum","property":"Power","filter":{typed_filter}}}"#
+        );
+        assert!(serde_json::from_str::<QuantityExpr>(&wrap(&legacy)).is_ok());
+    }
+
+    #[test]
+    fn property_aggregate_rejects_incompatible_source_property_pairs() {
+        let journal = CardTypeSetSource::TurnJournal {
+            journal: TurnJournalKind::SpellsCast,
+            scope: CountScope::Controller,
+            filter: None,
+        };
+        assert!(PropertyAggregate::new(
+            AggregateFunction::Sum,
+            ObjectProperty::ManaValue,
+            journal.clone()
+        )
+        .is_ok());
+        assert_eq!(
+            PropertyAggregate::new(AggregateFunction::Max, ObjectProperty::Power, journal),
+            Err(PropertyAggregateError::UnsupportedTurnJournalProperty(
+                ObjectProperty::Power
+            ))
+        );
+
+        let mixed = CardTypeSetSource::any_of(vec![
+            CardTypeSetSource::Objects {
+                filter: TargetFilter::Any,
+            },
+            CardTypeSetSource::TurnJournal {
+                journal: TurnJournalKind::SpellsCast,
+                scope: CountScope::Controller,
+                filter: None,
+            },
+        ])
+        .unwrap();
+        assert!(matches!(
+            PropertyAggregate::new(AggregateFunction::Min, ObjectProperty::Toughness, mixed),
+            Err(PropertyAggregateError::UnsupportedTurnJournalProperty(
+                ObjectProperty::Toughness
+            ))
+        ));
+
+        let invalid_json = r#"{"type":"PropertyAggregate","function":"Sum","property":"Power","source":{"type":"TurnJournal","journal":"SpellsCast","scope":"Controller"}}"#;
+        assert!(serde_json::from_str::<QuantityRef>(invalid_json).is_err());
     }
 
     #[test]

--- a/crates/engine/src/types/statics.rs
+++ b/crates/engine/src/types/statics.rs
@@ -1129,7 +1129,11 @@ pub enum StaticMode {
         spell_filter: Option<TargetFilter>,
         /// Dynamic multiplier (e.g. "for each [thing] you control").
         /// Only meaningful for `Reduce` and `Raise` — always `None` for `Minimum`.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            deserialize_with = "super::ability::deserialize_optional_quantity_ref_compat"
+        )]
         dynamic_count: Option<QuantityRef>,
     },
     /// CR 601.2f + CR 118.8: Imposes an additional non-mana cost on spells or
@@ -1170,7 +1174,11 @@ pub enum StaticMode {
         minimum_mana: Option<u32>,
         /// CR 601.2f: Dynamic multiplier for the adjustment (e.g., "for each Dragon you control").
         /// When present, the total adjustment is `amount * resolve_quantity(dynamic_count)`.
-        #[serde(default, skip_serializing_if = "Option::is_none")]
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            deserialize_with = "super::ability::deserialize_optional_quantity_ref_compat"
+        )]
         dynamic_count: Option<QuantityRef>,
         /// CR 605.1a: "unless they're mana abilities" / "that aren't mana abilities"
         /// exemption (Suppression Field, Zirda the Dawnwaker). Reuses the same
@@ -4038,7 +4046,10 @@ struct LegacyModifyCostPayload {
     amount: ManaCost,
     #[serde(default)]
     spell_filter: Option<TargetFilter>,
-    #[serde(default)]
+    #[serde(
+        default,
+        deserialize_with = "super::ability::deserialize_optional_quantity_ref_compat"
+    )]
     dynamic_count: Option<QuantityRef>,
 }
 
@@ -4774,6 +4785,53 @@ mod tests {
                     dynamic_count: None,
                 }
             );
+        }
+    }
+
+    #[test]
+    fn cost_modifiers_migrate_legacy_dynamic_aggregates_and_emit_canonical_non_null_values() {
+        #[derive(serde::Deserialize)]
+        struct Wrapper {
+            #[serde(deserialize_with = "deserialize_static_mode_fwd")]
+            mode: StaticMode,
+        }
+
+        let aggregate = r#"{"type":"Aggregate","function":"Sum","property":"Power","filter":{"type":"Typed","type_filters":["Creature"],"properties":[]}}"#;
+        let tracked = r#"{"type":"TrackedSetAggregate","function":"Max","property":"ManaValue","source":"TriggeringBatch"}"#;
+        let current_modify = format!(
+            r#"{{"ModifyCost":{{"mode":"Reduce","amount":{{"type":"Cost","shards":[],"generic":1}},"spell_filter":null,"dynamic_count":{aggregate}}}}}"#
+        );
+        let current_ability = format!(
+            r#"{{"ReduceAbilityCost":{{"keyword":"activated","amount":2,"dynamic_count":{tracked}}}}}"#
+        );
+        let legacy_reduce = format!(
+            r#"{{"mode":{{"ReduceCost":{{"amount":{{"type":"Cost","shards":[],"generic":3}},"spell_filter":null,"dynamic_count":{aggregate}}}}}}}"#
+        );
+
+        let modes = [
+            serde_json::from_str::<StaticMode>(&current_modify).unwrap(),
+            serde_json::from_str::<StaticMode>(&current_ability).unwrap(),
+            serde_json::from_str::<Wrapper>(&legacy_reduce)
+                .unwrap()
+                .mode,
+        ];
+
+        for mode in modes {
+            let dynamic_count = match &mode {
+                StaticMode::ModifyCost { dynamic_count, .. }
+                | StaticMode::ReduceAbilityCost { dynamic_count, .. } => dynamic_count,
+                other => panic!("expected a cost modifier, got {other:?}"),
+            };
+            assert!(matches!(
+                dynamic_count,
+                Some(QuantityRef::PropertyAggregate(_))
+            ));
+
+            let canonical = serde_json::to_string(&mode).unwrap();
+            assert!(canonical.contains(r#""dynamic_count":{"type":"PropertyAggregate""#));
+            assert!(!canonical.contains(r#""dynamic_count":null"#));
+            assert!(!canonical.contains(r#""type":"Aggregate""#));
+            assert!(!canonical.contains("TrackedSetAggregate"));
         }
     }
 

--- a/crates/engine/tests/integration/craft_material_references.rs
+++ b/crates/engine/tests/integration/craft_material_references.rs
@@ -138,16 +138,16 @@ fn mastercraft_raptor_power_is_total_power_of_craft_materials() {
     // additionally pins the source to the linked-exile pool, not a tracked set.
     match power_qty {
         QuantityExpr::Ref {
-            qty:
-                QuantityRef::Aggregate {
-                    function: AggregateFunction::Sum,
-                    property: ObjectProperty::Power,
-                    filter,
-                },
-        } => assert!(
-            filter_reads_exiled_by_source(filter),
-            "power aggregate must read ExiledBySource, got {filter:?}"
-        ),
+            qty: QuantityRef::PropertyAggregate(aggregate),
+        } if aggregate.function() == AggregateFunction::Sum
+            && aggregate.property() == ObjectProperty::Power =>
+        {
+            assert!(
+                matches!(aggregate.source(), CardTypeSetSource::Objects { filter } if filter_reads_exiled_by_source(filter)),
+                "power aggregate must read ExiledBySource, got {:?}",
+                aggregate.source()
+            )
+        }
         other => panic!("expected Aggregate{{Sum, Power, ExiledBySource}}, got {other:?}"),
     }
 
@@ -296,16 +296,16 @@ fn jadeheart_attendant_gains_life_equal_to_craft_material_mana_value() {
     // Revert guard: pre-fix this parsed to Unimplemented (name="gain").
     match amount {
         QuantityExpr::Ref {
-            qty:
-                QuantityRef::Aggregate {
-                    function: AggregateFunction::Sum,
-                    property: ObjectProperty::ManaValue,
-                    filter,
-                },
-        } => assert!(
-            filter_reads_exiled_by_source(filter),
-            "life amount must read ExiledBySource mana value, got {filter:?}"
-        ),
+            qty: QuantityRef::PropertyAggregate(aggregate),
+        } if aggregate.function() == AggregateFunction::Sum
+            && aggregate.property() == ObjectProperty::ManaValue =>
+        {
+            assert!(
+                matches!(aggregate.source(), CardTypeSetSource::Objects { filter } if filter_reads_exiled_by_source(filter)),
+                "life amount must read ExiledBySource mana value, got {:?}",
+                aggregate.source()
+            )
+        }
         other => panic!("expected Aggregate{{Sum, ManaValue, ExiledBySource}}, got {other:?}"),
     }
 

--- a/crates/engine/tests/integration/oversimplify_per_player_fractal.rs
+++ b/crates/engine/tests/integration/oversimplify_per_player_fractal.rs
@@ -120,18 +120,23 @@ fn oversimplify_per_player_fractal_counters_match_exiled_power() {
     let (counter_type, count_expr) = &enter_with_counters[0];
     assert_eq!(*counter_type, CounterType::Plus1Plus1);
     let expected_count = QuantityExpr::Ref {
-        qty: QuantityRef::Aggregate {
-            function: AggregateFunction::Sum,
-            property: ObjectProperty::Power,
-            filter: TargetFilter::And {
-                filters: vec![
-                    TargetFilter::Typed(
-                        TypedFilter::creature().controller(ControllerRef::ScopedPlayer),
-                    ),
-                    TargetFilter::ExiledBySource,
-                ],
-            },
-        },
+        qty: QuantityRef::PropertyAggregate(
+            engine::types::ability::PropertyAggregate::new(
+                AggregateFunction::Sum,
+                ObjectProperty::Power,
+                engine::types::ability::CardTypeSetSource::Objects {
+                    filter: TargetFilter::And {
+                        filters: vec![
+                            TargetFilter::Typed(
+                                TypedFilter::creature().controller(ControllerRef::ScopedPlayer),
+                            ),
+                            TargetFilter::ExiledBySource,
+                        ],
+                    },
+                },
+            )
+            .expect("statically valid property aggregate"),
+        ),
     };
     assert_eq!(
         count_expr, &expected_count,

--- a/crates/engine/tests/integration/tracked_set_anaphor_source.rs
+++ b/crates/engine/tests/integration/tracked_set_anaphor_source.rs
@@ -26,7 +26,8 @@ use engine::game::quantity::resolve_quantity;
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::parser::parse_oracle_text;
 use engine::types::ability::{
-    AggregateFunction, Effect, ObjectProperty, QuantityExpr, QuantityRef, TrackedAnaphorSource,
+    AggregateFunction, CardTypeSetSource, Effect, ObjectProperty, QuantityExpr, QuantityRef,
+    TrackedAnaphorSource,
 };
 use engine::types::events::GameEvent;
 use engine::types::phase::Phase;
@@ -60,16 +61,13 @@ fn aggregates(
     ) {
         match value {
             serde_json::Value::Object(map) => {
-                if map.get("type").and_then(|t| t.as_str()) == Some("TrackedSetAggregate") {
+                if map.get("type").and_then(|t| t.as_str()) == Some("PropertyAggregate") {
                     let qty: QuantityRef = serde_json::from_value(value.clone())
-                        .expect("TrackedSetAggregate round-trips");
-                    if let QuantityRef::TrackedSetAggregate {
-                        function,
-                        property,
-                        source,
-                    } = qty
-                    {
-                        out.push((function, property, source));
+                        .expect("PropertyAggregate round-trips");
+                    if let QuantityRef::PropertyAggregate(aggregate) = qty {
+                        if let CardTypeSetSource::TrackedSet { set, .. } = aggregate.source() {
+                            out.push((aggregate.function(), aggregate.property(), *set));
+                        }
                     }
                 }
                 for v in map.values() {
@@ -332,18 +330,30 @@ fn witch_king_state_is_red_under_the_chain_set_binding() {
     }];
 
     let batch = QuantityExpr::Ref {
-        qty: QuantityRef::TrackedSetAggregate {
-            function: AggregateFunction::Sum,
-            property: ObjectProperty::Power,
-            source: TrackedAnaphorSource::TriggeringBatch,
-        },
+        qty: QuantityRef::PropertyAggregate(
+            engine::types::ability::PropertyAggregate::new(
+                AggregateFunction::Sum,
+                ObjectProperty::Power,
+                engine::types::ability::CardTypeSetSource::TrackedSet {
+                    set: TrackedAnaphorSource::TriggeringBatch,
+                    caused_by: None,
+                },
+            )
+            .expect("statically valid property aggregate"),
+        ),
     };
     let chain = QuantityExpr::Ref {
-        qty: QuantityRef::TrackedSetAggregate {
-            function: AggregateFunction::Sum,
-            property: ObjectProperty::Power,
-            source: TrackedAnaphorSource::ChainSet,
-        },
+        qty: QuantityRef::PropertyAggregate(
+            engine::types::ability::PropertyAggregate::new(
+                AggregateFunction::Sum,
+                ObjectProperty::Power,
+                engine::types::ability::CardTypeSetSource::TrackedSet {
+                    set: TrackedAnaphorSource::ChainSet,
+                    caused_by: None,
+                },
+            )
+            .expect("statically valid property aggregate"),
+        ),
     };
 
     assert_eq!(
@@ -399,18 +409,30 @@ fn kylox_state_is_red_under_the_triggering_batch_binding() {
         .insert(set_id, vec![fodder_a, fodder_b]);
 
     let chain = QuantityExpr::Ref {
-        qty: QuantityRef::TrackedSetAggregate {
-            function: AggregateFunction::Sum,
-            property: ObjectProperty::Power,
-            source: TrackedAnaphorSource::ChainSet,
-        },
+        qty: QuantityRef::PropertyAggregate(
+            engine::types::ability::PropertyAggregate::new(
+                AggregateFunction::Sum,
+                ObjectProperty::Power,
+                engine::types::ability::CardTypeSetSource::TrackedSet {
+                    set: TrackedAnaphorSource::ChainSet,
+                    caused_by: None,
+                },
+            )
+            .expect("statically valid property aggregate"),
+        ),
     };
     let batch = QuantityExpr::Ref {
-        qty: QuantityRef::TrackedSetAggregate {
-            function: AggregateFunction::Sum,
-            property: ObjectProperty::Power,
-            source: TrackedAnaphorSource::TriggeringBatch,
-        },
+        qty: QuantityRef::PropertyAggregate(
+            engine::types::ability::PropertyAggregate::new(
+                AggregateFunction::Sum,
+                ObjectProperty::Power,
+                engine::types::ability::CardTypeSetSource::TrackedSet {
+                    set: TrackedAnaphorSource::TriggeringBatch,
+                    caused_by: None,
+                },
+            )
+            .expect("statically valid property aggregate"),
+        ),
     };
 
     assert_eq!(

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -43,6 +43,12 @@ pub enum ServerErrorCode {
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
 ///
+/// 46 — `QuantityRef::Aggregate` and `QuantityRef::TrackedSetAggregate` were
+///      replaced on the serialized `GameState` surface by the canonical
+///      `QuantityRef::PropertyAggregate` tag with a validated `source` object.
+///      New peers accept the two legacy input tags, but a v45 peer cannot
+///      deserialize the canonical tag emitted by v46, so full-game handshakes
+///      must refuse the one-way parse mismatch. Lobby messages are unchanged.
 /// 45 — `GameState` gained serialized cast-occurrence provenance and prepared-copy links.
 /// 44 — Resolution-time optional `PayCost(OneOf)` branch choice added a
 ///      serialized `WaitingFor`/`GameAction` pair.
@@ -189,7 +195,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 45;
+pub const PROTOCOL_VERSION: u32 = 46;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake **from clients that predate [`LOBBY_PROTOCOL_VERSION`]** — the
@@ -639,12 +645,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 45);
+        assert_eq!(PROTOCOL_VERSION, 46);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot
         // understand a success acknowledgment the submitting client awaits.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 44);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 45);
     }
 
     #[test]

--- a/crates/phase-ai/src/policies/condition_gated_activation.rs
+++ b/crates/phase-ai/src/policies/condition_gated_activation.rs
@@ -108,8 +108,8 @@ mod tests {
     use engine::game::zones::create_object;
     use engine::types::ability::{
         AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, AggregateFunction,
-        Comparator, ControllerRef, Effect, ObjectProperty, QuantityExpr, QuantityRef, TargetFilter,
-        TypeFilter, TypedFilter,
+        CardTypeSetSource, Comparator, ControllerRef, Effect, ObjectProperty, PropertyAggregate,
+        QuantityExpr, QuantityRef, TargetFilter, TypeFilter, TypedFilter,
     };
     use engine::types::card_type::CoreType;
     use engine::types::game_state::{GameState, WaitingFor};
@@ -127,15 +127,20 @@ mod tests {
     fn your_creatures_power_ge(threshold: i32) -> AbilityCondition {
         AbilityCondition::QuantityCheck {
             lhs: QuantityExpr::Ref {
-                qty: QuantityRef::Aggregate {
-                    function: AggregateFunction::Sum,
-                    property: ObjectProperty::Power,
-                    filter: TargetFilter::Typed(
-                        TypedFilter::default()
-                            .with_type(TypeFilter::Creature)
-                            .controller(ControllerRef::You),
-                    ),
-                },
+                qty: QuantityRef::PropertyAggregate(
+                    PropertyAggregate::new(
+                        AggregateFunction::Sum,
+                        ObjectProperty::Power,
+                        CardTypeSetSource::Objects {
+                            filter: TargetFilter::Typed(
+                                TypedFilter::default()
+                                    .with_type(TypeFilter::Creature)
+                                    .controller(ControllerRef::You),
+                            ),
+                        },
+                    )
+                    .expect("AI fixture uses a valid live-object aggregate"),
+                ),
             },
             comparator: Comparator::GE,
             rhs: QuantityExpr::Fixed { value: threshold },

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -2628,8 +2628,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_45() {
-        assert_eq!(PROTOCOL_VERSION, 45);
+    fn protocol_version_is_46() {
+        assert_eq!(PROTOCOL_VERSION, 46);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -2639,7 +2639,7 @@ mod tests {
     /// understand.
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
-    /// this guards — and this test reds while `protocol_version_is_42` stays
+    /// this guards — and this test reds while `protocol_version_is_44` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 45;
+const EXPECTED_PROTOCOL_VERSION = 46;
 // The LOBBY message-set version. Deliberately separate from the full-game
 // number above and deliberately NOT derived from it: a GameState-only bump must
 // not move the lobby's compatibility window. See the assertions at the bottom.
@@ -14,7 +14,7 @@ const EXPECTED_LOBBY_PROTOCOL_VERSION = 2;
 // here, so a full-game bump could ship with an unbumped P2P version and CI
 // stayed green — a v(n-1) host and a v(n) guest would then complete a
 // handshake and only fail when the incompatible payload arrived.
-const EXPECTED_WIRE_PROTOCOL_VERSION = 34;
+const EXPECTED_WIRE_PROTOCOL_VERSION = 35;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);


### PR DESCRIPTION
## Summary

Phase 2 of the accepted #6865 implementation, following the merged cast-occurrence authority in PR #7998.

- introduces one validated, source-bearing `PropertyAggregate` authority for object properties
- atomically migrates legacy `Aggregate` and `TrackedSetAggregate` wire shapes while emitting canonical-only JSON
- preserves object-count population semantics, tracked-set LKI, chain-set vs triggering-batch identity, and turn-journal cast-occurrence exclusion
- migrates visitors, rewrites, scanners, cost modifiers, AI fixtures, and canonical Karn snapshots
- bumps the full-game protocol to 46 and P2P protocol to 35 for the serialized game-state shape change

This PR intentionally does **not** add Call Forth the Tempest or Rootha grammar/card implementations. Those remain Phase 3 after this foundation merges.

## Architecture / compatibility

`PropertyAggregate::new` is the validation boundary. Runtime legacy aggregate authorities are removed; legacy payloads migrate at every bounded direct `QuantityRef` deserialization carrier, including recursive player filters, combat-tax scaling, restrictions, and static cost modifiers. Crossed/missing legacy shapes remain rejected.

The shared population walk delegates `Objects` membership to the existing object-count authority and retains live-or-LKI views for tracked objects. This preserves branch-local zone universes, `LastZoneChanged`/tracked populations, departed and ceased objects, and exact `AnyOf` deduplication.

## Validation

Exact head: `fc1d051e148eeb1d9947faac8ff01b401b908573`

- independent completion + maintainer-simulation review: pass, no findings
- `cargo fmt --all -- --check`: pass
- `git diff --check`: pass
- `cargo clippy --all-targets -- -D warnings`: pass
- full `phase-engine`: 19,955 unit tests + 5,648 integration tests passed; 0 failed
- full `phase-ai`: 2,102 main tests plus all auxiliary suites passed; 0 failed
- exact Phase 2 aggregate/serde/card/Karn matrix: pass
- protocol check: pass (full 46 / P2P 35)
- parser Gate G/A: pass
- frontend lint: pass (existing warnings only)
- frontend type/protocol check: pass
- frontend coverage suite: 4,078 passed, 0 failed

Tilt was unavailable in the local Windows environment, so the repository-documented direct Cargo fallback was used. The engine-authority semantic gates passed; the final census comparer reported the known Windows separator-only artifact (`crates\\...` added versus identical `crates/...` removed), so no census baseline was changed.

## Parse-diff plan

Phase 2 does not broaden Call Forth/Rootha grammar. After current-head CI completes, I will post the exact-head parse-diff receipt expected by the maintainer workflow. The immutable same-input candidate export for the two cards remains owned by Phase 3.

Part of #6865.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved calculation of aggregated card properties across objects, tracked sets, and game history.
  * Added validation for supported aggregate sources and properties.

* **Bug Fixes**
  * Improved handling of departed cards, triggering batches, and chain-based card references.
  * Preserved compatibility when reading older saved game data.

* **Compatibility**
  * Updated multiplayer protocols. Full-game connections require the latest protocol versions, while lobby messaging remains compatible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->