### PR TITLE
Add Goblin Plate Mail

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -1448,6 +1448,7 @@ fn scope_of(target: &TargetFilter, chain_root: Option<WriteScope>) -> WriteScope
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }
@@ -2406,6 +2407,9 @@ fn legacy_target_filter(f: &TargetFilter) -> bool {
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
+        // CR 701.47c: not one of the 12 frozen event-context tags, mirroring
+        // `ObjectScope::AmassedArmy`'s `legacy_object_scope` classification.
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::ExiledBySource
@@ -2647,6 +2651,10 @@ fn member_bound_target_filter(f: &TargetFilter) -> bool {
         | TargetFilter::ParentTargetOwner
         | TargetFilter::StackSpell
         | TargetFilter::CostPaidObject
+        // CR 701.47c: resolution-local, carried per-ability like `CostPaidObject`
+        // (`ResolvedAbility.amassed_army_object`), not per-source storage keyed
+        // by object id — not per-member-bound.
+        | TargetFilter::AmassedArmy
         | TargetFilter::ScopedPlayer
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
@@ -6912,6 +6920,9 @@ fn rw_target_filter(x: &TargetFilter) -> RwProfile {
         | TargetFilter::LastCreated
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
+        // CR 701.47c: not one of the 12 D5/legacy tags — a read-free selector
+        // (mirrors `ObjectScope::AmassedArmy`, which carries no event axis).
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::ExiledBySource

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -3084,6 +3084,9 @@ fn scan_target_filter(x: &TargetFilter, ctx: FilterReadContext, mode: ScanMode) 
         TargetFilter::AttachedTo => Axes::NONE,
         TargetFilter::LastCreated => Axes::NONE,
         TargetFilter::LastRevealed | TargetFilter::LastZoneChanged => Axes::NONE,
+        // CR 701.47c: per-resolution local (the Army amass just touched) — no
+        // event/sibling/projected axis, mirroring `ObjectScope::AmassedArmy`.
+        TargetFilter::AmassedArmy => Axes::NONE,
         TargetFilter::CostPaidObject => Axes {
             event: true,
             sibling: false,

--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2693,6 +2693,7 @@ fn matches_via_origin_scoped_branch(
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::ExiledBySource

--- a/crates/engine/src/game/cost_payability.rs
+++ b/crates/engine/src/game/cost_payability.rs
@@ -82,6 +82,7 @@ pub(crate) fn target_filter_has_x_mana_value_constraint(filter: &TargetFilter) -
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::ExiledBySource
@@ -262,6 +263,7 @@ pub(crate) fn relax_x_mana_value_constraint(filter: &TargetFilter) -> TargetFilt
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::ExiledBySource

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -591,6 +591,8 @@ fn fmt_target(filter: &TargetFilter) -> String {
         TargetFilter::LastRevealed => "last revealed".into(),
         TargetFilter::LastZoneChanged => "last zone changed".into(),
         TargetFilter::CostPaidObject => "cost-paid object".into(),
+        // CR 701.47c: matches `ObjectScope::AmassedArmy`'s description string.
+        TargetFilter::AmassedArmy => "amassed Army".into(),
         TargetFilter::ChosenCard => "last chosen card".into(),
         TargetFilter::TriggeringSpellController => "triggering spell's controller".into(),
         TargetFilter::TriggeringSpellOwner => "triggering spell's owner".into(),

--- a/crates/engine/src/game/effects/amass.rs
+++ b/crates/engine/src/game/effects/amass.rs
@@ -426,4 +426,135 @@ mod tests {
             "Chatterfang should append one Squirrel when amass creates the Army token"
         );
     }
+
+    // CR 701.47a + CR 701.47c + CR 301.5a (Goblin Plate Mail, HOB): the
+    // provenance-binding regression pair. "When this Equipment enters, amass
+    // Goblins 1, then attach this Equipment to the amassed Army" must attach
+    // to the EXACT Army object amass just touched — the freshly created
+    // token in the no-Army case, or the pre-existing Army in the other —
+    // never re-derived by rescanning the battlefield for "an Army you
+    // control" after the fact.
+    const GOBLIN_PLATE_MAIL_ORACLE: &str = "When this Equipment enters, amass Goblins 1, then \
+         attach this Equipment to the amassed Army. (To amass Goblins 1, put a +1/+1 counter on \
+         an Army you control. It's also a Goblin. If you don't control an Army, create a 0/0 \
+         black Goblin Army creature token first.)\nEquipped creature gets +1/+0 and has \
+         menace.\nEquip {4}";
+
+    /// CR 701.47a: no pre-existing Army — ETB creates a 0/0 black Goblin Army
+    /// token, amass puts one +1/+1 counter on it, and the Equipment ends up
+    /// attached to THAT token specifically. By the time resolution finishes,
+    /// the Equipment's own "equipped creature gets +1/+0" (CR 613.4c layer
+    /// 7c) is also live on its new host, so the token's EFFECTIVE power/
+    /// toughness is 2/1 (0/0 base + the counter's +1/+1 + the equipment's
+    /// +1/+0) — not the 1/1 the counter alone would produce.
+    #[test]
+    fn goblin_plate_mail_etb_creates_army_and_attaches_to_it() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(crate::types::phase::Phase::PreCombatMain);
+        let equipment = scenario
+            .add_artifact_to_hand_from_oracle(P0, "Goblin Plate Mail", GOBLIN_PLATE_MAIL_ORACLE)
+            .with_subtypes(vec!["Equipment"])
+            .with_mana_cost(crate::types::mana::ManaCost::generic(0))
+            .id();
+        let mut runner = scenario.build();
+
+        let outcome = runner.cast(equipment).resolve();
+        let state = outcome.state();
+
+        let armies: Vec<_> = state
+            .battlefield
+            .iter()
+            .filter_map(|id| state.objects.get(id))
+            .filter(|obj| obj.card_types.subtypes.iter().any(|s| s == "Army"))
+            .collect();
+        assert_eq!(
+            armies.len(),
+            1,
+            "expected exactly one Army on the battlefield"
+        );
+        let army = armies[0];
+        assert!(
+            army.is_token,
+            "no pre-existing Army — amass must create a token"
+        );
+        assert_eq!(army.base_power, Some(0), "amass creates a 0/0 Army token");
+        assert_eq!(
+            army.base_toughness,
+            Some(0),
+            "amass creates a 0/0 Army token"
+        );
+        assert_eq!(
+            army.counters.get(&CounterType::Plus1Plus1).copied(),
+            Some(1),
+            "amass Goblins 1 puts one +1/+1 counter on the amassed Army"
+        );
+        // CR 613.4c (layer 7c): once attached, Goblin Plate Mail's own
+        // "equipped creature gets +1/+0" is live on this token too, so the
+        // EFFECTIVE power/toughness is base 0/0 + the counter's +1/+1 + the
+        // equipment's +1/+0 = 2/1, not the 1/1 the counter alone would give.
+        assert_eq!(army.power, Some(2));
+        assert_eq!(army.toughness, Some(1));
+        assert!(army.card_types.subtypes.iter().any(|s| s == "Goblin"));
+
+        let equipment_obj = state.objects.get(&equipment).expect("equipment object");
+        assert_eq!(
+            equipment_obj.attached_to,
+            Some(crate::game::game_object::AttachTarget::Object(army.id)),
+            "Goblin Plate Mail must attach to the newly created Army token"
+        );
+    }
+
+    /// CR 701.47c: a pre-existing Army — amass must reuse it (not create a
+    /// second, phantom Army) and the Equipment must attach to THAT exact
+    /// object, not to some Army found by re-scanning the battlefield.
+    #[test]
+    fn goblin_plate_mail_etb_reuses_existing_army_and_attaches_to_it() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(crate::types::phase::Phase::PreCombatMain);
+        let existing_army = scenario
+            .add_creature(P0, "Zombie Army", 0, 0)
+            .with_subtypes(vec!["Army", "Zombie"])
+            .id();
+        scenario.with_counter(existing_army, CounterType::Plus1Plus1, 2);
+        let equipment = scenario
+            .add_artifact_to_hand_from_oracle(P0, "Goblin Plate Mail", GOBLIN_PLATE_MAIL_ORACLE)
+            .with_subtypes(vec!["Equipment"])
+            .with_mana_cost(crate::types::mana::ManaCost::generic(0))
+            .id();
+        let mut runner = scenario.build();
+
+        let outcome = runner.cast(equipment).resolve();
+        let state = outcome.state();
+
+        let armies: Vec<_> = state
+            .battlefield
+            .iter()
+            .filter_map(|id| state.objects.get(id))
+            .filter(|obj| obj.card_types.subtypes.iter().any(|s| s == "Army"))
+            .collect();
+        assert_eq!(
+            armies.len(),
+            1,
+            "must not create a second Army when the controller already has one"
+        );
+        let army = armies[0];
+        assert_eq!(
+            army.id, existing_army,
+            "must reuse the pre-existing Army object, not a new one"
+        );
+        assert_eq!(
+            army.counters.get(&CounterType::Plus1Plus1).copied(),
+            Some(3),
+            "amass Goblins 1 adds to the existing Army's counters (2 -> 3)"
+        );
+        assert!(army.card_types.subtypes.iter().any(|s| s == "Zombie"));
+        assert!(army.card_types.subtypes.iter().any(|s| s == "Goblin"));
+
+        let equipment_obj = state.objects.get(&equipment).expect("equipment object");
+        assert_eq!(
+            equipment_obj.attached_to,
+            Some(crate::game::game_object::AttachTarget::Object(existing_army)),
+            "Goblin Plate Mail must attach to the EXISTING Army amass touched, not a phantom new one"
+        );
+    }
 }

--- a/crates/engine/src/game/effects/effect.rs
+++ b/crates/engine/src/game/effects/effect.rs
@@ -679,6 +679,32 @@ fn register_transient_effect(
                 );
             }
         }
+        // CR 701.47c: A grant whose affected object is "the amassed Army"
+        // (e.g. a future "amass N, then the amassed Army gains/gets ..."
+        // continuation) resolves directly from the recursively-stamped
+        // `amassed_army_object`, never a target — mirrors the `CostPaidObject`
+        // arm immediately above. Unlike `CostPaidObject`, the Army is always
+        // on the battlefield when this resolves, so the broadcast-scan branch
+        // below would coincidentally bind the same single object too; this arm
+        // is still the correct seam because it names the object directly
+        // instead of relying on a battlefield re-scan happening to narrow to
+        // exactly one match.
+        Some(TargetFilter::AmassedArmy)
+            if ability.targets.is_empty() && ability.amassed_army_object.is_some() =>
+        {
+            if let Some(snap) = &ability.amassed_army_object {
+                install_transient(
+                    state,
+                    end_permission,
+                    ability.source_id,
+                    ability.controller,
+                    duration.clone(),
+                    TargetFilter::SpecificObject { id: snap.object_id },
+                    modifications.clone(),
+                    static_def.condition.clone(),
+                );
+            }
+        }
         // TriggeringSource is handled via early short-circuit to avoid target propagation bugs.
         Some(TargetFilter::ParentTarget) if ability.targets.is_empty() => {
             let tracked = state
@@ -790,7 +816,18 @@ fn transient_bound_filters(
 pub fn generic_effect_affected_uses_inherited_targets(filter: &TargetFilter) -> bool {
     matches!(
         filter,
-        TargetFilter::TriggeringSource | TargetFilter::ParentTarget | TargetFilter::CostPaidObject
+        TargetFilter::TriggeringSource
+            | TargetFilter::ParentTarget
+            | TargetFilter::CostPaidObject
+            // CR 701.47c: "the amassed Army" is a resolution-local single-object
+            // reference (`ResolvedAbility.amassed_army_object`), not a broadcast
+            // population — mirrors `CostPaidObject` immediately above. This
+            // routes a future "amass N, then the amassed Army gains/gets ..."
+            // continuous grant to the dedicated `amassed_army_object` arm below
+            // (mirroring the `CostPaidObject` arm) and to the matching
+            // early-return guard in the broadcast-scan arm, instead of relying
+            // on the battlefield re-scan happening to narrow to one object.
+            | TargetFilter::AmassedArmy
     )
 }
 
@@ -1091,6 +1128,90 @@ mod tests {
             tce.modifications,
             vec![ContinuousModification::AddKeyword {
                 keyword: Keyword::Flying,
+            }]
+        );
+    }
+
+    /// CR 701.47c: a hypothetical "amass N, then the amassed Army gains/gets
+    /// ..." continuous grant (`GenericEffect { affected: AmassedArmy }`) must
+    /// bind directly to the exact Army object `amassed_army_object` names —
+    /// the sibling-coverage counterpart of the `SelfRef` test above, and of
+    /// the pre-existing `CostPaidObject` dedicated-arm handling in
+    /// `resolve()`. Revert-fail: if `AmassedArmy` were removed from either
+    /// `generic_effect_affected_uses_inherited_targets` or its dedicated
+    /// resolution arm (while the other half stayed), this test fails —
+    /// dropping the helper-only half makes the broadcast-scan arm's
+    /// early-return guard fire before ever finding the object, so ZERO
+    /// transient effects install (not merely a different-looking one), which
+    /// is exactly the silent-no-op class of bug `is_context_ref` was fixed
+    /// for elsewhere in this same card's implementation.
+    #[test]
+    fn generic_effect_registers_transient_effect_for_amassed_army() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Source".to_string(),
+            Zone::Battlefield,
+        );
+        let army = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Army Token".to_string(),
+            Zone::Battlefield,
+        );
+        // A second, unrelated battlefield object: if `AmassedArmy` fell
+        // through to a real broadcast scan with an unfiltered/mismatched
+        // resolved filter, this decoy would surface a second (wrong) TCE.
+        let _decoy = create_object(
+            &mut state,
+            CardId(3),
+            PlayerId(1),
+            "Decoy".to_string(),
+            Zone::Battlefield,
+        );
+        let snapshot = crate::types::ability::CostPaidObjectSnapshot {
+            object_id: army,
+            lki: state.objects[&army].snapshot_public_characteristics(),
+        };
+
+        let static_def = StaticDefinition::continuous()
+            .affected(TargetFilter::AmassedArmy)
+            .modifications(vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Menace,
+            }]);
+
+        let mut ability = ResolvedAbility::new(
+            Effect::GenericEffect {
+                static_abilities: vec![static_def],
+                duration: Some(Duration::UntilEndOfTurn),
+                target: None,
+                end_cost: None,
+            },
+            vec![],
+            source,
+            PlayerId(0),
+        )
+        .duration(Duration::UntilEndOfTurn);
+        ability.set_amassed_army_object_recursive(snapshot);
+
+        let mut events = Vec::new();
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        assert_eq!(
+            state.transient_continuous_effects.len(),
+            1,
+            "must bind exactly one TCE, to the amassed Army — not zero (silent \
+             no-op) and not a battlefield-wide broadcast"
+        );
+        let tce = &state.transient_continuous_effects[0];
+        assert_eq!(tce.affected, TargetFilter::SpecificObject { id: army });
+        assert_eq!(
+            tce.modifications,
+            vec![ContinuousModification::AddKeyword {
+                keyword: Keyword::Menace,
             }]
         );
     }

--- a/crates/engine/src/game/effects/token.rs
+++ b/crates/engine/src/game/effects/token.rs
@@ -3314,6 +3314,7 @@ fn classify_attach_host_authority(filter: &TargetFilter) -> AttachHostAuthority 
         | TargetFilter::None
         | TargetFilter::GrantingObject
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::ChosenDamageSource { .. }
         | TargetFilter::TrackedSet { .. }

--- a/crates/engine/src/game/filter.rs
+++ b/crates/engine/src/game/filter.rs
@@ -180,6 +180,9 @@ pub(crate) fn affected_filter_uses_object_population(filter: &TargetFilter) -> b
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        // CR 701.47c: fixed resolution-local object ref — never whole-board
+        // population (mirrors `CostPaidObject`).
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }
@@ -457,6 +460,7 @@ pub(crate) fn target_filter_characteristic_reads_at(
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::ExiledBySource
@@ -833,6 +837,7 @@ pub(crate) fn entered_object_perturbs_affected_filter(
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }
@@ -1609,6 +1614,7 @@ pub(crate) fn filter_contains(filter: &TargetFilter, leaf: &dyn Fn(&TargetFilter
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::ExiledBySource
@@ -3435,6 +3441,14 @@ fn filter_inner_for_object(
                     .or(ability.effect_context_object.as_ref())
             })
             .is_some_and(|snapshot| snapshot.object_id == object_id),
+        // CR 701.47c: "the amassed Army" / "the Army you amassed" — the Army
+        // creature the current amass instruction chose, threaded via
+        // `ability.amassed_army_object` (mirrors `CostPaidObject` immediately
+        // above, minus the effect-context-object fallback: amass has no such
+        // secondary carrier).
+        TargetFilter::AmassedArmy => ability
+            .and_then(|ability| ability.amassed_army_object.as_ref())
+            .is_some_and(|snapshot| snapshot.object_id == object_id),
         // CR 613.1f + CR 611.2c + CR 400.7: the FILTER source's last-remembered
         // card (`ChosenAttribute::Card`, written by `Effect::RememberCard`). Read
         // live each layer pass against `source_id` (the permanent that HAS the
@@ -3950,6 +3964,7 @@ fn zone_change_filter_inner(
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }
@@ -4277,6 +4292,7 @@ pub fn spell_record_matches_filter(
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }
@@ -4591,6 +4607,7 @@ fn spell_object_matches_filter_inner(
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }

--- a/crates/engine/src/game/layers.rs
+++ b/crates/engine/src/game/layers.rs
@@ -3508,6 +3508,7 @@ fn target_filter_reads_life_total(filter: &TargetFilter) -> bool {
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::ExiledBySource

--- a/crates/engine/src/game/targeting.rs
+++ b/crates/engine/src/game/targeting.rs
@@ -808,6 +808,20 @@ pub fn resolved_targets(
             .map(|snap| TargetRef::Object(snap.object_id))
             .collect();
     }
+    // CR 701.47c: "the amassed Army" / "the Army you amassed" — resolves to
+    // the Army creature the current amass instruction chose, threaded via
+    // `ability.amassed_army_object` (stamped by the sub-ability chain walker
+    // in `game/effects/mod.rs` from the `Amass` effect's own resolution).
+    // Mirrors the `CostPaidObject` ladder immediately above: a resolution-local
+    // referent read out of ability state, not the targeting pipeline.
+    if matches!(target_filter, TargetFilter::AmassedArmy) {
+        return ability
+            .amassed_army_object
+            .as_ref()
+            .into_iter()
+            .map(|snap| TargetRef::Object(snap.object_id))
+            .collect();
+    }
     // CR 701.20e: "it" / "that card" after a look-at or reveal instruction.
     if matches!(target_filter, TargetFilter::LastRevealed) {
         return state

--- a/crates/engine/src/game/trigger_matchers.rs
+++ b/crates/engine/src/game/trigger_matchers.rs
@@ -885,6 +885,7 @@ pub(super) fn target_filter_matches_object(
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -10977,6 +10977,7 @@ fn filter_binding_diverges(filter: &TargetFilter) -> bool {
         // `ResolvedAbility`, so this matches nothing at fire time. The
         // population-level counterpart of `ObjectScope::CostPaidObject`.
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
 
         // ---- RESOLUTION-PUBLISHED LEDGERS (CR 608.2c): established BY a
         // ---- resolution, so the fire-time read is a different moment's set.

--- a/crates/engine/src/parser/oracle_effect/lower.rs
+++ b/crates/engine/src/parser/oracle_effect/lower.rs
@@ -2928,6 +2928,7 @@ fn ability_reads_last_created(def: &AbilityDefinition) -> bool {
             | TargetFilter::LastRevealed
             | TargetFilter::LastZoneChanged
             | TargetFilter::CostPaidObject
+            | TargetFilter::AmassedArmy
             | TargetFilter::ChosenCard
             | TargetFilter::TrackedSet { .. }
             | TargetFilter::ExiledBySource

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -8981,6 +8981,7 @@ fn rebind_controller_scope(filter: &mut TargetFilter, from: ControllerRef, to: C
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }

--- a/crates/engine/src/parser/oracle_effect/search.rs
+++ b/crates/engine/src/parser/oracle_effect/search.rs
@@ -2103,6 +2103,9 @@ fn object_scope_for_linked_reference(reference: &TargetFilter) -> Option<ObjectS
         TargetFilter::CostPaidObject => Some(ObjectScope::CostPaidObject),
         TargetFilter::ParentTarget => Some(ObjectScope::Target),
         TargetFilter::TriggeringSource => Some(ObjectScope::EventSource),
+        // CR 701.47c: "shares a creature type with the amassed Army" — bridge
+        // to the QuantityRef-side scope that already carries the same referent.
+        TargetFilter::AmassedArmy => Some(ObjectScope::AmassedArmy),
         _ => None,
     }
 }

--- a/crates/engine/src/parser/oracle_nom/quantity.rs
+++ b/crates/engine/src/parser/oracle_nom/quantity.rs
@@ -2547,6 +2547,7 @@ fn filter_is_population_anchored(filter: &TargetFilter) -> bool {
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }
@@ -2681,6 +2682,7 @@ pub(crate) fn objects_filter_zone_is_unambiguous(filter: &TargetFilter) -> bool 
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }

--- a/crates/engine/src/parser/oracle_static/restriction.rs
+++ b/crates/engine/src/parser/oracle_static/restriction.rs
@@ -2340,6 +2340,7 @@ fn usable_disjunctive_permission_filter(filter: &TargetFilter) -> bool {
         | TargetFilter::LastRevealed
         | TargetFilter::LastZoneChanged
         | TargetFilter::CostPaidObject
+        | TargetFilter::AmassedArmy
         | TargetFilter::ChosenCard
         | TargetFilter::TrackedSet { .. }
         | TargetFilter::TrackedSetFiltered { .. }

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -752,6 +752,15 @@ pub fn parse_target_with_syntax<'a>(
     if let Some((filter, rest)) = nom_on_lower(text, &lower, |input| {
         alt((
             |i| parse_cost_paid_object_reference(i, ctx),
+            // CR 701.47c: "the amassed Army" / "the Army you amassed" — the
+            // Army creature the current amass instruction chose. A
+            // resolution-local reference (mirrors `CostPaidObject` above),
+            // used by "amass Goblins 1, then attach this Equipment to the
+            // amassed Army" (Goblin Plate Mail).
+            value(
+                TargetFilter::AmassedArmy,
+                alt((tag("the amassed army"), tag("the army you amassed"))),
+            ),
             value(
                 TargetFilter::TriggeringSource,
                 (

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -9642,6 +9642,75 @@ fn dreadhorde_invasion_upkeep_lose_life_and_amass() {
     }
 }
 
+/// CR 701.47a + CR 701.47c + CR 301.5a (Goblin Plate Mail, HOB): "When this
+/// Equipment enters, amass Goblins 1, then attach this Equipment to the
+/// amassed Army." Amass is the `execute` head; the attach rides as its
+/// `SequentialSibling` sub_ability with `attachment: SelfRef` (the default —
+/// "this Equipment") and `target: AmassedArmy` — the CR 701.47c binding to
+/// the EXACT Army object amass just touched, not a re-scan of the
+/// battlefield for "an Army you control". Zero `Effect::Unimplemented` nodes.
+#[test]
+fn goblin_plate_mail_amass_then_attach_to_amassed_army() {
+    let def = parse_trigger_line(
+        "When this Equipment enters, amass Goblins 1, then attach this Equipment to the amassed \
+         Army.",
+        "Goblin Plate Mail",
+    );
+    assert_eq!(def.mode, TriggerMode::ChangesZone);
+    assert_eq!(def.destination, Some(Zone::Battlefield));
+    assert_eq!(def.valid_card, Some(TargetFilter::SelfRef));
+
+    let execute = def.execute.expect("execute");
+    match *execute.effect {
+        Effect::Amass {
+            ref subtype,
+            ref count,
+        } => {
+            assert_eq!(subtype, "Goblin");
+            assert!(
+                matches!(count, QuantityExpr::Fixed { value: 1 }),
+                "expected Amass count 1, got {count:?}"
+            );
+        }
+        ref other => panic!("expected Amass{{Goblin, 1}} head, got {other:?}"),
+    }
+
+    let sub = execute
+        .sub_ability
+        .expect("attach conjunct must survive as a sub_ability");
+    assert_eq!(
+        sub.sub_link,
+        SubAbilityLink::ContinuationStep,
+        "\"amass X, then attach ~\" is a within-sentence continuation (comma/\"then\" joined), \
+         the same shape as Squadron Hawk's \"...then shuffle\""
+    );
+    match *sub.effect {
+        Effect::Attach {
+            ref attachment,
+            ref target,
+        } => {
+            assert_eq!(
+                *attachment,
+                TargetFilter::SelfRef,
+                "attach \"this Equipment\" to the amassed Army — attachment is the source"
+            );
+            assert_eq!(
+                *target,
+                TargetFilter::AmassedArmy,
+                "must bind to the EXACT Army amass just touched, not a battlefield re-scan"
+            );
+        }
+        ref other => panic!("expected Attach{{SelfRef, AmassedArmy}}, got {other:?}"),
+    }
+
+    // No parse gap: neither clause fell back to `Effect::Unimplemented`.
+    assert!(
+        !matches!(*execute.effect, Effect::Unimplemented { .. })
+            && !matches!(*sub.effect, Effect::Unimplemented { .. }),
+        "expected zero Unimplemented nodes"
+    );
+}
+
 /// CR 603.4 + CR 122.1: "at the beginning of your end step, if there are
 /// thirty or more counters among artifacts and creatures you control, ..."
 /// — intervening-if with counter-count condition that sums across every

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -5976,6 +5976,21 @@ pub enum TargetFilter {
     /// resolving spell or ability. Used by effects such as "the exiled card"
     /// after an exile-as-cost clause.
     CostPaidObject,
+    /// CR 701.47c + CR 608.2c: "the amassed Army" / "the Army you amassed" —
+    /// the Army creature chosen by the current amass instruction, whether or
+    /// not it received counters. A resolution-local, non-targeted object
+    /// reference (the `TargetFilter` object-target counterpart of
+    /// [`ObjectScope::AmassedArmy`], which reads the same
+    /// `ResolvedAbility.amassed_army_object` snapshot for QuantityRef
+    /// properties like "the amassed Army's power"). Used by
+    /// `Effect::Attach.target` for "amass Goblins 1, then attach this
+    /// Equipment to the amassed Army" (Goblin Plate Mail): the sub-ability
+    /// chain walker in `game/effects/mod.rs` stamps `amassed_army_object`
+    /// from the `Amass` effect's resolution onto this sub-ability before it
+    /// resolves, so the attach binds to the EXACT Army amass just touched —
+    /// the newly created token, or an existing Army — never re-derived by
+    /// rescanning the battlefield for "an Army you control".
+    AmassedArmy,
     /// CR 613.1f + CR 611.2c + CR 400.7: Resolves to the single card most recently
     /// recorded on the FILTER's source object via `ChosenAttribute::Card` (written
     /// by `Effect::RememberCard`). Models "the last chosen card" — Koh, the Face
@@ -16888,6 +16903,16 @@ impl TargetFilter {
                 | TargetFilter::Neighbor { .. }
                 | TargetFilter::AttachedTo
                 | TargetFilter::CostPaidObject
+                // CR 701.47c: "the amassed Army" / "the Army you amassed" is
+                // resolved from `ResolvedAbility.amassed_army_object` after
+                // the current amass instruction runs — never declared as a
+                // target slot. Mirrors `CostPaidObject` immediately above:
+                // without this arm, the targeting layer treats it as a CR 115
+                // target needing legal candidates BEFORE amass has created or
+                // chosen the Army, so it always finds zero legal targets and
+                // the whole ability (Amass head included) is removed from the
+                // stack for lack of a legal target before it ever resolves.
+                | TargetFilter::AmassedArmy
                 | TargetFilter::ParentTarget
                 | TargetFilter::ParentTargetSlot { .. }
                 | TargetFilter::ParentTargetController

--- a/crates/engine/src/types/events.rs
+++ b/crates/engine/src/types/events.rs
@@ -535,6 +535,7 @@ impl EventObjectSnapshot {
             | TargetFilter::LastRevealed
             | TargetFilter::LastZoneChanged
             | TargetFilter::CostPaidObject
+            | TargetFilter::AmassedArmy
             | TargetFilter::ChosenCard
             | TargetFilter::TrackedSet { .. }
             | TargetFilter::ExiledCardByIndex { .. }


### PR DESCRIPTION
## Summary
Adds engine support for **Goblin Plate Mail** (HOB): ETB Amass-then-attach-to-the-amassed-Army, via a new `TargetFilter::AmassedArmy` mirroring the pre-existing `ObjectScope::AmassedArmy`. Also fixes two real bugs found and fixed during review: (1) `TargetFilter::is_context_ref()` would have made the whole ability silently fail to trigger (the new target variant wasn't recognized as a non-CR-115 context reference, so the targeting layer required a legal candidate before Amass could create one); (2) a sibling non-exhaustive helper, `generic_effect_affected_uses_inherited_targets` (`game/effects/effect.rs`), had the same missing-variant shape — completed with its own dedicated resolution arm so a future "amass N, then the amassed Army gains/gets ..." continuous grant binds to the exact Army object instead of silently no-oping.

## Files changed
- `crates/engine/src/types/ability.rs` — new `TargetFilter::AmassedArmy` variant; `is_context_ref()` taught about it
- `crates/engine/src/game/filter.rs` — `filter_inner_for_object` resolves `AmassedArmy` from `ability.amassed_army_object`, plus population/characteristic-read classification arms
- `crates/engine/src/game/targeting.rs` — `resolved_targets` resolves `AmassedArmy` to the snapshotted object
- `crates/engine/src/game/effects/amass.rs` — two discriminating runtime regression tests (no pre-existing Army / pre-existing Army) run through the real cast pipeline
- `crates/engine/src/game/effects/effect.rs` — **new in this PR's follow-up commit**: completes `generic_effect_affected_uses_inherited_targets` sibling coverage plus its dedicated `AmassedArmy` resolution arm, with a building-block regression test
- `crates/engine/src/game/effects/token.rs`, `crates/engine/src/game/ability_rw.rs`, `crates/engine/src/game/ability_scan.rs`, `crates/engine/src/game/casting.rs`, `crates/engine/src/game/cost_payability.rs`, `crates/engine/src/game/coverage.rs`, `crates/engine/src/game/layers.rs`, `crates/engine/src/game/trigger_matchers.rs`, `crates/engine/src/game/triggers.rs`, `crates/engine/src/types/events.rs` — `TargetFilter::AmassedArmy` wired through every exhaustive match already covering `TargetFilter::CostPaidObject`
- `crates/engine/src/parser/oracle_target.rs` — parses "the amassed Army" / "the Army you amassed" to `TargetFilter::AmassedArmy`
- `crates/engine/src/parser/oracle_effect/lower.rs`, `crates/engine/src/parser/oracle_effect/mod.rs`, `crates/engine/src/parser/oracle_effect/search.rs`, `crates/engine/src/parser/oracle_nom/quantity.rs`, `crates/engine/src/parser/oracle_static/restriction.rs` — sibling exhaustive-match wiring on the parser side
- `crates/engine/src/parser/oracle_trigger_tests.rs` — parse-shape test for the amass-then-attach chain

## Track
Developer

## LLM
Model: claude-sonnet-5
Tier: Frontier
Thinking: high

## Implementation method (required)
Method: /engine-implementer

## CR references
- CR 701.47a — Amass N (create/choose the Army, put counters on it)
- CR 701.47c — "the Army you amassed" / "the amassed Army" refers to the chosen creature whether or not it received counters
- CR 613.4c — Layer 7c: power/toughness modification effects and counters
- CR 608.2c — instruction order / anaphora resolution

## Verification
- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — PASS
- `cargo test -p phase-engine --lib` — 19839 passed; 0 failed; 6 ignored
- `cargo test -p phase-engine --test integration goblin` — 15 passed; 0 failed
- `cargo clippy -p phase-engine --all-targets -- -D warnings` — PASS (clean)
- `./scripts/check-parser-combinators.sh upstream/main` — Gate A/G PASS
- `cargo coverage` — Goblin Plate Mail: supported: false → true, gap_count: 1 → 0

## Gate A
Gate A PASS head=396144573a8fd92a31c5d9ae0cf13f8c57b8d94b base=5dc1b652cd99be1c20a8c56f64c8cdcd139e6db2

## Anchored on
- `crates/engine/src/types/ability.rs:6518` — the pre-existing `ObjectScope::AmassedArmy` precedent
- `crates/engine/src/types/ability.rs:5978` — the sibling `TargetFilter::CostPaidObject` precedent this mirrors

## Final review-impl
Final review-impl PASS head=396144573a8fd92a31c5d9ae0cf13f8c57b8d94b

## Claimed parse impact
Goblin Plate Mail (supported: false → true, gap_count: 1 → 0).

## Scope Expansion
Review found a second non-exhaustive helper with the same `AmassedArmy` gap-shape (`generic_effect_affected_uses_inherited_targets` in `game/effects/effect.rs`, unrelated to the original file list). Fixed in a follow-up commit on this branch with its own dedicated resolution arm and a building-block regression test, since leaving it half-consistent would have been a latent inconsistency for the next Amass-continuation card.

## Validation Failures
None.

## CI Failures
None.