### PR TITLE
fix: allow resolve all after ai recheck

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -8189,10 +8189,24 @@ fn begin_resolve_all_consent(
     priority_player: PlayerId,
     max_resolutions: u32,
 ) -> Result<WaitingFor, EngineError> {
-    if state.stack_resolution_session.is_some() {
-        return Err(EngineError::ActionNotAllowed(
-            "Resolve All cannot replace an active stack-resolution session".to_string(),
-        ));
+    match state
+        .stack_resolution_session
+        .as_ref()
+        .map(|session| session.policy)
+    {
+        // An AI-issued recheck is an internal, provisional shortcut. An
+        // explicit Resolve All proposal is the priority holder's replacement
+        // shortcut, so restore the saved preferences before asking every
+        // representative for the new proposal's consent.
+        Some(StackResolutionPolicy::RecheckNoMeaningfulPriorityAction) => {
+            take_and_restore_stack_resolution_session(state);
+        }
+        Some(StackResolutionPolicy::Committed) => {
+            return Err(EngineError::ActionNotAllowed(
+                "Resolve All cannot replace an active stack-resolution session".to_string(),
+            ));
+        }
+        None => {}
     }
     super::priority::pass_priority_legality(state, priority_player)?;
     let current_representative =

--- a/crates/engine/src/game/engine_auto_pass_decision_tests.rs
+++ b/crates/engine/src/game/engine_auto_pass_decision_tests.rs
@@ -2057,6 +2057,59 @@ fn verified_ai_pass_installs_rechecking_session_and_pauses_for_unverified_priori
 }
 
 #[test]
+fn resolve_all_supersedes_a_rechecking_ai_session_and_retains_auto_pass_baseline() {
+    let mut state = priority_state();
+    push_simple_stack_entry(&mut state, 30_109, PlayerId(1));
+    state.waiting_for = WaitingFor::Priority {
+        player: PlayerId(1),
+    };
+    state.priority_player = PlayerId(1);
+    state.auto_pass.insert(
+        PlayerId(0),
+        AutoPassMode::UntilTurnBoundary {
+            until: TurnBoundary::EndOfCurrentTurn,
+        },
+    );
+
+    let contract = AiDecisionContract::issue(&state, PlayerId(1));
+    apply_verified_ai_priority_pass(&mut state, PlayerId(1), &contract, GameAction::PassPriority)
+        .expect("the AI pass installs its provisional recheck session");
+    assert!(matches!(
+        state
+            .stack_resolution_session
+            .as_ref()
+            .map(|session| session.policy),
+        Some(StackResolutionPolicy::RecheckNoMeaningfulPriorityAction)
+    ));
+
+    let result = apply(
+        &mut state,
+        PlayerId(0),
+        GameAction::BeginResolveAll { max_resolutions: 0 },
+    )
+    .expect("the priority holder may replace an AI recheck with Resolve All");
+
+    assert!(matches!(
+        result.waiting_for,
+        WaitingFor::ResolveAllConsent {
+            representative: PlayerId(1),
+            ..
+        }
+    ));
+    assert!(state.stack_resolution_session.is_none());
+    assert!(matches!(
+        state
+            .resolve_all_consent_run
+            .as_ref()
+            .and_then(|run| run.auto_pass_baseline.as_ref())
+            .and_then(|baseline| baseline.get(&PlayerId(0))),
+        Some(AutoPassMode::UntilTurnBoundary {
+            until: TurnBoundary::EndOfCurrentTurn
+        })
+    ));
+}
+
+#[test]
 fn verified_ai_pass_cache_never_passes_an_unverified_representative() {
     let mut state = priority_state();
     push_simple_stack_entry(&mut state, 30_110, PlayerId(1));


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - “Resolve All” now correctly handles active automatic priority-check sessions.
  - Rechecking sessions can be replaced by “Resolve All” while preserving existing auto-pass preferences.
  - Committed sessions continue to be rejected as before.

- **Tests**
  - Added coverage verifying the updated “Resolve All” behavior and retained auto-pass settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->