### PR TITLE
fix(shell): remove orphaned artifact trust module

### DIFF
--- a/client/src-tauri/src/lib.rs
+++ b/client/src-tauri/src/lib.rs
@@ -1,8 +1,6 @@
 #[cfg(desktop)]
 use tauri::{Manager, WebviewWindowBuilder};
 
-#[cfg(desktop)]
-mod artifact_trust;
 mod audio_probe;
 mod host_platform;
 mod migration;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop application compatibility by removing an unnecessary desktop-only module declaration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->