### PR TITLE
fix: recover orphaned devour resolution state

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1413,16 +1413,21 @@ fn apply_action_boundary_core(
     // while the real state is repaired.
     effects::sweep_ownerless_post_replacement_strand(state);
     state.remove_empty_active_post_replacement_frame();
+    let recovered_devour_rest_boundary =
+        recover_orphaned_devour_completion_at_priority_boundary(state);
+    let recovered_stale_priority_pass =
+        recovered_devour_rest_boundary && matches!(action, GameAction::PassPriority);
     let boundary_snapshot = state.clone();
     let journal_start = state.resolved_rules_journal.entries().len();
     let is_actor_scoped_preference = action.is_actor_scoped_preference();
-    let suppress_auto_pass_once = matches!(
-        &action,
-        GameAction::RespondResolveAllConsent {
-            decision: ResolveAllConsentDecision::Decline,
-            ..
-        } | GameAction::RevokeResolveAllConsent { .. }
-    );
+    let suppress_auto_pass_once = recovered_stale_priority_pass
+        || matches!(
+            &action,
+            GameAction::RespondResolveAllConsent {
+                decision: ResolveAllConsentDecision::Decline,
+                ..
+            } | GameAction::RevokeResolveAllConsent { .. }
+        );
     interaction::ensure_interaction_authority(state);
     let previous_interaction_waiting = state.waiting_for.clone();
     let previous_interaction_slots = state.active_interaction_slots.clone();
@@ -1432,6 +1437,24 @@ fn apply_action_boundary_core(
         Some(semantic_owner)
     };
     let preserve_interaction = interaction::action_preserves_interaction(&action);
+    if recovered_stale_priority_pass {
+        return Ok(RawActionApplication {
+            result: ActionResult {
+                events: vec![],
+                waiting_for: state.waiting_for.clone(),
+                log_entries: vec![],
+            },
+            journal_start,
+            is_actor_scoped_preference,
+            suppress_auto_pass_once,
+            boundary_snapshot,
+            previous_interaction_waiting,
+            previous_interaction_slots,
+            submitted_interaction_owner,
+            preserve_interaction,
+            lifecycle,
+        });
+    }
     // Clear transient inter-effect state at the start of each player action.
     // last_effect_count is set by interactive handlers (e.g., DiscardChoice) and
     // consumed by sub_ability continuations via EventContextAmount fallback.
@@ -1507,6 +1530,45 @@ fn apply_action_boundary_core(
         preserve_interaction,
         lifecycle,
     })
+}
+
+/// CR 117.3b + CR 608.2c + CR 614.12a + CR 614.13a: A completed Devour entry
+/// cannot leave priority assigned to a later player while its spell carrier,
+/// empty replacement drain, and snapshot frame remain live. Recover the exact
+/// persisted rest shape before an old priority pass can advance the turn.
+///
+/// The recovery is intentionally narrower than ordinary continuation draining:
+/// it requires the captured two-frame shape (an empty `PostReplacement` parent
+/// and a Devour-only `ChangeZone` child), an active resolving carrier, and a
+/// live priority window. A prompt-bearing Devour entry or a pending multi-entry
+/// ChangeZone iteration therefore remains untouched.
+fn recover_orphaned_devour_completion_at_priority_boundary(state: &mut GameState) -> bool {
+    let is_orphaned_devour_completion = matches!(state.waiting_for, WaitingFor::Priority { .. })
+        && state.resolving_stack_entry.is_some()
+        && state.resolution_stack.len() == 2
+        && state.active_change_zone_frame().is_some_and(|frame| {
+            frame.pending.is_none() && frame.devour_eligible_snapshot.is_some()
+        })
+        && state
+            .active_post_replacement_drains()
+            .is_some_and(crate::types::game_state::PostReplacementDrainStack::is_empty);
+    if !is_orphaned_devour_completion {
+        return false;
+    }
+
+    let cleared = state.clear_completed_active_devour_snapshot();
+    debug_assert!(cleared, "the guarded Devour frame must be consumable");
+    state.remove_empty_active_post_replacement_frame();
+    settle_resolving_stack_entry_after_continuation_resume(state);
+    if state.resolving_stack_entry.is_some() {
+        return false;
+    }
+
+    priority::reset_priority(state);
+    state.waiting_for = WaitingFor::Priority {
+        player: state.active_player,
+    };
+    true
 }
 
 fn finish_action_boundary(

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -2756,6 +2756,10 @@ pub(crate) fn apply_pending_post_replacement_effect(
         // stack top, which is a wider set than "the frame this dispatch
         // addressed". Narrowing it would be a second, unrelated behavioural delta.
         state.remove_empty_active_post_replacement_frame();
+        // CR 614.12a + CR 614.13a: A Devour snapshot created by this completed
+        // entry can sit above this just-retired drain. It has no remaining
+        // iteration or prompt owner, so retire it before priority is restored.
+        state.clear_completed_active_devour_snapshot();
     }
     // NOTE: the inherited token-choice applied seed is intentionally NOT cleared
     // here. This drain runs for EVERY replacement continuation — including a

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -20238,6 +20238,23 @@ impl GameState {
         });
     }
 
+    /// CR 614.12a + CR 614.13a: A Devour-only ChangeZone frame owns the
+    /// pre-entry eligibility snapshot for exactly one completed entry event.
+    /// Once that event's replacement work has returned without parking an
+    /// iteration, retire the now-ownerless frame.
+    pub fn clear_completed_active_devour_snapshot(&mut self) -> bool {
+        if !self.active_change_zone_frame().is_some_and(|frame| {
+            frame.pending.is_none() && frame.devour_eligible_snapshot.is_some()
+        }) {
+            return false;
+        }
+
+        let _ = self
+            .take_active_change_zone_frame()
+            .expect("a completed Devour-only ChangeZone frame must be active");
+        true
+    }
+
     /// Parks a newly paused ChangeZone iteration. A Devour-only frame belongs
     /// to the same operation and is replaced; every other active frame remains
     /// the structural parent below this new child.
@@ -21298,13 +21315,7 @@ impl GameState {
             // child is retired, the snapshot is again the active owner and its
             // single-entry lifetime ends. A pending iteration keeps its snapshot
             // for the remaining co-arrivers.
-            if self.active_change_zone_frame().is_some_and(|frame| {
-                frame.pending.is_none() && frame.devour_eligible_snapshot.is_some()
-            }) {
-                let _ = self
-                    .take_active_change_zone_frame()
-                    .expect("a completed Devour-only ChangeZone frame must be active");
-            }
+            self.clear_completed_active_devour_snapshot();
         }
     }
 

--- a/crates/engine/tests/integration/devour_completion_rest_recovery.rs
+++ b/crates/engine/tests/integration/devour_completion_rest_recovery.rs
@@ -1,0 +1,74 @@
+//! Regression for the production capture `b152fcbf-0976-408a-a501-346237e1f8cb`:
+//! a Bloodspore Thrinax Devour entry completed with an empty post-replacement
+//! parent below its Devour-only ChangeZone snapshot. The stale resolution
+//! carrier then let a later priority pass enter `start_next_turn` and panic.
+
+use engine::game::engine::apply;
+use engine::types::actions::GameAction;
+use engine::types::format::FormatConfig;
+use engine::types::game_state::{
+    CastingVariant, GameState, PostReplacementDrainStack, StackEntry, StackEntryKind, WaitingFor,
+};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+const P2: PlayerId = PlayerId(2);
+const P3: PlayerId = PlayerId(3);
+
+/// CR 117.3b + CR 117.4 + CR 608.2c + CR 614.12a + CR 614.13a: an old pass
+/// submitted from the captured priority window repairs the completed Devour
+/// entry, grants priority to the active player, and does not advance the turn.
+#[test]
+fn captured_devour_rest_shape_recovers_before_a_stale_pass_can_start_the_next_turn() {
+    let mut state = GameState::new(FormatConfig::free_for_all(), 4, 0xB152_FCBF);
+    state.phase = Phase::Cleanup;
+    state.active_player = P3;
+    state.priority_player = P2;
+    state.waiting_for = WaitingFor::Priority { player: P2 };
+    state.priority_pass_count = 3;
+    state.priority_passes.extend([P0, P1, P3]);
+    state.resolving_stack_entry = Some(StackEntry {
+        id: ObjectId(347),
+        source_id: ObjectId(347),
+        controller: P3,
+        kind: StackEntryKind::Spell {
+            card_id: CardId(347),
+            ability: None,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 4,
+        },
+    });
+    state
+        .resolution_stack
+        .push_post_replacement(PostReplacementDrainStack::default());
+    state.push_devour_change_zone_snapshot([ObjectId(27), ObjectId(31)].into_iter().collect());
+
+    let result = apply(&mut state, P2, GameAction::PassPriority)
+        .expect("the stale captured pass repairs the ownerless rest state");
+
+    assert!(
+        state.resolution_stack.is_empty(),
+        "the empty replacement parent and its Devour-only snapshot must both retire"
+    );
+    assert!(
+        state.resolving_stack_entry.is_none(),
+        "the completed spell carrier must settle before another turn can begin"
+    );
+    assert_eq!(
+        state.phase,
+        Phase::Cleanup,
+        "the stale pass must not advance phase"
+    );
+    assert_eq!(state.priority_player, P3);
+    assert_eq!(
+        state.waiting_for,
+        WaitingFor::Priority { player: P3 },
+        "CR 117.3b grants the active player the recovered priority window"
+    );
+    assert!(state.priority_passes.is_empty());
+    assert_eq!(state.priority_pass_count, 0);
+    assert_eq!(result.waiting_for, state.waiting_for);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -195,6 +195,7 @@ mod destroy_redirect_to_battlefield_delivery_tail;
 mod deterministic_blocker_prompt_order;
 mod deterministic_game_state_serde;
 mod devour_co_entry_regression;
+mod devour_completion_rest_recovery;
 mod devour_intellect_treasure_rider;
 mod dig_impossible_keep_count;
 mod dig_rest_pile_stranding_on_etb_pause;


### PR DESCRIPTION
## Summary\n- retire completed Devour snapshot frames after direct post-replacement delivery\n- recover the captured stale priority/resolution state before it can start the next turn\n- cover the four-player stale-pass reproduction from game b152fcbf-0976-408a-a501-346237e1f8cb\n\n## Verification\n- cargo fmt --all --check\n- cargo test -p phase-engine --test integration devour_completion_rest_recovery\n- cargo clippy -p phase-engine --tests -- -D warnings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a rare issue where completed Devour actions could leave the game waiting on an outdated priority prompt.
  * The game now restores the correct active-player priority and cleans up stalled resolution states without advancing the phase.

* **Tests**
  * Added coverage for Devour completion recovery during Cleanup, including stale priority passes and multi-player game states.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->