### PR TITLE
Support resolution-time sacrifice payments

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -3626,14 +3626,14 @@ describe("P2P wire-protocol version gate", () => {
   // Both halves stamp LITERALS. A frame built from WIRE_PROTOCOL_VERSION
   // cannot tell a bumped client from an unbumped one, which is why every
   // other handshake fixture in the suite is useless as an instrument for a
-  // bump. Revert 35 → 34 and BOTH halves red: the v34 frame stops being
-  // refused, and the v35 frame stops being admitted. The admitting half is
-  // the reach-guard — without it "refuses v34" is also satisfied by a client
+  // bump. Revert 36 → 35 and BOTH halves red: the v35 frame stops being
+  // refused, and the v36 frame stops being admitted. The admitting half is
+  // the reach-guard — without it "refuses v35" is also satisfied by a client
   // that refuses everything.
-  it("refuses the previous wire protocol (v34) and admits its own (v35)", async () => {
+  it("refuses the previous wire protocol (v35) and admits its own (v36)", async () => {
     const refusing = makeGuest();
     await refusing.adapter.initialize();
-    await refusing.conn.simulateData(setupFrameAt(34));
+    await refusing.conn.simulateData(setupFrameAt(35));
 
     await expect(refusing.adapter.initializeGame()).rejects.toMatchObject({
       code: "P2P_REJECTED",
@@ -3645,7 +3645,7 @@ describe("P2P wire-protocol version gate", () => {
 
     const admitting = makeGuest();
     await admitting.adapter.initialize();
-    await admitting.conn.simulateData(setupFrameAt(35));
+    await admitting.conn.simulateData(setupFrameAt(36));
 
     await expect(admitting.adapter.initializeGame()).resolves.toBeDefined();
     expect(admitting.emitted).not.toHaveBeenCalledWith(

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -202,6 +202,8 @@ export class NativeEngineVersionMismatchError extends Error {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 47 — Resolution-time optional fixed sacrifice payments add a typed
+ *      replacement-resumable continuation to GameState.
  * 46 — QuantityRef.Aggregate and QuantityRef.TrackedSetAggregate were
  *      replaced in serialized GameState payloads by the canonical
  *      QuantityRef.PropertyAggregate tag with a validated source object. New
@@ -332,7 +334,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 46;
+export const PROTOCOL_VERSION = 47;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -36,8 +36,8 @@ const viewerInteractionWithProducedMana = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v35", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(35);
+  it("pins the P2P wire protocol to v36", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(36);
   });
 
   it("defaults shortcut actions for a legacy payload created before the additive field", () => {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -95,6 +95,8 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  * seat or adopts reconnect state.
  *
  * Bumps to date:
+ *  36 — Resolution-time optional fixed sacrifice payments add a typed
+ *       replacement-resumable continuation to GameState.
  *  35 — QuantityRef.Aggregate and QuantityRef.TrackedSetAggregate were
  *       replaced in GameState snapshots by the canonical
  *       QuantityRef.PropertyAggregate tag with a validated source object. New
@@ -203,7 +205,7 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  *       sub-phase on WaitingFor::MulliganDecision; the MulliganBottomCards
  *       variant was removed
  */
-export const WIRE_PROTOCOL_VERSION = 35 as const;
+export const WIRE_PROTOCOL_VERSION = 36 as const;
 
 export type P2PMessage = P2PAuthorityWire & (
   | {

--- a/crates/engine/src/ai_support/payment_continuation.rs
+++ b/crates/engine/src/ai_support/payment_continuation.rs
@@ -408,8 +408,11 @@ fn classify_parked_cost_move_root(state: &GameState) -> PaymentContinuationState
         // These are distinct cost/resolution continuations. They intentionally
         // retain their existing policies rather than being misidentified from a
         // coincidental PendingCast elsewhere in state.
+        PendingCostMoveResume::SacrificeForCost { pending: Some(pending), player, .. } => {
+            PaymentContinuationState::Affiliated(root_from_pending_cast(pending, *player))
+        }
         PendingCostMoveResume::Cast { .. }
-        | PendingCostMoveResume::SacrificeForCost { .. }
+        | PendingCostMoveResume::SacrificeForCost { pending: None, .. }
         | PendingCostMoveResume::WardSacrificePayment { .. }
         | PendingCostMoveResume::ReplacementMayCost { .. }
         | PendingCostMoveResume::Foretell { .. }
@@ -644,7 +647,7 @@ fn pending_cost_move_contains_root(
             pending: Some(pending),
             ..
         }) => pending_matches_root(pending, root),
-        Some(PendingCostMoveResume::SacrificeForCost { pending, .. }) => {
+        Some(PendingCostMoveResume::SacrificeForCost { pending: Some(pending), .. }) => {
             pending_matches_root(pending, root)
         }
         Some(PendingCostMoveResume::ManaAbilityPayment { pending, cursor }) => {
@@ -664,6 +667,7 @@ fn pending_cost_move_contains_root(
             CollectEvidenceResume::Effect { .. } => false,
         },
         Some(PendingCostMoveResume::Cast { pending: None, .. })
+        | Some(PendingCostMoveResume::SacrificeForCost { pending: None, .. })
         | Some(PendingCostMoveResume::WardSacrificePayment { .. })
         | Some(PendingCostMoveResume::ReplacementMayCost { .. })
         | Some(PendingCostMoveResume::Foretell { .. })
@@ -780,6 +784,9 @@ fn record_witness_attempts(_: usize) {}
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::types::ability::{Effect, ResolvedAbility};
+    use crate::types::game_state::PendingSacrificeCostCompletion;
+    use crate::types::resolution::OptionalEffectFrame;
 
     #[test]
     fn direct_mana_payment_without_a_live_root_fails_closed() {
@@ -809,6 +816,38 @@ mod tests {
         assert!(
             LAST_WITNESS_REDUCER_ATTEMPTS.load(std::sync::atomic::Ordering::Relaxed)
                 <= PAYMENT_CONTINUATION_MAX_REDUCER_ATTEMPTS
+        );
+    }
+
+    #[test]
+    fn resolution_optional_sacrifice_cursor_is_not_a_cast_root() {
+        let mut state = GameState::new_two_player(1);
+        state.pending_cost_move_resume = Some(PendingCostMoveResume::SacrificeForCost {
+            player: PlayerId(0),
+            pending: None,
+            chosen: Vec::new(),
+            paused_at_index: 0,
+            completion: PendingSacrificeCostCompletion::ResolutionOptionalPayment {
+                frame: Box::new(OptionalEffectFrame {
+                    ability: Box::new(ResolvedAbility::new(
+                        Effect::NoOp,
+                        vec![],
+                        ObjectId(7),
+                        PlayerId(0),
+                    )),
+                    trigger_event: None,
+                    trigger_events: Vec::new(),
+                    trigger_match_count: None,
+                }),
+                selected: Vec::new(),
+            },
+            deferred_cost_events: Vec::new(),
+            departure_record_indices: Vec::new(),
+        });
+
+        assert_eq!(
+            classify_payment_continuation(&state),
+            PaymentContinuationState::NotAffiliated
         );
     }
 }

--- a/crates/engine/src/game/casting_costs.rs
+++ b/crates/engine/src/game/casting_costs.rs
@@ -20,11 +20,12 @@ use crate::types::game_state::{
     PendingCostMoveResume, PendingDiscardForCostResume, PendingSacrificeCostCompletion,
     SpellCostSource, StackEntry, StackEntryKind, StackPaidSnapshot, WaitingFor,
 };
-use crate::types::identifiers::{CardId, ObjectId};
+use crate::types::identifiers::{CardId, ObjectId, ObjectIncarnationRef};
 use crate::types::keywords::{GiftKind, Keyword};
 use crate::types::mana::{ManaCost, ManaCostShard, ManaType, PaymentContext};
 use crate::types::player::PlayerId;
 use crate::types::replacements::ReplacementEvent;
+use crate::types::resolution::OptionalEffectFrame;
 use crate::types::resolved_commands::ResolvedStackEntryFinalizeCommand;
 use crate::types::statics::{CostModifyMode, StaticMode, StaticModeKind};
 use crate::types::zones::{ExileCostSourceZone, Zone};
@@ -2728,6 +2729,141 @@ fn record_sacrifice_cost_departure_records(
     }
 }
 
+fn sacrifice_selection_member_is_current(
+    state: &GameState,
+    completion: &PendingSacrificeCostCompletion,
+    index: usize,
+    object_id: ObjectId,
+) -> bool {
+    match completion {
+        PendingSacrificeCostCompletion::ResolutionOptionalPayment { selected, .. } => {
+            selected.get(index).is_some_and(|expected| {
+                expected.object_id == object_id
+                    && state.objects.get(&object_id).is_some_and(|object| {
+                        ObjectIncarnationRef::from_object(object) == *expected
+                    })
+            })
+        }
+        PendingSacrificeCostCompletion::SelectedNonSelf
+        | PendingSacrificeCostCompletion::SelfRef => true,
+    }
+}
+
+/// A serialized replacement prompt can outlive the selected permanent's zone
+/// incarnation. Fail closed before the replacement action can apply to a new
+/// object reusing the same ObjectId, and discard the optional payoff tail.
+pub(crate) fn abandon_stale_resolution_sacrifice_cursor(
+    state: &mut GameState,
+    events: &mut [GameEvent],
+) -> Option<WaitingFor> {
+    let stale = match state.pending_cost_move_resume.as_ref() {
+        Some(PendingCostMoveResume::SacrificeForCost {
+            pending: None,
+            chosen,
+            paused_at_index,
+            completion,
+            ..
+        }) if matches!(
+            completion,
+            PendingSacrificeCostCompletion::ResolutionOptionalPayment { .. }
+        ) =>
+        {
+            chosen
+                .iter()
+                .enumerate()
+                .skip(*paused_at_index)
+                .any(|(index, id)| {
+                    !sacrifice_selection_member_is_current(state, completion, index, *id)
+                })
+        }
+        _ => false,
+    };
+    if !stale {
+        return None;
+    }
+    let _ = take_and_settle_parked_resolution_optional_sacrifice(state, events)
+        .expect("stale resolution sacrifice cursor must own its optional frame");
+    stack::abandon_active_resolution_carrier(
+        state,
+        super::lifecycle::DelayedTerminalDisposition::Removed,
+    );
+    state.waiting_for = WaitingFor::Priority {
+        player: state.active_player,
+    };
+    Some(state.waiting_for.clone())
+}
+
+#[allow(clippy::too_many_arguments)]
+fn settle_abandoned_resolution_sacrifice_prefix(
+    state: &mut GameState,
+    chosen: &[ObjectId],
+    completed_prefix_end: usize,
+    mut deferred_cost_events: Vec<GameEvent>,
+    mut departure_record_indices: Vec<usize>,
+    events: &mut [GameEvent],
+    current_start: usize,
+) {
+    record_sacrifice_cost_departure_records(
+        &mut departure_record_indices,
+        &events[current_start..],
+        chosen,
+    );
+    let departed = crate::game::zones::departed_subset(state, &chosen[..completed_prefix_end]);
+    crate::game::zones::mark_simultaneous_departures(&mut deferred_cost_events, &departed);
+    crate::game::zones::mark_simultaneous_departures(&mut events[current_start..], &departed);
+    crate::game::zones::mark_simultaneous_departure_records(
+        state,
+        &departure_record_indices,
+        &departed,
+    );
+    settle_sacrifice_for_cost_events(
+        state,
+        None,
+        deferred_cost_events,
+        events,
+        current_start,
+        events.len(),
+    );
+}
+
+/// Consume a replacement-paused resolution sacrifice while preserving the
+/// fully completed prefix's trigger ledger. The paused object and later suffix
+/// remain unresolved and are deliberately excluded.
+pub(crate) fn take_and_settle_parked_resolution_optional_sacrifice(
+    state: &mut GameState,
+    events: &mut [GameEvent],
+) -> Option<OptionalEffectFrame> {
+    let resume = state.pending_cost_move_resume.take()?;
+    let PendingCostMoveResume::SacrificeForCost {
+        pending: None,
+        chosen,
+        paused_at_index,
+        completion: PendingSacrificeCostCompletion::ResolutionOptionalPayment { frame, .. },
+        deferred_cost_events,
+        departure_record_indices,
+        ..
+    } = resume
+    else {
+        state.pending_cost_move_resume = Some(resume);
+        return None;
+    };
+
+    let current = events.len();
+    settle_abandoned_resolution_sacrifice_prefix(
+        state,
+        &chosen,
+        paused_at_index,
+        deferred_cost_events,
+        departure_record_indices,
+        events,
+        current,
+    );
+    state.pending_replacement = None;
+    state.replacement_may_cost_paused = false;
+    super::replacement::abandon_post_replacement_continuation(state);
+    Some(*frame)
+}
+
 /// CR 601.2h + CR 602.2b + CR 616.1: Park one selected sacrifice component
 /// without exposing a partial event group to trigger collection. The currently
 /// paused object is delivered or prevented by the replacement action; the
@@ -2736,7 +2872,7 @@ fn record_sacrifice_cost_departure_records(
 fn pause_sacrifice_for_cost(
     state: &mut GameState,
     player: PlayerId,
-    pending: PendingCast,
+    pending: Option<PendingCast>,
     chosen: Vec<ObjectId>,
     paused_at_index: usize,
     completion: PendingSacrificeCostCompletion,
@@ -2754,7 +2890,7 @@ fn pause_sacrifice_for_cost(
     deferred_cost_events.extend_from_slice(&events[cost_event_start..]);
     state.pending_cost_move_resume = Some(PendingCostMoveResume::SacrificeForCost {
         player,
-        pending: Box::new(pending),
+        pending: pending.map(Box::new),
         chosen,
         paused_at_index,
         completion,
@@ -2774,15 +2910,17 @@ fn pause_sacrifice_for_cost(
 /// crossed a replacement-choice action boundary. Collect the full stamped set
 /// once, and claim the current action occurrences so its normal Priority
 /// pipeline cannot collect the same events again.
-fn settle_sacrifice_for_cost_events(
+pub(crate) fn settle_sacrifice_for_cost_events(
     state: &mut GameState,
-    pending: &mut PendingCast,
+    pending: Option<&mut PendingCast>,
     deferred_cost_events: Vec<GameEvent>,
     events: &[GameEvent],
     current_start: usize,
     current_end: usize,
 ) {
-    if let Some(collection) = pending.activation_trigger_collection.as_mut() {
+    if let Some(collection) =
+        pending.and_then(|pending| pending.activation_trigger_collection.as_mut())
+    {
         // Earlier action fragments carry no ordinal in THIS buffer, so the
         // consumed journal — whose ordinals are absolute within the current
         // action — must not be applied to them. The queued-context witness is
@@ -2866,7 +3004,7 @@ fn settle_sacrifice_for_cost_events(
 fn finish_sacrifice_for_cost(
     state: &mut GameState,
     player: PlayerId,
-    mut pending: PendingCast,
+    mut pending: Option<PendingCast>,
     chosen: &[ObjectId],
     completion: PendingSacrificeCostCompletion,
     mut deferred_cost_events: Vec<GameEvent>,
@@ -2893,24 +3031,54 @@ fn finish_sacrifice_for_cost(
     // before a later cast/activation prompt can hide this action's event span.
     settle_sacrifice_for_cost_events(
         state,
-        &mut pending,
+        pending.as_mut(),
         deferred_cost_events,
         events,
         current_start,
         current_end,
     );
 
-    if pending.activation_ability_index.is_some() {
-        pending.mark_activation_cost_committed();
-        if matches!(completion, PendingSacrificeCostCompletion::SelectedNonSelf) {
-            pending.activation_cost = pending
-                .activation_cost
-                .take()
-                .and_then(super::casting::remove_selected_non_self_sacrifice_cost);
+    if let Some(pending) = pending.as_mut() {
+        if pending.activation_ability_index.is_some() {
+            pending.mark_activation_cost_committed();
+            if matches!(completion, PendingSacrificeCostCompletion::SelectedNonSelf) {
+                pending.activation_cost = pending
+                    .activation_cost
+                    .take()
+                    .and_then(super::casting::remove_selected_non_self_sacrifice_cost);
+            }
         }
     }
 
-    let waiting_for = finish_pending_cost_or_cast(state, player, pending, events)?;
+    let waiting_for = match (pending, completion) {
+        (
+            Some(pending),
+            PendingSacrificeCostCompletion::SelectedNonSelf
+            | PendingSacrificeCostCompletion::SelfRef,
+        ) => finish_pending_cost_or_cast(state, player, pending, events)?,
+        (None, PendingSacrificeCostCompletion::ResolutionOptionalPayment { frame, .. }) => {
+            let mut frame = *frame;
+            let Effect::PayCost { cost, .. } = &mut frame.ability.effect else {
+                return Err(EngineError::InvalidAction(
+                    "resolution sacrifice completion lost its PayCost root".into(),
+                ));
+            };
+            // The selected sacrifice has already been fully committed through
+            // this cursor. Resume the optional resolver with an explicit prepaid
+            // no-op, never by globally teaching the direct executor to accept a
+            // non-self sacrifice that it does not itself perform.
+            *cost = AbilityCost::Composite { costs: Vec::new() };
+            state.push_optional_effect_frame(frame);
+            super::engine_payment_choices::handle_optional_effect_choice(state, true, events)?
+        }
+        (Some(_), PendingSacrificeCostCompletion::ResolutionOptionalPayment { .. })
+        | (None, PendingSacrificeCostCompletion::SelectedNonSelf)
+        | (None, PendingSacrificeCostCompletion::SelfRef) => {
+            return Err(EngineError::InvalidAction(
+                "sacrifice payment completion does not match its root".into(),
+            ));
+        }
+    };
     // CR 602.2b + CR 603.3b: The replacement-resumed sacrifice can itself
     // reach a later payment prompt. Park this action's final event fragment in
     // the same activation-local transaction as the earlier fragments.
@@ -2940,6 +3108,28 @@ pub(crate) fn resume_sacrifice_for_cost(
     };
 
     for index in paused_at_index + 1..chosen.len() {
+        if !sacrifice_selection_member_is_current(state, &completion, index, chosen[index]) {
+            settle_abandoned_resolution_sacrifice_prefix(
+                state,
+                &chosen,
+                index,
+                deferred_cost_events,
+                departure_record_indices,
+                events,
+                replacement_action_cost_event_start,
+            );
+            state.pending_replacement = None;
+            state.replacement_may_cost_paused = false;
+            super::replacement::abandon_post_replacement_continuation(state);
+            stack::abandon_active_resolution_carrier(
+                state,
+                super::lifecycle::DelayedTerminalDisposition::Removed,
+            );
+            state.waiting_for = WaitingFor::Priority {
+                player: state.active_player,
+            };
+            return Ok(state.waiting_for.clone());
+        }
         match super::sacrifice::sacrifice_permanent(state, chosen[index], player, events)
             .map_err(|error| EngineError::InvalidAction(error.to_string()))?
         {
@@ -2948,7 +3138,7 @@ pub(crate) fn resume_sacrifice_for_cost(
                 return Ok(pause_sacrifice_for_cost(
                     state,
                     player,
-                    *pending,
+                    pending.map(|pending| *pending),
                     chosen,
                     index,
                     completion,
@@ -2965,7 +3155,7 @@ pub(crate) fn resume_sacrifice_for_cost(
     finish_sacrifice_for_cost(
         state,
         player,
-        *pending,
+        pending.map(|pending| *pending),
         &chosen,
         completion,
         deferred_cost_events,
@@ -3152,7 +3342,7 @@ pub(crate) fn handle_sacrifice_for_cost(
                 return Ok(pause_sacrifice_for_cost(
                     state,
                     player,
-                    pending,
+                    Some(pending),
                     chosen.to_vec(),
                     index,
                     PendingSacrificeCostCompletion::SelectedNonSelf,
@@ -3190,6 +3380,118 @@ pub(crate) fn handle_sacrifice_for_cost(
         &waiting_for,
     );
     Ok(waiting_for)
+}
+
+/// CR 118.3 + CR 118.11-12: commit a fixed, non-self sacrifice selected while
+/// a root optional PayCost ability is resolving. The live controlled set is
+/// recomputed before the optional frame is consumed, so a stale prompt cannot
+/// latch the "if you do" branch. Once committed, the ordinary sacrifice-cost
+/// cursor owns replacement pauses, simultaneous stamping, and trigger settling.
+pub(crate) fn handle_resolution_optional_sacrifice_for_cost(
+    state: &mut GameState,
+    player: PlayerId,
+    advertised_choices: &[ObjectId],
+    chosen: &[ObjectId],
+    events: &mut Vec<GameEvent>,
+) -> Result<WaitingFor, EngineError> {
+    let frame = state
+        .active_optional_effect_frame()
+        .ok_or_else(|| EngineError::InvalidAction("optional payment frame is missing".into()))?;
+    let Effect::PayCost {
+        cost: AbilityCost::Sacrifice(cost),
+        ..
+    } = &frame.ability.effect
+    else {
+        return Err(EngineError::InvalidAction(
+            "optional payment root is not a sacrifice cost".into(),
+        ));
+    };
+    let count = cost.requirement.fixed_count().ok_or_else(|| {
+        EngineError::InvalidAction("resolution sacrifice cost is not fixed".into())
+    })? as usize;
+    if matches!(cost.target, TargetFilter::SelfRef) {
+        return Err(EngineError::InvalidAction(
+            "self sacrifice is not a selectable resolution cost".into(),
+        ));
+    }
+    let live = super::casting::find_eligible_sacrifice_targets(
+        state,
+        player,
+        frame.ability.source_id,
+        &cost.target,
+    );
+    if live.len() != advertised_choices.len()
+        || live.iter().any(|id| !advertised_choices.contains(id))
+    {
+        return Err(EngineError::InvalidAction(
+            "sacrifice payment choices are stale".into(),
+        ));
+    }
+    if chosen.len() != count
+        || chosen
+            .iter()
+            .enumerate()
+            .any(|(index, id)| chosen[index + 1..].contains(id) || !live.contains(id))
+    {
+        return Err(EngineError::InvalidAction(
+            "selected permanents do not fully pay the sacrifice cost".into(),
+        ));
+    }
+    let selected = chosen
+        .iter()
+        .map(|id| {
+            state
+                .objects
+                .get(id)
+                .map(ObjectIncarnationRef::from_object)
+                .ok_or_else(|| EngineError::InvalidAction("selected permanent is stale".into()))
+        })
+        .collect::<Result<Vec<_>, _>>()?;
+
+    // This is the performed-latch boundary: every authority check above has
+    // succeeded, and only now may the optional root leave the resolution stack.
+    let frame = state
+        .take_active_optional_effect_frame()
+        .map_err(|error| EngineError::InvalidAction(error.to_string()))?
+        .ok_or_else(|| EngineError::InvalidAction("optional payment frame is missing".into()))?;
+    let completion = PendingSacrificeCostCompletion::ResolutionOptionalPayment {
+        frame: Box::new(frame),
+        selected,
+    };
+    let cost_event_start = events.len();
+    for (index, &id) in chosen.iter().enumerate() {
+        match super::sacrifice::sacrifice_permanent(state, id, player, events)
+            .map_err(|error| EngineError::InvalidAction(error.to_string()))?
+        {
+            super::sacrifice::SacrificeOutcome::Complete => {}
+            super::sacrifice::SacrificeOutcome::NeedsReplacementChoice(choice_player) => {
+                return Ok(pause_sacrifice_for_cost(
+                    state,
+                    player,
+                    None,
+                    chosen.to_vec(),
+                    index,
+                    completion,
+                    Vec::new(),
+                    Vec::new(),
+                    events,
+                    cost_event_start,
+                    choice_player,
+                ));
+            }
+        }
+    }
+    finish_sacrifice_for_cost(
+        state,
+        player,
+        None,
+        chosen,
+        completion,
+        Vec::new(),
+        Vec::new(),
+        events,
+        cost_event_start,
+    )
 }
 
 /// CR 701.3d + CR 608.2k + CR 601.2d: Complete a non-self `UnattachFrom` cost
@@ -7436,7 +7738,7 @@ fn pay_additional_cost_with_source(
                         return Ok(pause_sacrifice_for_cost(
                             state,
                             player,
-                            pending,
+                            Some(pending),
                             vec![object_id],
                             0,
                             PendingSacrificeCostCompletion::SelfRef,
@@ -13819,11 +14121,178 @@ mod tests {
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
     use crate::types::counter::{CounterMatch, CounterType};
-    use crate::types::identifiers::CardId;
+    use crate::types::game_state::PendingContinuation;
+    use crate::types::identifiers::{
+        CardId, DelayedTriggerInstanceId, DelayedTriggerOrigin, DelayedTriggerToken, TriggerFiring,
+    };
     use crate::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
     use crate::types::replacements::ReplacementEvent;
     use crate::types::statics::StaticMode;
     use crate::types::triggers::TriggerMode;
+
+    fn install_receipt_eligible_sacrifice_cursor(
+        state: &mut GameState,
+        source_id: ObjectId,
+        chosen: Vec<ObjectId>,
+        paused_at_index: usize,
+        origin: DelayedTriggerOrigin,
+    ) {
+        let selected = chosen
+            .iter()
+            .map(|id| ObjectIncarnationRef::from_object(&state.objects[id]))
+            .collect();
+        let ability = ResolvedAbility::new(
+            Effect::PayCost {
+                cost: AbilityCost::Sacrifice(SacrificeCost::count(TargetFilter::Any, 1)),
+                scale: None,
+                payer: TargetFilter::Controller,
+            },
+            Vec::new(),
+            source_id,
+            PlayerId(0),
+        );
+        stack::begin_resolving_stack_entry(
+            state,
+            StackEntry {
+                id: ObjectId(99_000),
+                source_id,
+                controller: PlayerId(0),
+                kind: StackEntryKind::TriggeredAbility {
+                    source_id,
+                    ability: Box::new(ability.clone()),
+                    condition: None,
+                    trigger_event: None,
+                    description: Some("receipt stale sacrifice".to_string()),
+                    source_name: "Receipt source".to_string(),
+                    subject_match_count: None,
+                    die_result: None,
+                    provenance: None,
+                },
+            },
+            Some(TriggerFiring::ReceiptEligible(origin)),
+        );
+        state.park_ability_continuation(PendingContinuation::new(
+            Box::new(ResolvedAbility::new(
+                Effect::NoOp,
+                Vec::new(),
+                source_id,
+                PlayerId(0),
+            )),
+            state,
+        ));
+        state.pending_cost_move_resume = Some(PendingCostMoveResume::SacrificeForCost {
+            player: PlayerId(0),
+            pending: None,
+            chosen,
+            paused_at_index,
+            completion: PendingSacrificeCostCompletion::ResolutionOptionalPayment {
+                frame: Box::new(OptionalEffectFrame {
+                    ability: Box::new(ability),
+                    trigger_event: None,
+                    trigger_events: Vec::new(),
+                    trigger_match_count: None,
+                }),
+                selected,
+            },
+            deferred_cost_events: Vec::new(),
+            departure_record_indices: Vec::new(),
+        });
+    }
+
+    fn receipt_origin(source_id: ObjectId, token: u64) -> DelayedTriggerOrigin {
+        DelayedTriggerOrigin {
+            token: DelayedTriggerToken(token),
+            instance: DelayedTriggerInstanceId(token),
+            source_id,
+        }
+    }
+
+    #[test]
+    fn stale_resolution_sacrifice_selection_terminalizes_receipt_as_removed() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(70_001),
+            PlayerId(0),
+            "Receipt source".to_string(),
+            Zone::Battlefield,
+        );
+        let stale = create_object(
+            &mut state,
+            CardId(70_002),
+            PlayerId(0),
+            "Stale fodder".to_string(),
+            Zone::Battlefield,
+        );
+        let origin = receipt_origin(source, 70_001);
+        install_receipt_eligible_sacrifice_cursor(&mut state, source, vec![stale], 0, origin);
+        state.objects.get_mut(&stale).unwrap().incarnation += 1;
+
+        let lifecycle = crate::game::lifecycle::enter_action_frame();
+        let mut events = Vec::new();
+        assert!(abandon_stale_resolution_sacrifice_cursor(&mut state, &mut events).is_some());
+        let facts = lifecycle
+            .take_outer_facts()
+            .expect("outer stale-selection action owns lifecycle facts");
+
+        assert_eq!(
+            facts.receipt_terminal_disposition(origin),
+            Some(crate::game::lifecycle::DelayedTerminalDisposition::Removed)
+        );
+        assert!(state.active_ability_continuation().is_none());
+        assert!(state.resolving_stack_entry.is_none());
+        assert!(state.resolving_trigger_firing.is_none());
+    }
+
+    #[test]
+    fn stale_resolution_sacrifice_resume_terminalizes_receipt_as_removed() {
+        let mut state = GameState::new_two_player(42);
+        let source = create_object(
+            &mut state,
+            CardId(70_003),
+            PlayerId(0),
+            "Receipt source".to_string(),
+            Zone::Battlefield,
+        );
+        let completed = create_object(
+            &mut state,
+            CardId(70_004),
+            PlayerId(0),
+            "Completed fodder".to_string(),
+            Zone::Graveyard,
+        );
+        let stale = create_object(
+            &mut state,
+            CardId(70_005),
+            PlayerId(0),
+            "Stale suffix".to_string(),
+            Zone::Battlefield,
+        );
+        let origin = receipt_origin(source, 70_003);
+        install_receipt_eligible_sacrifice_cursor(
+            &mut state,
+            source,
+            vec![completed, stale],
+            0,
+            origin,
+        );
+        state.objects.get_mut(&stale).unwrap().incarnation += 1;
+
+        let lifecycle = crate::game::lifecycle::enter_action_frame();
+        let mut events = Vec::new();
+        resume_sacrifice_for_cost(&mut state, &mut events, 0).unwrap();
+        let facts = lifecycle
+            .take_outer_facts()
+            .expect("outer stale-resume action owns lifecycle facts");
+
+        assert_eq!(
+            facts.receipt_terminal_disposition(origin),
+            Some(crate::game::lifecycle::DelayedTerminalDisposition::Removed)
+        );
+        assert!(state.active_ability_continuation().is_none());
+        assert!(state.resolving_stack_entry.is_none());
+        assert!(state.resolving_trigger_firing.is_none());
+    }
 
     fn choice_bearing_offer_test_mana_ability() -> AbilityDefinition {
         AbilityDefinition::new(

--- a/crates/engine/src/game/costs.rs
+++ b/crates/engine/src/game/costs.rs
@@ -1979,6 +1979,23 @@ pub(crate) fn is_direct_resolution_optional_payment_branch(cost: &AbilityCost) -
     }
 }
 
+/// Runtime branch family for the resolution optional-payment prompt.
+///
+/// Fixed non-self sacrifice is added here before parser admission because its
+/// payment is intercepted by the replacement-safe sacrifice continuation
+/// rather than executed by [`pay_ability_cost_inner`]. The parser keeps using
+/// [`is_direct_resolution_optional_payment_branch`] until the card-facing
+/// grammar is enabled in the following change.
+pub(crate) fn is_resolution_optional_payment_prompt_branch(cost: &AbilityCost) -> bool {
+    is_direct_resolution_optional_payment_branch(cost)
+        || matches!(
+            cost,
+            AbilityCost::Sacrifice(sacrifice)
+                if !matches!(sacrifice.target, TargetFilter::SelfRef)
+                    && sacrifice.requirement.fixed_count().is_some_and(|count| count > 0)
+        )
+}
+
 /// CR 118.12: The single source of truth for which `AbilityCost` shapes
 /// `pay_ability_cost_inner` can actually pay at `PaymentScope::Resolution`. Both
 /// the resolution affordability oracle (`can_pay_resolution`) and the
@@ -1989,12 +2006,14 @@ pub(crate) fn is_direct_resolution_optional_payment_branch(cost: &AbilityCost) -
 /// A shape outside this set has no resolution-time payment arm: at resolution
 /// there is no interactive `WaitingFor` interceptor and no activation-window
 /// mana detour, so executing such an arm would either silently report a no-op
-/// cost as `Paid` (`Waterbend`, `ExileMaterials`, non-self `Sacrifice`, targeted
-/// `RemoveCounter`) or perform an effect that was never meant to fire at
+/// cost as `Paid` (`Waterbend`, `ExileMaterials`, targeted `RemoveCounter`) or
+/// perform an effect that was never meant to fire at
 /// resolution (singleton `Tap`, self-ref `Sacrifice`/`Exile`, `Loyalty`,
 /// `RemoveCounter { target: None }`, `Exert`, `Unattach`, arbitrary `EffectCost`,
 /// source-card `Discard`). Both outcomes violate CR 118.3 / CR 601.2h, so the
-/// guard refuses them with `Failed`.
+/// guard refuses them with `Failed`. Fixed non-self sacrifice is deliberately
+/// absent: the optional-branch selector intercepts it before this executor and
+/// rewrites the completed frame to an empty prepaid composite.
 pub(crate) fn supported_at_resolution(cost: &AbilityCost) -> bool {
     use crate::types::ability::{CardSelectionMode, DiscardSelfScope};
     match cost {
@@ -2025,10 +2044,10 @@ pub(crate) fn supported_at_resolution(cost: &AbilityCost) -> bool {
         // payment effects that the authority resolves directly.
         AbilityCost::EffectCost { .. } if cost.supports_effect_cost_payment() => true,
         AbilityCost::Discard { .. }
+        | AbilityCost::Sacrifice(_)
         | AbilityCost::Tap
         | AbilityCost::Untap
         | AbilityCost::Loyalty { .. }
-        | AbilityCost::Sacrifice(_)
         | AbilityCost::Exile { .. }
         | AbilityCost::ExileMaterials { .. }
         | AbilityCost::CollectEvidence { .. }
@@ -2362,6 +2381,22 @@ fn can_pay_resolution(
                 }
             }
         }
+        // CR 118.3: fixed non-self sacrifice is payable only when the complete
+        // controlled matching set can be selected at resolution.
+        AbilityCost::Sacrifice(cost)
+            if !matches!(cost.target, TargetFilter::SelfRef)
+                && cost.requirement.fixed_count().is_some() =>
+        {
+            let eligible = super::casting::find_eligible_sacrifice_targets(
+                state,
+                payer,
+                ability.source_id,
+                &cost.target,
+            );
+            cost.requirement
+                .fixed_count()
+                .is_some_and(|count| eligible.len() >= count as usize)
+        }
         // CR 117 + CR 118.3: Composite is payable iff every sub-cost is payable.
         AbilityCost::Composite { costs } => costs
             .iter()
@@ -2450,6 +2485,12 @@ mod tests {
     use crate::types::mana::{ManaCost, ManaCostShard};
 
     const P0: PlayerId = PlayerId(0);
+
+    #[test]
+    fn direct_resolution_executor_does_not_support_non_self_sacrifice() {
+        let cost = AbilityCost::Sacrifice(SacrificeCost::count(TargetFilter::Any, 1));
+        assert!(!supported_at_resolution(&cost));
+    }
 
     /// Build one representative value for EVERY `AbilityCost` variant via an
     /// exhaustive `match` over a tag enum. The `match` has no wildcard, so a new

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -7270,8 +7270,10 @@ pub(crate) fn resolution_optional_payment_options(
         .iter()
         .enumerate()
         .filter(|(_, cost)| {
-            crate::game::costs::is_direct_resolution_optional_payment_branch(cost)
-                && crate::game::costs::supported_at_resolution(cost)
+            let intercepted_sacrifice = matches!(cost, AbilityCost::Sacrifice(_));
+            crate::game::costs::is_resolution_optional_payment_prompt_branch(cost)
+                && ((!intercepted_sacrifice || ability.repeat_for.is_none())
+                    && (intercepted_sacrifice || crate::game::costs::supported_at_resolution(cost)))
                 && crate::game::costs::can_pay(state, payer, ability.source_id, cost, &scope)
         })
         .map(|(index, cost)| ResolutionOptionalPaymentOption {

--- a/crates/engine/src/game/elimination.rs
+++ b/crates/engine/src/game/elimination.rs
@@ -2,12 +2,14 @@ use std::collections::HashSet;
 
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    ActiveSearchDecisionAuthority, CollectEvidenceResume, DeferredLifeCostResume, GameState,
-    PendingCast, PendingCostMoveResume, WaitingFor,
+    ActiveSearchDecisionAuthority, CollectEvidenceResume, CostResume, DeferredLifeCostResume,
+    GameState, PayCostKind, PendingCast, PendingCostMoveResume, PendingSacrificeCostCompletion,
+    WaitingFor,
 };
 use crate::types::identifiers::ObjectIncarnationRef;
 use crate::types::match_config::MatchPhase;
 use crate::types::player::PlayerId;
+use crate::types::resolution::OptionalEffectFrame;
 use crate::types::resolved_commands::{
     ResolvedPlayerLeaveCommand, ResolvedPlayerLeaveReplayInvariantError,
 };
@@ -71,10 +73,11 @@ fn abandon_pending_spell_casts(
             PendingCostMoveResume::Cast {
                 pending: Some(pending),
                 ..
-            }
-            | PendingCostMoveResume::SacrificeForCost { pending, .. } => {
-                is_abandoned_spell(state, departing_player, spell_ids, pending)
-            }
+            } => is_abandoned_spell(state, departing_player, spell_ids, pending),
+            PendingCostMoveResume::SacrificeForCost {
+                pending: Some(pending),
+                ..
+            } => is_abandoned_spell(state, departing_player, spell_ids, pending),
             PendingCostMoveResume::CollectEvidencePayment { resume, .. } => matches!(
                 resume.as_ref(),
                 CollectEvidenceResume::Casting { pending_cast, .. }
@@ -84,6 +87,7 @@ fn abandon_pending_spell_casts(
                 is_abandoned_spell(state, departing_player, spell_ids, pending)
             }
             PendingCostMoveResume::Cast { pending: None, .. }
+            | PendingCostMoveResume::SacrificeForCost { pending: None, .. }
             | PendingCostMoveResume::WardSacrificePayment { .. }
             | PendingCostMoveResume::ReplacementMayCost { .. }
             | PendingCostMoveResume::Foretell { .. }
@@ -108,6 +112,66 @@ fn abandon_pending_spell_casts(
     {
         state.pending_discard_for_cost = None;
     }
+}
+
+/// Preserve the completed prefix of a replacement-paused resolution sacrifice
+/// before abandoning its unresolved current move. The deferred event ledger and
+/// departure records are settled exactly once; the returned frame still owns
+/// the optional branch's resolution context.
+/// CR 800.4f + CR 118.3: a departed payer cannot finish a resolving optional
+/// sacrifice payment. Park the canonical decline until after CR 800.4a has
+/// removed every leaving player and reverted their control effects, so the
+/// living controller's remaining instructions observe the final topology.
+/// Controller departure is instead owned by
+/// `abandon_source_bound_resolution_prompt` below.
+fn stage_resolution_optional_sacrifice_decline_for_departing_payer(
+    state: &mut GameState,
+    leaving_set: &HashSet<PlayerId>,
+    events: &mut [GameEvent],
+) -> Option<OptionalEffectFrame> {
+    let selecting_payer = match &state.waiting_for {
+        WaitingFor::PayCost {
+            player,
+            kind: PayCostKind::Sacrifice,
+            resume: CostResume::Resolution,
+            ..
+        } => Some(*player),
+        _ => None,
+    };
+    let selecting_controller = selecting_payer
+        .and_then(|_| state.active_optional_effect_frame())
+        .map(|frame| frame.ability.controller);
+    let parked = match state.pending_cost_move_resume.as_ref() {
+        Some(PendingCostMoveResume::SacrificeForCost {
+            player,
+            pending: None,
+            completion: PendingSacrificeCostCompletion::ResolutionOptionalPayment { frame, .. },
+            ..
+        }) => Some((*player, frame.ability.controller)),
+        _ => None,
+    };
+    let payer = selecting_payer.or_else(|| parked.map(|(payer, _)| payer));
+    let controller = selecting_controller.or_else(|| parked.map(|(_, controller)| controller));
+    let payer = payer?;
+    if !leaving_set.contains(&payer)
+        || controller.is_some_and(|controller| leaving_set.contains(&controller))
+    {
+        return None;
+    }
+
+    let frame = if selecting_payer.is_some() {
+        state
+            .take_active_optional_effect_frame()
+            .expect("elimination cannot stage a buried optional payment frame")
+            .expect("elimination cannot stage a missing optional payment frame")
+    } else {
+        super::casting_costs::take_and_settle_parked_resolution_optional_sacrifice(state, events)
+            .expect("parked optional sacrifice payment must own its resume cursor")
+    };
+    state.waiting_for = WaitingFor::Priority {
+        player: players::next_player(state, payer),
+    };
+    Some(frame)
 }
 
 /// Eliminate a player from the game per CR 800.4.
@@ -165,6 +229,12 @@ pub fn eliminate_players_simultaneously(
         super::turn_control::invalidate_resolve_all_consent_for_topology_change(state);
         super::engine::take_and_restore_stack_resolution_session(state);
     }
+    let staged_optional_sacrifice_decline =
+        stage_resolution_optional_sacrifice_decline_for_departing_payer(
+            state,
+            &leaving_set,
+            events,
+        );
 
     let interrupted_ordinary_search = state
         .pending_scoped_library_search
@@ -319,6 +389,9 @@ pub fn eliminate_players_simultaneously(
     prune_deferred_triggers_for_eliminated_players(state);
 
     if let Some(winner) = game_over_winner {
+        if staged_optional_sacrifice_decline.is_some() {
+            finish_abandoned_source_bound_resolution_carrier(state);
+        }
         // Terminal: drop trigger scaffolding the client would otherwise show as
         // a stuck stack / ordering prompt.
         let mut terminal_firings = state
@@ -353,6 +426,12 @@ pub fn eliminate_players_simultaneously(
         }
         state.waiting_for = WaitingFor::GameOver { winner };
     } else {
+        if let Some(frame) = staged_optional_sacrifice_decline {
+            state.push_optional_effect_frame(frame);
+            super::engine_payment_choices::handle_optional_effect_choice(state, false, events)
+                .expect("departed optional sacrifice payer must follow the canonical decline path");
+        }
+
         // CR 603.3b: If prune collapsed an ordering pass into
         // `deferred_triggers` while `waiting_for` is Priority, dispatch now so
         // combat auto-advance does not skip them (issue #1350).
@@ -852,7 +931,7 @@ fn do_eliminate(
     // cast-abandonment teardown can replace its prompt with priority.
     let leaving_is_latched_chooser = state.waiting_for.acting_player() == Some(player);
 
-    abandon_source_bound_resolution_prompt(state, player);
+    abandon_source_bound_resolution_prompt(state, player, events);
     retire_pending_zone_change_contexts_owned_by(state, player);
     abandon_change_zone_family_for_controller(state, player);
 
@@ -1350,59 +1429,86 @@ fn retire_pending_zone_change_contexts_owned_by(state: &mut GameState, player: P
 /// CR 800.4a: A response prompt owned by a player who left cannot retain a
 /// resolution context for a later same-ID object. The prompt, its deferred
 /// continuation, and the resolution-scoped re-latch form one atomic family.
-fn abandon_source_bound_resolution_prompt(state: &mut GameState, player: PlayerId) {
-    let abandon = match &state.waiting_for {
-        WaitingFor::NamedChoice {
-            free_entry: None,
-            player: chooser,
-            source,
-            persist_player,
+fn abandon_source_bound_resolution_prompt(
+    state: &mut GameState,
+    player: PlayerId,
+    events: &mut [GameEvent],
+) {
+    let selecting_resolution_sacrifice = matches!(
+        &state.waiting_for,
+        WaitingFor::PayCost {
+            kind: PayCostKind::Sacrifice,
+            resume: CostResume::Resolution,
             ..
-        } => {
-            *chooser == player
-                || *persist_player == Some(player)
-                || source
-                    .as_ref()
-                    .is_some_and(|source| source.prompt.controller == player)
         }
-        WaitingFor::OpponentGuess {
-            player: guesser,
-            source,
-            owner,
+    ) && state
+        .active_optional_effect_frame()
+        .is_some_and(|frame| frame.ability.controller == player);
+    let parked_resolution_sacrifice = matches!(
+        state.pending_cost_move_resume.as_ref(),
+        Some(PendingCostMoveResume::SacrificeForCost {
+            pending: None,
+            completion: PendingSacrificeCostCompletion::ResolutionOptionalPayment { frame, .. },
             ..
-        } => {
-            *guesser == player
-                || source.prompt.controller == player
-                || owner
-                    .as_ref()
-                    .is_some_and(|owner| owner.context.lki.controller == player)
-        }
-        _ => false,
-    };
+        }) if frame.ability.controller == player
+    );
+    let abandon = selecting_resolution_sacrifice
+        || parked_resolution_sacrifice
+        || match &state.waiting_for {
+            WaitingFor::NamedChoice {
+                free_entry: None,
+                player: chooser,
+                source,
+                persist_player,
+                ..
+            } => {
+                *chooser == player
+                    || *persist_player == Some(player)
+                    || source
+                        .as_ref()
+                        .is_some_and(|source| source.prompt.controller == player)
+            }
+            WaitingFor::OpponentGuess {
+                player: guesser,
+                source,
+                owner,
+                ..
+            } => {
+                *guesser == player
+                    || source.prompt.controller == player
+                    || owner
+                        .as_ref()
+                        .is_some_and(|owner| owner.context.lki.controller == player)
+            }
+            _ => false,
+        };
     if !abandon {
         return;
     }
 
-    let _ = state
-        .clear_active_ability_continuation()
-        .expect("elimination cannot clear a buried ability continuation");
-    crate::game::stack::finish_resolving_stack_entry(
-        state,
-        crate::game::lifecycle::DelayedTerminalDisposition::Eliminated,
-    );
-    state.resolution_source_relatch = None;
-    state.deferred_entry_events.clear();
-    // The prompt and its ability continuation are abandoned, so no realization point will ever be
-    // reached for a token battlefield entry parked by this resolution. Leaving the `Option` live
-    // would let a later token's park trip the fail-loud overwrite assert, and would let the
-    // action-boundary convergence write a CR 400.7 row and run a CR 603.6a trigger pass for a
-    // resolution that no longer exists. If the token itself survives the abandonment its entry row
-    // is lost — the same loss the `deferred_entry_events.clear()` above already accepts for that
-    // entry's trigger replay.
-    state.pending_token_battlefield_entry = None;
+    if selecting_resolution_sacrifice {
+        let _ = state
+            .take_active_optional_effect_frame()
+            .expect("elimination cannot consume a buried optional payment frame");
+    }
+    if parked_resolution_sacrifice {
+        let _ = super::casting_costs::take_and_settle_parked_resolution_optional_sacrifice(
+            state, events,
+        )
+        .expect("parked optional sacrifice payment must own its resume cursor");
+    }
+
+    finish_abandoned_source_bound_resolution_carrier(state);
     state.waiting_for = WaitingFor::Priority {
         player: players::next_player(state, player),
     };
+}
+
+fn finish_abandoned_source_bound_resolution_carrier(state: &mut GameState) {
+    crate::game::stack::abandon_active_resolution_carrier(
+        state,
+        crate::game::lifecycle::DelayedTerminalDisposition::Eliminated,
+    );
 }
 
 /// CR 800.4a: A paused ChangeZone iteration is a single resolving family's
@@ -1424,18 +1530,10 @@ fn abandon_change_zone_family_for_controller(state: &mut GameState, player: Play
     let _ = state
         .take_active_change_zone_frame()
         .expect("elimination cannot consume a buried ChangeZone frame");
-    let _ = state
-        .clear_active_ability_continuation()
-        .expect("elimination cannot clear a buried ability continuation");
-    crate::game::stack::finish_resolving_stack_entry(
+    crate::game::stack::abandon_active_resolution_carrier(
         state,
         crate::game::lifecycle::DelayedTerminalDisposition::Eliminated,
     );
-    state.resolution_source_relatch = None;
-    state.deferred_entry_events.clear();
-    // Same reasoning as `abandon_source_bound_resolution_prompt`: the owning resolution is gone,
-    // so a parked token battlefield entry has no realization point left.
-    state.pending_token_battlefield_entry = None;
     state.waiting_for = WaitingFor::Priority {
         player: players::next_player(state, player),
     };
@@ -1527,7 +1625,10 @@ mod tests {
         PendingReplacement, PendingSpellResolution, PendingZoneChangeDelivery, PromptSourceBinding,
         ResolutionSourceRelatch, StackEntry, StackEntryKind,
     };
-    use crate::types::identifiers::{CardId, ObjectId, ObjectIncarnationRef};
+    use crate::types::identifiers::{
+        CardId, DelayedTriggerInstanceId, DelayedTriggerOrigin, DelayedTriggerToken, ObjectId,
+        ObjectIncarnationRef, TriggerFiring,
+    };
     use crate::types::mana::ManaCost;
     use crate::types::proposed_event::{CounterPlacement, ProposedEvent};
     use crate::types::replacements::ReplacementEvent;
@@ -1580,6 +1681,60 @@ mod tests {
             )),
             state,
         )
+    }
+
+    fn install_receipt_eligible_resolution_sacrifice(
+        state: &mut GameState,
+        source_id: ObjectId,
+        controller: PlayerId,
+        payer: PlayerId,
+        origin: DelayedTriggerOrigin,
+    ) {
+        let ability = ResolvedAbility::new(Effect::NoOp, Vec::new(), source_id, controller);
+        crate::game::stack::begin_resolving_stack_entry(
+            state,
+            StackEntry {
+                id: ObjectId(90_000),
+                source_id,
+                controller,
+                kind: StackEntryKind::TriggeredAbility {
+                    source_id,
+                    ability: Box::new(ability.clone()),
+                    condition: None,
+                    trigger_event: None,
+                    description: Some("receipt-eligible optional sacrifice".to_string()),
+                    source_name: "Receipt source".to_string(),
+                    subject_match_count: None,
+                    die_result: None,
+                    provenance: None,
+                },
+            },
+            Some(TriggerFiring::ReceiptEligible(origin)),
+        );
+        let continuation = PendingContinuation::new(
+            Box::new(ResolvedAbility::new(
+                Effect::NoOp,
+                Vec::new(),
+                source_id,
+                controller,
+            )),
+            state,
+        );
+        state.park_ability_continuation(continuation);
+        state.push_optional_effect_frame(OptionalEffectFrame {
+            ability: Box::new(ability),
+            trigger_event: None,
+            trigger_events: Vec::new(),
+            trigger_match_count: None,
+        });
+        state.waiting_for = WaitingFor::PayCost {
+            player: payer,
+            kind: PayCostKind::Sacrifice,
+            choices: Vec::new(),
+            count: 1,
+            min_count: 0,
+            resume: CostResume::Resolution,
+        };
     }
 
     fn pending_search_found_batch(
@@ -2022,6 +2177,86 @@ mod tests {
                 player: PlayerId(2)
             }
         ));
+    }
+
+    #[test]
+    fn controller_exit_terminalizes_receipt_eligible_resolution_as_eliminated() {
+        let mut state = setup_three_player();
+        let source = create_object(
+            &mut state,
+            CardId(702),
+            PlayerId(0),
+            "Receipt source".to_string(),
+            Zone::Battlefield,
+        );
+        let origin = DelayedTriggerOrigin {
+            token: DelayedTriggerToken(702),
+            instance: DelayedTriggerInstanceId(702),
+            source_id: source,
+        };
+        install_receipt_eligible_resolution_sacrifice(
+            &mut state,
+            source,
+            PlayerId(0),
+            PlayerId(1),
+            origin,
+        );
+
+        let lifecycle = crate::game::lifecycle::enter_action_frame();
+        eliminate_player(&mut state, PlayerId(0), &mut Vec::new());
+        let facts = lifecycle
+            .take_outer_facts()
+            .expect("outer elimination owns lifecycle facts");
+
+        assert_eq!(
+            facts.receipt_terminal_disposition(origin),
+            Some(crate::game::lifecycle::DelayedTerminalDisposition::Eliminated)
+        );
+        assert!(state.resolving_stack_entry.is_none());
+        assert!(state.resolving_trigger_firing.is_none());
+    }
+
+    #[test]
+    fn terminal_payer_exit_terminalizes_staged_receipt_as_eliminated() {
+        let mut state = setup_two_player();
+        let source = create_object(
+            &mut state,
+            CardId(703),
+            PlayerId(0),
+            "Receipt source".to_string(),
+            Zone::Battlefield,
+        );
+        let origin = DelayedTriggerOrigin {
+            token: DelayedTriggerToken(703),
+            instance: DelayedTriggerInstanceId(703),
+            source_id: source,
+        };
+        install_receipt_eligible_resolution_sacrifice(
+            &mut state,
+            source,
+            PlayerId(0),
+            PlayerId(1),
+            origin,
+        );
+
+        let lifecycle = crate::game::lifecycle::enter_action_frame();
+        eliminate_player(&mut state, PlayerId(1), &mut Vec::new());
+        let facts = lifecycle
+            .take_outer_facts()
+            .expect("outer elimination owns lifecycle facts");
+
+        assert_eq!(
+            facts.receipt_terminal_disposition(origin),
+            Some(crate::game::lifecycle::DelayedTerminalDisposition::Eliminated)
+        );
+        assert!(matches!(
+            state.waiting_for,
+            WaitingFor::GameOver {
+                winner: Some(PlayerId(0))
+            }
+        ));
+        assert!(state.resolving_stack_entry.is_none());
+        assert!(state.resolving_trigger_firing.is_none());
     }
 
     #[test]

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -10374,6 +10374,15 @@ fn apply_action(
                 }
             },
             CostResume::Resolution => match kind {
+                PayCostKind::Sacrifice => {
+                    casting_costs::handle_resolution_optional_sacrifice_for_cost(
+                        state,
+                        *player,
+                        choices,
+                        &chosen,
+                        &mut events,
+                    )?
+                }
                 PayCostKind::TapCreatures { mode } => {
                     casting_costs::pay_tap_creatures_selection(
                         state,
@@ -10393,7 +10402,6 @@ fn apply_action(
                 }
                 PayCostKind::Discard
                 | PayCostKind::Reveal
-                | PayCostKind::Sacrifice
                 | PayCostKind::ReturnToHand
                 | PayCostKind::ExileFromZone { .. }
                 | PayCostKind::ExilePermanent { .. }
@@ -12004,7 +12012,13 @@ fn apply_action(
             }
         }
         (WaitingFor::ReplacementChoice { .. }, GameAction::ChooseReplacement { index }) => {
-            engine_replacement::handle_replacement_choice(state, index, &mut events)?
+            if let Some(waiting_for) =
+                casting_costs::abandon_stale_resolution_sacrifice_cursor(state, &mut events)
+            {
+                waiting_for
+            } else {
+                engine_replacement::handle_replacement_choice(state, index, &mut events)?
+            }
         }
         (
             WaitingFor::EntryControllerChoice { .. },

--- a/crates/engine/src/game/engine_payment_choices.rs
+++ b/crates/engine/src/game/engine_payment_choices.rs
@@ -105,6 +105,26 @@ pub(super) fn handle_resolution_optional_payment_choice(
     state
         .replace_active_optional_effect_frame(frame)
         .map_err(|error| EngineError::InvalidAction(error.to_string()))?;
+    if let AbilityCost::Sacrifice(cost) = &live_cost.cost {
+        let count = cost.requirement.fixed_count().ok_or_else(|| {
+            EngineError::InvalidAction("resolution sacrifice cost is not fixed".into())
+        })? as usize;
+        let choices = super::casting::find_eligible_sacrifice_targets(
+            state,
+            live_player,
+            advertised_source,
+            &cost.target,
+        );
+        state.waiting_for = WaitingFor::PayCost {
+            player: live_player,
+            kind: crate::types::game_state::PayCostKind::Sacrifice,
+            choices,
+            count,
+            min_count: count,
+            resume: crate::types::game_state::CostResume::Resolution,
+        };
+        return Ok(state.waiting_for.clone());
+    }
     handle_optional_effect_choice(state, true, events)
 }
 

--- a/crates/engine/src/game/lifecycle.rs
+++ b/crates/engine/src/game/lifecycle.rs
@@ -93,6 +93,22 @@ impl ProspectiveLifecycleFacts {
             )
         })
     }
+
+    #[cfg(test)]
+    pub(super) fn receipt_terminal_disposition(
+        &self,
+        origin: DelayedTriggerOrigin,
+    ) -> Option<DelayedTerminalDisposition> {
+        self.facts.iter().find_map(|fact| match fact {
+            ReducerLifecycleFact::Terminal {
+                firing: TriggerFiring::ReceiptEligible(observed),
+                disposition,
+            } if *observed == origin => Some(*disposition),
+            ReducerLifecycleFact::Terminal { .. }
+            | ReducerLifecycleFact::Installed { .. }
+            | ReducerLifecycleFact::Due { .. } => None,
+        })
+    }
 }
 
 #[derive(Default)]

--- a/crates/engine/src/game/stack.rs
+++ b/crates/engine/src/game/stack.rs
@@ -65,6 +65,22 @@ pub(super) fn finish_resolving_stack_entry(
     }
 }
 
+/// Abandon the currently resolving family as one lifecycle unit. Prompt owners
+/// call this only after settling any events already completed by their cursor.
+pub(super) fn abandon_active_resolution_carrier(
+    state: &mut GameState,
+    disposition: super::lifecycle::DelayedTerminalDisposition,
+) {
+    super::priority::clear_priority_passes(state);
+    let _ = state
+        .clear_active_ability_continuation()
+        .expect("resolution abandonment cannot clear a buried ability continuation");
+    finish_resolving_stack_entry(state, disposition);
+    state.resolution_source_relatch = None;
+    state.deferred_entry_events.clear();
+    state.pending_token_battlefield_entry = None;
+}
+
 /// CR 405.1: Add an object to the stack.
 pub fn push_to_stack(state: &mut GameState, entry: StackEntry, events: &mut Vec<GameEvent>) {
     let trigger_firing = matches!(entry.kind, StackEntryKind::TriggeredAbility { .. })

--- a/crates/engine/src/game/visibility.rs
+++ b/crates/engine/src/game/visibility.rs
@@ -2243,13 +2243,14 @@ mod tests {
         FrozenScopedSearchFoundDisposition, ManaAbilityCostCursor, ManaAbilityCostResolutionMode,
         ManaAbilityResume, MayTriggerAutoChoiceKey, MayTriggerOrigin, PendingBeginGameAbility,
         PendingCast, PendingCostMoveCompletion, PendingCostMoveResume, PendingManaAbility,
-        PendingScopedLibrarySearch, PendingSearchFoundBatch, PreparedScopedLibrarySearchChoice,
-        TargetEffectDetail,
+        PendingSacrificeCostCompletion, PendingScopedLibrarySearch, PendingSearchFoundBatch,
+        PreparedScopedLibrarySearchChoice, TargetEffectDetail,
     };
-    use crate::types::identifiers::CardId;
+    use crate::types::identifiers::{CardId, ObjectIncarnationRef};
     use crate::types::mana::ManaCost;
     use crate::types::proposed_event::{ProposedEvent, SearchFoundDisposition};
     use crate::types::replacements::ReplacementEvent;
+    use crate::types::resolution::OptionalEffectFrame;
     use crate::types::zones::{ExileCostSourceZone, Zone};
     use rand::RngCore;
 
@@ -6266,6 +6267,28 @@ mod tests {
             PendingCostMoveResume::DelveManaPayment {
                 player: PlayerId(0),
                 fuel_id: hidden,
+            },
+            PendingCostMoveResume::SacrificeForCost {
+                player: PlayerId(0),
+                pending: None,
+                chosen: vec![hidden],
+                paused_at_index: 0,
+                completion: PendingSacrificeCostCompletion::ResolutionOptionalPayment {
+                    frame: Box::new(OptionalEffectFrame {
+                        ability: Box::new(ResolvedAbility::new(
+                            Effect::NoOp,
+                            vec![],
+                            ObjectId(70_002),
+                            PlayerId(0),
+                        )),
+                        trigger_event: None,
+                        trigger_events: Vec::new(),
+                        trigger_match_count: None,
+                    }),
+                    selected: vec![ObjectIncarnationRef::from_object(&state.objects[&hidden])],
+                },
+                deferred_cost_events: Vec::new(),
+                departure_record_indices: Vec::new(),
             },
             mana_resume,
         ];

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -6897,11 +6897,18 @@ pub struct ManaAbilityCostCursor {
 /// replacement-paused sacrifice cost. Selected sacrifices remove their
 /// activation-cost component; a SelfRef sacrifice resumes the automatic
 /// additional-cost path without replaying the sacrifice.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
 #[serde(tag = "type")]
 pub enum PendingSacrificeCostCompletion {
     SelectedNonSelf,
     SelfRef,
+    /// CR 118.3 + CR 118.11-12: a resolving optional PayCost branch owns its
+    /// substituted root and exact selected incarnations until every sacrifice
+    /// has reached a terminal replacement outcome.
+    ResolutionOptionalPayment {
+        frame: Box<OptionalEffectFrame>,
+        selected: Vec<ObjectIncarnationRef>,
+    },
 }
 
 /// CR 702.21a + CR 701.21 + CR 616.1: The unpaid work after one ward sacrifice
@@ -6953,7 +6960,10 @@ pub enum PendingCostMoveResume {
     },
     SacrificeForCost {
         player: PlayerId,
-        pending: Box<PendingCast>,
+        /// Cast/activation payments retain their announcement. Resolution-time
+        /// optional payments instead carry their typed tail in `completion`.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        pending: Option<Box<PendingCast>>,
         chosen: Vec<ObjectId>,
         /// Index into `chosen` whose sacrifice completes or is prevented by
         /// the replacement action. Resumption continues at the next index.

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -17,15 +17,15 @@ use frame_vec::{FrameSlot, FrameVec};
 use crate::types::ability::{AbilityDefinition, DiscardedCardResult, ResolvedAbility, TargetRef};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
-    DrainStatus, DrawSequenceStack, GameState, GameStateDecode, GameStateDecodeMode,
-    PendingBatchDeliveries, PendingChangeZoneIteration, PendingChooseOneOf, PendingConniveReentry,
-    PendingContinuation, PendingCopyTokenResolution, PendingCounterAdditionQueue,
-    PendingCounterMoveQueue, PendingCounterRemovalQueue, PendingDebugCardEntries,
-    PendingEachPlayerCopyChosen, PendingLifeTotalAssignment, PendingMultiDraw,
-    PendingPerCategoryZoneChoice, PendingPerPlayerZoneChoice, PendingRepeatIteration,
-    PendingRepeatUntil, PendingSpellResolution, PendingVoteBallotIteration, PostReplacementDrain,
-    PostReplacementDrainDispatch, PostReplacementDrainStack, PostReplacementFrameId,
-    ResidentDrainPolicy, ResolvingTriggerContext, WaitingFor,
+    CostResume, DrainStatus, DrawSequenceStack, GameState, GameStateDecode, GameStateDecodeMode,
+    PayCostKind, PendingBatchDeliveries, PendingChangeZoneIteration, PendingChooseOneOf,
+    PendingConniveReentry, PendingContinuation, PendingCopyTokenResolution,
+    PendingCounterAdditionQueue, PendingCounterMoveQueue, PendingCounterRemovalQueue,
+    PendingDebugCardEntries, PendingEachPlayerCopyChosen, PendingLifeTotalAssignment,
+    PendingMultiDraw, PendingPerCategoryZoneChoice, PendingPerPlayerZoneChoice,
+    PendingRepeatIteration, PendingRepeatUntil, PendingSpellResolution, PendingVoteBallotIteration,
+    PostReplacementDrain, PostReplacementDrainDispatch, PostReplacementDrainStack,
+    PostReplacementFrameId, ResidentDrainPolicy, ResolvingTriggerContext, WaitingFor,
 };
 use crate::types::identifiers::{DiscardFrameId, ObjectId};
 use crate::types::player::PlayerId;
@@ -456,6 +456,14 @@ impl DirectChoiceGate {
                 | (
                     Self::OptionalEffect,
                     WaitingFor::ResolutionOptionalPaymentChoice { .. }
+                )
+                | (
+                    Self::OptionalEffect,
+                    WaitingFor::PayCost {
+                        kind: PayCostKind::Sacrifice,
+                        resume: CostResume::Resolution,
+                        ..
+                    }
                 )
                 | (Self::CoinFlipKeep, WaitingFor::CoinFlipKeepChoice { .. })
                 | (Self::Proliferate, WaitingFor::ProliferateChoice { .. })

--- a/crates/engine/tests/integration/resolution_optional_payments.rs
+++ b/crates/engine/tests/integration/resolution_optional_payments.rs
@@ -1,11 +1,12 @@
 use engine::game::effects::resolve_ability_chain;
+use engine::game::elimination::eliminate_player;
 use engine::game::engine::apply;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::game::zones::move_to_zone;
 use engine::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, CardSelectionMode,
-    DiscardSelfScope, Effect, QuantityExpr, ReplacementDefinition, ReplacementMode,
-    ResolvedAbility, TargetFilter,
+    DiscardSelfScope, Effect, PlayerFilter, QuantityExpr, ReplacementDefinition, ReplacementMode,
+    ResolvedAbility, SacrificeCost, SubAbilityLink, TargetFilter,
 };
 use engine::types::actions::{GameAction, ResolutionOptionalPaymentChoice};
 use engine::types::game_state::{
@@ -14,6 +15,7 @@ use engine::types::game_state::{
 use engine::types::identifiers::ObjectId;
 use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
 use engine::types::replacements::ReplacementEvent;
 use engine::types::zones::Zone;
 
@@ -52,6 +54,67 @@ fn optional_payment(source: ObjectId, costs: Vec<AbilityCost>) -> ResolvedAbilit
     root
 }
 
+fn optional_sacrifice_spell(payer: TargetFilter, count: u32) -> AbilityDefinition {
+    let mut root = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::PayCost {
+            cost: AbilityCost::OneOf {
+                costs: vec![
+                    sacrifice(count),
+                    AbilityCost::Mana {
+                        cost: ManaCost::generic(99),
+                    },
+                ],
+            },
+            scale: None,
+            payer,
+        },
+    );
+    root.optional = true;
+    let mut payoff = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::GainLife {
+            amount: QuantityExpr::Fixed { value: 3 },
+            player: TargetFilter::Controller,
+        },
+    );
+    payoff.condition = Some(AbilityCondition::effect_performed());
+    let mut continuation = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::LoseLife {
+            amount: QuantityExpr::Fixed { value: 1 },
+            target: Some(TargetFilter::ScopedPlayer),
+        },
+    );
+    continuation.player_scope = Some(PlayerFilter::Opponent);
+    continuation.sub_link = SubAbilityLink::SequentialSibling;
+    continuation.sub_ability = Some(Box::new(payoff));
+    root.sub_ability = Some(Box::new(continuation));
+    root
+}
+
+fn start_optional_sacrifice_spell(runner: &mut GameRunner, spell: ObjectId) {
+    runner.cast(spell).commit();
+    runner.resolve_top();
+    assert!(
+        runner.state().resolving_stack_entry.is_some(),
+        "fixture must pause a real resolving spell carrier"
+    );
+    if let WaitingFor::OptionalEffectChoice { player, .. } = &runner.state().waiting_for {
+        let player = *player;
+        apply(
+            runner.state_mut(),
+            player,
+            GameAction::DecideOptionalEffect { accept: true },
+        )
+        .unwrap();
+    }
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ResolutionOptionalPaymentChoice { .. }
+    ));
+}
+
 fn runner_with_hand(card_count: usize) -> (GameRunner, ObjectId, Vec<ObjectId>) {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
@@ -86,6 +149,60 @@ fn optional_graveyard_exile_replacement() -> ReplacementDefinition {
         ))
 }
 
+fn optional_graveyard_prevention() -> ReplacementDefinition {
+    ReplacementDefinition::new(ReplacementEvent::Moved)
+        .destination_zone(Zone::Graveyard)
+        .mode(ReplacementMode::Optional { decline: None })
+        .execute(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::ChangeZone {
+                origin: None,
+                destination: Zone::Battlefield,
+                target: TargetFilter::SelfRef,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: engine::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                enters_modified_if: None,
+                face_down_profile: None,
+            },
+        ))
+}
+
+fn sacrifice(count: u32) -> AbilityCost {
+    AbilityCost::Sacrifice(SacrificeCost::count(TargetFilter::Any, count))
+}
+
+#[test]
+fn direct_resolution_paycost_cannot_silently_prepaid_non_self_sacrifice() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Direct Payment Source", 1, 1)
+        .id();
+    let fodder = scenario.add_creature(P0, "Direct Fodder", 1, 1).id();
+    let mut runner = scenario.build();
+    let mut hostile = optional_payment(source, vec![sacrifice(1)]);
+    hostile.optional = false;
+    let Effect::PayCost {
+        cost: hostile_cost, ..
+    } = &mut hostile.effect
+    else {
+        unreachable!();
+    };
+    *hostile_cost = sacrifice(1);
+
+    resolve_ability_chain(runner.state_mut(), &hostile, &mut Vec::new(), 0).unwrap();
+    assert!(runner.state().cost_payment_failed_flag);
+    assert_eq!(runner.state().objects[&source].zone, Zone::Battlefield);
+    assert_eq!(runner.state().objects[&fodder].zone, Zone::Battlefield);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 20);
+}
+
 #[test]
 fn saved_decline_skips_resolution_optional_payment_prompt_and_payoff() {
     let (mut runner, source, cards) = runner_with_hand(1);
@@ -108,6 +225,30 @@ fn saved_decline_skips_resolution_optional_payment_prompt_and_payoff() {
         WaitingFor::Priority { .. }
     ));
     assert_eq!(runner.state().objects[&cards[0]].zone, Zone::Hand);
+    assert_eq!(runner.state().players[P0.0 as usize].life, 20);
+}
+
+#[test]
+fn repeated_optional_sacrifice_is_not_advertised_without_typed_resume_support() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_creature(P0, "Repeated Payment Source", 1, 1)
+        .id();
+    let first = scenario.add_creature(P0, "First Fodder", 1, 1).id();
+    let second = scenario.add_creature(P0, "Second Fodder", 1, 1).id();
+    let mut runner = scenario.build();
+    let mut ability = optional_payment(source, vec![sacrifice(1)]);
+    ability.repeat_for = Some(QuantityExpr::Fixed { value: 2 });
+
+    resolve_ability_chain(runner.state_mut(), &ability, &mut Vec::new(), 0).unwrap();
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { .. }
+    ));
+    assert_eq!(runner.state().objects[&first].zone, Zone::Battlefield);
+    assert_eq!(runner.state().objects[&second].zone, Zone::Battlefield);
     assert_eq!(runner.state().players[P0.0 as usize].life, 20);
 }
 
@@ -588,4 +729,791 @@ fn resolution_optional_oneof_routes_mana_through_existing_payment() {
     let after = serde_json::to_string(runner.state()).unwrap();
     assert!(apply(runner.state_mut(), P0, pay).is_err());
     assert_eq!(serde_json::to_string(runner.state()).unwrap(), after);
+}
+
+#[test]
+fn resolution_optional_oneof_routes_fixed_sacrifice_through_existing_cursor() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Payment Source", 1, 1).id();
+    let first = scenario.add_creature(P0, "First Fodder", 1, 1).id();
+    let second = scenario.add_creature(P0, "Second Fodder", 1, 1).id();
+    let opponent = scenario.add_creature(P1, "Opponent Fodder", 1, 1).id();
+    let mut runner = scenario.build();
+    let life = runner.state().players[P0.0 as usize].life;
+    resolve_ability_chain(
+        runner.state_mut(),
+        &optional_payment(source, vec![sacrifice(2)]),
+        &mut Vec::new(),
+        0,
+    )
+    .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::ChooseResolutionOptionalPaymentBranch {
+            choice: ResolutionOptionalPaymentChoice::Pay { index: 0 },
+        },
+    )
+    .unwrap();
+    let WaitingFor::PayCost {
+        player,
+        choices,
+        count,
+        min_count,
+        ..
+    } = &runner.state().waiting_for
+    else {
+        panic!("fixed sacrifice must surface the canonical PayCost selector");
+    };
+    assert_eq!((*player, *count, *min_count), (P0, 2, 2));
+    assert!(choices.contains(&first) && choices.contains(&second));
+    assert!(!choices.contains(&opponent));
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::SelectCards {
+            cards: vec![first, second],
+        },
+    )
+    .unwrap();
+    assert_eq!(runner.state().objects[&first].zone, Zone::Graveyard);
+    assert_eq!(runner.state().objects[&second].zone, Zone::Graveyard);
+    assert!(runner
+        .state()
+        .zone_changes_this_turn
+        .iter()
+        .any(|record| record.object_id == first && record.co_departed == vec![second]));
+    assert!(runner
+        .state()
+        .zone_changes_this_turn
+        .iter()
+        .any(|record| record.object_id == second && record.co_departed == vec![first]));
+    assert_eq!(runner.state().players[P0.0 as usize].life, life + 3);
+}
+
+#[test]
+fn resolution_optional_sacrifice_rejects_stale_control_before_performed_latch() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Payment Source", 1, 1).id();
+    let fodder = scenario.add_creature(P0, "Fodder", 1, 1).id();
+    let mut runner = scenario.build();
+    let life = runner.state().players[P0.0 as usize].life;
+    resolve_ability_chain(
+        runner.state_mut(),
+        &optional_payment(source, vec![sacrifice(1)]),
+        &mut Vec::new(),
+        0,
+    )
+    .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::ChooseResolutionOptionalPaymentBranch {
+            choice: ResolutionOptionalPaymentChoice::Pay { index: 0 },
+        },
+    )
+    .unwrap();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&fodder)
+        .unwrap()
+        .controller = P1;
+    let before = serde_json::to_string(runner.state()).unwrap();
+    assert!(apply(
+        runner.state_mut(),
+        P0,
+        GameAction::SelectCards {
+            cards: vec![fodder]
+        },
+    )
+    .is_err());
+    assert_eq!(serde_json::to_string(runner.state()).unwrap(), before);
+    assert_eq!(runner.state().players[P0.0 as usize].life, life);
+    assert!(runner.state().active_optional_effect_frame().is_some());
+}
+
+#[test]
+fn resolution_optional_sacrifice_replacement_redirect_still_counts_paid() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Payment Source", 1, 1).id();
+    let fodder = scenario.add_creature(P0, "Fodder", 1, 1).id();
+    scenario
+        .add_creature(P1, "Graveyard Warden", 1, 1)
+        .with_replacement_definition(optional_graveyard_exile_replacement());
+    let mut runner = scenario.build();
+    let life = runner.state().players[P0.0 as usize].life;
+    resolve_ability_chain(
+        runner.state_mut(),
+        &optional_payment(source, vec![sacrifice(1)]),
+        &mut Vec::new(),
+        0,
+    )
+    .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::ChooseResolutionOptionalPaymentBranch {
+            choice: ResolutionOptionalPaymentChoice::Pay { index: 0 },
+        },
+    )
+    .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::SelectCards {
+            cards: vec![fodder],
+        },
+    )
+    .unwrap();
+    let WaitingFor::ReplacementChoice { candidates, .. } = &runner.state().waiting_for else {
+        panic!("sacrifice payment must park on the existing replacement cursor");
+    };
+    assert!(matches!(
+        runner.state().pending_cost_move_resume,
+        Some(engine::types::game_state::PendingCostMoveResume::SacrificeForCost {
+            pending: None,
+            completion: engine::types::game_state::PendingSacrificeCostCompletion::ResolutionOptionalPayment { .. },
+            ..
+        })
+    ));
+    let accept = candidates
+        .iter()
+        .position(|candidate| candidate.description == "Accept")
+        .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::ChooseReplacement { index: accept },
+    )
+    .unwrap();
+    assert_eq!(runner.state().objects[&fodder].zone, Zone::Exile);
+    assert_eq!(runner.state().players[P0.0 as usize].life, life + 3);
+    assert!(runner.state().pending_cost_move_resume.is_none());
+}
+
+#[test]
+fn replacement_paused_resolution_sacrifice_stamps_the_full_selected_batch() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Payment Source", 1, 1).id();
+    let redirected = scenario
+        .add_creature(P0, "Redirected Fodder", 1, 1)
+        .with_replacement_definition(optional_graveyard_exile_replacement())
+        .id();
+    let ordinary = scenario.add_creature(P0, "Ordinary Fodder", 1, 1).id();
+    let mut runner = scenario.build();
+    resolve_ability_chain(
+        runner.state_mut(),
+        &optional_payment(source, vec![sacrifice(2)]),
+        &mut Vec::new(),
+        0,
+    )
+    .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::ChooseResolutionOptionalPaymentBranch {
+            choice: ResolutionOptionalPaymentChoice::Pay { index: 0 },
+        },
+    )
+    .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::SelectCards {
+            cards: vec![redirected, ordinary],
+        },
+    )
+    .unwrap();
+    let WaitingFor::ReplacementChoice { candidates, .. } = &runner.state().waiting_for else {
+        panic!("first selected sacrifice must pause on replacement");
+    };
+    let accept = candidates
+        .iter()
+        .position(|candidate| candidate.description == "Accept")
+        .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::ChooseReplacement { index: accept },
+    )
+    .unwrap();
+    assert_eq!(runner.state().objects[&redirected].zone, Zone::Exile);
+    assert_eq!(runner.state().objects[&ordinary].zone, Zone::Graveyard);
+    assert!(runner
+        .state()
+        .zone_changes_this_turn
+        .iter()
+        .any(|record| record.object_id == redirected && record.co_departed == vec![ordinary]));
+    assert!(runner
+        .state()
+        .zone_changes_this_turn
+        .iter()
+        .any(|record| record.object_id == ordinary && record.co_departed == vec![redirected]));
+    assert_eq!(runner.state().players[P0.0 as usize].life, 23);
+}
+
+#[test]
+fn stale_replacement_prompt_abandons_real_carrier_and_settles_completed_prefix() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand(P0, "Optional Sacrifice", false)
+        .with_mana_cost(ManaCost::generic(0))
+        .with_ability_definition(optional_sacrifice_spell(TargetFilter::Controller, 3))
+        .id();
+    let warden = scenario
+        .add_creature(P0, "Graveyard Warden", 1, 1)
+        .with_replacement_definition(optional_graveyard_exile_replacement())
+        .id();
+    let ordinary = scenario.add_creature(P0, "Ordinary Fodder", 1, 1).id();
+    let paused = scenario.add_creature(P0, "Paused Fodder", 1, 1).id();
+    let stale = scenario.add_creature(P0, "Stale Fodder", 1, 1).id();
+    let observer = PlayerId(2);
+    scenario.add_creature_from_oracle(
+        observer,
+        "Death Observer",
+        1,
+        1,
+        "Whenever another creature dies, you gain 1 life.",
+    );
+    let mut runner = scenario.build();
+    move_to_zone(runner.state_mut(), warden, Zone::Exile, &mut Vec::new());
+    start_optional_sacrifice_spell(&mut runner, spell);
+    move_to_zone(
+        runner.state_mut(),
+        warden,
+        Zone::Battlefield,
+        &mut Vec::new(),
+    );
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::ChooseResolutionOptionalPaymentBranch {
+            choice: ResolutionOptionalPaymentChoice::Pay { index: 0 },
+        },
+    )
+    .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::SelectCards {
+            cards: vec![ordinary, paused, stale],
+        },
+    )
+    .unwrap();
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    let WaitingFor::ReplacementChoice { candidates, .. } = &runner.state().waiting_for else {
+        unreachable!()
+    };
+    let decline = candidates
+        .iter()
+        .position(|candidate| candidate.description == "Decline")
+        .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::ChooseReplacement { index: decline },
+    )
+    .unwrap();
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&stale)
+        .unwrap()
+        .incarnation += 1;
+    let stale_incarnation = runner.state().objects[&stale].incarnation;
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::ChooseReplacement { index: 0 },
+    )
+    .unwrap();
+
+    assert_eq!(runner.state().objects[&ordinary].zone, Zone::Graveyard);
+    assert_eq!(runner.state().objects[&paused].zone, Zone::Battlefield);
+    assert_eq!(runner.state().objects[&stale].zone, Zone::Battlefield);
+    assert_eq!(
+        runner.state().objects[&stale].incarnation,
+        stale_incarnation
+    );
+    assert_eq!(runner.state().players[P0.0 as usize].life, 20);
+    assert!(runner.state().active_optional_effect_frame().is_none());
+    assert!(runner.state().active_ability_continuation().is_none());
+    assert!(runner.state().resolving_stack_entry.is_none());
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert!(runner.state().pending_replacement.is_none());
+    assert!(!matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+    runner.advance_until_stack_empty();
+    assert_eq!(
+        runner.state().players[observer.0 as usize].life,
+        21,
+        "the completed sacrifice prefix must publish its death trigger exactly once"
+    );
+    assert_eq!(runner.state().players[P1.0 as usize].life, 20);
+}
+
+#[test]
+fn serialized_replacement_pause_rejects_same_id_new_incarnation_suffix() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Payment Source", 1, 1).id();
+    let first = scenario
+        .add_creature(P0, "Replacement Fodder", 1, 1)
+        .with_replacement_definition(optional_graveyard_exile_replacement())
+        .id();
+    let stale = scenario.add_creature(P0, "Stale Fodder", 1, 1).id();
+    let mut runner = scenario.build();
+    resolve_ability_chain(
+        runner.state_mut(),
+        &optional_payment(source, vec![sacrifice(2)]),
+        &mut Vec::new(),
+        0,
+    )
+    .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::ChooseResolutionOptionalPaymentBranch {
+            choice: ResolutionOptionalPaymentChoice::Pay { index: 0 },
+        },
+    )
+    .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::SelectCards {
+            cards: vec![first, stale],
+        },
+    )
+    .unwrap();
+
+    let wire = serde_json::to_string(runner.state()).unwrap();
+    *runner.state_mut() = serde_json::from_str(&wire).unwrap();
+    runner
+        .state_mut()
+        .objects
+        .get_mut(&stale)
+        .unwrap()
+        .incarnation += 1;
+    let stale_incarnation = runner.state().objects[&stale].incarnation;
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::ChooseReplacement { index: 0 },
+    )
+    .unwrap();
+
+    assert_eq!(runner.state().objects[&first].zone, Zone::Battlefield);
+    assert_eq!(runner.state().objects[&stale].zone, Zone::Battlefield);
+    assert_eq!(
+        runner.state().objects[&stale].incarnation,
+        stale_incarnation
+    );
+    assert_eq!(runner.state().players[P0.0 as usize].life, 20);
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert!(runner.state().pending_replacement.is_none());
+    assert!(!matches!(
+        runner.state().waiting_for,
+        WaitingFor::ReplacementChoice { .. }
+    ));
+}
+
+#[test]
+fn resolution_optional_sacrifice_prevented_move_still_counts_paid() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Payment Source", 1, 1).id();
+    let fodder = scenario
+        .add_creature(P0, "Protected Fodder", 1, 1)
+        .with_replacement_definition(optional_graveyard_prevention())
+        .id();
+    let mut runner = scenario.build();
+    let life = runner.state().players[P0.0 as usize].life;
+    resolve_ability_chain(
+        runner.state_mut(),
+        &optional_payment(source, vec![sacrifice(1)]),
+        &mut Vec::new(),
+        0,
+    )
+    .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::ChooseResolutionOptionalPaymentBranch {
+            choice: ResolutionOptionalPaymentChoice::Pay { index: 0 },
+        },
+    )
+    .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::SelectCards {
+            cards: vec![fodder],
+        },
+    )
+    .unwrap();
+    let WaitingFor::ReplacementChoice { candidates, .. } = &runner.state().waiting_for else {
+        panic!("preventing replacement must pause sacrifice payment");
+    };
+    let accept = candidates
+        .iter()
+        .position(|candidate| candidate.description == "Accept")
+        .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::ChooseReplacement { index: accept },
+    )
+    .unwrap();
+    assert_eq!(runner.state().objects[&fodder].zone, Zone::Battlefield);
+    assert_eq!(runner.state().players[P0.0 as usize].life, life + 3);
+}
+
+#[test]
+fn eliminated_resolution_sacrifice_payer_declines_real_stack_carrier_without_payoff() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand(P0, "Optional Sacrifice", false)
+        .with_mana_cost(ManaCost::generic(0))
+        .with_ability_definition(optional_sacrifice_spell(TargetFilter::Opponent, 1))
+        .id();
+    scenario.add_creature(P1, "Foreign Fodder", 1, 1);
+    let mut runner = scenario.build();
+    let p0_life = runner.state().players[P0.0 as usize].life;
+    let p1_life = runner.state().players[P1.0 as usize].life;
+    let p2 = PlayerId(2);
+    let p2_life = runner.state().players[p2.0 as usize].life;
+    start_optional_sacrifice_spell(&mut runner, spell);
+    apply(
+        runner.state_mut(),
+        P1,
+        GameAction::ChooseResolutionOptionalPaymentBranch {
+            choice: ResolutionOptionalPaymentChoice::Pay { index: 0 },
+        },
+    )
+    .unwrap();
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::PayCost { player: P1, .. }
+    ));
+
+    eliminate_player(runner.state_mut(), P1, &mut Vec::new());
+
+    assert!(runner.state().active_optional_effect_frame().is_none());
+    assert!(runner.state().active_ability_continuation().is_none());
+    assert!(runner.state().resolving_stack_entry.is_none());
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert!(runner.state().pending_replacement.is_none());
+    assert_eq!(runner.state().players[P0.0 as usize].life, p0_life);
+    assert_eq!(
+        runner.state().players[P1.0 as usize].life,
+        p1_life,
+        "the continuation must not observe the departed payer as a living opponent"
+    );
+    assert_eq!(
+        runner.state().players[p2.0 as usize].life,
+        p2_life - 1,
+        "canonical decline must resume against the post-departure opponent set"
+    );
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Graveyard);
+}
+
+#[test]
+fn eliminated_resolution_sacrifice_payer_game_over_drops_staged_resolution() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand(P0, "Optional Sacrifice", false)
+        .with_mana_cost(ManaCost::generic(0))
+        .with_ability_definition(optional_sacrifice_spell(TargetFilter::Opponent, 1))
+        .id();
+    scenario.add_creature(P1, "Foreign Fodder", 1, 1);
+    let mut runner = scenario.build();
+    let life = runner.state().players[P0.0 as usize].life;
+    start_optional_sacrifice_spell(&mut runner, spell);
+    apply(
+        runner.state_mut(),
+        P1,
+        GameAction::ChooseResolutionOptionalPaymentBranch {
+            choice: ResolutionOptionalPaymentChoice::Pay { index: 0 },
+        },
+    )
+    .unwrap();
+
+    eliminate_player(runner.state_mut(), P1, &mut Vec::new());
+
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::GameOver { winner: Some(P0) }
+    ));
+    assert!(runner.state().active_optional_effect_frame().is_none());
+    assert!(runner.state().active_ability_continuation().is_none());
+    assert!(runner.state().resolving_stack_entry.is_none());
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert!(runner.state().pending_replacement.is_none());
+    assert_eq!(
+        runner.state().players[P0.0 as usize].life,
+        life,
+        "a terminal game must not resume the staged continuation"
+    );
+}
+
+#[test]
+fn eliminated_resolution_sacrifice_controller_terminates_real_stack_selection_as_eliminated() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand(P0, "Optional Sacrifice", false)
+        .with_mana_cost(ManaCost::generic(0))
+        .with_ability_definition(optional_sacrifice_spell(TargetFilter::Opponent, 1))
+        .id();
+    scenario.add_creature(P1, "Foreign Fodder", 1, 1);
+    let mut runner = scenario.build();
+    let life = runner.state().players[P0.0 as usize].life;
+    start_optional_sacrifice_spell(&mut runner, spell);
+    apply(
+        runner.state_mut(),
+        P1,
+        GameAction::ChooseResolutionOptionalPaymentBranch {
+            choice: ResolutionOptionalPaymentChoice::Pay { index: 0 },
+        },
+    )
+    .unwrap();
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::PayCost { player: P1, .. }
+    ));
+
+    eliminate_player(runner.state_mut(), P0, &mut Vec::new());
+
+    assert!(runner.state().active_optional_effect_frame().is_none());
+    assert!(runner.state().active_ability_continuation().is_none());
+    assert!(runner.state().resolving_stack_entry.is_none());
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert!(runner.state().pending_replacement.is_none());
+    assert_eq!(runner.state().players[P0.0 as usize].life, life);
+    assert!(!matches!(
+        runner.state().waiting_for,
+        WaitingFor::PayCost { .. }
+    ));
+}
+
+#[test]
+fn eliminated_resolution_sacrifice_controller_terminates_real_stack_replacement_pause() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand(P0, "Optional Sacrifice", false)
+        .with_mana_cost(ManaCost::generic(0))
+        .with_ability_definition(optional_sacrifice_spell(TargetFilter::Opponent, 2))
+        .id();
+    let warden = scenario
+        .add_creature(P0, "Graveyard Warden", 1, 1)
+        .with_replacement_definition(optional_graveyard_exile_replacement())
+        .id();
+    let first = scenario.add_creature(P1, "First Foreign Fodder", 1, 1).id();
+    let second = scenario
+        .add_creature(P1, "Second Foreign Fodder", 1, 1)
+        .id();
+    let p2 = PlayerId(2);
+    scenario.add_creature_from_oracle(
+        p2,
+        "Death Observer",
+        1,
+        1,
+        "Whenever another creature dies, you gain 1 life.",
+    );
+    let mut runner = scenario.build();
+    let life = runner.state().players[P0.0 as usize].life;
+    move_to_zone(runner.state_mut(), warden, Zone::Exile, &mut Vec::new());
+    start_optional_sacrifice_spell(&mut runner, spell);
+    move_to_zone(
+        runner.state_mut(),
+        warden,
+        Zone::Battlefield,
+        &mut Vec::new(),
+    );
+    apply(
+        runner.state_mut(),
+        P1,
+        GameAction::ChooseResolutionOptionalPaymentBranch {
+            choice: ResolutionOptionalPaymentChoice::Pay { index: 0 },
+        },
+    )
+    .unwrap();
+    apply(
+        runner.state_mut(),
+        P1,
+        GameAction::SelectCards {
+            cards: vec![first, second],
+        },
+    )
+    .unwrap();
+    let WaitingFor::ReplacementChoice {
+        player: replacement_chooser,
+        candidates,
+        ..
+    } = &runner.state().waiting_for
+    else {
+        panic!("first sacrifice must pause on replacement");
+    };
+    let replacement_chooser = *replacement_chooser;
+    let decline = candidates
+        .iter()
+        .position(|candidate| candidate.description == "Decline")
+        .unwrap();
+    apply(
+        runner.state_mut(),
+        replacement_chooser,
+        GameAction::ChooseReplacement { index: decline },
+    )
+    .unwrap();
+    assert!(runner.state().pending_replacement.is_some());
+    assert!(matches!(
+        runner.state().pending_cost_move_resume.as_ref(),
+        Some(
+            engine::types::game_state::PendingCostMoveResume::SacrificeForCost {
+                paused_at_index: 1,
+                ..
+            }
+        )
+    ));
+    assert_eq!(runner.state().objects[&first].zone, Zone::Graveyard);
+    assert_eq!(runner.state().objects[&second].zone, Zone::Battlefield);
+
+    let mut events = Vec::new();
+    eliminate_player(runner.state_mut(), P0, &mut events);
+    runner.advance_until_stack_empty();
+
+    assert!(runner.state().active_optional_effect_frame().is_none());
+    assert!(runner.state().active_ability_continuation().is_none());
+    assert!(runner.state().resolving_stack_entry.is_none());
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert!(runner.state().pending_replacement.is_none());
+    assert_eq!(runner.state().players[P0.0 as usize].life, life);
+    assert_eq!(runner.state().objects[&first].zone, Zone::Graveyard);
+    assert_eq!(runner.state().objects[&second].zone, Zone::Battlefield);
+    assert_eq!(
+        runner.state().players[p2.0 as usize].life,
+        21,
+        "the completed sacrifice prefix must still create its death trigger"
+    );
+}
+
+#[test]
+fn eliminated_resolution_sacrifice_payer_declines_real_stack_replacement_pause() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand(P0, "Optional Sacrifice", false)
+        .with_mana_cost(ManaCost::generic(0))
+        .with_ability_definition(optional_sacrifice_spell(TargetFilter::Opponent, 1))
+        .id();
+    let warden = scenario
+        .add_creature(P0, "Graveyard Warden", 1, 1)
+        .with_replacement_definition(optional_graveyard_exile_replacement())
+        .id();
+    let fodder = scenario.add_creature(P1, "Foreign Fodder", 1, 1).id();
+    let mut runner = scenario.build();
+    let life = runner.state().players[P0.0 as usize].life;
+    let p2 = PlayerId(2);
+    let p2_life = runner.state().players[p2.0 as usize].life;
+    move_to_zone(runner.state_mut(), warden, Zone::Exile, &mut Vec::new());
+    start_optional_sacrifice_spell(&mut runner, spell);
+    move_to_zone(
+        runner.state_mut(),
+        warden,
+        Zone::Battlefield,
+        &mut Vec::new(),
+    );
+    apply(
+        runner.state_mut(),
+        P1,
+        GameAction::ChooseResolutionOptionalPaymentBranch {
+            choice: ResolutionOptionalPaymentChoice::Pay { index: 0 },
+        },
+    )
+    .unwrap();
+    apply(
+        runner.state_mut(),
+        P1,
+        GameAction::SelectCards {
+            cards: vec![fodder],
+        },
+    )
+    .unwrap();
+    assert!(runner.state().pending_replacement.is_some());
+    assert!(runner.state().pending_cost_move_resume.is_some());
+
+    eliminate_player(runner.state_mut(), P1, &mut Vec::new());
+
+    assert!(runner.state().active_optional_effect_frame().is_none());
+    assert!(runner.state().active_ability_continuation().is_none());
+    assert!(runner.state().resolving_stack_entry.is_none());
+    assert!(runner.state().pending_cost_move_resume.is_none());
+    assert!(runner.state().pending_replacement.is_none());
+    assert_eq!(runner.state().players[P0.0 as usize].life, life);
+    assert_eq!(runner.state().players[p2.0 as usize].life, p2_life - 1);
+    assert_eq!(runner.state().objects[&spell].zone, Zone::Graveyard);
+}
+
+#[test]
+fn unrelated_elimination_preserves_resolution_sacrifice_root() {
+    let p2 = PlayerId(2);
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario.add_creature(P0, "Payment Source", 1, 1).id();
+    let fodder = scenario.add_creature(P0, "Fodder", 1, 1).id();
+    let mut runner = scenario.build();
+    resolve_ability_chain(
+        runner.state_mut(),
+        &optional_payment(source, vec![sacrifice(1)]),
+        &mut Vec::new(),
+        0,
+    )
+    .unwrap();
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::ChooseResolutionOptionalPaymentBranch {
+            choice: ResolutionOptionalPaymentChoice::Pay { index: 0 },
+        },
+    )
+    .unwrap();
+    eliminate_player(runner.state_mut(), p2, &mut Vec::new());
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::PayCost {
+            player: P0,
+            kind: engine::types::game_state::PayCostKind::Sacrifice,
+            ..
+        }
+    ));
+    assert!(runner.state().active_optional_effect_frame().is_some());
+    apply(
+        runner.state_mut(),
+        P0,
+        GameAction::SelectCards {
+            cards: vec![fodder],
+        },
+    )
+    .unwrap();
+    assert_eq!(runner.state().players[P0.0 as usize].life, 23);
 }

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -43,6 +43,8 @@ pub enum ServerErrorCode {
 /// handshake. When making such changes, plan a deprecation window where
 /// both the old and new variants coexist, then bump and remove the old.
 ///
+/// 47 — Resolution-time optional fixed sacrifice payments add a typed
+///      replacement-resumable continuation to `GameState`.
 /// 46 — `QuantityRef::Aggregate` and `QuantityRef::TrackedSetAggregate` were
 ///      replaced on the serialized `GameState` surface by the canonical
 ///      `QuantityRef::PropertyAggregate` tag with a validated `source` object.
@@ -195,7 +197,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 46;
+pub const PROTOCOL_VERSION: u32 = 47;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake **from clients that predate [`LOBBY_PROTOCOL_VERSION`]** — the
@@ -645,12 +647,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 46);
+        assert_eq!(PROTOCOL_VERSION, 47);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot
         // understand a success acknowledgment the submitting client awaits.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 45);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 46);
     }
 
     #[test]

--- a/crates/phase-ai/src/policies/sacrifice_value.rs
+++ b/crates/phase-ai/src/policies/sacrifice_value.rs
@@ -142,7 +142,9 @@ impl SacrificeValuePolicy {
             ctx.decision.waiting_for,
             WaitingFor::PayCost {
                 kind: PayCostKind::Sacrifice,
-                resume: CostResume::Spell { .. } | CostResume::SpellCost { .. },
+                resume: CostResume::Spell { .. }
+                    | CostResume::SpellCost { .. }
+                    | CostResume::Resolution,
                 ..
             } | WaitingFor::WardSacrificeChoice { .. }
                 | WaitingFor::EffectZoneChoice {
@@ -430,6 +432,23 @@ mod tests {
         choices: &[ObjectId],
         cards: Vec<ObjectId>,
     ) -> (f64, PolicyVerdict) {
+        let (raw, verdict, _) = sacrifice_policy_score_and_verdict_for_resume(
+            state,
+            choices,
+            cards,
+            CostResume::Spell {
+                spell: dummy_pending(),
+            },
+        );
+        (raw, verdict)
+    }
+
+    fn sacrifice_policy_score_and_verdict_for_resume(
+        state: &GameState,
+        choices: &[ObjectId],
+        cards: Vec<ObjectId>,
+        resume: CostResume,
+    ) -> (f64, PolicyVerdict, f64) {
         let config = AiConfig::default();
         let selection_count = cards.len();
         let decision = AiDecisionContext {
@@ -439,9 +458,7 @@ mod tests {
                 choices: choices.to_vec(),
                 count: selection_count,
                 min_count: selection_count,
-                resume: CostResume::Spell {
-                    spell: dummy_pending(),
-                },
+                resume,
             },
             candidates: Vec::new(),
         };
@@ -461,7 +478,42 @@ mod tests {
             search_depth: crate::policies::context::SearchDepth::Root,
         };
         let raw = SacrificeValuePolicy.score(&policy_context);
-        (raw, SacrificeValuePolicy.verdict(&policy_context))
+        (
+            raw,
+            SacrificeValuePolicy.verdict(&policy_context),
+            super::super::registry::PolicyRegistry::shared().score(&policy_context),
+        )
+    }
+
+    #[test]
+    fn resolution_payment_production_policy_prefers_fodder_over_commander() {
+        let mut state = GameState::new_two_player(42);
+        let fodder = creature_body(&mut state, "Fodder", 1, 1);
+        let commander = owned_commander_body(&mut state, "Commander", 5, 5, 5, 1);
+
+        let (fodder_score, _, fodder_production_score) =
+            sacrifice_policy_score_and_verdict_for_resume(
+                &state,
+                &[fodder, commander],
+                vec![fodder],
+                CostResume::Resolution,
+            );
+        let (commander_score, _, commander_production_score) =
+            sacrifice_policy_score_and_verdict_for_resume(
+                &state,
+                &[fodder, commander],
+                vec![commander],
+                CostResume::Resolution,
+            );
+
+        assert!(
+            fodder_score > commander_score,
+            "resolution-time payment must value fodder above the commander: {fodder_score} <= {commander_score}"
+        );
+        assert!(
+            fodder_production_score > commander_production_score,
+            "the production registry must rank the fodder selection above the commander: {fodder_production_score} <= {commander_production_score}"
+        );
     }
 
     /// At temperature 1.0, two equally priced 4/4 bodies gave the commander a

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -2628,8 +2628,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_46() {
-        assert_eq!(PROTOCOL_VERSION, 46);
+    fn protocol_version_is_47() {
+        assert_eq!(PROTOCOL_VERSION, 47);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -2639,7 +2639,7 @@ mod tests {
     /// understand.
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
-    /// this guards — and this test reds while `protocol_version_is_44` stays
+    /// this guards — and this test reds while `protocol_version_is_47` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 46;
+const EXPECTED_PROTOCOL_VERSION = 47;
 // The LOBBY message-set version. Deliberately separate from the full-game
 // number above and deliberately NOT derived from it: a GameState-only bump must
 // not move the lobby's compatibility window. See the assertions at the bottom.
@@ -14,7 +14,7 @@ const EXPECTED_LOBBY_PROTOCOL_VERSION = 2;
 // here, so a full-game bump could ship with an unbumped P2P version and CI
 // stayed green — a v(n-1) host and a v(n) guest would then complete a
 // handshake and only fail when the incompatible payload arrived.
-const EXPECTED_WIRE_PROTOCOL_VERSION = 35;
+const EXPECTED_WIRE_PROTOCOL_VERSION = 36;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);


### PR DESCRIPTION
## Summary

Phase 2 of issue #7966: add the serialized engine/runtime infrastructure for resolution-time sacrifice payments.

This PR:
- routes resolution-time sacrifice costs through the canonical cost-selection and replacement pipeline
- preserves optional-payment and reflexive continuation state across selection, replacement, save/load, visibility, AI, elimination, and terminal lifecycle paths
- ranks resolution-time sacrifice candidates through the existing AI sacrifice-value policy
- safely abandons stale resolution-payment cursors, settles completed sacrifice prefixes exactly once, and terminalizes their real carrier
- rejects currently unsupported repeated sacrifice-payment shapes instead of advertising an invalid prompt
- adds production-stack, replacement-pause, elimination, topology, serialization, stale-cursor, and receipt-disposition regressions
- bumps the full game protocol to 47 and P2P wire protocol to 36; the independently versioned lobby protocol remains 2

This is infrastructure only. It does **not** yet add K'un-Lun Warrior or Bullseye, Death Dealer card/parser code; that remains a later phase of #7966.

## Validation

Exact reviewed head: 503ca21804a34e9f4e99853aae3a898fa6a71daa (base `4b85b52c9d11cbe0c8da428aa1f5f1e80dcae029`, release v0.66.0)

- focused resolution optional payments: 29 passed
- stale real-carrier receipt regressions: 2 passed
- full phase-engine: 19,975 library targets + 5,664 integration passed, 0 failed
- full phase-ai: 2,103 core tests plus all auxiliary suites passed, 0 failed
- engine + AI clippy, all targets, warnings denied: passed
- interaction bindings check: passed
- protocol version gate: passed
- parser Gate G and explicit-base Gate A: passed
- frontend: 4,079/4,079 passed under en-US locale shim; TypeScript and ESLint passed
- cargo fmt and git diff checks: passed
- independent completion review: PASS
- independent maintainer-simulation review: PASS

The raw frontend run under a Danish locale had one decimal-comma snapshot mismatch; the same exact head passed 4,079/4,079 with an out-of-repo en-US locale shim and no repository change.

Part of #7966. Phase 1 was PR #7995.
