### PR TITLE
chore(shell): enable Web Inspector in desktop releases

### DIFF
--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ name = "phase_tauri_lib"
 crate-type = ["staticlib", "cdylib", "rlib"]
 
 [dependencies]
-tauri = { version = "2", features = [] }
+tauri = { version = "2", features = ["devtools"] }
 tauri-plugin-opener = "=2.5.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"


### PR DESCRIPTION
Enables Tauri Web Inspector in release desktop binaries. Toggle it on macOS with Command-Option-I while reproducing the offline catalog scan.