### PR TITLE
fix(engine): recover terminal spell resolution residue

### DIFF
--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1411,12 +1411,15 @@ fn apply_action_boundary_core(
     // defers to the next boundary at which the flag is clear. No "outermost"
     // depth test is added: gating on it would leave AI-probe clones unrepaired
     // while the real state is repaired.
+    let pre_recovery_pass_was_authorized = matches!(&action, GameAction::PassPriority)
+        && check_actor_authorization(state, authenticated_actor, &action).is_ok();
     effects::sweep_ownerless_post_replacement_strand(state);
-    state.remove_empty_active_post_replacement_frame();
     let recovered_devour_rest_boundary =
-        recover_orphaned_devour_completion_at_priority_boundary(state);
+        recover_orphaned_devour_completion_at_priority_boundary(state)
+            || recover_orphaned_spell_resolution_at_priority_boundary(state);
+    state.remove_empty_active_post_replacement_frame();
     let recovered_stale_priority_pass =
-        recovered_devour_rest_boundary && matches!(action, GameAction::PassPriority);
+        recovered_devour_rest_boundary && matches!(&action, GameAction::PassPriority);
     let boundary_snapshot = state.clone();
     let journal_start = state.resolved_rules_journal.entries().len();
     let is_actor_scoped_preference = action.is_actor_scoped_preference();
@@ -1437,6 +1440,25 @@ fn apply_action_boundary_core(
         Some(semantic_owner)
     };
     let preserve_interaction = interaction::action_preserves_interaction(&action);
+    // Clear transient inter-effect state at the start of each player action.
+    // last_effect_count is set by interactive handlers (e.g., DiscardChoice) and
+    // consumed by sub_ability continuations via EventContextAmount fallback.
+    state.last_effect_count = None;
+    state.last_effect_counts_by_player.clear();
+    state.exiled_from_hand_this_resolution = 0;
+    state.die_result_this_resolution = None;
+    state.consumed_before_priority_trigger_events.clear();
+    if recovered_stale_priority_pass && !pre_recovery_pass_was_authorized {
+        lifecycle.discard();
+        return Err(EngineError::WrongPlayer);
+    }
+    if !recovered_stale_priority_pass {
+        if let Err(err) = check_actor_authorization(state, authenticated_actor, &action) {
+            lifecycle.discard();
+            *state = boundary_snapshot;
+            return Err(err);
+        }
+    }
     if recovered_stale_priority_pass {
         return Ok(RawActionApplication {
             result: ActionResult {
@@ -1454,19 +1476,6 @@ fn apply_action_boundary_core(
             preserve_interaction,
             lifecycle,
         });
-    }
-    // Clear transient inter-effect state at the start of each player action.
-    // last_effect_count is set by interactive handlers (e.g., DiscardChoice) and
-    // consumed by sub_ability continuations via EventContextAmount fallback.
-    state.last_effect_count = None;
-    state.last_effect_counts_by_player.clear();
-    state.exiled_from_hand_this_resolution = 0;
-    state.die_result_this_resolution = None;
-    state.consumed_before_priority_trigger_events.clear();
-    if let Err(err) = check_actor_authorization(state, authenticated_actor, &action) {
-        lifecycle.discard();
-        *state = boundary_snapshot;
-        return Err(err);
     }
     let mut result = match apply_action(state, semantic_owner, action, stack_resolution_limit) {
         Ok(result) => result,
@@ -1556,18 +1565,67 @@ fn recover_orphaned_devour_completion_at_priority_boundary(state: &mut GameState
         return false;
     }
 
-    let cleared = state.clear_completed_active_devour_snapshot();
+    let mut recovered = state.clone();
+    let cleared = recovered.clear_completed_active_devour_snapshot();
     debug_assert!(cleared, "the guarded Devour frame must be consumable");
-    state.remove_empty_active_post_replacement_frame();
-    settle_resolving_stack_entry_after_continuation_resume(state);
-    if state.resolving_stack_entry.is_some() {
+    recovered.remove_empty_active_post_replacement_frame();
+    settle_resolving_stack_entry_after_continuation_resume(&mut recovered);
+    if recovered.resolving_stack_entry.is_some() {
         return false;
     }
 
-    priority::reset_priority(state);
-    state.waiting_for = WaitingFor::Priority {
-        player: state.active_player,
+    priority::reset_priority(&mut recovered);
+    recovered.waiting_for = WaitingFor::Priority {
+        player: recovered.active_player,
     };
+    *state = recovered;
+    true
+}
+
+/// CR 117.3b + CR 608.2c: A persisted permanent-spell epilogue may retain its
+/// sole `SpellResolution` frame after every other instruction has completed.
+/// Consume only that exact bare carrier rest, then route settlement through the
+/// ordinary completed-carrier authority.
+fn recover_orphaned_spell_resolution_at_priority_boundary(state: &mut GameState) -> bool {
+    let Some(pending) = state.active_spell_resolution() else {
+        return false;
+    };
+    let exact_bare_spell_resolution_rest = matches!(state.waiting_for, WaitingFor::Priority { .. })
+        && state.stack.is_empty()
+        && state.resolution_stack.len() == 1
+        && state.active_ability_continuation().is_none()
+        && state.pending_cast.is_none()
+        && state.pending_resolution_completion.is_none()
+        && matches!(
+            state.resolving_stack_entry.as_ref(),
+            Some(crate::types::game_state::StackEntry {
+                id,
+                kind: StackEntryKind::Spell { .. },
+                ..
+            }) if *id == pending.object_id
+        );
+    if !exact_bare_spell_resolution_rest {
+        return false;
+    }
+
+    let mut recovered = state.clone();
+    let pending = recovered
+        .take_active_spell_resolution()
+        .expect("the guarded bare spell-resolution frame must be active");
+    debug_assert!(matches!(
+        recovered.resolving_stack_entry.as_ref(),
+        Some(crate::types::game_state::StackEntry { id, .. }) if *id == pending.object_id
+    ));
+    settle_resolving_stack_entry_after_continuation_resume(&mut recovered);
+    if recovered.resolving_stack_entry.is_some() {
+        return false;
+    }
+
+    priority::reset_priority(&mut recovered);
+    recovered.waiting_for = WaitingFor::Priority {
+        player: recovered.active_player,
+    };
+    *state = recovered;
     true
 }
 

--- a/crates/engine/tests/integration/devour_completion_rest_recovery.rs
+++ b/crates/engine/tests/integration/devour_completion_rest_recovery.rs
@@ -3,11 +3,12 @@
 //! parent below its Devour-only ChangeZone snapshot. The stale resolution
 //! carrier then let a later priority pass enter `start_next_turn` and panic.
 
-use engine::game::engine::apply;
+use engine::game::engine::{apply, EngineError};
 use engine::types::actions::GameAction;
 use engine::types::format::FormatConfig;
 use engine::types::game_state::{
-    CastingVariant, GameState, PostReplacementDrainStack, StackEntry, StackEntryKind, WaitingFor,
+    CastingVariant, GameState, PendingResolutionCompletion, PendingSpellResolution,
+    PostReplacementDrainStack, StackEntry, StackEntryKind, WaitingFor,
 };
 use engine::types::identifiers::{CardId, ObjectId};
 use engine::types::phase::Phase;
@@ -17,6 +18,40 @@ const P0: PlayerId = PlayerId(0);
 const P1: PlayerId = PlayerId(1);
 const P2: PlayerId = PlayerId(2);
 const P3: PlayerId = PlayerId(3);
+
+fn bare_spell_resolution_rest_state() -> GameState {
+    let mut state = GameState::new(FormatConfig::free_for_all(), 4, 0xB152_FCBF);
+    state.phase = Phase::Cleanup;
+    state.active_player = P3;
+    state.priority_player = P2;
+    state.waiting_for = WaitingFor::Priority { player: P2 };
+    state.resolving_stack_entry = Some(StackEntry {
+        id: ObjectId(347),
+        source_id: ObjectId(347),
+        controller: P3,
+        kind: StackEntryKind::Spell {
+            card_id: CardId(347),
+            ability: None,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 4,
+        },
+    });
+    state.push_spell_resolution(PendingSpellResolution {
+        object_id: ObjectId(347),
+        controller: P3,
+        casting_variant: CastingVariant::Normal,
+        cast_from_zone: None,
+        cast_controller: Some(P3),
+        cast_timing_permission: None,
+        spell_targets: vec![],
+        actual_mana_spent: 4,
+        kickers_paid: vec![],
+        additional_cost_payment_count: 0,
+        additional_cost_payments: vec![],
+        convoked_creatures: vec![],
+    });
+    state
+}
 
 /// CR 117.3b + CR 117.4 + CR 608.2c + CR 614.12a + CR 614.13a: an old pass
 /// submitted from the captured priority window repairs the completed Devour
@@ -71,4 +106,73 @@ fn captured_devour_rest_shape_recovers_before_a_stale_pass_can_start_the_next_tu
     assert!(state.priority_passes.is_empty());
     assert_eq!(state.priority_pass_count, 0);
     assert_eq!(result.waiting_for, state.waiting_for);
+}
+
+/// An actor unauthorized in the captured window cannot consume the recovery
+/// no-op, even though the impossible persisted state is repaired.
+#[test]
+fn unauthorized_pass_repairs_but_cannot_spend_devour_recovery() {
+    let mut state = GameState::new(FormatConfig::free_for_all(), 4, 0xB152_FCBF);
+    state.phase = Phase::Cleanup;
+    state.active_player = P3;
+    state.priority_player = P2;
+    state.waiting_for = WaitingFor::Priority { player: P2 };
+    state.resolving_stack_entry = Some(StackEntry {
+        id: ObjectId(347),
+        source_id: ObjectId(347),
+        controller: P3,
+        kind: StackEntryKind::Spell {
+            card_id: CardId(347),
+            ability: None,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 4,
+        },
+    });
+    state
+        .resolution_stack
+        .push_post_replacement(PostReplacementDrainStack::default());
+    state.push_devour_change_zone_snapshot([ObjectId(27), ObjectId(31)].into_iter().collect());
+
+    assert!(matches!(
+        apply(&mut state, P0, GameAction::PassPriority),
+        Err(EngineError::WrongPlayer)
+    ));
+    assert!(state.resolution_stack.is_empty());
+    assert!(state.resolving_stack_entry.is_none());
+    assert_eq!(state.waiting_for, WaitingFor::Priority { player: P3 });
+}
+
+/// The Discord turn-26 capture has no Devour frame: only a completed
+/// permanent-spell epilogue remains above the resolving carrier.
+#[test]
+fn bare_spell_resolution_rest_recovers_before_a_captured_pass() {
+    let mut state = bare_spell_resolution_rest_state();
+
+    let result = apply(&mut state, P2, GameAction::PassPriority)
+        .expect("the captured priority holder may submit the recovery no-op");
+
+    assert!(state.resolution_stack.is_empty());
+    assert!(state.resolving_stack_entry.is_none());
+    assert_eq!(state.phase, Phase::Cleanup);
+    assert_eq!(state.waiting_for, WaitingFor::Priority { player: P3 });
+    assert_eq!(result.waiting_for, state.waiting_for);
+}
+
+/// A terminal-looking spell frame with another completion hold is live work,
+/// not persisted residue; recovery must leave it to the ordinary resumer.
+#[test]
+fn bare_spell_resolution_recovery_preserves_live_completion_work() {
+    let mut state = bare_spell_resolution_rest_state();
+    state.pending_resolution_completion = Some(PendingResolutionCompletion {
+        player: P3,
+        source_id: ObjectId(347),
+        final_cast: None,
+    });
+    let before = state.resolution_stack.clone();
+
+    apply(&mut state, P0, GameAction::SetPhaseStops { stops: vec![] })
+        .expect("actor-scoped preferences are valid at every prompt");
+
+    assert_eq!(state.resolution_stack, before);
+    assert!(state.resolving_stack_entry.is_some());
 }


### PR DESCRIPTION
Fixes the persisted AI game states that leave an empty game stack and Priority window while a terminal resolution carrier remains.

- retires the exact bare `SpellResolution` residue captured in Discord turn 26
- makes Devour residue recovery transactional, preserving any live completion work
- treats a pass authorized in the captured Priority window as the recovery no-op, so the client receives the repaired state instead of reconnecting into the same panic
- adds regressions for both captures, an unauthorized pass, and a live completion hold