### PR TITLE
fix(ci): publish Android assets before immutable release

### DIFF
--- a/.github/workflows/shell-release.yml
+++ b/.github/workflows/shell-release.yml
@@ -634,6 +634,34 @@ jobs:
           test "$(jq -r '.platforms | keys | sort | join(",")' artifacts/update.json)" = 'darwin-aarch64,linux-x86_64,windows-x86_64'
           ! grep -qi 'android' artifacts/update.json
 
+      - name: Download signed Android APKs
+        if: needs.build-android.outputs.apk_available == 'true'
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
+        with:
+          name: shell-tauri-android
+          path: artifacts/shell-tauri-android
+
+      - name: Validate release assets
+        env:
+          ANDROID_APKS_AVAILABLE: ${{ needs.build-android.outputs.apk_available }}
+        run: |
+          set -euo pipefail
+
+          for asset in \
+            artifacts/shell-tauri-linux/Phase-Desktop-Linux-x86_64.deb \
+            artifacts/shell-tauri-linux/Phase-Desktop-Linux-x86_64.AppImage \
+            artifacts/shell-tauri-macos/Phase-Desktop-macOS-Apple-Silicon.dmg \
+            artifacts/shell-tauri-macos/Phase-Desktop-macOS-Apple-Silicon.app.tar.gz \
+            artifacts/shell-tauri-windows/Phase-Desktop-Windows-x64-Setup.exe \
+            artifacts/update.json; do
+            test -s "$asset"
+          done
+
+          if [ "$ANDROID_APKS_AVAILABLE" = 'true' ]; then
+            test -s artifacts/shell-tauri-android/Phase-Android-ARM64.apk
+            test -s artifacts/shell-tauri-android/Phase-Android-ARMv7.apk
+          fi
+
       - name: Create shell release
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2
         with:
@@ -654,7 +682,9 @@ jobs:
 
             This is the official desktop app for [phase-rs.dev](https://phase-rs.dev).
             `update.json` is used by automatic updates; it is not a manual download.
-          fail_on_unmatched_files: true
+          # Android artifacts are optional, so unmatched APK globs are allowed.
+          # The preceding validation keeps every required desktop asset strict.
+          fail_on_unmatched_files: false
           files: |
             artifacts/shell-tauri-linux/Phase-Desktop-Linux-x86_64.deb
             artifacts/shell-tauri-linux/Phase-Desktop-Linux-x86_64.AppImage
@@ -662,6 +692,8 @@ jobs:
             artifacts/shell-tauri-macos/Phase-Desktop-macOS-Apple-Silicon.app.tar.gz
             artifacts/shell-tauri-windows/Phase-Desktop-Windows-x64-Setup.exe
             artifacts/update.json
+            artifacts/shell-tauri-android/Phase-Android-ARM64.apk
+            artifacts/shell-tauri-android/Phase-Android-ARMv7.apk
 
       - uses: actions/setup-node@v4
         with:
@@ -688,22 +720,3 @@ jobs:
 
           echo "::error::Published updater manifest did not report shell v${SHELL_VERSION}"
           exit 1
-
-      - name: Download signed Android APKs
-        if: needs.build-android.outputs.apk_available == 'true'
-        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4
-        with:
-          name: shell-tauri-android
-          path: artifacts/shell-tauri-android
-
-      - name: Attach signed Android APKs
-        if: needs.build-android.outputs.apk_available == 'true'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          gh release upload "$SHELL_TAG" \
-            artifacts/shell-tauri-android/Phase-Android-ARM64.apk \
-            artifacts/shell-tauri-android/Phase-Android-ARMv7.apk \
-            --repo "$GITHUB_REPOSITORY" \
-            --clobber


### PR DESCRIPTION
Downloads and validates optional signed Android APKs before creating the immutable GitHub release, so all artifacts are attached atomically. Keeps required desktop assets strict and removes the invalid post-release upload.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Release Improvements**
  - Android ARM64 and ARMv7 APKs are now attached to releases when signing is configured.
  - Release validation now confirms that all required desktop assets and update metadata are present and non-empty.
  - Optional Android assets no longer prevent releases when they are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->