### PR TITLE
ship/draft reconnect continuity

### DIFF
--- a/client/src/adapter/__tests__/draftPodAdapter.test.ts
+++ b/client/src/adapter/__tests__/draftPodAdapter.test.ts
@@ -957,6 +957,22 @@ describe("DraftPodGuestAdapter", () => {
     expect(mockGuestLeave).toHaveBeenCalled();
   });
 
+  it("retains guest event ownership when an explicit leave is not acknowledged", async () => {
+    await adapter.initialize({ kind: "new", roomCode: "ABCDE", displayName: "Alice" });
+    const guestEventHandler = mockGuestOnEvent.mock.calls[0][0];
+    const guestEventUnsub = mockGuestOnEvent.mock.results[0]!.value as ReturnType<typeof vi.fn>;
+    mockGuestLeave.mockRejectedValueOnce(new Error("Draft host disconnected before acknowledging leave"));
+
+    await expect(adapter.dispose({ preserveRecovery: false })).rejects.toThrow("disconnected before acknowledging leave");
+    expect(guestEventUnsub).not.toHaveBeenCalled();
+
+    guestEventHandler({ type: "reconnecting", attempt: 1 });
+    expect(events).toContainEqual({ type: "reconnecting", attempt: 1 });
+
+    await adapter.dispose({ preserveRecovery: false });
+    expect(guestEventUnsub).toHaveBeenCalledOnce();
+  });
+
   it("locally disposes an explicitly exited guest after its recovery is revoked", async () => {
     await adapter.initialize({ kind: "new", roomCode: "ABCDE", displayName: "Alice" });
     const guestEventHandler = mockGuestOnEvent.mock.calls[0][0];

--- a/client/src/adapter/__tests__/draftPodAdapter.test.ts
+++ b/client/src/adapter/__tests__/draftPodAdapter.test.ts
@@ -95,6 +95,7 @@ const mockGuestSubmitDeck = vi.fn(async () => {});
 const mockGuestUpdateWorkspace = vi.fn(async () => {});
 const mockGuestLeave = vi.fn(async () => {});
 const mockGuestDispose = vi.fn();
+let mockGuestRecoveryRevoked = false;
 
 vi.mock("../p2p-draft-guest", () => ({
   P2PDraftGuest: vi.fn().mockImplementation(function () {
@@ -107,6 +108,7 @@ vi.mock("../p2p-draft-guest", () => ({
       updateWorkspace: mockGuestUpdateWorkspace,
       leave: mockGuestLeave,
       dispose: mockGuestDispose,
+      get isRecoveryRevoked() { return mockGuestRecoveryRevoked; },
       view: null,
       seat: null,
       token: null,
@@ -820,6 +822,7 @@ describe("DraftPodGuestAdapter", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    mockGuestRecoveryRevoked = false;
     const { joinRoom } = await import("../../network/connection");
     (joinRoom as ReturnType<typeof vi.fn>).mockResolvedValue(mockJoinResult());
 
@@ -952,6 +955,17 @@ describe("DraftPodGuestAdapter", () => {
     await adapter.initialize({ kind: "new", roomCode: "ABCDE", displayName: "Alice" });
     await adapter.dispose({ preserveRecovery: false });
     expect(mockGuestLeave).toHaveBeenCalled();
+  });
+
+  it("locally disposes an explicitly exited guest after its recovery is revoked", async () => {
+    await adapter.initialize({ kind: "new", roomCode: "ABCDE", displayName: "Alice" });
+    const guestEventHandler = mockGuestOnEvent.mock.calls[0][0];
+    mockGuestRecoveryRevoked = true;
+    guestEventHandler({ type: "hostLeft", reason: "Host left" });
+
+    await expect(adapter.dispose({ preserveRecovery: false })).resolves.toBeUndefined();
+    expect(mockGuestDispose).toHaveBeenCalled();
+    expect(mockGuestLeave).not.toHaveBeenCalled();
   });
 
   it("emits error on connection failure", async () => {

--- a/client/src/adapter/__tests__/p2pDraftGuestHandshake.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftGuestHandshake.test.ts
@@ -13,6 +13,7 @@ type SavedDeckSubmission = {
 const sessionState = vi.hoisted(() => ({
   sessions: [] as Array<{
     handler: ((message: unknown) => void) | null;
+    end: (() => void) | null;
     send: ReturnType<typeof vi.fn>;
     close: ReturnType<typeof vi.fn>;
   }>,
@@ -30,9 +31,10 @@ const persistenceState = vi.hoisted(() => ({
 }));
 
 vi.mock("../../network/draftPeerSession", () => ({
-  createDraftPeerSession: vi.fn(() => {
+  createDraftPeerSession: vi.fn((_connection: unknown, options: { onSessionEnd: () => void }) => {
     const session = {
       handler: null as ((message: unknown) => void) | null,
+      end: options.onSessionEnd,
       send: vi.fn(async () => {}),
       close: vi.fn(),
     };
@@ -405,6 +407,54 @@ describe("P2P draft guest handshake attempts", () => {
     await leave;
     expect(persistenceState.clearDraftGuestRecovery).toHaveBeenCalledWith("phase2-ABCDE");
     expect(persistenceState.clearDraftDeckSubmission).toHaveBeenCalledWith("phase2-ABCDE");
+  });
+
+  it("keeps a dropped leave acknowledgement recoverable and permits a later leave", async () => {
+    const events: unknown[] = [];
+    const guest = new P2PDraftGuest(
+      { destroy: vi.fn() } as never,
+      "phase2-ABCDE",
+      {} as never,
+      { kind: "new", roomCode: "ABCDE", displayName: "Alice" },
+    );
+    guest.onEvent((event) => events.push(event));
+    const privateGuest = guest as unknown as {
+      handshakeOn: (connection: unknown, signal: AbortSignal | undefined, reconnect: boolean) => Promise<void>;
+    };
+    const handshake = privateGuest.handshakeOn({} as never, undefined, false);
+    await Promise.resolve();
+    sessionState.sessions[0]!.handler!({
+      type: "draft_welcome", draftProtocolVersion: DRAFT_PROTOCOL_VERSION,
+      draftToken: "leave-token", seatIndex: 2, draftCode: "draft-xyz",
+      view: { status: "Lobby", draft_effects: [], seats: [] }, workspaceState: null,
+    });
+    await handshake;
+
+    const abandonedLeave = guest.leave();
+    await vi.waitFor(() => expect(sessionState.sessions[0]!.send).toHaveBeenCalledWith({
+      type: "draft_leave", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+    }));
+    sessionState.sessions[0]!.end!();
+
+    await expect(abandonedLeave).rejects.toThrow("disconnected before acknowledging leave");
+    expect(guest.token).toBe("leave-token");
+    expect(events).toContainEqual({ type: "reconnecting", attempt: 1 });
+    expect(persistenceState.clearDraftGuestRecovery).not.toHaveBeenCalled();
+
+    const reconnect = privateGuest.handshakeOn({} as never, undefined, true);
+    await Promise.resolve();
+    sessionState.sessions[1]!.handler!(reconnectAck);
+    await reconnect;
+
+    const laterLeave = guest.leave();
+    await vi.waitFor(() => expect(sessionState.sessions[1]!.send).toHaveBeenCalledWith({
+      type: "draft_leave", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+    }));
+    sessionState.sessions[1]!.handler!({
+      type: "draft_leave_ack", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+    });
+    await laterLeave;
+    expect(persistenceState.clearDraftGuestRecovery).toHaveBeenCalledWith("phase2-ABCDE");
   });
 
   it("clears recovery and the deck outbox when the host ends the draft", async () => {

--- a/client/src/adapter/__tests__/p2pDraftGuestHandshake.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftGuestHandshake.test.ts
@@ -484,6 +484,40 @@ describe("P2P draft guest handshake attempts", () => {
     await vi.waitFor(() => expect(guest.isRecoveryRevoked).toBe(true));
   });
 
+  it.each([
+    ["draft_kicked", { type: "draft_kicked", reason: "Removed from draft" }, { type: "kicked", reason: "Removed from draft" }],
+    ["draft_host_left", { type: "draft_host_left", reason: "Host left" }, { type: "hostLeft", reason: "Host left" }],
+  ])("settles a pending leave when the host sends %s", async (_messageType, message, terminalEvent) => {
+    const events: unknown[] = [];
+    const guest = new P2PDraftGuest(
+      {} as never,
+      "phase2-ABCDE",
+      {} as never,
+      { kind: "new", roomCode: "ABCDE", displayName: "Alice" },
+    );
+    guest.onEvent((event) => events.push(event));
+    const privateGuest = guest as unknown as {
+      handshakeOn: (connection: unknown, signal: AbortSignal | undefined, reconnect: boolean) => Promise<void>;
+    };
+    const handshake = privateGuest.handshakeOn({} as never, undefined, false);
+    await Promise.resolve();
+    sessionState.sessions[0]!.handler!({
+      type: "draft_welcome", draftProtocolVersion: DRAFT_PROTOCOL_VERSION,
+      draftToken: "leave-token", seatIndex: 2, draftCode: "draft-xyz",
+      view: { status: "Lobby", draft_effects: [], seats: [] }, workspaceState: null,
+    });
+    await handshake;
+
+    const leave = guest.leave();
+    await vi.waitFor(() => expect(sessionState.sessions[0]!.send).toHaveBeenCalledWith({
+      type: "draft_leave", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+    }));
+    sessionState.sessions[0]!.handler!(message);
+
+    await expect(leave).resolves.toBeUndefined();
+    expect(events).toContainEqual(terminalEvent);
+  });
+
   it("finishes terminal host handling when recovery cleanup fails", async () => {
     const events: unknown[] = [];
     const guest = new P2PDraftGuest(

--- a/client/src/adapter/__tests__/p2pDraftGuestHandshake.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftGuestHandshake.test.ts
@@ -484,6 +484,37 @@ describe("P2P draft guest handshake attempts", () => {
     await vi.waitFor(() => expect(guest.isRecoveryRevoked).toBe(true));
   });
 
+  it("finishes terminal host handling when recovery cleanup fails", async () => {
+    const events: unknown[] = [];
+    const guest = new P2PDraftGuest(
+      {} as never,
+      "phase2-ABCDE",
+      {} as never,
+      { kind: "new", roomCode: "ABCDE", displayName: "Alice" },
+    );
+    guest.onEvent((event) => events.push(event));
+    const privateGuest = guest as unknown as {
+      handshakeOn: (connection: unknown, signal: AbortSignal | undefined, reconnect: boolean) => Promise<void>;
+    };
+    const handshake = privateGuest.handshakeOn({} as never, undefined, false);
+    await Promise.resolve();
+    sessionState.sessions[0]!.handler!({
+      type: "draft_welcome", draftProtocolVersion: DRAFT_PROTOCOL_VERSION,
+      draftToken: "host-left-token", seatIndex: 2, draftCode: "draft-xyz",
+      view: { status: "Lobby", draft_effects: [], seats: [] }, workspaceState: null,
+    });
+    await handshake;
+    persistenceState.clearDraftGuestRecovery.mockRejectedValueOnce(new Error("storage unavailable"));
+    persistenceState.clearDraftDeckSubmission.mockRejectedValueOnce(new Error("outbox unavailable"));
+
+    sessionState.sessions[0]!.handler!({ type: "draft_host_left", reason: "Host left" });
+
+    await vi.waitFor(() => expect(guest.isRecoveryRevoked).toBe(true));
+    expect(events).toContainEqual({ type: "hostLeft", reason: "Host left" });
+    expect(persistenceState.clearDraftGuestRecovery).toHaveBeenCalledWith("phase2-ABCDE");
+    expect(persistenceState.clearDraftDeckSubmission).toHaveBeenCalledWith("phase2-ABCDE");
+  });
+
   it("waits for token persistence before completing a reconnect acknowledgement", async () => {
     sessionState.sessions.length = 0;
     persistenceState.saveActiveDraftGuest.mockClear();

--- a/client/src/adapter/__tests__/p2pDraftGuestHandshake.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftGuestHandshake.test.ts
@@ -373,6 +373,66 @@ describe("P2P draft guest handshake attempts", () => {
     });
   });
 
+  it("clears recovery and the deck outbox only after the host acknowledges leave", async () => {
+    const guest = new P2PDraftGuest(
+      { destroy: vi.fn() } as never,
+      "phase2-ABCDE",
+      {} as never,
+      { kind: "new", roomCode: "ABCDE", displayName: "Alice" },
+    );
+    const privateGuest = guest as unknown as {
+      handshakeOn: (connection: unknown, signal: AbortSignal | undefined, reconnect: boolean) => Promise<void>;
+    };
+    const handshake = privateGuest.handshakeOn({} as never, undefined, false);
+    await Promise.resolve();
+    sessionState.sessions[0]!.handler!({
+      type: "draft_welcome", draftProtocolVersion: DRAFT_PROTOCOL_VERSION,
+      draftToken: "leave-token", seatIndex: 2, draftCode: "draft-xyz",
+      view: { status: "Lobby", draft_effects: [], seats: [] }, workspaceState: null,
+    });
+    await handshake;
+
+    const leave = guest.leave();
+    await vi.waitFor(() => expect(sessionState.sessions[0]!.send).toHaveBeenCalledWith({
+      type: "draft_leave", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+    }));
+    expect(persistenceState.clearDraftGuestRecovery).not.toHaveBeenCalled();
+    expect(persistenceState.clearDraftDeckSubmission).not.toHaveBeenCalled();
+
+    sessionState.sessions[0]!.handler!({
+      type: "draft_leave_ack", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+    });
+    await leave;
+    expect(persistenceState.clearDraftGuestRecovery).toHaveBeenCalledWith("phase2-ABCDE");
+    expect(persistenceState.clearDraftDeckSubmission).toHaveBeenCalledWith("phase2-ABCDE");
+  });
+
+  it("clears recovery and the deck outbox when the host ends the draft", async () => {
+    const guest = new P2PDraftGuest(
+      {} as never,
+      "phase2-ABCDE",
+      {} as never,
+      { kind: "new", roomCode: "ABCDE", displayName: "Alice" },
+    );
+    const privateGuest = guest as unknown as {
+      handshakeOn: (connection: unknown, signal: AbortSignal | undefined, reconnect: boolean) => Promise<void>;
+    };
+    const handshake = privateGuest.handshakeOn({} as never, undefined, false);
+    await Promise.resolve();
+    sessionState.sessions[0]!.handler!({
+      type: "draft_welcome", draftProtocolVersion: DRAFT_PROTOCOL_VERSION,
+      draftToken: "host-left-token", seatIndex: 2, draftCode: "draft-xyz",
+      view: { status: "Lobby", draft_effects: [], seats: [] }, workspaceState: null,
+    });
+    await handshake;
+    persistenceState.clearDraftGuestRecovery.mockClear();
+    persistenceState.clearDraftDeckSubmission.mockClear();
+
+    sessionState.sessions[0]!.handler!({ type: "draft_host_left", reason: "Host left" });
+    await vi.waitFor(() => expect(persistenceState.clearDraftGuestRecovery).toHaveBeenCalledWith("phase2-ABCDE"));
+    expect(persistenceState.clearDraftDeckSubmission).toHaveBeenCalledWith("phase2-ABCDE");
+  });
+
   it("waits for token persistence before completing a reconnect acknowledgement", async () => {
     sessionState.sessions.length = 0;
     persistenceState.saveActiveDraftGuest.mockClear();

--- a/client/src/adapter/__tests__/p2pDraftGuestHandshake.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftGuestHandshake.test.ts
@@ -431,6 +431,7 @@ describe("P2P draft guest handshake attempts", () => {
     sessionState.sessions[0]!.handler!({ type: "draft_host_left", reason: "Host left" });
     await vi.waitFor(() => expect(persistenceState.clearDraftGuestRecovery).toHaveBeenCalledWith("phase2-ABCDE"));
     expect(persistenceState.clearDraftDeckSubmission).toHaveBeenCalledWith("phase2-ABCDE");
+    await vi.waitFor(() => expect(guest.isRecoveryRevoked).toBe(true));
   });
 
   it("waits for token persistence before completing a reconnect acknowledgement", async () => {

--- a/client/src/adapter/__tests__/p2pDraftHostBo3.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftHostBo3.test.ts
@@ -419,6 +419,63 @@ describe("P2PDraftHost Bo3", () => {
       ]);
     });
 
+    it("assigns a bot match settlement to the human even when the bot has the lower seat", async () => {
+      const botPairing = pairing("bot-12", 2, 1, 2);
+      const botView = {
+        current_round: 2,
+        seats: [
+          { seat_index: 1, is_bot: true },
+          { seat_index: 2, is_bot: false },
+        ],
+      } as DraftPlayerView;
+      const privateHost = host as unknown as {
+        adapter: { exportSession: () => Promise<string> };
+        botDeckForSeat: () => Promise<{ main_deck: string[]; sideboard: string[]; commander: string[] }>;
+        sendMatchLaunch: (seat: number, launch: DraftMatchLaunch) => Promise<void>;
+        dispatchMatchLaunch: (pairing: PairingView, view: DraftPlayerView) => Promise<void>;
+        matchBindings: Map<string, DraftMatchBinding>;
+      };
+      privateHost.adapter.exportSession = vi.fn(async () => JSON.stringify({
+        pools: [[], [], []],
+        submitted_decks: {
+          human: { seat: 2, main_deck: ["Plains"] },
+        },
+      }));
+      privateHost.botDeckForSeat = vi.fn(async () => ({ main_deck: ["Island"], sideboard: [], commander: [] }));
+      privateHost.sendMatchLaunch = vi.fn(async () => {});
+
+      await privateHost.dispatchMatchLaunch(botPairing, botView);
+
+      expect(privateHost.sendMatchLaunch).toHaveBeenCalledWith(2, expect.objectContaining({
+        type: "Bot",
+        binding: expect.objectContaining({ matchAuthoritySeat: 2 }),
+      }));
+      const issuedBinding = privateHost.matchBindings.get("bot-12")!;
+      setHostView({ current_round: 2, pairings: [botPairing] });
+      await deliverSettlement(2, issuedBinding);
+      expect(reportSpy).toHaveBeenCalledWith("bot-12", 1);
+    });
+
+    it("does not create a participant binding for a bot-only pairing", async () => {
+      const botPairing = pairing("bots-12", 2, 1, 2);
+      const botView = {
+        current_round: 2,
+        seats: [
+          { seat_index: 1, is_bot: true },
+          { seat_index: 2, is_bot: true },
+        ],
+      } as DraftPlayerView;
+      const privateHost = host as unknown as {
+        dispatchMatchLaunch: (pairing: PairingView, view: DraftPlayerView) => Promise<void>;
+        matchBindings: Map<string, DraftMatchBinding>;
+      };
+
+      await privateHost.dispatchMatchLaunch(botPairing, botView);
+
+      expect(privateHost.matchBindings.has("bots-12")).toBe(false);
+      expect(reportSpy).toHaveBeenCalledWith("bots-12", 1);
+    });
+
     it("rejects the raw result shape", async () => {
       await deliverRaw(1, "m-12", 1);
       expect(reportSpy).not.toHaveBeenCalled();

--- a/client/src/adapter/__tests__/p2pDraftHostPersistence.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftHostPersistence.test.ts
@@ -419,7 +419,7 @@ describe("P2PDraftHost persistence disposal", () => {
       seatNames: Map<number, string>;
       handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
     };
-    const session = { send: vi.fn(async () => {}), close: vi.fn() };
+    const session = { onDisconnect: vi.fn(() => vi.fn()), send: vi.fn(async () => {}), close: vi.fn() };
     privateHost.guestSessions.set(1, session);
     privateHost.seatTokens.set(1, "leave-token");
     privateHost.seatNames.set(1, "Guest");
@@ -448,7 +448,7 @@ describe("P2PDraftHost persistence disposal", () => {
       expiredDisconnectedSeats: Set<number>;
       handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
     };
-    const session = { send: vi.fn(async () => {}), close: vi.fn() };
+    const session = { onDisconnect: vi.fn(() => vi.fn()), send: vi.fn(async () => {}), close: vi.fn() };
     const workspace = { schemaVersion: 1, placements: {}, virtualBasics: [] };
     privateHost.draftStarted = true;
     privateHost.adapter.setSeatConnected = vi.fn(async () => {});
@@ -474,6 +474,109 @@ describe("P2PDraftHost persistence disposal", () => {
     expect(session.close).not.toHaveBeenCalled();
   });
 
+  it("opens reconnect grace when the guest closes during a failed leave save", async () => {
+    vi.useFakeTimers();
+    try {
+      const host = recoveredHost("Host");
+      const privateHost = host as unknown as {
+        adapter: { setSeatConnected: ReturnType<typeof vi.fn>; exportSession: ReturnType<typeof vi.fn> };
+        draftStarted: boolean;
+        paused: boolean;
+        guestSessions: Map<number, unknown>;
+        seatTokens: Map<number, string>;
+        seatNames: Map<number, string>;
+        perSeatWorkspaceSnapshots: Map<number, unknown>;
+        disconnectedSeats: Map<number, { deadlineAt: number }>;
+        reconnectDeadlines: Map<number, number>;
+        handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
+      };
+      let disconnect!: () => void;
+      const session = {
+        onDisconnect: vi.fn((handler: () => void) => {
+          disconnect = handler;
+          return vi.fn();
+        }),
+        send: vi.fn(async () => {}),
+        close: vi.fn(),
+      };
+      const workspace = { schemaVersion: 1, placements: {}, virtualBasics: [] };
+      privateHost.draftStarted = true;
+      privateHost.adapter.setSeatConnected = vi.fn(async () => {});
+      privateHost.adapter.exportSession = vi.fn(async () => "{\"status\":\"Drafting\"}");
+      privateHost.guestSessions.set(1, session);
+      privateHost.seatTokens.set(1, "leave-token");
+      privateHost.seatNames.set(1, "Guest");
+      privateHost.perSeatWorkspaceSnapshots.set(1, workspace);
+      saveDraftHostSession.mockImplementationOnce(() => {
+        disconnect();
+        return Promise.reject(new Error("IDB unavailable"));
+      });
+
+      await expect(privateHost.handleGuestMessage(1, {
+        type: "draft_leave", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+      }, session)).rejects.toThrow("IDB unavailable");
+
+      const deadlineAt = privateHost.disconnectedSeats.get(1)?.deadlineAt;
+      expect(deadlineAt).toBe(Date.now() + 60_000);
+      expect(privateHost.reconnectDeadlines.get(1)).toBe(deadlineAt);
+      expect(privateHost.guestSessions.has(1)).toBe(false);
+      expect(privateHost.seatTokens.get(1)).toBe("leave-token");
+      expect(privateHost.seatNames.get(1)).toBe("Guest");
+      expect(privateHost.perSeatWorkspaceSnapshots.get(1)).toBe(workspace);
+      expect(privateHost.adapter.setSeatConnected).toHaveBeenNthCalledWith(1, 1, false);
+      expect(privateHost.adapter.setSeatConnected).toHaveBeenNthCalledWith(2, 1, false);
+      expect(privateHost.paused).toBe(true);
+      expect(session.send).not.toHaveBeenCalled();
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("retains an existing reconnect deadline when a failed leave session closes", async () => {
+    vi.useFakeTimers();
+    try {
+      const host = recoveredHost("Host");
+      const privateHost = host as unknown as {
+        guestSessions: Map<number, unknown>;
+        seatTokens: Map<number, string>;
+        seatNames: Map<number, string>;
+        disconnectedSeats: Map<number, { deadlineAt: number }>;
+        reconnectDeadlines: Map<number, number>;
+        handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
+      };
+      let disconnect!: () => void;
+      const session = {
+        onDisconnect: vi.fn((handler: () => void) => {
+          disconnect = handler;
+          return vi.fn();
+        }),
+        send: vi.fn(async () => {}),
+        close: vi.fn(),
+      };
+      const existingDeadline = Date.now() + 15_000;
+      privateHost.guestSessions.set(1, session);
+      privateHost.seatTokens.set(1, "leave-token");
+      privateHost.seatNames.set(1, "Guest");
+      privateHost.reconnectDeadlines.set(1, existingDeadline);
+      saveDraftHostSession.mockImplementationOnce(() => {
+        disconnect();
+        return Promise.reject(new Error("IDB unavailable"));
+      });
+
+      await expect(privateHost.handleGuestMessage(1, {
+        type: "draft_leave", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+      }, session)).rejects.toThrow("IDB unavailable");
+
+      expect(privateHost.disconnectedSeats.get(1)?.deadlineAt).toBe(existingDeadline);
+      expect(privateHost.reconnectDeadlines.get(1)).toBe(existingDeadline);
+      expect(privateHost.guestSessions.has(1)).toBe(false);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("does not replay a rolled-back leave snapshot on the next save", async () => {
     const host = recoveredHost("Host");
     const privateHost = host as unknown as {
@@ -487,7 +590,7 @@ describe("P2PDraftHost persistence disposal", () => {
       persistSession: () => void;
       handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
     };
-    const session = { send: vi.fn(async () => {}), close: vi.fn() };
+    const session = { onDisconnect: vi.fn(() => vi.fn()), send: vi.fn(async () => {}), close: vi.fn() };
     privateHost.draftStarted = true;
     privateHost.adapter.setSeatConnected = vi.fn(async () => {});
     privateHost.adapter.exportSession = vi.fn(async () => "{\"status\":\"Drafting\"}");
@@ -514,7 +617,7 @@ describe("P2PDraftHost persistence disposal", () => {
     expect(saveDraftHostSession).toHaveBeenCalledTimes(2);
     expect(saveDraftHostSession).toHaveBeenLastCalledWith("shared-recovery", expect.objectContaining({
       seatTokens: { 1: "leave-token" },
-      seatNames: { 1: "Guest" },
+      seatNames: expect.objectContaining({ 1: "Guest" }),
       kickedTokens: [],
       expiredDisconnectedSeats: [],
     }));
@@ -531,7 +634,7 @@ describe("P2PDraftHost persistence disposal", () => {
       expiredDisconnectedSeats: Set<number>;
       handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
     };
-    const session = { send: vi.fn(async () => {}), close: vi.fn() };
+    const session = { onDisconnect: vi.fn(() => vi.fn()), send: vi.fn(async () => {}), close: vi.fn() };
     privateHost.draftStarted = true;
     privateHost.adapter.setSeatConnected = vi.fn()
       .mockRejectedValueOnce(new Error("disconnect rejected"))
@@ -563,7 +666,7 @@ describe("P2PDraftHost persistence disposal", () => {
       expiredDisconnectedSeats: Set<number>;
       handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
     };
-    const session = { send: vi.fn(async () => {}), close: vi.fn() };
+    const session = { onDisconnect: vi.fn(() => vi.fn()), send: vi.fn(async () => {}), close: vi.fn() };
     const events = vi.fn();
     host.onEvent(events);
     privateHost.draftStarted = true;
@@ -678,7 +781,7 @@ describe("P2PDraftHost persistence disposal", () => {
       handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
       isBotSeat: (seat: number) => boolean;
     };
-    const session = { send: vi.fn(async () => {}), close: vi.fn() };
+    const session = { onDisconnect: vi.fn(() => vi.fn()), send: vi.fn(async () => {}), close: vi.fn() };
     privateHost.draftStarted = true;
     privateHost.adapter.setSeatConnected = vi.fn(async () => {});
     privateHost.adapter.exportSession = vi.fn(async () => "{\"status\":\"Drafting\"}");

--- a/client/src/adapter/__tests__/p2pDraftHostPersistence.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftHostPersistence.test.ts
@@ -436,6 +436,93 @@ describe("P2PDraftHost persistence disposal", () => {
     expect(privateHost.seatNames.has(1)).toBe(false);
   });
 
+  it("restores a leave's live recovery state when its durability fence fails", async () => {
+    const host = recoveredHost("Host");
+    const privateHost = host as unknown as {
+      adapter: { setSeatConnected: ReturnType<typeof vi.fn>; exportSession: ReturnType<typeof vi.fn> };
+      draftStarted: boolean;
+      guestSessions: Map<number, unknown>;
+      seatTokens: Map<number, string>;
+      seatNames: Map<number, string>;
+      perSeatWorkspaceSnapshots: Map<number, unknown>;
+      expiredDisconnectedSeats: Set<number>;
+      handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
+    };
+    const session = { send: vi.fn(async () => {}), close: vi.fn() };
+    const workspace = { schemaVersion: 1, placements: {}, virtualBasics: [] };
+    privateHost.draftStarted = true;
+    privateHost.adapter.setSeatConnected = vi.fn(async () => {});
+    privateHost.adapter.exportSession = vi.fn(async () => "{\"status\":\"Drafting\"}");
+    privateHost.guestSessions.set(1, session);
+    privateHost.seatTokens.set(1, "leave-token");
+    privateHost.seatNames.set(1, "Guest");
+    privateHost.perSeatWorkspaceSnapshots.set(1, workspace);
+    saveDraftHostSession.mockRejectedValueOnce(new Error("IDB unavailable"));
+
+    await expect(privateHost.handleGuestMessage(1, {
+      type: "draft_leave", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+    }, session)).rejects.toThrow("IDB unavailable");
+
+    expect(privateHost.guestSessions.get(1)).toBe(session);
+    expect(privateHost.seatTokens.get(1)).toBe("leave-token");
+    expect(privateHost.seatNames.get(1)).toBe("Guest");
+    expect(privateHost.perSeatWorkspaceSnapshots.get(1)).toBe(workspace);
+    expect(privateHost.expiredDisconnectedSeats.has(1)).toBe(false);
+    expect(privateHost.adapter.setSeatConnected).toHaveBeenNthCalledWith(1, 1, false);
+    expect(privateHost.adapter.setSeatConnected).toHaveBeenNthCalledWith(2, 1, true);
+    expect(session.send).not.toHaveBeenCalled();
+    expect(session.close).not.toHaveBeenCalled();
+  });
+
+  it("does not extend a reconnect deadline across repeated reconnect drops", async () => {
+    vi.useFakeTimers();
+    try {
+      const host = recoveredHost("Host");
+      const privateHost = host as unknown as {
+        adapter: {
+          setSeatConnected: ReturnType<typeof vi.fn>;
+          exportSession: ReturnType<typeof vi.fn>;
+          getViewForSeat: ReturnType<typeof vi.fn>;
+        };
+        draftStarted: boolean;
+        guestSessions: Map<number, unknown>;
+        seatTokens: Map<number, string>;
+        disconnectedSeats: Map<number, { deadlineAt: number }>;
+        mutationQueue: Promise<void>;
+        handleGuestDisconnect: (seat: number) => void;
+        handleReconnect: (session: unknown, token: string) => Promise<void>;
+      };
+      const view = { status: "Drafting", pool: [], seats: [] };
+      privateHost.draftStarted = true;
+      privateHost.adapter.setSeatConnected = vi.fn(async () => {});
+      privateHost.adapter.exportSession = vi.fn(async () => "{\"status\":\"Drafting\"}");
+      privateHost.adapter.getViewForSeat = vi.fn(async () => view);
+      privateHost.seatTokens.set(1, "guest-token");
+      privateHost.guestSessions.set(1, { send: vi.fn(async () => {}), close: vi.fn() });
+
+      privateHost.handleGuestDisconnect(1);
+      await privateHost.mutationQueue;
+      const deadlineAt = privateHost.disconnectedSeats.get(1)?.deadlineAt;
+      expect(deadlineAt).toBeDefined();
+
+      const firstReconnect = { onMessage: vi.fn(), send: vi.fn(async () => {}), close: vi.fn() };
+      await privateHost.handleReconnect(firstReconnect, "guest-token");
+      await vi.advanceTimersByTimeAsync(5_000);
+      privateHost.handleGuestDisconnect(1);
+      expect(privateHost.disconnectedSeats.get(1)?.deadlineAt).toBe(deadlineAt);
+      await privateHost.mutationQueue;
+
+      const secondReconnect = { onMessage: vi.fn(), send: vi.fn(async () => {}), close: vi.fn() };
+      await privateHost.handleReconnect(secondReconnect, "guest-token");
+      await vi.advanceTimersByTimeAsync(5_000);
+      privateHost.handleGuestDisconnect(1);
+      expect(privateHost.disconnectedSeats.get(1)?.deadlineAt).toBe(deadlineAt);
+      await host.dispose();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("makes a stale prior session inert after the seat reconnects", async () => {
     const host = recoveredHost("Host");
     const privateHost = host as unknown as {

--- a/client/src/adapter/__tests__/p2pDraftHostPersistence.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftHostPersistence.test.ts
@@ -21,6 +21,7 @@ vi.mock("../../services/draftPersistence", () => ({
 }));
 
 import { P2PDraftHost } from "../p2p-draft-host";
+import { DRAFT_PROTOCOL_VERSION } from "../../network/draftProtocol";
 
 type PersistenceHost = {
   adapter: { exportSession: () => Promise<string> };
@@ -364,7 +365,7 @@ describe("P2PDraftHost persistence disposal", () => {
         adapter: { setSeatConnected: ReturnType<typeof vi.fn>; exportSession: ReturnType<typeof vi.fn> };
         draftStarted: boolean;
         seatTokens: Map<number, string>;
-        armRecoveredGuestGrace: () => void;
+        armRecoveredGuestGrace: (deadlines: Record<number, number>) => boolean;
         expiredDisconnectedSeats: Set<number>;
         disconnectedSeats: Map<number, unknown>;
       };
@@ -372,7 +373,7 @@ describe("P2PDraftHost persistence disposal", () => {
       privateHost.seatTokens.set(1, "guest-token");
       privateHost.adapter.setSeatConnected = vi.fn(async () => {});
       privateHost.adapter.exportSession = vi.fn(async () => "{\"status\":\"Drafting\"}");
-      privateHost.armRecoveredGuestGrace();
+      privateHost.armRecoveredGuestGrace({ 1: Date.now() + 5 * 60_000 });
 
       await vi.advanceTimersByTimeAsync(5 * 60_000);
       expect(privateHost.expiredDisconnectedSeats.has(1)).toBe(true);
@@ -408,6 +409,89 @@ describe("P2PDraftHost persistence disposal", () => {
     } finally {
       vi.useRealTimers();
     }
+  });
+
+  it("durably revokes a lobby seat before acknowledging its explicit leave", async () => {
+    const host = recoveredHost("Host");
+    const privateHost = host as unknown as {
+      guestSessions: Map<number, unknown>;
+      seatTokens: Map<number, string>;
+      seatNames: Map<number, string>;
+      handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
+    };
+    const session = { send: vi.fn(async () => {}), close: vi.fn() };
+    privateHost.guestSessions.set(1, session);
+    privateHost.seatTokens.set(1, "leave-token");
+    privateHost.seatNames.set(1, "Guest");
+
+    await privateHost.handleGuestMessage(1, {
+      type: "draft_leave", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+    }, session);
+
+    expect(saveDraftHostSession).toHaveBeenCalledBefore(session.send);
+    expect(session.send).toHaveBeenCalledWith({
+      type: "draft_leave_ack", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+    });
+    expect(privateHost.seatTokens.has(1)).toBe(false);
+    expect(privateHost.seatNames.has(1)).toBe(false);
+  });
+
+  it("makes a stale prior session inert after the seat reconnects", async () => {
+    const host = recoveredHost("Host");
+    const privateHost = host as unknown as {
+      guestSessions: Map<number, unknown>;
+      seatTokens: Map<number, string>;
+      handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
+    };
+    const current = { send: vi.fn(async () => {}), close: vi.fn() };
+    const stale = { send: vi.fn(async () => {}), close: vi.fn() };
+    privateHost.guestSessions.set(1, current);
+    privateHost.seatTokens.set(1, "leave-token");
+
+    await privateHost.handleGuestMessage(1, {
+      type: "draft_leave", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+    }, stale);
+
+    expect(privateHost.seatTokens.get(1)).toBe("leave-token");
+    expect(current.send).not.toHaveBeenCalled();
+  });
+
+  it("turns a post-start leave into a terminal paused human seat without a bot", async () => {
+    const host = recoveredHost("Host");
+    const privateHost = host as unknown as {
+      adapter: {
+        setSeatConnected: ReturnType<typeof vi.fn>;
+        exportSession: ReturnType<typeof vi.fn>;
+        getViewForSeat: ReturnType<typeof vi.fn>;
+      };
+      draftStarted: boolean;
+      guestSessions: Map<number, unknown>;
+      seatTokens: Map<number, string>;
+      seatNames: Map<number, string>;
+      expiredDisconnectedSeats: Set<number>;
+      paused: boolean;
+      handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
+      isBotSeat: (seat: number) => boolean;
+    };
+    const session = { send: vi.fn(async () => {}), close: vi.fn() };
+    privateHost.draftStarted = true;
+    privateHost.adapter.setSeatConnected = vi.fn(async () => {});
+    privateHost.adapter.exportSession = vi.fn(async () => "{\"status\":\"Drafting\"}");
+    privateHost.adapter.getViewForSeat = vi.fn(async () => ({ status: "Drafting", seats: [] }));
+    privateHost.guestSessions.set(1, session);
+    privateHost.seatTokens.set(1, "leave-token");
+    privateHost.seatNames.set(1, "Guest");
+
+    await privateHost.handleGuestMessage(1, {
+      type: "draft_leave", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+    }, session);
+
+    expect(privateHost.adapter.setSeatConnected).toHaveBeenCalledWith(1, false);
+    expect(privateHost.expiredDisconnectedSeats.has(1)).toBe(true);
+    expect(privateHost.seatTokens.has(1)).toBe(false);
+    expect(privateHost.seatNames.get(1)).toBe("Guest");
+    expect(privateHost.isBotSeat(1)).toBe(false);
+    expect(privateHost.paused).toBe(true);
   });
 
   it("commits a joining guest's token before welcome and preserves it for recovery", async () => {

--- a/client/src/adapter/__tests__/p2pDraftHostPersistence.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftHostPersistence.test.ts
@@ -142,6 +142,23 @@ describe("P2PDraftHost persistence disposal", () => {
     await host.dispose();
   });
 
+  it("refuses to start a lobby while a retained guest is reconnecting", async () => {
+    const host = recoveredHost("Host");
+    const privateHost = host as unknown as {
+      adapter: { createMultiplayerDraft: ReturnType<typeof vi.fn> };
+      disconnectedSeats: Map<number, { deadlineAt: number; timer: ReturnType<typeof setTimeout> | null }>;
+      draftStarted: boolean;
+    };
+    privateHost.adapter.createMultiplayerDraft = vi.fn(async () => {});
+    privateHost.disconnectedSeats.set(1, { deadlineAt: Date.now() + 60_000, timer: null });
+
+    await expect(host.startDraft()).rejects.toThrow("Cannot start draft while a player is reconnecting");
+
+    expect(privateHost.adapter.createMultiplayerDraft).not.toHaveBeenCalled();
+    expect(privateHost.draftStarted).toBe(false);
+    await host.dispose();
+  });
+
   it("persists a deck receipt before ack and treats its exact retry as idempotent", async () => {
     const host = recoveredHost("Host");
     const privateHost = host as unknown as {
@@ -527,6 +544,61 @@ describe("P2PDraftHost persistence disposal", () => {
       expect(privateHost.adapter.setSeatConnected).toHaveBeenNthCalledWith(2, 1, false);
       expect(privateHost.paused).toBe(true);
       expect(session.send).not.toHaveBeenCalled();
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("pauses a started draft when leave recovery's follow-up save also fails", async () => {
+    vi.useFakeTimers();
+    try {
+      const host = recoveredHost("Host");
+      const privateHost = host as unknown as {
+        adapter: { setSeatConnected: ReturnType<typeof vi.fn>; exportSession: ReturnType<typeof vi.fn> };
+        draftStarted: boolean;
+        paused: boolean;
+        guestSessions: Map<number, unknown>;
+        seatTokens: Map<number, string>;
+        seatNames: Map<number, string>;
+        perSeatWorkspaceSnapshots: Map<number, unknown>;
+        disconnectedSeats: Map<number, { deadlineAt: number }>;
+        handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
+      };
+      let disconnect!: () => void;
+      const session = {
+        onDisconnect: vi.fn((handler: () => void) => {
+          disconnect = handler;
+          return vi.fn();
+        }),
+        send: vi.fn(async () => {}),
+        close: vi.fn(),
+      };
+      privateHost.draftStarted = true;
+      privateHost.adapter.setSeatConnected = vi.fn(async () => {});
+      privateHost.adapter.exportSession = vi.fn(async () => "{\"status\":\"Drafting\"}");
+      privateHost.guestSessions.set(1, session);
+      privateHost.seatTokens.set(1, "leave-token");
+      privateHost.seatNames.set(1, "Guest");
+      privateHost.perSeatWorkspaceSnapshots.set(1, { schemaVersion: 1, placements: {}, virtualBasics: [] });
+      saveDraftHostSession
+        .mockImplementationOnce(() => {
+          disconnect();
+          return Promise.reject(new Error("IDB unavailable"));
+        })
+        .mockRejectedValueOnce(new Error("IDB still unavailable"));
+
+      await expect(privateHost.handleGuestMessage(1, {
+        type: "draft_leave", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+      }, session)).rejects.toThrow("IDB unavailable");
+
+      expect(privateHost.adapter.setSeatConnected).toHaveBeenNthCalledWith(1, 1, false);
+      expect(privateHost.adapter.setSeatConnected).toHaveBeenNthCalledWith(2, 1, false);
+      expect(privateHost.paused).toBe(true);
+      expect(privateHost.disconnectedSeats.has(1)).toBe(true);
+      expect(privateHost.guestSessions.has(1)).toBe(false);
+      expect(session.send).not.toHaveBeenCalled();
+      expect(session.close).not.toHaveBeenCalled();
     } finally {
       vi.clearAllTimers();
       vi.useRealTimers();

--- a/client/src/adapter/__tests__/p2pDraftHostPersistence.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftHostPersistence.test.ts
@@ -474,6 +474,124 @@ describe("P2PDraftHost persistence disposal", () => {
     expect(session.close).not.toHaveBeenCalled();
   });
 
+  it("does not replay a rolled-back leave snapshot on the next save", async () => {
+    const host = recoveredHost("Host");
+    const privateHost = host as unknown as {
+      adapter: { setSeatConnected: ReturnType<typeof vi.fn>; exportSession: ReturnType<typeof vi.fn> };
+      draftStarted: boolean;
+      guestSessions: Map<number, unknown>;
+      seatTokens: Map<number, string>;
+      seatNames: Map<number, string>;
+      expiredDisconnectedSeats: Set<number>;
+      persistQueue: Promise<void>;
+      persistSession: () => void;
+      handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
+    };
+    const session = { send: vi.fn(async () => {}), close: vi.fn() };
+    privateHost.draftStarted = true;
+    privateHost.adapter.setSeatConnected = vi.fn(async () => {});
+    privateHost.adapter.exportSession = vi.fn(async () => "{\"status\":\"Drafting\"}");
+    privateHost.guestSessions.set(1, session);
+    privateHost.seatTokens.set(1, "leave-token");
+    privateHost.seatNames.set(1, "Guest");
+    saveDraftHostSession.mockRejectedValueOnce(new Error("IDB unavailable"));
+
+    await expect(privateHost.handleGuestMessage(1, {
+      type: "draft_leave", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+    }, session)).rejects.toThrow("IDB unavailable");
+
+    expect(saveDraftHostSession).toHaveBeenCalledWith("shared-recovery", expect.objectContaining({
+      seatTokens: {},
+      kickedTokens: ["leave-token"],
+      expiredDisconnectedSeats: [1],
+    }));
+
+    privateHost.persistSession();
+    await privateHost.persistQueue;
+
+    // The failed leave was compensated, so the next durable snapshot must be
+    // the recovered pre-leave state, not a retry of the revoked capability.
+    expect(saveDraftHostSession).toHaveBeenCalledTimes(2);
+    expect(saveDraftHostSession).toHaveBeenLastCalledWith("shared-recovery", expect.objectContaining({
+      seatTokens: { 1: "leave-token" },
+      seatNames: { 1: "Guest" },
+      kickedTokens: [],
+      expiredDisconnectedSeats: [],
+    }));
+  });
+
+  it("compensates an engine disconnect rejection without revoking recovery", async () => {
+    const host = recoveredHost("Host");
+    const privateHost = host as unknown as {
+      adapter: { setSeatConnected: ReturnType<typeof vi.fn> };
+      draftStarted: boolean;
+      guestSessions: Map<number, unknown>;
+      seatTokens: Map<number, string>;
+      seatNames: Map<number, string>;
+      expiredDisconnectedSeats: Set<number>;
+      handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
+    };
+    const session = { send: vi.fn(async () => {}), close: vi.fn() };
+    privateHost.draftStarted = true;
+    privateHost.adapter.setSeatConnected = vi.fn()
+      .mockRejectedValueOnce(new Error("disconnect rejected"))
+      .mockResolvedValueOnce(undefined);
+    privateHost.guestSessions.set(1, session);
+    privateHost.seatTokens.set(1, "leave-token");
+    privateHost.seatNames.set(1, "Guest");
+
+    await expect(privateHost.handleGuestMessage(1, {
+      type: "draft_leave", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+    }, session)).rejects.toThrow("disconnect rejected");
+
+    expect(privateHost.adapter.setSeatConnected).toHaveBeenNthCalledWith(1, 1, false);
+    expect(privateHost.adapter.setSeatConnected).toHaveBeenNthCalledWith(2, 1, true);
+    expect(privateHost.guestSessions.get(1)).toBe(session);
+    expect(privateHost.seatTokens.get(1)).toBe("leave-token");
+    expect(privateHost.seatNames.get(1)).toBe("Guest");
+    expect(privateHost.expiredDisconnectedSeats.has(1)).toBe(false);
+  });
+
+  it("retains recovery state and reports a rejected engine rollback", async () => {
+    const host = recoveredHost("Host");
+    const privateHost = host as unknown as {
+      adapter: { setSeatConnected: ReturnType<typeof vi.fn>; exportSession: ReturnType<typeof vi.fn> };
+      draftStarted: boolean;
+      guestSessions: Map<number, unknown>;
+      seatTokens: Map<number, string>;
+      seatNames: Map<number, string>;
+      expiredDisconnectedSeats: Set<number>;
+      handleGuestMessage: (seat: number, message: unknown, session: unknown) => Promise<void>;
+    };
+    const session = { send: vi.fn(async () => {}), close: vi.fn() };
+    const events = vi.fn();
+    host.onEvent(events);
+    privateHost.draftStarted = true;
+    privateHost.adapter.setSeatConnected = vi.fn()
+      .mockResolvedValueOnce(undefined)
+      .mockRejectedValueOnce(new Error("reconnect rejected"));
+    privateHost.adapter.exportSession = vi.fn(async () => "{\"status\":\"Drafting\"}");
+    privateHost.guestSessions.set(1, session);
+    privateHost.seatTokens.set(1, "leave-token");
+    privateHost.seatNames.set(1, "Guest");
+    saveDraftHostSession.mockRejectedValueOnce(new Error("IDB unavailable"));
+
+    await expect(privateHost.handleGuestMessage(1, {
+      type: "draft_leave", draftProtocolVersion: DRAFT_PROTOCOL_VERSION, draftToken: "leave-token",
+    }, session)).rejects.toThrow("IDB unavailable");
+
+    expect(privateHost.adapter.setSeatConnected).toHaveBeenNthCalledWith(1, 1, false);
+    expect(privateHost.adapter.setSeatConnected).toHaveBeenNthCalledWith(2, 1, true);
+    expect(privateHost.guestSessions.get(1)).toBe(session);
+    expect(privateHost.seatTokens.get(1)).toBe("leave-token");
+    expect(privateHost.seatNames.get(1)).toBe("Guest");
+    expect(privateHost.expiredDisconnectedSeats.has(1)).toBe(false);
+    expect(events).toHaveBeenCalledWith({
+      type: "error",
+      message: "leave rollback connectivity failed: reconnect rejected",
+    });
+  });
+
   it("does not extend a reconnect deadline across repeated reconnect drops", async () => {
     vi.useFakeTimers();
     try {

--- a/client/src/adapter/__tests__/p2pDraftHostResume.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftHostResume.test.ts
@@ -16,6 +16,7 @@ vi.mock("../draft-adapter", async (importOriginal) => {
 import { P2PDraftHost } from "../p2p-draft-host";
 import { EMPTY_DRAFT_POOL_GROUPS } from "../draft-adapter";
 import type { DraftPlayerView, PairingView } from "../draft-adapter";
+import type { DraftMatchBinding } from "../../network/draftProtocol";
 import type { PersistedDraftHostSession } from "../../services/draftPersistence";
 
 function pairing(round: number, table: number): PairingView {
@@ -191,5 +192,53 @@ describe("P2PDraftHost.restoreFromPersisted — pairing-window recovery", () => 
 
     expect(adapter.importSession).toHaveBeenCalled();
     expect(adapter.generatePairings).not.toHaveBeenCalled();
+  });
+
+  it("rotates only an active legacy bot authority to its human participant", async () => {
+    const activePairing = {
+      ...pairing(1, 0),
+      match_id: "bot-active",
+      seat_a: 1,
+      name_a: "Bot",
+      seat_b: 2,
+      name_b: "Human",
+      status: "InProgress" as const,
+    };
+    const restoredView = viewFor("MatchInProgress", 1, [activePairing]);
+    restoredView.seats = [
+      { seat_index: 1, is_bot: true },
+      { seat_index: 2, is_bot: false },
+    ] as DraftPlayerView["seats"];
+    const { host } = makeHost(restoredView);
+    const legacyBinding: DraftMatchBinding = {
+      podId: "draft-12345678",
+      matchId: "bot-active",
+      round: 1,
+      sessionKey: "session",
+      lease: "lease",
+      nonce: "nonce",
+      revision: 0,
+      matchAuthoritySeat: 1,
+    };
+    const futureBinding: DraftMatchBinding = {
+      ...legacyBinding,
+      matchId: "future-match",
+      round: 2,
+      matchAuthoritySeat: 1,
+    };
+
+    await host.restoreFromPersisted({
+      ...persistedSession(),
+      matchBindings: [legacyBinding, futureBinding],
+    });
+
+    const bindings = (host as unknown as {
+      matchBindings: Map<string, DraftMatchBinding>;
+      dispatchMatchLaunch: ReturnType<typeof vi.fn>;
+    }).matchBindings;
+    expect(bindings.get("bot-active")).toEqual({ ...legacyBinding, matchAuthoritySeat: 2 });
+    expect(bindings.get("future-match")).toEqual(futureBinding);
+    expect((host as unknown as { dispatchMatchLaunch: ReturnType<typeof vi.fn> }).dispatchMatchLaunch)
+      .not.toHaveBeenCalled();
   });
 });

--- a/client/src/adapter/__tests__/p2pDraftWorkspacePersistence.test.ts
+++ b/client/src/adapter/__tests__/p2pDraftWorkspacePersistence.test.ts
@@ -640,6 +640,8 @@ describe("P2P draft workspace persistence", () => {
     await expect(acknowledgement.promise).resolves.toMatchObject({ workspaceState: null });
     expect(privateHost.perSeatWorkspaceSnapshots.has(1)).toBe(false);
     expect(privateHost.perSeatWorkspaceSnapshots.has(2)).toBe(true);
-    expect(privateHost.persistSessionStrict).toHaveBeenCalledTimes(2);
+    // The reconnect durably records the handoff before persisting removal of
+    // the corrupt workspace entry.
+    expect(privateHost.persistSessionStrict).toHaveBeenCalledTimes(3);
   });
 });

--- a/client/src/adapter/draftPodGuestAdapter.ts
+++ b/client/src/adapter/draftPodGuestAdapter.ts
@@ -471,10 +471,6 @@ export class DraftPodGuestAdapter {
    * explicit participant leave is allowed to revoke durable guest recovery.
    */
   async dispose({ preserveRecovery = true }: { preserveRecovery?: boolean } = {}): Promise<void> {
-    if (this.guestEventUnsub) {
-      this.guestEventUnsub();
-      this.guestEventUnsub = null;
-    }
     if (this.guest) {
       if (preserveRecovery) {
         this.guest.dispose();
@@ -486,6 +482,10 @@ export class DraftPodGuestAdapter {
         await this.guest.leave();
       }
       this.guest = null;
+    }
+    if (this.guestEventUnsub) {
+      this.guestEventUnsub();
+      this.guestEventUnsub = null;
     }
     if (this.joinResult) {
       this.joinResult.destroyPeer();

--- a/client/src/adapter/draftPodGuestAdapter.ts
+++ b/client/src/adapter/draftPodGuestAdapter.ts
@@ -478,6 +478,10 @@ export class DraftPodGuestAdapter {
     if (this.guest) {
       if (preserveRecovery) {
         this.guest.dispose();
+      } else if (this.guest.isRecoveryRevoked) {
+        // Terminal host events already removed the capability, so there is
+        // no live participant session left to acknowledge another leave.
+        this.guest.dispose();
       } else {
         await this.guest.leave();
       }

--- a/client/src/adapter/p2p-draft-guest.ts
+++ b/client/src/adapter/p2p-draft-guest.ts
@@ -300,7 +300,6 @@ export class P2PDraftGuest {
       if (this.leaveAcknowledgement?.session === session) {
         this.leaveAcknowledgement.reject(new Error("Draft host disconnected before acknowledging leave"));
         this.leaveAcknowledgement = null;
-        return;
       }
       this.handleHostDisconnect();
     }

--- a/client/src/adapter/p2p-draft-guest.ts
+++ b/client/src/adapter/p2p-draft-guest.ts
@@ -136,6 +136,13 @@ export class P2PDraftGuest {
   private draftCode: string | null = null;
   private seatIndex: number | null = null;
   private terminated = false;
+  /**
+   * A host may explicitly revoke the persisted capability (kick, terminal
+   * host shutdown, or an acknowledged leave).  This is intentionally
+   * narrower than `terminated`: a protocol mismatch is terminal for this
+   * transport attempt but should retain recovery for a refreshed client.
+   */
+  private recoveryRevoked = false;
   private currentView: DraftPlayerView | null = null;
   private handshake: DraftHandshake | null = null;
   private reconnecting = false;
@@ -528,8 +535,7 @@ export class P2PDraftGuest {
         this.rejectHandshake(session, new Error(msg.reason));
         if (msg.kind === "Kicked" || msg.kind === "UnknownToken") {
           this.terminated = true;
-          void clearDraftGuestRecovery(this.hostPeerId);
-          void clearDraftDeckSubmission(this.hostPeerId);
+          await this.revokeRecovery();
         } else if (msg.kind === "ProtocolMismatch") {
           // Refresh can restore compatibility, so retain credentials, but a
           // version mismatch cannot be repaired by transport retries.
@@ -591,8 +597,7 @@ export class P2PDraftGuest {
 
       case "draft_kicked": {
         this.terminated = true;
-        void clearDraftGuestRecovery(this.hostPeerId);
-        void clearDraftDeckSubmission(this.hostPeerId);
+        await this.revokeRecovery();
         this.failDeckSubmissionWaiters(msg.reason);
         this.emit({ type: "kicked", reason: msg.reason });
         break;
@@ -664,8 +669,7 @@ export class P2PDraftGuest {
 
       case "draft_host_left": {
         this.terminated = true;
-        await clearDraftGuestRecovery(this.hostPeerId);
-        await clearDraftDeckSubmission(this.hostPeerId);
+        await this.revokeRecovery();
         this.failDeckSubmissionWaiters(msg.reason);
         this.emit({ type: "hostLeft", reason: msg.reason });
         break;
@@ -808,8 +812,7 @@ export class P2PDraftGuest {
     }
 
     this.terminated = true;
-    await clearDraftGuestRecovery(this.hostPeerId);
-    await clearDraftDeckSubmission(this.hostPeerId);
+    await this.revokeRecovery();
     this.dispose();
     try {
       this.guestPeer.destroy();
@@ -828,6 +831,17 @@ export class P2PDraftGuest {
 
   get token(): string | null {
     return this.draftToken;
+  }
+
+  /** Whether the host has durably revoked this guest's reconnect capability. */
+  get isRecoveryRevoked(): boolean {
+    return this.recoveryRevoked;
+  }
+
+  private async revokeRecovery(): Promise<void> {
+    await clearDraftGuestRecovery(this.hostPeerId);
+    await clearDraftDeckSubmission(this.hostPeerId);
+    this.recoveryRevoked = true;
   }
 
   private async persistRecoveryIdentity(data: { draftToken: string; seatIndex: number; draftCode: string }): Promise<void> {

--- a/client/src/adapter/p2p-draft-guest.ts
+++ b/client/src/adapter/p2p-draft-guest.ts
@@ -548,14 +548,7 @@ export class P2PDraftGuest {
       }
 
       case "draft_leave_ack": {
-        const pending = this.leaveAcknowledgement;
-        if (
-          pending
-          && pending.session === session
-          && pending.draftToken === msg.draftToken
-        ) {
-          pending.resolve();
-        }
+        this.resolveLeaveAcknowledgement(session, msg.draftToken);
         break;
       }
 
@@ -596,6 +589,7 @@ export class P2PDraftGuest {
 
       case "draft_kicked": {
         this.terminated = true;
+        this.resolveLeaveAcknowledgement(session);
         await this.revokeRecovery();
         this.failDeckSubmissionWaiters(msg.reason);
         this.emit({ type: "kicked", reason: msg.reason });
@@ -668,6 +662,7 @@ export class P2PDraftGuest {
 
       case "draft_host_left": {
         this.terminated = true;
+        this.resolveLeaveAcknowledgement(session);
         await this.revokeRecovery();
         this.failDeckSubmissionWaiters(msg.reason);
         this.emit({ type: "hostLeft", reason: msg.reason });
@@ -816,6 +811,18 @@ export class P2PDraftGuest {
     try {
       this.guestPeer.destroy();
     } catch { /* best-effort */ }
+  }
+
+  private resolveLeaveAcknowledgement(session: DraftPeerSession, draftToken?: string): void {
+    const pending = this.leaveAcknowledgement;
+    if (
+      pending
+      && pending.session === session
+      && (!draftToken || pending.draftToken === draftToken)
+    ) {
+      this.leaveAcknowledgement = null;
+      pending.resolve();
+    }
   }
 
   // ── Accessors ──────────────────────────────────────────────────────

--- a/client/src/adapter/p2p-draft-guest.ts
+++ b/client/src/adapter/p2p-draft-guest.ts
@@ -103,6 +103,7 @@ type DraftGuestEventListener = (event: DraftGuestEvent) => void;
 const RECONNECT_BACKOFF_MS = [1_000, 2_000, 4_000, 8_000, 15_000, 30_000, 60_000];
 const RECONNECT_STEADY_STATE_MS = 60_000;
 const FIRST_CONTACT_TIMEOUT_MS = 10_000;
+const LEAVE_ACK_TIMEOUT_MS = 10_000;
 
 function reconnectFailureForRejection(
   kind: DraftReconnectRejectionKind,
@@ -145,6 +146,13 @@ export class P2PDraftGuest {
   >();
   /** Set synchronously so two UI clicks share one outbox command. */
   private pendingDeckSubmission: Promise<void> | null = null;
+  private pendingLeave: Promise<void> | null = null;
+  private leaveAcknowledgement: {
+    session: DraftPeerSession;
+    draftToken: string;
+    resolve: () => void;
+    reject: (error: Error) => void;
+  } | null = null;
 
   constructor(
     private readonly guestPeer: Peer,
@@ -282,6 +290,11 @@ export class P2PDraftGuest {
     if (this.handshake?.session === session) {
       this.rejectHandshake(session, new Error("Draft host disconnected before acknowledging"));
     } else {
+      if (this.leaveAcknowledgement?.session === session) {
+        this.leaveAcknowledgement.reject(new Error("Draft host disconnected before acknowledging leave"));
+        this.leaveAcknowledgement = null;
+        return;
+      }
       this.handleHostDisconnect();
     }
   }
@@ -529,6 +542,18 @@ export class P2PDraftGuest {
         break;
       }
 
+      case "draft_leave_ack": {
+        const pending = this.leaveAcknowledgement;
+        if (
+          pending
+          && pending.session === session
+          && pending.draftToken === msg.draftToken
+        ) {
+          pending.resolve();
+        }
+        break;
+      }
+
       case "draft_state_update": {
         this.currentView = msg.view;
         this.emit({ type: "viewUpdated", view: msg.view });
@@ -639,6 +664,8 @@ export class P2PDraftGuest {
 
       case "draft_host_left": {
         this.terminated = true;
+        await clearDraftGuestRecovery(this.hostPeerId);
+        await clearDraftDeckSubmission(this.hostPeerId);
         this.failDeckSubmissionWaiters(msg.reason);
         this.emit({ type: "hostLeft", reason: msg.reason });
         break;
@@ -704,7 +731,7 @@ export class P2PDraftGuest {
   // ── Disconnect / Reconnect ─────────────────────────────────────────
 
   private handleHostDisconnect(): void {
-    if (this.terminated || this.reconnecting || !this.draftToken) return;
+    if (this.terminated || this.reconnecting || this.leaveAcknowledgement || !this.draftToken) return;
     this.reconnecting = true;
     void this.attemptReconnect(0);
   }
@@ -743,7 +770,43 @@ export class P2PDraftGuest {
     this.listeners = [];
   }
 
-  async leave(): Promise<void> {
+  leave(): Promise<void> {
+    if (this.pendingLeave) return this.pendingLeave;
+    const leave = this.leaveInner();
+    this.pendingLeave = leave;
+    void leave.finally(() => {
+      if (this.pendingLeave === leave) this.pendingLeave = null;
+    }).catch(() => undefined);
+    return leave;
+  }
+
+  private async leaveInner(): Promise<void> {
+    const session = this.session;
+    const draftToken = this.draftToken;
+    if (!session || !draftToken) throw new Error("Draft leave requires an active session");
+
+    const acknowledgement = new Promise<void>((resolve, reject) => {
+      this.leaveAcknowledgement = { session, draftToken, resolve, reject };
+    });
+    const timeout = setTimeout(() => {
+      if (this.leaveAcknowledgement?.session === session) {
+        this.leaveAcknowledgement.reject(new Error("Draft host did not acknowledge leave"));
+        this.leaveAcknowledgement = null;
+      }
+    }, LEAVE_ACK_TIMEOUT_MS);
+
+    try {
+      await session.send({
+        type: "draft_leave",
+        draftProtocolVersion: DRAFT_PROTOCOL_VERSION,
+        draftToken,
+      });
+      await acknowledgement;
+    } finally {
+      clearTimeout(timeout);
+      if (this.leaveAcknowledgement?.session === session) this.leaveAcknowledgement = null;
+    }
+
     this.terminated = true;
     await clearDraftGuestRecovery(this.hostPeerId);
     await clearDraftDeckSubmission(this.hostPeerId);

--- a/client/src/adapter/p2p-draft-guest.ts
+++ b/client/src/adapter/p2p-draft-guest.ts
@@ -838,8 +838,10 @@ export class P2PDraftGuest {
   }
 
   private async revokeRecovery(): Promise<void> {
-    await clearDraftGuestRecovery(this.hostPeerId);
-    await clearDraftDeckSubmission(this.hostPeerId);
+    await Promise.allSettled([
+      clearDraftGuestRecovery(this.hostPeerId),
+      clearDraftDeckSubmission(this.hostPeerId),
+    ]);
     this.recoveryRevoked = true;
   }
 

--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -1368,27 +1368,35 @@ export class P2PDraftHost {
     const wasKicked = this.kickedTokens.has(draftToken);
     const wasExpired = this.expiredDisconnectedSeats.has(seat);
 
-    this.guestSessions.delete(seat);
-    this.clearReconnectGrace(seat);
-    this.reconnectDeadlines.delete(seat);
-    this.perSeatWorkspaceSnapshots.delete(seat);
-
-    if (!this.draftStarted) {
-      this.seatTokens.delete(seat);
-      this.seatNames.delete(seat);
-    } else {
-      this.kickedTokens.add(draftToken);
-      this.seatTokens.delete(seat);
-      this.expiredDisconnectedSeats.add(seat);
-      await this.adapter.setSeatConnected(seat, false);
-    }
-
+    let attemptedDisconnect = false;
     try {
-      await this.persistSessionStrict();
+      this.guestSessions.delete(seat);
+      this.clearReconnectGrace(seat);
+      this.reconnectDeadlines.delete(seat);
+      this.perSeatWorkspaceSnapshots.delete(seat);
+
+      if (!this.draftStarted) {
+        this.seatTokens.delete(seat);
+        this.seatNames.delete(seat);
+      } else {
+        this.kickedTokens.add(draftToken);
+        this.seatTokens.delete(seat);
+        this.expiredDisconnectedSeats.add(seat);
+        // A rejected adapter call can still have changed the engine. Treat the
+        // attempted transition as needing compensation either way.
+        attemptedDisconnect = true;
+        await this.adapter.setSeatConnected(seat, false);
+      }
+
+      // Leave is a compensating transaction: unlike a reducer command, its
+      // failed snapshot must never be retained and replayed after this branch
+      // restores the participant's recovery capability.
+      await this.persistSessionStrict({ retainFailedDraftSnapshot: false });
     } catch (error) {
-      // A failed strict write leaves the prior durable session authoritative.
-      // Restore its complete in-memory counterpart before returning without an
-      // acknowledgement, so the existing recovery capability stays usable.
+      // A failed leave transition leaves the prior durable session
+      // authoritative. Restore its complete in-memory counterpart before
+      // returning without an acknowledgement, so the existing recovery
+      // capability stays usable.
       this.guestSessions.set(seat, session);
       if (priorGraceDeadline !== undefined) this.scheduleReconnectGrace(seat, priorGraceDeadline);
       else if (priorReconnectDeadline !== undefined) this.reconnectDeadlines.set(seat, priorReconnectDeadline);
@@ -1399,7 +1407,18 @@ export class P2PDraftHost {
       else this.kickedTokens.delete(draftToken);
       if (wasExpired) this.expiredDisconnectedSeats.add(seat);
       else this.expiredDisconnectedSeats.delete(seat);
-      if (this.draftStarted) await this.adapter.setSeatConnected(seat, true);
+      if (this.draftStarted && attemptedDisconnect) {
+        try {
+          await this.adapter.setSeatConnected(seat, true);
+        } catch (rollbackError) {
+          // The durable state and every local recovery record have already
+          // been restored. Surface the adapter failure without sacrificing the
+          // participant's capability by letting rollback abort halfway through.
+          const message = rollbackError instanceof Error ? rollbackError.message : String(rollbackError);
+          console.error("[P2PDraftHost] leave rollback connectivity failed:", rollbackError);
+          this.emit({ type: "error", message: `leave rollback connectivity failed: ${message}` });
+        }
+      }
       throw error;
     }
     await session.send({
@@ -2567,20 +2586,30 @@ export class P2PDraftHost {
     void this.enqueuePersistSession(snapshot).catch(() => {});
   }
 
-  /** Admission callers await this fence before issuing a recoverable token. */
-  private persistSessionStrict(): Promise<void> {
+  /**
+   * Callers await this fence before making a recovery capability externally
+   * visible. A caller that fully compensates its mutation can opt out of
+   * retaining its failed engine snapshot for replay.
+   */
+  private persistSessionStrict(
+    options: { retainFailedDraftSnapshot?: boolean } = {},
+  ): Promise<void> {
     if (!this.persistenceId || this.persistenceClosed) return Promise.resolve();
     return this.enqueuePersistSession(
       this.draftStarted ? undefined : this.buildPersistedSnapshot(null),
+      options.retainFailedDraftSnapshot,
     );
   }
 
   /**
    * Serializes snapshots while retaining a live queue after a failed write.
-   * Fire-and-forget mutations report errors through `persistSession`; admission
-   * awaits the returned task and rolls its mutation back on failure.
+   * Fire-and-forget mutations report errors through `persistSession`; callers
+   * that await the returned task may roll their mutation back on failure.
    */
-  private enqueuePersistSession(snapshotAtMutation?: PersistedDraftHostSession): Promise<void> {
+  private enqueuePersistSession(
+    snapshotAtMutation?: PersistedDraftHostSession,
+    retainFailedDraftSnapshot = true,
+  ): Promise<void> {
     if (!this.persistenceId || this.persistenceClosed) return Promise.resolve();
     const persist = this.persistQueue.then(async () => {
       if (this.persistenceClosed) return;
@@ -2601,7 +2630,7 @@ export class P2PDraftHost {
       } catch (error) {
         // Admission has its own transactional rollback.  Only an engine-backed
         // snapshot represents a reducer result that must be replayed exactly.
-        if (this.draftStarted) this.pendingDraftSnapshot = snapshot;
+        if (this.draftStarted && retainFailedDraftSnapshot) this.pendingDraftSnapshot = snapshot;
         throw error;
       }
 

--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -313,7 +313,7 @@ export class P2PDraftHost {
   private kickedTokens = new Set<string>();
   private disconnectedSeats = new Map<
     number,
-    { disconnectedAt: number; timer: ReturnType<typeof setTimeout> | null }
+    { deadlineAt: number; timer: ReturnType<typeof setTimeout> | null }
   >();
   private expiredDisconnectedSeats = new Set<number>();
   private picksThisRound = new Set<number>();
@@ -679,6 +679,7 @@ export class P2PDraftHost {
     }
 
     const reconnectSeat = seat;
+    let reconnectDeadlineAt: number | null = null;
     let live = true;
     const stopWatching = session.onDisconnect?.(() => { live = false; }) ?? (() => {});
     try {
@@ -704,12 +705,17 @@ export class P2PDraftHost {
         await this.rejectAndClose(session, "NoReconnectWindow", "Reconnect window expired", "Reconnect window expired");
         return;
       }
-      if (grace.timer !== null) clearTimeout(grace.timer);
-      this.disconnectedSeats.delete(reconnectSeat);
+      reconnectDeadlineAt = grace.deadlineAt;
+      this.clearReconnectGrace(reconnectSeat);
       this.guestSessions.set(reconnectSeat, session);
       session.onMessage((msg) => {
         this.runDetachedMutation("guest message", () => this.handleGuestMessage(reconnectSeat, msg, session));
       });
+
+      // The prior fence makes the engine's connected bitmap recoverable while
+      // this reconnect is tentative. This fence records the completed handoff:
+      // a later host recovery must not resurrect the old grace deadline.
+      await this.persistSessionStrict();
 
       const view = this.draftStarted
         ? await this.adapter.getViewForSeat(reconnectSeat)
@@ -739,11 +745,12 @@ export class P2PDraftHost {
       if (this.draftStarted) {
         try { await this.adapter.setSeatConnected(reconnectSeat, false); } catch { /* best-effort rollback */ }
       }
-      if (!this.disconnectedSeats.has(reconnectSeat)) {
-        const timer = setTimeout(() => {
-          this.runDetachedMutation("reconnect grace expiry", () => this.expireReconnectGrace(reconnectSeat));
-        }, this.gracePeriodMs);
-        this.disconnectedSeats.set(reconnectSeat, { disconnectedAt: Date.now(), timer });
+      if (!this.disconnectedSeats.has(reconnectSeat) && reconnectDeadlineAt !== null) {
+        if (reconnectDeadlineAt > Date.now()) {
+          this.scheduleReconnectGrace(reconnectSeat, reconnectDeadlineAt);
+        } else {
+          this.expiredDisconnectedSeats.add(reconnectSeat);
+        }
       }
       try {
         await this.persistSessionStrict();
@@ -780,7 +787,14 @@ export class P2PDraftHost {
     msg: DraftP2PMessage,
     originatingSession = this.guestSessions.get(seat),
   ): Promise<void> {
+    // A queued message from a replaced DataChannel must never act on the seat
+    // its successor now owns.
+    if (originatingSession && this.guestSessions.get(seat) !== originatingSession) return;
     switch (msg.type) {
+      case "draft_leave": {
+        await this.handleGuestLeave(seat, msg.draftToken, originatingSession);
+        break;
+      }
       case "draft_pick": {
         if (!this.canGuestPick(seat)) return;
         await this.handlePick(seat, msg.cardInstanceIds);
@@ -1325,39 +1339,85 @@ export class P2PDraftHost {
 
   // ── Disconnect / Reconnect ─────────────────────────────────────────
 
+  /**
+   * A participant's explicit exit revokes the capability rather than opening
+   * reconnect grace. Its acknowledgement is deliberately after the durable
+   * mutation, so a guest never drops its recovery state for a leave the host
+   * could lose on refresh.
+   */
+  private async handleGuestLeave(
+    seat: number,
+    draftToken: string,
+    originatingSession?: DraftPeerSession,
+  ): Promise<void> {
+    const session = this.guestSessions.get(seat);
+    if (!session || session !== originatingSession || this.seatTokens.get(seat) !== draftToken) return;
+
+    this.guestSessions.delete(seat);
+    this.clearReconnectGrace(seat);
+    this.perSeatWorkspaceSnapshots.delete(seat);
+
+    if (!this.draftStarted) {
+      this.seatTokens.delete(seat);
+      this.seatNames.delete(seat);
+    } else {
+      this.kickedTokens.add(draftToken);
+      this.seatTokens.delete(seat);
+      this.expiredDisconnectedSeats.add(seat);
+      await this.adapter.setSeatConnected(seat, false);
+    }
+
+    await this.persistSessionStrict();
+    await session.send({
+      type: "draft_leave_ack",
+      draftProtocolVersion: DRAFT_PROTOCOL_VERSION,
+      draftToken,
+    });
+    session.close("Participant left draft");
+
+    if (this.draftStarted) {
+      await this.broadcastViews();
+      this.reconcileEffectivePause();
+    } else {
+      this.syncLobbyToGuests();
+    }
+    this.emit({ type: "seatDisconnected", seatIndex: seat });
+  }
+
   private handleGuestDisconnect(seat: number): void {
     if (!this.guestSessions.has(seat)) return;
     if (this.disconnectedSeats.has(seat)) return;
 
     this.guestSessions.delete(seat);
 
-    if (!this.draftStarted) {
-      // Pre-draft disconnect: free the seat
-      this.seatTokens.delete(seat);
-      this.seatNames.delete(seat);
-      this.runDetachedMutation("pre-draft disconnect", async () => {
-        await this.persistSessionStrict();
-        this.syncLobbyToGuests();
-        this.emit({ type: "seatDisconnected", seatIndex: seat });
-      });
-      return;
-    }
-
-    // Mid-draft disconnect: grace window
-    const timer = setTimeout(() => {
-      this.runDetachedMutation("reconnect grace expiry", () => this.expireReconnectGrace(seat));
-    }, this.gracePeriodMs);
-
-    this.disconnectedSeats.set(seat, { disconnectedAt: Date.now(), timer });
+    this.scheduleReconnectGrace(seat, Date.now() + this.gracePeriodMs);
     // The socket callback is synchronous, but all externally visible state
     // follows the one durable queue: connected bitmap → snapshot → views/pause.
     this.runDetachedMutation("guest disconnect", async () => {
-      await this.adapter.setSeatConnected(seat, false);
+      if (this.draftStarted) await this.adapter.setSeatConnected(seat, false);
       await this.persistSessionStrict();
-      await this.broadcastViews();
-      this.reconcileEffectivePause();
+      if (this.draftStarted) {
+        await this.broadcastViews();
+        this.reconcileEffectivePause();
+      } else {
+        this.syncLobbyToGuests();
+      }
       this.emit({ type: "seatDisconnected", seatIndex: seat });
     });
+  }
+
+  private scheduleReconnectGrace(seat: number, deadlineAt: number): void {
+    const remainingMs = Math.max(0, deadlineAt - Date.now());
+    const timer = setTimeout(() => {
+      this.runDetachedMutation("reconnect grace expiry", () => this.expireReconnectGrace(seat));
+    }, remainingMs);
+    this.disconnectedSeats.set(seat, { deadlineAt, timer });
+  }
+
+  private clearReconnectGrace(seat: number): void {
+    const grace = this.disconnectedSeats.get(seat);
+    if (grace?.timer !== null && grace?.timer !== undefined) clearTimeout(grace.timer);
+    this.disconnectedSeats.delete(seat);
   }
 
   /**
@@ -1394,8 +1454,18 @@ export class P2PDraftHost {
   private async expireReconnectGrace(seat: number): Promise<void> {
     // Grace expiry remains an effective pause: a missing player cannot
     // silently resume the pod just because their reconnect window ended.
-    if (!this.disconnectedSeats.delete(seat)) return;
-    if (this.draftStarted) await this.adapter.setSeatConnected(seat, false);
+    if (!this.disconnectedSeats.has(seat)) return;
+    this.clearReconnectGrace(seat);
+    if (!this.draftStarted) {
+      this.seatTokens.delete(seat);
+      this.seatNames.delete(seat);
+      this.perSeatWorkspaceSnapshots.delete(seat);
+      await this.persistSessionStrict();
+      this.syncLobbyToGuests();
+      this.emit({ type: "seatDisconnected", seatIndex: seat });
+      return;
+    }
+    await this.adapter.setSeatConnected(seat, false);
     this.expiredDisconnectedSeats.add(seat);
     await this.persistSessionStrict();
     this.broadcastToGuests({
@@ -2001,8 +2071,7 @@ export class P2PDraftHost {
       const seed = this.draftSeed ?? hashStringToSeed(this.draftCode || this.roomCode || "draft");
       await this.adapter.replaceSeatWithBot(seat, this.botNameForSeat(seat, seed));
       const grace = this.disconnectedSeats.get(seat);
-      if (grace && grace.timer !== null) clearTimeout(grace.timer);
-      this.disconnectedSeats.delete(seat);
+      if (grace) this.clearReconnectGrace(seat);
       this.expiredDisconnectedSeats.delete(seat);
       this.seatTokens.delete(seat);
       this.seatNames.delete(seat);
@@ -2415,10 +2484,7 @@ export class P2PDraftHost {
 
     // Cancel grace timer if active
     const grace = this.disconnectedSeats.get(seat);
-    if (grace) {
-      if (grace.timer !== null) clearTimeout(grace.timer);
-      this.disconnectedSeats.delete(seat);
-    }
+    if (grace) this.clearReconnectGrace(seat);
     this.expiredDisconnectedSeats.delete(seat);
 
     await this.persistSessionStrict();
@@ -2523,6 +2589,9 @@ export class P2PDraftHost {
       seatTokens: Object.fromEntries(this.seatTokens),
       seatNames: Object.fromEntries(this.seatNames),
       kickedTokens: [...this.kickedTokens],
+      reconnectDeadlines: Object.fromEntries(
+        [...this.disconnectedSeats.entries()].map(([seat, grace]) => [seat, grace.deadlineAt]),
+      ),
       expiredDisconnectedSeats: [...this.expiredDisconnectedSeats],
       draftStarted: this.draftStarted,
       manualPause: this.manualPause,
@@ -2658,10 +2727,19 @@ export class P2PDraftHost {
       this.rememberMatchDecks(recoveredLaunch);
     }
 
-    this.armRecoveredGuestGrace();
+    const recoveryStateChanged = this.armRecoveredGuestGrace(session.reconnectDeadlines);
+    if (recoveryStateChanged) {
+      // Persist the recovery transition from the original engine snapshot
+      // before importing it. A second host crash during import therefore sees
+      // this same absolute deadline rather than granting a fresh window.
+      await this.enqueuePersistSession(this.buildPersistedSnapshot(session.draftSessionJson));
+    }
 
     if (session.draftSessionJson) {
       const view = await this.adapter.importSession(session.draftSessionJson, 2);
+      for (const seat of this.expiredDisconnectedSeats) {
+        await this.adapter.setSeatConnected(seat, false);
+      }
       if (this.reconcileRetainedWorkspace(0, view.pool).changed) this.persistSession();
       await this.recoverSettlementOutbox(view);
 
@@ -2696,15 +2774,46 @@ export class P2PDraftHost {
     return null;
   }
 
-  /** Restored guests get the same bounded reconnect window in lobby or draft. */
-  private armRecoveredGuestGrace(): void {
-    for (const seat of this.seatTokens.keys()) {
-      if (seat === 0 || this.disconnectedSeats.has(seat) || this.expiredDisconnectedSeats.has(seat)) continue;
-      const timer = setTimeout(() => {
-        this.runDetachedMutation("recovered reconnect grace expiry", () => this.expireReconnectGrace(seat));
-      }, 5 * 60_000);
-      this.disconnectedSeats.set(seat, { disconnectedAt: Date.now(), timer });
+  /**
+   * A recovered host is the first observer that knows its peers are gone. It
+   * persists that absolute deadline before serving recovery, so another host
+   * recovery cannot reset the grace clock. Snapshots from before this field
+   * existed fail closed rather than guessing how much grace remained.
+   */
+  private armRecoveredGuestGrace(reconnectDeadlines: Record<number, number> | undefined): boolean {
+    let changed = false;
+    const now = Date.now();
+    for (const seat of [...this.seatTokens.keys()]) {
+      if (seat === 0 || this.expiredDisconnectedSeats.has(seat)) continue;
+      if (reconnectDeadlines === undefined) {
+        if (this.draftStarted) {
+          this.expiredDisconnectedSeats.add(seat);
+        } else {
+          this.seatTokens.delete(seat);
+          this.seatNames.delete(seat);
+          this.perSeatWorkspaceSnapshots.delete(seat);
+        }
+        changed = true;
+        continue;
+      }
+
+      const deadlineAt = reconnectDeadlines[seat] ?? now + this.gracePeriodMs;
+      if (deadlineAt <= now) {
+        if (this.draftStarted) {
+          this.expiredDisconnectedSeats.add(seat);
+        } else {
+          this.seatTokens.delete(seat);
+          this.seatNames.delete(seat);
+          this.perSeatWorkspaceSnapshots.delete(seat);
+        }
+        changed = true;
+        continue;
+      }
+
+      this.scheduleReconnectGrace(seat, deadlineAt);
+      if (reconnectDeadlines[seat] === undefined) changed = true;
     }
+    return changed;
   }
 
   /** Replays only write-ahead settlements that the restored draft still lacks. */

--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -1367,6 +1367,12 @@ export class P2PDraftHost {
     const priorName = this.seatNames.get(seat);
     const wasKicked = this.kickedTokens.has(draftToken);
     const wasExpired = this.expiredDisconnectedSeats.has(seat);
+    let sessionEnded = false;
+    let sessionEndedAt: number | null = null;
+    const stopWatchingSession = session.onDisconnect(() => {
+      sessionEnded = true;
+      sessionEndedAt = Date.now();
+    });
 
     let attemptedDisconnect = false;
     try {
@@ -1397,9 +1403,17 @@ export class P2PDraftHost {
       // authoritative. Restore its complete in-memory counterpart before
       // returning without an acknowledgement, so the existing recovery
       // capability stays usable.
-      this.guestSessions.set(seat, session);
-      if (priorGraceDeadline !== undefined) this.scheduleReconnectGrace(seat, priorGraceDeadline);
-      else if (priorReconnectDeadline !== undefined) this.reconnectDeadlines.set(seat, priorReconnectDeadline);
+      if (!sessionEnded) this.guestSessions.set(seat, session);
+      const reconnectDeadline = priorGraceDeadline
+        ?? priorReconnectDeadline
+        ?? (sessionEndedAt === null ? undefined : sessionEndedAt + this.gracePeriodMs);
+      if (sessionEnded && reconnectDeadline !== undefined) {
+        this.scheduleReconnectGrace(seat, reconnectDeadline);
+      } else if (priorGraceDeadline !== undefined) {
+        this.scheduleReconnectGrace(seat, priorGraceDeadline);
+      } else if (priorReconnectDeadline !== undefined) {
+        this.reconnectDeadlines.set(seat, priorReconnectDeadline);
+      }
       if (priorWorkspace !== undefined) this.perSeatWorkspaceSnapshots.set(seat, priorWorkspace);
       if (priorToken !== undefined) this.seatTokens.set(seat, priorToken);
       if (priorName !== undefined) this.seatNames.set(seat, priorName);
@@ -1407,7 +1421,7 @@ export class P2PDraftHost {
       else this.kickedTokens.delete(draftToken);
       if (wasExpired) this.expiredDisconnectedSeats.add(seat);
       else this.expiredDisconnectedSeats.delete(seat);
-      if (this.draftStarted && attemptedDisconnect) {
+      if (this.draftStarted && attemptedDisconnect && !sessionEnded) {
         try {
           await this.adapter.setSeatConnected(seat, true);
         } catch (rollbackError) {
@@ -1419,7 +1433,28 @@ export class P2PDraftHost {
           this.emit({ type: "error", message: `leave rollback connectivity failed: ${message}` });
         }
       }
+      if (sessionEnded) {
+        if (this.draftStarted) {
+          try {
+            // A connection that closed during the failed leave is still gone.
+            // Keep the engine paused/disconnected for its recovered grace
+            // window instead of compensating it back to a live seat.
+            await this.adapter.setSeatConnected(seat, false);
+          } catch (disconnectError) {
+            this.reportDetachedMutationFailure("leave disconnect recovery", disconnectError);
+          }
+        }
+        try {
+          await this.persistSessionStrict({ retainFailedDraftSnapshot: false });
+          if (this.draftStarted) this.reconcileEffectivePause();
+          else this.syncLobbyToGuests();
+        } catch (persistError) {
+          this.reportDetachedMutationFailure("leave disconnect recovery", persistError);
+        }
+      }
       throw error;
+    } finally {
+      stopWatchingSession();
     }
     await session.send({
       type: "draft_leave_ack",

--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -891,6 +891,9 @@ export class P2PDraftHost {
 
   private async startDraftInner(botFillEmptySeats: boolean): Promise<void> {
     if (this.draftStarted) return;
+    if (this.disconnectedSeats.size > 0) {
+      throw new Error("Cannot start draft while a player is reconnecting");
+    }
 
     const seed = Math.floor(Math.random() * 0xffffffff);
     this.draftSeed = seed;
@@ -1446,11 +1449,14 @@ export class P2PDraftHost {
         }
         try {
           await this.persistSessionStrict({ retainFailedDraftSnapshot: false });
-          if (this.draftStarted) this.reconcileEffectivePause();
-          else this.syncLobbyToGuests();
         } catch (persistError) {
           this.reportDetachedMutationFailure("leave disconnect recovery", persistError);
         }
+        // A second persistence failure cannot make this lost connection look
+        // live. Pause/synchronize from the restored local state regardless of
+        // whether its recovery snapshot made it to storage.
+        if (this.draftStarted) this.reconcileEffectivePause();
+        else this.syncLobbyToGuests();
       }
       throw error;
     } finally {

--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -311,6 +311,11 @@ export class P2PDraftHost {
   private seatTokens = new Map<number, string>();
   private seatNames = new Map<number, string>();
   private kickedTokens = new Set<string>();
+  /**
+   * The absolute end of a guest's current reconnect episode. It survives a
+   * successful tentative reconnect so a later drop cannot grant a new window.
+   */
+  private reconnectDeadlines = new Map<number, number>();
   private disconnectedSeats = new Map<
     number,
     { deadlineAt: number; timer: ReturnType<typeof setTimeout> | null }
@@ -713,8 +718,9 @@ export class P2PDraftHost {
       });
 
       // The prior fence makes the engine's connected bitmap recoverable while
-      // this reconnect is tentative. This fence records the completed handoff:
-      // a later host recovery must not resurrect the old grace deadline.
+      // this reconnect is tentative. This fence records the completed handoff
+      // while retaining its absolute deadline, so a later recovery or drop
+      // can use only the remaining grace window.
       await this.persistSessionStrict();
 
       const view = this.draftStarted
@@ -749,6 +755,7 @@ export class P2PDraftHost {
         if (reconnectDeadlineAt > Date.now()) {
           this.scheduleReconnectGrace(reconnectSeat, reconnectDeadlineAt);
         } else {
+          this.reconnectDeadlines.delete(reconnectSeat);
           this.expiredDisconnectedSeats.add(reconnectSeat);
         }
       }
@@ -1353,8 +1360,17 @@ export class P2PDraftHost {
     const session = this.guestSessions.get(seat);
     if (!session || session !== originatingSession || this.seatTokens.get(seat) !== draftToken) return;
 
+    const priorGraceDeadline = this.disconnectedSeats.get(seat)?.deadlineAt;
+    const priorReconnectDeadline = this.reconnectDeadlines.get(seat);
+    const priorWorkspace = this.perSeatWorkspaceSnapshots.get(seat);
+    const priorToken = this.seatTokens.get(seat);
+    const priorName = this.seatNames.get(seat);
+    const wasKicked = this.kickedTokens.has(draftToken);
+    const wasExpired = this.expiredDisconnectedSeats.has(seat);
+
     this.guestSessions.delete(seat);
     this.clearReconnectGrace(seat);
+    this.reconnectDeadlines.delete(seat);
     this.perSeatWorkspaceSnapshots.delete(seat);
 
     if (!this.draftStarted) {
@@ -1367,7 +1383,25 @@ export class P2PDraftHost {
       await this.adapter.setSeatConnected(seat, false);
     }
 
-    await this.persistSessionStrict();
+    try {
+      await this.persistSessionStrict();
+    } catch (error) {
+      // A failed strict write leaves the prior durable session authoritative.
+      // Restore its complete in-memory counterpart before returning without an
+      // acknowledgement, so the existing recovery capability stays usable.
+      this.guestSessions.set(seat, session);
+      if (priorGraceDeadline !== undefined) this.scheduleReconnectGrace(seat, priorGraceDeadline);
+      else if (priorReconnectDeadline !== undefined) this.reconnectDeadlines.set(seat, priorReconnectDeadline);
+      if (priorWorkspace !== undefined) this.perSeatWorkspaceSnapshots.set(seat, priorWorkspace);
+      if (priorToken !== undefined) this.seatTokens.set(seat, priorToken);
+      if (priorName !== undefined) this.seatNames.set(seat, priorName);
+      if (wasKicked) this.kickedTokens.add(draftToken);
+      else this.kickedTokens.delete(draftToken);
+      if (wasExpired) this.expiredDisconnectedSeats.add(seat);
+      else this.expiredDisconnectedSeats.delete(seat);
+      if (this.draftStarted) await this.adapter.setSeatConnected(seat, true);
+      throw error;
+    }
     await session.send({
       type: "draft_leave_ack",
       draftProtocolVersion: DRAFT_PROTOCOL_VERSION,
@@ -1390,7 +1424,10 @@ export class P2PDraftHost {
 
     this.guestSessions.delete(seat);
 
-    this.scheduleReconnectGrace(seat, Date.now() + this.gracePeriodMs);
+    this.scheduleReconnectGrace(
+      seat,
+      this.reconnectDeadlines.get(seat) ?? Date.now() + this.gracePeriodMs,
+    );
     // The socket callback is synchronous, but all externally visible state
     // follows the one durable queue: connected bitmap → snapshot → views/pause.
     this.runDetachedMutation("guest disconnect", async () => {
@@ -1407,6 +1444,7 @@ export class P2PDraftHost {
   }
 
   private scheduleReconnectGrace(seat: number, deadlineAt: number): void {
+    this.reconnectDeadlines.set(seat, deadlineAt);
     const remainingMs = Math.max(0, deadlineAt - Date.now());
     const timer = setTimeout(() => {
       this.runDetachedMutation("reconnect grace expiry", () => this.expireReconnectGrace(seat));
@@ -1456,6 +1494,7 @@ export class P2PDraftHost {
     // silently resume the pod just because their reconnect window ended.
     if (!this.disconnectedSeats.has(seat)) return;
     this.clearReconnectGrace(seat);
+    this.reconnectDeadlines.delete(seat);
     if (!this.draftStarted) {
       this.seatTokens.delete(seat);
       this.seatNames.delete(seat);
@@ -2072,6 +2111,7 @@ export class P2PDraftHost {
       await this.adapter.replaceSeatWithBot(seat, this.botNameForSeat(seat, seed));
       const grace = this.disconnectedSeats.get(seat);
       if (grace) this.clearReconnectGrace(seat);
+      this.reconnectDeadlines.delete(seat);
       this.expiredDisconnectedSeats.delete(seat);
       this.seatTokens.delete(seat);
       this.seatNames.delete(seat);
@@ -2485,6 +2525,7 @@ export class P2PDraftHost {
     // Cancel grace timer if active
     const grace = this.disconnectedSeats.get(seat);
     if (grace) this.clearReconnectGrace(seat);
+    this.reconnectDeadlines.delete(seat);
     this.expiredDisconnectedSeats.delete(seat);
 
     await this.persistSessionStrict();
@@ -2589,9 +2630,7 @@ export class P2PDraftHost {
       seatTokens: Object.fromEntries(this.seatTokens),
       seatNames: Object.fromEntries(this.seatNames),
       kickedTokens: [...this.kickedTokens],
-      reconnectDeadlines: Object.fromEntries(
-        [...this.disconnectedSeats.entries()].map(([seat, grace]) => [seat, grace.deadlineAt]),
-      ),
+      reconnectDeadlines: Object.fromEntries(this.reconnectDeadlines),
       expiredDisconnectedSeats: [...this.expiredDisconnectedSeats],
       draftStarted: this.draftStarted,
       manualPause: this.manualPause,
@@ -2799,6 +2838,7 @@ export class P2PDraftHost {
 
       const deadlineAt = reconnectDeadlines[seat] ?? now + this.gracePeriodMs;
       if (deadlineAt <= now) {
+        this.reconnectDeadlines.delete(seat);
         if (this.draftStarted) {
           this.expiredDisconnectedSeats.add(seat);
         } else {
@@ -2849,6 +2889,7 @@ export class P2PDraftHost {
       if (timer !== null) clearTimeout(timer);
     }
     this.disconnectedSeats.clear();
+    this.reconnectDeadlines.clear();
     this.bo3State.clear();
     this.matchDecks.clear();
     this.matchLaunches.clear();

--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -1754,7 +1754,7 @@ export class P2PDraftHost {
     }
   }
 
-  private matchBindingFor(pairing: PairingView): DraftMatchBinding {
+  private matchBindingFor(pairing: PairingView, matchAuthoritySeat: number): DraftMatchBinding {
     const existing = this.matchBindings.get(pairing.match_id);
     if (existing && existing.round === pairing.round) return existing;
 
@@ -1766,7 +1766,7 @@ export class P2PDraftHost {
       lease: crypto.randomUUID(),
       nonce: crypto.randomUUID(),
       revision: 0,
-      matchAuthoritySeat: Math.min(pairing.seat_a, pairing.seat_b),
+      matchAuthoritySeat,
     };
     this.matchBindings.set(pairing.match_id, binding);
     return binding;
@@ -1899,16 +1899,16 @@ export class P2PDraftHost {
     const seatB = pairing.seat_b;
     const seatAIsBot = this.isBotSeatFromView(view, seatA);
     const seatBIsBot = this.isBotSeatFromView(view, seatB);
-    const session = await this.exportDraftSession();
-    const binding = this.matchBindingFor(pairing);
-
     if (seatAIsBot && seatBIsBot) {
       await this.reportMatchResult(pairing.match_id, Math.min(seatA, seatB));
       return;
     }
 
+    const session = await this.exportDraftSession();
+
     if (seatAIsBot || seatBIsBot) {
       const humanSeat = seatAIsBot ? seatB : seatA;
+      const binding = this.matchBindingFor(pairing, humanSeat);
       const botSeat = seatAIsBot ? seatA : seatB;
       const botName = seatAIsBot ? pairing.name_a : pairing.name_b;
       const humanDeck = this.submittedDeckForSeat(session, humanSeat);
@@ -1934,6 +1934,7 @@ export class P2PDraftHost {
     }
 
     const matchHostSeat = Math.min(seatA, seatB);
+    const binding = this.matchBindingFor(pairing, matchHostSeat);
     const guestSeat = matchHostSeat === seatA ? seatB : seatA;
     const matchRoomCode = `${this.draftCode ?? "draft"}-${pairing.match_id}`;
     const hostDeck = this.submittedDeckForSeat(session, matchHostSeat);
@@ -2810,6 +2811,9 @@ export class P2PDraftHost {
       }
       if (this.reconcileRetainedWorkspace(0, view.pool).changed) this.persistSession();
       await this.recoverSettlementOutbox(view);
+      if (this.rotateLegacyBotMatchAuthorities(view)) {
+        await this.persistSessionStrict();
+      }
 
       this.reconcileEffectivePause();
 
@@ -2881,6 +2885,35 @@ export class P2PDraftHost {
 
       this.scheduleReconnectGrace(seat, deadlineAt);
       if (reconnectDeadlines[seat] === undefined) changed = true;
+    }
+    return changed;
+  }
+
+  /**
+   * Old snapshots selected the lowest numbered seat as the settlement
+   * authority, including bot seats. A bot cannot return a participant
+   * settlement, so repair only the active human-versus-bot binding after the
+   * restored engine view identifies its human participant. Completed and
+   * future-round bindings intentionally retain their historical capability.
+   */
+  private rotateLegacyBotMatchAuthorities(view: DraftPlayerView): boolean {
+    let changed = false;
+    for (const pairing of view.pairings) {
+      if (pairing.round !== view.current_round || pairing.status !== "InProgress") continue;
+
+      const seatAIsBot = this.isBotSeatFromView(view, pairing.seat_a);
+      const seatBIsBot = this.isBotSeatFromView(view, pairing.seat_b);
+      if (seatAIsBot === seatBIsBot) continue;
+
+      const binding = this.matchBindings.get(pairing.match_id);
+      if (!binding || binding.round !== pairing.round) continue;
+
+      const humanSeat = seatAIsBot ? pairing.seat_b : pairing.seat_a;
+      const botSeat = seatAIsBot ? pairing.seat_a : pairing.seat_b;
+      if (binding.matchAuthoritySeat !== botSeat) continue;
+
+      this.matchBindings.set(pairing.match_id, { ...binding, matchAuthoritySeat: humanSeat });
+      changed = true;
     }
     return changed;
   }

--- a/client/src/adapter/p2p-draft-host.ts
+++ b/client/src/adapter/p2p-draft-host.ts
@@ -2939,7 +2939,7 @@ export class P2PDraftHost {
    */
   private rotateLegacyBotMatchAuthorities(view: DraftPlayerView): boolean {
     let changed = false;
-    for (const pairing of view.pairings) {
+    for (const pairing of view.pairings ?? []) {
       if (pairing.round !== view.current_round || pairing.status !== "InProgress") continue;
 
       const seatAIsBot = this.isBotSeatFromView(view, pairing.seat_a);

--- a/client/src/network/__tests__/draftProtocol.test.ts
+++ b/client/src/network/__tests__/draftProtocol.test.ts
@@ -40,8 +40,8 @@ describe("draftProtocol", () => {
   });
 
   describe("DRAFT_PROTOCOL_VERSION", () => {
-    it("is version 21", () => {
-      expect(DRAFT_PROTOCOL_VERSION).toBe(21);
+    it("is version 22", () => {
+      expect(DRAFT_PROTOCOL_VERSION).toBe(22);
     });
   });
 
@@ -261,6 +261,24 @@ describe("draftProtocol", () => {
   });
 
   describe("validateDraftMessage", () => {
+    it("accepts only versioned, token-bound draft leave messages", () => {
+      expect(validateDraftMessage({
+        type: "draft_leave",
+        draftProtocolVersion: DRAFT_PROTOCOL_VERSION,
+        draftToken: "seat-token",
+      })).toMatchObject({ type: "draft_leave", draftToken: "seat-token" });
+      expect(validateDraftMessage({
+        type: "draft_leave_ack",
+        draftProtocolVersion: DRAFT_PROTOCOL_VERSION,
+        draftToken: "seat-token",
+      })).toMatchObject({ type: "draft_leave_ack", draftToken: "seat-token" });
+      expect(() => validateDraftMessage({
+        type: "draft_leave",
+        draftProtocolVersion: DRAFT_PROTOCOL_VERSION - 1,
+        draftToken: "seat-token",
+      })).toThrow("Invalid draft leave message");
+    });
+
     it("accepts valid draft_join message", () => {
       const msg = validateDraftMessage({
         type: "draft_join",

--- a/client/src/network/draftProtocol.ts
+++ b/client/src/network/draftProtocol.ts
@@ -128,8 +128,12 @@ import type {
  *
  *  21 — complete, validated per-seat workspace snapshots and workspace pool
  *       metadata. This is additive and retains the v13–20 contract.
+ *  22 — durable, session-bound participant leave handshake. `draft_leave`
+ *       and its acknowledgement both carry the exact protocol version and
+ *       capability token, so a guest clears recoverable state only after the
+ *       host has durably revoked that exact seat.
  */
-export const DRAFT_PROTOCOL_VERSION = 21 as const;
+export const DRAFT_PROTOCOL_VERSION = 22 as const;
 
 /** Canonical multiset fingerprint: deck order is UI-only, card counts are not. */
 export function deckSubmissionFingerprint(mainDeck: readonly string[]): string {
@@ -258,12 +262,12 @@ export type DraftMatchLaunch =
  *
  * Flow:
  *   Guest → Host: `draft_join`, `draft_reconnect`, `draft_pick`, `draft_pick_with_draft_effect`, `draft_submit_deck`,
- *                 `draft_request_advance`, `draft_workspace_update`
+ *                 `draft_request_advance`, `draft_workspace_update`, `draft_leave`
  *   Host → Guest: `draft_welcome`, `draft_reconnect_ack`, `draft_reconnect_rejected`,
  *                 `draft_state_update`, `draft_pick_ack`, `draft_error`,
  *                 `draft_kicked`, `draft_pairing`, `draft_match_result`,
  *                 `draft_paused`, `draft_resumed`, `draft_lobby_update`,
- *                 `draft_host_left`, `draft_timer_sync`, `draft_match_start`
+ *                 `draft_host_left`, `draft_timer_sync`, `draft_match_start`, `draft_leave_ack`
  */
 export type DraftP2PMessage =
   // ── Guest → Host ───────────────────────────────────────────────────
@@ -304,6 +308,12 @@ export type DraftP2PMessage =
       type: "draft_workspace_update";
       workspaceState: DraftWorkspaceState;
     }
+  | {
+      /** Explicit participant exit, bound to the currently authenticated seat. */
+      type: "draft_leave";
+      draftProtocolVersion: typeof DRAFT_PROTOCOL_VERSION;
+      draftToken: string;
+    }
   // ── Host → Guest ───────────────────────────────────────────────────
   | {
       type: "draft_welcome";
@@ -330,6 +340,12 @@ export type DraftP2PMessage =
       type: "draft_reconnect_rejected";
       kind: DraftReconnectRejectionKind;
       reason: string;
+    }
+  | {
+      /** Sent only after the host has durably revoked this exact seat. */
+      type: "draft_leave_ack";
+      draftProtocolVersion: typeof DRAFT_PROTOCOL_VERSION;
+      draftToken: string;
     }
   | {
       type: "draft_state_update";
@@ -507,9 +523,11 @@ const VALID_DRAFT_TYPES = new Set([
   "draft_pick_with_draft_effect",
   "draft_submit_deck",
   "draft_workspace_update",
+  "draft_leave",
   "draft_welcome",
   "draft_reconnect_ack",
   "draft_reconnect_rejected",
+  "draft_leave_ack",
   "draft_state_update",
   "draft_deck_submit_ack",
   "draft_pick_ack",
@@ -835,6 +853,17 @@ export function validateDraftMessage(raw: unknown): DraftP2PMessage {
   const msg = raw as { type: string };
   if (!VALID_DRAFT_TYPES.has(msg.type)) {
     throw new Error(`Invalid draft message type: ${msg.type}`);
+  }
+  if (msg.type === "draft_leave" || msg.type === "draft_leave_ack") {
+    const leave = raw as Record<string, unknown>;
+    if (
+      leave.draftProtocolVersion !== DRAFT_PROTOCOL_VERSION
+      || typeof leave.draftToken !== "string"
+      || leave.draftToken.length === 0
+    ) {
+      throw new Error("Invalid draft leave message");
+    }
+    return leave as DraftP2PMessage;
   }
   if (msg.type === "draft_pick_with_draft_effect") {
     return validateDraftEffectPick(raw as Record<string, unknown>);

--- a/client/src/pages/DraftPodPage.tsx
+++ b/client/src/pages/DraftPodPage.tsx
@@ -1325,7 +1325,7 @@ export function DraftPodPage() {
   }, [enterKind, searchParams]);
 
   const handleLeave = useCallback(async () => {
-    await leave(true);
+    await leave(false);
     resetPod();
     navigate("/");
   }, [leave, resetPod, navigate]);

--- a/client/src/pages/__tests__/DraftPodPage.podError.test.tsx
+++ b/client/src/pages/__tests__/DraftPodPage.podError.test.tsx
@@ -76,6 +76,7 @@ describe("DraftPodPage pod error banner", () => {
     draftState.guestRecoveryFailure = null;
     draftState.clearError.mockClear();
     draftState.resumeDraft.mockClear();
+    draftState.leave.mockClear();
   });
 
   it("surfaces the store error in the pairing phase", () => {
@@ -166,6 +167,17 @@ describe("DraftPodPage pod error banner", () => {
 
     expect(screen.getByText("Refresh both windows")).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: "Try Reconnecting" })).toBeNull();
+  });
+
+  it("revokes recovery when the participant explicitly returns to the menu", async () => {
+    const user = userEvent.setup();
+    draftState.phase = "error";
+    renderPage();
+
+    await user.click(screen.getByRole("button", { name: "Return to Menu" }));
+
+    expect(draftState.leave).toHaveBeenCalledOnce();
+    expect(draftState.leave).toHaveBeenCalledWith(false);
   });
 
   it("aborts the retry attempt when its page unmounts", async () => {

--- a/client/src/services/__tests__/draftPersistence.test.ts
+++ b/client/src/services/__tests__/draftPersistence.test.ts
@@ -91,6 +91,27 @@ describe("draftPersistence", () => {
       expect(loaded).toEqual({ ...testSession, perSeatWorkspaceSnapshots: {} });
     });
 
+    it("retains validated absolute reconnect deadlines", async () => {
+      const deadline = Date.now() + 60_000;
+      await saveDraftHostSession("deadline-session", {
+        ...testSession,
+        reconnectDeadlines: { 1: deadline },
+      });
+
+      await expect(loadDraftHostSession("deadline-session")).resolves.toMatchObject({
+        reconnectDeadlines: { 1: deadline },
+      });
+    });
+
+    it("rejects malformed reconnect deadlines", async () => {
+      mockStore.set("phase-draft-host:bad-deadline", {
+        ...testSession,
+        reconnectDeadlines: { 1: "later" },
+      });
+
+      await expect(loadDraftHostSession("bad-deadline")).resolves.toBeNull();
+    });
+
     it("returns null for non-existent session", async () => {
       const loaded = await loadDraftHostSession("nonexistent");
       expect(loaded).toBeNull();

--- a/client/src/services/draftPersistence.ts
+++ b/client/src/services/draftPersistence.ts
@@ -47,6 +47,9 @@ export interface PersistedDraftHostSession {
   seatNames: Record<number, string>;
   /** Tokens that were kicked — refused on reconnect. */
   kickedTokens: string[];
+  /** Absolute reconnect deadline by seat. An absent field is legacy and cannot
+   * safely establish a new recovery window. */
+  reconnectDeadlines?: Record<number, number>;
   /** Seats whose reconnect grace elapsed while this host owned the pod. */
   expiredDisconnectedSeats?: number[];
   /** Whether StartDraft has been applied. */
@@ -432,6 +435,7 @@ function isPersistedDraftHostSession(value: unknown): value is PersistedDraftHos
     isSeatStringRecord(value.seatTokens) &&
     isSeatStringRecord(value.seatNames) &&
     Array.isArray(value.kickedTokens) && value.kickedTokens.every((token) => typeof token === "string") &&
+    (value.reconnectDeadlines === undefined || isSeatDeadlineRecord(value.reconnectDeadlines)) &&
     (value.expiredDisconnectedSeats === undefined ||
       (Array.isArray(value.expiredDisconnectedSeats) && value.expiredDisconnectedSeats.every(isNonnegativeInteger))) &&
     typeof value.draftStarted === "boolean" &&
@@ -505,6 +509,12 @@ function isSetPackSequence(data: Record<string, unknown>): boolean {
 
 function isSeatStringRecord(value: unknown): value is Record<number, string> {
   return isRecord(value) && Object.entries(value).every(([seat, token]) => isPositiveSeat(seat) && typeof token === "string");
+}
+
+function isSeatDeadlineRecord(value: unknown): value is Record<number, number> {
+  return isRecord(value) && Object.entries(value).every(
+    ([seat, deadline]) => isPositiveSeat(seat) && isPositiveFiniteNumber(deadline),
+  );
 }
 
 function isPositiveSeat(value: string): boolean {

--- a/client/src/stores/__tests__/multiplayerDraftStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerDraftStore.test.ts
@@ -834,6 +834,18 @@ describe("multiplayerDraftStore", () => {
     });
   });
 
+  describe("leave", () => {
+    it("routes an explicit guest leave through recovery revocation", async () => {
+      await useMultiplayerDraftStore.getState().joinDraft({
+        kind: "new", roomCode: "ABCDE", displayName: "Alice",
+      });
+
+      await useMultiplayerDraftStore.getState().leave();
+
+      expect(mockGuestAdapter.dispose).toHaveBeenCalledWith({ preserveRecovery: false });
+    });
+  });
+
   describe("shared actions", () => {
     it.each([
       {

--- a/client/src/stores/__tests__/multiplayerDraftStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerDraftStore.test.ts
@@ -844,6 +844,34 @@ describe("multiplayerDraftStore", () => {
 
       expect(mockGuestAdapter.dispose).toHaveBeenCalledWith({ preserveRecovery: false });
     });
+
+    it("keeps the guest lifecycle live when an acknowledged leave cannot complete", async () => {
+      await useMultiplayerDraftStore.getState().joinDraft({
+        kind: "new", roomCode: "ABCDE", displayName: "Alice",
+      });
+      const liveGuestEvent = capturedGuestEventHandler!;
+      const phaseBeforeLeave = useMultiplayerDraftStore.getState().phase;
+      mockGuestAdapter.dispose.mockRejectedValueOnce(
+        new Error("Draft host disconnected before acknowledging leave"),
+      );
+
+      await expect(useMultiplayerDraftStore.getState().leave()).rejects.toThrow(
+        "disconnected before acknowledging leave",
+      );
+      expect(useMultiplayerDraftStore.getState()).toMatchObject({ role: "guest", phase: phaseBeforeLeave });
+
+      liveGuestEvent({
+        type: "lobbyUpdate",
+        seats: [],
+        joined: 2,
+        total: 8,
+      });
+      expect(useMultiplayerDraftStore.getState().joined).toBe(2);
+
+      await useMultiplayerDraftStore.getState().leave();
+      expect(mockGuestAdapter.dispose).toHaveBeenCalledTimes(2);
+      expect(useMultiplayerDraftStore.getState()).toMatchObject({ role: null, phase: "idle" });
+    });
   });
 
   describe("shared actions", () => {

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -1899,19 +1899,30 @@ export const useMultiplayerDraftStore = create<
   },
 
   leave: async (preserveRecovery = false) => {
+    const host = activeHostAdapter;
+    const guest = activeGuestAdapter;
+
+    // An explicit guest leave is host-acknowledged. Until that completes, the
+    // live adapter remains the recovery owner; tearing down the lifecycle here
+    // would discard the session that must reconnect after a dropped ACK.
+    if (host) {
+      await host.dispose({ preserveSession: preserveRecovery });
+    }
+    if (guest) {
+      await guest.dispose({ preserveRecovery });
+    }
+
     beginDraftLifecycle();
-    // Dispose match adapter first (game P2P connection)
+    // The pod session has now ended, so its game transport can follow it.
     disposeMatchAdapter(set);
 
-    if (activeHostAdapter) {
-      await activeHostAdapter.dispose({ preserveSession: preserveRecovery });
+    if (activeHostAdapter === host) {
       activeHostAdapter = null;
       if (!preserveRecovery) {
         clearActiveDraftPod();
       }
     }
-    if (activeGuestAdapter) {
-      await activeGuestAdapter.dispose({ preserveRecovery });
+    if (activeGuestAdapter === guest) {
       activeGuestAdapter = null;
     }
     set({ ...initialState, interactionGeneration: lifecycleGeneration });

--- a/client/src/stores/multiplayerDraftStore.ts
+++ b/client/src/stores/multiplayerDraftStore.ts
@@ -305,8 +305,9 @@ interface MultiplayerDraftActions {
   requestPause: () => void;
   /** Host: resume the draft. */
   requestResume: () => void;
-  /** Both: tear down the connection and reset state. */
-  leave: (preserveSession?: boolean) => Promise<void>;
+  /** Both: tear down the connection and reset state. Lifecycle callers retain
+   * recovery; an explicit leave revokes it only after host acknowledgement. */
+  leave: (preserveRecovery?: boolean) => Promise<void>;
   /** Reset store to initial state (without network cleanup). */
   reset: () => void;
   /** Both: start the match for the current pairing. */
@@ -1897,20 +1898,20 @@ export const useMultiplayerDraftStore = create<
     });
   },
 
-  leave: async (preserveSession = false) => {
+  leave: async (preserveRecovery = false) => {
     beginDraftLifecycle();
     // Dispose match adapter first (game P2P connection)
     disposeMatchAdapter(set);
 
     if (activeHostAdapter) {
-      await activeHostAdapter.dispose({ preserveSession });
+      await activeHostAdapter.dispose({ preserveSession: preserveRecovery });
       activeHostAdapter = null;
-      if (!preserveSession) {
+      if (!preserveRecovery) {
         clearActiveDraftPod();
       }
     }
     if (activeGuestAdapter) {
-      await activeGuestAdapter.dispose();
+      await activeGuestAdapter.dispose({ preserveRecovery });
       activeGuestAdapter = null;
     }
     set({ ...initialState, interactionGeneration: lifecycleGeneration });

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1597,6 +1597,15 @@ async fn reconnect_draft_seat(
     tx: &mpsc::UnboundedSender<ServerMessage>,
 ) -> Result<draft_core::view::DraftPlayerView, String> {
     let mut manager = draft_state.lock().await;
+    if let Some((attached_code, _attached_seat, attached_token)) = identity.draft_seat() {
+        if attached_code != draft_code
+            || attached_token != player_token
+            || !draft_socket_is_current_while_state_locked(&manager, connections, identity, tx)
+                .await
+        {
+            return Err(DRAFT_SOCKET_AUTHORITY_REJECTION.to_string());
+        }
+    }
     let seat = manager
         .sessions
         .get(&draft_code)
@@ -10220,7 +10229,7 @@ mod draft_socket_authority_tests {
             &connections,
             &mut identity_b,
             draft_code.clone(),
-            player_token,
+            player_token.clone(),
             &b_tx,
         )
         .await
@@ -10234,6 +10243,17 @@ mod draft_socket_authority_tests {
         assert!(
             draft_socket_is_current_preflight(&draft_state, &connections, &identity_b, &b_tx).await
         );
+        let err = reconnect_draft_seat(
+            &draft_state,
+            &connections,
+            &mut identity_a,
+            draft_code.clone(),
+            player_token,
+            &a_tx,
+        )
+        .await
+        .expect_err("superseded A must not replace B after a stale reconnect");
+        assert_eq!(err, DRAFT_SOCKET_AUTHORITY_REJECTION);
         assert!(
             connections
                 .lock()

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1261,6 +1261,16 @@ impl SocketIdentity {
             self.player_token.as_deref()?,
         ))
     }
+
+    /// The draft seat claimed by this socket. A complete triple is required
+    /// before the socket can exercise a draft seat-scoped capability.
+    fn draft_seat(&self) -> Option<(&str, usize, &str)> {
+        Some((
+            self.draft_code.as_deref()?,
+            self.draft_seat?,
+            self.draft_token.as_deref()?,
+        ))
+    }
 }
 
 /// Full-mode authority required before a message reaches its handler.
@@ -1333,6 +1343,8 @@ fn full_socket_authority(message: &ClientMessage) -> FullSocketAuthority {
 const FULL_SOCKET_AUTHORITY_REJECTION: &str =
     "This socket's game session identity is no longer current";
 const FULL_SOCKET_FRESH_REJECTION: &str = "This socket is already attached to a game session";
+const DRAFT_SOCKET_AUTHORITY_REJECTION: &str =
+    "This socket's draft session identity is no longer current";
 
 /// Verifies a Full seat while the caller already owns the session-state lock.
 ///
@@ -1511,6 +1523,132 @@ async fn disconnect_full_seat_if_current(
     for sender in notify_senders {
         let _ = sender.send(message.clone());
     }
+}
+
+/// Verifies a draft seat while the caller already owns the draft-state lock.
+///
+/// This is the authority linearization point for draft mutations: the token
+/// resolves against the exact [`DraftSessionManager`] snapshot being mutated,
+/// then the draft sender-map entry must still belong to this socket. Both
+/// guards are released before persistence, socket I/O, or fan-out.
+async fn draft_socket_is_current_while_state_locked(
+    manager: &DraftSessionManager,
+    connections: &SharedConnections,
+    identity: &SocketIdentity,
+    tx: &mpsc::UnboundedSender<ServerMessage>,
+) -> bool {
+    let Some((draft_code, seat, player_token)) = identity.draft_seat() else {
+        return false;
+    };
+    let resolved_seat = manager
+        .sessions
+        .get(draft_code)
+        .and_then(|session| session.seat_for_token(player_token));
+    if resolved_seat != Some(seat) {
+        return false;
+    }
+
+    let conns = connections.lock().await;
+    conns
+        .get(draft_code)
+        .and_then(|players| players.get(&PlayerId(seat as u8)))
+        .is_some_and(|sender| sender.same_channel(tx))
+}
+
+/// A pre-dispatch authority check for reconnect attempts from an already
+/// attached draft socket. The reconnect transaction below rechecks under the
+/// draft-state lock before it replaces the sender.
+async fn draft_socket_is_current_preflight(
+    draft_state: &SharedDraftState,
+    connections: &SharedConnections,
+    identity: &SocketIdentity,
+    tx: &mpsc::UnboundedSender<ServerMessage>,
+) -> bool {
+    let manager = draft_state.lock().await;
+    draft_socket_is_current_while_state_locked(&manager, connections, identity, tx).await
+}
+
+/// Install a draft-seat sender while the caller owns the draft-state lock.
+/// The draft state -> connections nesting makes replacement and reconnect one
+/// transaction, so later broadcasts and match launches observe the new sender.
+async fn install_draft_sender_while_state_locked(
+    connections: &SharedConnections,
+    draft_code: &str,
+    seat: usize,
+    tx: &mpsc::UnboundedSender<ServerMessage>,
+) {
+    let mut conns = connections.lock().await;
+    conns
+        .entry(draft_code.to_string())
+        .or_default()
+        .insert(PlayerId(seat as u8), tx.clone());
+}
+
+/// Reconnect a draft seat and install its sender before assigning socket
+/// identity. The session operation and map replacement share draft-state ->
+/// connections lock ordering, preventing a fan-out from observing a renewed
+/// seat paired with its former socket.
+async fn reconnect_draft_seat(
+    draft_state: &SharedDraftState,
+    connections: &SharedConnections,
+    identity: &mut SocketIdentity,
+    draft_code: String,
+    player_token: String,
+    tx: &mpsc::UnboundedSender<ServerMessage>,
+) -> Result<draft_core::view::DraftPlayerView, String> {
+    let mut manager = draft_state.lock().await;
+    let seat = manager
+        .sessions
+        .get(&draft_code)
+        .and_then(|session| session.seat_for_token(&player_token))
+        .ok_or_else(|| "Invalid player token".to_string())?;
+    let view = manager.handle_reconnect(&draft_code, &player_token)?;
+    install_draft_sender_while_state_locked(connections, &draft_code, seat, tx).await;
+    drop(manager);
+
+    identity.draft_code = Some(draft_code);
+    identity.draft_seat = Some(seat);
+    identity.draft_token = Some(player_token);
+    Ok(view)
+}
+
+/// Mark a draft seat disconnected only if this socket still owns its sender
+/// entry. A superseded socket's close event must leave the replacement's seat
+/// connected and must not remove its sender from broadcasts or match launches.
+async fn disconnect_draft_seat_if_current(
+    draft_state: &SharedDraftState,
+    connections: &SharedConnections,
+    identity: &SocketIdentity,
+    tx: &mpsc::UnboundedSender<ServerMessage>,
+) {
+    let Some((draft_code, seat, player_token)) = identity.draft_seat() else {
+        return;
+    };
+
+    let mut manager = draft_state.lock().await;
+    if manager
+        .sessions
+        .get(draft_code)
+        .and_then(|session| session.seat_for_token(player_token))
+        != Some(seat)
+    {
+        return;
+    }
+
+    let mut conns = connections.lock().await;
+    let Some(players) = conns.get_mut(draft_code) else {
+        return;
+    };
+    let player_id = PlayerId(seat as u8);
+    if !players
+        .get(&player_id)
+        .is_some_and(|sender| sender.same_channel(tx))
+    {
+        return;
+    }
+
+    players.remove(&player_id);
+    manager.handle_disconnect(draft_code, seat);
 }
 
 /// `thread_stack_size` governs Tokio's worker and blocking threads, but
@@ -2020,16 +2158,7 @@ async fn serve() {
                 drop(mgr);
                 for draft_code in &affected_drafts {
                     // Broadcast to players
-                    let views: Vec<_> = {
-                        let mgr = bg_draft_state.lock().await;
-                        let Some(session) = mgr.sessions.get(draft_code) else {
-                            continue;
-                        };
-                        let pod_size = session.player_tokens.len();
-                        (0..pod_size).map(|i| session.view_for_seat(i)).collect()
-                    };
-                    broadcast_draft_views(draft_code, &views, &bg_connections, &bg_draft_state)
-                        .await;
+                    broadcast_draft_views(draft_code, &bg_connections, &bg_draft_state).await;
                     // Broadcast to spectators
                     broadcast_draft_spectator_views(
                         draft_code,
@@ -2954,11 +3083,7 @@ async fn handle_socket(
         player = ?identity.player_id,
         "client disconnected"
     );
-    // Handle draft session disconnect
-    if let (Some(draft_code), Some(seat)) = (&identity.draft_code, identity.draft_seat) {
-        let mut mgr = draft_state.lock().await;
-        mgr.handle_disconnect(draft_code, seat);
-    }
+    disconnect_draft_seat_if_current(&draft_state, &connections, &identity, &tx).await;
 
     disconnect_full_seat_if_current(&state, &connections, &identity, &tx).await;
 
@@ -3895,14 +4020,14 @@ async fn report_draft_game_over(
         "auto-reporting draft match result from GameOver"
     );
 
-    let views = {
+    {
         let mut mgr = draft_state.lock().await;
         let action = draft_core::types::DraftAction::ReportMatchResult {
             match_id,
             winner_seat,
         };
         match mgr.apply_system_action(&draft_code, action, None) {
-            Ok(views) => views,
+            Ok(_) => {}
             Err(e) => {
                 warn!(draft = %draft_code, error = %e, "failed to auto-report draft match result");
                 return;
@@ -3910,16 +4035,7 @@ async fn report_draft_game_over(
         }
     };
 
-    // Broadcast updated views to all draft pod members
-    let conns = connections.lock().await;
-    if let Some(players) = conns.get(&draft_code) {
-        for (pid, sender) in players.iter() {
-            let seat = pid.0 as usize;
-            if let Some(view) = views.get(seat) {
-                let _ = sender.send(ServerMessage::DraftStateUpdate { view: view.clone() });
-            }
-        }
-    }
+    broadcast_draft_views(&draft_code, connections, draft_state).await;
 }
 
 /// When the draft pod is pairing or in match play, generate pairings (server-internal)
@@ -3960,6 +4076,10 @@ async fn maybe_spawn_draft_matches(
         return;
     }
 
+    // Reacquire draft state before the sender map so a reconnect cannot renew
+    // its engine state between pairing generation and match-start delivery.
+    // Draft reconnects use the same draft state -> connections ordering.
+    let _draft_manager = draft_state.lock().await;
     let conns = connections.lock().await;
     let Some(players) = conns.get(draft_code) else {
         return;
@@ -3995,25 +4115,28 @@ async fn maybe_spawn_draft_matches(
 /// connections map keyed by draft_code.
 async fn broadcast_draft_views(
     draft_code: &str,
-    views: &[draft_core::view::DraftPlayerView],
     connections: &SharedConnections,
     draft_state: &SharedDraftState,
 ) {
+    // Serialize sender fan-out with reconnect's state -> connections
+    // transaction. Without this guard, a reconnect could mark its seat live
+    // while a concurrent broadcast still selected its superseded sender.
+    let draft_manager = draft_state.lock().await;
+    let Some(session) = draft_manager.sessions.get(draft_code) else {
+        return;
+    };
     let conns = connections.lock().await;
     // Draft connections are stored under the draft_code in the connections map
     if let Some(players) = conns.get(draft_code) {
         for (pid, sender) in players.iter() {
             let seat = pid.0 as usize;
-            if let Some(view) = views.get(seat) {
-                let msg = ServerMessage::DraftStateUpdate { view: view.clone() };
+            if seat < session.player_tokens.len() {
+                let msg = ServerMessage::DraftStateUpdate {
+                    view: session.view_for_seat(seat),
+                };
                 let _ = sender.send(msg);
             }
         }
-    } else {
-        // Fallback: broadcast to all sockets that have a matching draft_code
-        // by sending the first view (for reconnect cases where identity is set
-        // but connection may not be in the draft_code map yet)
-        let _ = draft_state; // suppress unused
     }
 }
 
@@ -4021,8 +4144,10 @@ async fn broadcast_draft_timer_sync(
     draft_code: &str,
     remaining_ms: u32,
     connections: &SharedConnections,
+    draft_state: &SharedDraftState,
 ) {
     let msg = ServerMessage::DraftTimerSync { remaining_ms };
+    let _draft_manager = draft_state.lock().await;
     let conns = connections.lock().await;
     if let Some(players) = conns.get(draft_code) {
         for sender in players.values() {
@@ -4068,7 +4193,13 @@ fn spawn_pick_timer(
                 session.timer_remaining_ms = Some(remaining_ms);
             }
 
-            broadcast_draft_timer_sync(&timer_draft_code, remaining_ms, &timer_connections).await;
+            broadcast_draft_timer_sync(
+                &timer_draft_code,
+                remaining_ms,
+                &timer_connections,
+                &timer_draft_state,
+            )
+            .await;
 
             if remaining_ms == 0 {
                 break;
@@ -4130,21 +4261,8 @@ fn spawn_pick_timer(
 
         session.timer_remaining_ms = None;
 
-        // Broadcast updated views
-        let views: Vec<_> = (0..pod_size).map(|i| session.view_for_seat(i)).collect();
         drop(mgr);
-
-        {
-            let conns = timer_connections.lock().await;
-            if let Some(players) = conns.get(&timer_draft_code) {
-                for (pid, sender) in players.iter() {
-                    let seat = pid.0 as usize;
-                    if let Some(view) = views.get(seat) {
-                        let _ = sender.send(ServerMessage::DraftStateUpdate { view: view.clone() });
-                    }
-                }
-            }
-        }
+        broadcast_draft_views(&timer_draft_code, &timer_connections, &timer_draft_state).await;
 
         // Re-arm for the next pick window if the draft is still in progress.
         let still_drafting = {
@@ -8860,35 +8978,41 @@ async fn handle_client_message(
 
             let result = {
                 let mut mgr = draft_state.lock().await;
-                let before_window = mgr.sessions.get(&draft_code).map(|s| {
-                    (
-                        s.session.status,
-                        s.session.current_pack_number,
-                        s.session.pick_number,
-                    )
-                });
-                let result = mgr.handle_draft_action(
-                    &draft_code,
-                    &token,
-                    action,
-                    pack_generator
-                        .as_ref()
-                        .map(|generator| generator as &dyn draft_core::pack_source::PackSource),
-                );
-                let after_window = mgr.sessions.get(&draft_code).map(|s| {
-                    (
-                        s.session.status,
-                        s.session.current_pack_number,
-                        s.session.pick_number,
-                    )
-                });
-                let should_rearm_timer =
-                    result.is_ok() && should_rearm_pick_timer(before_window, after_window);
-                result.map(|views| (views, should_rearm_timer))
+                if !draft_socket_is_current_while_state_locked(&mgr, connections, identity, tx)
+                    .await
+                {
+                    Err(DRAFT_SOCKET_AUTHORITY_REJECTION.to_string())
+                } else {
+                    let before_window = mgr.sessions.get(&draft_code).map(|s| {
+                        (
+                            s.session.status,
+                            s.session.current_pack_number,
+                            s.session.pick_number,
+                        )
+                    });
+                    let result = mgr.handle_draft_action(
+                        &draft_code,
+                        &token,
+                        action,
+                        pack_generator
+                            .as_ref()
+                            .map(|generator| generator as &dyn draft_core::pack_source::PackSource),
+                    );
+                    let after_window = mgr.sessions.get(&draft_code).map(|s| {
+                        (
+                            s.session.status,
+                            s.session.current_pack_number,
+                            s.session.pick_number,
+                        )
+                    });
+                    let should_rearm_timer =
+                        result.is_ok() && should_rearm_pick_timer(before_window, after_window);
+                    result.map(|_| should_rearm_timer)
+                }
             };
 
             match result {
-                Ok((views, should_rearm_timer)) => {
+                Ok(should_rearm_timer) => {
                     if is_start {
                         let removed = {
                             let mut lob_guard = lobby.lock().await;
@@ -8909,7 +9033,7 @@ async fn handle_client_message(
                     }
 
                     // Broadcast DraftStateUpdate to all connected sockets in the pod
-                    broadcast_draft_views(&draft_code, &views, connections, draft_state).await;
+                    broadcast_draft_views(&draft_code, connections, draft_state).await;
 
                     // (Re)arm only when a new pick window begins: StartDraft
                     // or a completed round that advanced pack/pick position.
@@ -8958,26 +9082,34 @@ async fn handle_client_message(
                 return;
             }
 
-            let result = {
-                let mut mgr = draft_state.lock().await;
-                mgr.handle_reconnect(&draft_code, &player_token)
-            };
+            if let Some((attached_code, _attached_seat, attached_token)) = identity.draft_seat() {
+                if attached_code != draft_code
+                    || attached_token != player_token
+                    || !draft_socket_is_current_preflight(draft_state, connections, identity, tx)
+                        .await
+                {
+                    let msg = ServerMessage::DraftActionRejected {
+                        reason: DRAFT_SOCKET_AUTHORITY_REJECTION.to_string(),
+                    };
+                    if let Ok(json) = serde_json::to_string(&msg) {
+                        let _ = socket.send(Message::text(json)).await;
+                    }
+                    return;
+                }
+            }
+
+            let result = reconnect_draft_seat(
+                draft_state,
+                connections,
+                identity,
+                draft_code.clone(),
+                player_token,
+                tx,
+            )
+            .await;
 
             match result {
                 Ok(view) => {
-                    // Restore identity
-                    let seat = {
-                        let mgr = draft_state.lock().await;
-                        mgr.sessions
-                            .get(&draft_code)
-                            .and_then(|s| s.seat_for_token(&player_token))
-                    };
-                    if let Some(seat) = seat {
-                        identity.draft_code = Some(draft_code.clone());
-                        identity.draft_seat = Some(seat);
-                        identity.draft_token = Some(player_token);
-                    }
-
                     let msg = ServerMessage::DraftStateUpdate { view };
                     if let Ok(json) = serde_json::to_string(&msg) {
                         let _ = socket.send(Message::text(json)).await;
@@ -10010,6 +10142,161 @@ mod full_socket_authority_tests {
         })
         .await
         .expect("state -> connections ordering must not deadlock");
+    }
+}
+
+#[cfg(test)]
+mod draft_socket_authority_tests {
+    use super::*;
+    use draft_core::types::{
+        DeckAddableCards, DraftConfig, DraftKind, DraftSource, PodPolicy, SpectatorVisibility,
+        TournamentFormat,
+    };
+
+    fn empty_identity() -> SocketIdentity {
+        SocketIdentity {
+            game_code: None,
+            player_id: None,
+            player_token: None,
+            lobby_subscribed: false,
+            session_span: None,
+            client_hello: None,
+            lobby_host_game: None,
+            seat_reservations: Vec::new(),
+            lobby_reservations: Vec::new(),
+            draft_code: None,
+            draft_seat: None,
+            draft_token: None,
+            spectator_draft_code: None,
+            spectator_visibility: None,
+            spectator_game_code: None,
+        }
+    }
+
+    fn test_draft() -> (SharedDraftState, SharedConnections, String, String) {
+        let config = DraftConfig {
+            source: DraftSource::single_set("TST".to_string()),
+            set_code: "TST".to_string(),
+            kind: DraftKind::Premier,
+            pod_size: 8,
+            cards_per_pack: 14,
+            pack_count: 3,
+            min_deck_size: 40,
+            addable_cards: DeckAddableCards::standard_basics(),
+            rng_seed: 42,
+            tournament_format: TournamentFormat::Swiss,
+            pod_policy: PodPolicy::Competitive,
+            spectator_visibility: SpectatorVisibility::default(),
+        };
+        let mut manager = DraftSessionManager::new();
+        let (draft_code, player_token, _) = manager.create_draft(config, "Alice".to_string());
+        (
+            Arc::new(Mutex::new(manager)),
+            Arc::new(Mutex::new(HashMap::new())),
+            draft_code,
+            player_token,
+        )
+    }
+
+    #[tokio::test]
+    async fn reconnect_replaces_the_draft_seat_sender_before_identity_is_exposed() {
+        let (draft_state, connections, draft_code, player_token) = test_draft();
+        let (a_tx, mut a_rx) = mpsc::unbounded_channel();
+        let (b_tx, mut b_rx) = mpsc::unbounded_channel();
+        let mut identity_a = empty_identity();
+        reconnect_draft_seat(
+            &draft_state,
+            &connections,
+            &mut identity_a,
+            draft_code.clone(),
+            player_token.clone(),
+            &a_tx,
+        )
+        .await
+        .expect("initial reconnect attaches A");
+        let mut identity_b = empty_identity();
+        reconnect_draft_seat(
+            &draft_state,
+            &connections,
+            &mut identity_b,
+            draft_code.clone(),
+            player_token,
+            &b_tx,
+        )
+        .await
+        .expect("replacement reconnect attaches B");
+
+        assert!(
+            !draft_socket_is_current_preflight(&draft_state, &connections, &identity_a, &a_tx)
+                .await,
+            "A must lose draft mutation authority once B replaces its sender"
+        );
+        assert!(
+            draft_socket_is_current_preflight(&draft_state, &connections, &identity_b, &b_tx).await
+        );
+        assert!(
+            connections
+                .lock()
+                .await
+                .get(&draft_code)
+                .and_then(|players| players.get(&PlayerId(0)))
+                .is_some_and(|sender| sender.same_channel(&b_tx)),
+            "the sender map must point at B before B receives its draft identity"
+        );
+
+        broadcast_draft_views(&draft_code, &connections, &draft_state).await;
+        assert!(matches!(
+            b_rx.try_recv(),
+            Ok(ServerMessage::DraftStateUpdate { .. })
+        ));
+        assert!(
+            a_rx.try_recv().is_err(),
+            "a broadcast after replacement must not target A's superseded sender"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_draft_close_cannot_disconnect_the_replacement_seat() {
+        let (draft_state, connections, draft_code, player_token) = test_draft();
+        let (a_tx, _a_rx) = mpsc::unbounded_channel();
+        let (b_tx, _b_rx) = mpsc::unbounded_channel();
+        let mut identity_a = empty_identity();
+        reconnect_draft_seat(
+            &draft_state,
+            &connections,
+            &mut identity_a,
+            draft_code.clone(),
+            player_token.clone(),
+            &a_tx,
+        )
+        .await
+        .unwrap();
+        let mut identity_b = empty_identity();
+        reconnect_draft_seat(
+            &draft_state,
+            &connections,
+            &mut identity_b,
+            draft_code.clone(),
+            player_token,
+            &b_tx,
+        )
+        .await
+        .unwrap();
+
+        disconnect_draft_seat_if_current(&draft_state, &connections, &identity_a, &a_tx).await;
+
+        assert!(
+            draft_state
+                .lock()
+                .await
+                .sessions
+                .get(&draft_code)
+                .is_some_and(|session| session.connected[0]),
+            "A's late close must not mark B's draft seat disconnected"
+        );
+        assert!(
+            draft_socket_is_current_preflight(&draft_state, &connections, &identity_b, &b_tx).await
+        );
     }
 }
 

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -1345,6 +1345,26 @@ const FULL_SOCKET_AUTHORITY_REJECTION: &str =
 const FULL_SOCKET_FRESH_REJECTION: &str = "This socket is already attached to a game session";
 const DRAFT_SOCKET_AUTHORITY_REJECTION: &str =
     "This socket's draft session identity is no longer current";
+const DRAFT_SOCKET_FRESH_REJECTION: &str = "This socket is already attached to a draft session";
+
+/// Draft creation and joining install a new seat identity. They therefore need
+/// the same fresh-socket rule as full-game creation and joining: an attached
+/// socket, including one whose sender has since been replaced, must not be
+/// allowed to overwrite the identity its close handler will later clean up.
+///
+/// Reconnecting is deliberately excluded. A new websocket has no draft seat
+/// identity and may reconnect, while an attached websocket is governed by the
+/// exact-seat checks in [`reconnect_draft_seat`].
+fn draft_socket_admission_rejection(
+    message: &ClientMessage,
+    identity: &SocketIdentity,
+) -> Option<&'static str> {
+    (matches!(
+        message,
+        ClientMessage::CreateDraftWithSettings { .. } | ClientMessage::JoinDraftWithPassword { .. }
+    ) && identity.draft_seat().is_some())
+    .then_some(DRAFT_SOCKET_FRESH_REJECTION)
+}
 
 /// Verifies a Full seat while the caller already owns the session-state lock.
 ///
@@ -5639,6 +5659,16 @@ async fn handle_client_message(
         {
             let msg = operation_failed_message(&client_msg, reason.to_string())
                 .unwrap_or_else(|| ServerMessage::error(reason.to_string()));
+            if let Ok(json) = serde_json::to_string(&msg) {
+                let _ = socket.send(Message::text(json)).await;
+            }
+            return;
+        }
+
+        if let Some(reason) = draft_socket_admission_rejection(&client_msg, identity) {
+            let msg = ServerMessage::DraftActionRejected {
+                reason: reason.to_string(),
+            };
             if let Ok(json) = serde_json::to_string(&msg) {
                 let _ = socket.send(Message::text(json)).await;
             }
@@ -10205,6 +10235,147 @@ mod draft_socket_authority_tests {
             draft_code,
             player_token,
         )
+    }
+
+    fn draft_admission_messages(draft_code: &str) -> [ClientMessage; 2] {
+        [
+            ClientMessage::CreateDraftWithSettings {
+                display_name: "Alice".to_string(),
+                set_codes: vec!["TST".to_string()],
+                kind: DraftKind::Premier,
+                public: false,
+                password: None,
+                timer_seconds: Some(75),
+                tournament_format: TournamentFormat::Swiss,
+                pod_policy: PodPolicy::Competitive,
+                pod_size: 8,
+            },
+            ClientMessage::JoinDraftWithPassword {
+                draft_code: draft_code.to_string(),
+                display_name: "Bob".to_string(),
+                password: None,
+            },
+        ]
+    }
+
+    #[test]
+    fn fresh_socket_keeps_draft_admission_and_reconnect_paths() {
+        let fresh = empty_identity();
+        for message in draft_admission_messages("DRAFT01") {
+            assert_eq!(
+                draft_socket_admission_rejection(&message, &fresh),
+                None,
+                "a fresh socket must reach {message:?}'s handler"
+            );
+        }
+        assert_eq!(
+            draft_socket_admission_rejection(
+                &ClientMessage::ReconnectDraft {
+                    draft_code: "DRAFT01".to_string(),
+                    player_token: "player-token".to_string(),
+                },
+                &fresh,
+            ),
+            None,
+            "a fresh socket must retain draft reconnect eligibility"
+        );
+    }
+
+    #[tokio::test]
+    async fn attached_draft_socket_cannot_create_or_join_without_replacing_its_seat() {
+        let (draft_state, connections, draft_code, player_token) = test_draft();
+        let (tx, _rx) = mpsc::unbounded_channel();
+        let mut identity = empty_identity();
+        reconnect_draft_seat(
+            &draft_state,
+            &connections,
+            &mut identity,
+            draft_code.clone(),
+            player_token,
+            &tx,
+        )
+        .await
+        .expect("attach draft seat");
+        let original_identity = (
+            identity.draft_code.clone(),
+            identity.draft_seat,
+            identity.draft_token.clone(),
+        );
+
+        for message in draft_admission_messages(&draft_code) {
+            assert_eq!(
+                draft_socket_admission_rejection(&message, &identity),
+                Some(DRAFT_SOCKET_FRESH_REJECTION),
+                "the gate must reject {message:?} before its handler mutates draft state"
+            );
+        }
+
+        assert_eq!(
+            (
+                identity.draft_code.clone(),
+                identity.draft_seat,
+                identity.draft_token.clone(),
+            ),
+            original_identity,
+            "the gate must not overwrite the socket's existing draft identity"
+        );
+        assert_eq!(draft_state.lock().await.sessions.len(), 1);
+        assert!(
+            connections
+                .lock()
+                .await
+                .get(&draft_code)
+                .and_then(|players| players.get(&PlayerId(0)))
+                .is_some_and(|sender| sender.same_channel(&tx)),
+            "the rejected admission must leave the original sender installed"
+        );
+    }
+
+    #[tokio::test]
+    async fn stale_draft_socket_cannot_create_or_join_another_pod() {
+        let (draft_state, connections, draft_code, player_token) = test_draft();
+        let (stale_tx, _stale_rx) = mpsc::unbounded_channel();
+        let (current_tx, _current_rx) = mpsc::unbounded_channel();
+        let mut stale_identity = empty_identity();
+        reconnect_draft_seat(
+            &draft_state,
+            &connections,
+            &mut stale_identity,
+            draft_code.clone(),
+            player_token.clone(),
+            &stale_tx,
+        )
+        .await
+        .expect("attach original socket");
+        let mut current_identity = empty_identity();
+        reconnect_draft_seat(
+            &draft_state,
+            &connections,
+            &mut current_identity,
+            draft_code.clone(),
+            player_token,
+            &current_tx,
+        )
+        .await
+        .expect("replace original socket");
+
+        for message in draft_admission_messages("OTHER01") {
+            assert_eq!(
+                draft_socket_admission_rejection(&message, &stale_identity),
+                Some(DRAFT_SOCKET_FRESH_REJECTION),
+                "a stale seat must be rejected before {message:?} can overwrite its identity"
+            );
+        }
+        assert!(
+            connections
+                .lock()
+                .await
+                .get(&draft_code)
+                .and_then(|players| players.get(&PlayerId(0)))
+                .is_some_and(|sender| sender.same_channel(&current_tx)),
+            "the stale socket must not displace the current sender"
+        );
+        assert_eq!(draft_state.lock().await.sessions.len(), 1);
     }
 
     #[tokio::test]


### PR DESCRIPTION
- **fix(draft): preserve guest reconnect capability**
- **fix(draft): retain reconnect deadline through retries**
- **fix(draft): keep failed leave recoverable**
- **fix(draft): revoke recovery on explicit exit**
- **fix(draft): assign bot matches to human seats**
- **fix(server): fence draft reconnect sockets**
- **fix(server): reject stale draft reconnects**
- **fix(draft): recover failed leave disconnects**
- **fix(draft): pause failed leave recoveries**
- **fix(draft): retain recovery after failed leave**
- **fix(server): fence draft seat reassignment**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a reliable participant leave flow that waits for host confirmation and supports retry after connection loss.
  * Improved recovery and reconnect handling, including persisted reconnect windows across reloads.
  * Added stronger session protection to prevent stale connections from affecting active drafts.
  * Corrected match-result ownership when bots participate in pairings.

* **Bug Fixes**
  * Prevented duplicate leave requests and unintended recovery-data removal.
  * Improved cleanup when hosts leave or reject reconnecting participants.
  * Fixed restoration of match authority during resumed drafts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->