### PR TITLE
fix(client): make between-games sideboard move controls reachable without hover

### DIFF
--- a/client/src/components/deck-builder/CardEntryRow.tsx
+++ b/client/src/components/deck-builder/CardEntryRow.tsx
@@ -67,9 +67,9 @@ export interface CardEntryRowProps {
   /** Eligibility predicate paired with `onSetAsCommander`. The row consults it
    *  per-entry so the parent doesn't have to fan out card-data lookups. */
   isCommanderEligible?: (name: string) => boolean;
-  /** "compact" (default) keeps the row controls hover-revealed — used by the
-   *  in-game BO3 sideboard modal. "comfortable" makes them always-visible and
-   *  touch-sized for the deck builder (hover reveal is invisible on touch). */
+  /** "compact" (default) keeps the row controls hover-revealed. "comfortable"
+   *  makes them always-visible and touch-sized, which is what any surface
+   *  reachable on touch needs (hover reveal is invisible there). */
   density?: "comfortable" | "compact";
   /** When provided, the alternate-art (✦) badge becomes a tap target that
    *  opens the printing picker — the touch path for art selection (right-click

--- a/client/src/components/deck-builder/MoveList.tsx
+++ b/client/src/components/deck-builder/MoveList.tsx
@@ -36,8 +36,9 @@ export interface MoveListProps {
   /** Forwarded to each row. See `CardEntryRowProps.onSetAsCommander`. */
   onSetAsCommander?: (name: string) => void;
   isCommanderEligible?: (name: string) => boolean;
-  /** Forwarded to each row. Defaults to "compact" so the BO3 sideboard modal
-   *  (which renders MoveList directly) is unchanged. See `CardEntryRowProps`. */
+  /** Forwarded to each row. Defaults to "compact", but every current call site
+   *  passes "comfortable" — hover-revealed controls are unreachable on touch.
+   *  See `CardEntryRowProps`. */
   density?: "comfortable" | "compact";
   /** Forwarded to each row's alternate-art badge. See `CardEntryRowProps`. */
   onOpenArtPicker?: (name: string) => void;

--- a/client/src/components/multiplayer/BetweenGamesSideboardModal.tsx
+++ b/client/src/components/multiplayer/BetweenGamesSideboardModal.tsx
@@ -87,6 +87,10 @@ function moveOne(
  * prompt as `min_main_deck_size` / `max_sideboard_size` — the partition is
  * free to be uneven (CR 100.5: no maximum deck size), so this must never
  * require the main deck to match its registered size.
+ *
+ * Both lists pin `density="comfortable"`: the move button is this modal's only
+ * card-moving affordance, and the default `compact` density hides it behind
+ * `group-hover`, which does not exist on touch — do not drop the prop.
  */
 export function BetweenGamesSideboardModal({
   pool,
@@ -178,6 +182,7 @@ export function BetweenGamesSideboardModal({
               entries={drafts.main}
               onMove={moveCard}
               alwaysShow
+              density="comfortable"
               emptyHint={t("sideboardModal.moveFromSideboard")}
             />
             <MoveList
@@ -193,6 +198,7 @@ export function BetweenGamesSideboardModal({
               entries={drafts.side}
               onMove={moveCard}
               alwaysShow
+              density="comfortable"
               emptyHint={t("sideboardModal.moveFromMain")}
             />
           </div>

--- a/client/src/components/multiplayer/__tests__/BetweenGamesSideboardModal.test.tsx
+++ b/client/src/components/multiplayer/__tests__/BetweenGamesSideboardModal.test.tsx
@@ -67,6 +67,38 @@ describe("BetweenGamesSideboardModal", () => {
     expect(screen.getByText(/Sideboard \(4\/15\)/)).toBeInTheDocument();
   });
 
+  it("lets a card be moved without hovering the row", () => {
+    // happy-dom resolves class selectors via getComputedStyle, so this local
+    // rule reproduces the one Tailwind utility under test; without it the
+    // hidden state is unobservable and the assertion would pass against the
+    // bug. Do NOT use toBeVisible() here — the modal's framer-motion root keeps
+    // opacity:0 under happy-dom, which makes every element in it fail that
+    // matcher unconditionally. This rule must track the utility class on
+    // CardEntryRow's `controlVisibility`: `visibility:hidden` is what removes
+    // the button from the accessibility tree, so if that ever becomes
+    // `opacity-0 group-hover:opacity-100` this test goes silently green while
+    // the bug returns.
+    render(
+      <>
+        <style>{".invisible{visibility:hidden}"}</style>
+        <BetweenGamesSideboardModal
+          pool={basePool}
+          gameNumber={2}
+          score={score}
+          {...bounds}
+          onSubmit={vi.fn()}
+        />
+      </>,
+    );
+    // Under the bug the control is visibility:hidden, so it is absent from the
+    // accessibility tree and this query throws.
+    fireEvent.click(
+      screen.getByRole("button", { name: /move one lightning bolt to sideboard/i }),
+    );
+    expect(screen.getByText(/Main \(16, min 17\)/)).toBeInTheDocument();
+    expect(screen.getByText(/Sideboard \(4\/15\)/)).toBeInTheDocument();
+  });
+
   it("disables submit when the main deck falls below the minimum deck size", () => {
     render(
       <BetweenGamesSideboardModal


### PR DESCRIPTION
The BO3 between-games sideboarding modal rendered its two MoveLists without
a `density` prop, so both took CardEntryRow's `"compact"` default. Under
compact density `controlVisibility` is `invisible group-hover:visible`, which
gates the move button behind `visibility: hidden` until a mouse hover fires.

That button is the modal's only card-moving affordance — the modal passes no
onRemove/onIncrement/onSetAsCommander — so on touch, where no hover event ever
fires, there was no way to move a card between main and sideboard at all. On
desktop it was a 20px target with no visible affordance until a row happened to
be hovered.

The deck builder already solved this: `6e247dc055` introduced `density` and
`c89284c3eb` added labelled move controls, both migrating only DeckList. The
modal kept the pre-fix path because `density` defaults to `"compact"`
specifically to leave it unchanged.

Pass `density="comfortable"` at both call sites, matching DeckList. No engine,
i18n, or behavioural change elsewhere; the two shared deck-builder files are
comment-only, correcting JSDoc this commit falsifies.

The regression test injects a local `<style>` supplying `.invisible
{visibility:hidden}` — happy-dom resolves class selectors through
getComputedStyle, but loads no Tailwind, so without that rule the probe passes
against the bug. With it, `visibility: hidden` removes the button from the
accessibility tree and `getByRole` throws. Verified to fail on the unfixed
component and pass on the fixed one, with every pre-existing test in the file
green in both states. Note `toBeVisible()` cannot be used here: the modal's
framer-motion root holds `opacity: 0` under happy-dom, which makes that matcher
unconditionally red for every element in the modal.

Claude-Session: https://claude.ai/code/session_01EkhnaTiiLE8PC1ijWvuHPB


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved the between-games sideboard experience on touch devices.
  - Card movement controls are now always visible in the sideboard modal, so cards can be moved without hovering.
  - Moving cards between the main deck and sideboard now works reliably on touch-based screens.

- **Tests**
  - Added coverage verifying cards can be moved from the main deck to the sideboard without hover interaction.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->