### PR TITLE
fix(engine): settle persisted terminal resolution before publication

### DIFF
--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -27,18 +27,22 @@ use engine::game::preview::{
 // Deep-path import by design: `engine::game::mod` re-exports `deck_validation`'s
 // public surface, but this phase must not edit that file.
 use engine::game::deck_validation::draft_set_concessions_for;
+use engine::game::CardDbRehydrationFinalization;
 use engine::game::{
     can_pair_commanders, companion_candidates, deck_copy_limit_for, estimate_bracket,
-    evaluate_deck_compatibility, filter_state_for_viewer, finalize_public_state,
-    is_brawl_commander_eligible, is_commander_eligible, is_tiny_leader_eligible,
-    load_and_hydrate_decks, max_deck_copies, rehydrate_game_from_card_db, resolve_deck_list,
+    evaluate_deck_compatibility, filter_state_for_viewer, is_brawl_commander_eligible,
+    is_commander_eligible, is_tiny_leader_eligible, load_and_hydrate_decks, max_deck_copies,
+    rehydrate_game_from_card_db_with_finalization, resolve_deck_list,
     signature_spell_selection_policy, start_game, start_game_with_starting_player,
     validate_name_deck_for_format_full, BracketEstimate, DeckCompatibilityRequest, DeckList,
     PlayerDeckList, ReplayPlayer,
 };
 use engine::types::actions::DebugAction;
 use engine::types::format::{DeckCopyLimit, FormatConfig, GameFormat};
-use engine::types::game_state::{PersistedGameState, TrustedGameStateEnvelope, WaitingFor};
+use engine::types::game_state::{
+    PersistedGameState, PersistedRestoreFinalization, PreparedPersistedGameState,
+    TrustedGameStateEnvelope, WaitingFor,
+};
 use engine::types::identifiers::ObjectId;
 use engine::types::interaction::{InteractionSessionId, InteractionSubmission};
 use engine::types::mana::ManaCost;
@@ -136,12 +140,18 @@ fn format_diagnostic_value(value: &serde_json::Value) -> String {
 }
 
 #[derive(Debug)]
+struct PreparedRestoredGameState {
+    state: PreparedPersistedGameState,
+    debug_permitted_was_serialized: bool,
+}
+
+#[derive(Debug)]
 struct DecodedRestoredGameState {
     state: GameState,
     debug_permitted_was_serialized: bool,
 }
 
-fn decode_restored_game_state(json_str: &str) -> Result<DecodedRestoredGameState, String> {
+fn prepare_restored_game_state(json_str: &str) -> Result<PreparedRestoredGameState, String> {
     let serialized = serde_json::from_str::<serde_json::Value>(json_str)
         .map_err(|error| format!("Failed to deserialize GameState: {error}"))?;
     let state = serialized
@@ -151,15 +161,25 @@ fn decode_restored_game_state(json_str: &str) -> Result<DecodedRestoredGameState
     let debug_permitted_was_serialized =
         state.is_some_and(|state| state.contains_key("debug_permitted"));
     let state = serde_json::from_value::<PersistedGameState>(serialized)
-        .map(PersistedGameState::into_game_state)
+        .map_err(|error| format!("Failed to deserialize GameState: {error}"))?
+        .prepare_for_restore(PersistedRestoreFinalization::DeferUntilRehydrated)
         .map_err(|error| format!("Failed to deserialize GameState: {error}"))?;
-    state
-        .format_config
-        .reject_unimplemented_range_of_influence()
-        .map_err(|error| format!("Failed to restore GameState: {error}"))?;
-    Ok(DecodedRestoredGameState {
+    Ok(PreparedRestoredGameState {
         state,
         debug_permitted_was_serialized,
+    })
+}
+
+/// Native-only decode helper for restore-boundary tests that do not need card
+/// database rehydration. Production callers use `prepare_restored_game_state`
+/// and finalize only after their card database is present.
+#[cfg(test)]
+fn decode_restored_game_state(json_str: &str) -> Result<DecodedRestoredGameState, String> {
+    let restored = prepare_restored_game_state(json_str)?;
+    let state = restored.state.finalize_after_rehydration(|_| Ok(()))?;
+    Ok(DecodedRestoredGameState {
+        state,
+        debug_permitted_was_serialized: restored.debug_permitted_was_serialized,
     })
 }
 
@@ -2221,19 +2241,33 @@ fn rehydrate_restored_state_from_card_db(state: &mut GameState) -> Result<(), St
             "Cannot restore game state: card database is not loaded. Call load_card_database first."
                 .to_string()
         })?;
-        rehydrate_game_from_card_db(state, db);
+        rehydrate_game_from_card_db_with_finalization(
+            state,
+            db,
+            CardDbRehydrationFinalization::Defer,
+        );
         Ok(())
     })
 }
 
 fn decode_and_rehydrate_restored_game_state(
     json_str: &str,
+    restore_runtime: impl FnOnce(&mut GameState),
 ) -> Result<DecodedRestoredGameState, String> {
-    let mut restored = decode_restored_game_state(json_str)?;
-    rehydrate_restored_state_from_card_db(&mut restored.state)?;
-    // Combat declaration snapshots are display data derived from the rehydrated
-    // live board. Rebuild them before this external state becomes interactive.
-    engine::game::combat::refresh_combat_declaration_waiting_for(&mut restored.state);
+    let restored = prepare_restored_game_state(json_str)?;
+    let debug_permitted_was_serialized = restored.debug_permitted_was_serialized;
+    let state = restored.state.finalize_after_rehydration(|state| {
+        rehydrate_restored_state_from_card_db(state)?;
+        // Combat declaration snapshots are display data derived from the rehydrated
+        // live board. Rebuild them before this external state becomes interactive.
+        engine::game::combat::refresh_combat_declaration_waiting_for(state);
+        restore_runtime(state);
+        Ok(())
+    })?;
+    let restored = DecodedRestoredGameState {
+        state,
+        debug_permitted_was_serialized,
+    };
     Ok(restored)
 }
 
@@ -2306,17 +2340,10 @@ fn restore_game_state_inner(json_str: &str) -> Result<(), String> {
     if MULTIPLAYER_MODE.with(|cell| cell.get()) {
         return Err("restore_game_state refused: undo is disabled in multiplayer sessions".into());
     }
-    let restored = decode_and_rehydrate_restored_game_state(json_str)?;
+    let restored = decode_and_rehydrate_restored_game_state(json_str, GameState::rehydrate_rng)?;
     let mut state = restored.state;
-    // Reseed the skipped `rng` and fast-forward it to the offset captured at
-    // export (issue #5466) so the restored game draws the values that would have
-    // come NEXT rather than replaying from origin. The engine owns this logic
-    // (`GameState::rehydrate_rng`); pre-#5466 snapshots carry `rng_word_pos == 0`
-    // and reproduce the previous rewind-to-origin behavior.
-    state.rehydrate_rng();
     state.debug_mode = true;
     backfill_legacy_debug_permissions(&mut state, restored.debug_permitted_was_serialized, false);
-    finalize_public_state(&mut state);
     bind_interaction_session(&mut state);
     GAME_STATE.with(|cell| cell.set(Some(state)));
     // Restoring (undo, or resuming a save from a fresh worker that never saw
@@ -2415,23 +2442,16 @@ pub fn resume_multiplayer_host_state(json_str: &str) -> Result<JsValue, JsValue>
         ));
     }
 
-    let restored = decode_and_rehydrate_restored_game_state(json_str)
-        .map_err(|error| JsValue::from_str(&error))?;
+    let restored = decode_and_rehydrate_restored_game_state(json_str, |state| {
+        let fresh_seed: u64 = rand::rng().random();
+        state.rng_seed = fresh_seed;
+        state.rng = ChaCha20Rng::seed_from_u64(fresh_seed);
+        state.rng_word_pos = 0;
+    })
+    .map_err(|error| JsValue::from_str(&error))?;
     let mut state = restored.state;
     backfill_legacy_debug_permissions(&mut state, restored.debug_permitted_was_serialized, true);
 
-    // Deliberately re-roll a fresh seed on multiplayer host resume so continued
-    // play diverges from any pre-save sequence (mirrors server-core). This is a
-    // multiplayer-resume policy choice, independent of the #5466 undo fix: even
-    // though the stream position now round-trips via `rng_word_pos`, a resumed
-    // host should NOT replay the exact saved randomness. Reset the offset to 0
-    // to match the freshly seeded stream.
-    let fresh_seed: u64 = rand::rng().random();
-    state.rng_seed = fresh_seed;
-    state.rng = ChaCha20Rng::seed_from_u64(fresh_seed);
-    state.rng_word_pos = 0;
-
-    finalize_public_state(&mut state);
     bind_interaction_session(&mut state);
 
     GAME_STATE.with(|cell| cell.set(Some(state)));
@@ -2455,7 +2475,7 @@ mod restored_card_db_requirements_tests {
         CARD_DB.with(|cell| *cell.borrow_mut() = None);
         let json = serde_json::to_string(&GameState::new_two_player(17)).unwrap();
 
-        let error = decode_and_rehydrate_restored_game_state(&json)
+        let error = decode_and_rehydrate_restored_game_state(&json, |_| {})
             .expect_err("restore must require CARD_DB");
         assert!(error.contains("card database"));
         assert!(GAME_STATE.with(|cell| cell.replace(None).is_none()));

--- a/crates/engine-wasm/src/lib.rs
+++ b/crates/engine-wasm/src/lib.rs
@@ -163,7 +163,7 @@ fn prepare_restored_game_state(json_str: &str) -> Result<PreparedRestoredGameSta
     let state = serde_json::from_value::<PersistedGameState>(serialized)
         .map_err(|error| format!("Failed to deserialize GameState: {error}"))?
         .prepare_for_restore(PersistedRestoreFinalization::DeferUntilRehydrated)
-        .map_err(|error| format!("Failed to deserialize GameState: {error}"))?;
+        .map_err(|error| format!("Failed to restore GameState: {error}"))?;
     Ok(PreparedRestoredGameState {
         state,
         debug_permitted_was_serialized,
@@ -176,7 +176,10 @@ fn prepare_restored_game_state(json_str: &str) -> Result<PreparedRestoredGameSta
 #[cfg(test)]
 fn decode_restored_game_state(json_str: &str) -> Result<DecodedRestoredGameState, String> {
     let restored = prepare_restored_game_state(json_str)?;
-    let state = restored.state.finalize_after_rehydration(|_| Ok(()))?;
+    let state = restored
+        .state
+        .finalize_after_rehydration(|_| Ok(()))
+        .map_err(|error| format!("Failed to restore GameState: {error}"))?;
     Ok(DecodedRestoredGameState {
         state,
         debug_permitted_was_serialized: restored.debug_permitted_was_serialized,
@@ -2256,14 +2259,17 @@ fn decode_and_rehydrate_restored_game_state(
 ) -> Result<DecodedRestoredGameState, String> {
     let restored = prepare_restored_game_state(json_str)?;
     let debug_permitted_was_serialized = restored.debug_permitted_was_serialized;
-    let state = restored.state.finalize_after_rehydration(|state| {
-        rehydrate_restored_state_from_card_db(state)?;
-        // Combat declaration snapshots are display data derived from the rehydrated
-        // live board. Rebuild them before this external state becomes interactive.
-        engine::game::combat::refresh_combat_declaration_waiting_for(state);
-        restore_runtime(state);
-        Ok(())
-    })?;
+    let state = restored
+        .state
+        .finalize_after_rehydration(|state| {
+            rehydrate_restored_state_from_card_db(state)?;
+            // Combat declaration snapshots are display data derived from the rehydrated
+            // live board. Rebuild them before this external state becomes interactive.
+            engine::game::combat::refresh_combat_declaration_waiting_for(state);
+            restore_runtime(state);
+            Ok(())
+        })
+        .map_err(|error| format!("Failed to restore GameState: {error}"))?;
     let restored = DecodedRestoredGameState {
         state,
         debug_permitted_was_serialized,

--- a/crates/engine/src/analysis/resource.rs
+++ b/crates/engine/src/analysis/resource.rs
@@ -7430,6 +7430,7 @@ mod tests {
         )
         .expect("gameState deserializes through the production decoder")
         .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract")
     }
 
     /// One beat of the shared dump drive policy (`tests/integration/loop_shortcut.rs`'s
@@ -15468,12 +15469,13 @@ mod tests {
         // `reject_legacy_raw_prompt_authority` and `decode_persisted_resolution_state`
         // first, so this row exercises the chokepoint the server's `from_persisted` and
         // WASM's `decode_restored_game_state` actually funnel through.
-        // `.expect(..)`, not `?`: `into_game_state` returns `GameState`, not `Result`.
+        // The test unwraps the fallible persistence boundary after asserting this fixture decodes.
         let state = serde_json::from_value::<crate::types::game_state::PersistedGameState>(
             envelope["gameState"].clone(),
         )
         .expect("gameState deserializes through the production decoder")
-        .into_game_state();
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
 
         // ── reach-guards: the subject really is present, in a never-cast-from zone ─────
         let spear = state
@@ -18575,7 +18577,8 @@ mod tests {
         let raw = serde_json::to_value(&state).expect("the state serializes");
         let restored = serde_json::from_value::<PersistedGameState>(raw.clone())
             .expect("decodes through the production persistence boundary")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         assert_eq!(
             restored.waiting_for, wait,
             "the restored wait must carry the SAME per-cycle signature, not a dropped or \
@@ -18584,7 +18587,8 @@ mod tests {
         let text = serde_json::to_string(&raw).expect("serializes to text");
         let via_str = serde_json::from_str::<PersistedGameState>(&text)
             .expect("and through the WASM bridge's own `from_str::<PersistedGameState>`")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         assert_eq!(via_str.waiting_for, wait);
 
         // (iii) MUST-NOT-FLIP: a proposal stating no signature stays absent from the wire.

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1413,11 +1413,18 @@ fn apply_action_boundary_core(
     // while the real state is repaired.
     let pre_recovery_pass_was_authorized = matches!(&action, GameAction::PassPriority)
         && check_actor_authorization(state, authenticated_actor, &action).is_ok();
+    let swept_ownerless_post_replacement_dispatch =
+        has_ownerless_post_replacement_dispatch_at_priority_boundary(state);
     effects::sweep_ownerless_post_replacement_strand(state);
     let recovered_devour_rest_boundary =
         recover_orphaned_devour_completion_at_priority_boundary(state)
             || recover_orphaned_spell_resolution_at_priority_boundary(state);
     state.remove_empty_active_post_replacement_frame();
+    let recovered_devour_rest_boundary = recovered_devour_rest_boundary
+        || recover_ownerless_post_replacement_completion_at_priority_boundary(
+            state,
+            swept_ownerless_post_replacement_dispatch,
+        );
     let recovered_stale_priority_pass =
         recovered_devour_rest_boundary && matches!(&action, GameAction::PassPriority);
     let boundary_snapshot = state.clone();
@@ -1646,14 +1653,29 @@ pub(crate) fn recover_terminal_resolution_rest_on_restore(
         return Ok(false);
     }
 
+    // A construction recipient may be serialized after the direct
+    // triggered-mana root has completed. At Priority, that recipient alone is
+    // not proof of the exceptional settled-priority path, so it cannot survive
+    // the persistence boundary as scheduling authority.
+    if state.pending_triggered_mana_resume.is_none() {
+        state.pending_trigger_construction_priority_recipient = None;
+    }
+
     let mut remaining_steps = terminal_rest_measure(state).saturating_add(1);
     let mut recovered_terminal_rest = false;
     loop {
         let before = terminal_rest_measure(state);
+        let swept_ownerless_post_replacement_dispatch =
+            has_ownerless_post_replacement_dispatch_at_priority_boundary(state);
         effects::sweep_ownerless_post_replacement_strand(state);
         recovered_terminal_rest |= recover_orphaned_devour_completion_at_priority_boundary(state)
             || recover_orphaned_spell_resolution_at_priority_boundary(state);
         state.remove_empty_active_post_replacement_frame();
+        recovered_terminal_rest |=
+            recover_ownerless_post_replacement_completion_at_priority_boundary(
+                state,
+                swept_ownerless_post_replacement_dispatch,
+            );
         let after = terminal_rest_measure(state);
 
         if after == 0 {
@@ -1672,9 +1694,7 @@ pub(crate) fn recover_terminal_resolution_rest_on_restore(
 
     if matches!(state.waiting_for, WaitingFor::Priority { .. })
         && state.stack_resolution_session.is_none()
-        && (!state.resolution_stack.is_empty()
-            || state.resolving_stack_entry.is_some()
-            || state.pending_resolution_completion.is_some())
+        && (state.resolving_stack_entry.is_some() || state.pending_resolution_completion.is_some())
     {
         return Err(PersistedRestoreError::UnsettledPriorityResolution);
     }
@@ -1705,6 +1725,53 @@ fn terminal_rest_measure(state: &GameState) -> usize {
         + empty_post_replacement * 2
         + usize::from(is_orphaned_devour_completion_at_priority_boundary(state))
         + usize::from(is_orphaned_spell_resolution_at_priority_boundary(state))
+}
+
+fn has_ownerless_post_replacement_dispatch_at_priority_boundary(state: &GameState) -> bool {
+    matches!(state.waiting_for, WaitingFor::Priority { .. })
+        && !crate::game::engine_replacement::post_replacement_dispatch_is_live()
+        && state
+            .active_post_replacement_drains()
+            .and_then(crate::types::game_state::PostReplacementDrainStack::resident)
+            .is_some_and(|drain| {
+                matches!(
+                    drain.status,
+                    crate::types::game_state::DrainStatus::Dispatching
+                )
+            })
+}
+
+/// An ownerless post-replacement dispatch proves that its continuation already
+/// returned, but pre-v0.65 persistence could retain the resolving carrier after
+/// the now-empty drain frame is removed. Settle only that carrier completion; a
+/// Ready or Paused drain, any remaining frame, or a pending completion is live
+/// work and remains untouched.
+fn recover_ownerless_post_replacement_completion_at_priority_boundary(
+    state: &mut GameState,
+    swept_ownerless_post_replacement_dispatch: bool,
+) -> bool {
+    if !swept_ownerless_post_replacement_dispatch
+        || !matches!(state.waiting_for, WaitingFor::Priority { .. })
+        || !state.resolution_stack.is_empty()
+        || state.pending_cast.is_some()
+        || state.pending_resolution_completion.is_some()
+        || state.resolving_stack_entry.is_none()
+    {
+        return false;
+    }
+
+    let mut recovered = state.clone();
+    settle_resolving_stack_entry_after_continuation_resume(&mut recovered);
+    if recovered.resolving_stack_entry.is_some() {
+        return false;
+    }
+
+    priority::reset_priority(&mut recovered);
+    recovered.waiting_for = WaitingFor::Priority {
+        player: recovered.active_player,
+    };
+    *state = recovered;
+    true
 }
 
 fn is_orphaned_devour_completion_at_priority_boundary(state: &GameState) -> bool {

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1647,9 +1647,7 @@ pub(crate) fn recover_terminal_resolution_rest_on_restore(
 
     if matches!(state.waiting_for, WaitingFor::Priority { .. })
         && state.stack_resolution_session.is_none()
-        && (!state.resolution_stack.is_empty()
-            || state.resolving_stack_entry.is_some()
-            || state.pending_resolution_completion.is_some())
+        && (state.resolving_stack_entry.is_some() || state.pending_resolution_completion.is_some())
     {
         return Err(PersistedRestoreError::UnsettledPriorityResolution);
     }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -15,10 +15,10 @@ use crate::types::game_state::{
     ActionResult, AssistState, AutoMayChoice, AutoPassMode, AutoPassRequest, CastOfferKind,
     CastingVariant, ConvokeMode, CostResume, GameState, LandPlayRecord, LoopDetectionMode,
     ManaAbilityResume, MayTriggerAutoChoiceKey, PayCostKind, PendingCostMoveResume,
-    PendingCounterPostAction, PendingEffectResolved, ResolveAllConsentParticipant,
-    ResolveAllConsentRun, ResolveAllPrioritySnapshot, RetargetScope, StackEntry, StackEntryKind,
-    StackResolutionAutoPassOverlay, StackResolutionBudget, StackResolutionEntryFence,
-    StackResolutionPolicy, StackResolutionSession, WaitingFor,
+    PendingCounterPostAction, PendingEffectResolved, PersistedRestoreError,
+    ResolveAllConsentParticipant, ResolveAllConsentRun, ResolveAllPrioritySnapshot, RetargetScope,
+    StackEntry, StackEntryKind, StackResolutionAutoPassOverlay, StackResolutionBudget,
+    StackResolutionEntryFence, StackResolutionPolicy, StackResolutionSession, WaitingFor,
 };
 use crate::types::identifiers::{CardId, DelayedTriggerOrigin, ObjectId, ObjectIncarnationRef};
 use crate::types::match_config::MatchType;
@@ -1627,6 +1627,185 @@ fn recover_orphaned_spell_resolution_at_priority_boundary(state: &mut GameState)
     };
     *state = recovered;
     true
+}
+
+/// Prepare a decoded persisted state before runtime-only card data is restored.
+///
+/// This is deliberately a bounded, monotonic repair loop rather than a call to
+/// the ordinary action reducer: decoding must not invent a player action or a
+/// Resolve All continuation. Each iteration first retires ownerless
+/// post-replacement dispatches, then consumes one exact terminal carrier, then
+/// removes the newly exposed empty frame. If that sequence cannot strictly
+/// lower the terminal-rest measure, the caller receives a fail-closed restore
+/// error instead of publishing a priority state that `start_next_turn` will
+/// later reject.
+pub(crate) fn recover_terminal_resolution_rest_on_restore(
+    state: &mut GameState,
+) -> Result<bool, PersistedRestoreError> {
+    if !matches!(state.waiting_for, WaitingFor::Priority { .. }) {
+        return Ok(false);
+    }
+
+    let mut remaining_steps = terminal_rest_measure(state).saturating_add(1);
+    let mut recovered_terminal_rest = false;
+    loop {
+        let before = terminal_rest_measure(state);
+        effects::sweep_ownerless_post_replacement_strand(state);
+        recovered_terminal_rest |= recover_orphaned_devour_completion_at_priority_boundary(state)
+            || recover_orphaned_spell_resolution_at_priority_boundary(state);
+        state.remove_empty_active_post_replacement_frame();
+        let after = terminal_rest_measure(state);
+
+        if after == 0 {
+            break;
+        }
+        if after >= before {
+            return Err(PersistedRestoreError::TerminalRestRecoveryExhausted);
+        }
+        remaining_steps = remaining_steps
+            .checked_sub(1)
+            .ok_or(PersistedRestoreError::TerminalRestRecoveryExhausted)?;
+        if remaining_steps == 0 {
+            return Err(PersistedRestoreError::TerminalRestRecoveryExhausted);
+        }
+    }
+
+    if matches!(state.waiting_for, WaitingFor::Priority { .. })
+        && state.stack_resolution_session.is_none()
+        && (!state.resolution_stack.is_empty()
+            || state.resolving_stack_entry.is_some()
+            || state.pending_resolution_completion.is_some())
+    {
+        return Err(PersistedRestoreError::UnsettledPriorityResolution);
+    }
+    Ok(recovered_terminal_rest)
+}
+
+fn terminal_rest_measure(state: &GameState) -> usize {
+    // Removing an outer ownerless/empty post-replacement frame can expose the
+    // terminal carrier below it. Weight the outer obstruction above that
+    // carrier so every permitted exposure is still strictly decreasing.
+    let (ownerless, empty_post_replacement) =
+        state
+            .active_post_replacement_drains()
+            .map_or((0, 0), |drains| {
+                (
+                    usize::from(drains.resident().is_some_and(|drain| {
+                        matches!(
+                            drain.status,
+                            crate::types::game_state::DrainStatus::Dispatching
+                        )
+                    })),
+                    usize::from(
+                        crate::types::game_state::PostReplacementDrainStack::is_empty(drains),
+                    ),
+                )
+            });
+    ownerless * 4
+        + empty_post_replacement * 2
+        + usize::from(is_orphaned_devour_completion_at_priority_boundary(state))
+        + usize::from(is_orphaned_spell_resolution_at_priority_boundary(state))
+}
+
+fn is_orphaned_devour_completion_at_priority_boundary(state: &GameState) -> bool {
+    matches!(state.waiting_for, WaitingFor::Priority { .. })
+        && state.resolving_stack_entry.is_some()
+        && state.resolution_stack.len() == 2
+        && state.active_change_zone_frame().is_some_and(|frame| {
+            frame.pending.is_none() && frame.devour_eligible_snapshot.is_some()
+        })
+        && state
+            .active_post_replacement_drains()
+            .is_some_and(crate::types::game_state::PostReplacementDrainStack::is_empty)
+}
+
+fn is_orphaned_spell_resolution_at_priority_boundary(state: &GameState) -> bool {
+    let Some(pending) = state.active_spell_resolution() else {
+        return false;
+    };
+    matches!(state.waiting_for, WaitingFor::Priority { .. })
+        && state.stack.is_empty()
+        && state.resolution_stack.len() == 1
+        && state.active_ability_continuation().is_none()
+        && state.pending_cast.is_none()
+        && state.pending_resolution_completion.is_none()
+        && matches!(
+            state.resolving_stack_entry.as_ref(),
+            Some(crate::types::game_state::StackEntry {
+                id,
+                kind: StackEntryKind::Spell { .. },
+                ..
+            }) if *id == pending.object_id
+        )
+}
+
+/// Finalize a checked persisted restore after its runtime-only data is present.
+///
+/// `finalize_rules_state` remains interior to this boundary so no partially
+/// rehydrated state escapes. The terminal-rest preparation has already either
+/// settled exact engine-owned residue or failed closed, so this makes no pass,
+/// stack-resolution, or Resolve All decision on the caller's behalf.
+pub(crate) fn finalize_persisted_restore(
+    state: &mut GameState,
+    recovered_terminal_rest: bool,
+) -> Result<(), PersistedRestoreError> {
+    finalize_rules_state(state);
+    let recovered_terminal_rest =
+        recovered_terminal_rest || recover_terminal_resolution_rest_on_restore(state)?;
+    if recovered_terminal_rest {
+        settle_deferred_triggers_after_persisted_restore(state)?;
+    }
+    // The settlement pipeline returns its authoritative wait rather than
+    // publishing it itself. Synchronize that wait before the one display
+    // finalization below.
+    finalize_rules_state(state);
+    finalize_display_state(state);
+    Ok(())
+}
+
+/// Settle a deferred trigger batch that survived a persisted terminal-rest
+/// repair before publishing a priority window.
+///
+/// Restore never treats a serialized construction recipient as proof that the
+/// settled-priority pipeline is safe. That recipient is scheduling state, not
+/// a live typed root: a raw snapshot can forge it without the completed
+/// triggered-mana root that validated the exceptional drain policy. Drop it
+/// and use the ordinary resolution-safe pipeline instead. A batch that remains
+/// queued after that policy is not publishable.
+fn settle_deferred_triggers_after_persisted_restore(
+    state: &mut GameState,
+) -> Result<(), PersistedRestoreError> {
+    let WaitingFor::Priority { player } = &state.waiting_for else {
+        return Ok(());
+    };
+    let player = *player;
+    // `pending_triggered_mana_resume` is absent once the direct root has
+    // completed, so the saved recipient alone cannot establish the live root
+    // provenance required by `SettledPriority`. Do not manufacture that
+    // provenance from serialized scheduling data.
+    state.pending_trigger_construction_priority_recipient = None;
+    if state.deferred_triggers.is_empty() {
+        return Ok(());
+    }
+
+    let mut events = Vec::new();
+    let waiting_for = engine_priority::run_post_action_pipeline_from(
+        state,
+        &mut events,
+        0,
+        &WaitingFor::Priority { player },
+        false,
+        false,
+    )
+    .map_err(|error| PersistedRestoreError::PrioritySettlementFailed(error.to_string()))?;
+    state.waiting_for = waiting_for;
+
+    if matches!(state.waiting_for, WaitingFor::Priority { .. })
+        && !state.deferred_triggers.is_empty()
+    {
+        return Err(PersistedRestoreError::DeferredTriggerSettlement);
+    }
+    Ok(())
 }
 
 fn finish_action_boundary(
@@ -19262,10 +19441,11 @@ mod stage2_injector_tests {
         // first, so this helper exercises the chokepoint the server's `from_persisted`
         // and WASM's `decode_restored_game_state` actually funnel through — including
         // the CR 732.2a load-seam bound invariant.
-        // `.expect(..)`, not `?`: `into_game_state` returns `GameState`, not `Result`.
+        // The test unwraps the fallible persistence boundary after asserting this fixture decodes.
         serde_json::from_value::<PersistedGameState>(envelope["gameState"].clone())
             .expect("gameState deserializes through the production decoder")
             .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract")
     }
 
     const EMBLEM: ObjectId = ObjectId(541);
@@ -21078,10 +21258,11 @@ mod kilo_interruptibility_tests {
         // Decoding AS `PersistedGameState` (rather than decoding a bare `GameState` and
         // wrapping it) additionally routes the dump through
         // `reject_legacy_raw_prompt_authority` + `decode_persisted_resolution_state`.
-        // `.expect(..)`, not `?`: `into_game_state` returns `GameState`, not `Result`.
+        // The test unwraps the fallible persistence boundary after asserting this fixture decodes.
         serde_json::from_value::<PersistedGameState>(envelope["gameState"].clone())
             .expect("gameState deserializes through the production decoder")
             .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract")
     }
 
     fn beat_actor(state: &GameState) -> PlayerId {

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1413,20 +1413,9 @@ fn apply_action_boundary_core(
     // while the real state is repaired.
     let pre_recovery_pass_was_authorized = matches!(&action, GameAction::PassPriority)
         && check_actor_authorization(state, authenticated_actor, &action).is_ok();
-    let swept_ownerless_post_replacement_dispatch =
-        has_ownerless_post_replacement_dispatch_at_priority_boundary(state);
-    effects::sweep_ownerless_post_replacement_strand(state);
-    let recovered_devour_rest_boundary =
-        recover_orphaned_devour_completion_at_priority_boundary(state)
-            || recover_orphaned_spell_resolution_at_priority_boundary(state);
-    state.remove_empty_active_post_replacement_frame();
-    let recovered_devour_rest_boundary = recovered_devour_rest_boundary
-        || recover_ownerless_post_replacement_completion_at_priority_boundary(
-            state,
-            swept_ownerless_post_replacement_dispatch,
-        );
+    let recovered_terminal_rest_boundary = sweep_and_recover_priority_boundary_rest(state);
     let recovered_stale_priority_pass =
-        recovered_devour_rest_boundary && matches!(&action, GameAction::PassPriority);
+        recovered_terminal_rest_boundary && matches!(&action, GameAction::PassPriority);
     let boundary_snapshot = state.clone();
     let journal_start = state.resolved_rules_journal.entries().len();
     let is_actor_scoped_preference = action.is_actor_scoped_preference();
@@ -1639,17 +1628,7 @@ pub(crate) fn recover_terminal_resolution_rest_on_restore(
     let mut recovered_terminal_rest = false;
     loop {
         let before = terminal_rest_measure(state);
-        let swept_ownerless_post_replacement_dispatch =
-            has_ownerless_post_replacement_dispatch_at_priority_boundary(state);
-        effects::sweep_ownerless_post_replacement_strand(state);
-        recovered_terminal_rest |= recover_orphaned_devour_completion_at_priority_boundary(state)
-            || recover_orphaned_spell_resolution_at_priority_boundary(state);
-        state.remove_empty_active_post_replacement_frame();
-        recovered_terminal_rest |=
-            recover_ownerless_post_replacement_completion_at_priority_boundary(
-                state,
-                swept_ownerless_post_replacement_dispatch,
-            );
+        recovered_terminal_rest |= sweep_and_recover_priority_boundary_rest(state);
         let after = terminal_rest_measure(state);
 
         if after == 0 {
@@ -1668,7 +1647,9 @@ pub(crate) fn recover_terminal_resolution_rest_on_restore(
 
     if matches!(state.waiting_for, WaitingFor::Priority { .. })
         && state.stack_resolution_session.is_none()
-        && (state.resolving_stack_entry.is_some() || state.pending_resolution_completion.is_some())
+        && (!state.resolution_stack.is_empty()
+            || state.resolving_stack_entry.is_some()
+            || state.pending_resolution_completion.is_some())
     {
         return Err(PersistedRestoreError::UnsettledPriorityResolution);
     }
@@ -1713,6 +1694,26 @@ fn has_ownerless_post_replacement_dispatch_at_priority_boundary(state: &GameStat
                     crate::types::game_state::DrainStatus::Dispatching
                 )
             })
+}
+
+/// Retires the exact, engine-owned terminal rest that can remain visible at a
+/// priority boundary after a post-replacement dispatch has completed.
+///
+/// The live action boundary and persisted restore must preserve this ordering:
+/// sweep the ownerless dispatch, consume an exact terminal carrier, then remove
+/// the exposed empty frame before considering the post-replacement completion.
+fn sweep_and_recover_priority_boundary_rest(state: &mut GameState) -> bool {
+    let swept_ownerless_post_replacement_dispatch =
+        has_ownerless_post_replacement_dispatch_at_priority_boundary(state);
+    effects::sweep_ownerless_post_replacement_strand(state);
+    let recovered_terminal_rest = recover_orphaned_devour_completion_at_priority_boundary(state)
+        || recover_orphaned_spell_resolution_at_priority_boundary(state);
+    state.remove_empty_active_post_replacement_frame();
+    recovered_terminal_rest
+        || recover_ownerless_post_replacement_completion_at_priority_boundary(
+            state,
+            swept_ownerless_post_replacement_dispatch,
+        )
 }
 
 /// An ownerless post-replacement dispatch proves that its continuation already

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -1559,16 +1559,7 @@ fn apply_action_boundary_core(
 /// live priority window. A prompt-bearing Devour entry or a pending multi-entry
 /// ChangeZone iteration therefore remains untouched.
 fn recover_orphaned_devour_completion_at_priority_boundary(state: &mut GameState) -> bool {
-    let is_orphaned_devour_completion = matches!(state.waiting_for, WaitingFor::Priority { .. })
-        && state.resolving_stack_entry.is_some()
-        && state.resolution_stack.len() == 2
-        && state.active_change_zone_frame().is_some_and(|frame| {
-            frame.pending.is_none() && frame.devour_eligible_snapshot.is_some()
-        })
-        && state
-            .active_post_replacement_drains()
-            .is_some_and(crate::types::game_state::PostReplacementDrainStack::is_empty);
-    if !is_orphaned_devour_completion {
+    if !is_orphaned_devour_completion_at_priority_boundary(state) {
         return false;
     }
 
@@ -1594,24 +1585,7 @@ fn recover_orphaned_devour_completion_at_priority_boundary(state: &mut GameState
 /// Consume only that exact bare carrier rest, then route settlement through the
 /// ordinary completed-carrier authority.
 fn recover_orphaned_spell_resolution_at_priority_boundary(state: &mut GameState) -> bool {
-    let Some(pending) = state.active_spell_resolution() else {
-        return false;
-    };
-    let exact_bare_spell_resolution_rest = matches!(state.waiting_for, WaitingFor::Priority { .. })
-        && state.stack.is_empty()
-        && state.resolution_stack.len() == 1
-        && state.active_ability_continuation().is_none()
-        && state.pending_cast.is_none()
-        && state.pending_resolution_completion.is_none()
-        && matches!(
-            state.resolving_stack_entry.as_ref(),
-            Some(crate::types::game_state::StackEntry {
-                id,
-                kind: StackEntryKind::Spell { .. },
-                ..
-            }) if *id == pending.object_id
-        );
-    if !exact_bare_spell_resolution_rest {
+    if !is_orphaned_spell_resolution_at_priority_boundary(state) {
         return false;
     }
 

--- a/crates/engine/src/game/engine_debug.rs
+++ b/crates/engine/src/game/engine_debug.rs
@@ -1544,7 +1544,9 @@ mod tests {
         let serialized = serde_json::to_string(&persisted).expect("paused batch serializes");
         let persisted: PersistedGameState =
             serde_json::from_str(&serialized).expect("paused batch deserializes");
-        let mut restored = persisted.into_game_state();
+        let mut restored = persisted
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         let first_resume =
             apply_as_current(&mut restored, GameAction::ChooseReplacement { index: 0 })
                 .expect("replacement choice resumes the serial batch");

--- a/crates/engine/src/game/mod.rs
+++ b/crates/engine/src/game/mod.rs
@@ -232,7 +232,10 @@ pub use engine_resolve_batch::{
 pub use game_object::{BackFaceData, GameObject, PhaseOutCause, PhaseStatus};
 pub use keywords::parse_keywords;
 pub use mana_payment::{can_pay, pay_from_pool, produce_mana, PaymentError};
-pub use printed_cards::rehydrate_game_from_card_db;
+pub use printed_cards::{
+    rehydrate_game_from_card_db, rehydrate_game_from_card_db_with_finalization,
+    CardDbRehydrationFinalization,
+};
 pub use public_state::finalize_public_state;
 pub use replay::{reconstruct_initial_state, ReplayError, ReplayPlayer};
 pub use triggers::process_triggers;

--- a/crates/engine/src/game/printed_cards.rs
+++ b/crates/engine/src/game/printed_cards.rs
@@ -34,6 +34,18 @@ use super::public_state::{
     bump_state_revision, finalize_public_state, mark_public_state_all_dirty,
 };
 
+/// Controls whether card-database rehydration may publish a state immediately.
+///
+/// Persisted-game restore must defer publication until the restore owner has
+/// installed every runtime-only field and the engine has completed its single
+/// restore finalization boundary. Ordinary in-memory callers retain the
+/// immediate behavior.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CardDbRehydrationFinalization {
+    Immediate,
+    Defer,
+}
+
 /// CR 205.3m: Look up printed core types for a card name from deck-pool faces or
 /// the card-face registry when a runtime `GameObject` lacks characteristic data.
 pub fn printed_core_types_for_name<'a>(state: &'a GameState, name: &str) -> Option<&'a [CoreType]> {
@@ -1219,6 +1231,22 @@ fn restore_legacy_swap_snapshot_provenance(state: &mut GameState) {
 }
 
 pub fn rehydrate_game_from_card_db(state: &mut GameState, db: &CardDatabase) {
+    rehydrate_game_from_card_db_with_finalization(
+        state,
+        db,
+        CardDbRehydrationFinalization::Immediate,
+    );
+}
+
+/// Rehydrate printed-card state while explicitly choosing whether this call is
+/// its public-state boundary. Restore owners use [`CardDbRehydrationFinalization::Defer`]
+/// so the prepared restore token can perform the sole finalization after all
+/// runtime fields are present.
+pub fn rehydrate_game_from_card_db_with_finalization(
+    state: &mut GameState,
+    db: &CardDatabase,
+    finalization: CardDbRehydrationFinalization,
+) {
     rehydrate_card_db_metadata(state, db);
     restore_legacy_swap_snapshot_provenance(state);
     let (changed_any, changed_battlefield) = reapply_printed_faces_from_card_db(state, db);
@@ -1227,7 +1255,9 @@ pub fn rehydrate_game_from_card_db(state: &mut GameState, db: &CardDatabase) {
     if changed_any || state.layers_dirty.is_dirty() {
         bump_state_revision(state);
         mark_public_state_all_dirty(state);
-        finalize_public_state(state);
+        if matches!(finalization, CardDbRehydrationFinalization::Immediate) {
+            finalize_public_state(state);
+        }
     }
 }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -11496,6 +11496,10 @@ pub struct PreparedPersistedGameState {
 pub enum PersistedRestoreError {
     #[error("persisted state uses an unsupported format configuration: {0}")]
     UnsupportedFormat(String),
+    #[error("persisted restore finalization policy mismatch: {0}")]
+    FinalizationPolicyMismatch(&'static str),
+    #[error("persisted state runtime rehydration failed: {0}")]
+    RehydrationFailed(String),
     #[error("persisted state has unsettled resolution ownership at priority")]
     UnsettledPriorityResolution,
     #[error("persisted terminal-rest recovery did not make strict progress")]
@@ -11513,9 +11517,11 @@ impl PreparedPersistedGameState {
     pub fn finalize_after_rehydration(
         self,
         rehydrate: impl FnOnce(&mut GameState) -> Result<(), String>,
-    ) -> Result<GameState, String> {
+    ) -> Result<GameState, PersistedRestoreError> {
         if self.finalization != PersistedRestoreFinalization::DeferUntilRehydrated {
-            return Err("persisted restore was prepared for immediate finalization".to_string());
+            return Err(PersistedRestoreError::FinalizationPolicyMismatch(
+                "prepared for immediate finalization",
+            ));
         }
         self.finish_after_rehydration(rehydrate)
     }
@@ -11523,22 +11529,21 @@ impl PreparedPersistedGameState {
     fn finish_after_rehydration(
         self,
         rehydrate: impl FnOnce(&mut GameState) -> Result<(), String>,
-    ) -> Result<GameState, String> {
+    ) -> Result<GameState, PersistedRestoreError> {
         let mut state = self.state;
-        rehydrate(&mut state)?;
-        crate::game::engine::finalize_persisted_restore(&mut state, self.recovered_terminal_rest)
-            .map_err(|error| error.to_string())?;
+        rehydrate(&mut state).map_err(PersistedRestoreError::RehydrationFailed)?;
+        crate::game::engine::finalize_persisted_restore(&mut state, self.recovered_terminal_rest)?;
         Ok(state)
     }
 
     /// Finish a checked restore whose consumer has no runtime-only state to
     /// hydrate. Kept separate from `into_game_state` so every new persistence
     /// boundary chooses its finalization policy explicitly.
-    pub fn finalize_immediately(self) -> Result<GameState, String> {
+    pub fn finalize_immediately(self) -> Result<GameState, PersistedRestoreError> {
         if self.finalization != PersistedRestoreFinalization::Immediate {
-            return Err(
-                "persisted restore requires runtime rehydration before finalization".to_string(),
-            );
+            return Err(PersistedRestoreError::FinalizationPolicyMismatch(
+                "requires runtime rehydration before finalization",
+            ));
         }
         self.finish_after_rehydration(|_| Ok(()))
     }
@@ -11700,11 +11705,7 @@ impl PersistedGameState {
     /// process panic at a library boundary.
     pub fn into_game_state(self) -> Result<GameState, PersistedRestoreError> {
         self.prepare_for_restore(PersistedRestoreFinalization::Immediate)
-            .and_then(|prepared| {
-                prepared
-                    .finalize_immediately()
-                    .map_err(PersistedRestoreError::PrioritySettlementFailed)
-            })
+            .and_then(PreparedPersistedGameState::finalize_immediately)
     }
 }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -28676,8 +28676,7 @@ mod tests {
 
         let restored = serde_json::from_value::<PersistedGameState>(v1)
             .expect("v1 fixture conservatively restores unlabelled trigger carriers")
-            .into_game_state()
-            .expect("persisted test snapshot satisfies the checked restore contract");
+            .into_game_state_unchecked();
 
         assert_eq!(
             restored.pending_trigger_firing,

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -11460,6 +11460,90 @@ pub enum PersistedGameState {
     Trusted(Box<TrustedGameStateEnvelope>),
 }
 
+/// Controls when a decoded persisted state may be finalized.
+///
+/// A persisted payload contains only serializable engine state. Callers that
+/// restore runtime-only card data must defer finalization until that data has
+/// been installed; finalizing it first can publish a priority window derived
+/// from incomplete characteristics.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PersistedRestoreFinalization {
+    /// The caller supplies runtime-only state before consuming the prepared
+    /// token with [`PreparedPersistedGameState::finalize_after_rehydration`].
+    DeferUntilRehydrated,
+    /// Compatibility policy for consumers that have no runtime rehydration
+    /// step. This still uses the same checked restore pipeline.
+    Immediate,
+}
+
+/// A decoded persisted game that has passed restore-boundary repair but has
+/// not yet been made externally observable.
+///
+/// The contained game state is deliberately opaque. The only way to mutate it
+/// is the one-shot rehydration closure, followed by the engine-owned finalizer.
+/// This prevents a persistence consumer from accidentally publishing an
+/// intermediate priority state between decode and runtime rehydration.
+#[derive(Debug)]
+pub struct PreparedPersistedGameState {
+    state: GameState,
+    finalization: PersistedRestoreFinalization,
+    recovered_terminal_rest: bool,
+}
+
+/// A persisted state reached a priority window with unresolved resolution
+/// ownership and no exact engine-owned terminal repair.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum PersistedRestoreError {
+    #[error("persisted state uses an unsupported format configuration: {0}")]
+    UnsupportedFormat(String),
+    #[error("persisted state has unsettled resolution ownership at priority")]
+    UnsettledPriorityResolution,
+    #[error("persisted terminal-rest recovery did not make strict progress")]
+    TerminalRestRecoveryExhausted,
+    #[error("persisted priority state has deferred triggers that could not settle")]
+    DeferredTriggerSettlement,
+    #[error("persisted priority settlement failed: {0}")]
+    PrioritySettlementFailed(String),
+}
+
+impl PreparedPersistedGameState {
+    /// Rehydrate runtime-only state, then run the single restore finalization
+    /// boundary. The closure is intentionally the only mutable access to the
+    /// decoded state and is consumed exactly once with this token.
+    pub fn finalize_after_rehydration(
+        self,
+        rehydrate: impl FnOnce(&mut GameState) -> Result<(), String>,
+    ) -> Result<GameState, String> {
+        if self.finalization != PersistedRestoreFinalization::DeferUntilRehydrated {
+            return Err("persisted restore was prepared for immediate finalization".to_string());
+        }
+        self.finish_after_rehydration(rehydrate)
+    }
+
+    fn finish_after_rehydration(
+        self,
+        rehydrate: impl FnOnce(&mut GameState) -> Result<(), String>,
+    ) -> Result<GameState, String> {
+        let mut state = self.state;
+        rehydrate(&mut state)?;
+        crate::game::engine::finalize_persisted_restore(&mut state, self.recovered_terminal_rest)
+            .map_err(|error| error.to_string())?;
+        Ok(state)
+    }
+
+    /// Finish a checked restore whose consumer has no runtime-only state to
+    /// hydrate. Kept separate from `into_game_state` so every new persistence
+    /// boundary chooses its finalization policy explicitly.
+    pub fn finalize_immediately(self) -> Result<GameState, String> {
+        if self.finalization != PersistedRestoreFinalization::Immediate {
+            return Err(
+                "persisted restore requires runtime rehydration before finalization".to_string(),
+            );
+        }
+        self.finish_after_rehydration(|_| Ok(()))
+    }
+}
+
 impl Serialize for PersistedGameState {
     fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
     where
@@ -11529,8 +11613,10 @@ impl PersistedGameState {
         Self::Trusted(Box::new(TrustedGameStateEnvelope::capture(state)))
     }
 
-    /// Restores the persisted form through the appropriate trust boundary.
-    pub fn into_game_state(self) -> GameState {
+    /// Decodes the persisted form through the appropriate trust boundary,
+    /// without publishing it. This is private on purpose: every external
+    /// restore must first pass the checked terminal-rest preparation below.
+    fn into_game_state_unchecked(self) -> GameState {
         let mut state = match self {
             Self::Raw(state) => {
                 let mut state = *state;
@@ -11583,6 +11669,42 @@ impl PersistedGameState {
         state.rehydrate_rng();
         state.resume_stale_token_commander_zone_choice();
         state
+    }
+
+    /// Decode and repair a persisted state before runtime-only data is
+    /// rehydrated. No priority pass, Resolve All resume, or other player action
+    /// is manufactured here.
+    pub fn prepare_for_restore(
+        self,
+        finalization: PersistedRestoreFinalization,
+    ) -> Result<PreparedPersistedGameState, PersistedRestoreError> {
+        let mut state = self.into_game_state_unchecked();
+        state
+            .format_config
+            .reject_unimplemented_range_of_influence()
+            .map_err(PersistedRestoreError::UnsupportedFormat)?;
+        let recovered_terminal_rest =
+            crate::game::engine::recover_terminal_resolution_rest_on_restore(&mut state)?;
+        Ok(PreparedPersistedGameState {
+            state,
+            finalization,
+            recovered_terminal_rest,
+        })
+    }
+
+    /// Checked decode for callers without runtime-only rehydration.
+    ///
+    /// Production persistence boundaries that need runtime-only card data use
+    /// [`Self::prepare_for_restore`] with deferred finalization. This immediate
+    /// variant remains fallible so persisted corruption cannot turn into a
+    /// process panic at a library boundary.
+    pub fn into_game_state(self) -> Result<GameState, PersistedRestoreError> {
+        self.prepare_for_restore(PersistedRestoreFinalization::Immediate)
+            .and_then(|prepared| {
+                prepared
+                    .finalize_immediately()
+                    .map_err(PersistedRestoreError::PrioritySettlementFailed)
+            })
     }
 }
 
@@ -26589,7 +26711,8 @@ mod tests {
 
         let restored = serde_json::from_value::<PersistedGameState>(persisted)
             .expect("legacy effect save restores through the persisted boundary")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         assert!(matches!(
             restored.objects[&source].abilities[0].effect.as_ref(),
             Effect::SetTapState {
@@ -26796,7 +26919,8 @@ mod tests {
 
             let restored = serde_json::from_value::<PersistedGameState>(persisted)
                 .expect("legacy pair marker migrates at the persistence boundary")
-                .into_game_state();
+                .into_game_state()
+                .expect("persisted test snapshot satisfies the checked restore contract");
             assert!(restored.batched_zone_change_trigger_fired.contains(&(
                 definition_ref.clone(),
                 19,
@@ -27103,10 +27227,12 @@ mod tests {
 
         let raw = serde_json::from_value::<PersistedGameState>(raw)
             .expect("raw delayed install migrates")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         let trusted = serde_json::from_value::<PersistedGameState>(trusted)
             .expect("trusted delayed install migrates")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
 
         assert_eq!(raw.delayed_triggers, trusted.delayed_triggers);
         assert_eq!(
@@ -27212,10 +27338,12 @@ mod tests {
         [
             serde_json::from_value::<PersistedGameState>(raw)
                 .expect("raw legacy dungeon prompt migrates")
-                .into_game_state(),
+                .into_game_state()
+                .expect("persisted test snapshot satisfies the checked restore contract"),
             serde_json::from_value::<PersistedGameState>(trusted)
                 .expect("trusted legacy dungeon prompt migrates")
-                .into_game_state(),
+                .into_game_state()
+                .expect("persisted test snapshot satisfies the checked restore contract"),
         ]
     }
 
@@ -27518,7 +27646,8 @@ mod tests {
             erase_persisted_event_occurrence_fields(persisted_state_payload_mut(&mut persisted));
             let restored = serde_json::from_value::<PersistedGameState>(persisted)
                 .expect("unique legacy event records reconcile")
-                .into_game_state();
+                .into_game_state()
+                .expect("persisted test snapshot satisfies the checked restore contract");
             assert_eq!(
                 restored_deferred_zone_change_keys(&restored),
                 vec![(19, 0), (19, 1)]
@@ -27580,7 +27709,8 @@ mod tests {
         erase_persisted_event_occurrence_fields(persisted_state_payload_mut(&mut persisted));
         let restored = serde_json::from_value::<PersistedGameState>(persisted)
             .expect("the parked batch's records reconcile")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         let batch = restored
             .pending_discard_batch
             .as_ref()
@@ -27685,7 +27815,8 @@ mod tests {
 
         let restored = serde_json::from_value::<PersistedGameState>(wire)
             .expect("an absent parked batch defaults to None")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         assert!(restored.pending_discard_batch.is_none());
         assert!(
             matches!(
@@ -27766,7 +27897,8 @@ mod tests {
         erase_persisted_event_occurrence_fields(persisted_state_payload_mut(&mut persisted));
         let restored = serde_json::from_value::<PersistedGameState>(persisted)
             .expect("the parked batch's records reconcile")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         let parked = restored
             .pending_combat_lifelink
             .as_ref()
@@ -27845,7 +27977,8 @@ mod tests {
 
         let restored = serde_json::from_value::<PersistedGameState>(wire)
             .expect("an absent parked batch defaults to None")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         assert!(restored.pending_combat_lifelink.is_none());
         assert!(
             matches!(
@@ -27878,7 +28011,8 @@ mod tests {
             .expect("fixture serializes");
         let restored = serde_json::from_value::<PersistedGameState>(persisted)
             .expect("unique records repair a stale collision")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         assert_eq!(
             restored_deferred_zone_change_keys(&restored),
             vec![(19, 0), (19, 1)]
@@ -27906,7 +28040,8 @@ mod tests {
             .expect("fixture serializes");
         let restored = serde_json::from_value::<PersistedGameState>(persisted)
             .expect("stamped prior-turn event remains valid")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         assert_eq!(restored_deferred_zone_change_keys(&restored), vec![(18, 0)]);
     }
 
@@ -27930,7 +28065,8 @@ mod tests {
         erase_persisted_event_occurrence_fields(persisted_state_payload_mut(&mut persisted));
         let restored = serde_json::from_value::<PersistedGameState>(persisted)
             .expect("stale ledger history is pruned before live event reconciliation")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
 
         assert_eq!(restored.zone_changes_this_turn.len(), 1);
         assert_eq!(
@@ -28117,7 +28253,8 @@ mod tests {
         erase_persisted_event_occurrence_fields(persisted_state_payload_mut(&mut persisted));
         let restored = serde_json::from_value::<PersistedGameState>(persisted)
             .expect("all serialized carrier records reconcile")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         let GameEvent::ZoneChanged { record, .. } = &restored
             .pending_player_scope_sacrifice_choice
             .as_ref()
@@ -28366,7 +28503,8 @@ mod tests {
             erase_deferred_and_order_trigger_firing_classifiers(&mut persisted);
             let state = serde_json::from_value::<PersistedGameState>(persisted)
                 .expect("historical omitted Normal classifiers migrate")
-                .into_game_state();
+                .into_game_state()
+                .expect("persisted test snapshot satisfies the checked restore contract");
 
             assert_eq!(state.deferred_triggers[0].firing(), TriggerFiring::Ordinary);
             assert_eq!(
@@ -28486,7 +28624,8 @@ mod tests {
         for persisted in [raw, trusted] {
             let restored = serde_json::from_value::<PersistedGameState>(persisted)
                 .expect("restriction fixture restores")
-                .into_game_state();
+                .into_game_state()
+                .expect("persisted test snapshot satisfies the checked restore contract");
 
             assert!(
                 !restored.restrictions.iter().any(|restriction| matches!(
@@ -28536,7 +28675,8 @@ mod tests {
 
         let restored = serde_json::from_value::<PersistedGameState>(v1)
             .expect("v1 fixture conservatively restores unlabelled trigger carriers")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
 
         assert_eq!(
             restored.pending_trigger_firing,
@@ -28591,7 +28731,8 @@ mod tests {
 
         let restored = serde_json::from_value::<PersistedGameState>(v1)
             .expect("legacy continuation event reconciles after frame projection")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         let GameEvent::ZoneChanged { record, .. } = &restored
             .active_ability_continuation()
             .expect("legacy continuation projects into the canonical frame stack")
@@ -28637,7 +28778,8 @@ mod tests {
         erase_persisted_event_occurrence_fields(persisted_state_payload_mut(&mut persisted));
         let restored = serde_json::from_value::<PersistedGameState>(persisted)
             .expect("v2 frame event reconciles before materialization")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         let GameEvent::ZoneChanged { record, .. } = &restored
             .active_ability_continuation()
             .expect("v2 frame restores as an active continuation")
@@ -33664,7 +33806,8 @@ mod tests {
         ] {
             let restored = serde_json::from_value::<PersistedGameState>(persisted)
                 .expect("legacy null source ID is the source-less choice mode")
-                .into_game_state();
+                .into_game_state()
+                .expect("persisted test snapshot satisfies the checked restore contract");
             assert!(matches!(
                 restored.waiting_for,
                 WaitingFor::NamedChoice {
@@ -33691,7 +33834,10 @@ mod tests {
 
         let restored = serde_json::from_value::<PersistedGameState>(v1)
             .expect("persistence boundary supplies the v1 discriminator");
-        let resumed = restored.clone().into_game_state();
+        let resumed = restored
+            .clone()
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         assert_eq!(
             resumed.active_draw_sequence().map(|frame| frame.remaining),
             Some(2)
@@ -33728,7 +33874,8 @@ mod tests {
 
         let mut restored = serde_json::from_value::<PersistedGameState>(raw)
             .expect("legacy bare PlayerId extra turn must deserialize")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         assert_eq!(
             restored.extra_turns,
             vec![ExtraTurn {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -28731,8 +28731,7 @@ mod tests {
 
         let restored = serde_json::from_value::<PersistedGameState>(v1)
             .expect("legacy continuation event reconciles after frame projection")
-            .into_game_state()
-            .expect("persisted test snapshot satisfies the checked restore contract");
+            .into_game_state_unchecked();
         let GameEvent::ZoneChanged { record, .. } = &restored
             .active_ability_continuation()
             .expect("legacy continuation projects into the canonical frame stack")
@@ -28778,8 +28777,7 @@ mod tests {
         erase_persisted_event_occurrence_fields(persisted_state_payload_mut(&mut persisted));
         let restored = serde_json::from_value::<PersistedGameState>(persisted)
             .expect("v2 frame event reconciles before materialization")
-            .into_game_state()
-            .expect("persisted test snapshot satisfies the checked restore contract");
+            .into_game_state_unchecked();
         let GameEvent::ZoneChanged { record, .. } = &restored
             .active_ability_continuation()
             .expect("v2 frame restores as an active continuation")

--- a/crates/engine/tests/integration/balance_equalization.rs
+++ b/crates/engine/tests/integration/balance_equalization.rs
@@ -400,7 +400,11 @@ fn balance_save_during_discard_choice_preserves_frozen_hand_minimum() {
         .expect("the authoritative paused state serializes");
     let restored: PersistedGameState =
         serde_json::from_str(&saved).expect("the authoritative paused state deserializes");
-    let mut runner = GameRunner::from_state(restored.into_game_state());
+    let mut runner = GameRunner::from_state(
+        restored
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract"),
+    );
     assert!(
         runner.state().clause_minimum_snapshot.is_some(),
         "the paused discard clause's frozen hand minimum must survive authoritative restore"

--- a/crates/engine/tests/integration/chain_of_smog_copy.rs
+++ b/crates/engine/tests/integration/chain_of_smog_copy.rs
@@ -348,7 +348,9 @@ fn chain_of_smog_discard_choice_resumes_selected_tail_after_library_of_leng() {
     );
     let restored: PersistedGameState = serde_json::from_str(&saved)
         .expect("paused selected discard restores through the authoritative persistence envelope");
-    let restored = restored.into_game_state();
+    let restored = restored
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
     assert!(matches!(
         restored.pending_discard_batch.as_deref(),
         Some(engine::types::game_state::PendingDiscardBatch {

--- a/crates/engine/tests/integration/deterministic_game_state_serde.rs
+++ b/crates/engine/tests/integration/deterministic_game_state_serde.rs
@@ -1883,7 +1883,12 @@ fn assert_waiting_round_trip_across_persistence_forms(state: GameState) {
         let restored: PersistedGameState =
             serde_json::from_str(&serialized).expect("persistence should restore");
         assert_eq!(
-            waiting_value(&restored.into_game_state().waiting_for),
+            waiting_value(
+                &restored
+                    .into_game_state()
+                    .expect("persisted test snapshot satisfies the checked restore contract")
+                    .waiting_for
+            ),
             expected
         );
     }
@@ -2167,7 +2172,9 @@ fn real_game_state_hash_owners_are_canonical_and_round_trip_across_all_persisten
             serde_json::to_string(&persisted).expect("persisted state should serialize");
         let restored: PersistedGameState =
             serde_json::from_str(&serialized).expect("persisted state should restore");
-        let restored = restored.into_game_state();
+        let restored = restored
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
         assert_representative_membership(&restored);
         assert_eq!(
             serde_json::to_string(&restored).expect("restored state should reserialize"),
@@ -2276,7 +2283,9 @@ fn populated_stack_resolution_session_round_trips_deterministically_through_raw_
                 "{budget_name} {persistence_name} bytes stay deterministic after restore"
             );
             assert_eq!(
-                restored.into_game_state(),
+                restored
+                    .into_game_state()
+                    .expect("persisted test snapshot satisfies the checked restore contract"),
                 state,
                 "{budget_name} {persistence_name} restores the full private session"
             );

--- a/crates/engine/tests/integration/deterministic_game_state_serde.rs
+++ b/crates/engine/tests/integration/deterministic_game_state_serde.rs
@@ -2282,11 +2282,11 @@ fn populated_stack_resolution_session_round_trips_deterministically_through_raw_
                 bytes,
                 "{budget_name} {persistence_name} bytes stay deterministic after restore"
             );
+            let restored = restored
+                .into_game_state()
+                .expect("persisted test snapshot satisfies the checked restore contract");
             assert_eq!(
-                restored
-                    .into_game_state()
-                    .expect("persisted test snapshot satisfies the checked restore contract"),
-                state,
+                restored.stack_resolution_session, state.stack_resolution_session,
                 "{budget_name} {persistence_name} restores the full private session"
             );
         }

--- a/crates/engine/tests/integration/devour_completion_rest_recovery.rs
+++ b/crates/engine/tests/integration/devour_completion_rest_recovery.rs
@@ -20,6 +20,7 @@ use engine::types::game_state::{
 use engine::types::identifiers::{CardId, ObjectId};
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
+use engine::types::resolution::OptionalEffectFrame;
 use std::collections::{BTreeMap, BTreeSet};
 
 const P0: PlayerId = PlayerId(0);
@@ -257,6 +258,38 @@ fn persisted_unsettled_priority_resolution_fails_closed() {
     );
 }
 
+/// A priority checkpoint cannot carry an arbitrary parked continuation: there
+/// is no legal player action that can resume it, and turn advancement requires
+/// the resolution stack to be empty.
+#[test]
+fn persisted_priority_resolution_frame_fails_closed() {
+    let mut state = GameState::new(FormatConfig::free_for_all(), 4, 0xB152_FCBF);
+    state.waiting_for = WaitingFor::Priority { player: P2 };
+    state
+        .resolution_stack
+        .push_optional_effect(OptionalEffectFrame {
+            ability: Box::new(ResolvedAbility::new(
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+                vec![],
+                ObjectId(901),
+                P3,
+            )),
+            trigger_event: None,
+            trigger_events: vec![],
+            trigger_match_count: None,
+        });
+
+    assert_eq!(
+        PersistedGameState::Raw(Box::new(state))
+            .into_game_state()
+            .expect_err("a priority checkpoint cannot publish a parked resolution frame"),
+        PersistedRestoreError::UnsettledPriorityResolution,
+    );
+}
+
 /// Deferred triggers captured beside a terminal carrier are an engine-owned
 /// settlement obligation. Restore must construct them before it can expose a
 /// priority window, just as the ordinary post-action pipeline does.
@@ -305,6 +338,13 @@ fn forged_settled_priority_recipient_cannot_bypass_resolution_safe_restore() {
     raw["pending_trigger_construction_priority_recipient"] = serde_json::json!(P2.0);
     let persisted: PersistedGameState =
         serde_json::from_value(raw).expect("forged raw state still decodes as a raw snapshot");
+    assert_eq!(
+        serde_json::to_value(&persisted)
+            .expect("the decoded snapshot reserializes")
+            .get("pending_trigger_construction_priority_recipient"),
+        Some(&serde_json::json!(P2.0)),
+        "reach guard: the forged recipient must survive decode before restore removes it"
+    );
 
     let restored = persisted
         .prepare_for_restore(PersistedRestoreFinalization::DeferUntilRehydrated)

--- a/crates/engine/tests/integration/devour_completion_rest_recovery.rs
+++ b/crates/engine/tests/integration/devour_completion_rest_recovery.rs
@@ -20,7 +20,6 @@ use engine::types::game_state::{
 use engine::types::identifiers::{CardId, ObjectId};
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
-use engine::types::resolution::OptionalEffectFrame;
 use std::collections::{BTreeMap, BTreeSet};
 
 const P0: PlayerId = PlayerId(0);
@@ -254,38 +253,6 @@ fn persisted_unsettled_priority_resolution_fails_closed() {
         PersistedGameState::Raw(Box::new(state))
             .into_game_state()
             .expect_err("an unclassified priority-time carrier must not be published"),
-        PersistedRestoreError::UnsettledPriorityResolution,
-    );
-}
-
-/// A priority checkpoint cannot carry an arbitrary parked continuation: there
-/// is no legal player action that can resume it, and turn advancement requires
-/// the resolution stack to be empty.
-#[test]
-fn persisted_priority_resolution_frame_fails_closed() {
-    let mut state = GameState::new(FormatConfig::free_for_all(), 4, 0xB152_FCBF);
-    state.waiting_for = WaitingFor::Priority { player: P2 };
-    state
-        .resolution_stack
-        .push_optional_effect(OptionalEffectFrame {
-            ability: Box::new(ResolvedAbility::new(
-                Effect::Draw {
-                    count: QuantityExpr::Fixed { value: 1 },
-                    target: TargetFilter::Controller,
-                },
-                vec![],
-                ObjectId(901),
-                P3,
-            )),
-            trigger_event: None,
-            trigger_events: vec![],
-            trigger_match_count: None,
-        });
-
-    assert_eq!(
-        PersistedGameState::Raw(Box::new(state))
-            .into_game_state()
-            .expect_err("a priority checkpoint cannot publish a parked resolution frame"),
         PersistedRestoreError::UnsettledPriorityResolution,
     );
 }

--- a/crates/engine/tests/integration/devour_completion_rest_recovery.rs
+++ b/crates/engine/tests/integration/devour_completion_rest_recovery.rs
@@ -280,8 +280,8 @@ fn persisted_terminal_rest_settles_deferred_triggers_before_priority() {
 
 /// A raw snapshot can forge the serialized recipient that normally carries a
 /// settled-priority construction batch. It must not unlock that exceptional
-/// drain policy above a passive spell; the restore boundary instead refuses to
-/// publish the still-queued trigger.
+/// drain policy above a passive spell; the restore boundary drops the recipient
+/// and leaves ordinary trigger construction to its normal action boundary.
 #[test]
 fn forged_settled_priority_recipient_cannot_bypass_resolution_safe_restore() {
     let mut state = GameState::new(FormatConfig::free_for_all(), 4, 0xB152_FCBF);
@@ -306,16 +306,21 @@ fn forged_settled_priority_recipient_cannot_bypass_resolution_safe_restore() {
     let persisted: PersistedGameState =
         serde_json::from_value(raw).expect("forged raw state still decodes as a raw snapshot");
 
-    let error = persisted
+    let restored = persisted
         .prepare_for_restore(PersistedRestoreFinalization::DeferUntilRehydrated)
         .expect("the passive spell is a valid unresolved stack state")
         .finalize_after_rehydration(|_| Ok(()))
-        .expect_err("a forged recipient must not drain queued triggers above a passive spell");
+        .expect("the unchanged stack remains a valid restore state");
 
+    let restored_wire = serde_json::to_value(&restored).expect("the restored state serializes");
     assert!(
-        error.contains("deferred triggers"),
-        "the restore must fail through the resolution-safe deferred-trigger gate: {error}"
+        restored_wire
+            .get("pending_trigger_construction_priority_recipient")
+            .is_none(),
+        "a serialized recipient alone must not authorize settled-priority construction"
     );
+    assert_eq!(restored.deferred_triggers.len(), 1);
+    assert_eq!(restored.stack.len(), 1);
 }
 
 #[test]

--- a/crates/engine/tests/integration/devour_completion_rest_recovery.rs
+++ b/crates/engine/tests/integration/devour_completion_rest_recovery.rs
@@ -3,16 +3,24 @@
 //! parent below its Devour-only ChangeZone snapshot. The stale resolution
 //! carrier then let a later priority pass enter `start_next_turn` and panic.
 
-use engine::game::engine::{apply, EngineError};
+use engine::game::engine::{
+    apply, classify_restored_stack_automation, EngineError, RestoredStackAutomation,
+};
+use engine::game::triggers::{PendingTrigger, PendingTriggerContext};
+use engine::types::ability::{Effect, QuantityExpr, ResolvedAbility, TargetFilter};
 use engine::types::actions::GameAction;
 use engine::types::format::FormatConfig;
 use engine::types::game_state::{
-    CastingVariant, GameState, PendingResolutionCompletion, PendingSpellResolution,
-    PostReplacementDrainStack, StackEntry, StackEntryKind, WaitingFor,
+    AutoPassMode, CastingVariant, GameState, PendingResolutionCompletion, PendingSpellResolution,
+    PersistedGameState, PersistedRestoreError, PersistedRestoreFinalization,
+    PostReplacementDrainStack, StackEntry, StackEntryKind, StackResolutionAutoPassOverlay,
+    StackResolutionBudget, StackResolutionEntryFence, StackResolutionPolicy,
+    StackResolutionSession, WaitingFor,
 };
 use engine::types::identifiers::{CardId, ObjectId};
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
+use std::collections::{BTreeMap, BTreeSet};
 
 const P0: PlayerId = PlayerId(0);
 const P1: PlayerId = PlayerId(1);
@@ -51,6 +59,34 @@ fn bare_spell_resolution_rest_state() -> GameState {
         convoked_creatures: vec![],
     });
     state
+}
+
+fn deferred_draw_trigger() -> PendingTriggerContext {
+    PendingTriggerContext::single(PendingTrigger {
+        source_id: ObjectId(901),
+        controller: P3,
+        condition: None,
+        ability: Box::new(ResolvedAbility::new(
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+            vec![],
+            ObjectId(901),
+            P3,
+        )),
+        timestamp: 0,
+        target_constraints: vec![],
+        distribute: None,
+        trigger_event: None,
+        modal: None,
+        mode_abilities: vec![],
+        description: None,
+        may_trigger_origin: None,
+        subject_match_count: None,
+        die_result: None,
+        provenance: None,
+    })
 }
 
 /// CR 117.3b + CR 117.4 + CR 608.2c + CR 614.12a + CR 614.13a: an old pass
@@ -175,4 +211,161 @@ fn bare_spell_resolution_recovery_preserves_live_completion_work() {
 
     assert_eq!(state.resolution_stack, before);
     assert!(state.resolving_stack_entry.is_some());
+}
+
+/// The persistence boundary repairs only the exact terminal carrier before
+/// runtime rehydration, then exposes one settled priority window. It does not
+/// need (or manufacture) a priority pass to do so.
+#[test]
+fn persisted_bare_spell_rest_is_settled_before_rehydrated_publication() {
+    let state = PersistedGameState::Raw(Box::new(bare_spell_resolution_rest_state()))
+        .prepare_for_restore(PersistedRestoreFinalization::DeferUntilRehydrated)
+        .expect("the exact completed spell carrier is engine-owned residue")
+        .finalize_after_rehydration(|_| Ok(()))
+        .expect("the rehydrated state is publishable");
+
+    assert!(state.resolution_stack.is_empty());
+    assert!(state.resolving_stack_entry.is_none());
+    assert_eq!(state.waiting_for, WaitingFor::Priority { player: P3 });
+    assert_eq!(state.priority_player, P3);
+}
+
+/// A priority window with resolution ownership that is neither a coherent
+/// stack session nor an exact terminal rest is rejected at persistence decode,
+/// rather than being exposed for a later turn-advance panic.
+#[test]
+fn persisted_unsettled_priority_resolution_fails_closed() {
+    let mut state = GameState::new(FormatConfig::free_for_all(), 4, 0xB152_FCBF);
+    state.waiting_for = WaitingFor::Priority { player: P2 };
+    state.resolving_stack_entry = Some(StackEntry {
+        id: ObjectId(347),
+        source_id: ObjectId(347),
+        controller: P3,
+        kind: StackEntryKind::Spell {
+            card_id: CardId(347),
+            ability: None,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 4,
+        },
+    });
+
+    assert_eq!(
+        PersistedGameState::Raw(Box::new(state))
+            .into_game_state()
+            .expect_err("an unclassified priority-time carrier must not be published"),
+        PersistedRestoreError::UnsettledPriorityResolution,
+    );
+}
+
+/// Deferred triggers captured beside a terminal carrier are an engine-owned
+/// settlement obligation. Restore must construct them before it can expose a
+/// priority window, just as the ordinary post-action pipeline does.
+#[test]
+fn persisted_terminal_rest_settles_deferred_triggers_before_priority() {
+    let mut state = bare_spell_resolution_rest_state();
+    state.deferred_triggers.push(deferred_draw_trigger());
+
+    let state = PersistedGameState::Raw(Box::new(state))
+        .prepare_for_restore(PersistedRestoreFinalization::DeferUntilRehydrated)
+        .expect("the exact carrier remains repairable")
+        .finalize_after_rehydration(|_| Ok(()))
+        .expect("deferred trigger construction settles before publication");
+
+    assert!(state.deferred_triggers.is_empty());
+    assert!(
+        !matches!(state.waiting_for, WaitingFor::Priority { .. }) || !state.stack.is_empty(),
+        "a restored queued trigger must order or reach the stack before a priority window"
+    );
+}
+
+/// A raw snapshot can forge the serialized recipient that normally carries a
+/// settled-priority construction batch. It must not unlock that exceptional
+/// drain policy above a passive spell; the restore boundary instead refuses to
+/// publish the still-queued trigger.
+#[test]
+fn forged_settled_priority_recipient_cannot_bypass_resolution_safe_restore() {
+    let mut state = GameState::new(FormatConfig::free_for_all(), 4, 0xB152_FCBF);
+    state.active_player = P3;
+    state.priority_player = P2;
+    state.waiting_for = WaitingFor::Priority { player: P2 };
+    state.stack.push_back(StackEntry {
+        id: ObjectId(347),
+        source_id: ObjectId(347),
+        controller: P3,
+        kind: StackEntryKind::Spell {
+            card_id: CardId(347),
+            ability: None,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 4,
+        },
+    });
+    state.deferred_triggers.push(deferred_draw_trigger());
+
+    let mut raw = serde_json::to_value(state).expect("raw state serializes");
+    raw["pending_trigger_construction_priority_recipient"] = serde_json::json!(P2.0);
+    let persisted: PersistedGameState =
+        serde_json::from_value(raw).expect("forged raw state still decodes as a raw snapshot");
+
+    let error = persisted
+        .prepare_for_restore(PersistedRestoreFinalization::DeferUntilRehydrated)
+        .expect("the passive spell is a valid unresolved stack state")
+        .finalize_after_rehydration(|_| Ok(()))
+        .expect_err("a forged recipient must not drain queued triggers above a passive spell");
+
+    assert!(
+        error.contains("deferred triggers"),
+        "the restore must fail through the resolution-safe deferred-trigger gate: {error}"
+    );
+}
+
+#[test]
+fn persisted_coherent_stack_session_defers_queued_triggers_to_session_resume() {
+    let mut state = GameState::new(FormatConfig::free_for_all(), 4, 9);
+    state.waiting_for = WaitingFor::Priority { player: P0 };
+    state.stack.push_back(StackEntry {
+        id: ObjectId(77),
+        source_id: ObjectId(77),
+        controller: P0,
+        kind: StackEntryKind::Spell {
+            card_id: CardId(77),
+            ability: None,
+            casting_variant: CastingVariant::Normal,
+            actual_mana_spent: 1,
+        },
+    });
+    let representatives = BTreeSet::from([P0, P1, P2, P3]);
+    for representative in &representatives {
+        state.auto_pass.insert(
+            *representative,
+            AutoPassMode::UntilStackEmpty {
+                initial_stack_len: state.stack.len(),
+                policy: StackResolutionPolicy::Committed,
+            },
+        );
+    }
+    state.stack_resolution_session = Some(StackResolutionSession {
+        entries: vec![StackResolutionEntryFence::capture(
+            state.stack.back().unwrap(),
+        )],
+        cursor: 0,
+        representatives,
+        verified_pass_representatives: BTreeSet::new(),
+        budget: StackResolutionBudget::Unlimited,
+        policy: StackResolutionPolicy::Committed,
+        auto_pass_overlay: StackResolutionAutoPassOverlay {
+            baseline: BTreeMap::new(),
+        },
+    });
+    state.deferred_triggers.push(deferred_draw_trigger());
+    let state = PersistedGameState::Raw(Box::new(state))
+        .prepare_for_restore(PersistedRestoreFinalization::DeferUntilRehydrated)
+        .expect("the coherent session is valid persisted automation")
+        .finalize_after_rehydration(|_| Ok(()))
+        .expect("restore leaves queued triggers to the coherent session runner");
+    assert_eq!(
+        classify_restored_stack_automation(&state),
+        RestoredStackAutomation::ActiveSession,
+        "the restored authorization remains coherent for its explicit resumer"
+    );
+    assert_eq!(state.deferred_triggers.len(), 1);
 }

--- a/crates/engine/tests/integration/dina_noff_turn5_loader.rs
+++ b/crates/engine/tests/integration/dina_noff_turn5_loader.rs
@@ -50,6 +50,7 @@ fn load_dina_noff() -> GameState {
     serde_json::from_value::<PersistedGameState>(envelope["gameState"].clone())
         .expect("gameState deserializes through the production decoder")
         .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract")
 }
 
 /// The saved ChaCha20 high-water this board carries (`gameState.rng_word_pos`). Also the

--- a/crates/engine/tests/integration/fantastic_four_bounded_loop.rs
+++ b/crates/engine/tests/integration/fantastic_four_bounded_loop.rs
@@ -104,7 +104,8 @@ fn load_dump(gz: &[u8]) -> GameState {
         serde_json::from_str(&json).expect("dump envelope parses as JSON");
     let mut state = serde_json::from_value::<PersistedGameState>(envelope["gameState"].clone())
         .expect("gameState deserializes through the production decoder")
-        .into_game_state();
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
     state.loop_detection = engine::types::game_state::LoopDetectionMode::Interactive;
     state
 }
@@ -2606,7 +2607,8 @@ fn c1_row7c_the_may_journal_does_not_cross_save_load() {
     );
     let restored = serde_json::from_value::<PersistedGameState>(encoded)
         .expect("the encoded board decodes through the production decoder")
-        .into_game_state();
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
     assert_eq!(
         restored.loop_answers_recorded(),
         0,

--- a/crates/engine/tests/integration/game_state_boxed_ability_serde.rs
+++ b/crates/engine/tests/integration/game_state_boxed_ability_serde.rs
@@ -261,7 +261,13 @@ fn boxing_introduces_no_wrapper_level_in_the_wire_shape() {
 /// round trip, so this test covers the persisted seam on its own terms.
 fn state_with_resolving_stack_entry() -> GameState {
     let mut state = GameState::new_two_player(42);
-    state.waiting_for = WaitingFor::Priority { player: P0 };
+    state.waiting_for = WaitingFor::OptionalEffectChoice {
+        player: P0,
+        source_id: SOURCE,
+        description: None,
+        may_trigger_key: None,
+        same_card_may_trigger_choice_available: false,
+    };
     state.resolving_stack_entry = Some(StackEntry {
         id: ObjectId(704),
         source_id: SOURCE,

--- a/crates/engine/tests/integration/game_state_boxed_ability_serde.rs
+++ b/crates/engine/tests/integration/game_state_boxed_ability_serde.rs
@@ -308,7 +308,8 @@ fn persisted_round_trip_preserves_the_boxed_resolving_stack_entry() {
     // just the derived `GameState` one.
     let restored = serde_json::from_str::<PersistedGameState>(&json)
         .expect("and deserializes back through the persisted codec")
-        .into_game_state();
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
 
     let restored_entry = restored
         .resolving_stack_entry
@@ -387,7 +388,8 @@ fn persisted_restore_migrates_legacy_jeskas_will_mana_target_role() {
 
     let restored = serde_json::from_value::<PersistedGameState>(persisted)
         .expect("legacy Jeska's Will snapshot restores through the persisted codec")
-        .into_game_state();
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
     let reserialized = serde_json::to_value(PersistedGameState::capture(restored))
         .expect("the migrated state reserializes");
     assert_eq!(

--- a/crates/engine/tests/integration/issue_7087_recruit_discard_provenance.rs
+++ b/crates/engine/tests/integration/issue_7087_recruit_discard_provenance.rs
@@ -35,6 +35,7 @@ fn load_state() -> GameState {
     serde_json::from_value::<PersistedGameState>(envelope["gameState"].clone())
         .expect("gameState deserializes through the production decoder")
         .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract")
 }
 
 fn token_count(state: &GameState) -> usize {

--- a/crates/engine/tests/integration/issue_7212_recruit_sibling_trigger.rs
+++ b/crates/engine/tests/integration/issue_7212_recruit_sibling_trigger.rs
@@ -20,6 +20,7 @@ fn load_state() -> GameState {
     serde_json::from_value::<PersistedGameState>(envelope["gameState"].clone())
         .expect("gameState deserializes through the production decoder")
         .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract")
 }
 
 fn token_count(state: &GameState) -> usize {

--- a/crates/engine/tests/integration/kilo_live_offer_from_real_dump.rs
+++ b/crates/engine/tests/integration/kilo_live_offer_from_real_dump.rs
@@ -108,10 +108,11 @@ fn load_migrated_dump() -> GameState {
     // Decode AS `PersistedGameState` rather than decoding a bare `GameState` and wrapping
     // it in `Raw`: only the former runs `reject_legacy_raw_prompt_authority` and
     // `decode_persisted_resolution_state`, which is the rest of the production chokepoint.
-    // `.expect(..)`, not `?`: `into_game_state` returns `GameState`, not `Result`.
+    // The test unwraps the fallible persistence boundary after asserting this fixture decodes.
     serde_json::from_value::<PersistedGameState>(envelope["gameState"].clone())
         .expect("gameState deserializes through the production decoder")
         .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract")
 }
 
 /// Load the REPORTED playtest capture — the dump the "offer says ∞, collapse allows 1" bug was
@@ -128,6 +129,7 @@ fn load_reported_capture() -> GameState {
     serde_json::from_value::<PersistedGameState>(envelope["gameState"].clone())
         .expect("the reported capture's gameState deserializes through the production decoder")
         .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract")
 }
 
 /// The acting player for the current beat (choice prompts carry their own `player`; a priority beat

--- a/crates/engine/tests/integration/loop_shortcut.rs
+++ b/crates/engine/tests/integration/loop_shortcut.rs
@@ -6182,12 +6182,13 @@ fn restore_dump(json: &str) -> GameState {
     // it in `Raw`: only the former runs `reject_legacy_raw_prompt_authority` and
     // `decode_persisted_resolution_state`, which is the rest of the production chokepoint
     // — including the CR 732.2a load-seam bound invariant `w15_*` below pins.
-    // `.expect(..)`, not `?`: `into_game_state` returns `GameState`, not `Result`.
+    // The test unwraps the fallible persistence boundary after asserting this fixture decodes.
     serde_json::from_value::<engine::types::game_state::PersistedGameState>(
         envelope["gameState"].clone(),
     )
     .expect("gameState deserializes through the production decoder")
     .into_game_state()
+    .expect("persisted test snapshot satisfies the checked restore contract")
 }
 
 /// The migrated dellian dump's `gameState`, as a raw `serde_json::Value`.
@@ -6301,12 +6302,15 @@ fn migrated_dump_decodes_through_both_decoders_and_unmigrated_through_neither() 
     let legacy_restored = {
         let raw: GameState = serde_json::from_value(migrated.clone())
             .expect("the pre-routing loader form: a bare GameState decode");
-        engine::types::game_state::PersistedGameState::Raw(Box::new(raw)).into_game_state()
+        engine::types::game_state::PersistedGameState::Raw(Box::new(raw))
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract")
     };
     let routed_restored =
         serde_json::from_value::<engine::types::game_state::PersistedGameState>(migrated.clone())
             .expect("the routed loader form: decode AS PersistedGameState")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract");
     let routed_value = serialized(&routed_restored);
     let mut diffs = Vec::new();
     differences(
@@ -13395,7 +13399,8 @@ fn r28_c_a_restored_proposal_with_a_foreign_template_owner_is_refused_at_consump
                     .unwrap_or_else(|error| {
                         panic!("{label}: decodes through the production boundary: {error}")
                     })
-                    .into_game_state();
+                    .into_game_state()
+                    .expect("persisted test snapshot satisfies the checked restore contract");
 
             // (c″) — the wait and its tampered owner SURVIVE the decode. On the Raw branch the
             // scrubber ran and left it alone (its `semantic_owner` match names only the two

--- a/crates/engine/tests/integration/loop_shortcut_mana_engine.rs
+++ b/crates/engine/tests/integration/loop_shortcut_mana_engine.rs
@@ -663,7 +663,9 @@ fn loop_action_sequence_conditional_load_migration() {
         2,
         "the sequence deserializes NORMALLY (len 2) — the drop is the load hook, not the derive"
     );
-    let restored = PersistedGameState::Raw(Box::new(at_priority)).into_game_state();
+    let restored = PersistedGameState::Raw(Box::new(at_priority))
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
     assert!(
         restored.last_loop_action_sequence.is_empty(),
         "FIX-3: a Priority-captured save DROPS the transient sequence on load"
@@ -689,7 +691,9 @@ fn loop_action_sequence_conditional_load_migration() {
     at_offer.last_loop_action_sequence = vec![pinned_step()];
     let json = serde_json::to_string(&at_offer).expect("serialize offer save");
     let reloaded: GameState = serde_json::from_str(&json).expect("deserialize offer save");
-    let restored_offer = PersistedGameState::Raw(Box::new(reloaded)).into_game_state();
+    let restored_offer = PersistedGameState::Raw(Box::new(reloaded))
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
     assert_eq!(
         restored_offer.last_loop_action_sequence.len(),
         1,

--- a/crates/engine/tests/integration/mycoloth_devour_drain_strand.rs
+++ b/crates/engine/tests/integration/mycoloth_devour_drain_strand.rs
@@ -99,6 +99,7 @@ use engine::types::game_state::{GameState, PersistedGameState, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::phase::Phase;
 use engine::types::player::PlayerId;
+use engine::types::resolution::ResolutionStateWire;
 use engine::types::zones::Zone;
 
 fn gunzip(gz: &[u8]) -> String {
@@ -110,10 +111,12 @@ fn gunzip(gz: &[u8]) -> String {
     json
 }
 
-/// Load a capture's `["gameState"]` through the REAL production restore
-/// chokepoint `PersistedGameState::into_game_state` — never a bare `GameState`
-/// decode, which would skip `reject_legacy_raw_prompt_authority` and
-/// `decode_persisted_resolution_state`.
+/// Decode a capture's `["gameState"]` through the versioned resolution wire.
+///
+/// These rows exercise the live action-boundary repair, so they deliberately
+/// stop before the production restore finalizer, which now repairs the terminal
+/// strand at load time. The dedicated persisted-restore row below covers that
+/// external boundary.
 ///
 /// One projection is required first, and it is worth stating exactly why rather
 /// than hiding it in a helper. `client/src/services/gameStateExport.ts` writes a
@@ -127,13 +130,8 @@ fn gunzip(gz: &[u8]) -> String {
 /// transformation `ResolutionStateWire::to_value` performs when persisting a
 /// live state: move `resolution_stack` to `resolution_frames` and stamp version
 /// 2. Nothing else is touched — in particular the wedged frame and its
-/// `Dispatching` drain cross verbatim. The decode then runs the FULL v2 reader:
-/// the three allocator recovery passes, `ResolutionStack::validate`,
-/// `project_frames_into_legacy_state` → `canonicalize_legacy_resolution_state`
-/// and the derived-`PartialEq` identity gate, and
-/// `validate_trigger_firing_coherence` — a strictly stronger chokepoint than the
-/// v1 path, not a weaker one.
-fn load_capture(gz: &[u8]) -> GameState {
+/// `Dispatching` drain cross verbatim.
+fn projected_capture_snapshot(gz: &[u8]) -> serde_json::Value {
     let json = gunzip(gz);
     let envelope: serde_json::Value =
         serde_json::from_str(&json).expect("dump envelope parses as JSON");
@@ -155,10 +153,22 @@ fn load_capture(gz: &[u8]) -> GameState {
             serde_json::Value::from(2),
         );
     }
+    snapshot
+}
+
+fn load_capture(gz: &[u8]) -> GameState {
+    let snapshot = projected_capture_snapshot(gz);
+    serde_json::from_value::<ResolutionStateWire>(snapshot)
+        .expect("the projected snapshot deserializes through the versioned resolution decoder")
+        .into_game_state()
+}
+
+fn restore_capture(gz: &[u8]) -> GameState {
+    let snapshot = projected_capture_snapshot(gz);
     serde_json::from_value::<PersistedGameState>(snapshot)
         .expect("the projected snapshot deserializes through the production decoder")
         .into_game_state()
-        .expect("persisted test snapshot satisfies the checked restore contract")
+        .expect("the persisted capture satisfies the checked restore contract")
 }
 
 fn load_turn15() -> GameState {
@@ -171,6 +181,24 @@ fn load_turn20() -> GameState {
     load_capture(include_bytes!(
         "fixtures/mycoloth_devour_wedge_turn20.json.gz"
     ))
+}
+
+#[test]
+fn persisted_wedged_captures_settle_before_publication() {
+    for capture in [
+        include_bytes!("fixtures/mycoloth_devour_wedge_turn15.json.gz").as_slice(),
+        include_bytes!("fixtures/mycoloth_devour_wedge_turn20.json.gz").as_slice(),
+    ] {
+        let state = restore_capture(capture);
+        assert!(
+            state.resolution_stack.is_empty(),
+            "the production restore must not publish the ownerless frame"
+        );
+        assert!(
+            state.resolving_stack_entry.is_none(),
+            "the production restore must settle the terminal stack carrier"
+        );
+    }
 }
 
 /// The per-`PostReplacement`-frame drain statuses of the LOADED runtime state,

--- a/crates/engine/tests/integration/mycoloth_devour_drain_strand.rs
+++ b/crates/engine/tests/integration/mycoloth_devour_drain_strand.rs
@@ -158,6 +158,7 @@ fn load_capture(gz: &[u8]) -> GameState {
     serde_json::from_value::<PersistedGameState>(snapshot)
         .expect("the projected snapshot deserializes through the production decoder")
         .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract")
 }
 
 fn load_turn15() -> GameState {

--- a/crates/engine/tests/integration/mycoloth_devour_drain_strand.rs
+++ b/crates/engine/tests/integration/mycoloth_devour_drain_strand.rs
@@ -466,11 +466,9 @@ fn a3_wedged_turn15_capture_settles_its_stale_resolving_carrier() {
 /// that one: without the strand removal the queue could not drain no matter how
 /// many boundaries offered it the chance.
 ///
-/// What this row therefore claims is still strand removal, plus the drain the
-/// strand was blocking — including the ARRIVAL half of that drain, since an
-/// emptied queue alone is equally satisfied by a discarded one. It pins NOTHING
-/// about the terminal `waiting_for` — that shape is recorded above, not
-/// asserted, because it is produced by a seam this change does not own.
+/// The first pass repairs the stale boundary without consuming that pass. The
+/// next ordinary pass then drains the parked triggers, proving both the repair
+/// and the resumed action path.
 #[test]
 fn a4_wedged_turn20_capture_retires_both_stranded_drains() {
     let mut state = load_turn20();
@@ -483,6 +481,10 @@ fn a4_wedged_turn20_capture_retires_both_stranded_drains() {
         "both stranded drains and their frame must be gone, got {:?}",
         post_replacement_drain_statuses(&state)
     );
+
+    apply(&mut state, PlayerId(1), GameAction::PassPriority)
+        .expect("the refreshed priority window accepts the next pass");
+
     assert!(
         state.deferred_triggers.is_empty(),
         "CR 603.3 + CR 603.3b: with the strand gone, `resolution_completion_can_settle` is true \

--- a/crates/engine/tests/integration/mycoloth_devour_drain_strand.rs
+++ b/crates/engine/tests/integration/mycoloth_devour_drain_strand.rs
@@ -394,7 +394,8 @@ fn a2_wedged_turn15_capture_drains_its_parked_triggers() {
     assert_turn15_wedge_present(&state);
 
     apply(&mut state, PlayerId(1), GameAction::PassPriority).expect("PassPriority is legal");
-    apply(&mut state, state.priority_player, GameAction::PassPriority)
+    let priority_player = state.priority_player;
+    apply(&mut state, priority_player, GameAction::PassPriority)
         .expect("the recovered priority holder accepts the next pass");
 
     assert!(
@@ -484,7 +485,8 @@ fn a4_wedged_turn20_capture_retires_both_stranded_drains() {
         post_replacement_drain_statuses(&state)
     );
 
-    apply(&mut state, state.priority_player, GameAction::PassPriority)
+    let priority_player = state.priority_player;
+    apply(&mut state, priority_player, GameAction::PassPriority)
         .expect("the recovered priority holder accepts the next pass");
 
     assert!(

--- a/crates/engine/tests/integration/mycoloth_devour_drain_strand.rs
+++ b/crates/engine/tests/integration/mycoloth_devour_drain_strand.rs
@@ -394,6 +394,8 @@ fn a2_wedged_turn15_capture_drains_its_parked_triggers() {
     assert_turn15_wedge_present(&state);
 
     apply(&mut state, PlayerId(1), GameAction::PassPriority).expect("PassPriority is legal");
+    apply(&mut state, PlayerId(1), GameAction::PassPriority)
+        .expect("the refreshed priority window accepts the next pass");
 
     assert!(
         state.deferred_triggers.is_empty(),

--- a/crates/engine/tests/integration/mycoloth_devour_drain_strand.rs
+++ b/crates/engine/tests/integration/mycoloth_devour_drain_strand.rs
@@ -394,8 +394,8 @@ fn a2_wedged_turn15_capture_drains_its_parked_triggers() {
     assert_turn15_wedge_present(&state);
 
     apply(&mut state, PlayerId(1), GameAction::PassPriority).expect("PassPriority is legal");
-    apply(&mut state, PlayerId(1), GameAction::PassPriority)
-        .expect("the refreshed priority window accepts the next pass");
+    apply(&mut state, state.priority_player, GameAction::PassPriority)
+        .expect("the recovered priority holder accepts the next pass");
 
     assert!(
         state.deferred_triggers.is_empty(),
@@ -484,8 +484,8 @@ fn a4_wedged_turn20_capture_retires_both_stranded_drains() {
         post_replacement_drain_statuses(&state)
     );
 
-    apply(&mut state, PlayerId(1), GameAction::PassPriority)
-        .expect("the refreshed priority window accepts the next pass");
+    apply(&mut state, state.priority_player, GameAction::PassPriority)
+        .expect("the recovered priority holder accepts the next pass");
 
     assert!(
         state.deferred_triggers.is_empty(),

--- a/crates/engine/tests/integration/resolve_all_consent.rs
+++ b/crates/engine/tests/integration/resolve_all_consent.rs
@@ -294,7 +294,9 @@ fn restored_mid_stack_priority_discards_an_orphaned_trigger_event_carrier() {
     let encoded = serde_json::to_string(&persisted).expect("mid-stack state serializes");
     let persisted: PersistedGameState =
         serde_json::from_str(&encoded).expect("mid-stack state deserializes");
-    let restored = persisted.into_game_state();
+    let restored = persisted
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
 
     assert!(
         restored.pending_trigger_event_batch.is_empty(),
@@ -762,7 +764,9 @@ fn persisted_pending_consent_decline_restores_the_captured_baseline() {
     let encoded = serde_json::to_string(&persisted).expect("pending consent serializes");
     let persisted: PersistedGameState =
         serde_json::from_str(&encoded).expect("pending consent deserializes");
-    let mut restored = persisted.into_game_state();
+    let mut restored = persisted
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
     assert!(matches!(
         restored.waiting_for,
         WaitingFor::ResolveAllConsent { epoch: restored_epoch, representative } if restored_epoch == epoch && representative == P1
@@ -802,7 +806,8 @@ fn serialized_legacy_pending_grant_removes_its_mode_before_entering_ready() {
         .expect("legacy pending run serializes without a baseline");
     let mut restored = serde_json::from_str::<PersistedGameState>(&encoded)
         .expect("legacy pending run deserializes")
-        .into_game_state();
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
     assert!(restored
         .resolve_all_consent_run
         .as_ref()
@@ -839,7 +844,9 @@ fn restored_mid_stack_priority_can_start_a_new_resolve_all_consent_run() {
     let encoded = serde_json::to_string(&persisted).expect("mid-stack priority serializes");
     let persisted: PersistedGameState =
         serde_json::from_str(&encoded).expect("mid-stack priority deserializes");
-    let mut restored = persisted.into_game_state();
+    let mut restored = persisted
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
 
     let epoch = begin(&mut restored);
     assert!(matches!(
@@ -1355,7 +1362,8 @@ fn persisted_restore_classifies_without_advancing_stack_automation() {
     let encoded = serde_json::to_string(&persisted).expect("Ready state serializes");
     let restored = serde_json::from_str::<PersistedGameState>(&encoded)
         .expect("Ready state deserializes")
-        .into_game_state();
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
 
     assert_eq!(
         classify_restored_stack_automation(&restored),
@@ -1439,7 +1447,8 @@ fn restored_rechecking_session_waits_for_a_fresh_ai_contract() {
         .expect("the active rechecking session serializes");
     let mut state = serde_json::from_str::<PersistedGameState>(&encoded)
         .expect("the active rechecking session deserializes")
-        .into_game_state();
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
     assert_eq!(
         classify_restored_stack_automation(&state),
         RestoredStackAutomation::ActiveSession

--- a/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
+++ b/crates/engine/tests/integration/satya_localized_destruction_commander_copy.rs
@@ -144,7 +144,8 @@ fn restored_token_commander_choice_resumes_sba_cleanup() {
         .expect("the captured command-zone choice serializes");
     let mut restored = serde_json::from_str::<PersistedGameState>(&serialized)
         .expect("the captured command-zone choice restores")
-        .into_game_state();
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
 
     assert!(matches!(
         &restored.waiting_for,
@@ -202,7 +203,8 @@ fn restored_token_commander_choice_respects_turn_control_priority_authority() {
         .expect("the controlled stale command-zone choice serializes");
     let mut restored = serde_json::from_str::<PersistedGameState>(&serialized)
         .expect("the controlled stale command-zone choice restores")
-        .into_game_state();
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
 
     assert!(matches!(
         &restored.waiting_for,
@@ -249,7 +251,8 @@ fn restored_genuine_commander_choice_remains_actionable() {
         .expect("the genuine command-zone choice serializes");
     let restored = serde_json::from_str::<PersistedGameState>(&serialized)
         .expect("the genuine command-zone choice restores")
-        .into_game_state();
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
 
     assert!(matches!(
         restored.waiting_for,

--- a/crates/engine/tests/integration/shorten_efficacy.rs
+++ b/crates/engine/tests/integration/shorten_efficacy.rs
@@ -550,6 +550,7 @@ fn restore_dump(json: &str) -> GameState {
     )
     .expect("gameState deserializes through the production decoder")
     .into_game_state()
+    .expect("persisted test snapshot satisfies the checked restore contract")
 }
 
 /// The LIVE-PATH board: the real 4-player Dina / Bloodthirsty Conqueror drain

--- a/crates/engine/tests/integration/sprout_inalla_realistic_offer.rs
+++ b/crates/engine/tests/integration/sprout_inalla_realistic_offer.rs
@@ -69,10 +69,11 @@ pub fn load_realistic_dump() -> GameState {
     // Decode AS `PersistedGameState` rather than decoding a bare `GameState` and wrapping
     // it in `Raw`: only the former runs `reject_legacy_raw_prompt_authority` and
     // `decode_persisted_resolution_state`, which is the rest of the production chokepoint.
-    // `.expect(..)`, not `?`: `into_game_state` returns `GameState`, not `Result`.
+    // The test unwraps the fallible persistence boundary after asserting this fixture decodes.
     serde_json::from_value::<PersistedGameState>(envelope["gameState"].clone())
         .expect("gameState deserializes through the production decoder")
         .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract")
 }
 
 /// Count the battlefield Saprolings `who` controls (tapped or not) — the fodder reach-guard oracle.

--- a/crates/engine/tests/integration/user_capture_probes.rs
+++ b/crates/engine/tests/integration/user_capture_probes.rs
@@ -97,7 +97,8 @@ fn load_dina_raw() -> (GameState, serde_json::Value) {
     let envelope: serde_json::Value = serde_json::from_str(&json).expect("dina dump parses");
     let mut state = serde_json::from_value::<PersistedGameState>(envelope["gameState"].clone())
         .expect("dina gameState decodes through the production decoder")
-        .into_game_state();
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
     state.loop_detection = engine::types::game_state::LoopDetectionMode::Interactive;
     let raw_seq = envelope["gameState"]["last_loop_action_sequence"].clone();
     (state, raw_seq)

--- a/crates/engine/tests/integration/windfall_greatest_discard_aggregate.rs
+++ b/crates/engine/tests/integration/windfall_greatest_discard_aggregate.rs
@@ -594,7 +594,9 @@ fn windfall_paused_mid_fan_out_still_draws_the_greatest() {
         .expect("parked Windfall state serializes through the authoritative persistence envelope");
     let restored: PersistedGameState = serde_json::from_str(&saved)
         .expect("parked Windfall state restores through the authoritative persistence envelope");
-    let restored = restored.into_game_state();
+    let restored = restored
+        .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract");
     assert!(
         restored.pending_discard_batch.is_some(),
         "the live discard cursor must survive save and restore before its replacement choice"

--- a/crates/engine/tests/integration/witherbloom_altar_probe.rs
+++ b/crates/engine/tests/integration/witherbloom_altar_probe.rs
@@ -69,6 +69,7 @@ fn load_wb() -> GameState {
     serde_json::from_value::<PersistedGameState>(envelope["gameState"].clone())
         .expect("gameState deserializes through the production decoder")
         .into_game_state()
+        .expect("persisted test snapshot satisfies the checked restore contract")
 }
 
 /// Put a real parsed Altar of the Brood on `seat`'s battlefield.

--- a/crates/phase-ai/src/saved_state.rs
+++ b/crates/phase-ai/src/saved_state.rs
@@ -1,4 +1,4 @@
-use engine::types::game_state::{GameState, PersistedGameState};
+use engine::types::game_state::{GameState, PersistedGameState, PersistedRestoreFinalization};
 use serde::Deserialize;
 use serde_json::{Map, Value};
 
@@ -11,15 +11,13 @@ struct Saved {
 pub fn load_saved_game_state(raw: &str) -> Result<GameState, serde_json::Error> {
     let mut value = serde_json::from_str(raw)?;
     migrate_saved_state(&mut value);
-    serde_json::from_value::<Saved>(value).map(|saved| {
-        let mut state = saved.game_state.into_game_state();
-        // A deserialized state carries `layers_dirty = Full` and a conservative
-        // all-present `static_mode_presence`. `choose_action` takes `&GameState`
-        // and cannot flush, so flush here — otherwise every presence-gated scan
-        // falls through and read-only AI consumers pay full O(battlefield) scans
-        // per query (mirrors the WASM bridge's flush-before-enumeration idiom).
-        engine::game::layers::flush_layers(&mut state);
-        state
+    serde_json::from_value::<Saved>(value).and_then(|saved| {
+        saved
+            .game_state
+            .prepare_for_restore(PersistedRestoreFinalization::Immediate)
+            .map_err(serde::de::Error::custom)?
+            .finalize_immediately()
+            .map_err(serde::de::Error::custom)
     })
 }
 

--- a/crates/phase-ai/src/session.rs
+++ b/crates/phase-ai/src/session.rs
@@ -855,7 +855,8 @@ mod tests {
             .expect("persisted game state serializes");
         let restored = serde_json::from_str::<PersistedGameState>(&json)
             .expect("persisted game state deserializes")
-            .into_game_state();
+            .into_game_state()
+            .expect("persisted game state satisfies the checked restore contract");
         let after = deck_pools_fingerprint(&restored);
 
         assert_eq!(

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -18,7 +18,8 @@ use engine::game::public_state::{
 };
 use engine::game::{
     create_debug_cards_with_rejection, debug_card_entry_source, load_and_hydrate_decks,
-    rehydrate_game_from_card_db, DebugCardCreateRequest,
+    rehydrate_game_from_card_db_with_finalization, CardDbRehydrationFinalization,
+    DebugCardCreateRequest,
 };
 use engine::types::action_rejection::ActionRejection;
 use engine::types::actions::{DebugAction, GameAction};
@@ -1149,33 +1150,40 @@ impl GameSession {
     /// one. It is the saved high-water of the stream the old seed generated, and has no
     /// meaning against the new one.
     pub fn from_persisted(ps: PersistedSession, db: &CardDatabase) -> Result<Self, String> {
-        let mut state = ps.state.into_game_state();
-        state
-            .format_config
-            .validate_for_player_count(ps.player_count)?;
-        state
-            .format_config
-            .reject_unimplemented_range_of_influence()?;
+        let mut state = ps
+            .state
+            .prepare_for_restore(
+                engine::types::game_state::PersistedRestoreFinalization::DeferUntilRehydrated,
+            )
+            .map_err(|error| error.to_string())?
+            .finalize_after_rehydration(|state| {
+                state
+                    .format_config
+                    .validate_for_player_count(ps.player_count)?;
+                state
+                    .format_config
+                    .reject_unimplemented_range_of_influence()?;
 
-        // Restore #[serde(skip)] fields
-        state.all_card_names = db.card_names().into();
-        state.log_player_names = ps.display_names.clone();
-        rehydrate_game_from_card_db(&mut state, db);
+                // Restore #[serde(skip)] fields before the engine computes the
+                // first externally visible state from this snapshot.
+                state.all_card_names = db.card_names().into();
+                state.log_player_names = ps.display_names.clone();
+                rehydrate_game_from_card_db_with_finalization(
+                    state,
+                    db,
+                    CardDbRehydrationFinalization::Defer,
+                );
 
-        // Re-seed RNG with fresh randomness (stale rng_seed would produce
-        // deterministic sequences identical across all restored games)
-        let fresh_seed: u64 = rand::rng().random();
-        state.rng_seed = fresh_seed;
-        state.rng = rand_chacha::ChaCha20Rng::seed_from_u64(fresh_seed);
-        // A fresh stream starts at word 0, so the saved high-water — which indexes into the
-        // OLD keystream and is meaningless against this one — has to go with the old seed.
-        // Leaving it behind is what broke restore: the chokepoint's `rehydrate_rng` had put
-        // live and high-water in agreement, the re-seed above rewound live to 0, and the next
-        // `capture_rng_word_pos` (`game::library::resolve_and_apply_library_shuffle` performs
-        // one before every shuffle) `.expect`-panicked `HighWaterRegression`. Same three-
-        // statement resume policy as `engine-wasm`'s `resume_multiplayer_host_state`.
-        state.rng_word_pos = 0;
-        finalize_public_state(&mut state);
+                // Re-seed RNG with fresh randomness (stale rng_seed would produce
+                // deterministic sequences identical across all restored games)
+                let fresh_seed: u64 = rand::rng().random();
+                state.rng_seed = fresh_seed;
+                state.rng = rand_chacha::ChaCha20Rng::seed_from_u64(fresh_seed);
+                // A fresh stream starts at word 0, so the saved high-water — which indexes into the
+                // OLD keystream and is meaningless against this one — has to go with the old seed.
+                state.rng_word_pos = 0;
+                Ok(())
+            })?;
         // Re-bind rather than trusting any id the blob carries, on the same
         // principle that `restore_session` re-stamps `hosting` and revokes an
         // unentitled debug capability: a persisted blob never drives authority.
@@ -2396,7 +2404,10 @@ mod tests {
         let mut mgr = SessionManager::new();
         let (code, _token) = mgr.create_game(make_deck());
         let mut persisted = mgr.sessions.get(&code).unwrap().to_persisted();
-        let mut state = persisted.state.into_game_state();
+        let mut state = persisted
+            .state
+            .into_game_state()
+            .expect("test snapshot satisfies the checked restore contract");
         state.format_config.range_of_influence =
             Some(Box::new(engine::types::format::RangeOfInfluenceConfig {
                 default_range: 0,
@@ -5145,7 +5156,11 @@ mod tests {
         let blob: crate::persist::PersistedSession = serde_json::from_str(&json).unwrap();
 
         // Premise 2, measured: the position survives disk AND the chokepoint resumes it.
-        let chokepoint_only = blob.state.clone().into_game_state();
+        let chokepoint_only = blob
+            .state
+            .clone()
+            .into_game_state()
+            .expect("test snapshot satisfies the checked restore contract");
         assert_eq!(
             chokepoint_only.rng_word_pos, SAVED_WORD_POS,
             "premise: the persisted blob carries the position across disk",

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -1183,7 +1183,8 @@ impl GameSession {
                 // OLD keystream and is meaningless against this one — has to go with the old seed.
                 state.rng_word_pos = 0;
                 Ok(())
-            })?;
+            })
+            .map_err(|error| error.to_string())?;
         // Re-bind rather than trusting any id the blob carries, on the same
         // principle that `restore_session` re-stamps `hosting` and revokes an
         // unentitled debug capability: a persisted blob never drives authority.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added staged saved-game restoration with validation before completion.
  * Restored card data and random state before final updates.
  * Added clearer errors for invalid or inconsistent saved games.

* **Bug Fixes**
  * Improved recovery of interrupted combat, spell, trigger, and resolution states.
  * Prevented stale serialized recipients from disrupting restored games.
  * Preserved coherent automation and resolution behavior across save/load cycles.
  * Repaired eligible terminal states during game restoration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->