### PR TITLE
Skip R2 publishing in forks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -603,7 +603,7 @@ jobs:
           jq --arg h "$HASH" '. + {card_data_hash: $h}' data/coverage-data.json > data/coverage-data.stamped.json
 
       - name: Upload data to R2 (preview)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'phase-rs/phase'
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
@@ -631,7 +631,7 @@ jobs:
         # bounded by distinct parser states, not commit count. best-effort
         # (continue-on-error): a missed publish just defers a PR's comment to
         # "baseline pending" until the next main push, never wedges main.
-        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main' && github.repository == 'phase-rs/phase'
         continue-on-error: true
         env:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}


### PR DESCRIPTION
Fork pushes to their own \main\ currently enter the Cloudflare R2 publication steps, but fork Actions cannot access the upstream repository secrets. This makes an otherwise-green fork sync CI fail after validation.\n\nGuard both R2-only steps with \github.repository == 'phase-rs/phase'\. Upstream main keeps publishing exactly as before (and the primary upload remains a hard failure), while forks still run all card-data validation and simply skip upstream-owned publication.\n\nValidation:\n- exact two-line workflow diff\n- git diff --check\n- independent read-only review: GO\n- actionlint reports only the existing constant-false condition at ci.yml:721

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restricted automated data uploads to pushes from the canonical repository, preventing unintended uploads from other repository contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->