### PR TITLE
fix(client): expose accessible names for shared game dialogs

### DIFF
--- a/client/src/components/modal/DialogShell.tsx
+++ b/client/src/components/modal/DialogShell.tsx
@@ -1,5 +1,11 @@
 import { AnimatePresence, motion, useDragControls, useReducedMotion } from "framer-motion";
-import { useEffect, useRef, type PointerEvent as ReactPointerEvent, type ReactNode } from "react";
+import {
+  useEffect,
+  useId,
+  useRef,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode,
+} from "react";
 import { useTranslation } from "react-i18next";
 
 import type { ObjectId } from "../../adapter/types.ts";
@@ -42,6 +48,7 @@ export function DialogShell({
   previewObjectId,
 }: DialogShellProps) {
   const { t } = useTranslation("game");
+  const titleId = useId();
   const peek = useOptionalDialogPeek();
   const isNarrow = useIsNarrowViewport();
   const inspectHoverProps = useInspectHoverProps();
@@ -103,6 +110,8 @@ export function DialogShell({
 
         <motion.div
           className={wrapperClass}
+          role="dialog"
+          aria-labelledby={titleId}
           initial={{ scale: 0.95, opacity: 0, y: 10 }}
           animate={{ scale: 1, opacity: 1, y: 0 }}
           exit={{ scale: 0.95, opacity: 0, y: 10 }}
@@ -119,6 +128,7 @@ export function DialogShell({
               eyebrow={resolvedEyebrow}
               eyebrowClassName={eyebrowClassName}
               title={title}
+              titleId={titleId}
               subtitle={subtitle}
               onHandlePointerDown={startHeaderDrag}
             />
@@ -146,6 +156,7 @@ interface DialogHeaderProps {
   eyebrow: ReactNode;
   eyebrowClassName?: string;
   title: ReactNode;
+  titleId: string;
   subtitle?: ReactNode;
   /** When provided, the header acts as the dialog's drag handle: pointer-down
    * starts a drag via the shell's `dragControls`. Absent → static header. */
@@ -156,6 +167,7 @@ export function DialogHeader({
   eyebrow,
   eyebrowClassName,
   title,
+  titleId,
   subtitle,
   onHandlePointerDown,
 }: DialogHeaderProps) {
@@ -176,7 +188,7 @@ export function DialogHeader({
       className={`relative border-b border-white/10 px-3 py-3 lg:px-5 lg:py-5 ${handleClass}`}
     >
       <div className={eyebrowClass}>{eyebrow}</div>
-      <h2 className="mt-1 text-base font-semibold text-white lg:text-xl">
+      <h2 id={titleId} className="mt-1 text-base font-semibold text-white lg:text-xl">
         {title}
       </h2>
       {subtitle ? (

--- a/client/src/components/modal/__tests__/DialogShell.test.tsx
+++ b/client/src/components/modal/__tests__/DialogShell.test.tsx
@@ -23,6 +23,20 @@ describe("DialogShell", () => {
     expect(screen.getByText("body")).toBeInTheDocument();
   });
 
+  it("exposes the title as the dialog's accessible name", () => {
+    render(
+      <DialogShell title="Choose attackers">
+        <div>body</div>
+      </DialogShell>,
+    );
+
+    const dialog = screen.getByRole("dialog", { name: "Choose attackers" });
+    const heading = screen.getByRole("heading", { name: "Choose attackers", level: 2 });
+
+    expect(dialog).toHaveAttribute("aria-labelledby", heading.id);
+    expect(heading.id).not.toBe("");
+  });
+
   it("renders default eyebrow when none is provided", () => {
     render(
       <DialogShell title="t">


### PR DESCRIPTION
## Summary

Give every shared game `DialogShell` an accessible dialog role and name derived from its existing heading. This improves screen-reader discovery across the shared shell's callers without claiming modal behavior while the shell's peek interaction can leave the background available.

## Files changed

- `client/src/components/modal/DialogShell.tsx` — connect the shared dialog wrapper to its rendered title with `useId`, `role="dialog"`, and `aria-labelledby`.
- `client/src/components/modal/__tests__/DialogShell.test.tsx` — verify role/name lookup and the heading-ID relationship.

## Track

Developer

## LLM

Model: gpt-5.6-sol
Tier: Frontier
Thinking: max

## Implementation method (required)

Method: not-applicable — frontend-only shared accessibility semantics

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — exit 0; committed worktree remained clean.
- `/usr/local/bin/node ../scripts/check-protocol-version.mjs` — exit 0.
- `/usr/local/bin/node ./node_modules/typescript/bin/tsc -b --noEmit` — exit 0.
- `/usr/local/bin/node ./node_modules/eslint/bin/eslint.js .` — exit 0; 0 errors and the repository's 41 existing warnings, none in the changed files.
- `/usr/local/bin/node ./node_modules/vitest/vitest.mjs run --reporter=dot --silent` — 396 test files passed, 2 skipped; 4,135 tests passed, 12 todo.
- `git diff --check origin/main...HEAD` — exit 0.
- Repository pre-commit hook — Gate G, Gate A, and Gate P passed.

## Gate A

Gate A PASS head=66637227c17840207cbb255057a670b9d8ca27a6 base=1136ea5c5007319413e2c47d00d4fbd1fdc2cad1

## Anchored on

- `client/src/components/ui/ModalPanelShell.tsx:32` — shared modal shell uses `useId` to bind dialog semantics to its title.
- `client/src/components/ui/TextPromptDialog.tsx:87` — dialog wrapper exposes its heading through `aria-labelledby`.

## Final review-impl

Final review-impl PASS head=66637227c17840207cbb255057a670b9d8ca27a6

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Accessibility**
  * Improved modal dialogs with properly associated titles for screen readers and assistive technologies.
  * Dialog titles now use clear level-two headings and stable identifiers.

* **Tests**
  * Added coverage verifying that modal dialogs expose their titles as accessible names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->