### PR TITLE
fix(client): keep document language in sync with preferences

### DIFF
--- a/client/src/i18n/README.md
+++ b/client/src/i18n/README.md
@@ -53,8 +53,8 @@ Namespaces: `common` (default), `menu`, `game`, `deck-builder`, `draft`,
 - Plurals: `key_one` / `key_other` + `t(key, { count })` (CLDR rules per locale).
   Don't hand-roll `count === 1 ? "" : "s"`.
 - Numbers needing locale grouping: `{{value, number}}`.
-- The store owns the active language; never call `i18n.changeLanguage` directly —
-  use `usePreferencesStore.getState().setLanguage(lng)`.
+- The store owns the active language; the i18n bootstrap mirrors it to i18next
+  and `<html lang>`, so use `usePreferencesStore.getState().setLanguage(lng)`.
 - English (`en`) is the typing oracle: add a key to `en/<ns>.json` **before**
   referencing it, or it won't type-check. Other locales fall back to English.
 - Encoding: catalogs are **UTF-8 with literal accented characters** (write

--- a/client/src/i18n/index.test.ts
+++ b/client/src/i18n/index.test.ts
@@ -1,0 +1,30 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+describe("i18n production bootstrap", () => {
+  afterEach(() => {
+    localStorage.clear();
+    document.documentElement.lang = "en";
+    vi.resetModules();
+  });
+
+  it("keeps the document language synchronized with the preferences store", async () => {
+    localStorage.setItem(
+      "phase-preferences",
+      JSON.stringify({ state: { language: "fr" }, version: 31 }),
+    );
+    document.documentElement.lang = "en";
+    vi.resetModules();
+
+    const { default: i18n } = await import("./index");
+    const { usePreferencesStore } = await import("../stores/preferencesStore");
+
+    expect(usePreferencesStore.getState().language).toBe("fr");
+    expect(i18n.language).toBe("fr");
+    expect(document.documentElement.lang).toBe("fr");
+
+    usePreferencesStore.getState().setLanguage("de");
+
+    expect(document.documentElement.lang).toBe("de");
+    await vi.waitFor(() => expect(i18n.language).toBe("de"));
+  });
+});

--- a/client/src/i18n/index.ts
+++ b/client/src/i18n/index.ts
@@ -2,7 +2,7 @@ import i18n from "i18next";
 import { initReactI18next } from "react-i18next";
 
 import { usePreferencesStore } from "../stores/preferencesStore";
-import { resources, SUPPORTED_LNGS } from "./resources";
+import { resources, SUPPORTED_LNGS, type SupportedLng } from "./resources";
 
 /** All translation namespaces, one per UI domain. `common` is the default ns and
  *  is loaded implicitly by every `useTranslation()`; others are opted into via
@@ -23,10 +23,20 @@ export const NAMESPACES = [
 // initial language is seeded from the preferences store, which has already
 // hydrated synchronously from localStorage by the time this module evaluates
 // (zustand `persist` over a sync storage hydrates during `create()`). The store
-// is the single source of truth; i18next is a derived mirror.
+// is the single source of truth; i18next and the document language are derived
+// mirrors.
+function syncDocumentLanguage(language: SupportedLng): void {
+  if (typeof document !== "undefined") {
+    document.documentElement.lang = language;
+  }
+}
+
+const initialLanguage = usePreferencesStore.getState().language;
+syncDocumentLanguage(initialLanguage);
+
 void i18n.use(initReactI18next).init({
   resources,
-  lng: usePreferencesStore.getState().language,
+  lng: initialLanguage,
   fallbackLng: "en",
   supportedLngs: SUPPORTED_LNGS,
   ns: NAMESPACES,
@@ -39,10 +49,17 @@ void i18n.use(initReactI18next).init({
 
 // Mirror store → i18next. Only the store writes the language; this keeps i18next's
 // active language in lockstep. Basic subscribe (no subscribeWithSelector needed).
-usePreferencesStore.subscribe((state, prev) => {
-  if (state.language !== prev.language && i18n.language !== state.language) {
-    void i18n.changeLanguage(state.language);
+const unsubscribePreferences = usePreferencesStore.subscribe((state, prev) => {
+  if (state.language !== prev.language) {
+    syncDocumentLanguage(state.language);
+    if (i18n.language !== state.language) {
+      void i18n.changeLanguage(state.language);
+    }
   }
 });
+
+if (import.meta.hot) {
+  import.meta.hot.dispose(unsubscribePreferences);
+}
 
 export default i18n;


### PR DESCRIPTION
## Summary

Keep the document's `<html lang>` metadata synchronized with the authoritative language preference during i18n bootstrap and runtime changes. This gives assistive technology and browser language features the same locale already used by the rendered interface.

## Files changed

- `client/src/i18n/index.ts` — mirror the initial and runtime language preference to `document.documentElement.lang`, with document safety and HMR subscription cleanup.
- `client/src/i18n/index.test.ts` — exercise persisted initial language and runtime preference changes through production wiring.
- `client/src/i18n/README.md` — document that the bootstrap mirrors the store to both i18next and `<html lang>`.

## Track

Developer

## LLM

Model: gpt-5.6-sol
Tier: Frontier
Thinking: max

## Implementation method (required)

Method: not-applicable — frontend-only i18n metadata synchronization

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — exit 0; committed worktree remained clean.
- `/usr/local/bin/node ../scripts/check-protocol-version.mjs` — exit 0.
- `/usr/local/bin/node ./node_modules/typescript/bin/tsc -b --noEmit` — exit 0.
- `/usr/local/bin/node ./node_modules/eslint/bin/eslint.js .` — exit 0; 0 errors and the repository's 41 existing warnings, none in the changed files.
- `/usr/local/bin/node ./node_modules/vitest/vitest.mjs run --reporter=dot --silent` — 397 test files passed, 2 skipped; 4,135 tests passed, 12 todo.
- `git diff --check origin/main...HEAD` — exit 0.
- Repository pre-commit hook — Gate G, Gate A, and Gate P passed.

## Gate A

Gate A PASS head=4b374d88f0f923f3796ac3bd171b73a9eb400e4a base=1136ea5c5007319413e2c47d00d4fbd1fdc2cad1

## Anchored on

- `client/src/i18n/index.ts:50` — the existing bootstrap subscription mirrors the authoritative preference store into i18next.
- `client/src/pages/GamePage.tsx:1161` — existing frontend code synchronizes a root-document property from a preferences-store value.

## Final review-impl

Final review-impl PASS head=4b374d88f0f923f3796ac3bd171b73a9eb400e4a

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Language preferences now stay synchronized across the app, translation system, and browser document language.
  - The selected language is applied correctly when the app starts and when users change it.
  - Language settings are handled more reliably during development updates.

- **Tests**
  - Added coverage for restoring saved French preferences and switching to German.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->