### PR TITLE
Fix Padeem, Consul of Innovation

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -7,7 +7,7 @@ use nom::branch::alt;
 use nom::bytes::complete::tag;
 use nom::bytes::complete::take_until;
 use nom::character::complete::multispace1;
-use nom::combinator::{eof, map, opt, peek, value, verify};
+use nom::combinator::{cut, eof, map, opt, peek, value, verify};
 use nom::multi::many0;
 use nom::sequence::{preceded, terminated};
 use nom::Parser;
@@ -3106,44 +3106,54 @@ fn parse_you_control_superlative_object_condition(
         tag(" with the "),
     )
     .parse(rest)?;
-
-    // CR 109.2 + CR 109.4: `you control` can describe battlefield permanents,
-    // not an off-battlefield "card" or a stack "spell". `parse_type_phrase`
-    // intentionally consumes those redundant terminal nouns for other parser
-    // contexts, so guard this controlled-permanent production before delegating.
-    if scan_at_word_boundaries(candidate_text, |word| {
-        terminated(
-            alt((tag("cards"), tag("card"), tag("spells"), tag("spell"))),
-            eof,
-        )
-        .parse(word)
-    })
-    .is_some()
-    {
-        return Err(oracle_err(candidate_text));
-    }
-
-    let (object_filter, candidate_remainder) = parse_type_phrase(candidate_text);
-    if matches!(object_filter, TargetFilter::Any) || !candidate_remainder.is_empty() {
-        return Err(oracle_err(candidate_remainder));
-    }
     let (rest, aggregate) = parse_superlative_adjective(rest)?;
     let (rest, _) = tag(" ").parse(rest)?;
     let (rest, property) = parse_property_keyword(rest)?;
-    let (rest, _) = parse_optional_tied_for_tail(rest, aggregate, property)?;
-    let (rest, population_filter) =
-        if let Ok((among_rest, _)) = tag::<_, _, OracleError<'_>>(" among ").parse(rest) {
-            let (filter, remainder) = parse_type_phrase(among_rest);
-            if matches!(filter, TargetFilter::Any) {
-                return Err(oracle_err(remainder));
-            }
-            let population_rest = remainder;
-            let (population_rest, _) = opt(tag(".")).parse(population_rest)?;
-            let (population_rest, _) = eof.parse(population_rest)?;
-            (population_rest, filter)
-        } else {
-            (rest, object_filter.clone())
-        };
+
+    // The adjective/property pair commits this production. Before that point,
+    // unrelated supported `you control` phrases must remain available to the
+    // ordinary control-condition parser. After it, every malformed candidate,
+    // tie tail, population, or leaf boundary is a hard failure so `alt` cannot
+    // reinterpret a partially consumed superlative as a weaker condition.
+    let (rest, (object_filter, population_filter)) = cut(|rest| {
+        // CR 109.2 + CR 109.4: `you control` describes a battlefield permanent,
+        // not an off-battlefield "card" or a stack "spell". `parse_type_phrase`
+        // intentionally consumes those terminal nouns in other contexts, so
+        // reject them before delegating the candidate noun phrase.
+        if scan_at_word_boundaries(candidate_text, |word| {
+            terminated(
+                alt((tag("cards"), tag("card"), tag("spells"), tag("spell"))),
+                eof,
+            )
+            .parse(word)
+        })
+        .is_some()
+        {
+            return Err(oracle_err(candidate_text));
+        }
+
+        let (object_filter, candidate_remainder) = parse_type_phrase(candidate_text);
+        if matches!(object_filter, TargetFilter::Any) || !candidate_remainder.is_empty() {
+            return Err(oracle_err(candidate_remainder));
+        }
+
+        let (rest, _) = parse_optional_tied_for_tail(rest, aggregate, property)?;
+        let (rest, population_filter) =
+            if let Ok((among_rest, _)) = tag::<_, _, OracleError<'_>>(" among ").parse(rest) {
+                let (filter, remainder) = parse_type_phrase(among_rest);
+                if matches!(filter, TargetFilter::Any) {
+                    return Err(oracle_err(remainder));
+                }
+                (remainder, filter)
+            } else {
+                (rest, object_filter.clone())
+            };
+
+        let (rest, _) =
+            peek(alt((eof, tag("."), tag(","), tag(" and "), tag(" or ")))).parse(rest)?;
+        Ok((rest, (object_filter, population_filter)))
+    })
+    .parse(rest)?;
     let (rest, _) = opt(tag(".")).parse(rest)?;
 
     let controlled_filter = add_filter_property(
@@ -3152,12 +3162,9 @@ fn parse_you_control_superlative_object_condition(
     );
     Ok((
         rest,
-        make_quantity_ge(
-            QuantityRef::ObjectCount {
-                filter: controlled_filter,
-            },
-            1,
-        ),
+        StaticCondition::IsPresent {
+            filter: Some(controlled_filter),
+        },
     ))
 }
 
@@ -20104,25 +20111,23 @@ mod tests {
         .unwrap();
         assert!(rest.is_empty(), "must fully consume, leftover: {rest:?}");
 
-        let StaticCondition::QuantityComparison {
-            lhs:
-                QuantityExpr::Ref {
-                    qty:
-                        QuantityRef::ObjectCount {
-                            filter: TargetFilter::Typed(candidate),
-                        },
-                },
-            comparator: Comparator::GE,
-            rhs: QuantityExpr::Fixed { value: 1 },
+        let StaticCondition::IsPresent {
+            filter: Some(TargetFilter::Typed(candidate)),
         } = condition
         else {
-            panic!("expected controlled artifact ObjectCount gate, got {condition:?}");
+            panic!("expected controlled artifact presence gate, got {condition:?}");
         };
         assert_eq!(candidate.controller, Some(ControllerRef::You));
         assert_eq!(candidate.type_filters, vec![TypeFilter::Artifact]);
-        assert_eq!(candidate.properties.len(), 1);
+        assert_eq!(candidate.properties.len(), 2);
+        assert!(candidate.properties.iter().any(|property| matches!(
+            property,
+            FilterProp::InZone {
+                zone: Zone::Battlefield
+            }
+        )));
 
-        let FilterProp::Cmc {
+        let Some(FilterProp::Cmc {
             comparator: Comparator::EQ,
             value:
                 QuantityExpr::Ref {
@@ -20133,7 +20138,10 @@ mod tests {
                             filter: TargetFilter::Typed(population),
                         },
                 },
-        } = &candidate.properties[0]
+        }) = candidate
+            .properties
+            .iter()
+            .find(|property| matches!(property, FilterProp::Cmc { .. }))
         else {
             panic!(
                 "expected exact mana-value membership in the artifact maximum, got {:?}",
@@ -20158,19 +20166,11 @@ mod tests {
         .unwrap();
         assert!(rest.is_empty(), "must fully consume, leftover: {rest:?}");
 
-        let StaticCondition::QuantityComparison {
-            lhs:
-                QuantityExpr::Ref {
-                    qty:
-                        QuantityRef::ObjectCount {
-                            filter: TargetFilter::Typed(candidate),
-                        },
-                },
-            comparator: Comparator::GE,
-            rhs: QuantityExpr::Fixed { value: 1 },
+        let StaticCondition::IsPresent {
+            filter: Some(TargetFilter::Typed(candidate)),
         } = condition
         else {
-            panic!("expected controlled artifact ObjectCount gate, got {condition:?}");
+            panic!("expected controlled artifact presence gate, got {condition:?}");
         };
         let Some(FilterProp::Cmc {
             comparator: Comparator::EQ,
@@ -20183,12 +20183,22 @@ mod tests {
                             filter: TargetFilter::Typed(population),
                         },
                 },
-        }) = candidate.properties.first()
+        }) = candidate
+            .properties
+            .iter()
+            .find(|property| matches!(property, FilterProp::Cmc { .. }))
         else {
             panic!("expected exact membership in the artifact minimum, got {candidate:?}");
         };
         assert_eq!(candidate.controller, Some(ControllerRef::You));
         assert_eq!(candidate.type_filters, vec![TypeFilter::Artifact]);
+        assert_eq!(candidate.properties.len(), 2);
+        assert!(candidate.properties.iter().any(|property| matches!(
+            property,
+            FilterProp::InZone {
+                zone: Zone::Battlefield
+            }
+        )));
         assert_eq!(population.type_filters, vec![TypeFilter::Artifact]);
         assert!(population.controller.is_none());
     }
@@ -20198,15 +20208,51 @@ mod tests {
     #[test]
     fn parse_inner_condition_you_control_superlative_rejects_nonpermanent_nouns_and_leftovers() {
         assert!(
-            parse_inner_condition("you control an artifact card with the greatest mana value.")
-                .is_err(),
+            matches!(
+                parse_inner_condition("you control an artifact card with the greatest mana value."),
+                Err(nom::Err::Failure(_))
+            ),
             "terminal `card` must not be accepted in a `you control` permanent predicate"
         );
         assert!(
-            parse_inner_condition("you control an artifact relic with the greatest mana value.")
-                .is_err(),
+            matches!(
+                parse_inner_condition(
+                    "you control an artifact relic with the greatest mana value."
+                ),
+                Err(nom::Err::Failure(_))
+            ),
             "an unparsed candidate-noun tail must fail closed"
         );
+    }
+
+    /// Before the superlative adjective/property commits the specialized
+    /// production, ordinary controlled-object conditions still fall through to
+    /// the established control-condition grammar.
+    #[test]
+    fn parse_inner_condition_you_control_superlative_keeps_supported_fallbacks() {
+        let (rest, plain) = parse_inner_condition("you control an artifact").unwrap();
+        assert!(rest.is_empty());
+        assert!(matches!(
+            plain,
+            StaticCondition::IsPresent { filter: Some(_) }
+        ));
+
+        let (rest, qualified) =
+            parse_inner_condition("you control a creature with flying").unwrap();
+        assert!(rest.is_empty());
+        let StaticCondition::IsPresent {
+            filter: Some(TargetFilter::Typed(filter)),
+        } = qualified
+        else {
+            panic!("expected controlled-creature presence gate, got {qualified:?}");
+        };
+        assert_eq!(filter.controller, Some(ControllerRef::You));
+        assert!(filter.properties.iter().any(|property| matches!(
+            property,
+            FilterProp::WithKeyword {
+                value: Keyword::Flying
+            }
+        )));
     }
 
     /// CR 608.2c: Abzan Beastmaster's resolve-time gate is an existential
@@ -20219,20 +20265,17 @@ mod tests {
         .unwrap();
         assert!(rest.is_empty(), "must fully consume, leftover: {rest:?}");
         match c {
-            StaticCondition::QuantityComparison {
-                lhs:
-                    QuantityExpr::Ref {
-                        qty:
-                            QuantityRef::ObjectCount {
-                                filter: TargetFilter::Typed(tf),
-                            },
-                    },
-                comparator,
-                rhs: QuantityExpr::Fixed { value: 1 },
+            StaticCondition::IsPresent {
+                filter: Some(TargetFilter::Typed(tf)),
             } => {
-                assert_eq!(comparator, Comparator::GE);
                 assert_eq!(tf.controller, Some(ControllerRef::You));
                 assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+                assert!(tf.properties.iter().any(|property| matches!(
+                    property,
+                    FilterProp::InZone {
+                        zone: Zone::Battlefield
+                    }
+                )));
                 let has_table_wide_toughness_max = tf.properties.iter().any(|prop| {
                     let FilterProp::PtComparison {
                         stat: PtStat::Toughness,
@@ -20266,7 +20309,7 @@ mod tests {
                     tf.properties
                 );
             }
-            other => panic!("expected controlled creature ObjectCount gate, got {other:?}"),
+            other => panic!("expected controlled creature presence gate, got {other:?}"),
         }
     }
 
@@ -20281,20 +20324,17 @@ mod tests {
         .unwrap();
         assert!(rest.is_empty(), "must fully consume, leftover: {rest:?}");
         match c {
-            StaticCondition::QuantityComparison {
-                lhs:
-                    QuantityExpr::Ref {
-                        qty:
-                            QuantityRef::ObjectCount {
-                                filter: TargetFilter::Typed(tf),
-                            },
-                    },
-                comparator,
-                rhs: QuantityExpr::Fixed { value: 1 },
+            StaticCondition::IsPresent {
+                filter: Some(TargetFilter::Typed(tf)),
             } => {
-                assert_eq!(comparator, Comparator::GE);
                 assert_eq!(tf.controller, Some(ControllerRef::You));
                 assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+                assert!(tf.properties.iter().any(|property| matches!(
+                    property,
+                    FilterProp::InZone {
+                        zone: Zone::Battlefield
+                    }
+                )));
                 let has_battlefield_power_max = tf.properties.iter().any(|prop| {
                     let FilterProp::PtComparison {
                         stat: PtStat::Power,
@@ -20335,8 +20375,26 @@ mod tests {
                     tf.properties
                 );
             }
-            other => panic!("expected controlled creature ObjectCount gate, got {other:?}"),
+            other => panic!("expected controlled creature presence gate, got {other:?}"),
         }
+    }
+
+    /// A superlative condition embedded before an effect clause keeps the
+    /// comma for the trigger/effect composer while still producing the fully
+    /// typed controlled-candidate predicate.
+    #[test]
+    fn parse_inner_condition_you_control_superlative_preserves_comma_boundary() {
+        let (rest, condition) = parse_inner_condition(
+            "you control a creature with the greatest power among creatures on the battlefield, create a token",
+        )
+        .unwrap();
+        assert_eq!(rest, ", create a token");
+        assert!(matches!(
+            condition,
+            StaticCondition::IsPresent {
+                filter: Some(TargetFilter::Typed(_))
+            }
+        ));
     }
 
     /// CR 702: "a creature you control has <keyword>" — subject-first

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -20,6 +20,7 @@ use super::primitives::{
     scan_at_word_boundaries,
 };
 use super::quantity as nom_quantity;
+use super::target as nom_target;
 use crate::parser::oracle_target::{
     cast_capable_zones_except, parse_shared_quality, parse_type_phrase, parse_zone_suffix,
     parse_zone_word, peek_zone_boundary, superlative_property_filter_prop,
@@ -3121,10 +3122,9 @@ fn parse_you_control_superlative_object_condition(
         // intentionally consumes those terminal nouns in other contexts, so
         // reject them before delegating the candidate noun phrase.
         if scan_at_word_boundaries(candidate_text, |word| {
-            terminated(
-                alt((tag("cards"), tag("card"), tag("spells"), tag("spell"))),
-                eof,
-            )
+            verify(nom_target::parse_type_filter_word, |type_filter| {
+                matches!(type_filter, TypeFilter::Card)
+            })
             .parse(word)
         })
         .is_some()
@@ -3135,6 +3135,13 @@ fn parse_you_control_superlative_object_condition(
         let (object_filter, candidate_remainder) = parse_type_phrase(candidate_text);
         if matches!(object_filter, TargetFilter::Any) || !candidate_remainder.is_empty() {
             return Err(oracle_err(candidate_remainder));
+        }
+        if object_filter
+            .extract_zones()
+            .iter()
+            .any(|zone| *zone != Zone::Battlefield)
+        {
+            return Err(oracle_err(candidate_text));
         }
 
         let (rest, _) = parse_optional_tied_for_tail(rest, aggregate, property)?;
@@ -20203,17 +20210,34 @@ mod tests {
         assert!(population.controller.is_none());
     }
 
-    /// CR 109.2 + CR 109.4: controlled-permanent superlatives must reject a
-    /// terminal off-battlefield/stack noun and any genuine type-phrase tail.
+    /// CR 109.2 + CR 109.4: controlled-permanent superlatives must reject
+    /// off-battlefield/stack nouns at any word boundary, explicit
+    /// non-battlefield zones, and any genuine type-phrase tail.
     #[test]
     fn parse_inner_condition_you_control_superlative_rejects_nonpermanent_nouns_and_leftovers() {
-        assert!(
-            matches!(
-                parse_inner_condition("you control an artifact card with the greatest mana value."),
-                Err(nom::Err::Failure(_))
+        for (text, reason) in [
+            (
+                "you control an artifact card with the greatest mana value.",
+                "terminal `card`",
             ),
-            "terminal `card` must not be accepted in a `you control` permanent predicate"
-        );
+            (
+                "you control a creature card in your graveyard with the greatest power.",
+                "zone-qualified `card`",
+            ),
+            (
+                "you control an artifact spell on the stack with the greatest mana value.",
+                "zone-qualified `spell`",
+            ),
+            (
+                "you control a creature in your graveyard with the greatest power.",
+                "explicit non-battlefield zone",
+            ),
+        ] {
+            assert!(
+                matches!(parse_inner_condition(text), Err(nom::Err::Failure(_))),
+                "{reason} must not be accepted in a `you control` permanent predicate"
+            );
+        }
         assert!(
             matches!(
                 parse_inner_condition(
@@ -20251,6 +20275,34 @@ mod tests {
             property,
             FilterProp::WithKeyword {
                 value: Keyword::Flying
+            }
+        )));
+    }
+
+    /// CR 109.2: an explicit battlefield candidate remains a permanent, and
+    /// forbidden-noun scanning must not treat a subtype such as Spellshaper as
+    /// the standalone word "spell".
+    #[test]
+    fn parse_inner_condition_you_control_superlative_accepts_explicit_battlefield_candidate() {
+        let (rest, condition) = parse_inner_condition(
+            "you control a spellshaper creature on the battlefield with the greatest power.",
+        )
+        .unwrap();
+        assert!(rest.is_empty());
+        let StaticCondition::IsPresent {
+            filter: Some(TargetFilter::Typed(filter)),
+        } = condition
+        else {
+            panic!("expected controlled permanent superlative, got {condition:?}");
+        };
+        assert_eq!(filter.controller, Some(ControllerRef::You));
+        assert!(filter
+            .type_filters
+            .contains(&TypeFilter::Subtype("Spellshaper".to_string())));
+        assert!(filter.properties.iter().any(|property| matches!(
+            property,
+            FilterProp::InZone {
+                zone: Zone::Battlefield
             }
         )));
     }

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -17,11 +17,12 @@ use super::error::{oracle_err, OracleError, OracleResult};
 use super::primitives::{
     parse_article, parse_color, parse_keyword_name, parse_mana_cost, parse_number,
     parse_object_recipient_pronoun, parse_property_keyword, parse_superlative_adjective,
+    scan_at_word_boundaries,
 };
 use super::quantity as nom_quantity;
 use crate::parser::oracle_target::{
     cast_capable_zones_except, parse_shared_quality, parse_type_phrase, parse_zone_suffix,
-    parse_zone_word, peek_zone_boundary,
+    parse_zone_word, peek_zone_boundary, superlative_property_filter_prop,
 };
 use crate::parser::oracle_util::parse_subtype;
 use crate::types::ability::{
@@ -3087,71 +3088,67 @@ fn parse_optional_tied_for_tail(
     Ok((rest, relaxed))
 }
 
-/// CR 608.2c + CR 109.4: Parse a player-control superlative gate such as
+/// CR 109.2 + CR 109.4 + CR 608.2c: Parse a player-control superlative gate such as
 /// "you control the creature with the greatest toughness or tied for the
-/// greatest toughness" or "you control a creature with the greatest power
-/// among creatures on the battlefield". This is not source-relative: the
-/// player controls at least one creature whose P/T is tied for the table-wide
-/// maximum/minimum.
+/// greatest toughness" or "you control an artifact with the greatest mana
+/// value". An unqualified type noun denotes a battlefield permanent, and the
+/// player controls at least one candidate whose property equals the aggregate
+/// over the implicit candidate population or an explicit `among` population.
 fn parse_you_control_superlative_object_condition(
     input: &str,
 ) -> OracleResult<'_, StaticCondition> {
     let (rest, _) = tag("you control ").parse(input)?;
-    let (rest, _) = alt((tag("the "), tag("a "))).parse(rest)?;
-    let (rest, object_filter) = value(
-        TargetFilter::Typed(TypedFilter::creature()),
-        tag("creature"),
+    let (rest, _) = alt((value((), tag("the ")), parse_article)).parse(rest)?;
+    let (rest, candidate_text) = terminated(
+        verify(take_until(" with the "), |candidate: &&str| {
+            !candidate.is_empty()
+        }),
+        tag(" with the "),
     )
     .parse(rest)?;
-    let (rest, _) = tag(" with the ").parse(rest)?;
+
+    // CR 109.2 + CR 109.4: `you control` can describe battlefield permanents,
+    // not an off-battlefield "card" or a stack "spell". `parse_type_phrase`
+    // intentionally consumes those redundant terminal nouns for other parser
+    // contexts, so guard this controlled-permanent production before delegating.
+    if scan_at_word_boundaries(candidate_text, |word| {
+        terminated(
+            alt((tag("cards"), tag("card"), tag("spells"), tag("spell"))),
+            eof,
+        )
+        .parse(word)
+    })
+    .is_some()
+    {
+        return Err(oracle_err(candidate_text));
+    }
+
+    let (object_filter, candidate_remainder) = parse_type_phrase(candidate_text);
+    if matches!(object_filter, TargetFilter::Any) || !candidate_remainder.is_empty() {
+        return Err(oracle_err(candidate_remainder));
+    }
     let (rest, aggregate) = parse_superlative_adjective(rest)?;
     let (rest, _) = tag(" ").parse(rest)?;
     let (rest, property) = parse_property_keyword(rest)?;
     let (rest, _) = parse_optional_tied_for_tail(rest, aggregate, property)?;
-    let comparator = match aggregate {
-        AggregateFunction::Max => Comparator::GE,
-        AggregateFunction::Min => Comparator::LE,
-        AggregateFunction::Sum => return Err(oracle_err(rest)),
-    };
     let (rest, population_filter) =
         if let Ok((among_rest, _)) = tag::<_, _, OracleError<'_>>(" among ").parse(rest) {
             let (filter, remainder) = parse_type_phrase(among_rest);
             if matches!(filter, TargetFilter::Any) {
                 return Err(oracle_err(remainder));
             }
-            let consumed = among_rest.len() - remainder.len();
-            (&among_rest[consumed..], filter)
+            let population_rest = remainder;
+            let (population_rest, _) = opt(tag(".")).parse(population_rest)?;
+            let (population_rest, _) = eof.parse(population_rest)?;
+            (population_rest, filter)
         } else {
             (rest, object_filter.clone())
         };
     let (rest, _) = opt(tag(".")).parse(rest)?;
 
-    let stat = match property {
-        ObjectProperty::Power => PtStat::Power,
-        ObjectProperty::Toughness => PtStat::Toughness,
-        ObjectProperty::ManaValue | ObjectProperty::ManaSymbolCount(_) => {
-            return Err(oracle_err(rest));
-        }
-    };
     let controlled_filter = add_filter_property(
-        inject_controller_you(object_filter.clone()),
-        FilterProp::PtComparison {
-            stat,
-            scope: PtValueScope::Current,
-            comparator,
-            value: QuantityExpr::Ref {
-                qty: QuantityRef::PropertyAggregate(
-                    PropertyAggregate::new(
-                        aggregate,
-                        property,
-                        CardTypeSetSource::Objects {
-                            filter: population_filter,
-                        },
-                    )
-                    .expect("object property aggregate is valid"),
-                ),
-            },
-        },
+        inject_controller_you(object_filter),
+        superlative_property_filter_prop(aggregate, property, population_filter),
     );
     Ok((
         rest,
@@ -10194,8 +10191,8 @@ pub(crate) fn match_when_you_do(i: &str) -> OracleResult<'_, ()> {
 mod tests {
     use super::*;
     use crate::types::ability::{
-        CardTypeSetSource, CountScope, RoundingMode, TriggerCondition, TypeFilter, TypedFilter,
-        ZoneRef,
+        CardTypeSetSource, CountScope, PtStat, PtValueScope, RoundingMode, TriggerCondition,
+        TypeFilter, TypedFilter, ZoneRef,
     };
     use crate::types::card_type::Supertype;
     use crate::types::mana::{ManaColor, ManaCost};
@@ -20095,6 +20092,123 @@ mod tests {
         }
     }
 
+    /// CR 109.2 + CR 109.4 + CR 608.2c: Padeem's intervening-if is an
+    /// existential controlled-artifact check against the table-wide greatest
+    /// artifact mana value. Candidate membership is exact equality to the Max,
+    /// so tied artifacts qualify without widening the predicate to GE.
+    #[test]
+    fn parse_inner_condition_you_control_artifact_with_greatest_mana_value() {
+        let (rest, condition) = parse_inner_condition(
+            "you control the artifact with the greatest mana value or tied for the greatest mana value.",
+        )
+        .unwrap();
+        assert!(rest.is_empty(), "must fully consume, leftover: {rest:?}");
+
+        let StaticCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty:
+                        QuantityRef::ObjectCount {
+                            filter: TargetFilter::Typed(candidate),
+                        },
+                },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 1 },
+        } = condition
+        else {
+            panic!("expected controlled artifact ObjectCount gate, got {condition:?}");
+        };
+        assert_eq!(candidate.controller, Some(ControllerRef::You));
+        assert_eq!(candidate.type_filters, vec![TypeFilter::Artifact]);
+        assert_eq!(candidate.properties.len(), 1);
+
+        let FilterProp::Cmc {
+            comparator: Comparator::EQ,
+            value:
+                QuantityExpr::Ref {
+                    qty:
+                        QuantityRef::Aggregate {
+                            function: AggregateFunction::Max,
+                            property: ObjectProperty::ManaValue,
+                            filter: TargetFilter::Typed(population),
+                        },
+                },
+        } = &candidate.properties[0]
+        else {
+            panic!(
+                "expected exact mana-value membership in the artifact maximum, got {:?}",
+                candidate.properties
+            );
+        };
+        assert_eq!(population.type_filters, vec![TypeFilter::Artifact]);
+        assert!(
+            population.controller.is_none(),
+            "implicit ranked population must be table-wide"
+        );
+    }
+
+    /// The Min mirror uses the same exact-membership building block: an
+    /// artifact qualifies iff its mana value equals the least artifact mana
+    /// value, including ties.
+    #[test]
+    fn parse_inner_condition_you_control_artifact_with_least_mana_value() {
+        let (rest, condition) = parse_inner_condition(
+            "you control an artifact with the least mana value or tied for the least mana value.",
+        )
+        .unwrap();
+        assert!(rest.is_empty(), "must fully consume, leftover: {rest:?}");
+
+        let StaticCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty:
+                        QuantityRef::ObjectCount {
+                            filter: TargetFilter::Typed(candidate),
+                        },
+                },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 1 },
+        } = condition
+        else {
+            panic!("expected controlled artifact ObjectCount gate, got {condition:?}");
+        };
+        let Some(FilterProp::Cmc {
+            comparator: Comparator::EQ,
+            value:
+                QuantityExpr::Ref {
+                    qty:
+                        QuantityRef::Aggregate {
+                            function: AggregateFunction::Min,
+                            property: ObjectProperty::ManaValue,
+                            filter: TargetFilter::Typed(population),
+                        },
+                },
+        }) = candidate.properties.first()
+        else {
+            panic!("expected exact membership in the artifact minimum, got {candidate:?}");
+        };
+        assert_eq!(candidate.controller, Some(ControllerRef::You));
+        assert_eq!(candidate.type_filters, vec![TypeFilter::Artifact]);
+        assert_eq!(population.type_filters, vec![TypeFilter::Artifact]);
+        assert!(population.controller.is_none());
+    }
+
+    /// CR 109.2 + CR 109.4: controlled-permanent superlatives must reject a
+    /// terminal off-battlefield/stack noun and any genuine type-phrase tail.
+    #[test]
+    fn parse_inner_condition_you_control_superlative_rejects_nonpermanent_nouns_and_leftovers() {
+        assert!(
+            parse_inner_condition("you control an artifact card with the greatest mana value.")
+                .is_err(),
+            "terminal `card` must not be accepted in a `you control` permanent predicate"
+        );
+        assert!(
+            parse_inner_condition("you control an artifact relic with the greatest mana value.")
+                .is_err(),
+            "an unparsed candidate-noun tail must fail closed"
+        );
+    }
+
     /// CR 608.2c: Abzan Beastmaster's resolve-time gate is an existential
     /// controlled-creature check against the table-wide greatest toughness.
     #[test]
@@ -20123,7 +20237,7 @@ mod tests {
                     let FilterProp::PtComparison {
                         stat: PtStat::Toughness,
                         scope: PtValueScope::Current,
-                        comparator: Comparator::GE,
+                        comparator: Comparator::EQ,
                         value:
                             QuantityExpr::Ref {
                                 qty: QuantityRef::PropertyAggregate(aggregate),
@@ -20185,7 +20299,7 @@ mod tests {
                     let FilterProp::PtComparison {
                         stat: PtStat::Power,
                         scope: PtValueScope::Current,
-                        comparator: Comparator::GE,
+                        comparator: Comparator::EQ,
                         value:
                             QuantityExpr::Ref {
                                 qty: QuantityRef::PropertyAggregate(aggregate),

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -30,8 +30,8 @@ use crate::types::ability::{
     AbilityCondition, AggregateFunction, CardTypeSetSource, CastManaObjectScope,
     CastManaSpentMetric, CommanderOwnership, Comparator, ControllerRef, CountScope, DamageChannel,
     DamageGroupKey, DamageKindFilter, FilterProp, ObjectProperty, ObjectScope, PlayerFilter,
-    PlayerRelation, PlayerScope, PropertyAggregate, PtStat, PtValueScope, QuantityExpr,
-    QuantityRef, SharedQuality, StaticCondition, TargetFilter, TypeFilter, TypedFilter, ZoneRef,
+    PlayerRelation, PlayerScope, PropertyAggregate, QuantityExpr, QuantityRef, SharedQuality,
+    StaticCondition, TargetFilter, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::events::PlayerActionKind;
@@ -20138,12 +20138,7 @@ mod tests {
             comparator: Comparator::EQ,
             value:
                 QuantityExpr::Ref {
-                    qty:
-                        QuantityRef::Aggregate {
-                            function: AggregateFunction::Max,
-                            property: ObjectProperty::ManaValue,
-                            filter: TargetFilter::Typed(population),
-                        },
+                    qty: QuantityRef::PropertyAggregate(aggregate),
                 },
         }) = candidate
             .properties
@@ -20154,6 +20149,14 @@ mod tests {
                 "expected exact mana-value membership in the artifact maximum, got {:?}",
                 candidate.properties
             );
+        };
+        assert_eq!(aggregate.function(), AggregateFunction::Max);
+        assert_eq!(aggregate.property(), ObjectProperty::ManaValue);
+        let CardTypeSetSource::Objects {
+            filter: TargetFilter::Typed(population),
+        } = aggregate.source()
+        else {
+            panic!("expected an artifact object population, got {aggregate:?}");
         };
         assert_eq!(population.type_filters, vec![TypeFilter::Artifact]);
         assert!(
@@ -20183,12 +20186,7 @@ mod tests {
             comparator: Comparator::EQ,
             value:
                 QuantityExpr::Ref {
-                    qty:
-                        QuantityRef::Aggregate {
-                            function: AggregateFunction::Min,
-                            property: ObjectProperty::ManaValue,
-                            filter: TargetFilter::Typed(population),
-                        },
+                    qty: QuantityRef::PropertyAggregate(aggregate),
                 },
         }) = candidate
             .properties
@@ -20196,6 +20194,14 @@ mod tests {
             .find(|property| matches!(property, FilterProp::Cmc { .. }))
         else {
             panic!("expected exact membership in the artifact minimum, got {candidate:?}");
+        };
+        assert_eq!(aggregate.function(), AggregateFunction::Min);
+        assert_eq!(aggregate.property(), ObjectProperty::ManaValue);
+        let CardTypeSetSource::Objects {
+            filter: TargetFilter::Typed(population),
+        } = aggregate.source()
+        else {
+            panic!("expected an artifact object population, got {aggregate:?}");
         };
         assert_eq!(candidate.controller, Some(ControllerRef::You));
         assert_eq!(candidate.type_filters, vec![TypeFilter::Artifact]);

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -177,7 +177,7 @@ fn parse_state_presence_conditions(input: &str) -> OracleResult<'_, StaticCondit
         // wins over the fixed-N "its power is N or greater" combinator inside
         // that group (which only matches numeric thresholds).
         parse_subject_property_superlative_comparison,
-        // CR 608.2c: Effect-resolution gates like Abzan Beastmaster's "if you
+        // CR 603.4 + CR 608.2a: Intervening-if gates like Abzan Beastmaster's "if you
         // control the creature with the greatest toughness or tied for the
         // greatest toughness" are player-control predicates over an implicit
         // creature aggregate population.
@@ -3089,7 +3089,7 @@ fn parse_optional_tied_for_tail(
     Ok((rest, relaxed))
 }
 
-/// CR 109.2 + CR 109.4 + CR 608.2c: Parse a player-control superlative gate such as
+/// CR 109.2 + CR 109.4 + CR 603.4 + CR 608.2a: Parse a player-control superlative gate such as
 /// "you control the creature with the greatest toughness or tied for the
 /// greatest toughness" or "you control an artifact with the greatest mana
 /// value". An unqualified type noun denotes a battlefield permanent, and the
@@ -20313,7 +20313,7 @@ mod tests {
         )));
     }
 
-    /// CR 608.2c: Abzan Beastmaster's resolve-time gate is an existential
+    /// CR 603.4 + CR 608.2a: Abzan Beastmaster's resolve-time gate is an existential
     /// controlled-creature check against the table-wide greatest toughness.
     #[test]
     fn parse_inner_condition_you_control_creature_tied_for_greatest_toughness() {

--- a/crates/engine/src/parser/oracle_target.rs
+++ b/crates/engine/src/parser/oracle_target.rs
@@ -5885,7 +5885,10 @@ fn parse_power_suffix(text: &str, ctx: &mut ParseContext) -> Option<(FilterProp,
     Some((prop, text.len() - rest.len()))
 }
 
-fn superlative_property_filter_prop(
+/// Canonical object-membership predicate for a superlative aggregate. Shared
+/// by target noun phrases and condition candidate filters so both use exact
+/// equality, including ties.
+pub(crate) fn superlative_property_filter_prop(
     function: AggregateFunction,
     property: ObjectProperty,
     filter: TargetFilter,

--- a/crates/engine/src/parser/oracle_tests.rs
+++ b/crates/engine/src/parser/oracle_tests.rs
@@ -20086,7 +20086,7 @@ fn assert_abzan_greatest_toughness_gate(condition: &AbilityCondition) {
         let FilterProp::PtComparison {
             stat: PtStat::Toughness,
             scope: PtValueScope::Current,
-            comparator: Comparator::GE,
+            comparator: Comparator::EQ,
             value:
                 QuantityExpr::Ref {
                     qty: QuantityRef::PropertyAggregate(aggregate),
@@ -20644,15 +20644,8 @@ fn assert_controlled_creature_greatest_power_ability_gate(condition: &AbilityCon
 }
 
 fn assert_controlled_creature_greatest_power_trigger_gate(condition: &TriggerCondition) {
-    let TriggerCondition::QuantityComparison {
-        lhs: QuantityExpr::Ref {
-            qty: QuantityRef::ObjectCount { filter },
-        },
-        comparator: Comparator::GE,
-        rhs: QuantityExpr::Fixed { value: 1 },
-    } = condition
-    else {
-        panic!("expected ObjectCount >= 1 trigger condition, got {condition:?}");
+    let TriggerCondition::ControlsType { filter } = condition else {
+        panic!("expected controlled-type trigger condition, got {condition:?}");
     };
     assert_controlled_creature_greatest_power_filter(filter);
 }
@@ -20663,11 +20656,22 @@ fn assert_controlled_creature_greatest_power_filter(filter: &TargetFilter) {
     };
     assert_eq!(controlled.controller, Some(ControllerRef::You));
     assert_eq!(controlled.type_filters, vec![TypeFilter::Creature]);
+    assert_eq!(
+        controlled.properties.len(),
+        2,
+        "expected exactly battlefield scope plus aggregate membership: {controlled:?}"
+    );
+    assert!(controlled.properties.iter().any(|property| matches!(
+        property,
+        FilterProp::InZone {
+            zone: Zone::Battlefield
+        }
+    )));
     let has_battlefield_power_max = controlled.properties.iter().any(|prop| {
         let FilterProp::PtComparison {
             stat: PtStat::Power,
             scope: PtValueScope::Current,
-            comparator: Comparator::GE,
+            comparator: Comparator::EQ,
             value:
                 QuantityExpr::Ref {
                     qty: QuantityRef::PropertyAggregate(aggregate),

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -945,6 +945,7 @@ mod orzhov_advokist;
 mod overload_no_legal_target;
 mod oversimplify_per_player_fractal;
 mod ozolith_leaves_battlefield_counters;
+mod padeem_consul_of_innovation;
 mod pain_magnification_single_source_damage;
 mod painters_servant_multi_zone_additive_color;
 mod palace_jailer;

--- a/crates/engine/tests/integration/padeem_consul_of_innovation.rs
+++ b/crates/engine/tests/integration/padeem_consul_of_innovation.rs
@@ -14,6 +14,7 @@ use engine::types::mana::ManaCost;
 use engine::types::phase::Phase;
 use engine::types::statics::StaticMode;
 use engine::types::triggers::TriggerMode;
+use engine::types::zones::Zone;
 
 const PADEEM_ORACLE: &str = "Artifacts you control have hexproof.\nAt the beginning of your upkeep, if you control the artifact with the greatest mana value or tied for the greatest mana value, draw a card.";
 
@@ -50,6 +51,31 @@ fn assert_padeem_condition(condition: &TriggerCondition) {
         Some(engine::types::ControllerRef::You)
     );
     assert_eq!(candidate.type_filters, vec![TypeFilter::Artifact]);
+    assert_eq!(
+        candidate.properties.len(),
+        2,
+        "expected exactly the battlefield and mana-value membership properties: {candidate:?}"
+    );
+    let battlefield_count = candidate
+        .properties
+        .iter()
+        .filter(|property| {
+            matches!(
+                property,
+                FilterProp::InZone {
+                    zone: Zone::Battlefield
+                }
+            )
+        })
+        .count();
+    assert_eq!(
+        battlefield_count, 1,
+        "expected exactly one battlefield property: {candidate:?}"
+    );
+    let mut cmc_properties = candidate
+        .properties
+        .iter()
+        .filter(|property| matches!(property, FilterProp::Cmc { .. }));
     let Some(FilterProp::Cmc {
         comparator: Comparator::EQ,
         value:
@@ -61,11 +87,14 @@ fn assert_padeem_condition(condition: &TriggerCondition) {
                         filter: TargetFilter::Typed(population),
                     },
             },
-    }) = candidate.properties.first()
+    }) = cmc_properties.next()
     else {
         panic!("expected exact membership in the artifact mana-value maximum: {candidate:?}");
     };
-    assert_eq!(candidate.properties.len(), 1);
+    assert!(
+        cmc_properties.next().is_none(),
+        "expected exactly one mana-value membership property: {candidate:?}"
+    );
     assert_eq!(population.type_filters, vec![TypeFilter::Artifact]);
     assert!(
         population.controller.is_none(),

--- a/crates/engine/tests/integration/padeem_consul_of_innovation.rs
+++ b/crates/engine/tests/integration/padeem_consul_of_innovation.rs
@@ -1,0 +1,310 @@
+//! Padeem, Consul of Innovation: the upkeep trigger keeps its intervening-if
+//! and compares controlled artifacts against the table-wide greatest artifact
+//! mana value.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityDefinition, AggregateFunction, Comparator, ContinuousModification, Effect, FilterProp,
+    ObjectProperty, QuantityExpr, QuantityRef, TargetFilter, TriggerCondition, TypeFilter,
+};
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::mana::ManaCost;
+use engine::types::phase::Phase;
+use engine::types::statics::StaticMode;
+use engine::types::triggers::TriggerMode;
+
+const PADEEM_ORACLE: &str = "Artifacts you control have hexproof.\nAt the beginning of your upkeep, if you control the artifact with the greatest mana value or tied for the greatest mana value, draw a card.";
+
+fn contains_unimplemented(definition: &AbilityDefinition) -> bool {
+    matches!(definition.effect.as_ref(), Effect::Unimplemented { .. })
+        || definition
+            .sub_ability
+            .as_deref()
+            .is_some_and(contains_unimplemented)
+        || definition
+            .else_ability
+            .as_deref()
+            .is_some_and(contains_unimplemented)
+}
+
+fn assert_padeem_condition(condition: &TriggerCondition) {
+    let TriggerCondition::QuantityComparison {
+        lhs:
+            QuantityExpr::Ref {
+                qty:
+                    QuantityRef::ObjectCount {
+                        filter: TargetFilter::Typed(candidate),
+                    },
+            },
+        comparator: Comparator::GE,
+        rhs: QuantityExpr::Fixed { value: 1 },
+    } = condition
+    else {
+        panic!("expected controlled-artifact ObjectCount >= 1, got {condition:?}");
+    };
+
+    assert_eq!(
+        candidate.controller,
+        Some(engine::types::ControllerRef::You)
+    );
+    assert_eq!(candidate.type_filters, vec![TypeFilter::Artifact]);
+    let Some(FilterProp::Cmc {
+        comparator: Comparator::EQ,
+        value:
+            QuantityExpr::Ref {
+                qty:
+                    QuantityRef::Aggregate {
+                        function: AggregateFunction::Max,
+                        property: ObjectProperty::ManaValue,
+                        filter: TargetFilter::Typed(population),
+                    },
+            },
+    }) = candidate.properties.first()
+    else {
+        panic!("expected exact membership in the artifact mana-value maximum: {candidate:?}");
+    };
+    assert_eq!(candidate.properties.len(), 1);
+    assert_eq!(population.type_filters, vec![TypeFilter::Artifact]);
+    assert!(
+        population.controller.is_none(),
+        "the ranked artifact population must include every controller"
+    );
+}
+
+fn parsed_padeem() -> engine::parser::oracle::ParsedAbilities {
+    parse_oracle_text(
+        PADEEM_ORACLE,
+        "Padeem, Consul of Innovation",
+        &[],
+        &["Creature".to_string()],
+        &["Vedalken".to_string(), "Artificer".to_string()],
+    )
+}
+
+struct Board {
+    runner: GameRunner,
+    padeem: ObjectId,
+    p0_artifact: ObjectId,
+    p1_artifact: ObjectId,
+}
+
+fn board(p0_artifact_mv: u32, p1_artifact_mv: u32, p1_nonartifact_mv: Option<u32>) -> Board {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::Untap);
+    let padeem = scenario
+        .add_creature(P0, "Padeem, Consul of Innovation", 1, 4)
+        .from_oracle_text(PADEEM_ORACLE)
+        .with_mana_cost(ManaCost::generic(4))
+        .id();
+    let p0_artifact = scenario
+        .add_creature(P0, "P0 Artifact", 2, 2)
+        .as_artifact()
+        .with_mana_cost(ManaCost::generic(p0_artifact_mv))
+        .id();
+    let p1_artifact = scenario
+        .add_creature(P1, "P1 Artifact", 2, 2)
+        .as_artifact()
+        .with_mana_cost(ManaCost::generic(p1_artifact_mv))
+        .id();
+    if let Some(mana_value) = p1_nonartifact_mv {
+        scenario
+            .add_creature(P1, "P1 Nonartifact", 9, 9)
+            .with_mana_cost(ManaCost::generic(mana_value));
+    }
+    scenario.add_card_to_library_top(P0, "P0 Draw Card");
+    scenario.add_card_to_library_top(P1, "P1 Draw Card");
+    Board {
+        runner: scenario.build(),
+        padeem,
+        p0_artifact,
+        p1_artifact,
+    }
+}
+
+fn padeem_stack_entries(runner: &GameRunner, padeem: ObjectId) -> Vec<&engine::types::StackEntry> {
+    runner
+        .state()
+        .stack
+        .iter()
+        .filter(|entry| entry.source_id == padeem)
+        .collect()
+}
+
+/// Positive parser reach: both printed abilities parse, the static grant and
+/// upkeep draw are typed, and no unimplemented/warning residue hides a dropped
+/// clause.
+#[test]
+fn padeem_full_oracle_parses_hexproof_and_typed_upkeep_condition() {
+    let parsed = parsed_padeem();
+    assert_eq!(
+        parsed.abilities.len()
+            + parsed.triggers.len()
+            + parsed.statics.len()
+            + parsed.replacements.len(),
+        2,
+        "Padeem has exactly two printed abilities"
+    );
+    assert!(parsed.abilities.is_empty());
+    assert_eq!(parsed.statics.len(), 1);
+    assert_eq!(parsed.triggers.len(), 1);
+    assert!(parsed.replacements.is_empty());
+    assert!(
+        parsed.parse_warnings.is_empty(),
+        "Padeem must have no warning or unconsumed fragment: {:?}",
+        parsed.parse_warnings
+    );
+
+    let static_definition = &parsed.statics[0];
+    assert_eq!(static_definition.mode, StaticMode::Continuous);
+    let Some(TargetFilter::Typed(affected)) = static_definition.affected.as_ref() else {
+        panic!("artifact hexproof static must have a typed affected filter");
+    };
+    assert_eq!(affected.type_filters, vec![TypeFilter::Artifact]);
+    assert_eq!(affected.controller, Some(engine::types::ControllerRef::You));
+    assert_eq!(
+        static_definition.modifications,
+        vec![ContinuousModification::AddKeyword {
+            keyword: Keyword::Hexproof,
+        }]
+    );
+
+    let trigger = &parsed.triggers[0];
+    assert_eq!(trigger.mode, TriggerMode::Phase);
+    assert_eq!(trigger.phase, Some(Phase::Upkeep));
+    assert_padeem_condition(
+        trigger
+            .condition
+            .as_ref()
+            .expect("Padeem's upkeep trigger must retain its intervening-if"),
+    );
+    let execute = trigger
+        .execute
+        .as_deref()
+        .expect("Padeem's upkeep trigger must draw");
+    assert_eq!(
+        execute.effect.as_ref(),
+        &Effect::Draw {
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::Controller,
+        }
+    );
+    assert!(!contains_unimplemented(execute));
+}
+
+/// CR 202.3 + CR 603.4: a strictly larger opponent artifact makes the
+/// intervening-if false at trigger time, so no Padeem ability reaches the stack
+/// and no card is drawn.
+#[test]
+fn padeem_does_not_trigger_when_opponent_artifact_has_greater_mana_value() {
+    let Board {
+        mut runner, padeem, ..
+    } = board(3, 5, None);
+    let parsed = parsed_padeem();
+    assert_padeem_condition(parsed.triggers[0].condition.as_ref().unwrap());
+    assert_eq!(runner.object(padeem).name, "Padeem, Consul of Innovation");
+    assert_padeem_condition(
+        runner.object(padeem).trigger_definitions[0]
+            .definition
+            .condition
+            .as_ref()
+            .expect("the battlefield Padeem source must carry the typed condition"),
+    );
+
+    let hand_before = runner.hand_count(P0);
+    runner.advance_to_upkeep();
+    assert!(
+        padeem_stack_entries(&runner, padeem).is_empty(),
+        "the false intervening-if must keep Padeem off the stack"
+    );
+    assert_eq!(runner.hand_count(P0), hand_before);
+}
+
+/// CR 202.3 + CR 603.4: equal greatest artifact mana values satisfy the exact
+/// aggregate-membership predicate. A larger nonartifact does not participate
+/// in the ranked population.
+#[test]
+fn padeem_triggers_on_tied_greatest_artifact_ignoring_larger_nonartifact() {
+    let Board {
+        mut runner, padeem, ..
+    } = board(5, 5, Some(9));
+    let hand_before = runner.hand_count(P0);
+
+    runner.advance_to_upkeep();
+    assert_eq!(
+        padeem_stack_entries(&runner, padeem).len(),
+        1,
+        "exactly one Padeem upkeep trigger must be on the stack"
+    );
+    runner.advance_until_stack_empty();
+    assert_eq!(runner.hand_count(P0), hand_before + 1);
+}
+
+/// CR 202.3 + CR 603.4: the condition is checked again on resolution. Raising
+/// the opponent's existing artifact above P0's maximum after the trigger is on
+/// the stack removes the ability without a draw.
+#[test]
+fn padeem_rechecks_greatest_artifact_at_resolution() {
+    let Board {
+        mut runner,
+        padeem,
+        p1_artifact,
+    } = board(5, 3, None);
+    let hand_before = runner.hand_count(P0);
+
+    runner.advance_to_upkeep();
+    assert_eq!(padeem_stack_entries(&runner, padeem).len(), 1);
+    let artifact = runner
+        .state_mut()
+        .objects
+        .get_mut(&p1_artifact)
+        .expect("fixture artifact exists");
+    artifact.mana_cost = ManaCost::generic(9);
+    artifact.base_mana_cost = artifact.mana_cost.clone();
+
+    runner.advance_until_stack_empty();
+    assert_eq!(
+        runner.hand_count(P0),
+        hand_before,
+        "the false resolution-time recheck must prevent the draw"
+    );
+}
+
+/// CR 109.4b + CR 109.5 + CR 603.4: the trigger and its word "you" keep P0 as
+/// controller after triggering even if the live Padeem permanent changes
+/// controller before resolution.
+#[test]
+fn padeem_trigger_keeps_captured_controller_after_source_control_changes() {
+    let Board {
+        mut runner,
+        padeem,
+        p0_artifact,
+        p1_artifact,
+    } = board(5, 3, None);
+    let p0_hand_before = runner.hand_count(P0);
+    let p1_hand_before = runner.hand_count(P1);
+
+    runner.advance_to_upkeep();
+    let entries = padeem_stack_entries(&runner, padeem);
+    assert_eq!(entries.len(), 1);
+    assert_eq!(entries[0].controller, P0, "the stack entry captures P0");
+
+    let live_padeem = runner
+        .state_mut()
+        .objects
+        .get_mut(&padeem)
+        .expect("Padeem remains on the battlefield");
+    live_padeem.base_controller = Some(P1);
+    live_padeem.controller = P1;
+    assert_eq!(runner.object(padeem).controller, P1);
+    assert_eq!(runner.object(p0_artifact).controller, P0);
+    assert_eq!(runner.object(p0_artifact).effective_mana_value(), 5);
+    assert_eq!(runner.object(p1_artifact).controller, P1);
+    assert_eq!(runner.object(p1_artifact).effective_mana_value(), 3);
+
+    runner.advance_until_stack_empty();
+    assert_eq!(runner.object(padeem).controller, P1);
+    assert_eq!(runner.hand_count(P0), p0_hand_before + 1);
+    assert_eq!(runner.hand_count(P1), p1_hand_before);
+}

--- a/crates/engine/tests/integration/padeem_consul_of_innovation.rs
+++ b/crates/engine/tests/integration/padeem_consul_of_innovation.rs
@@ -17,7 +17,7 @@ use engine::types::statics::StaticMode;
 use engine::types::triggers::TriggerMode;
 use engine::types::zones::Zone;
 
-const PADEEM_ORACLE: &str = "Artifacts you control have hexproof.\nAt the beginning of your upkeep, if you control the artifact with the greatest mana value or tied for the greatest mana value, draw a card.";
+const PADEEM_ORACLE: &str = "Artifacts you control have hexproof. (They can't be the targets of spells or abilities your opponents control.)\nAt the beginning of your upkeep, if you control the artifact with the greatest mana value or tied for the greatest mana value, draw a card.";
 
 fn contains_unimplemented(definition: &AbilityDefinition) -> bool {
     matches!(definition.effect.as_ref(), Effect::Unimplemented { .. })

--- a/crates/engine/tests/integration/padeem_consul_of_innovation.rs
+++ b/crates/engine/tests/integration/padeem_consul_of_innovation.rs
@@ -5,8 +5,9 @@
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::parser::oracle::parse_oracle_text;
 use engine::types::ability::{
-    AbilityDefinition, AggregateFunction, Comparator, ContinuousModification, Effect, FilterProp,
-    ObjectProperty, QuantityExpr, QuantityRef, TargetFilter, TriggerCondition, TypeFilter,
+    AbilityDefinition, AggregateFunction, CardTypeSetSource, Comparator, ContinuousModification,
+    Effect, FilterProp, ObjectProperty, QuantityExpr, QuantityRef, TargetFilter, TriggerCondition,
+    TypeFilter,
 };
 use engine::types::identifiers::ObjectId;
 use engine::types::keywords::Keyword;
@@ -72,12 +73,7 @@ fn assert_padeem_condition(condition: &TriggerCondition) {
         comparator: Comparator::EQ,
         value:
             QuantityExpr::Ref {
-                qty:
-                    QuantityRef::Aggregate {
-                        function: AggregateFunction::Max,
-                        property: ObjectProperty::ManaValue,
-                        filter: TargetFilter::Typed(population),
-                    },
+                qty: QuantityRef::PropertyAggregate(aggregate),
             },
     }) = cmc_properties.next()
     else {
@@ -87,6 +83,14 @@ fn assert_padeem_condition(condition: &TriggerCondition) {
         cmc_properties.next().is_none(),
         "expected exactly one mana-value membership property: {candidate:?}"
     );
+    assert_eq!(aggregate.function(), AggregateFunction::Max);
+    assert_eq!(aggregate.property(), ObjectProperty::ManaValue);
+    let CardTypeSetSource::Objects {
+        filter: TargetFilter::Typed(population),
+    } = aggregate.source()
+    else {
+        panic!("expected an artifact object population, got {aggregate:?}");
+    };
     assert_eq!(population.type_filters, vec![TypeFilter::Artifact]);
     assert!(
         population.controller.is_none(),

--- a/crates/engine/tests/integration/padeem_consul_of_innovation.rs
+++ b/crates/engine/tests/integration/padeem_consul_of_innovation.rs
@@ -31,19 +31,11 @@ fn contains_unimplemented(definition: &AbilityDefinition) -> bool {
 }
 
 fn assert_padeem_condition(condition: &TriggerCondition) {
-    let TriggerCondition::QuantityComparison {
-        lhs:
-            QuantityExpr::Ref {
-                qty:
-                    QuantityRef::ObjectCount {
-                        filter: TargetFilter::Typed(candidate),
-                    },
-            },
-        comparator: Comparator::GE,
-        rhs: QuantityExpr::Fixed { value: 1 },
+    let TriggerCondition::ControlsType {
+        filter: TargetFilter::Typed(candidate),
     } = condition
     else {
-        panic!("expected controlled-artifact ObjectCount >= 1, got {condition:?}");
+        panic!("expected controlled-artifact type condition, got {condition:?}");
     };
 
     assert_eq!(

--- a/crates/engine/tests/integration/padeem_consul_of_innovation.rs
+++ b/crates/engine/tests/integration/padeem_consul_of_innovation.rs
@@ -203,22 +203,33 @@ fn padeem_does_not_trigger_when_opponent_artifact_has_greater_mana_value() {
     } = board(3, 5, None);
     let parsed = parsed_padeem();
     assert_padeem_condition(parsed.triggers[0].condition.as_ref().unwrap());
-    assert_eq!(runner.object(padeem).name, "Padeem, Consul of Innovation");
+    let battlefield_padeem = runner
+        .state()
+        .objects
+        .get(&padeem)
+        .expect("Padeem remains on the battlefield");
+    assert_eq!(
+        battlefield_padeem.name.as_str(),
+        "Padeem, Consul of Innovation"
+    );
     assert_padeem_condition(
-        runner.object(padeem).trigger_definitions[0]
+        battlefield_padeem.trigger_definitions[0]
             .definition
             .condition
             .as_ref()
             .expect("the battlefield Padeem source must carry the typed condition"),
     );
 
-    let hand_before = runner.hand_count(P0);
+    let hand_before = runner.state().players[P0.0 as usize].hand.len();
     runner.advance_to_upkeep();
     assert!(
         padeem_stack_entries(&runner, padeem).is_empty(),
         "the false intervening-if must keep Padeem off the stack"
     );
-    assert_eq!(runner.hand_count(P0), hand_before);
+    assert_eq!(
+        runner.state().players[P0.0 as usize].hand.len(),
+        hand_before
+    );
 }
 
 /// CR 202.3 + CR 603.4: equal greatest artifact mana values satisfy the exact
@@ -229,7 +240,7 @@ fn padeem_triggers_on_tied_greatest_artifact_ignoring_larger_nonartifact() {
     let Board {
         mut runner, padeem, ..
     } = board(5, 5, Some(9));
-    let hand_before = runner.hand_count(P0);
+    let hand_before = runner.state().players[P0.0 as usize].hand.len();
 
     runner.advance_to_upkeep();
     assert_eq!(
@@ -238,7 +249,10 @@ fn padeem_triggers_on_tied_greatest_artifact_ignoring_larger_nonartifact() {
         "exactly one Padeem upkeep trigger must be on the stack"
     );
     runner.advance_until_stack_empty();
-    assert_eq!(runner.hand_count(P0), hand_before + 1);
+    assert_eq!(
+        runner.state().players[P0.0 as usize].hand.len(),
+        hand_before + 1
+    );
 }
 
 /// CR 202.3 + CR 603.4: the condition is checked again on resolution. Raising
@@ -250,8 +264,9 @@ fn padeem_rechecks_greatest_artifact_at_resolution() {
         mut runner,
         padeem,
         p1_artifact,
+        ..
     } = board(5, 3, None);
-    let hand_before = runner.hand_count(P0);
+    let hand_before = runner.state().players[P0.0 as usize].hand.len();
 
     runner.advance_to_upkeep();
     assert_eq!(padeem_stack_entries(&runner, padeem).len(), 1);
@@ -265,7 +280,7 @@ fn padeem_rechecks_greatest_artifact_at_resolution() {
 
     runner.advance_until_stack_empty();
     assert_eq!(
-        runner.hand_count(P0),
+        runner.state().players[P0.0 as usize].hand.len(),
         hand_before,
         "the false resolution-time recheck must prevent the draw"
     );
@@ -282,8 +297,8 @@ fn padeem_trigger_keeps_captured_controller_after_source_control_changes() {
         p0_artifact,
         p1_artifact,
     } = board(5, 3, None);
-    let p0_hand_before = runner.hand_count(P0);
-    let p1_hand_before = runner.hand_count(P1);
+    let p0_hand_before = runner.state().players[P0.0 as usize].hand.len();
+    let p1_hand_before = runner.state().players[P1.0 as usize].hand.len();
 
     runner.advance_to_upkeep();
     let entries = padeem_stack_entries(&runner, padeem);
@@ -297,14 +312,43 @@ fn padeem_trigger_keeps_captured_controller_after_source_control_changes() {
         .expect("Padeem remains on the battlefield");
     live_padeem.base_controller = Some(P1);
     live_padeem.controller = P1;
-    assert_eq!(runner.object(padeem).controller, P1);
-    assert_eq!(runner.object(p0_artifact).controller, P0);
-    assert_eq!(runner.object(p0_artifact).effective_mana_value(), 5);
-    assert_eq!(runner.object(p1_artifact).controller, P1);
-    assert_eq!(runner.object(p1_artifact).effective_mana_value(), 3);
+    let battlefield_padeem = runner
+        .state()
+        .objects
+        .get(&padeem)
+        .expect("Padeem remains on the battlefield");
+    let p0_artifact = runner
+        .state()
+        .objects
+        .get(&p0_artifact)
+        .expect("P0's artifact remains on the battlefield");
+    let p1_artifact = runner
+        .state()
+        .objects
+        .get(&p1_artifact)
+        .expect("P1's artifact remains on the battlefield");
+    assert_eq!(battlefield_padeem.controller, P1);
+    assert_eq!(p0_artifact.controller, P0);
+    assert_eq!(p0_artifact.effective_mana_value(), 5);
+    assert_eq!(p1_artifact.controller, P1);
+    assert_eq!(p1_artifact.effective_mana_value(), 3);
 
     runner.advance_until_stack_empty();
-    assert_eq!(runner.object(padeem).controller, P1);
-    assert_eq!(runner.hand_count(P0), p0_hand_before + 1);
-    assert_eq!(runner.hand_count(P1), p1_hand_before);
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .get(&padeem)
+            .expect("Padeem remains on the battlefield")
+            .controller,
+        P1
+    );
+    assert_eq!(
+        runner.state().players[P0.0 as usize].hand.len(),
+        p0_hand_before + 1
+    );
+    assert_eq!(
+        runner.state().players[P1.0 as usize].hand.len(),
+        p1_hand_before
+    );
 }

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -3,8 +3,8 @@
 Consolidated from 50 per-batch clustering passes over the whole card database. Synonymous per-batch clusters were merged into canonical root causes, their card lists unioned and deduped, and ranked by total card appearances (largest first).
 
 - **Canonical root causes:** 30
-- **Distinct cards implicated:** 4711
-- **Total card appearances across root causes:** 4744 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
+- **Distinct cards implicated:** 4710
+- **Total card appearances across root causes:** 4743 (a card may appear under more than one root cause when it exhibits multiple distinct misparses)
 
 This is the prioritized "fix N root causes → unlock M cards" backlog: the top handful of root causes account for the majority of broken cards.
 
@@ -13,7 +13,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | # | Root cause | # cards | Fix hint (where it likely lives) |
 |---|------------|--------:|----------------------------------|
 | 1 | Relative-clause / filter restriction on target dropped | 746 | oracle_target.rs / game/filter.rs — extend TargetFilter property extraction for trailing relative clauses |
-| 2 | Dropped intervening-if / gating condition (condition: null) | 585 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
+| 2 | Dropped intervening-if / gating condition (condition: null) | 584 | oracle_nom/condition.rs parse_inner_condition — trigger/static parsers must delegate condition extraction here |
 | 3 | Anaphor bound to wrong referent | 404 | oracle_quantity.rs context-ref resolution + game/ability_utils.rs forward_result wiring |
 | 4 | Conjoined / chained second effect clause dropped | 387 | oracle.rs effect-chain composition — split on 'and'/'then'/sentence boundaries and build sub_ability chain |
 | 5 | Dropped 'for each' / dynamic count collapsed to Fixed | 329 | oracle_quantity.rs parse_for_each_clause / parse_quantity_ref — thread ForEach/ObjectCount into the effect count field |
@@ -802,7 +802,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 2. Dropped intervening-if / gating condition (condition: null)  (585 cards)
+### 2. Dropped intervening-if / gating condition (condition: null)  (584 cards)
 
 **Signature.** Trigger/static/replacement/spell condition left null though Oracle has an 'if/while/as long as/unless' game-state gate; the effect resolves unconditionally (CR 603.4 / 608.2c).
 
@@ -1177,7 +1177,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Otterball Antics
 - Overgrowth Elemental
 - Overpowering Attack
-- Padeem, Consul of Innovation
 - Paladin of Atonement
 - Paliano Vanguard
 - Paragon of Modernity


### PR DESCRIPTION
## Summary

Fixes Padeem, Consul of Innovation's dropped intervening-if condition by lowering controlled-object superlatives through the existing typed condition and aggregate-filter seams. The class-general fix also canonicalizes tied superlative membership as exact equality and removes Padeem from the parser misparse backlog.

## Files changed

- `crates/engine/src/parser/oracle_nom/condition.rs`
- `crates/engine/src/parser/oracle_target.rs`
- `crates/engine/src/parser/oracle_tests.rs`
- `crates/engine/tests/integration/main.rs`
- `crates/engine/tests/integration/padeem_consul_of_innovation.rs`
- `docs/parser-misparse-backlog.md`

## Track

Developer

## LLM

Model: gpt-5.6-sol
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 109.2, CR 109.4, and CR 109.4b — cards, spells, and permanents occupy distinct zones, and control applies to battlefield permanents.
- CR 109.5 — plural object wording denotes the class of qualifying objects.
- CR 202.3 — mana value is derived from mana cost.
- CR 603.4 — an intervening-if triggered ability checks its condition both when it would trigger and when it resolves.
- CR 608.2c — conditional instructions are evaluated during resolution.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — PASS on current head.
- `cargo clippy-strict` — PASS with no diagnostics after the penultimate clean rebase; the final rebase adds only upstream commits and leaves the six-file contribution diff unchanged.
- `cargo test -p phase-engine --quiet` — PASS: 20,194 + 21 + 9 + 5,744 tests passed, 0 failed; the remaining suites contained 6, 2, and 7 ignored tests. Run on the identical contribution diff before the final clean upstream-only rebases.
- `cargo test -p phase-engine padeem_ --quiet` — PASS: 5 passed, 0 failed after the penultimate clean rebase.
- `cargo test -p phase-engine parse_inner_condition_you_control_superlative_ --quiet` — PASS: 4 passed, 0 failed after the penultimate clean rebase.
- `./scripts/gen-card-data.sh` on base and candidate snapshots — PASS on both: 31,842/35,798 supported (88.9%), 947 warnings.
- `coverage-parse-diff` — PASS: 9 cards changed across 6 signatures; no rows were dropped.
- `cargo coverage` — PASS: 31,842/35,798 supported (88.9%), 947 warnings.
- `cargo semantic-audit` — PASS: 32,798 cards audited; 251 existing findings; no Padeem finding.
- `git diff --check upstream/main...HEAD` — PASS on current head.

## Gate A

Gate A PASS head=59088b045686950765867772c67c34357968d493 base=6ee81509efd1aba7b487949cd24871e0fd4f0144

## Anchored on

- `crates/engine/src/parser/oracle_nom/condition.rs:3098` — existing controlled-object superlative condition production at the canonical condition parser seam.
- `crates/engine/src/parser/oracle_target.rs:5891` — existing canonical superlative aggregate membership helper shared by target filters and condition candidates.

## Final review-impl

Final review-impl PASS head=59088b045686950765867772c67c34357968d493

## Claimed parse impact

- Abzan Beastmaster
- High Score
- Padeem, Consul of Innovation
- Primal Empathy
- Summon: Fenrir
- Thickest in the Thicket
- Triumph of Cruelty
- Triumph of Ferocity
- Éomer of the Riddermark

## Scope Expansion

The shared superlative-membership correction also changes eight existing power/toughness superlative parses from `>= max` to exact `= max`, preserving tied candidates through the same reusable building block used for Padeem.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Improved parsing of “you control” superlative conditions for battlefield permanents, including artifacts and mana values.
  - Added support for ties and explicit population qualifiers in these conditions.

- **Bug Fixes**
  - Invalid candidates, malformed continuations, and non-battlefield references are now rejected correctly.
  - Corrected condition evaluation for changing control, resolution-time checks, and non-artifact permanents.

- **Tests**
  - Added comprehensive integration coverage for Padeem, Consul of Innovation.

- **Documentation**
  - Updated the parser misparse backlog to reflect the resolved card issue.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->