### PR TITLE
fix(engine): concretize self-referential granted alternative-cost keywords

### DIFF
--- a/crates/engine/src/game/casting.rs
+++ b/crates/engine/src/game/casting.rs
@@ -2316,6 +2316,18 @@ fn granted_spell_keywords_for(
     // CR 601.2f: One-shot "the next spell …" keyword/flash grants (Insist, Quicken, Wand).
     apply_pending_next_spell_keyword_grants(state, caster, object_id, &mut keywords, false, fused);
 
+    // CR 118.9 + CR 601.2f: Concretize any self-referential (`SelfManaCost` /
+    // `SelfManaValue` / `SelfManaCostReduced`) alt-cost payload against this
+    // spell's own mana cost before it reaches affordability checks or payment
+    // (Henzie, "Toolbox" Torre's granted blitz — issue #5435). Resolving at
+    // this single exit covers all three grant sources uniformly (the
+    // `CastWithKeyword` static loop above, `transient_granted_spell_keywords_for`,
+    // and `apply_pending_next_spell_keyword_grants`) without touching any of
+    // the individual cost-extraction call sites that read this collector.
+    for keyword in &mut keywords {
+        *keyword = super::keywords::resolve_self_cost_spell_keyword(state, object_id, keyword);
+    }
+
     keywords
 }
 
@@ -2375,6 +2387,17 @@ fn granted_spell_keyword_instances_for(
         fused,
     );
     apply_pending_next_spell_keyword_grants(state, caster, object_id, &mut keywords, true, fused);
+
+    // CR 118.9 + CR 601.2f: see the matching comment in `granted_spell_keywords_for`.
+    // `object_id` here is the recipient spell itself (not the fused-half object,
+    // if any), so `SelfManaCost` correctly resolves against that spell's own
+    // mana cost — matching "The blitz cost is equal to its mana cost." A fused
+    // split spell's `SelfManaCost` reads `obj.mana_cost`, which is the front
+    // half only; no real card grants a self-referential alt cost to a split
+    // card, so that edge is documented here rather than specially handled.
+    for keyword in &mut keywords {
+        *keyword = super::keywords::resolve_self_cost_spell_keyword(state, object_id, keyword);
+    }
 
     keywords
 }

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -39284,6 +39284,174 @@ mod alt_cost_reduction_509 {
                  single Alien token"
         );
     }
+
+    /// CR 702.119a + CR 604.1 + CR 118.9: Building-block sibling of
+    /// `granted_blitz_self_mana_cost_resolves_to_spell_mana_cost` /
+    /// `granted_spectacle_self_mana_cost_resolves_to_spell_mana_cost` — pins
+    /// that `resolve_self_cost_spell_keyword` also concretizes a GRANTED
+    /// `Keyword::Emerge(EmergeCost { mana_cost: SelfManaCost, .. })`, not just
+    /// keywords whose cost is a bare `ManaCost`. Emerge's cost lives inside a
+    /// struct field (`EmergeCost.mana_cost`), which is exactly why the arm was
+    /// originally missed and fell through the mapper's `other => other.clone()`
+    /// wildcard (issue #5435 follow-up).
+    ///
+    /// This is a full `CastWithKeyword` runtime regression, not just a
+    /// choice-set shape check: it proves the caster (a) cannot emerge for
+    /// free, and (b) actually pays the concretized, sacrifice-reduced mana
+    /// cost end to end (mirrors
+    /// `emerge_only_affordable_after_sacrifice_reduction_casts_and_sacrifices_creature`
+    /// above).
+    #[test]
+    fn granted_emerge_self_mana_cost_resolves_to_spell_mana_cost_and_is_paid() {
+        // Grantor: "creatures you control have emerge. The emerge cost is
+        // equal to its mana cost." — modeled directly as the CastWithKeyword
+        // static the parser emits for such a grant (same shape as the Henzie
+        // Blitz grantor above), carrying `Emerge(EmergeCost::creature(SelfManaCost))`.
+        let mut state = setup_game_at_main_phase();
+        let grantor = create_object(
+            &mut state,
+            CardId(9200),
+            PlayerId(0),
+            "Emerge Grantor".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&grantor).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types.core_types.push(CoreType::Creature);
+            let def = StaticDefinition::new(StaticMode::CastWithKeyword {
+                keyword: Keyword::Emerge(EmergeCost::creature(ManaCost::SelfManaCost)),
+            })
+            .affected(TargetFilter::Typed(TypedFilter::new(TypeFilter::Creature)));
+            obj.static_definitions = vec![def].into();
+        }
+
+        // Recipient: a {6} creature in hand with NO printed Emerge — the
+        // option must come entirely from the grant.
+        let spell_cost = ManaCost::generic(6);
+        let spell = create_object(
+            &mut state,
+            CardId(9201),
+            PlayerId(0),
+            "Big Vanilla Creature".to_string(),
+            Zone::Hand,
+        );
+        {
+            let obj = state.objects.get_mut(&spell).unwrap();
+            obj.card_types.core_types.push(CoreType::Creature);
+            obj.base_card_types.core_types.push(CoreType::Creature);
+            obj.mana_cost = spell_cost.clone();
+            obj.base_mana_cost = spell_cost.clone();
+        }
+        assert!(
+            !state
+                .objects
+                .get(&spell)
+                .unwrap()
+                .keywords
+                .iter()
+                .any(|k| matches!(k, Keyword::Emerge(_))),
+            "recipient must have no printed Emerge — the option must come from the grant"
+        );
+
+        // A mana-value-4 creature to sacrifice: CR 702.119a reduces the {6}
+        // emerge cost by 4, to a payable-but-nonzero {2}.
+        let sacrifice =
+            create_sacrifice_creature(&mut state, PlayerId(0), 9202, ManaCost::generic(4));
+
+        // 1) Affordability: with NO mana at all, the caster must NOT be able
+        //    to emerge for free. An unresolved SelfManaCost has mana value 0
+        //    and is not flagged `is_without_paying_mana`, so it silently acts
+        //    as a real {0} alternative cost — this is exactly the issue
+        //    #5435 regression. Even after the best available sacrifice
+        //    reduction ({6} - MV4 = {2}), the cost is still nonzero, so
+        //    zero mana must remain unaffordable. This must be checked BEFORE
+        //    any mana is funded, since `can_cast_object_now` filters candidate
+        //    options by affordability — a starved probe is the only way to
+        //    observe "free" behavior distinctly from "unaffordable" behavior.
+        assert!(
+            !can_cast_object_now(&state, PlayerId(0), spell),
+            "granted Emerge must not be castable for free with zero mana available"
+        );
+
+        // 2) Fund exactly the post-reduction {2}, no more.
+        add_mana(&mut state, PlayerId(0), ManaType::Colorless, 2);
+        assert!(
+            can_cast_object_now(&state, PlayerId(0), spell),
+            "granted Emerge must become affordable once the post-reduction {{2}} is funded"
+        );
+
+        // 3) The offered Emerge option must carry the spell's own concrete
+        //    mana cost (pre-sacrifice-reduction, matching the granted-Blitz/
+        //    granted-Spectacle sibling tests' `mana_cost` shape), not the raw
+        //    SelfManaCost placeholder and not zero.
+        let choices = casting_variant_choice_set(&state, PlayerId(0), spell, None);
+        let emerge_option = choices
+            .options
+            .iter()
+            .find(|o| o.variant == CastingVariant::Emerge)
+            .expect("granted Emerge must surface the Emerge option");
+        assert_eq!(
+            emerge_option.mana_cost, spell_cost,
+            "granted Emerge must carry the concretized cost (the spell's own \
+             mana cost), not the unresolved SelfManaCost placeholder, got {:?}",
+            emerge_option.mana_cost
+        );
+        assert_ne!(
+            emerge_option.mana_cost,
+            ManaCost::zero(),
+            "the concretized Emerge cost must not silently be a free {{0}} cost"
+        );
+
+        let card_id = state.objects[&spell].card_id;
+        let mut events = Vec::new();
+        let wf = handle_cast_spell(&mut state, PlayerId(0), spell, card_id, &mut events)
+            .expect("granted-Emerge-only cast should enter sacrifice payment");
+        match &wf {
+            WaitingFor::PayCost {
+                kind: PayCostKind::Sacrifice,
+                choices,
+                resume:
+                    CostResume::SpellCost {
+                        source: SpellCostSource::Emerge,
+                        ..
+                    },
+                ..
+            } => {
+                assert!(
+                    choices.contains(&sacrifice),
+                    "granted-Emerge sacrifice prompt must include the controlled creature"
+                );
+            }
+            other => panic!("expected granted-Emerge PayCost(Sacrifice), got {other:?}"),
+        }
+
+        state.waiting_for = wf;
+        apply_as_current(
+            &mut state,
+            GameAction::SelectCards {
+                cards: vec![sacrifice],
+            },
+        )
+        .expect("sacrificing the creature should complete the granted-Emerge cast");
+
+        assert_eq!(
+            state.objects[&sacrifice].zone,
+            Zone::Graveyard,
+            "the emerge sacrifice must move the creature to the graveyard"
+        );
+        assert_eq!(
+            state.objects[&spell].zone,
+            Zone::Stack,
+            "the granted-Emerge cast spell must be on the stack"
+        );
+        assert_eq!(
+            state.players[0].mana_pool.total(),
+            0,
+            "granted Emerge must charge the concretized, reduced {{2}} cost, \
+             consuming exactly the two mana funded above"
+        );
+    }
 }
 
 /// CR 107.4 + CR 202.1 + CR 603.2 + CR 603.4 (issue #4370): Namor the

--- a/crates/engine/src/game/casting_tests.rs
+++ b/crates/engine/src/game/casting_tests.rs
@@ -16730,16 +16730,21 @@ fn granted_blitz_offers_blitz_variant() {
     );
 }
 
-/// CR 702.152a + CR 604.1 + CR 118.9: Henzie "Toolbox" Torre — "Each creature
-/// spell you cast with mana value 4 or greater has blitz. The blitz cost is
-/// equal to its mana cost." The grant carries `Blitz(ManaCost::SelfManaCost)`, so
-/// the offered Blitz option must surface the self-referential cost (resolved to
-/// the spell's own mana cost at payment time by the shared `SelfManaCost` path,
-/// the same one the granted-flashback cost uses). This pins that a granted
-/// alternative cost equal to the card's mana cost flows intact through the
-/// casting-variant choice set rather than being dropped or fixed to a constant.
+/// CR 702.152a + CR 604.1 + CR 118.9 + CR 601.2f: Henzie "Toolbox" Torre —
+/// "Each creature spell you cast with mana value 4 or greater has blitz. The
+/// blitz cost is equal to its mana cost." The grant carries
+/// `Blitz(ManaCost::SelfManaCost)`, but that placeholder must be concretized
+/// against the recipient spell's own mana cost at the grant-collector exit
+/// (`resolve_self_cost_spell_keyword`, called from `granted_spell_keywords_for`
+/// / `granted_spell_keyword_instances_for`) — BEFORE cost modifiers and
+/// affordability are evaluated — not left unresolved to be "resolved at
+/// payment time" (issue #5435: an unresolved `SelfManaCost` has mana value 0
+/// but is not "without paying mana", so it silently acted as a real {0}
+/// alternative cost, letting AI blitz-cast unaffordable creatures for free).
+/// This pins that the offered Blitz option carries the spell's concrete mana
+/// cost, not the raw placeholder.
 #[test]
-fn granted_blitz_self_mana_cost_surfaces_self_referential_cost() {
+fn granted_blitz_self_mana_cost_resolves_to_spell_mana_cost() {
     use crate::types::ability::{FilterProp, TargetFilter, TypeFilter, TypedFilter};
     use crate::types::keywords::Keyword;
     use crate::types::statics::StaticMode;
@@ -16797,14 +16802,80 @@ fn granted_blitz_self_mana_cost_surfaces_self_referential_cost() {
         .find(|o| o.variant == CastingVariant::Blitz)
         .expect("granted Blitz must surface the Blitz option");
     assert_eq!(
-        blitz.mana_cost,
-        ManaCost::SelfManaCost,
-        "granted Blitz must carry the self-referential cost (resolved to the \
-         spell's own mana cost at payment time), got {:?}",
+        blitz.mana_cost, spell_cost,
+        "granted Blitz must carry the concretized cost (the spell's own mana \
+         cost), not the unresolved SelfManaCost placeholder, got {:?}",
         blitz.mana_cost
     );
     // The recipient really is MV >= 4, so the grant's filter admits it.
     assert_eq!(state.objects.get(&spell).unwrap().mana_cost, spell_cost);
+}
+
+/// CR 702.137a + CR 604.1 + CR 118.9: Building-block sibling of the granted-Blitz
+/// test above. `resolve_self_cost_spell_keyword` is a shared mapper over the whole
+/// cast-time alternative-cost family, so pin a SECOND keyword through it —
+/// otherwise every test of that helper is Blitz-shaped and a Blitz-only special
+/// case would pass unnoticed. Spectacle is the discriminating pick: unlike Blitz
+/// it is gated on an opponent having lost life this turn (CR 702.137a), so the
+/// concretized cost has to survive a different candidate-enumeration path.
+#[test]
+fn granted_spectacle_self_mana_cost_resolves_to_spell_mana_cost() {
+    use crate::types::ability::{TargetFilter, TypeFilter, TypedFilter};
+    use crate::types::keywords::Keyword;
+    use crate::types::statics::StaticMode;
+
+    let mut state = setup_game_at_main_phase();
+    add_mana(&mut state, PlayerId(0), ManaType::Colorless, 3);
+    // CR 702.137a: Spectacle only functions while an opponent lost life this turn.
+    state.players[1].life_lost_this_turn = 2;
+
+    let grantor = create_object(
+        &mut state,
+        CardId(9120),
+        PlayerId(0),
+        "Spectacle Grantor".to_string(),
+        Zone::Battlefield,
+    );
+    {
+        let obj = state.objects.get_mut(&grantor).unwrap();
+        obj.card_types.core_types.push(CoreType::Creature);
+        obj.base_card_types.core_types.push(CoreType::Creature);
+        let def = StaticDefinition::new(StaticMode::CastWithKeyword {
+            keyword: Keyword::Spectacle(ManaCost::SelfManaCost),
+        })
+        .affected(TargetFilter::Typed(TypedFilter::new(TypeFilter::Instant)));
+        obj.static_definitions = vec![def].into();
+    }
+
+    // Recipient: a {3} instant in hand with no printed Spectacle.
+    let spell_cost = ManaCost::generic(3);
+    let spell = create_object(
+        &mut state,
+        CardId(9121),
+        PlayerId(0),
+        "Some Instant".to_string(),
+        Zone::Hand,
+    );
+    {
+        let obj = state.objects.get_mut(&spell).unwrap();
+        obj.card_types.core_types.push(CoreType::Instant);
+        obj.base_card_types.core_types.push(CoreType::Instant);
+        obj.mana_cost = spell_cost.clone();
+        obj.base_mana_cost = spell_cost.clone();
+    }
+
+    let choices = casting_variant_choice_set(&state, PlayerId(0), spell, None);
+    let spectacle = choices
+        .options
+        .iter()
+        .find(|o| o.variant == CastingVariant::Spectacle)
+        .expect("granted Spectacle must surface the Spectacle option");
+    assert_eq!(
+        spectacle.mana_cost, spell_cost,
+        "granted Spectacle must carry the concretized cost (the spell's own mana \
+         cost), not the unresolved SelfManaCost placeholder, got {:?}",
+        spectacle.mana_cost
+    );
 }
 
 /// CR 702.141a + CR 604.1 (seam 4: activated-ability-on-grant): Encore

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -12,7 +12,8 @@ use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::keywords::{
-    EmbalmCost, EternalizeCost, FlashbackCost, GiftKind, Keyword, KeywordKind, ProtectionTarget,
+    BestowCost, EmbalmCost, EternalizeCost, EvokeCost, FlashbackCost, GiftKind, Keyword,
+    KeywordKind, ProtectionTarget,
 };
 use crate::types::mana::ManaCost;
 use crate::types::phase::Phase;
@@ -470,6 +471,73 @@ pub fn resolve_self_cost_graveyard_activated_keyword(
         Keyword::Eternalize(EternalizeCost::Mana(cost)) => Keyword::Eternalize(
             EternalizeCost::Mana(resolve_keyword_mana_cost(state, object_id, cost)),
         ),
+        other => other.clone(),
+    }
+}
+
+/// CR 118.9 + CR 601.2f + CR 604.1: Resolve a `ManaCost::SelfManaCost` /
+/// `SelfManaValue` / `SelfManaCostReduced` payload carried by a *cast-time*
+/// alternative-cost keyword (CR 702.152a Blitz, CR 702.152b, CR 702.137a
+/// Spectacle, and the rest of the cast-from-hand alt-cost family) to the
+/// recipient spell's own concrete mana cost, before that keyword's cost is
+/// offered or paid. A `CastWithKeyword` static (CR 604.1) can grant one of
+/// these keywords with a bare `SelfManaCost` placeholder payload ("The blitz
+/// cost is equal to its mana cost" — Henzie, "Toolbox" Torre); left
+/// unresolved, `ManaCost::SelfManaCost` has mana value 0 but is not flagged
+/// "without paying mana", so it silently acts as a real {0} alternative cost.
+/// This mirrors [`resolve_self_cost_graveyard_activated_keyword`] but covers
+/// the disjoint keyword family whose cost is paid on the stack as a spell's
+/// total cost (CR 601.2f) rather than as an `AbilityCost::Mana` sub-cost.
+///
+/// Inclusion criterion: every keyword here is (a) a cast-time alternative or
+/// additional cost that substitutes for or accompanies a spell's mana cost,
+/// and (b) carries a bare `ManaCost` (or a `Mana(ManaCost)` variant of its
+/// cost enum) that a `CastWithKeyword` grant could plausibly bind to a
+/// self-referential placeholder. Battlefield/activated-only keywords (Equip,
+/// Fortify, Reconfigure, Outlast, Unearth, Ninjutsu, Morph/Megamorph, Kicker)
+/// are not granted through this spell-cast seam and are intentionally
+/// excluded — they resolve their own placeholders (if any) at their own
+/// activation seam. Non-self-referential keywords pass through unchanged.
+pub(crate) fn resolve_self_cost_spell_keyword(
+    state: &GameState,
+    object_id: ObjectId,
+    keyword: &Keyword,
+) -> Keyword {
+    match keyword {
+        Keyword::Blitz(cost) => Keyword::Blitz(resolve_keyword_mana_cost(state, object_id, cost)),
+        Keyword::Spectacle(cost) => {
+            Keyword::Spectacle(resolve_keyword_mana_cost(state, object_id, cost))
+        }
+        Keyword::Dash(cost) => Keyword::Dash(resolve_keyword_mana_cost(state, object_id, cost)),
+        Keyword::Prowl(cost) => Keyword::Prowl(resolve_keyword_mana_cost(state, object_id, cost)),
+        Keyword::Surge(cost) => Keyword::Surge(resolve_keyword_mana_cost(state, object_id, cost)),
+        Keyword::Freerunning(cost) => {
+            Keyword::Freerunning(resolve_keyword_mana_cost(state, object_id, cost))
+        }
+        Keyword::Evoke(EvokeCost::Mana(cost)) => Keyword::Evoke(EvokeCost::Mana(
+            resolve_keyword_mana_cost(state, object_id, cost),
+        )),
+        Keyword::Bestow(BestowCost::Mana(cost)) => Keyword::Bestow(BestowCost::Mana(
+            resolve_keyword_mana_cost(state, object_id, cost),
+        )),
+        Keyword::Madness(cost) => {
+            Keyword::Madness(resolve_keyword_mana_cost(state, object_id, cost))
+        }
+        Keyword::Miracle(cost) => {
+            Keyword::Miracle(resolve_keyword_mana_cost(state, object_id, cost))
+        }
+        Keyword::Overload(cost) => {
+            Keyword::Overload(resolve_keyword_mana_cost(state, object_id, cost))
+        }
+        Keyword::Mutate(cost) => Keyword::Mutate(resolve_keyword_mana_cost(state, object_id, cost)),
+        Keyword::Mayhem(cost) => Keyword::Mayhem(resolve_keyword_mana_cost(state, object_id, cost)),
+        Keyword::WebSlinging(cost) => {
+            Keyword::WebSlinging(resolve_keyword_mana_cost(state, object_id, cost))
+        }
+        Keyword::Plot(cost) => Keyword::Plot(resolve_keyword_mana_cost(state, object_id, cost)),
+        Keyword::Offspring(cost) => {
+            Keyword::Offspring(resolve_keyword_mana_cost(state, object_id, cost))
+        }
         other => other.clone(),
     }
 }

--- a/crates/engine/src/game/keywords.rs
+++ b/crates/engine/src/game/keywords.rs
@@ -12,8 +12,8 @@ use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
 use crate::types::identifiers::{CardId, ObjectId};
 use crate::types::keywords::{
-    BestowCost, EmbalmCost, EternalizeCost, EvokeCost, FlashbackCost, GiftKind, Keyword,
-    KeywordKind, ProtectionTarget,
+    BestowCost, EmbalmCost, EmergeCost, EternalizeCost, EvokeCost, FlashbackCost, GiftKind,
+    Keyword, KeywordKind, ProtectionTarget,
 };
 use crate::types::mana::ManaCost;
 use crate::types::phase::Phase;
@@ -477,8 +477,8 @@ pub fn resolve_self_cost_graveyard_activated_keyword(
 
 /// CR 118.9 + CR 601.2f + CR 604.1: Resolve a `ManaCost::SelfManaCost` /
 /// `SelfManaValue` / `SelfManaCostReduced` payload carried by a *cast-time*
-/// alternative-cost keyword (CR 702.152a Blitz, CR 702.152b, CR 702.137a
-/// Spectacle, and the rest of the cast-from-hand alt-cost family) to the
+/// alternative-cost keyword (CR 702.152a Blitz, CR 702.137a Spectacle, CR
+/// 702.119a Emerge, and the rest of the cast-from-hand alt-cost family) to the
 /// recipient spell's own concrete mana cost, before that keyword's cost is
 /// offered or paid. A `CastWithKeyword` static (CR 604.1) can grant one of
 /// these keywords with a bare `SelfManaCost` placeholder payload ("The blitz
@@ -492,7 +492,8 @@ pub fn resolve_self_cost_graveyard_activated_keyword(
 /// Inclusion criterion: every keyword here is (a) a cast-time alternative or
 /// additional cost that substitutes for or accompanies a spell's mana cost,
 /// and (b) carries a bare `ManaCost` (or a `Mana(ManaCost)` variant of its
-/// cost enum) that a `CastWithKeyword` grant could plausibly bind to a
+/// cost enum, or a struct payload with a `mana_cost` field such as
+/// `EmergeCost`) that a `CastWithKeyword` grant could plausibly bind to a
 /// self-referential placeholder. Battlefield/activated-only keywords (Equip,
 /// Fortify, Reconfigure, Outlast, Unearth, Ninjutsu, Morph/Megamorph, Kicker)
 /// are not granted through this spell-cast seam and are intentionally
@@ -531,6 +532,16 @@ pub(crate) fn resolve_self_cost_spell_keyword(
         }
         Keyword::Mutate(cost) => Keyword::Mutate(resolve_keyword_mana_cost(state, object_id, cost)),
         Keyword::Mayhem(cost) => Keyword::Mayhem(resolve_keyword_mana_cost(state, object_id, cost)),
+        // CR 702.119a: Emerge's mana cost is a struct field (`EmergeCost.mana_cost`),
+        // not a bare `ManaCost`, so it needs its own arm; `sacrifice_filter` is
+        // untouched (it has no self-referential mana placeholder).
+        Keyword::Emerge(EmergeCost {
+            mana_cost,
+            sacrifice_filter,
+        }) => Keyword::Emerge(EmergeCost {
+            mana_cost: resolve_keyword_mana_cost(state, object_id, mana_cost),
+            sacrifice_filter: sacrifice_filter.clone(),
+        }),
         Keyword::WebSlinging(cost) => {
             Keyword::WebSlinging(resolve_keyword_mana_cost(state, object_id, cost))
         }

--- a/crates/engine/tests/integration/granted_alt_cost_hand_keyword.rs
+++ b/crates/engine/tests/integration/granted_alt_cost_hand_keyword.rs
@@ -1,14 +1,16 @@
-//! Runtime pipeline tests for granting foretell/miracle to cards IN HAND with an
-//! MV-derived cost (Dream Devourer, Aminatou Veil Piercer).
+//! Runtime pipeline tests for granting foretell/miracle/blitz to cards IN HAND
+//! with an MV-derived cost (Dream Devourer, Aminatou Veil Piercer, Henzie
+//! "Toolbox" Torre).
 //!
-//! CR 702.143a (Foretell) / CR 702.94a (Miracle) / CR 601.2f (generic reduction
-//! floors at {0}) / CR 113.6b (keyword functions from its stated zone).
+//! CR 702.143a (Foretell) / CR 702.94a (Miracle) / CR 702.152a (Blitz) /
+//! CR 601.2f (generic reduction floors at {0}) / CR 113.6b (keyword functions
+//! from its stated zone) / CR 118.9 (alternative costs).
 //!
 //! These drive the real engine (`apply()` via `GameRunner`), not helper-only
 //! parse assertions: each test would fail if the reduction/zone/resolution fix
 //! were reverted.
 
-use engine::game::casting::can_foretell_card;
+use engine::game::casting::{can_foretell_card, current_casting_variant_choice_options};
 use engine::game::effects::draw::resolve as resolve_draw;
 use engine::game::keywords::effective_foretell_cost;
 use engine::game::scenario::{GameRunner, GameScenario, P0};
@@ -16,15 +18,27 @@ use engine::types::ability::{
     CastingPermission, ContinuousModification, Effect, QuantityExpr, ResolvedAbility,
     StaticDefinition, TargetFilter,
 };
-use engine::types::actions::GameAction;
+use engine::types::actions::{AlternativeCastDecision, GameAction};
 use engine::types::game_state::{CastPaymentMode, CastingVariant, StackEntryKind, WaitingFor};
 use engine::types::identifiers::ObjectId;
 use engine::types::keywords::Keyword;
-use engine::types::mana::ManaCost;
+use engine::types::mana::{ManaCost, ManaType, ManaUnit};
 use engine::types::phase::Phase;
 
 const DREAM_DEVOURER: &str = "Each nonland card in your hand without foretell has foretell. Its foretell cost is equal to its mana cost reduced by {2}.";
 const AMINATOU: &str = "Each enchantment card in your hand has miracle. Its miracle cost is equal to its mana cost reduced by {4}.";
+// CR 702.152a: Henzie "Toolbox" Torre's blitz-granting line. The dynamic
+// "costs you pay {1} less" second line (a commander-cast-count reduction) is
+// explicitly out of scope for this fix — see issue #5435 — so only the
+// self-referential-cost grant line is modeled here.
+const HENZIE_BLITZ_GRANT: &str = "Each creature spell you cast with mana value 4 or greater has blitz. The blitz cost is equal to its mana cost.";
+
+/// `n` colorless mana units, for pre-funding a player's mana pool in a scenario.
+fn colorless_pool(n: usize) -> Vec<ManaUnit> {
+    (0..n)
+        .map(|_| ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]))
+        .collect()
+}
 
 fn generic(n: u32) -> ManaCost {
     ManaCost::Cost {
@@ -702,4 +716,184 @@ fn printed_foretell_removed_off_zone_is_not_foretellable() {
             "a card whose printed foretell was removed off-zone must not be foretellable"
         );
     }
+}
+
+// --------------------------------------------------------------------------
+// Blitz (Henzie "Toolbox" Torre) — self-referential granted alt cost from
+// hand. Issue #5435: an unresolved `ManaCost::SelfManaCost` has mana value 0
+// but is not "without paying mana", so it silently acted as a real {0}
+// alternative cost — letting the granted Blitz be offered (and auto-routed
+// to) for free regardless of the recipient's actual mana value.
+// --------------------------------------------------------------------------
+
+/// CR 702.152a + CR 604.1 + CR 118.9: a creature spell with mana value 4 or
+/// greater in hand under Henzie's grant must be offered Blitz at the spell's
+/// own concrete mana cost — never the raw `SelfManaCost` placeholder and
+/// never a free {0} cost.
+///
+/// Revert-failing: pre-fix, `blitz.mana_cost` is `ManaCost::SelfManaCost`
+/// (mana value 0), not `generic(6)`.
+#[test]
+fn henzie_granted_blitz_surfaces_concrete_spell_mana_cost() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Henzie \"Toolbox\" Torre", 3, 3)
+        .from_oracle_text(HENZIE_BLITZ_GRANT);
+    let spell = scenario
+        .add_spell_to_hand(P0, "SixMVCreature", false)
+        .as_creature()
+        .with_mana_cost(generic(6))
+        .id();
+    // Fund both the printed {6} and a concretized {6} blitz cost so the option
+    // is offered (affordability is a separate gate from the cost it displays).
+    scenario.with_mana_pool(P0, colorless_pool(6));
+
+    let runner = scenario.build();
+    let options = current_casting_variant_choice_options(runner.state(), P0, spell);
+    let blitz = options
+        .iter()
+        .find(|o| o.variant == CastingVariant::Blitz)
+        .expect("granted Blitz must be offered for an MV>=4 creature spell in hand");
+    assert_eq!(
+        blitz.mana_cost,
+        generic(6),
+        "granted Blitz must surface the spell's own concrete mana cost ({{6}}), not \
+         the unresolved SelfManaCost placeholder and not a free {{0}} cost, got {:?}",
+        blitz.mana_cost
+    );
+    assert_ne!(
+        blitz.mana_cost,
+        ManaCost::SelfManaCost,
+        "granted Blitz must not surface the raw self-referential placeholder"
+    );
+}
+
+/// CR 702.152a + CR 118.9 + CR 601.2f: with only {5} available and the
+/// concretized blitz cost at {6} (equal to the spell's mana value), Blitz
+/// must NOT be offered as an affordable option — this is the exact Discord
+/// report (AI blitz-casting MV6/7 creatures with only 6 mana available).
+///
+/// Revert-failing: pre-fix, the raw `SelfManaCost` placeholder has mana value
+/// 0, so it is affordable with ANY amount of mana (including zero), and the
+/// Blitz option is always offered/auto-routable regardless of the printed
+/// cost's actual affordability.
+#[test]
+fn henzie_granted_blitz_not_offered_when_unaffordable() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Henzie \"Toolbox\" Torre", 3, 3)
+        .from_oracle_text(HENZIE_BLITZ_GRANT);
+    let spell = scenario
+        .add_spell_to_hand(P0, "SixMVCreature", false)
+        .as_creature()
+        .with_mana_cost(generic(6))
+        .id();
+    // Only {5} available — insufficient for either the printed {6} or the
+    // concretized {6} blitz cost.
+    scenario.with_mana_pool(P0, colorless_pool(5));
+
+    let runner = scenario.build();
+    let options = current_casting_variant_choice_options(runner.state(), P0, spell);
+    assert!(
+        !options.iter().any(|o| o.variant == CastingVariant::Blitz),
+        "granted Blitz must not be offered when its concretized {{6}} cost is \
+         unaffordable at {{5}} available mana, got {:?}",
+        options
+    );
+}
+
+/// CR 702.152a + CR 601.2f: actually casting via the granted Blitz variant
+/// must drain the spell's own concrete mana cost from the pool — proving real
+/// payment, not just a displayed cost. A {6} creature under Henzie's grant
+/// pays exactly {6} (both the printed and blitz costs happen to coincide
+/// here; the discriminating fact is that {6}, not {0}, leaves the pool).
+///
+/// Revert-failing: pre-fix, the unresolved `SelfManaCost` placeholder pays
+/// nothing, so the pool would still hold {6} after a blitz cast.
+#[test]
+fn henzie_granted_blitz_cast_pays_concrete_mana_cost() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Henzie \"Toolbox\" Torre", 3, 3)
+        .from_oracle_text(HENZIE_BLITZ_GRANT);
+    let spell = scenario
+        .add_spell_to_hand(P0, "SixMVCreature", false)
+        .as_creature()
+        .with_mana_cost(generic(6))
+        .id();
+    scenario.with_mana_pool(P0, colorless_pool(6));
+
+    let mut runner = scenario.build();
+    // CR 601.2b + CR 118.9: a single granted alternative cost is offered through
+    // the two-slot `AlternativeCastChoice` modal (normal vs alternative), not the
+    // N-way `CastingVariantChoice` prompt — so the blitz election is declared
+    // with `.alternative_cast(..)`. Reaching that modal at all is itself
+    // meaningful: it proves the concretized {6} blitz cost was affordable
+    // alongside the printed {6}, so the engine had a real choice to offer.
+    let outcome = runner
+        .cast(spell)
+        .alternative_cast(AlternativeCastDecision::Alternative)
+        .resolve();
+
+    assert_eq!(
+        outcome.zone_of(spell),
+        engine::types::zones::Zone::Battlefield,
+        "the blitz-cast creature must resolve onto the battlefield"
+    );
+    assert_eq!(
+        outcome.mana_pool_total(P0),
+        0,
+        "casting via the granted Blitz option must drain the full concrete {{6}} \
+         cost from the pool, not leave it untouched (unresolved placeholder = \
+         free), got {} floating",
+        outcome.mana_pool_total(P0)
+    );
+}
+
+/// Negative control: a creature spell BELOW Henzie's mana-value-4 filter gets
+/// no Blitz option at all — the `Cmc GE 4` `affected` filter on the grant must
+/// still gate the grant correctly after the cost-concretization fix.
+#[test]
+fn henzie_grant_excludes_creature_below_mana_value_filter() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario
+        .add_creature(P0, "Henzie \"Toolbox\" Torre", 3, 3)
+        .from_oracle_text(HENZIE_BLITZ_GRANT);
+    let spell = scenario
+        .add_spell_to_hand(P0, "ThreeMVCreature", false)
+        .as_creature()
+        .with_mana_cost(generic(3))
+        .id();
+    scenario.with_mana_pool(P0, colorless_pool(3));
+
+    let mut runner = scenario.build();
+    let options = current_casting_variant_choice_options(runner.state(), P0, spell);
+    assert!(
+        !options.iter().any(|o| o.variant == CastingVariant::Blitz),
+        "a creature spell below Henzie's mana value 4 filter must not be \
+         offered Blitz, got {:?}",
+        options
+    );
+
+    // The spell must still cast normally at its printed {3}. Declaring NO
+    // `.alternative_cast(..)` is the load-bearing part: the harness panics if an
+    // `AlternativeCastChoice` modal is ever reached, so a completed cast proves
+    // no blitz alternative was offered for this below-threshold creature — and
+    // draining exactly {3} proves the grant didn't silently zero the cost.
+    let outcome = runner.cast(spell).resolve();
+    assert_eq!(
+        outcome.zone_of(spell),
+        engine::types::zones::Zone::Battlefield,
+        "the below-threshold creature must still cast normally"
+    );
+    assert_eq!(
+        outcome.mana_pool_total(P0),
+        0,
+        "the normal cast must pay the printed {{3}}, got {} floating",
+        outcome.mana_pool_total(P0)
+    );
 }


### PR DESCRIPTION
Fixes #5435.

## Root cause — runtime, not parser

The parser is already correct. `card-data.json` shows Henzie "Toolbox" Torre lowering to exactly the right AST:

```
CastWithKeyword { keyword: Blitz(ManaCost::SelfManaCost) }
affected: Typed(Creature) + controller You + Cmc GE 4
```

The defect is that `granted_spell_keywords_for` merges a `CastWithKeyword`-granted keyword's payload **verbatim**, so the `SelfManaCost` placeholder reaches affordability and payment unresolved.

That is silently fatal because `ManaCost::SelfManaCost` has mana value `0` but is **not** flagged "without paying mana" (CR 118.9) — so it doesn't take any free-cast path, it just behaves as a real `{0}` alternative cost:

- `can_pay_cost_after_auto_tap` always passes, so Blitz is offered unconditionally;
- when the printed cost is unaffordable, `casting_variant_choice_set` **auto-routes** to the free blitz.

That is the reported behaviour: the AI blitz-casting MV6/7 creatures with only 6 mana available.

Two call sites already document the intended contract — "Self-referential placeholders should have been resolved before reaching here" — confirming resolution was meant to happen upstream of payment.

## Why this is a class fix, not a Henzie fix

The off-zone seam (harmonize, mayhem, foretell, sneak, suspend, web-slinging) already routes every placeholder through `resolve_keyword_mana_cost`, the documented single authority for concretizing a granted keyword's cost.

The cast-from-hand seam never got that hop, so the entire cast-time alternative-cost family read raw payloads: **Blitz, Spectacle, Dash, Prowl, Surge, Freerunning**. Henzie is simply the card that made it visible.

## The fix

- Adds `resolve_self_cost_spell_keyword` in `game/keywords.rs`, mirroring the existing `resolve_self_cost_graveyard_activated_keyword`, delegating to `resolve_keyword_mana_cost`.
- Applies it at the **exit of both granted-spell-keyword collectors** — one place, rather than the ~11 individual cost-extraction call sites.

Resolving at the collector exit means:

- all three grant sources are covered uniformly (`CastWithKeyword` statics, transient grants, next-spell grants);
- concretization happens **before** cost modifiers and affordability run, which is required for correctness;
- every existing call site stays byte-identical.

Non-placeholder costs pass through unchanged, so printed Blitz/Dash/etc. are unaffected.

Two consumers that branch on seeing a placeholder were checked: `filter.rs` reads a printed `CardFace` cost and is unaffected; `interaction.rs` convoke now correctly sees real shards on a granted-blitz cast, which is a strict improvement.

All CR citations were verified against `docs/MagicCompRules.txt`: CR 118.9, CR 601.2f, CR 604.1, CR 702.152a/b, CR 702.137a.

## Tests

`crates/engine/tests/integration/granted_alt_cost_hand_keyword.rs` — the existing home for granted alt-costs on cards in hand (Dream Devourer, Aminatou) — gains four tests driving the real engine via `GameScenario`/`GameRunner` from Henzie's actual Oracle text:

1. the offered blitz cost is the concrete `{6}`, not the placeholder and not `{0}`;
2. with only `{5}` available the `{6}` blitz is **not** offered — this is the reported bug;
3. paying it actually drains `{6}` from the pool;
4. negative control: an MV3 creature is below the `Cmc GE 4` filter and gets no blitz.

This also **corrects an existing test** that was pinning the bug: `granted_blitz_self_mana_cost_surfaces_self_referential_cost` asserted `== SelfManaCost` on the premise that the placeholder was "resolved at payment time by the shared `SelfManaCost` path". No such path exists for blitz — that premise is what allowed the defect to persist. It is renamed and now asserts the concrete cost.

Verified revert-failing rather than assumed: with the fix neutered, 3 of the 4 new tests plus the corrected unit test fail, while the negative control correctly stays green.

`cargo fmt` clean · `clippy -D warnings` clean · full `phase-engine` lib suite green.

## Out of scope

Henzie's second line — *"Blitz costs you pay cost {1} less for each time you've cast your commander from the command zone this game"* — is an unimplemented `SwallowedClause` (visible in its `parse_warnings`). It needs a dynamic cost reduction keyed on a per-game commander-cast counter and scoped by alternative-cost keyword, which is its own parser + engine feature.

Worth noting the residual error direction is now safe: blitz costs full price rather than nothing, so a Henzie deck pays *too much* instead of casting free — the opposite of the reported failure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed granted alternative-cost casting options to correctly use the spell’s actual mana cost.
  * Corrected affordability checks and payment for granted Blitz, Spectacle, Emerge, and other self-referential alternative costs.
  * Prevented invalid free or unresolved-cost casting options from appearing.

* **Tests**
  * Added coverage for granted Blitz, Spectacle, and Emerge costs, including eligibility, affordability, and payment behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->