### PR TITLE
fix(client): respect a non-standard starting life total

### DIFF
--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -6,7 +6,7 @@ import {
   WebSocketAdapter,
 } from "../ws-adapter";
 import { AdapterError, supportsMatchConcede, supportsServerRewind } from "../types";
-import type { GameState } from "../types";
+import type { FormatConfig, GameState } from "../types";
 import type { PhaseSocketTransport } from "../../services/openPhaseSocket";
 
 // Minimal mock WebSocket. Latest-constructed instance is exposed via
@@ -514,6 +514,64 @@ describe("WebSocketAdapter", () => {
     // `reconnectFailed` before the `reconnecting` emit at all. The sidecar
     // runs `--single-user`, so its reconnect window is effectively unbounded
     // and the session is still there to reconnect to.
+    // The desktop (Tauri) solo route hands the setup screen's edited config to
+    // the sidecar through this frame and nowhere else: that route deliberately
+    // writes no resume pointer, so if `format_config` were dropped here the
+    // native server would fall back to Standard's 20 life with no other copy of
+    // the user's choice anywhere in the session.
+    it("carries a custom starting life to the native engine", async () => {
+      MockWebSocket.last = null;
+      const socketFactory = vi.fn(
+        () => new MockWebSocket("native-engine") as unknown as PhaseSocketTransport,
+      );
+      const formatConfig: FormatConfig = {
+        format: "Commander",
+        starting_life: 25,
+        min_players: 2,
+        max_players: 4,
+        deck_size: { type: "Exactly", data: 100 },
+        singleton: true,
+        command_zone: true,
+        commander_damage_threshold: 21,
+        range_of_influence: null,
+        team_based: false,
+        sideboard_policy: { type: "Forbidden" },
+        uses_commander: true,
+        allow_debug_actions: false,
+      };
+      const nativeAdapter = new WebSocketAdapter(
+        "native-engine",
+        "host",
+        { main_deck: [], sideboard: [] },
+        undefined,
+        undefined,
+        undefined,
+        "Player",
+        {
+          nativeAi: {
+            ...nativeAiOptions(socketFactory).nativeAi,
+            formatConfig,
+          },
+        },
+      );
+
+      const initPromise = nativeAdapter.initialize();
+      const nativeSocket = await completeHandshake(nativeAdapter);
+      const calls = nativeSocket.send.mock.calls;
+      const frame = JSON.parse(calls[calls.length - 1]![0] as string);
+      expect(frame.type).toBe("CreateGameWithSettings");
+      expect(frame.data.format_config).toEqual(formatConfig);
+
+      nativeSocket.dispatchSynthetic(
+        "message",
+        JSON.stringify({
+          type: "GameStarted",
+          data: { state: createMockState(), your_player: 0 },
+        }),
+      );
+      await initPromise;
+    });
+
     it("retries a dropped native-ai socket instead of failing on first drop", async () => {
       MockWebSocket.last = null;
       const nativeAdapter = new WebSocketAdapter(
@@ -577,6 +635,70 @@ describe("WebSocketAdapter", () => {
     // Scope guard: this asserts a property of the DIFF (the change was scoped
     // to `nativeAi` and did not widen to both options), not that 0 is the
     // right answer for pregame — that path is explicitly not analysed.
+    // Desktop hosting from the multiplayer screen: `P2PHostAdapter` builds a
+    // `NativeP2PBridge`, which creates the sidecar game through this pregame
+    // frame rather than the `nativeAi` one. `HostSetup`'s edited starting life
+    // reaches the engine only if it survives here too.
+    it("carries a custom starting life to the native pregame host", async () => {
+      MockWebSocket.last = null;
+      const formatConfig: FormatConfig = {
+        format: "Commander",
+        starting_life: 25,
+        min_players: 2,
+        max_players: 4,
+        deck_size: { type: "Exactly", data: 100 },
+        singleton: true,
+        command_zone: true,
+        commander_damage_threshold: 21,
+        range_of_influence: null,
+        team_based: false,
+        sideboard_policy: { type: "Forbidden" },
+        uses_commander: true,
+        allow_debug_actions: false,
+      };
+      const pregameAdapter = new WebSocketAdapter(
+        "native-engine",
+        "host",
+        { main_deck: [], sideboard: [] },
+        undefined,
+        undefined,
+        undefined,
+        "Host",
+        {
+          nativePregame: {
+            kind: "host",
+            socketFactory: () =>
+              new MockWebSocket("native-engine") as unknown as PhaseSocketTransport,
+            playerCount: 4,
+            aiSeats: [],
+            formatConfig,
+          },
+        },
+      );
+
+      const attached = pregameAdapter.initializePregame();
+      const nativeSocket = await completeHandshake(pregameAdapter);
+      const calls = nativeSocket.send.mock.calls;
+      const frame = JSON.parse(calls[calls.length - 1]![0] as string);
+      expect(frame.type).toBe("CreateGameWithSettings");
+      expect(frame.data.format_config).toEqual(formatConfig);
+
+      nativeSocket.dispatchSynthetic(
+        "message",
+        JSON.stringify({
+          type: "SessionAttached",
+          data: {
+            game_code: "WXYZ",
+            player_id: 0,
+            player_token: "tok",
+            full_key: { game_code: "WXYZ", generation: 1 },
+          },
+        }),
+      );
+      await attached;
+      pregameAdapter.dispose();
+    });
+
     it("leaves the native pregame transport failing on first drop", async () => {
       MockWebSocket.last = null;
       const pregameAdapter = new WebSocketAdapter(

--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -9,6 +9,7 @@ import type { AiSeatConfig, HostingSettings } from "../../stores/multiplayerStor
 import { useAiDeckCatalog } from "../../services/aiDeckCatalog";
 import { expandParsedDeck } from "../../services/deckParser";
 import { menuButtonClass } from "../menu/buttonStyles";
+import { IntegerField } from "../ui/IntegerField";
 import { MenuSelect, type MenuSelectGroup } from "../ui/MenuSelect";
 
 export type { AiSeatConfig };
@@ -479,17 +480,13 @@ export function HostSetup({
             </Field>
 
             <Field label={t("hostSetup.startingLife")} htmlFor="host-setup-life">
-              <input
+              <IntegerField
                 id="host-setup-life"
-                type="number"
                 value={formatConfig.starting_life}
-                onChange={(e) =>
-                  setLocalFormatConfig((prev) => ({
-                    ...prev,
-                    starting_life: Math.max(1, parseInt(e.target.value) || 1),
-                  }))
-                }
                 min={1}
+                onCommit={(starting_life) =>
+                  setLocalFormatConfig((prev) => ({ ...prev, starting_life }))
+                }
                 className={inp}
               />
             </Field>
@@ -576,17 +573,16 @@ export function HostSetup({
           {/* Commander damage threshold (Commander only) */}
           {formatConfig.commander_damage_threshold != null && (
             <Field label={t("hostSetup.commanderDamage")} htmlFor="host-setup-cmd-dmg">
-              <input
+              <IntegerField
                 id="host-setup-cmd-dmg"
-                type="number"
                 value={formatConfig.commander_damage_threshold ?? 21}
-                onChange={(e) =>
+                min={1}
+                onCommit={(threshold) =>
                   setLocalFormatConfig((prev) => ({
                     ...prev,
-                    commander_damage_threshold: Math.max(1, parseInt(e.target.value) || 21),
+                    commander_damage_threshold: threshold,
                   }))
                 }
-                min={1}
                 className={inp}
               />
             </Field>

--- a/client/src/components/lobby/__tests__/HostSetup.test.tsx
+++ b/client/src/components/lobby/__tests__/HostSetup.test.tsx
@@ -191,4 +191,46 @@ describe("HostSetup", () => {
     expect(difficultyButton).toHaveTextContent("Very Hard");
     expect(screen.queryByText("VeryHard")).not.toBeInTheDocument();
   });
+
+  it("hosts with the starting life the user typed after clearing the field", async () => {
+    const user = userEvent.setup();
+    const onHost = vi.fn();
+
+    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" />);
+
+    // Commander's 40 is already in the box, so entering a non-standard value
+    // means emptying it first. A per-keystroke clamp used to refill the box
+    // with a fallback, and the typed digits landed after it (25 became 125).
+    const life = screen.getByLabelText("Starting Life");
+    await user.clear(life);
+    await user.type(life, "25");
+
+    await user.click(screen.getByRole("button", { name: "Host Game" }));
+
+    expect(onHost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        formatConfig: expect.objectContaining({ starting_life: 25 }),
+      }),
+    );
+  });
+
+  it("keeps the last valid starting life when the field is left empty", async () => {
+    const user = userEvent.setup();
+    const onHost = vi.fn();
+
+    render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode="server" />);
+
+    const life = screen.getByLabelText("Starting Life");
+    await user.clear(life);
+
+    await user.click(screen.getByRole("button", { name: "Host Game" }));
+
+    expect(onHost).toHaveBeenCalledWith(
+      expect.objectContaining({
+        formatConfig: expect.objectContaining({
+          starting_life: FORMAT_DEFAULTS.Commander.starting_life,
+        }),
+      }),
+    );
+  });
 });

--- a/client/src/components/ui/IntegerField.tsx
+++ b/client/src/components/ui/IntegerField.tsx
@@ -1,0 +1,60 @@
+import { useState } from "react";
+
+/**
+ * Bounded integer text box for setup forms.
+ *
+ * Exists because the obvious controlled spelling —
+ * `value={n} onChange={e => set(Math.max(min, parseInt(e.target.value) || fallback))}` —
+ * silently corrupts what the user typed. Clearing the box makes `parseInt("")`
+ * NaN, the fallback re-renders the box with that number still in it, and the
+ * digits typed next append to it: clear a "40" and type "25" and the value
+ * committed is 125. The per-keystroke clamp that was meant to keep NaN out of
+ * the engine is what mangles the entry.
+ *
+ * So the raw text is held here and the caller is only told about readings that
+ * actually parse — the same reject-don't-coerce rule `AmountInput` follows for
+ * the engine's in-game amount prompts. An empty or half-typed box leaves the
+ * last committed value standing, and blurring re-syncs the display to it, so
+ * `value` is always a number the user really entered.
+ */
+export function IntegerField({
+  id,
+  value,
+  min,
+  onCommit,
+  className,
+  ariaLabel,
+}: {
+  id?: string;
+  /** The committed value. Shown whenever the box is not being edited. */
+  value: number;
+  min: number;
+  /** Called only for a reading that parses to an integer at or above `min`. */
+  onCommit: (next: number) => void;
+  className?: string;
+  ariaLabel?: string;
+}) {
+  // `null` = not editing, show `value`. A string = the user's in-progress text,
+  // which may legitimately be empty or below `min` mid-typing.
+  const [draft, setDraft] = useState<string | null>(null);
+
+  return (
+    <input
+      id={id}
+      type="number"
+      min={min}
+      aria-label={ariaLabel}
+      value={draft ?? String(value)}
+      onChange={(e) => {
+        const raw = e.target.value;
+        setDraft(raw);
+        const parsed = Number.parseInt(raw, 10);
+        if (Number.isFinite(parsed) && parsed >= min) {
+          onCommit(parsed);
+        }
+      }}
+      onBlur={() => setDraft(null)}
+      className={className}
+    />
+  );
+}

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -14,6 +14,7 @@ import type { TFunction } from "i18next";
 import type {
   CompanionRevealChoice,
   DeckCardCount,
+  FormatConfig,
   GameFormat,
   MatchConfig,
   ObjectId,
@@ -255,7 +256,9 @@ export function GamePage() {
   // Without this gate, refreshing `/game/<id>?mode=p2p-host` against a
   // Full-mode server would attempt `openBrokerClient` and surface an
   // "Expected LobbyOnly server, got Full" error to the user.
-  const locationState = location.state as { useBroker?: boolean } | null;
+  const locationState = location.state as
+    | { useBroker?: boolean; formatConfig?: FormatConfig }
+    | null;
   const cachedServerMode = useMultiplayerStore((s) => s.serverInfo?.mode);
   const useBroker = locationState?.useBroker ?? (cachedServerMode === "LobbyOnly");
   const rawMode = searchParams.get("mode");
@@ -278,6 +281,12 @@ export function GamePage() {
     activeGameMeta && activeGameMeta.id === gameId
       ? activeGameMeta.formatConfig
       : undefined;
+  // The setup screen's edited config (starting life), handed over on the
+  // navigation that started this game. `GameSetupPage`'s native-engine route
+  // writes no resume pointer, so router state is the only channel that
+  // reaches both engine routes; `savedFormatConfig` still wins because it
+  // survives a hard refresh, and the two agree whenever both are present.
+  const setupFormatConfig = locationState?.formatConfig;
   // Memoize so the `GameProvider` `useEffect` dep array doesn't
   // tear-down/rebuild the P2P session on every parent re-render. Without
   // `useMemo`, each render constructs a fresh object reference from
@@ -290,10 +299,10 @@ export function GamePage() {
       if (savedFormatConfig && isDirectSetupFormat(savedFormatConfig.format)) {
         return savedFormatConfig;
       }
-      return directSetupFormatConfig(formatParam);
+      return setupFormatConfig ?? directSetupFormatConfig(formatParam);
     }
     return savedFormatConfig ?? (formatParam ? FORMAT_DEFAULTS[formatParam] : undefined);
-  }, [formatParam, rawMode, savedFormatConfig]);
+  }, [formatParam, rawMode, savedFormatConfig, setupFormatConfig]);
   // CR 103.1: 0 = play first, 1 = draw first, undefined = random
   const firstPlayer = firstParam === "play" ? 0 : firstParam === "draw" ? 1 : undefined;
   const matchConfig = useMemo<MatchConfig>(

--- a/client/src/pages/GameSetupPage.tsx
+++ b/client/src/pages/GameSetupPage.tsx
@@ -17,6 +17,7 @@ import { FormatPicker } from "../components/menu/FormatPicker";
 import { MenuParticles } from "../components/menu/MenuParticles";
 import { MenuPanel, MenuShell } from "../components/menu/MenuShell";
 import { MyDecks, StatusBadge } from "../components/menu/MyDecks";
+import { IntegerField } from "../components/ui/IntegerField";
 import { ModalPanelShell } from "../components/ui/ModalPanelShell";
 import {
   getRepresentativeDeckVisual,
@@ -202,7 +203,7 @@ export function GameSetupPage() {
     // The native server owns a fresh AI session and v1 deliberately has no
     // resume contract. Preserve the existing pointer only for the WASM route.
     if (!canAttemptNativeEngine(prefs.nativeEngineEnabled) || firstPlayer !== "random") {
-      saveActiveGame({ id: gameId, mode: "ai", difficulty: headDifficulty, aiSeats });
+      saveActiveGame({ id: gameId, mode: "ai", difficulty: headDifficulty, aiSeats, formatConfig });
     }
     useGameStore.setState({ gameId });
     const firstParam = firstPlayer !== "random" ? `&first=${firstPlayer}` : "";
@@ -210,8 +211,14 @@ export function GameSetupPage() {
     // GamePage projects it onto the local MatchConfig. Omitted = Off (engine default).
     const loopMode = loopDetectionModeToQuery(loopDetection);
     const loopParam = loopMode ? `&loop=${loopMode}` : "";
+    // The URL carries the format NAME only, so the edited config (starting
+    // life) has to ride along out-of-band or GamePage re-derives it from
+    // `FORMAT_DEFAULTS` and silently discards the edit. Router state — the
+    // same channel `useBroker` uses — rather than a URL param, because the
+    // native-engine route above deliberately writes no resume pointer.
     navigate(
       `/game/${gameId}?mode=ai&difficulty=${headDifficulty}&format=${formatConfig.format}&players=${playerCount}&match=${matchType.toLowerCase()}${loopParam}${firstParam}`,
+      { state: { formatConfig } },
     );
   };
 
@@ -481,11 +488,11 @@ export function GameSetupPage() {
                 <div className="flex flex-col gap-3">
                   <label className="flex items-center justify-between">
                     <span className="text-xs text-slate-400">{t("gameSetup.config.startingLife")}</span>
-                    <input
-                      type="number"
+                    <IntegerField
                       value={formatConfig.starting_life}
-                      onChange={(e) =>
-                        setFormatConfig({ ...formatConfig, starting_life: Number(e.target.value) })
+                      min={1}
+                      onCommit={(starting_life) =>
+                        setFormatConfig({ ...formatConfig, starting_life })
                       }
                       className="w-16 rounded-lg border border-gray-700 bg-gray-800/60 px-2 py-1 text-right text-sm text-white"
                     />

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -285,9 +285,12 @@ vi.mock("../../hooks/useCardDataMeta", () => ({
 
 // ── Helpers ──────────────────────────────────────────────────────────────────
 
-function renderGamePage(initialEntry = "/game/test-game-123?mode=ai") {
+function renderGamePage(
+  initialEntry: string | { pathname: string; search: string; state: unknown } =
+    "/game/test-game-123?mode=ai",
+) {
   return render(
-    <MemoryRouter initialEntries={[initialEntry]}>
+    <MemoryRouter initialEntries={[initialEntry as never]}>
       <Routes>
         <Route path="/game/:id" element={<GamePage />} />
         <Route path="/setup" element={<div data-testid="setup-page">Setup</div>} />
@@ -376,6 +379,21 @@ describe("GamePage — cEDH bracket-violation blocking modal", () => {
     renderGamePage("/game/test-game-123?format=Planechase&players=4");
 
     expect(capturedFormatConfig?.format).toBe("Planechase");
+  });
+
+  // The setup screen hands its edited config over on the navigation rather than
+  // in the URL, which carries the format NAME only. Without this the memo falls
+  // back to the format registry and a custom starting life is silently replaced
+  // by the format default — including on the Tauri native route, which writes no
+  // resume pointer and so has no other copy of the user's choice.
+  it("prefers the setup screen's handed-over config over the format default", () => {
+    renderGamePage({
+      pathname: "/game/test-game-123",
+      search: "?mode=ai&format=Commander&players=2",
+      state: { formatConfig: { format: "Commander", starting_life: 25 } },
+    });
+
+    expect(capturedFormatConfig?.starting_life).toBe(25);
   });
 
   it("renders the blocking modal when bracketViolation flag is true", async () => {

--- a/client/src/pages/__tests__/GameSetupPage.startingLife.test.tsx
+++ b/client/src/pages/__tests__/GameSetupPage.startingLife.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * GameSetupPage — the edited starting life must reach the started game.
+ *
+ * The game URL carries the format NAME only, so `GamePage` re-derives the
+ * config from `FORMAT_DEFAULTS` unless the setup page hands the edited
+ * `FormatConfig` over out-of-band. This suite pins the hand-over: the
+ * active-game record (`ActiveGameMeta.formatConfig`) for the WASM route, and
+ * router state for the native route, which deliberately writes no record.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { MemoryRouter, Route, Routes, useLocation } from "react-router";
+
+import {
+  ACTIVE_DECK_KEY,
+  ACTIVE_GAME_KEY,
+  STORAGE_KEY_PREFIX,
+} from "../../constants/storage";
+import { FORMAT_DEFAULTS } from "../../stores/multiplayerStore";
+import { GameSetupPage } from "../GameSetupPage";
+
+vi.mock("../../components/menu/MenuParticles", () => ({ MenuParticles: () => null }));
+vi.mock("../../hooks/useCardImage", () => ({
+  useCardImage: () => ({ src: null, isLoading: false }),
+}));
+vi.mock("../../audio/useAudioContext", () => ({ useAudioContext: () => undefined }));
+vi.mock("../../adapter/wasm-adapter", () => ({
+  getSharedAdapter: () => ({ warmCardDatabase: () => Promise.resolve() }),
+}));
+vi.mock("../../components/menu/MyDecks", async () => {
+  const actual = await vi.importActual<typeof import("../../components/menu/MyDecks")>(
+    "../../components/menu/MyDecks",
+  );
+  return { ...actual, MyDecks: () => null };
+});
+vi.mock("../../hooks/useDecks", async () => {
+  const actual = await vi.importActual<typeof import("../../hooks/useDecks")>(
+    "../../hooks/useDecks",
+  );
+  return { ...actual, useDecks: () => ({ decks: null, status: "success" as const }) };
+});
+vi.mock("../../services/deckCompatibility", () => ({
+  evaluateDeckCompatibilityBatch: vi.fn().mockResolvedValue({}),
+}));
+vi.mock("../../hooks/useBracketEstimate", () => ({
+  useBracketEstimate: () => ({ estimate: null, loading: false, unsupported: false }),
+}));
+vi.mock("../../hooks/useSetSymbols", () => ({ useSetSymbol: () => null }));
+vi.mock("../../stores/cardDataStore", () => {
+  const store = (selector: (state: { status: string }) => unknown) => selector({ status: "ready" });
+  store.getState = () => ({ warm: vi.fn().mockResolvedValue(undefined) });
+  return { useCardDataStore: store };
+});
+// The Start button is gated on the AI seats having at least one legal deck.
+// The real component resolves that from the card database; report one so the
+// gate opens without pulling the catalog in.
+vi.mock("../../components/menu/AiOpponentConfig", () => ({
+  AiOpponentConfig: ({
+    onCandidateCountChange,
+  }: {
+    onCandidateCountChange: (count: number) => void;
+  }) => {
+    onCandidateCountChange(1);
+    return null;
+  },
+}));
+
+/** Echoes the router state the setup page navigated with. */
+function GameRouteProbe() {
+  const location = useLocation();
+  return (
+    <div data-testid="nav-state">
+      {JSON.stringify((location.state as Record<string, unknown> | null) ?? null)}
+    </div>
+  );
+}
+
+function renderSetup() {
+  return render(
+    <MemoryRouter initialEntries={["/game-setup"]}>
+      <Routes>
+        <Route path="/game-setup" element={<GameSetupPage />} />
+        <Route path="/game/:id" element={<GameRouteProbe />} />
+      </Routes>
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  localStorage.setItem(
+    STORAGE_KEY_PREFIX + "My Deck",
+    JSON.stringify({ main: [{ name: "Island", count: 100 }], sideboard: [] }),
+  );
+  localStorage.setItem(ACTIVE_DECK_KEY, "My Deck");
+});
+
+afterEach(cleanup);
+
+describe("GameSetupPage — starting life", () => {
+  it("hands an edited starting life to the game it starts", async () => {
+    const user = userEvent.setup();
+    renderSetup();
+
+    const lifeInput = await screen.findByLabelText("Starting Life");
+    await user.clear(lifeInput);
+    await user.type(lifeInput, "25");
+
+    await user.click(screen.getByRole("button", { name: /Start Match/i }));
+
+    const navState = JSON.parse(screen.getByTestId("nav-state").textContent!);
+    expect(navState.formatConfig.starting_life).toBe(25);
+
+    const meta = JSON.parse(localStorage.getItem(ACTIVE_GAME_KEY)!);
+    expect(meta.formatConfig.starting_life).toBe(25);
+  });
+
+  it("keeps the last valid starting life when the field is left empty", async () => {
+    const user = userEvent.setup();
+    renderSetup();
+
+    const lifeInput = await screen.findByLabelText("Starting Life");
+    await user.clear(lifeInput);
+
+    await user.click(screen.getByRole("button", { name: /Start Match/i }));
+
+    const meta = JSON.parse(localStorage.getItem(ACTIVE_GAME_KEY)!);
+    expect(meta.formatConfig.starting_life).toBe(
+      FORMAT_DEFAULTS.Commander.starting_life,
+    );
+  });
+});

--- a/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
+++ b/client/src/providers/__tests__/GameProvider.nativeEngine.test.tsx
@@ -55,7 +55,9 @@ const {
   };
   class WebSocketAdapter {
     private listener: ((event: NativeAdapterEvent) => void) | null = null;
-    readonly nativeAiOptions: { aiSeats: Array<{ difficulty: string }> } | undefined;
+    readonly nativeAiOptions:
+      | { aiSeats: Array<{ difficulty: string }>; formatConfig?: { starting_life: number } }
+      | undefined;
     readonly nativePregameOptions: NativePregameReconnect | undefined;
     dispose = vi.fn();
     onEvent = vi.fn((listener: (event: NativeAdapterEvent) => void) => {
@@ -74,7 +76,10 @@ const {
       _reservationToken?: string,
       _displayName?: string,
       options?: {
-        nativeAi?: { aiSeats: Array<{ difficulty: string }> };
+        nativeAi?: {
+          aiSeats: Array<{ difficulty: string }>;
+          formatConfig?: { starting_life: number };
+        };
         nativePregame?: NativePregameReconnect;
       },
     ) {
@@ -314,6 +319,7 @@ vi.mock("../../services/serverDetection", () => ({
   detectServerUrl: vi.fn(async () => "ws://test-server"),
 }));
 
+import type { FormatConfig } from "../../adapter/types";
 import { GameProvider } from "../GameProvider";
 import { AdapterError, AdapterErrorCode } from "../../adapter/types";
 import { clearPromptOverlayState } from "../../game/sessionCleanup";
@@ -589,6 +595,44 @@ describe("GameProvider native AI routing", () => {
       "VeryHard",
       "CEDH",
     ]);
+  });
+
+  // The Tauri solo route writes no resume pointer, so `GameSetupPage` hands its
+  // edited config over on the navigation and `GamePage` reads it back out of
+  // router state. This pins the last hop of that hand-over: whatever config the
+  // route resolved must reach the native adapter, or the sidecar starts the
+  // game on the format's default life instead of the user's.
+  it("passes the route's starting life to the native engine", async () => {
+    // Spelled out rather than spread from `FORMAT_DEFAULTS`: the store is
+    // mocked in this file, so the real registry is not reachable here.
+    const formatConfig: FormatConfig = {
+      format: "Commander",
+      starting_life: 25,
+      min_players: 2,
+      max_players: 4,
+      deck_size: { type: "Exactly", data: 100 },
+      singleton: true,
+      command_zone: true,
+      commander_damage_threshold: 21,
+      range_of_influence: null,
+      team_based: false,
+      sideboard_policy: { type: "Forbidden" },
+      uses_commander: true,
+      allow_debug_actions: false,
+    };
+
+    render(
+      <GameProvider gameId="native-starting-life" mode="ai" formatConfig={formatConfig}>
+        <div />
+      </GameProvider>,
+    );
+
+    await waitFor(() => {
+      expect(gameStoreState.setEngineMode).toHaveBeenCalledWith("native");
+      expect(nativeAdapters).toHaveLength(1);
+    });
+
+    expect(nativeAdapters[0]!.nativeAiOptions?.formatConfig?.starting_life).toBe(25);
   });
 
   async function expectNativeTerminalEvent(event: NativeAdapterEvent) {

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -2499,6 +2499,57 @@ mod tests {
         assert!(mgr.sessions.is_empty());
     }
 
+    /// CR 103.4: each player begins with a starting life total of 20, and some
+    /// variant games use a different one — so a host-configured `starting_life`
+    /// is the authority, not the format's default.
+    ///
+    /// This is the server-side half of the desktop (Tauri) solo/host route: the
+    /// native engine is this phase-server running as a sidecar, and the client
+    /// hands it the edited `FormatConfig` in `CreateGameWithSettings`. Dropping
+    /// it here would silently seat every player at the format default.
+    ///
+    /// REVERT-FAIL: make `create_game_n_players` ignore its `format_config`
+    /// argument (or re-derive one from `format_config.format`) ⇒ life is 40.
+    #[test]
+    fn create_game_honors_a_configured_starting_life() {
+        let mut mgr = SessionManager::new();
+        let mut format_config = FormatConfig::commander();
+        format_config.starting_life = 25;
+
+        let (code, _) = mgr
+            .create_game_n_players(
+                make_deck(),
+                "Host".to_string(),
+                None,
+                2,
+                MatchConfig::default(),
+                Some(format_config),
+            )
+            .expect("a custom starting life is a supported configuration");
+
+        let session = mgr.sessions.get(&code).unwrap();
+        assert_eq!(session.state.format_config.starting_life, 25);
+        for player in &session.state.players {
+            assert_eq!(
+                player.life, 25,
+                "every seat must start on the configured life total, not Commander's 40"
+            );
+        }
+
+        // The between-games rebuild re-reads the session's own format config, so
+        // game 2 of a match must not silently revert to the format default.
+        mgr.sessions
+            .get_mut(&code)
+            .unwrap()
+            .rebuild_pregame_state(2);
+        for player in &mgr.sessions.get(&code).unwrap().state.players {
+            assert_eq!(
+                player.life, 25,
+                "the rebuild must preserve the configured life total"
+            );
+        }
+    }
+
     /// CR 732.2a (#4603 opt-in, Best-of-N): the combo-detector opt-in lives on the
     /// immutable `MatchConfig` and is projected onto `GameState::loop_detection` by
     /// `set_match_config` at BOTH game creation AND the between-games rebuild, so a Bo3


### PR DESCRIPTION
The multiplayer host form clamped `starting_life` on every keystroke
(`Math.max(1, parseInt(value) || 1)`). The input is controlled, so
clearing the box re-rendered it showing the fallback and the digits typed
next appended to it: clearing Commander's 40 and typing 25 committed 125.
The commander-damage field had the same defect with a 21 fallback.

`IntegerField` holds the raw text and commits only readings that parse, so
an empty or half-typed box leaves the last valid value standing and blur
re-syncs the display. This is the reject-don't-coerce rule `AmountInput`
already applies to the engine's in-game amount prompts, applied to the
three setup fields that share the defect.

The vs-AI setup screen dropped the edited config outright: the game URL
carries the format NAME only, so `GamePage` rebuilt the whole
`FormatConfig` from `FORMAT_DEFAULTS`. Hand the edited config over on the
active-game record and on router state — the latter because that screen's
native-engine route deliberately writes no resume pointer, making it the
only channel that reaches both the WASM and the Tauri sidecar route.

Tests pin both native transports (the `nativeAi` frame and the desktop
P2P `nativePregame` host frame, which build their setup frames on separate
paths) and the server honoring a configured starting life across the Bo3
between-games rebuild. CR 103.4: some variant games have different
starting life totals.

Claude-Session: https://claude.ai/code/session_01BESCymTdnuA4f77dtpxHtz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Custom starting-life settings now persist when starting solo AI games and remain available during game setup.
  - Host and game setup forms use improved integer fields for starting life and Commander damage thresholds.
  - Settings are preserved across navigation and pregame setup, including native game modes.

- **Bug Fixes**
  - Fixed custom starting-life values being replaced by default format settings.
  - Empty fields now safely restore the last valid value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->