### PR TITLE
fix(engine): sacrifice the survivors when a snapshotted member ceased to exist (#8147)

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -18439,6 +18439,62 @@ mod idempotency_tests {
         }
     }
 
+    /// CR 608.2b + CR 111.7 (#8147): one mobilized token trades in combat before
+    /// the end step, so it has ceased to exist by the time the delayed
+    /// "sacrifice them" fires. The delayed trigger snapshots BOTH token ids at
+    /// creation and carries no incarnation pins, so `live_object_targets` still
+    /// hands the resolver the dead id; `sacrifice::resolve` used to `?` out with
+    /// `EffectError::ObjectNotFound` on it and abandon the whole effect, leaving
+    /// the survivor on the battlefield forever.
+    ///
+    /// Discriminating (fail-on-revert): restore the `ok_or(...)?` in
+    /// `effects/sacrifice.rs` and the survivor stays on the battlefield.
+    /// `synthesize_mobilize_runtime_sacrifices_tokens_at_next_end_step` cannot
+    /// see this — nothing dies in it, so every snapshotted id is still live.
+    #[test]
+    fn mobilize_end_step_sacrifice_still_takes_the_survivor_of_a_combat_trade() {
+        let mut face = CardFace::default();
+        face.keywords
+            .push(Keyword::Mobilize(QuantityExpr::Fixed { value: 2 }));
+        synthesize_mobilize(&mut face);
+
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Mobilizer".to_string(),
+            Zone::Battlefield,
+        );
+        let execute = face
+            .triggers
+            .first()
+            .and_then(|trigger| trigger.execute.as_deref())
+            .expect("mobilize trigger must have an execute body");
+        let ability = build_resolved_from_def(execute, source_id, PlayerId(0));
+        let mut events = Vec::new();
+        resolve_ability_chain(&mut state, &ability, &mut events, 0).unwrap();
+
+        let tokens = state.last_created_token_ids.clone();
+        assert_eq!(tokens.len(), 2);
+        let (died, survivor) = (tokens[0], tokens[1]);
+
+        // CR 111.7: a token that dies in combat ceases to exist.
+        state.battlefield.retain(|id| *id != died);
+        state.objects.remove(&died);
+
+        let stacked =
+            check_delayed_triggers(&mut state, &[GameEvent::PhaseChanged { phase: Phase::End }]);
+        assert_eq!(stacked.len(), 1, "end-step cleanup must still stack");
+        resolve_top(&mut state, &mut events);
+
+        assert_eq!(
+            state.objects[&survivor].zone,
+            Zone::Graveyard,
+            "surviving mobilized token must still be sacrificed"
+        );
+    }
+
     #[test]
     fn synthesize_mobilize_preserves_dynamic_quantity() {
         let quantity = QuantityExpr::Ref {

--- a/crates/engine/src/game/effects/sacrifice.rs
+++ b/crates/engine/src/game/effects/sacrifice.rs
@@ -389,10 +389,17 @@ pub fn resolve(
 
     let mut selections = Vec::new();
     for obj_id in targeted_objects {
-        let obj = state
-            .objects
-            .get(&obj_id)
-            .ok_or(EffectError::ObjectNotFound(obj_id))?;
+        // CR 608.2b + CR 111.7: a snapshotted member that no longer exists is a
+        // normal outcome, not an error — a token that left the battlefield
+        // ceases to exist, so a delayed "sacrifice them" whose set lost a member
+        // in the meantime must still sacrifice the survivors ("does as much as
+        // it can"). Erroring here aborted the WHOLE effect on the first missing
+        // id, which is how a Mobilize pair that traded one Warrior in combat
+        // left the other on the battlefield forever (#8147). Skipping matches
+        // the emblem / wrong-zone / wrong-controller guards immediately below.
+        let Some(obj) = state.objects.get(&obj_id) else {
+            continue;
+        };
 
         // CR 114.5: Emblems cannot be sacrificed
         if obj.is_emblem {


### PR DESCRIPTION
A delayed "sacrifice them" snapshots its object set at creation and carries
no incarnation pins, so `live_object_targets` still hands the resolver an id
whose object has since ceased to exist (CR 111.7). `sacrifice::resolve` then
`?`-returned `EffectError::ObjectNotFound` on that id and abandoned the whole
effect.

CR 608.2b: an effect does as much as it can. Skip the missing member instead,
matching the emblem / wrong-zone / wrong-controller guards immediately below.

Reported for Voice of Victory's Mobilize 2: one Warrior traded in combat, so
at the next end step the delayed sacrifice aborted on the dead id and left the
other Warrior on the battlefield permanently. The existing runtime test
`synthesize_mobilize_runtime_sacrifices_tokens_at_next_end_step` cannot see
this — nothing dies in it, so every snapshotted id is still live.

Not Mobilize-specific: every "create N tokens ... sacrifice them at the
beginning of the next end step" rider is exposed, and combat is exactly when
those tokens die.

Claude-Session: https://claude.ai/code/session_011bmKqduE8R5LCy8umePnLX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Delayed sacrifice effects now continue resolving when a previously selected token no longer exists.
  * Remaining valid tokens are still sacrificed correctly, including applicable replacement and control checks.
  * Prevented errors caused by stale targets after combat or other game-state changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->