### PR TITLE
fix(parser): lowercase the Aura tags so the aura-count gate is reachable (#8182)

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -2128,7 +2128,13 @@ fn parse_source_enchanted_by_aura_count(input: &str) -> OracleResult<'_, StaticC
         map(parse_ge_threshold, |n| (Comparator::GE, n)),
     ))
     .parse(rest)?;
-    let (rest, _) = alt((tag("Auras"), tag("Aura"))).parse(rest.trim_start())?;
+    // `parse_inner_condition` is a LOWERCASE-input combinator — its production
+    // entry point (`oracle_static::shared::parse_static_condition`) calls it
+    // with `&text.to_lowercase()`. Capitalized `tag("Aura")` here made this arm
+    // unreachable in a real parse, so Timber Paladin's three tiered gates all
+    // fell to `StaticCondition::Unrecognized`, which `game/layers.rs` evaluates
+    // as always-true — every tier applied and the 10/10 tier won on timestamp.
+    let (rest, _) = alt((tag("auras"), tag("aura"))).parse(rest.trim_start())?;
     let aura_filter = TargetFilter::Typed(TypedFilter {
         type_filters: vec![
             TypeFilter::Enchantment,
@@ -13345,7 +13351,7 @@ mod tests {
 
     #[test]
     fn test_source_enchanted_by_plural_aura_count() {
-        let (rest, c) = parse_inner_condition("~ is enchanted by 3 or more Auras").unwrap();
+        let (rest, c) = parse_inner_condition("~ is enchanted by 3 or more auras").unwrap();
         assert_eq!(rest, "");
         let StaticCondition::QuantityComparison {
             comparator, rhs, ..
@@ -13359,7 +13365,7 @@ mod tests {
 
     #[test]
     fn test_source_enchanted_by_exactly_one_aura() {
-        let (rest, c) = parse_inner_condition("~ is enchanted by exactly one Aura").unwrap();
+        let (rest, c) = parse_inner_condition("~ is enchanted by exactly one aura").unwrap();
         assert_eq!(rest, "");
         let StaticCondition::QuantityComparison {
             comparator, rhs, ..
@@ -13373,7 +13379,7 @@ mod tests {
 
     #[test]
     fn test_source_enchanted_by_exactly_two_auras() {
-        let (rest, c) = parse_inner_condition("~ is enchanted by exactly two Auras").unwrap();
+        let (rest, c) = parse_inner_condition("~ is enchanted by exactly two auras").unwrap();
         assert_eq!(rest, "");
         let StaticCondition::QuantityComparison {
             comparator, rhs, ..
@@ -13541,7 +13547,7 @@ mod tests {
     // (it is tried earlier in the `alt()` and requires `tag("is enchanted by ")`).
     #[test]
     fn test_source_is_enchanted_does_not_steal_aura_count() {
-        let (rest, c) = parse_inner_condition("~ is enchanted by exactly two Auras").unwrap();
+        let (rest, c) = parse_inner_condition("~ is enchanted by exactly two auras").unwrap();
         assert_eq!(rest, "");
         let StaticCondition::QuantityComparison {
             comparator, rhs, ..

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -10986,6 +10986,39 @@ fn unrecognized_lure_conjunct_surfaces_unimplemented_residual() {
     );
 }
 
+/// CR 303.4 + CR 613.1g: Timber Paladin's tiered gates, driven through the
+/// PRODUCTION entry point. `parse_static_condition` lowercases before handing
+/// off to `parse_inner_condition`, so a capitalized `tag("Aura")` in the
+/// combinator makes the whole arm unreachable in a real parse even while the
+/// combinator's own mixed-case unit tests stay green. That is exactly how
+/// Timber Paladin regressed after #2418: all three tiers landed as
+/// `StaticCondition::Unrecognized`, which `game/layers.rs` evaluates as
+/// always-true, so the 10/10 tier applied with zero Auras attached.
+///
+/// Discriminating (fail-on-revert): re-capitalize either `tag` and every case
+/// below returns `Unrecognized`.
+#[test]
+fn aura_count_gates_parse_from_printed_oracle_casing() {
+    for (text, comparator, value) in [
+        ("~ is enchanted by exactly one Aura", Comparator::EQ, 1),
+        ("~ is enchanted by exactly two Auras", Comparator::EQ, 2),
+        ("~ is enchanted by three or more Auras", Comparator::GE, 3),
+    ] {
+        let cond = parse_static_condition(text)
+            .unwrap_or_else(|| panic!("{text} must parse to a typed condition"));
+        let StaticCondition::QuantityComparison {
+            comparator: got_cmp,
+            rhs,
+            ..
+        } = cond
+        else {
+            panic!("{text} must parse to QuantityComparison, got {cond:?}");
+        };
+        assert_eq!(got_cmp, comparator, "{text}");
+        assert_eq!(rhs, QuantityExpr::Fixed { value }, "{text}");
+    }
+}
+
 /// Building-block (Step 3 backstop): `parse_static_condition` for combat state
 /// must no longer collapse an ATTACHED subject into a `Source*` condition, while
 /// the genuine source-referential forms are preserved unchanged.


### PR DESCRIPTION
`parse_source_enchanted_by_aura_count` matched the noun with `tag("Auras")` /
`tag("Aura")`, but the production entry point lowercases before dispatching:

    // oracle_static/shared.rs
    let lower = text.to_lowercase();
    nom_condition::parse_inner_condition(&lower)

so that `alt` arm could never fire in a real parse. `parse_inner_condition` is
a lowercase-input combinator — these were the only two capitalized `tag(...)`
literals in the file.

Timber Paladin's three tiered gates therefore all landed as
`StaticCondition::Unrecognized`, which `game/layers.rs` evaluates as
always-true, so every tier applied and the 10/10 + vigilance + trample tier
won on timestamp — the creature entered at max level with zero Auras. This is
the same symptom #2418 reported; that fix shipped the combinator but never
reached production.

Both tests #2418 shipped bypass the broken layer: the combinator's own unit
tests pass mixed-case text straight to `parse_inner_condition`, and
`tests/integration/issue_2418_timber_paladin.rs` hand-builds its
`StaticDefinition`s and never parses Oracle text. Adds
`aura_count_gates_parse_from_printed_oracle_casing`, which drives the printed
casing through `parse_static_condition` — the lowercasing entry point — so the
reachability gap cannot reopen unnoticed.

The always-true `Unrecognized` fallback that amplified this into a wrong game
result is tracked separately in #8183 (116 cards affected).

Claude-Session: https://claude.ai/code/session_011bmKqduE8R5LCy8umePnLX
