### PR TITLE
fix(client): keep a rematch on the life total it was played at

### DIFF
--- a/client/src/components/ui/IntegerField.tsx
+++ b/client/src/components/ui/IntegerField.tsx
@@ -16,6 +16,12 @@ import { useState } from "react";
  * the engine's in-game amount prompts. An empty or half-typed box leaves the
  * last committed value standing, and blurring re-syncs the display to it, so
  * `value` is always a number the user really entered.
+ *
+ * Rejecting is also why the reading comes from `valueAsNumber` rather than
+ * `parseInt`: `type="number"` accepts decimal and exponent text, and `parseInt`
+ * commits only the leading numeric run of it, so a typed "20.5" would commit 20
+ * while the box still showed 20.5 — the same silent disagreement between the
+ * entered and the committed value that this component exists to end.
  */
 export function IntegerField({
   id,
@@ -29,7 +35,7 @@ export function IntegerField({
   /** The committed value. Shown whenever the box is not being edited. */
   value: number;
   min: number;
-  /** Called only for a reading that parses to an integer at or above `min`. */
+  /** Called only for a reading that is a whole number at or above `min`. */
   onCommit: (next: number) => void;
   className?: string;
   ariaLabel?: string;
@@ -46,11 +52,12 @@ export function IntegerField({
       aria-label={ariaLabel}
       value={draft ?? String(value)}
       onChange={(e) => {
-        const raw = e.target.value;
-        setDraft(raw);
-        const parsed = Number.parseInt(raw, 10);
-        if (Number.isFinite(parsed) && parsed >= min) {
-          onCommit(parsed);
+        setDraft(e.currentTarget.value);
+        // `valueAsNumber` is NaN for an empty or unparseable box, which
+        // `isSafeInteger` rejects along with every non-whole reading.
+        const reading = e.currentTarget.valueAsNumber;
+        if (Number.isSafeInteger(reading) && reading >= min) {
+          onCommit(reading);
         }
       }}
       onBlur={() => setDraft(null)}

--- a/client/src/components/ui/__tests__/IntegerField.test.tsx
+++ b/client/src/components/ui/__tests__/IntegerField.test.tsx
@@ -1,0 +1,115 @@
+/**
+ * IntegerField — the commit contract.
+ *
+ * The component exists because a per-keystroke clamp corrupts what the user
+ * typed (see the component docstring). These tests pin both halves of the
+ * contract it replaced that clamp with: a reading is committed only when it is
+ * a whole number at or above `min`, and anything else leaves the last
+ * committed value standing while the box keeps showing what was typed.
+ */
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { useState } from "react";
+
+import { IntegerField } from "../IntegerField";
+
+/** Mirrors a real call site: the committed value is owned by the parent. */
+function Harness({ initial, min = 1, onCommit }: {
+  initial: number;
+  min?: number;
+  onCommit?: (next: number) => void;
+}) {
+  const [value, setValue] = useState(initial);
+  return (
+    <IntegerField
+      value={value}
+      min={min}
+      ariaLabel="Starting Life"
+      onCommit={(next) => {
+        onCommit?.(next);
+        setValue(next);
+      }}
+    />
+  );
+}
+
+afterEach(cleanup);
+
+describe("IntegerField", () => {
+  it("commits a value typed after clearing the box", async () => {
+    const user = userEvent.setup();
+    const onCommit = vi.fn();
+    render(<Harness initial={40} onCommit={onCommit} />);
+
+    const field = screen.getByLabelText("Starting Life");
+    await user.clear(field);
+    await user.type(field, "25");
+
+    // The clamp this component replaced turned this exact sequence into 125.
+    expect(onCommit).toHaveBeenLastCalledWith(25);
+  });
+
+  it("leaves the last committed value standing while the box is empty", async () => {
+    const user = userEvent.setup();
+    const onCommit = vi.fn();
+    render(<Harness initial={40} onCommit={onCommit} />);
+
+    const field = screen.getByLabelText("Starting Life");
+    await user.clear(field);
+
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(field).toHaveValue(null); // the box is empty, mid-edit
+  });
+
+  it("re-syncs the display to the committed value on blur", async () => {
+    const user = userEvent.setup();
+    render(<Harness initial={40} />);
+
+    const field = screen.getByLabelText("Starting Life");
+    await user.clear(field);
+    await user.tab();
+
+    expect(field).toHaveValue(40);
+  });
+
+  // `type="number"` accepts decimal and exponent text, so a value can arrive
+  // whole — pasted, or restored by the browser — without passing through the
+  // intermediate whole-number states that typing produces. That single arrival
+  // is where a `parseInt` reading would commit a number the box never showed.
+  //
+  // Only the decimal half of that is testable here. Exponent text ("1e2", which
+  // `parseInt` reads as 1 and the box means as 100) would be the other half, but
+  // happy-dom normalizes a pasted "1e2" to the literal "100", so `parseInt`
+  // reaches the same answer and the test would stay green against the very bug
+  // it claimed to catch. Browsers only blank *invalid* input, leaving "1e2"
+  // standing, so the divergence is real in production and unobservable here.
+  it("rejects a pasted decimal instead of committing its integer part", async () => {
+    const user = userEvent.setup();
+    const onCommit = vi.fn();
+    render(<Harness initial={40} onCommit={onCommit} />);
+
+    const field = screen.getByLabelText("Starting Life");
+    await user.clear(field);
+    await user.click(field);
+    await user.paste("20.5");
+
+    // `parseInt("20.5")` is 20 — committing that silently disagrees with the
+    // 20.5 the box is showing. Nothing whole was ever entered, so nothing is
+    // committed and the previous value stands.
+    expect(onCommit).not.toHaveBeenCalled();
+    expect(field).toHaveValue(20.5);
+  });
+
+  it("does not commit a reading below min", async () => {
+    const user = userEvent.setup();
+    const onCommit = vi.fn();
+    render(<Harness initial={40} min={10} onCommit={onCommit} />);
+
+    const field = screen.getByLabelText("Starting Life");
+    await user.clear(field);
+    await user.type(field, "5");
+
+    expect(onCommit).not.toHaveBeenCalled();
+  });
+});

--- a/client/src/pages/GamePage.tsx
+++ b/client/src/pages/GamePage.tsx
@@ -2899,7 +2899,14 @@ function GameOverScreen({
     params.delete("roomName");
     if (mode) params.set("mode", mode);
     params.set("difficulty", difficulty);
-    navigate(`/game/${newId}?${params.toString()}`);
+    // `format` names the format but carries none of its edited knobs, and the
+    // saved active-game record is keyed to the game id we are leaving — so a
+    // custom starting life would revert to the format default here. Hand over
+    // the config the engine actually played with, on the same router-state
+    // channel `GameSetupPage` uses to start a game.
+    navigate(`/game/${newId}?${params.toString()}`, {
+      state: { formatConfig: gameState?.format_config },
+    });
   };
 
   const handleBackToDraft = () => {

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -14,6 +14,7 @@ import { cleanup, render, screen, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { MemoryRouter, Route, Routes } from "react-router";
+import { MotionGlobalConfig } from "framer-motion";
 
 import { GamePage } from "../GamePage";
 import type { FormatConfig } from "../../adapter/types";
@@ -23,7 +24,10 @@ import { P2PHostAdapter } from "../../adapter/p2p-adapter";
 import { WebSocketAdapter } from "../../adapter/ws-adapter";
 import { usePreferencesStore } from "../../stores/preferencesStore";
 import { gameObjectFactory } from "../../test/factories/gameObjectFactory";
-import { gameStateFactory } from "../../test/factories/gameStateFactory";
+import {
+  buildCommanderFormatConfig,
+  gameStateFactory,
+} from "../../test/factories/gameStateFactory";
 
 // ── Hoisted variables (must be declared before vi.mock hoisting) ─────────────
 
@@ -1005,5 +1009,46 @@ describe("GamePage — bound whole-match concession", () => {
     expect(matchAction?.onConfirm).toBeTypeOf("function");
     act(() => matchAction?.onConfirm());
     expect(sendMatchConcede).toHaveBeenCalledOnce();
+  });
+});
+
+/**
+ * A rematch starts a NEW game id from the game-over screen. The URL it carries
+ * over names the format but holds none of its edited knobs, and the saved
+ * active-game record is keyed to the id being left — so the config has to be
+ * handed over explicitly or a custom starting life silently reverts to the
+ * format default.
+ */
+describe("GamePage — rematch preserves the format the game was played with", () => {
+  // The rematch button is gated on `onAnimationComplete` of the game-over
+  // title's spring, which never settles under happy-dom's rAF. `skipAnimations`
+  // is framer-motion's own switch for exactly this — animations jump to their
+  // end state and fire their completion callbacks — so the gate is satisfied
+  // the way the library intends rather than by mocking `motion` away. Scoped
+  // to this block so the suite's other renders keep real motion behaviour.
+  beforeEach(() => {
+    MotionGlobalConfig.skipAnimations = true;
+  });
+  afterEach(() => {
+    MotionGlobalConfig.skipAnimations = false;
+  });
+
+  it("hands the engine's own format config to the new game", async () => {
+    const user = userEvent.setup();
+    // A Commander game played at 25 life rather than the format's 40.
+    storeOverrides.gameState = gameStateFactory.withPlayers(0, 1).build({
+      format_config: buildCommanderFormatConfig({ starting_life: 25 }),
+    });
+    storeOverrides.waitingFor = { type: "GameOver", data: { winner: 0 } };
+
+    renderGamePage("/game/old-game-id?mode=ai&format=Commander");
+
+    await user.click(await screen.findByRole("button", { name: "Rematch" }));
+
+    // Asserted at the engine boundary: this is the config GameProvider would
+    // build the rematch with, not merely what was stashed on the navigation.
+    // `FORMAT_DEFAULTS` is a Proxy in this suite, so a lost hand-over surfaces
+    // as `undefined` here rather than as the real 40.
+    expect(capturedFormatConfig?.starting_life).toBe(25);
   });
 });


### PR DESCRIPTION
Two gaps in the starting-life hand-over, both found in review.

`IntegerField` read its box with `parseInt`, which commits only the leading
numeric run of the text. `type="number"` accepts decimal and exponent input,
so a value arriving whole — pasted, or restored by the browser — committed a
number the box never showed ("20.5" became 20). The reading now comes from
the field's own `valueAsNumber` and is rejected unless it is a whole number at
or above `min`, which is the reject-don't-coerce rule the component already
documented.

`handleRematch` carried the launch URL over to the new game id, but `format`
names a format without any of its edited knobs, and the saved active-game
record is keyed to the game being left. A Commander game played at 25 life
therefore restarted at 40. The rematch now hands over the config the engine
actually played with, read from `GameState.format_config`, on the same
router-state channel `GameSetupPage` starts a game through.

Both fixes are pinned by tests that were checked against the unfixed code.
The exponent-form half of the `parseInt` defect is deliberately untested:
happy-dom normalizes a pasted "1e2" to the literal "100", so `parseInt`
reaches the same answer and the test would stay green against the very bug it
claimed to catch.

Claude-Session: https://claude.ai/code/session_01BESCymTdnuA4f77dtpxHtz


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Integer inputs now commit only valid whole numbers at or above the minimum, preventing decimals, invalid values, and below-minimum entries from overwriting the last committed value.
  * Rematches now preserve customized game format settings, including starting life, instead of reverting to defaults.

* **Tests**
  * Added coverage for integer input behavior and preservation of customized settings during rematches.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->