### PR TITLE
docs(engine): cite CR 609.3 for a sacrifice set that lost a member

### DIFF
--- a/crates/engine/src/database/synthesis.rs
+++ b/crates/engine/src/database/synthesis.rs
@@ -18439,7 +18439,7 @@ mod idempotency_tests {
         }
     }
 
-    /// CR 608.2b + CR 111.7 (#8147): one mobilized token trades in combat before
+    /// CR 609.3 + CR 111.7 (#8147): one mobilized token trades in combat before
     /// the end step, so it has ceased to exist by the time the delayed
     /// "sacrifice them" fires. The delayed trigger snapshots BOTH token ids at
     /// creation and carries no incarnation pins, so `live_object_targets` still

--- a/crates/engine/src/game/effects/sacrifice.rs
+++ b/crates/engine/src/game/effects/sacrifice.rs
@@ -389,14 +389,18 @@ pub fn resolve(
 
     let mut selections = Vec::new();
     for obj_id in targeted_objects {
-        // CR 608.2b + CR 111.7: a snapshotted member that no longer exists is a
-        // normal outcome, not an error — a token that left the battlefield
-        // ceases to exist, so a delayed "sacrifice them" whose set lost a member
-        // in the meantime must still sacrifice the survivors ("does as much as
-        // it can"). Erroring here aborted the WHOLE effect on the first missing
-        // id, which is how a Mobilize pair that traded one Warrior in combat
-        // left the other on the battlefield forever (#8147). Skipping matches
-        // the emblem / wrong-zone / wrong-controller guards immediately below.
+        // CR 609.3 / CR 608.2b + CR 111.7: a member of this set that no longer
+        // exists is a normal outcome, not an error. Which rule says so depends
+        // on the caller, and this resolver serves both: for a snapshotted,
+        // non-targeted set the effect "does only as much as possible"
+        // (CR 609.3), while for a genuinely targeted sacrifice the vanished
+        // object is simply an illegal target (CR 608.2b). Either way a token
+        // that left the battlefield has ceased to exist (CR 111.7), so a
+        // delayed "sacrifice them" whose set lost a member must still sacrifice
+        // the survivors. Erroring here aborted the WHOLE effect on the first
+        // missing id, which is how a Mobilize pair that traded one Warrior in
+        // combat left the other on the battlefield forever (#8147). Skipping
+        // matches the emblem / wrong-zone / wrong-controller guards below.
         let Some(obj) = state.objects.get(&obj_id) else {
             continue;
         };


### PR DESCRIPTION
Review follow-up to #8185. The comment on the missing-object `continue` in
`sacrifice::resolve` cited only CR 608.2b, which is target legality — the wrong
rule for the case it describes. The Mobilize path that motivated the fix
snapshots its token ids and does not target them, so what licenses sacrificing
the survivors is CR 609.3, "if an effect attempts to do something impossible,
it does only as much as possible".

CR 608.2b is kept rather than replaced. `targeted_objects` is built from
`ability.live_object_targets(state)` / `ability.targets`, so the same `continue`
also covers genuinely targeted sacrifices, and for those a vanished object is
an illegal target — exactly CR 608.2b. Dropping it would leave those callers
citing a rule no longer present. The two are alternatives, so they are joined
with `/` per the annotation format, with CR 111.7 retained for token cessation.

All three numbers grep-verified against docs/MagicCompRules.txt. Comment-only:
no executable line changes.

Claude-Session: https://claude.ai/code/session_01BESCymTdnuA4f77dtpxHtz
