### PR TITLE
feat: operator status message on the menu and multiplayer screens

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,10 @@ client/public/decks.json
 client/public/decks-skipped.json
 client/public/draft-pools.json
 client/public/parser-warning-patterns.json
+# Local operator status message, written by scripts/publish-status.sh
+# --channel local so the maintainer can preview the banner in `pnpm dev`. It is
+# a throwaway test payload — the real object is published to R2 out of band.
+client/public/status.json
 # Atomic-write staging files from gen-card-data.sh (cleaned on normal exit,
 # but may linger after SIGKILL / power loss).
 client/public/*.tmp

--- a/client/src/components/chrome/AppShell.tsx
+++ b/client/src/components/chrome/AppShell.tsx
@@ -1,5 +1,5 @@
 import { Suspense, useState } from "react";
-import { Link, Outlet } from "react-router";
+import { Link, Outlet, useLocation } from "react-router";
 import { useTranslation } from "react-i18next";
 
 import { useChangelog } from "../../hooks/useChangelog";
@@ -11,6 +11,7 @@ import { ChromeControls } from "./ChromeControls";
 import { Rail } from "./Rail";
 import { DraftShellChromeProvider, ShellProvider, type DraftShellChromeConfig } from "./ShellContext";
 import { SocialBar } from "./SocialBar";
+import { StatusBanner } from "./StatusBanner";
 import { TabBar } from "./TabBar";
 import { HomeIcon } from "./navIcons";
 
@@ -39,6 +40,14 @@ export function AppShell() {
     ? "deckbuilding"
     : "drafting";
   const changelog = useChangelog();
+  // The operator status banner targets exactly the landing surface and the
+  // online lobby, so the shell owns the route gate rather than the (propless)
+  // banner: keeping it here means the banner's fetch + poll never start on any
+  // other shell route. The gate is also load-bearing for layout — the deck
+  // builder shell is sized with a hard calc(100dvh - …) that a block-level
+  // banner would silently overflow — so widening it is not free.
+  const { pathname } = useLocation();
+  const showStatusBanner = pathname === "/" || pathname === "/multiplayer";
   const openWhatsNew = () => {
     setWhatsNewOpen(true);
     changelog.openAndLoad();
@@ -129,6 +138,10 @@ export function AppShell() {
             {/* Inner Suspense so a lazy route's load swaps ONLY the content area —
                 the rail/scene persist (true SPA feel). */}
             <main className={`shell-content min-h-0 min-w-0 flex-1 ${responsiveDraftChrome ? "overflow-hidden" : "max-[820px]:pb-[76px]"}`}>
+              {/* Above the Suspense boundary, not inside it: a banner mounted
+                  inside would be swapped out for the route spinner on every
+                  lazy-chunk load and blink away on each navigation. */}
+              {showStatusBanner && <StatusBanner />}
               <Suspense
                 fallback={
                   <div className="flex min-h-full items-center justify-center py-24">

--- a/client/src/components/chrome/StatusBanner.tsx
+++ b/client/src/components/chrome/StatusBanner.tsx
@@ -1,0 +1,114 @@
+import { useTranslation } from "react-i18next";
+
+import { useStatusMessage } from "../../hooks/useStatusMessage";
+import { openExternal } from "../../services/openExternal";
+import type { StatusSeverity } from "../../services/status";
+import { usePreferencesStore } from "../../stores/preferencesStore";
+
+/**
+ * Severity → visual tone, ARIA role, and eyebrow key. `critical` is the only
+ * severity that interrupts a screen reader (`alert`); info/warning announce
+ * politely, matching `DeckLegalityChip`'s split between a legality result and a
+ * legality failure. The class strings are literals so Tailwind's source scan
+ * sees them.
+ */
+const TONE = {
+  info: {
+    box: "border-sky-400/20 bg-sky-500/[0.07]",
+    text: "text-sky-200",
+    subtle: "text-sky-200/80",
+    role: "status",
+    dismiss: "text-sky-200/70 hover:text-sky-200",
+    eyebrow: "chrome.statusBanner.severity.info",
+  },
+  warning: {
+    box: "border-amber-400/25 bg-amber-500/[0.08]",
+    text: "text-amber-200",
+    subtle: "text-amber-200/80",
+    role: "status",
+    dismiss: "text-amber-200/70 hover:text-amber-200",
+    eyebrow: "chrome.statusBanner.severity.warning",
+  },
+  critical: {
+    box: "border-rose-400/20 bg-rose-500/[0.07]",
+    text: "text-rose-200",
+    subtle: "text-rose-200/80",
+    role: "alert",
+    dismiss: "text-rose-200/70 hover:text-rose-200",
+    eyebrow: "chrome.statusBanner.severity.critical",
+  },
+} as const satisfies Record<
+  StatusSeverity,
+  {
+    box: string;
+    text: string;
+    subtle: string;
+    dismiss: string;
+    role: "status" | "alert";
+    eyebrow: string;
+  }
+>;
+
+/**
+ * The operator status banner — an out-of-band message from the maintainer
+ * (outage, maintenance window, known issue) shown above the page content.
+ *
+ * Propless and self-sourcing (the `PodErrorBanner` convention): it owns the
+ * fetch/poll/expiry/dismissal logic via `useStatusMessage` and renders nothing
+ * when there is nothing live to show. WHERE it appears is the shell's decision,
+ * not this component's — `AppShell` gates the mount to the two surfaces the
+ * message targets.
+ *
+ * The author's text is shown verbatim in every locale (only the chrome — the
+ * eyebrow and the dismiss label — is translated), and `body` renders as TEXT,
+ * never HTML.
+ */
+export function StatusBanner() {
+  const { t } = useTranslation();
+  const message = useStatusMessage();
+  const setDismissedStatusId = usePreferencesStore((s) => s.setDismissedStatusId);
+
+  if (!message) return null;
+
+  const tone = TONE[message.severity];
+  const link = message.link;
+
+  return (
+    <div className="px-2 pt-2 min-[820px]:px-4 min-[820px]:pt-3">
+      <div
+        role={tone.role}
+        className={`mx-auto flex w-full max-w-3xl items-start gap-3 rounded-[10px] border px-4 py-2.5 shadow-[0_8px_22px_rgba(0,0,0,0.18)] backdrop-blur-sm ${tone.box}`}
+      >
+        <div className="flex min-w-0 flex-1 flex-col">
+          <span className={`text-[10px] font-semibold uppercase tracking-wide ${tone.subtle}`}>
+            {t(tone.eyebrow)}
+          </span>
+          <span className={`text-xs font-medium ${tone.text}`}>{message.title}</span>
+          <p className={`mt-1 text-[11px] leading-5 ${tone.subtle}`}>{message.body}</p>
+          {link && (
+            // A button, not an <a>: the desktop webview opens nothing from a
+            // bare target="_blank", and openExternal is the single URL authority
+            // that rejects a non-http(s) href from a published payload.
+            <button
+              type="button"
+              onClick={() => openExternal(link.url)}
+              className={`mt-1 self-start text-[11px] font-medium underline underline-offset-2 ${tone.text}`}
+            >
+              {link.label}
+            </button>
+          )}
+        </div>
+        {message.dismissible && (
+          <button
+            type="button"
+            onClick={() => setDismissedStatusId(message.id)}
+            aria-label={t("chrome.statusBanner.dismiss")}
+            className={`min-h-11 min-w-11 shrink-0 text-lg leading-none transition-colors ${tone.dismiss}`}
+          >
+            &times;
+          </button>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/chrome/__tests__/StatusBanner.test.tsx
+++ b/client/src/components/chrome/__tests__/StatusBanner.test.tsx
@@ -1,0 +1,128 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { StatusBanner } from "../StatusBanner";
+import { fetchStatus, type StatusMessage } from "../../../services/status";
+import { openExternal } from "../../../services/openExternal";
+import { usePreferencesStore } from "../../../stores/preferencesStore";
+
+// The banner is propless — it sources its message through the hook — so the
+// service is the only injection point a test has. Everything else (the expiry
+// predicate, the validator) stays real.
+vi.mock("../../../services/status", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../../services/status")>()),
+  fetchStatus: vi.fn(),
+}));
+
+// The link must route through openExternal, which is both the Tauri-webview
+// opener and the http/https guard against a javascript: URL in a published
+// payload. Mocking it is what lets the test assert the routing rather than the
+// markup.
+vi.mock("../../../services/openExternal", () => ({ openExternal: vi.fn() }));
+
+const BASE: StatusMessage = {
+  id: 1756482000000,
+  severity: "info",
+  title: "Multiplayer maintenance",
+  body: "The lobby restarts at 20:00 UTC.",
+  dismissible: true,
+};
+
+function publish(message: StatusMessage | null) {
+  vi.mocked(fetchStatus).mockResolvedValue(message);
+}
+
+beforeEach(() => {
+  localStorage.clear();
+  usePreferencesStore.setState({ dismissedStatusId: undefined });
+  publish(BASE);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+describe("StatusBanner", () => {
+  it("leaves the dismissal watermark unset by default", () => {
+    // getInitialState(), not getState(): the beforeEach above writes its own
+    // snapshot, which would make a getState() read vacuous.
+    expect(usePreferencesStore.getInitialState().dismissedStatusId).toBeUndefined();
+  });
+
+  it.each([
+    ["info", "status", "Notice"],
+    ["warning", "status", "Heads up"],
+    ["critical", "alert", "Important"],
+  ] as const)("announces a %s message as role=%s", async (severity, role, eyebrow) => {
+    publish({ ...BASE, severity });
+    render(<StatusBanner />);
+
+    const banner = await screen.findByRole(role);
+    expect(banner).toHaveTextContent(eyebrow);
+    expect(banner).toHaveTextContent("Multiplayer maintenance");
+    expect(banner).toHaveTextContent("The lobby restarts at 20:00 UTC.");
+  });
+
+  it("hides the banner and records the id when the message is dismissed", async () => {
+    const user = userEvent.setup();
+    render(<StatusBanner />);
+
+    await user.click(await screen.findByRole("button", { name: "Dismiss this message" }));
+
+    await waitFor(() => expect(screen.queryByRole("status")).not.toBeInTheDocument());
+    expect(usePreferencesStore.getState().dismissedStatusId).toBe(BASE.id);
+  });
+
+  it("offers no dismiss affordance when the author marked the message undismissible", async () => {
+    publish({ ...BASE, dismissible: false });
+    render(<StatusBanner />);
+
+    await screen.findByRole("status");
+    expect(screen.queryByRole("button", { name: "Dismiss this message" })).not.toBeInTheDocument();
+  });
+
+  it("stays hidden for a message the player already dismissed", async () => {
+    usePreferencesStore.setState({ dismissedStatusId: BASE.id });
+    render(<StatusBanner />);
+
+    await waitFor(() => expect(fetchStatus).toHaveBeenCalled());
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("re-shows when a newer message is published after a dismissal", async () => {
+    usePreferencesStore.setState({ dismissedStatusId: BASE.id });
+    publish({ ...BASE, id: BASE.id + 1, title: "Lobby is back" });
+    render(<StatusBanner />);
+
+    expect(await screen.findByRole("status")).toHaveTextContent("Lobby is back");
+  });
+
+  it("renders nothing once the message has expired", async () => {
+    publish({ ...BASE, expiresAt: new Date(Date.now() - 60_000).toISOString() });
+    render(<StatusBanner />);
+
+    await waitFor(() => expect(fetchStatus).toHaveBeenCalled());
+    expect(screen.queryByRole("status")).not.toBeInTheDocument();
+  });
+
+  it("opens an optional link through openExternal", async () => {
+    publish({
+      ...BASE,
+      link: { url: "https://discord.gg/example", label: "Details on Discord" },
+    });
+    render(<StatusBanner />);
+
+    await userEvent.click(await screen.findByRole("button", { name: "Details on Discord" }));
+    expect(openExternal).toHaveBeenCalledWith("https://discord.gg/example");
+  });
+
+  it("renders no link affordance when the message carries none", async () => {
+    publish(BASE);
+    render(<StatusBanner />);
+
+    await screen.findByRole("status");
+    expect(screen.queryByRole("button", { name: "Details on Discord" })).not.toBeInTheDocument();
+  });
+});

--- a/client/src/hooks/__tests__/useStatusMessage.test.ts
+++ b/client/src/hooks/__tests__/useStatusMessage.test.ts
@@ -1,0 +1,150 @@
+import { act, cleanup, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useStatusMessage } from "../useStatusMessage";
+import { fetchStatus, type StatusMessage } from "../../services/status";
+import { usePreferencesStore } from "../../stores/preferencesStore";
+
+vi.mock("../../services/status", async (importOriginal) => ({
+  ...(await importOriginal<typeof import("../../services/status")>()),
+  fetchStatus: vi.fn(),
+}));
+
+const BASE: StatusMessage = {
+  id: 1756482000000,
+  severity: "warning",
+  title: "Multiplayer maintenance",
+  body: "The lobby restarts at 20:00 UTC.",
+  dismissible: true,
+};
+
+// happy-dom exposes `visibilityState` as a getter, so vi.stubGlobal cannot
+// replace it — redefine the property and drive it through this variable. There
+// is no in-repo precedent for this: every production read is read-only.
+let visibility: DocumentVisibilityState = "visible";
+Object.defineProperty(document, "visibilityState", {
+  configurable: true,
+  get: () => visibility,
+});
+
+function setVisibility(next: DocumentVisibilityState) {
+  visibility = next;
+  document.dispatchEvent(new Event("visibilitychange"));
+}
+
+/** Let the mocked fetch's promise chain settle inside act(). */
+async function settle() {
+  await act(async () => {
+    await Promise.resolve();
+  });
+}
+
+async function advance(ms: number) {
+  await act(async () => {
+    vi.advanceTimersByTime(ms);
+  });
+  await settle();
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  visibility = "visible";
+  localStorage.clear();
+  usePreferencesStore.setState({ dismissedStatusId: undefined });
+  vi.mocked(fetchStatus).mockResolvedValue(BASE);
+});
+
+afterEach(() => {
+  cleanup();
+  vi.useRealTimers();
+  vi.clearAllMocks();
+});
+
+describe("useStatusMessage", () => {
+  it("fetches on mount and re-polls once a minute while the tab is visible", async () => {
+    const { result } = renderHook(() => useStatusMessage());
+    await settle();
+
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual(BASE);
+
+    await advance(60_000);
+    expect(fetchStatus).toHaveBeenCalledTimes(2);
+
+    await advance(60_000);
+    expect(fetchStatus).toHaveBeenCalledTimes(3);
+  });
+
+  it("never polls while the tab is hidden", async () => {
+    visibility = "hidden";
+    renderHook(() => useStatusMessage());
+    await settle();
+
+    expect(fetchStatus).not.toHaveBeenCalled();
+
+    await advance(180_000);
+    expect(fetchStatus).not.toHaveBeenCalled();
+  });
+
+  it("catches up as soon as a hidden tab becomes visible again", async () => {
+    visibility = "hidden";
+    const { result } = renderHook(() => useStatusMessage());
+    await settle();
+    await advance(120_000);
+    expect(fetchStatus).not.toHaveBeenCalled();
+
+    await act(async () => {
+      setVisibility("visible");
+    });
+    await settle();
+
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+    expect(result.current).toEqual(BASE);
+  });
+
+  it("clears both the interval and the visibilitychange listener on unmount", async () => {
+    const { unmount } = renderHook(() => useStatusMessage());
+    await settle();
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+
+    unmount();
+
+    await advance(180_000);
+    await act(async () => {
+      setVisibility("hidden");
+      setVisibility("visible");
+    });
+    await settle();
+
+    // Still 1: a leaked interval or listener would have polled again.
+    expect(fetchStatus).toHaveBeenCalledTimes(1);
+  });
+
+  it("drops an expired message on the next tick even when the payload is unchanged", async () => {
+    // Inside the max-age=60 freshness window a poll is served from the HTTP
+    // cache and returns a byte-identical payload, so expiry must be re-checked
+    // against a fresh clock rather than memoized on payload identity.
+    const message: StatusMessage = {
+      ...BASE,
+      expiresAt: new Date(Date.now() + 30_000).toISOString(),
+    };
+    vi.mocked(fetchStatus).mockResolvedValue(message);
+
+    const { result } = renderHook(() => useStatusMessage());
+    await settle();
+    expect(result.current).toEqual(message);
+
+    await advance(60_000);
+
+    expect(fetchStatus).toHaveBeenCalledTimes(2);
+    expect(result.current).toBeNull();
+  });
+
+  it("suppresses a message the player has already dismissed", async () => {
+    usePreferencesStore.setState({ dismissedStatusId: BASE.id });
+    const { result } = renderHook(() => useStatusMessage());
+    await settle();
+
+    expect(result.current).toBeNull();
+  });
+});

--- a/client/src/hooks/useStatusMessage.ts
+++ b/client/src/hooks/useStatusMessage.ts
@@ -1,0 +1,60 @@
+import { useEffect, useState } from "react";
+
+import { fetchStatus, isStatusLive, type StatusMessage } from "../services/status";
+import { usePreferencesStore } from "../stores/preferencesStore";
+
+/** Poll cadence. The object is served with `max-age=60`, so a 60s poll bounds
+ * how long a newly published (or cleared) message stays invisible at roughly two
+ * minutes — poll and TTL drift independently — at negligible cost for a ~300
+ * byte object. Polls are suppressed entirely while the tab is hidden. */
+const POLL_INTERVAL_MS = 60_000;
+
+/**
+ * Drives the operator status banner: the currently renderable message, or null.
+ *
+ * Null covers every "show nothing" case uniformly — nothing published, the
+ * fetch failed, the message expired, or this player dismissed this exact id.
+ *
+ * Expiry is re-evaluated against a FRESH clock on every tick rather than only
+ * when the payload changes: inside the `max-age=60` freshness window a poll is
+ * served straight from the HTTP cache and returns a byte-identical payload, so
+ * payload-identity memoization would leave an expired message on screen forever
+ * in a tab left open.
+ */
+export function useStatusMessage(): StatusMessage | null {
+  // Selector, not getState(): the store write from the dismiss button must
+  // re-render this hook's consumer, otherwise the banner would not hide.
+  const dismissedId = usePreferencesStore((s) => s.dismissedStatusId);
+  const [message, setMessage] = useState<StatusMessage | null>(null);
+  // Re-stamped on every completed poll — this is what re-evaluates expiry.
+  const [checkedAt, setCheckedAt] = useState(() => Date.now());
+
+  useEffect(() => {
+    let active = true;
+    const poll = () => {
+      // A hidden tab has no one to show the banner to; skip the round trip.
+      if (document.visibilityState !== "visible") return;
+      void fetchStatus().then((next) => {
+        if (!active) return;
+        setMessage(next);
+        setCheckedAt(Date.now());
+      });
+    };
+
+    poll();
+    const timer = setInterval(poll, POLL_INTERVAL_MS);
+    // Doubles as the catch-up fetch: a tab that was hidden across one or more
+    // suppressed ticks refreshes the moment it comes back.
+    document.addEventListener("visibilitychange", poll);
+    return () => {
+      active = false;
+      clearInterval(timer);
+      document.removeEventListener("visibilitychange", poll);
+    };
+  }, []);
+
+  if (!message) return null;
+  // Equality, not >=: a NEW id after a dismissal re-shows the banner.
+  if (message.id === dismissedId) return null;
+  return isStatusLive(message, checkedAt) ? message : null;
+}

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -295,7 +295,15 @@
     "back": "Zurück",
     "settings": "Einstellungen",
     "languageSettings": "Sprache ({{lang}}) — Einstellungen öffnen",
-    "languageTitle": "Sprache: {{lang}}"
+    "languageTitle": "Sprache: {{lang}}",
+    "statusBanner": {
+      "dismiss": "Diese Meldung schließen",
+      "severity": {
+        "info": "Hinweis",
+        "warning": "Achtung",
+        "critical": "Wichtig"
+      }
+    }
   },
   "errorBoundary": {
     "heading": "Etwas ist schiefgelaufen",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -295,7 +295,15 @@
     "back": "Back",
     "settings": "Settings",
     "languageSettings": "Language ({{lang}}) — open settings",
-    "languageTitle": "Language: {{lang}}"
+    "languageTitle": "Language: {{lang}}",
+    "statusBanner": {
+      "dismiss": "Dismiss this message",
+      "severity": {
+        "info": "Notice",
+        "warning": "Heads up",
+        "critical": "Important"
+      }
+    }
   },
   "errorBoundary": {
     "heading": "Something went wrong",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -295,7 +295,15 @@
     "back": "Atrás",
     "settings": "Ajustes",
     "languageSettings": "Idioma ({{lang}}) — abrir ajustes",
-    "languageTitle": "Idioma: {{lang}}"
+    "languageTitle": "Idioma: {{lang}}",
+    "statusBanner": {
+      "dismiss": "Descartar este mensaje",
+      "severity": {
+        "info": "Aviso",
+        "warning": "Atención",
+        "critical": "Importante"
+      }
+    }
   },
   "errorBoundary": {
     "heading": "Algo salió mal",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -295,7 +295,15 @@
     "back": "Retour",
     "settings": "Paramètres",
     "languageSettings": "Langue ({{lang}}) — ouvrir les paramètres",
-    "languageTitle": "Langue : {{lang}}"
+    "languageTitle": "Langue : {{lang}}",
+    "statusBanner": {
+      "dismiss": "Ignorer ce message",
+      "severity": {
+        "info": "Information",
+        "warning": "Attention",
+        "critical": "Important"
+      }
+    }
   },
   "errorBoundary": {
     "heading": "Une erreur est survenue",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -295,7 +295,15 @@
     "back": "Indietro",
     "settings": "Impostazioni",
     "languageSettings": "Lingua ({{lang}}) — apri impostazioni",
-    "languageTitle": "Lingua: {{lang}}"
+    "languageTitle": "Lingua: {{lang}}",
+    "statusBanner": {
+      "dismiss": "Ignora questo messaggio",
+      "severity": {
+        "info": "Avviso",
+        "warning": "Attenzione",
+        "critical": "Importante"
+      }
+    }
   },
   "errorBoundary": {
     "heading": "Qualcosa è andato storto",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -295,7 +295,15 @@
     "back": "Wstecz",
     "settings": "Ustawienia",
     "languageSettings": "Język ({{lang}}) — otwórz ustawienia",
-    "languageTitle": "Język: {{lang}}"
+    "languageTitle": "Język: {{lang}}",
+    "statusBanner": {
+      "dismiss": "Zamknij tę wiadomość",
+      "severity": {
+        "info": "Informacja",
+        "warning": "Uwaga",
+        "critical": "Ważne"
+      }
+    }
   },
   "errorBoundary": {
     "heading": "Coś poszło nie tak",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -295,7 +295,15 @@
     "back": "Voltar",
     "settings": "Configurações",
     "languageSettings": "Idioma ({{lang}}) — abrir configurações",
-    "languageTitle": "Idioma: {{lang}}"
+    "languageTitle": "Idioma: {{lang}}",
+    "statusBanner": {
+      "dismiss": "Dispensar esta mensagem",
+      "severity": {
+        "info": "Aviso",
+        "warning": "Atenção",
+        "critical": "Importante"
+      }
+    }
   },
   "errorBoundary": {
     "heading": "Algo deu errado",

--- a/client/src/services/__tests__/status.test.ts
+++ b/client/src/services/__tests__/status.test.ts
@@ -1,0 +1,103 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+import { fetchStatus, isStatusLive, type StatusMessage } from "../status";
+
+/** A payload that satisfies every field of the contract. Each rejection case
+ * below overrides exactly ONE field of this object, so a `null` result is
+ * attributable to that field and not to an accidentally-broken baseline. */
+const VALID = {
+  id: 1756482000000,
+  severity: "warning",
+  title: "Multiplayer maintenance",
+  body: "The lobby restarts at 20:00 UTC. Games in progress are unaffected.",
+  dismissible: true,
+};
+
+function mockFetch(response: Partial<Response> & { json?: () => Promise<unknown> }) {
+  vi.stubGlobal("fetch", vi.fn(() => Promise.resolve(response as Response)));
+}
+
+function mockPayload(payload: unknown) {
+  mockFetch({ ok: true, json: () => Promise.resolve(payload) });
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals();
+});
+
+describe("fetchStatus", () => {
+  it("returns the published message when the payload satisfies the contract", async () => {
+    mockPayload(VALID);
+    expect(await fetchStatus()).toEqual(VALID);
+  });
+
+  it("keeps the optional expiresAt and link fields", async () => {
+    const full = {
+      ...VALID,
+      expiresAt: "2026-08-30T21:00:00Z",
+      link: { url: "https://discord.gg/example", label: "Details on Discord" },
+    };
+    mockPayload(full);
+    expect(await fetchStatus()).toEqual(full);
+  });
+
+  it("resolves to null when nothing is published (404)", async () => {
+    mockFetch({ ok: false, status: 404 });
+    expect(await fetchStatus()).toBeNull();
+  });
+
+  it("resolves to null when the network rejects", async () => {
+    vi.stubGlobal("fetch", vi.fn(() => Promise.reject(new Error("offline"))));
+    expect(await fetchStatus()).toBeNull();
+  });
+
+  it("resolves to null on malformed JSON", async () => {
+    mockFetch({ ok: true, json: () => Promise.reject(new SyntaxError("Unexpected token")) });
+    expect(await fetchStatus()).toBeNull();
+  });
+
+  // One uniform rule: any contract violation means the payload is not a
+  // StatusMessage, so there is nothing to render. No field is ever dropped and
+  // the rest rendered.
+  const violations: Array<[string, unknown]> = [
+    ["an unknown severity", { ...VALID, severity: "urgent" }],
+    ["a missing title", { ...VALID, title: undefined }],
+    ["an empty title", { ...VALID, title: "" }],
+    ["a whitespace-only title", { ...VALID, title: "   " }],
+    // The load-bearing one: React throws on a non-string child, and the app's
+    // <ErrorBoundary> wraps the whole <Routes> tree — one bad field here would
+    // otherwise blank the entire app on / and /multiplayer.
+    ["a non-string body", { ...VALID, body: { text: "oops" } }],
+    ["a non-number id", { ...VALID, id: "1756482000000" }],
+    ["a non-boolean dismissible", { ...VALID, dismissible: "false" }],
+    ["a link missing its url", { ...VALID, link: { label: "Details" } }],
+    ["a link missing its label", { ...VALID, link: { url: "https://example.com" } }],
+    ["a non-object link", { ...VALID, link: "https://example.com" }],
+    ["an unparseable expiresAt", { ...VALID, expiresAt: "tomorrow" }],
+    ["a non-object payload", "maintenance"],
+  ];
+
+  for (const [label, payload] of violations) {
+    it(`resolves to null for ${label}`, async () => {
+      mockPayload(payload);
+      expect(await fetchStatus()).toBeNull();
+    });
+  }
+});
+
+describe("isStatusLive", () => {
+  const now = Date.parse("2026-08-29T12:00:00Z");
+  const message = VALID as StatusMessage;
+
+  it("is false once expiresAt has passed", () => {
+    expect(isStatusLive({ ...message, expiresAt: "2026-08-29T11:59:00Z" }, now)).toBe(false);
+  });
+
+  it("is true while expiresAt is still in the future", () => {
+    expect(isStatusLive({ ...message, expiresAt: "2026-08-29T12:01:00Z" }, now)).toBe(true);
+  });
+
+  it("is true when no expiry was published", () => {
+    expect(isStatusLive(message, now)).toBe(true);
+  });
+});

--- a/client/src/services/status.ts
+++ b/client/src/services/status.ts
@@ -1,0 +1,112 @@
+/**
+ * Operator status message data access.
+ *
+ * A single, tiny JSON object the maintainer publishes out of band (never by a
+ * deploy) so an outage notice, a maintenance window, or a "the lobby is down"
+ * heads-up reaches every player without a release. It resolves through the
+ * build-time `__STATUS_URL__` define: the R2 prefix on deploy, the site-root
+ * path in local dev — matching every other data consumer.
+ *
+ * Unlike `changelog.ts` there is deliberately NO module-level session cache:
+ * the hook re-polls so a message published (or cleared) mid-session is picked
+ * up, and a cache would defeat that entirely.
+ */
+
+/**
+ * Closed set of severities, mirroring `ChangelogTag`'s closed-union discipline
+ * so the severity→tone/role lookup stays exhaustive and a stray value from a
+ * hand-authored payload is rejected rather than rendered untoned.
+ */
+export type StatusSeverity = "info" | "warning" | "critical";
+
+export interface StatusLink {
+  /** http(s) only — routed through `openExternal`, which re-validates. */
+  url: string;
+  label: string;
+}
+
+export interface StatusMessage {
+  /** Epoch ms at publish time. Compared for EQUALITY against the dismissal
+   * watermark, so every new publish re-shows even after a dismissal. */
+  id: number;
+  severity: StatusSeverity;
+  title: string;
+  /** Plain text — rendered as text, never HTML (same rule as `ChangelogEntry.body`). */
+  body: string;
+  /** Whether the author allows the player to dismiss this message. */
+  dismissible: boolean;
+  /** ISO 8601 instant after which the message stops rendering. Absent ⇒ shows
+   * until the maintainer clears it. */
+  expiresAt?: string;
+  /** Optional deep link (Discord post, status page, …). */
+  link?: StatusLink;
+}
+
+function isSeverity(value: unknown): value is StatusSeverity {
+  return value === "info" || value === "warning" || value === "critical";
+}
+
+function isStatusLink(value: unknown): boolean {
+  if (typeof value !== "object" || value === null) return false;
+  const link = value as Record<string, unknown>;
+  return typeof link.url === "string" && typeof link.label === "string";
+}
+
+/**
+ * ONE UNIFORM RULE: any contract violation means the payload is not a
+ * `StatusMessage`, so there is nothing to render and `fetchStatus` yields null.
+ * No per-field "drop the field and carry on" special cases.
+ *
+ * Every declared field is checked, not just the ones that drive the tone:
+ *  - a non-string `body` is the severe one — React THROWS on an object/array
+ *    child, and the nearest boundary is the `<ErrorBoundary>` wrapping the whole
+ *    `<Routes>` tree, so one bad field in hand-authored JSON would replace the
+ *    entire app with "Something went wrong".
+ *  - a string `id` would break the equality-compared dismissal watermark and be
+ *    handed to a `(id: number)` setter.
+ *  - a string `dismissible` ("false" is truthy) would render a dismiss button on
+ *    a message the operator marked undismissible.
+ *  - an unparseable `expiresAt` fails CLOSED (reject the message). Fail-open
+ *    would instead give a permanent banner clearable only by unpublishing.
+ */
+function isStatusMessage(value: unknown): value is StatusMessage {
+  if (typeof value !== "object" || value === null) return false;
+  const msg = value as Record<string, unknown>;
+  if (typeof msg.id !== "number") return false;
+  if (!isSeverity(msg.severity)) return false;
+  if (typeof msg.title !== "string" || msg.title.trim().length === 0) return false;
+  if (typeof msg.body !== "string") return false;
+  if (typeof msg.dismissible !== "boolean") return false;
+  if (msg.link !== undefined && !isStatusLink(msg.link)) return false;
+  if (
+    msg.expiresAt !== undefined &&
+    (typeof msg.expiresAt !== "string" || Number.isNaN(Date.parse(msg.expiresAt)))
+  ) {
+    return false;
+  }
+  return true;
+}
+
+/**
+ * Fetch the published status message. Resolves to null on ANY failure (404 —
+ * the normal "nothing published" state — offline, malformed JSON, or a contract
+ * violation) and never throws: a status banner is chrome, and no failure of it
+ * may surface to the player.
+ */
+export function fetchStatus(): Promise<StatusMessage | null> {
+  return fetch(__STATUS_URL__)
+    .then((res) => (res.ok ? (res.json() as Promise<unknown>) : null))
+    .then((data) => (isStatusMessage(data) ? data : null))
+    .catch(() => null);
+}
+
+/**
+ * Pure expiry predicate, evaluated against a caller-supplied clock so the
+ * polling hook can re-check a still-mounted message on every tick. A message
+ * with no `expiresAt` shows until the maintainer clears it. `expiresAt` is
+ * guaranteed parseable — {@link isStatusMessage} rejects anything else.
+ */
+export function isStatusLive(message: StatusMessage, now: number): boolean {
+  if (message.expiresAt === undefined) return true;
+  return Date.parse(message.expiresAt) > now;
+}

--- a/client/src/stores/preferencesStore.ts
+++ b/client/src/stores/preferencesStore.ts
@@ -294,6 +294,7 @@ function buildDefaultPreferences(): PreferencesState {
     battlefieldCardDisplay: "art_crop",
     collapsedFolderIds: [],
     lastSeenChangelogId: undefined,
+    dismissedStatusId: undefined,
     commandZoneDisplay: "auto",
     collapseLands: "auto",
     collapseSupport: "auto",
@@ -369,6 +370,10 @@ interface PreferencesState {
    * silently seeds it to the current latest so they get no unread dot for
    * entries that predate their first visit. */
   lastSeenChangelogId?: number;
+  /** Id of the operator status message this player dismissed. Compared for
+   * EQUALITY, so a newly published message (which always carries a new id)
+   * re-shows even after the previous one was dismissed. */
+  dismissedStatusId?: number;
   /** Command-zone layout mode (inline dock / compact pile / auto-by-viewport). */
   commandZoneDisplay: CommandZoneDisplay;
   /** Whether the lands sub-row collapses into its summary tile (auto/on/off). */
@@ -473,6 +478,7 @@ interface PreferencesActions {
   toggleFolderCollapsed: (id: string) => void;
   setCollapsedFolderIds: (ids: string[]) => void;
   setLastSeenChangelogId: (id: number) => void;
+  setDismissedStatusId: (id: number) => void;
   setCommandZoneDisplay: (display: CommandZoneDisplay) => void;
   setCollapseLands: (mode: ZoneCollapseMode) => void;
   setCollapseSupport: (mode: ZoneCollapseMode) => void;
@@ -635,6 +641,7 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
         })),
       setCollapsedFolderIds: (ids) => set({ collapsedFolderIds: ids }),
       setLastSeenChangelogId: (id) => set({ lastSeenChangelogId: id }),
+      setDismissedStatusId: (id) => set({ dismissedStatusId: id }),
       setCommandZoneDisplay: (display) => set({ commandZoneDisplay: display }),
       setCollapseLands: (mode) => set({ collapseLands: mode }),
       setCollapseSupport: (mode) => set({ collapseSupport: mode }),
@@ -804,7 +811,7 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
     }),
     {
       name: "phase-preferences",
-      version: 31,
+      version: 32,
       // v0 → v1: flat aiDifficulty + aiDeckName become aiSeats[0].
       // v1 → v2: discrete animationSpeed/combatPacing enums become numeric
       //          animationSpeedMultiplier/combatPacingMultiplier.
@@ -874,6 +881,9 @@ export const usePreferencesStore = create<PreferencesState & PreferencesActions>
       //          via the shallow merge.
       // v30 → v31: Add draftDoubleClickConfirmPick; legacy stores default to
       //          true via the shallow merge.
+      // v31 → v32: Add dismissedStatusId; legacy stores default to undefined
+      //          via the shallow merge, so no operator status message counts as
+      //          already dismissed for an existing user.
       migrate: (persisted: unknown, version: number) => {
         if (!persisted || typeof persisted !== "object") return persisted;
         let migrated = persisted as Record<string, unknown>;

--- a/client/src/vite-env.d.ts
+++ b/client/src/vite-env.d.ts
@@ -13,6 +13,7 @@ declare const __SCRYFALL_IMAGES_LOCALE_URL_TEMPLATE__: string;
 declare const __CARD_NAMES_URL__: string;
 declare const __CHANGELOG_URL__: string;
 declare const __CHANGELOG_META_URL__: string;
+declare const __STATUS_URL__: string;
 declare const __COVERAGE_DATA_URL__: string;
 declare const __COVERAGE_SUMMARY_URL__: string;
 declare const __CARD_DATA_META_URL__: string;

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -177,6 +177,14 @@ function dataFileDefines(mode: string): Record<string, string> {
     // compiles to a permanent no-op and nothing is ever sent anywhere.
     __TELEMETRY_URL__: JSON.stringify(process.env.TELEMETRY_URL || ""),
     __CARD_DATA_URL__: JSON.stringify(process.env.CARD_DATA_URL || "/card-data.json"),
+    // Operator status message. Deliberately NOT manifest-driven: the deploy
+    // workflow's upload loop reads data-files.json and (a) hard-errors when a
+    // listed file was not generated into client/public/, and (b) re-uploads
+    // whatever it finds on EVERY deploy — which would clobber a live status
+    // message the maintainer published out of band. It is published and cleared
+    // by scripts/publish-status.sh alone; no CI job ever touches the object.
+    // Same explicit, non-manifest shape as __CARD_DATA_URL__ above.
+    __STATUS_URL__: JSON.stringify(base ? `${base}/status.json` : "/status.json"),
     // Per-locale content-i18n sidecar URL template ({lng} replaced at runtime).
     // The sidecars are listed in data-files.json, so on deploy they are uploaded
     // to `${DATA_BASE_URL}/card-data.<lng>.json` and stripped from the Pages

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -68,6 +68,7 @@ export default defineConfig({
     __SCRYFALL_IMAGES_LOCALE_URL_TEMPLATE__: JSON.stringify("/scryfall-images.v2.{lng}.json"),
     __CHANGELOG_URL__: JSON.stringify("/changelog.json"),
     __CHANGELOG_META_URL__: JSON.stringify("/changelog-meta.json"),
+    __STATUS_URL__: JSON.stringify("/status.json"),
     __APP_VERSION__: JSON.stringify("0.0.0-test"),
     __BUILD_HASH__: JSON.stringify("testhash"),
     __ENGINE_WASM_URL__: "undefined",

--- a/scripts/publish-status.sh
+++ b/scripts/publish-status.sh
@@ -1,0 +1,316 @@
+#!/usr/bin/env bash
+#
+# Publish the operator status message consumed by `client/src/services/status.ts`.
+#
+# The payload is deliberately NOT part of any deploy: `data-files.json` (repo ROOT,
+# not client/public) drives the upload loop in BOTH `.github/workflows/deploy.yml`
+# (staging, on CI completion on main) and `release.yml` (production), and that loop
+# also hard-errors when a listed file is missing from client/public. A status message
+# routed through that manifest would therefore be silently clobbered on every deploy.
+# This script is the only writer.
+#
+set -euo pipefail
+
+# Anchor at the repo root: `client/public/status.json` and every
+# `(cd client && pnpm wrangler ...)` invocation below are repo-root-relative.
+cd "$(dirname "$0")/.."
+
+R2_BUCKET="phase-rs-data"
+PREVIEW_KEY="$R2_BUCKET/staging/status.json"
+RELEASE_KEY="$R2_BUCKET/status.json"
+LOCAL_FILE="client/public/status.json"
+CACHE_CONTROL="public, max-age=60, must-revalidate"
+
+usage() {
+  cat <<'EOF'
+Usage: scripts/publish-status.sh --severity <s> --title <t> --body <b> [options]
+       scripts/publish-status.sh --clear [--channel <c>] [--dry-run]
+
+Publishes the operator status banner shown on / and /multiplayer.
+
+Channels (--channel, default: local)
+  local     client/public/status.json          served by `pnpm dev` at /status.json
+  preview   phase-rs-data/staging/status.json  the PREVIEW site's data prefix
+  release   phase-rs-data/status.json          production
+  both      preview first, then release, with an identical payload and id
+
+  NOTE: `--channel preview` writes the "staging/" prefix, NOT the unrelated
+  "preview/" prefix that CI uses for per-PR preview data. "staging/" is what the
+  preview site's DATA_BASE_URL resolves to.
+
+Required for a publish
+  --severity info|warning|critical
+  --title <text>              One line. Whitespace-only is rejected.
+  --body <text>               ONE PARAGRAPH — the banner renders it in a <p>
+                              without whitespace-pre-line, so embedded newlines
+                              do not display as breaks.
+
+Options
+  --until <ISO 8601>          Expiry instant; must parse under JS Date.parse.
+                              Omitted => shows until cleared.
+  --link <url>                http:// or https:// only. Requires --link-label.
+  --link-label <text>         Requires --link.
+  --dismissible               Force a dismiss button.
+  --no-dismissible            Force no dismiss button.
+                              Default: true, except --severity critical => false.
+  --clear                     Remove the published message from the channel.
+                              Cannot be combined with any payload flag.
+  --dry-run                   Print what would happen; write nothing, call nothing.
+  -h, --help                  This text.
+
+Every publish mints a fresh epoch-ms `id`, and dismissal is compared by EQUALITY,
+so re-running re-shows the banner to every player who had already dismissed it.
+EOF
+}
+
+# Runtime failure: message only. Deliberately NOT `die` — a partial-channel
+# failure's recovery instruction is the most important line the operator will
+# read, and appending the ~39-line usage block would scroll it off screen.
+fail() {
+  echo "ERROR: $*" >&2
+  exit 1
+}
+
+die() {
+  echo "ERROR: $*" >&2
+  echo >&2
+  usage >&2
+  exit 1
+}
+
+CHANNEL="local"
+SEVERITY=""
+TITLE=""
+BODY=""
+UNTIL=""
+URL=""
+LABEL=""
+DISMISSIBLE=""
+CLEAR=false
+DRY_RUN=false
+
+while [ $# -gt 0 ]; do
+  case "$1" in
+    --channel) CHANNEL="${2:-}"; [ -n "$CHANNEL" ] || die "--channel requires a value"; shift 2 ;;
+    --severity) SEVERITY="${2:-}"; [ -n "$SEVERITY" ] || die "--severity requires a value"; shift 2 ;;
+    --title) TITLE="${2:-}"; [ -n "$TITLE" ] || die "--title requires a value"; shift 2 ;;
+    --body) BODY="${2:-}"; [ -n "$BODY" ] || die "--body requires a value"; shift 2 ;;
+    --until) UNTIL="${2:-}"; [ -n "$UNTIL" ] || die "--until requires a value"; shift 2 ;;
+    --link) URL="${2:-}"; [ -n "$URL" ] || die "--link requires a value"; shift 2 ;;
+    --link-label) LABEL="${2:-}"; [ -n "$LABEL" ] || die "--link-label requires a value"; shift 2 ;;
+    --dismissible) DISMISSIBLE=true; shift ;;
+    --no-dismissible) DISMISSIBLE=false; shift ;;
+    --clear) CLEAR=true; shift ;;
+    --dry-run) DRY_RUN=true; shift ;;
+    -h|--help) usage; exit 0 ;;
+    *) die "unknown flag '$1'" ;;
+  esac
+done
+
+case "$CHANNEL" in
+  local|preview|release|both) ;;
+  *) die "--channel must be one of local, preview, release, both (got '$CHANNEL')" ;;
+esac
+
+# --- Clear takes an early branch: it carries no payload to validate ------------
+
+clear_local() {
+  if [ "$DRY_RUN" = true ]; then
+    echo "rm -f $LOCAL_FILE"
+    return 0
+  fi
+  rm -f "$LOCAL_FILE"
+  echo "Cleared $LOCAL_FILE"
+}
+
+# `--remote` and `--force` are both load-bearing: without --remote the delete hits
+# the local emulator and the LIVE object survives, so the operator believes a stale
+# banner is gone while every player still sees it. --force skips the confirmation
+# prompt. Precedent: .github/workflows/preview-server.yml:431.
+clear_remote() {
+  local key="$1"
+  if [ "$DRY_RUN" = true ]; then
+    echo "(cd client && pnpm wrangler r2 object delete \"$key\" --remote --force)"
+    return 0
+  fi
+  (cd client && pnpm wrangler r2 object delete "$key" --remote --force) || return 1
+  # Mirror the publish path's read-back. --remote alone only proves we did not
+  # address the local emulator; it does not prove the live object is GONE, and a
+  # stale banner the operator believes they took down is the failure this whole
+  # script treats as worst. The get must now FAIL.
+  if (cd client && pnpm wrangler r2 object get "$key" --remote --pipe) >/dev/null 2>&1; then
+    echo "ERROR: $key still readable after delete; it was NOT cleared" >&2
+    return 1
+  fi
+  echo "Cleared $key"
+}
+
+if [ "$CLEAR" = true ]; then
+  [ -z "$SEVERITY$TITLE$BODY$UNTIL$URL$LABEL$DISMISSIBLE" ] ||
+    die "--clear cannot be combined with a payload flag"
+
+  case "$CHANNEL" in
+    local) clear_local ;;
+    preview) clear_remote "$PREVIEW_KEY" ;;
+    release) clear_remote "$RELEASE_KEY" ;;
+    both)
+      # Inverse of the publish order: for a takedown the failure that matters is
+      # the one that leaves PRODUCTION stale, so release goes first.
+      clear_remote "$RELEASE_KEY" ||
+        fail "release clear failed; nothing was cleared (preview NOT attempted)"
+      clear_remote "$PREVIEW_KEY" ||
+        fail "preview clear failed; cleared so far: release"
+      ;;
+  esac
+  exit 0
+fi
+
+# --- Validate the payload BEFORE any write or network call --------------------
+#
+# Every check below mirrors `fetchStatus`'s reject-the-whole-message rule: without
+# it an operator gets a well-formed file the client discards ENTIRELY — no banner
+# and no error anywhere.
+
+case "$SEVERITY" in
+  info|warning|critical) ;;
+  "") die "--severity is required (info, warning, or critical)" ;;
+  *) die "--severity must be one of info, warning, critical (got '$SEVERITY')" ;;
+esac
+
+[ -n "$TITLE" ] || die "--title is required"
+# The landed validator rejects via `title.trim().length === 0`, so a
+# whitespace-only title is the same silent-discard shape as an absent one.
+[ -n "${TITLE//[[:space:]]/}" ] || die "--title must not be whitespace-only"
+[ -n "$BODY" ] || die "--body is required"
+[ -n "${BODY//[[:space:]]/}" ] || die "--body must not be whitespace-only"
+
+# All-or-nothing. `isStatusLink` accepts ANY string, so a bad-scheme URL publishes
+# a banner whose button `openExternal` then inertly refuses — a dead control with
+# no error anywhere.
+if [ -n "$URL" ] || [ -n "$LABEL" ]; then
+  [ -n "$URL" ] || die "--link-label requires --link"
+  [ -n "$LABEL" ] || die "--link requires --link-label"
+  [ -n "${LABEL//[[:space:]]/}" ] ||
+    die "--link-label must not be whitespace-only; it would render an invisible clickable button"
+  # Defer to the SAME rule the client's single URL authority uses. A prefix glob
+  # is laxer: `https://` and `http://a b` pass it, pass the payload validator
+  # (isStatusLink only checks `typeof === "string"`), render a clickable button —
+  # and are then refused by isOpenableExternalUrl, which parses with `new URL()`.
+  # That dead button with no error anywhere is precisely what this guard exists
+  # to prevent, so the guard must not be more permissive than the authority.
+  node -e 'try{const u=new URL(process.argv[1]);process.exit(u.protocol==="http:"||u.protocol==="https:"?0:1)}catch{process.exit(1)}' "$URL" ||
+    die "--link must be a URL openExternal accepts — http/https with a valid host (got '$URL')"
+fi
+
+# Node is the only oracle with the same acceptance as the client's `Date.parse`:
+# BSD `date -d` does not exist on darwin, and every substitute accepts a different
+# set of strings — which is the exact mismatch this check exists to close.
+# The `if` guard is load-bearing: UNTIL is "" when the flag is omitted and
+# `Date.parse("")` is NaN, so an unguarded check would fail every publish.
+if [ -n "$UNTIL" ]; then
+  # Two distinct failures, because "accepted by the validator" is not the same as
+  # "will ever render": a past expiry passes isStatusMessage, uploads, reads back
+  # clean, and prints a full success line for a banner isStatusLive hides forever.
+  set +e
+  node -e 'const t=Date.parse(process.argv[1]); process.exit(Number.isNaN(t) ? 1 : (t <= Date.now() ? 2 : 0))' "$UNTIL"
+  until_rc=$?
+  set -e
+  [ "$until_rc" = 1 ] && die "--until '$UNTIL' is not parseable by Date.parse"
+  [ "$until_rc" = 2 ] && die "--until '$UNTIL' is already in the past; the message would never render"
+fi
+
+if [ -z "$DISMISSIBLE" ]; then
+  if [ "$SEVERITY" = critical ]; then DISMISSIBLE=false; else DISMISSIBLE=true; fi
+fi
+
+# --- Compose the payload ONCE -------------------------------------------------
+#
+# One composition means `--channel both` publishes an identical payload and id by
+# construction; re-composing per channel would mint a second id and re-show the
+# banner to everyone who had dismissed it on the other channel.
+#
+# The temp file is ABSOLUTE because the upload runs inside `(cd client && ...)`,
+# where a repo-root-relative --file path would resolve against client/ and fail.
+# Never write client/public/status.json for a remote publish: a leftover there is
+# copied into dist/ by a later local build.
+ID=$(( $(date +%s) * 1000 ))  # `date +%s%3N` is GNU-only; darwin emits a literal 3N
+TMP="$(mktemp "${TMPDIR:-/tmp}/status-payload.XXXXXX")"
+trap 'rm -f "$TMP"' EXIT
+
+# Optional fields are OMITTED, never null: the validator rejects the WHOLE message
+# on `"link": null` / `"expiresAt": null`, which is what jq emits for a null arg.
+# `--argjson` (not `--arg`) for id and dismissible — `--arg` is string-valued and
+# the contract requires a JSON number and a JSON boolean.
+jq -n --argjson id "$ID" --arg severity "$SEVERITY" --arg title "$TITLE" \
+      --arg body "$BODY" --argjson dismissible "$DISMISSIBLE" \
+      --arg until "$UNTIL" --arg url "$URL" --arg label "$LABEL" \
+  '{id:$id, severity:$severity, title:$title, body:$body, dismissible:$dismissible}
+   + (if $until == "" then {} else {expiresAt:$until} end)
+   + (if $url   == "" then {} else {link:{url:$url,label:$label}} end)' > "$TMP"
+
+# --- Publish ------------------------------------------------------------------
+
+publish_local() {
+  if [ "$DRY_RUN" = true ]; then
+    # No wrangler argv exists for this channel, so the composed payload is what
+    # there is to show — and nothing is written.
+    cat "$TMP"
+    return 0
+  fi
+  cp "$TMP" "$LOCAL_FILE"
+  echo "Wrote $LOCAL_FILE (id $ID)"
+  echo
+  echo "  Load / or /multiplayer under \`cd client && pnpm dev\` to see it."
+  echo "  Promotion path: local -> preview -> release"
+  echo "    scripts/publish-status.sh --channel preview ...   (staging/status.json)"
+  echo "    scripts/publish-status.sh --channel release ...   (status.json)"
+  echo "  Run \`scripts/publish-status.sh --clear --channel local\` before any local"
+  echo "  \`pnpm build\` / Tauri bundle: Vite copies client/public into dist/, so a"
+  echo "  leftover test payload would be baked into the artifact."
+}
+
+publish_remote() {
+  local key="$1" body
+  if [ "$DRY_RUN" = true ]; then
+    echo "(cd client && pnpm wrangler r2 object put \"$key\" --file \"$TMP\" --remote --content-type application/json --cache-control \"$CACHE_CONTROL\")"
+    echo "(cd client && pnpm wrangler r2 object get \"$key\" --remote --pipe) | jq -e --argjson id $ID '.id == \$id'"
+    return 0
+  fi
+  # Uncompressed: the payload is ~300 bytes, so brotli would add a dependency for
+  # no gain. `pnpm wrangler` from client/ (not npx) — a maintainer's shell has no
+  # guaranteed node env; precedent scripts/deploy-cf.sh:69,93,158.
+  (cd client && pnpm wrangler r2 object put "$key" --file "$TMP" --remote \
+    --content-type application/json \
+    --cache-control "$CACHE_CONTROL") || return 1
+
+  # Read back through the BUCKET and assert payload IDENTITY, not reachability. A
+  # public-URL curl cannot serve as the emulator guard: data.phase-rs.dev returns
+  # cf-cache-status: HIT under this very max-age=60 even for a no-cache client, so
+  # on any publish after the first a 200 can come from the edge holding the
+  # PREVIOUS message. The existing curl precedents in deploy.yml/release.yml are
+  # sound only because they verify content-hash-named objects; status.json is the
+  # first mutable fixed-key object in this bucket.
+  body="$(cd client && pnpm wrangler r2 object get "$key" --remote --pipe)" || return 1
+  printf '%s' "$body" | jq -e --argjson id "$ID" '.id == $id' >/dev/null || {
+    echo "ERROR: $key did not land remotely (or is not the payload just composed)" >&2
+    echo "  read-back returned: $body" >&2
+    return 1
+  }
+  echo "Published $key (id $ID)"
+}
+
+case "$CHANNEL" in
+  local) publish_local ;;
+  preview) publish_remote "$PREVIEW_KEY" ;;
+  release) publish_remote "$RELEASE_KEY" ;;
+  both)
+    # Preview first: a preview failure must leave production untouched. Do NOT
+    # advise "just re-run" on a partial failure — a re-run mints a NEW id and,
+    # because dismissal is equality-compared, re-shows the banner to every player
+    # who had already dismissed the channel that DID land.
+    publish_remote "$PREVIEW_KEY" ||
+      fail "preview publish failed; nothing was published (release NOT attempted)"
+    publish_remote "$RELEASE_KEY" ||
+      fail "release publish failed; published so far: preview (id $ID). Re-run with --channel release --title ... to finish; a full re-run would mint a new id and re-show the banner to players who dismissed the preview one."
+    ;;
+esac


### PR DESCRIPTION
## What

A status message the maintainer publishes **out of band** as JSON, which automatically appears to all players on the main menu (`/`) and the online multiplayer screen (`/multiplayer`). Severity-toned, optionally dismissible, self-expiring.

## How it's published

`scripts/publish-status.sh`. **`--channel local` is the default**, writing `client/public/status.json` so the banner can be previewed in `pnpm dev` before anything touches R2 — a bare invocation can never reach production. Then:

```
./scripts/publish-status.sh --severity warning --title "Multiplayer maintenance" \
    --body "The lobby restarts at 20:00 UTC." --until 2026-08-30T21:00:00Z
./scripts/publish-status.sh --channel preview ...   # phase-rs-data/staging/status.json
./scripts/publish-status.sh --channel release ...   # phase-rs-data/status.json
./scripts/publish-status.sh --clear --channel both
```

## Design points worth reviewer attention

**`status.json` is deliberately NOT in `data-files.json`.** The deploy R2 upload loop hard-errors when a manifest file is missing from `client/public`, and a committed placeholder would be re-uploaded on every deploy — silently clobbering the live message. It follows the `__CARD_DATA_URL__` precedent of an explicit, non-manifest define, declared in **both** `vite.config.ts` and `vitest.config.ts` (vitest does not inherit vite's define block).

**`fetchStatus` never throws, and applies one uniform rule: any contract violation resolves `null`.** Every field is validated, not just `severity`/`title` — a non-string `body` would otherwise reach React as a child, throw, and blank the whole app through the root `<ErrorBoundary>` that wraps `<Routes>`.

**The banner mounts once in `AppShell`,** inside `<main>` but *above* the inner `<Suspense>` so the route spinner cannot replace it on navigation, and is route-gated there rather than inside the component — gating inside would inject an unmocked `fetch` and a live 60s interval into the existing `AppShell.responsiveDraft.test.tsx`.

**Both remote mutations verify themselves through the bucket, not the CDN.** `data.phase-rs.dev` is edge-cached under the same `max-age=60` the upload sets and returns `HIT` even for a `no-cache` client, so a 200 proves nothing for a mutable fixed key. A publish reads the object back and asserts payload identity; a clear reads it back and requires the read to *fail*. The `curl` precedents in `deploy.yml`/`release.yml` are sound only because they verify content-hash-named objects.

**Dismissal compares the message `id` by equality,** so any newly published message (always a fresh epoch-ms id) re-shows. `preferencesStore` persist version bumped 31 → 32.

## Verification

- `check-frontend` and `test-frontend` green (`tilt-wait` exit 0): **408 test files, 4306 tests passing**.
- 37 new tests — `status.test.ts` (20), `StatusBanner.test.tsx` (11), `useStatusMessage.test.ts` (6).
- `shellcheck` clean on the script; every negative validation case exits 1 with no file written.
- Verified live in a browser: warning renders `role="status"`, `critical` renders `role="alert"` with no dismiss button, absent on `/my-decks`, dismissal persists the exact id the script minted, and a real pre-existing v31 store migrated to v32 with `dismissedStatusId` absent.

**Limitation, stated plainly:** the remote (`preview`/`release`) publish paths were **deliberately never executed** — doing so would publish a test banner to real players. They are covered by `--dry-run` argv assertions plus a `pnpm`-stubbed exercise of every failure path (put failure, stale-id read-back, wrangler-banner-text read-back, both partial-failure orders), not by a real upload.

## Known non-blocking follow-up

`StatusBanner` sets no `overflow-wrap`/`break-words`, so a long unbroken token pasted into `--body` (e.g. a bare URL) overflows the banner horizontally.
