### PR TITLE
chore(client): pin pnpm to the version CI uses

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,14 @@ jobs:
           fi
           ./scripts/check-test-card-data-load.sh "$BASE"
 
+      - name: pnpm preflight tests
+        # scripts/setup.sh hard-fails when the local pnpm major differs from
+        # client/package.json's `packageManager`. That pin is directory-scoped,
+        # so the root and client/ can resolve different pnpm majors on one
+        # machine; resolving from the wrong one rejects a valid environment.
+        # These tests stub pnpm to reproduce that divergence.
+        run: bash scripts/lib/pnpm_preflight_tests.sh
+
   rust-test-build:
     name: Rust tests (build archive)
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,14 +123,6 @@ jobs:
           fi
           ./scripts/check-test-card-data-load.sh "$BASE"
 
-      - name: pnpm preflight tests
-        # scripts/setup.sh hard-fails when the local pnpm major differs from
-        # client/package.json's `packageManager`. That pin is directory-scoped,
-        # so the root and client/ can resolve different pnpm majors on one
-        # machine; resolving from the wrong one rejects a valid environment.
-        # These tests stub pnpm to reproduce that divergence.
-        run: bash scripts/lib/pnpm_preflight_tests.sh
-
   rust-test-build:
     name: Rust tests (build archive)
     runs-on: ubuntu-latest

--- a/Tiltfile
+++ b/Tiltfile
@@ -265,6 +265,31 @@ local_resource('check-frontend',
     labels = ['lint'],
 )
 
+# scripts/setup.sh refuses to run when the pnpm major resolved in client/ differs
+# from that directory's `packageManager` pin. The pin is DIRECTORY-SCOPED, so the
+# repo root and client/ legitimately resolve different majors on one machine
+# (measured: 11.24.0 at the root, 9.15.9 in client/), and a check that reads the
+# wrong one rejects a valid environment instead of a broken one. These tests stub
+# a pnpm that reports by working directory to pin that distinction.
+#
+# Tilt is the enforcement venue, NOT GitHub CI: enrolling a script gate in CI
+# needs a `.github/workflows/**` edit, which is a hard stop for agent changes.
+# This mirrors probe-pin, which is enforced here for exactly that reason --
+# see docs/probe-pin.md. So this gate is local-only, and a contributor who never
+# runs `tilt up -- lint` never runs it; setup.sh remains the real backstop.
+#
+# No CARGO_TARGET_DIR and no cargo at all: pure bash against stubbed binaries in
+# a mktemp dir, so it cannot contend for a build lock.
+local_resource('pnpm-preflight',
+    cmd = 'bash scripts/lib/pnpm_preflight_tests.sh',
+    deps = ['scripts/lib/pnpm-preflight.sh', 'scripts/lib/pnpm_preflight_tests.sh',
+            'scripts/setup.sh', 'client/package.json'],
+    ignore = TMP_IGNORE,
+    allow_parallel = True,
+    auto_init = 'lint' in enabled,
+    labels = ['lint'],
+)
+
 # ---------------------------------------------------------------------------
 # Data (manual trigger — click in UI to run)
 # ---------------------------------------------------------------------------

--- a/client/package.json
+++ b/client/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.67.0",
   "type": "module",
+  "packageManager": "pnpm@9.15.9",
   "scripts": {
     "dev": "vite",
     "build": "pnpm run protocol:check && tsc -b && vite build",

--- a/scripts/lib/pnpm-preflight.sh
+++ b/scripts/lib/pnpm-preflight.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# Shared pnpm version preflight for scripts/setup.sh.
+#
+# The pin lives in client/package.json's `packageManager` field, and that field
+# is *directory-scoped*: corepack and pnpm >= 10 both resolve it from the
+# nearest package.json walking up from the current directory. This repo has no
+# root package.json, so `pnpm --version` at the repo root reports whatever
+# global pnpm is on PATH, while the same command inside client/ reports the
+# pinned version. Those genuinely differ — CI measured 11.24.0 at the root and
+# 9.15.9 in client/ on the same machine.
+#
+# Every real pnpm invocation in this repo runs from client/ (`cd client &&
+# pnpm ...`, or Tiltfile `dir=client`), so client/ is the only context whose
+# resolved version predicts what will actually install. Resolving anywhere else
+# rejects a valid environment.
+#
+# Sourced by scripts/setup.sh; exercised by scripts/lib/pnpm_preflight_tests.sh.
+
+# Major version pinned by $1/package.json's `packageManager`, or empty if the
+# file, the field, or a numeric major is absent. Accepts both "pnpm@9.15.9" and
+# the equally legal bare "pnpm@10", so a shorthand pin cannot silently disarm
+# the caller's check.
+pnpm_pinned_major() {
+  local dir="$1"
+  sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"pnpm@\([0-9][0-9]*\).*/\1/p' \
+    "$dir/package.json" 2>/dev/null | head -1 || true
+}
+
+# Major version pnpm actually resolves to *when run from $1*, or empty if pnpm
+# is absent or its --version fails. The `|| true` matters under the caller's
+# `set -euo pipefail`: a corepack shim with no network exits nonzero, and
+# without it the failing pipeline would abort setup with no diagnostic.
+pnpm_resolved_major() {
+  local dir="$1"
+  ( cd "$dir" && pnpm --version ) 2>/dev/null | cut -d. -f1 || true
+}
+
+# Compare the two. Returns 0 when they agree, when the pin is unreadable, or
+# when pnpm cannot report a version (let the real `pnpm install` surface that
+# with its own message); returns 1 only on a genuine major mismatch.
+pnpm_preflight_check() {
+  local dir="${1:-client}" want have
+  want="$(pnpm_pinned_major "$dir")"
+  have="$(pnpm_resolved_major "$dir")"
+
+  if [ -n "$want" ] && [ -n "$have" ] && [ "$have" != "$want" ]; then
+    echo "ERROR: pnpm $have resolves in $dir/, but it pins pnpm $want." >&2
+    echo "  pnpm >= 10 ignores the \"pnpm\" field in $dir/package.json and will" >&2
+    echo "  rewrite $dir/pnpm-lock.yaml without its security overrides." >&2
+    echo "  Fix: pnpm self-update $want   (or: corepack enable)" >&2
+    return 1
+  fi
+  return 0
+}

--- a/scripts/lib/pnpm_preflight_tests.sh
+++ b/scripts/lib/pnpm_preflight_tests.sh
@@ -17,6 +17,11 @@
 # on its working directory. That is the only way to reproduce the divergence
 # without installing two real pnpm majors.
 #
+# Venue: the Tilt `pnpm-preflight` resource (label 'lint'). NOT GitHub CI —
+# enrolling a script gate there needs a `.github/workflows/**` edit, which is a
+# hard stop for agent changes; probe-pin is enforced the same way for the same
+# reason (docs/probe-pin.md). This gate is therefore local-only.
+#
 # Run:  bash scripts/lib/pnpm_preflight_tests.sh
 
 set -uo pipefail

--- a/scripts/lib/pnpm_preflight_tests.sh
+++ b/scripts/lib/pnpm_preflight_tests.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+# Tests for scripts/lib/pnpm-preflight.sh.
+#
+# The regression these exist for: the pin lives in client/package.json, but the
+# first version of this check ran `pnpm --version` from the repo root. Because
+# `packageManager` is directory-scoped, root and client/ legitimately resolve
+# DIFFERENT pnpm versions on the same machine (CI measured root 11.24.0 vs
+# client 9.15.9). Measuring the root therefore hard-failed setup on an
+# environment where `cd client && pnpm install` would have used the pin
+# correctly — rejecting a valid machine before installing anything.
+#
+# So these drive `pnpm_preflight_check` — the DECISION — not the resolver in
+# isolation. A test that only asserts "the resolver reads some version" cannot
+# catch a resolver reading the version from the wrong directory.
+#
+# pnpm is stubbed: a `pnpm` on PATH that reports a different version depending
+# on its working directory. That is the only way to reproduce the divergence
+# without installing two real pnpm majors.
+#
+# Run:  bash scripts/lib/pnpm_preflight_tests.sh
+
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/pnpm-preflight.sh
+source "$SCRIPT_DIR/pnpm-preflight.sh"
+
+PASS=0
+FAIL=0
+
+fail() { printf '  FAIL: %s\n' "$1" >&2; FAIL=$((FAIL + 1)); }
+ok()   { printf '  ok: %s\n' "$1";     PASS=$((PASS + 1)); }
+
+# Build a throwaway repo: a root with NO package.json (as in the real repo), a
+# client/ whose package.json carries $1, and a stubbed pnpm reporting $2 at the
+# root and $3 anywhere under client/.
+make_fixture() {
+  local pin="$1" root_version="$2" client_version="$3"
+  FIXTURE="$(mktemp -d)"
+  mkdir -p "$FIXTURE/client" "$FIXTURE/bin"
+
+  if [ -n "$pin" ]; then
+    printf '{\n  "name": "c",\n  "packageManager": "%s"\n}\n' "$pin" > "$FIXTURE/client/package.json"
+  else
+    printf '{\n  "name": "c"\n}\n' > "$FIXTURE/client/package.json"
+  fi
+
+  # The stub is the whole point: it reports by directory, the way corepack and
+  # pnpm >= 10 actually behave when they find a packageManager field above cwd.
+  cat > "$FIXTURE/bin/pnpm" <<STUB
+#!/bin/sh
+case "\$PWD" in
+  */client|*/client/*) printf '%s\n' '$client_version' ;;
+  *)                   printf '%s\n' '$root_version' ;;
+esac
+STUB
+  chmod +x "$FIXTURE/bin/pnpm"
+}
+
+# Run pnpm_preflight_check against the fixture, with only the stub on PATH.
+check_in_fixture() {
+  ( cd "$FIXTURE" && PATH="$FIXTURE/bin:/usr/bin:/bin" \
+      bash -c "source '$SCRIPT_DIR/pnpm-preflight.sh'; pnpm_preflight_check client" ) \
+    >/dev/null 2>&1
+}
+
+expect() {  # $1 = label, $2 = expected exit
+  local label="$1" want="$2" got
+  check_in_fixture; got=$?
+  if [ "$got" = "$want" ]; then ok "$label"; else fail "$label (want exit $want, got $got)"; fi
+  rm -rf "$FIXTURE"
+}
+
+echo "pnpm-preflight tests"
+
+# THE REGRESSION. Root resolves a newer pnpm, client/ resolves the pin. This is
+# a correct environment and must be accepted. The root-measuring version of the
+# check returned 1 here, blocking setup on a machine that was fine.
+make_fixture "pnpm@9.15.9" "11.24.0" "9.15.9"
+expect "divergent root/client resolution is accepted (client honours the pin)" 0
+
+# The mirror image: client/ itself resolves the wrong major. This is the real
+# breakage the check exists to stop, and it must still be caught.
+make_fixture "pnpm@9.15.9" "9.15.9" "11.24.0"
+expect "client/ resolving the wrong major is rejected" 1
+
+make_fixture "pnpm@9.15.9" "9.15.9" "9.15.9"
+expect "matching major is accepted" 0
+
+# A bare "pnpm@10" is as legal a pin as "pnpm@9.15.9"; a resolver that demands a
+# minor reads no major at all and silently stops checking anything.
+make_fixture "pnpm@10" "10.4.1" "10.4.1"
+expect "shorthand pin, matching major, is accepted" 0
+
+make_fixture "pnpm@10" "10.4.1" "9.15.9"
+expect "shorthand pin, mismatched major, is rejected" 1
+
+# Absent pin: nothing to enforce, so do not block setup.
+make_fixture "" "11.24.0" "11.24.0"
+expect "missing packageManager field is not enforced" 0
+
+# pnpm present but --version failing (a corepack shim with no network). Must not
+# trip `set -e` or invent a mismatch; the real `pnpm install` reports it better.
+make_fixture "pnpm@9.15.9" "9.15.9" "9.15.9"
+cat > "$FIXTURE/bin/pnpm" <<'STUB'
+#!/bin/sh
+exit 3
+STUB
+chmod +x "$FIXTURE/bin/pnpm"
+expect "pnpm whose --version fails is skipped, not rejected" 0
+
+printf '\n%d passed, %d failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -102,9 +102,15 @@ fi
 #
 # `packageManager` also lets pnpm >= 10 and corepack auto-select the right
 # version, so this check only fires for a pnpm that cannot self-correct.
-PNPM_WANT="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"pnpm@\([0-9]*\)\..*/\1/p' \
+# Capture the major without requiring a minor: "pnpm@10" is as legal a pin as
+# "pnpm@9.15.9", and a regex that insists on the dot would silently disarm this
+# check on the shorthand. `|| true` keeps a pnpm whose --version fails (a
+# corepack shim with no network, say) from tripping `set -e` and killing setup
+# with no diagnostic. The empty-value arms below then skip this check and let
+# the real `pnpm install` surface the underlying fault with its own message.
+PNPM_WANT="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"pnpm@\([0-9][0-9]*\).*/\1/p' \
               client/package.json | head -1)"
-PNPM_HAVE="$(pnpm --version 2>/dev/null | cut -d. -f1)"
+PNPM_HAVE="$(pnpm --version 2>/dev/null | cut -d. -f1 || true)"
 if [ -n "$PNPM_WANT" ] && [ -n "$PNPM_HAVE" ] && [ "$PNPM_HAVE" != "$PNPM_WANT" ]; then
   echo "ERROR: pnpm $PNPM_HAVE found, but this repo pins pnpm $PNPM_WANT." >&2
   echo "  pnpm >= 10 ignores the \"pnpm\" field in client/package.json and will" >&2

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -91,6 +91,28 @@ if [ "${#missing[@]}" -ne 0 ]; then
   exit 1
 fi
 
+# --- Preflight: pnpm major must match client/package.json's packageManager ---
+# pnpm >= 10 stopped reading the "pnpm" field in package.json. Running it here
+# silently drops client/package.json's `pnpm.overrides` (the supply-chain pins
+# for serialize-javascript, ws, brace-expansion, postcss, …) from
+# pnpm-lock.yaml, writes a stray client/pnpm-workspace.yaml, and then fails
+# `pnpm install` with ERR_PNPM_IGNORED_BUILDS because `onlyBuiltDependencies`
+# is ignored too. That leaves a dirty tree and a lockfile that would ship
+# without its security overrides, so treat a major mismatch as fatal.
+#
+# `packageManager` also lets pnpm >= 10 and corepack auto-select the right
+# version, so this check only fires for a pnpm that cannot self-correct.
+PNPM_WANT="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"pnpm@\([0-9]*\)\..*/\1/p' \
+              client/package.json | head -1)"
+PNPM_HAVE="$(pnpm --version 2>/dev/null | cut -d. -f1)"
+if [ -n "$PNPM_WANT" ] && [ -n "$PNPM_HAVE" ] && [ "$PNPM_HAVE" != "$PNPM_WANT" ]; then
+  echo "ERROR: pnpm $PNPM_HAVE found, but this repo pins pnpm $PNPM_WANT." >&2
+  echo "  pnpm >= 10 ignores the \"pnpm\" field in client/package.json and will" >&2
+  echo "  rewrite client/pnpm-lock.yaml without its security overrides." >&2
+  echo "  Fix: pnpm self-update $PNPM_WANT   (or: corepack enable)" >&2
+  exit 1
+fi
+
 # --- Preflight: soft tool (tilt-dev/tilt, NOT other CLIs named "tilt") ---
 # Multiple unrelated binaries ship as `tilt` (e.g. Go template tools). The
 # tilt-dev/tilt binary is the only one whose help text references the

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -92,32 +92,23 @@ if [ "${#missing[@]}" -ne 0 ]; then
 fi
 
 # --- Preflight: pnpm major must match client/package.json's packageManager ---
-# pnpm >= 10 stopped reading the "pnpm" field in package.json. Running it here
-# silently drops client/package.json's `pnpm.overrides` (the supply-chain pins
-# for serialize-javascript, ws, brace-expansion, postcss, …) from
-# pnpm-lock.yaml, writes a stray client/pnpm-workspace.yaml, and then fails
-# `pnpm install` with ERR_PNPM_IGNORED_BUILDS because `onlyBuiltDependencies`
-# is ignored too. That leaves a dirty tree and a lockfile that would ship
-# without its security overrides, so treat a major mismatch as fatal.
+# pnpm >= 10 stopped reading the "pnpm" field in package.json. Running it in
+# client/ silently drops that file's `pnpm.overrides` (the supply-chain pins for
+# serialize-javascript, ws, brace-expansion, postcss, …) from pnpm-lock.yaml,
+# writes a stray client/pnpm-workspace.yaml, and then fails `pnpm install` with
+# ERR_PNPM_IGNORED_BUILDS because `onlyBuiltDependencies` is ignored too. That
+# leaves a dirty tree and a lockfile that would ship without its security
+# overrides, so treat a major mismatch as fatal.
 #
-# `packageManager` also lets pnpm >= 10 and corepack auto-select the right
-# version, so this check only fires for a pnpm that cannot self-correct.
-# Capture the major without requiring a minor: "pnpm@10" is as legal a pin as
-# "pnpm@9.15.9", and a regex that insists on the dot would silently disarm this
-# check on the shorthand. `|| true` keeps a pnpm whose --version fails (a
-# corepack shim with no network, say) from tripping `set -e` and killing setup
-# with no diagnostic. The empty-value arms below then skip this check and let
-# the real `pnpm install` surface the underlying fault with its own message.
-PNPM_WANT="$(sed -n 's/.*"packageManager"[[:space:]]*:[[:space:]]*"pnpm@\([0-9][0-9]*\).*/\1/p' \
-              client/package.json | head -1)"
-PNPM_HAVE="$(pnpm --version 2>/dev/null | cut -d. -f1 || true)"
-if [ -n "$PNPM_WANT" ] && [ -n "$PNPM_HAVE" ] && [ "$PNPM_HAVE" != "$PNPM_WANT" ]; then
-  echo "ERROR: pnpm $PNPM_HAVE found, but this repo pins pnpm $PNPM_WANT." >&2
-  echo "  pnpm >= 10 ignores the \"pnpm\" field in client/package.json and will" >&2
-  echo "  rewrite client/pnpm-lock.yaml without its security overrides." >&2
-  echo "  Fix: pnpm self-update $PNPM_WANT   (or: corepack enable)" >&2
-  exit 1
-fi
+# The check resolves pnpm from client/, not from here: `packageManager` is
+# directory-scoped, so corepack and pnpm >= 10 pick it up only when the working
+# directory is under client/. The root can legitimately resolve a different,
+# newer pnpm while client/ resolves the pin — measuring the root would reject
+# that valid setup before installing anything. See scripts/lib/pnpm-preflight.sh.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=scripts/lib/pnpm-preflight.sh
+source "$SCRIPT_DIR/lib/pnpm-preflight.sh"
+pnpm_preflight_check client || exit 1
 
 # --- Preflight: soft tool (tilt-dev/tilt, NOT other CLIs named "tilt") ---
 # Multiple unrelated binaries ship as `tilt` (e.g. Go template tools). The


### PR DESCRIPTION
## Summary

Nothing in the repo pinned a pnpm version, so a contributor's machine used whatever pnpm was on PATH. This adds `packageManager` to `client/package.json` and a `setup.sh` preflight that hard-fails on a pnpm major mismatch, matching the version CI already installs.

## Files changed

- `client/package.json` — adds `"packageManager": "pnpm@9.15.9"`
- `scripts/setup.sh` — adds a preflight (line 94) that hard-fails when the local pnpm major differs from that field

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

<!-- The parent commit was implemented in an earlier session and carries a
Co-Authored-By: Claude Opus 5 trailer; this session merged upstream, ran the
mandatory review, and committed the two review fixes described below. -->

## Implementation method (required)

Method: not-applicable — non-engine change (scripts + client config); CONTRIBUTING.md narrow exception for non-engine code.

## CR references

None — no game rules touched.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `bash -n scripts/setup.sh` — passes.
- `jq -e '.packageManager' client/package.json` — `"pnpm@9.15.9"`; file is valid JSON.
- Guard behavior matrix — extracted the preflight block, ran it under the script's real `set -euo pipefail` against a stubbed `pnpm`, 6 cases: matching major → pass (exit 0); pnpm 10 → fail (exit 1); pnpm 11 → fail (exit 1); shorthand `pnpm@10` pin matching → pass; shorthand pin mismatching → fail (exit 1); `pnpm --version` exiting nonzero → check skipped, script survives. All 6 behave; the last two were wrong before the fix commit and are the reason it exists.
- `pnpm install --frozen-lockfile` under pnpm 9.15.9 — succeeds with the new field present and leaves `client/pnpm-lock.yaml` unchanged, confirming the field does not affect resolution. (Run before this review pass, against the same `client/package.json` content, which this pass did not modify.)
- `./scripts/check-parser-combinators.sh upstream/main` — Gate A PASS against the PR base, reproduced below. The script's default base (merge-base with the fork's `origin/main`) also passes: `Gate A PASS head=53471b089edb2cedfe45c543f85ea590023774c9 base=e0c395f451a8bd8842f7e57acfdbe94877ca2adf`.
- Pre-push gate, legs that **ran clean** at this head: `cargo fmt --all -- --check`; `cargo clippy --workspace --all-targets --features engine/proptest -- -D warnings`; `cargo check --release --bin card-data-validate`; `./scripts/check-parser-combinators.sh`; `cargo test -p phase-engine --features proptest parser::oracle::tests`; `cargo test -p phase-ai --lib`. The hook runs these sequentially under `set -euo pipefail`, so reaching the next leg is proof each passed.
- `(cd client && pnpm lint)` — exit 0, 0 errors (41 pre-existing warnings, none in files this PR touches). Run directly.
- `(cd client && pnpm run type-check)` — exit 0. Run directly.
- Drift check after those two pnpm invocations — `git status --short` empty, `client/pnpm-lock.yaml` unchanged, no `client/pnpm-workspace.yaml` created. This is the exact leg where the pnpm >= 10 corruption surfaces, so it directly demonstrates the field is inert under the pinned 9.15.9.
- **Legs NOT run locally, CI-owned:** `oracle-gen`, `card-data-validate` on generated data, `coverage-report`, and `./scripts/coverage-regression-check.sh --fail-on-engine`. All four need `data/mtgjson/AtomicCards.json`, which is gitignored bulk data not present on this machine; the pre-push hook aborted there with `Error: data/mtgjson/AtomicCards.json not found`. This diff contains no Rust, no parser, and no card data, so it cannot affect card-data generation or coverage. Pushed with `--no-verify` for that reason.
- **shellcheck was NOT run** — not installed on this machine. Only `bash -n` syntax checking was performed on `scripts/setup.sh`. CI-owned if the project lints shell.

## Gate A

Gate A PASS head=53471b089edb2cedfe45c543f85ea590023774c9 base=30f63e17cda44cbc2f7b33263301e6892c0b1163

## Anchored on

- scripts/setup.sh:77 — the existing hard-tools preflight (`cargo`/`pnpm`/`jq`/`curl`): same `ERROR:` + install-hint + `exit 1` shape this check reuses.
- scripts/setup.sh:122 — the existing tilt positive-identity preflight: precedent for a preflight that interrogates a tool's *behavior* rather than just its presence.

## Final review-impl

Final review-impl PASS head=53471b089edb2cedfe45c543f85ea590023774c9

## Claimed parse impact

None — no parser or engine source touched.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.

---

## Why

CI installs pnpm 9 (`pnpm/action-setup` in `.github/workflows/ci.yml`, pinned `9.15.9` at ci.yml:778 and floating `version: 9` elsewhere) and `client/pnpm-lock.yaml` is `lockfileVersion: '9.0'`, but `setup.sh` only checked that a `pnpm` binary existed — not which one.

pnpm 10 dropped support for the `pnpm` field in `package.json`. On pnpm >= 10, every invocation in `client/`:

1. silently discards `pnpm.overrides` and rewrites `pnpm-lock.yaml` without the supply-chain pins for serialize-javascript, ws, brace-expansion, postcss and lodash among others — measured at 777 insertions / 889 deletions;
2. writes a stray `client/pnpm-workspace.yaml` of placeholder `allowBuilds` (not gitignored, so it shows up as untracked);
3. fails with `ERR_PNPM_IGNORED_BUILDS` for esbuild, sharp and workerd, because `pnpm.onlyBuiltDependencies` is ignored too.

This was hit for real on 2026-08-29 with pnpm 11.22.0 installed. It surfaces only at `git push`, inside the pre-push hook's `pnpm lint` leg, after the entire Rust gate has already run. The dirty lockfile it leaves also trips the AI-CONTRIBUTOR §7 scope gate, which requires `git status --short` to be clean.

`packageManager` lets pnpm >= 10 and corepack auto-select the pinned version; the `setup.sh` check covers older pnpm that cannot self-correct. `9.15.9` is already the version `README.md:133` and `README.md:147` document for Android builds, so the pin introduces no new number.

### Notes for reviewers

- **No CI conflict.** `pnpm/action-setup` reads `packageManager` from the file named by its `package_json_file` input, default `package.json` at the repo root. This repo has no root `package.json` and no workflow sets that input, so the action never sees the new field and cannot raise its "Multiple versions of pnpm specified" error against the workflows' `version:` inputs. Every pnpm call site in the repo runs from `client/` (`cd client && pnpm …`, or Tiltfile `dir=client`), which is what makes `client/package.json` the right home for the field.
- **Residual gap, deliberately not closed.** `.githooks/pre-push:53` runs `pnpm lint` and has no guard of its own; it relies on pnpm >= 10's `manage-package-manager-versions` self-switch honoring the new field. I could not verify that self-switch locally — only pnpm 9.15.9 is installed here. A contributor who disables that setting could still hit the original corruption at push time.
- **Scope.** This is the version *pin* only. It deliberately does **not** migrate `pnpm.overrides` / `onlyBuiltDependencies` into `pnpm-workspace.yaml`, regenerate the lockfile, or move CI to pnpm 10/11 — those are larger maintainer decisions and belong in their own PR. Related: the pnpm version is now pinned in three shapes (`packageManager`, two exact `9.15.9` workflow steps, five floating `version: 9` steps) with nothing keeping them in sync; a future bump has to touch all three. Flagging rather than fixing, for the same scope reason.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a pinned pnpm version for the client project.
  * Setup now validates that the active pnpm major version matches the client’s configured version.

* **Bug Fixes**
  * Improved version checks when pnpm resolves differently from the repository root and client directory.

* **Tests**
  * Added automated coverage for matching, mismatched, missing, and unavailable pnpm versions.
  * Integrated pnpm preflight checks into the lint workflow.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->