### PR TITLE
fix(client): render live draft procedure values

### DIFF
--- a/client/src/components/draft/DraftIntro.tsx
+++ b/client/src/components/draft/DraftIntro.tsx
@@ -83,7 +83,15 @@ export function DraftIntro({
   // duplicating either sentence into seven locales.
   const commanderSteps: Step[] = [
     { icon: "1", text: t("intro.pod.step1", { count: podSize }) },
-    { icon: "2", text: t("intro.commander.step2") },
+    {
+      icon: "2",
+      text: mixedPackSizes
+        ? t("intro.commander.step2Mixed", {
+            packs,
+            packSizes: packSizeLabels,
+          })
+        : t("intro.commander.step2", { packs, cardsPerPack: cardsPerPackLabel }),
+    },
     { icon: "3", text: packPassing },
     { icon: "4", text: t("intro.commander.step4", { minimumDeckCards }) },
   ];

--- a/client/src/components/draft/DraftIntro.tsx
+++ b/client/src/components/draft/DraftIntro.tsx
@@ -8,9 +8,10 @@ type DraftMode = "quick" | "pod" | "commander";
 
 interface DraftIntroProps {
   mode: DraftMode;
-  podSize?: number;
-  packCount?: number;
-  cardsPerPack?: number;
+  podSize: number;
+  packCount: number;
+  cardsPerPack: number;
+  minDeckSize: number;
   /**
    * Engine-provided size of each booster, in pack order. A multi-set draft
    * mixes sizes, so the "packs of N cards" line only holds when they agree.
@@ -30,9 +31,10 @@ interface Step {
 
 export function DraftIntro({
   mode,
-  podSize = 8,
-  packCount = 3,
-  cardsPerPack = 14,
+  podSize,
+  packCount,
+  cardsPerPack,
+  minDeckSize,
   packSizes,
   onContinue,
 }: DraftIntroProps) {
@@ -40,36 +42,50 @@ export function DraftIntro({
 
   const mixedPackSizes = (packSizes?.length ?? 0) > 1
     && new Set(packSizes).size > 1;
+  const packs = t("intro.quantity.packsOpened", { count: packCount });
+  const cardsPerPackLabel = t("intro.quantity.cardsContained", { count: cardsPerPack });
+  const minimumDeckCards = t("intro.quantity.minimumDeckCards", { count: minDeckSize });
+  const packSizeLabels = (packSizes ?? [])
+    .map((size) => t("intro.quantity.packSizeEntry", { count: size }));
+  const packPassing = t("intro.packPassing", { count: packCount });
 
   const quickSteps: Step[] = [
     {
       icon: "1",
       text: mixedPackSizes
         ? t("intro.quick.step1Mixed", {
-            packCount,
-            packSizes: (packSizes ?? []).join(", "),
+            packs,
+            packSizes: packSizeLabels,
           })
-        : t("intro.quick.step1", { packCount, cardsPerPack }),
+        : t("intro.quick.step1", { packs, cardsPerPack: cardsPerPackLabel }),
     },
     { icon: "2", text: t("intro.quick.step2") },
-    { icon: "3", text: t("intro.quick.step3") },
-    { icon: "4", text: t("intro.quick.step4") },
+    { icon: "3", text: packPassing },
+    { icon: "4", text: t("intro.quick.step4", { minimumDeckCards }) },
   ];
   const podStepList: Step[] = [
     { icon: "1", text: t("intro.pod.step1", { count: podSize }) },
-    { icon: "2", text: t("intro.pod.step2") },
-    { icon: "3", text: t("intro.pod.step3") },
-    { icon: "4", text: t("intro.pod.step4") },
+    {
+      icon: "2",
+      text: mixedPackSizes
+        ? t("intro.pod.step2Mixed", {
+            packs,
+            packSizes: packSizeLabels,
+          })
+        : t("intro.pod.step2", { packs, cardsPerPack: cardsPerPackLabel }),
+    },
+    { icon: "3", text: packPassing },
+    { icon: "4", text: t("intro.pod.step4", { minimumDeckCards }) },
   ];
-  // CR 903.13a/b. Steps 1 and 3 are identical to the pod procedure, so they REUSE the
-  // pod keys rather than duplicating two sentences into seven locales — the same reuse
-  // the draft landing page makes for the menu-namespace "Enter" CTA. It also keeps
-  // `{{count}}` on a key whose seven translations already interpolate it correctly.
+  // CR 903.13a/b: Commander Draft is a draft followed by a multiplayer game,
+  // and players draft two cards from each booster before passing it. Commander
+  // reuses the pod player-count key and the shared pack-passing key rather than
+  // duplicating either sentence into seven locales.
   const commanderSteps: Step[] = [
     { icon: "1", text: t("intro.pod.step1", { count: podSize }) },
     { icon: "2", text: t("intro.commander.step2") },
-    { icon: "3", text: t("intro.pod.step3") },
-    { icon: "4", text: t("intro.commander.step4") },
+    { icon: "3", text: packPassing },
+    { icon: "4", text: t("intro.commander.step4", { minimumDeckCards }) },
   ];
 
   // Total over `DraftMode`: a future mode is a compile error here rather than a

--- a/client/src/components/draft/SealedPackOpening.tsx
+++ b/client/src/components/draft/SealedPackOpening.tsx
@@ -190,7 +190,9 @@ export function SealedPackOpening({ view, onComplete }: SealedPackOpeningProps) 
       {!showReview && (
         <div className="mb-5 text-center">
           <h1 className="menu-display text-3xl text-white">{t("sealedOpening.title")}</h1>
-          <p className="mt-2 text-sm text-white/50">{t("sealedOpening.subtitle")}</p>
+          <p className="mt-2 text-sm text-white/50">
+            {t("sealedOpening.subtitle", { count: packs.length })}
+          </p>
         </div>
       )}
       <AnimatePresence mode="wait">

--- a/client/src/components/draft/SealedPackOpening.tsx
+++ b/client/src/components/draft/SealedPackOpening.tsx
@@ -191,7 +191,7 @@ export function SealedPackOpening({ view, onComplete }: SealedPackOpeningProps) 
         <div className="mb-5 text-center">
           <h1 className="menu-display text-3xl text-white">{t("sealedOpening.title")}</h1>
           <p className="mt-2 text-sm text-white/50">
-            {t("sealedOpening.subtitle", { count: packs.length })}
+            {t("sealedOpening.subtitle", { count: view.pack_count })}
           </p>
         </div>
       )}

--- a/client/src/components/draft/__tests__/DraftIntro.test.tsx
+++ b/client/src/components/draft/__tests__/DraftIntro.test.tsx
@@ -33,9 +33,9 @@ describe("DraftIntro", () => {
       <DraftIntro
         mode="commander"
         podSize={4}
-        packCount={3}
-        cardsPerPack={20}
-        packSizes={[20, 20, 20]}
+        packCount={4}
+        cardsPerPack={18}
+        packSizes={[18, 18, 18, 18]}
         minDeckSize={63}
         onContinue={vi.fn()}
       />,
@@ -44,7 +44,9 @@ describe("DraftIntro", () => {
     // CR 903.13b requires two picks per pack, while CR 903.13f sets a 60-card
     // floor. REVERT-FAILING: 63 proves the copy reads the engine's stricter
     // published minimum instead of duplicating that floor here.
-    expect(screen.getByText("Pick two cards from each pack, then pass the rest")).toBeInTheDocument();
+    expect(
+      screen.getByText("Open 4 packs; each pack contains 18 cards — pick two cards, pass the rest"),
+    ).toBeInTheDocument();
     expect(
       screen.getByText(
         "After drafting, build a Commander deck of at least 63 cards and play one multiplayer game",
@@ -56,6 +58,26 @@ describe("DraftIntro", () => {
     expect(screen.getByText("You're drafting with 4 players in a pod")).toBeInTheDocument();
     expect(
       screen.getByText("The passing direction alternates each round"),
+    ).toBeInTheDocument();
+  });
+
+  it("lists every pack size for a mixed-size Commander draft", () => {
+    render(
+      <DraftIntro
+        mode="commander"
+        podSize={6}
+        packCount={3}
+        cardsPerPack={20}
+        packSizes={[20, 18, 20]}
+        minDeckSize={60}
+        onContinue={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Open 3 packs of mixed sizes, in this order: 20 cards, 18 cards, and 20 cards — pick two cards, pass the rest",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -83,7 +105,11 @@ describe("DraftIntro", () => {
     ).toBeInTheDocument();
     // Non-vacuous: the positive assertions above prove this render mounted, so
     // the absent Commander step is a real absence.
-    expect(screen.queryByText("Pick two cards from each pack, then pass the rest")).toBeNull();
+    expect(
+      screen.queryByText(
+        "Open 4 packs; each pack contains 12 cards — pick two cards, pass the rest",
+      ),
+    ).toBeNull();
   });
 
   it("lists every booster's size when a multi-set draft mixes them", () => {

--- a/client/src/components/draft/__tests__/DraftIntro.test.tsx
+++ b/client/src/components/draft/__tests__/DraftIntro.test.tsx
@@ -12,38 +12,75 @@ describe("DraftIntro", () => {
     render(
       <DraftIntro
         mode="quick"
+        podSize={8}
         packCount={4}
         cardsPerPack={12}
+        minDeckSize={35}
         onContinue={vi.fn()}
       />,
     );
 
-    expect(screen.getByText("You'll open 4 packs of 12 cards each")).toBeInTheDocument();
+    expect(screen.getByText("You'll open 4 packs; each pack contains 12 cards")).toBeInTheDocument();
+    expect(
+      screen.getByText("After all picks, build a deck of at least 35 cards and play a match"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("The passing direction alternates each round")).toBeInTheDocument();
     expect(screen.getByText("Quick Draft")).toBeInTheDocument();
   });
 
   it("describes the Commander procedure in commander mode", () => {
-    render(<DraftIntro mode="commander" podSize={4} onContinue={vi.fn()} />);
+    render(
+      <DraftIntro
+        mode="commander"
+        podSize={4}
+        packCount={3}
+        cardsPerPack={20}
+        packSizes={[20, 20, 20]}
+        minDeckSize={63}
+        onContinue={vi.fn()}
+      />,
+    );
 
-    // REVERT-FAILING: BASE has no "commander" mode, so these two steps have no
-    // renderer and no i18n key. CR 903.13b (two cards per pack) and
-    // CR 903.13f (60-card minimum) are what this copy asserts.
+    // CR 903.13b requires two picks per pack, while CR 903.13f sets a 60-card
+    // floor. REVERT-FAILING: 63 proves the copy reads the engine's stricter
+    // published minimum instead of duplicating that floor here.
     expect(screen.getByText("Pick two cards from each pack, then pass the rest")).toBeInTheDocument();
-    expect(screen.getByText(/60-card Commander deck/)).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "After drafting, build a Commander deck of at least 63 cards and play one multiplayer game",
+      ),
+    ).toBeInTheDocument();
     expect(screen.getByText("Commander Draft")).toBeInTheDocument();
-    // Reach guard for the REUSE decision: steps 1 and 3 resolve through the
-    // shared `intro.pod.*` keys, with the passed `podSize` interpolated.
+    // Reach guard for the REUSE decision: step 1 resolves through the shared
+    // `intro.pod.step1` key, with the passed `podSize` interpolated.
     expect(screen.getByText("You're drafting with 4 players in a pod")).toBeInTheDocument();
     expect(
-      screen.getByText("Packs alternate direction each round — left, right, left"),
+      screen.getByText("The passing direction alternates each round"),
     ).toBeInTheDocument();
   });
 
-  it("leaves the pod variant unchanged", () => {
-    render(<DraftIntro mode="pod" podSize={8} onContinue={vi.fn()} />);
+  it("shows the pod's configured procedure", () => {
+    render(
+      <DraftIntro
+        mode="pod"
+        podSize={8}
+        packCount={4}
+        cardsPerPack={12}
+        packSizes={[12, 12, 12, 12]}
+        minDeckSize={45}
+        onContinue={vi.fn()}
+      />,
+    );
 
     expect(screen.getByText("Pod Draft")).toBeInTheDocument();
-    expect(screen.getByText("Open 3 packs of 14 cards — pick one, pass the rest")).toBeInTheDocument();
+    expect(
+      screen.getByText("Open 4 packs; each pack contains 12 cards — pick one, pass the rest"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "After drafting, build a deck of at least 45 cards and play tournament matches",
+      ),
+    ).toBeInTheDocument();
     // Non-vacuous: the positive assertions above prove this render mounted, so
     // the absent Commander step is a real absence.
     expect(screen.queryByText("Pick two cards from each pack, then pass the rest")).toBeNull();
@@ -53,15 +90,19 @@ describe("DraftIntro", () => {
     render(
       <DraftIntro
         mode="quick"
+        podSize={8}
         packCount={3}
         cardsPerPack={15}
         packSizes={[15, 14, 15]}
+        minDeckSize={40}
         onContinue={vi.fn()}
       />,
     );
 
     expect(
-      screen.getByText("You'll open 3 packs of mixed sizes — 15, 14, 15 cards, in that order"),
+      screen.getByText(
+        "You'll open 3 packs of mixed sizes, in this order: 15 cards, 14 cards, and 15 cards",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -69,13 +110,59 @@ describe("DraftIntro", () => {
     render(
       <DraftIntro
         mode="quick"
+        podSize={8}
         packCount={3}
         cardsPerPack={15}
         packSizes={[15, 15, 15]}
+        minDeckSize={40}
         onContinue={vi.fn()}
       />,
     );
 
-    expect(screen.getByText("You'll open 3 packs of 15 cards each")).toBeInTheDocument();
+    expect(screen.getByText("You'll open 3 packs; each pack contains 15 cards")).toBeInTheDocument();
+  });
+
+  it("lists every pack size for a mixed-size pod draft", () => {
+    render(
+      <DraftIntro
+        mode="pod"
+        podSize={6}
+        packCount={3}
+        cardsPerPack={15}
+        packSizes={[15, 14, 15]}
+        minDeckSize={40}
+        onContinue={vi.fn()}
+      />,
+    );
+
+    expect(
+      screen.getByText(
+        "Open 3 packs of mixed sizes, in this order: 15 cards, 14 cards, and 15 cards — pick one, pass the rest",
+      ),
+    ).toBeInTheDocument();
+  });
+
+  it("uses singular quantities and direction copy for a one-pack cube", () => {
+    render(
+      <DraftIntro
+        mode="quick"
+        podSize={2}
+        packCount={1}
+        cardsPerPack={1}
+        packSizes={[1]}
+        minDeckSize={1}
+        onContinue={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("You'll open 1 pack; each pack contains 1 card")).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "This draft has one pack round, so the passing direction does not alternate",
+      ),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("After all picks, build a deck of at least 1 card and play a match"),
+    ).toBeInTheDocument();
   });
 });

--- a/client/src/components/draft/__tests__/SealedPackOpening.test.tsx
+++ b/client/src/components/draft/__tests__/SealedPackOpening.test.tsx
@@ -106,6 +106,7 @@ describe("SealedPackOpening", () => {
       />,
     );
 
+    expect(screen.getByText("Open 2 packs, one at a time.")).toBeInTheDocument();
     expect(screen.getByText("Pack 1 of 2")).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: "Open pack" }));
     expect(await screen.findAllByText("Silvercoat Lion")).toHaveLength(2);
@@ -122,5 +123,16 @@ describe("SealedPackOpening", () => {
 
     fireEvent.click(screen.getByRole("button", { name: "Build deck" }));
     expect(onComplete).toHaveBeenCalledOnce();
+  });
+
+  it("uses singular copy for one engine-provided pack", () => {
+    render(
+      <SealedPackOpening
+        view={{ ...VIEW, sealed_packs: [[VIEW.pool[0]]] }}
+        onComplete={vi.fn()}
+      />,
+    );
+
+    expect(screen.getByText("Open 1 pack.")).toBeInTheDocument();
   });
 });

--- a/client/src/components/draft/__tests__/SealedPackOpening.test.tsx
+++ b/client/src/components/draft/__tests__/SealedPackOpening.test.tsx
@@ -128,7 +128,7 @@ describe("SealedPackOpening", () => {
   it("uses singular copy for one engine-provided pack", () => {
     render(
       <SealedPackOpening
-        view={{ ...VIEW, sealed_packs: [[VIEW.pool[0]]] }}
+        view={{ ...VIEW, pack_count: 1, sealed_packs: [[VIEW.pool[0]]] }}
         onComplete={vi.fn()}
       />,
     );

--- a/client/src/i18n/__tests__/localeParity.test.ts
+++ b/client/src/i18n/__tests__/localeParity.test.ts
@@ -33,16 +33,7 @@ const KNOWN_PLACEHOLDER_GAPS: ReadonlyArray<{
   ns: string;
   key: string;
   why: string;
-}> = [
-  {
-    ns: "draft.json",
-    key: "intro.quick.step1",
-    why:
-      "All six translations hard-code the default '3 packs of 14 cards' instead " +
-      "of interpolating {{packCount}}/{{cardsPerPack}}, so a non-default draft " +
-      "shows wrong numbers. Pre-existing; tracked separately.",
-  },
-];
+}> = [];
 
 type Flat = Record<string, unknown>;
 
@@ -144,6 +135,12 @@ const WORKSPACE_SHELL_KEYS = [
 ] as const;
 
 const FOUR_FORM_STEMS = [
+  "intro.quantity.packsOpened",
+  "intro.quantity.cardsContained",
+  "intro.quantity.packSizeEntry",
+  "intro.quantity.minimumDeckCards",
+  "intro.packPassing",
+  "sealedOpening.subtitle",
   "workspace.count.deck",
   "workspace.count.sideboard",
   "workspace.sideboard.expand",
@@ -198,7 +195,7 @@ describe("locale parity", () => {
     }
   });
 
-  it("keeps_all_workspace_plural_families_complete_in_every_locale", () => {
+  it("keeps_all_plural_families_complete_in_every_locale", () => {
     for (const locale of [SOURCE, ...locales]) {
       const target = load(locale, "draft.json");
       for (const stem of FOUR_FORM_STEMS) {
@@ -219,6 +216,30 @@ describe("locale parity", () => {
     expect(instance.t("pack.cardsInPack", { ns: "draft", count: 5 })).toBe("5 kart w boosterze");
     expect(instance.t("pack.cardsInPack", { ns: "draft", count: 12 })).toBe("12 kart w boosterze");
     expect(instance.t("pack.cardsInPack", { ns: "draft", count: 1.5 })).toBe("1.5 karty w boosterze");
+
+    const quantityFamilies = [
+      ["intro.quantity.packsOpened", ["1 booster", "2 boostery", "5 boosterów", "12 boosterów", "1,5 boostera"]],
+      ["intro.quantity.cardsContained", ["1 kartę", "2 karty", "5 kart", "12 kart", "1,5 karty"]],
+      ["intro.quantity.packSizeEntry", ["1 karta", "2 karty", "5 kart", "12 kart", "1,5 karty"]],
+      ["intro.quantity.minimumDeckCards", ["1 karty", "2 kart", "5 kart", "12 kart", "1,5 karty"]],
+    ] as const;
+    for (const [key, expected] of quantityFamilies) {
+      expect([1, 2, 5, 12, 1.5].map((count) => instance.t(key, { ns: "draft", count }))).toEqual(expected);
+    }
+
+    const packs = instance.t("intro.quantity.packsOpened", { ns: "draft", count: 3 });
+    const packSizes = [1, 2, 5].map((count) =>
+      instance.t("intro.quantity.packSizeEntry", { ns: "draft", count }),
+    );
+    expect(instance.t("intro.quick.step1Mixed", { ns: "draft", packs, packSizes })).toBe(
+      "Otworzysz 3 boostery o różnych rozmiarach, w tej kolejności: 1 karta, 2 karty i 5 kart",
+    );
+    expect(instance.t("intro.packPassing", { ns: "draft", count: 1 })).toBe(
+      "Ten draft ma tylko jedną rundę boosterów, więc kierunek przekazywania się nie zmienia",
+    );
+    expect(instance.t("intro.packPassing", { ns: "draft", count: 3 })).toBe(
+      "Kierunek przekazywania zmienia się w każdej rundzie",
+    );
 
     const header = (count: number) => instance.t("workspace.headers.accessible", {
       ns: "draft", count, column: 3, labels: "Niebieskie",

--- a/client/src/i18n/locales/de/draft.json
+++ b/client/src/i18n/locales/de/draft.json
@@ -5,22 +5,43 @@
     "commanderTitle": "Commander Draft",
     "subtitle": "So funktioniert es",
     "startDrafting": "Mit dem Draften beginnen",
+    "quantity": {
+      "packsOpened_one": "{{count, number}} Booster",
+      "packsOpened_few": "{{count, number}} Booster",
+      "packsOpened_many": "{{count, number}} Booster",
+      "packsOpened_other": "{{count, number}} Booster",
+      "cardsContained_one": "{{count, number}} Karte",
+      "cardsContained_few": "{{count, number}} Karten",
+      "cardsContained_many": "{{count, number}} Karten",
+      "cardsContained_other": "{{count, number}} Karten",
+      "packSizeEntry_one": "{{count, number}} Karte",
+      "packSizeEntry_few": "{{count, number}} Karten",
+      "packSizeEntry_many": "{{count, number}} Karten",
+      "packSizeEntry_other": "{{count, number}} Karten",
+      "minimumDeckCards_one": "{{count, number}} Karte",
+      "minimumDeckCards_few": "{{count, number}} Karten",
+      "minimumDeckCards_many": "{{count, number}} Karten",
+      "minimumDeckCards_other": "{{count, number}} Karten"
+    },
+    "packPassing_one": "Dieser Draft hat nur eine Boosterrunde, daher wechselt die Weitergaberichtung nicht",
+    "packPassing_few": "Die Weitergaberichtung wechselt in jeder Runde",
+    "packPassing_many": "Die Weitergaberichtung wechselt in jeder Runde",
+    "packPassing_other": "Die Weitergaberichtung wechselt in jeder Runde",
     "quick": {
-      "step1": "Du öffnest 3 Booster mit je 14 Karten",
+      "step1": "Du öffnest {{packs}}; jeder Booster enthält {{cardsPerPack}}",
       "step2": "Wähle pro Booster eine Karte und gib den Rest an KI-Drafter weiter",
-      "step3": "Booster wechseln jede Runde die Richtung — links, rechts, links",
-      "step4": "Baue nach allen Picks ein 40-Karten-Deck und spiele eine Partie",
-      "step1Mixed": "Du öffnest {{packCount}} Booster unterschiedlicher Größe — {{packSizes}} Karten, in dieser Reihenfolge"
+      "step4": "Baue nach allen Picks ein Deck mit mindestens {{minimumDeckCards}} und spiele eine Partie",
+      "step1Mixed": "Du öffnest {{packs}} unterschiedlicher Größe, in dieser Reihenfolge: {{packSizes, list}}"
     },
     "pod": {
       "step1": "Du draftest mit {{count}} Spielern in einem Pod",
-      "step2": "Öffne 3 Booster mit 14 Karten — wähle eine, gib den Rest weiter",
-      "step3": "Booster wechseln jede Runde die Richtung — links, rechts, links",
-      "step4": "Baue nach dem Draften ein 40-Karten-Deck und spiele Turnierpartien"
+      "step2": "Öffne {{packs}}; jeder Booster enthält {{cardsPerPack}} — wähle eine Karte, gib den Rest weiter",
+      "step2Mixed": "Öffne {{packs}} unterschiedlicher Größe, in dieser Reihenfolge: {{packSizes, list}} — wähle eine Karte, gib den Rest weiter",
+      "step4": "Baue nach dem Draften ein Deck mit mindestens {{minimumDeckCards}} und spiele Turnierpartien"
     },
     "commander": {
       "step2": "Wähle zwei Karten aus jedem Booster und gib den Rest weiter",
-      "step4": "Baue nach dem Draften ein Commander-Deck mit 60 Karten und spiele eine Mehrspielerpartie"
+      "step4": "Baue nach dem Draften ein Commander-Deck mit mindestens {{minimumDeckCards}} und spiele eine Mehrspielerpartie"
     }
   },
   "steps": {
@@ -122,7 +143,10 @@
   },
   "sealedOpening": {
     "title": "Öffne deinen Sealed-Pool",
-    "subtitle": "Öffne sechs Booster, einen nach dem anderen.",
+    "subtitle_one": "Öffne {{count}} Booster.",
+    "subtitle_few": "Öffne {{count}} Booster, einen nach dem anderen.",
+    "subtitle_many": "Öffne {{count}} Booster, einen nach dem anderen.",
+    "subtitle_other": "Öffne {{count}} Booster, einen nach dem anderen.",
     "packProgress": "Booster {{current}} von {{total}}",
     "openPack": "Booster öffnen",
     "openPackArt": "Booster-Artwork öffnen",

--- a/client/src/i18n/locales/de/draft.json
+++ b/client/src/i18n/locales/de/draft.json
@@ -40,7 +40,8 @@
       "step4": "Baue nach dem Draften ein Deck mit mindestens {{minimumDeckCards}} und spiele Turnierpartien"
     },
     "commander": {
-      "step2": "Wähle zwei Karten aus jedem Booster und gib den Rest weiter",
+      "step2": "Öffne {{packs}}; jeder Booster enthält {{cardsPerPack}} — wähle zwei Karten, gib den Rest weiter",
+      "step2Mixed": "Öffne {{packs}} unterschiedlicher Größe, in dieser Reihenfolge: {{packSizes, list}} — wähle zwei Karten, gib den Rest weiter",
       "step4": "Baue nach dem Draften ein Commander-Deck mit mindestens {{minimumDeckCards}} und spiele eine Mehrspielerpartie"
     }
   },

--- a/client/src/i18n/locales/en/draft.json
+++ b/client/src/i18n/locales/en/draft.json
@@ -5,22 +5,43 @@
     "commanderTitle": "Commander Draft",
     "subtitle": "Here's how it works",
     "startDrafting": "Start Drafting",
+    "quantity": {
+      "packsOpened_one": "{{count, number}} pack",
+      "packsOpened_few": "{{count, number}} packs",
+      "packsOpened_many": "{{count, number}} packs",
+      "packsOpened_other": "{{count, number}} packs",
+      "cardsContained_one": "{{count, number}} card",
+      "cardsContained_few": "{{count, number}} cards",
+      "cardsContained_many": "{{count, number}} cards",
+      "cardsContained_other": "{{count, number}} cards",
+      "packSizeEntry_one": "{{count, number}} card",
+      "packSizeEntry_few": "{{count, number}} cards",
+      "packSizeEntry_many": "{{count, number}} cards",
+      "packSizeEntry_other": "{{count, number}} cards",
+      "minimumDeckCards_one": "{{count, number}} card",
+      "minimumDeckCards_few": "{{count, number}} cards",
+      "minimumDeckCards_many": "{{count, number}} cards",
+      "minimumDeckCards_other": "{{count, number}} cards"
+    },
+    "packPassing_one": "This draft has one pack round, so the passing direction does not alternate",
+    "packPassing_few": "The passing direction alternates each round",
+    "packPassing_many": "The passing direction alternates each round",
+    "packPassing_other": "The passing direction alternates each round",
     "quick": {
-      "step1": "You'll open {{packCount}} packs of {{cardsPerPack}} cards each",
+      "step1": "You'll open {{packs}}; each pack contains {{cardsPerPack}}",
       "step2": "Pick one card per pack, then pass the rest to AI drafters",
-      "step3": "Packs alternate direction each round — left, right, left",
-      "step4": "After all picks, build a 40-card deck and play a match",
-      "step1Mixed": "You'll open {{packCount}} packs of mixed sizes — {{packSizes}} cards, in that order"
+      "step4": "After all picks, build a deck of at least {{minimumDeckCards}} and play a match",
+      "step1Mixed": "You'll open {{packs}} of mixed sizes, in this order: {{packSizes, list}}"
     },
     "pod": {
       "step1": "You're drafting with {{count}} players in a pod",
-      "step2": "Open 3 packs of 14 cards — pick one, pass the rest",
-      "step3": "Packs alternate direction each round — left, right, left",
-      "step4": "After drafting, build a 40-card deck and play tournament matches"
+      "step2": "Open {{packs}}; each pack contains {{cardsPerPack}} — pick one, pass the rest",
+      "step2Mixed": "Open {{packs}} of mixed sizes, in this order: {{packSizes, list}} — pick one, pass the rest",
+      "step4": "After drafting, build a deck of at least {{minimumDeckCards}} and play tournament matches"
     },
     "commander": {
       "step2": "Pick two cards from each pack, then pass the rest",
-      "step4": "After drafting, build a 60-card Commander deck and play one multiplayer game"
+      "step4": "After drafting, build a Commander deck of at least {{minimumDeckCards}} and play one multiplayer game"
     }
   },
   "steps": {
@@ -122,7 +143,10 @@
   },
   "sealedOpening": {
     "title": "Open your sealed pool",
-    "subtitle": "Open six packs, one at a time.",
+    "subtitle_one": "Open {{count}} pack.",
+    "subtitle_few": "Open {{count}} packs, one at a time.",
+    "subtitle_many": "Open {{count}} packs, one at a time.",
+    "subtitle_other": "Open {{count}} packs, one at a time.",
     "packProgress": "Pack {{current}} of {{total}}",
     "openPack": "Open pack",
     "openPackArt": "Open pack artwork",

--- a/client/src/i18n/locales/en/draft.json
+++ b/client/src/i18n/locales/en/draft.json
@@ -40,7 +40,8 @@
       "step4": "After drafting, build a deck of at least {{minimumDeckCards}} and play tournament matches"
     },
     "commander": {
-      "step2": "Pick two cards from each pack, then pass the rest",
+      "step2": "Open {{packs}}; each pack contains {{cardsPerPack}} — pick two cards, pass the rest",
+      "step2Mixed": "Open {{packs}} of mixed sizes, in this order: {{packSizes, list}} — pick two cards, pass the rest",
       "step4": "After drafting, build a Commander deck of at least {{minimumDeckCards}} and play one multiplayer game"
     }
   },

--- a/client/src/i18n/locales/es/draft.json
+++ b/client/src/i18n/locales/es/draft.json
@@ -5,22 +5,43 @@
     "commanderTitle": "Commander Draft",
     "subtitle": "Así funciona",
     "startDrafting": "Empezar a draftear",
+    "quantity": {
+      "packsOpened_one": "{{count, number}} sobre",
+      "packsOpened_few": "{{count, number}} sobres",
+      "packsOpened_many": "{{count, number}} sobres",
+      "packsOpened_other": "{{count, number}} sobres",
+      "cardsContained_one": "{{count, number}} carta",
+      "cardsContained_few": "{{count, number}} cartas",
+      "cardsContained_many": "{{count, number}} cartas",
+      "cardsContained_other": "{{count, number}} cartas",
+      "packSizeEntry_one": "{{count, number}} carta",
+      "packSizeEntry_few": "{{count, number}} cartas",
+      "packSizeEntry_many": "{{count, number}} cartas",
+      "packSizeEntry_other": "{{count, number}} cartas",
+      "minimumDeckCards_one": "{{count, number}} carta",
+      "minimumDeckCards_few": "{{count, number}} cartas",
+      "minimumDeckCards_many": "{{count, number}} cartas",
+      "minimumDeckCards_other": "{{count, number}} cartas"
+    },
+    "packPassing_one": "Este draft tiene una sola ronda de sobres, por lo que la dirección de pase no cambia",
+    "packPassing_few": "La dirección de pase cambia en cada ronda",
+    "packPassing_many": "La dirección de pase cambia en cada ronda",
+    "packPassing_other": "La dirección de pase cambia en cada ronda",
     "quick": {
-      "step1": "Abrirás 3 sobres de 14 cartas cada uno",
+      "step1": "Abrirás {{packs}}; cada sobre contiene {{cardsPerPack}}",
       "step2": "Elige una carta por sobre y luego pasa el resto a los drafters de IA",
-      "step3": "Los sobres alternan de dirección en cada ronda — izquierda, derecha, izquierda",
-      "step4": "Tras todas las elecciones, construye un mazo de 40 cartas y juega una partida",
-      "step1Mixed": "Abrirás {{packCount}} sobres de tamaños distintos: {{packSizes}} cartas, en ese orden"
+      "step4": "Tras todas las elecciones, construye un mazo de al menos {{minimumDeckCards}} y juega una partida",
+      "step1Mixed": "Abrirás {{packs}} de tamaños distintos, en este orden: {{packSizes, list}}"
     },
     "pod": {
       "step1": "Estás haciendo draft con {{count}} jugadores en un pod",
-      "step2": "Abre 3 sobres de 14 cartas — elige una, pasa el resto",
-      "step3": "Los sobres alternan de dirección en cada ronda — izquierda, derecha, izquierda",
-      "step4": "Tras el draft, construye un mazo de 40 cartas y juega partidas de torneo"
+      "step2": "Abre {{packs}}; cada sobre contiene {{cardsPerPack}} — elige una carta y pasa el resto",
+      "step2Mixed": "Abre {{packs}} de tamaños distintos, en este orden: {{packSizes, list}} — elige una carta y pasa el resto",
+      "step4": "Tras el draft, construye un mazo de al menos {{minimumDeckCards}} y juega partidas de torneo"
     },
     "commander": {
       "step2": "Elige dos cartas de cada sobre y pasa el resto",
-      "step4": "Tras el draft, construye un mazo Commander de 60 cartas y juega una partida multijugador"
+      "step4": "Tras el draft, construye un mazo Commander de al menos {{minimumDeckCards}} y juega una partida multijugador"
     }
   },
   "steps": {
@@ -122,7 +143,10 @@
   },
   "sealedOpening": {
     "title": "Abre tu pool de sellado",
-    "subtitle": "Abre seis sobres, uno a la vez.",
+    "subtitle_one": "Abre {{count}} sobre.",
+    "subtitle_few": "Abre {{count}} sobres, uno a la vez.",
+    "subtitle_many": "Abre {{count}} sobres, uno a la vez.",
+    "subtitle_other": "Abre {{count}} sobres, uno a la vez.",
     "packProgress": "Sobre {{current}} de {{total}}",
     "openPack": "Abrir sobre",
     "openPackArt": "Abrir ilustración del sobre",

--- a/client/src/i18n/locales/es/draft.json
+++ b/client/src/i18n/locales/es/draft.json
@@ -40,7 +40,8 @@
       "step4": "Tras el draft, construye un mazo de al menos {{minimumDeckCards}} y juega partidas de torneo"
     },
     "commander": {
-      "step2": "Elige dos cartas de cada sobre y pasa el resto",
+      "step2": "Abre {{packs}}; cada sobre contiene {{cardsPerPack}} — elige dos cartas y pasa el resto",
+      "step2Mixed": "Abre {{packs}} de tamaños distintos, en este orden: {{packSizes, list}} — elige dos cartas y pasa el resto",
       "step4": "Tras el draft, construye un mazo Commander de al menos {{minimumDeckCards}} y juega una partida multijugador"
     }
   },

--- a/client/src/i18n/locales/fr/draft.json
+++ b/client/src/i18n/locales/fr/draft.json
@@ -5,22 +5,43 @@
     "commanderTitle": "Commander Draft",
     "subtitle": "Voici comment ça fonctionne",
     "startDrafting": "Commencer le draft",
+    "quantity": {
+      "packsOpened_one": "{{count, number}} booster",
+      "packsOpened_few": "{{count, number}} boosters",
+      "packsOpened_many": "{{count, number}} boosters",
+      "packsOpened_other": "{{count, number}} boosters",
+      "cardsContained_one": "{{count, number}} carte",
+      "cardsContained_few": "{{count, number}} cartes",
+      "cardsContained_many": "{{count, number}} cartes",
+      "cardsContained_other": "{{count, number}} cartes",
+      "packSizeEntry_one": "{{count, number}} carte",
+      "packSizeEntry_few": "{{count, number}} cartes",
+      "packSizeEntry_many": "{{count, number}} cartes",
+      "packSizeEntry_other": "{{count, number}} cartes",
+      "minimumDeckCards_one": "{{count, number}} carte",
+      "minimumDeckCards_few": "{{count, number}} cartes",
+      "minimumDeckCards_many": "{{count, number}} cartes",
+      "minimumDeckCards_other": "{{count, number}} cartes"
+    },
+    "packPassing_one": "Ce draft ne comporte qu'une seule manche de boosters, donc le sens de passage n'alterne pas",
+    "packPassing_few": "Le sens de passage change à chaque manche",
+    "packPassing_many": "Le sens de passage change à chaque manche",
+    "packPassing_other": "Le sens de passage change à chaque manche",
     "quick": {
-      "step1": "Vous ouvrirez 3 boosters de 14 cartes chacun",
+      "step1": "Vous ouvrirez {{packs}} ; chaque booster contient {{cardsPerPack}}",
       "step2": "Choisissez une carte par booster, puis passez le reste aux drafteurs IA",
-      "step3": "Les boosters changent de sens à chaque manche — gauche, droite, gauche",
-      "step4": "Après tous les choix, construisez un deck de 40 cartes et jouez un match",
-      "step1Mixed": "Vous ouvrirez {{packCount}} boosters de tailles différentes — {{packSizes}} cartes, dans cet ordre"
+      "step4": "Après tous les choix, construisez un deck d'au moins {{minimumDeckCards}} et jouez un match",
+      "step1Mixed": "Vous ouvrirez {{packs}} de tailles différentes, dans cet ordre : {{packSizes, list}}"
     },
     "pod": {
       "step1": "Vous draftez avec {{count}} joueurs dans un pod",
-      "step2": "Ouvrez 3 boosters de 14 cartes — choisissez-en une, passez le reste",
-      "step3": "Les boosters changent de sens à chaque manche — gauche, droite, gauche",
-      "step4": "Après le draft, construisez un deck de 40 cartes et jouez des matchs de tournoi"
+      "step2": "Ouvrez {{packs}} ; chaque booster contient {{cardsPerPack}} — choisissez une carte, puis passez le reste",
+      "step2Mixed": "Ouvrez {{packs}} de tailles différentes, dans cet ordre : {{packSizes, list}} — choisissez une carte, puis passez le reste",
+      "step4": "Après le draft, construisez un deck d'au moins {{minimumDeckCards}} et jouez des matchs de tournoi"
     },
     "commander": {
       "step2": "Choisissez deux cartes dans chaque booster, puis passez le reste",
-      "step4": "Après le draft, construisez un deck Commander de 60 cartes et jouez une partie multijoueur"
+      "step4": "Après le draft, construisez un deck Commander d'au moins {{minimumDeckCards}} et jouez une partie multijoueur"
     }
   },
   "steps": {
@@ -122,7 +143,10 @@
   },
   "sealedOpening": {
     "title": "Ouvrez votre pool scellé",
-    "subtitle": "Ouvrez six boosters, un à la fois.",
+    "subtitle_one": "Ouvrez {{count}} booster.",
+    "subtitle_few": "Ouvrez {{count}} boosters, un à la fois.",
+    "subtitle_many": "Ouvrez {{count}} boosters, un à la fois.",
+    "subtitle_other": "Ouvrez {{count}} boosters, un à la fois.",
     "packProgress": "Booster {{current}} sur {{total}}",
     "openPack": "Ouvrir le booster",
     "openPackArt": "Ouvrir l’illustration du booster",

--- a/client/src/i18n/locales/fr/draft.json
+++ b/client/src/i18n/locales/fr/draft.json
@@ -40,7 +40,8 @@
       "step4": "Après le draft, construisez un deck d'au moins {{minimumDeckCards}} et jouez des matchs de tournoi"
     },
     "commander": {
-      "step2": "Choisissez deux cartes dans chaque booster, puis passez le reste",
+      "step2": "Ouvrez {{packs}} ; chaque booster contient {{cardsPerPack}} — choisissez deux cartes, puis passez le reste",
+      "step2Mixed": "Ouvrez {{packs}} de tailles différentes, dans cet ordre : {{packSizes, list}} — choisissez deux cartes, puis passez le reste",
       "step4": "Après le draft, construisez un deck Commander d'au moins {{minimumDeckCards}} et jouez une partie multijoueur"
     }
   },

--- a/client/src/i18n/locales/it/draft.json
+++ b/client/src/i18n/locales/it/draft.json
@@ -5,22 +5,43 @@
     "commanderTitle": "Commander Draft",
     "subtitle": "Ecco come funziona",
     "startDrafting": "Inizia il draft",
+    "quantity": {
+      "packsOpened_one": "{{count, number}} busta",
+      "packsOpened_few": "{{count, number}} buste",
+      "packsOpened_many": "{{count, number}} buste",
+      "packsOpened_other": "{{count, number}} buste",
+      "cardsContained_one": "{{count, number}} carta",
+      "cardsContained_few": "{{count, number}} carte",
+      "cardsContained_many": "{{count, number}} carte",
+      "cardsContained_other": "{{count, number}} carte",
+      "packSizeEntry_one": "{{count, number}} carta",
+      "packSizeEntry_few": "{{count, number}} carte",
+      "packSizeEntry_many": "{{count, number}} carte",
+      "packSizeEntry_other": "{{count, number}} carte",
+      "minimumDeckCards_one": "{{count, number}} carta",
+      "minimumDeckCards_few": "{{count, number}} carte",
+      "minimumDeckCards_many": "{{count, number}} carte",
+      "minimumDeckCards_other": "{{count, number}} carte"
+    },
+    "packPassing_one": "Questo draft ha un solo round di buste, quindi la direzione di passaggio non cambia",
+    "packPassing_few": "La direzione di passaggio cambia a ogni round",
+    "packPassing_many": "La direzione di passaggio cambia a ogni round",
+    "packPassing_other": "La direzione di passaggio cambia a ogni round",
     "quick": {
-      "step1": "Aprirai 3 buste da 14 carte ciascuna",
+      "step1": "Aprirai {{packs}}; ogni busta contiene {{cardsPerPack}}",
       "step2": "Scegli una carta per busta, poi passa il resto agli altri draftatori IA",
-      "step3": "Le buste alternano direzione a ogni round — sinistra, destra, sinistra",
-      "step4": "Dopo tutte le scelte, costruisci un mazzo da 40 carte e gioca una partita",
-      "step1Mixed": "Aprirai {{packCount}} buste di dimensioni diverse — {{packSizes}} carte, in quest'ordine"
+      "step4": "Dopo tutte le scelte, costruisci un mazzo di almeno {{minimumDeckCards}} e gioca una partita",
+      "step1Mixed": "Aprirai {{packs}} di dimensioni diverse, in quest'ordine: {{packSizes, list}}"
     },
     "pod": {
       "step1": "Stai draftando con {{count}} giocatori in un pod",
-      "step2": "Apri 3 buste da 14 carte — scegline una, passa il resto",
-      "step3": "Le buste alternano direzione a ogni round — sinistra, destra, sinistra",
-      "step4": "Dopo il draft, costruisci un mazzo da 40 carte e gioca le partite del torneo"
+      "step2": "Apri {{packs}}; ogni busta contiene {{cardsPerPack}} — scegli una carta e passa il resto",
+      "step2Mixed": "Apri {{packs}} di dimensioni diverse, in quest'ordine: {{packSizes, list}} — scegli una carta e passa il resto",
+      "step4": "Dopo il draft, costruisci un mazzo di almeno {{minimumDeckCards}} e gioca le partite del torneo"
     },
     "commander": {
       "step2": "Scegli due carte da ogni busta, poi passa il resto",
-      "step4": "Dopo il draft, costruisci un mazzo Commander da 60 carte e gioca una partita multigiocatore"
+      "step4": "Dopo il draft, costruisci un mazzo Commander di almeno {{minimumDeckCards}} e gioca una partita multigiocatore"
     }
   },
   "steps": {
@@ -122,7 +143,10 @@
   },
   "sealedOpening": {
     "title": "Apri il tuo pool Sealed",
-    "subtitle": "Apri sei buste, una alla volta.",
+    "subtitle_one": "Apri {{count}} busta.",
+    "subtitle_few": "Apri {{count}} buste, una alla volta.",
+    "subtitle_many": "Apri {{count}} buste, una alla volta.",
+    "subtitle_other": "Apri {{count}} buste, una alla volta.",
     "packProgress": "Busta {{current}} di {{total}}",
     "openPack": "Apri busta",
     "openPackArt": "Apri l’illustrazione della busta",

--- a/client/src/i18n/locales/it/draft.json
+++ b/client/src/i18n/locales/it/draft.json
@@ -40,7 +40,8 @@
       "step4": "Dopo il draft, costruisci un mazzo di almeno {{minimumDeckCards}} e gioca le partite del torneo"
     },
     "commander": {
-      "step2": "Scegli due carte da ogni busta, poi passa il resto",
+      "step2": "Apri {{packs}}; ogni busta contiene {{cardsPerPack}} — scegli due carte e passa il resto",
+      "step2Mixed": "Apri {{packs}} di dimensioni diverse, in quest'ordine: {{packSizes, list}} — scegli due carte e passa il resto",
       "step4": "Dopo il draft, costruisci un mazzo Commander di almeno {{minimumDeckCards}} e gioca una partita multigiocatore"
     }
   },

--- a/client/src/i18n/locales/pl/draft.json
+++ b/client/src/i18n/locales/pl/draft.json
@@ -5,22 +5,43 @@
     "commanderTitle": "Commander Draft",
     "subtitle": "Oto jak to działa",
     "startDrafting": "Rozpocznij draft",
+    "quantity": {
+      "packsOpened_one": "{{count, number}} booster",
+      "packsOpened_few": "{{count, number}} boostery",
+      "packsOpened_many": "{{count, number}} boosterów",
+      "packsOpened_other": "{{count, number}} boostera",
+      "cardsContained_one": "{{count, number}} kartę",
+      "cardsContained_few": "{{count, number}} karty",
+      "cardsContained_many": "{{count, number}} kart",
+      "cardsContained_other": "{{count, number}} karty",
+      "packSizeEntry_one": "{{count, number}} karta",
+      "packSizeEntry_few": "{{count, number}} karty",
+      "packSizeEntry_many": "{{count, number}} kart",
+      "packSizeEntry_other": "{{count, number}} karty",
+      "minimumDeckCards_one": "{{count, number}} karty",
+      "minimumDeckCards_few": "{{count, number}} kart",
+      "minimumDeckCards_many": "{{count, number}} kart",
+      "minimumDeckCards_other": "{{count, number}} karty"
+    },
+    "packPassing_one": "Ten draft ma tylko jedną rundę boosterów, więc kierunek przekazywania się nie zmienia",
+    "packPassing_few": "Kierunek przekazywania zmienia się w każdej rundzie",
+    "packPassing_many": "Kierunek przekazywania zmienia się w każdej rundzie",
+    "packPassing_other": "Kierunek przekazywania zmienia się w każdej rundzie",
     "quick": {
-      "step1": "Otworzysz 3 boostery po 14 kart każdy",
+      "step1": "Otworzysz {{packs}}; każdy booster zawiera {{cardsPerPack}}",
       "step2": "Wybierz jedną kartę z każdego boostera, a resztę przekaż dalej do botów",
-      "step3": "Boostery zmieniają kierunek w każdej rundzie — w lewo, w prawo, w lewo",
-      "step4": "Po wszystkich wyborach zbuduj talię z 40 kart i rozegraj mecz",
-      "step1Mixed": "Otworzysz {{packCount}} boosterów o różnych rozmiarach — {{packSizes}} kart, w tej kolejności"
+      "step4": "Po wszystkich wyborach zbuduj talię z co najmniej {{minimumDeckCards}} i rozegraj mecz",
+      "step1Mixed": "Otworzysz {{packs}} o różnych rozmiarach, w tej kolejności: {{packSizes, list}}"
     },
     "pod": {
       "step1": "Draftujesz z {{count}} graczami w grupie",
-      "step2": "Otwórz 3 boostery po 14 kart — wybierz jedną, resztę przekaż dalej",
-      "step3": "Boostery zmieniają kierunek w każdej rundzie — w lewo, w prawo, w lewo",
-      "step4": "Po drafcie zbuduj talię z 40 kart i rozegraj mecze turniejowe"
+      "step2": "Otwórz {{packs}}; każdy booster zawiera {{cardsPerPack}} — wybierz jedną kartę, a resztę przekaż dalej",
+      "step2Mixed": "Otwórz {{packs}} o różnych rozmiarach, w tej kolejności: {{packSizes, list}} — wybierz jedną kartę, a resztę przekaż dalej",
+      "step4": "Po drafcie zbuduj talię z co najmniej {{minimumDeckCards}} i rozegraj mecze turniejowe"
     },
     "commander": {
       "step2": "Wybierz dwie karty z każdego boostera, a resztę przekaż dalej",
-      "step4": "Po drafcie zbuduj talię Commander z 60 kart i rozegraj jedną grę wieloosobową"
+      "step4": "Po drafcie zbuduj talię Commander z co najmniej {{minimumDeckCards}} i rozegraj jedną grę wieloosobową"
     }
   },
   "steps": {
@@ -122,7 +143,10 @@
   },
   "sealedOpening": {
     "title": "Otwórz swoją pulę Sealed",
-    "subtitle": "Otwórz sześć boosterów, po jednym na raz.",
+    "subtitle_one": "Otwórz {{count}} booster.",
+    "subtitle_few": "Otwórz {{count}} boostery, po jednym na raz.",
+    "subtitle_many": "Otwórz {{count}} boosterów, po jednym na raz.",
+    "subtitle_other": "Otwórz {{count}} boostera, po jednym na raz.",
     "packProgress": "Booster {{current}} z {{total}}",
     "openPack": "Otwórz booster",
     "openPackArt": "Otwórz grafikę boostera",

--- a/client/src/i18n/locales/pl/draft.json
+++ b/client/src/i18n/locales/pl/draft.json
@@ -40,7 +40,8 @@
       "step4": "Po drafcie zbuduj talię z co najmniej {{minimumDeckCards}} i rozegraj mecze turniejowe"
     },
     "commander": {
-      "step2": "Wybierz dwie karty z każdego boostera, a resztę przekaż dalej",
+      "step2": "Otwórz {{packs}}; każdy booster zawiera {{cardsPerPack}} — wybierz dwie karty, a resztę przekaż dalej",
+      "step2Mixed": "Otwórz {{packs}} o różnych rozmiarach, w tej kolejności: {{packSizes, list}} — wybierz dwie karty, a resztę przekaż dalej",
       "step4": "Po drafcie zbuduj talię Commander z co najmniej {{minimumDeckCards}} i rozegraj jedną grę wieloosobową"
     }
   },

--- a/client/src/i18n/locales/pt/draft.json
+++ b/client/src/i18n/locales/pt/draft.json
@@ -40,7 +40,8 @@
       "step4": "Após o draft, monte um deck de pelo menos {{minimumDeckCards}} e jogue as partidas do torneio"
     },
     "commander": {
-      "step2": "Escolha duas cartas de cada booster e passe o restante",
+      "step2": "Abra {{packs}}; cada booster contém {{cardsPerPack}} — escolha duas cartas e passe o restante",
+      "step2Mixed": "Abra {{packs}} de tamanhos diferentes, nesta ordem: {{packSizes, list}} — escolha duas cartas e passe o restante",
       "step4": "Após o draft, monte um deck Commander de pelo menos {{minimumDeckCards}} e jogue uma partida multijogador"
     }
   },

--- a/client/src/i18n/locales/pt/draft.json
+++ b/client/src/i18n/locales/pt/draft.json
@@ -5,22 +5,43 @@
     "commanderTitle": "Commander Draft",
     "subtitle": "Veja como funciona",
     "startDrafting": "Começar a Draftar",
+    "quantity": {
+      "packsOpened_one": "{{count, number}} booster",
+      "packsOpened_few": "{{count, number}} boosters",
+      "packsOpened_many": "{{count, number}} boosters",
+      "packsOpened_other": "{{count, number}} boosters",
+      "cardsContained_one": "{{count, number}} carta",
+      "cardsContained_few": "{{count, number}} cartas",
+      "cardsContained_many": "{{count, number}} cartas",
+      "cardsContained_other": "{{count, number}} cartas",
+      "packSizeEntry_one": "{{count, number}} carta",
+      "packSizeEntry_few": "{{count, number}} cartas",
+      "packSizeEntry_many": "{{count, number}} cartas",
+      "packSizeEntry_other": "{{count, number}} cartas",
+      "minimumDeckCards_one": "{{count, number}} carta",
+      "minimumDeckCards_few": "{{count, number}} cartas",
+      "minimumDeckCards_many": "{{count, number}} cartas",
+      "minimumDeckCards_other": "{{count, number}} cartas"
+    },
+    "packPassing_one": "Este draft tem apenas uma rodada de boosters, então a direção dos passes não muda",
+    "packPassing_few": "A direção dos passes muda a cada rodada",
+    "packPassing_many": "A direção dos passes muda a cada rodada",
+    "packPassing_other": "A direção dos passes muda a cada rodada",
     "quick": {
-      "step1": "Você abrirá 3 boosters de 14 cartas cada",
+      "step1": "Você abrirá {{packs}}; cada booster contém {{cardsPerPack}}",
       "step2": "Escolha uma carta por booster e passe o restante para os draftadores de IA",
-      "step3": "Os boosters alternam de direção a cada rodada — esquerda, direita, esquerda",
-      "step4": "Após todas as escolhas, monte um deck de 40 cartas e jogue uma partida",
-      "step1Mixed": "Você abrirá {{packCount}} boosters de tamanhos diferentes — {{packSizes}} cartas, nessa ordem"
+      "step4": "Após todas as escolhas, monte um deck de pelo menos {{minimumDeckCards}} e jogue uma partida",
+      "step1Mixed": "Você abrirá {{packs}} de tamanhos diferentes, nesta ordem: {{packSizes, list}}"
     },
     "pod": {
       "step1": "Você está draftando com {{count}} jogadores em um pod",
-      "step2": "Abra 3 boosters de 14 cartas — escolha uma, passe o restante",
-      "step3": "Os boosters alternam de direção a cada rodada — esquerda, direita, esquerda",
-      "step4": "Após o draft, monte um deck de 40 cartas e jogue as partidas do torneio"
+      "step2": "Abra {{packs}}; cada booster contém {{cardsPerPack}} — escolha uma carta e passe o restante",
+      "step2Mixed": "Abra {{packs}} de tamanhos diferentes, nesta ordem: {{packSizes, list}} — escolha uma carta e passe o restante",
+      "step4": "Após o draft, monte um deck de pelo menos {{minimumDeckCards}} e jogue as partidas do torneio"
     },
     "commander": {
       "step2": "Escolha duas cartas de cada booster e passe o restante",
-      "step4": "Após o draft, monte um deck Commander de 60 cartas e jogue uma partida multijogador"
+      "step4": "Após o draft, monte um deck Commander de pelo menos {{minimumDeckCards}} e jogue uma partida multijogador"
     }
   },
   "steps": {
@@ -122,7 +143,10 @@
   },
   "sealedOpening": {
     "title": "Abra seu pool de Selado",
-    "subtitle": "Abra seis boosters, um de cada vez.",
+    "subtitle_one": "Abra {{count}} booster.",
+    "subtitle_few": "Abra {{count}} boosters, um de cada vez.",
+    "subtitle_many": "Abra {{count}} boosters, um de cada vez.",
+    "subtitle_other": "Abra {{count}} boosters, um de cada vez.",
     "packProgress": "Booster {{current}} de {{total}}",
     "openPack": "Abrir booster",
     "openPackArt": "Abrir arte do booster",

--- a/client/src/pages/DraftPage.tsx
+++ b/client/src/pages/DraftPage.tsx
@@ -684,12 +684,14 @@ export function DraftPage() {
           </div>
         )}
 
-        {phase === "drafting" && !introDismissed && (
+        {phase === "drafting" && !introDismissed && draftView && (
           <DraftIntro
             mode="quick"
-            packCount={draftView?.pack_count}
-            cardsPerPack={draftView?.cards_per_pack}
-            packSizes={draftView?.pack_sizes}
+            podSize={draftView.seats.length}
+            packCount={draftView.pack_count}
+            cardsPerPack={draftView.cards_per_pack}
+            packSizes={draftView.pack_sizes}
+            minDeckSize={draftView.min_deck_size}
             onContinue={() => setIntroDismissed(true)}
           />
         )}

--- a/client/src/pages/DraftPodPage.tsx
+++ b/client/src/pages/DraftPodPage.tsx
@@ -917,13 +917,19 @@ function DraftingPhaseContent({
     // so `view` is genuinely nullable here. In that window the seat count is unknown
     // and nothing is rendered: an intro sentence stating a confident wrong number is
     // worse than a frame with no intro, and the following `viewUpdated` supplies it.
-    return view ? (
+    if (!view) return null;
+
+    return (
       <DraftIntro
         mode={view.kind === "CommanderDraft" ? "commander" : "pod"}
         podSize={view.seats.length}
+        packCount={view.pack_count}
+        cardsPerPack={view.cards_per_pack}
+        packSizes={view.pack_sizes}
+        minDeckSize={view.min_deck_size}
         onContinue={() => setIntroDismissed(true)}
       />
-    ) : null;
+    );
   }
 
   // Wire `pauseReason` is `DraftPauseReason` (PascalCase) — same shape as the

--- a/client/src/pages/__tests__/DraftPage.workspace.test.tsx
+++ b/client/src/pages/__tests__/DraftPage.workspace.test.tsx
@@ -13,6 +13,16 @@ import type { LocalDeckBuilderController } from "../../components/draft/LimitedD
 import type { PackDisplayController, PackDisplayPresentation } from "../../components/draft/PackDisplay";
 import { projectWorkspaceLandCounts } from "../../components/draft/workspace/workspaceProjection";
 
+interface DraftIntroCapture {
+  mode: string;
+  podSize: number;
+  packCount: number;
+  cardsPerPack: number;
+  packSizes?: number[];
+  minDeckSize: number;
+  onContinue(): void;
+}
+
 const wasm = vi.hoisted(() => ({
   ...(() => {
     Object.assign(globalThis, {
@@ -59,6 +69,7 @@ const captured = vi.hoisted(() => ({
   phoneToolbarPinned: null as boolean | null,
   shellMode: null as string | null,
   steps: null as { phase?: string; compact?: boolean; arrowSeparators?: boolean } | null,
+  intro: null as DraftIntroCapture | null,
 }));
 
 vi.mock("@wasm/draft", () => wasm);
@@ -112,7 +123,10 @@ vi.mock("../../components/draft/SealedPackOpening", () => ({
   ),
 }));
 vi.mock("../../components/draft/DraftIntro", () => ({
-  DraftIntro: ({ onContinue }: { onContinue(): void }) => <button type="button" onClick={onContinue}>Continue</button>,
+  DraftIntro: (props: DraftIntroCapture) => {
+    captured.intro = props;
+    return <button type="button" onClick={props.onContinue}>Continue</button>;
+  },
 }));
 
 import { useDraftStore } from "../../stores/draftStore";
@@ -155,6 +169,7 @@ describe("DraftPage local deckbuilding wiring", () => {
     captured.phoneToolbarPinned = null;
     captured.shellMode = null;
     captured.steps = null;
+    captured.intro = null;
     usePreferencesStore.setState({ draftCardPreviewMode: "none", draftDoubleClickConfirmPick: true });
     useDraftStore.getState().reset();
     Object.defineProperty(window, "innerWidth", { configurable: true, writable: true, value: 1440 });
@@ -212,6 +227,29 @@ describe("DraftPage local deckbuilding wiring", () => {
     expect(stepsSpacing).toHaveClass("mb-4");
     expect(captured.preview).toMatchObject({ mode: "side", hoverDelayMs: 0 });
     expect(captured.pack).toMatchObject({ kind: "local-workspace", doubleClickPick: true });
+  });
+
+  it("forwards the engine-published procedure to the draft intro", async () => {
+    wasm.start_quick_draft.mockReturnValue(view({
+      pack_count: 4,
+      cards_per_pack: 12,
+      pack_sizes: [12, 12, 12, 12],
+      min_deck_size: 35,
+    }));
+    await act(async () => {
+      await useDraftStore.getState().startDraft("pool", "TST", "Test", 2);
+    });
+
+    render(<MemoryRouter><DraftPage /></MemoryRouter>);
+
+    expect(captured.intro).toMatchObject({
+      mode: "quick",
+      podSize: 0,
+      packCount: 4,
+      cardsPerPack: 12,
+      packSizes: [12, 12, 12, 12],
+      minDeckSize: 35,
+    });
   });
 
   it("hides_draft_progress_on_phone_viewports", async () => {

--- a/client/src/pages/__tests__/DraftPodPage.modeEntry.test.tsx
+++ b/client/src/pages/__tests__/DraftPodPage.modeEntry.test.tsx
@@ -211,7 +211,9 @@ describe("DraftPodPage ?kind= mode entry", () => {
     expect(useDraftPodStore.getState().config.kind).toBe("Premier");
     // REVERT-FAILING: BASE renders `<DraftIntro mode="pod" .../>` unconditionally.
     expect(
-      screen.getByText("Pick two cards from each pack, then pass the rest"),
+      screen.getByText(
+        "Open 4 packs; each pack contains 12 cards — pick two cards, pass the rest",
+      ),
     ).toBeInTheDocument();
     expect(
       screen.getByText(
@@ -271,7 +273,9 @@ describe("DraftPodPage ?kind= mode entry", () => {
     ).toBeInTheDocument();
     // Non-vacuous: the positive above proves the intro mounted.
     expect(
-      screen.queryByText("Pick two cards from each pack, then pass the rest"),
+      screen.queryByText(
+        "Open 4 packs; each pack contains 12 cards — pick two cards, pass the rest",
+      ),
     ).toBeNull();
   });
 

--- a/client/src/pages/__tests__/DraftPodPage.modeEntry.test.tsx
+++ b/client/src/pages/__tests__/DraftPodPage.modeEntry.test.tsx
@@ -25,7 +25,14 @@ const mocks = vi.hoisted(() => ({
     // host locator. `absent` terminates it, leaving the kind-intent effect as
     // this suite's only subject.
     resumeDraft: vi.fn(async () => "absent" as const),
-    view: null as { kind: string; seats: { seat_index: number }[] } | null,
+    view: null as {
+      kind: string;
+      seats: { seat_index: number }[];
+      pack_count: number;
+      cards_per_pack: number;
+      pack_sizes: number[];
+      min_deck_size: number;
+    } | null,
   },
 }));
 
@@ -68,13 +75,27 @@ vi.mock("../../components/draft/CubeSetupPanel", () => ({ CubeSetupPanel: () => 
 import { DraftPodPage } from "../DraftPodPage";
 import { useDraftPodStore } from "../../stores/draftPodStore";
 
-/** An engine-published `DraftPlayerView` slice: the two fields the intro reads.
+/** An engine-published `DraftPlayerView` slice containing the procedure the intro reads.
  *  `seats` is the pod's real size — `draftPodStore.config.podSize` is this client's
  *  own intent and is deliberately left on its default in every fixture below. */
-function engineView(kind: string, seatCount: number) {
+function engineView(
+  kind: string,
+  seatCount: number,
+  procedure: Partial<{
+    pack_count: number;
+    cards_per_pack: number;
+    pack_sizes: number[];
+    min_deck_size: number;
+  }> = {},
+) {
   return {
     kind,
     seats: Array.from({ length: seatCount }, (_, seat_index) => ({ seat_index })),
+    pack_count: 4,
+    cards_per_pack: 12,
+    pack_sizes: [12, 12, 12, 12],
+    min_deck_size: 45,
+    ...procedure,
   };
 }
 
@@ -182,13 +203,20 @@ describe("DraftPodPage ?kind= mode entry", () => {
     // kind, so the intro must read `view.kind`. This fixture is exactly that
     // case: the store is left on its "Premier" default.
     mocks.multiplayerState.phase = "drafting";
-    mocks.multiplayerState.view = engineView("CommanderDraft", 4);
+    mocks.multiplayerState.view = engineView("CommanderDraft", 4, {
+      min_deck_size: 63,
+    });
     renderAt("/draft-pod");
 
     expect(useDraftPodStore.getState().config.kind).toBe("Premier");
     // REVERT-FAILING: BASE renders `<DraftIntro mode="pod" .../>` unconditionally.
     expect(
       screen.getByText("Pick two cards from each pack, then pass the rest"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "After drafting, build a Commander deck of at least 63 cards and play one multiplayer game",
+      ),
     ).toBeInTheDocument();
   });
 
@@ -234,11 +262,32 @@ describe("DraftPodPage ?kind= mode entry", () => {
     renderAt("/draft-pod");
 
     expect(
-      screen.getByText("Open 3 packs of 14 cards — pick one, pass the rest"),
+      screen.getByText("Open 4 packs; each pack contains 12 cards — pick one, pass the rest"),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText(
+        "After drafting, build a deck of at least 45 cards and play tournament matches",
+      ),
     ).toBeInTheDocument();
     // Non-vacuous: the positive above proves the intro mounted.
     expect(
       screen.queryByText("Pick two cards from each pack, then pass the rest"),
     ).toBeNull();
+  });
+
+  it("renders mixed pack sizes from the engine-published view", () => {
+    mocks.multiplayerState.phase = "drafting";
+    mocks.multiplayerState.view = engineView("Premier", 8, {
+      pack_count: 3,
+      cards_per_pack: 15,
+      pack_sizes: [15, 14, 15],
+    });
+    renderAt("/draft-pod");
+
+    expect(
+      screen.getByText(
+        "Open 3 packs of mixed sizes, in this order: 15 cards, 14 cards, and 15 cards — pick one, pass the rest",
+      ),
+    ).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary

Render live draft and sealed procedure instructions from the engine-published pack count, pack sizes, and minimum deck size instead of default-format constants. Quick, pod, and Commander intros now cover uniform and mixed-size pack procedures, while sealed copy reads the published procedure count. The localized copy composes context-specific CLDR quantity phrases and locale-aware lists across all seven catalogs, including singular and mixed-size edge cases.

## Files changed

- `client/src/components/draft/DraftIntro.tsx`
- `client/src/components/draft/SealedPackOpening.tsx`
- `client/src/components/draft/__tests__/DraftIntro.test.tsx`
- `client/src/components/draft/__tests__/SealedPackOpening.test.tsx`
- `client/src/i18n/__tests__/localeParity.test.ts`
- `client/src/i18n/locales/de/draft.json`
- `client/src/i18n/locales/en/draft.json`
- `client/src/i18n/locales/es/draft.json`
- `client/src/i18n/locales/fr/draft.json`
- `client/src/i18n/locales/it/draft.json`
- `client/src/i18n/locales/pl/draft.json`
- `client/src/i18n/locales/pt/draft.json`
- `client/src/pages/DraftPage.tsx`
- `client/src/pages/DraftPodPage.tsx`
- `client/src/pages/__tests__/DraftPage.workspace.test.tsx`
- `client/src/pages/__tests__/DraftPodPage.modeEntry.test.tsx`

## Track

Developer

## LLM

Model: gpt-5.6-sol
Tier: Frontier
Thinking: max

## Implementation method (required)

Method: not-applicable — frontend-only display, localization data, and regression tests

## CR references

- CR 903.13a, CR 903.13b, and CR 903.13f — copy/test documentation only; no rules implementation changed.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — exit 0; committed worktree remained clean.
- `corepack pnpm@9.15.9 run protocol:check` — exit 0.
- `corepack pnpm@9.15.9 exec tsc -b --noEmit` — exit 0.
- `corepack pnpm@9.15.9 exec eslint .` — exit 0; 0 errors and the repository's 41 existing warnings, none in the changed files.
- Focused Vitest run for the five changed component/page/localization suites — 5 test files passed; 134 tests passed.
- `corepack pnpm@9.15.9 exec vitest run` — 402 test files passed, 2 skipped; 4,193 tests passed, 12 todo.
- `jq -e .` across all seven changed `draft.json` catalogs — exit 0.
- `git diff --check origin/main...HEAD` — exit 0.
- Repository gate scripts — Gate G, Gate A, and Gate P passed after the final review at the committed head.

## Gate A

Gate A PASS head=7d10e28e724e55c67e367c2a5b65bbe4f46b3c65 base=2c42e0f45632aac25a53f2e4b07e9f63d1705928

## Anchored on

- `client/src/components/draft/DraftProgress.tsx:37` — existing draft progress renders the engine-published `pack_count` rather than duplicating a format default.
- `client/src/components/draft/SealedPackOpening.tsx:116` — existing sealed copy routes the engine-derived card count through a CLDR-aware count key.

## Final review-impl

Final review-impl PASS head=7d10e28e724e55c67e367c2a5b65bbe4f46b3c65

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Draft introductions now show accurate pack counts, pack sizes, minimum deck sizes, and pack-passing directions for Quick, Pod, and Commander drafts.
  - Mixed-size packs are clearly described in drafting instructions.
  - Sealed pack-opening instructions now reflect the actual number of packs.

- **Localization**
  - Updated draft and sealed-opening instructions across supported languages with singular and plural wording.
  - Added dynamic translations for pack quantities, card counts, deck minimums, and pack sizes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
