### PR TITLE
fix(engine): stop offering a Resolve All consent nobody can grant

### DIFF
--- a/crates/engine/src/ai_support/candidates.rs
+++ b/crates/engine/src/ai_support/candidates.rs
@@ -388,24 +388,39 @@ pub fn candidate_actions_exact(state: &GameState) -> Vec<CandidateAction> {
             epoch,
             representative,
         } => {
-            let mut actions = vec![
-                candidate(
-                    GameAction::RespondResolveAllConsent {
-                        epoch: *epoch,
-                        decision: ResolveAllConsentDecision::Grant,
-                    },
-                    TacticalClass::Selection,
-                    Some(*representative),
-                ),
-                candidate(
-                    GameAction::RespondResolveAllConsent {
-                        epoch: *epoch,
-                        decision: ResolveAllConsentDecision::Decline,
-                    },
-                    TacticalClass::Selection,
-                    Some(*representative),
-                ),
-            ];
+            // The consent prompt alone does not prove the reducer will accept a
+            // response to it. `ResolveAllConsentRun::accepts_response_from` is
+            // the same authority `respond_resolve_all_consent` applies, so a
+            // prompt standing over an absent or superseded run issues nothing
+            // rather than a Grant that can only be rejected. This prompt's
+            // contract is issued without reducer simulation
+            // (`decision_contract_requires_reducer_validation`), so this is the
+            // only place the mismatch can be caught before an AI submits.
+            let mut actions = Vec::new();
+            if state
+                .resolve_all_consent_run
+                .as_ref()
+                .is_some_and(|run| run.accepts_response_from(*epoch, *representative))
+            {
+                actions.extend([
+                    candidate(
+                        GameAction::RespondResolveAllConsent {
+                            epoch: *epoch,
+                            decision: ResolveAllConsentDecision::Grant,
+                        },
+                        TacticalClass::Selection,
+                        Some(*representative),
+                    ),
+                    candidate(
+                        GameAction::RespondResolveAllConsent {
+                            epoch: *epoch,
+                            decision: ResolveAllConsentDecision::Decline,
+                        },
+                        TacticalClass::Selection,
+                        Some(*representative),
+                    ),
+                ]);
+            }
             append_resolve_all_revocations(state, *epoch, &mut actions);
             actions
         }

--- a/crates/engine/src/game/engine.rs
+++ b/crates/engine/src/game/engine.rs
@@ -9251,7 +9251,7 @@ fn respond_resolve_all_consent(
         let run = state.resolve_all_consent_run.as_mut().ok_or_else(|| {
             EngineError::InvalidAction("Resolve All consent is not active".to_string())
         })?;
-        if run.epoch != epoch || run.next_pending_representative() != Some(representative) {
+        if !run.accepts_response_from(epoch, representative) {
             return Err(EngineError::InvalidAction(
                 "Resolve All consent response is no longer pending".to_string(),
             ));

--- a/crates/engine/src/game/engine_resolve_batch.rs
+++ b/crates/engine/src/game/engine_resolve_batch.rs
@@ -488,6 +488,27 @@ pub fn classify_restored_stack_automation(state: &GameState) -> RestoredStackAut
             RestoredStackAutomation::Repair
         };
     }
+    // A pending consent prompt is a live decision, not automation to resume, so
+    // a coherent one classifies as `None` like any ordinary prompt. An
+    // incoherent one is the third unanswerable saved authorization, alongside a
+    // stale session and a run-less Ready latch: its representative can neither
+    // Grant nor Decline, and `WaitingFor::ResolveAllConsent` has no consumer
+    // entry point of its own that could repair it later. `repair_restored_stack_automation`
+    // already routes a consent wait to `rebase_invalid_resolve_all_consent`;
+    // only this classification was missing.
+    if let WaitingFor::ResolveAllConsent {
+        epoch,
+        representative,
+    } = &state.waiting_for
+    {
+        if !state
+            .resolve_all_consent_run
+            .as_ref()
+            .is_some_and(|run| run.accepts_response_from(*epoch, *representative))
+        {
+            return RestoredStackAutomation::Repair;
+        }
+    }
     RestoredStackAutomation::None
 }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2121,6 +2121,21 @@ impl ResolveAllConsentRun {
             .find(|participant| !participant.granted)
             .map(|participant| participant.representative)
     }
+
+    /// The single authority for whether a `RespondResolveAllConsent` naming
+    /// `epoch` and `representative` is still answerable.
+    ///
+    /// The public `WaitingFor::ResolveAllConsent` prompt and this private run
+    /// are separate fields, and a run can be absent behind a standing prompt —
+    /// a viewer projection redacts the run (`visibility.rs`) while retaining
+    /// the prompt, so any state reconstructed from one carries the prompt with
+    /// no run behind it. Every producer of the prompt's action domain must ask
+    /// this before offering Grant or Decline: an offer the reducer can only
+    /// reject leaves the representative hammering an unanswerable prompt with
+    /// no other legal action, which no later boundary can undo.
+    pub fn accepts_response_from(&self, epoch: u64, representative: PlayerId) -> bool {
+        self.epoch == epoch && self.next_pending_representative() == Some(representative)
+    }
 }
 
 /// CR 609.7a: A source of damage chosen while creating a prevention or

--- a/crates/engine/tests/integration/resolve_all_consent.rs
+++ b/crates/engine/tests/integration/resolve_all_consent.rs
@@ -2,7 +2,9 @@
 
 use std::collections::{BTreeMap, BTreeSet};
 
-use engine::ai_support::{candidate_actions, legal_actions_for_viewer, AiDecisionContract};
+use engine::ai_support::{
+    candidate_actions, legal_actions_for_viewer, stuck_decision_diagnostic, AiDecisionContract,
+};
 use engine::game::elimination::eliminate_player;
 use engine::game::engine::{
     apply, apply_verified_ai_priority_pass, classify_restored_stack_automation,
@@ -1744,6 +1746,105 @@ fn a_ready_latch_with_no_run_repairs_to_priority_without_resolving() {
     );
     assert!(state.auto_pass.is_empty());
 }
+
+/// The reporter's shape: P0 proposes Resolve All, P1's consent is queued, and
+/// the private run is gone while the public prompt still stands.
+fn pending_consent_without_its_run() -> GameState {
+    let mut state = GameState::new(FormatConfig::free_for_all(), 2, 0x0C0F_FEE2);
+    state.stack.push_back(no_op_entry(1, P0));
+    let epoch = begin(&mut state);
+    // Not an arbitrary mutation: this is exactly what a viewer projection of a
+    // pending consent carries, so any state reconstructed from one has it.
+    let projected = filter_state_for_viewer(&state, P0);
+    assert_eq!(projected.waiting_for, state.waiting_for);
+    assert!(projected.resolve_all_consent_run.is_none());
+    state.resolve_all_consent_run = None;
+    assert!(matches!(
+        state.waiting_for,
+        WaitingFor::ResolveAllConsent { epoch: e, representative: P1 } if e == epoch
+    ));
+    state
+}
+
+#[test]
+fn a_consent_prompt_with_no_run_issues_no_response_and_reports_a_wedge() {
+    let mut state = pending_consent_without_its_run();
+    let WaitingFor::ResolveAllConsent { epoch, .. } = state.waiting_for else {
+        unreachable!("the fixture asserts its own prompt")
+    };
+
+    assert!(
+        !candidate_actions(&state).iter().any(|candidate| matches!(
+            candidate.action,
+            GameAction::RespondResolveAllConsent { .. }
+        )),
+        "a response the reducer can only reject must never enter the issued domain"
+    );
+    assert!(
+        AiDecisionContract::issue(&state, P1).candidates.is_empty(),
+        "this prompt's contract is issued without reducer simulation, so an \
+         unanswerable candidate would reach an AI submission unchecked"
+    );
+    for decision in [
+        ResolveAllConsentDecision::Grant,
+        ResolveAllConsentDecision::Decline,
+    ] {
+        assert!(
+            apply(
+                &mut state,
+                P1,
+                GameAction::RespondResolveAllConsent { epoch, decision },
+            )
+            .is_err(),
+            "the empty domain is correct rather than over-strict: {decision:?} is refused"
+        );
+    }
+
+    let diagnostic = stuck_decision_diagnostic(&state)
+        .expect("a decision nobody can answer must surface as a wedge");
+    assert_eq!(diagnostic.waiting_for_kind, "ResolveAllConsent");
+    assert_eq!(diagnostic.stuck_players, vec![P1]);
+    assert!(
+        legal_actions_for_viewer(&state, P1).0.is_empty(),
+        "the representative's own viewer set was already empty; the issued \
+         domain is what disagreed with it"
+    );
+}
+
+#[test]
+fn a_consent_prompt_with_no_run_repairs_to_priority_without_resolving() {
+    let mut coherent = GameState::new(FormatConfig::free_for_all(), 2, 0x0C0F_FEE3);
+    coherent.stack.push_back(no_op_entry(1, P0));
+    begin(&mut coherent);
+    assert_eq!(
+        classify_restored_stack_automation(&coherent),
+        RestoredStackAutomation::None,
+        "a live consent prompt is a decision to answer, not automation to resume"
+    );
+
+    let mut state = pending_consent_without_its_run();
+    assert_eq!(
+        classify_restored_stack_automation(&state),
+        RestoredStackAutomation::Repair,
+        "an unanswerable saved authorization is a repair, like a run-less Ready latch"
+    );
+
+    let resumed = resume_restored_stack_automation(&mut state);
+
+    assert_eq!(
+        resumed.presentation.outcome,
+        RestoredStackAutomationOutcome::ZeroResolutionRepair
+    );
+    assert_eq!(resumed.presentation.automated_resolution_count, 0);
+    assert_eq!(state.stack.len(), 1, "the stack entry survives the repair");
+    assert!(
+        matches!(state.waiting_for, WaitingFor::Priority { .. }),
+        "the repair must restore ordinary priority, got {:?}",
+        state.waiting_for
+    );
+    assert!(state.resolve_all_consent_run.is_none());
+}
+
 /// Generic restore classification is inert on the overwhelming majority of
 /// states, which carry no stack automation at all.
 #[test]


### PR DESCRIPTION
A `WaitingFor::ResolveAllConsent` prompt and its private
`resolve_all_consent_run` are separate fields, and the prompt can stand
over an absent run: `filter_state_for_viewer` redacts the run while
retaining the prompt, so any state reconstructed from a viewer
projection carries one without the other.

In that shape `candidate_actions_exact` still issued Grant and Decline,
which `respond_resolve_all_consent` can only reject. `ResolveAllConsent`
is not in `decision_contract_requires_reducer_validation`, so
`AiDecisionContract::issue` never simulated the candidate away: an AI
representative received a proposal the same engine refused, retried, and
halted. The seat's own `legal_actions_for_viewer` was correctly empty
the whole time, so no player had any action and no diagnostic fired —
`stuck_decision_diagnostic` keys on `legal_actions_full` being empty,
which this arm kept non-empty.

Gate the pair on the run through one new authority,
`ResolveAllConsentRun::accepts_response_from`, which the reducer now
consults too so the issued domain and the accepted domain cannot drift.
An unanswerable prompt then issues nothing, which is what makes the
wedge visible.

Classify an incoherent consent prompt as `RestoredStackAutomation::Repair`.
`repair_restored_stack_automation` already routes a consent wait to
`rebase_invalid_resolve_all_consent`; only the classification reaching it
was missing, so a restore reinstalled the same wedge instead of rebasing
to ordinary priority. A coherent prompt still classifies as `None` — it
is a live decision, not automation to resume.

CR 117.4: the repair restarts the suspended pass cycle rather than
resolving any stack object; the entry survives untouched.

This is the recovery half. Whatever drops the run behind a standing
prompt is unfixed and still costs a player their in-progress Resolve All.

Claude-Session: https://claude.ai/code/session_012TXUKEudeu7bzkoCZhYgWd


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolve All consent prompts now offer Grant or Decline only when the prompt is still valid.
  * Invalid or incomplete saved consent states are detected and repaired instead of remaining stuck.
  * Invalid responses are rejected, preventing unintended resolutions.

* **Reliability**
  * Improved handling of restored or viewer-projected game states with missing consent information.

* **Tests**
  * Added coverage for invalid, missing, and unrecoverable consent scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->