### PR TITLE
fix(parser): type the static gates that fell to Unrecognized

### DIFF
--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -896,7 +896,7 @@ pub(crate) fn parse_typed_you_control_subject_filter(
 ///    "blocking" / "blocked" and the compound "attacking or blocking" (which
 ///    `~ is …` lowers to `Or([SourceIsAttacking, SourceIsBlocking])`)
 ///    (CR 508.1k / 509.1g / 509.1h), "modified" (CR 700.9), "equipped"
-///    (CR 301.5a) and "enchanted" (CR 303.4) — nine phrases — plus the two
+///    (CR 301.5a) and "enchanted" (CR 303.4b) — nine phrases — plus the two
 ///    non-contraction "it entered …" forms handled below, "it entered this turn"
 ///    and "it entered the battlefield this turn" (CR 400.7).
 ///    "it" is otherwise overloaded: "it's your

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -928,7 +928,7 @@ pub(crate) fn rewrite_self_pronoun_subject(condition: &str) -> String {
         // CR 508.1k / CR 509.1g / CR 509.1h: combat-state pronoun siblings of the
         // tapped/untapped rewrite. CR 700.9: "modified" is the self-state sibling
         // for "it's modified" (Obstinate Gargoyle, Skyward Spider). CR 301.5a:
-        // "equipped"; CR 303.4: "enchanted" — self-state predicates for SelfRef
+        // "equipped"; CR 303.4b: "enchanted" — self-state predicates for SelfRef
         // statics (Merry "as long as it's equipped"; Fledgling Osprey "as long as
         // it's enchanted"). Exact-match only — "attacking alone" keeps its trailing
         // word and is left for SourceAttackingAlone; "modified creature" and

--- a/crates/engine/src/parser/oracle_static/anthem.rs
+++ b/crates/engine/src/parser/oracle_static/anthem.rs
@@ -890,17 +890,34 @@ pub(crate) fn parse_typed_you_control_subject_filter(
 ///    attached-subject statics (an Aura/Equipment whose "it" refers to the
 ///    enchanted/equipped creature) the pronoun is not the source.
 /// 2. Only the bare source-STATE predicates that `~ is …` already resolves to a
-///    typed condition are rewritten — the tapped/untapped pair plus their
-///    combat-state siblings "attacking"/"blocking"/"blocked" and the compound
-///    "attacking or blocking" (which `~ is …` lowers to
-///    `Or([SourceIsAttacking, SourceIsBlocking])`)
-///    (CR 508.1k / 509.1g / 509.1h). "it" is otherwise overloaded: "it's your
+///    typed condition are rewritten. The list below is the WHOLE list and must
+///    stay in lockstep with the `matches!` arms in the body:
+///    "tapped" / "untapped", their combat-state siblings "attacking" /
+///    "blocking" / "blocked" and the compound "attacking or blocking" (which
+///    `~ is …` lowers to `Or([SourceIsAttacking, SourceIsBlocking])`)
+///    (CR 508.1k / 509.1g / 509.1h), "modified" (CR 700.9), "equipped"
+///    (CR 301.5a) and "enchanted" (CR 303.4) — nine phrases — plus the two
+///    non-contraction "it entered …" forms handled below, "it entered this turn"
+///    and "it entered the battlefield this turn" (CR 400.7).
+///    "it" is otherwise overloaded: "it's your
 ///    turn" is impersonal (a turn reference, not the source); "it's a Wall" /
 ///    "it's red" / "it's legendary" are type/characteristic gates with their own
 ///    parse paths. Rewriting those would break or mis-bind them, so they are
 ///    left untouched. The match is EXACT, so "it's attacking alone" keeps its
 ///    trailing word and falls through to `SourceAttackingAlone` rather than
 ///    collapsing to `SourceIsAttacking`.
+///
+/// STANDING CONSTRAINT on guard #1. Its premise ("the caller only applies this
+/// when the affected subject is SelfRef, therefore `it` names the source") has
+/// exactly one corpus counterexample today: Hobble ("Enchanted creature can't
+/// block if it's black.") reaches the `CantBlock` dispatch arm, which hardcodes
+/// `affected: SelfRef` even though the printed subject is the enchanted
+/// creature. Its `it` therefore names the RECIPIENT, not the source, and the
+/// only thing holding it inert is that "black" is a CHARACTERISTIC and so is
+/// absent from the exact list above. No characteristic predicate (a color, a
+/// card type, a supertype) may join that list without first re-running the
+/// census of SelfRef-affected statics whose description begins
+/// "Enchanted|Equipped creature".
 ///
 /// Returns the condition unchanged when neither guard matches.
 pub(crate) fn rewrite_self_pronoun_subject(condition: &str) -> String {
@@ -956,7 +973,11 @@ pub(crate) fn parse_continuous_gets_has(
 
     // CR 611.3a: Split "as long as [condition]" BEFORE "for each" — the condition applies
     // to the entire static, not to a quantity count. Mirrors parse_enchanted_equipped_predicate.
-    if let Some((before_cond, after_cond)) = tp.split_around(" as long as ") {
+    // Only peel when the split point sits OUTSIDE a quoted granted ability —
+    // `split_around_outside_quotes` is the single authority for that rule
+    // (Ancestral Katana / Giant's Amulet: the inner "as long as" gates the GRANTED
+    // ability, not the +N/+M).
+    if let Some((before_cond, after_cond)) = tp.split_around_outside_quotes(" as long as ") {
         let continuous_text = before_cond.original;
         let condition_text = after_cond.original.trim().trim_end_matches('.');
         // Recursively parse the continuous part without the condition
@@ -965,12 +986,10 @@ pub(crate) fn parse_continuous_gets_has(
         {
             // CR 611.3a: only resolve the self-pronoun "it" to the source when the
             // static modifies itself; attached-subject statics keep "it" bound to
-            // the enchanted/equipped creature and stay an honest gap.
-            let typed = if matches!(affected, TargetFilter::SelfRef) {
-                parse_static_condition(&rewrite_self_pronoun_subject(condition_text))
-            } else {
-                parse_static_condition(condition_text)
-            };
+            // the enchanted/equipped creature and stay an honest gap. That binding
+            // decision has ONE authority — `parse_affected_scoped_static_condition`
+            // (shared.rs) — shared with the "as long as"/"unless"/"if" gate parsers.
+            let typed = parse_affected_scoped_static_condition(condition_text, Some(&affected));
             let condition = typed.unwrap_or(StaticCondition::Unrecognized {
                 text: condition_text.to_string(),
             });
@@ -986,25 +1005,18 @@ pub(crate) fn parse_continuous_gets_has(
     // gated on Not(SourceIsAttacking)). Only peel when the split sits OUTSIDE a
     // quoted granted ability — a granted ability's own inner "unless" (e.g. "gains
     // 'counter target spell unless its controller pays {1}'") must stay with the
-    // quoted text; balanced double quotes in the body signal the split is outside
-    // any "...". As with the " as long as " form, the self-pronoun condition
+    // quoted text. `split_around_outside_quotes` is the single authority for that
+    // rule. As with the " as long as " form, the self-pronoun condition
     // subject ("it's attacking"/"it's tapped") is resolved to the source only for
     // SelfRef grants — an attached-subject "it" keeps its enchanted/equipped
     // binding and stays an honest gap.
-    if let Some((before_cond, after_cond)) = tp
-        .split_around(" unless ")
-        .filter(|(body, _)| body.original.chars().filter(|&c| c == '"').count() % 2 == 0)
-    {
+    if let Some((before_cond, after_cond)) = tp.split_around_outside_quotes(" unless ") {
         let continuous_text = before_cond.original;
         let condition_text = after_cond.original.trim().trim_end_matches('.');
         if let Some(mut def) =
             parse_continuous_gets_has(continuous_text, affected.clone(), description)
         {
-            let typed = if matches!(affected, TargetFilter::SelfRef) {
-                parse_static_condition(&rewrite_self_pronoun_subject(condition_text))
-            } else {
-                parse_static_condition(condition_text)
-            };
+            let typed = parse_affected_scoped_static_condition(condition_text, Some(&affected));
             let condition = match typed {
                 Some(inner) => StaticCondition::Not {
                     condition: Box::new(inner),

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2217,19 +2217,53 @@ pub(crate) fn parse_static_line_inner(
                 }
             }
 
-            let condition = if after_blocked.is_empty() {
-                None
-            } else {
-                // CR 509.1h: parse_condition handles "as long as " prefix via nom combinator
-                nom_condition::parse_condition(after_blocked)
-                    .ok()
-                    .and_then(|(r, c)| r.trim().is_empty().then_some(c))
-                    .or_else(|| {
-                        Some(StaticCondition::Unrecognized {
-                            text: after_blocked.to_string(),
-                        })
+            // CR 509.1b + CR 604.1 + CR 611.3a: an evasion restriction's trailing
+            // gate is the SAME grammar as the attack/block restrictions' ("can't
+            // attack" / "can't block", below) — "unless <cond>" / "as long as
+            // <cond>" / "if <cond>". CR 509.1b is the rule that governs it: it
+            // names evasion abilities explicitly ("A restriction may be created by
+            // an evasion ability (a static ability an attacking creature has that
+            // restricts what can block it)") and is re-checked each time blockers
+            // are declared.
+            //
+            // This branch is the FALLBACK in a two-authority series:
+            // `parse_subject_rule_static` (dispatch.rs, above → evasion.rs's
+            // `cant_be_blocked_mode`) classifies the same grammar first, and
+            // control only arrives here when that declines — either because the
+            // subject did not parse (a flavor-word prefix) or because the gate did
+            // not type under `nom_condition::parse_condition`. Route the fallback
+            // through the shared trio rather than calling `parse_condition` a
+            // second time, so the branch that catches what the cheap authority
+            // drops inherits (a) every arm `parse_static_condition` adds over
+            // `parse_inner_condition`, (b) the affected-scoped source-anaphor
+            // binding, and (c) the ONE `unless` polarity rule
+            // (`nom_condition::parse_unless_condition`). Calling `parse_condition`
+            // here previously dropped the `unless` negation on failure, leaving a
+            // bare `Unrecognized` that evaluates TRUE — making the restriction
+            // unconditional (CR 604.1: a static is "simply true", and an `unless`
+            // static is simply true precisely when its condition is FALSE).
+            // Graxiplon was permanently unblockable.
+            let self_ref = TargetFilter::SelfRef;
+            let gate_affected = Some(&self_ref);
+            let condition = parse_unless_static_condition(&tp, gate_affected)
+                .or_else(|| parse_as_long_as_static_condition(&tp, gate_affected))
+                .or_else(|| parse_if_static_condition(&tp, gate_affected))
+                .or_else(|| {
+                    // The trio all declined. A non-empty tail is an honest gap and
+                    // must keep its `Unrecognized` marker; an EMPTY tail means the
+                    // line is a bare "<subject> can't be blocked." that reached
+                    // this fallback only because its subject did not parse upstream
+                    // (a flavor-word prefix: Canoptek Wraith's "Wraith Form — ",
+                    // Ghost, Spectral Saboteur's "Intangibility — ", Wraith,
+                    // Vicious Vigilante's "Fear Gas — "). Those rows have NO gate,
+                    // so emitting `Unrecognized{""}` would invent a condition — and
+                    // under the layer system's fail-open arm it would read as an
+                    // always-true gate on a restriction that is unconditional by
+                    // print. Keep `None`.
+                    (!after_blocked.is_empty()).then(|| StaticCondition::Unrecognized {
+                        text: after_blocked.to_string(),
                     })
-            };
+                });
             let mut def = StaticDefinition::new(StaticMode::CantBeBlocked)
                 .affected(TargetFilter::SelfRef)
                 .description(text.to_string());
@@ -2332,10 +2366,11 @@ pub(crate) fn parse_static_line_inner(
         // `split_trailing_gate_condition`'s precedence. (CR 509.1b is the block
         // *restriction* rule — "a creature can't block" — not 509.1c, which is
         // block *requirements*.)
-        if let Some(condition) = parse_unless_static_condition(&tp)
-            .or_else(|| parse_as_long_as_static_condition(&tp))
-            .or_else(|| parse_if_static_condition(&tp))
-        {
+        let gate_affected = def.affected.as_ref();
+        let gate = parse_unless_static_condition(&tp, gate_affected)
+            .or_else(|| parse_as_long_as_static_condition(&tp, gate_affected))
+            .or_else(|| parse_if_static_condition(&tp, gate_affected));
+        if let Some(condition) = gate {
             def.condition = Some(condition);
         }
         return Some(def);
@@ -2380,10 +2415,11 @@ pub(crate) fn parse_static_line_inner(
         // attach whichever is present. "as long as" is tried before "if" to match
         // `split_trailing_gate_condition`'s precedence (Seer of the Bright Side:
         // "... can't attack or block as long as it has a stun counter on it.").
-        if let Some(condition) = parse_unless_static_condition(&tp)
-            .or_else(|| parse_as_long_as_static_condition(&tp))
-            .or_else(|| parse_if_static_condition(&tp))
-        {
+        let gate_affected = def.affected.as_ref();
+        let gate = parse_unless_static_condition(&tp, gate_affected)
+            .or_else(|| parse_as_long_as_static_condition(&tp, gate_affected))
+            .or_else(|| parse_if_static_condition(&tp, gate_affected));
+        if let Some(condition) = gate {
             def.condition = Some(condition);
         }
         return Some(def);
@@ -2470,7 +2506,7 @@ pub(crate) fn parse_static_line_inner(
         })
         .affected(TargetFilter::SelfRef)
         .description(text.to_string());
-        if let Some(condition) = parse_unless_static_condition(&tp) {
+        if let Some(condition) = parse_unless_static_condition(&tp, def.affected.as_ref()) {
             def.condition = Some(condition);
         }
         return Some(def);

--- a/crates/engine/src/parser/oracle_static/dispatch.rs
+++ b/crates/engine/src/parser/oracle_static/dispatch.rs
@@ -2223,8 +2223,10 @@ pub(crate) fn parse_static_line_inner(
             // <cond>" / "if <cond>". CR 509.1b is the rule that governs it: it
             // names evasion abilities explicitly ("A restriction may be created by
             // an evasion ability (a static ability an attacking creature has that
-            // restricts what can block it)") and is re-checked each time blockers
-            // are declared.
+            // restricts what can block it)"). The check happens when blockers are
+            // declared; CR 509.1b adds that an attacking creature gaining or losing
+            // an evasion ability AFTER a legal block has been declared does not
+            // affect that block.
             //
             // This branch is the FALLBACK in a two-authority series:
             // `parse_subject_rule_static` (dispatch.rs, above → evasion.rs's

--- a/crates/engine/src/parser/oracle_static/evasion.rs
+++ b/crates/engine/src/parser/oracle_static/evasion.rs
@@ -2448,7 +2448,7 @@ pub(crate) fn parse_subject_combat_rule_static(text: &str) -> Option<StaticDefin
     }
     if let Some(unless_cond) = {
         let tp = TextPair::new(text, &lower);
-        super::shared::parse_unless_static_condition(&tp)
+        super::shared::parse_unless_static_condition(&tp, def.affected.as_ref())
     } {
         def.condition = Some(unless_cond);
         return Some(def);
@@ -2547,7 +2547,7 @@ fn parse_forced_attack_defender_static_body(text: &str) -> Option<StaticDefiniti
     // not parse as if the rider were absent.
     tag::<_, _, OracleError<'_>>("unless ").parse(rest).ok()?;
     let tp = TextPair::new(text, &lower);
-    let condition = super::shared::parse_unless_static_condition(&tp)?;
+    let condition = super::shared::parse_unless_static_condition(&tp, def.affected.as_ref())?;
     // Coverage-honesty gate (CR 604.1): only emit the forced-attack static when the
     // `unless` gate is a FULLY-MODELED condition. `parse_unless_static_condition`
     // wraps an unrecognized inner clause as `Not(Unrecognized)` — which (a) would

--- a/crates/engine/src/parser/oracle_static/grammar.rs
+++ b/crates/engine/src/parser/oracle_static/grammar.rs
@@ -862,17 +862,17 @@ pub(crate) fn parse_enchanted_equipped_predicate(
     // "gets +3/+3 unless it shares a color…") when the split point sits OUTSIDE a
     // quoted/granted ability. A granted ability's own inner "unless" (e.g. Sunken
     // Field's "Counter target spell unless its controller pays {1}") must stay
-    // with the quoted text — the body has balanced double quotes iff the split is
-    // outside any "...".
-    let unless_split = pred_tp
-        .split_around(" unless ")
-        .filter(|(body, _)| body.original.chars().filter(|&c| c == '"').count() % 2 == 0);
+    // with the quoted text. `split_around_outside_quotes` is the single authority
+    // for that rule.
+    let unless_split = pred_tp.split_around_outside_quotes(" unless ");
     let (body_tp, suffix_condition) = if let Some((body_tp, _)) = unless_split {
         (
             body_tp,
-            super::shared::parse_unless_static_condition(&pred_tp),
+            super::shared::parse_unless_static_condition(&pred_tp, Some(&affected)),
         )
-    } else if let Some((body_tp, condition_tp)) = pred_tp.split_around(" as long as ") {
+    } else if let Some((body_tp, condition_tp)) =
+        pred_tp.split_around_outside_quotes(" as long as ")
+    {
         let condition_text = condition_tp.original.trim().trim_end_matches('.');
         (
             body_tp,
@@ -949,7 +949,7 @@ pub(crate) fn parse_enchanted_equipped_predicate(
 
     // --- Conditional grants: split "as long as" before passing to continuous parser ---
     // Handles both "gets +1/+1 as long as ..." and "has flying as long as ..."
-    if let Some((before_cond, after_cond)) = pred_tp.split_around(" as long as ") {
+    if let Some((before_cond, after_cond)) = pred_tp.split_around_outside_quotes(" as long as ") {
         let continuous_text = before_cond.original;
         let condition_text = after_cond.original.trim().trim_end_matches('.');
         if let Some(mut def) =

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -3354,10 +3354,22 @@ pub(crate) fn rebind_source_object_quantity_ref_to_recipient(qty: QuantityRef) -
 /// no affected set (`MaxUntapPerType`) is categorically not SelfRef and must not
 /// be coerced into a literal it does not carry.
 ///
-/// SINGLE AUTHORITY for that binding decision. Every static gate parser
-/// ("as long as" / "unless" / "if") routes through here; no call site re-decides
-/// it. Replaces the ternary formerly duplicated in `parse_continuous_gets_has`
-/// (anthem.rs, both the as-long-as and unless arms).
+/// Authority for that binding decision on every AFFECTED-BEARING static gate
+/// ("as long as" / "unless" / "if"): those route through here and no call site
+/// re-decides it. Replaces the ternary formerly duplicated in
+/// `parse_continuous_gets_has` (anthem.rs, both the as-long-as and unless arms).
+///
+/// ONE DELIBERATE EXCEPTION, and it is the same static named above:
+/// `parse_max_untap_per_type_static` (dispatch.rs) calls
+/// `rewrite_self_pronoun_subject` directly and ALWAYS applies it. That is not an
+/// oversight and must not be "fixed" by routing it through here. The two
+/// statements are reconciled by scope, not by precedence: this helper decides
+/// binding from `affected`, and a `None` affected set carries no SelfRef literal
+/// to read — so it correctly declines. `MaxUntapPerType` has no attached-subject
+/// variant at all (CR 611.3a), so its gate is always a state check on the cap's
+/// own source and the rewrite is unconditionally right there. A caller with that
+/// proof out-of-band may rewrite before calling; a caller without one may not.
+/// These are the only two production callers of `rewrite_self_pronoun_subject`.
 ///
 /// NORMALIZATION IS PART OF THE CONTRACT, not the caller's job.
 /// `rewrite_self_pronoun_subject` matches an EXACT closed list, so a trailing

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -3360,14 +3360,19 @@ pub(crate) fn rebind_source_object_quantity_ref_to_recipient(qty: QuantityRef) -
 /// re-decides it. Replaces the ternary formerly duplicated in
 /// `parse_continuous_gets_has` (anthem.rs, both the as-long-as and unless arms).
 ///
-/// The claim is deliberately NOT "every affected-bearing static gate". Other
-/// arms build a SelfRef static and parse its gate with a bare
-/// `parse_static_condition` — `evasion.rs`'s `CanAttackWithDefender` subject arm
-/// and two `dispatch.rs` arms (the `~ has <kw> as long as <cond>` and
-/// self-referential type-removal branches). They decide the binding by omission,
-/// the opposite of what this helper decides. Whether any of them is REACHABLE
-/// with a pronoun gate is unmeasured; they are named here so the next change
-/// starts from the real list rather than from a false universal.
+/// The claim is deliberately NOT "every affected-bearing static gate", and NOT a
+/// complete enumeration of the arms that fall outside it. Review found three
+/// that build a SelfRef static and parse its gate with a bare
+/// `parse_static_condition`, deciding the binding by omission — `evasion.rs`'s
+/// `CanAttackWithDefender` subject arm, and `dispatch.rs`'s
+/// `~ has <kw> as long as <cond>` and self-referential type-removal branches.
+/// A proximity scan (a `SelfRef` assignment within ~45 lines of a
+/// `parse_static_condition` call) flags substantially more than three, but that
+/// instrument over-reports across sibling branches, so neither three nor its own
+/// figure is a defensible count. THE COMPLETE SET IS UNMEASURED, as is whether
+/// any such arm is REACHABLE with a pronoun gate. Named here so the next change
+/// starts from a known-incomplete list it can extend, rather than from a
+/// universal that is false.
 ///
 /// PRE-REWRITING CALLERS ARE ENUMERATED, not permitted by predicate.
 /// `parse_max_untap_per_type_static` (dispatch.rs) is the ONLY caller allowed to

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -3344,7 +3344,7 @@ pub(crate) fn rebind_source_object_quantity_ref_to_recipient(qty: QuantityRef) -
 /// anaphoric "it" indicates is fixed by the static's subject: in a self-modifying
 /// static (`TargetFilter::SelfRef`) "it" names the source permanent, so
 /// `it's <state>` is normalized to `~ is <state>` (CR 301.5a "equipped creature";
-/// CR 303.4 Auras). In an attached-subject static ("Enchanted creature has shroud
+/// CR 303.4b "enchanted"). In an attached-subject static ("Enchanted creature has shroud
 /// as long as it's untapped" — Spectral Cloak) "it" names the enchanted/equipped
 /// RECIPIENT and is left for the recipient grammar; binding it to the
 /// Aura/Equipment would gate on a permanent that is never itself tapped or
@@ -3354,22 +3354,34 @@ pub(crate) fn rebind_source_object_quantity_ref_to_recipient(qty: QuantityRef) -
 /// no affected set (`MaxUntapPerType`) is categorically not SelfRef and must not
 /// be coerced into a literal it does not carry.
 ///
-/// Authority for that binding decision on every AFFECTED-BEARING static gate
-/// ("as long as" / "unless" / "if"): those route through here and no call site
+/// Authority for that binding decision within the three static-gate helpers
+/// `parse_unless_static_condition`, `parse_as_long_as_static_condition` and
+/// `parse_if_static_condition`: those route through here and no call site
 /// re-decides it. Replaces the ternary formerly duplicated in
 /// `parse_continuous_gets_has` (anthem.rs, both the as-long-as and unless arms).
 ///
-/// ONE DELIBERATE EXCEPTION, and it is the same static named above:
-/// `parse_max_untap_per_type_static` (dispatch.rs) calls
-/// `rewrite_self_pronoun_subject` directly and ALWAYS applies it. That is not an
-/// oversight and must not be "fixed" by routing it through here. The two
-/// statements are reconciled by scope, not by precedence: this helper decides
-/// binding from `affected`, and a `None` affected set carries no SelfRef literal
-/// to read — so it correctly declines. `MaxUntapPerType` has no attached-subject
-/// variant at all (CR 611.3a), so its gate is always a state check on the cap's
-/// own source and the rewrite is unconditionally right there. A caller with that
-/// proof out-of-band may rewrite before calling; a caller without one may not.
-/// These are the only two production callers of `rewrite_self_pronoun_subject`.
+/// The claim is deliberately NOT "every affected-bearing static gate". Other
+/// arms build a SelfRef static and parse its gate with a bare
+/// `parse_static_condition` — `evasion.rs`'s `CanAttackWithDefender` subject arm
+/// and two `dispatch.rs` arms (the `~ has <kw> as long as <cond>` and
+/// self-referential type-removal branches). They decide the binding by omission,
+/// the opposite of what this helper decides. Whether any of them is REACHABLE
+/// with a pronoun gate is unmeasured; they are named here so the next change
+/// starts from the real list rather than from a false universal.
+///
+/// PRE-REWRITING CALLERS ARE ENUMERATED, not permitted by predicate.
+/// `parse_max_untap_per_type_static` (dispatch.rs) is the ONLY caller allowed to
+/// call `rewrite_self_pronoun_subject` before/instead of routing through here,
+/// and it always applies the rewrite. That is not an oversight and must not be
+/// "fixed" by routing it through this helper. The two are reconciled by scope,
+/// not precedence: this helper reads binding off `affected`, and
+/// `MaxUntapPerType` never sets `affected` (`StaticDefinition::new` defaults it
+/// to `None`), so the helper correctly declines — while that same structural
+/// fact, not any rule, is why the static has no attached-subject variant and why
+/// its gate is always a state check on the cap's own source.
+/// Adding a second pre-rewriting caller requires re-running the census of
+/// SelfRef-affected statics first. These are the only two production callers of
+/// `rewrite_self_pronoun_subject`.
 ///
 /// NORMALIZATION IS PART OF THE CONTRACT, not the caller's job.
 /// `rewrite_self_pronoun_subject` matches an EXACT closed list, so a trailing

--- a/crates/engine/src/parser/oracle_static/shared.rs
+++ b/crates/engine/src/parser/oracle_static/shared.rs
@@ -1,5 +1,6 @@
 // CR 604 / CR 613 — shared static parser infrastructure.
 
+use super::anthem::rewrite_self_pronoun_subject;
 #[allow(unused_imports)]
 use super::prelude::*;
 #[allow(unused_imports)]
@@ -3335,11 +3336,65 @@ pub(crate) fn rebind_source_object_quantity_ref_to_recipient(qty: QuantityRef) -
     }
 }
 
+/// CR 604.1 + CR 611.3a: resolve a static ability's gate-condition text against
+/// the static's own affected set.
+///
+/// CR 611.3a — a continuous effect from a static ability isn't "locked in"; it
+/// applies at any moment to whatever its text indicates. WHICH object its gate's
+/// anaphoric "it" indicates is fixed by the static's subject: in a self-modifying
+/// static (`TargetFilter::SelfRef`) "it" names the source permanent, so
+/// `it's <state>` is normalized to `~ is <state>` (CR 301.5a "equipped creature";
+/// CR 303.4 Auras). In an attached-subject static ("Enchanted creature has shroud
+/// as long as it's untapped" — Spectral Cloak) "it" names the enchanted/equipped
+/// RECIPIENT and is left for the recipient grammar; binding it to the
+/// Aura/Equipment would gate on a permanent that is never itself tapped or
+/// attacking.
+///
+/// `affected` is `Option` because `StaticDefinition::affected` is: a static with
+/// no affected set (`MaxUntapPerType`) is categorically not SelfRef and must not
+/// be coerced into a literal it does not carry.
+///
+/// SINGLE AUTHORITY for that binding decision. Every static gate parser
+/// ("as long as" / "unless" / "if") routes through here; no call site re-decides
+/// it. Replaces the ternary formerly duplicated in `parse_continuous_gets_has`
+/// (anthem.rs, both the as-long-as and unless arms).
+///
+/// NORMALIZATION IS PART OF THE CONTRACT, not the caller's job.
+/// `rewrite_self_pronoun_subject` matches an EXACT closed list, so a trailing
+/// sentence period defeats it ("enchanted." is not "enchanted").
+/// `parse_as_long_as_static_condition` does not pre-strip (its two siblings do),
+/// so the period must be removed here, before the rewrite — not left to
+/// `parse_static_condition`, which strips only after the rewrite has already run.
+///
+/// NOTE: the binding MUST stay context-gated here rather than being pushed into
+/// `oracle_nom::condition` as a blanket `it's` subject arm — bare "it's" is
+/// target-anaphoric in spell bodies (Awaken the Sleeper), and a blanket arm would
+/// mis-bind every attached-subject static. See
+/// `parse_contraction_source_state_condition`.
+pub(crate) fn parse_affected_scoped_static_condition(
+    text: &str,
+    affected: Option<&TargetFilter>,
+) -> Option<StaticCondition> {
+    let text = text.trim().trim_end_matches('.');
+    if matches!(affected, Some(TargetFilter::SelfRef)) {
+        parse_static_condition(&rewrite_self_pronoun_subject(text))
+    } else {
+        parse_static_condition(text)
+    }
+}
+
 /// Parse the trailing " unless [condition]" clause of a combat-restriction
 /// static. Delegates `Not`-wrapping (with the `UnlessPay` raw-passthrough
 /// exception) to the shared `parse_unless_condition` combinator so the static
 /// layer and the `parse_condition` "unless " dispatch share one polarity rule.
-pub(crate) fn parse_unless_static_condition(tp: &TextPair<'_>) -> Option<StaticCondition> {
+///
+/// `affected` is the host static's affected set, threaded to
+/// `parse_affected_scoped_static_condition` so the gate's anaphoric "it" binds
+/// to the source only for a SelfRef static (CR 611.3a).
+pub(crate) fn parse_unless_static_condition(
+    tp: &TextPair<'_>,
+    affected: Option<&TargetFilter>,
+) -> Option<StaticCondition> {
     let (_, unless_text) = tp.split_around(" unless ")?;
     let original = unless_text.original.trim().trim_end_matches('.');
     let lower = original.to_lowercase();
@@ -3350,7 +3405,7 @@ pub(crate) fn parse_unless_static_condition(tp: &TextPair<'_>) -> Option<StaticC
     // <condition> is false — fall back to the shared static-condition parser and
     // negate, so a recognized inner condition (e.g. Heroic Defiance's most-common-
     // color check) gates the grant instead of being swallowed as Unrecognized.
-    if let Some(condition) = parse_static_condition(original) {
+    if let Some(condition) = parse_affected_scoped_static_condition(original, affected) {
         return Some(StaticCondition::Not {
             condition: Box::new(condition),
         });
@@ -3618,11 +3673,14 @@ pub(crate) fn split_trailing_gate_condition_with_body<'a>(
 /// combat-restriction static ("~ can't attack if defending player controls an
 /// untapped land"; "~ can't block if you control an untapped land"). Mirrors
 /// `parse_unless_static_condition`; delegates the condition body to
-/// `parse_static_condition` → `parse_inner_condition` (the single authority
-/// for game-state conditions).
-pub(crate) fn parse_if_static_condition(tp: &TextPair<'_>) -> Option<StaticCondition> {
+/// `parse_affected_scoped_static_condition` → `parse_static_condition` →
+/// `parse_inner_condition` (the single authority for game-state conditions).
+pub(crate) fn parse_if_static_condition(
+    tp: &TextPair<'_>,
+    affected: Option<&TargetFilter>,
+) -> Option<StaticCondition> {
     let condition_text = split_trailing_if_condition_tp(tp)?;
-    parse_static_condition(condition_text.trim_end_matches('.'))
+    parse_affected_scoped_static_condition(condition_text, affected)
 }
 
 /// CR 611.3a: Parse the trailing " as long as [condition]" clause of a
@@ -3630,12 +3688,16 @@ pub(crate) fn parse_if_static_condition(tp: &TextPair<'_>) -> Option<StaticCondi
 /// counter on it" — Seer of the Bright Side). "As long as" and "if" both express
 /// a continuous game-state gate on a static ability (CR 611.3a), so this mirrors
 /// [`parse_if_static_condition`] exactly, delegating the condition body to
-/// `parse_static_condition` → `parse_inner_condition` (the single authority for
+/// `parse_affected_scoped_static_condition` → `parse_static_condition` →
+/// `parse_inner_condition` (the single authority for
 /// game-state conditions). Restriction arms peel "unless"/"if" but historically
 /// dropped the "as long as" rider on their SelfRef restriction, enforcing it
 /// unconditionally; this closes that keyword gap without touching the shared
 /// condition grammar.
-pub(crate) fn parse_as_long_as_static_condition(tp: &TextPair<'_>) -> Option<StaticCondition> {
+pub(crate) fn parse_as_long_as_static_condition(
+    tp: &TextPair<'_>,
+    affected: Option<&TargetFilter>,
+) -> Option<StaticCondition> {
     // CR 611.3a vs duration seam: "for as long as" is effect-duration/provenance
     // text (`Duration::ForAsLongAs` — Promise of Loyalty: "... can't attack you
     // or planeswalkers you control for as long as it has a vow counter on it"),
@@ -3647,7 +3709,7 @@ pub(crate) fn parse_as_long_as_static_condition(tp: &TextPair<'_>) -> Option<Sta
         return None;
     }
     let (_, as_long_as_text) = tp.split_around(" as long as ")?;
-    parse_static_condition(as_long_as_text.original)
+    parse_affected_scoped_static_condition(as_long_as_text.original, affected)
 }
 
 /// Result of the combat-tax nom parse.

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -20381,6 +20381,27 @@ fn cant_be_blocked_attacking_alone() {
     assert_eq!(def.condition, Some(StaticCondition::SourceAttackingAlone));
 }
 
+/// CR 303.4b: an Aura's host is "enchanted", so "as long as it's enchanted" on a
+/// SelfRef static is a self-state gate, not an unparsed remainder. Metathran
+/// Elite is the corpus witness for the `as long as` branch of the pronoun
+/// rewrite; every other #8183 regression test rides the `unless` branch, which
+/// already trimmed its clause before this fix. Without the shared trim in
+/// `parse_affected_scoped_static_condition`, the trailing period survives into
+/// `rewrite_self_pronoun_subject`, whose match is exact, so "enchanted." misses
+/// and the condition fails open as `Unrecognized`.
+#[test]
+fn cant_be_blocked_as_long_as_its_enchanted() {
+    let def =
+        parse_static_line("This creature can't be blocked as long as it's enchanted.").unwrap();
+    assert_eq!(def.mode, StaticMode::CantBeBlocked);
+    assert_eq!(
+        def.condition,
+        Some(StaticCondition::SourceIsEnchanted),
+        "Metathran Elite's gate must resolve to a typed self-state condition; \
+         an Unrecognized remainder fails open in the layer system (#8183)"
+    );
+}
+
 #[test]
 fn enchanted_creature_cant_be_blocked_as_long_as_you_control_gate() {
     let def =

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -1499,7 +1499,8 @@ fn as_long_as_peel_rejects_for_as_long_as_duration() {
     let dur_l = dur.to_lowercase();
     assert!(
         super::shared::parse_as_long_as_static_condition(
-            &crate::parser::oracle_util::TextPair::new(dur, &dur_l)
+            &crate::parser::oracle_util::TextPair::new(dur, &dur_l),
+            Some(&TargetFilter::SelfRef)
         )
         .is_none(),
         "\"for as long as\" is duration text and must not attach as a static gate"
@@ -1510,7 +1511,8 @@ fn as_long_as_peel_rejects_for_as_long_as_duration() {
     let gate_l = gate.to_lowercase();
     assert!(
         super::shared::parse_as_long_as_static_condition(
-            &crate::parser::oracle_util::TextPair::new(gate, &gate_l)
+            &crate::parser::oracle_util::TextPair::new(gate, &gate_l),
+            Some(&TargetFilter::SelfRef)
         )
         .is_some(),
         "bare \"as long as\" must still attach as a static gate (no over-rejection)"

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -195,7 +195,12 @@ impl<'a> TextPair<'a> {
     /// odd-quote body refuses the split outright rather than scanning on to a
     /// later separator that may lie outside the quotes
     /// (`has "X as long as Y" as long as Z`). No corpus line has that shape
-    /// today (3 odd-quote static lines total), and both incumbent guards already
+    /// today. Measured over the distinct oracle lines in MTGJSON AtomicCards:
+    /// 7 lines have an odd-quote FIRST `" as long as "` and 24 have an odd-quote
+    /// first `" unless "`, and for BOTH separators ZERO of those lines carry a
+    /// LATER outside-quotes occurrence — which is the claim that actually
+    /// matters, since it is what makes the first-occurrence refusal lossless.
+    /// Both incumbent guards already
     /// behave this way, so this is a documented property rather than a
     /// deviation.
     ///

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -182,6 +182,30 @@ impl<'a> TextPair<'a> {
         })
     }
 
+    /// CR 604.1: split around `sep` only when the split point sits OUTSIDE a
+    /// quoted granted ability. An ability written in quotation marks is a
+    /// separate static whose own gate belongs to IT, not to the clause granting
+    /// it (Ancestral Katana: `gets +2/+2 and has "This creature has first strike
+    /// as long as it's attacking."` — the `as long as` gates the granted first
+    /// strike, not the +2/+2). A body with an EVEN number of double quotes ends
+    /// outside any "…", so the split point is safe; an odd count means the
+    /// separator was found inside a quoted region and the split must be refused.
+    ///
+    /// INHERITS [`Self::split_around`]'s FIRST-OCCURRENCE semantics: an
+    /// odd-quote body refuses the split outright rather than scanning on to a
+    /// later separator that may lie outside the quotes
+    /// (`has "X as long as Y" as long as Z`). No corpus line has that shape
+    /// today (3 odd-quote static lines total), and both incumbent guards already
+    /// behave this way, so this is a documented property rather than a
+    /// deviation.
+    ///
+    /// SINGLE AUTHORITY for that rule. Callers must not re-derive the quote
+    /// count.
+    pub(crate) fn split_around_outside_quotes(&self, sep: &str) -> Option<(Self, Self)> {
+        self.split_around(sep)
+            .filter(|(body, _)| body.original.chars().filter(|&c| c == '"').count() % 2 == 0)
+    }
+
     /// Find last `needle` in lowered text, return `(before, after)` excluding needle.
     pub fn rsplit_around(&self, needle: &str) -> Option<(Self, Self)> {
         self.lower.rfind(needle).map(|pos| {

--- a/crates/engine/src/parser/oracle_util.rs
+++ b/crates/engine/src/parser/oracle_util.rs
@@ -2712,6 +2712,62 @@ mod tests {
     use crate::types::mana::ManaCostShard;
     use nom::Parser;
 
+    fn tp(text: &str) -> (String, String) {
+        (text.to_string(), text.to_lowercase())
+    }
+
+    /// CR 604.1: the building block, exercised across its documented contract
+    /// rather than through any one card. An EVEN quote count before the
+    /// separator means the split point is outside a quoted granted ability and
+    /// the split is safe; an ODD count means the separator was found inside
+    /// `"…"` and the split must be refused, so the quoted ability keeps its own
+    /// gate instead of the gate being hoisted onto the granting clause.
+    #[test]
+    fn split_around_outside_quotes_refuses_separator_inside_a_quoted_ability() {
+        // Zero quotes before the separator — plain conditional static, splits.
+        let (o, l) = tp("this creature gets +1/+1 as long as you control a Swamp");
+        let (body, cond) = TextPair::new(&o, &l)
+            .split_around_outside_quotes(" as long as ")
+            .expect("an unquoted gate must split");
+        assert_eq!(body.original, "this creature gets +1/+1");
+        assert_eq!(cond.original, "you control a Swamp");
+
+        // ONE quote before the separator — the separator is inside the quoted
+        // granted ability (the Ancestral Katana / Giant's Amulet shape). Refuse:
+        // splitting here would drop the granted ability and hoist its gate onto
+        // the unconditional buff.
+        let (o, l) =
+            tp("gets +2/+2 and has \"this creature has first strike as long as it's attacking.\"");
+        assert!(
+            TextPair::new(&o, &l)
+                .split_around_outside_quotes(" as long as ")
+                .is_none(),
+            "a separator inside a quoted granted ability must not split"
+        );
+
+        // TWO quotes before the separator — the quoted region CLOSED before the
+        // separator, so the gate belongs to the granting clause. Splits.
+        let (o, l) =
+            tp("creatures you control have \"first strike\" as long as you control a Swamp");
+        let (body, cond) = TextPair::new(&o, &l)
+            .split_around_outside_quotes(" as long as ")
+            .expect("a closed quoted region must not block a later outside split");
+        assert_eq!(body.original, "creatures you control have \"first strike\"");
+        assert_eq!(cond.original, "you control a Swamp");
+
+        // Documented FIRST-OCCURRENCE property: an odd-quote body refuses
+        // outright rather than scanning on to a later outside-quotes separator.
+        // No corpus line has this shape; pinning it makes the deviation
+        // deliberate rather than accidental if one ever appears.
+        let (o, l) = tp("has \"x as long as y\" as long as you control a Swamp");
+        assert!(
+            TextPair::new(&o, &l)
+                .split_around_outside_quotes(" as long as ")
+                .is_none(),
+            "first-occurrence semantics: refuse, do not scan on to the later separator"
+        );
+    }
+
     fn parse_every_creature_type_prefix(input: &str) -> OracleResult<'_, ()> {
         let (input, _) = tag("creatures you control are").parse(input)?;
         let (input, _) = tag(" every creature type.").parse(input)?;

--- a/crates/engine/tests/integration/issue_8183_static_gate_fail_open.rs
+++ b/crates/engine/tests/integration/issue_8183_static_gate_fail_open.rs
@@ -43,7 +43,7 @@
 //! shape as its primary claim; the two AST assertions present are explicitly
 //! labelled reach-guards.
 
-use engine::game::combat::{AttackTarget, AttackerInfo, CombatState};
+use engine::game::combat::AttackTarget;
 use engine::game::game_object::AttachTarget;
 use engine::game::keywords::has_keyword;
 use engine::game::layers::evaluate_layers;
@@ -321,11 +321,17 @@ fn ancestral_katana_granted_first_strike_binds_to_equipped_creature() {
     );
 
     // Attacking: CR 508.1k — the equipped creature is now an attacking
-    // creature, so the granted static's gate is TRUE.
-    runner.state_mut().combat = Some(CombatState {
-        attackers: vec![AttackerInfo::attacking_player(bearer, P1)],
-        ..Default::default()
-    });
+    // creature, so the granted static's gate is TRUE. Drive this through the
+    // engine's own declaration rather than installing a hand-built CombatState:
+    // a hand-built one makes the assertion depend on this test's idea of how
+    // attackers are recorded, so it could stay green while real combat stopped
+    // granting first strike. The bearer is an unrestricted Runeclaw Bear, so it
+    // is itself the legal attacker that makes the step reachable, and the
+    // Katana's own trigger needs a Samurai or Warrior and so cannot fire here.
+    advance_to_declare_attackers(&mut runner);
+    runner
+        .declare_attackers(&[(bearer, AttackTarget::Player(P1))])
+        .expect("the equipped bearer must be a legal attacker");
     assert!(
         has_kw(&mut runner, bearer, &Keyword::FirstStrike),
         "an ATTACKING equipped creature must have the granted first strike \

--- a/crates/engine/tests/integration/issue_8183_static_gate_fail_open.rs
+++ b/crates/engine/tests/integration/issue_8183_static_gate_fail_open.rs
@@ -1,0 +1,320 @@
+//! Issue #8183 — a static ability's gate condition that the parser could not
+//! type lands as `StaticCondition::Unrecognized`, which the layer system
+//! evaluates as ALWAYS TRUE (fail-open). Three shapes of that defect are fixed
+//! in the PARSER (no `layers.rs` change), and this file is the runtime proof
+//! that the fixed AST actually changes what the game allows.
+//!
+//! CR 604.1: a static ability is "simply true" — its gate decides whether it
+//! currently applies, so a gate the parser drops or mis-polarizes silently
+//! turns the restriction on (or off) for every board state.
+//!
+//!  1. **Graxiplon** — "This creature can't be blocked unless defending player
+//!     controls three or more creatures that share a creature type."
+//!     The `unless` NEGATION was dropped at the `can't be blocked` fallback
+//!     branch, leaving a bare `Unrecognized` that evaluates TRUE, so
+//!     `CantBeBlocked` applied unconditionally: Graxiplon was permanently
+//!     unblockable. With the fix the gate is `Not(Unrecognized)`, which
+//!     evaluates FALSE, so the restriction does not apply and the block is
+//!     legal (CR 509.1b — the defending player checks each creature for
+//!     blocking restrictions, and an evasion ability creates one).
+//!
+//!  2. **Training Drone** — "This creature can't attack or block unless it's
+//!     equipped." The anaphoric "it" in the gate was never resolved to the
+//!     source, so the gate stayed `Not(Unrecognized)` = FALSE and the
+//!     restriction NEVER applied: an unequipped Training Drone could attack.
+//!     With the fix the gate is `Not(SourceIsEquipped)` (CR 301.5a — the
+//!     creature an Equipment is attached to is the "equipped creature"), so an
+//!     unequipped Drone cannot be declared as an attacker (CR 508.1d) and an
+//!     equipped one can.
+//!
+//!  3. **Ancestral Katana** — `Equipped creature gets +2/+2 and has "This
+//!     creature has first strike as long as it's attacking."` The predicate was
+//!     split on the ` as long as ` INSIDE the quoted granted ability, so the
+//!     granted first strike was destroyed and its gate was mis-attached to the
+//!     +2/+2. With the fix the quoted ability survives as a granted static whose
+//!     own gate is evaluated against the EQUIPPED CREATURE (CR 611.3a — a
+//!     continuous effect from a static ability applies at any given moment to
+//!     whatever its text indicates; CR 508.1k — an attacking creature).
+//!
+//! Every card here is built from VERBATIM Oracle text through
+//! `GameScenario`/`GameRunner`, so the whole production route runs: Oracle text
+//! → static parser → `StaticDefinition.condition` → `evaluate_condition*` →
+//! combat legality / layer evaluation. No test in this file asserts an AST
+//! shape as its primary claim; the two AST assertions present are explicitly
+//! labelled reach-guards.
+
+use engine::game::combat::{AttackTarget, AttackerInfo, CombatState};
+use engine::game::game_object::AttachTarget;
+use engine::game::keywords::has_keyword;
+use engine::game::layers::evaluate_layers;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::phase::Phase;
+use engine::types::statics::StaticMode;
+
+/// Verbatim Graxiplon Oracle text (MTGJSON AtomicCards).
+const GRAXIPLON: &str = "This creature can't be blocked unless defending player controls three or more creatures that share a creature type.";
+
+/// Verbatim Training Drone Oracle text (MTGJSON AtomicCards).
+const TRAINING_DRONE: &str = "This creature can't attack or block unless it's equipped.";
+
+/// Verbatim Ancestral Katana Oracle text — the Alchemy rebalanced printing,
+/// which MTGJSON keys as `A-Ancestral Katana` and whose printed card name is
+/// "Ancestral Katana". The PAPER Ancestral Katana reads
+/// "Equipped creature gets +2/+1." and carries no quoted granted ability at
+/// all, so a fixture built from the paper text could not exercise this defect.
+const ANCESTRAL_KATANA: &str = "Whenever a Samurai or Warrior you control attacks alone, you may pay {1}. When you do, attach Ancestral Katana to it.\nEquipped creature gets +2/+2 and has \"This creature has first strike as long as it's attacking.\"\nEquip {2}";
+
+/// Wire `equipment` onto `host` the way the equip action does (CR 301.5).
+/// Mirrors the local `attach` helper in `mjolnir_hammer_double_damage.rs`.
+fn attach(runner: &mut GameRunner, equipment: ObjectId, host: ObjectId) {
+    let state = runner.state_mut();
+    state.objects.get_mut(&equipment).unwrap().attached_to = Some(AttachTarget::Object(host));
+    state
+        .objects
+        .get_mut(&host)
+        .unwrap()
+        .attachments
+        .push(equipment);
+}
+
+/// True iff `id` has `keyword` after a fresh layer evaluation (CR 613).
+/// Same idiom as `knighthood_first_strike_grant.rs`.
+fn has_kw(runner: &mut GameRunner, id: ObjectId, keyword: &Keyword) -> bool {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    has_keyword(&runner.state().objects[&id], keyword)
+}
+
+/// From `Phase::PreCombatMain`, pass to the declare-attackers step and assert we
+/// actually arrived — so a harness change surfaces as a clear failure rather
+/// than silently making every legality assertion below vacuous.
+fn advance_to_declare_attackers(runner: &mut GameRunner) {
+    runner.pass_both_players();
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::DeclareAttackers { .. }
+        ),
+        "fixture must reach the declare-attackers step; got {:?}",
+        runner.state().waiting_for
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 1. Graxiplon — the dropped `unless` negation
+// ---------------------------------------------------------------------------
+
+/// REACH-GUARD for the Graxiplon runtime test below.
+///
+/// `graxiplon_can_be_blocked_when_gate_unmet` asserts a block is LEGAL. That
+/// assertion is satisfied for the wrong reason if Graxiplon parsed no
+/// `CantBeBlocked` static at all, or parsed one with no gate. This pins that
+/// the static exists AND carries a condition, so the legal block below is
+/// evidence about the GATE and not about an absent static.
+#[test]
+fn graxiplon_parses_a_condition_gated_cant_be_blocked_static() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let graxiplon = scenario
+        .add_creature_from_oracle(P0, "Graxiplon", 4, 4, GRAXIPLON)
+        .id();
+    let runner = scenario.build();
+
+    let statics = &runner.state().objects[&graxiplon].static_definitions;
+    let gated: Vec<_> = statics
+        .iter_unchecked()
+        .filter(|d| matches!(d.mode, StaticMode::CantBeBlocked))
+        .collect();
+    assert_eq!(
+        gated.len(),
+        1,
+        "Graxiplon must parse to exactly one CantBeBlocked static: {statics:#?}"
+    );
+    assert!(
+        gated[0].condition.is_some(),
+        "the CantBeBlocked static must carry the `unless` gate as a condition, \
+         not be unconditional: {statics:#?}"
+    );
+}
+
+/// CR 509.1b + CR 604.1: with the `unless` gate UNMET (the defending player
+/// controls a single creature, not three sharing a type), the evasion
+/// restriction does NOT apply and the block is legal.
+///
+/// Discriminating: revert U2 (restore the bare
+/// `nom_condition::parse_condition(after_blocked)` fallback) and the gate
+/// becomes a bare `Unrecognized`, which the layer system evaluates as TRUE —
+/// `CantBeBlocked` applies unconditionally and `declare_blockers` returns Err.
+/// The `is_ok()` assertion is what flips.
+#[test]
+fn graxiplon_can_be_blocked_when_gate_unmet() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let graxiplon = scenario
+        .add_creature_from_oracle(P0, "Graxiplon", 4, 4, GRAXIPLON)
+        .id();
+    // ONE creature for the defender: the printed gate ("three or more creatures
+    // that share a creature type") is unmet by construction.
+    let blocker = scenario.add_creature(P1, "Runeclaw Bear", 2, 2).id();
+
+    let mut runner = scenario.build();
+
+    advance_to_declare_attackers(&mut runner);
+    runner
+        .declare_attackers(&[(graxiplon, AttackTarget::Player(P1))])
+        .expect("Graxiplon must be a legal attacker");
+
+    // CR 508.2 + CR 117.1c: the active player gets priority after attackers are
+    // declared; pass through it to reach the declare-blockers step.
+    if matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
+        runner.pass_both_players();
+    }
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::DeclareBlockers { .. }
+        ),
+        "fixture must reach the declare-blockers step; got {:?}",
+        runner.state().waiting_for
+    );
+
+    assert!(
+        runner.declare_blockers(&[(blocker, graxiplon)]).is_ok(),
+        "with the `unless` gate unmet the CantBeBlocked restriction must NOT \
+         apply, so the block is legal (CR 509.1b)"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 2. Training Drone — the unresolved source anaphor
+// ---------------------------------------------------------------------------
+
+/// CR 508.1d + CR 301.5a: an UNEQUIPPED Training Drone cannot be declared as an
+/// attacker.
+///
+/// Discriminating: revert U1 (make the helper's SelfRef arm unreachable) and the
+/// gate stays `Not(Unrecognized)` = FALSE, the restriction never applies, and
+/// `declare_attackers` returns Ok. The `is_err()` assertion is what flips.
+///
+/// Paired positive reach-guard: `training_drone_can_attack_while_equipped`
+/// below. Without it this negative could be satisfied by summoning sickness or
+/// a tapped state rather than by the restriction under test.
+#[test]
+fn training_drone_cannot_attack_while_unequipped() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let drone = scenario
+        .add_creature_from_oracle(P0, "Training Drone", 1, 1, TRAINING_DRONE)
+        .id();
+    let mut runner = scenario.build();
+
+    advance_to_declare_attackers(&mut runner);
+    assert!(
+        runner
+            .declare_attackers(&[(drone, AttackTarget::Player(P1))])
+            .is_err(),
+        "an unequipped Training Drone must not be a legal attacker \
+         (CR 508.1d; the `unless it's equipped` gate is unmet)"
+    );
+}
+
+/// Paired positive for the negative above: attach an Equipment and the SAME
+/// declaration becomes legal. This is what proves the negative is caused by the
+/// gate and not by an unrelated attack-legality failure.
+#[test]
+fn training_drone_can_attack_while_equipped() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let drone = scenario
+        .add_creature_from_oracle(P0, "Training Drone", 1, 1, TRAINING_DRONE)
+        .id();
+    // CR 301.5 + CR 704.5p: a bare attached noncreature permanent that is
+    // neither Aura, Equipment, nor Fortification is unattached by SBAs, so the
+    // Equipment subtype is load-bearing for the fixture.
+    let equipment = scenario
+        .add_creature(P0, "Bone Saw", 0, 0)
+        .as_artifact()
+        .with_subtypes(vec!["Equipment"])
+        .id();
+
+    let mut runner = scenario.build();
+    attach(&mut runner, equipment, drone);
+
+    advance_to_declare_attackers(&mut runner);
+    assert!(
+        runner
+            .declare_attackers(&[(drone, AttackTarget::Player(P1))])
+            .is_ok(),
+        "an EQUIPPED Training Drone must be a legal attacker — the \
+         `unless it's equipped` gate is met, so the restriction does not apply"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 3. Ancestral Katana — the quoted granted ability and its own gate
+// ---------------------------------------------------------------------------
+
+/// CR 611.3a + CR 508.1k: the ability written in quotation marks is a separate
+/// static granted to the equipped creature, and ITS gate ("as long as it's
+/// attacking") is evaluated against the EQUIPPED CREATURE, not against the
+/// Equipment and not against the +2/+2 grant.
+///
+/// Discriminating: revert any one of U3's three ` as long as ` quote guards and
+/// the predicate is split inside the quotation marks — the granted first strike
+/// is destroyed entirely and its gate is mis-attached to the +2/+2 — so the
+/// attacking case has no first strike to find. The `has_kw(... FirstStrike)`
+/// assertion under `state.combat` is what flips.
+///
+/// The not-attacking case is the paired reach-guard: a grant that applied
+/// unconditionally (or never applied at all) would make one of the two halves
+/// vacuous, and the pair rules both out.
+#[test]
+fn ancestral_katana_granted_first_strike_binds_to_equipped_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    // Deliberately NOT a Samurai or Warrior: the Equipment's own attack trigger
+    // ("Whenever a Samurai or Warrior you control attacks alone") must not fire
+    // and add an unrelated prompt to this fixture.
+    let bearer = scenario.add_creature(P0, "Runeclaw Bear", 2, 2).id();
+    let katana = scenario
+        .add_creature(P0, "Ancestral Katana", 0, 0)
+        .as_artifact()
+        .with_subtypes(vec!["Equipment"])
+        .from_oracle_text(ANCESTRAL_KATANA)
+        .id();
+
+    let mut runner = scenario.build();
+    attach(&mut runner, katana, bearer);
+
+    // Not attacking: the granted static's own gate is FALSE, so no first strike.
+    assert!(
+        !has_kw(&mut runner, bearer, &Keyword::FirstStrike),
+        "the granted first strike is gated on `as long as it's attacking`; a \
+         non-attacking equipped creature must NOT have it"
+    );
+    // The +2/+2 half of the same line must apply unconditionally — the gate
+    // belongs to the QUOTED ability, not to the P/T grant. Without this the
+    // not-attacking assertion above is also satisfied by a line that parsed to
+    // nothing at all.
+    assert_eq!(
+        runner.state().objects[&bearer].power,
+        Some(4),
+        "the +2/+2 grant is ungated and must apply to the equipped creature \
+         whether or not it is attacking"
+    );
+
+    // Attacking: CR 508.1k — the equipped creature is now an attacking
+    // creature, so the granted static's gate is TRUE.
+    runner.state_mut().combat = Some(CombatState {
+        attackers: vec![AttackerInfo::attacking_player(bearer, P1)],
+        ..Default::default()
+    });
+    assert!(
+        has_kw(&mut runner, bearer, &Keyword::FirstStrike),
+        "an ATTACKING equipped creature must have the granted first strike \
+         (CR 611.3a: the granted static's `it` names the equipped creature)"
+    );
+}

--- a/crates/engine/tests/integration/issue_8183_static_gate_fail_open.rs
+++ b/crates/engine/tests/integration/issue_8183_static_gate_fail_open.rs
@@ -92,7 +92,11 @@ fn has_kw(runner: &mut GameRunner, id: ObjectId, keyword: &Keyword) -> bool {
 /// actually arrived — so a harness change surfaces as a clear failure rather
 /// than silently making every legality assertion below vacuous.
 fn advance_to_declare_attackers(runner: &mut GameRunner) {
-    runner.pass_both_players();
+    // CR 508.1: use the scenario harness's purpose-built combat advance rather
+    // than a single priority round-trip. A lone `pass_both_players()` lands on
+    // the next `Priority` in the same phase, never on the declare-attackers
+    // turn-based action.
+    runner.advance_to_combat();
     assert!(
         matches!(
             runner.state().waiting_for,
@@ -209,6 +213,14 @@ fn training_drone_cannot_attack_while_unequipped() {
     let drone = scenario
         .add_creature_from_oracle(P0, "Training Drone", 1, 1, TRAINING_DRONE)
         .id();
+    // CR 508.1: a second, unrestricted attacker is REQUIRED, not decorative.
+    // With the Drone as the only creature its restriction leaves zero legal
+    // attackers, the engine never surfaces the declare-attackers turn-based
+    // action, and the harness advances turns until a player decks — the test
+    // then fails in the reach-guard on `GameOver` rather than exercising its
+    // claim. The bear guarantees the step is reached so the assertion below
+    // isolates the DRONE's legality specifically.
+    let _bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
     let mut runner = scenario.build();
 
     advance_to_declare_attackers(&mut runner);

--- a/crates/engine/tests/integration/issue_8183_static_gate_fail_open.rs
+++ b/crates/engine/tests/integration/issue_8183_static_gate_fail_open.rs
@@ -24,7 +24,7 @@
 //!     restriction NEVER applied: an unequipped Training Drone could attack.
 //!     With the fix the gate is `Not(SourceIsEquipped)` (CR 301.5a — the
 //!     creature an Equipment is attached to is the "equipped creature"), so an
-//!     unequipped Drone cannot be declared as an attacker (CR 508.1d) and an
+//!     unequipped Drone cannot be declared as an attacker (CR 508.1c) and an
 //!     equipped one can.
 //!
 //!  3. **Ancestral Katana** — `Equipped creature gets +2/+2 and has "This
@@ -60,9 +60,11 @@ const GRAXIPLON: &str = "This creature can't be blocked unless defending player 
 /// Verbatim Training Drone Oracle text (MTGJSON AtomicCards).
 const TRAINING_DRONE: &str = "This creature can't attack or block unless it's equipped.";
 
-/// Verbatim Ancestral Katana Oracle text — the Alchemy rebalanced printing,
+/// Ancestral Katana Oracle text — the Alchemy rebalanced printing,
 /// which MTGJSON keys as `A-Ancestral Katana` and whose printed card name is
-/// "Ancestral Katana". The PAPER Ancestral Katana reads
+/// "Ancestral Katana". Lines 1-2 are verbatim; the trailing `Equip {2}` drops
+/// MTGJSON's reminder text, which no assertion here reads.
+/// The PAPER Ancestral Katana reads
 /// "Equipped creature gets +2/+1." and carries no quoted granted ability at
 /// all, so a fixture built from the paper text could not exercise this defect.
 const ANCESTRAL_KATANA: &str = "Whenever a Samurai or Warrior you control attacks alone, you may pay {1}. When you do, attach Ancestral Katana to it.\nEquipped creature gets +2/+2 and has \"This creature has first strike as long as it's attacking.\"\nEquip {2}";
@@ -171,7 +173,7 @@ fn graxiplon_can_be_blocked_when_gate_unmet() {
         .declare_attackers(&[(graxiplon, AttackTarget::Player(P1))])
         .expect("Graxiplon must be a legal attacker");
 
-    // CR 508.2 + CR 117.1c: the active player gets priority after attackers are
+    // CR 508.2: the active player gets priority after attackers are
     // declared; pass through it to reach the declare-blockers step.
     if matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
         runner.pass_both_players();
@@ -196,7 +198,7 @@ fn graxiplon_can_be_blocked_when_gate_unmet() {
 // 2. Training Drone — the unresolved source anaphor
 // ---------------------------------------------------------------------------
 
-/// CR 508.1d + CR 301.5a: an UNEQUIPPED Training Drone cannot be declared as an
+/// CR 508.1c + CR 301.5a: an UNEQUIPPED Training Drone cannot be declared as an
 /// attacker.
 ///
 /// Discriminating: revert U1 (make the helper's SelfRef arm unreachable) and the
@@ -229,7 +231,7 @@ fn training_drone_cannot_attack_while_unequipped() {
             .declare_attackers(&[(drone, AttackTarget::Player(P1))])
             .is_err(),
         "an unequipped Training Drone must not be a legal attacker \
-         (CR 508.1d; the `unless it's equipped` gate is unmet)"
+         (CR 508.1c; the `unless it's equipped` gate is unmet)"
     );
 }
 

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -780,6 +780,7 @@ mod issue_787_once_upon_a_time;
 mod issue_788_unexpectedly_absent;
 mod issue_7945_free_grant_face_down;
 mod issue_8024_terminal_rest_captures;
+mod issue_8183_static_gate_fail_open;
 mod issue_822_erode_path_to_exile_search_controller;
 mod issue_828_full_throttle;
 mod issue_841_selvala_explorer_returned;


### PR DESCRIPTION
Fixes #8183.

Static-ability conditions the Oracle parser could not type fell to
`StaticCondition::Unrecognized`, which the layer system treats as **true**. A
conditional static therefore applied unconditionally — the gate failed open.

## What was wrong

**A1 — the `can't be blocked` fallback bypassed the shared condition parsers.**
`oracle_static/dispatch.rs` called `nom_condition::parse_condition` directly,
skipping `parse_static_condition`, the self-pronoun rewrite, and the `unless`
negation. Graxiplon was permanently unblockable.

**A2 — no balanced-quote guard on ` as long as ` splits.** A gate inside a
quoted granted ability was split as if it belonged to the granting clause, so
the granted ability was dropped *and* its condition was hoisted onto an
unconditional buff (A-Ancestral Katana, Giant's Amulet).

## What changed

The `can't be blocked` fallback now routes through the same three gate helpers
every other static uses, and `TextPair::split_around_outside_quotes` becomes the
single authority for the quote rule — replacing two re-derived inline `% 2`
guards.

`layers.rs` is untouched. **The fail-open `Unrecognized => true` behaviour is
deliberately NOT flipped**, for two independent reasons: the hoisted-condition
cards make fail-open accidentally correct until A2 lands, and 29 `Not`-wrapped
rows are wrong under *both* polarities. That flip needs its own change.

No new `StaticCondition` variant; `oracle_nom/condition.rs` untouched.

## Verification

- **Corpus parser-output diff: exactly the 5 predicted cards change** —
  a-ancestral katana, giant's amulet, graxiplon, metathran elite, training
  drone. No collateral. Controls: identical card sets (35798 both sides) and
  **`oracle_text` byte-identical for all 35798 cards**, so every delta is
  parser-driven. MTGJSON inputs were pinned by hardlink so the two projections
  provably read the same bytes.
- Full engine suite: lib **20220 passed / 0 failed**, integration **5770 passed
  / 0 failed**.
- `scripts/check-parser-combinators.sh`: Gate G + Gate A pass.
- **Fail-on-revert probe.** Reverting the trailing-dot trim at
  `shared.rs:3378` initially left BOTH suites green — nothing pinned it. All
  five integration tests ride the ` unless ` branch, whose trim was already
  incumbent; the ` as long as ` branch's only corpus witness is Metathran Elite.
  `cant_be_blocked_as_long_as_its_enchanted` closes that, and re-probing now
  correctly fails.
- A unit test for `split_around_outside_quotes` covers zero/odd/even quote
  counts and the documented first-occurrence refusal.

## Known-open, stated rather than implied

- The `revert -> red` claims for the quote guards are **re-derived reasoning,
  not measurements**; only the trailing-dot guard was empirically probed. All
  three share one named test, so one probe would cover them.
- Three review findings were recorded as inert rather than fixed, each with the
  census behind it (0 corpus rows with ` unless ` before `can't be blocked`; an
  empty-tail guard that preserves prior behaviour; a pre-existing `Not`-rewrap
  lacking the `UnlessPay` exception, unreachable from a nine-phrase match list).
- `tests.rs`'s incumbent `CR 509.1a` on a `DefendingPlayerControls` gate is a
  misfit (509.1b is the evasion-restriction rule). Left for the follow-up that
  owns that construct.

Reviewed across two independent rounds; every CR citation grep-verified for fit
rather than existence, which caught four adjacent-but-wrong cites
(508.1d→508.1c, 117.1c dropped, 303.4→303.4b, and an unsupported 611.3a).

https://claude.ai/code/session_011bmKqduE8R5LCy8umePnLX


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of conditional static abilities, including “unless,” “if,” and “as long as” clauses.
  * Correctly resolves self-referential conditions such as “it’s enchanted.”
  * Prevents quoted ability text from being split incorrectly.
  * Fixed cases where unrecognized conditions could incorrectly make restrictions fail open.

* **Tests**
  * Added regression coverage for affected combat restrictions and quoted ability conditions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->