### PR TITLE
feat(client): curated visual pack — one image per card, with delta sync

### DIFF
--- a/client/src/components/settings/visual-packs/OperationProgress.tsx
+++ b/client/src/components/settings/visual-packs/OperationProgress.tsx
@@ -1,6 +1,7 @@
 import { useTranslation } from "react-i18next";
 
 import type { OperationStatus, ProgressEvent } from "../../../services/visualPacks/types.ts";
+import { shortDigest } from "./packLabels.ts";
 
 interface OperationProgressProps {
   operation: OperationStatus;
@@ -12,10 +13,43 @@ interface OperationProgressProps {
 
 export function OperationProgress({ operation, progressPhase, pendingActions, onCancel, onResume }: OperationProgressProps) {
   const { t } = useTranslation("settings");
+  const imageTotal = operation.objectEstimate ?? operation.objectTotal;
   const startPending = pendingActions.has("install") || pendingActions.has("repair") || pendingActions.has("resume");
   const canCancel = operation.state === "downloading" && progressPhase !== "failed";
-  const canResume = operation.state === "downloading" && progressPhase === "failed";
-  const displayedState = progressPhase === "failed" ? "failed" : operation.state;
+  /**
+   * `finalizing` as well as `downloading`, because a failure there really is
+   * resumable and the backend already treats it that way: `finish()` leaves the
+   * record `finalizing` when its transaction rejects, that classifies as
+   * `storage`, `storage` is retryable — and `create()`'s pending loop re-runs
+   * every `downloading` OR `finalizing` record on the next launch. Offering
+   * Resume only makes available now what would otherwise happen silently at
+   * relaunch; `start({ kind: "resume" })` accepts a `finalizing` record on the
+   * same path, and `run()` refuses a second worker for an operation already
+   * running.
+   */
+  const canResume = (operation.state === "downloading" || operation.state === "finalizing")
+    && progressPhase === "failed";
+  /**
+   * Three endings, not two, because the record and the event each know half of
+   * one of them.
+   *
+   * `operation.state` alone cannot report a failure: the backend terminates a
+   * non-retryable operation by writing `state: "cancelled"`, the same value a
+   * user's Cancel writes, so rendering the record would show a conflict as a
+   * cancellation the user never asked for. The event's `failed` phase is what
+   * says otherwise, and it wins.
+   *
+   * Which of the two failure labels shows is keyed to `canResume` — the same
+   * test that decides whether the button is there — and deliberately NOT to the
+   * record's terminality. "Failed — ready to resume" is a sentence about a
+   * control, so it must be true exactly when the control is: keying it to
+   * terminality instead promises a Resume beside no Resume for a
+   * `cancel_requested` record, which is not terminal and is not resumable
+   * either. The bug this had was that `canResume`'s SET was wrong — it omitted
+   * `finalizing` — and that is fixed above, at the definition, rather than
+   * worked around here.
+   */
+  const displayedState = progressPhase === "failed" ? (canResume ? "failed" : "terminated") : operation.state;
   return (
     <section aria-label={t("visualPacks.operation.title")} className="rounded-[16px] border border-sky-400/30 bg-sky-400/[0.07] p-3 sm:p-4">
       <div>
@@ -26,7 +60,7 @@ export function OperationProgress({ operation, progressPhase, pendingActions, on
       </div>
       <dl className="mt-3 grid grid-cols-[auto_minmax(0,1fr)] gap-x-2 gap-y-1 text-xs text-sky-100">
         <dt className="text-sky-200/70">{t("visualPacks.operation.id")}</dt><dd className="break-all font-mono">{operation.operationId}</dd>
-        <dt className="text-sky-200/70">{t("visualPacks.operation.root")}</dt><dd className="break-all font-mono">{operation.catalogRoot}</dd>
+        <dt className="text-sky-200/70">{t("visualPacks.operation.root")}</dt><dd className="break-all font-mono">{shortDigest(operation.catalogRoot)}</dd>
       </dl>
       <label className="mt-4 block text-xs text-sky-50">
         <span className="flex items-center justify-between gap-3">
@@ -37,12 +71,14 @@ export function OperationProgress({ operation, progressPhase, pendingActions, on
       </label>
       <label className="mt-3 block text-xs text-sky-50">
         <span className="flex items-center justify-between gap-3">
-          <span>{t("visualPacks.operation.objects", { current: operation.objectsPromoted, total: operation.objectTotal })}</span>
-          <span className="font-medium tabular-nums">{operation.objectsPromoted}/{operation.objectTotal}</span>
+          <span>{t("visualPacks.operation.objects", { current: operation.objectsPromoted, total: imageTotal })}</span>
+          <span className="font-medium tabular-nums">{operation.objectsPromoted}/{imageTotal}</span>
         </span>
-        <progress className="mt-1.5 block h-2 w-full accent-sky-400" value={operation.objectsPromoted} max={Math.max(operation.objectTotal, 1)} />
+        <progress className="mt-1.5 block h-2 w-full accent-sky-400" value={operation.objectsPromoted} max={Math.max(imageTotal, 1)} />
       </label>
-      <p className="mt-3 text-xs leading-relaxed text-sky-100/80">{t("visualPacks.operation.scanNote")}</p>
+      <p className="mt-3 text-xs leading-relaxed text-sky-100/80">
+        {t(operation.objectEstimate === null ? "visualPacks.operation.scanNote" : "visualPacks.operation.estimateNote")}
+      </p>
       {operation.state === "finalizing" && <progress aria-label={t("visualPacks.operation.finalizing")} className="mt-4 block h-2 w-full accent-sky-400" />}
       <div className="mt-3 flex flex-wrap gap-2">
         {canCancel && (

--- a/client/src/components/settings/visual-packs/PackSelector.tsx
+++ b/client/src/components/settings/visual-packs/PackSelector.tsx
@@ -1,24 +1,52 @@
-import { useMemo, useState } from "react";
+import type { TFunction } from "i18next";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useTranslation } from "react-i18next";
 
 import { useSetCatalog } from "../../../hooks/useSetSymbols.ts";
 import {
   packId,
   type CatalogSummary,
+  type CatalogScanProgress,
+  type CuratedDrift,
+  type CuratedInstallSelector,
   type InstallEstimate,
   type InstallSelector,
 } from "../../../services/visualPacks/types.ts";
+import { usePreferencesStore } from "../../../stores/preferencesStore.ts";
+import { formatByteSize } from "../../../utils/byteSize.ts";
+import { packLabel } from "./packLabels.ts";
+import { curatedDriftState } from "./useVisualPackManager.ts";
 
 const IMAGE_LOCALES = ["de", "es", "fr", "it", "pt"] as const;
 const MUTATION_ACTIONS = new Set(["install", "cancel", "resume", "repair", "remove"]);
 type ImageLocale = (typeof IMAGE_LOCALES)[number];
-type SelectorKind = "core" | "printing" | "locale" | "complete";
+type SelectorKind = "core" | "printing" | "locale" | "complete" | "curated";
+
+const SELECTOR_KINDS = ["curated", "core", "printing", "locale", "complete"] as const;
+
+const CURATED = packId("curated");
+
+/**
+ * How long a curated selection settles before its estimate is requested.
+ *
+ * Curated is the one selector estimated without a click, so a user flicking
+ * through the radios would otherwise start a membership plan for every one
+ * they pass through. Short enough that a deliberate choice reads as immediate.
+ */
+const CURATED_ESTIMATE_DEBOUNCE_MS = 200;
+
+/** The catalog-scan figures, which only a bulk selector has. */
+const BULK_METRICS = ["assetRecords", "uniqueObjects", "logicalImageBytes", "uniqueImageBytes", "shardCount", "shardBytes"] as const;
 
 interface PackSelectorProps {
   summary: CatalogSummary;
+  curatedSelector: CuratedInstallSelector | null;
+  curatedDrift: CuratedDrift | null;
   estimate: { selector: InstallSelector; value: InstallEstimate } | null;
+  estimateProgress: CatalogScanProgress | null;
   pendingActions: ReadonlySet<string>;
   durableMutationActive: boolean;
+  onSelectCurated(): void;
   onEstimate(selector: InstallSelector): void;
   onInstall(selector: InstallSelector): void;
 }
@@ -27,7 +55,13 @@ function normalizedSet(value: string): string {
   return value.trim().normalize("NFC").toLowerCase();
 }
 
-function validSelector(kind: SelectorKind, setInput: string, language: ImageLocale, summary: CatalogSummary): InstallSelector | null {
+function validSelector(
+  kind: SelectorKind,
+  setInput: string,
+  language: ImageLocale,
+  summary: CatalogSummary,
+  curated: CuratedInstallSelector | null,
+): InstallSelector | null {
   const set = normalizedSet(setInput);
   try {
     switch (kind) {
@@ -41,10 +75,65 @@ function validSelector(kind: SelectorKind, setInput: string, language: ImageLoca
         return { kind: "locale", language, set };
       case "complete":
         return { kind: "complete", rootSha256: summary.catalogRoot };
+      case "curated":
+        // Not composed here. The digest names a membership only the planner
+        // can compute, so the backend resolves it and this option merely
+        // reports what came back — null until it has.
+        return curated;
     }
   } catch {
     return null;
   }
+}
+
+/** A `shardBytes` figure, which is a byte count when it is a number at all and
+ *  the literal `"unknown"` when the selector reads no shard. */
+function formatCatalogSize(value: string, locale: string): string {
+  const bytes = Number(value);
+  return Number.isFinite(bytes) ? formatByteSize(bytes, locale) : value;
+}
+
+/**
+ * The figures worth showing for the selector this estimate was taken for.
+ *
+ * The list is selector-aware because the bulk figures are not merely
+ * uninteresting for a curated pack, they are FALSE about it: it reads no shard
+ * of the Scryfall archive, so "Metadata files: 0" and "Compressed Scryfall
+ * catalog: unknown" describe an archive it never opens. Its own two record
+ * counts are the same number by construction, so one of them is shown.
+ *
+ * The download size and the free space the browser reports are common to every
+ * selector — they are the two numbers the Install decision is actually made on.
+ */
+function estimateRows(
+  estimate: InstallEstimate,
+  curated: boolean,
+  locale: string,
+  t: TFunction<"settings">,
+): Array<{ key: string; label: string; value: string }> {
+  const count = new Intl.NumberFormat(locale);
+  const rows = curated
+    ? [{ key: "uniqueObjects", label: t("visualPacks.metrics.uniqueObjects"), value: count.format(Number(estimate.uniqueObjects)) }]
+    : BULK_METRICS.map((metric) => ({
+      key: metric,
+      label: t(`visualPacks.metrics.${metric}`),
+      value: metric === "shardBytes" ? formatCatalogSize(estimate[metric], locale) : estimate[metric],
+    }));
+  rows.push({
+    key: "estimatedImageBytes",
+    label: t("visualPacks.metrics.estimatedImageBytes"),
+    value: formatByteSize(estimate.estimatedImageBytes, locale),
+  });
+  // Omitted rather than shown as zero when the browser will not say: `null`
+  // means unknown, and rendering it as a figure would read as "no space left".
+  if (estimate.storage.availableBytes !== null) {
+    rows.push({
+      key: "availableBytes",
+      label: t("visualPacks.metrics.availableBytes"),
+      value: formatByteSize(estimate.storage.availableBytes, locale),
+    });
+  }
+  return rows;
 }
 
 function sameSelector(left: InstallSelector, right: InstallSelector): boolean {
@@ -58,30 +147,111 @@ function sameSelector(left: InstallSelector, right: InstallSelector): boolean {
       return right.kind === "locale" && left.language === right.language && left.set === right.set;
     case "complete":
       return right.kind === "complete" && left.rootSha256 === right.rootSha256;
+    case "curated":
+      return right.kind === "curated" && left.membershipDigest === right.membershipDigest;
   }
 }
 
-export function PackSelector({ summary, estimate, pendingActions, durableMutationActive, onEstimate, onInstall }: PackSelectorProps) {
-  const { t } = useTranslation("settings");
+export function PackSelector({ summary, curatedSelector, curatedDrift, estimate, estimateProgress, pendingActions, durableMutationActive, onSelectCurated, onEstimate, onInstall }: PackSelectorProps) {
+  const { t, i18n } = useTranslation("settings");
   const { catalog } = useSetCatalog();
+  const artChain = usePreferencesStore((state) => state.artChain);
   const [kind, setKind] = useState<SelectorKind>("core");
   const [setInput, setSetInput] = useState("");
   const [language, setLanguage] = useState<ImageLocale>("de");
+  const curated = kind === "curated";
   const selector = useMemo(
-    () => validSelector(kind, setInput, language, summary),
-    [kind, language, setInput, summary],
+    () => validSelector(kind, setInput, language, summary, curatedSelector),
+    [curatedSelector, kind, language, setInput, summary],
   );
   const matchingEstimate = selector && estimate && sameSelector(selector, estimate.selector)
     && estimate.value.catalogRoot === summary.catalogRoot
     && estimate.value.installedRevision === summary.installedRevision
     ? estimate.value
     : null;
+  // Built on the panel's own language rather than the runtime default, like
+  // every other figure this component renders.
+  const number = new Intl.NumberFormat(i18n.language);
+  const estimatePending = pendingActions.has("estimate");
+  /** Curated chosen, but the backend has not (or could not) say what it means. */
+  const curatedUnresolved = curated && !curatedSelector;
+  /**
+   * What may be said about the installed curated pack, from the one predicate
+   * that decides it for the badge as well.
+   *
+   * `unknown` is "say nothing" and covers every case with nothing measured
+   * behind it: nothing installed, the read not finished, the read failed, or
+   * the card data not resident so the backend declined to load 76 MB to answer.
+   */
+  const driftState = curatedDriftState(summary, curatedDrift);
+  /**
+   * Whether there is a curated pack on disk — which is what makes the primary
+   * action a sync rather than an install.
+   *
+   * Read from the SUMMARY, never from whether drift has been measured. Those
+   * are different questions with a reachable, permanent gap between them: with
+   * a curated pack installed and the card data not resident, a
+   * `curatedSelector()` that rejects (the card-data fetch failing makes
+   * `planMembership` throw `network`) leaves both the selector and the drift
+   * null for the life of the tab — and the button would have offered to
+   * "install" a pack already installed, for ever. The summary answers it for
+   * free and cannot fail.
+   */
+  const curatedInstalled = summary.installedPacks.some((entry) => entry.packId === CURATED);
+  const autoEstimatedRef = useRef<string | null>(null);
+
+  // Ask what "curated" means the moment it is chosen, and not before: the
+  // answer costs a membership plan, and every other option is composed from
+  // what is already on screen.
+  useEffect(() => {
+    if (curated && !curatedSelector) onSelectCurated();
+  }, [curated, curatedSelector, onSelectCurated]);
+
+  // Estimate on selection, for curated only. Curated opens no bulk stream, so
+  // there is nothing for a user to consent to before it runs and no reason to
+  // make them press a button whose label promises a catalog scan; every other
+  // selector reads the multi-gigabyte archive and must stay a deliberate act.
+  //
+  // Keyed on the digest AND the catalog the estimate would be bound to,
+  // because the hook discards an estimate taken against a superseded one — so
+  // a summary change has to be able to ask again, while a re-render must not.
+  useEffect(() => {
+    if (!curated || !curatedSelector) return;
+    // Already on screen: nothing to ask for. The key is deliberately NOT
+    // cleared here — leaving the option does that, and doing it in both places
+    // was measured to be redundant (no probe could kill this line).
+    if (matchingEstimate) return;
+    // The estimate slot is single-occupancy: `estimateInstall` refuses a
+    // second request outright. Asking now would be dropped silently and leave
+    // Install disabled with no estimate and no error, so wait for the slot
+    // instead — `estimatePending` is a dependency, so freeing it re-runs this.
+    if (estimatePending) return;
+    const key = `${curatedSelector.membershipDigest}:${summary.catalogRoot}:${summary.installedRevision}`;
+    // Asked for exactly this and got nothing back, so the request failed
+    // rather than raced. Retrying on a timer would hammer a failing backend at
+    // five requests a second; the user retries with the button, or by
+    // reselecting the option, which clears this below.
+    if (autoEstimatedRef.current === key) return;
+    const timer = setTimeout(() => {
+      autoEstimatedRef.current = key;
+      onEstimate(curatedSelector);
+    }, CURATED_ESTIMATE_DEBOUNCE_MS);
+    return () => clearTimeout(timer);
+  }, [curated, curatedSelector, estimatePending, matchingEstimate, onEstimate, summary]);
+
+  // Leaving the option forgets that we asked. A bulk estimate taken in the
+  // meantime displaces the curated one from `estimate`, so coming back finds
+  // no matching estimate and must be free to ask again — and re-asking is
+  // nearly free, because the membership plan behind it is memoized.
+  useEffect(() => {
+    if (!curated) autoEstimatedRef.current = null;
+  }, [curated]);
 
   return (
     <fieldset className="flex flex-col gap-4 rounded-[16px] border border-white/10 bg-slate-950/20 p-3 sm:p-4">
       <legend className="px-1 text-sm font-semibold text-slate-100">{t("visualPacks.selector.title")}</legend>
       <div className="grid gap-2 sm:grid-cols-2" role="radiogroup" aria-label={t("visualPacks.selector.title")}>
-        {(["core", "printing", "locale", "complete"] as const).map((option) => (
+        {SELECTOR_KINDS.map((option) => (
           <label
             key={option}
             className={`flex min-h-14 cursor-pointer items-center gap-3 rounded-[14px] border px-3 py-3 text-sm transition-colors focus-within:ring-2 focus-within:ring-sky-300 ${
@@ -133,33 +303,110 @@ export function PackSelector({ summary, estimate, pendingActions, durableMutatio
       {kind === "complete" && (
         <p className="break-all text-xs text-slate-400">{t("visualPacks.selector.currentRoot", { root: summary.catalogRoot })}</p>
       )}
+      {curated && (
+        // Two sentences, because the honest one depends on whether the user
+        // has actually made the setting this pack follows. An empty art chain
+        // is the DEFAULT, and it selects each card's canonical art — copy that
+        // said "your configured set priority" would credit the user with a
+        // choice they have not made.
+        <p className="text-xs text-slate-400">
+          {t(artChain.length === 0 ? "visualPacks.selector.curatedDefaultNote" : "visualPacks.selector.curatedNote")}
+        </p>
+      )}
+      {/* What a Sync would change, in the three categories the backend counts.
+          THREE, not two: a Scryfall re-scan moves a `sourceUrl` under an
+          unchanged asset key, so the membership differs while both key sets are
+          identical — an add/remove-only report would say "0 to add, 0 to
+          remove" beside a live Sync button and read as a bug. Nothing here
+          starts a download; only pressing Sync does. */}
+      {/* `curatedDrift &&` is the type narrowing, not a second condition:
+          `driftState` is `unknown` whenever it is null. */}
+      {curated && driftState !== "unknown" && curatedDrift && (
+        <p className={`text-xs ${driftState === "current" ? "text-slate-400" : "text-amber-200"}`}>
+          {driftState === "current"
+            ? t("visualPacks.selector.driftNone")
+            : t("visualPacks.selector.driftSummary", {
+              add: number.format(curatedDrift.add),
+              remove: number.format(curatedDrift.remove),
+              refresh: number.format(curatedDrift.refresh),
+            })}
+        </p>
+      )}
       {!selector && (kind === "printing" || kind === "locale") && (
         <p role="alert" className="text-xs text-rose-300">{t("visualPacks.selector.invalidSet")}</p>
       )}
       {matchingEstimate && (
-        <section aria-label={t("visualPacks.estimate.title")} className="rounded-[14px] border border-sky-400/20 bg-sky-400/[0.06] p-3 text-xs text-sky-100">
-          <h4 className="mb-2 font-semibold text-slate-100">{t("visualPacks.estimate.title")}</h4>
+        <section
+          aria-label={t(curated ? "visualPacks.estimate.curatedTitle" : "visualPacks.estimate.title")}
+          className="rounded-[14px] border border-sky-400/20 bg-sky-400/[0.06] p-3 text-xs text-sky-100"
+        >
+          <h4 className="mb-2 font-semibold text-slate-100">
+            {t(curated ? "visualPacks.estimate.curatedTitle" : "visualPacks.estimate.title")}
+          </h4>
           <ol className="mb-3 list-decimal space-y-1 pl-5">
-            {matchingEstimate.packIds.map((id) => <li key={id} className="break-all">{id}</li>)}
+            {matchingEstimate.packIds.map((id) => <li key={id} className="break-all">{packLabel(id, t)}</li>)}
           </ol>
           <dl className="grid grid-cols-[minmax(0,1fr)_auto] gap-x-3 gap-y-1 tabular-nums">
-            {(["assetRecords", "uniqueObjects", "logicalImageBytes", "uniqueImageBytes", "shardCount", "shardBytes"] as const).map((metric) => (
-              <div className="contents" key={metric}>
-                <dt>{t(`visualPacks.metrics.${metric}`)}</dt>
-                <dd className="break-all font-mono text-slate-100">{matchingEstimate[metric]}</dd>
+            {estimateRows(matchingEstimate, curated, i18n.language, t).map((row) => (
+              <div className="contents" key={row.key}>
+                <dt>{row.label}</dt>
+                <dd className="break-all font-mono text-slate-100">{row.value}</dd>
               </div>
             ))}
           </dl>
+          {/* A warning, never a veto: the projection behind it is an
+              order-of-magnitude figure from six samples per rung, and running
+              out of quota mid-download is the milder failure — it classifies
+              as `storage`, which is retryable, and a resume skips everything
+              already cached. See `InstallEstimate.headroom`. */}
+          {matchingEstimate.headroom === "insufficient" && (
+            <p className="mt-3 text-amber-200">{t("visualPacks.estimate.headroomWarning")}</p>
+          )}
+          {matchingEstimate.storage.persistence === "best_effort" && (
+            <p className="mt-2 text-amber-200">{t("visualPacks.estimate.evictionWarning")}</p>
+          )}
+        </section>
+      )}
+      {estimateProgress && (
+        <section aria-label={t("visualPacks.estimate.progressTitle")} className="rounded-[14px] border border-sky-400/20 bg-sky-400/[0.06] p-3 text-xs text-sky-100">
+          <h4 className="mb-2 font-semibold text-slate-100">{t("visualPacks.estimate.progressTitle")}</h4>
+          <progress
+            value={estimateProgress.compressedBytesRead}
+            max={estimateProgress.compressedBytesTotal}
+            className="h-2 w-full overflow-hidden rounded-full accent-sky-400"
+          />
+          <p className="mt-2 tabular-nums text-sky-100/80">
+            {t("visualPacks.estimate.progress", {
+              downloaded: number.format(Math.floor(estimateProgress.compressedBytesRead / (1024 * 1024))),
+              total: number.format(Math.ceil(estimateProgress.compressedBytesTotal / (1024 * 1024))),
+              records: number.format(estimateProgress.recordsScanned),
+              images: number.format(estimateProgress.assetRecords),
+            })}
+          </p>
         </section>
       )}
       <div className="flex flex-wrap gap-2 border-t border-white/8 pt-3">
         <button
           type="button"
-          disabled={!selector || pendingActions.has("estimate")}
-          onClick={() => selector && onEstimate(selector)}
+          // Enabled with no selector when curated's resolution FAILED, because
+          // that is the only state in which the panel has an error on screen
+          // and every control beneath it dead: the selector is null, so both
+          // buttons would be disabled and the only undiscoverable way out is
+          // to pick another option and come back. Here it retries the thing
+          // that failed.
+          disabled={(!selector && !curatedUnresolved) || estimatePending || pendingActions.has("curated")}
+          onClick={() => {
+            if (curatedUnresolved) onSelectCurated();
+            else if (selector) onEstimate(selector);
+          }}
           className="min-h-11 rounded-[12px] border border-sky-400/50 bg-sky-400/10 px-4 py-2 text-sm font-medium text-sky-50 transition-colors hover:bg-sky-400/18 disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-sky-300"
         >
-          {pendingActions.has("estimate") ? t("visualPacks.actions.estimating") : t("visualPacks.actions.estimate")}
+          {/* Curated scans no catalog, so it says neither "Scan catalog" nor
+              "Scanning": the estimate has already run on selection and this is
+              only the way back to it. */}
+          {curated
+            ? t(estimatePending ? "visualPacks.actions.estimatingCurated" : "visualPacks.actions.estimateCurated")
+            : t(estimatePending ? "visualPacks.actions.estimating" : "visualPacks.actions.estimate")}
         </button>
         <button
           type="button"
@@ -167,7 +414,11 @@ export function PackSelector({ summary, estimate, pendingActions, durableMutatio
           onClick={() => selector && onInstall(selector)}
           className="min-h-11 rounded-[12px] border border-emerald-400/50 bg-emerald-400/10 px-4 py-2 text-sm font-medium text-emerald-50 transition-colors hover:bg-emerald-400/18 disabled:opacity-40 focus-visible:ring-2 focus-visible:ring-emerald-300"
         >
-          {t("visualPacks.actions.install")}
+          {/* "Sync" once a curated pack is on disk: the same request, but the
+              act is bringing an existing pack up to date rather than adding one.
+              `driftState` says by HOW MUCH and may be `unknown`; whether there
+              is anything to sync at all is a question the summary answers. */}
+          {t(curated && curatedInstalled ? "visualPacks.actions.sync" : "visualPacks.actions.install")}
         </button>
       </div>
     </fieldset>

--- a/client/src/components/settings/visual-packs/PackStatus.tsx
+++ b/client/src/components/settings/visual-packs/PackStatus.tsx
@@ -1,16 +1,50 @@
 import { useState } from "react";
 import { useTranslation } from "react-i18next";
 
-import type {
-  CatalogSummary,
-  PackId,
-  RemovalResponse,
-  VerificationResponse,
+import {
+  packId,
+  type CatalogSummary,
+  type CuratedDrift,
+  type InstalledPack,
+  type PackId,
+  type RemovalResponse,
+  type VerificationResponse,
 } from "../../../services/visualPacks/types.ts";
-import { hasPendingVisualPackMutation } from "./useVisualPackManager.ts";
+import { formatByteSize } from "../../../utils/byteSize.ts";
+import { packLabel, shortDigest } from "./packLabels.ts";
+import { curatedDriftState, hasPendingVisualPackMutation } from "./useVisualPackManager.ts";
+
+const CURATED = packId("curated");
+
+/**
+ * Whether an installed pack is behind what the panel could install now.
+ *
+ * For every bulk pack that is a catalog-identity question, and the comparison
+ * below answers it: the pack was installed from a Scryfall snapshot, and a
+ * newer snapshot means a newer pack.
+ *
+ * The curated pack is not in that namespace at all. Its `catalogRoot` IS its
+ * membership digest, so `entry.catalogRoot !== summary.catalogRoot` compares a
+ * membership fingerprint against a snapshot hash. Those are sha256s of two
+ * different things, so short of a collision they differ for every curated
+ * install, always: the badge it lit was a constant, and a constant badge tells
+ * a user nothing except to distrust the badge.
+ *
+ * The question that means the same thing for curated is drift, and it is asked
+ * through the ONE predicate every surface asks it through — a badge and a
+ * selector that spelled it out separately had already disagreed about
+ * `installedDigest: null`, which means nothing is installed rather than
+ * everything has changed. `unknown` shows nothing: an unmeasured claim here
+ * would be a claim that a multi-gigabyte download is outstanding.
+ */
+function upgradeAvailable(entry: InstalledPack, summary: CatalogSummary, drift: CuratedDrift | null): boolean {
+  if (entry.packId !== CURATED) return entry.catalogRoot !== summary.catalogRoot;
+  return curatedDriftState(summary, drift) === "drifted";
+}
 
 interface PackStatusProps {
   summary: CatalogSummary;
+  curatedDrift: CuratedDrift | null;
   verification: VerificationResponse | null;
   removal: RemovalResponse | null;
   pendingActions: ReadonlySet<string>;
@@ -24,6 +58,7 @@ interface PackStatusProps {
 
 export function PackStatus({
   summary,
+  curatedDrift,
   verification,
   removal,
   pendingActions,
@@ -34,7 +69,7 @@ export function PackStatus({
   onRemoveComplete,
   onRemoveAll,
 }: PackStatusProps) {
-  const { t } = useTranslation("settings");
+  const { t, i18n } = useTranslation("settings");
   const [selected, setSelected] = useState<Set<PackId>>(new Set());
   const selectedIds = summary.installedPacks.map((entry) => entry.packId).filter((id) => selected.has(id));
   const mutationPending = hasPendingVisualPackMutation(pendingActions);
@@ -42,8 +77,30 @@ export function PackStatus({
     <section className="flex flex-col gap-3 rounded-[16px] border border-white/10 p-3">
       <h4 className="text-sm font-semibold text-slate-100">{t("visualPacks.status.title")}</h4>
       <dl className="grid grid-cols-[auto_minmax(0,1fr)] gap-x-3 gap-y-1 text-xs text-slate-300">
-        <dt>{t("visualPacks.status.root")}</dt><dd className="break-all font-mono">{summary.catalogRoot}</dd>
+        <dt>{t("visualPacks.status.root")}</dt><dd className="break-all font-mono">{shortDigest(summary.catalogRoot)}</dd>
         <dt>{t("visualPacks.status.revision")}</dt><dd className="break-all font-mono">{summary.installedRevision}</dd>
+        {/* Omitted rather than shown as zero when the browser will not say —
+            `null` means unknown, and a "0 B" here would read as "nothing
+            stored". Same rule PackSelector applies to `availableBytes`.
+
+            The figure is the ORIGIN's usage, not this feature's: it counts
+            every byte this site keeps, offline images among them. The label
+            says site, and must keep saying site — attributing all of it to the
+            visual packs would be the display layer inventing a breakdown the
+            engine never measured. */}
+        {summary.storage.usageBytes !== null && (
+          <>
+            <dt>{t("visualPacks.status.storageUsage")}</dt>
+            <dd className="tabular-nums">{formatByteSize(summary.storage.usageBytes, i18n.language)}</dd>
+          </>
+        )}
+        {/* Rendered for all three arms, `unsupported` included: "this browser
+            will not say" is an answer a user managing offline downloads needs,
+            and dropping the row would let silence read as a grant. */}
+        <dt>{t("visualPacks.status.persistence")}</dt>
+        <dd className={summary.storage.persistence === "best_effort" ? "text-amber-300" : undefined}>
+          {t(`visualPacks.status.persistenceState.${summary.storage.persistence}`)}
+        </dd>
       </dl>
       <fieldset className="flex flex-col gap-2">
         <legend className="text-xs font-semibold text-slate-300">{t("visualPacks.status.installed")}</legend>
@@ -60,10 +117,15 @@ export function PackStatus({
               })}
             />
             <span className="min-w-0 break-all">
-              {entry.packId}
-              {entry.catalogRoot !== summary.catalogRoot && <span className="ml-2 text-amber-300">{t("visualPacks.status.upgradeAvailable")}</span>}
+              {packLabel(entry.packId, t)}
+              {upgradeAvailable(entry, summary, curatedDrift) && <span className="ml-2 text-amber-300">{t("visualPacks.status.upgradeAvailable")}</span>}
               <span className="mt-1 block text-slate-500">
-                {t("visualPacks.status.receiptRoot", { root: entry.catalogRoot })}
+                {/* Curated is stored under its own membership digest, so
+                    "installed from snapshot" would name a Scryfall snapshot it
+                    was never built from. */}
+                {entry.packId === CURATED
+                  ? t("visualPacks.status.membershipDigest", { digest: shortDigest(entry.catalogRoot) })
+                  : t("visualPacks.status.receiptRoot", { root: shortDigest(entry.catalogRoot) })}
               </span>
             </span>
           </label>

--- a/client/src/components/settings/visual-packs/VisualPackManager.test.tsx
+++ b/client/src/components/settings/visual-packs/VisualPackManager.test.tsx
@@ -1,16 +1,24 @@
 import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
-import { VisualPackBackendError, type VisualPackBackend } from "../../../services/visualPacks/backend.ts";
+import {
+  VisualPackBackendError,
+  VisualPackStorageRefusalError,
+  type VisualPackBackend,
+} from "../../../services/visualPacks/backend.ts";
 import {
   catalogRoot,
+  estimatedImageBytes,
   installedRevision,
   operationId,
   packId,
   type CatalogSummary,
+  type CuratedDrift,
+  type InstallEstimate,
   type ProgressEvent,
   type RevisionEvent,
 } from "../../../services/visualPacks/types.ts";
+import { shortDigest } from "./packLabels.ts";
 import { VisualPackManager } from "./VisualPackManager.tsx";
 import i18n from "../../../i18n/index.ts";
 import { usePreferencesStore } from "../../../stores/preferencesStore.ts";
@@ -22,11 +30,45 @@ vi.mock("../../../hooks/useSetSymbols.ts", () => ({ useSetCatalog: () => ({ cata
 const ROOT_A = catalogRoot("a".repeat(64));
 const ROOT_B = catalogRoot("b".repeat(64));
 const OPERATION = operationId("c".repeat(32));
+/** A curated pack's root IS its membership digest, so it is deliberately
+ *  neither of the catalog roots above — an estimate that matched one of those
+ *  would hide a selector-identity bug rather than expose it. */
+const CURATED_DIGEST = catalogRoot("d".repeat(64));
+
+/** The storage half of an `InstallEstimate`, as a browser that answers reports
+ *  it. These tests are about the panel, not about storage, so every fixture
+ *  uses the same roomy, granted snapshot. */
+const STORAGE = {
+  usageBytes: 0,
+  quotaBytes: 8 * 1024 * 1024 * 1024,
+  availableBytes: 8 * 1024 * 1024 * 1024,
+  persistence: "persisted" as const,
+};
 
 function deferred<T>() {
   let resolve!: (value: T) => void;
   const promise = new Promise<T>((done) => { resolve = done; });
   return { promise, resolve };
+}
+
+/**
+ * The default drift answer: nothing installed, so nothing has drifted.
+ *
+ * `installedDigest: null` is what the backend returns when no curated pack is
+ * on disk, and it is the right default here because the default `summary()`
+ * installs only `core`. A fixture that reported an installed digest would put
+ * a Sync affordance on a panel with no curated pack to sync.
+ */
+function noDrift(): CuratedDrift {
+  return { membershipDigest: CURATED_DIGEST, installedDigest: null, add: 105_165, remove: 0, refresh: 0 };
+}
+
+/** A summary whose installed list carries a curated pack at `digest`. */
+function curatedSummary(digest = CURATED_DIGEST, revision = "90071992547409930"): CatalogSummary {
+  return {
+    ...summary(ROOT_A, revision),
+    installedPacks: [{ packId: packId("core"), catalogRoot: ROOT_A }, { packId: packId("curated"), catalogRoot: digest }],
+  };
 }
 
 function summary(root = ROOT_A, revision = "90071992547409930"): CatalogSummary {
@@ -37,6 +79,7 @@ function summary(root = ROOT_A, revision = "90071992547409930"): CatalogSummary 
     shardCount: 3,
     installedRevision: installedRevision(revision),
     installedPacks: [{ packId: packId("core"), catalogRoot: root }],
+    storage: STORAGE,
   };
 }
 
@@ -45,28 +88,35 @@ function backend(status: VisualPackBackend["catalogStatus"] = vi.fn(async () => 
   let revision: ((event: RevisionEvent) => void) | null = null;
   const value: VisualPackBackend = {
     catalogStatus: status,
+    curatedSelector: vi.fn(async () => ({ kind: "curated" as const, membershipDigest: CURATED_DIGEST })),
+    curatedDrift: vi.fn(async () => noDrift()),
     refreshCatalog: vi.fn(async () => summary()),
     catalogSummary: vi.fn(async () => summary()),
     estimateInstall: vi.fn(async (selector) => ({
       catalogRoot: ROOT_A,
       installedRevision: installedRevision("90071992547409930"),
       selector: selector.kind,
-      packIds: [packId("core")],
+      packIds: [packId(selector.kind === "curated" ? "curated" : "core")],
       assetRecords: "1",
       uniqueObjects: "1",
       logicalImageBytes: "2",
       uniqueImageBytes: "2",
       shardCount: "1",
       shardBytes: "3",
+      estimatedImageBytes: estimatedImageBytes(1),
+      storage: STORAGE,
+      headroom: "sufficient" as const,
     })),
-    start: vi.fn(async () => ({ status: "started" as const, operationId: OPERATION, catalogRoot: ROOT_A })),
+    start: vi.fn(async () => ({
+      status: "started" as const, operationId: OPERATION, catalogRoot: ROOT_A, persistence: "persisted" as const,
+    })),
     cancel: vi.fn(async () => ({
       operationId: OPERATION, catalogRoot: ROOT_A, kind: "install" as const, state: "cancelled" as const,
-      packTotal: 1, packsPromoted: 0, objectTotal: 1, objectsPromoted: 0, completedRevision: null,
+      packTotal: 1, packsPromoted: 0, objectTotal: 1, objectEstimate: null, objectsPromoted: 0, completedRevision: null,
     })),
     operationStatus: vi.fn(async () => ({
       operationId: OPERATION, catalogRoot: ROOT_A, kind: "install" as const, state: "downloading" as const,
-      packTotal: 1, packsPromoted: 0, objectTotal: 2, objectsPromoted: 0, completedRevision: null,
+      packTotal: 1, packsPromoted: 0, objectTotal: 2, objectEstimate: null, objectsPromoted: 0, completedRevision: null,
     })),
     remove: vi.fn(async () => ({ removed: [], revision: installedRevision("90071992547409931"), cleanupIssues: [] })),
     verify: vi.fn(async () => ({ revision: installedRevision("90071992547409930"), issues: [] })),
@@ -161,13 +211,13 @@ describe("VisualPackManager initialization", () => {
     render(<VisualPackManager />);
     await screen.findByText(/Offline card images/i);
     fixture.emitRevision({ cause: "remove", operationId: null, catalogRoot: ROOT_B, revision: installedRevision("90071992547409931") });
-    expect(await screen.findByText(ROOT_B)).toBeInTheDocument();
+    expect(await screen.findByText(shortDigest(ROOT_B))).toBeInTheDocument();
     fixture.emitProgress({
       phase: "failed",
       error: "storage",
       operation: {
         operationId: operationId("d".repeat(32)), catalogRoot: ROOT_A, kind: "install", state: "cancelled",
-        packTotal: 1, packsPromoted: 0, objectTotal: 1, objectsPromoted: 0, completedRevision: null,
+        packTotal: 1, packsPromoted: 0, objectTotal: 1, objectEstimate: null, objectsPromoted: 0, completedRevision: null,
       },
     });
     await waitFor(() => expect(screen.queryByText(/could not be written/i)).not.toBeInTheDocument());
@@ -183,7 +233,7 @@ describe("VisualPackManager initialization", () => {
     await screen.findByText(/Offline card images/i);
     fireEvent.click(screen.getByRole("button", { name: /verify metadata/i }));
     fireEvent.click(screen.getByRole("button", { name: /check Scryfall catalog/i }));
-    expect(await screen.findByText(ROOT_B)).toBeInTheDocument();
+    expect(await screen.findByText(shortDigest(ROOT_B))).toBeInTheDocument();
     pending.resolve({ revision: installedRevision("90071992547409930"), issues: [{ kind: "projection_drift" }] });
     await waitFor(() => expect(screen.queryByText(/lookup records differ/i)).not.toBeInTheDocument());
   });
@@ -197,7 +247,7 @@ describe("VisualPackManager initialization", () => {
     fireEvent.click(screen.getByRole("button", { name: /scan catalog and estimate/i }));
     expect(await screen.findByText(/Scryfall snapshot scan/i)).toBeInTheDocument();
     fireEvent.click(screen.getByRole("button", { name: /check Scryfall catalog/i }));
-    expect(await screen.findByText(ROOT_B)).toBeInTheDocument();
+    expect(await screen.findByText(shortDigest(ROOT_B))).toBeInTheDocument();
     expect(screen.queryByText(/Scryfall snapshot scan/i)).not.toBeInTheDocument();
     expect(screen.getByRole("button", { name: /install selection/i })).toBeDisabled();
   });
@@ -213,6 +263,64 @@ describe("VisualPackManager initialization", () => {
     fireEvent.click(screen.getByRole("button", { name: /scan catalog and estimate/i }));
     expect(await screen.findByText(/catalog operation could not be completed/i)).toBeInTheDocument();
     expect(screen.getByText("TypeError: DecompressionStream is not a constructor")).toBeInTheDocument();
+  });
+
+  it("shows catalog scan progress while an estimate is running", async () => {
+    const fixture = backend();
+    const estimate = deferred<Awaited<ReturnType<VisualPackBackend["estimateInstall"]>>>();
+    vi.mocked(fixture.value.estimateInstall).mockImplementation((_selector, onProgress) => {
+      onProgress?.({
+        compressedBytesRead: 50 * 1024 * 1024,
+        compressedBytesTotal: 100 * 1024 * 1024,
+        recordsScanned: 12_345,
+        assetRecords: 36_000,
+      });
+      return estimate.promise;
+    });
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    fireEvent.click(screen.getByRole("button", { name: /scan catalog and estimate/i }));
+    expect(await screen.findByRole("progressbar")).toHaveAttribute("value", "52428800");
+    expect(screen.getByText(/50 MB of 100 MB read.*12,345 cards scanned.*36,000 images found/i)).toBeInTheDocument();
+    estimate.resolve({
+      catalogRoot: ROOT_A,
+      installedRevision: installedRevision("90071992547409930"),
+      selector: "core",
+      packIds: [packId("core")],
+      assetRecords: "1", uniqueObjects: "1", logicalImageBytes: "2",
+      uniqueImageBytes: "2", shardCount: "1", shardBytes: "3",
+      estimatedImageBytes: estimatedImageBytes(1), storage: STORAGE, headroom: "sufficient",
+    });
+    await waitFor(() => expect(screen.queryByRole("progressbar")).not.toBeInTheDocument());
+  });
+
+  it("starts an install with the pinned image estimate", async () => {
+    const fixture = backend();
+    vi.mocked(fixture.value.estimateInstall).mockResolvedValue({
+      catalogRoot: ROOT_A,
+      installedRevision: installedRevision("90071992547409930"),
+      selector: "core",
+      packIds: [packId("core")],
+      // DISTINCT from `assetRecords` on purpose: PackSelector renders both
+      // metrics, so equal values make the `findByText` below match two
+      // elements and fail as an ambiguous query. `objectEstimate` is derived
+      // from `assetRecords` alone, so the assertion at the end is unaffected.
+      assetRecords: "353331", uniqueObjects: "353330", logicalImageBytes: "unknown",
+      uniqueImageBytes: "unknown", shardCount: "1", shardBytes: "392267935",
+      estimatedImageBytes: estimatedImageBytes(353_331), storage: STORAGE, headroom: "sufficient",
+    });
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    fireEvent.click(screen.getByRole("button", { name: /scan catalog and estimate/i }));
+    await screen.findByText("353331");
+    fireEvent.click(screen.getByRole("button", { name: /install selection/i }));
+    expect(fixture.value.start).toHaveBeenCalledWith({
+      kind: "install",
+      selector: { kind: "core" },
+      objectEstimate: 353331,
+    });
   });
 
   it("allows unrelated estimate and verification reads to overlap", async () => {
@@ -235,9 +343,787 @@ describe("VisualPackManager initialization", () => {
       packIds: [packId("core")],
       assetRecords: "1", uniqueObjects: "1", logicalImageBytes: "2",
       uniqueImageBytes: "2", shardCount: "1", shardBytes: "3",
+      estimatedImageBytes: estimatedImageBytes(1), storage: STORAGE, headroom: "sufficient",
     });
     verification.resolve({ revision: installedRevision("90071992547409930"), issues: [] });
     expect(await screen.findByText(/No verification issues found/i)).toBeInTheDocument();
+  });
+
+  /**
+   * Drive the panel to the point where Install is live, then press it.
+   *
+   * Install is gated on a matching estimate, so the scan has to happen first;
+   * waiting on the button's own enabled state rather than on a rendered metric
+   * keeps this independent of what the estimate panel chooses to show.
+   */
+  async function pressInstall(estimateLabel: RegExp, installLabel: RegExp): Promise<void> {
+    fireEvent.click(screen.getByRole("button", { name: estimateLabel }));
+    await waitFor(() => expect(screen.getByRole("button", { name: installLabel })).toBeEnabled());
+    fireEvent.click(screen.getByRole("button", { name: installLabel }));
+  }
+
+  /** 5.67 GiB needed against 1 GiB free — the shape `reserveStorage` refuses
+   *  with, in the units it reports: raw bytes, for the panel to format. */
+  const REFUSAL = { requiredBytes: 6_090_752_000, availableBytes: 1_073_741_824 };
+
+  it("reports a storage refusal as a size, not as engine bytes", async () => {
+    const fixture = backend();
+    vi.mocked(fixture.value.start).mockRejectedValue(new VisualPackStorageRefusalError(REFUSAL));
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    await pressInstall(/scan catalog and estimate/i, /install selection/i);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("6.1 GB");
+    expect(alert).toHaveTextContent("1.1 GB");
+    // The defect this replaces, asserted as an ABSENCE and on the digits
+    // themselves: a grouped "6,090,752,000" would slip past a match on the
+    // literal, so compare what is left once every separator is stripped.
+    expect(alert.textContent?.replace(/\D/g, "")).not.toContain("6090752000");
+    expect(alert.textContent?.replace(/\D/g, "")).not.toContain("1073741824");
+    // A refusal carries no verbatim detail line, so the Error's own
+    // developer-facing message never reaches the panel either.
+    expect(alert).not.toHaveTextContent(/visual-pack backend/i);
+  });
+
+  it("renders the refusal size in the active locale's unit and separators", async () => {
+    // The half a hand-written `toFixed(1) + " GB"` gets wrong in six of the
+    // seven locales: French writes Go, and the decimal separator is a comma.
+    usePreferencesStore.getState().setLanguage("fr");
+    await waitFor(() => expect(i18n.resolvedLanguage).toBe("fr"));
+    const fixture = backend();
+    vi.mocked(fixture.value.start).mockRejectedValue(new VisualPackStorageRefusalError(REFUSAL));
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText("Catalogue visuel hors ligne");
+
+    await pressInstall(/téléchargement de devis/i, /sélection d'installation/i);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent("6,1 Go");
+    expect(alert).toHaveTextContent("1,1 Go");
+    expect(alert).toHaveTextContent(/espace libre insuffisant/i);
+  });
+
+  /** A summary whose storage half the browser answered differently. */
+  function summaryWithStorage(storage: CatalogSummary["storage"]): CatalogSummary {
+    return { ...summary(), storage };
+  }
+
+  it("reports disk in use and the eviction grant without running an estimate", async () => {
+    const fixture = backend(vi.fn(async () => ({
+      status: "ready" as const,
+      summary: summaryWithStorage({ ...STORAGE, usageBytes: 6_500_000_000 }),
+    })));
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    expect(await screen.findByText(/Storage used by this site/i)).toBeInTheDocument();
+    expect(screen.getByText("6.5 GB")).toBeInTheDocument();
+    expect(screen.getByText(/will keep these images/i)).toBeInTheDocument();
+    // The whole of NB7 + G1: a user who has ALREADY installed can see their
+    // disk without first pricing an install they are not making. The figure
+    // used to be reachable only through `InstallEstimate`.
+    expect(fixture.value.estimateInstall).not.toHaveBeenCalled();
+    // And the panel started no operation of its own to get them. That the
+    // BACKEND asks for no storage grant while reading a summary is a different
+    // claim, checked against the real backend in `installSizing.test.ts` —
+    // this fixture is a mock and could not show it.
+    expect(fixture.value.start).not.toHaveBeenCalled();
+  });
+
+  it("omits the usage row when the browser will not say, rather than showing zero", async () => {
+    const fixture = backend(vi.fn(async () => ({
+      status: "ready" as const,
+      summary: summaryWithStorage({
+        usageBytes: null, quotaBytes: null, availableBytes: null, persistence: "unsupported",
+      }),
+    })));
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    expect(await screen.findByText(/will not say/i)).toBeInTheDocument();
+    // `null` is unknown, and "0 B" would read as "nothing stored" — a figure
+    // the panel would be inventing.
+    expect(screen.queryByText(/Storage used by this site/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/^0 /)).not.toBeInTheDocument();
+  });
+
+  it("names an ungranted origin as evictable in the status panel", async () => {
+    const fixture = backend(vi.fn(async () => ({
+      status: "ready" as const,
+      summary: summaryWithStorage({ ...STORAGE, usageBytes: 512_000_000, persistence: "best_effort" }),
+    })));
+    vi.mocked(fixture.value.estimateInstall).mockResolvedValue(curatedEstimate());
+    platform.load.mockResolvedValue(fixture.value);
+    usePreferencesStore.setState({ artChain: [], artOverrides: {} });
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    expect(await screen.findByText(/may delete these images/i)).toBeInTheDocument();
+
+    // REACH GUARD for the absence below. The headroom warning lives inside
+    // PackSelector's estimate block, which is UNMOUNTED until an estimate is on
+    // screen — asserting it absent without one asserts nothing whatever.
+    chooseCurated();
+    expect(await screen.findByText(/Estimated download size/i)).toBeInTheDocument();
+    // Rendered, not judged: the panel states what the browser reported and
+    // computes no headroom verdict from it. This estimate says `sufficient`,
+    // so the warning must be absent from a block that is mounted and would
+    // otherwise show it. `InstallEstimate.headroom` is where a verdict lives,
+    // and the engine produces that one.
+    expect(screen.queryByText(/larger than the free space/i)).not.toBeInTheDocument();
+  });
+
+  /**
+   * A curated estimate as the backend signs one: named by its PACK id — which
+   * is what `signedSelectorName` maps a curated selector to, and what the hook
+   * checks before accepting an estimate — and taken against the catalog the
+   * summary reports rather than against the membership digest.
+   *
+   * 105,165 image records is the measured curated default — 35,055 non-token
+   * faces at three rungs each — so the size it projects is the one a real user
+   * reads rather than a toy figure.
+   */
+  function curatedEstimate(overrides: Partial<InstallEstimate> = {}): InstallEstimate {
+    return {
+      catalogRoot: ROOT_A,
+      installedRevision: installedRevision("90071992547409930"),
+      selector: "curated",
+      packIds: [packId("curated")],
+      assetRecords: "105165", uniqueObjects: "105165",
+      logicalImageBytes: "unknown", uniqueImageBytes: "unknown",
+      shardCount: "0", shardBytes: "unknown",
+      estimatedImageBytes: estimatedImageBytes(105_165),
+      storage: STORAGE,
+      headroom: "sufficient",
+      ...overrides,
+    };
+  }
+
+  /** Longer than PackSelector's curated debounce, so an estimate that was
+   *  going to fire has fired by the time this resolves. */
+  /** A `complete` estimate — what displaces a curated one from the panel. */
+  function bulkEstimate(): InstallEstimate {
+    return {
+      ...curatedEstimate(),
+      selector: "complete",
+      packIds: [packId("complete")],
+      shardCount: "1", shardBytes: "392267935",
+    };
+  }
+
+  function pastCuratedDebounce(): Promise<void> {
+    return new Promise((resolve) => setTimeout(resolve, 600));
+  }
+
+  function chooseCurated(): void {
+    fireEvent.click(screen.getByRole("radio", { name: /one image per card/i }));
+  }
+
+  it("estimates the curated pack on selection and installs it without a second click", async () => {
+    const fixture = backend();
+    vi.mocked(fixture.value.estimateInstall).mockResolvedValue(curatedEstimate({
+      assetRecords: "6", uniqueObjects: "6", estimatedImageBytes: estimatedImageBytes(6),
+    }));
+    platform.load.mockResolvedValue(fixture.value);
+    usePreferencesStore.setState({ artChain: [], artOverrides: {} });
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    expect(fixture.value.curatedSelector).not.toHaveBeenCalled();
+
+    chooseCurated();
+
+    // The panel names a kind; the backend resolves the digest. A UI that built
+    // the selector itself would be planning a membership in a display layer,
+    // and would be a second assembly of the planner's input beside the one
+    // `start()` compares against.
+    await waitFor(() => expect(fixture.value.curatedSelector).toHaveBeenCalledTimes(1));
+    // No button was pressed between the radio and this call.
+    await waitFor(() => expect(fixture.value.estimateInstall).toHaveBeenCalledWith(
+      { kind: "curated", membershipDigest: CURATED_DIGEST },
+      expect.any(Function),
+    ));
+
+    const install = await screen.findByRole("button", { name: /install selection/i });
+    await waitFor(() => expect(install).toBeEnabled());
+    fireEvent.click(install);
+
+    expect(fixture.value.start).toHaveBeenCalledWith({
+      kind: "install",
+      selector: { kind: "curated", membershipDigest: CURATED_DIGEST },
+      objectEstimate: 6,
+    });
+  });
+
+  it("leaves the bulk selectors' catalog scan behind a deliberate click", async () => {
+    const fixture = backend();
+    vi.mocked(fixture.value.estimateInstall).mockResolvedValue(curatedEstimate());
+    platform.load.mockResolvedValue(fixture.value);
+    usePreferencesStore.setState({ artChain: [], artOverrides: {} });
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    // Positive control in the same test: curated auto-estimates, so a zero
+    // below is a property of the bulk selectors rather than of a debounce that
+    // never fired at all.
+    chooseCurated();
+    await waitFor(() => expect(fixture.value.estimateInstall).toHaveBeenCalledTimes(1));
+
+    fireEvent.click(screen.getByRole("radio", { name: /all current english card images/i }));
+    await pastCuratedDebounce();
+
+    // `complete` reads the whole multi-gigabyte Scryfall archive. Estimating
+    // that because a radio moved would start a very expensive download nobody
+    // asked for.
+    expect(fixture.value.estimateInstall).toHaveBeenCalledTimes(1);
+  });
+
+  it("estimates curated once the scan it arrived during releases the slot", async () => {
+    const fixture = backend();
+    const scan = deferred<InstallEstimate>();
+    vi.mocked(fixture.value.estimateInstall)
+      .mockReturnValueOnce(scan.promise)
+      .mockResolvedValue(curatedEstimate());
+    platform.load.mockResolvedValue(fixture.value);
+    usePreferencesStore.setState({ artChain: [], artOverrides: {} });
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    // A bulk scan holds the single estimate slot. `estimateInstall` REFUSES a
+    // second request outright, so a curated selection made while this runs is
+    // dropped in silence — no estimate, no error, Install disabled for ever.
+    fireEvent.click(screen.getByRole("radio", { name: /all current english card images/i }));
+    fireEvent.click(screen.getByRole("button", { name: /scan catalog and estimate/i }));
+    await waitFor(() => expect(fixture.value.estimateInstall).toHaveBeenCalledTimes(1));
+
+    chooseCurated();
+    await pastCuratedDebounce();
+    expect(fixture.value.estimateInstall).toHaveBeenCalledTimes(1);
+
+    scan.resolve(bulkEstimate());
+    // Freeing the slot must be what re-asks; nothing else changes here.
+    await waitFor(() => expect(fixture.value.estimateInstall).toHaveBeenCalledTimes(2), { timeout: 3000 });
+    expect(await screen.findByText(/Estimated download size/i)).toBeInTheDocument();
+  });
+
+  it("re-estimates curated after a bulk estimate displaced it", async () => {
+    const fixture = backend();
+    vi.mocked(fixture.value.estimateInstall)
+      .mockResolvedValueOnce(curatedEstimate())
+      .mockResolvedValueOnce(bulkEstimate())
+      .mockResolvedValue(curatedEstimate());
+    platform.load.mockResolvedValue(fixture.value);
+    usePreferencesStore.setState({ artChain: [], artOverrides: {} });
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    chooseCurated();
+    expect(await screen.findByText(/Estimated download size/i)).toBeInTheDocument();
+
+    // A bulk estimate replaces the one on screen. Returning to curated finds
+    // no matching estimate, and the auto-estimate must be free to ask again —
+    // the plan behind it is memoized, so re-asking costs nothing.
+    fireEvent.click(screen.getByRole("radio", { name: /all current english card images/i }));
+    fireEvent.click(screen.getByRole("button", { name: /scan catalog and estimate/i }));
+    await waitFor(() => expect(fixture.value.estimateInstall).toHaveBeenCalledTimes(2));
+
+    chooseCurated();
+    await waitFor(() => expect(fixture.value.estimateInstall).toHaveBeenCalledTimes(3), { timeout: 3000 });
+    expect(await screen.findByRole("button", { name: /install selection/i })).toBeEnabled();
+  });
+
+  it("asks again for an estimate that failed once the option is reselected", async () => {
+    const fixture = backend();
+    vi.mocked(fixture.value.estimateInstall)
+      .mockRejectedValueOnce(new VisualPackBackendError("network"))
+      .mockResolvedValue(curatedEstimate());
+    platform.load.mockResolvedValue(fixture.value);
+    usePreferencesStore.setState({ artChain: [], artOverrides: {} });
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    chooseCurated();
+    await waitFor(() => expect(fixture.value.estimateInstall).toHaveBeenCalledTimes(1));
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+
+    // A failed estimate must NOT be retried on the debounce timer — that would
+    // be five requests a second at a backend that is already failing — so the
+    // key stays recorded and the auto-estimate stays quiet.
+    await pastCuratedDebounce();
+    expect(fixture.value.estimateInstall).toHaveBeenCalledTimes(1);
+
+    // Reselecting is the recovery the panel offers beside the button, and it
+    // only works because leaving the option forgets that we asked.
+    fireEvent.click(screen.getByRole("radio", { name: /all current english card images/i }));
+    chooseCurated();
+    await waitFor(() => expect(fixture.value.estimateInstall).toHaveBeenCalledTimes(2), { timeout: 3000 });
+    expect(await screen.findByText(/Estimated download size/i)).toBeInTheDocument();
+  });
+
+  it("shows the curated download size and free space, and none of the bulk catalog figures", async () => {
+    const fixture = backend();
+    vi.mocked(fixture.value.estimateInstall).mockResolvedValue(curatedEstimate());
+    platform.load.mockResolvedValue(fixture.value);
+    usePreferencesStore.setState({ artChain: [], artOverrides: {} });
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    chooseCurated();
+
+    const size = await screen.findByText(/Estimated download size/i);
+    const estimatePanel = size.closest("section");
+    expect(estimatePanel).toHaveTextContent("6.9 GB");
+    expect(estimatePanel).toHaveTextContent(/Free space available/i);
+    expect(estimatePanel).toHaveTextContent("8.6 GB");
+    // False about a curated pack, not merely uninteresting: it opens no shard
+    // of the Scryfall archive, so these describe an archive it never reads.
+    expect(estimatePanel).not.toHaveTextContent(/Metadata files/i);
+    expect(estimatePanel).not.toHaveTextContent(/Compressed Scryfall catalog/i);
+    expect(estimatePanel).not.toHaveTextContent(/known after download/i);
+    // No raw byte integer anywhere, compared on the digits alone so a grouped
+    // "6,928,003,000" cannot slip past a match on the literal.
+    expect(estimatePanel?.textContent?.replace(/\D/g, ""))
+      .not.toContain(String(estimatedImageBytes(105_165)));
+  });
+
+  it("warns about insufficient headroom without blocking the install", async () => {
+    const fixture = backend();
+    vi.mocked(fixture.value.estimateInstall).mockResolvedValue(curatedEstimate({
+      headroom: "insufficient",
+      storage: { ...STORAGE, quotaBytes: 2_000_000_000, availableBytes: 2_000_000_000 },
+    }));
+    platform.load.mockResolvedValue(fixture.value);
+    usePreferencesStore.setState({ artChain: [], artOverrides: {} });
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    chooseCurated();
+
+    expect(await screen.findByText(/larger than the free space/i)).toBeInTheDocument();
+    // A warning, never a veto: the projection is an order-of-magnitude figure
+    // from six samples per rung, and a quota failure mid-download is the
+    // milder outcome because the operation stays resumable.
+    await waitFor(() => expect(screen.getByRole("button", { name: /install selection/i })).toBeEnabled());
+  });
+
+  it("warns that a best-effort pack may be evicted", async () => {
+    const fixture = backend();
+    vi.mocked(fixture.value.estimateInstall).mockResolvedValue(curatedEstimate({
+      storage: { ...STORAGE, persistence: "best_effort" },
+    }));
+    platform.load.mockResolvedValue(fixture.value);
+    usePreferencesStore.setState({ artChain: [], artOverrides: {} });
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    chooseCurated();
+
+    expect(await screen.findByText(/has not granted persistent storage/i)).toBeInTheDocument();
+  });
+
+  it("says the pack follows each card's default art when no art rules are set", async () => {
+    const fixture = backend();
+    platform.load.mockResolvedValue(fixture.value);
+    // The SHIPPED default (preferencesStore), and the state most users are in:
+    // with no rules, no override and no deck source, every card falls to its
+    // canonical art. Copy claiming "your configured set priority" would credit
+    // the user with a choice they have not made.
+    usePreferencesStore.setState({ artChain: [], artOverrides: {} });
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    chooseCurated();
+
+    expect(await screen.findByText(/no card art rules/i)).toBeInTheDocument();
+    expect(screen.getByText(/default art/i)).toBeInTheDocument();
+    // And it names where to change that, because the setting lives in a
+    // different panel entirely.
+    expect(screen.getByText(/Card Art Preferences/i)).toBeInTheDocument();
+  });
+
+  it("says the pack follows the configured art rules once there are any", async () => {
+    const fixture = backend();
+    platform.load.mockResolvedValue(fixture.value);
+    usePreferencesStore.setState({ artChain: [{ type: "newest" }], artOverrides: {} });
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    chooseCurated();
+
+    expect(await screen.findByText(/chosen by your Card Art Preferences/i)).toBeInTheDocument();
+    expect(screen.queryByText(/no card art rules/i)).not.toBeInTheDocument();
+  });
+
+  it("reports a failed curated resolution in the panel's own language", async () => {
+    const fixture = backend();
+    vi.mocked(fixture.value.curatedSelector).mockRejectedValue(new VisualPackBackendError("network"));
+    platform.load.mockResolvedValue(fixture.value);
+    usePreferencesStore.setState({ artChain: [], artOverrides: {} });
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    chooseCurated();
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/Scryfall catalog or image download failed/i);
+    // The `Error`'s own developer-facing default must not appear under the
+    // translated sentence. It is the message whenever no detail was supplied,
+    // and it is English in all seven languages.
+    expect(alert).not.toHaveTextContent(/visual-pack backend/i);
+  });
+
+  /**
+   * A panel whose summary already carries an installed curated pack, plus the
+   * drift the backend reports for it.
+   *
+   * `catalogSummary` is mocked alongside `catalogStatus` because the hook
+   * re-reads it after any revision event, and a second answer without the
+   * curated pack would silently take the drift indicator off screen.
+   */
+  function installedCuratedFixture(drift: CuratedDrift | null, installedAt = CURATED_DIGEST) {
+    const fixture = backend(vi.fn(async () => ({ status: "ready" as const, summary: curatedSummary(installedAt) })));
+    vi.mocked(fixture.value.catalogSummary).mockResolvedValue(curatedSummary(installedAt));
+    vi.mocked(fixture.value.curatedDrift).mockResolvedValue(drift);
+    vi.mocked(fixture.value.estimateInstall).mockResolvedValue(curatedEstimate());
+    platform.load.mockResolvedValue(fixture.value);
+    usePreferencesStore.setState({ artChain: [], artOverrides: {} });
+    return fixture;
+  }
+
+  it("reports the three-way drift of an installed curated pack and offers Sync", async () => {
+    const fixture = installedCuratedFixture(
+      { membershipDigest: CURATED_DIGEST, installedDigest: ROOT_B, add: 1200, remove: 34, refresh: 7 },
+      ROOT_B,
+    );
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    chooseCurated();
+
+    expect(await screen.findByText(/1,200 to add, 34 to remove, 7 to refresh/i)).toBeInTheDocument();
+    // Renaming the primary control is how the panel says this is an update to
+    // a pack that is already there rather than a new install.
+    expect(await screen.findByRole("button", { name: /sync images/i })).toBeInTheDocument();
+    // The whole point of a user-initiated Sync: reading the drift downloads
+    // nothing. Asserted on the START spy, because a mocked backend downloads
+    // nothing whatever the panel does.
+    expect(fixture.value.start).not.toHaveBeenCalled();
+  });
+
+  it("reports a refresh-only drift rather than an empty diff", async () => {
+    // A Scryfall re-scan moves a `sourceUrl` under an unchanged asset key: the
+    // membership digest differs, so Sync is live, while both key sets are
+    // identical. An add/remove-only report reads as a bug in the panel.
+    installedCuratedFixture(
+      { membershipDigest: CURATED_DIGEST, installedDigest: ROOT_B, add: 0, remove: 0, refresh: 412 },
+      ROOT_B,
+    );
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    chooseCurated();
+
+    expect(await screen.findByText(/0 to add, 0 to remove, 412 to refresh/i)).toBeInTheDocument();
+  });
+
+  it("says an installed curated pack is up to date when its digest matches", async () => {
+    installedCuratedFixture(
+      { membershipDigest: CURATED_DIGEST, installedDigest: CURATED_DIGEST, add: 0, remove: 0, refresh: 0 },
+    );
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    chooseCurated();
+
+    expect(await screen.findByText(/already match these settings/i)).toBeInTheDocument();
+    // The badge is the discoverable half of the same fact, and a curated pack
+    // whose digest matches has nothing to upgrade to. It was lit here BY
+    // CONSTRUCTION before: a membership digest can never equal a catalog root.
+    expect(screen.queryByText(/Upgrade available/i)).not.toBeInTheDocument();
+  });
+
+  it("lights the upgrade badge for a curated pack only once drift says so", async () => {
+    installedCuratedFixture(
+      { membershipDigest: CURATED_DIGEST, installedDigest: ROOT_B, add: 5, remove: 0, refresh: 0 },
+      ROOT_B,
+    );
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    expect(await screen.findByText(/Upgrade available/i)).toBeInTheDocument();
+  });
+
+  it("recomputes drift on an art-preference change without downloading anything", async () => {
+    const fixture = installedCuratedFixture(
+      { membershipDigest: CURATED_DIGEST, installedDigest: CURATED_DIGEST, add: 0, remove: 0, refresh: 0 },
+    );
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    await waitFor(() => expect(fixture.value.curatedDrift).toHaveBeenCalledTimes(1));
+
+    vi.mocked(fixture.value.curatedDrift).mockResolvedValue(
+      { membershipDigest: ROOT_B, installedDigest: CURATED_DIGEST, add: 9, remove: 2, refresh: 0 },
+    );
+    usePreferencesStore.setState({ artChain: [{ type: "newest" }] });
+
+    await waitFor(() => expect(fixture.value.curatedDrift).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText(/Upgrade available/i)).toBeInTheDocument();
+    // A preference toggle must never start a multi-gigabyte fetch on its own.
+    expect(fixture.value.start).not.toHaveBeenCalled();
+  });
+
+  it("names installed packs and shortens their digests instead of quoting wire ids", async () => {
+    const fixture = backend(vi.fn(async () => ({
+      status: "ready" as const,
+      summary: {
+        ...summary(),
+        installedPacks: [
+          { packId: packId("printing:fin"), catalogRoot: ROOT_A },
+          { packId: packId("curated"), catalogRoot: CURATED_DIGEST },
+        ],
+      },
+    })));
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    // Scoped to the installed list: "One image per card" also names the
+    // curated RADIO, and an unscoped query would pass on that alone.
+    const installed = (await screen.findByText(/FIN printings/)).closest("section");
+    expect(installed).toHaveTextContent(/One image per card/);
+    expect(screen.queryByText("printing:fin")).not.toBeInTheDocument();
+    // A curated pack's root is its membership, not a snapshot it was built
+    // from, so it must not be labelled as one.
+    expect(screen.getByText(/Membership fingerprint: dddddddddddd…/)).toBeInTheDocument();
+    expect(screen.getByText(/Installed from snapshot: aaaaaaaaaaaa…/)).toBeInTheDocument();
+    expect(screen.queryByText(new RegExp(CURATED_DIGEST))).not.toBeInTheDocument();
+  });
+
+  it("reports a stale selection as out of date rather than as a dependency", async () => {
+    // `conflict` is thrown when the catalog root or the curated membership a
+    // selection names is no longer current. `remove()` never throws it — it
+    // ignores its `RemovalMode` entirely — so the removal sentence this used to
+    // carry described a behaviour no backend in this app has.
+    const fixture = backend();
+    vi.mocked(fixture.value.start).mockRejectedValue(new VisualPackBackendError("conflict"));
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    await pressInstall(/scan catalog and estimate/i, /install selection/i);
+
+    const alert = await screen.findByRole("alert");
+    expect(alert).toHaveTextContent(/selection is out of date/i);
+    expect(alert).not.toHaveTextContent(/depend on this selection/i);
+  });
+
+  /** Drive the panel to an operation that has failed and is offering Resume. */
+  async function reachFailedOperation(fixture: ReturnType<typeof backend>): Promise<void> {
+    await pressInstall(/scan catalog and estimate/i, /install selection/i);
+    await waitFor(() => expect(fixture.value.start).toHaveBeenCalled());
+    fixture.emitProgress({
+      phase: "failed",
+      error: "network",
+      operation: {
+        operationId: OPERATION, catalogRoot: ROOT_A, kind: "install", state: "downloading",
+        packTotal: 1, packsPromoted: 0, objectTotal: 2, objectEstimate: null, objectsPromoted: 1, completedRevision: null,
+      },
+    });
+    await screen.findByRole("button", { name: /resume operation/i });
+  }
+
+  it("reports a terminated operation as stopped, not as a cancellation", async () => {
+    const fixture = backend();
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    await reachFailedOperation(fixture);
+
+    // The resume path: `run()` terminates a non-retryable operation by writing
+    // `state: "cancelled"` — the same value a user's Cancel writes — so the
+    // status `trackStarted` reads back cannot say which happened, and only the
+    // event that follows it can.
+    vi.mocked(fixture.value.operationStatus).mockResolvedValue({
+      operationId: OPERATION, catalogRoot: ROOT_A, kind: "install", state: "cancelled",
+      packTotal: 1, packsPromoted: 0, objectTotal: 2, objectEstimate: null, objectsPromoted: 1, completedRevision: null,
+    });
+    fireEvent.click(screen.getByRole("button", { name: /resume operation/i }));
+    await waitFor(() => expect(fixture.value.operationStatus).toHaveBeenCalled());
+
+    fixture.emitProgress({
+      phase: "failed",
+      error: "conflict",
+      operation: {
+        operationId: OPERATION, catalogRoot: ROOT_A, kind: "install", state: "cancelled",
+        packTotal: 1, packsPromoted: 0, objectTotal: 2, objectEstimate: null, objectsPromoted: 1, completedRevision: null,
+      },
+    });
+
+    expect(await screen.findByText(/cannot be resumed/i)).toBeInTheDocument();
+    expect(screen.queryByText(/^Cancelled$/)).not.toBeInTheDocument();
+    // And the diagnostic that says WHY, which was dropped with the event.
+    expect(await screen.findByText(/selection is out of date/i)).toBeInTheDocument();
+  });
+
+  it("keeps a deliberate cancellation from being re-reported as a failure", async () => {
+    const fixture = backend();
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    await pressInstall(/scan catalog and estimate/i, /install selection/i);
+    await screen.findByRole("button", { name: /cancel operation/i });
+
+    fireEvent.click(screen.getByRole("button", { name: /cancel operation/i }));
+    expect(await screen.findByText("Cancelled")).toBeInTheDocument();
+
+    // A late event for the operation the user just cancelled. The panel
+    // witnessed the cancellation, so nothing arriving afterwards may relabel it.
+    fixture.emitProgress({
+      phase: "failed",
+      error: "network",
+      operation: {
+        operationId: OPERATION, catalogRoot: ROOT_A, kind: "install", state: "cancelled",
+        packTotal: 1, packsPromoted: 0, objectTotal: 2, objectEstimate: null, objectsPromoted: 0, completedRevision: null,
+      },
+    });
+
+    await pastCuratedDebounce();
+    expect(screen.getByText("Cancelled")).toBeInTheDocument();
+    expect(screen.queryByText(/cannot be resumed/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/image download failed/i)).not.toBeInTheDocument();
+  });
+
+  it("says nothing about drift the backend declined to measure", async () => {
+    // `null` is the backend refusing to load 76 MB of card data to answer a
+    // question nobody asked. It is UNMEASURED, never "no drift" — so the badge
+    // and the selector must both stay silent rather than report "up to date".
+    const fixture = installedCuratedFixture(null, ROOT_B);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    // Reach guard: the effect really did run and really did ask. Without this
+    // the absences below would pass just as well if drift were never read.
+    await waitFor(() => expect(fixture.value.curatedDrift).toHaveBeenCalled());
+
+    chooseCurated();
+    expect(await screen.findByText(/Estimated download size/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Upgrade available/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/already match these settings/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/out of date/i)).not.toBeInTheDocument();
+    // But the ACTION is still a sync: a curated pack is on disk, and the
+    // summary says so for free. Keying the label on whether drift was measured
+    // instead offered to "install" an installed pack — reachable and permanent,
+    // because a `curatedSelector()` that rejects leaves both null for the life
+    // of the tab.
+    expect(screen.getByRole("button", { name: /sync images/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /install selection/i })).not.toBeInTheDocument();
+  });
+
+  it("reads a null installed digest as nothing installed, not as total drift", async () => {
+    // The divergence F3 named: the badge tested `installedDigest !==
+    // membershipDigest`, which is TRUE for a null, while the selector read the
+    // same null as "nothing to report". They now ask one predicate, and it
+    // compares against the digest the SUMMARY reports installed.
+    installedCuratedFixture(
+      { membershipDigest: ROOT_B, installedDigest: null, add: 105_165, remove: 0, refresh: 0 },
+      ROOT_B,
+    );
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    chooseCurated();
+
+    expect(await screen.findByText(/already match these settings/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Upgrade available/i)).not.toBeInTheDocument();
+  });
+
+  it("offers Resume for a finalize that failed, and does not call it unresumable", async () => {
+    // `finish()` leaves the record `finalizing` when its transaction rejects;
+    // that classifies as `storage`, which is retryable, and `create()`'s pending
+    // loop re-runs every `downloading` OR `finalizing` record on next launch.
+    // Calling it "stopped, cannot be resumed" was false, and it said so while
+    // `durableMutationActive` held every other control disabled.
+    const fixture = backend();
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    await pressInstall(/scan catalog and estimate/i, /install selection/i);
+    await waitFor(() => expect(fixture.value.start).toHaveBeenCalled());
+
+    fixture.emitProgress({
+      phase: "failed",
+      error: "storage",
+      operation: {
+        operationId: OPERATION, catalogRoot: ROOT_A, kind: "install", state: "finalizing",
+        packTotal: 1, packsPromoted: 1, objectTotal: 2, objectEstimate: null, objectsPromoted: 2, completedRevision: null,
+      },
+    });
+
+    expect(await screen.findByText(/ready to resume/i)).toBeInTheDocument();
+    expect(screen.queryByText(/cannot be resumed/i)).not.toBeInTheDocument();
+    // The label promises a control, so the control has to be there — and it has
+    // to reach the backend, which the hook's own guard used to refuse.
+    const resume = await screen.findByRole("button", { name: /resume operation/i });
+    fireEvent.click(resume);
+    await waitFor(() => expect(fixture.value.start).toHaveBeenCalledWith({ kind: "resume", operationId: OPERATION }));
+  });
+
+  it("re-reads drift once the user's own action has loaded the card data", async () => {
+    // The cold path: mount with a curated pack installed but no card data
+    // resident, so the backend declines to measure. Choosing the curated option
+    // resolves a selector through the same planner, which loads that data — so
+    // the read that was unmeasurable a moment ago is now free, and the panel
+    // has to ask again or the badge stays dark until a remount.
+    const fixture = installedCuratedFixture(null, ROOT_B);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    await waitFor(() => expect(fixture.value.curatedDrift).toHaveBeenCalledTimes(1));
+    expect(screen.queryByText(/Upgrade available/i)).not.toBeInTheDocument();
+
+    vi.mocked(fixture.value.curatedDrift).mockResolvedValue(
+      { membershipDigest: CURATED_DIGEST, installedDigest: ROOT_B, add: 12, remove: 0, refresh: 3 },
+    );
+    chooseCurated();
+
+    await waitFor(() => expect(fixture.value.curatedDrift).toHaveBeenCalledTimes(2));
+    expect(await screen.findByText(/Upgrade available/i)).toBeInTheDocument();
+    expect(await screen.findByText(/12 to add, 0 to remove, 3 to refresh/i)).toBeInTheDocument();
+  });
+
+  it("does not attribute a curated download's total to the Scryfall snapshot", async () => {
+    // `OperationStatus` carries no selector, so this note is shown for every
+    // install alike — which made it claim a bulk provenance over a total that
+    // came from `planCuratedPack()` over this app's own data files.
+    const fixture = backend();
+    vi.mocked(fixture.value.estimateInstall).mockResolvedValue(curatedEstimate());
+    vi.mocked(fixture.value.operationStatus).mockResolvedValue({
+      operationId: OPERATION, catalogRoot: ROOT_A, kind: "install", state: "downloading",
+      packTotal: 1, packsPromoted: 0, objectTotal: 105_165, objectEstimate: 105_165,
+      objectsPromoted: 0, completedRevision: null,
+    });
+    platform.load.mockResolvedValue(fixture.value);
+    usePreferencesStore.setState({ artChain: [], artOverrides: {} });
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+
+    chooseCurated();
+    const install = await screen.findByRole("button", { name: /install selection/i });
+    await waitFor(() => expect(install).toBeEnabled());
+    fireEvent.click(install);
+
+    const note = await screen.findByText(/total was fixed when this download started/i);
+    expect(note).toBeInTheDocument();
+    expect(note).not.toHaveTextContent(/snapshot/i);
+    // And the operation's own root is a label, not a 64-character identifier
+    // dropped into the most prominent position on the screen.
+    const operation = note.closest("section");
+    expect(operation).toHaveTextContent("aaaaaaaaaaaa…");
+    expect(operation?.textContent).not.toContain(ROOT_A);
   });
 
   it("renders a representative translated locale through the real manager", async () => {

--- a/client/src/components/settings/visual-packs/VisualPackManager.tsx
+++ b/client/src/components/settings/visual-packs/VisualPackManager.tsx
@@ -1,11 +1,14 @@
+import type { TFunction } from "i18next";
 import { useTranslation } from "react-i18next";
 
 import type {
   RemovalSelector,
   VisualPackErrorKind,
 } from "../../../services/visualPacks/types.ts";
+import { formatByteSize } from "../../../utils/byteSize.ts";
 import { ConfirmDialog } from "../../ui/ConfirmDialog.tsx";
 import { OperationProgress } from "./OperationProgress.tsx";
+import { packLabel, shortDigest } from "./packLabels.ts";
 import { PackSelector } from "./PackSelector.tsx";
 import { PackStatus } from "./PackStatus.tsx";
 import {
@@ -23,16 +26,20 @@ function errorKey(kind: VisualPackErrorKind): string {
     case "cancelled": return "visualPacks.errors.cancelled";
     case "network": return "visualPacks.errors.network";
     case "storage": return "visualPacks.errors.storage";
+    case "insufficient_storage": return "visualPacks.errors.insufficient_storage";
     case "trust": return "visualPacks.errors.trust";
     case "emit": return "visualPacks.errors.emit";
     case "internal": return "visualPacks.errors.internal";
   }
 }
 
-function selectorLabel(selector: RemovalSelector): string {
+/** What the confirmation sentence names, in the words the rest of the panel
+ *  uses for the same packs — a removal prompt is the last place to quote wire
+ *  identities at somebody. */
+function selectorLabel(selector: RemovalSelector, t: TFunction<"settings">): string {
   switch (selector.kind) {
-    case "packs": return selector.packIds.join(", ");
-    case "complete": return selector.rootSha256;
+    case "packs": return selector.packIds.map((id) => packLabel(id, t)).join(", ");
+    case "complete": return shortDigest(selector.rootSha256);
     case "all_installed": return "";
   }
 }
@@ -61,9 +68,21 @@ function confirmationKeys(confirmation: FrozenConfirmation): { title: string; me
 }
 
 export function VisualPackManager() {
-  const { t } = useTranslation("settings");
+  const { t, i18n } = useTranslation("settings");
   const manager = useVisualPackManager();
   const confirmationCopy = manager.confirmation ? confirmationKeys(manager.confirmation) : null;
+  const refusal = manager.actionErrorRefusal;
+  // One message for both places the panel reports a failed action. The figures
+  // are the backend's own — the ones its pre-flight gate compared — and only
+  // their unit and separators are decided here.
+  const actionErrorMessage = manager.actionError
+    ? t(errorKey(manager.actionError) as never, refusal
+      ? {
+          required: formatByteSize(refusal.requiredBytes, i18n.language),
+          available: formatByteSize(refusal.availableBytes, i18n.language),
+        }
+      : {})
+    : null;
 
   return (
     <section className="rounded-[20px] border border-white/10 bg-black/18 p-4 shadow-[0_18px_54px_rgba(0,0,0,0.18)] backdrop-blur-md sm:p-5">
@@ -118,7 +137,7 @@ export function VisualPackManager() {
             )}
             {manager.actionError && (
               <div role="alert" className="rounded-[12px] border border-rose-400/25 bg-rose-400/[0.08] px-3 py-2 text-sm text-rose-100">
-                <p>{t(errorKey(manager.actionError) as never)}</p>
+                <p>{actionErrorMessage}</p>
                 {manager.actionErrorDetail && (
                   <code className="mt-1 block select-text break-words font-mono text-xs text-rose-100/90">
                     {manager.actionErrorDetail}
@@ -128,14 +147,19 @@ export function VisualPackManager() {
             )}
             <PackSelector
               summary={manager.summary}
+              curatedSelector={manager.curatedSelector}
+              curatedDrift={manager.curatedDrift}
               estimate={manager.estimate}
+              estimateProgress={manager.estimateProgress}
               pendingActions={manager.pendingActions}
               durableMutationActive={manager.durableMutationActive}
+              onSelectCurated={manager.resolveCuratedSelector}
               onEstimate={manager.estimateInstall}
               onInstall={manager.install}
             />
             <PackStatus
               summary={manager.summary}
+              curatedDrift={manager.curatedDrift}
               verification={manager.verification?.value ?? null}
               removal={manager.removal}
               pendingActions={manager.pendingActions}
@@ -150,7 +174,7 @@ export function VisualPackManager() {
         )}
         {manager.actionError && manager.availability.kind !== "ready" && (
           <div role="alert" className="text-sm text-rose-200">
-            <p>{t(errorKey(manager.actionError) as never)}</p>
+            <p>{actionErrorMessage}</p>
             {manager.actionErrorDetail && (
               <code className="mt-1 block select-text break-words font-mono text-xs text-rose-100/90">
                 {manager.actionErrorDetail}
@@ -163,7 +187,7 @@ export function VisualPackManager() {
         open={manager.confirmation != null}
         title={confirmationCopy ? t(confirmationCopy.title as never) : ""}
         message={manager.confirmation && confirmationCopy
-          ? t(confirmationCopy.message as never, { selection: selectorLabel(manager.confirmation.selector) })
+          ? t(confirmationCopy.message as never, { selection: selectorLabel(manager.confirmation.selector, t) })
           : ""}
         confirmLabel={confirmationCopy ? t(confirmationCopy.action as never) : ""}
         onConfirm={manager.confirmRemoval}

--- a/client/src/components/settings/visual-packs/packLabels.ts
+++ b/client/src/components/settings/visual-packs/packLabels.ts
@@ -1,0 +1,50 @@
+import type { TFunction } from "i18next";
+
+import type { CatalogRoot, PackId } from "../../../services/visualPacks/types.ts";
+
+const PRINTING = /^printing:([a-z0-9]{3,6})$/;
+const LOCALE = /^locale:(de|es|fr|it|pt):([a-z0-9]{3,6})$/;
+
+/**
+ * How much of a 64-hex digest is shown.
+ *
+ * Enough to tell two installed packs apart at a glance and to quote in a bug
+ * report; not enough to be mistaken for something the user is meant to read.
+ * Twelve hex characters is 48 bits. The panel DOES compare digests, in roughly
+ * fifteen places — estimate binding, summary acceptance, operation identity,
+ * the curated drift verdict — and every one of those compares the full value.
+ * Only display truncates, so a shortened digest is never an operand.
+ */
+const DIGEST_PREFIX = 12;
+
+/**
+ * The name a user sees for an installed or planned pack.
+ *
+ * `PackId` is a wire identity with a grammar (`printing:fin`,
+ * `locale:de:fin`), and the panel rendered it verbatim: a user managing their
+ * own downloads was reading the selector vocabulary of the backend. The set
+ * code stays, uppercased, because it IS what the user typed to install the
+ * pack and is the only part that distinguishes one printing pack from another.
+ *
+ * Unrecognised ids fall through to the raw value rather than to a placeholder.
+ * `PackId`'s pattern admits exactly the five shapes below, so this is
+ * unreachable through the brand — but the row it labels is an INSTALLED pack,
+ * read back from a database written by an older version of this app, and a row
+ * the panel cannot name must still be nameable to whoever is asked to remove
+ * it.
+ */
+export function packLabel(id: PackId, t: TFunction<"settings">): string {
+  if (id === "core") return t("visualPacks.packs.core");
+  if (id === "complete") return t("visualPacks.packs.complete");
+  if (id === "curated") return t("visualPacks.packs.curated");
+  const printing = PRINTING.exec(id);
+  if (printing) return t("visualPacks.packs.printing", { set: printing[1].toUpperCase() });
+  const locale = LOCALE.exec(id);
+  if (locale) return t("visualPacks.packs.locale", { set: locale[2].toUpperCase(), language: locale[1].toUpperCase() });
+  return id;
+}
+
+/** A digest as a label — see `DIGEST_PREFIX`. */
+export function shortDigest(digest: CatalogRoot): string {
+  return `${digest.slice(0, DIGEST_PREFIX)}…`;
+}

--- a/client/src/components/settings/visual-packs/useVisualPackManager.ts
+++ b/client/src/components/settings/visual-packs/useVisualPackManager.ts
@@ -3,11 +3,16 @@ import { useCallback, useEffect, useRef, useState } from "react";
 import { loadVisualPackBackend } from "../../../services/platform.ts";
 import {
   VisualPackBackendError,
+  VisualPackStorageRefusalError,
   type VisualPackBackend,
 } from "../../../services/visualPacks/backend.ts";
 import {
   compareRevisions,
+  packId,
   type CatalogSummary,
+  type CatalogScanProgress,
+  type CuratedDrift,
+  type CuratedInstallSelector,
   type InstallEstimate,
   type InstallSelector,
   type OperationStatus,
@@ -17,10 +22,12 @@ import {
   type RemovalResponse,
   type RemovalSelector,
   type RevisionEvent,
+  type StorageRefusal,
   type VerificationMode,
   type VerificationResponse,
   type VisualPackErrorKind,
 } from "../../../services/visualPacks/types.ts";
+import { usePreferencesStore } from "../../../stores/preferencesStore.ts";
 
 export type ManagerAvailability =
   | { kind: "loading" }
@@ -50,24 +57,61 @@ interface BoundVerification {
 interface ProgressOutcome {
   identity: string | null;
   failed: boolean;
+  /**
+   * A cancellation this panel WITNESSED — a `cancelled` progress event, or its
+   * own `cancel()` call returning a cancelled status.
+   *
+   * Deliberately not the same fact as a `cancelled` operation RECORD, which is
+   * what `terminal` below is set from. `run()` writes `state: "cancelled"` for
+   * a non-retryable failure as well as for a user cancel, so a record read back
+   * through `operationStatus()` says the operation ended and nothing about why.
+   * This one is only ever set where the ending is known to be the user's.
+   */
+  cancelled: boolean;
   terminal: boolean;
 }
 
 export interface VisualPackManagerState {
   availability: ManagerAvailability;
   summary: CatalogSummary | null;
+  /**
+   * The curated selector as the backend resolved it, or null until the user
+   * picks that option.
+   *
+   * Resolved on demand rather than alongside the summary because it costs a
+   * membership plan, and most sessions never open this panel to install the
+   * curated pack.
+   */
+  curatedSelector: CuratedInstallSelector | null;
+  /**
+   * How far the installed curated pack has drifted from what the stored
+   * preferences name now, or null when there is nothing to say.
+   *
+   * Null covers three different situations and the panel must treat all three
+   * the same way — say nothing: no curated pack is installed, the read has not
+   * finished, or it failed. A drift claim the panel has not measured is a
+   * claim about a multi-gigabyte download, so it is never guessed.
+   */
+  curatedDrift: CuratedDrift | null;
   estimate: BoundEstimate | null;
+  estimateProgress: CatalogScanProgress | null;
   operation: OperationStatus | null;
   progress: ProgressEvent | null;
   verification: BoundVerification | null;
   removal: RemovalResponse | null;
   actionError: VisualPackErrorKind | null;
+  /** Verbatim diagnostic text from the platform, for the `<code>` line. Null
+   *  when the failure carries structured state instead — see `errorDetail`. */
   actionErrorDetail: string | null;
+  /** The figures behind an `insufficient_storage` refusal, for the panel to
+   *  format. Null for every other kind. */
+  actionErrorRefusal: StorageRefusal | null;
   pendingActions: ReadonlySet<string>;
   durableMutationActive: boolean;
   confirmation: FrozenConfirmation | null;
   retry(): void;
   refresh(): void;
+  resolveCuratedSelector(): void;
   estimateInstall(selector: InstallSelector): void;
   install(selector: InstallSelector): void;
   cancel(): void;
@@ -83,18 +127,71 @@ export interface VisualPackManagerState {
 
 const MUTATION_ACTIONS: ReadonlySet<string> = new Set(["install", "cancel", "resume", "repair", "remove"]);
 const MAX_BUFFERED_START_OPERATIONS = 8;
+const CURATED = packId("curated");
 
 export function hasPendingVisualPackMutation(pending: ReadonlySet<string>): boolean {
   return [...pending].some((entry) => MUTATION_ACTIONS.has(entry));
+}
+
+/**
+ * What the panel may say about the installed curated pack.
+ *
+ * `unknown` is "say nothing", and it covers three states the display must treat
+ * identically: no curated pack is installed, the drift has not been measured,
+ * or measuring it failed. It is NEVER "no drift" — that is a measurement, and
+ * this is its absence.
+ */
+export type CuratedDriftState = "unknown" | "current" | "drifted";
+
+/**
+ * The single authority on what curated drift means, for every surface.
+ *
+ * Three sites spelled this comparison out independently and had already
+ * diverged: the badge read `installedDigest !== membershipDigest`, which is
+ * TRUE for `installedDigest: null` — the backend's way of saying nothing is
+ * installed — while the selector read that same null as "nothing to report".
+ * `InstallEstimate.headroom` lives on the engine so that a verdict has one
+ * definition; this is the same discipline one layer down, and three hand-written
+ * copies are what produced the disagreement.
+ *
+ * Compared against the digest the SUMMARY reports installed, not against
+ * `drift.installedDigest`. For a curated pack the installed pack's
+ * `catalogRoot` IS its membership digest, and the summary is the authority on
+ * what is on disk right now, while a drift is a measurement that may have been
+ * taken before an install or a removal moved it.
+ */
+export function curatedDriftState(summary: CatalogSummary, drift: CuratedDrift | null): CuratedDriftState {
+  const installed = summary.installedPacks.find((entry) => entry.packId === CURATED);
+  if (!drift || !installed) return "unknown";
+  return installed.catalogRoot === drift.membershipDigest ? "current" : "drifted";
 }
 
 function errorKind(error: unknown): VisualPackErrorKind {
   return error instanceof VisualPackBackendError ? error.kind : "internal";
 }
 
+/**
+ * The verbatim line shown beneath the translated sentence.
+ *
+ * A `VisualPackBackendError` is asked for its `detail` rather than its
+ * `message`, because those answer different questions: `message` falls back to
+ * a developer-facing default so a stack trace is never blank, and rendering
+ * that default would put untranslated English underneath a translated sentence
+ * in a seven-language panel. Every kind already HAS a translated sentence, so
+ * an error that supplied no detail has nothing further to say.
+ *
+ * That covers a storage refusal, whose figures ride on `refusal` instead, and
+ * the curated planner's `network` — but as a rule rather than as a list, so a
+ * kind added later cannot leak English by forgetting to join it.
+ */
 function errorDetail(error: unknown): string | null {
+  if (error instanceof VisualPackBackendError) return error.detail;
   if (error instanceof Error) return error.message || null;
   return typeof error === "string" && error ? error : null;
+}
+
+function errorRefusal(error: unknown): StorageRefusal | null {
+  return error instanceof VisualPackStorageRefusalError ? error.refusal : null;
 }
 
 function selectorIdentity(selector: InstallSelector): string {
@@ -107,11 +204,20 @@ function selectorIdentity(selector: InstallSelector): string {
       return `locale:${selector.language}:${selector.set}`;
     case "complete":
       return `complete:${selector.rootSha256}`;
+    case "curated":
+      return `curated:${selector.membershipDigest}`;
   }
 }
 
+/**
+ * The name the backend stamps on `InstallEstimate.selector` — its pack id.
+ *
+ * For most selectors that is the identity string, but the two root-bearing
+ * kinds carry a root the pack id does not, so their identity would never match
+ * and their estimate would be discarded as stale rather than rendered.
+ */
 function signedSelectorName(selector: InstallSelector): string {
-  return selector.kind === "complete" ? "complete" : selectorIdentity(selector);
+  return selector.kind === "complete" || selector.kind === "curated" ? selector.kind : selectorIdentity(selector);
 }
 
 function operationIsTerminal(status: OperationStatus): boolean {
@@ -149,32 +255,38 @@ export function useVisualPackManager(): VisualPackManagerState {
   const summaryRef = useRef<CatalogSummary | null>(null);
   const operationRef = useRef<OperationStatus | null>(null);
   const progressRef = useRef<ProgressEvent | null>(null);
-  const progressOutcomeRef = useRef<ProgressOutcome>({ identity: null, failed: false, terminal: false });
+  const progressOutcomeRef = useRef<ProgressOutcome>({ identity: null, failed: false, cancelled: false, terminal: false });
   const startEventBufferRef = useRef({ active: false, events: new Map<string, ProgressEvent>() });
   const pendingRef = useRef(new Set<string>());
   const listenersRef = useRef<Array<() => void>>([]);
   const initializedRef = useRef(false);
-  const requestRef = useRef({ initialize: 0, summary: 0, estimate: 0, verify: 0 });
+  const requestRef = useRef({ initialize: 0, summary: 0, estimate: 0, verify: 0, curated: 0, drift: 0 });
 
   const [availability, setAvailability] = useState<ManagerAvailability>({ kind: "loading" });
   const [summary, setSummary] = useState<CatalogSummary | null>(null);
+  const [curatedSelector, setCuratedSelector] = useState<CuratedInstallSelector | null>(null);
+  const [curatedDrift, setCuratedDrift] = useState<CuratedDrift | null>(null);
   const [estimate, setEstimate] = useState<BoundEstimate | null>(null);
+  const [estimateProgress, setEstimateProgress] = useState<CatalogScanProgress | null>(null);
   const [operation, setOperation] = useState<OperationStatus | null>(null);
   const [progress, setProgress] = useState<ProgressEvent | null>(null);
   const [verification, setVerification] = useState<BoundVerification | null>(null);
   const [removal, setRemoval] = useState<RemovalResponse | null>(null);
   const [actionError, setActionError] = useState<VisualPackErrorKind | null>(null);
   const [actionErrorDetail, setActionErrorDetail] = useState<string | null>(null);
+  const [actionErrorRefusal, setActionErrorRefusal] = useState<StorageRefusal | null>(null);
   const [pendingActions, setPendingActions] = useState<ReadonlySet<string>>(new Set());
   const [confirmation, setConfirmation] = useState<FrozenConfirmation | null>(null);
 
   const clearActionError = useCallback(() => {
     setActionError(null);
     setActionErrorDetail(null);
+    setActionErrorRefusal(null);
   }, []);
   const reportActionError = useCallback((error: unknown) => {
     setActionError(errorKind(error));
     setActionErrorDetail(errorDetail(error));
+    setActionErrorRefusal(errorRefusal(error));
   }, []);
 
   const beginPending = useCallback((value: string): boolean => {
@@ -255,11 +367,27 @@ export function useVisualPackManager(): VisualPackManagerState {
     if (outcome.identity !== identity) {
       outcome.identity = identity;
       outcome.failed = false;
+      outcome.cancelled = false;
       outcome.terminal = false;
     }
-    if (outcome.failed || outcome.terminal) return;
+    // An ending this panel WITNESSED is final. A merely terminal status is not,
+    // and the difference decides whether a stopped operation reads as the
+    // user's cancel or as the failure it was: `run()` writes
+    // `state: "cancelled"` for a non-retryable failure too, so a record read
+    // back through `operationStatus()` cannot say which happened. The `failed`
+    // event is the sole carrier of WHY, and on the resume path it arrives AFTER
+    // `trackStarted` has read the terminated record and set `terminal` —
+    // dropping it there rendered a conflict as a deliberate cancel, with no
+    // diagnostic anywhere on screen.
+    //
+    // `completed` is excluded from the reopening because that ending is
+    // unambiguous: `run()`'s catch leaves an already-completed record alone, so
+    // it can emit `failed` carrying one, and a finished install must not flip.
+    if (outcome.failed || outcome.cancelled) return;
+    if (outcome.terminal && (event.phase !== "failed" || event.operation.state === "completed")) return;
     if (operationRank(event.operation) < operationRank(selected)) return;
     if (event.phase === "failed") outcome.failed = true;
+    if (event.phase === "cancelled") outcome.cancelled = true;
     if (progressIsTerminal(event)) outcome.terminal = true;
     operationRef.current = event.operation;
     progressRef.current = event;
@@ -268,7 +396,12 @@ export function useVisualPackManager(): VisualPackManagerState {
     if (event.phase === "failed") {
       if (event.error) {
         setActionError(event.error);
+        // All three move together or the kind and the payload describe
+        // different failures: `actionErrorRefusal`'s contract is "null for
+        // every other kind", and a progress event carries a kind with no error
+        // object to source a payload from.
         setActionErrorDetail(null);
+        setActionErrorRefusal(null);
       }
     } else {
       clearActionError();
@@ -301,6 +434,7 @@ export function useVisualPackManager(): VisualPackManagerState {
       packTotal: 0,
       packsPromoted: 0,
       objectTotal: 0,
+      objectEstimate: null,
       objectsPromoted: 0,
       completedRevision: null,
     };
@@ -311,7 +445,7 @@ export function useVisualPackManager(): VisualPackManagerState {
     buffer.events.clear();
     operationRef.current = pending;
     progressRef.current = null;
-    progressOutcomeRef.current = { identity, failed: false, terminal: false };
+    progressOutcomeRef.current = { identity, failed: false, cancelled: false, terminal: false };
     setOperation(pending);
     setProgress(null);
     if (buffered) handleProgress(buffered);
@@ -395,6 +529,8 @@ export function useVisualPackManager(): VisualPackManagerState {
       requests.summary += 1;
       requests.estimate += 1;
       requests.verify += 1;
+      requests.curated += 1;
+      requests.drift += 1;
       for (const unlisten of listeners.splice(0)) unlisten();
     };
   }, [initialize]);
@@ -402,6 +538,85 @@ export function useVisualPackManager(): VisualPackManagerState {
   const retry = useCallback(() => {
     if (!initializedRef.current) void initialize();
   }, [initialize]);
+
+  // Two of the three values `planCuratedPack()` memoizes on, read as VALUES
+  // rather than through `getState()` so a change re-runs the effect below.
+  //
+  // NOT for an art rule edited on the Visual tab: that tab and this one are
+  // mutually exclusive branches of the same modal, so editing a rule there has
+  // already unmounted this panel. What earns the dependency is
+  // `ResetAllFooter` -> `resetAllPreferences`, which renders on EVERY tab and
+  // replaces both of these references while this panel is mounted — without the
+  // dependency the panel would go on reporting drift against art rules the user
+  // has just cleared.
+  const artChain = usePreferencesStore((state) => state.artChain);
+  const artOverrides = usePreferencesStore((state) => state.artOverrides);
+  const curatedInstalled = summary?.installedPacks.some((entry) => entry.packId === CURATED) ?? false;
+  const installedRevisionValue = summary?.installedRevision;
+
+  /**
+   * Recompute curated drift whenever the membership it compares against moves.
+   *
+   * Gated on a curated pack BEING INSTALLED, and that gate is what makes it
+   * affordable: `curatedDrift()` plans the whole membership from the card data
+   * and then reads every installed curated row, and a session that never
+   * installed one is buying an answer it has no question for. A user who HAS
+   * installed one has already committed to a multi-gigabyte download, so
+   * telling them it has gone stale is worth a plan they effectively already
+   * paid for. `planCuratedPack()` memoizes on THREE values — these two plus a
+   * serialization of every saved deck's stored text — so a hit is cheap but not
+   * free: the third component is a `localStorage` read and a `JSON.stringify`
+   * on every call, hit or miss.
+   *
+   * It RECOMPUTES; it never downloads. A preference toggle producing a delta is
+   * the whole point, and the delta is what the user then presses Sync on.
+   *
+   * THIS READ NEVER FETCHES. `curatedDrift()` answers `null` rather than loading
+   * the card data behind a membership plan — 76 MB across two files — and a
+   * null renders as "say nothing".
+   *
+   * Scoped to this read, and not a claim about mounting: mounting DOES reach
+   * `loadVisualPackBackend()` -> `create()`, whose pending loop calls `run()`
+   * for every `downloading` or `finalizing` record, which resumes an interrupted
+   * download and plans a membership on the way. That is a user-initiated
+   * operation continuing, which is correct, and it is why the sentence has to
+   * be about the effect rather than about the mount.
+   * `curatedSelector` is a dependency for that reason: resolving a selector is
+   * a user-initiated action that goes through the same planner and therefore
+   * loads that data, so its arrival is the moment a previously unmeasurable
+   * drift becomes free to measure. The panel asks again; the backend, which
+   * owns the question, decides again.
+   *
+   * A failure leaves the drift null and reports NOTHING. Nobody asked for this
+   * read, and an alert beside the install controls would be attributed to
+   * whatever the user did last; the same failure is surfaced WITH an error on
+   * the path a user does ask for, `resolveCuratedSelector`.
+   *
+   * The saved decks are the third input `planCuratedPack()` keys on and are not
+   * watched, and that costs nothing reachable: they are edited in the deck
+   * builder, which is not interactive behind this modal, so a deck cannot
+   * change while this panel is mounted. `savedDeckText()` reads `localStorage`
+   * directly and there is no deck store in `src/stores/` to subscribe to
+   * anyway. Were one to change, the digest the backend installs would still be
+   * right — `start()` replans — so the worst case is a stale display, not a
+   * divergence.
+   */
+  useEffect(() => {
+    const backend = backendRef.current;
+    if (!backend || !curatedInstalled) {
+      setCuratedDrift(null);
+      return;
+    }
+    const generation = ++requestRef.current.drift;
+    void backend.curatedDrift().then(
+      (drift) => {
+        if (mountedRef.current && generation === requestRef.current.drift) setCuratedDrift(drift);
+      },
+      () => {
+        if (mountedRef.current && generation === requestRef.current.drift) setCuratedDrift(null);
+      },
+    );
+  }, [artChain, artOverrides, curatedInstalled, curatedSelector, installedRevisionValue]);
 
   const refresh = useCallback(async () => {
     const backend = backendRef.current;
@@ -418,17 +633,47 @@ export function useVisualPackManager(): VisualPackManagerState {
     }
   }, [acceptSummary, beginPending, clearActionError, endPending, reportActionError]);
 
+  /**
+   * Ask the backend what "curated" currently means.
+   *
+   * Its own pending key, deliberately not one of `MUTATION_ACTIONS`: resolving
+   * a digest reads preferences and card data and writes nothing, so it must
+   * not disable Install or Remove while it runs.
+   */
+  const resolveCuratedSelector = useCallback(async () => {
+    const backend = backendRef.current;
+    if (!backend || !beginPending("curated")) return;
+    clearActionError();
+    const generation = ++requestRef.current.curated;
+    try {
+      const selector = await backend.curatedSelector();
+      if (mountedRef.current && generation === requestRef.current.curated) setCuratedSelector(selector);
+    } catch (error) {
+      if (mountedRef.current && generation === requestRef.current.curated) reportActionError(error);
+    } finally {
+      if (mountedRef.current) endPending("curated");
+    }
+  }, [beginPending, clearActionError, endPending, reportActionError]);
+
   const estimateInstall = useCallback(async (selector: InstallSelector) => {
     const backend = backendRef.current;
     const current = summaryRef.current;
     if (!backend || !current) return;
+    // The generation bump follows the slot check, and the order is load-bearing:
+    // bumping first would let a request this function then REFUSES invalidate
+    // the one already running, so the in-flight estimate's own `finally` would
+    // no longer recognise itself and would leave the scan-progress section on
+    // screen for ever. A refused request must change nothing.
+    if (!beginPending("estimate")) return;
     const generation = ++requestRef.current.estimate;
     const root = current.catalogRoot;
     const revision = current.installedRevision;
-    if (!beginPending("estimate")) return;
     clearActionError();
+    setEstimateProgress(null);
     try {
-      const value = await backend.estimateInstall(selector);
+      const value = await backend.estimateInstall(selector, (progress) => {
+        if (mountedRef.current && generation === requestRef.current.estimate) setEstimateProgress(progress);
+      });
       const latest = summaryRef.current;
       if (
         !mountedRef.current
@@ -444,6 +689,7 @@ export function useVisualPackManager(): VisualPackManagerState {
     } catch (error) {
       if (mountedRef.current && generation === requestRef.current.estimate) reportActionError(error);
     } finally {
+      if (mountedRef.current && generation === requestRef.current.estimate) setEstimateProgress(null);
       if (mountedRef.current) endPending("estimate");
     }
   }, [beginPending, clearActionError, endPending, reportActionError]);
@@ -466,6 +712,11 @@ export function useVisualPackManager(): VisualPackManagerState {
         progressOutcomeRef.current = {
           identity: `${status.operationId}:${status.catalogRoot}`,
           failed: false,
+          // A status READ BACK, so the ending is not witnessed: a `cancelled`
+          // record here is equally a user cancel and a terminated failure, and
+          // claiming the former would suppress the `failed` event that is
+          // about to say which.
+          cancelled: false,
           terminal: true,
         };
       }
@@ -497,7 +748,11 @@ export function useVisualPackManager(): VisualPackManagerState {
     clearActionError();
     beginStartEventBuffer();
     try {
-      const result = await backend.start({ kind: "install", selector });
+      const result = await backend.start({
+        kind: "install",
+        selector,
+        objectEstimate: Number(bound.value.assetRecords),
+      });
       if (!mountedRef.current) return;
       if (result.status === "healthy") {
         clearStartEventBuffer();
@@ -535,6 +790,10 @@ export function useVisualPackManager(): VisualPackManagerState {
           progressOutcomeRef.current = {
             identity: `${status.operationId}:${status.catalogRoot}`,
             failed: false,
+            // Witnessed: this branch only runs because THIS panel asked for the
+            // cancellation and the backend confirmed it. Nothing arriving
+            // afterwards may re-report it as a failure.
+            cancelled: true,
             terminal: true,
           };
         }
@@ -559,8 +818,12 @@ export function useVisualPackManager(): VisualPackManagerState {
     const selectedProgress = progressRef.current;
     if (
       !backend
+      // `finalizing` too: a failure there leaves a record `create()` re-runs on
+      // the next launch, so it is resumable and OperationProgress offers the
+      // button. A guard that admitted only `downloading` would render a live
+      // control that silently did nothing.
       || !selected
-      || selected.state !== "downloading"
+      || (selected.state !== "downloading" && selected.state !== "finalizing")
       || progressRef.current?.phase !== "failed"
       || !beginPending("resume")
     ) return;
@@ -569,6 +832,7 @@ export function useVisualPackManager(): VisualPackManagerState {
     progressOutcomeRef.current = {
       identity: `${selected.operationId}:${selected.catalogRoot}`,
       failed: false,
+      cancelled: false,
       terminal: false,
     };
     try {
@@ -577,7 +841,7 @@ export function useVisualPackManager(): VisualPackManagerState {
       if (result.status === "healthy") {
         operationRef.current = null;
         progressRef.current = null;
-        progressOutcomeRef.current = { identity: null, failed: false, terminal: false };
+        progressOutcomeRef.current = { identity: null, failed: false, cancelled: false, terminal: false };
         setOperation(null);
         setProgress(null);
         await refreshSummary();
@@ -625,6 +889,40 @@ export function useVisualPackManager(): VisualPackManagerState {
     }
   }, [beginPending, clearActionError, endPending, reportActionError]);
 
+  /**
+   * Repair the named packs. DELIBERATELY NOT GATED ON STORAGE, unlike install.
+   *
+   * `install` sends an `objectEstimate` the user has seen, and `reserveStorage`
+   * refuses the request when even the cheapest reading of that figure cannot
+   * fit. A repair reaches none of that: `reserveStorage`'s size branch is
+   * gated on `request.kind === "install"`, and `StartRequest`'s repair arm
+   * carries pack ids only.
+   *
+   * Producing a figure for it is not free, and it is not uniformly expensive
+   * either — the honest shape is per selector. `reserveStorage` substitutes its
+   * own count for CURATED alone (`curatedFetchCount`, no catalog scan); every
+   * other selector keeps the caller's `objectEstimate`, and the only way to
+   * produce one for them is `countScryfallAssets` reading the whole compressed
+   * Scryfall archive. So a curated repair could in principle be gated cheaply —
+   * except that `start()` filters it out entirely, leaving nothing to gate —
+   * while a bulk repair could be gated only by putting a multi-gigabyte scan
+   * behind a button labelled Repair.
+   *
+   * And a repair is not free of new bytes, so "it downloads nothing an install
+   * did not account for" is NOT available as a reason: `start()` re-derives a
+   * repair's selector from the root the pack was INSTALLED at, then drops any
+   * selector already installed at the root it resolves to — so repairing a
+   * current pack is a no-op, while repairing one whose catalog root has moved
+   * re-fetches it at the new root, which for `complete` is the entire catalog.
+   *
+   * What it rests on is the asymmetry `reserveStorage` documents, which holds
+   * whatever a count would have cost. Running out of quota mid-download is
+   * classified `storage`, `storage` is retryable, so the operation record stays
+   * `downloading`, the panel offers Resume, and the resume skips every object
+   * already cached. A wrong refusal has no override anywhere. Given a choice
+   * between a recoverable failure and an unappealable one, the repair path takes
+   * the recoverable one.
+   */
   const runStart = useCallback(async (packIds: PackId[]) => {
     const backend = backendRef.current;
     if (
@@ -701,18 +999,23 @@ export function useVisualPackManager(): VisualPackManagerState {
   return {
     availability,
     summary,
+    curatedSelector,
+    curatedDrift,
     estimate,
+    estimateProgress,
     operation,
     progress,
     verification,
     removal,
     actionError,
     actionErrorDetail,
+    actionErrorRefusal,
     pendingActions,
     durableMutationActive: operationIsDurableMutation(operation),
     confirmation,
     retry,
     refresh,
+    resolveCuratedSelector,
     estimateInstall,
     install,
     cancel,

--- a/client/src/hooks/__tests__/useCardImage.test.tsx
+++ b/client/src/hooks/__tests__/useCardImage.test.tsx
@@ -573,4 +573,200 @@ describe("useCardImage", () => {
     await waitFor(() => expect(result.current.src).toBe("http://visual-pack.localhost/back-1"));
   });
 
+  // Regression anchor for the art-selection chain. Before these, the suite
+  // configured only an EMPTY `artChain`, so `applyChain`/`applyChainEntry`
+  // could be changed arbitrarily without a single test turning red. They must
+  // stay at the `useCardImage` level: an extracted-function unit test asserts
+  // the extracted function against itself and cannot show that the hook still
+  // reaches it.
+  describe("art precedence", () => {
+    // `dmu` is printings[0] (what a `newest` entry would pick) and `sld` is the
+    // only borderless one, so every expectation below distinguishes the entry
+    // under test from its neighbours. The scryfall-data face URL is a third,
+    // distinct value, so "the chain did nothing" is also distinguishable.
+    const PRINTINGS = [
+      {
+        id: "dmu-bolt",
+        set: "dmu",
+        set_name: "Dominaria United",
+        collector_number: "137",
+        released_at: "2022-09-09",
+        border_color: "black",
+        frame_effects: [],
+        full_art: false,
+        faces: [{ normal: "https://img.example/dmu.jpg", art_crop: "https://img.example/dmu-art.jpg" }],
+      },
+      {
+        id: "sld-bolt",
+        set: "sld",
+        set_name: "Secret Lair Drop",
+        collector_number: "1",
+        released_at: "2023-04-01",
+        border_color: "borderless",
+        frame_effects: [],
+        full_art: false,
+        faces: [{ normal: "https://img.example/sld.jpg", art_crop: "https://img.example/sld-art.jpg" }],
+      },
+    ];
+
+    function stubPrintingsFixture(): void {
+      vi.doMock("../../services/visualPacks/repository.ts", () => ({
+        visualPackRepository: {
+          currentRevision: () => "0",
+          subscribe: () => () => {},
+          resolve: vi.fn(async ({ remote }: { remote: { src: string } }) => ({
+            revision: "0",
+            sources: [{ kind: "remote" as const, src: remote.src }, { kind: "fallback" as const, src: null }],
+          })),
+        },
+      }));
+      vi.stubGlobal("fetch", vi.fn((url: string) => {
+        if (url === "/scryfall-data.json") {
+          return Promise.resolve(jsonResponse({
+            "lightning bolt": {
+              oracle_id: "oracle-bolt",
+              face_names: ["lightning bolt"],
+              faces: [{ normal: "https://img.example/default.jpg", art_crop: "https://img.example/default-art.jpg" }],
+              name: "Lightning Bolt",
+              mana_cost: "{R}",
+              cmc: 1,
+              type_line: "Instant",
+              colors: ["R"],
+              color_identity: ["R"],
+              keywords: [],
+            },
+          }));
+        }
+        if (url === "/scryfall-printings.json") {
+          return Promise.resolve(jsonResponse({ "oracle-bolt": PRINTINGS }));
+        }
+        return Promise.resolve(jsonResponse({}));
+      }));
+    }
+
+    it("walks past a chain entry that matches no printing and applies the next one", async () => {
+      stubPrintingsFixture();
+
+      const { usePreferencesStore } = await import("../../stores/preferencesStore");
+      usePreferencesStore.getState().clearAllArtOverrides();
+      usePreferencesStore.getState().setArtChain([
+        { type: "set", setCode: "zzz", label: "Nonexistent Set" },
+        { type: "prefer_borderless" },
+      ]);
+
+      const { useCardImage } = await import("../useCardImage");
+      const { result } = renderHook(() => useCardImage("Lightning Bolt"));
+
+      await waitFor(() => expect(result.current.src).toBe("https://img.example/sld.jpg"));
+    });
+
+    it("honors a set entry ahead of the rest of the chain", async () => {
+      stubPrintingsFixture();
+
+      const { usePreferencesStore } = await import("../../stores/preferencesStore");
+      usePreferencesStore.getState().clearAllArtOverrides();
+      usePreferencesStore.getState().setArtChain([
+        { type: "set", setCode: "dmu", label: "Dominaria United" },
+        { type: "prefer_borderless" },
+      ]);
+
+      const { useCardImage } = await import("../useCardImage");
+      const { result } = renderHook(() => useCardImage("Lightning Bolt"));
+
+      await waitFor(() => expect(result.current.src).toBe("https://img.example/dmu.jpg"));
+    });
+
+    it("resolves a source_printing chain entry from the deck's printing", async () => {
+      stubPrintingsFixture();
+
+      const { usePreferencesStore } = await import("../../stores/preferencesStore");
+      usePreferencesStore.getState().clearAllArtOverrides();
+      // `newest` sits behind `source_printing` and would pick `dmu`, so an sld
+      // result can only come from the source-printing entry consuming the
+      // caller's `sourcePrinting`.
+      usePreferencesStore.getState().setArtChain([
+        { type: "source_printing" },
+        { type: "newest" },
+      ]);
+
+      const { useCardImage } = await import("../useCardImage");
+      const { result } = renderHook(() =>
+        useCardImage("Lightning Bolt", {
+          sourcePrinting: { setCode: "SLD", collectorNumber: "1" },
+        })
+      );
+
+      await waitFor(() => expect(result.current.src).toBe("https://img.example/sld.jpg"));
+    });
+
+    // Precedence branch 4: with an EMPTY chain, a `sourcePrinting` still wins
+    // over the canonical scryfall-data art. This is the default configuration,
+    // so any planner that models only the chain disagrees with the renderer
+    // for every default-config user.
+    it("uses the source printing when the chain is empty", async () => {
+      stubPrintingsFixture();
+
+      const { usePreferencesStore } = await import("../../stores/preferencesStore");
+      usePreferencesStore.getState().clearAllArtOverrides();
+      usePreferencesStore.getState().setArtChain([]);
+
+      const { useCardImage } = await import("../useCardImage");
+      const { result } = renderHook(() =>
+        useCardImage("Lightning Bolt", {
+          sourcePrinting: { setCode: "SLD", collectorNumber: "1" },
+        })
+      );
+
+      await waitFor(() => expect(result.current.src).toBe("https://img.example/sld.jpg"));
+    });
+
+    // Precedence branch 2: a per-card override outranks the whole chain.
+    it("prefers an art override over the chain", async () => {
+      stubPrintingsFixture();
+
+      const { usePreferencesStore } = await import("../../stores/preferencesStore");
+      usePreferencesStore.getState().clearAllArtOverrides();
+      usePreferencesStore.getState().setArtChain([{ type: "prefer_borderless" }]);
+      usePreferencesStore.getState().setArtOverride("oracle-bolt", {
+        scryfallId: "dmu-bolt",
+        setCode: "dmu",
+        collectorNumber: "137",
+      });
+
+      const { useCardImage } = await import("../useCardImage");
+      const { result } = renderHook(() => useCardImage("Lightning Bolt"));
+
+      await waitFor(() => expect(result.current.src).toBe("https://img.example/dmu.jpg"));
+      usePreferencesStore.getState().clearAllArtOverrides();
+    });
+
+    // Pins the renderer's behavior that `services/artSelection.ts` must model:
+    // `else if (artOverrides[oracleId])` gates on key PRESENCE, so a pin whose
+    // scryfallId is no longer in the printings data consumes the branch and
+    // yields no override URL — but with an EMPTY chain the async path is still
+    // handed the source printing, so the deck's art is what renders. Neither
+    // the canonical art nor nothing.
+    it("still shows the deck's printing when a stale art override resolves to no printing", async () => {
+      stubPrintingsFixture();
+
+      const { usePreferencesStore } = await import("../../stores/preferencesStore");
+      usePreferencesStore.getState().clearAllArtOverrides();
+      usePreferencesStore.getState().setArtChain([]);
+      usePreferencesStore.getState().setArtOverride("oracle-bolt", {
+        scryfallId: "printing-that-no-longer-exists",
+        setCode: "xxx",
+        collectorNumber: "1",
+      });
+
+      const { useCardImage } = await import("../useCardImage");
+      const { result } = renderHook(() =>
+        useCardImage("Lightning Bolt", {
+          sourcePrinting: { setCode: "SLD", collectorNumber: "1" },
+        })
+      );
+
+      await waitFor(() => expect(result.current.src).toBe("https://img.example/sld.jpg"));
+      usePreferencesStore.getState().clearAllArtOverrides();
+    });
+  });
 });

--- a/client/src/hooks/useCardImage.ts
+++ b/client/src/hooks/useCardImage.ts
@@ -14,13 +14,13 @@ import {
   isLocaleArtReady,
   imageUrlSize,
   loadLocaleArt,
-  pickOldestPrinting,
   resolveFaceIndexSync,
   resolveOracleIdSync,
   resolvePrintingImageUrl,
 } from "../services/scryfall.ts";
 import type { ImageSize, PrintingEntry, TokenSearchFilters } from "../services/scryfall.ts";
 import type { CardImageAsset } from "../services/scryfall.ts";
+import { applyChain } from "../services/artSelection.ts";
 import type { TokenImageRef } from "../adapter/types.ts";
 import {
   cardBackCandidate,
@@ -272,39 +272,6 @@ export function useLocaleArt(): string {
   }, [language]);
 
   return localeArtCacheKey(language);
-}
-
-function applyChainEntry(
-  entry: ArtChainEntry,
-  printings: PrintingEntry[],
-  source?: SourcePrinting,
-): PrintingEntry | null {
-  switch (entry.type) {
-    case "set":
-      return printings.find((p) => p.set === entry.setCode) ?? null;
-    case "newest":
-      return printings[0];
-    case "oldest":
-      return pickOldestPrinting(printings);
-    case "prefer_borderless":
-      return printings.find((p) => p.border_color === "borderless") ?? null;
-    case "prefer_extended":
-      return printings.find((p) => p.frame_effects.includes("extendedart")) ?? null;
-    case "source_printing": {
-      if (!source) return null;
-      const setLower = source.setCode.toLowerCase();
-      return printings.find((p) => p.set === setLower && p.collector_number === source.collectorNumber) ?? null;
-    }
-  }
-}
-
-function applyChain(chain: ArtChainEntry[], printings: PrintingEntry[], source?: SourcePrinting): PrintingEntry | null {
-  if (printings.length === 0) return null;
-  for (const entry of chain) {
-    const match = applyChainEntry(entry, printings, source);
-    if (match) return match;
-  }
-  return null;
 }
 
 function resolveStrategyInBackground(oracleId: string, chain: ArtChainEntry[]): void {

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -225,6 +225,11 @@
       "printing": "Englische Satzdrucke",
       "locale": "Lokalisierte Satzdrucke",
       "complete": "Kompletter aktueller Katalog",
+      "curated": "Ein Bild pro Karte",
+      "curatedNote": "Ein Bild pro Karte, ausgewählt durch deine Karten-Artwork-Einstellungen im Reiter „Grafik“. Änderst du sie dort, folgt diese Auswahl.",
+      "curatedDefaultNote": "Ein Bild pro Karte. Du hast keine Artwork-Regeln festgelegt, daher wird das Standardbild jeder Karte geladen — füge unter „Karten-Artwork-Einstellungen“ im Reiter „Grafik“ Regeln hinzu, um andere Drucke zu wählen.",
+      "driftNone": "Deine installierten Bilder entsprechen bereits diesen Einstellungen.",
+      "driftSummary": "Deine installierten Bilder sind veraltet: {{add}} hinzuzufügen, {{remove}} zu entfernen, {{refresh}} zu erneuern.",
       "setCode": "Code festlegen",
       "setPlaceholder": "z. B. fin",
       "language": "Bildsprache",
@@ -234,7 +239,10 @@
     "actions": {
       "estimate": "Geschätzter Download",
       "estimating": "Scryfall-Katalog wird durchsucht…",
+      "estimateCurated": "Größe neu berechnen",
+      "estimatingCurated": "Größe wird ermittelt…",
       "install": "Auswahl installieren",
+      "sync": "Bilder synchronisieren",
       "cancel": "Vorgang abbrechen",
       "resume": "Betrieb wieder aufnehmen",
       "retry": "Versuchen Sie es erneut",
@@ -248,11 +256,18 @@
       "removeAll": "Entfernen Sie alle Offline-Visuals"
     },
     "estimate": {
-      "title": "Backend-Schätzung und Abhängigkeitsschließung"
+      "title": "Backend-Schätzung und Abhängigkeitsschließung",
+      "progressTitle": "Fortschritt des Katalog-Scans",
+      "curatedTitle": "Geschätzter Download",
+      "headroomWarning": "Das ist größer als der freie Speicher, den dieser Browser meldet. Du kannst trotzdem installieren — geht der Platz aus, lässt sich der Download fortsetzen und behält alles bereits Gespeicherte.",
+      "evictionWarning": "Dieser Browser hat keinen dauerhaften Speicher gewährt und kann diese Bilder löschen, wenn der Gerätespeicher knapp wird.",
+      "progress": "{{downloaded}} MB von {{total}} MB gelesen · {{records}} Karten durchsucht · {{images}} Bilder gefunden"
     },
     "metrics": {
       "assetRecords": "Vermögensaufzeichnungen",
-      "uniqueObjects": "Einzigartige Objekte",
+      "estimatedImageBytes": "Geschätzte Downloadgröße",
+      "availableBytes": "Verfügbarer freier Speicher",
+      "uniqueObjects": "Herunterzuladende Bilder",
       "logicalImageBytes": "Logische Bildbytes",
       "uniqueImageBytes": "Eindeutige Bildbytes",
       "shardCount": "Scherben",
@@ -265,6 +280,7 @@
         "cancel_requested": "Stornierung beantragt",
         "finalizing": "Finalisierung",
         "failed": "Fehlgeschlagen – bereit zur Fortsetzung",
+        "terminated": "Gestoppt – dieser Vorgang kann nicht fortgesetzt werden",
         "completed": "Abgeschlossen",
         "cancelled": "Abgesagt"
       },
@@ -273,6 +289,7 @@
       "packs": "Pakete: {{current}} von {{total}}",
       "objects": "Bilder: {{current}} von {{total}}",
       "scanNote": "Die Gesamtzahl wächst beim Durchsuchen des Scryfall-Snapshots. Bereits geladene Bilder bleiben lokal und werden beim Fortsetzen übersprungen.",
+      "estimateNote": "Die Gesamtzahl stand beim Start dieses Downloads fest. Bereits geladene Bilder bleiben lokal und werden beim Fortsetzen übersprungen.",
       "finalizing": "Die Installation des Katalogs wird abgeschlossen"
     },
     "status": {
@@ -285,7 +302,15 @@
       "installed": "Installierte Pakete",
       "noneInstalled": "Es sind keine visuellen Pakete installiert.",
       "upgradeAvailable": "Upgrade verfügbar",
-      "receiptRoot": "Empfangsstamm: {{root}}"
+      "receiptRoot": "Installiert aus Snapshot: {{root}}",
+      "membershipDigest": "Zusammenstellungs-Fingerabdruck: {{digest}}",
+      "storageUsage": "Von dieser Website belegter Speicher",
+      "persistence": "Schutz vor Löschung",
+      "persistenceState": {
+        "persisted": "Gewährt – dieser Browser behält diese Bilder",
+        "best_effort": "Nicht gewährt – dieser Browser kann diese Bilder löschen, wenn der Speicher knapp wird",
+        "unsupported": "Dieser Browser macht dazu keine Angabe"
+      }
     },
     "verification": {
       "revision": "Verifizierte installierte Revision {{revision}}.",
@@ -312,15 +337,23 @@
       "remove_failed": "Eine Cache-Datei konnte nicht entfernt werden",
       "catalog_state": "Der historische Katalogstatus konnte nicht wiederhergestellt werden"
     },
+    "packs": {
+      "core": "Kernvisualisierungen",
+      "complete": "Kompletter aktueller Katalog",
+      "curated": "Ein Bild pro Karte",
+      "printing": "{{set}}-Drucke",
+      "locale": "{{set}}-Drucke ({{language}})"
+    },
     "errors": {
       "unsupported_shell": "Diese App-Version unterstützt keine visuellen Offline-Kataloge.",
       "unauthorized": "In diesem Fenster dürfen keine Offline-Visualkataloge verwaltet werden.",
       "unavailable": "Die Offline-Verwaltung des visuellen Katalogs ist vorübergehend nicht verfügbar.",
       "invalid_input": "Die angeforderte Katalogauswahl ist ungültig.",
-      "conflict": "Installierte Pakete hängen von dieser Auswahl ab.",
+      "conflict": "Diese Auswahl ist veraltet: Der Katalog oder deine Artwork-Einstellungen haben sich seitdem geändert. Berechne sie erneut und versuche es noch einmal.",
       "cancelled": "Der Vorgang wurde abgebrochen.",
       "network": "Die Katalognetzwerkanforderung ist fehlgeschlagen.",
       "storage": "Der Katalog konnte nicht in den Gerätespeicher geschrieben werden.",
+      "insufficient_storage": "Nicht genügend freier Speicherplatz: Dieser Download benötigt mindestens {{required}}, aber nur {{available}} sind frei.",
       "trust": "Der Katalogantwort konnte nicht vertraut werden.",
       "emit": "Die App konnte den Katalogfortschritt nicht melden.",
       "internal": "Der Katalogvorgang konnte nicht abgeschlossen werden."

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -229,6 +229,11 @@
       "printing": "English set printings",
       "locale": "Localized set printings",
       "complete": "All current English card images",
+      "curated": "One image per card",
+      "curatedNote": "One image per card, chosen by your Card Art Preferences on the Visual tab. Change them there and this selection follows.",
+      "curatedDefaultNote": "One image per card. You have no card art rules, so this downloads each card's default art — add rules under Card Art Preferences on the Visual tab to pick different printings.",
+      "driftNone": "Your installed images already match these settings.",
+      "driftSummary": "Your installed images are out of date: {{add}} to add, {{remove}} to remove, {{refresh}} to refresh.",
       "setCode": "Set code",
       "setPlaceholder": "e.g. fin",
       "language": "Image language",
@@ -238,7 +243,10 @@
     "actions": {
       "estimate": "Scan catalog and estimate",
       "estimating": "Scanning Scryfall catalog…",
+      "estimateCurated": "Recalculate size",
+      "estimatingCurated": "Working out the size…",
       "install": "Install selection",
+      "sync": "Sync images",
       "cancel": "Cancel operation",
       "resume": "Resume operation",
       "retry": "Try again",
@@ -251,9 +259,18 @@
       "removeComplete": "Remove complete catalog",
       "removeAll": "Remove all offline visuals"
     },
-    "estimate": { "title": "Scryfall snapshot scan" },
+    "estimate": {
+      "title": "Scryfall snapshot scan",
+      "progressTitle": "Catalog scan progress",
+      "curatedTitle": "Download estimate",
+      "headroomWarning": "This is larger than the free space this browser reports. You can still install it — if space runs out the download can be resumed, and it keeps everything already saved.",
+      "evictionWarning": "This browser has not granted persistent storage, so it may delete these images when the device runs low on space.",
+      "progress": "{{downloaded}} MB of {{total}} MB read · {{records}} cards scanned · {{images}} images found"
+    },
     "metrics": {
       "assetRecords": "Image records",
+      "estimatedImageBytes": "Estimated download size",
+      "availableBytes": "Free space available",
       "uniqueObjects": "Images to download",
       "logicalImageBytes": "Image bytes (known after download)",
       "uniqueImageBytes": "Unique image bytes (known after download)",
@@ -267,6 +284,7 @@
         "cancel_requested": "Cancellation requested",
         "finalizing": "Finalizing",
         "failed": "Failed — ready to resume",
+        "terminated": "Stopped — this operation cannot be resumed",
         "completed": "Completed",
         "cancelled": "Cancelled"
       },
@@ -275,6 +293,7 @@
       "packs": "Packs: {{current}} of {{total}}",
       "objects": "Images: {{current}} of {{total}}",
       "scanNote": "The total grows as the Scryfall snapshot is scanned. Completed images are stored locally and skipped when you resume.",
+      "estimateNote": "The total was fixed when this download started. Completed images are stored locally and skipped when you resume.",
       "finalizing": "Finalizing offline image installation"
     },
     "status": {
@@ -287,7 +306,15 @@
       "installed": "Installed packs",
       "noneInstalled": "No visual packs are installed.",
       "upgradeAvailable": "Upgrade available"
-      ,"receiptRoot": "Installed from snapshot: {{root}}"
+      ,"receiptRoot": "Installed from snapshot: {{root}}",
+      "membershipDigest": "Membership fingerprint: {{digest}}",
+      "storageUsage": "Storage used by this site",
+      "persistence": "Eviction protection",
+      "persistenceState": {
+        "persisted": "Granted — this browser will keep these images",
+        "best_effort": "Not granted — this browser may delete these images when the device runs low on space",
+        "unsupported": "This browser will not say"
+      }
     },
     "verification": {
       "revision": "Verified installed revision {{revision}}.",
@@ -312,15 +339,23 @@
       "remove_failed": "A cache file could not be removed",
       "catalog_state": "Historical catalog state could not be reclaimed"
     },
+    "packs": {
+      "core": "Card back",
+      "complete": "All current English card images",
+      "curated": "One image per card",
+      "printing": "{{set}} printings",
+      "locale": "{{set}} printings ({{language}})"
+    },
     "errors": {
       "unsupported_shell": "This app version does not support offline visual catalogs.",
       "unauthorized": "This window is not allowed to manage offline visual catalogs.",
       "unavailable": "Offline image downloads are unavailable in this browser.",
       "invalid_input": "The requested catalog selection is invalid.",
-      "conflict": "Installed packs depend on this selection.",
+      "conflict": "This selection is out of date: the catalog or your art preferences changed after it was made. Estimate it again, then retry.",
       "cancelled": "The operation was cancelled.",
       "network": "The Scryfall catalog or image download failed.",
       "storage": "The catalog could not be written to device storage.",
+      "insufficient_storage": "Not enough free space: this download needs at least {{required}}, and only {{available}} is free.",
       "trust": "The downloaded image could not be verified locally.",
       "emit": "The app could not report catalog progress.",
       "internal": "The catalog operation could not be completed."

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -225,6 +225,11 @@
       "printing": "Impresiones en inglés",
       "locale": "Impresiones de conjuntos localizados",
       "complete": "Todas las imágenes actuales de cartas en inglés",
+      "curated": "Una imagen por carta",
+      "curatedNote": "Una imagen por carta, elegida por tus Preferencias de ilustración de cartas en la pestaña Visual. Si las cambias allí, esta selección las sigue.",
+      "curatedDefaultNote": "Una imagen por carta. No tienes reglas de ilustración, así que se descarga la ilustración predeterminada de cada carta: añade reglas en Preferencias de ilustración de cartas, en la pestaña Visual, para elegir otras ediciones.",
+      "driftNone": "Tus imágenes instaladas ya coinciden con estos ajustes.",
+      "driftSummary": "Tus imágenes instaladas están desactualizadas: {{add}} por añadir, {{remove}} por quitar, {{refresh}} por actualizar.",
       "setCode": "Código de colección",
       "setPlaceholder": "por ej. fin",
       "language": "Idioma de la imagen",
@@ -234,7 +239,10 @@
     "actions": {
       "estimate": "Descarga de presupuesto",
       "estimating": "Analizando el catálogo de Scryfall…",
+      "estimateCurated": "Recalcular tamaño",
+      "estimatingCurated": "Calculando el tamaño…",
       "install": "Instalar selección",
+      "sync": "Sincronizar imágenes",
       "cancel": "Cancelar operación",
       "resume": "Reanudar operación",
       "retry": "Inténtalo de nuevo",
@@ -248,11 +256,18 @@
       "removeAll": "Eliminar todos los elementos visuales sin conexión"
     },
     "estimate": {
-      "title": "Análisis de la instantánea de Scryfall"
+      "title": "Análisis de la instantánea de Scryfall",
+      "progressTitle": "Progreso del análisis del catálogo",
+      "curatedTitle": "Descarga estimada",
+      "headroomWarning": "Esto supera el espacio libre que informa este navegador. Aun así puedes instalarlo: si se queda sin espacio, la descarga puede reanudarse y conserva todo lo ya guardado.",
+      "evictionWarning": "Este navegador no ha concedido almacenamiento persistente, por lo que puede borrar estas imágenes cuando al dispositivo le quede poco espacio.",
+      "progress": "{{downloaded}} MB de {{total}} MB leídos · {{records}} cartas analizadas · {{images}} imágenes encontradas"
     },
     "metrics": {
       "assetRecords": "Registros de activos",
-      "uniqueObjects": "Objetos únicos",
+      "estimatedImageBytes": "Tamaño estimado de descarga",
+      "availableBytes": "Espacio libre disponible",
+      "uniqueObjects": "Imágenes por descargar",
       "logicalImageBytes": "Bytes de imagen lógica",
       "uniqueImageBytes": "Bytes de imagen únicos",
       "shardCount": "fragmentos",
@@ -265,6 +280,7 @@
         "cancel_requested": "Cancelación solicitada",
         "finalizing": "Finalizando",
         "failed": "Error: listo para reanudar",
+        "terminated": "Detenido: esta operación no se puede reanudar",
         "completed": "Completado",
         "cancelled": "Cancelado"
       },
@@ -273,6 +289,7 @@
       "packs": "Paquetes: {{current}} de {{total}}",
       "objects": "Imágenes: {{current}} de {{total}}",
       "scanNote": "El total aumenta mientras se analiza la instantánea de Scryfall. Las imágenes ya descargadas permanecen locales y se omiten al reanudar.",
+      "estimateNote": "El total quedó fijado al iniciar esta descarga. Las imágenes ya descargadas permanecen locales y se omiten al reanudar.",
       "finalizing": "Finalizando la instalación del catálogo"
     },
     "status": {
@@ -285,7 +302,15 @@
       "installed": "Paquetes instalados",
       "noneInstalled": "No hay paquetes visuales instalados.",
       "upgradeAvailable": "Actualización disponible",
-      "receiptRoot": "Raíz del recibo: {{root}}"
+      "receiptRoot": "Instalado desde la instantánea: {{root}}",
+      "membershipDigest": "Huella de la selección: {{digest}}",
+      "storageUsage": "Almacenamiento usado por este sitio",
+      "persistence": "Protección contra borrado",
+      "persistenceState": {
+        "persisted": "Concedida: este navegador conservará estas imágenes",
+        "best_effort": "No concedida: este navegador puede borrar estas imágenes cuando quede poco espacio",
+        "unsupported": "Este navegador no lo indica"
+      }
     },
     "verification": {
       "revision": "Revisión instalada verificada {{revision}}.",
@@ -312,15 +337,23 @@
       "remove_failed": "No se pudo eliminar un archivo de caché",
       "catalog_state": "No se pudo recuperar el estado del catálogo histórico"
     },
+    "packs": {
+      "core": "Reverso de carta",
+      "complete": "Todas las imágenes actuales de cartas en inglés",
+      "curated": "Una imagen por carta",
+      "printing": "Impresiones de {{set}}",
+      "locale": "Impresiones de {{set}} ({{language}})"
+    },
     "errors": {
       "unsupported_shell": "Esta versión de la aplicación no admite catálogos visuales sin conexión.",
       "unauthorized": "Esta ventana no puede administrar catálogos visuales sin conexión.",
       "unavailable": "La gestión del catálogo visual sin conexión no está disponible temporalmente.",
       "invalid_input": "La selección de catálogo solicitada no es válida.",
-      "conflict": "Los paquetes instalados dependen de esta selección.",
+      "conflict": "Esta selección está desactualizada: el catálogo o tus preferencias de ilustración cambiaron después de hacerla. Vuelve a calcularla e inténtalo de nuevo.",
       "cancelled": "La operación fue cancelada.",
       "network": "La solicitud de red del catálogo falló.",
       "storage": "El catálogo no se pudo escribir en el almacenamiento del dispositivo.",
+      "insufficient_storage": "No hay espacio suficiente: esta descarga necesita al menos {{required}}, pero solo hay {{available}} libres.",
       "trust": "No se puede confiar en la respuesta del catálogo.",
       "emit": "La aplicación no pudo informar el progreso del catálogo.",
       "internal": "No se pudo completar la operación del catálogo."

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -225,6 +225,11 @@
       "printing": "Impressions de décors anglais",
       "locale": "Impressions de décors localisées",
       "complete": "Catalogue actuel complet",
+      "curated": "Une image par carte",
+      "curatedNote": "Une image par carte, choisie par vos Préférences d'illustration des cartes dans l'onglet Visuel. Modifiez-les là-bas et cette sélection suit.",
+      "curatedDefaultNote": "Une image par carte. Vous n'avez aucune règle d'illustration, donc l'illustration par défaut de chaque carte est téléchargée — ajoutez des règles dans Préférences d'illustration des cartes, onglet Visuel, pour choisir d'autres éditions.",
+      "driftNone": "Vos images installées correspondent déjà à ces réglages.",
+      "driftSummary": "Vos images installées ne sont plus à jour : {{add}} à ajouter, {{remove}} à retirer, {{refresh}} à actualiser.",
       "setCode": "Définir le code",
       "setPlaceholder": "par ex. aileron",
       "language": "Langage des images",
@@ -234,7 +239,10 @@
     "actions": {
       "estimate": "Téléchargement de devis",
       "estimating": "Analyse du catalogue Scryfall…",
+      "estimateCurated": "Recalculer la taille",
+      "estimatingCurated": "Calcul de la taille…",
       "install": "Sélection d'installation",
+      "sync": "Synchroniser les images",
       "cancel": "Annuler l'opération",
       "resume": "Reprendre l'opération",
       "retry": "Réessayez",
@@ -248,11 +256,18 @@
       "removeAll": "Supprimer tous les visuels hors ligne"
     },
     "estimate": {
-      "title": "Estimation backend et fermeture des dépendances"
+      "title": "Estimation backend et fermeture des dépendances",
+      "progressTitle": "Progression de l’analyse du catalogue",
+      "curatedTitle": "Téléchargement estimé",
+      "headroomWarning": "C'est plus que l'espace libre annoncé par ce navigateur. Vous pouvez tout de même installer : si l'espace vient à manquer, le téléchargement peut reprendre et conserve tout ce qui est déjà enregistré.",
+      "evictionWarning": "Ce navigateur n'a pas accordé de stockage persistant : il peut supprimer ces images lorsque l'appareil manque d'espace.",
+      "progress": "{{downloaded}} Mo sur {{total}} Mo lus · {{records}} cartes analysées · {{images}} images trouvées"
     },
     "metrics": {
       "assetRecords": "Enregistrements d'actifs",
-      "uniqueObjects": "Objets uniques",
+      "estimatedImageBytes": "Taille estimée du téléchargement",
+      "availableBytes": "Espace libre disponible",
+      "uniqueObjects": "Images à télécharger",
       "logicalImageBytes": "Octets d'image logique",
       "uniqueImageBytes": "Octets d'image uniques",
       "shardCount": "Éclats",
@@ -265,6 +280,7 @@
         "cancel_requested": "Annulation demandée",
         "finalizing": "Finalisation",
         "failed": "Échec – prêt à reprendre",
+        "terminated": "Arrêté – cette opération ne peut pas reprendre",
         "completed": "Terminé",
         "cancelled": "Annulé"
       },
@@ -273,6 +289,7 @@
       "packs": "Packs : {{current}} sur {{total}}",
       "objects": "Images : {{current}} sur {{total}}",
       "scanNote": "Le total augmente pendant l’analyse de l’instantané Scryfall. Les images déjà téléchargées restent locales et sont ignorées à la reprise.",
+      "estimateNote": "Le total a été fixé au démarrage de ce téléchargement. Les images déjà téléchargées restent locales et sont ignorées à la reprise.",
       "finalizing": "Finalisation de l'installation du catalogue"
     },
     "status": {
@@ -285,7 +302,15 @@
       "installed": "Packs installés",
       "noneInstalled": "Aucun pack visuel n’est installé.",
       "upgradeAvailable": "Mise à niveau disponible",
-      "receiptRoot": "Racine du reçu : {{root}}"
+      "receiptRoot": "Installé depuis l'instantané : {{root}}",
+      "membershipDigest": "Empreinte de la sélection : {{digest}}",
+      "storageUsage": "Stockage utilisé par ce site",
+      "persistence": "Protection contre l'effacement",
+      "persistenceState": {
+        "persisted": "Accordée – ce navigateur conservera ces images",
+        "best_effort": "Non accordée – ce navigateur peut supprimer ces images lorsque l'espace vient à manquer",
+        "unsupported": "Ce navigateur ne le précise pas"
+      }
     },
     "verification": {
       "revision": "Révision installée vérifiée {{revision}}.",
@@ -312,15 +337,23 @@
       "remove_failed": "Un fichier cache n'a pas pu être supprimé",
       "catalog_state": "L'état du catalogue historique n'a pas pu être récupéré"
     },
+    "packs": {
+      "core": "Visuels de base",
+      "complete": "Catalogue actuel complet",
+      "curated": "Une image par carte",
+      "printing": "Éditions {{set}}",
+      "locale": "Éditions {{set}} ({{language}})"
+    },
     "errors": {
       "unsupported_shell": "Cette version de l'application ne prend pas en charge les catalogues visuels hors ligne.",
       "unauthorized": "Cette fenêtre n'est pas autorisée à gérer les catalogues visuels hors ligne.",
       "unavailable": "La gestion visuelle du catalogue hors ligne est temporairement indisponible.",
       "invalid_input": "La sélection de catalogue demandée n'est pas valide.",
-      "conflict": "Les packs installés dépendent de cette sélection.",
+      "conflict": "Cette sélection n'est plus à jour : le catalogue ou vos préférences d'illustration ont changé depuis. Refaites l'estimation, puis réessayez.",
       "cancelled": "L'opération a été annulée.",
       "network": "La demande de réseau de catalogue a échoué.",
       "storage": "Le catalogue n'a pas pu être écrit sur le stockage de l'appareil.",
+      "insufficient_storage": "Espace libre insuffisant : ce téléchargement nécessite au moins {{required}}, mais il ne reste que {{available}}.",
       "trust": "La réponse du catalogue n'était pas fiable.",
       "emit": "L'application n'a pas pu signaler la progression du catalogue.",
       "internal": "L'opération de catalogue n'a pas pu être terminée."

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -225,6 +225,11 @@
       "printing": "Stampe inglesi",
       "locale": "Stampe di set localizzate",
       "complete": "Tutte le immagini attuali delle carte inglesi",
+      "curated": "Un'immagine per carta",
+      "curatedNote": "Un'immagine per carta, scelta dalle tue Preferenze illustrazione carte nella scheda Grafica. Modificale lì e questa selezione le segue.",
+      "curatedDefaultNote": "Un'immagine per carta. Non hai regole di illustrazione, quindi viene scaricata l'illustrazione predefinita di ogni carta: aggiungi regole in Preferenze illustrazione carte, scheda Grafica, per scegliere altre stampe.",
+      "driftNone": "Le immagini installate corrispondono già a queste impostazioni.",
+      "driftSummary": "Le immagini installate non sono aggiornate: {{add}} da aggiungere, {{remove}} da rimuovere, {{refresh}} da aggiornare.",
       "setCode": "Codice del set",
       "setPlaceholder": "ad es. fin",
       "language": "Linguaggio dell'immagine",
@@ -234,7 +239,10 @@
     "actions": {
       "estimate": "Scarica preventivo",
       "estimating": "Scansione del catalogo Scryfall…",
+      "estimateCurated": "Ricalcola dimensione",
+      "estimatingCurated": "Calcolo della dimensione…",
       "install": "Installa la selezione",
+      "sync": "Sincronizza le immagini",
       "cancel": "Annulla l'operazione",
       "resume": "Riprendere l'operazione",
       "retry": "Riprova",
@@ -248,11 +256,18 @@
       "removeAll": "Rimuovi tutti gli elementi visivi offline"
     },
     "estimate": {
-      "title": "Analisi dell'istantanea di Scryfall"
+      "title": "Analisi dell'istantanea di Scryfall",
+      "progressTitle": "Avanzamento della scansione del catalogo",
+      "curatedTitle": "Download stimato",
+      "headroomWarning": "È più dello spazio libero segnalato da questo browser. Puoi comunque installarlo: se lo spazio finisce, il download può essere ripreso e conserva tutto ciò che è già stato salvato.",
+      "evictionWarning": "Questo browser non ha concesso l'archiviazione persistente, quindi può eliminare queste immagini quando il dispositivo esaurisce lo spazio.",
+      "progress": "{{downloaded}} MB di {{total}} MB letti · {{records}} carte analizzate · {{images}} immagini trovate"
     },
     "metrics": {
       "assetRecords": "Registri patrimoniali",
-      "uniqueObjects": "Oggetti unici",
+      "estimatedImageBytes": "Dimensione stimata del download",
+      "availableBytes": "Spazio libero disponibile",
+      "uniqueObjects": "Immagini da scaricare",
       "logicalImageBytes": "Byte di immagine logici",
       "uniqueImageBytes": "Byte di immagine univoci",
       "shardCount": "Frammenti",
@@ -265,6 +280,7 @@
         "cancel_requested": "Richiesta cancellazione",
         "finalizing": "Finalizzazione",
         "failed": "Non riuscito: pronto per riprendere",
+        "terminated": "Interrotto: questa operazione non può essere ripresa",
         "completed": "Completato",
         "cancelled": "Annullato"
       },
@@ -273,6 +289,7 @@
       "packs": "Pacchetti: {{current}} di {{total}}",
       "objects": "Immagini: {{current}} di {{total}}",
       "scanNote": "Il totale cresce durante la scansione dell’istantanea Scryfall. Le immagini già scaricate restano locali e vengono ignorate alla ripresa.",
+      "estimateNote": "Il totale è stato fissato all’avvio di questo download. Le immagini già scaricate restano locali e vengono ignorate alla ripresa.",
       "finalizing": "Finalizzazione dell'installazione del catalogo"
     },
     "status": {
@@ -285,7 +302,15 @@
       "installed": "Pacchetti installati",
       "noneInstalled": "Nessun pacchetto visivo è installato.",
       "upgradeAvailable": "Aggiornamento disponibile",
-      "receiptRoot": "Radice della ricevuta: {{root}}"
+      "receiptRoot": "Installato dallo snapshot: {{root}}",
+      "membershipDigest": "Impronta della selezione: {{digest}}",
+      "storageUsage": "Spazio usato da questo sito",
+      "persistence": "Protezione dalla cancellazione",
+      "persistenceState": {
+        "persisted": "Concessa: questo browser conserverà queste immagini",
+        "best_effort": "Non concessa: questo browser può eliminare queste immagini quando lo spazio scarseggia",
+        "unsupported": "Questo browser non lo dichiara"
+      }
     },
     "verification": {
       "revision": "Revisione installata verificata {{revision}}.",
@@ -312,15 +337,23 @@
       "remove_failed": "Impossibile rimuovere un file di cache",
       "catalog_state": "Impossibile recuperare lo stato del catalogo storico"
     },
+    "packs": {
+      "core": "Retro della carta",
+      "complete": "Tutte le immagini attuali delle carte inglesi",
+      "curated": "Un'immagine per carta",
+      "printing": "Stampe {{set}}",
+      "locale": "Stampe {{set}} ({{language}})"
+    },
     "errors": {
       "unsupported_shell": "Questa versione dell'app non supporta i cataloghi visivi offline.",
       "unauthorized": "Questa finestra non è autorizzata a gestire cataloghi visivi offline.",
       "unavailable": "La gestione del catalogo visivo offline è temporaneamente non disponibile.",
       "invalid_input": "La selezione del catalogo richiesta non è valida.",
-      "conflict": "I pacchetti installati dipendono da questa selezione.",
+      "conflict": "Questa selezione non è aggiornata: il catalogo o le tue preferenze di illustrazione sono cambiati da allora. Ricalcola la stima e riprova.",
       "cancelled": "L'operazione è stata annullata.",
       "network": "La richiesta della rete del catalogo non è riuscita.",
       "storage": "Non è stato possibile scrivere il catalogo nella memoria del dispositivo.",
+      "insufficient_storage": "Spazio libero insufficiente: questo download richiede almeno {{required}}, ma sono liberi solo {{available}}.",
       "trust": "Non è possibile considerare attendibile la risposta del catalogo.",
       "emit": "L'app non è riuscita a segnalare l'avanzamento del catalogo.",
       "internal": "Impossibile completare l'operazione del catalogo."

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -225,6 +225,11 @@
       "printing": "Nadruki zestawów angielskich",
       "locale": "Zlokalizowane wydruki setów",
       "complete": "Uzupełnij aktualny katalog",
+      "curated": "Jeden obraz na kartę",
+      "curatedNote": "Jeden obraz na kartę, wybrany według twoich Preferencji grafiki kart w zakładce Grafika. Zmień je tam, a ten wybór podąży za nimi.",
+      "curatedDefaultNote": "Jeden obraz na kartę. Nie masz żadnych reguł grafiki, więc pobierana jest domyślna grafika każdej karty — dodaj reguły w Preferencjach grafiki kart w zakładce Grafika, aby wybrać inne wydania.",
+      "driftNone": "Zainstalowane obrazy już odpowiadają tym ustawieniom.",
+      "driftSummary": "Zainstalowane obrazy są nieaktualne: {{add}} do dodania, {{remove}} do usunięcia, {{refresh}} do odświeżenia.",
       "setCode": "Ustaw kod",
       "setPlaceholder": "np. płetwa",
       "language": "Język obrazu",
@@ -234,7 +239,10 @@
     "actions": {
       "estimate": "Oszacuj pobranie",
       "estimating": "Skanowanie katalogu Scryfall…",
+      "estimateCurated": "Przelicz rozmiar",
+      "estimatingCurated": "Obliczanie rozmiaru…",
       "install": "Zainstaluj wybór",
+      "sync": "Synchronizuj obrazy",
       "cancel": "Anuluj operację",
       "resume": "Wznów działanie",
       "retry": "Spróbuj ponownie",
@@ -248,11 +256,18 @@
       "removeAll": "Usuń wszystkie wizualizacje offline"
     },
     "estimate": {
-      "title": "Oszacowanie zaplecza i zamknięcie zależności"
+      "title": "Oszacowanie zaplecza i zamknięcie zależności",
+      "progressTitle": "Postęp skanowania katalogu",
+      "curatedTitle": "Szacowane pobieranie",
+      "headroomWarning": "To więcej niż wolne miejsce zgłaszane przez tę przeglądarkę. Nadal możesz zainstalować — jeśli miejsca zabraknie, pobieranie można wznowić i zachowuje wszystko, co już zapisano.",
+      "evictionWarning": "Ta przeglądarka nie przyznała trwałego magazynu, więc może usunąć te obrazy, gdy na urządzeniu zabraknie miejsca.",
+      "progress": "Odczytano {{downloaded}} MB z {{total}} MB · przeskanowano {{records}} kart · znaleziono {{images}} obrazów"
     },
     "metrics": {
       "assetRecords": "Zapisy majątku",
-      "uniqueObjects": "Unikalne obiekty",
+      "estimatedImageBytes": "Szacowany rozmiar pobierania",
+      "availableBytes": "Dostępne wolne miejsce",
+      "uniqueObjects": "Obrazy do pobrania",
       "logicalImageBytes": "Bajty obrazu logicznego",
       "uniqueImageBytes": "Unikalne bajty obrazu",
       "shardCount": "Odłamki",
@@ -265,6 +280,7 @@
         "cancel_requested": "Zażądano anulowania",
         "finalizing": "Finalizowanie",
         "failed": "Niepowodzenie — można wznowić",
+        "terminated": "Zatrzymano — tej operacji nie można wznowić",
         "completed": "Ukończono",
         "cancelled": "Anulowano"
       },
@@ -273,6 +289,7 @@
       "packs": "Pakiety: {{current}} z {{total}}",
       "objects": "Obrazy: {{current}} z {{total}}",
       "scanNote": "Łączna liczba rośnie podczas skanowania migawki Scryfall. Pobrane obrazy pozostają lokalnie i są pomijane po wznowieniu.",
+      "estimateNote": "Łączna liczba została ustalona przy starcie tego pobierania. Pobrane obrazy pozostają lokalnie i są pomijane po wznowieniu.",
       "finalizing": "Kończenie instalacji katalogu"
     },
     "status": {
@@ -285,7 +302,15 @@
       "installed": "Zainstalowane pakiety",
       "noneInstalled": "Nie są zainstalowane żadne pakiety wizualne.",
       "upgradeAvailable": "Dostępna aktualizacja",
-      "receiptRoot": "Katalog główny paragonu: {{root}}"
+      "receiptRoot": "Zainstalowano z migawki: {{root}}",
+      "membershipDigest": "Odcisk zestawu: {{digest}}",
+      "storageUsage": "Pamięć zajęta przez tę witrynę",
+      "persistence": "Ochrona przed usunięciem",
+      "persistenceState": {
+        "persisted": "Przyznana — ta przeglądarka zachowa te obrazy",
+        "best_effort": "Nieprzyznana — ta przeglądarka może usunąć te obrazy, gdy zabraknie miejsca",
+        "unsupported": "Ta przeglądarka tego nie podaje"
+      }
     },
     "verification": {
       "revision": "Zweryfikowano zainstalowaną wersję {{revision}}.",
@@ -312,15 +337,23 @@
       "remove_failed": "Nie można usunąć pliku pamięci podręcznej",
       "catalog_state": "Nie udało się odzyskać historycznego stanu katalogu"
     },
+    "packs": {
+      "core": "Podstawowe wizualizacje",
+      "complete": "Uzupełnij aktualny katalog",
+      "curated": "Jeden obraz na kartę",
+      "printing": "Wydania {{set}}",
+      "locale": "Wydania {{set}} ({{language}})"
+    },
     "errors": {
       "unsupported_shell": "Ta wersja aplikacji nie obsługuje katalogów wizualnych offline.",
       "unauthorized": "W tym oknie nie można zarządzać katalogami wizualnymi offline.",
       "unavailable": "Wizualne zarządzanie katalogiem w trybie offline jest tymczasowo niedostępne.",
       "invalid_input": "Żądany wybór katalogu jest nieprawidłowy.",
-      "conflict": "Zainstalowane pakiety zależą od tego wyboru.",
+      "conflict": "Ten wybór jest nieaktualny: katalog lub twoje preferencje grafiki zmieniły się od jego dokonania. Oblicz go ponownie i spróbuj jeszcze raz.",
       "cancelled": "Operację odwołano.",
       "network": "Żądanie sieciowe katalogu nie powiodło się.",
       "storage": "Nie można zapisać katalogu w pamięci urządzenia.",
+      "insufficient_storage": "Za mało wolnego miejsca: to pobieranie wymaga co najmniej {{required}}, a wolne jest tylko {{available}}.",
       "trust": "Nie można ufać odpowiedzi katalogu.",
       "emit": "Aplikacja nie mogła zgłosić postępu katalogu.",
       "internal": "Nie można ukończyć operacji na katalogu."

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -225,6 +225,11 @@
       "printing": "Impressões de conjuntos em inglês",
       "locale": "Impressões de conjuntos localizados",
       "complete": "Catálogo atual completo",
+      "curated": "Uma imagem por carta",
+      "curatedNote": "Uma imagem por carta, escolhida pelas suas Preferências de Arte das Cartas na aba Visual. Altere-as lá e esta seleção acompanha.",
+      "curatedDefaultNote": "Uma imagem por carta. Você não tem regras de arte, então a arte padrão de cada carta é baixada — adicione regras em Preferências de Arte das Cartas, na aba Visual, para escolher outras edições.",
+      "driftNone": "As suas imagens instaladas já correspondem a estas definições.",
+      "driftSummary": "As suas imagens instaladas estão desatualizadas: {{add}} a adicionar, {{remove}} a remover, {{refresh}} a atualizar.",
       "setCode": "Definir código",
       "setPlaceholder": "por exemplo barbatana",
       "language": "Linguagem da imagem",
@@ -234,7 +239,10 @@
     "actions": {
       "estimate": "Estimativa de download",
       "estimating": "Analisando o catálogo do Scryfall…",
+      "estimateCurated": "Recalcular tamanho",
+      "estimatingCurated": "Calculando o tamanho…",
       "install": "Seleção de instalação",
+      "sync": "Sincronizar imagens",
       "cancel": "Cancelar operação",
       "resume": "Retomar operação",
       "retry": "Tente novamente",
@@ -248,11 +256,18 @@
       "removeAll": "Remova todos os recursos visuais off-line"
     },
     "estimate": {
-      "title": "Estimativa de back-end e fechamento de dependência"
+      "title": "Estimativa de back-end e fechamento de dependência",
+      "progressTitle": "Progresso da análise do catálogo",
+      "curatedTitle": "Download estimado",
+      "headroomWarning": "Isso é maior que o espaço livre que este navegador informa. Você ainda pode instalar: se o espaço acabar, o download pode ser retomado e mantém tudo o que já foi salvo.",
+      "evictionWarning": "Este navegador não concedeu armazenamento persistente, portanto pode apagar estas imagens quando o dispositivo ficar sem espaço.",
+      "progress": "{{downloaded}} MB de {{total}} MB lidos · {{records}} cartas analisadas · {{images}} imagens encontradas"
     },
     "metrics": {
       "assetRecords": "Registros de ativos",
-      "uniqueObjects": "Objetos únicos",
+      "estimatedImageBytes": "Tamanho estimado do download",
+      "availableBytes": "Espaço livre disponível",
+      "uniqueObjects": "Imagens a transferir",
       "logicalImageBytes": "Bytes de imagem lógica",
       "uniqueImageBytes": "Bytes de imagem exclusivos",
       "shardCount": "Fragmentos",
@@ -265,6 +280,7 @@
         "cancel_requested": "Cancelamento solicitado",
         "finalizing": "Finalizando",
         "failed": "Falha – pronto para retomar",
+        "terminated": "Parado – esta operação não pode ser retomada",
         "completed": "Concluído",
         "cancelled": "Cancelado"
       },
@@ -273,6 +289,7 @@
       "packs": "Pacotes: {{current}} de {{total}}",
       "objects": "Imagens: {{current}} de {{total}}",
       "scanNote": "O total cresce enquanto a captura do Scryfall é analisada. As imagens já baixadas ficam locais e são ignoradas ao retomar.",
+      "estimateNote": "O total foi fixado no início desta transferência. As imagens já baixadas ficam locais e são ignoradas ao retomar.",
       "finalizing": "Finalizando a instalação do catálogo"
     },
     "status": {
@@ -285,7 +302,15 @@
       "installed": "Pacotes instalados",
       "noneInstalled": "Nenhum pacote visual está instalado.",
       "upgradeAvailable": "Atualização disponível",
-      "receiptRoot": "Raiz do recibo: {{root}}"
+      "receiptRoot": "Instalado a partir do instantâneo: {{root}}",
+      "membershipDigest": "Impressão digital da seleção: {{digest}}",
+      "storageUsage": "Armazenamento usado por este site",
+      "persistence": "Proteção contra remoção",
+      "persistenceState": {
+        "persisted": "Concedida — este navegador manterá estas imagens",
+        "best_effort": "Não concedida — este navegador pode apagar estas imagens quando faltar espaço",
+        "unsupported": "Este navegador não informa"
+      }
     },
     "verification": {
       "revision": "Revisão instalada verificada {{revision}}.",
@@ -312,15 +337,23 @@
       "remove_failed": "Não foi possível remover um arquivo de cache",
       "catalog_state": "O estado do catálogo histórico não pôde ser recuperado"
     },
+    "packs": {
+      "core": "Visuais principais",
+      "complete": "Catálogo atual completo",
+      "curated": "Uma imagem por carta",
+      "printing": "Impressões {{set}}",
+      "locale": "Impressões {{set}} ({{language}})"
+    },
     "errors": {
       "unsupported_shell": "Esta versão do aplicativo não oferece suporte a catálogos visuais offline.",
       "unauthorized": "Esta janela não tem permissão para gerenciar catálogos visuais offline.",
       "unavailable": "O gerenciamento offline do catálogo visual está temporariamente indisponível.",
       "invalid_input": "A seleção de catálogo solicitada é inválida.",
-      "conflict": "Os pacotes instalados dependem desta seleção.",
+      "conflict": "Esta seleção está desatualizada: o catálogo ou as suas preferências de arte mudaram depois de ela ser feita. Calcule novamente e tente outra vez.",
       "cancelled": "A operação foi cancelada.",
       "network": "A solicitação de rede do catálogo falhou.",
       "storage": "Não foi possível gravar o catálogo no armazenamento do dispositivo.",
+      "insufficient_storage": "Espaço livre insuficiente: este download precisa de pelo menos {{required}}, mas há apenas {{available}} livres.",
       "trust": "A resposta do catálogo não era confiável.",
       "emit": "O aplicativo não pôde relatar o progresso do catálogo.",
       "internal": "A operação de catálogo não pôde ser concluída."

--- a/client/src/services/__tests__/artSelection.test.ts
+++ b/client/src/services/__tests__/artSelection.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from "vitest";
+
+import { applyChain, selectedPrinting } from "../artSelection.ts";
+import type { PrintingEntry } from "../scryfall.ts";
+import type { ArtChainEntry, CardArtOverride } from "../../stores/preferencesStore.ts";
+
+function printing(fields: Partial<PrintingEntry> & { id: string; set: string }): PrintingEntry {
+  return {
+    set_name: fields.set.toUpperCase(),
+    collector_number: "1",
+    released_at: "2020-01-01",
+    border_color: "black",
+    frame_effects: [],
+    full_art: false,
+    faces: [{ normal: `https://img.example/${fields.id}.jpg`, art_crop: `https://img.example/${fields.id}-art.jpg` }],
+    ...fields,
+  };
+}
+
+// Deliberately not sorted by release date: `newest` is defined as the catalog's
+// own first entry, while `oldest` re-sorts by `released_at`, so a fixture where
+// those disagree is the only one that can tell them apart.
+const NEWEST = printing({ id: "dmu", set: "dmu", collector_number: "137", released_at: "2022-09-09" });
+const BORDERLESS = printing({
+  id: "sld",
+  set: "sld",
+  border_color: "borderless",
+  released_at: "2021-06-01",
+});
+const EXTENDED = printing({
+  id: "znr",
+  set: "znr",
+  collector_number: "42",
+  frame_effects: ["extendedart"],
+  released_at: "2020-09-25",
+});
+const PRINTINGS = [NEWEST, BORDERLESS, EXTENDED];
+
+const NO_OVERRIDES: Record<string, CardArtOverride> = {};
+
+describe("applyChain", () => {
+  it("returns null when the card has no printings at all", () => {
+    expect(applyChain([{ type: "newest" }], [])).toBeNull();
+  });
+
+  it("resolves a set entry to that set's printing", () => {
+    expect(applyChain([{ type: "set", setCode: "znr", label: "Zendikar Rising" }], PRINTINGS))
+      .toBe(EXTENDED);
+  });
+
+  it("resolves a newest entry to the catalog's first printing", () => {
+    expect(applyChain([{ type: "newest" }], PRINTINGS)).toBe(NEWEST);
+  });
+
+  it("resolves an oldest entry by release date, not catalog order", () => {
+    expect(applyChain([{ type: "oldest" }], PRINTINGS)).toBe(EXTENDED);
+  });
+
+  it("resolves a prefer_borderless entry to the borderless printing", () => {
+    expect(applyChain([{ type: "prefer_borderless" }], PRINTINGS)).toBe(BORDERLESS);
+  });
+
+  it("resolves a prefer_extended entry to the extended-art printing", () => {
+    expect(applyChain([{ type: "prefer_extended" }], PRINTINGS)).toBe(EXTENDED);
+  });
+
+  it("resolves a source_printing entry to the deck's set and collector number", () => {
+    expect(applyChain([{ type: "source_printing" }], PRINTINGS, { setCode: "DMU", collectorNumber: "137" }))
+      .toBe(NEWEST);
+  });
+
+  it("matches a source_printing entry on the collector number, not the set alone", () => {
+    expect(applyChain([{ type: "source_printing" }], PRINTINGS, { setCode: "DMU", collectorNumber: "999" }))
+      .toBeNull();
+  });
+
+  it("skips a source_printing entry when the caller supplied no source", () => {
+    expect(applyChain([{ type: "source_printing" }, { type: "newest" }], PRINTINGS)).toBe(NEWEST);
+  });
+
+  it("walks past entries that match nothing and applies the first that does", () => {
+    const chain: ArtChainEntry[] = [
+      { type: "set", setCode: "zzz", label: "Nonexistent Set" },
+      { type: "prefer_borderless" },
+      { type: "newest" },
+    ];
+    expect(applyChain(chain, PRINTINGS)).toBe(BORDERLESS);
+  });
+
+  it("returns null when no entry in the chain matches", () => {
+    const chain: ArtChainEntry[] = [
+      { type: "set", setCode: "zzz", label: "Nonexistent Set" },
+      { type: "prefer_extended" },
+    ];
+    expect(applyChain(chain, [NEWEST, BORDERLESS])).toBeNull();
+  });
+});
+
+describe("selectedPrinting", () => {
+  it("prefers a per-card art override over the chain", () => {
+    const overrides = { bolt: { scryfallId: "znr", setCode: "znr", collectorNumber: "42" } };
+    expect(selectedPrinting("bolt", PRINTINGS, [{ type: "newest" }], overrides)).toBe(EXTENDED);
+  });
+
+  // A pinned printing becomes unresolvable the moment the printings data is
+  // regenerated without that scryfallId — not an exotic case. The hook's
+  // `else if (artOverrides[oracleId])` gate fires on key PRESENCE, so the stale
+  // pin consumes the branch and never falls through to the chain.
+  const STALE_OVERRIDE = {
+    bolt: { scryfallId: "not-a-printing", setCode: "xxx", collectorNumber: "1" },
+  };
+
+  it("stops at an override naming a printing the card does not have", () => {
+    expect(selectedPrinting("bolt", PRINTINGS, [{ type: "newest" }], STALE_OVERRIDE)).toBeNull();
+  });
+
+  // The renderer's async path is handed the source printing whenever the chain
+  // is empty, regardless of whether the override branch was taken — so with a
+  // stale pin and no chain it still displays the deck's printing. A planner
+  // that returned null here would cache the canonical asset and the pack would
+  // not contain what the app actually shows.
+  it("falls back to the deck's source printing when a stale override has no chain behind it", () => {
+    expect(selectedPrinting("bolt", PRINTINGS, [], STALE_OVERRIDE, { setCode: "SLD", collectorNumber: "1" }))
+      .toBe(BORDERLESS);
+  });
+
+  it("ignores the source for a stale override once any chain is configured", () => {
+    // With a non-empty chain the hook passes `undefined` for the source, so the
+    // renderer falls through to canonical art and this must return null.
+    expect(selectedPrinting("bolt", PRINTINGS, [{ type: "newest" }], STALE_OVERRIDE, { setCode: "SLD", collectorNumber: "1" }))
+      .toBeNull();
+  });
+
+  it("returns null for a stale override with neither chain nor source", () => {
+    expect(selectedPrinting("bolt", PRINTINGS, [], STALE_OVERRIDE)).toBeNull();
+  });
+
+  it("ignores an override belonging to a different card", () => {
+    const overrides = { other: { scryfallId: "znr", setCode: "znr", collectorNumber: "42" } };
+    expect(selectedPrinting("bolt", PRINTINGS, [{ type: "newest" }], overrides)).toBe(NEWEST);
+  });
+
+  it("applies the chain when no override applies", () => {
+    expect(selectedPrinting("bolt", PRINTINGS, [{ type: "prefer_borderless" }], NO_OVERRIDES))
+      .toBe(BORDERLESS);
+  });
+
+  it("consumes the source only through a source_printing entry", () => {
+    const source = { setCode: "SLD", collectorNumber: "1" };
+    const withEntry: ArtChainEntry[] = [{ type: "source_printing" }, { type: "newest" }];
+    expect(selectedPrinting("bolt", PRINTINGS, withEntry, NO_OVERRIDES, source)).toBe(BORDERLESS);
+    // A `source_printing` entry is the only reader of `source`, so a chain
+    // without one is unaffected by it and its own first match wins — the deck's
+    // printing must not leak into `newest`, `oldest` or the preference entries.
+    expect(selectedPrinting("bolt", PRINTINGS, [{ type: "newest" }], NO_OVERRIDES, source)).toBe(NEWEST);
+  });
+
+  it("returns null when the chain matches nothing, falling back to canonical art", () => {
+    const chain: ArtChainEntry[] = [{ type: "set", setCode: "zzz", label: "Nonexistent Set" }];
+    expect(selectedPrinting("bolt", PRINTINGS, chain, NO_OVERRIDES)).toBeNull();
+  });
+
+  // Precedence branch 4 — the DEFAULT configuration. An empty chain plus a deck
+  // list's `(SET) NUM` annotation still resolves to the deck's own printing, so
+  // a caller modelling only the chain would disagree with the renderer for
+  // every default-config user.
+  it("resolves the deck's source printing when the chain is empty", () => {
+    expect(selectedPrinting("bolt", PRINTINGS, [], NO_OVERRIDES, { setCode: "SLD", collectorNumber: "1" }))
+      .toBe(BORDERLESS);
+  });
+
+  it("matches the source printing's set code case-insensitively", () => {
+    expect(selectedPrinting("bolt", PRINTINGS, [], NO_OVERRIDES, { setCode: "ZNR", collectorNumber: "42" }))
+      .toBe(EXTENDED);
+  });
+
+  it("returns null when the source printing is not among the card's printings", () => {
+    expect(selectedPrinting("bolt", PRINTINGS, [], NO_OVERRIDES, { setCode: "ZZZ", collectorNumber: "1" }))
+      .toBeNull();
+  });
+
+  it("returns null when no override, no chain and no source apply", () => {
+    expect(selectedPrinting("bolt", PRINTINGS, [], NO_OVERRIDES)).toBeNull();
+  });
+});

--- a/client/src/services/artSelection.ts
+++ b/client/src/services/artSelection.ts
@@ -1,0 +1,103 @@
+import { findPrintingById, pickOldestPrinting } from "./scryfall.ts";
+import type { PrintingEntry } from "./scryfall.ts";
+// Type-only, so no runtime dependency is created from `services/` back into
+// `hooks/`. `services/deckParser.ts` already sources `SourcePrinting` the same
+// way — the interface stays declared next to the hook that consumes it.
+import type { SourcePrinting } from "../hooks/useCardImage.ts";
+import type { ArtChainEntry, CardArtOverride } from "../stores/preferencesStore.ts";
+
+/**
+ * The printing a deck list's `(SET) NUM` annotation names. Set codes are stored
+ * lowercase in `scryfall-printings.json` but arrive uppercase from deck lists.
+ */
+function matchSourcePrinting(
+  printings: PrintingEntry[],
+  source: SourcePrinting,
+): PrintingEntry | null {
+  const setLower = source.setCode.toLowerCase();
+  return printings.find(
+    (p) => p.set === setLower && p.collector_number === source.collectorNumber,
+  ) ?? null;
+}
+
+function applyChainEntry(
+  entry: ArtChainEntry,
+  printings: PrintingEntry[],
+  source?: SourcePrinting,
+): PrintingEntry | null {
+  switch (entry.type) {
+    case "set":
+      return printings.find((p) => p.set === entry.setCode) ?? null;
+    case "newest":
+      return printings[0];
+    case "oldest":
+      return pickOldestPrinting(printings);
+    case "prefer_borderless":
+      return printings.find((p) => p.border_color === "borderless") ?? null;
+    case "prefer_extended":
+      return printings.find((p) => p.frame_effects.includes("extendedart")) ?? null;
+    case "source_printing":
+      return source ? matchSourcePrinting(printings, source) : null;
+  }
+}
+
+/**
+ * Walk the user's ordered art chain and return the first printing an entry
+ * matches, or `null` when no entry matches (including an empty printings list).
+ */
+export function applyChain(
+  chain: ArtChainEntry[],
+  printings: PrintingEntry[],
+  source?: SourcePrinting,
+): PrintingEntry | null {
+  if (printings.length === 0) return null;
+  for (const entry of chain) {
+    const match = applyChainEntry(entry, printings, source);
+    if (match) return match;
+  }
+  return null;
+}
+
+/**
+ * The printing the app will display for this card under stored preferences.
+ *
+ * Single authority for "which printing": `useCardImage` renders what this
+ * decides, so any consumer that needs to know the same answer ahead of render
+ * (a downloader planning which images to cache, for instance) must ask here
+ * rather than re-deriving the rule.
+ *
+ * Models branches 2-4 of `useCardImage`'s precedence. It does NOT model the
+ * `scryfallId` prop (branch 1) — that is a per-render caller argument naming a
+ * printing the UI is already showing, not a stored preference.
+ *
+ * `null` means no stored preference resolves to a printing; the caller falls
+ * back to the canonical `scryfall-data` entry.
+ */
+export function selectedPrinting(
+  oracleId: string,
+  printings: PrintingEntry[],
+  artChain: ArtChainEntry[],
+  artOverrides: Record<string, CardArtOverride>,
+  source?: SourcePrinting,
+): PrintingEntry | null {
+  const override = artOverrides[oracleId];
+  if (override) {
+    const pinned = findPrintingById(printings, override.scryfallId);
+    if (pinned) return pinned;
+    // An override that resolves to nothing does NOT fall through to the chain:
+    // the hook's `else if (artOverrides[oracleId])` gate fires on key presence,
+    // so a stale pin (the printings data was regenerated and that id vanished)
+    // consumes the branch and leaves `overrideUrl` null. What renders next is
+    // decided by the async path, which is handed the source printing only when
+    // the chain is empty — so an empty chain still shows the deck's printing,
+    // while any configured chain falls through to canonical art.
+    return artChain.length === 0 && source ? matchSourcePrinting(printings, source) : null;
+  }
+  // `source` is passed unconditionally: only a `source_printing` entry reads
+  // it, so a chain without one is unaffected. The hook guards this call with
+  // `artChain.some(...)` because there the guard selects between two different
+  // caches, not between two different results.
+  if (artChain.length > 0) return applyChain(artChain, printings, source);
+  if (source) return matchSourcePrinting(printings, source);
+  return null;
+}

--- a/client/src/services/scryfall.ts
+++ b/client/src/services/scryfall.ts
@@ -97,6 +97,51 @@ export function loadPrintingsData(): Promise<PrintingsDataMap | null> {
   return printingsDataPromise;
 }
 
+/**
+ * True when both card-data maps are already in memory, so a caller that needs
+ * them can run without a fetch.
+ *
+ * `scryfall-data.json` is 36,748,238 bytes and `scryfall-printings.json` is
+ * 39,541,979 bytes, and the two loaders above memoize at module scope — so this
+ * is the difference between a free read and a 76 MB download-and-parse. It
+ * exists so a PASSIVE surface can decline to be what triggers that: the
+ * visual-pack panel measures curated drift on mount, and a user who opens
+ * Preferences without having rendered a card must not pay for a measurement
+ * they never asked for.
+ *
+ * WHICH SESSIONS REACH THE RESIDENT STATE, precisely, because the two maps are
+ * NOT loaded together and the conjunction is much narrower than "has drawn a
+ * card":
+ *
+ *  - `scryfall-data.json` is the common one. `fetchCardImageAsset` and
+ *    `fetchCardImageAssetByOracleId` each await `loadScryfallData` and nothing
+ *    else, so any rendered card image has it.
+ *  - `scryfall-printings.json` is reached only on CONDITIONAL paths: the
+ *    placeholder fallback in `resolveImageAssetWithPrintingFallback` (only when
+ *    the resolved art is a placeholder), `resolveStrategyInBackground` in
+ *    `useCardImage` (only inside the `artChain.length > 0` branch), and the
+ *    deck-pinned lookup (only when a `sourcePrinting` is set).
+ *
+ * So a user on the DEFAULT empty art chain, with no overrides and no
+ * `(SET) NUM` annotations in their decks, can play a whole game and still have
+ * the printings map unloaded — and this stays false for the life of the tab.
+ * That user is not exotic; `PackSelector` ships a `curatedDefaultNote` written
+ * for exactly them. For them the drift badge does not appear on mount, and
+ * becomes available only when something else loads printings or when they
+ * select the curated option, which plans a membership and loads both.
+ *
+ * The conjunction is still the right test and must NOT be widened:
+ * `planCuratedPack` needs both maps, so either one missing means measuring
+ * would fetch. Its failure direction is the safe one — it declines to measure
+ * rather than declining to protect.
+ *
+ * Same shape as `isLocaleArtReady`: a synchronous predicate over this module's
+ * own resolved state, doubling as the caller's "do I need to load?" gate.
+ */
+export function isCardDataResident(): boolean {
+  return scryfallDataResolved !== null && printingsDataResolved !== null;
+}
+
 function loadTokenImagesData(): Promise<TokenImagesDataMap | null> {
   if (!tokenImagesDataPromise) {
     tokenImagesDataPromise = fetch(__SCRYFALL_TOKEN_IMAGES_URL__)

--- a/client/src/services/visualPacks/__tests__/curatedMembership.test.ts
+++ b/client/src/services/visualPacks/__tests__/curatedMembership.test.ts
@@ -1,0 +1,586 @@
+import { describe, expect, it } from "vitest";
+
+import type { PrintingEntry } from "../../scryfall.ts";
+import type { ArtChainEntry, CardArtOverride } from "../../../stores/preferencesStore.ts";
+import { cardCandidateGroups, decodeCandidateKey } from "../candidateKeys.ts";
+import { planCuratedMembership } from "../curatedMembership.ts";
+import type { CuratedCardEntry, CuratedMembershipInput } from "../curatedMembership.ts";
+import { packId } from "../types.ts";
+import type { ScryfallAssetDescriptor } from "../browser/descriptors.ts";
+
+// `curated` is not an admissible PackId until the selector lands; the planner
+// takes the pack from its caller, so any existing id exercises it.
+const PACK = packId("complete");
+
+// Oracle ids carry hex LETTERS on purpose: an all-digit UUID makes
+// `.toUpperCase()` a no-op and silently voids every case-folding assertion.
+const BOLT = "11111111-abcd-4111-8111-111111111111";
+const GIANT = "22222222-abcd-4222-8222-222222222222";
+const SOLO = "33333333-abcd-4333-8333-333333333333";
+const SHORT = "55555555-abcd-4555-8555-555555555555";
+const TOKEN_ORACLE = "44444444-abcd-4444-8444-444444444444";
+const BLANK = "66666666-abcd-4666-8666-666666666666";
+
+function url(token: string, size: string): string {
+  return `https://cards.scryfall.io/${size}/front/a/b/${token}.jpg?1`;
+}
+
+function imageFace(token: string) {
+  return { normal: url(token, "normal"), art_crop: url(token, "art_crop") };
+}
+
+function printing(overrides: Partial<PrintingEntry> & Pick<PrintingEntry, "id" | "set">): PrintingEntry {
+  return {
+    set_name: overrides.set.toUpperCase(),
+    collector_number: "1",
+    released_at: "2020-01-01",
+    border_color: "black",
+    frame_effects: [],
+    full_art: false,
+    faces: [imageFace(overrides.id)],
+    ...overrides,
+  };
+}
+
+const BOLT_NEW = printing({ id: "aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", set: "m20", released_at: "2019-07-12" });
+const BOLT_OLD = printing({ id: "bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", set: "lea", released_at: "1993-08-05", collector_number: "161" });
+// Two-faced, so the planner's pairing of entry-sourced face NAMES with
+// printing-sourced face IMAGES is exercised on the exact_printing path.
+const GIANT_NEW = printing({
+  id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+  set: "m21",
+  released_at: "2020-07-03",
+  faces: [imageFace("giant-p0"), imageFace("giant-p1")],
+});
+
+function cardEntry(
+  oracleId: string,
+  name: string,
+  faceNames: string[],
+  faces?: CuratedCardEntry["faces"],
+): CuratedCardEntry {
+  return {
+    oracle_id: oracleId,
+    name,
+    face_names: faceNames,
+    faces: faces ?? faceNames.map((_, index) => imageFace(`${oracleId}-${index}`)),
+  };
+}
+
+const BOLT_ENTRY = cardEntry(BOLT, "Lightning Bolt", ["lightning bolt"]);
+const GIANT_ENTRY = cardEntry(GIANT, "Giant Growth", ["giant front", "giant back"]);
+// Absent from PRINTINGS, so it takes the canonical path. Its two faces carry
+// names distinct from each other and from the card name, so an alias built
+// from the wrong one is visible.
+const SOLO_ENTRY = cardEntry(SOLO, "Solo Print", ["solo front", "solo back"]);
+// face_names is SHORTER than faces — real data for a face Scryfall names only
+// on the front — so the fallback to the card name is exercised.
+const SHORT_ENTRY: CuratedCardEntry = {
+  oracle_id: SHORT,
+  name: "Short Names",
+  face_names: ["short front"],
+  faces: [imageFace(`${SHORT}-0`), imageFace(`${SHORT}-1`)],
+};
+// A printing Scryfall has no images for. `gen-scryfall-printings.sh` writes an
+// explicit null for every URL; the declared face type says `string`, which is
+// why the cast is here rather than a defect in the fixture. Measured over
+// client/public/scryfall-printings.json: 696 of the 88,846 stored printings
+// have this shape, every one of them multi-face, and all 696 are null on
+// `art_crop` wherever they are null on `normal`.
+const NO_IMAGE_FACE = { normal: null as unknown as string, art_crop: null as unknown as string };
+const BLANK_UNIMAGED = printing({
+  id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+  set: "sld",
+  released_at: "2021-01-01",
+  faces: [NO_IMAGE_FACE, NO_IMAGE_FACE],
+});
+const BLANK_IMAGED = printing({
+  id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+  set: "m19",
+  released_at: "2018-07-13",
+  faces: [imageFace("blank-p0"), imageFace("blank-p1")],
+});
+// Its scryfall-data.json entry DOES carry images, as all 211 affected cards do
+// (measured, 0 missing), so canonical art is available for exactly this class.
+const BLANK_ENTRY = cardEntry(BLANK, "Blank Print", ["blank front", "blank back"]);
+
+/** Mirrors `scryfall-data.json`: cards are keyed by oracle id AND by one or
+ *  two lowercased name forms, and tokens are keyed under a `token:` prefix. */
+const CARDS: Record<string, CuratedCardEntry> = {
+  [BOLT]: BOLT_ENTRY,
+  "lightning bolt": BOLT_ENTRY,
+  [GIANT]: GIANT_ENTRY,
+  "giant growth": GIANT_ENTRY,
+  "giant front": GIANT_ENTRY,
+  [SOLO]: SOLO_ENTRY,
+  [SHORT]: SHORT_ENTRY,
+  [`token:${TOKEN_ORACLE}`]: cardEntry(TOKEN_ORACLE, "Saproling", ["saproling"]),
+  "token:saproling": cardEntry(TOKEN_ORACLE, "Saproling", ["saproling"]),
+};
+
+const PRINTINGS: Record<string, PrintingEntry[]> = {
+  [BOLT]: [BOLT_NEW, BOLT_OLD],
+  [GIANT]: [GIANT_NEW],
+};
+
+const NEWEST: ArtChainEntry[] = [{ type: "newest" }];
+const EMPTY_CHAIN: ArtChainEntry[] = [];
+const LEA_161 = { setCode: "LEA", collectorNumber: "161" };
+
+function input(overrides: Partial<CuratedMembershipInput> = {}): CuratedMembershipInput {
+  return {
+    packId: PACK,
+    cards: CARDS,
+    printings: PRINTINGS,
+    artChain: NEWEST,
+    artOverrides: {},
+    ...overrides,
+  };
+}
+
+function keysOf(descriptors: readonly ScryfallAssetDescriptor[]): string[] {
+  return descriptors.map((value) => value.assetKey);
+}
+
+function exactPrintingIds(descriptors: readonly ScryfallAssetDescriptor[]): Set<string> {
+  const ids = new Set<string>();
+  for (const value of descriptors) {
+    const match = /^asset:v1:exact_printing:(.{36})-/.exec(value.assetKey);
+    if (match) ids.add(match[1]);
+  }
+  return ids;
+}
+
+function aliasesOf(descriptor: ScryfallAssetDescriptor | undefined): unknown[] {
+  return (descriptor?.candidateKeys ?? [])
+    .map((key) => decodeCandidateKey(key))
+    .filter(([kind]) => kind === "oracle_alias")
+    .map(([, tuple]) => tuple[0]);
+}
+
+describe("planCuratedMembership", () => {
+  it("emits one printing per card across all three rungs", async () => {
+    const { descriptors } = await planCuratedMembership(input());
+
+    // Bolt 1 face + Giant 2 + Solo 2 + Short 2 = 7 faces x 3 rungs.
+    expect(descriptors).toHaveLength(21);
+    expect(exactPrintingIds(descriptors)).toEqual(new Set([BOLT_NEW.id, GIANT_NEW.id]));
+    expect(new Set(keysOf(descriptors))).toHaveLength(21);
+  });
+
+  it("plans each card once per oracle id, not once per map key", async () => {
+    // Deduplicating descriptors by assetKey would hide key-order inflation in
+    // the output, so the rule is measured where it bites: the per-card work.
+    // CARDS keys Lightning Bolt twice and Giant Growth three times, matching
+    // the uneven 1/2/3-keys-per-card shape of the real scryfall-data map.
+    const lookups: string[] = [];
+    const printings = new Proxy(PRINTINGS, {
+      get(target, property) {
+        if (typeof property === "string") lookups.push(property);
+        return target[property as string];
+      },
+    });
+
+    await planCuratedMembership(input({ printings }));
+
+    expect(lookups.filter((id) => id === BOLT)).toHaveLength(1);
+    expect(lookups.filter((id) => id === GIANT)).toHaveLength(1);
+  });
+
+  it("skips token: keys entirely", async () => {
+    const { descriptors } = await planCuratedMembership(input());
+
+    expect(keysOf(descriptors).filter((key) => key.includes(TOKEN_ORACLE))).toEqual([]);
+  });
+
+  it("derives the small rung from normal and emits all three rungs per face", async () => {
+    const { descriptors } = await planCuratedMembership(input());
+    const bolt = descriptors.filter((value) => value.assetKey.includes(BOLT_NEW.id));
+
+    expect(keysOf(bolt).sort()).toEqual([
+      `asset:v1:exact_printing:${BOLT_NEW.id}-0-art_crop-art_crop`,
+      `asset:v1:exact_printing:${BOLT_NEW.id}-0-full_card-normal`,
+      `asset:v1:exact_printing:${BOLT_NEW.id}-0-full_card-small`,
+    ]);
+    expect(bolt.find((value) => value.assetKey.endsWith("small"))?.sourceUrl)
+      .toBe(url(BOLT_NEW.id, "small"));
+  });
+
+  describe("face names", () => {
+    it("aliases each canonical face by its own name, not the card name alone", async () => {
+      const { descriptors } = await planCuratedMembership(input());
+      const back = descriptors.find((value) =>
+        value.assetKey === `asset:v1:canonical_card:${SOLO}-1-full_card-normal`);
+
+      expect(aliasesOf(back)).toEqual(["solo print", "solo back"]);
+    });
+
+    it("pairs entry face names with printing face images on the exact path", async () => {
+      const { descriptors } = await planCuratedMembership(input());
+      const back = descriptors.find((value) =>
+        value.assetKey === `asset:v1:exact_printing:${GIANT_NEW.id}-1-full_card-normal`);
+
+      expect(aliasesOf(back)).toEqual(["giant growth", "giant back"]);
+      expect(back?.sourceUrl).toBe(url("giant-p1", "normal"));
+    });
+
+    it("falls back to the card name for a face beyond the face_names array", async () => {
+      const { descriptors } = await planCuratedMembership(input());
+      const named = descriptors.find((value) =>
+        value.assetKey === `asset:v1:canonical_card:${SHORT}-0-full_card-normal`);
+      const unnamed = descriptors.find((value) =>
+        value.assetKey === `asset:v1:canonical_card:${SHORT}-1-full_card-normal`);
+
+      expect(aliasesOf(named)).toEqual(["short names", "short front"]);
+      expect(aliasesOf(unnamed)).toEqual(["short names"]);
+    });
+  });
+
+  describe("canonical fallback", () => {
+    it("uses the canonical form for a card absent from scryfall-printings.json", async () => {
+      const { descriptors } = await planCuratedMembership(input());
+      const solo = descriptors.filter((value) => value.assetKey.includes(SOLO));
+
+      expect(keysOf(solo).sort()).toEqual([
+        `asset:v1:canonical_card:${SOLO}-0-art_crop-art_crop`,
+        `asset:v1:canonical_card:${SOLO}-0-full_card-normal`,
+        `asset:v1:canonical_card:${SOLO}-0-full_card-small`,
+        `asset:v1:canonical_card:${SOLO}-1-art_crop-art_crop`,
+        `asset:v1:canonical_card:${SOLO}-1-full_card-normal`,
+        `asset:v1:canonical_card:${SOLO}-1-full_card-small`,
+      ]);
+      expect(solo.find((value) => value.assetKey === `asset:v1:canonical_card:${SOLO}-0-full_card-small`)?.sourceUrl)
+        .toBe(url(`${SOLO}-0`, "small"));
+    });
+
+    it("uses the canonical form when the chain yields no winner", async () => {
+      const noWinner: ArtChainEntry[] = [{ type: "set", setCode: "zzz", label: "Nope" }];
+      const { descriptors } = await planCuratedMembership(input({ artChain: noWinner }));
+
+      expect(keysOf(descriptors).filter((key) => key.startsWith("asset:v1:exact_printing:"))).toEqual([]);
+      expect(keysOf(descriptors).sort()).toContain(`asset:v1:canonical_card:${BOLT}-0-full_card-normal`);
+    });
+
+    it("carries only the oracle candidate group — the keys a render with no printing asks for", async () => {
+      const { descriptors } = await planCuratedMembership(input());
+      const solo = descriptors.find((value) =>
+        value.assetKey === `asset:v1:canonical_card:${SOLO}-1-full_card-normal`);
+
+      // `useCardImage` passes an empty englishPrintingId when no stored
+      // preference resolves to a printing, so `cardCandidateGroups` emits the
+      // oracle group alone. The descriptor must carry exactly those keys.
+      expect(solo?.candidateKeys).toEqual(cardCandidateGroups({
+        oracleId: SOLO,
+        oracleAliases: ["Solo Print", "solo back"],
+        faceIndex: 1,
+        variant: "full_card",
+        rung: "normal",
+      }).flatMap((group) => group.keys));
+      expect(solo?.candidateKeys.map((key) => decodeCandidateKey(key)[0]))
+        .toEqual(["oracle", "oracle_alias", "oracle_alias"]);
+    });
+
+    it("never emits both asset forms for one card", async () => {
+      const { descriptors } = await planCuratedMembership(input());
+      const canonical = new Set(keysOf(descriptors)
+        .flatMap((key) => /^asset:v1:canonical_card:(.{36})-/.exec(key)?.[1] ?? []));
+
+      expect(canonical).toEqual(new Set([SOLO, SHORT]));
+      expect(exactPrintingIds(descriptors).has(SOLO)).toBe(false);
+    });
+  });
+
+  describe("a selected printing with no stored images", () => {
+    // MEASURED over client/public/scryfall-printings.json and
+    // scryfall-data.json: 214 oracle ids own at least one printing whose every
+    // face stores null for both `normal` and `art_crop`; 211 of them have NO
+    // renderable printing at all, and all 211 carry an image in
+    // scryfall-data.json. Gating the canonical fallback on "selected no
+    // printings" left those 211 cards contributing ZERO descriptors, while the
+    // renderer falls through to canonical art — the network, in a feature whose
+    // whole purpose is offline play.
+    function blankInput(
+      list: PrintingEntry[],
+      overrides: Partial<CuratedMembershipInput> = {},
+    ): CuratedMembershipInput {
+      return input({
+        cards: { ...CARDS, [BLANK]: BLANK_ENTRY },
+        printings: { ...PRINTINGS, [BLANK]: list },
+        ...overrides,
+      });
+    }
+
+    /** Every key this card contributes, in either asset form. */
+    function blankKeys(descriptors: readonly ScryfallAssetDescriptor[]): string[] {
+      return keysOf(descriptors)
+        .filter((key) => key.includes(BLANK) || key.includes(BLANK_UNIMAGED.id) || key.includes(BLANK_IMAGED.id))
+        .sort();
+    }
+
+    function exactKeys(id: string): string[] {
+      return [
+        `asset:v1:exact_printing:${id}-0-art_crop-art_crop`,
+        `asset:v1:exact_printing:${id}-0-full_card-normal`,
+        `asset:v1:exact_printing:${id}-0-full_card-small`,
+        `asset:v1:exact_printing:${id}-1-art_crop-art_crop`,
+        `asset:v1:exact_printing:${id}-1-full_card-normal`,
+        `asset:v1:exact_printing:${id}-1-full_card-small`,
+      ];
+    }
+
+    it("selects the image-less printing under this chain, so the fixture is reachable", async () => {
+      // The reachability control for the test below. Same printings array, same
+      // preferences, and the index-0 printing's face URLs as the ONLY
+      // difference: the planner emits that printing's own descriptors, so the
+      // chain does select it. A canonical result below is therefore caused by
+      // its missing URLs, not by a fixture the chain never reaches.
+      const imaged = { ...BLANK_UNIMAGED, faces: [imageFace("blank-n0"), imageFace("blank-n1")] };
+      const { descriptors } = await planCuratedMembership(blankInput([imaged, BLANK_IMAGED]));
+
+      expect(blankKeys(descriptors)).toEqual(exactKeys(BLANK_UNIMAGED.id));
+    });
+
+    it("emits the canonical form when every face of the selected printing is null", async () => {
+      const { descriptors } = await planCuratedMembership(blankInput([BLANK_UNIMAGED, BLANK_IMAGED]));
+
+      expect(blankKeys(descriptors)).toEqual([
+        `asset:v1:canonical_card:${BLANK}-0-art_crop-art_crop`,
+        `asset:v1:canonical_card:${BLANK}-0-full_card-normal`,
+        `asset:v1:canonical_card:${BLANK}-0-full_card-small`,
+        `asset:v1:canonical_card:${BLANK}-1-art_crop-art_crop`,
+        `asset:v1:canonical_card:${BLANK}-1-full_card-normal`,
+        `asset:v1:canonical_card:${BLANK}-1-full_card-small`,
+      ]);
+      // The bytes come from the scryfall-data entry, which is what the
+      // renderer's oracle/name path resolves for this card.
+      expect(descriptors.find((value) =>
+        value.assetKey === `asset:v1:canonical_card:${BLANK}-0-full_card-normal`)?.sourceUrl)
+        .toBe(url(`${BLANK}-0`, "normal"));
+    });
+
+    it("keeps the exact form and emits no canonical when the selected printing renders", async () => {
+      // The mixed population — a renderable printing beside the image-less one,
+      // measured at 3 oracle ids. The exclusivity gate must still fire here:
+      // both forms carry this card's oracle-group candidate keys, and
+      // `sortMatches` orders `canonical_card:` first, so a card reachable by
+      // both would render the WRONG art at `sources[0]`.
+      const { descriptors } = await planCuratedMembership(blankInput([BLANK_IMAGED, BLANK_UNIMAGED]));
+
+      expect(blankKeys(descriptors)).toEqual(exactKeys(BLANK_IMAGED.id));
+    });
+
+    it("emits no canonical when only one of two selected printings has images", async () => {
+      // A chain naming `source_printing` selects TWO printings here: the deck's
+      // (image-less) and the chain's fallback (renderable). Descriptors are
+      // produced, so the gate does not fire — deliberately. Emitting canonical
+      // alongside would break the exclusivity invariant and hand `sources[0]`
+      // to canonical for the chain render too. The deck render's fallback to
+      // canonical art stays a network fetch: an accepted residual of the
+      // one-form rule, not an oversight.
+      const chain: ArtChainEntry[] = [{ type: "source_printing" }, { type: "newest" }];
+      const { descriptors } = await planCuratedMembership(blankInput([BLANK_IMAGED, BLANK_UNIMAGED], {
+        artChain: chain,
+        deckPrintings: [{ oracleId: BLANK, source: { setCode: "SLD", collectorNumber: "1" } }],
+      }));
+
+      expect(blankKeys(descriptors)).toEqual(exactKeys(BLANK_IMAGED.id));
+    });
+  });
+
+  it("keys candidates on the lowercased oracle id the renderer stamps", async () => {
+    const upper = { ...SOLO_ENTRY, oracle_id: SOLO.toUpperCase() };
+    const { descriptors } = await planCuratedMembership(input({
+      cards: { [SOLO.toUpperCase()]: upper },
+    }));
+
+    expect(keysOf(descriptors)).toContain(`asset:v1:canonical_card:${SOLO}-0-full_card-normal`);
+    expect(descriptors[0].candidateKeys.map((key) => decodeCandidateKey(key)[1][0]))
+      .toContain(SOLO);
+  });
+
+  it("looks printings up by the stored oracle id, which the generator does not fold", async () => {
+    // `gen-scryfall-printings.sh` writes `key: .[0].oracle_id` unmodified, and
+    // `getCardPrintings` indexes it with the same unmodified value. Folding the
+    // lookup key would miss the entry that the renderer would still find.
+    const upper = { ...BOLT_ENTRY, oracle_id: BOLT.toUpperCase() };
+    const { descriptors } = await planCuratedMembership(input({
+      cards: { [BOLT.toUpperCase()]: upper },
+      printings: { [BOLT.toUpperCase()]: [BOLT_NEW, BOLT_OLD] },
+    }));
+
+    expect(exactPrintingIds(descriptors)).toEqual(new Set([BOLT_NEW.id]));
+  });
+
+  it("skips a face whose stored URLs are both null", async () => {
+    const nullFaced: CuratedCardEntry = {
+      ...SOLO_ENTRY,
+      faces: [imageFace(`${SOLO}-0`), { normal: null, art_crop: null }],
+    };
+    const { descriptors } = await planCuratedMembership(input({
+      cards: { ...CARDS, [SOLO]: nullFaced },
+    }));
+
+    expect(keysOf(descriptors).filter((key) => key.includes(`${SOLO}-1-`))).toEqual([]);
+    expect(keysOf(descriptors).filter((key) => key.includes(`${SOLO}-0-`))).toHaveLength(3);
+  });
+
+  it("skips a printing face with a null normal but keeps its art crop", async () => {
+    const halfNull = { ...BOLT_NEW, faces: [{ normal: null as unknown as string, art_crop: url(BOLT_NEW.id, "art_crop") }] };
+    const { descriptors } = await planCuratedMembership(input({
+      printings: { ...PRINTINGS, [BOLT]: [halfNull, BOLT_OLD] },
+    }));
+
+    expect(keysOf(descriptors).filter((key) => key.includes(BOLT_NEW.id)))
+      .toEqual([`asset:v1:exact_printing:${BOLT_NEW.id}-0-art_crop-art_crop`]);
+  });
+
+  describe("deck printings", () => {
+    it("carries the deck's printing under the default empty chain", async () => {
+      const { descriptors } = await planCuratedMembership(input({
+        artChain: EMPTY_CHAIN,
+        deckPrintings: [{ oracleId: BOLT, source: LEA_161 }],
+      }));
+
+      expect(exactPrintingIds(descriptors)).toEqual(new Set([BOLT_OLD.id]));
+    });
+
+    it("emits no canonical form for a deck card — an ACCEPTED divergence", async () => {
+      // Under an empty chain a deck card plans exactly one printing, so the
+      // exclusivity gate suppresses canonical and this card's battlefield,
+      // hand and search renders resolve through the oracle group onto the
+      // DECK printing. Offline they show the deck's art where online they
+      // would show canonical.
+      //
+      // This is pinned deliberately. Adding canonical back to close that gap
+      // looks like a coverage win and is a regression: both forms would carry
+      // this card's oracle-group keys, and `sortMatches` puts
+      // `canonical_card:` first, so canonical would take `sources[0]` for the
+      // DECK render too and break the deck half of the feature. Do not
+      // "fix" this without re-deriving that ordering.
+      const { descriptors } = await planCuratedMembership(input({
+        artChain: EMPTY_CHAIN,
+        deckPrintings: [{ oracleId: BOLT, source: LEA_161 }],
+      }));
+
+      expect(keysOf(descriptors).filter((key) => key.startsWith(`asset:v1:canonical_card:${BOLT}-`)))
+        .toEqual([]);
+      expect(keysOf(descriptors)).toContain(`asset:v1:exact_printing:${BOLT_OLD.id}-0-full_card-normal`);
+    });
+
+    it("resolves the deck printing through a chain that names source_printing", async () => {
+      const chain: ArtChainEntry[] = [{ type: "source_printing" }, { type: "newest" }];
+      const { descriptors } = await planCuratedMembership(input({
+        artChain: chain,
+        deckPrintings: [{ oracleId: BOLT, source: LEA_161 }],
+      }));
+
+      expect(exactPrintingIds(descriptors)).toEqual(new Set([BOLT_NEW.id, BOLT_OLD.id, GIANT_NEW.id]));
+    });
+
+    it("omits the deck printing when the chain would not display it", async () => {
+      // The renderer reaches its source-printing branch only for an empty
+      // chain or a chain naming source_printing. Under any other chain the
+      // deck's own art never appears on screen, so the pack must not carry it.
+      const { descriptors } = await planCuratedMembership(input({
+        deckPrintings: [{ oracleId: BOLT, source: LEA_161 }],
+      }));
+
+      expect(exactPrintingIds(descriptors)).toEqual(new Set([BOLT_NEW.id, GIANT_NEW.id]));
+    });
+
+    it("matches a deck printing whose oracle id differs in case", async () => {
+      const { descriptors } = await planCuratedMembership(input({
+        artChain: EMPTY_CHAIN,
+        deckPrintings: [{ oracleId: BOLT.toUpperCase(), source: LEA_161 }],
+      }));
+
+      expect(exactPrintingIds(descriptors)).toEqual(new Set([BOLT_OLD.id]));
+    });
+  });
+
+  describe("art overrides", () => {
+    it("omits the chain winner that a divergent override supersedes", async () => {
+      // An override suppresses the chain entirely at render time, so the chain
+      // winner is art the user cannot see. Carrying it would cost bytes and
+      // put a second exact_printing under this card's oracle-group keys.
+      const artOverrides: Record<string, CardArtOverride> = {
+        [BOLT]: { scryfallId: BOLT_OLD.id, setCode: "lea", collectorNumber: "161" },
+      };
+      const { descriptors } = await planCuratedMembership(input({ artOverrides }));
+
+      expect(exactPrintingIds(descriptors)).toEqual(new Set([BOLT_OLD.id, GIANT_NEW.id]));
+    });
+
+    it("carries exactly one printing when the override is the chain winner", async () => {
+      const artOverrides: Record<string, CardArtOverride> = {
+        [BOLT]: { scryfallId: BOLT_NEW.id, setCode: "m20", collectorNumber: "1" },
+      };
+      const { descriptors } = await planCuratedMembership(input({ artOverrides }));
+
+      expect(exactPrintingIds(descriptors)).toEqual(new Set([BOLT_NEW.id, GIANT_NEW.id]));
+    });
+
+    it("falls to canonical when the override names a printing that is gone", async () => {
+      // `selectedPrinting` returns null rather than falling through to the
+      // chain, and `resolveOverrideUrl` likewise yields no URL, so the render
+      // resolves through the oracle group — which is the canonical asset.
+      const artOverrides: Record<string, CardArtOverride> = {
+        [BOLT]: { scryfallId: GIANT_NEW.id, setCode: "m21", collectorNumber: "1" },
+      };
+      const { descriptors } = await planCuratedMembership(input({ artOverrides }));
+
+      expect(exactPrintingIds(descriptors)).toEqual(new Set([GIANT_NEW.id]));
+      expect(keysOf(descriptors)).toContain(`asset:v1:canonical_card:${BOLT}-0-full_card-normal`);
+    });
+  });
+
+  describe("membership digest", () => {
+    it("is stable across permutations of the input map order", async () => {
+      const reversed = Object.fromEntries(Object.entries(CARDS).reverse());
+      const first = await planCuratedMembership(input());
+      const second = await planCuratedMembership(input({ cards: reversed }));
+
+      expect(second.membershipDigest).toBe(first.membershipDigest);
+      expect(keysOf(second.descriptors)).toEqual(keysOf(first.descriptors));
+    });
+
+    it("is sorted by assetKey", async () => {
+      const { descriptors } = await planCuratedMembership(input());
+
+      expect(keysOf(descriptors)).toEqual([...keysOf(descriptors)].sort());
+    });
+
+    it("changes when only a sourceUrl changes and the assetKeys are identical", async () => {
+      // A `scryfall-data.json` regeneration can move the bytes behind an
+      // unchanged canonical_card key. Digesting keys alone would miss it.
+      const regenerated: CuratedCardEntry = {
+        ...SOLO_ENTRY,
+        faces: [
+          { normal: url(`${SOLO}-0`, "normal").replace("?1", "?2"), art_crop: url(`${SOLO}-0`, "art_crop") },
+          imageFace(`${SOLO}-1`),
+        ],
+      };
+      const before = await planCuratedMembership(input());
+      const after = await planCuratedMembership(input({ cards: { ...CARDS, [SOLO]: regenerated } }));
+
+      expect(keysOf(after.descriptors)).toEqual(keysOf(before.descriptors));
+      expect(after.membershipDigest).not.toBe(before.membershipDigest);
+    });
+
+    it("changes when the membership changes", async () => {
+      const before = await planCuratedMembership(input({ artChain: EMPTY_CHAIN }));
+      const after = await planCuratedMembership(input({
+        artChain: EMPTY_CHAIN,
+        deckPrintings: [{ oracleId: BOLT, source: LEA_161 }],
+      }));
+
+      expect(after.membershipDigest).not.toBe(before.membershipDigest);
+    });
+
+    it("is a 64-character lowercase hex CatalogRoot", async () => {
+      const { membershipDigest } = await planCuratedMembership(input());
+
+      expect(membershipDigest).toMatch(/^[0-9a-f]{64}$/);
+    });
+  });
+});

--- a/client/src/services/visualPacks/__tests__/curatedPlanMemo.test.ts
+++ b/client/src/services/visualPacks/__tests__/curatedPlanMemo.test.ts
@@ -1,0 +1,303 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { PrintingEntry } from "../../scryfall.ts";
+import { STORAGE_KEY_PREFIX } from "../../../constants/storage.ts";
+import type { DeckEntry } from "../../deckParser.ts";
+import { usePreferencesStore } from "../../../stores/preferencesStore.ts";
+import type { ArtChainEntry } from "../../../stores/preferencesStore.ts";
+import { planCuratedMembership } from "../curatedMembership.ts";
+import { planCuratedPack } from "../curatedPack.ts";
+
+/**
+ * The card data the planner reads, swapped per test.
+ *
+ * Partial mock: `curatedMembership.ts` also imports `deriveImageUrl` from this
+ * module at runtime, so replacing the whole module would break the very
+ * planner under test.
+ */
+const data = vi.hoisted(() => ({
+  cards: null as unknown,
+  printings: null as unknown,
+  /** Held open by the window test below, so the plan can be parked exactly
+   *  where production parks it: inside `loadScryfallData`. */
+  gate: Promise.resolve(),
+}));
+
+vi.mock("../../scryfall.ts", async (importOriginal) => ({
+  ...await importOriginal<typeof import("../../scryfall.ts")>(),
+  loadScryfallData: async () => {
+    await data.gate;
+    return data.cards;
+  },
+  loadPrintingsData: async () => data.printings,
+}));
+
+/** The real planner, counted. This is the 130-330 ms the memo exists to skip;
+ *  nothing cheaper is a proxy for it, because the ~76 MB card maps behind it
+ *  are module-level memoized promises and are already resident. */
+vi.mock("../curatedMembership.ts", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("../curatedMembership.ts")>();
+  return { ...actual, planCuratedMembership: vi.fn(actual.planCuratedMembership) };
+});
+
+const BOLT = "11111111-abcd-4111-8111-111111111111";
+const GIANT = "22222222-abcd-4222-8222-222222222222";
+
+function url(token: string, size: string): string {
+  return `https://cards.scryfall.io/${size}/front/a/b/${token}.jpg`;
+}
+
+function imageFace(token: string) {
+  return { normal: url(token, "normal"), art_crop: url(token, "art_crop") };
+}
+
+function printing(id: string, set: string, releasedAt: string): PrintingEntry {
+  return {
+    id,
+    set,
+    set_name: set.toUpperCase(),
+    collector_number: "1",
+    released_at: releasedAt,
+    border_color: "black",
+    frame_effects: [],
+    full_art: false,
+    faces: [imageFace(id)],
+  };
+}
+
+const BOLT_NEW = printing("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", "m20", "2019-07-12");
+const BOLT_OLD = printing("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", "lea", "1993-08-05");
+
+function cardEntry(oracleId: string, name: string, faceName: string) {
+  return { oracle_id: oracleId, name, face_names: [faceName], faces: [imageFace(oracleId)] };
+}
+
+const BOLT_ENTRY = cardEntry(BOLT, "Lightning Bolt", "lightning bolt");
+const GIANT_ENTRY = cardEntry(GIANT, "Giant Growth", "giant growth");
+
+const CARDS = {
+  [BOLT]: BOLT_ENTRY,
+  "lightning bolt": BOLT_ENTRY,
+  [GIANT]: GIANT_ENTRY,
+  "giant growth": GIANT_ENTRY,
+};
+// Two printings for Bolt, released 26 years apart, so "newest" and "oldest"
+// genuinely select different art: an invalidation assertion that only counted
+// calls would pass even if the second plan produced the same membership.
+const PRINTINGS: Record<string, PrintingEntry[]> = { [BOLT]: [BOLT_NEW, BOLT_OLD] };
+
+const NEWEST = (): ArtChainEntry[] => [{ type: "newest" }];
+const OLDEST = (): ArtChainEntry[] => [{ type: "oldest" }];
+/**
+ * A chain that consults a deck's `(SET) NUM` annotation first and falls back
+ * to `newest` — the production shape of a preference set under which a saved
+ * deck can matter at all.
+ *
+ * Kept for the deck tests below even though nothing here reads a deck's
+ * CONTENT: this file mocks `loadScryfallData`, so the module global
+ * `resolveOracleIdSync` consults is never assigned and `deckPrintings` resolves
+ * no names. The subject here is the memo KEY — whether a deck edit misses — and
+ * that is measured on planner call counts. What a pinned `(SET) NUM` actually
+ * contributes to a membership is `browser/__tests__/curatedDelta.test.ts`'s
+ * subject, where the real loader runs against a stubbed `/scryfall-data.json`.
+ */
+const SOURCE_THEN_NEWEST = (): ArtChainEntry[] => [{ type: "source_printing" }, { type: "newest" }];
+
+/** A deck as it is really stored: whatever `DeckBuilder` last wrote, verbatim.
+ *  `loadSavedDeck` re-parses and re-repairs this on every call, which is why
+ *  the memo cannot key on what it returns. */
+function saveDeck(name: string, main: DeckEntry[], sideboard: DeckEntry[] = []): void {
+  localStorage.setItem(STORAGE_KEY_PREFIX + name, JSON.stringify({ main, sideboard }));
+}
+
+const plan = vi.mocked(planCuratedMembership);
+
+/**
+ * Preferences no previous test can have planned under.
+ *
+ * The memo is module-level state by design — the panel and the backend must
+ * share one entry — and it keys on the IDENTITY of the two preference values,
+ * so a fresh array and a fresh object are a guaranteed miss even when their
+ * contents repeat. That is what starts each test from a cold cache without
+ * reaching into the module for a reset hook that production has no use for.
+ */
+function coldStart(artChain: ArtChainEntry[] = NEWEST()): void {
+  usePreferencesStore.setState({ artChain, artOverrides: {} });
+}
+
+describe("curated plan memo", () => {
+  beforeEach(() => {
+    data.cards = CARDS;
+    data.printings = PRINTINGS;
+    data.gate = Promise.resolve();
+    localStorage.clear();
+    plan.mockClear();
+  });
+
+  it("plans once for repeated calls at unchanged preferences", async () => {
+    coldStart();
+
+    const first = await planCuratedPack();
+    const second = await planCuratedPack();
+
+    // One install asks four or more times over — the panel's selector, the
+    // estimate, `start()`'s conflict guard, `run()`'s descriptor pass — and
+    // `create()` asks again for every pending record on each app launch.
+    expect(plan).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+  });
+
+  it("shares one plan between callers that overlap", async () => {
+    coldStart();
+
+    // Not awaited in between: the promise is cached, not the resolved value,
+    // so a second caller arriving before the first settles joins it instead of
+    // starting a second plan.
+    const [first, second] = await Promise.all([planCuratedPack(), planCuratedPack()]);
+
+    expect(plan).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+  });
+
+  it("re-plans when the art chain changes", async () => {
+    coldStart();
+    const first = await planCuratedPack();
+
+    usePreferencesStore.setState({ artChain: OLDEST() });
+    const second = await planCuratedPack();
+
+    expect(plan).toHaveBeenCalledTimes(2);
+    // The digest, not just the call count: a memo that re-ran the planner but
+    // returned the first membership would satisfy the count alone.
+    expect(second.membershipDigest).not.toBe(first.membershipDigest);
+  });
+
+  it("re-plans when a per-card art override changes", async () => {
+    coldStart();
+    const first = await planCuratedPack();
+
+    usePreferencesStore.setState({
+      artOverrides: { [BOLT]: { scryfallId: BOLT_OLD.id, setCode: "lea", collectorNumber: "1" } },
+    });
+    const second = await planCuratedPack();
+
+    expect(plan).toHaveBeenCalledTimes(2);
+    expect(second.membershipDigest).not.toBe(first.membershipDigest);
+  });
+
+  it("re-plans when a saved deck changes", async () => {
+    saveDeck("Burn", [
+      { count: 4, name: "Lightning Bolt", sourcePrinting: { setCode: "M20", collectorNumber: "1" } },
+    ]);
+    coldStart(SOURCE_THEN_NEWEST());
+    const first = await planCuratedPack();
+
+    saveDeck("Burn", [
+      { count: 4, name: "Lightning Bolt", sourcePrinting: { setCode: "LEA", collectorNumber: "1" } },
+    ]);
+    const second = await planCuratedPack();
+
+    // Nothing about the PREFERENCES moved here, so a key covering only those
+    // two would have served the first membership back.
+    expect(plan).toHaveBeenCalledTimes(2);
+    // The membership OBJECT, not its digest: the loader is mocked in this file
+    // and never assigns the module global `resolveOracleIdSync` reads, so a
+    // deck resolves no card names here and cannot move a digest. What that
+    // deck's `(SET) NUM` annotation actually puts in a membership is
+    // `curatedDelta.test.ts`'s subject, under the real loader; this file's
+    // subject is the KEY, and identity is what proves a second plan was served
+    // rather than the cached first one.
+    expect(second).not.toBe(first);
+  });
+
+  it("re-plans when a deck is added and again when it is deleted", async () => {
+    coldStart(SOURCE_THEN_NEWEST());
+    const empty = await planCuratedPack();
+
+    saveDeck("Burn", [
+      { count: 4, name: "Lightning Bolt", sourcePrinting: { setCode: "LEA", collectorNumber: "1" } },
+    ]);
+    const added = await planCuratedPack();
+    localStorage.removeItem(STORAGE_KEY_PREFIX + "Burn");
+    const removed = await planCuratedPack();
+
+    // The deck SET, not just a deck's contents: a key built from the stored
+    // bodies alone would miss the appearance and disappearance of a whole deck.
+    expect(plan).toHaveBeenCalledTimes(3);
+    expect(added).not.toBe(empty);
+    expect(removed).not.toBe(added);
+  });
+
+  it("files a plan under the decks it read, not the ones sampled before the await", async () => {
+    saveDeck("Burn", [
+      { count: 4, name: "Lightning Bolt", sourcePrinting: { setCode: "M20", collectorNumber: "1" } },
+    ]);
+    coldStart(SOURCE_THEN_NEWEST());
+
+    // Park the plan exactly where production parks it: inside the card-data
+    // load. That await is a real one — a cold start fetches ~76 MB, so seconds
+    // can pass — and the decks are read on the far side of it.
+    let release = (): void => undefined;
+    data.gate = new Promise<void>((resolve) => { release = resolve; });
+    const inFlight = planCuratedPack();
+    saveDeck("Burn", [
+      { count: 4, name: "Lightning Bolt", sourcePrinting: { setCode: "LEA", collectorNumber: "1" } },
+    ]);
+    release();
+    await inFlight;
+
+    // The revert — an undo in the deck builder, or cloud sync rewriting
+    // localStorage. The decks are byte-for-byte what they were when the key was
+    // SAMPLED, and nothing else has moved.
+    saveDeck("Burn", [
+      { count: 4, name: "Lightning Bolt", sourcePrinting: { setCode: "M20", collectorNumber: "1" } },
+    ]);
+    await planCuratedPack();
+
+    // Filed under the text sampled BEFORE the await, this revert is a hit, and
+    // the membership planned from the OTHER deck set is served for the life of
+    // the tab. Stamping the key beside the deck read makes it a miss.
+    expect(plan).toHaveBeenCalledTimes(2);
+  });
+
+  it("plans once for repeated calls while the saved decks are unchanged", async () => {
+    saveDeck("Burn", [
+      { count: 4, name: "Lightning Bolt", sourcePrinting: { setCode: "LEA", collectorNumber: "1" } },
+    ]);
+    coldStart(SOURCE_THEN_NEWEST());
+
+    const first = await planCuratedPack();
+    const second = await planCuratedPack();
+
+    // The other direction, and the failure that hides: `loadSavedDeck` returns
+    // a fresh object on every call, so a key that reached for the PARSED decks
+    // would miss here every time — a memo that is useless rather than stale,
+    // with nothing going red to say so.
+    expect(plan).toHaveBeenCalledTimes(1);
+    expect(second).toBe(first);
+  });
+
+  it("reports missing card data as a translatable kind with no prose", async () => {
+    coldStart();
+    data.cards = null;
+
+    // `detail` is what the panel renders verbatim beneath the translated
+    // sentence. `network` already has that sentence in all seven locales, so
+    // an English phrase here would appear untranslated under a translated one.
+    await expect(planCuratedPack()).rejects.toMatchObject({ kind: "network", detail: null });
+    expect(plan).not.toHaveBeenCalled();
+  });
+
+  it("does not remember a failed plan as the answer", async () => {
+    coldStart();
+    data.cards = null;
+    await expect(planCuratedPack()).rejects.toMatchObject({ kind: "network" });
+
+    data.cards = CARDS;
+    const membership = await planCuratedPack();
+
+    // A cached rejection would make one transient card-data failure permanent
+    // for the life of the tab, with no preference change available to clear it.
+    expect(membership.descriptors.length).toBeGreaterThan(0);
+  });
+});

--- a/client/src/services/visualPacks/__tests__/repository.test.ts
+++ b/client/src/services/visualPacks/__tests__/repository.test.ts
@@ -54,6 +54,8 @@ function fakeBackend(
   const unavailable = vi.fn(async (): Promise<never> => { throw new Error("unused"); });
   return {
     catalogStatus: unavailable,
+    curatedSelector: unavailable,
+    curatedDrift: unavailable,
     refreshCatalog: unavailable,
     catalogSummary: unavailable,
     estimateInstall: unavailable,

--- a/client/src/services/visualPacks/backend.ts
+++ b/client/src/services/visualPacks/backend.ts
@@ -1,6 +1,9 @@
 import type {
   CatalogStatus,
   CatalogSummary,
+  CatalogScanProgress,
+  CuratedDrift,
+  CuratedInstallSelector,
   InstallEstimate,
   InstallSelector,
   OperationId,
@@ -14,23 +17,87 @@ import type {
   RevisionEvent,
   StartRequest,
   StartResponse,
+  StorageRefusal,
   VerificationMode,
   VerificationResponse,
   VisualPackErrorKind,
 } from "./types.ts";
 
 export class VisualPackBackendError extends Error {
+  /**
+   * The diagnostic text a caller supplied, or null when it supplied none.
+   *
+   * Kept apart from `message` because the two answer different questions.
+   * `message` must always say something in a stack trace, so it falls back to
+   * a developer-facing default; the panel renders `detail` verbatim beneath a
+   * translated sentence, and that default is untranslated English prose which
+   * would then appear under it in all seven languages. A `kind` on its own is
+   * already a complete, translatable message — a null here says exactly that
+   * and is not an absence of information.
+   */
+  readonly detail: string | null;
+
   constructor(public readonly kind: VisualPackErrorKind, detail?: string) {
     super(detail || `visual-pack backend ${kind}`);
     this.name = "VisualPackBackendError";
+    this.detail = detail ?? null;
+  }
+}
+
+/**
+ * A pre-flight refusal, with the figures it was decided on.
+ *
+ * The payload rides ALONGSIDE the message rather than inside it. `detail` IS
+ * `message` — the base constructor passes it straight to `super` — so anything
+ * written there is prose, and prose composed in this layer is prose the panel
+ * cannot translate. The message here is left to the base default so it stays a
+ * developer-facing string in a stack trace, and the two numbers a user is owed
+ * are typed fields instead.
+ */
+export class VisualPackStorageRefusalError extends VisualPackBackendError {
+  constructor(public readonly refusal: StorageRefusal) {
+    super("insufficient_storage");
+    this.name = "VisualPackStorageRefusalError";
   }
 }
 
 export interface VisualPackBackend {
   catalogStatus(): Promise<CatalogStatus>;
+  /**
+   * The curated selector for the preferences stored right now.
+   *
+   * Every other selector is composed from what the user typed into the panel,
+   * so the panel can build it. This one is a membership digest: computing it
+   * means planning the whole membership from the card data and the art
+   * preferences, which is engine work, and a display layer that did it would
+   * be deriving state rather than rendering it. Worse, it would be a SECOND
+   * assembly of the planner's input beside the one `start()` and `run()` use,
+   * and the two would disagree the moment either gained a source the other
+   * lacked — the panel would then show a digest the backend never installs.
+   */
+  curatedSelector(): Promise<CuratedInstallSelector>;
+  /**
+   * The planned curated membership against the one on disk.
+   *
+   * A superset of `curatedSelector()` in what it RETURNS — `membershipDigest`
+   * is on both — but not in what it costs: this one also reads every installed
+   * curated `objects` row to say how far the two have diverged. The two stay
+   * separate because their callers differ: a first install needs only the
+   * digest, and paying for a diff against a pack that is not installed would
+   * be work with no answer to give.
+   *
+   * `null` is UNMEASURED, and it is a normal answer rather than a failure: the
+   * membership behind a measurement is planned from card data that may not be
+   * loaded, and loading it is tens of megabytes. A caller renders nothing for a
+   * null — it must never be read as "no drift", which is a measurement this did
+   * not make. `curatedSelector()` carries no such arm: it is only ever called
+   * because a user chose the curated option, so paying to load is what they
+   * asked for.
+   */
+  curatedDrift(): Promise<CuratedDrift | null>;
   refreshCatalog(): Promise<CatalogSummary>;
   catalogSummary(): Promise<CatalogSummary>;
-  estimateInstall(selector: InstallSelector): Promise<InstallEstimate>;
+  estimateInstall(selector: InstallSelector, onProgress?: (progress: CatalogScanProgress) => void): Promise<InstallEstimate>;
   start(request: StartRequest): Promise<StartResponse>;
   cancel(operationId: OperationId): Promise<OperationStatus>;
   operationStatus(operationId: OperationId): Promise<OperationStatus>;

--- a/client/src/services/visualPacks/browser/__tests__/curatedDelta.test.ts
+++ b/client/src/services/visualPacks/browser/__tests__/curatedDelta.test.ts
@@ -1,0 +1,1066 @@
+import "fake-indexeddb/auto";
+
+import { IDBFactory } from "fake-indexeddb";
+import { openDB } from "idb";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { STORAGE_KEY_PREFIX } from "../../../../constants/storage.ts";
+import { usePreferencesStore, type ArtChainEntry, type CardArtOverride } from "../../../../stores/preferencesStore.ts";
+import type { DeckEntry } from "../../../deckParser.ts";
+import { CARD_BACK_URL, loadScryfallData, type PrintingEntry } from "../../../scryfall.ts";
+import { assetKey, packId } from "../../types.ts";
+import type { AssetKey, CatalogRoot, CuratedDrift, InstallSelector, OperationId, ProgressEvent, ResolutionResponse } from "../../types.ts";
+import type { ScryfallAssetDescriptor } from "../descriptors.ts";
+import { ScryfallBrowserVisualPackBackend } from "../scryfallBackend.ts";
+import { planCuratedMembership } from "../../curatedMembership.ts";
+import { planCuratedPack } from "../../curatedPack.ts";
+
+// Step 4's subject is the DELTA: what a second curated install at a second
+// digest downloads, keeps, and throws away. Every assertion below is therefore
+// about the difference between two installs, never about one.
+//
+// The harness mirrors `curatedSelector.test.tsx` rather than importing from it
+// — a test file is not a module other tests may depend on — but the fixture is
+// deliberately larger in one dimension: Lightning Bolt has THREE printings, so
+// three DISTINCT memberships exist. Two are not enough. The abandoned-root case
+// needs an install to be stranded at a digest that a LATER, DIFFERENT digest
+// then supersedes, and with only two memberships the third install would land
+// back on the installed root and be short-circuited to `{status:"healthy"}`
+// before any sweep could run.
+
+const BULK_INDEX_URL = "https://api.scryfall.com/bulk-data";
+const BULK_DOWNLOAD_URL = "https://data.scryfall.io/all-cards.jsonl.gz";
+const BULK_RECORD = {
+  type: "all_cards",
+  updated_at: "2026-08-01T00:00:00.000Z",
+  jsonl_download_uri: BULK_DOWNLOAD_URL,
+  compressed_size: 2_400_000_000,
+};
+
+const BOLT = "11111111-abcd-4111-8111-111111111111";
+const GIANT = "22222222-abcd-4222-8222-222222222222";
+const TOKEN_ORACLE = "33333333-abcd-4333-8333-333333333333";
+const EOWYN = "44444444-abcd-4444-8444-444444444444";
+
+function url(token: string, size: string): string {
+  return `https://cards.scryfall.io/${size}/front/a/b/${token}.jpg`;
+}
+
+function imageFace(token: string) {
+  return { normal: url(token, "normal"), art_crop: url(token, "art_crop") };
+}
+
+function printing(id: string, set: string, releasedAt: string): PrintingEntry {
+  return {
+    id,
+    set,
+    set_name: set.toUpperCase(),
+    collector_number: "1",
+    released_at: releasedAt,
+    border_color: "black",
+    frame_effects: [],
+    full_art: false,
+    faces: [imageFace(id)],
+  };
+}
+
+const BOLT_NEW = printing("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", "m20", "2019-07-12");
+const BOLT_MID = printing("cccccccc-cccc-4ccc-8ccc-cccccccccccc", "mh1", "2019-06-14");
+const BOLT_OLD = printing("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", "lea", "1993-08-05");
+
+function cardEntry(oracleId: string, name: string, faceName: string) {
+  return { oracle_id: oracleId, name, face_names: [faceName], faces: [imageFace(oracleId)] };
+}
+
+const BOLT_ENTRY = cardEntry(BOLT, "Lightning Bolt", "lightning bolt");
+const GIANT_ENTRY = cardEntry(GIANT, "Giant Growth", "giant growth");
+/** A card whose only name key carries a diacritic, which is how
+ *  `scryfall-data.json` really stores this class — and the class this repo has
+ *  a history of losing to ASCII-only folding. */
+const EOWYN_ENTRY = cardEntry(EOWYN, "Éowyn, Fearless Knight", "éowyn, fearless knight");
+
+const CARDS = {
+  [BOLT]: BOLT_ENTRY,
+  "lightning bolt": BOLT_ENTRY,
+  [GIANT]: GIANT_ENTRY,
+  "giant growth": GIANT_ENTRY,
+  [EOWYN]: EOWYN_ENTRY,
+  "éowyn, fearless knight": EOWYN_ENTRY,
+  [`token:${TOKEN_ORACLE}`]: cardEntry(TOKEN_ORACLE, "Soldier", "soldier"),
+};
+/**
+ * Éowyn's two printings, arranged so that only a DECK can tell them apart.
+ *
+ * `EOWYN_MH1` is `printings[0]` (so `newest` picks it), the oldest by
+ * `released_at` (so `oldest` picks it too), and in `mh1` (so `MIDDLE` picks it
+ * as well). Every chain this file installs under therefore selects the same
+ * Éowyn art, which keeps her out of every drift count below; only the
+ * `source_printing` entry of `SOURCE_THEN_NEWEST`, handed the deck's `(SLD) 1`
+ * annotation, reaches `EOWYN_SLD`.
+ */
+const EOWYN_MH1 = printing("dddddddd-dddd-4ddd-8ddd-dddddddddddd", "mh1", "2019-06-14");
+const EOWYN_SLD = printing("eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee", "sld", "2024-02-02");
+// `newest` returns `printings[0]` by ARRAY order, so the order here is what
+// makes the three chains below select three different printings.
+const PRINTINGS: Record<string, PrintingEntry[]> = {
+  [BOLT]: [BOLT_NEW, BOLT_MID, BOLT_OLD],
+  [EOWYN]: [EOWYN_MH1, EOWYN_SLD],
+};
+
+const NEWEST: ArtChainEntry[] = [{ type: "newest" }];
+const OLDEST: ArtChainEntry[] = [{ type: "oldest" }];
+const MIDDLE: ArtChainEntry[] = [{ type: "set", setCode: "mh1", label: "MH1" }];
+/**
+ * A chain that consults a deck's `(SET) NUM` annotation first and falls back
+ * to `newest`.
+ *
+ * This is what makes a deck test discriminating rather than merely non-empty.
+ * `selectedPrintings` asks `selectedPrinting` once with NO source and once per
+ * deck source: with no source the `source_printing` entry matches nothing and
+ * the chain falls through to `newest`, while with the deck's source it resolves
+ * the annotated printing. The deck's contribution is therefore a descriptor the
+ * preferences alone could never produce.
+ *
+ * A FACTORY, unlike the three constants above: the plan memo keys on the
+ * identity of the stored `artChain`, so a fresh array is a guaranteed miss.
+ */
+const SOURCE_THEN_NEWEST = (): ArtChainEntry[] => [{ type: "source_printing" }, { type: "newest" }];
+
+/**
+ * How many image records every chain in this file agrees on.
+ *
+ * Giant Growth is absent from `PRINTINGS`, so it is canonical under any chain,
+ * and Éowyn's two printings are arranged (see above) so that `NEWEST`, `OLDEST`
+ * and `MIDDLE` all land on `EOWYN_MH1`. Three rungs each. Only Lightning Bolt's
+ * three rungs follow the chain, which is what every delta below measures.
+ */
+const CHAIN_INVARIANT_ASSETS = 6;
+
+/** An in-memory `Cache`, holding only what this backend asks of one. */
+class MemoryCache {
+  readonly entries = new Map<string, { body: Uint8Array; type: string }>();
+
+  async put(request: string, response: Response): Promise<void> {
+    this.entries.set(request, {
+      body: new Uint8Array(await response.arrayBuffer()),
+      type: response.headers.get("Content-Type") ?? "application/octet-stream",
+    });
+  }
+
+  async match(request: string): Promise<Response | undefined> {
+    const entry = this.entries.get(request);
+    return entry ? new Response(entry.body, { headers: { "Content-Type": entry.type } }) : undefined;
+  }
+
+  async delete(request: string): Promise<boolean> {
+    return this.entries.delete(request);
+  }
+}
+
+let cache = new MemoryCache();
+let requested: string[] = [];
+/** A total image outage: `fetchImage` rejects a non-200 as `network`. */
+let failImages = false;
+/** Holds the matching image fetches open indefinitely, so one backend can be
+ *  parked mid-install while a second one runs to completion against the same
+ *  database. Releasing it lets the parked install finish. */
+let held: { matches: (source: string) => boolean; gate: Promise<void>; release: () => void } | null = null;
+
+function holdImages(matches: (source: string) => boolean): () => void {
+  let release = (): void => undefined;
+  const gate = new Promise<void>((resolve) => { release = resolve; });
+  held = { matches, gate, release };
+  return release;
+}
+/** How many card images may still be served before the outage begins. Lets a
+ *  test strand a PARTIAL membership at a digest rather than an empty one. */
+let imageBudget = Number.POSITIVE_INFINITY;
+let imagesServed = 0;
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), { status: 200, headers: { "Content-Type": "application/json" } });
+}
+
+function imageResponse(source: string): Response {
+  // URL-derived bytes, so content-addressed paths differ per asset the way real
+  // images do — and so two URLs deliberately served the SAME bytes land on one
+  // shared cache entry, which is what the sharing tests need.
+  return new Response(new TextEncoder().encode(source), { status: 200, headers: { "Content-Type": "image/jpeg" } });
+}
+
+const fetchStub = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+  const source = String(input);
+  requested.push(source);
+  if (source === BULK_INDEX_URL) return jsonResponse({ data: [BULK_RECORD] });
+  if (source === "/scryfall-data.json") return jsonResponse(CARDS);
+  if (source === "/scryfall-printings.json") return jsonResponse(PRINTINGS);
+  // The `core` pack's only image, served with the SAME bytes as Bolt's newest
+  // normal rung. Content addressing then gives both packs one cache entry, so
+  // "an image another pack still uses" is a real shared path rather than a
+  // claim about one.
+  if (source === CARD_BACK_URL) return imageResponse(url(BOLT_NEW.id, "normal"));
+  if (source.startsWith("https://cards.scryfall.io/")) {
+    if (held?.matches(source)) await held.gate;
+    if (failImages || imagesServed >= imageBudget) return new Response("", { status: 503 });
+    imagesServed += 1;
+    return imageResponse(source);
+  }
+  throw new Error(`unexpected fetch: ${source}`);
+});
+
+const DATABASE = "phase-visual-packs-scryfall-v1";
+
+interface StoredObject {
+  id: string;
+  root: CatalogRoot;
+  packId: string;
+  assetKey: AssetKey;
+  path: string;
+  sourceUrl?: string;
+}
+
+/**
+ * The backend's own private methods, as an interposition seam.
+ *
+ * Two of the properties below have no public seam at all: whether a donor scan
+ * happened is invisible to fetch counts, and the window between `completePack`
+ * and the sweep contains no cache or fetch call to hook. The methods themselves
+ * are the only points at which either can be observed, so they are replaced on
+ * the prototype and restored in the test's own `finally`.
+ */
+type BackendInternals = Record<string, (this: unknown, ...args: never[]) => unknown>;
+
+function internals(): BackendInternals {
+  return ScryfallBrowserVisualPackBackend.prototype as unknown as BackendInternals;
+}
+
+/** Only card-image requests. `loadScryfallData`/`loadPrintingsData` memoize
+ *  their resolved maps for the lifetime of the module, so the data files are
+ *  fetched at most once per FILE and a raw request count cannot discriminate
+ *  anything about a second install. */
+function imageRequests(): string[] {
+  return requested.filter((entry) => entry.startsWith("https://cards.scryfall.io/"));
+}
+
+async function objectRows(): Promise<StoredObject[]> {
+  const database = await openDB(DATABASE, 1);
+  const rows = await database.getAll("objects") as StoredObject[];
+  database.close();
+  return rows;
+}
+
+function pathOf(rows: readonly StoredObject[], key: AssetKey): string {
+  const row = rows.find((entry) => entry.assetKey === key);
+  if (!row) throw new Error(`no installed row for ${key}`);
+  return row.path;
+}
+
+/** The bytes actually behind a cached path, as text. `imageResponse` encodes
+ *  the source URL, so this reads back WHICH image a row is really serving —
+ *  the difference between reusing stale bytes and re-fetching moved ones. */
+function cachedText(path: string): string | null {
+  const entry = cache.entries.get(path);
+  return entry ? new TextDecoder().decode(entry.body) : null;
+}
+
+/**
+ * Rewrite every `objects` row into the shape the build BEFORE this step wrote:
+ * no `sourceUrl` at all. Returns the count so a caller can prove the rows it is
+ * about to test against actually existed.
+ */
+async function dropStoredSourceUrls(): Promise<number> {
+  const database = await openDB(DATABASE, 1);
+  const rows = await database.getAll("objects") as StoredObject[];
+  for (const row of rows) {
+    const legacy: StoredObject = { ...row };
+    delete legacy.sourceUrl;
+    await database.put("objects", legacy);
+  }
+  database.close();
+  return rows.length;
+}
+
+/**
+ * Move Giant Growth's `normal` face URL, as a regeneration of
+ * `scryfall-data.json` does. The map is mutated in place because
+ * `loadScryfallData` memoizes its RESOLVED value, so re-serving the fetch would
+ * change nothing; every key carrying this oracle id is updated because the JSON
+ * round-trip gives the oracle-id key and the name key independent objects.
+ */
+async function moveGiantNormal(token: string): Promise<string> {
+  const cards = await loadScryfallData();
+  if (!cards) throw new Error("card data unavailable");
+  const next = url(token, "normal");
+  for (const entry of Object.values(cards)) {
+    if (entry.oracle_id === GIANT) entry.faces[0].normal = next;
+  }
+  return next;
+}
+
+async function curatedSelector(): Promise<{ selector: InstallSelector; descriptors: readonly ScryfallAssetDescriptor[] }> {
+  const membership = await planCuratedPack();
+  return {
+    selector: { kind: "curated", membershipDigest: membership.membershipDigest },
+    descriptors: membership.descriptors,
+  };
+}
+
+/** The `failed` progress events one backend instance emits, from this point on. */
+async function failures(backend: ScryfallBrowserVisualPackBackend): Promise<ProgressEvent[]> {
+  const events: ProgressEvent[] = [];
+  await backend.subscribeProgress((event) => {
+    if (event.phase === "failed") events.push(event);
+  });
+  return events;
+}
+
+async function settle(backend: ScryfallBrowserVisualPackBackend, operation: OperationId): Promise<void> {
+  await vi.waitFor(async () => {
+    expect((await backend.operationStatus(operation)).state).toBe("completed");
+  }, { timeout: 5000 });
+}
+
+async function startCurated(backend: ScryfallBrowserVisualPackBackend): Promise<{
+  digest: CatalogRoot;
+  descriptors: readonly ScryfallAssetDescriptor[];
+  operation: OperationId;
+}> {
+  const { selector, descriptors } = await curatedSelector();
+  const response = await backend.start({ kind: "install", selector, objectEstimate: descriptors.length });
+  if (response.status !== "started") throw new Error("curated install did not start");
+  return {
+    digest: (selector as { membershipDigest: CatalogRoot }).membershipDigest,
+    descriptors,
+    operation: response.operationId,
+  };
+}
+
+async function installCurated(backend: ScryfallBrowserVisualPackBackend): Promise<{
+  digest: CatalogRoot;
+  descriptors: readonly ScryfallAssetDescriptor[];
+  operation: OperationId;
+}> {
+  const started = await startCurated(backend);
+  await settle(backend, started.operation);
+  return started;
+}
+
+async function installCore(backend: ScryfallBrowserVisualPackBackend): Promise<void> {
+  const response = await backend.start({ kind: "install", selector: { kind: "core" }, objectEstimate: 1 });
+  if (response.status !== "started") throw new Error("core install did not start");
+  await settle(backend, response.operationId);
+}
+
+/** Every installed object a render-time asset lookup can actually reach. */
+async function resolvedAssets(
+  backend: ScryfallBrowserVisualPackBackend,
+  descriptors: readonly ScryfallAssetDescriptor[],
+): Promise<ResolutionResponse["entries"][number]["matches"]> {
+  const response = await backend.resolve(descriptors.map((value) => ({ kind: "asset", key: value.assetKey })));
+  return response.entries.flatMap((entry) => entry.matches);
+}
+
+/** A deck as it is really stored: whatever `DeckBuilder` last wrote, verbatim.
+ *  `loadSavedDeck` re-parses and re-repairs this on every call, which is why
+ *  the plan memo cannot key on what it returns. */
+function saveDeck(name: string, main: DeckEntry[], sideboard: DeckEntry[] = []): void {
+  localStorage.setItem(STORAGE_KEY_PREFIX + name, JSON.stringify({ main, sideboard }));
+}
+
+/** Every `exact_printing` asset key in a membership, so an assertion can name
+ *  the printing that appeared rather than only how many did. */
+function exactKeys(membership: { descriptors: readonly { assetKey: string }[] }): string[] {
+  return membership.descriptors
+    .map((value) => value.assetKey)
+    .filter((key) => key.startsWith("asset:v1:exact_printing:"));
+}
+
+/** The membership an explicit set chain produces, planned straight from the
+ *  fixtures. Names the printing a deck is supposed to pin INDEPENDENTLY of the
+ *  deck, so a deck assertion is about that printing rather than about a count. */
+async function membershipForSet(setCode: string): Promise<{ descriptors: readonly ScryfallAssetDescriptor[] }> {
+  return planCuratedMembership({
+    packId: packId("curated"),
+    cards: CARDS,
+    printings: PRINTINGS,
+    artChain: [{ type: "set", setCode, label: setCode.toUpperCase() }],
+    artOverrides: {},
+  });
+}
+
+/** The descriptors a second membership adds to a first — by (assetKey,
+ *  sourceUrl), which is exactly the identity content reuse matches on. */
+function addedBy(
+  next: readonly ScryfallAssetDescriptor[],
+  previous: readonly ScryfallAssetDescriptor[],
+): ScryfallAssetDescriptor[] {
+  return next.filter((value) =>
+    !previous.some((old) => old.assetKey === value.assetKey && old.sourceUrl === value.sourceUrl));
+}
+
+/**
+ * `curatedDrift()` with its unmeasured arm asserted away.
+ *
+ * It answers `null` when the card data behind a membership plan is not
+ * resident, so that a passive read cannot trigger a 76 MB load. That cannot be
+ * the case in this file: every test here has already planned a membership
+ * through `installCurated` or `curatedSelector`, which loads it. Asserted
+ * rather than `!`-ed, so a change that breaks that assumption fails by name
+ * instead of as a property access on null.
+ */
+async function measuredDrift(backend: ScryfallBrowserVisualPackBackend): Promise<CuratedDrift> {
+  const drift = await backend.curatedDrift();
+  if (!drift) throw new Error("curated drift was not measured");
+  return drift;
+}
+
+describe("curated delta install", () => {
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory();
+    cache = new MemoryCache();
+    requested = [];
+    failImages = false;
+    imageBudget = Number.POSITIVE_INFINITY;
+    imagesServed = 0;
+    held = null;
+    fetchStub.mockClear();
+    vi.stubGlobal("fetch", fetchStub);
+    vi.stubGlobal("caches", { open: async () => cache } as unknown as CacheStorage);
+    usePreferencesStore.setState({ artChain: NEWEST, artOverrides: {} });
+  });
+
+  afterEach(() => {
+    held?.release();
+    held = null;
+    vi.unstubAllGlobals();
+  });
+
+  it("downloads only the assets a new digest adds, and still finishes", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const first = await installCurated(backend);
+    expect(imageRequests()).toHaveLength(first.descriptors.length);
+    const donorRows = await objectRows();
+    requested = [];
+
+    usePreferencesStore.setState({ artChain: OLDEST });
+    const second = await installCurated(backend);
+
+    expect(second.digest).not.toBe(first.digest);
+    // Part of the membership moves and part does not: Bolt's three exact rungs
+    // follow the chain to a different printing, while the chain-invariant ones
+    // are untouched. Without content reuse the whole membership is fetched
+    // again.
+    const added = addedBy(second.descriptors, first.descriptors);
+    expect(added).toHaveLength(3);
+    expect(imageRequests()).toHaveLength(3);
+    expect(new Set(imageRequests())).toEqual(new Set(added.map((value) => value.sourceUrl)));
+
+    // A fetch count cannot see any of what follows, because the reused assets
+    // never call `fetchImage`. `markComplete` writes the objects ROW as well as
+    // the counter, so a reuse path that skipped it would produce a pack that is
+    // silently that many assets short — and this step's own sweep would then
+    // find those cache entries referenced by no row and delete the bytes too.
+    //
+    // The user-facing property first, so the two assertions do not mask each
+    // other under probing: every asset of the new membership, the reused ones
+    // included, resolves AFTER the sweep that ran inside this install.
+    const reused = second.descriptors.filter((value) => !added.includes(value));
+    expect(reused).toHaveLength(CHAIN_INVARIANT_ASSETS);
+    const matches = await resolvedAssets(backend, second.descriptors);
+    expect(matches).toHaveLength(second.descriptors.length);
+    expect(reused.every((value) => matches.some((match) => match.assetKey === value.assetKey))).toBe(true);
+
+    // ...and each reused key resolves to the DONOR's entry, not merely to some
+    // entry. "It resolves" is satisfied by adopting the wrong donor, which is
+    // the failure mode `contentId`'s source-URL half exists to prevent, so the
+    // path and the bytes behind it are both asserted against the row the first
+    // install actually wrote.
+    for (const value of reused) {
+      const match = matches.find((entry) => entry.assetKey === value.assetKey);
+      expect(match?.url).toBe(pathOf(donorRows, value.assetKey));
+      expect(cachedText(match!.url)).toBe(value.sourceUrl);
+    }
+
+    // Then the accounting. MEASURED: losing this alone does NOT hang the
+    // operation — `finish()` never compares the two counters, so the record
+    // still reaches `completed` and the panel simply reports a figure that is
+    // permanently short.
+    const status = await backend.operationStatus(second.operation);
+    expect(status.state).toBe("completed");
+    expect(status.objectTotal).toBe(second.descriptors.length);
+    expect(status.objectsPromoted).toBe(status.objectTotal);
+  });
+
+  it("re-fetches an asset whose source URL moved under an unchanged key", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const first = await installCurated(backend);
+    const before = await moveGiantNormal(GIANT);
+    try {
+      const moved = await moveGiantNormal("44444444-abcd-4444-8444-444444444444");
+      // `moveGiantNormal` edits the card map IN PLACE, which the plan memo
+      // cannot see: it keys on the identity of the two preference values, and
+      // in production the card data is fetched once per session and never
+      // mutated, so a URL that moves arrives with a fresh map in a fresh tab.
+      // A fresh but CONTENT-EQUAL `artOverrides` forces the miss without
+      // perturbing the membership, so the only thing that differs between the
+      // two plans below is still the moved URL.
+      usePreferencesStore.setState({ artOverrides: {} });
+      requested = [];
+
+      const second = await installCurated(backend);
+
+      // The discriminating shape: these keys are IDENTICAL across the two
+      // memberships and only the URL behind them moved. A `canonical_card:` key
+      // names no printing, so its bytes are whatever the card data currently
+      // supplies — reuse keyed on the asset key alone would adopt the
+      // superseded image and serve stale art for ever, with the digest already
+      // changed and no path back.
+      const added = addedBy(second.descriptors, first.descriptors);
+      expect(added).toHaveLength(2);
+      expect(added.every((value) => first.descriptors.some((old) => old.assetKey === value.assetKey))).toBe(true);
+      expect(new Set(imageRequests())).toEqual(new Set(added.map((value) => value.sourceUrl)));
+
+      // Giant's art_crop rung shares the key AND the URL, so it is reused.
+      const crop = assetKey(`asset:v1:canonical_card:${GIANT}-0-art_crop-art_crop`);
+      expect(imageRequests()).not.toContain(url(GIANT, "art_crop"));
+      expect(second.descriptors.some((value) => value.assetKey === crop)).toBe(true);
+
+      // Stronger than the fetch count: read back WHICH image the moved key is
+      // serving. Reuse would leave the old URL's bytes under the new row.
+      const normal = assetKey(`asset:v1:canonical_card:${GIANT}-0-full_card-normal`);
+      const match = (await resolvedAssets(backend, second.descriptors)).find((value) => value.assetKey === normal);
+      expect(match).toBeDefined();
+      expect(cachedText(match!.url)).toBe(moved);
+      expect(cachedText(match!.url)).not.toBe(before);
+    } finally {
+      await moveGiantNormal(GIANT);
+    }
+  });
+
+  it("never reuses a row written before source URLs were recorded", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const first = await installCurated(backend);
+
+    // Exactly what a row written by the build before this step looks like. Such
+    // a row cannot say which URL its bytes came from, so it must never be
+    // reused — which is what makes the field additive and the store
+    // migration-free.
+    expect(await dropStoredSourceUrls()).toBe(first.descriptors.length);
+    usePreferencesStore.setState({ artChain: OLDEST });
+    requested = [];
+
+    const second = await installCurated(backend);
+
+    // The same three assets the first test reuses are downloaded again here.
+    expect(addedBy(second.descriptors, first.descriptors)).toHaveLength(3);
+    expect(imageRequests()).toHaveLength(second.descriptors.length);
+    expect(imageRequests()).toContain(url(GIANT, "art_crop"));
+    expect(await resolvedAssets(backend, second.descriptors)).toHaveLength(second.descriptors.length);
+  });
+
+  it("keeps an image another pack still uses and deletes one only the dropped root used", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    await installCore(backend);
+    const first = await installCurated(backend);
+    const rows = await objectRows();
+
+    const shared = first.descriptors.find((value) => value.sourceUrl === url(BOLT_NEW.id, "normal"));
+    const solo = first.descriptors.find((value) => value.sourceUrl === url(BOLT_NEW.id, "art_crop"));
+    expect(shared).toBeDefined();
+    expect(solo).toBeDefined();
+    const sharedPath = pathOf(rows, shared!.assetKey);
+    const soloPath = pathOf(rows, solo!.assetKey);
+    // Without this the survival assertion below would hold for the wrong
+    // reason: the card back and this rung must genuinely be ONE cache entry.
+    expect(pathOf(rows, assetKey("asset:v1:card_back:default"))).toBe(sharedPath);
+    expect(soloPath).not.toBe(sharedPath);
+
+    usePreferencesStore.setState({ artChain: OLDEST });
+    await installCurated(backend);
+
+    expect(cache.entries.has(sharedPath)).toBe(true);
+    expect(cache.entries.has(soloPath)).toBe(false);
+    const back = await backend.resolve([{ kind: "asset", key: assetKey("asset:v1:card_back:default") }]);
+    expect(back.entries[0].matches).toHaveLength(1);
+  });
+
+  it("sweeps identically when a pack is removed rather than replaced", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    await installCore(backend);
+    const first = await installCurated(backend);
+    const rows = await objectRows();
+
+    const shared = first.descriptors.find((value) => value.sourceUrl === url(BOLT_NEW.id, "normal"));
+    const solo = first.descriptors.find((value) => value.sourceUrl === url(BOLT_NEW.id, "art_crop"));
+    const sharedPath = pathOf(rows, shared!.assetKey);
+    const soloPath = pathOf(rows, solo!.assetKey);
+    expect(pathOf(rows, assetKey("asset:v1:card_back:default"))).toBe(sharedPath);
+
+    // `remove()`'s sweep and the curated delta's sweep are one function. This
+    // asserts the pre-existing caller keeps the pre-existing behaviour on the
+    // same fixture the replacement path is asserted against above: shared
+    // survives, sole-referenced goes.
+    await backend.remove({ kind: "packs", packIds: [packId("curated")] }, "reject_dependents");
+
+    expect(cache.entries.has(sharedPath)).toBe(true);
+    expect(cache.entries.has(soloPath)).toBe(false);
+    expect(await resolvedAssets(backend, first.descriptors)).toHaveLength(0);
+    const back = await backend.resolve([{ kind: "asset", key: assetKey("asset:v1:card_back:default") }]);
+    expect(back.entries[0].matches).toHaveLength(1);
+  });
+
+  it("clears rows and images stranded at a cancelled install's digest", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const failed = await failures(backend);
+    const first = await installCurated(backend);
+
+    // Strand a PARTIAL membership at a second digest. `markComplete` writes
+    // rows during the download, so the reused ones and the one image served
+    // before the outage all land at this digest while the packs row still names
+    // the first — and cancelling leaves them there.
+    usePreferencesStore.setState({ artChain: OLDEST });
+    imagesServed = 0;
+    imageBudget = 1;
+    const stranded = await startCurated(backend);
+    await vi.waitFor(() => { expect(failed).toHaveLength(1); }, { timeout: 5000 });
+    await backend.cancel(stranded.operation);
+
+    const stalled = await objectRows();
+    const abandoned = stalled.filter((row) => row.root === stranded.digest);
+    // Non-vacuity, and stated as a PROPERTY rather than as a named asset so the
+    // assertion cannot start passing or failing for fixture-ordering reasons:
+    // the stranded root must really hold rows, and exactly one of them must
+    // reference an image that nothing else in the database does. Without that
+    // one, "no cache entries left behind" would be unmeasurable — every other
+    // path it holds is shared with a root that survives.
+    expect(abandoned.length).toBeGreaterThan(0);
+    const orphans = abandoned.filter((row) => stalled.filter((other) => other.path === row.path).length === 1);
+    expect(orphans).toHaveLength(1);
+    const orphanPath = orphans[0].path;
+
+    usePreferencesStore.setState({ artChain: MIDDLE });
+    imageBudget = Number.POSITIVE_INFINITY;
+    const third = await installCurated(backend);
+    expect(third.digest).not.toBe(first.digest);
+    expect(third.digest).not.toBe(stranded.digest);
+
+    // Every root but the installed one is gone, rows and images alike. Nothing
+    // else could ever have reached those rows: their root names no pack, so
+    // both the replace path and `remove()` filter right past them.
+    const survivors = await objectRows();
+    expect(new Set(survivors.map((row) => row.root))).toEqual(new Set([third.digest]));
+    expect(survivors).toHaveLength(third.descriptors.length);
+    expect(cache.entries.has(orphanPath)).toBe(false);
+    // ...and the sweep is discriminating rather than indiscriminate: the shared
+    // canonical images the stranded root also referenced are still here.
+    expect(await resolvedAssets(backend, third.descriptors)).toHaveLength(third.descriptors.length);
+  });
+
+  it("does not leave a curated operation downloading when the planner throws", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, descriptors } = await curatedSelector();
+    const failed = await failures(backend);
+
+    failImages = true;
+    const started = await backend.start({ kind: "install", selector, objectEstimate: descriptors.length });
+    if (started.status !== "started") throw new Error("curated install did not start");
+    await vi.waitFor(() => { expect(failed).toHaveLength(1); }, { timeout: 5000 });
+    // The over-reach control, in the same test: a transient failure must leave
+    // the record resumable, which is the state the containment below must not
+    // start claiming for everything.
+    expect(failed[0].error).toBe("network");
+    expect((await backend.operationStatus(started.operationId)).state).toBe("downloading");
+
+    // An unexpected throw from inside the planner. The value is not the point
+    // and the containment makes no claim about causes: what matters is that
+    // something below `curatedDescriptors` throws an error that is not already
+    // a backend error, which is the class that used to reach `run()` naked,
+    // classify as the retryable `storage` default, and leave the record
+    // `downloading` — Resume its only enabled control, every durable mutation
+    // disabled, and `create()`'s pending loop re-failing on every launch.
+    usePreferencesStore.setState({ artOverrides: null as unknown as Record<string, CardArtOverride> });
+    failImages = false;
+
+    await backend.start({ kind: "resume", operationId: started.operationId });
+    await vi.waitFor(async () => {
+      expect((await backend.operationStatus(started.operationId)).state).not.toBe("downloading");
+    }, { timeout: 5000 });
+
+    expect((await backend.operationStatus(started.operationId)).state).toBe("cancelled");
+    expect(failed[1].error).toBe("internal");
+  });
+
+  it("does not scan for donors on a non-curated install", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    // A throwing stub rather than a counting one: a scan that happened would
+    // fail the install outright, so this cannot pass by the assertion being
+    // evaluated before the scan it is about.
+    const scan = vi.fn(async (): Promise<never> => { throw new Error("donor scan on a non-curated install"); });
+    const original = internals().adoptableContent;
+    internals().adoptableContent = scan;
+    const restore = () => { internals().adoptableContent = original; };
+    try {
+      await installCore(backend);
+      expect(scan).not.toHaveBeenCalled();
+
+      // Positive reach-guard: the SAME stub is reached by a curated install on
+      // the same backend, so "core did not reach it" is a property of the pack
+      // gate rather than of a seam that is dead in this fixture.
+      const { selector, descriptors } = await curatedSelector();
+      const started = await backend.start({ kind: "install", selector, objectEstimate: descriptors.length });
+      expect(started.status).toBe("started");
+      await vi.waitFor(() => { expect(scan).toHaveBeenCalled(); }, { timeout: 5000 });
+    } finally {
+      restore();
+    }
+  });
+
+  it("adopts content from a pack that is not curated", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const first = await installCurated(backend);
+
+    // A row belonging to a DIFFERENT pack at a DIFFERENT root, carrying the same
+    // (assetKey, sourceUrl) identity as one curated descriptor. Its content
+    // fields are copied from a row the backend really wrote, so only the three
+    // fields that make it another pack's row are hand-built. This is what an
+    // installed `complete`/`printing`/`locale` pack leaves behind, and
+    // `adoptableContent` opens a plain cursor with no pack filter precisely so
+    // that a curated install can reuse it.
+    const shared = first.descriptors.find((value) => value.sourceUrl === url(GIANT, "art_crop"));
+    expect(shared).toBeDefined();
+    const source = (await objectRows()).find((row) => row.assetKey === shared!.assetKey);
+    expect(source).toBeDefined();
+    const foreignPack = packId("complete");
+    const foreignRoot = "e".repeat(64) as CatalogRoot;
+    const database = await openDB(DATABASE, 1);
+    await database.put("objects", { ...source, id: `${foreignRoot}:${foreignPack}:${shared!.assetKey}`, root: foreignRoot, packId: foreignPack });
+    await database.put("packs", { id: foreignPack, packId: foreignPack, root: foreignRoot, dependencies: [], operationId: "foreign-operation" });
+    database.close();
+
+    // Drop the curated pack entirely, so nothing curated is left to adopt FROM
+    // and any reuse below has to have crossed a pack boundary. The foreign row
+    // is what keeps this one cache entry alive through `remove()`'s sweep —
+    // asserted, because if it did not the reinstall would simply re-fetch.
+    const donorPath = source!.path;
+    await backend.remove({ kind: "packs", packIds: [packId("curated")] }, "reject_dependents");
+    expect((await objectRows()).filter((row) => row.packId === packId("curated"))).toHaveLength(0);
+    expect(cache.entries.has(donorPath)).toBe(true);
+    requested = [];
+
+    const second = await installCurated(backend);
+
+    expect(second.digest).toBe(first.digest);
+    expect(imageRequests()).toHaveLength(second.descriptors.length - 1);
+    expect(imageRequests()).not.toContain(url(GIANT, "art_crop"));
+    // The fetch count above is the assertion that discriminates adoption, and
+    // it is the only one that can: paths are content-addressed, so a re-download
+    // lands on the SAME path with the SAME bytes. MEASURED — pack-filtering
+    // `adoptableContent` to curated rows fails the count (6 rather than 5) and
+    // nothing below it. What these two add is that the row the adopt path wrote
+    // is a usable one: it resolves, at the donor's entry, with the donor's
+    // bytes, rather than pointing somewhere the cache cannot serve.
+    const match = (await resolvedAssets(backend, second.descriptors))
+      .find((entry) => entry.assetKey === shared!.assetKey && entry.packId === packId("curated"));
+    expect(match?.url).toBe(donorPath);
+    expect(cachedText(donorPath)).toBe(url(GIANT, "art_crop"));
+  });
+
+  it("keeps a membership another tab is still installing", async () => {
+    // Two backend instances over ONE database, which is what two tabs are:
+    // `loadVisualPackBackend` memoizes per tab, IndexedDB does not.
+    const tabA = await ScryfallBrowserVisualPackBackend.create();
+    const tabB = await ScryfallBrowserVisualPackBackend.create();
+    await installCurated(tabA);
+
+    // Tab A starts a second membership and parks on its Bolt images. Its
+    // chain-invariant rows are adopted from the first membership and land
+    // immediately: `markComplete` writes rows DURING the download, so a partial
+    // membership is on disk at a root no packs row names — exactly the shape
+    // the abandoned root sweep collects, and exactly the shape it must not
+    // collect here.
+    const release = holdImages((source) => source.includes(BOLT_OLD.id));
+    usePreferencesStore.setState({ artChain: OLDEST });
+    const parked = await startCurated(tabA);
+    await vi.waitFor(async () => {
+      expect((await objectRows()).filter((row) => row.root === parked.digest))
+        .toHaveLength(CHAIN_INVARIANT_ASSETS);
+    }, { timeout: 5000 });
+
+    // Tab B installs a third membership and completes, running the sweep while
+    // A's rows are on disk and A's record is still `downloading`.
+    usePreferencesStore.setState({ artChain: MIDDLE });
+    const other = await installCurated(tabB);
+    expect(other.digest).not.toBe(parked.digest);
+
+    release();
+    await settle(tabA, parked.operation);
+
+    // The user-facing property: A's pack is whole. Its own status is NOT a
+    // witness for this and never can be — `objectsPromoted` counts
+    // `operationObjects` completion flags, so it reads 6 of 6 either way; the
+    // assertion below is on rows a render can actually reach.
+    const status = await tabA.operationStatus(parked.operation);
+    expect(status.state).toBe("completed");
+    expect(status.objectsPromoted).toBe(status.objectTotal);
+    expect(await resolvedAssets(tabA, parked.descriptors)).toHaveLength(parked.descriptors.length);
+  });
+
+  it("keeps a membership another tab promoted between the replace and the sweep", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    await installCurated(backend);
+
+    // The window this guards is between `completePack` and the sweep, and there
+    // is no cache or fetch seam inside it — so the seam is the sweep's own
+    // entry. Interposing there lands the injection at the first instruction of
+    // the window, where another tab's promotion would be visible to the sweep
+    // and to nothing before it.
+    const foreignRoot = "f".repeat(64) as CatalogRoot;
+    const foreignKey = assetKey("asset:v1:canonical_card:foreign-0-full_card-normal");
+    const foreignPath = "/visual-packs/v1/foreign-membership.jpg";
+    let injected = false;
+    const original = internals().collectCuratedGarbage;
+    const restore = () => { internals().collectCuratedGarbage = original; };
+    internals().collectCuratedGarbage = async function (this: unknown, ...args: never[]) {
+      if (!injected) {
+        injected = true;
+        const database = await openDB(DATABASE, 1);
+        await database.put("objects", {
+          id: `${foreignRoot}:${packId("curated")}:${foreignKey}`,
+          root: foreignRoot,
+          packId: packId("curated"),
+          assetKey: foreignKey,
+          candidateKeys: [],
+          sourceUrl: url("foreign", "normal"),
+          object: foreignRoot,
+          byteLength: 3,
+          media: "image/jpeg",
+          path: foreignPath,
+        });
+        await database.put("packs", { id: packId("curated"), packId: packId("curated"), root: foreignRoot, dependencies: [], operationId: "foreign-operation" });
+        database.close();
+        cache.entries.set(foreignPath, { body: new TextEncoder().encode("bar"), type: "image/jpeg" });
+      }
+      return original.apply(this, args);
+    };
+    try {
+      usePreferencesStore.setState({ artChain: OLDEST });
+      await installCurated(backend);
+      expect(injected).toBe(true);
+
+      const survivors = (await objectRows()).filter((row) => row.root === foreignRoot);
+      expect(survivors).toHaveLength(1);
+      expect(cache.entries.has(foreignPath)).toBe(true);
+    } finally {
+      restore();
+    }
+  });
+
+  // --- what a sync WOULD do, before it does it -----------------------------
+  //
+  // The install tests above measure the delta by watching an install run.
+  // `curatedDrift` answers the same question ahead of time, which is what the
+  // panel renders and what the pre-flight storage gate is allowed to refuse on.
+
+  it("reports an uninstalled curated pack as all-add", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { descriptors } = await curatedSelector();
+
+    const drift = await measuredDrift(backend);
+
+    // The first-install case, pinned so the delta work cannot quietly report
+    // nothing to do where there is no pack at all.
+    expect(drift.installedDigest).toBeNull();
+    expect(drift).toMatchObject({ add: descriptors.length, remove: 0, refresh: 0 });
+  });
+
+  it("reports a moved source URL as a refresh, with identical asset keys", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const first = await installCurated(backend);
+
+    const moved = await moveGiantNormal("moved");
+    // The map is edited IN PLACE and the plan memo keys on preference identity
+    // and deck text, neither of which moved — so the miss has to be forced.
+    usePreferencesStore.setState({ artOverrides: {} });
+
+    const drift = await measuredDrift(backend);
+
+    // THE CASE TWO CATEGORIES CANNOT EXPRESS: the pack is out of date — the
+    // digest says so — while both asset-key sets are identical. An
+    // add/remove-only diff renders this as "0 to add, 0 to remove" beside an
+    // enabled Sync.
+    expect(drift.membershipDigest).not.toBe(first.digest);
+    expect(drift.installedDigest).toBe(first.digest);
+    const installedKeys = (await objectRows()).map((row) => row.assetKey).sort();
+    const plannedKeys = (await curatedSelector()).descriptors.map((value) => value.assetKey).sort();
+    expect(plannedKeys).toEqual(installedKeys);
+    // `normal` moved and `small` is derived from it; `art_crop` did not.
+    expect(drift).toMatchObject({ add: 0, remove: 0, refresh: 2 });
+    expect(moved).toBe(url("moved", "normal"));
+  });
+
+  it("counts a row written before source URLs were recorded as a refresh", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const first = await installCurated(backend);
+    expect(await dropStoredSourceUrls()).toBe(first.descriptors.length);
+    usePreferencesStore.setState({ artChain: OLDEST });
+    requested = [];
+
+    const drift = await measuredDrift(backend);
+
+    // Such a row cannot say which URL its bytes came from, so `installObject`
+    // will never reuse it and the sync WILL fetch it. Counting it as unchanged
+    // would under-report the download; counting it as an add would claim the
+    // slot is not installed. It is a refresh, and it must not throw on the
+    // absent field. The chain-invariant assets are exactly the ones that would
+    // otherwise have been reported as unchanged.
+    expect(drift).toMatchObject({ add: 3, remove: 3, refresh: CHAIN_INVARIANT_ASSETS });
+
+    // The figure is only worth anything if it predicts the real download, so
+    // run the sync and compare — the whole membership, which is exactly what
+    // the no-source-URL reuse test above measures from the other end.
+    await installCurated(backend);
+    expect(imageRequests()).toHaveLength(drift.add + drift.refresh);
+  });
+
+  it("counts only the installed root's rows, not ones stranded at an abandoned digest", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const failed = await failures(backend);
+    const installed = await installCurated(backend);
+
+    // Strand a PARTIAL third membership. `markComplete` writes rows DURING the
+    // download, so the adopted ones and the single image served before the
+    // outage land at a root that no packs row names.
+    usePreferencesStore.setState({ artChain: MIDDLE });
+    imagesServed = 0;
+    imageBudget = 1;
+    const stranded = await startCurated(backend);
+    await vi.waitFor(() => { expect(failed).toHaveLength(1); }, { timeout: 5000 });
+    imageBudget = Number.POSITIVE_INFINITY;
+
+    // Reach guard: the abandoned root must really hold a row whose asset key
+    // the installed membership does not, or the filter under test has nothing
+    // to filter and the counts below would come out right either way.
+    const installedKeys = new Set(installed.descriptors.map((value) => value.assetKey));
+    await vi.waitFor(async () => {
+      const strays = (await objectRows())
+        .filter((row) => row.root === stranded.digest && !installedKeys.has(row.assetKey));
+      expect(strays).toHaveLength(1);
+    }, { timeout: 5000 });
+
+    usePreferencesStore.setState({ artChain: OLDEST });
+    const drift = await measuredDrift(backend);
+
+    // Bolt's three rungs move, Giant's three do not, and the stray is NOT a
+    // fourth thing to remove: it belongs to an abandoned membership, which is
+    // `collectCuratedGarbage`'s business. Counting it here would tell the user
+    // their sync has work that has nothing to do with their pack.
+    expect(drift.installedDigest).toBe(installed.digest);
+    expect(drift).toMatchObject({ add: 3, remove: 3, refresh: 0 });
+  });
+
+  it("separates the assets a new chain adds from the ones it leaves alone", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    await installCurated(backend);
+    usePreferencesStore.setState({ artChain: OLDEST });
+    requested = [];
+
+    const drift = await measuredDrift(backend);
+
+    // The control for the two tests above: with every stored source URL intact
+    // and none of them moved, `refresh` is zero. Without this, a diff that
+    // reported everything as a refresh would satisfy both of them.
+    expect(drift).toMatchObject({ add: 3, remove: 3, refresh: 0 });
+    await installCurated(backend);
+    expect(imageRequests()).toHaveLength(drift.add + drift.refresh);
+  });
+
+  // --- what the SAVED DECKS contribute to a membership ----------------------
+  //
+  // These live here, rather than beside the plan memo's own tests, because
+  // `deckPrintings` resolves a deck's card names through `resolveOracleIdSync`
+  // — which reads the module global `loadScryfallData` assigns. A file that
+  // module-mocks the loader never sets it, so the resolver would answer `null`
+  // for every name and a deck would silently pin nothing. Here the REAL loader
+  // runs against a `/scryfall-data.json` served by the fetch stub, which is the
+  // production ordering: `planMembership` awaits the loader before it reads a
+  // single deck.
+  describe("saved deck printings", () => {
+    afterEach(() => {
+      for (const name of ["Burn", "Plain", "Riders"]) localStorage.removeItem(STORAGE_KEY_PREFIX + name);
+    });
+
+    it("contributes nothing for a deck list that pins no printing", async () => {
+      usePreferencesStore.setState({ artChain: SOURCE_THEN_NEWEST(), artOverrides: {} });
+      const withoutDeck = await planCuratedPack();
+
+      // A plain "4 Lightning Bolt" list, which is what most saved decks are:
+      // `sourcePrinting` is optional and only a `(SET) NUM` annotation sets it.
+      // The common case, and the one a fixture can silently fall into — hence
+      // the two tests below pin the discriminating case explicitly.
+      saveDeck("Plain", [{ count: 4, name: "Lightning Bolt" }]);
+      usePreferencesStore.setState({ artChain: SOURCE_THEN_NEWEST(), artOverrides: {} });
+      const withDeck = await planCuratedPack();
+
+      expect(withDeck.membershipDigest).toBe(withoutDeck.membershipDigest);
+    });
+
+    it("plans the printing a saved deck pins, which the art chain alone would not select", async () => {
+      usePreferencesStore.setState({ artChain: SOURCE_THEN_NEWEST(), artOverrides: {} });
+      const withoutDeck = await planCuratedPack();
+
+      saveDeck("Burn", [
+        { count: 4, name: "Lightning Bolt", sourcePrinting: { setCode: "LEA", collectorNumber: "1" } },
+      ]);
+      usePreferencesStore.setState({ artChain: SOURCE_THEN_NEWEST(), artOverrides: {} });
+      const withDeck = await planCuratedPack();
+
+      // The deck's printing named INDEPENDENTLY, by planning the membership a
+      // chain pinned to LEA produces. Asserting on a count, or on "more keys
+      // than before", would pass for a deck that resolved to nothing and a
+      // chain that happened to move.
+      const lea = await membershipForSet("lea");
+      expect(exactKeys(lea)).toHaveLength(3);
+
+      for (const key of exactKeys(lea)) {
+        expect(exactKeys(withDeck)).toContain(key);
+        // The other half of the claim, and the half a single positive assertion
+        // cannot make: without the deck these keys are unreachable, so their
+        // presence is the DECK's doing and not the chain's.
+        expect(exactKeys(withoutDeck)).not.toContain(key);
+      }
+      // ...and it ADDS to the chain's own answer rather than replacing it: the
+      // no-source render context still resolves through `newest`.
+      for (const key of exactKeys(withoutDeck)) expect(exactKeys(withDeck)).toContain(key);
+      expect(exactKeys(withDeck)).toHaveLength(exactKeys(withoutDeck).length + exactKeys(lea).length);
+    });
+
+    it("resolves an accented deck name through the app's folded-name index", async () => {
+      usePreferencesStore.setState({ artChain: SOURCE_THEN_NEWEST(), artOverrides: {} });
+      const withoutDeck = await planCuratedPack();
+
+      // Typed WITHOUT the accent, which is what a decklist pasted out of a text
+      // file carries. Bare lowercasing yields "eowyn, fearless knight" and the
+      // card is stored under "éowyn, ..."; only the folded-name index bridges
+      // them, and that index exists only once the real loader has resolved.
+      //
+      // In the SIDEBOARD, which pins art exactly as the main deck does: the
+      // builder renders those cards too, and both slots are `DeckEntry[]`. The
+      // remaining slots — commander, companion, stickers, planar, scheme,
+      // signature spell — carry no printing identity at all.
+      saveDeck("Riders", [], [
+        { count: 1, name: "Eowyn, Fearless Knight", sourcePrinting: { setCode: "SLD", collectorNumber: "1" } },
+      ]);
+      usePreferencesStore.setState({ artChain: SOURCE_THEN_NEWEST(), artOverrides: {} });
+      const withDeck = await planCuratedPack();
+
+      const sld = await membershipForSet("sld");
+      // Only Éowyn has an SLD printing, so this names her pinned art and nothing
+      // else — the assertions below are about that card, not about a count.
+      expect(exactKeys(sld)).toHaveLength(3);
+      for (const key of exactKeys(sld)) {
+        expect(exactKeys(withDeck)).toContain(key);
+        expect(exactKeys(withoutDeck)).not.toContain(key);
+      }
+    });
+  });
+});

--- a/client/src/services/visualPacks/browser/__tests__/curatedSelector.test.tsx
+++ b/client/src/services/visualPacks/browser/__tests__/curatedSelector.test.tsx
@@ -1,0 +1,627 @@
+import "fake-indexeddb/auto";
+
+import { IDBFactory } from "fake-indexeddb";
+import { openDB } from "idb";
+import { act, cleanup, fireEvent, render, renderHook, screen, waitFor } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { VisualPackManager } from "../../../../components/settings/visual-packs/VisualPackManager.tsx";
+import { useVisualPackManager } from "../../../../components/settings/visual-packs/useVisualPackManager.ts";
+import { usePreferencesStore, type ArtChainEntry } from "../../../../stores/preferencesStore.ts";
+import type { PrintingEntry } from "../../../scryfall.ts";
+import { packId } from "../../types.ts";
+import type { CatalogRoot, InstallSelector, OperationId, ProgressEvent, ResolutionResponse } from "../../types.ts";
+import type { ScryfallAssetDescriptor } from "../descriptors.ts";
+import { ScryfallBrowserVisualPackBackend } from "../scryfallBackend.ts";
+import { planCuratedPack } from "../../curatedPack.ts";
+
+const platform = vi.hoisted(() => ({ load: vi.fn() }));
+vi.mock("../../../platform.ts", () => ({ loadVisualPackBackend: platform.load }));
+vi.mock("../../../../hooks/useSetSymbols.ts", () => ({ useSetCatalog: () => ({ catalog: null, isLoading: false }) }));
+
+// The one URL this whole selector exists to avoid. `loadScryfallBulkSource`
+// still fetches the small INDEX above it — that is intended — so the download
+// uri is what a curated install must never request.
+//
+// The GUARD on that is the fetch stub, which throws `unexpected fetch` on any
+// URL it does not recognise, this one included: a curated install that opened
+// the bulk stream would fail the test at the fetch, before any assertion ran.
+// The `expect(requested).not.toContain(BULK_DOWNLOAD_URL)` lines below can
+// therefore never be the failing assertion. They are kept as a statement of
+// intent for the reader, not as the mechanism.
+const BULK_INDEX_URL = "https://api.scryfall.com/bulk-data";
+const BULK_DOWNLOAD_URL = "https://data.scryfall.io/all-cards.jsonl.gz";
+const BULK_RECORD = {
+  type: "all_cards",
+  updated_at: "2026-08-01T00:00:00.000Z",
+  jsonl_download_uri: BULK_DOWNLOAD_URL,
+  compressed_size: 2_400_000_000,
+};
+
+const BOLT = "11111111-abcd-4111-8111-111111111111";
+const GIANT = "22222222-abcd-4222-8222-222222222222";
+const TOKEN_ORACLE = "33333333-abcd-4333-8333-333333333333";
+
+function url(token: string, size: string): string {
+  return `https://cards.scryfall.io/${size}/front/a/b/${token}.jpg`;
+}
+
+function imageFace(token: string) {
+  return { normal: url(token, "normal"), art_crop: url(token, "art_crop") };
+}
+
+function printing(id: string, set: string, releasedAt: string): PrintingEntry {
+  return {
+    id,
+    set,
+    set_name: set.toUpperCase(),
+    collector_number: "1",
+    released_at: releasedAt,
+    border_color: "black",
+    frame_effects: [],
+    full_art: false,
+    faces: [imageFace(id)],
+  };
+}
+
+const BOLT_NEW = printing("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", "m20", "2019-07-12");
+const BOLT_OLD = printing("bbbbbbbb-bbbb-4bbb-8bbb-bbbbbbbbbbbb", "lea", "1993-08-05");
+
+function cardEntry(oracleId: string, name: string, faceName: string) {
+  return { oracle_id: oracleId, name, face_names: [faceName], faces: [imageFace(oracleId)] };
+}
+
+const BOLT_ENTRY = cardEntry(BOLT, "Lightning Bolt", "lightning bolt");
+const GIANT_ENTRY = cardEntry(GIANT, "Giant Growth", "giant growth");
+
+// Keyed by oracle id AND by lowercased name, exactly as `scryfall-data.json`
+// is, plus one `token:` key the planner must skip.
+const CARDS = {
+  [BOLT]: BOLT_ENTRY,
+  "lightning bolt": BOLT_ENTRY,
+  [GIANT]: GIANT_ENTRY,
+  "giant growth": GIANT_ENTRY,
+  [`token:${TOKEN_ORACLE}`]: cardEntry(TOKEN_ORACLE, "Soldier", "soldier"),
+};
+// Giant Growth is absent, so it takes the canonical path; Lightning Bolt has
+// two printings, so the art chain picks a different one for each of them.
+const PRINTINGS: Record<string, PrintingEntry[]> = { [BOLT]: [BOLT_NEW, BOLT_OLD] };
+
+const NEWEST: ArtChainEntry[] = [{ type: "newest" }];
+const OLDEST: ArtChainEntry[] = [{ type: "oldest" }];
+
+/** An in-memory `Cache`, holding only what this backend asks of one. */
+class MemoryCache {
+  readonly entries = new Map<string, { body: Uint8Array; type: string }>();
+
+  async put(request: string, response: Response): Promise<void> {
+    this.entries.set(request, {
+      body: new Uint8Array(await response.arrayBuffer()),
+      type: response.headers.get("Content-Type") ?? "application/octet-stream",
+    });
+  }
+
+  async match(request: string): Promise<Response | undefined> {
+    const entry = this.entries.get(request);
+    return entry ? new Response(entry.body, { headers: { "Content-Type": entry.type } }) : undefined;
+  }
+
+  async delete(request: string): Promise<boolean> {
+    return this.entries.delete(request);
+  }
+}
+
+let cache = new MemoryCache();
+let requested: string[] = [];
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), { status: 200, headers: { "Content-Type": "application/json" } });
+}
+
+function imageResponse(source: string): Response {
+  // URL-derived bytes, so content-addressed paths differ per asset the way
+  // real images do.
+  return new Response(new TextEncoder().encode(source), { status: 200, headers: { "Content-Type": "image/jpeg" } });
+}
+
+/** A transient image outage: `fetchImage` rejects a non-200 as `network`. */
+let failImages = false;
+
+const fetchStub = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+  const source = String(input);
+  requested.push(source);
+  if (source === BULK_INDEX_URL) return jsonResponse({ data: [BULK_RECORD] });
+  if (source === "/scryfall-data.json") return jsonResponse(CARDS);
+  if (source === "/scryfall-printings.json") return jsonResponse(PRINTINGS);
+  if (source.startsWith("https://cards.scryfall.io/") || source.startsWith("https://backs.scryfall.io/")) {
+    return failImages ? new Response("", { status: 503 }) : imageResponse(source);
+  }
+  throw new Error(`unexpected fetch: ${source}`);
+});
+
+const DATABASE = "phase-visual-packs-scryfall-v1";
+
+/**
+ * Reopen the crash window between `completePack` and `finish`: the pack's row
+ * is already written with this operation's id while the operation itself is
+ * still `downloading`. Emptying the cache alongside this makes "nothing was
+ * re-downloaded" measurable in fetch counts rather than in a cache hit.
+ *
+ * A caller that also clears the cache must read the follow-up
+ * `resolvedAssets(...)` accordingly: `resolve()` admits a row only when its
+ * bytes are still cached, so an emptied cache forces that count to 0 no matter
+ * what the resume did. It is an artifact of the cache clear and says nothing
+ * about resume behaviour. The load-bearing assertions are the fetch count and
+ * `settle()` reaching `completed`.
+ */
+async function interrupt(operation: OperationId): Promise<void> {
+  const database = await openDB(DATABASE, 1);
+  const record = await database.get("operations", operation);
+  await database.put("operations", { ...record, state: "downloading", completedRevision: null });
+  database.close();
+}
+
+function imageRequests(): string[] {
+  return requested.filter((entry) => entry.startsWith("https://cards.scryfall.io/"));
+}
+
+async function curatedSelector(): Promise<{ selector: InstallSelector; descriptors: readonly ScryfallAssetDescriptor[] }> {
+  const membership = await planCuratedPack();
+  return {
+    selector: { kind: "curated", membershipDigest: membership.membershipDigest },
+    descriptors: membership.descriptors,
+  };
+}
+
+/** The `failed` progress events one backend instance emits, from this point on. */
+async function failures(backend: ScryfallBrowserVisualPackBackend): Promise<ProgressEvent[]> {
+  const events: ProgressEvent[] = [];
+  await backend.subscribeProgress((event) => {
+    if (event.phase === "failed") events.push(event);
+  });
+  return events;
+}
+
+/** Every persisted operation record, read the way a fresh launch reads them. */
+async function operationRecords(): Promise<unknown[]> {
+  const database = await openDB(DATABASE, 1);
+  const records = await database.getAll("operations");
+  database.close();
+  return records;
+}
+
+async function settle(backend: ScryfallBrowserVisualPackBackend, operation: OperationId): Promise<void> {
+  await vi.waitFor(async () => {
+    expect((await backend.operationStatus(operation)).state).toBe("completed");
+  }, { timeout: 5000 });
+}
+
+async function installCurated(backend: ScryfallBrowserVisualPackBackend): Promise<{
+  digest: CatalogRoot;
+  descriptors: readonly ScryfallAssetDescriptor[];
+  operation: OperationId;
+}> {
+  const { selector, descriptors } = await curatedSelector();
+  const response = await backend.start({ kind: "install", selector, objectEstimate: descriptors.length });
+  if (response.status !== "started") throw new Error("curated install did not start");
+  await settle(backend, response.operationId);
+  return { digest: (selector as { membershipDigest: CatalogRoot }).membershipDigest, descriptors, operation: response.operationId };
+}
+
+/** Every installed object a render-time asset lookup can actually reach. This
+ *  is the whole membership as the app sees it: `resolve` admits a row only
+ *  when its root matches its pack's root and its bytes are still cached. */
+async function resolvedAssets(
+  backend: ScryfallBrowserVisualPackBackend,
+  descriptors: readonly ScryfallAssetDescriptor[],
+): Promise<ResolutionResponse["entries"][number]["matches"]> {
+  const response = await backend.resolve(descriptors.map((value) => ({ kind: "asset", key: value.assetKey })));
+  return response.entries.flatMap((entry) => entry.matches);
+}
+
+describe("curated install selector", () => {
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory();
+    cache = new MemoryCache();
+    requested = [];
+    failImages = false;
+    fetchStub.mockClear();
+    vi.stubGlobal("fetch", fetchStub);
+    vi.stubGlobal("caches", { open: async () => cache } as unknown as CacheStorage);
+    usePreferencesStore.setState({ artChain: NEWEST, artOverrides: {} });
+    platform.load.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.unstubAllGlobals();
+  });
+
+  it("installs the planned membership without opening the bulk stream", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { digest, descriptors, operation } = await installCurated(backend);
+
+    expect(requested).not.toContain(BULK_DOWNLOAD_URL);
+    expect(imageRequests()).toHaveLength(descriptors.length);
+    // Two rungs from Bolt's chain-selected printing plus its art crop, and the
+    // same three for Giant Growth's canonical form. The token key contributes
+    // nothing.
+    expect(descriptors).toHaveLength(6);
+    expect(descriptors.filter((value) => value.assetKey.startsWith("asset:v1:canonical_card:"))).toHaveLength(3);
+
+    const matches = await resolvedAssets(backend, descriptors);
+    expect(matches).toHaveLength(descriptors.length);
+    expect(new Set(matches.map((match) => match.catalogRoot))).toEqual(new Set([digest]));
+
+    // The operation reports the CATALOG's identity, not the pack's root.
+    const summary = await backend.catalogSummary();
+    const status = await backend.operationStatus(operation);
+    expect(status.catalogRoot).toBe(summary.catalogRoot);
+    expect(status.catalogRoot).not.toBe(digest);
+    expect(summary.selectorCount).toBe(5);
+  });
+
+  it("records the curated pack at its membership digest and starts at the catalog root", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, descriptors } = await curatedSelector();
+    const digest = (selector as { membershipDigest: CatalogRoot }).membershipDigest;
+    const revisions: CatalogRoot[] = [];
+    await backend.subscribeRevision((event) => {
+      if (event.catalogRoot) revisions.push(event.catalogRoot);
+    });
+
+    const response = await backend.start({ kind: "install", selector, objectEstimate: descriptors.length });
+    if (response.status !== "started") throw new Error("curated install did not start");
+    await settle(backend, response.operationId);
+
+    const summary = await backend.catalogSummary();
+    expect(summary.installedPacks).toEqual([{ packId: packId("curated"), catalogRoot: digest }]);
+    // StartResponse and the revision event both name the CATALOG.
+    expect(response.catalogRoot).toBe(summary.catalogRoot);
+    expect(revisions).toEqual([summary.catalogRoot]);
+  });
+
+  it("reports ready and renders the pack manager after a curated-only install", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { digest } = await installCurated(backend);
+
+    const status = await backend.catalogStatus();
+    expect(status.status).toBe("ready");
+    if (status.status !== "ready") throw new Error("catalog not ready");
+    expect(status.summary.installedPacks).toEqual([{ packId: packId("curated"), catalogRoot: digest }]);
+
+    platform.load.mockResolvedValue(backend);
+    render(<VisualPackManager />);
+    expect(await screen.findByText(/Offline card images/i)).toBeInTheDocument();
+    // The installed curated row, found by the one line only that row renders.
+    // Its NAME is now "One image per card", which the selector radio also
+    // carries, so matching on the name alone would be ambiguous — and matching
+    // on the raw `curated` pack id no longer finds anything, because the panel
+    // stopped quoting wire identities at users (step 5c-ii, item 4).
+    expect(await screen.findByText(/Membership fingerprint:/)).toBeInTheDocument();
+  });
+
+  it("estimates a curated pack without the bulk archive's shard figures", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const catalog = await backend.refreshCatalog();
+    const { selector, descriptors } = await curatedSelector();
+
+    const estimate = await backend.estimateInstall(selector);
+
+    expect(estimate.shardCount).toBe("0");
+    expect(estimate.shardBytes).toBe("unknown");
+    expect(estimate.assetRecords).toBe(String(descriptors.length));
+    expect(estimate.uniqueObjects).toBe(String(descriptors.length));
+    // The estimate names the catalog it was taken against; PackSelector only
+    // renders one whose root equals the summary's.
+    expect(estimate.catalogRoot).toBe(catalog.catalogRoot);
+    expect(requested).not.toContain(BULK_DOWNLOAD_URL);
+  });
+
+  it("refuses a curated selector the planned membership no longer hashes to", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector } = await curatedSelector();
+    usePreferencesStore.setState({ artChain: OLDEST });
+
+    // The digest IS the pack's catalog root, so honouring a stale selector
+    // would store this membership under a root it does not hash to. Same
+    // reason `complete` rejects a selector naming a superseded bulk root.
+    await expect(backend.estimateInstall(selector)).rejects.toMatchObject({ kind: "conflict" });
+  });
+
+  it("refuses a stale curated install before any operation record exists", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, descriptors } = await curatedSelector();
+    usePreferencesStore.setState({ artChain: OLDEST });
+
+    // The common sequence: estimate, change the art chain, then press Install.
+    // A curated conflict is structurally non-retryable, so it has to reach the
+    // caller as a rejected request. Creating a record first and failing it
+    // inside `run()` leaves an operation stuck in `downloading` whose only
+    // enabled control is a Resume that can never succeed.
+    await expect(backend.start({ kind: "install", selector, objectEstimate: descriptors.length }))
+      .rejects.toMatchObject({ kind: "conflict" });
+
+    // Asserted on the store, not on the return value: the defect this replaces
+    // returned `{status:"started"}` and left the record behind.
+    expect(await operationRecords()).toHaveLength(0);
+  });
+
+  it("keeps a curated operation resumable after a transient download failure", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, descriptors } = await curatedSelector();
+    const failed = await failures(backend);
+
+    failImages = true;
+    const started = await backend.start({ kind: "install", selector, objectEstimate: descriptors.length });
+    if (started.status !== "started") throw new Error("curated install did not start");
+    await vi.waitFor(() => { expect(failed).toHaveLength(1); }, { timeout: 5000 });
+
+    // The regression guard on the terminate rule. Only a STRUCTURALLY
+    // non-retryable failure may end a record; a network outage must leave it
+    // `downloading`, because that state is precisely what keeps Resume offered
+    // and able to succeed.
+    expect(failed[0].error).toBe("network");
+    expect((await backend.operationStatus(started.operationId)).state).toBe("downloading");
+
+    failImages = false;
+    expect(await backend.start({ kind: "resume", operationId: started.operationId }))
+      .toMatchObject({ status: "started", operationId: started.operationId });
+    await settle(backend, started.operationId);
+    expect(await resolvedAssets(backend, descriptors)).toHaveLength(descriptors.length);
+  });
+
+  it("terminates a curated operation whose membership moved and never resurrects it", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, descriptors } = await curatedSelector();
+    const failed = await failures(backend);
+
+    // A transient failure first: `start()` now refuses a stale digest outright,
+    // so the only way a curated record can outlive its own start and then meet
+    // a conflict is a preference change AFTER it was created.
+    failImages = true;
+    const started = await backend.start({ kind: "install", selector, objectEstimate: descriptors.length });
+    if (started.status !== "started") throw new Error("curated install did not start");
+    await vi.waitFor(() => { expect(failed).toHaveLength(1); }, { timeout: 5000 });
+
+    usePreferencesStore.setState({ artChain: OLDEST });
+    failImages = false;
+
+    // The launch path: `create()` re-runs every record still `downloading`.
+    const relaunched = await ScryfallBrowserVisualPackBackend.create();
+    await vi.waitFor(async () => {
+      expect((await relaunched.operationStatus(started.operationId)).state).not.toBe("downloading");
+    }, { timeout: 5000 });
+    expect((await relaunched.operationStatus(started.operationId)).state).toBe("cancelled");
+
+    const again = await ScryfallBrowserVisualPackBackend.create();
+    const relaunchFailures = await failures(again);
+
+    // A fresh curated install at the CURRENT digest, on the instance that just
+    // launched, does two jobs: it proves the panel is genuinely unwedged rather
+    // than merely flagged, and it is the positive control for the wait window
+    // below — a resurrected operation reaches its own conflict in far less work
+    // than a full six-image install, so zero failures across it is a
+    // measurement rather than a timeout.
+    const fresh = await installCurated(again);
+    expect(await resolvedAssets(again, fresh.descriptors)).toHaveLength(fresh.descriptors.length);
+    expect(fresh.digest).not.toBe((selector as { membershipDigest: CatalogRoot }).membershipDigest);
+    expect(relaunchFailures).toHaveLength(0);
+    expect((await again.operationStatus(started.operationId)).state).toBe("cancelled");
+  });
+
+  it("survives another tab promoting the curated pack mid-install", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, descriptors } = await curatedSelector();
+    const digest = (selector as { membershipDigest: CatalogRoot }).membershipDigest;
+    let announce: (value: OperationId) => void = () => undefined;
+    const running = new Promise<OperationId>((resolve) => { announce = resolve; });
+    let promoted = false;
+
+    // `run()` serialises work within ONE backend instance, but IndexedDB is
+    // shared across tabs and `loadVisualPackBackend` is a per-tab memo, so two
+    // tabs can resume the same pending operation with no lock between them.
+    // This is that interleaving: the other tab promotes the pack — same
+    // operation id, same root — while this one is still downloading.
+    vi.stubGlobal("fetch", vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+      const source = String(input);
+      if (!promoted && source.startsWith("https://cards.scryfall.io/")) {
+        promoted = true;
+        const database = await openDB(DATABASE, 1);
+        await database.put("packs", {
+          id: packId("curated"),
+          packId: packId("curated"),
+          root: digest,
+          dependencies: [],
+          operationId: await running,
+        });
+        database.close();
+      }
+      return fetchStub(input);
+    }));
+
+    const response = await backend.start({ kind: "install", selector, objectEstimate: descriptors.length });
+    if (response.status !== "started") throw new Error("curated install did not start");
+    announce(response.operationId);
+    await settle(backend, response.operationId);
+
+    // `completePack`'s replace-guard is what stops this: comparing the existing
+    // row's root against the SELECTOR's root recognises the promotion and
+    // returns. Comparing it against the bulk root cannot ever match a curated
+    // pack, so the cursor loop below it deletes every objects row at the
+    // digest — the entire membership.
+    expect(await resolvedAssets(backend, descriptors)).toHaveLength(descriptors.length);
+  });
+
+  it("surfaces a curated estimate through the manager hook", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    await backend.refreshCatalog();
+    platform.load.mockResolvedValue(backend);
+    const { selector, descriptors } = await curatedSelector();
+
+    const { result } = renderHook(() => useVisualPackManager());
+    await waitFor(() => { expect(result.current.availability.kind).toBe("ready"); });
+    act(() => { result.current.estimateInstall(selector); });
+
+    // `signedSelectorName` must map a curated selector to its PACK ID. The hook
+    // discards an estimate whose `selector` field disagrees, and a curated
+    // selector's identity string carries a digest the pack id does not — so
+    // without that mapping the estimate is dropped SILENTLY: no estimate, no
+    // error, and Install permanently disabled. `actionError` is therefore as
+    // load-bearing here as the value.
+    await waitFor(() => {
+      expect(result.current.estimate?.value.assetRecords).toBe(String(descriptors.length));
+    });
+    expect(result.current.actionError).toBeNull();
+  });
+
+  it("short-circuits a re-install at an unchanged digest without churning the membership", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { descriptors } = await installCurated(backend);
+    const before = await resolvedAssets(backend, descriptors);
+    // Without this the "intact" comparison below would hold vacuously over two
+    // empty memberships.
+    expect(before).toHaveLength(descriptors.length);
+    requested = [];
+
+    const { selector } = await curatedSelector();
+    const response = await backend.start({ kind: "install", selector, objectEstimate: descriptors.length });
+
+    expect(response).toEqual({ status: "healthy" });
+    expect(imageRequests()).toHaveLength(0);
+    expect(await resolvedAssets(backend, descriptors)).toEqual(before);
+  });
+
+  it("leaves the membership intact when the curated pack is repaired", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { descriptors } = await installCurated(backend);
+    const before = await resolvedAssets(backend, descriptors);
+    // Without this the "intact" comparison below would hold vacuously over two
+    // empty memberships.
+    expect(before).toHaveLength(descriptors.length);
+    requested = [];
+
+    // Curated repair is structurally a no-op: the repair selector's digest is
+    // sourced from the packs row it is then compared against. Sourcing it from
+    // the bulk root instead would let the operation run and cursor-delete the
+    // whole membership.
+    const response = await backend.start({ kind: "repair", packIds: [packId("curated")] });
+
+    expect(response).toEqual({ status: "healthy" });
+    expect(imageRequests()).toHaveLength(0);
+    expect(await resolvedAssets(backend, descriptors)).toEqual(before);
+  });
+
+  it("re-downloads nothing when an interrupted curated operation resumes", async () => {
+    const first = await ScryfallBrowserVisualPackBackend.create();
+    const { descriptors, operation } = await installCurated(first);
+
+    await interrupt(operation);
+    cache.entries.clear();
+    requested = [];
+
+    const resumed = await ScryfallBrowserVisualPackBackend.create();
+    await settle(resumed, operation);
+
+    expect(requested).toHaveLength(0);
+    expect(await resolvedAssets(resumed, descriptors)).toHaveLength(0);
+  });
+
+  it("resumes an interrupted curated operation at the catalog root", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { descriptors, operation } = await installCurated(backend);
+    const catalog = await backend.catalogSummary();
+    await interrupt(operation);
+    cache.entries.clear();
+    requested = [];
+
+    const response = await backend.start({ kind: "resume", operationId: operation });
+
+    // `unsupported` because happy-dom exposes no `navigator.storage`; the
+    // point of asserting it here is that a resume reports the grant at all,
+    // since a resume writes bytes exactly like the install it continues.
+    expect(response).toEqual({
+      status: "started",
+      operationId: operation,
+      catalogRoot: catalog.catalogRoot,
+      persistence: "unsupported",
+    });
+    await settle(backend, operation);
+    expect(requested).toHaveLength(0);
+    expect(await resolvedAssets(backend, descriptors)).toHaveLength(0);
+  });
+
+  it("keeps a non-curated pack on the bulk catalog root", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const response = await backend.start({ kind: "install", selector: { kind: "core" }, objectEstimate: 1 });
+    if (response.status !== "started") throw new Error("core install did not start");
+    await settle(backend, response.operationId);
+
+    const summary = await backend.catalogSummary();
+    expect(summary.installedPacks).toEqual([{ packId: packId("core"), catalogRoot: summary.catalogRoot }]);
+    expect(response.catalogRoot).toBe(summary.catalogRoot);
+    // The restructured installed-filter must still short-circuit a re-install.
+    expect(await backend.start({ kind: "install", selector: { kind: "core" }, objectEstimate: 1 }))
+      .toEqual({ status: "healthy" });
+  });
+
+  it("replaces the membership wholesale when the art chain changes the digest", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const first = await installCurated(backend);
+
+    usePreferencesStore.setState({ artChain: OLDEST });
+    const second = await installCurated(backend);
+
+    expect(second.digest).not.toBe(first.digest);
+    // The chain now picks Bolt's older printing, so its three exact_printing
+    // keys move while Giant Growth's canonical three stay put.
+    expect(second.descriptors.map((value) => value.assetKey))
+      .not.toEqual(first.descriptors.map((value) => value.assetKey));
+
+    const matches = await resolvedAssets(backend, second.descriptors);
+    expect(matches).toHaveLength(second.descriptors.length);
+    expect(new Set(matches.map((match) => match.catalogRoot))).toEqual(new Set([second.digest]));
+
+    const summary = await backend.catalogSummary();
+    expect(summary.installedPacks).toEqual([{ packId: packId("curated"), catalogRoot: second.digest }]);
+    // The superseded root keeps no reachable rows.
+    const stale = first.descriptors.filter((value) =>
+      !second.descriptors.some((kept) => kept.assetKey === value.assetKey));
+    expect(stale.length).toBeGreaterThan(0);
+    expect(await resolvedAssets(backend, stale)).toHaveLength(0);
+  });
+
+  it("installs a curated pack driven entirely from the settings panel", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    await backend.refreshCatalog();
+    platform.load.mockResolvedValue(backend);
+    const { selector, descriptors } = await curatedSelector();
+    const digest = (selector as { membershipDigest: CatalogRoot }).membershipDigest;
+    requested = [];
+
+    render(<VisualPackManager />);
+    // The radio, not the panel title: the title renders in every availability
+    // state including `loading`, so awaiting it would let the click race the
+    // backend's initialize and find no radiogroup at all.
+    fireEvent.click(await screen.findByRole("radio", { name: /one image per card/i }));
+
+    // The only click between here and a running install is Install itself:
+    // the estimate that enables it is requested by the selection. Install is
+    // gated on a matching estimate, so its enabled state IS that assertion.
+    const install = await screen.findByRole("button", { name: /install selection/i });
+    await waitFor(() => { expect(install).toBeEnabled(); }, { timeout: 5000 });
+    fireEvent.click(install);
+
+    await waitFor(async () => {
+      expect(await resolvedAssets(backend, descriptors)).toHaveLength(descriptors.length);
+    }, { timeout: 5000 });
+
+    expect(await backend.catalogSummary())
+      .toMatchObject({ installedPacks: [{ packId: packId("curated"), catalogRoot: digest }] });
+    // The scan this selector exists to avoid, from the path a user actually
+    // takes. The fetch stub throws on any unrecognised URL, so opening the
+    // bulk stream would fail this test at the fetch rather than here.
+    expect(requested).not.toContain(BULK_DOWNLOAD_URL);
+    expect(imageRequests()).toHaveLength(descriptors.length);
+  });
+});

--- a/client/src/services/visualPacks/browser/__tests__/installSizing.test.ts
+++ b/client/src/services/visualPacks/browser/__tests__/installSizing.test.ts
@@ -1,0 +1,666 @@
+import "fake-indexeddb/auto";
+
+import { gzipSync } from "node:zlib";
+
+import { IDBFactory } from "fake-indexeddb";
+import { openDB } from "idb";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { usePreferencesStore, type ArtChainEntry } from "../../../../stores/preferencesStore.ts";
+import { loadScryfallData, type PrintingEntry } from "../../../scryfall.ts";
+import { VisualPackStorageRefusalError } from "../../backend.ts";
+import { planCuratedPack } from "../../curatedPack.ts";
+import { estimatedImageBytes, IMAGE_RUNG_MEDIAN_BYTES, minimumImageBytes } from "../../types.ts";
+import type { CatalogRoot, InstallSelector } from "../../types.ts";
+import { ScryfallBrowserVisualPackBackend } from "../scryfallBackend.ts";
+
+/**
+ * The three-rung ladder's total median size for ONE card face.
+ *
+ * Summed here from the exported per-rung table rather than written as a
+ * literal: a literal would have to be hand-edited whenever the sampled
+ * constants move, and a figure hand-edited to match the code it is meant to
+ * pin stops pinning anything. What these tests assert is the RELATION — one
+ * face costs one full ladder — which is the model's actual claim.
+ */
+const FACE_BYTES = Object.values(IMAGE_RUNG_MEDIAN_BYTES).reduce((total, bytes) => total + bytes, 0);
+const RUNGS_PER_FACE = Object.keys(IMAGE_RUNG_MEDIAN_BYTES).length;
+const GIB = 1024 ** 3;
+
+const BULK_INDEX_URL = "https://api.scryfall.com/bulk-data";
+const BULK_DOWNLOAD_URL = "https://data.scryfall.io/all-cards.jsonl.gz";
+
+const BOLT = "11111111-abcd-4111-8111-111111111111";
+const GIANT = "22222222-abcd-4222-8222-222222222222";
+
+function url(token: string, size: string): string {
+  return `https://cards.scryfall.io/${size}/front/a/b/${token}.jpg`;
+}
+
+function imageFace(token: string) {
+  return { normal: url(token, "normal"), art_crop: url(token, "art_crop") };
+}
+
+/** Scryfall's own shape, as the bulk JSONL carries it: all three rungs. */
+function bulkImages(token: string) {
+  return { small: url(token, "small"), normal: url(token, "normal"), art_crop: url(token, "art_crop") };
+}
+
+function printing(id: string, set: string, releasedAt: string): PrintingEntry {
+  return {
+    id,
+    set,
+    set_name: set.toUpperCase(),
+    collector_number: "1",
+    released_at: releasedAt,
+    border_color: "black",
+    frame_effects: [],
+    full_art: false,
+    faces: [imageFace(id)],
+  };
+}
+
+function cardEntry(oracleId: string, name: string, faceName: string) {
+  return { oracle_id: oracleId, name, face_names: [faceName], faces: [imageFace(oracleId)] };
+}
+
+const BOLT_ENTRY = cardEntry(BOLT, "Lightning Bolt", "lightning bolt");
+const GIANT_ENTRY = cardEntry(GIANT, "Giant Growth", "giant growth");
+const CARDS = {
+  [BOLT]: BOLT_ENTRY,
+  "lightning bolt": BOLT_ENTRY,
+  [GIANT]: GIANT_ENTRY,
+  "giant growth": GIANT_ENTRY,
+};
+const PRINTINGS: Record<string, PrintingEntry[]> = {
+  [BOLT]: [printing("aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa", "m20", "2019-07-12")],
+};
+const NEWEST: ArtChainEntry[] = [{ type: "newest" }];
+
+/**
+ * Three English faces across two English printings, plus one non-English
+ * printing the `complete` selector must skip. Nine image records, three faces.
+ */
+const BULK_LINES = [
+  {
+    id: "cccccccc-cccc-4ccc-8ccc-cccccccccccc",
+    oracle_id: BOLT, set: "m20", lang: "en", name: "Lightning Bolt", collector_number: "1",
+    image_uris: bulkImages("bulk-bolt"),
+  },
+  {
+    id: "dddddddd-dddd-4ddd-8ddd-dddddddddddd",
+    oracle_id: GIANT, set: "m20", lang: "en", name: "Two // Faced", collector_number: "2",
+    card_faces: [
+      { name: "Two", image_uris: bulkImages("bulk-two") },
+      { name: "Faced", image_uris: bulkImages("bulk-faced") },
+    ],
+  },
+  {
+    id: "eeeeeeee-eeee-4eee-8eee-eeeeeeeeeeee",
+    oracle_id: BOLT, set: "m20", lang: "de", name: "Blitzschlag", collector_number: "1",
+    image_uris: bulkImages("bulk-de"),
+  },
+];
+const BULK_FACES = 3;
+
+const BULK_BODY = gzipSync(Buffer.from(BULK_LINES.map((line) => JSON.stringify(line)).join("\n") + "\n"));
+const BULK_RECORD = {
+  type: "all_cards",
+  updated_at: "2026-08-01T00:00:00.000Z",
+  jsonl_download_uri: BULK_DOWNLOAD_URL,
+  compressed_size: BULK_BODY.byteLength,
+};
+
+class MemoryCache {
+  readonly entries = new Map<string, { body: Uint8Array; type: string }>();
+
+  async put(request: string, response: Response): Promise<void> {
+    this.entries.set(request, {
+      body: new Uint8Array(await response.arrayBuffer()),
+      type: response.headers.get("Content-Type") ?? "application/octet-stream",
+    });
+  }
+
+  async match(request: string): Promise<Response | undefined> {
+    const entry = this.entries.get(request);
+    return entry ? new Response(entry.body, { headers: { "Content-Type": entry.type } }) : undefined;
+  }
+
+  async delete(request: string): Promise<boolean> {
+    return this.entries.delete(request);
+  }
+}
+
+let cache = new MemoryCache();
+
+function jsonResponse(value: unknown): Response {
+  return new Response(JSON.stringify(value), { status: 200, headers: { "Content-Type": "application/json" } });
+}
+
+const fetchStub = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
+  const source = String(input);
+  if (source === BULK_INDEX_URL) return jsonResponse({ data: [BULK_RECORD] });
+  if (source === BULK_DOWNLOAD_URL) {
+    return new Response(new Uint8Array(BULK_BODY), { status: 200, headers: { "Content-Type": "application/gzip" } });
+  }
+  if (source === "/scryfall-data.json") return jsonResponse(CARDS);
+  if (source === "/scryfall-printings.json") return jsonResponse(PRINTINGS);
+  if (source.startsWith("https://cards.scryfall.io/")) {
+    return new Response(new TextEncoder().encode(source), { status: 200, headers: { "Content-Type": "image/jpeg" } });
+  }
+  throw new Error(`unexpected fetch: ${source}`);
+});
+
+/**
+ * Replace `navigator.storage` for one test.
+ *
+ * Defined on the existing navigator rather than by stubbing the whole global,
+ * so nothing else about the environment moves. `undefined` reproduces the
+ * browsers and private windows that expose no Storage API at all — which is
+ * also happy-dom's own default, hence `absent()` below is a named no-op rather
+ * than a silent reliance on the environment.
+ */
+function stubStorage(manager: Partial<StorageManager> | undefined): void {
+  Object.defineProperty(globalThis.navigator, "storage", { value: manager, configurable: true, writable: true });
+}
+
+/**
+ * A browser that answers: `available` bytes free, behind a nonzero existing
+ * usage so that headroom is `quota - usage` and not merely `quota`.
+ */
+function roomyStorage(available: number, granted = true) {
+  const usage = 3 * GIB;
+  return {
+    estimate: vi.fn(async () => ({ usage, quota: usage + available })),
+    persisted: vi.fn(async () => false),
+    persist: vi.fn(async () => granted),
+  };
+}
+
+const DATABASE = "phase-visual-packs-scryfall-v1";
+
+/** Reopen the crash window between `completePack` and `finish`: the pack row
+ *  is written with this operation's id while the operation is still
+ *  `downloading`, which is the state a resume actually continues from. */
+async function interrupt(operation: string): Promise<void> {
+  const database = await openDB(DATABASE, 1);
+  const record = await database.get("operations", operation);
+  await database.put("operations", { ...record, state: "downloading", completedRevision: null });
+  database.close();
+}
+
+async function operationRecords(): Promise<unknown[]> {
+  const database = await openDB(DATABASE, 1);
+  const records = await database.getAll("operations");
+  database.close();
+  return records;
+}
+
+/**
+ * Move Giant Growth's `normal` face URL, as a regeneration of
+ * `scryfall-data.json` does — the case in which a pack is out of date while
+ * every asset key it holds is unchanged. Mutated in place because
+ * `loadScryfallData` memoizes its RESOLVED value, so re-serving the fetch would
+ * change nothing; every key carrying this oracle id is updated because the JSON
+ * round-trip gives the oracle-id key and the name key independent objects.
+ */
+async function moveGiantNormal(token: string): Promise<void> {
+  const cards = await loadScryfallData();
+  if (!cards) throw new Error("card data unavailable");
+  for (const entry of Object.values(cards)) {
+    if (entry.oracle_id === GIANT) entry.faces[0].normal = url(token, "normal");
+  }
+}
+
+async function curatedSelector(): Promise<{ selector: InstallSelector; records: number }> {
+  const membership = await planCuratedPack();
+  return {
+    selector: { kind: "curated", membershipDigest: membership.membershipDigest as CatalogRoot },
+    records: membership.descriptors.length,
+  };
+}
+
+async function settle(backend: ScryfallBrowserVisualPackBackend, operation: string): Promise<void> {
+  await vi.waitFor(async () => {
+    expect((await backend.operationStatus(operation as never)).state).toBe("completed");
+  }, { timeout: 5000 });
+}
+
+describe("install sizing and storage headroom", () => {
+  beforeEach(() => {
+    globalThis.indexedDB = new IDBFactory();
+    cache = new MemoryCache();
+    fetchStub.mockClear();
+    vi.stubGlobal("fetch", fetchStub);
+    vi.stubGlobal("caches", { open: async () => cache } as unknown as CacheStorage);
+    usePreferencesStore.setState({ artChain: NEWEST, artOverrides: {} });
+    stubStorage(undefined);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    stubStorage(undefined);
+  });
+
+  /**
+   * FIRST IN THIS FILE, DELIBERATELY. `loadScryfallData` and `loadPrintingsData`
+   * memoize at module scope, so any earlier test that plans a membership leaves
+   * the card data resident and silently turns this into the warm case. The
+   * `toBeNull()` below ENFORCES that rather than assuming it — a warm module
+   * makes this fail loudly instead of passing vacuously.
+   */
+  it("measures no drift, and fetches no card data, until the card data is resident", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+
+    const cold = await backend.curatedDrift();
+
+    // The settings panel reads this on mount. `scryfall-data.json` and
+    // `scryfall-printings.json` are 36,748,238 and 39,541,979 bytes, so a
+    // measurement that loaded them would turn opening a tab into a 76 MB
+    // download with no progress indication and no way to cancel.
+    expect(cold).toBeNull();
+    const cursor = fetchStub.mock.calls.map(([input]) => String(input));
+    expect(cursor).not.toContain("/scryfall-data.json");
+    expect(cursor).not.toContain("/scryfall-printings.json");
+
+    // The complementary branch, so the gate is not merely stuck off: an action
+    // the user took plans a membership, which loads the data...
+    await curatedSelector();
+    expect(fetchStub.mock.calls.map(([input]) => String(input))).toContain("/scryfall-data.json");
+
+    const warm = await backend.curatedDrift();
+
+    // ...and the next read measures for free.
+    expect(warm).not.toBeNull();
+    expect(warm?.installedDigest).toBeNull();
+  });
+
+  it("reports a curated download size derived from the faces it will fetch", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, records } = await curatedSelector();
+
+    const estimate = await backend.estimateInstall(selector);
+
+    // Every planned face carries the whole ladder, which is what makes a
+    // per-record mean the right weighting. Assert it rather than assume it:
+    // a remainder here would mean some face contributes fewer rungs and the
+    // face-derived expectation below would silently stop being the model.
+    expect(records % RUNGS_PER_FACE).toBe(0);
+    const faces = records / RUNGS_PER_FACE;
+    expect(faces).toBeGreaterThan(0);
+    expect(estimate.estimatedImageBytes).toBe(faces * FACE_BYTES);
+    expect(estimate.assetRecords).toBe(String(records));
+  });
+
+  it("reports a download size for a bulk selector from the same model", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const summary = await backend.refreshCatalog();
+
+    const estimate = await backend.estimateInstall({ kind: "complete", rootSha256: summary.catalogRoot });
+
+    // Counted off the real bulk scan, not off a stubbed number: three English
+    // faces, with the German printing skipped.
+    expect(estimate.assetRecords).toBe(String(BULK_FACES * RUNGS_PER_FACE));
+    expect(estimate.estimatedImageBytes).toBe(BULK_FACES * FACE_BYTES);
+  });
+
+  it("prices the two selectors on the same per-face scale", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const summary = await backend.refreshCatalog();
+    const { selector, records } = await curatedSelector();
+
+    const curated = await backend.estimateInstall(selector);
+    const complete = await backend.estimateInstall({ kind: "complete", rootSha256: summary.catalogRoot });
+
+    // The comparison the feature exists to let a user make. In this fixture
+    // the bulk side is the larger one; at real catalog scale the ratio is what
+    // the test below pins.
+    expect(curated.estimatedImageBytes / complete.estimatedImageBytes)
+      .toBeCloseTo((records / RUNGS_PER_FACE) / BULK_FACES, 10);
+  });
+
+  it("stays the right order of magnitude at real catalog scale", () => {
+    // MEASURED from the shipped data files: 35,055 distinct non-token faces in
+    // scryfall-data.json and 90,831 faces in scryfall-printings.json, every one
+    // of which carries `normal` and `art_crop` together. A band rather than an
+    // equality, so a sampled constant may be re-measured without hand-editing a
+    // golden — but a constant that moved by an order of magnitude, which is the
+    // way this model actually breaks, still fails here.
+    const curatedGib = estimatedImageBytes(35_055 * RUNGS_PER_FACE) / GIB;
+    const printingsGib = estimatedImageBytes(90_831 * RUNGS_PER_FACE) / GIB;
+
+    expect(curatedGib).toBeGreaterThan(5);
+    expect(curatedGib).toBeLessThan(8);
+    expect(printingsGib).toBeGreaterThan(14);
+    expect(printingsGib).toBeLessThan(20);
+    expect(printingsGib / curatedGib).toBeCloseTo(90_831 / 35_055, 10);
+  });
+
+  it("calls an estimate sufficient when the browser reports room for it", async () => {
+    stubStorage(roomyStorage(64 * GIB));
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector } = await curatedSelector();
+
+    const estimate = await backend.estimateInstall(selector);
+
+    // Headroom is what is LEFT, not the whole quota: the fixture is already
+    // 3 GiB into a 67 GiB budget, so reporting the quota would overstate the
+    // room by exactly that much.
+    expect(estimate.storage).toEqual({
+      usageBytes: 3 * GIB,
+      quotaBytes: 67 * GIB,
+      availableBytes: 64 * GIB,
+      persistence: "best_effort",
+    });
+    expect(estimate.headroom).toBe("sufficient");
+  });
+
+  it("warns but still installs when the projection alone exceeds the headroom", async () => {
+    // The band this whole design turns on. Free space sits BELOW the expected
+    // size and ABOVE the cheapest reading of it, which is exactly where a
+    // six-sample-per-rung projection cannot tell whether the install fits.
+    const { selector, records } = await curatedSelector();
+    const between = Math.round((minimumImageBytes(records) + estimatedImageBytes(records)) / 2);
+    // Guard the fixture: if these two figures ever collapse together there is
+    // no band left and this test would silently stop testing anything.
+    expect(minimumImageBytes(records)).toBeLessThan(between);
+    expect(between).toBeLessThan(estimatedImageBytes(records));
+    const manager = roomyStorage(between);
+    stubStorage(manager);
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+
+    const estimate = await backend.estimateInstall(selector);
+    // Warned...
+    expect(estimate.headroom).toBe("insufficient");
+    expect(estimate.estimatedImageBytes).toBeGreaterThan(estimate.storage.availableBytes!);
+
+    // ...and NOT blocked. A refusal here has no override; a quota failure
+    // part-way through does, because `storage` is retryable and a resume skips
+    // every object already cached.
+    const response = await backend.start({ kind: "install", selector, objectEstimate: records });
+    if (response.status !== "started") throw new Error("curated install did not start");
+    await settle(backend, response.operationId);
+    expect(cache.entries.size).toBe(records);
+  });
+
+  it("refuses only when no reading of the model could fit", async () => {
+    // 1 KiB free inside a multi-gigabyte quota: below even the cheapest-rung
+    // floor, so no error bar on the sampled constants rescues it. Also a check
+    // that compared against the QUOTA rather than the remaining room would
+    // call this sufficient.
+    const manager = roomyStorage(1024);
+    stubStorage(manager);
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, records } = await curatedSelector();
+    expect(minimumImageBytes(records)).toBeGreaterThan(1024);
+
+    const estimate = await backend.estimateInstall(selector);
+    expect(estimate.headroom).toBe("insufficient");
+
+    const refused: unknown = await backend
+      .start({ kind: "install", selector, objectEstimate: records })
+      .then(() => null, (error: unknown) => error);
+
+    // Its OWN kind, not the `storage` catch-all every unrecognised error lands
+    // in, so the panel can say "nothing was written, free some space" instead
+    // of "the write failed".
+    expect(refused).toBeInstanceOf(VisualPackStorageRefusalError);
+    // The figures the gate actually compared, carried as data. A panel that
+    // recomputed the floor would read the browser's quota at a different
+    // instant than this comparison did.
+    expect((refused as VisualPackStorageRefusalError).refusal).toEqual({
+      requiredBytes: minimumImageBytes(records),
+      availableBytes: 1024,
+    });
+    // ...and NOT as prose. `detail` is `message`, and the panel renders
+    // `message` verbatim beneath a translated sentence, so a figure that
+    // reached it would be an untranslatable number in seven languages.
+    expect((refused as Error).message).not.toMatch(/\d/);
+    // Refused BEFORE anything exists, so there is nothing to unwedge and no
+    // half-written pack. Without this the rejection alone would be satisfied by
+    // a guard that runs after the record is persisted.
+    expect(await operationRecords()).toHaveLength(0);
+    expect(cache.entries.size).toBe(0);
+  });
+
+  it("reports the origin's storage on the summary, and asks for no grant to do it", async () => {
+    const manager = roomyStorage(64 * GIB);
+    stubStorage(manager);
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+
+    const summary = await backend.refreshCatalog();
+
+    // The figures a panel renders for a user who has ALREADY installed, and
+    // which used to be reachable only by running an estimate for a new one.
+    // Asserted as VALUES, because `storage` is a required field: `tsc` proves
+    // it is present, and nothing but this proves it is the browser's answer
+    // rather than a blank the backend made up. (3 GiB is the existing usage
+    // `roomyStorage` reports behind its free space.)
+    expect(summary.storage).toEqual({
+      usageBytes: 3 * GIB,
+      quotaBytes: 3 * GIB + 64 * GIB,
+      availableBytes: 64 * GIB,
+      persistence: "best_effort",
+    });
+    // A settings panel reads this summary on open, and `persist()` is the one
+    // Storage API method that can raise a browser permission prompt — so a
+    // summary read that reached it would prompt every user who opened the
+    // panel, for a permission they never asked to give. Today that is
+    // guaranteed statically: `persist()` has a single call site, inside
+    // `requestPersistence`, which only `reserveStorage` calls, and
+    // `reserveStorage` is reachable only from `start()`. A static trace holds
+    // only until someone adds a second caller; this is what fails when they do.
+    expect(manager.persist).not.toHaveBeenCalled();
+    // Reach guard: the summary really did consult the browser, so the absence
+    // above is a choice of METHOD rather than a storage read that never ran.
+    expect(manager.persisted).toHaveBeenCalled();
+    expect(manager.estimate).toHaveBeenCalled();
+  });
+
+  it("requests a persistence grant before an install writes anything", async () => {
+    const manager = roomyStorage(64 * GIB);
+    // The grant protects the bytes that come after it, so "before" is the
+    // claim, not merely "at some point". Recorded from inside the stub because
+    // a call count alone is satisfied by a grant requested at the very end.
+    //
+    // Weakly discriminating TODAY and deliberately kept: `start()` fires the
+    // download without awaiting it, so nothing is cached by the time it
+    // returns and this reads 0 almost by construction. What it pins is that a
+    // later refactor cannot move the request down into the download loop,
+    // where the first images would already be on disk unprotected.
+    const cachedWhenGranted: number[] = [];
+    manager.persist.mockImplementation(async () => {
+      cachedWhenGranted.push(cache.entries.size);
+      return true;
+    });
+    stubStorage(manager);
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, records } = await curatedSelector();
+
+    const response = await backend.start({ kind: "install", selector, objectEstimate: records });
+
+    if (response.status !== "started") throw new Error("curated install did not start");
+    expect(manager.persist).toHaveBeenCalledTimes(1);
+    expect(cachedWhenGranted).toEqual([0]);
+    expect(response.persistence).toBe("persisted");
+    await settle(backend, response.operationId);
+    // ...and the install really did write something afterwards, so the 0 above
+    // is an ordering fact rather than an install that never ran.
+    expect(cache.entries.size).toBe(records);
+  });
+
+  it("installs anyway when the grant is refused, and says so", async () => {
+    const manager = roomyStorage(64 * GIB, false);
+    stubStorage(manager);
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, records } = await curatedSelector();
+
+    const response = await backend.start({ kind: "install", selector, objectEstimate: records });
+
+    if (response.status !== "started") throw new Error("curated install did not start");
+    expect(response.persistence).toBe("best_effort");
+    await settle(backend, response.operationId);
+    // A refused grant costs eviction protection, not the download.
+    expect(cache.entries.size).toBe(records);
+  });
+
+  it("installs when the Storage API is absent altogether", async () => {
+    stubStorage(undefined);
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, records } = await curatedSelector();
+
+    const estimate = await backend.estimateInstall(selector);
+    expect(estimate.headroom).toBe("unknown");
+    expect(estimate.storage).toEqual({
+      usageBytes: null, quotaBytes: null, availableBytes: null, persistence: "unsupported",
+    });
+
+    const response = await backend.start({ kind: "install", selector, objectEstimate: records });
+    if (response.status !== "started") throw new Error("curated install did not start");
+    expect(response.persistence).toBe("unsupported");
+    await settle(backend, response.operationId);
+    expect(cache.entries.size).toBe(records);
+  });
+
+  it("installs when every Storage API call rejects", async () => {
+    // The case an `in`-style feature detection passes and then falls over on:
+    // the methods are present, and they throw. Older Safari and private
+    // windows reject `persist()`; a storage-pressure failure can reject
+    // `estimate()`.
+    const boom = () => Promise.reject(new DOMException("denied", "SecurityError"));
+    const manager = { estimate: vi.fn(boom), persisted: vi.fn(boom), persist: vi.fn(boom) };
+    stubStorage(manager);
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, records } = await curatedSelector();
+
+    const estimate = await backend.estimateInstall(selector);
+    expect(estimate.headroom).toBe("unknown");
+    expect(estimate.storage.persistence).toBe("unsupported");
+
+    const response = await backend.start({ kind: "install", selector, objectEstimate: records });
+    if (response.status !== "started") throw new Error("curated install did not start");
+    expect(response.persistence).toBe("unsupported");
+    await settle(backend, response.operationId);
+    expect(manager.persisted).toHaveBeenCalled();
+    expect(cache.entries.size).toBe(records);
+  });
+
+  it("requests a persistence grant for a resume as well, and reports it", async () => {
+    // A resume writes bytes exactly like the install it continues, so it needs
+    // the same eviction protection. The suite's other resume tests run with no
+    // Storage API at all, where "unsupported" comes out whether or not the
+    // grant was ever asked for — a stubbed manager is what makes this
+    // observable.
+    const manager = roomyStorage(64 * GIB);
+    stubStorage(manager);
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, records } = await curatedSelector();
+    const first = await backend.start({ kind: "install", selector, objectEstimate: records });
+    if (first.status !== "started") throw new Error("curated install did not start");
+    await settle(backend, first.operationId);
+    await interrupt(first.operationId);
+    manager.persist.mockClear();
+    manager.persisted.mockClear();
+
+    const resumed = await backend.start({ kind: "resume", operationId: first.operationId });
+
+    if (resumed.status !== "started") throw new Error("curated resume did not start");
+    expect(manager.persisted).toHaveBeenCalledTimes(1);
+    expect(manager.persist).toHaveBeenCalledTimes(1);
+    expect(resumed.persistence).toBe("persisted");
+    await settle(backend, first.operationId);
+  });
+
+  it("does not ask for a grant when a sync turns out to have nothing to do", async () => {
+    const manager = roomyStorage(64 * GIB);
+    stubStorage(manager);
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, records } = await curatedSelector();
+
+    const first = await backend.start({ kind: "install", selector, objectEstimate: records });
+    if (first.status !== "started") throw new Error("curated install did not start");
+    await settle(backend, first.operationId);
+    const grantsAfterInstall = manager.persist.mock.calls.length + manager.persisted.mock.calls.length;
+    // Reach guard: without this, an implementation that asked for no grant
+    // anywhere would satisfy the "unchanged" assertion below with 0 === 0.
+    expect(grantsAfterInstall).toBeGreaterThan(0);
+
+    const second = await backend.start({ kind: "install", selector, objectEstimate: records });
+
+    expect(second).toEqual({ status: "healthy" });
+    expect(manager.persist.mock.calls.length + manager.persisted.mock.calls.length).toBe(grantsAfterInstall);
+  });
+
+  it("reports the same count the panel prices, for a pack with nothing to sync", async () => {
+    stubStorage(roomyStorage(64 * GIB));
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, records } = await curatedSelector();
+    const first = await backend.start({ kind: "install", selector, objectEstimate: records });
+    if (first.status !== "started") throw new Error("curated install did not start");
+    await settle(backend, first.operationId);
+
+    // What reopening the panel on an installed pack does: it auto-runs an
+    // estimate against the selector it already has.
+    const estimate = await backend.estimateInstall(selector);
+
+    // `uniqueObjects` is the panel's ONLY count row for a curated estimate and
+    // it renders directly beside `estimatedImageBytes` under "Images to
+    // download". The two must be the same figure or the panel contradicts
+    // itself — "Images to download: 105,165" beside "Estimated download size:
+    // 0 B" is what reporting the membership there produced.
+    expect(estimate.estimatedImageBytes).toBe(0);
+    expect(Number(estimate.uniqueObjects)).toBe(0);
+    // ...and the membership is STILL reported whole, on the other field. This
+    // conjunct is what pins the distinction rather than collapsing the two:
+    // `assetRecords` is the panel's `objectEstimate`, the denominator of a
+    // progress bar whose numerator counts every object the run promotes.
+    expect(estimate.assetRecords).toBe(String(records));
+    expect(records).toBeGreaterThan(0);
+  });
+
+  it("sizes and gates a re-sync on what it must fetch, not on the whole membership", async () => {
+    stubStorage(roomyStorage(64 * GIB));
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const { selector, records } = await curatedSelector();
+    const first = await backend.start({ kind: "install", selector, objectEstimate: records });
+    if (first.status !== "started") throw new Error("curated install did not start");
+    await settle(backend, first.operationId);
+
+    await moveGiantNormal("moved");
+    // The card map is edited in place, which the plan memo's key cannot see.
+    usePreferencesStore.setState({ artOverrides: {} });
+    const next = await curatedSelector();
+    expect(next.selector).not.toEqual(selector);
+    expect(next.records).toBe(records);
+    // `normal` moved and `small` is derived from it: two of six assets, and
+    // every asset key unchanged.
+    expect(await backend.curatedDrift()).toMatchObject({ add: 0, remove: 0, refresh: 2 });
+
+    // One byte short of the cheapest possible reading of the WHOLE membership,
+    // which is the figure the gate used to compare against — and room for the
+    // two moved rungs several times over.
+    const available = minimumImageBytes(records) - 1;
+    expect(minimumImageBytes(records)).toBeGreaterThan(available);
+    expect(minimumImageBytes(2)).toBeLessThanOrEqual(available);
+    stubStorage(roomyStorage(available));
+
+    const estimate = await backend.estimateInstall(next.selector);
+
+    expect(estimate.estimatedImageBytes).toBe(estimatedImageBytes(2));
+    expect(estimate.estimatedImageBytes).toBeLessThan(estimatedImageBytes(records));
+    // The membership itself is still reported whole. It is what the panel
+    // passes as `objectEstimate`, and that is the denominator of a progress bar
+    // whose numerator counts every object the run promotes — reused included.
+    expect(estimate.assetRecords).toBe(String(records));
+
+    // Not refused, where the old figure had no reading that could fit.
+    const response = await backend.start({
+      kind: "install",
+      selector: next.selector,
+      objectEstimate: next.records,
+    });
+
+    if (response.status !== "started") throw new Error("curated re-sync did not start");
+    await settle(backend, response.operationId);
+  });
+});

--- a/client/src/services/visualPacks/browser/descriptors.ts
+++ b/client/src/services/visualPacks/browser/descriptors.ts
@@ -1,0 +1,130 @@
+import { cardCandidateGroups } from "../candidateKeys.ts";
+import type { VisualVariant } from "../candidateKeys.ts";
+import { assetKey } from "../types.ts";
+import type { AssetKey, CandidateKey, PackId, VisualImageRung, VisualPackMedia } from "../types.ts";
+
+/**
+ * One downloadable image, named by the asset key it is stored under and by the
+ * candidate keys a render-time lookup may arrive with.
+ */
+export interface ScryfallAssetDescriptor {
+  readonly packId: PackId;
+  readonly assetKey: AssetKey;
+  readonly candidateKeys: readonly CandidateKey[];
+  readonly sourceUrl: string;
+  readonly media: VisualPackMedia;
+}
+
+/** A card face as the descriptor builders see it: a display name plus the
+ *  source URLs available for it, keyed by rung. */
+export interface DescriptorFace {
+  readonly name: string;
+  readonly images: Record<string, string>;
+}
+
+/**
+ * A card identified only by its oracle id. `scryfall-data.json` entries carry
+ * no printing `id`, so this is all a planner working from that map has.
+ */
+export interface CanonicalCardIdentity {
+  readonly oracleId: string;
+  readonly name: string;
+  readonly faces: readonly DescriptorFace[];
+}
+
+/** A card identified down to one specific printing. */
+export interface CardIdentity extends CanonicalCardIdentity {
+  readonly id: string;
+  readonly set: string;
+  readonly collector: string;
+}
+
+/**
+ * The three images every card face contributes, in the order the packs store
+ * them. `small` and `normal` are the two rungs of the `full_card` variant;
+ * `art_crop` is both its own variant and its own rung.
+ */
+const IMAGE_LADDER: readonly (readonly [VisualVariant, VisualImageRung])[] = [
+  ["full_card", "small"],
+  ["full_card", "normal"],
+  ["art_crop", "art_crop"],
+];
+
+interface FaceImage {
+  readonly face: DescriptorFace;
+  readonly faceIndex: number;
+  readonly variant: VisualVariant;
+  readonly rung: VisualImageRung;
+  readonly url: string;
+}
+
+/**
+ * Every face x ladder rung for which a source URL actually exists.
+ *
+ * The absent-URL skip is load-bearing rather than defensive: Scryfall omits
+ * image variants for some printings, and `scryfall-printings.json` stores an
+ * explicit null for those faces.
+ */
+function faceImages(card: CanonicalCardIdentity): FaceImage[] {
+  return card.faces.flatMap((face, faceIndex) =>
+    IMAGE_LADDER.flatMap(([variant, rung]) => {
+      const url = face.images[rung];
+      return url ? [{ face, faceIndex, variant, rung, url }] : [];
+    }));
+}
+
+export function descriptor(
+  selectedPack: PackId,
+  card: CardIdentity,
+  faceIndex: number,
+  variant: VisualVariant,
+  rung: VisualImageRung,
+  sourceUrl: string,
+  candidates: CandidateKey[],
+): ScryfallAssetDescriptor {
+  const asset = assetKey(`asset:v1:exact_printing:${card.id}-${faceIndex}-${variant}-${rung}`);
+  return { packId: selectedPack, assetKey: asset, candidateKeys: candidates, sourceUrl, media: "image/jpeg" };
+}
+
+/** Descriptors for one English printing, keyed by that printing's id. */
+export function englishDescriptors(selectedPack: PackId, card: CardIdentity): ScryfallAssetDescriptor[] {
+  return faceImages(card).map(({ face, faceIndex, variant, rung, url }) =>
+    descriptor(selectedPack, card, faceIndex, variant, rung, url, cardCandidateGroups({
+      englishPrintingId: card.id,
+      oracleId: card.oracleId,
+      englishAliases: [card.name, face.name],
+      oracleAliases: [card.name, face.name],
+      faceIndex,
+      variant,
+      rung,
+    }).flatMap((group) => group.keys)));
+}
+
+/**
+ * Descriptors for a card whose printing is unknown — the `canonical_card`
+ * asset form.
+ *
+ * Because no printing id is available, the candidate keys are deliberately
+ * limited to the oracle group. That mirrors what `useCardImage` requests when
+ * no stored preference resolves to a printing: it passes an empty
+ * `englishPrintingId`, so `cardCandidateGroups` emits the oracle group alone.
+ * Emitting the english group here would produce keys no render ever asks for.
+ */
+export function canonicalDescriptors(
+  selectedPack: PackId,
+  card: CanonicalCardIdentity,
+): ScryfallAssetDescriptor[] {
+  return faceImages(card).map(({ face, faceIndex, variant, rung, url }) => ({
+    packId: selectedPack,
+    assetKey: assetKey(`asset:v1:canonical_card:${card.oracleId}-${faceIndex}-${variant}-${rung}`),
+    candidateKeys: cardCandidateGroups({
+      oracleId: card.oracleId,
+      oracleAliases: [card.name, face.name],
+      faceIndex,
+      variant,
+      rung,
+    }).flatMap((group) => group.keys),
+    sourceUrl: url,
+    media: "image/jpeg" as const,
+  }));
+}

--- a/client/src/services/visualPacks/browser/scryfallBackend.ts
+++ b/client/src/services/visualPacks/browser/scryfallBackend.ts
@@ -1,8 +1,12 @@
 import { openDB, type DBSchema, type IDBPDatabase } from "idb";
 
-import { VisualPackBackendError, type VisualPackBackend } from "../backend.ts";
+import { VisualPackBackendError, VisualPackStorageRefusalError, type VisualPackBackend } from "../backend.ts";
+import { isCardDataResident } from "../../scryfall.ts";
+import { curatedDescriptors, planCuratedPack } from "../curatedPack.ts";
 import {
+  estimatedImageBytes,
   installedRevision,
+  minimumImageBytes,
   operationId,
   packId,
   type AssetKey,
@@ -10,6 +14,9 @@ import {
   type CatalogRoot,
   type CatalogStatus,
   type CatalogSummary,
+  type CatalogScanProgress,
+  type CuratedDrift,
+  type CuratedInstallSelector,
   type InstallEstimate,
   type InstallSelector,
   type OperationId,
@@ -24,6 +31,9 @@ import {
   type RevisionEvent,
   type StartRequest,
   type StartResponse,
+  type StorageHeadroom,
+  type StorageOutlook,
+  type StoragePersistence,
   type VerificationMode,
   type VerificationResponse,
   type VisualPackErrorKind,
@@ -31,6 +41,7 @@ import {
 } from "../types.ts";
 import { syntheticCachePath } from "./records.ts";
 import {
+  countScryfallAssets,
   forEachScryfallAsset,
   loadScryfallBulkSource,
   ScryfallBulkError,
@@ -41,6 +52,8 @@ import {
 const DATABASE = "phase-visual-packs-scryfall-v1";
 const CACHE = "phase-visual-pack-scryfall-images-v1";
 const STATE = "state";
+const DOWNLOAD_CONCURRENCY = 4;
+const PROGRESS_INTERVAL_MS = 250;
 
 type CatalogRecord = Readonly<ScryfallBulkSource>;
 
@@ -64,9 +77,29 @@ type ObjectRecord = Readonly<{
   packId: PackId;
   assetKey: AssetKey;
   candidateKeys: readonly CandidateKey[];
+  /**
+   * The URL these bytes were downloaded from — half of the identity by which a
+   * NEW root may reuse them instead of downloading them again.
+   *
+   * Optional because it is additive. A row written before this field existed
+   * carries `undefined`, which no descriptor's `sourceUrl` can equal, so such a
+   * row is never reused. That is the safe default in the direction that
+   * matters: re-downloading only costs time, whereas reusing bytes whose
+   * provenance is unrecorded would serve the wrong art. It is also why the
+   * store needs no version bump and no migration.
+   */
+  sourceUrl?: string;
   object: CatalogRoot;
   byteLength: number;
   media: VisualPackMedia;
+  path: string;
+}>;
+
+/** The content half of an `ObjectRecord`: the bytes a row points at, with no
+ *  claim about which pack or root points at them. */
+type ObjectContent = Readonly<{
+  object: CatalogRoot;
+  byteLength: number;
   path: string;
 }>;
 
@@ -87,6 +120,7 @@ type ScryfallOperationRecord = Readonly<{
   packTotal: number;
   packsPromoted: number;
   objectTotal: number;
+  objectEstimate?: number;
   objectsPromoted: number;
   completedRevision: string | null;
 }>;
@@ -107,6 +141,28 @@ function operationObjectId(selectedOperation: OperationId, selectedObject: strin
   return `${selectedOperation}:${selectedObject}`;
 }
 
+/**
+ * The identity under which an already-downloaded image may be reused by a
+ * DIFFERENT catalog root. `objectId` cannot serve: it is keyed on the root, so
+ * a new root matches nothing and every image is fetched again.
+ *
+ * Both halves are load-bearing. An asset key alone names a slot, not bytes: a
+ * `canonical_card:` key carries no printing identity, so what stands behind it
+ * is whatever `scryfall-data.json` currently supplies, and a regeneration of
+ * that file moves the URL while the key stays put. Reusing on the key alone
+ * would pin the superseded art with no way to notice — which is the same
+ * reason the membership digest covers source URLs as well as keys.
+ */
+function contentId(selectedAsset: AssetKey, sourceUrl: string): string {
+  return `${selectedAsset}\t${sourceUrl}`;
+}
+
+/** The reuse snapshot for a selector that does not participate in content
+ *  reuse. Shared and empty, so a non-curated install never scans `objects` and
+ *  `installObject` keeps ONE code path rather than growing a second one that
+ *  could drift from it. */
+const NO_DONORS = (): Promise<Map<string, ObjectContent>> => Promise.resolve(new Map());
+
 function operationStatus(record: ScryfallOperationRecord): OperationStatus {
   return {
     operationId: record.id,
@@ -116,6 +172,7 @@ function operationStatus(record: ScryfallOperationRecord): OperationStatus {
     packTotal: record.packTotal,
     packsPromoted: record.packsPromoted,
     objectTotal: record.objectTotal,
+    objectEstimate: record.objectEstimate ?? null,
     objectsPromoted: record.objectsPromoted,
     completedRevision: record.completedRevision === null ? null : installedRevision(record.completedRevision),
   };
@@ -142,6 +199,35 @@ function errorKind(error: unknown): VisualPackErrorKind {
   return "storage";
 }
 
+/**
+ * Whether re-running an operation record could ever reach a different outcome.
+ *
+ * `conflict` is the one kind that says the request no longer describes
+ * reality. A curated selector stores only a membership digest, and a digest is
+ * not invertible, so once the stored preferences move there is no way to
+ * reconstruct the membership the record named — replanning would install a
+ * DIFFERENT membership under the old root, and adopting the new digest would
+ * orphan every row already written under the old one. Network and storage
+ * failures carry no such claim: they are transient, and an operation that hits
+ * one MUST stay resumable, which is what the panel's Resume control is for.
+ *
+ * `internal` is the second, for a different reason and with the same
+ * consequence: it is what a defect in our own deterministic planning code is
+ * classified as, and re-running deterministic code reaches the same defect.
+ * Leaving such an operation resumable wedges the panel across restarts, since
+ * `create()` re-runs every record still `downloading` on every launch.
+ *
+ * Everything else is retryable by default, which `insufficient_storage`
+ * inherits CORRECTLY: freeing disk changes the outcome, so a record left
+ * resumable can still succeed. It is also unreachable from here today —
+ * `reserveStorage` throws out of `start()` before any record is persisted, and
+ * this function is consulted only from `run()`'s catch — so the default is a
+ * statement about a future caller rather than about the refusal path.
+ */
+function retryable(kind: VisualPackErrorKind): boolean {
+  return kind !== "conflict" && kind !== "internal";
+}
+
 function backendError(error: unknown): VisualPackBackendError {
   if (error instanceof VisualPackBackendError) return error;
   return new VisualPackBackendError(errorKind(error), error instanceof Error ? error.message : undefined);
@@ -153,12 +239,26 @@ function selectorPack(selector: InstallSelector): PackId {
     case "printing": return packId(`printing:${selector.set}`);
     case "locale": return packId(`locale:${selector.language}:${selector.set}`);
     case "complete": return packId("complete");
+    case "curated": return packId("curated");
   }
+}
+
+/**
+ * The catalog root a selector's packs and objects are stored at.
+ *
+ * Curated membership is identified by its own digest; every other selector is
+ * identified by the bulk catalog it was built from. The root is a property of
+ * a SELECTOR, not of an operation — an operation installs and repairs a list
+ * of packs — so it is derived here rather than stored on the record.
+ */
+function selectorRoot(selector: InstallSelector, catalog: CatalogRecord): CatalogRoot {
+  return selector.kind === "curated" ? selector.membershipDigest : catalog.root;
 }
 
 function selectorForPack(selectedPack: PackId, root: CatalogRoot): InstallSelector {
   if (selectedPack === packId("core")) return { kind: "core" };
   if (selectedPack === packId("complete")) return { kind: "complete", rootSha256: root };
+  if (selectedPack === packId("curated")) return { kind: "curated", membershipDigest: root };
   const printing = /^printing:([a-z0-9]{3,6})$/.exec(selectedPack);
   if (printing) return { kind: "printing", set: printing[1] };
   const locale = /^locale:(de|es|fr|it|pt):([a-z0-9]{3,6})$/.exec(selectedPack);
@@ -186,8 +286,90 @@ async function state(database: IDBPDatabase<ScryfallVisualPackSchema>): Promise<
   return (await database.get("state", STATE)) ?? initialState();
 }
 
-async function cacheContains(path: string): Promise<boolean> {
-  return (await (await caches.open(CACHE)).match(path)) !== undefined;
+/**
+ * `navigator.storage`, or `undefined` where there is none.
+ *
+ * Read through `globalThis` and through optional chaining because the Storage
+ * API is absent in older Safari, absent in some private windows, and absent in
+ * the test environment. Every caller below turns both "absent" and "threw"
+ * into the same answer, so that a pack download which would otherwise succeed
+ * is never blocked by a failure to introspect the storage it writes to.
+ *
+ * The explicit `!manager` checks in the two callers are therefore REDUNDANT
+ * with their `catch`, and MEASURED to be: deleting them turns no test red,
+ * because the resulting TypeError lands in the same handler. They are kept
+ * anyway, and only for the reason that an absent API is an ordinary condition
+ * rather than a failure, so it should not be routed through an exception. Do
+ * not read them as the thing that makes absence safe — the `catch` is.
+ */
+function storageManager(): StorageManager | undefined {
+  return globalThis.navigator?.storage;
+}
+
+/** Whether this origin's storage is already exempt from eviction. */
+async function currentPersistence(): Promise<StoragePersistence> {
+  try {
+    const manager = storageManager();
+    if (!manager) return "unsupported";
+    return (await manager.persisted()) ? "persisted" : "best_effort";
+  } catch {
+    return "unsupported";
+  }
+}
+
+/**
+ * Ask the browser to stop evicting this origin's storage, and report what it
+ * said.
+ *
+ * A refusal is a normal outcome, not an error: without the grant Cache Storage
+ * stays best-effort and the browser MAY discard the whole pack under disk
+ * pressure, but the download itself works either way. Reporting `best_effort`
+ * is how that stays visible instead of being assumed away.
+ *
+ * `persisted()` is consulted first so an origin that already holds the grant
+ * does not ask for it a second time.
+ */
+async function requestPersistence(): Promise<StoragePersistence> {
+  try {
+    const manager = storageManager();
+    if (!manager) return "unsupported";
+    if (await manager.persisted()) return "persisted";
+    return (await manager.persist()) ? "persisted" : "best_effort";
+  } catch {
+    return "unsupported";
+  }
+}
+
+/** The origin's usage and quota, with `persistence` supplied by whichever of
+ *  the two calls above the caller made. */
+async function storageOutlook(persistence: StoragePersistence): Promise<StorageOutlook> {
+  let usageBytes: number | null = null;
+  let quotaBytes: number | null = null;
+  try {
+    const report = await storageManager()?.estimate();
+    if (typeof report?.usage === "number") usageBytes = report.usage;
+    if (typeof report?.quota === "number") quotaBytes = report.quota;
+  } catch {
+    // Reported as "would not say" below, exactly like an absent API.
+  }
+  const availableBytes = usageBytes === null || quotaBytes === null ? null : Math.max(quotaBytes - usageBytes, 0);
+  return { usageBytes, quotaBytes, availableBytes, persistence };
+}
+
+/**
+ * Whether a projected download fits the space the browser reports.
+ *
+ * `unknown` when the browser would not say, and callers must treat that as
+ * "cannot tell" rather than as "fits": a browser with no Storage API must
+ * still be able to install.
+ */
+function headroomFor(projectedBytes: number, outlook: StorageOutlook): StorageHeadroom {
+  if (outlook.availableBytes === null) return "unknown";
+  return projectedBytes <= outlook.availableBytes ? "sufficient" : "insufficient";
+}
+
+async function cacheContains(cache: Cache, path: string): Promise<boolean> {
+  return (await cache.match(path)) !== undefined;
 }
 
 async function sha256(bytes: Uint8Array): Promise<CatalogRoot> {
@@ -210,8 +392,7 @@ async function fetchImage(descriptor: ScryfallAssetDescriptor, signal: AbortSign
   return new Uint8Array(await response.arrayBuffer());
 }
 
-async function storeVerifiedObject(path: string, media: VisualPackMedia, bytes: Uint8Array): Promise<void> {
-  const cache = await caches.open(CACHE);
+async function storeVerifiedObject(cache: Cache, path: string, media: VisualPackMedia, bytes: Uint8Array): Promise<void> {
   await cache.put(path, new Response(bytes, {
     headers: {
       "Content-Type": media,
@@ -258,8 +439,18 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
     this.work = task.catch(() => undefined);
     void task.catch(async (error) => {
       if (controller.signal.aborted) return;
-      const operation = await this.database.get("operations", selectedOperation);
-      if (operation) this.emit({ phase: "failed", operation: operationStatus(operation), error: errorKind(error) });
+      const kind = errorKind(error);
+      // A retryable failure leaves the record `downloading`, which is exactly
+      // what makes it resumable. A non-retryable one never can be, so leaving
+      // it there wedges the panel: OperationProgress offers Resume instead of
+      // Cancel, every durable mutation stays disabled, and `create()`'s
+      // pending loop re-runs the same doomed operation on every launch.
+      // Terminating the record restores those controls and stops the loop.
+      const operation = retryable(kind)
+        ? await this.database.get("operations", selectedOperation)
+        : await this.updateOperation(selectedOperation, (current) =>
+            current.state === "completed" ? current : { ...current, state: "cancelled" }).catch(() => undefined);
+      if (operation) this.emit({ phase: "failed", operation: operationStatus(operation), error: kind });
     }).finally(() => this.workers.delete(selectedOperation));
   }
 
@@ -317,62 +508,227 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
     await transaction.done;
   }
 
-  private async installObject(operation: ScryfallOperationRecord, descriptor: ScryfallAssetDescriptor, signal: AbortSignal): Promise<void> {
-    const id = objectId(operation.catalog.root, descriptor.packId, descriptor.assetKey);
+  /**
+   * Every already-downloaded image that a different root may reuse, keyed by
+   * `contentId`.
+   *
+   * One streamed pass over `objects`, reduced to the three content fields.
+   * `objects` is indexed by pack and not by asset key, and this step adds no
+   * index — so the choice is one pass per selector or a full-store scan per
+   * descriptor. Callers build it lazily, so an install whose rows are all
+   * already present at its own root never pays for it at all.
+   */
+  private async adoptableContent(): Promise<Map<string, ObjectContent>> {
+    const found = new Map<string, ObjectContent>();
+    let cursor = await this.database.transaction("objects").store.openCursor();
+    while (cursor) {
+      const row = cursor.value;
+      if (row.sourceUrl !== undefined) {
+        const key = contentId(row.assetKey, row.sourceUrl);
+        if (!found.has(key)) found.set(key, { object: row.object, byteLength: row.byteLength, path: row.path });
+      }
+      cursor = await cursor.continue();
+    }
+    return found;
+  }
+
+  /** `root` is the SELECTOR's root, supplied by the per-selector loop. It
+   *  cannot be re-derived here: neither `descriptor.packId` nor the operation
+   *  record carries a curated membership digest, so any local derivation would
+   *  silently key and stamp curated objects at the bulk root.
+   *
+   *  `donors` is the per-selector reuse snapshot, deferred behind a thunk so it
+   *  is built only if some descriptor actually misses at this root. */
+  private async installObject(
+    operation: ScryfallOperationRecord,
+    descriptor: ScryfallAssetDescriptor,
+    root: CatalogRoot,
+    signal: AbortSignal,
+    cache: Cache,
+    donors: () => Promise<Map<string, ObjectContent>>,
+  ): Promise<void> {
+    const id = objectId(root, descriptor.packId, descriptor.assetKey);
     const completion = await this.markSeen(operation.id, id);
     const existing = await this.database.get("objects", id);
-    if (completion.complete && existing && await cacheContains(existing.path)) return;
+    if (completion.complete && existing && await cacheContains(cache, existing.path)) return;
     if (completion.complete) await this.invalidateCompletion(operation.id, id);
-    if (existing && await cacheContains(existing.path)) {
+    if (existing && await cacheContains(cache, existing.path)) {
       await this.markComplete(operation.id, id, existing);
       return;
     }
-    const bytes = await fetchImage(descriptor, signal);
-    const object = await sha256(bytes);
+    // A preference change gives the curated pack a new root, so nothing above
+    // matched even though most of the membership is byte-for-byte the images
+    // already on disk. Reuse them; the cache, not the row, is the authority on
+    // whether the bytes are really still there, since an eviction or a sweep
+    // may have run since the snapshot was taken.
+    //
+    // This `cacheContains` is also the ONLY thing that repairs a curated row
+    // whose cache entry has gone missing. `repair` cannot: it builds its
+    // selector from the installed packs row and then filters against that same
+    // row, so a curated repair is always removed before an operation exists and
+    // returns `{status:"healthy"}` while the entry stays missing. MEASURED —
+    // `verify` reports `missing_object`, `repair` reports healthy, and a second
+    // `verify` still reports it. Recovery is a preference change (this check
+    // fails and the asset is fetched again) or remove-and-reinstall. Do not
+    // justify anything here by "verify/repair will fix it".
+    const donor = (await donors()).get(contentId(descriptor.assetKey, descriptor.sourceUrl));
+    let content: ObjectContent;
+    if (donor && await cacheContains(cache, donor.path)) {
+      content = donor;
+    } else {
+      const bytes = await fetchImage(descriptor, signal);
+      const object = await sha256(bytes);
+      content = { object, byteLength: bytes.byteLength, path: syntheticCachePath(object, descriptor.media) };
+      await storeVerifiedObject(cache, content.path, descriptor.media, bytes);
+    }
     const metadata: ObjectRecord = Object.freeze({
       id,
-      root: operation.catalog.root,
+      // The stamp every deletion path filters on. It must agree with the key
+      // `id` was built from, or the row is deletable by no path at all.
+      root,
       packId: descriptor.packId,
       assetKey: descriptor.assetKey,
       candidateKeys: [...descriptor.candidateKeys],
-      object,
-      byteLength: bytes.byteLength,
+      sourceUrl: descriptor.sourceUrl,
+      object: content.object,
+      byteLength: content.byteLength,
       media: descriptor.media,
-      path: syntheticCachePath(object, descriptor.media),
+      path: content.path,
     });
-    await storeVerifiedObject(metadata.path, metadata.media, bytes);
+    // Reuse and download converge here deliberately: a reuse path that skipped
+    // `markComplete` would never increment `objectsPromoted`. `finish()` does
+    // not compare that counter against `objectTotal`, so the record would
+    // still reach `completed` and the only symptom would be a progress figure
+    // permanently short by however many images were reused — a wrong number no
+    // fetch count can see. One exit is what makes that unrepresentable.
     await this.markComplete(operation.id, id, metadata);
   }
 
-  private async completePack(operation: ScryfallOperationRecord, selectedPack: PackId): Promise<void> {
+  /** `root` is the SELECTOR's root, supplied by the per-selector loop — the
+   *  same value `installObject` keyed and stamped this pack's objects with.
+   *
+   *  Returns the cache paths of the rows it deleted, so a caller that owns this
+   *  pack's garbage can ask whether those images are now unreferenced. The
+   *  deletion and the promotion stay in ONE transaction, which is why the paths
+   *  are handed back rather than recollected afterwards — by then the rows that
+   *  named them are gone. Callers that own no garbage simply ignore the value;
+   *  nothing else about this method changed. */
+  private async completePack(operation: ScryfallOperationRecord, selectedPack: PackId, root: CatalogRoot): Promise<Set<string>> {
+    const dropped = new Set<string>();
     const transaction = this.database.transaction(["packs", "objects", "operations"], "readwrite");
     const current = await transaction.objectStore("operations").get(operation.id);
     if (!current || current.state !== "downloading") {
       await transaction.done;
-      return;
+      return dropped;
     }
     const existing = await transaction.objectStore("packs").get(selectedPack);
-    if (existing?.operationId === operation.id && existing.root === operation.catalog.root) {
+    if (existing?.operationId === operation.id && existing.root === root) {
       await transaction.done;
-      return;
+      return dropped;
     }
     if (existing) {
       const index = transaction.objectStore("objects").index("by-pack");
       let cursor = await index.openCursor(existing.packId);
       while (cursor) {
-        if (cursor.value.root === existing.root) await cursor.delete();
+        if (cursor.value.root === existing.root) {
+          dropped.add(cursor.value.path);
+          await cursor.delete();
+        }
         cursor = await cursor.continue();
       }
     }
     await transaction.objectStore("packs").put({
       id: selectedPack,
       packId: selectedPack,
-      root: operation.catalog.root,
+      root,
       dependencies: [],
       operationId: operation.id,
     });
     await transaction.objectStore("operations").put({ ...current, packsPromoted: current.packsPromoted + 1 });
     await transaction.done;
+    return dropped;
+  }
+
+  /**
+   * Delete every path in `paths` that no remaining objects row — in ANY pack —
+   * still references.
+   *
+   * Content addressing means two packs that downloaded the same bytes share one
+   * cache entry, so "this pack's row is gone" is never on its own a reason to
+   * delete the image. `remove()` has always swept exactly this way; naming it
+   * here lets the curated delta path reuse that sweep instead of growing a
+   * second one that could disagree with it.
+   *
+   * The reference set is indexed rather than rescanned per path. `remove()`
+   * swept a handful of paths on a rare user action, so a linear scan inside the
+   * loop never showed; a curated preference change hands this every path of the
+   * replaced membership, and both sides are then the whole membership. MEASURED
+   * at 105,261 paths against 105,261 rows: 103.8 s scanning, 36.6 ms indexed,
+   * with identical deletion sets. The predicate is unchanged — `path` is in the
+   * set exactly when some remaining row references it — so WHICH paths are
+   * deleted does not move for either caller.
+   */
+  private async sweepUnreferenced(paths: ReadonlySet<string>, cache: Cache): Promise<void> {
+    if (paths.size === 0) return;
+    const referenced = new Set((await this.database.getAll("objects")).map((entry) => entry.path));
+    for (const path of paths) {
+      if (!referenced.has(path)) await cache.delete(path);
+    }
+  }
+
+  /**
+   * Drop every curated objects row that no root still points at, then sweep the
+   * images that leaves unreferenced.
+   *
+   * `markComplete` writes rows DURING the download, before `completePack`
+   * promotes the pack, while every deletion path is scoped to a single root
+   * (`completePack` to the row it replaces, `remove()` to the row it removes).
+   * So a curated install at digest D2 that is cancelled or interrupted leaves
+   * its rows at D2 while the packs row still names D1, and the next install at
+   * D3 clears only D1. Nothing can ever reach the D2 rows again: they are keyed
+   * and stamped at a root no pack names. The cache sweep cannot help either —
+   * those rows still exist and still reference their paths, which is exactly
+   * what makes the sweep keep them. Because a curated pack re-syncs on every
+   * preference change, they accumulate against the disk budget the pack exists
+   * to protect.
+   *
+   * A root is abandoned only if NOTHING still claims it, and three things can:
+   * this operation, the installed packs row, and any operation that has not
+   * reached a terminal state. The third is not a refinement — IDB is shared
+   * across tabs while a backend instance is not, so another tab's install is
+   * writing rows under a root that is neither of the first two, and it writes
+   * them DURING its download. Without that clause this sweep deletes a live
+   * membership out from under the tab installing it, and nothing downstream can
+   * notice: `objectsPromoted` counts `operationObjects` completion flags, never
+   * the surviving rows, so that tab still reports `completed` with every asset
+   * promoted while its pack is missing whatever this sweep took. Terminal
+   * operations are deliberately NOT kept — a cancelled or completed record's
+   * root is exactly the garbage this collects.
+   */
+  private async collectCuratedGarbage(root: CatalogRoot, dropped: ReadonlySet<string>, cache: Cache): Promise<void> {
+    const curated = packId("curated");
+    const paths = new Set(dropped);
+    const transaction = this.database.transaction(["packs", "objects", "operations"], "readwrite");
+    const installed = await transaction.objectStore("packs").get(curated);
+    const keep = new Set<CatalogRoot>([root]);
+    if (installed) keep.add(installed.root);
+    for (const operation of await transaction.objectStore("operations").getAll()) {
+      if (operation.state === "completed" || operation.state === "cancelled") continue;
+      for (const [position, selector] of operation.selectors.entries()) {
+        if (operation.packIds[position] === curated) keep.add(selectorRoot(selector, operation.catalog));
+      }
+    }
+    const index = transaction.objectStore("objects").index("by-pack");
+    let cursor = await index.openCursor(curated);
+    while (cursor) {
+      if (!keep.has(cursor.value.root)) {
+        paths.add(cursor.value.path);
+        await cursor.delete();
+      }
+      cursor = await cursor.continue();
+    }
+    await transaction.done;
+    await this.sweepUnreferenced(paths, cache);
   }
 
   private async finish(selectedOperation: OperationId): Promise<void> {
@@ -403,22 +759,86 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
       await this.updateOperation(selectedOperation, (current) => ({ ...current, state: "cancelled" }));
       return;
     }
+    const cache = await caches.open(CACHE);
     for (const [index, selector] of operation.selectors.entries()) {
       operation = await this.database.get("operations", selectedOperation);
       if (!operation || operation.state === "cancel_requested" || signal.aborted) break;
       const selectedPack = operation.packIds[index];
+      const root = selectorRoot(selector, operation.catalog);
       const installed = await this.database.get("packs", selectedPack);
-      if (installed?.operationId === selectedOperation && installed.root === operation.catalog.root) continue;
-      await forEachScryfallAsset(operation.catalog, selector, signal, async (descriptor) => {
-        const current = await this.database.get("operations", selectedOperation);
-        if (!current || current.state === "cancel_requested" || signal.aborted) return;
-        await this.installObject(current, descriptor, signal);
-        const updated = await this.operationStatus(selectedOperation);
-        this.emit({ phase: "running", operation: updated, error: null });
-      });
+      if (installed?.operationId === selectedOperation && installed.root === root) continue;
+      const inFlight = new Set<Promise<void>>();
+      // The reuse snapshot for this selector, taken at most once, only if some
+      // descriptor misses at this root, and only for `curated`.
+      //
+      // Deferred rather than eager because a resume, where every row is already
+      // present, must not pay a full pass over `objects` to learn that.
+      //
+      // Restricted to `curated` because curated is what this step was scoped
+      // to make cheap, and because the snapshot is not free: MEASURED at ~520
+      // bytes of retained Map per row, so ~55 MiB across a curated membership
+      // and ~191 MiB across a `complete` pack's rows, held live for the whole
+      // download on a client with mobile OOM history.
+      //
+      // The gate is NOT a claim that reuse would be worthless for the others.
+      // A republished bulk catalog leaves most image URLs where they were, so
+      // letting `complete` adopt would very likely turn a root bump into
+      // almost no downloads at all. That is a feature with a memory bound to
+      // establish and tests to write, and it is not something to acquire as a
+      // side effect of a change whose rule was that the other selectors do not
+      // move. Adopting ACROSS packs is a separate axis and stays fully
+      // available: keying on content rather than on pack means a curated
+      // install reads every row in the store, `complete`/`printing`/`locale`
+      // included.
+      let adoptable: Promise<Map<string, ObjectContent>> | null = null;
+      const donors = selectedPack === packId("curated")
+        ? () => (adoptable ??= this.adoptableContent())
+        : NO_DONORS;
+      let failure: unknown = null;
+      let lastProgressAt = 0;
+      let progressUpdate = Promise.resolve();
+      const reportProgress = (force = false) => {
+        const now = performance.now();
+        if (!force && now - lastProgressAt < PROGRESS_INTERVAL_MS) return;
+        lastProgressAt = now;
+        progressUpdate = progressUpdate.then(async () => {
+          const updated = await this.operationStatus(selectedOperation);
+          this.emit({ phase: "running", operation: updated, error: null });
+        }).catch(() => undefined);
+      };
+      const schedule = (descriptor: ScryfallAssetDescriptor): Promise<void> | void => {
+        if (failure) throw failure;
+        const task: Promise<void> = (async () => {
+          const current = await this.database.get("operations", selectedOperation);
+          if (!current || current.state === "cancel_requested" || signal.aborted) return;
+          await this.installObject(current, descriptor, root, signal, cache, donors);
+          reportProgress();
+        })().catch((error) => {
+          failure ??= error;
+        }).finally(() => inFlight.delete(task));
+        inFlight.add(task);
+        return inFlight.size >= DOWNLOAD_CONCURRENCY ? Promise.race(inFlight) : undefined;
+      };
+      await forEachScryfallAsset(operation.catalog, selector, signal, schedule);
+      await Promise.all(inFlight);
+      // Every `installObject` for this selector has settled, so the reuse
+      // snapshot has no reader left. Dropping the reference here rather than at
+      // the end of the iteration keeps it from overlapping the sweep below,
+      // which materialises every remaining row AND a path set of its own —
+      // three structures the size of the membership, live at once, on the peak
+      // this pack exists to keep small.
+      adoptable = null;
+      if (failure) throw failure;
+      reportProgress(true);
+      await progressUpdate;
       operation = await this.database.get("operations", selectedOperation);
       if (!operation || operation.state === "cancel_requested" || signal.aborted) break;
-      await this.completePack(operation, selectedPack);
+      const dropped = await this.completePack(operation, selectedPack, root);
+      // Curated is the only pack whose root moves under the user rather than
+      // under Scryfall, so it is the only one that strands rows and images
+      // behind on a change of preference. Every other selector is left exactly
+      // as it was: it discards `dropped` and collects no garbage.
+      if (selectedPack === packId("curated")) await this.collectCuratedGarbage(root, dropped, cache);
       this.emit({ phase: "running", operation: await this.operationStatus(selectedOperation), error: null });
     }
     operation = await this.database.get("operations", selectedOperation);
@@ -431,22 +851,278 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
     await this.finish(selectedOperation);
   }
 
-  private async estimate(source: CatalogRecord, selector: InstallSelector, revision: string): Promise<InstallEstimate> {
+  /**
+   * Secure the storage an operation is about to consume, and refuse one that
+   * provably will not fit.
+   *
+   * The grant is requested for every USER-INITIATED operation that downloads,
+   * not only for something judged "large". It is deliberately NOT requested on
+   * the auto-resume path: `create()` calls `run()` directly for every record
+   * left `downloading`/`finalizing`, so a launch never prompts without the user
+   * having asked for anything. Without it Cache Storage is best-effort and the browser MAY
+   * evict the pack under disk pressure — for a pack downloaded so the app works
+   * offline, that is the exact failure the pack exists to prevent, and it is no
+   * less a failure for a small pack than for a big one. It is requested BEFORE
+   * any byte is written, since it protects the bytes that follow it.
+   *
+   * The size refusal is gated on `objectEstimate`, which only an `install`
+   * request carries. `repair` re-fetches objects an install already accounted
+   * for, and `resume` continues an operation that was checked when it started,
+   * so neither has a figure to check and neither introduces bytes this could
+   * have caught.
+   *
+   * IT REFUSES ON `minimumImageBytes`, NOT ON THE EXPECTED SIZE, and the gap
+   * between the two is the whole design. `estimatedImageBytes` rests on six
+   * CDN samples per rung; against ~35,000 faces of wildly varying card art the
+   * real total could plausibly sit tens of percent either side of it. The two
+   * outcomes are not symmetric:
+   *
+   *  - Refusing wrongly denies an install that would have worked, and there is
+   *    no override anywhere in this backend or the panel to undo it.
+   *  - Running out of quota mid-download is recoverable. A `QuotaExceededError`
+   *    from `cache.put` is classified `storage`, `storage` is `retryable`, so
+   *    the record stays `downloading` and the panel offers Resume; and the
+   *    resume re-downloads almost nothing, because `installObject` returns
+   *    early for every object already complete and still cached.
+   *
+   * So the expected figure is a WARNING, carried on `InstallEstimate.headroom`
+   * for the UI to show, and this gate fires only where even the cheapest
+   * possible reading of the same constants cannot fit — a case no error bar on
+   * them can rescue.
+   */
+  private async reserveStorage(request: StartRequest): Promise<StoragePersistence> {
+    const persistence = await requestPersistence();
+    if (request.kind !== "install") return persistence;
+    // The same delta the estimate reports, recomputed here rather than taken
+    // from `request.objectEstimate`. Two reasons: `objectEstimate` is the
+    // progress denominator and so is the whole membership by design, and a
+    // caller's figure was read at whatever moment it ran its estimate — a gate
+    // must compare the space free NOW against the work outstanding NOW. Only
+    // curated has a recoverable installed membership to diff against; every
+    // other selector keeps the caller's count.
+    const floorBytes = minimumImageBytes(
+      request.selector.kind === "curated"
+        ? await this.curatedFetchCount(request.selector.membershipDigest)
+        : request.objectEstimate,
+    );
+    const outlook = await storageOutlook(persistence);
+    // `unknown` proceeds deliberately. A browser that will not report a quota
+    // is not reporting that the download fails to fit, and refusing on silence
+    // would make every browser without the Storage API unable to install
+    // anything at all.
+    //
+    // Refused as its own kind rather than as `storage`, and with the two
+    // figures as typed fields rather than interpolated into a message: the
+    // panel renders them in the user's language and unit, and it must render
+    // the numbers THIS comparison was made on. The alternative — a floor
+    // recomputed in the panel from the estimate — reads the browser's quota at
+    // a different instant than the gate did and can disagree with it.
+    const { availableBytes } = outlook;
+    if (availableBytes !== null && headroomFor(floorBytes, outlook) === "insufficient") {
+      throw new VisualPackStorageRefusalError({ requiredBytes: floorBytes, availableBytes });
+    }
+    return persistence;
+  }
+
+  private async estimate(
+    source: CatalogRecord,
+    selector: InstallSelector,
+    revision: string,
+    onProgress?: (progress: CatalogScanProgress) => void,
+  ): Promise<InstallEstimate> {
     if (selector.kind === "complete" && selector.rootSha256 !== source.root) throw new VisualPackBackendError("conflict");
-    let assetRecords = 0;
-    await forEachScryfallAsset(source, selector, new AbortController().signal, async () => { assetRecords += 1; });
+    const assetRecords = await countScryfallAssets(source, selector, new AbortController().signal, onProgress);
+    // The size question is "what will this DOWNLOAD", which for a pack already
+    // installed is not the size of its membership. Step 4 made a re-sync nearly
+    // free by skipping cached objects per object at download time, but that
+    // saving was invisible ahead of the run, so a sync fetching a handful of
+    // moved images reported the whole 6.5 GB — and `reserveStorage` could
+    // refuse it at low disk.
+    //
+    // TWO COUNTS, TWO CONSUMERS, and they legitimately differ for a curated
+    // re-sync:
+    //
+    //  - `assetRecords` is what the run will PROMOTE. It stays the WHOLE
+    //    membership: the panel passes it as `objectEstimate`, and that is the
+    //    denominator of a progress bar whose numerator counts every object the
+    //    run promotes, reused ones included. A denominator smaller than the
+    //    numerator's reach would run the bar past its end.
+    //  - `uniqueObjects` is what the run will DOWNLOAD. It is the panel's only
+    //    count row for a curated estimate, rendered directly beside
+    //    `estimatedImageBytes` under a label that says "Images to download", so
+    //    it must be the SAME figure that byte projection was computed from.
+    //    Reporting the membership there put "Images to download: 105,165"
+    //    beside "Estimated download size: 0 B" on an already-installed pack.
+    //
+    // For every non-curated selector the two are the same number, so nothing
+    // but the curated re-sync moves.
+    const downloadRecords = selector.kind === "curated"
+      ? await this.curatedFetchCount(selector.membershipDigest)
+      : assetRecords;
+    const projectedBytes = estimatedImageBytes(downloadRecords);
+    const storage = await storageOutlook(await currentPersistence());
     return {
       catalogRoot: source.root,
       installedRevision: installedRevision(revision),
       selector: selectorPack(selector),
       packIds: [selectorPack(selector)],
       assetRecords: String(assetRecords),
-      uniqueObjects: String(assetRecords),
+      uniqueObjects: String(downloadRecords),
+      // Still "unknown", and NOT where the projection below goes. These two are
+      // the ONLY write sites they have, and both hardcode this string: nothing
+      // in the codebase has ever populated them, and their labels say so in no
+      // language — `en` hedges with "(known after download)" and the other six
+      // name a measurement outright. They are left alone
+      // rather than repurposed only so a projection is never written into a
+      // field whose label claims to be a measurement; deciding their fate
+      // (populate or delete, with their seven locales) is open work.
       logicalImageBytes: "unknown",
       uniqueImageBytes: "unknown",
-      shardCount: "1",
-      shardBytes: String(source.compressedBytes),
+      // A curated pack reads no shard of the bulk archive, so reporting that
+      // archive's compressed size would show the user the multi-gigabyte
+      // download this selector exists to avoid.
+      shardCount: selector.kind === "curated" ? "0" : "1",
+      shardBytes: selector.kind === "curated" ? "unknown" : String(source.compressedBytes),
+      // The size question every selector must answer, curated and bulk alike:
+      // the whole point of the curated pack is that this figure is far smaller
+      // than `complete`'s, and a user cannot see that unless both report one.
+      estimatedImageBytes: projectedBytes,
+      storage,
+      headroom: headroomFor(projectedBytes, storage),
     };
+  }
+
+  /**
+   * The curated selector for the preferences stored right now.
+   *
+   * Reads no catalog and opens no bulk stream: the digest comes from the same
+   * `planCuratedPack()` memo that `start()`'s conflict guard and `run()`'s
+   * descriptor pass go through, so a selector this returns is one those two
+   * agree with rather than a second opinion about it.
+   */
+  async curatedSelector(): Promise<CuratedInstallSelector> {
+    try {
+      const { membershipDigest } = await planCuratedPack();
+      return { kind: "curated", membershipDigest };
+    } catch (error) {
+      throw backendError(error);
+    }
+  }
+
+  /**
+   * What a curated sync would do right now: the planned membership against the
+   * one on disk, in the three categories `CuratedDrift` documents.
+   *
+   * The installed membership needs no new storage to recover. `objects` rows
+   * carry `assetKey` and `sourceUrl` and are indexed `by-pack`, and for curated
+   * the pack's root IS its membership digest — so the `by-pack` rows filtered
+   * to the installed root are exactly the installed `(assetKey, sourceUrl)` set.
+   *
+   * READ ONLY, so it takes them in ONE indexed request rather than cursoring.
+   * `collectCuratedGarbage` and `adoptableContent` cursor the same rows, but
+   * neither is precedent for doing so here: the first DELETES through its
+   * cursor and the second streams while it builds. The read-only precedent in
+   * this file is `sweepUnreferenced`, which went indexed with a measurement
+   * attached — 105,261 rows, 103.8 s cursoring against 36.6 ms indexed. This
+   * runs at that same scale and now runs twice per install start (`estimate()`
+   * and `reserveStorage()`) plus once per `curatedDrift()`, all on the main
+   * thread.
+   *
+   * Rows at any OTHER root under the curated pack are deliberately excluded:
+   * those belong to a superseded or an in-flight membership, and counting them
+   * would report a sync as having work to remove that `completePack` is going
+   * to remove anyway.
+   */
+  private async curatedDiff(
+    descriptors: readonly ScryfallAssetDescriptor[],
+  ): Promise<Omit<CuratedDrift, "membershipDigest">> {
+    const curated = packId("curated");
+    const installedPack = await this.database.get("packs", curated);
+    // Nothing installed: every descriptor is an add, which is what the
+    // first-install estimate has always reported.
+    if (!installedPack) return { installedDigest: null, add: descriptors.length, remove: 0, refresh: 0 };
+    const installed = new Map<AssetKey, string | undefined>();
+    for (const row of await this.database.getAllFromIndex("objects", "by-pack", curated)) {
+      if (row.root === installedPack.root) installed.set(row.assetKey, row.sourceUrl);
+    }
+    const planned = new Set<AssetKey>();
+    let add = 0;
+    let refresh = 0;
+    for (const descriptor of descriptors) {
+      planned.add(descriptor.assetKey);
+      // `has` before `get`, so a row that stores `undefined` is told apart from
+      // a row that is not there: the first is a refresh, the second an add.
+      // Both are fetched, but they are different facts and the panel names them
+      // differently.
+      if (!installed.has(descriptor.assetKey)) add += 1;
+      else if (installed.get(descriptor.assetKey) !== descriptor.sourceUrl) refresh += 1;
+    }
+    let remove = 0;
+    for (const key of installed.keys()) if (!planned.has(key)) remove += 1;
+    return { installedDigest: installedPack.root, add, remove, refresh };
+  }
+
+  /**
+   * The images a curated install would actually FETCH, as opposed to the size
+   * of its membership: `add + refresh`.
+   *
+   * This is a count of ROWS, and whether a fetch happens is a CACHE fact. Not
+   * counted requires `installed.has(assetKey) && installed.get(assetKey) ===
+   * descriptor.sourceUrl` — an `objects` row saying those bytes were stored;
+   * `installObject` decides reuse by asking `cacheContains` whether they are
+   * still there. So the figure moves in BOTH directions:
+   *
+   *  - It OVERSTATES when a row under a DIFFERENT pack holds the same content:
+   *    that row donates and no request is made, while this counts only the
+   *    curated pack's own rows.
+   *  - It UNDERSTATES when a cache entry has been evicted out from under a
+   *    surviving row. That state is reachable and permanent — see
+   *    `installObject`, where the MEASURED note records `verify` reporting
+   *    `missing_object` while `repair` reports healthy — so an eviction leaves
+   *    the row counted as installed and the sync fetches it anyway.
+   *
+   * No guard, because the only consumer that can refuse a user gates on
+   * `minimumImageBytes` of this — roughly a quarter of `estimatedImageBytes` —
+   * and `reserveStorage`'s own doc block takes the asymmetry deliberately: a
+   * wrong refusal has no override, while running out of quota mid-download is a
+   * `storage` failure, which is retryable, and the resume re-fetches almost
+   * nothing.
+   */
+  private async curatedFetchCount(digest: CatalogRoot): Promise<number> {
+    const diff = await this.curatedDiff(await curatedDescriptors(digest));
+    return diff.add + diff.refresh;
+  }
+
+  /**
+   * `curatedDiff` against the membership preferences and decks name right now,
+   * for the panel to render before a sync runs.
+   *
+   * Reached through `VisualPackBackend`: the panel reads it whenever the
+   * summary reports an installed curated pack, and again whenever the art
+   * preferences behind the membership move. It only ever REPORTS — the sync it
+   * describes waits for the user to press it.
+   *
+   * NULL WHEN MEASURING WOULD MEAN LOADING, and that is the point of the guard
+   * rather than an incidental early return. `planCuratedPack()` awaits
+   * `loadScryfallData()` and `loadPrintingsData()`; together those are a 76 MB
+   * fetch and JSON parse, and the caller is a settings panel reading this on
+   * mount. Opening Preferences having rendered no card is ordinary, passive
+   * navigation with no progress indication and no way to cancel.
+   *
+   * Decided HERE and not in the panel: which data files are resident is engine
+   * knowledge, and a display layer that reasoned about it would be deriving
+   * state. Once anything has loaded them — a rendered card image, or the user
+   * choosing the curated option, which resolves a selector through this same
+   * planner — the next call measures for free.
+   */
+  async curatedDrift(): Promise<CuratedDrift | null> {
+    try {
+      if (!isCardDataResident()) return null;
+      const { membershipDigest, descriptors } = await planCuratedPack();
+      return { membershipDigest, ...await this.curatedDiff(descriptors) };
+    } catch (error) {
+      throw backendError(error);
+    }
   }
 
   async catalogStatus(): Promise<CatalogStatus> {
@@ -478,18 +1154,22 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
     return {
       catalogRoot: current.catalog.root,
       epoch: 0,
-      selectorCount: 4,
+      selectorCount: 5,
       shardCount: 1,
       installedRevision: installedRevision(current.revision),
       installedPacks: installed.map((entry) => ({ packId: entry.packId, catalogRoot: entry.root })),
+      // `currentPersistence`, never `requestPersistence`: this is a read, and a
+      // summary refresh must not ask the user for a storage grant. The grant is
+      // requested exactly where a user has started an operation that writes.
+      storage: await storageOutlook(await currentPersistence()),
     };
   }
 
-  async estimateInstall(selector: InstallSelector): Promise<InstallEstimate> {
+  async estimateInstall(selector: InstallSelector, onProgress?: (progress: CatalogScanProgress) => void): Promise<InstallEstimate> {
     try {
       const current = await state(this.database);
       const catalog = current.catalog ?? await loadScryfallBulkSource();
-      return this.estimate(catalog, selector, current.revision);
+      return this.estimate(catalog, selector, current.revision, onProgress);
     } catch (error) {
       throw backendError(error);
     }
@@ -506,24 +1186,49 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
         if (!operation) throw new VisualPackBackendError("invalid_input");
         if (operation.state === "completed") return { status: "healthy" };
         if (operation.state === "cancelled") throw new VisualPackBackendError("cancelled");
+        const resumePersistence = await this.reserveStorage(request);
         this.run(request.operationId);
-        return { status: "started", operationId: request.operationId, catalogRoot: operation.catalog.root };
+        return {
+          status: "started",
+          operationId: request.operationId,
+          catalogRoot: operation.catalog.root,
+          persistence: resumePersistence,
+        };
       }
       if (request.kind === "repair") {
         if (!current.catalog) throw new VisualPackBackendError("unavailable");
         catalog = current.catalog;
-        selectors = request.packIds.map((selectedPack) => selectorForPack(selectedPack, catalog.root));
+        // A repair must target the root the pack was INSTALLED at, not the
+        // current bulk root. For a curated pack the two differ by definition,
+        // and repairing at the bulk root would write objects there and then
+        // let completePack cursor-delete the entire installed membership.
+        selectors = request.packIds.map((selectedPack) =>
+          selectorForPack(selectedPack, installed.find((entry) => entry.packId === selectedPack)?.root ?? catalog.root));
       } else {
         catalog = current.catalog ?? await loadScryfallBulkSource();
         if (request.selector.kind === "complete" && request.selector.rootSha256 !== catalog.root) {
           throw new VisualPackBackendError("conflict");
         }
+        // The curated counterpart of the guard above, and it belongs HERE for
+        // the same reason: a conflict is not retryable, so it must reach the
+        // caller as a rejected request rather than as a failed operation
+        // record. This is the common case — estimate, change the art chain,
+        // then install — and catching it before any record exists leaves
+        // nothing behind to unwedge.
+        if (request.selector.kind === "curated") await curatedDescriptors(request.selector.membershipDigest);
         selectors = [request.selector];
       }
-      const packIds = selectors.map(selectorPack).filter((selectedPack) =>
-        !installed.some((entry) => entry.packId === selectedPack && entry.root === catalog.root));
-      if (packIds.length === 0) return { status: "healthy" };
-      selectors = selectors.filter((selector) => packIds.includes(selectorPack(selector)));
+      // Filtered over the SELECTORS rather than their pack ids: a pack id
+      // alone cannot say which root that selector installs at, and mapping
+      // first discards the curated selector's digest.
+      selectors = selectors.filter((selector) =>
+        !installed.some((entry) => entry.packId === selectorPack(selector) && entry.root === selectorRoot(selector, catalog)));
+      if (selectors.length === 0) return { status: "healthy" };
+      // After the short-circuit above, never before it: a sync that turns out
+      // to have nothing to do must not ask for a persistence grant, and it
+      // cannot run out of room for bytes it will not download.
+      const persistence = await this.reserveStorage(request);
+      const packIds = selectors.map(selectorPack);
       const selectedOperation = operationToken();
       const operation: ScryfallOperationRecord = Object.freeze({
         id: selectedOperation,
@@ -535,6 +1240,7 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
         packTotal: packIds.length,
         packsPromoted: 0,
         objectTotal: 0,
+        objectEstimate: request.kind === "install" ? request.objectEstimate : undefined,
         objectsPromoted: 0,
         completedRevision: null,
       });
@@ -544,7 +1250,7 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
       await transaction.done;
       this.emit({ phase: "started", operation: operationStatus(operation), error: null });
       this.run(selectedOperation);
-      return { status: "started", operationId: selectedOperation, catalogRoot: catalog.root };
+      return { status: "started", operationId: selectedOperation, catalogRoot: catalog.root, persistence };
     } catch (error) {
       throw backendError(error);
     }
@@ -597,11 +1303,7 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
       const revision = String(BigInt(current.revision) + 1n);
       await transaction.objectStore("state").put({ ...current, revision });
       await transaction.done;
-      const cache = await caches.open(CACHE);
-      const remaining = await this.database.getAll("objects");
-      for (const path of paths) {
-        if (!remaining.some((entry) => entry.path === path)) await cache.delete(path);
-      }
+      await this.sweepUnreferenced(paths, await caches.open(CACHE));
       this.publish({ cause: "remove", operationId: null, catalogRoot: null, revision: installedRevision(revision) });
       return { removed: removed.map((entry) => ({ packId: entry.packId, catalogRoot: entry.root })), revision: installedRevision(revision), cleanupIssues: [] };
     } catch (error) {

--- a/client/src/services/visualPacks/browser/scryfallBulk.ts
+++ b/client/src/services/visualPacks/browser/scryfallBulk.ts
@@ -1,8 +1,16 @@
 import { Gunzip } from "fflate";
 
 import { cardBackCandidate, cardCandidateGroups, setIconCandidate } from "../candidateKeys.ts";
-import { assetKey, catalogRoot, packId, type AssetKey, type CandidateKey, type CatalogRoot, type InstallSelector, type PackId, type VisualPackMedia } from "../types.ts";
+import { curatedDescriptors } from "../curatedPack.ts";
+import { assetKey, catalogRoot, packId, type CatalogRoot, type CatalogScanProgress, type InstallSelector, type PackId } from "../types.ts";
+import { descriptor, englishDescriptors } from "./descriptors.ts";
+import type { CardIdentity, ScryfallAssetDescriptor } from "./descriptors.ts";
 import { CARD_BACK_URL } from "../../scryfall.ts";
+
+// `ScryfallAssetDescriptor` moved to `descriptors.ts` alongside the builders
+// that produce it; re-exported so existing importers of this module are
+// unaffected by the extraction.
+export type { ScryfallAssetDescriptor };
 
 const BULK_INDEX_URL = "https://api.scryfall.com/bulk-data";
 const GZIP_INPUT_CHUNK_BYTES = 1024 * 1024;
@@ -20,14 +28,6 @@ export interface ScryfallBulkSource {
   readonly downloadUrl: string;
   readonly updatedAt: string;
   readonly compressedBytes: number;
-}
-
-export interface ScryfallAssetDescriptor {
-  readonly packId: PackId;
-  readonly assetKey: AssetKey;
-  readonly candidateKeys: readonly CandidateKey[];
-  readonly sourceUrl: string;
-  readonly media: VisualPackMedia;
 }
 
 interface BulkRecord {
@@ -51,15 +51,6 @@ interface ScryfallCard {
   readonly collector_number?: unknown;
   readonly image_uris?: unknown;
   readonly card_faces?: unknown;
-}
-
-interface CardIdentity {
-  readonly id: string;
-  readonly oracleId: string;
-  readonly set: string;
-  readonly collector: string;
-  readonly name: string;
-  readonly faces: readonly { readonly name: string; readonly images: Record<string, string> }[];
 }
 
 function asRecord(value: unknown): Record<string, unknown> | null {
@@ -121,42 +112,6 @@ function identityKey(card: CardIdentity): string {
   return `${card.oracleId}:${card.set}:${card.collector}`;
 }
 
-function descriptor(
-  selectedPack: PackId,
-  card: CardIdentity,
-  faceIndex: number,
-  variant: "full_card" | "art_crop",
-  rung: "small" | "normal" | "art_crop",
-  sourceUrl: string,
-  candidates: CandidateKey[],
-): ScryfallAssetDescriptor {
-  const asset = assetKey(`asset:v1:exact_printing:${card.id}-${faceIndex}-${variant}-${rung}`);
-  return { packId: selectedPack, assetKey: asset, candidateKeys: candidates, sourceUrl, media: "image/jpeg" };
-}
-
-function englishDescriptors(selectedPack: PackId, card: CardIdentity): ScryfallAssetDescriptor[] {
-  return card.faces.flatMap((face, faceIndex) => {
-    const result: ScryfallAssetDescriptor[] = [];
-    const add = (variant: "full_card" | "art_crop", rung: "small" | "normal" | "art_crop", url: string | undefined) => {
-      if (!url) return;
-      const candidates = cardCandidateGroups({
-        englishPrintingId: card.id,
-        oracleId: card.oracleId,
-        englishAliases: [card.name, face.name],
-        oracleAliases: [card.name, face.name],
-        faceIndex,
-        variant,
-        rung,
-      }).flatMap((group) => group.keys);
-      result.push(descriptor(selectedPack, card, faceIndex, variant, rung, url, candidates));
-    };
-    add("full_card", "small", face.images.small);
-    add("full_card", "normal", face.images.normal);
-    add("art_crop", "art_crop", face.images.art_crop);
-    return result;
-  });
-}
-
 function localizedDescriptors(selectedPack: PackId, english: CardIdentity, localized: CardIdentity, language: string): ScryfallAssetDescriptor[] {
   return localized.faces.flatMap((face, faceIndex) => {
     const englishFace = english.faces[faceIndex];
@@ -179,6 +134,17 @@ function localizedDescriptors(selectedPack: PackId, english: CardIdentity, local
     add("art_crop", "art_crop", face.images.art_crop);
     return result;
   });
+}
+
+function imageCount(card: CardIdentity, faceLimit = card.faces.length): number {
+  let count = 0;
+  for (const [index, face] of card.faces.entries()) {
+    if (index >= faceLimit) break;
+    if (face.images.small) count += 1;
+    if (face.images.normal) count += 1;
+    if (face.images.art_crop) count += 1;
+  }
+  return count;
 }
 
 function coreDescriptors(): ScryfallAssetDescriptor[] {
@@ -238,7 +204,12 @@ async function bulkResponse(source: ScryfallBulkSource, signal: AbortSignal, fet
   return response;
 }
 
-async function* jsonLines(response: Response, signal: AbortSignal): AsyncGenerator<unknown> {
+async function scanJsonLines(
+  response: Response,
+  signal: AbortSignal,
+  visit: (value: unknown) => Promise<void> | void,
+  onCompressedBytesRead?: (bytes: number) => void,
+): Promise<void> {
   if (!response.body) throw new ScryfallBulkError("network");
   const reader = response.body.getReader();
   const chunks: Uint8Array[] = [];
@@ -246,7 +217,23 @@ async function* jsonLines(response: Response, signal: AbortSignal): AsyncGenerat
   let trailing = "";
   let trailingUtf8 = new Uint8Array();
   let lineNumber = 0;
+  let compressedBytesRead = 0;
+  let lastYieldAt = performance.now();
   let stage = "reading the bulk response";
+  const yieldToUi = async () => {
+    if (performance.now() - lastYieldAt < 16) return;
+    await new Promise<void>((resolve) => setTimeout(resolve, 0));
+    lastYieldAt = performance.now();
+  };
+  const visitLine = (line: string): Promise<void> | void => {
+    lineNumber += 1;
+    if (!line) return;
+    let value: unknown;
+    try { value = JSON.parse(line); } catch (error) {
+      throw new ScryfallBulkError("network", `JSONL record ${lineNumber}: ${errorDetail(error) ?? "invalid JSON"}`);
+    }
+    return visit(value);
+  };
   try {
     while (true) {
       if (signal.aborted) return;
@@ -257,6 +244,7 @@ async function* jsonLines(response: Response, signal: AbortSignal): AsyncGenerat
         chunks.length = 0;
         stage = `decompressing bytes ${offset}-${end}`;
         gunzip.push(input.slice(offset, end), next.done && end === input.byteLength);
+        onCompressedBytesRead?.(compressedBytesRead + end);
         for (const chunk of chunks) {
           for (let outputOffset = 0; outputOffset < chunk.byteLength; outputOffset += JSONL_INPUT_CHUNK_BYTES) {
             stage = `decoding JSONL after byte ${end}`;
@@ -273,25 +261,23 @@ async function* jsonLines(response: Response, signal: AbortSignal): AsyncGenerat
             const lines = `${trailing}${new TextDecoder().decode(bytes.subarray(0, completeLength))}`.split("\n");
             trailing = lines.pop() ?? "";
             for (const line of lines) {
-              lineNumber += 1;
               if (signal.aborted) return;
-              if (!line) continue;
-              try { yield JSON.parse(line); } catch (error) {
-                throw new ScryfallBulkError("network", `JSONL record ${lineNumber}: ${errorDetail(error) ?? "invalid JSON"}`);
-              }
+              const pending = visitLine(line);
+              if (pending) await pending;
             }
+            await yieldToUi();
           }
         }
+        await yieldToUi();
       }
+      compressedBytesRead += input.byteLength;
       if (next.done) break;
     }
     stage = "finishing JSONL decoding";
     trailing += new TextDecoder().decode(trailingUtf8);
     if (trailing) {
-      lineNumber += 1;
-      try { yield JSON.parse(trailing); } catch (error) {
-        throw new ScryfallBulkError("network", `JSONL record ${lineNumber}: ${errorDetail(error) ?? "invalid JSON"}`);
-      }
+      const pending = visitLine(trailing);
+      if (pending) await pending;
     }
   } catch (error) {
     throw new ScryfallBulkError("network", `${stage}: ${errorDetail(error) ?? "unknown error"}`);
@@ -305,42 +291,129 @@ export async function forEachScryfallAsset(
   source: ScryfallBulkSource,
   selector: InstallSelector,
   signal: AbortSignal,
-  visit: (descriptor: ScryfallAssetDescriptor) => Promise<void>,
+  visit: (descriptor: ScryfallAssetDescriptor) => Promise<void> | void,
   fetcher: typeof fetch = globalThis.fetch,
 ): Promise<void> {
   if (selector.kind === "core") {
-    for (const value of coreDescriptors()) await visit(value);
+    for (const value of coreDescriptors()) {
+      const pending = visit(value);
+      if (pending) await pending;
+    }
+    return;
+  }
+  // The curated membership is planned from local data, so `source` is unused
+  // here and the multi-gigabyte bulk stream is never opened.
+  if (selector.kind === "curated") {
+    for (const value of await curatedDescriptors(selector.membershipDigest)) {
+      if (signal.aborted) return;
+      const pending = visit(value);
+      if (pending) await pending;
+    }
     return;
   }
   try {
     const selectedPack = selector.kind === "complete" ? packId("complete")
       : selector.kind === "printing" ? packId(`printing:${selector.set}`)
         : packId(`locale:${selector.language}:${selector.set}`);
-    if (selector.kind === "printing") await visit(setIconDescriptor(selectedPack, selector.set));
+    if (selector.kind === "printing") {
+      const pending = visit(setIconDescriptor(selectedPack, selector.set));
+      if (pending) await pending;
+    }
     const english = new Map<string, CardIdentity>();
     const localized = new Map<string, CardIdentity>();
-    for await (const value of jsonLines(await bulkResponse(source, signal, fetcher), signal)) {
+    await scanJsonLines(await bulkResponse(source, signal, fetcher), signal, (value) => {
       if (signal.aborted) return;
       const raw = value as ScryfallCard;
       const card = cardIdentity(raw);
-      if (!card) continue;
+      if (!card) return;
       if (selector.kind === "locale") {
-        if (raw.set !== selector.set) continue;
+        if (raw.set !== selector.set) return;
         if (raw.lang === "en") english.set(identityKey(card), card);
         if (raw.lang === selector.language) localized.set(identityKey(card), card);
       } else if (selected(selector, raw)) {
-        for (const descriptorValue of englishDescriptors(selectedPack, card)) await visit(descriptorValue);
+        let pending: Promise<void> | undefined;
+        for (const descriptorValue of englishDescriptors(selectedPack, card)) {
+          if (pending) {
+            pending = pending.then(() => visit(descriptorValue));
+          } else {
+            const next = visit(descriptorValue);
+            if (next) pending = next;
+          }
+        }
+        return pending;
       }
-    }
+    });
     if (selector.kind === "locale") {
       for (const [key, local] of localized) {
         const base = english.get(key);
         if (!base) continue;
-        for (const descriptorValue of localizedDescriptors(selectedPack, base, local, selector.language)) await visit(descriptorValue);
+        for (const descriptorValue of localizedDescriptors(selectedPack, base, local, selector.language)) {
+          const pending = visit(descriptorValue);
+          if (pending) await pending;
+        }
       }
     }
   } catch (error) {
     if (error instanceof Error && error.name === "VisualPackBackendError") throw error;
+    throw sourceError(error);
+  }
+}
+
+export async function countScryfallAssets(
+  source: ScryfallBulkSource,
+  selector: InstallSelector,
+  signal: AbortSignal,
+  onProgress?: (progress: CatalogScanProgress) => void,
+  fetcher: typeof fetch = globalThis.fetch,
+): Promise<number> {
+  if (selector.kind === "core") return coreDescriptors().length;
+  if (selector.kind === "curated") return (await curatedDescriptors(selector.membershipDigest)).length;
+  try {
+    let count = selector.kind === "printing" ? 1 : 0;
+    let compressedBytesRead = 0;
+    let recordsScanned = 0;
+    let lastReportedAt = 0;
+    const report = (force = false) => {
+      const now = performance.now();
+      if (!force && now - lastReportedAt < 100) return;
+      lastReportedAt = now;
+      onProgress?.({
+        compressedBytesRead: Math.min(compressedBytesRead, source.compressedBytes),
+        compressedBytesTotal: source.compressedBytes,
+        recordsScanned,
+        assetRecords: count,
+      });
+    };
+    const english = new Map<string, CardIdentity>();
+    const localized = new Map<string, CardIdentity>();
+    await scanJsonLines(await bulkResponse(source, signal, fetcher), signal, (value) => {
+      if (signal.aborted) return;
+      recordsScanned += 1;
+      const raw = value as ScryfallCard;
+      const card = cardIdentity(raw);
+      if (!card) return;
+      if (selector.kind === "locale") {
+        if (raw.set !== selector.set) return;
+        if (raw.lang === "en") english.set(identityKey(card), card);
+        if (raw.lang === selector.language) localized.set(identityKey(card), card);
+      } else if (selected(selector, raw)) {
+        count += imageCount(card);
+      }
+      report();
+    }, (bytes) => {
+      compressedBytesRead = bytes;
+      report();
+    });
+    if (signal.aborted) return count;
+    if (selector.kind === "locale") {
+      for (const [key, local] of localized) {
+        const base = english.get(key);
+        if (base) count += imageCount(local, base.faces.length);
+      }
+    }
+    report(true);
+    return count;
+  } catch (error) {
     throw sourceError(error);
   }
 }

--- a/client/src/services/visualPacks/curatedMembership.ts
+++ b/client/src/services/visualPacks/curatedMembership.ts
@@ -1,0 +1,273 @@
+import { selectedPrinting } from "../artSelection.ts";
+import { deriveImageUrl } from "../scryfall.ts";
+import type { PrintingEntry } from "../scryfall.ts";
+// Type-only, matching `artSelection.ts`: no runtime dependency is created from
+// `services/` back into `hooks/`.
+import type { SourcePrinting } from "../../hooks/useCardImage.ts";
+import type { ArtChainEntry, CardArtOverride } from "../../stores/preferencesStore.ts";
+import { canonicalDescriptors, englishDescriptors } from "./browser/descriptors.ts";
+import type { CanonicalCardIdentity, DescriptorFace, ScryfallAssetDescriptor } from "./browser/descriptors.ts";
+import { catalogRoot } from "./types.ts";
+import type { AssetKey, CatalogRoot, PackId } from "./types.ts";
+
+/**
+ * The subset of a `scryfall-data.json` entry the planner reads.
+ *
+ * Declared structurally rather than imported because `ScryfallDataEntry` is
+ * private to `services/scryfall.ts`. Note what is absent: these entries carry
+ * no printing `id`, which is why a card with no selected printing can only be
+ * expressed in the `canonical_card` asset form.
+ */
+export interface CuratedCardEntry {
+  readonly oracle_id: string;
+  readonly name: string;
+  /** Lowercased face names in Scryfall's `card_faces` order. */
+  readonly face_names: readonly string[];
+  readonly faces: readonly ImageFace[];
+}
+
+/** A stored face's image URLs. Both are nullable in the generated data. */
+interface ImageFace {
+  readonly normal?: string | null;
+  readonly art_crop?: string | null;
+}
+
+/** A printing a saved deck names via its `(SET) NUM` annotation. */
+export interface CuratedDeckPrinting {
+  readonly oracleId: string;
+  readonly source: SourcePrinting;
+}
+
+export interface CuratedMembershipInput {
+  /**
+   * The pack the descriptors belong to. Supplied by the caller rather than
+   * hardcoded: the `curated` pack id is not admissible until the selector
+   * lands, and the planner has no other reason to know its own pack.
+   */
+  readonly packId: PackId;
+  /** The `scryfall-data.json` map, keyed by oracle id AND by lowercased name. */
+  readonly cards: Readonly<Record<string, CuratedCardEntry>>;
+  /** The `scryfall-printings.json` map, keyed by oracle id. */
+  readonly printings: Readonly<Record<string, PrintingEntry[]>>;
+  readonly artChain: ArtChainEntry[];
+  readonly artOverrides: Record<string, CardArtOverride>;
+  readonly deckPrintings?: readonly CuratedDeckPrinting[];
+}
+
+export interface CuratedMembership {
+  /** Ascending by `assetKey`, so the list is a function of its content. */
+  readonly descriptors: readonly ScryfallAssetDescriptor[];
+  /** sha256 over the sorted `"<assetKey>\t<sourceUrl>"` lines. */
+  readonly membershipDigest: CatalogRoot;
+}
+
+/** `scryfall-data.json` prefixes token keys; tokens resolve through
+ *  `tokenCandidateGroups`, so their images would download and never resolve. */
+const TOKEN_KEY_PREFIX = "token:";
+
+/**
+ * The rung URLs one stored face offers.
+ *
+ * Neither `scryfall-data.json` nor `scryfall-printings.json` stores `small`;
+ * it is derived from `normal`, exactly as `scryfall.ts`'s own face resolver
+ * does. Both stored URLs are nullable — the printings generator writes an
+ * explicit null when Scryfall has no image for a face — so each is admitted
+ * only when present, and `small` only when there is a `normal` to derive from.
+ */
+function rungUrls(face: ImageFace | undefined): Record<string, string> {
+  const images: Record<string, string> = {};
+  if (face?.normal) {
+    images.normal = face.normal;
+    images.small = deriveImageUrl(face.normal, "small");
+  }
+  if (face?.art_crop) images.art_crop = face.art_crop;
+  return images;
+}
+
+function descriptorFaces(entry: CuratedCardEntry, faces: readonly ImageFace[]): DescriptorFace[] {
+  return faces.map((face, faceIndex) => ({
+    name: entry.face_names[faceIndex] ?? entry.name,
+    images: rungUrls(face),
+  }));
+}
+
+/**
+ * Every printing the app could display for this card under stored preferences.
+ *
+ * `selectedPrinting` is the single authority for "which printing", and this
+ * reduces to that one question asked once per render context the card appears
+ * in: with no deck source — every battlefield, hand, search and deck-builder
+ * render — and once per distinct printing a decklist names.
+ *
+ * The no-source context is load-bearing for two reasons. Most cards are in no
+ * deck at all, so `sources` is empty and it is the only context there is. And
+ * a chain naming `source_printing` makes the two genuinely diverge: without a
+ * source that entry matches nothing and the chain falls through to its next
+ * entry, while with one it resolves the deck's printing — two different arts,
+ * both displayed, at different sites.
+ *
+ * It is NOT needed to keep a deck card's plain renders on canonical art, and
+ * this is an ACCEPTED DIVERGENCE rather than an oversight. Under an EMPTY
+ * chain a deck card plans exactly one printing: the no-source answer is null
+ * (no override, no chain, no source), the deck context yields the deck's
+ * printing, and the exclusivity gate below therefore emits no canonical form.
+ * That card's battlefield, hand and search renders resolve through the oracle
+ * group onto the deck printing's `exact_printing` descriptor, so offline they
+ * show the deck's art where online they would show canonical. Emitting both
+ * forms to close the gap would be worse, not better: they would share this
+ * card's oracle-group candidate keys and `sortMatches` orders
+ * `canonical_card:` first, so canonical would win `sources[0]` for the DECK
+ * render too — breaking the half of the feature that motivated it. Of the
+ * three available behaviors this is the best one.
+ *
+ * Nothing is added on top of those answers. Two extras were tried and removed:
+ * the chain winner beside a pinned `artOverride`, and a deck's own printing
+ * beside whatever the chain resolves for that deck render. Neither is ever
+ * displayed — an override suppresses the chain entirely, and `useCardImage`
+ * consults a deck source only through its `else if (sourcePrinting)` branch,
+ * reachable solely when `artChain` is empty because it follows
+ * `else if (artChain.length > 0)`, or through a chain that itself names
+ * `source_printing`; both are already what the call below returns. Each extra
+ * would cost bytes on a feature whose whole purpose is fewer bytes, and would
+ * put a second `exact_printing` under one card's oracle-group candidate keys —
+ * which makes `unambiguousCompanion` see two candidates and drop rung pairing,
+ * and lets `sortMatches` order `canonical_card:` ahead of `exact_printing:` so
+ * the wrong art lands at `sources[0]`. Both `artChain` and `artOverrides` are
+ * digest inputs, so un-pinning an override or switching chains changes the
+ * digest, reports drift, and lets the delta sync fetch what is newly
+ * displayed. That is what the drift mechanism is for.
+ */
+function selectedPrintings(
+  oracleId: string,
+  printings: PrintingEntry[],
+  input: CuratedMembershipInput,
+  sources: readonly SourcePrinting[],
+): PrintingEntry[] {
+  const { artChain, artOverrides } = input;
+  const byId = new Map<string, PrintingEntry>();
+  for (const source of [undefined, ...sources]) {
+    const printing = selectedPrinting(oracleId, printings, artChain, artOverrides, source);
+    if (printing) byId.set(printing.id, printing);
+  }
+  return [...byId.values()];
+}
+
+function cardDescriptors(
+  entry: CuratedCardEntry,
+  input: CuratedMembershipInput,
+  sources: readonly SourcePrinting[],
+): ScryfallAssetDescriptor[] {
+  // The app keys these two things on DIFFERENT forms of the oracle id, so the
+  // planner must too. Preference and printing lookups use the id exactly as
+  // stored: `getCardPrintings` indexes `scryfall-printings.json`, whose
+  // generator writes the id unmodified, and `PrintingPickerModal` writes
+  // `artOverrides` under that same value. Candidate keys use the lowercased
+  // form, because `scryfall.ts` stamps `CardImageAsset.semantic.oracleId` with
+  // `.toLowerCase()` before `useCardImage` builds its lookup groups from it.
+  // Today every stored id is already lowercase, so the two coincide; keying
+  // both on one form would silently rely on that.
+  const oracleId = entry.oracle_id;
+  const candidateOracleId = oracleId.toLowerCase();
+  const printings = selectedPrintings(
+    oracleId,
+    input.printings[oracleId] ?? [],
+    input,
+    sources,
+  );
+  const exact = printings.flatMap((printing) => englishDescriptors(input.packId, {
+    id: printing.id,
+    oracleId: candidateOracleId,
+    set: printing.set,
+    collector: printing.collector_number,
+    name: entry.name,
+    faces: descriptorFaces(entry, printing.faces),
+  }));
+  // A card that produced NO `exact_printing` descriptor falls back to the
+  // canonical form, and one that produced any never emits it. The trigger is
+  // stated as "emitted nothing" rather than "selected nothing" because the
+  // invariant being protected is emission: the two forms share this card's
+  // oracle-group candidate keys, so a card reachable by BOTH returns two
+  // matches for every oracle-group lookup — and `sortMatches` orders by
+  // assetKey within a pack, where `canonical_card:` sorts before
+  // `exact_printing:`. The canonical art would become `sources[0]` and the
+  // WRONG printing would render, not merely a degraded rung pairing. A card
+  // emitting no `exact_printing` descriptor cannot be reachable by both, so
+  // this tests the invariant directly instead of through a proxy.
+  //
+  // Two situations reach it. No printing was selected: the card is absent from
+  // `scryfall-printings.json`, or the chain found no winner. Or a printing was
+  // selected and stores no image — `scryfall-printings.json` holds 696 such
+  // printings, null on `art_crop` as well as `normal` across every face, and
+  // 211 cards have no renderable printing at all. `faceImages` skips every rung
+  // for those, so the older `printings.length === 0` gate left them
+  // contributing nothing at all while the renderer, whose `overrideUrl` is null
+  // for the same reason, falls through to canonical art — 211 cards needing the
+  // network in an offline-play feature. All 211 do carry an image in
+  // `scryfall-data.json`, which is what the canonical form serves. Three more
+  // cards own image-less and renderable printings both, and fall back only when
+  // the chain picks an image-less one — which, measured under a `newest` chain,
+  // is all three of them.
+  //
+  // A card with SEVERAL selected printings, only some of them image-less, still
+  // emits the exact form alone. Its image-less render context falls back to
+  // canonical art online, and the one-form rule above is what forbids caching
+  // it; that residual is the price of the rule, not an oversight.
+  if (exact.length === 0) {
+    const canonical: CanonicalCardIdentity = {
+      oracleId: candidateOracleId,
+      name: entry.name,
+      faces: descriptorFaces(entry, entry.faces),
+    };
+    return canonicalDescriptors(input.packId, canonical);
+  }
+  return exact;
+}
+
+async function sha256Hex(value: string): Promise<string> {
+  const digest = new Uint8Array(await crypto.subtle.digest("SHA-256", new TextEncoder().encode(value)));
+  return Array.from(digest, (byte) => byte.toString(16).padStart(2, "0")).join("");
+}
+
+/**
+ * Plan the curated pack: one art per card under the user's configured art
+ * chain, plus the printings their overrides and decklists pin.
+ *
+ * The digest covers each descriptor's source URL as well as its asset key. A
+ * `canonical_card` key names no printing, so the bytes behind it are whatever
+ * `scryfall-data.json` currently supplies — a pipeline regeneration can move
+ * the URL under an unchanged key. Digesting keys alone would leave that
+ * invisible and pin stale art with no path to a refresh.
+ */
+export async function planCuratedMembership(
+  input: CuratedMembershipInput,
+): Promise<CuratedMembership> {
+  // Case-folded on both sides: whether a caller's oracle id arrived from the
+  // engine or from a `scryfall-data` entry, the same card must match.
+  const sourcesByOracleId = new Map<string, SourcePrinting[]>();
+  for (const { oracleId, source } of input.deckPrintings ?? []) {
+    const key = oracleId.toLowerCase();
+    const existing = sourcesByOracleId.get(key);
+    if (existing) existing.push(source);
+    else sourcesByOracleId.set(key, [source]);
+  }
+
+  // `scryfall-data.json` keys each card by its oracle id AND by one or two
+  // name forms, unevenly. Iterating keys would emit most cards two or three
+  // times over, so distinctness is tracked on the oracle id itself.
+  const seen = new Set<string>();
+  const byAssetKey = new Map<AssetKey, ScryfallAssetDescriptor>();
+  for (const [key, entry] of Object.entries(input.cards)) {
+    if (key.startsWith(TOKEN_KEY_PREFIX)) continue;
+    const oracleId = entry.oracle_id.toLowerCase();
+    if (seen.has(oracleId)) continue;
+    seen.add(oracleId);
+    for (const value of cardDescriptors(entry, input, sourcesByOracleId.get(oracleId) ?? [])) {
+      byAssetKey.set(value.assetKey, value);
+    }
+  }
+
+  const descriptors = [...byAssetKey.values()].sort((a, b) =>
+    a.assetKey < b.assetKey ? -1 : a.assetKey > b.assetKey ? 1 : 0);
+  const lines = descriptors.map((value) => `${value.assetKey}\t${value.sourceUrl}\n`).join("");
+  return { descriptors, membershipDigest: catalogRoot(await sha256Hex(lines)) };
+}

--- a/client/src/services/visualPacks/curatedPack.ts
+++ b/client/src/services/visualPacks/curatedPack.ts
@@ -1,0 +1,283 @@
+import { VisualPackBackendError } from "./backend.ts";
+import { planCuratedMembership } from "./curatedMembership.ts";
+import type { CuratedDeckPrinting, CuratedMembership } from "./curatedMembership.ts";
+import type { ScryfallAssetDescriptor } from "./browser/descriptors.ts";
+import { packId } from "./types.ts";
+import type { CatalogRoot } from "./types.ts";
+import { loadPrintingsData, loadScryfallData, resolveOracleIdSync } from "../scryfall.ts";
+import { listSavedDeckNames, loadSavedDeck, STORAGE_KEY_PREFIX } from "../../constants/storage.ts";
+import {
+  usePreferencesStore,
+  type ArtChainEntry,
+  type CardArtOverride,
+} from "../../stores/preferencesStore.ts";
+
+/**
+ * What a membership was planned from, and therefore what a later call must
+ * match to be served it.
+ *
+ * Built BEFORE the plan it keys, and handed to `planMembership` so that the
+ * plan can re-stamp `deckText` at the moment it actually reads the decks — see
+ * `planMembership`, which is where the two samples differ and why.
+ */
+interface CuratedPlanKey {
+  artChain: ArtChainEntry[];
+  artOverrides: Record<string, CardArtOverride>;
+  deckText: string;
+}
+
+/**
+ * The one membership this module is holding on to, and the preferences it was
+ * planned from.
+ *
+ * SINGLE-ENTRY on purpose. A curated membership is ~105,000 descriptors at
+ * roughly 500 bytes of retained object per row, so a map keyed by preference
+ * would grow tens of MiB per distinct art chain a user tries — a cache whose
+ * miss is 130-330 ms must not trade that for unbounded heap.
+ *
+ * The PROMISE is cached rather than the resolved value, so two callers that
+ * overlap (the panel resolving a selector while an estimate is already in
+ * flight) share one plan instead of racing two. A rejected plan evicts itself:
+ * a transient card-data failure must not be remembered as the answer.
+ */
+interface CuratedPlan {
+  key: CuratedPlanKey;
+  membership: Promise<CuratedMembership>;
+}
+
+let cachedPlan: CuratedPlan | null = null;
+
+/**
+ * The saved decks as their STORED TEXT, in `listSavedDeckNames`' alphabetical
+ * order.
+ *
+ * This is the memo key's third component and it is a raw-string compare BY
+ * DECISION, over the two alternatives:
+ *
+ * - NOT the parsed decks. `loadSavedDeck` runs `JSON.parse` +
+ *   `repairParsedDeck` + `projectSavedDeckSpecialSlots` on every call, so it
+ *   returns a fresh object every time and has no identity to key on. Keying on
+ *   one would miss on every single call — a memo that is useless rather than
+ *   stale, which is the failure that hides: nothing goes red, the 130-330 ms
+ *   plan simply runs four times per install again.
+ * - NOT a digest. `sha256Hex` is `crypto.subtle`, so an awaited key would make
+ *   the cache check asynchronous, and `planCuratedPack` deliberately answers
+ *   SYNCHRONOUSLY on a hit — that is what lets two overlapping callers share
+ *   one in-flight plan instead of both missing in the await window.
+ *
+ * The text is exact (a byte the parser ignores is a spurious miss at worst,
+ * never a stale hit), parse-free on a hit, and retains a few hundred KiB at
+ * most beside a membership that already retains tens of MiB.
+ *
+ * BODIES ONLY — the deck names are not part of the key. The membership is a
+ * function of what the decks CONTAIN, so a rename must not force a re-plan, and
+ * the list's own shape is still covered: adding or deleting a deck changes the
+ * array's length, and the alphabetical order fixes each body's position. A name
+ * was in this key until a mutation probe could not find a single test that
+ * depended on it, which is what a line that cannot be wrong looks like.
+ *
+ * Serialized through `JSON.stringify` rather than joined on a separator so the
+ * encoding is unambiguous: a deck body is arbitrary stored text and can contain
+ * whatever character a hand-rolled separator picked, which would let two
+ * different deck sets flatten to one string — the one direction that turns a
+ * spurious miss into a stale hit.
+ */
+function savedDeckText(): string {
+  return JSON.stringify(listSavedDeckNames().map((name) => localStorage.getItem(STORAGE_KEY_PREFIX + name)));
+}
+
+/**
+ * Every printing the user's saved decks pin, as the planner's `deckPrintings`.
+ *
+ * ONLY `main` and `sideboard` are `DeckEntry[]` and therefore the only slots
+ * carrying `sourcePrinting`. `commander`, `sticker_sheets`, `planar_deck`,
+ * `scheme_deck` and `signature_spell` are `string[]` — names with no printing
+ * identity — and `companion` is a bare `string` that
+ * `projectSavedDeckSpecialSlots` folds into `sideboard` as `{count: 1, name}`
+ * for a non-commander format, again with no `sourcePrinting`. So a commander's
+ * or a companion's art cannot be pinned by the deck it belongs to, and nothing
+ * here should be read as claiming otherwise.
+ *
+ * `sourcePrinting` is itself optional: a plain "4 Lightning Bolt" list pins
+ * nothing, and only a list carrying `(SET) NUM` annotations contributes at all.
+ * An empty result is the common case, not a failure.
+ *
+ * `resolveOracleIdSync` is the app's single name-to-oracle-id rule — annotation
+ * stripping, diacritic folding ("Eowyn" for "Éowyn"), and the front-face
+ * fallback that makes a decklist's "Fire // Ice" resolve — and it is reused
+ * rather than restated. It reads `scryfall-data.json` through the module global
+ * that `loadScryfallData` assigns, and answers `null` until that assignment has
+ * happened; this runs only from `planMembership`, AFTER its `await
+ * loadScryfallData()`, so by then the global is set. That is an ordering fact
+ * about the one call site, not an assumption about the loader.
+ */
+function deckPrintings(): CuratedDeckPrinting[] {
+  const pinned: CuratedDeckPrinting[] = [];
+  for (const name of listSavedDeckNames()) {
+    const deck = loadSavedDeck(name);
+    if (!deck) continue;
+    for (const entry of [...deck.main, ...deck.sideboard]) {
+      if (!entry.sourcePrinting) continue;
+      const oracleId = resolveOracleIdSync(entry.name);
+      if (oracleId) pinned.push({ oracleId, source: entry.sourcePrinting });
+    }
+  }
+  return pinned;
+}
+
+/**
+ * Plan the curated pack from the app's own card data and stored art
+ * preferences — the single authority for what "curated" contains.
+ *
+ * The backend installs exactly these descriptors and the settings UI compares
+ * this digest against the installed pack's root to report drift, so both must
+ * come from here: two independent assemblies of the planner's input would
+ * disagree the moment one of them gained a source the other lacked.
+ *
+ * It lives outside `browser/scryfallBulk.ts` so that a UI module can import it
+ * without pulling the bulk JSONL scanner along: the backend is reached through
+ * a dynamic `import()` in `services/platform.ts`, which code-splits that
+ * scanner out of the eager bundle, and a static import of the planner from the
+ * settings panel would drag it back in.
+ *
+ * MEMOIZED against the preferences it reads. One install plans four or more
+ * times today — the panel resolving a selector, the estimate, `start()`'s
+ * conflict guard, and `run()`'s own descriptor pass — and `create()` re-runs
+ * every pending record on each app launch, so this is load-bearing rather than
+ * an optimisation. The card data behind it is already resident: `loadScryfallData`
+ * and `loadPrintingsData` are module-level memoized promises, so the cost being
+ * avoided here is `planCuratedMembership` itself.
+ *
+ * The key has THREE components: the identity of the two preference values, and
+ * the saved decks' stored text (see `savedDeckText`, which explains why the
+ * third one cannot be an identity). Decks are a membership input — a deck's
+ * `(SET) NUM` annotation pins a printing the art chain would not otherwise
+ * select — so a key covering only the preferences would return the cached
+ * membership after a deck edit, silently, until something else moved.
+ *
+ * The preference half is the IDENTITY of the two values, which is sound because
+ * every writer replaces them: the chain mutators build a new array
+ * (`[...artChain, entry]`, `.filter`, `.slice()`), the override mutators build
+ * a new object (spread, rest-spread, `{}`), `resetAllPreferences` calls a
+ * FUNCTION returning a fresh literal, and the persist layer's `merge` and
+ * `persist.rehydrate()` both install freshly parsed objects. `addArtChainEntry`
+ * returning `state` unchanged on a duplicate keeps identity AND contents, which
+ * is the correct hit. A
+ * new reference holding equal contents is a MISS, which costs one re-plan and
+ * yields the same digest; there is no reference-equal path to changed
+ * contents, so a stale hit cannot happen.
+ *
+ * The key deliberately does NOT cover the card data, and that is an assumption
+ * about a different module rather than something checked here: `loadScryfallData`
+ * and `loadPrintingsData` memoize one fetch each at module scope, so within a
+ * session the maps are fetched once and never replaced. A moved source URL
+ * therefore arrives with a fresh map in a fresh tab, where this cache starts
+ * empty. Nothing in `src/` resets those promises, so the assumption holds — but
+ * a test that edits the maps IN PLACE is invisible to this key and must force a
+ * miss itself (see `curatedDelta.test.ts`), and any future in-session reload of
+ * card data would have to invalidate here as well.
+ */
+export function planCuratedPack(): Promise<CuratedMembership> {
+  const { artChain, artOverrides } = usePreferencesStore.getState();
+  const deckText = savedDeckText();
+  const cached = cachedPlan;
+  if (
+    cached
+    && cached.key.artChain === artChain
+    && cached.key.artOverrides === artOverrides
+    && cached.key.deckText === deckText
+  ) return cached.membership;
+  // The key object is built first and handed to the plan, which overwrites
+  // `deckText` with the sample taken beside its own deck read. What is compared
+  // above is therefore always a description of the decks the cached membership
+  // was actually planned from.
+  const key: CuratedPlanKey = { artChain, artOverrides, deckText };
+  const entry: CuratedPlan = { key, membership: planMembership(artChain, artOverrides, key) };
+  cachedPlan = entry;
+  // Evict a failure rather than serve it forever. The `catch` is on a branch
+  // of the promise, not on the one returned, so the caller still sees the
+  // rejection.
+  void entry.membership.catch(() => { if (cachedPlan === entry) cachedPlan = null; });
+  return entry.membership;
+}
+
+async function planMembership(
+  artChain: ArtChainEntry[],
+  artOverrides: Record<string, CardArtOverride>,
+  key: CuratedPlanKey,
+): Promise<CuratedMembership> {
+  try {
+    const [cards, printings] = await Promise.all([loadScryfallData(), loadPrintingsData()]);
+    // No detail: `network` is already a complete sentence in all seven
+    // locales, and any prose composed here would render verbatim, in English,
+    // underneath the translated one.
+    if (!cards || !printings) throw new VisualPackBackendError("network");
+    // The decks are read HERE, after the await, because `resolveOracleIdSync`
+    // needs the loader to have resolved — and the await is a real one: a cold
+    // start fetches ~76 MB, so seconds can pass, not a microtask.
+    //
+    // So the text `planCuratedPack` sampled before that wait describes the
+    // decks as they were BEFORE it, not the ones read below. Filing this plan
+    // under that older text would be a stale hit waiting for a revert: decks
+    // D1 -> D2 inside the window, membership(D2) filed under text(D1), decks
+    // reverted to D1, and every later call matches text(D1) and is served
+    // membership(D2) for the life of the tab.
+    //
+    // The two statements below are one synchronous block with no await between
+    // them, so nothing can interleave: whatever `deckPrintings` read is what
+    // `savedDeckText` describes, and stamping it onto the key makes the stored
+    // key describe the decks actually planned. The revert above is then a MISS.
+    const pinned = deckPrintings();
+    key.deckText = savedDeckText();
+    return await planCuratedMembership({
+      packId: packId("curated"),
+      cards,
+      printings,
+      artChain,
+      artOverrides,
+      deckPrintings: pinned,
+    });
+  } catch (error) {
+    if (error instanceof VisualPackBackendError) throw error;
+    // Classify the rest DELIBERATELY rather than let the backend guess.
+    //
+    // `errorKind` ends in `return "storage"`, which is RETRYABLE, and the
+    // curated arm of `forEachScryfallAsset` sits ABOVE the try that wraps the
+    // bulk path — so an unclassified throw from here reaches `run()` naked,
+    // reads as transient, and leaves the operation record `downloading`. That
+    // state offers Resume as the only enabled control while disabling every
+    // durable mutation, and `create()`'s pending loop re-runs the record on
+    // every launch, so the settings panel stays wedged across restarts.
+    //
+    // This contains the CLASS, without a claim about what produced it: a throw
+    // that is not already a backend error is a defect in this planner or in
+    // the data it reads, both of which are deterministic, so re-running cannot
+    // reach a different outcome. `internal` says exactly that and is not
+    // retryable, so the record terminates and the panel stays usable. The
+    // transient failures raised above as `VisualPackBackendError` are
+    // deliberately NOT captured — they must stay resumable.
+    throw new VisualPackBackendError("internal", error instanceof Error ? error.message : undefined);
+  }
+}
+
+/**
+ * The curated membership a selector names, refusing one it does not name.
+ *
+ * The digest is the pack's catalog root, so installing a membership whose
+ * digest is not the selector's would store those objects under a root they do
+ * not hash to. This is the curated counterpart of the `complete` selector's
+ * `rootSha256` conflict guard, and it fires when preferences change between
+ * the estimate the user accepted and the install they started.
+ *
+ * The refusal is STRUCTURALLY non-retryable: the selector stores only a
+ * digest, and a digest is not invertible, so once preferences move there is no
+ * way to reconstruct the membership it named. Callers must therefore surface
+ * `conflict` through something other than a retry affordance — `start()`
+ * rejects the request outright, and `run()` terminates an operation record
+ * that hits it rather than leaving it resumable.
+ */
+export async function curatedDescriptors(digest: CatalogRoot): Promise<readonly ScryfallAssetDescriptor[]> {
+  const membership = await planCuratedPack();
+  if (membership.membershipDigest !== digest) throw new VisualPackBackendError("conflict");
+  return membership.descriptors;
+}

--- a/client/src/services/visualPacks/types.ts
+++ b/client/src/services/visualPacks/types.ts
@@ -16,7 +16,7 @@ export type OperationId = Brand<string, "OperationId">;
 const LOWER_HEX_64 = /^[0-9a-f]{64}$/;
 const LOWER_HEX_32 = /^[0-9a-f]{32}$/;
 const DECIMAL = /^(0|[1-9][0-9]*)$/;
-const PACK_ID = /^(complete|core|printing:[a-z0-9]{3,6}|locale:(de|es|fr|it|pt):[a-z0-9]{3,6})$/;
+const PACK_ID = /^(complete|core|curated|printing:[a-z0-9]{3,6}|locale:(de|es|fr|it|pt):[a-z0-9]{3,6})$/;
 const ASSET_KEY = /^asset:v1:(canonical_card|exact_printing|localized_printing|token|card_back|mana_symbol|set_icon):[A-Za-z0-9_-]+$/;
 const CANDIDATE_KEY = /^candidate:v1:(localized_printing|localized_alias|english_printing|english_alias|oracle|oracle_alias|token_reference|token_alias|card_back|mana_symbol|set_icon):([A-Za-z0-9_-]+)$/;
 const CANDIDATE_UUID = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/;
@@ -185,10 +185,19 @@ export type InstallSelector =
   | { kind: "core" }
   | { kind: "printing"; set: string }
   | { kind: "locale"; language: string; set: string }
-  | { kind: "complete"; rootSha256: CatalogRoot };
+  | { kind: "complete"; rootSha256: CatalogRoot }
+  // The curated pack IS its membership: the digest names both the selection
+  // and the catalog root that selection's packs and objects are stored at, so
+  // a changed preference reads as an ordinary root change.
+  | { kind: "curated"; membershipDigest: CatalogRoot };
+
+/** The curated arm of `InstallSelector`, named so a resolver can return it
+ *  without widening to the union and making every caller re-narrow to read the
+ *  digest it exists to carry. */
+export type CuratedInstallSelector = Extract<InstallSelector, { kind: "curated" }>;
 
 export type StartRequest =
-  | { kind: "install"; selector: InstallSelector }
+  | { kind: "install"; selector: InstallSelector; objectEstimate: number }
   | { kind: "repair"; packIds: PackId[] }
   | { kind: "resume"; operationId: OperationId };
 
@@ -214,12 +223,188 @@ export interface CatalogSummary {
   shardCount: number;
   installedRevision: InstalledRevision;
   installedPacks: InstalledPack[];
+  /**
+   * What the browser says about this origin's storage, read at the same instant
+   * as the rest of this summary.
+   *
+   * Here as well as on `InstallEstimate` because the two answer different
+   * questions for different people. The estimate's copy is about a download the
+   * user has not committed to yet, and is reachable only by running one; this
+   * copy is about the disk they are ALREADY using, which is the question a
+   * panel whose subject is managing offline storage has to be able to answer
+   * without first asking the user to price a new install.
+   *
+   * Reading it prompts nobody. `storageOutlook` calls `estimate()` and
+   * `currentPersistence` calls `persisted()`; both are queries. `persist()` —
+   * the one method the Storage Standard defines as REQUESTING permission — is
+   * reached only from `requestPersistence`, which only `reserveStorage` calls,
+   * and only when a user has started an operation.
+   *
+   * Every figure inside is nullable and `persistence` has an `unsupported`
+   * arm, because a browser may decline to say. A display layer renders what is
+   * there and omits what is not; it does not fill a null in with a zero, and it
+   * does not turn these into a verdict — `InstallEstimate.headroom` is what a
+   * verdict looks like, and the engine computes it.
+   */
+  storage: StorageOutlook;
 }
 
 export type CatalogStatus =
   | { status: "empty" }
   | { status: "invalid" }
   | { status: "ready"; summary: CatalogSummary };
+
+/**
+ * Median encoded size of ONE image at each rung of the image ladder, in bytes,
+ * sampled live from Scryfall's CDN in August 2026 with **n = 6 per rung**.
+ *
+ * n = 6 makes these order-of-magnitude constants and nothing finer. They exist
+ * so the panel can tell a ~50 MB download apart from a ~6 GB one BEFORE the
+ * user commits to it. They are not a per-card measurement, and no figure
+ * derived from them may be presented as one.
+ *
+ * Values are KiB (x1024), matching how the samples were recorded. At this
+ * precision the choice of 1000 vs 1024 is well inside the sampling error and
+ * is fixed here only so the arithmetic is reproducible.
+ */
+export const IMAGE_RUNG_MEDIAN_BYTES: Readonly<Record<VisualImageRung, number>> = {
+  small: 17 * 1024,
+  normal: 103 * 1024,
+  art_crop: 73 * 1024,
+};
+
+const RUNG_MEDIANS = Object.values(IMAGE_RUNG_MEDIAN_BYTES);
+const MEAN_IMAGE_BYTES = RUNG_MEDIANS.reduce((total, bytes) => total + bytes, 0) / RUNG_MEDIANS.length;
+const CHEAPEST_IMAGE_BYTES = Math.min(...RUNG_MEDIANS);
+
+/**
+ * The expected download size, in bytes, of `imageRecords` images.
+ *
+ * An install is counted in image RECORDS — one per (face, rung) — and that
+ * count carries no rung breakdown, so every record is weighted by the MEAN of
+ * the three rung medians. That weighting is exact only when the records divide
+ * evenly across the ladder, and for a pack planned from this app's own card
+ * data they do, EXACTLY: MEASURED over `scryfall-data.json` (35,055 distinct
+ * non-token faces) and `scryfall-printings.json` (90,831 faces), every face
+ * that carries a `normal` URL also carries an `art_crop`, none carries
+ * `art_crop` alone, and `small` is derived from `normal` — so each face
+ * contributes either the full three-rung ladder or nothing.
+ *
+ * The bulk selectors take their rungs from Scryfall's own `image_uris` instead,
+ * which is NOT measured here; a set of records skewed entirely onto one rung
+ * would be overstated ~3.8x (all `small`) or understated ~1.6x (all `normal`).
+ *
+ * `core` and `printing` also contribute a card back and a set icon, which are
+ * not card art at all. One and one per pack against tens of thousands of card
+ * images, so they are counted at the same weight rather than modelled.
+ */
+export function estimatedImageBytes(imageRecords: number): number {
+  return Math.round(imageRecords * MEAN_IMAGE_BYTES);
+}
+
+/**
+ * The smallest `imageRecords` images could plausibly weigh: every one of them
+ * at the cheapest rung on the ladder.
+ *
+ * This is NOT a guarantee — it is the most optimistic reading of the same six
+ * samples `estimatedImageBytes` averages, and a real `small` image can be
+ * under its own median. It exists so that a decision whose cost of being WRONG
+ * is blocking a user has a different, deliberately generous threshold from one
+ * whose cost is only showing a warning. Nothing may refuse a user on
+ * `estimatedImageBytes`; a refusal needs a figure no reading of these
+ * constants can get under.
+ */
+export function minimumImageBytes(imageRecords: number): number {
+  return Math.round(imageRecords * CHEAPEST_IMAGE_BYTES);
+}
+
+/** Whether the browser will keep this origin's storage under disk pressure.
+ *  `best_effort` is the default and means the whole pack may be evicted. */
+export type StoragePersistence = "persisted" | "best_effort" | "unsupported";
+
+/**
+ * What the browser will say about this origin's storage.
+ *
+ * Every figure is nullable because `navigator.storage` is absent in some
+ * browsers and private windows and may reject in others, and a download that
+ * would otherwise succeed must not be blocked by not knowing.
+ */
+export interface StorageOutlook {
+  usageBytes: number | null;
+  quotaBytes: number | null;
+  /** `quota - usage`, or null when either is unavailable. */
+  availableBytes: number | null;
+  persistence: StoragePersistence;
+}
+
+/** Whether an install fits the storage the browser reports. `unknown` means the
+ *  browser would not say, NOT that it fits. */
+export type StorageHeadroom = "sufficient" | "insufficient" | "unknown";
+
+/**
+ * The two figures a pre-flight storage refusal was actually decided on.
+ *
+ * Carried on the error rather than left for the panel to recompute. The floor
+ * comes from `minimumImageBytes` and the space from a `navigator.storage`
+ * reading taken at that instant; a display layer that re-derived either would
+ * be deriving engine state, and would disagree with the gate the moment the
+ * estimate's reading and the start-time reading differ.
+ *
+ * Bytes, unformatted: which unit and which locale to render them in is the one
+ * part of this the display layer does know.
+ */
+export interface StorageRefusal {
+  /** `minimumImageBytes` of the request — the cheapest reading of the model. */
+  requiredBytes: number;
+  /** `quota - usage` as the browser reported it when the gate ran. */
+  availableBytes: number;
+}
+
+/**
+ * How far the installed curated pack has drifted from the membership the
+ * user's preferences and saved decks name RIGHT NOW.
+ *
+ * THREE categories, because two cannot express the case that matters most. A
+ * regeneration of `scryfall-data.json` moves a `sourceUrl` under an unchanged
+ * `assetKey`: the membership digest differs — so the pack is out of date and
+ * Sync must be offered — while both asset-key sets are IDENTICAL. An
+ * add/remove-only diff renders that as "0 to add, 0 to remove" beside an
+ * enabled Sync button, which reads as a bug in the panel.
+ *
+ * An installed row whose `sourceUrl` is absent counts as `refresh`. Such a row
+ * was written before the field existed and cannot say which URL its bytes came
+ * from, so `installObject` will never reuse it and the sync WILL fetch it — the
+ * count and the download agree, which is what makes this figure usable as the
+ * pre-flight storage gate's subject.
+ *
+ * `add + refresh` is therefore the sync's download, up to what a row can know:
+ * these are ROW facts, while reuse is decided against the CACHE, so the figure
+ * overstates where another pack's row donates the same content and understates
+ * where a cache entry was evicted out from under a surviving row (see
+ * `curatedFetchCount`, which documents both directions and why neither is
+ * guarded). `remove` is what the sync UNREFERENCES, not what it frees:
+ * `completePack` deletes the ROWS, and `sweepUnreferenced` deletes a cache
+ * entry only once no row in ANY pack still names that content-addressed path,
+ * so bytes shared with `complete` or a `printing` pack stay on disk.
+ *
+ * Whatever their error bars, neither the panel nor the gate should ever use the
+ * size of the whole membership for a pack that is already installed.
+ */
+export interface CuratedDrift {
+  /** The digest of the membership planned from preferences and decks now. */
+  membershipDigest: CatalogRoot;
+  /** The installed curated pack's root, or null when none is installed.
+   *  For curated the pack root IS its membership digest, so `installedDigest
+   *  !== membershipDigest` is the whole of drift DETECTION — the counts below
+   *  exist only to say how much. */
+  installedDigest: CatalogRoot | null;
+  /** Planned asset keys with no installed row. */
+  add: number;
+  /** Installed asset keys the current membership no longer names. */
+  remove: number;
+  /** Asset keys in both whose installed `sourceUrl` is not the planned one. */
+  refresh: number;
+}
 
 export interface InstallEstimate {
   catalogRoot: CatalogRoot;
@@ -232,11 +417,57 @@ export interface InstallEstimate {
   uniqueImageBytes: string;
   shardCount: string;
   shardBytes: string;
+  /**
+   * What this selection will cost to download, in bytes.
+   *
+   * A number rather than one of the pre-rendered strings above, because the
+   * decision it supports is "50 MB or 6 GB?" and only the display layer knows
+   * which unit to render that in.
+   *
+   * `logicalImageBytes` / `uniqueImageBytes` above stay `"unknown"` and are NOT
+   * kept because they report a measurement: they have exactly one write site,
+   * which hardcodes `"unknown"`, and nothing has ever populated them. Their
+   * labels are wrong in two different ways — `en` alone hedges with "(known
+   * after download)", a promise the code does not keep, while the other six
+   * read plainly ("Logische Bildbytes", "Octets d'image logique"), naming a
+   * measurement with no hedge at all. They are left untouched only so that a
+   * projection is never mistaken for a measurement by overwriting a field
+   * whose label claims to be one; deciding their fate (populate or delete,
+   * with their seven locales) is open work.
+   */
+  estimatedImageBytes: number;
+  storage: StorageOutlook;
+  /**
+   * `estimatedImageBytes` against `storage.availableBytes`, decided here
+   * rather than in the UI: the frontend renders engine-computed state and does
+   * not derive it.
+   *
+   * `insufficient` is a WARNING and not a veto. The projection behind it comes
+   * from six CDN samples per rung, so it is an order-of-magnitude figure, and
+   * blocking a user on it would deny an install that a ±30% error makes
+   * perfectly feasible — with no override anywhere to undo that. Running out
+   * of quota mid-download is the milder failure: it is classified `storage`,
+   * `storage` is retryable, so the operation stays resumable, and a resume
+   * skips every object already cached. The UI must therefore render this
+   * beside `estimatedImageBytes` and `storage.availableBytes` and let the user
+   * decide. `start()` refuses only the hopeless case — see `reserveStorage`.
+   */
+  headroom: StorageHeadroom;
+}
+
+export interface CatalogScanProgress {
+  compressedBytesRead: number;
+  compressedBytesTotal: number;
+  recordsScanned: number;
+  assetRecords: number;
 }
 
 export type StartResponse =
   | { status: "healthy" }
-  | { status: "started"; operationId: OperationId; catalogRoot: CatalogRoot };
+  /** `persistence` is the outcome of the grant requested as part of starting.
+   *  Required rather than optional so a second `started` site cannot omit it
+   *  and silently report a pack as evictable when it is not, or the reverse. */
+  | { status: "started"; operationId: OperationId; catalogRoot: CatalogRoot; persistence: StoragePersistence };
 
 export interface OperationStatus {
   operationId: OperationId;
@@ -246,6 +477,7 @@ export interface OperationStatus {
   packTotal: number;
   packsPromoted: number;
   objectTotal: number;
+  objectEstimate: number | null;
   objectsPromoted: number;
   completedRevision: InstalledRevision | null;
 }
@@ -315,7 +547,21 @@ export type VisualPackErrorKind =
   | "conflict"
   | "cancelled"
   | "network"
+  /**
+   * The unclassified bucket. `errorKind` ends in `return "storage"`, so this is
+   * what an error nothing recognised is reported as, alongside a genuine
+   * `QuotaExceededError` from a write that was attempted and failed.
+   */
   | "storage"
+  /**
+   * A pre-flight refusal: nothing was attempted and nothing was written,
+   * because the space the browser reports cannot hold even the cheapest
+   * reading of the download. Distinct from `storage` because the sentence a
+   * user needs is a different one — and because sharing a kind with the
+   * catch-all would make that sentence fire for unrecognised errors too.
+   * Carries a `StorageRefusal` (see `VisualPackStorageRefusalError`).
+   */
+  | "insufficient_storage"
   | "trust"
   | "emit"
   | "internal";

--- a/client/src/utils/byteSize.ts
+++ b/client/src/utils/byteSize.ts
@@ -1,0 +1,32 @@
+const BYTE_UNITS = [
+  { unit: "gigabyte", scale: 1_000_000_000 },
+  { unit: "megabyte", scale: 1_000_000 },
+] as const;
+
+/**
+ * A byte count as a person reads it, in the language the caller renders in.
+ *
+ * `Intl.NumberFormat`'s unit style rather than a hand-written suffix: six of
+ * the app's seven locales use a comma decimal separator, and French writes
+ * Go/Mo — a `toFixed(1) + " GB"` ships an English point and an English unit
+ * into all six, in the panel whose entire subject is this number.
+ *
+ * Rendered on the decimal scale, which is what "GB"/"MB" mean beside a
+ * browser's own quota figures. The engine's sampled size constants are
+ * recorded in KiB, but they are six-sample medians and the 1000-vs-1024
+ * difference is far inside their error; what must not happen is a label
+ * implying one base while the arithmetic uses the other.
+ *
+ * It lives here rather than beside its first caller because two components in
+ * the visual-pack panel now render byte figures, and exporting it from the
+ * parent component would make the child import its own parent.
+ */
+export function formatByteSize(bytes: number, locale: string): string {
+  const { unit, scale } = bytes >= BYTE_UNITS[0].scale ? BYTE_UNITS[0] : BYTE_UNITS[1];
+  return new Intl.NumberFormat(locale, {
+    style: "unit",
+    unit,
+    unitDisplay: "short",
+    maximumFractionDigits: 1,
+  }).format(bytes / scale);
+}


### PR DESCRIPTION
Installing offline card images meant downloading every printing of every
card. This adds a curated pack that resolves ONE image per card from the
user's configured art chain, plus the extras they have actually asked for,
and re-syncs by delta instead of by re-download.

Membership is the user's art chain, their per-card art overrides, and the
printings their saved decks pin via `(SET) NUM` annotations. A curated
pack's CatalogRoot IS its membership digest, so changing a preference looks
like an ordinary root change and reuses the existing install, repair and
resume machinery rather than adding a parallel path.

Change detection is a three-way add/remove/refresh diff against what is
installed, so a re-sync is sized and storage-gated by what it will actually
fetch. A row whose recorded sourceUrl is absent counts as a refresh, since
`installObject` will not reuse it. The drift read is gated on the card data
already being resident: measuring is otherwise a 76 MB fetch, and a settings
panel opened by passive navigation must not be what triggers that.

Also in the panel: readable pack labels instead of raw ids and 64-hex roots,
disk usage and eviction protection surfaced without first running an
estimate, a user-pressed Sync (a preference change never starts a download),
and a diagnostic on a non-retryable failure that previously rendered as a
bare "Cancelled".

Claude-Session: https://claude.ai/code/session_01XhqLZKQRzPsRMVfSvdLc8f


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a curated visual pack option with one image per card and automatic membership updates.
  * Added download estimates showing image sizes, storage headroom, scan progress, and disk usage.
  * Added localized pack labels, catalog status details, synchronization actions, and improved error messages.
* **Bug Fixes**
  * Improved operation recovery, including resuming finalizing downloads and distinguishing terminated operations from failures.
  * Corrected card art selection fallback and precedence behavior.
  * Added clearer insufficient-storage handling with localized size information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->