### PR TITLE
docs(test): document the capture-fixture gunzip helpers

### DIFF
--- a/crates/engine/tests/integration/vanquish_horde_ai_manapayment_wedge.rs
+++ b/crates/engine/tests/integration/vanquish_horde_ai_manapayment_wedge.rs
@@ -45,6 +45,7 @@ use engine::types::player::PlayerId;
 /// `ManaPayment` subject are all seat 2.
 const STUCK: PlayerId = PlayerId(2);
 
+/// Inflate a gzipped capture fixture to its UTF-8 JSON text.
 fn gunzip(gz: &[u8]) -> String {
     use std::io::Read;
     let mut json = String::new();

--- a/crates/phase-ai/tests/manapayment_finalize_from_floating_pool.rs
+++ b/crates/phase-ai/tests/manapayment_finalize_from_floating_pool.rs
@@ -61,6 +61,7 @@ use std::io::Read;
 /// `ManaPayment` subject.
 const STUCK: PlayerId = PlayerId(1);
 
+/// Inflate a gzipped capture fixture to its UTF-8 JSON text.
 fn gunzip_fixture(gz: &[u8]) -> String {
     let mut json = String::new();
     flate2::read::GzDecoder::new(gz)


### PR DESCRIPTION
CodeRabbit's docstring-coverage check on #8197 measured 76.92% against an 80%
threshold. The two undocumented functions were the gzip helpers in the
ManaPayment regression tests; the review raised no blocking findings and rated
merge risk minimal, so this was deliberately held back rather than ejecting an
already-admitted merge-queue entry to land two comment lines.

Claude-Session: https://claude.ai/code/session_01N6y3BSTMNGygG7uQFnneZ4
