### PR TITLE
fix(client): let cancel settle its worker before the record goes terminal

### DIFF
--- a/client/src/services/visualPacks/browser/__tests__/curatedDelta.test.ts
+++ b/client/src/services/visualPacks/browser/__tests__/curatedDelta.test.ts
@@ -1100,4 +1100,42 @@ describe("curated delta install", () => {
     release();
     await vi.waitFor(() => { expect(failed).toHaveLength(1); }, { timeout: 5000 });
   });
+
+  it("writes nothing more once cancel has returned", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+
+    // Park a download and wait until it is provably AT the gate, so a task is
+    // certainly past the guard and inside `fetchImage` when the cancel lands.
+    // `installObject` consults `signal` only there — its donor-reuse and
+    // cache-hit paths never do — so such a task reaches `markComplete`
+    // whatever the abort says. Waiting on a request COUNT instead would not
+    // pin this down: the batch reaches the gate at a variable point, and the
+    // assertion below then holds or fails on timing rather than on behaviour.
+    let seen = 0;
+    let parked = false;
+    const release = holdImages((source) => {
+      if (!source.startsWith("https://cards.scryfall.io/")) return false;
+      if ((seen += 1) !== 2) return false;
+      parked = true;
+      return true;
+    });
+    const started = await startCurated(backend);
+    await vi.waitFor(() => { expect(parked).toBe(true); }, { timeout: 5000 });
+
+    // Released on a timer rather than inline: `cancel()` now waits for the
+    // worker, so it cannot return until this fires, while a `cancel()` that
+    // did NOT wait returns first and reports a count the parked task then
+    // moves. That ordering is what the assertion reads.
+    const pending = backend.cancel(started.operation);
+    setTimeout(release, 150);
+    const status = await pending;
+    expect(status.state).toBe("cancelled");
+
+    // THE INVARIANT, asserted on the SNAPSHOT `cancel()` returns, because that
+    // is the value the panel publishes its terminal outcome from. Once it is
+    // handed over, nothing may still be promoting into the operation.
+    await new Promise((resolve) => { setTimeout(resolve, 400); });
+    const settledRecord = await backend.operationStatus(started.operation);
+    expect(settledRecord.objectsPromoted).toBe(status.objectsPromoted);
+  });
 });

--- a/client/src/services/visualPacks/browser/scryfallBackend.ts
+++ b/client/src/services/visualPacks/browser/scryfallBackend.ts
@@ -405,7 +405,9 @@ async function storeVerifiedObject(cache: Cache, path: string, media: VisualPack
 export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
   private readonly progressListeners = new Set<(event: ProgressEvent) => void>();
   private readonly revisionListeners = new Set<(event: RevisionEvent) => void>();
-  private readonly workers = new Map<OperationId, AbortController>();
+  /** Each running worker's abort handle AND the promise that settles when it
+   *  has finished writing, so `cancel()` can wait for it. */
+  private readonly workers = new Map<OperationId, { controller: AbortController; settled: Promise<void> }>();
   private work = Promise.resolve();
 
   private constructor(private readonly database: IDBPDatabase<ScryfallVisualPackSchema>) {}
@@ -434,10 +436,9 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
   private run(selectedOperation: OperationId): void {
     if (this.workers.has(selectedOperation)) return;
     const controller = new AbortController();
-    this.workers.set(selectedOperation, controller);
     const task = this.work.then(async () => this.resume(selectedOperation, controller.signal));
     this.work = task.catch(() => undefined);
-    void task.catch(async (error) => {
+    const settled = task.catch(async (error) => {
       if (controller.signal.aborted) return;
       const kind = errorKind(error);
       // A retryable failure leaves the record `downloading`, which is exactly
@@ -451,7 +452,12 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
         : await this.updateOperation(selectedOperation, (current) =>
             current.state === "completed" ? current : { ...current, state: "cancelled" }).catch(() => undefined);
       if (operation) this.emit({ phase: "failed", operation: operationStatus(operation), error: kind });
-    }).finally(() => this.workers.delete(selectedOperation));
+    }).catch(() => undefined).finally(() => this.workers.delete(selectedOperation));
+    void settled;
+    // Registered AFTER the chain is built so `settled` can be handed out, and
+    // safe to do so: `run()` returns before any microtask, so the `has` guard
+    // above still sees a worker that a synchronous caller registered first.
+    this.workers.set(selectedOperation, { controller, settled });
   }
 
   private async updateOperation(
@@ -1276,7 +1282,16 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
     try {
       const requested = await this.updateOperation(selectedOperation, (current) =>
         current.state === "completed" || current.state === "cancelled" ? current : { ...current, state: "cancel_requested" });
-      this.workers.get(selectedOperation)?.abort();
+      const worker = this.workers.get(selectedOperation);
+      worker?.controller.abort();
+      // Let the worker put its downloads down before this record goes terminal.
+      // `installObject` consults `signal` only inside `fetchImage` — the
+      // donor-reuse and cache-hit paths never do — so a task already past the
+      // guard finishes into `markComplete` whatever the abort says, writing an
+      // `objects` row at `root` and incrementing `objectsPromoted`. Waiting
+      // here puts those writes BEFORE the terminal state rather than after
+      // `cancel()` has returned and the panel has published the outcome.
+      await worker?.settled;
       if (requested.state === "cancel_requested") {
         await this.updateOperation(selectedOperation, (current) => ({ ...current, state: "cancelled" }));
       }


### PR DESCRIPTION
Review follow-up on the previous commit. `Promise.allSettled(inFlight)` keeps
`resume()` alive through a FAILURE, but `cancel()` writes `state: "cancelled"`
straight after `.abort()` and never waits for the worker — so the cancel exit
still published a terminal record with downloads running behind it.

The abort does not stop them. `installObject` consults `signal` only inside
`fetchImage`; its donor-reuse branch and its `existing && cacheContains` branch
never look at it, and neither does anything between the fetch resolving and
`markComplete`. A task already past the guard therefore finishes into
`markComplete` regardless, putting an `objects` row at `root` and incrementing
`objectsPromoted` on a record the panel has already been told is terminal.

`cancel()` now awaits the worker before that transition, which needed the
worker's settlement promise to be reachable — `workers` maps to the abort
handle and that promise rather than to the handle alone. Awaiting is what keeps
the panel's contract intact: `useVisualPackManager` publishes its cancelled
outcome from `operationIsTerminal(status)` on the value `cancel()` returns, so
handing the transition to the worker instead would have left that branch
unreachable in exactly the case that matters — cancelling a live download.

The regression test parks a download and waits until it is provably AT the
gate, then releases on a timer so the two orderings separate: a `cancel()` that
waits cannot return until the release, while one that does not returns first
and reports a count the parked task then moves. It asserts on the snapshot
`cancel()` returns, since that is the value the panel reads.

Both of those details were forced by measurement. An earlier version waited on
a request COUNT and asserted on rows read afterwards; it passed against the bug
4 runs out of 4, because `objectRows()` opens IndexedDB and that alone gave the
released task time to finish before either sample. Waiting on the gate and
reading the returned snapshot fails 4/4 against the bug and passes 4/4 with it.

Claude-Session: https://claude.ai/code/session_01XhqLZKQRzPsRMVfSvdLc8f
