### PR TITLE
fix(parser): type defending-player scope and lift group-shared-quality counts

### DIFF
--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -31,7 +31,7 @@ use crate::types::ability::{
     CastManaSpentMetric, CommanderOwnership, Comparator, ControllerRef, CountScope, DamageChannel,
     DamageGroupKey, DamageKindFilter, FilterProp, ObjectProperty, ObjectScope, PlayerFilter,
     PlayerRelation, PlayerScope, PropertyAggregate, QuantityExpr, QuantityRef, SharedQuality,
-    StaticCondition, TargetFilter, TypeFilter, TypedFilter, ZoneRef,
+    SharedQualityRelation, StaticCondition, TargetFilter, TypeFilter, TypedFilter, ZoneRef,
 };
 use crate::types::counter::{CounterMatch, CounterType};
 use crate::types::events::PlayerActionKind;
@@ -4024,56 +4024,175 @@ fn parse_control_count_ge_distinct_quality(input: &str) -> OracleResult<'_, Stat
     ))
 }
 
-/// CR 201.2 + CR 109.3: Parse "you control N or more [type] with the same name
-/// as one another"
-/// → `QuantityComparison(ObjectCountBySharedQuality[Name, Max] >= N)`.
+/// Lift a GROUP shared-quality marker out of a filter produced by
+/// `parse_type_phrase`, returning its quality and removing the property.
 ///
-/// The same-quality mirror of `parse_control_count_ge_distinct_quality`. Both read
-/// "you control " + a GE threshold + a type phrase + a shared-characteristic
-/// suffix; they differ only on the RELATION over that characteristic (`different`
-/// → count the distinct values; `the same` → group by value and take the largest
-/// group). `aggregate: Max` is what makes "three or more lands with the same name"
-/// mean "some ONE name is shared by at least three of your lands" rather than
-/// "you have at least three lands in total".
+/// `FilterProp::SharesQuality { reference: None }` is a GROUP-SELECTION
+/// constraint on a chosen candidate set: CR 601.2c is where the player
+/// "announces their choice of an appropriate object or player for each target
+/// the spell requires", and CR 608.2b is where the engine re-checks that choice
+/// on resolution — which is exactly where `game::effects::mod`'s group
+/// validator runs it. `game::filter::filter_prop_uses_object_population`
+/// documents the marker as "candidate-local, validated at resolution time, not
+/// whole-board membership", and `game::filter::evaluate_shares_quality`
+/// accordingly answers TRUE for every object when the reference is absent.
 ///
-/// Name is the only quality printed with this relation today (Endless Atlas,
-/// Sceptre of Eternal Glory); the `alt` is the extension point for the rest of
-/// `SharedQuality` when a card prints one.
+/// That contract makes it INERT inside a whole-board count: a
+/// `QuantityRef::ObjectCount` over such a filter counts every matching object
+/// and silently drops the shared-quality constraint. The counting authority for
+/// "N objects that share quality Q" is
+/// `QuantityRef::ObjectCountBySharedQuality` with `AggregateFunction::Max`.
+///
+/// The rules supply the VOCABULARY the quality axis ranges over, and nothing
+/// more: CR 109.3 enumerates an object's characteristics (and closes with "Any
+/// other information about an object isn't a characteristic"), and CR 205.3m
+/// enumerates the creature types `SharedQuality::CreatureType` reads. The
+/// aggregate semantic — "some ONE value of the characteristic is shared by at
+/// least N objects" — is `AggregateFunction::Max` over
+/// `game::filter::object_shared_quality_values_public`'s buckets. That is an
+/// engine representation fact and is deliberately left UNATTRIBUTED: neither
+/// 109.3 nor 205.3m says anything about a value being shared by at least N
+/// objects. The group/count layer split likewise carries no CR number of its
+/// own. This function moves the constraint from the filter to that authority.
+///
+/// Declines, leaving the filter untouched, for:
+///   * `reference: Some(..)` — that IS a per-object predicate and
+///     `ObjectCount` is correct for it;
+///   * `SharedQualityRelation::DoesNotShare` — no aggregate form exists;
+///   * a non-`Typed` filter — an `Or`/`And` of counted populations is not one
+///     bucketed count.
+///
+/// In each case the caller's `alt` falls through to `parse_control_count_ge`
+/// and the row keeps exactly the shape it has today. A refusal cannot be raised
+/// from here instead: three transitive callers disagree about what a refusal
+/// means, and two of them (`static_helpers::try_parse_cost_modification` and
+/// `oracle_trigger::try_extract_intervening`) turn one into an UNCONDITIONAL
+/// static or an unhoisted intervening-if — strictly worse than the shape they
+/// would refuse.
+fn take_group_shared_quality(filter: &mut TargetFilter) -> Option<SharedQuality> {
+    let TargetFilter::Typed(tf) = filter else {
+        return None;
+    };
+    let idx = tf.properties.iter().position(|prop| {
+        matches!(
+            prop,
+            FilterProp::SharesQuality {
+                reference: None,
+                relation: SharedQualityRelation::Shares,
+                ..
+            }
+        )
+    })?;
+    // `position` matched this variant at `idx` on the line above and `remove`
+    // cannot change it; `let … else` keeps the destructure total without a
+    // wildcard arm or a panic.
+    let FilterProp::SharesQuality { quality, .. } = tf.properties.remove(idx) else {
+        return None;
+    };
+    Some(quality)
+}
+
+/// CR 201.2 + CR 109.3: Parse "<scope> control(s) N or more [type] that share a
+/// [quality]" and "<scope> control(s) N or more [type] with the same [quality]
+/// [as one another]"
+/// → `QuantityComparison(ObjectCountBySharedQuality[quality, Max] >= N)`.
+///
+/// The same-quality mirror of `parse_control_count_ge_distinct_quality`. Both
+/// read a control-scope prefix + a GE threshold + a type phrase + a
+/// shared-characteristic constraint; they differ only on the RELATION over that
+/// characteristic (`different` → count the distinct values; `the same` / `share
+/// a` → group by value and take the largest group). `aggregate: Max` is what
+/// makes "three or more lands with the same name" mean "some ONE name is shared
+/// by at least three of your lands" rather than "you have at least three lands
+/// in total".
+///
+/// **Two printings, one predicate.** English prints this constraint either as a
+/// relative clause ("three or more creatures **that share a creature type**",
+/// Graxiplon, Littjara Kinseekers, Synchronized Eviction) or as a postmodifier
+/// ("three or more lands **with the same name**", Endless Atlas, Sceptre of
+/// Eternal Glory, Mechanized Production, Chrome Replicator). The two reach this
+/// function differently and so are two branches, not two parsers:
+///
+///   * **Branch A (relative clause)** — `parse_type_phrase` has ALREADY consumed
+///     the clause through `oracle_target::parse_that_clause_suffix`, leaving a
+///     `FilterProp::SharesQuality` group marker on the filter and an empty
+///     remainder. `take_group_shared_quality` lifts the marker onto this
+///     counting authority rather than re-parsing the text, so
+///     `oracle_target::parse_shared_quality_clause` stays the single authority
+///     for that vocabulary.
+///   * **Branch B (postmodifier)** — not a `that …` clause, so
+///     `parse_type_phrase` leaves it in the remainder and the quality noun is
+///     delegated to the same shared authority, `parse_shared_quality`.
+///
+/// The controller scope is parameterized on `parse_control_scope_prefix`, so
+/// all three of `you` / `your opponents` / `defending player` are covered by one
+/// path. CR 508.5 + CR 508.5a resolve the defending-player anchor per attacking
+/// creature; CR 509.1b is the rule that makes an evasion ability a blocking
+/// restriction, which is the form the defending-player scope is printed in
+/// today (Graxiplon).
+///
+/// Branch B's quality vocabulary widens from `name` alone to the full
+/// `parse_shared_quality` set as a consequence of that DRY substitution.
+/// `game::filter::shared_quality_values` matches every `SharedQuality` variant
+/// exhaustively, so nothing is accepted here that cannot be evaluated; `name`
+/// is simply the only one printed with this relation today.
+///
+/// ORDERING: this arm must precede the plain `parse_control_count_ge` arm in
+/// `parse_control_conditions` — see the ordering warning there, which is the
+/// authority on why.
 fn parse_control_count_ge_shared_quality(input: &str) -> OracleResult<'_, StaticCondition> {
-    let (rest, _) = tag("you control ").parse(input)?;
+    let (rest, ctrl) = parse_control_scope_prefix(input)?;
     let (rest, n) = parse_ge_threshold(rest)?;
     let type_text = rest.trim_end_matches('.');
-    let (filter, remainder) = parse_type_phrase(type_text);
+    let (mut filter, remainder) = parse_type_phrase(type_text);
     if matches!(filter, TargetFilter::Any) {
         return Err(nom::Err::Error(nom::error::Error::new(
             input,
             nom::error::ErrorKind::Fail,
         )));
     }
-    let trimmed = remainder.trim_start();
-    let (after_suffix, quality) = preceded(
-        tag("with the same "),
-        terminated(
-            alt((value(SharedQuality::Name, tag("name")),)),
-            opt(tag(" as one another")),
-        ),
-    )
-    .parse(trimmed)?;
-    let filter = inject_controller_you(filter);
-    let consumed = after_suffix.as_ptr() as usize - input.as_ptr() as usize;
-    Ok((
-        &input[consumed..],
-        StaticCondition::QuantityComparison {
-            lhs: QuantityExpr::Ref {
-                qty: QuantityRef::ObjectCountBySharedQuality {
+    // Branch A — relative-clause printing.
+    if let Some(quality) = take_group_shared_quality(&mut filter) {
+        let filter = inject_controller(filter, ctrl);
+        // `remainder` is empty here but still points into `input`, so the
+        // pointer arithmetic re-includes any `.` that `trim_end_matches`
+        // dropped. Same idiom as `parse_control_count_ge`.
+        let consumed = remainder.as_ptr() as usize - input.as_ptr() as usize;
+        return Ok((
+            &input[consumed..],
+            make_quantity_comparison(
+                QuantityRef::ObjectCountBySharedQuality {
                     filter,
                     quality,
                     aggregate: AggregateFunction::Max,
                 },
+                Comparator::GE,
+                n,
+            ),
+        ));
+    }
+    // Branch B — postmodifier printing. `parse_shared_quality` tries the plural
+    // `names` before the singular `name`, so on "name as one another" the
+    // singular arm wins and the `opt` consumes the tail.
+    let trimmed = remainder.trim_start();
+    let (after_suffix, quality) = preceded(
+        tag("with the same "),
+        terminated(parse_shared_quality, opt(tag(" as one another"))),
+    )
+    .parse(trimmed)?;
+    let filter = inject_controller(filter, ctrl);
+    let consumed = after_suffix.as_ptr() as usize - input.as_ptr() as usize;
+    Ok((
+        &input[consumed..],
+        make_quantity_comparison(
+            QuantityRef::ObjectCountBySharedQuality {
+                filter,
+                quality,
+                aggregate: AggregateFunction::Max,
             },
-            comparator: Comparator::GE,
-            rhs: QuantityExpr::Fixed { value: n as i32 },
-        },
+            Comparator::GE,
+            n,
+        ),
     ))
 }
 
@@ -4144,28 +4263,68 @@ fn controlled_battlefield_subtype_filter(subtype: String) -> TargetFilter {
 
 /// Parse the leading controller-scope phrase of a "control N or more" count
 /// condition, returning the `ControllerRef` the count is scoped to:
-/// "you control " → `You`, "your opponents control " → `Opponent`.
+/// "you control " → `You`, "your opponents control " → `Opponent`,
+/// "defending player controls " → `DefendingPlayer`.
 ///
-/// CR 109.3: object control is a per-player property; this is the single axis
-/// that distinguishes the self-scoped ("you control three or more creatures")
-/// and opponent-scoped ("your opponents control three or more creatures",
-/// Lashwhip Predator) forms of the same `ObjectCount >= N` threshold.
+/// CR 109.2 + CR 109.3: object control is a per-player property, and a
+/// description that names a card type without naming a zone means a permanent
+/// on the battlefield — which is why every leaf here is paired with
+/// `inject_controller`'s `InZone { Battlefield }`. This is the single axis that
+/// distinguishes the self-scoped ("you control three or more creatures"),
+/// opponent-scoped ("your opponents control three or more creatures", Lashwhip
+/// Predator) and combat-scoped ("defending player controls three or more
+/// artifacts", Ayesha Tanaka, Armorer) forms of the same `ObjectCount >= N`
+/// threshold.
+///
+/// The `defending player` leaf is the only one whose resolution depends on
+/// combat state; outside combat it answers `None`, which the filter door
+/// renders as a zero count. For a `CantBeBlocked` static the anchor binds — the
+/// source is already in `combat.attackers` when CR 509.1b's blocking-restriction
+/// check runs — but for a `CantAttack` static it does NOT, because the
+/// declaration is validated before the candidate is recorded as an attacker.
+/// See `issue_8183_static_gate_fail_open.rs`'s Dandân test, which pins that gap.
 fn parse_control_scope_prefix(input: &str) -> OracleResult<'_, ControllerRef> {
     alt((
         value(ControllerRef::You, tag("you control ")),
         value(ControllerRef::Opponent, tag("your opponents control ")),
+        // CR 508.5 + CR 508.5a: the combat-context leaf of the same
+        // control-subject axis. The defending player is determined per
+        // attacking creature and resolved at read time by the shared
+        // `combat` anchor authority, so the count is scoped exactly like the
+        // `you` / `your opponents` forms with no new condition variant.
+        // CR 509.1b: a restriction may be created by an evasion ability —
+        // Ayesha Tanaka, Armorer, "…can't be blocked as long as defending
+        // player controls three or more artifacts".
+        value(
+            ControllerRef::DefendingPlayer,
+            tag("defending player controls "),
+        ),
     ))
     .parse(input)
 }
 
-/// Canonical combinator: "you control / your opponents control N or more [type]"
-/// → QuantityComparison.
+/// Canonical combinator: "you control / your opponents control / defending
+/// player controls N or more [type]" → QuantityComparison.
 ///
-/// Single authority for this pattern — called from `oracle_static.rs` and
-/// `oracle_trigger.rs` to avoid three-way duplication. The controller scope is
-/// parameterized on the `you control` / `your opponents control` axis
-/// (`parse_control_scope_prefix`) so both forms share one parse path.
+/// Single authority for this pattern. It has no direct external caller; it is
+/// reached only as an arm of `parse_control_conditions`, which is what
+/// `oracle_static/evasion.rs`'s rule-static `unless` rider calls and what the
+/// `parse_condition` / `parse_inner_condition` dispatch chain reaches. The
+/// controller scope is parameterized on the `you control` / `your opponents
+/// control` / `defending player controls` axis (`parse_control_scope_prefix`)
+/// so all three forms share one parse path.
 /// Returns the remainder after the type phrase (may be non-empty for trailing text).
+///
+/// ORDERING CONSTRAINT — do not disturb. `parse_control_scope_prefix` is
+/// consumed here and by `parse_control_count_ge_shared_quality`, and BOTH
+/// require `parse_ge_threshold` (a numeral or `at least N`) immediately after
+/// the prefix. The incumbent `defending player controls a/an <type>` rows
+/// present an ARTICLE, not a numeral, so they fail `parse_ge_threshold`, this
+/// arm declines, and they fall through to `parse_defending_player_controls`
+/// exactly as before. **Do NOT route `parse_you_control_a` / `_no` /
+/// `_dont_control_a` / `parse_control_count_le` / `_eq` through
+/// `parse_control_scope_prefix`** — that would move every one of those rows
+/// onto this production.
 pub fn parse_control_count_ge(input: &str) -> OracleResult<'_, StaticCondition> {
     let (rest, ctrl) = parse_control_scope_prefix(input)?;
     let (rest, n) = parse_ge_threshold(rest)?;
@@ -10367,6 +10526,282 @@ mod tests {
                 tf.properties
             );
         }
+    }
+
+    /// Destructure an `ObjectCountBySharedQuality >= N` comparison over a
+    /// `Typed` filter for the group-share rows below, panicking with the
+    /// offending input rather than on an opaque match failure.
+    ///
+    /// Also asserts THE repair property shared by every row here: no GROUP
+    /// `FilterProp::SharesQuality { reference: None, relation: Shares }` is left
+    /// on the filter. That marker is a group-selection constraint that
+    /// `game::filter::evaluate_shares_quality` answers TRUE for every object, so
+    /// a filter that still carries it inside a count silently drops the
+    /// constraint — the shipped defect this lift repairs.
+    fn expect_group_shared_count(
+        text: &str,
+        cond: StaticCondition,
+    ) -> (TypedFilter, SharedQuality, AggregateFunction, i32) {
+        let StaticCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty:
+                        QuantityRef::ObjectCountBySharedQuality {
+                            filter,
+                            quality,
+                            aggregate,
+                        },
+                },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value },
+        } = cond
+        else {
+            panic!("expected ObjectCountBySharedQuality >= N for {text:?}, got {cond:?}");
+        };
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("expected Typed filter for {text:?}, got {filter:?}");
+        };
+        assert!(
+            tf.properties.contains(&FilterProp::InZone {
+                zone: Zone::Battlefield,
+            }),
+            "inject_controller must add InZone{{Battlefield}} for {text:?}, got {:?}",
+            tf.properties
+        );
+        assert!(
+            !tf.properties.iter().any(|prop| matches!(
+                prop,
+                FilterProp::SharesQuality {
+                    reference: None,
+                    relation: SharedQualityRelation::Shares,
+                    ..
+                }
+            )),
+            "the group SharesQuality marker must be LIFTED out of the filter for \
+             {text:?}, not merely accompanied by the count; got {:?}",
+            tf.properties
+        );
+        (tf, quality, aggregate, value)
+    }
+
+    /// CR 508.5 + CR 509.1b: "defending player controls N or more [type]" — the
+    /// combat-scoped leaf of the control-count axis (Ayesha Tanaka, Armorer:
+    /// "…can't be blocked as long as defending player controls three or more
+    /// artifacts").
+    ///
+    /// The input is exactly what `parse_compound_cant_be_blocked_condition`
+    /// hands over after the `~ ` subject and the trailing `.` are stripped, so
+    /// it must NOT carry a trailing period.
+    ///
+    /// Revert-failing: remove the `defending player controls ` arm from
+    /// `parse_control_scope_prefix` and the prefix is rejected, the whole
+    /// condition fails to parse, and the `unwrap_or_else` panics.
+    #[test]
+    fn parse_defending_player_control_count_ge_artifacts() {
+        let text = "as long as defending player controls three or more artifacts";
+        let (rest, cond) =
+            parse_condition(text).unwrap_or_else(|e| panic!("failed to parse {text:?}: {e:?}"));
+        assert_eq!(rest, "", "unconsumed remainder for {text:?}");
+        let StaticCondition::QuantityComparison {
+            lhs:
+                QuantityExpr::Ref {
+                    qty: QuantityRef::ObjectCount { filter },
+                },
+            comparator: Comparator::GE,
+            rhs: QuantityExpr::Fixed { value: 3 },
+        } = cond
+        else {
+            panic!("expected ObjectCount >= 3 for {text:?}, got {cond:?}");
+        };
+        let TargetFilter::Typed(tf) = filter else {
+            panic!("expected Typed filter for {text:?}, got {filter:?}");
+        };
+        assert_eq!(tf.type_filters, vec![TypeFilter::Artifact]);
+        assert_eq!(
+            tf.controller,
+            Some(ControllerRef::DefendingPlayer),
+            "the count must be scoped to the defending player, not the source's \
+             controller"
+        );
+        assert!(
+            tf.properties.contains(&FilterProp::InZone {
+                zone: Zone::Battlefield,
+            }),
+            "inject_controller must add InZone{{Battlefield}}, got {:?}",
+            tf.properties
+        );
+    }
+
+    /// CR 508.5 + CR 509.1b + CR 205.3m: Graxiplon's printed gate — the
+    /// defending-player scope crossed with the RELATIVE-CLAUSE printing of the
+    /// group-share count, entered through `unless ` (which supplies the `Not`).
+    ///
+    /// Revert-failing twice over: remove the `defending player controls ` arm
+    /// and the parse fails outright; revert the Branch A lift and
+    /// `parse_control_count_ge_shared_quality` declines (its Branch B needs
+    /// `tag("with the same ")` on the empty remainder the consumed relative
+    /// clause leaves), so `parse_control_count_ge` lands the INERT `ObjectCount`
+    /// and both the destructure and the residual-marker assertion fire.
+    #[test]
+    fn parse_defending_player_control_count_ge_group_shared_creature_type() {
+        let text =
+            "unless defending player controls three or more creatures that share a creature type";
+        let (rest, cond) =
+            parse_condition(text).unwrap_or_else(|e| panic!("failed to parse {text:?}: {e:?}"));
+        assert_eq!(rest, "", "unconsumed remainder for {text:?}");
+        let StaticCondition::Not { condition } = cond else {
+            panic!("`unless` must supply the negation for {text:?}, got {cond:?}");
+        };
+        let (tf, quality, aggregate, value) = expect_group_shared_count(text, *condition);
+        assert_eq!(value, 3);
+        assert_eq!(quality, SharedQuality::CreatureType);
+        assert_eq!(aggregate, AggregateFunction::Max);
+        assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+        assert_eq!(tf.controller, Some(ControllerRef::DefendingPlayer));
+    }
+
+    /// CR 205.3m + CR 603.4 + CR 601.2f: "you control <threshold> creatures
+    /// that share a creature type" — the RELATIVE-CLAUSE printing on the `you`
+    /// scope. Two rules because the two inputs take two routes: the first is a
+    /// triggered ability's intervening-if (CR 603.4), the second is a
+    /// cost-reduction static read during cost determination (CR 601.2f).
+    ///
+    /// These are the two SHIPPED rows this change repairs: Littjara Kinseekers
+    /// (`three or more`, reaching the runtime through
+    /// `oracle_trigger::try_extract_intervening`) and Synchronized Eviction
+    /// (`at least two`, through `static_helpers::try_parse_cost_modification`).
+    /// On main both land `QuantityRef::ObjectCount` over a filter that still
+    /// carries the group `SharesQuality` marker, and
+    /// `game::filter::evaluate_shares_quality` answers TRUE for every object
+    /// when `reference` is `None` — so the count is the plain creature count and
+    /// the gate fires on ANY three (respectively two) creatures.
+    ///
+    /// The second input is also the only row in this file that exercises
+    /// `parse_ge_threshold`'s `at least N` arm.
+    ///
+    /// Revert-failing: revert Branch A and `parse_control_count_ge` lands the
+    /// inert `ObjectCount`, firing both the destructure and the residual-marker
+    /// assertion. Reverting the `defending player controls ` leaf does NOT move
+    /// these rows — the `you control ` arm is untouched by it — which is what
+    /// makes this the exclusive discriminator for the lift.
+    #[test]
+    fn parse_you_control_count_ge_group_shared_creature_type() {
+        for (text, expected_n) in [
+            // Littjara Kinseekers' intervening-if, after `~` normalization.
+            (
+                "if you control three or more creatures that share a creature type",
+                3,
+            ),
+            // Synchronized Eviction's cost-reduction gate.
+            (
+                "if you control at least two creatures that share a creature type",
+                2,
+            ),
+        ] {
+            let (rest, cond) =
+                parse_condition(text).unwrap_or_else(|e| panic!("failed to parse {text:?}: {e:?}"));
+            assert_eq!(rest, "", "unconsumed remainder for {text:?}");
+            let (tf, quality, aggregate, value) = expect_group_shared_count(text, cond);
+            assert_eq!(value, expected_n, "threshold for {text:?}");
+            assert_eq!(quality, SharedQuality::CreatureType, "quality for {text:?}");
+            assert_eq!(aggregate, AggregateFunction::Max, "aggregate for {text:?}");
+            assert_eq!(tf.type_filters, vec![TypeFilter::Creature]);
+            assert_eq!(
+                tf.controller,
+                Some(ControllerRef::You),
+                "scope for {text:?}"
+            );
+        }
+    }
+
+    /// REGRESSION GUARD for the four incumbent Branch B (postmodifier) rows the
+    /// rewritten `parse_control_count_ge_shared_quality` must not move: Endless
+    /// Atlas and Sceptre of Eternal Glory (activated-ability conditions),
+    /// Mechanized Production and Chrome Replicator (trigger intervening-ifs).
+    ///
+    /// Chrome Replicator is the only one with a compound type phrase and a
+    /// non-zone `FilterProp` sitting where a `SharesQuality` marker would sit,
+    /// and its route (`try_extract_intervening`) drops the whole intervening-if
+    /// on a decline — so a Branch B regression there is SILENT and the ETB
+    /// creates its token unconditionally.
+    ///
+    /// Goes RED on any breakage of Branch B, of the `parse_shared_quality`
+    /// substitution, or of the `inject_controller_you` → `inject_controller(ctrl)`
+    /// swap. Reverting either unit wholesale restores the incumbent Branch B, so
+    /// these rows guard regressions INSIDE the rewrite rather than discriminating
+    /// a revert.
+    #[test]
+    fn parse_control_count_ge_shared_name_postmodifier_rows_are_unchanged() {
+        for (text, expected_n, expected_types, expects_non_token) in [
+            // Endless Atlas / Sceptre of Eternal Glory.
+            (
+                "as long as you control three or more lands with the same name",
+                3,
+                vec![TypeFilter::Land],
+                false,
+            ),
+            // Mechanized Production — the ` as one another` tail and the `if `
+            // entry rather than `as long as `.
+            (
+                "if you control eight or more artifacts with the same name as one another",
+                8,
+                vec![TypeFilter::Artifact],
+                false,
+            ),
+            // Chrome Replicator.
+            (
+                "if you control two or more nonland, nontoken permanents with the same name as one another",
+                2,
+                vec![TypeFilter::Permanent, TypeFilter::Non(Box::new(TypeFilter::Land))],
+                true,
+            ),
+        ] {
+            let (rest, cond) =
+                parse_condition(text).unwrap_or_else(|e| panic!("failed to parse {text:?}: {e:?}"));
+            assert_eq!(rest, "", "unconsumed remainder for {text:?}");
+            let (tf, quality, aggregate, value) = expect_group_shared_count(text, cond);
+            assert_eq!(value, expected_n, "threshold for {text:?}");
+            assert_eq!(quality, SharedQuality::Name, "quality for {text:?}");
+            assert_eq!(aggregate, AggregateFunction::Max, "aggregate for {text:?}");
+            assert_eq!(tf.type_filters, expected_types, "types for {text:?}");
+            assert_eq!(tf.controller, Some(ControllerRef::You), "scope for {text:?}");
+            assert_eq!(
+                tf.properties.contains(&FilterProp::NonToken),
+                expects_non_token,
+                "NonToken property for {text:?}, got {:?}",
+                tf.properties
+            );
+        }
+    }
+
+    /// HOSTILE FIXTURE — Bursting Beebles: "can't be blocked as long as
+    /// defending player controls two or more nonland permanents that share an
+    /// artist."
+    ///
+    /// CR 109.3 enumerates an object's characteristics and closes with "Any
+    /// other information about an object isn't a characteristic." Artist is not
+    /// among them, `GameObject` carries no artist field, and `SharedQuality`
+    /// correctly has no `Artist` arm. So `parse_shared_quality_clause` never
+    /// consumes the clause, this arm leaves it in the remainder, and the
+    /// caller's emptiness check refuses — the gate stays
+    /// `StaticCondition::Unrecognized` and `coverage.rs` keeps reporting the
+    /// gap honestly.
+    ///
+    /// **If this ever goes RED the fix is NOT to relax the test.** A consumed
+    /// remainder here means some route accepted a gate BROADER than printed
+    /// (Beebles would become unblockable on any two nonland permanents) while
+    /// coverage went green — a silent, coverage-invisible regression.
+    #[test]
+    fn share_an_artist_is_not_consumed_and_stays_an_honest_gap() {
+        let text =
+            "as long as defending player controls two or more nonland permanents that share an artist";
+        let (rest, _cond) =
+            parse_condition(text).unwrap_or_else(|e| panic!("failed to parse {text:?}: {e:?}"));
+        assert_eq!(
+            rest, " that share an artist",
+            "the artist clause must be left UNCONSUMED so the caller's \
+             emptiness check refuses the whole gate"
+        );
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_nom/condition.rs
+++ b/crates/engine/src/parser/oracle_nom/condition.rs
@@ -4084,27 +4084,38 @@ fn take_group_shared_quality(filter: &mut TargetFilter) -> Option<SharedQuality>
         )
     })?;
     // `position` matched this variant at `idx` on the line above and `remove`
-    // cannot change it; `let … else` keeps the destructure total without a
-    // wildcard arm or a panic.
+    // cannot change it, so this arm is unreachable. It must PANIC rather than
+    // return `None`: the property has already been removed by the time we get
+    // here, so a silent decline would hand the caller's `alt` fall-through a
+    // filter with a dropped constraint.
     let FilterProp::SharesQuality { quality, .. } = tf.properties.remove(idx) else {
-        return None;
+        unreachable!(
+            "`position` matched FilterProp::SharesQuality at index {idx}; \
+             `Vec::remove` returns that same element"
+        )
     };
     Some(quality)
 }
 
-/// CR 201.2 + CR 109.3: Parse "<scope> control(s) N or more [type] that share a
+/// CR 201.2a + CR 109.3: Parse "<scope> control(s) N or more [type] that share a
 /// [quality]" and "<scope> control(s) N or more [type] with the same [quality]
 /// [as one another]"
 /// → `QuantityComparison(ObjectCountBySharedQuality[quality, Max] >= N)`.
 ///
 /// The same-quality mirror of `parse_control_count_ge_distinct_quality`. Both
-/// read a control-scope prefix + a GE threshold + a type phrase + a
-/// shared-characteristic constraint; they differ only on the RELATION over that
+/// read a controller prefix + a GE threshold + a type phrase + a
+/// shared-characteristic constraint, and differ on the RELATION over that
 /// characteristic (`different` → count the distinct values; `the same` / `share
-/// a` → group by value and take the largest group). `aggregate: Max` is what
-/// makes "three or more lands with the same name" mean "some ONE name is shared
-/// by at least three of your lands" rather than "you have at least three lands
-/// in total".
+/// a` → group by value and take the largest group). They now also differ on
+/// SCOPE: this function is parameterized on `parse_control_scope_prefix` while
+/// the distinct-quality sibling still hard-codes `tag("you control ")`. That
+/// asymmetry is deliberate — no card prints "defending player controls N or
+/// more … with different …", so widening the sibling would add an unexercised
+/// path with no corpus evidence behind it. Widen it when such a card prints.
+///
+/// `aggregate: Max` is what makes "three or more lands with the same name" mean
+/// "some ONE name is shared by at least three of your lands" rather than "you
+/// have at least three lands in total".
 ///
 /// **Two printings, one predicate.** English prints this constraint either as a
 /// relative clause ("three or more creatures **that share a creature type**",
@@ -4160,13 +4171,12 @@ fn parse_control_count_ge_shared_quality(input: &str) -> OracleResult<'_, Static
         let consumed = remainder.as_ptr() as usize - input.as_ptr() as usize;
         return Ok((
             &input[consumed..],
-            make_quantity_comparison(
+            make_quantity_ge(
                 QuantityRef::ObjectCountBySharedQuality {
                     filter,
                     quality,
                     aggregate: AggregateFunction::Max,
                 },
-                Comparator::GE,
                 n,
             ),
         ));
@@ -4184,13 +4194,12 @@ fn parse_control_count_ge_shared_quality(input: &str) -> OracleResult<'_, Static
     let consumed = after_suffix.as_ptr() as usize - input.as_ptr() as usize;
     Ok((
         &input[consumed..],
-        make_quantity_comparison(
+        make_quantity_ge(
             QuantityRef::ObjectCountBySharedQuality {
                 filter,
                 quality,
                 aggregate: AggregateFunction::Max,
             },
-            Comparator::GE,
             n,
         ),
     ))
@@ -10791,6 +10800,16 @@ mod tests {
     /// remainder here means some route accepted a gate BROADER than printed
     /// (Beebles would become unblockable on any two nonland permanents) while
     /// coverage went green — a silent, coverage-invisible regression.
+    ///
+    /// Revert-failing: the `defending player controls ` leaf of
+    /// `parse_control_scope_prefix` ONLY, and it fails as a PANIC rather than an
+    /// assertion — without that leaf nothing parses this prefix, `parse_condition`
+    /// returns `Err`, and the row dies at the `unwrap_or_else`. Reverting the
+    /// Branch B `parse_shared_quality` substitution leaves this row GREEN,
+    /// because `artist` is outside that vocabulary either way. Neither is the
+    /// guard this row exists for: its guard is that the remainder stays
+    /// `" that share an artist"`, which goes RED the moment any route learns to
+    /// consume the clause.
     #[test]
     fn share_an_artist_is_not_consumed_and_stays_an_honest_gap() {
         let text =

--- a/crates/engine/src/parser/oracle_static/tests.rs
+++ b/crates/engine/src/parser/oracle_static/tests.rs
@@ -20356,7 +20356,10 @@ fn classify_block_exception_count_vs_quality() {
 
 #[test]
 fn cant_be_blocked_as_long_as_defending_controls() {
-    // CR 509.1a: "can't be blocked as long as defending player controls an artifact"
+    // CR 509.1b: an evasion ability creates a blocking restriction — "can't be
+    // blocked as long as defending player controls an artifact". NOT 509.1a,
+    // which governs only which creatures the defending player chooses to block
+    // with and says nothing about restrictions.
     let def = parse_static_line(
         "This creature can't be blocked as long as defending player controls an artifact.",
     )

--- a/crates/engine/tests/integration/issue_8183_static_gate_fail_open.rs
+++ b/crates/engine/tests/integration/issue_8183_static_gate_fail_open.rs
@@ -7,15 +7,12 @@
 //! as ALWAYS TRUE — fail-open) and now covers four layers of the same genus:
 //!
 //!   * sections 1–3 — #8183's own three: a gate that failed to TYPE;
-//!   * section 4 — the defending-player gates. Ayesha and Graxiplon are parser
-//!     gaps like #8183's; **Dandân's is different in kind** — its gate types
+//!   * sections 4–5 — the defending-player gates. Ayesha's gate (section 5)
+//!     and Graxiplon's (section 1) are parser gaps like #8183's;
+//!     **Dandân's (section 4) is different in kind** — its gate types
 //!     correctly and the ANCHOR cannot bind;
-//!   * section 5 — the group-share counting gap: the gate types, the anchor
+//!   * section 6 — the group-share counting gap: the gate types, the anchor
 //!     binds, and the gate is STILL inert because of what the filter carries.
-//!
-//! CR 604.1: a static ability is "simply true" — its gate decides whether it
-//! currently applies, so a gate the parser drops or mis-polarizes silently
-//! turns the restriction on (or off) for every board state.
 //!
 //! CR 604.1: a static ability is "simply true" — its gate decides whether it
 //! currently applies, so a gate the parser drops or mis-polarizes silently
@@ -26,10 +23,16 @@
 //!     The `unless` NEGATION was dropped at the `can't be blocked` fallback
 //!     branch, leaving a bare `Unrecognized` that evaluates TRUE, so
 //!     `CantBeBlocked` applied unconditionally: Graxiplon was permanently
-//!     unblockable. With the fix the gate is `Not(Unrecognized)`, which
-//!     evaluates FALSE, so the restriction does not apply and the block is
-//!     legal (CR 509.1b — the defending player checks each creature for
-//!     blocking restrictions, and an evasion ability creates one).
+//!     unblockable. #8183 restored the NEGATION but not its operand: the gate
+//!     became `Not(Unrecognized)`, and since `Unrecognized` evaluates TRUE the
+//!     `Not` evaluates FALSE, so the restriction applied on NO board. That was
+//!     an honest improvement over permanent unblockability, but it is still not
+//!     the printed card. The `defending player controls ` leaf of
+//!     `parse_control_scope_prefix` types the operand, so the gate finally
+//!     answers the board: with the printed gate UNMET the `Not` is TRUE, the
+//!     restriction APPLIES, and the block is ILLEGAL (CR 509.1b — the
+//!     defending player checks each creature for blocking restrictions, and an
+//!     evasion ability creates one).
 //!
 //!  2. **Training Drone** — "This creature can't attack or block unless it's
 //!     equipped." The anaphoric "it" in the gate was never resolved to the
@@ -49,27 +52,28 @@
 //!     continuous effect from a static ability applies at any given moment to
 //!     whatever its text indicates; CR 508.1k — an attacking creature).
 //!
-//!  4. **The defending-player gates.**
-//!     **Ayesha Tanaka, Armorer** — "can't be blocked as long as defending
-//!     player controls three or more artifacts" — and **Graxiplon** —
-//!     "…unless defending player controls three or more creatures that share a
-//!     creature type" — both fell to `Unrecognized` because the control-count
-//!     combinator had only `you control` and `your opponents control` leaves.
-//!     With the `defending player controls` leaf the count is scoped through
-//!     `ControllerRef::DefendingPlayer` and the anchor binds: for a
-//!     `CantBeBlocked` static the source is already in `combat.attackers` when
-//!     CR 509.1b's blocking-restriction check runs (CR 508.5 / CR 508.5a
-//!     determine which seat).
-//!
-//!     **Dandân** — "can't attack unless defending player controls an Island" —
-//!     is the same printed grammar on the OTHER side of combat, and it is a
+//!  4. **Dandân — the defending-player anchor that cannot bind.**
+//!     "Can't attack unless defending player controls an Island" is the same
+//!     printed grammar as section 5's on the OTHER side of combat, and it is a
 //!     RUNTIME ANCHOR gap rather than a parser gap. Its gate types correctly,
 //!     but attack legality is checked before the candidate is recorded as an
 //!     attacker, so the anchor resolves to nothing and the gate reads UNMET on
 //!     every board. That test pins the gap deliberately; read its doc comment
 //!     before changing it.
 //!
-//!  5. **The group-share counting gap.**
+//!  5. **Ayesha Tanaka, Armorer — the defending-player count that never typed.**
+//!     "Can't be blocked as long as defending player controls three or more
+//!     artifacts" — and, on the same combinator, **Graxiplon**'s "…unless
+//!     defending player controls three or more creatures that share a creature
+//!     type" from section 1 — both fell to `Unrecognized` because the
+//!     control-count combinator had only `you control` and `your opponents
+//!     control` leaves. With the `defending player controls ` leaf the count is
+//!     scoped through `ControllerRef::DefendingPlayer` and the anchor binds: for
+//!     a `CantBeBlocked` static the source is already in `combat.attackers` when
+//!     CR 509.1b's blocking-restriction check runs (CR 508.5 / CR 508.5a
+//!     determine which seat).
+//!
+//!  6. **The group-share counting gap.**
 //!     **Littjara Kinseekers** ("if you control three or more creatures that
 //!     share a creature type", CR 603.4) and **Synchronized Eviction** ("costs
 //!     {2} less to cast if you control at least two creatures that share a
@@ -398,11 +402,13 @@ fn legal_attackers_for(runner: &GameRunner, blocker: ObjectId) -> Vec<ObjectId> 
 
 /// REACH-GUARD for the Graxiplon runtime test below.
 ///
-/// `graxiplon_can_be_blocked_when_gate_unmet` asserts a block is LEGAL. That
-/// assertion is satisfied for the wrong reason if Graxiplon parsed no
-/// `CantBeBlocked` static at all, or parsed one with no gate. This pins that
-/// the static exists AND carries a condition, so the legal block below is
-/// evidence about the GATE and not about an absent static.
+/// `graxiplon_cannot_be_blocked_when_gate_unmet` asserts a block is ILLEGAL.
+/// That assertion is satisfied for the wrong reason if Graxiplon parsed a
+/// `CantBeBlocked` static carrying NO gate, which would refuse every block
+/// unconditionally and reproduce the pre-#8183 bug while reading green. This
+/// pins that the static exists AND carries a condition, so the illegal block
+/// below is evidence about the GATE and not about an unconditional
+/// restriction.
 #[test]
 fn graxiplon_parses_a_condition_gated_cant_be_blocked_static() {
     let mut scenario = GameScenario::new();
@@ -1059,9 +1065,14 @@ fn dandan_attack_legality_ignores_the_defending_players_board() {
 ///
 /// Both rows assert a blocking outcome. Either is satisfied for the wrong
 /// reason if Ayesha parsed no `CantBeBlocked` static, or parsed one whose gate
-/// is still an always-true `Unrecognized`. Naming the whole condition tree here
-/// — a single `QuantityComparison` leaf — pins both at once: it exists, it is
-/// typed, and there is no `Unrecognized` anywhere inside it.
+/// is still an always-true `Unrecognized`. The pattern names the VARIANT, not
+/// the whole tree (`QuantityComparison { .. }`), which is sufficient here: it
+/// pins that the gate exists and is typed, and a `QuantityComparison` carries
+/// only `QuantityExpr` / `Comparator` fields, `QuantityExpr` is closed over
+/// arithmetic on `QuantityRef` / `i32`, and no `QuantityRef` variant embeds a
+/// `StaticCondition` — so no `Unrecognized` can hide inside it. Contrast
+/// Dandân's guard above, which destructures every node and needs no such
+/// type-level argument.
 ///
 /// Revert-discrimination: the `defending player controls ` leaf only. The
 /// Branch A lift never touches Ayesha, whose gate carries no shared-quality
@@ -1376,10 +1387,18 @@ fn synchronized_eviction_is_reduced_when_two_creatures_share_a_type() {
 ///
 /// **No lands and no other mana source on either board.** `can_cast_object_now`
 /// asks whether the cost is feasibly PAYABLE, not whether the floating pool
-/// alone covers it, so a single untapped land would make both rows castable and
-/// destroy the discrimination. The floating pool must be the only mana
-/// available — the same reason `hollow_one_cost_reduction.rs` puts no lands on
-/// its board. This is the most breakable property of this fixture.
+/// alone covers it: it reaches
+/// `casting::can_feasibly_pay_mana_cost_without_x_with_probe`, whose first act
+/// is the auto-tap probe `casting::can_pay_cost_after_auto_tap_with_probe`, and
+/// only the residual is charged against the pool. So the floating pool must be
+/// the only mana available — the same reason `hollow_one_cost_reduction.rs`
+/// puts no lands on its board.
+///
+/// Breaking it FAILS LOUDLY, which is why it is documented rather than
+/// asserted: `synchronized_eviction_is_not_reduced_when_creatures_share_no_type`
+/// asserts `!can_cast_object_now`, so any added mana source turns THAT row RED.
+/// "Both rows go green proving nothing" is not a reachable state. Only P0's
+/// side is load-bearing either way.
 ///
 /// The phase is `PreCombatMain` to match that precedent; Synchronized Eviction
 /// is an INSTANT, so the phase is not load-bearing for legality.

--- a/crates/engine/tests/integration/issue_8183_static_gate_fail_open.rs
+++ b/crates/engine/tests/integration/issue_8183_static_gate_fail_open.rs
@@ -1,8 +1,21 @@
-//! Issue #8183 — a static ability's gate condition that the parser could not
-//! type lands as `StaticCondition::Unrecognized`, which the layer system
-//! evaluates as ALWAYS TRUE (fail-open). Three shapes of that defect are fixed
-//! in the PARSER (no `layers.rs` change), and this file is the runtime proof
-//! that the fixed AST actually changes what the game allows.
+//! **Gates a card prints that the engine does not actually gate**, and the
+//! runtime proof that fixing them changes what the game allows. Every fix here
+//! is in the PARSER — no `layers.rs` change.
+//!
+//! The file started at issue #8183 (a gate condition the parser could not type
+//! lands as `StaticCondition::Unrecognized`, which the layer system evaluates
+//! as ALWAYS TRUE — fail-open) and now covers four layers of the same genus:
+//!
+//!   * sections 1–3 — #8183's own three: a gate that failed to TYPE;
+//!   * section 4 — the defending-player gates. Ayesha and Graxiplon are parser
+//!     gaps like #8183's; **Dandân's is different in kind** — its gate types
+//!     correctly and the ANCHOR cannot bind;
+//!   * section 5 — the group-share counting gap: the gate types, the anchor
+//!     binds, and the gate is STILL inert because of what the filter carries.
+//!
+//! CR 604.1: a static ability is "simply true" — its gate decides whether it
+//! currently applies, so a gate the parser drops or mis-polarizes silently
+//! turns the restriction on (or off) for every board state.
 //!
 //! CR 604.1: a static ability is "simply true" — its gate decides whether it
 //! currently applies, so a gate the parser drops or mis-polarizes silently
@@ -36,26 +49,148 @@
 //!     continuous effect from a static ability applies at any given moment to
 //!     whatever its text indicates; CR 508.1k — an attacking creature).
 //!
+//!  4. **The defending-player gates.**
+//!     **Ayesha Tanaka, Armorer** — "can't be blocked as long as defending
+//!     player controls three or more artifacts" — and **Graxiplon** —
+//!     "…unless defending player controls three or more creatures that share a
+//!     creature type" — both fell to `Unrecognized` because the control-count
+//!     combinator had only `you control` and `your opponents control` leaves.
+//!     With the `defending player controls` leaf the count is scoped through
+//!     `ControllerRef::DefendingPlayer` and the anchor binds: for a
+//!     `CantBeBlocked` static the source is already in `combat.attackers` when
+//!     CR 509.1b's blocking-restriction check runs (CR 508.5 / CR 508.5a
+//!     determine which seat).
+//!
+//!     **Dandân** — "can't attack unless defending player controls an Island" —
+//!     is the same printed grammar on the OTHER side of combat, and it is a
+//!     RUNTIME ANCHOR gap rather than a parser gap. Its gate types correctly,
+//!     but attack legality is checked before the candidate is recorded as an
+//!     attacker, so the anchor resolves to nothing and the gate reads UNMET on
+//!     every board. That test pins the gap deliberately; read its doc comment
+//!     before changing it.
+//!
+//!  5. **The group-share counting gap.**
+//!     **Littjara Kinseekers** ("if you control three or more creatures that
+//!     share a creature type", CR 603.4) and **Synchronized Eviction** ("costs
+//!     {2} less to cast if you control at least two creatures that share a
+//!     creature type") both parsed, both reported as supported, and both were
+//!     WRONG: `parse_type_phrase` consumes the relative clause into a
+//!     `FilterProp::SharesQuality { reference: None }`, which is a
+//!     group-SELECTION marker that `filter::evaluate_shares_quality` answers
+//!     TRUE for every object. Inside a `QuantityRef::ObjectCount` that silently
+//!     drops the constraint, so the gate fired on ANY three (respectively two)
+//!     creatures. The marker is now lifted onto the counting authority,
+//!     `QuantityRef::ObjectCountBySharedQuality { aggregate: Max }`.
+//!
+//!     These are the first CAST-SIDE rows in this file, and the inert marker
+//!     reaches the runtime through two different consumers: a trigger's
+//!     intervening-if (Littjara, driven through the cast pipeline per the
+//!     `/card-test` recipe) and a cost-modifying static (Synchronized Eviction,
+//!     via `casting::self_spell_cost_condition_matches` →
+//!     `layers::evaluate_condition`, asserted through `can_cast_object_now` at a
+//!     tuned pool after `hollow_one_cost_reduction.rs`).
+//!
 //! Every card here is built from VERBATIM Oracle text through
 //! `GameScenario`/`GameRunner`, so the whole production route runs: Oracle text
 //! → static parser → `StaticDefinition.condition` → `evaluate_condition*` →
-//! combat legality / layer evaluation. No test in this file asserts an AST
-//! shape as its primary claim; the two AST assertions present are explicitly
-//! labelled reach-guards.
+//! combat legality / cost modification / layer evaluation. No test in this file
+//! asserts an AST shape as its primary claim; the AST assertions present are
+//! explicitly labelled reach-guards.
+//!
+//! # FIXTURE CONTRACT
+//!
+//! Three separate rounds of this work produced three instances of ONE failure
+//! class: an assertion that could not fail for the reason it claimed, because
+//! the fixture never reached the state under test. Per-row repairs did not
+//! hold, because each covered only the instance it found. The properties are
+//! therefore stated once, here, and constructed by helpers rather than by each
+//! row.
+//!
+//! **R1 — every combat fixture leaves at least one legal block available.**
+//! The engine's auto-pass loop AUTO-SUBMITS the declare-blockers step when
+//! `valid_blocker_ids` is empty, so a fixture where the restriction under test
+//! correctly applies and nothing else is blockable never enters the step at
+//! all. Adding defenders does not help — the step is skipped on "no legal block
+//! anywhere", not on "no blockers". Constructed by declaring TWO attackers in
+//! every combat row: the card under test and an unrestricted ally. Checked by
+//! `declare_attackers_and_reach_blockers`, which asserts both `valid_blocker_ids`
+//! and `valid_block_targets` are non-empty on arrival; each row then also
+//! asserts the defender's blocker lists the ALLY among its legal targets, which
+//! is what makes its `Err` on the card under test specific rather than global.
+//!
+//! **R2 — `state.all_creature_types` matches the board.**
+//! `filter::shared_quality_values` filters an object's subtypes against that
+//! registry (CR 205.3m) and `GameScenario` leaves it EMPTY, so every bucket is
+//! empty, `AggregateFunction::Max` answers 0, and every gate-MET fixture
+//! silently reads UNMET. `seed_creature_types_from_board` derives it from the
+//! battlefield.
+//!
+//! **That seeding is structural ONLY for rows that enter combat**, because
+//! `declare_attackers_and_reach_blockers` is what calls the seeder. A row that
+//! does NOT enter combat is obliged to call `seed_creature_types_from_board`
+//! itself — as the Littjara and Synchronized Eviction rows do. There is no
+//! compiler or helper protection against omitting it: a non-combat row with an
+//! unseeded registry gets `Max = 0`, every gate reads UNMET, and any "no
+//! counter" / "not castable" assertion passes for the wrong reason, which is
+//! exactly the vacuous negative R4 exists to forbid.
+//!
+//! Board-derived seeding is a SUBSET of CR 205.3m's full list. That is faithful
+//! only while nothing reads the registry as a whole, which `Keyword::Changeling`
+//! does. A changeling row is admissible under exactly one of two discharges and
+//! must state which: (1) seed the full CR 205.3m list, or (2) prove the row's
+//! assertion is invariant under registry extension. The Littjara pair takes (2).
+//!
+//! **R3 — nothing between declare-attackers and declare-blockers needs player
+//! input.** The pass loop stops on any interactive `WaitingFor`. Ayesha's own
+//! attack trigger lowers to `Effect::Dig`, which with a non-empty library yields
+//! a `DigChoice` and strands the loop. It is a no-op here only because
+//! `GameScenario` builds every library EMPTY unless a fixture explicitly adds
+//! cards. A row that ever needs library cards must resolve the prompt rather
+//! than pass through it. The helper's arrival assertion names this property so
+//! such a failure reads as "R3 violated" rather than as an opaque panic.
+//!
+//! **R4 — negative assertions are paired, and the pair differs in exactly one
+//! variable.** Every row whose primary claim is an ABSENCE — a block that must
+//! be `Err`, a counter that must not be placed, a cast that must not be legal —
+//! has a PRESENCE sibling on an otherwise identical fixture. For the group-share
+//! pairs the creature COUNT is held equal across the pair, so the pre-fix inert
+//! count answers the same in both and the pair isolates the lift rather than the
+//! board size; the Synchronized Eviction pair additionally holds the mana pool
+//! byte-identical, since there the pool is the instrument.
 
+use engine::game::casting::can_cast_object_now;
 use engine::game::combat::AttackTarget;
 use engine::game::game_object::AttachTarget;
 use engine::game::keywords::has_keyword;
 use engine::game::layers::evaluate_layers;
-use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::scenario::{CastOutcome, GameRunner, GameScenario, P0, P1};
+use engine::types::ability::{StaticCondition, TargetFilter, TypeFilter};
+use engine::types::card_type::CoreType;
+use engine::types::counter::CounterType;
 use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::ObjectId;
 use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaColor, ManaCost, ManaCostShard, ManaType, ManaUnit};
 use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
 use engine::types::statics::StaticMode;
+use engine::types::zones::Zone;
 
 /// Verbatim Graxiplon Oracle text (MTGJSON AtomicCards).
 const GRAXIPLON: &str = "This creature can't be blocked unless defending player controls three or more creatures that share a creature type.";
+
+/// Verbatim Ayesha Tanaka, Armorer Oracle text (MTGJSON AtomicCards).
+/// The evasion line uses the PRINTED CARD NAME, not "This creature" — `~`
+/// normalization is what resolves it, so no fixture may paraphrase it.
+const AYESHA: &str = "Whenever Ayesha Tanaka attacks, look at the top four cards of your library. You may put any number of artifact cards with mana value less than or equal to Ayesha Tanaka's power from among them onto the battlefield tapped. Put the rest on the bottom of your library in a random order.\nAyesha Tanaka can't be blocked as long as defending player controls three or more artifacts.";
+
+/// Verbatim Littjara Kinseekers Oracle text (MTGJSON AtomicCards).
+/// Line 1 is a KEYWORD line with reminder text and MUST be supplied through
+/// `from_oracle_text_with_keywords(&["Changeling"], ..)`.
+const LITTJARA_KINSEEKERS: &str = "Changeling (This card is every creature type.)\nWhen this creature enters, if you control three or more creatures that share a creature type, put a +1/+1 counter on this creature, then scry 1.";
+
+/// Verbatim Synchronized Eviction Oracle text (MTGJSON AtomicCards).
+const SYNCHRONIZED_EVICTION: &str = "This spell costs {2} less to cast if you control at least two creatures that share a creature type.\nPut target nonland permanent into its owner's library second from the top.";
 
 /// Verbatim Training Drone Oracle text (MTGJSON AtomicCards).
 const TRAINING_DRONE: &str = "This creature can't attack or block unless it's equipped.";
@@ -68,6 +203,12 @@ const TRAINING_DRONE: &str = "This creature can't attack or block unless it's eq
 /// "Equipped creature gets +2/+1." and carries no quoted granted ability at
 /// all, so a fixture built from the paper text could not exercise this defect.
 const ANCESTRAL_KATANA: &str = "Whenever a Samurai or Warrior you control attacks alone, you may pay {1}. When you do, attach Ancestral Katana to it.\nEquipped creature gets +2/+2 and has \"This creature has first strike as long as it's attacking.\"\nEquip {2}";
+
+/// Verbatim Dandân Oracle text (MTGJSON AtomicCards).
+/// The SECOND line is load-bearing for the fixture, not decoration: without an
+/// Island under Dandân's OWN controller the creature is sacrificed and the
+/// attack-legality assertions below become vacuous.
+const DANDAN: &str = "This creature can't attack unless defending player controls an Island.\nWhen you control no Islands, sacrifice this creature.";
 
 /// Wire `equipment` onto `host` the way the equip action does (CR 301.5).
 /// Mirrors the local `attach` helper in `mjolnir_hammer_double_damage.rs`.
@@ -109,6 +250,148 @@ fn advance_to_declare_attackers(runner: &mut GameRunner) {
     );
 }
 
+/// FIXTURE PROPERTY R2 (see the module doc's FIXTURE CONTRACT).
+///
+/// CR 205.3m: `SharedQuality::CreatureType` filters an object's subtypes
+/// against `state.all_creature_types` (`game::filter::shared_quality_values`),
+/// and `GameScenario` leaves that registry EMPTY — the same trap
+/// `borg_queen_assimilate.rs` records for a different consumer. With it empty
+/// every bucket is empty, `AggregateFunction::Max` answers 0, and every
+/// gate-MET fixture in this file silently reads UNMET.
+///
+/// Seeded FROM THE BOARD rather than from a hand-written list, so a fixture
+/// cannot add typed creatures and forget to declare them. Board-derived seeding
+/// is a SUBSET of CR 205.3m's full creature-type list; that is faithful only
+/// while nothing reads the registry as a whole, which `Keyword::Changeling`
+/// does — `shared_quality_values` early-returns the WHOLE registry for a
+/// changeling.
+///
+/// One caller here does use a changeling: the Littjara Kinseekers pair. It is
+/// admissible because its assertion is INVARIANT under registry extension, not
+/// because the registry happens to be complete. Extending the registry beyond
+/// the board's own subtypes can only create buckets whose sole member is the
+/// changeling itself, so every added bucket has size 1 and cannot raise
+/// `AggregateFunction::Max`. Any future changeling caller must either repeat
+/// that argument in its own doc or seed the full CR 205.3m list instead.
+fn seed_creature_types_from_board(runner: &mut GameRunner) {
+    let mut creature_types: Vec<String> = runner
+        .state()
+        .objects
+        .values()
+        .filter(|obj| {
+            obj.zone == Zone::Battlefield && obj.card_types.core_types.contains(&CoreType::Creature)
+        })
+        .flat_map(|obj| obj.card_types.subtypes.iter().cloned())
+        .collect();
+    // `objects` iterates in unspecified order; sort + dedup so the seeded
+    // registry is deterministic across runs.
+    creature_types.sort();
+    creature_types.dedup();
+    runner.state_mut().all_creature_types = creature_types;
+}
+
+/// FIXTURE PROPERTIES R1 + R3 (see the module doc's FIXTURE CONTRACT).
+///
+/// Declare `attackers`, seed the creature-type registry from the board, then
+/// pass priority until the declare-blockers step and PROVE we arrived with a
+/// block actually available.
+///
+/// CR 508.2: the active player gets priority after attackers are declared.
+/// CR 117.3d: a player who takes no action passes and the next player receives
+/// priority. CR 117.4: when all players pass in succession the step ends —
+/// which is what reaches CR 509.1's declare-blockers step. A single
+/// `pass_both_players()` is not enough: it passes only two seats, so a
+/// three-player game needs more, and an attack trigger that goes on the stack
+/// adds another round.
+///
+/// The registry is seeded after the declaration and before the pass loop
+/// because the gates under test are read at CR 509.1b's blocking-restriction
+/// check, which happens at the far end of that loop.
+///
+/// The arrival assertion names which property failed, because the three failure
+/// modes are not distinguishable from the panic alone:
+///   * still `Priority` — the pass budget is too small;
+///   * any other `WaitingFor` — R3 violated: an ability of a fixture card needs
+///     player input (Ayesha's attack trigger is an `Effect::Dig`; it is a no-op
+///     only because `GameScenario` builds empty libraries);
+///   * `DeclareBlockers` with an empty `valid_blocker_ids` cannot be observed,
+///     because the engine's auto-pass loop auto-submits that case — which is
+///     R1's mechanism, and why every row here declares a second unrestricted
+///     attacker.
+fn declare_attackers_and_reach_blockers(
+    runner: &mut GameRunner,
+    attackers: &[(ObjectId, AttackTarget)],
+) {
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::DeclareAttackers { .. }
+        ),
+        "fixture must be at the declare-attackers step before declaring; got {}",
+        runner.state().waiting_for.variant_name()
+    );
+    runner
+        .declare_attackers(attackers)
+        .expect("every attacker in this fixture must be a legal attacker");
+    seed_creature_types_from_board(runner);
+
+    // CR 117.4: bounded so a stuck transition fails loudly instead of spinning.
+    // Two seats per iteration; a three-player game and a triggered ability on
+    // the stack each cost extra rounds.
+    for _ in 0..8 {
+        if !matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
+            break;
+        }
+        runner.pass_both_players();
+    }
+
+    let WaitingFor::DeclareBlockers {
+        valid_blocker_ids,
+        valid_block_targets,
+        ..
+    } = &runner.state().waiting_for
+    else {
+        panic!(
+            "fixture must reach the declare-blockers step (CR 509.1); got {}. \
+             Still `Priority` means the pass budget is too short; any other \
+             prompt means FIXTURE PROPERTY R3 is violated — some ability of a \
+             fixture card needs player input",
+            runner.state().waiting_for.variant_name()
+        );
+    };
+    assert!(
+        !valid_blocker_ids.is_empty(),
+        "FIXTURE PROPERTY R1: the declare-blockers step must be reached with at \
+         least one legal block available, or the engine auto-submits empty \
+         blockers and the row's block assertion is never evaluated"
+    );
+    assert!(
+        !valid_block_targets.is_empty(),
+        "FIXTURE PROPERTY R1: at least one blocker must have a legal attacker \
+         to block; got an empty valid_block_targets map"
+    );
+}
+
+/// The defending player's per-blocker legal-attacker list at the
+/// declare-blockers step (`valid_block_targets` maps blocker → the attackers it
+/// may legally block, CR 509.1a).
+fn legal_attackers_for(runner: &GameRunner, blocker: ObjectId) -> Vec<ObjectId> {
+    let WaitingFor::DeclareBlockers {
+        valid_block_targets,
+        ..
+    } = &runner.state().waiting_for
+    else {
+        panic!(
+            "must be at the declare-blockers step to read valid_block_targets; got {}",
+            runner.state().waiting_for.variant_name()
+        );
+    };
+    valid_block_targets
+        .get(&blocker)
+        .cloned()
+        .unwrap_or_default()
+}
+
 // ---------------------------------------------------------------------------
 // 1. Graxiplon — the dropped `unless` negation
 // ---------------------------------------------------------------------------
@@ -147,21 +430,38 @@ fn graxiplon_parses_a_condition_gated_cant_be_blocked_static() {
 }
 
 /// CR 509.1b + CR 604.1: with the `unless` gate UNMET (the defending player
-/// controls a single creature, not three sharing a type), the evasion
-/// restriction does NOT apply and the block is legal.
+/// controls a single creature, not three sharing a creature type), the
+/// restriction the printed card imposes DOES apply and the block is ILLEGAL.
 ///
-/// Discriminating: revert U2 (restore the bare
-/// `nom_condition::parse_condition(after_blocked)` fallback) and the gate
-/// becomes a bare `Unrecognized`, which the layer system evaluates as TRUE —
-/// `CantBeBlocked` applies unconditionally and `declare_blockers` returns Err.
-/// The `is_ok()` assertion is what flips.
+/// **Polarity note — this assertion was flipped by this change.** Graxiplon
+/// reads "can't be blocked **unless** …", so the gate is `Not(X)`: with `X`
+/// false the restriction applies. The previous version of this test asserted
+/// the block was LEGAL and documented that as correct; it was not. It encoded
+/// #8183's honestly-reported intermediate state, where the gate was
+/// `Not(Unrecognized)` — `Unrecognized` evaluates TRUE, the `Not` makes it
+/// FALSE, and the restriction never applied. #8183 was a real improvement over
+/// an unconditionally-unblockable Graxiplon, but "less wrong" is not the card.
+///
+/// Discriminating: revert the `defending player controls ` leaf of
+/// `parse_control_scope_prefix` and the gate falls back to
+/// `Not(Unrecognized)` = FALSE, the restriction stops applying, and the block
+/// becomes legal — the `is_err()` assertion is what flips. Reverting the Branch
+/// A lift alone does NOT move this row: on a one-Bear board the inert
+/// `ObjectCount` answers 1, `1 >= 3` is false, `Not(false)` is true, and the
+/// block is still refused. The lift's runtime discriminators are the two
+/// non-sharing boards below.
 #[test]
-fn graxiplon_can_be_blocked_when_gate_unmet() {
+fn graxiplon_cannot_be_blocked_when_gate_unmet() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     let graxiplon = scenario
         .add_creature_from_oracle(P0, "Graxiplon", 4, 4, GRAXIPLON)
         .id();
+    // FIXTURE PROPERTY R1: a second, unrestricted attacker is REQUIRED. With
+    // Graxiplon alone and its restriction correctly applying there is no legal
+    // block anywhere, the engine auto-submits empty blockers, and the arrival
+    // guard fires before this row's assertion is ever evaluated.
+    let ally = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
     // ONE creature for the defender: the printed gate ("three or more creatures
     // that share a creature type") is unmet by construction.
     let blocker = scenario.add_creature(P1, "Runeclaw Bear", 2, 2).id();
@@ -169,28 +469,271 @@ fn graxiplon_can_be_blocked_when_gate_unmet() {
     let mut runner = scenario.build();
 
     advance_to_declare_attackers(&mut runner);
-    runner
-        .declare_attackers(&[(graxiplon, AttackTarget::Player(P1))])
-        .expect("Graxiplon must be a legal attacker");
-
-    // CR 508.2: the active player gets priority after attackers are
-    // declared; pass through it to reach the declare-blockers step.
-    if matches!(runner.state().waiting_for, WaitingFor::Priority { .. }) {
-        runner.pass_both_players();
-    }
-    assert!(
-        matches!(
-            runner.state().waiting_for,
-            WaitingFor::DeclareBlockers { .. }
-        ),
-        "fixture must reach the declare-blockers step; got {:?}",
-        runner.state().waiting_for
+    declare_attackers_and_reach_blockers(
+        &mut runner,
+        &[
+            (graxiplon, AttackTarget::Player(P1)),
+            (ally, AttackTarget::Player(P1)),
+        ],
     );
 
+    // IN-FIXTURE POSITIVE: the defender's Bear can still block the ally, so the
+    // Err below is specific to Graxiplon rather than a global blocking failure.
+    let legal = legal_attackers_for(&runner, blocker);
+    assert!(
+        legal.contains(&ally),
+        "the defender's blocker must still be able to block the unrestricted \
+         ally; got {legal:?}"
+    );
+    assert!(
+        !legal.contains(&graxiplon),
+        "with the `unless` gate unmet the evasion restriction applies, so \
+         Graxiplon must not appear among the blocker's legal targets; got {legal:?}"
+    );
+    assert!(
+        runner.declare_blockers(&[(blocker, graxiplon)]).is_err(),
+        "CR 509.1b: `can't be blocked UNLESS defending player controls three or \
+         more creatures that share a creature type` — the defender controls one \
+         creature, so the gate is unmet, the restriction APPLIES, and the block \
+         is illegal"
+    );
+}
+
+/// GATE MET — three Goblins and a Zombie: the largest same-creature-type group
+/// is 3, so `AggregateFunction::Max` answers 3, the `unless` gate is satisfied
+/// and the evasion restriction does NOT apply.
+///
+/// Aggregate discrimination: this board is deliberately NOT three bare Goblins.
+/// On a bare three-Goblin board `Max`, `Sum` and the pre-fix inert count all
+/// answer 3, so it would discriminate nothing. Adding a fourth creature of a
+/// different type keeps `Max` at 3 while ruling out `Min` (which would answer 1
+/// and refuse the block).
+///
+/// Revert-discrimination: NEITHER unit alone turns this row red — it is the
+/// presence sibling for the three `Err` rows around it and the canary for
+/// FIXTURE PROPERTY R2 (an unseeded creature-type registry makes `Max` answer 0
+/// and this row fails for a reason unrelated to the code under test).
+#[test]
+fn graxiplon_can_be_blocked_when_three_share_a_creature_type() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let graxiplon = scenario
+        .add_creature_from_oracle(P0, "Graxiplon", 4, 4, GRAXIPLON)
+        .id();
+    let ally = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let blocker = scenario
+        .add_creature(P1, "Goblin Piker", 2, 1)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    scenario
+        .add_creature(P1, "Goblin Raider", 2, 2)
+        .with_subtypes(vec!["Goblin"]);
+    scenario
+        .add_creature(P1, "Goblin Brigand", 2, 2)
+        .with_subtypes(vec!["Goblin"]);
+    scenario
+        .add_creature(P1, "Zombie Brute", 3, 3)
+        .with_subtypes(vec!["Zombie"]);
+
+    let mut runner = scenario.build();
+
+    advance_to_declare_attackers(&mut runner);
+    declare_attackers_and_reach_blockers(
+        &mut runner,
+        &[
+            (graxiplon, AttackTarget::Player(P1)),
+            (ally, AttackTarget::Player(P1)),
+        ],
+    );
+
+    let legal = legal_attackers_for(&runner, blocker);
+    assert!(
+        legal.contains(&graxiplon),
+        "with three Goblins on the defender's board the gate is MET (Max = 3), \
+         so Graxiplon must be blockable; got {legal:?}"
+    );
     assert!(
         runner.declare_blockers(&[(blocker, graxiplon)]).is_ok(),
-        "with the `unless` gate unmet the CantBeBlocked restriction must NOT \
-         apply, so the block is legal (CR 509.1b)"
+        "CR 509.1b: the `unless` gate is satisfied by three creatures sharing \
+         the Goblin type, so the evasion restriction does not apply"
+    );
+}
+
+/// GATE UNMET, and the row that discriminates the LIFT from the shipped defect:
+/// three creatures, all of DIFFERENT creature types. The largest same-type
+/// group is 1, so `Max` answers 1 and the gate is unmet.
+///
+/// **The inert pre-fix count answers 3 on this board and would allow the
+/// block.** That is the whole point: the creature COUNT is held at the
+/// threshold while the shared-type arithmetic is not, so only a parse that
+/// actually enforces the shared-quality constraint refuses here.
+///
+/// Revert-discrimination: this row goes RED on a revert of EITHER unit. Revert
+/// the `defending player controls ` leaf and the gate is `Not(Unrecognized)` =
+/// FALSE, so the restriction never applies and the block is legal. Revert the
+/// Branch A lift and the inert `ObjectCount` answers 3, `3 >= 3` is true,
+/// `Not(true)` is false, and the block is legal again.
+#[test]
+fn graxiplon_cannot_be_blocked_when_no_three_share_a_creature_type() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let graxiplon = scenario
+        .add_creature_from_oracle(P0, "Graxiplon", 4, 4, GRAXIPLON)
+        .id();
+    let ally = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let blocker = scenario
+        .add_creature(P1, "Goblin Piker", 2, 1)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    scenario
+        .add_creature(P1, "Zombie Brute", 3, 3)
+        .with_subtypes(vec!["Zombie"]);
+    scenario
+        .add_creature(P1, "Elvish Scout", 1, 1)
+        .with_subtypes(vec!["Elf"]);
+
+    let mut runner = scenario.build();
+
+    advance_to_declare_attackers(&mut runner);
+    declare_attackers_and_reach_blockers(
+        &mut runner,
+        &[
+            (graxiplon, AttackTarget::Player(P1)),
+            (ally, AttackTarget::Player(P1)),
+        ],
+    );
+
+    let legal = legal_attackers_for(&runner, blocker);
+    assert!(
+        legal.contains(&ally),
+        "in-fixture positive: the blocker must still be able to block the ally; \
+         got {legal:?}"
+    );
+    assert!(
+        runner.declare_blockers(&[(blocker, graxiplon)]).is_err(),
+        "three creatures of three DIFFERENT types share no creature type \
+         (Max = 1 < 3), so the `unless` gate is unmet and the evasion \
+         restriction applies. A count that ignored the shared-type constraint \
+         would answer 3 and wrongly allow this block"
+    );
+}
+
+/// GATE UNMET with the largest shared group at TWO: two Goblins and two
+/// Zombies. `Max` answers 2 (< 3) so the gate is unmet.
+///
+/// This row rules out `AggregateFunction::Sum`, which the sibling above cannot:
+/// `Sum` over the two buckets answers 4 and would allow the block, as would the
+/// pre-fix inert count (4 creatures).
+///
+/// Revert-discrimination: RED on a revert of either unit, by the same
+/// arithmetic as its sibling.
+#[test]
+fn graxiplon_cannot_be_blocked_when_the_largest_shared_group_is_two() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let graxiplon = scenario
+        .add_creature_from_oracle(P0, "Graxiplon", 4, 4, GRAXIPLON)
+        .id();
+    let ally = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let blocker = scenario
+        .add_creature(P1, "Goblin Piker", 2, 1)
+        .with_subtypes(vec!["Goblin"])
+        .id();
+    scenario
+        .add_creature(P1, "Goblin Raider", 2, 2)
+        .with_subtypes(vec!["Goblin"]);
+    scenario
+        .add_creature(P1, "Zombie Brute", 3, 3)
+        .with_subtypes(vec!["Zombie"]);
+    scenario
+        .add_creature(P1, "Zombie Warrior", 2, 2)
+        .with_subtypes(vec!["Zombie"]);
+
+    let mut runner = scenario.build();
+
+    advance_to_declare_attackers(&mut runner);
+    declare_attackers_and_reach_blockers(
+        &mut runner,
+        &[
+            (graxiplon, AttackTarget::Player(P1)),
+            (ally, AttackTarget::Player(P1)),
+        ],
+    );
+
+    let legal = legal_attackers_for(&runner, blocker);
+    assert!(
+        legal.contains(&ally),
+        "in-fixture positive: the blocker must still be able to block the ally; \
+         got {legal:?}"
+    );
+    assert!(
+        runner.declare_blockers(&[(blocker, graxiplon)]).is_err(),
+        "the largest same-type group is 2 (< 3), so the gate is unmet. \
+         `AggregateFunction::Sum` would answer 4 and wrongly allow this block, \
+         as would a count that ignored the shared-type constraint"
+    );
+}
+
+/// CR 508.5a (multi-authority hostile fixture): in a multiplayer game
+/// "defending player" names ONE specific defending player — the one the
+/// attacking creature is attacking — not any defender and not a merged
+/// population.
+///
+/// Graxiplon and its ally attack P1, who controls a single Runeclaw Bear. Seat
+/// 2 controls three Goblins, a board that WOULD satisfy the gate. The gate must
+/// read P1's board and refuse the block.
+///
+/// Goes RED if the anchor resolves to a coarse "any defender" fallback, to a
+/// merged count across seats, or to the wrong seat.
+///
+/// Revert-discrimination: the `defending player controls ` leaf only — on P1's
+/// one-Bear board the lift's arithmetic is identical either way (see the
+/// gate-unmet row above). Its job is the ANCHOR claim (which seat's board is
+/// read), not the lift.
+#[test]
+fn graxiplon_reads_only_the_seat_it_is_attacking() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let graxiplon = scenario
+        .add_creature_from_oracle(P0, "Graxiplon", 4, 4, GRAXIPLON)
+        .id();
+    let ally = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let blocker = scenario.add_creature(P1, "Runeclaw Bear", 2, 2).id();
+    // The seat that is NOT being attacked holds a gate-satisfying board.
+    let bystander = PlayerId(2);
+    scenario
+        .add_creature(bystander, "Goblin Piker", 2, 1)
+        .with_subtypes(vec!["Goblin"]);
+    scenario
+        .add_creature(bystander, "Goblin Raider", 2, 2)
+        .with_subtypes(vec!["Goblin"]);
+    scenario
+        .add_creature(bystander, "Goblin Brigand", 2, 2)
+        .with_subtypes(vec!["Goblin"]);
+
+    let mut runner = scenario.build();
+
+    advance_to_declare_attackers(&mut runner);
+    declare_attackers_and_reach_blockers(
+        &mut runner,
+        &[
+            (graxiplon, AttackTarget::Player(P1)),
+            (ally, AttackTarget::Player(P1)),
+        ],
+    );
+
+    let legal = legal_attackers_for(&runner, blocker);
+    assert_eq!(
+        legal,
+        vec![ally],
+        "CR 508.5a: the gate must be evaluated against P1 — the seat Graxiplon \
+         is attacking — whose single creature leaves it unmet. Seat 2's three \
+         Goblins must not satisfy it"
+    );
+    assert!(
+        runner.declare_blockers(&[(blocker, graxiplon)]).is_err(),
+        "CR 508.5a: a third seat's gate-satisfying board must not make \
+         Graxiplon blockable by the seat it is actually attacking"
     );
 }
 
@@ -337,4 +880,554 @@ fn ancestral_katana_granted_first_strike_binds_to_equipped_creature() {
         "an ATTACKING equipped creature must have the granted first strike \
          (CR 611.3a: the granted static's `it` names the equipped creature)"
     );
+}
+
+// ---------------------------------------------------------------------------
+// 4. Dandân — the defending-player anchor that cannot bind (V0 pre-flight)
+// ---------------------------------------------------------------------------
+
+/// REACH-GUARD for `dandan_attack_legality_ignores_the_defending_players_board`.
+///
+/// That test asserts Dandân is an ILLEGAL attacker in BOTH arms. That is
+/// satisfied for the wrong reason if Dandân's gate mis-parsed into something
+/// that can never be satisfied. Destructuring the exact two-node tree
+/// `Not(DefendingPlayerControls{Island})` pins that the gate typed correctly
+/// and — because the whole tree is named here — that no
+/// `StaticCondition::Unrecognized` hides anywhere inside it.
+///
+/// CR 508.1c: "can't attack unless <condition>" is a restriction, so the
+/// printed `unless` is the negation the `Not` carries.
+#[test]
+fn dandan_parses_a_condition_gated_cant_attack_static() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let dandan = scenario
+        .add_creature_from_oracle(P0, "Dandan", 4, 1, DANDAN)
+        .id();
+    let runner = scenario.build();
+
+    let statics = &runner.state().objects[&dandan].static_definitions;
+    let gated: Vec<_> = statics
+        .iter_unchecked()
+        .filter(|d| matches!(d.mode, StaticMode::CantAttack))
+        .collect();
+    assert_eq!(
+        gated.len(),
+        1,
+        "Dandân must parse to exactly one CantAttack static: {statics:#?}"
+    );
+    let Some(StaticCondition::Not { condition }) = &gated[0].condition else {
+        panic!(
+            "the CantAttack static must carry the printed `unless` gate as \
+             Not(..), not be unconditional or Unrecognized: {statics:#?}"
+        );
+    };
+    let StaticCondition::DefendingPlayerControls { filter } = condition.as_ref() else {
+        panic!(
+            "the negated gate must be a typed DefendingPlayerControls, not an \
+             Unrecognized leaf: {condition:#?}"
+        );
+    };
+    let TargetFilter::Typed(tf) = filter else {
+        panic!("the gate's filter must be Typed: {filter:#?}");
+    };
+    assert!(
+        tf.type_filters
+            .contains(&TypeFilter::Subtype("Island".to_string())),
+        "the gate must name the Island subtype the printed card asks about, \
+         got {:?}",
+        tf.type_filters
+    );
+}
+
+/// **This test pins a KNOWN ENGINE GAP, not correct behaviour.**
+///
+/// Dandân prints "This creature can't attack unless defending player controls
+/// an Island." The gate types correctly (see the reach-guard above), but the
+/// `DefendingPlayerControls` anchor cannot bind during the attack-legality
+/// check: `combat::creature_cant_attack_gated` evaluates the static's condition
+/// through `functioning_abilities::active_static_definitions` →
+/// `layers::evaluate_condition` with no combat context, and both
+/// `validate_attack_declaration` and `get_valid_attacker_ids` run BEFORE the
+/// candidate is recorded in `state.combat.attackers`. The anchor resolves to
+/// `None`, which the filter door renders as "no matching permanent", so the
+/// `unless` gate reads UNMET on every board and the restriction always applies.
+///
+/// CR 506.2 + CR 508.1c: this is an ENGINE gap, not a rules gap. In this
+/// two-player fixture the nonactive player is the defending player for the
+/// whole combat phase (CR 506.2), so the defender is already determined when
+/// CR 508.1c's restriction check runs. **CR 508.1b does not run here** — its
+/// antecedent (the defending player controls planeswalkers, is the protector of
+/// a battle, or the game allows attacking multiple players) is false in this
+/// fixture — which is why CR 506.2 is the cite and 508.1b is not.
+///
+/// The 2×2, and what each outcome would mean:
+///
+/// | (island arm, no-island arm) | meaning |
+/// |---|---|
+/// | **(Err, Err)** — what this test asserts | the anchor never binds; the gap is real |
+/// | (Ok, Err) | the anchor DOES bind — the gap is closed |
+/// | (Ok, Ok) | the restriction never applies at all — a different defect |
+/// | (Err, Ok) | inverted — escalate |
+///
+/// **If this test ever fails because the Island arm became `Ok`, do not relax
+/// it — the engine gap was fixed.** Flip the Island arm to `is_ok()` and re-open
+/// the `CantAttack` cards that are scoped out on this mechanism (Chained
+/// Throatseeker, Crown-Hunter Hireling, Goblin Goon, Mogg Toady, Monstrous
+/// Hound, Vantress Gargoyle, and the other 32 statics gated on
+/// `DefendingPlayerControls`).
+///
+/// Paired positive control, in BOTH arms: an unrestricted Grizzly Bears is
+/// listed in `valid_attacker_ids` and is a legal attacker. That excludes
+/// summoning sickness, an illegal attack target, a Dandân sacrificed by its own
+/// second line, and a harness artifact as causes of the `Err`.
+#[test]
+fn dandan_attack_legality_ignores_the_defending_players_board() {
+    for defender_island in [true, false] {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let dandan = scenario
+            .add_creature_from_oracle(P0, "Dandan", 4, 1, DANDAN)
+            .id();
+        let bear = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+        // Dandân's OWN controller must hold an Island in both arms, or its
+        // second line ("When you control no Islands, sacrifice this creature.")
+        // removes the creature under test and every assertion below is vacuous.
+        scenario.add_basic_land(P0, ManaColor::Blue);
+        let defender_land = defender_island.then(|| scenario.add_basic_land(P1, ManaColor::Blue));
+
+        let mut runner = scenario.build();
+
+        // BOARD REACH-GUARD: without this an `(Err, Err)` is also compatible
+        // with "the fixture never gave the defender an Island", which would
+        // make the insensitivity claim vacuous rather than true.
+        if let Some(land) = defender_land {
+            let obj = &runner.state().objects[&land];
+            assert!(
+                obj.card_types.core_types.contains(&CoreType::Land)
+                    && obj.card_types.subtypes.iter().any(|s| s == "Island"),
+                "the Island arm must actually give P1 a Land with the Island \
+                 subtype; got {:?} / {:?}",
+                obj.card_types.core_types,
+                obj.card_types.subtypes
+            );
+        }
+
+        advance_to_declare_attackers(&mut runner);
+        let WaitingFor::DeclareAttackers {
+            valid_attacker_ids, ..
+        } = &runner.state().waiting_for
+        else {
+            panic!(
+                "advance_to_declare_attackers must leave the declare-attackers \
+                 prompt in place; got {:?}",
+                runner.state().waiting_for.variant_name()
+            );
+        };
+        assert!(
+            valid_attacker_ids.contains(&bear),
+            "positive control: the unrestricted bear must be a valid attacker \
+             (defender_island = {defender_island}); got {valid_attacker_ids:?}"
+        );
+
+        assert!(
+            runner
+                .declare_attackers(&[(dandan, AttackTarget::Player(P1))])
+                .is_err(),
+            "ENGINE GAP (CR 506.2 + CR 508.1c): Dandân's attack legality is \
+             insensitive to the defending player's board — it is refused even \
+             with defender_island = {defender_island}. If this arm is now Ok, \
+             the anchor binds and this test's premise is obsolete; read the \
+             doc comment before changing it"
+        );
+        assert!(
+            runner
+                .declare_attackers(&[(bear, AttackTarget::Player(P1))])
+                .is_ok(),
+            "positive control: the unrestricted bear must be a legal attacker \
+             (defender_island = {defender_island})"
+        );
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 5. Ayesha Tanaka, Armorer — the defending-player count that never typed
+// ---------------------------------------------------------------------------
+
+/// REACH-GUARD for the two Ayesha runtime rows below (labelled as such per this
+/// file's convention).
+///
+/// Both rows assert a blocking outcome. Either is satisfied for the wrong
+/// reason if Ayesha parsed no `CantBeBlocked` static, or parsed one whose gate
+/// is still an always-true `Unrecognized`. Naming the whole condition tree here
+/// — a single `QuantityComparison` leaf — pins both at once: it exists, it is
+/// typed, and there is no `Unrecognized` anywhere inside it.
+///
+/// Revert-discrimination: the `defending player controls ` leaf only. The
+/// Branch A lift never touches Ayesha, whose gate carries no shared-quality
+/// clause.
+#[test]
+fn ayesha_parses_a_condition_gated_cant_be_blocked_static() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let ayesha = scenario
+        .add_creature_from_oracle(P0, "Ayesha Tanaka, Armorer", 2, 2, AYESHA)
+        .id();
+    let runner = scenario.build();
+
+    let statics = &runner.state().objects[&ayesha].static_definitions;
+    let gated: Vec<_> = statics
+        .iter_unchecked()
+        .filter(|d| matches!(d.mode, StaticMode::CantBeBlocked))
+        .collect();
+    assert_eq!(
+        gated.len(),
+        1,
+        "Ayesha must parse to exactly one CantBeBlocked static: {statics:#?}"
+    );
+    let Some(StaticCondition::QuantityComparison { .. }) = &gated[0].condition else {
+        panic!(
+            "the CantBeBlocked static's `as long as defending player controls \
+             three or more artifacts` gate must be a typed quantity comparison, \
+             not absent and not an Unrecognized leaf: {statics:#?}"
+        );
+    };
+}
+
+/// CR 509.1b + CR 508.5: gate MET — the defending player controls three
+/// artifacts, so Ayesha's evasion restriction APPLIES and she cannot be
+/// blocked.
+///
+/// Ayesha's polarity is `as long as` (positive), the mirror of Graxiplon's
+/// `unless`.
+///
+/// Revert-discrimination: NEITHER unit alone turns this row red. Reverting the
+/// `defending player controls ` leaf leaves the gate as an always-true
+/// `Unrecognized`, so the restriction still applies and the block is still
+/// refused. This row is the presence sibling of the two-artifact row below,
+/// which is the actual discriminator.
+///
+/// FIXTURE PROPERTY R3: Ayesha's own attack trigger lowers to `Effect::Dig`,
+/// which would open a `DigChoice` prompt and strand the pass loop. It is a
+/// no-op here only because `GameScenario` builds every library EMPTY. A future
+/// edit that gives P0 library cards must resolve that prompt explicitly.
+#[test]
+fn ayesha_cannot_be_blocked_when_defender_controls_three_artifacts() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let ayesha = scenario
+        .add_creature_from_oracle(P0, "Ayesha Tanaka, Armorer", 2, 2, AYESHA)
+        .id();
+    // FIXTURE PROPERTY R1.
+    let ally = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let blocker = scenario.add_creature(P1, "Runeclaw Bear", 2, 2).id();
+    for name in ["Bone Saw", "Chrome Mox", "Star Compass"] {
+        scenario.add_artifact_from_oracle(P1, name, "");
+    }
+
+    let mut runner = scenario.build();
+
+    advance_to_declare_attackers(&mut runner);
+    declare_attackers_and_reach_blockers(
+        &mut runner,
+        &[
+            (ayesha, AttackTarget::Player(P1)),
+            (ally, AttackTarget::Player(P1)),
+        ],
+    );
+
+    let legal = legal_attackers_for(&runner, blocker);
+    assert!(
+        legal.contains(&ally),
+        "in-fixture positive: the blocker must still be able to block the \
+         unrestricted ally; got {legal:?}"
+    );
+    assert!(
+        !legal.contains(&ayesha),
+        "with three artifacts on the defender's board the gate is MET, so \
+         Ayesha must be absent from the blocker's legal targets; got {legal:?}"
+    );
+    assert!(
+        runner.declare_blockers(&[(blocker, ayesha)]).is_err(),
+        "CR 509.1b: `can't be blocked as long as defending player controls \
+         three or more artifacts` — the defender controls three, so the \
+         restriction applies and the block is illegal"
+    );
+}
+
+/// CR 509.1b + CR 508.5: gate UNMET — the defending player controls only TWO
+/// artifacts, one short of the printed threshold, so the restriction does NOT
+/// apply and the block is legal.
+///
+/// **This is the discriminating runtime row for the `defending player
+/// controls ` leaf.** Revert it and the gate falls back to an always-true
+/// `Unrecognized`: the restriction applies on every board, Ayesha becomes
+/// permanently unblockable, and the `is_ok()` assertion flips. The Branch A
+/// lift does not move this row — Ayesha's gate has no shared-quality clause.
+///
+/// Its sibling above holds every board fact equal except the artifact count, so
+/// the pair isolates the threshold rather than the fixture.
+#[test]
+fn ayesha_can_be_blocked_when_defender_controls_two_artifacts() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let ayesha = scenario
+        .add_creature_from_oracle(P0, "Ayesha Tanaka, Armorer", 2, 2, AYESHA)
+        .id();
+    let ally = scenario.add_creature(P0, "Grizzly Bears", 2, 2).id();
+    let blocker = scenario.add_creature(P1, "Runeclaw Bear", 2, 2).id();
+    for name in ["Bone Saw", "Chrome Mox"] {
+        scenario.add_artifact_from_oracle(P1, name, "");
+    }
+
+    let mut runner = scenario.build();
+
+    advance_to_declare_attackers(&mut runner);
+    declare_attackers_and_reach_blockers(
+        &mut runner,
+        &[
+            (ayesha, AttackTarget::Player(P1)),
+            (ally, AttackTarget::Player(P1)),
+        ],
+    );
+
+    let legal = legal_attackers_for(&runner, blocker);
+    assert!(
+        legal.contains(&ayesha),
+        "with only two artifacts the gate is UNMET, so Ayesha must appear among \
+         the blocker's legal targets; got {legal:?}"
+    );
+    assert!(
+        runner.declare_blockers(&[(blocker, ayesha)]).is_ok(),
+        "CR 509.1b: two artifacts do not satisfy `three or more`, so the \
+         evasion restriction does not apply and the block is legal"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// 6. The group-share counting gap — a gate that TYPED but is still inert
+// ---------------------------------------------------------------------------
+
+/// CR 603.4 + CR 205.3m: Littjara Kinseekers' intervening-if is UNMET on a
+/// board whose largest same-creature-type group is two, so the ETB ability
+/// never goes on the stack and no +1/+1 counter is placed.
+///
+/// **This is the discriminating runtime row for the `you`-scope Branch A
+/// repair.** Both this row and its sibling below hold exactly THREE creatures
+/// once Littjara resolves, so the pre-fix inert `ObjectCount` answers 3 in
+/// both — on `main` both rows get the counter. Only the lifted
+/// `ObjectCountBySharedQuality { aggregate: Max }` tells them apart. Revert the
+/// Branch A lift and this row goes RED while its sibling stays green, which is
+/// the signature of a lift that did not land. Reverting the `defending player
+/// controls ` leaf moves neither row: Littjara's gate is `you`-scoped.
+///
+/// The arithmetic: Littjara is a changeling, so it belongs to EVERY creature
+/// type. With one Goblin and one Zombie beside it the buckets are
+/// `{Littjara, Goblin}` = 2 and `{Littjara, Zombie}` = 2, so `Max` = 2 < 3.
+///
+/// FIXTURE PROPERTY R2, changeling discharge (2): the registry is seeded from
+/// the board while Littjara is still in hand, so it holds `{Goblin, Zombie}`.
+/// The assertion is INVARIANT under any superset of that: extending the
+/// registry can only add buckets whose sole member is the changeling itself, so
+/// every added bucket has size 1 and cannot raise `Max` above 2.
+///
+/// This row does not enter combat, so `declare_attackers_and_reach_blockers`
+/// never runs and R2's seeding is this row's own obligation — see the call
+/// below.
+///
+/// Reach guards for the absence claim: `assert_zone` proves the cast actually
+/// resolved onto the battlefield, and `final_waiting_for` proves the pipeline
+/// halted on a clean priority window rather than on an unanswered prompt. Its
+/// presence sibling proves the trigger path fires at all.
+#[test]
+fn littjara_gets_no_counter_when_only_two_share_a_creature_type() {
+    let (outcome, littjara) = cast_littjara_into_board(&["Goblin", "Zombie"]);
+    outcome.assert_zone(&[littjara], Zone::Battlefield);
+    assert!(
+        matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }),
+        "the cast pipeline must halt on a clean priority window, not on an \
+         unanswered prompt; got {}",
+        outcome.final_waiting_for().variant_name()
+    );
+    outcome.assert_counters(littjara, CounterType::Plus1Plus1, 0);
+}
+
+/// PRESENCE SIBLING and reach guard for the row above (FIXTURE PROPERTY R4).
+///
+/// Same construction, same creature COUNT, one variable changed: both of
+/// Littjara's neighbours are Goblins, so the bucket `{Littjara, Goblin, Goblin}`
+/// has three members, `Max` = 3, CR 603.4's intervening-if is satisfied and the
+/// +1/+1 counter is placed.
+///
+/// Revert-discrimination: NEITHER unit. On `main` the inert count also answers
+/// 3 here, so this row is green before and after. Its job is to prove the ETB
+/// trigger path is live, so its sibling's absence claim cannot be satisfied by
+/// a trigger that never fires.
+///
+/// R2 discharge (2) again: `Max` = 3 under any superset of `{Goblin}`.
+#[test]
+fn littjara_gets_a_counter_when_three_share_a_creature_type() {
+    let (outcome, littjara) = cast_littjara_into_board(&["Goblin", "Goblin"]);
+    outcome.assert_zone(&[littjara], Zone::Battlefield);
+    assert!(
+        matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }),
+        "the cast pipeline must halt on a clean priority window, not on an \
+         unanswered prompt; got {}",
+        outcome.final_waiting_for().variant_name()
+    );
+    outcome.assert_counters(littjara, CounterType::Plus1Plus1, 1);
+}
+
+/// Shared construction for the Littjara pair: two vanilla creatures carrying
+/// `subtypes` on P0's battlefield, Littjara cast from P0's hand, and the
+/// creature-type registry seeded from the board BEFORE the cast (the registry
+/// is read when the intervening-if is evaluated).
+///
+/// The neighbours are vanilla bodies with no Oracle text, so nothing else in
+/// the fixture can trigger. `then scry 1` needs no handling: the cast driver
+/// auto-answers a scry prompt, and the library is empty anyway.
+fn cast_littjara_into_board(subtypes: &[&str; 2]) -> (CastOutcome, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    for (index, subtype) in subtypes.iter().enumerate() {
+        scenario
+            .add_creature(P0, &format!("Vanilla {index}"), 2, 2)
+            .with_subtypes(vec![subtype]);
+    }
+    // FOOT-GUN: line 1 is a KEYWORD line with reminder text. It must be
+    // supplied through `from_oracle_text_with_keywords(&["Changeling"], ..)` or
+    // it lowers to `Effect::Unimplemented` and the changeling expansion this
+    // fixture's arithmetic depends on never happens.
+    let littjara = scenario
+        .add_creature_to_hand(P0, "Littjara Kinseekers", 2, 4)
+        .from_oracle_text_with_keywords(&["Changeling"], LITTJARA_KINSEEKERS)
+        .id();
+
+    let mut runner = scenario.build();
+    // FIXTURE PROPERTY R2 — this row never reaches
+    // `declare_attackers_and_reach_blockers`, so the seeding is its own
+    // obligation. It must run BEFORE the cast: the registry is read when the
+    // intervening-if is evaluated. Littjara is still in hand here, so the
+    // registry is exactly the board's own subtypes.
+    seed_creature_types_from_board(&mut runner);
+
+    (runner.cast(littjara).resolve(), littjara)
+}
+
+/// CR 601.2f + CR 604.1: Synchronized Eviction's cost-reduction gate is UNMET
+/// on a board whose largest same-creature-type group is one, so no reduction is
+/// due, the full printed {4}{U} must be paid, and a pool holding exactly the
+/// REDUCED cost cannot pay it.
+///
+/// **This is the discriminating runtime row for the `you`-scope Branch A repair
+/// on the cost-modifying consumer**, the second of the two runtime routes the
+/// inert marker reaches (the other is Littjara's trigger intervening-if). The
+/// path is `casting::self_spell_cost_modifier_applies_before_targets` →
+/// `self_spell_cost_condition_matches` → `layers::evaluate_condition`.
+///
+/// Both this row and its sibling hold exactly TWO creatures and a
+/// byte-identical pool, so the pre-fix inert `ObjectCount` answers 2 in both and
+/// on `main` both rows are castable. Revert the Branch A lift and this row goes
+/// RED while its sibling stays green. Reverting the `defending player
+/// controls ` leaf moves neither: Synchronized Eviction is `you`-scoped.
+///
+/// Pattern precedent: `hollow_one_cost_reduction.rs`, which asserts a cost
+/// delta through `can_cast_object_now` at a tuned pool because `CastOutcome`
+/// exposes no mana-paid accessor.
+#[test]
+fn synchronized_eviction_is_not_reduced_when_creatures_share_no_type() {
+    let (runner, eviction) = build_synchronized_eviction_board(&["Goblin", "Zombie"]);
+    assert!(
+        !can_cast_object_now(runner.state(), P0, eviction),
+        "one Goblin and one Zombie share no creature type (Max = 1 < 2), so the \
+         {{2}} reduction is NOT due, the full printed {{4}}{{U}} is owed, and a \
+         three-mana pool cannot pay it. A count that ignored the shared-type \
+         constraint would answer 2, grant the reduction, and wrongly make this \
+         cast legal"
+    );
+}
+
+/// PRESENCE SIBLING and reach guard for the row above (FIXTURE PROPERTY R4).
+///
+/// Same construction, same creature COUNT, byte-identical pool, one variable
+/// changed: both creatures are Goblins, so `Max` = 2, the {2} reduction applies
+/// and {2}{U} is due — exactly the pool held.
+///
+/// This is the primary guard against a vacuous negative: it proves the entire
+/// path is live (spell in hand, printed cost set, pool funded, priority
+/// available, a legal target present), so its sibling's `false` can only be the
+/// missing reduction. Target availability is symmetric by construction —
+/// Synchronized Eviction targets a nonland permanent and both boards hold
+/// exactly two creatures — so it cannot be the variable.
+///
+/// Revert-discrimination: NEITHER unit. On `main` the inert count also answers
+/// 2 here, so this row is green before and after.
+#[test]
+fn synchronized_eviction_is_reduced_when_two_creatures_share_a_type() {
+    let (runner, eviction) = build_synchronized_eviction_board(&["Goblin", "Goblin"]);
+    assert!(
+        can_cast_object_now(runner.state(), P0, eviction),
+        "two Goblins share the Goblin creature type (Max = 2), so the {{2}} \
+         reduction applies, {{2}}{{U}} is due, and the pool holds exactly that"
+    );
+}
+
+/// Shared construction for the Synchronized Eviction pair.
+///
+/// **No lands and no other mana source on either board.** `can_cast_object_now`
+/// asks whether the cost is feasibly PAYABLE, not whether the floating pool
+/// alone covers it, so a single untapped land would make both rows castable and
+/// destroy the discrimination. The floating pool must be the only mana
+/// available — the same reason `hollow_one_cost_reduction.rs` puts no lands on
+/// its board. This is the most breakable property of this fixture.
+///
+/// The phase is `PreCombatMain` to match that precedent; Synchronized Eviction
+/// is an INSTANT, so the phase is not load-bearing for legality.
+///
+/// FIXTURE PROPERTY R2: seeded from the board before the verdict, because
+/// `filter::shared_quality_values` reads the registry when
+/// `layers::evaluate_condition` evaluates the gate. No changeling is on either
+/// board, so R2's changeling side condition does not fire and board-derived
+/// seeding is exact: extending the registry beyond `{Goblin, Zombie}` /
+/// `{Goblin}` adds only buckets no object on the board belongs to, so `Max` is
+/// unchanged under any superset.
+fn build_synchronized_eviction_board(subtypes: &[&str; 2]) -> (GameRunner, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    for (index, subtype) in subtypes.iter().enumerate() {
+        scenario
+            .add_creature(P0, &format!("Vanilla {index}"), 2, 2)
+            .with_subtypes(vec![subtype]);
+    }
+    // Both printed lines: the second is what makes it a targeted spell, and
+    // dropping it would change what the cast pipeline sees.
+    let eviction = scenario
+        .add_spell_to_hand_from_oracle(
+            P0,
+            "Synchronized Eviction",
+            /* is_instant */ true,
+            SYNCHRONIZED_EVICTION,
+        )
+        // The PRINTED cost, not a convenience cost: the reduction is what is
+        // under test, so the pre-reduction figure has to be real.
+        .with_mana_cost(ManaCost::Cost {
+            shards: vec![ManaCostShard::Blue],
+            generic: 4,
+        })
+        .id();
+    // Exactly the REDUCED cost {2}{U}, and byte-identical between the two rows.
+    // The pool is the instrument; if the two rows' pools differed the pair
+    // would prove nothing.
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Blue, eviction, false, Vec::new()),
+            ManaUnit::new(ManaType::Colorless, eviction, false, Vec::new()),
+            ManaUnit::new(ManaType::Colorless, eviction, false, Vec::new()),
+        ],
+    );
+
+    let mut runner = scenario.build();
+    seed_creature_types_from_board(&mut runner);
+    (runner, eviction)
 }


### PR DESCRIPTION
Two static-gate classes parsed to `StaticCondition::Unrecognized`, which the layer
system evaluates as `true` — so the gates were never enforced.

## What changed

**`parse_control_scope_prefix` gains a `defending player controls ` arm.** This types
the evasion gates that read the defender's board (Ayesha Tanaka, Graxiplon). The anchor
is per-attacker (CR 508.5 / CR 508.5a) and is read live at the blocking-restriction
check (CR 509.1b), not latched at declaration.

**`parse_control_count_ge_shared_quality` lifts the group-share marker off the target
filter** into `QuantityRef::ObjectCountBySharedQuality { quality, aggregate: Max }`.
The marker was inert — `evaluate_shares_quality` returns `true` unconditionally when
`reference` is `None` — so *"three or more creatures that share a creature type"* was
satisfied by **any** three creatures. This silently mis-answered two shipped cards:

- **Littjara Kinseekers** placed its +1/+1 counter without a shared type.
- **Synchronized Eviction** applied its cost reduction without one.

Both branches are scope-parameterized, and the quality noun delegates to
`parse_shared_quality` instead of hard-coding `name`.

**`parse_control_count_ge` is deliberately unchanged and no fail-open guard was added.**
Its two production callers each degrade *worse* than the inert count on a refusal — an
unconditional `ModifyCost`, and a dropped intervening-if (CR 603.4) — so refusing at the
leaf would be a regression. The refusal's corpus domain is empty.

Also corrects `CR 509.1a` to `CR 509.1b` (509.1a governs which creatures the defending
player blocks with, not the evasion restriction being asserted), and `CR 201.2` to
`CR 201.2a` on the same-name reading.

## Measured evidence

Base-vs-candidate corpus export diff, both sides generated from one **hardlinked**
`AtomicCards.json` (same inode, link count 2, digest re-verified before and after each
generation — an upstream refresh swapped the file mid-run, which a symlink would not
have survived):

```
base keys=35798  cand keys=35798
added=0  removed=0  common=35798
CHANGED=4  — ayesha tanaka, armorer / graxiplon / littjara kinseekers / synchronized eviction
positive control: inject 1 change -> detector reports 5
```

Exactly the predicted set, no unpredicted card moved. Byte accounting closes:
+176/+211/+8/+8 = 403 content bytes against a 404-byte file delta (the odd byte is a
trailing newline). Watch figures re-derived base-vs-candidate:
`ObjectCountBySharedQuality`+`InZone` 4 -> 7 (no strangers), `DefendingPlayerControls`
45 -> 45, `CantAttack`&`DefendingPlayerControls` 38 -> 38, sets identical by `comm -3`.

The committed integration fixture is untouched and verified current: `mechanized
production` and `dandân` are byte-identical base-to-candidate, so `ordering_parity_sweep`
is not asserting over a stale AST.

## Tests

13 new tests (5 parser over 8 input rows, plus 13 runtime rows in the integration file;
one existing row renamed as its assertion is inverted).

Every group-share pair holds creature **count** equal across the pair, so the pre-fix
inert count answers identically in both arms and cannot be the discriminating variable.
Revert-discrimination was measured, not derived: reverting the group-share lift turns
exactly 4 rows red; reverting the scope leaf turns exactly 6 red. Both units have
non-empty exclusive discriminator sets.

`graxiplon_can_be_blocked_when_gate_unmet` is renamed to `..._cannot_be_...` and its
assertion inverted — the old assertion encoded an honest intermediate state from #8183,
not the printed card. Oracle text re-verified against the corpus.

```
cargo test -p phase-engine --lib   ->  20227 passed; 0 failed; 6 ignored
cargo test -p phase-engine --test integration -> 5789 passed; 0 failed; 2 ignored
cargo clippy -p phase-engine --all-targets -- -D warnings -> exit 0, zero warnings
```

Follow-up (not in this PR): `parse_control_count_ge_distinct_quality` carries a
pre-existing `CR 201.2` for its *different*-names reading, which should be `CR 201.2b`.
Left untouched rather than churning a citation outside this diff.

https://claude.ai/code/session_011bmKqduE8R5LCy8umePnLX