### PR TITLE
fix(client): order opponents clockwise from viewer

### DIFF
--- a/client/src/components/hud/OpponentHud.tsx
+++ b/client/src/components/hud/OpponentHud.tsx
@@ -17,6 +17,7 @@ import { usePreferencesStore } from "../../stores/preferencesStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 import { partitionByType } from "../../viewmodel/battlefieldProps.ts";
 import {
+  getAllOpponentIds,
   getOpponentIds,
   getWaitingForClickTargetRefs,
   getWaitingForPlayerChoiceIds,
@@ -73,11 +74,10 @@ export function OpponentHud({
 
   const teamBased = gameState?.format_config?.team_based ?? false;
 
-  const allOpponents = useMemo(() => {
-    if (!gameState) return [];
-    const seatOrder = gameState.seat_order ?? gameState.players.map((p) => p.id);
-    return seatOrder.filter((id) => id !== playerId);
-  }, [gameState, playerId]);
+  const allOpponents = useMemo(
+    () => getAllOpponentIds(gameState, playerId),
+    [gameState, playerId],
+  );
 
   const eliminated = gameState?.eliminated_players ?? [];
   const liveOpponents = useMemo(() => getOpponentIds(gameState, playerId), [gameState, playerId]);

--- a/client/src/components/hud/__tests__/OpponentHud.test.tsx
+++ b/client/src/components/hud/__tests__/OpponentHud.test.tsx
@@ -88,10 +88,14 @@ describe("OpponentHud", () => {
     expect(screen.getByTitle("This player's turn is next.")).toHaveTextContent("Next Up");
   });
 
-  it("keeps multiplayer opponent tabs in stable seat order while marking next up", () => {
+  it("renders opponent tabs clockwise from a non-zero viewer, including eliminated seats", () => {
+    useMultiplayerStore.setState({ activePlayerId: 1 });
+    useUiStore.setState({ focusedOpponent: 2 });
     useGameStore.setState({
+      gameMode: "online",
       gameState: createGameState({
         seat_order: [0, 3, 1, 2],
+        eliminated_players: [0],
         derived: {
           turn_order: [
             { player: 2, slot_index: 1, turns_from_now: 1, turn_number: 2 },
@@ -105,7 +109,8 @@ describe("OpponentHud", () => {
     render(<OpponentHud />);
 
     const tabs = Array.from(document.querySelectorAll('button[data-player-hud]'));
-    expect(tabs.map((tab) => tab.getAttribute("data-player-hud"))).toEqual(["3", "1", "2"]);
+    expect(tabs.map((tab) => tab.getAttribute("data-player-hud"))).toEqual(["2", "0", "3"]);
+    expect(tabs[1]).toBeDisabled();
     expect(screen.getByTitle("This player's turn is next.")).toHaveTextContent("Next Up");
   });
 

--- a/client/src/viewmodel/__tests__/gameStateView.test.ts
+++ b/client/src/viewmodel/__tests__/gameStateView.test.ts
@@ -34,6 +34,7 @@ import {
   getBattlefieldSacrificeChoice,
   getBoardChoiceView,
   getCastableZoneViewerTarget,
+  getAllOpponentIds,
   getOpponentIds,
   getSeatCount,
   getVisibleBoardPlayerIds,
@@ -873,8 +874,12 @@ describe("getCastableZoneViewerTarget", () => {
 });
 
 describe("getOpponentIds", () => {
-  it("excludes the perspective player and eliminated players", () => {
-    expect(getOpponentIds(makeState([0, 1, 2, 3], [2]), 0)).toEqual([1, 3]);
+  it("rotates clockwise after a non-zero perspective player", () => {
+    expect(getOpponentIds(makeState([0, 3, 1, 2]), 1)).toEqual([2, 0, 3]);
+  });
+
+  it("excludes eliminated players without changing clockwise seat order", () => {
+    expect(getOpponentIds(makeState([0, 3, 1, 2], [0]), 1)).toEqual([2, 3]);
   });
 
   it("returns an empty array in a 2-player game with the opponent eliminated", () => {
@@ -882,6 +887,17 @@ describe("getOpponentIds", () => {
     // guards against — `opponents[0]` is undefined here, and the layout
     // must not index `gameState.players[undefined]`.
     expect(getOpponentIds(makeState([0, 1], [1]), 0)).toEqual([]);
+  });
+});
+
+describe("getAllOpponentIds", () => {
+  it("retains eliminated opponents in their physical clockwise seats", () => {
+    expect(getAllOpponentIds(makeState([0, 3, 1, 2], [0]), 1)).toEqual([2, 0, 3]);
+  });
+
+  it("rotates the players fallback when seat_order is absent", () => {
+    const state = buildGameStateWithoutSeatOrder({ players: buildPlayers([0, 3, 1, 2]) });
+    expect(getAllOpponentIds(state, 1)).toEqual([2, 0, 3]);
   });
 });
 

--- a/client/src/viewmodel/gameStateView.ts
+++ b/client/src/viewmodel/gameStateView.ts
@@ -28,14 +28,34 @@ export interface PlayerBattlefieldView {
   other: GroupedPermanent[];
 }
 
-export function getOpponentIds(
+/**
+ * Returns every opposing seat in fixed physical clockwise order, starting
+ * immediately after the viewer and wrapping once. Eliminated seats remain so
+ * seat-rendering UI can preserve their physical position.
+ */
+export function getAllOpponentIds(
   gameState: GameState | null,
   playerId: PlayerId,
 ): PlayerId[] {
   if (!gameState) return [];
   const seatOrder = gameState.seat_order ?? gameState.players.map((player) => player.id);
+  const viewerSeatIndex = seatOrder.indexOf(playerId);
+  if (viewerSeatIndex === -1) return seatOrder.filter((id) => id !== playerId);
+
+  return [
+    ...seatOrder.slice(viewerSeatIndex + 1),
+    ...seatOrder.slice(0, viewerSeatIndex),
+  ];
+}
+
+/** Returns live opposing seats in fixed physical clockwise order. */
+export function getOpponentIds(
+  gameState: GameState | null,
+  playerId: PlayerId,
+): PlayerId[] {
+  if (!gameState) return [];
   const eliminated = new Set(gameState.eliminated_players ?? []);
-  return seatOrder.filter((id) => id !== playerId && !eliminated.has(id));
+  return getAllOpponentIds(gameState, playerId).filter((id) => !eliminated.has(id));
 }
 
 /** Resolve the opponent tab/board focus, ignoring eliminated seats. */


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected opponent tab ordering to follow consistent clockwise seating from the viewer’s position.
  * Preserved eliminated players in their physical seat positions while disabling their tabs.
  * Improved opponent display when seat-order data is unavailable.
* **Tests**
  * Added coverage for rotated seating perspectives, eliminated players, and fallback ordering.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->