### PR TITLE
fix(engine): close delayed modal target escape

### DIFF
--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -2675,6 +2675,12 @@ fn effect_contains_event_target(effect: &Effect) -> bool {
                     .as_ref()
                     .is_some_and(target_filter_contains_event_target)
         }
+        Effect::CreateDelayedTrigger {
+            condition, effect, ..
+        } => {
+            delayed_condition_contains_event_target(condition)
+                || ability_contains_event_target(effect)
+        }
         Effect::PutCounterAll { target, .. }
         | Effect::PumpAll { target, .. }
         | Effect::DamageAll { target, .. }
@@ -2700,6 +2706,8 @@ fn demote_becomes_target_delayed_payloads(ability: &mut AbilityDefinition) {
                 "becomes_target_delayed_event_target",
                 "delayed BecomesTarget payload requires an unsupported event snapshot",
             );
+            effect.modal = None;
+            effect.mode_abilities.clear();
             effect.sub_ability = None;
             effect.else_ability = None;
         }

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -251,13 +251,69 @@ fn becomes_target_delayed_payload_fails_honestly() {
         .execute
         .as_deref()
         .expect("delayed trigger installer");
-    let Effect::CreateDelayedTrigger { effect, .. } = execute.effect.as_ref() else {
+    let Effect::CreateDelayedTrigger {
+        condition, effect, ..
+    } = execute.effect.as_ref()
+    else {
         panic!("expected CreateDelayedTrigger, got {:?}", execute.effect);
+    };
+    assert!(matches!(
+        condition,
+        DelayedTriggerCondition::WhenDies {
+            filter: TargetFilter::ParentTarget
+        }
+    ));
+    assert!(matches!(
+        effect.effect.as_ref(),
+        Effect::Unimplemented { .. }
+    ));
+}
+
+#[test]
+fn becomes_target_delayed_modal_payload_fails_honestly() {
+    let nested_delayed = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::CreateDelayedTrigger {
+            condition: DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
+            effect: Box::new(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::Destroy {
+                    target: TargetFilter::EventTarget,
+                    cant_regenerate: false,
+                },
+            )),
+            uses_tracked_set: false,
+        },
+    );
+    let modal_payload = AbilityDefinition::new(AbilityKind::Spell, Effect::NoOp).with_modal(
+        ModalChoice {
+            min_choices: 1,
+            max_choices: 1,
+            mode_count: 1,
+            ..Default::default()
+        },
+        vec![nested_delayed],
+    );
+    let mut execute = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::CreateDelayedTrigger {
+            condition: DelayedTriggerCondition::AtNextPhase { phase: Phase::End },
+            effect: Box::new(modal_payload),
+            uses_tracked_set: false,
+        },
+    );
+
+    demote_becomes_target_delayed_payloads(&mut execute);
+
+    let Effect::CreateDelayedTrigger { effect, .. } = execute.effect.as_ref() else {
+        unreachable!("constructed delayed trigger installer")
     };
     assert!(matches!(
         effect.effect.as_ref(),
         Effect::Unimplemented { .. }
     ));
+    assert!(effect.modal.is_none());
+    assert!(effect.mode_abilities.is_empty());
 }
 
 #[test]
@@ -270,9 +326,18 @@ fn becomes_target_delayed_condition_fails_honestly() {
         .execute
         .as_deref()
         .expect("delayed trigger installer");
-    let Effect::CreateDelayedTrigger { effect, .. } = execute.effect.as_ref() else {
+    let Effect::CreateDelayedTrigger {
+        condition, effect, ..
+    } = execute.effect.as_ref()
+    else {
         panic!("expected CreateDelayedTrigger, got {:?}", execute.effect);
     };
+    assert!(matches!(
+        condition,
+        DelayedTriggerCondition::WhenDies {
+            filter: TargetFilter::ParentTarget
+        }
+    ));
     assert!(matches!(
         effect.effect.as_ref(),
         Effect::Unimplemented { .. }


### PR DESCRIPTION
Follow-up to #8204.\n\nFail closed when a delayed BecomesTarget payload reaches event-bound references through nested delayed/modal branches, and add regressions for condition reachability and modal cleanup.