### PR TITLE
fix(setup): generate scryfall-sets.json during onboarding

### DIFF
--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -7,8 +7,9 @@ set -euo pipefail
 #
 #   Mode axis — what gets fetched/built:
 #     * Full mode (default): everything an interactive human dev needs to run
-#       the app in a browser, including the three Scryfall image/printing
-#       sidecars consumed at runtime by the React frontend for card art.
+#       the app in a browser, including the five Scryfall sidecars —
+#       image/printing data and the set-icon catalog — consumed at runtime by
+#       the React frontend.
 #     * Agent mode (--agent, env PHASE_SETUP_AGENT=1): skips the Scryfall
 #       sidecars. They are runtime-only image data — no Rust or frontend test
 #       depends on them (the one vitest test that names them mocks `fetch`).
@@ -125,11 +126,16 @@ else
   # the same category of artifact: runtime-only frontend image data, needed
   # only when a non-English UI language is selected.
   ./scripts/gen-scryfall-locale-images.sh  & PID_LOCALE_IMAGES=$!
+  # Set-icon catalog (icon_svg_uri + release dates) for the draft/Sealed set
+  # picker — metadata that drives set-icon images. Fetched from the small
+  # /sets endpoint, not the bulk download.
+  ./scripts/gen-scryfall-sets.sh           & PID_SETS=$!
 
   wait $PID_IMAGES        || FAIL=1
   wait $PID_TOKEN_IMAGES  || FAIL=1
   wait $PID_PRINTINGS     || FAIL=1
   wait $PID_LOCALE_IMAGES || FAIL=1
+  wait $PID_SETS          || FAIL=1
   if [ $FAIL -ne 0 ]; then
     echo "ERROR: Scryfall sidecar fetch failed." >&2
     exit 1


### PR DESCRIPTION
## Description (LLM)

SetSelector (the draft/Sealed set picker) fetches /scryfall-sets.json and parses it with res.json(). The file is gitignored and no onboarding path ever generated it: setup.sh never listed gen-scryfall-sets.sh (verified across its full git history), the Tiltfile has never mentioned Scryfall, and only CI (release.yml/deploy.yml) runs the script. With the file missing, Vite's SPA fallback serves index.html with HTTP 200, so setsResp.ok is true and json() throws "Unexpected token '<'".

Add gen-scryfall-sets.sh to setup.sh's Step 1 Scryfall sidecar batch. Step 1 has no tilt gate — it runs in both Tilt and manual modes, so this covers every setup path. Agent mode keeps skipping it: runtime-only frontend data, same contract as the other sidecars.

## Intro (Human)

Need this for Sealed on the local dev server. 😅

## Files changed

- `scripts/setup.sh`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Setup now includes set-icon metadata alongside the other Scryfall sidecars.
  * Setup downloads the set metadata helper in parallel to reduce installation time.

* **Bug Fixes**
  * Setup now properly detects and reports failures when fetching set metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->