### PR TITLE
fix(draft): keep sealed run phase and format on resume

### DIFF
--- a/client/src/stores/__tests__/draftStore.workspace.test.ts
+++ b/client/src/stores/__tests__/draftStore.workspace.test.ts
@@ -44,7 +44,14 @@ const persistence = vi.hoisted(() => ({
   inspectActiveQuickDraftLifecycle: vi.fn<() => Promise<unknown>>(async () => null),
   loadDraftRun: vi.fn<() => Promise<unknown>>(async () => null),
   loadQuickDraftSession: vi.fn<() => Promise<unknown>>(async () => null),
-  persistQuickDraftSnapshot: vi.fn(async () => undefined),
+  persistQuickDraftSnapshot: vi.fn<
+    (
+      id: string,
+      sessionJson: string,
+      uiState: unknown,
+      meta: { runFormat?: string; phase?: string },
+    ) => Promise<void>
+  >(async () => undefined),
   publishInitialDraftMatch: vi.fn<(input: { run: unknown }) => Promise<void>>(
     async () => undefined,
   ),
@@ -600,6 +607,184 @@ describe("draft store workspace authority", () => {
       useDraftStore.getState().workspaceState!,
       useDraftStore.getState().view!.pool,
     )).toEqual(["Returned"]);
+  });
+
+  it.each([
+    {
+      label: "Sealed run between games (session Pairing, run in progress)",
+      kind: "Sealed",
+      persistedPhase: "playing",
+      sessionStatus: "Pairing",
+      expectedPhase: "playing",
+      fetchDatabase: true,
+    },
+    {
+      label: "Sealed run finished (session Pairing, run complete)",
+      kind: "Sealed",
+      persistedPhase: "complete",
+      sessionStatus: "Pairing",
+      expectedPhase: "complete",
+      fetchDatabase: true,
+    },
+    {
+      label: "Quick run between games (session Complete, run in progress)",
+      kind: "Quick",
+      persistedPhase: "playing",
+      sessionStatus: "Complete",
+      expectedPhase: "playing",
+      fetchDatabase: false,
+    },
+    {
+      label: "Quick run finished (session Complete, run complete)",
+      kind: "Quick",
+      persistedPhase: "complete",
+      sessionStatus: "Complete",
+      expectedPhase: "complete",
+      fetchDatabase: false,
+    },
+  ])("resume keeps the run phase: $label", async ({
+    kind,
+    persistedPhase,
+    sessionStatus,
+    expectedPhase,
+    fetchDatabase,
+  }) => {
+    if (fetchDatabase) {
+      vi.stubGlobal("fetch", vi.fn(async () => ({ text: async () => "database" })));
+    }
+    persistence.inspectActiveQuickDraftLifecycle.mockResolvedValue({
+      id: "run-id",
+      setCode: "TST",
+      setName: "Test",
+      difficulty: 2,
+      kind,
+      phase: persistedPhase,
+      runFormat: "run",
+      runWins: persistedPhase === "complete" ? 7 : 1,
+      runLosses: persistedPhase === "complete" ? 3 : 0,
+      runDraws: 0,
+    });
+    persistence.loadQuickDraftSession.mockResolvedValue({
+      sessionJson: "session",
+      mainDeck: ["C1", "C2"],
+      landCounts: {},
+      poolSortMode: "color",
+      poolPanelOpen: true,
+      workspace: null,
+    });
+    persistence.loadDraftRun.mockResolvedValue({
+      format: "run",
+      results: persistedPhase === "complete"
+        ? [
+          { gameId: "g1", result: "win" }, { gameId: "g2", result: "win" },
+          { gameId: "g3", result: "win" }, { gameId: "g4", result: "win" },
+          { gameId: "g5", result: "win" }, { gameId: "g6", result: "win" },
+          { gameId: "g7", result: "win" },
+        ]
+        : [{ gameId: "g1", result: "win" }],
+      playerDeck: ["C1", "C2"],
+      opponentDeck: ["O1", "O2"],
+      usedBotSeats: [1],
+    });
+    wasm.import_draft_session.mockReturnValue({
+      ...view([card("c1", "C1"), card("c2", "C2")]),
+      kind,
+      status: sessionStatus,
+    });
+
+    await useDraftStore.getState().resumeDraft();
+
+    expect(useDraftStore.getState().phase).toBe(expectedPhase);
+    // A Sealed run launched as Full Run must resume as Full Run, not fall
+    // back to the event's single-match default — next-match staging compares
+    // the store format against the persisted run's format.
+    expect(useDraftStore.getState().runFormat).toBe("run");
+    expect(useDraftStore.getState().runState?.format).toBe("run");
+  });
+
+  it("resume before a Sealed run's first match keeps launching with the remembered format", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ text: async () => "database" })));
+    persistence.inspectActiveQuickDraftLifecycle.mockResolvedValue({
+      id: "sealed-pre-run-id",
+      setCode: "TST",
+      setName: "Test",
+      difficulty: 2,
+      kind: "Sealed",
+      phase: "launching",
+      runFormat: "run", // user already picked Full Run on the format picker
+    });
+    persistence.loadQuickDraftSession.mockResolvedValue({
+      sessionJson: "session",
+      mainDeck: ["C1", "C2"],
+      landCounts: { Plains: 2 },
+      poolSortMode: "color",
+      poolPanelOpen: true,
+      workspace: null,
+    });
+    persistence.loadDraftRun.mockResolvedValue(null);
+    wasm.import_draft_session.mockReturnValue({
+      ...view([card("c1", "C1"), card("c2", "C2")]),
+      kind: "Sealed",
+      status: "Pairing",
+    });
+
+    await useDraftStore.getState().resumeDraft();
+
+    expect(useDraftStore.getState().phase).toBe("launching");
+    expect(useDraftStore.getState().runFormat).toBe("run");
+    expect(useDraftStore.getState().runState).toBeNull();
+  });
+
+  it("persists a nondefault format picker choice before the first match and restores it on resume", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ text: async () => "database" })));
+    const poolView = {
+      ...view([card("c1", "C1"), card("c2", "C2")]),
+      kind: "Sealed" as const,
+      status: "Deckbuilding" as const,
+    };
+    wasm.start_sealed_draft.mockReturnValue(poolView);
+    await useDraftStore.getState().startSealedDraft("pool", "TST", "Test", 2);
+    useDraftStore.getState().completeSealedOpening();
+    wasm.submit_deck.mockReturnValue({ ...poolView, status: "Pairing" });
+    await useDraftStore.getState().submitDeck();
+    expect(useDraftStore.getState().phase).toBe("launching");
+    expect(useDraftStore.getState().runFormat).toBe("single");
+    const metaOf = (): { runFormat?: string; phase?: string } | null => {
+      const calls = persistence.persistQuickDraftSnapshot.mock.calls;
+      return calls.length > 0 ? calls[calls.length - 1][3] : null;
+    };
+
+    await settleTimers();
+    // Deck submission persisted the Sealed default (Single Match).
+    expect(metaOf()?.runFormat).toBe("single");
+
+    // Choosing Full Run on the picker must persist: the run record only
+    // appears at Start Match, so the persisted meta is the sole pre-run
+    // resume authority. Without the schedule, the last meta stays "single".
+    useDraftStore.getState().setRunFormat("run");
+    await settleTimers();
+    expect(metaOf()?.runFormat).toBe("run");
+
+    // Reload before a run exists — the resumed picker must show the choice.
+    persistence.inspectActiveQuickDraftLifecycle.mockResolvedValue(
+      metaOf(),
+    );
+    persistence.loadQuickDraftSession.mockResolvedValue({
+      sessionJson: "session",
+      mainDeck: ["C1", "C2"],
+      landCounts: {},
+      poolSortMode: "color",
+      poolPanelOpen: true,
+      workspace: null,
+    });
+    persistence.loadDraftRun.mockResolvedValue(null);
+    wasm.import_draft_session.mockReturnValue({ ...poolView, status: "Pairing" });
+
+    await useDraftStore.getState().resumeDraft();
+
+    expect(useDraftStore.getState().phase).toBe("launching");
+    expect(useDraftStore.getState().runFormat).toBe("run");
+    expect(useDraftStore.getState().runState).toBeNull();
   });
 
   it.each([

--- a/client/src/stores/__tests__/draftStore.workspace.test.ts
+++ b/client/src/stores/__tests__/draftStore.workspace.test.ts
@@ -57,7 +57,9 @@ const persistence = vi.hoisted(() => ({
   ),
   publishStagedDraftMatch: vi.fn(async () => undefined),
   recordDraftMatchResult: vi.fn(async () => null),
-  runLimits: vi.fn(() => ({ maxWins: 1, maxLosses: 1 })),
+  runLimits: vi.fn((format: string) => (
+    format === "run" ? { maxWins: 7, maxLosses: 3 } : { maxWins: 1, maxLosses: 1 }
+  )),
 }));
 
 vi.mock("@wasm/draft", () => wasm);
@@ -785,6 +787,101 @@ describe("draft store workspace authority", () => {
     expect(useDraftStore.getState().phase).toBe("launching");
     expect(useDraftStore.getState().runFormat).toBe("run");
     expect(useDraftStore.getState().runState).toBeNull();
+  });
+
+  it("resumes an interrupted first-match launch from the durable run (stale launching meta)", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ text: async () => "database" })));
+    // Crash between publishInitialDraftMatch's run write and meta write:
+    // meta still says "launching", but the durable run is committed with an
+    // active staged match. Resume must show Between Matches, not the picker.
+    persistence.inspectActiveQuickDraftLifecycle.mockResolvedValueOnce({
+      id: "interrupted-launch-id",
+      setCode: "TST",
+      setName: "Test",
+      difficulty: 2,
+      kind: "Sealed",
+      phase: "launching",
+      runFormat: "run",
+    });
+    persistence.loadQuickDraftSession.mockResolvedValueOnce({
+      sessionJson: "session",
+      mainDeck: ["C1", "C2"],
+      landCounts: {},
+      poolSortMode: "color",
+      poolPanelOpen: true,
+      workspace: null,
+    });
+    persistence.loadDraftRun.mockResolvedValueOnce({
+      format: "run",
+      results: [],
+      playerDeck: ["C1", "C2"],
+      opponentDeck: ["O1", "O2"],
+      usedBotSeats: [1],
+      activeMatch: {
+        draftId: "interrupted-launch-id",
+        gameId: "g1",
+        format: "run",
+        resultCountAtLaunch: 0,
+        botSeat: 1,
+        opponentDeck: ["O1", "O2"],
+      },
+    });
+    wasm.import_draft_session.mockReturnValue({
+      ...view([card("c1", "C1"), card("c2", "C2")]),
+      kind: "Sealed",
+      status: "Pairing",
+    });
+
+    await useDraftStore.getState().resumeDraft();
+
+    expect(useDraftStore.getState().phase).toBe("playing");
+    expect(useDraftStore.getState().runState?.activeMatch?.gameId).toBe("g1");
+  });
+
+  it("resumes a terminal run as complete (stale playing meta)", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ text: async () => "database" })));
+    // Crash between recordDraftMatchResult's run write and meta write: meta
+    // still says "playing", but the durable run has hit the 3-loss limit.
+    // Resume must show RunComplete — Between Matches would reject Next Match.
+    persistence.inspectActiveQuickDraftLifecycle.mockResolvedValueOnce({
+      id: "interrupted-result-id",
+      setCode: "TST",
+      setName: "Test",
+      difficulty: 2,
+      kind: "Sealed",
+      phase: "playing",
+      runFormat: "run",
+    });
+    persistence.loadQuickDraftSession.mockResolvedValueOnce({
+      sessionJson: "session",
+      mainDeck: ["C1", "C2"],
+      landCounts: {},
+      poolSortMode: "color",
+      poolPanelOpen: true,
+      workspace: null,
+    });
+    persistence.loadDraftRun.mockResolvedValueOnce({
+      format: "run",
+      results: [
+        { gameId: "g1", result: "loss" },
+        { gameId: "g2", result: "loss" },
+        { gameId: "g3", result: "loss" },
+      ],
+      playerDeck: ["C1", "C2"],
+      opponentDeck: ["O1", "O2"],
+      usedBotSeats: [1],
+      activeMatch: undefined,
+    });
+    wasm.import_draft_session.mockReturnValue({
+      ...view([card("c1", "C1"), card("c2", "C2")]),
+      kind: "Sealed",
+      status: "Pairing",
+    });
+
+    await useDraftStore.getState().resumeDraft();
+
+    expect(useDraftStore.getState().phase).toBe("complete");
+    expect(useDraftStore.getState().runState?.results).toHaveLength(3);
   });
 
   it.each([

--- a/client/src/stores/__tests__/draftStore.workspace.test.ts
+++ b/client/src/stores/__tests__/draftStore.workspace.test.ts
@@ -12,6 +12,11 @@ import {
   MAX_MATERIALIZED_VIRTUAL_BASICS,
   migrateLegacyWorkspace,
 } from "../../components/draft/workspace/workspaceMigration";
+import type {
+  ActiveQuickDraftMeta,
+  DraftMatchResult,
+  DraftRunState,
+} from "../../services/quickDraftPersistence";
 import {
   createDraftWorkspaceState,
   makeInteractiveVirtualBasicInstanceId,
@@ -56,7 +61,14 @@ const persistence = vi.hoisted(() => ({
     async () => undefined,
   ),
   publishStagedDraftMatch: vi.fn(async () => undefined),
-  recordDraftMatchResult: vi.fn(async () => null),
+  recordDraftMatchResult: vi.fn<
+    (input: {
+      draftId: string;
+      gameId: string;
+      result: DraftMatchResult;
+      makeMeta: (run: DraftRunState) => ActiveQuickDraftMeta;
+    }) => Promise<{ run: DraftRunState; meta: ActiveQuickDraftMeta } | null>
+  >(async () => null),
   runLimits: vi.fn((format: string) => (
     format === "run" ? { maxWins: 7, maxLosses: 3 } : { maxWins: 1, maxLosses: 1 }
   )),
@@ -882,6 +894,85 @@ describe("draft store workspace authority", () => {
 
     expect(useDraftStore.getState().phase).toBe("complete");
     expect(useDraftStore.getState().runState?.results).toHaveLength(3);
+  });
+
+  it("records a resumed run's result with legacy metadata lacking runFormat", async () => {
+    vi.stubGlobal("fetch", vi.fn(async () => ({ text: async () => "database" })));
+    // ActiveQuickDraftMeta deliberately permits an absent runFormat (legacy
+    // metadata shape). Resume restores the format from the durable run —
+    // result recording must not gate out on the absent meta field and drop
+    // the match, and the replacement metadata must learn the run's format so
+    // a later recording is not dropped the same way.
+    persistence.inspectActiveQuickDraftLifecycle.mockResolvedValue({
+      id: "legacy-meta-id",
+      setCode: "TST",
+      setName: "Test",
+      difficulty: 2,
+      kind: "Sealed",
+      phase: "playing",
+      // no runFormat field — legacy shape
+    });
+    persistence.loadQuickDraftSession.mockResolvedValueOnce({
+      sessionJson: "session",
+      mainDeck: ["C1", "C2"],
+      landCounts: {},
+      poolSortMode: "color",
+      poolPanelOpen: true,
+      workspace: null,
+    });
+    persistence.loadDraftRun.mockResolvedValueOnce({
+      format: "run",
+      results: [{ gameId: "g1", result: "win" }],
+      playerDeck: ["C1", "C2"],
+      opponentDeck: ["O1", "O2"],
+      usedBotSeats: [1],
+      activeMatch: undefined,
+    });
+    wasm.import_draft_session.mockReturnValue({
+      ...view([card("c1", "C1"), card("c2", "C2")]),
+      kind: "Sealed",
+      status: "Pairing",
+    });
+
+    await useDraftStore.getState().resumeDraft();
+    expect(useDraftStore.getState().phase).toBe("playing");
+    expect(useDraftStore.getState().runFormat).toBe("run");
+
+    const recorded: Array<{
+      gameId: string;
+      result: DraftMatchResult;
+      metaRunFormat?: string;
+      metaPhase?: string;
+    }> = [];
+    persistence.recordDraftMatchResult.mockImplementation(async (input) => {
+      const nextRun: DraftRunState = {
+        format: "run",
+        results: [{ gameId: input.gameId, result: input.result }],
+        playerDeck: ["C1", "C2"],
+        opponentDeck: ["O1", "O2"],
+        usedBotSeats: [1],
+      };
+      const meta = input.makeMeta(nextRun);
+      recorded.push({
+        gameId: input.gameId,
+        result: input.result,
+        metaRunFormat: meta.runFormat,
+        metaPhase: meta.phase,
+      });
+      return { run: nextRun, meta };
+    });
+
+    await useDraftStore.getState().recordMatchResult("g2", "win");
+
+    // The result reached the durable writer at all (not gated out), and the
+    // replacement metadata carries the run's format for future recordings.
+    expect(recorded).toHaveLength(1);
+    expect(recorded[0]?.gameId).toBe("g2");
+    expect(recorded[0]?.result).toBe("win");
+    expect(recorded[0]?.metaRunFormat).toBe("run");
+    expect(recorded[0]?.metaPhase).toBe("playing");
+    expect(useDraftStore.getState().runState?.results).toHaveLength(1);
+    expect(useDraftStore.getState().phase).toBe("playing");
   });
 
   it.each([

--- a/client/src/stores/draftStore.ts
+++ b/client/src/stores/draftStore.ts
@@ -1285,7 +1285,7 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()((set,
 
   recordMatchResult: async (gameId, result) => {
     const meta = await inspectActiveQuickDraftLifecycle("inspect");
-    if (!meta?.runFormat) return;
+    if (!meta) return;
     const persisted = await recordDraftMatchResult({
       draftId: meta.id,
       gameId,
@@ -1296,6 +1296,11 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()((set,
         const draws = run.results.filter((entry) => entry.result === "draw").length;
         return {
           ...meta,
+          // Legacy metadata may predate the runFormat field; the durable run
+          // is the only authoritative source for it. Without this, a later
+          // recordMatchResult would gate out on the absent field and drop
+          // the next match's result too.
+          runFormat: run.format,
           phase: draftRunPhase(run),
           updatedAt: Date.now(),
           runWins: wins,

--- a/client/src/stores/draftStore.ts
+++ b/client/src/stores/draftStore.ts
@@ -338,6 +338,22 @@ function phaseForView(view: DraftPlayerView, persistedPhase: DraftPhase): DraftP
   return view.status === "Pairing" ? "launching" : persistedPhase;
 }
 
+/** The run phase the durable record dictates: `complete` once the run hits its
+ * win/loss limits, otherwise `playing`. Single authority for run terminality —
+ * recordMatchResult's meta, launchNextMatch's guard, and resumeDraft all read
+ * this. The run is authoritative over the persisted metadata: the run and the
+ * meta are written as separate operations (publishInitialDraftMatch /
+ * recordDraftMatchResult save the run before the meta), so a crash between
+ * them leaves stale metadata that resume must not trust. Mirrors CR-adjacent
+ * ladder semantics (7 wins / 3 losses) owned by `runLimits` in
+ * quickDraftPersistence. */
+function draftRunPhase(run: DraftRunState): "playing" | "complete" {
+  const limits = runLimits(run.format);
+  const wins = run.results.filter((entry) => entry.result === "win").length;
+  const losses = run.results.filter((entry) => entry.result === "loss").length;
+  return wins >= limits.maxWins || losses >= limits.maxLosses ? "complete" : "playing";
+}
+
 type WorkspaceInstallPatch = Partial<Omit<
   DraftStoreState,
   | "view"
@@ -903,6 +919,13 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()((set,
         return lease.importSession(saved.sessionJson, meta.difficulty);
       });
       if (lifecycle !== lifecycleGeneration) return;
+      // The durable run is authoritative for run phases: the run and the meta
+      // are persisted as separate writes (publishInitialDraftMatch /
+      // recordDraftMatchResult save the run first), so a crash between them
+      // leaves the meta stale — it may still say "launching" for an already
+      // active run, or "playing" for a terminal one. The run's results vs its
+      // limits decide; the meta's phase only matters before a run exists.
+      const resumedPhase: DraftPhase = run ? draftRunPhase(run) : meta.phase;
       installWorkspace({
         kind: "state",
         authoritativeView: view,
@@ -910,7 +933,7 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()((set,
         patch: {
           draftId: meta.id,
           adapter,
-          phase: phaseForView(view, meta.phase),
+          phase: phaseForView(view, resumedPhase),
           difficulty: meta.difficulty,
           selectedSet: meta.setCode,
           selectedSetName: meta.setName ?? null,
@@ -1271,10 +1294,9 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()((set,
         const wins = run.results.filter((entry) => entry.result === "win").length;
         const losses = run.results.filter((entry) => entry.result === "loss").length;
         const draws = run.results.filter((entry) => entry.result === "draw").length;
-        const limits = runLimits(run.format);
         return {
           ...meta,
-          phase: wins >= limits.maxWins || losses >= limits.maxLosses ? "complete" : "playing",
+          phase: draftRunPhase(run),
           updatedAt: Date.now(),
           runWins: wins,
           runLosses: losses,
@@ -1302,10 +1324,7 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()((set,
       const durableRun = await loadDraftRun(state.draftId);
       if (!durableRun) throw new Error("Missing durable draft run");
       const playerDeck = projectDeckNames(state.workspaceState, state.view.pool);
-      const limits = runLimits(durableRun.format);
-      const wins = durableRun.results.filter((entry) => entry.result === "win").length;
-      const losses = durableRun.results.filter((entry) => entry.result === "loss").length;
-      if (wins >= limits.maxWins || losses >= limits.maxLosses) throw new Error("Draft run is complete");
+      if (draftRunPhase(durableRun) === "complete") throw new Error("Draft run is complete");
       let run = durableRun;
       let saveRun = false;
       if (durableRun.activeMatch) {

--- a/client/src/stores/draftStore.ts
+++ b/client/src/stores/draftStore.ts
@@ -325,6 +325,13 @@ function makeMeta(state: DraftStoreState, phase: ActiveQuickDraftMeta["phase"], 
 }
 
 function phaseForView(view: DraftPlayerView, persistedPhase: DraftPhase): DraftPhase {
+  // Run phases are owned by the run record, not the draft session's pairing
+  // status. A Sealed session sits idle in `Pairing` once its deck is in, so
+  // resuming BETWEEN run games (or after the last game) must keep the run
+  // phase (`playing` → BetweenMatches, `complete` → RunComplete) — mapping
+  // `Pairing` to `launching` there bounces the player back to the format
+  // picker mid-run.
+  if (persistedPhase === "playing" || persistedPhase === "complete") return persistedPhase;
   if (view.status === "Deckbuilding") {
     return view.kind === "Sealed" && persistedPhase === "opening" ? "opening" : "deckbuilding";
   }
@@ -913,7 +920,11 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()((set,
           pickInteractionLocked: false,
           poolSortMode: saved.poolSortMode,
           poolPanelOpen: saved.poolPanelOpen,
-          runFormat: meta.kind === "Sealed" ? "single" : run?.format ?? "run",
+          // The persisted run's format is authoritative once a run exists — a
+          // Sealed run may be a 7W/3L ladder even though the event's picker
+          // default is a single match. Before the first match there is no run,
+          // so fall back to the meta's remembered choice, then the kind default.
+          runFormat: run?.format ?? meta.runFormat ?? (meta.kind === "Sealed" ? "single" : "run"),
           runState: run,
         },
         persistence: "skip",
@@ -1158,7 +1169,10 @@ export const useDraftStore = create<DraftStoreState & DraftStoreActions>()((set,
   togglePoolPanel: () => { set((state) => ({ poolPanelOpen: !state.poolPanelOpen })); schedulePersistence(); },
   setDifficulty: (difficulty) => set({ difficulty }),
   setSelectedSet: (selectedSet) => set({ selectedSet }),
-  setRunFormat: (runFormat) => set({ runFormat }),
+  // The picker selection is the resume authority before the first match (the
+  // run record only appears at launch), so persist it — otherwise reloading on
+  // the launching screen restores the stale default. Mirrors setPoolSortMode.
+  setRunFormat: (runFormat) => { set({ runFormat }); schedulePersistence(); },
 
   launchMatch: async (navigate) => {
     const token = admitExclusive("launch");


### PR DESCRIPTION
## Summary

Fixes Sealed (and pre-run Draft) Full Run resume: winning a match sent the browser back to `/draft/quick?resume=1`, but the restore path rebuilt the format picker screen (with a broken Start Match) instead of the between-matches screen. Two `resumeDraft` restore defects — the engine's restored Sealed session reports `Pairing` (a solo Sealed draft uses `PostDraftPlay::TournamentPairings`, unlike Quick's `Complete`), so `phaseForView` incorrectly remapped the run phases `playing`/`complete` to `launching`; and the run format was forced back to `single` for any Sealed kind, discarding the Full Run choice.

## Files changed

- `client/src/stores/draftStore.ts` — `phaseForView` keeps run-owned phases (`playing`/`complete`) unchanged; `resumeDraft` restores `runFormat` as `run.format` → `meta.runFormat` → kind default
- `client/src/stores/__tests__/draftStore.workspace.test.ts` — resume regression tests: Sealed/Quick × both run phases, plus pre-first-match Sealed launching resume

## Track

Developer

## LLM

Model: deepseek-v4-flash-0731
Tier: frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — frontend-only change (`client/src/stores/`); no `crates/engine/` parser, effects, resolver, targeting, or rules behavior touched. The draft-core session status facts are read, not modified.

## CR references

None — no rules-bearing engine code added or touched (the resume flow is client state orchestration).

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `tsc -b --noEmit` — 0 errors (clean on committed head `c8e2413d6`)
- `eslint .` — 0 errors; 41 warnings, all pre-existing in untouched files, none in the changed files
- `vitest run src/stores/__tests__/draftStore.workspace.test.ts` — 63/63 passed
- `vitest run src/services/__tests__/quickDraftPersistence.test.ts` — 6/6 passed
- `vitest run src/pages/__tests__/DraftLandingPage.test.tsx` — 4/4 passed
- `vitest run --config vitest.integration.config.ts` — 4 files, 19/19 passed
- Pre-commit gates (parser combinator, router grant, PreLowered ratchet) — passed on both commits
- Manual browser click-through of a Sealed Full Run (win → Continue Run → between-matches) — confirmed by user

## Gate A

Gate A PASS head=c8e2413d68765d01b6a43fd1dc1ec7fe768d73ca base=e78ee3703e0ea68d09cc84c54b8e862782494b3a

## Anchored on

- client/src/stores/draftStore.ts:1158 — `submitDeck` maps the engine `view.status` to `launching` (pre-run), the same store seam whose `phaseForView` generalization must not swallow run phases
- client/src/stores/draftStore.ts:1251 / 1350 — `launchMatch`/`launchNextMatch` set `phase: "playing"` with `runState`: the single authority that run phases belong to the run record, which resume now preserves

## Final review-impl

Final review-impl PASS head=c8e2413d68765d01b6a43fd1dc1ec7fe768d73ca

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resuming an in-progress or completed run now preserves its correct phase instead of returning to format selection.
  * Resumed drafts retain the selected run format, including Full Run.
  * Improved resume behavior before the first match and between run games.
  * Run format selections now persist when made before a run begins.
  * Run completion status now reflects recorded win and loss totals.
  * Match results are no longer lost when resuming runs with legacy saved metadata.

* **Tests**
  * Added coverage for restoring runs across completed, in-progress, and pre-match states, including legacy metadata.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->