### PR TITLE
fix(client): pin the vite dev port so it cannot drift

### DIFF
--- a/client/src/config/__tests__/devServerPort.test.ts
+++ b/client/src/config/__tests__/devServerPort.test.ts
@@ -1,0 +1,143 @@
+// @vitest-environment node
+import { mkdtempSync, readFileSync, rmSync } from "node:fs";
+import { createServer as createTcpServer, type AddressInfo } from "node:net";
+import { tmpdir } from "node:os";
+import path from "node:path";
+
+import { createServer, loadConfigFromFile, resolveConfig } from "vite";
+import { afterAll, describe, expect, it } from "vitest";
+
+/**
+ * Scope: the occurrences of the port that a process resolves at runtime — the
+ * vite config, tauri.conf.json's devUrl, the Caddyfile upstreams, the Tiltfile
+ * link. Prose mentions of the literal are out of scope.
+ */
+const DEV_PORT = 5173;
+const REPO = path.resolve(__dirname, "../../../..");
+const CLIENT = path.join(REPO, "client");
+
+// Isolated so the harness never writes into the cache dir a live `pnpm dev`
+// owns: createServer({configFile:false, root:CLIENT}) otherwise resolves
+// cacheDir to client/node_modules/.vite and orphans a deps_temp_* dir per run.
+const CACHE = mkdtempSync(path.join(tmpdir(), "vite-devport-"));
+afterAll(() => rmSync(CACHE, { recursive: true, force: true }));
+
+/** The `server` options this repo's config *declares*. */
+async function repoServerOptions() {
+  const loaded = await loadConfigFromFile(
+    { command: "serve", mode: "development" },
+    path.join(CLIENT, "vite.config.ts"),
+    CLIENT,
+    "silent",
+  );
+  if (!loaded) throw new Error("vite.config.ts did not load");
+  return loaded.config.server ?? {};
+}
+
+function boundPort(address: string | AddressInfo | null | undefined): number {
+  if (address === null || address === undefined || typeof address === "string") {
+    throw new Error(`expected a TCP address, got ${String(address)}`);
+  }
+  return address.port;
+}
+
+function occupyEphemeralPort(): Promise<{ close: () => Promise<void>; port: number }> {
+  return new Promise((resolve, reject) => {
+    const held = createTcpServer();
+    held.on("error", reject);
+    held.listen(0, "127.0.0.1", () => {
+      resolve({
+        close: () => new Promise<void>((done) => held.close(() => done())),
+        port: boundPort(held.address()),
+      });
+    });
+  });
+}
+
+/** Resolves to the bound port, or rejects the way vite rejects. */
+async function startVite(port: number, strictPort: boolean | undefined): Promise<number> {
+  const dev = await createServer({
+    configFile: false,
+    root: CLIENT,
+    cacheDir: CACHE,
+    logLevel: "silent",
+    server: { port, strictPort, host: "127.0.0.1" },
+  });
+  try {
+    await dev.listen();
+    return boundPort(dev.httpServer?.address());
+  } finally {
+    await dev.close();
+  }
+}
+
+describe("dev server port", () => {
+  it("declares the pinned port and refuses to drift", async () => {
+    const server = await repoServerOptions();
+    // Reach guard, first: allowedHosts is a value this config owns, so it is
+    // what separates "read our config" from "read nothing". The port readings
+    // cannot do that job — 5173 is also vite's own default.
+    expect(server.allowedHosts).toContain("local.phase-rs.dev");
+    expect(server.port).toBe(DEV_PORT);
+    expect(server.strictPort).toBe(true);
+
+    // What `pnpm dev` actually runs on: every plugin config() hook applied,
+    // which loadConfigFromFile runs none of.
+    const resolved = await resolveConfig(
+      { root: CLIENT, cacheDir: CACHE, logLevel: "silent" },
+      "serve",
+      "development",
+    );
+    expect(resolved.server.allowedHosts).toContain("local.phase-rs.dev");
+    expect(resolved.server.strictPort).toBe(true);
+    // Catches a plugin config() hook moving the port out from under the pin,
+    // which the declared reading above is blind to.
+    expect(resolved.server.port).toBe(DEV_PORT);
+  });
+
+  it(
+    "refuses the pinned port when taken, and would drift without strictPort",
+    { timeout: 20_000 },
+    async () => {
+      const { strictPort } = await repoServerOptions();
+      // Ephemeral, never 5173: this must not depend on 5173 being free, nor
+      // steal it from a developer's running `pnpm dev`.
+      const taken = await occupyEphemeralPort();
+      try {
+        await expect(startVite(taken.port, strictPort)).rejects.toThrow(/already in use/);
+        // Paired positive control: same harness, same contended port,
+        // strictPort off. Proves the refusal is decided by our config value and
+        // not by an unrelated startup failure that would reject either way.
+        expect(await startVite(taken.port, false)).toBeGreaterThan(taken.port);
+      } finally {
+        await taken.close();
+      }
+    },
+  );
+
+  it("agrees with the Tauri devUrl", () => {
+    const conf = JSON.parse(
+      readFileSync(path.join(REPO, "client/src-tauri/tauri.conf.json"), "utf8"),
+    ) as { build?: { devUrl?: string } };
+    expect(conf.build?.devUrl).toBeDefined();
+    expect(new URL(String(conf.build?.devUrl)).port).toBe(String(DEV_PORT));
+  });
+
+  it("agrees with the Caddy and Tilt upstreams", () => {
+    const proxies = [
+      ...readFileSync(path.join(REPO, "Caddyfile"), "utf8").matchAll(
+        /reverse_proxy localhost:(\d+)/g,
+      ),
+    ];
+    expect(proxies.length).toBeGreaterThan(0);
+    for (const [, port] of proxies) expect(port).toBe(String(DEV_PORT));
+
+    const tiltPorts = [
+      ...readFileSync(path.join(REPO, "Tiltfile"), "utf8").matchAll(/links\s*=\s*\[([^\]]*)\]/g),
+    ].flatMap((m) => [...m[1].matchAll(/http:\/\/localhost:(\d+)/g)].map((p) => p[1]));
+    expect(tiltPorts.length).toBeGreaterThan(0);
+    // Membership, not every-capture: the Tiltfile legitimately links several
+    // services, while every Caddy upstream is this one server.
+    expect(tiltPorts).toContain(String(DEV_PORT));
+  });
+});

--- a/client/vite.config.ts
+++ b/client/vite.config.ts
@@ -461,6 +461,16 @@ export default defineConfig(({ mode }) => ({
   // hit Caddy rather than the bare :5173 dev server. Both are gated on a
   // hostname presence check so plain `pnpm dev` on localhost still works.
   server: {
+    // Every consumer of this dev server pins :5173 as a literal it cannot
+    // re-resolve — tauri.conf.json's `devUrl`, the Caddyfile's reverse_proxy
+    // upstreams, the Tiltfile's link. `strictPort` is the enforcement: vite
+    // defaults it to false and on EADDRINUSE drifts to ++port, announced only
+    // by an info line that scrolls past inside `tauri dev`, leaving the shell
+    // on a dead URL painting a blank white document. `port` declares the pin;
+    // `strictPort` is what holds it. `vite preview` inherits strictPort from
+    // here (its own port stays 4173), so `pnpm preview` refuses.
+    port: 5173,
+    strictPort: true,
     allowedHosts: ["local.phase-rs.dev", ".local.phase-rs.dev"],
     hmr: process.env.CADDY_PROXY === "1"
       ? { protocol: "wss", host: "local.phase-rs.dev", clientPort: 443 }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

The Tauri dev shell can boot to a blank white window. `vite.config.ts` declared no `strictPort`, so when 5173 is taken vite logs one info line and then listens on `++port` instead, while `tauri.conf.json`'s `devUrl` pins `http://localhost:5173` and never re-resolves — leaving the webview on a dead URL. The drift is announced in vite's own output but invisible where it lands: that line scrolls past inside `tauri dev`'s `beforeDevCommand` log, nowhere near the blank window it explains. Setting `strictPort` makes the conflict a startup failure that names the port instead.

## Files changed

- `client/vite.config.ts` — add `port: 5173` + `strictPort: true` to the existing `server:` block
- `client/src/config/__tests__/devServerPort.test.ts` — new test

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

None — no MTG game rule is implemented, enforced, or referenced. This is dev-server build configuration.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

Run in a clean detached worktree at the committed head, not against the working tree:

- `pnpm exec vitest run` — Test Files 423 passed | 2 skipped (425); exit 0
- `pnpm run type-check` — exit 0
- `pnpm exec tsc -b --noEmit --force` — exit 0 (non-incremental, so not a cached vacuous pass)
- `pnpm lint` — 43 problems (0 errors, 43 warnings); exit 0. Byte-identical to the pre-change baseline measured on the same worktree, so no warning is introduced here.
- `pnpm exec vitest run src/config/__tests__/devServerPort.test.ts` — 4 passed; `environment 0ms`, confirming the `// @vitest-environment node` docblock took effect

Non-vacuity, measured rather than asserted — the shipped test was run against this commit's parent, with `client/vite.config.ts` reverted and everything else symlinked: **2 of 4 tests fail there.** Test 1 fails `expected undefined to be 5173`; test 2 fails `promise resolved "44744" instead of rejecting` against a held port of 44743 — the harness reproduces the exact `++port` drift this PR fixes. Two assertions deliberately do not discriminate this diff and say so in the code: `resolved.server.port` (5173 is vite's own `DEFAULT_DEV_PORT`) and the `allowedHosts` reach guards. Tests 3 and 4 guard the other end of the pin — someone moving `devUrl` or a Caddy upstream.

Acceptance against the reported symptom: with 5173 genuinely occupied, `pnpm dev` from this branch now exits 1 with `Error: Port 5173 is already in use` and nothing binds 5174-5179. Before the change, the same conditions produced `Port 5173 is in use, trying another one...` followed by `Local: http://localhost:5174/`, and a 1280x800 shell window measuring 100% `#FFFFFF`.

## Gate A

Gate A PASS head=83ae61850d9ac132353d28999dae6c4bac71a5ea base=c1c47f022ba2d75ced84c3c1a7dd58ce54329cbf

Disclosed as **vacuous**: this diff changes 0 files under `crates/engine/src/parser/`, so the gate had nothing to inspect. Control on the same instrument without the pathspec reports the 2 changed files, so the gate ran and the empty parser set is real rather than a dead instrument.

## Anchored on

- client/src/config/multiplayerServerUrls.ts — the existing authority for a value `vite.config.ts` shares with another config consumer, tested from `client/src/config/__tests__/`; same seam, same test home
- client/src/i18n/__tests__/localeParity.test.ts:22 — the existing vitest gate that reads non-`src` repo files via `__dirname` and asserts cross-file consistency; same shape as this PR's agreement assertions

## Final review-impl

Final review-impl PASS head=83ae61850d9ac132353d28999dae6c4bac71a5ea

## Claimed parse impact

None.

## Scope Expansion

None. `client/src-tauri/tauri.conf.json` already reads `5173`, so pinning the producer required no consumer edit and `client/src-tauri/gen/schemas/*.json` is not regenerated. No `Tiltfile`, `Caddyfile`, or `client/package.json` change.

## Validation Failures

None.

One intended behaviour change worth flagging to a reviewer rather than burying: `vite preview` inherits `strictPort` from `server` (`preview.port` is unaffected and stays 4173), so `pnpm preview` now refuses on an occupied 4173 instead of drifting. Nothing in the Tiltfile, CI, or any script invokes `vite preview` — the sole occurrence is the `client/package.json` script definition. Accepted deliberately: a preview server that refuses and names the port is the same improvement, and carving it out would preserve the exact failure mode this PR removes.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Standardized the development server on port 5173 for consistent local access.
  * Added support for the configured local development host.

* **Bug Fixes**
  * The development server now stops with an error if port 5173 is already in use instead of switching to another port.

* **Tests**
  * Added automated checks to verify port, host, and local development configuration consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->