### PR TITLE
Fix Varragoth, Bloodsky Sire's Boast searching card into hand instead of library top

### DIFF
--- a/crates/engine/src/parser/oracle_effect/sequence.rs
+++ b/crates/engine/src/parser/oracle_effect/sequence.rs
@@ -205,6 +205,31 @@ fn is_search_result_put_onto_battlefield_restatement(lower: &str) -> bool {
         .unwrap_or(false)
 }
 
+/// CR 701.23a + CR 701.24b: "put(s) that card/it/them/the card/those cards/the
+/// chosen cards on top" — the abbreviated positional-put clause used after a
+/// search-and-shuffle compound (e.g. "search your library for a card, then
+/// shuffle and put that card on top"). Composed from the same verb/pronoun
+/// axes as [`parse_search_result_put_onto_battlefield_restatement`] above:
+/// the verb conjugates to "puts" (rather than "put") when the search's
+/// subject is third-person ("target player", "each of them") instead of
+/// "you" — Varragoth, Bloodsky Sire; Scheming Symmetry; and Deceptive
+/// Divination all read "... then shuffles and puts that card on top."
+fn parse_search_result_put_on_top_restatement(
+    input: &str,
+) -> Result<(&str, ()), nom::Err<OracleError<'_>>> {
+    let (input, _) = alt((tag::<_, _, OracleError<'_>>("put "), tag("puts "))).parse(input)?;
+    let (input, _) = alt((
+        tag("that card "),
+        tag("it "),
+        tag("them "),
+        tag("the card "),
+        tag("those cards "),
+        tag("the chosen cards "),
+    ))
+    .parse(input)?;
+    value((), tag("on top")).parse(input)
+}
+
 fn has_conditional_search_result_destination(lower: &str) -> bool {
     fn parse_clause(input: &str) -> Result<(&str, ()), nom::Err<OracleError<'_>>> {
         let (input, _) = parse_search_result_put_onto_battlefield_restatement(input)?;
@@ -5574,19 +5599,22 @@ pub(super) fn parse_intrinsic_continuation_ast(
             if has_conditional_search_result_destination(&full_lower) {
                 return None;
             }
-            // CR 701.24b: If later clauses contain "put on top", suppress the default
-            // ChangeZone(→Hand) — the card stays in the library and a separate
-            // PutAtLibraryPosition effect in the chain handles placement.
-            // Also suppress for "Nth from the top" (Long-Term Plans, etc.)
-            let has_positional_put =
-                nom_primitives::scan_contains(&full_lower, "put that card on top")
-                    || nom_primitives::scan_contains(&full_lower, "put it on top")
-                    || nom_primitives::scan_contains(&full_lower, "put the card on top")
-                    || nom_primitives::scan_contains(&full_lower, "put them on top")
-                    || nom_primitives::scan_contains(&full_lower, "put those cards on top")
-                    || nom_primitives::scan_contains(&full_lower, "put the chosen cards on top")
-                    || (nom_primitives::scan_contains(&full_lower, "put that card")
-                        && nom_primitives::scan_contains(&full_lower, "from the top"));
+            // CR 701.24b: If later clauses contain "put(s) on top" (in either
+            // the "you"-subject "put" conjugation or the third-person "puts"
+            // conjugation — see `parse_search_result_put_on_top_restatement`),
+            // suppress the default ChangeZone(→Hand) — the card stays in the
+            // library and a separate PutAtLibraryPosition effect in the chain
+            // handles placement. Also suppress for "Nth from the top"
+            // (Long-Term Plans, etc.)
+            let has_positional_put = nom_primitives::scan_at_word_boundaries(&full_lower, |i| {
+                parse_search_result_put_on_top_restatement(i)
+            })
+            .is_some()
+                || (nom_primitives::scan_at_word_boundaries(&full_lower, |i| {
+                    preceded(alt((tag("put "), tag("puts "))), tag("that card")).parse(i)
+                })
+                .is_some()
+                    && nom_primitives::scan_contains(&full_lower, "from the top"));
             if has_positional_put {
                 return None;
             }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1144,6 +1144,7 @@ mod urzas_saga_chapter_two;
 mod urzas_tower_conditional_mana;
 mod valakut_exploration_end_step_exile_sweep;
 mod vanquish_horde_ai_manapayment_wedge;
+mod varragoth_boast_library_top;
 mod vengeful_ancestor_goaded_attack_trigger;
 mod veteran_armorsmith_soldier_anthem;
 mod veyran_storm_source_scope;

--- a/crates/engine/tests/integration/varragoth_boast_library_top.rs
+++ b/crates/engine/tests/integration/varragoth_boast_library_top.rs
@@ -1,0 +1,133 @@
+//! Issue #8162 — Varragoth, Bloodsky Sire's Boast puts the searched card into
+//! hand instead of on top of the library.
+//!
+//! Oracle text (verified against Scryfall): "Deathtouch\nBoast — {1}{B}: Target
+//! player searches their library for a card, then shuffles and puts that card
+//! on top. (Activate only if this creature attacked this turn and only once
+//! each turn.)"
+//!
+//! CR 701.24b: "Some effects cause a player to search a library for a card or
+//! cards, shuffle that library, then put some or all of the found cards into a
+//! different zone or in a certain position in that library." Varragoth's Boast
+//! is exactly this shape — the found card must stay in the library
+//! (repositioned to the top), never routed through the hand.
+//!
+//! Root cause: the search's subject is third-person ("Target player ...
+//! shuffles and puts that card on top") rather than "you", so the clause reads
+//! "puts" (not "put"). The `has_positional_put` suppression gate in
+//! `parse_intrinsic_continuation_ast` (oracle_effect/sequence.rs) only matched
+//! the "put" conjugation, so it failed to suppress the default
+//! `ChangeZone(Library -> Hand)` continuation, and the chain became
+//! `SearchLibrary -> ChangeZone(Hand) -> Shuffle -> PutAtLibraryPosition(Top)`
+//! instead of `SearchLibrary -> Shuffle -> PutAtLibraryPosition(Top)`.
+//!
+//! Same-class cards affected by the identical "puts that card on top"
+//! conjugation: Scheming Symmetry, Deceptive Divination.
+//!
+//! Revert probe: reverting `parse_search_result_put_on_top_restatement` (or the
+//! `has_positional_put` call site) to only recognize the bare "put" conjugation
+//! reintroduces the spurious `ChangeZone(Hand)` sub-ability, which flips
+//! `varragoth_boast_puts_found_card_on_top_of_library` below (the found card
+//! ends up in the searching player's hand instead of on top of their library).
+
+use engine::game::scenario::{GameRunner, GameScenario};
+use engine::types::ability::Effect;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::player::PlayerId;
+use engine::types::zones::Zone;
+
+const P0: PlayerId = PlayerId(0);
+const P1: PlayerId = PlayerId(1);
+
+const VARRAGOTH: &str = "Deathtouch\nBoast — {1}{B}: Target player searches their library for a card, then shuffles and puts that card on top. (Activate only if this creature attacked this turn and only once each turn.)";
+
+/// Index of Varragoth's Boast activated ability (the only `SearchLibrary`
+/// ability it carries).
+fn boast_index(runner: &GameRunner, varragoth: ObjectId) -> usize {
+    runner.state().objects[&varragoth]
+        .abilities
+        .iter()
+        .position(|a| matches!(a.effect.as_ref(), Effect::SearchLibrary { .. }))
+        .expect("Varragoth must carry a SearchLibrary (Boast) activated ability")
+}
+
+/// Build a battlefield Varragoth (controlled by P0) that has attacked this
+/// turn, with P0 holding priority on an empty stack in a main phase, enough
+/// mana ({1}{B}) pooled to pay the Boast cost, and a single deterministic card
+/// on top of P1's library for the mandatory search to find.
+fn setup() -> (GameRunner, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PostCombatMain);
+    let varragoth = scenario
+        .add_creature_from_oracle(P0, "Varragoth, Bloodsky Sire", 2, 3, VARRAGOTH)
+        .id();
+    scenario.with_mana_pool(
+        P0,
+        vec![
+            ManaUnit::new(ManaType::Black, ObjectId(0), false, vec![]),
+            ManaUnit::new(ManaType::Colorless, ObjectId(0), false, vec![]),
+        ],
+    );
+    // A single card in P1's library — deterministic "search for a card" find.
+    let tutored = scenario.add_card_to_library_top(P1, "Tutored Card");
+
+    let mut runner = scenario.build();
+    // CR 702.142a: Boast requires the source to have attacked this turn.
+    runner
+        .state_mut()
+        .creatures_attacked_this_turn
+        .insert(varragoth);
+    runner.state_mut().active_player = P0;
+    runner.state_mut().priority_player = P0;
+    runner.state_mut().waiting_for = WaitingFor::Priority { player: P0 };
+    (runner, varragoth, tutored)
+}
+
+/// Activating Varragoth's Boast targeting an opponent, then searching that
+/// opponent's library, must leave the found card ON TOP of that opponent's
+/// library (CR 701.24b) — never in their hand.
+///
+/// Revert probe: reverting the `has_positional_put` fix in
+/// `parse_intrinsic_continuation_ast` to only match "put" (not "puts") makes
+/// this fail: the found card ends up in P1's hand instead of on top of P1's
+/// library.
+#[test]
+fn varragoth_boast_puts_found_card_on_top_of_library() {
+    let (mut runner, varragoth, tutored) = setup();
+    let idx = boast_index(&runner, varragoth);
+
+    let outcome = runner
+        .activate(varragoth, idx)
+        .target_player(P1)
+        .search_first_legal()
+        .resolve();
+
+    // The found card must still be in the library, not the hand.
+    outcome.assert_zone(&[tutored], Zone::Library);
+
+    // And specifically on TOP of P1's library (CR 701.24b: the shuffle
+    // excludes the found card, which is then placed in the stated position).
+    let p1 = outcome
+        .state()
+        .players
+        .iter()
+        .find(|p| p.id == P1)
+        .expect("P1 exists");
+    assert_eq!(
+        p1.library.front(),
+        Some(&tutored),
+        "the searched card must be on top of P1's library after the shuffle, \
+         got library order {:?}",
+        p1.library
+    );
+
+    // P1's hand must be empty — the bug routed the found card there instead.
+    assert!(
+        p1.hand.is_empty(),
+        "the searched card must NOT be delivered to P1's hand, got hand {:?}",
+        p1.hand
+    );
+}

--- a/docs/parser-misparse-backlog.md
+++ b/docs/parser-misparse-backlog.md
@@ -18,7 +18,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 | 4 | Conjoined / chained second effect clause dropped | 387 | oracle.rs effect-chain composition — split on 'and'/'then'/sentence boundaries and build sub_ability chain |
 | 5 | Dropped 'for each' / dynamic count collapsed to Fixed | 329 | oracle_quantity.rs parse_for_each_clause / parse_quantity_ref — thread ForEach/ObjectCount into the effect count field |
 | 6 | Disjunctive (or-list) collapsed to first branch | 238 | oracle_nom/filter.rs + oracle_target.rs — build TargetFilter::Or across all alt() branches |
-| 7 | Wrong / dropped zone parameters on zone-change effect | 211 | game/zones.rs + oracle parser zone routing — derive correct origin/destination/owner from Oracle |
+| 7 | Wrong / dropped zone parameters on zone-change effect | 209 | game/zones.rs + oracle parser zone routing — derive correct origin/destination/owner from Oracle |
 | 8 | Additional / alternative casting cost dropped | 210 | oracle_cost.rs — parse additional/alternative cost clauses into Spell.cost / AdditionalCost |
 | 9 | Wrong player/controller scope (You where Opponent/Scoped/Target/Defending needed) | 182 | oracle parser ControllerRef binding — resolve scoped/defending/iterated player refs instead of defaulting to You |
 | 10 | Trigger event/mode unrecognized → Unknown | 167 | oracle_trigger.rs — add typed TriggerMode variants for the unrecognized event classes |
@@ -2805,7 +2805,7 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 
 </details>
 
-### 7. Wrong / dropped zone parameters on zone-change effect  (211 cards)
+### 7. Wrong / dropped zone parameters on zone-change effect  (209 cards)
 
 **Signature.** ChangeZone/ChangeZoneAll/Dig uses the wrong origin/destination zone, drops a count, inverts hand↔library, defaults origin to Exile, or omits a graveyard/owner-library routing.
 
@@ -2964,7 +2964,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Rory Williams
 - Saheeli's Directive
 - Scaled Destruction
-- Scheming Symmetry
 - Scholar of New Horizons
 - Season of the Witch
 - Seek Thrills
@@ -3005,7 +3004,6 @@ This is the prioritized "fix N root causes → unlock M cards" backlog: the top 
 - Ultron the Annihilator
 - Ultron's Auxiliary
 - Vampire Charmseeker
-- Varragoth, Bloodsky Sire
 - Vault 101: Birthday Party
 - Vaultborn Tyrant
 - Verdant Crescendo


### PR DESCRIPTION
## Summary

Fixes Varragoth, Bloodsky Sire's Boast ability, which delivered the searched
card to hand instead of the top of the library. The search's subject is
third-person ("Target player ... shuffles and puts that card on top"), and
the parser's `has_positional_put` suppression gate only recognized the
"you"-subject "put" conjugation, not "puts" — so the default
`ChangeZone(Hand)` continuation fired unsuppressed. Also fixes Scheming
Symmetry and Deceptive Divination, which share the identical "then shuffles
and puts that card on top" phrasing.

Closes #8162

## Files changed

- `crates/engine/src/parser/oracle_effect/sequence.rs` — add
  `parse_search_result_put_on_top_restatement` (put/puts-conjugated
  positional-put combinator) and use it in `has_positional_put`
- `crates/engine/tests/integration/varragoth_boast_library_top.rs` (new) —
  production-pipeline regression test
- `crates/engine/tests/integration/main.rs` — register the new test module
- `docs/parser-misparse-backlog.md` — remove Varragoth, Bloodsky Sire and
  Scheming Symmetry from root-cause category 7 (both now parse correctly)
  and adjust the category's card count (211 → 209)

## CR references

- CR 701.24b — "Some effects cause a player to search a library for a card
  or cards, shuffle that library, then put some or all of the found cards
  into a different zone or in a certain position in that library" — the
  exact shape of Varragoth's Boast; already annotated at the fixed call
  site, verified unchanged.
- CR 701.23a — search-compound destination handling; already annotated,
  verified unchanged.
- CR 702.142a — Boast keyword definition, cited in the new test's setup
  comment (`creatures_attacked_this_turn` precondition).

## Implementation method (required)

Method: /engine-implementer

## Track

Developer

## LLM

Model: claude-sonnet-5
Tier: Frontier
Thinking: high

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — clean, no diff
- `cargo clippy -p phase-engine --all-targets -- -D warnings` — clean (0 warnings, 0 errors)
- `cargo test -p phase-engine --lib` — 20306 passed; 0 failed; 6 ignored
- `cargo test -p phase-engine --test integration varragoth_boast` — 1 passed (new test)
- Revert probe: reverted `has_positional_put` to the pre-fix "put"-only phrase list, reran the new test — it FAILED with `assertion left == right failed: object 2 expected in Library, found in Hand` (exactly the reported bug), then restored the fix and reran — PASSED. Confirms the test is genuinely discriminating.
- `cargo test -p phase-engine --test integration search` — 61 passed; 0 failed (includes `enlightened_tutor_regression` — the "you"-subject sibling, unaffected)
- `cargo test -p phase-engine --test integration boast` — 13 passed; 0 failed
- `cargo test -p phase-engine --test integration on_top` — 11 passed; 0 failed
- `MTGJSON_SKIP_REFRESH=1 ./scripts/gen-card-data.sh` — regenerated `client/public/card-data.json` from the local cache; confirmed Varragoth, Scheming Symmetry, and Deceptive Divination's search ability now parses to `SearchLibrary -> Shuffle -> PutAtLibraryPosition` (no more spurious `ChangeZone(Hand)`)
- `cargo semantic-audit` — 251 findings across the card set, zero for Varragoth/Scheming Symmetry/Deceptive Divination
- `cargo coverage` — 31839/35798 supported (88.9%); Varragoth and Scheming Symmetry remain `supported: true, gap_count: 0` (the misparse was invisible to coverage, only caught by semantic-audit/manual inspection — consistent with `docs/parser-misparse-backlog.md` category 7's signature); Deceptive Divination remains `supported: false, gap_count: 1` for its unrelated, pre-existing "Change the text of each sorcery spell..." gap

## Gate A

Gate A PASS head=d4b448febace32c36c627ac7d9568eb66a26ad4e base=c1c47f022ba2d75ced84c3c1a7dd58ce54329cbf

## Anchored on

- `crates/engine/src/parser/oracle_effect/sequence.rs:182` — existing `parse_search_result_put_onto_battlefield_restatement`, the direct precedent this fix mirrors: `alt((tag("put "), tag("puts ")))` composed with a pronoun `alt()` for the analogous "put(s) ... onto the battlefield" search restatement.
- `crates/engine/src/parser/oracle_effect/sequence.rs:9136` (test `search_result_put_restatement_parses_independent_axes`) — `let verbs = ["put ", "puts "];` — the established convention that put/puts conjugation is an independent grammatical axis to be tested across, not enumerated per-card.

## Final review-impl

Final review-impl PASS head=d4b448febace32c36c627ac7d9568eb66a26ad4e

Self-review applying the review-impl universal lenses (findings-only; none found):
- Correct seam: the `has_positional_put` gate inside `parse_intrinsic_continuation_ast` (`oracle_effect/sequence.rs`) is the sole authority deciding whether the default `ChangeZone(Hand)` search continuation is suppressed — confirmed by tracing the full chain from `SearchLibrary` parsing through to the resolved `AbilityDefinition`.
- Idiomatic: composed via `alt`/`tag`/`preceded`/`scan_at_word_boundaries`, mirroring the existing `parse_search_result_put_onto_battlefield_restatement` combinator one-for-one; no string `.contains`/`.find` dispatch introduced.
- Class vs single case: covers 3 named cards (Varragoth, Bloodsky Sire; Scheming Symmetry; Deceptive Divination), all independently verified via `card-data.json` before/after inspection.
- Sibling coverage: checked `parse_search_destination` (the Zone-selection function used by the same continuation) for the identical conjugation gap — it matches on the object+preposition ("into hand", "on top of library"), never the verb, so it was never vulnerable; no sibling fix needed there.
- Test adequacy + vacuous-negative guard: the new test drives `GameRunner::activate(...).resolve()` (the real `GameAction::ActivateAbility` pipeline), asserts the found card's zone, its position at `library.front()` (positive reach-guard), and the negative `hand.is_empty()` paired with that positive. The revert probe (documented above) proves it fails for the right reason.
- CR annotations: `CR 701.24b`, `CR 701.23a` (both pre-existing, unchanged), `CR 702.142a` (test-only) all grep-verified against `docs/MagicCompRules.txt`.

## Claimed parse impact

Varragoth, Bloodsky Sire; Scheming Symmetry; Deceptive Divination — all three now parse their search-then-shuffle-then-put-on-top clause to `SearchLibrary -> Shuffle -> PutAtLibraryPosition` instead of `SearchLibrary -> ChangeZone(Hand) -> Shuffle -> PutAtLibraryPosition`. No other card's parsed AST changed (confirmed via `cargo semantic-audit` and `cargo coverage` totals matching the pre-fix run except for these three).

## Scope Expansion

None. `docs/parser-misparse-backlog.md` is updated only to remove the two entries (Varragoth, Scheming Symmetry) this exact fix resolves, per the same list-hygiene convention required for misparse-backlog fixes — a direct, mechanical byproduct of this change, not new scope.

## Validation Failures

None.

## CI Failures

None.
