### PR TITLE
Preserve player-scope linked exile batches

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -10,26 +10,27 @@ use crate::game::filter;
 use crate::game::speed::has_max_speed;
 use crate::types::ability::{
     AbilityCondition, AbilityCost, AbilityDefinition, AbilityKind, CardPlayMode, CardTypeSetSource,
-    ChosenAttribute, CommanderOwnership, ControllerRef, CopyRetargetPermission,
+    CastFromZoneDriver, ChosenAttribute, CommanderOwnership, ControllerRef, CopyRetargetPermission,
     CostPaidObjectSnapshot, DetachedRemainder, EachDamageRecipient, Effect, EffectError,
     EffectKind, EffectOutcomeSignal, EffectResolutionResult, EffectScope, FilterProp,
-    ForwardedResultContext, ManaProduction, OpponentMayScope, PlayerFilter, PlayerScope,
-    QuantityExpr, QuantityRef, RepeatContinuation, ResolvedAbility, RevealUntilDisposition,
-    SacrificeCost, SacrificeRequirement, SharedQuality, SharedQualityRelation, SiblingCondition,
-    StaticDefinition, SubAbilityLink, TapStateChange, TargetChoiceTiming, TargetFilter, TargetRef,
-    ThisWayCause,
+    ForEachCategoryAction, ForwardedResultContext, ManaProduction, OpponentMayScope, PlayerFilter,
+    PlayerScope, QuantityExpr, QuantityRef, RepeatContinuation, ResolvedAbility,
+    RevealUntilDisposition, SacrificeCost, SacrificeRequirement, SharedQuality,
+    SharedQualityRelation, SiblingCondition, StaticDefinition, SubAbilityLink, TapStateChange,
+    TargetChoiceTiming, TargetFilter, TargetRef, ThisWayCause,
 };
 #[cfg(test)]
 use crate::types::ability::{AttackScope, AttackSubject};
 use crate::types::events::{GameEvent, PlayerActionKind};
 use crate::types::game_state::{
-    AutoMayChoice, CastOfferKind, ClauseMinimumSnapshot, DayNight, DiscardBatchCursor, GameState,
-    LKISnapshot, ManaAbilityResume, MayTriggerAutoChoiceKey, PendingContinuation,
-    PendingCostMoveResume, PendingDiscardBatchCompletion, PendingPlayerScopeSacrificeChoice,
+    AutoMayChoice, CastOfferKind, ClauseMinimumSnapshot, DayNight, DiscardBatchCursor,
+    ExileLinkKind, GameState, LKISnapshot, ManaAbilityResume, MayTriggerAutoChoiceKey,
+    PendingContinuation, PendingCostMoveResume, PendingDiscardBatchCompletion,
+    PendingPlayerScopeLinkedExile, PendingPlayerScopeSacrificeChoice,
     PendingPlayerScopeSacrificeCompletion, PendingPlayerScopeSacrificeFollowUp,
     ResolutionOptionalPaymentOption, WaitingFor, ZoneChangeRecord,
 };
-use crate::types::identifiers::{ObjectId, TrackedSetId};
+use crate::types::identifiers::{ObjectId, ObjectIncarnationRef, TrackedSetId};
 use crate::types::mana::ManaCost;
 use crate::types::player::{Player, PlayerId};
 use crate::types::resolution::{
@@ -784,6 +785,19 @@ pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec
     if !waits_for_resolution_choice(&state.waiting_for)
         && state.active_ability_continuation().is_some()
     {
+        let scoped_source = state
+            .active_ability_continuation()
+            .and_then(|pending| pending.player_scope_linked_exile.as_ref())
+            .map(|scope| scope.source_id);
+        if let Some(source_id) = scoped_source {
+            let additions = linked_exile_batch_from_events(state, source_id, events);
+            if let Some(scope) = state
+                .active_ability_continuation_frame_mut()
+                .and_then(|frame| frame.pending.player_scope_linked_exile.as_mut())
+            {
+                extend_linked_exile_batch(&mut scope.batch, additions);
+            }
+        }
         let discard_frame = state
             .resolution_stack
             .active_ability_continuation_discard_parent_id();
@@ -817,6 +831,8 @@ pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec
             trigger_firing,
             attachment_choice,
             attachment_remainder: _,
+            player_scope_linked_exile,
+            player_scope_queue_end,
         } = cont;
         debug_assert!(
             attachment_choice.is_none(),
@@ -824,6 +840,10 @@ pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec
         );
         restore_continuation_trigger_firing(state, trigger_firing);
         state.resolving_continuation_attach_host = search_attach_host;
+        let previous_scope = std::mem::replace(
+            &mut state.resolving_player_scope_linked_exile,
+            player_scope_linked_exile,
+        );
         let source_id = chain.source_id;
         // CR 608.2: replay the resolving ability's snapshotted trigger
         // context so TargetFilter::TriggeringPlayer (and its siblings)
@@ -831,11 +851,26 @@ pub(crate) fn drain_pending_continuation(state: &mut GameState, events: &mut Vec
         let trigger_snapshot = trigger_context
             .as_ref()
             .map(|ctx| super::triggers::push_resolving_trigger_context(state, ctx));
-        let _ = resolve_ability_chain(state, &chain, events, 1);
+        if !player_scope_queue_end {
+            let _ = resolve_ability_chain(state, &chain, events, 1);
+        }
+        if let Some(scope) = state.resolving_player_scope_linked_exile.as_ref() {
+            mark_exile_choice_tracks_by_source(state, scope.source_id);
+        }
         if let Some(snapshot) = trigger_snapshot {
             super::triggers::restore_trigger_event_context(state, snapshot);
         }
+        let completed_scope = std::mem::take(&mut state.resolving_player_scope_linked_exile);
+        state.resolving_player_scope_linked_exile = previous_scope;
         state.resolving_continuation_attach_host = None;
+        if !waits_for_resolution_choice(&state.waiting_for)
+            && state.active_ability_continuation().is_none()
+        {
+            if let Some(mut scope) = completed_scope {
+                bind_resolution_exile_batch_paths(&mut scope.after_scope, &scope.batch);
+                let _ = resolve_ability_chain(state, &scope.after_scope, events, 1);
+            }
+        }
         if let Some(kind) = parent_kind {
             events.push(GameEvent::EffectResolved {
                 kind,
@@ -1853,6 +1888,8 @@ fn prepend_to_pending_continuation(state: &mut GameState, mut head: ResolvedAbil
             trigger_firing,
             attachment_choice,
             attachment_remainder,
+            player_scope_linked_exile,
+            player_scope_queue_end,
         } = existing;
         super::ability_utils::append_to_sub_chain(&mut head, *chain);
         state.push_ability_continuation(AbilityContinuationFrame {
@@ -1867,6 +1904,8 @@ fn prepend_to_pending_continuation(state: &mut GameState, mut head: ResolvedAbil
                 trigger_firing,
                 attachment_choice,
                 attachment_remainder,
+                player_scope_linked_exile,
+                player_scope_queue_end,
             },
             choose_zone_trigger_context: frame.choose_zone_trigger_context,
         });
@@ -1874,6 +1913,17 @@ fn prepend_to_pending_continuation(state: &mut GameState, mut head: ResolvedAbil
     }
 
     state.park_ability_continuation(PendingContinuation::new(Box::new(head), state));
+}
+
+fn park_player_scope_queue_end(state: &mut GameState, placeholder: ResolvedAbility) {
+    let pending = PendingContinuation::player_scope_queue_end(Box::new(placeholder), state);
+    if active_frame_requires_ability_continuation_parent(state) {
+        state
+            .insert_ability_continuation_parent_of_active(pending)
+            .expect("player-scope queue end must remain outside its paused child");
+    } else {
+        state.park_ability_continuation(pending);
+    }
 }
 
 /// CR 118.12 + CR 608.2c: Complete the original rider of a paused
@@ -8912,7 +8962,7 @@ fn publish_player_scope_clause_results(
     zero_fill_domain: &[PlayerId],
     after_scope_needs_linked_exile: bool,
     scoped_events: &[GameEvent],
-) {
+) -> Vec<ObjectIncarnationRef> {
     let counts_by_player = previous_effect_counts_by_player_from_events(
         EffectKind::from(&scoped_template.effect),
         scoped_template.source_id,
@@ -8978,6 +9028,121 @@ fn publish_player_scope_clause_results(
     state.last_zone_changed_ids = ids;
     if next_sub_needs_tracked_set(outer) {
         publish_tracked_set_with_causes(state, affected_with_causes);
+    }
+    linked_exile_batch_from_events(state, outer.source_id, scoped_events)
+}
+
+/// CR 400.7 + CR 608.2f: capture only current incarnations exiled by this
+/// completed slice of a multi-player instruction, preserving event order.
+fn linked_exile_batch_from_events(
+    state: &GameState,
+    source_id: ObjectId,
+    events: &[GameEvent],
+) -> Vec<ObjectIncarnationRef> {
+    let mut batch: Vec<ObjectIncarnationRef> = Vec::new();
+    for id in events.iter().filter_map(|event| match event {
+        GameEvent::ZoneChanged { object_id, .. } => Some(*object_id),
+        _ => None,
+    }) {
+        if !batch.iter().any(|pin| pin.object_id == id)
+            && state
+                .objects
+                .get(&id)
+                .is_some_and(|object| object.zone == Zone::Exile)
+            && state.exile_links.iter().any(|link| {
+                link.exiled_id == id
+                    && link.source_id == source_id
+                    && link.kind == ExileLinkKind::TrackedBySource
+            })
+        {
+            batch.push(ObjectIncarnationRef::from_object(&state.objects[&id]));
+        }
+    }
+    batch
+}
+
+fn extend_linked_exile_batch(
+    batch: &mut Vec<ObjectIncarnationRef>,
+    additions: impl IntoIterator<Item = ObjectIncarnationRef>,
+) {
+    for pin in additions {
+        if !batch
+            .iter()
+            .any(|existing| existing.object_id == pin.object_id)
+        {
+            batch.push(pin);
+        }
+    }
+}
+
+fn linked_exile_producer_barrier(ability: &ResolvedAbility) -> bool {
+    this_way_cause_for_effect(&ability.effect) == Some(ThisWayCause::Exiled)
+        || matches!(
+            &ability.effect,
+            Effect::Seek {
+                destination: Zone::Exile,
+                ..
+            } | Effect::ForEachCategory {
+                action: ForEachCategoryAction::ExileFromPool { .. },
+                ..
+            } | Effect::ExileFaceDownPile { .. }
+                | Effect::ExileHaunting { .. }
+                | Effect::HeistExile
+                | Effect::Discover { .. }
+                | Effect::Cascade
+        )
+}
+
+/// CR 608.2f: append one completed seat's exact exile batch to the single
+/// resolution window after a synthesized APNAP continuation. Independent exile
+/// producers remain barriers; only player-scope siblings may be crossed.
+fn bind_resolution_exile_batch_paths(
+    ability: &mut ResolvedAbility,
+    batch: &[ObjectIncarnationRef],
+) {
+    let eligible = matches!(
+        &ability.effect,
+        Effect::CastFromZone { target, driver: CastFromZoneDriver::ResolutionWindow { .. }, .. }
+            if target.references_exiled_by_source()
+                && !effect_refs_parent_target(&ability.effect)
+    );
+    if eligible {
+        let paired = ability.targets.len() == ability.target_incarnations.len()
+            && ability
+                .targets
+                .iter()
+                .zip(&ability.target_incarnations)
+                .all(
+                    |(target, pin)| matches!(target, TargetRef::Object(id) if *id == pin.object_id),
+                );
+        if paired {
+            for pin in batch {
+                if !ability
+                    .target_incarnations
+                    .iter()
+                    .any(|existing| existing.object_id == pin.object_id)
+                {
+                    ability.targets.push(TargetRef::Object(pin.object_id));
+                    ability.target_incarnations.push(*pin);
+                }
+            }
+        }
+        if let Some(sub) = ability.sub_ability.as_mut() {
+            bind_resolution_exile_batch_paths(sub, batch);
+        }
+        if let Some(else_branch) = ability.else_ability.as_mut() {
+            bind_resolution_exile_batch_paths(else_branch, batch);
+        }
+        return;
+    }
+    if linked_exile_producer_barrier(ability) {
+        return;
+    }
+    if let Some(sub) = ability.sub_ability.as_mut() {
+        bind_resolution_exile_batch_paths(sub, batch);
+    }
+    if let Some(else_branch) = ability.else_ability.as_mut() {
+        bind_resolution_exile_batch_paths(else_branch, batch);
     }
 }
 
@@ -9849,7 +10014,7 @@ pub(crate) fn drain_pending_discard_batch(
         // drained, so `events` still holds only the resumed action's own span.
         let mut window = std::mem::take(&mut batch.preceding_events);
         window.extend_from_slice(events);
-        publish_player_scope_clause_results(
+        let _ = publish_player_scope_clause_results(
             state,
             &fan_out.outer,
             &fan_out.scoped_template,
@@ -11044,7 +11209,14 @@ fn resolve_chain_body(
                     return Ok(());
                 }
                 let remaining = &matching_players[i + 1..];
-                let mut tail = after_scope.clone();
+                // The unscoped tail is owned explicitly by the continuation
+                // sidecar below. Only generated per-seat nodes are linearized
+                // here, so no ordinary scoped sibling can impersonate them.
+                let mut tail = if after_scope_needs_linked_exile {
+                    None
+                } else {
+                    after_scope.clone()
+                };
                 // Build continuation chain for remaining players in APNAP order.
                 // Each remaining player gets the scoped instruction only; the
                 // unscoped tail runs once after the final scoped iteration.
@@ -11089,7 +11261,7 @@ fn resolve_chain_body(
                 break;
             }
         }
-        publish_player_scope_clause_results(
+        let linked_batch = publish_player_scope_clause_results(
             state,
             ability,
             &scoped_template,
@@ -11103,8 +11275,25 @@ fn resolve_chain_body(
             // tail is another `player_scope` clause, that recursive entry will
             // capture its own fresh snapshot against the post-this-clause board.
             state.clause_minimum_snapshot = None;
-            if let Some(after_scope) = after_scope {
+            if let Some(mut after_scope) = after_scope {
+                bind_resolution_exile_batch_paths(&mut after_scope, &linked_batch);
                 resolve_ability_chain(state, &after_scope, events, depth + 1)?;
+            }
+        } else if after_scope_needs_linked_exile {
+            if let Some(after_scope) = after_scope {
+                if state.active_ability_continuation().is_none() {
+                    park_player_scope_queue_end(state, after_scope.as_ref().clone());
+                }
+                if let Some(frame) = state.active_ability_continuation_frame_mut() {
+                    // CR 608.2f: generated APNAP nodes and their exact union are
+                    // explicit pause authority. The detached tail resolves once only
+                    // after every generated seat has drained.
+                    frame.pending.player_scope_linked_exile = Some(PendingPlayerScopeLinkedExile {
+                        source_id: ability.source_id,
+                        after_scope,
+                        batch: linked_batch,
+                    });
+                }
             }
         }
         return Ok(());
@@ -12307,6 +12496,22 @@ fn resolve_chain_body(
             _ => None,
         })
         .collect();
+    let linked_batch =
+        linked_exile_batch_from_events(state, ability.source_id, &events[events_before..]);
+    if let Some(scope) = state.resolving_player_scope_linked_exile.as_mut() {
+        extend_linked_exile_batch(&mut scope.batch, linked_batch.iter().copied());
+    }
+    let linked_batch_owned;
+    let ability = if linked_batch.is_empty() || ability.sub_ability.is_none() {
+        ability
+    } else {
+        let mut owned = ability.clone();
+        if let Some(sub) = owned.sub_ability.as_mut() {
+            bind_resolution_exile_batch_paths(sub, &linked_batch);
+        }
+        linked_batch_owned = owned;
+        &linked_batch_owned
+    };
     let result_context_owned;
     let ability = if let Some(result) = immediate_effect_result {
         let mut owned = ability.clone();
@@ -12597,6 +12802,15 @@ fn resolve_chain_body(
     }) {
         crate::game::sba::apply_city_blessing_if_triggered(state, events);
         crate::game::sba::apply_enduring_story_if_triggered(state, events);
+    }
+
+    if ability.sub_ability.is_none()
+        && waits_for_resolution_choice(&state.waiting_for)
+        && state.resolving_player_scope_linked_exile.is_some()
+        && state.active_ability_continuation().is_none()
+    {
+        park_player_scope_queue_end(state, ability.clone());
+        return Ok(());
     }
 
     // Follow typed sub_ability chain, propagating parent targets when sub has none.
@@ -15274,6 +15488,42 @@ fn resolve_add_pending_enters_modifications(
 mod tests {
     use super::*;
     use crate::database::synthesis::synthesize_extort;
+
+    #[test]
+    fn resolution_window_batch_reaches_a_chained_consumer() {
+        let window = || {
+            ResolvedAbility::new(
+                Effect::CastFromZone {
+                    target: TargetFilter::ExiledBySource,
+                    without_paying_mana_cost: true,
+                    mode: CardPlayMode::Cast,
+                    cast_transformed: false,
+                    alt_ability_cost: None,
+                    constraint: None,
+                    duration: None,
+                    driver: CastFromZoneDriver::ResolutionWindow {
+                        bounds: crate::types::ability::ResolutionCastWindow::UNBOUNDED,
+                    },
+                    mana_spend_permission: None,
+                },
+                vec![],
+                ObjectId(1),
+                PlayerId(0),
+            )
+        };
+        let pin = ObjectIncarnationRef::of(ObjectId(2), 3);
+        let mut first = window();
+        first.sub_ability = Some(Box::new(window()));
+
+        bind_resolution_exile_batch_paths(&mut first, &[pin]);
+
+        assert_eq!(first.target_incarnations, vec![pin]);
+        assert_eq!(
+            first.sub_ability.as_ref().unwrap().target_incarnations,
+            vec![pin],
+            "a subsequent linked-exile consumer on the same path needs the same exact batch"
+        );
+    }
 
     /// V14 — CR 701.17a: the "this way" producer verb agrees with the mill's
     /// destination conjunct in `effects::mill`. Only a graveyard-bound

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -2426,6 +2426,17 @@ pub struct PendingAttachmentRemainder {
     pub producer: Box<ResolvedAbility>,
 }
 
+/// Private continuation authority for an interactive player-scope exile
+/// instruction. Keeping the detached tail here makes generated APNAP nodes
+/// explicit without adding runtime provenance to `ResolvedAbility`.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub(crate) struct PendingPlayerScopeLinkedExile {
+    pub source_id: ObjectId,
+    pub after_scope: Box<ResolvedAbility>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub batch: Vec<ObjectIncarnationRef>,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub struct PendingContinuation {
     pub chain: Box<ResolvedAbility>,
@@ -2455,9 +2466,26 @@ pub struct PendingContinuation {
     /// unprocessed members of a selected multi-attachment operation.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub attachment_remainder: Option<PendingAttachmentRemainder>,
+    /// CR 608.2f: exact linked-exile union and detached unscoped tail owned by
+    /// a generated player-scope continuation. Legacy saves default to `None`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub(crate) player_scope_linked_exile: Option<PendingPlayerScopeLinkedExile>,
+    /// Private queue terminator for generated player-scope continuations. The
+    /// placeholder `chain` is never resolved when this is set.
+    #[serde(default, skip_serializing_if = "std::ops::Not::not")]
+    pub(crate) player_scope_queue_end: bool,
 }
 
 impl PendingContinuation {
+    pub(crate) fn player_scope_queue_end(
+        placeholder: Box<ResolvedAbility>,
+        state: &GameState,
+    ) -> Self {
+        let mut pending = Self::new(placeholder, state);
+        pending.player_scope_queue_end = true;
+        pending
+    }
+
     /// Construct a continuation with no parent-kind emission. Used for chains
     /// whose per-node `EffectResolved` events are the full observable story
     /// (targeted damage continuations, Learn rummage, Bolster, Clash, etc.).
@@ -2470,6 +2498,8 @@ impl PendingContinuation {
             trigger_firing: state.resolving_trigger_firing,
             attachment_choice: None,
             attachment_remainder: None,
+            player_scope_linked_exile: state.resolving_player_scope_linked_exile.clone(),
+            player_scope_queue_end: false,
         }
     }
 
@@ -2490,6 +2520,8 @@ impl PendingContinuation {
             trigger_firing: state.resolving_trigger_firing,
             attachment_choice: None,
             attachment_remainder: None,
+            player_scope_linked_exile: state.resolving_player_scope_linked_exile.clone(),
+            player_scope_queue_end: false,
         }
     }
 }
@@ -18271,6 +18303,12 @@ declare_game_state! {
     #[serde(skip)]
     pub resolving_continuation_attach_host: Option<AttachTarget>,
 
+    /// Execution-local view of the active generated player-scope continuation.
+    /// The serialized authority lives on `PendingContinuation`; every pause
+    /// re-parks it before control returns to callers.
+    #[serde(skip)]
+    pub(crate) resolving_player_scope_linked_exile: Option<PendingPlayerScopeLinkedExile>,
+
     /// CR 730.3e (second clause): routing override for the card components of a
     /// TOKEN merged permanent leaving the battlefield under a card-scoped
     /// (`NonToken`) `Moved` redirect. "If the merged permanent is a token but
@@ -23170,6 +23208,7 @@ impl GameState {
             product_knowledge_state: Box::default(),
             resolution_stack: Box::default(),
             resolving_continuation_attach_host: None,
+            resolving_player_scope_linked_exile: None,
             merged_card_component_route: None,
             resolution_coin_flip: None,
             pending_player_scope_sacrifice_choice: None,
@@ -25199,6 +25238,7 @@ fn _gamestate_partition_is_total(s: &GameState) {
         product_knowledge_state: _,
         resolution_stack: _,
         resolving_continuation_attach_host: _,
+        resolving_player_scope_linked_exile: _,
         merged_card_component_route: _,
         resolution_coin_flip: _,
         may_trigger_auto_choices: _,

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -973,6 +973,7 @@ mod peter_parker_modal_back_face_cast;
 mod phantom_general_token_anthem;
 mod phyrexian_fleshgorger_ward;
 mod plaguecrafter_etb_class;
+mod player_scope_linked_exile_batch;
 mod ponder_decline_shuffle_regression;
 mod power_fist_combat_damage_regression;
 mod power_leak_dynamic_prevention;

--- a/crates/engine/tests/integration/player_scope_linked_exile_batch.rs
+++ b/crates/engine/tests/integration/player_scope_linked_exile_batch.rs
@@ -1,0 +1,255 @@
+//! Regression for exact linked-exile batches across interactive player-scope fan-out.
+
+use engine::game::effects::resolve_ability_chain;
+use engine::game::engine::apply;
+use engine::game::zones::create_object;
+use engine::types::ability::{
+    CardPlayMode, CastFromZoneDriver, ControllerRef, Effect, EffectKind, FilterProp,
+    LibraryPosition, PlayerFilter, QuantityExpr, ResolutionCastWindow, ResolvedAbility,
+    SubAbilityLink, TargetFilter, TypeFilter, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::card_type::CoreType;
+use engine::types::events::GameEvent;
+use engine::types::format::FormatConfig;
+use engine::types::game_state::{
+    ActionResult, CastOfferKind, ExileLinkKind, GameState, WaitingFor,
+};
+use engine::types::identifiers::{CardId, ObjectId};
+use engine::types::player::PlayerId;
+use engine::types::zones::{EtbTapState, Zone};
+
+fn graveyard_creature(
+    state: &mut GameState,
+    card_id: u64,
+    owner: PlayerId,
+    name: &str,
+) -> ObjectId {
+    let id = create_object(
+        state,
+        CardId(card_id),
+        owner,
+        name.to_string(),
+        Zone::Graveyard,
+    );
+    let object = state.objects.get_mut(&id).expect("created object exists");
+    object.card_types.core_types.push(CoreType::Creature);
+    object.base_card_types = object.card_types.clone();
+    id
+}
+
+fn choose_exile(state: &mut GameState, player: PlayerId, card: ObjectId) -> ActionResult {
+    match &state.waiting_for {
+        WaitingFor::EffectZoneChoice {
+            player: prompted,
+            cards,
+            destination: Some(Zone::Exile),
+            track_exiled_by_source,
+            ..
+        } => {
+            assert_eq!(*prompted, player);
+            assert!(cards.contains(&card));
+            assert!(*track_exiled_by_source);
+        }
+        other => panic!("expected exile choice for {player:?}, got {other:?}"),
+    }
+    apply(state, player, GameAction::SelectCards { cards: vec![card] })
+        .expect("player-scope exile choice resolves")
+}
+
+fn cast_window(source: ObjectId) -> ResolvedAbility {
+    ResolvedAbility::new(
+        Effect::CastFromZone {
+            target: TargetFilter::ExiledBySource,
+            without_paying_mana_cost: true,
+            mode: CardPlayMode::Cast,
+            cast_transformed: false,
+            alt_ability_cost: None,
+            constraint: None,
+            duration: None,
+            driver: CastFromZoneDriver::ResolutionWindow {
+                bounds: ResolutionCastWindow::UNBOUNDED,
+            },
+            mana_spend_permission: None,
+        },
+        vec![],
+        source,
+        PlayerId(0),
+    )
+}
+
+fn scoped_graveyard_exile(source: ObjectId, tail: ResolvedAbility) -> ResolvedAbility {
+    let mut exile = ResolvedAbility::new(
+        Effect::ChangeZone {
+            origin: Some(Zone::Graveyard),
+            destination: Zone::Exile,
+            target: TargetFilter::Typed(TypedFilter {
+                type_filters: vec![TypeFilter::Card],
+                controller: Some(ControllerRef::You),
+                properties: vec![FilterProp::InZone {
+                    zone: Zone::Graveyard,
+                }],
+            }),
+            owner_library: false,
+            enter_transformed: false,
+            enters_under: None,
+            enter_tapped: EtbTapState::Unspecified,
+            enters_attacking: false,
+            up_to: false,
+            enter_with_counters: vec![],
+            conditional_enter_with_counters: vec![],
+            face_down_profile: None,
+            enters_modified_if: None,
+        },
+        vec![],
+        source,
+        PlayerId(0),
+    );
+    exile.player_scope = Some(PlayerFilter::All);
+    exile.sub_ability = Some(Box::new(tail));
+    exile
+}
+
+/// CR 608.2f: each paused player contributes an independent exact batch. The
+/// final resolution window must see their union, including the intermediate
+/// resumed seat whose producer is separated by another producer barrier.
+#[test]
+fn player_scope_pauses_accumulate_exact_linked_batch_for_final_cast_window() {
+    let mut state = GameState::new(FormatConfig::standard(), 3, 42);
+    let source = create_object(
+        &mut state,
+        CardId(1),
+        PlayerId(0),
+        "Player-scope source".to_string(),
+        Zone::Battlefield,
+    );
+    let p0_pick = graveyard_creature(&mut state, 10, PlayerId(0), "P0 pick");
+    let p0_other = graveyard_creature(&mut state, 11, PlayerId(0), "P0 other");
+    let p1_pick = graveyard_creature(&mut state, 20, PlayerId(1), "P1 pick");
+    let p1_other = graveyard_creature(&mut state, 21, PlayerId(1), "P1 other");
+    let p2_pick = graveyard_creature(&mut state, 30, PlayerId(2), "P2 pick");
+    let p2_other = graveyard_creature(&mut state, 31, PlayerId(2), "P2 other");
+
+    let exile = scoped_graveyard_exile(source, cast_window(source));
+
+    resolve_ability_chain(&mut state, &exile, &mut Vec::new(), 0)
+        .expect("player-scope chain starts");
+    choose_exile(&mut state, PlayerId(0), p0_pick);
+    state = serde_json::from_value(serde_json::to_value(&state).expect("pause serializes"))
+        .expect("pause restores");
+    choose_exile(&mut state, PlayerId(1), p1_pick);
+    let prior_count_before_final_continuation = state.last_effect_count;
+    let final_result = choose_exile(&mut state, PlayerId(2), p2_pick);
+
+    assert_eq!(
+        final_result
+            .events
+            .iter()
+            .filter(|event| matches!(event, GameEvent::ZoneChanged { object_id, .. } if *object_id == p2_pick))
+            .count(),
+        1,
+        "the final seat must publish its real exile exactly once"
+    );
+    assert!(
+        !final_result.events.iter().any(|event| matches!(
+            event,
+            GameEvent::EffectResolved {
+                kind: EffectKind::NoOp,
+                ..
+            }
+        )),
+        "synthetic queue terminator must not emit an event: {:?}",
+        final_result.events
+    );
+    assert_eq!(
+        state.last_effect_count,
+        prior_count_before_final_continuation
+    );
+
+    let WaitingFor::CastOffer {
+        player: PlayerId(0),
+        kind: CastOfferKind::FreeCastWindow { candidates, .. },
+    } = &state.waiting_for
+    else {
+        panic!(
+            "expected final free-cast window, got {:?}",
+            state.waiting_for
+        );
+    };
+    let mut actual = candidates.clone();
+    actual.sort_by_key(|id| id.0);
+    let mut expected = vec![p0_pick, p1_pick, p2_pick];
+    expected.sort_by_key(|id| id.0);
+    assert_eq!(
+        actual, expected,
+        "window must contain the exact three-seat union"
+    );
+    for picked in expected {
+        assert_eq!(state.objects[&picked].zone, Zone::Exile);
+        assert!(state.exile_links.iter().any(|link| {
+            link.exiled_id == picked
+                && link.source_id == source
+                && link.kind == ExileLinkKind::TrackedBySource
+        }));
+    }
+    for unpicked in [p0_other, p1_other, p2_other] {
+        assert!(!candidates.contains(&unpicked));
+        assert_eq!(state.objects[&unpicked].zone, Zone::Graveyard);
+    }
+}
+
+/// An ordinary scoped `SequentialSibling` is not queue provenance. Even when
+/// it is itself an exile producer, the prior player-scope batch must stop at
+/// that producer barrier; only its own exact batch reaches its cast window.
+#[test]
+fn ordinary_scoped_sequential_exile_producer_remains_a_batch_barrier() {
+    let mut state = GameState::new(FormatConfig::standard(), 3, 43);
+    let source = create_object(
+        &mut state,
+        CardId(100),
+        PlayerId(0),
+        "Barrier source".to_string(),
+        Zone::Battlefield,
+    );
+    let p0_pick = graveyard_creature(&mut state, 110, PlayerId(0), "P0 prior batch");
+    let _p0_other = graveyard_creature(&mut state, 111, PlayerId(0), "P0 other");
+    let p1_pick = graveyard_creature(&mut state, 120, PlayerId(1), "P1 prior batch");
+    let _p1_other = graveyard_creature(&mut state, 121, PlayerId(1), "P1 other");
+    let p2_pick = graveyard_creature(&mut state, 130, PlayerId(2), "P2 prior batch");
+    let _p2_other = graveyard_creature(&mut state, 131, PlayerId(2), "P2 other");
+    let barrier_hit = graveyard_creature(&mut state, 140, PlayerId(0), "Barrier hit");
+    engine::game::zones::move_to_zone(&mut state, barrier_hit, Zone::Library, &mut vec![]);
+
+    let mut barrier = ResolvedAbility::new(
+        Effect::ExileTop {
+            player: TargetFilter::Controller,
+            count: QuantityExpr::Fixed { value: 1 },
+            position: LibraryPosition::Top,
+            face_down: false,
+        },
+        vec![],
+        source,
+        PlayerId(0),
+    );
+    barrier.scoped_player = Some(PlayerId(0));
+    barrier.sub_link = SubAbilityLink::SequentialSibling;
+    barrier.sub_ability = Some(Box::new(cast_window(source)));
+    let exile = scoped_graveyard_exile(source, barrier);
+
+    resolve_ability_chain(&mut state, &exile, &mut Vec::new(), 0).expect("fan-out starts");
+    choose_exile(&mut state, PlayerId(0), p0_pick);
+    choose_exile(&mut state, PlayerId(1), p1_pick);
+    choose_exile(&mut state, PlayerId(2), p2_pick);
+
+    let WaitingFor::CastOffer {
+        kind: CastOfferKind::FreeCastWindow { candidates, .. },
+        ..
+    } = &state.waiting_for
+    else {
+        panic!("expected barrier cast window, got {:?}", state.waiting_for);
+    };
+    assert_eq!(candidates, &vec![barrier_hit]);
+    assert!([p0_pick, p1_pick, p2_pick]
+        .iter()
+        .all(|prior| !candidates.contains(prior)));
+}


### PR DESCRIPTION
## Summary

Preserve the exact source-linked exile batch across paused multi-player player_scope fan-out, including save/reload, before resolving the detached trailing cast window. This is the prerequisite state-lifecycle slice extracted from PR #8223 after review exposed an intermediate resumed-seat omission.

## Files changed

- crates/engine/src/game/effects/mod.rs — accumulate, persist, restore, and bind exact incarnation batches across the generated APNAP queue.
- crates/engine/src/types/game_state.rs — add private serde-defaulted pending-continuation state and typed queue termination.
- crates/engine/tests/integration/main.rs — register the integration regression module.
- crates/engine/tests/integration/player_scope_linked_exile_batch.rs — positive 3-seat save/reload and negative ordinary producer-barrier regressions.

## Track

Developer

## LLM

Model: GPT-5 (Codex; canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 400.7j: new-zone objects after zone changes.
- CR 406.6: cards exiled together may be tracked as a linked pile.
- CR 608.2c: resolve instructions in printed order.
- CR 608.2j: effects may use information from earlier resolution steps.
- CR 101.4: APNAP ordering for simultaneous player choices.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- cargo test -p phase-engine --lib --quiet — 20,316 passed; 0 failed; 6 ignored.
- full integration suite — 5,876 passed; 0 failed; 2 ignored.
- focused linked-exile integration regressions — 2 passed; 0 failed.
- chained linked-consumer regression — 1 passed; 0 failed.
- cargo clippy -p phase-engine --all-targets -- -D warnings — passed.
- cargo fmt --all -- --check — passed.
- git diff --check — passed.
- bash scripts/check-parser-combinators.sh upstream/main — Gate G and Gate A passed.

## Gate A

Gate A PASS head=6d012fed5ad6a9963fd2d64930c83ddb729adaa6 base=2a067a66d64178b346b1c016f7207982096831af

## Anchored on

- crates/engine/src/game/effects/mod.rs:4539 — existing player-scope chain split/detached-tail authority.
- crates/engine/src/game/effects/mod.rs:9816 — existing serialized paused fan-out drain authority.

## Final review-impl

Final review-impl PASS head=6d012fed5ad6a9963fd2d64930c83ddb729adaa6

## Claimed parse impact

None.

## Scope Expansion

This is the independently mergeable player-scope continuation prerequisite extracted from PR #8223 to stay below the 800-line hard limit. ExileFromTopUntil replacement/no-hit lifecycle remains in PR #8223 after this prerequisite merges.

## Validation Failures

None.

## CI Failures

None.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved multiplayer exile resolution so all eligible exiled cards are correctly accumulated and available in the final resolution window.
  * Prevented duplicate exile events and unintended no-op events during interactive resolution.
  * Preserved correct behavior across pauses, including save and restore.
  * Ensured sequential exile effects properly separate independent batches.

* **Tests**
  * Added regression coverage for multiplayer linked-exile batches, chained resolution windows, and sequential effect boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->