### PR TITLE
chore: refresh metagame feeds

### DIFF
--- a/client/public/feeds/mtggoldfish-commander.json
+++ b/client/public/feeds/mtggoldfish-commander.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "commander",
   "version": 1,
-  "updated": "2026-08-30T00:00:00Z",
+  "updated": "2026-08-31T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/commander",
   "decks": [
     {
@@ -30,6 +30,18 @@
         },
         {
           "count": 1,
+          "name": "Arcane Sanctum"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
+          "name": "Archaeomancer's Map"
+        },
+        {
+          "count": 1,
           "name": "Archmage Emeritus"
         },
         {
@@ -38,7 +50,87 @@
         },
         {
           "count": 1,
+          "name": "Ash Barrens"
+        },
+        {
+          "count": 1,
+          "name": "Astrologian's Planisphere"
+        },
+        {
+          "count": 1,
+          "name": "Authority of the Consuls"
+        },
+        {
+          "count": 1,
           "name": "Baleful Strix"
+        },
+        {
+          "count": 1,
+          "name": "Bastion of Remembrance"
+        },
+        {
+          "count": 1,
+          "name": "Blue Mage's Cane"
+        },
+        {
+          "count": 1,
+          "name": "Champions from Beyond"
+        },
+        {
+          "count": 1,
+          "name": "Choked Estuary"
+        },
+        {
+          "count": 1,
+          "name": "Circle of Power"
+        },
+        {
+          "count": 1,
+          "name": "Cleansing Nova"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Contaminated Aquifer"
+        },
+        {
+          "count": 1,
+          "name": "Coveted Jewel"
+        },
+        {
+          "count": 1,
+          "name": "Crux of Fate"
+        },
+        {
+          "count": 1,
+          "name": "Cut a Deal"
+        },
+        {
+          "count": 1,
+          "name": "Dancer's Chakrams"
+        },
+        {
+          "count": 1,
+          "name": "Darkwater Catacombs"
+        },
+        {
+          "count": 1,
+          "name": "Demolition Field"
+        },
+        {
+          "count": 1,
+          "name": "Desolate Mire"
+        },
+        {
+          "count": 1,
+          "name": "Dig Through Time"
+        },
+        {
+          "count": 1,
+          "name": "Drowned Catacomb"
         },
         {
           "count": 1,
@@ -50,11 +142,39 @@
         },
         {
           "count": 1,
+          "name": "Evolving Wilds"
+        },
+        {
+          "count": 1,
+          "name": "Exotic Orchard"
+        },
+        {
+          "count": 1,
+          "name": "Exsanguinate"
+        },
+        {
+          "count": 1,
+          "name": "Eye of Nidhogg"
+        },
+        {
+          "count": 1,
           "name": "Fandaniel, Telophoroi Ascian"
         },
         {
           "count": 1,
+          "name": "Fetid Heath"
+        },
+        {
+          "count": 1,
+          "name": "Final Judgment"
+        },
+        {
+          "count": 1,
           "name": "G'raha Tia, Scion Reborn"
+        },
+        {
+          "count": 1,
+          "name": "Glacial Fortress"
         },
         {
           "count": 1,
@@ -74,7 +194,31 @@
         },
         {
           "count": 1,
+          "name": "Idyllic Beachfront"
+        },
+        {
+          "count": 1,
+          "name": "Into the Story"
+        },
+        {
+          "count": 3,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Isolated Chapel"
+        },
+        {
+          "count": 1,
           "name": "Krile Baldesion"
+        },
+        {
+          "count": 1,
+          "name": "Lethal Scheme"
+        },
+        {
+          "count": 1,
+          "name": "Lingering Souls"
         },
         {
           "count": 1,
@@ -86,251 +230,11 @@
         },
         {
           "count": 1,
-          "name": "Papalymo Totolymo"
-        },
-        {
-          "count": 1,
-          "name": "Summon: Good King Mog XII"
-        },
-        {
-          "count": 1,
-          "name": "Tataru Taru"
-        },
-        {
-          "count": 1,
-          "name": "Thancred Waters"
-        },
-        {
-          "count": 1,
-          "name": "Torrential Gearhulk"
-        },
-        {
-          "count": 1,
-          "name": "Urianger Augurelt"
-        },
-        {
-          "count": 1,
-          "name": "Dig Through Time"
-        },
-        {
-          "count": 1,
-          "name": "Into the Story"
-        },
-        {
-          "count": 1,
-          "name": "Lethal Scheme"
-        },
-        {
-          "count": 1,
-          "name": "Snuff Out"
-        },
-        {
-          "count": 1,
-          "name": "Sublime Epiphany"
-        },
-        {
-          "count": 1,
-          "name": "Swords to Plowshares"
-        },
-        {
-          "count": 1,
-          "name": "Transpose"
-        },
-        {
-          "count": 1,
-          "name": "Void Rend"
-        },
-        {
-          "count": 1,
-          "name": "Circle of Power"
-        },
-        {
-          "count": 1,
-          "name": "Cleansing Nova"
-        },
-        {
-          "count": 1,
-          "name": "Crux of Fate"
-        },
-        {
-          "count": 1,
-          "name": "Cut a Deal"
-        },
-        {
-          "count": 1,
-          "name": "Exsanguinate"
-        },
-        {
-          "count": 1,
-          "name": "Final Judgment"
-        },
-        {
-          "count": 1,
-          "name": "Lingering Souls"
-        },
-        {
-          "count": 1,
-          "name": "Rite of Replication"
-        },
-        {
-          "count": 1,
-          "name": "Syphon Mind"
-        },
-        {
-          "count": 1,
-          "name": "Vindicate"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Archaeomancer's Map"
-        },
-        {
-          "count": 1,
-          "name": "Astrologian's Planisphere"
-        },
-        {
-          "count": 1,
-          "name": "Blue Mage's Cane"
-        },
-        {
-          "count": 1,
-          "name": "Coveted Jewel"
-        },
-        {
-          "count": 1,
-          "name": "Dancer's Chakrams"
-        },
-        {
-          "count": 1,
-          "name": "Reaper's Scythe"
-        },
-        {
-          "count": 1,
-          "name": "Relic of Legends"
-        },
-        {
-          "count": 1,
-          "name": "Sage's Nouliths"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Dominance"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Hierarchy"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Progress"
-        },
-        {
-          "count": 1,
-          "name": "Thought Vessel"
-        },
-        {
-          "count": 1,
-          "name": "Tome of Legends"
-        },
-        {
-          "count": 1,
-          "name": "White Auracite"
-        },
-        {
-          "count": 1,
-          "name": "Authority of the Consuls"
-        },
-        {
-          "count": 1,
-          "name": "Bastion of Remembrance"
-        },
-        {
-          "count": 1,
-          "name": "Champions from Beyond"
-        },
-        {
-          "count": 1,
-          "name": "Eye of Nidhogg"
-        },
-        {
-          "count": 1,
           "name": "Observed Stasis"
         },
         {
           "count": 1,
-          "name": "Propaganda"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Sanctum"
-        },
-        {
-          "count": 1,
-          "name": "Ash Barrens"
-        },
-        {
-          "count": 1,
-          "name": "Choked Estuary"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Contaminated Aquifer"
-        },
-        {
-          "count": 1,
-          "name": "Darkwater Catacombs"
-        },
-        {
-          "count": 1,
-          "name": "Demolition Field"
-        },
-        {
-          "count": 1,
-          "name": "Desolate Mire"
-        },
-        {
-          "count": 1,
-          "name": "Drowned Catacomb"
-        },
-        {
-          "count": 1,
-          "name": "Evolving Wilds"
-        },
-        {
-          "count": 1,
-          "name": "Exotic Orchard"
-        },
-        {
-          "count": 1,
-          "name": "Fetid Heath"
-        },
-        {
-          "count": 1,
-          "name": "Glacial Fortress"
-        },
-        {
-          "count": 1,
-          "name": "Idyllic Beachfront"
-        },
-        {
-          "count": 3,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Isolated Chapel"
+          "name": "Papalymo Totolymo"
         },
         {
           "count": 1,
@@ -350,6 +254,26 @@
         },
         {
           "count": 1,
+          "name": "Propaganda"
+        },
+        {
+          "count": 1,
+          "name": "Reaper's Scythe"
+        },
+        {
+          "count": 1,
+          "name": "Relic of Legends"
+        },
+        {
+          "count": 1,
+          "name": "Rite of Replication"
+        },
+        {
+          "count": 1,
+          "name": "Sage's Nouliths"
+        },
+        {
+          "count": 1,
           "name": "Scavenger Grounds"
         },
         {
@@ -359,6 +283,22 @@
         {
           "count": 1,
           "name": "Skycloud Expanse"
+        },
+        {
+          "count": 1,
+          "name": "Snuff Out"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Sublime Epiphany"
+        },
+        {
+          "count": 1,
+          "name": "Summon: Good King Mog XII"
         },
         {
           "count": 1,
@@ -378,11 +318,71 @@
         },
         {
           "count": 1,
+          "name": "Swords to Plowshares"
+        },
+        {
+          "count": 1,
+          "name": "Syphon Mind"
+        },
+        {
+          "count": 1,
+          "name": "Talisman of Dominance"
+        },
+        {
+          "count": 1,
+          "name": "Talisman of Hierarchy"
+        },
+        {
+          "count": 1,
+          "name": "Talisman of Progress"
+        },
+        {
+          "count": 1,
+          "name": "Tataru Taru"
+        },
+        {
+          "count": 1,
           "name": "Temple of the False God"
         },
         {
           "count": 1,
+          "name": "Thancred Waters"
+        },
+        {
+          "count": 1,
+          "name": "Thought Vessel"
+        },
+        {
+          "count": 1,
+          "name": "Tome of Legends"
+        },
+        {
+          "count": 1,
+          "name": "Torrential Gearhulk"
+        },
+        {
+          "count": 1,
+          "name": "Transpose"
+        },
+        {
+          "count": 1,
           "name": "Underground River"
+        },
+        {
+          "count": 1,
+          "name": "Urianger Augurelt"
+        },
+        {
+          "count": 1,
+          "name": "Vindicate"
+        },
+        {
+          "count": 1,
+          "name": "Void Rend"
+        },
+        {
+          "count": 1,
+          "name": "White Auracite"
         },
         {
           "count": 1,
@@ -702,10 +702,6 @@
         "metagame"
       ],
       "main": [
-        {
-          "count": 1,
-          "name": "Thorin, King of Durin's Folk <019f75e5-20db-70eb-ae91-6e2e56fcd177> [HOC]"
-        },
         {
           "count": 1,
           "name": "Dain, Lord of the Iron Hills"
@@ -1041,15 +1037,21 @@
         {
           "count": 1,
           "name": "Forth Eorlingas!"
+        },
+        {
+          "count": 1,
+          "name": "Thorin, King of Durin's Folk <019f75e5-20db-70eb-ae91-6e2e56fcd177> [HOC]"
         }
       ],
       "sideboard": []
     },
     {
-      "name": "Beorn the Fierce",
+      "name": "Kaalia of the Vast",
       "author": "MTGGoldfish",
       "colors": [
-        "G"
+        "R",
+        "W",
+        "B"
       ],
       "tags": [
         "metagame"
@@ -1057,211 +1059,31 @@
       "main": [
         {
           "count": 1,
-          "name": "Beorn the Fierce"
+          "name": "Kaalia of the Vast"
         },
         {
           "count": 1,
-          "name": "Ayula, Queen Among Bears"
+          "name": "Arcane Signet"
         },
         {
           "count": 1,
-          "name": "The Earth King"
+          "name": "Boros Signet"
         },
         {
           "count": 1,
-          "name": "Vastlands Scavenger"
+          "name": "Commander's Sphere"
         },
         {
           "count": 1,
-          "name": "Chameleon Colossus"
+          "name": "Lightning Greaves"
         },
         {
           "count": 1,
-          "name": "Primordial Sage"
+          "name": "Orzhov Signet"
         },
         {
           "count": 1,
-          "name": "Selfless Safewright"
-        },
-        {
-          "count": 1,
-          "name": "Flaxen Intruder"
-        },
-        {
-          "count": 1,
-          "name": "Ghalta, Primal Hunger"
-        },
-        {
-          "count": 1,
-          "name": "Terrian, World Tyrant"
-        },
-        {
-          "count": 1,
-          "name": "Soul of the Harvest"
-        },
-        {
-          "count": 1,
-          "name": "Ursine Monstrosity"
-        },
-        {
-          "count": 1,
-          "name": "Owlbear Cub"
-        },
-        {
-          "count": 1,
-          "name": "Druid's Familiar"
-        },
-        {
-          "count": 1,
-          "name": "Llanowar Elves"
-        },
-        {
-          "count": 1,
-          "name": "Studious First-Year"
-        },
-        {
-          "count": 1,
-          "name": "Keeper of Fables"
-        },
-        {
-          "count": 1,
-          "name": "Garruk's Packleader"
-        },
-        {
-          "count": 1,
-          "name": "Bane of Progress"
-        },
-        {
-          "count": 1,
-          "name": "Lizard, Connors's Curse"
-        },
-        {
-          "count": 1,
-          "name": "Evercoat Ursine"
-        },
-        {
-          "count": 1,
-          "name": "Titan of Industry"
-        },
-        {
-          "count": 1,
-          "name": "Thunderfoot Baloth"
-        },
-        {
-          "count": 1,
-          "name": "Jubilation"
-        },
-        {
-          "count": 1,
-          "name": "Raucous Audience"
-        },
-        {
-          "count": 1,
-          "name": "Ilysian Caryatid"
-        },
-        {
-          "count": 1,
-          "name": "Quakestrider Ceratops"
-        },
-        {
-          "count": 1,
-          "name": "Ruxa, Patient Professor"
-        },
-        {
-          "count": 1,
-          "name": "Gigantosaurus"
-        },
-        {
-          "count": 1,
-          "name": "Owlbear"
-        },
-        {
-          "count": 1,
-          "name": "Goreclaw, Terror of Qal Sisma"
-        },
-        {
-          "count": 1,
-          "name": "Werebear"
-        },
-        {
-          "count": 1,
-          "name": "Chomping Changeling"
-        },
-        {
-          "count": 1,
-          "name": "Gigantic Big Bear"
-        },
-        {
-          "count": 1,
-          "name": "Titania's Command"
-        },
-        {
-          "count": 1,
-          "name": "Origin of Metalbending"
-        },
-        {
-          "count": 1,
-          "name": "Grizzly Fate"
-        },
-        {
-          "count": 1,
-          "name": "Kamahl's Summons"
-        },
-        {
-          "count": 1,
-          "name": "Overrun"
-        },
-        {
-          "count": 1,
-          "name": "Ram Through"
-        },
-        {
-          "count": 1,
-          "name": "Super Combo"
-        },
-        {
-          "count": 1,
-          "name": "Harmonize"
-        },
-        {
-          "count": 1,
-          "name": "Rampant Growth"
-        },
-        {
-          "count": 1,
-          "name": "Cultivate"
-        },
-        {
-          "count": 1,
-          "name": "Explosive Vegetation"
-        },
-        {
-          "count": 1,
-          "name": "Return of the Wildspeaker"
-        },
-        {
-          "count": 1,
-          "name": "Become the Avalanche"
-        },
-        {
-          "count": 1,
-          "name": "Beast Within"
-        },
-        {
-          "count": 1,
-          "name": "Shamanic Revelation"
-        },
-        {
-          "count": 1,
-          "name": "Oblivion Stone"
-        },
-        {
-          "count": 1,
-          "name": "Hunter's Bow"
-        },
-        {
-          "count": 1,
-          "name": "Lifecrafter's Bestiary"
+          "name": "Rakdos Signet"
         },
         {
           "count": 1,
@@ -1269,75 +1091,295 @@
         },
         {
           "count": 1,
-          "name": "Firdoch Core"
+          "name": "Swiftfoot Boots"
         },
         {
           "count": 1,
-          "name": "Mind Stone"
+          "name": "Talisman of Conviction"
         },
         {
           "count": 1,
-          "name": "Words of Wilding"
+          "name": "Talisman of Hierarchy"
         },
         {
           "count": 1,
-          "name": "Hunter's Talent"
+          "name": "Battlefield Forge"
         },
         {
           "count": 1,
-          "name": "Lignify"
+          "name": "Bloodfell Caves"
         },
         {
           "count": 1,
-          "name": "Garruk's Uprising"
+          "name": "Clifftop Retreat"
         },
         {
           "count": 1,
-          "name": "Fertile Ground"
+          "name": "Command Tower"
         },
         {
           "count": 1,
-          "name": "Wild Growth"
+          "name": "Evolving Wilds"
         },
         {
           "count": 1,
-          "name": "Ayula's Influence"
-        },
-        {
-          "count": 30,
-          "name": "Forest"
+          "name": "Exotic Orchard"
         },
         {
           "count": 1,
-          "name": "Turntimber Symbiosis"
+          "name": "Isolated Chapel"
+        },
+        {
+          "count": 6,
+          "name": "Mountain"
         },
         {
           "count": 1,
-          "name": "Bonders' Enclave"
+          "name": "Nomad Outpost"
+        },
+        {
+          "count": 8,
+          "name": "Plains"
         },
         {
           "count": 1,
-          "name": "Bridgeworks Battle"
+          "name": "Rogue's Passage"
         },
         {
           "count": 1,
-          "name": "Ominous Cemetery"
+          "name": "Scoured Barrens"
         },
         {
           "count": 1,
-          "name": "Mosswort Bridge"
+          "name": "Shattered Landscape"
+        },
+        {
+          "count": 8,
+          "name": "Swamp"
         },
         {
           "count": 1,
-          "name": "Lair of the Hydra"
+          "name": "Temple of Silence"
         },
         {
           "count": 1,
-          "name": "Khalni Ambush"
+          "name": "Temple of Triumph"
         },
         {
           "count": 1,
-          "name": "Disciple of Freyalise"
+          "name": "Terramorphic Expanse"
+        },
+        {
+          "count": 1,
+          "name": "Wind-Scarred Crag"
+        },
+        {
+          "count": 1,
+          "name": "Aegis Angel"
+        },
+        {
+          "count": 1,
+          "name": "Akroma, Angel of Fury"
+        },
+        {
+          "count": 1,
+          "name": "Angel of Despair"
+        },
+        {
+          "count": 1,
+          "name": "Angel of Serenity"
+        },
+        {
+          "count": 1,
+          "name": "Angel of the Ruins"
+        },
+        {
+          "count": 1,
+          "name": "Archfiend of Depravity"
+        },
+        {
+          "count": 1,
+          "name": "Aurelia, the Law Above"
+        },
+        {
+          "count": 1,
+          "name": "Aurelia, the Warleader"
+        },
+        {
+          "count": 1,
+          "name": "Bloodgift Demon"
+        },
+        {
+          "count": 1,
+          "name": "Demon of Loathing"
+        },
+        {
+          "count": 1,
+          "name": "Demonlord Belzenlok"
+        },
+        {
+          "count": 1,
+          "name": "Dragon Mage"
+        },
+        {
+          "count": 1,
+          "name": "Drakuseth, Maw of Flames"
+        },
+        {
+          "count": 1,
+          "name": "Giada, Font of Hope"
+        },
+        {
+          "count": 1,
+          "name": "Gisela, Blade of Goldnight"
+        },
+        {
+          "count": 1,
+          "name": "Harvester of Souls"
+        },
+        {
+          "count": 1,
+          "name": "Indulgent Tormentor"
+        },
+        {
+          "count": 1,
+          "name": "Isshin, Two Heavens as One"
+        },
+        {
+          "count": 1,
+          "name": "Karmic Guide"
+        },
+        {
+          "count": 1,
+          "name": "Liesa, Forgotten Archangel"
+        },
+        {
+          "count": 1,
+          "name": "Master of Cruelties"
+        },
+        {
+          "count": 1,
+          "name": "Overseer of the Damned"
+        },
+        {
+          "count": 1,
+          "name": "Piru, the Volatile"
+        },
+        {
+          "count": 1,
+          "name": "Reya Dawnbringer"
+        },
+        {
+          "count": 1,
+          "name": "Rune-Scarred Demon"
+        },
+        {
+          "count": 1,
+          "name": "Scourge of the Throne"
+        },
+        {
+          "count": 1,
+          "name": "Sephara, Sky's Blade"
+        },
+        {
+          "count": 1,
+          "name": "Shilgengar, Sire of Famine"
+        },
+        {
+          "count": 1,
+          "name": "Steel Hellkite"
+        },
+        {
+          "count": 1,
+          "name": "Tariel, Reckoner of Souls"
+        },
+        {
+          "count": 1,
+          "name": "Vile Mutilator"
+        },
+        {
+          "count": 1,
+          "name": "Kaya's Ghostform"
+        },
+        {
+          "count": 1,
+          "name": "Phyrexian Arena"
+        },
+        {
+          "count": 1,
+          "name": "Rising of the Day"
+        },
+        {
+          "count": 1,
+          "name": "Warstorm Surge"
+        },
+        {
+          "count": 1,
+          "name": "Windcrag Siege"
+        },
+        {
+          "count": 1,
+          "name": "Boros Charm"
+        },
+        {
+          "count": 1,
+          "name": "Crackling Doom"
+        },
+        {
+          "count": 1,
+          "name": "Despark"
+        },
+        {
+          "count": 1,
+          "name": "Mortify"
+        },
+        {
+          "count": 1,
+          "name": "Path to Exile"
+        },
+        {
+          "count": 1,
+          "name": "Rakdos Charm"
+        },
+        {
+          "count": 1,
+          "name": "Swords to Plowshares"
+        },
+        {
+          "count": 1,
+          "name": "Terminate"
+        },
+        {
+          "count": 1,
+          "name": "Thrill of Possibility"
+        },
+        {
+          "count": 1,
+          "name": "Diabolic Tutor"
+        },
+        {
+          "count": 1,
+          "name": "Faithless Looting"
+        },
+        {
+          "count": 1,
+          "name": "Night's Whisper"
+        },
+        {
+          "count": 1,
+          "name": "Painful Truths"
+        },
+        {
+          "count": 1,
+          "name": "Read the Bones"
+        },
+        {
+          "count": 1,
+          "name": "Sign in Blood"
+        },
+        {
+          "count": 1,
+          "name": "Unburial Rites"
         }
       ],
       "sideboard": []
@@ -1758,12 +1800,10 @@
       "sideboard": []
     },
     {
-      "name": "Kaalia of the Vast",
+      "name": "Beorn the Fierce",
       "author": "MTGGoldfish",
       "colors": [
-        "W",
-        "B",
-        "R"
+        "G"
       ],
       "tags": [
         "metagame"
@@ -1771,39 +1811,211 @@
       "main": [
         {
           "count": 1,
-          "name": "Sephara, Sky's Blade"
+          "name": "Beorn the Fierce"
         },
         {
           "count": 1,
-          "name": "Aurelia, the Warleader"
+          "name": "Ayula, Queen Among Bears"
         },
         {
           "count": 1,
-          "name": "Spawn of Mayhem"
+          "name": "The Earth King"
         },
         {
           "count": 1,
-          "name": "Doom Whisperer"
+          "name": "Vastlands Scavenger"
         },
         {
           "count": 1,
-          "name": "Master of Cruelties"
+          "name": "Chameleon Colossus"
         },
         {
           "count": 1,
-          "name": "Rakdos, Lord of Riots"
+          "name": "Primordial Sage"
         },
         {
           "count": 1,
-          "name": "Vilis, Broker of Blood"
+          "name": "Selfless Safewright"
         },
         {
           "count": 1,
-          "name": "Liliana's Contract"
+          "name": "Flaxen Intruder"
         },
         {
           "count": 1,
-          "name": "Lightning Greaves"
+          "name": "Ghalta, Primal Hunger"
+        },
+        {
+          "count": 1,
+          "name": "Terrian, World Tyrant"
+        },
+        {
+          "count": 1,
+          "name": "Soul of the Harvest"
+        },
+        {
+          "count": 1,
+          "name": "Ursine Monstrosity"
+        },
+        {
+          "count": 1,
+          "name": "Owlbear Cub"
+        },
+        {
+          "count": 1,
+          "name": "Druid's Familiar"
+        },
+        {
+          "count": 1,
+          "name": "Llanowar Elves"
+        },
+        {
+          "count": 1,
+          "name": "Studious First-Year"
+        },
+        {
+          "count": 1,
+          "name": "Keeper of Fables"
+        },
+        {
+          "count": 1,
+          "name": "Garruk's Packleader"
+        },
+        {
+          "count": 1,
+          "name": "Bane of Progress"
+        },
+        {
+          "count": 1,
+          "name": "Lizard, Connors's Curse"
+        },
+        {
+          "count": 1,
+          "name": "Evercoat Ursine"
+        },
+        {
+          "count": 1,
+          "name": "Titan of Industry"
+        },
+        {
+          "count": 1,
+          "name": "Thunderfoot Baloth"
+        },
+        {
+          "count": 1,
+          "name": "Jubilation"
+        },
+        {
+          "count": 1,
+          "name": "Raucous Audience"
+        },
+        {
+          "count": 1,
+          "name": "Ilysian Caryatid"
+        },
+        {
+          "count": 1,
+          "name": "Quakestrider Ceratops"
+        },
+        {
+          "count": 1,
+          "name": "Ruxa, Patient Professor"
+        },
+        {
+          "count": 1,
+          "name": "Gigantosaurus"
+        },
+        {
+          "count": 1,
+          "name": "Owlbear"
+        },
+        {
+          "count": 1,
+          "name": "Goreclaw, Terror of Qal Sisma"
+        },
+        {
+          "count": 1,
+          "name": "Werebear"
+        },
+        {
+          "count": 1,
+          "name": "Chomping Changeling"
+        },
+        {
+          "count": 1,
+          "name": "Gigantic Big Bear"
+        },
+        {
+          "count": 1,
+          "name": "Titania's Command"
+        },
+        {
+          "count": 1,
+          "name": "Origin of Metalbending"
+        },
+        {
+          "count": 1,
+          "name": "Grizzly Fate"
+        },
+        {
+          "count": 1,
+          "name": "Kamahl's Summons"
+        },
+        {
+          "count": 1,
+          "name": "Overrun"
+        },
+        {
+          "count": 1,
+          "name": "Ram Through"
+        },
+        {
+          "count": 1,
+          "name": "Super Combo"
+        },
+        {
+          "count": 1,
+          "name": "Harmonize"
+        },
+        {
+          "count": 1,
+          "name": "Rampant Growth"
+        },
+        {
+          "count": 1,
+          "name": "Cultivate"
+        },
+        {
+          "count": 1,
+          "name": "Explosive Vegetation"
+        },
+        {
+          "count": 1,
+          "name": "Return of the Wildspeaker"
+        },
+        {
+          "count": 1,
+          "name": "Become the Avalanche"
+        },
+        {
+          "count": 1,
+          "name": "Beast Within"
+        },
+        {
+          "count": 1,
+          "name": "Shamanic Revelation"
+        },
+        {
+          "count": 1,
+          "name": "Oblivion Stone"
+        },
+        {
+          "count": 1,
+          "name": "Hunter's Bow"
+        },
+        {
+          "count": 1,
+          "name": "Lifecrafter's Bestiary"
         },
         {
           "count": 1,
@@ -1811,323 +2023,75 @@
         },
         {
           "count": 1,
-          "name": "Swiftfoot Boots"
+          "name": "Firdoch Core"
         },
         {
           "count": 1,
-          "name": "Arcane Signet"
+          "name": "Mind Stone"
         },
         {
           "count": 1,
-          "name": "Rakdos Signet"
+          "name": "Words of Wilding"
         },
         {
           "count": 1,
-          "name": "Boros Signet"
+          "name": "Hunter's Talent"
         },
         {
           "count": 1,
-          "name": "Orzhov Signet"
+          "name": "Lignify"
         },
         {
           "count": 1,
-          "name": "Valakut Awakening"
+          "name": "Garruk's Uprising"
         },
         {
           "count": 1,
-          "name": "Boros Charm"
+          "name": "Fertile Ground"
         },
         {
           "count": 1,
-          "name": "Dark Ritual"
+          "name": "Wild Growth"
         },
         {
           "count": 1,
-          "name": "Ruinous Ultimatum"
+          "name": "Ayula's Influence"
         },
         {
-          "count": 1,
-          "name": "Blasphemous Act"
-        },
-        {
-          "count": 1,
-          "name": "Demonic Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Vesuva"
-        },
-        {
-          "count": 1,
-          "name": "Savai Triome"
-        },
-        {
-          "count": 1,
-          "name": "Rugged Prairie"
-        },
-        {
-          "count": 1,
-          "name": "Fetid Heath"
-        },
-        {
-          "count": 1,
-          "name": "Graven Cairns"
-        },
-        {
-          "count": 1,
-          "name": "Godless Shrine"
-        },
-        {
-          "count": 1,
-          "name": "Arid Mesa"
-        },
-        {
-          "count": 1,
-          "name": "Flagstones of Trokair"
-        },
-        {
-          "count": 1,
-          "name": "Blightstep Pathway"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Temple of Triumph"
-        },
-        {
-          "count": 1,
-          "name": "Temple of Silence"
-        },
-        {
-          "count": 1,
-          "name": "Clifftop Retreat"
-        },
-        {
-          "count": 1,
-          "name": "Dragonskull Summit"
-        },
-        {
-          "count": 1,
-          "name": "Sacred Foundry"
-        },
-        {
-          "count": 3,
-          "name": "Mountain"
-        },
-        {
-          "count": 7,
-          "name": "Swamp"
-        },
-        {
-          "count": 3,
-          "name": "Plains"
-        },
-        {
-          "count": 1,
-          "name": "Razaketh, the Foulblooded"
-        },
-        {
-          "count": 1,
-          "name": "Archfiend of Despair"
-        },
-        {
-          "count": 1,
-          "name": "Demonlord Belzenlok"
-        },
-        {
-          "count": 1,
-          "name": "Overseer of the Damned"
-        },
-        {
-          "count": 1,
-          "name": "Rune-Scarred Demon"
-        },
-        {
-          "count": 1,
-          "name": "Archfiend of Depravity"
-        },
-        {
-          "count": 1,
-          "name": "Lord of the Void"
-        },
-        {
-          "count": 1,
-          "name": "Demon of Wailing Agonies"
-        },
-        {
-          "count": 1,
-          "name": "Harvester of Souls"
-        },
-        {
-          "count": 1,
-          "name": "Bloodgift Demon"
-        },
-        {
-          "count": 1,
-          "name": "Demon of Loathing"
-        },
-        {
-          "count": 1,
-          "name": "Reaper from the Abyss"
-        },
-        {
-          "count": 1,
-          "name": "Kaalia of the Vast"
-        },
-        {
-          "count": 1,
-          "name": "Terminate"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Hierarchy"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Conviction"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Indulgence"
-        },
-        {
-          "count": 1,
-          "name": "Utter End"
-        },
-        {
-          "count": 1,
-          "name": "Vindicate"
-        },
-        {
-          "count": 1,
-          "name": "Demonic Counsel"
-        },
-        {
-          "count": 1,
-          "name": "Rakdos Charm"
-        },
-        {
-          "count": 1,
-          "name": "Unholy Annex // Ritual Chamber"
-        },
-        {
-          "count": 1,
-          "name": "Varragoth, Bloodsky Sire"
-        },
-        {
-          "count": 1,
-          "name": "Arena of Glory"
-        },
-        {
-          "count": 1,
-          "name": "Phyrexian Arena"
-        },
-        {
-          "count": 1,
-          "name": "Swords to Plowshares"
-        },
-        {
-          "count": 1,
-          "name": "Herald of Slaanesh"
-        },
-        {
-          "count": 1,
-          "name": "Dragon Tempest"
-        },
-        {
-          "count": 1,
-          "name": "Marsh Flats"
-        },
-        {
-          "count": 1,
-          "name": "Bloodstained Mire"
-        },
-        {
-          "count": 1,
-          "name": "Badlands"
-        },
-        {
-          "count": 1,
-          "name": "Black Market Connections"
-        },
-        {
-          "count": 1,
-          "name": "Damn"
-        },
-        {
-          "count": 1,
-          "name": "Giver of Runes"
-        },
-        {
-          "count": 1,
-          "name": "Mother of Runes"
-        },
-        {
-          "count": 1,
-          "name": "Professional Face-Breaker"
-        },
-        {
-          "count": 1,
-          "name": "Hall of the Bandit Lord"
-        },
-        {
-          "count": 1,
-          "name": "Crashing Drawbridge"
-        },
-        {
-          "count": 1,
-          "name": "City of Brass"
-        },
-        {
-          "count": 1,
-          "name": "Necropotence"
-        },
-        {
-          "count": 1,
-          "name": "Vampiric Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Valgavoth, Terror Eater"
-        },
-        {
-          "count": 1,
-          "name": "Hoarding Broodlord"
+          "count": 30,
+          "name": "Forest"
         },
         {
           "count": 1,
-          "name": "Imperial Seal"
+          "name": "Turntimber Symbiosis"
         },
         {
           "count": 1,
-          "name": "Balefire Dragon"
+          "name": "Bonders' Enclave"
         },
         {
           "count": 1,
-          "name": "Avacyn, Angel of Hope"
+          "name": "Bridgeworks Battle"
         },
         {
           "count": 1,
-          "name": "Anguished Unmaking"
+          "name": "Ominous Cemetery"
         },
         {
           "count": 1,
-          "name": "Animate Dead"
+          "name": "Mosswort Bridge"
         },
         {
           "count": 1,
-          "name": "Armageddon"
+          "name": "Lair of the Hydra"
         },
         {
           "count": 1,
-          "name": "Cabal Ritual"
+          "name": "Khalni Ambush"
         },
         {
           "count": 1,
-          "name": "Insidious Dreams"
+          "name": "Disciple of Freyalise"
         }
       ],
       "sideboard": []
@@ -2145,243 +2109,7 @@
       "main": [
         {
           "count": 1,
-          "name": "Abandoned Air Temple"
-        },
-        {
-          "count": 1,
-          "name": "Aetherflux Reservoir"
-        },
-        {
-          "count": 1,
-          "name": "An Unexpected Party"
-        },
-        {
-          "count": 1,
-          "name": "Angel of Invention"
-        },
-        {
-          "count": 1,
-          "name": "Authority of the Consuls"
-        },
-        {
-          "count": 1,
-          "name": "Bard the Bowman"
-        },
-        {
-          "count": 1,
-          "name": "Bard's Company"
-        },
-        {
-          "count": 1,
           "name": "Bard, King of Dale"
-        },
-        {
-          "count": 1,
-          "name": "Belladonna Took"
-        },
-        {
-          "count": 1,
-          "name": "Bender's Waterskin"
-        },
-        {
-          "count": 1,
-          "name": "Bilbo's Gambit"
-        },
-        {
-          "count": 1,
-          "name": "Bilbo, Luckwearer"
-        },
-        {
-          "count": 1,
-          "name": "Bilbo, Thief in the Night"
-        },
-        {
-          "count": 1,
-          "name": "Celebrate the Mountain-king"
-        },
-        {
-          "count": 1,
-          "name": "Clone Legion"
-        },
-        {
-          "count": 1,
-          "name": "Collective Effort"
-        },
-        {
-          "count": 1,
-          "name": "Confusticate and Bebother"
-        },
-        {
-          "count": 1,
-          "name": "Crashing Wave"
-        },
-        {
-          "count": 1,
-          "name": "Daze"
-        },
-        {
-          "count": 1,
-          "name": "Dain, Lord of the Iron Hills"
-        },
-        {
-          "count": 1,
-          "name": "Docent of Perfection"
-        },
-        {
-          "count": 1,
-          "name": "Dispel"
-        },
-        {
-          "count": 1,
-          "name": "Ember Island Production"
-        },
-        {
-          "count": 1,
-          "name": "Esgaroth Garrison"
-        },
-        {
-          "count": 1,
-          "name": "Essence Scatter"
-        },
-        {
-          "count": 1,
-          "name": "Extricator of Sin"
-        },
-        {
-          "count": 1,
-          "name": "Faramir, Prince of Ithilien"
-        },
-        {
-          "count": 1,
-          "name": "Glamdring, Foe-hammer"
-        },
-        {
-          "count": 1,
-          "name": "Great Gilded Boat"
-        },
-        {
-          "count": 1,
-          "name": "Halo Fountain"
-        },
-        {
-          "count": 1,
-          "name": "Hedron Crawler"
-        },
-        {
-          "count": 1,
-          "name": "Insidious Will"
-        },
-        {
-          "count": 16,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Katara, Water Tribe's Hope"
-        },
-        {
-          "count": 1,
-          "name": "Lake-town"
-        },
-        {
-          "count": 1,
-          "name": "Lake-town Lookout"
-        },
-        {
-          "count": 1,
-          "name": "Library of Leng"
-        },
-        {
-          "count": 1,
-          "name": "Magnifying Glass"
-        },
-        {
-          "count": 1,
-          "name": "Mind's Dilation"
-        },
-        {
-          "count": 1,
-          "name": "Mystic Remora"
-        },
-        {
-          "count": 1,
-          "name": "Nephalia Academy"
-        },
-        {
-          "count": 1,
-          "name": "North Pole Gates"
-        },
-        {
-          "count": 1,
-          "name": "Odric, Lunarch Marshal"
-        },
-        {
-          "count": 1,
-          "name": "Basri, Tomorrow's Champion"
-        },
-        {
-          "count": 16,
-          "name": "Plains"
-        },
-        {
-          "count": 1,
-          "name": "Psychosis Crawler"
-        },
-        {
-          "count": 1,
-          "name": "Prince Imrahil the Fair"
-        },
-        {
-          "count": 1,
-          "name": "Plunder the Trollshaws"
-        },
-        {
-          "count": 1,
-          "name": "Ravenhill Flock"
-        },
-        {
-          "count": 1,
-          "name": "Repel the Abominable"
-        },
-        {
-          "count": 1,
-          "name": "Reprieve"
-        },
-        {
-          "count": 1,
-          "name": "Rootborn Defenses"
-        },
-        {
-          "count": 1,
-          "name": "Sea Gate Restoration"
-        },
-        {
-          "count": 1,
-          "name": "Settle the Wreckage"
-        },
-        {
-          "count": 1,
-          "name": "Sound the Trumpets"
-        },
-        {
-          "count": 1,
-          "name": "Spectral Reserves"
-        },
-        {
-          "count": 1,
-          "name": "Sram's Expertise"
-        },
-        {
-          "count": 1,
-          "name": "Suki, Courageous Rescuer"
-        },
-        {
-          "count": 1,
-          "name": "Thalia, Heretic Cathar"
-        },
-        {
-          "count": 1,
-          "name": "The Arkenstone"
         },
         {
           "count": 1,
@@ -2389,7 +2117,59 @@
         },
         {
           "count": 1,
-          "name": "The Mechanist, Aerial Artisan"
+          "name": "Eerie Interference"
+        },
+        {
+          "count": 1,
+          "name": "Esgaroth Garrison"
+        },
+        {
+          "count": 1,
+          "name": "Sleep"
+        },
+        {
+          "count": 1,
+          "name": "A.I.M. Scientists"
+        },
+        {
+          "count": 1,
+          "name": "Palace Guard"
+        },
+        {
+          "count": 1,
+          "name": "Essence Capture"
+        },
+        {
+          "count": 1,
+          "name": "Lake-town"
+        },
+        {
+          "count": 1,
+          "name": "Celebrate the Mountain-king"
+        },
+        {
+          "count": 1,
+          "name": "Master's Councillors"
+        },
+        {
+          "count": 1,
+          "name": "Patient Instructor"
+        },
+        {
+          "count": 1,
+          "name": "Bilbo, Luckwearer"
+        },
+        {
+          "count": 1,
+          "name": "Long Lake Nuisance"
+        },
+        {
+          "count": 1,
+          "name": "Pacifism"
+        },
+        {
+          "count": 1,
+          "name": "Repulse"
         },
         {
           "count": 1,
@@ -2397,31 +2177,187 @@
         },
         {
           "count": 1,
-          "name": "The Queen of Dale"
+          "name": "Born to Drive"
         },
         {
           "count": 1,
-          "name": "Topplegeist"
+          "name": "Lakeshore Apothecary"
         },
         {
           "count": 1,
-          "name": "Tranquil Cove"
+          "name": "Lake-town Lookout"
         },
         {
           "count": 1,
-          "name": "Troop of Ponies"
+          "name": "Downpour"
         },
         {
           "count": 1,
-          "name": "Uncover the Moon-Letters"
+          "name": "Captain's Defense"
         },
         {
           "count": 1,
-          "name": "Waterbending Lesson"
+          "name": "Pym Particles"
         },
         {
           "count": 1,
-          "name": "Wizard's Staff"
+          "name": "Hermes, Overseer of Elpis"
+        },
+        {
+          "count": 1,
+          "name": "Alphinaud Leveilleur"
+        },
+        {
+          "count": 1,
+          "name": "Super Intelligence"
+        },
+        {
+          "count": 1,
+          "name": "Sound the Trumpets"
+        },
+        {
+          "count": 1,
+          "name": "Blue Marvel, Adam Brashear"
+        },
+        {
+          "count": 1,
+          "name": "Firemind Vessel"
+        },
+        {
+          "count": 1,
+          "name": "Plunder the Trollshaws"
+        },
+        {
+          "count": 1,
+          "name": "Bard's Company"
+        },
+        {
+          "count": 1,
+          "name": "Old Thrush"
+        },
+        {
+          "count": 1,
+          "name": "Most Decrepit Old Bird"
+        },
+        {
+          "count": 1,
+          "name": "Enchanted River's Grasp"
+        },
+        {
+          "count": 1,
+          "name": "Sensor Splicer"
+        },
+        {
+          "count": 1,
+          "name": "Luxurious Locomotive"
+        },
+        {
+          "count": 1,
+          "name": "Bard the Bowman"
+        },
+        {
+          "count": 1,
+          "name": "Old Fat Spider Can't See Me"
+        },
+        {
+          "count": 1,
+          "name": "Ravenhill Flock"
+        },
+        {
+          "count": 1,
+          "name": "Call the Cavalry"
+        },
+        {
+          "count": 1,
+          "name": "Bilbo Baggins, Burglar"
+        },
+        {
+          "count": 1,
+          "name": "Essence Scatter"
+        },
+        {
+          "count": 1,
+          "name": "Ministrant of Obligation"
+        },
+        {
+          "count": 1,
+          "name": "S.H.I.E.L.D. Deployment Drone"
+        },
+        {
+          "count": 1,
+          "name": "Futurist Forge"
+        },
+        {
+          "count": 1,
+          "name": "Dwarven Provisioner"
+        },
+        {
+          "count": 1,
+          "name": "Knightly Valor"
+        },
+        {
+          "count": 1,
+          "name": "Talrand's Invocation"
+        },
+        {
+          "count": 1,
+          "name": "Waterwind Scout"
+        },
+        {
+          "count": 1,
+          "name": "Harrier Strix"
+        },
+        {
+          "count": 1,
+          "name": "Storm Herd"
+        },
+        {
+          "count": 1,
+          "name": "Harbin, Vanguard Aviator"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Azorius Cluestone"
+        },
+        {
+          "count": 1,
+          "name": "Azorius Locket"
+        },
+        {
+          "count": 1,
+          "name": "Azorius Keyrune"
+        },
+        {
+          "count": 1,
+          "name": "Azorius Signet"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
+          "name": "Bard, Heir of Girion"
+        },
+        {
+          "count": 22,
+          "name": "Island"
+        },
+        {
+          "count": 17,
+          "name": "Plains"
+        },
+        {
+          "count": 1,
+          "name": "Fili the Pathfinder"
+        },
+        {
+          "count": 1,
+          "name": "Thorin's Last Stand"
         }
       ],
       "sideboard": []
@@ -2430,8 +2366,8 @@
       "name": "The Great Goblin",
       "author": "MTGGoldfish",
       "colors": [
-        "B",
-        "R"
+        "R",
+        "B"
       ],
       "tags": [
         "metagame"
@@ -2439,255 +2375,7 @@
       "main": [
         {
           "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "The Great Goblin"
-        },
-        {
-          "count": 1,
-          "name": "Assault on Osgiliath"
-        },
-        {
-          "count": 1,
-          "name": "Chain Reaction"
-        },
-        {
-          "count": 1,
-          "name": "Swarming of Moria"
-        },
-        {
-          "count": 1,
-          "name": "Book of Mazarbul"
-        },
-        {
-          "count": 1,
-          "name": "Warbeast of Gorgoroth"
-        },
-        {
-          "count": 1,
-          "name": "Fear, Fire, Foes!"
-        },
-        {
-          "count": 1,
-          "name": "Drakuseth, Maw of Flames"
-        },
-        {
-          "count": 1,
-          "name": "Gathering of Darkness"
-        },
-        {
-          "count": 1,
-          "name": "Foray of Orcs"
-        },
-        {
-          "count": 1,
-          "name": "Gothmog, Morgul Lieutenant"
-        },
-        {
-          "count": 1,
-          "name": "Ugluk of the White Hand"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Fireleaper"
-        },
-        {
-          "count": 1,
-          "name": "Moria Marauder"
-        },
-        {
-          "count": 1,
-          "name": "Choreographed Sparks"
-        },
-        {
-          "count": 1,
-          "name": "Tidings of War"
-        },
-        {
-          "count": 1,
-          "name": "Mudbutton Cursetosser"
-        },
-        {
-          "count": 1,
-          "name": "Fireblade Charger"
-        },
-        {
-          "count": 1,
-          "name": "Frenzied Goblin"
-        },
-        {
-          "count": 1,
-          "name": "Stir Up Trouble"
-        },
-        {
-          "count": 1,
-          "name": "Impractical Joke"
-        },
-        {
-          "count": 1,
-          "name": "Great Train Heist"
-        },
-        {
-          "count": 1,
-          "name": "March from the Black Gate"
-        },
-        {
-          "count": 1,
-          "name": "Orcish Medicine"
-        },
-        {
-          "count": 1,
-          "name": "Mauhur, Uruk-hai Captain"
-        },
-        {
-          "count": 1,
-          "name": "Mordor Muster"
-        },
-        {
-          "count": 1,
-          "name": "Dai Li Indoctrination"
-        },
-        {
-          "count": 1,
-          "name": "Iroh's Demonstration"
-        },
-        {
-          "count": 1,
-          "name": "Boggart Cursecrafter"
-        },
-        {
-          "count": 1,
-          "name": "Draconautics Engineer"
-        },
-        {
-          "count": 1,
-          "name": "Fling"
-        },
-        {
-          "count": 1,
-          "name": "Gorbag of Minas Morgul"
-        },
-        {
-          "count": 1,
-          "name": "Transmogrant Altar"
-        },
-        {
-          "count": 1,
-          "name": "Grub, Storied Matriarch"
-        },
-        {
-          "count": 1,
-          "name": "Boggart Mischief"
-        },
-        {
-          "count": 1,
-          "name": "Mordor Trebuchet"
-        },
-        {
-          "count": 1,
-          "name": "Gnashing of Teeth"
-        },
-        {
-          "count": 1,
-          "name": "Bothersome Noisemaker"
-        },
-        {
-          "count": 1,
-          "name": "Underworld Breach"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Plate Mail"
-        },
-        {
-          "count": 1,
-          "name": "Goblin-town Flunkies"
-        },
-        {
-          "count": 1,
-          "name": "Easterling Vanguard"
-        },
-        {
-          "count": 1,
-          "name": "The Torment of Gollum"
-        },
-        {
-          "count": 1,
-          "name": "Dunland Crebain"
-        },
-        {
-          "count": 1,
-          "name": "Sourbread Auntie"
-        },
-        {
-          "count": 1,
-          "name": "Champion of the Weird"
-        },
-        {
-          "count": 1,
-          "name": "Gutsplitter Gang"
-        },
-        {
-          "count": 1,
-          "name": "Redcap Gutter-Dweller"
-        },
-        {
-          "count": 1,
-          "name": "Buzzard-Wasp Colony"
-        },
-        {
-          "count": 1,
-          "name": "Grond, the Gatebreaker"
-        },
-        {
-          "count": 1,
-          "name": "Burn, Burn, Tree and Fern"
-        },
-        {
-          "count": 1,
-          "name": "Great Ugly-Looking Goblin"
-        },
-        {
-          "count": 1,
-          "name": "Misty Mountains Raider"
-        },
-        {
-          "count": 1,
-          "name": "Bolg of the North"
-        },
-        {
-          "count": 1,
-          "name": "Fearsome Goblin Pair"
-        },
-        {
-          "count": 1,
-          "name": "Down, Down to Goblin-town"
-        },
-        {
-          "count": 1,
-          "name": "Rage into the Valley"
-        },
-        {
-          "count": 1,
-          "name": "Grishnakh, Brash Instigator"
-        },
-        {
-          "count": 1,
-          "name": "Sting-Slinger"
-        },
-        {
-          "count": 1,
-          "name": "Rhovanion Rampager"
-        },
-        {
-          "count": 1,
-          "name": "Bilbo's Deadly Slice"
+          "name": "Along the Crooked Way"
         },
         {
           "count": 1,
@@ -2695,15 +2383,79 @@
         },
         {
           "count": 1,
-          "name": "Realm of Koh"
+          "name": "Azog, Moria's Ruin"
         },
         {
           "count": 1,
-          "name": "Hobbit Hole"
+          "name": "Beetleback Chief"
         },
         {
           "count": 1,
-          "name": "Secluded Courtyard"
+          "name": "Bloodfell Caves"
+        },
+        {
+          "count": 1,
+          "name": "Boggart Birth Rite"
+        },
+        {
+          "count": 1,
+          "name": "Boggart Cursecrafter"
+        },
+        {
+          "count": 1,
+          "name": "Bolg's Company"
+        },
+        {
+          "count": 1,
+          "name": "Chain Reaction"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Dragon Fodder"
+        },
+        {
+          "count": 1,
+          "name": "Foreboding Ruins"
+        },
+        {
+          "count": 1,
+          "name": "Gathering of Darkness"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Cratermaker"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Fireleaper"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Instigator"
+        },
+        {
+          "count": 1,
+          "name": "The Great Goblin"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Matron"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Motivator"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Negotiation"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Surprise"
         },
         {
           "count": 1,
@@ -2711,19 +2463,259 @@
         },
         {
           "count": 1,
-          "name": "Barad-dur"
+          "name": "Great Ugly-Looking Goblin"
         },
         {
           "count": 1,
-          "name": "The Grey Havens"
+          "name": "Grond, the Gatebreaker"
         },
         {
-          "count": 15,
+          "count": 1,
+          "name": "Grub's Command"
+        },
+        {
+          "count": 1,
+          "name": "Hordeling Outburst"
+        },
+        {
+          "count": 1,
+          "name": "Krenko's Command"
+        },
+        {
+          "count": 1,
+          "name": "Krenko, Mob Boss"
+        },
+        {
+          "count": 1,
+          "name": "Mauhur, Uruk-hai Captain"
+        },
+        {
+          "count": 1,
+          "name": "Mob Justice"
+        },
+        {
+          "count": 1,
+          "name": "Mordor Muster"
+        },
+        {
+          "count": 1,
+          "name": "Mudbutton Torchrunner"
+        },
+        {
+          "count": 1,
+          "name": "Munitions Expert"
+        },
+        {
+          "count": 1,
+          "name": "Orcish Cannonade"
+        },
+        {
+          "count": 1,
+          "name": "Orcish Medicine"
+        },
+        {
+          "count": 1,
+          "name": "Orcish Vandal"
+        },
+        {
+          "count": 1,
+          "name": "Rage into the Valley"
+        },
+        {
+          "count": 1,
+          "name": "Siege-Gang Commander"
+        },
+        {
+          "count": 1,
+          "name": "Smoldering Marsh"
+        },
+        {
+          "count": 1,
+          "name": "Stir Up Trouble"
+        },
+        {
+          "count": 1,
+          "name": "Swarming of Moria"
+        },
+        {
+          "count": 1,
+          "name": "The Torment of Gollum"
+        },
+        {
+          "count": 1,
+          "name": "Volley Veteran"
+        },
+        {
+          "count": 8,
+          "name": "Mountain"
+        },
+        {
+          "count": 8,
           "name": "Swamp"
         },
         {
-          "count": 15,
-          "name": "Mountain"
+          "count": 1,
+          "name": "Goblin Bombardment"
+        },
+        {
+          "count": 1,
+          "name": "Go for the Throat"
+        },
+        {
+          "count": 1,
+          "name": "Blasphemous Act"
+        },
+        {
+          "count": 1,
+          "name": "Warg Rider"
+        },
+        {
+          "count": 1,
+          "name": "Sling-Gang Lieutenant"
+        },
+        {
+          "count": 1,
+          "name": "Mirkwood Bats"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Trashmaster"
+        },
+        {
+          "count": 1,
+          "name": "Warren Soultrader"
+        },
+        {
+          "count": 1,
+          "name": "Taurean Mauler"
+        },
+        {
+          "count": 1,
+          "name": "Hobgoblin Bandit Lord"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Chieftain"
+        },
+        {
+          "count": 1,
+          "name": "Hexing Squelcher"
+        },
+        {
+          "count": 1,
+          "name": "Frogtosser Banneret"
+        },
+        {
+          "count": 1,
+          "name": "Conspicuous Snoop"
+        },
+        {
+          "count": 1,
+          "name": "Moria Marauder"
+        },
+        {
+          "count": 1,
+          "name": "Gorbag of Minas Morgul"
+        },
+        {
+          "count": 1,
+          "name": "Great Goblin, Foul-Hearted"
+        },
+        {
+          "count": 1,
+          "name": "Ugluk of the White Hand"
+        },
+        {
+          "count": 1,
+          "name": "Bolg, Erebor's Reckoning"
+        },
+        {
+          "count": 1,
+          "name": "Brightstone Ritual"
+        },
+        {
+          "count": 1,
+          "name": "Goblin War Strike"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Ringleader"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Warchief"
+        },
+        {
+          "count": 1,
+          "name": "Reliquary Tower"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Grenade"
+        },
+        {
+          "count": 1,
+          "name": "Rakdos Signet"
+        },
+        {
+          "count": 1,
+          "name": "Swiftfoot Boots"
+        },
+        {
+          "count": 1,
+          "name": "Angrath, Captain of Chaos"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Lackey"
+        },
+        {
+          "count": 1,
+          "name": "Dunland Crebain"
+        },
+        {
+          "count": 1,
+          "name": "Chaos Warp"
+        },
+        {
+          "count": 1,
+          "name": "Blasphemous Edict"
+        },
+        {
+          "count": 1,
+          "name": "Corrupted Conviction"
+        },
+        {
+          "count": 1,
+          "name": "Dark Ritual"
+        },
+        {
+          "count": 1,
+          "name": "Jet Medallion"
+        },
+        {
+          "count": 1,
+          "name": "Lightning Greaves"
+        },
+        {
+          "count": 1,
+          "name": "Crude Bent Blade"
+        },
+        {
+          "count": 1,
+          "name": "Orcrist, Goblin-cleaver"
+        },
+        {
+          "count": 1,
+          "name": "Patchwork Banner"
+        },
+        {
+          "count": 1,
+          "name": "Orcish Siegemaster"
+        },
+        {
+          "count": 1,
+          "name": "Gothmog, Morgul Lieutenant"
         }
       ],
       "sideboard": []
@@ -2944,10 +2936,6 @@
         },
         {
           "count": 1,
-          "name": "Smaug the Magnificent"
-        },
-        {
-          "count": 1,
           "name": "Knuckles the Echidna"
         },
         {
@@ -3013,15 +3001,20 @@
         {
           "count": 1,
           "name": "Dragonspeaker Shaman"
+        },
+        {
+          "count": 1,
+          "name": "Smaug the Magnificent"
         }
       ],
       "sideboard": []
     },
     {
-      "name": "Deadpool, Trading Card",
+      "name": "Pantlaza, Sun-Favored",
       "author": "MTGGoldfish",
       "colors": [
-        "B",
+        "G",
+        "W",
         "R"
       ],
       "tags": [
@@ -3030,259 +3023,215 @@
       "main": [
         {
           "count": 1,
-          "name": "Abrade"
+          "name": "Pantlaza, Sun-Favored"
         },
         {
           "count": 1,
-          "name": "Alesha, Who Laughs at Fate"
+          "name": "Radagast of Rhosgobel"
         },
         {
           "count": 1,
-          "name": "Animate Dead"
+          "name": "Gishath, Sun's Avatar"
         },
         {
           "count": 1,
-          "name": "Arcane Signet"
+          "name": "Zacama, Primal Calamity"
         },
         {
           "count": 1,
-          "name": "Bedevil"
+          "name": "Regisaur Alpha"
         },
         {
           "count": 1,
-          "name": "Big Score"
+          "name": "Wrathful Raptors"
         },
         {
           "count": 1,
-          "name": "Blade of Selves"
+          "name": "Earthshaker Dreadmaw"
         },
         {
           "count": 1,
-          "name": "Blasphemous Act"
+          "name": "Curious Altisaur"
         },
         {
           "count": 1,
-          "name": "Blazemire Verge"
+          "name": "Topiary Stomper"
         },
         {
           "count": 1,
-          "name": "Blood Crypt"
+          "name": "Bronzebeak Foragers"
         },
         {
           "count": 1,
-          "name": "Bloodstained Mire"
+          "name": "Wakening Sun's Avatar"
         },
         {
           "count": 1,
-          "name": "Bojuka Bog"
+          "name": "Rhythm of the Wild"
         },
         {
           "count": 1,
-          "name": "Buried Ruin"
+          "name": "Farseek"
         },
         {
           "count": 1,
-          "name": "Canyon Slough"
+          "name": "Nature's Lore"
         },
         {
           "count": 1,
-          "name": "Chainer, Nightmare Adept"
+          "name": "Three Visits"
         },
         {
           "count": 1,
-          "name": "Chthonian Nightmare"
+          "name": "Wayward Swordtooth"
         },
         {
           "count": 1,
-          "name": "Command Tower"
+          "name": "Path to Exile"
         },
         {
           "count": 1,
-          "name": "Conjurer's Closet"
+          "name": "Swords to Plowshares"
         },
         {
           "count": 1,
-          "name": "Dark Ritual"
+          "name": "Garruk's Uprising"
         },
         {
           "count": 1,
-          "name": "Deadly Dispute"
+          "name": "Quartzwood Crasher"
         },
         {
           "count": 1,
-          "name": "Deadly Rollick"
+          "name": "Otepec Huntmaster"
         },
         {
           "count": 1,
-          "name": "Delina, Wild Mage"
+          "name": "Hulking Raptor"
         },
         {
           "count": 1,
-          "name": "Demonic Counsel"
+          "name": "Kinjalli's Sunwing"
         },
         {
           "count": 1,
-          "name": "Deserted Temple"
+          "name": "Regal Behemoth"
         },
         {
           "count": 1,
-          "name": "Devastating Onslaught"
+          "name": "Trumpeting Carnosaur"
         },
         {
           "count": 1,
-          "name": "Disciple of Bolas"
+          "name": "Thrashing Brontodon"
         },
         {
           "count": 1,
-          "name": "Disrupt Decorum"
+          "name": "Ghalta and Mavren"
         },
         {
           "count": 1,
-          "name": "Drossforge Bridge"
+          "name": "Zetalpa, Primal Dawn"
         },
         {
           "count": 1,
-          "name": "Electroduplicate"
+          "name": "Marauding Raptor"
         },
         {
           "count": 1,
-          "name": "Exotic Orchard"
+          "name": "Bonehoard Dracosaur"
         },
         {
           "count": 1,
-          "name": "Feldon of the Third Path"
+          "name": "Atzocan Seer"
         },
         {
           "count": 1,
-          "name": "Fervor"
+          "name": "Hunting Velociraptor"
         },
         {
           "count": 1,
-          "name": "Foreboding Ruins"
+          "name": "Ixalli's Lorekeeper"
         },
         {
           "count": 1,
-          "name": "Gray Merchant of Asphodel"
+          "name": "Vaultborn Tyrant"
         },
         {
           "count": 1,
-          "name": "Heartless Summoning"
+          "name": "Dinosaurs on a Spaceship"
         },
         {
           "count": 1,
-          "name": "Impact Tremors"
+          "name": "Drover of the Mighty"
         },
         {
           "count": 1,
-          "name": "Jaxis, the Troublemaker"
+          "name": "Devil Dinosaur"
         },
         {
           "count": 1,
-          "name": "Jeska's Will"
+          "name": "Ravenous Tyrannosaurus"
         },
         {
           "count": 1,
-          "name": "Jet Medallion"
+          "name": "Regal Imperiosaur"
         },
         {
           "count": 1,
-          "name": "Joo Dee, One of Many"
+          "name": "Kinjalli's Caller"
         },
         {
           "count": 1,
-          "name": "Kardur, Doomscourge"
+          "name": "Return of the Wildspeaker"
         },
         {
           "count": 1,
-          "name": "Kaya's Ghostform"
+          "name": "Heroic Intervention"
         },
         {
           "count": 1,
-          "name": "Lagomos, Hand of Hatred"
+          "name": "Flawless Maneuver"
         },
         {
           "count": 1,
-          "name": "Malicious Affliction"
+          "name": "Get Lost"
         },
         {
           "count": 1,
-          "name": "Mirkwood Bats"
+          "name": "Parting Gust"
         },
         {
           "count": 1,
-          "name": "Mirror Box"
+          "name": "Rampant Growth"
         },
         {
           "count": 1,
-          "name": "Mirror Gallery"
+          "name": "Skyshroud Claim"
         },
         {
           "count": 1,
-          "name": "Mirrorpool"
+          "name": "Urza's Incubator"
         },
         {
           "count": 1,
-          "name": "Morbid Opportunist"
-        },
-        {
-          "count": 10,
-          "name": "Mountain"
+          "name": "Kodama's Reach"
         },
         {
           "count": 1,
-          "name": "Nasty End"
+          "name": "Cultivate"
         },
         {
           "count": 1,
-          "name": "Necropotence"
+          "name": "Elemental Bond"
         },
         {
           "count": 1,
-          "name": "Not Dead After All"
+          "name": "Welcome to . . ."
         },
         {
           "count": 1,
-          "name": "Orthion, Hero of Lavabrink"
-        },
-        {
-          "count": 1,
-          "name": "Rakdos Carnarium"
-        },
-        {
-          "count": 1,
-          "name": "Rakdos Joins Up"
-        },
-        {
-          "count": 1,
-          "name": "Reanimate"
-        },
-        {
-          "count": 1,
-          "name": "Redoubled Stormsinger"
-        },
-        {
-          "count": 1,
-          "name": "Rionya, Fire Dancer"
-        },
-        {
-          "count": 1,
-          "name": "Ruby Medallion"
-        },
-        {
-          "count": 1,
-          "name": "Saw in Half"
-        },
-        {
-          "count": 1,
-          "name": "Shadowblood Ridge"
-        },
-        {
-          "count": 1,
-          "name": "Slicer, Hired Muscle"
-        },
-        {
-          "count": 1,
-          "name": "Smoldering Marsh"
+          "name": "Poetic Ingenuity"
         },
         {
           "count": 1,
@@ -3290,75 +3239,171 @@
         },
         {
           "count": 1,
-          "name": "Splinter Twin"
+          "name": "Arcane Signet"
         },
         {
           "count": 1,
-          "name": "Splinter's Technique"
-        },
-        {
-          "count": 9,
-          "name": "Swamp"
+          "name": "Patchwork Banner"
         },
         {
           "count": 1,
-          "name": "Takenuma, Abandoned Mire"
+          "name": "Blasphemous Act"
         },
         {
           "count": 1,
-          "name": "Talisman of Indulgence"
+          "name": "Everything Comes to Dust"
         },
         {
           "count": 1,
-          "name": "The Darkness Crystal"
+          "name": "Palani's Hatcher"
         },
         {
           "count": 1,
-          "name": "The Fire Crystal"
+          "name": "Huatli, Poet of Unity"
         },
         {
           "count": 1,
-          "name": "The Lord of Pain"
+          "name": "Spire Garden"
         },
         {
           "count": 1,
-          "name": "The Master, Multiplied"
+          "name": "Bountiful Promenade"
         },
         {
           "count": 1,
-          "name": "The Meathook Massacre"
+          "name": "Spectator Seating"
         },
         {
           "count": 1,
-          "name": "Twinflame"
+          "name": "Sunpetal Grove"
         },
         {
           "count": 1,
-          "name": "Undying Malice"
+          "name": "Rootbound Crag"
         },
         {
           "count": 1,
-          "name": "Untimely Malfunction"
+          "name": "Restless Ridgeline"
         },
         {
           "count": 1,
-          "name": "Valgavoth, Harrower of Souls"
+          "name": "Battlefield Forge"
         },
         {
           "count": 1,
-          "name": "Vandalblast"
+          "name": "Karplusan Forest"
         },
         {
           "count": 1,
-          "name": "Vesuva"
+          "name": "Brushland"
+        },
+        {
+          "count": 3,
+          "name": "Snow-Covered Forest"
+        },
+        {
+          "count": 2,
+          "name": "Snow-Covered Plains"
+        },
+        {
+          "count": 2,
+          "name": "Snow-Covered Mountain"
         },
         {
           "count": 1,
-          "name": "Victimize"
+          "name": "Arid Mesa"
         },
         {
           "count": 1,
-          "name": "Deadpool, Trading Card"
+          "name": "Wooded Foothills"
+        },
+        {
+          "count": 1,
+          "name": "Windswept Heath"
+        },
+        {
+          "count": 1,
+          "name": "Scattered Groves"
+        },
+        {
+          "count": 1,
+          "name": "Sheltered Thicket"
+        },
+        {
+          "count": 1,
+          "name": "Elegant Parlor"
+        },
+        {
+          "count": 1,
+          "name": "Cavern of Souls"
+        },
+        {
+          "count": 1,
+          "name": "Commercial District"
+        },
+        {
+          "count": 1,
+          "name": "Lush Portico"
+        },
+        {
+          "count": 1,
+          "name": "Jetmir's Garden"
+        },
+        {
+          "count": 1,
+          "name": "Unclaimed Territory"
+        },
+        {
+          "count": 1,
+          "name": "Stomping Ground"
+        },
+        {
+          "count": 1,
+          "name": "Temple Garden"
+        },
+        {
+          "count": 1,
+          "name": "Sacred Foundry"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Path of Ancestry"
+        },
+        {
+          "count": 1,
+          "name": "Cinder Glade"
+        },
+        {
+          "count": 1,
+          "name": "Canopy Vista"
+        },
+        {
+          "count": 1,
+          "name": "Three Tree City"
+        },
+        {
+          "count": 1,
+          "name": "Arena of Glory"
+        },
+        {
+          "count": 1,
+          "name": "Castle Garenbrig"
+        },
+        {
+          "count": 1,
+          "name": "Kessig Wolf Run"
+        },
+        {
+          "count": 1,
+          "name": "Boseiju, Who Endures"
+        },
+        {
+          "count": 1,
+          "name": "Yavimaya, Cradle of Growth"
         }
       ],
       "sideboard": []

--- a/client/public/feeds/mtggoldfish-modern.json
+++ b/client/public/feeds/mtggoldfish-modern.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "modern",
   "version": 1,
-  "updated": "2026-08-30T00:00:00Z",
+  "updated": "2026-08-31T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/modern",
   "decks": [
     {
@@ -294,6 +294,173 @@
       ]
     },
     {
+      "name": "Eldrazi",
+      "author": "MTGGoldfish",
+      "colors": [
+        "G",
+        "R"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 4,
+          "name": "Ancient Stirrings"
+        },
+        {
+          "count": 4,
+          "name": "Basking Broodscale"
+        },
+        {
+          "count": 3,
+          "name": "Blade of the Bloodchief"
+        },
+        {
+          "count": 1,
+          "name": "Boseiju, Who Endures"
+        },
+        {
+          "count": 2,
+          "name": "Cavern of Souls"
+        },
+        {
+          "count": 1,
+          "name": "Commercial District"
+        },
+        {
+          "count": 4,
+          "name": "Eldrazi Temple"
+        },
+        {
+          "count": 3,
+          "name": "Emrakul, the Promised End"
+        },
+        {
+          "count": 2,
+          "name": "Forest"
+        },
+        {
+          "count": 1,
+          "name": "Gemstone Caverns"
+        },
+        {
+          "count": 1,
+          "name": "Glaring Fleshraker"
+        },
+        {
+          "count": 4,
+          "name": "Grove of the Burnwillows"
+        },
+        {
+          "count": 1,
+          "name": "Haywire Mite"
+        },
+        {
+          "count": 4,
+          "name": "Kozilek's Command"
+        },
+        {
+          "count": 4,
+          "name": "Malevolent Rumble"
+        },
+        {
+          "count": 1,
+          "name": "Misty Rainforest"
+        },
+        {
+          "count": 1,
+          "name": "Soul-Guide Lantern"
+        },
+        {
+          "count": 4,
+          "name": "Sowing Mycospawn"
+        },
+        {
+          "count": 1,
+          "name": "Springleaf Drum"
+        },
+        {
+          "count": 1,
+          "name": "Stomping Ground"
+        },
+        {
+          "count": 2,
+          "name": "Unholy Heat"
+        },
+        {
+          "count": 4,
+          "name": "Urza's Saga"
+        },
+        {
+          "count": 1,
+          "name": "Verdant Catacombs"
+        },
+        {
+          "count": 2,
+          "name": "Vexing Bauble"
+        },
+        {
+          "count": 1,
+          "name": "Wooded Foothills"
+        },
+        {
+          "count": 2,
+          "name": "Writhing Chrysalis"
+        },
+        {
+          "count": 1,
+          "name": "Pithing Needle"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 1,
+          "name": "Ghost Quarter"
+        },
+        {
+          "count": 1,
+          "name": "Grafdigger's Cage"
+        },
+        {
+          "count": 1,
+          "name": "Kozilek's Return"
+        },
+        {
+          "count": 2,
+          "name": "Nature's Claim"
+        },
+        {
+          "count": 1,
+          "name": "Pyroclasm"
+        },
+        {
+          "count": 1,
+          "name": "Soulless Jailer"
+        },
+        {
+          "count": 2,
+          "name": "Thief of Existence"
+        },
+        {
+          "count": 2,
+          "name": "Unholy Heat"
+        },
+        {
+          "count": 2,
+          "name": "Warping Wail"
+        },
+        {
+          "count": 1,
+          "name": "Wrenn and Six"
+        },
+        {
+          "count": 1,
+          "name": "Vexing Bauble"
+        }
+      ]
+    },
+    {
       "name": "Izzet Prowess",
       "author": "MTGGoldfish",
       "colors": [
@@ -564,173 +731,6 @@
         {
           "count": 2,
           "name": "Wrath of the Skies"
-        }
-      ]
-    },
-    {
-      "name": "Eldrazi",
-      "author": "MTGGoldfish",
-      "colors": [
-        "G",
-        "R"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 4,
-          "name": "Ancient Stirrings"
-        },
-        {
-          "count": 4,
-          "name": "Basking Broodscale"
-        },
-        {
-          "count": 3,
-          "name": "Blade of the Bloodchief"
-        },
-        {
-          "count": 1,
-          "name": "Boseiju, Who Endures"
-        },
-        {
-          "count": 2,
-          "name": "Cavern of Souls"
-        },
-        {
-          "count": 1,
-          "name": "Commercial District"
-        },
-        {
-          "count": 4,
-          "name": "Eldrazi Temple"
-        },
-        {
-          "count": 3,
-          "name": "Emrakul, the Promised End"
-        },
-        {
-          "count": 2,
-          "name": "Forest"
-        },
-        {
-          "count": 1,
-          "name": "Gemstone Caverns"
-        },
-        {
-          "count": 1,
-          "name": "Glaring Fleshraker"
-        },
-        {
-          "count": 4,
-          "name": "Grove of the Burnwillows"
-        },
-        {
-          "count": 1,
-          "name": "Haywire Mite"
-        },
-        {
-          "count": 4,
-          "name": "Kozilek's Command"
-        },
-        {
-          "count": 4,
-          "name": "Malevolent Rumble"
-        },
-        {
-          "count": 1,
-          "name": "Misty Rainforest"
-        },
-        {
-          "count": 1,
-          "name": "Soul-Guide Lantern"
-        },
-        {
-          "count": 4,
-          "name": "Sowing Mycospawn"
-        },
-        {
-          "count": 1,
-          "name": "Springleaf Drum"
-        },
-        {
-          "count": 1,
-          "name": "Stomping Ground"
-        },
-        {
-          "count": 2,
-          "name": "Unholy Heat"
-        },
-        {
-          "count": 4,
-          "name": "Urza's Saga"
-        },
-        {
-          "count": 1,
-          "name": "Verdant Catacombs"
-        },
-        {
-          "count": 2,
-          "name": "Vexing Bauble"
-        },
-        {
-          "count": 1,
-          "name": "Wooded Foothills"
-        },
-        {
-          "count": 2,
-          "name": "Writhing Chrysalis"
-        },
-        {
-          "count": 1,
-          "name": "Pithing Needle"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 1,
-          "name": "Ghost Quarter"
-        },
-        {
-          "count": 1,
-          "name": "Grafdigger's Cage"
-        },
-        {
-          "count": 1,
-          "name": "Kozilek's Return"
-        },
-        {
-          "count": 2,
-          "name": "Nature's Claim"
-        },
-        {
-          "count": 1,
-          "name": "Pyroclasm"
-        },
-        {
-          "count": 1,
-          "name": "Soulless Jailer"
-        },
-        {
-          "count": 2,
-          "name": "Thief of Existence"
-        },
-        {
-          "count": 2,
-          "name": "Unholy Heat"
-        },
-        {
-          "count": 2,
-          "name": "Warping Wail"
-        },
-        {
-          "count": 1,
-          "name": "Wrenn and Six"
-        },
-        {
-          "count": 1,
-          "name": "Vexing Bauble"
         }
       ]
     },
@@ -1342,11 +1342,11 @@
       ]
     },
     {
-      "name": "Neobrand",
+      "name": "Ruby Storm",
       "author": "MTGGoldfish",
       "colors": [
-        "G",
-        "U"
+        "U",
+        "R"
       ],
       "tags": [
         "metagame"
@@ -1354,157 +1354,145 @@
       "main": [
         {
           "count": 4,
-          "name": "Neoform"
-        },
-        {
-          "count": 4,
-          "name": "Planar Genesis"
-        },
-        {
-          "count": 4,
-          "name": "Eldritch Evolution"
-        },
-        {
-          "count": 2,
-          "name": "Generous Ent"
-        },
-        {
-          "count": 2,
-          "name": "Forest"
-        },
-        {
-          "count": 1,
-          "name": "Griselbrand"
-        },
-        {
-          "count": 1,
-          "name": "Preordain"
-        },
-        {
-          "count": 4,
-          "name": "Misty Rainforest"
-        },
-        {
-          "count": 3,
-          "name": "Hedge Maze"
-        },
-        {
-          "count": 4,
-          "name": "Allosaurus Rider"
-        },
-        {
-          "count": 2,
           "name": "Scalding Tarn"
         },
         {
-          "count": 1,
-          "name": "Breeding Pool"
+          "count": 4,
+          "name": "Desperate Ritual"
         },
         {
           "count": 4,
-          "name": "Consign to Memory"
+          "name": "Manamorphose"
         },
         {
-          "count": 1,
+          "count": 2,
           "name": "Island"
         },
         {
           "count": 1,
-          "name": "Hooting Mandrills"
-        },
-        {
-          "count": 1,
-          "name": "Verdant Catacombs"
-        },
-        {
-          "count": 1,
-          "name": "Xenagos, God of Revels"
+          "name": "Flooded Strand"
         },
         {
           "count": 2,
-          "name": "Disciple of Freyalise"
-        },
-        {
-          "count": 2,
-          "name": "Veil of Summer"
-        },
-        {
-          "count": 2,
-          "name": "Ghalta, Stampede Tyrant"
-        },
-        {
-          "count": 2,
-          "name": "Nature's Claim"
-        },
-        {
-          "count": 1,
-          "name": "Ureni, the Song Unending"
-        },
-        {
-          "count": 1,
-          "name": "Boseiju, Who Endures"
+          "name": "Past in Flames"
         },
         {
           "count": 4,
-          "name": "Summoner's Pact"
+          "name": "Pyretic Ritual"
+        },
+        {
+          "count": 4,
+          "name": "Ral, Monsoon Mage"
         },
         {
           "count": 3,
-          "name": "Pact of Negation"
+          "name": "Thundering Falls"
+        },
+        {
+          "count": 2,
+          "name": "Steam Vents"
+        },
+        {
+          "count": 2,
+          "name": "Mountain"
+        },
+        {
+          "count": 2,
+          "name": "Stock Up"
         },
         {
           "count": 1,
-          "name": "Bridgeworks Battle"
+          "name": "Misty Rainforest"
         },
         {
           "count": 1,
-          "name": "Endurance"
+          "name": "Otawara, Soaring City"
+        },
+        {
+          "count": 4,
+          "name": "Stormcatch Mentor"
+        },
+        {
+          "count": 4,
+          "name": "Preordain"
+        },
+        {
+          "count": 4,
+          "name": "Flow State"
         },
         {
           "count": 1,
-          "name": "Atraxa, Grand Unifier"
+          "name": "Sink into Stupor"
+        },
+        {
+          "count": 1,
+          "name": "Arid Mesa"
+        },
+        {
+          "count": 1,
+          "name": "Valakut Awakening"
+        },
+        {
+          "count": 1,
+          "name": "Grapeshot"
+        },
+        {
+          "count": 2,
+          "name": "Strike It Rich"
+        },
+        {
+          "count": 1,
+          "name": "Flame of Anor"
+        },
+        {
+          "count": 4,
+          "name": "Hex Magic"
+        },
+        {
+          "count": 1,
+          "name": "Vexing Bauble"
         }
       ],
       "sideboard": [
         {
           "count": 1,
-          "name": "Elesh Norn, Grand Cenobite"
-        },
-        {
-          "count": 1,
-          "name": "Nature's Claim"
-        },
-        {
-          "count": 1,
-          "name": "Abhorrent Oculus"
-        },
-        {
-          "count": 4,
-          "name": "Mystical Dispute"
-        },
-        {
-          "count": 1,
-          "name": "Hooting Mandrills"
-        },
-        {
-          "count": 1,
           "name": "Into the Flood Maw"
         },
         {
-          "count": 2,
-          "name": "Thundertrap Trainer"
+          "count": 1,
+          "name": "Soul-Guide Lantern"
         },
         {
           "count": 2,
-          "name": "Veil of Summer"
+          "name": "Brotherhood's End"
+        },
+        {
+          "count": 2,
+          "name": "Vexing Bauble"
+        },
+        {
+          "count": 2,
+          "name": "Consign to Memory"
         },
         {
           "count": 1,
-          "name": "Pact of Negation"
+          "name": "Fire Magic"
+        },
+        {
+          "count": 2,
+          "name": "Flame of Anor"
+        },
+        {
+          "count": 2,
+          "name": "Defense Grid"
         },
         {
           "count": 1,
-          "name": "Natural State"
+          "name": "Lightning Bolt"
+        },
+        {
+          "count": 1,
+          "name": "Untimely Malfunction"
         }
       ]
     }

--- a/client/public/feeds/mtggoldfish-pioneer.json
+++ b/client/public/feeds/mtggoldfish-pioneer.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "pioneer",
   "version": 1,
-  "updated": "2026-08-30T00:00:00Z",
+  "updated": "2026-08-31T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/pioneer",
   "decks": [
     {
@@ -164,78 +164,6 @@
       "main": [
         {
           "count": 2,
-          "name": "Restless Cottage"
-        },
-        {
-          "count": 4,
-          "name": "Badgermole Cub"
-        },
-        {
-          "count": 4,
-          "name": "Overgrown Tomb"
-        },
-        {
-          "count": 4,
-          "name": "Unholy Annex // Ritual Chamber"
-        },
-        {
-          "count": 1,
-          "name": "Boseiju, Who Endures"
-        },
-        {
-          "count": 1,
-          "name": "Culling Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Maelstrom Pulse"
-        },
-        {
-          "count": 1,
-          "name": "Forest"
-        },
-        {
-          "count": 4,
-          "name": "Graveyard Trespasser"
-        },
-        {
-          "count": 4,
-          "name": "Llanowar Wastes"
-        },
-        {
-          "count": 4,
-          "name": "Fatal Push"
-        },
-        {
-          "count": 4,
-          "name": "Thoughtseize"
-        },
-        {
-          "count": 1,
-          "name": "Duress"
-        },
-        {
-          "count": 2,
-          "name": "Bitter Triumph"
-        },
-        {
-          "count": 3,
-          "name": "Sheoldred, the Apocalypse"
-        },
-        {
-          "count": 3,
-          "name": "Abrupt Decay"
-        },
-        {
-          "count": 1,
-          "name": "Takenuma, Abandoned Mire"
-        },
-        {
-          "count": 1,
-          "name": "Urborg, Tomb of Yawgmoth"
-        },
-        {
-          "count": 3,
           "name": "Swamp"
         },
         {
@@ -243,22 +171,94 @@
           "name": "Blooming Marsh"
         },
         {
+          "count": 1,
+          "name": "Boseiju, Who Endures"
+        },
+        {
+          "count": 4,
+          "name": "Overgrown Tomb"
+        },
+        {
+          "count": 4,
+          "name": "Llanowar Wastes"
+        },
+        {
+          "count": 4,
+          "name": "Graveyard Trespasser"
+        },
+        {
+          "count": 3,
+          "name": "Abrupt Decay"
+        },
+        {
+          "count": 4,
+          "name": "Fatal Push"
+        },
+        {
+          "count": 2,
+          "name": "Restless Cottage"
+        },
+        {
           "count": 4,
           "name": "Mutavault"
         },
         {
+          "count": 3,
+          "name": "Sheoldred, the Apocalypse"
+        },
+        {
+          "count": 1,
+          "name": "Takenuma, Abandoned Mire"
+        },
+        {
+          "count": 1,
+          "name": "Maelstrom Pulse"
+        },
+        {
+          "count": 1,
+          "name": "Urborg, Tomb of Yawgmoth"
+        },
+        {
+          "count": 1,
+          "name": "Forest"
+        },
+        {
+          "count": 4,
+          "name": "Unholy Annex // Ritual Chamber"
+        },
+        {
+          "count": 2,
+          "name": "Bitter Triumph"
+        },
+        {
+          "count": 1,
+          "name": "Duress"
+        },
+        {
+          "count": 1,
+          "name": "Culling Ritual"
+        },
+        {
+          "count": 1,
+          "name": "Castle Locthwain"
+        },
+        {
+          "count": 4,
+          "name": "Badgermole Cub"
+        },
+        {
           "count": 4,
           "name": "Professor Dellian Fel"
+        },
+        {
+          "count": 4,
+          "name": "Thoughtseize"
         }
       ],
       "sideboard": [
         {
-          "count": 3,
-          "name": "Unlicensed Hearse"
-        },
-        {
-          "count": 3,
-          "name": "Invoke Despair"
+          "count": 1,
+          "name": "Culling Ritual"
         },
         {
           "count": 2,
@@ -266,7 +266,19 @@
         },
         {
           "count": 2,
+          "name": "Invoke Despair"
+        },
+        {
+          "count": 2,
           "name": "Nowhere to Run"
+        },
+        {
+          "count": 1,
+          "name": "Maelstrom Pulse"
+        },
+        {
+          "count": 4,
+          "name": "Leyline of the Void"
         },
         {
           "count": 1,
@@ -275,10 +287,6 @@
         {
           "count": 2,
           "name": "Cruelclaw's Heist"
-        },
-        {
-          "count": 2,
-          "name": "Culling Ritual"
         }
       ]
     },
@@ -687,9 +695,9 @@
       "name": "Jeskai Lessons",
       "author": "MTGGoldfish",
       "colors": [
-        "R",
         "W",
-        "U"
+        "U",
+        "R"
       ],
       "tags": [
         "metagame"
@@ -705,6 +713,14 @@
         },
         {
           "count": 4,
+          "name": "Combustion Technique"
+        },
+        {
+          "count": 4,
+          "name": "Divide by Zero"
+        },
+        {
+          "count": 4,
           "name": "Firebending Lesson"
         },
         {
@@ -712,16 +728,52 @@
           "name": "Gran-Gran"
         },
         {
-          "count": 3,
-          "name": "Sacred Foundry"
+          "count": 1,
+          "name": "Hallowed Fountain"
+        },
+        {
+          "count": 1,
+          "name": "Sundown Pass"
+        },
+        {
+          "count": 4,
+          "name": "It'll Quench Ya!"
+        },
+        {
+          "count": 1,
+          "name": "Stock Up"
         },
         {
           "count": 4,
           "name": "Steam Vents"
         },
         {
+          "count": 2,
+          "name": "Island"
+        },
+        {
+          "count": 3,
+          "name": "Sacred Foundry"
+        },
+        {
+          "count": 4,
+          "name": "Jeskai Revelation"
+        },
+        {
+          "count": 1,
+          "name": "Stormcarved Coast"
+        },
+        {
           "count": 4,
           "name": "Tablet of Discovery"
+        },
+        {
+          "count": 2,
+          "name": "Thor, God of Thunder"
+        },
+        {
+          "count": 3,
+          "name": "Hallowed Fountain"
         },
         {
           "count": 4,
@@ -730,72 +782,28 @@
         {
           "count": 4,
           "name": "Riverpyre Verge"
-        },
-        {
-          "count": 1,
-          "name": "Stock Up"
-        },
-        {
-          "count": 4,
-          "name": "Jeskai Revelation"
-        },
-        {
-          "count": 2,
-          "name": "Island"
-        },
-        {
-          "count": 4,
-          "name": "Hallowed Fountain"
-        },
-        {
-          "count": 4,
-          "name": "Divide by Zero"
-        },
-        {
-          "count": 4,
-          "name": "It'll Quench Ya!"
-        },
-        {
-          "count": 2,
-          "name": "Thor, God of Thunder"
-        },
-        {
-          "count": 4,
-          "name": "Combustion Technique"
-        },
-        {
-          "count": 1,
-          "name": "Stormcarved Coast"
-        },
-        {
-          "count": 1,
-          "name": "Sundown Pass"
         }
       ],
       "sideboard": [
         {
-          "count": 2,
-          "name": "Avengers Disassembled"
+          "count": 1,
+          "name": "Accumulate Wisdom"
         },
         {
           "count": 1,
-          "name": "Emeritus of Ideation"
+          "name": "Airbender's Reversal"
         },
         {
           "count": 1,
           "name": "Anger of the Gods"
         },
         {
-          "count": 1,
-          "name": "Price of Freedom"
+          "count": 2,
+          "name": "Avengers Disassembled"
         },
         {
           "count": 1,
-          "name": "Soulless Jailer"
-        },
-        {
-          "count": 1,
-          "name": "Sokka's Haiku"
+          "name": "Ral, Crackling Wit"
         },
         {
           "count": 1,
@@ -807,23 +815,277 @@
         },
         {
           "count": 1,
-          "name": "Ral, Crackling Wit"
+          "name": "Price of Freedom"
         },
         {
           "count": 1,
-          "name": "Accumulate Wisdom"
+          "name": "Emeritus of Ideation"
+        },
+        {
+          "count": 1,
+          "name": "Sokka's Haiku"
+        },
+        {
+          "count": 1,
+          "name": "Soulless Jailer"
         },
         {
           "count": 1,
           "name": "Sphinx of the Final Word"
         },
         {
-          "count": 1,
-          "name": "Airbender's Reversal"
+          "count": 2,
+          "name": "Ghost Vacuum"
+        }
+      ]
+    },
+    {
+      "name": "Dimir Self-Bounce",
+      "author": "MTGGoldfish",
+      "colors": [
+        "B",
+        "U"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 4,
+          "name": "Boomerang Basics"
+        },
+        {
+          "count": 4,
+          "name": "Clearwater Pathway"
+        },
+        {
+          "count": 4,
+          "name": "Cryogen Relic"
+        },
+        {
+          "count": 4,
+          "name": "Darkslick Shores"
+        },
+        {
+          "count": 4,
+          "name": "Thoughtseize"
+        },
+        {
+          "count": 4,
+          "name": "Fear of Isolation"
         },
         {
           "count": 2,
-          "name": "Ghost Vacuum"
+          "name": "Stock Up"
+        },
+        {
+          "count": 4,
+          "name": "Hopeless Nightmare"
+        },
+        {
+          "count": 2,
+          "name": "Swamp"
+        },
+        {
+          "count": 4,
+          "name": "Momentum Breaker"
+        },
+        {
+          "count": 4,
+          "name": "Narset, Parter of Veils"
+        },
+        {
+          "count": 4,
+          "name": "Nowhere to Run"
+        },
+        {
+          "count": 1,
+          "name": "Otawara, Soaring City"
+        },
+        {
+          "count": 4,
+          "name": "Petrified Hamlet"
+        },
+        {
+          "count": 4,
+          "name": "Shipwreck Marsh"
+        },
+        {
+          "count": 2,
+          "name": "Underground River"
+        },
+        {
+          "count": 4,
+          "name": "Stormchaser's Talent"
+        },
+        {
+          "count": 2,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Takenuma, Abandoned Mire"
+        },
+        {
+          "count": 4,
+          "name": "This Town Ain't Big Enough"
+        },
+        {
+          "count": 4,
+          "name": "Fatal Push"
+        },
+        {
+          "count": 2,
+          "name": "Urborg, Tomb of Yawgmoth"
+        },
+        {
+          "count": 4,
+          "name": "Watery Grave"
+        },
+        {
+          "count": 4,
+          "name": "Gloomlake Verge"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 2,
+          "name": "Change the Equation"
+        },
+        {
+          "count": 2,
+          "name": "Go Blank"
+        },
+        {
+          "count": 4,
+          "name": "Grim Bauble"
+        },
+        {
+          "count": 3,
+          "name": "Invoke Despair"
+        },
+        {
+          "count": 1,
+          "name": "Yorion, Sky Nomad"
+        },
+        {
+          "count": 3,
+          "name": "Unlicensed Hearse"
+        }
+      ]
+    },
+    {
+      "name": "Izzet Phoenix",
+      "author": "MTGGoldfish",
+      "colors": [
+        "U",
+        "R"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 4,
+          "name": "Arclight Phoenix"
+        },
+        {
+          "count": 4,
+          "name": "Artist's Talent"
+        },
+        {
+          "count": 4,
+          "name": "Consider"
+        },
+        {
+          "count": 4,
+          "name": "Fiery Impulse"
+        },
+        {
+          "count": 2,
+          "name": "Flashback"
+        },
+        {
+          "count": 3,
+          "name": "Into the Flood Maw"
+        },
+        {
+          "count": 3,
+          "name": "Lightning Axe"
+        },
+        {
+          "count": 4,
+          "name": "Island"
+        },
+        {
+          "count": 4,
+          "name": "Spirebluff Canal"
+        },
+        {
+          "count": 1,
+          "name": "Otawara, Soaring City"
+        },
+        {
+          "count": 4,
+          "name": "Picklock Prankster"
+        },
+        {
+          "count": 1,
+          "name": "Prismari Command"
+        },
+        {
+          "count": 1,
+          "name": "Proft's Eidetic Memory"
+        },
+        {
+          "count": 1,
+          "name": "Stormcarved Coast"
+        },
+        {
+          "count": 4,
+          "name": "Treasure Cruise"
+        },
+        {
+          "count": 4,
+          "name": "Opt"
+        },
+        {
+          "count": 4,
+          "name": "Riverglide Pathway"
+        },
+        {
+          "count": 4,
+          "name": "Sleight of Hand"
+        },
+        {
+          "count": 4,
+          "name": "Steam Vents"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 1,
+          "name": "Abrade"
+        },
+        {
+          "count": 2,
+          "name": "Disdainful Stroke"
+        },
+        {
+          "count": 4,
+          "name": "Ledger Shredder"
+        },
+        {
+          "count": 3,
+          "name": "Mystical Dispute"
+        },
+        {
+          "count": 3,
+          "name": "Redcap Melee"
+        },
+        {
+          "count": 2,
+          "name": "Brazen Borrower"
         }
       ]
     },
@@ -979,321 +1241,19 @@
       ]
     },
     {
-      "name": "Dimir Self-Bounce",
-      "author": "MTGGoldfish",
-      "colors": [
-        "U",
-        "B"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 4,
-          "name": "Boomerang Basics"
-        },
-        {
-          "count": 4,
-          "name": "Clearwater Pathway"
-        },
-        {
-          "count": 4,
-          "name": "Cryogen Relic"
-        },
-        {
-          "count": 4,
-          "name": "Fatal Push"
-        },
-        {
-          "count": 4,
-          "name": "Gloomlake Verge"
-        },
-        {
-          "count": 4,
-          "name": "Fear of Isolation"
-        },
-        {
-          "count": 4,
-          "name": "Shipwreck Marsh"
-        },
-        {
-          "count": 4,
-          "name": "Hopeless Nightmare"
-        },
-        {
-          "count": 2,
-          "name": "Island"
-        },
-        {
-          "count": 4,
-          "name": "Momentum Breaker"
-        },
-        {
-          "count": 4,
-          "name": "Narset, Parter of Veils"
-        },
-        {
-          "count": 4,
-          "name": "Nowhere to Run"
-        },
-        {
-          "count": 1,
-          "name": "Otawara, Soaring City"
-        },
-        {
-          "count": 3,
-          "name": "Petrified Hamlet"
-        },
-        {
-          "count": 4,
-          "name": "Thoughtseize"
-        },
-        {
-          "count": 3,
-          "name": "Stock Up"
-        },
-        {
-          "count": 4,
-          "name": "Stormchaser's Talent"
-        },
-        {
-          "count": 1,
-          "name": "Takenuma, Abandoned Mire"
-        },
-        {
-          "count": 4,
-          "name": "This Town Ain't Big Enough"
-        },
-        {
-          "count": 2,
-          "name": "Urborg, Tomb of Yawgmoth"
-        },
-        {
-          "count": 2,
-          "name": "Underground River"
-        },
-        {
-          "count": 4,
-          "name": "Watery Grave"
-        },
-        {
-          "count": 4,
-          "name": "Darkslick Shores"
-        },
-        {
-          "count": 2,
-          "name": "Swamp"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 2,
-          "name": "Change the Equation"
-        },
-        {
-          "count": 2,
-          "name": "Go Blank"
-        },
-        {
-          "count": 4,
-          "name": "Grim Bauble"
-        },
-        {
-          "count": 3,
-          "name": "Invoke Despair"
-        },
-        {
-          "count": 1,
-          "name": "Yorion, Sky Nomad"
-        },
-        {
-          "count": 3,
-          "name": "Unlicensed Hearse"
-        }
-      ]
-    },
-    {
-      "name": "Izzet Phoenix",
-      "author": "MTGGoldfish",
-      "colors": [
-        "U",
-        "R"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 4,
-          "name": "Arclight Phoenix"
-        },
-        {
-          "count": 4,
-          "name": "Artist's Talent"
-        },
-        {
-          "count": 4,
-          "name": "Consider"
-        },
-        {
-          "count": 4,
-          "name": "Fiery Impulse"
-        },
-        {
-          "count": 2,
-          "name": "Flashback"
-        },
-        {
-          "count": 3,
-          "name": "Into the Flood Maw"
-        },
-        {
-          "count": 3,
-          "name": "Lightning Axe"
-        },
-        {
-          "count": 4,
-          "name": "Island"
-        },
-        {
-          "count": 4,
-          "name": "Spirebluff Canal"
-        },
-        {
-          "count": 1,
-          "name": "Otawara, Soaring City"
-        },
-        {
-          "count": 4,
-          "name": "Picklock Prankster"
-        },
-        {
-          "count": 1,
-          "name": "Prismari Command"
-        },
-        {
-          "count": 1,
-          "name": "Proft's Eidetic Memory"
-        },
-        {
-          "count": 1,
-          "name": "Stormcarved Coast"
-        },
-        {
-          "count": 4,
-          "name": "Treasure Cruise"
-        },
-        {
-          "count": 4,
-          "name": "Opt"
-        },
-        {
-          "count": 4,
-          "name": "Riverglide Pathway"
-        },
-        {
-          "count": 4,
-          "name": "Sleight of Hand"
-        },
-        {
-          "count": 4,
-          "name": "Steam Vents"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 1,
-          "name": "Abrade"
-        },
-        {
-          "count": 2,
-          "name": "Disdainful Stroke"
-        },
-        {
-          "count": 4,
-          "name": "Ledger Shredder"
-        },
-        {
-          "count": 3,
-          "name": "Mystical Dispute"
-        },
-        {
-          "count": 3,
-          "name": "Redcap Melee"
-        },
-        {
-          "count": 2,
-          "name": "Brazen Borrower"
-        }
-      ]
-    },
-    {
       "name": "Izzet Lessons",
       "author": "MTGGoldfish",
       "colors": [
-        "U",
-        "R"
+        "R",
+        "U"
       ],
       "tags": [
         "metagame"
       ],
       "main": [
         {
-          "count": 4,
-          "name": "Abandon Attachments"
-        },
-        {
           "count": 3,
-          "name": "Accumulate Wisdom"
-        },
-        {
-          "count": 3,
-          "name": "Thor, God of Thunder"
-        },
-        {
-          "count": 4,
-          "name": "Firebending Lesson"
-        },
-        {
-          "count": 4,
-          "name": "Gran-Gran"
-        },
-        {
-          "count": 4,
-          "name": "It'll Quench Ya!"
-        },
-        {
-          "count": 4,
-          "name": "Tablet of Discovery"
-        },
-        {
-          "count": 2,
-          "name": "Ral, Crackling Wit"
-        },
-        {
-          "count": 4,
-          "name": "Steam Vents"
-        },
-        {
-          "count": 4,
-          "name": "Spirebluff Canal"
-        },
-        {
-          "count": 4,
-          "name": "Riverpyre Verge"
-        },
-        {
-          "count": 3,
-          "name": "Shivan Reef"
-        },
-        {
-          "count": 1,
-          "name": "Stock Up"
-        },
-        {
-          "count": 4,
-          "name": "Combustion Technique"
+          "name": "Mountain"
         },
         {
           "count": 4,
@@ -1304,54 +1264,114 @@
           "name": "Divide by Zero"
         },
         {
-          "count": 4,
+          "count": 1,
+          "name": "Stormcarved Coast"
+        },
+        {
+          "count": 3,
           "name": "Island"
+        },
+        {
+          "count": 4,
+          "name": "Riverpyre Verge"
+        },
+        {
+          "count": 2,
+          "name": "Anger of the Gods"
+        },
+        {
+          "count": 3,
+          "name": "Accumulate Wisdom"
+        },
+        {
+          "count": 4,
+          "name": "It'll Quench Ya!"
+        },
+        {
+          "count": 4,
+          "name": "Combustion Technique"
+        },
+        {
+          "count": 4,
+          "name": "Firebending Lesson"
+        },
+        {
+          "count": 3,
+          "name": "Gran-Gran"
+        },
+        {
+          "count": 4,
+          "name": "Abandon Attachments"
+        },
+        {
+          "count": 4,
+          "name": "Tablet of Discovery"
+        },
+        {
+          "count": 3,
+          "name": "Thor, God of Thunder"
+        },
+        {
+          "count": 4,
+          "name": "Spirebluff Canal"
+        },
+        {
+          "count": 1,
+          "name": "Spell Pierce"
+        },
+        {
+          "count": 1,
+          "name": "Ral, Crackling Wit"
+        },
+        {
+          "count": 4,
+          "name": "Steam Vents"
         }
       ],
       "sideboard": [
+        {
+          "count": 3,
+          "name": "Fable of the Mirror-Breaker"
+        },
         {
           "count": 1,
           "name": "Accumulate Wisdom"
         },
         {
           "count": 1,
-          "name": "Sphinx of the Final Word"
-        },
-        {
-          "count": 1,
-          "name": "Anger of the Gods"
-        },
-        {
-          "count": 1,
-          "name": "Emeritus of Ideation"
-        },
-        {
-          "count": 2,
-          "name": "Improvisation Capstone"
-        },
-        {
-          "count": 1,
-          "name": "Iroh's Demonstration"
-        },
-        {
-          "count": 2,
-          "name": "Avengers Disassembled"
-        },
-        {
-          "count": 1,
-          "name": "Price of Freedom"
-        },
-        {
-          "count": 1,
           "name": "Sokka's Haiku"
         },
         {
-          "count": 2,
-          "name": "Unable to Scream"
+          "count": 1,
+          "name": "Negate"
         },
         {
-          "count": 2,
-          "name": "Ghost Vacuum"
+          "count": 1,
+          "name": "Brazen Borrower"
+        },
+        {
+          "count": 1,
+          "name": "Improvisation Capstone"
+        },
+        {
+          "count": 3,
+          "name": "Mystical Dispute"
+        },
+        {
+          "count": 1,
+          "name": "Ral, Crackling Wit"
+        },
+        {
+          "count": 1,
+          "name": "Abrade"
+        },
+        {
+          "count": 1,
+          "name": "Abrade"
+        },
+        {
+          "count": 1,
+          "name": "Unlicensed Hearse"
         }
       ]
     }

--- a/client/public/feeds/mtggoldfish-standard.json
+++ b/client/public/feeds/mtggoldfish-standard.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "standard",
   "version": 1,
-  "updated": "2026-08-30T00:00:00Z",
+  "updated": "2026-08-31T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/standard",
   "decks": [
     {
@@ -258,6 +258,145 @@
       ]
     },
     {
+      "name": "Izzet Spellementals",
+      "author": "MTGGoldfish",
+      "colors": [
+        "U",
+        "R"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 3,
+          "name": "Burst Lightning"
+        },
+        {
+          "count": 3,
+          "name": "Traumatic Critique"
+        },
+        {
+          "count": 4,
+          "name": "Prismari Charm"
+        },
+        {
+          "count": 2,
+          "name": "Impractical Joke"
+        },
+        {
+          "count": 4,
+          "name": "Sunderflock"
+        },
+        {
+          "count": 2,
+          "name": "Spell Pierce"
+        },
+        {
+          "count": 4,
+          "name": "Steam Vents"
+        },
+        {
+          "count": 4,
+          "name": "Spirebluff Canal"
+        },
+        {
+          "count": 4,
+          "name": "Riverpyre Verge"
+        },
+        {
+          "count": 2,
+          "name": "Get Out"
+        },
+        {
+          "count": 4,
+          "name": "Hearth Elemental"
+        },
+        {
+          "count": 4,
+          "name": "Opt"
+        },
+        {
+          "count": 1,
+          "name": "Stormcarved Coast"
+        },
+        {
+          "count": 3,
+          "name": "Winternight Stories"
+        },
+        {
+          "count": 1,
+          "name": "Multiversal Passage"
+        },
+        {
+          "count": 1,
+          "name": "Spell Snare"
+        },
+        {
+          "count": 3,
+          "name": "Sleight of Hand"
+        },
+        {
+          "count": 1,
+          "name": "Sleight of Hand"
+        },
+        {
+          "count": 4,
+          "name": "Eddymurk Crab"
+        },
+        {
+          "count": 3,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Island"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 2,
+          "name": "Annul"
+        },
+        {
+          "count": 1,
+          "name": "Flashfreeze"
+        },
+        {
+          "count": 1,
+          "name": "Sear"
+        },
+        {
+          "count": 2,
+          "name": "Shore Up"
+        },
+        {
+          "count": 1,
+          "name": "Ral, Crackling Wit"
+        },
+        {
+          "count": 2,
+          "name": "Spell Snare"
+        },
+        {
+          "count": 4,
+          "name": "Colorstorm Stallion"
+        },
+        {
+          "count": 2,
+          "name": "Hydro-Man, Fluid Felon"
+        }
+      ]
+    },
+    {
       "name": "4c Control",
       "author": "MTGGoldfish",
       "colors": [
@@ -443,150 +582,11 @@
       ]
     },
     {
-      "name": "Izzet Spellementals",
-      "author": "MTGGoldfish",
-      "colors": [
-        "U",
-        "R"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 3,
-          "name": "Burst Lightning"
-        },
-        {
-          "count": 3,
-          "name": "Traumatic Critique"
-        },
-        {
-          "count": 4,
-          "name": "Prismari Charm"
-        },
-        {
-          "count": 2,
-          "name": "Impractical Joke"
-        },
-        {
-          "count": 4,
-          "name": "Sunderflock"
-        },
-        {
-          "count": 2,
-          "name": "Spell Pierce"
-        },
-        {
-          "count": 4,
-          "name": "Steam Vents"
-        },
-        {
-          "count": 4,
-          "name": "Spirebluff Canal"
-        },
-        {
-          "count": 4,
-          "name": "Riverpyre Verge"
-        },
-        {
-          "count": 2,
-          "name": "Get Out"
-        },
-        {
-          "count": 4,
-          "name": "Hearth Elemental"
-        },
-        {
-          "count": 4,
-          "name": "Opt"
-        },
-        {
-          "count": 1,
-          "name": "Stormcarved Coast"
-        },
-        {
-          "count": 3,
-          "name": "Winternight Stories"
-        },
-        {
-          "count": 1,
-          "name": "Multiversal Passage"
-        },
-        {
-          "count": 1,
-          "name": "Spell Snare"
-        },
-        {
-          "count": 3,
-          "name": "Sleight of Hand"
-        },
-        {
-          "count": 1,
-          "name": "Sleight of Hand"
-        },
-        {
-          "count": 4,
-          "name": "Eddymurk Crab"
-        },
-        {
-          "count": 3,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Island"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 2,
-          "name": "Annul"
-        },
-        {
-          "count": 1,
-          "name": "Flashfreeze"
-        },
-        {
-          "count": 1,
-          "name": "Sear"
-        },
-        {
-          "count": 2,
-          "name": "Shore Up"
-        },
-        {
-          "count": 1,
-          "name": "Ral, Crackling Wit"
-        },
-        {
-          "count": 2,
-          "name": "Spell Snare"
-        },
-        {
-          "count": 4,
-          "name": "Colorstorm Stallion"
-        },
-        {
-          "count": 2,
-          "name": "Hydro-Man, Fluid Felon"
-        }
-      ]
-    },
-    {
       "name": "Lifegain",
       "author": "MTGGoldfish",
       "colors": [
-        "B",
-        "W"
+        "W",
+        "B"
       ],
       "tags": [
         "metagame"
@@ -594,11 +594,15 @@
       "main": [
         {
           "count": 1,
-          "name": "Swamp"
+          "name": "Plains"
         },
         {
-          "count": 1,
-          "name": "Swamp"
+          "count": 2,
+          "name": "Plains"
+        },
+        {
+          "count": 4,
+          "name": "Godless Shrine"
         },
         {
           "count": 3,
@@ -606,121 +610,133 @@
         },
         {
           "count": 4,
-          "name": "Case of the Uneaten Feast"
-        },
-        {
-          "count": 1,
-          "name": "Raise the Past"
+          "name": "Amalia Benavides Aguirre"
         },
         {
           "count": 3,
-          "name": "Deep-Cavern Bat"
-        },
-        {
-          "count": 3,
-          "name": "Erode"
-        },
-        {
-          "count": 3,
-          "name": "Plains"
-        },
-        {
-          "count": 2,
-          "name": "Multiversal Passage"
-        },
-        {
-          "count": 3,
-          "name": "Haliya, Guided by Light"
-        },
-        {
-          "count": 4,
-          "name": "Hinterland Sanctifier"
-        },
-        {
-          "count": 4,
           "name": "Lunar Convocation"
         },
         {
-          "count": 3,
-          "name": "Moseo, Vein's New Dean"
-        },
-        {
           "count": 4,
-          "name": "Godless Shrine"
+          "name": "Case of the Uneaten Feast"
         },
         {
           "count": 2,
           "name": "Essence Channeler"
         },
         {
-          "count": 3,
-          "name": "Concealed Courtyard"
-        },
-        {
-          "count": 2,
-          "name": "Bleachbone Verge"
-        },
-        {
           "count": 2,
           "name": "Starscape Cleric"
         },
         {
+          "count": 4,
+          "name": "Hinterland Sanctifier"
+        },
+        {
+          "count": 1,
+          "name": "Zoraline, Cosmos Caller"
+        },
+        {
+          "count": 1,
+          "name": "Bleachbone Verge"
+        },
+        {
           "count": 3,
-          "name": "Starting Town"
+          "name": "Leonardo, Cutting Edge"
+        },
+        {
+          "count": 3,
+          "name": "Voice of Victory"
         },
         {
           "count": 1,
           "name": "Strategic Betrayal"
+        },
+        {
+          "count": 1,
+          "name": "Dalkovan Encampment"
+        },
+        {
+          "count": 4,
+          "name": "Starting Town"
+        },
+        {
+          "count": 3,
+          "name": "Haliya, Guided by Light"
+        },
+        {
+          "count": 1,
+          "name": "Curious Farm Animals"
+        },
+        {
+          "count": 2,
+          "name": "Emptiness"
+        },
+        {
+          "count": 2,
+          "name": "Erode"
+        },
+        {
+          "count": 3,
+          "name": "Moseo, Vein's New Dean"
         },
         {
           "count": 1,
           "name": "Aunt May"
         },
         {
-          "count": 2,
-          "name": "Voice of Victory"
-        },
-        {
-          "count": 4,
-          "name": "Amalia Benavides Aguirre"
+          "count": 1,
+          "name": "Swamp"
         },
         {
           "count": 1,
-          "name": "Zoraline, Cosmos Caller"
+          "name": "Swamp"
+        },
+        {
+          "count": 3,
+          "name": "Concealed Courtyard"
         }
       ],
       "sideboard": [
+        {
+          "count": 1,
+          "name": "Phyrexian Arena"
+        },
+        {
+          "count": 1,
+          "name": "Authority of the Consuls"
+        },
+        {
+          "count": 2,
+          "name": "Shoot the Sheriff"
+        },
+        {
+          "count": 1,
+          "name": "Enduring Tenacity"
+        },
         {
           "count": 2,
           "name": "Ancient Vendetta"
         },
         {
-          "count": 4,
-          "name": "Leyline of the Void"
+          "count": 1,
+          "name": "Seam Rip"
+        },
+        {
+          "count": 2,
+          "name": "Curious Farm Animals"
         },
         {
           "count": 1,
-          "name": "Duress"
+          "name": "Erode"
         },
         {
           "count": 1,
           "name": "Decorum Dissertation"
         },
         {
-          "count": 2,
-          "name": "Requiting Hex"
-        },
-        {
-          "count": 2,
-          "name": "Seam Rip"
-        },
-        {
-          "count": 2,
-          "name": "Starscape Cleric"
-        },
-        {
-          "count": 1,
-          "name": "Strategic Betrayal"
+          "count": 3,
+          "name": "Leyline of the Void"
         }
       ]
     },
@@ -867,9 +883,9 @@
       "name": "Mardu Discard",
       "author": "MTGGoldfish",
       "colors": [
-        "R",
         "W",
-        "B"
+        "B",
+        "R"
       ],
       "tags": [
         "metagame"
@@ -877,19 +893,19 @@
       "main": [
         {
           "count": 4,
-          "name": "Sacred Foundry"
+          "name": "Bloodghast"
         },
         {
-          "count": 4,
-          "name": "Moonshadow"
-        },
-        {
-          "count": 3,
-          "name": "Godless Shrine"
+          "count": 2,
+          "name": "Carnage, Crimson Chaos"
         },
         {
           "count": 3,
           "name": "Concealed Courtyard"
+        },
+        {
+          "count": 3,
+          "name": "Godless Shrine"
         },
         {
           "count": 4,
@@ -900,16 +916,16 @@
           "name": "Erode"
         },
         {
-          "count": 3,
-          "name": "Carnage, Crimson Chaos"
+          "count": 2,
+          "name": "Inspiring Vantage"
         },
         {
           "count": 4,
           "name": "Hardened Academic"
         },
         {
-          "count": 1,
-          "name": "Mountain"
+          "count": 4,
+          "name": "Moonshadow"
         },
         {
           "count": 2,
@@ -925,14 +941,14 @@
         },
         {
           "count": 4,
-          "name": "Bloodghast"
+          "name": "Sacred Foundry"
         },
         {
           "count": 1,
-          "name": "Inspiring Vantage"
+          "name": "Mountain"
         },
         {
-          "count": 3,
+          "count": 4,
           "name": "Practiced Offense"
         },
         {
@@ -941,28 +957,24 @@
         },
         {
           "count": 4,
-          "name": "Blood Crypt"
-        },
-        {
-          "count": 4,
           "name": "Starting Town"
         },
         {
           "count": 1,
-          "name": "Inspiring Vantage"
+          "name": "Swamp"
         },
         {
           "count": 2,
           "name": "Tersa Lightshatter"
         },
         {
-          "count": 1,
-          "name": "Swamp"
+          "count": 4,
+          "name": "Blood Crypt"
         }
       ],
       "sideboard": [
         {
-          "count": 2,
+          "count": 1,
           "name": "Abrade"
         },
         {
@@ -979,7 +991,7 @@
         },
         {
           "count": 1,
-          "name": "Duress"
+          "name": "Pyroclasm"
         },
         {
           "count": 1,
@@ -995,7 +1007,118 @@
         },
         {
           "count": 1,
-          "name": "Pyroclasm"
+          "name": "Duress"
+        },
+        {
+          "count": 1,
+          "name": "Sheltered by Ghosts"
+        }
+      ]
+    },
+    {
+      "name": "Selesnya Landfall",
+      "author": "MTGGoldfish",
+      "colors": [
+        "W",
+        "G"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 2,
+          "name": "Dyadrine, Synthesis Amalgam"
+        },
+        {
+          "count": 4,
+          "name": "Erode"
+        },
+        {
+          "count": 3,
+          "name": "Escape Tunnel"
+        },
+        {
+          "count": 4,
+          "name": "Fabled Passage"
+        },
+        {
+          "count": 2,
+          "name": "Plains"
+        },
+        {
+          "count": 3,
+          "name": "Esper Origins"
+        },
+        {
+          "count": 4,
+          "name": "Mightform Harmonizer"
+        },
+        {
+          "count": 4,
+          "name": "Llanowar Elves"
+        },
+        {
+          "count": 2,
+          "name": "Shared Roots"
+        },
+        {
+          "count": 3,
+          "name": "Mossborn Hydra"
+        },
+        {
+          "count": 4,
+          "name": "Icetill Explorer"
+        },
+        {
+          "count": 1,
+          "name": "Hushwood Verge"
+        },
+        {
+          "count": 4,
+          "name": "Sazh's Chocobo"
+        },
+        {
+          "count": 9,
+          "name": "Forest"
+        },
+        {
+          "count": 4,
+          "name": "Earthbender Ascension"
+        },
+        {
+          "count": 3,
+          "name": "Ba Sing Se"
+        },
+        {
+          "count": 4,
+          "name": "Temple Garden"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 4,
+          "name": "Sapling Nursery"
+        },
+        {
+          "count": 2,
+          "name": "Torpor Orb"
+        },
+        {
+          "count": 2,
+          "name": "Surrak, Elusive Hunter"
+        },
+        {
+          "count": 4,
+          "name": "Sheltered by Ghosts"
+        },
+        {
+          "count": 2,
+          "name": "Rest in Peace"
+        },
+        {
+          "count": 1,
+          "name": "Mossborn Hydra"
         }
       ]
     },
@@ -1135,130 +1258,6 @@
         {
           "count": 1,
           "name": "Negate"
-        }
-      ]
-    },
-    {
-      "name": "Sultai Reanimator",
-      "author": "MTGGoldfish",
-      "colors": [
-        "U",
-        "B",
-        "G"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 4,
-          "name": "Overlord of the Balemurk"
-        },
-        {
-          "count": 2,
-          "name": "Watery Grave"
-        },
-        {
-          "count": 4,
-          "name": "Breeding Pool"
-        },
-        {
-          "count": 3,
-          "name": "Wastewood Verge"
-        },
-        {
-          "count": 4,
-          "name": "Bringer of the Last Gift"
-        },
-        {
-          "count": 2,
-          "name": "Ouroboroid"
-        },
-        {
-          "count": 2,
-          "name": "Ardyn, the Usurper"
-        },
-        {
-          "count": 4,
-          "name": "Oblivious Bookworm"
-        },
-        {
-          "count": 1,
-          "name": "Kiora, the Rising Tide"
-        },
-        {
-          "count": 3,
-          "name": "Overgrown Tomb"
-        },
-        {
-          "count": 2,
-          "name": "Forest"
-        },
-        {
-          "count": 3,
-          "name": "Town Greeter"
-        },
-        {
-          "count": 4,
-          "name": "Starting Town"
-        },
-        {
-          "count": 4,
-          "name": "Formidable Speaker"
-        },
-        {
-          "count": 4,
-          "name": "Superior Spider-Man"
-        },
-        {
-          "count": 3,
-          "name": "Jadzi, Steward of Fate"
-        },
-        {
-          "count": 2,
-          "name": "Wistfulness"
-        },
-        {
-          "count": 1,
-          "name": "Disruptive Stormbrood"
-        },
-        {
-          "count": 4,
-          "name": "Rapid Rescue"
-        },
-        {
-          "count": 4,
-          "name": "Cavern of Souls"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 2,
-          "name": "Strategic Betrayal"
-        },
-        {
-          "count": 4,
-          "name": "Requiting Hex"
-        },
-        {
-          "count": 1,
-          "name": "Dauntless Scrapbot"
-        },
-        {
-          "count": 1,
-          "name": "Leatherhead, Swamp Stalker"
-        },
-        {
-          "count": 1,
-          "name": "Professor Dellian Fel"
-        },
-        {
-          "count": 4,
-          "name": "Duress"
-        },
-        {
-          "count": 2,
-          "name": "Wistfulness"
         }
       ]
     },


### PR DESCRIPTION
Automated daily metagame feed refresh from MTGGoldfish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added refreshed MTGGoldfish Commander, Modern, Pioneer, and Standard decklists.
  * Added new archetypes, including Ruby Storm, Dimir Self-Bounce, Izzet Phoenix, Selesnya Landfall, Bard, and Great Goblin.
  * Updated existing decklists, card counts, sideboards, colors, and rankings.
* **Data Updates**
  * Updated feed timestamps to August 31, 2026.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->