### PR TITLE
fix(client): remove On from loop-detection mode selector

### DIFF
--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -540,13 +540,6 @@ export function HostSetup({
                 </button>
                 <button
                   type="button"
-                  onClick={() => setLoopDetection({ type: "On" })}
-                  className={seg(loopDetection.type === "On")}
-                >
-                  {t("common:comboDetector.on")}
-                </button>
-                <button
-                  type="button"
                   onClick={() => setLoopDetection({ type: "Interactive" })}
                   className={seg(loopDetection.type === "Interactive")}
                 >

--- a/client/src/game/__tests__/loopDetectionMode.test.ts
+++ b/client/src/game/__tests__/loopDetectionMode.test.ts
@@ -8,12 +8,14 @@ import {
 describe("loop detection URL mode", () => {
   it("round-trips every selectable loop-detection mode", () => {
     expect(loopDetectionModeToQuery({ type: "Off" })).toBeNull();
-    expect(loopDetectionModeToQuery({ type: "On" })).toBe("on");
     expect(loopDetectionModeToQuery({ type: "Interactive" })).toBe("interactive");
 
     expect(loopDetectionModeFromQuery(null)).toEqual({ type: "Off" });
-    expect(loopDetectionModeFromQuery("on")).toEqual({ type: "On" });
     expect(loopDetectionModeFromQuery("INTERACTIVE")).toEqual({ type: "Interactive" });
+  });
+
+  it("coerces the retired 'on' query value forward to Interactive, not back to Off", () => {
+    expect(loopDetectionModeFromQuery("on")).toEqual({ type: "Interactive" });
   });
 
   it("defaults unknown query values to Off", () => {

--- a/client/src/game/loopDetectionMode.ts
+++ b/client/src/game/loopDetectionMode.ts
@@ -7,8 +7,12 @@ import type { LoopDetectionMode } from "../adapter/types";
  */
 export function loopDetectionModeFromQuery(value: string | null): LoopDetectionMode {
   switch (value?.toLowerCase()) {
+    // The selector retired the standalone "On" choice in favor of
+    // "Interactive" (its surviving semantics); a bookmarked/shared
+    // `?loopDetection=on` link must still enable the detector, so it maps
+    // forward rather than silently falling through to "Off" below.
     case "on":
-      return { type: "On" };
+      return { type: "Interactive" };
     case "interactive":
       return { type: "Interactive" };
     default:

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -61,7 +61,6 @@
   "comboDetector": {
     "label": "Combo-Detektor (experimentell)",
     "title": "Unendliche Schleifen erkennen: Pflichtschleifen automatisch beenden und ∞-Ressourcen anzeigen (standardmäßig aus)",
-    "on": "An",
     "off": "Aus",
     "interactive": "Interaktiv"
   },

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -61,7 +61,6 @@
   "comboDetector": {
     "label": "Combo Detector (experimental)",
     "title": "Detect infinite loops: end mandatory loops automatically and show ∞ resources (off by default)",
-    "on": "On",
     "off": "Off",
     "interactive": "Interactive"
   },

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -61,7 +61,6 @@
   "comboDetector": {
     "label": "Detector de combos (experimental)",
     "title": "Detectar bucles infinitos: terminar bucles obligatorios automáticamente y mostrar recursos ∞ (desactivado por defecto)",
-    "on": "Activado",
     "off": "Desactivado",
     "interactive": "Interactivo"
   },

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -61,7 +61,6 @@
   "comboDetector": {
     "label": "Détecteur de combos (expérimental)",
     "title": "Détecter les boucles infinies : terminer automatiquement les boucles obligatoires et afficher les ressources ∞ (désactivé par défaut)",
-    "on": "Activé",
     "off": "Désactivé",
     "interactive": "Interactif"
   },

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -61,7 +61,6 @@
   "comboDetector": {
     "label": "Rilevatore di combo (sperimentale)",
     "title": "Rileva i loop infiniti: termina automaticamente i loop obbligatori e mostra le risorse ∞ (disattivato per impostazione predefinita)",
-    "on": "Attivo",
     "off": "Disattivato",
     "interactive": "Interattivo"
   },

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -61,7 +61,6 @@
   "comboDetector": {
     "label": "Wykrywacz combosów (eksperymentalne)",
     "title": "Wykrywaj nieskończone pętle: automatycznie kończ obowiązkowe pętle i pokazuj zasoby ∞ (domyślnie wyłączone)",
-    "on": "Wł.",
     "off": "Wył.",
     "interactive": "Interaktywny"
   },

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -61,7 +61,6 @@
   "comboDetector": {
     "label": "Detector de combos (experimental)",
     "title": "Detectar loops infinitos: encerrar loops obrigatórios automaticamente e mostrar recursos ∞ (desativado por padrão)",
-    "on": "Ligado",
     "off": "Desligado",
     "interactive": "Interativo"
   },

--- a/client/src/pages/GameSetupPage.tsx
+++ b/client/src/pages/GameSetupPage.tsx
@@ -557,7 +557,7 @@ export function GameSetupPage() {
                     <span className="text-xs text-slate-400" title={t("common:comboDetector.title")}>
                       {t("common:comboDetector.label")}
                     </span>
-                    <div className="grid grid-cols-3 gap-1 rounded-[10px] border border-gray-700 bg-gray-950/70 p-1">
+                    <div className="grid grid-cols-2 gap-1 rounded-[10px] border border-gray-700 bg-gray-950/70 p-1">
                       <button
                         type="button"
                         onClick={() => setLoopDetection({ type: "Off" })}
@@ -568,17 +568,6 @@ export function GameSetupPage() {
                         }`}
                       >
                         {t("common:comboDetector.off")}
-                      </button>
-                      <button
-                        type="button"
-                        onClick={() => setLoopDetection({ type: "On" })}
-                        className={`rounded-[7px] px-3 py-1.5 text-xs font-medium transition-colors ${
-                          loopDetection.type === "On"
-                            ? "bg-indigo-600 text-white"
-                            : "bg-gray-800 text-gray-400 hover:bg-gray-700 hover:text-gray-200"
-                        }`}
-                      >
-                        {t("common:comboDetector.on")}
                       </button>
                       <button
                         type="button"

--- a/client/src/stores/__tests__/multiplayerStore.test.ts
+++ b/client/src/stores/__tests__/multiplayerStore.test.ts
@@ -30,6 +30,7 @@ import { formatMetadata } from "../../data/formatRegistry";
 import {
   FORMAT_DEFAULTS,
   isServerCompatible,
+  migrateLegacyLoopDetectionOn,
   migrateOfficialServerAddress,
   migratePersistedMultiplayerState,
   type HostingSettings,
@@ -375,6 +376,63 @@ describe("multiplayerStore", () => {
         3,
       ),
     ).toEqual({ serverAddress: "wss://lobby.phase-rs.dev/ws" });
+  });
+
+  it("forwards a legacy 'On' loop-detection choice to Interactive", () => {
+    expect(
+      migrateLegacyLoopDetectionOn({
+        format: "Commander",
+        loopDetection: { type: "On" },
+      }),
+    ).toEqual({ format: "Commander", loopDetection: { type: "Interactive" } });
+  });
+
+  it("leaves Off/Interactive loop-detection choices unchanged", () => {
+    expect(
+      migrateLegacyLoopDetectionOn({ format: "Commander", loopDetection: { type: "Off" } }),
+    ).toEqual({ format: "Commander", loopDetection: { type: "Off" } });
+    expect(
+      migrateLegacyLoopDetectionOn({
+        format: "Commander",
+        loopDetection: { type: "Interactive" },
+      }),
+    ).toEqual({ format: "Commander", loopDetection: { type: "Interactive" } });
+  });
+
+  it("passes through a null lastHostConfig unchanged", () => {
+    expect(migrateLegacyLoopDetectionOn(null)).toBeNull();
+  });
+
+  it("re-runs the legacy loop-detection migration for v3 stores (v3 -> v4)", () => {
+    expect(
+      migratePersistedMultiplayerState(
+        {
+          lastHostConfig: {
+            format: "Commander",
+            loopDetection: { type: "On" },
+          },
+        },
+        3,
+      ),
+    ).toEqual({
+      lastHostConfig: { format: "Commander", loopDetection: { type: "Interactive" } },
+    });
+  });
+
+  it("does not re-migrate a store already at v4", () => {
+    expect(
+      migratePersistedMultiplayerState(
+        {
+          lastHostConfig: {
+            format: "Commander",
+            loopDetection: { type: "On" },
+          },
+        },
+        4,
+      ),
+    ).toEqual({
+      lastHostConfig: { format: "Commander", loopDetection: { type: "On" } },
+    });
   });
 
   it("strips AI seats from team-based server host settings", async () => {

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -528,6 +528,19 @@ export function migrateOfficialServerAddress(
     : address;
 }
 
+// The host-setup selector retired its standalone "On" loop-detection choice
+// in favor of "Interactive" (its surviving semantics). A `lastHostConfig`
+// persisted before that change may still carry `{ type: "On" }`; forward it
+// to Interactive rather than silently dropping to Off, which would turn the
+// detector off for a player who had chosen it on.
+export function migrateLegacyLoopDetectionOn(lastHostConfig: unknown): unknown {
+  if (!lastHostConfig || typeof lastHostConfig !== "object") return lastHostConfig;
+  const config = lastHostConfig as Record<string, unknown>;
+  const loopDetection = config.loopDetection as { type?: unknown } | undefined;
+  if (loopDetection?.type !== "On") return lastHostConfig;
+  return { ...config, loopDetection: { type: "Interactive" } };
+}
+
 export function migratePersistedMultiplayerState(
   persisted: unknown,
   version: number,
@@ -539,6 +552,9 @@ export function migratePersistedMultiplayerState(
       migrated.serverAddress,
       DEFAULT_MULTIPLAYER_SERVER_URL,
     );
+  }
+  if (version < 4) {
+    migrated.lastHostConfig = migrateLegacyLoopDetectionOn(migrated.lastHostConfig);
   }
   return migrated;
 }
@@ -1494,7 +1510,7 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
     }),
     {
       name: "phase-multiplayer",
-      version: 3,
+      version: 4,
       // v0/v1 → v2: official hosted lobby addresses are deployment defaults,
       // not user intent. A self-hosted build must move returning browsers from
       // the official lobby to its configured default while preserving explicit
@@ -1507,6 +1523,12 @@ export const useMultiplayerStore = create<MultiplayerState & MultiplayerActions>
       // lobby its build cannot handshake with. Re-running the same migration
       // repoints it at this channel's broker; a user-typed non-official address
       // is still preserved.
+      //
+      // v3 → v4: the host-setup selector dropped its standalone "On"
+      // loop-detection choice. A `lastHostConfig.loopDetection` of `{ type:
+      // "On" }` persisted under an older build is forwarded to `Interactive`
+      // (its surviving semantics) rather than left to silently fall back to
+      // `Off` on next read.
       migrate: migratePersistedMultiplayerState,
       partialize: (state) => ({
         playerId: state.playerId,


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Removes the "On" button from the combo (infinite-loop) detector mode selector, leaving Off/Interactive only, ahead of the planned On/Interactive semantic merge. Legacy "On" values are coerced forward to Interactive (never silently dropped to Off) at both real ingress seams: the URL query parser and a new persisted-store migration for a remembered host config.

## Files changed

- `client/src/components/lobby/HostSetup.tsx` — remove the On button from the lobby host-setup selector
- `client/src/pages/GameSetupPage.tsx` — remove the On button from the local-game setup selector; `grid-cols-3` → `grid-cols-2`
- `client/src/game/loopDetectionMode.ts` — `loopDetectionModeFromQuery("on")` now returns `Interactive` instead of `On`
- `client/src/game/__tests__/loopDetectionMode.test.ts` — updated/added coverage for the coercion
- `client/src/stores/multiplayerStore.ts` — new `migrateLegacyLoopDetectionOn` helper + `phase-multiplayer` persist migration v3→v4
- `client/src/stores/__tests__/multiplayerStore.test.ts` — 5 new tests for the v3→v4 migration
- `client/src/i18n/locales/{de,en,es,fr,it,pl,pt}/common.json` — remove the now-unused `comboDetector.on` key (verified no other reader; 7-locale parity)

## Track

Developer

## LLM

Model: claude-sonnet-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — UI-only display-layer patch (button removal + legacy-value ingress coercion + i18n key parity); no engine/parser/rules-engine logic touched. Executed as a single maintainer-authorized direct patch under explicit dispensation (no `/engine-implementer` plan/review pipeline for this scope).

## CR references

None. The pre-existing `CR 732.2a` comments on the touched selector blocks are left as-is; no rules logic or new CR annotations were added.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [ ] Final review-impl below is clean for the current committed head. — not run; see Implementation method. No `/engine-implementer` review-impl cycle was requested or executed for this dispensation-scoped patch.
- [x] Both anchors cite existing analogous code at the same seam.

- `cd client && pnpm run type-check` (`tsc -b --noEmit`) — clean, 0 errors. Confirmed the instrument is live via an injected-error positive control (a deliberate type mismatch in `loopDetectionMode.ts` was caught, then reverted) before trusting the clean run.
- `cd client && pnpm lint` — 0 errors, 43 pre-existing warnings unrelated to any touched file.
- `cd client && npx vitest run` — 423 files / 4597 tests passed, 2 skipped, 12 todo (all pre-existing), 0 failures.
- `bash scripts/check-parser-combinators.sh <upstream/main SHA>` — Gate A/Gate G PASS (see below). This diff touches zero Rust files, so Gate A/Gate G pass vacuously for this PR's own range; disclosed rather than presented as meaningful Rust-architecture coverage.

## Gate A

Gate A PASS head=d79153c6d332865d9cf87cca60a927c1f4d9f2d9 base=518a1b046dde89721ed4d2f922c890c44b664b5d

## Anchored on

- client/src/stores/multiplayerStore.ts:522 — existing `migrateOfficialServerAddress`/v2→v3 persisted-migration pattern this PR's new v3→v4 `migrateLegacyLoopDetectionOn` migration mirrors
- client/src/game/loopDetectionMode.ts:8 — existing `loopDetectionModeFromQuery` URL-ingress switch this PR extends with the "on"→Interactive coercion case

## Final review-impl

Not applicable — no `/engine-implementer` review-impl cycle was run for this patch; see Implementation method and the unchecked Verification box above for why. Verification instead rests on the commands and results listed above.

## Claimed parse impact

None.

## Scope Expansion

None. The persisted-store migration and URL-ingress coercion are required by the brief's own legacy-value-handling scope (not incidental), and the locale key removal is required by the brief's own i18n-parity scope.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Simplified combo-detector settings to “Off” and “Interactive” modes.
  * Existing saved settings and shared links using the legacy “On” mode now continue with “Interactive.”

* **Bug Fixes**
  * Updated game setup layouts and localized labels to reflect the available options.
  * Preserved loop-detection behavior when loading older saved configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->