### PR TITLE
fix(tilt): attach tauri dev to the shared frontend vite instead of spawning a second

### DIFF
--- a/Tiltfile
+++ b/Tiltfile
@@ -106,6 +106,11 @@ local_resource('frontend',
     allow_parallel = True,
     links = ['http://localhost:5173'],
     labels = ['serve'],
+    # `tauri` depends on this resource being ready (see below) so it doesn't
+    # open devUrl before Vite accepts connections — the default Tilt
+    # readiness (process started) isn't enough, since Vite compiles for a
+    # moment before it binds :5173.
+    readiness_probe = probe(period_secs = 5, tcp_socket = tcp_socket_action(port = 5173)),
 )
 
 # Deck-import + lobby broker Worker. vite.config.ts proxies /import-deck to

--- a/Tiltfile
+++ b/Tiltfile
@@ -103,7 +103,6 @@ local_resource('frontend',
     serve_cmd = 'pnpm dev',
     serve_dir = 'client',
     serve_env = {'CADDY_PROXY': '1'} if 'https' in enabled else {},
-    auto_init = 'tauri' not in enabled,
     allow_parallel = True,
     links = ['http://localhost:5173'],
     labels = ['serve'],
@@ -145,21 +144,26 @@ local_resource('caddy',
     labels = ['serve'],
 )
 
-# Thin-shell dev loop. `tauri dev` starts vite itself (beforeDevCommand) and
-# points the window at devUrl http://localhost:5173, so the shell hosts the
-# LOCAL frontend instead of the production bootstrap->remote-origin flow —
-# that is why `frontend` sets auto_init = 'tauri' not in enabled (both would
-# bind :5173). The shell crate is workspace-excluded and self-contained, and
-# `tauri dev` watches client/src-tauri/src/ and rebuilds on its own; Tilt only
-# restarts the loop when the Tauri config or crate manifest changes. The old
-# phase-server sidecar build is gone with the thin shell: production shells
-# download their native engine via signed manifests, and local multiplayer
-# testing talks to the `server` resource on :9374.
+# Thin-shell dev loop. Plain `tauri dev` starts its own vite via
+# beforeDevCommand, which would fight the `frontend` resource for :5173 —
+# so this resource attaches to `frontend`'s already-running vite instead of
+# spawning a second one. tauri.tilt.conf.json overlays beforeDevCommand to a
+# no-op (--config merges over tauri.conf.json), and resource_deps ensures
+# `frontend` is up first. devUrl still points at http://localhost:5173, so
+# the shell window hosts that shared LOCAL frontend rather than the
+# production bootstrap->remote-origin flow. The shell crate is
+# workspace-excluded and self-contained, and `tauri dev` watches
+# client/src-tauri/src/ and rebuilds on its own; Tilt only restarts the loop
+# when the Tauri config or crate manifest changes. The old phase-server
+# sidecar build is gone with the thin shell: production shells download
+# their native engine via signed manifests, and local multiplayer testing
+# talks to the `server` resource on :9374.
 local_resource('tauri',
-    serve_cmd = 'pnpm tauri:dev',
+    serve_cmd = 'pnpm exec tauri dev --config src-tauri/tauri.tilt.conf.json',
     serve_dir = 'client',
-    deps = ['client/src-tauri/tauri.conf.json', 'client/src-tauri/Cargo.toml'],
+    deps = ['client/src-tauri/tauri.conf.json', 'client/src-tauri/tauri.tilt.conf.json', 'client/src-tauri/Cargo.toml'],
     ignore = TMP_IGNORE,
+    resource_deps = ['frontend'],
     auto_init = 'tauri' in enabled,
     labels = ['serve'],
 )

--- a/client/src-tauri/tauri.tilt.conf.json
+++ b/client/src-tauri/tauri.tilt.conf.json
@@ -1,0 +1,5 @@
+{
+  "build": {
+    "beforeDevCommand": ""
+  }
+}


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

`tauri`'s `beforeDevCommand` spawned a second vite on the same port as the `frontend` Tilt resource's vite; since `frontend`'s recent `--strictPort` fix, that second vite now exits with `Port 5173 is already in use` and kills the `tauri` resource. This attaches `tauri dev` to `frontend`'s already-running vite via a `--config` overlay instead of excluding the two resources from each other.

## Files changed

- `Tiltfile` — `tauri` resource runs `tauri dev --config src-tauri/tauri.tilt.conf.json`, adds `resource_deps = ['frontend']`; `frontend` drops its `auto_init = 'tauri' not in enabled` mutual exclusion; comment above `tauri` rewritten for the attach regime.
- `client/src-tauri/tauri.tilt.conf.json` (new) — Tauri v2 config overlay that no-ops `beforeDevCommand` so `tauri dev` doesn't spawn its own vite. `client/src-tauri/tauri.conf.json` (used by standalone `pnpm tauri:dev` outside Tilt) is untouched.

## Track

Non-developer

## LLM

Model: claude-sonnet-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — Tilt/dev-tooling config change, no `crates/engine/` game logic touched. Maintainer-authorized patch-mode dispensation (no plan/review pipeline) for this single tightly-scoped fix.

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `tilt alpha tiltfile-result -f Tiltfile` (dry Starlark eval, no live Tilt instance touched) — `"Error": null`.
- `jq . client/src-tauri/tauri.tilt.conf.json` — valid JSON.
- Premise probe, disposable worktree, main Tilt's `frontend` vite live on `:5173`:
  - Patched: `pnpm exec tauri dev --config src-tauri/tauri.tilt.conf.json` goes straight from `Running DevCommand` to `cargo run` — no `Running BeforeDevCommand`, no vite spawn, no port-5173 error.
  - Control (unpatched `pnpm tauri:dev`, same worktree): reproduces the reported bug verbatim — `Running BeforeDevCommand (\`pnpm dev\`)` → vite → `Error: Port 5173 is already in use` → `beforeDevCommand terminated with a non-zero status code` → exit 1.
- No Rust/TS source changed, so `clippy`/`test-engine`/`check-frontend` carry no signal for this diff; not run.

## Gate A

Gate A PASS head=e109a9540656b090d13dc447c8e6830cbb9049cd base=9831e0143724c73ba9e7ffc3e0511ec3539712d3

## Anchored on

- Tiltfile:141 (`caddy` resource) — `resource_deps = ['frontend']` is the existing pattern for a Tilt resource that depends on `frontend`'s running vite; `tauri` now follows it.
- client/src-tauri/tauri.conf.json:9 — the `build.beforeDevCommand` key the overlay neutralizes; confirmed via probe that Tauri v2's `--config` merge accepts an empty-string override to skip the spawn.

## Final review-impl

not-applicable — patch-mode dispensation, no review pipeline run for this change.

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tauri development now starts alongside the existing frontend development server.
  * Added a dedicated configuration for launching Tauri without starting a second frontend process.

* **Improvements**
  * Frontend development starts automatically, including when Tauri development is enabled.
  * Tauri development now uses the shared Vite server for a smoother local development workflow.
  * Frontend services now report ready only after the development server is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->