### PR TITLE
fix(client): restore offline image progress and removal feedback

### DIFF
--- a/client/src/components/settings/visual-packs/OperationProgress.tsx
+++ b/client/src/components/settings/visual-packs/OperationProgress.tsx
@@ -13,7 +13,8 @@ interface OperationProgressProps {
 
 export function OperationProgress({ operation, progressPhase, pendingActions, onCancel, onResume }: OperationProgressProps) {
   const { t } = useTranslation("settings");
-  const imageTotal = operation.objectEstimate ?? operation.objectTotal;
+  const imageTotal = operation.objectEstimate
+    ?? (operation.state === "finalizing" || operation.state === "completed" ? operation.objectTotal : null);
   const startPending = pendingActions.has("install") || pendingActions.has("repair") || pendingActions.has("resume");
   const canCancel = operation.state === "downloading" && progressPhase !== "failed";
   /**
@@ -71,10 +72,14 @@ export function OperationProgress({ operation, progressPhase, pendingActions, on
       </label>
       <label className="mt-3 block text-xs text-sky-50">
         <span className="flex items-center justify-between gap-3">
-          <span>{t("visualPacks.operation.objects", { current: operation.objectsPromoted, total: imageTotal })}</span>
-          <span className="font-medium tabular-nums">{operation.objectsPromoted}/{imageTotal}</span>
+          <span>{imageTotal === null
+            ? t("visualPacks.operation.objectsUnknown", { current: operation.objectsPromoted })
+            : t("visualPacks.operation.objects", { current: operation.objectsPromoted, total: imageTotal })}</span>
+          <span className="font-medium tabular-nums">{imageTotal === null ? operation.objectsPromoted : `${operation.objectsPromoted}/${imageTotal}`}</span>
         </span>
-        <progress className="mt-1.5 block h-2 w-full accent-sky-400" value={operation.objectsPromoted} max={Math.max(imageTotal, 1)} />
+        {imageTotal === null
+          ? <progress className="mt-1.5 block h-2 w-full accent-sky-400" />
+          : <progress className="mt-1.5 block h-2 w-full accent-sky-400" value={operation.objectsPromoted} max={Math.max(imageTotal, 1)} />}
       </label>
       <p className="mt-3 text-xs leading-relaxed text-sky-100/80">
         {t(operation.objectEstimate === null ? "visualPacks.operation.scanNote" : "visualPacks.operation.estimateNote")}

--- a/client/src/components/settings/visual-packs/PackStatus.tsx
+++ b/client/src/components/settings/visual-packs/PackStatus.tsx
@@ -167,6 +167,9 @@ export function PackStatus({
           </ul>
         </div>
       )}
+      {pendingActions.has("remove") && (
+        <p aria-live="polite" className="text-xs text-slate-300">{t("visualPacks.removal.inProgress")}</p>
+      )}
     </section>
   );
 }

--- a/client/src/components/settings/visual-packs/VisualPackManager.test.tsx
+++ b/client/src/components/settings/visual-packs/VisualPackManager.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import { act, cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 import {
@@ -30,6 +30,7 @@ vi.mock("../../../hooks/useSetSymbols.ts", () => ({ useSetCatalog: () => ({ cata
 const ROOT_A = catalogRoot("a".repeat(64));
 const ROOT_B = catalogRoot("b".repeat(64));
 const OPERATION = operationId("c".repeat(32));
+const OTHER_OPERATION = operationId("f".repeat(32));
 /** A curated pack's root IS its membership digest, so it is deliberately
  *  neither of the catalog roots above — an estimate that matched one of those
  *  would hide a selector-identity bug rather than expose it. */
@@ -1737,19 +1738,78 @@ describe("VisualPackManager initialization", () => {
   });
 
   /** Drive the panel to an operation that has failed and is offering Resume. */
-  async function reachFailedOperation(fixture: ReturnType<typeof backend>): Promise<void> {
+  async function reachFailedOperation(
+    fixture: ReturnType<typeof backend>,
+    state: "downloading" | "finalizing" = "downloading",
+  ): Promise<void> {
     await pressInstall(/scan catalog and estimate/i, /install selection/i);
     await waitFor(() => expect(fixture.value.start).toHaveBeenCalled());
     fixture.emitProgress({
       phase: "failed",
       error: "network",
       operation: {
-        operationId: OPERATION, catalogRoot: ROOT_A, kind: "install", state: "downloading",
+        operationId: OPERATION, catalogRoot: ROOT_A, kind: "install", state,
         packTotal: 1, packsPromoted: 0, objectTotal: 2, objectEstimate: null, objectsPromoted: 1, completedRevision: null,
       },
     });
     await screen.findByRole("button", { name: /resume operation/i });
   }
+
+  it.each(["downloading", "finalizing"] as const)("adopts a different durable operation after a failed %s operation", async (state) => {
+    const fixture = backend();
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    await reachFailedOperation(fixture, state);
+
+    await act(async () => {
+      fixture.emitProgress({
+        phase: "running",
+        error: null,
+        operation: {
+          operationId: OTHER_OPERATION, catalogRoot: ROOT_B, kind: "install", state: "downloading",
+          packTotal: 1, packsPromoted: 0, objectTotal: 3, objectEstimate: 3, objectsPromoted: 2, completedRevision: null,
+        },
+      });
+    });
+
+    expect(await screen.findByText("2/3")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /resume operation/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+  });
+
+  it("does not let a different durable operation replace an active operation", async () => {
+    const fixture = backend();
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    await pressInstall(/scan catalog and estimate/i, /install selection/i);
+    await waitFor(() => expect(fixture.value.start).toHaveBeenCalled());
+
+    fixture.emitProgress({
+      phase: "running",
+      error: null,
+      operation: {
+        operationId: OPERATION, catalogRoot: ROOT_A, kind: "install", state: "downloading",
+        packTotal: 1, packsPromoted: 0, objectTotal: 2, objectEstimate: 2, objectsPromoted: 1, completedRevision: null,
+      },
+    });
+    expect(await screen.findByText("1/2")).toBeInTheDocument();
+
+    await act(async () => {
+      fixture.emitProgress({
+        phase: "running",
+        error: null,
+        operation: {
+          operationId: OTHER_OPERATION, catalogRoot: ROOT_B, kind: "install", state: "downloading",
+          packTotal: 1, packsPromoted: 0, objectTotal: 3, objectEstimate: 3, objectsPromoted: 2, completedRevision: null,
+        },
+      });
+    });
+
+    expect(screen.getByText("1/2")).toBeInTheDocument();
+    expect(screen.queryByText("2/3")).not.toBeInTheDocument();
+  });
 
   it("preserves a failed progress event emitted before a manual start reply", async () => {
     const fixture = backend();

--- a/client/src/components/settings/visual-packs/VisualPackManager.test.tsx
+++ b/client/src/components/settings/visual-packs/VisualPackManager.test.tsx
@@ -189,6 +189,65 @@ describe("VisualPackManager initialization", () => {
     expect(revisionUnlisten).toHaveBeenCalledTimes(1);
   });
 
+  it("adopts a background operation and accepts a live lower-progress update", async () => {
+    const fixture = backend();
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    await waitFor(() => expect(fixture.value.subscribeProgress).toHaveBeenCalled());
+    const running = {
+      operationId: OPERATION, catalogRoot: ROOT_A, kind: "install" as const, state: "downloading" as const,
+      packTotal: 1, packsPromoted: 0, objectTotal: 2, objectEstimate: 2, objectsPromoted: 1, completedRevision: null,
+    };
+    fixture.emitProgress({ phase: "running", error: null, operation: running });
+    expect(await screen.findByText("1/2")).toBeInTheDocument();
+
+    fixture.emitProgress({ phase: "running", error: null, operation: { ...running, objectsPromoted: 0 } });
+    expect(await screen.findByText("0/2")).toBeInTheDocument();
+
+    fixture.emitProgress({ phase: "completed", error: null, operation: { ...running, state: "completed", objectsPromoted: 2, completedRevision: installedRevision("2") } });
+    expect(await screen.findByText("Completed")).toBeInTheDocument();
+    fixture.emitProgress({
+      phase: "started",
+      error: null,
+      operation: {
+        ...running,
+        operationId: operationId("d".repeat(32)),
+        catalogRoot: ROOT_B,
+        kind: "repair",
+        objectsPromoted: 0,
+        completedRevision: null,
+      },
+    });
+    expect(await screen.findByText("0/2")).toBeInTheDocument();
+  });
+
+  it("keeps unknown image totals indeterminate until finalization makes the total authoritative", async () => {
+    const fixture = backend();
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    await waitFor(() => expect(fixture.value.subscribeProgress).toHaveBeenCalled());
+    const operation = {
+      operationId: OPERATION, catalogRoot: ROOT_A, kind: "repair" as const, state: "downloading" as const,
+      packTotal: 1, packsPromoted: 0, objectTotal: 0, objectEstimate: null, objectsPromoted: 0, completedRevision: null,
+    };
+    fixture.emitProgress({ phase: "running", error: null, operation });
+    expect(await screen.findByText("Images downloaded: 0")).toBeInTheDocument();
+    const progressBars = screen.getAllByRole("progressbar");
+    expect(progressBars[progressBars.length - 1]).not.toHaveAttribute("value");
+
+    fixture.emitProgress({ phase: "running", error: null, operation: { ...operation, objectEstimate: 0 } });
+    expect(await screen.findByText("0/0")).toBeInTheDocument();
+    const knownProgressBars = screen.getAllByRole("progressbar");
+    expect(knownProgressBars[knownProgressBars.length - 1]).toHaveAttribute("value", "0");
+
+    fixture.emitProgress({ phase: "running", error: null, operation: { ...operation, objectTotal: 2, objectsPromoted: 1 } });
+    expect(await screen.findByText("Images downloaded: 1")).toBeInTheDocument();
+    fixture.emitProgress({ phase: "running", error: null, operation: { ...operation, state: "finalizing", objectTotal: 2, objectsPromoted: 1 } });
+    expect(await screen.findByText("1/2")).toBeInTheDocument();
+  });
+
   it("restores a removal confirmation to its pointer launcher", async () => {
     const fixture = backend();
     platform.load.mockResolvedValue(fixture.value);
@@ -1691,6 +1750,77 @@ describe("VisualPackManager initialization", () => {
     });
     await screen.findByRole("button", { name: /resume operation/i });
   }
+
+  it("preserves a failed progress event emitted before a manual start reply", async () => {
+    const fixture = backend();
+    const started = deferred<Awaited<ReturnType<VisualPackBackend["start"]>>>();
+    vi.mocked(fixture.value.start).mockReturnValue(started.promise);
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    await pressInstall(/scan catalog and estimate/i, /install selection/i);
+    await waitFor(() => expect(fixture.value.start).toHaveBeenCalled());
+    fixture.emitProgress({
+      phase: "failed",
+      error: "network",
+      operation: {
+        operationId: OPERATION, catalogRoot: ROOT_A, kind: "install", state: "downloading",
+        packTotal: 1, packsPromoted: 0, objectTotal: 2, objectEstimate: 2, objectsPromoted: 1, completedRevision: null,
+      },
+    });
+    started.resolve({ status: "started", operationId: OPERATION, catalogRoot: ROOT_A, persistence: "persisted" });
+
+    expect(await screen.findByRole("button", { name: /resume operation/i })).toBeInTheDocument();
+  });
+
+  it("reopens a failed operation only when the backend starts its retry", async () => {
+    const fixture = backend();
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    await reachFailedOperation(fixture);
+
+    fixture.emitProgress({
+      phase: "started",
+      error: null,
+      operation: {
+        operationId: OPERATION, catalogRoot: ROOT_A, kind: "install", state: "downloading",
+        packTotal: 1, packsPromoted: 0, objectTotal: 2, objectEstimate: 2, objectsPromoted: 0, completedRevision: null,
+      },
+    });
+    expect(await screen.findByText("0/2")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /resume operation/i })).not.toBeInTheDocument();
+
+    fixture.emitProgress({
+      phase: "completed",
+      error: null,
+      operation: {
+        operationId: OPERATION, catalogRoot: ROOT_A, kind: "install", state: "completed",
+        packTotal: 1, packsPromoted: 1, objectTotal: 2, objectEstimate: 2, objectsPromoted: 2, completedRevision: installedRevision("2"),
+      },
+    });
+    expect(await screen.findByText("Completed")).toBeInTheDocument();
+  });
+
+  it("accepts reconciliation cancellation after a retryable failure", async () => {
+    const fixture = backend();
+    platform.load.mockResolvedValue(fixture.value);
+    render(<VisualPackManager />);
+    await screen.findByText(/Offline card images/i);
+    await reachFailedOperation(fixture);
+
+    fixture.emitProgress({
+      phase: "cancelled",
+      error: null,
+      operation: {
+        operationId: OPERATION, catalogRoot: ROOT_A, kind: "install", state: "cancelled",
+        packTotal: 1, packsPromoted: 0, objectTotal: 2, objectEstimate: 2, objectsPromoted: 1, completedRevision: null,
+      },
+    });
+
+    expect(await screen.findByText("Cancelled")).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /resume operation/i })).not.toBeInTheDocument();
+  });
 
   it("reports a terminated operation as stopped, not as a cancellation", async () => {
     const fixture = backend();

--- a/client/src/components/settings/visual-packs/useVisualPackManager.ts
+++ b/client/src/components/settings/visual-packs/useVisualPackManager.ts
@@ -363,7 +363,20 @@ export function useVisualPackManager(): VisualPackManagerState {
 
   const handleProgress = useCallback((event: ProgressEvent) => {
     if (!mountedRef.current) return;
-    const selected = operationRef.current;
+    let selected = operationRef.current;
+    if (
+      operationIsDurableMutation(event.operation)
+      && !startEventBufferRef.current.active
+      && (!selected || (!operationIsDurableMutation(selected) && progressIdentity(event) !== `${selected.operationId}:${selected.catalogRoot}`))
+    ) {
+      const identity = progressIdentity(event);
+      operationRef.current = event.operation;
+      progressRef.current = null;
+      progressOutcomeRef.current = { identity, failed: false, cancelled: false, terminal: false };
+      setOperation(event.operation);
+      setProgress(null);
+      selected = event.operation;
+    }
     if (
       !selected
       || event.operation.operationId !== selected.operationId
@@ -410,9 +423,31 @@ export function useVisualPackManager(): VisualPackManagerState {
     // `completed` is excluded from the reopening because that ending is
     // unambiguous: `run()`'s catch leaves an already-completed record alone, so
     // it can emit `failed` carrying one, and a finished install must not flip.
-    if (outcome.failed || outcome.cancelled) return;
+    // A retryable failure leaves its record live. Its next authoritative
+    // `started` event is a new run of THAT record, so it may reopen the
+    // failure latch. Do this only after proving the event still names a live
+    // operation: a late start must never revive a witnessed cancellation or a
+    // completed/terminal record.
+    const restartingAfterRetryableFailure = event.phase === "started"
+      && outcome.failed
+      && !outcome.cancelled
+      && !outcome.terminal
+      && operationIsDurableMutation(event.operation);
+    const acceptingCancellationAfterRetryableFailure = event.phase === "cancelled"
+      && outcome.failed
+      && !outcome.terminal
+      && operationIsDurableMutation(selected);
+    if (outcome.cancelled) return;
+    // Reconciliation can authoritatively cancel a previously failed but still
+    // retryable operation when its membership is superseded. That terminal
+    // event must replace the Resume state; ordinary running updates may not.
+    if (outcome.failed && !restartingAfterRetryableFailure && !acceptingCancellationAfterRetryableFailure) return;
     if (outcome.terminal && (event.phase !== "failed" || event.operation.state === "completed")) return;
     if (operationRank(event.operation) < operationRank(selected)) return;
+    if (restartingAfterRetryableFailure) {
+      outcome.failed = false;
+      outcome.terminal = false;
+    }
     if (event.phase === "failed") outcome.failed = true;
     if (event.phase === "cancelled") outcome.cancelled = true;
     if (progressIsTerminal(event)) outcome.terminal = true;

--- a/client/src/components/settings/visual-packs/useVisualPackManager.ts
+++ b/client/src/components/settings/visual-packs/useVisualPackManager.ts
@@ -367,7 +367,7 @@ export function useVisualPackManager(): VisualPackManagerState {
     if (
       operationIsDurableMutation(event.operation)
       && !startEventBufferRef.current.active
-      && (!selected || (!operationIsDurableMutation(selected) && progressIdentity(event) !== `${selected.operationId}:${selected.catalogRoot}`))
+      && (!selected || ((progressOutcomeRef.current.failed || !operationIsDurableMutation(selected)) && progressIdentity(event) !== `${selected.operationId}:${selected.catalogRoot}`))
     ) {
       const identity = progressIdentity(event);
       operationRef.current = event.operation;

--- a/client/src/i18n/locales/de/settings.json
+++ b/client/src/i18n/locales/de/settings.json
@@ -289,6 +289,7 @@
       "root": "Katalogstamm",
       "packs": "Pakete: {{current}} von {{total}}",
       "objects": "Bilder: {{current}} von {{total}}",
+      "objectsUnknown": "Heruntergeladene Bilder: {{current}}",
       "scanNote": "Die Gesamtzahl wächst beim Durchsuchen des Scryfall-Snapshots. Bereits geladene Bilder bleiben lokal und werden beim Fortsetzen übersprungen.",
       "estimateNote": "Die Gesamtzahl stand beim Start dieses Downloads fest. Bereits geladene Bilder bleiben lokal und werden beim Fortsetzen übersprungen.",
       "finalizing": "Die Installation des Katalogs wird abgeschlossen"
@@ -330,7 +331,8 @@
       }
     },
     "removal": {
-      "committed": "Entfernung wurde bei Revision {{revision}} durchgeführt."
+      "committed": "Entfernung wurde bei Revision {{revision}} durchgeführt.",
+      "inProgress": "Offline-Visualisierungen werden entfernt…"
     },
     "cleanup": {
       "malformed_entry": "Ein fehlerhafter Cache-Eintrag konnte nicht wiederhergestellt werden",

--- a/client/src/i18n/locales/en/settings.json
+++ b/client/src/i18n/locales/en/settings.json
@@ -293,6 +293,7 @@
       "root": "Scryfall snapshot",
       "packs": "Packs: {{current}} of {{total}}",
       "objects": "Images: {{current}} of {{total}}",
+      "objectsUnknown": "Images downloaded: {{current}}",
       "scanNote": "The total grows as the Scryfall snapshot is scanned. Completed images are stored locally and skipped when you resume.",
       "estimateNote": "The total was fixed when this download started. Completed images are stored locally and skipped when you resume.",
       "finalizing": "Finalizing offline image installation"
@@ -333,7 +334,10 @@
         "projection_drift": "Installed lookup records differ from the trusted catalog"
       }
     },
-    "removal": { "committed": "Removal committed at revision {{revision}}." },
+    "removal": {
+      "committed": "Removal committed at revision {{revision}}.",
+      "inProgress": "Removing offline visuals…"
+    },
     "cleanup": {
       "malformed_entry": "A malformed cache entry could not be reclaimed",
       "unsafe_entry": "An unsafe cache entry was left untouched",

--- a/client/src/i18n/locales/es/settings.json
+++ b/client/src/i18n/locales/es/settings.json
@@ -289,6 +289,7 @@
       "root": "raíz del catálogo",
       "packs": "Paquetes: {{current}} de {{total}}",
       "objects": "Imágenes: {{current}} de {{total}}",
+      "objectsUnknown": "Imágenes descargadas: {{current}}",
       "scanNote": "El total aumenta mientras se analiza la instantánea de Scryfall. Las imágenes ya descargadas permanecen locales y se omiten al reanudar.",
       "estimateNote": "El total quedó fijado al iniciar esta descarga. Las imágenes ya descargadas permanecen locales y se omiten al reanudar.",
       "finalizing": "Finalizando la instalación del catálogo"
@@ -330,7 +331,8 @@
       }
     },
     "removal": {
-      "committed": "Eliminación confirmada en la revisión {{revision}}."
+      "committed": "Eliminación confirmada en la revisión {{revision}}.",
+      "inProgress": "Eliminando elementos visuales sin conexión…"
     },
     "cleanup": {
       "malformed_entry": "No se pudo recuperar una entrada de caché con formato incorrecto",

--- a/client/src/i18n/locales/fr/settings.json
+++ b/client/src/i18n/locales/fr/settings.json
@@ -288,7 +288,8 @@
       "id": "Fonctionnement",
       "root": "Racine du catalogue",
       "packs": "Packs : {{current}} sur {{total}}",
-      "objects": "Images : {{current}} sur {{total}}",
+      "objects": "Images : {{current}} sur {{total}}",
+      "objectsUnknown": "Images téléchargées : {{current}}",
       "scanNote": "Le total augmente pendant l’analyse de l’instantané Scryfall. Les images déjà téléchargées restent locales et sont ignorées à la reprise.",
       "estimateNote": "Le total a été fixé au démarrage de ce téléchargement. Les images déjà téléchargées restent locales et sont ignorées à la reprise.",
       "finalizing": "Finalisation de l'installation du catalogue"
@@ -330,7 +331,8 @@
       }
     },
     "removal": {
-      "committed": "Suppression validée lors de la révision {{revision}}."
+      "committed": "Suppression validée lors de la révision {{revision}}.",
+      "inProgress": "Suppression des visuels hors ligne…"
     },
     "cleanup": {
       "malformed_entry": "Une entrée de cache mal formée n'a pas pu être récupérée",

--- a/client/src/i18n/locales/it/settings.json
+++ b/client/src/i18n/locales/it/settings.json
@@ -289,6 +289,7 @@
       "root": "Radice del catalogo",
       "packs": "Pacchetti: {{current}} di {{total}}",
       "objects": "Immagini: {{current}} di {{total}}",
+      "objectsUnknown": "Immagini scaricate: {{current}}",
       "scanNote": "Il totale cresce durante la scansione dell’istantanea Scryfall. Le immagini già scaricate restano locali e vengono ignorate alla ripresa.",
       "estimateNote": "Il totale è stato fissato all’avvio di questo download. Le immagini già scaricate restano locali e vengono ignorate alla ripresa.",
       "finalizing": "Finalizzazione dell'installazione del catalogo"
@@ -330,7 +331,8 @@
       }
     },
     "removal": {
-      "committed": "Rimozione commessa alla revisione {{revision}}."
+      "committed": "Rimozione commessa alla revisione {{revision}}.",
+      "inProgress": "Rimozione degli elementi visivi offline…"
     },
     "cleanup": {
       "malformed_entry": "Non è stato possibile recuperare una voce della cache dal formato errato",

--- a/client/src/i18n/locales/pl/settings.json
+++ b/client/src/i18n/locales/pl/settings.json
@@ -289,6 +289,7 @@
       "root": "Katalog główny",
       "packs": "Pakiety: {{current}} z {{total}}",
       "objects": "Obrazy: {{current}} z {{total}}",
+      "objectsUnknown": "Pobrane obrazy: {{current}}",
       "scanNote": "Łączna liczba rośnie podczas skanowania migawki Scryfall. Pobrane obrazy pozostają lokalnie i są pomijane po wznowieniu.",
       "estimateNote": "Łączna liczba została ustalona przy starcie tego pobierania. Pobrane obrazy pozostają lokalnie i są pomijane po wznowieniu.",
       "finalizing": "Kończenie instalacji katalogu"
@@ -330,7 +331,8 @@
       }
     },
     "removal": {
-      "committed": "Usunięcie dokonane w wersji {{revision}}."
+      "committed": "Usunięcie dokonane w wersji {{revision}}.",
+      "inProgress": "Usuwanie elementów wizualnych offline…"
     },
     "cleanup": {
       "malformed_entry": "Nie można odzyskać źle sformułowanego wpisu w pamięci podręcznej",

--- a/client/src/i18n/locales/pt/settings.json
+++ b/client/src/i18n/locales/pt/settings.json
@@ -289,6 +289,7 @@
       "root": "Raiz do catálogo",
       "packs": "Pacotes: {{current}} de {{total}}",
       "objects": "Imagens: {{current}} de {{total}}",
+      "objectsUnknown": "Imagens baixadas: {{current}}",
       "scanNote": "O total cresce enquanto a captura do Scryfall é analisada. As imagens já baixadas ficam locais e são ignoradas ao retomar.",
       "estimateNote": "O total foi fixado no início desta transferência. As imagens já baixadas ficam locais e são ignoradas ao retomar.",
       "finalizing": "Finalizando a instalação do catálogo"
@@ -330,7 +331,8 @@
       }
     },
     "removal": {
-      "committed": "Remoção confirmada na revisão {{revision}}."
+      "committed": "Remoção confirmada na revisão {{revision}}.",
+      "inProgress": "A remover elementos visuais offline…"
     },
     "cleanup": {
       "malformed_entry": "Uma entrada de cache malformada não pôde ser recuperada",

--- a/client/src/services/visualPacks/browser/__tests__/curatedSelector.test.tsx
+++ b/client/src/services/visualPacks/browser/__tests__/curatedSelector.test.tsx
@@ -126,6 +126,9 @@ function imageResponse(source: string): Response {
 
 /** A transient image outage: `fetchImage` rejects a non-200 as `network`. */
 let failImages = false;
+let holdLaterImages = false;
+let releaseHeldImages: (() => void) | null = null;
+let heldImages: Promise<void> = Promise.resolve();
 
 const fetchStub = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
   const source = String(input);
@@ -134,6 +137,7 @@ const fetchStub = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
   if (source === "/scryfall-data.json") return jsonResponse(CARDS);
   if (source === "/scryfall-printings.json") return jsonResponse(PRINTINGS);
   if (source.startsWith("https://cards.scryfall.io/") || source.startsWith("https://backs.scryfall.io/")) {
+    if (holdLaterImages && imageRequests().length > 1) await heldImages;
     return failImages ? new Response("", { status: 503 }) : imageResponse(source);
   }
   throw new Error(`unexpected fetch: ${source}`);
@@ -225,6 +229,8 @@ describe("curated install selector", () => {
     cache = new MemoryCache();
     requested = [];
     failImages = false;
+    holdLaterImages = false;
+    heldImages = new Promise((resolve) => { releaseHeldImages = resolve; });
     fetchStub.mockClear();
     vi.stubGlobal("fetch", fetchStub);
     vi.stubGlobal("caches", { open: async () => cache } as unknown as CacheStorage);
@@ -233,6 +239,8 @@ describe("curated install selector", () => {
   });
 
   afterEach(() => {
+    releaseHeldImages?.();
+    releaseHeldImages = null;
     cleanup();
     vi.unstubAllGlobals();
   });
@@ -623,5 +631,30 @@ describe("curated install selector", () => {
     // bulk stream would fail this test at the fetch rather than here.
     expect(requested).not.toContain(BULK_DOWNLOAD_URL);
     expect(imageRequests()).toHaveLength(descriptors.length);
+  });
+
+  it("restores a paused manual install with its saved-image progress", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    await backend.refreshCatalog();
+    const { selector, descriptors } = await curatedSelector();
+    holdLaterImages = true;
+    const started = await backend.start({ kind: "install", selector, objectEstimate: descriptors.length });
+    if (started.status !== "started") throw new Error("curated install did not start");
+
+    await vi.waitFor(async () => {
+      expect((await backend.operationStatus(started.operationId)).objectsPromoted).toBeGreaterThan(0);
+    });
+    platform.load.mockResolvedValue(backend);
+    render(<VisualPackManager />);
+
+    // This panel did not start the operation. Its first visible count therefore
+    // comes from subscribeProgress's current-operation snapshot, not a mocked
+    // progress event or an eventual completion.
+    expect(await screen.findByText(`1/${descriptors.length}`)).toBeInTheDocument();
+    const progress = screen.getAllByRole("progressbar").find((element) => element.getAttribute("value") === "1");
+    expect(progress).toBeDefined();
+
+    releaseHeldImages?.();
+    await settle(backend, started.operationId);
   });
 });

--- a/client/src/services/visualPacks/browser/__tests__/deckLibrarySelector.test.tsx
+++ b/client/src/services/visualPacks/browser/__tests__/deckLibrarySelector.test.tsx
@@ -2,8 +2,10 @@ import "fake-indexeddb/auto";
 
 import { IDBFactory } from "fake-indexeddb";
 import { openDB } from "idb";
+import { cleanup, render, screen } from "@testing-library/react";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
+import { VisualPackManager } from "../../../../components/settings/visual-packs/VisualPackManager.tsx";
 import { VisualPackBackendError } from "../../backend.ts";
 import { assetKey, catalogRoot, estimatedImageBytes, minimumImageBytes, operationId, packId } from "../../types.ts";
 import type { DeckLibraryInstallSelector, InstallSelector, ProgressEvent } from "../../types.ts";
@@ -21,6 +23,12 @@ const CURATED = packId("curated");
 const EMPTY_DIGEST = catalogRoot("f".repeat(64));
 const BULK_INDEX_URL = "https://api.scryfall.com/bulk-data";
 
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  const promise = new Promise<T>((done) => { resolve = done; });
+  return { promise, resolve };
+}
+
 class MemoryCache {
   readonly entries = new Map<string, Response>();
 
@@ -34,6 +42,7 @@ class MemoryCache {
   }
 
   async delete(path: string): Promise<boolean> {
+    if (path === holdCacheDeletePath) await new Promise<void>((resolve) => { releaseCacheDelete = resolve; });
     return this.entries.delete(path);
   }
 }
@@ -44,6 +53,8 @@ let holdSecondImage = false;
 let releaseSecondImage: (() => void) | null = null;
 let holdCachePath: string | null = null;
 let releaseCacheMatch: (() => void) | null = null;
+let holdCacheDeletePath: string | null = null;
+let releaseCacheDelete: (() => void) | null = null;
 let failImages = false;
 let failedImage: string | null = null;
 
@@ -53,6 +64,7 @@ const state = vi.hoisted(() => ({
   plan: vi.fn(),
   invalidate: vi.fn(),
 }));
+const platform = vi.hoisted(() => ({ load: vi.fn() }));
 
 vi.mock("../../../scryfall.ts", () => ({
   isCardDataResident: () => state.cardDataResident,
@@ -62,6 +74,8 @@ vi.mock("../../deckLibraryPack.ts", () => ({
   planDeckLibraryPack: state.plan,
   invalidateDeckLibraryPack: state.invalidate,
 }));
+vi.mock("../../../platform.ts", () => ({ loadVisualPackBackend: platform.load }));
+vi.mock("../../../../hooks/useSetSymbols.ts", () => ({ useSetCatalog: () => ({ catalog: null, isLoading: false }) }));
 
 class FifoWebLocks {
   private tail = Promise.resolve();
@@ -153,8 +167,11 @@ describe("deck-library selector and drift contract", () => {
     releaseSecondImage = null;
     holdCachePath = null;
     releaseCacheMatch = null;
+    holdCacheDeletePath = null;
+    releaseCacheDelete = null;
     failImages = false;
     failedImage = null;
+    platform.load.mockReset();
     vi.stubGlobal("caches", { open: async () => cache } as unknown as CacheStorage);
     fetchMock = vi.fn(async (input: RequestInfo | URL): Promise<Response> => {
       const source = String(input);
@@ -180,6 +197,7 @@ describe("deck-library selector and drift contract", () => {
   });
 
   afterEach(() => {
+    cleanup();
     releaseSecondImage?.();
     releaseCacheMatch?.();
     vi.unstubAllGlobals();
@@ -619,6 +637,84 @@ describe("deck-library selector and drift contract", () => {
     expect(cache.entries.has(sharedPath)).toBe(true);
   });
 
+  it("publishes a committed removal before slow cache cleanup finishes", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    await backend.refreshCatalog();
+    await seedPack(DECK_LIBRARY, PLANNED_DIGEST);
+    await seedObject(DECK_LIBRARY, PLANNED_DIGEST, FIRST);
+    const database = await openDB(DATABASE, 1);
+    const [stored] = await database.getAllFromIndex("objects", "by-pack", DECK_LIBRARY);
+    database.close();
+    if (!stored) throw new Error("seed object was not written");
+    cache.entries.set(stored.path, new Response("image", { headers: { "Content-Type": "image/jpeg" } }));
+    holdCacheDeletePath = stored.path;
+    const revisions: string[] = [];
+    await backend.subscribeRevision((event) => revisions.push(event.revision));
+
+    const removing = backend.remove({ kind: "packs", packIds: [DECK_LIBRARY] }, "reject_dependents");
+    await vi.waitFor(() => expect(releaseCacheDelete).not.toBeNull());
+
+    expect(revisions).toHaveLength(1);
+    expect((await backend.catalogSummary()).installedPacks).toEqual([]);
+
+    releaseCacheDelete?.();
+    await removing;
+  });
+
+  it("restores a paused deck-library download in the settings panel", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    await backend.refreshCatalog();
+    holdSecondImage = true;
+    const started = await backend.start({
+      kind: "install", selector: { kind: "deck_library", membershipDigest: PLANNED_DIGEST }, objectEstimate: 2,
+    });
+    if (started.status !== "started") throw new Error("deck-library install did not start");
+    await vi.waitFor(async () => {
+      expect((await backend.operationStatus(started.operationId)).objectsPromoted).toBe(1);
+    });
+    platform.load.mockResolvedValue(backend);
+    render(<VisualPackManager />);
+
+    expect(await screen.findByText("1/2")).toBeInTheDocument();
+
+    releaseSecondImage?.();
+    await vi.waitFor(async () => expect((await backend.operationStatus(started.operationId)).state).toBe("completed"));
+  });
+
+  it("does not replay a stale snapshot after live progress arrives during subscription", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    await backend.refreshCatalog();
+    holdSecondImage = true;
+    const started = await backend.start({
+      kind: "install", selector: { kind: "deck_library", membershipDigest: PLANNED_DIGEST }, objectEstimate: 2,
+    });
+    if (started.status !== "started") throw new Error("deck-library install did not start");
+    await vi.waitFor(() => expect(releaseSecondImage).not.toBeNull());
+    const privateBackend = backend as unknown as {
+      database: { getAll(store: string): Promise<unknown[]> };
+      emit(event: ProgressEvent): void;
+    };
+    const originalGetAll = privateBackend.database.getAll.bind(privateBackend.database);
+    const snapshot = deferred<unknown[]>();
+    let snapshotRead = false;
+    privateBackend.database.getAll = async () => {
+      snapshotRead = true;
+      return snapshot.promise;
+    };
+    const events: ProgressEvent[] = [];
+    const subscribed = backend.subscribeProgress((event) => events.push(event));
+    await vi.waitFor(() => expect(snapshotRead).toBe(true));
+    const live = await backend.operationStatus(started.operationId);
+    privateBackend.emit({ phase: "failed", operation: { ...live, objectsPromoted: 0 }, error: "network" });
+    snapshot.resolve(await originalGetAll("operations"));
+    const unlisten = await subscribed;
+
+    expect(events).toEqual([expect.objectContaining({ phase: "failed", error: "network" })]);
+    unlisten();
+    releaseSecondImage?.();
+    await backend.cancel(started.operationId);
+  });
+
   it("removes both an installed receipt and a cancelled delta root while retaining shared cache", async () => {
     const backend = await ScryfallBrowserVisualPackBackend.create();
     const initial = await backend.start({
@@ -645,6 +741,7 @@ describe("deck-library selector and drift contract", () => {
       expect((await rows.getAllFromIndex("objects", "by-pack", DECK_LIBRARY)).some((row) => row.root === EMPTY_DIGEST)).toBe(true);
       rows.close();
     });
+    await vi.waitFor(() => expect(releaseSecondImage).not.toBeNull());
     const cancelling = backend.cancel(delta.operationId);
     releaseSecondImage?.();
     await cancelling;
@@ -948,6 +1045,38 @@ describe("deck-library selector and drift contract", () => {
     await vi.waitFor(async () => expect((await recreated.operationStatus(operation.id)).state).toBe("completed"));
   });
 
+  it("restarts a failed background sync at the same membership digest", async () => {
+    const backend = await ScryfallBrowserVisualPackBackend.create();
+    const initial = await backend.start({
+      kind: "install", selector: { kind: "deck_library", membershipDigest: PLANNED_DIGEST }, objectEstimate: 2,
+    });
+    if (initial.status !== "started") throw new Error("deck-library install did not start");
+    await vi.waitFor(async () => expect((await backend.operationStatus(initial.operationId)).state).toBe("completed"));
+    state.membership = { membershipDigest: EMPTY_DIGEST, descriptors: [FIRST, MOVED] };
+    failImages = true;
+    installWebLocks();
+    await expect(backend.reconcileDeckLibrary()).rejects.toMatchObject({ kind: "network" });
+    const failed = await openDB(DATABASE, 1);
+    const operation = (await failed.getAll("operations")).find((entry) => entry.background);
+    failed.close();
+    if (!operation) throw new Error("background operation was not persisted");
+
+    const events: ProgressEvent[] = [];
+    await backend.subscribeProgress((event) => events.push(event));
+    platform.load.mockResolvedValue(backend);
+    render(<VisualPackManager />);
+    expect(await screen.findByRole("button", { name: /resume operation/i })).toBeInTheDocument();
+    failImages = false;
+    await expect(backend.reconcileDeckLibrary()).resolves.toBeUndefined();
+
+    expect((await backend.operationStatus(operation.id)).state).toBe("completed");
+    expect(await screen.findByText("Completed")).toBeInTheDocument();
+    expect(events).toEqual(expect.arrayContaining([
+      expect.objectContaining({ phase: "started", operation: expect.objectContaining({ operationId: operation.id }) }),
+      expect.objectContaining({ phase: "completed", operation: expect.objectContaining({ operationId: operation.id }) }),
+    ]));
+  });
+
   it("collects a failed delta when membership returns to its installed root", async () => {
     const backend = await ScryfallBrowserVisualPackBackend.create();
     const initial = await backend.start({
@@ -977,6 +1106,11 @@ describe("deck-library selector and drift contract", () => {
     });
     failed.close();
 
+    const events: ProgressEvent[] = [];
+    await backend.subscribeProgress((event) => events.push(event));
+    platform.load.mockResolvedValue(backend);
+    render(<VisualPackManager />);
+    expect(await screen.findByRole("button", { name: /resume operation/i })).toBeInTheDocument();
     failedImage = null;
     state.membership = { membershipDigest: PLANNED_DIGEST, descriptors: [FIRST, SECOND] };
     fetchMock.mockClear();
@@ -989,6 +1123,11 @@ describe("deck-library selector and drift contract", () => {
     expect(d1Rows.every((row) => row.root === PLANNED_DIGEST)).toBe(true);
     expect((await after.get("operations", operation.id))?.state).toBe("cancelled");
     after.close();
+    expect(await screen.findByText("Cancelled")).toBeInTheDocument();
+    expect(events).toContainEqual(expect.objectContaining({
+      phase: "cancelled",
+      operation: expect.objectContaining({ operationId: operation.id, state: "cancelled" }),
+    }));
     expect(fetchMock).not.toHaveBeenCalled();
     expect(cache.entries.has(d2Row.path)).toBe(true);
     expect(cache.entries.has(d2OnlyRow.path)).toBe(false);
@@ -1233,11 +1372,11 @@ describe("deck-library selector and drift contract", () => {
       changed.close();
       releaseFinish();
       await vi.waitFor(async () => expect((await recreated.operationStatus(OPERATION)).state).toBe("cancelled"));
-      expect(progress).toEqual([expect.objectContaining({
+      expect(progress[progress.length - 1]).toEqual(expect.objectContaining({
         phase: "cancelled",
         operation: expect.objectContaining({ state: "cancelled" }),
         error: null,
-      })]);
+      }));
       expect(revisions).toEqual([]);
       const after = await openDB(DATABASE, 1);
       expect((await after.get("state", "state"))?.revision).toBe(current.revision);

--- a/client/src/services/visualPacks/browser/scryfallBackend.ts
+++ b/client/src/services/visualPacks/browser/scryfallBackend.ts
@@ -1364,6 +1364,7 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
         return;
       }
       try {
+        this.emit({ phase: "started", operation: await this.operationStatus(selectedOperation), error: null });
         await this.runAndWait(selectedOperation);
       } catch (error) {
         const afterFailure = await this.database.get("packs", packId("deck_library"));
@@ -1414,6 +1415,7 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
     }
     const operations = await transaction.objectStore("operations").getAll();
     let superseded = false;
+    let cancelled: OperationStatus | null = null;
     const active = operations.find((operation) =>
       deckLibraryOperation(operation)
       && operation.deckLibraryGeneration === expectedGeneration
@@ -1427,9 +1429,11 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
       }
       await transaction.objectStore("operations").put({ ...active, state: "cancelled" });
       superseded = true;
+      cancelled = operationStatus({ ...active, state: "cancelled" });
     }
     if (receipt.root === membership.membershipDigest) {
       await transaction.done;
+      if (cancelled) this.emit({ phase: "cancelled", operation: cancelled, error: null });
       if (superseded) {
         await this.collectLocalPackGarbage(
           packId("deck_library"),
@@ -1464,7 +1468,7 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
     } satisfies ScryfallOperationRecord);
     await transaction.objectStore("operations").put(operation);
     await transaction.done;
-    this.emit({ phase: "started", operation: operationStatus(operation), error: null });
+    if (cancelled) this.emit({ phase: "cancelled", operation: cancelled, error: null });
     return selectedOperation;
   }
 
@@ -1701,6 +1705,10 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
       const revision = String(BigInt(current.revision) + 1n);
       await transaction.objectStore("state").put({ ...current, revision });
       await transaction.done;
+      // The installed membership has committed. Publish it before cache cleanup,
+      // which can be slow on WebKit, so every observer can refresh its receipt
+      // state while the reference-aware sweep continues in the background.
+      this.publish({ cause: "remove", operationId: null, catalogRoot: null, revision: installedRevision(revision) });
       if (deckLibrarySelected) {
         for (const controller of this.reconciliationControllers) controller.abort();
         for (const selectedOperation of invalidatedDeckLibraryOperations) {
@@ -1710,7 +1718,6 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
           this.workers.get(selectedOperation)?.settled));
       }
       await this.sweepUnreferenced(paths, await caches.open(CACHE));
-      this.publish({ cause: "remove", operationId: null, catalogRoot: null, revision: installedRevision(revision) });
       return { removed: removed.map((entry) => ({ packId: entry.packId, catalogRoot: entry.root })), revision: installedRevision(revision), cleanupIssues: [] };
     } catch (error) {
       throw backendError(error);
@@ -1764,6 +1771,27 @@ export class ScryfallBrowserVisualPackBackend implements VisualPackBackend {
   }
 
   async subscribeProgress(listener: (event: ProgressEvent) => void): Promise<() => void> {
+    const liveOperations = new Set<OperationId>();
+    const forwarded = (event: ProgressEvent) => {
+      liveOperations.add(event.operation.operationId);
+      listener(event);
+    };
+    this.progressListeners.add(forwarded);
+    try {
+      const operations = await this.database.getAll("operations");
+      for (const operation of operations) {
+        if (
+          liveOperations.has(operation.id)
+          || (operation.state !== "downloading" && operation.state !== "cancel_requested" && operation.state !== "finalizing")
+        ) continue;
+        const failure = this.workerFailures.get(operation.id);
+        listener({ phase: failure ? "failed" : "running", operation: operationStatus(operation), error: failure?.kind ?? null });
+      }
+    } catch (error) {
+      this.progressListeners.delete(forwarded);
+      throw error;
+    }
+    this.progressListeners.delete(forwarded);
     this.progressListeners.add(listener);
     return () => this.progressListeners.delete(listener);
   }


### PR DESCRIPTION
Restore active image operations when Settings opens, preserve progress event ordering, and follow background retry and cancellation transitions. Publish catalog removal before cache cleanup and display pending cleanup and accurate final progress.

Verified with 4612 frontend tests, type-check/lint, independent review, and real WebKit install/reopen/removal probes. The original other-Mac manually-started 0% freeze was not reproduced; the original code advanced in the controlled WebKit baseline.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Visual pack downloads now display accurate progress when totals are known and a clear downloaded-image count when totals are unavailable.
  * Removal operations now show an in-progress status.
  * In-progress downloads can restore their saved progress when returning to settings.

* **Bug Fixes**
  * Improved handling of retries, cancellations, completion, and superseded operations.
  * Prevented stale updates from reviving cancelled or finished operations.
  * Improved progress event delivery during background synchronization.

* **Localization**
  * Added corresponding progress and removal-status translations across supported languages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->