### PR TITLE
feat(server): per-game JSON-Lines debug logs (#7978)

### DIFF
--- a/crates/phase-server/src/logging.rs
+++ b/crates/phase-server/src/logging.rs
@@ -1,12 +1,9 @@
-use std::collections::HashMap;
-use std::fs::{self, File, OpenOptions};
-use std::io::{BufWriter, Write};
+use std::fs;
 use std::path::PathBuf;
-use std::sync::{Arc, Mutex};
-use std::time::SystemTime;
+use std::sync::Arc;
 
-use engine::types::log::GameLogEntry;
 use serde_json::{Map, Value};
+use server_core::game_log::{format_timestamp, GameFileCache, Stream};
 use tracing::field::{Field, Visit};
 use tracing::span::{Attributes, Id};
 use tracing::{Event, Subscriber};
@@ -65,149 +62,11 @@ impl Visit for JsonFieldVisitor {
     }
 }
 
-/// Format a UTC timestamp as `YYYY-MM-DDTHH:MM:SS.mmmZ` without external crates.
-fn format_timestamp() -> String {
-    let duration = SystemTime::now()
-        .duration_since(SystemTime::UNIX_EPOCH)
-        .unwrap_or_default();
-    let secs = duration.as_secs();
-    let millis = duration.subsec_millis();
-
-    // Convert epoch seconds to date/time components.
-    let days = secs / 86400;
-    let time_of_day = secs % 86400;
-    let hours = time_of_day / 3600;
-    let minutes = (time_of_day % 3600) / 60;
-    let seconds = time_of_day % 60;
-
-    // Civil date from day count (algorithm from Howard Hinnant).
-    let z = days as i64 + 719468;
-    let era = z.div_euclid(146097);
-    let doe = z.rem_euclid(146097) as u64;
-    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
-    let y = (yoe as i64) + era * 400;
-    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
-    let mp = (5 * doy + 2) / 153;
-    let d = doy - (153 * mp + 2) / 5 + 1;
-    let m = if mp < 10 { mp + 3 } else { mp - 9 };
-    let y = if m <= 2 { y + 1 } else { y };
-
-    format!(
-        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
-        y, m, d, hours, minutes, seconds, millis
-    )
-}
-
-/// A category of per-game log row. Each category is its own JSON-Lines file
-/// (`<games_dir>/<game_code>.<category>.jsonl`) so a reader can select one
-/// concern (`jq` per file) without filtering a merged stream.
-///
-/// - `"session"`: transport/session-lifecycle tracing events (connects,
-///   actions dispatched, game-over, errors) — whatever already flows through
-///   the `game_session` tracing span.
-/// - `"events"`: the engine's own [`GameLogEntry`] rows (already categorized
-///   internally via `GameLogEntry::category`), one per rules-level event.
-type Stream = &'static str;
-const STREAM_SESSION: Stream = "session";
-const STREAM_EVENTS: Stream = "events";
-
-/// `None` value = open was attempted and failed (sentinel to avoid retry storms).
-type FileMap = HashMap<(String, Stream), Option<BufWriter<File>>>;
-
-/// Shared per-game JSON-Lines file cache. Each `(game_code, stream)` pair maps
-/// to a lazily-opened, append-only file, flushed after every write so a crash
-/// never loses more than the write in flight. `games_dir: None` means logging
-/// is disabled (stdout-only run) and every write is a no-op.
-pub struct GameFileCache {
-    games_dir: Option<PathBuf>,
-    files: Mutex<FileMap>,
-}
-
-impl GameFileCache {
-    fn new(games_dir: PathBuf) -> Self {
-        Self {
-            games_dir: Some(games_dir),
-            files: Mutex::new(HashMap::new()),
-        }
-    }
-
-    fn disabled() -> Self {
-        Self {
-            games_dir: None,
-            files: Mutex::new(HashMap::new()),
-        }
-    }
-}
-
-impl Default for GameFileCache {
-    /// A disabled cache, so `ServerContext`'s `#[derive(Default)]` (used
-    /// throughout its test call sites) gets a real, inert no-op writer
-    /// rather than requiring every test to wire one up.
-    fn default() -> Self {
-        Self::disabled()
-    }
-}
-
-impl GameFileCache {
-    fn open_file(&self, game_code: &str, stream: Stream) -> Option<BufWriter<File>> {
-        let dir = self.games_dir.as_ref()?;
-        let path = dir.join(format!("{game_code}.{stream}.jsonl"));
-        OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-            .ok()
-            .map(BufWriter::new)
-    }
-
-    fn write_line(&self, game_code: &str, stream: Stream, line: &str) {
-        if self.games_dir.is_none() {
-            return;
-        }
-        let mut files = self.files.lock().unwrap_or_else(|e| e.into_inner());
-        let entry = files
-            .entry((game_code.to_string(), stream))
-            .or_insert_with(|| self.open_file(game_code, stream));
-        if let Some(writer) = entry {
-            let _ = writer.write_all(line.as_bytes());
-            let _ = writer.write_all(b"\n");
-            let _ = writer.flush();
-        }
-    }
-
-    /// Write one JSON-Lines row per [`GameLogEntry`], stamped with the
-    /// wall-clock moment of writing — the entries themselves carry only
-    /// game-time (`seq`/`turn`/`phase`), not wall-clock time.
-    pub fn write_game_log_entries(&self, game_code: &str, entries: &[GameLogEntry]) {
-        if self.games_dir.is_none() {
-            return;
-        }
-        for entry in entries {
-            let Ok(Value::Object(mut fields)) = serde_json::to_value(entry) else {
-                continue;
-            };
-            fields.insert("ts".to_string(), Value::String(format_timestamp()));
-            if let Ok(line) = serde_json::to_string(&Value::Object(fields)) {
-                self.write_line(game_code, STREAM_EVENTS, &line);
-            }
-        }
-    }
-
-    /// Flush and drop every stream's cached writer for a game whose
-    /// `game_session` span just closed. Reopened lazily if another
-    /// connection resumes writing to the same game.
-    fn close(&self, game_code: &str) {
-        let mut files = self.files.lock().unwrap_or_else(|e| e.into_inner());
-        for stream in [STREAM_SESSION, STREAM_EVENTS] {
-            if let Some(Some(mut writer)) = files.remove(&(game_code.to_string(), stream)) {
-                let _ = writer.flush();
-            }
-        }
-    }
-}
-
-/// A tracing `Layer` that routes events occurring within a `game_session` span
-/// to the `"session"` per-game JSON-Lines stream.
+/// A tracing `Layer` that routes events occurring within a `game_session`
+/// span to the `Stream::Session` per-game JSON-Lines stream. The engine's own
+/// per-rules-event rows (`Stream::Events`) are written separately, directly
+/// by `server-core` at the point each action result is minted — see
+/// `server_core::game_log`'s module doc.
 pub struct GameFileLayer {
     cache: Arc<GameFileCache>,
 }
@@ -266,7 +125,7 @@ where
         );
 
         if let Ok(line) = serde_json::to_string(&Value::Object(fields)) {
-            self.cache.write_line(&game_code, STREAM_SESSION, &line);
+            self.cache.write_line(&game_code, Stream::Session, &line);
         }
     }
 
@@ -284,11 +143,13 @@ where
 ///
 /// When `log_dir` is `Some`, logs are written to files:
 /// - Main log: `<dir>/phase-server.log` (daily rolling; JSON-formatted iff `json`)
-/// - Per-game logs: `<dir>/games/<GAME_CODE>.session.jsonl` and
-///   `<dir>/games/<GAME_CODE>.events.jsonl` — always JSON-Lines, independent
-///   of `json`. The per-game format is not optional: it exists so a game's
-///   logs are parseable, and gating that behind a flag would leave the
-///   default output exactly as unparseable as before this existed.
+/// - Per-game logs: `<dir>/games/<GAME_CODE>.session.jsonl` (this file's
+///   `GameFileLayer`) and `<dir>/games/<GAME_CODE>.events.jsonl` (the
+///   engine's own `GameLogEntry` rows, written by `server-core` — see
+///   `server_core::game_log`) — always JSON-Lines, independent of `json`.
+///   The per-game format is not optional: it exists so a game's logs are
+///   parseable, and gating that behind a flag would leave the default output
+///   exactly as unparseable as before this existed.
 ///
 /// When `log_dir` is `None`, logs are written to stdout (local dev mode) and
 /// the returned [`GameFileCache`] is disabled (every write a no-op).
@@ -296,6 +157,10 @@ where
 /// Returns a `WorkerGuard` that must be held alive for the program's lifetime
 /// to ensure buffered logs are flushed. Use a **named binding** (`let _guard = ...`),
 /// NOT bare `_` which drops immediately.
+///
+/// The returned [`GameFileCache`] must be installed on the live
+/// `SessionManager` (`SessionManager.game_log`) — that's what makes the
+/// `events` stream live; this function only wires up the `session` stream.
 pub fn init_logging(
     log_dir: Option<&str>,
     json: bool,
@@ -362,140 +227,5 @@ pub fn init_logging(
             }
             (None, Arc::new(GameFileCache::disabled()))
         }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use engine::types::log::{LogCategory, LogPresentation};
-    use engine::types::phase::Phase;
-
-    #[test]
-    fn format_timestamp_is_valid_iso8601() {
-        let ts = format_timestamp();
-        // Expect: YYYY-MM-DDTHH:MM:SS.mmmZ
-        assert_eq!(ts.len(), 24);
-        assert!(ts.ends_with('Z'));
-        assert_eq!(&ts[4..5], "-");
-        assert_eq!(&ts[7..8], "-");
-        assert_eq!(&ts[10..11], "T");
-        assert_eq!(&ts[13..14], ":");
-        assert_eq!(&ts[16..17], ":");
-        assert_eq!(&ts[19..20], ".");
-    }
-
-    #[test]
-    fn game_file_cache_creates_session_stream_file() {
-        let tmp = tempfile::tempdir().unwrap();
-        let games_dir = tmp.path().join("games");
-        fs::create_dir_all(&games_dir).unwrap();
-
-        let cache = GameFileCache::new(games_dir.clone());
-        cache.write_line("TEST01", STREAM_SESSION, r#"{"message":"hello"}"#);
-
-        let log_path = games_dir.join("TEST01.session.jsonl");
-        assert!(log_path.exists());
-    }
-
-    #[test]
-    fn game_file_cache_appends_to_existing_files() {
-        let tmp = tempfile::tempdir().unwrap();
-        let games_dir = tmp.path().join("games");
-        fs::create_dir_all(&games_dir).unwrap();
-
-        let cache = GameFileCache::new(games_dir.clone());
-        let log_path = games_dir.join("APPEND.session.jsonl");
-
-        cache.write_line("APPEND", STREAM_SESSION, r#"{"n":1}"#);
-        cache.write_line("APPEND", STREAM_SESSION, r#"{"n":2}"#);
-
-        let content = fs::read_to_string(&log_path).unwrap();
-        assert_eq!(content, "{\"n\":1}\n{\"n\":2}\n");
-    }
-
-    #[test]
-    fn game_file_cache_disabled_writes_nothing() {
-        // A disabled cache (stdout mode, no log_dir) must not create files.
-        let cache = GameFileCache::disabled();
-        cache.write_line("FAIL01", STREAM_SESSION, r#"{"n":1}"#);
-        // No games_dir exists to assert against — the write path itself
-        // early-returns (`games_dir.is_none()`), which is what this pins.
-        assert!(cache.games_dir.is_none());
-    }
-
-    fn sample_entry(seq: u32, category: LogCategory) -> GameLogEntry {
-        GameLogEntry {
-            seq,
-            turn: 1,
-            phase: Phase::PreCombatMain,
-            category,
-            segments: Vec::new(),
-            presentation: LogPresentation::default(),
-        }
-    }
-
-    #[test]
-    fn write_game_log_entries_preserves_category_and_timestamps() {
-        let tmp = tempfile::tempdir().unwrap();
-        let games_dir = tmp.path().join("games");
-        fs::create_dir_all(&games_dir).unwrap();
-        let cache = GameFileCache::new(games_dir.clone());
-
-        cache.write_game_log_entries("CAT01", &[sample_entry(1, LogCategory::Combat)]);
-
-        let content = fs::read_to_string(games_dir.join("CAT01.events.jsonl")).unwrap();
-        let line: Value = serde_json::from_str(content.trim_end()).unwrap();
-        // Discriminating: a bug that dropped the category field, or one that
-        // always tagged entries `Debug`, fails this assertion against a
-        // deliberately non-Debug variant.
-        assert_eq!(line["category"], "Combat");
-        assert!(line["ts"].as_str().unwrap().ends_with('Z'));
-    }
-
-    #[test]
-    fn write_game_log_entries_writes_one_line_per_entry_not_overwritten() {
-        let tmp = tempfile::tempdir().unwrap();
-        let games_dir = tmp.path().join("games");
-        fs::create_dir_all(&games_dir).unwrap();
-        let cache = GameFileCache::new(games_dir.clone());
-
-        cache.write_game_log_entries(
-            "SEQ01",
-            &[
-                sample_entry(1, LogCategory::Turn),
-                sample_entry(2, LogCategory::Combat),
-            ],
-        );
-
-        let content = fs::read_to_string(games_dir.join("SEQ01.events.jsonl")).unwrap();
-        let lines: Vec<&str> = content.lines().collect();
-        assert_eq!(
-            lines.len(),
-            2,
-            "each entry must be its own line, not overwritten"
-        );
-        let first: Value = serde_json::from_str(lines[0]).unwrap();
-        let second: Value = serde_json::from_str(lines[1]).unwrap();
-        assert_eq!(first["seq"], 1);
-        assert_eq!(second["seq"], 2);
-    }
-
-    #[test]
-    fn closing_session_stream_does_not_lose_flushed_events_stream_content() {
-        let tmp = tempfile::tempdir().unwrap();
-        let games_dir = tmp.path().join("games");
-        fs::create_dir_all(&games_dir).unwrap();
-        let cache = GameFileCache::new(games_dir.clone());
-
-        cache.write_game_log_entries("BOTH01", &[sample_entry(1, LogCategory::Zone)]);
-        cache.write_line("BOTH01", STREAM_SESSION, r#"{"message":"joined"}"#);
-
-        // Simulate the game_session span closing — this must not touch
-        // content already flushed to the independent "events" stream.
-        cache.close("BOTH01");
-
-        let events_content = fs::read_to_string(games_dir.join("BOTH01.events.jsonl")).unwrap();
-        assert_eq!(events_content.lines().count(), 1);
     }
 }

--- a/crates/phase-server/src/logging.rs
+++ b/crates/phase-server/src/logging.rs
@@ -2,9 +2,11 @@ use std::collections::HashMap;
 use std::fs::{self, File, OpenOptions};
 use std::io::{BufWriter, Write};
 use std::path::PathBuf;
-use std::sync::Mutex;
+use std::sync::{Arc, Mutex};
 use std::time::SystemTime;
 
+use engine::types::log::GameLogEntry;
+use serde_json::{Map, Value};
 use tracing::field::{Field, Visit};
 use tracing::span::{Attributes, Id};
 use tracing::{Event, Subscriber};
@@ -28,30 +30,38 @@ impl Visit for GameCodeVisitor {
     fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
 }
 
-/// Visitor that formats all event fields as `key=value` pairs.
-struct FieldFormatter(String);
+/// Visitor that collects every tracing event field into a JSON object, keyed
+/// by field name verbatim (tracing already names the message field
+/// `"message"`, so no special-casing is needed here).
+struct JsonFieldVisitor(Map<String, Value>);
 
-impl Visit for FieldFormatter {
+impl Visit for JsonFieldVisitor {
     fn record_str(&mut self, field: &Field, value: &str) {
-        if field.name() == "message" {
-            self.0.push_str(value);
-        } else {
-            if !self.0.is_empty() {
-                self.0.push(' ');
-            }
-            self.0.push_str(&format!("{}={}", field.name(), value));
-        }
+        self.0
+            .insert(field.name().to_string(), Value::String(value.to_string()));
+    }
+
+    fn record_bool(&mut self, field: &Field, value: bool) {
+        self.0.insert(field.name().to_string(), Value::Bool(value));
+    }
+
+    fn record_i64(&mut self, field: &Field, value: i64) {
+        self.0.insert(field.name().to_string(), Value::from(value));
+    }
+
+    fn record_u64(&mut self, field: &Field, value: u64) {
+        self.0.insert(field.name().to_string(), Value::from(value));
+    }
+
+    fn record_f64(&mut self, field: &Field, value: f64) {
+        self.0.insert(field.name().to_string(), Value::from(value));
     }
 
     fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-        if field.name() == "message" {
-            self.0.push_str(&format!("{:?}", value));
-        } else {
-            if !self.0.is_empty() {
-                self.0.push(' ');
-            }
-            self.0.push_str(&format!("{}={:?}", field.name(), value));
-        }
+        self.0.insert(
+            field.name().to_string(),
+            Value::String(format!("{value:?}")),
+        );
     }
 }
 
@@ -88,33 +98,123 @@ fn format_timestamp() -> String {
     )
 }
 
-/// A tracing `Layer` that routes events occurring within a `game_session` span
-/// to per-game log files in the `games/` subdirectory.
+/// A category of per-game log row. Each category is its own JSON-Lines file
+/// (`<games_dir>/<game_code>.<category>.jsonl`) so a reader can select one
+/// concern (`jq` per file) without filtering a merged stream.
 ///
-/// File handles are lazily opened on first write and cleaned up when the
-/// associated `game_session` span closes.
-pub struct GameFileLayer {
-    games_dir: PathBuf,
-    /// `None` value = open was attempted and failed (sentinel to avoid retry storms).
-    files: Mutex<HashMap<String, Option<BufWriter<File>>>>,
+/// - `"session"`: transport/session-lifecycle tracing events (connects,
+///   actions dispatched, game-over, errors) — whatever already flows through
+///   the `game_session` tracing span.
+/// - `"events"`: the engine's own [`GameLogEntry`] rows (already categorized
+///   internally via `GameLogEntry::category`), one per rules-level event.
+type Stream = &'static str;
+const STREAM_SESSION: Stream = "session";
+const STREAM_EVENTS: Stream = "events";
+
+/// `None` value = open was attempted and failed (sentinel to avoid retry storms).
+type FileMap = HashMap<(String, Stream), Option<BufWriter<File>>>;
+
+/// Shared per-game JSON-Lines file cache. Each `(game_code, stream)` pair maps
+/// to a lazily-opened, append-only file, flushed after every write so a crash
+/// never loses more than the write in flight. `games_dir: None` means logging
+/// is disabled (stdout-only run) and every write is a no-op.
+pub struct GameFileCache {
+    games_dir: Option<PathBuf>,
+    files: Mutex<FileMap>,
 }
 
-impl GameFileLayer {
-    pub fn new(games_dir: PathBuf) -> Self {
+impl GameFileCache {
+    fn new(games_dir: PathBuf) -> Self {
         Self {
-            games_dir,
+            games_dir: Some(games_dir),
             files: Mutex::new(HashMap::new()),
         }
     }
 
-    fn open_file(&self, game_code: &str) -> Option<BufWriter<File>> {
-        let path = self.games_dir.join(format!("{}.log", game_code));
+    fn disabled() -> Self {
+        Self {
+            games_dir: None,
+            files: Mutex::new(HashMap::new()),
+        }
+    }
+}
+
+impl Default for GameFileCache {
+    /// A disabled cache, so `ServerContext`'s `#[derive(Default)]` (used
+    /// throughout its test call sites) gets a real, inert no-op writer
+    /// rather than requiring every test to wire one up.
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+impl GameFileCache {
+    fn open_file(&self, game_code: &str, stream: Stream) -> Option<BufWriter<File>> {
+        let dir = self.games_dir.as_ref()?;
+        let path = dir.join(format!("{game_code}.{stream}.jsonl"));
         OpenOptions::new()
             .create(true)
             .append(true)
             .open(path)
             .ok()
             .map(BufWriter::new)
+    }
+
+    fn write_line(&self, game_code: &str, stream: Stream, line: &str) {
+        if self.games_dir.is_none() {
+            return;
+        }
+        let mut files = self.files.lock().unwrap_or_else(|e| e.into_inner());
+        let entry = files
+            .entry((game_code.to_string(), stream))
+            .or_insert_with(|| self.open_file(game_code, stream));
+        if let Some(writer) = entry {
+            let _ = writer.write_all(line.as_bytes());
+            let _ = writer.write_all(b"\n");
+            let _ = writer.flush();
+        }
+    }
+
+    /// Write one JSON-Lines row per [`GameLogEntry`], stamped with the
+    /// wall-clock moment of writing — the entries themselves carry only
+    /// game-time (`seq`/`turn`/`phase`), not wall-clock time.
+    pub fn write_game_log_entries(&self, game_code: &str, entries: &[GameLogEntry]) {
+        if self.games_dir.is_none() {
+            return;
+        }
+        for entry in entries {
+            let Ok(Value::Object(mut fields)) = serde_json::to_value(entry) else {
+                continue;
+            };
+            fields.insert("ts".to_string(), Value::String(format_timestamp()));
+            if let Ok(line) = serde_json::to_string(&Value::Object(fields)) {
+                self.write_line(game_code, STREAM_EVENTS, &line);
+            }
+        }
+    }
+
+    /// Flush and drop every stream's cached writer for a game whose
+    /// `game_session` span just closed. Reopened lazily if another
+    /// connection resumes writing to the same game.
+    fn close(&self, game_code: &str) {
+        let mut files = self.files.lock().unwrap_or_else(|e| e.into_inner());
+        for stream in [STREAM_SESSION, STREAM_EVENTS] {
+            if let Some(Some(mut writer)) = files.remove(&(game_code.to_string(), stream)) {
+                let _ = writer.flush();
+            }
+        }
+    }
+}
+
+/// A tracing `Layer` that routes events occurring within a `game_session` span
+/// to the `"session"` per-game JSON-Lines stream.
+pub struct GameFileLayer {
+    cache: Arc<GameFileCache>,
+}
+
+impl GameFileLayer {
+    fn new(cache: Arc<GameFileCache>) -> Self {
+        Self { cache }
     }
 }
 
@@ -152,21 +252,21 @@ where
             None => return, // Not inside a game_session span — skip.
         };
 
-        // Format the event as a human-readable log line.
-        let now = format_timestamp();
-        let level = event.metadata().level();
-        let mut formatter = FieldFormatter(String::new());
-        event.record(&mut formatter);
+        let mut visitor = JsonFieldVisitor(Map::new());
+        event.record(&mut visitor);
+        let mut fields = visitor.0;
+        fields.insert("ts".to_string(), Value::String(format_timestamp()));
+        fields.insert(
+            "level".to_string(),
+            Value::String(event.metadata().level().to_string()),
+        );
+        fields.insert(
+            "target".to_string(),
+            Value::String(event.metadata().target().to_string()),
+        );
 
-        let line = format!("{} {:>5} {}\n", now, level, formatter.0);
-
-        let mut files = self.files.lock().unwrap_or_else(|e| e.into_inner());
-        let entry = files
-            .entry(game_code.clone())
-            .or_insert_with(|| self.open_file(&game_code));
-        if let Some(writer) = entry {
-            let _ = writer.write_all(line.as_bytes());
-            let _ = writer.flush();
+        if let Ok(line) = serde_json::to_string(&Value::Object(fields)) {
+            self.cache.write_line(&game_code, STREAM_SESSION, &line);
         }
     }
 
@@ -175,11 +275,7 @@ where
             .span(&id)
             .and_then(|span| span.extensions().get::<GameCode>().map(|gc| gc.0.clone()));
         if let Some(game_code) = game_code {
-            let mut files = self.files.lock().unwrap_or_else(|e| e.into_inner());
-            // Flush and remove — reopened lazily if another connection writes to the same game.
-            if let Some(Some(mut writer)) = files.remove(&game_code) {
-                let _ = writer.flush();
-            }
+            self.cache.close(&game_code);
         }
     }
 }
@@ -187,13 +283,15 @@ where
 /// Initialize the tracing subscriber.
 ///
 /// When `log_dir` is `Some`, logs are written to files:
-/// - Main log: `<dir>/phase-server.log` (daily rolling)
-/// - Per-game logs: `<dir>/games/<GAME_CODE>.log` (human-readable)
+/// - Main log: `<dir>/phase-server.log` (daily rolling; JSON-formatted iff `json`)
+/// - Per-game logs: `<dir>/games/<GAME_CODE>.session.jsonl` and
+///   `<dir>/games/<GAME_CODE>.events.jsonl` — always JSON-Lines, independent
+///   of `json`. The per-game format is not optional: it exists so a game's
+///   logs are parseable, and gating that behind a flag would leave the
+///   default output exactly as unparseable as before this existed.
 ///
-/// When `log_dir` is `None`, logs are written to stdout (local dev mode).
-///
-/// The `json` flag controls the format of the main log. Per-game files are
-/// always human-readable regardless of this flag.
+/// When `log_dir` is `None`, logs are written to stdout (local dev mode) and
+/// the returned [`GameFileCache`] is disabled (every write a no-op).
 ///
 /// Returns a `WorkerGuard` that must be held alive for the program's lifetime
 /// to ensure buffered logs are flushed. Use a **named binding** (`let _guard = ...`),
@@ -201,7 +299,10 @@ where
 pub fn init_logging(
     log_dir: Option<&str>,
     json: bool,
-) -> Option<tracing_appender::non_blocking::WorkerGuard> {
+) -> (
+    Option<tracing_appender::non_blocking::WorkerGuard>,
+    Arc<GameFileCache>,
+) {
     use tracing_subscriber::layer::SubscriberExt;
     use tracing_subscriber::util::SubscriberInitExt;
 
@@ -220,7 +321,8 @@ pub fn init_logging(
             let file_appender = tracing_appender::rolling::daily(&dir, "phase-server.log");
             let (non_blocking, guard) = tracing_appender::non_blocking(file_appender);
 
-            let game_layer = GameFileLayer::new(games_dir);
+            let game_cache = Arc::new(GameFileCache::new(games_dir));
+            let game_layer = GameFileLayer::new(Arc::clone(&game_cache));
 
             if json {
                 tracing_subscriber::registry()
@@ -245,7 +347,7 @@ pub fn init_logging(
                     .init();
             }
 
-            Some(guard)
+            (Some(guard), game_cache)
         }
         None => {
             // Stdout mode — preserves current behavior for local dev.
@@ -258,7 +360,7 @@ pub fn init_logging(
             } else {
                 tracing_subscriber::fmt().with_env_filter(env_filter).init();
             }
-            None
+            (None, Arc::new(GameFileCache::disabled()))
         }
     }
 }
@@ -266,6 +368,8 @@ pub fn init_logging(
 #[cfg(test)]
 mod tests {
     use super::*;
+    use engine::types::log::{LogCategory, LogPresentation};
+    use engine::types::phase::Phase;
 
     #[test]
     fn format_timestamp_is_valid_iso8601() {
@@ -282,53 +386,116 @@ mod tests {
     }
 
     #[test]
-    fn game_file_layer_creates_log_files() {
+    fn game_file_cache_creates_session_stream_file() {
         let tmp = tempfile::tempdir().unwrap();
         let games_dir = tmp.path().join("games");
         fs::create_dir_all(&games_dir).unwrap();
 
-        let layer = GameFileLayer::new(games_dir.clone());
+        let cache = GameFileCache::new(games_dir.clone());
+        cache.write_line("TEST01", STREAM_SESSION, r#"{"message":"hello"}"#);
 
-        // Simulate opening a file for a game.
-        let writer = layer.open_file("TEST01");
-        assert!(writer.is_some());
-
-        let log_path = games_dir.join("TEST01.log");
+        let log_path = games_dir.join("TEST01.session.jsonl");
         assert!(log_path.exists());
     }
 
     #[test]
-    fn game_file_layer_appends_to_existing_files() {
+    fn game_file_cache_appends_to_existing_files() {
         let tmp = tempfile::tempdir().unwrap();
         let games_dir = tmp.path().join("games");
         fs::create_dir_all(&games_dir).unwrap();
 
-        let layer = GameFileLayer::new(games_dir.clone());
-        let log_path = games_dir.join("APPEND.log");
+        let cache = GameFileCache::new(games_dir.clone());
+        let log_path = games_dir.join("APPEND.session.jsonl");
 
-        // First open + write.
-        {
-            let mut writer = layer.open_file("APPEND").unwrap();
-            writer.write_all(b"line 1\n").unwrap();
-            writer.flush().unwrap();
-        }
-
-        // Second open + write (simulates re-open after on_close).
-        {
-            let mut writer = layer.open_file("APPEND").unwrap();
-            writer.write_all(b"line 2\n").unwrap();
-            writer.flush().unwrap();
-        }
+        cache.write_line("APPEND", STREAM_SESSION, r#"{"n":1}"#);
+        cache.write_line("APPEND", STREAM_SESSION, r#"{"n":2}"#);
 
         let content = fs::read_to_string(&log_path).unwrap();
-        assert_eq!(content, "line 1\nline 2\n");
+        assert_eq!(content, "{\"n\":1}\n{\"n\":2}\n");
     }
 
     #[test]
-    fn game_file_layer_sentinel_on_bad_path() {
-        // A GameFileLayer with a non-existent directory should return None.
-        let layer = GameFileLayer::new(PathBuf::from("/nonexistent/path/games"));
-        let writer = layer.open_file("FAIL01");
-        assert!(writer.is_none());
+    fn game_file_cache_disabled_writes_nothing() {
+        // A disabled cache (stdout mode, no log_dir) must not create files.
+        let cache = GameFileCache::disabled();
+        cache.write_line("FAIL01", STREAM_SESSION, r#"{"n":1}"#);
+        // No games_dir exists to assert against — the write path itself
+        // early-returns (`games_dir.is_none()`), which is what this pins.
+        assert!(cache.games_dir.is_none());
+    }
+
+    fn sample_entry(seq: u32, category: LogCategory) -> GameLogEntry {
+        GameLogEntry {
+            seq,
+            turn: 1,
+            phase: Phase::PreCombatMain,
+            category,
+            segments: Vec::new(),
+            presentation: LogPresentation::default(),
+        }
+    }
+
+    #[test]
+    fn write_game_log_entries_preserves_category_and_timestamps() {
+        let tmp = tempfile::tempdir().unwrap();
+        let games_dir = tmp.path().join("games");
+        fs::create_dir_all(&games_dir).unwrap();
+        let cache = GameFileCache::new(games_dir.clone());
+
+        cache.write_game_log_entries("CAT01", &[sample_entry(1, LogCategory::Combat)]);
+
+        let content = fs::read_to_string(games_dir.join("CAT01.events.jsonl")).unwrap();
+        let line: Value = serde_json::from_str(content.trim_end()).unwrap();
+        // Discriminating: a bug that dropped the category field, or one that
+        // always tagged entries `Debug`, fails this assertion against a
+        // deliberately non-Debug variant.
+        assert_eq!(line["category"], "Combat");
+        assert!(line["ts"].as_str().unwrap().ends_with('Z'));
+    }
+
+    #[test]
+    fn write_game_log_entries_writes_one_line_per_entry_not_overwritten() {
+        let tmp = tempfile::tempdir().unwrap();
+        let games_dir = tmp.path().join("games");
+        fs::create_dir_all(&games_dir).unwrap();
+        let cache = GameFileCache::new(games_dir.clone());
+
+        cache.write_game_log_entries(
+            "SEQ01",
+            &[
+                sample_entry(1, LogCategory::Turn),
+                sample_entry(2, LogCategory::Combat),
+            ],
+        );
+
+        let content = fs::read_to_string(games_dir.join("SEQ01.events.jsonl")).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(
+            lines.len(),
+            2,
+            "each entry must be its own line, not overwritten"
+        );
+        let first: Value = serde_json::from_str(lines[0]).unwrap();
+        let second: Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(first["seq"], 1);
+        assert_eq!(second["seq"], 2);
+    }
+
+    #[test]
+    fn closing_session_stream_does_not_lose_flushed_events_stream_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let games_dir = tmp.path().join("games");
+        fs::create_dir_all(&games_dir).unwrap();
+        let cache = GameFileCache::new(games_dir.clone());
+
+        cache.write_game_log_entries("BOTH01", &[sample_entry(1, LogCategory::Zone)]);
+        cache.write_line("BOTH01", STREAM_SESSION, r#"{"message":"joined"}"#);
+
+        // Simulate the game_session span closing — this must not touch
+        // content already flushed to the independent "events" stream.
+        cache.close("BOTH01");
+
+        let events_content = fs::read_to_string(games_dir.join("BOTH01.events.jsonl")).unwrap();
+        assert_eq!(events_content.lines().count(), 1);
     }
 }

--- a/crates/phase-server/src/logging.rs
+++ b/crates/phase-server/src/logging.rs
@@ -11,29 +11,45 @@ use tracing_subscriber::layer::Context;
 use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::Layer;
 
-/// Extension data stored on `game_session` spans to identify the game code.
-struct GameCode(String);
+/// Extension data stored on `game_session` spans: the game code (used to pick
+/// the output file) and, when present, the player id — both inherited by
+/// every event within the span unless the event itself restates the field
+/// (`on_event` lets an event-level value win; see `SpanFieldsVisitor`'s doc
+/// comment for why a row otherwise carries no seat attribution).
+struct GameSessionFields {
+    game: String,
+    player: Option<String>,
+}
 
-/// Visitor that extracts the `game` field from span attributes. The span is
-/// created as `game = %game_code` (`SocketIdentity::set_session`) — `%`
-/// records via `record_debug`, not `record_str` (tracing wraps the value in
-/// a `Debug` adapter whose impl delegates to `Display`), so `record_debug`
-/// must capture it too or every span silently carries no game code and this
-/// entire layer is a no-op. Verified with a driven probe: the real macro
-/// form (`%`) reaches `record_debug`; only a raw `&str` field reaches
-/// `record_str`.
-struct GameCodeVisitor(Option<String>);
+/// Visitor that extracts the `game` and `player` fields from span
+/// attributes. The span is created as `game = %game_code, player =
+/// ?player_id` (`SocketIdentity::set_session`) — both `%` and `?` record via
+/// `record_debug`, not `record_str` (tracing wraps the value in a `Debug`
+/// adapter — `%`'s impl delegates to `Display`, `?`'s uses the value's own
+/// `Debug` — so `record_debug` must capture both or every span silently
+/// carries no game code / player id and this entire layer is a no-op).
+/// Verified with a driven probe: the real macro form (`%`/`?`) reaches
+/// `record_debug`; only a raw `&str` field reaches `record_str`.
+#[derive(Default)]
+struct SpanFieldsVisitor {
+    game: Option<String>,
+    player: Option<String>,
+}
 
-impl Visit for GameCodeVisitor {
+impl Visit for SpanFieldsVisitor {
     fn record_str(&mut self, field: &Field, value: &str) {
-        if field.name() == "game" {
-            self.0 = Some(value.to_string());
+        match field.name() {
+            "game" => self.game = Some(value.to_string()),
+            "player" => self.player = Some(value.to_string()),
+            _ => {}
         }
     }
 
     fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
-        if field.name() == "game" {
-            self.0 = Some(format!("{value:?}"));
+        match field.name() {
+            "game" => self.game = Some(format!("{value:?}")),
+            "player" => self.player = Some(format!("{value:?}")),
+            _ => {}
         }
     }
 }
@@ -96,29 +112,32 @@ where
         if attrs.metadata().name() != "game_session" {
             return;
         }
-        let mut visitor = GameCodeVisitor(None);
+        let mut visitor = SpanFieldsVisitor::default();
         attrs.record(&mut visitor);
-        if let Some(game_code) = visitor.0 {
+        if let Some(game) = visitor.game {
             if let Some(span) = ctx.span(id) {
-                span.extensions_mut().insert(GameCode(game_code));
+                span.extensions_mut().insert(GameSessionFields {
+                    game,
+                    player: visitor.player,
+                });
             }
         }
     }
 
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
         // Walk up the span scope to find the nearest game_session span.
-        let game_code = ctx.event_span(event).and_then(|span| {
+        let span_fields = ctx.event_span(event).and_then(|span| {
             // scope() yields the span itself first, then walks up to parents.
             for s in span.scope() {
-                if let Some(gc) = s.extensions().get::<GameCode>() {
-                    return Some(gc.0.clone());
+                if let Some(gc) = s.extensions().get::<GameSessionFields>() {
+                    return Some((gc.game.clone(), gc.player.clone()));
                 }
             }
             None
         });
 
-        let game_code = match game_code {
-            Some(gc) => gc,
+        let (game_code, player) = match span_fields {
+            Some(v) => v,
             None => return, // Not inside a game_session span — skip.
         };
 
@@ -126,8 +145,19 @@ where
         event.record(&mut visitor);
         let mut fields = visitor.0;
         // `or_insert`, not `insert`: an event field that happens to be named
-        // `ts`/`level`/`target` must not be silently destroyed by this
-        // transport metadata — the event's own data wins on collision.
+        // `player`/`ts`/`level`/`target` must not be silently destroyed by
+        // this transport/span metadata — the event's own data wins on
+        // collision. `player` is seeded from the span (not the game code —
+        // that's already the output filename, so restating it per row is
+        // pure redundancy) because per-event `player = ?player_id` fields
+        // are the exception, not the rule: most rows would otherwise carry
+        // no seat attribution at all, which is the whole point of a
+        // per-game debug log.
+        if let Some(player) = player {
+            fields
+                .entry("player".to_string())
+                .or_insert_with(|| Value::String(player));
+        }
         fields
             .entry("ts".to_string())
             .or_insert_with(|| Value::String(format_timestamp()));
@@ -144,9 +174,11 @@ where
     }
 
     fn on_close(&self, id: Id, ctx: Context<'_, S>) {
-        let game_code = ctx
-            .span(&id)
-            .and_then(|span| span.extensions().get::<GameCode>().map(|gc| gc.0.clone()));
+        let game_code = ctx.span(&id).and_then(|span| {
+            span.extensions()
+                .get::<GameSessionFields>()
+                .map(|gc| gc.game.clone())
+        });
         if let Some(game_code) = game_code {
             self.cache.close(&game_code);
         }
@@ -253,7 +285,7 @@ mod tests {
     /// `game_session` span created as `game = %code` (the real macro form
     /// `SocketIdentity::set_session` uses) dispatches through `record_debug`,
     /// not `record_str`. Before that visitor arm existed, `on_new_span` never
-    /// captured a `GameCode` extension, so `on_event`'s span walk always hit
+    /// captured a `GameSessionFields` extension, so `on_event`'s span walk always hit
     /// `None => return` and no session-stream file was ever created — this
     /// test drives the real span/event macros through a real `GameFileLayer`
     /// and would fail exactly that way on the old code.
@@ -311,5 +343,61 @@ mod tests {
             row["level"], "custom-level-value",
             "a real event field named `level` must not be clobbered by the synthesized one"
         );
+    }
+
+    /// CodeRabbit finding on PR #8245: the span's `player` field (recorded
+    /// via `?`, same `record_debug` dispatch as `game`) never reached the
+    /// JSON row unless the event itself restated it — most rows carried no
+    /// seat attribution at all. This event omits `player` entirely, so the
+    /// row must inherit it from the span.
+    #[test]
+    fn player_field_inherited_from_span_when_event_omits_it() {
+        let dir = tempfile::tempdir().unwrap();
+        let games_dir = dir.path().join("games");
+        fs::create_dir_all(&games_dir).unwrap();
+
+        let cache = Arc::new(GameFileCache::new(games_dir.clone()));
+        let layer = GameFileLayer::new(Arc::clone(&cache));
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("game_session", game = %"CODE789", player = ?7u8);
+            let _enter = span.enter();
+            tracing::info!("test event without an explicit player field");
+        });
+
+        let path = games_dir.join("CODE789.session.jsonl");
+        let content = fs::read_to_string(&path).expect("session stream file must exist");
+        let row: Value =
+            serde_json::from_str(content.lines().next().unwrap()).expect("row must be valid JSON");
+        assert_eq!(
+            row["player"], "7",
+            "row must inherit the span's player field when the event doesn't restate it"
+        );
+    }
+
+    /// An event that DOES restate `player` must win over the span-inherited
+    /// value — span inheritance is a fallback, not an override.
+    #[test]
+    fn event_supplied_player_field_wins_over_span_inherited_value() {
+        let dir = tempfile::tempdir().unwrap();
+        let games_dir = dir.path().join("games");
+        fs::create_dir_all(&games_dir).unwrap();
+
+        let cache = Arc::new(GameFileCache::new(games_dir.clone()));
+        let layer = GameFileLayer::new(Arc::clone(&cache));
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("game_session", game = %"CODE790", player = ?7u8);
+            let _enter = span.enter();
+            tracing::info!(player = "explicit-override", "test event");
+        });
+
+        let path = games_dir.join("CODE790.session.jsonl");
+        let content = fs::read_to_string(&path).expect("session stream file must exist");
+        let row: Value =
+            serde_json::from_str(content.lines().next().unwrap()).expect("row must be valid JSON");
+        assert_eq!(row["player"], "explicit-override");
     }
 }

--- a/crates/phase-server/src/logging.rs
+++ b/crates/phase-server/src/logging.rs
@@ -14,7 +14,14 @@ use tracing_subscriber::Layer;
 /// Extension data stored on `game_session` spans to identify the game code.
 struct GameCode(String);
 
-/// Visitor that extracts the `game` field from span attributes.
+/// Visitor that extracts the `game` field from span attributes. The span is
+/// created as `game = %game_code` (`SocketIdentity::set_session`) — `%`
+/// records via `record_debug`, not `record_str` (tracing wraps the value in
+/// a `Debug` adapter whose impl delegates to `Display`), so `record_debug`
+/// must capture it too or every span silently carries no game code and this
+/// entire layer is a no-op. Verified with a driven probe: the real macro
+/// form (`%`) reaches `record_debug`; only a raw `&str` field reaches
+/// `record_str`.
 struct GameCodeVisitor(Option<String>);
 
 impl Visit for GameCodeVisitor {
@@ -24,7 +31,11 @@ impl Visit for GameCodeVisitor {
         }
     }
 
-    fn record_debug(&mut self, _field: &Field, _value: &dyn std::fmt::Debug) {}
+    fn record_debug(&mut self, field: &Field, value: &dyn std::fmt::Debug) {
+        if field.name() == "game" {
+            self.0 = Some(format!("{value:?}"));
+        }
+    }
 }
 
 /// Visitor that collects every tracing event field into a JSON object, keyed
@@ -114,15 +125,18 @@ where
         let mut visitor = JsonFieldVisitor(Map::new());
         event.record(&mut visitor);
         let mut fields = visitor.0;
-        fields.insert("ts".to_string(), Value::String(format_timestamp()));
-        fields.insert(
-            "level".to_string(),
-            Value::String(event.metadata().level().to_string()),
-        );
-        fields.insert(
-            "target".to_string(),
-            Value::String(event.metadata().target().to_string()),
-        );
+        // `or_insert`, not `insert`: an event field that happens to be named
+        // `ts`/`level`/`target` must not be silently destroyed by this
+        // transport metadata — the event's own data wins on collision.
+        fields
+            .entry("ts".to_string())
+            .or_insert_with(|| Value::String(format_timestamp()));
+        fields
+            .entry("level".to_string())
+            .or_insert_with(|| Value::String(event.metadata().level().to_string()));
+        fields
+            .entry("target".to_string())
+            .or_insert_with(|| Value::String(event.metadata().target().to_string()));
 
         if let Ok(line) = serde_json::to_string(&Value::Object(fields)) {
             self.cache.write_line(&game_code, Stream::Session, &line);
@@ -227,5 +241,75 @@ pub fn init_logging(
             }
             (None, Arc::new(GameFileCache::disabled()))
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tracing_subscriber::layer::SubscriberExt;
+
+    /// End-to-end pin for the HIGH bug the second review round caught: a
+    /// `game_session` span created as `game = %code` (the real macro form
+    /// `SocketIdentity::set_session` uses) dispatches through `record_debug`,
+    /// not `record_str`. Before that visitor arm existed, `on_new_span` never
+    /// captured a `GameCode` extension, so `on_event`'s span walk always hit
+    /// `None => return` and no session-stream file was ever created — this
+    /// test drives the real span/event macros through a real `GameFileLayer`
+    /// and would fail exactly that way on the old code.
+    #[test]
+    fn game_session_span_with_display_recorded_code_writes_session_stream_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let games_dir = dir.path().join("games");
+        fs::create_dir_all(&games_dir).unwrap();
+
+        let cache = Arc::new(GameFileCache::new(games_dir.clone()));
+        let layer = GameFileLayer::new(Arc::clone(&cache));
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("game_session", game = %"CODE123");
+            let _enter = span.enter();
+            tracing::info!(extra = "value", "test event");
+        });
+
+        let path = games_dir.join("CODE123.session.jsonl");
+        let content = fs::read_to_string(&path)
+            .expect("session stream file must exist — proves the %-recorded `game` field reached record_debug");
+        let row: Value =
+            serde_json::from_str(content.lines().next().unwrap()).expect("row must be valid JSON");
+        assert_eq!(row["extra"], "value");
+        assert_eq!(row["message"], "test event");
+        assert_eq!(row["level"], "INFO");
+        assert!(row["ts"].is_string());
+    }
+
+    /// Pins the LOW clobbering fix: an event field literally named `level`
+    /// must survive — `or_insert` only synthesizes the metadata key when the
+    /// event didn't already supply one.
+    #[test]
+    fn user_supplied_field_wins_over_synthesized_metadata_key() {
+        let dir = tempfile::tempdir().unwrap();
+        let games_dir = dir.path().join("games");
+        fs::create_dir_all(&games_dir).unwrap();
+
+        let cache = Arc::new(GameFileCache::new(games_dir.clone()));
+        let layer = GameFileLayer::new(Arc::clone(&cache));
+        let subscriber = tracing_subscriber::registry().with(layer);
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::info_span!("game_session", game = %"CODE456");
+            let _enter = span.enter();
+            tracing::info!(level = "custom-level-value", "test event");
+        });
+
+        let path = games_dir.join("CODE456.session.jsonl");
+        let content = fs::read_to_string(&path).expect("session stream file must exist");
+        let row: Value =
+            serde_json::from_str(content.lines().next().unwrap()).expect("row must be valid JSON");
+        assert_eq!(
+            row["level"], "custom-level-value",
+            "a real event field named `level` must not be clobbered by the synthesized one"
+        );
     }
 }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -703,9 +703,6 @@ struct ServerContext {
     /// has no way to turn a label back into a number.
     replica_ordinal: Option<u32>,
     metrics: Arc<metrics::ServerMetrics>,
-    /// Per-game JSON-Lines log sink (see `logging::GameFileCache`). Disabled
-    /// (no-op writes) unless `PHASE_LOG_DIR` is set.
-    game_log: Arc<logging::GameFileCache>,
 }
 
 // The lobby-only broker capacity cap (`MAX_LOBBY_ENTRIES`) now lives in
@@ -1724,7 +1721,6 @@ async fn serve() {
         },
         replica_ordinal: cli.replica_ordinal,
         metrics: Arc::new(metrics::ServerMetrics::default()),
-        game_log,
     };
     info!(
         max_connections = server_context.limits.max_connections,
@@ -1805,11 +1801,16 @@ async fn serve() {
     // ten years is effectively unbounded without risking overflow in `now + grace`.
     // It also stamps `HostingMode::SingleUser` on every session this manager
     // owns, which is what grants the desktop sidecar its debug capability.
-    let state: SharedState = Arc::new(Mutex::new(if cli.single_user {
+    let mut session_manager = if cli.single_user {
         SessionManager::single_user(Duration::from_secs(10 * 365 * 24 * 60 * 60))
     } else {
         SessionManager::new()
-    }));
+    };
+    // Every session this manager creates or restores gets this cache
+    // (`SessionManager`/`GameSession` re-stamp it, same lifecycle as
+    // `hosting`) — see `server_core::game_log`.
+    session_manager.game_log = Arc::clone(&game_log);
+    let state: SharedState = Arc::new(Mutex::new(session_manager));
     let draft_sessions: SharedDraftState = Arc::new(Mutex::new(DraftSessionManager::new()));
     let draft_pools_path = data_path.join("draft-pools.json");
     let draft_pools: SharedDraftPools = match draft_pools::DraftPools::from_path(&draft_pools_path)
@@ -4933,7 +4934,6 @@ async fn handle_full_game_submission(
     // take it by shared reference; only `dispatch_broker` and
     // `handle_client_message` need `&mut`. Do not "fix" this to `&mut`.
     identity: &SocketIdentity,
-    game_log: &Arc<logging::GameFileCache>,
 ) {
     let kind = submission.kind();
     let is_zero_count_debug_create = submission.is_zero_count_debug_create();
@@ -5110,17 +5110,6 @@ async fn handle_full_game_submission(
                     let _ = socket.send(Message::text(json)).await;
                 }
                 return;
-            }
-
-            // Per-game JSON debug log (issue #7978): one row per typed
-            // `GameLogEntry` the engine produced for this action, plus any
-            // AI follow-up actions run under the same lock. No-op unless
-            // `PHASE_LOG_DIR` is set.
-            game_log.write_game_log_entries(&game_code, &log_entries);
-            for (_, ai_result) in &ai_results {
-                // `.3` is `log_entries` — `session::ActionResult` is an
-                // unnamed tuple alias, not a struct.
-                game_log.write_game_log_entries(&game_code, &ai_result.3);
             }
 
             let terminal_deliveries = match terminal {
@@ -6038,7 +6027,6 @@ async fn handle_client_message(
                 game_db,
                 game_spectators,
                 identity,
-                &context.game_log,
             )
             .await;
         }
@@ -6055,7 +6043,6 @@ async fn handle_client_message(
                 game_db,
                 game_spectators,
                 identity,
-                &context.game_log,
             )
             .await;
         }

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -703,6 +703,9 @@ struct ServerContext {
     /// has no way to turn a label back into a number.
     replica_ordinal: Option<u32>,
     metrics: Arc<metrics::ServerMetrics>,
+    /// Per-game JSON-Lines log sink (see `logging::GameFileCache`). Disabled
+    /// (no-op writes) unless `PHASE_LOG_DIR` is set.
+    game_log: Arc<logging::GameFileCache>,
 }
 
 // The lobby-only broker capacity cap (`MAX_LOBBY_ENTRIES`) now lives in
@@ -1707,7 +1710,7 @@ fn main() {
 async fn serve() {
     let cli = Cli::parse();
 
-    let _log_guard = logging::init_logging(cli.log_dir.as_deref(), cli.log_json);
+    let (_log_guard, game_log) = logging::init_logging(cli.log_dir.as_deref(), cli.log_json);
     let mode: Mode = if cli.lobby_only {
         ServerMode::LobbyOnly
     } else {
@@ -1721,6 +1724,7 @@ async fn serve() {
         },
         replica_ordinal: cli.replica_ordinal,
         metrics: Arc::new(metrics::ServerMetrics::default()),
+        game_log,
     };
     info!(
         max_connections = server_context.limits.max_connections,
@@ -4929,6 +4933,7 @@ async fn handle_full_game_submission(
     // take it by shared reference; only `dispatch_broker` and
     // `handle_client_message` need `&mut`. Do not "fix" this to `&mut`.
     identity: &SocketIdentity,
+    game_log: &Arc<logging::GameFileCache>,
 ) {
     let kind = submission.kind();
     let is_zero_count_debug_create = submission.is_zero_count_debug_create();
@@ -5105,6 +5110,17 @@ async fn handle_full_game_submission(
                     let _ = socket.send(Message::text(json)).await;
                 }
                 return;
+            }
+
+            // Per-game JSON debug log (issue #7978): one row per typed
+            // `GameLogEntry` the engine produced for this action, plus any
+            // AI follow-up actions run under the same lock. No-op unless
+            // `PHASE_LOG_DIR` is set.
+            game_log.write_game_log_entries(&game_code, &log_entries);
+            for (_, ai_result) in &ai_results {
+                // `.3` is `log_entries` — `session::ActionResult` is an
+                // unnamed tuple alias, not a struct.
+                game_log.write_game_log_entries(&game_code, &ai_result.3);
             }
 
             let terminal_deliveries = match terminal {
@@ -6022,6 +6038,7 @@ async fn handle_client_message(
                 game_db,
                 game_spectators,
                 identity,
+                &context.game_log,
             )
             .await;
         }
@@ -6038,6 +6055,7 @@ async fn handle_client_message(
                 game_db,
                 game_spectators,
                 identity,
+                &context.game_log,
             )
             .await;
         }

--- a/crates/server-core/src/game_log.rs
+++ b/crates/server-core/src/game_log.rs
@@ -1,0 +1,338 @@
+//! Per-game JSON-Lines debug log sink (GitHub issue #7978).
+//!
+//! Shared by `server-core` (writes the engine's own [`GameLogEntry`] rows at
+//! the point each action result is minted — `SessionManager::handle_action`,
+//! `SessionManager::handle_interaction_with_rejection`,
+//! `GameSession::run_ai_action_batch` — so every path that produces a
+//! transition is covered by construction, not by remembering to call a hook
+//! at each of `phase-server`'s call sites) and `phase-server` (writes
+//! transport/session-lifecycle tracing events to a separate stream).
+//! Configured via `PHASE_LOG_DIR`; [`GameFileCache::default`] is a disabled
+//! no-op sink.
+
+use std::collections::HashMap;
+use std::fs::{File, OpenOptions};
+use std::io::{BufWriter, Write};
+use std::path::PathBuf;
+use std::sync::Mutex;
+use std::time::SystemTime;
+
+use engine::types::log::GameLogEntry;
+use serde_json::Value;
+
+/// Which per-game JSON-Lines file a row belongs to.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Stream {
+    /// Transport/session-lifecycle tracing events (connects, actions
+    /// dispatched, game-over, errors) — `phase-server`'s `game_session` span.
+    Session,
+    /// The engine's own [`GameLogEntry`] rows, one per rules-level event.
+    Events,
+}
+
+impl Stream {
+    fn as_str(self) -> &'static str {
+        match self {
+            Stream::Session => "session",
+            Stream::Events => "events",
+        }
+    }
+}
+
+/// Format a UTC timestamp as `YYYY-MM-DDTHH:MM:SS.mmmZ` without external crates.
+pub fn format_timestamp() -> String {
+    let duration = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap_or_default();
+    let secs = duration.as_secs();
+    let millis = duration.subsec_millis();
+
+    // Convert epoch seconds to date/time components.
+    let days = secs / 86400;
+    let time_of_day = secs % 86400;
+    let hours = time_of_day / 3600;
+    let minutes = (time_of_day % 3600) / 60;
+    let seconds = time_of_day % 60;
+
+    // Civil date from day count (algorithm from Howard Hinnant).
+    let z = days as i64 + 719468;
+    let era = z.div_euclid(146097);
+    let doe = z.rem_euclid(146097) as u64;
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146096) / 365;
+    let y = (yoe as i64) + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let d = doy - (153 * mp + 2) / 5 + 1;
+    let m = if mp < 10 { mp + 3 } else { mp - 9 };
+    let y = if m <= 2 { y + 1 } else { y };
+
+    format!(
+        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}.{:03}Z",
+        y, m, d, hours, minutes, seconds, millis
+    )
+}
+
+type FileMap = HashMap<(String, Stream), Option<BufWriter<File>>>;
+
+/// Shared per-game JSON-Lines file cache. Each `(game_code, stream)` pair
+/// maps to a lazily-opened, append-only file, flushed after every write so a
+/// crash never loses more than the write in flight. `games_dir: None` means
+/// logging is disabled (stdout-only run) and every write is a no-op.
+pub struct GameFileCache {
+    games_dir: Option<PathBuf>,
+    /// `None` value = open was attempted and failed (sentinel to avoid retry storms).
+    files: Mutex<FileMap>,
+}
+
+impl GameFileCache {
+    pub fn new(games_dir: PathBuf) -> Self {
+        Self {
+            games_dir: Some(games_dir),
+            files: Mutex::new(HashMap::new()),
+        }
+    }
+
+    pub fn disabled() -> Self {
+        Self {
+            games_dir: None,
+            files: Mutex::new(HashMap::new()),
+        }
+    }
+
+    fn open_file(&self, game_code: &str, stream: Stream) -> Option<BufWriter<File>> {
+        let dir = self.games_dir.as_ref()?;
+        let path = dir.join(format!("{game_code}.{}.jsonl", stream.as_str()));
+        OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+            .ok()
+            .map(BufWriter::new)
+    }
+
+    pub fn write_line(&self, game_code: &str, stream: Stream, line: &str) {
+        if self.games_dir.is_none() {
+            return;
+        }
+        let mut files = self.files.lock().unwrap_or_else(|e| e.into_inner());
+        let entry = files
+            .entry((game_code.to_string(), stream))
+            .or_insert_with(|| self.open_file(game_code, stream));
+        if let Some(writer) = entry {
+            let _ = writer.write_all(line.as_bytes());
+            let _ = writer.write_all(b"\n");
+            let _ = writer.flush();
+        }
+    }
+
+    /// Write one JSON-Lines row per [`GameLogEntry`], stamped with the
+    /// wall-clock moment of writing — the entries themselves carry only
+    /// game-time (`turn`/`phase`); `seq` is left at whatever the engine set
+    /// (currently always `0` here — see `GameLogEntry`'s doc comment, it is
+    /// assigned downstream by a UI consumer, not by this write path).
+    /// Ordering for this stream comes from write order (callers write while
+    /// holding the session lock, so it's the actual game order), not `seq`.
+    pub fn write_game_log_entries(&self, game_code: &str, entries: &[GameLogEntry]) {
+        if self.games_dir.is_none() {
+            return;
+        }
+        for entry in entries {
+            let Ok(Value::Object(mut fields)) = serde_json::to_value(entry) else {
+                continue;
+            };
+            fields.insert("ts".to_string(), Value::String(format_timestamp()));
+            if let Ok(line) = serde_json::to_string(&Value::Object(fields)) {
+                self.write_line(game_code, Stream::Events, &line);
+            }
+        }
+    }
+
+    /// Flush and drop every stream's cached writer for a game. Reopened
+    /// lazily (in append mode) if another connection resumes writing to the
+    /// same game.
+    pub fn close(&self, game_code: &str) {
+        let mut files = self.files.lock().unwrap_or_else(|e| e.into_inner());
+        for stream in [Stream::Session, Stream::Events] {
+            if let Some(Some(mut writer)) = files.remove(&(game_code.to_string(), stream)) {
+                let _ = writer.flush();
+            }
+        }
+    }
+}
+
+impl Default for GameFileCache {
+    /// A disabled cache, so callers that default-construct their owner
+    /// (`SessionManager`, `ServerContext`, ...) get a real, inert no-op
+    /// writer rather than requiring every test to wire one up.
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use engine::types::log::{LogCategory, LogPresentation};
+    use engine::types::phase::Phase;
+    use std::fs;
+
+    #[test]
+    fn format_timestamp_is_valid_iso8601() {
+        let ts = format_timestamp();
+        // Expect: YYYY-MM-DDTHH:MM:SS.mmmZ
+        assert_eq!(ts.len(), 24);
+        assert!(ts.ends_with('Z'));
+        assert_eq!(&ts[4..5], "-");
+        assert_eq!(&ts[7..8], "-");
+        assert_eq!(&ts[10..11], "T");
+        assert_eq!(&ts[13..14], ":");
+        assert_eq!(&ts[16..17], ":");
+        assert_eq!(&ts[19..20], ".");
+    }
+
+    #[test]
+    fn game_file_cache_creates_session_stream_file() {
+        let tmp = tempfile::tempdir().unwrap();
+        let games_dir = tmp.path().join("games");
+        fs::create_dir_all(&games_dir).unwrap();
+
+        let cache = GameFileCache::new(games_dir.clone());
+        cache.write_line("TEST01", Stream::Session, r#"{"message":"hello"}"#);
+
+        let log_path = games_dir.join("TEST01.session.jsonl");
+        assert!(log_path.exists());
+    }
+
+    #[test]
+    fn game_file_cache_appends_across_reopen_after_close() {
+        // Not just "two writes in a row" (which never exercises `open_file`
+        // twice, since the cached writer stays open) — this closes the
+        // session between writes, forcing a real reopen in append mode.
+        // Flipping `OpenOptions::append(true)` to `truncate(true)` at the
+        // reopen would make this fail.
+        let tmp = tempfile::tempdir().unwrap();
+        let games_dir = tmp.path().join("games");
+        fs::create_dir_all(&games_dir).unwrap();
+        let cache = GameFileCache::new(games_dir.clone());
+        let log_path = games_dir.join("APPEND.session.jsonl");
+
+        cache.write_line("APPEND", Stream::Session, r#"{"n":1}"#);
+        cache.close("APPEND");
+        cache.write_line("APPEND", Stream::Session, r#"{"n":2}"#);
+
+        let content = fs::read_to_string(&log_path).unwrap();
+        assert_eq!(content, "{\"n\":1}\n{\"n\":2}\n");
+    }
+
+    #[test]
+    fn open_file_sentinel_on_bad_path_does_not_panic_or_retry_loop() {
+        // A non-existent, uncreatable parent directory: `open_file` must
+        // return `None` (not panic), and `write_line` must not panic either.
+        let cache = GameFileCache::new(PathBuf::from("/nonexistent/path/games"));
+        assert!(cache.open_file("FAIL01", Stream::Session).is_none());
+        cache.write_line("FAIL01", Stream::Session, r#"{"n":1}"#);
+        // The failed open is cached as a `None` sentinel, not retried.
+        // `matches!`, not `assert_eq!`: `BufWriter<File>` has no `PartialEq`.
+        let files = cache.files.lock().unwrap();
+        assert!(matches!(
+            files.get(&("FAIL01".to_string(), Stream::Session)),
+            Some(None)
+        ));
+    }
+
+    #[test]
+    fn game_file_cache_disabled_write_touches_no_state() {
+        // A disabled cache (stdout mode, no log_dir) must not create files
+        // AND must not populate its internal map — asserting only
+        // `games_dir.is_none()` (a constructor property) would stay green
+        // even if the `games_dir.is_none()` early-return in `write_line`
+        // were deleted, since `open_file` also short-circuits to `None` and
+        // gets cached as a sentinel either way. This asserts the map itself
+        // stays empty, which only the early-return guarantees.
+        let cache = GameFileCache::disabled();
+        cache.write_line("FAIL01", Stream::Session, r#"{"n":1}"#);
+        assert!(cache.files.lock().unwrap().is_empty());
+    }
+
+    fn sample_entry(category: LogCategory) -> GameLogEntry {
+        GameLogEntry {
+            // The engine always emits `seq: 0` here (assigned downstream by
+            // a UI consumer, not this layer) — using a non-zero value would
+            // test a fixture production never produces.
+            seq: 0,
+            turn: 1,
+            phase: Phase::PreCombatMain,
+            category,
+            segments: Vec::new(),
+            presentation: LogPresentation::default(),
+        }
+    }
+
+    #[test]
+    fn write_game_log_entries_preserves_category_and_timestamps() {
+        let tmp = tempfile::tempdir().unwrap();
+        let games_dir = tmp.path().join("games");
+        fs::create_dir_all(&games_dir).unwrap();
+        let cache = GameFileCache::new(games_dir.clone());
+
+        cache.write_game_log_entries("CAT01", &[sample_entry(LogCategory::Combat)]);
+
+        let content = fs::read_to_string(games_dir.join("CAT01.events.jsonl")).unwrap();
+        let line: Value = serde_json::from_str(content.trim_end()).unwrap();
+        // Discriminating: a bug that dropped the category field, or one that
+        // always tagged entries `Debug`, fails this assertion against a
+        // deliberately non-Debug variant.
+        assert_eq!(line["category"], "Combat");
+        assert!(line["ts"].as_str().unwrap().ends_with('Z'));
+    }
+
+    #[test]
+    fn write_game_log_entries_writes_one_line_per_entry_in_order_not_overwritten() {
+        let tmp = tempfile::tempdir().unwrap();
+        let games_dir = tmp.path().join("games");
+        fs::create_dir_all(&games_dir).unwrap();
+        let cache = GameFileCache::new(games_dir.clone());
+
+        cache.write_game_log_entries(
+            "SEQ01",
+            &[
+                sample_entry(LogCategory::Turn),
+                sample_entry(LogCategory::Combat),
+            ],
+        );
+
+        let content = fs::read_to_string(games_dir.join("SEQ01.events.jsonl")).unwrap();
+        let lines: Vec<&str> = content.lines().collect();
+        assert_eq!(
+            lines.len(),
+            2,
+            "each entry must be its own line, not overwritten"
+        );
+        // `seq` is always 0 in production (see `sample_entry`) — order is
+        // established by write/line position, not by `.seq`.
+        let first: Value = serde_json::from_str(lines[0]).unwrap();
+        let second: Value = serde_json::from_str(lines[1]).unwrap();
+        assert_eq!(first["category"], "Turn");
+        assert_eq!(second["category"], "Combat");
+    }
+
+    #[test]
+    fn closing_session_stream_does_not_lose_flushed_events_stream_content() {
+        let tmp = tempfile::tempdir().unwrap();
+        let games_dir = tmp.path().join("games");
+        fs::create_dir_all(&games_dir).unwrap();
+        let cache = GameFileCache::new(games_dir.clone());
+
+        cache.write_game_log_entries("BOTH01", &[sample_entry(LogCategory::Zone)]);
+        cache.write_line("BOTH01", Stream::Session, r#"{"message":"joined"}"#);
+
+        // Simulate the game_session span closing — this must not touch
+        // content already flushed to the independent "events" stream, and a
+        // write after close (a reopen) must still land in the same file.
+        cache.close("BOTH01");
+        cache.write_game_log_entries("BOTH01", &[sample_entry(LogCategory::Life)]);
+
+        let events_content = fs::read_to_string(games_dir.join("BOTH01.events.jsonl")).unwrap();
+        assert_eq!(events_content.lines().count(), 2);
+    }
+}

--- a/crates/server-core/src/game_log.rs
+++ b/crates/server-core/src/game_log.rs
@@ -163,6 +163,16 @@ impl GameFileCache {
             }
         }
     }
+
+    /// Number of cached writer entries (open or sentinel) across all games.
+    /// Test-only introspection for proving `close`/`SessionManager::remove_game`
+    /// actually evict the cache, not just that the written file's content is
+    /// correct — `files` is private, so `server_core::session`'s tests need
+    /// this to observe eviction from outside `game_log`.
+    #[cfg(test)]
+    pub(crate) fn cached_entry_count(&self) -> usize {
+        self.files.lock().unwrap_or_else(|e| e.into_inner()).len()
+    }
 }
 
 impl Default for GameFileCache {

--- a/crates/server-core/src/game_log.rs
+++ b/crates/server-core/src/game_log.rs
@@ -140,7 +140,12 @@ impl GameFileCache {
             let Ok(Value::Object(mut fields)) = serde_json::to_value(entry) else {
                 continue;
             };
-            fields.insert("ts".to_string(), Value::String(format_timestamp()));
+            // `or_insert`, not `insert`: `GameLogEntry` has no `ts` field
+            // today, but this keeps the same non-clobbering contract as the
+            // `phase-server` session-stream writer if that ever changes.
+            fields
+                .entry("ts".to_string())
+                .or_insert_with(|| Value::String(format_timestamp()));
             if let Ok(line) = serde_json::to_string(&Value::Object(fields)) {
                 self.write_line(game_code, Stream::Events, &line);
             }

--- a/crates/server-core/src/lib.rs
+++ b/crates/server-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod draft_wire_guard;
 pub mod emote_guard;
 pub mod filter;
 pub mod game_action_payload_guard;
+pub mod game_log;
 pub mod game_reconnect_guard;
 pub mod game_state_snapshot_wire_guard;
 #[cfg(test)]
@@ -41,6 +42,7 @@ pub use draft_wire_guard::{
 };
 pub use emote_guard::guard_emote;
 pub use filter::{filter_events_for_player, filter_state_for_player};
+pub use game_log::{GameFileCache, Stream as GameLogStream};
 pub use game_reconnect_guard::guard_game_reconnect;
 pub use game_state_snapshot_wire_guard::{
     guard_game_state_for_broadcast, guard_state_snapshot_broadcast, StateSnapshotParts,

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -42,6 +42,7 @@ use serde::{Deserialize, Serialize};
 use tracing::{debug, info, warn};
 
 use crate::filter::filter_state_for_player;
+use crate::game_log::GameFileCache;
 use crate::persist::{PersistedLobbyMeta, PersistedSession};
 use crate::protocol::PlayerSlotInfo;
 use crate::reconnect::ReconnectManager;
@@ -337,6 +338,11 @@ pub enum HostingMode {
 
 pub struct GameSession {
     pub game_code: String,
+    /// Per-game JSON debug log sink (issue #7978), copied from the owning
+    /// `SessionManager` at creation and re-stamped, never deserialized, at
+    /// `SessionManager::restore_session` — same lifecycle as `hosting`
+    /// below, for the same reason: a runtime handle, not session state.
+    pub game_log: Arc<GameFileCache>,
     /// Server-issued durable identity for a Full session lifetime. This is
     /// stamped by phase-server after persistence binds the newly-created
     /// session; it is not trusted from the serialized game blob.
@@ -1070,6 +1076,15 @@ impl GameSession {
                 // point; a rule that promoted entries out of
                 // `takeback_history` could not, because `run_ai` pushes none.
                 self.observe_transition(&r.events, &r.state);
+                // Per-game JSON debug log (issue #7978): this is the single
+                // AI-transition mint point every caller of `run_ai` funnels
+                // through (takeback approve/reject, reconnect, game start,
+                // Play-vs-AI start, and the AI follow-up after a human
+                // action) — one hook here covers all of them, matching the
+                // human-action hooks in `handle_action`/
+                // `handle_interaction_with_rejection`.
+                self.game_log
+                    .write_game_log_entries(&self.game_code, &r.log_entries);
                 (
                     revision,
                     (
@@ -1228,6 +1243,12 @@ impl GameSession {
             display_names: ps.display_names,
             reservations: HashMap::new(),
             timer_seconds: ps.timer_seconds,
+            // Placeholder, same rationale as `hosting` below: a runtime
+            // handle, not persisted state, re-stamped by
+            // `SessionManager::restore_session`. `Arc::default()` is a
+            // disabled (no-op) sink, so nothing is under- or over-logged
+            // between here and that stamp.
+            game_log: Arc::default(),
             // Least-privilege placeholder. `hosting` is a property of THIS
             // process, not of the persisted blob, and is re-stamped by
             // `SessionManager::restore_session`. Between here and that stamp
@@ -1295,6 +1316,11 @@ pub struct SessionManager {
     pub hosting: HostingMode,
     /// Maps player_token -> game_code for token-based lookups.
     token_to_game: HashMap<String, String>,
+    /// Per-game JSON debug log sink (issue #7978), stamped onto every session
+    /// this manager creates or restores — same lifecycle as `hosting`.
+    /// Disabled (no-op writes) unless the transport wires a real one in
+    /// (`phase-server` does this once at startup, from `PHASE_LOG_DIR`).
+    pub game_log: Arc<GameFileCache>,
 }
 
 impl SessionManager {
@@ -1305,6 +1331,7 @@ impl SessionManager {
             reconnect: ReconnectManager::default(),
             hosting: HostingMode::Shared,
             token_to_game: HashMap::new(),
+            game_log: Arc::default(),
         }
     }
 
@@ -1317,6 +1344,7 @@ impl SessionManager {
             reconnect: ReconnectManager::new(grace_period),
             hosting: HostingMode::SingleUser,
             token_to_game: HashMap::new(),
+            game_log: Arc::default(),
         }
     }
 
@@ -1411,6 +1439,7 @@ impl SessionManager {
             reservations: HashMap::new(),
             timer_seconds,
             hosting: self.hosting,
+            game_log: Arc::clone(&self.game_log),
             player_count,
             ai_seats: HashSet::new(),
             ai_configs: HashMap::new(),
@@ -1866,6 +1895,16 @@ impl SessionManager {
         let post_state = session.state.clone();
         session.observe_transition(&result.events, &post_state);
 
+        // Per-game JSON debug log (issue #7978): written here, at the point
+        // the engine's `GameLogEntry` rows are minted, not by each transport
+        // call site — so every path that reaches this function (and
+        // `handle_interaction_with_rejection`, and AI transitions via
+        // `run_ai_action_batch`) is covered without remembering a hook per
+        // caller.
+        session
+            .game_log
+            .write_game_log_entries(&session.game_code, &result.log_entries);
+
         Ok((
             post_state,
             result.events,
@@ -1978,6 +2017,12 @@ impl SessionManager {
         // Same capture, same placement rationale, as `handle_action`.
         let post_state = session.state.clone();
         session.observe_transition(&applied.result.events, &post_state);
+
+        // Per-game JSON debug log (issue #7978) — see `handle_action`'s
+        // sibling comment above; this is the interaction-path mint point.
+        session
+            .game_log
+            .write_game_log_entries(&session.game_code, &applied.result.log_entries);
 
         Ok((
             post_state,
@@ -2153,6 +2198,7 @@ impl SessionManager {
         // sole entry for a restored session into a manager (`sessions.insert`
         // has exactly two call sites: create, and this one).
         session.hosting = self.hosting;
+        session.game_log = Arc::clone(&self.game_log);
         // The stamp above only stops the blob from driving a future
         // *derivation*. `debug_mode` / `debug_permitted` are serialized state
         // and arrive already set, so a sidecar's capability would otherwise
@@ -5587,6 +5633,7 @@ mod tests {
 
         let mut session = GameSession {
             game_code: "TEST01".to_string(),
+            game_log: Arc::default(),
             full_runtime: None,
             state_revision: 0,
             ai_driver_fault: None,

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -2185,11 +2185,20 @@ impl SessionManager {
 
     /// Remove a game session entirely, cleaning up the token-to-game index.
     /// Returns the removed session if it existed.
+    ///
+    /// Also releases this game's cached per-game log writers (issue #7978
+    /// follow-up): every removal path — normal game-over cleanup, restored-
+    /// terminal cleanup, and reconnect-grace expiry — funnels through here,
+    /// and some of those (restored-terminal, expiry) run before any
+    /// `game_session` tracing span exists, so `GameFileLayer::on_close`
+    /// never fires for them. Closing here, once, covers all of them instead
+    /// of requiring every removal call site to remember it.
     pub fn remove_game(&mut self, game_code: &str) -> Option<GameSession> {
         let session = self.sessions.remove(game_code)?;
         for token in &session.player_tokens {
             self.unindex_token(token);
         }
+        self.game_log.close(game_code);
         Some(session)
     }
 
@@ -2998,6 +3007,52 @@ mod tests {
         assert!(
             !content.trim().is_empty(),
             "events stream file exists but is empty"
+        );
+    }
+
+    /// Maintainer review finding on PR #8245: `GameFileCache` cached a
+    /// writer for every game it ever logged and never released it —
+    /// `GameFileCache::close` existed, but nothing called it from
+    /// `SessionManager::remove_game`, so every removal path (game-over,
+    /// restored-terminal cleanup, reconnect-grace expiry) leaked the cached
+    /// `BufWriter`/file handle for the process lifetime. This setup has no
+    /// tracing span at all (server-core doesn't do tracing) — deliberately
+    /// exercising the "no active `game_session` span" removal shape the
+    /// finding named, where `GameFileLayer::on_close` (the OTHER eviction
+    /// path, span-teardown-triggered) never fires.
+    #[test]
+    fn remove_game_evicts_cached_log_writers() {
+        let dir = tempfile::tempdir().unwrap();
+        let games_dir = dir.path().join("games");
+        std::fs::create_dir_all(&games_dir).unwrap();
+
+        let mut mgr = SessionManager::new();
+        mgr.game_log = std::sync::Arc::new(GameFileCache::new(games_dir));
+        let db = engine::database::CardDatabase::default();
+        let (code, _token) = mgr
+            .create_game_with_ai(
+                make_deck(),
+                "Host".to_string(),
+                None,
+                MatchConfig::default(),
+                vec![(1, AiDifficulty::Easy, make_deck())],
+                Vec::new(),
+                None,
+                &db,
+            )
+            .expect("supported format config");
+
+        assert!(
+            mgr.game_log.cached_entry_count() > 0,
+            "start_game's write hook should have opened and cached a writer"
+        );
+
+        mgr.remove_game(&code);
+
+        assert_eq!(
+            mgr.game_log.cached_entry_count(),
+            0,
+            "remove_game must evict this game's cached writers, not just the session"
         );
     }
 

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -2965,6 +2965,42 @@ mod tests {
         assert!(row.get("ts").is_some(), "row must carry a ts field: {row}");
     }
 
+    /// Proves `GameSession::start_game`'s write hook is reachable, not just
+    /// present in source — `create_game_n_players`/`join_game` never call
+    /// `start_game` (see `handle_action_hook_writes_real_events_stream_file`'s
+    /// doc comment), so `create_game_with_ai` is the only `SessionManager`
+    /// path that reaches it, mirroring `takeback_auto_approves_for_sole_human_seat`'s setup.
+    #[test]
+    fn start_game_hook_writes_real_events_stream_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let games_dir = dir.path().join("games");
+        std::fs::create_dir_all(&games_dir).unwrap();
+
+        let mut mgr = SessionManager::new();
+        mgr.game_log = std::sync::Arc::new(GameFileCache::new(games_dir.clone()));
+        let db = engine::database::CardDatabase::default();
+        let (code, _token) = mgr
+            .create_game_with_ai(
+                make_deck(),
+                "Host".to_string(),
+                None,
+                MatchConfig::default(),
+                vec![(1, AiDifficulty::Easy, make_deck())],
+                Vec::new(),
+                None,
+                &db,
+            )
+            .expect("supported format config");
+
+        let events_path = games_dir.join(format!("{code}.events.jsonl"));
+        let content = std::fs::read_to_string(&events_path)
+            .expect("start_game's write hook must have written the events stream file");
+        assert!(
+            !content.trim().is_empty(),
+            "events stream file exists but is empty"
+        );
+    }
+
     /// `SetPhaseStops` is keyed to the authenticated player and delegated to the
     /// engine write-handler (keyed by `actor`), so a non-priority player's stops
     /// land on their OWN entry — not the priority holder's. Mirrors the

--- a/crates/server-core/src/session.rs
+++ b/crates/server-core/src/session.rs
@@ -968,6 +968,10 @@ impl GameSession {
         // can surface them; the broadcaster clears `start_events` afterward so
         // joiners/reconnects do not re-see the dice.
         let result = start_game(&mut self.state);
+        // Per-game JSON debug log (issue #7978): "Game started"/"Turn 1" rows
+        // — otherwise every game's events.jsonl would start mid-game.
+        self.game_log
+            .write_game_log_entries(&self.game_code, &result.log_entries);
         // Deliberately NOT a turn-rewind capture site, unlike the four
         // transition handlers. These events never reach a transition handler,
         // and turn 1's opening state sits adjacent to the mulligan flow —
@@ -1296,6 +1300,11 @@ impl GameSession {
         // still needs to observe every one of them.
         let post_state = self.state.clone();
         self.observe_transition(&resumed.action_result().events, &post_state);
+        // Per-game JSON debug log (issue #7978): stack automation replayed
+        // after a server restart is exactly the post-crash scenario this log
+        // exists to make debuggable — it must not be invisible here.
+        self.game_log
+            .write_game_log_entries(&self.game_code, &resumed.action_result().log_entries);
         let revision = self.advance_state_revision();
         let (legal_actions, spell_costs, by_object) = engine_legal_actions_full(&self.state);
         let auto_pass = auto_pass_recommended(&self.state, &legal_actions);
@@ -2882,6 +2891,78 @@ mod tests {
             }
         }
         (mgr, code, token0, token1)
+    }
+
+    /// Proves a production mint point (`handle_action` ->
+    /// `handle_action_with_card_db_outcome`'s write hook) actually reaches a
+    /// real `GameFileCache`, not just that `write_game_log_entries` works in
+    /// isolation. Attaching the cache post-hoc on `setup_two_player_game`'s
+    /// manager would not do this: `GameSession.game_log` is copied from
+    /// `SessionManager.game_log` at session-creation time, so the cache must
+    /// be installed before `create_game`. This is also the exact wiring gap
+    /// (`GameCodeVisitor::record_debug` never captured the span field) that
+    /// the second review round caught — a test reaching the real hook is what
+    /// would have caught it directly.
+    #[test]
+    fn handle_action_hook_writes_real_events_stream_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let games_dir = dir.path().join("games");
+        std::fs::create_dir_all(&games_dir).unwrap();
+
+        let mut mgr = SessionManager::new();
+        mgr.game_log = std::sync::Arc::new(GameFileCache::new(games_dir.clone()));
+        let (code, token0) = mgr.create_game(make_deck());
+        let (token1, _) = mgr.join_game(&code, make_deck()).unwrap();
+        for _ in 0..20 {
+            let session = mgr.sessions.get(&code).unwrap();
+            match &session.state.waiting_for.clone() {
+                WaitingFor::MulliganDecision { pending, .. } => {
+                    for entry in pending {
+                        let tok = if entry.player == PlayerId(0) {
+                            token0.clone()
+                        } else {
+                            token1.clone()
+                        };
+                        let _ = mgr.handle_action(
+                            &code,
+                            &tok,
+                            GameAction::MulliganDecision {
+                                choice: engine::types::actions::MulliganChoice::Keep,
+                            },
+                        );
+                    }
+                }
+                WaitingFor::Priority { .. } => break,
+                _ => break,
+            }
+        }
+
+        let priority_player = match &mgr.sessions.get(&code).unwrap().state.waiting_for {
+            WaitingFor::Priority { player } => *player,
+            other => panic!("expected Priority, got {other:?}"),
+        };
+        let acting_token = if priority_player == PlayerId(0) {
+            &token0
+        } else {
+            &token1
+        };
+        let result = mgr.handle_action(&code, acting_token, GameAction::PassPriority);
+        assert!(result.is_ok(), "PassPriority should succeed: {result:?}");
+
+        let events_path = games_dir.join(format!("{code}.events.jsonl"));
+        let content = std::fs::read_to_string(&events_path)
+            .expect("a real production action hook must have written the events stream file");
+        assert!(
+            !content.trim().is_empty(),
+            "events stream file exists but is empty"
+        );
+        let row: serde_json::Value = serde_json::from_str(content.lines().next().unwrap())
+            .expect("each row must be valid JSON");
+        assert!(
+            row.get("category").is_some(),
+            "row must carry the engine's LogCategory field: {row}"
+        );
+        assert!(row.get("ts").is_some(), "row must carry a ts field: {row}");
     }
 
     /// `SetPhaseStops` is keyed to the authenticated player and delegated to the


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Adds configurable, per-game JSON-Lines debug logs to `phase-server` so user-reported game issues can be diagnosed from a structured trace rather than reconstructed from memory. Two streams per game: `<code>.session.jsonl` (transport/session-lifecycle tracing events) and `<code>.events.jsonl` (the engine's own typed `GameLogEntry` rows, reused as-is — zero engine changes). Enabled by setting `PHASE_LOG_DIR`; JSON is unconditional once a log directory is configured (not a separate opt-in flag), so the default per-game output is always parseable. Log rotation/retention/expiry/download are explicitly out of scope (separate infra PR per the issue).

Closes #7978

## Files changed

- `crates/server-core/src/game_log.rs` (new) — `GameFileCache`, `Stream`, `format_timestamp`; shared file-cache sink used by both crates
- `crates/server-core/src/lib.rs` — export `game_log` module
- `crates/server-core/src/session.rs` — `SessionManager.game_log` / `GameSession.game_log` fields (same lifecycle as `hosting: HostingMode`); write hooks at all five `GameLogEntry` mint points (`handle_action_with_card_db_outcome`, `handle_interaction_with_rejection`, `run_ai_action_batch`, `start_game`, `resume_restored_stack_automation`); 4 new tests
- `crates/phase-server/src/logging.rs` — `GameFileLayer` (tracing `Layer` routing `game_session`-span events to the session stream), `init_logging` now also returns the shared `Arc<GameFileCache>`; 2 new tests
- `crates/phase-server/src/main.rs` — wires `PHASE_LOG_DIR`/`PHASE_LOG_JSON` through `init_logging`, installs the returned cache onto `SessionManager.game_log` at startup

## Track

Developer

## LLM

Model: claude-sonnet-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — server-side observability plumbing confined to `crates/phase-server` and `crates/server-core` (no `crates/engine/` game-logic changes; the engine's existing `GameLogEntry`/`LogCategory` types are reused unmodified). The maintainer explicitly directed a middleweight design-note → implement → verify → single-review flow for this lane instead of the full `/engine-implementer` pipeline (that pipeline is scoped to engine rules-logic changes).

## CR references

None — server-side plumbing, no game-rules logic touched.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — clean
- `cargo clippy -p phase-server -p server-core --all-targets -- -D warnings` — clean (0 warnings)
- `cargo test -p server-core` — 371 passed; 0 failed
- `cargo test -p phase-server --bin phase-server` — 163 passed; 0 failed

<!-- Commands run and exact results. Every required box must be checked. -->

## Gate A

Gate A PASS head=16b1a3809b0806c68192672814b880b960b77a78 base=a136efbd50a5f05ebd268f644036df84d3f4b5ae

## Anchored on

- `crates/server-core/src/session.rs:405` — `pub hosting: HostingMode` on `GameSession`: the precedented "runtime handle stamped at creation, re-stamped at restore, never deserialized" field pattern `game_log: Arc<GameFileCache>` mirrors exactly
- `crates/engine/src/types/log.rs:11` / `:97` — `GameLogEntry` / `LogCategory`, the engine's existing typed, `Serialize`-derived log row shape reused verbatim as the `events` stream's row format (no new taxonomy invented)

## Final review-impl

Three review-impl rounds ran on this branch (single-diff mode, not part of an `/engine-implementer` pipeline — see Implementation method above). Commit SHAs below are pre-rebase identity references to the reviewed diffs; the branch was later rebased onto upstream/main (see current history: `0aeabe1e6`→`7c6b48f5e`→`140f4e8a6`→`16b1a3809`, same net diffs, no conflicts):
- Round 1 (head 58c80c9e3): 8 findings (1 HIGH — write hook at wrong architectural layer, 5 MED, 3 LOW). Fixed in 0f04abec6.
- Round 2, confirming pass at the rebased two-commit diff (head 0f04abec6): 7/8 round-1 findings confirmed closed; 4 new findings (1 HIGH — `game_session` span's `%`-recorded field was never captured, so the `session` stream was dead at runtime; 2 MED — two `GameLogEntry` mint points were unhooked; 1 LOW — metadata keys could clobber same-named event fields). Fixed in 10866a3b6 (now `140f4e8a6`), with 3 new tests added (one exercises the real span macro end-to-end and is the discriminating test that would have caught the HIGH bug directly).
- Round 3, scoped to only the round-2 fix commit (10866a3b6): 3/4 findings confirmed correctly fixed and non-vacuously tested; 1 new LOW (the two write hooks added in round 2's fix — `start_game`, `resume_restored_stack_automation` — still had no direct test reaching them). Fixed at head 16b1a3809b0806c68192672814b880b960b77a78 (current HEAD) with one additional test (`start_game_hook_writes_real_events_stream_file`); not re-reviewed by a further round — bounded at three rounds per direction, with maintainer review and CodeRabbit as the remaining checks by design.

Final review-impl PASS head=16b1a3809b0806c68192672814b880b960b77a78

## Claimed parse impact

None.

## Scope Expansion

The implementation's footprint grew beyond "one call site" (the original plan) to: a new shared module (`server-core/src/game_log.rs`), two new fields on `SessionManager`/`GameSession`, and five write-hook call sites — all still confined to the two chartered crates (`server-core`, `phase-server`), driven by round-1 review finding that a single phase-server call site missed every AI-driven and reconnect-driven log transition. No engine or frontend files touched.

## Validation Failures

None.

## CI Failures

None (not yet run — PR just opened).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added per-game JSON-Lines logs for session activity and game events.
  * Logs include timestamps, severity, targets, structured event details, and player information.
  * Game events are recorded throughout gameplay, including starts, actions, automated transitions, and restored sessions.
  * Logs are written incrementally and preserved when reopened.

* **Bug Fixes**
  * Prevented generated metadata from overwriting event fields with matching names.
  * Improved capture of displayed game identifiers and player details in log records.
  * Ensured removed games properly close their associated log files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->