### PR TITLE
fix(client): export authoritative game state for reports

### DIFF
--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -2113,17 +2113,6 @@ export class P2PHostAdapter implements EngineAdapter {
     return this.wasm.previewManaPayment(action, actor);
   }
 
-  async exportPersistenceState(): Promise<string> {
-    this.assertNotDisposed();
-    if (!this.ownsAuthority()) {
-      throw new AdapterError("P2P_ERROR", "Host session superseded", true);
-    }
-    if (this.nativeBridge) {
-      throw new AdapterError("P2P_ERROR", "Native P2P persistence is managed by phase-server", false);
-    }
-    return this.wasm.exportPersistenceState();
-  }
-
   /** Releases a complete native-server revision only after every local seat
    * socket has supplied its own filtered view. The native server is the
    * authority for this revision; PeerJS carries it through to terminal

--- a/client/src/components/chrome/DebugPanel.tsx
+++ b/client/src/components/chrome/DebugPanel.tsx
@@ -11,7 +11,7 @@ import { usePlayerId } from "../../hooks/usePlayerId";
 import { getSeatColor } from "../../hooks/useSeatColor";
 import {
   copyGameStateDebugSnapshot,
-  exportGameStateDebugZip,
+  exportAuthoritativeGameStateZip,
 } from "../../services/gameStateExport";
 import { gameStateFromImportText, readImportFile } from "../../services/gameStateImport";
 import { useGameStore } from "../../stores/gameStore";
@@ -173,14 +173,14 @@ export function DebugPanel({
   }, [gameState]);
 
   const handleExportGameState = useCallback(() => {
-    if (!gameState) return;
-    exportGameStateDebugZip(gameState)
+    if (!adapter) return;
+    exportAuthoritativeGameStateZip(adapter)
       .then((filename) => setStatus({ type: "success", message: `Exported ${filename}` }))
       .catch((err: unknown) => {
         if (err instanceof DOMException && err.name === "AbortError") return;
         setStatus({ type: "error", message: "Failed to export game state" });
       });
-  }, [gameState]);
+  }, [adapter]);
 
   // Same destination as the top-left report flag. Close this panel first — it
   // renders at z-[9999], above the report dialog's z-50 overlay, so leaving it
@@ -518,11 +518,11 @@ export function DebugPanel({
           </button>
           <button
             onClick={handleExportGameState}
-            disabled={!gameState}
+            disabled={!adapter?.exportPersistenceState}
             className="mt-1 w-full rounded bg-gray-800 px-2 py-1 text-xs transition-colors hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-40"
-            title="Download the current debug game state as minified JSON inside a compressed ZIP"
+            title={t("debug.exportAuthoritativeTitle")}
           >
-            Export Game State
+            {t("debug.exportAuthoritative")}
           </button>
         </section>
 

--- a/client/src/components/chrome/DebugPanel.tsx
+++ b/client/src/components/chrome/DebugPanel.tsx
@@ -14,7 +14,7 @@ import {
   exportAuthoritativeGameStateZip,
 } from "../../services/gameStateExport";
 import { gameStateFromImportText, readImportFile } from "../../services/gameStateImport";
-import { useGameStore } from "../../stores/gameStore";
+import { canExportAuthoritativeState, useGameStore } from "../../stores/gameStore";
 import { getPlayerDisplayName } from "../../stores/multiplayerStore";
 import { useUiStore } from "../../stores/uiStore";
 import { DebugActions } from "./DebugActions";
@@ -71,6 +71,8 @@ export function DebugPanel({
   const adapter = useGameStore((s) => s.adapter);
   const gameState = useGameStore((s) => s.gameState);
   const gameMode = useGameStore((s) => s.gameMode);
+  const canExportAuthoritative = canExportAuthoritativeState(gameMode)
+    && adapter?.exportPersistenceState !== undefined;
   // The transport, not the mode, decides whether a rollback request can be
   // bound to an authenticated session — same idiom as `supportsMatchConcede`.
   const rewindAdapter = supportsServerRewind(adapter) ? adapter : null;
@@ -518,7 +520,7 @@ export function DebugPanel({
           </button>
           <button
             onClick={handleExportGameState}
-            disabled={!adapter?.exportPersistenceState}
+            disabled={!canExportAuthoritative}
             className="mt-1 w-full rounded bg-gray-800 px-2 py-1 text-xs transition-colors hover:bg-gray-700 disabled:cursor-not-allowed disabled:opacity-40"
             title={t("debug.exportAuthoritativeTitle")}
           >

--- a/client/src/components/chrome/__tests__/DebugPanel.sandboxCapability.test.tsx
+++ b/client/src/components/chrome/__tests__/DebugPanel.sandboxCapability.test.tsx
@@ -27,6 +27,8 @@ const storeState = {
 const debugDispatch = vi.fn();
 
 vi.mock("../../../stores/gameStore", () => ({
+  canExportAuthoritativeState: (mode: GameMode | null) =>
+    mode === "ai" || mode === "local" || mode === "native-ai",
   useGameStore: Object.assign(
     vi.fn((selector: (s: typeof storeState) => unknown) => selector(storeState)),
     { getState: () => storeState, setState: vi.fn() },

--- a/client/src/components/chrome/__tests__/DebugPanel.serverRewind.test.tsx
+++ b/client/src/components/chrome/__tests__/DebugPanel.serverRewind.test.tsx
@@ -41,6 +41,8 @@ const storeState = {
 };
 
 vi.mock("../../../stores/gameStore", () => ({
+  canExportAuthoritativeState: (mode: GameMode | null) =>
+    mode === "ai" || mode === "local" || mode === "native-ai",
   useGameStore: Object.assign(
     vi.fn((selector: (s: typeof storeState) => unknown) => selector(storeState)),
     { getState: () => storeState, setState: vi.fn() },

--- a/client/src/components/help/HelpSheet.tsx
+++ b/client/src/components/help/HelpSheet.tsx
@@ -6,7 +6,7 @@ import type { TFunction } from "i18next";
 import type { GameAction, GameState, WaitingFor } from "../../adapter/types.ts";
 import {
   copyGameStateDebugSnapshot,
-  exportGameStateDebugZip,
+  exportAuthoritativeGameStateZip,
 } from "../../services/gameStateExport.ts";
 import { downloadCurrentReplay } from "../../services/replayExport.ts";
 import { useCanActForWaitingState, usePlayerId } from "../../hooks/usePlayerId.ts";
@@ -236,8 +236,9 @@ export function HelpSheet() {
   };
 
   const handleExportState = () => {
-    if (!gameState) return;
-    exportGameStateDebugZip(gameState)
+    const adapter = useGameStore.getState().adapter;
+    if (!adapter) return;
+    exportAuthoritativeGameStateZip(adapter)
       .then((filename) => setStatus(t("help.status.exported", { filename })))
       .catch((err: unknown) => {
         if (err instanceof DOMException && err.name === "AbortError") return;

--- a/client/src/components/help/HelpSheet.tsx
+++ b/client/src/components/help/HelpSheet.tsx
@@ -10,7 +10,7 @@ import {
 } from "../../services/gameStateExport.ts";
 import { downloadCurrentReplay } from "../../services/replayExport.ts";
 import { useCanActForWaitingState, usePlayerId } from "../../hooks/usePlayerId.ts";
-import { useGameStore } from "../../stores/gameStore.ts";
+import { canExportAuthoritativeState, useGameStore } from "../../stores/gameStore.ts";
 import { useUiStore } from "../../stores/uiStore.ts";
 
 type HelpSection = "Flow" | "Shortcuts" | "Recovery";
@@ -141,6 +141,8 @@ export function HelpSheet() {
   const setOpen = useUiStore((s) => s.setHelpSheetOpen);
   const toggleDebugPanel = useUiStore((s) => s.toggleDebugPanel);
   const gameState = useGameStore((s) => s.gameState);
+  const gameMode = useGameStore((s) => s.gameMode);
+  const adapter = useGameStore((s) => s.adapter);
   const waitingFor = useGameStore((s) => s.waitingFor);
   const legalActions = useGameStore((s) => s.legalActions);
   const legalActionsByObject = useGameStore((s) => s.legalActionsByObject);
@@ -153,6 +155,8 @@ export function HelpSheet() {
   const searchRef = useRef<HTMLInputElement | null>(null);
   const restoreFocusRef = useRef<HTMLElement | null>(null);
   const titleId = useId();
+  const canExportAuthoritative = canExportAuthoritativeState(gameMode)
+    && adapter?.exportPersistenceState !== undefined;
 
   useEffect(() => {
     if (!open) return;
@@ -236,8 +240,7 @@ export function HelpSheet() {
   };
 
   const handleExportState = () => {
-    const adapter = useGameStore.getState().adapter;
-    if (!adapter) return;
+    if (!canExportAuthoritative || !adapter) return;
     exportAuthoritativeGameStateZip(adapter)
       .then((filename) => setStatus(t("help.status.exported", { filename })))
       .catch((err: unknown) => {
@@ -370,7 +373,7 @@ export function HelpSheet() {
                   </button>
                   <button
                     type="button"
-                    disabled={!gameState}
+                    disabled={!gameState || !canExportAuthoritative}
                     onClick={handleExportState}
                     className="rounded-lg border border-white/10 bg-white/8 px-3 py-2 text-sm font-semibold text-slate-100 transition hover:bg-white/12 disabled:cursor-not-allowed disabled:opacity-40"
                   >

--- a/client/src/components/help/HelpSheet.tsx
+++ b/client/src/components/help/HelpSheet.tsx
@@ -240,7 +240,7 @@ export function HelpSheet() {
   };
 
   const handleExportState = () => {
-    if (!canExportAuthoritative || !adapter) return;
+    if (!canExportAuthoritative || !adapter?.exportPersistenceState) return;
     exportAuthoritativeGameStateZip(adapter)
       .then((filename) => setStatus(t("help.status.exported", { filename })))
       .catch((err: unknown) => {

--- a/client/src/components/modal/EngineLostModal.tsx
+++ b/client/src/components/modal/EngineLostModal.tsx
@@ -200,7 +200,7 @@ export function EngineLostModal() {
               ? t("engineLost.exportFailed")
               : exported
                 ? t("engineLost.exported")
-                : t("engineLost.exportGameState")}
+                : t("engineLost.exportClientSnapshot")}
           </button>
           {isPanic && (
             <>

--- a/client/src/hooks/useKeyboardShortcuts.ts
+++ b/client/src/hooks/useKeyboardShortcuts.ts
@@ -1,6 +1,10 @@
 import { useEffect } from "react";
 
-import { isAuthorityRemote, useGameStore } from "../stores/gameStore";
+import {
+  canExportAuthoritativeState,
+  isAuthorityRemote,
+  useGameStore,
+} from "../stores/gameStore";
 import { useUiStore } from "../stores/uiStore";
 import { dispatchAction } from "../game/dispatch";
 import { getPlayerId } from "./usePlayerId";
@@ -187,7 +191,7 @@ export function useKeyboardShortcuts(): void {
         case "D":
           if (e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
             e.preventDefault();
-            if (adapter) {
+            if (adapter && canExportAuthoritativeState(gameMode)) {
               exportAuthoritativeGameStateZip(adapter)
                 .then((filename) => console.log(`[Debug] Game state exported to ${filename}`))
                 .catch((err) => console.error("[Debug] Failed to export:", err));

--- a/client/src/hooks/useKeyboardShortcuts.ts
+++ b/client/src/hooks/useKeyboardShortcuts.ts
@@ -8,7 +8,7 @@ import { useAltToggle } from "./useAltToggle";
 import { useShiftHeld } from "./useShiftHeld";
 import {
   copyGameStateDebugSnapshot,
-  exportGameStateDebugZip,
+  exportAuthoritativeGameStateZip,
 } from "../services/gameStateExport";
 
 /**
@@ -79,6 +79,7 @@ export function useKeyboardShortcuts(): void {
         stateHistory,
         gameMode,
         manaPaymentShortcutActions,
+        adapter,
       } = useGameStore.getState();
       const uiState = useUiStore.getState();
 
@@ -186,8 +187,8 @@ export function useKeyboardShortcuts(): void {
         case "D":
           if (e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
             e.preventDefault();
-            if (gameState) {
-              exportGameStateDebugZip(gameState)
+            if (adapter) {
+              exportAuthoritativeGameStateZip(adapter)
                 .then((filename) => console.log(`[Debug] Game state exported to ${filename}`))
                 .catch((err) => console.error("[Debug] Failed to export:", err));
             }

--- a/client/src/hooks/useKeyboardShortcuts.ts
+++ b/client/src/hooks/useKeyboardShortcuts.ts
@@ -191,7 +191,7 @@ export function useKeyboardShortcuts(): void {
         case "D":
           if (e.ctrlKey && !e.metaKey && !e.altKey && !e.shiftKey) {
             e.preventDefault();
-            if (adapter && canExportAuthoritativeState(gameMode)) {
+            if (adapter?.exportPersistenceState && canExportAuthoritativeState(gameMode)) {
               exportAuthoritativeGameStateZip(adapter)
                 .then((filename) => console.log(`[Debug] Game state exported to ${filename}`))
                 .catch((err) => console.error("[Debug] Failed to export:", err));

--- a/client/src/i18n/locales/de/common.json
+++ b/client/src/i18n/locales/de/common.json
@@ -5,6 +5,10 @@
     "close": "Schließen",
     "closeNamed": "{{name}} schließen"
   },
+  "debug": {
+    "exportAuthoritative": "Autoritativen Spielzustand exportieren",
+    "exportAuthoritativeTitle": "Lädt den engine-eigenen Zustand herunter, mit dem dieses Spiel diagnostiziert und wiederhergestellt wird"
+  },
   "quantityRef": {
     "highestNumber": "die höchste Zahl",
     "lowestNumber": "die niedrigste Zahl",

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -2041,6 +2041,7 @@
     "diagnostic": "Diagnose: {{reason}}",
     "showDetails": "Details anzeigen",
     "exportGameState": "Spielzustand exportieren",
+    "exportClientSnapshot": "Client-Snapshot exportieren",
     "exported": "Exportiert",
     "exportFailed": "Export fehlgeschlagen",
     "copyDiagnostic": "Diagnose kopieren",

--- a/client/src/i18n/locales/en/common.json
+++ b/client/src/i18n/locales/en/common.json
@@ -5,6 +5,10 @@
     "close": "Close",
     "closeNamed": "Close {{name}}"
   },
+  "debug": {
+    "exportAuthoritative": "Export Authoritative Game State",
+    "exportAuthoritativeTitle": "Download the engine-owned state used to diagnose and restore this game"
+  },
   "quantityRef": {
     "highestNumber": "the highest number",
     "lowestNumber": "the lowest number",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -2099,6 +2099,7 @@
     "diagnostic": "diagnostic: {{reason}}",
     "showDetails": "Show details",
     "exportGameState": "Export Game State",
+    "exportClientSnapshot": "Export client snapshot",
     "exported": "Exported",
     "exportFailed": "Export failed",
     "copyDiagnostic": "Copy diagnostic",

--- a/client/src/i18n/locales/es/common.json
+++ b/client/src/i18n/locales/es/common.json
@@ -5,6 +5,10 @@
     "close": "Cerrar",
     "closeNamed": "Cerrar {{name}}"
   },
+  "debug": {
+    "exportAuthoritative": "Exportar estado de juego autoritativo",
+    "exportAuthoritativeTitle": "Descarga el estado propiedad del motor que se usa para diagnosticar y restaurar esta partida"
+  },
   "quantityRef": {
     "highestNumber": "el número más alto",
     "lowestNumber": "el número más bajo",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -2041,6 +2041,7 @@
     "diagnostic": "diagnóstico: {{reason}}",
     "showDetails": "Mostrar detalles",
     "exportGameState": "Exportar estado de la partida",
+    "exportClientSnapshot": "Exportar instantánea del cliente",
     "exported": "Exportado",
     "exportFailed": "Error al exportar",
     "copyDiagnostic": "Copiar diagnóstico",

--- a/client/src/i18n/locales/fr/common.json
+++ b/client/src/i18n/locales/fr/common.json
@@ -5,6 +5,10 @@
     "close": "Fermer",
     "closeNamed": "Fermer {{name}}"
   },
+  "debug": {
+    "exportAuthoritative": "Exporter l’état de jeu faisant autorité",
+    "exportAuthoritativeTitle": "Télécharge l’état détenu par le moteur, utilisé pour diagnostiquer et restaurer cette partie"
+  },
   "quantityRef": {
     "highestNumber": "le nombre le plus élevé",
     "lowestNumber": "le nombre le plus bas",

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -2041,6 +2041,7 @@
     "diagnostic": "diagnostic : {{reason}}",
     "showDetails": "Afficher les détails",
     "exportGameState": "Exporter l'état de la partie",
+    "exportClientSnapshot": "Exporter l’instantané du client",
     "exported": "Exporté",
     "exportFailed": "Échec de l'exportation",
     "copyDiagnostic": "Copier le diagnostic",

--- a/client/src/i18n/locales/it/common.json
+++ b/client/src/i18n/locales/it/common.json
@@ -5,6 +5,10 @@
     "close": "Chiudi",
     "closeNamed": "Chiudi {{name}}"
   },
+  "debug": {
+    "exportAuthoritative": "Esporta lo stato di gioco autorevole",
+    "exportAuthoritativeTitle": "Scarica lo stato gestito dal motore usato per diagnosticare e ripristinare questa partita"
+  },
   "quantityRef": {
     "highestNumber": "il numero più alto",
     "lowestNumber": "il numero più basso",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -2041,6 +2041,7 @@
     "diagnostic": "diagnostica: {{reason}}",
     "showDetails": "Mostra dettagli",
     "exportGameState": "Esporta stato partita",
+    "exportClientSnapshot": "Esporta istantanea del client",
     "exported": "Esportato",
     "exportFailed": "Esportazione non riuscita",
     "copyDiagnostic": "Copia diagnostica",

--- a/client/src/i18n/locales/pl/common.json
+++ b/client/src/i18n/locales/pl/common.json
@@ -5,6 +5,10 @@
     "close": "Zamknij",
     "closeNamed": "Zamknij {{name}}"
   },
+  "debug": {
+    "exportAuthoritative": "Eksportuj autorytatywny stan gry",
+    "exportAuthoritativeTitle": "Pobiera stan należący do silnika, używany do diagnozowania i przywracania tej gry"
+  },
   "quantityRef": {
     "highestNumber": "najwyższa liczba",
     "lowestNumber": "najniższa liczba",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -2041,6 +2041,7 @@
     "diagnostic": "diagnostyka: {{reason}}",
     "showDetails": "Pokaż szczegóły",
     "exportGameState": "Eksportuj stan gry",
+    "exportClientSnapshot": "Eksportuj migawkę klienta",
     "exported": "Wyeksportowano",
     "exportFailed": "Eksport nie powiódł się",
     "copyDiagnostic": "Kopiuj diagnostykę",

--- a/client/src/i18n/locales/pt/common.json
+++ b/client/src/i18n/locales/pt/common.json
@@ -5,6 +5,10 @@
     "close": "Fechar",
     "closeNamed": "Fechar {{name}}"
   },
+  "debug": {
+    "exportAuthoritative": "Exportar estado de jogo autoritativo",
+    "exportAuthoritativeTitle": "Baixa o estado controlado pelo mecanismo usado para diagnosticar e restaurar este jogo"
+  },
   "quantityRef": {
     "highestNumber": "o número mais alto",
     "lowestNumber": "o número mais baixo",

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -2041,6 +2041,7 @@
     "diagnostic": "diagnóstico: {{reason}}",
     "showDetails": "Mostrar detalhes",
     "exportGameState": "Exportar estado do jogo",
+    "exportClientSnapshot": "Exportar instantâneo do cliente",
     "exported": "Exportado",
     "exportFailed": "Falha na exportação",
     "copyDiagnostic": "Copiar diagnóstico",

--- a/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
+++ b/client/src/pages/__tests__/GamePage.bracketViolation.test.tsx
@@ -176,6 +176,9 @@ vi.mock("../../stores/gameStore", async () => ({
   hasRemoteHumans: (
     await vi.importActual<typeof import("../../stores/gameStore")>("../../stores/gameStore")
   ).hasRemoteHumans,
+  canExportAuthoritativeState: (
+    await vi.importActual<typeof import("../../stores/gameStore")>("../../stores/gameStore")
+  ).canExportAuthoritativeState,
   loadActiveGame: vi.fn(() => null),
   saveActiveGame: vi.fn(),
   clearActiveGame: vi.fn(),

--- a/client/src/services/__tests__/gameStateExport.test.ts
+++ b/client/src/services/__tests__/gameStateExport.test.ts
@@ -91,6 +91,7 @@ describe("gameStateExport", () => {
     const adapter = buildEngineAdapterMock(undefined, {
       exportPersistenceState: vi.fn().mockResolvedValue(trustedState),
     });
+    useGameStore.setState({ gameMode: "ai" });
 
     const filename = await exportAuthoritativeGameStateZip(adapter);
 
@@ -100,5 +101,18 @@ describe("gameStateExport", () => {
     const [entryName] = Object.keys(entries);
     expect(entryName).toMatch(/^authoritative-game-state-.*\.json$/);
     expect(strFromU8(entries[entryName])).toBe(trustedState);
+  });
+
+  it("does not expose the trusted envelope from a shared game", async () => {
+    const exportPersistenceState = vi.fn().mockResolvedValue(JSON.stringify({
+      state: { players: [{ hand: ["hidden-card"] }] },
+    }));
+    const adapter = buildEngineAdapterMock(undefined, { exportPersistenceState });
+    useGameStore.setState({ gameMode: "p2p-host" });
+
+    await expect(exportAuthoritativeGameStateZip(adapter)).rejects.toThrow(
+      "Authoritative state export is unavailable for shared games",
+    );
+    expect(exportPersistenceState).not.toHaveBeenCalled();
   });
 });

--- a/client/src/services/__tests__/gameStateExport.test.ts
+++ b/client/src/services/__tests__/gameStateExport.test.ts
@@ -2,9 +2,11 @@ import { strFromU8, unzipSync } from "fflate";
 import { afterEach, describe, expect, it, vi } from "vitest";
 
 import { useGameStore } from "../../stores/gameStore.ts";
+import { buildEngineAdapterMock } from "../../test/factories/engineAdapterFactory.ts";
 import { buildGameState } from "../../test/factories/gameStateFactory.ts";
 import {
   exportGameStateDebugZip,
+  exportAuthoritativeGameStateZip,
   serializeGameStateDebugSnapshot,
 } from "../gameStateExport.ts";
 
@@ -69,5 +71,34 @@ describe("gameStateExport", () => {
     expect(entryName).toMatch(/^game-state-turn-7-.*\.json$/);
     expect(json).not.toContain("\n");
     expect(JSON.parse(json).gameState.turn_number).toBe(7);
+  });
+
+  it("writes the trusted engine envelope, not the client snapshot", async () => {
+    const trustedState = JSON.stringify({
+      state: { stack_resolution_session: { policy: "RecheckNoMeaningfulPriorityAction" } },
+      schema_version: 1,
+    });
+    let writtenBlob: Blob | null = null;
+    const write = vi.fn(async (blob: Blob) => {
+      writtenBlob = blob;
+    });
+    Object.defineProperty(window, "showSaveFilePicker", {
+      configurable: true,
+      value: vi.fn(async () => ({
+        createWritable: async () => ({ write, close: vi.fn(async () => {}) }),
+      })),
+    });
+    const adapter = buildEngineAdapterMock(undefined, {
+      exportPersistenceState: vi.fn().mockResolvedValue(trustedState),
+    });
+
+    const filename = await exportAuthoritativeGameStateZip(adapter);
+
+    expect(filename).toMatch(/^authoritative-game-state-.*\.zip$/);
+    expect(adapter.exportPersistenceState).toHaveBeenCalledOnce();
+    const entries = unzipSync(new Uint8Array(await writtenBlob!.arrayBuffer()));
+    const [entryName] = Object.keys(entries);
+    expect(entryName).toMatch(/^authoritative-game-state-.*\.json$/);
+    expect(strFromU8(entries[entryName])).toBe(trustedState);
   });
 });

--- a/client/src/services/gameStateExport.ts
+++ b/client/src/services/gameStateExport.ts
@@ -1,6 +1,6 @@
 import { strToU8, zipSync } from "fflate";
 
-import type { GameState } from "../adapter/types.ts";
+import type { EngineAdapter, GameState } from "../adapter/types.ts";
 import { useGameStore } from "../stores/gameStore.ts";
 import { copyText } from "./copyText";
 
@@ -32,35 +32,9 @@ type WindowWithSaveFilePicker = Window & {
   showSaveFilePicker?: (options?: SaveFilePickerOptions) => Promise<FileSystemFileHandle>;
 };
 
-export function buildGameStateDebugSnapshot(gameState: GameState): GameStateDebugSnapshot {
-  const store = useGameStore.getState();
-  return {
-    gameState,
-    waitingFor: gameState.waiting_for,
-    legalActions: store.legalActions,
-    turnCheckpoints: store.turnCheckpoints,
-  };
-}
-
-export function serializeGameStateDebugSnapshot(gameState: GameState, pretty = false): string {
-  return JSON.stringify(buildGameStateDebugSnapshot(gameState), null, pretty ? 2 : undefined);
-}
-
-export async function copyGameStateDebugSnapshot(gameState: GameState): Promise<void> {
-  if (!(await copyText(serializeGameStateDebugSnapshot(gameState, true)))) {
-    throw new Error("Clipboard write failed");
-  }
-}
-
-export async function exportGameStateDebugZip(gameState: GameState): Promise<string> {
-  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
-  const baseName = `game-state-turn-${gameState.turn_number}-${stamp}`;
-  const jsonFilename = `${baseName}.json`;
+async function downloadZip(baseName: string, contents: Record<string, Uint8Array>): Promise<string> {
   const zipFilename = `${baseName}.zip`;
-  const zipped = zipSync(
-    { [jsonFilename]: strToU8(serializeGameStateDebugSnapshot(gameState)) },
-    { level: 9 },
-  );
+  const zipped = zipSync(contents, { level: 9 });
   const blob = new Blob([zipped as BlobPart], { type: "application/zip" });
 
   const saveFilePicker = (window as WindowWithSaveFilePicker).showSaveFilePicker;
@@ -89,4 +63,54 @@ export async function exportGameStateDebugZip(gameState: GameState): Promise<str
   document.body.removeChild(anchor);
   URL.revokeObjectURL(url);
   return zipFilename;
+}
+
+export function buildGameStateDebugSnapshot(gameState: GameState): GameStateDebugSnapshot {
+  const store = useGameStore.getState();
+  return {
+    gameState,
+    waitingFor: gameState.waiting_for,
+    legalActions: store.legalActions,
+    turnCheckpoints: store.turnCheckpoints,
+  };
+}
+
+export function serializeGameStateDebugSnapshot(gameState: GameState, pretty = false): string {
+  return JSON.stringify(buildGameStateDebugSnapshot(gameState), null, pretty ? 2 : undefined);
+}
+
+export async function copyGameStateDebugSnapshot(gameState: GameState): Promise<void> {
+  if (!(await copyText(serializeGameStateDebugSnapshot(gameState, true)))) {
+    throw new Error("Clipboard write failed");
+  }
+}
+
+export async function exportGameStateDebugZip(gameState: GameState): Promise<string> {
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const baseName = `game-state-turn-${gameState.turn_number}-${stamp}`;
+  const jsonFilename = `${baseName}.json`;
+  return downloadZip(
+    baseName,
+    { [jsonFilename]: strToU8(serializeGameStateDebugSnapshot(gameState)) },
+  );
+}
+
+/**
+ * Exports the engine-owned persistence envelope for a bug report. Unlike a
+ * rendered client snapshot, this retains private runtime state needed to
+ * diagnose and restore the game accurately.
+ */
+export async function exportAuthoritativeGameStateZip(adapter: EngineAdapter): Promise<string> {
+  if (!adapter.exportPersistenceState) {
+    throw new Error("The current game authority cannot export a trusted state");
+  }
+
+  const stamp = new Date().toISOString().replace(/[:.]/g, "-");
+  const baseName = `authoritative-game-state-${stamp}`;
+  const jsonFilename = `${baseName}.json`;
+  const trustedState = await adapter.exportPersistenceState();
+  return downloadZip(
+    baseName,
+    { [jsonFilename]: strToU8(trustedState) },
+  );
 }

--- a/client/src/services/gameStateExport.ts
+++ b/client/src/services/gameStateExport.ts
@@ -1,7 +1,7 @@
 import { strToU8, zipSync } from "fflate";
 
 import type { EngineAdapter, GameState } from "../adapter/types.ts";
-import { useGameStore } from "../stores/gameStore.ts";
+import { canExportAuthoritativeState, useGameStore } from "../stores/gameStore.ts";
 import { copyText } from "./copyText";
 
 interface GameStateDebugSnapshot {
@@ -101,6 +101,9 @@ export async function exportGameStateDebugZip(gameState: GameState): Promise<str
  * diagnose and restore the game accurately.
  */
 export async function exportAuthoritativeGameStateZip(adapter: EngineAdapter): Promise<string> {
+  if (!canExportAuthoritativeState(useGameStore.getState().gameMode)) {
+    throw new Error("Authoritative state export is unavailable for shared games");
+  }
   if (!adapter.exportPersistenceState) {
     throw new Error("The current game authority cannot export a trusted state");
   }

--- a/client/src/stores/__tests__/gameStore.test.ts
+++ b/client/src/stores/__tests__/gameStore.test.ts
@@ -10,7 +10,12 @@ import {
   buildStackEntry,
 } from "../../test/factories/gameStateFactory";
 import type { GameMode } from "../gameStore";
-import { hasRemoteHumans, isAuthorityRemote, useGameStore } from "../gameStore";
+import {
+  canExportAuthoritativeState,
+  hasRemoteHumans,
+  isAuthorityRemote,
+  useGameStore,
+} from "../gameStore";
 
 describe("game mode classification", () => {
   // The two questions the old `isMultiplayerMode` answered with one bit:
@@ -53,6 +58,20 @@ describe("game mode classification", () => {
     expect(hasRemoteHumans("local")).toBe(false);
     expect(isAuthorityRemote("local")).toBe(false);
   });
+
+  it.each(["ai", "local", "native-ai"] as GameMode[])(
+    "allows authoritative bug reports in private %s games",
+    (mode) => {
+      expect(canExportAuthoritativeState(mode)).toBe(true);
+    },
+  );
+
+  it.each(["online", "p2p-host", "p2p-join", "draft-match", "spectate"] as GameMode[])(
+    "blocks authoritative bug reports in shared %s games",
+    (mode) => {
+      expect(canExportAuthoritativeState(mode)).toBe(false);
+    },
+  );
 
   it("answers false to both for the pre-game null mode", () => {
     expect(isAuthorityRemote(null)).toBe(false);

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -164,6 +164,16 @@ export function hasRemoteHumans(mode: GameMode | null): boolean {
 }
 
 /**
+ * Whether this client may download the engine's unredacted persistence envelope.
+ * A shared remote table must never turn the authority's private view into a
+ * player-facing file; solo games have no remote player whose hidden information
+ * could be disclosed.
+ */
+export function canExportAuthoritativeState(mode: GameMode | null): boolean {
+  return mode !== null && !hasRemoteHumans(mode);
+}
+
+/**
  * The seat axis of the census: where this client's own seat number comes from.
  *
  * Read this instead of testing `gameMode` against a list at the call site. The


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added authoritative game-state export for diagnostics and game restoration.
  - Export actions now download the engine-owned persistence state.
  - Added a separate client snapshot label when the engine is unavailable.
  - Added translations for these export options across supported languages.

- **Bug Fixes**
  - Prevented authoritative exports when the required game state is unavailable.
  - Improved export reliability by using trusted persistence data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->