### PR TITLE
Fix Grishnákh haste-grant target binding

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -21332,6 +21332,39 @@ fn has_typed_target_widened(effect: &Effect) -> bool {
 /// succeeds at the originating typed clause. It stops at the first clause that is
 /// conditional or is neither typed nor a `ParentTarget` carrier, so it never
 /// reaches across an unrelated referent.
+///
+/// CR 603.12 + CR 608.2c carve-out: a `WhenYouDo` clause does NOT bail the walk,
+/// even though it carries a `condition` — it is still inspected as a possible
+/// typed introducer before the walk gives up. Grishnákh, Brash Instigator:
+/// "When ~ enters, amass Orcs 2. **When you do**, until end of turn, gain
+/// control of target nonlegendary creature an opponent controls with power
+/// less than or equal to the amassed Army's power. Untap that creature. It
+/// gains haste until end of turn." The `WhenYouDo`-conditioned `GainControl`
+/// clause IS the typed introducer for the trailing "It gains haste" anaphor two
+/// clauses later; the old unconditional bail never got far enough back to see
+/// it, leaving "It" to fall back to `SelfRef` (the source, Grishnákh itself)
+/// instead of the stolen creature (issue #8145).
+///
+/// This carve-out is intentionally narrower than the identical-looking one on
+/// the sibling walk `chain_prior_referent_is_created_token` below, which also
+/// admits `EffectOutcome::OptionalEffectPerformed` ("if you do" tied to a
+/// separately-declinable optional action) behind an additional
+/// `gated_publisher_reaches` prediction — that extra machinery exists there
+/// because a declined inline "if you do" gate can leave `resolve_ability_chain`
+/// still descending into an independent `SequentialSibling` instruction with no
+/// referent ever having been produced (a stale-bind hazard for the
+/// game-lifetime `last_created_token_ids` ledger the sibling reads).
+/// `WhenYouDo` has no such hazard: `game::effects::consume_reflexive_creation_gate`
+/// treats `WhenYouDo` as a whole-body membership marker for a CR 603.12
+/// reflexive triggered ability and materializes it as a genuinely separate
+/// stack object (`build_reflexive_pending_trigger`) only when the antecedent
+/// action actually occurred; that object chooses its own targets at the time
+/// it is put on the stack (CR 603.3d, which applies CR 601.2c's target-choice
+/// process to triggered abilities), so if this walk ever reaches a
+/// `WhenYouDo` clause, that reflexive ability necessarily fired with real
+/// targets recorded — there is no "gate false, chain still descends" case to
+/// guard against. Extending this carve-out to `OptionalEffectPerformed` needs
+/// its own hostile-fixture proof and is deliberately left out of this fix.
 fn chain_has_prior_typed_referent(clauses: &[ClauseIr], skip_first_conditional: bool) -> bool {
     // CR 608.2c: An `Otherwise` else-branch anaphor ("... and it's a 3/3 Robot ...")
     // binds to the referent that was in scope BEFORE the paired conditional it is the
@@ -21343,12 +21376,22 @@ fn chain_has_prior_typed_referent(clauses: &[ClauseIr], skip_first_conditional: 
     // reaches the originating `Choose target artifact card`. A SECOND conditional
     // still bails (never walk across an unrelated conditional). Default `false`
     // preserves the byte-for-byte behavior of the non-else callers.
+    //
+    // The `WhenYouDo` carve-out above shares this same one-shot allowance
+    // bookkeeping rather than bypassing it: the FIRST conditional encountered —
+    // `WhenYouDo` or not — always consumes `skipped_conditional`, so a `WhenYouDo`
+    // clause standing in the `Otherwise` pairing slot doesn't leave the allowance
+    // unspent for some unrelated SECOND conditional further back to steal (which
+    // would let an `Otherwise` anaphor bind across a conditional it was never
+    // paired with). Only once the allowance is already spent does a `WhenYouDo`
+    // clause additionally never bail on its own account, matching every other
+    // caller's unconditional carve-out.
     let mut skipped_conditional = false;
     for prev in clauses.iter().rev() {
-        if prev.condition.is_some() {
+        if let Some(cond) = prev.condition.as_ref() {
             if skip_first_conditional && !skipped_conditional {
                 skipped_conditional = true;
-            } else {
+            } else if *cond != AbilityCondition::WhenYouDo {
                 return false;
             }
         }

--- a/crates/engine/tests/integration/mauhur_swarming_of_moria.rs
+++ b/crates/engine/tests/integration/mauhur_swarming_of_moria.rs
@@ -4,6 +4,8 @@
 //! move those counters to itself; it increases the number put on that Army.
 
 use engine::game::effects::counters::add_counter_with_replacement;
+use engine::game::keywords::has_keyword;
+use engine::game::layers::evaluate_layers;
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
 use engine::types::ability::{
     ControllerRef, Effect, ObjectScope, QuantityExpr, QuantityModification, QuantityRef,
@@ -14,6 +16,7 @@ use engine::types::counter::{CounterMatch, CounterType};
 use engine::types::events::GameEvent;
 use engine::types::game_state::WaitingFor;
 use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
 use engine::types::mana::{ManaColor, ManaCost};
 use engine::types::phase::Phase;
 use engine::types::proposed_event::{TokenCharacteristics, TokenSpec};
@@ -29,10 +32,13 @@ const SWARMING_OF_MORIA: &str = "Create a Treasure token.\nAmass Orcs 2.";
 const FORAY_OF_ORCS: &str = "Amass Orcs 2. When you do, Foray of Orcs deals X damage \
 to target creature an opponent controls, where X is the amassed Army's power.";
 
-const GRISHNAKH: &str = "When Grishnákh, Brash Instigator enters the battlefield, \
-amass Orcs 2. When you do, until end of turn, gain control of target nonlegendary \
-creature an opponent controls with power less than or equal to the amassed Army's \
-power. Untap that creature. It gains haste until end of turn.";
+// Verbatim Scryfall Oracle text (verified against the live API). "Grishnákh"
+// alone (not the full printed name "Grishnákh, Brash Instigator") is the
+// card's own self-reference here, exactly as printed.
+const GRISHNAKH_VERBATIM: &str = "When Grishnákh enters, amass Orcs 2. When you do, until \
+end of turn, gain control of target nonlegendary creature an opponent controls with power \
+less than or equal to the amassed Army's power. Untap that creature. It gains haste until \
+end of turn.";
 
 const SURROUNDED_BY_ORCS: &str =
     "Amass Orcs 3, then target player mills X cards, where X is the amassed Army's power.";
@@ -254,7 +260,13 @@ fn grishnakh_target_eligibility_uses_the_amassed_armys_current_power() {
     let mut scenario = GameScenario::new();
     scenario.at_phase(Phase::PreCombatMain);
     let grishnakh = scenario
-        .add_creature_to_hand_from_oracle(P0, "Grishnákh, Brash Instigator", 1, 1, GRISHNAKH)
+        .add_creature_to_hand_from_oracle(
+            P0,
+            "Grishnákh, Brash Instigator",
+            1,
+            1,
+            GRISHNAKH_VERBATIM,
+        )
         .with_mana_cost(ManaCost::zero())
         .id();
     let legal_target = scenario.add_creature(P1, "Legal Target", 2, 2).id();
@@ -286,6 +298,85 @@ fn grishnakh_target_eligibility_uses_the_amassed_armys_current_power() {
     assert!(
         matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }),
         "Grishnákh should resolve its reflexive trigger and return priority"
+    );
+}
+
+/// True iff `id` has `keyword` after a fresh layer evaluation (CR 613).
+fn has_kw(runner: &mut GameRunner, id: ObjectId, keyword: &Keyword) -> bool {
+    runner.state_mut().layers_dirty.mark_full();
+    evaluate_layers(runner.state_mut());
+    has_keyword(&runner.state().objects[&id], keyword)
+}
+
+/// Regression for issue #8145: Grishnákh's reflexive ability reads "Untap that
+/// creature. It gains haste until end of turn." — CR 608.2c: both "that
+/// creature" and "It" are anaphors for the SAME referent, the just-stolen
+/// creature named by "gain control of target nonlegendary creature ...", not
+/// Grishnákh itself. Before the fix, the "It gains haste" clause fell back to
+/// `SelfRef` (the ability's own source) instead of `ParentTarget` (the chosen
+/// creature), so the stolen creature never gained haste and Grishnákh wrongly
+/// did.
+///
+/// Drives the real cast → ETB trigger → reflexive-ability pipeline
+/// (`runner.cast(..).resolve()`), not a parsed-AST shape assertion, and reads
+/// back the EFFECTIVE post-layer-evaluation keyword set on both creatures.
+#[test]
+fn grishnakh_reflexive_haste_binds_to_the_stolen_creature_not_self() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let grishnakh = scenario
+        .add_creature_to_hand_from_oracle(
+            P0,
+            "Grishnákh, Brash Instigator",
+            1,
+            1,
+            GRISHNAKH_VERBATIM,
+        )
+        .with_mana_cost(ManaCost::zero())
+        .id();
+    let stolen = scenario.add_creature(P1, "Stolen Creature", 2, 2).id();
+    let mut runner = scenario.build();
+
+    // Baseline before the ability resolves: neither creature has haste yet.
+    assert!(
+        !has_kw(&mut runner, stolen, &Keyword::Haste),
+        "baseline: the target has no haste before Grishnákh resolves"
+    );
+    assert!(
+        !has_kw(&mut runner, grishnakh, &Keyword::Haste),
+        "baseline: Grishnákh has no haste before its own ETB resolves"
+    );
+
+    let outcome = runner.cast(grishnakh).target_object(stolen).resolve();
+
+    // Positive reach-guard: prove the ETB trigger and reflexive ability
+    // actually ran the full chain (amass -> gain control -> untap) before
+    // asserting on the haste grant, so the negative assertion below isn't
+    // vacuously true from an early parse/resolution short-circuit.
+    assert_eq!(
+        runner.state().objects[&stolen].controller,
+        P0,
+        "Grishnákh's reflexive ability must gain control of the targeted creature"
+    );
+    assert!(
+        !runner.state().objects[&stolen].tapped,
+        "'Untap that creature' must untap the stolen creature"
+    );
+    assert!(
+        matches!(outcome.final_waiting_for(), WaitingFor::Priority { .. }),
+        "Grishnákh's ETB and reflexive ability should fully resolve back to priority"
+    );
+
+    // The regression: "It gains haste" must bind to the stolen creature.
+    assert!(
+        has_kw(&mut runner, stolen, &Keyword::Haste),
+        "the stolen creature must gain haste from Grishnákh's reflexive ability"
+    );
+    // The regression's inverse: Grishnákh must NOT be the one that gains
+    // haste from this trigger.
+    assert!(
+        !has_kw(&mut runner, grishnakh, &Keyword::Haste),
+        "Grishnákh itself must NOT gain haste from this trigger"
     );
 }
 


### PR DESCRIPTION
## Summary

Fixes issue #8145: Grishnákh, Brash Instigator's ETB reflexive ability ("Untap that creature. It gains haste until end of turn.") granted haste to Grishnákh itself instead of the just-stolen creature. Root cause: `chain_has_prior_typed_referent` (the parser's backward anaphor-referent walk) bailed on ANY conditional clause during its walk, including a `WhenYouDo`-conditioned clause that is itself the typed introducer two clauses before the trailing "It gains haste" anaphor — so "It" fell back to `SelfRef` instead of `ParentTarget`.

Closes #8145.

## Files changed

- `crates/engine/src/parser/oracle_effect/mod.rs` — `chain_has_prior_typed_referent`: `WhenYouDo`-conditioned clauses no longer unconditionally bail the backward anaphor walk; they are still inspected as a possible typed introducer, sharing the existing `skip_first_conditional` allowance bookkeeping so the unrelated `Otherwise`-branch caller is provably unchanged.
- `crates/engine/tests/integration/mauhur_swarming_of_moria.rs` — new discriminating regression test `grishnakh_reflexive_haste_binds_to_the_stolen_creature_not_self`, driven through the real cast → ETB trigger → reflexive-ability pipeline; also replaces the file's pre-existing paraphrased Oracle-text const with a verbatim one shared by both Grishnákh tests.

## Track

Developer

## LLM

Model: claude-sonnet-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer
<!-- Plan → review-plan (opus, FAIL with 4 blockers on round 1, addressed) → implement → verify (controlled full-corpus parse-diff + clippy + cargo test + semantic-audit) → review-impl (opus, PASS with 2 LOW findings, addressed) → final review-impl (opus, PASS) → commit, per the engine-planner/review-engine-plan/engine-implementer/review-impl skills read and executed manually. -->

## CR references

- CR 603.12 — reflexive triggered abilities ("when you do"): the antecedent-action gate that does not itself introduce or interrupt the chain's object referent.
- CR 608.2c — "read the whole text and apply the rules of English": the anaphor-binding authority for "that creature"/"It" resolving to the earlier chosen target.
- CR 603.3d — target selection for a triggered ability follows the same process as casting a spell (CR 601.2c–d), which is what guarantees a `WhenYouDo` reflexive ability that fires necessarily has real targets recorded (the safety argument for narrowing the carve-out to `WhenYouDo` only, not the broader `is_affirmative_reflexive_gate()`).
- CR 601.2c — the target-announcement process CR 603.3d applies to triggered abilities.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all` — clean, no changes.
- `cargo clippy -p phase-engine --all-targets -- -D warnings` — exit 0, clean (run three times across iterations, including independently by the final review-impl agent).
- `cargo test -p phase-engine --lib` — 20306 passed; 0 failed; 6 ignored.
- `cargo test -p phase-engine --test integration mauhur_swarming_of_moria` — 10 passed; 0 failed, including both `grishnakh_*` tests.
- Discrimination proof: reverted the one-line production fix (`git checkout` of my own uncommitted change, from a saved patch), re-ran `grishnakh_reflexive_haste_binds_to_the_stolen_creature_not_self` — **FAILED** at "the stolen creature must gain haste from Grishnákh's reflexive ability" (both the positive and negative assertions flip on revert, confirmed independently by the review agent too). Restored the fix from the saved patch, re-ran — **passed**.
- `./scripts/gen-card-data.sh` — regenerated `client/public/card-data.json` (35,798 cards) with the fix; `cargo semantic-audit` — 32,787 cards audited, zero findings for Grishnákh (`grep -ci grishn data/semantic-audit.{json,md}` → 0/0).
- **Controlled full-corpus blast-radius check** (addressing a plan-review blocker that an uncontrolled before/after diff showed 1007 changed cards, later traced to `gen-card-data.sh`'s date-based `GATED_SETS_AS_OF` set-unlock advancing between runs, not to this fix): regenerated the full card database twice with **`GATED_SETS_AS_OF` pinned to the same date** — once with the fix, once with it temporarily reverted (same saved-patch technique) — and diffed all 35,798 cards' parsed AST. Exactly **one card changed: Grishnákh, Brash Instigator**, and its new AST (`affected: ParentTarget`, `target: ParentTarget`) is now byte-for-byte structurally identical to the already-shipped-correct Zealous Conscripts' unconditioned version of the same clause shape.

## Gate A

Gate A PASS head=54383145dbce036d7cadbe05b447e6e17d5e26d8 base=2f665a28b252677ac37acf8d9a2b68cc78da1b50

## Anchored on

- `crates/engine/src/parser/oracle_effect/mod.rs:21475` (`chain_prior_referent_is_created_token`) — existing sibling backward-walk predicate carving `AbilityCondition::is_affirmative_reflexive_gate()` out of an unconditional conditional-bail, for the identical CR 603.12 reason ("a reflexive gate does not itself introduce/interrupt the chain's referent").
- `crates/engine/src/parser/oracle_effect/mod.rs:21597` (`chain_source_becomes_attachment`) — a second, simpler sibling with the same `!c.is_affirmative_reflexive_gate()` bail carve-out pattern, confirming this is an established idiom in this module, not a one-off.
- `crates/engine/src/game/effects/mod.rs:2378` (`ability.condition == Some(AbilityCondition::WhenYouDo)`) — the existing house idiom for equality-comparing `AbilityCondition` against `WhenYouDo` that the new `prev.condition != Some(AbilityCondition::WhenYouDo)` line mirrors.

## Final review-impl

Final review-impl PASS head=54383145dbce036d7cadbe05b447e6e17d5e26d8

## Claimed parse impact

Grishnákh, Brash Instigator — `affected`/`target` on the ETB reflexive ability's haste-granting `GenericEffect` change from `SelfRef`/`null` to `ParentTarget`/`ParentTarget`, matching the already-shipped-correct shape used by Zealous Conscripts' unconditioned analog. Confirmed by a controlled (same-`GATED_SETS_AS_OF`) full-corpus before/after diff to be the *only* card whose parsed AST changes.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.
