### PR TITLE
Fix Light-Paws, Emperor's Voice

### DIFF
--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -24,7 +24,7 @@ use crate::types::game_state::{
     LogicalZoneChangeTerminalOutcome, MayTriggerAutoChoiceKey, MayTriggerOrigin,
     ProductionOverride, StackEntry, StackEntryKind, SyntheticTriggerProvenance,
     TargetSelectionConstraint, TargetSelectionSlot, TriggerObservationTime, TriggerSourceContext,
-    WaitingFor,
+    TriggerSourceRead, WaitingFor,
 };
 use crate::types::identifiers::{
     DelayedInstallIdentity, DelayedTriggerInstanceId, DelayedTriggerOrigin, DelayedTriggerToken,
@@ -13063,6 +13063,94 @@ fn zone_changed_condition_provenance_is_coherent(event: &GameEvent) -> bool {
     })
 }
 
+/// CR 603.4 + CR 608.2h + CR 113.7a: Selects the ONE authority that answers a
+/// subject-relative intervening-if leaf ("if you cast **it**").
+///
+/// CR 603.4: a `ZoneChanged` trigger event NAMES its subject, and that subject —
+/// never the trigger source — is what the pronoun binds to. The subject's live
+/// object may answer only while it is still THIS entrant:
+///   * CR 400.7: a leave + re-entry reuses the same `ObjectId` but bumps the
+///     object's incarnation, so a re-entered object is a different object for
+///     this trigger. `ZoneChangeRecord::entered_incarnation` is the entrant's
+///     post-entry incarnation; `None` (legacy / synthesized records) falls back
+///     to the zone-only check.
+///   * CR 400.7: `reset_for_battlefield_exit` clears the cast/play provenance
+///     stamps on the live object, so a departed subject answers "not cast" from
+///     information that is no longer valid.
+///
+/// CR 608.2h + CR 113.7a: once the subject is no longer in the zone it was
+/// expected to be in, its LAST KNOWN INFORMATION is used. The event's own
+/// `ZoneChangeRecord` owns the exact event-time projection of the subject
+/// (`GameObject::snapshot_for_zone_change`, captured pre-move at
+/// `game/zones.rs`), and `zone_changed_condition_provenance_is_coherent` has
+/// already proven that projection coherent with this event, so it is consumed
+/// here without re-deriving coherence.
+///
+/// PRECONDITION FOR THE LKI BRANCH — READ BEFORE REUSING THIS HELPER.
+/// The record's projection is snapshotted BEFORE the move that produced the
+/// record. It can therefore only answer for provenance that was stamped on the
+/// object BEFORE that move. That holds for `cast_from_zone` / `cast_controller`,
+/// which are written on the STACK object during casting
+/// (`game/casting_costs.rs`, `game/stack.rs`) and so are captured by the
+/// Stack->Battlefield snapshot. It does NOT hold universally: for example
+/// `entered_via_ability_source` (behind `TriggerCondition::PlacedByAbilitySource`)
+/// is written AFTER the move, inside `apply_resolved_entry_provenance`, so the record
+/// context never carries it and this helper's `Latched` branch would report
+/// `None` for it. Any migration of another condition arm onto this helper MUST
+/// first establish that the provenance it reads is stamped pre-move.
+///
+/// Returns `None` when the event names a subject that nothing can answer for —
+/// fail closed. A different object's provenance is NEVER substituted for the
+/// subject's; that substitution is issue #8163.
+///
+/// When the trigger event names no subject at all (a `SpellCast`-shaped event —
+/// Cascade, Ripple, Discover — or a CR 603.4 re-check with no stored event), the
+/// trigger SOURCE is the subject and its own `source_read` is the authority.
+///
+/// Mirrors the battlefield-entry LKI dispatch in `game/filter.rs`
+/// (`matches_zone_change_event_object_filter`), which solves the same problem for ETB
+/// trigger FILTERS.
+fn trigger_subject_read<'event, 'state>(
+    state: &'state GameState,
+    trigger_event: Option<&'event GameEvent>,
+    source_context: Option<&'event TriggerSourceContext>,
+) -> Option<TriggerSourceRead<'event, 'state>> {
+    let Some(GameEvent::ZoneChanged {
+        object_id, record, ..
+    }) = trigger_event
+    else {
+        // CR 603.4: no named subject — the trigger source IS the subject.
+        return source_context.map(|source| source.source_read(state));
+    };
+
+    let live = state.objects.get(object_id);
+    // CR 400.7: the live object answers only while it is still THIS entrant.
+    let is_entrant = live.is_some_and(|object| {
+        object.zone == record.to_zone
+            && record
+                .entered_incarnation
+                .is_none_or(|incarnation| object.incarnation == incarnation)
+    });
+    if is_entrant {
+        return live.map(TriggerSourceRead::ExactLive);
+    }
+
+    // CR 608.2h + CR 113.7a: the subject has left the zone it was expected in —
+    // its last known information is the event record's own projection.
+    record
+        .trigger_source_context()
+        .map(TriggerSourceRead::Latched)
+        // DEFENSIVE ONLY — unreachable in production. Every production
+        // `ZoneChanged` trigger event carries a record built by
+        // `GameObject::snapshot_for_zone_change`, whose context is always
+        // `Some` (token battlefield entries included, via
+        // `zones::record_and_emit_entry_from_no_zone`). Context-free records
+        // exist only in `#[cfg(test)]` fixtures (`ZoneChangeRecord::test_minimal`)
+        // and in hand-built / deserialized states; this arm keeps them
+        // answerable from the live object. NEVER the trigger source.
+        .or_else(|| live.map(TriggerSourceRead::ExactLive))
+}
+
 /// Check whether an intervening-if condition is satisfied.
 /// Used both at fire-time and resolution-time.
 ///
@@ -13328,16 +13416,24 @@ fn evaluate_trigger_condition_with_source(
         // cast as a spell (regardless of origin zone). For ETB-based triggers like
         // Light-Paws, Emperor's Voice ("Whenever an Aura you control enters, if you
         // cast it..."), the trigger source is the permanent with the ability, not the
-        // entering Aura — so we must check the entering object from the trigger event,
-        // falling back to source_id for self-referential cases (Cascade's SpellCast
-        // event, Discover ETBs where source == cast spell).
+        // entering Aura — so the event's own SUBJECT is the authority. It is read
+        // live while it is still the entrant, and through its own event-record last
+        // known information (CR 608.2h + CR 113.7a) once it is not. The trigger
+        // SOURCE is consulted only when the event names no subject at all
+        // (Cascade's SpellCast event, Discover ETBs where source == cast spell).
+        // See `trigger_subject_read` and issue #8163.
         //
         // Negation ("if it wasn't cast" / "if none of them were cast") wraps via
-        // `Not { Box::new(WasCast) }`. The `Not` arm inverts the result, so a
-        // missing entering-object resolves Not(WasCast) to `true` (consistent
-        // with CR 603.4's intervening-if being permissive when source state is
-        // indeterminate; the ability is removed from the stack at resolution
-        // anyway per CR 603.4 if the source has left the relevant zone).
+        // `Not { Box::new(WasCast) }`. The `Not` arm inverts the result, so an
+        // unanswerable subject resolves Not(WasCast) to `true`. This is NOT because
+        // CR 603.4 removes the ability when the source leaves its zone — CR 603.4
+        // (`docs/MagicCompRules.txt:2596`) says nothing about the source's zone, and
+        // CR 113.7a explicitly says the opposite for abilities ("Destruction or
+        // removal of the source after that time won't affect the ability"). Rather,
+        // a subject the engine cannot answer for yields `false` for the plain
+        // condition, and `Not` inverts that `false` to `true` — the same
+        // "unanswerable is not a licence to substitute a different object" contract
+        // `trigger_subject_read` documents.
         // CR 601.2 + CR 603.4: cast-origin check. zone=None → cast from anywhere
         // (Discover/Wedding Ring/Satoru back-compat). zone=Some(z) → cast specifically
         // from zone z (Twilight Diviner: graveyard). Two independent scope axes:
@@ -13351,45 +13447,24 @@ fn evaluate_trigger_condition_with_source(
         //     cast from your graveyard"). An opponent casting your card from your
         //     graveyard satisfies owner=You; you casting from an opponent's
         //     graveyard does not.
-        // Reads the ENTERING object's cast provenance, never the trigger source.
+        // Reads the EVENT SUBJECT's cast provenance, never the trigger source —
+        // enforced by `trigger_subject_read`, not merely asserted here.
         TriggerCondition::WasCast {
             zone,
             controller: caster_scope,
             owner: owner_scope,
-        } => {
-            let event_object_id = trigger_event.and_then(|e| match e {
-                GameEvent::ZoneChanged { object_id, .. } => Some(*object_id),
-                _ => None,
-            });
-            let event_matches =
-                event_object_id
-                    .and_then(|id| state.objects.get(&id))
-                    .is_some_and(|object| {
-                        object.cast_from_zone.is_some_and(|cast_zone| {
-                            zone.is_none_or(|expected| expected == cast_zone)
-                        }) && caster_scope.as_ref().is_none_or(|scope| {
-                            object.cast_controller.is_some_and(|caster| {
-                                controller_ref_matches_player(caster, controller, scope)
-                            })
-                        }) && owner_scope.as_ref().is_none_or(|scope| {
-                            controller_ref_matches_player(object.owner, controller, scope)
-                        })
-                    });
-            event_object_id.is_some_and(|_| event_matches)
-                || source_context.is_some_and(|source| {
-                    let read = source.source_read(state);
-                    read.cast_from_zone()
-                        .is_some_and(|cast_zone| zone.is_none_or(|expected| expected == cast_zone))
-                        && caster_scope.as_ref().is_none_or(|scope| {
-                            read.cast_controller().is_some_and(|caster| {
-                                controller_ref_matches_player(caster, controller, scope)
-                            })
-                        })
-                        && owner_scope.as_ref().is_none_or(|scope| {
-                            controller_ref_matches_player(read.owner(), controller, scope)
-                        })
+        } => trigger_subject_read(state, trigger_event, source_context).is_some_and(|read| {
+            read.cast_from_zone()
+                .is_some_and(|cast_zone| zone.is_none_or(|expected| expected == cast_zone))
+                && caster_scope.as_ref().is_none_or(|scope| {
+                    read.cast_controller().is_some_and(|caster| {
+                        controller_ref_matches_player(caster, controller, scope)
+                    })
                 })
-        }
+                && owner_scope.as_ref().is_none_or(|scope| {
+                    controller_ref_matches_player(read.owner(), controller, scope)
+                })
+        }),
         // CR 603.4 + CR 603.6a: "put onto the battlefield with this ability" —
         // the entering object was placed by THIS trigger's source ability.
         // Resolve the entering object from the ZoneChanged event (self-referential
@@ -33540,8 +33615,12 @@ pub mod tests {
         ));
     }
 
+    /// Issue #8163: Light-Paws was itself cast from hand — the normal way it
+    /// reaches the battlefield. The renamed assertion below only discriminates
+    /// the bug if the SOURCE's own cast provenance is realistic (i.e., present)
+    /// while the entering Aura's is not.
     #[test]
-    fn was_cast_false_when_aura_put_onto_battlefield_not_cast() {
+    fn was_cast_false_when_aura_put_onto_battlefield_even_though_source_was_cast() {
         let mut state = setup();
         let light_paws = create_object(
             &mut state,
@@ -33559,7 +33638,11 @@ pub mod tests {
         );
         // Aura entered via reanimation / Academy Rector-style "put onto battlefield".
         state.objects.get_mut(&aura).unwrap().cast_from_zone = None;
-        state.objects.get_mut(&light_paws).unwrap().cast_from_zone = None;
+        // REALISTIC PROVENANCE (issue #8163): Light-Paws was itself cast from hand —
+        // the normal way it reaches the battlefield. Nulling the SOURCE's
+        // `cast_from_zone`, as this test previously did, masks the source fallback and
+        // makes the assertion vacuous: it passed even while the trigger recursed.
+        state.objects.get_mut(&light_paws).unwrap().cast_from_zone = Some(Zone::Hand);
 
         let event = zone_changed_event(
             aura,
@@ -33826,6 +33909,522 @@ pub mod tests {
                 "both-axes-scoped gravecast mismatch: {label}"
             );
         }
+    }
+
+    // ---------------------------------------------------------------------
+    // Issue #8163: `TriggerCondition::WasCast` must read the TRIGGER EVENT's
+    // subject — live while it is still the entrant, its own event-record last
+    // known information once it is not (CR 608.2h + CR 113.7a) — and read the
+    // trigger SOURCE only when the event names no subject at all. See
+    // `trigger_subject_read` above the `WasCast` arm.
+    // ---------------------------------------------------------------------
+
+    /// The entry event's record owns the subject's exact event-time projection
+    /// (`GameObject::snapshot_for_zone_change`), which is what CR 608.2h reads once
+    /// the entrant has left. Built from the live STACK object so `cast_from_zone`
+    /// and `cast_controller` are the real cast stamps.
+    fn battlefield_entry_event_from_live(state: &GameState, object_id: ObjectId) -> GameEvent {
+        let object = state.objects.get(&object_id).expect("entrant exists");
+        GameEvent::ZoneChanged {
+            object_id,
+            from: Some(Zone::Stack),
+            to: Zone::Battlefield,
+            record: Box::new(object.snapshot_for_zone_change(
+                object_id,
+                Some(Zone::Stack),
+                Zone::Battlefield,
+            )),
+        }
+    }
+
+    /// Shared U4-U7 fixture: a separate SOURCE permanent (Light-Paws shape,
+    /// deliberately stamped `cast_from_zone = None` so a wrongly-consulted
+    /// source fallback answers `false`) and an ENTRANT (Feasting Troll King
+    /// shape) that was genuinely cast from hand, then left the battlefield
+    /// before the CR 603.4 re-check with its live cast provenance cleared —
+    /// exactly as `reset_for_battlefield_exit` clears it. Returns
+    /// `(state, source, entrant, entry_event)`.
+    fn was_cast_lki_fixture() -> (GameState, ObjectId, ObjectId, GameEvent) {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Light-Paws, Emperor's Voice".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&source).unwrap().cast_from_zone = None;
+
+        let entrant = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Feasting Troll King".to_string(),
+            Zone::Stack,
+        );
+        {
+            let obj = state.objects.get_mut(&entrant).unwrap();
+            obj.cast_from_zone = Some(Zone::Hand);
+            obj.cast_controller = Some(PlayerId(0));
+        }
+        let event = battlefield_entry_event_from_live(&state, entrant);
+
+        // Simulate `reset_for_battlefield_exit`: the entrant left before the
+        // CR 603.4 re-check, and its live cast provenance is cleared (CR 400.7).
+        {
+            let obj = state.objects.get_mut(&entrant).unwrap();
+            obj.zone = Zone::Graveyard;
+            obj.cast_from_zone = None;
+            obj.cast_controller = None;
+        }
+
+        (state, source, entrant, event)
+    }
+
+    /// Issue #8163, primary unit discriminator: the trigger SOURCE having been
+    /// cast must never license a different, entering SUBJECT that was NOT
+    /// cast. CR 603.4: "if you cast it" binds to the trigger event's subject,
+    /// not the ability's source.
+    #[test]
+    fn light_paws_source_was_cast_entering_aura_was_not() {
+        let mut state = setup();
+        let light_paws = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Light-Paws, Emperor's Voice".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&light_paws).unwrap().cast_from_zone = Some(Zone::Hand);
+        let aura = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Fetched Aura".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&aura).unwrap().cast_from_zone = None;
+
+        let event = zone_changed_event(
+            aura,
+            Zone::Library,
+            Zone::Battlefield,
+            vec![CoreType::Enchantment],
+            vec!["Aura"],
+        );
+
+        assert!(
+            !check_trigger_condition(
+                &state,
+                &TriggerCondition::WasCast {
+                    zone: None,
+                    controller: None,
+                    owner: None,
+                },
+                PlayerId(0),
+                Some(light_paws),
+                Some(&event),
+            ),
+            "the source's own cast provenance must never answer for a different, uncast subject"
+        );
+    }
+
+    /// Paired reach-guard for `light_paws_source_was_cast_entering_aura_was_not`:
+    /// an entrant that WAS cast must still fire, proving the negative above is
+    /// not vacuous.
+    #[test]
+    fn light_paws_entering_aura_was_cast_fires() {
+        let mut state = setup();
+        let light_paws = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Light-Paws, Emperor's Voice".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&light_paws).unwrap().cast_from_zone = Some(Zone::Hand);
+        let aura = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Cast Aura".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&aura).unwrap().cast_from_zone = Some(Zone::Hand);
+
+        let event = zone_changed_event(
+            aura,
+            Zone::Hand,
+            Zone::Battlefield,
+            vec![CoreType::Enchantment],
+            vec!["Aura"],
+        );
+
+        assert!(
+            check_trigger_condition(
+                &state,
+                &TriggerCondition::WasCast {
+                    zone: None,
+                    controller: None,
+                    owner: None,
+                },
+                PlayerId(0),
+                Some(light_paws),
+                Some(&event),
+            ),
+            "paired reach-guard for U1: an entrant that WAS cast must still fire"
+        );
+    }
+
+    /// CR 603.4: source fallback survives only when the event names no
+    /// subject at all (Cascade / Ripple / Discover / a resolution re-check
+    /// with no stored event).
+    #[test]
+    fn was_cast_source_fallback_survives_for_spell_cast_shape() {
+        let mut state = setup();
+        let cascade_spell = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Cascading Spell".to_string(),
+            Zone::Stack,
+        );
+        state
+            .objects
+            .get_mut(&cascade_spell)
+            .unwrap()
+            .cast_from_zone = Some(Zone::Hand);
+
+        assert!(
+            check_trigger_condition(
+                &state,
+                &TriggerCondition::WasCast {
+                    zone: None,
+                    controller: None,
+                    owner: None,
+                },
+                PlayerId(0),
+                Some(cascade_spell),
+                None,
+            ),
+            "the source fallback must still answer when the event names no subject at all"
+        );
+
+        state
+            .objects
+            .get_mut(&cascade_spell)
+            .unwrap()
+            .cast_from_zone = None;
+        assert!(
+            !check_trigger_condition(
+                &state,
+                &TriggerCondition::WasCast {
+                    zone: None,
+                    controller: None,
+                    owner: None,
+                },
+                PlayerId(0),
+                Some(cascade_spell),
+                None,
+            ),
+            "the source fallback answers `false` once its own cast provenance is cleared"
+        );
+    }
+
+    /// Blocker-1 unit guard: once the entrant has left the zone it was
+    /// expected in, its own event-record last known information answers the
+    /// intervening-if — never the trigger source, which is deliberately
+    /// stamped `cast_from_zone = None` in the shared fixture.
+    #[test]
+    fn was_cast_reads_event_record_lki_when_entrant_has_left() {
+        let (state, source, _entrant, event) = was_cast_lki_fixture();
+        assert!(
+            check_trigger_condition(
+                &state,
+                &TriggerCondition::WasCast {
+                    zone: None,
+                    controller: None,
+                    owner: None,
+                },
+                PlayerId(0),
+                Some(source),
+                Some(&event),
+            ),
+            "the event record's own LKI must answer once the entrant has left, per \
+             CR 608.2h — never the trigger source, which is separately stamped as NOT cast"
+        );
+    }
+
+    /// This test retires the `cast_controller` caveat (plan §3.3): it fails if
+    /// `cast_controller` is unreachable from the event record's
+    /// `TriggerSourceContext`.
+    #[test]
+    fn was_cast_record_lki_answers_zone_caster_and_owner_scopes() {
+        let (state, source, _entrant, event) = was_cast_lki_fixture();
+        assert!(
+            check_trigger_condition(
+                &state,
+                &TriggerCondition::WasCast {
+                    zone: Some(Zone::Hand),
+                    controller: Some(ControllerRef::You),
+                    owner: Some(ControllerRef::You),
+                },
+                PlayerId(0),
+                Some(source),
+                Some(&event),
+            ),
+            "fails if `cast_controller` is unreachable from the record — this test \
+             retires the cast_controller caveat (issue #8163 plan §3.3)"
+        );
+    }
+
+    /// Paired negative for `was_cast_record_lki_answers_zone_caster_and_owner_scopes`.
+    #[test]
+    fn was_cast_record_lki_rejects_wrong_caster_scope() {
+        let (state, source, _entrant, event) = was_cast_lki_fixture();
+        assert!(
+            !check_trigger_condition(
+                &state,
+                &TriggerCondition::WasCast {
+                    zone: Some(Zone::Hand),
+                    controller: Some(ControllerRef::Opponent),
+                    owner: Some(ControllerRef::You),
+                },
+                PlayerId(0),
+                Some(source),
+                Some(&event),
+            ),
+            "paired negative: the record LKI's caster does not match the Opponent scope"
+        );
+    }
+
+    /// CR 400.7: a leave + re-entry reuses the same `ObjectId` but bumps the
+    /// object's incarnation, so a re-entered object is a different object for
+    /// this trigger — it must not answer for the ORIGINAL entrant's
+    /// provenance. Mirrors `filter.rs:3026-3032`.
+    #[test]
+    fn was_cast_reads_original_entrant_lki_after_leave_and_reentry() {
+        let (mut state, source, entrant, mut event) = was_cast_lki_fixture();
+        let entered_incarnation = 5;
+        if let GameEvent::ZoneChanged { record, .. } = &mut event {
+            record.entered_incarnation = Some(entered_incarnation);
+        }
+        // The entrant left and came back as a NEW object at the same storage
+        // id, two incarnations later, with no memory of its old cast stamps.
+        {
+            let obj = state.objects.get_mut(&entrant).unwrap();
+            obj.zone = Zone::Battlefield;
+            obj.incarnation = entered_incarnation + 2;
+            obj.cast_from_zone = None;
+            obj.cast_controller = None;
+        }
+
+        assert!(
+            check_trigger_condition(
+                &state,
+                &TriggerCondition::WasCast {
+                    zone: None,
+                    controller: None,
+                    owner: None,
+                },
+                PlayerId(0),
+                Some(source),
+                Some(&event),
+            ),
+            "CR 400.7: a later incarnation at the same storage id must not answer for \
+             the original entrant — the record LKI of the ORIGINAL entry must still be read"
+        );
+    }
+
+    /// Pins the fail-closed contract: an unanswerable subject (absent from
+    /// `state.objects`, with a context-free `test_minimal` record) must never
+    /// fall back to the trigger source, even though the source WAS cast.
+    #[test]
+    fn was_cast_false_when_subject_absent_and_record_has_no_context() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Light-Paws, Emperor's Voice".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&source).unwrap().cast_from_zone = Some(Zone::Hand);
+
+        // A subject id absent from `state.objects`, with a context-free
+        // `test_minimal` record — no authority can answer for it.
+        let vanished = ObjectId(999_999);
+        let event = zone_changed_event(
+            vanished,
+            Zone::Library,
+            Zone::Battlefield,
+            vec![CoreType::Enchantment],
+            vec!["Aura"],
+        );
+
+        assert!(
+            !check_trigger_condition(
+                &state,
+                &TriggerCondition::WasCast {
+                    zone: None,
+                    controller: None,
+                    owner: None,
+                },
+                PlayerId(0),
+                Some(source),
+                Some(&event),
+            ),
+            "fail-closed: an unanswerable subject must never fall back to the source, \
+             even though the source WAS cast"
+        );
+    }
+
+    /// Proves authority selection is upstream of the zone/caster/owner axes:
+    /// the source's own `{Hand, You, You}` must not satisfy a zone-scoped
+    /// check for an entrant that wasn't cast, even though the source's stamp
+    /// would exactly satisfy the scope if it were (wrongly) consulted.
+    #[test]
+    fn was_cast_zone_scoped_reads_event_subject_not_source() {
+        let mut state = setup();
+        let wild_pair = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Wild Pair".to_string(),
+            Zone::Battlefield,
+        );
+        {
+            let obj = state.objects.get_mut(&wild_pair).unwrap();
+            obj.cast_from_zone = Some(Zone::Hand);
+            obj.cast_controller = Some(PlayerId(0));
+        }
+        let entering = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Entering Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&entering).unwrap().cast_from_zone = None;
+
+        let event = zone_changed_event(
+            entering,
+            Zone::Library,
+            Zone::Battlefield,
+            vec![CoreType::Creature],
+            Vec::new(),
+        );
+
+        assert!(
+            !check_trigger_condition(
+                &state,
+                &TriggerCondition::WasCast {
+                    zone: Some(Zone::Hand),
+                    controller: Some(ControllerRef::You),
+                    owner: Some(ControllerRef::You),
+                },
+                PlayerId(0),
+                Some(wild_pair),
+                Some(&event),
+            ),
+            "authority selection must be upstream of the scope axes: the source's \
+             matching {{Hand, You, You}} must not satisfy the check for an entrant \
+             that wasn't cast"
+        );
+    }
+
+    /// Issue #8163, opposite-polarity discriminator: `Not(WasCast)` must
+    /// invert the CORRECTED result. Preston-shaped: a reanimated (put, not
+    /// cast) creature enters while the source WAS cast from hand — today's bug
+    /// makes this a false NEGATIVE (the mirror of Light-Paws' false positive).
+    #[test]
+    fn not_was_cast_true_for_put_permanent_when_source_was_cast() {
+        let mut state = setup();
+        let preston = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Preston, the Vanisher".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&preston).unwrap().cast_from_zone = Some(Zone::Hand);
+        let reanimated = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Reanimated Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&reanimated).unwrap().cast_from_zone = None;
+
+        let event = zone_changed_event(
+            reanimated,
+            Zone::Graveyard,
+            Zone::Battlefield,
+            vec![CoreType::Creature],
+            Vec::new(),
+        );
+
+        let condition = TriggerCondition::Not {
+            condition: Box::new(TriggerCondition::WasCast {
+                zone: None,
+                controller: None,
+                owner: None,
+            }),
+        };
+
+        assert!(
+            check_trigger_condition(&state, &condition, PlayerId(0), Some(preston), Some(&event),),
+            "issue #8163, opposite polarity: a put (not cast) subject must satisfy \
+             Not(WasCast) even though the source WAS cast"
+        );
+    }
+
+    /// Paired reach-guard for `not_was_cast_true_for_put_permanent_when_source_was_cast`.
+    #[test]
+    fn not_was_cast_false_for_cast_permanent() {
+        let mut state = setup();
+        let preston = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Preston, the Vanisher".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&preston).unwrap().cast_from_zone = Some(Zone::Hand);
+        let cast_creature = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Cast Creature".to_string(),
+            Zone::Battlefield,
+        );
+        state
+            .objects
+            .get_mut(&cast_creature)
+            .unwrap()
+            .cast_from_zone = Some(Zone::Hand);
+
+        let event = zone_changed_event(
+            cast_creature,
+            Zone::Stack,
+            Zone::Battlefield,
+            vec![CoreType::Creature],
+            Vec::new(),
+        );
+
+        let condition = TriggerCondition::Not {
+            condition: Box::new(TriggerCondition::WasCast {
+                zone: None,
+                controller: None,
+                owner: None,
+            }),
+        };
+
+        assert!(
+            !check_trigger_condition(&state, &condition, PlayerId(0), Some(preston), Some(&event),),
+            "paired reach-guard: a cast subject must not satisfy Not(WasCast)"
+        );
     }
 
     /// CR 603.4 + CR 601.2h: Satoru's intervening-if must fail at resolution

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -13099,6 +13099,17 @@ fn zone_changed_condition_provenance_is_coherent(event: &GameEvent) -> bool {
 /// `None` for it. Any migration of another condition arm onto this helper MUST
 /// first establish that the provenance it reads is stamped pre-move.
 ///
+/// The live-entrant branch is also scoped to `record.to_zone == Zone::Battlefield`
+/// — CR 608.2h + CR 113.7a: only the battlefield is the "public zone it was
+/// expected in" for reading current-info characteristics such as the
+/// pre-`reset_for_battlefield_exit` cast stamps this helper's `WasCast` caller
+/// depends on; any other destination must always fall through to the record's
+/// LKI, never the live object, even when the live object still sits in
+/// `record.to_zone` with a matching incarnation. This mirrors the
+/// `destination == Zone::Battlefield` gate in `matches_zone_change_event_object_filter`
+/// (`game/filter.rs`) cited below. Any migration of another condition arm onto
+/// this helper MUST preserve this destination scope.
+///
 /// Returns `None` when the event names a subject that nothing can answer for —
 /// fail closed. A different object's provenance is NEVER substituted for the
 /// subject's; that substitution is issue #8163.
@@ -13124,13 +13135,19 @@ fn trigger_subject_read<'event, 'state>(
     };
 
     let live = state.objects.get(object_id);
+    // CR 608.2h + CR 113.7a: the live-entrant branch is scoped to battlefield
+    // destinations only, mirroring `matches_zone_change_event_object_filter`
+    // (`game/filter.rs`) — a non-battlefield destination always falls through
+    // to the record's own LKI below, even when the live object still sits in
+    // that zone with a matching incarnation.
     // CR 400.7: the live object answers only while it is still THIS entrant.
-    let is_entrant = live.is_some_and(|object| {
-        object.zone == record.to_zone
-            && record
-                .entered_incarnation
-                .is_none_or(|incarnation| object.incarnation == incarnation)
-    });
+    let is_entrant = record.to_zone == Zone::Battlefield
+        && live.is_some_and(|object| {
+            object.zone == record.to_zone
+                && record
+                    .entered_incarnation
+                    .is_none_or(|incarnation| object.incarnation == incarnation)
+        });
     if is_entrant {
         return live.map(TriggerSourceRead::ExactLive);
     }
@@ -34152,6 +34169,87 @@ pub mod tests {
             ),
             "the event record's own LKI must answer once the entrant has left, per \
              CR 608.2h — never the trigger source, which is separately stamped as NOT cast"
+        );
+    }
+
+    /// `/review-impl` LOW finding (second round): `trigger_subject_read`'s
+    /// live-entrant branch must be scoped to `record.to_zone == Zone::Battlefield`,
+    /// mirroring the `destination == Zone::Battlefield` gate in
+    /// `matches_zone_change_event_object_filter` (`game/filter.rs`). A
+    /// `ZoneChanged` event whose `to_zone` is NOT the battlefield (a
+    /// dies/exiled-shaped trigger carrying a cast-provenance intervening-if)
+    /// must never read a live object sitting in that non-battlefield
+    /// `to_zone` even when its zone and incarnation both match the record —
+    /// `entered_incarnation` is only ever stamped by battlefield entries, so a
+    /// zone-only match there would license reading a live object whose cast
+    /// stamps were already cleared. It must fall through to the event
+    /// record's own last known information (CR 608.2h + CR 113.7a).
+    #[test]
+    fn was_cast_non_battlefield_destination_reads_record_lki_not_cleared_live_object() {
+        let mut state = setup();
+        let source = create_object(
+            &mut state,
+            CardId(1),
+            PlayerId(0),
+            "Light-Paws, Emperor's Voice".to_string(),
+            Zone::Battlefield,
+        );
+        state.objects.get_mut(&source).unwrap().cast_from_zone = None;
+
+        let entrant = create_object(
+            &mut state,
+            CardId(2),
+            PlayerId(0),
+            "Feasting Troll King".to_string(),
+            Zone::Stack,
+        );
+        {
+            let obj = state.objects.get_mut(&entrant).unwrap();
+            obj.cast_from_zone = Some(Zone::Hand);
+            obj.cast_controller = Some(PlayerId(0));
+        }
+        // Non-battlefield destination: the record's projection is captured
+        // pre-move, while the entrant's real cast stamps are still live.
+        let event = GameEvent::ZoneChanged {
+            object_id: entrant,
+            from: Some(Zone::Stack),
+            to: Zone::Graveyard,
+            record: Box::new(
+                state
+                    .objects
+                    .get(&entrant)
+                    .unwrap()
+                    .snapshot_for_zone_change(entrant, Some(Zone::Stack), Zone::Graveyard),
+            ),
+        };
+
+        // The live object now sits in `record.to_zone` (Graveyard) with its
+        // cast stamps cleared, exactly as `reset_for_battlefield_exit` clears
+        // them on a battlefield departure — but `entered_incarnation` is
+        // `None` here (only battlefield entries stamp it), so a zone-only
+        // check would wrongly treat this as "still the entrant".
+        {
+            let obj = state.objects.get_mut(&entrant).unwrap();
+            obj.zone = Zone::Graveyard;
+            obj.cast_from_zone = None;
+            obj.cast_controller = None;
+        }
+
+        assert!(
+            check_trigger_condition(
+                &state,
+                &TriggerCondition::WasCast {
+                    zone: None,
+                    controller: None,
+                    owner: None,
+                },
+                PlayerId(0),
+                Some(source),
+                Some(&event),
+            ),
+            "a non-battlefield destination must never license reading the live \
+             object's cleared cast stamps -- it must fall through to the event \
+             record's LKI (CR 608.2h + CR 113.7a)"
         );
     }
 

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -13101,19 +13101,27 @@ fn zone_changed_condition_provenance_is_coherent(event: &GameEvent) -> bool {
 ///
 /// The live-entrant branch is also scoped to `record.to_zone == Zone::Battlefield`
 /// — not because CR 608.2h + CR 113.7a's "public zone it was expected in" is
-/// battlefield-only (it is not), but because CR 400.7's new-object rule makes
-/// the event record's pre-move projection a superset of the live object's
-/// provenance for every destination, while only the battlefield-exit path
-/// (`reset_for_battlefield_exit`) affirmatively clears those provenance
-/// stamps — such as the cast stamps this helper's `WasCast` caller depends
-/// on — on the live object. So for every non-battlefield destination the live
-/// object can only ever be equal-or-worse as an authority than the record's
-/// LKI, and this helper always falls through to the record's LKI there,
+/// battlefield-only (it is not), but because of ordering, not enumeration: the
+/// record's projection is captured pre-move by `snapshot_for_zone_change`
+/// (invoked at `game/zones.rs:1248`), strictly before `apply_zone_exit_cleanup`
+/// (`game/zones.rs:1298`) runs. Every path that clears a live object's
+/// provenance stamps — today `reset_for_battlefield_exit` and
+/// `clear_cast_origin_off_provenance_zones` (`game/zones.rs`) — is invoked from
+/// inside that same cleanup, so whichever one fires for a given move fires
+/// AFTER the snapshot already exists, and a future clearing path added there
+/// inherits the same ordering. So for every destination the record's LKI is
+/// always an equal-or-better authority than the live object once the subject
+/// has moved, and this helper always falls through to the record's LKI there,
 /// never the live object, even when the live object still sits in
-/// `record.to_zone` with a matching incarnation. This mirrors the
-/// `destination == Zone::Battlefield` gate in `matches_zone_change_event_object_filter`
-/// (`game/filter.rs`) cited below. Any migration of another condition arm onto
-/// this helper MUST preserve this destination scope.
+/// `record.to_zone` with a matching incarnation. Concretely: on a
+/// Stack->Graveyard move (a countered spell, no battlefield involved),
+/// `clear_cast_origin_off_provenance_zones` nulls the live object's
+/// `cast_from_zone` while the record's LKI still carries
+/// `cast_from_zone = Some(Hand)` — proof this gate is required, not merely
+/// conservative. This mirrors the `destination == Zone::Battlefield` gate in
+/// `matches_zone_change_event_object_filter` (`game/filter.rs`) cited below.
+/// Any migration of another condition arm onto this helper MUST preserve this
+/// destination scope.
 ///
 /// Returns `None` when the event names a subject that nothing can answer for —
 /// fail closed. A different object's provenance is NEVER substituted for the

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -13100,11 +13100,16 @@ fn zone_changed_condition_provenance_is_coherent(event: &GameEvent) -> bool {
 /// first establish that the provenance it reads is stamped pre-move.
 ///
 /// The live-entrant branch is also scoped to `record.to_zone == Zone::Battlefield`
-/// — CR 608.2h + CR 113.7a: only the battlefield is the "public zone it was
-/// expected in" for reading current-info characteristics such as the
-/// pre-`reset_for_battlefield_exit` cast stamps this helper's `WasCast` caller
-/// depends on; any other destination must always fall through to the record's
-/// LKI, never the live object, even when the live object still sits in
+/// — not because CR 608.2h + CR 113.7a's "public zone it was expected in" is
+/// battlefield-only (it is not), but because CR 400.7's new-object rule makes
+/// the event record's pre-move projection a superset of the live object's
+/// provenance for every destination, while only the battlefield-exit path
+/// (`reset_for_battlefield_exit`) affirmatively clears those provenance
+/// stamps — such as the cast stamps this helper's `WasCast` caller depends
+/// on — on the live object. So for every non-battlefield destination the live
+/// object can only ever be equal-or-worse as an authority than the record's
+/// LKI, and this helper always falls through to the record's LKI there,
+/// never the live object, even when the live object still sits in
 /// `record.to_zone` with a matching incarnation. This mirrors the
 /// `destination == Zone::Battlefield` gate in `matches_zone_change_event_object_filter`
 /// (`game/filter.rs`) cited below. Any migration of another condition arm onto

--- a/crates/engine/src/game/triggers.rs
+++ b/crates/engine/src/game/triggers.rs
@@ -13101,24 +13101,20 @@ fn zone_changed_condition_provenance_is_coherent(event: &GameEvent) -> bool {
 ///
 /// The live-entrant branch is also scoped to `record.to_zone == Zone::Battlefield`
 /// — not because CR 608.2h + CR 113.7a's "public zone it was expected in" is
-/// battlefield-only (it is not), but because of ordering, not enumeration: the
-/// record's projection is captured pre-move by `snapshot_for_zone_change`
-/// (invoked at `game/zones.rs:1248`), strictly before `apply_zone_exit_cleanup`
-/// (`game/zones.rs:1298`) runs. Every path that clears a live object's
-/// provenance stamps — today `reset_for_battlefield_exit` and
-/// `clear_cast_origin_off_provenance_zones` (`game/zones.rs`) — is invoked from
-/// inside that same cleanup, so whichever one fires for a given move fires
-/// AFTER the snapshot already exists, and a future clearing path added there
-/// inherits the same ordering. So for every destination the record's LKI is
-/// always an equal-or-better authority than the live object once the subject
-/// has moved, and this helper always falls through to the record's LKI there,
-/// never the live object, even when the live object still sits in
-/// `record.to_zone` with a matching incarnation. Concretely: on a
-/// Stack->Graveyard move (a countered spell, no battlefield involved),
-/// `clear_cast_origin_off_provenance_zones` nulls the live object's
-/// `cast_from_zone` while the record's LKI still carries
-/// `cast_from_zone = Some(Hand)` — proof this gate is required, not merely
-/// conservative. This mirrors the `destination == Zone::Battlefield` gate in
+/// battlefield-only (it is not), but because the PRECONDITION above cuts both
+/// ways: the projection is snapshotted (`snapshot_for_zone_change`,
+/// `game/zones.rs:1248`) before the move it describes, so once the subject
+/// has moved, whatever that move writes to the live object afterward —
+/// inline, or downstream through a callee that receives the already-built
+/// record by value, as `resolve_and_apply_zone_change` (`game/zones.rs:817`)
+/// does — necessarily lands after the snapshot. So for every destination the
+/// record's projection is an equal-or-better authority than the live object,
+/// regardless of which step does the writing or where a future one is added.
+/// Concretely: on a Stack->Graveyard move (a countered spell, no battlefield
+/// involved) the live object's `cast_from_zone` ends up cleared while the
+/// record's LKI still carries `cast_from_zone = Some(Hand)` — proof this gate
+/// is required, not merely conservative. This mirrors the
+/// `destination == Zone::Battlefield` gate in
 /// `matches_zone_change_event_object_filter` (`game/filter.rs`) cited below.
 /// Any migration of another condition arm onto this helper MUST preserve this
 /// destination scope.

--- a/crates/engine/tests/integration/issue_8163_was_cast_event_subject.rs
+++ b/crates/engine/tests/integration/issue_8163_was_cast_event_subject.rs
@@ -1,0 +1,741 @@
+//! Issue #8163: a `WasCast` intervening-if reads the TRIGGER EVENT's subject —
+//! live while it is still the entrant, its own `ZoneChangeRecord` last known
+//! information once it is not (CR 608.2h / CR 113.7a) — and reads the trigger
+//! SOURCE only when the event names no subject at all.
+//!
+//! Before the fix, `TriggerCondition::WasCast` fell through an unguarded `||` to
+//! the trigger source whenever the event's subject failed the check. A searched-up
+//! Aura has `cast_from_zone == None` (it was PUT, not cast — CR 601.2a), so
+//! Light-Paws read its OWN `Some(Hand)` stamp and re-triggered on every Aura it
+//! fetched, chain-searching the library dry.
+//!
+//! REVERT DISCRIMINATORS (three, in different directions):
+//!  * `light_paws_cast_aura_fetches_exactly_one_aura` — restore the unguarded
+//!    `||` and BOTH staged library Auras reach the battlefield.
+//!  * `preston_creates_token_for_reanimated_creature` — the same revert fails in
+//!    the OPPOSITE direction (no token at all).
+//!  * `feasting_troll_king_etb_still_makes_food_after_removal_in_response` —
+//!    guards the OTHER cliff: gating the source fallback on
+//!    `event_object_id.is_none()` (the withdrawn round-1 design) makes this
+//!    produce ZERO Food tokens, silently breaking all 61 self-referential
+//!    `WasCast` cards at the CR 603.4 resolution re-check.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0};
+use engine::game::zones::move_to_zone;
+use engine::parser::oracle::parse_oracle_text;
+use engine::types::ability::{
+    AbilityDefinition, Effect, TargetFilter, TriggerCondition, TypedFilter,
+};
+use engine::types::actions::GameAction;
+use engine::types::game_state::{GameState, StackEntryKind, WaitingFor};
+use engine::types::identifiers::ObjectId;
+use engine::types::keywords::Keyword;
+use engine::types::mana::{ManaCost, ManaCostShard, ManaType, ManaUnit};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+// ---------------------------------------------------------------------------
+// Verbatim Oracle text (data/card-data.json, confirmed in this worktree)
+// ---------------------------------------------------------------------------
+
+const LIGHT_PAWS: &str = "Whenever an Aura you control enters, if you cast it, you may search your library for an Aura card with mana value less than or equal to that Aura and with a different name than each Aura you control, put that card onto the battlefield attached to Light-Paws, then shuffle.";
+
+const FEASTING_TROLL_KING: &str = "Vigilance, trample\nWhen this creature enters, if you cast it from your hand, create three Food tokens. (They're artifacts with \"{2}, {T}, Sacrifice this token: You gain 3 life.\")\nSacrifice three Foods: Return this card from your graveyard to the battlefield. Activate only during your turn.";
+
+const PRESTON: &str = "Whenever another nontoken creature you control enters, if it wasn't cast, create a token that's a copy of that creature, except it's a 0/1 white Illusion.\n{1}{W}, Sacrifice five Illusions: Exile target nonland permanent.";
+
+const WILD_PAIR: &str = "Whenever a creature enters, if you cast it from your hand, you may search your library for a creature card with the same total power and toughness, put it onto the battlefield, then shuffle.";
+
+const SEVINNES_RECLAMATION: &str = "Return target permanent card with mana value 3 or less from your graveyard to the battlefield. If this spell was cast from a graveyard, you may copy this spell and may choose a new target for the copy.\nFlashback {4}{W} (You may cast this card from your graveyard for its flashback cost. Then exile it.)";
+
+const REANIMATE: &str = "Put target creature card from a graveyard onto the battlefield under your control. You lose life equal to that card's mana value.";
+
+// ---------------------------------------------------------------------------
+// Shared helpers
+// ---------------------------------------------------------------------------
+
+/// CR 303.4f: an Aura entering the battlefield other than by resolving as an
+/// Aura spell has its host chosen as it enters.
+fn answer_aura_hosts(runner: &mut GameRunner) {
+    while let WaitingFor::ReturnAsAuraTarget { legal_targets, .. } =
+        runner.state().waiting_for.clone()
+    {
+        let host = legal_targets
+            .first()
+            .expect("CR 303.4f offers a host")
+            .clone();
+        runner
+            .act(GameAction::ChooseTarget { target: Some(host) })
+            .expect("the chooser answers the CR 303.4f host choice");
+    }
+}
+
+/// CR 117.3b + CR 608.1: pass priority until the committed SPELL has left the
+/// stack — and stop there, BEFORE the ETB trigger it produced resolves.
+///
+/// `GameRunner::resolve_top` cannot express this window: it breaks only when
+/// `stack.len() < initial_stack_len`, and the ETB trigger pushed during the
+/// same resolving apply restores the length, so that loop resolves the
+/// trigger too. The predicate here is the stack's SHAPE.
+fn pass_until_spell_resolves(runner: &mut GameRunner) {
+    for _ in 0..8 {
+        let spell_on_stack = runner
+            .state()
+            .stack
+            .iter()
+            .any(|entry| matches!(entry.kind, StackEntryKind::Spell { .. }));
+        if !spell_on_stack {
+            return;
+        }
+        assert!(
+            matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
+            "CR 117.1: expected a priority window while the spell is on the stack, got {:?}",
+            runner.state().waiting_for
+        );
+        runner
+            .act(GameAction::PassPriority)
+            .expect("passing priority with a spell on the stack is legal");
+    }
+    panic!("the committed spell never left the stack within 8 priority passes");
+}
+
+/// Food tokens on the battlefield. CR 111.1: a token is an object, so it
+/// appears in `state.objects` like any permanent.
+fn food_tokens(state: &GameState) -> Vec<ObjectId> {
+    state
+        .objects
+        .iter()
+        .filter(|(_, o)| {
+            o.zone == Zone::Battlefield
+                && o.is_token
+                && o.card_types.subtypes.iter().any(|s| s == "Food")
+        })
+        .map(|(id, _)| *id)
+        .collect()
+}
+
+/// 0/1 white Illusion tokens on the battlefield (Preston's copy tokens).
+fn illusion_tokens(state: &GameState) -> Vec<ObjectId> {
+    state
+        .objects
+        .iter()
+        .filter(|(_, o)| {
+            o.zone == Zone::Battlefield
+                && o.is_token
+                && o.card_types.subtypes.iter().any(|s| s == "Illusion")
+        })
+        .map(|(id, _)| *id)
+        .collect()
+}
+
+fn white_mana(count: usize, id_base: u64) -> Vec<ManaUnit> {
+    (0..count)
+        .map(|i| ManaUnit::new(ManaType::White, ObjectId(id_base + i as u64), false, vec![]))
+        .collect()
+}
+
+fn green_mana(count: usize, id_base: u64) -> Vec<ManaUnit> {
+    (0..count)
+        .map(|i| ManaUnit::new(ManaType::Green, ObjectId(id_base + i as u64), false, vec![]))
+        .collect()
+}
+
+fn black_mana(count: usize, id_base: u64) -> Vec<ManaUnit> {
+    (0..count)
+        .map(|i| ManaUnit::new(ManaType::Black, ObjectId(id_base + i as u64), false, vec![]))
+        .collect()
+}
+
+/// True if any effect in `ability`'s chain (`sub_ability`/`else_ability`) is
+/// `Effect::Unimplemented` — a structural guard against a vacuous parse
+/// satisfying the runtime rows below (R1/R5) for the wrong reason.
+fn ability_chain_has_unimplemented(ability: &AbilityDefinition) -> bool {
+    matches!(ability.effect.as_ref(), Effect::Unimplemented { .. })
+        || ability
+            .sub_ability
+            .as_deref()
+            .is_some_and(ability_chain_has_unimplemented)
+        || ability
+            .else_ability
+            .as_deref()
+            .is_some_and(ability_chain_has_unimplemented)
+}
+
+// ---------------------------------------------------------------------------
+// R1/R2/R3/R4 — Light-Paws, Emperor's Voice
+// ---------------------------------------------------------------------------
+
+struct LightPawsBoard {
+    runner: GameRunner,
+    light_paws: ObjectId,
+    aura_lib_one: ObjectId,
+    aura_lib_two: ObjectId,
+    /// A fourth, distinctly-named MV-2 Aura pre-staged (and pre-funded) in
+    /// hand, uncast. R1 ignores it entirely (an uncast card in hand affects
+    /// nothing); R2 casts it afterward to prove the fix does not over-suppress.
+    aura_hand_two: ObjectId,
+}
+
+/// Casts Light-Paws for real (`cast_from_zone = Some(Hand)`), then casts one
+/// MV-2 Aura for real (also from hand) targeting Light-Paws, with two more
+/// distinctly-named MV-2 Auras staged in the library — all three MV-2 and
+/// distinctly named so that, UNDER THE BUG, the second fetch is legal on both
+/// filter axes (`Cmc LE ObjectManaValue{CostPaidObject}` and
+/// `DifferentNameFrom`). Resolves through Light-Paws' own optional search.
+fn build_and_resolve_light_paws_board() -> LightPawsBoard {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let light_paws = scenario
+        .add_creature_to_hand_from_oracle(P0, "Light-Paws, Emperor's Voice", 2, 2, LIGHT_PAWS)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::White],
+        })
+        .id();
+
+    let cast_aura = scenario
+        .add_spell_to_hand(P0, "Cast Aura One", false)
+        .as_enchantment()
+        .with_subtypes(vec!["Aura"])
+        .with_keyword(Keyword::Enchant(TargetFilter::Typed(
+            TypedFilter::creature(),
+        )))
+        .with_mana_cost(ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::White],
+        })
+        .id();
+
+    let aura_lib_one = scenario
+        .add_spell_to_library_top(P0, "Library Aura One", false)
+        .as_enchantment()
+        .with_subtypes(vec!["Aura"])
+        .with_keyword(Keyword::Enchant(TargetFilter::Typed(
+            TypedFilter::creature(),
+        )))
+        .with_mana_cost(ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::White],
+        })
+        .id();
+
+    let aura_lib_two = scenario
+        .add_spell_to_library_top(P0, "Library Aura Two", false)
+        .as_enchantment()
+        .with_subtypes(vec!["Aura"])
+        .with_keyword(Keyword::Enchant(TargetFilter::Typed(
+            TypedFilter::creature(),
+        )))
+        .with_mana_cost(ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::White],
+        })
+        .id();
+
+    let aura_hand_two = scenario
+        .add_spell_to_hand(P0, "Cast Aura Three", false)
+        .as_enchantment()
+        .with_subtypes(vec!["Aura"])
+        .with_keyword(Keyword::Enchant(TargetFilter::Typed(
+            TypedFilter::creature(),
+        )))
+        .with_mana_cost(ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::White],
+        })
+        .id();
+
+    // Enough mana for Light-Paws ({1}{W}), Cast Aura One ({1}{W}), AND the
+    // pre-staged fourth Aura ({1}{W}) that only R2 spends.
+    scenario.with_mana_pool(P0, white_mana(6, 9_000));
+
+    let mut runner = scenario.build();
+
+    runner.cast(light_paws).resolve();
+    runner
+        .cast(cast_aura)
+        .target_object(light_paws)
+        .accept_optional()
+        .search_first_legal()
+        .resolve();
+
+    LightPawsBoard {
+        runner,
+        light_paws,
+        aura_lib_one,
+        aura_lib_two,
+        aura_hand_two,
+    }
+}
+
+/// R1 — PRIMARY: exactly one cast Aura => exactly one fetch. Revert (restore
+/// the unguarded `||`) => BOTH staged library Auras reach the battlefield.
+#[test]
+fn light_paws_cast_aura_fetches_exactly_one_aura() {
+    let board = build_and_resolve_light_paws_board();
+    let one_on_bf = board.runner.state().objects[&board.aura_lib_one].zone == Zone::Battlefield;
+    let two_on_bf = board.runner.state().objects[&board.aura_lib_two].zone == Zone::Battlefield;
+    assert_eq!(
+        one_on_bf as u8 + two_on_bf as u8,
+        1,
+        "exactly one library Aura must be fetched, got aura_lib_one on Battlefield={one_on_bf} \
+         aura_lib_two on Battlefield={two_on_bf}"
+    );
+    let fetched = if one_on_bf {
+        board.aura_lib_one
+    } else {
+        board.aura_lib_two
+    };
+    // R4 — attach guard: the fetch completed, not a no-op masquerading as "one".
+    assert_eq!(
+        board.runner.state().objects[&fetched].attached_to,
+        Some(engine::game::game_object::AttachTarget::Object(
+            board.light_paws
+        )),
+        "CR 701.3: the fetched Aura must attach to Light-Paws"
+    );
+}
+
+/// R2 — reach-guard for R1: the fix must not over-suppress. A FOURTH,
+/// distinctly-named, genuinely cast MV-2 Aura must still fetch the Aura R1
+/// left stranded in the library.
+#[test]
+fn light_paws_second_cast_aura_fetches_the_remaining_aura() {
+    let mut board = build_and_resolve_light_paws_board();
+    let stranded = if board.runner.state().objects[&board.aura_lib_one].zone == Zone::Library {
+        board.aura_lib_one
+    } else {
+        board.aura_lib_two
+    };
+    assert_eq!(
+        board.runner.state().objects[&stranded].zone,
+        Zone::Library,
+        "reach-guard: R1's board leaves exactly one library Aura stranded"
+    );
+
+    board
+        .runner
+        .cast(board.aura_hand_two)
+        .target_object(board.light_paws)
+        .accept_optional()
+        .search_first_legal()
+        .resolve();
+
+    assert_eq!(
+        board.runner.state().objects[&stranded].zone,
+        Zone::Battlefield,
+        "a genuinely cast Aura must still fetch the previously-stranded library Aura"
+    );
+}
+
+/// R3 — structural guard against a vacuous parse.
+#[test]
+fn light_paws_parses_with_no_unimplemented() {
+    let parsed = parse_oracle_text(
+        LIGHT_PAWS,
+        "Light-Paws, Emperor's Voice",
+        &[],
+        &["Creature".to_string()],
+        &[],
+    );
+    let trigger = parsed
+        .triggers
+        .first()
+        .expect("Light-Paws must parse an ETB trigger");
+    assert_eq!(
+        trigger.condition,
+        Some(TriggerCondition::WasCast {
+            zone: None,
+            controller: None,
+            owner: None,
+        }),
+        "Light-Paws' intervening-if must be the zoneless WasCast"
+    );
+    assert!(
+        trigger.optional,
+        "the search must be parsed as optional (\"you may\")"
+    );
+    let execute = trigger
+        .execute
+        .as_deref()
+        .expect("Light-Paws' trigger must carry an execute ability");
+    assert!(
+        !ability_chain_has_unimplemented(execute),
+        "Light-Paws must parse with zero Effect::Unimplemented in its trigger chain"
+    );
+}
+
+/// R5 — put-not-cast: an Aura returned from the graveyard (not cast) must not
+/// trigger Light-Paws' search, even though `.accept_optional().search_first_legal()`
+/// is armed and WOULD fetch if the trigger wrongly fired.
+#[test]
+fn light_paws_put_aura_does_not_trigger() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let light_paws = scenario
+        .add_creature_to_hand_from_oracle(P0, "Light-Paws, Emperor's Voice", 2, 2, LIGHT_PAWS)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::White],
+        })
+        .id();
+
+    let graveyard_aura = scenario
+        .add_spell_to_graveyard(P0, "Graveyard Aura", false)
+        .as_enchantment()
+        .with_subtypes(vec!["Aura"])
+        .with_keyword(Keyword::Enchant(TargetFilter::Typed(
+            TypedFilter::creature(),
+        )))
+        .with_mana_cost(ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::White],
+        })
+        .id();
+
+    let library_aura = scenario
+        .add_spell_to_library_top(P0, "Library Aura", false)
+        .as_enchantment()
+        .with_subtypes(vec!["Aura"])
+        .with_keyword(Keyword::Enchant(TargetFilter::Typed(
+            TypedFilter::creature(),
+        )))
+        .with_mana_cost(ManaCost::Cost {
+            generic: 1,
+            shards: vec![ManaCostShard::White],
+        })
+        .id();
+
+    let sevinnes = scenario
+        .add_spell_to_hand_from_oracle(P0, "Sevinne's Reclamation", false, SEVINNES_RECLAMATION)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 2,
+            shards: vec![ManaCostShard::White],
+        })
+        .id();
+
+    scenario.with_mana_pool(P0, white_mana(5, 9_200));
+
+    let mut runner = scenario.build();
+
+    runner.cast(light_paws).resolve();
+    runner
+        .cast(sevinnes)
+        .target_object(graveyard_aura)
+        .accept_optional()
+        .search_first_legal()
+        .resolve();
+    answer_aura_hosts(&mut runner);
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&graveyard_aura].zone,
+        Zone::Battlefield,
+        "reach-guard: Sevinne's Reclamation returned the graveyard Aura"
+    );
+    assert_eq!(
+        runner.state().objects[&library_aura].zone,
+        Zone::Library,
+        "CR 601.2a: a put (not cast) Aura must not trigger Light-Paws' search"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// R6 — Wild Pair (three-axis: zone + caster + owner)
+// ---------------------------------------------------------------------------
+
+/// R6 — three-axis: Wild Pair cast from hand, so its own `Some(Hand)/P0/P0`
+/// exactly satisfies `{Hand, You, You}`. Two matching library creatures (same
+/// total P/T as each other AND as the genuinely cast creature) let a wrongly
+/// re-fetched first library creature's own entry recurse onto the second
+/// under the bug (Light-Paws-shaped recursion, driven by Wild Pair's own cast
+/// stamp).
+#[test]
+fn wild_pair_cast_creature_fetches_exactly_one() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let wild_pair = scenario
+        .add_spell_to_hand(P0, "Wild Pair", false)
+        .as_enchantment()
+        .from_oracle_text(WILD_PAIR)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 4,
+            shards: vec![ManaCostShard::Green, ManaCostShard::Green],
+        })
+        .id();
+
+    let library_one = scenario
+        .add_creature_to_hand(P0, "Library Beast One", 2, 2)
+        .id();
+    let library_two = scenario
+        .add_creature_to_hand(P0, "Library Beast Two", 2, 2)
+        .id();
+    let cast_creature = scenario
+        .add_creature_to_hand(P0, "Cast Beast", 2, 2)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+
+    scenario.with_mana_pool(P0, green_mana(6, 9_300));
+
+    let mut runner = scenario.build();
+    move_to_zone(
+        runner.state_mut(),
+        library_one,
+        Zone::Library,
+        &mut Vec::new(),
+    );
+    move_to_zone(
+        runner.state_mut(),
+        library_two,
+        Zone::Library,
+        &mut Vec::new(),
+    );
+
+    runner.cast(wild_pair).resolve();
+    runner
+        .cast(cast_creature)
+        .accept_optional()
+        .search_first_legal()
+        .resolve();
+
+    let fetched_count = [library_one, library_two]
+        .into_iter()
+        .filter(|&id| runner.state().objects[&id].zone == Zone::Battlefield)
+        .count();
+    assert_eq!(
+        fetched_count, 1,
+        "exactly one matching library creature must be fetched; revert => both"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// R7/R8 — Preston, the Vanisher (opposite polarity)
+// ---------------------------------------------------------------------------
+
+/// R7 — opposite polarity, primary discriminator: reanimating (putting, not
+/// casting) a creature must satisfy `Not(WasCast)` and create Preston's
+/// Illusion copy token. Revert (restore the unguarded `||`) fails in the
+/// OPPOSITE direction from Light-Paws: no token at all.
+#[test]
+fn preston_creates_token_for_reanimated_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let preston = scenario
+        .add_creature_to_hand_from_oracle(P0, "Preston, the Vanisher", 2, 5, PRESTON)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 3,
+            shards: vec![ManaCostShard::White],
+        })
+        .id();
+
+    let bait = scenario
+        .add_creature_to_graveyard(P0, "Grizzly Bears", 2, 2)
+        .id();
+
+    let reanimate = scenario
+        .add_spell_to_hand_from_oracle(P0, "Reanimate", false, REANIMATE)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 0,
+            shards: vec![ManaCostShard::Black],
+        })
+        .id();
+
+    let mut pool = white_mana(4, 9_400);
+    pool.extend(black_mana(1, 9_450));
+    scenario.with_mana_pool(P0, pool);
+
+    let mut runner = scenario.build();
+
+    runner.cast(preston).resolve();
+    runner.cast(reanimate).target_object(bait).resolve();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&bait].zone,
+        Zone::Battlefield,
+        "reach-guard: Reanimate put the bait creature onto the battlefield"
+    );
+    assert_eq!(
+        illusion_tokens(runner.state()).len(),
+        1,
+        "issue #8163, opposite polarity: Not(WasCast) must fire for a put (not cast) creature"
+    );
+}
+
+/// R8 — reach-guard for R7: a genuinely cast creature must NOT satisfy
+/// `Not(WasCast)`, confirming R7's token is a real decision, not an
+/// unconditional ETB copy.
+#[test]
+fn preston_makes_no_token_for_cast_creature() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let preston = scenario
+        .add_creature_to_hand_from_oracle(P0, "Preston, the Vanisher", 2, 5, PRESTON)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 3,
+            shards: vec![ManaCostShard::White],
+        })
+        .id();
+
+    let creature = scenario
+        .add_creature_to_hand(P0, "Cast Creature", 2, 2)
+        .with_mana_cost(ManaCost::generic(0))
+        .id();
+
+    scenario.with_mana_pool(P0, white_mana(4, 9_500));
+
+    let mut runner = scenario.build();
+
+    runner.cast(preston).resolve();
+    runner.cast(creature).resolve();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&creature].zone,
+        Zone::Battlefield,
+        "reach-guard: the creature was cast and resolved"
+    );
+    assert!(
+        illusion_tokens(runner.state()).is_empty(),
+        "paired reach-guard: a genuinely cast creature must not create an Illusion token"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// R9/R10 — Feasting Troll King (LKI regression, Blocker-1 first-class
+// deliverable)
+// ---------------------------------------------------------------------------
+
+/// R9 — LKI REGRESSION: Feasting Troll King is `SelfRef` with
+/// `WasCast{Hand, You, You}`. Cast it, let it resolve and enter, then remove
+/// it (through the REAL exit seam) WHILE its own ETB trigger is still on the
+/// stack, then let the trigger resolve. CR 608.2h + CR 113.7a: the event
+/// record's own last known information must still answer `{Hand, You, You}`,
+/// even though the live subject's cast stamps were cleared on exit.
+///
+/// Round-1's withdrawn design (`event_object_id.is_none() &&`) produces ZERO
+/// Food tokens here — this is the regression guard for all 61 self-referential
+/// `WasCast` cards at the CR 603.4 resolution re-check.
+#[test]
+fn feasting_troll_king_etb_still_makes_food_after_removal_in_response() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    // Staging: real printed stats (7/6) and real cost ({2}{G}{G}{G}{G}).
+    let troll = scenario
+        .add_creature_to_hand_from_oracle(P0, "Feasting Troll King", 7, 6, FEASTING_TROLL_KING)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 2,
+            shards: vec![ManaCostShard::Green; 4],
+        })
+        .id();
+    scenario.with_mana_pool(P0, green_mana(6, 9_600));
+
+    let mut runner = scenario.build();
+
+    // (1) CR 601.2i: commit the spell to the stack WITHOUT draining it. The
+    //     `CastCommit` borrow of `runner` ends at the semicolon.
+    runner.cast(troll).commit();
+
+    // (2) Pass priority until the SPELL leaves the stack — and no further.
+    pass_until_spell_resolves(&mut runner);
+
+    // (3) THE WINDOW ASSERTION. Exactly the ETB trigger is on the stack, the
+    //     permanent has entered, and nothing has resolved past it.
+    {
+        let state = runner.state();
+        assert_eq!(
+            state.stack.len(),
+            1,
+            "CR 603.3: the ETB trigger was put on the stack the next time a player would \
+             receive priority, got {:?}",
+            state.stack
+        );
+        let entry = state.stack.last().expect("one stack entry");
+        assert!(
+            matches!(entry.kind, StackEntryKind::TriggeredAbility { .. }),
+            "the sole stack entry must be the ETB trigger, got {:?}",
+            entry.kind
+        );
+        assert_eq!(
+            entry.source_id, troll,
+            "the trigger's source is Feasting Troll King"
+        );
+        assert_eq!(
+            state.objects[&troll].zone,
+            Zone::Battlefield,
+            "CR 608.3: the permanent spell resolved and entered before its trigger resolves"
+        );
+        assert!(
+            food_tokens(state).is_empty(),
+            "no Food may exist before the trigger resolves"
+        );
+    }
+
+    // (4) Removal in response, through the REAL exit seam (pre-move snapshot
+    //     zones.rs:1248 -> apply_zone_exit_cleanup :1298 -> reset_for_battlefield_exit,
+    //     which clears cast_from_zone / cast_controller on the LIVE object per CR 400.7).
+    move_to_zone(runner.state_mut(), troll, Zone::Graveyard, &mut Vec::new());
+    assert_eq!(
+        runner.state().objects[&troll].cast_from_zone,
+        None,
+        "CR 400.7: the live object's cast stamp is cleared on battlefield exit — the record \
+         LKI is the only remaining authority"
+    );
+
+    // (5) Resolve the trigger. CR 603.4 re-checks the intervening-if here.
+    runner.advance_until_stack_empty();
+
+    // (6) CR 608.2h + CR 113.7a: the record LKI answers {Hand, You, You}.
+    assert_eq!(
+        food_tokens(runner.state()).len(),
+        3,
+        "three Food tokens (CR 113.7a)"
+    );
+}
+
+/// R10 — reach-guard for R9: a REANIMATED (put, not cast) Feasting Troll King
+/// must create ZERO Food tokens, confirming R9's Foods are a real `WasCast`
+/// decision, not an unconditional ETB. Reanimate drives the real put through
+/// the real pipeline, and the explicit drain guarantees the trigger had its
+/// chance to resolve.
+#[test]
+fn feasting_troll_king_reanimated_makes_no_food() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let troll = scenario
+        .add_creature_to_graveyard(P0, "Feasting Troll King", 7, 6)
+        .from_oracle_text(FEASTING_TROLL_KING)
+        .id();
+
+    let reanimate = scenario
+        .add_spell_to_hand_from_oracle(P0, "Reanimate", false, REANIMATE)
+        .with_mana_cost(ManaCost::Cost {
+            generic: 0,
+            shards: vec![ManaCostShard::Black],
+        })
+        .id();
+
+    scenario.with_mana_pool(P0, black_mana(1, 9_700));
+
+    let mut runner = scenario.build();
+
+    runner.cast(reanimate).target_object(troll).resolve();
+    runner.advance_until_stack_empty();
+
+    assert_eq!(
+        runner.state().objects[&troll].zone,
+        Zone::Battlefield,
+        "reach-guard: the Troll was actually reanimated"
+    );
+    assert!(
+        food_tokens(runner.state()).is_empty(),
+        "put-into-play (not cast) must not create Food tokens"
+    );
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -784,6 +784,7 @@ mod issue_788_unexpectedly_absent;
 mod issue_7945_free_grant_face_down;
 mod issue_8024_terminal_rest_captures;
 mod issue_8101_candelabra_target_selection;
+mod issue_8163_was_cast_event_subject;
 mod issue_8183_static_gate_fail_open;
 mod issue_822_erode_path_to_exile_search_controller;
 mod issue_828_full_throttle;


### PR DESCRIPTION
## Summary

Fixes the `WasCast` intervening-if ("if you cast it") so it reads the **trigger event's subject** rather than falling through to the trigger **source's** cast provenance. Light-Paws, Emperor's Voice was itself cast from hand, so every Aura its ability searched up and *put* onto the battlefield read as "cast" and re-triggered the ability, chain-searching the library until no legal target remained.

Closes #8163

## Files changed

- `crates/engine/src/game/triggers.rs`
- `crates/engine/tests/integration/issue_8163_was_cast_event_subject.rs` (new)
- `crates/engine/tests/integration/main.rs`

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

<!-- Honest breakdown, since two models contributed and both appear in the commit
trailers: planning, every review round, and orchestration ran on claude-opus-5;
the implementation commits were authored by claude-sonnet-5 at the maintainer's
direction. Both are Frontier tier per AI-CONTRIBUTOR.md 0.1.1, so the gate is
satisfied either way. -->

## Implementation method (required)

Method: /engine-implementer

## CR references

- **CR 601.2a** — casting moves the card to the stack, so a permanent *put* onto the battlefield was never cast
- **CR 603.4** — the intervening-if pronoun binds to the trigger event's subject; rechecked on resolution
- **CR 608.2h** + **CR 113.7a** — a subject no longer in its expected zone is read from last known information
- **CR 400.7** — a leave and re-entry is a new object
- **CR 603.2c**, **CR 603.3**, **CR 603.5**, **CR 601.2i**, **CR 608.1**, **CR 608.3**, **CR 117.1**, **CR 117.3b**, **CR 111.1**, **CR 303.4f**, **CR 701.3**, **CR 701.23** — cited in the evaluator and the new integration module

The change also **corrects a pre-existing CR over-reading** in the arm's doc block: it asserted that CR 603.4 removes an ability from the stack if its *source* has left the relevant zone. CR 603.4 says nothing about the source's zone, and CR 113.7a says the opposite ("Destruction or removal of the source after that time won't affect the ability").

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — exit 0
- `cargo clippy-strict` — exit 0, clean, full workspace
- `cargo test -p phase-engine` — exit 0: lib 20298 passed / 0 failed / 6 ignored; 21 passed; 9 passed; integration 5874 passed / 0 failed / 2 ignored; doc-tests 0 passed / 7 ignored
- `cargo test -p phase-engine --test integration issue_8163` — 9 passed / 0 failed
- `cargo test -p phase-engine --lib was_cast` — 18 passed / 0 failed
- `./scripts/check-parser-combinators.sh` — Gate A PASS (below)
- `git status --short` — empty
- `git diff --stat upstream/main...HEAD` — 3 files, 1493 insertions(+), 45 deletions(-)

**Pre-fix RED check** (AI-CONTRIBUTOR 6-7). Tests were written and run *before* the production change:
- RED pre-fix: R1 (fetched 2 Auras, not 1 — the reported recursion, reproduced), R6 (2 not 1), R7 (0 tokens, not 1), the corrected unit test, and units U1/U5/U9/U10. Bonus RED: U4, U7, U8, R5, R2.
- GREEN pre-fix, as required: R9 and R10 — they guard behavior that is already correct today and would break under a rejected earlier design (see *Scope Expansion*).
- Nothing failed to compile at any point, so every result is a genuine pass/fail.

**Deviation, stated rather than omitted:** completion verification ran in the implementation worktree (`HEAD == CANDIDATE_SHA`) rather than a separate detached worktree. The only untracked-dirty files at the time were `client/src/wasm/*.d.ts`, TypeScript declarations regenerated by `scripts/setup.sh` that cannot affect a Rust build; they were restored before the scope gate, which is empty. A pristine detached worktree would have forced a full cold rebuild for no additional signal.

## Gate A

Gate A PASS head=f38203814f09d4cb955e8bab319c071c9d0f7cce base=e0c395f451a8bd8842f7e57acfdbe94877ca2adf

## Anchored on

- `crates/engine/src/game/filter.rs:3005` — `matches_zone_change_event_object_filter`'s `if destination == Zone::Battlefield` live-vs-LKI dispatch: the same "read the entrant live while it is still the entrant, else its LKI" rule, already solved in production for ETB trigger *filters*. This change applies it to ETB trigger *conditions* using the same `entered_incarnation` discriminator.
- `crates/engine/src/game/triggers.rs:13539` — `TriggerCondition::AdditionalCostPaid`, the adjacent arm using the same event-subject-first / source-only-when-absent discipline (`if let Some(event_object_id) = … { event read } else { source read }`).
- `crates/engine/src/game/triggers.rs:13500` — `TriggerCondition::PlacedByAbilitySource`, gating its source fallback on `event_object_id.is_none()`.

## Final review-impl

Final review-impl PASS head=f38203814f09d4cb955e8bab319c071c9d0f7cce

## Claimed parse impact

None. No file under `crates/engine/src/parser/` is touched and the AST is unchanged — the parser already emitted `TriggerCondition::WasCast` correctly. Coverage status for all `WasCast` cards is unchanged; only runtime behavior changes.

## Scope Expansion

None.

<!-- Context that may be useful in review, not a scope claim:

WHY THIS IS A CLASS FIX, NOT A CARD FIX. The bug is in the condition evaluator,
so it corrects every card whose cast-provenance intervening-if sits on a trigger
whose subject can be a different permanent than the source — 12 cards, across all
four axis combinations (bare, zone-scoped, caster/owner-scoped, and Not-wrapped):
Light-Paws, Wild Pair, Prototype X-8, The Sibsig Ceremony, Mirror of Life
Trapping, Prized Amalgam, Grist, Twilight Diviner, Preston, Rapid Augmenter,
Chainer, Satoru. The remaining 61 self-referential cards are the regression
surface and are protected.

BOTH POLARITIES. Light-Paws false-positived; Preston, the Vanisher ("if it
wasn't cast") false-negatived and silently failed to create its token. A
"just return false" special case would fix one and leave the other broken.

A REJECTED DESIGN, RECORDED BECAUSE R9/R10 EXIST TO GUARD IT. The first design
gated the source fallback on `event_object_id.is_none()`. Plan review proved
that regresses all 61 self-referential cards at the CR 603.4 resolution
re-check: `reset_for_battlefield_exit` clears `cast_from_zone` on the live
object while the record's pre-move projection preserves it, so "cast Feasting
Troll King, opponent removes it in response to the ETB trigger, trigger
resolves" must still satisfy the intervening-if per CR 608.2h / CR 113.7a.
R9 and R10 pass before and after this change and fail under that design.

TWO PRE-EXISTING TESTS PASSED WITH THE BUG PRESENT, which is how it shipped:
- the `WasCast` unit test nulled the SOURCE's `cast_from_zone`, masking the
  fallback it claimed to exclude. Corrected here to the realistic configuration
  and renamed.
- `tests/integration/issue_4824_light_paws_aura_attach.rs` stages Light-Paws
  directly onto the battlefield (so there is no cast stamp) and stages only one
  library Aura (so a recursion has nothing to fetch second). The new fixture
  casts Light-Paws for real and stages three MV-2, distinctly-named Auras so the
  recursive fetch is legal on both of Light-Paws' filter axes.

DEFERRED, WITH THE REASON IN THE CODE. `WasPlayed` (triggers.rs:13523),
`AdditionalCostPaid` (:13539) and `PlacedByAbilitySource` (:13500) were checked
and deliberately not migrated. `PlacedByAbilitySource` structurally cannot use
the new helper: `entered_via_ability_source` is stamped after the move, while
the record is snapshotted before it. That precondition is documented in the
helper's doc comment so a future migrator hits it.
-->

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected “Was Cast” trigger checks to evaluate the triggering event’s subject.
  - Preserved accurate results when permanents leave play, change zones, re-enter, or are reanimated.
  - Fixed cases where effects incorrectly fell back to the trigger source.
  - Ensured “Was Not Cast” conditions produce the correct opposite result.

- **Tests**
  - Added comprehensive regression coverage for casting, non-casting, removal, re-entry, and last-known information scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->