### PR TITLE
feat(helm): expose per-game logs via an internal-only sidecar

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -158,6 +158,10 @@ jobs:
           grep -Pzoq -- "$data_mount_ro" /tmp/logging-default.yaml
           # Only the entry Service in the default (non-scale-out) shape.
           test "$(grep -c 'targetPort: logs' /tmp/logging-default.yaml)" -eq 1
+          # Operator-only must not depend on networkPolicy.enabled: the sidecar
+          # binds loopback-only regardless, so the Service/pod-IP path is dead
+          # even if NetworkPolicy is off or the CNI doesn't enforce it.
+          grep -q 'listen 127.0.0.1:' /tmp/logging-default.yaml
 
           helm template phase-server deploy/helm/phase-server \
             --namespace phase -f /tmp/scaleout.yaml --set logging.enabled=true \
@@ -171,6 +175,25 @@ jobs:
           grep -Pzoq -- "$data_mount_ro" /tmp/logging-scaleout.yaml
           # Entry + headless + one per ordinal, at scaleOut.replicaMax 3 above.
           test "$(grep -c 'targetPort: logs' /tmp/logging-scaleout.yaml)" -eq 5
+          grep -q 'listen 127.0.0.1:' /tmp/logging-scaleout.yaml
+
+      # Pins the chosen invariant for the reported unsafe combination: with
+      # NetworkPolicy off, nothing in the chart restricts ingress by policy,
+      # so the sidecar's own loopback-only bind must be the thing that keeps
+      # it operator-only. Rendered with the ingress/scale-out values too, so
+      # the Service actually carries `targetPort: logs` while this holds.
+      - name: helm template (logging enabled, networkPolicy disabled) stays loopback-only
+        run: |
+          helm template phase-server deploy/helm/phase-server \
+            --namespace phase -f /tmp/scaleout.yaml \
+            --set logging.enabled=true --set networkPolicy.enabled=false \
+            --api-versions monitoring.coreos.com/v1 \
+            --api-versions monitoring.coreos.com/v1/PrometheusRule \
+            --api-versions monitoring.coreos.com/v1/PodMonitor \
+            --api-versions monitoring.coreos.com/v1/ServiceMonitor > /tmp/logging-no-netpol.yaml
+          if grep -q 'kind: NetworkPolicy' /tmp/logging-no-netpol.yaml; then echo "unexpected 'kind: NetworkPolicy' in /tmp/logging-no-netpol.yaml"; exit 1; fi
+          grep -q 'targetPort: logs' /tmp/logging-no-netpol.yaml
+          grep -q 'listen 127.0.0.1:' /tmp/logging-no-netpol.yaml
 
       # Regression pin: a `logging.dir` that string-prefix-matches
       # PHASE_DATA_DIR but trims to an empty (or `..`-containing) subPath

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -131,12 +131,20 @@ jobs:
       # the default and scale-out shapes.
       - name: helm template (logging enabled)
         run: |
+          # The security-relevant mount is the *combination* of subPath and
+          # read-only, not either alone: a generic `readOnly` grep can match
+          # an unrelated mount (the ConfigMap's is read-only too) and would
+          # stay green even if `readOnly: true` were dropped from this one,
+          # granting the sidecar write access to the logs subtree. Match the
+          # exact contiguous block instead of two independent greps.
+          data_mount_ro='- name: data\n\s+mountPath: /var/lib/phase-server/logs\n\s+subPath: logs\n\s+readOnly: true'
+
           helm template phase-server deploy/helm/phase-server \
             --namespace phase --set logging.enabled=true > /tmp/logging-default.yaml
           grep -q 'kind: ConfigMap' /tmp/logging-default.yaml
           grep -q 'name: PHASE_LOG_DIR' /tmp/logging-default.yaml
           grep -q 'nginxinc/nginx-unprivileged' /tmp/logging-default.yaml
-          grep -q 'subPath: logs$' /tmp/logging-default.yaml
+          grep -Pzoq -- "$data_mount_ro" /tmp/logging-default.yaml
           # Only the entry Service in the default (non-scale-out) shape.
           test "$(grep -c 'targetPort: logs' /tmp/logging-default.yaml)" -eq 1
 
@@ -149,7 +157,7 @@ jobs:
           grep -q 'kind: ConfigMap' /tmp/logging-scaleout.yaml
           grep -q 'name: PHASE_LOG_DIR' /tmp/logging-scaleout.yaml
           grep -q 'nginxinc/nginx-unprivileged' /tmp/logging-scaleout.yaml
-          grep -q 'subPath: logs$' /tmp/logging-scaleout.yaml
+          grep -Pzoq -- "$data_mount_ro" /tmp/logging-scaleout.yaml
           # Entry + headless + one per ordinal, at scaleOut.replicaMax 3 above.
           test "$(grep -c 'targetPort: logs' /tmp/logging-scaleout.yaml)" -eq 5
 
@@ -177,6 +185,18 @@ jobs:
             echo "expected the render to fail for a logging.dir containing '..'"; exit 1
           fi
           grep -q 'traversal-free descendant' /tmp/logging-traversal.err
+
+          # A trailing `.` string-prefix-matches PHASE_DATA_DIR just like the
+          # empty-subPath case above, and kubelet's subPath join treats a
+          # bare `.` segment as the volume root too -- reproducing the same
+          # exposure under a different disguise.
+          if helm template phase-server deploy/helm/phase-server \
+               --namespace phase --set logging.enabled=true \
+               --set logging.dir=/var/lib/phase-server/. \
+               > /tmp/logging-dot.yaml 2>/tmp/logging-dot.err; then
+            echo "expected the render to fail for logging.dir=/var/lib/phase-server/."; exit 1
+          fi
+          grep -q 'traversal-free descendant' /tmp/logging-dot.err
 
       # `scaleOut.scheme` names the URL each ordinal advertises, and the client
       # turns that string into the "CODE@host" share link a friend dials. Every

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -125,6 +125,59 @@ jobs:
           grep -q 'volumeClaimTemplates' /tmp/scaleout-render.yaml
           if grep -q 'kind: Deployment' /tmp/scaleout-render.yaml; then echo "unexpected 'kind: Deployment' in /tmp/scaleout-render.yaml"; exit 1; fi
 
+      # The read-only logs sidecar (PHASE_LOG_DIR, its ConfigMap, and the
+      # `logs` Service port) is entirely gated on `logging.enabled`, so none
+      # of the renders above ever touch it — assert it explicitly, in both
+      # the default and scale-out shapes.
+      - name: helm template (logging enabled)
+        run: |
+          helm template phase-server deploy/helm/phase-server \
+            --namespace phase --set logging.enabled=true > /tmp/logging-default.yaml
+          grep -q 'kind: ConfigMap' /tmp/logging-default.yaml
+          grep -q 'name: PHASE_LOG_DIR' /tmp/logging-default.yaml
+          grep -q 'nginxinc/nginx-unprivileged' /tmp/logging-default.yaml
+          grep -q 'subPath: logs$' /tmp/logging-default.yaml
+          # Only the entry Service in the default (non-scale-out) shape.
+          test "$(grep -c 'targetPort: logs' /tmp/logging-default.yaml)" -eq 1
+
+          helm template phase-server deploy/helm/phase-server \
+            --namespace phase -f /tmp/scaleout.yaml --set logging.enabled=true \
+            --api-versions monitoring.coreos.com/v1 \
+            --api-versions monitoring.coreos.com/v1/PrometheusRule \
+            --api-versions monitoring.coreos.com/v1/PodMonitor \
+            --api-versions monitoring.coreos.com/v1/ServiceMonitor > /tmp/logging-scaleout.yaml
+          grep -q 'kind: ConfigMap' /tmp/logging-scaleout.yaml
+          grep -q 'name: PHASE_LOG_DIR' /tmp/logging-scaleout.yaml
+          grep -q 'nginxinc/nginx-unprivileged' /tmp/logging-scaleout.yaml
+          grep -q 'subPath: logs$' /tmp/logging-scaleout.yaml
+          # Entry + headless + one per ordinal, at scaleOut.replicaMax 3 above.
+          test "$(grep -c 'targetPort: logs' /tmp/logging-scaleout.yaml)" -eq 5
+
+      # Regression pin: a `logging.dir` that string-prefix-matches
+      # PHASE_DATA_DIR but trims to an empty (or `..`-containing) subPath
+      # would mount the *entire* data PVC — games.db and its WAL included —
+      # read-only into the autoindexed sidecar, not just the logs subtree.
+      # Both must-fail cases are paired with the must-succeed render above,
+      # so the guard is proven to track the value, not to refuse the
+      # feature outright.
+      - name: helm template (logging enabled, unsafe logging.dir) must fail
+        run: |
+          if helm template phase-server deploy/helm/phase-server \
+               --namespace phase --set logging.enabled=true \
+               --set logging.dir=/var/lib/phase-server/ \
+               > /tmp/logging-root.yaml 2>/tmp/logging-root.err; then
+            echo "expected the render to fail for logging.dir at the PVC root"; exit 1
+          fi
+          grep -q 'traversal-free descendant' /tmp/logging-root.err
+
+          if helm template phase-server deploy/helm/phase-server \
+               --namespace phase --set logging.enabled=true \
+               --set logging.dir=/var/lib/phase-server/logs/../../etc \
+               > /tmp/logging-traversal.yaml 2>/tmp/logging-traversal.err; then
+            echo "expected the render to fail for a logging.dir containing '..'"; exit 1
+          fi
+          grep -q 'traversal-free descendant' /tmp/logging-traversal.err
+
       # `scaleOut.scheme` names the URL each ordinal advertises, and the client
       # turns that string into the "CODE@host" share link a friend dials. Every
       # IngressRoute the chart renders terminates TLS, so `http` is refused

--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -125,6 +125,17 @@ jobs:
           grep -q 'volumeClaimTemplates' /tmp/scaleout-render.yaml
           if grep -q 'kind: Deployment' /tmp/scaleout-render.yaml; then echo "unexpected 'kind: Deployment' in /tmp/scaleout-render.yaml"; exit 1; fi
 
+      # `logging.enabled` defaults to false (values.yaml), so the default
+      # render must carry none of the logging surface — a regression in any
+      # of the `if .Values.logging.enabled` gates would otherwise ship an
+      # opt-in component on by default with every check above staying green.
+      - name: assert logging is absent by default
+        run: |
+          if grep -q 'kind: ConfigMap' /tmp/default.yaml; then echo "unexpected 'kind: ConfigMap' in /tmp/default.yaml"; exit 1; fi
+          if grep -q 'PHASE_LOG_DIR' /tmp/default.yaml; then echo "unexpected 'PHASE_LOG_DIR' in /tmp/default.yaml"; exit 1; fi
+          if grep -q 'nginxinc/nginx-unprivileged' /tmp/default.yaml; then echo "unexpected 'nginxinc/nginx-unprivileged' in /tmp/default.yaml"; exit 1; fi
+          if grep -q 'targetPort: logs' /tmp/default.yaml; then echo "unexpected 'targetPort: logs' in /tmp/default.yaml"; exit 1; fi
+
       # The read-only logs sidecar (PHASE_LOG_DIR, its ConfigMap, and the
       # `logs` Service port) is entirely gated on `logging.enabled`, so none
       # of the renders above ever touch it — assert it explicitly, in both

--- a/deploy/helm/phase-server/README.md
+++ b/deploy/helm/phase-server/README.md
@@ -109,8 +109,13 @@ write flat text `games/<code>.log`, that commit and later write JSON-Lines
 `games/<code>.session.jsonl` + `games/<code>.events.jsonl` instead.
 
 Like `/admin`, this is never routed through the Ingress and has no
-NetworkPolicy ingress rule — it is unreachable from the public host or from
-other pods, only from an operator with cluster access:
+NetworkPolicy ingress rule. Unlike `/admin`, that policy isn't the only thing
+standing between it and other pods: the sidecar binds `127.0.0.1` only, so
+the Service/pod-IP path is refused outright even with `networkPolicy.enabled:
+false` or a CNI that doesn't enforce NetworkPolicy at all. It's reachable
+only from an operator with cluster access, via `kubectl port-forward` (which
+tunnels into the pod's own network namespace, so the loopback bind doesn't
+block it):
 
 ```bash
 kubectl -n <namespace> port-forward svc/<release>[-<ordinal>] 8080:<logging.server.port>

--- a/deploy/helm/phase-server/README.md
+++ b/deploy/helm/phase-server/README.md
@@ -95,6 +95,32 @@ storage (k3s `local-path`, hostPath) the volume is the node's root filesystem,
 and a retention window sized for a quiet week fills the disk during a busy one —
 which evicts pods, this chart's included.
 
+## Game logs
+
+`logging.enabled` sets `PHASE_LOG_DIR` to `logging.dir` (default
+`/var/lib/phase-server/logs`, a subdirectory of the existing `data` PVC — no
+second or shared volume needed) and adds a `logs` sidecar (a small
+`nginxinc/nginx-unprivileged` static file server, autoindex on) that mounts
+just that subdirectory, read-only, from the same volume: it can list and serve
+log files but never touch `games.db`. The server writes the main log
+(`phase-server.log`) and one file pair per game (`games/<code>.*`) there; the
+per-game format depends on the running image — commits before `e2e5f0ae8`
+write flat text `games/<code>.log`, that commit and later write JSON-Lines
+`games/<code>.session.jsonl` + `games/<code>.events.jsonl` instead.
+
+Like `/admin`, this is never routed through the Ingress and has no
+NetworkPolicy ingress rule — it is unreachable from the public host or from
+other pods, only from an operator with cluster access:
+
+```bash
+kubectl -n <namespace> port-forward svc/<release>[-<ordinal>] 8080:<logging.server.port>
+curl http://127.0.0.1:8080/games/
+```
+
+Under `scaleOut`, logs are per-replica (each ordinal owns its own `data` PVC),
+so port-forward the specific ordinal's Service (`<release>-<ordinal>`) — same
+as reaching that ordinal's games.
+
 ## Behind Cloudflare
 
 Traefik typically sees a SNAT'd node IP (Service `externalTrafficPolicy: Cluster`),

--- a/deploy/helm/phase-server/templates/_helpers.tpl
+++ b/deploy/helm/phase-server/templates/_helpers.tpl
@@ -96,7 +96,9 @@ traefik.ingress.kubernetes.io/router.tls.options: {{ include "phase-server.crdRe
 
 {{/* Pod annotations: the operator's own, plus the prometheus.io/* trio when
      metrics.annotations is set (for scrapers that discover by annotation
-     rather than by PodMonitor/ServiceMonitor). */}}
+     rather than by PodMonitor/ServiceMonitor), plus a checksum of the logs
+     sidecar's ConfigMap so editing it (e.g. logging.server.port) rolls the
+     pod — Kubernetes does not restart pods on ConfigMap changes on its own. */}}
 {{- define "phase-server.podAnnotations" -}}
 {{- $annotations := default (dict) .Values.podAnnotations -}}
 {{- if and .Values.metrics.enabled .Values.metrics.annotations -}}
@@ -105,9 +107,26 @@ traefik.ingress.kubernetes.io/router.tls.options: {{ include "phase-server.crdRe
       "prometheus.io/port" (printf "%v" .Values.metrics.port)
       "prometheus.io/path" .Values.metrics.path) $annotations -}}
 {{- end -}}
+{{- if .Values.logging.enabled -}}
+{{- $annotations = merge (dict
+      "checksum/logs-config" (include (print $.Template.BasePath "/logs-configmap.yaml") . | sha256sum)) $annotations -}}
+{{- end -}}
 {{- with $annotations }}
 {{- toYaml . }}
 {{- end }}
+{{- end -}}
+
+{{/* `logging.dir` as a path relative to PHASE_DATA_DIR, i.e. the
+     `subPath:` the `logs` sidecar mounts from the shared `data` volume.
+     Enforced (not just documented) because there is no other writable
+     volume for logs to land on — a value outside PHASE_DATA_DIR would mount
+     an empty, unrelated subtree into the sidecar and it would serve nothing. */}}
+{{- define "phase-server.logSubPath" -}}
+{{- $prefix := "/var/lib/phase-server/" -}}
+{{- if not (hasPrefix $prefix .Values.logging.dir) -}}
+{{- fail (printf "logging.dir %q must be a subdirectory of %s (the data PVC mount point) so the logs sidecar can mount it from the same volume." .Values.logging.dir $prefix) -}}
+{{- end -}}
+{{- trimPrefix $prefix .Values.logging.dir -}}
 {{- end -}}
 
 {{/* Middleware references for an IngressRoute.
@@ -245,6 +264,10 @@ containers:
         value: {{ .Values.server.corsOrigin | quote }}
       - name: PHASE_LOG_JSON
         value: {{ .Values.server.logJson | quote }}
+      {{- if .Values.logging.enabled }}
+      - name: PHASE_LOG_DIR
+        value: {{ .Values.logging.dir | quote }}
+      {{- end }}
       - name: RUST_LOG
         value: {{ .Values.server.rustLog | quote }}
       {{- if $scaleOut }}
@@ -324,8 +347,41 @@ containers:
     volumeMounts:
       - name: data
         mountPath: /var/lib/phase-server
-{{- if not $scaleOut }}
+  {{- if .Values.logging.enabled }}
+  - name: logs
+    image: {{ .Values.logging.server.image.repository }}:{{ .Values.logging.server.image.tag }}
+    imagePullPolicy: {{ .Values.image.pullPolicy }}
+    # Read-only static file server for `logging.dir`, diagnosis only — never
+    # write access, and only the logs subtree of `data` (not games.db).
+    securityContext:
+      readOnlyRootFilesystem: true
+      allowPrivilegeEscalation: false
+      runAsNonRoot: true
+      runAsUser: {{ .Values.logging.server.runAsUser }}
+      runAsGroup: {{ .Values.logging.server.runAsGroup }}
+      capabilities:
+        drop: ["ALL"]
+    ports:
+      - name: logs
+        containerPort: {{ .Values.logging.server.port }}
+        protocol: TCP
+    resources:
+      {{- toYaml .Values.logging.server.resources | nindent 6 }}
+    volumeMounts:
+      - name: data
+        mountPath: {{ .Values.logging.dir }}
+        subPath: {{ include "phase-server.logSubPath" . }}
+        readOnly: true
+      - name: logs-conf
+        mountPath: /etc/nginx/nginx.conf
+        subPath: nginx.conf
+        readOnly: true
+      - name: logs-tmp
+        mountPath: /tmp
+  {{- end }}
+{{- if or (not $scaleOut) .Values.logging.enabled }}
 volumes:
+{{- if not $scaleOut }}
   - name: data
     {{- if .Values.persistence.enabled }}
     persistentVolumeClaim:
@@ -333,6 +389,14 @@ volumes:
     {{- else }}
     emptyDir: {}
     {{- end }}
+{{- end }}
+{{- if .Values.logging.enabled }}
+  - name: logs-conf
+    configMap:
+      name: {{ include "phase-server.fullname" . }}-logs-conf
+  - name: logs-tmp
+    emptyDir: {}
+{{- end }}
 {{- end }}
 {{- with .Values.nodeSelector }}
 nodeSelector:

--- a/deploy/helm/phase-server/templates/_helpers.tpl
+++ b/deploy/helm/phase-server/templates/_helpers.tpl
@@ -125,17 +125,20 @@ traefik.ingress.kubernetes.io/router.tls.options: {{ include "phase-server.crdRe
      Must be a STRICT, traversal-free descendant, not the PVC root itself:
      `logging.dir: /var/lib/phase-server/` string-prefix-matches but trims to
      an empty subPath, which mounts the *entire* volume — games.db and its
-     WAL included — into the read-only autoindexed sidecar. A `..` segment
-     is rejected for the same reason (the check below is a string prefix,
-     not a filesystem walk, so `/var/lib/phase-server/../etc` would
-     otherwise also match). */}}
+     WAL included — into the read-only autoindexed sidecar. A `.` or `..`
+     path segment is rejected for the same reason: the check below is a
+     string prefix, not a filesystem walk, so `/var/lib/phase-server/../etc`
+     would otherwise also match, and kubelet's subPath join treats a bare
+     `.` segment as the volume root too (`logging.dir:
+     /var/lib/phase-server/.` trims to subPath `"."`, exactly as exposed as
+     the empty-subPath case this guard exists for). */}}
 {{- define "phase-server.logSubPath" -}}
 {{- $prefix := "/var/lib/phase-server/" -}}
 {{- if not (hasPrefix $prefix .Values.logging.dir) -}}
 {{- fail (printf "logging.dir %q must be a subdirectory of %s (the data PVC mount point) so the logs sidecar can mount it from the same volume." .Values.logging.dir $prefix) -}}
 {{- end -}}
 {{- $sub := trimPrefix $prefix .Values.logging.dir -}}
-{{- if or (eq $sub "") (regexMatch "(^|/)\\.\\.($|/)" $sub) -}}
+{{- if or (eq $sub "") (regexMatch "(^|/)\\.{1,2}($|/)" $sub) -}}
 {{- fail (printf "logging.dir %q must be a strict, traversal-free descendant of %s -- the PVC root itself (or a path containing '..') would mount the whole data volume, games.db included, into the read-only autoindexed logs sidecar, not just logs." .Values.logging.dir $prefix) -}}
 {{- end -}}
 {{- $sub -}}

--- a/deploy/helm/phase-server/templates/_helpers.tpl
+++ b/deploy/helm/phase-server/templates/_helpers.tpl
@@ -36,6 +36,15 @@ app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end -}}
 {{- end -}}
 
+{{- define "phase-server.logsImage" -}}
+{{- $img := .Values.logging.server.image -}}
+{{- if $img.digest -}}
+{{- printf "%s:%s@%s" $img.repository $img.tag $img.digest -}}
+{{- else -}}
+{{- printf "%s:%s" $img.repository $img.tag -}}
+{{- end -}}
+{{- end -}}
+
 {{/* PUBLIC_URL is what the server advertises to clients, so it is never
      guessed. Deriving it from ingress.host is only sound when that host is
      actually serving: with the ingress off it yields the values.yaml
@@ -364,7 +373,7 @@ containers:
         mountPath: /var/lib/phase-server
   {{- if .Values.logging.enabled }}
   - name: logs
-    image: {{ .Values.logging.server.image.repository }}:{{ .Values.logging.server.image.tag }}
+    image: {{ include "phase-server.logsImage" . }}
     imagePullPolicy: {{ .Values.image.pullPolicy }}
     # Read-only static file server for `logging.dir`, diagnosis only — never
     # write access, and only the logs subtree of `data` (not games.db).

--- a/deploy/helm/phase-server/templates/_helpers.tpl
+++ b/deploy/helm/phase-server/templates/_helpers.tpl
@@ -120,13 +120,25 @@ traefik.ingress.kubernetes.io/router.tls.options: {{ include "phase-server.crdRe
      `subPath:` the `logs` sidecar mounts from the shared `data` volume.
      Enforced (not just documented) because there is no other writable
      volume for logs to land on — a value outside PHASE_DATA_DIR would mount
-     an empty, unrelated subtree into the sidecar and it would serve nothing. */}}
+     an empty, unrelated subtree into the sidecar and it would serve nothing.
+
+     Must be a STRICT, traversal-free descendant, not the PVC root itself:
+     `logging.dir: /var/lib/phase-server/` string-prefix-matches but trims to
+     an empty subPath, which mounts the *entire* volume — games.db and its
+     WAL included — into the read-only autoindexed sidecar. A `..` segment
+     is rejected for the same reason (the check below is a string prefix,
+     not a filesystem walk, so `/var/lib/phase-server/../etc` would
+     otherwise also match). */}}
 {{- define "phase-server.logSubPath" -}}
 {{- $prefix := "/var/lib/phase-server/" -}}
 {{- if not (hasPrefix $prefix .Values.logging.dir) -}}
 {{- fail (printf "logging.dir %q must be a subdirectory of %s (the data PVC mount point) so the logs sidecar can mount it from the same volume." .Values.logging.dir $prefix) -}}
 {{- end -}}
-{{- trimPrefix $prefix .Values.logging.dir -}}
+{{- $sub := trimPrefix $prefix .Values.logging.dir -}}
+{{- if or (eq $sub "") (regexMatch "(^|/)\\.\\.($|/)" $sub) -}}
+{{- fail (printf "logging.dir %q must be a strict, traversal-free descendant of %s -- the PVC root itself (or a path containing '..') would mount the whole data volume, games.db included, into the read-only autoindexed logs sidecar, not just logs." .Values.logging.dir $prefix) -}}
+{{- end -}}
+{{- $sub -}}
 {{- end -}}
 
 {{/* Middleware references for an IngressRoute.

--- a/deploy/helm/phase-server/templates/logs-configmap.yaml
+++ b/deploy/helm/phase-server/templates/logs-configmap.yaml
@@ -1,0 +1,36 @@
+{{- if .Values.logging.enabled }}
+{{- /* Static-file server for `logging.dir`, mounted read-only by the `logs`
+     sidecar in phase-server.podSpec. Config lives in a ConfigMap (not baked
+     into the image) so it stays generic across whatever image.repository is
+     set to. Temp/pid paths are under /tmp (an emptyDir) because the sidecar
+     runs with readOnlyRootFilesystem: true. */}}
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "phase-server.fullname" . }}-logs-conf
+  labels:
+    {{- include "phase-server.labels" . | nindent 4 }}
+data:
+  nginx.conf: |
+    worker_processes 1;
+    pid /tmp/nginx.pid;
+    events {
+      worker_connections 64;
+    }
+    http {
+      client_body_temp_path /tmp/client_temp;
+      proxy_temp_path /tmp/proxy_temp;
+      fastcgi_temp_path /tmp/fastcgi_temp;
+      uwsgi_temp_path /tmp/uwsgi_temp;
+      scgi_temp_path /tmp/scgi_temp;
+      access_log /dev/stdout;
+      error_log /dev/stderr;
+      server {
+        listen {{ .Values.logging.server.port }};
+        autoindex on;
+        location / {
+          root {{ .Values.logging.dir }};
+        }
+      }
+    }
+{{- end }}

--- a/deploy/helm/phase-server/templates/logs-configmap.yaml
+++ b/deploy/helm/phase-server/templates/logs-configmap.yaml
@@ -26,7 +26,14 @@ data:
       access_log /dev/stdout;
       error_log /dev/stderr;
       server {
-        listen {{ .Values.logging.server.port }};
+        # Loopback-only: the pod's network namespace is shared by every
+        # container in it, so `kubectl port-forward` (which tunnels into
+        # that namespace and connects to localhost) still reaches this, but
+        # traffic arriving on the pod's real interface — from the Service,
+        # another pod, or a CNI that silently doesn't enforce NetworkPolicy
+        # — gets refused outright. Operator-only stays true independent of
+        # networkPolicy.enabled.
+        listen 127.0.0.1:{{ .Values.logging.server.port }};
         autoindex on;
         location / {
           root {{ .Values.logging.dir }};

--- a/deploy/helm/phase-server/templates/service-ordinals.yaml
+++ b/deploy/helm/phase-server/templates/service-ordinals.yaml
@@ -22,6 +22,12 @@ spec:
       targetPort: metrics
       protocol: TCP
     {{- end }}
+    {{- if .Values.logging.enabled }}
+    - name: logs
+      port: {{ .Values.logging.server.port }}
+      targetPort: logs
+      protocol: TCP
+    {{- end }}
   selector:
     {{- include "phase-server.selectorLabels" . | nindent 4 }}
 {{- range $i := until (int .Values.scaleOut.replicaMax) }}
@@ -44,6 +50,12 @@ spec:
       port: {{ $.Values.service.port }}
       targetPort: http
       protocol: TCP
+    {{- if $.Values.logging.enabled }}
+    - name: logs
+      port: {{ $.Values.logging.server.port }}
+      targetPort: logs
+      protocol: TCP
+    {{- end }}
   selector:
     {{- include "phase-server.selectorLabels" $ | nindent 4 }}
     statefulset.kubernetes.io/pod-name: {{ $fullname }}-{{ $i }}

--- a/deploy/helm/phase-server/templates/service.yaml
+++ b/deploy/helm/phase-server/templates/service.yaml
@@ -17,5 +17,11 @@ spec:
       targetPort: metrics
       protocol: TCP
     {{- end }}
+    {{- if .Values.logging.enabled }}
+    - name: logs
+      port: {{ .Values.logging.server.port }}
+      targetPort: logs
+      protocol: TCP
+    {{- end }}
   selector:
     {{- include "phase-server.selectorLabels" . | nindent 4 }}

--- a/deploy/helm/phase-server/values.yaml
+++ b/deploy/helm/phase-server/values.yaml
@@ -52,6 +52,30 @@ persistence:
   storageClass: ""     # "" = cluster default
   existingClaim: ""
 
+# PHASE_LOG_DIR: main log (phase-server.log) + one file pair per game
+# (games/<code>.*) for diagnosis. Off by default — nothing writes here until
+# enabled. `dir` must be a subdirectory of PHASE_DATA_DIR (/var/lib/phase-server):
+# logs land on the same per-ordinal `data` PVC already mounted, so no second or
+# shared (RWX) volume is needed.
+logging:
+  enabled: false
+  dir: /var/lib/phase-server/logs
+  # Sidecar that serves `dir` read-only for diagnosis (autoindex on). Never
+  # routed through the public Ingress or allowed by NetworkPolicy — reach it
+  # the same way as /admin: `kubectl port-forward svc/<release>[-<ordinal>]
+  # <server.port>` (see README).
+  server:
+    image:
+      repository: nginxinc/nginx-unprivileged
+      tag: 1.27-alpine
+    # The image's own non-root uid/gid; change together if you swap the image.
+    runAsUser: 101
+    runAsGroup: 101
+    port: 8080
+    resources:
+      requests: { cpu: 5m, memory: 8Mi }
+      limits: { memory: 32Mi }
+
 resources:
   requests:
     cpu: 250m

--- a/deploy/helm/phase-server/values.yaml
+++ b/deploy/helm/phase-server/values.yaml
@@ -68,6 +68,10 @@ logging:
     image:
       repository: nginxinc/nginx-unprivileged
       tag: 1.27-alpine
+      # Multi-arch index digest for the tag above, pinned so a registry-side
+      # retag can't change what's pulled without a reviewed values.yaml change.
+      # Re-resolve with: docker buildx imagetools inspect nginxinc/nginx-unprivileged:<tag>
+      digest: sha256:65e3e85dbaed8ba248841d9d58a899b6197106c23cb0ff1a132b7bfe0547e4c0
     # The image's own non-root uid/gid; change together if you swap the image.
     runAsUser: 101
     runAsGroup: 101


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Wires `PHASE_LOG_DIR` (per-game logs, #7978/#8245) into the k3s Helm chart via a
values-gated, internal-only `logs` sidecar, so game logs on the cluster are
reachable for diagnosis without phase-server itself serving files (prior
ruling on #7978: log access/lifecycle is infra's job, not the app's).

## Files changed

- `deploy/helm/phase-server/values.yaml` — new `logging.*` block (off by default)
- `deploy/helm/phase-server/templates/logs-configmap.yaml` — new: nginx.conf for the sidecar
- `deploy/helm/phase-server/templates/_helpers.tpl` — `PHASE_LOG_DIR` env, `logs` sidecar container, `logSubPath` helper, volumes restructure, checksum annotation
- `deploy/helm/phase-server/templates/service.yaml` / `service-ordinals.yaml` — `logs` port on the entry/headless/per-ordinal Services
- `deploy/helm/phase-server/README.md` — new "Game logs" section

## Track

Developer

## LLM

Model: claude-sonnet-5
Tier: Frontier
Thinking: high (harness-configured for this agent; exact reasoning-effort tier not introspectable from the model side)

## Implementation method (required)

Method: not-applicable — chart-only infrastructure change (`deploy/helm/phase-server/**`); no `crates/engine/` or other Rust/TypeScript files touched.

## CR references

None (infra-only change, no game rules touched).

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [ ] Gate A output below is for the current committed head. — not applicable, no engine change (see Implementation method)
- [ ] Final review-impl below is clean for the current committed head. — not applicable, no engine change
- [ ] Both anchors cite existing analogous code at the same seam. — not applicable, no engine change

- `helm lint deploy/helm/phase-server` — `1 chart(s) linted, 0 chart(s) failed` (default values, and again with `logging.enabled=true` × `scaleOut.enabled={true,false}`)
- `helm template ...` with `logging.enabled=true` × `scaleOut.enabled={true,false}` — renders clean; verified the `logs` sidecar, ConfigMap, and per-Service `logs:8080` port all appear with correct `subPath`/mount wiring
- `helm template ... --set logging.dir=/tmp/elsewhere` — fails render as designed: `logging.dir "/tmp/elsewhere" must be a subdirectory of /var/lib/phase-server/ ...`
- `helm upgrade phase-server . -n phase --dry-run=server -f <live values> --set logging.enabled=true` — clean against the live cluster/CRDs
- Applied for real: `helm upgrade` (release `phase-server`, namespace `phase`, cluster is this repo's owner's personal k3s deployment) — pod rolled `2/2 Running`, 0 restarts throughout all verification below
- Live, non-vacuous verification: created real games over the WebSocket wire protocol (not synthetic files) against the live server, then fetched real content through the new internal endpoint via `kubectl port-forward`:
  - `curl http://<svc>:8080/phase-server.log.2026-09-01` → 12709 bytes of real tracing content (positive control)
  - `curl http://<svc>:8080/games/` → reachable, correctly empty (see note below)
  - Confirmed no public route: all 4 live IngressRoutes route only to port 9374; the live NetworkPolicy's ingress rules cover only ports `http`/`metrics`, none for `logs` — default-deny applies, matching this chart's existing `/admin` (port-forward-only) convention
- No cargo/pnpm build required or run — chart-only change, no code paths compiled

**Note on per-game log content**: the currently-deployed image (`v0.69.0`, an ancestor
of `e2e5f0ae8`) never actually writes a `games/<code>.log` file — confirmed by creating
4 real game sessions (including one that fully started vs. an AI opponent, plus a
Reconnect) and observing the main log correctly attribute events to the `game_session`
span while `games/` stayed empty on disk (`kubectl exec` also confirmed the sidecar's
mount/permissions are not the cause: a manual write to that exact path succeeds). Root
cause, read directly from `crates/phase-server/src/logging.rs` at the deployed commit:
`GameCodeVisitor::record_debug` is a no-op stub, but `set_session()` builds the span via
`game = %game_code` (Display, `%`) — tracing dispatches `%`-recorded fields through
`record_debug`, not `record_str`, so the game code is never captured onto the span and
`on_event` silently skips every write. `e2e5f0ae8`/#8245 already fixes this as a side
effect of its `SpanFieldsVisitor` rewrite (confirmed by that code's own comment: "the
real macro form (%/?) reaches record_debug ... Verified with a driven probe"). This is a
pre-existing server bug, unrelated to and out of scope for this chart-only PR, and is
already fixed on `main` — it just isn't in a released image yet. Once a newer image is
deployed, per-game logs (JSON-Lines, both `session` and `events` streams) will populate
under the same `games/` directory this PR already wires up and serves, no further chart
change needed.

## Gate A

Not applicable — chart-only change, no engine code.

## Anchored on

- `deploy/helm/phase-server/README.md` (existing `/admin` section) — the internal-only, port-forward-reachable-only pattern this PR's `logs` sidecar follows exactly (no Ingress route, no NetworkPolicy ingress rule)
- `deploy/helm/phase-server/templates/service-ordinals.yaml` (existing `metrics` port) — the precedent for adding a second, diagnostics-only named port to the entry/headless/per-ordinal Services without routing it through the Ingress

## Final review-impl

Not applicable — chart-only change, no engine code.

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added optional file-based game logging for Phase Server deployments, disabled by default.
  * Added a read-only logs service for browsing log files without modifying game data.
  * Logs can be accessed locally through port forwarding, including per-replica access when scaling out.
  * Added configurable log directory, server port, container image, security, and resource settings.

* **Documentation**
  * Documented log locations, access instructions, scaling behavior, and network exposure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->