### PR TITLE
fix(engine): recognize "defending player" as an unless-clause payer

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -14945,6 +14945,22 @@ fn resolve_unless_payer(
         TargetFilter::Player => {
             crate::game::targeting::resolve_effect_player_ref(state, ability, payer)
         }
+        // CR 508.5 + CR 118.12a: "[Effect] unless defending player [pays cost]"
+        // (Ogre Marauder). CR 508.5 fixes the payer as the player the ability's
+        // attacking source is attacking — determined per attacker, and in
+        // multiplayer one specific defending player (CR 508.5a), never all of
+        // them. `resolve_event_context_target` owns that lookup: it reads live
+        // combat state first and falls back to the defender captured on the
+        // triggering `AttackersDeclared` event once the creature has left
+        // combat, so a trigger that resolves after its attacker died still
+        // taxes the right player.
+        TargetFilter::DefendingPlayer => {
+            crate::game::targeting::resolve_event_context_target(state, payer, ability.source_id)
+                .and_then(|target| match target {
+                    TargetRef::Player(player) => Some(player),
+                    _ => None,
+                })
+        }
         // CR 118.12a + CR 608.2f: "Each player/each opponent ... unless they pay" —
         // the payer is the player_scope iteration's scoped player, not a chosen
         // target. resolve_effect_player_ref maps ScopedPlayer -> ability.scoped_player
@@ -14962,7 +14978,21 @@ fn resolve_unless_payer(
         _ if crate::game::ability_utils::payer_is_declared_target(payer) => {
             crate::game::targeting::resolve_effect_player_ref(state, ability, payer)
         }
-        _ => None,
+        // CR 118.12a: An unresolved payer yields an EMPTY poll list, which makes
+        // the caller's `!unless_payers.is_empty()` guard skip the payment
+        // entirely and apply the effect for free. That fail-open is exactly how
+        // Ogre Marauder's missing `DefendingPlayer` arm went unnoticed: the
+        // trigger resolved, nobody was taxed, and nothing anywhere said so. Warn
+        // so the next unhandled subject surfaces instead of shipping silently.
+        _ => {
+            tracing::warn!(
+                ?payer,
+                source_id = ?ability.source_id,
+                "unless-payer did not resolve to a player; the payment is skipped \
+                 and the unless-effect applies unconditionally"
+            );
+            None
+        }
     }
 }
 

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -36481,7 +36481,11 @@ pub(super) fn parse_unless_payment(lower: &str) -> Option<AbilityCost> {
     // spell's controller by `counter_unless_pay_modifier` at the call site, so
     // rewriting the recognized subject does not affect resolution.
     let normalized = normalize_counter_unless_subject(after_unless)?;
+    // The payer the subject names is discarded here on purpose: the counter
+    // path pins the payer to the targeted spell's controller at the call site
+    // (`counter_unless_pay_modifier`), per the normalization note above.
     crate::parser::oracle_trigger::parse_unless_they_alt_cost_chain(&normalized)
+        .map(|alt_cost| alt_cost.cost)
 }
 
 /// CR 117.3 + CR 107.14: Parse the mana / energy / dynamic-{X} forms of an
@@ -36811,7 +36815,7 @@ fn extract_resolution_unless_pay_modifier(
                 }),
             );
         }
-        if let Some(cost) =
+        if let Some(alt_cost) =
             crate::parser::oracle_trigger::parse_unless_they_alt_cost_chain(after_unless_lower)
         {
             // Strip the entire " unless ..." tail from the cleaned effect
@@ -36825,21 +36829,32 @@ fn extract_resolution_unless_pay_modifier(
             // preceding word. The mask preserves byte length, so `.len()` indexes
             // the original text exactly.
             let cleaned = text[..before_unless.len()].trim().to_string();
-            // CR 118.12a + CR 608.2f: select the payer for "they X". A
-            // permanent's controller in the pre-"unless" text (Fade Away)
-            // takes precedence. Otherwise, when this chunk carries a
-            // `player_scope` ("each opponent/each player ... unless they X"),
-            // the payer is the per-iteration scoped player (`ScopedPlayer`,
-            // bound by the fan-out) rather than a chosen player target.
-            // Non-scoped punishers (Tergrid's Lantern) keep `Player`.
-            let payer = if nom_primitives::scan_contains(before_unless, "controller") {
-                TargetFilter::ParentTargetController
-            } else if player_scope.is_some() {
-                TargetFilter::ScopedPlayer
-            } else {
-                TargetFilter::Player
-            };
-            return (cleaned, Some(UnlessPayModifier { cost, payer }));
+            // CR 508.5 + CR 118.12a + CR 608.2f: select the payer. A subject
+            // that NAMES its payer ("defending player" — Ogre Marauder) is
+            // authoritative; the fallbacks below only exist to find the
+            // referent of an anaphoric pronoun. A permanent's controller in
+            // the pre-"unless" text (Fade Away) takes precedence there.
+            // Otherwise, when this chunk carries a `player_scope` ("each
+            // opponent/each player ... unless they X"), the payer is the
+            // per-iteration scoped player (`ScopedPlayer`, bound by the
+            // fan-out) rather than a chosen player target. Non-scoped
+            // punishers (Tergrid's Lantern) keep `Player`.
+            let payer = alt_cost.payer.unwrap_or_else(|| {
+                if nom_primitives::scan_contains(before_unless, "controller") {
+                    TargetFilter::ParentTargetController
+                } else if player_scope.is_some() {
+                    TargetFilter::ScopedPlayer
+                } else {
+                    TargetFilter::Player
+                }
+            });
+            return (
+                cleaned,
+                Some(UnlessPayModifier {
+                    cost: alt_cost.cost,
+                    payer,
+                }),
+            );
         }
     }
 

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -3361,12 +3361,12 @@ fn extract_unless_pay_modifier(
         return (cleaned, Some(UnlessPayModifier { cost, payer }));
     }
 
-    // CR 118.12a: "[trigger] ... unless they/that player/that opponent
-    // {sacrifice|discard|pay life} [or ...]" — same disjunctive non-mana
+    // CR 118.12a: "[trigger] ... unless they/that player/that opponent/defending
+    // player {sacrifice|discard|pay life} [or ...]" — same disjunctive non-mana
     // unless-cost shape the resolution-time path handles. Delegate to the
     // single authority (`parse_unless_they_alt_cost_chain`) so trigger-side
     // and resolution-side parse identically. The chain requires an explicit
-    // pronoun ("they"/"that player"/"that opponent"), so "you"/mana forms
+    // subject (`parse_unless_payer_subject`), so "you"/mana forms
     // fall through to the existing blocks unchanged.
     //
     // GUARD: the chain's per-branch `unless_branch_boundary` stops at the
@@ -3377,11 +3377,22 @@ fn extract_unless_pay_modifier(
     // terminal unless-cost; defer to the gap path (mirrors the `unless`
     // dispatch guard below at the `Unsupported unless clause` site).
     if !has_later_sentence_if(&lower) {
-        if let Some(cost) = parse_unless_they_alt_cost_chain(after_unless) {
-            let payer = infer_pronoun_unless_payer(&lower[..unless_pos], condition_lower)
-                .unwrap_or(TargetFilter::TriggeringPlayer);
+        if let Some(alt_cost) = parse_unless_they_alt_cost_chain(after_unless) {
+            // CR 508.5: a subject that NAMES its payer ("defending player")
+            // outranks the anaphoric inference below, which exists only to
+            // find the referent of a pronoun.
+            let payer = alt_cost.payer.unwrap_or_else(|| {
+                infer_pronoun_unless_payer(&lower[..unless_pos], condition_lower)
+                    .unwrap_or(TargetFilter::TriggeringPlayer)
+            });
             let cleaned = text[..unless_pos].trim().to_string();
-            return (cleaned, Some(UnlessPayModifier { cost, payer }));
+            return (
+                cleaned,
+                Some(UnlessPayModifier {
+                    cost: alt_cost.cost,
+                    payer,
+                }),
+            );
         }
     }
 
@@ -4231,12 +4242,12 @@ fn parse_unless_counted_target_filter(rest: &str) -> Option<(u32, TargetFilter)>
     Some((count, filter))
 }
 
-/// CR 118.12 + CR 118.12a: Parse a chain of "they"-pronoun alternative
-/// payment verbs joined by " or " into either a single `AbilityCost` (one
-/// branch) or `AbilityCost::OneOf { costs }` (two or more branches). Used by
-/// the resolution-time "[Effect] unless they X or Y" pattern (Tergrid's
-/// Lantern: "Target player loses 3 life unless they sacrifice a nonland
-/// permanent of their choice or discard a card.").
+/// CR 118.12 + CR 118.12a: Parse an unless-clause subject followed by a chain
+/// of alternative payment verbs joined by " or ", into either a single
+/// `AbilityCost` (one branch) or `AbilityCost::OneOf { costs }` (two or more).
+/// Used by the resolution-time "[Effect] unless <subject> X or Y" pattern
+/// (Tergrid's Lantern: "Target player loses 3 life unless they sacrifice a
+/// nonland permanent of their choice or discard a card.").
 ///
 /// The "of their choice" qualifier on `parse_unless_they_sacrifice_filter`
 /// is structurally redundant — the runtime sacrifice-cost prompt
@@ -4245,20 +4256,30 @@ fn parse_unless_counted_target_filter(rest: &str) -> Option<(u32, TargetFilter)>
 /// must be absorbed to avoid leaving unparsed tail text on the cost.
 ///
 /// `after_unless` is the lowercase tail immediately after the literal
-/// `"unless "` prefix has been consumed; the sole caller
-/// (`extract_resolution_unless_pay_modifier`) strips the entire unless
-/// clause from the surrounding effect text using its own pre-computed
-/// `before_unless` offset, so this combinator only needs to return the
-/// parsed cost. Returns `None` if no "they X" branch is recognized.
-pub(crate) fn parse_unless_they_alt_cost_chain(after_unless: &str) -> Option<AbilityCost> {
-    let (first_cost, after_first) = parse_unless_they_single_alt_cost(after_unless)?;
+/// `"unless "` prefix has been consumed. Every caller strips the entire
+/// unless clause from the surrounding effect text using its own pre-computed
+/// offset, so this combinator returns only what the clause itself carries:
+/// the cost, plus the payer its SUBJECT names (see `parse_unless_payer_subject`
+/// — `Some` for a named role like CR 508.5's "defending player", `None` for
+/// the anaphoric pronouns, whose referent only the caller's surrounding
+/// context can supply). Returns `None` if no subject+verb branch is
+/// recognized.
+///
+/// Three production callers consume this: the trigger-side
+/// `extract_unless_pay_modifier`, the resolution-side
+/// `extract_resolution_unless_pay_modifier`, and the counter path's
+/// `parse_unless_payment` (which discards the payer — it pins the payer to the
+/// targeted spell's controller at its own call site).
+pub(crate) fn parse_unless_they_alt_cost_chain(after_unless: &str) -> Option<UnlessAltCost> {
+    let (first, after_first) = parse_unless_they_single_alt_cost(after_unless)?;
+    let payer = first.payer;
 
     // CR 118.12a: Greedily consume " or {alt_cost}" continuations to build
     // a disjunctive `OneOf`. English elides the second-clause subject
     // pronoun ("unless they sacrifice X or discard Y" — the "they" before
     // "discard" is implicit). `parse_unless_they_continuation` accepts
     // either form, dispatching by verb.
-    let mut costs = vec![first_cost];
+    let mut costs = vec![first.cost];
     let mut remainder = after_first;
     while let Ok((after_or, _)) = tag::<_, _, OracleError<'_>>(" or ").parse(remainder) {
         let Some((next_cost, after_next)) = parse_unless_they_continuation(after_or) else {
@@ -4268,33 +4289,85 @@ pub(crate) fn parse_unless_they_alt_cost_chain(after_unless: &str) -> Option<Abi
         remainder = after_next;
     }
 
-    if costs.len() == 1 {
-        costs.pop()
+    let cost = if costs.len() == 1 {
+        costs.pop()?
     } else {
-        Some(AbilityCost::OneOf { costs })
-    }
+        AbilityCost::OneOf { costs }
+    };
+    Some(UnlessAltCost { cost, payer })
 }
 
-/// CR 118.12: Parse a single "they {verb} ..." alternative payment branch.
-/// Mirrors the verb set of `parse_unless_alt_cost` but with the "they"
-/// pronoun (the target player) instead of "you" (the resolving ability's
-/// controller). Returns the cost and the unconsumed tail.
-fn parse_unless_they_single_alt_cost(input: &str) -> Option<(AbilityCost, &str)> {
-    // CR 118.12a: The first branch requires an explicit payer pronoun — it
-    // anchors the unless-clause to the paying player. The pronoun axis is
-    // parameterized: "they " (Tergrid's Lantern — a player target) and "that
-    // player " / "that opponent " (Nicol Bolas, Torment of Hailfire — the
-    // per-opponent scoped player). All forms resolve to the same payer, so
-    // only the verb dispatch downstream needs the remainder. Continuation
-    // branches omit the pronoun (English elision).
-    let (rest, _) = alt((
-        tag::<_, _, OracleError<'_>>("they "),
-        tag("that player "),
-        tag("that opponent "),
+/// CR 118.12a: An "unless [subject] [verb] …" alternative cost together with
+/// the payer its *subject* names outright.
+///
+/// The subject axis has two kinds of member (see
+/// [`parse_unless_payer_subject`]): anaphoric pronouns, which name no player of
+/// their own and leave `payer` as `None` for the caller to resolve from the
+/// surrounding effect text, and named combat/game roles, which resolve to a
+/// concrete [`TargetFilter`] here. Carrying the two in one value keeps the
+/// subject grammar in a single authority instead of forcing every caller to
+/// re-scan the clause to learn who the subject was.
+#[derive(Debug)]
+pub(crate) struct UnlessAltCost {
+    pub(crate) cost: AbilityCost,
+    /// `Some` when the clause's subject names its payer directly; `None` for
+    /// the anaphoric pronouns, whose referent only the caller's surrounding
+    /// context can supply.
+    pub(crate) payer: Option<TargetFilter>,
+}
+
+/// CR 118.12a: The subject of an "unless [subject] [verb] …" clause, as the
+/// payer it names (or `None` when it names none).
+///
+/// Two kinds of subject share this position in the grammar:
+///
+/// - **Anaphoric pronouns** — "they " (Tergrid's Lantern — a player target),
+///   "that player " / "that opponent " (Nicol Bolas, Torment of Hailfire — the
+///   per-opponent scoped player). These point back at a player the surrounding
+///   effect text established, so they carry no payer of their own; the caller
+///   infers it (`infer_pronoun_unless_payer` trigger-side, the
+///   `before_unless` scan resolution-side).
+/// - **Named roles** — CR 508.5: "defending player" is the player the
+///   attacking creature is attacking, determined per attacker and resolved
+///   from combat state, so the clause names its payer outright and no
+///   surrounding context is needed (Ogre Marauder). CR 508.5a makes this one
+///   specific player in multiplayer, which is exactly what
+///   `TargetFilter::DefendingPlayer` resolves to.
+fn parse_unless_payer_subject(input: &str) -> OracleResult<'_, Option<TargetFilter>> {
+    alt((
+        // CR 508.5: named role — the subject IS the payer.
+        value(
+            Some(TargetFilter::DefendingPlayer),
+            alt((
+                tag("the defending player "),
+                tag::<_, _, OracleError<'_>>("defending player "),
+            )),
+        ),
+        // CR 118.12a: anaphoric pronouns — payer resolved by the caller.
+        value(
+            None,
+            alt((
+                tag::<_, _, OracleError<'_>>("they "),
+                tag("that player "),
+                tag("that opponent "),
+            )),
+        ),
     ))
     .parse(input)
-    .ok()?;
-    parse_unless_they_branch_by_verb(rest)
+}
+
+/// CR 118.12: Parse a single "[subject] {verb} ..." alternative payment
+/// branch. Mirrors the verb set of `parse_unless_alt_cost` but with a payer
+/// subject (the paying player) instead of "you" (the resolving ability's
+/// controller). Returns the cost, the payer its subject names (if any), and
+/// the unconsumed tail.
+fn parse_unless_they_single_alt_cost(input: &str) -> Option<(UnlessAltCost, &str)> {
+    // CR 118.12a: The first branch requires an explicit payer subject — it
+    // anchors the unless-clause to the paying player. Continuation branches
+    // omit it (English elision).
+    let (rest, payer) = parse_unless_payer_subject(input).ok()?;
+    let (cost, after) = parse_unless_they_branch_by_verb(rest)?;
+    Some((UnlessAltCost { cost, payer }, after))
 }
 
 /// CR 118.12a: Parse the second-or-later branch of a "unless they X or Y"

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -14807,10 +14807,10 @@ fn unless_discard_cost_phrase_without_random_tail_stays_chosen() {
 /// branch for the disjunction combinator — the count axis must not swallow it.
 #[test]
 fn unless_they_discard_plural_keeps_chained_or_branch() {
-    let cost = parse_unless_they_alt_cost_chain("they discard two cards or pay 5 life")
+    let parsed = parse_unless_they_alt_cost_chain("they discard two cards or pay 5 life")
         .expect("disjunctive chain should lower");
-    let AbilityCost::OneOf { costs } = &cost else {
-        panic!("expected OneOf, got {cost:?}");
+    let AbilityCost::OneOf { costs } = &parsed.cost else {
+        panic!("expected OneOf, got {:?}", parsed.cost);
     };
     assert_eq!(costs.len(), 2, "both branches should survive: {costs:?}");
     assert!(
@@ -31171,4 +31171,169 @@ fn the_notary_hobbits_etb_copy_guards_on_token_and_strips_legendary() {
         },
         other => panic!("expected Mana effect, got {other:?}"),
     }
+}
+
+// ---------------------------------------------------------------------------
+// CR 118.12a + CR 508.5: the unless-clause PAYER SUBJECT axis
+// ---------------------------------------------------------------------------
+
+/// CR 118.12a: The anaphoric pronoun subjects ("they" / "that player" / "that
+/// opponent") name no player of their own — they point back at a player the
+/// surrounding effect text established, so the chain must report `payer: None`
+/// and leave the referent to the caller's inference. This is the invariant that
+/// keeps the named-role arm below from silently capturing the pronoun class.
+#[test]
+fn unless_pronoun_subjects_carry_no_payer_of_their_own() {
+    for subject in ["they ", "that player ", "that opponent "] {
+        let clause = format!("{subject}sacrifices a creature of their choice");
+        let parsed = parse_unless_they_alt_cost_chain(&clause)
+            .unwrap_or_else(|| panic!("pronoun subject {subject:?} must still parse"));
+        assert!(
+            parsed.payer.is_none(),
+            "anaphoric subject {subject:?} must defer its payer to the caller"
+        );
+        assert!(
+            matches!(parsed.cost, AbilityCost::Sacrifice(_)),
+            "subject {subject:?} must still reach the sacrifice verb"
+        );
+    }
+}
+
+/// CR 508.5 + CR 118.12a: "defending player" is a NAMED role, not an anaphor —
+/// CR 508.5 fixes it as the player the attacking creature is attacking, so the
+/// clause names its payer outright and the chain must surface
+/// `TargetFilter::DefendingPlayer` instead of leaving it to pronoun inference
+/// (which would fall back to the triggering player).
+///
+/// Exercised across the whole verb axis, and with the optional definite
+/// article, because the subject and verb are independent dimensions of the
+/// grammar — the payer must not depend on which cost follows it.
+#[test]
+fn unless_defending_player_subject_names_its_own_payer() {
+    for (clause, expect_cost) in [
+        (
+            "defending player sacrifices a creature of their choice",
+            "sacrifice",
+        ),
+        ("the defending player sacrifices a creature", "sacrifice"),
+        ("defending player discards a card", "discard"),
+        ("defending player pays 3 life", "life"),
+    ] {
+        let parsed = parse_unless_they_alt_cost_chain(clause)
+            .unwrap_or_else(|| panic!("{clause:?} must parse"));
+        assert_eq!(
+            parsed.payer,
+            Some(TargetFilter::DefendingPlayer),
+            "{clause:?} must name the defending player as payer (CR 508.5)"
+        );
+        let matched = matches!(
+            (&parsed.cost, expect_cost),
+            (AbilityCost::Sacrifice(_), "sacrifice")
+                | (AbilityCost::Discard { .. }, "discard")
+                | (AbilityCost::PayLife { .. }, "life")
+        );
+        assert!(
+            matched,
+            "{clause:?} must yield a {expect_cost} cost, got {:?}",
+            parsed.cost
+        );
+    }
+}
+
+/// CR 118.12a: The subject axis and the `or`-disjunction axis compose — a named
+/// role still owns the payer when the clause offers several alternative costs,
+/// and the elided continuation subject does not reset it.
+#[test]
+fn unless_defending_player_subject_survives_or_disjunction() {
+    let parsed = parse_unless_they_alt_cost_chain(
+        "defending player sacrifices a creature of their choice or discards a card",
+    )
+    .expect("disjunctive defending-player clause must parse");
+    assert_eq!(parsed.payer, Some(TargetFilter::DefendingPlayer));
+    match &parsed.cost {
+        AbilityCost::OneOf { costs } => assert_eq!(
+            costs.len(),
+            2,
+            "both alternative costs must survive, got {costs:?}"
+        ),
+        other => panic!("disjunctive unless-cost must be OneOf, got {other:?}"),
+    }
+}
+
+/// CR 508.5 + CR 118.12a + CR 701.21a: Ogre Marauder end-to-end through the
+/// trigger parser — "Whenever this creature attacks, it gains 'this creature
+/// can't be blocked' until end of turn unless defending player sacrifices a
+/// creature of their choice."
+///
+/// Before the subject axis learned "defending player", the whole clause fell
+/// through to the `Unsupported unless clause` gap: the trigger went on the
+/// stack and resolved to nothing, so the grant never applied AND the defending
+/// player was never taxed — the creature stayed blockable for free.
+///
+/// The trigger must carry BOTH halves: the unless-cost (a sacrifice paid by the
+/// defending player) and the body grant (`CantBeBlocked` on the source, until
+/// end of turn).
+#[test]
+fn ogre_marauder_attack_trigger_carries_defending_player_unless_sacrifice() {
+    use crate::types::statics::StaticMode;
+
+    let parsed = parse_oracle_text(
+        "Whenever this creature attacks, it gains \"this creature can't be blocked\" \
+         until end of turn unless defending player sacrifices a creature of their choice.",
+        "Ogre Marauder",
+        &[],
+        &["Creature".into()],
+        &["Ogre".into(), "Warrior".into()],
+    );
+
+    let trigger = parsed
+        .triggers
+        .iter()
+        .find(|t| matches!(t.mode, TriggerMode::Attacks))
+        .expect("the attack trigger must parse");
+
+    // (1) The unless-cost: CR 701.21a sacrifice, paid by the defending player.
+    let unless = trigger
+        .unless_pay
+        .as_ref()
+        .expect("the attack trigger must carry an unless-cost, not a parser gap");
+    assert_eq!(
+        unless.payer,
+        TargetFilter::DefendingPlayer,
+        "CR 508.5: the defending player pays, not the triggering player"
+    );
+    assert!(
+        matches!(unless.cost, AbilityCost::Sacrifice(_)),
+        "the unless-cost must be a sacrifice, got {:?}",
+        unless.cost
+    );
+
+    // (2) The body: the source gains "can't be blocked" until end of turn.
+    let execute = trigger.execute.as_ref().expect("execute must be Some");
+    let statics = match &*execute.effect {
+        Effect::GenericEffect {
+            static_abilities, ..
+        } => static_abilities,
+        other => panic!("body must lower to a GenericEffect grant, got {other:?}"),
+    };
+    assert!(
+        statics
+            .iter()
+            .any(|s| s.modifications.iter().any(|m| matches!(
+                m,
+                ContinuousModification::AddStaticMode {
+                    mode: StaticMode::CantBeBlocked
+                }
+            ))),
+        "the grant must add StaticMode::CantBeBlocked, got {statics:?}"
+    );
+    assert_eq!(
+        execute.duration,
+        Some(Duration::UntilEndOfTurn),
+        "the grant lasts until end of turn"
+    );
+    assert!(
+        !format!("{:?}", execute.effect).contains("Unimplemented"),
+        "the body must not fall through to a parser gap"
+    );
 }

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -945,6 +945,7 @@ mod ob_nixilis_captive_kingpin_life_loss;
 mod obeka_splitter_additional_phases;
 mod obliterate_regression;
 mod officious_interrogation_bare_strive_surcharge;
+mod ogre_marauder_defending_player_unless_sacrifice;
 mod old_growth_troll_return_as_aura;
 mod omniscience_free_cast_chalice_x;
 mod omniscience_free_cast_vexing_bauble;

--- a/crates/engine/tests/integration/ogre_marauder_defending_player_unless_sacrifice.rs
+++ b/crates/engine/tests/integration/ogre_marauder_defending_player_unless_sacrifice.rs
@@ -1,0 +1,216 @@
+//! Production-path coverage for Ogre Marauder — the "defending player" payer
+//! class of unless-costs.
+//!
+//! Oracle:
+//!   "Whenever this creature attacks, it gains \"this creature can't be
+//!    blocked\" until end of turn unless defending player sacrifices a creature
+//!    of their choice."
+//!
+//! Reported bug: the trigger went on the stack, but the defending player could
+//! still block Ogre Marauder even without sacrificing. The clause's subject —
+//! "defending player" — was not in the unless-payer subject grammar, so the
+//! whole clause fell through to an `Unsupported unless clause` gap: the trigger
+//! resolved to nothing, no payment was demanded, and no grant was applied.
+//!
+//! Both branches are asserted here, because a fix that only grants the
+//! unblockable ability (never offering the payment) and a fix that only demands
+//! the sacrifice (never granting) each look correct from one side.
+//!
+//! CR ANCHORS (verified against docs/MagicCompRules.txt):
+//!   * CR 118.12a — "[Do something] unless [a player does something else]."
+//!   * CR 508.5 — an attacking creature's ability that refers to "defending
+//!     player" means the player that creature is attacking.
+//!   * CR 508.1m — abilities that trigger on attackers being declared trigger.
+//!   * CR 509.1a — the defending player chooses which creatures block and what
+//!     each one blocks.
+//!   * CR 509.1b — a declaration that disobeys a block restriction is illegal.
+//!   * CR 701.21a — to sacrifice a permanent, its controller moves it from the
+//!     battlefield to its owner's graveyard.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use super::rules::AttackTarget;
+
+const OGRE_MARAUDER: &str = "Whenever this creature attacks, it gains \
+     \"this creature can't be blocked\" until end of turn unless defending \
+     player sacrifices a creature of their choice.";
+
+struct Board {
+    runner: GameRunner,
+    marauder: ObjectId,
+    /// P1's would-be blocker.
+    blocker: ObjectId,
+    /// A second P1 creature, so the sacrifice has a choice that is not the
+    /// blocker itself.
+    fodder: ObjectId,
+}
+
+/// Build the board, attack with Ogre Marauder, and run the trigger up to the
+/// point where the defending player must decide (CR 508.1m + CR 118.12a).
+fn attack_and_reach_payment_prompt() -> Board {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+
+    let marauder = scenario
+        .add_creature_from_oracle(P0, "Ogre Marauder", 3, 1, OGRE_MARAUDER)
+        .id();
+    let blocker = scenario.add_creature(P1, "Grizzly Bears", 2, 2).id();
+    let fodder = scenario.add_creature(P1, "Llanowar Elves", 1, 1).id();
+
+    let mut runner = scenario.build();
+    runner.pass_both_players();
+    runner
+        .declare_attackers(&[(marauder, AttackTarget::Player(P1))])
+        .expect("Ogre Marauder may attack P1");
+    runner.advance_until_stack_empty();
+
+    Board {
+        runner,
+        marauder,
+        blocker,
+        fodder,
+    }
+}
+
+/// True once the engine is at the declare-blockers decision.
+fn at_declare_blockers(runner: &GameRunner) -> bool {
+    matches!(
+        runner.state().waiting_for,
+        WaitingFor::DeclareBlockers { .. }
+    )
+}
+
+/// CR 509.1b: ask the engine's own block-declaration authority whether the
+/// defending player may block `attacker` with `blocker`.
+///
+/// `validate_blockers_for_player` is the same predicate the `DeclareBlockers`
+/// action runs, so this asserts the real restriction rather than a test-local
+/// re-derivation — and, unlike driving the action, it does not depend on the
+/// engine stopping at `WaitingFor::DeclareBlockers`, which it skips entirely
+/// when the only attacker cannot be blocked.
+fn block_is_legal(runner: &GameRunner, blocker: ObjectId, attacker: ObjectId) -> bool {
+    engine::game::combat::validate_blockers_for_player(runner.state(), P1, &[(blocker, attacker)])
+        .is_ok()
+}
+
+/// Pass priority until the declare-blockers decision is reached. Only valid on
+/// the branch where a legal block exists — with the attacker unblockable the
+/// engine skips the step.
+fn advance_to_declare_blockers(runner: &mut GameRunner) {
+    for _ in 0..12 {
+        if at_declare_blockers(runner) {
+            return;
+        }
+        runner.pass_both_players();
+    }
+    panic!(
+        "never reached declare blockers; stuck at {:?}",
+        runner.state().waiting_for
+    );
+}
+
+/// CR 508.5 + CR 118.12a: the attack trigger must prompt the DEFENDING player —
+/// the player Ogre Marauder is attacking — for the sacrifice. Prompting the
+/// attacker's controller (the `TriggeringPlayer` fallback the pronoun subjects
+/// use) would let the attacker pay their own tax.
+#[test]
+fn attack_trigger_prompts_the_defending_player() {
+    let board = attack_and_reach_payment_prompt();
+    match board.runner.state().waiting_for {
+        WaitingFor::UnlessPayment { player, .. } => assert_eq!(
+            player, P1,
+            "CR 508.5: the defending player pays, not the attacker's controller"
+        ),
+        ref other => panic!("attack trigger must offer the unless-payment, got {other:?}"),
+    }
+}
+
+/// CR 118.12a + CR 509.1b: DECLINING the sacrifice applies the effect — Ogre
+/// Marauder gains "this creature can't be blocked" until end of turn, so a
+/// block declaration naming it is illegal. This is the reported bug: before the
+/// fix the block was accepted even though nothing was sacrificed.
+#[test]
+fn declining_the_sacrifice_makes_ogre_marauder_unblockable() {
+    let mut board = attack_and_reach_payment_prompt();
+
+    board
+        .runner
+        .act(GameAction::PayUnlessCost { pay: false })
+        .expect("the defending player may decline the sacrifice");
+
+    // Nothing was sacrificed: both P1 creatures are still on the battlefield.
+    for id in [board.blocker, board.fodder] {
+        assert_eq!(
+            board.runner.state().objects[&id].zone,
+            Zone::Battlefield,
+            "declining must not sacrifice anything"
+        );
+    }
+
+    // CR 509.1b: the grant is live, so no block declaration naming Ogre
+    // Marauder is legal. This is the reported bug — before the fix the trigger
+    // resolved to nothing and this exact block was accepted.
+    assert!(
+        engine::game::combat::has_cant_be_blocked_static(board.runner.state(), board.marauder),
+        "declining must leave Ogre Marauder with the \"can't be blocked\" grant"
+    );
+    assert!(
+        !block_is_legal(&board.runner, board.blocker, board.marauder),
+        "CR 509.1b: blocking an unblockable attacker must be rejected"
+    );
+}
+
+/// CR 118.12a + CR 701.21a: PAYING the cost prevents the effect — the defending
+/// player sacrifices a creature of their choice, Ogre Marauder never gains
+/// "can't be blocked", and a block with a surviving creature is legal.
+#[test]
+fn paying_the_sacrifice_keeps_ogre_marauder_blockable() {
+    let mut board = attack_and_reach_payment_prompt();
+
+    board
+        .runner
+        .act(GameAction::PayUnlessCost { pay: true })
+        .expect("the defending player may choose to pay");
+    assert!(
+        matches!(
+            board.runner.state().waiting_for,
+            WaitingFor::WardSacrificeChoice { .. }
+        ),
+        "CR 701.21a: paying must prompt the payer to choose which creature to sacrifice, got {:?}",
+        board.runner.state().waiting_for
+    );
+    board
+        .runner
+        .act(GameAction::SelectCards {
+            cards: vec![board.fodder],
+        })
+        .expect("the chosen creature pays the unless-cost");
+
+    assert_ne!(
+        board.runner.state().objects[&board.fodder].zone,
+        Zone::Battlefield,
+        "the sacrificed creature must leave the battlefield"
+    );
+
+    // CR 118.12a: the payment prevented the effect, so no grant was applied.
+    assert!(
+        !engine::game::combat::has_cant_be_blocked_static(board.runner.state(), board.marauder),
+        "paying the unless-cost must prevent the \"can't be blocked\" grant"
+    );
+    assert!(
+        block_is_legal(&board.runner, board.blocker, board.marauder),
+        "CR 509.1a: having paid, the defending player may block normally"
+    );
+
+    // ... and the declaration goes through on the real action path.
+    advance_to_declare_blockers(&mut board.runner);
+    board
+        .runner
+        .declare_blockers(&[(board.blocker, board.marauder)])
+        .expect("having paid, the defending player may block normally");
+}


### PR DESCRIPTION
## Summary

Ogre Marauder's attack trigger went on the stack and then did nothing: the defending player was never asked for the sacrifice, and the creature stayed blockable for free. The clause subject "defending player" was absent from the unless-payer subject grammar, so the whole clause — body grant included — fell through to `Effect::Unimplemented { name: "Unsupported unless clause" }`. This parameterizes the subject axis so a subject can name its own payer, and adds the matching `DefendingPlayer` arm to the runtime payer resolver.

## Files changed

- `crates/engine/src/parser/oracle_trigger.rs` — new `parse_unless_payer_subject` combinator and `UnlessAltCost { cost, payer }`; `parse_unless_they_alt_cost_chain` / `parse_unless_they_single_alt_cost` rethreaded to carry the payer; trigger-side call site prefers a named payer
- `crates/engine/src/parser/oracle_effect/mod.rs` — resolution-side call site prefers a named payer over its pronoun heuristic; the counter path discards it explicitly (it pins the payer at its own call site)
- `crates/engine/src/game/effects/mod.rs` — `DefendingPlayer` arm in `resolve_unless_payer`; `tracing::warn!` on the wildcard fail-open
- `crates/engine/src/parser/oracle_trigger_tests.rs` — four building-block tests over the subject axis; one existing test updated for the new return type
- `crates/engine/tests/integration/ogre_marauder_defending_player_unless_sacrifice.rs` — new, three runtime tests
- `crates/engine/tests/integration/main.rs` — `mod` line for the above

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — implemented directly, then put through the pipeline's review stages; see the deviation note below.

> **Deviation, stated plainly.** This commit was written directly rather than dispatched through `/engine-implementer`'s executor. The pipeline *was* run afterwards for a wider scope (see "Scope Expansion"), producing three plan rounds and three independent `/review-engine-plan` rounds in isolated worktrees; that wider work is **not** in this PR. What this commit did receive is the pipeline's §5 gate: an independent `/review-impl` against the committed head, returning CLEAN with three LOW findings, two of which were then fixed and the review re-run against the amended head. I am flagging the process gap rather than letting the Method line imply a pipeline run that did not produce this code.

## CR references

Added or touched: `CR 118.12`, `CR 118.12a`, `CR 508.1m`, `CR 508.5`, `CR 508.5a`, `CR 509.1a`, `CR 509.1b`, `CR 608.2f`, `CR 701.21a`.

Each verified by grepping `docs/MagicCompRules.txt` before being written. The load-bearing ones: CR 508.5 / 508.5a fix the payer as the player *this* attacking creature is attacking, determined per attacker and, in multiplayer, exactly one specific player — which is what `TargetFilter::DefendingPlayer` resolves to. CR 118.12a is the unless-clause equivalence rule. CR 701.21a is the sacrifice.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

Tilt was down on this machine (`tilt get uiresource clippy` non-zero), so cargo ran directly per the guide's fallback branch.

- `cargo fmt --all` — clean
- `cargo clippy -p phase-engine --all-targets -- -D warnings` — clean
- `cargo test -p phase-engine --lib` — **20320 passed, 0 failed**, 6 ignored
- `cargo test -p phase-engine --test integration -- --skip game_state_stack_budget` — **5877 passed, 0 failed**, 2 ignored, 1 filtered (see Validation Failures)
- `./scripts/gen-card-data.sh` — regenerated; Ogre Marauder carries no `Unimplemented` node and lowers to `GenericEffect` + `AddStaticMode{CantBeBlocked}` + `unless_pay{payer: DefendingPlayer}`
- `cargo coverage` — completed; Ogre Marauder supported, gap-free
- `cargo semantic-audit` — 32788 cards audited; **zero findings for Ogre Marauder**

Corpus regression check: all 35,798 cards regenerated and diffed against a pre-change dump. Exactly one card's parse changes — see "Claimed parse impact".

## Gate A

Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=d9b19e66d617d49e29812afe9903aa70d6a3c9f2 base=2a067a66d64178b346b1c016f7207982096831af

## Anchored on

- `crates/engine/src/parser/oracle_target.rs:307` — `value(TargetFilter::DefendingPlayer, tag("defending player"))` in `parse_event_context_ref`, annotated CR 508.5 / CR 508.5a. The new `parse_unless_payer_subject` arm mirrors this exact combinator family and CR anchoring for the unless-subject position.
- `crates/engine/src/game/effects/mod.rs:14925` — `resolve_unless_payer`'s `TriggeringSpellController` arm, which delegates to `resolve_event_context_target` and unwraps with `.and_then(|target| match target { TargetRef::Player(p) => Some(p), _ => None })`. The new `DefendingPlayer` arm is the same shape at the same seam.

## Final review-impl

Final review-impl PASS head=d9b19e66d617d49e29812afe9903aa70d6a3c9f2

Two independent `/review-impl` passes were run: one against the pre-amend head (CLEAN, three LOW), and this one against the amended head after two of those were fixed. The second reviewer additionally drove real 3-player games out-of-band and confirmed empirically that the payer resolves per-attacker (not to the batch-wide `AttackersDeclared` field), that attacking a planeswalker bills its controller, and that removing the attacker from combat before the trigger resolves still yields the correct player via the LKI fallback.

Four LOW findings remain open and are recorded here rather than fixed, since none blocks and each is better addressed deliberately than in a polish cycle. Two are in code I wrote:

1. The new `tracing::warn!` covers only the wildcard *unhandled-subject* arm, not the larger *handled-but-unresolvable* class — `DefendingPlayer`, `Player`, `TriggeringPlayer` and `ScopedPlayer` all still return `None` silently. The better placement is around the whole match in `resolve_unless_payers`. (The wildcard arm is unreachable today: the reviewer confirmed every payer produced anywhere in the corpus is covered by a named arm.)
2. The rewritten doc comment on `parse_unless_they_alt_cost_chain` retains two inaccuracies — line 4248 still says "resolution-time", contradicting the three-caller paragraph below it, and the counter caller passes a subject-normalized string so it can never observe a `Some` payer, making "which discards the payer" describe a branch that cannot occur.
3. All three integration fixtures take the live-combat branch of the defender lookup; the LKI fallback, the CR 508.5a multiplayer split, and planeswalker/battle resolution are asserted in comments and verified out-of-band, but reached by no committed fixture.
4. The new arm resolves the CR 508.5 anaphor through `resolve_event_context_target` rather than `combat::defending_player_cr508_5`, which `combat.rs:6412` names as the single authority. Defensible here (`resolve_unless_payer` has no `TriggerSourceContext`, and passing `None` would degrade the lookup) but it is a fourth door that could drift.

## Claimed parse impact

Ogre Marauder — from `Effect::Unimplemented { name: "Unsupported unless clause" }` to the real `CantBeBlocked` grant plus `unless_pay { cost: Sacrifice, payer: DefendingPlayer }`.

No other card's parse changes. Verified by regenerating all 35,798 cards and diffing: the only unless-related delta is Ogre Marauder.

## Scope Expansion

None in this PR.

For the record: the unless-clause payer subject is enumerated in roughly a dozen places across the parser, and those copies have measurably diverged (`its controller` resolves to `TriggeringSpellController` in a trigger body but `ParentTargetController` in a spell clause; the counterspell path parses the subject and discards it). Folding them onto one authority was scoped, planned and reviewed here but deliberately **not** included — it puts ~411 payer-producing cards at risk to unlock ~1, and belongs behind its own corpus-diff gate. Filed separately; this PR adds one `Named` arm to one site and leaves every anaphor resolving exactly as before.

## Validation Failures

`crates/engine/tests/integration/game_state_stack_budget.rs::four_player_commander_action_fits_a_bounded_stack` aborts the whole integration binary with a stack overflow on this machine (aarch64-apple-darwin), so it is skipped in the run above.

**Pre-existing, not caused by this change.** Reproduced on a pristine `git worktree` at the base commit `2a067a66d` with none of this diff applied — identical SIGABRT. The test is a deliberately calibrated 3 MiB stack canary, `cfg`-gated to aarch64 macOS, and its own header documents this failure mode ("a SIGABRT with no assertion message on whatever unrelated PR happens to be in the queue"). CI runs x86_64, where the test is `cfg`'d out. Not fixed here; the documented remedy is re-running its bisection.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Corrected “unless” effects so explicitly named payers, including the defending player, are recognized and prompted appropriately.
  - Prevented unresolved payers from silently causing alternate costs to be skipped.
  - Preserved expected behavior for pronoun-based payer references and counter-related costs.

- **Tests**
  - Added coverage for defending-player sacrifice, discard, and life-payment clauses.
  - Verified both payment and refusal outcomes, including blocking restrictions and battlefield changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->