### PR TITLE
chore: refresh metagame feeds

### DIFF
--- a/client/public/feeds/mtggoldfish-commander.json
+++ b/client/public/feeds/mtggoldfish-commander.json
@@ -5,392 +5,9 @@
   "icon": "G",
   "format": "commander",
   "version": 1,
-  "updated": "2026-08-31T00:00:00Z",
+  "updated": "2026-09-01T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/commander",
   "decks": [
-    {
-      "name": "Y'shtola, Night's Blessed",
-      "author": "MTGGoldfish",
-      "colors": [
-        "U",
-        "W",
-        "B"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Alisaie Leveilleur"
-        },
-        {
-          "count": 1,
-          "name": "Alphinaud Leveilleur"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Sanctum"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Archaeomancer's Map"
-        },
-        {
-          "count": 1,
-          "name": "Archmage Emeritus"
-        },
-        {
-          "count": 1,
-          "name": "Ardbert, Warrior of Darkness"
-        },
-        {
-          "count": 1,
-          "name": "Ash Barrens"
-        },
-        {
-          "count": 1,
-          "name": "Astrologian's Planisphere"
-        },
-        {
-          "count": 1,
-          "name": "Authority of the Consuls"
-        },
-        {
-          "count": 1,
-          "name": "Baleful Strix"
-        },
-        {
-          "count": 1,
-          "name": "Bastion of Remembrance"
-        },
-        {
-          "count": 1,
-          "name": "Blue Mage's Cane"
-        },
-        {
-          "count": 1,
-          "name": "Champions from Beyond"
-        },
-        {
-          "count": 1,
-          "name": "Choked Estuary"
-        },
-        {
-          "count": 1,
-          "name": "Circle of Power"
-        },
-        {
-          "count": 1,
-          "name": "Cleansing Nova"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Contaminated Aquifer"
-        },
-        {
-          "count": 1,
-          "name": "Coveted Jewel"
-        },
-        {
-          "count": 1,
-          "name": "Crux of Fate"
-        },
-        {
-          "count": 1,
-          "name": "Cut a Deal"
-        },
-        {
-          "count": 1,
-          "name": "Dancer's Chakrams"
-        },
-        {
-          "count": 1,
-          "name": "Darkwater Catacombs"
-        },
-        {
-          "count": 1,
-          "name": "Demolition Field"
-        },
-        {
-          "count": 1,
-          "name": "Desolate Mire"
-        },
-        {
-          "count": 1,
-          "name": "Dig Through Time"
-        },
-        {
-          "count": 1,
-          "name": "Drowned Catacomb"
-        },
-        {
-          "count": 1,
-          "name": "Emet-Selch of the Third Seat"
-        },
-        {
-          "count": 1,
-          "name": "Estinien Varlineau"
-        },
-        {
-          "count": 1,
-          "name": "Evolving Wilds"
-        },
-        {
-          "count": 1,
-          "name": "Exotic Orchard"
-        },
-        {
-          "count": 1,
-          "name": "Exsanguinate"
-        },
-        {
-          "count": 1,
-          "name": "Eye of Nidhogg"
-        },
-        {
-          "count": 1,
-          "name": "Fandaniel, Telophoroi Ascian"
-        },
-        {
-          "count": 1,
-          "name": "Fetid Heath"
-        },
-        {
-          "count": 1,
-          "name": "Final Judgment"
-        },
-        {
-          "count": 1,
-          "name": "G'raha Tia, Scion Reborn"
-        },
-        {
-          "count": 1,
-          "name": "Glacial Fortress"
-        },
-        {
-          "count": 1,
-          "name": "Hermes, Overseer of Elpis"
-        },
-        {
-          "count": 1,
-          "name": "Hildibrand Manderville"
-        },
-        {
-          "count": 1,
-          "name": "Hraesvelgr of the First Brood"
-        },
-        {
-          "count": 1,
-          "name": "Hypnotic Sprite"
-        },
-        {
-          "count": 1,
-          "name": "Idyllic Beachfront"
-        },
-        {
-          "count": 1,
-          "name": "Into the Story"
-        },
-        {
-          "count": 3,
-          "name": "Island"
-        },
-        {
-          "count": 1,
-          "name": "Isolated Chapel"
-        },
-        {
-          "count": 1,
-          "name": "Krile Baldesion"
-        },
-        {
-          "count": 1,
-          "name": "Lethal Scheme"
-        },
-        {
-          "count": 1,
-          "name": "Lingering Souls"
-        },
-        {
-          "count": 1,
-          "name": "Lyse Hext"
-        },
-        {
-          "count": 1,
-          "name": "Murderous Rider"
-        },
-        {
-          "count": 1,
-          "name": "Observed Stasis"
-        },
-        {
-          "count": 1,
-          "name": "Papalymo Totolymo"
-        },
-        {
-          "count": 1,
-          "name": "Path of Ancestry"
-        },
-        {
-          "count": 4,
-          "name": "Plains"
-        },
-        {
-          "count": 1,
-          "name": "Port Town"
-        },
-        {
-          "count": 1,
-          "name": "Prairie Stream"
-        },
-        {
-          "count": 1,
-          "name": "Propaganda"
-        },
-        {
-          "count": 1,
-          "name": "Reaper's Scythe"
-        },
-        {
-          "count": 1,
-          "name": "Relic of Legends"
-        },
-        {
-          "count": 1,
-          "name": "Rite of Replication"
-        },
-        {
-          "count": 1,
-          "name": "Sage's Nouliths"
-        },
-        {
-          "count": 1,
-          "name": "Scavenger Grounds"
-        },
-        {
-          "count": 1,
-          "name": "Shineshadow Snarl"
-        },
-        {
-          "count": 1,
-          "name": "Skycloud Expanse"
-        },
-        {
-          "count": 1,
-          "name": "Snuff Out"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Sublime Epiphany"
-        },
-        {
-          "count": 1,
-          "name": "Summon: Good King Mog XII"
-        },
-        {
-          "count": 1,
-          "name": "Sunken Hollow"
-        },
-        {
-          "count": 1,
-          "name": "Sunken Ruins"
-        },
-        {
-          "count": 1,
-          "name": "Sunlit Marsh"
-        },
-        {
-          "count": 4,
-          "name": "Swamp"
-        },
-        {
-          "count": 1,
-          "name": "Swords to Plowshares"
-        },
-        {
-          "count": 1,
-          "name": "Syphon Mind"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Dominance"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Hierarchy"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Progress"
-        },
-        {
-          "count": 1,
-          "name": "Tataru Taru"
-        },
-        {
-          "count": 1,
-          "name": "Temple of the False God"
-        },
-        {
-          "count": 1,
-          "name": "Thancred Waters"
-        },
-        {
-          "count": 1,
-          "name": "Thought Vessel"
-        },
-        {
-          "count": 1,
-          "name": "Tome of Legends"
-        },
-        {
-          "count": 1,
-          "name": "Torrential Gearhulk"
-        },
-        {
-          "count": 1,
-          "name": "Transpose"
-        },
-        {
-          "count": 1,
-          "name": "Underground River"
-        },
-        {
-          "count": 1,
-          "name": "Urianger Augurelt"
-        },
-        {
-          "count": 1,
-          "name": "Vindicate"
-        },
-        {
-          "count": 1,
-          "name": "Void Rend"
-        },
-        {
-          "count": 1,
-          "name": "White Auracite"
-        },
-        {
-          "count": 1,
-          "name": "Y'shtola, Night's Blessed"
-        }
-      ],
-      "sideboard": []
-    },
     {
       "name": "Mutagen Man, Living Ooze",
       "author": "MTGGoldfish",
@@ -695,7 +312,7 @@
       "sideboard": []
     },
     {
-      "name": "Thorin, King of Durin's Folk",
+      "name": "Y'shtola, Night's Blessed",
       "author": "MTGGoldfish",
       "colors": [],
       "tags": [
@@ -704,67 +321,385 @@
       "main": [
         {
           "count": 1,
-          "name": "Dain, Lord of the Iron Hills"
+          "name": "Y'shtola, Night's Blessed [FIC]"
         },
         {
           "count": 1,
-          "name": "Dwalin, Weaponmaster"
+          "name": "Drannith Magistrate [IKO]"
         },
         {
           "count": 1,
-          "name": "Kili the Resourceful"
+          "name": "Orcish Bowmasters [LTR]"
         },
         {
           "count": 1,
-          "name": "Thorin Oakenshield"
+          "name": "Opposition Agent [CMR]"
         },
         {
           "count": 1,
-          "name": "Koll, the Forgemaster"
+          "name": "Sheoldred, the Apocalypse [DMU]"
         },
         {
           "count": 1,
-          "name": "Magda, Brazen Outlaw"
+          "name": "Teferi, Time Raveler [RVR]"
         },
         {
           "count": 1,
-          "name": "Reyav, Master Smith"
+          "name": "Narset, Parter of Veils [WAR]"
         },
         {
           "count": 1,
-          "name": "Sram, Senior Edificer"
+          "name": "Sol Ring [CMD]"
         },
         {
           "count": 1,
-          "name": "Dain Ironfoot"
+          "name": "Arcane Signet <brawl deck> [ELD]"
         },
         {
           "count": 1,
-          "name": "Depala, Pilot Exemplar"
+          "name": "Talisman of Dominance [MRD]"
         },
         {
           "count": 1,
-          "name": "Digsite Engineer"
+          "name": "Talisman of Hierarchy [MH1]"
         },
         {
           "count": 1,
-          "name": "Duergar Hedge-Mage"
+          "name": "Talisman of Progress [MRD]"
         },
         {
           "count": 1,
-          "name": "Dwarven Recruiter"
+          "name": "Chromatic Lantern [GRN]"
         },
         {
           "count": 1,
-          "name": "Fili and Kili, Joyous"
+          "name": "Relic of Legends [DMU]"
         },
         {
           "count": 1,
-          "name": "Gloin, Dwarf Emissary [LTR]"
+          "name": "Thought Vessel [CMR]"
         },
         {
           "count": 1,
-          "name": "Hammers of Moradin [CLB]"
+          "name": "Midnight Clock [ELD]"
+        },
+        {
+          "count": 1,
+          "name": "Staff of Compleation [ONE]"
+        },
+        {
+          "count": 1,
+          "name": "Sensei's Divining Top [CHK]"
+        },
+        {
+          "count": 1,
+          "name": "Trinisphere [DST]"
+        },
+        {
+          "count": 1,
+          "name": "Aetherflux Reservoir [KLD]"
+        },
+        {
+          "count": 1,
+          "name": "The One Ring [LTR]"
+        },
+        {
+          "count": 1,
+          "name": "Norn's Annex [NPH]"
+        },
+        {
+          "count": 1,
+          "name": "Bolas's Citadel [WAR]"
+        },
+        {
+          "count": 1,
+          "name": "Authority of the Consuls [KLD]"
+        },
+        {
+          "count": 1,
+          "name": "Mystic Remora [ICE]"
+        },
+        {
+          "count": 1,
+          "name": "Bloodchief Ascension [ZEN]"
+        },
+        {
+          "count": 1,
+          "name": "Blind Obedience [GTC]"
+        },
+        {
+          "count": 1,
+          "name": "Rhystic Study [PR]"
+        },
+        {
+          "count": 1,
+          "name": "Propaganda [TE]"
+        },
+        {
+          "count": 1,
+          "name": "Ghostly Prison [CMD]"
+        },
+        {
+          "count": 1,
+          "name": "Grasp of Fate [C15]"
+        },
+        {
+          "count": 1,
+          "name": "Smothering Tithe [RNA]"
+        },
+        {
+          "count": 1,
+          "name": "Painful Quandary [SOM]"
+        },
+        {
+          "count": 1,
+          "name": "Swords to Plowshares [LEA]"
+        },
+        {
+          "count": 1,
+          "name": "Path to Exile [CON]"
+        },
+        {
+          "count": 1,
+          "name": "Enlightened Tutor [MI]"
+        },
+        {
+          "count": 1,
+          "name": "Vampiric Tutor [VI]"
+        },
+        {
+          "count": 1,
+          "name": "Mystical Tutor [MI]"
+        },
+        {
+          "count": 1,
+          "name": "Mana Drain [LEG]"
+        },
+        {
+          "count": 1,
+          "name": "Cyclonic Rift [RTR]"
+        },
+        {
+          "count": 1,
+          "name": "Fierce Guardianship [C20]"
+        },
+        {
+          "count": 1,
+          "name": "Render Silent [GK2]"
+        },
+        {
+          "count": 1,
+          "name": "Undermine [IN]"
+        },
+        {
+          "count": 1,
+          "name": "Void Rend [SNC]"
+        },
+        {
+          "count": 1,
+          "name": "Anguished Unmaking [SOI]"
+        },
+        {
+          "count": 1,
+          "name": "Deadly Rollick [C20]"
+        },
+        {
+          "count": 1,
+          "name": "Demonic Tutor [UMA]"
+        },
+        {
+          "count": 1,
+          "name": "Grim Tutor [S99]"
+        },
+        {
+          "count": 1,
+          "name": "Cut a Deal [BLC]"
+        },
+        {
+          "count": 1,
+          "name": "Solve the Equation [STX]"
+        },
+        {
+          "count": 1,
+          "name": "Windfall [CMD]"
+        },
+        {
+          "count": 1,
+          "name": "Stock Up [DFT]"
+        },
+        {
+          "count": 1,
+          "name": "Risky Shortcut [DFT]"
+        },
+        {
+          "count": 1,
+          "name": "Read the Bones [THS]"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Craving [S99]"
+        },
+        {
+          "count": 1,
+          "name": "Supreme Verdict [RTR]"
+        },
+        {
+          "count": 1,
+          "name": "Farewell [NEO]"
+        },
+        {
+          "count": 1,
+          "name": "Approach of the Second Sun [AKH]"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower [CMD]"
+        },
+        {
+          "count": 1,
+          "name": "City of Brass [MMA]"
+        },
+        {
+          "count": 1,
+          "name": "Mana Confluence [JOU]"
+        },
+        {
+          "count": 1,
+          "name": "Flooded Strand [ONS]"
+        },
+        {
+          "count": 1,
+          "name": "Polluted Delta [ONS]"
+        },
+        {
+          "count": 1,
+          "name": "Windswept Heath [ONS]"
+        },
+        {
+          "count": 1,
+          "name": "Bloodstained Mire [ONS]"
+        },
+        {
+          "count": 1,
+          "name": "Marsh Flats [ZEN]"
+        },
+        {
+          "count": 1,
+          "name": "Scalding Tarn [ZEN]"
+        },
+        {
+          "count": 1,
+          "name": "Misty Rainforest [ZEN]"
+        },
+        {
+          "count": 1,
+          "name": "Arid Mesa [ZEN]"
+        },
+        {
+          "count": 1,
+          "name": "Verdant Catacombs [ZEN]"
+        },
+        {
+          "count": 1,
+          "name": "Hallowed Fountain [DIS]"
+        },
+        {
+          "count": 1,
+          "name": "Watery Grave [RAV]"
+        },
+        {
+          "count": 1,
+          "name": "Godless Shrine [GPT]"
+        },
+        {
+          "count": 1,
+          "name": "Raffine's Tower [SNC]"
+        },
+        {
+          "count": 1,
+          "name": "Undercity Sewers [MKM]"
+        },
+        {
+          "count": 1,
+          "name": "Meticulous Archive [MKM]"
+        },
+        {
+          "count": 1,
+          "name": "Shadowy Backstreet [MKM]"
+        },
+        {
+          "count": 1,
+          "name": "Sea of Clouds [BBD]"
+        },
+        {
+          "count": 1,
+          "name": "Morphic Pool [BBD]"
+        },
+        {
+          "count": 1,
+          "name": "Shineshadow Snarl [CMM]"
+        },
+        {
+          "count": 1,
+          "name": "Mystic Gate [SHM]"
+        },
+        {
+          "count": 1,
+          "name": "Sunken Ruins [SHM]"
+        },
+        {
+          "count": 1,
+          "name": "Otawara, Soaring City [NEO]"
+        },
+        {
+          "count": 1,
+          "name": "Ancient Tomb [TE]"
+        },
+        {
+          "count": 6,
+          "name": "Island [UGL]"
+        },
+        {
+          "count": 4,
+          "name": "Plains [UGL]"
+        },
+        {
+          "count": 2,
+          "name": "Swamp [UGL]"
+        },
+        {
+          "count": 1,
+          "name": "Swan Song [THS]"
+        },
+        {
+          "count": 1,
+          "name": "An Offer You Can't Refuse [FDN]"
+        },
+        {
+          "count": 1,
+          "name": "Dovin's Veto [WAR]"
+        },
+        {
+          "count": 1,
+          "name": "Hullbreaker Horror [INR]"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "Thorin, King of Durin's Folk",
+      "author": "MTGGoldfish",
+      "colors": [
+        "W",
+        "R"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Thorin, King of Durin's Folk"
         },
         {
           "count": 1,
@@ -772,135 +707,23 @@
         },
         {
           "count": 1,
-          "name": "Gloin the Mighty"
-        },
-        {
-          "count": 1,
-          "name": "Smaug the Magnificent <019de533-a02c-7e23-8236-6a2379118894> [HOB]"
-        },
-        {
-          "count": 1,
-          "name": "Gandalf the White [LTR]"
-        },
-        {
-          "count": 1,
           "name": "Bifur, Melodic Rider"
         },
         {
           "count": 1,
-          "name": "Ori, Plate Stacker"
+          "name": "Thorin Oakenshield"
         },
         {
           "count": 1,
-          "name": "Taunt from the Rampart [LTC]"
+          "name": "Fili and Kili, Joyous"
         },
         {
           "count": 1,
-          "name": "Legion Leadership [MH3]"
+          "name": "Gloin, Dwarf Emissary"
         },
         {
           "count": 1,
-          "name": "Diamond Pick-Axe"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring <019fc778-aae7-71a7-a402-4571d4ff1c78> [SLD]"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet [LTC]"
-        },
-        {
-          "count": 1,
-          "name": "Blade of Selves"
-        },
-        {
-          "count": 1,
-          "name": "Boros Signet"
-        },
-        {
-          "count": 1,
-          "name": "Dwarven Mattock"
-        },
-        {
-          "count": 1,
-          "name": "Erebor Heirloom <019fc778-a487-71b0-87a1-aaca23b2c5ce> [SLD]"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Greaves <019fc778-a6de-7133-a4ae-8bd37638146b> [SLD]"
-        },
-        {
-          "count": 1,
-          "name": "Liquimetal Torque <019fc778-a7d8-740f-ad4c-aaefcee04f6b> [SLD]"
-        },
-        {
-          "count": 1,
-          "name": "Long-Lost Lances <019f7603-7807-78cd-8edc-2631decb4778> [HOC]"
-        },
-        {
-          "count": 1,
-          "name": "Sting, Bilbo's Sword"
-        },
-        {
-          "count": 1,
-          "name": "Talisman of Conviction [LTC]"
-        },
-        {
-          "count": 1,
-          "name": "Thought Vessel <019fc778-ad4f-7c5d-8188-0e0de0dad558> [SLD]"
-        },
-        {
-          "count": 1,
-          "name": "Trailblazer's Boots"
-        },
-        {
-          "count": 1,
-          "name": "Bearded Axe [KHM]"
-        },
-        {
-          "count": 1,
-          "name": "Bilbo's Ring"
-        },
-        {
-          "count": 1,
-          "name": "Heirloom Blade [LTC]"
-        },
-        {
-          "count": 1,
-          "name": "Mithril Coat"
-        },
-        {
-          "count": 1,
-          "name": "Orcrist, Goblin-cleaver"
-        },
-        {
-          "count": 1,
-          "name": "Patchwork Banner"
-        },
-        {
-          "count": 1,
-          "name": "Sword of Hearth and Home <Herugrim, Sword of Rohan> [LTC]"
-        },
-        {
-          "count": 1,
-          "name": "Banner of Kinship <borderless> [FDN]"
-        },
-        {
-          "count": 1,
-          "name": "The Arkenstone"
-        },
-        {
-          "count": 1,
-          "name": "Gleaming Splendor <019fb8b6-7558-7000-bb6e-6f379cfea13e> [HOB]"
-        },
-        {
-          "count": 1,
-          "name": "The Misty Mountains Cold"
-        },
-        {
-          "count": 1,
-          "name": "There and Back Again [LTR]"
+          "name": "Magda, Brazen Outlaw"
         },
         {
           "count": 1,
@@ -908,119 +731,155 @@
         },
         {
           "count": 1,
-          "name": "Command Tower [LTC]"
+          "name": "Gimli of the Glittering Caves"
         },
         {
           "count": 1,
-          "name": "Dragon-Cursed Halls"
+          "name": "Dain's Company"
         },
         {
           "count": 1,
-          "name": "Dwarven Mine [ELD]"
+          "name": "Orcrist, Goblin-cleaver"
         },
         {
           "count": 1,
-          "name": "Exotic Orchard [LTC]"
+          "name": "Dain, Lord of the Iron Hills"
         },
         {
           "count": 1,
-          "name": "Great Hall of the Citadel [LTR]"
+          "name": "Bofur, Reliable Guardian"
         },
         {
           "count": 1,
-          "name": "Hobbit Hole"
+          "name": "Gloin the Mighty"
         },
         {
           "count": 1,
-          "name": "Iron Hills"
+          "name": "Ori, Plate Stacker"
         },
         {
           "count": 1,
-          "name": "Mines of Moria"
-        },
-        {
-          "count": 4,
-          "name": "Mountain <019de565-ac23-7d48-b4eb-efaa4b601946> [HOB]"
-        },
-        {
-          "count": 2,
-          "name": "Mountain <278 - Map> [LTR]"
-        },
-        {
-          "count": 2,
-          "name": "Mountain <278 - Map> [LTR] (F)"
-        },
-        {
-          "count": 6,
-          "name": "Plains <019de565-a87b-7494-a007-a431649d1386> [HOB]"
-        },
-        {
-          "count": 4,
-          "name": "Plains <019de565-af1a-7697-aef0-c7531b8e6143> [HOB]"
-        },
-        {
-          "count": 2,
-          "name": "Plains <272 - Map> [LTR]"
-        },
-        {
-          "count": 2,
-          "name": "Plains <272 - Map> [LTR] (F)"
+          "name": "Swords to Plowshares"
         },
         {
           "count": 1,
-          "name": "Rogue's Passage <019fb8b7-36bb-76b1-82b5-324e7af603d7> [HOC]"
+          "name": "Dori, Bearer of Friends"
         },
         {
           "count": 1,
-          "name": "Secluded Courtyard [LTC]"
+          "name": "Dain of the Ancient Halls"
         },
         {
           "count": 1,
-          "name": "The Grey Havens [LTR]"
+          "name": "Thorin, Company's Leader"
         },
         {
           "count": 1,
-          "name": "The Lonely Mountain <019f75e9-14d8-7852-8297-709ab7e085a4> [HOB]"
+          "name": "Cadric, Soul Kindler"
         },
         {
           "count": 1,
-          "name": "Treasure Vault"
+          "name": "Plundering Barbarian"
         },
         {
           "count": 1,
-          "name": "Brass Squire [MBS]"
+          "name": "Boros Charm"
         },
         {
           "count": 1,
-          "name": "Belladonna Took"
+          "name": "Big Score"
         },
         {
           "count": 1,
-          "name": "The Queen of Dale"
+          "name": "Unexpected Windfall"
         },
         {
           "count": 1,
-          "name": "Esper Sentinel"
+          "name": "Chaos Warp"
         },
         {
           "count": 1,
-          "name": "Mangara, the Diplomat"
+          "name": "Unbreakable Formation"
         },
         {
           "count": 1,
-          "name": "Bilbo, Unexpected Adventurer"
+          "name": "Goldspan Dragon"
         },
         {
           "count": 1,
-          "name": "Sevinne's Reclamation"
+          "name": "Hellkite Tyrant"
         },
         {
           "count": 1,
-          "name": "Sejiri Shelter"
+          "name": "Cavern-Hoard Dragon"
         },
         {
           "count": 1,
-          "name": "Goblin Bombardment"
+          "name": "Goldlust Triad"
+        },
+        {
+          "count": 1,
+          "name": "Seize the Spoils"
+        },
+        {
+          "count": 1,
+          "name": "Dwarven Reinforcements"
+        },
+        {
+          "count": 1,
+          "name": "Brass's Bounty"
+        },
+        {
+          "count": 1,
+          "name": "Dragon's Desire"
+        },
+        {
+          "count": 1,
+          "name": "Lorehold Charm"
+        },
+        {
+          "count": 1,
+          "name": "Vandalblast"
+        },
+        {
+          "count": 1,
+          "name": "Faithless Looting"
+        },
+        {
+          "count": 1,
+          "name": "The Reaver Cleaver"
+        },
+        {
+          "count": 1,
+          "name": "Diamond Pick-Axe"
+        },
+        {
+          "count": 1,
+          "name": "Bloodforged Battle-Axe"
+        },
+        {
+          "count": 1,
+          "name": "Bearded Axe"
+        },
+        {
+          "count": 1,
+          "name": "Dwarven Mattock"
+        },
+        {
+          "count": 1,
+          "name": "Goldvein Pick"
+        },
+        {
+          "count": 1,
+          "name": "Beamtown Beatstick"
+        },
+        {
+          "count": 1,
+          "name": "Door of Destinies"
+        },
+        {
+          "count": 1,
+          "name": "Rain of Riches"
         },
         {
           "count": 1,
@@ -1028,19 +887,1439 @@
         },
         {
           "count": 1,
-          "name": "Puresteel Paladin"
+          "name": "Rising of the Day"
         },
         {
           "count": 1,
-          "name": "Crime Novelist"
+          "name": "Sol Ring"
         },
         {
           "count": 1,
-          "name": "Forth Eorlingas!"
+          "name": "Arcane Signet"
         },
         {
           "count": 1,
-          "name": "Thorin, King of Durin's Folk <019f75e5-20db-70eb-ae91-6e2e56fcd177> [HOC]"
+          "name": "Talisman of Conviction"
+        },
+        {
+          "count": 1,
+          "name": "Commander's Sphere"
+        },
+        {
+          "count": 1,
+          "name": "Terramorphic Expanse"
+        },
+        {
+          "count": 1,
+          "name": "Rustvale Bridge"
+        },
+        {
+          "count": 1,
+          "name": "Radiant Summit"
+        },
+        {
+          "count": 14,
+          "name": "Plains"
+        },
+        {
+          "count": 1,
+          "name": "Myriad Landscape"
+        },
+        {
+          "count": 14,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "Hobbit Hole"
+        },
+        {
+          "count": 1,
+          "name": "Evolving Wilds"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Clifftop Retreat"
+        },
+        {
+          "count": 1,
+          "name": "Darksteel Plate"
+        },
+        {
+          "count": 1,
+          "name": "Ghirapur Aether Grid"
+        },
+        {
+          "count": 1,
+          "name": "Torbran, Thane of Red Fell"
+        },
+        {
+          "count": 1,
+          "name": "Magda, the Hoardmaster"
+        },
+        {
+          "count": 1,
+          "name": "Dwarven Provisioner"
+        },
+        {
+          "count": 1,
+          "name": "Hammers of Moradin"
+        },
+        {
+          "count": 1,
+          "name": "Hellkite Charger"
+        },
+        {
+          "count": 1,
+          "name": "Furnace Hellkite"
+        },
+        {
+          "count": 1,
+          "name": "Hellkite Igniter"
+        },
+        {
+          "count": 1,
+          "name": "Collective Inferno"
+        },
+        {
+          "count": 1,
+          "name": "Electrodominance"
+        },
+        {
+          "count": 1,
+          "name": "Aggravated Assault"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "Thranduil, the Elvenking",
+      "author": "MTGGoldfish",
+      "colors": [
+        "B",
+        "G",
+        "U"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Thranduil, the Elvenking"
+        },
+        {
+          "count": 1,
+          "name": "Overgrown Tomb"
+        },
+        {
+          "count": 1,
+          "name": "Breeding Pool"
+        },
+        {
+          "count": 1,
+          "name": "Zagoth Triome"
+        },
+        {
+          "count": 1,
+          "name": "Gilt-Leaf Palace"
+        },
+        {
+          "count": 1,
+          "name": "Elven Passage"
+        },
+        {
+          "count": 1,
+          "name": "Hedge Maze"
+        },
+        {
+          "count": 1,
+          "name": "Underground Mortuary"
+        },
+        {
+          "count": 1,
+          "name": "Rejuvenating Springs"
+        },
+        {
+          "count": 1,
+          "name": "Undergrowth Stadium"
+        },
+        {
+          "count": 1,
+          "name": "Llanowar Wastes"
+        },
+        {
+          "count": 1,
+          "name": "Yavimaya Coast"
+        },
+        {
+          "count": 1,
+          "name": "Wastewood Verge"
+        },
+        {
+          "count": 1,
+          "name": "Dreamroot Cascade"
+        },
+        {
+          "count": 1,
+          "name": "Deathcap Glade"
+        },
+        {
+          "count": 1,
+          "name": "Mana Confluence"
+        },
+        {
+          "count": 1,
+          "name": "Hinterland Harbor"
+        },
+        {
+          "count": 1,
+          "name": "Woodland Cemetery"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Bojuka Bog"
+        },
+        {
+          "count": 1,
+          "name": "Three Tree City"
+        },
+        {
+          "count": 1,
+          "name": "Evendo, Waking Haven"
+        },
+        {
+          "count": 1,
+          "name": "Shifting Woodland"
+        },
+        {
+          "count": 1,
+          "name": "Vernal Fen"
+        },
+        {
+          "count": 1,
+          "name": "Verdant Catacombs"
+        },
+        {
+          "count": 1,
+          "name": "Polluted Delta"
+        },
+        {
+          "count": 1,
+          "name": "Misty Rainforest"
+        },
+        {
+          "count": 1,
+          "name": "Prismatic Vista"
+        },
+        {
+          "count": 1,
+          "name": "Fabled Passage"
+        },
+        {
+          "count": 1,
+          "name": "Rain-Slicked Copse"
+        },
+        {
+          "count": 4,
+          "name": "Forest"
+        },
+        {
+          "count": 2,
+          "name": "Swamp"
+        },
+        {
+          "count": 1,
+          "name": "Island"
+        },
+        {
+          "count": 1,
+          "name": "Lorien Revealed"
+        },
+        {
+          "count": 1,
+          "name": "Troll of Khazad-dum"
+        },
+        {
+          "count": 1,
+          "name": "Generous Ent"
+        },
+        {
+          "count": 1,
+          "name": "Elvish Mystic"
+        },
+        {
+          "count": 1,
+          "name": "Llanowar Elves"
+        },
+        {
+          "count": 1,
+          "name": "Fyndhorn Elves"
+        },
+        {
+          "count": 1,
+          "name": "Elves of Deep Shadow"
+        },
+        {
+          "count": 1,
+          "name": "Deathrite Shaman"
+        },
+        {
+          "count": 1,
+          "name": "Urborg Elf"
+        },
+        {
+          "count": 1,
+          "name": "Devoted Druid"
+        },
+        {
+          "count": 1,
+          "name": "Priest of Titania"
+        },
+        {
+          "count": 1,
+          "name": "Imperious Perfect"
+        },
+        {
+          "count": 1,
+          "name": "Eladamri, Lord of Leaves"
+        },
+        {
+          "count": 1,
+          "name": "Lathril, Blade of the Elves"
+        },
+        {
+          "count": 1,
+          "name": "Immaculate Magistrate"
+        },
+        {
+          "count": 1,
+          "name": "Circle of Dreams Druid"
+        },
+        {
+          "count": 1,
+          "name": "Elvish Warmaster"
+        },
+        {
+          "count": 1,
+          "name": "Elvish Archdruid"
+        },
+        {
+          "count": 1,
+          "name": "Heritage Druid"
+        },
+        {
+          "count": 1,
+          "name": "Nettle Sentinel"
+        },
+        {
+          "count": 1,
+          "name": "Leaf-Crowned Visionary"
+        },
+        {
+          "count": 1,
+          "name": "Dwynen, Gilt-Leaf Daen"
+        },
+        {
+          "count": 1,
+          "name": "Dwynen's Elite"
+        },
+        {
+          "count": 1,
+          "name": "Prime Speaker Vannifar"
+        },
+        {
+          "count": 1,
+          "name": "Jarad, Golgari Lich Lord"
+        },
+        {
+          "count": 1,
+          "name": "Wood Elves"
+        },
+        {
+          "count": 1,
+          "name": "Marwyn, the Nurturer"
+        },
+        {
+          "count": 1,
+          "name": "Tyvar, the Pummeler"
+        },
+        {
+          "count": 1,
+          "name": "Craterhoof Behemoth"
+        },
+        {
+          "count": 1,
+          "name": "Ezuri, Renegade Leader"
+        },
+        {
+          "count": 1,
+          "name": "Allosaurus Shepherd"
+        },
+        {
+          "count": 1,
+          "name": "Cantankerous Keepers"
+        },
+        {
+          "count": 1,
+          "name": "Elvish Champion"
+        },
+        {
+          "count": 1,
+          "name": "Quirion Ranger"
+        },
+        {
+          "count": 1,
+          "name": "Tyvar, Jubilant Brawler"
+        },
+        {
+          "count": 1,
+          "name": "Tyvar the Bellicose"
+        },
+        {
+          "count": 1,
+          "name": "Eladamri, Korvecdal"
+        },
+        {
+          "count": 1,
+          "name": "Galadhrim Brigade"
+        },
+        {
+          "count": 1,
+          "name": "Lys Alana Huntmaster"
+        },
+        {
+          "count": 1,
+          "name": "Dionus, Elvish Archdruid"
+        },
+        {
+          "count": 1,
+          "name": "Thranduil the Strategist"
+        },
+        {
+          "count": 1,
+          "name": "Thranduil, Sindarin Liege"
+        },
+        {
+          "count": 1,
+          "name": "Glimpse of Nature"
+        },
+        {
+          "count": 1,
+          "name": "Harmonized Crescendo"
+        },
+        {
+          "count": 1,
+          "name": "Bloodline Bidding"
+        },
+        {
+          "count": 1,
+          "name": "Kindred Dominance"
+        },
+        {
+          "count": 1,
+          "name": "Crippling Fear"
+        },
+        {
+          "count": 1,
+          "name": "Swan Song"
+        },
+        {
+          "count": 1,
+          "name": "Genesis Wave"
+        },
+        {
+          "count": 1,
+          "name": "Finale of Devastation"
+        },
+        {
+          "count": 1,
+          "name": "Torment of Hailfire"
+        },
+        {
+          "count": 1,
+          "name": "Negate"
+        },
+        {
+          "count": 1,
+          "name": "Assassin's Trophy"
+        },
+        {
+          "count": 1,
+          "name": "Malevolent Rumble"
+        },
+        {
+          "count": 1,
+          "name": "Snuff Out"
+        },
+        {
+          "count": 1,
+          "name": "Abrupt Decay"
+        },
+        {
+          "count": 1,
+          "name": "Tear Asunder"
+        },
+        {
+          "count": 1,
+          "name": "Reanimate"
+        },
+        {
+          "count": 1,
+          "name": "Raise the Palisade"
+        },
+        {
+          "count": 1,
+          "name": "Trystan's Command"
+        },
+        {
+          "count": 1,
+          "name": "Green Sun's Zenith"
+        },
+        {
+          "count": 1,
+          "name": "Chord of Calling"
+        },
+        {
+          "count": 1,
+          "name": "Nature's Claim"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "The Great Goblin",
+      "author": "MTGGoldfish",
+      "colors": [
+        "B",
+        "R"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Arena of Glory"
+        },
+        {
+          "count": 1,
+          "name": "Auntie's Hovel"
+        },
+        {
+          "count": 1,
+          "name": "Azog, Moria's Ruin"
+        },
+        {
+          "count": 1,
+          "name": "Barad-dur"
+        },
+        {
+          "count": 1,
+          "name": "Battle Hymn"
+        },
+        {
+          "count": 1,
+          "name": "Black Sun's Zenith"
+        },
+        {
+          "count": 1,
+          "name": "Blade of the Bloodchief"
+        },
+        {
+          "count": 1,
+          "name": "Blazemire Verge"
+        },
+        {
+          "count": 1,
+          "name": "Blood Crypt"
+        },
+        {
+          "count": 1,
+          "name": "Bloodchief Ascension"
+        },
+        {
+          "count": 1,
+          "name": "Boggart Cursecrafter"
+        },
+        {
+          "count": 1,
+          "name": "Boggart Harbinger"
+        },
+        {
+          "count": 1,
+          "name": "Boggart Mischief"
+        },
+        {
+          "count": 1,
+          "name": "Bogslither's Embrace"
+        },
+        {
+          "count": 1,
+          "name": "Bothersome Noisemaker"
+        },
+        {
+          "count": 1,
+          "name": "Brightstone Ritual"
+        },
+        {
+          "count": 1,
+          "name": "Cavern of Souls"
+        },
+        {
+          "count": 1,
+          "name": "Champion of the Weird"
+        },
+        {
+          "count": 1,
+          "name": "Chaos Warp"
+        },
+        {
+          "count": 1,
+          "name": "Chthonian Nightmare"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Conspicuous Snoop"
+        },
+        {
+          "count": 1,
+          "name": "Culling the Weak"
+        },
+        {
+          "count": 1,
+          "name": "Deadly Dispute"
+        },
+        {
+          "count": 1,
+          "name": "Dragonskull Summit"
+        },
+        {
+          "count": 1,
+          "name": "Eclipsed Realms"
+        },
+        {
+          "count": 1,
+          "name": "Feign Death"
+        },
+        {
+          "count": 1,
+          "name": "First Day of Class"
+        },
+        {
+          "count": 1,
+          "name": "Frogtosser Banneret"
+        },
+        {
+          "count": 1,
+          "name": "Gev, Scaled Scorch"
+        },
+        {
+          "count": 1,
+          "name": "Gleeful Demolition"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Bombardment"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Chirurgeon"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Matron"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Sledder"
+        },
+        {
+          "count": 1,
+          "name": "Goblin Warchief"
+        },
+        {
+          "count": 1,
+          "name": "Goblin-town"
+        },
+        {
+          "count": 1,
+          "name": "Goblin-town Flunkies"
+        },
+        {
+          "count": 1,
+          "name": "Grub, Storied Matriarch"
+        },
+        {
+          "count": 1,
+          "name": "Haunted Ridge"
+        },
+        {
+          "count": 1,
+          "name": "High Market"
+        },
+        {
+          "count": 1,
+          "name": "Howlsquad Heavy"
+        },
+        {
+          "count": 1,
+          "name": "Imp's Mischief"
+        },
+        {
+          "count": 1,
+          "name": "Impact Tremors"
+        },
+        {
+          "count": 1,
+          "name": "Impulsive Pilferer"
+        },
+        {
+          "count": 1,
+          "name": "Knucklebone Witch"
+        },
+        {
+          "count": 1,
+          "name": "Krenko, Baron of Tin Street"
+        },
+        {
+          "count": 1,
+          "name": "Krenko, Mob Boss"
+        },
+        {
+          "count": 1,
+          "name": "Krenko, Tin Street Kingpin"
+        },
+        {
+          "count": 1,
+          "name": "Kuldotha Rebirth"
+        },
+        {
+          "count": 1,
+          "name": "Living Death"
+        },
+        {
+          "count": 1,
+          "name": "Metallic Mimic"
+        },
+        {
+          "count": 1,
+          "name": "Mogg War Marshal"
+        },
+        {
+          "count": 1,
+          "name": "Molten Duplication"
+        },
+        {
+          "count": 1,
+          "name": "Mount Doom"
+        },
+        {
+          "count": 8,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "Munitions Expert"
+        },
+        {
+          "count": 1,
+          "name": "Murderous Redcap"
+        },
+        {
+          "count": 1,
+          "name": "Nasty End"
+        },
+        {
+          "count": 1,
+          "name": "Pashalik Mons"
+        },
+        {
+          "count": 1,
+          "name": "Patriarch's Bidding"
+        },
+        {
+          "count": 1,
+          "name": "Phyrexian Tower"
+        },
+        {
+          "count": 1,
+          "name": "Pit of Offerings"
+        },
+        {
+          "count": 1,
+          "name": "Pitiless Plunderer"
+        },
+        {
+          "count": 1,
+          "name": "Plumb the Forbidden"
+        },
+        {
+          "count": 1,
+          "name": "Putrid Goblin"
+        },
+        {
+          "count": 1,
+          "name": "Reanimate"
+        },
+        {
+          "count": 1,
+          "name": "Roaming Throne"
+        },
+        {
+          "count": 1,
+          "name": "Scuzzback Scrounger"
+        },
+        {
+          "count": 1,
+          "name": "Siege-Gang Commander"
+        },
+        {
+          "count": 1,
+          "name": "Skirk Prospector"
+        },
+        {
+          "count": 1,
+          "name": "Skullclamp"
+        },
+        {
+          "count": 1,
+          "name": "Sling-Gang Lieutenant"
+        },
+        {
+          "count": 1,
+          "name": "Smoldering Marsh"
+        },
+        {
+          "count": 1,
+          "name": "Spymaster's Vault"
+        },
+        {
+          "count": 1,
+          "name": "Sulfurous Springs"
+        },
+        {
+          "count": 5,
+          "name": "Swamp"
+        },
+        {
+          "count": 1,
+          "name": "Tainted Peak"
+        },
+        {
+          "count": 1,
+          "name": "Tarrian's Soulcleaver"
+        },
+        {
+          "count": 1,
+          "name": "Taurean Mauler"
+        },
+        {
+          "count": 1,
+          "name": "Three Tree City"
+        },
+        {
+          "count": 1,
+          "name": "Tibalt's Trickery"
+        },
+        {
+          "count": 1,
+          "name": "Undying Malice"
+        },
+        {
+          "count": 1,
+          "name": "Untimely Malfunction"
+        },
+        {
+          "count": 1,
+          "name": "Urborg, Tomb of Yawgmoth"
+        },
+        {
+          "count": 1,
+          "name": "Victimize"
+        },
+        {
+          "count": 1,
+          "name": "Warren Soultrader"
+        },
+        {
+          "count": 1,
+          "name": "Wily Goblin"
+        },
+        {
+          "count": 1,
+          "name": "The Great Goblin"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "Beorn the Fierce",
+      "author": "MTGGoldfish",
+      "colors": [
+        "G"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Adaptive Automaton"
+        },
+        {
+          "count": 1,
+          "name": "Archdruid's Charm"
+        },
+        {
+          "count": 1,
+          "name": "Atraxa's Fall"
+        },
+        {
+          "count": 1,
+          "name": "Ayula, Queen Among Bears"
+        },
+        {
+          "count": 1,
+          "name": "Beast Whisperer"
+        },
+        {
+          "count": 1,
+          "name": "Beorn the Fierce"
+        },
+        {
+          "count": 1,
+          "name": "Beorn, Reluctant Host"
+        },
+        {
+          "count": 1,
+          "name": "Beorn's Hospitality"
+        },
+        {
+          "count": 1,
+          "name": "Birds of Paradise"
+        },
+        {
+          "count": 1,
+          "name": "Bite Down"
+        },
+        {
+          "count": 1,
+          "name": "Bosco, Just a Bear"
+        },
+        {
+          "count": 1,
+          "name": "Bushwhack"
+        },
+        {
+          "count": 1,
+          "name": "Castle Garenbrig"
+        },
+        {
+          "count": 1,
+          "name": "Collective Resistance"
+        },
+        {
+          "count": 1,
+          "name": "Copper Host Crusher"
+        },
+        {
+          "count": 1,
+          "name": "Dancing from Dark to Dawn"
+        },
+        {
+          "count": 1,
+          "name": "Descendants' Path"
+        },
+        {
+          "count": 1,
+          "name": "Dragon-Scarred Bear"
+        },
+        {
+          "count": 1,
+          "name": "Drover Grizzly"
+        },
+        {
+          "count": 1,
+          "name": "Emerald Medallion"
+        },
+        {
+          "count": 1,
+          "name": "Evercoat Ursine"
+        },
+        {
+          "count": 31,
+          "name": "Forest"
+        },
+        {
+          "count": 1,
+          "name": "Garruk's Uprising"
+        },
+        {
+          "count": 1,
+          "name": "Gigantic Big Bear"
+        },
+        {
+          "count": 1,
+          "name": "Glorious Sunrise"
+        },
+        {
+          "count": 1,
+          "name": "Goreclaw, Terror of Qal Sisma"
+        },
+        {
+          "count": 1,
+          "name": "Guardian Project"
+        },
+        {
+          "count": 1,
+          "name": "Hard-Hitting Question"
+        },
+        {
+          "count": 1,
+          "name": "Herald's Horn"
+        },
+        {
+          "count": 1,
+          "name": "Lightning Greaves"
+        },
+        {
+          "count": 1,
+          "name": "Little Bear"
+        },
+        {
+          "count": 1,
+          "name": "Llanowar Elves"
+        },
+        {
+          "count": 1,
+          "name": "Lumra, Bellow of the Woods"
+        },
+        {
+          "count": 1,
+          "name": "Masked Vandal"
+        },
+        {
+          "count": 1,
+          "name": "Master's Rebuke"
+        },
+        {
+          "count": 1,
+          "name": "Metallic Mimic"
+        },
+        {
+          "count": 1,
+          "name": "Mother Bear"
+        },
+        {
+          "count": 1,
+          "name": "Natural State"
+        },
+        {
+          "count": 1,
+          "name": "Nature's Claim"
+        },
+        {
+          "count": 1,
+          "name": "Nature's Lore"
+        },
+        {
+          "count": 1,
+          "name": "Nature's Way"
+        },
+        {
+          "count": 1,
+          "name": "Nissa's Pilgrimage"
+        },
+        {
+          "count": 1,
+          "name": "Ordinary Bear"
+        },
+        {
+          "count": 1,
+          "name": "Origin of Metalbending"
+        },
+        {
+          "count": 1,
+          "name": "Owlbear"
+        },
+        {
+          "count": 1,
+          "name": "Owlbear Cub"
+        },
+        {
+          "count": 1,
+          "name": "Primeval Bounty"
+        },
+        {
+          "count": 1,
+          "name": "Quarrel"
+        },
+        {
+          "count": 1,
+          "name": "Radagast of Rhosgobel"
+        },
+        {
+          "count": 1,
+          "name": "Ram Through"
+        },
+        {
+          "count": 1,
+          "name": "Rampaging Yao Guai"
+        },
+        {
+          "count": 1,
+          "name": "Rampant Growth"
+        },
+        {
+          "count": 1,
+          "name": "Return of the Wildspeaker"
+        },
+        {
+          "count": 1,
+          "name": "Return to Nature"
+        },
+        {
+          "count": 1,
+          "name": "Rhonas's Monument"
+        },
+        {
+          "count": 1,
+          "name": "Rishkar's Expertise"
+        },
+        {
+          "count": 1,
+          "name": "Skyshroud Claim"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Studious First-Year"
+        },
+        {
+          "count": 1,
+          "name": "Surrak and Goreclaw"
+        },
+        {
+          "count": 1,
+          "name": "Swiftfoot Boots"
+        },
+        {
+          "count": 1,
+          "name": "The Earth King"
+        },
+        {
+          "count": 1,
+          "name": "The Great Henge"
+        },
+        {
+          "count": 1,
+          "name": "Three Visits"
+        },
+        {
+          "count": 1,
+          "name": "Tribute to the World Tree"
+        },
+        {
+          "count": 1,
+          "name": "Unnatural Growth"
+        },
+        {
+          "count": 1,
+          "name": "Ursine Monstrosity"
+        },
+        {
+          "count": 1,
+          "name": "Vastlands Scavenger"
+        },
+        {
+          "count": 1,
+          "name": "Wild Growth"
+        },
+        {
+          "count": 1,
+          "name": "Wilson, Refined Grizzly"
+        }
+      ],
+      "sideboard": []
+    },
+    {
+      "name": "Bard, King of Dale",
+      "author": "MTGGoldfish",
+      "colors": [
+        "U",
+        "W"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 1,
+          "name": "Bard, King of Dale"
+        },
+        {
+          "count": 1,
+          "name": "The Eagles Are Coming!"
+        },
+        {
+          "count": 1,
+          "name": "Eerie Interference"
+        },
+        {
+          "count": 1,
+          "name": "Esgaroth Garrison"
+        },
+        {
+          "count": 1,
+          "name": "Sleep"
+        },
+        {
+          "count": 1,
+          "name": "A.I.M. Scientists"
+        },
+        {
+          "count": 1,
+          "name": "Palace Guard"
+        },
+        {
+          "count": 1,
+          "name": "Essence Capture"
+        },
+        {
+          "count": 1,
+          "name": "Lake-town"
+        },
+        {
+          "count": 1,
+          "name": "Celebrate the Mountain-king"
+        },
+        {
+          "count": 1,
+          "name": "Master's Councillors"
+        },
+        {
+          "count": 1,
+          "name": "Patient Instructor"
+        },
+        {
+          "count": 1,
+          "name": "Bilbo, Luckwearer"
+        },
+        {
+          "count": 1,
+          "name": "Long Lake Nuisance"
+        },
+        {
+          "count": 1,
+          "name": "Pacifism"
+        },
+        {
+          "count": 1,
+          "name": "Repulse"
+        },
+        {
+          "count": 1,
+          "name": "The Mountain-king's Return"
+        },
+        {
+          "count": 1,
+          "name": "Born to Drive"
+        },
+        {
+          "count": 1,
+          "name": "Lakeshore Apothecary"
+        },
+        {
+          "count": 1,
+          "name": "Lake-town Lookout"
+        },
+        {
+          "count": 1,
+          "name": "Downpour"
+        },
+        {
+          "count": 1,
+          "name": "Captain's Defense"
+        },
+        {
+          "count": 1,
+          "name": "Pym Particles"
+        },
+        {
+          "count": 1,
+          "name": "Hermes, Overseer of Elpis"
+        },
+        {
+          "count": 1,
+          "name": "Alphinaud Leveilleur"
+        },
+        {
+          "count": 1,
+          "name": "Super Intelligence"
+        },
+        {
+          "count": 1,
+          "name": "Sound the Trumpets"
+        },
+        {
+          "count": 1,
+          "name": "Blue Marvel, Adam Brashear"
+        },
+        {
+          "count": 1,
+          "name": "Firemind Vessel"
+        },
+        {
+          "count": 1,
+          "name": "Plunder the Trollshaws"
+        },
+        {
+          "count": 1,
+          "name": "Bard's Company"
+        },
+        {
+          "count": 1,
+          "name": "Old Thrush"
+        },
+        {
+          "count": 1,
+          "name": "Most Decrepit Old Bird"
+        },
+        {
+          "count": 1,
+          "name": "Enchanted River's Grasp"
+        },
+        {
+          "count": 1,
+          "name": "Sensor Splicer"
+        },
+        {
+          "count": 1,
+          "name": "Luxurious Locomotive"
+        },
+        {
+          "count": 1,
+          "name": "Bard the Bowman"
+        },
+        {
+          "count": 1,
+          "name": "Old Fat Spider Can't See Me"
+        },
+        {
+          "count": 1,
+          "name": "Ravenhill Flock"
+        },
+        {
+          "count": 1,
+          "name": "Call the Cavalry"
+        },
+        {
+          "count": 1,
+          "name": "Bilbo Baggins, Burglar"
+        },
+        {
+          "count": 1,
+          "name": "Essence Scatter"
+        },
+        {
+          "count": 1,
+          "name": "Ministrant of Obligation"
+        },
+        {
+          "count": 1,
+          "name": "S.H.I.E.L.D. Deployment Drone"
+        },
+        {
+          "count": 1,
+          "name": "Futurist Forge"
+        },
+        {
+          "count": 1,
+          "name": "Dwarven Provisioner"
+        },
+        {
+          "count": 1,
+          "name": "Knightly Valor"
+        },
+        {
+          "count": 1,
+          "name": "Talrand's Invocation"
+        },
+        {
+          "count": 1,
+          "name": "Waterwind Scout"
+        },
+        {
+          "count": 1,
+          "name": "Harrier Strix"
+        },
+        {
+          "count": 1,
+          "name": "Storm Herd"
+        },
+        {
+          "count": 1,
+          "name": "Harbin, Vanguard Aviator"
+        },
+        {
+          "count": 1,
+          "name": "Sol Ring"
+        },
+        {
+          "count": 1,
+          "name": "Azorius Cluestone"
+        },
+        {
+          "count": 1,
+          "name": "Azorius Locket"
+        },
+        {
+          "count": 1,
+          "name": "Azorius Keyrune"
+        },
+        {
+          "count": 1,
+          "name": "Azorius Signet"
+        },
+        {
+          "count": 1,
+          "name": "Arcane Signet"
+        },
+        {
+          "count": 1,
+          "name": "Bard, Heir of Girion"
+        },
+        {
+          "count": 22,
+          "name": "Island"
+        },
+        {
+          "count": 17,
+          "name": "Plains"
+        },
+        {
+          "count": 1,
+          "name": "Fili the Pathfinder"
+        },
+        {
+          "count": 1,
+          "name": "Thorin's Last Stand"
         }
       ],
       "sideboard": []
@@ -1385,722 +2664,11 @@
       "sideboard": []
     },
     {
-      "name": "Thranduil, the Elvenking",
+      "name": "Pantlaza, Sun-Favored",
       "author": "MTGGoldfish",
       "colors": [
-        "U",
         "G",
-        "B"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Thranduil, Sindarin Liege"
-        },
-        {
-          "count": 1,
-          "name": "Elrond, Moon-Reader"
-        },
-        {
-          "count": 1,
-          "name": "Elven Passage"
-        },
-        {
-          "count": 1,
-          "name": "Devoted Druid"
-        },
-        {
-          "count": 1,
-          "name": "Mindbreak Trap"
-        },
-        {
-          "count": 1,
-          "name": "Tainted Pact"
-        },
-        {
-          "count": 1,
-          "name": "Pact of Negation"
-        },
-        {
-          "count": 1,
-          "name": "Flusterstorm"
-        },
-        {
-          "count": 1,
-          "name": "Finale of Devastation"
-        },
-        {
-          "count": 1,
-          "name": "Buried Alive"
-        },
-        {
-          "count": 1,
-          "name": "Dark Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Shang-Chi, Master of Kung Fu"
-        },
-        {
-          "count": 1,
-          "name": "Mystic Remora"
-        },
-        {
-          "count": 1,
-          "name": "Tyvar, Jubilant Brawler"
-        },
-        {
-          "count": 1,
-          "name": "Chord of Calling"
-        },
-        {
-          "count": 1,
-          "name": "Crop Rotation"
-        },
-        {
-          "count": 1,
-          "name": "Mental Misstep"
-        },
-        {
-          "count": 1,
-          "name": "Demonic Consultation"
-        },
-        {
-          "count": 1,
-          "name": "Force of Negation"
-        },
-        {
-          "count": 1,
-          "name": "Delighted Halfling"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Spirit Guide"
-        },
-        {
-          "count": 1,
-          "name": "Diabolic Intent"
-        },
-        {
-          "count": 1,
-          "name": "Veil of Summer"
-        },
-        {
-          "count": 1,
-          "name": "Thranduil, the Elvenking"
-        },
-        {
-          "count": 1,
-          "name": "Ancient Tomb"
-        },
-        {
-          "count": 1,
-          "name": "Rhystic Study"
-        },
-        {
-          "count": 1,
-          "name": "Mana Vault"
-        },
-        {
-          "count": 1,
-          "name": "Gaea's Cradle"
-        },
-        {
-          "count": 1,
-          "name": "Demonic Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Force of Will"
-        },
-        {
-          "count": 1,
-          "name": "Chrome Mox"
-        },
-        {
-          "count": 1,
-          "name": "Vampiric Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Survival of the Fittest"
-        },
-        {
-          "count": 1,
-          "name": "Elves of Deep Shadow"
-        },
-        {
-          "count": 1,
-          "name": "Deathrite Shaman"
-        },
-        {
-          "count": 1,
-          "name": "Incubation Druid"
-        },
-        {
-          "count": 1,
-          "name": "Zameck Guildmage"
-        },
-        {
-          "count": 1,
-          "name": "Faerie Mastermind"
-        },
-        {
-          "count": 1,
-          "name": "Birds of Paradise"
-        },
-        {
-          "count": 1,
-          "name": "Orcish Bowmasters"
-        },
-        {
-          "count": 1,
-          "name": "Bloom Tender"
-        },
-        {
-          "count": 1,
-          "name": "Hermit Druid"
-        },
-        {
-          "count": 1,
-          "name": "Priest of Titania"
-        },
-        {
-          "count": 1,
-          "name": "Kinnan, Bonder Prodigy"
-        },
-        {
-          "count": 1,
-          "name": "Badgermole Cub"
-        },
-        {
-          "count": 1,
-          "name": "Selvala, Heart of the Wilds"
-        },
-        {
-          "count": 1,
-          "name": "Fauna Shaman"
-        },
-        {
-          "count": 1,
-          "name": "Elvish Mystic"
-        },
-        {
-          "count": 1,
-          "name": "Valley Floodcaller"
-        },
-        {
-          "count": 1,
-          "name": "Llanowar Elves"
-        },
-        {
-          "count": 1,
-          "name": "Mockingbird"
-        },
-        {
-          "count": 1,
-          "name": "Thassa's Oracle"
-        },
-        {
-          "count": 1,
-          "name": "Thousand-Year Elixir"
-        },
-        {
-          "count": 1,
-          "name": "Lion's Eye Diamond"
-        },
-        {
-          "count": 1,
-          "name": "Brain Freeze"
-        },
-        {
-          "count": 1,
-          "name": "Mox Diamond"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Lotus Petal"
-        },
-        {
-          "count": 1,
-          "name": "Praetor's Grasp"
-        },
-        {
-          "count": 1,
-          "name": "Basalt Monolith"
-        },
-        {
-          "count": 1,
-          "name": "The One Ring"
-        },
-        {
-          "count": 1,
-          "name": "Thrasios, Triton Hero"
-        },
-        {
-          "count": 1,
-          "name": "Narcomoeba"
-        },
-        {
-          "count": 1,
-          "name": "Dread Return"
-        },
-        {
-          "count": 1,
-          "name": "Dauthi Voidwalker"
-        },
-        {
-          "count": 1,
-          "name": "Opposition Agent"
-        },
-        {
-          "count": 1,
-          "name": "Entomb"
-        },
-        {
-          "count": 1,
-          "name": "Mystical Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Worldly Tutor"
-        },
-        {
-          "count": 1,
-          "name": "Fierce Guardianship"
-        },
-        {
-          "count": 1,
-          "name": "Swan Song"
-        },
-        {
-          "count": 1,
-          "name": "Cyclonic Rift"
-        },
-        {
-          "count": 1,
-          "name": "Abrupt Decay"
-        },
-        {
-          "count": 1,
-          "name": "Assassin's Trophy"
-        },
-        {
-          "count": 1,
-          "name": "Bloodstained Mire"
-        },
-        {
-          "count": 1,
-          "name": "Flooded Strand"
-        },
-        {
-          "count": 1,
-          "name": "Marsh Flats"
-        },
-        {
-          "count": 1,
-          "name": "Misty Rainforest"
-        },
-        {
-          "count": 1,
-          "name": "Polluted Delta"
-        },
-        {
-          "count": 1,
-          "name": "Scalding Tarn"
-        },
-        {
-          "count": 1,
-          "name": "Verdant Catacombs"
-        },
-        {
-          "count": 1,
-          "name": "Windswept Heath"
-        },
-        {
-          "count": 1,
-          "name": "Wooded Foothills"
-        },
-        {
-          "count": 1,
-          "name": "Bayou"
-        },
-        {
-          "count": 1,
-          "name": "Tropical Island"
-        },
-        {
-          "count": 1,
-          "name": "Underground Sea"
-        },
-        {
-          "count": 1,
-          "name": "Breeding Pool"
-        },
-        {
-          "count": 1,
-          "name": "Overgrown Tomb"
-        },
-        {
-          "count": 1,
-          "name": "Watery Grave"
-        },
-        {
-          "count": 1,
-          "name": "City of Brass"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Exotic Orchard"
-        },
-        {
-          "count": 1,
-          "name": "Mana Confluence"
-        },
-        {
-          "count": 1,
-          "name": "Morphic Pool"
-        },
-        {
-          "count": 1,
-          "name": "Rejuvenating Springs"
-        },
-        {
-          "count": 1,
-          "name": "Undergrowth Stadium"
-        },
-        {
-          "count": 1,
-          "name": "Boseiju, Who Endures"
-        },
-        {
-          "count": 1,
-          "name": "Cephalid Coliseum"
-        },
-        {
-          "count": 1,
-          "name": "Gemstone Caverns"
-        },
-        {
-          "count": 1,
-          "name": "Otawara, Soaring City"
-        }
-      ],
-      "sideboard": []
-    },
-    {
-      "name": "Beorn the Fierce",
-      "author": "MTGGoldfish",
-      "colors": [
-        "G"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Beorn the Fierce"
-        },
-        {
-          "count": 1,
-          "name": "Ayula, Queen Among Bears"
-        },
-        {
-          "count": 1,
-          "name": "The Earth King"
-        },
-        {
-          "count": 1,
-          "name": "Vastlands Scavenger"
-        },
-        {
-          "count": 1,
-          "name": "Chameleon Colossus"
-        },
-        {
-          "count": 1,
-          "name": "Primordial Sage"
-        },
-        {
-          "count": 1,
-          "name": "Selfless Safewright"
-        },
-        {
-          "count": 1,
-          "name": "Flaxen Intruder"
-        },
-        {
-          "count": 1,
-          "name": "Ghalta, Primal Hunger"
-        },
-        {
-          "count": 1,
-          "name": "Terrian, World Tyrant"
-        },
-        {
-          "count": 1,
-          "name": "Soul of the Harvest"
-        },
-        {
-          "count": 1,
-          "name": "Ursine Monstrosity"
-        },
-        {
-          "count": 1,
-          "name": "Owlbear Cub"
-        },
-        {
-          "count": 1,
-          "name": "Druid's Familiar"
-        },
-        {
-          "count": 1,
-          "name": "Llanowar Elves"
-        },
-        {
-          "count": 1,
-          "name": "Studious First-Year"
-        },
-        {
-          "count": 1,
-          "name": "Keeper of Fables"
-        },
-        {
-          "count": 1,
-          "name": "Garruk's Packleader"
-        },
-        {
-          "count": 1,
-          "name": "Bane of Progress"
-        },
-        {
-          "count": 1,
-          "name": "Lizard, Connors's Curse"
-        },
-        {
-          "count": 1,
-          "name": "Evercoat Ursine"
-        },
-        {
-          "count": 1,
-          "name": "Titan of Industry"
-        },
-        {
-          "count": 1,
-          "name": "Thunderfoot Baloth"
-        },
-        {
-          "count": 1,
-          "name": "Jubilation"
-        },
-        {
-          "count": 1,
-          "name": "Raucous Audience"
-        },
-        {
-          "count": 1,
-          "name": "Ilysian Caryatid"
-        },
-        {
-          "count": 1,
-          "name": "Quakestrider Ceratops"
-        },
-        {
-          "count": 1,
-          "name": "Ruxa, Patient Professor"
-        },
-        {
-          "count": 1,
-          "name": "Gigantosaurus"
-        },
-        {
-          "count": 1,
-          "name": "Owlbear"
-        },
-        {
-          "count": 1,
-          "name": "Goreclaw, Terror of Qal Sisma"
-        },
-        {
-          "count": 1,
-          "name": "Werebear"
-        },
-        {
-          "count": 1,
-          "name": "Chomping Changeling"
-        },
-        {
-          "count": 1,
-          "name": "Gigantic Big Bear"
-        },
-        {
-          "count": 1,
-          "name": "Titania's Command"
-        },
-        {
-          "count": 1,
-          "name": "Origin of Metalbending"
-        },
-        {
-          "count": 1,
-          "name": "Grizzly Fate"
-        },
-        {
-          "count": 1,
-          "name": "Kamahl's Summons"
-        },
-        {
-          "count": 1,
-          "name": "Overrun"
-        },
-        {
-          "count": 1,
-          "name": "Ram Through"
-        },
-        {
-          "count": 1,
-          "name": "Super Combo"
-        },
-        {
-          "count": 1,
-          "name": "Harmonize"
-        },
-        {
-          "count": 1,
-          "name": "Rampant Growth"
-        },
-        {
-          "count": 1,
-          "name": "Cultivate"
-        },
-        {
-          "count": 1,
-          "name": "Explosive Vegetation"
-        },
-        {
-          "count": 1,
-          "name": "Return of the Wildspeaker"
-        },
-        {
-          "count": 1,
-          "name": "Become the Avalanche"
-        },
-        {
-          "count": 1,
-          "name": "Beast Within"
-        },
-        {
-          "count": 1,
-          "name": "Shamanic Revelation"
-        },
-        {
-          "count": 1,
-          "name": "Oblivion Stone"
-        },
-        {
-          "count": 1,
-          "name": "Hunter's Bow"
-        },
-        {
-          "count": 1,
-          "name": "Lifecrafter's Bestiary"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Firdoch Core"
-        },
-        {
-          "count": 1,
-          "name": "Mind Stone"
-        },
-        {
-          "count": 1,
-          "name": "Words of Wilding"
-        },
-        {
-          "count": 1,
-          "name": "Hunter's Talent"
-        },
-        {
-          "count": 1,
-          "name": "Lignify"
-        },
-        {
-          "count": 1,
-          "name": "Garruk's Uprising"
-        },
-        {
-          "count": 1,
-          "name": "Fertile Ground"
-        },
-        {
-          "count": 1,
-          "name": "Wild Growth"
-        },
-        {
-          "count": 1,
-          "name": "Ayula's Influence"
-        },
-        {
-          "count": 30,
-          "name": "Forest"
-        },
-        {
-          "count": 1,
-          "name": "Turntimber Symbiosis"
-        },
-        {
-          "count": 1,
-          "name": "Bonders' Enclave"
-        },
-        {
-          "count": 1,
-          "name": "Bridgeworks Battle"
-        },
-        {
-          "count": 1,
-          "name": "Ominous Cemetery"
-        },
-        {
-          "count": 1,
-          "name": "Mosswort Bridge"
-        },
-        {
-          "count": 1,
-          "name": "Lair of the Hydra"
-        },
-        {
-          "count": 1,
-          "name": "Khalni Ambush"
-        },
-        {
-          "count": 1,
-          "name": "Disciple of Freyalise"
-        }
-      ],
-      "sideboard": []
-    },
-    {
-      "name": "Bard, King of Dale",
-      "author": "MTGGoldfish",
-      "colors": [
-        "U",
+        "R",
         "W"
       ],
       "tags": [
@@ -2109,211 +2677,159 @@
       "main": [
         {
           "count": 1,
-          "name": "Bard, King of Dale"
+          "name": "Ixalli's Lorekeeper"
         },
         {
           "count": 1,
-          "name": "The Eagles Are Coming!"
+          "name": "Otepec Huntmaster"
         },
         {
           "count": 1,
-          "name": "Eerie Interference"
+          "name": "Marauding Raptor"
         },
         {
           "count": 1,
-          "name": "Esgaroth Garrison"
+          "name": "Intrepid Paleontologist"
         },
         {
           "count": 1,
-          "name": "Sleep"
+          "name": "Drover of the Mighty"
         },
         {
           "count": 1,
-          "name": "A.I.M. Scientists"
+          "name": "Belligerent Yearling"
         },
         {
           "count": 1,
-          "name": "Palace Guard"
+          "name": "Thrashing Brontodon"
         },
         {
           "count": 1,
-          "name": "Essence Capture"
+          "name": "Atzocan Seer"
         },
         {
           "count": 1,
-          "name": "Lake-town"
+          "name": "Itzquinth, Firstborn of Gishath"
         },
         {
           "count": 1,
-          "name": "Celebrate the Mountain-king"
+          "name": "Sunfrill Imitator"
         },
         {
           "count": 1,
-          "name": "Master's Councillors"
+          "name": "Pugnacious Hammerskull"
         },
         {
           "count": 1,
-          "name": "Patient Instructor"
+          "name": "Pantlaza, Sun-Favored"
         },
         {
           "count": 1,
-          "name": "Bilbo, Luckwearer"
+          "name": "Runic Armasaur"
         },
         {
           "count": 1,
-          "name": "Long Lake Nuisance"
+          "name": "Kinjalli's Sunwing"
         },
         {
           "count": 1,
-          "name": "Pacifism"
+          "name": "Topiary Stomper"
         },
         {
           "count": 1,
-          "name": "Repulse"
+          "name": "Regal Imperiosaur"
         },
         {
           "count": 1,
-          "name": "The Mountain-king's Return"
+          "name": "Wayward Swordtooth"
         },
         {
           "count": 1,
-          "name": "Born to Drive"
+          "name": "Bronzebeak Foragers"
         },
         {
           "count": 1,
-          "name": "Lakeshore Apothecary"
+          "name": "Curious Altisaur"
         },
         {
           "count": 1,
-          "name": "Lake-town Lookout"
+          "name": "Hulking Raptor"
         },
         {
           "count": 1,
-          "name": "Downpour"
+          "name": "Ripjaw Raptor"
         },
         {
           "count": 1,
-          "name": "Captain's Defense"
+          "name": "Bonehoard Dracosaur"
         },
         {
           "count": 1,
-          "name": "Pym Particles"
+          "name": "Quartzwood Crasher"
         },
         {
           "count": 1,
-          "name": "Hermes, Overseer of Elpis"
+          "name": "Regisaur Alpha"
         },
         {
           "count": 1,
-          "name": "Alphinaud Leveilleur"
+          "name": "Temple Altisaur"
         },
         {
           "count": 1,
-          "name": "Super Intelligence"
+          "name": "Wrathful Raptors"
         },
         {
           "count": 1,
-          "name": "Sound the Trumpets"
+          "name": "Earthshaker Dreadmaw"
         },
         {
           "count": 1,
-          "name": "Blue Marvel, Adam Brashear"
+          "name": "Etali, Primal Storm"
         },
         {
           "count": 1,
-          "name": "Firemind Vessel"
+          "name": "Trumpeting Carnosaur"
         },
         {
           "count": 1,
-          "name": "Plunder the Trollshaws"
+          "name": "Ghalta and Mavren"
         },
         {
           "count": 1,
-          "name": "Bard's Company"
+          "name": "Rampaging Brontodon"
         },
         {
           "count": 1,
-          "name": "Old Thrush"
+          "name": "Agonasaur Rex"
         },
         {
           "count": 1,
-          "name": "Most Decrepit Old Bird"
+          "name": "Gishath, Sun's Avatar"
         },
         {
           "count": 1,
-          "name": "Enchanted River's Grasp"
+          "name": "Wakening Sun's Avatar"
         },
         {
           "count": 1,
-          "name": "Sensor Splicer"
+          "name": "Zetalpa, Primal Dawn"
         },
         {
           "count": 1,
-          "name": "Luxurious Locomotive"
+          "name": "Apex Altisaur"
         },
         {
           "count": 1,
-          "name": "Bard the Bowman"
+          "name": "Zacama, Primal Calamity"
         },
         {
           "count": 1,
-          "name": "Old Fat Spider Can't See Me"
+          "name": "Ghalta, Primal Hunger"
         },
         {
           "count": 1,
-          "name": "Ravenhill Flock"
-        },
-        {
-          "count": 1,
-          "name": "Call the Cavalry"
-        },
-        {
-          "count": 1,
-          "name": "Bilbo Baggins, Burglar"
-        },
-        {
-          "count": 1,
-          "name": "Essence Scatter"
-        },
-        {
-          "count": 1,
-          "name": "Ministrant of Obligation"
-        },
-        {
-          "count": 1,
-          "name": "S.H.I.E.L.D. Deployment Drone"
-        },
-        {
-          "count": 1,
-          "name": "Futurist Forge"
-        },
-        {
-          "count": 1,
-          "name": "Dwarven Provisioner"
-        },
-        {
-          "count": 1,
-          "name": "Knightly Valor"
-        },
-        {
-          "count": 1,
-          "name": "Talrand's Invocation"
-        },
-        {
-          "count": 1,
-          "name": "Waterwind Scout"
-        },
-        {
-          "count": 1,
-          "name": "Harrier Strix"
-        },
-        {
-          "count": 1,
-          "name": "Storm Herd"
-        },
-        {
-          "count": 1,
-          "name": "Harbin, Vanguard Aviator"
+          "name": "Goring Ceratops"
         },
         {
           "count": 1,
@@ -2321,377 +2837,7 @@
         },
         {
           "count": 1,
-          "name": "Azorius Cluestone"
-        },
-        {
-          "count": 1,
-          "name": "Azorius Locket"
-        },
-        {
-          "count": 1,
-          "name": "Azorius Keyrune"
-        },
-        {
-          "count": 1,
-          "name": "Azorius Signet"
-        },
-        {
-          "count": 1,
           "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Bard, Heir of Girion"
-        },
-        {
-          "count": 22,
-          "name": "Island"
-        },
-        {
-          "count": 17,
-          "name": "Plains"
-        },
-        {
-          "count": 1,
-          "name": "Fili the Pathfinder"
-        },
-        {
-          "count": 1,
-          "name": "Thorin's Last Stand"
-        }
-      ],
-      "sideboard": []
-    },
-    {
-      "name": "The Great Goblin",
-      "author": "MTGGoldfish",
-      "colors": [
-        "R",
-        "B"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Along the Crooked Way"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Azog, Moria's Ruin"
-        },
-        {
-          "count": 1,
-          "name": "Beetleback Chief"
-        },
-        {
-          "count": 1,
-          "name": "Bloodfell Caves"
-        },
-        {
-          "count": 1,
-          "name": "Boggart Birth Rite"
-        },
-        {
-          "count": 1,
-          "name": "Boggart Cursecrafter"
-        },
-        {
-          "count": 1,
-          "name": "Bolg's Company"
-        },
-        {
-          "count": 1,
-          "name": "Chain Reaction"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Dragon Fodder"
-        },
-        {
-          "count": 1,
-          "name": "Foreboding Ruins"
-        },
-        {
-          "count": 1,
-          "name": "Gathering of Darkness"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Cratermaker"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Fireleaper"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Instigator"
-        },
-        {
-          "count": 1,
-          "name": "The Great Goblin"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Matron"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Motivator"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Negotiation"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Surprise"
-        },
-        {
-          "count": 1,
-          "name": "Goblin-town"
-        },
-        {
-          "count": 1,
-          "name": "Great Ugly-Looking Goblin"
-        },
-        {
-          "count": 1,
-          "name": "Grond, the Gatebreaker"
-        },
-        {
-          "count": 1,
-          "name": "Grub's Command"
-        },
-        {
-          "count": 1,
-          "name": "Hordeling Outburst"
-        },
-        {
-          "count": 1,
-          "name": "Krenko's Command"
-        },
-        {
-          "count": 1,
-          "name": "Krenko, Mob Boss"
-        },
-        {
-          "count": 1,
-          "name": "Mauhur, Uruk-hai Captain"
-        },
-        {
-          "count": 1,
-          "name": "Mob Justice"
-        },
-        {
-          "count": 1,
-          "name": "Mordor Muster"
-        },
-        {
-          "count": 1,
-          "name": "Mudbutton Torchrunner"
-        },
-        {
-          "count": 1,
-          "name": "Munitions Expert"
-        },
-        {
-          "count": 1,
-          "name": "Orcish Cannonade"
-        },
-        {
-          "count": 1,
-          "name": "Orcish Medicine"
-        },
-        {
-          "count": 1,
-          "name": "Orcish Vandal"
-        },
-        {
-          "count": 1,
-          "name": "Rage into the Valley"
-        },
-        {
-          "count": 1,
-          "name": "Siege-Gang Commander"
-        },
-        {
-          "count": 1,
-          "name": "Smoldering Marsh"
-        },
-        {
-          "count": 1,
-          "name": "Stir Up Trouble"
-        },
-        {
-          "count": 1,
-          "name": "Swarming of Moria"
-        },
-        {
-          "count": 1,
-          "name": "The Torment of Gollum"
-        },
-        {
-          "count": 1,
-          "name": "Volley Veteran"
-        },
-        {
-          "count": 8,
-          "name": "Mountain"
-        },
-        {
-          "count": 8,
-          "name": "Swamp"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Bombardment"
-        },
-        {
-          "count": 1,
-          "name": "Go for the Throat"
-        },
-        {
-          "count": 1,
-          "name": "Blasphemous Act"
-        },
-        {
-          "count": 1,
-          "name": "Warg Rider"
-        },
-        {
-          "count": 1,
-          "name": "Sling-Gang Lieutenant"
-        },
-        {
-          "count": 1,
-          "name": "Mirkwood Bats"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Trashmaster"
-        },
-        {
-          "count": 1,
-          "name": "Warren Soultrader"
-        },
-        {
-          "count": 1,
-          "name": "Taurean Mauler"
-        },
-        {
-          "count": 1,
-          "name": "Hobgoblin Bandit Lord"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Chieftain"
-        },
-        {
-          "count": 1,
-          "name": "Hexing Squelcher"
-        },
-        {
-          "count": 1,
-          "name": "Frogtosser Banneret"
-        },
-        {
-          "count": 1,
-          "name": "Conspicuous Snoop"
-        },
-        {
-          "count": 1,
-          "name": "Moria Marauder"
-        },
-        {
-          "count": 1,
-          "name": "Gorbag of Minas Morgul"
-        },
-        {
-          "count": 1,
-          "name": "Great Goblin, Foul-Hearted"
-        },
-        {
-          "count": 1,
-          "name": "Ugluk of the White Hand"
-        },
-        {
-          "count": 1,
-          "name": "Bolg, Erebor's Reckoning"
-        },
-        {
-          "count": 1,
-          "name": "Brightstone Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Goblin War Strike"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Ringleader"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Warchief"
-        },
-        {
-          "count": 1,
-          "name": "Reliquary Tower"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Grenade"
-        },
-        {
-          "count": 1,
-          "name": "Rakdos Signet"
-        },
-        {
-          "count": 1,
-          "name": "Swiftfoot Boots"
-        },
-        {
-          "count": 1,
-          "name": "Angrath, Captain of Chaos"
-        },
-        {
-          "count": 1,
-          "name": "Goblin Lackey"
-        },
-        {
-          "count": 1,
-          "name": "Dunland Crebain"
-        },
-        {
-          "count": 1,
-          "name": "Chaos Warp"
-        },
-        {
-          "count": 1,
-          "name": "Blasphemous Edict"
-        },
-        {
-          "count": 1,
-          "name": "Corrupted Conviction"
-        },
-        {
-          "count": 1,
-          "name": "Dark Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Jet Medallion"
         },
         {
           "count": 1,
@@ -2699,23 +2845,203 @@
         },
         {
           "count": 1,
-          "name": "Crude Bent Blade"
+          "name": "Swiftfoot Boots"
         },
         {
           "count": 1,
-          "name": "Orcrist, Goblin-cleaver"
+          "name": "The Skullspore Nexus"
         },
         {
           "count": 1,
-          "name": "Patchwork Banner"
+          "name": "Descendants' Path"
         },
         {
           "count": 1,
-          "name": "Orcish Siegemaster"
+          "name": "Elemental Bond"
         },
         {
           "count": 1,
-          "name": "Gothmog, Morgul Lieutenant"
+          "name": "Garruk's Uprising"
+        },
+        {
+          "count": 1,
+          "name": "Rhythm of the Wild"
+        },
+        {
+          "count": 1,
+          "name": "Ephemerate"
+        },
+        {
+          "count": 1,
+          "name": "Path to Exile"
+        },
+        {
+          "count": 1,
+          "name": "Beast Within"
+        },
+        {
+          "count": 1,
+          "name": "Blasphemous Act"
+        },
+        {
+          "count": 1,
+          "name": "Boros Charm"
+        },
+        {
+          "count": 1,
+          "name": "Sundering Eruption"
+        },
+        {
+          "count": 1,
+          "name": "Swords to Plowshares"
+        },
+        {
+          "count": 1,
+          "name": "Generous Gift"
+        },
+        {
+          "count": 1,
+          "name": "Return of the Wildspeaker"
+        },
+        {
+          "count": 1,
+          "name": "Farseek"
+        },
+        {
+          "count": 1,
+          "name": "Rampant Growth"
+        },
+        {
+          "count": 1,
+          "name": "Thunderherd Migration"
+        },
+        {
+          "count": 1,
+          "name": "Cultivate"
+        },
+        {
+          "count": 1,
+          "name": "Kodama's Reach"
+        },
+        {
+          "count": 1,
+          "name": "Chandra's Ignition"
+        },
+        {
+          "count": 1,
+          "name": "Rishkar's Expertise"
+        },
+        {
+          "count": 1,
+          "name": "Brushland"
+        },
+        {
+          "count": 1,
+          "name": "Fire-Lit Thicket"
+        },
+        {
+          "count": 1,
+          "name": "Rockfall Vale"
+        },
+        {
+          "count": 1,
+          "name": "Legion Leadership"
+        },
+        {
+          "count": 1,
+          "name": "Command Tower"
+        },
+        {
+          "count": 1,
+          "name": "Overgrown Farmland"
+        },
+        {
+          "count": 1,
+          "name": "Exotic Orchard"
+        },
+        {
+          "count": 6,
+          "name": "Forest"
+        },
+        {
+          "count": 1,
+          "name": "Canopy Vista"
+        },
+        {
+          "count": 1,
+          "name": "Rootbound Crag"
+        },
+        {
+          "count": 1,
+          "name": "Sundown Pass"
+        },
+        {
+          "count": 1,
+          "name": "Gruul Turf"
+        },
+        {
+          "count": 1,
+          "name": "Selesnya Sanctuary"
+        },
+        {
+          "count": 1,
+          "name": "Jungle Shrine"
+        },
+        {
+          "count": 1,
+          "name": "Kessig Wolf Run"
+        },
+        {
+          "count": 1,
+          "name": "Mosswort Bridge"
+        },
+        {
+          "count": 2,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "Path of Ancestry"
+        },
+        {
+          "count": 3,
+          "name": "Plains"
+        },
+        {
+          "count": 1,
+          "name": "Sunpetal Grove"
+        },
+        {
+          "count": 1,
+          "name": "Battlefield Forge"
+        },
+        {
+          "count": 1,
+          "name": "Secluded Courtyard"
+        },
+        {
+          "count": 1,
+          "name": "Karplusan Forest"
+        },
+        {
+          "count": 1,
+          "name": "Cinder Glade"
+        },
+        {
+          "count": 1,
+          "name": "Unclaimed Territory"
+        },
+        {
+          "count": 1,
+          "name": "Rogue's Passage"
+        },
+        {
+          "count": 1,
+          "name": "Stump Stomp"
+        },
+        {
+          "count": 1,
+          "name": "Bridgeworks Battle"
         }
       ],
       "sideboard": []
@@ -2741,14 +3067,6 @@
         {
           "count": 1,
           "name": "Inspired Tinkering"
-        },
-        {
-          "count": 1,
-          "name": "Sarkhan, Dragon Ascendant"
-        },
-        {
-          "count": 1,
-          "name": "Quicksmith Genius"
         },
         {
           "count": 1,
@@ -2780,15 +3098,7 @@
         },
         {
           "count": 1,
-          "name": "Thundermane Dragon"
-        },
-        {
-          "count": 1,
           "name": "Vault Robber"
-        },
-        {
-          "count": 1,
-          "name": "Kolaghan Warmonger"
         },
         {
           "count": 1,
@@ -2816,10 +3126,6 @@
         },
         {
           "count": 1,
-          "name": "Fable of the Mirror-Breaker"
-        },
-        {
-          "count": 1,
           "name": "Strike It Rich"
         },
         {
@@ -2829,10 +3135,6 @@
         {
           "count": 1,
           "name": "Dragon's Fire"
-        },
-        {
-          "count": 1,
-          "name": "Spikefield Hazard"
         },
         {
           "count": 1,
@@ -2936,6 +3238,10 @@
         },
         {
           "count": 1,
+          "name": "Smaug the Magnificent"
+        },
+        {
+          "count": 1,
           "name": "Knuckles the Echidna"
         },
         {
@@ -2972,10 +3278,6 @@
         },
         {
           "count": 1,
-          "name": "Nesting Dragon"
-        },
-        {
-          "count": 1,
           "name": "Improvised Weaponry"
         },
         {
@@ -3004,406 +3306,31 @@
         },
         {
           "count": 1,
-          "name": "Smaug the Magnificent"
-        }
-      ],
-      "sideboard": []
-    },
-    {
-      "name": "Pantlaza, Sun-Favored",
-      "author": "MTGGoldfish",
-      "colors": [
-        "G",
-        "W",
-        "R"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 1,
-          "name": "Pantlaza, Sun-Favored"
-        },
-        {
-          "count": 1,
-          "name": "Radagast of Rhosgobel"
-        },
-        {
-          "count": 1,
-          "name": "Gishath, Sun's Avatar"
-        },
-        {
-          "count": 1,
-          "name": "Zacama, Primal Calamity"
-        },
-        {
-          "count": 1,
-          "name": "Regisaur Alpha"
-        },
-        {
-          "count": 1,
-          "name": "Wrathful Raptors"
-        },
-        {
-          "count": 1,
-          "name": "Earthshaker Dreadmaw"
-        },
-        {
-          "count": 1,
-          "name": "Curious Altisaur"
-        },
-        {
-          "count": 1,
-          "name": "Topiary Stomper"
-        },
-        {
-          "count": 1,
-          "name": "Bronzebeak Foragers"
-        },
-        {
-          "count": 1,
-          "name": "Wakening Sun's Avatar"
-        },
-        {
-          "count": 1,
-          "name": "Rhythm of the Wild"
-        },
-        {
-          "count": 1,
-          "name": "Farseek"
-        },
-        {
-          "count": 1,
-          "name": "Nature's Lore"
-        },
-        {
-          "count": 1,
-          "name": "Three Visits"
-        },
-        {
-          "count": 1,
-          "name": "Wayward Swordtooth"
-        },
-        {
-          "count": 1,
-          "name": "Path to Exile"
-        },
-        {
-          "count": 1,
-          "name": "Swords to Plowshares"
-        },
-        {
-          "count": 1,
-          "name": "Garruk's Uprising"
-        },
-        {
-          "count": 1,
-          "name": "Quartzwood Crasher"
-        },
-        {
-          "count": 1,
-          "name": "Otepec Huntmaster"
-        },
-        {
-          "count": 1,
-          "name": "Hulking Raptor"
-        },
-        {
-          "count": 1,
-          "name": "Kinjalli's Sunwing"
-        },
-        {
-          "count": 1,
-          "name": "Regal Behemoth"
-        },
-        {
-          "count": 1,
-          "name": "Trumpeting Carnosaur"
-        },
-        {
-          "count": 1,
-          "name": "Thrashing Brontodon"
-        },
-        {
-          "count": 1,
-          "name": "Ghalta and Mavren"
-        },
-        {
-          "count": 1,
-          "name": "Zetalpa, Primal Dawn"
-        },
-        {
-          "count": 1,
-          "name": "Marauding Raptor"
-        },
-        {
-          "count": 1,
           "name": "Bonehoard Dracosaur"
         },
         {
           "count": 1,
-          "name": "Atzocan Seer"
+          "name": "Professional Face-Breaker"
         },
         {
           "count": 1,
-          "name": "Hunting Velociraptor"
+          "name": "The Reaver Cleaver"
         },
         {
           "count": 1,
-          "name": "Ixalli's Lorekeeper"
+          "name": "Dragon's Hoard"
         },
         {
           "count": 1,
-          "name": "Vaultborn Tyrant"
+          "name": "Desert Were-Worm"
         },
         {
           "count": 1,
-          "name": "Dinosaurs on a Spaceship"
+          "name": "Idol of Oblivion"
         },
         {
           "count": 1,
-          "name": "Drover of the Mighty"
-        },
-        {
-          "count": 1,
-          "name": "Devil Dinosaur"
-        },
-        {
-          "count": 1,
-          "name": "Ravenous Tyrannosaurus"
-        },
-        {
-          "count": 1,
-          "name": "Regal Imperiosaur"
-        },
-        {
-          "count": 1,
-          "name": "Kinjalli's Caller"
-        },
-        {
-          "count": 1,
-          "name": "Return of the Wildspeaker"
-        },
-        {
-          "count": 1,
-          "name": "Heroic Intervention"
-        },
-        {
-          "count": 1,
-          "name": "Flawless Maneuver"
-        },
-        {
-          "count": 1,
-          "name": "Get Lost"
-        },
-        {
-          "count": 1,
-          "name": "Parting Gust"
-        },
-        {
-          "count": 1,
-          "name": "Rampant Growth"
-        },
-        {
-          "count": 1,
-          "name": "Skyshroud Claim"
-        },
-        {
-          "count": 1,
-          "name": "Urza's Incubator"
-        },
-        {
-          "count": 1,
-          "name": "Kodama's Reach"
-        },
-        {
-          "count": 1,
-          "name": "Cultivate"
-        },
-        {
-          "count": 1,
-          "name": "Elemental Bond"
-        },
-        {
-          "count": 1,
-          "name": "Welcome to . . ."
-        },
-        {
-          "count": 1,
-          "name": "Poetic Ingenuity"
-        },
-        {
-          "count": 1,
-          "name": "Sol Ring"
-        },
-        {
-          "count": 1,
-          "name": "Arcane Signet"
-        },
-        {
-          "count": 1,
-          "name": "Patchwork Banner"
-        },
-        {
-          "count": 1,
-          "name": "Blasphemous Act"
-        },
-        {
-          "count": 1,
-          "name": "Everything Comes to Dust"
-        },
-        {
-          "count": 1,
-          "name": "Palani's Hatcher"
-        },
-        {
-          "count": 1,
-          "name": "Huatli, Poet of Unity"
-        },
-        {
-          "count": 1,
-          "name": "Spire Garden"
-        },
-        {
-          "count": 1,
-          "name": "Bountiful Promenade"
-        },
-        {
-          "count": 1,
-          "name": "Spectator Seating"
-        },
-        {
-          "count": 1,
-          "name": "Sunpetal Grove"
-        },
-        {
-          "count": 1,
-          "name": "Rootbound Crag"
-        },
-        {
-          "count": 1,
-          "name": "Restless Ridgeline"
-        },
-        {
-          "count": 1,
-          "name": "Battlefield Forge"
-        },
-        {
-          "count": 1,
-          "name": "Karplusan Forest"
-        },
-        {
-          "count": 1,
-          "name": "Brushland"
-        },
-        {
-          "count": 3,
-          "name": "Snow-Covered Forest"
-        },
-        {
-          "count": 2,
-          "name": "Snow-Covered Plains"
-        },
-        {
-          "count": 2,
-          "name": "Snow-Covered Mountain"
-        },
-        {
-          "count": 1,
-          "name": "Arid Mesa"
-        },
-        {
-          "count": 1,
-          "name": "Wooded Foothills"
-        },
-        {
-          "count": 1,
-          "name": "Windswept Heath"
-        },
-        {
-          "count": 1,
-          "name": "Scattered Groves"
-        },
-        {
-          "count": 1,
-          "name": "Sheltered Thicket"
-        },
-        {
-          "count": 1,
-          "name": "Elegant Parlor"
-        },
-        {
-          "count": 1,
-          "name": "Cavern of Souls"
-        },
-        {
-          "count": 1,
-          "name": "Commercial District"
-        },
-        {
-          "count": 1,
-          "name": "Lush Portico"
-        },
-        {
-          "count": 1,
-          "name": "Jetmir's Garden"
-        },
-        {
-          "count": 1,
-          "name": "Unclaimed Territory"
-        },
-        {
-          "count": 1,
-          "name": "Stomping Ground"
-        },
-        {
-          "count": 1,
-          "name": "Temple Garden"
-        },
-        {
-          "count": 1,
-          "name": "Sacred Foundry"
-        },
-        {
-          "count": 1,
-          "name": "Command Tower"
-        },
-        {
-          "count": 1,
-          "name": "Path of Ancestry"
-        },
-        {
-          "count": 1,
-          "name": "Cinder Glade"
-        },
-        {
-          "count": 1,
-          "name": "Canopy Vista"
-        },
-        {
-          "count": 1,
-          "name": "Three Tree City"
-        },
-        {
-          "count": 1,
-          "name": "Arena of Glory"
-        },
-        {
-          "count": 1,
-          "name": "Castle Garenbrig"
-        },
-        {
-          "count": 1,
-          "name": "Kessig Wolf Run"
-        },
-        {
-          "count": 1,
-          "name": "Boseiju, Who Endures"
-        },
-        {
-          "count": 1,
-          "name": "Yavimaya, Cradle of Growth"
+          "name": "Inspiring Statuary"
         }
       ],
       "sideboard": []

--- a/client/public/feeds/mtggoldfish-modern.json
+++ b/client/public/feeds/mtggoldfish-modern.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "modern",
   "version": 1,
-  "updated": "2026-08-31T00:00:00Z",
+  "updated": "2026-09-01T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/modern",
   "decks": [
     {
@@ -1345,36 +1345,61 @@
       "name": "Ruby Storm",
       "author": "MTGGoldfish",
       "colors": [
-        "U",
-        "R"
+        "R",
+        "G",
+        "W"
       ],
       "tags": [
         "metagame"
       ],
       "main": [
         {
-          "count": 4,
-          "name": "Scalding Tarn"
+          "count": 1,
+          "name": "Mountain"
+        },
+        {
+          "count": 2,
+          "name": "Artist's Talent"
         },
         {
           "count": 4,
           "name": "Desperate Ritual"
         },
         {
-          "count": 4,
-          "name": "Manamorphose"
-        },
-        {
-          "count": 2,
-          "name": "Island"
+          "count": 1,
+          "name": "Commercial District"
         },
         {
           "count": 1,
-          "name": "Flooded Strand"
+          "name": "Stomping Ground"
         },
         {
           "count": 2,
-          "name": "Past in Flames"
+          "name": "Arid Mesa"
+        },
+        {
+          "count": 1,
+          "name": "Gemstone Caverns"
+        },
+        {
+          "count": 1,
+          "name": "Strike It Rich"
+        },
+        {
+          "count": 4,
+          "name": "Hex Magic"
+        },
+        {
+          "count": 1,
+          "name": "Sacred Foundry"
+        },
+        {
+          "count": 1,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "Scalding Tarn"
         },
         {
           "count": 4,
@@ -1385,82 +1410,82 @@
           "name": "Ral, Monsoon Mage"
         },
         {
+          "count": 4,
+          "name": "Reckless Impulse"
+        },
+        {
+          "count": 4,
+          "name": "Ruby Medallion"
+        },
+        {
           "count": 3,
-          "name": "Thundering Falls"
+          "name": "Past in Flames"
         },
         {
           "count": 2,
-          "name": "Steam Vents"
+          "name": "Wooded Foothills"
+        },
+        {
+          "count": 1,
+          "name": "Sunbaked Canyon"
         },
         {
           "count": 2,
+          "name": "Valakut Awakening"
+        },
+        {
+          "count": 2,
+          "name": "Wish"
+        },
+        {
+          "count": 4,
+          "name": "Wrenn's Resolve"
+        },
+        {
+          "count": 1,
           "name": "Mountain"
         },
         {
+          "count": 1,
+          "name": "Mountain"
+        },
+        {
+          "count": 1,
+          "name": "Elegant Parlor"
+        },
+        {
+          "count": 1,
+          "name": "Boseiju, Who Endures"
+        },
+        {
+          "count": 4,
+          "name": "Manamorphose"
+        },
+        {
           "count": 2,
-          "name": "Stock Up"
-        },
+          "name": "Bloodstained Mire"
+        }
+      ],
+      "sideboard": [
         {
           "count": 1,
-          "name": "Misty Rainforest"
-        },
-        {
-          "count": 1,
-          "name": "Otawara, Soaring City"
-        },
-        {
-          "count": 4,
-          "name": "Stormcatch Mentor"
-        },
-        {
-          "count": 4,
-          "name": "Preordain"
-        },
-        {
-          "count": 4,
-          "name": "Flow State"
-        },
-        {
-          "count": 1,
-          "name": "Sink into Stupor"
-        },
-        {
-          "count": 1,
-          "name": "Arid Mesa"
-        },
-        {
-          "count": 1,
-          "name": "Valakut Awakening"
+          "name": "Stormscale Scion"
         },
         {
           "count": 1,
           "name": "Grapeshot"
         },
         {
-          "count": 2,
-          "name": "Strike It Rich"
+          "count": 1,
+          "name": "Past in Flames"
+        },
+        {
+          "count": 3,
+          "name": "Prismatic Ending"
         },
         {
           "count": 1,
-          "name": "Flame of Anor"
-        },
-        {
-          "count": 4,
-          "name": "Hex Magic"
-        },
-        {
-          "count": 1,
-          "name": "Vexing Bauble"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 1,
-          "name": "Into the Flood Maw"
-        },
-        {
-          "count": 1,
-          "name": "Soul-Guide Lantern"
+          "name": "Wear // Tear"
         },
         {
           "count": 2,
@@ -1468,31 +1493,15 @@
         },
         {
           "count": 2,
-          "name": "Vexing Bauble"
-        },
-        {
-          "count": 2,
-          "name": "Consign to Memory"
-        },
-        {
-          "count": 1,
-          "name": "Fire Magic"
-        },
-        {
-          "count": 2,
-          "name": "Flame of Anor"
-        },
-        {
-          "count": 2,
-          "name": "Defense Grid"
-        },
-        {
-          "count": 1,
-          "name": "Lightning Bolt"
-        },
-        {
-          "count": 1,
           "name": "Untimely Malfunction"
+        },
+        {
+          "count": 3,
+          "name": "Silence"
+        },
+        {
+          "count": 1,
+          "name": "Boseiju, Who Endures"
         }
       ]
     }

--- a/client/public/feeds/mtggoldfish-pioneer.json
+++ b/client/public/feeds/mtggoldfish-pioneer.json
@@ -5,15 +5,15 @@
   "icon": "G",
   "format": "pioneer",
   "version": 1,
-  "updated": "2026-08-31T00:00:00Z",
+  "updated": "2026-09-01T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/pioneer",
   "decks": [
     {
       "name": "Izzet Prowess",
       "author": "MTGGoldfish",
       "colors": [
-        "U",
-        "R"
+        "R",
+        "U"
       ],
       "tags": [
         "metagame"
@@ -28,56 +28,40 @@
           "name": "Boomerang Basics"
         },
         {
-          "count": 1,
-          "name": "Monstrous Rage"
-        },
-        {
-          "count": 3,
-          "name": "Riverpyre Verge"
-        },
-        {
           "count": 4,
-          "name": "Flow State"
+          "name": "Burst Lightning"
         },
         {
           "count": 1,
-          "name": "Island"
-        },
-        {
-          "count": 4,
-          "name": "Monastery Swiftspear"
-        },
-        {
-          "count": 2,
           "name": "Mountain"
-        },
-        {
-          "count": 3,
-          "name": "Reckless Rage"
-        },
-        {
-          "count": 2,
-          "name": "Riverglide Pathway"
         },
         {
           "count": 3,
           "name": "Shivan Reef"
         },
         {
+          "count": 1,
+          "name": "Den of the Bugbear"
+        },
+        {
+          "count": 1,
+          "name": "Mountain"
+        },
+        {
+          "count": 2,
+          "name": "Riverglide Pathway"
+        },
+        {
           "count": 4,
-          "name": "Emberheart Challenger"
+          "name": "Riverpyre Verge"
+        },
+        {
+          "count": 4,
+          "name": "Monastery Swiftspear"
         },
         {
           "count": 4,
           "name": "Soul-Scar Mage"
-        },
-        {
-          "count": 3,
-          "name": "Burst Lightning"
-        },
-        {
-          "count": 4,
-          "name": "Steam Vents"
         },
         {
           "count": 4,
@@ -85,30 +69,34 @@
         },
         {
           "count": 4,
-          "name": "Sleight of Hand"
+          "name": "Steam Vents"
         },
         {
-          "count": 1,
-          "name": "Spell Pierce"
+          "count": 4,
+          "name": "Flow State"
+        },
+        {
+          "count": 4,
+          "name": "Reckless Rage"
+        },
+        {
+          "count": 3,
+          "name": "Emberheart Challenger"
+        },
+        {
+          "count": 3,
+          "name": "Experimental Synthesizer"
+        },
+        {
+          "count": 3,
+          "name": "Sleight of Hand"
         },
         {
           "count": 4,
           "name": "Spirebluff Canal"
-        },
-        {
-          "count": 2,
-          "name": "Quantum Riddler"
         }
       ],
       "sideboard": [
-        {
-          "count": 1,
-          "name": "Abrade"
-        },
-        {
-          "count": 1,
-          "name": "Accumulate Wisdom"
-        },
         {
           "count": 1,
           "name": "Boomerang Basics"
@@ -119,11 +107,11 @@
         },
         {
           "count": 1,
-          "name": "Iroh's Demonstration"
+          "name": "It'll Quench Ya!"
         },
         {
           "count": 1,
-          "name": "It'll Quench Ya!"
+          "name": "Iroh's Demonstration"
         },
         {
           "count": 1,
@@ -131,23 +119,31 @@
         },
         {
           "count": 1,
-          "name": "Quantum Riddler"
+          "name": "Soul-Guide Lantern"
+        },
+        {
+          "count": 1,
+          "name": "Abandon Attachments"
         },
         {
           "count": 2,
           "name": "Redcap Melee"
         },
         {
-          "count": 2,
-          "name": "Scorching Shot"
+          "count": 1,
+          "name": "Disdainful Stroke"
         },
         {
-          "count": 2,
-          "name": "Soul-Guide Lantern"
+          "count": 3,
+          "name": "Spell Pierce"
         },
         {
           "count": 1,
-          "name": "Spell Pierce"
+          "name": "Broadside Barrage"
+        },
+        {
+          "count": 1,
+          "name": "Flowstone Infusion"
         }
       ]
     },
@@ -168,31 +164,43 @@
         },
         {
           "count": 4,
-          "name": "Blooming Marsh"
+          "name": "Badgermole Cub"
         },
         {
-          "count": 1,
-          "name": "Boseiju, Who Endures"
+          "count": 2,
+          "name": "Bitter Triumph"
         },
         {
           "count": 4,
           "name": "Overgrown Tomb"
         },
         {
+          "count": 1,
+          "name": "Boseiju, Who Endures"
+        },
+        {
+          "count": 1,
+          "name": "Castle Locthwain"
+        },
+        {
+          "count": 1,
+          "name": "Culling Ritual"
+        },
+        {
+          "count": 1,
+          "name": "Maelstrom Pulse"
+        },
+        {
           "count": 4,
-          "name": "Llanowar Wastes"
+          "name": "Fatal Push"
         },
         {
           "count": 4,
           "name": "Graveyard Trespasser"
         },
         {
-          "count": 3,
-          "name": "Abrupt Decay"
-        },
-        {
           "count": 4,
-          "name": "Fatal Push"
+          "name": "Llanowar Wastes"
         },
         {
           "count": 2,
@@ -200,7 +208,7 @@
         },
         {
           "count": 4,
-          "name": "Mutavault"
+          "name": "Professor Dellian Fel"
         },
         {
           "count": 3,
@@ -208,11 +216,19 @@
         },
         {
           "count": 1,
-          "name": "Takenuma, Abandoned Mire"
+          "name": "Duress"
         },
         {
-          "count": 1,
-          "name": "Maelstrom Pulse"
+          "count": 4,
+          "name": "Blooming Marsh"
+        },
+        {
+          "count": 3,
+          "name": "Abrupt Decay"
+        },
+        {
+          "count": 4,
+          "name": "Unholy Annex // Ritual Chamber"
         },
         {
           "count": 1,
@@ -223,36 +239,16 @@
           "name": "Forest"
         },
         {
-          "count": 4,
-          "name": "Unholy Annex // Ritual Chamber"
-        },
-        {
-          "count": 2,
-          "name": "Bitter Triumph"
-        },
-        {
           "count": 1,
-          "name": "Duress"
-        },
-        {
-          "count": 1,
-          "name": "Culling Ritual"
-        },
-        {
-          "count": 1,
-          "name": "Castle Locthwain"
-        },
-        {
-          "count": 4,
-          "name": "Badgermole Cub"
-        },
-        {
-          "count": 4,
-          "name": "Professor Dellian Fel"
+          "name": "Takenuma, Abandoned Mire"
         },
         {
           "count": 4,
           "name": "Thoughtseize"
+        },
+        {
+          "count": 4,
+          "name": "Mutavault"
         }
       ],
       "sideboard": [
@@ -261,8 +257,8 @@
           "name": "Culling Ritual"
         },
         {
-          "count": 2,
-          "name": "Languish"
+          "count": 1,
+          "name": "Maelstrom Pulse"
         },
         {
           "count": 2,
@@ -270,11 +266,7 @@
         },
         {
           "count": 2,
-          "name": "Nowhere to Run"
-        },
-        {
-          "count": 1,
-          "name": "Maelstrom Pulse"
+          "name": "Languish"
         },
         {
           "count": 4,
@@ -283,6 +275,10 @@
         {
           "count": 1,
           "name": "Duress"
+        },
+        {
+          "count": 2,
+          "name": "Nowhere to Run"
         },
         {
           "count": 2,
@@ -529,13 +525,17 @@
           "name": "Mutavault"
         },
         {
-          "count": 3,
-          "name": "Flowstone Infusion"
+          "count": 1,
+          "name": "Sunspine Lynx"
+        },
+        {
+          "count": 2,
+          "name": "Bonecrusher Giant"
         }
       ],
       "sideboard": [
         {
-          "count": 2,
+          "count": 3,
           "name": "Scorching Shot"
         },
         {
@@ -551,10 +551,6 @@
           "name": "Weathered Runestone"
         },
         {
-          "count": 1,
-          "name": "Sunspine Lynx"
-        },
-        {
           "count": 2,
           "name": "The Legend of Roku"
         }
@@ -564,8 +560,8 @@
       "name": "Azorius Control",
       "author": "MTGGoldfish",
       "colors": [
-        "W",
-        "U"
+        "U",
+        "W"
       ],
       "tags": [
         "metagame"
@@ -573,34 +569,26 @@
       "main": [
         {
           "count": 2,
-          "name": "Out of Air"
-        },
-        {
-          "count": 4,
-          "name": "Hallowed Fountain"
-        },
-        {
-          "count": 4,
-          "name": "Dovin's Veto"
-        },
-        {
-          "count": 4,
-          "name": "Teferi, Hero of Dominaria"
-        },
-        {
-          "count": 4,
-          "name": "Seachrome Coast"
+          "name": "Island"
         },
         {
           "count": 2,
-          "name": "Hall of Storm Giants"
-        },
-        {
-          "count": 2,
-          "name": "Plains"
+          "name": "Emeritus of Ideation"
         },
         {
           "count": 4,
+          "name": "Consult the Star Charts"
+        },
+        {
+          "count": 1,
+          "name": "Fountainport"
+        },
+        {
+          "count": 2,
+          "name": "Beza, the Bounding Spring"
+        },
+        {
+          "count": 3,
           "name": "Meticulous Archive"
         },
         {
@@ -609,31 +597,83 @@
         },
         {
           "count": 4,
-          "name": "March of Otherworldly Light"
+          "name": "Get Lost"
         },
         {
-          "count": 4,
-          "name": "Memory Deluge"
+          "count": 3,
+          "name": "Restless Anchorage"
         },
         {
           "count": 2,
-          "name": "Island"
-        },
-        {
-          "count": 4,
-          "name": "Glacial Fortress"
-        },
-        {
-          "count": 4,
-          "name": "Spell Snare"
-        },
-        {
-          "count": 4,
-          "name": "Deserted Beach"
+          "name": "Change the Equation"
         },
         {
           "count": 4,
           "name": "Temporary Lockdown"
+        },
+        {
+          "count": 1,
+          "name": "Otawara, Soaring City"
+        },
+        {
+          "count": 1,
+          "name": "Eiganjo, Seat of the Empire"
+        },
+        {
+          "count": 4,
+          "name": "March of Otherworldly Light"
+        },
+        {
+          "count": 1,
+          "name": "Island"
+        },
+        {
+          "count": 2,
+          "name": "Irrigated Farmland"
+        },
+        {
+          "count": 2,
+          "name": "Field of Ruin"
+        },
+        {
+          "count": 2,
+          "name": "Teferi, Hero of Dominaria"
+        },
+        {
+          "count": 4,
+          "name": "Dovin's Veto"
+        },
+        {
+          "count": 1,
+          "name": "Castle Ardenvale"
+        },
+        {
+          "count": 4,
+          "name": "Hengegate Pathway"
+        },
+        {
+          "count": 2,
+          "name": "Hall of Storm Giants"
+        },
+        {
+          "count": 3,
+          "name": "Deserted Beach"
+        },
+        {
+          "count": 2,
+          "name": "Ultima"
+        },
+        {
+          "count": 3,
+          "name": "The Wandering Emperor"
+        },
+        {
+          "count": 2,
+          "name": "Plains"
+        },
+        {
+          "count": 2,
+          "name": "Glacial Fortress"
         },
         {
           "count": 2,
@@ -644,50 +684,58 @@
           "name": "Petrified Hamlet"
         },
         {
-          "count": 4,
-          "name": "Restless Anchorage"
+          "count": 1,
+          "name": "Narset, Parter of Veils"
         },
         {
           "count": 4,
-          "name": "Hengegate Pathway"
+          "name": "Hallowed Fountain"
         },
         {
-          "count": 4,
-          "name": "Get Out"
+          "count": 3,
+          "name": "Omen of the Sea"
         },
         {
-          "count": 2,
-          "name": "Get Lost"
-        },
-        {
-          "count": 4,
-          "name": "Plunder the Trollshaws"
-        },
-        {
-          "count": 2,
-          "name": "Beza, the Bounding Spring"
+          "count": 1,
+          "name": "The Unagi of Kyoshi Island"
         }
       ],
       "sideboard": [
+        {
+          "count": 2,
+          "name": "Rest in Peace"
+        },
+        {
+          "count": 2,
+          "name": "Narset's Reversal"
+        },
         {
           "count": 1,
           "name": "Yorion, Sky Nomad"
         },
         {
-          "count": 4,
-          "name": "Three Steps Ahead"
-        },
-        {
-          "count": 4,
-          "name": "Quantum Riddler"
+          "count": 2,
+          "name": "High Noon"
         },
         {
           "count": 2,
           "name": "Beza, the Bounding Spring"
         },
         {
-          "count": 4,
+          "count": 3,
           "name": "Kutzil's Flanker"
+        },
+        {
+          "count": 1,
+          "name": "Farewell"
+        },
+        {
+          "count": 1,
+          "name": "Erode"
+        },
+        {
+          "count": 1,
+          "name": "Three Steps Ahead"
         }
       ]
     },
@@ -695,9 +743,9 @@
       "name": "Jeskai Lessons",
       "author": "MTGGoldfish",
       "colors": [
+        "R",
         "W",
-        "U",
-        "R"
+        "U"
       ],
       "tags": [
         "metagame"
@@ -728,40 +776,44 @@
           "name": "Gran-Gran"
         },
         {
-          "count": 1,
-          "name": "Hallowed Fountain"
-        },
-        {
-          "count": 1,
-          "name": "Sundown Pass"
-        },
-        {
-          "count": 4,
-          "name": "It'll Quench Ya!"
-        },
-        {
-          "count": 1,
-          "name": "Stock Up"
-        },
-        {
-          "count": 4,
-          "name": "Steam Vents"
+          "count": 3,
+          "name": "Sacred Foundry"
         },
         {
           "count": 2,
           "name": "Island"
         },
         {
+          "count": 4,
+          "name": "It'll Quench Ya!"
+        },
+        {
           "count": 3,
-          "name": "Sacred Foundry"
+          "name": "Jeskai Revelation"
         },
         {
           "count": 4,
+          "name": "Riverpyre Verge"
+        },
+        {
+          "count": 1,
           "name": "Jeskai Revelation"
+        },
+        {
+          "count": 4,
+          "name": "Hallowed Fountain"
+        },
+        {
+          "count": 1,
+          "name": "Stock Up"
         },
         {
           "count": 1,
           "name": "Stormcarved Coast"
+        },
+        {
+          "count": 1,
+          "name": "Sundown Pass"
         },
         {
           "count": 4,
@@ -772,16 +824,12 @@
           "name": "Thor, God of Thunder"
         },
         {
-          "count": 3,
-          "name": "Hallowed Fountain"
-        },
-        {
           "count": 4,
           "name": "Spirebluff Canal"
         },
         {
           "count": 4,
-          "name": "Riverpyre Verge"
+          "name": "Steam Vents"
         }
       ],
       "sideboard": [
@@ -803,7 +851,11 @@
         },
         {
           "count": 1,
-          "name": "Ral, Crackling Wit"
+          "name": "Emeritus of Ideation"
+        },
+        {
+          "count": 2,
+          "name": "Ghost Vacuum"
         },
         {
           "count": 1,
@@ -819,7 +871,7 @@
         },
         {
           "count": 1,
-          "name": "Emeritus of Ideation"
+          "name": "Ral, Crackling Wit"
         },
         {
           "count": 1,
@@ -827,15 +879,126 @@
         },
         {
           "count": 1,
-          "name": "Soulless Jailer"
-        },
-        {
-          "count": 1,
           "name": "Sphinx of the Final Word"
         },
         {
+          "count": 1,
+          "name": "Soulless Jailer"
+        }
+      ]
+    },
+    {
+      "name": "Izzet Phoenix",
+      "author": "MTGGoldfish",
+      "colors": [
+        "U",
+        "R"
+      ],
+      "tags": [
+        "metagame"
+      ],
+      "main": [
+        {
+          "count": 4,
+          "name": "Arclight Phoenix"
+        },
+        {
+          "count": 4,
+          "name": "Artist's Talent"
+        },
+        {
+          "count": 4,
+          "name": "Consider"
+        },
+        {
+          "count": 4,
+          "name": "Fiery Impulse"
+        },
+        {
           "count": 2,
-          "name": "Ghost Vacuum"
+          "name": "Flashback"
+        },
+        {
+          "count": 3,
+          "name": "Into the Flood Maw"
+        },
+        {
+          "count": 3,
+          "name": "Lightning Axe"
+        },
+        {
+          "count": 4,
+          "name": "Island"
+        },
+        {
+          "count": 4,
+          "name": "Spirebluff Canal"
+        },
+        {
+          "count": 1,
+          "name": "Otawara, Soaring City"
+        },
+        {
+          "count": 4,
+          "name": "Picklock Prankster"
+        },
+        {
+          "count": 1,
+          "name": "Prismari Command"
+        },
+        {
+          "count": 1,
+          "name": "Proft's Eidetic Memory"
+        },
+        {
+          "count": 1,
+          "name": "Stormcarved Coast"
+        },
+        {
+          "count": 4,
+          "name": "Treasure Cruise"
+        },
+        {
+          "count": 4,
+          "name": "Opt"
+        },
+        {
+          "count": 4,
+          "name": "Riverglide Pathway"
+        },
+        {
+          "count": 4,
+          "name": "Sleight of Hand"
+        },
+        {
+          "count": 4,
+          "name": "Steam Vents"
+        }
+      ],
+      "sideboard": [
+        {
+          "count": 1,
+          "name": "Abrade"
+        },
+        {
+          "count": 2,
+          "name": "Disdainful Stroke"
+        },
+        {
+          "count": 4,
+          "name": "Ledger Shredder"
+        },
+        {
+          "count": 3,
+          "name": "Mystical Dispute"
+        },
+        {
+          "count": 3,
+          "name": "Redcap Melee"
+        },
+        {
+          "count": 2,
+          "name": "Brazen Borrower"
         }
       ]
     },
@@ -975,121 +1138,6 @@
       ]
     },
     {
-      "name": "Izzet Phoenix",
-      "author": "MTGGoldfish",
-      "colors": [
-        "U",
-        "R"
-      ],
-      "tags": [
-        "metagame"
-      ],
-      "main": [
-        {
-          "count": 4,
-          "name": "Arclight Phoenix"
-        },
-        {
-          "count": 4,
-          "name": "Artist's Talent"
-        },
-        {
-          "count": 4,
-          "name": "Consider"
-        },
-        {
-          "count": 4,
-          "name": "Fiery Impulse"
-        },
-        {
-          "count": 2,
-          "name": "Flashback"
-        },
-        {
-          "count": 3,
-          "name": "Into the Flood Maw"
-        },
-        {
-          "count": 3,
-          "name": "Lightning Axe"
-        },
-        {
-          "count": 4,
-          "name": "Island"
-        },
-        {
-          "count": 4,
-          "name": "Spirebluff Canal"
-        },
-        {
-          "count": 1,
-          "name": "Otawara, Soaring City"
-        },
-        {
-          "count": 4,
-          "name": "Picklock Prankster"
-        },
-        {
-          "count": 1,
-          "name": "Prismari Command"
-        },
-        {
-          "count": 1,
-          "name": "Proft's Eidetic Memory"
-        },
-        {
-          "count": 1,
-          "name": "Stormcarved Coast"
-        },
-        {
-          "count": 4,
-          "name": "Treasure Cruise"
-        },
-        {
-          "count": 4,
-          "name": "Opt"
-        },
-        {
-          "count": 4,
-          "name": "Riverglide Pathway"
-        },
-        {
-          "count": 4,
-          "name": "Sleight of Hand"
-        },
-        {
-          "count": 4,
-          "name": "Steam Vents"
-        }
-      ],
-      "sideboard": [
-        {
-          "count": 1,
-          "name": "Abrade"
-        },
-        {
-          "count": 2,
-          "name": "Disdainful Stroke"
-        },
-        {
-          "count": 4,
-          "name": "Ledger Shredder"
-        },
-        {
-          "count": 3,
-          "name": "Mystical Dispute"
-        },
-        {
-          "count": 3,
-          "name": "Redcap Melee"
-        },
-        {
-          "count": 2,
-          "name": "Brazen Borrower"
-        }
-      ]
-    },
-    {
       "name": "Temur Lessons",
       "author": "MTGGoldfish",
       "colors": [
@@ -1113,12 +1161,12 @@
           "name": "It'll Quench Ya!"
         },
         {
-          "count": 3,
+          "count": 4,
           "name": "Firebending Lesson"
         },
         {
-          "count": 4,
-          "name": "Steam Vents"
+          "count": 2,
+          "name": "Island"
         },
         {
           "count": 4,
@@ -1129,31 +1177,31 @@
           "name": "Tablet of Discovery"
         },
         {
-          "count": 2,
-          "name": "Island"
-        },
-        {
           "count": 4,
           "name": "Riverpyre Verge"
         },
         {
-          "count": 4,
+          "count": 1,
           "name": "Riverglide Pathway"
         },
         {
-          "count": 3,
+          "count": 4,
+          "name": "Steam Vents"
+        },
+        {
+          "count": 4,
           "name": "Combustion Technique"
         },
         {
-          "count": 1,
-          "name": "Iroh's Demonstration"
+          "count": 3,
+          "name": "Spirebluff Canal"
+        },
+        {
+          "count": 3,
+          "name": "Riverglide Pathway"
         },
         {
           "count": 1,
-          "name": "Mountain"
-        },
-        {
-          "count": 2,
           "name": "Pop Quiz"
         },
         {
@@ -1161,7 +1209,7 @@
           "name": "Abandon Attachments"
         },
         {
-          "count": 1,
+          "count": 2,
           "name": "Thor, God of Thunder"
         },
         {
@@ -1169,20 +1217,12 @@
           "name": "Willowrush Verge"
         },
         {
-          "count": 3,
+          "count": 4,
           "name": "Questing Druid"
         },
         {
-          "count": 3,
-          "name": "Spirebluff Canal"
-        },
-        {
           "count": 1,
-          "name": "Fiery Impulse"
-        },
-        {
-          "count": 1,
-          "name": "Thor, God of Thunder"
+          "name": "Mountain"
         }
       ],
       "sideboard": [
@@ -1192,10 +1232,10 @@
         },
         {
           "count": 1,
-          "name": "Fiery Impulse"
+          "name": "Environmental Sciences"
         },
         {
-          "count": 1,
+          "count": 2,
           "name": "Sokka's Haiku"
         },
         {
@@ -1203,40 +1243,32 @@
           "name": "Price of Freedom"
         },
         {
-          "count": 2,
-          "name": "Aether Gust"
+          "count": 1,
+          "name": "Iroh's Demonstration"
         },
         {
           "count": 1,
           "name": "Accumulate Wisdom"
         },
         {
-          "count": 1,
-          "name": "Firebending Lesson"
-        },
-        {
-          "count": 1,
+          "count": 2,
           "name": "Improvisation Capstone"
         },
         {
-          "count": 1,
-          "name": "Ghost Vacuum"
+          "count": 2,
+          "name": "Anger of the Gods"
         },
         {
           "count": 1,
           "name": "Origin of Metalbending"
         },
         {
+          "count": 1,
+          "name": "True Ancestry"
+        },
+        {
           "count": 2,
-          "name": "Ashiok, Dream Render"
-        },
-        {
-          "count": 1,
-          "name": "Combustion Technique"
-        },
-        {
-          "count": 1,
-          "name": "Redirect Lightning"
+          "name": "Narset, Parter of Veils"
         }
       ]
     },
@@ -1244,48 +1276,20 @@
       "name": "Izzet Lessons",
       "author": "MTGGoldfish",
       "colors": [
-        "R",
-        "U"
+        "U",
+        "R"
       ],
       "tags": [
         "metagame"
       ],
       "main": [
         {
-          "count": 3,
-          "name": "Mountain"
-        },
-        {
           "count": 4,
-          "name": "Riverglide Pathway"
-        },
-        {
-          "count": 4,
-          "name": "Divide by Zero"
-        },
-        {
-          "count": 1,
-          "name": "Stormcarved Coast"
-        },
-        {
-          "count": 3,
-          "name": "Island"
-        },
-        {
-          "count": 4,
-          "name": "Riverpyre Verge"
-        },
-        {
-          "count": 2,
-          "name": "Anger of the Gods"
+          "name": "Abandon Attachments"
         },
         {
           "count": 3,
           "name": "Accumulate Wisdom"
-        },
-        {
-          "count": 4,
-          "name": "It'll Quench Ya!"
         },
         {
           "count": 4,
@@ -1293,85 +1297,113 @@
         },
         {
           "count": 4,
+          "name": "Divide by Zero"
+        },
+        {
+          "count": 4,
           "name": "Firebending Lesson"
         },
         {
-          "count": 3,
+          "count": 4,
           "name": "Gran-Gran"
-        },
-        {
-          "count": 4,
-          "name": "Abandon Attachments"
-        },
-        {
-          "count": 4,
-          "name": "Tablet of Discovery"
-        },
-        {
-          "count": 3,
-          "name": "Thor, God of Thunder"
         },
         {
           "count": 4,
           "name": "Spirebluff Canal"
         },
         {
-          "count": 1,
-          "name": "Spell Pierce"
+          "count": 4,
+          "name": "It'll Quench Ya!"
         },
         {
-          "count": 1,
+          "count": 2,
           "name": "Ral, Crackling Wit"
         },
         {
           "count": 4,
+          "name": "Riverglide Pathway"
+        },
+        {
+          "count": 4,
+          "name": "Riverpyre Verge"
+        },
+        {
+          "count": 2,
+          "name": "Shivan Reef"
+        },
+        {
+          "count": 1,
+          "name": "Shivan Reef"
+        },
+        {
+          "count": 4,
+          "name": "Island"
+        },
+        {
+          "count": 4,
+          "name": "Tablet of Discovery"
+        },
+        {
+          "count": 4,
           "name": "Steam Vents"
+        },
+        {
+          "count": 1,
+          "name": "Stock Up"
+        },
+        {
+          "count": 1,
+          "name": "Thor, God of Thunder"
+        },
+        {
+          "count": 2,
+          "name": "Thor, God of Thunder"
         }
       ],
       "sideboard": [
-        {
-          "count": 3,
-          "name": "Fable of the Mirror-Breaker"
-        },
         {
           "count": 1,
           "name": "Accumulate Wisdom"
         },
         {
           "count": 1,
-          "name": "Sokka's Haiku"
+          "name": "Anger of the Gods"
+        },
+        {
+          "count": 2,
+          "name": "Avengers Disassembled"
+        },
+        {
+          "count": 2,
+          "name": "Quantum Riddler"
         },
         {
           "count": 1,
-          "name": "Negate"
+          "name": "Abrade"
         },
         {
           "count": 1,
-          "name": "Brazen Borrower"
+          "name": "Iroh's Demonstration"
+        },
+        {
+          "count": 1,
+          "name": "Price of Freedom"
+        },
+        {
+          "count": 1,
+          "name": "Flashfreeze"
+        },
+        {
+          "count": 2,
+          "name": "Unable to Scream"
+        },
+        {
+          "count": 2,
+          "name": "Ghost Vacuum"
         },
         {
           "count": 1,
           "name": "Improvisation Capstone"
-        },
-        {
-          "count": 3,
-          "name": "Mystical Dispute"
-        },
-        {
-          "count": 1,
-          "name": "Ral, Crackling Wit"
-        },
-        {
-          "count": 1,
-          "name": "Abrade"
-        },
-        {
-          "count": 1,
-          "name": "Abrade"
-        },
-        {
-          "count": 1,
-          "name": "Unlicensed Hearse"
         }
       ]
     }

--- a/client/public/feeds/mtggoldfish-standard.json
+++ b/client/public/feeds/mtggoldfish-standard.json
@@ -5,7 +5,7 @@
   "icon": "G",
   "format": "standard",
   "version": 1,
-  "updated": "2026-08-31T00:00:00Z",
+  "updated": "2026-09-01T00:00:00Z",
   "source": "https://www.mtggoldfish.com/metagame/standard",
   "decks": [
     {


### PR DESCRIPTION
Automated daily metagame feed refresh from MTGGoldfish.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updated Content**
  * Refreshed MTGGoldfish Modern, Pioneer, and Standard metagame feeds through September 1, 2026.
  * Updated Modern and Pioneer deck lists, including card configurations, color identities, and deck composition.
  * Replaced the Modern Ruby Storm deck configuration with the latest list.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->