### PR TITLE
fix(helm): send Cache-Control: no-store on logs sidecar responses

### DIFF
--- a/.github/workflows/helm-chart.yml
+++ b/.github/workflows/helm-chart.yml
@@ -162,6 +162,9 @@ jobs:
           # binds loopback-only regardless, so the Service/pod-IP path is dead
           # even if NetworkPolicy is off or the CNI doesn't enforce it.
           grep -q 'listen 127.0.0.1:' /tmp/logging-default.yaml
+          # No freshness policy otherwise, so a cached file or autoindex
+          # response could persist across port-forward targets.
+          grep -q 'add_header Cache-Control no-store always;' /tmp/logging-default.yaml
 
           helm template phase-server deploy/helm/phase-server \
             --namespace phase -f /tmp/scaleout.yaml --set logging.enabled=true \
@@ -176,6 +179,7 @@ jobs:
           # Entry + headless + one per ordinal, at scaleOut.replicaMax 3 above.
           test "$(grep -c 'targetPort: logs' /tmp/logging-scaleout.yaml)" -eq 5
           grep -q 'listen 127.0.0.1:' /tmp/logging-scaleout.yaml
+          grep -q 'add_header Cache-Control no-store always;' /tmp/logging-scaleout.yaml
 
       # Pins the chosen invariant for the reported unsafe combination: with
       # NetworkPolicy off, nothing in the chart restricts ingress by policy,

--- a/deploy/helm/phase-server/templates/logs-configmap.yaml
+++ b/deploy/helm/phase-server/templates/logs-configmap.yaml
@@ -37,6 +37,11 @@ data:
         autoindex on;
         location / {
           root {{ .Values.logging.dir }};
+          # NGINX sets no Cache-Control/Expires by default, so a
+          # port-forward that lands on a different pod after this one
+          # could otherwise reuse the previous pod's cached file and
+          # autoindex responses.
+          add_header Cache-Control no-store always;
         }
       }
     }


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Follow-up to #8255: adds `add_header Cache-Control no-store always;` to the
`logs` sidecar's nginx `location /` block so cached file and autoindex
responses can't persist across `kubectl port-forward` targets after a
rollout moves which pod a given port-forward reaches. Fixes CodeRabbit
review comment [#8255 (comment)](https://github.com/phase-rs/phase/pull/8255#discussion_r3906130181)
(id `3906130181`), which landed after #8255 merged.

## Files changed

- `deploy/helm/phase-server/templates/logs-configmap.yaml` — add the `no-store` header to the log-serving `location` block
- `.github/workflows/helm-chart.yml` — pin the header in the existing `helm template (logging enabled)` rendered-output assertions (default + scale-out renders), following the same lane's precedent for every other invariant in this chart

## Track

Developer

## LLM

Model: claude-sonnet-5
Tier: Frontier
Thinking: high (harness-configured for this agent; exact reasoning-effort tier not introspectable from the model side)

## Implementation method (required)

Method: not-applicable — chart-only infrastructure change (`deploy/helm/phase-server/**`, `.github/workflows/helm-chart.yml`); no `crates/engine/` or other Rust/TypeScript files touched.

## CR references

None (infra-only change, no game rules touched).

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [ ] Gate A output below is for the current committed head. — not applicable, no engine change (see Implementation method)
- [ ] Final review-impl below is clean for the current committed head. — not applicable, no engine change
- [ ] Both anchors cite existing analogous code at the same seam. — not applicable, no engine change

- `helm lint deploy/helm/phase-server` — `1 chart(s) linted, 0 chart(s) failed`
- `helm template ... --set logging.enabled=true` (default and scale-out) — renders clean; `location /` block carries `root` and the new `add_header Cache-Control no-store always;` line
- `helm template ...` (logging disabled, default values) — still renders no `ConfigMap`/logs resources, confirming the existing "logging is absent by default" CI invariant is untouched
- New CI assertions (`grep -q 'add_header Cache-Control no-store always;'` on both the default- and scale-out-logging renders) run locally against the rendered output — both pass
- Live leg on a disposable k3s namespace: rendered the sidecar's nginx.conf verbatim into two throwaway pods (one with this fix, one built from the unmodified `logs-configmap.yaml` on `upstream/main` as a negative control), `kubectl port-forward` to each, `curl -I` a log file path and the autoindex directory listing on both:
  - Fixed conf: `Cache-Control: no-store` present on both the file response and the autoindex response
  - Pre-fix conf (negative control): header absent on both, everything else in the response identical (confirms the control isolates this change, not some other confound)
  - Namespace deleted after verification

## Gate A

Not applicable — chart-only change, no engine code.

## Anchored on

- `deploy/helm/phase-server/templates/logs-configmap.yaml` (existing `listen 127.0.0.1:...` line and its comment) — same file, same `server`/`location` block this PR extends
- `.github/workflows/helm-chart.yml` `helm template (logging enabled)` step (existing `grep -q 'listen 127.0.0.1:'` assertions on `/tmp/logging-default.yaml` and `/tmp/logging-scaleout.yaml`) — the precedent this PR's new assertions follow exactly, same two render targets

## Final review-impl

Not applicable — chart-only change, no engine code.

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Disabled browser and proxy caching for log viewer responses.
  - Ensured port-forwarded log views always display current files and directory listings, even when connections switch between pods.

- **Tests**
  - Added validation to Helm chart checks confirming the no-cache header is included in standard and scale-out configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->