### PR TITLE
fix(client): require a trusted event for external windows

### DIFF
--- a/client/src/components/chrome/DiscordBadge.tsx
+++ b/client/src/components/chrome/DiscordBadge.tsx
@@ -14,7 +14,7 @@ export function DiscordBadge({ className }: DiscordBadgeProps) {
       rel="noopener noreferrer"
       onClick={(e) => {
         e.preventDefault();
-        openExternal(DISCORD_INVITE_URL);
+        openExternal(DISCORD_INVITE_URL, e.nativeEvent);
       }}
       aria-label="Discord"
       className={

--- a/client/src/components/chrome/PreviewBadge.tsx
+++ b/client/src/components/chrome/PreviewBadge.tsx
@@ -85,7 +85,7 @@ export function PreviewBadge() {
             return;
           }
           e.preventDefault();
-          openExternal(__PREVIEW_SITE_URL__);
+          openExternal(__PREVIEW_SITE_URL__, e.nativeEvent);
         }}
         aria-describedby={tooltipId}
         className="group relative flex items-center gap-1 rounded-full border border-amber-400/40 bg-amber-500/10 px-3 py-1 text-[11px] font-semibold text-amber-200 shadow-[0_0_16px_-2px_rgba(245,158,11,0.45)] backdrop-blur-sm transition-all hover:border-amber-300/70 hover:bg-amber-500/20 hover:text-amber-100 hover:shadow-[0_0_22px_0_rgba(245,158,11,0.65)] sm:gap-1.5 sm:px-3.5 sm:py-1.5 sm:text-xs"

--- a/client/src/components/chrome/StatusBanner.tsx
+++ b/client/src/components/chrome/StatusBanner.tsx
@@ -91,7 +91,7 @@ export function StatusBanner() {
             // that rejects a non-http(s) href from a published payload.
             <button
               type="button"
-              onClick={() => openExternal(link.url)}
+              onClick={(event) => openExternal(link.url, event.nativeEvent)}
               className={`mt-1 self-start text-[11px] font-medium underline underline-offset-2 ${tone.text}`}
             >
               {link.label}

--- a/client/src/components/chrome/__tests__/StatusBanner.test.tsx
+++ b/client/src/components/chrome/__tests__/StatusBanner.test.tsx
@@ -115,7 +115,10 @@ describe("StatusBanner", () => {
     render(<StatusBanner />);
 
     await userEvent.click(await screen.findByRole("button", { name: "Details on Discord" }));
-    expect(openExternal).toHaveBeenCalledWith("https://discord.gg/example");
+    expect(openExternal).toHaveBeenCalledWith(
+      "https://discord.gg/example",
+      expect.any(MouseEvent),
+    );
   });
 
   it("renders no link affordance when the message carries none", async () => {

--- a/client/src/components/chrome/socialLinks.tsx
+++ b/client/src/components/chrome/socialLinks.tsx
@@ -12,7 +12,7 @@ const SPONSOR_URL = "https://github.com/sponsors/matthewevans";
 export function social(url: string) {
   return (e: MouseEvent) => {
     e.preventDefault();
-    openExternal(url);
+    openExternal(url, e.nativeEvent);
   };
 }
 

--- a/client/src/services/__tests__/openExternal.test.ts
+++ b/client/src/services/__tests__/openExternal.test.ts
@@ -14,6 +14,8 @@ vi.mock("@tauri-apps/plugin-opener", () => {
 
 import { openExternal } from "../openExternal";
 
+const trustedEvent = { isTrusted: true } as Event;
+
 afterEach(() => {
   mocks.tauri = false;
   mocks.openUrl.mockReset();
@@ -30,7 +32,7 @@ describe("direct external-link routing", () => {
     "phase://deck/1",
   ])("rejects %s before either browser route is reached", (url) => {
     const browserOpen = vi.spyOn(window, "open").mockImplementation(() => null);
-    openExternal(url);
+    openExternal(url, trustedEvent);
     expect(mocks.moduleLoaded).not.toHaveBeenCalled();
     expect(mocks.openUrl).not.toHaveBeenCalled();
     expect(browserOpen).not.toHaveBeenCalled();
@@ -38,7 +40,7 @@ describe("direct external-link routing", () => {
 
   it("uses the exact browser window.open contract for HTTPS", () => {
     const browserOpen = vi.spyOn(window, "open").mockImplementation(() => null);
-    openExternal("https://example.com/cards");
+    openExternal("https://example.com/cards", trustedEvent);
     expect(browserOpen).toHaveBeenCalledWith(
       "https://example.com/cards",
       "_blank",
@@ -50,7 +52,7 @@ describe("direct external-link routing", () => {
   it("dynamically routes Tauri HTTP URLs through opener", async () => {
     mocks.tauri = true;
     const browserOpen = vi.spyOn(window, "open").mockImplementation(() => null);
-    openExternal("http://example.com");
+    openExternal("http://example.com", trustedEvent);
     await vi.waitFor(() => expect(mocks.openUrl).toHaveBeenCalledWith("http://example.com"));
     expect(browserOpen).not.toHaveBeenCalled();
   });
@@ -59,7 +61,16 @@ describe("direct external-link routing", () => {
     mocks.tauri = true;
     const warn = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     mocks.openUrl.mockRejectedValueOnce(new Error("denied"));
-    openExternal("https://example.com");
+    openExternal("https://example.com", trustedEvent);
     await vi.waitFor(() => expect(warn).toHaveBeenCalledOnce());
+  });
+
+  it("refuses an untrusted event before opening a browser window", () => {
+    const browserOpen = vi.spyOn(window, "open").mockImplementation(() => null);
+
+    openExternal("https://example.com/cards", new Event("click"));
+
+    expect(browserOpen).not.toHaveBeenCalled();
+    expect(mocks.moduleLoaded).not.toHaveBeenCalled();
   });
 });

--- a/client/src/services/openExternal.ts
+++ b/client/src/services/openExternal.ts
@@ -10,9 +10,15 @@ export function isOpenableExternalUrl(url: string): boolean {
   }
 }
 
-/** Open a validated HTTP(S) URL in the user's default browser. */
-export function openExternal(url: string): void {
-  if (!isOpenableExternalUrl(url)) return;
+/**
+ * Open a validated HTTP(S) URL in the user's default browser.
+ *
+ * External windows are an explicit-click affordance. Requiring the trusted
+ * browser event keeps hover, render, and asynchronous state updates from ever
+ * creating a tab or history entry.
+ */
+export function openExternal(url: string, event: Event): void {
+  if (!event.isTrusted || !isOpenableExternalUrl(url)) return;
 
   if (isTauri()) {
     void import("@tauri-apps/plugin-opener")


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * External links now open only from trusted user interactions, improving protection against unintended or unauthorized browser navigation.
  * Discord, preview, status, and social links now preserve the originating click context when opened externally.

* **Tests**
  * Added coverage for trusted and untrusted link-opening events, including blocked navigation scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->