### PR TITLE
fix(engine): chain tracked-set pollution by in-place producers (Shiva chapter III)

### DIFF
--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5888,6 +5888,13 @@ fn population_does_not_move(effect: &Effect) -> bool {
 ///
 /// `repeat_for: TrackedSetSize` consumers are not publisher positions (they
 /// publish nothing), so Seasoned Pyromancer (#740) is unaffected.
+///
+/// The [`ResolvedAbility::detached_remainder`] leg-3 term is deliberately
+/// UNNARROWED: the splitter's stamp carries no moving/in-place detail, so a
+/// player-scope template whose remainder is a same-class in-place producer
+/// would be vetoed where its non-scoped twin publishes. No corpus row
+/// exercises that shape today; if one appears, refine the stamp, not this
+/// gate.
 fn transitive_publish_superseded(producer: &ResolvedAbility) -> bool {
     population_does_not_move(&producer.effect)
         && (later_node_is_moving_publisher_position(producer)

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5918,7 +5918,7 @@ fn population_does_not_move(effect: &Effect) -> bool {
 /// through `sacrifice_permanent`; `CreateTokenCopyFromPool`/`CopyTokenOf` —
 /// both drain through the shared copy-token entry authority.
 ///
-/// SYNCHRONOUS round-2 movers (verified per variant; each emits `ZoneChanged`
+/// Synchronous movers (verified per variant; each emits `ZoneChanged`
 /// inside its `resolve`'s own event slice through the `zone_pipeline`
 /// primitives): `Draw` — `start_draw_sequence_with_replacement_applied`
 /// (draw.rs:259) delivers each unit via `resume_pending_draw_delivery` →
@@ -5994,7 +5994,7 @@ fn population_moves(effect: &Effect) -> bool {
         | Effect::ExileFromTopUntil { .. }
         | Effect::Counter { .. }
         | Effect::CounterAll { .. }
-        // Synchronous round-2 movers (verified inventory above):
+        // Synchronous movers (verified inventory above):
         | Effect::Draw { .. }
         | Effect::Seek { .. }
         | Effect::Cascade
@@ -6019,8 +6019,8 @@ fn population_moves(effect: &Effect) -> bool {
         | Effect::CreateTokenCopyFromPool { .. }
         | Effect::CopyTokenOf { .. } => true,
         // NOT moving: interactive-window variants move in the answer-handler
-        // cycle; no ZoneChanged reaches the resolver-side harvest (disclosed
-        // flip vs the round-3 negation-based classification).
+        // cycle; no ZoneChanged reaches the resolver-side harvest that both
+        // mobility classifiers read.
         _ => false,
     }
 }
@@ -26896,7 +26896,7 @@ mod tests {
         );
     }
 
-    // ---- Typed moving/in-place classification battery (round-6 remediation) ----
+    // ---- Typed moving/in-place classification battery ----
 
     fn tap_leg() -> ResolvedAbility {
         ResolvedAbility::new(
@@ -26953,7 +26953,7 @@ mod tests {
         )
     }
 
-    /// A synchronous round-2 mover leg: Seek delivers its sought card
+    /// A synchronous mover leg: Seek delivers its sought card
     /// Library→Hand through `zone_pipeline::move_objects_simultaneously`
     /// inside `resolve`'s own event slice (seek.rs:102) — `population_moves`
     /// is true.
@@ -26982,7 +26982,7 @@ mod tests {
         node.sub_ability = Some(Box::new(leg));
     }
 
-    /// MED-2 congruence, matched pair A: a player-scoped chain whose detached
+    /// Scoped/unsplit congruence, matched pair A: a player-scoped chain whose detached
     /// remainder holds a MOVING producer (`exile → reader{TS}`) takes the SAME
     /// supersession verdict as its unsplit twin — vetoed. The stamp assertion
     /// pins the TYPED verdict: the moving walk (arm 1), not merely the wider
@@ -27045,7 +27045,7 @@ mod tests {
         );
     }
 
-    /// MED-2, matched pair B (the revert-failing row): a player-scoped chain
+    /// Scoped/unsplit congruence, matched pair B (the revert-failing row): a player-scoped chain
     /// whose detached remainder is a same-class IN-PLACE producer followed by
     /// a TERMINAL reader must PUBLISH exactly like its unsplit twin. The
     /// pre-typing leg 3 (`!= NoProducer`) vetoed exactly this shape — revert
@@ -27081,11 +27081,11 @@ mod tests {
         assert!(
             !transitive_publish_superseded(&scoped),
             "CR 608.2c congruence: a same-class in-place remainder must NOT veto — \
-             the MED-2 divergence is closed"
+             the scoped chain must publish like its unsplit equivalent"
         );
     }
 
-    /// R4-1 unsplit regression: the Kathril doc shape
+    /// Unsplit regression: the Kathril doc shape
     /// `tap → tap2 → exile → reader{TS}` — tap2 is TRANSPARENT under the
     /// own-consumption gate (its tracked-set reference lives in its SUBTREE,
     /// not its own effect), so the walk reaches the moving exile and the first
@@ -27099,12 +27099,12 @@ mod tests {
         append_test_leg(&mut chain, grant_leg());
         assert!(
             transitive_publish_superseded(&chain),
-            "R4-1: tap2 does not own-consume, so the walk must reach the moving exile \
+            "tap2 does not own-consume, so the walk must reach the moving exile \
              and veto the first tap (Kathril doc contract)"
         );
     }
 
-    /// R4-1 scoped twin: the detached tail `tap2 → exile → reader{TS}` stamps
+    /// Scoped twin: the detached tail `tap2 → exile → reader{TS}` stamps
     /// `HoldsMovingPublisher` through the corrected walk (arm 1) and the scoped
     /// head is vetoed — congruent with the unsplit twin above.
     #[test]
@@ -27129,18 +27129,17 @@ mod tests {
         );
     }
 
-    /// Round-2 remediation discriminator: a detached remainder shaped
+    /// Moving-remainder discriminator: a detached remainder shaped
     /// `in-place producer → SYNCHRONOUS MOVER → reader{TS}` must veto the
     /// in-place head through the production predicate
     /// (`transitive_publish_superseded`, leg 3). The mover is `Effect::Seek`
-    /// — one of the nine synchronous ZoneChanged emitters the round-2 review
-    /// added to `population_moves` (seek.rs:102, a synchronous
+    /// — one of the synchronous ZoneChanged emitters in `population_moves`'
+    /// inventory (seek.rs:102, a synchronous
     /// `zone_pipeline::move_objects_simultaneously` inside `resolve`).
     /// Revert Seek's classification and the tail stamps
     /// `HoldsInPlacePublisher` via arm 2 instead of `HoldsMovingPublisher`
-    /// via arm 1, leg 3 stops firing, and the head flips to publish — the
-    /// parent-commit veto behavior for this class, restored by the positive
-    /// classifier.
+    /// via arm 1, leg 3 stops firing, and the head flips to publish —
+    /// reintroducing the very CR 608.2c pollution this veto exists to prevent.
     #[test]
     fn detached_in_place_then_synchronous_mover_tail_vetoes_via_the_typed_stamp() {
         let mut tail = tap_leg();
@@ -27187,7 +27186,8 @@ mod tests {
     /// structural mirror of the integration fixture
     /// `nested_tracked_set_consumers_keep_the_tap_publish`): the walk's reader
     /// boundary fires at the FIRST reader, so the tap publish is NOT superseded
-    /// and both readers bind. Under the round-3 negation this was TRUE.
+    /// and both readers bind (the negation-based walk this replaces read the
+    /// reader as a moving producer and flipped this to TRUE).
     #[test]
     fn nested_reader_boundary_keeps_the_in_place_publish() {
         let mut chain = tap_leg();
@@ -27247,7 +27247,7 @@ mod tests {
     /// the generic-arm ZoneChanged emitters (Token, Incubate, Bounce, Conjure
     /// {Battlefield}, Amass, CastFromZone, Manifest), the destination-guarded
     /// Conjure arm, the interactive-window not-moving variants, and the
-    /// round-2 synchronous movers (Draw, Seek, Cascade, Discover, Ripple,
+    /// synchronous movers (Draw, Seek, Cascade, Discover, Ripple,
     /// Explore, ExploreAll, Cloak — resolver-source citations in
     /// `population_moves`' doc) plus the harvest-inert CollectEvidence row.
     /// Removing any variant from `population_moves`' positive list flips its

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5840,6 +5840,15 @@ fn node_or_later_is_publisher_position(node: &ResolvedAbility) -> bool {
 /// (Atraxa's "from among the revealed cards"). Widening to them is the
 /// documented extension point: one line here plus a full-suite run under the
 /// measurement protocol in `transitive_publish_superseded`.
+///
+/// Harvest-inert (deliberately in NEITHER predicate — recorded per the
+/// forward-maintenance rule): `CollectEvidence` moves graveyard cards to
+/// exile, but only in the ANSWER-HANDLER cycle (`handle_choice` →
+/// `move_evidence_costs` → `zone_pipeline::move_object`,
+/// collect_evidence.rs:220); its `resolve` parks a player choice and emits
+/// `EffectResolved` only (collect_evidence.rs:139-146), so the resolver-side
+/// harvest — the sole signal both classifiers read — finds no zone-change
+/// event.
 fn population_does_not_move(effect: &Effect) -> bool {
     matches!(
         effect,
@@ -5861,8 +5870,11 @@ fn population_does_not_move(effect: &Effect) -> bool {
 /// arm) would harvest? The positive twin of [`population_does_not_move`]: the
 /// two predicates are DISJOINT BY CONTRACT — tap/counter/damage read
 /// `PermanentTapped`/`CounterAdded`/`DamageDealt`, every moving class reads a
-/// zone-change or leave-zone event — and every `Effect` variant is classified
-/// in exactly ONE of them. Forward-maintenance rule: a future resolver that
+/// zone-change or leave-zone event — while every OTHER variant is deliberately
+/// NEUTRAL: it belongs to NEITHER predicate (event-less heads, in-place reveal
+/// harvests, interactive-window variants, harvest-inert movers — see the NOT
+/// moving list below), so absence from these lists classifies nothing.
+/// Forward-maintenance rule: a future resolver that
 /// routes a move through the `zones.rs`/`zone_pipeline` primitives MUST be
 /// classified in exactly ONE of the two predicates (added here, or proven
 /// harvest-inert in a comment beside [`population_does_not_move`]) — the
@@ -5906,13 +5918,37 @@ fn population_does_not_move(effect: &Effect) -> bool {
 /// through `sacrifice_permanent`; `CreateTokenCopyFromPool`/`CopyTokenOf` —
 /// both drain through the shared copy-token entry authority.
 ///
+/// SYNCHRONOUS round-2 movers (verified per variant; each emits `ZoneChanged`
+/// inside its `resolve`'s own event slice through the `zone_pipeline`
+/// primitives): `Draw` — `start_draw_sequence_with_replacement_applied`
+/// (draw.rs:259) delivers each unit via `resume_pending_draw_delivery` →
+/// `zone_pipeline::move_object` (draw.rs:677); empty-library and
+/// replaced-away draws deliver nothing (conservative at variant granularity,
+/// same as `Amass`); `Seek` — `move_objects_simultaneously` (seek.rs:102);
+/// `Cascade` — `move_objects_simultaneously_then` (cascade.rs:94/:248);
+/// `Discover` — synchronous exile loop `zone_pipeline::move_object`
+/// (discover.rs:61); `Ripple` — synchronous exile loop
+/// `zone_pipeline::move_object` (ripple.rs:71); `Explore` — the
+/// revealed-land Library→Hand batch `move_objects_simultaneously_then`
+/// (explore.rs:323; the nonland branch parks a DigChoice instead);
+/// `ExploreAll` — the same per-explorer batch via `resolve_all`;
+/// `Cloak` — the effect-owned Battlefield→Exile batch
+/// `move_objects_simultaneously_then` (cloak.rs:122).
+///
 /// NOT moving (measured exclusions, carried from
 /// [`population_does_not_move`]): the interactive-window variants
 /// `MadnessCast`, `MiracleCast`, `FreeCastFromZones`, `PutOnTopOrBottom`
 /// move in the ANSWER-HANDLER cycle, never inside the resolver's own event
 /// slice (the engine's manual re-publishes in `engine_resolution_choices`
 /// acknowledge this), so the generic arm's scan over the resolver's events
-/// finds nothing. Also neutral: reveal-only dispositions
+/// finds nothing. Harvest-inert for the same reason (per-variant evidence,
+/// classified NEITHER predicate): `CollectEvidence` — `resolve` parks a
+/// player choice and emits `EffectResolved` only (collect_evidence.rs:139-146);
+/// the exiles run in the answer-handler `handle_choice` →
+/// `move_evidence_costs` → `zone_pipeline::move_object`
+/// (collect_evidence.rs:220), so the resolver-side scan finds no
+/// `ZoneChanged`.
+/// Also neutral: reveal-only dispositions
 /// (`RevealUntil{RevealOnly}`, `Dig{reveal: true, keep_count: Some(0)}` —
 /// they harvest `CardsRevealed` in place), and the event-less heads
 /// (`PumpAll`/`GoadAll`/`GiveControl`/`GenericEffect`, plus
@@ -5958,6 +5994,15 @@ fn population_moves(effect: &Effect) -> bool {
         | Effect::ExileFromTopUntil { .. }
         | Effect::Counter { .. }
         | Effect::CounterAll { .. }
+        // Synchronous round-2 movers (verified inventory above):
+        | Effect::Draw { .. }
+        | Effect::Seek { .. }
+        | Effect::Cascade
+        | Effect::Discover { .. }
+        | Effect::Ripple { .. }
+        | Effect::Explore
+        | Effect::ExploreAll { .. }
+        | Effect::Cloak { .. } => true,
         // Generic-arm ZoneChanged emitters (verified inventory above):
         | Effect::Token { .. }
         | Effect::Incubate { .. }
@@ -26908,6 +26953,25 @@ mod tests {
         )
     }
 
+    /// A synchronous round-2 mover leg: Seek delivers its sought card
+    /// Library→Hand through `zone_pipeline::move_objects_simultaneously`
+    /// inside `resolve`'s own event slice (seek.rs:102) — `population_moves`
+    /// is true.
+    fn seek_leg() -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::Seek {
+                filter: TargetFilter::Any,
+                count: QuantityExpr::Fixed { value: 1 },
+                from_top: None,
+                destination: Zone::Hand,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        )
+    }
+
     /// Append `leg` at the tail of `chain`'s sub_ability spine (the tests
     /// cannot call the crate-private `append_to_sub_chain`; same walk, inline).
     fn append_test_leg(chain: &mut ResolvedAbility, leg: ResolvedAbility) {
@@ -27065,6 +27129,60 @@ mod tests {
         );
     }
 
+    /// Round-2 remediation discriminator: a detached remainder shaped
+    /// `in-place producer → SYNCHRONOUS MOVER → reader{TS}` must veto the
+    /// in-place head through the production predicate
+    /// (`transitive_publish_superseded`, leg 3). The mover is `Effect::Seek`
+    /// — one of the nine synchronous ZoneChanged emitters the round-2 review
+    /// added to `population_moves` (seek.rs:102, a synchronous
+    /// `zone_pipeline::move_objects_simultaneously` inside `resolve`).
+    /// Revert Seek's classification and the tail stamps
+    /// `HoldsInPlacePublisher` via arm 2 instead of `HoldsMovingPublisher`
+    /// via arm 1, leg 3 stops firing, and the head flips to publish — the
+    /// parent-commit veto behavior for this class, restored by the positive
+    /// classifier.
+    #[test]
+    fn detached_in_place_then_synchronous_mover_tail_vetoes_via_the_typed_stamp() {
+        let mut tail = tap_leg();
+        append_test_leg(&mut tail, seek_leg());
+        append_test_leg(&mut tail, grant_leg());
+
+        // Stamp through the production classification point, not by hand.
+        assert_eq!(
+            detached_remainder_verdict(Some(&tail)),
+            DetachedRemainder::HoldsMovingPublisher,
+            "the synchronous mover (Seek — a verified ZoneChanged emitter in its \
+             resolver's own event slice) in publisher position must stamp the \
+             MOVING variant through arm 1"
+        );
+
+        let mut head = tap_leg();
+        head.detached_remainder = detached_remainder_verdict(Some(&tail));
+        assert!(
+            transitive_publish_superseded(&head),
+            "CR 608.2c nearest-antecedent veto (leg 3, HoldsMovingPublisher): an \
+             in-place head whose detached remainder is tap2 → Seek → reader{{TS}} \
+             is superseded by the synchronous mover"
+        );
+
+        // Non-vacuity twin: the mover REMOVED (tap2 → reader{TS}) stamps
+        // IN-PLACE and the head publishes — so the veto above is caused by
+        // Seek's moving classification, not by the class gate or the split.
+        let mut moverless_tail = tap_leg();
+        append_test_leg(&mut moverless_tail, grant_leg());
+        let mut head_without_mover = tap_leg();
+        head_without_mover.detached_remainder = detached_remainder_verdict(Some(&moverless_tail));
+        assert_eq!(
+            head_without_mover.detached_remainder,
+            DetachedRemainder::HoldsInPlacePublisher
+        );
+        assert!(
+            !transitive_publish_superseded(&head_without_mover),
+            "non-vacuity: without the mover the same-shape remainder stamps \
+             IN-PLACE and the head publishes"
+        );
+    }
+
     /// Flipped nested-reader semantics pinned at the predicate level (the
     /// structural mirror of the integration fixture
     /// `nested_tracked_set_consumers_keep_the_tap_publish`): the walk's reader
@@ -27128,8 +27246,12 @@ mod tests {
     /// true), and each representative pins its class — the moving list includes
     /// the generic-arm ZoneChanged emitters (Token, Incubate, Bounce, Conjure
     /// {Battlefield}, Amass, CastFromZone, Manifest), the destination-guarded
-    /// Conjure arm, and the interactive-window not-moving variants. Removing
-    /// any variant from `population_moves`' positive list flips its row red.
+    /// Conjure arm, the interactive-window not-moving variants, and the
+    /// round-2 synchronous movers (Draw, Seek, Cascade, Discover, Ripple,
+    /// Explore, ExploreAll, Cloak — resolver-source citations in
+    /// `population_moves`' doc) plus the harvest-inert CollectEvidence row.
+    /// Removing any variant from `population_moves`' positive list flips its
+    /// row red.
     #[test]
     fn population_mobility_classifiers_are_disjoint_and_representatives_are_pinned() {
         use crate::types::ability::{
@@ -27350,6 +27472,64 @@ mod tests {
                     target: TargetFilter::Any,
                     chooser: TargetFilter::Controller,
                 },
+                false,
+                false,
+            ),
+            (
+                "Draw",
+                Effect::Draw {
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Controller,
+                },
+                true,
+                false,
+            ),
+            (
+                "Seek",
+                Effect::Seek {
+                    filter: TargetFilter::Any,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    from_top: None,
+                    destination: Zone::Hand,
+                    enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                },
+                true,
+                false,
+            ),
+            ("Cascade", Effect::Cascade, true, false),
+            (
+                "Discover",
+                Effect::Discover {
+                    mana_value_limit: QuantityExpr::Fixed { value: 4 },
+                    player: TargetFilter::Controller,
+                },
+                true,
+                false,
+            ),
+            ("Ripple", Effect::Ripple { count: 1 }, true, false),
+            ("Explore", Effect::Explore, true, false),
+            (
+                "ExploreAll",
+                Effect::ExploreAll {
+                    filter: TargetFilter::Any,
+                },
+                true,
+                false,
+            ),
+            (
+                "Cloak",
+                Effect::Cloak {
+                    target: TargetFilter::Any,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    object_source: None,
+                    enters_under: None,
+                },
+                true,
+                false,
+            ),
+            (
+                "CollectEvidence",
+                Effect::CollectEvidence { amount: 4 },
                 false,
                 false,
             ),

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -5608,6 +5608,12 @@ pub fn is_known_effect(effect: &Effect) -> bool {
 /// for each of those cards") expose both exiled objects to the grant.
 ///
 /// The walk STOPS at a mode boundary — see [`crosses_modal_boundary`].
+///
+/// The walk itself is UNCHANGED by the in-place-producer veto: transitive
+/// publication of *in-place-population* producers (tap/counter/damage — see
+/// [`population_does_not_move`]) is now additionally gated by
+/// [`transitive_publish_superseded`] at the publish sites, which reuses this
+/// predicate (unmodified) as its publisher-position input.
 pub(crate) fn next_sub_needs_tracked_set(ability: &ResolvedAbility) -> bool {
     branch_references_tracked_set(ability.sub_ability.as_deref())
 }
@@ -5712,6 +5718,15 @@ pub(crate) fn chain_references_tracked_set(ability: &ResolvedAbility) -> bool {
 /// root, pinned by `build_resolved_from_def_preserves_player_scope`, and 17
 /// corpus cards carry a mode-level `player_scope` — Rankle's Prank on all three
 /// modes.)
+///
+/// SIBLING GATE: [`transitive_publish_superseded`] now applies the same leg-2
+/// (later-publisher) and leg-3 (`DetachedRemainder`) verdicts at the tracked-set
+/// publish gates for EVENT-FUL in-place-population producers (tap/counter/damage),
+/// whose harvest never yields `[]` and therefore cannot use this function's
+/// empty fall-through. The two gates must stay semantically aligned: this
+/// function keeps leg 1 (`no_earlier_producer`), which the veto deliberately
+/// omits (a head with no earlier producer would always clear the veto and
+/// re-admit the tap population).
 fn is_sole_chain_producer(state: &GameState, ability: &ResolvedAbility) -> bool {
     let no_earlier_producer = state.chain_tracked_set_id.is_none_or(|id| {
         state
@@ -5785,6 +5800,127 @@ fn node_or_later_is_publisher_position(node: &ResolvedAbility) -> bool {
             .else_ability
             .as_deref()
             .is_some_and(node_or_later_is_publisher_position)
+}
+
+/// CR 608.2c: does this producer's tracked-set population STAY IN PLACE —
+/// i.e. is its harvest signal an event that is not a zone change? Tap/untap
+/// (CR 701.26a), counter addition (CR 122.1) and damage (CR 120.3) leave the
+/// affected objects in their zones, so a later instruction that moves
+/// *different* objects can never be naming them via zone provenance.
+///
+/// COVERED KINDS (doc-comment exhaustiveness contract — `matches!` variant
+/// patterns are NOT compiler-checked, so any future non-zone-change harvest
+/// kind MUST be added to both this list and the `matches!` below):
+/// SetTapState, PutCounter, PutCounterAll, MultiplyCounter,
+/// ReproduceEventCounters, MoveCounters, DealDamage, DamageAll.
+///
+/// Deliberately EXCLUDED (moving populations, harvested from ZoneChanged or
+/// leave-the-zone events): Counter, CounterAll, Destroy, Sacrifice, Discard,
+/// Mill, Dig, ExileTop, RevealUntil-with-destination. Also excluded — and
+/// this exclusion is MEASURED, not principled: reveal-only (`CardsRevealed`)
+/// and `GainControl`/`GainControlAll` are the same in-place class in
+/// principle but have ZERO corpus rows today and distinct consumer binding
+/// (Atraxa's "from among the revealed cards"). Widening to them is the
+/// documented extension point: one line here plus a full-suite run under the
+/// measurement protocol in `transitive_publish_superseded`.
+fn population_does_not_move(effect: &Effect) -> bool {
+    matches!(
+        effect,
+        Effect::SetTapState { .. }
+            | Effect::PutCounter { .. }
+            | Effect::PutCounterAll { .. }
+            | Effect::MultiplyCounter { .. }
+            | Effect::ReproduceEventCounters { .. }
+            | Effect::MoveCounters { .. }
+            | Effect::DealDamage { .. }
+            | Effect::DamageAll { .. }
+    )
+}
+
+/// CR 608.2c nearest-antecedent: the event-ful companion of
+/// [`is_sole_chain_producer`]'s legs 2+3. An in-place-population producer
+/// (see [`population_does_not_move`]) whose chain is followed by another
+/// producer is not the antecedent a later "this way"/"it" reference names —
+/// the later producer is. Declining the publish keeps that population out of
+/// the chain tracked set entirely, so EVERY sentinel consumer (the interactive
+/// `EffectZoneChoice` scan and the `ChangeZoneAll` mass-move alike) sees only
+/// the later producer's population.
+///
+/// Zone-change producers are exempt on purpose: same-verb compound zone
+/// changes (Suspend Aggression's two exiles) are ONE antecedent and must
+/// unify (`compound_zone_change_chain_unifies_tracked_set`).
+///
+/// Scope of the supersession verdict (MEASURED, then narrowed — see below).
+/// A leg followed ONLY by TERMINAL consumers is never superseded — "terminal"
+/// means the consumer's subtree contains no further `TrackedSet` reference
+/// ([`ability_or_branch_references_tracked_set`]; Urge to Feed, Najeela, and
+/// the Sanar Vivid `Exile → PutCounterAll → caused_by` merge row all keep
+/// publishing — structurally guaranteed). A later node whose OWN subtree
+/// contains a further tracked-set reference IS in publisher position
+/// ([`node_or_later_is_publisher_position`]'s `node_or_later` disjunct) and
+/// supersedes — but ONLY when that later node is itself a MOVING
+/// (zone-change-class) producer: same-class in-place producers chained ahead
+/// of the consumer keep BACKWARD-MERGING, because the consumer's "… this way"
+/// aggregates over the whole same-verb instruction group.
+///
+/// The narrowing is corpus-forced, exactly per the veto's measurement protocol:
+/// Kathril, Aspect Warper (#6321 class) — "put a [keyword] counter on any
+/// creature you control if … Repeat this process for … Then put a +1/+1
+/// counter on Kathril for each counter put on a creature this way" — needs
+/// every `PutCounter` leg to publish into the set its SIBLING legs and the
+/// tail read. Under the un-narrowed chain-wide walk each leg's later sibling
+/// leg is in publisher position (its subtree reaches the tail's TrackedSetSize)
+/// and the veto declined every leg whose own gate was false, leaving the tail
+/// counting 0
+/// (`kathril_reaches_matching_counter_and_tail_past_false_earlier_gates` red).
+/// The distinguishing rule is CR 608.2c's nearest antecedent read on the VERB:
+/// a later producer of a DIFFERENT (zone-moving) harvest class is the
+/// antecedent a later zone-provenance "it" names (Shiva: tap → exile → "return
+/// it"), while a later producer of the SAME in-place class is part of the very
+/// action the "this way" counts. The walk therefore continues PAST a non-moving
+/// publisher node and only fires on a moving one: `tap → tap2 → exile →
+/// consumer` still vetoes the first tap (the exile is found deeper), while
+/// `tap → tap2 → consumer` keeps the full union (no moving producer
+/// intervenes). A later CONSUMER (e.g. `consumer{TrackedSet} →
+/// consumer2{TrackedSet}`) is not an in-place producer, so it still supersedes
+/// — the Motivated Pony LOADED GUN disclosed in
+/// [`later_node_is_publisher_position`]'s doc carries over in that shape.
+///
+/// `repeat_for: TrackedSetSize` consumers are not publisher positions (they
+/// publish nothing), so Seasoned Pyromancer (#740) is unaffected.
+fn transitive_publish_superseded(producer: &ResolvedAbility) -> bool {
+    population_does_not_move(&producer.effect)
+        && (later_node_is_moving_publisher_position(producer)
+            || producer.detached_remainder != DetachedRemainder::NoProducer)
+}
+
+/// CR 608.2c: the narrowed later-node term of
+/// [`transitive_publish_superseded`] — like
+/// [`later_node_is_publisher_position`], but only a later node that is BOTH in
+/// publisher position AND a MOVING (non-in-place, see
+/// [`population_does_not_move`]) producer supersedes. Walks past non-moving
+/// publisher nodes so a moving producer anywhere later still fires; stops at a
+/// mode boundary exactly like its sibling.
+fn later_node_is_moving_publisher_position(ability: &ResolvedAbility) -> bool {
+    ability
+        .sub_ability
+        .as_deref()
+        .is_some_and(node_or_later_is_moving_publisher_position)
+}
+
+fn node_or_later_is_moving_publisher_position(node: &ResolvedAbility) -> bool {
+    if crosses_modal_boundary(node) {
+        return false;
+    }
+    (next_sub_needs_tracked_set(node) && !population_does_not_move(&node.effect))
+        || node
+            .sub_ability
+            .as_deref()
+            .is_some_and(node_or_later_is_moving_publisher_position)
+        || node
+            .else_ability
+            .as_deref()
+            .is_some_and(node_or_later_is_moving_publisher_position)
 }
 
 fn ability_or_branch_references_tracked_set(ability: &ResolvedAbility) -> bool {
@@ -9094,17 +9230,19 @@ fn publish_player_scope_clause_results(
             state.last_effect_excess_amount = excess;
         }
     }
-    let affected_with_causes =
-        if next_sub_needs_tracked_set(outer) || after_scope_needs_linked_exile {
-            affected_objects_with_causes(
-                state,
-                scoped_template,
-                &scoped_template.effect,
-                scoped_events,
-            )
-        } else {
-            Vec::new()
-        };
+    let affected_with_causes = if (next_sub_needs_tracked_set(outer)
+        && !transitive_publish_superseded(scoped_template))
+        || after_scope_needs_linked_exile
+    {
+        affected_objects_with_causes(
+            state,
+            scoped_template,
+            &scoped_template.effect,
+            scoped_events,
+        )
+    } else {
+        Vec::new()
+    };
     let affected_ids: Vec<ObjectId> = affected_with_causes.iter().map(|(id, _)| *id).collect();
     if after_scope_needs_linked_exile {
         for id in &affected_ids {
@@ -9133,7 +9271,7 @@ fn publish_player_scope_clause_results(
     ids.sort_unstable_by_key(|id| id.0);
     ids.dedup();
     state.last_zone_changed_ids = ids;
-    if next_sub_needs_tracked_set(outer) {
+    if next_sub_needs_tracked_set(outer) && !transitive_publish_superseded(scoped_template) {
         publish_tracked_set_with_causes(state, affected_with_causes);
     }
     linked_exile_batch_from_events(state, outer.source_id, scoped_events)
@@ -12722,7 +12860,7 @@ fn resolve_chain_body(
     //   - Counter-adding effects → `CounterAdded` (CR 122.1), so "those
     //     creatures" after a mass counter instruction means the permanents that
     //     actually received counters.
-    if next_sub_needs_tracked_set(ability) {
+    if next_sub_needs_tracked_set(ability) && !transitive_publish_superseded(ability) {
         let affected_with_causes =
             affected_objects_with_causes(state, ability, &ability.effect, &events[events_before..]);
         publish_tracked_set_with_causes(state, affected_with_causes);

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -4654,12 +4654,29 @@ fn split_player_scope_chain(
     (scoped, tail)
 }
 
-/// CR 608.2c: classify a detached chain remainder for the publish gate. The walk
-/// is the same one leg 2 uses, applied to the detached node itself.
+/// CR 608.2c: classify a detached chain remainder for the publish gates. The
+/// walks are the same ones the publish sites use, applied to the detached node
+/// itself.
+///
+/// Arm ORDER is load-bearing: the moving walk
+/// ([`node_or_later_is_moving_publisher_position`]) is a strict subset of the
+/// publisher-position walk ([`node_or_later_is_publisher_position`]), so the
+/// moving check must come first. Arm 1 uses the OWN-CONSUMPTION
+/// consumer-boundary moving walk and reuses the walk's own classifier
+/// ([`population_moves`]), so the split stamp and the unsplit walk share ONE
+/// authority and can never disagree by construction; a tail shaped
+/// `tap → exile → consumer` stamps `HoldsMovingPublisher`, not
+/// `HoldsInPlacePublisher` (the boundary gate is the node's OWN consumption,
+/// not its subtree). Arm 2 preserves `is_sole_chain_producer`'s documented
+/// chain-wide verdict byte-for-byte — its doc stays authoritative for the
+/// event-less class.
 fn detached_remainder_verdict(tail: Option<&ResolvedAbility>) -> DetachedRemainder {
     match tail {
+        Some(node) if node_or_later_is_moving_publisher_position(node) => {
+            DetachedRemainder::HoldsMovingPublisher
+        }
         Some(node) if node_or_later_is_publisher_position(node) => {
-            DetachedRemainder::HoldsPublisher
+            DetachedRemainder::HoldsInPlacePublisher
         }
         _ => DetachedRemainder::NoProducer,
     }
@@ -5837,6 +5854,132 @@ fn population_does_not_move(effect: &Effect) -> bool {
     )
 }
 
+/// CR 608.2c: does this producer's resolver synchronously emit
+/// `GameEvent::ZoneChanged` (or another leave-the-zone event) into its OWN
+/// resolution events — i.e. is its affected population the one the generic
+/// `_ =>` arm of `affected_objects_from_events` (or a dedicated zone-event
+/// arm) would harvest? The positive twin of [`population_does_not_move`]: the
+/// two predicates are DISJOINT BY CONTRACT — tap/counter/damage read
+/// `PermanentTapped`/`CounterAdded`/`DamageDealt`, every moving class reads a
+/// zone-change or leave-zone event — and every `Effect` variant is classified
+/// in exactly ONE of them. Forward-maintenance rule: a future resolver that
+/// routes a move through the `zones.rs`/`zone_pipeline` primitives MUST be
+/// classified in exactly ONE of the two predicates (added here, or proven
+/// harvest-inert in a comment beside [`population_does_not_move`]) — the
+/// `_ => false` catch-all below is a documented, inventoried default, not an
+/// implicit one.
+///
+/// COVERED KINDS (doc-comment exhaustiveness contract — `matches!` variant
+/// patterns are NOT compiler-checked, so the lists below are the inventory):
+///
+/// DEDICATED-ARM MOVING (one-for-one with the `affected_objects_from_events`
+/// harvest arms): `ChangeZone`/`ChangeZoneAll` (generic `ZoneChanged`),
+/// `Destroy`/`DestroyAll` (`CreatureDestroyed`), `Sacrifice`
+/// (`PermanentSacrificed`), `Discard`/`DiscardCard`
+/// (`ZoneChanged{Graveyard}`), `Mill` (destination-zone harvest),
+/// `Bounce`/`BounceAll` (`ZoneChanged{→Hand}`),
+/// `ExileTop`/`ExileFromTopUntil` (`Zone::Exile`), `Counter`/`CounterAll`
+/// (`SpellCountered` — the object leaves the stack, CR 701.6a), and
+/// `RevealUntil` with any disposition except `RevealOnly` (harvests
+/// `ZoneChanged` into `kept_destination`/`kept_destination_if`).
+///
+/// GENERIC-ARM MOVING (no dedicated harvest arm; the resolver emits
+/// `ZoneChanged` through the shared `zones.rs`/`zone_pipeline` entry
+/// authorities, verified per variant): `Token` — every produced token emits
+/// `ZoneChanged{None→Battlefield}` via `record_and_emit_entry_from_no_zone`
+/// (token.rs, the shared entry authority); `Incubate` — same shared
+/// authority; `Conjure { destination: Battlefield }` — routes through that
+/// authority, and the arm is DESTINATION-GUARDED because a
+/// library/hand/graveyard/exile-destination Conjure emits only
+/// `ObjectConjured`; `Amass` — the no-Army branch creates the Army token
+/// through the shared token authority (conservative at variant granularity:
+/// the with-Army branch is counter-only); `Bounce` — `zone_pipeline::
+/// move_object`; `CastFromZone` — casts synchronously during resolution, so
+/// the `ZoneChanged{→Stack}` lands inside `resolve()`'s own event slice;
+/// `Manifest` — all branches via `morph::manifest_card`; `ManifestDread` —
+/// classified on its synchronous count==1 path (the count==2 path moves in
+/// the answer handler, the harvest-faithful class below);
+/// `ExileFaceDownPile`, `PutAtLibraryPosition`, `ReturnAsAura` —
+/// `move_objects_simultaneously_then`; `ExileHaunting` — `zone_pipeline::
+/// move_object`; `HeistExile` — its face-down finalizer;
+/// `ChooseAndSacrificeRest` — the unchosen-sacrifice paths run synchronously
+/// through `sacrifice_permanent`; `CreateTokenCopyFromPool`/`CopyTokenOf` —
+/// both drain through the shared copy-token entry authority.
+///
+/// NOT moving (measured exclusions, carried from
+/// [`population_does_not_move`]): the interactive-window variants
+/// `MadnessCast`, `MiracleCast`, `FreeCastFromZones`, `PutOnTopOrBottom`
+/// move in the ANSWER-HANDLER cycle, never inside the resolver's own event
+/// slice (the engine's manual re-publishes in `engine_resolution_choices`
+/// acknowledge this), so the generic arm's scan over the resolver's events
+/// finds nothing. Also neutral: reveal-only dispositions
+/// (`RevealUntil{RevealOnly}`, `Dig{reveal: true, keep_count: Some(0)}` —
+/// they harvest `CardsRevealed` in place), and the event-less heads
+/// (`PumpAll`/`GoadAll`/`GiveControl`/`GenericEffect`, plus
+/// `GainControl`/`GainControlAll`), which publish through their own
+/// filter/event arms, not a zone harvest.
+fn population_moves(effect: &Effect) -> bool {
+    match effect {
+        // Reveal-only dispositions harvest CardsRevealed (in place).
+        Effect::RevealUntil {
+            matched_disposition: RevealUntilDisposition::RevealOnly,
+            ..
+        } => false,
+        // RevealUntil with a landing destination harvests ZoneChanged.
+        Effect::RevealUntil { .. } => true,
+        // Reveal-only Digs harvest CardsRevealed; other Digs hit the generic
+        // ZoneChanged arm.
+        Effect::Dig {
+            reveal: true,
+            keep_count: Some(0),
+            ..
+        } => false,
+        Effect::Dig { .. } => true,
+        // Conjure emits ZoneChanged ONLY for a battlefield destination
+        // (conjure.rs routes only that destination through the shared entry
+        // authority); other destinations emit ObjectConjured only.
+        Effect::Conjure {
+            destination: Zone::Battlefield,
+            ..
+        } => true,
+        // Dedicated zone-change/leave-zone harvest arms, one-for-one with
+        // `affected_objects_from_events`.
+        Effect::ChangeZone { .. }
+        | Effect::ChangeZoneAll { .. }
+        | Effect::Destroy { .. }
+        | Effect::DestroyAll { .. }
+        | Effect::Sacrifice { .. }
+        | Effect::Discard { .. }
+        | Effect::DiscardCard { .. }
+        | Effect::Mill { .. }
+        | Effect::Bounce { .. }
+        | Effect::BounceAll { .. }
+        | Effect::ExileTop { .. }
+        | Effect::ExileFromTopUntil { .. }
+        | Effect::Counter { .. }
+        | Effect::CounterAll { .. }
+        // Generic-arm ZoneChanged emitters (verified inventory above):
+        | Effect::Token { .. }
+        | Effect::Incubate { .. }
+        | Effect::Amass { .. }
+        | Effect::CastFromZone { .. }
+        | Effect::Manifest { .. }
+        | Effect::ManifestDread
+        | Effect::ExileFaceDownPile { .. }
+        | Effect::ExileHaunting { .. }
+        | Effect::HeistExile
+        | Effect::ChooseAndSacrificeRest { .. }
+        | Effect::PutAtLibraryPosition { .. }
+        | Effect::ReturnAsAura { .. }
+        | Effect::CreateTokenCopyFromPool { .. }
+        | Effect::CopyTokenOf { .. } => true,
+        // NOT moving: interactive-window variants move in the answer-handler
+        // cycle; no ZoneChanged reaches the resolver-side harvest (disclosed
+        // flip vs the round-3 negation-based classification).
+        _ => false,
+    }
+}
+
 /// CR 608.2c nearest-antecedent: the event-ful companion of
 /// [`is_sole_chain_producer`]'s legs 2+3. An in-place-population producer
 /// (see [`population_does_not_move`]) whose chain is followed by another
@@ -5850,64 +5993,70 @@ fn population_does_not_move(effect: &Effect) -> bool {
 /// changes (Suspend Aggression's two exiles) are ONE antecedent and must
 /// unify (`compound_zone_change_chain_unifies_tracked_set`).
 ///
-/// Scope of the supersession verdict (MEASURED, then narrowed — see below).
-/// A leg followed ONLY by TERMINAL consumers is never superseded — "terminal"
-/// means the consumer's subtree contains no further `TrackedSet` reference
-/// ([`ability_or_branch_references_tracked_set`]; Urge to Feed, Najeela, and
-/// the Sanar Vivid `Exile → PutCounterAll → caused_by` merge row all keep
-/// publishing — structurally guaranteed). A later node whose OWN subtree
-/// contains a further tracked-set reference IS in publisher position
-/// ([`node_or_later_is_publisher_position`]'s `node_or_later` disjunct) and
-/// supersedes — but ONLY when that later node is itself a MOVING
-/// (zone-change-class) producer: same-class in-place producers chained ahead
-/// of the consumer keep BACKWARD-MERGING, because the consumer's "… this way"
-/// aggregates over the whole same-verb instruction group.
+/// Scope of the supersession verdict — the OWN-CONSUMPTION CONSUMER-BOUNDARY
+/// walk ([`node_or_later_is_moving_publisher_position`]). A leg followed by
+/// TERMINAL consumers keeps its publish ("terminal" = the consumer's subtree
+/// contains no further `TrackedSet` reference; Urge to Feed, Najeela, and the
+/// Sanar Vivid `Exile → PutCounterAll → caused_by` merge row all keep
+/// publishing — structurally guaranteed) AND a leg followed by NESTED
+/// tracked-set consumers (a reader with a tracked-set-reading descendant)
+/// ALSO keeps its publish: a reader never creates a new antecedent, so BOTH
+/// readers of `tap → grant{TS} → grant2{TS}` bind the tap population. Only an
+/// intervening MOVING (zone-change-harvest, see [`population_moves`])
+/// producer found before any own-consumption consumer boundary supersedes.
+/// In-place producers and neutral nodes are TRANSPARENT and walked past
+/// (same-class aggregation). The Motivated Pony loaded gun is NOT inherited
+/// here: it remains disclosed solely in
+/// [`later_node_is_publisher_position`]'s doc, which governs the event-less
+/// `is_sole_chain_producer` gate and is deliberately unchanged.
 ///
-/// The narrowing is corpus-forced, exactly per the veto's measurement protocol:
-/// Kathril, Aspect Warper (#6321 class) — "put a [keyword] counter on any
-/// creature you control if … Repeat this process for … Then put a +1/+1
-/// counter on Kathril for each counter put on a creature this way" — needs
-/// every `PutCounter` leg to publish into the set its SIBLING legs and the
-/// tail read. Under the un-narrowed chain-wide walk each leg's later sibling
-/// leg is in publisher position (its subtree reaches the tail's TrackedSetSize)
-/// and the veto declined every leg whose own gate was false, leaving the tail
-/// counting 0
+/// The transparency of in-place producers is corpus-forced, exactly per this
+/// veto's measurement protocol: Kathril, Aspect Warper (#6321 class) — "put a
+/// [keyword] counter on any creature you control if … Repeat this process for
+/// … Then put a +1/+1 counter on Kathril for each counter put on a creature
+/// this way" — needs every `PutCounter` leg to publish into the set its
+/// SIBLING legs and the tail read. Under a chain-wide walk each leg's later
+/// sibling leg is in publisher position (its subtree reaches the tail's
+/// TrackedSetSize) and the veto declined every leg whose own gate was false,
+/// leaving the tail counting 0
 /// (`kathril_reaches_matching_counter_and_tail_past_false_earlier_gates` red).
 /// The distinguishing rule is CR 608.2c's nearest antecedent read on the VERB:
 /// a later producer of a DIFFERENT (zone-moving) harvest class is the
 /// antecedent a later zone-provenance "it" names (Shiva: tap → exile → "return
 /// it"), while a later producer of the SAME in-place class is part of the very
-/// action the "this way" counts. The walk therefore continues PAST a non-moving
-/// publisher node and only fires on a moving one: `tap → tap2 → exile →
-/// consumer` still vetoes the first tap (the exile is found deeper), while
-/// `tap → tap2 → consumer` keeps the full union (no moving producer
-/// intervenes). A later CONSUMER (e.g. `consumer{TrackedSet} →
-/// consumer2{TrackedSet}`) is not an in-place producer, so it still supersedes
-/// — the Motivated Pony LOADED GUN disclosed in
-/// [`later_node_is_publisher_position`]'s doc carries over in that shape.
+/// action the "this way" counts. The walk therefore continues PAST a
+/// non-moving node — including past a same-class producer chained ahead of a
+/// deeper moving one (`tap → tap2 → exile → consumer` still vetoes the first
+/// tap, the own-consumption boundary being tap2's node, not its subtree) — and
+/// only fires on a moving one, and it STOPS at the first node that
+/// OWN-consumes the tracked set (`tap → grant{TS} → grant2{TS}` keeps the
+/// publish; both readers bind).
 ///
 /// `repeat_for: TrackedSetSize` consumers are not publisher positions (they
 /// publish nothing), so Seasoned Pyromancer (#740) is unaffected.
 ///
-/// The [`ResolvedAbility::detached_remainder`] leg-3 term is deliberately
-/// UNNARROWED: the splitter's stamp carries no moving/in-place detail, so a
-/// player-scope template whose remainder is a same-class in-place producer
-/// would be vetoed where its non-scoped twin publishes. No corpus row
-/// exercises that shape today; if one appears, refine the stamp, not this
-/// gate.
+/// Leg 3 (the [`ResolvedAbility::detached_remainder`] term) is TYPED: the
+/// splitter stamps the same moving/in-place classification the unsplit walk
+/// uses (`DetachedRemainder::HoldsMovingPublisher` /
+/// `DetachedRemainder::HoldsInPlacePublisher`, computed once at split time by
+/// `detached_remainder_verdict` over the same walks), so a player-scoped chain
+/// takes the SAME supersession decision as its unsplit equivalent. The
+/// previously disclosed UNNARROWED gap — a player-scope template whose
+/// remainder is a same-class in-place producer, vetoed where the unsplit
+/// chain publishes — is CLOSED by this typing, not deferred.
 fn transitive_publish_superseded(producer: &ResolvedAbility) -> bool {
     population_does_not_move(&producer.effect)
         && (later_node_is_moving_publisher_position(producer)
-            || producer.detached_remainder != DetachedRemainder::NoProducer)
+            || producer.detached_remainder == DetachedRemainder::HoldsMovingPublisher)
 }
 
-/// CR 608.2c: the narrowed later-node term of
-/// [`transitive_publish_superseded`] — like
-/// [`later_node_is_publisher_position`], but only a later node that is BOTH in
-/// publisher position AND a MOVING (non-in-place, see
-/// [`population_does_not_move`]) producer supersedes. Walks past non-moving
-/// publisher nodes so a moving producer anywhere later still fires; stops at a
-/// mode boundary exactly like its sibling.
+/// CR 608.2c: the later-node term of [`transitive_publish_superseded`] — like
+/// [`later_node_is_publisher_position`], but only a MOVING (zone-change
+/// harvest, see [`population_moves`]) producer in publisher position
+/// supersedes, and the walk STOPS at the first node that OWN-consumes the
+/// tracked set (a reader boundary; see
+/// [`node_or_later_is_moving_publisher_position`]). Stops at a mode boundary
+/// exactly like its sibling.
 fn later_node_is_moving_publisher_position(ability: &ResolvedAbility) -> bool {
     ability
         .sub_ability
@@ -5915,40 +6064,78 @@ fn later_node_is_moving_publisher_position(ability: &ResolvedAbility) -> bool {
         .is_some_and(node_or_later_is_moving_publisher_position)
 }
 
+/// CR 608.2c + CR 700.2: is THIS node, or any strictly-later node of its
+/// chain, a MOVING producer in publisher position? The walk STOPS at the
+/// first node that OWN-consumes the tracked set —
+/// [`node_consumes_tracked_set`], NOT the branch-inclusive
+/// [`ability_or_branch_references_tracked_set`] wrapper, else
+/// `tap → tap2 → exile → consumer` dies at tap2 (whose tracked-set reference
+/// lives in its SUBTREE, not its own effect) and the first tap is never
+/// vetoed. Only a MOVING producer found before any such boundary supersedes;
+/// in-place producers and neutral nodes are transparent.
+///
+/// The firing branch is evaluated at EVERY non-mode-boundary node BEFORE the
+/// boundary test, so a non-own-consuming moving producer whose consumer is a
+/// descendant is classified (the exile leg in Shiva; the Token leg in the
+/// generic-arm class). An own-consuming MOVING node (a `ChangeZoneAll {
+/// TrackedSet }` mass-move consumer) supersedes itself — correct: it IS the
+/// later zone-change antecedent. Stops at a mode boundary exactly like its
+/// sibling.
 fn node_or_later_is_moving_publisher_position(node: &ResolvedAbility) -> bool {
     if crosses_modal_boundary(node) {
         return false;
     }
-    (next_sub_needs_tracked_set(node) && !population_does_not_move(&node.effect))
-        || node
-            .sub_ability
-            .as_deref()
-            .is_some_and(node_or_later_is_moving_publisher_position)
+    // Firing branch at EVERY non-mode-boundary node: a MOVING producer in
+    // publisher position supersedes — whether or not it own-consumes the set
+    // and whether or not the tracked set is referenced only deeper in its
+    // subtree.
+    if next_sub_needs_tracked_set(node) && population_moves(&node.effect) {
+        return true;
+    }
+    // Reader boundary: own-consuming NON-moving reader (the moving case was
+    // already caught by the firing branch above). A reader having a reader
+    // descendant does not create a new antecedent.
+    if node_consumes_tracked_set(node) {
+        return false;
+    }
+    // Transparent (in-place producer or neutral node): keep walking.
+    node.sub_ability
+        .as_deref()
+        .is_some_and(node_or_later_is_moving_publisher_position)
         || node
             .else_ability
             .as_deref()
             .is_some_and(node_or_later_is_moving_publisher_position)
 }
 
-fn ability_or_branch_references_tracked_set(ability: &ResolvedAbility) -> bool {
-    let consumes = matches!(
-        &ability.effect,
+/// CR 608.2c: does THIS node's OWN effect (not its continuation branches)
+/// consume the chain's tracked set? The supersession walk's consumer
+/// boundary — OWN consumption only; the branch-inclusive tail lives in
+/// [`ability_or_branch_references_tracked_set`], which composes this helper
+/// with its two [`branch_references_tracked_set`] terms (byte-identical
+/// semantics for every existing caller).
+///
+/// CR 608.2c: `repeat_for` is a loop-count quantity on the ResolvedAbility,
+/// not inside Effect — e.g. "for each nonland card discarded this way, create
+/// a token" uses `repeat_for: TrackedSetSize`. Without this check, the
+/// forced-discard path (no WaitingFor pause) never publishes the tracked set,
+/// so the downstream token loop sees size 0 and creates no tokens (Seasoned
+/// Pyromancer bug #740).
+fn node_consumes_tracked_set(node: &ResolvedAbility) -> bool {
+    matches!(
+        &node.effect,
         Effect::CreateDelayedTrigger {
             uses_tracked_set: true,
             ..
         } | Effect::ChooseFromZone { .. }
-    ) || effect_references_tracked_set(&ability.effect)
-        // CR 608.2c: `repeat_for` is a loop-count quantity on the
-        // ResolvedAbility, not inside Effect — e.g. "for each nonland card
-        // discarded this way, create a token" uses `repeat_for: TrackedSetSize`.
-        // Without this check, the forced-discard path (no WaitingFor pause)
-        // never publishes the tracked set, so the downstream token loop sees
-        // size 0 and creates no tokens (Seasoned Pyromancer bug #740).
-        || ability
+    ) || effect_references_tracked_set(&node.effect)
+        || node
             .repeat_for
             .as_ref()
-            .is_some_and(quantity_expr_references_tracked_set);
+            .is_some_and(quantity_expr_references_tracked_set)
+}
 
+fn ability_or_branch_references_tracked_set(ability: &ResolvedAbility) -> bool {
     // CR 700.2 + CR 608.2c: both descents stop at a mode boundary. Guarding only
     // the entry hop in `next_sub_needs_tracked_set` is INSUFFICIENT whenever a
     // mode has more than one node: `append_to_sub_chain` hangs the next mode's
@@ -5966,7 +6153,7 @@ fn ability_or_branch_references_tracked_set(ability: &ResolvedAbility) -> bool {
     // at the highest index of its card. That corpus is a generated artifact and
     // its consumer side may be undercounted relative to this branch's parser;
     // regenerate `card-data.json` to close it.
-    consumes
+    node_consumes_tracked_set(ability)
         || branch_references_tracked_set(ability.sub_ability.as_deref())
         || branch_references_tracked_set(ability.else_ability.as_deref())
 }
@@ -26631,8 +26818,9 @@ mod tests {
         );
         assert_eq!(
             scoped.detached_remainder,
-            DetachedRemainder::HoldsPublisher,
-            "the splitter must record that the detached remainder still holds a producer"
+            DetachedRemainder::HoldsInPlacePublisher,
+            "the splitter must record that the detached remainder still holds a producer \
+             (its tail is a SetTapState — an IN-PLACE publisher position)"
         );
         assert!(
             !is_sole_chain_producer(&state, &scoped),
@@ -26661,6 +26849,541 @@ mod tests {
             "non-vacuity: with nothing consuming downstream the head DOES publish, so the \
              veto above is caused by the publisher position and not by the split itself"
         );
+    }
+
+    // ---- Typed moving/in-place classification battery (round-6 remediation) ----
+
+    fn tap_leg() -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::SetTapState {
+                target: TargetFilter::Any,
+                scope: EffectScope::All,
+                state: TapStateChange::Tap,
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        )
+    }
+
+    /// A tracked-set READER (GrantCastingPermission binds the set's members
+    /// without moving them — `population_moves` is false).
+    fn grant_leg() -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::GrantCastingPermission {
+                permission: crate::types::ability::CastingPermission::WarpExile {
+                    castable_after_turn: 1,
+                },
+                target: TargetFilter::TrackedSet {
+                    id: crate::types::identifiers::TrackedSetId(0),
+                },
+                grantee: crate::types::ability::PermissionGrantee::AbilityController,
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        )
+    }
+
+    fn exile_leg() -> ResolvedAbility {
+        ResolvedAbility::new(
+            Effect::ChangeZone {
+                origin: Some(Zone::Battlefield),
+                destination: Zone::Exile,
+                target: TargetFilter::SelfRef,
+                owner_library: false,
+                enter_transformed: false,
+                enters_under: None,
+                enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+                enters_attacking: false,
+                up_to: false,
+                enter_with_counters: vec![],
+                conditional_enter_with_counters: vec![],
+                face_down_profile: None,
+                enters_modified_if: None,
+            },
+            vec![],
+            ObjectId(1),
+            PlayerId(0),
+        )
+    }
+
+    /// Append `leg` at the tail of `chain`'s sub_ability spine (the tests
+    /// cannot call the crate-private `append_to_sub_chain`; same walk, inline).
+    fn append_test_leg(chain: &mut ResolvedAbility, leg: ResolvedAbility) {
+        let mut node = chain;
+        while node.sub_ability.is_some() {
+            node = node.sub_ability.as_mut().unwrap().as_mut();
+        }
+        node.sub_ability = Some(Box::new(leg));
+    }
+
+    /// MED-2 congruence, matched pair A: a player-scoped chain whose detached
+    /// remainder holds a MOVING producer (`exile → reader{TS}`) takes the SAME
+    /// supersession verdict as its unsplit twin — vetoed. The stamp assertion
+    /// pins the TYPED verdict: the moving walk (arm 1), not merely the wider
+    /// publisher-position walk, classifies the tail. Paired non-vacuity twin
+    /// proves the veto is leg 3's stamp, not the class gate alone.
+    #[test]
+    fn scoped_split_with_a_moving_remainder_supersedes_like_the_unsplit_chain() {
+        let build = |player_scope: Option<PlayerFilter>| {
+            let mut head = tap_leg();
+            head.player_scope = player_scope;
+            append_test_leg(&mut head, exile_leg());
+            append_test_leg(&mut head, grant_leg());
+            head
+        };
+
+        // Unsplit twin: the own-consumption boundary walk finds the moving
+        // exile before any reader boundary → superseded (positive reach-guard
+        // for the veto below).
+        let unsplit = build(None);
+        assert!(
+            transitive_publish_superseded(&unsplit),
+            "unsplit tap → exile → reader is superseded by the moving exile (CR 608.2c)"
+        );
+
+        let (scoped, tail) =
+            split_player_scope_chain(&build(Some(PlayerFilter::All)), &PlayerFilter::All);
+        assert!(
+            tail.is_some(),
+            "precondition: the SetTapState → ChangeZone continuation must detach, \
+             else this test proves nothing about the detached case"
+        );
+        assert_eq!(
+            scoped.detached_remainder,
+            DetachedRemainder::HoldsMovingPublisher,
+            "the splitter must classify the moving exile through the corrected \
+             own-consumption walk"
+        );
+        assert!(
+            transitive_publish_superseded(&scoped),
+            "CR 608.2c congruence: the scoped chain is superseded exactly like its \
+             unsplit twin"
+        );
+
+        // Non-vacuity twin: same head class, inert remainder (an untap leg that
+        // consumes nothing downstream) — both legs false, the head publishes.
+        let mut inert_head = tap_leg();
+        inert_head.player_scope = Some(PlayerFilter::All);
+        append_test_leg(&mut inert_head, tap_leg());
+        let (scoped_inert, tail_inert) = split_player_scope_chain(&inert_head, &PlayerFilter::All);
+        assert!(tail_inert.is_some(), "precondition: same detachment");
+        assert_eq!(
+            scoped_inert.detached_remainder,
+            DetachedRemainder::NoProducer
+        );
+        assert!(
+            !transitive_publish_superseded(&scoped_inert),
+            "non-vacuity: with no producer in the detached remainder the head DOES \
+             publish, so the veto above is caused by the moving stamp and not by \
+             the split or the class gate"
+        );
+    }
+
+    /// MED-2, matched pair B (the revert-failing row): a player-scoped chain
+    /// whose detached remainder is a same-class IN-PLACE producer followed by
+    /// a TERMINAL reader must PUBLISH exactly like its unsplit twin. The
+    /// pre-typing leg 3 (`!= NoProducer`) vetoed exactly this shape — revert
+    /// the typed leg 3 and this row flips red while the moving pair stays
+    /// green.
+    #[test]
+    fn scoped_split_with_an_in_place_remainder_publishes_like_the_unsplit_chain() {
+        let build = |player_scope: Option<PlayerFilter>| {
+            let mut head = tap_leg();
+            head.player_scope = player_scope;
+            append_test_leg(&mut head, tap_leg());
+            append_test_leg(&mut head, grant_leg());
+            head
+        };
+
+        // Unsplit twin (positive reach-guard): same-class chain, no moving
+        // producer, reader boundary at the grant → the tap publish survives.
+        let unsplit = build(None);
+        assert!(
+            !transitive_publish_superseded(&unsplit),
+            "unsplit tap → tap2 → terminal reader keeps the tap publish (no moving \
+             producer; the walk stops at the reader boundary)"
+        );
+
+        let (scoped, tail) =
+            split_player_scope_chain(&build(Some(PlayerFilter::All)), &PlayerFilter::All);
+        assert!(tail.is_some(), "precondition: same detachment");
+        assert_eq!(
+            scoped.detached_remainder,
+            DetachedRemainder::HoldsInPlacePublisher,
+            "the in-place tap2 in publisher position must stamp the IN-PLACE variant"
+        );
+        assert!(
+            !transitive_publish_superseded(&scoped),
+            "CR 608.2c congruence: a same-class in-place remainder must NOT veto — \
+             the MED-2 divergence is closed"
+        );
+    }
+
+    /// R4-1 unsplit regression: the Kathril doc shape
+    /// `tap → tap2 → exile → reader{TS}` — tap2 is TRANSPARENT under the
+    /// own-consumption gate (its tracked-set reference lives in its SUBTREE,
+    /// not its own effect), so the walk reaches the moving exile and the first
+    /// tap IS vetoed. Under a branch-inclusive (subtree) boundary gate the walk
+    /// dies at tap2 and this row flips false.
+    #[test]
+    fn own_consumption_boundary_walks_past_a_transparent_in_place_producer_to_the_moving_exile() {
+        let mut chain = tap_leg();
+        append_test_leg(&mut chain, tap_leg());
+        append_test_leg(&mut chain, exile_leg());
+        append_test_leg(&mut chain, grant_leg());
+        assert!(
+            transitive_publish_superseded(&chain),
+            "R4-1: tap2 does not own-consume, so the walk must reach the moving exile \
+             and veto the first tap (Kathril doc contract)"
+        );
+    }
+
+    /// R4-1 scoped twin: the detached tail `tap2 → exile → reader{TS}` stamps
+    /// `HoldsMovingPublisher` through the corrected walk (arm 1) and the scoped
+    /// head is vetoed — congruent with the unsplit twin above.
+    #[test]
+    fn scoped_split_with_transparent_in_place_then_moving_tail_stamps_the_moving_variant() {
+        let mut head = tap_leg();
+        head.player_scope = Some(PlayerFilter::All);
+        append_test_leg(&mut head, tap_leg());
+        append_test_leg(&mut head, exile_leg());
+        append_test_leg(&mut head, grant_leg());
+
+        let (scoped, tail) = split_player_scope_chain(&head, &PlayerFilter::All);
+        assert!(tail.is_some(), "precondition: same detachment");
+        assert_eq!(
+            scoped.detached_remainder,
+            DetachedRemainder::HoldsMovingPublisher,
+            "arm 1 must run the own-consumption walk: tap2 is transparent, the exile \
+             is a moving producer found before any reader boundary"
+        );
+        assert!(
+            transitive_publish_superseded(&scoped),
+            "the moving stamp fires veto leg 3 on the scoped head"
+        );
+    }
+
+    /// Flipped nested-reader semantics pinned at the predicate level (the
+    /// structural mirror of the integration fixture
+    /// `nested_tracked_set_consumers_keep_the_tap_publish`): the walk's reader
+    /// boundary fires at the FIRST reader, so the tap publish is NOT superseded
+    /// and both readers bind. Under the round-3 negation this was TRUE.
+    #[test]
+    fn nested_reader_boundary_keeps_the_in_place_publish() {
+        let mut chain = tap_leg();
+        append_test_leg(&mut chain, grant_leg());
+        append_test_leg(&mut chain, grant_leg());
+        assert!(
+            !transitive_publish_superseded(&chain),
+            "a reader never creates a new antecedent: both chained readers keep the \
+             tap publish (CR 608.2c)"
+        );
+    }
+
+    /// Reader-tail stamp units (congruence table rows 3-4): a TERMINAL reader
+    /// tail stamps `NoProducer` (no sub, no else — arm 2 is false), a NESTED
+    /// reader tail stamps `HoldsInPlacePublisher` (the reader's subtree reaches
+    /// the second reader's own consumption). Both feed the veto on an in-place
+    /// head, where the class gate passes, and NEITHER fires it — publish both
+    /// ways, via different stamps.
+    #[test]
+    fn reader_tails_stamp_no_producer_when_terminal_and_in_place_when_nested() {
+        let terminal = grant_leg();
+        assert_eq!(
+            detached_remainder_verdict(Some(&terminal)),
+            DetachedRemainder::NoProducer,
+            "a terminal reader is not a publisher position (nothing downstream)"
+        );
+
+        let mut nested = grant_leg();
+        append_test_leg(&mut nested, grant_leg());
+        assert_eq!(
+            detached_remainder_verdict(Some(&nested)),
+            DetachedRemainder::HoldsInPlacePublisher,
+            "the nested reader's subtree reaches the second reader's own consumption"
+        );
+
+        // Both stamps ride veto leg 3 on an IN-PLACE head (class gate true) and
+        // must stay publish-side (non-vacuous: the class gate alone cannot
+        // produce these rows' verdict).
+        let mut head_t = tap_leg();
+        head_t.detached_remainder = detached_remainder_verdict(Some(&terminal));
+        assert!(
+            !transitive_publish_superseded(&head_t),
+            "publish: a terminal reader tail's NoProducer stamp fires nothing"
+        );
+        let mut head_n = tap_leg();
+        head_n.detached_remainder = detached_remainder_verdict(Some(&nested));
+        assert!(
+            !transitive_publish_superseded(&head_n),
+            "publish: a NESTED reader tail's IN-PLACE stamp never fires the event-ful \
+             veto"
+        );
+    }
+
+    /// Disjointness + classification-representation unit: the two mobility
+    /// classifiers answer disjointly for every representative (no row has both
+    /// true), and each representative pins its class — the moving list includes
+    /// the generic-arm ZoneChanged emitters (Token, Incubate, Bounce, Conjure
+    /// {Battlefield}, Amass, CastFromZone, Manifest), the destination-guarded
+    /// Conjure arm, and the interactive-window not-moving variants. Removing
+    /// any variant from `population_moves`' positive list flips its row red.
+    #[test]
+    fn population_mobility_classifiers_are_disjoint_and_representatives_are_pinned() {
+        use crate::types::ability::{
+            BounceSelection, ConjureCard, ConjureSource, DigRestOrder, DigSource,
+            SpellStackToGraveyardReplacement,
+        };
+        use crate::types::counter::CounterType;
+
+        let conjure = |destination| Effect::Conjure {
+            cards: vec![ConjureCard {
+                source: ConjureSource::Named {
+                    name: "Conjured".to_string(),
+                },
+                count: QuantityExpr::Fixed { value: 1 },
+            }],
+            destination,
+            tapped: false,
+            library_position: None,
+            library_players: None,
+        };
+        let reveal_until = |disposition| Effect::RevealUntil {
+            player: TargetFilter::Controller,
+            filter: TargetFilter::Any,
+            count: QuantityExpr::Fixed { value: 1 },
+            matched_disposition: disposition,
+            kept_destination: Zone::Exile,
+            rest_destination: Zone::Library,
+            enter_tapped: crate::types::zones::EtbTapState::Unspecified,
+            enters_attacking: false,
+            kept_optional_to: None,
+            enters_under: None,
+            kept_destination_if: None,
+        };
+
+        // (name, effect, population_moves, population_does_not_move)
+        let rows: Vec<(&str, Effect, bool, bool)> = vec![
+            ("ChangeZone", exile_leg().effect, true, false),
+            ("SetTapState", tap_leg().effect, false, true),
+            (
+                "PutCounter",
+                Effect::PutCounter {
+                    counter_type: CounterType::Plus1Plus1,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Any,
+                },
+                false,
+                true,
+            ),
+            (
+                "DealDamage",
+                Effect::DealDamage {
+                    amount: QuantityExpr::Fixed { value: 1 },
+                    target: TargetFilter::Any,
+                    damage_source: None,
+                    excess: None,
+                },
+                false,
+                true,
+            ),
+            (
+                "Counter",
+                Effect::Counter {
+                    target: TargetFilter::Any,
+                    source_rider: None,
+                    countered_spell_zone: None,
+                },
+                true,
+                false,
+            ),
+            (
+                "Dig{reveal-only}",
+                Effect::Dig {
+                    player: TargetFilter::Controller,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    destination: None,
+                    keep_count: Some(0),
+                    keep_count_expr: None,
+                    up_to: false,
+                    filter: TargetFilter::Any,
+                    rest_destination: None,
+                    rest_order: DigRestOrder::Preserve,
+                    reveal: true,
+                    enter_tapped: false,
+                    enters_attacking: false,
+                    source: DigSource::Library,
+                },
+                false,
+                false,
+            ),
+            (
+                "RevealUntil{RevealOnly}",
+                reveal_until(RevealUntilDisposition::RevealOnly),
+                false,
+                false,
+            ),
+            (
+                "RevealUntil{KeepEach}",
+                reveal_until(RevealUntilDisposition::KeepEach),
+                true,
+                false,
+            ),
+            (
+                "Token",
+                Effect::Token {
+                    name: "Treasure".to_string(),
+                    power: PtValue::Fixed(0),
+                    toughness: PtValue::Fixed(0),
+                    types: vec![],
+                    colors: vec![],
+                    keywords: vec![],
+                    tapped: false,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    owner: TargetFilter::Controller,
+                    attach_to: None,
+                    enters_attacking: false,
+                    supertypes: vec![],
+                    static_abilities: vec![],
+                    enter_with_counters: vec![],
+                },
+                true,
+                false,
+            ),
+            (
+                "Incubate",
+                Effect::Incubate {
+                    count: QuantityExpr::Fixed { value: 1 },
+                },
+                true,
+                false,
+            ),
+            (
+                "Bounce",
+                Effect::Bounce {
+                    target: TargetFilter::Any,
+                    destination: None,
+                    selection: BounceSelection::Targeted,
+                },
+                true,
+                false,
+            ),
+            (
+                "Conjure{Battlefield}",
+                conjure(Zone::Battlefield),
+                true,
+                false,
+            ),
+            ("Conjure{Library}", conjure(Zone::Library), false, false),
+            (
+                "Manifest",
+                Effect::Manifest {
+                    target: TargetFilter::Any,
+                    count: QuantityExpr::Fixed { value: 1 },
+                    object_source: None,
+                    profile: None,
+                    enters_under: None,
+                },
+                true,
+                false,
+            ),
+            (
+                "Amass",
+                Effect::Amass {
+                    subtype: "Zombie".to_string(),
+                    count: QuantityExpr::Fixed { value: 1 },
+                },
+                true,
+                false,
+            ),
+            (
+                "CastFromZone",
+                Effect::CastFromZone {
+                    target: TargetFilter::Any,
+                    without_paying_mana_cost: true,
+                    mode: CardPlayMode::Cast,
+                    cast_transformed: false,
+                    alt_ability_cost: None,
+                    constraint: None,
+                    duration: None,
+                    driver: CastFromZoneDriver::ResolutionWindow {
+                        bounds: crate::types::ability::ResolutionCastWindow::UNBOUNDED,
+                    },
+                    mana_spend_permission: None,
+                },
+                true,
+                false,
+            ),
+            (
+                "MadnessCast",
+                Effect::MadnessCast {
+                    cost: ManaCost::default(),
+                },
+                false,
+                false,
+            ),
+            (
+                "MiracleCast",
+                Effect::MiracleCast {
+                    cost: ManaCost::default(),
+                },
+                false,
+                false,
+            ),
+            (
+                "FreeCastFromZones",
+                Effect::FreeCastFromZones {
+                    count: Some(1),
+                    max_total_mv: None,
+                    filter: TargetFilter::Any,
+                    zones: vec![Zone::Graveyard],
+                    graveyard_replacement: Some(SpellStackToGraveyardReplacement::Exile),
+                },
+                false,
+                false,
+            ),
+            (
+                "PutOnTopOrBottom",
+                Effect::PutOnTopOrBottom {
+                    target: TargetFilter::Any,
+                    chooser: TargetFilter::Controller,
+                },
+                false,
+                false,
+            ),
+        ];
+
+        for (name, effect, moves, stays) in &rows {
+            assert_eq!(
+                population_moves(effect),
+                *moves,
+                "population_moves({name}) pins the mobility classification"
+            );
+            assert_eq!(
+                population_does_not_move(effect),
+                *stays,
+                "population_does_not_move({name}) pins the in-place classification"
+            );
+            assert!(
+                !(population_moves(effect) && population_does_not_move(effect)),
+                "the two classifiers are DISJOINT BY CONTRACT — {name} violated it"
+            );
+        }
+    }
+
+    /// Serde hardening control: the pre-enrichment stamp string deserializes to
+    /// the conservative-publish default instead of erroring (the verdict is
+    /// resolution-transient; no save/load path round-trips it across builds).
+    #[test]
+    fn legacy_detached_remainder_string_deserializes_to_no_producer() {
+        let legacy: DetachedRemainder = serde_json::from_str("\"HoldsPublisher\"")
+            .expect("a legacy stamp string must not fail deserialization");
+        assert_eq!(legacy, DetachedRemainder::NoProducer);
+        let round = serde_json::to_string(&DetachedRemainder::HoldsMovingPublisher)
+            .expect("the stamp must serialize");
+        assert_eq!(round, "\"HoldsMovingPublisher\"");
     }
 
     /// CR 608.2c (maintainer review, #7484): the event-less `GenericEffect`

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -27816,16 +27816,42 @@ pub enum ParentTargetMissingReason {
 /// the wrong population. The verdict is purely structural, so it is computed
 /// once at split time and carried on the template rather than re-derived.
 ///
-/// SOLE WRITERS: `split_player_scope_chain`, `split_multi_target_player_chain`.
+/// SOLE WRITERS: `split_player_scope_chain`, `split_multi_target_player_chain`,
+/// both through `detached_remainder_verdict`. SOLE READER VERDICTS:
+/// `is_sole_chain_producer` leg 3 vetoes on ANY non-`NoProducer` variant (the
+/// event-less gate's chain-wide verdict is unchanged by the split), while
+/// `transitive_publish_superseded` leg 3 vetoes ONLY on `HoldsMovingPublisher`
+/// — a same-class in-place remainder must publish exactly like the unsplit
+/// chain (CR 608.2c congruence). Serde compat: the verdict is
+/// resolution-transient (written only at split time, read only while the same
+/// chain resolves — no save/load, replay, or test path round-trips it across
+/// builds), so a legacy string this build does not know — e.g. the
+/// pre-enrichment `"HoldsPublisher"` — deserializes to the `NoProducer` default
+/// (conservative-publish) instead of erroring.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
 pub enum DetachedRemainder {
-    /// Nothing was detached, or the detached remainder holds no producer in
-    /// publisher position. The template's own walk is the whole truth.
+    /// The detached remainder holds a publisher position whose population
+    /// STAYS IN PLACE (tap/counter/damage class — see
+    /// `effects::population_does_not_move`). `is_sole_chain_producer` leg 3
+    /// vetoes on this variant (the event-less gate's chain-wide verdict is
+    /// unchanged); the event-ful veto (`transitive_publish_superseded`) does
+    /// NOT — a same-class in-place remainder must publish exactly like the
+    /// unsplit chain.
+    HoldsInPlacePublisher,
+    /// The detached remainder holds a MOVING (zone-change-harvest) producer
+    /// in publisher position before any own-consumption consumer boundary —
+    /// the same verdict `effects::population_moves` drives in the unsplit
+    /// walk. Both gates veto.
+    HoldsMovingPublisher,
+    /// Nothing was detached, or the detached remainder holds no node that
+    /// binds the tracked set. The template's own walk is the whole truth.
+    /// LAST variant so serde's catch-all applies (serde requires
+    /// `#[serde(other)]` on the last variant): a legacy-state string this
+    /// build does not know deserializes here (conservative-publish; see the
+    /// sole-writer doc).
     #[default]
+    #[serde(other)]
     NoProducer,
-    /// The detached remainder holds a node in publisher position, so this node
-    /// is NOT the sole producer of its pre-split chain and must not publish.
-    HoldsPublisher,
 }
 
 /// CR 701.3a + CR 608.2d: The three semantic roles of an [`Effect::Attach`]

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1046,6 +1046,7 @@ mod sensei_golden_tail_5950;
 mod sentinel_sliver_vigilance_grant;
 mod serpent_society_ward_poison_cost;
 mod serras_emissary_chosen_card_type_protection;
+mod shiva_chapter3_tap_publish_leak;
 mod shorten_efficacy;
 mod sin_spiras_punishment_repeat;
 mod skitterfang_reflexive_without_counter;

--- a/crates/engine/tests/integration/shiva_chapter3_tap_publish_leak.rs
+++ b/crates/engine/tests/integration/shiva_chapter3_tap_publish_leak.rs
@@ -525,13 +525,13 @@ fn all_untapped_board_does_not_pollute_return_candidates() {
 }
 
 /// Hostile fixture (iii): two same-class in-place publishers chained
-/// (`tap lands → tap creatures → grant{TrackedSet}`). Under the narrowed veto
-/// (MEASURED via Kathril, see `transitive_publish_superseded`'s doc), a
-/// same-class in-place sibling producer is NOT a superseding moving publisher,
-/// so both tap legs keep publishing and the grant binds the UNION the chain
-/// unification produces — the plan's original (iii) semantics, which also pins
-/// that the narrowing did not reintroduce forward-only suppression for
-/// same-verb chains (the Kathril #6321 class).
+/// (`tap lands → tap creatures → grant{TrackedSet}`). Both tap legs are
+/// TRANSPARENT to the supersession walk (in-place producers and neutral nodes
+/// are walked past — there is no moving producer and the walk's own-consumption
+/// reader boundary only fires at the grant), so both tap legs keep publishing
+/// and the grant binds the UNION the chain unification produces. This also
+/// pins that the own-consumption boundary did not reintroduce forward-only
+/// suppression for same-verb chains (the Kathril #6321 class).
 #[test]
 fn chained_tap_publishers_grant_binds_the_unified_union() {
     let execute = parse_effect_chain(TAP_LANDS_AND_CREATURES, AbilityKind::Spell);
@@ -587,9 +587,10 @@ fn chained_tap_publishers_grant_binds_the_unified_union() {
 }
 
 /// Hostile fixture (iv), terminal side: `tap → grant{TrackedSet}` — the grant
-/// is a TERMINAL consumer (its subtree contains no further tracked-set
-/// reference), so the tap leg is NOT in superseded publisher position and MUST
-/// keep publishing. Pins the R2-1 terminal-consumer guarantee behaviorally.
+/// is a TERMINAL consumer (no tracked-set-reading descendant), so the walk's
+/// own-consumption reader boundary fires there and the tap leg keeps its
+/// publish. Pins the terminal-consumer guarantee behaviorally — the nested
+/// twin below proves a reader with a reader descendant behaves the SAME way.
 #[test]
 fn terminal_tracked_set_consumer_keeps_the_tap_publish() {
     let execute = parse_effect_chain(TAP_LANDS, AbilityKind::Spell);
@@ -621,14 +622,16 @@ fn terminal_tracked_set_consumer_keeps_the_tap_publish() {
 }
 
 /// Hostile fixture (iv), nested side: `tap → grant{TrackedSet} →
-/// grant2{TrackedSet}` — the first consumer's own subtree references
-/// TrackedSet, so it IS in publisher position (`node_or_later_is_publisher_position`'s
-/// `node_or_later` disjunct) and the tap leg IS superseded: neither reader
-/// binds the tap population, even though both wanted it (the Motivated Pony
-/// loaded gun, carried verbatim into the veto's doc). Pins the R2-1
-/// chain-wide scope behaviorally.
+/// grant2{TrackedSet}` — the walk's own-consumption consumer boundary fires at
+/// the FIRST reader (a reader never creates a new antecedent), so the tap leg
+/// keeps its publish and BOTH readers bind the tap population. The Motivated
+/// Pony loaded gun is NOT inherited by the event-ful veto: it stays disclosed
+/// solely in `later_node_is_publisher_position`'s doc, which governs the
+/// event-less `is_sole_chain_producer` gate. The preserved counter-shape is
+/// the Shiva `tap → exile` veto — the exile is a MOVING producer found before
+/// any consumer boundary (see the primary repro and discriminator A).
 #[test]
-fn nested_tracked_set_consumer_supersedes_the_tap_publish() {
+fn nested_tracked_set_consumers_keep_the_tap_publish() {
     let execute = parse_effect_chain(TAP_LANDS, AbilityKind::Spell);
     let (scenario, lands) = build_scenario_with_untapped_lands(8);
     let mut runner = scenario.build();
@@ -642,7 +645,7 @@ fn nested_tracked_set_consumer_supersedes_the_tap_publish() {
 
     let state = runner.state();
     // Reach-guard: the tap leg ran (all eight lands transitioned and are
-    // tapped) — the veto was a publish-gate narrowing, not a dead tap leg.
+    // tapped) — the publish-gate semantics changed, not the leg itself.
     assert_eq!(
         tapped_object_ids(&events).len(),
         8,
@@ -650,12 +653,16 @@ fn nested_tracked_set_consumer_supersedes_the_tap_publish() {
     );
     for land in &lands {
         assert!(state.objects[land].tapped);
-        // Discriminating assertion: a nested consumer supersedes the publish —
-        // the tap population reaches NEITHER reader.
-        assert!(
-            state.objects[land].casting_permissions.is_empty(),
-            "with two chained tracked-set consumers the superseded tap leg's \
-             population must reach neither reader (CR 608.2c chain-wide scope)"
+        // Discriminating assertion: BOTH chained readers bound the tap
+        // population — `grant_permission::resolve` pushes one permission per
+        // resolve, so two chained grants stack additively to exactly 2 per
+        // tapped land (0 under the round-3 superseding walk, 1 under any
+        // single-reader mistake — only both readers binding yields 2).
+        assert_eq!(
+            state.objects[land].casting_permissions.len(),
+            2,
+            "nested tracked-set consumers keep the tap publish: every tapped land \
+             must receive BOTH grants (CR 608.2c reader-boundary contract)"
         );
     }
 }

--- a/crates/engine/tests/integration/shiva_chapter3_tap_publish_leak.rs
+++ b/crates/engine/tests/integration/shiva_chapter3_tap_publish_leak.rs
@@ -118,7 +118,7 @@ fn stage_shiva(runner: &mut GameRunner) -> ObjectId {
     obj.card_types.core_types.push(CoreType::Enchantment);
     obj.card_types.subtypes.push("Saga".to_string());
     obj.base_card_types = obj.card_types.clone();
-    // CR 712.4a: the lore-counter trigger has TRANSFORMED the saga to its back
+    // CR 712.9 + CR 712.18: the lore-counter trigger has TRANSFORMED the saga to its back
     // face — the chapter resolves while Shiva is showing, exactly as in the
     // live dump. Without this flag the zone-exit front-face revert never fires
     // and the fixture diverges from the live game (whose exiled object 23 was
@@ -158,7 +158,7 @@ fn shiva_chapter_iii_tap_leg_must_not_pollute_return_candidates() {
     );
     assert_eq!(
         state.objects[&shiva_id].name, "Jill, Shiva's Dominant",
-        "the returned permanent must show its front face (CR 712.14a)"
+        "the returned permanent must show its front face (CR 712.14)"
     );
     assert_eq!(
         state.objects[&untapped_land].zone,

--- a/crates/engine/tests/integration/shiva_chapter3_tap_publish_leak.rs
+++ b/crates/engine/tests/integration/shiva_chapter3_tap_publish_leak.rs
@@ -355,13 +355,13 @@ fn grant_reader_binds_only_the_exiled_saga_not_tapped_lands() {
 
 /// Discriminator B (CR 608.2c, mass-move consumer): the same producer shape
 /// consumed by a hand-built `ChangeZoneAll { target: TrackedSet(0) }` — the
-/// brief's second sentinel-reading path (change_zone.rs resolves the sentinel
+/// second of the two sentinel-reading paths (change_zone.rs resolves the sentinel
 /// for the mass path too).
 ///
-/// The destination is Graveyard, NOT the plan's literal `Battlefield`: with
+/// The destination is Graveyard, NOT `Battlefield`: with
 /// destination == the polluted members' current zone, a same-zone mass move is
 /// a fully silent no-op (no event, no count inflation, no movement), so the
-/// plan's literal shape cannot fail pre-fix and does not discriminate. Moving
+/// Battlefield shape cannot fail pre-fix and does not discriminate. Moving
 /// to a zone OUTSIDE the polluted population makes the corruption observable
 /// while exercising the identical sentinel path. Exactly the Saga is moved;
 /// no land is eligible (pre-fix the polluted set puts the battlefield lands
@@ -656,7 +656,7 @@ fn nested_tracked_set_consumers_keep_the_tap_publish() {
         // Discriminating assertion: BOTH chained readers bound the tap
         // population — `grant_permission::resolve` pushes one permission per
         // resolve, so two chained grants stack additively to exactly 2 per
-        // tapped land (0 under the round-3 superseding walk, 1 under any
+        // tapped land (0 if the tap publish were superseded, 1 under any
         // single-reader mistake — only both readers binding yields 2).
         assert_eq!(
             state.objects[land].casting_permissions.len(),

--- a/crates/engine/tests/integration/shiva_chapter3_tap_publish_leak.rs
+++ b/crates/engine/tests/integration/shiva_chapter3_tap_publish_leak.rs
@@ -1,0 +1,661 @@
+//! Regression test for the 2026-09-01 live-game bug report — Shiva, Warden of Ice
+//! (back face of Jill, Shiva's Dominant) chapter III:
+//!
+//! `III — Cold Snap — Tap all lands your opponents control. Exile Shiva, then
+//! return it to the battlefield (front face up).`
+//!
+//! The reported bug: after the chapter resolved, the human was prompted
+//! "Choose 1 card to put onto the battlefield" with TWO candidates — the exiled
+//! Saga AND an opponent's land that was already on the battlefield.
+//!
+//! Mechanism (verified against the authoritative game-state dump):
+//! 1. Seven of the opponent's eight lands were already tapped, so the tap leg
+//!    transitioned only the eighth — exactly one `PermanentTapped` event.
+//! 2. The chapter's return leg reads `TrackedSet(0)` (the "it" anaphor), so the
+//!    transitive `next_sub_needs_tracked_set` walk makes the tap leg publish
+//!    its affected set (`Effect::SetTapState` harvest arm in
+//!    `affected_objects_from_events`) into the chain tracked set.
+//! 3. The exile leg extends the same chain set with the exiled Saga
+//!    (chain unification in `publish_tracked_set`).
+//! 4. The return leg's `TrackedSetId(0)` sentinel resolves to the merged set;
+//!    `scan_zones` derives from the members' zones (Battlefield + Exile) and
+//!    the opponent's land becomes an eligible "put onto the battlefield"
+//!    candidate.
+//!
+//! CR 608.2c: the chain tracked set feeds "this way" anaphors; the chapter's
+//! "return it" names the card the exile leg exiled — the tap leg's population
+//! is not part of that antecedent.
+
+use engine::game::ability_utils::build_resolved_from_def;
+use engine::game::effects::resolve_ability_chain;
+use engine::game::game_object::BackFaceData;
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::zones::create_object;
+use engine::parser::oracle_effect::parse_effect_chain;
+use engine::types::ability::{
+    AbilityKind, CastingPermission, Effect, PermissionGrantee, ResolvedAbility, TargetFilter,
+    ThisWayCause,
+};
+use engine::types::card_type::{CardType, CoreType};
+use engine::types::counter::CounterType;
+use engine::types::events::GameEvent;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::{CardId, ObjectId, TrackedSetId};
+use engine::types::mana::{ManaColor, ManaCost};
+use engine::types::player::PlayerId;
+use engine::types::zones::{EtbTapState, Zone};
+
+/// Verbatim chapter body from the card's Oracle text (card-data.json,
+/// "shiva, warden of ice"), with the printed card-name reference "Exile Shiva"
+/// written as "Exile ~" — the same self-reference normalization the saga
+/// parser applies for the card's own name (the live game's parse lowers the
+/// exile leg to `SelfRef`).
+const COLD_SNAP: &str =
+    "Tap all lands your opponents control. Exile ~, then return it to the battlefield (front face up).";
+
+/// Jill, Shiva's Dominant — the front face the saga returns to.
+fn jill_back_face() -> BackFaceData {
+    BackFaceData {
+        is_swap_snapshot: false,
+        name: "Jill, Shiva's Dominant".to_string(),
+        power: Some(2),
+        toughness: Some(3),
+        loyalty: None,
+        printed_loyalty: None,
+        defense: None,
+        card_types: CardType {
+            supertypes: vec![],
+            core_types: vec![CoreType::Creature],
+            subtypes: vec![
+                "Human".to_string(),
+                "Noble".to_string(),
+                "Warrior".to_string(),
+            ],
+        },
+        mana_cost: ManaCost::default(),
+        keywords: vec![],
+        abilities: vec![],
+        trigger_definitions: Default::default(),
+        replacement_definitions: Default::default(),
+        static_definitions: Default::default(),
+        color: vec![ManaColor::Blue],
+        printed_ref: None,
+        modal: None,
+        additional_cost: None,
+        strive_cost: None,
+        casting_restrictions: vec![],
+        casting_options: vec![],
+        layout_kind: None,
+        parse_warnings: vec![],
+    }
+}
+
+/// Build the game: P1 controls eight lands, seven already tapped (its mana was
+/// spent on the previous turn) and one untapped — the exact board shape from
+fn build_scenario_with_polluted_board() -> (GameScenario, Vec<ObjectId>, ObjectId) {
+    let mut scenario = GameScenario::new();
+    let mut tapped_lands = Vec::new();
+    for _ in 0..7 {
+        let land = scenario.add_basic_land(P1, ManaColor::Blue);
+        tapped_lands.push(land);
+    }
+    let untapped_land = scenario.add_basic_land(P1, ManaColor::Blue);
+    (scenario, tapped_lands, untapped_land)
+}
+
+/// Place the Shiva-faced Saga on P0's battlefield after the runner exists
+/// (`GameScenario.state` is private outside the crate).
+fn stage_shiva(runner: &mut GameRunner) -> ObjectId {
+    let state = runner.state_mut();
+    let id = create_object(
+        state,
+        CardId(500),
+        P0,
+        "Shiva, Warden of Ice".to_string(),
+        Zone::Battlefield,
+    );
+    let obj = state.objects.get_mut(&id).unwrap();
+    obj.card_types.core_types.push(CoreType::Enchantment);
+    obj.card_types.subtypes.push("Saga".to_string());
+    obj.base_card_types = obj.card_types.clone();
+    // CR 712.4a: the lore-counter trigger has TRANSFORMED the saga to its back
+    // face — the chapter resolves while Shiva is showing, exactly as in the
+    // live dump. Without this flag the zone-exit front-face revert never fires
+    // and the fixture diverges from the live game (whose exiled object 23 was
+    // already "Jill, Shiva's Dominant").
+    obj.transformed = true;
+    obj.counters.insert(CounterType::Lore, 3);
+    obj.back_face = Some(jill_back_face());
+    id
+}
+
+#[test]
+fn shiva_chapter_iii_tap_leg_must_not_pollute_return_candidates() {
+    let execute = parse_effect_chain(COLD_SNAP, AbilityKind::Spell);
+    let (scenario, tapped_lands, untapped_land) = build_scenario_with_polluted_board();
+    let mut runner = scenario.build();
+    for land in &tapped_lands {
+        runner.state_mut().objects.get_mut(land).unwrap().tapped = true;
+    }
+    let shiva_id = stage_shiva(&mut runner);
+    let resolved = build_resolved_from_def(&execute, shiva_id, P0);
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("chapter III resolves");
+
+    let state = runner.state();
+    let waiting = &state.waiting_for;
+    assert!(
+        !matches!(waiting, WaitingFor::EffectZoneChoice { .. }),
+        "chapter III's return leg has a single eligible card (the exiled Saga); \
+         the opponent's already-battlefield land must not join the candidate pool \
+         (CR 608.2c): {waiting:?}"
+    );
+    assert_eq!(
+        state.objects[&shiva_id].zone,
+        Zone::Battlefield,
+        "the Saga must return to the battlefield automatically (single candidate)"
+    );
+    assert_eq!(
+        state.objects[&shiva_id].name, "Jill, Shiva's Dominant",
+        "the returned permanent must show its front face (CR 712.14a)"
+    );
+    assert_eq!(
+        state.objects[&untapped_land].zone,
+        Zone::Battlefield,
+        "the opponent's land must never be a return candidate"
+    );
+    // Reach-guard (paired with the no-pause negative above): the tap leg
+    // really ran — exactly one untapped→tapped transition (the eighth land),
+    // and all eight P1 lands end tapped. Proves the fix narrowed the publish
+    // gate, not the leg itself.
+    assert_eq!(
+        tapped_object_ids(&events),
+        vec![untapped_land],
+        "exactly one PermanentTapped event (the single untapped→tapped transition) \
+         must prove the tap leg executed"
+    );
+    assert!(
+        tapped_lands
+            .iter()
+            .chain(std::iter::once(&untapped_land))
+            .all(|land| state.objects[land].tapped),
+        "all eight P1 lands must be tapped after chapter III"
+    );
+    // Reach-guard (second): the exile leg really ran — the Saga reached Exile
+    // before the return leg auto-resolved it back (CR 608.2c).
+    assert!(
+        zone_changed_to(&events, shiva_id, Zone::Exile),
+        "the exile leg must emit ZoneChanged → Exile for the Saga"
+    );
+}
+/// The tap + exile producer legs with the tracked-set-consuming return leg
+/// REMOVED — used by the discriminating fixtures that attach their own
+/// consumer leg. Producers stay parsed from real Oracle text; only the
+/// consumer is synthesized (hand-built legs are the established precedent:
+/// `compound_zone_change_chain_unifies_tracked_set` in the engine lib tests).
+const TAP_AND_EXILE: &str = "Tap all lands your opponents control. Exile ~.";
+
+/// Two same-class in-place producers, for the tap→tap→grant union fixture.
+const TAP_LANDS_AND_CREATURES: &str =
+    "Tap all lands your opponents control. Tap all creatures you control.";
+
+/// A single tap leg with a TERMINAL tracked-set consumer, for the
+/// terminal-vs-nested-consumer fixtures.
+const TAP_LANDS: &str = "Tap all lands your opponents control.";
+
+/// Append `leg` to the tail of `ability`'s sub_ability chain. The integration
+/// crate cannot call the crate-private `append_to_sub_chain`; the walk mirrors
+/// it exactly.
+fn append_leg(ability: &mut ResolvedAbility, leg: ResolvedAbility) {
+    let mut node = ability;
+    while node.sub_ability.is_some() {
+        node = node.sub_ability.as_mut().unwrap().as_mut();
+    }
+    node.sub_ability = Some(Box::new(leg));
+}
+
+/// A NON-consuming tracked-set reader: `GrantCastingPermission` with the
+/// `TrackedSetId(0)` sentinel resolves through `grant_permission::resolve`'s
+/// highest-set-id ladder WITHOUT removing the set, so the chain's tracked set
+/// stays inspectable after `resolve_ability_chain` returns. This is the only
+/// post-resolve set-content read that is not vacuous — the `ChangeZone`
+/// consumer removes the set and its member-causes in lockstep when it scans.
+fn grant_tracked_set_leg(source_id: ObjectId, controller: PlayerId) -> ResolvedAbility {
+    ResolvedAbility::new(
+        Effect::GrantCastingPermission {
+            permission: CastingPermission::WarpExile {
+                castable_after_turn: 1,
+            },
+            target: TargetFilter::TrackedSet {
+                id: TrackedSetId(0),
+            },
+            grantee: PermissionGrantee::AbilityController,
+        },
+        vec![],
+        source_id,
+        controller,
+    )
+}
+
+/// Board with `count` P1 basic lands, all untapped (hostile fixture (i): the
+/// tap leg transitions `count` objects — pollution magnitude changes, the
+/// behavior must not).
+fn build_scenario_with_untapped_lands(count: usize) -> (GameScenario, Vec<ObjectId>) {
+    let mut scenario = GameScenario::new();
+    let lands = (0..count)
+        .map(|_| scenario.add_basic_land(P1, ManaColor::Blue))
+        .collect();
+    (scenario, lands)
+}
+
+/// Objects that received a `PermanentTapped` event, in event order — the
+/// transition-only tap population.
+fn tapped_object_ids(events: &[GameEvent]) -> Vec<ObjectId> {
+    events
+        .iter()
+        .filter_map(|event| match event {
+            GameEvent::PermanentTapped { object_id, .. } => Some(*object_id),
+            _ => None,
+        })
+        .collect()
+}
+
+fn zone_changed_to(events: &[GameEvent], object_id: ObjectId, to: Zone) -> bool {
+    events.iter().any(|event| {
+        matches!(
+            event,
+            GameEvent::ZoneChanged {
+                object_id: id,
+                to: dest,
+                ..
+            } if *id == object_id && *dest == to
+        )
+    })
+}
+
+/// Any zone change at all for `object_id` — used to prove a non-member never
+/// entered a mass-move's eligible pool.
+fn zone_changed_at_all(events: &[GameEvent], object_id: ObjectId) -> bool {
+    events.iter().any(
+        |event| matches!(event, GameEvent::ZoneChanged { object_id: id, .. } if *id == object_id),
+    )
+}
+
+/// Discriminator A (CR 608.2c nearest-antecedent, set-content): the tap leg is
+/// superseded by the exile leg in publisher position, so the chain tracked set
+/// must contain ONLY the exiled Saga — never a tapped land. The non-consuming
+/// `GrantCastingPermission` reader keeps the set inspectable after resolution
+/// (unlike the `ChangeZone` consumer, which drains it on scan).
+///
+/// Pre-fix: the tap leg publishes the tapped land into the chain set
+/// (transitive `next_sub_needs_tracked_set` walk) and the exile leg extends the
+/// same set (chain unification) → the bound set is [land, Saga] and this
+/// assertion fails. Post-fix: the veto declines the tap publish → [Saga] only.
+#[test]
+fn grant_reader_binds_only_the_exiled_saga_not_tapped_lands() {
+    let execute = parse_effect_chain(TAP_AND_EXILE, AbilityKind::Spell);
+    let (scenario, tapped_lands, untapped_land) = build_scenario_with_polluted_board();
+    let mut runner = scenario.build();
+    for land in &tapped_lands {
+        runner.state_mut().objects.get_mut(land).unwrap().tapped = true;
+    }
+    let shiva_id = stage_shiva(&mut runner);
+    let mut resolved = build_resolved_from_def(&execute, shiva_id, P0);
+    append_leg(&mut resolved, grant_tracked_set_leg(shiva_id, P0));
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("tap → exile → grant chain resolves");
+
+    let state = runner.state();
+    // Reach-guards: the tap leg ran (exactly one untapped→tapped transition)
+    // and the exile leg ran (Saga reached Exile; the grant reader proves it
+    // bound the Saga).
+    assert_eq!(
+        tapped_object_ids(&events),
+        vec![untapped_land],
+        "the tap leg must run (one untapped→tapped transition)"
+    );
+    assert_eq!(
+        state.objects[&shiva_id].zone,
+        Zone::Exile,
+        "the exile leg must run (Saga sits in Exile; no return leg in this fixture)"
+    );
+    assert_eq!(
+        state.objects[&shiva_id].casting_permissions.len(),
+        1,
+        "the grant reader must bind the Saga — proves the consumer executed"
+    );
+
+    // Discriminating assertion, targeted at the CHAIN's set id (the grant
+    // ladder's `max_by_key` spans the append-only map; never a whole-map sweep).
+    let set_id = state
+        .chain_tracked_set_id
+        .expect("the exile leg must publish the chain tracked set the reader binds");
+    let bound = &state.tracked_object_sets[&set_id];
+    assert_eq!(
+        bound.as_slice(),
+        &[shiva_id],
+        "the chain tracked set must contain ONLY the exiled Saga — the tap leg's \
+         population is not the antecedent of the tracked-set reader (CR 608.2c): {bound:?}"
+    );
+    // Cause-stamp coherence: the exile leg stamps `Exiled`; no land carries any
+    // member-cause stamp.
+    let causes = &state.tracked_set_member_causes[&set_id];
+    assert_eq!(
+        causes.get(&shiva_id),
+        Some(&ThisWayCause::Exiled),
+        "the Saga must carry the Exiled cause stamp"
+    );
+    assert!(
+        causes.keys().all(|id| *id == shiva_id),
+        "no tapped land may carry a member-cause stamp: {causes:?}"
+    );
+}
+
+/// Discriminator B (CR 608.2c, mass-move consumer): the same producer shape
+/// consumed by a hand-built `ChangeZoneAll { target: TrackedSet(0) }` — the
+/// brief's second sentinel-reading path (change_zone.rs resolves the sentinel
+/// for the mass path too).
+///
+/// The destination is Graveyard, NOT the plan's literal `Battlefield`: with
+/// destination == the polluted members' current zone, a same-zone mass move is
+/// a fully silent no-op (no event, no count inflation, no movement), so the
+/// plan's literal shape cannot fail pre-fix and does not discriminate. Moving
+/// to a zone OUTSIDE the polluted population makes the corruption observable
+/// while exercising the identical sentinel path. Exactly the Saga is moved;
+/// no land is eligible (pre-fix the polluted set puts the battlefield lands
+/// into the member scan and moves every one of them to the Graveyard).
+#[test]
+fn change_zone_all_mass_move_moves_only_the_exiled_saga() {
+    let execute = parse_effect_chain(TAP_AND_EXILE, AbilityKind::Spell);
+    let (scenario, tapped_lands, untapped_land) = build_scenario_with_polluted_board();
+    let mut runner = scenario.build();
+    for land in &tapped_lands {
+        runner.state_mut().objects.get_mut(land).unwrap().tapped = true;
+    }
+    let shiva_id = stage_shiva(&mut runner);
+    let all_lands: Vec<ObjectId> = tapped_lands
+        .iter()
+        .chain(std::iter::once(&untapped_land))
+        .copied()
+        .collect();
+    let mut resolved = build_resolved_from_def(&execute, shiva_id, P0);
+    append_leg(
+        &mut resolved,
+        ResolvedAbility::new(
+            Effect::ChangeZoneAll {
+                origin: None,
+                destination: Zone::Graveyard,
+                target: TargetFilter::TrackedSet {
+                    id: TrackedSetId(0),
+                },
+                enters_under: None,
+                enter_tapped: EtbTapState::Unspecified,
+                enters_attacking: false,
+                enter_with_counters: vec![],
+                face_down_profile: None,
+                library_position: None,
+                random_order: false,
+            },
+            vec![],
+            shiva_id,
+            P0,
+        ),
+    );
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("tap → exile → mass-move chain resolves");
+
+    let state = runner.state();
+    // Reach-guards: tap leg ran; exile leg ran (Saga reached Exile before the
+    // mass move took it on to the Graveyard).
+    assert_eq!(
+        tapped_object_ids(&events),
+        vec![untapped_land],
+        "the tap leg must run (one untapped→tapped transition)"
+    );
+    assert!(
+        zone_changed_to(&events, shiva_id, Zone::Exile),
+        "the exile leg must emit ZoneChanged → Exile for the Saga"
+    );
+    // Discriminating assertion: exactly the Saga is moved.
+    assert_eq!(
+        state.objects[&shiva_id].zone,
+        Zone::Graveyard,
+        "the mass move must move the exiled Saga (the tracked set's only member)"
+    );
+    for land in &all_lands {
+        assert!(
+            !zone_changed_at_all(&events, *land),
+            "a tapped land must never enter the ChangeZoneAll member scan (CR 608.2c)"
+        );
+        assert_eq!(
+            state.objects[land].zone,
+            Zone::Battlefield,
+            "the opponent's land must never be moved by the mass-move consumer"
+        );
+    }
+    // Second discriminator: the mass path must move exactly ONE object. Pre-fix
+    // the polluted set puts the battlefield lands into the member scan pool, so
+    // the move count inflates.
+    assert_eq!(
+        state.last_effect_count,
+        Some(1),
+        "the ChangeZoneAll mass move must move exactly the exiled Saga (CR 608.2c), \
+         got count {count:?}",
+        count = state.last_effect_count
+    );
+}
+
+/// Negative control: `SetTapState → ChangeZone{Exile}` with NO tracked-set
+/// consumer publishes nothing. Pre-fix this passes (the publish gate only
+/// fires when a descendant references TrackedSet); post-fix it must STAY green
+/// — it catches an accidental unconditional veto that would wedge every
+/// producer publish.
+#[test]
+fn tap_exile_chain_with_no_consumer_publishes_no_tracked_set() {
+    let execute = parse_effect_chain(TAP_AND_EXILE, AbilityKind::Spell);
+    let (scenario, tapped_lands, untapped_land) = build_scenario_with_polluted_board();
+    let mut runner = scenario.build();
+    for land in &tapped_lands {
+        runner.state_mut().objects.get_mut(land).unwrap().tapped = true;
+    }
+    let shiva_id = stage_shiva(&mut runner);
+    let mut events = Vec::new();
+    let resolved = build_resolved_from_def(&execute, shiva_id, P0);
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("producer-only chain resolves");
+    let state = runner.state();
+    // Reach-guard: the chain really ran — the Saga was exiled and the tap
+    // transitioned the eighth land.
+    assert_eq!(
+        state.objects[&shiva_id].zone,
+        Zone::Exile,
+        "the exile leg must run in the producer-only chain"
+    );
+    assert_eq!(
+        tapped_object_ids(&events),
+        vec![untapped_land],
+        "the tap leg must run in the producer-only chain"
+    );
+    assert!(
+        !state.tracked_object_sets.values().any(|set| set
+            .iter()
+            .any(|id| *id == shiva_id || tapped_lands.contains(id) || *id == untapped_land)),
+        "no consumer → no publish: no tracked set may contain the Saga or any land"
+    );
+}
+
+/// Hostile fixture (i): ALL eight lands untapped. The tap leg now transitions
+/// eight objects (pollution magnitude changes) — the behavior must not.
+#[test]
+fn all_untapped_board_does_not_pollute_return_candidates() {
+    let execute = parse_effect_chain(COLD_SNAP, AbilityKind::Spell);
+    let (scenario, lands) = build_scenario_with_untapped_lands(8);
+    let mut runner = scenario.build();
+    let shiva_id = stage_shiva(&mut runner);
+    let mut events = Vec::new();
+    let resolved = build_resolved_from_def(&execute, shiva_id, P0);
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("chapter III resolves");
+    let state = runner.state();
+    assert!(
+        !matches!(state.waiting_for, WaitingFor::EffectZoneChoice { .. }),
+        "no return-candidate prompt on the all-untapped board: {:?}",
+        state.waiting_for
+    );
+    assert_eq!(state.objects[&shiva_id].zone, Zone::Battlefield);
+    assert_eq!(state.objects[&shiva_id].name, "Jill, Shiva's Dominant");
+    // Reach-guard: the tap leg transitioned all eight lands.
+    let tapped = tapped_object_ids(&events);
+    assert_eq!(
+        tapped.len(),
+        8,
+        "all eight lands transitioned untapped→tapped (larger pollution magnitude)"
+    );
+    for land in &lands {
+        assert!(state.objects[land].tapped, "every land must be tapped");
+        assert_eq!(
+            state.objects[land].zone,
+            Zone::Battlefield,
+            "the land must never be a return candidate"
+        );
+    }
+}
+
+/// Hostile fixture (iii): two same-class in-place publishers chained
+/// (`tap lands → tap creatures → grant{TrackedSet}`). Under the narrowed veto
+/// (MEASURED via Kathril, see `transitive_publish_superseded`'s doc), a
+/// same-class in-place sibling producer is NOT a superseding moving publisher,
+/// so both tap legs keep publishing and the grant binds the UNION the chain
+/// unification produces — the plan's original (iii) semantics, which also pins
+/// that the narrowing did not reintroduce forward-only suppression for
+/// same-verb chains (the Kathril #6321 class).
+#[test]
+fn chained_tap_publishers_grant_binds_the_unified_union() {
+    let execute = parse_effect_chain(TAP_LANDS_AND_CREATURES, AbilityKind::Spell);
+    let (mut scenario, tapped_lands, untapped_land) = build_scenario_with_polluted_board();
+    let creature_b = scenario.add_vanilla(P0, 2, 2);
+    let creature_a = scenario.add_vanilla(P0, 2, 2);
+    let mut runner = scenario.build();
+    for land in &tapped_lands {
+        runner.state_mut().objects.get_mut(land).unwrap().tapped = true;
+    }
+    let shiva_id = stage_shiva(&mut runner);
+    let mut resolved = build_resolved_from_def(&execute, shiva_id, P0);
+    append_leg(&mut resolved, grant_tracked_set_leg(shiva_id, P0));
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("tap → tap → grant chain resolves");
+
+    let state = runner.state();
+    // Reach-guards: both tap legs ran (land transition + creature transitions).
+    let tapped = tapped_object_ids(&events);
+    assert!(
+        tapped.contains(&untapped_land)
+            && tapped.contains(&creature_a)
+            && tapped.contains(&creature_b),
+        "both tap legs must run: {tapped:?}"
+    );
+    assert!(state.objects[&creature_a].tapped && state.objects[&creature_b].tapped);
+    // Union assertion: the grant binds BOTH producers' populations — same-class
+    // in-place chains backward-merge through chain unification.
+    for creature in [&creature_a, &creature_b] {
+        assert_eq!(
+            state.objects[creature].casting_permissions.len(),
+            1,
+            "the grant must bind the second tap leg's population"
+        );
+    }
+    // The first tap leg's AFFECTED population is transition-only: the single
+    // untapped→tapped land joins the union; the seven already-tapped lands were
+    // not affected by the leg and are correctly absent.
+    assert_eq!(
+        state.objects[&untapped_land].casting_permissions.len(),
+        1,
+        "the grant must also bind the first tap leg's affected population (union, \
+         not forward-only suppression)"
+    );
+    for land in &tapped_lands {
+        assert!(
+            state.objects[land].casting_permissions.is_empty(),
+            "a land the tap leg did not transition is not part of any affected \
+             population and must not receive the grant"
+        );
+    }
+}
+
+/// Hostile fixture (iv), terminal side: `tap → grant{TrackedSet}` — the grant
+/// is a TERMINAL consumer (its subtree contains no further tracked-set
+/// reference), so the tap leg is NOT in superseded publisher position and MUST
+/// keep publishing. Pins the R2-1 terminal-consumer guarantee behaviorally.
+#[test]
+fn terminal_tracked_set_consumer_keeps_the_tap_publish() {
+    let execute = parse_effect_chain(TAP_LANDS, AbilityKind::Spell);
+    let (scenario, lands) = build_scenario_with_untapped_lands(8);
+    let mut runner = scenario.build();
+    let shiva_id = stage_shiva(&mut runner);
+    let mut resolved = build_resolved_from_def(&execute, shiva_id, P0);
+    append_leg(&mut resolved, grant_tracked_set_leg(shiva_id, P0));
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("tap → grant chain resolves");
+
+    let state = runner.state();
+    // Reach-guard: the tap leg transitioned all eight lands.
+    assert_eq!(
+        tapped_object_ids(&events).len(),
+        8,
+        "the tap leg must run and transition all eight lands"
+    );
+    // Positive assertion: a terminal consumer keeps the publish — every tapped
+    // land receives the grant.
+    for land in &lands {
+        assert_eq!(
+            state.objects[land].casting_permissions.len(),
+            1,
+            "a terminal tracked-set consumer keeps the tap leg's publish (CR 608.2c)"
+        );
+    }
+}
+
+/// Hostile fixture (iv), nested side: `tap → grant{TrackedSet} →
+/// grant2{TrackedSet}` — the first consumer's own subtree references
+/// TrackedSet, so it IS in publisher position (`node_or_later_is_publisher_position`'s
+/// `node_or_later` disjunct) and the tap leg IS superseded: neither reader
+/// binds the tap population, even though both wanted it (the Motivated Pony
+/// loaded gun, carried verbatim into the veto's doc). Pins the R2-1
+/// chain-wide scope behaviorally.
+#[test]
+fn nested_tracked_set_consumer_supersedes_the_tap_publish() {
+    let execute = parse_effect_chain(TAP_LANDS, AbilityKind::Spell);
+    let (scenario, lands) = build_scenario_with_untapped_lands(8);
+    let mut runner = scenario.build();
+    let shiva_id = stage_shiva(&mut runner);
+    let mut resolved = build_resolved_from_def(&execute, shiva_id, P0);
+    append_leg(&mut resolved, grant_tracked_set_leg(shiva_id, P0));
+    append_leg(&mut resolved, grant_tracked_set_leg(shiva_id, P0));
+    let mut events = Vec::new();
+    resolve_ability_chain(runner.state_mut(), &resolved, &mut events, 0)
+        .expect("tap → grant → grant chain resolves");
+
+    let state = runner.state();
+    // Reach-guard: the tap leg ran (all eight lands transitioned and are
+    // tapped) — the veto was a publish-gate narrowing, not a dead tap leg.
+    assert_eq!(
+        tapped_object_ids(&events).len(),
+        8,
+        "the tap leg must run and transition all eight lands"
+    );
+    for land in &lands {
+        assert!(state.objects[land].tapped);
+        // Discriminating assertion: a nested consumer supersedes the publish —
+        // the tap population reaches NEITHER reader.
+        assert!(
+            state.objects[land].casting_permissions.is_empty(),
+            "with two chained tracked-set consumers the superseded tap leg's \
+             population must reach neither reader (CR 608.2c chain-wide scope)"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Fixes chain tracked-set pollution by in-place-population producers (CR 608.2c): a resolution leg whose affected population stays in place (tap/untap, counter addition, damage) no longer publishes into the chain tracked set when a later moving producer exists in the same chain, so a downstream `TrackedSet` anaphor ("Exile ~, then return **it** to the battlefield") binds only the zone-change producer's population. Reported live: Shiva, Warden of Ice chapter III offered a "Choose 1 card to put onto the battlefield" prompt containing the exiled Saga AND an opponent's land already on the battlefield; the return leg now auto-resolves on the single eligible card.

## Files changed

- `crates/engine/src/game/effects/mod.rs` — `population_does_not_move` (in-place effect-class predicate, doc-comment exhaustiveness contract), `transitive_publish_superseded` (CR 608.2c nearest-antecedent publish veto), `later_node_is_moving_publisher_position` / `node_or_later_is_moving_publisher_position` (narrowed later-publisher walk, mode-boundary stop preserved), the three tracked-set publish gates (generic ~12866; player-scope ~9230 parenthesized, ~9274 explicit rewrite), doc updates to `next_sub_needs_tracked_set` and `is_sole_chain_producer`.
- `crates/engine/tests/integration/shiva_chapter3_tap_publish_leak.rs` (new) — 8 runtime tests: primary repro, set-content discriminator via non-consuming `GrantCastingPermission` reader (asserts `chain_tracked_set_id`, not the whole append-only map), behavioral `ChangeZoneAll` mass-move discriminator, all-untapped board, same-class union, terminal-vs-nested consumers, negative control; every negative paired with tap/exile reach-guards.
- `crates/engine/tests/integration/main.rs` — `mod` registration.

## Track

Developer

## LLM

Model: glm-5.3-flash
Tier: Frontier
Thinking: max

## Implementation method (required)

Method: /engine-implementer
<!-- Or: Method: not-applicable — <specific non-engine reason> -->

> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver,
> targeting, rules behavior — is expected to go through `/engine-implementer`.
> The "not used" box is for changes that genuinely fall outside that scope.

## CR references

- CR 608.2c — rules of English / nearest antecedent: the veto's basis (mod.rs, new predicates + publish gates).
- CR 701.26a (tap), CR 122.1 (counter addition), CR 120.3 (damage) — the in-place harvest classes covered by `population_does_not_move`.
- CR 712.9, CR 712.14, CR 712.18 — test-fixture transform/front-face staging and assertion comments (corrections verified against `docs/MagicCompRules.txt` :5878/:5901/:5917).

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo test -p phase-engine --test integration shiva_chapter3` — 8 passed; 0 failed. Independent revert-gate check (reviewer, throwaway worktree at be87002e6 with the three publish gates reverted): 5/8 red (primary, both discriminators, all-untapped, nested-consumer), 3 designed controls green — the fix is the load-bearing element.
- `cargo test -p phase-engine --test integration <filter>` (najeela, urge_to_feed, jeskai_ascendancy, living_death, god_pharaohs_gift, emperor, sanar, winding_way, std_longtail, player_scope_linked_exile, kiora, kathril, motivated_pony, if_you_do) — all green (corpus traps: Suspend Aggression unification, Zimone routing, Living Death causes, Beseech Shuffle-not-wipe, Najeela/Urge-to-Feed terminal consumers, mode-boundary rows; Random Encounter/Suicidal Charge/Taunt-from-the-Rampart/Witness rows covered by the full suite).
- `cargo test -p phase-engine --lib` — 20366 passed; 0 failed; 6 ignored.
- `cargo test -p phase-engine` (full) — lib 20366 passed / 0 failed; integration 5940 passed / 0 failed; 2 ignored. Zero failures to attribute.
- `cargo clippy --all-targets -- -D warnings` — clean (re-run at dbfda4375ae7387a356d846cb53e7bdd7e4931c5).
- `cargo fmt --all -- --check` — clean; `git diff --check` clean.
- `./scripts/check-parser-combinators.sh` — Gate G PASS, Gate A PASS (parser untouched; no parse-shape change).

## Gate A

Gate A PASS head=dbfda4375ae7387a356d846cb53e7bdd7e4931c5 base=8a43f90bda9060205f9918cc5a51f9f5e31e61e0

## Anchored on

- crates/engine/src/game/effects/mod.rs:5730 — `is_sole_chain_producer`: the existing CR 608.2c nearest-antecedent gate for event-less producer heads (issue #6682); this fix extends the same verdict to event-ful in-place producers.
- crates/engine/src/game/effects/mod.rs:5769 — `later_node_is_publisher_position` / `node_or_later_is_publisher_position`: the structural later-publisher walk the veto reuses (mode-boundary stop, unmodified `next_sub_needs_tracked_set`).
- crates/engine/tests/integration/jeskai_ascendancy_pump_untap_anaphora_6857.rs — sibling-class precedent (Outlaws' Fury pump → exile → grant anaphora, issue #6857).

## Final review-impl

Final review-impl PASS head=dbfda4375ae7387a356d846cb53e7bdd7e4931c5

- Full `$review-impl` at be87002e62f3e5385b510e9da4451c752ff32583: verdict ACCEPT — zero blocking findings; 3 LOW strictly-advisory findings (two CR citation corrections, one doc-comment asymmetry note).
- Advisories applied per the `/engine-implementer` advisory clause (no behavior change; 9+/2− across the two files above) → dbfda4375ae7387a356d846cb53e7bdd7e4931c5.
- Extra focused `$review-impl` delta certification at dbfda4375ae7387a356d846cb53e7bdd7e4931c5: status clean (delta comment/string-only; corrected CR citations verified against the comp rules; discriminating suite 8 passed / 0 failed at the head).

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where tapped, countered, or damaged permanents could incorrectly affect tracked-set results.
  * Corrected “put onto the battlefield” and similar candidate detection after chained or nested effects.
  * Improved handling of effects that move objects between zones, including synchronous and mass-movement effects.
  * Fixed a case where previously existing lands could be incorrectly treated as newly entering the battlefield.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->