### PR TITLE
Fix Divine Gambit and Metamorphose hand-put prompts

### DIFF
--- a/crates/engine/src/game/effects/change_zone.rs
+++ b/crates/engine/src/game/effects/change_zone.rs
@@ -665,7 +665,7 @@ pub fn resolve(
             });
     }
     let filter_controller =
-        crate::game::effects::controller_for_relative_filter(ability, target_filter);
+        crate::game::effects::controller_for_relative_filter(state, ability, target_filter);
     let track_exiled_by_source =
         crate::game::exile_links::should_track_exiled_by_source(state, ability.source_id, ability);
 
@@ -1810,7 +1810,7 @@ pub fn resolve_all(
     let player_scope = change_zone_all_player_scope(state, ability, &target_filter);
 
     let filter_controller =
-        crate::game::effects::controller_for_relative_filter(ability, &target_filter);
+        crate::game::effects::controller_for_relative_filter(state, ability, &target_filter);
     let target_filter = owner_scoped_nonbattlefield_mass_filter(target_filter, &origin_zones);
 
     // Use a permissive default filter if the effect's target is None

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -8081,9 +8081,24 @@ pub(crate) fn ability_uses_relative_controller_scoped(ability: &ResolvedAbility)
 }
 
 pub(crate) fn controller_for_relative_filter(
+    state: &GameState,
     ability: &ResolvedAbility,
     target_filter: &TargetFilter,
 ) -> PlayerId {
+    // CR 608.2c + CR 608.2d: a typed private-zone choice scoped to the
+    // parent target's controller belongs to that snapshotted player, even
+    // though the new object itself is chosen at resolution (Metamorphose).
+    // This is distinct from an ordinary Resolution-timed "you" filter below.
+    if target_filter_controller_scope(target_filter) == Some(ControllerRef::ParentTargetController)
+    {
+        if let Some(player) = crate::game::targeting::resolve_effect_player_ref(
+            state,
+            ability,
+            &TargetFilter::ParentTargetController,
+        ) {
+            return player;
+        }
+    }
     // CR 503.1a + CR 608.2d (issue #1535): a filter scoped to the per-iteration
     // scoped player ("that player ... from their hand" under "each player's
     // upkeep") resolves to that scoped player, not the ability's controller.
@@ -8290,6 +8305,22 @@ pub(crate) fn optional_prompt_player(state: &GameState, ability: &ResolvedAbilit
         }
     }
     if let Effect::Sacrifice { target, .. } = &ability.effect {
+        if target_filter_controller_scope(target) == Some(ControllerRef::ParentTargetController) {
+            if let Some(player) = crate::game::targeting::resolve_effect_player_ref(
+                state,
+                ability,
+                &TargetFilter::ParentTargetController,
+            ) {
+                return player;
+            }
+        }
+    }
+    // CR 608.2d: "That player/opponent may put a permanent card from their
+    // hand onto the battlefield" is a subject-anchored ChangeZone choice.
+    // The candidate filter names the earlier target's controller, so route
+    // the optional prompt through the same LKI-aware player resolver before
+    // opening the subsequent EffectZoneChoice (Metamorphose, Divine Gambit).
+    if let Effect::ChangeZone { target, .. } = &ability.effect {
         if target_filter_controller_scope(target) == Some(ControllerRef::ParentTargetController) {
             if let Some(player) = crate::game::targeting::resolve_effect_player_ref(
                 state,

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -7039,15 +7039,18 @@ pub(crate) fn effect_refs_parent_target(effect: &Effect) -> bool {
         .any(|filter| filter_refs_parent_target(filter))
 }
 
-/// Whether an effect needs the parent object itself, rather than only the
-/// parent object's controller/owner metadata. Used when deciding whether a
-/// resolution-time private-zone choice owns a fresh object-selection slot.
+/// CR 608.2c + CR 608.2h: Whether a later instruction needs the parent object
+/// itself, rather than only its move-time controller/owner metadata. Used when
+/// deciding whether a resolution-time private-zone choice owns a fresh
+/// object-selection slot.
 fn effect_requires_parent_target_object(effect: &Effect) -> bool {
     effect_parent_ref_slots(effect)
         .iter()
         .any(|filter| filter_requires_parent_target_object(filter))
 }
 
+/// CR 608.2c + CR 608.2h: Recursively identify the filter forms that require
+/// the parent's object referent rather than its last-known identity metadata.
 fn filter_requires_parent_target_object(filter: &TargetFilter) -> bool {
     match filter {
         TargetFilter::ParentTarget | TargetFilter::ParentTargetSlot { .. } => true,
@@ -7068,13 +7071,16 @@ fn filter_requires_parent_target_object(filter: &TargetFilter) -> bool {
     }
 }
 
-/// Whether an effect reads only identity metadata from the parent object.
+/// CR 608.2c + CR 608.2h: Whether a later instruction reads only controller or
+/// owner metadata from the parent object.
 fn effect_refs_parent_target_metadata(effect: &Effect) -> bool {
     effect_parent_ref_slots(effect)
         .iter()
         .any(|filter| filter_refs_parent_target_metadata(filter))
 }
 
+/// CR 608.2c + CR 608.2h: Recursively identify metadata-only parent references
+/// that remain resolvable from the move-time LKI snapshot.
 fn filter_refs_parent_target_metadata(filter: &TargetFilter) -> bool {
     match filter {
         TargetFilter::ParentTargetController | TargetFilter::ParentTargetOwner => true,
@@ -12954,6 +12960,9 @@ fn resolve_chain_body(
         vec![]
     };
     let effect_events = &events[events_before..];
+    // CR 608.2c + CR 608.2h: a later instruction may read a public-to-hidden
+    // move's last-known controller/owner metadata, without treating the hidden
+    // object itself as an available parent referent.
     let effect_context_object =
         parent_referent_context_from_events(state, effect_events).or_else(|| {
             ability

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -2213,6 +2213,30 @@ fn moved_object_context_from_events(events: &[GameEvent]) -> Option<CostPaidObje
     moved.next().is_none().then_some(first)
 }
 
+/// CR 608.2h: retain only controller/owner metadata for one object moved from
+/// a public zone to the hidden Library. This is deliberately separate from
+/// `moved_object_context_from_events`: it must not make the hidden object a
+/// general `ParentTarget` referent, but later "that player's" instructions may
+/// still identify the player from the move-time LKI snapshot.
+fn library_move_metadata_context_from_events(
+    events: &[GameEvent],
+) -> Option<CostPaidObjectSnapshot> {
+    let mut moved = events.iter().filter_map(|event| match event {
+        GameEvent::ZoneChanged {
+            object_id,
+            from: Some(from_zone),
+            to: Zone::Library,
+            record,
+        } if is_public_zone(*from_zone) => Some(CostPaidObjectSnapshot {
+            object_id: *object_id,
+            lki: lki_snapshot_from_zone_change_record(record),
+        }),
+        _ => None,
+    });
+    let first = moved.next()?;
+    moved.next().is_none().then_some(first)
+}
+
 /// CR 707.10 + CR 608.2c: A `CopySpell` that puts a copy onto the stack
 /// introduces a singular object a chained `ParentTarget` consumer (Isochron
 /// Scepter's free cast) binds to.
@@ -3132,7 +3156,7 @@ fn has_resolution_owned_zone_choice(sub: &ResolvedAbility) -> bool {
     let selection_zones = origin.map_or_else(|| target.extract_zones(), |zone| vec![zone]);
     !selection_zones.is_empty()
         && !target.is_context_ref()
-        && !effect_refs_parent_target(&sub.effect)
+        && !effect_requires_parent_target_object(&sub.effect)
 }
 
 /// Whether a child owns an object-selection slot independent of its parent's
@@ -3140,13 +3164,13 @@ fn has_resolution_owned_zone_choice(sub: &ResolvedAbility) -> bool {
 /// referent even when their effect is a resolution-time typed zone choice.
 fn sub_has_independent_object_target_slot(sub: &ResolvedAbility) -> bool {
     (crate::game::triggers::extract_target_filter_from_effect(&sub.effect).is_some()
-        && !effect_refs_parent_target(&sub.effect)
+        && !effect_requires_parent_target_object(&sub.effect)
         && !sub_ability_target_belongs_to_reflexive_context(sub))
         || (sub
             .effect
             .target_filter()
             .is_some_and(TargetFilter::references_exiled_by_source)
-            && !effect_refs_parent_target(&sub.effect))
+            && !effect_requires_parent_target_object(&sub.effect))
         || (has_resolution_owned_zone_choice(sub)
             && !sub_ability_target_belongs_to_reflexive_context(sub))
 }
@@ -7013,6 +7037,61 @@ pub(crate) fn effect_refs_parent_target(effect: &Effect) -> bool {
     effect_parent_ref_slots(effect)
         .iter()
         .any(|filter| filter_refs_parent_target(filter))
+}
+
+/// Whether an effect needs the parent object itself, rather than only the
+/// parent object's controller/owner metadata. Used when deciding whether a
+/// resolution-time private-zone choice owns a fresh object-selection slot.
+fn effect_requires_parent_target_object(effect: &Effect) -> bool {
+    effect_parent_ref_slots(effect)
+        .iter()
+        .any(|filter| filter_requires_parent_target_object(filter))
+}
+
+fn filter_requires_parent_target_object(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::ParentTarget | TargetFilter::ParentTargetSlot { .. } => true,
+        TargetFilter::Typed(typed) => typed.properties.iter().any(|property| {
+            matches!(
+                property,
+                FilterProp::DistinctFrom { reference }
+                    if filter_requires_parent_target_object(reference)
+            )
+        }),
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().any(filter_requires_parent_target_object)
+        }
+        TargetFilter::Not { filter } | TargetFilter::TrackedSetFiltered { filter, .. } => {
+            filter_requires_parent_target_object(filter)
+        }
+        _ => false,
+    }
+}
+
+/// Whether an effect reads only identity metadata from the parent object.
+fn effect_refs_parent_target_metadata(effect: &Effect) -> bool {
+    effect_parent_ref_slots(effect)
+        .iter()
+        .any(|filter| filter_refs_parent_target_metadata(filter))
+}
+
+fn filter_refs_parent_target_metadata(filter: &TargetFilter) -> bool {
+    match filter {
+        TargetFilter::ParentTargetController | TargetFilter::ParentTargetOwner => true,
+        TargetFilter::Typed(typed) => {
+            matches!(
+                typed.controller,
+                Some(ControllerRef::ParentTargetController)
+            )
+        }
+        TargetFilter::Or { filters } | TargetFilter::And { filters } => {
+            filters.iter().any(filter_refs_parent_target_metadata)
+        }
+        TargetFilter::Not { filter } | TargetFilter::TrackedSetFiltered { filter, .. } => {
+            filter_refs_parent_target_metadata(filter)
+        }
+        _ => false,
+    }
 }
 
 /// CR 115.6: True when the resolving ability head permits zero targets and the
@@ -12843,8 +12922,19 @@ fn resolve_chain_body(
     } else {
         vec![]
     };
+    let effect_events = &events[events_before..];
     let effect_context_object =
-        parent_referent_context_from_events(state, &events[events_before..]);
+        parent_referent_context_from_events(state, effect_events).or_else(|| {
+            ability
+                .sub_ability
+                .as_deref()
+                .is_some_and(|sub| {
+                    effect_refs_parent_target_metadata(&sub.effect)
+                        && !effect_requires_parent_target_object(&sub.effect)
+                })
+                .then(|| library_move_metadata_context_from_events(effect_events))
+                .flatten()
+        });
     let amassed_army_object = amassed_army_context_from_events(state, &events[events_before..]);
 
     // CR 608.2c: "[Mandatory action]. If you do, [rider]." — seed the

--- a/crates/engine/src/game/engine_resolution_choices.rs
+++ b/crates/engine/src/game/engine_resolution_choices.rs
@@ -137,7 +137,7 @@ fn legacy_mass_library_order_prompt_is_current(
     let player_scope = effects::change_zone::change_zone_all_player_scope(state, ability, target);
     let filter_context = super::filter::FilterContext::from_ability_with_controller(
         ability,
-        effects::controller_for_relative_filter(ability, target),
+        effects::controller_for_relative_filter(state, ability, target),
     );
     let member_is_current = |card_id: ObjectId, expected_owner| {
         state.objects.get(&card_id).is_some_and(|object| {

--- a/crates/engine/tests/integration/divine_gambit_metamorphose_prompt_8257.rs
+++ b/crates/engine/tests/integration/divine_gambit_metamorphose_prompt_8257.rs
@@ -8,9 +8,13 @@
 //! both cards in hand.
 
 use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
 use engine::types::phase::Phase;
 use engine::types::zones::Zone;
-use engine::types::ObjectId;
+use engine::types::{ObjectId, PlayerId};
+
+const P2: PlayerId = PlayerId(2);
 
 const DIVINE_GAMBIT: &str = "Exile target artifact, creature, or enchantment an opponent controls. That player may put a permanent card from their hand onto the battlefield.";
 const METAMORPHOSE: &str = "Put target permanent an opponent controls on top of its owner's library. That opponent may put an artifact, creature, enchantment, or land card from their hand onto the battlefield.";
@@ -91,4 +95,69 @@ fn metamorphose_decline_leaves_opponents_hand_untouched() {
     assert_eq!(outcome.zone_of(target), Zone::Library);
     assert_eq!(outcome.zone_of(creature), Zone::Hand);
     assert_eq!(outcome.zone_of(land), Zone::Hand);
+}
+
+#[test]
+fn metamorphose_prompts_targets_controller_not_owner_after_library_move() {
+    let mut scenario = GameScenario::new_n_player(3, 42);
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, "Metamorphose", false, METAMORPHOSE)
+        .id();
+    let target = {
+        let mut target = scenario.add_artifact_from_oracle(P1, "P1-Owned P2 Target", "");
+        target.controlled_by(P2);
+        target.id()
+    };
+    let p1_card = scenario.add_land_to_hand(P1, "P1 Forest").id();
+    let p2_card = scenario.add_land_to_hand(P2, "P2 Island").id();
+    let p2_other = scenario.add_creature_to_hand(P2, "P2 Bear", 2, 2).id();
+    let mut runner = scenario.build();
+
+    let mut cast = runner.cast(spell).target_object(target).commit();
+    while matches!(cast.state().waiting_for, WaitingFor::Priority { .. }) {
+        cast.act(GameAction::PassPriority)
+            .expect("priority pass must advance Metamorphose resolution");
+    }
+
+    match &cast.state().waiting_for {
+        WaitingFor::OptionalEffectChoice { player, .. } => assert_eq!(
+            *player, P2,
+            "the optional hand-put choice belongs to the target's controller"
+        ),
+        other => panic!("expected Metamorphose optional choice for P2, got {other:?}"),
+    }
+    cast.act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("P2 must be able to accept Metamorphose's optional effect");
+
+    match &cast.state().waiting_for {
+        WaitingFor::EffectZoneChoice { player, cards, .. } => {
+            assert_eq!(
+                *player, P2,
+                "the hand-card prompt must remain assigned to P2"
+            );
+            assert!(
+                cards.contains(&p2_card),
+                "P2's hand card must be selectable"
+            );
+            assert!(
+                cards.contains(&p2_other),
+                "P2's second permanent forces the interactive choice path"
+            );
+            assert!(
+                !cards.contains(&p1_card),
+                "the target owner's hand must not replace its controller's hand"
+            );
+        }
+        other => panic!("expected Metamorphose hand choice for P2, got {other:?}"),
+    }
+    cast.act(GameAction::SelectCards {
+        cards: vec![p2_card],
+    })
+    .expect("P2 must be able to put the selected permanent onto the battlefield");
+
+    assert_eq!(cast.state().objects[&target].zone, Zone::Library);
+    assert_eq!(cast.state().objects[&p2_card].zone, Zone::Battlefield);
+    assert_eq!(cast.state().objects[&p2_other].zone, Zone::Hand);
+    assert_eq!(cast.state().objects[&p1_card].zone, Zone::Hand);
 }

--- a/crates/engine/tests/integration/divine_gambit_metamorphose_prompt_8257.rs
+++ b/crates/engine/tests/integration/divine_gambit_metamorphose_prompt_8257.rs
@@ -1,0 +1,94 @@
+//! Issue #8257 — resolution-time private-zone choices controlled by the
+//! controller of an earlier target must not inherit that target object.
+//!
+//! Divine Gambit exiles the target, while Metamorphose moves it to the hidden
+//! Library. In both cases the opponent, not the caster, owns the optional hand
+//! choice. These tests drive the real cast/resolve pipeline with two eligible
+//! cards so accepting must surface an `EffectZoneChoice`; declining must leave
+//! both cards in hand.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+use engine::types::ObjectId;
+
+const DIVINE_GAMBIT: &str = "Exile target artifact, creature, or enchantment an opponent controls. That player may put a permanent card from their hand onto the battlefield.";
+const METAMORPHOSE: &str = "Put target permanent an opponent controls on top of its owner's library. That opponent may put an artifact, creature, enchantment, or land card from their hand onto the battlefield.";
+
+fn setup(oracle: &str, name: &str) -> (GameRunner, ObjectId, ObjectId, ObjectId, ObjectId) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let spell = scenario
+        .add_spell_to_hand_from_oracle(P0, name, false, oracle)
+        .id();
+    let target = scenario
+        .add_artifact_from_oracle(P1, "Opponent Target", "")
+        .id();
+    let creature = scenario
+        .add_creature_to_hand(P1, "Opponent Bear", 2, 2)
+        .id();
+    let land = scenario.add_land_to_hand(P1, "Opponent Forest").id();
+    (scenario.build(), spell, target, creature, land)
+}
+
+#[test]
+fn divine_gambit_accept_prompts_opponent_and_puts_chosen_permanent() {
+    let (mut runner, spell, target, creature, land) = setup(DIVINE_GAMBIT, "Divine Gambit");
+
+    let outcome = runner
+        .cast(spell)
+        .target_objects(&[target])
+        .accept_optional()
+        .effect_zone(&[creature])
+        .resolve();
+
+    assert_eq!(outcome.zone_of(target), Zone::Exile);
+    assert_eq!(outcome.zone_of(creature), Zone::Battlefield);
+    assert_eq!(outcome.zone_of(land), Zone::Hand);
+}
+
+#[test]
+fn divine_gambit_decline_leaves_opponents_hand_untouched() {
+    let (mut runner, spell, target, creature, land) = setup(DIVINE_GAMBIT, "Divine Gambit");
+
+    let outcome = runner
+        .cast(spell)
+        .target_objects(&[target])
+        .decline_optional()
+        .resolve();
+
+    assert_eq!(outcome.zone_of(target), Zone::Exile);
+    assert_eq!(outcome.zone_of(creature), Zone::Hand);
+    assert_eq!(outcome.zone_of(land), Zone::Hand);
+}
+
+#[test]
+fn metamorphose_accept_prompts_opponent_after_hidden_library_move() {
+    let (mut runner, spell, target, creature, land) = setup(METAMORPHOSE, "Metamorphose");
+
+    let outcome = runner
+        .cast(spell)
+        .target_objects(&[target])
+        .accept_optional()
+        .effect_zone(&[land])
+        .resolve();
+
+    assert_eq!(outcome.zone_of(target), Zone::Library);
+    assert_eq!(outcome.zone_of(land), Zone::Battlefield);
+    assert_eq!(outcome.zone_of(creature), Zone::Hand);
+}
+
+#[test]
+fn metamorphose_decline_leaves_opponents_hand_untouched() {
+    let (mut runner, spell, target, creature, land) = setup(METAMORPHOSE, "Metamorphose");
+
+    let outcome = runner
+        .cast(spell)
+        .target_objects(&[target])
+        .decline_optional()
+        .resolve();
+
+    assert_eq!(outcome.zone_of(target), Zone::Library);
+    assert_eq!(outcome.zone_of(creature), Zone::Hand);
+    assert_eq!(outcome.zone_of(land), Zone::Hand);
+}

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -213,6 +213,7 @@ mod diluvian_primordial_6754;
 mod dina_noff_turn5_loader;
 mod disjunctive_state_change_head_coverage_honesty;
 mod disorder_in_the_court_5955;
+mod divine_gambit_metamorphose_prompt_8257;
 mod divine_visitation_token_substitution;
 mod doom_s_time_platform_exile_with_time_counters;
 mod doomsday;


### PR DESCRIPTION
## Summary

Closes #8257. Fixes Divine Gambit and Metamorphose so their optional resolution-time hand choice is offered to the earlier target's controller, while the selected hand permanent remains a fresh choice rather than inheriting the earlier object target. Metamorphose retains only move-time controller/owner metadata across its public-to-hidden Library move.

## Files changed

- `crates/engine/src/game/effects/mod.rs`
- `crates/engine/src/game/effects/change_zone.rs`
- `crates/engine/src/game/engine_resolution_choices.rs`
- `crates/engine/tests/integration/divine_gambit_metamorphose_prompt_8257.rs`
- `crates/engine/tests/integration/main.rs`

## Track

Developer

## LLM

Model: GPT-5 (Codex; canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

- CR 115.10 — nontargeted objects and players are chosen as the spell or ability resolves.
- CR 608.2c — instructions resolve in printed order and later instructions may refer to earlier results.
- CR 608.2d — non-casting choices are announced while applying the effect.
- CR 608.2h — controller/owner information for an object moved from a public zone to a hidden zone uses move-time last known information.

All four references were verified against the repository's fetched 2026-08-19 Comprehensive Rules text, including their adjacent rules.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo test -p phase-engine --test integration divine_gambit_metamorphose_prompt_8257` — 5 passed, 0 failed.
- `cargo test -p phase-engine reflexive_typed_zone_change_resolves_inherited_parent_object --lib` — 1 passed, 0 failed.
- `cargo test -p phase-engine worldsouls_rage_object_target_and_x_one_allow_a_land_subset --lib` — 1 passed, 0 failed.
- `cargo clippy -p phase-engine --lib -- -D warnings` — clean.
- `cargo fmt --all --check` and `git diff --check` — clean.
- Test-first discrimination: before the controller-routing correction, the three-player Metamorphose regression observed both `OptionalEffectChoice` and `EffectZoneChoice` addressed to P0 instead of P2. The corrected production path makes the same test pass while proving P1's owner-only hand remains excluded.
- `git range-diff` confirms the two implementation commits are patch-identical after rebasing from prerequisite PR #8259 onto current upstream `main`.

## Gate A

Gate A PASS head=65e885b9d9b36251eded55bb9c05a0c43fbd9efa base=ed86c9a6dc902f5117489d8476193c621f4c44ea

## Anchored on

- `crates/engine/src/game/effects/mod.rs:8307` — the existing `Sacrifice` optional-prompt branch resolves `ParentTargetController` through the same LKI-aware `resolve_effect_player_ref` authority.
- `crates/engine/src/game/effects/mod.rs:8358` — the existing `SearchLibrary` subject-anchored optional branch uses that same player-resolution seam after an earlier target has moved.
- `crates/engine/src/game/effects/mod.rs:2175` — `moved_object_context_from_events` is the existing move-event/LKI snapshot authority; the new Library helper deliberately narrows it to metadata-only eligibility.

## Final review-impl

Final review-impl PASS head=65e885b9d9b36251eded55bb9c05a0c43fbd9efa

A fresh full-diff review against `.claude/skills/review-impl/SKILL.md` found no defects: the change is at the shared resolution-choice and parent-context authorities, reuses the typed `ControllerRef` and central LKI-aware player resolver, adds no serialized surface or parser dispatch, and covers accept, decline, two-player, and discriminating three-player owner/controller separation through the production cast/resolve pipeline. The previous maintainer finding is resolved by asserting both prompt recipients, candidate membership, owner exclusion, selected-card movement, and retention of the unselected P2 card.

## Claimed parse impact

None. No parser code or card AST shape changes.

## Scope Expansion

None. The prerequisite Broken Bond fix is now on upstream `main`; this rebased PR contains only the controller/owner metadata behavior and issue #8257 regressions.

## Validation Failures

None.

## CI Failures

None. Current-head GitHub CI is expected to restart after this rebase.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed optional hand-to-battlefield choices for Divine Gambit and Metamorphose so prompts are assigned to the target’s current controller.
  - Corrected multiplayer scenarios where prompts could be sent to the previous object owner after a hidden Library move.
  - Ensured accepting a choice moves the selected card to the battlefield, while declining leaves eligible cards in hand.
  - Improved handling of controller-based choices when hidden card movements occur during resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->