### PR TITLE
fix(ai): refresh the file a symlinked baseline points at, not the link

### DIFF
--- a/crates/phase-ai/src/bin/ai_gate.rs
+++ b/crates/phase-ai/src/bin/ai_gate.rs
@@ -82,6 +82,12 @@ fn main() {
     };
 
     let mut options = SuiteOptions::new(args.difficulty, args.games, args.seed);
+    // `--baseline` names an entry, not necessarily a file. Resolve it to the file it designates
+    // BEFORE anything is derived from it, because two things downstream have to agree on that
+    // one answer: the staging sibling and the promotion target.
+    let destination = args
+        .refresh_baseline
+        .then(|| resolve_destination(&args.baseline));
     // On a refresh, the suite writes to a staging file BESIDE the baseline rather than to
     // `--current-output`, and the baseline is replaced by renaming that file only after every
     // guard has passed. The alias check above already refuses the one path that reached this
@@ -94,7 +100,7 @@ fn main() {
     // `--current-output` is therefore unused on the refresh path — the refreshed baseline IS
     // the run's report. No workflow passes `--refresh-baseline`, so nothing in CI depends on
     // the old behaviour.
-    let staging = args.refresh_baseline.then(|| staging_path(&args.baseline));
+    let staging = destination.as_deref().map(staging_path);
     // RESERVE the staging path before the suite can write a byte to it.
     //
     // Third route to the same destruction, and the only one no argument check could ever catch:
@@ -220,6 +226,8 @@ fn main() {
         // by checking failures first, because a run that is merely gameless — a
         // `--suite-filter` matching nothing — has no failing matchups to report.
         let staging = staging.expect("staging path is set whenever refresh_baseline is");
+        let destination =
+            destination.expect("the destination is resolved whenever refresh_baseline is");
         // Every exit below leaves the staging file behind otherwise, and a stale
         // `*.staging.json` next to a baseline is exactly the kind of artefact someone later
         // mistakes for a real one.
@@ -270,15 +278,12 @@ fn main() {
         // The run is accepted: promote the staging file. `rename` replaces the baseline in one
         // step, so a reader never observes a half-written baseline and a failure here leaves the
         // previous one intact.
-        if let Err(err) = std::fs::rename(&staging, &args.baseline) {
+        if let Err(err) = std::fs::rename(&staging, &destination) {
             let _ = std::fs::remove_file(&staging);
-            eprintln!(
-                "failed to write baseline {}: {err}",
-                args.baseline.display()
-            );
+            eprintln!("failed to write baseline {}: {err}", destination.display());
             std::process::exit(1);
         }
-        eprintln!("baseline refreshed at {}", args.baseline.display());
+        eprintln!("baseline refreshed at {}", destination.display());
         return;
     }
 
@@ -468,6 +473,47 @@ fn same_inode(_a: &Path, _b: &Path) -> Option<bool> {
     None
 }
 
+/// The file `--baseline` designates, following symlinks the way the write it replaces did.
+///
+/// A refresh used to open the baseline with `File::create`, which follows a symlink chain and
+/// refreshes the file at its end. Staging + `rename` does not: `rename` acts on the entry, so
+/// promoting onto the supplied spelling would replace the link with a regular file and leave its
+/// target stale. Resolving first restores the old destination and is also what keeps the
+/// promotion atomic — the staging file is a sibling of THIS path, and `rename` is only atomic
+/// within one filesystem, so a link that crosses a mount would otherwise stage on one device and
+/// rename onto another (`EXDEV`).
+///
+/// Not `canonicalize`, on three counts: it requires every component to exist, so a dangling link
+/// and a first-ever refresh both fail where `File::create` succeeded; it rewrites a relative path
+/// the caller typed into an absolute one, which then appears in every message; and on Windows it
+/// returns a `\\?\` UNC path. Reading only the links that are actually there leaves a plain path
+/// exactly as supplied.
+///
+/// Hard links are deliberately NOT followed — a hard link has no target to follow, it IS the
+/// file. `rename` breaks the link rather than truncating the shared inode, which is the less
+/// destructive of the two.
+///
+/// The budget bounds a symlink cycle, which would otherwise spin here forever. Exhausting it
+/// leaves a still-unresolved path, and nothing acts on it: the kernel refuses the same chain, so
+/// `load_report` below fails with `FilesystemLoop` — not `NotFound` — and the run exits before
+/// the promotion.
+fn resolve_destination(path: &Path) -> PathBuf {
+    let mut current = path.to_path_buf();
+    // Linux's own `MAXSYMLINKS`; a chain this deep is already refused by every open() on it.
+    for _ in 0..40 {
+        // `Err` is the ordinary exit: not a symlink, or not there at all.
+        let Ok(target) = std::fs::read_link(&current) else {
+            return current;
+        };
+        current = match current.parent() {
+            // A link's target is relative to the directory the link sits in, not to the cwd.
+            Some(parent) if target.is_relative() => parent.join(target),
+            _ => target,
+        };
+    }
+    current
+}
+
 /// Where a refresh run stages its report before it earns the right to be the baseline.
 ///
 /// Beside the baseline, so the later `rename` is a same-filesystem atomic replace.
@@ -493,6 +539,46 @@ fn print_usage() {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// The sibling property has to hold of the RESOLVED destination, not of the spelling the
+    /// caller typed. `rename` is only atomic within one filesystem, so a staging file left beside
+    /// a link whose target lives on another mount would fail with `EXDEV`; measured directly,
+    /// tmpfs staging renamed onto a btrfs target returns `Invalid cross-device link (os error 18)`.
+    /// A cross-filesystem fixture is not constructible in a portable test, so the property is
+    /// pinned here, at the derivation.
+    #[test]
+    fn the_staging_file_is_a_sibling_of_the_resolved_destination() {
+        let dir = std::env::temp_dir().join(format!("phase-resolve-dest-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("real")).expect("scratch dir");
+        let target = dir.join("real/baseline.json");
+        std::fs::write(&target, "{}").expect("write");
+        #[cfg(unix)]
+        {
+            let link = dir.join("link.json");
+            std::os::unix::fs::symlink(&target, &link).expect("symlink");
+            assert_eq!(
+                resolve_destination(&link),
+                target,
+                "the link must resolve to its target"
+            );
+            assert_eq!(
+                staging_path(&resolve_destination(&link)).parent(),
+                target.parent(),
+                "staging must sit beside the resolved destination, not beside the link"
+            );
+            // PREMISE: the two spellings really do have different parents, so the assertion above
+            // is about resolution and not about a trivially equal comparison.
+            assert_ne!(link.parent(), target.parent());
+        }
+        // Control: a path that is not a link comes back exactly as supplied — a relative spelling
+        // stays relative, which is what keeps `baseline refreshed at ...` printing what the caller
+        // typed (and, on Windows, keeps a `\\?\` prefix out of it).
+        let plain = Path::new(DEFAULT_BASELINE);
+        assert_eq!(resolve_destination(plain), plain);
+        assert_eq!(resolve_destination(&target), target);
+        std::fs::remove_dir_all(&dir).ok();
+    }
 
     /// The staging file must be a SIBLING of the baseline. `rename` is only atomic within one
     /// filesystem, so a staging path that drifted to `/tmp` (or anywhere else the baseline is

--- a/crates/phase-ai/tests/refresh_baseline_cli.rs
+++ b/crates/phase-ai/tests/refresh_baseline_cli.rs
@@ -746,3 +746,128 @@ fn distinct_paths_are_not_treated_as_aliases() {
     );
     std::fs::remove_dir_all(&dir).ok();
 }
+
+/// A symlinked baseline names a file somewhere else, and a refresh must update THAT file.
+///
+/// The pre-staging code opened the baseline with `File::create`, which follows the link and
+/// refreshes its target. Staging + `rename` does not: `rename` acts on the entry, so promoting
+/// onto the supplied spelling replaces the link with a regular file and leaves the target on its
+/// old bytes. Measured on the binary before the fix, over all four arms: exit 0,
+/// "baseline refreshed at <link>", the link no longer a link, and the target byte-identical.
+///
+/// The arms are the ends of the class, not a sample. An absolute and a relative link target
+/// separate a resolver that joins the link's own directory from one that does not; a dangling link
+/// is the first-refresh-through-a-link case, where the target has to be CREATED, which is what
+/// `File::create` did; and a two-hop chain separates a resolver that reads one link from one that
+/// follows to the end. A hard-linked baseline is deliberately absent — a hard link has no target,
+/// and `rename` breaking it instead of truncating the shared inode is the intended behaviour.
+///
+/// The target sits in a SUBDIRECTORY of the link so that "resolved" and "supplied" differ by more
+/// than a file name: a staging file derived from the wrong one lands in the wrong directory.
+///
+/// `#[cfg(unix)]` because creating a symlink on Windows needs a privilege the test process is not
+/// guaranteed to hold; this repository's CI is Linux (`ci.yml`, every job `runs-on: ubuntu-latest`),
+/// so this arm does run there, and the existing
+/// `a_pre_existing_staging_alias_cannot_truncate_the_baseline` sets the precedent.
+#[cfg(unix)]
+#[test]
+fn a_symlinked_baseline_refreshes_its_target_and_stays_a_link() {
+    for kind in ["absolute", "relative", "dangling", "chain"] {
+        let dir = scratch(&format!("symlink-{kind}"));
+        let data_arg = empty_card_db(&dir);
+        std::fs::create_dir_all(dir.join("real")).expect("create target dir");
+        let target = dir.join("real/baseline.json");
+        let link = dir.join("link.json");
+
+        // A marked, VALID baseline at the target for every arm but `dangling`, whose whole point is
+        // that the target does not exist yet. An unparseable one would be refused before the suite
+        // ran, and the assertions would then pass on a run that never reached the promotion.
+        let marked = (kind != "dangling").then(|| {
+            let recorded = record_baseline(&dir, &data_arg, "real/baseline.json");
+            let mut old: serde_json::Value =
+                serde_json::from_str(&std::fs::read_to_string(&recorded).expect("read baseline"))
+                    .expect("baseline is JSON");
+            old["git_sha"] = serde_json::json!("OLD-BASELINE-MARKER");
+            let marked = serde_json::to_string(&old).expect("serialize baseline");
+            std::fs::write(&recorded, &marked).expect("write baseline");
+            marked
+        });
+
+        match kind {
+            // Relative because a link's target resolves against the link's own directory: a
+            // resolver that passes the raw target onward yields `real/baseline.json` relative to
+            // the process cwd, which is not this file.
+            "relative" => std::os::unix::fs::symlink("real/baseline.json", &link),
+            // Two hops. A resolver that reads one link stops at `mid.json` and renames over THAT.
+            "chain" => {
+                let mid = dir.join("mid.json");
+                std::os::unix::fs::symlink(&target, &mid).expect("symlink mid");
+                std::os::unix::fs::symlink(&mid, &link)
+            }
+            _ => std::os::unix::fs::symlink(&target, &link),
+        }
+        .expect("symlink");
+
+        // PREMISE: the link really resolves to the target the assertions read — and, on the
+        // `dangling` arm, really resolves to nothing yet. Without this the fixture could be inert.
+        assert_eq!(
+            std::fs::read_to_string(&link).ok(),
+            marked,
+            "{kind}: the link must resolve to the target under test"
+        );
+
+        let (code, stderr) = run(&[
+            "--refresh-baseline",
+            "--data-root",
+            &data_arg,
+            "--baseline",
+            &link.display().to_string(),
+            "--current-output",
+            &dir.join("current.json").display().to_string(),
+            "--suite-filter",
+            "red-mirror",
+            "--games",
+            "1",
+        ]);
+
+        // Reach guard. Every assertion below is also satisfied by a binary that refuses the run —
+        // which would leave the link a link and the target untouched — so the ACCEPTED path has to
+        // be the one that was taken.
+        assert_eq!(
+            code,
+            Some(0),
+            "{kind}: the refresh must be accepted; stderr:\n{stderr}"
+        );
+        // The defect, in the direction that made the refresh a no-op for the caller: the entry
+        // named on the command line was replaced by a regular file.
+        assert!(
+            std::fs::symlink_metadata(&link)
+                .expect("stat link")
+                .file_type()
+                .is_symlink(),
+            "{kind}: --baseline was a symlink and must still be one"
+        );
+        // The other half: the file the link designates carries THIS run's report. Asserted
+        // positively rather than as "changed", so it covers the `dangling` arm, where the target
+        // had to be created, and so a truncation cannot pass for an update.
+        let written = std::fs::read_to_string(&target).expect("read the link's target");
+        let report: serde_json::Value =
+            serde_json::from_str(&written).expect("the target must hold a report");
+        assert_eq!(report["games_per_matchup"], 1, "{kind}: {written}");
+        assert_eq!(report["results"][0]["matchup_id"], "red-mirror", "{kind}");
+        assert_ne!(
+            report["git_sha"],
+            serde_json::json!("OLD-BASELINE-MARKER"),
+            "{kind}: the target still holds the old baseline"
+        );
+        assert!(
+            !dir.join("real/baseline.json.staging.json").exists(),
+            "{kind}: staging survived beside the resolved destination"
+        );
+        assert!(
+            !dir.join("link.json.staging.json").exists(),
+            "{kind}: staging survived beside the supplied spelling"
+        );
+        std::fs::remove_dir_all(&dir).ok();
+    }
+}


### PR DESCRIPTION
## Summary

`--refresh-baseline` destroys a symlinked baseline instead of refreshing the file it points at. This
resolves the destination before staging, so the link survives and its target gets the new bytes.
This is the `[MED]` finding from #7029's review; the commit was pushed to that PR but the squash
landed the approved snapshot instead, so the regression is currently live on `main`.

## Files changed

- `crates/phase-ai/src/bin/ai_gate.rs` — `resolve_destination`, and staging now derives from the resolved path
- `crates/phase-ai/tests/refresh_baseline_cli.rs` — four-arm symlink regression test

## Track

Developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: /engine-implementer

## CR references

None. This is CI/tooling plumbing in `crates/phase-ai`, not game logic.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all --check` — exit 0
- `cargo clippy --locked -p phase-ai --all-targets -- -D warnings` — exit 0
- `cargo nextest run -p phase-ai` — 2286 passed, 0 failed, 19 skipped
- `bash scripts/check-parser-combinators.sh` — Gate G PASS, Gate A PASS

**A caveat on Gate A rather than a bare PASS:** the script resolves its own base and selected
`d6d28370c` (the fork's `main`), not this PR's base `0d3a15b3e`. So it ran over a range wider than
this delta, not a narrower one. It is also non-discriminating for this change either way — the diff
touches no parser code.

**How the test is known to discriminate.** Two named mutants, each leaving the other 12 tests green:
collapsing the resolver to `path.to_path_buf()` fails the `absolute` arm (`--baseline was a symlink
and must still be one`); cutting the walk to a single hop fails the `chain` arm (`the target still
holds the old baseline`). A reach guard (`assert_eq!(code, Some(0))`) precedes the state assertions,
so a binary that refuses outright cannot pass vacuously.

## Gate A

Gate A PASS head=32ddff1b637bc7a36340f2d2a033176b6fbf2930 base=d6d28370c09242182488cac72e16e5a84941885f

## Anchored on

- `crates/phase-ai/src/bin/ai_gate.rs:520` — `staging_path`, the existing authority for deriving the staging sibling; this change feeds it a resolved path rather than changing how it derives
- `crates/phase-ai/src/bin/ai_gate.rs:451` — `same_inode`, the established pattern in this file of asking the filesystem an identity question before writing, rather than comparing path spellings

## Final review-impl

Final review-impl PASS head=4ff54abed6e3b26098b68af5bac101dcb6003e8f

<!-- 32ddff1b6 is 4ff54abed cherry-picked onto 0d3a15b3e. 433a44524's tree is byte-identical to the
merge commit's, so the cherry-pick is a same-content replay: `git diff 4ff54abed 32ddff1b6` over the
two touched files is empty. -->

## Claimed parse impact

None.

## Scope Expansion

None.

## Validation Failures

None.

## CI Failures

None.

---

### Why this is a regression rather than a pre-existing gap

At the merge base `d6d28370c`, refresh was `write_report(&current, &args.baseline)` — `File::create`,
which follows a symlink and refreshes the target. The staging + `rename` design added in #7029
replaces the *link entry itself*. `rename` cannot cross filesystems (tmpfs to btrfs is `EXDEV`,
`Invalid cross-device link (os error 18)`), which is why staging must be a sibling of the resolved
destination rather than of the link.

`canonicalize` is not usable here: it returns `NotFound` on both shapes that matter — a dangling
link and a first-ever refresh — and on Windows rewrites the path with the `\\?\` extended-length
prefix. Hard links are deliberately not followed (`read_link` returns `InvalidInput`), so the
existing alias guard still fires on them.

`..` through a symlinked parent is left un-normalized on purpose: the un-normalized path was measured
to have the same `(dev, ino)` the kernel opens through the link, whereas lexical normalization would
select a different, wrong file.

### Disclosed, rather than left to be found

- A dangling link into a missing directory now `create_dir_all`s it. This makes the link case agree
  with the plain-file case, which the merge-base `write_report` already did.
- #7029 made refresh load and validate the baseline (before it, refresh never opened the file), and
  #7026 added `render_error_markdown` to that load-failure arm. Together, a refresh over a *corrupt*
  baseline now posts a markdown block on stdout. That reads as an improvement for the nightly, which
  posts stdout, but it is a combination neither PR exercises.
- The compare path — the only one CI invokes, since `--refresh-baseline` appears in no workflow — is
  unchanged. `bool::then` is lazy, so it makes no additional syscalls.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed baseline refreshes for symlinked baseline paths.
  - Refresh operations now update the symlink’s resolved target while preserving the symlink itself.
  - Added support for absolute, relative, dangling, and chained symlinks.
  - Prevented temporary staging files from remaining after a successful refresh.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->