### PR TITLE
feat(server): negotiate gzip WebSocket envelopes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1987,6 +1987,7 @@ dependencies = [
  "axum",
  "clap",
  "draft-core",
+ "flate2",
  "futures-util",
  "http",
  "lobby-broker",

--- a/client/src/adapter/server-draft-adapter.ts
+++ b/client/src/adapter/server-draft-adapter.ts
@@ -19,6 +19,7 @@ import {
   HandshakeError,
   openPhaseSocket,
   type PhaseSocket,
+  type PhaseSocketTransport,
 } from "../services/openPhaseSocket";
 import { isValidWebSocketUrl } from "../services/serverDetection";
 import type {
@@ -133,7 +134,7 @@ export class ServerDraftAdapter implements EngineAdapter {
   private _gameCode: string | null = null;
 
   // ── Infrastructure ─────────────────────────────────────────────────
-  private ws: WebSocket | null = null;
+  private ws: PhaseSocketTransport | null = null;
   private pendingResolve: ((result: SubmitResult) => void) | null = null;
   private pendingReject: ((error: Error) => void) | null = null;
   private nextManaPaymentPreviewRequestId = 1;

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -32,6 +32,7 @@ import {
   commitFullTerminalDelivery,
   type FullTerminalDelivery,
 } from "../services/fullTerminalResult";
+import type { WireFormat } from "../network/wireEnvelope";
 
 /** Deck data format matching server protocol. */
 export interface DeckData {
@@ -457,6 +458,8 @@ export interface ServerInfo {
   /** Public base URL the server advertises for `<code>@<host>` join strings
    * (a tunnel/proxy URL), or undefined when the server has none to share. */
   publicUrl?: string;
+  /** Optional binary JSON envelopes understood by this server. */
+  wireFormats?: WireFormat[];
 }
 
 /**

--- a/client/src/network/__tests__/wireEnvelope.test.ts
+++ b/client/src/network/__tests__/wireEnvelope.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import {
+  decodeJsonEnvelope,
+  encodeJsonEnvelope,
+  WIRE_MAX_DECODED_BYTES,
+} from "../wireEnvelope";
+
+describe("wire envelope decoded-size limit", () => {
+  it("rejects an oversized raw envelope", async () => {
+    const envelope = new Uint8Array(WIRE_MAX_DECODED_BYTES + 2);
+    envelope[0] = 0x00;
+
+    await expect(decodeJsonEnvelope(envelope)).rejects.toThrow(
+      "wire message exceeds decoded size limit",
+    );
+  });
+
+  it("rejects highly compressible gzip content above the limit", async () => {
+    const json = "x".repeat(WIRE_MAX_DECODED_BYTES + 1);
+    const envelope = await encodeJsonEnvelope(json);
+
+    expect(envelope[0]).toBe(0x01);
+    expect(envelope.byteLength).toBeLessThan(WIRE_MAX_DECODED_BYTES);
+    await expect(decodeJsonEnvelope(envelope)).rejects.toThrow(
+      "wire message exceeds decoded size limit",
+    );
+  });
+});

--- a/client/src/network/__tests__/wireEnvelope.test.ts
+++ b/client/src/network/__tests__/wireEnvelope.test.ts
@@ -7,16 +7,17 @@ import {
 } from "../wireEnvelope";
 
 describe("wire envelope decoded-size limit", () => {
-  it("rejects an oversized raw envelope", async () => {
+  it("rejects oversized or malformed raw content", async () => {
     const envelope = new Uint8Array(WIRE_MAX_DECODED_BYTES + 2);
     envelope[0] = 0x00;
 
     await expect(decodeJsonEnvelope(envelope)).rejects.toThrow(
       "wire message exceeds decoded size limit",
     );
+    await expect(decodeJsonEnvelope(new Uint8Array([0x00, 0xff]))).rejects.toThrow();
   });
 
-  it("rejects highly compressible gzip content above the limit", async () => {
+  it("rejects oversized or malformed gzip content", async () => {
     const json = "x".repeat(WIRE_MAX_DECODED_BYTES + 1);
     const envelope = await encodeJsonEnvelope(json);
 
@@ -25,5 +26,9 @@ describe("wire envelope decoded-size limit", () => {
     await expect(decodeJsonEnvelope(envelope)).rejects.toThrow(
       "wire message exceeds decoded size limit",
     );
+    const stream = new Blob([new Uint8Array([0xff])]).stream()
+      .pipeThrough(new CompressionStream("gzip"));
+    const compressed = new Uint8Array(await new Response(stream).arrayBuffer());
+    await expect(decodeJsonEnvelope(new Uint8Array([0x01, ...compressed]))).rejects.toThrow();
   });
 });

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -14,6 +14,7 @@ import type { InteractionSubmission, ViewerInteraction } from "../adapter/genera
 import type { SeatMutation, SeatView } from "../multiplayer/seatTypes";
 import type { P2PAuthorityStamp, P2PSessionKey } from "../services/p2pSession";
 import type { P2PTerminalResult } from "../services/p2pTerminalResult";
+import { decodeJsonEnvelope, encodeJsonEnvelope } from "./wireEnvelope";
 
 /**
  * The stable session identity is carried on reconnect so a resumed host can
@@ -397,39 +398,11 @@ export function validateMessage(raw: unknown): P2PMessage {
 // ~20-byte header would inflate sub-100-byte payloads. Ping/pong and small
 // control messages take the raw path; state broadcasts take the gzip path.
 
-const FORMAT_RAW = 0x00;
-const FORMAT_GZIP = 0x01;
-const COMPRESSION_THRESHOLD = 256;
-
 export async function encodeWireMessage(msg: P2PMessage): Promise<Uint8Array> {
-  const json = JSON.stringify(msg);
-  const jsonBytes = new TextEncoder().encode(json);
-  if (jsonBytes.length < COMPRESSION_THRESHOLD) {
-    const out = new Uint8Array(1 + jsonBytes.length);
-    out[0] = FORMAT_RAW;
-    out.set(jsonBytes, 1);
-    return out;
-  }
-  const stream = new Blob([jsonBytes]).stream().pipeThrough(new CompressionStream("gzip"));
-  const gzipped = new Uint8Array(await new Response(stream).arrayBuffer());
-  const out = new Uint8Array(1 + gzipped.length);
-  out[0] = FORMAT_GZIP;
-  out.set(gzipped, 1);
-  return out;
+  return encodeJsonEnvelope(JSON.stringify(msg));
 }
 
 export async function decodeWireMessage(bytes: Uint8Array): Promise<P2PMessage> {
-  if (bytes.length < 1) throw new Error("empty wire message");
-  const version = bytes[0];
-  const payload = bytes.subarray(1);
-  let json: string;
-  if (version === FORMAT_RAW) {
-    json = new TextDecoder().decode(payload);
-  } else if (version === FORMAT_GZIP) {
-    const stream = new Blob([payload]).stream().pipeThrough(new DecompressionStream("gzip"));
-    json = await new Response(stream).text();
-  } else {
-    throw new Error(`unknown wire format version: 0x${version.toString(16)}`);
-  }
+  const json = await decodeJsonEnvelope(bytes);
   return validateMessage(JSON.parse(json));
 }

--- a/client/src/network/wireEnvelope.ts
+++ b/client/src/network/wireEnvelope.ts
@@ -5,6 +5,7 @@
 
 // Keep this aligned with crates/phase-server/src/wire.rs.
 export const WIRE_COMPRESSION_THRESHOLD = 256;
+export const WIRE_MAX_DECODED_BYTES = 1024 * 1024;
 export type WireFormat = "GzipEnvelopeV1";
 
 const FORMAT_RAW = 0x00;
@@ -38,11 +39,35 @@ export async function decodeJsonEnvelope(bytes: Uint8Array): Promise<string> {
   const format = bytes[0];
   const payload = bytes.subarray(1);
   if (format === FORMAT_RAW) {
+    if (payload.length > WIRE_MAX_DECODED_BYTES) {
+      throw new Error("wire message exceeds decoded size limit");
+    }
     return new TextDecoder().decode(payload);
   }
   if (format === FORMAT_GZIP) {
     const stream = new Blob([payload]).stream().pipeThrough(new DecompressionStream("gzip"));
-    return new Response(stream).text();
+    const reader = stream.getReader();
+    const decoder = new TextDecoder();
+    let decodedBytes = 0;
+    let decoded = "";
+
+    try {
+      while (true) {
+        const { value, done } = await reader.read();
+        if (done) break;
+        decodedBytes += value.byteLength;
+        if (decodedBytes > WIRE_MAX_DECODED_BYTES) {
+          throw new Error("wire message exceeds decoded size limit");
+        }
+        decoded += decoder.decode(value, { stream: true });
+      }
+      return decoded + decoder.decode();
+    } catch (error) {
+      await reader.cancel(error).catch(() => undefined);
+      throw error;
+    } finally {
+      reader.releaseLock();
+    }
   }
   throw new Error(`unknown wire format version: 0x${format.toString(16)}`);
 }

--- a/client/src/network/wireEnvelope.ts
+++ b/client/src/network/wireEnvelope.ts
@@ -42,12 +42,12 @@ export async function decodeJsonEnvelope(bytes: Uint8Array): Promise<string> {
     if (payload.length > WIRE_MAX_DECODED_BYTES) {
       throw new Error("wire message exceeds decoded size limit");
     }
-    return new TextDecoder().decode(payload);
+    return new TextDecoder("utf-8", { fatal: true }).decode(payload);
   }
   if (format === FORMAT_GZIP) {
     const stream = new Blob([payload]).stream().pipeThrough(new DecompressionStream("gzip"));
     const reader = stream.getReader();
-    const decoder = new TextDecoder();
+    const decoder = new TextDecoder("utf-8", { fatal: true });
     let decodedBytes = 0;
     let decoded = "";
 

--- a/client/src/network/wireEnvelope.ts
+++ b/client/src/network/wireEnvelope.ts
@@ -1,0 +1,48 @@
+// Shared binary JSON envelope used by both WebRTC DataChannels and the
+// client/server WebSocket transport:
+//   [0x00][raw UTF-8 JSON]
+//   [0x01][gzip-compressed UTF-8 JSON]
+
+// Keep this aligned with crates/phase-server/src/wire.rs.
+export const WIRE_COMPRESSION_THRESHOLD = 256;
+export type WireFormat = "GzipEnvelopeV1";
+
+const FORMAT_RAW = 0x00;
+const FORMAT_GZIP = 0x01;
+
+export function supportsGzipEnvelope(): boolean {
+  return typeof CompressionStream !== "undefined"
+    && typeof DecompressionStream !== "undefined";
+}
+
+export async function encodeJsonEnvelope(json: string): Promise<Uint8Array> {
+  const jsonBytes = new TextEncoder().encode(json);
+  if (jsonBytes.length < WIRE_COMPRESSION_THRESHOLD) {
+    const out = new Uint8Array(1 + jsonBytes.length);
+    out[0] = FORMAT_RAW;
+    out.set(jsonBytes, 1);
+    return out;
+  }
+
+  const stream = new Blob([jsonBytes]).stream().pipeThrough(new CompressionStream("gzip"));
+  const gzipped = new Uint8Array(await new Response(stream).arrayBuffer());
+  const out = new Uint8Array(1 + gzipped.length);
+  out[0] = FORMAT_GZIP;
+  out.set(gzipped, 1);
+  return out;
+}
+
+export async function decodeJsonEnvelope(bytes: Uint8Array): Promise<string> {
+  if (bytes.length < 1) throw new Error("empty wire message");
+
+  const format = bytes[0];
+  const payload = bytes.subarray(1);
+  if (format === FORMAT_RAW) {
+    return new TextDecoder().decode(payload);
+  }
+  if (format === FORMAT_GZIP) {
+    const stream = new Blob([payload]).stream().pipeThrough(new DecompressionStream("gzip"));
+    return new Response(stream).text();
+  }
+  throw new Error(`unknown wire format version: 0x${format.toString(16)}`);
+}

--- a/client/src/services/__tests__/openPhaseSocket.test.ts
+++ b/client/src/services/__tests__/openPhaseSocket.test.ts
@@ -16,8 +16,9 @@ class MockWebSocket extends EventTarget {
   static OPEN = 1;
   static instances: MockWebSocket[] = [];
   readyState = MockWebSocket.OPEN;
+  binaryType: BinaryType = "blob";
   onopen: (() => void) | null = null;
-  onmessage: ((event: { data: string }) => void) | null = null;
+  onmessage: ((event: { data: unknown }) => void) | null = null;
   onerror: (() => void) | null = null;
   onclose: (() => void) | null = null;
   send = vi.fn();
@@ -29,7 +30,7 @@ class MockWebSocket extends EventTarget {
     super();
     MockWebSocket.instances.push(this);
   }
-  deliverMessage(data: string) {
+  deliverMessage(data: unknown) {
     this.onmessage?.({ data });
   }
   fireError() {
@@ -44,6 +45,7 @@ function helloFrame(
     protocol_version: number;
     mode: "Full" | "LobbyOnly";
     lobby_protocol_version: number;
+    wire_formats: string[];
   }> = {},
 ): string {
   return JSON.stringify({
@@ -84,6 +86,32 @@ describe("openPhaseSocket", () => {
     expect(ws.send).toHaveBeenCalledWith(
       expect.stringContaining('"type":"ClientHello"'),
     );
+  });
+
+  it("negotiates the gzip envelope and queues binary sends in order", async () => {
+    const promise = openPhaseSocket("ws://test");
+    const raw = MockWebSocket.instances[0];
+    raw.deliverMessage(helloFrame({ wire_formats: ["GzipEnvelopeV1"] }));
+
+    const socket = await promise;
+    expect(socket.serverInfo.wireFormats).toEqual(["GzipEnvelopeV1"]);
+    expect(raw.send).toHaveBeenCalledWith(
+      expect.stringContaining('"wire_formats":["GzipEnvelopeV1"]'),
+    );
+
+    socket.ws.send(JSON.stringify({ type: "Ping", data: { timestamp: 7 } }));
+    await vi.waitFor(() => {
+      expect(raw.send).toHaveBeenCalledWith(expect.any(Uint8Array));
+    });
+    const binary = raw.send.mock.calls.find(([value]) => value instanceof Uint8Array)?.[0];
+    expect(binary?.[0]).toBe(0x00);
+
+    const received = vi.fn();
+    socket.ws.onmessage = received;
+    const response = new TextEncoder().encode(JSON.stringify({ type: "Pong" }));
+    raw.deliverMessage(new Uint8Array([0x00, ...response]).buffer);
+    await vi.waitFor(() => expect(received).toHaveBeenCalledOnce());
+    expect(received.mock.calls[0][0].data).toBe('{"type":"Pong"}');
   });
 
   it("rejects with protocol_mismatch when versions diverge and closes the socket", async () => {

--- a/client/src/services/__tests__/openPhaseSocket.test.ts
+++ b/client/src/services/__tests__/openPhaseSocket.test.ts
@@ -106,12 +106,16 @@ describe("openPhaseSocket", () => {
     const binary = raw.send.mock.calls.find(([value]) => value instanceof Uint8Array)?.[0];
     expect(binary?.[0]).toBe(0x00);
 
-    const received = vi.fn();
+    const order: string[] = [];
+    const received = vi.fn((_event: MessageEvent<string>) => order.push("message"));
     socket.ws.onmessage = received;
+    socket.ws.addEventListener("close", () => order.push("close"));
     const response = new TextEncoder().encode(JSON.stringify({ type: "Pong" }));
     raw.deliverMessage(new Uint8Array([0x00, ...response]).buffer);
+    raw.close();
     await vi.waitFor(() => expect(received).toHaveBeenCalledOnce());
-    expect(received.mock.calls[0][0].data).toBe('{"type":"Pong"}');
+    expect(received).toHaveBeenCalledWith(expect.objectContaining({ data: '{"type":"Pong"}' }));
+    expect(order).toEqual(["message", "close"]);
   });
 
   it("reports a queued binary send failure before closing", async () => {

--- a/client/src/services/__tests__/openPhaseSocket.test.ts
+++ b/client/src/services/__tests__/openPhaseSocket.test.ts
@@ -114,6 +114,23 @@ describe("openPhaseSocket", () => {
     expect(received.mock.calls[0][0].data).toBe('{"type":"Pong"}');
   });
 
+  it("reports a queued binary send failure before closing", async () => {
+    const promise = openPhaseSocket("ws://test");
+    const raw = MockWebSocket.instances[0];
+    raw.deliverMessage(helloFrame({ wire_formats: ["GzipEnvelopeV1"] }));
+
+    const socket = await promise;
+    const onerror = vi.fn();
+    socket.ws.onerror = onerror;
+    raw.send.mockImplementationOnce(() => {
+      throw new Error("socket closed before queued send");
+    });
+    socket.ws.send('{"type":"Ping"}');
+
+    await vi.waitFor(() => expect(onerror).toHaveBeenCalledOnce());
+    expect(raw.close).toHaveBeenCalled();
+  });
+
   it("rejects with protocol_mismatch when versions diverge and closes the socket", async () => {
     const promise = openPhaseSocket("ws://test");
     const ws = MockWebSocket.instances[0];

--- a/client/src/services/gzipEnvelopeSocket.ts
+++ b/client/src/services/gzipEnvelopeSocket.ts
@@ -1,0 +1,113 @@
+import { decodeJsonEnvelope, encodeJsonEnvelope } from "../network/wireEnvelope";
+import type { PhaseSocketTransport } from "./openPhaseSocket";
+
+type MessageListener = (event: MessageEvent<string>) => void;
+
+/**
+ * Keeps the WebSocket-shaped API used by the adapters while serializing the
+ * asynchronous CompressionStream work. Both queues are FIFO so compression
+ * cannot reorder actions or authoritative state updates.
+ */
+export class GzipEnvelopeSocket implements PhaseSocketTransport {
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: MessageListener | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+
+  private readonly messageListeners = new Map<MessageListener, boolean>();
+  private sendQueue = Promise.resolve();
+  private receiveQueue = Promise.resolve();
+
+  constructor(private readonly socket: PhaseSocketTransport) {
+    if ("binaryType" in socket) {
+      (socket as PhaseSocketTransport & { binaryType: BinaryType }).binaryType = "arraybuffer";
+    }
+    socket.onopen = (event) => this.onopen?.(event);
+    socket.onerror = (event) => this.onerror?.(event);
+    socket.onclose = (event) => this.onclose?.(event);
+    socket.onmessage = (event) => {
+      this.receiveQueue = this.receiveQueue
+        .then(async () => this.decodeIncoming(event.data as unknown))
+        .then((json) => {
+          const decoded = new MessageEvent<string>("message", { data: json });
+          this.onmessage?.(decoded);
+          for (const [listener, once] of this.messageListeners) {
+            listener(decoded);
+            if (once) this.messageListeners.delete(listener);
+          }
+        })
+        .catch(() => {
+          // A malformed envelope is an untrusted wire frame. Drop it just as
+          // openPhaseSocket drops malformed JSON during the handshake.
+        });
+    };
+  }
+
+  get readyState(): number {
+    return this.socket.readyState;
+  }
+
+  send(data: string): void {
+    this.sendQueue = this.sendQueue
+      .then(async () => {
+        const encoded = await encodeJsonEnvelope(data);
+        (this.socket as unknown as { send(data: Uint8Array): void }).send(encoded);
+      })
+      .catch(() => this.socket.close());
+  }
+
+  close(): void {
+    this.socket.close();
+  }
+
+  addEventListener(
+    type: "close",
+    listener: (event: CloseEvent) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+  addEventListener(
+    type: "message",
+    listener: MessageListener,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+  addEventListener(
+    type: "close" | "message",
+    listener: ((event: CloseEvent) => void) | MessageListener,
+    options?: AddEventListenerOptions | boolean,
+  ): void {
+    if (type === "message") {
+      const once = typeof options === "object" && options.once === true;
+      this.messageListeners.set(listener as MessageListener, once);
+    } else {
+      this.socket.addEventListener("close", listener as (event: CloseEvent) => void, options);
+    }
+  }
+
+  removeEventListener(
+    type: "close",
+    listener: (event: CloseEvent) => void,
+  ): void;
+  removeEventListener(type: "message", listener: MessageListener): void;
+  removeEventListener(
+    type: "close" | "message",
+    listener: ((event: CloseEvent) => void) | MessageListener,
+  ): void {
+    if (type === "message") {
+      this.messageListeners.delete(listener as MessageListener);
+    } else {
+      this.socket.removeEventListener("close", listener as (event: CloseEvent) => void);
+    }
+  }
+
+  private async decodeIncoming(data: unknown): Promise<string> {
+    if (typeof data === "string") return data;
+    if (data instanceof Blob) {
+      return decodeJsonEnvelope(new Uint8Array(await data.arrayBuffer()));
+    }
+    if (ArrayBuffer.isView(data)) {
+      return decodeJsonEnvelope(new Uint8Array(data.buffer, data.byteOffset, data.byteLength));
+    }
+    if (data instanceof ArrayBuffer) return decodeJsonEnvelope(new Uint8Array(data));
+    throw new Error("unsupported WebSocket frame type");
+  }
+}

--- a/client/src/services/gzipEnvelopeSocket.ts
+++ b/client/src/services/gzipEnvelopeSocket.ts
@@ -3,11 +3,7 @@ import type { PhaseSocketTransport } from "./openPhaseSocket";
 
 type MessageListener = (event: MessageEvent<string>) => void;
 
-/**
- * Keeps the WebSocket-shaped API used by the adapters while serializing the
- * asynchronous CompressionStream work. Both queues are FIFO so compression
- * cannot reorder actions or authoritative state updates.
- */
+/** Serializes async envelope work without reordering socket events. */
 export class GzipEnvelopeSocket implements PhaseSocketTransport {
   onopen: ((event: Event) => void) | null = null;
   onmessage: MessageListener | null = null;
@@ -15,8 +11,10 @@ export class GzipEnvelopeSocket implements PhaseSocketTransport {
   onclose: ((event: CloseEvent) => void) | null = null;
 
   private readonly messageListeners = new Map<MessageListener, boolean>();
+  private readonly closeListeners = new Map<(event: CloseEvent) => void, boolean>();
   private sendQueue = Promise.resolve();
   private receiveQueue = Promise.resolve();
+  private closeQueued = false;
 
   constructor(private readonly socket: PhaseSocketTransport) {
     if ("binaryType" in socket) {
@@ -24,7 +22,17 @@ export class GzipEnvelopeSocket implements PhaseSocketTransport {
     }
     socket.onopen = (event) => this.onopen?.(event);
     socket.onerror = (event) => this.onerror?.(event);
-    socket.onclose = (event) => this.onclose?.(event);
+    socket.onclose = (event) => {
+      if (this.closeQueued) return;
+      this.closeQueued = true;
+      this.receiveQueue = this.receiveQueue.then(() => {
+        this.onclose?.(event);
+        for (const [listener, once] of this.closeListeners) {
+          listener(event);
+          if (once) this.closeListeners.delete(listener);
+        }
+      });
+    };
     socket.onmessage = (event) => {
       this.receiveQueue = this.receiveQueue
         .then(async () => this.decodeIncoming(event.data as unknown))
@@ -36,10 +44,7 @@ export class GzipEnvelopeSocket implements PhaseSocketTransport {
             if (once) this.messageListeners.delete(listener);
           }
         })
-        .catch(() => {
-          // A malformed envelope is an untrusted wire frame. Drop it just as
-          // openPhaseSocket drops malformed JSON during the handshake.
-        });
+        .catch(() => undefined);
     };
   }
 
@@ -82,7 +87,8 @@ export class GzipEnvelopeSocket implements PhaseSocketTransport {
       const once = typeof options === "object" && options.once === true;
       this.messageListeners.set(listener as MessageListener, once);
     } else {
-      this.socket.addEventListener("close", listener as (event: CloseEvent) => void, options);
+      const once = typeof options === "object" && options.once === true;
+      this.closeListeners.set(listener as (event: CloseEvent) => void, once);
     }
   }
 
@@ -98,7 +104,7 @@ export class GzipEnvelopeSocket implements PhaseSocketTransport {
     if (type === "message") {
       this.messageListeners.delete(listener as MessageListener);
     } else {
-      this.socket.removeEventListener("close", listener as (event: CloseEvent) => void);
+      this.closeListeners.delete(listener as (event: CloseEvent) => void);
     }
   }
 

--- a/client/src/services/gzipEnvelopeSocket.ts
+++ b/client/src/services/gzipEnvelopeSocket.ts
@@ -53,7 +53,10 @@ export class GzipEnvelopeSocket implements PhaseSocketTransport {
         const encoded = await encodeJsonEnvelope(data);
         (this.socket as unknown as { send(data: Uint8Array): void }).send(encoded);
       })
-      .catch(() => this.socket.close());
+      .catch(() => {
+        this.onerror?.(new Event("error"));
+        this.socket.close();
+      });
   }
 
   close(): void {

--- a/client/src/services/nativeEngineSocket.ts
+++ b/client/src/services/nativeEngineSocket.ts
@@ -6,6 +6,7 @@ type BridgeEvent =
   | { type: "error"; detail: string };
 
 type CloseListener = (event: CloseEvent) => void;
+type MessageListener = (event: MessageEvent<string>) => void;
 
 /**
  * WebSocket-shaped client for the shell-owned native-engine bridge.
@@ -30,6 +31,7 @@ export class NativeEngineSocket {
   onclose: ((event: CloseEvent) => void) | null = null;
 
   private readonly closeListeners = new Map<CloseListener, boolean>();
+  private readonly messageListeners = new Map<MessageListener, boolean>();
   private readonly pendingEvents: BridgeEvent[] = [];
   private bridgeId: number | null = null;
   private _readyState = NativeEngineSocket.CONNECTING;
@@ -49,15 +51,27 @@ export class NativeEngineSocket {
     type: "close",
     listener: CloseListener,
     options?: AddEventListenerOptions | boolean,
+  ): void;
+  addEventListener(
+    type: "message",
+    listener: MessageListener,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
+  addEventListener(
+    type: "close" | "message",
+    listener: CloseListener | MessageListener,
+    options?: AddEventListenerOptions | boolean,
   ): void {
-    if (type !== "close") return;
     const once = typeof options === "object" && options.once === true;
-    this.closeListeners.set(listener, once);
+    if (type === "close") this.closeListeners.set(listener as CloseListener, once);
+    else this.messageListeners.set(listener as MessageListener, once);
   }
 
-  removeEventListener(type: "close", listener: CloseListener): void {
-    if (type !== "close") return;
-    this.closeListeners.delete(listener);
+  removeEventListener(type: "close", listener: CloseListener): void;
+  removeEventListener(type: "message", listener: MessageListener): void;
+  removeEventListener(type: "close" | "message", listener: CloseListener | MessageListener): void {
+    if (type === "close") this.closeListeners.delete(listener as CloseListener);
+    else this.messageListeners.delete(listener as MessageListener);
   }
 
   send(text: string): void {
@@ -144,7 +158,12 @@ export class NativeEngineSocket {
     switch (event.type) {
       case "message":
         if (this.readyState === NativeEngineSocket.OPEN) {
-          this.onmessage?.(new MessageEvent("message", { data: event.text }));
+          const message = new MessageEvent<string>("message", { data: event.text });
+          this.onmessage?.(message);
+          for (const [listener, once] of this.messageListeners) {
+            listener(message);
+            if (once) this.messageListeners.delete(listener);
+          }
         }
         break;
       case "error":

--- a/client/src/services/openPhaseSocket.ts
+++ b/client/src/services/openPhaseSocket.ts
@@ -5,6 +5,8 @@ import {
   type ProtocolSurface,
   type ServerInfo,
 } from "../adapter/ws-adapter";
+import { supportsGzipEnvelope, type WireFormat } from "../network/wireEnvelope";
+import { GzipEnvelopeSocket } from "./gzipEnvelopeSocket";
 
 /**
  * Result of a successful handshake with `phase-server`. Wraps the live
@@ -23,7 +25,13 @@ export interface PhaseSocketTransport {
     listener: (event: CloseEvent) => void,
     options?: AddEventListenerOptions | boolean,
   ): void;
+  addEventListener(
+    type: "message",
+    listener: (event: MessageEvent<string>) => void,
+    options?: AddEventListenerOptions | boolean,
+  ): void;
   removeEventListener(type: "close", listener: (event: CloseEvent) => void): void;
+  removeEventListener(type: "message", listener: (event: MessageEvent<string>) => void): void;
   send(data: string): void;
   close(): void;
 }
@@ -31,7 +39,7 @@ export interface PhaseSocketTransport {
 export type PhaseSocketFactory<T extends PhaseSocketTransport = PhaseSocketTransport> =
   (url: string) => T;
 
-export interface PhaseSocket<T extends PhaseSocketTransport = WebSocket> {
+export interface PhaseSocket<T extends PhaseSocketTransport = PhaseSocketTransport> {
   readonly ws: T;
   readonly serverInfo: ServerInfo;
   close(): void;
@@ -111,11 +119,11 @@ export class HandshakeError extends Error {
 export function openPhaseSocket(
   wsUrl: string,
   opts?: OpenOptions<WebSocket>,
-): Promise<PhaseSocket<WebSocket>>;
+): Promise<PhaseSocket<PhaseSocketTransport>>;
 export function openPhaseSocket<T extends PhaseSocketTransport>(
   wsUrl: string,
   opts: OpenOptions<T>,
-): Promise<PhaseSocket<T>>;
+): Promise<PhaseSocket<PhaseSocketTransport>>;
 export function openPhaseSocket(
   wsUrl: string,
   opts: OpenOptions<PhaseSocketTransport> = {},
@@ -231,6 +239,7 @@ export function openPhaseSocket(
         mode: "Full" | "LobbyOnly";
         lobby_protocol_version?: number;
         public_url?: string;
+        wire_formats?: WireFormat[];
       };
       const info: ServerInfo = {
         version: data.server_version,
@@ -239,6 +248,7 @@ export function openPhaseSocket(
         mode: data.mode,
         lobbyProtocolVersion: data.lobby_protocol_version,
         publicUrl: data.public_url,
+        wireFormats: data.wire_formats ?? [],
       };
 
       const rejection = serverProtocolRejection(info, surface);
@@ -270,6 +280,9 @@ export function openPhaseSocket(
       // it gates on that instead, which is what decouples the lobby handshake
       // from full-game churn. Servers that predate the field ignore it (nothing
       // sets `deny_unknown_fields`).
+      const localWireFormats: WireFormat[] = supportsGzipEnvelope() && "binaryType" in ws
+        ? ["GzipEnvelopeV1"]
+        : [];
       ws.send(
         JSON.stringify({
           type: "ClientHello",
@@ -278,13 +291,16 @@ export function openPhaseSocket(
             build_commit: __BUILD_HASH__,
             protocol_version: clientProtocolVersion,
             lobby_protocol_version: LOBBY_PROTOCOL_VERSION,
+            wire_formats: localWireFormats,
           },
         }),
       );
 
       settle(() => {
+        const useGzipEnvelope = localWireFormats.includes("GzipEnvelopeV1")
+          && info.wireFormats?.includes("GzipEnvelopeV1");
         resolve({
-          ws,
+          ws: useGzipEnvelope ? new GzipEnvelopeSocket(ws) : ws,
           serverInfo: info,
           close: () => ws.close(),
         });

--- a/client/src/stores/multiplayerStore.ts
+++ b/client/src/stores/multiplayerStore.ts
@@ -40,6 +40,7 @@ import {
   openPhaseSocket,
   withReconnect,
   type PhaseSocket,
+  type PhaseSocketTransport,
   type ReconnectHandle,
 } from "../services/openPhaseSocket";
 import { isValidWebSocketUrl } from "../services/serverDetection";
@@ -72,7 +73,7 @@ type ConnectionStatus = "disconnected" | "connecting" | "connected";
 type HostingStatus = "idle" | "connecting" | "waiting";
 
 // Module-level WebSocket ref (non-serializable, lives outside store)
-let hostWs: WebSocket | null = null;
+let hostWs: PhaseSocketTransport | null = null;
 // Module-level broker client for P2P LobbyOnly hosting. Survives page
 // navigations so the lobby entry stays alive while the tile is showing.
 let activeBroker: BrokerClient | null = null;
@@ -447,7 +448,7 @@ function closeHostWebSocket(): void {
   }
 }
 
-function activeServerHostingSocket(get: () => MultiplayerState): WebSocket | null {
+function activeServerHostingSocket(get: () => MultiplayerState): PhaseSocketTransport | null {
   if (hostWs) {
     if (hostWs.readyState !== WebSocket.OPEN) {
       throw new Error("Host connection is not active.");
@@ -844,7 +845,7 @@ function clearPregameHostMetadataFromWsSession(): void {
 function handleServerHostMessage(
   set: MultiplayerSet,
   get: MultiplayerGet,
-  ws: WebSocket,
+  ws: PhaseSocketTransport,
   msg: { type: string; data?: unknown },
 ): void {
   if (msg.type === "GameCreated") {

--- a/crates/phase-server/Cargo.toml
+++ b/crates/phase-server/Cargo.toml
@@ -26,6 +26,7 @@ tokio = { version = "1", features = ["full"] }
 tower-http = { version = "0.6", features = ["cors", "compression-gzip"] }
 serde = { workspace = true }
 serde_json = "1"
+flate2 = "1"
 tempfile = "3"
 tracing = { workspace = true }
 tracing-appender = "0.2"

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -11732,10 +11732,6 @@ mod issue_4548_full_create_tests {
                 recv_enveloped_server_message(&mut socket).await,
                 ServerMessage::LobbyUpdate { .. }
             ));
-            while tokio::time::timeout(Duration::from_millis(20), socket.next())
-                .await
-                .is_ok()
-            {}
             for _ in 0..RATE_LIMIT_MESSAGES {
                 socket
                     .send(WsMessage::Binary(vec![0x01, 1, 2, 3].into()))
@@ -11743,11 +11739,18 @@ mod issue_4548_full_create_tests {
                     .expect("send malformed gzip");
             }
             send_test_message(&mut socket, &ClientMessage::Ping { timestamp: 7 }, true).await;
-            assert!(
-                tokio::time::timeout(Duration::from_millis(100), socket.next())
-                    .await
-                    .is_err()
-            );
+            let pong = tokio::time::timeout(Duration::from_millis(100), async {
+                loop {
+                    if matches!(
+                        recv_enveloped_server_message(&mut socket).await,
+                        ServerMessage::Pong { .. }
+                    ) {
+                        break;
+                    }
+                }
+            })
+            .await;
+            assert!(pong.is_err());
         })
         .await;
         server.abort();

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -11585,6 +11585,24 @@ mod issue_4548_full_create_tests {
         }
     }
 
+    async fn recv_enveloped_server_message<S>(socket: &mut WebSocketStream<S>) -> ServerMessage
+    where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let frame = socket
+            .next()
+            .await
+            .expect("websocket message")
+            .expect("websocket frame");
+        let WsMessage::Binary(bytes) = frame else {
+            panic!("expected binary server message, got {frame:?}");
+        };
+        let json = wire::decode_client_envelope(bytes.to_vec(), MAX_WS_MESSAGE_BYTES)
+            .await
+            .expect("decode server envelope");
+        serde_json::from_str(&json).expect("server message")
+    }
+
     #[tokio::test]
     async fn full_mode_create_sends_slots_after_game_created() {
         let (url, server, _temp_dir, _game_db) = spawn_full_mode_server().await;
@@ -11717,6 +11735,87 @@ mod issue_4548_full_create_tests {
         server.abort();
 
         assert!(result.is_ok(), "binary envelope roundtrip timed out");
+    }
+
+    #[tokio::test]
+    async fn lobby_broadcast_uses_each_clients_negotiated_frame_format() {
+        let (url, server, _temp_dir, _game_db) = spawn_full_mode_server().await;
+        let result = tokio::time::timeout(Duration::from_secs(2), async {
+            let (mut compressed, _) = tokio_tungstenite::connect_async(&url)
+                .await
+                .expect("connect compressed client");
+            assert!(matches!(
+                recv_server_message(&mut compressed).await,
+                ServerMessage::ServerHello { .. }
+            ));
+            let (mut legacy, _) = tokio_tungstenite::connect_async(&url)
+                .await
+                .expect("connect legacy client");
+            assert!(matches!(
+                recv_server_message(&mut legacy).await,
+                ServerMessage::ServerHello { .. }
+            ));
+
+            let hello = |wire_formats| ClientMessage::ClientHello {
+                client_version: env!("CARGO_PKG_VERSION").to_string(),
+                build_commit: build_commit().to_string(),
+                protocol_version: PROTOCOL_VERSION,
+                lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+                wire_formats,
+            };
+            compressed
+                .send(WsMessage::Text(
+                    serde_json::to_string(&hello(vec![WireFormat::GzipEnvelopeV1]))
+                        .expect("hello json")
+                        .into(),
+                ))
+                .await
+                .expect("send compressed hello");
+            legacy
+                .send(WsMessage::Text(
+                    serde_json::to_string(&hello(Vec::new()))
+                        .expect("hello json")
+                        .into(),
+                ))
+                .await
+                .expect("send legacy hello");
+
+            let subscribe =
+                serde_json::to_vec(&ClientMessage::SubscribeLobby).expect("subscribe json");
+            compressed
+                .send(WsMessage::Binary(
+                    [vec![0x00], subscribe.clone()].concat().into(),
+                ))
+                .await
+                .expect("subscribe compressed client");
+            legacy
+                .send(WsMessage::Text(
+                    String::from_utf8(subscribe).expect("subscribe utf8").into(),
+                ))
+                .await
+                .expect("subscribe legacy client");
+
+            for _ in 0..2 {
+                recv_enveloped_server_message(&mut compressed).await;
+                recv_server_message(&mut legacy).await;
+            }
+
+            let (_trigger, _) = tokio_tungstenite::connect_async(&url)
+                .await
+                .expect("connect broadcast trigger");
+            while !matches!(
+                recv_enveloped_server_message(&mut compressed).await,
+                ServerMessage::PlayerCount { count: 3 }
+            ) {}
+            while !matches!(
+                recv_server_message(&mut legacy).await,
+                ServerMessage::PlayerCount { count: 3 }
+            ) {}
+        })
+        .await;
+        server.abort();
+
+        assert!(result.is_ok(), "mixed-version lobby broadcast timed out");
     }
 
     #[tokio::test]

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -4,6 +4,7 @@ mod draft_pools;
 mod logging;
 mod metrics;
 mod persistence;
+mod wire;
 
 use std::collections::HashMap;
 use std::net::IpAddr;
@@ -67,8 +68,8 @@ use server_core::lobby::RegisterGameRequest;
 use server_core::lobby_subscriber_wire_guard::guard_lobby_subscriber_capacity;
 use server_core::protocol::{
     build_commit, resolve_draft_source_intent, ClientMessage, RankedPlayerResult, ServerMessage,
-    ServerMode, LOBBY_MIN_SUPPORTED_PROTOCOL, LOBBY_PROTOCOL_VERSION, MIN_SUPPORTED_LOBBY_PROTOCOL,
-    MIN_SUPPORTED_PROTOCOL, PROTOCOL_VERSION,
+    ServerMode, WireFormat, LOBBY_MIN_SUPPORTED_PROTOCOL, LOBBY_PROTOCOL_VERSION,
+    MIN_SUPPORTED_LOBBY_PROTOCOL, MIN_SUPPORTED_PROTOCOL, PROTOCOL_VERSION,
 };
 use server_core::resolve_deck;
 use server_core::seat_mutation_wire_guard::guard_seat_mutation;
@@ -995,7 +996,10 @@ struct SocketIdentity {
 struct ClientHelloInfo {
     client_version: String,
     build_commit: String,
+    wire_format: Option<WireFormat>,
 }
+
+const MAX_ADVERTISED_WIRE_FORMATS: usize = 8;
 
 /// Outcome of evaluating the handshake gate against an incoming message.
 /// Extracted into a pure function so the gate's invariants can be unit-tested
@@ -1084,6 +1088,7 @@ fn classify_hello_gate(
                 build_commit,
                 protocol_version,
                 lobby_protocol_version,
+                wire_formats,
             },
         ) => {
             // The `server` field on RejectProtocol surfaces the version this
@@ -1093,12 +1098,19 @@ fn classify_hello_gate(
                 acceptance.reject(*protocol_version, *lobby_protocol_version)
             {
                 HelloGateOutcome::RejectProtocol { client, server }
+            } else if wire_formats.len() > MAX_ADVERTISED_WIRE_FORMATS {
+                HelloGateOutcome::RejectInvalidHello(
+                    "ClientHello advertises too many wire formats".to_string(),
+                )
             } else if let Err(reason) = guard_client_hello(client_version, build_commit) {
                 HelloGateOutcome::RejectInvalidHello(reason)
             } else {
                 HelloGateOutcome::Accept(ClientHelloInfo {
                     client_version: client_version.clone(),
                     build_commit: build_commit.clone(),
+                    wire_format: wire_formats
+                        .contains(&WireFormat::GzipEnvelopeV1)
+                        .then_some(WireFormat::GzipEnvelopeV1),
                 })
             }
         }
@@ -3248,6 +3260,47 @@ struct ConnectionSlot {
     armed: bool,
 }
 
+/// Per-connection WebSocket writer. Once the text handshake negotiates a wire
+/// format, every later JSON text send passes through the same envelope path —
+/// including direct errors as well as queued broadcasts.
+struct NegotiatedSocket {
+    inner: WebSocket,
+    wire_format: Option<WireFormat>,
+}
+
+impl NegotiatedSocket {
+    fn new(inner: WebSocket) -> Self {
+        Self {
+            inner,
+            wire_format: None,
+        }
+    }
+
+    fn set_wire_format(&mut self, wire_format: Option<WireFormat>) {
+        self.wire_format = wire_format;
+    }
+
+    fn uses_gzip_envelope(&self) -> bool {
+        self.wire_format == Some(WireFormat::GzipEnvelopeV1)
+    }
+
+    async fn send(&mut self, message: Message) -> Result<(), axum::Error> {
+        let message = match message {
+            Message::Text(json) => {
+                wire::encode_json_message(json.to_string(), self.uses_gzip_envelope())
+                    .await
+                    .map_err(axum::Error::new)?
+            }
+            other => other,
+        };
+        self.inner.send(message).await
+    }
+
+    async fn recv(&mut self) -> Option<Result<Message, axum::Error>> {
+        self.inner.recv().await
+    }
+}
+
 impl ConnectionSlot {
     fn new(player_count: SharedPlayerCount) -> Self {
         Self {
@@ -3271,7 +3324,7 @@ impl Drop for ConnectionSlot {
 
 #[allow(clippy::too_many_arguments)]
 async fn handle_socket(
-    mut socket: WebSocket,
+    socket: WebSocket,
     state: SharedState,
     draft_state: SharedDraftState,
     draft_pools: SharedDraftPools,
@@ -3289,6 +3342,7 @@ async fn handle_socket(
     online_count: u32,
     slot: ConnectionSlot,
 ) {
+    let mut socket = NegotiatedSocket::new(socket);
     let (tx, mut rx) = mpsc::unbounded_channel::<ServerMessage>();
 
     // The slot was reserved before the upgrade; from here the two `fetch_sub`
@@ -3331,6 +3385,7 @@ async fn handle_socket(
         mode,
         lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
         public_url,
+        wire_formats: vec![WireFormat::GzipEnvelopeV1],
     };
     if let Ok(json) = serde_json::to_string(&hello) {
         if socket.send(Message::text(json)).await.is_err() {
@@ -3345,9 +3400,7 @@ async fn handle_socket(
             biased;
             Some(msg) = rx.recv() => {
                 if let Ok(json) = serde_json::to_string(&msg) {
-                    if socket.send(Message::text(json)).await.is_err() {
-                        break;
-                    }
+                    if socket.send(Message::text(json)).await.is_err() { break; }
                 }
             }
 
@@ -3356,6 +3409,15 @@ async fn handle_socket(
                     Some(Ok(msg)) => {
                         let text = match msg {
                             Message::Text(t) => t.to_string(),
+                            Message::Binary(bytes) if socket.uses_gzip_envelope() => {
+                                match wire::decode_client_envelope(bytes.to_vec(), MAX_WS_MESSAGE_BYTES).await {
+                                    Ok(text) => text,
+                                    Err(error) => {
+                                        warn!(%error, "failed to decode client binary envelope");
+                                        continue;
+                                    }
+                                }
+                            }
                             Message::Close(_) => break,
                             _ => continue,
                         };
@@ -3544,6 +3606,9 @@ fn to_server_message(m: lobby_broker::LobbyServerMessage) -> ServerMessage {
             // LobbyOnly brokers run no server-side game, so there is no
             // game-server URL to advertise for a `<code>@<host>` share string.
             public_url: None,
+            // Socket negotiation uses the canonical ServerHello sent directly
+            // by handle_socket; broker-originated hellos are only projections.
+            wire_formats: Vec::new(),
         },
         L::GameCreated {
             game_code,
@@ -3639,6 +3704,7 @@ fn to_lobby_client_message(msg: &ClientMessage) -> Option<lobby_broker::LobbyCli
             build_commit,
             protocol_version,
             lobby_protocol_version,
+            wire_formats: _,
         } => L::ClientHello {
             client_version: client_version.clone(),
             build_commit: build_commit.clone(),
@@ -4827,7 +4893,7 @@ async fn broadcast_game_started(
     broadcast_ai_failure(connections, game_code, ai_failure).await;
 }
 
-async fn require_host(identity: &SocketIdentity, socket: &mut WebSocket) -> Result<(), ()> {
+async fn require_host(identity: &SocketIdentity, socket: &mut NegotiatedSocket) -> Result<(), ()> {
     if identity.player_id != Some(PlayerId(0)) {
         let msg = ServerMessage::error("Only the host can modify seats.".to_string());
         if let Ok(json) = serde_json::to_string(&msg) {
@@ -4852,7 +4918,7 @@ fn is_joining_current_game(identity: &SocketIdentity, target_game_code: &str) ->
 async fn reject_joining_current_game(
     identity: &SocketIdentity,
     target_game_code: &str,
-    socket: &mut WebSocket,
+    socket: &mut NegotiatedSocket,
 ) -> Result<(), ()> {
     if !is_joining_current_game(identity, target_game_code) {
         return Ok(());
@@ -5329,7 +5395,7 @@ impl GameSubmission {
 #[allow(clippy::too_many_arguments)]
 async fn handle_full_game_submission(
     submission: GameSubmission,
-    socket: &mut WebSocket,
+    socket: &mut NegotiatedSocket,
     state: &SharedState,
     db: &SharedDb,
     draft_state: &SharedDraftState,
@@ -5960,7 +6026,7 @@ async fn handle_resolve_all(
 #[allow(clippy::too_many_arguments)]
 async fn handle_client_message(
     client_msg: ClientMessage,
-    socket: &mut WebSocket,
+    socket: &mut NegotiatedSocket,
     state: &SharedState,
     draft_state: &SharedDraftState,
     draft_pools: &SharedDraftPools,
@@ -5990,6 +6056,7 @@ async fn handle_client_message(
                 commit = %info.build_commit,
                 "ClientHello accepted"
             );
+            socket.set_wire_format(info.wire_format);
             identity.client_hello = Some(info);
             return;
         }
@@ -11536,6 +11603,7 @@ mod issue_4548_full_create_tests {
                 build_commit: build_commit().to_string(),
                 protocol_version: PROTOCOL_VERSION,
                 lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+                wire_formats: Vec::new(),
             };
             socket
                 .send(WsMessage::Text(
@@ -11595,6 +11663,63 @@ mod issue_4548_full_create_tests {
     }
 
     #[tokio::test]
+    async fn negotiated_gzip_envelope_accepts_and_returns_binary_frames() {
+        let (url, server, _temp_dir, _game_db) = spawn_full_mode_server().await;
+        let result = tokio::time::timeout(Duration::from_secs(2), async {
+            let (mut socket, _) = tokio_tungstenite::connect_async(url)
+                .await
+                .expect("connect");
+
+            let server_hello = recv_server_message(&mut socket).await;
+            assert!(matches!(
+                server_hello,
+                ServerMessage::ServerHello { wire_formats, .. }
+                    if wire_formats.contains(&WireFormat::GzipEnvelopeV1)
+            ));
+
+            let hello = ClientMessage::ClientHello {
+                client_version: env!("CARGO_PKG_VERSION").to_string(),
+                build_commit: build_commit().to_string(),
+                protocol_version: PROTOCOL_VERSION,
+                lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+                wire_formats: vec![WireFormat::GzipEnvelopeV1],
+            };
+            socket
+                .send(WsMessage::Text(
+                    serde_json::to_string(&hello).expect("hello json").into(),
+                ))
+                .await
+                .expect("send hello");
+
+            let subscribe =
+                serde_json::to_vec(&ClientMessage::SubscribeLobby).expect("subscribe json");
+            let binary = [vec![0x00], subscribe].concat();
+            socket
+                .send(WsMessage::Binary(binary.into()))
+                .await
+                .expect("send binary subscribe");
+
+            let frame = socket
+                .next()
+                .await
+                .expect("server response")
+                .expect("server frame");
+            let WsMessage::Binary(bytes) = frame else {
+                panic!("negotiated response must be binary, got {frame:?}");
+            };
+            let json = wire::decode_client_envelope(bytes.to_vec(), MAX_WS_MESSAGE_BYTES)
+                .await
+                .expect("decode server envelope");
+            let message: ServerMessage = serde_json::from_str(&json).expect("server message");
+            assert!(matches!(message, ServerMessage::LobbyUpdate { .. }));
+        })
+        .await;
+        server.abort();
+
+        assert!(result.is_ok(), "binary envelope roundtrip timed out");
+    }
+
+    #[tokio::test]
     async fn full_mode_create_rejects_format_invalid_host_deck() {
         let (url, server, _temp_dir, _game_db) = spawn_full_mode_server().await;
         let result = tokio::time::timeout(Duration::from_secs(2), async {
@@ -11612,6 +11737,7 @@ mod issue_4548_full_create_tests {
                 build_commit: build_commit().to_string(),
                 protocol_version: PROTOCOL_VERSION,
                 lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+                wire_formats: Vec::new(),
             };
             socket
                 .send(WsMessage::Text(
@@ -11678,6 +11804,7 @@ mod issue_4548_full_create_tests {
                 build_commit: build_commit().to_string(),
                 protocol_version: PROTOCOL_VERSION,
                 lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+                wire_formats: Vec::new(),
             };
             socket
                 .send(WsMessage::Text(
@@ -11810,6 +11937,7 @@ mod game_submission_tests {
             build_commit: build_commit().to_string(),
             protocol_version: PROTOCOL_VERSION,
             lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+            wire_formats: Vec::new(),
         };
         socket
             .send(WsMessage::Text(
@@ -12344,6 +12472,7 @@ mod game_submission_tests {
                 build_commit: build_commit().to_string(),
                 protocol_version: PROTOCOL_VERSION,
                 lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+                wire_formats: Vec::new(),
             };
             socket
                 .send(WsMessage::Text(
@@ -12508,6 +12637,7 @@ mod mode_gate_tests {
                 build_commit: "abc".into(),
                 protocol_version: PROTOCOL_VERSION,
                 lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+                wire_formats: Vec::new(),
             },
             ClientMessage::SubscribeLobby,
             ClientMessage::UnsubscribeLobby,
@@ -12903,6 +13033,7 @@ mod handshake_tests {
                 // Legacy client: predates the lobby-owned version, so the
                 // gate must fall back to the `protocol_version` window.
                 lobby_protocol_version: None,
+                wire_formats: Vec::new(),
             },
             hello_acceptance(ServerMode::Full),
         );
@@ -12911,6 +13042,30 @@ mod handshake_tests {
             HelloGateOutcome::Accept(ClientHelloInfo {
                 client_version: "0.1.11".into(),
                 build_commit: "abc1234".into(),
+                wire_format: None,
+            })
+        );
+    }
+
+    #[test]
+    fn negotiates_gzip_envelope_from_client_hello_capability() {
+        let outcome = classify_hello_gate(
+            false,
+            &ClientMessage::ClientHello {
+                client_version: "0.1.11".into(),
+                build_commit: "abc1234".into(),
+                protocol_version: PROTOCOL_VERSION,
+                lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+                wire_formats: vec![WireFormat::GzipEnvelopeV1],
+            },
+            hello_acceptance(ServerMode::Full),
+        );
+        assert_eq!(
+            outcome,
+            HelloGateOutcome::Accept(ClientHelloInfo {
+                client_version: "0.1.11".into(),
+                build_commit: "abc1234".into(),
+                wire_format: Some(WireFormat::GzipEnvelopeV1),
             })
         );
     }
@@ -12931,6 +13086,7 @@ mod handshake_tests {
                 // Legacy client: predates the lobby-owned version, so the
                 // gate must fall back to the `protocol_version` window.
                 lobby_protocol_version: None,
+                wire_formats: Vec::new(),
             },
             hello_acceptance(ServerMode::Full),
         );
@@ -12955,6 +13111,7 @@ mod handshake_tests {
                 // Legacy client: predates the lobby-owned version, so the
                 // gate must fall back to the `protocol_version` window.
                 lobby_protocol_version: None,
+                wire_formats: Vec::new(),
             },
             hello_acceptance(ServerMode::LobbyOnly),
         );
@@ -12975,6 +13132,7 @@ mod handshake_tests {
                 // Far outside LOBBY_MIN_SUPPORTED_PROTOCOL..=PROTOCOL_VERSION.
                 protocol_version: PROTOCOL_VERSION.saturating_sub(9),
                 lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+                wire_formats: Vec::new(),
             },
             hello_acceptance(ServerMode::LobbyOnly),
         );
@@ -12995,6 +13153,7 @@ mod handshake_tests {
                 build_commit: "future12".into(),
                 protocol_version: PROTOCOL_VERSION,
                 lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION + 5),
+                wire_formats: Vec::new(),
             },
             hello_acceptance(ServerMode::LobbyOnly),
         );
@@ -13016,6 +13175,7 @@ mod handshake_tests {
                 build_commit: "ancient1".into(),
                 protocol_version: PROTOCOL_VERSION,
                 lobby_protocol_version: Some(below),
+                wire_formats: Vec::new(),
             },
             hello_acceptance(ServerMode::LobbyOnly),
         );
@@ -13041,6 +13201,7 @@ mod handshake_tests {
                 build_commit: "old1234".into(),
                 protocol_version: previous,
                 lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+                wire_formats: Vec::new(),
             },
             hello_acceptance(ServerMode::Full),
         );
@@ -13065,6 +13226,7 @@ mod handshake_tests {
                 // Legacy client: predates the lobby-owned version, so the
                 // gate must fall back to the `protocol_version` window.
                 lobby_protocol_version: None,
+                wire_formats: Vec::new(),
             },
             hello_acceptance(ServerMode::Full),
         );
@@ -13088,6 +13250,7 @@ mod handshake_tests {
                 // Legacy client: predates the lobby-owned version, so the
                 // gate must fall back to the `protocol_version` window.
                 lobby_protocol_version: None,
+                wire_formats: Vec::new(),
             },
             hello_acceptance(ServerMode::Full),
         );
@@ -13111,6 +13274,7 @@ mod handshake_tests {
                 // Legacy client: predates the lobby-owned version, so the
                 // gate must fall back to the `protocol_version` window.
                 lobby_protocol_version: None,
+                wire_formats: Vec::new(),
             },
             hello_acceptance(ServerMode::Full),
         );
@@ -13128,6 +13292,7 @@ mod handshake_tests {
                 // Legacy client: predates the lobby-owned version, so the
                 // gate must fall back to the `protocol_version` window.
                 lobby_protocol_version: None,
+                wire_formats: Vec::new(),
             },
             hello_acceptance(ServerMode::Full),
         );
@@ -13178,6 +13343,7 @@ mod handshake_tests {
                 // Legacy client: predates the lobby-owned version, so the
                 // gate must fall back to the `protocol_version` window.
                 lobby_protocol_version: None,
+                wire_formats: Vec::new(),
             },
             hello_acceptance(ServerMode::Full),
         );
@@ -14623,6 +14789,7 @@ mod metrics_tests {
             build_commit: build_commit().to_string(),
             protocol_version: PROTOCOL_VERSION,
             lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+            wire_formats: Vec::new(),
         };
         socket
             .send(WsMessage::Text(

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -3407,6 +3407,11 @@ async fn handle_socket(
             result = socket.recv() => {
                 match result {
                     Some(Ok(msg)) => {
+                        if !rate_limiter.check() {
+                            debug!("rate limit exceeded, dropping message");
+                            continue;
+                        }
+
                         let text = match msg {
                             Message::Text(t) => t.to_string(),
                             Message::Binary(bytes) if socket.uses_gzip_envelope() => {
@@ -3421,11 +3426,6 @@ async fn handle_socket(
                             Message::Close(_) => break,
                             _ => continue,
                         };
-
-                        if !rate_limiter.check() {
-                            debug!("rate limit exceeded, dropping message");
-                            continue;
-                        }
 
                         let client_msg: ClientMessage = match serde_json::from_str(&text) {
                             Ok(m) => m,
@@ -11603,6 +11603,32 @@ mod issue_4548_full_create_tests {
         serde_json::from_str(&json).expect("server message")
     }
 
+    fn test_client_hello(wire_formats: Vec<WireFormat>) -> ClientMessage {
+        ClientMessage::ClientHello {
+            client_version: env!("CARGO_PKG_VERSION").to_string(),
+            build_commit: build_commit().to_string(),
+            protocol_version: PROTOCOL_VERSION,
+            lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+            wire_formats,
+        }
+    }
+
+    async fn send_test_message<S>(
+        socket: &mut WebSocketStream<S>,
+        message: &ClientMessage,
+        enveloped: bool,
+    ) where
+        S: AsyncRead + AsyncWrite + Unpin,
+    {
+        let json = serde_json::to_vec(message).expect("client message json");
+        let frame = if enveloped {
+            WsMessage::Binary([vec![0x00], json].concat().into())
+        } else {
+            WsMessage::Text(String::from_utf8(json).expect("client message utf8").into())
+        };
+        socket.send(frame).await.expect("send client message");
+    }
+
     #[tokio::test]
     async fn full_mode_create_sends_slots_after_game_created() {
         let (url, server, _temp_dir, _game_db) = spawn_full_mode_server().await;
@@ -11695,41 +11721,33 @@ mod issue_4548_full_create_tests {
                     if wire_formats.contains(&WireFormat::GzipEnvelopeV1)
             ));
 
-            let hello = ClientMessage::ClientHello {
-                client_version: env!("CARGO_PKG_VERSION").to_string(),
-                build_commit: build_commit().to_string(),
-                protocol_version: PROTOCOL_VERSION,
-                lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
-                wire_formats: vec![WireFormat::GzipEnvelopeV1],
-            };
-            socket
-                .send(WsMessage::Text(
-                    serde_json::to_string(&hello).expect("hello json").into(),
-                ))
+            send_test_message(
+                &mut socket,
+                &test_client_hello(vec![WireFormat::GzipEnvelopeV1]),
+                false,
+            )
+            .await;
+            send_test_message(&mut socket, &ClientMessage::SubscribeLobby, true).await;
+            assert!(matches!(
+                recv_enveloped_server_message(&mut socket).await,
+                ServerMessage::LobbyUpdate { .. }
+            ));
+            while tokio::time::timeout(Duration::from_millis(20), socket.next())
                 .await
-                .expect("send hello");
-
-            let subscribe =
-                serde_json::to_vec(&ClientMessage::SubscribeLobby).expect("subscribe json");
-            let binary = [vec![0x00], subscribe].concat();
-            socket
-                .send(WsMessage::Binary(binary.into()))
-                .await
-                .expect("send binary subscribe");
-
-            let frame = socket
-                .next()
-                .await
-                .expect("server response")
-                .expect("server frame");
-            let WsMessage::Binary(bytes) = frame else {
-                panic!("negotiated response must be binary, got {frame:?}");
-            };
-            let json = wire::decode_client_envelope(bytes.to_vec(), MAX_WS_MESSAGE_BYTES)
-                .await
-                .expect("decode server envelope");
-            let message: ServerMessage = serde_json::from_str(&json).expect("server message");
-            assert!(matches!(message, ServerMessage::LobbyUpdate { .. }));
+                .is_ok()
+            {}
+            for _ in 0..RATE_LIMIT_MESSAGES {
+                socket
+                    .send(WsMessage::Binary(vec![0x01, 1, 2, 3].into()))
+                    .await
+                    .expect("send malformed gzip");
+            }
+            send_test_message(&mut socket, &ClientMessage::Ping { timestamp: 7 }, true).await;
+            assert!(
+                tokio::time::timeout(Duration::from_millis(100), socket.next())
+                    .await
+                    .is_err()
+            );
         })
         .await;
         server.abort();
@@ -11744,56 +11762,21 @@ mod issue_4548_full_create_tests {
             let (mut compressed, _) = tokio_tungstenite::connect_async(&url)
                 .await
                 .expect("connect compressed client");
-            assert!(matches!(
-                recv_server_message(&mut compressed).await,
-                ServerMessage::ServerHello { .. }
-            ));
+            recv_server_message(&mut compressed).await;
             let (mut legacy, _) = tokio_tungstenite::connect_async(&url)
                 .await
                 .expect("connect legacy client");
-            assert!(matches!(
-                recv_server_message(&mut legacy).await,
-                ServerMessage::ServerHello { .. }
-            ));
+            recv_server_message(&mut legacy).await;
 
-            let hello = |wire_formats| ClientMessage::ClientHello {
-                client_version: env!("CARGO_PKG_VERSION").to_string(),
-                build_commit: build_commit().to_string(),
-                protocol_version: PROTOCOL_VERSION,
-                lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
-                wire_formats,
-            };
-            compressed
-                .send(WsMessage::Text(
-                    serde_json::to_string(&hello(vec![WireFormat::GzipEnvelopeV1]))
-                        .expect("hello json")
-                        .into(),
-                ))
-                .await
-                .expect("send compressed hello");
-            legacy
-                .send(WsMessage::Text(
-                    serde_json::to_string(&hello(Vec::new()))
-                        .expect("hello json")
-                        .into(),
-                ))
-                .await
-                .expect("send legacy hello");
-
-            let subscribe =
-                serde_json::to_vec(&ClientMessage::SubscribeLobby).expect("subscribe json");
-            compressed
-                .send(WsMessage::Binary(
-                    [vec![0x00], subscribe.clone()].concat().into(),
-                ))
-                .await
-                .expect("subscribe compressed client");
-            legacy
-                .send(WsMessage::Text(
-                    String::from_utf8(subscribe).expect("subscribe utf8").into(),
-                ))
-                .await
-                .expect("subscribe legacy client");
+            send_test_message(
+                &mut compressed,
+                &test_client_hello(vec![WireFormat::GzipEnvelopeV1]),
+                false,
+            )
+            .await;
+            send_test_message(&mut legacy, &test_client_hello(Vec::new()), false).await;
+            send_test_message(&mut compressed, &ClientMessage::SubscribeLobby, true).await;
+            send_test_message(&mut legacy, &ClientMessage::SubscribeLobby, false).await;
 
             for _ in 0..2 {
                 recv_enveloped_server_message(&mut compressed).await;

--- a/crates/phase-server/src/wire.rs
+++ b/crates/phase-server/src/wire.rs
@@ -102,8 +102,19 @@ mod tests {
             .unwrap_err()
             .contains("unknown"));
 
+        assert!(decode_envelope(&[FORMAT_GZIP, 1, 2, 3], 8)
+            .unwrap_err()
+            .contains("invalid gzip"));
+
         let oversized = [vec![FORMAT_RAW], vec![b'x'; 9]].concat();
         assert!(decode_envelope(&oversized, 8)
+            .unwrap_err()
+            .contains("exceeds"));
+
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        encoder.write_all(&[b'x'; 9]).unwrap();
+        let oversized_gzip = [vec![FORMAT_GZIP], encoder.finish().unwrap()].concat();
+        assert!(decode_envelope(&oversized_gzip, 8)
             .unwrap_err()
             .contains("exceeds"));
     }

--- a/crates/phase-server/src/wire.rs
+++ b/crates/phase-server/src/wire.rs
@@ -1,0 +1,136 @@
+use std::io::{Read, Write};
+
+use axum::extract::ws::Message;
+use flate2::read::GzDecoder;
+use flate2::write::GzEncoder;
+use flate2::Compression;
+
+// Keep this aligned with client/src/network/wireEnvelope.ts.
+const FORMAT_RAW: u8 = 0x00;
+const FORMAT_GZIP: u8 = 0x01;
+const COMPRESSION_THRESHOLD: usize = 256;
+
+pub async fn encode_json_message(json: String, use_envelope: bool) -> Result<Message, String> {
+    if !use_envelope {
+        return Ok(Message::text(json));
+    }
+
+    let bytes = json.into_bytes();
+    if bytes.len() < COMPRESSION_THRESHOLD {
+        let mut framed = Vec::with_capacity(bytes.len() + 1);
+        framed.push(FORMAT_RAW);
+        framed.extend(bytes);
+        return Ok(Message::binary(framed));
+    }
+
+    let framed = tokio::task::spawn_blocking(move || {
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        encoder
+            .write_all(&bytes)
+            .map_err(|error| error.to_string())?;
+        let compressed = encoder.finish().map_err(|error| error.to_string())?;
+        let mut framed = Vec::with_capacity(compressed.len() + 1);
+        framed.push(FORMAT_GZIP);
+        framed.extend(compressed);
+        Ok::<_, String>(framed)
+    })
+    .await
+    .map_err(|error| error.to_string())??;
+
+    Ok(Message::binary(framed))
+}
+
+pub async fn decode_client_envelope(
+    bytes: Vec<u8>,
+    max_json_bytes: usize,
+) -> Result<String, String> {
+    tokio::task::spawn_blocking(move || decode_envelope(&bytes, max_json_bytes))
+        .await
+        .map_err(|error| error.to_string())?
+}
+
+fn decode_envelope(bytes: &[u8], max_json_bytes: usize) -> Result<String, String> {
+    let (&format, payload) = bytes
+        .split_first()
+        .ok_or_else(|| "empty binary envelope".to_string())?;
+    let decoded = match format {
+        FORMAT_RAW => payload.to_vec(),
+        FORMAT_GZIP => {
+            let mut decoded = Vec::new();
+            GzDecoder::new(payload)
+                .take((max_json_bytes + 1) as u64)
+                .read_to_end(&mut decoded)
+                .map_err(|error| format!("invalid gzip envelope: {error}"))?;
+            decoded
+        }
+        other => return Err(format!("unknown binary envelope format: {other:#04x}")),
+    };
+    if decoded.len() > max_json_bytes {
+        return Err("decompressed WebSocket message exceeds limit".to_string());
+    }
+    String::from_utf8(decoded).map_err(|error| format!("envelope is not UTF-8 JSON: {error}"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use server_core::protocol::ServerMessage;
+
+    async fn encode_server_message(
+        message: &ServerMessage,
+        use_envelope: bool,
+    ) -> Result<Message, String> {
+        let json = serde_json::to_string(message).map_err(|error| error.to_string())?;
+        encode_json_message(json, use_envelope).await
+    }
+
+    #[test]
+    fn raw_and_gzip_envelopes_decode() {
+        let raw = [vec![FORMAT_RAW], br#"{"type":"Ping"}"#.to_vec()].concat();
+        assert_eq!(decode_envelope(&raw, 1024).unwrap(), r#"{"type":"Ping"}"#);
+
+        let body = vec![b'x'; 1024];
+        let mut encoder = GzEncoder::new(Vec::new(), Compression::fast());
+        encoder.write_all(&body).unwrap();
+        let gzip = [vec![FORMAT_GZIP], encoder.finish().unwrap()].concat();
+        assert_eq!(decode_envelope(&gzip, 1024).unwrap().into_bytes(), body);
+    }
+
+    #[test]
+    fn rejects_unknown_and_oversized_envelopes() {
+        assert!(decode_envelope(&[0xff, 1], 8)
+            .unwrap_err()
+            .contains("unknown"));
+
+        let oversized = [vec![FORMAT_RAW], vec![b'x'; 9]].concat();
+        assert!(decode_envelope(&oversized, 8)
+            .unwrap_err()
+            .contains("exceeds"));
+    }
+
+    #[tokio::test]
+    async fn outgoing_frames_preserve_text_fallback_and_select_envelope_format() {
+        let small = ServerMessage::Pong { timestamp: 7 };
+        assert!(matches!(
+            encode_server_message(&small, false).await.unwrap(),
+            Message::Text(_)
+        ));
+
+        let raw = encode_server_message(&small, true).await.unwrap();
+        let Message::Binary(raw) = raw else {
+            panic!("negotiated small frame must use the raw binary envelope");
+        };
+        assert_eq!(raw[0], FORMAT_RAW);
+        assert!(decode_envelope(&raw, 1024).unwrap().contains("Pong"));
+
+        let large = ServerMessage::error("x".repeat(COMPRESSION_THRESHOLD * 2));
+        let gzip = encode_server_message(&large, true).await.unwrap();
+        let Message::Binary(gzip) = gzip else {
+            panic!("negotiated large frame must use gzip");
+        };
+        assert_eq!(gzip[0], FORMAT_GZIP);
+        assert!(decode_envelope(&gzip, 4096)
+            .unwrap()
+            .contains(&"x".repeat(64)));
+    }
+}

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -56,6 +56,18 @@ pub enum ServerMode {
     LobbyOnly,
 }
 
+/// Optional binary JSON envelopes a WebSocket peer can encode and decode.
+/// Capabilities are negotiated independently of the semantic protocol version
+/// so old peers retain the plain-text JSON path during rolling deployments.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+pub enum WireFormat {
+    GzipEnvelopeV1,
+    /// Future capability advertised by a newer peer. Unknown entries must not
+    /// make an otherwise compatible additive handshake fail.
+    #[serde(other)]
+    Unknown,
+}
+
 pub use engine::starter_decks::DeckData;
 
 /// AI seat configuration sent by the client when creating a game with AI opponents.
@@ -267,6 +279,8 @@ pub enum ClientMessage {
         /// versions its own message set separately from `PROTOCOL_VERSION`.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         lobby_protocol_version: Option<u32>,
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        wire_formats: Vec<WireFormat>,
     },
     CreateGame {
         deck: DeckData,
@@ -566,6 +580,9 @@ pub enum ServerMessage {
         /// LobbyOnly brokers and for servers with no advertised address.
         #[serde(default, skip_serializing_if = "Option::is_none")]
         public_url: Option<String>,
+        /// Binary envelopes this server can negotiate after the text hello.
+        #[serde(default, skip_serializing_if = "Vec::is_empty")]
+        wire_formats: Vec<WireFormat>,
     },
     GameCreated {
         game_code: String,
@@ -1935,6 +1952,7 @@ mod tests {
             build_commit: "abc1234".to_string(),
             protocol_version: PROTOCOL_VERSION,
             lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
+            wire_formats: vec![WireFormat::GzipEnvelopeV1],
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ClientMessage = serde_json::from_str(&json).unwrap();
@@ -1944,14 +1962,32 @@ mod tests {
                 build_commit,
                 protocol_version,
                 lobby_protocol_version,
+                wire_formats,
             } => {
                 assert_eq!(client_version, "0.1.11");
                 assert_eq!(build_commit, "abc1234");
                 assert_eq!(protocol_version, PROTOCOL_VERSION);
                 assert_eq!(lobby_protocol_version, Some(LOBBY_PROTOCOL_VERSION));
+                assert_eq!(wire_formats, vec![WireFormat::GzipEnvelopeV1]);
             }
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn client_hello_defaults_missing_and_future_wire_formats_safely() {
+        let legacy = r#"{"type":"ClientHello","data":{"client_version":"0.1.0","build_commit":"abc","protocol_version":1}}"#;
+        assert!(matches!(
+            serde_json::from_str::<ClientMessage>(legacy).unwrap(),
+            ClientMessage::ClientHello { wire_formats, .. } if wire_formats.is_empty()
+        ));
+
+        let future = r#"{"type":"ClientHello","data":{"client_version":"0.1.0","build_commit":"abc","protocol_version":1,"wire_formats":["FutureEnvelopeV2"]}}"#;
+        assert!(matches!(
+            serde_json::from_str::<ClientMessage>(future).unwrap(),
+            ClientMessage::ClientHello { wire_formats, .. }
+                if wire_formats == vec![WireFormat::Unknown]
+        ));
     }
 
     #[test]
@@ -1963,6 +1999,7 @@ mod tests {
             mode: ServerMode::Full,
             lobby_protocol_version: Some(LOBBY_PROTOCOL_VERSION),
             public_url: Some("https://x.ngrok-free.app".to_string()),
+            wire_formats: vec![WireFormat::GzipEnvelopeV1],
         };
         let json = serde_json::to_string(&msg).unwrap();
         let parsed: ServerMessage = serde_json::from_str(&json).unwrap();
@@ -1974,6 +2011,7 @@ mod tests {
                 mode,
                 lobby_protocol_version,
                 public_url,
+                wire_formats,
             } => {
                 assert_eq!(server_version, "0.1.11");
                 assert_eq!(build_commit, "abc1234");
@@ -1981,6 +2019,7 @@ mod tests {
                 assert_eq!(mode, ServerMode::Full);
                 assert_eq!(lobby_protocol_version, Some(LOBBY_PROTOCOL_VERSION));
                 assert_eq!(public_url.as_deref(), Some("https://x.ngrok-free.app"));
+                assert_eq!(wire_formats, vec![WireFormat::GzipEnvelopeV1]);
             }
             _ => panic!("wrong variant"),
         }
@@ -1998,6 +2037,7 @@ mod tests {
             mode: ServerMode::LobbyOnly,
             lobby_protocol_version: None,
             public_url: None,
+            wire_formats: Vec::new(),
         };
         let json = serde_json::to_string(&msg).unwrap();
         assert!(!json.contains("public_url"), "None must be omitted: {json}");
@@ -2006,6 +2046,10 @@ mod tests {
         assert!(
             !json.contains("lobby_protocol_version"),
             "None must be omitted: {json}"
+        );
+        assert!(
+            !json.contains("wire_formats"),
+            "empty list must be omitted: {json}"
         );
     }
 

--- a/crates/server-core/tests/lobby_wire_contract.rs
+++ b/crates/server-core/tests/lobby_wire_contract.rs
@@ -47,6 +47,7 @@ fn canonical_client_frames_parse_via_broker() {
         build_commit: "abc".into(),
         protocol_version: sc::PROTOCOL_VERSION,
         lobby_protocol_version: Some(sc::LOBBY_PROTOCOL_VERSION),
+        wire_formats: Vec::new(),
     };
     let json = serde_json::to_string(&canonical).unwrap();
     match lb::parse_lobby_client_message(&json) {
@@ -190,6 +191,7 @@ fn server_hello_mode_byte_identical() {
         // None + skip_serializing_if keeps the wire identical to the lobby
         // broker's ServerHello, which has no public_url field.
         public_url: None,
+        wire_formats: Vec::new(),
     };
     assert_eq!(
         serde_json::to_string(&lb_hello).unwrap(),


### PR DESCRIPTION
## Summary

Adds additive WebSocket wire-format negotiation and a versioned gzip envelope for post-handshake JSON traffic. Old clients and servers keep using text frames, while negotiated peers use raw UTF-8 envelopes for small messages and gzip envelopes for larger messages.

Closes #8274.

## Files changed

- `Cargo.lock` — records the server compression dependency.
- `client/src/adapter/server-draft-adapter.ts` — supports binary WebSocket messages.
- `client/src/adapter/ws-adapter.ts` — sets the browser socket binary type.
- `client/src/network/protocol.ts` — reuses the shared envelope implementation.
- `client/src/network/__tests__/wireEnvelope.test.ts` — rejects oversized raw and compressed payloads.
- `client/src/network/wireEnvelope.ts` — provides the shared versioned raw/gzip codec.
- `client/src/services/__tests__/openPhaseSocket.test.ts` — covers negotiation and legacy fallback.
- `client/src/services/gzipEnvelopeSocket.ts` — wraps negotiated sockets with ordered envelope encoding/decoding.
- `client/src/services/nativeEngineSocket.ts` — exposes the shared message-listener transport surface.
- `client/src/services/openPhaseSocket.ts` — advertises and activates supported wire formats.
- `client/src/stores/multiplayerStore.ts` — accepts binary lobby messages.
- `crates/phase-server/Cargo.toml` — adds `flate2`.
- `crates/phase-server/src/main.rs` — negotiates the format and centralizes post-handshake framing.
- `crates/phase-server/src/wire.rs` — implements bounded server envelope encoding/decoding.
- `crates/server-core/src/protocol.rs` — adds typed additive wire-format capabilities to hello messages.
- `crates/server-core/tests/lobby_wire_contract.rs` — updates the wire-contract fixture.

## Track

Developer

## LLM

Model: GPT-5 (Codex; canonical id not exposed)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — transport/protocol change; no engine game logic

## CR references

None.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `cargo fmt --all -- --check` — clean.
- `cargo clippy -p phase-server -p server-core --all-targets -- -D warnings` — clean.
- `cargo test -p phase-server` — 177 passed, 0 failed.
- `cargo test -p server-core protocol` — 85 passed, 0 failed.
- Targeted post-rebase Rust envelope/negotiation tests — 5 passed, 0 failed.
- `pnpm typecheck` — clean.
- Five affected frontend suites — 137 passed, 0 failed.
- Security-finding regression plus affected wire suites — 221 passed, 0 failed; type-check and targeted lint clean.
- Malformed UTF-8 regression — raw and gzip-decoded invalid bytes rejected; 23 focused tests, type-check, and targeted lint clean.
- Close-order/rate-limit regressions — binary message precedes close; malformed gzip exhausts the inbound limit before a valid ping; focused tests and phase-server clippy clean.
- Rate-limit regression repeated 5 times after removing the timing-sensitive no-frame assumption — 5/5 passed.
- Real WebSocket negotiation test — negotiated client binary request decoded and server binary response decoded successfully.
- Mixed-version broadcast test — negotiated client received binary while the legacy client received text.
- Server envelope rejection tests — malformed gzip and oversized raw/gzip payloads rejected.

## Gate A

Gate A PASS head=ead82939f2d419add1fd2e78294dad0d24176908 base=03fbdf7096a47ddda0890d66216899f97a6366d0

## Anchored on

- `client/src/network/protocol.ts:394` — existing version-prefixed raw/gzip envelope for game DataChannels.
- `client/src/network/draftProtocol.ts:1044` — existing version-prefixed raw/gzip envelope for draft DataChannels.

## Final review-impl

Final review-impl PASS head=ead82939f2d419add1fd2e78294dad0d24176908

## Claimed parse impact

None.

## Scope Expansion

The native socket listener surface and P2P envelope helper were touched to share one transport contract and codec. Non-negotiated and native peers retain their existing text behavior.

## Validation Failures

The complete frontend suite had 4,674 passing tests and one unrelated pre-existing locale-sensitive failure in `AiDecisionOverlay.test.tsx`: the Danish Windows locale renders decimal commas while the test hardcodes decimal points. All 137 affected tests pass.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added negotiated gzip compression for WebSocket communication.
  * Larger messages can use binary envelopes to reduce transfer size.
  * Added wire-format capability exchange during connection handshakes.
  * Added binary message support across socket transports.

* **Compatibility**
  * Uncompressed communication remains available when compression is unsupported or not negotiated.
  * Unknown wire formats are handled safely for future protocol versions.

* **Bug Fixes**
  * Improved handling of malformed, unsupported, oversized, and queued messages.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->







