### PR TITLE
fix(client): preview a permanent that has no name (#8293)

### DIFF
--- a/client/src/components/card/CardPreview.tsx
+++ b/client/src/components/card/CardPreview.tsx
@@ -164,7 +164,9 @@ export function CardPreview({
   } | null>(null);
 
   useLayoutEffect(() => {
-    if (!cardName || handSourceObjectId == null || typeof document === "undefined") {
+    // Same question as the render gate below, spelled the same way: an empty
+    // name is a subject, only `null` is "nothing to preview".
+    if (cardName == null || handSourceObjectId == null || typeof document === "undefined") {
       setMeasuredHandOrigin(null);
       return;
     }
@@ -252,7 +254,13 @@ export function CardPreview({
 
   return (
     <AnimatePresence>
-      {cardName && handMeasurementReady ? (
+      {/* CR 709.5: a permanent with a shared type line doesn't have the name
+          of a half it hasn't unlocked, and CR 709.5d gives a copy of a Room
+          neither unlocked designation — so it has NO name at all. Its art
+          still resolves from the object's `printed_ref`, so an empty name is
+          a preview subject like any other. Only `null` is the caller's
+          "show nothing". */}
+      {cardName != null && handMeasurementReady ? (
         <CardPreviewInner
           key={previewKey}
           cardName={cardName}

--- a/client/src/components/card/__tests__/CardPreview.test.tsx
+++ b/client/src/components/card/__tests__/CardPreview.test.tsx
@@ -744,3 +744,69 @@ describe("CardPreview activate labels", () => {
     expect(container.textContent).not.toContain("~");
   });
 });
+
+describe("CardPreview nameless permanent", () => {
+  // CR 709.5: a permanent with a shared type line doesn't have the name of a
+  // half it hasn't unlocked, and CR 709.5d gives a copy of a Room neither
+  // unlocked designation — so it has no name at all. The hover must still
+  // answer with the card. An empty name is a real permanent; only `null`
+  // means "there is nothing to preview".
+  function namelessRoomCopy(overrides: Partial<GameObject> = {}): GameObject {
+    return battlefieldObject({
+      name: "",
+      printed_ref: { oracle_id: "greenhouse-oracle-id", face_name: "Greenhouse" },
+      ...overrides,
+    });
+  }
+
+  it("previews a battlefield permanent whose name is empty", () => {
+    const object = namelessRoomCopy();
+    useGameStore.setState({ gameState: gameStateWithObject(object), spellCosts: {} });
+
+    const { container } = render(
+      <CardPreview cardName="" objectId={object.id} position={{ x: 20, y: 20 }} />,
+    );
+
+    expect(container.querySelector("[data-card-preview]")).not.toBeNull();
+    // The identity the art is resolved FROM is the object's `printed_ref`,
+    // never the name — the empty name reaches the hook untouched beside it.
+    expect(useCardImage).toHaveBeenCalledWith(
+      "",
+      expect.objectContaining({
+        oracleId: "greenhouse-oracle-id",
+        faceName: "Greenhouse",
+      }),
+    );
+    expect(container.querySelector("img")?.getAttribute("src")).toBe(
+      "greenhouse-oracle-id.png",
+    );
+  });
+
+  it("measures a hand origin for a nameless card the same way", () => {
+    // The hand-origin gate asks the same question as the render gate. Left
+    // asking for truthiness it withholds `measuredHandOrigin`, and the preview
+    // never mounts — the same defect on the other branch.
+    const object = namelessRoomCopy({ zone: "Hand" });
+    useGameStore.setState({ gameState: gameStateWithObject(object), spellCosts: {} });
+    const source = document.createElement("div");
+    source.dataset.handCard = "";
+    source.dataset.handRotation = "-4";
+    source.dataset.objectId = String(object.id);
+    Object.defineProperty(source, "offsetWidth", { configurable: true, value: 120 });
+    source.matches = vi.fn((selector) => selector === ":hover");
+    source.getBoundingClientRect = () => ({
+      bottom: 748, height: 168, left: 220, right: 340, top: 580, width: 120,
+      x: 220, y: 580, toJSON: () => ({}),
+    });
+    document.body.appendChild(source);
+
+    const { container } = render(
+      <CardPreview cardName="" objectId={object.id} handSourceObjectId={object.id} />,
+    );
+
+    const preview = container.querySelector<HTMLElement>("[data-card-preview]");
+    expect(preview).not.toBeNull();
+    expect(preview?.style.bottom).toBe("0px");
+    source.remove();
+  });
+});

--- a/client/src/hooks/__tests__/useCardImage.test.tsx
+++ b/client/src/hooks/__tests__/useCardImage.test.tsx
@@ -769,4 +769,60 @@ describe("useCardImage", () => {
       usePreferencesStore.getState().clearAllArtOverrides();
     });
   });
+
+  it("resolves art from the oracle id alone when the card has no name (#8293)", async () => {
+    // CR 709.5 + CR 709.5d: a copy of a Room enters with neither half
+    // unlocked and so has no name, but its `printed_ref` still points at the
+    // printing. The empty name alone must not short-circuit the lookup — the
+    // bail-out requires the oracle id and the token ref to be absent too.
+    const fetchCardImageAsset = vi.fn();
+    const fetchCardImageAssetByOracleId = vi.fn().mockResolvedValue({
+      src: "https://img.example/greenhouse.jpg",
+      isRotated: false,
+      source: { kind: "remote", src: "https://img.example/greenhouse.jpg" },
+      semantic: { oracleId: "greenhouse-oracle", faceIndex: 0 },
+    });
+    vi.doMock("../../services/visualPacks/repository.ts", () => ({
+      visualPackRepository: {
+        currentRevision: () => "0",
+        subscribe: () => () => {},
+        resolve: vi.fn(async ({ remote }: { remote: { src: string } }) => ({
+          revision: "0",
+          sources: [{ kind: "remote" as const, src: remote.src }, { kind: "fallback" as const, src: null }],
+        })),
+      },
+    }));
+    vi.doMock("../../services/scryfall.ts", () => ({
+      deriveImageUrl: (url: string) => url,
+      fetchCardImageAsset,
+      fetchCardImageAssetByOracleId,
+      fetchCardImageByOracleId: vi.fn(),
+      fetchCardImageUrl: vi.fn(),
+      fetchTokenImageAssetByRef: vi.fn(),
+      fetchTokenImageUrl: vi.fn(),
+      findPrintingById: vi.fn(),
+      getCardPrintings: vi.fn().mockResolvedValue([]),
+      imageUrlSize: vi.fn().mockReturnValue(null),
+      isCardImageFlipLayoutSync: vi.fn().mockReturnValue(false),
+      isCardImageRotatedSync: vi.fn().mockReturnValue(false),
+      isLocaleArtReady: vi.fn().mockReturnValue(true),
+      loadLocaleArt: vi.fn().mockResolvedValue(new Map()),
+      resolveFaceIndexSync: vi.fn().mockReturnValue(null),
+      resolveOracleIdSync: vi.fn().mockReturnValue(null),
+      resolvePrintingImageUrl: vi.fn(),
+    }));
+
+    const { useCardImage } = await import("../useCardImage");
+    const { result } = renderHook(() =>
+      useCardImage("", { size: "normal", oracleId: "greenhouse-oracle", faceName: "Greenhouse" }),
+    );
+
+    await waitFor(() => expect(result.current.src).toBe("https://img.example/greenhouse.jpg"));
+    expect(fetchCardImageAssetByOracleId).toHaveBeenCalledWith(
+      "greenhouse-oracle",
+      "Greenhouse",
+      "normal",
+    );
+    expect(fetchCardImageAsset).not.toHaveBeenCalled();
+  });
 });


### PR DESCRIPTION
Addresses the second half of #8293. The first half is #8294.

## The defect

A permanent with a shared type line doesn't have the name of a half it hasn't unlocked (CR 709.5), and a copy of a Room enters the battlefield with **neither** unlocked designation (CR 709.5d) — so the permanent has no name at all. Hovering it showed **nothing whatsoever**: no art, no frame, no footer. Once the original left the battlefield, the player had no way to see what they still controlled.

## Cause

`CardPreview` gated its entire render on the **truthiness** of `cardName`:

```tsx
{cardName && handMeasurementReady ? (
```

An empty name is a real permanent, not an absent one. `null` is the caller's own "show nothing" signal, and `GameCardPreview` already uses it that way — it returns `null` for a suppressed shift-mode preview and for a face-down card in a hidden zone with no marker cause (issue #2889), which must keep rendering no preview. Asking `!= null` separates those two cases; asking for truthiness conflated them.

## Why nothing else had to change

The art never went through the name. `useCardImage` resolves through `printed_ref.oracle_id` / `face_name` — PR #7698's path — and the copy carries that ref because the layer-1 `CopyValues` application writes it in `layers.rs` beside `display_source`; `apply_copiable_values` never touches it. The hook's own bail-out is `!cardName && !oracleId && !resolvableTokenImageRef`, so an empty name alone never stopped the lookup. That is now pinned on the hook itself as well, next to the two existing empty-name cases.

The name line stays empty because the card **has** no name (CR 709.5d). The preview shows the card, which is all the player asked of it.

## The second gate

The hand-origin measurement gate asks the same question and now spells it the same way. Left disagreeing it would silently kill the preview again on the other branch.

It is **engine**-unreachable today: the empty name is zone-bound (`room::door_gated_battlefield_name` returns `None` off the battlefield) and a face-down card blanks `printed_ref` together with its name (`morph.rs`). But the gate is reachable through this component's own public `handSourceObjectId` prop, so it is pinned directly rather than argued.

## One-authority sweep

A sweep for the same shape found one other name-truthiness gate, `ChoiceModal`'s `CardTextboxPreview`. It is correctly different: that component resolves art from the name alone, with no object and no `printed_ref` — it has no second authority to fall back on, so gating on truthiness there costs nothing.

## Revert probes

| probe | red tests |
|---|---|
| render gate asks truthiness again | both nameless-permanent tests |
| hand-measurement gate asks truthiness again | the hand-origin test |

`devServerPort` flips red only under full-suite load on this machine (green 3/3 on its own); it starts real vite servers and is unrelated to this file.

## Playtest

Confirmed in a local build by the reporter, on the same board that produced the issue: a Room copy with both halves locked now answers the hover with its art.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2sfFLrGQyVSkdA5FDwMKP


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Nameless cards now display previews correctly instead of being treated as unavailable.
  - Card artwork resolves correctly for cards with an empty name, including alternate faces and battlefield or hand cards.

- **Tests**
  - Added regression coverage for nameless card previews, artwork lookup, and hand-card positioning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->