### PR TITLE
fix(client): park a free cast's {0} beside the printed cost, not on it (#8299)

### DIFF
--- a/client/src/components/mana/ManaCostPips.tsx
+++ b/client/src/components/mana/ManaCostPips.tsx
@@ -34,6 +34,14 @@ const PIP_SIZES: Record<PipSize, { container: string; gap: string; backdrop: str
 // together, and every card overlay wants the same placement.
 const FLUID_ANCHOR = "absolute right-[6.5%] top-[5%]";
 
+// A cost the engine reduced all the way to {0} is a badge of exactly ONE
+// symbol whose width never varies with the card. It also carries nothing the
+// player doesn't already know from the offer itself, while the mana VALUE it
+// would cover is what alternative costs are measured in — Amped Raptor pays an
+// amount of {E} equal to it, Nashi pays that much life. So this one badge parks
+// in the frame's right margin instead: beside the printed cost, not on it.
+const FLUID_ANCHOR_FREE = "absolute right-[0.5%] top-[5%]";
+
 interface ManaCostPipsProps {
   cost: ManaCost;
   isReduced?: boolean;
@@ -45,13 +53,15 @@ interface ManaCostPipsProps {
 export function ManaCostPips({ cost, isReduced, size = "md", className = "" }: ManaCostPipsProps) {
   const shards = manaCostToShards(cost);
   // Show {0} only when cost was reduced to zero (not for tokens/naturally free cards)
-  if (shards.length === 0 && isReduced) shards.push("0");
+  const isFreeBadge = shards.length === 0 && isReduced;
+  if (isFreeBadge) shards.push("0");
   if (shards.length === 0) return null;
 
   const s = PIP_SIZES[size];
+  const anchor = size !== "fluid" ? "" : isFreeBadge ? FLUID_ANCHOR_FREE : FLUID_ANCHOR;
 
   return (
-    <div className={`pointer-events-none ${size === "fluid" ? FLUID_ANCHOR : ""} ${className}`}>
+    <div className={`pointer-events-none ${anchor} ${className}`}>
       <div className={`relative flex ${s.gap}`}>
         <div
           data-mana-cost-backdrop

--- a/client/src/components/mana/__tests__/ManaCostPips.test.tsx
+++ b/client/src/components/mana/__tests__/ManaCostPips.test.tsx
@@ -1,0 +1,78 @@
+import { cleanup, render, within } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ManaCost } from "../../../adapter/types.ts";
+import { ManaCostPips } from "../ManaCostPips.tsx";
+
+const useManaSymbolImage = vi.hoisted(() => vi.fn());
+
+vi.mock("../../../hooks/useFixedVisualImage.ts", () => ({
+  useManaSymbolImage,
+}));
+
+beforeEach(() => {
+  useManaSymbolImage.mockImplementation((shard: string | null) => ({
+    src: shard ? `visual-pack://mana/${encodeURIComponent(shard)}` : null,
+    isLoading: false,
+    advanceFailedSource: vi.fn(),
+  }));
+});
+
+afterEach(() => {
+  cleanup();
+  vi.clearAllMocks();
+});
+
+/** Reads one of this component's own declared geometry values off the DOM. */
+function geometry(pattern: RegExp, className: string): number {
+  const match = pattern.exec(className);
+  if (!match) throw new Error(`no ${pattern} in ${className}`);
+  return Number(match[1]);
+}
+
+const RIGHT_OFFSET = /right-\[([\d.]+)%\]/;
+const PIP_WIDTH = /w-\[([\d.]+)cqi\]/;
+
+const printedCost: ManaCost = { type: "Cost", shards: ["Red"], generic: 1 };
+
+describe("ManaCostPips over card art", () => {
+  it("keeps a free-cast {0} clear of the printed cost instead of covering it", () => {
+    // A cost reduced to {0} says nothing the offer doesn't already say, while
+    // the mana VALUE underneath it is what alternative costs are measured in
+    // (Amped Raptor pays {E} equal to it, Nashi pays that much life). So this
+    // badge parks in the frame's right margin.
+    const printed = render(<ManaCostPips cost={printedCost} size="fluid" />);
+    const printedEdge = geometry(RIGHT_OFFSET, printed.container.firstElementChild!.className);
+
+    const free = render(<ManaCostPips cost={{ type: "NoCost" }} isReduced size="fluid" />);
+    const badge = free.container.firstElementChild!;
+    const pip = within(free.container).getByAltText("0").parentElement!;
+
+    // 1cqi is 1% of the card's width, so the two units are comparable: the
+    // whole free badge fits between the card edge and the printed cost's own
+    // right edge, which is where the ordinary badge is anchored.
+    expect(
+      geometry(RIGHT_OFFSET, badge.className) + geometry(PIP_WIDTH, pip.className),
+    ).toBeLessThanOrEqual(printedEdge);
+  });
+
+  it("still anchors a reduced cost on the printed cost — that is what is paid", () => {
+    // Only the {0} badge leaves the printed cost. A cost reduced to a real
+    // amount REPLACES the printed one, so covering it is the whole point of
+    // the overlay — it must stay farther from the card edge than the {0}.
+    const free = render(<ManaCostPips cost={{ type: "NoCost" }} isReduced size="fluid" />);
+    const reduced = render(
+      <ManaCostPips cost={{ type: "Cost", shards: [], generic: 3 }} isReduced size="fluid" />,
+    );
+
+    expect(
+      geometry(RIGHT_OFFSET, reduced.container.firstElementChild!.className),
+    ).toBeGreaterThan(geometry(RIGHT_OFFSET, free.container.firstElementChild!.className));
+  });
+
+  it("renders nothing for a naturally free card — no badge to place", () => {
+    const { container } = render(<ManaCostPips cost={{ type: "NoCost" }} size="fluid" />);
+
+    expect(container.firstElementChild).toBeNull();
+  });
+});


### PR DESCRIPTION
Addresses the first half of #8299.

The badge sits on the printed cost by design — `FLUID_ANCHOR` is "where the printed cost sits on an M15 frame". Art is fixed, the price is not.

That breaks at {0}. The badge is then one pip. It says nothing the offer doesn't. And it covers the one number still needed:

- **Amped Raptor** — "an amount of {E} equal to **its mana value**"
- **Nashi, Moon Sage's Scion** — "pay life equal to **its mana value**"

So the {0} badge — only that one — parks in the frame's right margin. Its width never varies with the card, so a fixed spot works: pip 6cqi, printed cost's right edge 6.5% in. It clears.

Nothing else moves. A cost reduced to a real amount still replaces the printed one.

## Probes

| probe | red |
|---|---|
| {0} back on the printed-cost anchor | clearance test |
| every fluid badge into the margin | both anchor tests |
| synthesize {0} for naturally free cards too | no-badge test |

## Playtest

Omniscience on the battlefield, hand costs of 1 / 4 / 6 symbols, plus a Room. Confirmed by the reporter.

## One question

Is that where you want it? If not, just tell me where and how you want it.

The second half of #8299 — a Room showing both halves' costs — needs the engine to say which half is left, so it waits on #8294.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01V2sfFLrGQyVSkdA5FDwMKP
