### PR TITLE
ci: publish the web image

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -687,6 +687,61 @@ jobs:
             ${{ env.IMAGE_NAME }}:${{ env.RELEASE_TAG }}
             ${{ env.IMAGE_NAME }}:latest
 
+  build-web-image:
+    name: Build Web Image
+    needs: [resolve-release-ref, build-wasm]
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      packages: write
+    env:
+      RELEASE_TAG: ${{ needs.resolve-release-ref.outputs.release_tag }}
+      RELEASE_SHA: ${{ needs.resolve-release-ref.outputs.release_sha }}
+      IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/phase-web
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ env.RELEASE_SHA }}
+
+      # The same bundle Pages gets, so the image and the official site are the
+      # same build. Its baked-in default lobby is this release's, which is what
+      # a self-hoster who configures nothing should reach; the chart overrides it
+      # at runtime through /config.js.
+      - name: Download frontend bundle
+        uses: actions/download-artifact@v4
+        with:
+          name: frontend-dist
+          path: client/dist
+
+      - name: Verify build context
+        run: test -s client/dist/index.html
+
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # No setup-qemu-action, unlike build-server-image: deploy/phase-web.Dockerfile
+      # is FROM + COPY with no RUN step, so there is nothing to execute in either
+      # target rootfs and buildx assembles both platforms natively.
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Build and push web image
+        uses: docker/build-push-action@v6
+        env:
+          DOCKER_BUILD_RECORD_UPLOAD: false
+        with:
+          context: client
+          file: deploy/phase-web.Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.IMAGE_NAME }}:${{ env.RELEASE_TAG }}
+            ${{ env.IMAGE_NAME }}:latest
+
   deploy-production:
     name: Deploy Production (Cloudflare Pages)
     needs: [build-wasm, release]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,12 @@ on:
   workflow_dispatch:
     inputs:
       tag:
-        description: Release tag to recover, e.g. v0.1.32
+        # Dispatch from the tag's own ref -- `gh workflow run release.yml --ref "$TAG"` --
+        # never from a branch. `build-web-image` deploys to the protected `release`
+        # environment, whose tag policy is matched against the run's GITHUB_REF and not
+        # against this input, so a branch-ref dispatch is turned away there; `release`
+        # needs that job, so the whole recovery run would then produce no release.
+        description: Release tag to recover, e.g. v0.1.32 (dispatch from that tag's ref, not from a branch)
         required: true
         type: string
 
@@ -695,6 +700,7 @@ jobs:
     permissions:
       contents: read
       packages: write
+    environment: release
     env:
       RELEASE_TAG: ${{ needs.resolve-release-ref.outputs.release_tag }}
       RELEASE_SHA: ${{ needs.resolve-release-ref.outputs.release_sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -700,7 +700,7 @@ jobs:
       RELEASE_SHA: ${{ needs.resolve-release-ref.outputs.release_sha }}
       IMAGE_NAME: ghcr.io/${{ github.repository_owner }}/phase-web
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
         with:
           ref: ${{ env.RELEASE_SHA }}
 
@@ -709,7 +709,7 @@ jobs:
       # a self-hoster who configures nothing should reach; the chart overrides it
       # at runtime through /config.js.
       - name: Download frontend bundle
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
         with:
           name: frontend-dist
           path: client/dist
@@ -718,7 +718,7 @@ jobs:
         run: test -s client/dist/index.html
 
       - name: Login to GHCR
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3.7.0
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
@@ -727,10 +727,10 @@ jobs:
       # No setup-qemu-action, unlike build-server-image: deploy/phase-web.Dockerfile
       # is FROM + COPY with no RUN step, so there is nothing to execute in either
       # target rootfs and buildx assembles both platforms natively.
-      - uses: docker/setup-buildx-action@v3
+      - uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
 
       - name: Build and push web image
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6.19.2
         env:
           DOCKER_BUILD_RECORD_UPLOAD: false
         with:
@@ -984,12 +984,13 @@ jobs:
 
   release:
     name: Create GitHub Release
-    needs: [resolve-release-ref, build-wasm, build-server, build-server-image]
+    needs: [resolve-release-ref, build-wasm, build-server, build-server-image, build-web-image]
     if: >-
       always() &&
       needs.build-wasm.result == 'success' &&
       needs.build-server.result == 'success' &&
-      needs.build-server-image.result == 'success'
+      needs.build-server-image.result == 'success' &&
+      needs.build-web-image.result == 'success'
     runs-on: ubuntu-latest
     timeout-minutes: 15
     env:


### PR DESCRIPTION
:robot: _AI text below_ :robot:

## Summary

Publishes `ghcr.io/phase-rs/phase-web` from the release workflow, giving the chart's `web.image.repository` default a real image to point at. Without this the self-hosted web option merged in #8295 has no upstream image — `ghcr.io/phase-rs/phase-web` currently 403s on every tag. Now also runs that job in the protected `release` environment, which the 00:05Z review asked for and which became safe once the environment's tag policy was widened.

## Files changed

- `.github/workflows/release.yml` — adds the `build-web-image` job; gates the `release` job on it; pins the job's five action refs to commit SHAs; runs the job in the `release` environment; documents on the `tag` input that a recovery dispatch must come from the tag's ref

## Track

Non-developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — CI workflow only; no `crates/engine/` game logic is touched.

## CR references

None. CI packaging change, no rules behavior.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- `actionlint .github/workflows/release.yml` — **one** finding, `if: ${{ false }}` on the deliberately disabled `deploy-server` job. That finding is pre-existing: the identical finding-set (line numbers stripped) comes back from `upstream/main` and from the pre-rebase PR head, so this change adds **zero** new findings. Positive control in the same sweep: a scratch copy with `runs-on:` misspelled produced 18 additional findings, so the comparison instrument is live.
- `python3 -c "yaml.safe_load(...)"` on the edited workflow — parses. Asserted structurally rather than by reading the diff: exactly one job declares an environment and it is `{'build-web-image': 'release'}`; `release.needs` still contains `build-web-image`; `release.if` still requires `needs.build-web-image.result == 'success'`; the `tag` input is still `required: true`, `type: string`.
- `git diff upstream/main --name-only` — exactly `.github/workflows/release.yml`; count of non-`release.yml` paths is 0 against a control count of 1 for `release.yml`.
- `gh api repos/phase-rs/phase/environments/release/deployment-branch-policies` — one policy, `{"name":"v[0-9]*.[0-9]*.[0-9]*","type":"tag"}`. This is the precondition that makes the environment attach safe; see the comment below for what it replaced.
- `gh api repos/phase-rs/phase/environments/release` — `protection_rules` is exactly `[{"type":"branch_policy"}]`. No required reviewers and no wait timer, so attaching the job adds a ref check, not a human gate that would pause every release.
- **The job itself is CI-owned and cannot run before merge**: it triggers on release publication, so its first real execution is the next release. No cargo or pnpm build is warranted for a workflow-only delta, and none was run. The multi-arch claim is a review-time reading of the workflow, not a measured manifest — flagged rather than asserted.

## Gate A

Gate A PASS head=4f7b9593a4068499981edf18195c24d6dcb7656b base=d6d28370c09242182488cac72e16e5a84941885f

**Disclosure — this gate is inapplicable to this diff rather than evidence for it.** The PR changes one YAML file and zero `.rs` files. The run is not vacuous (297 commits in its range), but the gate derives its base from `origin/main`, which is the fork; the 540 `.rs` files it walks are fork-to-upstream drift, not anything this PR touched.

## Anchored on

- `.github/workflows/release.yml` — `build-server-image` job, same seam: same GHCR login, same `docker/build-push-action`, same release-sha checkout.
- `.github/workflows/deploy.yml:723` — `build-pages` declares `environment: github-pages` with `permissions: contents/pages/id-token` and **no** `deployments:` entry. That is the in-repo precedent that an environment declaration needs no extra permission, and it is a live one: the `Build & Deploy Pages` job succeeded in runs 33752719448 and 33714374953.

## Final review-impl

Final review-impl PASS head=4f7b9593a4068499981edf18195c24d6dcb7656b

Scope of that review is the three-line environment delta, not a repeat of the whole job. Two failure modes an environment attach can introduce were checked rather than reasoned about: (1) it does not need a `deployments:` permission the job lacks — the `build-pages` precedent above is measured, not recalled; (2) it cannot change which secrets resolve, because the job references exactly one secret in its whole body, `secrets.GITHUB_TOKEN`, the automatic per-run token.

## Claimed parse impact

None.

## Scope Expansion

None. This is the second half of the split ruled on for #8295. The `helm-chart.yml` wiring that originally sat in this commit landed in #8295 instead, and has been dropped here rather than duplicated. The `tag` input's description changed in the same commit as the environment attach because the attach is what creates the constraint it documents — see the comment below.

## Validation Failures

None.

## CI Failures

`Superagent Security Scan` failed on the previous head `f4e799828`. Its two findings duplicated maintainer blockers 2 and 3; blocker 2 (SHA-pinning) was fixed at that head and blocker 3 (the `release` environment) is fixed at this one, so the scan is expected to re-evaluate clean on `4f7b9593a`. Reporting it as unresolved until it actually re-runs rather than declaring it fixed.

---

**Maintainer-handled by policy.** `.agents/pr-review-policy.toml` lists `.github/workflows/**` under `[hard_stops]`, and that classification is per-PR, so this cannot be self-enqueued. The 14:09Z sweep asked for two things before re-review — an explicit release-infrastructure maintainer review, and the security check resolved on the current head. This push addresses the second; the first is a request I cannot fill myself.

Flagging one design point for your judgement, unchanged from the previous head: the job omits `setup-qemu-action`, unlike `build-server-image`. `deploy/phase-web.Dockerfile` is `FROM` + `COPY` with no `RUN` step, so there is nothing to execute in either target rootfs and buildx should assemble both platforms natively — but that is a reading of the Dockerfile, not something measurable before the job first runs.
