### PR TITLE
fix(engine): order shock-land enter-tapped against "lands enter untapped"

### DIFF
--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -4272,14 +4272,14 @@ describe("P2P wire-protocol version gate", () => {
   // Both halves stamp LITERALS. A frame built from WIRE_PROTOCOL_VERSION
   // cannot tell a bumped client from an unbumped one, which is why every
   // other handshake fixture in the suite is useless as an instrument for a
-  // bump. Revert 46 → 45 and BOTH halves red: the v45 frame stops being
-  // refused, and the v46 frame stops being admitted. The admitting half is
-  // the reach-guard — without it "refuses v45" is also satisfied by a client
+  // bump. Revert 47 → 46 and BOTH halves red: the v46 frame stops being
+  // refused, and the v47 frame stops being admitted. The admitting half is
+  // the reach-guard — without it "refuses v46" is also satisfied by a client
   // that refuses everything.
-  it("refuses the previous wire protocol (v45) and admits its own (v46)", async () => {
+  it("refuses the previous wire protocol (v46) and admits its own (v47)", async () => {
     const refusing = makeGuest();
     await refusing.adapter.initialize();
-    await refusing.conn.simulateData(setupFrameAt(45));
+    await refusing.conn.simulateData(setupFrameAt(46));
 
     await expect(refusing.adapter.initializeGame()).rejects.toMatchObject({
       code: "P2P_REJECTED",
@@ -4291,7 +4291,7 @@ describe("P2P wire-protocol version gate", () => {
 
     const admitting = makeGuest();
     await admitting.adapter.initialize();
-    await admitting.conn.simulateData(setupFrameAt(46));
+    await admitting.conn.simulateData(setupFrameAt(47));
 
     await expect(admitting.adapter.initializeGame()).resolves.toBeDefined();
     expect(admitting.emitted).not.toHaveBeenCalledWith(

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -2085,7 +2085,7 @@ export type WaitingFor =
   | { type: "DeclareAttackers"; data: { player: PlayerId; valid_attacker_ids: ObjectId[]; valid_attack_targets?: AttackTarget[]; valid_attack_targets_by_attacker?: Record<string, AttackTarget[]>; attacker_constraints?: Record<string, CombatRequirement> } }
   | { type: "DeclareBlockers"; data: { player: PlayerId; valid_blocker_ids: ObjectId[]; valid_block_targets: Record<string, ObjectId[]>; block_requirements?: Record<string, BlockRequirementInfo>; blocker_constraints?: Record<string, CombatRequirement> } }
   | { type: "GameOver"; data: { winner: PlayerId | null } }
-  | { type: "ReplacementChoice"; data: { player: PlayerId; candidate_count: number; candidates?: ReplacementCandidateSummary[]; kind?: ReplacementChoiceKind } }
+  | { type: "ReplacementChoice"; data: { player: PlayerId; candidate_count: number; candidates?: ReplacementCandidateSummary[]; kind?: ReplacementChoiceKind; last_applied_decides?: boolean } }
   | { type: "EntryControllerChoice"; data: { player: PlayerId; candidates: PlayerId[] } }
   | { type: "OrderTriggers"; data: { player: PlayerId; triggers: PendingTriggerSummary[] } }
   | { type: "CopyTargetChoice"; data: { player: PlayerId; source_id: ObjectId; valid_targets: ObjectId[]; max_mana_value?: number | null; purpose?: { type: "BecomeCopy" | "PersistChosenAttribute" } } }

--- a/client/src/adapter/types.ts
+++ b/client/src/adapter/types.ts
@@ -1957,6 +1957,22 @@ export interface ReplacementCandidateSummary {
   description: string;
 }
 
+// CR 616.1: which kind of decision a ReplacementChoice is asking for. One
+// WaitingFor serves three structurally different prompts and the candidate list
+// alone cannot distinguish them (an accept/decline pair and a two-effect
+// ordering prompt are both "two candidates"). Engine-owned — never infer this
+// from label text.
+//   Order                  - CR 616.1e: arrange competing effects. CR 616.1f
+//                            applies them in sequence, so the LAST one applied
+//                            is the one whose write survives.
+//   OptionalBranch         - CR 614.1: a "you may" yes/no; index 0 accepts,
+//                            index 1 declines. Never a sortable list.
+//   SearchFoundDestination - alternative destinations for a found card.
+export type ReplacementChoiceKind =
+  | { type: "Order" }
+  | { type: "OptionalBranch" }
+  | { type: "SearchFoundDestination" };
+
 export type EmergeSacrificeQuality =
   | { type: "Artifact" }
   | { type: "Battle" }
@@ -2069,7 +2085,7 @@ export type WaitingFor =
   | { type: "DeclareAttackers"; data: { player: PlayerId; valid_attacker_ids: ObjectId[]; valid_attack_targets?: AttackTarget[]; valid_attack_targets_by_attacker?: Record<string, AttackTarget[]>; attacker_constraints?: Record<string, CombatRequirement> } }
   | { type: "DeclareBlockers"; data: { player: PlayerId; valid_blocker_ids: ObjectId[]; valid_block_targets: Record<string, ObjectId[]>; block_requirements?: Record<string, BlockRequirementInfo>; blocker_constraints?: Record<string, CombatRequirement> } }
   | { type: "GameOver"; data: { winner: PlayerId | null } }
-  | { type: "ReplacementChoice"; data: { player: PlayerId; candidate_count: number; candidates?: ReplacementCandidateSummary[] } }
+  | { type: "ReplacementChoice"; data: { player: PlayerId; candidate_count: number; candidates?: ReplacementCandidateSummary[]; kind?: ReplacementChoiceKind } }
   | { type: "EntryControllerChoice"; data: { player: PlayerId; candidates: PlayerId[] } }
   | { type: "OrderTriggers"; data: { player: PlayerId; triggers: PendingTriggerSummary[] } }
   | { type: "CopyTargetChoice"; data: { player: PlayerId; source_id: ObjectId; valid_targets: ObjectId[]; max_mana_value?: number | null; purpose?: { type: "BecomeCopy" | "PersistChosenAttribute" } } }

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -437,7 +437,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 62;
+export const PROTOCOL_VERSION = 63;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.

--- a/client/src/components/modal/ReplacementModal.tsx
+++ b/client/src/components/modal/ReplacementModal.tsx
@@ -171,9 +171,20 @@ export function ReplacementModal() {
                 key={candidateIndex}
                 value={candidateIndex}
                 whileDrag={{ scale: 1.03, zIndex: 20 }}
-                // `touch-none` keeps a touch-drag from scrolling the dialog
-                // instead of reordering (the codebase's established pattern).
-                className="flex touch-none cursor-grab items-start gap-2 rounded-[16px] border border-white/8 bg-white/5 px-4 py-3 active:cursor-grabbing"
+                // `!touch-none` (note the `!` — it emits `!important`) keeps a
+                // touch-drag reordering the list instead of scrolling the
+                // dialog. The bang is load-bearing and must not be "cleaned up":
+                // `Reorder.Item` writes its own INLINE `touch-action` for the
+                // drag axis (`pan-x` when `axis="y"`), and framer re-asserts it,
+                // so neither a plain `touch-none` class nor an inline
+                // `style={{ touchAction }}` survives — only an `!important` rule
+                // wins the cascade against it. Verified in-browser under touch
+                // emulation: without the bang the computed value is `pan-x` and
+                // a vertical touch-drag is claimed by page scroll. The
+                // codebase's other `touch-none` usages sit on plain elements
+                // driven by the hand-rolled pointer engine, where nothing
+                // competes with the class.
+                className="flex !touch-none cursor-grab items-start gap-2 rounded-[16px] border border-white/8 bg-white/5 px-4 py-3 active:cursor-grabbing"
                 {...(candidate ? hoverProps(candidate.source_id) : {})}
               >
                 <div className="flex-1 text-left">

--- a/client/src/components/modal/ReplacementModal.tsx
+++ b/client/src/components/modal/ReplacementModal.tsx
@@ -1,5 +1,6 @@
-import { useCallback } from "react";
+import { useCallback, useEffect, useState } from "react";
 import { useTranslation } from "react-i18next";
+import { Reorder } from "framer-motion";
 
 import type { ReplacementCandidateSummary } from "../../adapter/types.ts";
 import { useInspectHoverProps } from "../../hooks/useInspectHoverProps.ts";
@@ -11,12 +12,20 @@ const EMPTY_CANDIDATES: ReplacementCandidateSummary[] = [];
 
 /**
  * CR 616.1 / CR 614: Surfaced when the local player must apply an optional
- * replacement effect ("you may") or choose the order in which multiple
- * applicable replacements apply. The engine owns all logic and provides one
- * {@link ReplacementCandidateSummary} per option, so each button can show the
- * source object (or rule-based virtual replacement) creating that effect.
- * This component only dispatches the chosen index — no re-derivation from
- * `state.objects`.
+ * replacement effect ("you may"), choose between alternative destinations, or
+ * order two-or-more competing replacements. The engine owns all logic and
+ * provides one {@link ReplacementCandidateSummary} per option plus a `kind`
+ * discriminator; this component only permutes an index array or dispatches a
+ * chosen index. No rules computation, and the prompt shape is NEVER inferred
+ * from label text.
+ *
+ * CR 616.1e/f — why ordering needs its own presentation: the engine applies the
+ * selected candidate, then re-prompts for whatever is still applicable, so the
+ * effect applied LAST is the one whose write survives. Rendering the candidates
+ * as plain "pick one" buttons made outcome-worded labels ("Enters untapped")
+ * state the opposite of the result, because picking one applied it FIRST and
+ * let the other overwrite it. The ordering list shows the whole sequence with
+ * explicit applied-first/applied-last framing instead.
  */
 export function ReplacementModal() {
   const { t } = useTranslation("game");
@@ -31,6 +40,34 @@ export function ReplacementModal() {
   const candidates: ReplacementCandidateSummary[] = isReplacementChoice
     ? (waitingFor.data.candidates ?? EMPTY_CANDIDATES)
     : EMPTY_CANDIDATES;
+  // CR 616.1: only a distinct multi-candidate set is an ordering decision. The
+  // engine defaults to `Order`; an accept/decline or destination pick is never
+  // sortable. A 1-candidate prompt has no order to choose.
+  const kindType =
+    waitingFor?.type === "ReplacementChoice"
+      ? (waitingFor.data.kind?.type ?? "Order")
+      : "Order";
+  const isOrdering = kindType === "Order" && candidateCount > 1;
+
+  // Local UI state: the chosen permutation (indices into `candidates`).
+  // Identity to start; reset on every new prompt because successive CR 616.1f
+  // rounds can carry the same candidate count.
+  const [order, setOrder] = useState<number[]>(() =>
+    Array.from({ length: candidateCount }, (_, i) => i),
+  );
+  useEffect(() => {
+    setOrder(Array.from({ length: candidateCount }, (_, i) => i));
+  }, [candidateCount, candidates, isReplacementChoice]);
+
+  const move = useCallback((from: number, to: number) => {
+    setOrder((prev) => {
+      if (to < 0 || to >= prev.length) return prev;
+      const next = prev.slice();
+      const [item] = next.splice(from, 1);
+      next.splice(to, 0, item);
+      return next;
+    });
+  }, []);
 
   const handleChoose = useCallback(
     (index: number) => {
@@ -39,44 +76,156 @@ export function ReplacementModal() {
     [dispatch],
   );
 
+  // CR 616.1f: submit only the first entry. The engine applies it and re-prompts
+  // with whatever remains applicable — which may legitimately differ from this
+  // plan (CR 616.2: applying one effect can add or remove others, as with a
+  // copy effect that strips the enters-tapped ability). Sending the whole
+  // permutation blind would be wrong for those classes.
+  const handleConfirmOrder = useCallback(() => {
+    const first = order[0];
+    if (first !== undefined) handleChoose(first);
+  }, [handleChoose, order]);
+
   if (!isReplacementChoice || candidateCount === 0) return null;
 
   const indices = Array.from({ length: candidateCount }, (_, i) => i);
+  const labelFor = (index: number) =>
+    candidates[index]?.description ||
+    t("replacement.candidateFallback", { number: index + 1 });
+
+  if (!isOrdering) {
+    return (
+      <DialogShell
+        eyebrow={t("replacement.eyebrow")}
+        title={t("replacement.title")}
+        subtitle={t("replacement.chooseSubtitle")}
+        size="md"
+        scrollable
+      >
+        <div className="px-3 py-3 lg:px-5 lg:py-5">
+          <div className="flex flex-col gap-2">
+            {indices.map((index) => {
+              const candidate = candidates[index];
+              return (
+                <button
+                  key={index}
+                  onClick={() => handleChoose(index)}
+                  {...(candidate ? hoverProps(candidate.source_id) : {})}
+                  className="min-h-11 rounded-[16px] border border-white/8 bg-white/5 px-4 py-3 text-left transition hover:bg-white/8 hover:ring-1 hover:ring-cyan-400/40"
+                >
+                  <span className="block font-semibold text-white">
+                    <RichLabel text={labelFor(index)} size="sm" />
+                  </span>
+                  {candidate?.source_name && (
+                    <span className="mt-0.5 block text-xs text-white/60">
+                      {candidate.source_name}
+                    </span>
+                  )}
+                </button>
+              );
+            })}
+          </div>
+        </div>
+      </DialogShell>
+    );
+  }
+
+  // The winning effect is the one applied last — the bottom of the list.
+  const winningLabel = labelFor(order[order.length - 1] ?? 0);
 
   return (
     <DialogShell
       eyebrow={t("replacement.eyebrow")}
       title={t("replacement.title")}
-      subtitle={t("replacement.subtitle")}
+      subtitle={t("replacement.orderSubtitle")}
       size="md"
       scrollable
+      footer={
+        <button
+          type="button"
+          onClick={handleConfirmOrder}
+          className="min-h-11 rounded-[16px] bg-cyan-500/80 px-5 py-3 font-semibold text-white transition hover:bg-cyan-500"
+        >
+          {t("replacement.confirmOrder")}
+        </button>
+      }
     >
       <div className="px-3 py-3 lg:px-5 lg:py-5">
-        <div className="flex flex-col gap-2">
-          {indices.map((index) => {
-            const candidate = candidates[index];
-            const label =
-              candidate?.description ||
-              t("replacement.candidateFallback", { number: index + 1 });
+        <div className="mb-2 text-xs uppercase tracking-wide text-white/50">
+          {t("replacement.appliedFirst")}
+        </div>
+        <Reorder.Group
+          as="ol"
+          axis="y"
+          values={order}
+          onReorder={setOrder}
+          className="flex flex-col gap-2"
+        >
+          {order.map((candidateIndex, position) => {
+            const candidate = candidates[candidateIndex];
             return (
-              <button
-                key={index}
-                onClick={() => handleChoose(index)}
+              <Reorder.Item
+                as="li"
+                // Index-keyed, not source-keyed: an optional replacement sends
+                // the same `source_id` twice, so source ids are not unique.
+                key={candidateIndex}
+                value={candidateIndex}
+                whileDrag={{ scale: 1.03, zIndex: 20 }}
+                // `touch-none` keeps a touch-drag from scrolling the dialog
+                // instead of reordering (the codebase's established pattern).
+                className="flex touch-none cursor-grab items-start gap-2 rounded-[16px] border border-white/8 bg-white/5 px-4 py-3 active:cursor-grabbing"
                 {...(candidate ? hoverProps(candidate.source_id) : {})}
-                className="min-h-11 rounded-[16px] border border-white/8 bg-white/5 px-4 py-3 text-left transition hover:bg-white/8 hover:ring-1 hover:ring-cyan-400/40"
               >
-                <span className="block font-semibold text-white">
-                  <RichLabel text={label} size="sm" />
-                </span>
-                {candidate?.source_name && (
-                  <span className="mt-0.5 block text-xs text-white/60">
-                    {candidate.source_name}
-                  </span>
-                )}
-              </button>
+                <div className="flex-1 text-left">
+                  <div className="font-semibold text-white">
+                    <RichLabel text={labelFor(candidateIndex)} size="sm" />
+                  </div>
+                  {candidate?.source_name && (
+                    <div className="mt-0.5 text-xs text-white/60">
+                      {candidate.source_name}
+                    </div>
+                  )}
+                </div>
+                {/* Arrow controls are the accessible path: a drag-only list is
+                    unusable by keyboard and screen-reader users. */}
+                <div className="flex flex-col gap-1">
+                  <button
+                    type="button"
+                    aria-label={t("replacement.moveUp")}
+                    disabled={position === 0}
+                    onClick={() => move(position, position - 1)}
+                    className="min-h-8 rounded border border-white/10 px-2 text-white/80 transition hover:bg-white/10 disabled:opacity-30"
+                  >
+                    ▲
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={t("replacement.moveDown")}
+                    disabled={position === order.length - 1}
+                    onClick={() => move(position, position + 1)}
+                    className="min-h-8 rounded border border-white/10 px-2 text-white/80 transition hover:bg-white/10 disabled:opacity-30"
+                  >
+                    ▼
+                  </button>
+                </div>
+              </Reorder.Item>
             );
           })}
+        </Reorder.Group>
+        <div className="mt-2 text-xs uppercase tracking-wide text-cyan-300/80">
+          {t("replacement.appliedLast")}
         </div>
+        {/* State the concrete outcome so the player never has to infer it from
+            the ordering semantics. */}
+        <div className="mt-3 rounded-[12px] border border-cyan-400/20 bg-cyan-400/5 px-3 py-2 text-sm font-semibold text-cyan-200">
+          <RichLabel
+            text={t("replacement.resultLabel", { outcome: winningLabel })}
+            size="sm"
+          />
+        </div>
+        <p className="mt-2 text-center text-xs text-white/40">
+          {t("replacement.dragHint")}
+        </p>
       </div>
     </DialogShell>
   );

--- a/client/src/components/modal/ReplacementModal.tsx
+++ b/client/src/components/modal/ReplacementModal.tsx
@@ -48,6 +48,12 @@ export function ReplacementModal() {
       ? (waitingFor.data.kind?.type ?? "Order")
       : "Order";
   const isOrdering = kindType === "Order" && candidateCount > 1;
+  // CR 616.1f: engine-computed — does the last-applied candidate alone decide
+  // the outcome? Absent (legacy/unknown) means "don't claim a winner".
+  const lastAppliedDecides =
+    waitingFor?.type === "ReplacementChoice"
+      ? (waitingFor.data.last_applied_decides ?? false)
+      : false;
 
   // Local UI state: the chosen permutation (indices into `candidates`).
   // Identity to start; reset on every new prompt because successive CR 616.1f
@@ -55,9 +61,21 @@ export function ReplacementModal() {
   const [order, setOrder] = useState<number[]>(() =>
     Array.from({ length: candidateCount }, (_, i) => i),
   );
+  // Reset on a genuinely NEW prompt, keyed on stable CONTENT rather than array
+  // identity. `candidates` is a fresh array on every engine snapshot commit, so
+  // depending on it would blow away an in-progress reorder whenever any
+  // unrelated state pushed — the user would watch their arrangement snap back
+  // mid-drag. Successive CR 616.1f rounds change the candidate set, so the
+  // identity key changes and the reset still fires when it should.
+  const promptKey = isReplacementChoice
+    ? `${candidateCount}|${candidates.map((c) => `${c.source_id}:${c.description}`).join("|")}`
+    : "";
   useEffect(() => {
     setOrder(Array.from({ length: candidateCount }, (_, i) => i));
-  }, [candidateCount, candidates, isReplacementChoice]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps -- promptKey encodes
+    // candidateCount + candidate content; adding `candidates` would reintroduce
+    // the identity-churn reset this key exists to avoid.
+  }, [promptKey]);
 
   const move = useCallback((from: number, to: number) => {
     setOrder((prev) => {
@@ -130,14 +148,25 @@ export function ReplacementModal() {
     );
   }
 
-  // The winning effect is the one applied last — the bottom of the list.
-  const winningLabel = labelFor(order[order.length - 1] ?? 0);
+  // CR 616.1f: name a concrete winning result ONLY when the engine says the
+  // last-applied effect decides the outcome. That holds for whole-field
+  // overwrites (the enters-tapped class) but NOT for compositional collisions
+  // — a damage doubler ordered against a damage adder has both effects apply,
+  // so there is no winner to name and the order changes the arithmetic instead.
+  // The engine owns this distinction; never infer it from the candidate labels.
+  const winningLabel = lastAppliedDecides
+    ? labelFor(order[order.length - 1] ?? 0)
+    : null;
 
   return (
     <DialogShell
       eyebrow={t("replacement.eyebrow")}
       title={t("replacement.title")}
-      subtitle={t("replacement.orderSubtitle")}
+      subtitle={
+        lastAppliedDecides
+          ? t("replacement.orderSubtitle")
+          : t("replacement.orderSubtitleComposing")
+      }
       size="md"
       scrollable
       footer={
@@ -152,7 +181,9 @@ export function ReplacementModal() {
     >
       <div className="px-3 py-3 lg:px-5 lg:py-5">
         <div className="mb-2 text-xs uppercase tracking-wide text-white/50">
-          {t("replacement.appliedFirst")}
+          {lastAppliedDecides
+            ? t("replacement.appliedFirst")
+            : t("replacement.appliedEarlier")}
         </div>
         <Reorder.Group
           as="ol"
@@ -188,6 +219,14 @@ export function ReplacementModal() {
                 {...(candidate ? hoverProps(candidate.source_id) : {})}
               >
                 <div className="flex-1 text-left">
+                  {/* Position is visually obvious from the list order but
+                      invisible to a screen reader, which reads rows in isolation. */}
+                  <span className="sr-only">
+                    {t("replacement.positionAnnounce", {
+                      position: position + 1,
+                      total: order.length,
+                    })}
+                  </span>
                   <div className="font-semibold text-white">
                     <RichLabel text={labelFor(candidateIndex)} size="sm" />
                   </div>
@@ -202,7 +241,9 @@ export function ReplacementModal() {
                 <div className="flex flex-col gap-1">
                   <button
                     type="button"
-                    aria-label={t("replacement.moveUp")}
+                    aria-label={t("replacement.moveUpNamed", {
+                      name: labelFor(candidateIndex),
+                    })}
                     disabled={position === 0}
                     onClick={() => move(position, position - 1)}
                     className="min-h-8 rounded border border-white/10 px-2 text-white/80 transition hover:bg-white/10 disabled:opacity-30"
@@ -211,7 +252,9 @@ export function ReplacementModal() {
                   </button>
                   <button
                     type="button"
-                    aria-label={t("replacement.moveDown")}
+                    aria-label={t("replacement.moveDownNamed", {
+                      name: labelFor(candidateIndex),
+                    })}
                     disabled={position === order.length - 1}
                     onClick={() => move(position, position + 1)}
                     className="min-h-8 rounded border border-white/10 px-2 text-white/80 transition hover:bg-white/10 disabled:opacity-30"
@@ -224,16 +267,24 @@ export function ReplacementModal() {
           })}
         </Reorder.Group>
         <div className="mt-2 text-xs uppercase tracking-wide text-cyan-300/80">
-          {t("replacement.appliedLast")}
+          {lastAppliedDecides
+            ? t("replacement.appliedLast")
+            : t("replacement.appliedLater")}
         </div>
         {/* State the concrete outcome so the player never has to infer it from
-            the ordering semantics. */}
-        <div className="mt-3 rounded-[12px] border border-cyan-400/20 bg-cyan-400/5 px-3 py-2 text-sm font-semibold text-cyan-200">
-          <RichLabel
-            text={t("replacement.resultLabel", { outcome: winningLabel })}
-            size="sm"
-          />
-        </div>
+            the ordering semantics — but only when one effect actually wins. */}
+        {winningLabel !== null ? (
+          <div className="mt-3 rounded-[12px] border border-cyan-400/20 bg-cyan-400/5 px-3 py-2 text-sm font-semibold text-cyan-200">
+            <RichLabel
+              text={t("replacement.resultLabel", { outcome: winningLabel })}
+              size="sm"
+            />
+          </div>
+        ) : (
+          <div className="mt-3 rounded-[12px] border border-white/10 bg-white/5 px-3 py-2 text-sm text-white/70">
+            {t("replacement.composesNote")}
+          </div>
+        )}
         <p className="mt-2 text-center text-xs text-white/40">
           {t("replacement.dragHint")}
         </p>

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -2253,7 +2253,15 @@
   "replacement": {
     "eyebrow": "Auflösungsreihenfolge",
     "title": "Ersatzeffekte",
-    "subtitle": "Wähle, welcher Ersatzeffekt zuerst angewendet wird.",
+    "orderSubtitle": "Diese Effekte ändern alle, wie dieses Ereignis abläuft. Ziehe, um die Reihenfolge festzulegen — der zuletzt angewendete Effekt ist der wirksame (CR 616.1).",
+    "appliedFirst": "Zuerst angewendet (wird überschrieben)",
+    "appliedLast": "Zuletzt angewendet — dieser gilt",
+    "resultLabel": "Ergebnis: {{outcome}}",
+    "confirmOrder": "Reihenfolge bestätigen",
+    "moveUp": "Nach vorne",
+    "moveDown": "Nach hinten",
+    "dragHint": "Zum Umsortieren ziehen oder die Pfeile benutzen.",
+    "chooseSubtitle": "Wähle, welcher Ersatzeffekt angewendet wird.",
     "candidateFallback": "Ersatzeffekt {{number}}"
   },
   "retargetChoice": {

--- a/client/src/i18n/locales/de/game.json
+++ b/client/src/i18n/locales/de/game.json
@@ -6,7 +6,13 @@
     "prohibited": "Das Aktivieren dieser Fähigkeit ist verboten",
     "costNotPayableNow": "Du kannst diese Kosten gerade nicht bezahlen"
   },
-  "manaSourceSelection": { "title": "Manaquelle wählen", "description": "Diese Manafähigkeit erfordert das Opfern einer bleibenden Karte.", "sacrifice": "Opfern", "back": "Zurück zur Manabezahlung", "unknownSource": "Manaquelle" },
+  "manaSourceSelection": {
+    "title": "Manaquelle wählen",
+    "description": "Diese Manafähigkeit erfordert das Opfern einer bleibenden Karte.",
+    "sacrifice": "Opfern",
+    "back": "Zurück zur Manabezahlung",
+    "unknownSource": "Manaquelle"
+  },
   "comboShortcut": {
     "declareTitle": "Loop Shortcut",
     "declareSubtitle": "You control a loop with a determined outcome. Take the shortcut to resolve it.",
@@ -71,9 +77,23 @@
   },
   "restoredAutomation": {
     "dismiss": "Schließen",
-    "noop": {"title": "Gespeichertes Spiel geladen", "summary_one": "Keine Stapelautomatisierung zum Fortsetzen erforderlich.", "summary_other": "Keine Stapelautomatisierung zum Fortsetzen erforderlich."},
-    "progressed": {"title": "Stapelautomatisierung fortgesetzt", "summary_one": "Die Engine hat {{count}} automatisierte Auflösung abgeschlossen.", "summary_other": "Die Engine hat {{count}} automatisierte Auflösungen abgeschlossen.", "omitted_one": "{{count}} Zwischenereignis wurde ausgelassen.", "omitted_other": "{{count}} Zwischenereignisse wurden ausgelassen."},
-    "zeroResolutionRepair": {"title": "Stapelautomatisierung repariert", "summary_one": "Die gespeicherte Automatisierung wurde vor der Fortsetzung sicher repariert.", "summary_other": "Die gespeicherte Automatisierung wurde vor der Fortsetzung sicher repariert."}
+    "noop": {
+      "title": "Gespeichertes Spiel geladen",
+      "summary_one": "Keine Stapelautomatisierung zum Fortsetzen erforderlich.",
+      "summary_other": "Keine Stapelautomatisierung zum Fortsetzen erforderlich."
+    },
+    "progressed": {
+      "title": "Stapelautomatisierung fortgesetzt",
+      "summary_one": "Die Engine hat {{count}} automatisierte Auflösung abgeschlossen.",
+      "summary_other": "Die Engine hat {{count}} automatisierte Auflösungen abgeschlossen.",
+      "omitted_one": "{{count}} Zwischenereignis wurde ausgelassen.",
+      "omitted_other": "{{count}} Zwischenereignisse wurden ausgelassen."
+    },
+    "zeroResolutionRepair": {
+      "title": "Stapelautomatisierung repariert",
+      "summary_one": "Die gespeicherte Automatisierung wurde vor der Fortsetzung sicher repariert.",
+      "summary_other": "Die gespeicherte Automatisierung wurde vor der Fortsetzung sicher repariert."
+    }
   },
   "resolveAllConsent": {
     "eyebrow": "Alles auflösen",
@@ -2258,11 +2278,16 @@
     "appliedLast": "Zuletzt angewendet — dieser gilt",
     "resultLabel": "Ergebnis: {{outcome}}",
     "confirmOrder": "Reihenfolge bestätigen",
-    "moveUp": "Nach vorne",
-    "moveDown": "Nach hinten",
     "dragHint": "Zum Umsortieren ziehen oder die Pfeile benutzen.",
     "chooseSubtitle": "Wähle, welcher Ersatzeffekt angewendet wird.",
-    "candidateFallback": "Ersatzeffekt {{number}}"
+    "candidateFallback": "Ersatzeffekt {{number}}",
+    "orderSubtitleComposing": "Diese Effekte ändern alle, wie dieses Ereignis geschieht. Ziehe, um die Reihenfolge festzulegen — jeder wird angewendet, die Reihenfolge ändert das Ergebnis (CR 616.1).",
+    "appliedEarlier": "Früher angewendet",
+    "appliedLater": "Später angewendet",
+    "composesNote": "Jeder Effekt wird angewendet — die Reihenfolge ändert ihre Kombination.",
+    "moveUpNamed": "{{name}} nach vorne verschieben",
+    "moveDownNamed": "{{name}} nach hinten verschieben",
+    "positionAnnounce": "Position {{position}} von {{total}}"
   },
   "retargetChoice": {
     "title": "Ziel ändern",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -2316,11 +2316,16 @@
     "appliedLast": "Applied last — this wins",
     "resultLabel": "Result: {{outcome}}",
     "confirmOrder": "Confirm Order",
-    "moveUp": "Move earlier",
-    "moveDown": "Move later",
     "dragHint": "Drag to reorder, or use the arrows.",
     "chooseSubtitle": "Choose which replacement effect to apply.",
-    "candidateFallback": "Replacement Effect {{number}}"
+    "candidateFallback": "Replacement Effect {{number}}",
+    "orderSubtitleComposing": "These effects all change how this event happens. Drag to set the order they apply in — each one applies, so the order changes the result (CR 616.1).",
+    "appliedEarlier": "Applied earlier",
+    "appliedLater": "Applied later",
+    "composesNote": "Every effect applies — the order changes how they combine.",
+    "moveUpNamed": "Move {{name}} earlier",
+    "moveDownNamed": "Move {{name}} later",
+    "positionAnnounce": "Position {{position}} of {{total}}"
   },
   "retargetChoice": {
     "title": "Change Target",

--- a/client/src/i18n/locales/en/game.json
+++ b/client/src/i18n/locales/en/game.json
@@ -2311,7 +2311,15 @@
   "replacement": {
     "eyebrow": "Resolution Order",
     "title": "Replacement Effects",
-    "subtitle": "Choose which replacement effect applies first.",
+    "orderSubtitle": "These effects all change how this event happens. Drag to set the order they apply in — the last one applied is the one that takes effect (CR 616.1).",
+    "appliedFirst": "Applied first (overwritten)",
+    "appliedLast": "Applied last — this wins",
+    "resultLabel": "Result: {{outcome}}",
+    "confirmOrder": "Confirm Order",
+    "moveUp": "Move earlier",
+    "moveDown": "Move later",
+    "dragHint": "Drag to reorder, or use the arrows.",
+    "chooseSubtitle": "Choose which replacement effect to apply.",
     "candidateFallback": "Replacement Effect {{number}}"
   },
   "retargetChoice": {

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -6,7 +6,13 @@
     "prohibited": "Activar esta habilidad está prohibido",
     "costNotPayableNow": "No puedes pagar este coste ahora mismo"
   },
-  "manaSourceSelection": { "title": "Elige una fuente de maná", "description": "Esta habilidad de maná requiere sacrificar un permanente.", "sacrifice": "Sacrificar", "back": "Volver al pago de maná", "unknownSource": "Fuente de maná" },
+  "manaSourceSelection": {
+    "title": "Elige una fuente de maná",
+    "description": "Esta habilidad de maná requiere sacrificar un permanente.",
+    "sacrifice": "Sacrificar",
+    "back": "Volver al pago de maná",
+    "unknownSource": "Fuente de maná"
+  },
   "comboShortcut": {
     "declareTitle": "Loop Shortcut",
     "declareSubtitle": "You control a loop with a determined outcome. Take the shortcut to resolve it.",
@@ -71,9 +77,23 @@
   },
   "restoredAutomation": {
     "dismiss": "Cerrar",
-    "noop": {"title": "Partida guardada cargada", "summary_one": "No fue necesario reanudar la automatización de la pila.", "summary_other": "No fue necesario reanudar la automatización de la pila."},
-    "progressed": {"title": "Automatización de la pila reanudada", "summary_one": "El motor completó {{count}} resolución automatizada.", "summary_other": "El motor completó {{count}} resoluciones automatizadas.", "omitted_one": "Se omitió {{count}} evento intermedio.", "omitted_other": "Se omitieron {{count}} eventos intermedios."},
-    "zeroResolutionRepair": {"title": "Automatización de la pila reparada", "summary_one": "La automatización guardada se reparó de forma segura antes de reanudar la partida.", "summary_other": "La automatización guardada se reparó de forma segura antes de reanudar la partida."}
+    "noop": {
+      "title": "Partida guardada cargada",
+      "summary_one": "No fue necesario reanudar la automatización de la pila.",
+      "summary_other": "No fue necesario reanudar la automatización de la pila."
+    },
+    "progressed": {
+      "title": "Automatización de la pila reanudada",
+      "summary_one": "El motor completó {{count}} resolución automatizada.",
+      "summary_other": "El motor completó {{count}} resoluciones automatizadas.",
+      "omitted_one": "Se omitió {{count}} evento intermedio.",
+      "omitted_other": "Se omitieron {{count}} eventos intermedios."
+    },
+    "zeroResolutionRepair": {
+      "title": "Automatización de la pila reparada",
+      "summary_one": "La automatización guardada se reparó de forma segura antes de reanudar la partida.",
+      "summary_other": "La automatización guardada se reparó de forma segura antes de reanudar la partida."
+    }
   },
   "resolveAllConsent": {
     "eyebrow": "Resolver todo",
@@ -2258,11 +2278,16 @@
     "appliedLast": "Aplicado el último: este prevalece",
     "resultLabel": "Resultado: {{outcome}}",
     "confirmOrder": "Confirmar orden",
-    "moveUp": "Mover antes",
-    "moveDown": "Mover después",
     "dragHint": "Arrastra para reordenar o usa las flechas.",
     "chooseSubtitle": "Elige qué efecto de reemplazo aplicar.",
-    "candidateFallback": "Efecto de reemplazo {{number}}"
+    "candidateFallback": "Efecto de reemplazo {{number}}",
+    "orderSubtitleComposing": "Todos estos efectos cambian cómo ocurre este evento. Arrastra para fijar el orden en que se aplican: todos se aplican, así que el orden cambia el resultado (CR 616.1).",
+    "appliedEarlier": "Aplicado antes",
+    "appliedLater": "Aplicado después",
+    "composesNote": "Todos los efectos se aplican: el orden cambia cómo se combinan.",
+    "moveUpNamed": "Mover {{name}} antes",
+    "moveDownNamed": "Mover {{name}} después",
+    "positionAnnounce": "Posición {{position}} de {{total}}"
   },
   "retargetChoice": {
     "title": "Cambiar objetivo",

--- a/client/src/i18n/locales/es/game.json
+++ b/client/src/i18n/locales/es/game.json
@@ -2253,7 +2253,15 @@
   "replacement": {
     "eyebrow": "Orden de resolución",
     "title": "Efectos de reemplazo",
-    "subtitle": "Elige qué efecto de reemplazo se aplica primero.",
+    "orderSubtitle": "Todos estos efectos cambian cómo ocurre este evento. Arrastra para establecer el orden en que se aplican: el último aplicado es el que surte efecto (CR 616.1).",
+    "appliedFirst": "Aplicado primero (será sobrescrito)",
+    "appliedLast": "Aplicado el último: este prevalece",
+    "resultLabel": "Resultado: {{outcome}}",
+    "confirmOrder": "Confirmar orden",
+    "moveUp": "Mover antes",
+    "moveDown": "Mover después",
+    "dragHint": "Arrastra para reordenar o usa las flechas.",
+    "chooseSubtitle": "Elige qué efecto de reemplazo aplicar.",
     "candidateFallback": "Efecto de reemplazo {{number}}"
   },
   "retargetChoice": {

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -2253,7 +2253,15 @@
   "replacement": {
     "eyebrow": "Ordre de résolution",
     "title": "Effets de remplacement",
-    "subtitle": "Choisissez quel effet de remplacement s'applique en premier.",
+    "orderSubtitle": "Ces effets modifient tous la façon dont cet événement se produit. Faites glisser pour définir l'ordre d'application : le dernier appliqué est celui qui prend effet (CR 616.1).",
+    "appliedFirst": "Appliqué en premier (sera écrasé)",
+    "appliedLast": "Appliqué en dernier — celui-ci l'emporte",
+    "resultLabel": "Résultat : {{outcome}}",
+    "confirmOrder": "Confirmer l'ordre",
+    "moveUp": "Déplacer avant",
+    "moveDown": "Déplacer après",
+    "dragHint": "Faites glisser pour réordonner, ou utilisez les flèches.",
+    "chooseSubtitle": "Choisissez quel effet de remplacement appliquer.",
     "candidateFallback": "Effet de remplacement {{number}}"
   },
   "retargetChoice": {

--- a/client/src/i18n/locales/fr/game.json
+++ b/client/src/i18n/locales/fr/game.json
@@ -6,7 +6,13 @@
     "prohibited": "L'activation de cette capacité est interdite",
     "costNotPayableNow": "Vous ne pouvez pas payer ce coût pour le moment"
   },
-  "manaSourceSelection": { "title": "Choisir une source de mana", "description": "Cette capacité de mana demande de sacrifier un permanent.", "sacrifice": "Sacrifier", "back": "Retour au paiement de mana", "unknownSource": "Source de mana" },
+  "manaSourceSelection": {
+    "title": "Choisir une source de mana",
+    "description": "Cette capacité de mana demande de sacrifier un permanent.",
+    "sacrifice": "Sacrifier",
+    "back": "Retour au paiement de mana",
+    "unknownSource": "Source de mana"
+  },
   "comboShortcut": {
     "declareTitle": "Loop Shortcut",
     "declareSubtitle": "You control a loop with a determined outcome. Take the shortcut to resolve it.",
@@ -71,9 +77,23 @@
   },
   "restoredAutomation": {
     "dismiss": "Fermer",
-    "noop": {"title": "Partie sauvegardée chargée", "summary_one": "Aucune automatisation de pile n’était nécessaire pour reprendre.", "summary_other": "Aucune automatisation de pile n’était nécessaire pour reprendre."},
-    "progressed": {"title": "Automatisation de la pile reprise", "summary_one": "Le moteur a effectué {{count}} résolution automatisée.", "summary_other": "Le moteur a effectué {{count}} résolutions automatisées.", "omitted_one": "{{count}} événement intermédiaire a été omis.", "omitted_other": "{{count}} événements intermédiaires ont été omis."},
-    "zeroResolutionRepair": {"title": "Automatisation de la pile réparée", "summary_one": "L’automatisation sauvegardée a été réparée en toute sécurité avant la reprise.", "summary_other": "L’automatisation sauvegardée a été réparée en toute sécurité avant la reprise."}
+    "noop": {
+      "title": "Partie sauvegardée chargée",
+      "summary_one": "Aucune automatisation de pile n’était nécessaire pour reprendre.",
+      "summary_other": "Aucune automatisation de pile n’était nécessaire pour reprendre."
+    },
+    "progressed": {
+      "title": "Automatisation de la pile reprise",
+      "summary_one": "Le moteur a effectué {{count}} résolution automatisée.",
+      "summary_other": "Le moteur a effectué {{count}} résolutions automatisées.",
+      "omitted_one": "{{count}} événement intermédiaire a été omis.",
+      "omitted_other": "{{count}} événements intermédiaires ont été omis."
+    },
+    "zeroResolutionRepair": {
+      "title": "Automatisation de la pile réparée",
+      "summary_one": "L’automatisation sauvegardée a été réparée en toute sécurité avant la reprise.",
+      "summary_other": "L’automatisation sauvegardée a été réparée en toute sécurité avant la reprise."
+    }
   },
   "resolveAllConsent": {
     "eyebrow": "Tout résoudre",
@@ -2258,11 +2278,16 @@
     "appliedLast": "Appliqué en dernier — celui-ci l'emporte",
     "resultLabel": "Résultat : {{outcome}}",
     "confirmOrder": "Confirmer l'ordre",
-    "moveUp": "Déplacer avant",
-    "moveDown": "Déplacer après",
     "dragHint": "Faites glisser pour réordonner, ou utilisez les flèches.",
     "chooseSubtitle": "Choisissez quel effet de remplacement appliquer.",
-    "candidateFallback": "Effet de remplacement {{number}}"
+    "candidateFallback": "Effet de remplacement {{number}}",
+    "orderSubtitleComposing": "Ces effets modifient tous la façon dont cet événement se produit. Faites glisser pour définir l'ordre d'application : chacun s'applique, donc l'ordre change le résultat (CR 616.1).",
+    "appliedEarlier": "Appliqué avant",
+    "appliedLater": "Appliqué après",
+    "composesNote": "Chaque effet s'applique — l'ordre change leur combinaison.",
+    "moveUpNamed": "Déplacer {{name}} plus tôt",
+    "moveDownNamed": "Déplacer {{name}} plus tard",
+    "positionAnnounce": "Position {{position}} sur {{total}}"
   },
   "retargetChoice": {
     "title": "Changer de cible",

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -2253,7 +2253,15 @@
   "replacement": {
     "eyebrow": "Ordine di risoluzione",
     "title": "Effetti di sostituzione",
-    "subtitle": "Scegli quale effetto di sostituzione si applica per primo.",
+    "orderSubtitle": "Questi effetti cambiano tutti il modo in cui avviene questo evento. Trascina per stabilire l'ordine di applicazione: l'ultimo applicato è quello che ha effetto (CR 616.1).",
+    "appliedFirst": "Applicato per primo (verrà sovrascritto)",
+    "appliedLast": "Applicato per ultimo — questo prevale",
+    "resultLabel": "Risultato: {{outcome}}",
+    "confirmOrder": "Conferma ordine",
+    "moveUp": "Sposta prima",
+    "moveDown": "Sposta dopo",
+    "dragHint": "Trascina per riordinare, o usa le frecce.",
+    "chooseSubtitle": "Scegli quale effetto di sostituzione applicare.",
     "candidateFallback": "Effetto di sostituzione {{number}}"
   },
   "retargetChoice": {

--- a/client/src/i18n/locales/it/game.json
+++ b/client/src/i18n/locales/it/game.json
@@ -6,7 +6,13 @@
     "prohibited": "L'attivazione di questa abilità è proibita",
     "costNotPayableNow": "Non puoi pagare questo costo in questo momento"
   },
-  "manaSourceSelection": { "title": "Scegli una fonte di mana", "description": "Questa abilità di mana richiede di sacrificare un permanente.", "sacrifice": "Sacrifica", "back": "Torna al pagamento del mana", "unknownSource": "Fonte di mana" },
+  "manaSourceSelection": {
+    "title": "Scegli una fonte di mana",
+    "description": "Questa abilità di mana richiede di sacrificare un permanente.",
+    "sacrifice": "Sacrifica",
+    "back": "Torna al pagamento del mana",
+    "unknownSource": "Fonte di mana"
+  },
   "comboShortcut": {
     "declareTitle": "Loop Shortcut",
     "declareSubtitle": "You control a loop with a determined outcome. Take the shortcut to resolve it.",
@@ -71,9 +77,23 @@
   },
   "restoredAutomation": {
     "dismiss": "Chiudi",
-    "noop": {"title": "Partita salvata caricata", "summary_one": "Non è stato necessario riprendere l’automazione della pila.", "summary_other": "Non è stato necessario riprendere l’automazione della pila."},
-    "progressed": {"title": "Automazione della pila ripresa", "summary_one": "Il motore ha completato {{count}} risoluzione automatizzata.", "summary_other": "Il motore ha completato {{count}} risoluzioni automatizzate.", "omitted_one": "È stato omesso {{count}} evento intermedio.", "omitted_other": "Sono stati omessi {{count}} eventi intermedi."},
-    "zeroResolutionRepair": {"title": "Automazione della pila riparata", "summary_one": "L’automazione salvata è stata riparata in modo sicuro prima di riprendere.", "summary_other": "L’automazione salvata è stata riparata in modo sicuro prima di riprendere."}
+    "noop": {
+      "title": "Partita salvata caricata",
+      "summary_one": "Non è stato necessario riprendere l’automazione della pila.",
+      "summary_other": "Non è stato necessario riprendere l’automazione della pila."
+    },
+    "progressed": {
+      "title": "Automazione della pila ripresa",
+      "summary_one": "Il motore ha completato {{count}} risoluzione automatizzata.",
+      "summary_other": "Il motore ha completato {{count}} risoluzioni automatizzate.",
+      "omitted_one": "È stato omesso {{count}} evento intermedio.",
+      "omitted_other": "Sono stati omessi {{count}} eventi intermedi."
+    },
+    "zeroResolutionRepair": {
+      "title": "Automazione della pila riparata",
+      "summary_one": "L’automazione salvata è stata riparata in modo sicuro prima di riprendere.",
+      "summary_other": "L’automazione salvata è stata riparata in modo sicuro prima di riprendere."
+    }
   },
   "resolveAllConsent": {
     "eyebrow": "Risolvi tutto",
@@ -2258,11 +2278,16 @@
     "appliedLast": "Applicato per ultimo — questo prevale",
     "resultLabel": "Risultato: {{outcome}}",
     "confirmOrder": "Conferma ordine",
-    "moveUp": "Sposta prima",
-    "moveDown": "Sposta dopo",
     "dragHint": "Trascina per riordinare, o usa le frecce.",
     "chooseSubtitle": "Scegli quale effetto di sostituzione applicare.",
-    "candidateFallback": "Effetto di sostituzione {{number}}"
+    "candidateFallback": "Effetto di sostituzione {{number}}",
+    "orderSubtitleComposing": "Questi effetti cambiano tutti il modo in cui accade questo evento. Trascina per impostare l'ordine di applicazione: si applicano tutti, quindi l'ordine cambia il risultato (CR 616.1).",
+    "appliedEarlier": "Applicato prima",
+    "appliedLater": "Applicato dopo",
+    "composesNote": "Ogni effetto si applica — l'ordine cambia come si combinano.",
+    "moveUpNamed": "Sposta {{name}} prima",
+    "moveDownNamed": "Sposta {{name}} dopo",
+    "positionAnnounce": "Posizione {{position}} di {{total}}"
   },
   "retargetChoice": {
     "title": "Cambia bersaglio",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -6,7 +6,13 @@
     "prohibited": "Aktywacja tej zdolności jest zabroniona",
     "costNotPayableNow": "Nie możesz teraz zapłacić tego kosztu"
   },
-  "manaSourceSelection": { "title": "Wybierz źródło many", "description": "Ta zdolność many wymaga poświęcenia permanenta.", "sacrifice": "Poświęć", "back": "Wróć do płatności many", "unknownSource": "Źródło many" },
+  "manaSourceSelection": {
+    "title": "Wybierz źródło many",
+    "description": "Ta zdolność many wymaga poświęcenia permanenta.",
+    "sacrifice": "Poświęć",
+    "back": "Wróć do płatności many",
+    "unknownSource": "Źródło many"
+  },
   "comboShortcut": {
     "declareTitle": "Loop Shortcut",
     "declareSubtitle": "You control a loop with a determined outcome. Take the shortcut to resolve it.",
@@ -71,9 +77,23 @@
   },
   "restoredAutomation": {
     "dismiss": "Zamknij",
-    "noop": {"title": "Wczytano zapisaną grę", "summary_one": "Nie trzeba było wznawiać automatyzacji stosu.", "summary_other": "Nie trzeba było wznawiać automatyzacji stosu."},
-    "progressed": {"title": "Wznowiono automatyzację stosu", "summary_one": "Silnik ukończył {{count}} automatyczne rozpatrzenie.", "summary_other": "Silnik ukończył {{count}} automatyczne rozpatrzenia.", "omitted_one": "Pominięto {{count}} zdarzenie pośrednie.", "omitted_other": "Pominięto {{count}} zdarzeń pośrednich."},
-    "zeroResolutionRepair": {"title": "Naprawiono automatyzację stosu", "summary_one": "Zapisana automatyzacja została bezpiecznie naprawiona przed wznowieniem gry.", "summary_other": "Zapisana automatyzacja została bezpiecznie naprawiona przed wznowieniem gry."}
+    "noop": {
+      "title": "Wczytano zapisaną grę",
+      "summary_one": "Nie trzeba było wznawiać automatyzacji stosu.",
+      "summary_other": "Nie trzeba było wznawiać automatyzacji stosu."
+    },
+    "progressed": {
+      "title": "Wznowiono automatyzację stosu",
+      "summary_one": "Silnik ukończył {{count}} automatyczne rozpatrzenie.",
+      "summary_other": "Silnik ukończył {{count}} automatyczne rozpatrzenia.",
+      "omitted_one": "Pominięto {{count}} zdarzenie pośrednie.",
+      "omitted_other": "Pominięto {{count}} zdarzeń pośrednich."
+    },
+    "zeroResolutionRepair": {
+      "title": "Naprawiono automatyzację stosu",
+      "summary_one": "Zapisana automatyzacja została bezpiecznie naprawiona przed wznowieniem gry.",
+      "summary_other": "Zapisana automatyzacja została bezpiecznie naprawiona przed wznowieniem gry."
+    }
   },
   "resolveAllConsent": {
     "eyebrow": "Rozpatrz wszystko",
@@ -2258,11 +2278,16 @@
     "appliedLast": "Zastosowany ostatni — ten zadziała",
     "resultLabel": "Wynik: {{outcome}}",
     "confirmOrder": "Potwierdź kolejność",
-    "moveUp": "Przesuń wcześniej",
-    "moveDown": "Przesuń później",
     "dragHint": "Przeciągnij, aby zmienić kolejność, lub użyj strzałek.",
     "chooseSubtitle": "Wybierz, który efekt zastępujący zastosować.",
-    "candidateFallback": "Efekt zastępujący {{number}}"
+    "candidateFallback": "Efekt zastępujący {{number}}",
+    "orderSubtitleComposing": "Wszystkie te efekty zmieniają przebieg tego zdarzenia. Przeciągnij, aby ustawić kolejność ich zastosowania — każdy zostanie zastosowany, więc kolejność zmienia wynik (CR 616.1).",
+    "appliedEarlier": "Zastosowany wcześniej",
+    "appliedLater": "Zastosowany później",
+    "composesNote": "Każdy efekt zostaje zastosowany — kolejność zmienia sposób ich połączenia.",
+    "moveUpNamed": "Przenieś {{name}} wcześniej",
+    "moveDownNamed": "Przenieś {{name}} później",
+    "positionAnnounce": "Pozycja {{position}} z {{total}}"
   },
   "retargetChoice": {
     "title": "Zmień cel",

--- a/client/src/i18n/locales/pl/game.json
+++ b/client/src/i18n/locales/pl/game.json
@@ -2253,7 +2253,15 @@
   "replacement": {
     "eyebrow": "Kolejność rozpatrywania",
     "title": "Efekty zastępujące",
-    "subtitle": "Wybierz, który efekt zastępujący zastosować jako pierwszy.",
+    "orderSubtitle": "Wszystkie te efekty zmieniają przebieg tego zdarzenia. Przeciągnij, aby ustalić kolejność — ostatni zastosowany efekt jest tym, który zadziała (CR 616.1).",
+    "appliedFirst": "Zastosowany pierwszy (zostanie nadpisany)",
+    "appliedLast": "Zastosowany ostatni — ten zadziała",
+    "resultLabel": "Wynik: {{outcome}}",
+    "confirmOrder": "Potwierdź kolejność",
+    "moveUp": "Przesuń wcześniej",
+    "moveDown": "Przesuń później",
+    "dragHint": "Przeciągnij, aby zmienić kolejność, lub użyj strzałek.",
+    "chooseSubtitle": "Wybierz, który efekt zastępujący zastosować.",
     "candidateFallback": "Efekt zastępujący {{number}}"
   },
   "retargetChoice": {

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -2253,7 +2253,15 @@
   "replacement": {
     "eyebrow": "Ordem de Resolução",
     "title": "Efeitos de Substituição",
-    "subtitle": "Escolha qual efeito de substituição se aplica primeiro.",
+    "orderSubtitle": "Todos estes efeitos alteram como este evento acontece. Arraste para definir a ordem de aplicação — o último aplicado é o que prevalece (CR 616.1).",
+    "appliedFirst": "Aplicado primeiro (será sobrescrito)",
+    "appliedLast": "Aplicado por último — este prevalece",
+    "resultLabel": "Resultado: {{outcome}}",
+    "confirmOrder": "Confirmar ordem",
+    "moveUp": "Mover para antes",
+    "moveDown": "Mover para depois",
+    "dragHint": "Arraste para reordenar, ou use as setas.",
+    "chooseSubtitle": "Escolha qual efeito de substituição aplicar.",
     "candidateFallback": "Efeito de Substituição {{number}}"
   },
   "retargetChoice": {

--- a/client/src/i18n/locales/pt/game.json
+++ b/client/src/i18n/locales/pt/game.json
@@ -6,7 +6,13 @@
     "prohibited": "Ativar esta habilidade é proibido",
     "costNotPayableNow": "Você não pode pagar este custo agora"
   },
-  "manaSourceSelection": { "title": "Escolha uma fonte de mana", "description": "Esta habilidade de mana exige sacrificar uma permanente.", "sacrifice": "Sacrificar", "back": "Voltar ao pagamento de mana", "unknownSource": "Fonte de mana" },
+  "manaSourceSelection": {
+    "title": "Escolha uma fonte de mana",
+    "description": "Esta habilidade de mana exige sacrificar uma permanente.",
+    "sacrifice": "Sacrificar",
+    "back": "Voltar ao pagamento de mana",
+    "unknownSource": "Fonte de mana"
+  },
   "comboShortcut": {
     "declareTitle": "Loop Shortcut",
     "declareSubtitle": "You control a loop with a determined outcome. Take the shortcut to resolve it.",
@@ -71,9 +77,23 @@
   },
   "restoredAutomation": {
     "dismiss": "Fechar",
-    "noop": {"title": "Jogo salvo carregado", "summary_one": "Não foi necessário retomar a automação da pilha.", "summary_other": "Não foi necessário retomar a automação da pilha."},
-    "progressed": {"title": "Automação da pilha retomada", "summary_one": "O motor concluiu {{count}} resolução automatizada.", "summary_other": "O motor concluiu {{count}} resoluções automatizadas.", "omitted_one": "{{count}} evento intermediário foi omitido.", "omitted_other": "{{count}} eventos intermediários foram omitidos."},
-    "zeroResolutionRepair": {"title": "Automação da pilha reparada", "summary_one": "A automação salva foi reparada com segurança antes de retomar o jogo.", "summary_other": "A automação salva foi reparada com segurança antes de retomar o jogo."}
+    "noop": {
+      "title": "Jogo salvo carregado",
+      "summary_one": "Não foi necessário retomar a automação da pilha.",
+      "summary_other": "Não foi necessário retomar a automação da pilha."
+    },
+    "progressed": {
+      "title": "Automação da pilha retomada",
+      "summary_one": "O motor concluiu {{count}} resolução automatizada.",
+      "summary_other": "O motor concluiu {{count}} resoluções automatizadas.",
+      "omitted_one": "{{count}} evento intermediário foi omitido.",
+      "omitted_other": "{{count}} eventos intermediários foram omitidos."
+    },
+    "zeroResolutionRepair": {
+      "title": "Automação da pilha reparada",
+      "summary_one": "A automação salva foi reparada com segurança antes de retomar o jogo.",
+      "summary_other": "A automação salva foi reparada com segurança antes de retomar o jogo."
+    }
   },
   "resolveAllConsent": {
     "eyebrow": "Resolver tudo",
@@ -2258,11 +2278,16 @@
     "appliedLast": "Aplicado por último — este prevalece",
     "resultLabel": "Resultado: {{outcome}}",
     "confirmOrder": "Confirmar ordem",
-    "moveUp": "Mover para antes",
-    "moveDown": "Mover para depois",
     "dragHint": "Arraste para reordenar, ou use as setas.",
     "chooseSubtitle": "Escolha qual efeito de substituição aplicar.",
-    "candidateFallback": "Efeito de Substituição {{number}}"
+    "candidateFallback": "Efeito de Substituição {{number}}",
+    "orderSubtitleComposing": "Todos esses efeitos mudam como este evento acontece. Arraste para definir a ordem em que se aplicam: todos se aplicam, então a ordem muda o resultado (CR 616.1).",
+    "appliedEarlier": "Aplicado antes",
+    "appliedLater": "Aplicado depois",
+    "composesNote": "Todos os efeitos se aplicam — a ordem muda como se combinam.",
+    "moveUpNamed": "Mover {{name}} antes",
+    "moveDownNamed": "Mover {{name}} depois",
+    "positionAnnounce": "Posição {{position}} de {{total}}"
   },
   "retargetChoice": {
     "title": "Mudar Alvo",

--- a/client/src/network/__tests__/protocol.test.ts
+++ b/client/src/network/__tests__/protocol.test.ts
@@ -71,8 +71,8 @@ const PREVIEW_ANSWER = {
 } as never;
 
 describe("encodeWireMessage / decodeWireMessage", () => {
-  it("pins the P2P wire protocol to v46", () => {
-    expect(WIRE_PROTOCOL_VERSION).toBe(46);
+  it("pins the P2P wire protocol to v47", () => {
+    expect(WIRE_PROTOCOL_VERSION).toBe(47);
   });
 
   it("defaults shortcut actions for a legacy payload created before the additive field", () => {

--- a/client/src/network/protocol.ts
+++ b/client/src/network/protocol.ts
@@ -106,6 +106,11 @@ export function legalActionsFromWire(wire: LegalActionsWire): LegalActionsResult
  * seat or adopts reconnect state.
  *
  * Bumps to date:
+ *  47 — WaitingFor.ReplacementChoice gained an engine-owned
+ *       ReplacementChoiceKind discriminator and a last_applied_decides flag.
+ *       Both are optional on the wire, so a skewed host/guest pair decodes
+ *       successfully and then misrenders the prompt instead of failing at
+ *       first contact.
  *  45 — Effect.ChooseCounterKind gained domain and chooser, carried inside
  *       GameObject.abilities and trigger definitions on every GameState frame
  *       (CR 608.2d). Additive behind serde defaults; a v44 peer has no field to
@@ -327,7 +332,7 @@ export type P2PInteractionPreviewAnswer =
   | { type: "preview"; preview: InteractionPreview }
   | { type: "failed"; message: string };
 
-export const WIRE_PROTOCOL_VERSION = 46 as const;
+export const WIRE_PROTOCOL_VERSION = 47 as const;
 
 export type P2PMessage = P2PAuthorityWire & (
   | {

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -4111,6 +4111,7 @@ mod tests {
             player: PlayerId(0),
             candidate_count: 2,
             candidates: Vec::new(),
+            kind: Default::default(),
         };
 
         assert!(cheap_reject_candidate(

--- a/crates/engine/src/ai_support/mod.rs
+++ b/crates/engine/src/ai_support/mod.rs
@@ -4112,6 +4112,7 @@ mod tests {
             candidate_count: 2,
             candidates: Vec::new(),
             kind: Default::default(),
+            last_applied_decides: false,
         };
 
         assert!(cheap_reject_candidate(

--- a/crates/engine/src/game/effects/destroy.rs
+++ b/crates/engine/src/game/effects/destroy.rs
@@ -1037,7 +1037,7 @@ mod tests {
             player,
             candidate_count,
             candidates,
-            ..
+            kind,
         } = &state.waiting_for
         else {
             panic!(
@@ -1048,6 +1048,13 @@ mod tests {
         };
         assert_eq!(*player, PlayerId(0));
         assert_eq!(*candidate_count, 2);
+        // CR 616.1e: two distinct competing replacements — an ordering decision,
+        // not an optional accept/decline. The frontend keys its presentation off
+        // this discriminator, so pin it here.
+        assert_eq!(
+            *kind,
+            crate::types::game_state::ReplacementChoiceKind::Order
+        );
         let descriptions: Vec<&str> = candidates.iter().map(|c| c.description.as_str()).collect();
         assert_eq!(
             descriptions.as_slice(),

--- a/crates/engine/src/game/effects/destroy.rs
+++ b/crates/engine/src/game/effects/destroy.rs
@@ -1038,6 +1038,7 @@ mod tests {
             candidate_count,
             candidates,
             kind,
+            ..
         } = &state.waiting_for
         else {
             panic!(

--- a/crates/engine/src/game/effects/destroy.rs
+++ b/crates/engine/src/game/effects/destroy.rs
@@ -1037,6 +1037,7 @@ mod tests {
             player,
             candidate_count,
             candidates,
+            ..
         } = &state.waiting_for
         else {
             panic!(

--- a/crates/engine/src/game/effects/fight.rs
+++ b/crates/engine/src/game/effects/fight.rs
@@ -778,6 +778,7 @@ mod tests {
                 source_name: String::new(),
                 description: "Shield".to_string(),
             }],
+            kind: Default::default(),
         };
 
         // Accept the replacement for bear → wolf (first direction).

--- a/crates/engine/src/game/effects/fight.rs
+++ b/crates/engine/src/game/effects/fight.rs
@@ -779,6 +779,7 @@ mod tests {
                 description: "Shield".to_string(),
             }],
             kind: Default::default(),
+            last_applied_decides: false,
         };
 
         // Accept the replacement for bear → wolf (first direction).

--- a/crates/engine/src/game/elimination.rs
+++ b/crates/engine/src/game/elimination.rs
@@ -2039,6 +2039,7 @@ mod tests {
             player: PlayerId(0),
             candidate_count: 1,
             candidates: Vec::new(),
+            kind: Default::default(),
         };
         state.push_batch_delivery(crate::types::game_state::PendingBatchDeliveries {
             logical_zone_change_group: group,
@@ -2104,6 +2105,7 @@ mod tests {
             player: PlayerId(0),
             candidate_count: 1,
             candidates: Vec::new(),
+            kind: Default::default(),
         };
         state.push_change_zone_iteration(pending_change_zone_iteration(
             group,
@@ -3000,6 +3002,7 @@ mod tests {
             player: PlayerId(2),
             candidate_count: 1,
             candidates: vec![],
+            kind: Default::default(),
         };
         // Coupled continuation slots the resume drain would clear on a normal answer.
         state.replacement_may_cost_paused = true;
@@ -3137,6 +3140,7 @@ mod tests {
             player: PlayerId(0),
             candidate_count: 1,
             candidates: Vec::new(),
+            kind: Default::default(),
         };
         state.push_connive_reentry(PendingConniveReentry {
             conniver: state
@@ -3188,6 +3192,7 @@ mod tests {
             player: PlayerId(0),
             candidate_count: 1,
             candidates: Vec::new(),
+            kind: Default::default(),
         };
         state.push_batch_delivery(pending_search_found_zone_delivery(found));
         assert!(state.active_batch_delivery().is_some());
@@ -3230,6 +3235,7 @@ mod tests {
             player: PlayerId(0),
             candidate_count: 1,
             candidates: vec![],
+            kind: Default::default(),
         };
         let parked_found = ObjectId(77);
         state.pending_search_found_batch =
@@ -3302,6 +3308,7 @@ mod tests {
             player: PlayerId(0),
             candidate_count: 1,
             candidates: Vec::new(),
+            kind: Default::default(),
         };
         let source = create_object(
             &mut state,

--- a/crates/engine/src/game/elimination.rs
+++ b/crates/engine/src/game/elimination.rs
@@ -2040,6 +2040,7 @@ mod tests {
             candidate_count: 1,
             candidates: Vec::new(),
             kind: Default::default(),
+            last_applied_decides: false,
         };
         state.push_batch_delivery(crate::types::game_state::PendingBatchDeliveries {
             logical_zone_change_group: group,
@@ -2106,6 +2107,7 @@ mod tests {
             candidate_count: 1,
             candidates: Vec::new(),
             kind: Default::default(),
+            last_applied_decides: false,
         };
         state.push_change_zone_iteration(pending_change_zone_iteration(
             group,
@@ -3003,6 +3005,7 @@ mod tests {
             candidate_count: 1,
             candidates: vec![],
             kind: Default::default(),
+            last_applied_decides: false,
         };
         // Coupled continuation slots the resume drain would clear on a normal answer.
         state.replacement_may_cost_paused = true;
@@ -3141,6 +3144,7 @@ mod tests {
             candidate_count: 1,
             candidates: Vec::new(),
             kind: Default::default(),
+            last_applied_decides: false,
         };
         state.push_connive_reentry(PendingConniveReentry {
             conniver: state
@@ -3193,6 +3197,7 @@ mod tests {
             candidate_count: 1,
             candidates: Vec::new(),
             kind: Default::default(),
+            last_applied_decides: false,
         };
         state.push_batch_delivery(pending_search_found_zone_delivery(found));
         assert!(state.active_batch_delivery().is_some());
@@ -3236,6 +3241,7 @@ mod tests {
             candidate_count: 1,
             candidates: vec![],
             kind: Default::default(),
+            last_applied_decides: false,
         };
         let parked_found = ObjectId(77);
         state.pending_search_found_batch =
@@ -3309,6 +3315,7 @@ mod tests {
             candidate_count: 1,
             candidates: Vec::new(),
             kind: Default::default(),
+            last_applied_decides: false,
         };
         let source = create_object(
             &mut state,

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -9289,6 +9289,33 @@ fn enter_tapped_commute_class(effect: &Effect) -> Option<CommuteClass> {
     }
 }
 
+/// CR 614.1c: the `enter_tapped` commute class an ability CHAIN writes, walking
+/// `sub_ability` links so a self tap on a chained link is not missed by a
+/// root-only check.
+///
+/// Mirrors [`EventModifiers::event_modifiers_for_ability`] EXACTLY, including
+/// its stopping rule: that walk consumes only a contiguous prefix of
+/// event-modifier effects and breaks at the first non-modifier link, and it
+/// keeps the FIRST tap/untap it sees rather than the last. A tap sitting after
+/// a non-modifier effect (e.g. `Draw`) is therefore never applied as an entry
+/// modifier, so classifying it as an `enter_tapped` write would promise an
+/// ordering prompt that cannot change the outcome — a classifier/applier
+/// disagreement that is worse than the missing prompt it would be papering
+/// over. If the applier's traversal is ever widened, widen this in lockstep.
+fn chained_enter_tapped_commute_class(def: &AbilityDefinition) -> Option<CommuteClass> {
+    let mut current = Some(def);
+    while let Some(def) = current {
+        if let Some(commute) = enter_tapped_commute_class(&def.effect) {
+            return Some(commute);
+        }
+        if !EventModifiers::is_event_modifier_effect(&def.effect) {
+            return None;
+        }
+        current = def.sub_ability.as_deref();
+    }
+    None
+}
+
 /// CR 616.1: classify a candidate. A `null`-`execute` replacement is *not* a
 /// guaranteed no-op — it can carry an event-modifying side field
 /// (`quantity_modification` / `mana_modification` / `damage_modification`) that
@@ -9448,8 +9475,13 @@ fn candidate_materiality(
         //
         // The declined branch is the one that can collide: paying the cost runs
         // `execute` (here, nothing), so only the decline path writes the field.
+        // The decline branch is walked as a CHAIN, exactly like the `execute`
+        // path below: a self tap can sit on a `sub_ability` link rather than at
+        // the root ("...it enters tapped" composed after another clause), and a
+        // root-only check would classify that `Disjoint` and again suppress the
+        // ordering prompt.
         if let Some(decline) = replacement_mode_decline(&repl_def.mode) {
-            if let Some(commute) = enter_tapped_commute_class(&decline.effect) {
+            if let Some(commute) = chained_enter_tapped_commute_class(decline) {
                 return CandidateMateriality::Writes {
                     field: EventField::EnterTapped,
                     commute,

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -1010,11 +1010,27 @@ pub fn replacement_choice_waiting_for(player: PlayerId, state: &GameState) -> Wa
         };
     }
 
+    // CR 616.1f: only the engine can say whether a winner exists; the client
+    // must not infer it from the candidate labels.
+    let last_applied_decides = state.pending_replacement.as_ref().is_some_and(|p| {
+        // CR 703.4q: the `EmptyManaPool` sentinel path hardcodes `Order` and is
+        // FIRST-applied-wins — `apply_empty_mana_pool_replacement` skips any unit
+        // whose disposition the earlier handler already claimed. Naming the last
+        // entry as the winner there would state the exact inverse, so it is
+        // excluded before the field check.
+        if matches!(p.proposed, ProposedEvent::EmptyManaPool { .. }) {
+            return false;
+        }
+        kind == ReplacementChoiceKind::Order
+            && replacement_last_applied_decides(state, &p.candidates, &p.proposed)
+    });
+
     WaitingFor::ReplacementChoice {
         player,
         candidate_count,
         candidates,
         kind,
+        last_applied_decides,
     }
 }
 
@@ -9131,6 +9147,42 @@ fn apply_single_replacement_and_dirty(
 /// shapes default to MATERIAL — never auto-resolve a possibly order-sensitive
 /// set; this conservative default also covers self-replacement effects
 /// (CR 616.1a / CR 614.15).
+/// CR 616.1f: whether the LAST-applied candidate alone determines this event's
+/// outcome — i.e. every colliding write is a whole-field overwrite rather than a
+/// composition.
+///
+/// True only for the `EnterTapped` class: two single-target `SetTapState`
+/// writers each stamp the whole field, so the final write wins and "the last one
+/// applied is the one that takes effect" is literally true. It is FALSE for
+/// arithmetic/compositional collisions — `Damage` (Furnace of Rath `Double` +
+/// Torbran `Plus{2}`), `Count`, and `ManaType` — where both effects apply and
+/// the order changes the arithmetic without producing a "winner"; and for
+/// `Unconditional` candidates, whose interaction is unproven by construction.
+///
+/// The display layer must not assume last-write-wins: presenting a "Result: X"
+/// banner for a composing collision states an outcome that does not exist.
+pub(crate) fn replacement_last_applied_decides(
+    state: &GameState,
+    candidates: &[ReplacementId],
+    proposed: &ProposedEvent,
+) -> bool {
+    let mut saw_overwrite = false;
+    for rid in candidates {
+        match candidate_materiality(state, *rid, proposed) {
+            // Unproven interaction — never claim a winner.
+            CandidateMateriality::Unconditional => return false,
+            CandidateMateriality::Writes { field, .. } => {
+                if field != EventField::EnterTapped {
+                    return false;
+                }
+                saw_overwrite = true;
+            }
+            CandidateMateriality::Disjoint => {}
+        }
+    }
+    saw_overwrite
+}
+
 pub(crate) fn replacement_ordering_is_material(
     state: &GameState,
     candidates: &[ReplacementId],
@@ -9293,7 +9345,7 @@ fn enter_tapped_commute_class(effect: &Effect) -> Option<CommuteClass> {
 /// `sub_ability` links so a self tap on a chained link is not missed by a
 /// root-only check.
 ///
-/// Mirrors [`EventModifiers::event_modifiers_for_ability`] EXACTLY, including
+/// Mirrors [`event_modifiers_for_ability`] EXACTLY, including
 /// its stopping rule: that walk consumes only a contiguous prefix of
 /// event-modifier effects and breaks at the first non-modifier link, and it
 /// keeps the FIRST tap/untap it sees rather than the last. A tap sitting after
@@ -12203,6 +12255,111 @@ mod tests {
             panic!("expected NeedsChoice for enter_tapped field collision, got {result:?}");
         };
         assert_eq!(player, PlayerId(0));
+    }
+
+    /// CR 616.1f: `replacement_last_applied_decides` must distinguish a
+    /// whole-field OVERWRITE collision from a COMPOSITIONAL one.
+    ///
+    /// Two single-target `SetTapState` writers each stamp the whole
+    /// `enter_tapped` field, so the last applied decides — the client may name a
+    /// winning result. Two damage modifiers (Furnace of Rath `Double` + Torbran
+    /// `Plus`) BOTH apply: the order changes the arithmetic ((x*2)+2 vs (x+2)*2)
+    /// but neither is overwritten, so there is no winner to name. A UI that
+    /// claimed one would state an outcome that does not exist.
+    ///
+    /// Goes RED if the `EventField::EnterTapped` guard is dropped.
+    #[test]
+    fn last_applied_decides_only_for_whole_field_overwrites() {
+        let tap_repl = ReplacementDefinition::new(ReplacementEvent::Moved)
+            .execute(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::SetTapState {
+                    target: TargetFilter::SelfRef,
+                    scope: EffectScope::Single,
+                    state: TapStateChange::Tap,
+                },
+            ))
+            .valid_card(TargetFilter::SelfRef)
+            .destination_zone(Zone::Battlefield);
+        let untap_repl = ReplacementDefinition::new(ReplacementEvent::Moved)
+            .execute(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::SetTapState {
+                    target: TargetFilter::SelfRef,
+                    scope: EffectScope::Single,
+                    state: TapStateChange::Untap,
+                },
+            ))
+            .valid_card(TargetFilter::SelfRef)
+            .destination_zone(Zone::Battlefield);
+        let mut state =
+            test_state_with_object(ObjectId(1), Zone::Battlefield, vec![tap_repl, untap_repl]);
+        let entering = GameObject::new(
+            ObjectId(20),
+            CardId(2),
+            PlayerId(0),
+            "Tapland".to_string(),
+            Zone::Hand,
+        );
+        state.objects.insert(ObjectId(20), entering);
+        let zone_event =
+            ProposedEvent::zone_change(ObjectId(20), Zone::Hand, Zone::Battlefield, None);
+        let tap_candidates = vec![
+            ReplacementId {
+                source: ObjectId(1),
+                index: 0,
+            },
+            ReplacementId {
+                source: ObjectId(1),
+                index: 1,
+            },
+        ];
+        assert!(
+            replacement_last_applied_decides(&state, &tap_candidates, &zone_event),
+            "CR 616.1f: opposite enter_tapped writes overwrite the whole field,              so the last applied decides"
+        );
+
+        // A damage collision composes — both modifiers apply, no winner.
+        let double = ReplacementDefinition::new(ReplacementEvent::DamageDone)
+            .damage_modification(DamageModification::Double)
+            .valid_card(TargetFilter::Any);
+        let plus = ReplacementDefinition::new(ReplacementEvent::DamageDone)
+            .damage_modification(DamageModification::Plus {
+                value: QuantityExpr::Fixed { value: 2 },
+            })
+            .valid_card(TargetFilter::Any);
+        let mut dmg_state =
+            test_state_with_object(ObjectId(1), Zone::Battlefield, vec![double, plus]);
+        let victim = GameObject::new(
+            ObjectId(30),
+            CardId(3),
+            PlayerId(0),
+            "Victim".to_string(),
+            Zone::Battlefield,
+        );
+        dmg_state.objects.insert(ObjectId(30), victim);
+        dmg_state.battlefield.push_back(ObjectId(30));
+        let dmg_event = ProposedEvent::Damage {
+            source_id: ObjectId(1),
+            target: crate::types::ability::TargetRef::Object(ObjectId(30)),
+            amount: 2,
+            is_combat: false,
+            applied: HashSet::new(),
+        };
+        let dmg_candidates = vec![
+            ReplacementId {
+                source: ObjectId(1),
+                index: 0,
+            },
+            ReplacementId {
+                source: ObjectId(1),
+                index: 1,
+            },
+        ];
+        assert!(
+            !replacement_last_applied_decides(&dmg_state, &dmg_candidates, &dmg_event),
+            "CR 616.1f: a damage doubler and adder both apply — the order changes              the arithmetic but neither overwrites the other, so there is no winner"
+        );
     }
 
     #[test]

--- a/crates/engine/src/game/replacement.rs
+++ b/crates/engine/src/game/replacement.rs
@@ -21,7 +21,7 @@ use super::filter::{
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
     DrainStatus, GameState, PendingReplacement, PostReplacementDrain, ReplacementCandidateSummary,
-    ReplacementIndexEntry, ResidentDrainPolicy, WaitingFor,
+    ReplacementChoiceKind, ReplacementIndexEntry, ResidentDrainPolicy, WaitingFor,
 };
 use crate::types::identifiers::{ObjectId, ObjectIncarnationRef};
 use crate::types::mana::{StepEndManaAction, UnitDisposition};
@@ -873,7 +873,7 @@ pub fn replacement_choice_waiting_for(player: PlayerId, state: &GameState) -> Wa
             .map(|obj| obj.name.clone())
             .unwrap_or_default()
     };
-    let (candidate_count, candidates) = state
+    let (candidate_count, candidates, kind) = state
         .pending_replacement
         .as_ref()
         .map(|p| match &p.proposed {
@@ -896,7 +896,7 @@ pub fn replacement_choice_waiting_for(player: PlayerId, state: &GameState) -> Wa
                             })
                     })
                     .collect();
-                (cands.len(), cands)
+                (cands.len(), cands, ReplacementChoiceKind::Order)
             }
             _ => {
                 let all_search_found_candidates_optional = !p.search_found_candidates.is_empty()
@@ -904,6 +904,17 @@ pub fn replacement_choice_waiting_for(player: PlayerId, state: &GameState) -> Wa
                         .iter()
                         .all(|candidate| candidate.is_optional);
                 let count = pending_replacement_option_count(state, p);
+                // CR 616.1: classify the prompt shape for the display layer.
+                // Only a distinct multi-candidate set is an ordering decision;
+                // optional accept/decline and found-card destinations are
+                // alternatives and must not render as a sortable list.
+                let kind = if p.is_optional {
+                    ReplacementChoiceKind::OptionalBranch
+                } else if !p.search_found_candidates.is_empty() {
+                    ReplacementChoiceKind::SearchFoundDestination
+                } else {
+                    ReplacementChoiceKind::Order
+                };
                 let cands: Vec<ReplacementCandidateSummary> = if p.is_optional
                     && !p.search_found_candidates.is_empty()
                 {
@@ -975,10 +986,10 @@ pub fn replacement_choice_waiting_for(player: PlayerId, state: &GameState) -> Wa
                         })
                         .collect()
                 };
-                (count, cands)
+                (count, cands, kind)
             }
         })
-        .unwrap_or((0, vec![]));
+        .unwrap_or((0, vec![], ReplacementChoiceKind::Order));
 
     // Issue #4277 softlock guard: a zero-candidate `ReplacementChoice` is
     // unactionable. `candidate_actions_exact` enumerates `(0..candidate_count)`,
@@ -1003,6 +1014,7 @@ pub fn replacement_choice_waiting_for(player: PlayerId, state: &GameState) -> Wa
         player,
         candidate_count,
         candidates,
+        kind,
     }
 }
 
@@ -1222,10 +1234,19 @@ fn replacement_cost_description(cost: &AbilityCost) -> String {
     }
 }
 
-/// CR 616.1 / CR 614.1c / CR 614.1d: Outcome-descriptive label for one
-/// candidate in a competing-replacement (distinct, non-optional) choice.
-/// Derived from the replacement's own `execute` effect so the label states
-/// the *result* of selecting it, not the source card's Oracle text.
+/// CR 616.1 / CR 614.1c / CR 614.1d: Effect-descriptive label for one candidate
+/// in a competing-replacement (distinct, non-optional) choice. Derived from the
+/// replacement's own `execute` effect so the label names what that effect DOES
+/// ("Enters tapped"), not the source card's Oracle text.
+///
+/// IMPORTANT — this is the label for one *effect*, not for the final outcome of
+/// the event. In a CR 616.1e ordering prompt the player arranges candidates and
+/// CR 616.1f applies them in sequence, so the effect applied LAST is the one
+/// whose write survives. A UI that renders these labels as if picking one
+/// selects its outcome states the exact opposite of the result whenever two
+/// candidates write the same field in opposite directions (the tapland +
+/// Spelunking class). Ordering prompts must present these as sequence entries
+/// with an explicit "applied last wins" frame; see `ReplacementChoiceKind`.
 ///
 /// NOTE: unlike the sibling `replacement_cost_description` (which is a
 /// fully-exhaustive `match` on `AbilityCost` with no wildcard, so a new
@@ -9244,6 +9265,30 @@ enum CandidateMateriality {
     Disjoint,
 }
 
+/// CR 614.1c: the `enter_tapped` commute class an effect writes, if it is the
+/// single-target self tap/untap modifier class. `None` for every other effect.
+///
+/// The single authority for "does this effect write `enter_tapped`, and in which
+/// direction" — shared by the `execute` path and the `decline`-branch path in
+/// [`candidate_materiality`] so the two cannot drift on which shapes count.
+/// The `target: TargetFilter::SelfRef` + `EffectScope::Single` constraints are
+/// load-bearing: a mass or non-self tap is not an ETB entry modifier.
+fn enter_tapped_commute_class(effect: &Effect) -> Option<CommuteClass> {
+    match effect {
+        // CR 701.26a / CR 701.26b: keyed by the value written, so opposite
+        // directions (tapland vs Spelunking) do NOT commute.
+        Effect::SetTapState {
+            target: TargetFilter::SelfRef,
+            scope: EffectScope::Single,
+            state,
+        } => Some(match state {
+            TapStateChange::Tap => CommuteClass::EnterTapped,
+            TapStateChange::Untap => CommuteClass::EnterUntapped,
+        }),
+        _ => None,
+    }
+}
+
 /// CR 616.1: classify a candidate. A `null`-`execute` replacement is *not* a
 /// guaranteed no-op — it can carry an event-modifying side field
 /// (`quantity_modification` / `mana_modification` / `damage_modification`) that
@@ -9389,6 +9434,28 @@ fn candidate_materiality(
                 commute: damage_commute_class(modification),
             };
         }
+        // CR 614.1c + CR 616.1e: a `null` `execute` whose MODE carries a
+        // `decline` branch still writes an event field when that branch runs.
+        // The shock-land class ("As this land enters, you may pay 2 life. If you
+        // don't, it enters tapped.") parses as `execute: None` +
+        // `MayCost { decline: SetTapState(Tap) }` — the enters-tapped write lives
+        // entirely in the decline branch. Without this the candidate classified
+        // `Disjoint`, no `enter_tapped` collision with a "lands enter untapped"
+        // source (Spelunking / Archelos) was detected, and the CR 616.1 ordering
+        // choice was silently skipped: declining the payment applied the tap
+        // unopposed. Mirrors the prevention-shield fix above, which had this
+        // identical `execute:null` blind spot.
+        //
+        // The declined branch is the one that can collide: paying the cost runs
+        // `execute` (here, nothing), so only the decline path writes the field.
+        if let Some(decline) = replacement_mode_decline(&repl_def.mode) {
+            if let Some(commute) = enter_tapped_commute_class(&decline.effect) {
+                return CandidateMateriality::Writes {
+                    field: EventField::EnterTapped,
+                    commute,
+                };
+            }
+        }
         return CandidateMateriality::Disjoint;
     };
     // CR 616.1: a proliferate count-doubler ("proliferate twice instead",
@@ -9442,6 +9509,10 @@ fn candidate_materiality(
             } => {
                 field = Some(EventField::EnterTapped);
                 // Keyed by the value written so opposite directions don't commute.
+                // NOTE: this arm is deliberately looser than
+                // `enter_tapped_commute_class` (it does not constrain `target`),
+                // preserving the pre-existing `execute`-path behavior; the shared
+                // helper is used for the stricter `decline`-branch classification.
                 enter_tapped_commute = Some(match state {
                     TapStateChange::Tap => CommuteClass::EnterTapped,
                     TapStateChange::Untap => CommuteClass::EnterUntapped,

--- a/crates/engine/src/game/resolution_prompt.rs
+++ b/crates/engine/src/game/resolution_prompt.rs
@@ -1038,6 +1038,7 @@ mod tests {
             player: PlayerId(0),
             candidate_count: 2,
             candidates: Vec::new(),
+            kind: Default::default(),
         };
         assert!(
             !matches!(base.waiting_for, WaitingFor::ReplacementChoice { .. }),

--- a/crates/engine/src/game/resolution_prompt.rs
+++ b/crates/engine/src/game/resolution_prompt.rs
@@ -1039,6 +1039,7 @@ mod tests {
             candidate_count: 2,
             candidates: Vec::new(),
             kind: Default::default(),
+            last_applied_decides: false,
         };
         assert!(
             !matches!(base.waiting_for, WaitingFor::ReplacementChoice { .. }),

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -4284,6 +4284,7 @@ mod tests {
             player: PlayerId(2),
             candidate_count: 1,
             candidates: vec![],
+            kind: Default::default(),
         };
         state.pending_replacement = Some(crate::types::game_state::PendingReplacement {
             proposed: ProposedEvent::Draw {

--- a/crates/engine/src/game/sba.rs
+++ b/crates/engine/src/game/sba.rs
@@ -4285,6 +4285,7 @@ mod tests {
             candidate_count: 1,
             candidates: vec![],
             kind: Default::default(),
+            last_applied_decides: false,
         };
         state.pending_replacement = Some(crate::types::game_state::PendingReplacement {
             proposed: ProposedEvent::Draw {

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -12337,6 +12337,14 @@ pub enum WaitingFor {
         /// and the many test constructions keep deserializing unchanged.
         #[serde(default)]
         kind: ReplacementChoiceKind,
+        /// CR 616.1f: whether the LAST-applied candidate alone decides the
+        /// outcome (every colliding write overwrites the whole field), so the
+        /// UI may name a concrete winning result. False for compositional
+        /// collisions — damage doublers vs adders, count and mana modifiers —
+        /// where both effects apply and there is no single winner. The display
+        /// layer must not assume last-write-wins; this is the engine's answer.
+        #[serde(default)]
+        last_applied_decides: bool,
     },
     /// CR 614.12a: choose the opponent that a permanent enters under before
     /// the zone change is delivered. `candidates` is captured at replacement
@@ -28325,6 +28333,7 @@ mod tests {
             candidate_count: 2,
             candidates: Vec::new(),
             kind: Default::default(),
+            last_applied_decides: false,
         };
         assert!(
             !matches!(state.waiting_for, WaitingFor::Priority { .. }),
@@ -28493,6 +28502,7 @@ mod tests {
             candidate_count: 2,
             candidates: Vec::new(),
             kind: Default::default(),
+            last_applied_decides: false,
         };
         assert!(
             !matches!(state.waiting_for, WaitingFor::Priority { .. }),
@@ -33648,6 +33658,7 @@ mod tests {
             candidate_count: 2,
             candidates: vec![],
             kind: Default::default(),
+            last_applied_decides: false,
         }));
         variants.push(Box::new(WaitingFor::ExploreChoice {
             player: PlayerId(0),

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -8471,12 +8471,15 @@ pub enum ReplacementChoiceKind {
     /// effect applied LAST is the one whose write survives.
     #[default]
     Order,
-    /// CR 614.1: a single optional ("you may") replacement surfaced as two
-    /// branches of one source — index 0 accepts, index 1 declines. A yes/no
-    /// decision, NOT an ordering; it must never render as a sortable list.
+    /// A single optional ("you may") replacement surfaced as two branches of
+    /// one source — index 0 accepts, index 1 declines. This is an engine
+    /// presentation shape, not a CR-numbered category: the yes/no decision
+    /// belongs to whoever the effect's own text gives it to. It is NOT an
+    /// ordering and must never render as a sortable list.
     OptionalBranch,
-    /// CR 616.1: a choice between destinations for a found card. Distinct
-    /// alternatives rather than a sequence, so it also renders as plain options.
+    /// A choice between destinations for a found card. Like `OptionalBranch`
+    /// this is an engine presentation shape: the options are mutually exclusive
+    /// alternatives rather than a sequence, so it renders as plain options.
     SearchFoundDestination,
 }
 
@@ -11589,6 +11592,39 @@ impl TrustedGameStateEnvelope {
 }
 
 impl GameState {
+    /// CR 616.1 load migration: re-derive `ReplacementChoice::kind` from the
+    /// live pending replacement.
+    ///
+    /// `kind` is `#[serde(default)]`, so a save written before the field existed
+    /// deserializes every parked prompt as `Order` — including an optional
+    /// "you may" accept/decline and a search-found destination pick. The
+    /// frontend keys its presentation off `kind`, so a restored legacy save
+    /// would render a sortable ordering list for a yes/no decision.
+    ///
+    /// `replacement_choice_waiting_for` is the single authority that classifies
+    /// a prompt from `pending_replacement`, so re-deriving through it keeps the
+    /// restored value identical to what a live park would have produced. With no
+    /// pending replacement there is nothing to classify and the prompt is left
+    /// untouched (it is already unactionable and handled by the count-0 guard).
+    fn migrate_restored_replacement_choice_kind(&mut self) {
+        let WaitingFor::ReplacementChoice { player, .. } = self.waiting_for else {
+            return;
+        };
+        if self.pending_replacement.is_none() {
+            return;
+        }
+        let rederived = crate::game::replacement::replacement_choice_waiting_for(player, self);
+        if let WaitingFor::ReplacementChoice { kind, .. } = rederived {
+            if let WaitingFor::ReplacementChoice {
+                kind: restored_kind,
+                ..
+            } = &mut self.waiting_for
+            {
+                *restored_kind = kind;
+            }
+        }
+    }
+
     /// CR 732.2a (FIX-3) load migration: `last_loop_action_sequence` is transient loop-detection
     /// bookkeeping that re-accumulates from live play. On restore, DROP it UNLESS the save was
     /// captured inside an object-growth shortcut proposal/response window
@@ -11902,6 +11938,12 @@ impl PersistedGameState {
         // CR 732.2a (FIX-3): drop stale transient loop-detection bookkeeping on load unless the save
         // sits in an object-growth shortcut window whose pending resolution still consumes it.
         state.migrate_transient_loop_sequence();
+        // CR 616.1: re-derive a parked replacement prompt's `kind` (see
+        // `migrate_restored_replacement_choice_kind`). Placed at this shared
+        // chokepoint so BOTH the untrusted `Raw` and trusted envelope paths get
+        // the repair — a legacy save restored through either one would
+        // otherwise present an optional or search-found prompt as an ordering.
+        state.migrate_restored_replacement_choice_kind();
         // `pending_trigger_event_batch` is a construction carrier for the
         // corresponding `pending_trigger`. A historical save can retain the
         // carrier after its trigger was dropped; it cannot represent live

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -8456,6 +8456,30 @@ pub struct ReplacementCandidateSummary {
     pub description: String,
 }
 
+/// CR 616.1: Which *kind* of decision a [`WaitingFor::ReplacementChoice`] asks
+/// for. One `WaitingFor` variant serves three structurally different prompts,
+/// and the display layer cannot tell them apart from the candidate list alone
+/// (an accept/decline pair and a two-effect ordering prompt are both "two
+/// candidates"). The engine owns the distinction; the frontend must never
+/// re-derive it by inspecting label text.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(tag = "type")]
+pub enum ReplacementChoiceKind {
+    /// CR 616.1e: two or more *distinct* applicable replacements whose order is
+    /// material. The player arranges them; per CR 616.1f the engine applies the
+    /// selected one and re-prompts for whatever is still applicable, so the
+    /// effect applied LAST is the one whose write survives.
+    #[default]
+    Order,
+    /// CR 614.1: a single optional ("you may") replacement surfaced as two
+    /// branches of one source — index 0 accepts, index 1 declines. A yes/no
+    /// decision, NOT an ordering; it must never render as a sortable list.
+    OptionalBranch,
+    /// CR 616.1: a choice between destinations for a found card. Distinct
+    /// alternatives rather than a sequence, so it also renders as plain options.
+    SearchFoundDestination,
+}
+
 /// CR 603.3b + CR 603.7: One completed normal-plus-delayed trigger collection
 /// for a single raw event batch, produced before any live occurrence is claimed.
 ///
@@ -12266,6 +12290,11 @@ pub enum WaitingFor {
         candidate_count: usize,
         #[serde(default)]
         candidates: Vec<ReplacementCandidateSummary>,
+        /// CR 616.1: which kind of decision this is. Defaults to
+        /// [`ReplacementChoiceKind::Order`] so pre-existing serialized states
+        /// and the many test constructions keep deserializing unchanged.
+        #[serde(default)]
+        kind: ReplacementChoiceKind,
     },
     /// CR 614.12a: choose the opponent that a permanent enters under before
     /// the zone change is delivered. `candidates` is captured at replacement
@@ -28253,6 +28282,7 @@ mod tests {
             player: PlayerId(0),
             candidate_count: 2,
             candidates: Vec::new(),
+            kind: Default::default(),
         };
         assert!(
             !matches!(state.waiting_for, WaitingFor::Priority { .. }),
@@ -28420,6 +28450,7 @@ mod tests {
             player: PlayerId(0),
             candidate_count: 2,
             candidates: Vec::new(),
+            kind: Default::default(),
         };
         assert!(
             !matches!(state.waiting_for, WaitingFor::Priority { .. }),
@@ -33574,6 +33605,7 @@ mod tests {
             player: PlayerId(0),
             candidate_count: 2,
             candidates: vec![],
+            kind: Default::default(),
         }));
         variants.push(Box::new(WaitingFor::ExploreChoice {
             player: PlayerId(0),

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -985,6 +985,7 @@ fn stage_prevented_cost_move(state: &mut GameState, source: engine::types::ident
         player: P0,
         candidate_count: 1,
         candidates: vec![],
+        kind: Default::default(),
     };
 }
 
@@ -4740,6 +4741,7 @@ fn effect_pay_cost_composite_mana_life_prevention_serializes_and_rides_once() {
         player: P0,
         candidate_count: 1,
         candidates: vec![],
+        kind: Default::default(),
     };
 
     let json = serde_json::to_string(runner.state())

--- a/crates/engine/tests/integration/cost_zone_pipeline.rs
+++ b/crates/engine/tests/integration/cost_zone_pipeline.rs
@@ -986,6 +986,7 @@ fn stage_prevented_cost_move(state: &mut GameState, source: engine::types::ident
         candidate_count: 1,
         candidates: vec![],
         kind: Default::default(),
+        last_applied_decides: false,
     };
 }
 
@@ -4742,6 +4743,7 @@ fn effect_pay_cost_composite_mana_life_prevention_serializes_and_rides_once() {
         candidate_count: 1,
         candidates: vec![],
         kind: Default::default(),
+        last_applied_decides: false,
     };
 
     let json = serde_json::to_string(runner.state())

--- a/crates/engine/tests/integration/issue_7234_cumulative_upkeep_effect_cost.rs
+++ b/crates/engine/tests/integration/issue_7234_cumulative_upkeep_effect_cost.rs
@@ -287,6 +287,7 @@ fn assert_replacement_choice_between_vorinclex_and_doc_samson(
         player,
         candidate_count,
         ref candidates,
+        ..
     } = runner.state().waiting_for
     else {
         panic!("{context}, got {:?}", runner.state().waiting_for);

--- a/crates/engine/tests/integration/loyalty_replacement_order_resume.rs
+++ b/crates/engine/tests/integration/loyalty_replacement_order_resume.rs
@@ -90,6 +90,7 @@ fn activate_to_ordering_prompt() -> (GameRunner, ObjectId, usize) {
             player,
             candidate_count,
             candidates,
+            ..
         } => {
             assert_eq!(*player, P0, "the affected permanent's controller chooses");
             assert_eq!(*candidate_count, 2, "doubler + halver compete");

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1093,6 +1093,7 @@ mod spear_of_bashenga_attacks_monarch_5249;
 mod special_action_x_runtime;
 mod specialize_runtime;
 mod spellstutter_sprite_counter_with_x;
+mod spelunking_shockland_order;
 mod sphinx_of_uthuun_etb_pile_separation;
 mod spikeshell_harrier_speed_superlative;
 mod split_offstack_mana_value;

--- a/crates/engine/tests/integration/spelunking_shockland_order.rs
+++ b/crates/engine/tests/integration/spelunking_shockland_order.rs
@@ -118,3 +118,282 @@ fn ordering_the_shockland_tap_last_still_enters_tapped() {
         "CR 616.1f: with the shock land's tap applied last the land enters tapped"
     );
 }
+
+/// CR 614.1c + CR 616.1e: the decline branch's self tap can sit on a CHAINED
+/// `sub_ability` rather than at the root ("...enters with a +1/+1 counter and
+/// enters tapped"). `candidate_materiality` must walk the decline chain the way
+/// the applier does, or the tap is classified `Disjoint` and the ordering
+/// prompt is suppressed exactly as it was for the root-level shock land.
+///
+/// The lead link is a SelfRef `PutCounter` — an event-modifier effect — because
+/// `EventModifiers::event_modifiers_for_ability` walks only a contiguous prefix
+/// of event modifiers. A non-modifier lead (e.g. `Draw`) stops the applier's
+/// walk, so a tap behind it is never applied and must NOT be classified as an
+/// `enter_tapped` write (see `chained_enter_tapped_commute_class`).
+///
+/// Goes RED if the decline walk is reduced to a root-only `decline.effect` check.
+#[test]
+fn chained_decline_tap_still_collides_with_an_untap_source() {
+    use engine::types::ability::{
+        AbilityCost, AbilityDefinition, AbilityKind, Effect, EffectScope, QuantityExpr,
+        ReplacementDefinition, ReplacementMode, TapStateChange, TargetFilter,
+    };
+    use engine::types::counter::CounterType;
+    use engine::types::replacements::ReplacementEvent;
+
+    // Decline branch: enter with a +1/+1 counter, THEN enter tapped. The lead
+    // link is itself an event modifier, so the applier's walk reaches the tap.
+    let chained_decline = AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::PutCounter {
+            counter_type: CounterType::Plus1Plus1,
+            count: QuantityExpr::Fixed { value: 1 },
+            target: TargetFilter::SelfRef,
+        },
+    )
+    .sub_ability(AbilityDefinition::new(
+        AbilityKind::Spell,
+        Effect::SetTapState {
+            target: TargetFilter::SelfRef,
+            scope: EffectScope::Single,
+            state: TapStateChange::Tap,
+        },
+    ));
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_enchantment_from_oracle(P0, "Spelunking", "Lands you control enter untapped.");
+    let mut builder = scenario.add_land_to_hand(P0, "Chained Tapland");
+    builder.with_replacement_definition(
+        ReplacementDefinition::new(ReplacementEvent::Moved)
+            .valid_card(TargetFilter::SelfRef)
+            .destination_zone(Zone::Battlefield)
+            .mode(ReplacementMode::MayCost {
+                cost: AbilityCost::PayLife {
+                    amount: QuantityExpr::Fixed { value: 2 },
+                },
+                decline: Some(Box::new(chained_decline)),
+            })
+            .description(
+                "As ~ enters, you may pay 2 life. If you don't, it enters tapped.".to_string(),
+            ),
+    );
+    let land_id = builder.id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&land_id].card_id;
+    runner
+        .act(GameAction::PlayLand {
+            object_id: land_id,
+            card_id,
+        })
+        .expect("play land should succeed");
+
+    let mut rounds = 0;
+    while let WaitingFor::ReplacementChoice { candidates, .. } = &runner.state().waiting_for {
+        let labels: Vec<String> = candidates.iter().map(|c| c.description.clone()).collect();
+        let pick = if let Some(i) = labels.iter().position(|d| d == "Decline") {
+            i
+        } else {
+            // Order the chained tap FIRST so Spelunking's untap applies last.
+            candidates
+                .iter()
+                .position(|c| c.source_name == "Chained Tapland")
+                .unwrap_or(0)
+        };
+        runner
+            .act(GameAction::ChooseReplacement { index: pick })
+            .expect("replacement choice should succeed");
+        rounds += 1;
+        assert!(rounds <= 6, "replacement prompt failed to terminate");
+    }
+
+    assert!(
+        rounds >= 2,
+        "CR 616.1e: a chained decline tap must still surface the ordering prompt, got {rounds} round(s)"
+    );
+    assert!(
+        !runner.state().objects[&land_id].tapped,
+        "CR 616.1f: with the untap applied last the land must enter untapped"
+    );
+}
+
+/// CR 616.1 restore migration: `ReplacementChoice::kind` is `#[serde(default)]`,
+/// so a save written before the field existed deserializes EVERY parked prompt
+/// as `Order` — including an optional "you may" accept/decline. The frontend
+/// keys its presentation off `kind`, so such a restore would render a sortable
+/// ordering list for a yes/no decision.
+///
+/// Simulates a legacy save by stripping `kind` from the serialized JSON, then
+/// asserts the restore re-derives it from the live pending replacement.
+///
+/// Goes RED if `migrate_restored_replacement_choice_kind` is removed from the
+/// shared load chokepoint.
+#[test]
+fn legacy_save_restores_an_optional_prompt_as_optional_not_ordering() {
+    use engine::game::scenario::GameRunner;
+    use engine::types::game_state::{PersistedGameState, ReplacementChoiceKind};
+
+    // Park a shock land's optional pay-2-life prompt (no untap source, so this
+    // is a pure OptionalBranch decision).
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let mut builder = scenario.add_land_to_hand(P0, "Stomping Ground");
+    builder.from_oracle_text(SHOCK_LAND);
+    let land_id = builder.id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&land_id].card_id;
+    runner
+        .act(GameAction::PlayLand {
+            object_id: land_id,
+            card_id,
+        })
+        .expect("play land should succeed");
+
+    let WaitingFor::ReplacementChoice { kind, .. } = &runner.state().waiting_for else {
+        panic!("expected the shock land to park an optional replacement prompt");
+    };
+    assert_eq!(
+        *kind,
+        ReplacementChoiceKind::OptionalBranch,
+        "reach guard: a live park must classify the shock payment as OptionalBranch"
+    );
+
+    // Round-trip with `kind` stripped, exactly as a pre-field save would decode.
+    let saved = serde_json::to_string(&PersistedGameState::capture(runner.state().clone()))
+        .expect("the paused state serializes");
+    let legacy = saved.replace(r#""kind":{"type":"OptionalBranch"},"#, "");
+    assert_ne!(
+        legacy, saved,
+        "reach guard: the `kind` field must actually be stripped, or this test is vacuous"
+    );
+
+    let restored: PersistedGameState =
+        serde_json::from_str(&legacy).expect("the legacy state deserializes");
+    let runner = GameRunner::from_state(
+        restored
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract"),
+    );
+
+    let WaitingFor::ReplacementChoice { kind, .. } = runner.state().waiting_for else {
+        panic!("the restored state must still carry the parked replacement prompt");
+    };
+    assert_eq!(
+        kind,
+        ReplacementChoiceKind::OptionalBranch,
+        "CR 616.1: a legacy save's optional prompt must restore as OptionalBranch, \
+         not as the serde default `Order` — otherwise the client renders a \
+         sortable ordering list for a yes/no decision"
+    );
+}
+
+/// CR 616.1 restore migration, search-found shape. Companion to the optional
+/// case above: a found-card destination prompt is a set of mutually exclusive
+/// alternatives, NOT a sequence, so a legacy save must not restore it as
+/// `Order` and render a sortable list.
+///
+/// Builds the parked prompt directly — a full search scenario is not needed to
+/// exercise the classification seam the migration re-derives through.
+///
+/// Goes RED if `migrate_restored_replacement_choice_kind` is removed from the
+/// shared load chokepoint.
+#[test]
+fn legacy_save_restores_a_search_found_prompt_as_search_found_not_ordering() {
+    use engine::game::scenario::GameRunner;
+    use engine::types::game_state::{
+        PendingReplacement, PersistedGameState, ReplacementChoiceKind, ZoneDeliveryExileTracking,
+    };
+    use engine::types::identifiers::ObjectIncarnationRef;
+    use engine::types::proposed_event::{
+        BoundSearchFoundCandidate, BoundSearchFoundDisposition, ProposedEvent,
+        SearchFoundDisposition,
+    };
+    use engine::types::ReplacementId;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let source = scenario
+        .add_enchantment_from_oracle(P0, "Search Rider", "")
+        .id();
+    let mut runner = scenario.build();
+
+    let rid = ReplacementId { source, index: 0 };
+    let found = runner.state().objects[&source].id;
+    let candidate = BoundSearchFoundCandidate {
+        replacement_id: rid,
+        disposition: BoundSearchFoundDisposition {
+            destination: Zone::Exile,
+            source: ObjectIncarnationRef {
+                object_id: source,
+                incarnation: runner.state().objects[&source].incarnation,
+            },
+            grant: None,
+        },
+        source_name: "Search Rider".to_string(),
+        description: "Exile it instead".to_string(),
+        is_optional: false,
+    };
+    let state = runner.state_mut();
+    state.pending_replacement = Some(PendingReplacement {
+        proposed: ProposedEvent::SearchFound {
+            searcher: P0,
+            library_owner: Some(P0),
+            object_id: found,
+            disposition: SearchFoundDisposition::Original,
+            applied: Default::default(),
+        },
+        sacrifice_provenance: None,
+        candidates: vec![rid],
+        search_found_candidates: vec![candidate],
+        depth: 0,
+        is_optional: false,
+        library_placement: None,
+        exile_controller: None,
+        exile_duration: None,
+        exile_tracking: ZoneDeliveryExileTracking::None,
+        excess_recipient: None,
+        lifelink_bonus: 0,
+        may_cost_paid: false,
+        may_cost_remaining: None,
+    });
+    let parked = engine::game::replacement::replacement_choice_waiting_for(P0, runner.state());
+    runner.state_mut().waiting_for = parked;
+
+    let WaitingFor::ReplacementChoice { kind, .. } = runner.state().waiting_for else {
+        panic!("expected a parked search-found replacement prompt");
+    };
+    assert_eq!(
+        kind,
+        ReplacementChoiceKind::SearchFoundDestination,
+        "reach guard: a live park must classify this as SearchFoundDestination, \
+         or the restore assertion below is vacuous"
+    );
+
+    let saved = serde_json::to_string(&PersistedGameState::capture(runner.state().clone()))
+        .expect("the paused state serializes");
+    let legacy = saved.replace(r#""kind":{"type":"SearchFoundDestination"},"#, "");
+    assert_ne!(
+        legacy, saved,
+        "reach guard: the `kind` field must actually be stripped, or this test is vacuous"
+    );
+
+    let restored: PersistedGameState =
+        serde_json::from_str(&legacy).expect("the legacy state deserializes");
+    let runner = GameRunner::from_state(
+        restored
+            .into_game_state()
+            .expect("persisted test snapshot satisfies the checked restore contract"),
+    );
+
+    let WaitingFor::ReplacementChoice { kind, .. } = runner.state().waiting_for else {
+        panic!("the restored state must still carry the parked replacement prompt");
+    };
+    assert_eq!(
+        kind,
+        ReplacementChoiceKind::SearchFoundDestination,
+        "CR 616.1: a legacy save's search-found prompt must restore as \
+         SearchFoundDestination, not as the serde default `Order`"
+    );
+}

--- a/crates/engine/tests/integration/spelunking_shockland_order.rs
+++ b/crates/engine/tests/integration/spelunking_shockland_order.rs
@@ -132,8 +132,9 @@ fn ordering_the_shockland_tap_last_still_enters_tapped() {
 /// `enter_tapped` write (see `chained_enter_tapped_commute_class`).
 ///
 /// Goes RED if the decline walk is reduced to a root-only `decline.effect` check.
-#[test]
-fn chained_decline_tap_still_collides_with_an_untap_source() {
+/// Drives the chained-decline scenario, declining the payment. `untap_last`
+/// picks the ordering; returns `(entered_tapped, prompt_rounds)`.
+fn play_chained_tapland_declining(untap_last: bool) -> (bool, usize) {
     use engine::types::ability::{
         AbilityCost, AbilityDefinition, AbilityKind, Effect, EffectScope, QuantityExpr,
         ReplacementDefinition, ReplacementMode, TapStateChange, TargetFilter,
@@ -195,11 +196,20 @@ fn chained_decline_tap_still_collides_with_an_untap_source() {
         let pick = if let Some(i) = labels.iter().position(|d| d == "Decline") {
             i
         } else {
-            // Order the chained tap FIRST so Spelunking's untap applies last.
-            candidates
+            // CR 616.1f: the effect applied LAST wins, so selecting the TAP
+            // first makes the untap win, and vice versa.
+            let tap = candidates
                 .iter()
-                .position(|c| c.source_name == "Chained Tapland")
-                .unwrap_or(0)
+                .position(|c| c.source_name == "Chained Tapland");
+            let untap = candidates
+                .iter()
+                .position(|c| c.source_name == "Spelunking");
+            let (first, other) = if untap_last {
+                (tap, untap)
+            } else {
+                (untap, tap)
+            };
+            first.or(other).unwrap_or(0)
         };
         runner
             .act(GameAction::ChooseReplacement { index: pick })
@@ -208,13 +218,46 @@ fn chained_decline_tap_still_collides_with_an_untap_source() {
         assert!(rounds <= 6, "replacement prompt failed to terminate");
     }
 
+    let obj = &runner.state().objects[&land_id];
+    assert_eq!(obj.zone, Zone::Battlefield, "the land entered play");
+    (obj.tapped, rounds)
+}
+
+/// CR 616.1e: the chained decline tap must surface the ordering prompt.
+///
+/// Goes RED if the decline walk is reduced to a root-only `decline.effect` check.
+#[test]
+fn chained_decline_tap_still_collides_with_an_untap_source() {
+    let (tapped, rounds) = play_chained_tapland_declining(true);
     assert!(
         rounds >= 2,
         "CR 616.1e: a chained decline tap must still surface the ordering prompt, got {rounds} round(s)"
     );
     assert!(
-        !runner.state().objects[&land_id].tapped,
+        !tapped,
         "CR 616.1f: with the untap applied last the land must enter untapped"
+    );
+}
+
+/// The MIRROR of the case above, and the half that makes it discriminating.
+///
+/// `!tapped` alone is equally consistent with "the chained tap was applied and
+/// then correctly overwritten" and with "the chained tap was never applied at
+/// all" — it passes in both the working and the broken world. This test pins
+/// the opposite ordering: applying the chained tap LAST must leave the land
+/// TAPPED, which is only true if the classifier and the applier agree that the
+/// chained tap really writes `enter_tapped`. A degenerate ordering (or a
+/// classifier/applier disagreement) fails one of the pair.
+#[test]
+fn ordering_the_chained_decline_tap_last_still_enters_tapped() {
+    let (tapped, rounds) = play_chained_tapland_declining(false);
+    assert!(
+        rounds >= 2,
+        "CR 616.1e: the ordering prompt must still be offered, got {rounds} round(s)"
+    );
+    assert!(
+        tapped,
+        "CR 616.1f: with the chained tap applied last the land must enter tapped —          if this fails while its mirror passes, the chained tap is never applied          and the classifier disagrees with the applier"
     );
 }
 
@@ -395,5 +438,73 @@ fn legacy_save_restores_a_search_found_prompt_as_search_found_not_ordering() {
         ReplacementChoiceKind::SearchFoundDestination,
         "CR 616.1: a legacy save's search-found prompt must restore as \
          SearchFoundDestination, not as the serde default `Order`"
+    );
+}
+
+/// CR 616.1f: the ordering prompt's `last_applied_decides` flag must be TRUE for
+/// a whole-field overwrite collision (the enters-tapped class), so the client may
+/// name a concrete winning result.
+///
+/// The companion negative case lives in the engine unit tests: a compositional
+/// collision (damage doubler vs adder) and the first-applied-wins EmptyManaPool
+/// sentinel must both report FALSE, because naming a "winner" there would state
+/// an outcome that does not exist (or the exact inverse).
+///
+/// Goes RED if the flag is hardcoded true or dropped from the payload.
+#[test]
+fn enter_tapped_ordering_prompt_reports_last_applied_decides() {
+    use engine::types::game_state::ReplacementChoiceKind;
+
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_enchantment_from_oracle(P0, "Spelunking", "Lands you control enter untapped.");
+    let mut builder = scenario.add_land_to_hand(P0, "Stomping Ground");
+    builder.from_oracle_text(SHOCK_LAND);
+    let land_id = builder.id();
+
+    let mut runner = scenario.build();
+    let card_id = runner.state().objects[&land_id].card_id;
+    runner
+        .act(GameAction::PlayLand {
+            object_id: land_id,
+            card_id,
+        })
+        .expect("play land should succeed");
+
+    // With an untap source out, the tap-vs-untap ordering prompt is raised
+    // alongside the shock land's own optional payment. Capture the flag from the
+    // FIRST prompt whose kind is `Order` — that is the one the client renders as
+    // a sortable list.
+    let mut seen_order = None;
+    let mut guard = 0;
+    while let WaitingFor::ReplacementChoice {
+        kind,
+        last_applied_decides,
+        ref candidates,
+        ..
+    } = runner.state().waiting_for
+    {
+        if kind == ReplacementChoiceKind::Order && seen_order.is_none() {
+            seen_order = Some(last_applied_decides);
+        }
+        // Advance: decline a payment branch when offered, else take the first
+        // ordering candidate.
+        let pick = candidates
+            .iter()
+            .position(|c| c.description == "Decline")
+            .unwrap_or(0);
+        runner
+            .act(GameAction::ChooseReplacement { index: pick })
+            .expect("replacement choice should succeed");
+        guard += 1;
+        assert!(guard <= 6, "replacement prompt failed to terminate");
+    }
+
+    let last_applied_decides = seen_order
+        .expect("reach guard: an Order prompt must occur, or the flag assertion is vacuous");
+    assert!(
+        last_applied_decides,
+        "CR 616.1f: two single-target SetTapState writers each stamp the whole \
+         `enter_tapped` field, so the last one applied decides the outcome"
     );
 }

--- a/crates/engine/tests/integration/spelunking_shockland_order.rs
+++ b/crates/engine/tests/integration/spelunking_shockland_order.rs
@@ -1,0 +1,120 @@
+//! CR 616.1e/f: a shock land played while a "lands enter untapped" source is on
+//! the battlefield must offer the ordering choice, so the player can have the
+//! untap effect apply LAST and win.
+//!
+//! The shock-land class ("As this land enters, you may pay 2 life. If you don't,
+//! it enters tapped.") parses as `execute: None` with the enters-tapped write
+//! living in `ReplacementMode::MayCost`'s `decline` branch. `candidate_materiality`
+//! only walked `execute`, so the candidate classified `Disjoint`, no
+//! `enter_tapped` collision with Spelunking was detected, and declining the
+//! payment applied the tap unopposed — the land entered tapped with no ordering
+//! prompt, contradicting Spelunking's ruling that the player chooses.
+//!
+//! Goes RED if the decline-branch arm in `candidate_materiality` is reverted.
+
+use engine::game::scenario::{GameScenario, P0};
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+const SHOCK_LAND: &str =
+    "({T}: Add {R} or {G}.)\nAs this land enters, you may pay 2 life. If you don't, it enters tapped.";
+
+/// Plays a shock land under Spelunking, declining the life payment. `untap_last`
+/// picks the ordering: when the untap is applied last it must win (CR 616.1f).
+/// Returns `(entered_tapped, prompt_rounds, life_paid)`.
+fn play_shockland_declining(untap_last: bool) -> (bool, usize, i32) {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.add_enchantment_from_oracle(P0, "Spelunking", "Lands you control enter untapped.");
+    let mut builder = scenario.add_land_to_hand(P0, "Stomping Ground");
+    builder.from_oracle_text(SHOCK_LAND);
+    let land_id = builder.id();
+
+    let mut runner = scenario.build();
+    let starting_life = runner.state().players[0].life;
+    let card_id = runner.state().objects[&land_id].card_id;
+    runner
+        .act(GameAction::PlayLand {
+            object_id: land_id,
+            card_id,
+        })
+        .expect("play land should succeed");
+
+    let mut rounds = 0;
+    while let WaitingFor::ReplacementChoice { candidates, .. } = &runner.state().waiting_for {
+        // Decline the "Pay 2 life" branch; in an ordering round, put the shock
+        // land's tap first (so Spelunking's untap applies last) or vice versa.
+        let labels: Vec<String> = candidates.iter().map(|c| c.description.clone()).collect();
+        // Identify the ordering candidates by SOURCE, not by label text: the
+        // shock land's ordering label is its full Oracle text, not "Enters
+        // tapped" (its tap lives in the decline branch, so
+        // `replacement_choice_label` falls back to the description).
+        let untap_idx = candidates
+            .iter()
+            .position(|c| c.source_name == "Spelunking");
+        let tap_idx = candidates
+            .iter()
+            .position(|c| c.source_name == "Stomping Ground");
+        let pick = if let Some(i) = labels.iter().position(|d| d == "Decline") {
+            i
+        } else {
+            // CR 616.1f: the effect applied LAST wins, so to make the untap win
+            // we select the TAP first.
+            let (first, other) = if untap_last {
+                (tap_idx, untap_idx)
+            } else {
+                (untap_idx, tap_idx)
+            };
+            first.or(other).unwrap_or(0)
+        };
+        runner
+            .act(GameAction::ChooseReplacement { index: pick })
+            .expect("replacement choice should succeed");
+        rounds += 1;
+        assert!(rounds <= 6, "replacement prompt failed to terminate");
+    }
+
+    let obj = &runner.state().objects[&land_id];
+    assert_eq!(obj.zone, Zone::Battlefield, "the land entered play");
+    (
+        obj.tapped,
+        rounds,
+        starting_life - runner.state().players[0].life,
+    )
+}
+
+#[test]
+fn declining_shockland_under_spelunking_can_enter_untapped() {
+    let (tapped, rounds, life_paid) = play_shockland_declining(true);
+
+    // CR 616.1: declining the payment must NOT end the decision — the shock
+    // land's tap and Spelunking's untap both write `enter_tapped`, so the
+    // player is owed the ordering choice.
+    assert!(
+        rounds >= 2,
+        "CR 616.1e: expected a second prompt to order the shock land's tap \
+         against Spelunking's untap, got {rounds} round(s)"
+    );
+
+    // CR 616.1f: the untap was applied last, so it wins.
+    assert!(
+        !tapped,
+        "CR 616.1f: with Spelunking's untap applied last the land must enter untapped"
+    );
+
+    // The payment was declined, so no life was paid.
+    assert_eq!(life_paid, 0, "declining the shock payment costs no life");
+}
+
+#[test]
+fn ordering_the_shockland_tap_last_still_enters_tapped() {
+    // The mirror ordering stays reachable — CR 616.1e genuinely offers both
+    // outcomes, so this must NOT be "Spelunking always wins".
+    let (tapped, _rounds, _life_paid) = play_shockland_declining(false);
+    assert!(
+        tapped,
+        "CR 616.1f: with the shock land's tap applied last the land enters tapped"
+    );
+}

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -38,6 +38,14 @@ pub enum ServerErrorCode {
 /// rather than a parse error, and the handshake is the only place that pairing
 /// can be refused. See 24.
 ///
+/// 63 — `WaitingFor::ReplacementChoice` gained an engine-owned
+///      `ReplacementChoiceKind` discriminator and a `last_applied_decides`
+///      flag. Both are `#[serde(default)]`, so a v62 peer decodes the payload
+///      successfully and then falls back to the `Order` default: it renders a
+///      drag-to-order list for a yes/no "you may" prompt, and names a winning
+///      outcome for a compositional collision that has none. A silent
+///      misrender rather than a decode failure, so the exact-match full-game
+///      handshake must refuse the pairing. Lobby messages are unchanged.
 /// 62 — `ServerMessage::{GameStarted, StateUpdate}` gained
 ///      `activation_block_reasons: HashMap<ObjectId, Vec<AbilityBlockEntry>>` —
 ///      the CR 118.3 "you can't pay this cost right now" read-out, scoped to the
@@ -330,7 +338,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 62;
+pub const PROTOCOL_VERSION: u32 = 63;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake **from clients that predate [`LOBBY_PROTOCOL_VERSION`]** — the
@@ -1076,12 +1084,12 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 62);
+        assert_eq!(PROTOCOL_VERSION, 63);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot
         // understand a success acknowledgment the submitting client awaits.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 61);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 62);
     }
 
     #[test]

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -3099,8 +3099,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_62_for_activation_block_readout() {
-        assert_eq!(PROTOCOL_VERSION, 62);
+    fn protocol_version_is_63_for_replacement_choice_kind() {
+        assert_eq!(PROTOCOL_VERSION, 63);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -3111,7 +3111,7 @@ mod tests {
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
     /// this guards — and this test reds while
-    /// `protocol_version_is_62_for_activation_block_readout` stays
+    /// `protocol_version_is_63_for_replacement_choice_kind` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 62;
+const EXPECTED_PROTOCOL_VERSION = 63;
 // The LOBBY message-set version, not derived from the full-game number above.
 // The classifier below refuses an expression only on the SOURCE constants; this
 // script never reads itself, so its own EXPECTED_* must stay literals.
@@ -14,7 +14,7 @@ const EXPECTED_LOBBY_PROTOCOL_VERSION = 4;
 // here, so a full-game bump could ship with an unbumped P2P version and CI
 // stayed green — a v(n-1) host and a v(n) guest would then complete a
 // handshake and only fail when the incompatible payload arrived.
-const EXPECTED_WIRE_PROTOCOL_VERSION = 46;
+const EXPECTED_WIRE_PROTOCOL_VERSION = 47;
 
 function extractVersion(source, pattern, label) {
   const match = source.match(pattern);


### PR DESCRIPTION
A shock land played while Spelunking is on the battlefield entered tapped
with no chance to order the two replacements, contradicting Spelunking's
ruling that the player chooses the outcome.

CR 616.1e/f: both effects modify the same ETB event, so the affected
object's controller orders them and the effect applied LAST wins.
`candidate_materiality` decided whether a replacement writes `enter_tapped`
by walking `execute` only. The shock-land class ("As this land enters, you
may pay 2 life. If you don't, it enters tapped.") parses as `execute: None`
with the tap living in `ReplacementMode::MayCost`'s `decline` branch, so it
classified `Disjoint`, no collision with the untap source was detected, and
declining applied the tap unopposed.

Inspect the decline branch through a new shared `enter_tapped_commute_class`
helper, mirroring the prevention-shield fix that had the identical
`execute: null` blind spot. Covers the whole class, not one card: every
shock land, plus any "you may pay/do X, otherwise it enters tapped" land.

Also rework the replacement prompt, which stated the opposite of the result.
`replacement_choice_label` produces outcome-worded labels ("Enters
untapped"), but an ordering prompt applies the selected candidate FIRST, so
picking the label you want handed you the other outcome:

- Engine: add `ReplacementChoiceKind` (Order / OptionalBranch /
  SearchFoundDestination) to `WaitingFor::ReplacementChoice`. The candidate
  list alone cannot distinguish an accept/decline pair from a two-effect
  ordering prompt, and the display layer must not infer it from label text.
  `#[serde(default)]` keeps existing serialized states loading.
- Frontend: ordering prompts render as a reorderable list — drag
  (framer-motion `Reorder`, `touch-none` so touch reorders instead of
  scrolling) plus arrow buttons as the accessible path — with
  applied-first/applied-last framing and a live "Result:" banner. Optional
  and destination prompts keep plain option buttons.
- Copy updated in all seven locales (localeParity requires key parity).

Only the first entry is submitted per round: CR 616.2 lets applying one
effect add or remove others (a copy effect can strip the enters-tapped
ability), so the engine re-prompts rather than replaying a blind permutation.

Tests: full integration suite 5883 passed; engine lib 1004 passed.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for ordering multiple replacement effects during gameplay decisions.
  * Added drag-and-drop and move controls, applied-first/applied-last labels, result messaging, and confirmation for replacement ordering.
  * Added localized replacement-ordering guidance in English, German, Spanish, French, Italian, Polish, and Portuguese.
  * Added guidance for composing effects whose order changes the final outcome.

* **Bug Fixes**
  * Improved replacement ordering for effects affecting whether permanents enter tapped.
  * Replacement prompts now distinguish ordering, optional choices, and destination selection.
  * Restored games now recover the appropriate replacement prompt type.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->