### PR TITLE
fix(p2p): reject stale state snapshots

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -824,7 +824,10 @@ jobs:
           test -x "$NODE_BIN"
           test -f "$TAURI_JS"
           export ORG_GRADLE_PROJECT_phaseNodeExecutable="$NODE_BIN"
-          "$NODE_BIN" "$TAURI_JS" android build --debug --target aarch64 --apk
+          (
+            cd client
+            "$NODE_BIN" "$TAURI_JS" android build --debug --target aarch64 --apk
+          )
 
       - name: Inspect ARM64 debug APK
         run: |

--- a/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
+++ b/client/src/adapter/__tests__/p2p-adapter-multiplayer.test.ts
@@ -738,6 +738,19 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
     expect(mocks.setAiDecisionDiagnosticsEnabled).toHaveBeenCalledWith(true);
   });
 
+  it("exposes authoritative export from every P2P host", async () => {
+    const { adapter } = makeHost(2);
+
+    expect(adapter.exportPersistenceState).toBeDefined();
+    await expect(adapter.exportPersistenceState!()).resolves.toBe(
+      JSON.stringify({ players: [], objects: {} }),
+    );
+    expect(mocks.exportPersistenceState).toHaveBeenCalledOnce();
+
+    const { adapter: nativeHost } = makeNativeHost();
+    expect(nativeHost.exportPersistenceState).toBeDefined();
+  });
+
   it("exposes local diagnostics after native guest attachment falls back to WASM", async () => {
     const { adapter, emitConnection } = makeNativeHost();
     nativeWebSocketMocks.waitForPlayerSlots.mockResolvedValue([]);
@@ -2893,6 +2906,59 @@ describe("P2PHostAdapter — 3-4p multiplayer", () => {
         logEntries: unsolicitedLogs,
       }),
     );
+  });
+
+  it("does not replace a guest's newer snapshot with a stale state revision", async () => {
+    const { peer } = createFakePeer();
+    const conn = new FakeDataConnection();
+    const adapter = new P2PGuestAdapter(
+      { player: { main_deck: [], sideboard: [] } },
+      peer as unknown as Peer,
+      "host-peer",
+      conn as unknown as DataConnection,
+    );
+    const emitted = vi.fn();
+    adapter.onEvent(emitted);
+    await adapter.initialize();
+
+    await conn.simulateData({
+      type: "game_setup",
+      wireProtocolVersion: WIRE_PROTOCOL_VERSION,
+      assignedPlayerId: 1,
+      playerToken: "seat-token",
+      revision: 8,
+      state: remoteState("setup"),
+      events: [],
+      legalActions: [],
+      autoPassRecommended: false,
+      manaPaymentShortcutActions: [],
+    });
+    await adapter.initializeGame();
+    emitted.mockClear();
+
+    await conn.simulateData({
+      type: "state_update",
+      revision: 9,
+      state: remoteState("current"),
+      events: [],
+      legalActions: [],
+      autoPassRecommended: false,
+      manaPaymentShortcutActions: [],
+    });
+    emitted.mockClear();
+
+    await conn.simulateData({
+      type: "state_update",
+      revision: 8,
+      state: remoteState("stale"),
+      events: [],
+      legalActions: [],
+      autoPassRecommended: false,
+      manaPaymentShortcutActions: [],
+    });
+
+    expect(((await adapter.getState()) as unknown as { label: string }).label).toBe("current");
+    expect(emitted).not.toHaveBeenCalled();
   });
 
   it("guest receive path resolves action_noop without replacing its cached snapshot", async () => {

--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -126,7 +126,7 @@ describe("WebSocketAdapter", () => {
   beforeEach(async () => {
     MockWebSocket.last = null;
     adapter = new WebSocketAdapter(
-      "ws://localhost:9374/ws",
+      "wss://localhost:9374/ws",
       "host",
       { main_deck: [], sideboard: [] },
     );
@@ -177,6 +177,20 @@ describe("WebSocketAdapter", () => {
     await expect(exported).rejects.toMatchObject({
       code: "WS_ERROR",
       message: "Only the game host can export authoritative state",
+      recoverable: false,
+    });
+  });
+
+  it("does not request an authoritative export over cleartext WebSocket", async () => {
+    const insecure = new WebSocketAdapter(
+      "ws://localhost:9374/ws",
+      "host",
+      { main_deck: [], sideboard: [] },
+    );
+
+    await expect(insecure.exportPersistenceState()).rejects.toMatchObject({
+      code: "WS_ERROR",
+      message: "Authoritative-state export requires a secure connection",
       recoverable: false,
     });
   });

--- a/client/src/adapter/__tests__/ws-adapter.test.ts
+++ b/client/src/adapter/__tests__/ws-adapter.test.ts
@@ -151,6 +151,36 @@ describe("WebSocketAdapter", () => {
     expect(ws.send).toHaveBeenLastCalledWith(JSON.stringify({ type: "ConcedeMatch" }));
   });
 
+  it("exports only the trusted snapshot returned by the server", async () => {
+    const exported = adapter.exportPersistenceState();
+
+    expect(ws.send).toHaveBeenLastCalledWith(JSON.stringify({ type: "ExportAuthoritativeState" }));
+
+    ws.dispatchSynthetic(
+      "message",
+      JSON.stringify({ type: "AuthoritativeStateExport", data: { state: "{\"state\":{}}" } }),
+    );
+
+    await expect(exported).resolves.toBe("{\"state\":{}}");
+  });
+
+  it("rejects an authoritative export failure without ending the session", async () => {
+    const exported = adapter.exportPersistenceState();
+    ws.dispatchSynthetic(
+      "message",
+      JSON.stringify({
+        type: "AuthoritativeStateExportFailed",
+        data: { message: "Only the game host can export authoritative state" },
+      }),
+    );
+
+    await expect(exported).rejects.toMatchObject({
+      code: "WS_ERROR",
+      message: "Only the game host can export authoritative state",
+      recoverable: false,
+    });
+  });
+
 /* Legacy browser-owned Resolve All transport coverage removed with the transport.
   it("publishes a Resolve All decision state before resolving its acknowledgement", async () => {
     const listener = vi.fn();

--- a/client/src/adapter/p2p-adapter.ts
+++ b/client/src/adapter/p2p-adapter.ts
@@ -345,6 +345,10 @@ class NativeP2PBridge {
     return this.clientFor(playerId).previewManaPayment(action, playerId);
   }
 
+  async exportPersistenceState(): Promise<string> {
+    return this.clientFor(0).exportPersistenceState();
+  }
+
   async getState(): Promise<GameState> {
     return this.clientFor(0).getState();
   }
@@ -736,6 +740,8 @@ function hostDisposedError(): AdapterError {
 export class P2PHostAdapter implements EngineAdapter {
   private wasm = getHostAdapter();
   private nativeBridge: NativeP2PBridge | null = null;
+  /** Present for a P2P host, whether its authority is browser WASM or native. */
+  exportPersistenceState?: () => Promise<string>;
   private nativeInitialSetupPending = false;
   private listeners: P2PAdapterEventListener[] = [];
   /**
@@ -972,17 +978,24 @@ export class P2PHostAdapter implements EngineAdapter {
         (fault) => this.enqueueDelivery(() => this.handleNativeAiDriverFault(fault)),
         nativeResume,
       );
-    } else {
-      this.attachBrowserAiDecisionDiagnostics();
     }
+    this.attachAuthorityDiagnostics();
   }
 
   /**
-   * Installs the local-only diagnostics capability once this host is backed by
-   * browser WASM. It deliberately remains an instance property: native hosts
-   * and P2P guests must fail capability detection rather than receive a no-op.
+   * Installs the local authority diagnostics capability. Native hosts request
+   * the server's trusted envelope; browser hosts obtain it from their WASM
+   * engine. P2P guests never construct this adapter.
    */
-  private attachBrowserAiDecisionDiagnostics(): void {
+  private attachAuthorityDiagnostics(): void {
+    this.exportPersistenceState = async () => {
+      this.assertNotDisposed();
+      if (!this.ownsAuthority()) {
+        throw new AdapterError("P2P_ERROR", "P2P host authority changed", false);
+      }
+      if (this.nativeBridge) return this.nativeBridge.exportPersistenceState();
+      return this.wasm.exportPersistenceState();
+    };
     if (this.nativeBridge) return;
     Object.assign(this, {
       setAiDecisionDiagnosticsEnabled: (enabled: boolean) =>
@@ -1584,7 +1597,7 @@ export class P2PHostAdapter implements EngineAdapter {
           });
           this.nativeBridge.dispose();
           this.nativeBridge = null;
-          this.attachBrowserAiDecisionDiagnostics();
+          this.attachAuthorityDiagnostics();
         }
       }
       // A teardown may have landed while `wasm.initialize()` (and the native
@@ -1806,7 +1819,7 @@ export class P2PHostAdapter implements EngineAdapter {
           });
           this.nativeBridge.dispose();
           this.nativeBridge = null;
-          this.attachBrowserAiDecisionDiagnostics();
+          this.attachAuthorityDiagnostics();
         }
       }
       if (!this.ownsAuthority()) {
@@ -1921,7 +1934,7 @@ export class P2PHostAdapter implements EngineAdapter {
       });
       this.nativeBridge.dispose();
       this.nativeBridge = null;
-      this.attachBrowserAiDecisionDiagnostics();
+      this.attachAuthorityDiagnostics();
     }
   }
 
@@ -3868,6 +3881,17 @@ export class P2PGuestAdapter implements EngineAdapter {
       }
       case "state_update": {
         if (this.authenticatedSession !== session) return;
+        // PeerJS normally preserves message order, but state resync after a
+        // reconnect can race a previously queued delivery. Never let that old
+        // view overwrite a newer authority revision: it can leave two peers
+        // each waiting for the other to act.
+        if (
+          msg.revision !== undefined
+          && this.cachedRevision !== null
+          && msg.revision < this.cachedRevision
+        ) {
+          return;
+        }
         this.cachedRevision = msg.revision ?? null;
         const updateSnapshot = this.cacheSnapshot(msg.state, legalActionsFromWire(msg));
         if (this.pendingResolve) {

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -203,6 +203,9 @@ export class NativeEngineVersionMismatchError extends Error {
  * `crates/server-core/src/protocol.rs`. Bump in lockstep when either side
  * adds, removes, renames, or changes the type of a protocol variant field.
  *
+ * 56 — Host-only authoritative-state export request/response variants. Native
+ *      P2P sends each player a redacted view, so the host must ask its local
+ *      server for the trusted engine envelope rather than export that view.
  * 55 — DerivedViews.room_half_identities publishes both halves of every
  *      battlefield Room in printed order, resolved through the COPIED halves
  *      for a permanent that copies a Room (CR 709.5b + CR 707.2). The unlock
@@ -388,7 +391,7 @@ export class NativeEngineVersionMismatchError extends Error {
  *      into a MulliganDecisionPhase::BottomCards sub-phase on
  *      WaitingFor::MulliganDecision.
  */
-export const PROTOCOL_VERSION = 55;
+export const PROTOCOL_VERSION = 56;
 
 /**
  * Lowest server protocol version this client will accept in the handshake.
@@ -616,6 +619,10 @@ export class WebSocketAdapter implements EngineAdapter {
     number,
     { resolve: (sourceIds: ObjectId[]) => void; reject: (error: Error) => void }
   >();
+  private pendingAuthoritativeStateExport: {
+    resolve: (state: string) => void;
+    reject: (error: Error) => void;
+  } | null = null;
   private initResolve: (() => void) | null = null;
   private initReject: ((error: Error) => void) | null = null;
   /** Starting-player contest event captured from the initial GameStarted
@@ -974,6 +981,9 @@ export class WebSocketAdapter implements EngineAdapter {
       this.rejectPendingManaPaymentPreviews(
         new AdapterError("WS_CLOSED", "Connection closed during mana-payment preview", true),
       );
+      this.rejectAuthoritativeStateExport(
+        new AdapterError("WS_CLOSED", "Connection closed during authoritative-state export", true),
+      );
       this.rejectPregameMutation(
         new AdapterError("WS_CLOSED", "Connection closed during seat mutation", true),
       );
@@ -1070,6 +1080,27 @@ export class WebSocketAdapter implements EngineAdapter {
       if (!this.send({ type: "PreviewManaPayment", data: { request_id: requestId, action } })) {
         this.pendingManaPaymentPreviews.delete(requestId);
         reject(new AdapterError("WS_CLOSED", "Failed to send mana-payment preview", true));
+      }
+    });
+  }
+
+  /**
+   * Requests the server-owned trusted engine envelope. The server authorizes
+   * this separately from ordinary redacted state broadcasts.
+   */
+  async exportPersistenceState(): Promise<string> {
+    if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
+      throw new AdapterError("WS_ERROR", "WebSocket not connected", false);
+    }
+    if (this.pendingAuthoritativeStateExport) {
+      throw new AdapterError("WS_ERROR", "Authoritative-state export already in progress", false);
+    }
+
+    return new Promise<string>((resolve, reject) => {
+      this.pendingAuthoritativeStateExport = { resolve, reject };
+      if (!this.send({ type: "ExportAuthoritativeState" })) {
+        this.pendingAuthoritativeStateExport = null;
+        reject(new AdapterError("WS_CLOSED", "Failed to request authoritative state", true));
       }
     });
   }
@@ -1198,6 +1229,9 @@ export class WebSocketAdapter implements EngineAdapter {
     this.pendingReject = null;
     this.rejectPendingManaPaymentPreviews(
       new AdapterError("WS_CLOSED", "Adapter disposed during mana-payment preview", true),
+    );
+    this.rejectAuthoritativeStateExport(
+      new AdapterError("WS_CLOSED", "Adapter disposed during authoritative-state export", true),
     );
     this.rejectPregameMutation(
       new AdapterError("WS_CLOSED", "Adapter disposed during seat mutation", true),
@@ -1431,6 +1465,11 @@ export class WebSocketAdapter implements EngineAdapter {
       reject(error);
     }
     this.pendingManaPaymentPreviews.clear();
+  }
+
+  private rejectAuthoritativeStateExport(error: Error): void {
+    this.pendingAuthoritativeStateExport?.reject(error);
+    this.pendingAuthoritativeStateExport = null;
   }
 
   /** Snapshot of the server's advertised identity, or null before ServerHello. */
@@ -1805,6 +1844,36 @@ export class WebSocketAdapter implements EngineAdapter {
           this.pendingManaPaymentPreviews.delete(data.request_id);
           pending.reject(new AdapterError("WS_ERROR", data.message, false));
         }
+        break;
+      }
+
+      case "AuthoritativeStateExport": {
+        const data = msg.data as { state?: unknown };
+        const pending = this.pendingAuthoritativeStateExport;
+        this.pendingAuthoritativeStateExport = null;
+        if (pending) {
+          if (typeof data.state === "string") {
+            pending.resolve(data.state);
+          } else {
+            pending.reject(new AdapterError(
+              "WS_ERROR",
+              "Server sent an invalid authoritative-state export.",
+              false,
+            ));
+          }
+        }
+        break;
+      }
+
+      case "AuthoritativeStateExportFailed": {
+        const data = msg.data as { message?: unknown };
+        const pending = this.pendingAuthoritativeStateExport;
+        this.pendingAuthoritativeStateExport = null;
+        pending?.reject(new AdapterError(
+          "WS_ERROR",
+          typeof data.message === "string" ? data.message : "Authoritative-state export failed.",
+          false,
+        ));
         break;
       }
 

--- a/client/src/adapter/ws-adapter.ts
+++ b/client/src/adapter/ws-adapter.ts
@@ -1089,6 +1089,18 @@ export class WebSocketAdapter implements EngineAdapter {
    * this separately from ordinary redacted state broadcasts.
    */
   async exportPersistenceState(): Promise<string> {
+    // An unredacted engine envelope must not cross a cleartext WebSocket. The
+    // native sidecar is a local trusted transport rather than a network socket.
+    if (
+      !this.serverUrl.startsWith("wss://")
+      && !this.serverUrl.startsWith("native-engine://")
+    ) {
+      throw new AdapterError(
+        "WS_ERROR",
+        "Authoritative-state export requires a secure connection",
+        false,
+      );
+    }
     if (!this.ws || this.ws.readyState !== WebSocket.OPEN) {
       throw new AdapterError("WS_ERROR", "WebSocket not connected", false);
     }

--- a/client/src/services/__tests__/gameStateExport.test.ts
+++ b/client/src/services/__tests__/gameStateExport.test.ts
@@ -103,12 +103,24 @@ describe("gameStateExport", () => {
     expect(strFromU8(entries[entryName])).toBe(trustedState);
   });
 
-  it("does not expose the trusted envelope from a shared game", async () => {
+  it("exports the trusted envelope from the P2P host", async () => {
+    const trustedState = JSON.stringify({ state: { players: [{ hand: ["host-only-card"] }] } });
+    const adapter = buildEngineAdapterMock(undefined, {
+      exportPersistenceState: vi.fn().mockResolvedValue(trustedState),
+    });
+    useGameStore.setState({ gameMode: "p2p-host" });
+
+    await exportAuthoritativeGameStateZip(adapter);
+
+    expect(adapter.exportPersistenceState).toHaveBeenCalledOnce();
+  });
+
+  it("does not expose the trusted envelope from a P2P guest", async () => {
     const exportPersistenceState = vi.fn().mockResolvedValue(JSON.stringify({
       state: { players: [{ hand: ["hidden-card"] }] },
     }));
     const adapter = buildEngineAdapterMock(undefined, { exportPersistenceState });
-    useGameStore.setState({ gameMode: "p2p-host" });
+    useGameStore.setState({ gameMode: "p2p-join" });
 
     await expect(exportAuthoritativeGameStateZip(adapter)).rejects.toThrow(
       "Authoritative state export is unavailable for shared games",

--- a/client/src/stores/__tests__/gameStore.test.ts
+++ b/client/src/stores/__tests__/gameStore.test.ts
@@ -59,15 +59,15 @@ describe("game mode classification", () => {
     expect(isAuthorityRemote("local")).toBe(false);
   });
 
-  it.each(["ai", "local", "native-ai"] as GameMode[])(
-    "allows authoritative bug reports in private %s games",
+  it.each(["ai", "local", "native-ai", "p2p-host"] as GameMode[])(
+    "allows authoritative bug reports when %s owns the state",
     (mode) => {
       expect(canExportAuthoritativeState(mode)).toBe(true);
     },
   );
 
-  it.each(["online", "p2p-host", "p2p-join", "draft-match", "spectate"] as GameMode[])(
-    "blocks authoritative bug reports in shared %s games",
+  it.each(["online", "p2p-join", "draft-match", "spectate"] as GameMode[])(
+    "blocks authoritative bug reports when %s only has a redacted view",
     (mode) => {
       expect(canExportAuthoritativeState(mode)).toBe(false);
     },

--- a/client/src/stores/gameStore.ts
+++ b/client/src/stores/gameStore.ts
@@ -99,6 +99,8 @@ interface GameModeTraits {
   readonly authority: EngineAuthority;
   readonly company: TableCompany;
   readonly seat: SeatSource;
+  /** Whether this client can request the unredacted state from its authority. */
+  readonly mayExportAuthoritativeState: boolean;
 }
 
 /**
@@ -113,14 +115,14 @@ interface GameModeTraits {
  * `spectate` is `remote-humans` by the *game* it observes, not by the observer.
  */
 export const GAME_MODE_TRAITS: Record<GameMode, GameModeTraits> = {
-  "ai": { authority: "client", company: "solo", seat: "seat-zero" },
-  "local": { authority: "client", company: "solo", seat: "seat-zero" },
-  "native-ai": { authority: "wire", company: "solo", seat: "seat-zero" },
-  "online": { authority: "wire", company: "remote-humans", seat: "wire-assigned" },
-  "p2p-host": { authority: "wire", company: "remote-humans", seat: "seat-zero" },
-  "p2p-join": { authority: "wire", company: "remote-humans", seat: "wire-assigned" },
-  "draft-match": { authority: "wire", company: "remote-humans", seat: "wire-assigned" },
-  "spectate": { authority: "wire", company: "remote-humans", seat: "no-seat" },
+  "ai": { authority: "client", company: "solo", seat: "seat-zero", mayExportAuthoritativeState: true },
+  "local": { authority: "client", company: "solo", seat: "seat-zero", mayExportAuthoritativeState: true },
+  "native-ai": { authority: "wire", company: "solo", seat: "seat-zero", mayExportAuthoritativeState: true },
+  "online": { authority: "wire", company: "remote-humans", seat: "wire-assigned", mayExportAuthoritativeState: false },
+  "p2p-host": { authority: "wire", company: "remote-humans", seat: "seat-zero", mayExportAuthoritativeState: true },
+  "p2p-join": { authority: "wire", company: "remote-humans", seat: "wire-assigned", mayExportAuthoritativeState: false },
+  "draft-match": { authority: "wire", company: "remote-humans", seat: "wire-assigned", mayExportAuthoritativeState: false },
+  "spectate": { authority: "wire", company: "remote-humans", seat: "no-seat", mayExportAuthoritativeState: false },
 };
 
 /** True when the authoritative engine state lives off this client — i.e. the
@@ -165,12 +167,12 @@ export function hasRemoteHumans(mode: GameMode | null): boolean {
 
 /**
  * Whether this client may download the engine's unredacted persistence envelope.
- * A shared remote table must never turn the authority's private view into a
- * player-facing file; solo games have no remote player whose hidden information
- * could be disclosed.
+ * Only the client that owns the P2P authority may export from a shared table.
+ * Guests and spectators receive redacted views, while the host's local WASM
+ * engine or native server owns the unredacted persistence envelope.
  */
 export function canExportAuthoritativeState(mode: GameMode | null): boolean {
-  return mode !== null && !hasRemoteHumans(mode);
+  return mode !== null && GAME_MODE_TRAITS[mode].mayExportAuthoritativeState;
 }
 
 /**

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -1457,6 +1457,7 @@ mod target_incarnation_revalidation;
 mod teamwork_keyword;
 mod teferis_puzzle_box_4241;
 mod temporal_anchor;
+mod temporal_extortion_priority;
 mod temporary_cant_be_blocked_view;
 mod tergrid_mirrormade_copy_on_effect_entry;
 mod the_mind_stone_harness_infinity;

--- a/crates/engine/tests/integration/temporal_extortion_priority.rs
+++ b/crates/engine/tests/integration/temporal_extortion_priority.rs
@@ -1,0 +1,130 @@
+//! Reproduction coverage for Temporal Extortion's cast trigger, optional
+//! payment, extra turn, and viewer-priority projection.
+
+use engine::game::scenario::{GameRunner, GameScenario, P0, P1};
+use engine::game::visibility::filter_state_for_viewer;
+use engine::types::actions::GameAction;
+use engine::types::game_state::WaitingFor;
+use engine::types::identifiers::ObjectId;
+use engine::types::mana::{ManaType, ManaUnit};
+use engine::types::phase::Phase;
+
+const TEMPORAL_EXTORTION_ORACLE: &str = "When you cast this spell, any player may pay half their life, rounded up. If a player does, counter Temporal Extortion.\nTake an extra turn after this one.";
+
+fn mana(n: usize, mana_type: ManaType) -> Vec<ManaUnit> {
+    (0..n)
+        .map(|_| ManaUnit::new(mana_type, ObjectId(0), false, vec![]))
+        .collect()
+}
+
+fn pass_through_empty_turn(
+    runner: &mut GameRunner,
+    player: engine::types::PlayerId,
+    turns_taken_before: u32,
+) {
+    for _ in 0..128 {
+        if runner.state().active_player == player
+            && runner.state().players[player.0 as usize].turns_taken > turns_taken_before
+        {
+            return;
+        }
+        if runner.state().active_player != player {
+            return;
+        }
+        match &runner.state().waiting_for {
+            WaitingFor::Priority { .. } => runner
+                .act(GameAction::PassPriority)
+                .expect("priority pass during an empty turn"),
+            WaitingFor::DeclareAttackers { .. } => runner
+                .act(GameAction::DeclareAttackers {
+                    attacks: vec![],
+                    bands: vec![],
+                })
+                .expect("empty attackers declaration"),
+            WaitingFor::DeclareBlockers { .. } => runner
+                .act(GameAction::DeclareBlockers {
+                    assignments: vec![],
+                })
+                .expect("empty blockers declaration"),
+            other => panic!("unexpected waiting state while ending empty turn: {other:?}"),
+        };
+    }
+    panic!("turn did not finish within the guard");
+}
+
+/// CR 117.3b + CR 500.7: after both players decline the cast trigger, the
+/// spell resolves, grants its controller an extra turn, and both viewer
+/// projections agree that controller has priority in that turn.
+#[test]
+fn temporal_extortion_declined_by_all_starts_extra_turn_with_shared_priority() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let temporal_extortion = scenario
+        .add_spell_to_hand_from_oracle(P0, "Temporal Extortion", false, TEMPORAL_EXTORTION_ORACLE)
+        .id();
+    // The original turn must reach its draw step before its queued extra turn
+    // starts, so neither player may deck out during this focused scenario.
+    scenario.with_library_top(P0, &["Forest", "Forest", "Forest"]);
+    scenario.with_library_top(P1, &["Forest", "Forest", "Forest"]);
+    scenario.with_mana_pool(P0, mana(3, ManaType::Colorless));
+    scenario.with_mana_pool(P0, mana(1, ManaType::Black));
+
+    let mut runner = scenario.build();
+    let mut cast = runner.cast(temporal_extortion).commit();
+    let mut offered_to = Vec::new();
+
+    for _ in 0..24 {
+        match cast.state().waiting_for.clone() {
+            WaitingFor::OpponentMayChoice { player, .. } => {
+                offered_to.push(player);
+                cast.act(GameAction::DecideOptionalEffect { accept: false })
+                    .expect("declining Temporal Extortion's payment must succeed");
+            }
+            WaitingFor::Priority { .. } if offered_to.len() < 2 => {
+                cast.act(GameAction::PassPriority)
+                    .expect("priority pass before Temporal Extortion resolves");
+            }
+            WaitingFor::Priority { .. } => break,
+            other => panic!("unexpected Temporal Extortion resolution state: {other:?}"),
+        }
+    }
+    assert_eq!(
+        offered_to,
+        vec![P0, P1],
+        "any player must be offered the payment in APNAP order",
+    );
+
+    let outcome = cast.resolve();
+    assert!(
+        outcome
+            .state()
+            .extra_turns
+            .iter()
+            .any(|turn| turn.player == P0),
+        "all declines must allow Temporal Extortion to enqueue P0's extra turn",
+    );
+
+    let mut after_resolution = GameRunner::from_state(outcome.state().clone());
+    let original_turns_taken = after_resolution.state().players[P0.0 as usize].turns_taken;
+    pass_through_empty_turn(&mut after_resolution, P0, original_turns_taken);
+
+    assert_eq!(after_resolution.state().active_player, P0);
+    assert!(
+        after_resolution.state().players[P0.0 as usize].turns_taken > original_turns_taken,
+        "P0 must begin the extra turn after their original turn ends",
+    );
+    assert!(matches!(
+        after_resolution.state().waiting_for,
+        WaitingFor::Priority { player: P0 }
+    ));
+    assert_eq!(after_resolution.state().priority_player, P0);
+
+    for viewer in [P0, P1] {
+        let view = filter_state_for_viewer(after_resolution.state(), viewer);
+        assert!(matches!(
+            view.waiting_for,
+            WaitingFor::Priority { player: P0 }
+        ));
+        assert_eq!(view.priority_player, P0);
+    }
+}

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -38,6 +38,9 @@ pub enum ServerErrorCode {
 /// rather than a parse error, and the handshake is the only place that pairing
 /// can be refused. See 24.
 ///
+/// 56 — Host-only authoritative-state export request/response variants. Native
+///      P2P host diagnostics must use a trusted server envelope rather than a
+///      redacted player view. Lobby messages are unchanged.
 /// 55 — `DerivedViews::room_half_identities` publishes both halves of every
 ///      battlefield Room in printed order, resolved through the COPIED halves
 ///      for a permanent that copies a Room (CR 709.5b + CR 707.2). The unlock
@@ -260,7 +263,7 @@ pub enum ServerErrorCode {
 ///      payload; mulligan bottoming folded into a
 ///      `MulliganDecisionPhase::BottomCards` sub-phase on
 ///      `WaitingFor::MulliganDecision`.
-pub const PROTOCOL_VERSION: u32 = 55;
+pub const PROTOCOL_VERSION: u32 = 56;
 
 /// Minimum protocol version accepted by lobby-only brokers at the hello
 /// handshake **from clients that predate [`LOBBY_PROTOCOL_VERSION`]** — the
@@ -1006,7 +1009,7 @@ mod tests {
 
     #[test]
     fn protocol_version_tracks_full_game_wire_additions() {
-        assert_eq!(PROTOCOL_VERSION, 55);
+        assert_eq!(PROTOCOL_VERSION, 56);
         // Lobby keeps its one-version rollout window; full-game servers stay
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot

--- a/crates/lobby-broker/src/protocol.rs
+++ b/crates/lobby-broker/src/protocol.rs
@@ -1014,7 +1014,7 @@ mod tests {
         // current-only (`server_core::MIN_SUPPORTED_PROTOCOL == PROTOCOL_VERSION`),
         // which is what refuses an older full-game peer whose GameState cannot
         // understand a success acknowledgment the submitting client awaits.
-        assert_eq!(MIN_SUPPORTED_PROTOCOL, 54);
+        assert_eq!(MIN_SUPPORTED_PROTOCOL, 55);
     }
 
     #[test]

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -74,8 +74,8 @@ use server_core::protocol::{
 use server_core::resolve_deck;
 use server_core::seat_mutation_wire_guard::guard_seat_mutation;
 use server_core::session::{
-    ActionResult, FullRuntime, GameSession, RevisionedActionResult, SessionActionError,
-    SessionManager,
+    ActionResult, FullRuntime, GameSession, HostingMode, RevisionedActionResult,
+    SessionActionError, SessionManager,
 };
 use server_core::spectator_wire_guard::{
     guard_draft_spectator_capacity, guard_game_spectator_capacity, guard_spectate_draft,
@@ -6507,7 +6507,7 @@ async fn handle_client_message(
                 (Some(game_code), Some(PlayerId(0))) => {
                     let mut manager = state.lock().await;
                     match manager.sessions.get_mut(game_code) {
-                        Some(session) => {
+                        Some(session) if session.hosting == HostingMode::SingleUser => {
                             let mut snapshot = session.state.clone();
                             snapshot.capture_rng_word_pos();
                             match serde_json::to_string(&TrustedGameStateEnvelope::capture(
@@ -6521,6 +6521,11 @@ async fn handle_client_message(
                                 },
                             }
                         }
+                        Some(_) => ServerMessage::AuthoritativeStateExportFailed {
+                            message:
+                                "Authoritative state export is available only from a local host"
+                                    .to_string(),
+                        },
                         None => ServerMessage::AuthoritativeStateExportFailed {
                             message: "Game session is no longer available".to_string(),
                         },

--- a/crates/phase-server/src/main.rs
+++ b/crates/phase-server/src/main.rs
@@ -33,7 +33,7 @@ use engine::game::validate_name_deck_for_format_full;
 use engine::types::action_rejection::{ActionRejection, ActionRejectionCode};
 use engine::types::actions::GameAction;
 use engine::types::events::GameEvent;
-use engine::types::game_state::GameState;
+use engine::types::game_state::{GameState, TrustedGameStateEnvelope};
 use engine::types::interaction::InteractionSubmission;
 use engine::types::player::PlayerId;
 use engine::types::GameLogEntry;
@@ -1158,6 +1158,7 @@ fn reject_if_disabled(msg: &ClientMessage, mode: ServerMode) -> Option<&'static 
         | ClientMessage::Action { .. }
         | ClientMessage::Interaction { .. }
         | ClientMessage::PreviewManaPayment { .. }
+        | ClientMessage::ExportAuthoritativeState
         | ClientMessage::Reconnect { .. }
         | ClientMessage::AbandonGame
         | ClientMessage::SeatMutate { .. }
@@ -1417,6 +1418,7 @@ fn full_socket_authority(message: &ClientMessage) -> FullSocketAuthority {
         ClientMessage::Action { .. }
         | ClientMessage::Interaction { .. }
         | ClientMessage::PreviewManaPayment { .. }
+        | ClientMessage::ExportAuthoritativeState
         | ClientMessage::AbandonGame
         | ClientMessage::SeatMutate { .. }
         | ClientMessage::Concede
@@ -5272,6 +5274,9 @@ fn operation_failed_message(msg: &ClientMessage, message: String) -> Option<Serv
                 message,
             })
         }
+        ClientMessage::ExportAuthoritativeState => {
+            Some(ServerMessage::AuthoritativeStateExportFailed { message })
+        }
         ClientMessage::ClientHello { .. }
         | ClientMessage::CreateGame { .. }
         | ClientMessage::JoinGame { .. }
@@ -6482,6 +6487,49 @@ async fn handle_client_message(
                 }
                 _ => ServerMessage::ManaPaymentPreviewFailed {
                     request_id,
+                    message: "Not in a game".to_string(),
+                },
+            };
+
+            if let Ok(json) = serde_json::to_string(&response) {
+                let _ = socket.send(Message::text(json)).await;
+            }
+        }
+
+        ClientMessage::ExportAuthoritativeState => {
+            // The native P2P host is always Player 1 (seat zero). Its local
+            // server deliberately redacts normal broadcast snapshots per
+            // viewer, but the host needs an unredacted snapshot to report an
+            // engine stall. The export is a trusted engine envelope, not a
+            // PersistedSession, so reconnect tokens and server metadata never
+            // leave the server.
+            let response = match (identity.game_code.as_deref(), identity.player_id) {
+                (Some(game_code), Some(PlayerId(0))) => {
+                    let mut manager = state.lock().await;
+                    match manager.sessions.get_mut(game_code) {
+                        Some(session) => {
+                            let mut snapshot = session.state.clone();
+                            snapshot.capture_rng_word_pos();
+                            match serde_json::to_string(&TrustedGameStateEnvelope::capture(
+                                snapshot,
+                            )) {
+                                Ok(state) => ServerMessage::AuthoritativeStateExport { state },
+                                Err(error) => ServerMessage::AuthoritativeStateExportFailed {
+                                    message: format!(
+                                        "Failed to serialize authoritative game state: {error}"
+                                    ),
+                                },
+                            }
+                        }
+                        None => ServerMessage::AuthoritativeStateExportFailed {
+                            message: "Game session is no longer available".to_string(),
+                        },
+                    }
+                }
+                (Some(_), Some(_)) => ServerMessage::AuthoritativeStateExportFailed {
+                    message: "Only the game host can export authoritative state".to_string(),
+                },
+                _ => ServerMessage::AuthoritativeStateExportFailed {
                     message: "Not in a game".to_string(),
                 },
             };
@@ -12621,6 +12669,7 @@ mod mode_gate_tests {
                 request_id: 1,
                 action: GameAction::PassPriority,
             },
+            ClientMessage::ExportAuthoritativeState,
             ClientMessage::Reconnect {
                 game_code: "X".into(),
                 player_token: "t".into(),
@@ -12708,6 +12757,13 @@ mod mode_gate_tests {
             ),
             Some(ServerMessage::ManaPaymentPreviewFailed { request_id: 5, message }) if message == "disabled"
         ));
+        assert!(matches!(
+            operation_failed_message(
+                &ClientMessage::ExportAuthoritativeState,
+                "disabled".to_string(),
+            ),
+            Some(ServerMessage::AuthoritativeStateExportFailed { message }) if message == "disabled"
+        ));
         assert!(
             operation_failed_message(&ClientMessage::ConcedeMatch, "disabled".to_string(),)
                 .is_none()
@@ -12777,6 +12833,7 @@ mod mode_gate_tests {
                 request_id: 1,
                 action: GameAction::PassPriority,
             },
+            ClientMessage::ExportAuthoritativeState,
             ClientMessage::AbandonGame,
             ClientMessage::Concede,
             ClientMessage::ConcedeMatch,

--- a/crates/server-core/src/client_message_wire_guard.rs
+++ b/crates/server-core/src/client_message_wire_guard.rs
@@ -85,6 +85,7 @@ pub fn guard_client_message_before_dispatch(
         | ClientMessage::Concede
         | ClientMessage::ConcedeMatch
         | ClientMessage::AbandonGame
+        | ClientMessage::ExportAuthoritativeState
         | ClientMessage::RequestTakeback(_)
         | ClientMessage::RespondTakeback { .. }
         | ClientMessage::CancelTakeback => Ok(()),
@@ -306,6 +307,7 @@ pub fn wire_rejection_message(msg: &ClientMessage, reason: String) -> ServerMess
         | ClientMessage::JoinGame { .. }
         | ClientMessage::Reconnect { .. }
         | ClientMessage::AbandonGame
+        | ClientMessage::ExportAuthoritativeState
         | ClientMessage::SubscribeLobby
         | ClientMessage::UnsubscribeLobby
         | ClientMessage::CreateGameWithSettings { .. }
@@ -470,6 +472,7 @@ pub fn guard_broker_projection_inbound(msg: &ClientMessage) -> Result<(), String
         | ClientMessage::Action { .. }
         | ClientMessage::Interaction { .. }
         | ClientMessage::PreviewManaPayment { .. }
+        | ClientMessage::ExportAuthoritativeState
         | ClientMessage::Reconnect { .. }
         | ClientMessage::AbandonGame
         | ClientMessage::Concede

--- a/crates/server-core/src/protocol.rs
+++ b/crates/server-core/src/protocol.rs
@@ -298,6 +298,10 @@ pub enum ClientMessage {
         request_id: u64,
         action: GameAction,
     },
+    /// Requests an unredacted, trusted engine snapshot for diagnostics. The
+    /// server authorizes this capability from the authenticated host seat;
+    /// neither a player token nor a game code travels in the payload.
+    ExportAuthoritativeState,
     /// One opaque, engine-authored interaction response. The client echoes the
     /// submission the engine published in `ViewerInteraction`; it never derives
     /// a `GameAction` from the opportunity schema. Like `Action`, the
@@ -740,6 +744,16 @@ pub enum ServerMessage {
         request_id: u64,
         message: String,
     },
+    /// Host-only trusted engine persistence snapshot. This deliberately
+    /// contains no server-session metadata or player reconnect tokens.
+    AuthoritativeStateExport {
+        state: String,
+    },
+    /// Requester-only operational or authorization failure for an
+    /// authoritative-state export.
+    AuthoritativeStateExportFailed {
+        message: String,
+    },
     OpponentDisconnected {
         grace_seconds: u32,
         #[serde(default)]
@@ -1079,6 +1093,25 @@ mod tests {
             }
             _ => panic!("wrong variant"),
         }
+    }
+
+    #[test]
+    fn authoritative_state_export_messages_roundtrip() {
+        let request = ClientMessage::ExportAuthoritativeState;
+        let request_json = serde_json::to_string(&request).unwrap();
+        assert!(matches!(
+            serde_json::from_str::<ClientMessage>(&request_json).unwrap(),
+            ClientMessage::ExportAuthoritativeState
+        ));
+
+        let response = ServerMessage::AuthoritativeStateExport {
+            state: "{\"state\":{}}".to_string(),
+        };
+        let response_json = serde_json::to_string(&response).unwrap();
+        assert!(matches!(
+            serde_json::from_str::<ServerMessage>(&response_json).unwrap(),
+            ServerMessage::AuthoritativeStateExport { state } if state == "{\"state\":{}}"
+        ));
     }
 
     #[test]
@@ -2920,8 +2953,8 @@ mod tests {
     }
 
     #[test]
-    fn protocol_version_is_55_for_room_half_identities() {
-        assert_eq!(PROTOCOL_VERSION, 55);
+    fn protocol_version_is_56_for_authoritative_state_export() {
+        assert_eq!(PROTOCOL_VERSION, 56);
     }
 
     /// The bump alone is inert — a version number nobody enforces prevents no
@@ -2932,7 +2965,7 @@ mod tests {
     ///
     /// REVERT-PROBE: relax to `PROTOCOL_VERSION - 1` — the exact regression
     /// this guards — and this test reds while
-    /// `protocol_version_is_55_for_room_half_identities` stays
+    /// `protocol_version_is_56_for_authoritative_state_export` stays
     /// green, which is why the two are separate assertions.
     #[test]
     fn full_game_floor_is_current_only_not_a_rollout_window() {

--- a/scripts/check-protocol-version.mjs
+++ b/scripts/check-protocol-version.mjs
@@ -3,7 +3,7 @@ import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), "..");
-const EXPECTED_PROTOCOL_VERSION = 55;
+const EXPECTED_PROTOCOL_VERSION = 56;
 // The LOBBY message-set version. Deliberately separate from the full-game
 // number above and deliberately NOT derived from it: a GameState-only bump must
 // not move the lobby's compatibility window. See the assertions at the bottom.


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Hosts can export a trusted, authoritative game-state snapshot for supported game modes.
  - State exports now provide clear failure feedback without ending the active session.

- **Bug Fixes**
  - Prevented older multiplayer updates from overwriting newer state after reconnects.
  - Authoritative-state export availability now reflects the game mode and state ownership more accurately.

- **Tests**
  - Added coverage for state exports, stale update handling, and Temporal Extortion turn-priority behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->