### PR TITLE
ship/dyadrine counter selection

### DIFF
--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -5811,6 +5811,7 @@ fn rw_effect(
             filter: _,
             min: _,
             max: _,
+            ..
         }
         | Effect::RingTemptsYou
         | Effect::TimeTravel

--- a/crates/engine/src/game/ability_rw.rs
+++ b/crates/engine/src/game/ability_rw.rs
@@ -5806,13 +5806,7 @@ fn rw_effect(
             player: _,
             count: _,
         }
-        | Effect::ChooseObjectsIntoTrackedSet {
-            chooser: _,
-            filter: _,
-            min: _,
-            max: _,
-            ..
-        }
+        | Effect::ChooseObjectsIntoTrackedSet { .. }
         | Effect::RingTemptsYou
         | Effect::TimeTravel
         | Effect::Planeswalk

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1583,6 +1583,7 @@ fn scan_effect(x: &Effect, mode: ScanMode) -> Axes {
             filter,
             min: _,
             max: _,
+            ..
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(chooser, target_ctx, mode));

--- a/crates/engine/src/game/ability_scan.rs
+++ b/crates/engine/src/game/ability_scan.rs
@@ -1579,11 +1579,7 @@ fn scan_effect(x: &Effect, mode: ScanMode) -> Axes {
             ForEachCategoryAction::ExileFromPool { .. } => Axes::NONE,
         },
         Effect::ChooseObjectsIntoTrackedSet {
-            chooser,
-            filter,
-            min: _,
-            max: _,
-            ..
+            chooser, filter, ..
         } => {
             let mut acc = Axes::NONE;
             acc = acc.or(scan_target_filter(chooser, target_ctx, mode));

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -22,12 +22,13 @@ use crate::types::ability::{
     CountScope, CounterSourceRider, DelayedTriggerCondition, DieRollModifier, DoublePTMode,
     Duration, EachDamageRecipient, Effect, EffectOutcomeSignal, EffectScope, FilterProp,
     ForEachCategoryAction, GameRestriction, LibraryPosition, ManaProduction, ObjectProperty,
-    ObjectScope, ParsedCondition, PerpetualModification, PlayerFilter, PlayerRelation, PlayerScope,
-    PtStat, PtValue, PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition,
-    ReplacementDefinition, ReplacementMode, SeatDirection, SharedQuality, SharedQualityRelation,
-    SpeedDelta, SpellCastingOption, SpellCastingOptionKind, SpellStackToGraveyardReplacement,
-    StackAbilityKind, StaticCondition, StaticDefinition, TapStateChange, TargetFilter,
-    TriggerDefinition, TypeFilter, TypedFilter, VoteSubject, ZoneRef,
+    ObjectScope, ObjectSelectionCardinality, ObjectSelectionEligibility, ParsedCondition,
+    PerpetualModification, PlayerFilter, PlayerRelation, PlayerScope, PtStat, PtValue,
+    PtValueScope, QuantityExpr, QuantityRef, ReplacementCondition, ReplacementDefinition,
+    ReplacementMode, SeatDirection, SharedQuality, SharedQualityRelation, SpeedDelta,
+    SpellCastingOption, SpellCastingOptionKind, SpellStackToGraveyardReplacement, StackAbilityKind,
+    StaticCondition, StaticDefinition, TapStateChange, TargetFilter, TriggerDefinition, TypeFilter,
+    TypedFilter, VoteSubject, ZoneRef,
 };
 use crate::types::card::CardFace;
 use crate::types::card_type::CoreType;
@@ -3577,7 +3578,8 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
             filter,
             min,
             max,
-            ..
+            cardinality,
+            eligibility,
         } => {
             d.push(("chooser".into(), fmt_target(chooser)));
             d.push(("filter".into(), fmt_target(filter)));
@@ -3586,6 +3588,19 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
                 "max".into(),
                 max.map_or_else(|| "any".to_string(), |m| m.to_string()),
             ));
+            if let Some(ObjectSelectionCardinality::Exactly { count }) = cardinality {
+                d.push(("cardinality".into(), format!("exactly {count}")));
+            }
+            if let Some(ObjectSelectionEligibility::RemovableCounter { counter_type }) = eligibility
+            {
+                d.push((
+                    "eligibility".into(),
+                    counter_type.as_ref().map_or_else(
+                        || "removable counter".to_string(),
+                        |counter_type| format!("removable {} counter", counter_type.as_str()),
+                    ),
+                ));
+            }
         }
         Effect::ChooseCounterKind { target } => {
             d.push(("target".into(), fmt_target(target)));
@@ -12184,6 +12199,60 @@ mod tests {
             labels.len(),
             8,
             "every AttackTargetFilter variant must map to a distinct label: {labels:?}"
+        );
+    }
+
+    /// Exact cardinality and counter-removal eligibility are semantic parser
+    /// axes. Defaults deliberately render nothing, preserving existing
+    /// signatures, while non-default selections remain distinguishable.
+    #[test]
+    fn object_selection_cardinality_and_eligibility_reach_parse_details() {
+        let selection = |cardinality, eligibility| Effect::ChooseObjectsIntoTrackedSet {
+            chooser: TargetFilter::Controller,
+            filter: TargetFilter::Typed(TypedFilter::creature()),
+            min: 0,
+            max: None,
+            cardinality,
+            eligibility,
+        };
+        let default = effect_details(&selection(None, None));
+        assert!(
+            !default
+                .iter()
+                .any(|(key, _)| key == "cardinality" || key == "eligibility"),
+            "the legacy selection shape must not gain signature keys"
+        );
+
+        let exact = effect_details(&selection(
+            Some(ObjectSelectionCardinality::Exactly { count: 2 }),
+            None,
+        ));
+        assert!(
+            exact
+                .iter()
+                .any(|(key, value)| key == "cardinality" && value == "exactly 2"),
+            "an exact selection cardinality must be visible to parse coverage: {exact:?}"
+        );
+        assert_ne!(
+            default, exact,
+            "exact and legacy selections must not collapse"
+        );
+
+        let removable = effect_details(&selection(
+            Some(ObjectSelectionCardinality::Exactly { count: 2 }),
+            Some(ObjectSelectionEligibility::RemovableCounter {
+                counter_type: Some(CounterType::Plus1Plus1),
+            }),
+        ));
+        assert!(
+            removable
+                .iter()
+                .any(|(key, value)| { key == "eligibility" && value == "removable P1P1 counter" }),
+            "counter-removal eligibility must be visible to parse coverage: {removable:?}"
+        );
+        assert_ne!(
+            exact, removable,
+            "counter-eligible and unconstrained exact selections must not collapse"
         );
     }
 

--- a/crates/engine/src/game/coverage.rs
+++ b/crates/engine/src/game/coverage.rs
@@ -3577,6 +3577,7 @@ fn effect_details(effect: &Effect) -> Vec<(String, String)> {
             filter,
             min,
             max,
+            ..
         } => {
             d.push(("chooser".into(), fmt_target(chooser)));
             d.push(("filter".into(), fmt_target(filter)));

--- a/crates/engine/src/game/effects/choose_objects_into_tracked_set.rs
+++ b/crates/engine/src/game/effects/choose_objects_into_tracked_set.rs
@@ -8,9 +8,13 @@
 //! a fresh tracked set so downstream effects ("pay {N} for each ... chosen
 //! this way", "untap those creatures") resolve against the exact selection.
 
+use crate::game::effects::counters::counter_removal_blocked;
 use crate::game::filter::{matches_target_filter, FilterContext};
 use crate::game::targeting::resolve_effect_player_ref;
-use crate::types::ability::{Effect, EffectError, EffectKind, ResolvedAbility, TargetRef};
+use crate::types::ability::{
+    Effect, EffectError, EffectKind, ObjectSelectionCardinality, ObjectSelectionEligibility,
+    ResolvedAbility, TargetRef,
+};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{GameState, WaitingFor};
 
@@ -21,13 +25,22 @@ pub fn resolve(
     ability: &ResolvedAbility,
     events: &mut Vec<GameEvent>,
 ) -> Result<(), EffectError> {
-    let (chooser_filter, filter, min, max) = match &ability.effect {
+    let (chooser_filter, filter, min, max, cardinality, eligibility) = match &ability.effect {
         Effect::ChooseObjectsIntoTrackedSet {
             chooser,
             filter,
             min,
             max,
-        } => (chooser.clone(), filter.clone(), *min, *max),
+            cardinality,
+            eligibility,
+        } => (
+            chooser.clone(),
+            filter.clone(),
+            *min,
+            *max,
+            *cardinality,
+            eligibility.clone(),
+        ),
         _ => {
             return Err(EffectError::MissingParam(
                 "ChooseObjectsIntoTrackedSet".to_string(),
@@ -53,20 +66,20 @@ pub fn resolve(
     // ability controller, so bind the filter context controller to the
     // chooser (mirrors `pay.rs`'s payer-rebinding pattern).
     let ctx = FilterContext::from_ability_with_controller(ability, chooser);
-    let eligible: Vec<TargetRef> = state
-        .battlefield
-        .iter()
-        .filter(|&&obj_id| matches_target_filter(state, obj_id, &filter, &ctx))
-        .map(|&obj_id| TargetRef::Object(obj_id))
-        .collect();
+    let eligible = eligible_targets(state, ability, &filter, &ctx, eligibility.as_ref());
 
     // CR 609.3: If a resolving effect asks for more objects than are
     // available, the player chooses all that are available. Publish an
     // achievable runtime range at this trust seam so every consumer (engine,
     // AI, and client) sees the same liveness-preserving cardinality.
-    let available = u32::try_from(eligible.len()).unwrap_or(u32::MAX);
-    let max = max.map(|maximum| maximum.min(available));
-    let min = min.min(max.unwrap_or(available));
+    let (min, max) = match cardinality {
+        Some(ObjectSelectionCardinality::Exactly { count }) => (count, Some(count)),
+        None => {
+            let available = u32::try_from(eligible.len()).unwrap_or(u32::MAX);
+            let max = max.map(|maximum| maximum.min(available));
+            (min.min(max.unwrap_or(available)), max)
+        }
+    };
 
     // CR 608.2c: Surface the interactive selection. Even with an empty
     // `eligible` set the prompt is raised — the player's act of submitting an
@@ -89,15 +102,87 @@ pub fn resolve(
     Ok(())
 }
 
+/// CR 122.1 + CR 101.2: A counter-removal selection may include only objects
+/// that hold a removable matching counter. This is shared by the prompt and the
+/// optional-effect feasibility gate so they cannot disagree about availability.
+fn eligible_targets(
+    state: &GameState,
+    ability: &ResolvedAbility,
+    filter: &crate::types::ability::TargetFilter,
+    ctx: &FilterContext,
+    eligibility: Option<&ObjectSelectionEligibility>,
+) -> Vec<TargetRef> {
+    state
+        .battlefield
+        .iter()
+        .filter(|&&obj_id| matches_target_filter(state, obj_id, filter, ctx))
+        .filter(|&&obj_id| match eligibility {
+            None => true,
+            Some(ObjectSelectionEligibility::RemovableCounter {
+                counter_type,
+                count,
+            }) => {
+                let required = u32::try_from(
+                    crate::game::quantity::resolve_quantity_with_targets(state, count, ability)
+                        .max(1),
+                )
+                .unwrap_or(u32::MAX);
+                state.objects.get(&obj_id).is_some_and(|object| {
+                    let removable = object.counters.iter().filter_map(|(kind, &available)| {
+                        (counter_type
+                            .as_ref()
+                            .is_none_or(|expected| expected == kind)
+                            && !counter_removal_blocked(state, obj_id, kind))
+                        .then_some(available)
+                    });
+                    if counter_type.is_some() {
+                        removable.into_iter().next().unwrap_or_default() >= required
+                    } else {
+                        removable.sum::<u32>() >= required
+                    }
+                })
+            }
+        })
+        .map(|&obj_id| TargetRef::Object(obj_id))
+        .collect()
+}
+
+/// CR 608.2d: An optional exact selection is unavailable unless its complete
+/// selection cardinality can be met from the same eligible set shown by the UI.
+pub(crate) fn optional_exact_selection_is_infeasible(
+    state: &GameState,
+    ability: &ResolvedAbility,
+) -> bool {
+    let Effect::ChooseObjectsIntoTrackedSet {
+        chooser,
+        filter,
+        cardinality: Some(ObjectSelectionCardinality::Exactly { count }),
+        eligibility,
+        ..
+    } = &ability.effect
+    else {
+        return false;
+    };
+    let Some(chooser) = resolve_effect_player_ref(state, ability, chooser) else {
+        return true;
+    };
+    let ctx = FilterContext::from_ability_with_controller(ability, chooser);
+    eligible_targets(state, ability, filter, &ctx, eligibility.as_ref()).len() < *count as usize
+}
+
 #[cfg(test)]
 mod tests {
+    use super::optional_exact_selection_is_infeasible;
+    use crate::game::effects::resolve_ability_chain;
     use crate::game::scenario::GameScenario;
     use crate::parser::oracle_effect::parse_effect_chain;
     use crate::types::ability::{
-        AbilityDefinition, AbilityKind, Effect, TargetFilter, TypedFilter,
+        AbilityDefinition, AbilityKind, Effect, ObjectSelectionCardinality,
+        ObjectSelectionEligibility, ResolvedAbility, TargetFilter, TargetRef, TypedFilter,
     };
     use crate::types::actions::GameAction;
     use crate::types::card_type::CoreType;
+    use crate::types::counter::CounterType;
     use crate::types::game_state::WaitingFor;
     use crate::types::identifiers::ObjectId;
     use crate::types::phase::Phase;
@@ -118,6 +203,8 @@ mod tests {
                 filter: TargetFilter::Typed(TypedFilter::creature()),
                 min: 2,
                 max: Some(2),
+                cardinality: None,
+                eligibility: None,
             },
         );
         let host = {
@@ -150,6 +237,174 @@ mod tests {
                 targets: vec![crate::types::ability::TargetRef::Object(only_eligible)],
             })
             .expect("CR 609.3 permits choosing the sole available object");
+    }
+
+    /// CR 608.2d + CR 122.1: an optional exact selection is offerable only
+    /// when its complete removable-counter set exists; unlike a legacy range,
+    /// one eligible object cannot be silently clamped into a "choose two".
+    #[test]
+    fn optional_exact_counter_selection_requires_every_object() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let host = scenario
+            .add_artifact_from_oracle(P0, "Choice Host", "")
+            .id();
+        let creatures = [
+            scenario.add_creature(P0, "First", 1, 1).id(),
+            scenario.add_creature(P0, "Second", 1, 1).id(),
+        ];
+        let mut state = scenario.build().state().clone();
+        let effect = Effect::ChooseObjectsIntoTrackedSet {
+            chooser: TargetFilter::Controller,
+            filter: TargetFilter::Typed(TypedFilter::creature()),
+            min: 2,
+            max: Some(2),
+            cardinality: Some(ObjectSelectionCardinality::Exactly { count: 2 }),
+            eligibility: Some(ObjectSelectionEligibility::RemovableCounter {
+                counter_type: Some(CounterType::Plus1Plus1),
+                count: crate::types::ability::QuantityExpr::Fixed { value: 2 },
+            }),
+        };
+        let ability = ResolvedAbility::new(effect, Vec::new(), host, P0);
+
+        assert!(optional_exact_selection_is_infeasible(&state, &ability));
+        state
+            .objects
+            .get_mut(&creatures[0])
+            .expect("first creature exists")
+            .counters
+            .insert(CounterType::Plus1Plus1, 1);
+        assert!(optional_exact_selection_is_infeasible(&state, &ability));
+        state
+            .objects
+            .get_mut(&creatures[1])
+            .expect("second creature exists")
+            .counters
+            .insert(CounterType::Plus1Plus1, 1);
+        assert!(
+            optional_exact_selection_is_infeasible(&state, &ability),
+            "one counter on each creature cannot pay a two-counter removal"
+        );
+        for creature in creatures {
+            state
+                .objects
+                .get_mut(&creature)
+                .expect("creature exists")
+                .counters
+                .insert(CounterType::Plus1Plus1, 2);
+        }
+        assert!(!optional_exact_selection_is_infeasible(&state, &ability));
+    }
+
+    /// CR 608.2c + CR 608.2d: An infeasible optional exact selection takes
+    /// the ordinary decline path instead of installing a choice whose minimum
+    /// is impossible to submit.
+    #[test]
+    fn infeasible_optional_exact_counter_selection_auto_declines() {
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let host = scenario
+            .add_artifact_from_oracle(P0, "Choice Host", "")
+            .id();
+        let mut state = scenario.build().state().clone();
+        let mut ability = ResolvedAbility::new(
+            Effect::ChooseObjectsIntoTrackedSet {
+                chooser: TargetFilter::Controller,
+                filter: TargetFilter::Typed(TypedFilter::creature()),
+                min: 2,
+                max: Some(2),
+                cardinality: Some(ObjectSelectionCardinality::Exactly { count: 2 }),
+                eligibility: Some(ObjectSelectionEligibility::RemovableCounter {
+                    counter_type: Some(CounterType::Plus1Plus1),
+                    count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                }),
+            },
+            Vec::new(),
+            host,
+            P0,
+        );
+        ability.optional = true;
+
+        resolve_ability_chain(&mut state, &ability, &mut Vec::new(), 0)
+            .expect("infeasible optional selection declines");
+        assert!(
+            !matches!(state.waiting_for, WaitingFor::ChooseObjectsSelection { .. }),
+            "an infeasible exact selection must not leave the game waiting"
+        );
+    }
+
+    /// CR 608.2c + CR 122.1: The exact selection's tracked set feeds the
+    /// removal continuation, so both selected creatures lose their counters.
+    #[test]
+    fn exact_counter_selection_removes_from_every_selected_creature() {
+        let removal = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::RemoveCounter {
+                counter_type: Some(CounterType::Plus1Plus1),
+                count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::TrackedSet {
+                    id: crate::types::identifiers::TrackedSetId(0),
+                },
+            },
+        );
+        let choice = AbilityDefinition::new(
+            AbilityKind::Activated,
+            Effect::ChooseObjectsIntoTrackedSet {
+                chooser: TargetFilter::Controller,
+                filter: TargetFilter::Typed(TypedFilter::creature()),
+                min: 2,
+                max: Some(2),
+                cardinality: Some(ObjectSelectionCardinality::Exactly { count: 2 }),
+                eligibility: Some(ObjectSelectionEligibility::RemovableCounter {
+                    counter_type: Some(CounterType::Plus1Plus1),
+                    count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                }),
+            },
+        )
+        .sub_ability(removal);
+        let mut scenario = GameScenario::new();
+        scenario.at_phase(Phase::PreCombatMain);
+        let host = {
+            let mut builder = scenario.add_artifact_from_oracle(P0, "Choice Host", "");
+            builder.with_ability_definition(choice);
+            builder.id()
+        };
+        let first = {
+            let mut builder = scenario.add_creature(P0, "First", 1, 1);
+            builder.with_plus_counters(1);
+            builder.id()
+        };
+        let second = {
+            let mut builder = scenario.add_creature(P0, "Second", 1, 1);
+            builder.with_plus_counters(1);
+            builder.id()
+        };
+        let mut runner = scenario.build();
+        runner
+            .act(GameAction::ActivateAbility {
+                source_id: host,
+                ability_index: 0,
+            })
+            .expect("activate exact counter-removal choice");
+        runner.advance_until_stack_empty();
+        runner
+            .act(GameAction::SelectTargets {
+                targets: vec![TargetRef::Object(first), TargetRef::Object(second)],
+            })
+            .expect("select both eligible creatures");
+        for creature in [first, second] {
+            assert_eq!(
+                runner
+                    .state()
+                    .objects
+                    .get(&creature)
+                    .and_then(|object| object.counters.get(&CounterType::Plus1Plus1))
+                    .copied()
+                    .unwrap_or_default(),
+                0,
+                "selected creature must lose its +1/+1 counter"
+            );
+        }
     }
 
     /// CR 608.2c + CR 608.2d + official ruling: The Day of the Doctor IV — "Choose

--- a/crates/engine/src/game/effects/choose_objects_into_tracked_set.rs
+++ b/crates/engine/src/game/effects/choose_objects_into_tracked_set.rs
@@ -66,14 +66,24 @@ pub fn resolve(
     // ability controller, so bind the filter context controller to the
     // chooser (mirrors `pay.rs`'s payer-rebinding pattern).
     let ctx = FilterContext::from_ability_with_controller(ability, chooser);
-    let eligible = eligible_targets(state, ability, &filter, &ctx, eligibility.as_ref());
+    let eligible = eligible_targets(state, &filter, &ctx, eligibility.as_ref());
 
     // CR 609.3: If a resolving effect asks for more objects than are
     // available, the player chooses all that are available. Publish an
     // achievable runtime range at this trust seam so every consumer (engine,
     // AI, and client) sees the same liveness-preserving cardinality.
     let (min, max) = match cardinality {
-        Some(ObjectSelectionCardinality::Exactly { count }) => (count, Some(count)),
+        // CR 609.3: a mandatory instruction does as much as possible. An
+        // optional exact selection is screened before this resolver can run,
+        // so retain its exact published cardinality for that decision path.
+        Some(ObjectSelectionCardinality::Exactly { count }) if ability.optional => {
+            (count, Some(count))
+        }
+        Some(ObjectSelectionCardinality::Exactly { count }) => {
+            let available = u32::try_from(eligible.len()).unwrap_or(u32::MAX);
+            let achievable = count.min(available);
+            (achievable, Some(achievable))
+        }
         None => {
             let available = u32::try_from(eligible.len()).unwrap_or(u32::MAX);
             let max = max.map(|maximum| maximum.min(available));
@@ -107,7 +117,6 @@ pub fn resolve(
 /// optional-effect feasibility gate so they cannot disagree about availability.
 fn eligible_targets(
     state: &GameState,
-    ability: &ResolvedAbility,
     filter: &crate::types::ability::TargetFilter,
     ctx: &FilterContext,
     eligibility: Option<&ObjectSelectionEligibility>,
@@ -118,28 +127,15 @@ fn eligible_targets(
         .filter(|&&obj_id| matches_target_filter(state, obj_id, filter, ctx))
         .filter(|&&obj_id| match eligibility {
             None => true,
-            Some(ObjectSelectionEligibility::RemovableCounter {
-                counter_type,
-                count,
-            }) => {
-                let required = u32::try_from(
-                    crate::game::quantity::resolve_quantity_with_targets(state, count, ability)
-                        .max(1),
-                )
-                .unwrap_or(u32::MAX);
+            Some(ObjectSelectionEligibility::RemovableCounter { counter_type }) => {
                 state.objects.get(&obj_id).is_some_and(|object| {
-                    let removable = object.counters.iter().filter_map(|(kind, &available)| {
-                        (counter_type
+                    object.counters.iter().any(|(kind, &available)| {
+                        counter_type
                             .as_ref()
                             .is_none_or(|expected| expected == kind)
-                            && !counter_removal_blocked(state, obj_id, kind))
-                        .then_some(available)
-                    });
-                    if counter_type.is_some() {
-                        removable.into_iter().next().unwrap_or_default() >= required
-                    } else {
-                        removable.sum::<u32>() >= required
-                    }
+                            && available > 0
+                            && !counter_removal_blocked(state, obj_id, kind)
+                    })
                 })
             }
         })
@@ -167,7 +163,7 @@ pub(crate) fn optional_exact_selection_is_infeasible(
         return true;
     };
     let ctx = FilterContext::from_ability_with_controller(ability, chooser);
-    eligible_targets(state, ability, filter, &ctx, eligibility.as_ref()).len() < *count as usize
+    eligible_targets(state, filter, &ctx, eligibility.as_ref()).len() < *count as usize
 }
 
 #[cfg(test)]
@@ -203,7 +199,7 @@ mod tests {
                 filter: TargetFilter::Typed(TypedFilter::creature()),
                 min: 2,
                 max: Some(2),
-                cardinality: None,
+                cardinality: Some(ObjectSelectionCardinality::Exactly { count: 2 }),
                 eligibility: None,
             },
         );
@@ -262,7 +258,6 @@ mod tests {
             cardinality: Some(ObjectSelectionCardinality::Exactly { count: 2 }),
             eligibility: Some(ObjectSelectionEligibility::RemovableCounter {
                 counter_type: Some(CounterType::Plus1Plus1),
-                count: crate::types::ability::QuantityExpr::Fixed { value: 2 },
             }),
         };
         let ability = ResolvedAbility::new(effect, Vec::new(), host, P0);
@@ -282,18 +277,9 @@ mod tests {
             .counters
             .insert(CounterType::Plus1Plus1, 1);
         assert!(
-            optional_exact_selection_is_infeasible(&state, &ability),
-            "one counter on each creature cannot pay a two-counter removal"
+            !optional_exact_selection_is_infeasible(&state, &ability),
+            "one removable counter on each creature makes both objects selectable"
         );
-        for creature in creatures {
-            state
-                .objects
-                .get_mut(&creature)
-                .expect("creature exists")
-                .counters
-                .insert(CounterType::Plus1Plus1, 2);
-        }
-        assert!(!optional_exact_selection_is_infeasible(&state, &ability));
     }
 
     /// CR 608.2c + CR 608.2d: An infeasible optional exact selection takes
@@ -316,7 +302,6 @@ mod tests {
                 cardinality: Some(ObjectSelectionCardinality::Exactly { count: 2 }),
                 eligibility: Some(ObjectSelectionEligibility::RemovableCounter {
                     counter_type: Some(CounterType::Plus1Plus1),
-                    count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
                 }),
             },
             Vec::new(),
@@ -334,14 +319,16 @@ mod tests {
     }
 
     /// CR 608.2c + CR 122.1: The exact selection's tracked set feeds the
-    /// removal continuation, so both selected creatures lose their counters.
+    /// removal continuation. `RemoveCounter` removes as many as possible from
+    /// each selected object, so one counter remains a legal selection for a
+    /// two-counter instruction.
     #[test]
-    fn exact_counter_selection_removes_from_every_selected_creature() {
+    fn exact_counter_selection_allows_partial_removal_from_every_selected_creature() {
         let removal = AbilityDefinition::new(
             AbilityKind::Activated,
             Effect::RemoveCounter {
                 counter_type: Some(CounterType::Plus1Plus1),
-                count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
+                count: crate::types::ability::QuantityExpr::Fixed { value: 2 },
                 target: TargetFilter::TrackedSet {
                     id: crate::types::identifiers::TrackedSetId(0),
                 },
@@ -357,7 +344,6 @@ mod tests {
                 cardinality: Some(ObjectSelectionCardinality::Exactly { count: 2 }),
                 eligibility: Some(ObjectSelectionEligibility::RemovableCounter {
                     counter_type: Some(CounterType::Plus1Plus1),
-                    count: crate::types::ability::QuantityExpr::Fixed { value: 1 },
                 }),
             },
         )

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -2751,6 +2751,8 @@ pub fn resolve_remove(
         effect_kind: EffectKind::from(&ability.effect),
         source_ability_id: ability.source_id,
         total,
+        applied_total: 0,
+        in_flight: None,
     });
     drain_pending_counter_removals(state, events);
 
@@ -2896,6 +2898,8 @@ pub(crate) fn validate_and_queue_counter_removal(
         effect_kind: EffectKind::from(&pending_effect.effect),
         source_ability_id: pending_effect.source_id,
         total,
+        applied_total: 0,
+        in_flight: None,
     });
     Ok(())
 }
@@ -2905,20 +2909,36 @@ pub(crate) fn validate_and_queue_counter_removal(
 /// single-authority remove pipeline so prevention/modification replacements
 /// apply. Mirrors `drain_pending_counter_moves`: re-parks the queue (returning
 /// early) when a per-removal replacement surfaces a `ReplacementChoice`, and when
-/// the queue empties stamps `last_effect_count = total` BEFORE emitting
+/// the queue empties stamps `last_effect_count = applied_total` BEFORE emitting
 /// `EffectResolved` so a downstream "create that many" / "add that much" rider
 /// reading `QuantityRef::EventContextAmount` picks up the removed count.
 pub(crate) fn drain_pending_counter_removals(state: &mut GameState, events: &mut Vec<GameEvent>) {
     while let Some(mut queue) = state.active_counter_removals().cloned() {
+        if let Some(in_flight) = queue.in_flight.take() {
+            let counter_count_after = counter_count(
+                state,
+                in_flight.removal.object_id,
+                &in_flight.removal.counter_type,
+            );
+            queue.applied_total = queue.applied_total.saturating_add(
+                in_flight
+                    .counter_count_before
+                    .saturating_sub(counter_count_after),
+            );
+            state
+                .replace_active_counter_removals(queue)
+                .expect("settled counter-removal must retain its active frame");
+            continue;
+        }
         let Some(PendingCounterRemoval {
             object_id,
             counter_type,
             count,
         }) = queue.remaining.first().cloned()
         else {
-            // CR 608.2h: ordering invariant — stamp the total removed before the
+            // CR 608.2h: ordering invariant — stamp the actual removed total before the
             // terminating EffectResolved (and thus before the continuation drains).
-            state.last_effect_count = Some(queue.total as i32);
+            state.last_effect_count = Some(queue.applied_total as i32);
             state
                 .take_active_counter_removals()
                 .expect("settled counter-removals queue must own the active frame")
@@ -2931,6 +2951,14 @@ pub(crate) fn drain_pending_counter_removals(state: &mut GameState, events: &mut
             continue;
         };
         queue.remaining.remove(0);
+        queue.in_flight = Some(crate::types::game_state::PendingCounterRemovalInFlight {
+            counter_count_before: counter_count(state, object_id, &counter_type),
+            removal: PendingCounterRemoval {
+                object_id,
+                counter_type: counter_type.clone(),
+                count,
+            },
+        });
         state
             .replace_active_counter_removals(queue)
             .expect("re-parked counter-removals queue must own the active frame");
@@ -3638,6 +3666,11 @@ mod tests {
                 .counters
                 .contains_key(&CounterType::Plus1Plus1),
             "zero-count +1/+1 entry should be pruned after removal"
+        );
+        assert_eq!(
+            state.last_effect_count,
+            Some(1),
+            "effect context records the one counter actually removed, not the requested three"
         );
     }
 
@@ -4922,6 +4955,14 @@ mod tests {
                 .len(),
             1
         );
+        assert!(
+            state
+                .active_counter_removals()
+                .expect("counter-removals queue owns its prompt")
+                .in_flight
+                .is_some(),
+            "the paused replacement's removal remains serializable until its actual count settles"
+        );
 
         let saved = serde_json::to_value(ResolutionStateWire::from_game_state(state))
             .expect("paused CounterRemovals prompt serializes as v2");
@@ -4931,17 +4972,22 @@ mod tests {
             serde_json::from_value(saved).expect("v2 CounterRemovals prompt restores");
         let mut state = restored.into_game_state();
 
-        for _ in 0..8 {
+        for replacement_index in 0..8 {
             if !matches!(state.waiting_for, WaitingFor::ReplacementChoice { .. }) {
                 break;
             }
             apply_as_current(&mut state, GameAction::ChooseReplacement { index: 0 })
                 .expect("production replacement action resumes the counter-removals queue");
             if matches!(state.waiting_for, WaitingFor::ReplacementChoice { .. }) {
-                assert!(matches!(
-                    state.resolution_stack.last(),
-                    Some(ResolutionFrame::CounterRemovals(_))
-                ));
+                let queue = state
+                    .active_counter_removals()
+                    .expect("re-parked counter-removals queue owns the next prompt");
+                assert_eq!(
+                    queue.applied_total,
+                    replacement_index + 1,
+                    "each completed replacement-delayed removal is accumulated before the next re-park"
+                );
+                assert!(queue.in_flight.is_some());
             }
         }
 

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -14,8 +14,8 @@ use crate::types::events::GameEvent;
 use crate::types::game_state::{
     CounterAddedRecord, CounterMoveChoice, CounterRemoveChoice, DelayedTrigger, GameState,
     PendingCounterAddition, PendingCounterAdditionQueue, PendingCounterMove,
-    PendingCounterMoveQueue, PendingCounterPostAction, PendingCounterRemovalQueue,
-    PendingEffectResolutionEvent, PendingEffectResolved, WaitingFor,
+    PendingCounterMoveQueue, PendingCounterPostAction, PendingCounterRemoval,
+    PendingCounterRemovalQueue, PendingEffectResolutionEvent, PendingEffectResolved, WaitingFor,
 };
 use crate::types::identifiers::{ObjectId, ObjectIncarnationRef};
 use crate::types::player::PlayerId;
@@ -2680,7 +2680,15 @@ pub fn resolve_remove(
         _ => (Some(CounterType::Plus1Plus1), 1),
     };
 
-    let targets = resolve_defined_or_targets(state, ability);
+    let targets = match &ability.effect {
+        Effect::RemoveCounter {
+            target:
+                target @ (TargetFilter::TrackedSet { .. } | TargetFilter::TrackedSetFiltered { .. }),
+            ..
+        } => crate::game::targeting::resolved_object_ids_for_filter(state, ability, target),
+        _ => resolve_defined_or_targets(state, ability),
+    };
+    let mut remaining = Vec::new();
     for obj_id in targets {
         // Build the list of (counter_type, count) pairs to remove.
         let removals: Vec<(CounterType, u32)> = if let Some(counter_type) = &counter_type {
@@ -2728,27 +2736,23 @@ pub fn resolve_remove(
             }
         };
 
-        for (ct, counter_num) in removals {
-            // CR 614.1: Delegate to the single-authority remove pipeline so
-            // prevention/modification replacements apply and derived fields
-            // (obj.loyalty / obj.defense) stay in lockstep with the counter map.
-            remove_counter_with_replacement(state, obj_id, ct, counter_num, events);
-            // If a replacement requires player choice, suspend and bail — the
-            // continuation re-enters the remove pipeline after the choice resolves.
-            if matches!(
-                state.waiting_for,
-                crate::types::game_state::WaitingFor::ReplacementChoice { .. }
-            ) {
-                return Ok(());
-            }
-        }
+        remaining.extend(removals.into_iter().filter_map(|(counter_type, count)| {
+            (count > 0).then_some(PendingCounterRemoval {
+                object_id: obj_id,
+                counter_type,
+                count,
+            })
+        }));
     }
 
-    events.push(GameEvent::EffectResolved {
-        kind: EffectKind::from(&ability.effect),
-        source_id: ability.source_id,
-        subject: None,
+    let total = remaining.iter().map(|entry| entry.count).sum();
+    state.push_counter_removals(PendingCounterRemovalQueue {
+        remaining,
+        effect_kind: EffectKind::from(&ability.effect),
+        source_ability_id: ability.source_id,
+        total,
     });
+    drain_pending_counter_removals(state, events);
 
     Ok(())
 }
@@ -2879,13 +2883,16 @@ pub(crate) fn validate_and_queue_counter_removal(
     pending_effect: &ResolvedAbility,
 ) -> Result<(), EffectError> {
     let total = validate_counter_selection(available, selections)?;
-    let remaining: Vec<(CounterType, u32)> = selections
+    let remaining: Vec<PendingCounterRemoval> = selections
         .iter()
-        .map(|s| (s.counter_type.clone(), s.count))
+        .map(|s| PendingCounterRemoval {
+            object_id: source_id,
+            counter_type: s.counter_type.clone(),
+            count: s.count,
+        })
         .collect();
     state.push_counter_removals(PendingCounterRemovalQueue {
         remaining,
-        source_id,
         effect_kind: EffectKind::from(&pending_effect.effect),
         source_ability_id: pending_effect.source_id,
         total,
@@ -2903,7 +2910,12 @@ pub(crate) fn validate_and_queue_counter_removal(
 /// reading `QuantityRef::EventContextAmount` picks up the removed count.
 pub(crate) fn drain_pending_counter_removals(state: &mut GameState, events: &mut Vec<GameEvent>) {
     while let Some(mut queue) = state.active_counter_removals().cloned() {
-        let Some((counter_type, count)) = queue.remaining.first().cloned() else {
+        let Some(PendingCounterRemoval {
+            object_id,
+            counter_type,
+            count,
+        }) = queue.remaining.first().cloned()
+        else {
             // CR 608.2h: ordering invariant — stamp the total removed before the
             // terminating EffectResolved (and thus before the continuation drains).
             state.last_effect_count = Some(queue.total as i32);
@@ -2919,13 +2931,12 @@ pub(crate) fn drain_pending_counter_removals(state: &mut GameState, events: &mut
             continue;
         };
         queue.remaining.remove(0);
-        let source_id = queue.source_id;
         state
             .replace_active_counter_removals(queue)
             .expect("re-parked counter-removals queue must own the active frame");
         // CR 614.1: single-authority remove pipeline (applies prevention /
         // modification replacements; keeps obj.loyalty / obj.defense in lockstep).
-        remove_counter_with_replacement(state, source_id, counter_type, count, events);
+        remove_counter_with_replacement(state, object_id, counter_type, count, events);
         // If a replacement needs a player choice, suspend — the ReplacementChoice
         // resume path re-invokes this drain to finish the remaining removals.
         if matches!(state.waiting_for, WaitingFor::ReplacementChoice { .. }) {

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -4997,6 +4997,109 @@ mod tests {
         assert!(state.objects[&source_id].counters.is_empty());
     }
 
+    /// CR 122.1 + CR 614.1 + CR 608.2h: a v1 save parked an accepted
+    /// counter-removal replacement after removing its current tuple from the
+    /// queue. Restore reconstructs that tuple from `pending_replacement`, so
+    /// accepting the replacement counts it before the queued tail drains.
+    #[test]
+    fn legacy_counter_removal_replacement_pause_recovers_in_flight_removal() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(916),
+            PlayerId(0),
+            "Legacy Counter Removal Source".to_string(),
+            Zone::Battlefield,
+        );
+        let charge = CounterType::Generic("charge".to_string());
+        {
+            let source = state
+                .objects
+                .get_mut(&source_id)
+                .expect("counter-removal source exists");
+            source.counters.insert(CounterType::Plus1Plus1, 1);
+            source.counters.insert(charge.clone(), 1);
+        }
+        install_counter_removal_optional_replacement(&mut state);
+        state.waiting_for = WaitingFor::RemoveCountersChoice {
+            player: PlayerId(0),
+            source_id,
+            counter_type: None,
+            available: vec![(CounterType::Plus1Plus1, 1), (charge.clone(), 1)],
+            pending_effect: Box::new(make_counter_ability(
+                Effect::RemoveCounter {
+                    counter_type: None,
+                    count: QuantityExpr::Fixed { value: -1 },
+                    target: TargetFilter::Any,
+                },
+                source_id,
+            )),
+        };
+        apply_as_current(
+            &mut state,
+            GameAction::ChooseCountersToRemove {
+                selections: vec![
+                    CounterRemoveChoice {
+                        counter_type: CounterType::Plus1Plus1,
+                        count: 1,
+                    },
+                    CounterRemoveChoice {
+                        counter_type: charge.clone(),
+                        count: 1,
+                    },
+                ],
+            },
+        )
+        .expect("production removal choice creates its first replacement prompt");
+
+        let queue = state
+            .active_counter_removals()
+            .expect("counter-removals queue owns the paused prompt")
+            .clone();
+        let mut legacy_queue = serde_json::to_value(queue).expect("queue serializes");
+        legacy_queue["source_id"] = serde_json::to_value(source_id).expect("source ID serializes");
+        legacy_queue["remaining"] =
+            serde_json::to_value(vec![(charge.clone(), 1_u32)]).expect("legacy tail serializes");
+        legacy_queue
+            .as_object_mut()
+            .expect("queue is an object")
+            .remove("in_flight");
+
+        let mut v1 = serde_json::to_value(state).expect("paused game state serializes");
+        v1.as_object_mut()
+            .expect("game state is an object")
+            .remove("resolution_stack");
+        v1["pending_counter_removals"] = legacy_queue;
+        v1["resolution_state_version"] = serde_json::json!(1);
+
+        let restored: ResolutionStateWire =
+            serde_json::from_value(v1).expect("v1 counter-removal prompt restores");
+        let mut state = restored.into_game_state();
+        let in_flight = state
+            .active_counter_removals()
+            .expect("restored counter-removals queue owns the prompt")
+            .in_flight
+            .as_ref()
+            .expect("legacy replacement prompt recovers its current removal");
+        assert_eq!(in_flight.removal.object_id, source_id);
+        assert_eq!(in_flight.removal.counter_type, CounterType::Plus1Plus1);
+        assert_eq!(in_flight.removal.count, 1);
+        assert_eq!(in_flight.counter_count_before, 1);
+
+        for _ in 0..8 {
+            if !matches!(state.waiting_for, WaitingFor::ReplacementChoice { .. }) {
+                break;
+            }
+            apply_as_current(&mut state, GameAction::ChooseReplacement { index: 0 })
+                .expect("replacement choice resumes the legacy counter-removals queue");
+        }
+
+        assert!(state.active_counter_removals().is_none());
+        assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
+        assert_eq!(state.last_effect_count, Some(2));
+        assert!(state.objects[&source_id].counters.is_empty());
+    }
+
     /// CR 122.1 + CR 616.1: the production multi-target counter-addition
     /// resolver parks its remaining recipients and completion in CounterAdditions
     /// while each recipient's placement chooses among noncommuting replacements.

--- a/crates/engine/src/game/effects/counters.rs
+++ b/crates/engine/src/game/effects/counters.rs
@@ -5100,6 +5100,107 @@ mod tests {
         assert!(state.objects[&source_id].counters.is_empty());
     }
 
+    /// CR 122.1 + CR 614.1 + CR 608.2h: a v1 queue did not retain the actual
+    /// count of a replacement-settled prefix. When its second removal is
+    /// paused, migration reconstructs the current removal from the proposed
+    /// event and seeds the already-consumed prefix from the only v1 evidence:
+    /// requested total minus the unconsumed tail and current request.
+    #[test]
+    fn legacy_counter_removal_replacement_pause_seeds_settled_prefix() {
+        let mut state = GameState::new_two_player(42);
+        let source_id = create_object(
+            &mut state,
+            CardId(917),
+            PlayerId(0),
+            "Legacy Counter Removal Prefix Source".to_string(),
+            Zone::Battlefield,
+        );
+        let charge = CounterType::Generic("charge".to_string());
+        {
+            let source = state
+                .objects
+                .get_mut(&source_id)
+                .expect("counter-removal source exists");
+            source.counters.insert(CounterType::Plus1Plus1, 1);
+            source.counters.insert(charge.clone(), 1);
+        }
+        install_counter_removal_optional_replacement(&mut state);
+        state.waiting_for = WaitingFor::RemoveCountersChoice {
+            player: PlayerId(0),
+            source_id,
+            counter_type: None,
+            available: vec![(CounterType::Plus1Plus1, 1), (charge.clone(), 1)],
+            pending_effect: Box::new(make_counter_ability(
+                Effect::RemoveCounter {
+                    counter_type: None,
+                    count: QuantityExpr::Fixed { value: -1 },
+                    target: TargetFilter::Any,
+                },
+                source_id,
+            )),
+        };
+        apply_as_current(
+            &mut state,
+            GameAction::ChooseCountersToRemove {
+                selections: vec![
+                    CounterRemoveChoice {
+                        counter_type: CounterType::Plus1Plus1,
+                        count: 1,
+                    },
+                    CounterRemoveChoice {
+                        counter_type: charge.clone(),
+                        count: 1,
+                    },
+                ],
+            },
+        )
+        .expect("first removal creates its replacement prompt");
+        apply_as_current(&mut state, GameAction::ChooseReplacement { index: 0 })
+            .expect("first replacement settles and pauses the second removal");
+
+        let queue = state
+            .active_counter_removals()
+            .expect("counter-removals queue owns the second prompt");
+        assert!(queue.remaining.is_empty());
+        assert_eq!(queue.applied_total, 1);
+        assert!(queue.in_flight.is_some());
+
+        let mut legacy_queue = serde_json::to_value(queue).expect("queue serializes");
+        legacy_queue["source_id"] = serde_json::to_value(source_id).expect("source ID serializes");
+        let legacy_queue_object = legacy_queue.as_object_mut().expect("queue is an object");
+        legacy_queue_object.remove("applied_total");
+        legacy_queue_object.remove("in_flight");
+
+        let mut v1 = serde_json::to_value(state).expect("paused game state serializes");
+        v1.as_object_mut()
+            .expect("game state is an object")
+            .remove("resolution_stack");
+        v1["pending_counter_removals"] = legacy_queue;
+        v1["resolution_state_version"] = serde_json::json!(1);
+
+        let restored: ResolutionStateWire =
+            serde_json::from_value(v1).expect("v1 second counter-removal prompt restores");
+        let mut state = restored.into_game_state();
+        let queue = state
+            .active_counter_removals()
+            .expect("restored counter-removals queue owns the second prompt");
+        assert_eq!(queue.applied_total, 1);
+        assert!(queue.in_flight.is_some());
+
+        for _ in 0..8 {
+            if !matches!(state.waiting_for, WaitingFor::ReplacementChoice { .. }) {
+                break;
+            }
+            apply_as_current(&mut state, GameAction::ChooseReplacement { index: 0 })
+                .expect("replacement choice resumes the legacy counter-removals queue");
+        }
+
+        assert!(state.active_counter_removals().is_none());
+        assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
+        assert_eq!(state.last_effect_count, Some(2));
+        assert!(state.objects[&source_id].counters.is_empty());
+    }
+
     /// CR 122.1 + CR 616.1: the production multi-target counter-addition
     /// resolver parks its remaining recipients and completion in CounterAdditions
     /// while each recipient's placement chooses among noncommuting replacements.

--- a/crates/engine/src/game/effects/mod.rs
+++ b/crates/engine/src/game/effects/mod.rs
@@ -13,9 +13,9 @@ use crate::types::ability::{
     CastFromZoneDriver, ChosenAttribute, CommanderOwnership, ControllerRef, CopyRetargetPermission,
     CostPaidObjectSnapshot, DetachedRemainder, EachDamageRecipient, Effect, EffectError,
     EffectKind, EffectOutcomeSignal, EffectResolutionResult, EffectScope, FilterProp,
-    ForEachCategoryAction, ForwardedResultContext, ManaProduction, OpponentMayScope, PlayerFilter,
-    PlayerScope, QuantityExpr, QuantityRef, RepeatContinuation, ResolvedAbility,
-    RevealUntilDisposition, SacrificeCost, SacrificeRequirement, SharedQuality,
+    ForEachCategoryAction, ForwardedResultContext, ManaProduction, ObjectSelectionCardinality,
+    OpponentMayScope, PlayerFilter, PlayerScope, QuantityExpr, QuantityRef, RepeatContinuation,
+    ResolvedAbility, RevealUntilDisposition, SacrificeCost, SacrificeRequirement, SharedQuality,
     SharedQualityRelation, SiblingCondition, StaticDefinition, SubAbilityLink, TapStateChange,
     TargetChoiceTiming, TargetDamageSourceBinding, TargetFilter, TargetRef, ThisWayCause,
 };
@@ -7416,6 +7416,11 @@ fn optional_effect_is_infeasible(state: &GameState, ability: &ResolvedAbility) -
         Effect::RemoveCounter { .. } => {
             counters::remove_counter_optional_is_infeasible(state, ability)
         }
+        // CR 608.2d + CR 122.1: an optional exact counter-removal selection
+        // cannot be accepted unless every required permanent is selectable.
+        Effect::ChooseObjectsIntoTrackedSet { .. } => {
+            choose_objects_into_tracked_set::optional_exact_selection_is_infeasible(state, ability)
+        }
         // CR 701.61a + CR 608.2d: A player cannot choose to forage unless at
         // least one complete forage mode is currently available.
         Effect::Forage => !forage::can_forage(state, ability),
@@ -11773,18 +11778,27 @@ fn resolve_chain_body(
 
     let optional_is_infeasible = ability.optional && optional_effect_is_infeasible(state, ability);
 
-    // CR 608.2c + CR 608.2d: An infeasible optional cast/play instruction does
-    // not happen. Route every such CastFromZone outcome through the existing
+    // CR 608.2c + CR 608.2d: An infeasible optional cast/play instruction or
+    // exact object selection does not happen. Route either outcome through the existing
     // decline authority instead of merely suppressing the prompt and falling
     // through to `resolve_effect`: a missing exact parent could consume an
     // unrelated inherited target, while another current-legality failure (such
     // as trying to cast a land) could mutate casting permissions before the
-    // cast authority rejects it. The decline path also preserves the printed
+    // cast authority rejects it. An impossible exact selection must likewise
+    // decline instead of surfacing an unsatisfiable waiting state. The decline path preserves the printed
     // tail semantics: dependent "if you do" riders stay gated while independent
     // sequential siblings and explicit decline branches continue. Other
     // infeasible optional effects (PutChosenCounter/RemoveCounter) retain their
     // established resolver no-op.
-    if optional_is_infeasible && matches!(ability.effect, Effect::CastFromZone { .. }) {
+    let auto_decline_infeasible_optional = matches!(
+        &ability.effect,
+        Effect::CastFromZone { .. }
+            | Effect::ChooseObjectsIntoTrackedSet {
+                cardinality: Some(ObjectSelectionCardinality::Exactly { .. }),
+                ..
+            }
+    );
+    if optional_is_infeasible && auto_decline_infeasible_optional {
         return resolve_optional_effect_decision(
             state,
             ability.clone(),

--- a/crates/engine/src/parser/oracle_effect/counter.rs
+++ b/crates/engine/src/parser/oracle_effect/counter.rs
@@ -1089,6 +1089,53 @@ pub(super) fn try_parse_remove_counter(lower: &str, ctx: &mut ParseContext) -> O
     })
 }
 
+/// CR 115.1d + CR 122.1: Extract the fixed resolution-time selection in
+/// "remove … from each of two creatures you control". The surrounding remove
+/// parser remains the authority for the counter phrase and object filter; this
+/// nom-shaped probe preserves only the untargeted cardinality that `Effect`
+/// cannot represent by itself.
+pub(super) fn remove_counter_exact_selection_count(lower: &str) -> Option<u32> {
+    let descriptor = remove_counter_each_of_descriptor(lower)?;
+    parse_fixed_count_descriptor(descriptor).map(|(count, _)| count)
+}
+
+/// CR 601.2c: Recover the announced target cardinality in the targeted
+/// counterpart, "remove … from each of two target creatures". This stays
+/// distinct from the untargeted exact-selection descriptor above.
+pub(super) fn remove_counter_exact_target_multi_target(lower: &str) -> Option<MultiTargetSpec> {
+    let descriptor = remove_counter_each_of_descriptor(lower)?;
+    let (remainder, count) = super::parse_multi_target_count_expr(descriptor).ok()?;
+    nom_on_lower(remainder, remainder, |input| {
+        value((), preceded(space1, tag("target "))).parse(input)
+    })
+    .map(|_| MultiTargetSpec::exact(count))
+}
+
+/// Extract the descriptor following a remove-counter "from each of" phrase.
+/// Keeping the structural prefix parser shared prevents target and untargeted
+/// exact-count recognition from drifting.
+fn remove_counter_each_of_descriptor(lower: &str) -> Option<&str> {
+    let ((), descriptor) = nom_on_lower(lower, lower, |input| {
+        preceded(
+            take_until(" from each of "),
+            value((), tag(" from each of ")),
+        )
+        .parse(input)
+    })?;
+    Some(descriptor)
+}
+
+/// Parse the non-targeted descriptor after "each of". Targeted fixed-count
+/// wording remains in the ordinary target-selection pipeline (CR 601.2c).
+fn parse_fixed_count_descriptor(input: &str) -> Option<(u32, &str)> {
+    let (count, remainder) = nom_on_lower(input, input, nom_primitives::parse_number)?;
+    let is_targeted = nom_on_lower(remainder, remainder, |i| {
+        value((), preceded(space1, tag("target "))).parse(i)
+    })
+    .is_some();
+    (!is_targeted && count > 0).then_some((count, remainder.trim_start()))
+}
+
 /// Normalize oracle-text counter type strings to canonical engine names.
 ///
 /// - `+1/+1` / `-1/-1` map to the canonical `P1P1` / `M1M1` keys.
@@ -1115,6 +1162,14 @@ fn strip_remove_counter_each_of_any_number(input: &str) -> Option<&str> {
     .map(|((), rest)| rest.trim_start())
 }
 
+/// CR 115.1d + CR 122.1: Strip the fixed-count counterpart of the variable
+/// distribution prefix. The number is carried by the imperative AST; this
+/// helper leaves the object phrase for the normal typed-filter parser.
+fn strip_remove_counter_each_of_fixed_number(input: &str) -> Option<&str> {
+    let ((), after_each_of) = nom_on_lower(input, input, |i| value((), tag("each of ")).parse(i))?;
+    parse_fixed_count_descriptor(after_each_of).map(|(_, remainder)| remainder)
+}
+
 /// CR 122.1 + CR 115.1d: Resolve the "from <objects>" clause of a remove-counter
 /// effect. The optional "each of any number of" prefix denotes a variable-count
 /// non-target distribution — strip it and parse the remainder as a type phrase
@@ -1128,7 +1183,9 @@ fn resolve_remove_counter_from_target(text: &str, ctx: &mut ParseContext) -> Tar
         // CR 608.2k: Bare pronoun — context-dependent
         return resolve_it_pronoun(ctx);
     }
-    if let Some(filter_text) = strip_remove_counter_each_of_any_number(text) {
+    if let Some(filter_text) = strip_remove_counter_each_of_any_number(text)
+        .or_else(|| strip_remove_counter_each_of_fixed_number(text))
+    {
         let (t, _rem) = parse_type_phrase_with_ctx(filter_text, ctx);
         #[cfg(debug_assertions)]
         assert_no_compound_remainder(_rem, filter_text);
@@ -2208,6 +2265,21 @@ mod tests {
             panic!("expected RemoveCounter, got {:?}", clause.effect);
         };
         assert!(matches!(target, TargetFilter::Typed(_)));
+    }
+
+    /// CR 601.2c: Fixed-count wording with `target` still announces its
+    /// targets. It must not be reclassified as the untargeted tracked-set
+    /// selection used by "each of two creatures".
+    #[test]
+    fn remove_counter_each_of_two_target_creatures_keeps_multi_targeting() {
+        let text = "remove a +1/+1 counter from each of two target creatures";
+        assert_eq!(remove_counter_exact_selection_count(text), None);
+        let clause = super::super::parse_effect_clause(text, &mut default_ctx());
+        assert_eq!(
+            clause.multi_target,
+            Some(MultiTargetSpec::exact(QuantityExpr::Fixed { value: 2 }))
+        );
+        assert!(matches!(clause.effect, Effect::RemoveCounter { .. }));
     }
 
     #[test]

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -8,8 +8,10 @@ use nom::sequence::{pair, preceded, terminated};
 use nom::Parser;
 
 use super::counter::{
-    parse_counter_anaphor, try_parse_double_effect, try_parse_move_counters_from,
-    try_parse_multiply_pt_effect, try_parse_put_counter, try_parse_remove_counter,
+    parse_counter_anaphor, remove_counter_exact_selection_count,
+    remove_counter_exact_target_multi_target, try_parse_double_effect,
+    try_parse_move_counters_from, try_parse_multiply_pt_effect, try_parse_put_counter,
+    try_parse_remove_counter,
 };
 use super::lower::{
     parse_for_each_multiplier_prefix, parse_multi_target_count_expr,
@@ -39,8 +41,9 @@ use crate::types::ability::{
     CardSelectionMode, CategoryChooserScope, ChoiceType, Chooser, ContinuousModification,
     ControlWindow, ControllerRef, CopyRetargetPermission, CounterAdjustment, DigSource, DoorLockOp,
     Duration, Effect, EffectScope, FaceDownProfile, FilterProp, ForceBlockAttackerRef,
-    GrantedAbilityScope, LibraryPosition, MultiTargetSpec, OutsideGameSourcePool, PerPlayerScope,
-    PlayerScope, PreventionAmount, PreventionScope, PtStat, PtValue, QuantityExpr, QuantityRef,
+    GrantedAbilityScope, LibraryPosition, MultiTargetSpec, ObjectSelectionCardinality,
+    ObjectSelectionEligibility, OutsideGameSourcePool, PerPlayerScope, PlayerScope,
+    PreventionAmount, PreventionScope, PtStat, PtValue, QuantityExpr, QuantityRef,
     ReassembleControlMode, SearchSelectionConstraint, StaticDefinition, StickerTicketCostPayment,
     TapStateChange, TargetFilter, TargetSelectionMode, ThisWayCause, TypeFilter, TypedFilter,
     ZoneOwner,
@@ -3270,7 +3273,7 @@ pub(super) fn parse_search_and_creation_ast(
                     colors,
                     keywords,
                     tapped,
-                    count,
+                    count: count.clone(),
                     attach_to,
                     static_abilities,
                     enters_attacking,
@@ -12567,6 +12570,43 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             }
             clause
         }
+        // CR 115.1d + CR 122.1: "remove a +1/+1 counter from each of two
+        // creatures you control" is an untargeted exact selection followed by
+        // removal from the selected set. It must not become a blank typed target
+        // filter, which the targeting layer correctly interprets as a player.
+        ImperativeFamilyAst::ZoneCounter(ZoneCounterImperativeAst::RemoveCounter {
+            counter_type,
+            count,
+            target,
+            exact_selection: Some(selection_count),
+            multi_target: None,
+        }) => {
+            let removal = AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::RemoveCounter {
+                    counter_type: counter_type.clone(),
+                    count: count.clone(),
+                    target: TargetFilter::TrackedSet {
+                        id: crate::types::identifiers::TrackedSetId(0),
+                    },
+                },
+            );
+            let mut clause = parsed_clause(Effect::ChooseObjectsIntoTrackedSet {
+                chooser: TargetFilter::Controller,
+                filter: target,
+                min: selection_count,
+                max: Some(selection_count),
+                cardinality: Some(ObjectSelectionCardinality::Exactly {
+                    count: selection_count,
+                }),
+                eligibility: Some(ObjectSelectionEligibility::RemovableCounter {
+                    counter_type,
+                    count,
+                }),
+            });
+            clause.sub_ability = Some(Box::new(removal));
+            clause
+        }
         // CR 608.2c: A tracked-set partition with a rest complement ("Put all
         // <filter> revealed this way into your hand and the rest into your
         // graveyard" — Winding Way). The primary mass move sends the chosen
@@ -12708,6 +12748,26 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
             target,
             multi_target,
         }) => lower_put_counter_list(entries, target, multi_target),
+        // CR 601.2c + CR 122.1: The targeted fixed-count counterpart of the
+        // untargeted exact-selection grammar retains its announced target
+        // cardinality through lowering.
+        ImperativeFamilyAst::ZoneCounter(
+            ast @ ZoneCounterImperativeAst::RemoveCounter {
+                exact_selection: None,
+                multi_target: Some(_),
+                ..
+            },
+        ) => {
+            let multi_target = match &ast {
+                ZoneCounterImperativeAst::RemoveCounter { multi_target, .. } => {
+                    multi_target.clone()
+                }
+                _ => None,
+            };
+            let mut clause = parsed_clause(lower_zone_counter_ast(ast));
+            clause.multi_target = multi_target;
+            clause
+        }
         // CR 115.1c + CR 601.2c: "Choose target X and target Y" — two
         // independent target slots. Lowered to a primary `Effect::TargetOnly`
         // (slot A) with a chained `TargetOnly` sub_ability (slot B). At
@@ -13852,6 +13912,8 @@ pub(super) fn parse_zone_counter_ast(
                     counter_type,
                     count,
                     target,
+                    exact_selection: remove_counter_exact_selection_count(lower),
+                    multi_target: remove_counter_exact_target_multi_target(lower),
                 }),
                 _ => None,
             };
@@ -14041,6 +14103,8 @@ pub(super) fn lower_zone_counter_ast(ast: ZoneCounterImperativeAst) -> Effect {
             counter_type,
             count,
             target,
+            exact_selection: _,
+            multi_target: _,
         } => Effect::RemoveCounter {
             counter_type,
             count,
@@ -16048,6 +16112,7 @@ mod tests {
                 counter_type: None,
                 count: QuantityExpr::Fixed { value: -1 },
                 target,
+                ..
             }) = result
             else {
                 panic!("{input}: expected anaphoric RemoveCounter (count -1), got {result:?}");
@@ -23310,5 +23375,59 @@ mod tests {
             ),
             "reach-guard: the printed assimilate phrase must produce the Assimilate node"
         );
+    }
+
+    /// SHAPE — CR 115.1d + CR 122.1: A fixed "each of two creatures" counter
+    /// removal is a resolution-time object selection, never two target slots
+    /// (and therefore never a player-target prompt).
+    #[test]
+    fn fixed_each_counter_removal_lowers_to_exact_tracked_set_selection() {
+        let text = "remove a +1/+1 counter from each of two creatures you control";
+        let ast = parse_imperative_family_ast(text, text, &mut ParseContext::default())
+            .expect("fixed untargeted counter-removal phrase must parse");
+        let clause = lower_imperative_family_ast(ast);
+        let Effect::ChooseObjectsIntoTrackedSet {
+            chooser,
+            filter,
+            min,
+            max,
+            cardinality,
+            eligibility,
+            ..
+        } = &clause.effect
+        else {
+            panic!(
+                "fixed each removal must lower to object selection: {:?}",
+                clause.effect
+            );
+        };
+        assert_eq!(*chooser, TargetFilter::Controller);
+        assert!(
+            matches!(filter, TargetFilter::Typed(_)),
+            "the selected objects must retain the creature filter, got {filter:?}"
+        );
+        assert_eq!(*min, 2);
+        assert_eq!(*max, Some(2));
+        assert_eq!(
+            *cardinality,
+            Some(ObjectSelectionCardinality::Exactly { count: 2 })
+        );
+        assert_eq!(
+            eligibility,
+            &Some(ObjectSelectionEligibility::RemovableCounter {
+                counter_type: Some(crate::types::counter::CounterType::Plus1Plus1),
+                count: QuantityExpr::Fixed { value: 1 },
+            })
+        );
+        let removal = clause
+            .sub_ability
+            .expect("selection must continue into the counter removal");
+        assert!(matches!(
+            *removal.effect,
+            Effect::RemoveCounter {
+                target: TargetFilter::TrackedSet { .. },
+                ..
+            }
+        ));
     }
 }

--- a/crates/engine/src/parser/oracle_effect/imperative.rs
+++ b/crates/engine/src/parser/oracle_effect/imperative.rs
@@ -12599,10 +12599,7 @@ pub(super) fn lower_imperative_family_ast(ast: ImperativeFamilyAst) -> ParsedEff
                 cardinality: Some(ObjectSelectionCardinality::Exactly {
                     count: selection_count,
                 }),
-                eligibility: Some(ObjectSelectionEligibility::RemovableCounter {
-                    counter_type,
-                    count,
-                }),
+                eligibility: Some(ObjectSelectionEligibility::RemovableCounter { counter_type }),
             });
             clause.sub_ability = Some(Box::new(removal));
             clause
@@ -23416,7 +23413,6 @@ mod tests {
             eligibility,
             &Some(ObjectSelectionEligibility::RemovableCounter {
                 counter_type: Some(crate::types::counter::CounterType::Plus1Plus1),
-                count: QuantityExpr::Fixed { value: 1 },
             })
         );
         let removal = clause

--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -8188,6 +8188,8 @@ fn try_parse_choose_and_pay_per_object(
         filter,
         min,
         max,
+        cardinality: None,
+        eligibility: None,
     });
     clause.sub_ability = Some(Box::new(pay_ability));
     // CR 603.4: The "that player may" modal makes the whole clause optional —
@@ -14987,6 +14989,8 @@ fn parse_choose_survivors_destroy_rest_ir(
                 filter,
                 min: 0,
                 max: Some(max),
+                cardinality: None,
+                eligibility: None,
             }),
             Some(match connector {
                 DestroyRestConnector::Then => ClauseBoundary::Then,
@@ -30995,6 +30999,8 @@ fn maybe_convert_choose_head_into_tracked_set(def: &mut AbilityDefinition) {
         filter,
         min,
         max,
+        cardinality: None,
+        eligibility: None,
     };
     def.multi_target = None;
 }
@@ -31607,6 +31613,8 @@ fn parse_exile_pile_shuffle_cloak_ir(
                 filter,
                 min: 0,
                 max: None,
+                cardinality: None,
+                eligibility: None,
             }),
             Some(ClauseBoundary::Comma),
             ClauseDisposition::Emit {

--- a/crates/engine/src/parser/oracle_effect/tests.rs
+++ b/crates/engine/src/parser/oracle_effect/tests.rs
@@ -54149,6 +54149,7 @@ fn expose_the_culprit_mode2_lowers_to_choose_shuffle_cloak_chain() {
         filter,
         min,
         max,
+        ..
     } = &*head.effect
     else {
         panic!(
@@ -54217,6 +54218,7 @@ fn duneblast_lowers_choose_survivor_then_destroy_rest() {
         filter,
         min,
         max,
+        ..
     } = def.effect.as_ref()
     else {
         panic!("expected tracked-set survivor choice, got {:?}", def.effect);
@@ -54258,6 +54260,7 @@ fn mount_doom_lowers_choose_two_then_destroy_rest() {
         filter,
         min,
         max,
+        ..
     } = def.effect.as_ref()
     else {
         panic!("expected tracked-set survivor choice, got {:?}", def.effect);

--- a/crates/engine/src/parser/oracle_ir/ast.rs
+++ b/crates/engine/src/parser/oracle_ir/ast.rs
@@ -1831,6 +1831,13 @@ pub(crate) enum ZoneCounterImperativeAst {
         counter_type: Option<CounterType>,
         count: QuantityExpr,
         target: TargetFilter,
+        /// CR 115.1d + CR 122.1: A fixed `each of N <permanents>` phrase is
+        /// an untargeted resolution-time selection, not N target slots.
+        exact_selection: Option<u32>,
+        /// CR 601.2c: A fixed "each of N target <objects>" phrase keeps its
+        /// announced target cardinality instead of becoming an untargeted
+        /// resolution-time selection.
+        multi_target: Option<MultiTargetSpec>,
     },
     /// CR 122.1 + CR 608.2d (Clockspinning sentence 2): "Remove that counter ...
     /// or put another of those counters on it." The single target object is

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -69,10 +69,7 @@ pub enum ObjectSelectionCardinality {
 /// be selected for a counter-removal instruction.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ObjectSelectionEligibility {
-    RemovableCounter {
-        counter_type: Option<CounterType>,
-        count: QuantityExpr,
-    },
+    RemovableCounter { counter_type: Option<CounterType> },
 }
 
 #[cfg(test)]

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -57,7 +57,8 @@ pub enum Chooser {
     OwningPlayer,
 }
 
-/// CR 608.2c: A selection cardinality that must remain exact at resolution.
+/// CR 608.2d: Resolution-time choice cardinality.
+///
 /// Unlike the legacy `min`/`max` range, an exact selection is infeasible when
 /// fewer eligible objects exist and is therefore suitable for optional actions.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
@@ -65,7 +66,7 @@ pub enum ObjectSelectionCardinality {
     Exactly { count: u32 },
 }
 
-/// CR 122.1 + CR 101.2: Additional eligibility required before an object may
+/// CR 608.2d + CR 101.2: Additional eligibility required before an object may
 /// be selected for a counter-removal instruction.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 pub enum ObjectSelectionEligibility {

--- a/crates/engine/src/types/ability.rs
+++ b/crates/engine/src/types/ability.rs
@@ -57,6 +57,24 @@ pub enum Chooser {
     OwningPlayer,
 }
 
+/// CR 608.2c: A selection cardinality that must remain exact at resolution.
+/// Unlike the legacy `min`/`max` range, an exact selection is infeasible when
+/// fewer eligible objects exist and is therefore suitable for optional actions.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+pub enum ObjectSelectionCardinality {
+    Exactly { count: u32 },
+}
+
+/// CR 122.1 + CR 101.2: Additional eligibility required before an object may
+/// be selected for a counter-removal instruction.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub enum ObjectSelectionEligibility {
+    RemovableCounter {
+        counter_type: Option<CounterType>,
+        count: QuantityExpr,
+    },
+}
+
 #[cfg(test)]
 mod trigger_occurrence_tests {
     use super::*;
@@ -16219,6 +16237,14 @@ pub enum Effect {
         min: u32,
         /// Maximum number of objects selectable (`None` = "any number").
         max: Option<u32>,
+        /// An exact-cardinality selection. `None` preserves legacy min/max
+        /// semantics and its serialized shape.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        cardinality: Option<ObjectSelectionCardinality>,
+        /// Extra resolution-time eligibility beyond the printed object filter.
+        /// `None` preserves legacy selection behavior and wire format.
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        eligibility: Option<ObjectSelectionEligibility>,
     },
     /// CR 101.4 + CR 701.21a: Each player chooses one permanent per type category
     /// from among the permanents they control, then sacrifices the rest.

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5270,7 +5270,7 @@ pub struct PendingCounterMoveQueue {
 /// drained one `(counter_type, count)` at a time by
 /// `effects::counters::drain_pending_counter_removals`, which re-parks the queue
 /// when a per-removal replacement surfaces a `ReplacementChoice` mid-batch. When
-/// the queue empties, `total` is stamped into `last_effect_count` so a downstream
+/// the queue empties, `applied_total` is stamped into `last_effect_count` so a downstream
 /// "create that many" / "add that much" rider (Tetravus, storage lands) reading
 /// `QuantityRef::EventContextAmount` picks up the count removed.
 ///
@@ -5283,6 +5283,15 @@ pub struct PendingCounterRemoval {
     pub count: u32,
 }
 
+/// A removal awaiting its replacement-pipeline result. The pre-removal count
+/// lets the queue record the actual clamped or replacement-modified removal
+/// when a `ReplacementChoice` resumes the parked queue.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingCounterRemovalInFlight {
+    pub removal: PendingCounterRemoval,
+    pub counter_count_before: u32,
+}
+
 #[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct PendingCounterRemovalQueue {
     /// Remaining per-object counter removals.
@@ -5291,9 +5300,15 @@ pub struct PendingCounterRemovalQueue {
     pub effect_kind: EffectKind,
     /// Ability source object for the terminating `EffectResolved` event.
     pub source_ability_id: ObjectId,
-    /// Total counters requested across all entries; stamped into
-    /// `last_effect_count` when the queue empties.
+    /// Total counters requested across all entries. Retained for diagnostics and
+    /// legacy wire compatibility; use `applied_total` for effect result context.
     pub total: u32,
+    /// Counters actually removed so far, after clamping and replacements.
+    #[serde(default, skip_serializing_if = "is_zero_u32")]
+    pub applied_total: u32,
+    /// A removal whose replacement pipeline has not settled yet.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub in_flight: Option<PendingCounterRemovalInFlight>,
 }
 
 #[derive(Deserialize)]
@@ -5304,6 +5319,10 @@ struct PendingCounterRemovalQueueWire {
     effect_kind: EffectKind,
     source_ability_id: ObjectId,
     total: u32,
+    #[serde(default)]
+    applied_total: u32,
+    #[serde(default)]
+    in_flight: Option<PendingCounterRemovalInFlight>,
 }
 
 #[derive(Deserialize)]
@@ -5341,6 +5360,8 @@ impl<'de> Deserialize<'de> for PendingCounterRemovalQueue {
             effect_kind: wire.effect_kind,
             source_ability_id: wire.source_ability_id,
             total: wire.total,
+            applied_total: wire.applied_total,
+            in_flight: wire.in_flight,
         })
     }
 }
@@ -26983,6 +27004,8 @@ mod tests {
             effect_kind: EffectKind::RemoveCounter,
             source_ability_id: ObjectId(18),
             total: 2,
+            applied_total: 0,
+            in_flight: None,
         })
         .expect("current counter-removal queue serializes");
         legacy_wire["source_id"] = serde_json::to_value(source_id).expect("source ID serializes");
@@ -27002,6 +27025,14 @@ mod tests {
                 count: 2,
             }],
             "legacy entries inherit their queue's single source ID"
+        );
+        assert_eq!(
+            restored.applied_total, 0,
+            "queues persisted before applied-count tracking start at zero"
+        );
+        assert!(
+            restored.in_flight.is_none(),
+            "legacy queues never carry a replacement-pipeline in-flight removal"
         );
     }
 

--- a/crates/engine/src/types/game_state.rs
+++ b/crates/engine/src/types/game_state.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 
 use rand::SeedableRng;
 use rand_chacha::ChaCha20Rng;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
 use super::ability::{
     default_target_filter_permanent, legacy_trigger_entry_list,
@@ -5277,11 +5277,16 @@ pub struct PendingCounterMoveQueue {
 /// Serialized in the `CounterRemovals` frame so a mid-batch re-park survives the
 /// server→client→server state round-trip a `ReplacementChoice` requires.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PendingCounterRemoval {
+    pub object_id: ObjectId,
+    pub counter_type: CounterType,
+    pub count: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
 pub struct PendingCounterRemovalQueue {
-    /// Remaining per-type removals to apply to `source_id`.
-    pub remaining: Vec<(CounterType, u32)>,
-    /// The object counters are removed from (the effect's single source).
-    pub source_id: ObjectId,
+    /// Remaining per-object counter removals.
+    pub remaining: Vec<PendingCounterRemoval>,
     /// Effect kind for the terminating `EffectResolved` event.
     pub effect_kind: EffectKind,
     /// Ability source object for the terminating `EffectResolved` event.
@@ -5289,6 +5294,55 @@ pub struct PendingCounterRemovalQueue {
     /// Total counters requested across all entries; stamped into
     /// `last_effect_count` when the queue empties.
     pub total: u32,
+}
+
+#[derive(Deserialize)]
+struct PendingCounterRemovalQueueWire {
+    remaining: Vec<PendingCounterRemovalWire>,
+    #[serde(default)]
+    source_id: Option<ObjectId>,
+    effect_kind: EffectKind,
+    source_ability_id: ObjectId,
+    total: u32,
+}
+
+#[derive(Deserialize)]
+#[serde(untagged)]
+enum PendingCounterRemovalWire {
+    Current(PendingCounterRemoval),
+    Legacy((CounterType, u32)),
+}
+
+/// CR 122.1 + CR 614.1: Accept the legacy single-source queue on the wire
+/// while persisting new multi-object removals with their object per entry.
+impl<'de> Deserialize<'de> for PendingCounterRemovalQueue {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let wire = PendingCounterRemovalQueueWire::deserialize(deserializer)?;
+        let remaining = wire
+            .remaining
+            .into_iter()
+            .map(|entry| match entry {
+                PendingCounterRemovalWire::Current(entry) => Ok(entry),
+                PendingCounterRemovalWire::Legacy((counter_type, count)) => wire
+                    .source_id
+                    .map(|object_id| PendingCounterRemoval {
+                        object_id,
+                        counter_type,
+                        count,
+                    })
+                    .ok_or_else(|| serde::de::Error::missing_field("source_id")),
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self {
+            remaining,
+            effect_kind: wire.effect_kind,
+            source_ability_id: wire.source_ability_id,
+            total: wire.total,
+        })
+    }
 }
 
 /// CR 603.10a + CR 616.1: The not-yet-delivered tail of a simultaneous
@@ -26918,6 +26972,36 @@ mod tests {
             persisted["unrelated"],
             serde_json::json!({ "type": "Untap" }),
             "only serialized Effect payloads are migrated"
+        );
+    }
+
+    #[test]
+    fn pending_counter_removal_queue_migrates_legacy_single_source_entries() {
+        let source_id = ObjectId(17);
+        let mut legacy_wire = serde_json::to_value(PendingCounterRemovalQueue {
+            remaining: Vec::new(),
+            effect_kind: EffectKind::RemoveCounter,
+            source_ability_id: ObjectId(18),
+            total: 2,
+        })
+        .expect("current counter-removal queue serializes");
+        legacy_wire["source_id"] = serde_json::to_value(source_id).expect("source ID serializes");
+        legacy_wire["remaining"] = serde_json::json!([[
+            serde_json::to_value(CounterType::Plus1Plus1).expect("counter type serializes"),
+            2
+        ]]);
+
+        let restored: PendingCounterRemovalQueue = serde_json::from_value(legacy_wire)
+            .expect("legacy single-source counter-removal queue migrates");
+
+        assert_eq!(
+            restored.remaining,
+            vec![PendingCounterRemoval {
+                object_id: source_id,
+                counter_type: CounterType::Plus1Plus1,
+                count: 2,
+            }],
+            "legacy entries inherit their queue's single source ID"
         );
     }
 

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -4052,7 +4052,34 @@ fn migrate_legacy_counter_removal_replacement_pause(state: &mut GameState) {
                     count,
                     ..
                 } => Some((*object_id, counter_type.clone(), *count)),
-                _ => None,
+                ProposedEvent::ZoneChange { .. }
+                | ProposedEvent::Damage { .. }
+                | ProposedEvent::Draw { .. }
+                | ProposedEvent::SearchFound { .. }
+                | ProposedEvent::Scry { .. }
+                | ProposedEvent::Mill { .. }
+                | ProposedEvent::CoinFlip { .. }
+                | ProposedEvent::Explore { .. }
+                | ProposedEvent::Connive { .. }
+                | ProposedEvent::Proliferate { .. }
+                | ProposedEvent::LifeGain { .. }
+                | ProposedEvent::LifeLoss { .. }
+                | ProposedEvent::AddCounter { .. }
+                | ProposedEvent::MoveCounter { .. }
+                | ProposedEvent::CreateToken { .. }
+                | ProposedEvent::TokenEntry { .. }
+                | ProposedEvent::Discard { .. }
+                | ProposedEvent::Tap { .. }
+                | ProposedEvent::Untap { .. }
+                | ProposedEvent::TurnFaceUp { .. }
+                | ProposedEvent::Destroy { .. }
+                | ProposedEvent::Sacrifice { .. }
+                | ProposedEvent::BeginTurn { .. }
+                | ProposedEvent::BeginPhase { .. }
+                | ProposedEvent::ProduceMana { .. }
+                | ProposedEvent::EmptyManaPool { .. }
+                | ProposedEvent::Planeswalk { .. }
+                | ProposedEvent::Attach { .. } => None,
             })
     else {
         return;

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -14,21 +14,25 @@ use serde_json::{Map, Value};
 pub use frame_vec::ChildStackDepth;
 use frame_vec::{FrameSlot, FrameVec};
 
-use crate::types::ability::{AbilityDefinition, DiscardedCardResult, ResolvedAbility, TargetRef};
+use crate::types::ability::{
+    AbilityDefinition, DiscardedCardResult, EffectKind, ResolvedAbility, TargetRef,
+};
 use crate::types::events::GameEvent;
 use crate::types::game_state::{
     CostResume, DrainStatus, DrawSequenceStack, GameState, GameStateDecode, GameStateDecodeMode,
     PayCostKind, PendingBatchDeliveries, PendingChangeZoneIteration, PendingChooseOneOf,
     PendingConniveReentry, PendingContinuation, PendingCopyTokenResolution,
-    PendingCounterAdditionQueue, PendingCounterMoveQueue, PendingCounterRemovalQueue,
-    PendingDebugCardEntries, PendingEachPlayerCopyChosen, PendingLifeTotalAssignment,
-    PendingMultiDraw, PendingPerCategoryZoneChoice, PendingPerPlayerZoneChoice,
-    PendingRepeatIteration, PendingRepeatUntil, PendingSpellResolution, PendingVoteBallotIteration,
-    PostReplacementDrain, PostReplacementDrainDispatch, PostReplacementDrainStack,
-    PostReplacementFrameId, ResidentDrainPolicy, ResolvingTriggerContext, WaitingFor,
+    PendingCounterAdditionQueue, PendingCounterMoveQueue, PendingCounterRemoval,
+    PendingCounterRemovalInFlight, PendingCounterRemovalQueue, PendingDebugCardEntries,
+    PendingEachPlayerCopyChosen, PendingLifeTotalAssignment, PendingMultiDraw,
+    PendingPerCategoryZoneChoice, PendingPerPlayerZoneChoice, PendingRepeatIteration,
+    PendingRepeatUntil, PendingSpellResolution, PendingVoteBallotIteration, PostReplacementDrain,
+    PostReplacementDrainDispatch, PostReplacementDrainStack, PostReplacementFrameId,
+    ResidentDrainPolicy, ResolvingTriggerContext, WaitingFor,
 };
 use crate::types::identifiers::{DiscardFrameId, ObjectId};
 use crate::types::player::PlayerId;
+use crate::types::proposed_event::ProposedEvent;
 
 /// The complete shipped draw authority carried by one `MultiDraw` frame.
 ///
@@ -3863,6 +3867,7 @@ impl ResolutionStateWire {
                 if let Some(frame) = legacy_counter_removals.into_frame() {
                     legacy.push_counter_removals(frame);
                 }
+                migrate_legacy_counter_removal_replacement_pause(&mut legacy);
                 // A per-player copy walk parks beneath its inner token-copy
                 // work, and CopyToken in turn parks beneath an ETB-counter
                 // child. Rebuild that exact outer-to-inner order from the v1
@@ -4024,6 +4029,60 @@ fn normalize_legacy_completed_resolution_carrier(state: &mut GameState) {
         state.resolving_trigger_firing = None;
         state.resolution_source_relatch = None;
     }
+}
+
+/// CR 122.1 + CR 614.1: v1 counter-removal queues removed the current tuple
+/// before a replacement choice but did not serialize it separately. Rebuild
+/// that unsettled removal from the parked proposed event so its actual result
+/// contributes to the resumed queue's `applied_total`.
+fn migrate_legacy_counter_removal_replacement_pause(state: &mut GameState) {
+    let Some((object_id, counter_type, count)) =
+        state
+            .pending_replacement
+            .as_ref()
+            .and_then(|pending| match &pending.proposed {
+                ProposedEvent::RemoveCounter {
+                    object_id,
+                    counter_type,
+                    count,
+                    ..
+                } => Some((*object_id, counter_type.clone(), *count)),
+                _ => None,
+            })
+    else {
+        return;
+    };
+    if !matches!(state.waiting_for, WaitingFor::ReplacementChoice { .. }) {
+        return;
+    }
+
+    let counter_count_before = state
+        .objects
+        .get(&object_id)
+        .and_then(|object| object.counters.get(&counter_type))
+        .copied()
+        .unwrap_or(0);
+    let Some(queue) = state.active_counter_removals_mut() else {
+        return;
+    };
+    if queue.effect_kind != EffectKind::RemoveCounter
+        || queue.in_flight.is_some()
+        || !queue
+            .remaining
+            .iter()
+            .all(|removal| removal.object_id == object_id)
+    {
+        return;
+    }
+
+    queue.in_flight = Some(PendingCounterRemovalInFlight {
+        removal: PendingCounterRemoval {
+            object_id,
+            counter_type,
+            count,
+        },
+        counter_count_before,
+    });
 }
 
 impl Serialize for ResolutionStateWire {

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -6608,7 +6608,6 @@ mod tests {
             counter_removals,
             PendingCounterRemovalQueue {
                 remaining: Vec::new(),
-                source_id: ObjectId(115),
                 effect_kind: EffectKind::RemoveCounter,
                 source_ability_id: ObjectId(115),
                 total: 0,

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -4034,7 +4034,12 @@ fn normalize_legacy_completed_resolution_carrier(state: &mut GameState) {
 /// CR 122.1 + CR 614.1: v1 counter-removal queues removed the current tuple
 /// before a replacement choice but did not serialize it separately. Rebuild
 /// that unsettled removal from the parked proposed event so its actual result
-/// contributes to the resumed queue's `applied_total`.
+/// contributes to the resumed queue's `applied_total`. v1 only retained the
+/// queue's original requested total and unconsumed tail, so it cannot recover
+/// a replacement-modified actual count for a fully settled prefix. Preserve
+/// that format's requested-count semantics by seeding the prefix as
+/// `total - remaining requested - current requested`; the reconstructed current
+/// removal still contributes its measured actual result after it resumes.
 fn migrate_legacy_counter_removal_replacement_pause(state: &mut GameState) {
     let Some((object_id, counter_type, count)) =
         state
@@ -4075,6 +4080,18 @@ fn migrate_legacy_counter_removal_replacement_pause(state: &mut GameState) {
         return;
     }
 
+    let remaining_requested = queue
+        .remaining
+        .iter()
+        .map(|removal| removal.count)
+        .sum::<u32>();
+    // v1 removed the current tuple from `remaining` before it surfaced the
+    // replacement choice. Its settled prefix has no actual-count record, so
+    // retain the legacy requested-count accounting for that unrecoverable
+    // prefix while the in-flight tuple below remains actual-count based.
+    queue.applied_total = queue
+        .total
+        .saturating_sub(remaining_requested.saturating_add(count));
     queue.in_flight = Some(PendingCounterRemovalInFlight {
         removal: PendingCounterRemoval {
             object_id,

--- a/crates/engine/src/types/resolution.rs
+++ b/crates/engine/src/types/resolution.rs
@@ -6611,6 +6611,8 @@ mod tests {
                 effect_kind: EffectKind::RemoveCounter,
                 source_ability_id: ObjectId(115),
                 total: 0,
+                applied_total: 0,
+                in_flight: None,
             },
         ));
         assert!(counter_removals.active_counter_removals().is_none());

--- a/crates/engine/tests/integration/dyadrine_counter_selection.rs
+++ b/crates/engine/tests/integration/dyadrine_counter_selection.rs
@@ -1,0 +1,137 @@
+//! Dyadrine, Synthesis Amalgam — attack-triggered non-targeted counter choice.
+//!
+//! CR 508.2 + CR 608.2c: declaring an attack puts the trigger on the stack;
+//! accepting its `may` instruction then chooses exactly two eligible creatures
+//! during resolution, removes counters from both, draws, and creates the Robot.
+
+use engine::game::scenario::{GameScenario, P0, P1};
+use engine::types::ability::TargetRef;
+use engine::types::actions::GameAction;
+use engine::types::counter::CounterType;
+use engine::types::game_state::WaitingFor;
+use engine::types::phase::Phase;
+use engine::types::zones::Zone;
+
+use super::rules::AttackTarget;
+
+const DYADRINE_ORACLE: &str = "Whenever you attack, you may remove a +1/+1 counter from each of two creatures you control. If you do, draw a card and create a 2/2 colorless Robot artifact creature token.";
+
+#[test]
+fn dyadrine_attack_acceptance_selects_creatures_then_removes_draws_and_creates_robot() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    let dyadrine = scenario
+        .add_creature_from_oracle(P0, "Dyadrine, Synthesis Amalgam", 2, 2, DYADRINE_ORACLE)
+        .id();
+    let first = {
+        let mut builder = scenario.add_creature(P0, "First Counter Bearer", 1, 1);
+        builder.with_plus_counters(1);
+        builder.id()
+    };
+    let second = {
+        let mut builder = scenario.add_creature(P0, "Second Counter Bearer", 1, 1);
+        builder.with_plus_counters(1);
+        builder.id()
+    };
+    scenario.with_library_top(P0, &["Dyadrine Draw"]);
+    let mut runner = scenario.build();
+    let hand_before = runner.state().players[0].hand.len();
+
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(dyadrine, AttackTarget::Player(P1))])
+        .expect("Dyadrine attacks");
+
+    for _ in 0..12 {
+        match runner.state().waiting_for.clone() {
+            WaitingFor::OrderTriggers { triggers, .. } => {
+                runner
+                    .act(GameAction::OrderTriggers {
+                        order: (0..triggers.len()).collect(),
+                    })
+                    .expect("order Dyadrine's attack trigger");
+            }
+            WaitingFor::OptionalEffectChoice { player, .. } => {
+                assert_eq!(player, P0, "the trigger controller chooses the may action");
+                break;
+            }
+            WaitingFor::Priority { .. } => {
+                runner.pass_both_players();
+            }
+            other => panic!("unexpected state before Dyadrine's may choice: {other:?}"),
+        }
+    }
+    assert!(
+        matches!(
+            runner.state().waiting_for,
+            WaitingFor::OptionalEffectChoice { .. }
+        ),
+        "Dyadrine's counter-removal instruction must be offered as a may choice"
+    );
+
+    runner
+        .act(GameAction::DecideOptionalEffect { accept: true })
+        .expect("accept Dyadrine's counter-removal instruction");
+    let WaitingFor::ChooseObjectsSelection {
+        eligible, min, max, ..
+    } = runner.state().waiting_for.clone()
+    else {
+        panic!(
+            "accepting Dyadrine must prompt a non-targeted creature selection, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(
+        (min, max),
+        (2, Some(2)),
+        "must choose exactly two creatures"
+    );
+    assert_eq!(
+        eligible,
+        vec![TargetRef::Object(first), TargetRef::Object(second)],
+        "only creatures carrying removable +1/+1 counters are selectable"
+    );
+
+    runner
+        .act(GameAction::SelectTargets {
+            targets: vec![TargetRef::Object(first), TargetRef::Object(second)],
+        })
+        .expect("select the two counter-bearing creatures");
+    runner.advance_until_stack_empty();
+
+    for id in [first, second] {
+        assert_eq!(
+            runner.state().objects[&id]
+                .counters
+                .get(&CounterType::Plus1Plus1)
+                .copied()
+                .unwrap_or_default(),
+            0,
+            "each selected creature loses its +1/+1 counter"
+        );
+    }
+    assert_eq!(
+        runner.state().players[0].hand.len(),
+        hand_before + 1,
+        "the accepted and completed removal draws one card"
+    );
+    assert_eq!(
+        runner
+            .state()
+            .objects
+            .values()
+            .filter(|object| {
+                object.is_token
+                    && object.zone == Zone::Battlefield
+                    && object.controller == P0
+                    && object
+                        .card_types
+                        .subtypes
+                        .iter()
+                        .any(|subtype| subtype == "Robot")
+            })
+            .count(),
+        1,
+        "the completed removal creates one Robot token"
+    );
+}

--- a/crates/engine/tests/integration/dyadrine_counter_selection.rs
+++ b/crates/engine/tests/integration/dyadrine_counter_selection.rs
@@ -33,6 +33,11 @@ fn dyadrine_attack_acceptance_selects_creatures_then_removes_draws_and_creates_r
         builder.with_plus_counters(1);
         builder.id()
     };
+    let third = {
+        let mut builder = scenario.add_creature(P0, "Third Counter Bearer", 1, 1);
+        builder.with_plus_counters(1);
+        builder.id()
+    };
     scenario.with_library_top(P0, &["Dyadrine Draw"]);
     let mut runner = scenario.build();
     let hand_before = runner.state().players[0].hand.len();
@@ -88,8 +93,21 @@ fn dyadrine_attack_acceptance_selects_creatures_then_removes_draws_and_creates_r
     );
     assert_eq!(
         eligible,
-        vec![TargetRef::Object(first), TargetRef::Object(second)],
+        vec![
+            TargetRef::Object(first),
+            TargetRef::Object(second),
+            TargetRef::Object(third),
+        ],
         "only creatures carrying removable +1/+1 counters are selectable"
+    );
+
+    assert!(
+        runner
+            .act(GameAction::SelectTargets {
+                targets: vec![TargetRef::Object(first)],
+            })
+            .is_err(),
+        "an exact-two selection must reject a one-creature submission"
     );
 
     runner
@@ -110,6 +128,15 @@ fn dyadrine_attack_acceptance_selects_creatures_then_removes_draws_and_creates_r
             "each selected creature loses its +1/+1 counter"
         );
     }
+    assert_eq!(
+        runner.state().objects[&third]
+            .counters
+            .get(&CounterType::Plus1Plus1)
+            .copied()
+            .unwrap_or_default(),
+        1,
+        "the eligible but unselected third creature retains its counter"
+    );
     assert_eq!(
         runner.state().players[0].hand.len(),
         hand_before + 1,

--- a/crates/engine/tests/integration/main.rs
+++ b/crates/engine/tests/integration/main.rs
@@ -229,6 +229,7 @@ mod dream_salvage_target_opponent_discards;
 mod dredgers_insight_mill_from_among;
 mod druid_of_purification_destroy_chosen_4780;
 mod duskmantle_seer_each_player_reveal;
+mod dyadrine_counter_selection;
 mod elemental_spectacle_regression;
 mod elusive_otter_repro;
 mod embiggen_typeline_pump;

--- a/crates/engine/tests/integration/mount_doom_destroy_rest.rs
+++ b/crates/engine/tests/integration/mount_doom_destroy_rest.rs
@@ -176,6 +176,8 @@ fn choose_objects_runtime_rejects_fewer_than_required_minimum() {
             filter: TargetFilter::Typed(TypedFilter::creature()),
             min: 1,
             max: Some(2),
+            cardinality: None,
+            eligibility: None,
         },
     );
     let host = {


### PR DESCRIPTION
- **fix(engine): resolve Dyadrine counter selection**
- **fix(engine): preserve exact counter selection semantics**


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added support for exact-count counter-removal effects, including phrases such as “remove a counter from each of two creatures.”
  - Selections can now require exactly a specified number of eligible objects and identify objects with removable counters.

- **Bug Fixes**
  - Corrected targeted counter-removal parsing so announced target counts are preserved.
  - Optional exact selections now decline automatically when requirements cannot be met.
  - Counter removals resolve correctly across multiple selected objects, including replacement effects.
  - Preserved counter-removal progress when resuming saved games or paused replacement choices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->