### PR TITLE
fix(parser): bind "it" to the damaged creature in combat-damage untap triggers

### DIFF
--- a/crates/engine/src/parser/oracle_effect/mod.rs
+++ b/crates/engine/src/parser/oracle_effect/mod.rs
@@ -34392,7 +34392,18 @@ pub(crate) fn parse_effect_chain_ir(
             .find_map(|clause| nearest_dig_rest_zone_in_clause(&clause.parsed));
         let mut chunk_ctx = ParseContext {
             subject: chunk_subject,
-            object_pronoun_ref: prior_typed_referent.then_some(TargetFilter::ParentTarget),
+            // CR 608.2c: a bare "it" in this chunk binds to `ParentTarget` when
+            // an earlier in-body clause chose a typed target (`prior_typed_referent`),
+            // OR when the enclosing trigger's CONDITION already established a
+            // `ParentTarget` object antecedent (a "deals combat damage to a
+            // creature" / "blocks a creature" trigger — Orochi Ranger). The
+            // trigger-level `object_pronoun_ref` is a whole-body property, so it
+            // must reach every chunk, not just the first; only the `ParentTarget`
+            // form is propagated here so an unrelated `TriggeringSource`
+            // spell-cast antecedent keeps its established per-chunk scoping.
+            object_pronoun_ref: (prior_typed_referent
+                || matches!(ctx.object_pronoun_ref, Some(TargetFilter::ParentTarget)))
+            .then_some(TargetFilter::ParentTarget),
             card_name: ctx.card_name.clone(),
             // CR 707.9a + CR 603.1: propagate the trigger index from the parent
             // ctx — `current_trigger_index` is a property of the whole trigger

--- a/crates/engine/src/parser/oracle_trigger.rs
+++ b/crates/engine/src/parser/oracle_trigger.rs
@@ -10483,6 +10483,25 @@ fn trigger_object_pronoun_ref_for_condition(condition_text: &str) -> Option<Targ
         return Some(TargetFilter::TriggeringSource);
     }
 
+    // CR 608.2c + CR 510.1c / CR 509.1h: a "deals [combat] damage to a creature"
+    // or "blocks a creature" trigger introduces that creature — the damage
+    // recipient / blocked creature, carried by the trigger as its
+    // `ParentTarget` (see the `valid_target` the condition parse assigns) — as
+    // the effect body's untargeted object antecedent. A bare "it" that follows
+    // the "that creature" anaphor in the same body co-refers with it: Orochi
+    // Ranger, the Kashi-Tribe / Matsu-Tribe cycle, Frostwalk Bastion — "tap
+    // that creature and it doesn't untap during its controller's next untap
+    // step." Without this the bare "it" fell through `resolve_it_pronoun` to
+    // the self-watching trigger source, so the CantUntap static locked the
+    // *source* — a silent no-op once it has left combat or died.
+    let introduces_damaged_or_blocked_creature =
+        scan_contains(after_keyword, "deals combat damage to a creature")
+            || scan_contains(after_keyword, "deals damage to a creature")
+            || scan_contains(after_keyword, "blocks a creature");
+    if introduces_damaged_or_blocked_creature {
+        return Some(TargetFilter::ParentTarget);
+    }
+
     None
 }
 

--- a/crates/engine/src/parser/oracle_trigger_tests.rs
+++ b/crates/engine/src/parser/oracle_trigger_tests.rs
@@ -15015,6 +15015,54 @@ fn trigger_blocks_a_creature() {
 }
 
 #[test]
+fn trigger_combat_damage_tap_and_it_doesnt_untap_binds_parent_target() {
+    // CR 608.2c + CR 502.3: "Whenever this creature deals combat damage to a
+    // creature, tap that creature and it doesn't untap during its controller's
+    // next untap step." The bare "it" co-refers with "that creature" (the
+    // damaged creature = the trigger's `ParentTarget`), NOT the self-watching
+    // trigger source. Regression guard for Orochi Ranger / the Kashi-Tribe /
+    // Matsu-Tribe cycle / Frostwalk Bastion: before the fix the `CantUntap`
+    // static's `affected` was `SelfRef`, so the lock silently did nothing once
+    // the source left combat or died.
+    for (name, text) in [
+        (
+            "Orochi Ranger",
+            "Whenever this creature deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step.",
+        ),
+        (
+            "Queen of Ice",
+            "Whenever this creature deals combat damage to a creature, tap that creature. It doesn't untap during its controller's next untap step.",
+        ),
+    ] {
+        let def = parse_trigger_line(text, name);
+        assert_eq!(def.mode, TriggerMode::DamageDone, "{name}");
+
+        let mut cursor = def.execute.as_deref();
+        let mut affected = None;
+        while let Some(ability) = cursor {
+            if let Effect::GenericEffect {
+                static_abilities, ..
+            } = ability.effect.as_ref()
+            {
+                if let Some(static_def) = static_abilities
+                    .iter()
+                    .find(|s| s.mode == StaticMode::CantUntap)
+                {
+                    affected = static_def.affected.clone();
+                    break;
+                }
+            }
+            cursor = ability.sub_ability.as_deref();
+        }
+        assert_eq!(
+            affected,
+            Some(TargetFilter::ParentTarget),
+            "{name}: CantUntap static must lock the damaged creature (ParentTarget), got {affected:?}",
+        );
+    }
+}
+
+#[test]
 fn trigger_blocks_or_becomes_blocked() {
     // CR 509.1h + CR 509.3d: "blocks or becomes blocked" is a compound trigger —
     // the remainder must no longer be silently dropped into a plain `Blocks`.


### PR DESCRIPTION
## Summary

`Orochi Ranger` — *"Whenever this creature deals combat damage to a creature, tap that creature and it doesn't untap during its controller's next untap step."* — parsed the bare pronoun **"it"** as `SelfRef`, so the `CantUntap` static locked the trigger *source* instead of the damaged creature; once the source left combat or died, nothing kept the creature tapped. The damaged creature is introduced by the trigger *condition*, so `resolve_it_pronoun` had no antecedent and fell through to the self-watching source (CR 608.2c). The parser now seeds a `ParentTarget` object antecedent for *"deals \[combat\] damage to a creature"* / *"blocks a creature"* triggers and propagates it to every clause in the effect body.

## Files changed

- `crates/engine/src/parser/oracle_trigger.rs` — `trigger_object_pronoun_ref_for_condition` recognizes damage-to-creature / blocks-a-creature conditions and returns `ParentTarget`
- `crates/engine/src/parser/oracle_effect/mod.rs` — effect-chain chunk loop propagates a trigger-level `ParentTarget` `object_pronoun_ref` to all chunks, not just the first
- `crates/engine/src/parser/oracle_trigger_tests.rs` — regression test (`trigger_combat_damage_tap_and_it_doesnt_untap_binds_parent_target`) covering Orochi Ranger and Queen of Ice

## Track

Non-developer

## LLM

Model: claude-sonnet-5 (Claude Sonnet 5)
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — direct investigation from a user bug report, not an `/engine-implementer` run. The change is a scoped parser anaphor-resolution fix; it was validated by a full `card-data.json` regeneration diffed against unmodified `main` (see Claimed parse impact) plus the parser test suites below. Happy to re-run it through `/engine-implementer` if the maintainers want the pipeline artifacts.

## CR references

- `CR 608.2c` — resolve pronouns by reading the whole instruction ("apply the rules of English"); the "it" anaphor co-refers with "that creature" (touched in new comments)
- `CR 502.3` — effects can keep a permanent from untapping (new test comment)
- `CR 510.1c` / `CR 509.1h` — combat damage to a blocked/blocking creature; a creature becomes blocked (new comment, condition provenance)

No `CR XXX.Y` annotations on executable lines were added or changed — the fix is anaphor plumbing, not a new rule implementation.

## Verification

Tilt was not running in this environment, so the Tilt-owned `clippy` / `test-engine` resources were not exercised; the equivalents were run directly and are listed below. Maintainers should let CI run the canonical checks.

- `cargo fmt --all` — clean, no diff
- `cargo test -p phase-engine --lib parser::oracle_trigger::` — **1200 passed, 0 failed**
- `cargo test -p phase-engine --lib parser::oracle_effect::` — **3058 passed, 0 failed**
- `cargo test -p phase-engine --lib -- untap` — **229 passed, 0 failed** (includes `untap_it_anaphor_binds_to_trigger_subject_not_parent_target`, which still passes — the "enters tapped" / "attacks" anaphor classes are untouched)
- `cargo test -p phase-engine --lib -- snapshot` — **475 passed, 0 failed**
- `cargo test -p phase-engine --lib trigger_combat_damage_tap_and_it_doesnt_untap_binds_parent_target` — **1 passed** (new test)
- `cargo test -p phase-engine --test integration chandra_revolution_doesnt_untap` — **2 passed** (CantUntap `affected` binding)
- `cargo run --bin oracle-gen -- data/` full regeneration, diffed against a regeneration from unmodified `main` — **10 cards changed, all corrections, 0 regressions** (see Claimed parse impact). A pre-existing single-process stack overflow in `cargo test --test integration` reproduces identically on unmodified `main`; it is unrelated (the repo runs integration tests via `cargo nextest`).

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below. *(direct-run equivalents above; Tilt/CI not available in this environment)*
- [ ] Gate A output below is for the current committed head. *(not run — `/engine-implementer` not used)*
- [ ] Final review-impl below is clean for the current committed head. *(not run — `/engine-implementer` not used)*
- [x] Both anchors cite existing analogous code at the same seam.

## Gate A

Not run — `/engine-implementer` was not used for this change (see Implementation method). Direct verification for `head=bab0b1489040025abf39321404b1e50ff9ca2e9f base=f41ed842f9f48153818039d474749f54c9a327dd` is in the Verification section.

## Anchored on

- `crates/engine/src/parser/oracle_trigger.rs:10469` — `trigger_object_pronoun_ref_for_condition`'s existing spell-cast arm returns `TriggeringSource` for a condition-introduced object antecedent; the new arm follows the same shape for the damage/block-introduced creature
- `crates/engine/src/parser/oracle_effect/mod.rs:34395` — the existing `object_pronoun_ref: prior_typed_referent.then_some(TargetFilter::ParentTarget)` chunk-context seed; the change only widens the same `ParentTarget` seed to also fire when the trigger condition established the antecedent

## Final review-impl

Not run — see Implementation method. Self-review: the change is gated to trigger context via `trigger_object_pronoun_ref_for_condition` (only called from the trigger parse path) and to the `ParentTarget` form in the chunk loop, so a `TriggeringSource` spell-cast antecedent keeps its established per-chunk scoping. Full-corpus parse diff confirms the blast radius is exactly the 10 cards below.

## Claimed parse impact

10 cards, all corrections (bare "it" / modal "it" in the effect body was binding `SelfRef` and now binds the intended object):

- Orochi Ranger
- Queen of Ice
- Frostwalk Bastion
- Kashi-Tribe Elite
- Kashi-Tribe Reaver
- Kashi-Tribe Warriors
- Matsu-Tribe Birdstalker
- Matsu-Tribe Decoy
- Matsu-Tribe Sniper
- Jhoira's Timebug — latent sibling bug: *"remove a time counter from it"* / *"put another time counter on it"* in its modal `{T}` ability was also bound to `SelfRef`, now `ParentTarget` (the chosen permanent)

## Scope Expansion

None. Jhoira's Timebug is not a combat-damage trigger; it is caught by the chunk-loop propagation change (its `ChooseOneOf` branches now inherit the parent-target antecedent chosen by the head "Choose target permanent" clause) and the fix there is a strict correction.

## Validation Failures

None.

## CI Failures

None.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved parsing of creature combat-damage and blocking triggers.
  * Follow-up references such as “it” now correctly refer to the affected creature instead of the triggering creature when appropriate.
  * Corrected parsing for effects that apply to damaged creatures, including tap-and-lock abilities.

* **Tests**
  * Added regression coverage for combat-damage triggers and their follow-up effects.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->