### PR TITLE
fix(engine): route combat-damage skip triggers to the damaged player

### DIFF
--- a/crates/engine/src/game/effects/skip_next_step.rs
+++ b/crates/engine/src/game/effects/skip_next_step.rs
@@ -27,6 +27,19 @@ pub fn resolve(
 
     let player = match target {
         TargetFilter::Controller | TargetFilter::SelfRef => ability.controller,
+        // CR 603.7c + CR 510.2: "that player" on a triggered ability ("Whenever
+        // ~ deals combat damage to a player, that player skips their next combat
+        // phase" — Blinding Angel) is an event-context reference to the damaged
+        // player, not a chosen target, so `ability.targets` is empty. Resolve it
+        // from the triggering event, mirroring `additional_phase`'s
+        // `TriggeringPlayer` arm. Without this the skip fell through to
+        // `ability.controller`, so the Angel's own controller lost their combat
+        // phase while the damaged opponent was unaffected.
+        TargetFilter::TriggeringPlayer => state
+            .current_trigger_event
+            .as_ref()
+            .and_then(|event| crate::game::targeting::extract_player_from_event(event, state))
+            .unwrap_or(ability.controller),
         _ => {
             if let Some(TargetRef::Player(pid)) = ability.targets.first() {
                 *pid
@@ -217,6 +230,62 @@ mod tests {
         // Non-combat steps must not be touched.
         assert!(skips.get(&Phase::Untap).is_none(), "Untap must not be set");
         assert!(skips.get(&Phase::Draw).is_none(), "Draw must not be set");
+    }
+
+    /// CR 603.7c + CR 510.2 + CR 500.11: Blinding Angel — "Whenever this creature
+    /// deals combat damage to a player, that player skips their next combat
+    /// phase." The `TriggeringPlayer` target must resolve to the damaged player
+    /// carried on `current_trigger_event`, not the ability's controller. The
+    /// controller's own combat steps must be untouched.
+    #[test]
+    fn triggering_player_skip_targets_damaged_player_not_controller() {
+        use crate::types::events::GameEvent;
+        use crate::types::identifiers::ObjectId;
+
+        let mut state = GameState::default();
+        let mut events = Vec::new();
+
+        let mut ability = make_ability_scoped(
+            StepSkipTarget::CombatPhase,
+            QuantityExpr::Fixed { value: 1 },
+            SkipScope::NextOccurrence,
+        );
+        ability.controller = PlayerId(0);
+        ability.effect = Effect::SkipNextStep {
+            target: TargetFilter::TriggeringPlayer,
+            step: StepSkipTarget::CombatPhase,
+            count: QuantityExpr::Fixed { value: 1 },
+            scope: SkipScope::NextOccurrence,
+        };
+
+        // Blinding Angel (controller P0) deals combat damage to P1.
+        state.current_trigger_event = Some(GameEvent::DamageDealt {
+            source_id: ObjectId(1),
+            target: TargetRef::Player(PlayerId(1)),
+            amount: 2,
+            is_combat: true,
+            excess: 0,
+        });
+
+        resolve(&mut state, &ability, &mut events).unwrap();
+
+        // CR 500.11: all five combat steps skipped for the DAMAGED player (P1).
+        let p1 = &state.steps_to_skip[1];
+        assert_eq!(p1.get(&Phase::BeginCombat), Some(&1), "BeginCombat");
+        assert_eq!(
+            p1.get(&Phase::DeclareAttackers),
+            Some(&1),
+            "DeclareAttackers"
+        );
+        assert_eq!(p1.get(&Phase::DeclareBlockers), Some(&1), "DeclareBlockers");
+        assert_eq!(p1.get(&Phase::CombatDamage), Some(&1), "CombatDamage");
+        assert_eq!(p1.get(&Phase::EndCombat), Some(&1), "EndCombat");
+
+        // The Angel's controller (P0) must NOT be affected.
+        assert!(
+            state.steps_to_skip.first().is_none_or(|m| m.is_empty()),
+            "controller's combat phase must be untouched"
+        );
     }
 
     /// CR 614.10 + CR 614.10a: an `AllOfNextTurn` combat skip arms one pending


### PR DESCRIPTION
Blinding Angel ("Whenever this creature deals combat damage to a player,
that player skips their next combat phase") applied the skip to the
ability's controller instead of the player who was dealt damage, so the
Angel's own controller lost their next combat phase and the damaged
opponent was unaffected.

The `SkipNextStep` resolver only mapped `TargetFilter::Controller`/`SelfRef`
and a chosen `TargetRef::Player` to a `PlayerId`. The anaphoric
`TargetFilter::TriggeringPlayer` — an event-context reference with no chosen
target, so `ability.targets` is empty — fell through to `ability.controller`.
Add a `TriggeringPlayer` arm that resolves the player from
`state.current_trigger_event` via `extract_player_from_event`, mirroring the
matching arm in `additional_phase.rs`.

The three sibling cards (Stonehorn Dignitary, Revenant Patriarch, Moment of
Silence) say "target player/opponent"; they still resolve through
`ability.targets` and are unaffected.

CR 603.7c + CR 510.2 + CR 500.11

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

## Summary

<!-- What this PR changes and why. One or two sentences. -->

## Files changed

<!-- Every changed path, as a short bullet list. -->

## Track

<Developer | Non-developer>

## LLM

Model: <actual Frontier model identifier or reported name | not-applicable (no LLM)>
Tier: <Frontier | not-applicable (no LLM)>
Thinking: <high | max | not-applicable (no LLM)>

<!-- Keep Model and Tier as exact, standalone canonical lines. AI-assisted PRs
must report their actual Frontier model, Tier: Frontier, and thinking level.
If your harness does not expose an exact model identifier, report the name it
does give you — e.g. "Model: gpt-5.6-sol (via GitHub Copilot; canonical id not
exposed)" — rather than guessing an identifier. See AI-CONTRIBUTOR.md
§0.1.1. -->

## Implementation method (required)

Method: /engine-implementer
<!-- Or: Method: not-applicable — <specific non-engine reason> -->

> [!NOTE]
> Any change to `crates/engine/` game logic — parser, effects, resolver,
> targeting, rules behavior — is expected to go through `/engine-implementer`.
> The "not used" box is for changes that genuinely fall outside that scope.

## CR references

<!-- `CR XXX.Y` annotations added or touched, or "None" for non-rules changes. -->

## Verification

- [ ] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [ ] Gate A output below is for the current committed head.
- [ ] Final review-impl below is clean for the current committed head.
- [ ] Both anchors cite existing analogous code at the same seam.

- `<exact command or CI check>` — <exact result>

<!-- Commands run and exact results. Every required box must be checked. -->

## Gate A

Gate A PASS head=<40-hex-sha> base=<40-hex-sha>

## Anchored on

- path/to/existing.rs:123 — analogous authority/pattern
- path/to/existing.rs:456 — second analogous authority/pattern

## Final review-impl

Final review-impl PASS head=<40-hex-sha>

## Claimed parse impact

None.
<!-- List exact card names only when the parse-diff changes cards. -->

## Scope Expansion

None.
<!-- Describe any change that crosses the issue/card's stated scope. -->

## Validation Failures

None.
<!-- Replace with the unresolved validation failure and its evidence. -->

## CI Failures

None.
<!-- Replace with the unresolved CI failure and its evidence. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed “skip next step” effects targeting the player who triggered the event, such as the damaged opponent, instead of incorrectly targeting the ability’s controller.
  - Added coverage to verify that triggering-player targets skip the correct player’s next phase.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->