### PR TITLE
fix(client): expose accessible names for host setup switches

### DIFF
--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useMemo, useRef, useState, type ReactNode } from "react";
+import { useEffect, useId, useMemo, useRef, useState, type ReactNode } from "react";
 import { useTranslation } from "react-i18next";
 
 import type {
@@ -111,10 +111,14 @@ function Field({
 /** iOS-style toggle switch (mirrors the mockup's Host-setup `Toggle`). The
  *  on-state accent follows the connection mode (emerald server / cyan P2P). */
 function Toggle({
+  label,
+  describedBy,
   on,
   onChange,
   accent,
 }: {
+  label: string;
+  describedBy?: string;
   on: boolean;
   onChange: (next: boolean) => void;
   accent: "emerald" | "cyan";
@@ -125,6 +129,8 @@ function Toggle({
     <button
       type="button"
       role="switch"
+      aria-label={label}
+      aria-describedby={describedBy}
       aria-checked={on}
       onClick={() => onChange(!on)}
       className={`flex h-6 w-[42px] shrink-0 items-center rounded-full p-0.5 transition-colors ${on ? onBg : "bg-white/12"}`}
@@ -149,13 +155,14 @@ function OptionRow({
   onChange: (next: boolean) => void;
   accent: "emerald" | "cyan";
 }) {
+  const descriptionId = useId();
   return (
     <div className="flex items-center justify-between gap-4">
       <div className="min-w-0">
         <div className="text-sm text-fg-card-body">{label}</div>
-        {desc && <div className="mt-0.5 text-xs text-fg-meta">{desc}</div>}
+        {desc && <div id={descriptionId} className="mt-0.5 text-xs text-fg-meta">{desc}</div>}
       </div>
-      <Toggle on={on} onChange={onChange} accent={accent} />
+      <Toggle label={label} describedBy={desc ? descriptionId : undefined} on={on} onChange={onChange} accent={accent} />
     </div>
   );
 }

--- a/client/src/components/lobby/HostSetup.tsx
+++ b/client/src/components/lobby/HostSetup.tsx
@@ -133,9 +133,11 @@ function Toggle({
       aria-describedby={describedBy}
       aria-checked={on}
       onClick={() => onChange(!on)}
-      className={`flex h-6 w-[42px] shrink-0 items-center rounded-full p-0.5 transition-colors ${on ? onBg : "bg-white/12"}`}
+      className="flex min-h-11 min-w-11 shrink-0 items-center justify-center rounded-full"
     >
-      <span className={`h-5 w-5 rounded-full transition-transform duration-150 ${knob} ${on ? "translate-x-[18px]" : ""}`} />
+      <span aria-hidden="true" className={`flex h-6 w-[42px] items-center rounded-full p-0.5 transition-colors ${on ? onBg : "bg-white/12"}`}>
+        <span className={`h-5 w-5 rounded-full transition-transform duration-150 ${knob} ${on ? "translate-x-[18px]" : ""}`} />
+      </span>
     </button>
   );
 }

--- a/client/src/components/lobby/__tests__/HostSetup.test.tsx
+++ b/client/src/components/lobby/__tests__/HostSetup.test.tsx
@@ -1,5 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, screen } from "@testing-library/react";
+import { act } from "react";
+import i18n from "i18next";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 // A real `localStorage` for the store's `persist` middleware and for the
@@ -85,6 +87,8 @@ vi.mock("../../../adapter/wasm-adapter", () => ({
 import { HostSetup } from "../HostSetup";
 import { FORMAT_DEFAULTS, useMultiplayerStore } from "../../../stores/multiplayerStore";
 import { saveCustomFormat } from "../../../services/customFormats";
+import enMultiplayer from "../../../i18n/locales/en/multiplayer.json";
+import deMultiplayer from "../../../i18n/locales/de/multiplayer.json";
 
 describe("HostSetup", () => {
   beforeEach(() => {
@@ -96,8 +100,9 @@ describe("HostSetup", () => {
     });
   });
 
-  afterEach(() => {
+  afterEach(async () => {
     cleanup();
+    await i18n.changeLanguage("en");
   });
 
   it("uses P2P labeling/theme and hides server-only lobby listing in p2p mode", () => {
@@ -129,6 +134,147 @@ describe("HostSetup", () => {
     // server-mode submit button + the server-only "List in lobby" toggle.
     expect(screen.getByRole("button", { name: "Host Game" })).toBeInTheDocument();
     expect(screen.getByText("List in lobby")).toBeInTheDocument();
+  });
+
+  describe.each(["server", "p2p"] as const)("accessible hosting options (%s mode)", (connectionMode) => {
+    it("names every visible switch and associates only the sandbox help", () => {
+      render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode={connectionMode} />);
+
+      const names = ["Start when full", "Sandbox Mode — allow debug actions", "Set password"];
+      if (connectionMode === "server") names.unshift("List in lobby");
+
+      expect(screen.getAllByRole("switch")).toHaveLength(names.length);
+      for (const name of names) {
+        const control = screen.getByRole("switch", { name });
+        if (name === "Sandbox Mode — allow debug actions") {
+          expect(control).toHaveAccessibleDescription(enMultiplayer.hostSetup.sandboxModeHelp);
+        } else {
+          expect(control).not.toHaveAttribute("aria-describedby");
+          expect(control).not.toHaveAccessibleDescription();
+        }
+      }
+      if (connectionMode === "p2p") {
+        expect(screen.queryByRole("switch", { name: "List in lobby" })).not.toBeInTheDocument();
+      }
+    });
+
+    it("supports native Space and Enter without submitting until Host is activated", async () => {
+      const user = userEvent.setup();
+      const onHost = vi.fn();
+      render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode={connectionMode} />);
+
+      if (connectionMode === "server") {
+        const publicSwitch = screen.getByRole("switch", { name: "List in lobby" });
+        expect(publicSwitch).toBeChecked();
+        await user.click(publicSwitch);
+        expect(publicSwitch).not.toBeChecked();
+      }
+
+      const startSwitch = screen.getByRole("switch", { name: "Start when full" });
+      expect(startSwitch).toBeChecked();
+      startSwitch.focus();
+      await user.keyboard(" ");
+      expect(startSwitch).not.toBeChecked();
+
+      const sandboxSwitch = screen.getByRole("switch", { name: "Sandbox Mode — allow debug actions" });
+      await user.tab();
+      expect(sandboxSwitch).toHaveFocus();
+      expect(sandboxSwitch).not.toBeChecked();
+      await user.keyboard("{Enter}");
+      expect(sandboxSwitch).toBeChecked();
+
+      const passwordSwitch = screen.getByRole("switch", { name: "Set password" });
+      await user.tab();
+      expect(passwordSwitch).toHaveFocus();
+      expect(passwordSwitch).not.toBeChecked();
+      await user.keyboard(" ");
+      expect(passwordSwitch).toBeChecked();
+      await user.type(screen.getByPlaceholderText("Game password"), "test-password");
+
+      expect(onHost).not.toHaveBeenCalled();
+      await user.click(screen.getByRole("button", {
+        name: connectionMode === "server" ? "Host Game" : "Host P2P Game",
+      }));
+      expect(onHost).toHaveBeenCalledTimes(1);
+      expect(onHost).toHaveBeenCalledWith(expect.objectContaining({
+        public: connectionMode === "p2p",
+        startWhenFull: false,
+        password: "test-password",
+        formatConfig: expect.objectContaining({ allow_debug_actions: true }),
+      }));
+    });
+
+    it("clears a password when its named switch is turned off", async () => {
+      const user = userEvent.setup();
+      const onHost = vi.fn();
+      render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode={connectionMode} />);
+
+      const passwordSwitch = screen.getByRole("switch", { name: "Set password" });
+      await user.click(passwordSwitch);
+      await user.type(screen.getByPlaceholderText("Game password"), "discarded-password");
+      await user.click(passwordSwitch);
+      expect(screen.queryByPlaceholderText("Game password")).not.toBeInTheDocument();
+      await user.click(passwordSwitch);
+      expect(screen.getByPlaceholderText("Game password")).toHaveValue("");
+      await user.click(passwordSwitch);
+
+      expect(onHost).not.toHaveBeenCalled();
+      await user.click(screen.getByRole("button", {
+        name: connectionMode === "server" ? "Host Game" : "Host P2P Game",
+      }));
+      expect(onHost).toHaveBeenCalledTimes(1);
+      expect(onHost).toHaveBeenCalledWith(expect.objectContaining({
+        public: true,
+        startWhenFull: true,
+        password: "",
+        formatConfig: expect.objectContaining({ allow_debug_actions: false }),
+      }));
+    });
+  });
+
+  it("updates switch names and sandbox help when the active locale changes", async () => {
+    const user = userEvent.setup();
+    i18n.addResourceBundle("de", "multiplayer", deMultiplayer, true, true);
+    render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="server" />);
+
+    const translations = [
+      ["List in lobby", "In Lobby listen"],
+      ["Start when full", "Starten, wenn voll"],
+      ["Sandbox Mode — allow debug actions", "Sandbox-Modus — Debug-Aktionen erlauben"],
+      ["Set password", "Passwort festlegen"],
+    ] as const;
+    const switches = translations.map(([name]) => screen.getByRole("switch", { name }));
+    const startSwitch = screen.getByRole("switch", { name: "Start when full" });
+    const sandboxSwitch = screen.getByRole("switch", { name: "Sandbox Mode — allow debug actions" });
+    expect(sandboxSwitch).toHaveAccessibleDescription(enMultiplayer.hostSetup.sandboxModeHelp);
+    await user.click(startSwitch);
+
+    // Component tests use their own lean i18next setup, without the production
+    // preferences-store subscription. Change that test instance while mounted.
+    await act(async () => {
+      await i18n.changeLanguage("de");
+    });
+
+    for (const [index, [, name]] of translations.entries()) {
+      expect(screen.getByRole("switch", { name })).toBe(switches[index]);
+    }
+    expect(sandboxSwitch).toHaveAccessibleDescription(deMultiplayer.hostSetup.sandboxModeHelp);
+    expect(startSwitch).not.toBeChecked();
+  });
+
+  it("keeps sandbox descriptions associated with their own mounted form", () => {
+    const first = render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="server" />);
+    const second = render(<HostSetup onHost={vi.fn()} onBack={vi.fn()} connectionMode="p2p" />);
+
+    const descriptionIds = [first, second].map(({ container }) => {
+      const control = within(container).getByRole("switch", { name: "Sandbox Mode — allow debug actions" });
+      const description = within(container).getByText(enMultiplayer.hostSetup.sandboxModeHelp);
+      expect(description.id).not.toBe("");
+      expect(control).toHaveAttribute("aria-describedby", description.id);
+      expect(control).toHaveAccessibleDescription(enMultiplayer.hostSetup.sandboxModeHelp);
+      return description.id;
+    });
+    expect(new Set(descriptionIds).size).toBe(2);
   });
 
   it("allows Free-for-All hosts to choose 40-card deck size", async () => {

--- a/client/src/components/lobby/__tests__/HostSetup.test.tsx
+++ b/client/src/components/lobby/__tests__/HostSetup.test.tsx
@@ -158,6 +158,29 @@ describe("HostSetup", () => {
       }
     });
 
+    it("keeps the compact track inside a non-shrinking touch target", async () => {
+      const user = userEvent.setup();
+      const onHost = vi.fn();
+      render(<HostSetup onHost={onHost} onBack={vi.fn()} connectionMode={connectionMode} />);
+
+      for (const control of screen.getAllByRole("switch")) {
+        // Happy DOM does not lay out CSS. Pin the sizing contract here; check
+        // rendered dimensions and clicks outside the track in a real browser.
+        expect(control).toHaveClass("min-h-11", "min-w-11", "shrink-0");
+        const track = control.firstElementChild;
+        expect(track).toHaveAttribute("aria-hidden", "true");
+        expect(track).toHaveClass("h-6", "w-[42px]");
+        if (!track) throw new Error("Switch track is missing");
+
+        const wasChecked = control.getAttribute("aria-checked");
+        await user.click(control);
+        expect(control).toHaveAttribute("aria-checked", wasChecked === "true" ? "false" : "true");
+        await user.click(track);
+        expect(control).toHaveAttribute("aria-checked", wasChecked);
+      }
+      expect(onHost).not.toHaveBeenCalled();
+    });
+
     it("supports native Space and Enter without submitting until Host is activated", async () => {
       const user = userEvent.setup();
       const onHost = vi.fn();


### PR DESCRIPTION
## Summary

Expose the existing translated labels as accessible names for the host-setup lobby, automatic-start, sandbox, and password switches, and associate optional help text using an instance-local ID. Give each native button a minimum 44×44 touch target while keeping the compact 42×24 visual track, native keyboard behavior, and hosting settings.

## Files changed

- `client/src/components/lobby/HostSetup.tsx`
- `client/src/components/lobby/__tests__/HostSetup.test.tsx`

## Track

Developer

## LLM

Model: gpt-5.6-sol
Tier: Frontier
Thinking: ultra

## Implementation method (required)

Method: not-applicable — component accessibility attributes, touch-target layout, and regression tests only; no engine, parser, AST, rules, or transport changes.

## CR references

None — presentation/accessibility only.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

Local verification uses Node v24.18.0 and the pinned pnpm 9.15.9. Tilt is unavailable in this environment, so the documented direct frontend checks were used.

- `cd client && pnpm exec vitest run src/components/lobby/__tests__/HostSetup.test.tsx` — 23 passed: 13 original tests, 8 accessible-name/description cases, and 2 touch-target cases. The original 8 additions failed before the naming fix (13 existing tests passed); the 2 touch-target additions failed before the sizing fix (21 existing tests passed).
- The new cases cover both connection modes, names and optional descriptions, native Space/Enter activation without early submission, exact relevant hosting payloads, password clearing, live English-to-German labels/help, and distinct description IDs across mounted instances. They render the real `HostSetup`; no toggle/component mock replaces the changed path.
- Touch-target regression coverage pins the non-shrinking minimum-size classes on every rendered switch in both connection modes, the separate compact decorative track, and single activation from both the native button and its track without submitting the form. These are class-contract/interaction tests: Happy DOM does not perform CSS layout, so geometry is verified separately in the browser.
- Browser check in the isolated local app: the accessibility tree initially exposed four unnamed switches. After the fix it exposed all four translated names; DOM inspection confirmed the sandbox description references its visible help. Space then Enter toggled automatic start off and back on while remaining in setup. No room was created, and no claim is made about testing with a physical screen reader or iOS device.
- Review follow-up browser check: before the sizing fix, all four buttons measured 42×24. With the fix, all four measured 44×44 with 42×24 tracks at both 390×844 and 1280×900 viewports. At the narrow viewport, clicking above and below each visible track toggled its switch once and restored the original state. Native Space/Enter also worked, and no room was created. This is responsive browser verification, not physical touchscreen/device testing.
- `cd client && pnpm exec vitest run --maxWorkers=4` — 4,844 tests passed across 430 test files; 2 files skipped and 12 tests marked TODO.
- `cd client && pnpm run type-check` — TypeScript and protocol validation passed.
- `cd client && pnpm lint` — passed with zero errors and 44 existing warnings; none are in the changed files.
- `cargo fmt --all` and `git diff --check` — passed.
- CI-owned broader verification for this non-Rust change: Rust lint/parser gates, Rust test archive and four shards, card-data generation/validation/coverage, WASM, Android, lobby-worker, and the other applicable workflow checks. These are not claimed as local runs.

## Gate A

Raw output from `./scripts/check-parser-combinators.sh`, run after the final review on the committed head:

```text
Gate G PASS (router/grant architecture: strict router vs permissive grant boundary intact)
Gate A PASS head=32bdbe62c66ab5ec02ba0265ea7ca5353c5fc584 base=f41ed842f9f48153818039d474749f54c9a327dd
```

## Anchored on

- `client/src/components/menu/AiOpponentConfig.tsx:173` — an existing native switch receives its translated visible label through `aria-label` and keeps native button activation.
- `client/src/components/chrome/VolumeControl.tsx:142` — an existing control links optional explanatory text with `aria-describedby` and an ID created by `useId` (line 47), separately from its accessible name.
- `client/src/components/chrome/StatusBanner.tsx:106` — an existing native button uses `min-h-11 min-w-11 shrink-0` for a non-shrinking touch target. The colocated regression follows the rendered-component sizing-class precedent in `client/src/components/draft/__tests__/LimitedDeckBuilder.test.tsx:910`.

## Final review-impl

Final review-impl PASS head=32bdbe62c66ab5ec02ba0265ea7ca5353c5fc584

A fresh independent reviewer inspected the full committed span from `f41ed842f9f48153818039d474749f54c9a327dd` to this head and reported no actionable findings. The review covered the shared component seam, the reviewer-requested touch-target fix, accessible names/descriptions, native activation, localization, per-instance IDs, unchanged hosting settings, and regression-test discrimination. Static review only; the checks and browser verification above were performed separately. CodeRabbit's earlier touch-target finding was checked against this head and addressed; its earlier review is not claimed as a current-head external review.

## Claimed parse impact

None.

## Scope Expansion

The reviewer-requested touch-target fix stays in the existing `OptionRow`/`Toggle` presentation seam and its colocated tests. It enlarges the interactive area without enlarging the visible track; no new shared framework, keyboard handlers, translation keys, or hosting logic.

## Validation Failures

None unresolved.

## CI Failures

CI results for the review-fix head are pending; previous-head CI results are not attributed to this update.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Accessibility**
  - Improved lobby setup switches with clearer screen reader labels and descriptions.
  - Ensured each option’s description is uniquely associated with its corresponding toggle.
  - Added accessible descriptions across server and peer-to-peer setup options.
  - Enlarged switch touch targets to at least 44×44 pixels while preserving compact visual styling.

- **Quality Improvements**
  - Verified switches respond when clicking either the control or its track without submitting the setup form.
  - Expanded coverage for keyboard interaction, password clearing, locale changes, and switch accessibility.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
