### PR TITLE
fix(engine): isolate replacement child waiting states

### DIFF
--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -5870,7 +5870,7 @@ mod tests {
             let ReplacementResult::NeedsChoice(player) = replacement_mod::replace_event(
                 &mut state,
                 ProposedEvent::LifeGain {
-                    player_id: PlayerId(0),
+                    player_id: PlayerId(1),
                     amount: 1,
                     applied: HashSet::new(),
                 },
@@ -5878,6 +5878,11 @@ mod tests {
             ) else {
                 panic!("optional replacement must request an actual choice")
             };
+            assert_eq!(player, PlayerId(1), "the source controller must choose");
+            assert_ne!(
+                player, state.active_player,
+                "the replacement's controller must differ from the active player"
+            );
             state.waiting_for = replacement_mod::replacement_choice_waiting_for(player, &state);
 
             apply_as_current(&mut state, GameAction::ChooseReplacement { index: 0 })

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -2592,8 +2592,12 @@ pub(super) fn apply_post_replacement_effect(
     resolve_post_replacement_chain(state, &resolved, events)
 }
 
-/// CR 615.5 + CR 608.2c: replacement follow-ups execute immediately, in order,
-/// independently of an input prompt belonging to their caller.
+/// CR 608.2c: execute instructions in the order written.
+/// CR 615.5: a prevention effect's additional effect occurs immediately after
+/// the prevention.
+///
+/// Engine invariant: isolate `state.waiting_for` so caller-owned prompts cannot
+/// suspend the child chain or be mistaken for new child input.
 fn resolve_post_replacement_chain(
     state: &mut GameState,
     resolved: &ResolvedAbility,

--- a/crates/engine/src/game/engine_replacement.rs
+++ b/crates/engine/src/game/engine_replacement.rs
@@ -2527,11 +2527,7 @@ pub(super) fn apply_post_replacement_effect(
             let mut resolved =
                 build_resolved_from_def_with_targets(real_work, source_id, controller, targets);
             resolved.set_replacement_applied_recursive(replacement_applied);
-            let _ = effects::resolve_ability_chain(state, &resolved, events, 0);
-            return match &state.waiting_for {
-                WaitingFor::Priority { .. } => None,
-                wf => Some(wf.clone()),
-            };
+            return resolve_post_replacement_chain(state, &resolved, events);
         } else {
             return Some(WaitingFor::CopyTargetChoice {
                 player: controller,
@@ -2593,11 +2589,34 @@ pub(super) fn apply_post_replacement_effect(
     let mut resolved =
         build_resolved_from_def_with_targets(effect_def, source_id, controller, targets);
     resolved.set_replacement_applied_recursive(replacement_applied);
-    let _ = effects::resolve_ability_chain(state, &resolved, events, 0);
+    resolve_post_replacement_chain(state, &resolved, events)
+}
+
+/// CR 615.5 + CR 608.2c: replacement follow-ups execute immediately, in order,
+/// independently of an input prompt belonging to their caller.
+fn resolve_post_replacement_chain(
+    state: &mut GameState,
+    resolved: &ResolvedAbility,
+    events: &mut Vec<GameEvent>,
+) -> Option<WaitingFor> {
+    // CR 117.2e: this is an internal execution sentinel, not a priority grant.
+    // Isolate before running the chain: an inherited resolution choice would
+    // otherwise park its synchronous tail, even if the first effect completed.
+    let caller_wait = std::mem::replace(
+        &mut state.waiting_for,
+        WaitingFor::Priority {
+            player: state.priority_player,
+        },
+    );
+    let _ = effects::resolve_ability_chain(state, resolved, events, 0);
 
     match &state.waiting_for {
-        WaitingFor::Priority { .. } => None,
-        wf => Some(wf.clone()),
+        WaitingFor::Priority { .. } => {
+            state.waiting_for = caller_wait;
+            None
+        }
+        // A new child prompt may have exactly the same payload as caller_wait.
+        waiting_for => Some(waiting_for.clone()),
     }
 }
 
@@ -2900,12 +2919,7 @@ fn apply_post_replacement_resolved_effect(
 ) -> Option<WaitingFor> {
     let mut resolved = resolved.clone();
     resolved.set_replacement_applied_recursive(replacement_applied);
-    let _ = effects::resolve_ability_chain(state, &resolved, events, 0);
-
-    match &state.waiting_for {
-        WaitingFor::Priority { .. } => None,
-        wf => Some(wf.clone()),
-    }
+    resolve_post_replacement_chain(state, &resolved, events)
 }
 
 /// CR 608.3: Complete post-resolution work for a permanent spell whose ETB
@@ -5773,6 +5787,403 @@ mod tests {
         );
         assert!(!targets.contains(&unmarked_exile));
         assert!(!targets.contains(&bf_creature));
+    }
+
+    fn inherited_replacement_waits(source: ObjectId, other: ObjectId) -> [WaitingFor; 2] {
+        [
+            WaitingFor::AssignCombatDamage {
+                player: PlayerId(0),
+                attacker_id: source,
+                total_damage: 2,
+                blockers: vec![crate::types::game_state::DamageSlot {
+                    blocker_id: other,
+                    lethal_minimum: 2,
+                }],
+                assignment_modes: vec![Default::default()],
+                trample: None,
+                defending_player: PlayerId(1),
+                attack_target: crate::game::combat::AttackTarget::Player(PlayerId(1)),
+                pw_loyalty: None,
+                pw_controller: None,
+            },
+            WaitingFor::ScryChoice {
+                player: PlayerId(0),
+                cards: vec![other],
+            },
+        ]
+    }
+
+    #[test]
+    fn post_replacement_public_answer_distinguishes_template_copy_and_child_choice() {
+        let mut initial = GameState::new_two_player(42);
+        let source = install_optional_replacement(&mut initial, ReplacementEvent::GainLife);
+        let scry_card = create_object(
+            &mut initial,
+            CardId(10),
+            PlayerId(1),
+            "Scry card".to_string(),
+            Zone::Library,
+        );
+        let chosen = create_object(
+            &mut initial,
+            CardId(11),
+            PlayerId(0),
+            "Exiled copy source".to_string(),
+            Zone::Exile,
+        );
+        initial
+            .cards_exiled_with_source_this_turn
+            .insert(source, vec![chosen]);
+        for effect in [
+            Effect::LoseLife {
+                amount: QuantityExpr::Fixed { value: 2 },
+                target: Some(TargetFilter::Controller),
+            },
+            Effect::BecomeCopy {
+                target: TargetFilter::ExiledCardByIndex { index: 0 },
+                recipient: TargetFilter::SelfRef,
+                duration: Some(crate::types::ability::Duration::Permanent),
+                mana_value_limit: None,
+                additional_modifications: Vec::new(),
+            },
+            Effect::Scry {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        ] {
+            let mut state = initial.clone();
+            let mut template = AbilityDefinition::new(AbilityKind::Spell, effect.clone());
+            template.sub_ability = Some(Box::new(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::LoseLife {
+                    amount: QuantityExpr::Fixed { value: 5 },
+                    target: Some(TargetFilter::Controller),
+                },
+            )));
+            state
+                .objects
+                .get_mut(&source)
+                .unwrap()
+                .replacement_definitions[0]
+                .execute = Some(Box::new(template));
+            let mut events = Vec::new();
+            let ReplacementResult::NeedsChoice(player) = replacement_mod::replace_event(
+                &mut state,
+                ProposedEvent::LifeGain {
+                    player_id: PlayerId(0),
+                    amount: 1,
+                    applied: HashSet::new(),
+                },
+                &mut events,
+            ) else {
+                panic!("optional replacement must request an actual choice")
+            };
+            state.waiting_for = replacement_mod::replacement_choice_waiting_for(player, &state);
+
+            apply_as_current(&mut state, GameAction::ChooseReplacement { index: 0 })
+                .expect("accept the replacement through the public reducer");
+            if matches!(effect, Effect::Scry { .. }) {
+                assert_eq!(
+                    state.waiting_for,
+                    WaitingFor::ScryChoice {
+                        player: PlayerId(1),
+                        cards: vec![scry_card]
+                    }
+                );
+                assert_eq!(state.players[1].life, 20, "child tail waits for its answer");
+                assert!(
+                    !state.resolution_stack.is_empty(),
+                    "real input retains its owner"
+                );
+                apply_as_current(
+                    &mut state,
+                    GameAction::SelectCards {
+                        cards: vec![scry_card],
+                    },
+                )
+                .expect("answer the actual child choice");
+            }
+            if matches!(effect, Effect::BecomeCopy { .. }) {
+                assert_eq!(state.objects[&source].name, "Exiled copy source");
+            }
+            let initial_loss = if matches!(effect, Effect::LoseLife { .. }) {
+                2
+            } else {
+                0
+            };
+            assert_eq!(
+                state.players[1].life,
+                15 - initial_loss,
+                "each instruction runs once for its controller"
+            );
+            assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
+            assert!(
+                state.resolution_stack.is_empty(),
+                "synchronous work cannot own the answered replacement prompt"
+            );
+            apply_as_current(&mut state, GameAction::PassPriority)
+                .expect("ordinary priority after replacement");
+            assert_eq!(state.players[1].life, 15 - initial_loss);
+        }
+    }
+
+    #[test]
+    fn post_replacement_synchronous_chains_restore_inherited_waits() {
+        for tail_amount in [None, Some(3)] {
+            let mut initial = GameState::new_two_player(42);
+            let source = make_creature(&mut initial, PlayerId(1), "Replacement source");
+            let other = make_creature(&mut initial, PlayerId(0), "Other object");
+            let mut template = AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::LoseLife {
+                    amount: QuantityExpr::Fixed { value: 2 },
+                    target: Some(TargetFilter::Controller),
+                },
+            );
+            if let Some(value) = tail_amount {
+                template.sub_ability = Some(Box::new(AbilityDefinition::new(
+                    AbilityKind::Spell,
+                    Effect::LoseLife {
+                        amount: QuantityExpr::Fixed { value },
+                        target: Some(TargetFilter::Controller),
+                    },
+                )));
+            }
+            let resolved = build_resolved_from_def_with_targets(
+                &template,
+                source,
+                PlayerId(1),
+                vec![TargetRef::Object(source)],
+            );
+            for continuation in [
+                PostReplacementContinuation::Template(Box::new(template)),
+                PostReplacementContinuation::Resolved(Box::new(resolved)),
+            ] {
+                for caller_wait in inherited_replacement_waits(source, other) {
+                    let mut state = initial.clone();
+                    state.waiting_for = caller_wait.clone();
+                    state.install_ready_continuation(continuation.clone());
+                    let mut events = Vec::new();
+                    let waiting = apply_pending_post_replacement_effect(
+                        &mut state,
+                        Some(source),
+                        None,
+                        None,
+                        &mut events,
+                    );
+
+                    // CR 608.2c: every instruction completes in written order;
+                    // an inherited resolution choice cannot park the tail.
+                    assert_eq!(state.players[1].life, 18 - tail_amount.unwrap_or(0));
+                    assert_eq!(state.players[0].life, 20);
+                    assert!(
+                        waiting.is_none(),
+                        "completed child must not claim caller input"
+                    );
+                    assert_eq!(state.waiting_for, caller_wait);
+                    assert!(
+                        state.resolution_stack.is_empty(),
+                        "no false paused drain or tail"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn post_replacement_identical_scry_prompt_resumes_context_tail_once() {
+        let mut initial = GameState::new_two_player(42);
+        let shield = make_creature(&mut initial, PlayerId(0), "Replacement source");
+        let damage_source = make_creature(&mut initial, PlayerId(1), "Damage source");
+        let recipient = make_creature(&mut initial, PlayerId(0), "Damage recipient");
+        // These creatures must survive the public answer's state-based actions.
+        for id in [shield, damage_source, recipient] {
+            let object = initial.objects.get_mut(&id).unwrap();
+            object.power = Some(2);
+            object.toughness = Some(2);
+            object.base_power = Some(2);
+            object.base_toughness = Some(2);
+            object.base_card_types = object.card_types.clone();
+        }
+        let scry_card = create_object(
+            &mut initial,
+            CardId(10),
+            PlayerId(0),
+            "Scry card".to_string(),
+            Zone::Library,
+        );
+        create_object(
+            &mut initial,
+            CardId(11),
+            PlayerId(1),
+            "Source controller draw".to_string(),
+            Zone::Library,
+        );
+        let mut counters = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::PutCounter {
+                counter_type: CounterType::Plus1Plus1,
+                count: QuantityExpr::Fixed { value: 3 },
+                target: TargetFilter::PostReplacementDamageTarget,
+            },
+        );
+        counters.sub_ability = Some(Box::new(AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Draw {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::PostReplacementSourceController,
+            },
+        )));
+        let mut template = AbilityDefinition::new(
+            AbilityKind::Spell,
+            Effect::Scry {
+                count: QuantityExpr::Fixed { value: 1 },
+                target: TargetFilter::Controller,
+            },
+        );
+        template.sub_ability = Some(Box::new(counters));
+        let resolved = build_resolved_from_def_with_targets(
+            &template,
+            shield,
+            PlayerId(0),
+            vec![TargetRef::Object(shield)],
+        );
+        for continuation in [
+            PostReplacementContinuation::Template(Box::new(template)),
+            PostReplacementContinuation::Resolved(Box::new(resolved)),
+        ] {
+            let mut state = initial.clone();
+            let caller_wait = WaitingFor::ScryChoice {
+                player: PlayerId(0),
+                cards: vec![scry_card],
+            };
+            state.waiting_for = caller_wait.clone();
+            state.install_ready_continuation(continuation);
+            let drain = state
+                .active_post_replacement_drains_mut()
+                .and_then(crate::types::game_state::PostReplacementDrainStack::resident_mut)
+                .expect("replacement context is resident");
+            drain.source = Some(shield);
+            drain.event_source = Some(damage_source);
+            drain.event_target = Some(TargetRef::Object(recipient));
+            let mut events = Vec::new();
+            let waiting = apply_pending_post_replacement_effect(
+                &mut state,
+                Some(shield),
+                None,
+                Some(ReplacementEvent::DamageDone),
+                &mut events,
+            );
+
+            assert_eq!(
+                waiting,
+                Some(caller_wait.clone()),
+                "new identical prompt still belongs to child"
+            );
+            assert_eq!(state.waiting_for, caller_wait);
+            assert!(matches!(
+                state
+                    .active_post_replacement_drains()
+                    .and_then(crate::types::game_state::PostReplacementDrainStack::resident)
+                    .map(|drain| &drain.status),
+                Some(crate::types::game_state::DrainStatus::Paused)
+            ));
+            assert!(
+                state.objects[&recipient].counters.is_empty(),
+                "tail must wait for answer"
+            );
+            assert!(state.players[1].hand.is_empty());
+
+            let answer = apply_as_current(
+                &mut state,
+                GameAction::SelectCards {
+                    cards: vec![scry_card],
+                },
+            )
+            .expect("public scry answer resumes the child");
+            // CR 615.5: the paused rider retains the prevented event's target
+            // and source controller until every instruction has completed.
+            assert_eq!(
+                state.objects[&recipient]
+                    .counters
+                    .get(&CounterType::Plus1Plus1),
+                Some(&3)
+            );
+            assert!(state.objects[&shield].counters.is_empty());
+            assert!(state.objects[&damage_source].counters.is_empty());
+            assert_eq!(state.players[1].hand.len(), 1);
+            assert!(state.players[0].hand.is_empty());
+            assert_eq!(answer.events.iter().filter(|event| matches!(event,
+                GameEvent::CounterAdded { object_id, count: 3, .. } if *object_id == recipient
+            )).count(), 1);
+            assert!(
+                state.resolution_stack.is_empty(),
+                "answered child retires its context"
+            );
+            assert!(matches!(state.waiting_for, WaitingFor::Priority { .. }));
+            apply_as_current(&mut state, GameAction::PassPriority)
+                .expect("normal priority resumes");
+            assert_eq!(state.players[1].hand.len(), 1, "tail must not run twice");
+            assert_eq!(
+                state.objects[&recipient]
+                    .counters
+                    .get(&CounterType::Plus1Plus1),
+                Some(&3)
+            );
+        }
+    }
+
+    #[test]
+    fn post_replacement_predetermined_copy_restores_wait_and_completes_tail() {
+        for caller_wait_index in 0..2 {
+            let mut state = GameState::new_two_player(42);
+            let source = make_creature(&mut state, PlayerId(0), "Copy recipient");
+            let chosen = make_creature(&mut state, PlayerId(1), "Chosen copy source");
+            let caller_wait =
+                inherited_replacement_waits(source, chosen)[caller_wait_index].clone();
+            state.waiting_for = caller_wait.clone();
+            let mut template = AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::BecomeCopy {
+                    target: TargetFilter::SpecificObject { id: chosen },
+                    recipient: TargetFilter::SelfRef,
+                    duration: Some(crate::types::ability::Duration::Permanent),
+                    mana_value_limit: None,
+                    additional_modifications: Vec::new(),
+                },
+            );
+            template.sub_ability = Some(Box::new(AbilityDefinition::new(
+                AbilityKind::Spell,
+                Effect::LoseLife {
+                    amount: QuantityExpr::Fixed { value: 2 },
+                    target: Some(TargetFilter::Controller),
+                },
+            )));
+            state.install_ready_continuation(PostReplacementContinuation::Template(Box::new(
+                template,
+            )));
+            let mut events = Vec::new();
+            let waiting = apply_pending_post_replacement_effect(
+                &mut state,
+                Some(source),
+                None,
+                Some(ReplacementEvent::ChangeZone),
+                &mut events,
+            );
+
+            assert_eq!(
+                state.objects[&source].name, "Chosen copy source",
+                "predetermined copy actually executes"
+            );
+            assert_eq!(
+                state.players[0].life, 18,
+                "copy's synchronous tail completes"
+            );
+            assert_eq!(state.players[1].life, 20);
+            assert!(waiting.is_none());
+            assert_eq!(state.waiting_for, caller_wait);
+            assert!(state.resolution_stack.is_empty());
+        }
     }
 
     /// 2026-05-09 audit M4 regression: the unified

--- a/crates/engine/tests/integration/vigor_regression.rs
+++ b/crates/engine/tests/integration/vigor_regression.rs
@@ -1,16 +1,183 @@
 //! Vigor — damage prevention applies only to other creatures you control, and
 //! the +1/+1 counter rider uses the prevented event's recipient.
 
+use engine::game::combat::AttackTarget;
 use engine::game::scenario::{GameScenario, P0, P1};
 use engine::types::ability::{ShieldKind, TargetFilter};
+use engine::types::actions::GameAction;
 use engine::types::counter::CounterType;
+use engine::types::events::GameEvent;
 use engine::types::game_state::WaitingFor;
 use engine::types::mana::{ManaType, ManaUnit};
 use engine::types::phase::Phase;
 use engine::types::replacements::ReplacementEvent;
 const VIGOR_ORACLE: &str = "Trample\n\
 If damage would be dealt to another creature you control, prevent that damage. \
-Put a +1/+1 counter on that creature for each 1 damage prevented this way.";
+Put a +1/+1 counter on that creature for each 1 damage prevented this way.\n\
+When Vigor is put into a graveyard from anywhere, shuffle it into its owner's library.";
+
+#[test]
+fn vigor_thirty_blockers_complete_prevention_riders_and_reach_next_turn() {
+    let mut scenario = GameScenario::new();
+    scenario.at_phase(Phase::PreCombatMain);
+    scenario.with_library_top(P0, &["Forest", "Forest"]);
+    scenario.with_library_top(P1, &["Island", "Island"]);
+    let vigor = scenario
+        .add_creature_from_oracle(P0, "Vigor", 6, 6, VIGOR_ORACLE)
+        .with_plus_counters(2)
+        .id();
+    let attacker = scenario
+        .add_creature(P0, "Protected attacker", 4, 4)
+        .with_plus_counters(28)
+        .id();
+    let blockers: Vec<_> = (0..30)
+        .map(|index| {
+            scenario
+                .add_creature(P1, &format!("Blocker {index}"), 2, 5)
+                .id()
+        })
+        .collect();
+    let mut runner = scenario.build();
+    let initial_turn = runner.state().turn_number;
+    runner.advance_to_combat();
+    runner
+        .declare_attackers(&[(attacker, AttackTarget::Player(P1))])
+        .expect("declare protected attacker");
+    for _ in 0..8 {
+        if matches!(
+            runner.state().waiting_for,
+            WaitingFor::DeclareBlockers { .. }
+        ) {
+            break;
+        }
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::Priority { .. }
+        ));
+        runner
+            .act(GameAction::PassPriority)
+            .expect("advance to blockers");
+    }
+    runner
+        .declare_blockers(
+            &blockers
+                .iter()
+                .map(|&blocker| (blocker, attacker))
+                .collect::<Vec<_>>(),
+        )
+        .expect("all thirty creatures block the attacker");
+    for _ in 0..8 {
+        if matches!(
+            runner.state().waiting_for,
+            WaitingFor::AssignCombatDamage { .. }
+        ) {
+            break;
+        }
+        assert!(matches!(
+            runner.state().waiting_for,
+            WaitingFor::Priority { .. }
+        ));
+        runner
+            .act(GameAction::PassPriority)
+            .expect("advance to damage assignment");
+    }
+    let WaitingFor::AssignCombatDamage {
+        attacker_id,
+        blockers: slots,
+        ..
+    } = &runner.state().waiting_for
+    else {
+        panic!(
+            "expected actual combat assignment, got {:?}",
+            runner.state().waiting_for
+        );
+    };
+    assert_eq!(*attacker_id, attacker);
+    assert_eq!(slots.len(), 30);
+    assert!(runner.state().resolution_stack.is_empty());
+    let assignment = engine::ai_support::legal_actions(runner.state())
+        .into_iter()
+        .find(|action| matches!(action, GameAction::AssignCombatDamage { .. }))
+        .expect("engine supplies legal damage assignment");
+    let result = runner
+        .act(assignment)
+        .expect("deal the assigned combat damage");
+
+    // CR 510.2 + CR 615.5: all thirty blockers deal simultaneously; each
+    // prevention rider completes immediately using that event's recipient.
+    let prevented: Vec<_> = result
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            GameEvent::DamagePrevented { amount, .. } => Some(*amount),
+            _ => None,
+        })
+        .collect();
+    assert!(
+        !prevented.is_empty(),
+        "combat damage was actually prevented"
+    );
+    assert_eq!(prevented.iter().sum::<u32>(), 60);
+    let counters: Vec<_> = result
+        .events
+        .iter()
+        .filter_map(|event| match event {
+            GameEvent::CounterAdded {
+                object_id,
+                counter_type: CounterType::Plus1Plus1,
+                count,
+                ..
+            } => Some((*object_id, *count)),
+            _ => None,
+        })
+        .collect();
+    assert_eq!(counters.len(), 30);
+    assert!(counters
+        .iter()
+        .all(|(id, count)| *id == attacker && *count == 2));
+    assert_eq!(
+        runner.state().objects[&attacker].counters[&CounterType::Plus1Plus1],
+        88
+    );
+    assert_eq!(
+        runner.state().objects[&vigor].counters[&CounterType::Plus1Plus1],
+        2
+    );
+    assert_eq!(runner.state().objects[&attacker].damage_marked, 0);
+    assert!(
+        runner.state().resolution_stack.is_empty(),
+        "completed riders must not leave false paused drains"
+    );
+
+    for _ in 0..32 {
+        if runner.state().turn_number > initial_turn {
+            break;
+        }
+        assert!(
+            matches!(runner.state().waiting_for, WaitingFor::Priority { .. }),
+            "combat and end-step work must finish: {:?}",
+            runner.state().waiting_for
+        );
+        runner
+            .act(GameAction::PassPriority)
+            .expect("ordinary passes reach the next turn");
+    }
+    assert_eq!(runner.state().turn_number, initial_turn + 1);
+    assert_eq!(runner.state().active_player, P1);
+    assert!(matches!(
+        runner.state().waiting_for,
+        WaitingFor::Priority { .. }
+    ));
+    assert!(runner.state().resolution_stack.is_empty());
+    assert_eq!(
+        runner.state().objects[&attacker].counters[&CounterType::Plus1Plus1],
+        88
+    );
+    assert_eq!(
+        runner.state().objects[&vigor].counters[&CounterType::Plus1Plus1],
+        2
+    );
+}
 
 #[test]
 fn vigor_does_not_prevent_damage_to_opponents_creature() {


### PR DESCRIPTION
Replacement follow-up chains could inherit their caller's input prompt and report completed work as paused. Vigor's combat-damage prevention applied its counter riders but left stale resolution owners, preventing later stack settlement.

Run prepared template, resolved, and predetermined-copy chains through one helper that isolates the caller's waiting state during child execution. Restore the caller when the child finishes synchronously; retain genuine child input, including a new prompt with an identical payload. Existing dispatch and continuation ownership remain authoritative.

Adds regressions for synchronous tails, public replacement answers, copies, identical Scry prompts, and thirty-blocker Vigor combat. The combat test requires exactly 60 prevented damage and 60 counters on the protected creature, no stale paused work, and normal next-turn progression.

Fixes #8312.

## Validation

- [CI](https://github.com/phase-rs/phase/actions/runs/33740820482): all four Rust shards passed **30,219 tests**; lint, card-data, frontend, WASM, Android, and lobby checks passed. No card-parse changes or coverage regressions.
- Clean candidate checkout: all 28 default engine/AI test executables accounted for, **28,930 passed / 27 ignored** across the recorded runs; doctests accounted for. Workspace all-targets Clippy with `-D warnings` and formatting passed.
- Saved-checkpoint replay: the same legal-action prefix yields **60 prevented / 60 counters**, zero false Paused drains, and nonterminal **turn 48** with empty stack/frames and no carrier. The incomplete original debug export retains its normal loader rejection.
- Mutation check: removing only wait isolation makes the combat regression fail on stale paused work after the correct prevention/counter assertions; restoring it passes.
- Fresh independent whole-diff review: **Completion Gate PASS**, **Maintainer-Simulation Gate PASS**, no candidate findings. Added CR references verified against the local rules text.

The initial local lean-profile integration run aborted in an existing macOS fixed-3-MiB stack test. The unchanged test reproduced the overflow at both base and candidate under matched settings. The **entire unfiltered integration suite then passed under normal tool settings**, including that test with its limit intact (6,014 passed, 2 ignored). The failed attempt is not counted as a suite pass.

<details>
<summary>Retained pipeline report — accepted candidate</summary>

- Base: `f41ed842f9f48153818039d474749f54c9a327dd`.
- Accepted candidate: `ee7792cd1e251d40b254f5ab1ad469f83033dd71`.
- Plan review: two rounds, final plan clean; no surgical mode.
- Implementation review: two rounds, final whole-diff review clean at the accepted candidate.
- Scope: `crates/engine/src/game/engine_replacement.rs` and `crates/engine/tests/integration/vigor_regression.rs`.
- Checkpoints: `c6b1f354586381d35ee5a71c63192509940e121f` adds the helper/tests in both paths; `ee7792cd1e251d40b254f5ab1ad469f83033dd71` corrects the optional-event controller fixture in `engine_replacement.rs`. Round starts were the base and c6 respectively.
- Architecture: one prepared-chain execution boundary; existing typed waiting states, dispatch handles, event context, and continuations retain authority.
- Preparatory evidence: formatting, pre-commit gates, and the discriminating mutation experiment. Completion evidence is listed above and bound to the immutable candidate. CI's tested merge tree exactly equals the candidate tree.
- Coverage: runtime fix; zero parse changes or support delta.
- Verification adjustments: corrected the new fixture's player scope; retained and diagnosed the pre-existing lean-profile stack failure, then completed the normal-profile suite. No candidate source change was made during final verification.
- Phase fit: one unit, two paths, single phase; final T1/T2 false. No charter, abandoned candidate, or remaining implementation item.
- Remaining external step: maintainer review and merge.

Immutable acceptance snapshot: pipeline-reviewed head and branch head both equal the accepted candidate; pipeline status is `current`; current-head review is `none` (separate from the completed pipeline review).

</details>

## PR handoff

```text
Pipeline-reviewed head: ee7792cd1e251d40b254f5ab1ad469f83033dd71
Current branch head: 90bf17669bea19a7952a19444bd897010c462505
Pipeline status: historical — documentation-only CR citation clarification
Current-head review: none
```

Documentation follow-up at `90bf17669bea19a7952a19444bd897010c462505`: scoped CR 615.5 to prevention's additional effects and separated the wait-state engine invariant. Local rules verification, focused documentation review, formatting, whitespace checks, and pre-commit gates passed. Executable code is unchanged; the full-suite results above remain bound to the accepted candidate.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved continuation after replacement effects so inherited prompts are preserved correctly.
  * Prevented synchronous child effects from incorrectly replacing active prompts.
  * Ensured identical prompts and predetermined copy effects resume with the correct waiting state.

* **Tests**
  * Added coverage for nested replacement-effect choices and prompt restoration.
  * Expanded combat regression testing for large blocker groups, damage prevention, counter effects, and turn progression.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
