### PR TITLE
fix(scripts): resolve the self-host card pool through its manifest

### DIFF
--- a/scripts/build-selfhost-web.sh
+++ b/scripts/build-selfhost-web.sh
@@ -66,14 +66,22 @@ else
   # disguise, as "Card database not loaded" from the engine worker.
   if [ -z "${CARD_DATA_URL:-}" ]; then
     meta_url="$DATA_BASE_URL/card-data-meta.json"
-    if ! meta=$(curl -fsSL "$meta_url"); then
+    if ! meta=$(curl -fsSL --connect-timeout 10 --max-time 60 "$meta_url"); then
       echo "ERROR: could not fetch $meta_url to resolve the card pool." >&2
       echo "  Set CARD_DATA_URL to a content-addressed card-data-<hash>.json, or" >&2
       echo "  generate a pool matching this checkout: ./scripts/gen-card-data.sh" >&2
       exit 2
     fi
-    if ! card_data_file=$(printf '%s' "$meta" | jq -re '.data_filename'); then
-      echo "ERROR: $meta_url has no .data_filename." >&2
+    if ! card_data_file=$(printf '%s' "$meta" | jq -er '
+      if (.data_filename | type) == "string"
+        and (.data_filename | test("^card-data-[0-9a-f]{16}\\.json$"))
+      then .data_filename
+      else error("invalid data_filename")
+      end
+    '); then
+      echo "ERROR: $meta_url has no valid content-addressed .data_filename." >&2
+      echo "  Set CARD_DATA_URL to a content-addressed card-data-<hash>.json, or" >&2
+      echo "  generate a pool matching this checkout: ./scripts/gen-card-data.sh" >&2
       exit 2
     fi
     export CARD_DATA_URL="$DATA_BASE_URL/$card_data_file"

--- a/scripts/build-selfhost-web.sh
+++ b/scripts/build-selfhost-web.sh
@@ -58,8 +58,34 @@ export AUDIO_BASE_URL="${AUDIO_BASE_URL:-$DATA_BASE_URL/audio}"
 if [ -f client/public/card-data.json ]; then
   echo "card data: bundling client/public/card-data.json (matches this checkout)"
 else
-  export CARD_DATA_URL="${CARD_DATA_URL:-$DATA_BASE_URL/card-data.json}"
-  echo "card data: $CARD_DATA_URL (run ./scripts/gen-card-data.sh to bundle your own instead)"
+  # Resolve the pool through card-data-meta.json rather than naming a file.
+  # The deployed pools are content-addressed, and the unversioned card-data.json
+  # is a stale relic that still answers 200 — pinning it hands the locally built
+  # engine a pool from an older schema, which serde rejects at load. That failure
+  # is swallowed into a console warning, so it reaches the user much later and in
+  # disguise, as "Card database not loaded" from the engine worker.
+  if [ -z "${CARD_DATA_URL:-}" ]; then
+    meta_url="$DATA_BASE_URL/card-data-meta.json"
+    if ! meta=$(curl -fsSL "$meta_url"); then
+      echo "ERROR: could not fetch $meta_url to resolve the card pool." >&2
+      echo "  Set CARD_DATA_URL to a content-addressed card-data-<hash>.json, or" >&2
+      echo "  generate a pool matching this checkout: ./scripts/gen-card-data.sh" >&2
+      exit 2
+    fi
+    if ! card_data_file=$(printf '%s' "$meta" | jq -re '.data_filename'); then
+      echo "ERROR: $meta_url has no .data_filename." >&2
+      exit 2
+    fi
+    export CARD_DATA_URL="$DATA_BASE_URL/$card_data_file"
+    # The pool matches the commit it was generated from, not necessarily this
+    # checkout. Print it so a schema mismatch is visible here rather than as a
+    # runtime load failure in the browser.
+    echo "card data: $CARD_DATA_URL"
+    echo "  (upstream pool generated at commit $(printf '%s' "$meta" | jq -r '.commit_short // "unknown"'); \
+run ./scripts/gen-card-data.sh to bundle one matching this checkout instead)"
+  else
+    echo "card data: $CARD_DATA_URL (caller-supplied)"
+  fi
 fi
 
 # ENGINE_WASM_URL is deliberately left unset so the engine is bundled locally


### PR DESCRIPTION
## Summary

A site built by `scripts/build-selfhost-web.sh` serves the client but cannot start a game: every deck-compatibility check answers *"Card database not loaded. Call loadCardDb or loadCardDbFromUrl first."* The pool is not missing — it is **rejected**, because the script pinned `CARD_DATA_URL` to the unversioned `card-data.json`, which still answers 200 but holds a pool from an older schema. This resolves the pool through `card-data-meta.json` instead, the way the rest of the pipeline already does.

## Files changed

- `scripts/build-selfhost-web.sh` — resolve `CARD_DATA_URL` from `card-data-meta.json`'s `data_filename`; fail with an actionable message rather than falling back to a name that silently serves the wrong schema; print the pool's originating commit

## Track

Non-developer

## LLM

Model: claude-opus-5
Tier: Frontier
Thinking: high

## Implementation method (required)

Method: not-applicable — build script only; no `crates/engine/` game logic is touched.

## CR references

None. Build/packaging change, no rules behavior.

## Verification

- [x] Required checks ran clean, or the exact CI-owned alternative is stated below.
- [x] Gate A output below is for the current committed head.
- [x] Final review-impl below is clean for the current committed head.
- [x] Both anchors cite existing analogous code at the same seam.

- **`cargo run --release --bin card-data-validate`** — the repo's own deploy-time gate, run over both pools as a discriminating pair. Same binary, same invocation, only the file differs:
  - unversioned `card-data.json` → `FAIL: ... could not be parsed by current engine schema / unknown variant 'Tap', expected one of ... 'SetTapState' ...`, exit **1**
  - `card-data-42e155406dd98960.json` (named by `card-data-meta.json`) → `OK: 35800 cards parsed`, exit **0**
- **Browser reproduction** (headless Chromium over CDP, capturing page *and* worker): the worker's fetch of the unversioned pool **succeeds** — 200, `content-encoding: zstd`, `loadingFinished` at 9,683,316 encoded bytes — and the very next console line is `Failed to load card database: Error: Failed to parse card database: unknown variant 'Tap'...`. So this is not a fetch, CORS, or timing failure.
- **The new resolution block, exercised from the file's own bytes** (extracted by line range, not retyped) in three cases: live manifest → resolves `card-data-42e155406dd98960.json` and prints commit `500b3af`; unreachable manifest → exits **2** with the actionable message instead of silently pinning something stale; caller-supplied `CARD_DATA_URL` → passes through untouched.
- **A real end-to-end build** using the changed script printed `card data: https://data.phase-rs.dev/card-data-42e155406dd98960.json` before proceeding into the WASM and Vite steps.
- No repo-wide Rust or frontend build is warranted for a shell-script change and none was run; there is no shell-test harness in the tree to add a case to.

## Gate A

Gate A PASS head=cfefeb913e12743722212daf61b30b654fb9ea75 base=d6d28370c09242182488cac72e16e5a84941885f

**Disclosure — inapplicable to this diff rather than evidence for it.** The change is one shell script and zero `.rs` files. The run is not vacuous (296 commits in range), but the gate derives its base from a fork's `origin/main`, so what it walks is fork-to-upstream drift, not this PR.

## Anchored on

- `.github/workflows/release.yml:424` — `CARD_DATA_URL: "https://data.phase-rs.dev/${{ steps.card-data-hash.outputs.filename }}"`. The release path already pins the content-addressed filename; this makes the self-host path do the same thing.
- `.github/workflows/deploy.yml:788` — the staging equivalent, `.../staging/${{ needs.preview-inputs.outputs.card_data_filename }}`. Two independent existing call sites at the same seam, both resolving a filename rather than naming `card-data.json`.

## Final review-impl

Final review-impl PASS head=cfefeb913e12743722212daf61b30b654fb9ea75

Scope is the one resolution block. Checked: `set -euo pipefail` is already in force, so the `if ! x=$(...)` guards are the correct shape and neither `curl` nor `jq` failure can fall through silently; `jq -re` makes a `null`/absent `data_filename` a non-zero exit rather than the string `"null"`; `jq` was already a dependency of this script (used for `data-files.json`); and the `CARD_DATA_URL` pass-through preserves the existing override contract, including the downstream `if [ -n "${CARD_DATA_URL:-}" ]` strip step, which still sees the variable set exactly when the pool is remote.

## Claimed parse impact

None.

## Scope Expansion

None. Deliberately **not** included: making the card-data URL runtime-configurable through `/config.js` alongside `multiplayerServerUrl`. That would be a faster knob but reintroduces exactly the WASM/pool drift the content-addressing exists to prevent — `vite.config.ts` pins `__CARD_DATA_URL__` at build time on purpose, and `card_data_validate.rs` describes the pairing as making that drift "structurally impossible". The build-time resolution is the right layer.

## Validation Failures

None.

## CI Failures

None.

---

## One question I cannot act on: the relic itself

This change stops *new* self-host builds from pinning `https://data.phase-rs.dev/card-data.json`, but that object is still published and still returns 200 with a pool old enough to be rejected by the current engine. I have no access to R2, so this is a maintainer decision:

- **Delete it** — then any build still pinning it fails loudly at fetch instead of silently loading an unparseable pool, and this class of bug cannot recur for anyone on an older checkout of this script.
- **Keep it and make it current** — it becomes a valid "latest" alias, at the cost of reintroducing a mutable, non-content-addressed pool that can drift out from under a pinned WASM bundle, which is the thing `card-data-meta.json` and the `<hash>` naming exist to prevent.

**Where the relic comes from, since it bears on the choice.** `scripts/deploy-cf.sh` is its producer, not another victim: it uploads `public/card-data.json` to that exact R2 key (`scripts/deploy-cf.sh:43`), `wait`s for the upload to finish, and only then runs `pnpm build` with `CARD_DATA_URL` pointed at it (`:15`, `:135-146`). Producer and consumer in one run, so the pool it pins is the one it just published from its own checkout — the same bytes by construction, with no skew possible. That is why it is **not** a member of the class this PR repairs and I have deliberately left it unchanged: `build-selfhost-web.sh` was broken because it pinned a pool it does *not* produce, and that distinction is the whole defect.

It does mean the object is stale rather than abandoned — it reflects whenever `deploy-cf.sh` last ran, while CI publishes the content-addressed files. So deleting it is safe for consumers once this lands, but it is not permanent: the next `deploy-cf.sh` run republishes it, current. I would still suggest deleting it now — a 200 that cannot be parsed is worse than a 404 — but either choice is coherent, and if you want it gone for good the upload entry at `:43` is the line to drop.

Worth noting for whoever owns the client: the reason this took a browser to diagnose is that `ensureCardDb` in `client/src/adapter/wasm-adapter.ts` catches the load failure into a `console.warn` and then **resolves anyway**, leaving `cardDbLoaded` false. Callers such as `checkDeckCompatibility` correctly `await ensureCardDb()` and then call the worker regardless, so a schema rejection is re-narrated as "you forgot to call loadCardDb". The real cause exists only in a console warning. I have not touched that here — it is a separate decision about whether a failed load should surface — but the misleading symptom is worth knowing about.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved self-hosted builds to resolve the latest card data through versioned metadata instead of a potentially stale default file.
  - Added validation and clearer errors when card data metadata cannot be retrieved or does not provide a valid data file.
  - Build output now reports the resolved card data URL and upstream pool version.
  - Existing custom card data URLs continue to be honored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->